### PR TITLE
Support syscall futex

### DIFF
--- a/litebox_common_linux/src/errno/mod.rs
+++ b/litebox_common_linux/src/errno/mod.rs
@@ -341,3 +341,20 @@ impl From<litebox::event::polling::TryOpError<Errno>> for Errno {
         }
     }
 }
+
+impl From<litebox::platform::ImmediatelyWokenUp> for Errno {
+    fn from(_: litebox::platform::ImmediatelyWokenUp) -> Self {
+        Errno::EAGAIN
+    }
+}
+
+impl From<litebox::platform::RawMutexBlockError> for Errno {
+    fn from(value: litebox::platform::RawMutexBlockError) -> Self {
+        match value {
+            litebox::platform::RawMutexBlockError::ImmediatelyWokenUp => Errno::EAGAIN,
+            litebox::platform::RawMutexBlockError::Interrupted => Errno::EINTR,
+            litebox::platform::RawMutexBlockError::InvalidAddress => Errno::EFAULT,
+            _ => unimplemented!(),
+        }
+    }
+}

--- a/litebox_common_linux/src/lib.rs
+++ b/litebox_common_linux/src/lib.rs
@@ -1333,6 +1333,52 @@ pub struct CapData {
     pub inheritable: u32,
 }
 
+#[non_exhaustive]
+#[repr(i32)]
+#[derive(Debug, IntEnum, PartialEq)]
+pub enum FutexOperation {
+    WAIT = 0,
+    WAKE = 1,
+    WAIT_BITSET = 9,
+}
+
+bitflags::bitflags! {
+    #[derive(Debug)]
+    pub struct FutexFlags: i32 {
+        const PRIVATE = 0x80; // FUTEX_PRIVATE_FLAG
+        const CLOCK_REALTIME = 0x100; // FUTEX_CLOCK_REALTIME
+        /// <https://docs.rs/bitflags/*/bitflags/#externally-defined-flags>
+        const _ = !0;
+
+        const FUTEX_CMD_MASK = !(FutexFlags::PRIVATE.bits() | FutexFlags::CLOCK_REALTIME.bits());
+    }
+}
+
+#[non_exhaustive]
+pub enum FutexArgs<Platform: litebox::platform::RawPointerProvider> {
+    WAIT {
+        addr: Platform::RawConstPointer<u32>,
+        flags: FutexFlags,
+        val: u32,
+        // Note: for FUTEX_WAIT, timeout is interpreted as a relative
+        //   value.  This differs from other futex operations, where
+        //   timeout is interpreted as an absolute value.
+        timeout: Option<Platform::RawConstPointer<Timespec>>,
+    },
+    WAIT_BITSET {
+        addr: Platform::RawConstPointer<u32>,
+        flags: FutexFlags,
+        val: u32,
+        timeout: Option<Platform::RawConstPointer<Timespec>>,
+        bitmask: u32,
+    },
+    WAKE {
+        addr: Platform::RawConstPointer<u32>,
+        flags: FutexFlags,
+        count: u32,
+    },
+}
+
 /// Request to syscall handler
 #[non_exhaustive]
 pub enum SyscallRequest<'a, Platform: litebox::platform::RawPointerProvider> {
@@ -1624,6 +1670,9 @@ pub enum SyscallRequest<'a, Platform: litebox::platform::RawPointerProvider> {
     CapGet {
         header: Platform::RawMutPointer<CapHeader>,
         data: Option<Platform::RawMutPointer<CapData>>,
+    },
+    Futex {
+        args: FutexArgs<Platform>,
     },
     /// A sentinel that is expected to be "handled" by trivially returning its value.
     Ret(errno::Errno),
@@ -2200,6 +2249,40 @@ impl<'a, Platform: litebox::platform::RawPointerProvider> SyscallRequest<'a, Pla
                     },
                 }
             }
+            Sysno::futex => {
+                let op: i32 = ctx.syscall_arg(1).reinterpret_as_signed().truncate();
+                let cmd = FutexOperation::try_from(op & FutexFlags::FUTEX_CMD_MASK.bits())
+                    .expect("Invalid futex operation");
+                let flags = FutexFlags::from_bits(op & !FutexFlags::FUTEX_CMD_MASK.bits()).unwrap();
+                let addr = Platform::RawConstPointer::from_usize(ctx.syscall_arg(0));
+                let val = ctx.syscall_arg(2).truncate();
+                let timeout = if ctx.syscall_arg(3) == 0 {
+                    None
+                } else {
+                    Some(Platform::RawConstPointer::from_usize(ctx.syscall_arg(3)))
+                };
+                let args = match cmd {
+                    FutexOperation::WAIT => FutexArgs::WAIT {
+                        addr,
+                        flags,
+                        val,
+                        timeout,
+                    },
+                    FutexOperation::WAIT_BITSET => FutexArgs::WAIT_BITSET {
+                        addr,
+                        flags,
+                        val,
+                        timeout,
+                        bitmask: ctx.syscall_arg(5).truncate(),
+                    },
+                    FutexOperation::WAKE => FutexArgs::WAKE {
+                        addr,
+                        flags,
+                        count: val,
+                    },
+                };
+                SyscallRequest::Futex { args }
+            }
             Sysno::statx | Sysno::io_uring_setup | Sysno::rseq => {
                 SyscallRequest::Ret(errno::Errno::ENOSYS)
             }
@@ -2243,9 +2326,7 @@ pub enum PunchthroughSyscall<Platform: litebox::platform::RawPointerProvider> {
     },
     /// Set the FS base register to the value in `addr`.
     #[cfg(target_arch = "x86_64")]
-    SetFsBase {
-        addr: usize,
-    },
+    SetFsBase { addr: usize },
     /// Get the current value of the FS base register and store it in `addr`.
     #[cfg(target_arch = "x86_64")]
     GetFsBase {
@@ -2254,9 +2335,6 @@ pub enum PunchthroughSyscall<Platform: litebox::platform::RawPointerProvider> {
     #[cfg(target_arch = "x86")]
     SetThreadArea {
         user_desc: Platform::RawMutPointer<UserDesc>,
-    },
-    WakeByAddress {
-        addr: Platform::RawMutPointer<i32>,
     },
 }
 

--- a/litebox_platform_freebsd_userland/src/lib.rs
+++ b/litebox_platform_freebsd_userland/src/lib.rs
@@ -8,10 +8,10 @@ use core::sync::atomic::AtomicU32;
 use core::time::Duration;
 
 use litebox::fs::OFlags;
+use litebox::platform::RawConstPointer;
 use litebox::platform::page_mgmt::MemoryRegionPermissions;
 use litebox::platform::trivial_providers::TransparentMutPtr;
-use litebox::platform::{ImmediatelyWokenUp, RawConstPointer};
-use litebox::platform::{ThreadLocalStorageProvider, UnblockedOrTimedOut};
+use litebox::platform::{RawMutexBlockError, ThreadLocalStorageProvider, UnblockedOrTimedOut};
 use litebox::utils::ReinterpretUnsignedExt as _;
 use litebox_common_linux::{ProtFlags, PunchthroughSyscall};
 
@@ -362,124 +362,36 @@ impl litebox::platform::ThreadProvider for FreeBSDUserland {
 
 impl litebox::platform::RawMutexProvider for FreeBSDUserland {
     type RawMutex = RawMutex;
+    type UserRawMutex = UserRawMutex;
 
     fn new_raw_mutex(&self) -> Self::RawMutex {
         RawMutex {
             inner: AtomicU32::new(0),
-            num_to_wake_up: AtomicU32::new(0),
         }
+    }
+
+    fn from_raw_ptr(ptr: Self::RawConstPointer<u32>) -> Option<Self::UserRawMutex> {
+        if ptr.as_usize() % core::mem::align_of::<AtomicU32>() != 0 {
+            return None;
+        }
+        Some(UserRawMutex(ptr))
     }
 }
 
-/// Raw mutex for FreeBSD.
-pub struct RawMutex {
-    // The `inner` is the value shown to the outside world as an underlying atomic.
-    inner: AtomicU32,
-    num_to_wake_up: AtomicU32,
-}
+pub struct UserRawMutex(litebox::platform::trivial_providers::TransparentConstPtr<u32>);
 
-impl RawMutex {
-    fn block_or_maybe_timeout(
-        &self,
-        val: u32,
-        timeout: Option<Duration>,
-    ) -> Result<UnblockedOrTimedOut, ImmediatelyWokenUp> {
-        use core::sync::atomic::Ordering::SeqCst;
-
-        // We immediately wake up (without even hitting syscalls) if we can clearly see that the
-        // value is different.
-        if self.inner.load(SeqCst) != val {
-            return Err(ImmediatelyWokenUp);
-        }
-
-        // Track some initial information.
-        let mut first_time = true;
-        let start = std::time::Instant::now();
-
-        // We'll be looping unless we find a good reason to exit out of the loop, either due to a
-        // wake-up or a time-out. We do a singular (only as a one-off) check for the
-        // immediate-wake-up purely as an optimization, but otherwise, the only way to exit this
-        // loop is to actually hit an `Ok` state out for this function.
-        loop {
-            let remaining_time = match timeout {
-                None => None,
-                Some(timeout) => match timeout.checked_sub(start.elapsed()) {
-                    None => {
-                        break Ok(UnblockedOrTimedOut::TimedOut);
-                    }
-                    Some(remaining_time) => Some(remaining_time),
-                },
-            };
-
-            // We wait on the umtx_op, with a timeout if needed; the timeout is based on how much time
-            // remains to be elapsed.
-            match umtx_op_operation_timeout(
-                &self.num_to_wake_up,
-                freebsd_types::UmtxOpOperation::UMTX_OP_WAIT_UINT,
-                /* expected value */ 0,
-                remaining_time,
-            ) {
-                Ok(0) => {
-                    // Fallthrough: just let the waker to clean up the value.
-                    return Ok(UnblockedOrTimedOut::Unblocked);
-                }
-                Err(e) if e == i32::from(crate::errno::Errno::EAGAIN) as isize => {
-                    // A wake-up was already in progress when we attempted to wait. Has someone
-                    // already touched inner value? We only check this on the first time around,
-                    // anything else could be a true wake.
-                    if first_time && self.inner.load(SeqCst) != val {
-                        // Ah, we seem to have actually been immediately woken up! Let us not
-                        // miss this.
-                        return Err(ImmediatelyWokenUp);
-                    } else {
-                        // Try again.
-                        first_time = false;
-                    }
-                }
-                Err(e) => {
-                    panic!("Unexpected errno={e} for UMTX_OP_WAIT")
-                }
-                _ => unreachable!(),
-            }
-        }
-    }
-}
-
-impl litebox::platform::RawMutex for RawMutex {
-    fn underlying_atomic(&self) -> &AtomicU32 {
-        &self.inner
-    }
-
-    /// Wake up multiple waiters.
-    /// Always returns `n` on success, and `0` on failure.
+impl litebox::platform::UserRawMutex for UserRawMutex {
     fn wake_many(&self, n: usize) -> usize {
-        use core::sync::atomic::Ordering::SeqCst;
-
         assert!(n > 0);
         let n: u32 = n.try_into().unwrap();
         // The highest two bits are always reserved as "lock bits".
         let n = n.min((1 << 30) - 1);
 
-        // For FreeBSD, we can't do the same requeue trick as Linux futex, nor can we infer
-        // the actually woken up count, so we always clear the `num_to_wake_up` value
-        // and let the kernel decide the number of threads to wake up.
-
-        // Set the number of waiters we want allowed to know that they can wake up, while
-        // also grabbing the "lock bit"s.
-        while self
-            .num_to_wake_up
-            .compare_exchange(0, n | (0b11 << 30), SeqCst, SeqCst)
-            .is_err()
-        {
-            // If someone else is _also_ attempting to wake waiters up, then we should just spin
-            // until the other waker is done with their job and brings the value down.
-            core::hint::spin_loop();
-        }
-
+        let mutex = unsafe { &*(self.0.as_usize() as *const AtomicU32) };
         // Now we can actually wake them up using FreeBSD's umtx_op and it always returns 0
         // on success. We cannot ask the kernel how many were woken up.
         match umtx_op_operation_timeout(
-            &self.num_to_wake_up,
+            mutex,
             freebsd_types::UmtxOpOperation::UMTX_OP_WAKE,
             n as usize, // Number of threads to wake
             None,       // No timeout for wake operations
@@ -489,18 +401,16 @@ impl litebox::platform::RawMutex for RawMutex {
                 return 0;
             }
             Ok(_) => {
-                // Unlock the lock bits and clean up the value, allowing other wakers to run.
-                self.num_to_wake_up.store(0, SeqCst);
                 return n as usize;
             }
         };
     }
 
-    fn block(&self, val: u32) -> Result<(), ImmediatelyWokenUp> {
-        match self.block_or_maybe_timeout(val, None) {
-            Ok(UnblockedOrTimedOut::Unblocked) => Ok(()),
-            Ok(UnblockedOrTimedOut::TimedOut) => unreachable!(),
-            Err(ImmediatelyWokenUp) => Err(ImmediatelyWokenUp),
+    fn block(&self, val: u32) -> Result<(), RawMutexBlockError> {
+        let mutex = unsafe { &*(self.0.as_usize() as *const AtomicU32) };
+        match block_or_maybe_timeout(mutex, val, None)? {
+            UnblockedOrTimedOut::Unblocked => Ok(()),
+            UnblockedOrTimedOut::TimedOut => unreachable!(),
         }
     }
 
@@ -508,8 +418,126 @@ impl litebox::platform::RawMutex for RawMutex {
         &self,
         val: u32,
         timeout: Duration,
-    ) -> Result<UnblockedOrTimedOut, ImmediatelyWokenUp> {
-        self.block_or_maybe_timeout(val, Some(timeout))
+    ) -> Result<UnblockedOrTimedOut, RawMutexBlockError> {
+        let mutex = unsafe { &*(self.0.as_usize() as *const AtomicU32) };
+        block_or_maybe_timeout(mutex, val, Some(timeout))
+    }
+}
+
+/// Raw mutex for FreeBSD.
+pub struct RawMutex {
+    // The `inner` is the value shown to the outside world as an underlying atomic.
+    inner: AtomicU32,
+}
+
+fn block_or_maybe_timeout(
+    mutex: &AtomicU32,
+    val: u32,
+    timeout: Option<Duration>,
+) -> Result<UnblockedOrTimedOut, RawMutexBlockError> {
+    use core::sync::atomic::Ordering::SeqCst;
+
+    // We immediately wake up (without even hitting syscalls) if we can clearly see that the
+    // value is different.
+    if mutex.load(SeqCst) != val {
+        return Err(RawMutexBlockError::ImmediatelyWokenUp);
+    }
+
+    // Track some initial information.
+    let start = std::time::Instant::now();
+
+    // We'll be looping unless we find a good reason to exit out of the loop, either due to a
+    // wake-up or a time-out. We do a singular (only as a one-off) check for the
+    // immediate-wake-up purely as an optimization, but otherwise, the only way to exit this
+    // loop is to actually hit an `Ok` state out for this function.
+    loop {
+        let remaining_time = match timeout {
+            None => None,
+            Some(timeout) => match timeout.checked_sub(start.elapsed()) {
+                None => {
+                    break Ok(UnblockedOrTimedOut::TimedOut);
+                }
+                Some(remaining_time) => Some(remaining_time),
+            },
+        };
+
+        // We wait on the umtx_op, with a timeout if needed; the timeout is based on how much time
+        // remains to be elapsed.
+        match umtx_op_operation_timeout(
+            mutex,
+            freebsd_types::UmtxOpOperation::UMTX_OP_WAIT_UINT,
+            /* expected value */ val as usize,
+            remaining_time,
+        ) {
+            Ok(0) => {
+                if mutex.load(SeqCst) != val {
+                    return Ok(UnblockedOrTimedOut::Unblocked);
+                }
+            }
+            Err(e) if e == i32::from(crate::errno::Errno::EAGAIN) as isize => {
+                if mutex.load(SeqCst) != val {
+                    // Ah, we seem to have actually been immediately woken up! Let us not
+                    // miss this.
+                    return Err(RawMutexBlockError::ImmediatelyWokenUp);
+                }
+            }
+            Err(e) if e == i32::from(crate::errno::Errno::ETIMEDOUT) as isize => {
+                return Ok(UnblockedOrTimedOut::TimedOut);
+            }
+            Err(e) => {
+                panic!("Unexpected errno={e} for UMTX_OP_WAIT")
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl litebox::platform::RawMutex for RawMutex {
+    fn underlying_atomic(&self) -> &AtomicU32 {
+        &self.inner
+    }
+}
+
+impl litebox::platform::UserRawMutex for RawMutex {
+    /// Wake up multiple waiters.
+    /// Always returns `n` on success, and `0` on failure.
+    fn wake_many(&self, n: usize) -> usize {
+        assert!(n > 0);
+        let n: u32 = n.try_into().unwrap();
+        // The highest two bits are always reserved as "lock bits".
+        let n = n.min((1 << 30) - 1);
+
+        // Now we can actually wake them up using FreeBSD's umtx_op and it always returns 0
+        // on success. We cannot ask the kernel how many were woken up.
+        match umtx_op_operation_timeout(
+            &self.inner,
+            freebsd_types::UmtxOpOperation::UMTX_OP_WAKE,
+            n as usize, // Number of threads to wake
+            None,       // No timeout for wake operations
+        ) {
+            Err(_) => {
+                // Wake failed.
+                return 0;
+            }
+            Ok(_) => {
+                return n as usize;
+            }
+        };
+    }
+
+    fn block(&self, val: u32) -> Result<(), RawMutexBlockError> {
+        match block_or_maybe_timeout(&self.inner, val, None)? {
+            UnblockedOrTimedOut::Unblocked => Ok(()),
+            UnblockedOrTimedOut::TimedOut => unreachable!(),
+        }
+    }
+
+    fn block_or_timeout(
+        &self,
+        val: u32,
+        timeout: Duration,
+    ) -> Result<UnblockedOrTimedOut, RawMutexBlockError> {
+        block_or_maybe_timeout(&self.inner, val, Some(timeout))
     }
 }
 
@@ -594,21 +622,6 @@ impl litebox::platform::PunchthroughToken for PunchthroughToken {
                 )?;
                 Ok(0)
             }
-            PunchthroughSyscall::WakeByAddress { addr } => unsafe {
-                syscalls::syscall5(
-                    syscalls::Sysno::UmtxOp,
-                    addr.as_usize(),
-                    freebsd_types::UmtxOpOperation::UMTX_OP_WAKE as usize,
-                    1,
-                    addr.as_usize(),
-                    0,
-                )
-            }
-            .map_err(|err| match err {
-                errno::Errno::EINVAL => litebox_common_linux::errno::Errno::EINVAL,
-                _ => panic!("unexpected error {err}"),
-            })
-            .map_err(litebox::platform::PunchthroughError::Failure),
             _ => {
                 unimplemented!(
                     "PunchthroughToken for FreeBSDUserland is not fully implemented yet"
@@ -1065,7 +1078,6 @@ mod tests {
     fn test_raw_mutex() {
         let mutex = std::sync::Arc::new(super::RawMutex {
             inner: AtomicU32::new(0),
-            num_to_wake_up: AtomicU32::new(0),
         });
 
         let copied_mutex = mutex.clone();

--- a/litebox_platform_linux_kernel/src/host/snp/snp_impl.rs
+++ b/litebox_platform_linux_kernel/src/host/snp/snp_impl.rs
@@ -3,6 +3,7 @@
 use core::arch::asm;
 
 use litebox::platform::{RawConstPointer, RawMutPointer};
+use litebox::utils::ReinterpretUnsignedExt as _;
 use litebox_common_linux::{SigSet, SigmaskHow};
 
 use super::ghcb::ghcb_prints;
@@ -98,9 +99,6 @@ const PHYS_ADDR_MAX: u64 = 0x10_0000_0000u64; // 64GB
 
 const NR_SYSCALL_FUTEX: u32 = 202;
 const NR_SYSCALL_RT_SIGPROCMASK: u32 = 14;
-
-const FUTEX_WAIT: i32 = 0;
-const FUTEX_WAKE: i32 = 1;
 
 /// Punchthrough for syscalls
 ///
@@ -284,7 +282,18 @@ impl HostInterface for HostSnpInterface {
     fn wake_many(mutex: &core::sync::atomic::AtomicU32, n: usize) -> Result<usize, Errno> {
         // TODO: sandbox driver needs to be updated to accept a kernel pointer from the guest
         Self::syscalls(SyscallN::<6, NR_SYSCALL_FUTEX> {
-            args: [mutex.as_ptr() as u64, FUTEX_WAKE as u64, n as u64, 0, 0, 0],
+            args: [
+                core::ptr::from_ref(mutex) as u64,
+                u64::from(
+                    (litebox_common_linux::FutexOperation::WAKE as i32
+                        | litebox_common_linux::FutexFlags::PRIVATE.bits())
+                    .reinterpret_as_unsigned(),
+                ),
+                n as u64,
+                0,
+                0,
+                0,
+            ],
         })
     }
 
@@ -300,8 +309,12 @@ impl HostInterface for HostSnpInterface {
         // TODO: sandbox driver needs to be updated to accept a kernel pointer from the guest
         Self::syscalls(SyscallN::<6, NR_SYSCALL_FUTEX> {
             args: [
-                mutex.as_ptr() as u64,
-                FUTEX_WAIT as u64,
+                core::ptr::from_ref(mutex) as u64,
+                u64::from(
+                    (litebox_common_linux::FutexOperation::WAIT as i32
+                        | litebox_common_linux::FutexFlags::PRIVATE.bits())
+                    .reinterpret_as_unsigned(),
+                ),
                 u64::from(val),
                 timeout
                     .as_ref()

--- a/litebox_platform_linux_userland/src/lib.rs
+++ b/litebox_platform_linux_userland/src/lib.rs
@@ -10,10 +10,10 @@ use std::sync::atomic::Ordering::SeqCst;
 use std::time::Duration;
 
 use litebox::fs::OFlags;
-use litebox::platform::UnblockedOrTimedOut;
 use litebox::platform::page_mgmt::MemoryRegionPermissions;
-use litebox::platform::trivial_providers::TransparentMutPtr;
-use litebox::platform::{ImmediatelyWokenUp, RawConstPointer, ThreadLocalStorageProvider};
+use litebox::platform::trivial_providers::{TransparentConstPtr, TransparentMutPtr};
+use litebox::platform::{RawConstPointer, ThreadLocalStorageProvider};
+use litebox::platform::{RawMutexBlockError, UnblockedOrTimedOut};
 use litebox::utils::{ReinterpretSignedExt, ReinterpretUnsignedExt as _, TruncateExt};
 use litebox_common_linux::{CloneFlags, MRemapFlags, MapFlags, ProtFlags, PunchthroughSyscall};
 
@@ -528,11 +528,55 @@ impl litebox::platform::ThreadProvider for LinuxUserland {
 
 impl litebox::platform::RawMutexProvider for LinuxUserland {
     type RawMutex = RawMutex;
+    type UserRawMutex = UserRawMutex;
 
     fn new_raw_mutex(&self) -> Self::RawMutex {
         RawMutex {
             inner: AtomicU32::new(0),
         }
+    }
+
+    fn from_raw_ptr(ptr: Self::RawConstPointer<u32>) -> Option<Self::UserRawMutex> {
+        if ptr.as_usize() % core::mem::align_of::<AtomicU32>() != 0 {
+            return None;
+        }
+        Some(UserRawMutex(ptr))
+    }
+}
+
+pub struct UserRawMutex(TransparentConstPtr<u32>);
+
+impl litebox::platform::UserRawMutex for UserRawMutex {
+    fn wake_many(&self, n: usize) -> usize {
+        assert!(n > 0);
+        let n: u32 = n.try_into().unwrap();
+
+        let mutex = unsafe { &*(self.0.as_usize() as *const AtomicU32) };
+        futex_val2(
+            mutex,
+            FutexOperation::Wake,
+            /* number to wake up */ n,
+            /* val2: ignored */ 0,
+            /* uaddr2: ignored */ None,
+        )
+        .expect("failed to wake up waiters")
+    }
+
+    fn block(&self, val: u32) -> Result<(), RawMutexBlockError> {
+        let mutex = unsafe { &*(self.0.as_usize() as *const AtomicU32) };
+        match block_or_maybe_timeout(mutex, val, None)? {
+            UnblockedOrTimedOut::Unblocked => Ok(()),
+            UnblockedOrTimedOut::TimedOut => unreachable!(),
+        }
+    }
+
+    fn block_or_timeout(
+        &self,
+        val: u32,
+        timeout: Duration,
+    ) -> Result<UnblockedOrTimedOut, RawMutexBlockError> {
+        let mutex = unsafe { &*(self.0.as_usize() as *const AtomicU32) };
+        block_or_maybe_timeout(mutex, val, Some(timeout))
     }
 }
 
@@ -544,75 +588,68 @@ pub struct RawMutex {
     inner: AtomicU32,
 }
 
-impl RawMutex {
-    fn block_or_maybe_timeout(
-        &self,
-        val: u32,
-        timeout: Option<Duration>,
-    ) -> Result<UnblockedOrTimedOut, ImmediatelyWokenUp> {
-        // We immediately wake up (without even hitting syscalls) if we can clearly see that the
-        // value is different.
-        if self.inner.load(SeqCst) != val {
-            return Err(ImmediatelyWokenUp);
-        }
+fn block_or_maybe_timeout(
+    mutex: &AtomicU32,
+    val: u32,
+    timeout: Option<Duration>,
+) -> Result<UnblockedOrTimedOut, RawMutexBlockError> {
+    // We immediately wake up (without even hitting syscalls) if we can clearly see that the
+    // value is different.
+    if mutex.load(SeqCst) != val {
+        return Err(RawMutexBlockError::ImmediatelyWokenUp);
+    }
 
-        // Track some initial information.
-        let start = std::time::Instant::now();
+    // Track some initial information.
+    let start = std::time::Instant::now();
 
-        // We'll be looping unless we find a good reason to exit out of the loop, either due to a
-        // wake-up or a time-out. We do a singular (only as a one-off) check for the
-        // immediate-wake-up purely as an optimization, but otherwise, the only way to exit this
-        // loop is to actually hit an `Ok` state out for this function.
-        loop {
-            let remaining_time = match timeout {
-                None => None,
-                Some(timeout) => match timeout.checked_sub(start.elapsed()) {
-                    None => {
-                        break Ok(UnblockedOrTimedOut::TimedOut);
-                    }
-                    Some(remaining_time) => Some(remaining_time),
-                },
-            };
+    // We'll be looping unless we find a good reason to exit out of the loop, either due to a
+    // wake-up or a time-out. We do a singular (only as a one-off) check for the
+    // immediate-wake-up purely as an optimization, but otherwise, the only way to exit this
+    // loop is to actually hit an `Ok` state out for this function.
+    loop {
+        let remaining_time = match timeout {
+            None => None,
+            Some(timeout) => match timeout.checked_sub(start.elapsed()) {
+                None => {
+                    break Ok(UnblockedOrTimedOut::TimedOut);
+                }
+                Some(remaining_time) => Some(remaining_time),
+            },
+        };
 
-            // We wait on the futex, with a timeout if needed; the timeout is based on how much time
-            // remains to be elapsed.
-            match futex_timeout(
-                &self.inner,
-                FutexOperation::Wait,
-                /* expected value */ val,
-                remaining_time,
-                /* ignored */ None,
-                /* ignored */ 0,
-            ) {
-                Ok(0) => {
-                    if self.inner.load(SeqCst) != val {
-                        return Ok(UnblockedOrTimedOut::Unblocked);
-                    }
+        // We wait on the futex, with a timeout if needed; the timeout is based on how much time
+        // remains to be elapsed.
+        match futex_timeout(
+            mutex,
+            FutexOperation::Wait,
+            /* expected value */ val,
+            remaining_time,
+            /* ignored */ None,
+        ) {
+            Ok(0) => {
+                if mutex.load(SeqCst) != val {
+                    return Ok(UnblockedOrTimedOut::Unblocked);
                 }
-                Err(syscalls::Errno::EAGAIN) => {
-                    if self.inner.load(SeqCst) != val {
-                        // Ah, we seem to have actually been immediately woken up! Let us not
-                        // miss this.
-                        return Err(ImmediatelyWokenUp);
-                    }
-                }
-                Err(syscalls::Errno::ETIMEDOUT) => {
-                    return Ok(UnblockedOrTimedOut::TimedOut);
-                }
-                Err(e) => {
-                    panic!("Unexpected errno={e} for FUTEX_WAIT")
-                }
-                _ => unreachable!(),
             }
+            Err(syscalls::Errno::EAGAIN) => {
+                if mutex.load(SeqCst) != val {
+                    // Ah, we seem to have actually been immediately woken up! Let us not
+                    // miss this.
+                    return Err(RawMutexBlockError::ImmediatelyWokenUp);
+                }
+            }
+            Err(syscalls::Errno::ETIMEDOUT) => {
+                return Ok(UnblockedOrTimedOut::TimedOut);
+            }
+            Err(e) => {
+                panic!("Unexpected errno={e} for FUTEX_WAIT")
+            }
+            _ => unreachable!(),
         }
     }
 }
 
-impl litebox::platform::RawMutex for RawMutex {
-    fn underlying_atomic(&self) -> &AtomicU32 {
-        &self.inner
-    }
-
+impl litebox::platform::UserRawMutex for RawMutex {
     fn wake_many(&self, n: usize) -> usize {
         assert!(n > 0);
         let n: u32 = n.try_into().unwrap();
@@ -623,16 +660,14 @@ impl litebox::platform::RawMutex for RawMutex {
             /* number to wake up */ n,
             /* val2: ignored */ 0,
             /* uaddr2: ignored */ None,
-            /* val3: ignored */ 0,
         )
         .expect("failed to wake up waiters")
     }
 
-    fn block(&self, val: u32) -> Result<(), ImmediatelyWokenUp> {
-        match self.block_or_maybe_timeout(val, None) {
-            Ok(UnblockedOrTimedOut::Unblocked) => Ok(()),
-            Ok(UnblockedOrTimedOut::TimedOut) => unreachable!(),
-            Err(ImmediatelyWokenUp) => Err(ImmediatelyWokenUp),
+    fn block(&self, val: u32) -> Result<(), RawMutexBlockError> {
+        match block_or_maybe_timeout(&self.inner, val, None)? {
+            UnblockedOrTimedOut::Unblocked => Ok(()),
+            UnblockedOrTimedOut::TimedOut => unreachable!(),
         }
     }
 
@@ -640,8 +675,14 @@ impl litebox::platform::RawMutex for RawMutex {
         &self,
         val: u32,
         timeout: Duration,
-    ) -> Result<UnblockedOrTimedOut, ImmediatelyWokenUp> {
-        self.block_or_maybe_timeout(val, Some(timeout))
+    ) -> Result<UnblockedOrTimedOut, RawMutexBlockError> {
+        block_or_maybe_timeout(&self.inner, val, Some(timeout))
+    }
+}
+
+impl litebox::platform::RawMutex for RawMutex {
+    fn underlying_atomic(&self) -> &AtomicU32 {
+        &self.inner
     }
 }
 
@@ -852,22 +893,6 @@ impl litebox::platform::PunchthroughToken for PunchthroughToken {
             PunchthroughSyscall::SetThreadArea { user_desc } => {
                 set_thread_area(user_desc).map_err(litebox::platform::PunchthroughError::Failure)
             }
-            PunchthroughSyscall::WakeByAddress { addr } => unsafe {
-                syscalls::syscall6(
-                    syscalls::Sysno::futex,
-                    addr.as_usize(),
-                    usize::try_from(FutexOperation::Wake as i32).unwrap(),
-                    1,
-                    0,
-                    0,
-                    0,
-                )
-            }
-            .map_err(|err| match err {
-                syscalls::Errno::EINVAL => litebox_common_linux::errno::Errno::EINVAL,
-                _ => panic!("unexpected error {err}"),
-            })
-            .map_err(litebox::platform::PunchthroughError::Failure),
         }
     }
 }
@@ -918,7 +943,6 @@ fn futex_timeout(
     val: u32,
     timeout: Option<Duration>,
     uaddr2: Option<&AtomicU32>,
-    val3: u32,
 ) -> Result<usize, syscalls::Errno> {
     let uaddr: *const AtomicU32 = uaddr as _;
     let futex_op: i32 = futex_op as _;
@@ -950,7 +974,7 @@ fn futex_timeout(
                 0 // No timeout
             },
             uaddr2 as usize,
-            val3 as usize,
+            syscall_intercept::SYSCALL_ARG_MAGIC,
         )
     }
 }
@@ -962,7 +986,6 @@ fn futex_val2(
     val: u32,
     val2: u32,
     uaddr2: Option<&AtomicU32>,
-    val3: u32,
 ) -> Result<usize, syscalls::Errno> {
     let uaddr: *const AtomicU32 = uaddr as _;
     let futex_op: i32 = futex_op as _;
@@ -975,7 +998,7 @@ fn futex_val2(
             val as usize,
             val2 as usize,
             uaddr2 as usize,
-            val3 as usize,
+            syscall_intercept::SYSCALL_ARG_MAGIC,
         )
     }
 }
@@ -1550,7 +1573,7 @@ mod tests {
     use core::sync::atomic::AtomicU32;
     use std::thread::sleep;
 
-    use litebox::platform::{RawMutex, ThreadLocalStorageProvider as _};
+    use litebox::platform::{RawMutex, ThreadLocalStorageProvider as _, UserRawMutex as _};
 
     use crate::LinuxUserland;
     use litebox::platform::PageManagementProvider;
@@ -1572,7 +1595,7 @@ mod tests {
             copied_mutex.wake_many(10);
         });
 
-        assert!(mutex.block(0).is_ok());
+        assert!(RawMutex::block(mutex.as_ref(), 0).is_ok());
     }
 
     #[test]

--- a/litebox_platform_linux_userland/src/syscall_intercept/systrap.rs
+++ b/litebox_platform_linux_userland/src/syscall_intercept/systrap.rs
@@ -238,7 +238,45 @@ fn register_seccomp_filter() {
                 .unwrap(),
             ],
         ),
-        (libc::SYS_futex, vec![]),
+        (
+            libc::SYS_futex,
+            vec![
+                SeccompRule::new(vec![
+                    SeccompCondition::new(
+                        1,
+                        SeccompCmpArgLen::Dword,
+                        SeccompCmpOp::MaskedEq(0x7f),
+                        libc::FUTEX_WAIT as u64,
+                    )
+                    .unwrap(),
+                    SeccompCondition::new(
+                        5,
+                        SeccompCmpArgLen::Qword,
+                        SeccompCmpOp::Eq,
+                        super::SYSCALL_ARG_MAGIC as u64,
+                    )
+                    .unwrap(),
+                ])
+                .unwrap(),
+                SeccompRule::new(vec![
+                    SeccompCondition::new(
+                        1,
+                        SeccompCmpArgLen::Dword,
+                        SeccompCmpOp::MaskedEq(0x7f),
+                        libc::FUTEX_WAKE as u64,
+                    )
+                    .unwrap(),
+                    SeccompCondition::new(
+                        5,
+                        SeccompCmpArgLen::Qword,
+                        SeccompCmpOp::Eq,
+                        super::SYSCALL_ARG_MAGIC as u64,
+                    )
+                    .unwrap(),
+                ])
+                .unwrap(),
+            ],
+        ),
         (
             libc::SYS_exit,
             vec![

--- a/litebox_platform_lvbs/src/lib.rs
+++ b/litebox_platform_lvbs/src/lib.rs
@@ -16,12 +16,13 @@ use core::{
 };
 use host::linux::sigset_t;
 use litebox::mm::linux::PageRange;
+use litebox::platform::RawPointerProvider;
 use litebox::platform::page_mgmt::DeallocationError;
 use litebox::platform::{
-    DebugLogProvider, ExitProvider, IPInterfaceProvider, ImmediatelyWokenUp,
-    PageManagementProvider, RawMutexProvider, StdioProvider, TimeProvider, UnblockedOrTimedOut,
+    DebugLogProvider, ExitProvider, IPInterfaceProvider, PageManagementProvider,
+    RawConstPointer as _, RawMutexBlockError, RawMutexProvider, StdioProvider, TimeProvider,
+    UnblockedOrTimedOut,
 };
-use litebox::platform::{RawMutex as _, RawPointerProvider};
 use litebox_common_linux::errno::Errno;
 use ptr::{UserConstPtr, UserMutPtr};
 use x86_64::structures::paging::{
@@ -358,6 +359,7 @@ impl<Host: HostInterface> LinuxKernel<Host> {
 
 impl<Host: HostInterface> RawMutexProvider for LinuxKernel<Host> {
     type RawMutex = RawMutex<Host>;
+    type UserRawMutex = UserRawMutex<Host>;
 
     fn new_raw_mutex(&self) -> Self::RawMutex {
         Self::RawMutex {
@@ -365,6 +367,21 @@ impl<Host: HostInterface> RawMutexProvider for LinuxKernel<Host> {
             host: core::marker::PhantomData,
         }
     }
+
+    fn from_raw_ptr<'a>(ptr: Self::RawConstPointer<u32>) -> Option<Self::UserRawMutex> {
+        if ptr.as_usize() % core::mem::align_of::<AtomicU32>() != 0 {
+            return None;
+        }
+        Some(UserRawMutex {
+            inner: ptr,
+            host: core::marker::PhantomData,
+        })
+    }
+}
+
+pub struct UserRawMutex<Host: HostInterface> {
+    inner: UserConstPtr<u32>,
+    host: core::marker::PhantomData<Host>,
 }
 
 /// An implementation of [`litebox::platform::RawMutex`]
@@ -381,71 +398,90 @@ impl<Host: HostInterface> litebox::platform::RawMutex for RawMutex<Host> {
     fn underlying_atomic(&self) -> &core::sync::atomic::AtomicU32 {
         &self.inner
     }
+}
 
+impl<Host: HostInterface> litebox::platform::UserRawMutex for RawMutex<Host> {
     fn wake_many(&self, n: usize) -> usize {
         Host::wake_many(&self.inner, n).unwrap()
     }
 
-    fn block(&self, val: u32) -> Result<(), ImmediatelyWokenUp> {
-        match self.block_or_maybe_timeout(val, None) {
-            Ok(UnblockedOrTimedOut::Unblocked) => Ok(()),
-            Ok(UnblockedOrTimedOut::TimedOut) => unreachable!(),
-            Err(ImmediatelyWokenUp) => Err(ImmediatelyWokenUp),
-        }
+    fn block(&self, val: u32) -> Result<(), litebox::platform::RawMutexBlockError> {
+        block_or_maybe_timeout::<Host>(&self.inner, val, None, || {
+            Some(self.inner.load(core::sync::atomic::Ordering::Relaxed))
+        })
+        .map(|res| match res {
+            UnblockedOrTimedOut::Unblocked => (),
+            UnblockedOrTimedOut::TimedOut => unreachable!(),
+        })
     }
 
     fn block_or_timeout(
         &self,
         val: u32,
         time: core::time::Duration,
-    ) -> Result<litebox::platform::UnblockedOrTimedOut, ImmediatelyWokenUp> {
-        self.block_or_maybe_timeout(val, Some(time))
+    ) -> Result<UnblockedOrTimedOut, litebox::platform::RawMutexBlockError> {
+        block_or_maybe_timeout::<Host>(&self.inner, val, Some(time), || {
+            Some(self.inner.load(core::sync::atomic::Ordering::Relaxed))
+        })
     }
 }
 
-impl<Host: HostInterface> RawMutex<Host> {
-    fn block_or_maybe_timeout(
+impl<Host: HostInterface> litebox::platform::UserRawMutex for UserRawMutex<Host> {
+    fn wake_many(&self, n: usize) -> usize {
+        let mutex = unsafe { &*(self.inner.as_usize() as *const AtomicU32) };
+        Host::wake_many(mutex, n).unwrap()
+    }
+
+    fn block(&self, val: u32) -> Result<(), RawMutexBlockError> {
+        let mutex = unsafe { &*(self.inner.as_usize() as *const AtomicU32) };
+        block_or_maybe_timeout::<Host>(mutex, val, None, || {
+            unsafe { self.inner.read_at_offset(0) }.map(alloc::borrow::Cow::into_owned)
+        })
+        .map(|res| match res {
+            UnblockedOrTimedOut::Unblocked => (),
+            UnblockedOrTimedOut::TimedOut => unreachable!(),
+        })
+    }
+
+    fn block_or_timeout(
         &self,
         val: u32,
-        timeout: Option<core::time::Duration>,
-    ) -> Result<UnblockedOrTimedOut, ImmediatelyWokenUp> {
-        loop {
-            // No need to wait if the value already changed.
-            if self
-                .underlying_atomic()
-                .load(core::sync::atomic::Ordering::Relaxed)
-                != val
-            {
-                return Err(ImmediatelyWokenUp);
+        time: core::time::Duration,
+    ) -> Result<litebox::platform::UnblockedOrTimedOut, RawMutexBlockError> {
+        let mutex = unsafe { &*(self.inner.as_usize() as *const AtomicU32) };
+        block_or_maybe_timeout::<Host>(mutex, val, Some(time), || {
+            unsafe { self.inner.read_at_offset(0) }.map(alloc::borrow::Cow::into_owned)
+        })
+    }
+}
+
+fn block_or_maybe_timeout<Host: HostInterface>(
+    mutex: &AtomicU32,
+    val: u32,
+    timeout: Option<core::time::Duration>,
+    load: impl Fn() -> Option<u32>,
+) -> Result<UnblockedOrTimedOut, RawMutexBlockError> {
+    loop {
+        // No need to wait if the value already changed.
+        if load().ok_or(RawMutexBlockError::InvalidAddress)? != val {
+            return Err(RawMutexBlockError::ImmediatelyWokenUp);
+        }
+
+        match Host::block_or_maybe_timeout(mutex, val, timeout) {
+            Ok(()) => {
+                if load().ok_or(RawMutexBlockError::InvalidAddress)? != val {
+                    return Ok(UnblockedOrTimedOut::Unblocked);
+                }
             }
-
-            let ret = Host::block_or_maybe_timeout(&self.inner, val, timeout);
-
-            match ret {
-                Ok(()) => {
-                    if self
-                        .underlying_atomic()
-                        .load(core::sync::atomic::Ordering::Relaxed)
-                        != val
-                    {
-                        return Ok(UnblockedOrTimedOut::Unblocked);
+            Err(e) => {
+                return match e {
+                    Errno::EAGAIN => Err(RawMutexBlockError::ImmediatelyWokenUp),
+                    Errno::EINTR => Err(RawMutexBlockError::Interrupted),
+                    Errno::ETIMEDOUT => Ok(UnblockedOrTimedOut::TimedOut),
+                    _ => {
+                        panic!("Unexpected error: {:?}", e);
                     }
-                }
-                Err(Errno::EAGAIN) => {
-                    // If the futex value does not match val, then the call fails
-                    // immediately with the error EAGAIN.
-                    return Err(ImmediatelyWokenUp);
-                }
-                Err(Errno::EINTR) => {
-                    // return Err(ImmediatelyWokenUp);
-                    todo!("EINTR");
-                }
-                Err(Errno::ETIMEDOUT) => {
-                    return Ok(UnblockedOrTimedOut::TimedOut);
-                }
-                Err(e) => {
-                    panic!("Error: {:?}", e);
-                }
+                };
             }
         }
     }

--- a/litebox_shim_linux/src/lib.rs
+++ b/litebox_shim_linux/src/lib.rs
@@ -693,6 +693,7 @@ pub fn handle_syscall_request(request: SyscallRequest<Platform>) -> isize {
         SyscallRequest::CapGet { header, data } => {
             syscalls::misc::sys_capget(header, data).map(|()| 0)
         }
+        SyscallRequest::Futex { args } => syscalls::process::sys_futex(args),
         _ => {
             todo!()
         }


### PR DESCRIPTION
Add support for syscall futex with some limitations:

1. Shared futex is treated as private futex as we don't support multi-processing
2. Only support WAIT/WAKE/WAIT_BITSET
3. For WAIT_BITSET, only support bitmask `FUTEX_BITSET_MATCH_ANY`, which essentially is `WAIT`. Supporting arbitrary bitmask is possible but require some more work.
4. For Linux userland, our `TimeProvider` calls `libc::clock_gettime(CLOCK_MONOTONIC)` (which in turn calls into vDSO). Thus, only support monotonic time but not real time for `timeout` parameter in this PR.

This PR also adds test for running node using rewriter backend. However, the test becomes really slow (5-10min) because rewriting node (>100MB) takes time. Also, it may trigger OOM when I tested it locally. Thus, this is also disabled for now.