### PR TITLE
Move integer utilities into litebox

### DIFF
--- a/litebox/src/lib.rs
+++ b/litebox/src/lib.rs
@@ -29,3 +29,6 @@ pub mod sync;
 // Explicitly-private, the utilities are not exposed to users of LiteBox, and are intended entirely
 // to contain implementation-internal code.
 mod utilities;
+
+// Public utilities that might be used in other LiteBox crates.
+pub mod utils;

--- a/litebox/src/utils/mod.rs
+++ b/litebox/src/utils/mod.rs
@@ -1,8 +1,14 @@
-//! "The kitchen sink": helpful utilities that are hard to organize into other modules.
+//! Miscellaneous "kitchen sink" for use in various LiteBox crates.
+//!
+//! Note: while we do not anticipate significant API changes in these utilities, these utilities do
+//! not (necessarily) come with the API stability guarantees of the rest of LiteBox's modules. They
+//! exist mostly to share utility code that used in the various LiteBox crates, and as such, might
+//! be changed if necessary.
+// NOTE: There is a separate `utilities` module in this crate meant for crate-internal utilities.
 
 /// An extension trait that adds `truncate` to truncate integers to a specific size of the same
 /// signedness.
-pub(crate) trait TruncateExt<To> {
+pub trait TruncateExt<To> {
     /// Truncate `self` to `To`, taking only lower-order bits.
     fn truncate(self) -> To;
 }
@@ -51,18 +57,14 @@ impl_truncate! { i32, i8 }
 impl_truncate! { i16, i8 }
 
 /// An extension trait that adds `reinterpret_as_signed` to unsigned integers.
-pub(crate) trait ReinterpretSignedExt {
+pub trait ReinterpretSignedExt {
     type Signed;
     /// Reinterpret `self` to `Self::To`
     fn reinterpret_as_signed(self) -> Self::Signed;
 }
 
 /// An extension trait that adds `reinterpret_as_unsigned` to signed integers.
-#[expect(
-    dead_code,
-    reason = "currently unused; remove this attr once it is used"
-)]
-pub(crate) trait ReinterpretUnsignedExt {
+pub trait ReinterpretUnsignedExt {
     type Unsigned;
     /// Reinterpret `self` to `Self::To`
     fn reinterpret_as_unsigned(self) -> Self::Unsigned;

--- a/litebox_platform_linux_userland/src/lib.rs
+++ b/litebox_platform_linux_userland/src/lib.rs
@@ -14,7 +14,6 @@ use litebox::platform::UnblockedOrTimedOut;
 use litebox::platform::page_mgmt::MemoryRegionPermissions;
 
 mod syscall_intercept;
-mod utils;
 
 /// The userland Linux platform.
 ///

--- a/litebox_platform_linux_userland/src/syscall_intercept/systrap.rs
+++ b/litebox_platform_linux_userland/src/syscall_intercept/systrap.rs
@@ -1,10 +1,10 @@
 //! The systrap platform relies on seccomp’s `SECCOMP_RET_TRAP` feature to intercept system calls.
 
-use crate::utils::{ReinterpretSignedExt as _, TruncateExt as _};
 use core::arch::global_asm;
 use core::ffi::{c_int, c_uint};
 use litebox::platform::RawMutPointer as _;
 use litebox::platform::trivial_providers::{TransparentConstPtr, TransparentMutPtr};
+use litebox::utils::{ReinterpretSignedExt as _, TruncateExt as _};
 use litebox_common_linux::SyscallRequest;
 use nix::sys::signal::{self, SaFlags, SigAction, SigHandler, SigSet, Signal};
 


### PR DESCRIPTION
This moves #59 into the `litebox` crate, for use with other `litebox_...` crates