### PR TITLE
Make punchthrough take shared borrow

### DIFF
--- a/litebox/src/platform/mock.rs
+++ b/litebox/src/platform/mock.rs
@@ -118,7 +118,7 @@ impl TimeProvider for MockPlatform {
 impl PunchthroughProvider for MockPlatform {
     type PunchthroughToken = trivial_providers::ImpossiblePunchthroughToken;
     fn get_punchthrough_token_for(
-        &mut self,
+        &self,
         punchthrough: <Self::PunchthroughToken as PunchthroughToken>::Punchthrough,
     ) -> Option<Self::PunchthroughToken> {
         None

--- a/litebox/src/platform/mod.rs
+++ b/litebox/src/platform/mod.rs
@@ -40,12 +40,13 @@ pub trait PunchthroughProvider {
     type PunchthroughToken: PunchthroughToken;
     /// Give permission token to invoke `punchthrough`, possibly after checking that it is ok.
     ///
-    /// The reason `&mut self` is taken mutably is to ensure that tokens aren't being held around
-    /// for too long (i.e., all other platform interaction is disallowed between the creation and
-    /// consumption of a token), as well as allowing the token to (possibly) get mutable access to
-    /// the underlying platform storage.
+    /// Even though `&self` is taken shared, the intention with the tokens is to use them
+    /// _immediately_ before invoking other platform interactions. Ideally, we would ensure this via
+    /// an `&mut self` to guarantee exclusivity, but this would limit us from supporting the ability
+    /// for other threads being blocked when a punchthrough is done. Thus, this is kept as a
+    /// `&self`. Morally this should be viewed as a `&mut self`.
     fn get_punchthrough_token_for(
-        &mut self,
+        &self,
         punchthrough: <Self::PunchthroughToken as PunchthroughToken>::Punchthrough,
     ) -> Option<Self::PunchthroughToken>;
 }

--- a/litebox/src/platform/trivial_providers.rs
+++ b/litebox/src/platform/trivial_providers.rs
@@ -13,7 +13,7 @@ pub struct ImpossiblePunchthroughProvider {}
 impl PunchthroughProvider for ImpossiblePunchthroughProvider {
     type PunchthroughToken = ImpossiblePunchthroughToken;
     fn get_punchthrough_token_for(
-        &mut self,
+        &self,
         punchthrough: <Self::PunchthroughToken as PunchthroughToken>::Punchthrough,
     ) -> Option<Self::PunchthroughToken> {
         // Since `ImpossiblePunchthrough` is an empty enum, it is impossible to actually invoke
@@ -53,7 +53,7 @@ pub struct IgnoredPunchthroughProvider {}
 impl PunchthroughProvider for IgnoredPunchthroughProvider {
     type PunchthroughToken = IgnoredPunchthroughToken;
     fn get_punchthrough_token_for(
-        &mut self,
+        &self,
         punchthrough: <Self::PunchthroughToken as PunchthroughToken>::Punchthrough,
     ) -> Option<Self::PunchthroughToken> {
         Some(IgnoredPunchthroughToken { punchthrough })

--- a/litebox_platform_linux_kernel/src/lib.rs
+++ b/litebox_platform_linux_kernel/src/lib.rs
@@ -85,7 +85,7 @@ impl<Host: HostInterface> PunchthroughProvider for LinuxKernel<Host> {
     type PunchthroughToken = LinuxPunchthroughToken<Host>;
 
     fn get_punchthrough_token_for(
-        &mut self,
+        &self,
         punchthrough: <Self::PunchthroughToken as PunchthroughToken>::Punchthrough,
     ) -> Option<Self::PunchthroughToken> {
         Some(LinuxPunchthroughToken {

--- a/litebox_platform_linux_userland/src/lib.rs
+++ b/litebox_platform_linux_userland/src/lib.rs
@@ -352,7 +352,7 @@ impl<PunchthroughProvider: litebox::platform::PunchthroughProvider>
     type PunchthroughToken = PunchthroughProvider::PunchthroughToken;
 
     fn get_punchthrough_token_for(
-        &mut self,
+        &self,
         punchthrough: <Self::PunchthroughToken as litebox::platform::PunchthroughToken>::Punchthrough,
     ) -> Option<Self::PunchthroughToken> {
         // TODO(jayb): We may wish to make the linux userland platform less generic, and support a


### PR DESCRIPTION
@CvvT pointed out an important use case that was blocked by the mutable borrow restriction on punchthroughs. In particular, it would prevent us from maintaining any mutex/... blocks on other threads when attempting to do a punchthrough. Thus, this PR switches the `PunchthroughProvider` from a mutable borrow to a shared borrow.