### PR TITLE
fix file metadata

### DIFF
--- a/litebox/src/fs/layered.rs
+++ b/litebox/src/fs/layered.rs
@@ -894,7 +894,7 @@ impl<Platform: sync::RawSyncPrimitivesProvider, Upper: super::FileSystem, Lower:
         let descriptor = descriptors.get(fd);
         match descriptor.entry.as_ref() {
             EntryX::Upper { fd } => self.upper.set_file_metadata(fd, metadata),
-            EntryX::Lower { fd } => unimplemented!(),
+            EntryX::Lower { fd } => self.lower.set_file_metadata(fd, metadata),
             EntryX::Tombstone => unreachable!(),
         }
     }
@@ -908,7 +908,7 @@ impl<Platform: sync::RawSyncPrimitivesProvider, Upper: super::FileSystem, Lower:
         let descriptor = descriptors.get(fd);
         match descriptor.entry.as_ref() {
             EntryX::Upper { fd } => self.upper.set_fd_metadata(fd, metadata),
-            EntryX::Lower { fd } => unimplemented!(),
+            EntryX::Lower { fd } => self.lower.set_fd_metadata(fd, metadata),
             EntryX::Tombstone => unreachable!(),
         }
     }


### PR DESCRIPTION
Lower layer of fs like `tar_ro` should also maintain per-fd metadata (e.g., fcntl `GETFD` and `SETFD` for files from `tar_ro`).