### PR TITLE
Add exit/exit_group

### DIFF
--- a/litebox/src/litebox.rs
+++ b/litebox/src/litebox.rs
@@ -33,7 +33,7 @@ impl<Platform: RawSyncPrimitivesProvider + ExitProvider> LiteBox<Platform> {
         // TODO(jayb): After #24, #31, we will be able to pass along clean-up operations to
         // subcomponents, to request a clean-up. For now, there is no clean-up necessary, we can
         // just exit.
-        self.x.platform.exit(exit_code)
+        self.x.platform.exit(exit_code, true)
     }
 }
 

--- a/litebox/src/platform/mock.rs
+++ b/litebox/src/platform/mock.rs
@@ -50,7 +50,7 @@ impl ExitProvider for MockPlatform {
     type ExitCode = i32;
     const EXIT_SUCCESS: Self::ExitCode = 0;
     const EXIT_FAILURE: Self::ExitCode = 1;
-    fn exit(&self, code: Self::ExitCode) -> ! {
+    fn exit(&self, code: Self::ExitCode, is_exit_group: bool) -> ! {
         unimplemented!("exit for MockPlatform")
     }
 }

--- a/litebox/src/platform/mod.rs
+++ b/litebox/src/platform/mod.rs
@@ -47,7 +47,9 @@ pub trait ExitProvider: Sized {
     const EXIT_SUCCESS: Self::ExitCode;
     const EXIT_FAILURE: Self::ExitCode;
     /// Exits the program with the given exit code.
-    fn exit(&self, code: Self::ExitCode) -> !;
+    ///
+    /// `is_exit_group` indicates whether it terminates all threads in the process or just the current thread.
+    fn exit(&self, code: Self::ExitCode, is_exit_group: bool) -> !;
 }
 
 /// Punch through any functionality for a particular platform that is not explicitly part of the

--- a/litebox_common_linux/src/lib.rs
+++ b/litebox_common_linux/src/lib.rs
@@ -546,6 +546,12 @@ pub enum SyscallRequest<Platform: litebox::platform::RawPointerProvider> {
         sockfd: i32,
         backlog: u16,
     },
+    Exit {
+        code: i32,
+    },
+    ExitGroup {
+        code: i32,
+    },
     Fcntl {
         fd: i32,
         arg: FcntlArg,

--- a/litebox_platform_linux_kernel/src/lib.rs
+++ b/litebox_platform_linux_kernel/src/lib.rs
@@ -69,7 +69,7 @@ impl<Host: HostInterface> ExitProvider for LinuxKernel<Host> {
     type ExitCode = i32;
     const EXIT_SUCCESS: Self::ExitCode = 0;
     const EXIT_FAILURE: Self::ExitCode = 1;
-    fn exit(&self, _code: Self::ExitCode) -> ! {
+    fn exit(&self, _code: Self::ExitCode, _is_exit_group: bool) -> ! {
         // TODO: We should probably expand the host to handle an error code?
         Host::exit()
     }

--- a/litebox_platform_lvbs/src/lib.rs
+++ b/litebox_platform_lvbs/src/lib.rs
@@ -45,7 +45,7 @@ impl<Host: HostInterface> ExitProvider for LinuxKernel<Host> {
     type ExitCode = i32;
     const EXIT_SUCCESS: Self::ExitCode = 0;
     const EXIT_FAILURE: Self::ExitCode = 1;
-    fn exit(&self, _code: Self::ExitCode) -> ! {
+    fn exit(&self, _code: Self::ExitCode, _is_exit_group: bool) -> ! {
         // TODO: We should probably expand the host to handle an error code?
         Host::exit()
     }


### PR DESCRIPTION
We need to differentiate between `exit` and `exit_group` as `exit` only terminates the current calling thread while `exit_group` terminates the whole process.