### PR TITLE
Update CI workflow to include apt update before package installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Check out repo
         uses: actions/checkout@v4
-      - run: sudo apt install -y musl-tools
+      - run: sudo apt update && sudo apt install -y musl-tools
       - name: "Ratchet: ensure number of 'transmute's in codebase is not increasing"
         run: |
           if [ $(find . -name \*.rs -print0 | xargs -0 grep 'transmute' | wc -l) -eq 5 ]; then \
@@ -59,7 +59,7 @@ jobs:
     steps:
       - name: Check out repo
         uses: actions/checkout@v4
-      - run: sudo apt install -y gcc-multilib musl-tools
+      - run: sudo apt update && sudo apt install -y gcc-multilib musl-tools
       - name: Set up Rust
         run: |
           rustup toolchain install $(awk -F'"' '/channel/{print $2}' rust-toolchain.toml) --profile minimal --no-self-update --component rustfmt,clippy --target i686-unknown-linux-gnu,i686-unknown-linux-musl


### PR DESCRIPTION
Apparently, as per [GitHub Actions documentation](https://docs.github.com/en/actions/how-tos/using-github-hosted-runners/customizing-github-hosted-runners#installing-software-on-ubuntu-runners), we need to run `apt update` before `apt install`.  We have not hit a particularly bad apt cache in our runner images (since GH Actions updates them very regularly) before, so we were able to save a tiny bit of time by not actually running `apt update`.  However, apparently in PR #211 (see [this CI run result](https://github.com/microsoft/litebox/actions/runs/16306783607/job/46054462004?pr=211)), we actually hit a cache issue.

This PR fixes this by always doing an `apt update`.

<details><summary>Output from the GitHub Actions result linked above (Click to view)</summary>

```
sudo apt install -y gcc-multilib musl-tools
  shell: /usr/bin/bash -e {0}
  env:
    CARGO_TERM_COLOR: always
    RUSTFLAGS: -Dwarnings

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

Reading package lists...
Building dependency tree...
Reading state information...
The following additional packages will be installed:
  gcc-13-multilib lib32asan8 lib32atomic1 lib32gcc-13-dev lib32gomp1 lib32itm1
  lib32quadmath0 lib32ubsan1 libc6-dev-i386 libc6-dev-x32 libc6-x32
  libx32asan8 libx32atomic1 libx32gcc-13-dev libx32gcc-s1 libx32gomp1
  libx32itm1 libx32quadmath0 libx32stdc++6 libx32ubsan1 musl musl-dev
The following NEW packages will be installed:
  gcc-13-multilib gcc-multilib lib32asan8 lib32atomic1 lib32gcc-13-dev
  lib32gomp1 lib32itm1 lib32quadmath0 lib32ubsan1 libc6-dev-i386 libc6-dev-x32
  libc6-x32 libx32asan8 libx32atomic1 libx32gcc-13-dev libx32gcc-s1
  libx32gomp1 libx32itm1 libx32quadmath0 libx32stdc++6 libx32ubsan1 musl
  musl-dev musl-tools
0 upgraded, 24 newly installed, 0 to remove and 4 not upgraded.
Need to get 21.3 MB of archives.
After this operation, 79.3 MB of additional disk space will be used.
Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [144 B]
Ign:2 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libc6-dev-i386 amd64 2.39-0ubuntu8.4
Ign:3 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libc6-x32 amd64 2.39-0ubuntu8.4
Ign:4 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libc6-dev-x32 amd64 2.39-0ubuntu8.4
Get:5 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libx32gcc-s1 amd64 14.2.0-4ubuntu2~24.04 [78.5 kB]
Get:6 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 lib32gomp1 amd64 14.2.0-4ubuntu2~24.04 [141 kB]
Get:7 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libx32gomp1 amd64 14.2.0-4ubuntu2~24.04 [145 kB]
Get:8 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 lib32itm1 amd64 14.2.0-4ubuntu2~24.04 [29.6 kB]
Get:9 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libx32itm1 amd64 14.2.0-4ubuntu2~24.04 [29.8 kB]
Get:10 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 lib32atomic1 amd64 14.2.0-4ubuntu2~24.04 [8586 B]
Get:11 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libx32atomic1 amd64 14.2.0-4ubuntu2~24.04 [10.3 kB]
Get:12 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 lib32asan8 amd64 14.2.0-4ubuntu2~24.04 [2879 kB]
Get:13 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libx32asan8 amd64 14.2.0-4ubuntu2~24.04 [2893 kB]
Ign:2 https://archive.ubuntu.com/ubuntu noble-updates/main amd64 libc6-dev-i386 amd64 2.39-0ubuntu8.4
Ign:3 https://archive.ubuntu.com/ubuntu noble-updates/main amd64 libc6-x32 amd64 2.39-0ubuntu8.4
Get:14 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 lib32ubsan1 amd64 14.2.0-4ubuntu2~24.04 [1150 kB]
Ign:4 https://archive.ubuntu.com/ubuntu noble-updates/main amd64 libc6-dev-x32 amd64 2.39-0ubuntu8.4
Get:15 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libx32stdc++6 amd64 14.2.0-4ubuntu2~24.04 [778 kB]
Get:16 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libx32ubsan1 amd64 14.2.0-4ubuntu2~24.04 [1169 kB]
Ign:2 https://security.ubuntu.com/ubuntu noble-updates/main amd64 libc6-dev-i386 amd64 2.39-0ubuntu8.4
Err:2 mirror+file:/etc/apt/apt-mirrors.txt noble-updates/main amd64 libc6-dev-i386 amd64 2.39-0ubuntu8.4
  404  Not Found [IP: 52.154.174.208 80]
Get:17 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 lib32quadmath0 amd64 14.2.0-4ubuntu2~24.04 [227 kB]
Get:18 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libx32quadmath0 amd64 14.2.0-4ubuntu2~24.04 [157 kB]
Ign:3 https://security.ubuntu.com/ubuntu noble-updates/main amd64 libc6-x32 amd64 2.39-0ubuntu8.4
Err:3 mirror+file:/etc/apt/apt-mirrors.txt noble-updates/main amd64 libc6-x32 amd64 2.39-0ubuntu8.4
  404  Not Found [IP: 52.154.174.208 80]
Get:19 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 lib32gcc-13-dev amd64 13.3.0-6ubuntu2~24.04 [2380 kB]
Ign:4 https://security.ubuntu.com/ubuntu noble-updates/main amd64 libc6-dev-x32 amd64 2.39-0ubuntu8.4
Err:4 mirror+file:/etc/apt/apt-mirrors.txt noble-updates/main amd64 libc6-dev-x32 amd64 2.39-0ubuntu8.4
  404  Not Found [IP: 52.154.174.208 80]
Get:20 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libx32gcc-13-dev amd64 13.3.0-6ubuntu2~24.04 [2190 kB]
Get:21 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 gcc-13-multilib amd64 13.3.0-6ubuntu2~24.04 [878 B]
Get:22 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 gcc-multilib amd64 4:13.2.0-7ubuntu1 [1474 B]
Get:23 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 musl amd64 1.2.4-2 [416 kB]
Get:24 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 musl-dev amd64 1.2.4-2 [616 kB]
Get:25 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 musl-tools amd64 1.2.4-2 [5540 B]
Fetched 15.3 MB in 3s (4790 kB/s)
E: Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/pool/main/g/glibc/libc6-dev-i386_2.39-0ubuntu8.4_amd64.deb  404  Not Found [IP: 52.154.174.208 80]
E: Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/pool/main/g/glibc/libc6-x32_2.39-0ubuntu8.4_amd64.deb  404  Not Found [IP: 52.154.174.208 80]
E: Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/pool/main/g/glibc/libc6-dev-x32_2.39-0ubuntu8.4_amd64.deb  404  Not Found [IP: 52.154.174.208 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```

</details>