### PR TITLE
semver-checks: add check to ensure PR base is `main`

### DIFF
--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -11,6 +11,11 @@ jobs:
     name: Check SemVer Correctness
     runs-on: ubuntu-latest
     steps:
+      - name: Fail if PR base is not main
+        if: github.event.pull_request.base.ref != 'main'
+        run: |
+          echo "This PR does not target the 'main' branch. Exiting."
+          exit 1
       - name: Check out repo
         uses: actions/checkout@v4
       - name: Ensure that the main branch is fetched
@@ -74,4 +79,4 @@ jobs:
           -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
           https://api.github.com/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/issues/${{ github.event.number }}/comments \
-          -d "$(if [ -s /tmp/semver-checks-stdout ]; then echo -e ':robot: SemverChecks :robot: Potential breaking API changes detected\n\n<details><summary>Click for details</summary>\n\n```'"$(cat /tmp/semver-checks-stdout)"'\n```\n</details>'; else echo -e ':robot: SemverChecks :robot: No breaking API changes detected\n\nNote: this does not mean API is unchanged, or even that there are no breaking changes; simply, none of the detections triggered.'; fi | jq -sR '{body: .}')"
+          -d "$(if [ -s /tmp/semver-checks-stdout ]; then echo -e ':robot: SemverChecks :robot: :warning: Potential breaking API changes detected :warning:\n\n<details><summary>Click for details</summary>\n\n```'"$(cat /tmp/semver-checks-stdout)"'\n```\n</details>'; else echo -e ':robot: SemverChecks :robot: No breaking API changes detected\n\nNote: this does not mean API is unchanged, or even that there are no breaking changes; simply, none of the detections triggered.'; fi | jq -sR '{body: .}')"


### PR DESCRIPTION
Turns out semver-checks is quite confusing if the PR base is not `main`. This PR adds a check to ensure that the PR base is `main`.  It also updates the "breaking changes" text to have ⚠️ symbols to make it visually stand out.

I expect this PR to initially fail (as a test) and then to succeed once I force-push and then update base (currently I've chosen a random other branch as base, just as a test).

EDIT: Tested to fail in situations (where base is not set to `main`) as expected. I will merge it upon a CI green.