### PR TITLE
De-parameterize Linux punchthroughs

### DIFF
--- a/litebox_platform_linux_kernel/src/ptr.rs
+++ b/litebox_platform_linux_kernel/src/ptr.rs
@@ -34,6 +34,13 @@ impl<T: Clone> UserConstPtr<T> {
     pub fn from_user_at_offset(self, off: isize) -> Option<T> {
         unsafe { Some(self.read_at_offset(off)?.into_owned()) }
     }
+
+    /// Cast to a pointer with different underlying type
+    pub fn cast<U>(self) -> UserConstPtr<U> {
+        UserConstPtr {
+            inner: self.inner.cast(),
+        }
+    }
 }
 
 /// Represent a user space pointer to a mutable object
@@ -81,5 +88,12 @@ impl<T: Clone> UserMutPtr<T> {
     /// Write to user space at the `off` offset
     pub fn to_user_at_offset(self, off: isize, value: T) -> Option<()> {
         unsafe { self.write_at_offset(off, value) }
+    }
+
+    /// Cast to a pointer with different underlying type
+    pub fn cast<U>(self) -> UserMutPtr<U> {
+        UserMutPtr {
+            inner: self.inner.cast(),
+        }
     }
 }

--- a/litebox_platform_linux_userland/src/syscall_intercept/mod.rs
+++ b/litebox_platform_linux_userland/src/syscall_intercept/mod.rs
@@ -10,7 +10,7 @@ pub(crate) mod systrap {
     pub(crate) const SYSCALL_ARG_MAGIC: u32 = u32::from_le_bytes(*b"LtBx");
 
     pub(crate) fn init_sys_intercept(
-        _handler: impl Fn(SyscallRequest<crate::LinuxUserland>) -> i64 + Send + Sync + 'static,
+        _handler: impl Fn(SyscallRequest<crate::LinuxUserland>) -> isize + Send + Sync + 'static,
     ) {
         // TODO: Actually start intercepting syscalls on 32-bit Linux.
         //

--- a/litebox_runner_linux_userland/src/lib.rs
+++ b/litebox_runner_linux_userland/src/lib.rs
@@ -89,10 +89,7 @@ pub fn run(cli_args: CliArgs) -> Result<()> {
     // TODO: We also need to pick the type of syscall interception based on whether we want
     // systrap/sigsys interception, or binary rewriting interception. Currently
     // `litebox_platform_linux_userland` does not provide a way to pick between the two.
-    let platform = Platform::new(
-        None,
-        litebox::platform::trivial_providers::ImpossiblePunchthroughProvider {},
-    );
+    let platform = Platform::new(None);
     let litebox = LiteBox::new(platform);
     let initial_file_system = {
         let mut in_mem = litebox::fs::in_mem::FileSystem::new(&litebox);

--- a/litebox_shim_linux/src/channel.rs
+++ b/litebox_shim_linux/src/channel.rs
@@ -223,14 +223,13 @@ impl<T> Channel<T> {
 
 #[cfg(test)]
 mod tests {
-    use litebox::platform::trivial_providers::ImpossiblePunchthroughProvider;
     use litebox_common_linux::errno::Errno;
     use litebox_platform_multiplex::{Platform, set_platform};
 
     extern crate std;
 
     fn init_platform() {
-        set_platform(Platform::new(None, ImpossiblePunchthroughProvider {}));
+        set_platform(Platform::new(None));
     }
 
     #[test]

--- a/litebox_shim_linux/src/syscalls/eventfd.rs
+++ b/litebox_shim_linux/src/syscalls/eventfd.rs
@@ -84,14 +84,13 @@ impl<Platform: RawSyncPrimitivesProvider> EventFile<Platform> {
 
 #[cfg(test)]
 mod tests {
-    use litebox::platform::trivial_providers::ImpossiblePunchthroughProvider;
     use litebox_common_linux::{EfdFlags, errno::Errno};
     use litebox_platform_multiplex::{Platform, set_platform};
 
     extern crate std;
 
     fn init_platform() {
-        set_platform(Platform::new(None, ImpossiblePunchthroughProvider {}));
+        set_platform(Platform::new(None));
     }
 
     #[test]

--- a/litebox_shim_linux/src/syscalls/tests.rs
+++ b/litebox_shim_linux/src/syscalls/tests.rs
@@ -1,11 +1,11 @@
-use litebox::{fs::OFlags, platform::trivial_providers::ImpossiblePunchthroughProvider};
+use litebox::fs::OFlags;
 use litebox_common_linux::{EfdFlags, FcntlArg, FileDescriptorFlags};
 use litebox_platform_multiplex::{Platform, set_platform};
 
 use super::file::{sys_eventfd2, sys_fcntl, sys_pipe2};
 
 pub(crate) fn init_platform() {
-    set_platform(Platform::new(None, ImpossiblePunchthroughProvider {}));
+    set_platform(Platform::new(None));
 
     let platform = litebox_platform_multiplex::platform();
     let litebox = litebox::LiteBox::new(platform);

--- a/litebox_shim_linux/tests/common/mod.rs
+++ b/litebox_shim_linux/tests/common/mod.rs
@@ -3,7 +3,6 @@ use std::{arch::global_asm, ffi::CString};
 use litebox::{
     LiteBox,
     fs::{FileSystem as _, Mode, OFlags},
-    platform::trivial_providers::ImpossiblePunchthroughProvider,
 };
 use litebox_platform_multiplex::{Platform, set_platform};
 use litebox_shim_linux::{litebox_fs, loader::load_program, set_fs};
@@ -44,7 +43,7 @@ unsafe extern "C" {
 }
 
 pub fn init_platform() {
-    let platform = Platform::new(None, ImpossiblePunchthroughProvider {});
+    let platform = Platform::new(None);
     set_platform(platform);
     let platform = litebox_platform_multiplex::platform();
     let litebox = LiteBox::new(platform);


### PR DESCRIPTION
Closes #105

This PR removes the generalized parametricity that we were keeping for punchthrough for Linux-y LiteBox systems. The old reason for keeping these was because we had not yet finalized `litebox_common_linux` or what we actually needed from punchthroughs, or how the shim layer would look like. At this point, we have a relatively good design for each of them, thus we don't need the parametricity, and can instead put the shared elements together in a nicer form, so that there is a clearer indication of what needs to be punched through in order to support a Linux-y north interface.

Future PR(s) are going to do even more cleanup to pull out shared elements across the different Linux-y platforms.