### PR TITLE
Refine the testcase `process` for WindowsUserland

### DIFF
--- a/litebox_shim_linux/src/syscalls/process.rs
+++ b/litebox_shim_linux/src/syscalls/process.rs
@@ -636,19 +636,18 @@ mod tests {
                     unsafe { current_fs_base.assume_init() },
                     "FS base should match TLS pointer"
                 );
-            }
 
-            // Check the TLS value from FS base
-            let mut fs_0: u8;
-            unsafe {
-                core::arch::asm!("mov {0}, fs:0", out(reg_byte) fs_0);
+                // Check the TLS value from FS base
+                let mut fs_0: u8;
+                unsafe {
+                    core::arch::asm!("mov {0}, fs:0", out(reg_byte) fs_0);
+                }
+                // Verify that the TLS value is initialized to its correct value (`1`).
+                assert_eq!(
+                    fs_0, 0x1,
+                    "TLS value from FS base should match the initialized value"
+                );
             }
-
-            // Verify that the TLS value is initialized to its correct value (`1`).
-            assert_eq!(
-                fs_0, 0x1,
-                "TLS value from FS base should match the initialized value"
-            );
 
             assert!(unsafe { CHILD_TID } > 0, "Child TID should be set");
             assert_eq!(


### PR DESCRIPTION
In `litebox_shim_linux`'s syscall testcases, also added TLS content read check for WindowsUserland to make sure it can handle the memory access violation (caused by un-saved `FS` at OS context switches).