### PR TITLE
Make semver-checks a non-failing reaction

### DIFF
--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -23,4 +23,27 @@ jobs:
           curl -L --proto '=https' --tlsv1.2 -sSf https://github.com/obi1kenobi/cargo-semver-checks/releases/latest/download/cargo-semver-checks-x86_64-unknown-linux-gnu.tar.gz | tar xzvf -
           mv cargo-semver-checks ~/.cargo/bin
       - name: Check semver match against the main branch
-        run: cargo semver-checks --baseline-rev main
+        id: semver_check
+        run: |
+          # TODO(jayb): we are temporarily preventing a failure in semver-checks
+          # from showing up as a `X`, but instead triggering a comment on the
+          # PR. Once things go public, we will likely switch this out to make it
+          # actually complain as usual, essentially backing out the commit that
+          # introduced this comment.
+          if cargo semver-checks --baseline-rev main; then
+            echo "Semver check succeeded."
+            echo "reaction=hooray" >> "$GITHUB_OUTPUT"
+          else
+            echo "Semver check failed."
+            echo "reaction=confused" >> "$GITHUB_OUTPUT"
+          fi
+      - name: React to the PR based on semver-checks
+        if: ${{ github.event.pull_request }}
+        run: |
+          curl -L \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/issues/${{ github.event.number }}/reactions \
+          -d '{"content":"${{ steps.semver_check.outputs.reaction }}"}'


### PR DESCRIPTION
The SemverChecks action will now automatically react to the PR with a 🎉 or 😕 depending on whether the PR correctly handles semver checking or not. We should revert out this PR when we make LiteBox public, so as to actually start maintaining semver checks (and forcing us to bump semver whenever things fail).