### PR TITLE
Make Linux-userland-platform tun dependency optional

### DIFF
--- a/litebox_platform_linux_userland/Cargo.toml
+++ b/litebox_platform_linux_userland/Cargo.toml
@@ -3,9 +3,6 @@ name = "litebox_platform_linux_userland"
 version = "0.1.0"
 edition = "2024"
 
-[features]
-unstable-testing = []
-
 [dependencies]
 libc = { version = "0.2.169", default-features = false }
 litebox = { path = "../litebox/", version = "0.1.0" }

--- a/litebox_platform_multiplex/Cargo.toml
+++ b/litebox_platform_multiplex/Cargo.toml
@@ -10,7 +10,6 @@ once_cell = { version = "1.20.2", default-features = false, features = ["alloc",
 
 [features]
 default = ["platform_linux_userland"]
-unstable-testing = ["litebox_platform_linux_userland?/unstable-testing"]
 platform_linux_userland = ["dep:litebox_platform_linux_userland"]
 
 [lints]

--- a/litebox_shim_linux/Cargo.toml
+++ b/litebox_shim_linux/Cargo.toml
@@ -19,5 +19,4 @@ unstable-testing = []
 workspace = true
 
 [dev-dependencies]
-litebox_platform_multiplex = { path = "../litebox_platform_multiplex/", version = "0.1.0", features = ["unstable-testing"] }
 litebox_shim_linux = { path = ".", features = ["unstable-testing"] }

--- a/litebox_shim_linux/tests/common/mod.rs
+++ b/litebox_shim_linux/tests/common/mod.rs
@@ -26,8 +26,7 @@ unsafe extern "C" {
 }
 
 pub fn init_platform() {
-    let platform =
-        unsafe { Platform::new_for_test(ImpossiblePunchthroughProvider {}, syscall_entry) };
+    let platform = Platform::new(None, ImpossiblePunchthroughProvider {}, syscall_entry);
     set_platform(platform);
 
     let mut in_mem_fs =


### PR DESCRIPTION
We don't actually want/need network access always when using the Linux userland platform (especially since we haven't yet finished the 9p FS implementation migration), so this PR disables the requirement for the tun device. This also means that we don't need `new_for_test` anymore.