### PR TITLE
support pread/pwrite

### DIFF
--- a/litebox/src/fs/in_mem.rs
+++ b/litebox/src/fs/in_mem.rs
@@ -181,7 +181,12 @@ impl<Platform: sync::RawSyncPrimitivesProvider> super::FileSystem for FileSystem
         Ok(())
     }
 
-    fn read(&self, fd: &FileFd, buf: &mut [u8]) -> Result<usize, ReadError> {
+    fn read(
+        &self,
+        fd: &FileFd,
+        buf: &mut [u8],
+        mut offset: Option<usize>,
+    ) -> Result<usize, ReadError> {
         let mut descriptors = self.descriptors.write();
         let Descriptor::File {
             file,
@@ -195,6 +200,7 @@ impl<Platform: sync::RawSyncPrimitivesProvider> super::FileSystem for FileSystem
         if !*read_allowed {
             return Err(ReadError::NotForReading);
         }
+        let position = offset.as_mut().unwrap_or(position);
         let file = file.read();
         let start = (*position).min(file.data.len());
         let end = position
@@ -208,7 +214,12 @@ impl<Platform: sync::RawSyncPrimitivesProvider> super::FileSystem for FileSystem
         Ok(retlen)
     }
 
-    fn write(&self, fd: &FileFd, buf: &[u8]) -> Result<usize, WriteError> {
+    fn write(
+        &self,
+        fd: &FileFd,
+        buf: &[u8],
+        mut offset: Option<usize>,
+    ) -> Result<usize, WriteError> {
         let mut descriptors = self.descriptors.write();
         let Descriptor::File {
             file,
@@ -222,6 +233,7 @@ impl<Platform: sync::RawSyncPrimitivesProvider> super::FileSystem for FileSystem
         if !*write_allowed {
             return Err(WriteError::NotForWriting);
         }
+        let position = offset.as_mut().unwrap_or(position);
         let mut file = file.write();
         let start = if *position < file.data.len() {
             let start = *position;

--- a/litebox/src/fs/mod.rs
+++ b/litebox/src/fs/mod.rs
@@ -43,10 +43,18 @@ pub trait FileSystem: private::Sealed {
     fn open(&self, path: impl path::Arg, flags: OFlags, mode: Mode) -> Result<FileFd, OpenError>;
     /// Close the file at `fd`
     fn close(&self, fd: FileFd) -> Result<(), CloseError>;
-    /// Read from a file descriptor into a buffer
-    fn read(&self, fd: &FileFd, buf: &mut [u8]) -> Result<usize, ReadError>;
-    /// Write from a buffer to a file descriptor
-    fn write(&self, fd: &FileFd, buf: &[u8]) -> Result<usize, WriteError>;
+    /// Read from a file descriptor at `offset` into a buffer
+    ///
+    /// If `offset` is None, the read will start at the current file offset and update the file offset
+    /// to the end of the read.
+    /// If `offset` is Some, the file offset is not changed.
+    fn read(&self, fd: &FileFd, buf: &mut [u8], offset: Option<usize>) -> Result<usize, ReadError>;
+    /// Write from a buffer to a file descriptor at `offset`
+    ///
+    /// If `offset` is None, the write will start at the current file offset and update the file offset
+    /// to the end of the write.
+    /// If `offset` is Some, the file offset is not changed.
+    fn write(&self, fd: &FileFd, buf: &[u8], offset: Option<usize>) -> Result<usize, WriteError>;
     /// Change the permissions of a file
     fn chmod(&self, path: impl path::Arg, mode: Mode) -> Result<(), ChmodError>;
     /// Unlink a file

--- a/litebox/src/fs/nine_p.rs
+++ b/litebox/src/fs/nine_p.rs
@@ -41,6 +41,7 @@ impl<Platform: platform::Provider> super::FileSystem for FileSystem<'_, Platform
         &self,
         fd: &crate::fd::FileFd,
         buf: &mut [u8],
+        offset: Option<usize>,
     ) -> Result<usize, super::errors::ReadError> {
         todo!()
     }
@@ -49,6 +50,7 @@ impl<Platform: platform::Provider> super::FileSystem for FileSystem<'_, Platform
         &self,
         fd: &crate::fd::FileFd,
         buf: &[u8],
+        offset: Option<usize>,
     ) -> Result<usize, super::errors::WriteError> {
         todo!()
     }


### PR DESCRIPTION
Support [pread/pwrite](https://www.man7.org/linux/man-pages/man2/pread.2.html). Compared to `read/write`, the only difference is whether it needs to update the file offset.