### PR TITLE
Update nostd CI to fail on cargo build errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,13 +74,22 @@ jobs:
           #   more precise check, but as long as we are tracking the underlying
           #   platforms, we are unlikely to hit any significant issues here.
           #
+          # - `litebox_runner_linux_userland` is allowed to have `std` access
+          #   since it needs to actually access the file-system, pull in
+          #   relevant files, and then actually trigger LiteBox itself.
+          #
           # - `litebox_shim_linux` (in its default feature set) depends on
           #   `litebox_platform_multiplex`; similarly, ideally we'd do a more
           #   precise check.
+          #
+          # - `litebox_syscall_rewriter` is allowed to have `std` access since
+          #   it is a helper binary that runs in userland to AOT "compile" ELFs.
           find . -type f -name 'Cargo.toml' \
             -not -path './Cargo.toml' \
             -not -path './litebox_platform_linux_userland/Cargo.toml' \
             -not -path './litebox_platform_multiplex/Cargo.toml' \
+            -not -path './litebox_runner_linux_userland/Cargo.toml' \
             -not -path './litebox_shim_linux/Cargo.toml' \
+            -not -path './litebox_syscall_rewriter/Cargo.toml' \
             -print0 | \
               xargs -0 -I '{}' sh -c 'cd "$(dirname "{}")"; pwd; cargo build --target x86_64-unknown-none || exit 1; echo; echo'


### PR DESCRIPTION
It appears that our `Confirm no_std` CI job was not actually complaining upon usage of `std` (it would show up in the logs, but would not exit with non-zero exit code, and thus would not show up as a :x: in the GitHub interface). Thankfully, we don't have any new _unexpected_ usage of `std` that has shown up yet. I mostly recognized this because the CI did _not_ complain in a situation where new _expected_ `std` usage showed up. There _are_ two crates that it should have complained about (the syscall rewriter, and the runner) that _do_ use `std` (unsurprisingly). These have now been added to the exclusions, as well as fixing up the CI to actually complain.

Essentially, we should see the first commit d2611b61c34e5f880b7cb35964f9bcb15ba39576 (which fixes the CI) have a failure, while the second commit 67c7518ee0b295d052daf6cacf8b5a935bb9d2eb (which adds the two exclusions) should succeed.