### PR TITLE
Update semver-checks workflow to provide stdout feedback

### DIFF
--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -28,22 +28,50 @@ jobs:
           # TODO(jayb): we are temporarily preventing a failure in semver-checks
           # from showing up as a `X`, but instead triggering a comment on the
           # PR. Once things go public, we will likely switch this out to make it
-          # actually complain as usual, essentially backing out the commit that
-          # introduced this comment.
-          if cargo semver-checks --baseline-rev main; then
+          # actually complain as usual, possibly still keeping in the comment bot?
+          if cargo semver-checks --baseline-rev main --color=never >/tmp/semver-checks-stdout; then
+            cat /tmp/semver-checks-stdout
             echo "Semver check succeeded."
             echo "reaction=hooray" >> "$GITHUB_OUTPUT"
           else
+            cat /tmp/semver-checks-stdout
             echo "Semver check failed."
             echo "reaction=eyes" >> "$GITHUB_OUTPUT"
           fi
-      - name: React to the PR based on semver-checks
-        if: ${{ github.event.pull_request }}
+      # - name: React to the PR based on semver-checks
+      #   if: ${{ github.event.pull_request }}
+      #   run: |
+      #     curl -L \
+      #     -X POST \
+      #     -H "Accept: application/vnd.github+json" \
+      #     -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+      #     -H "X-GitHub-Api-Version: 2022-11-28" \
+      #     https://api.github.com/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/issues/${{ github.event.number }}/reactions \
+      #     -d '{"content":"${{ steps.semver_check.outputs.reaction }}"}'
+      - name: Delete old semver checks comments, if any
+        run: |
+          # Get the old comments
+          COMMENT_IDS=$(curl -L \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/issues/${{ github.event.number }}/comments | \
+              jq '.[] | select(.body | contains(":robot: SemverChecks :robot:")) | .id')
+          # Delete them all
+          for ID in $COMMENT_IDS; do
+            curl -L \
+            -X DELETE \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/issues/comments/$ID
+          done
+      - name: Add a new issue comment if needed
         run: |
           curl -L \
           -X POST \
           -H "Accept: application/vnd.github+json" \
           -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
-          https://api.github.com/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/issues/${{ github.event.number }}/reactions \
-          -d '{"content":"${{ steps.semver_check.outputs.reaction }}"}'
+          https://api.github.com/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/issues/${{ github.event.number }}/comments \
+          -d "$(if [ -s /tmp/semver-checks-stdout ]; then echo -e ':robot: SemverChecks :robot: API Changed\n\n<details><summary>Click for stdout</summary>\n\n```'"$(cat /tmp/semver-checks-stdout)"'\n```\n</details>'; else echo ':robot: SemverChecks :robot: API Unchanged'; fi | jq -sR '{body: .}')"


### PR DESCRIPTION
It got a little annoying to look at the semver-checks changes, so this PR updates it to place it as a comment, which should hopefully be easier to see. When placing the comment, it removes older comments it has made, so that we are not flooded with such comments, but it acts as an easy look-up for the changes.

This PR also disables the reaction thing, which (while useful) was not sufficiently discoverable, and thus is not ideal.