### PR TITLE
Remove dependence on `std` for loader

### DIFF
--- a/litebox_shim_linux/Cargo.toml
+++ b/litebox_shim_linux/Cargo.toml
@@ -13,7 +13,7 @@ once_cell = { version = "1.20.2", default-features = false, features = ["alloc",
 # https://github.com/weizhiao/rust-elfloader/ causes trouble on the latest
 # released version of elf-loader, thus we limit ourselves to the released
 # version right before it.
-elf_loader = { version = "=0.10.0", features = ["fs"] }
+elf_loader = { version = "=0.10.0", default-features = false, features = [] }
 thiserror = { version = "2.0.6", default-features = false }
 ringbuf = { version = "0.4.8", default-features = false, features = ["alloc"] }
 
@@ -23,7 +23,7 @@ ringbuf = { version = "0.4.8", default-features = false, features = ["alloc"] }
 # we need to do it as a target-specific dependency.
 #
 # NOTE: We must keep this in sync with the version above.
-elf_loader = { version = "=0.10.0", features = ["fs", "rel"] }
+elf_loader = { version = "=0.10.0", default-features = false, features = ["rel"] }
 
 [features]
 unstable-testing = []

--- a/litebox_shim_linux/src/loader/elf.rs
+++ b/litebox_shim_linux/src/loader/elf.rs
@@ -54,7 +54,7 @@ impl ElfObject for ElfFile {
                 Ok(bytes_read) => {
                     if bytes_read == 0 {
                         // reached the end of the file
-                        return Err(elf_loader::Error::IOError {
+                        return Err(elf_loader::Error::MmapError {
                             msg: "failed to fill buffer".to_string(),
                         });
                     } else {
@@ -65,7 +65,7 @@ impl ElfObject for ElfFile {
                 }
                 Err(_) => {
                     // Error occurred
-                    return Err(elf_loader::Error::IOError {
+                    return Err(elf_loader::Error::MmapError {
                         msg: "failed to read from file".to_string(),
                     });
                 }


### PR DESCRIPTION
The only usage of `fs` in `elf_loader` in our shim is for `IOError` part of the enum. The actual choice of the enum doesn't _really_ matter for this error, since it is only used to print out the message.

`elf_loader` itself doesn't _need_ to know if things are being `mmap`d in, or they are being I/O'd in. Thus, by switching the error codes to be an `MmapError`, we are able to remove `fs` from the required features for `elf_loader`. This in turn allows us to remove the (transitive) dependency both `libc` and `syscalls` within the shim (specifically, `elf_loader` requires you to depend on at least one of the two, if you have the `fs` feature around, even if you are not using them).