### PR TITLE
Refine CI trigger to only main branch for push events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,11 @@
 name: CI
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
This PR reduces our CI load to not automatically trigger the CI on all push events; instead, it will only trigger on PRs (or on pushes to the `main` branch).