### PR TITLE
Add `MappedRwLock` guards for more flexible data handling

### DIFF
--- a/litebox/src/sync/lock_tracing.rs
+++ b/litebox/src/sync/lock_tracing.rs
@@ -194,6 +194,18 @@ impl<Platform: RawSyncPrimitivesProvider> Drop for LockedWitness<Platform> {
         assert!(self.unlocked, "Someone forgot to call `mark_unlock`");
     }
 }
+impl<Platform: RawSyncPrimitivesProvider> LockedWitness<Platform> {
+    /// This function creates a new witness from a borrowed witness. This is only safe to run if
+    /// `&self` is under a `ManuallyDrop` and thus won't be auto-dropped. This is intended to be
+    /// used only with the mapped guards.
+    pub(crate) unsafe fn reborrow_for_mapped_guard(&mut self) -> Self {
+        Self {
+            idx: self.idx,
+            unlocked: self.unlocked,
+            tracker: self.tracker.clone(),
+        }
+    }
+}
 
 /// A witness to having invoked [`LockTracker::begin_lock_attempt`].
 ///

--- a/litebox/src/sync/mod.rs
+++ b/litebox/src/sync/mod.rs
@@ -17,7 +17,9 @@ mod lock_tracing;
 
 pub use condvar::Condvar;
 pub use mutex::{Mutex, MutexGuard};
-pub use rwlock::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+pub use rwlock::{
+    MappedRwLockReadGuard, MappedRwLockWriteGuard, RwLock, RwLockReadGuard, RwLockWriteGuard,
+};
 
 #[cfg(not(feature = "lock_tracing"))]
 /// A convenience name for specific requirements from the platform


### PR DESCRIPTION
This PR adds `map` to the read/write guards for `RwLocks`. I have not yet implemented similar functionality for `Mutex`, since I didn't yet find a need for it.

I ended up needing this functionality on the way to implementing some other functionality, but decided to split this out into a separate PR to make it easier to review.

At a high level, this interface mimics the (currently nightly-only) `mapped_lock_guards` API in Rust std (see https://doc.rust-lang.org/std/sync/struct.RwLockReadGuard.html#method.map for an example), but relevant changes have been made to make sure our lock tracing features still work.