### PR TITLE
Support syscall dup/dup2/dup3

### DIFF
--- a/litebox_common_linux/src/lib.rs
+++ b/litebox_common_linux/src/lib.rs
@@ -486,15 +486,8 @@ pub enum SyscallRequest<Platform: litebox::platform::RawPointerProvider> {
     },
     Dup {
         oldfd: i32,
-    },
-    Dup2 {
-        oldfd: i32,
-        newfd: i32,
-    },
-    Dup3 {
-        oldfd: i32,
-        newfd: i32,
-        flags: litebox::fs::OFlags,
+        newfd: Option<i32>,
+        flags: Option<litebox::fs::OFlags>,
     },
     Socket {
         domain: AddressFamily,

--- a/litebox_platform_linux_userland/src/syscall_intercept/systrap.rs
+++ b/litebox_platform_linux_userland/src/syscall_intercept/systrap.rs
@@ -300,15 +300,20 @@ unsafe extern "C" fn syscall_dispatcher(syscall_number: i64, args: *const usize)
         },
         libc::SYS_dup => SyscallRequest::Dup {
             oldfd: syscall_args[0].reinterpret_as_signed().truncate(),
+            newfd: None,
+            flags: None,
         },
-        libc::SYS_dup2 => SyscallRequest::Dup2 {
+        libc::SYS_dup2 => SyscallRequest::Dup {
             oldfd: syscall_args[0].reinterpret_as_signed().truncate(),
-            newfd: syscall_args[1].reinterpret_as_signed().truncate(),
+            newfd: Some(syscall_args[1].reinterpret_as_signed().truncate()),
+            flags: None,
         },
-        libc::SYS_dup3 => SyscallRequest::Dup3 {
+        libc::SYS_dup3 => SyscallRequest::Dup {
             oldfd: syscall_args[0].reinterpret_as_signed().truncate(),
-            newfd: syscall_args[1].reinterpret_as_signed().truncate(),
-            flags: litebox::fs::OFlags::from_bits_truncate(syscall_args[2].truncate()),
+            newfd: Some(syscall_args[1].reinterpret_as_signed().truncate()),
+            flags: Some(litebox::fs::OFlags::from_bits_truncate(
+                syscall_args[2].truncate(),
+            )),
         },
         libc::SYS_socket => {
             let domain: u32 = syscall_args[0].truncate();

--- a/litebox_shim_linux/src/lib.rs
+++ b/litebox_shim_linux/src/lib.rs
@@ -157,6 +157,9 @@ impl Descriptors {
         }
     }
     fn insert_at(&mut self, descriptor: Descriptor, idx: usize) -> Option<Descriptor> {
+        if idx >= self.descriptors.len() {
+            self.descriptors.resize_with(idx + 1, Default::default);
+        }
         self.descriptors
             .get_mut(idx)
             .and_then(|v| v.replace(descriptor))
@@ -337,15 +340,11 @@ pub fn syscall_entry(request: SyscallRequest<Platform>) -> isize {
                 syscalls::file::sys_access(path, mode).map(|()| 0)
             })
         }
-        SyscallRequest::Dup { oldfd } => syscalls::file::sys_dup(oldfd).map(|newfd| newfd as usize),
-        SyscallRequest::Dup2 { oldfd, newfd } => {
-            syscalls::file::sys_dup2(oldfd, newfd).map(|newfd| newfd as usize)
-        }
-        SyscallRequest::Dup3 {
+        SyscallRequest::Dup {
             oldfd,
             newfd,
             flags,
-        } => syscalls::file::sys_dup3(oldfd, newfd, flags).map(|newfd| newfd as usize),
+        } => syscalls::file::sys_dup(oldfd, newfd, flags).map(|newfd| newfd as usize),
         SyscallRequest::Socket {
             domain,
             ty,

--- a/litebox_shim_linux/src/stdio.rs
+++ b/litebox_shim_linux/src/stdio.rs
@@ -139,7 +139,7 @@ mod tests {
         let stdin = 0;
         let flags = sys_fcntl(stdin, FcntlArg::GETFL).unwrap();
 
-        let stdin2 = i32::try_from(sys_dup(stdin).unwrap()).unwrap();
+        let stdin2 = i32::try_from(sys_dup(stdin, None, None).unwrap()).unwrap();
         assert_eq!(flags, sys_fcntl(stdin2, FcntlArg::GETFL).unwrap());
 
         let mut stdio_path: [u8; 32] = [0; 32];


### PR DESCRIPTION
This PR adds support for syscall dup/dup2/dup3. Currently, it only supports `dup` for stdio.

#74/#76 provide storage for per-file and per-fd metadata. `close_on_exec` is per-fd metadata while file `status` is per-file-struct metadata (which is different from per-file metadata). Basically, `status` is shared among `dup`ed fds, while `open`ed fds that point to same file do not share the same `status`. I added a [test](https://github.com/MSRSSP/litebox/blob/5d30eb0a8fc407bb59359a7cddbf73cf70d53eb8/litebox_shim_linux/src/stdio.rs#L136) that might be clearer.