### PR TITLE
Account for spurious or immediate wakeups

### DIFF
--- a/litebox_platform_linux_userland/src/lib.rs
+++ b/litebox_platform_linux_userland/src/lib.rs
@@ -286,7 +286,7 @@ impl litebox::platform::RawMutex for RawMutex {
         // Unlock the lock bits, allowing other wakers to run.
         let remain = n - num_woken_up;
         while let Err(v) = self.num_to_wake_up.fetch_update(SeqCst, SeqCst, |v| {
-            // due to spurious or immediate wake-ups (i.e., unexpected wakeups that may decrease `num_to_wake_up`),
+            // Due to spurious or immediate wake-ups (i.e., unexpected wakeups that may decrease `num_to_wake_up`),
             // `num_to_wake_up` might end up being less than expected. Thus, we check `<=` rather than `==`.
             if v & ((1 << 30) - 1) <= remain {
                 Some(0)


### PR DESCRIPTION
Ran into another problem introduced by #75:  

https://github.com/MSRSSP/litebox/blob/1ff952fbcf9c3958c394a13fbc06e3bcf4fcf382/litebox_platform_linux_userland/src/lib.rs#L287-L291
If `n` = 1 and `num_wake_up` = 0, `num_to_wake_up` should remain `(0b11 << 30) | 1`. However, it is possible that there is an immediate wakeup that updates `num_to_wake_up` to `(0b11 << 30)`. To fix it, instead of checking the exact number, we should check if the current value is less than or equal to `remain`.

I don't have a reliable test case for this. This was found when testing some other code that uses mutex.