### PR TITLE
Support punchthrough tokens that have lifetime restrictions

### DIFF
--- a/litebox/src/platform/mod.rs
+++ b/litebox/src/platform/mod.rs
@@ -32,17 +32,19 @@ pub trait Provider:
 /// punchthrough, their code is suspicious; if all host invocations pass through the punchthrough,
 /// then it is sufficient to audit the punchthrough interface".
 pub trait PunchthroughProvider {
-    type PunchthroughToken: PunchthroughToken;
+    type PunchthroughToken<'a>: PunchthroughToken
+    where
+        Self: 'a;
     /// Give permission token to invoke `punchthrough`, possibly after checking that it is ok.
     ///
     /// The reason `&mut self` is taken mutably is to ensure that tokens aren't being held around
     /// for too long (i.e., all other platform interaction is disallowed between the creation and
     /// consumption of a token), as well as allowing the token to (possibly) get mutable access to
     /// the underlying platform storage.
-    fn get_punchthrough_token_for(
-        &mut self,
-        punchthrough: <Self::PunchthroughToken as PunchthroughToken>::Punchthrough,
-    ) -> Option<Self::PunchthroughToken>;
+    fn get_punchthrough_token_for<'a>(
+        &'a mut self,
+        punchthrough: <Self::PunchthroughToken<'a> as PunchthroughToken>::Punchthrough,
+    ) -> Option<Self::PunchthroughToken<'a>>;
 }
 
 /// A token that demonstrates that the platform is allowing access for a particular [`Punchthrough`]

--- a/litebox/src/platform/trivial_providers.rs
+++ b/litebox/src/platform/trivial_providers.rs
@@ -8,11 +8,14 @@ use super::{Punchthrough, PunchthroughError, PunchthroughProvider, PunchthroughT
 /// A trivial provider, useful when no punchthrough is necessary.
 pub struct ImpossiblePunchthroughProvider {}
 impl PunchthroughProvider for ImpossiblePunchthroughProvider {
-    type PunchthroughToken = ImpossiblePunchthroughToken;
+    type PunchthroughToken<'a>
+        = ImpossiblePunchthroughToken
+    where
+        Self: 'a;
     fn get_punchthrough_token_for(
         &mut self,
-        punchthrough: <Self::PunchthroughToken as PunchthroughToken>::Punchthrough,
-    ) -> Option<Self::PunchthroughToken> {
+        punchthrough: <Self::PunchthroughToken<'_> as PunchthroughToken>::Punchthrough,
+    ) -> Option<Self::PunchthroughToken<'_>> {
         // Since `ImpossiblePunchthrough` is an empty enum, it is impossible to actually invoke
         // `execute` upon it, meaning that the implementation here is irrelevant, since anything
         // within it is provably unreachable.
@@ -48,11 +51,14 @@ impl PunchthroughToken for ImpossiblePunchthroughToken {
 /// simply caught as "unimplemented" temporarily, while more infrastructure is set up.
 pub struct IgnoredPunchthroughProvider {}
 impl PunchthroughProvider for IgnoredPunchthroughProvider {
-    type PunchthroughToken = IgnoredPunchthroughToken;
+    type PunchthroughToken<'a>
+        = IgnoredPunchthroughToken
+    where
+        Self: 'a;
     fn get_punchthrough_token_for(
         &mut self,
-        punchthrough: <Self::PunchthroughToken as PunchthroughToken>::Punchthrough,
-    ) -> Option<Self::PunchthroughToken> {
+        punchthrough: <Self::PunchthroughToken<'_> as PunchthroughToken>::Punchthrough,
+    ) -> Option<Self::PunchthroughToken<'_>> {
         Some(IgnoredPunchthroughToken { punchthrough })
     }
 }

--- a/litebox_platform_linux_userland/src/lib.rs
+++ b/litebox_platform_linux_userland/src/lib.rs
@@ -349,12 +349,15 @@ impl litebox::platform::Instant for Instant {
 impl<PunchthroughProvider: litebox::platform::PunchthroughProvider>
     litebox::platform::PunchthroughProvider for LinuxUserland<PunchthroughProvider>
 {
-    type PunchthroughToken = PunchthroughProvider::PunchthroughToken;
+    type PunchthroughToken<'a>
+        = PunchthroughProvider::PunchthroughToken<'a>
+    where
+        Self: 'a;
 
-    fn get_punchthrough_token_for(
-        &mut self,
-        punchthrough: <Self::PunchthroughToken as litebox::platform::PunchthroughToken>::Punchthrough,
-    ) -> Option<Self::PunchthroughToken> {
+    fn get_punchthrough_token_for<'a>(
+        &'a mut self,
+        punchthrough: <Self::PunchthroughToken<'a> as litebox::platform::PunchthroughToken>::Punchthrough,
+    ) -> Option<Self::PunchthroughToken<'a>> {
         // TODO(jayb): We may wish to make the linux userland platform less generic, and support a
         // _specific_ syscall-based punchthrough interface?
         self.punchthrough_provider


### PR DESCRIPTION
This PR adds a generic lifetime bound to the associated type for the `PunchthroughToken`, which allows us to more precisely capture lifetimes, and thereby de-restrict the conditions under which punchthrough tokens can be implemented (such as those with explicit lifetimes within them).