### PR TITLE
Move memory management syscalls/functions to `litebox_common_linux`

### DIFF
--- a/litebox_common_linux/src/lib.rs
+++ b/litebox_common_linux/src/lib.rs
@@ -13,6 +13,7 @@ use litebox::{
 use syscalls::Sysno;
 
 pub mod errno;
+pub mod mm;
 
 extern crate alloc;
 

--- a/litebox_common_linux/src/mm.rs
+++ b/litebox_common_linux/src/mm.rs
@@ -1,0 +1,249 @@
+//! Common implementation of memory management related syscalls, eg., `mmap`, `munmap`, etc.
+
+use litebox::{
+    mm::linux::{
+        CreatePagesFlags, MappingError, NonZeroAddress, NonZeroPageSize, PAGE_SIZE, VmemUnmapError,
+    },
+    platform::{RawConstPointer, page_mgmt::DeallocationError},
+};
+
+use crate::{MRemapFlags, MapFlags, ProtFlags, errno::Errno};
+
+const PAGE_MASK: usize = !(PAGE_SIZE - 1);
+
+#[inline]
+fn align_up(addr: usize, align: usize) -> usize {
+    debug_assert!(align.is_power_of_two());
+    (addr + align - 1) & !(align - 1)
+}
+
+#[inline]
+fn align_down(addr: usize, align: usize) -> usize {
+    debug_assert!(align.is_power_of_two());
+    addr & !(align - 1)
+}
+
+pub fn do_mmap<
+    Platform: litebox::platform::RawPointerProvider
+        + litebox::sync::RawSyncPrimitivesProvider
+        + litebox::platform::PageManagementProvider<{ litebox::mm::linux::PAGE_SIZE }>,
+>(
+    pm: &litebox::mm::PageManager<Platform, { litebox::mm::linux::PAGE_SIZE }>,
+    suggested_addr: Option<usize>,
+    len: usize,
+    prot: ProtFlags,
+    flags: MapFlags,
+    ensure_space_after: bool,
+    op: impl FnOnce(Platform::RawMutPointer<u8>) -> Result<usize, litebox::mm::linux::MappingError>,
+) -> Result<Platform::RawMutPointer<u8>, litebox::mm::linux::MappingError> {
+    let flags = {
+        let mut create_flags = CreatePagesFlags::empty();
+        create_flags.set(
+            CreatePagesFlags::FIXED_ADDR,
+            flags.contains(MapFlags::MAP_FIXED),
+        );
+        create_flags.set(
+            CreatePagesFlags::POPULATE_PAGES_IMMEDIATELY,
+            flags.contains(MapFlags::MAP_POPULATE),
+        );
+        create_flags.set(CreatePagesFlags::ENSURE_SPACE_AFTER, ensure_space_after);
+        create_flags.set(
+            CreatePagesFlags::MAP_FILE,
+            !flags.contains(MapFlags::MAP_ANONYMOUS),
+        );
+        create_flags
+    };
+    let suggested_addr = match suggested_addr {
+        Some(addr) => Some(NonZeroAddress::new(addr).ok_or(MappingError::UnAligned)?),
+        None => None,
+    };
+    let length = NonZeroPageSize::new(len).ok_or(MappingError::UnAligned)?;
+    match prot {
+        ProtFlags::PROT_READ_EXEC => unsafe {
+            pm.create_executable_pages(suggested_addr, length, flags, op)
+        },
+        ProtFlags::PROT_READ_WRITE => unsafe {
+            pm.create_writable_pages(suggested_addr, length, flags, op)
+        },
+        ProtFlags::PROT_READ => unsafe {
+            pm.create_readable_pages(suggested_addr, length, flags, op)
+        },
+        ProtFlags::PROT_NONE => unsafe {
+            pm.create_inaccessible_pages(suggested_addr, length, flags, op)
+        },
+        _ => todo!("Unsupported prot flags {:?}", prot),
+    }
+}
+
+/// Handle syscall `munmap`
+pub fn sys_munmap<
+    Platform: litebox::platform::RawPointerProvider
+        + litebox::sync::RawSyncPrimitivesProvider
+        + litebox::platform::PageManagementProvider<{ litebox::mm::linux::PAGE_SIZE }>,
+>(
+    pm: &litebox::mm::PageManager<Platform, { litebox::mm::linux::PAGE_SIZE }>,
+    addr: Platform::RawMutPointer<u8>,
+    len: usize,
+) -> Result<(), Errno> {
+    if addr.as_usize() & !PAGE_MASK != 0 {
+        return Err(Errno::EINVAL);
+    }
+    if len == 0 {
+        return Err(Errno::EINVAL);
+    }
+    let aligned_len = align_up(len, PAGE_SIZE);
+    if addr.as_usize().checked_add(aligned_len).is_none() {
+        return Err(Errno::EINVAL);
+    }
+
+    match unsafe { pm.remove_pages(addr, aligned_len) } {
+        Err(VmemUnmapError::UnAligned) => Err(Errno::EINVAL),
+        Err(VmemUnmapError::UnmapError(e)) => match e {
+            DeallocationError::Unaligned => Err(Errno::EINVAL),
+            // It is not an error if the indicated range does not contain any mapped pages.
+            DeallocationError::AlreadyUnallocated => Ok(()),
+            _ => unimplemented!(),
+        },
+        Ok(()) => Ok(()),
+    }
+}
+
+/// Handle syscall `mprotect`
+pub fn sys_mprotect<
+    Platform: litebox::platform::RawPointerProvider
+        + litebox::sync::RawSyncPrimitivesProvider
+        + litebox::platform::PageManagementProvider<{ litebox::mm::linux::PAGE_SIZE }>,
+>(
+    pm: &litebox::mm::PageManager<Platform, { litebox::mm::linux::PAGE_SIZE }>,
+    addr: Platform::RawMutPointer<u8>,
+    len: usize,
+    prot: ProtFlags,
+) -> Result<(), Errno> {
+    if addr.as_usize() & !PAGE_MASK != 0 {
+        return Err(Errno::EINVAL);
+    }
+    if len == 0 {
+        return Ok(());
+    }
+
+    match prot {
+        ProtFlags::PROT_READ_EXEC => unsafe { pm.make_pages_executable(addr, len) },
+        ProtFlags::PROT_READ_WRITE => unsafe { pm.make_pages_writable(addr, len) },
+        ProtFlags::PROT_READ => unsafe { pm.make_pages_readable(addr, len) },
+        ProtFlags::PROT_NONE => unsafe { pm.make_pages_inaccessible(addr, len) },
+        ProtFlags::PROT_READ_WRITE_EXEC => unsafe { pm.make_pages_rwx(addr, len) },
+        _ => todo!("Unsupported prot flags {:?}", prot),
+    }
+    .map_err(Errno::from)
+}
+
+/// Handle syscall `mremap`
+pub fn sys_mremap<
+    Platform: litebox::platform::RawPointerProvider
+        + litebox::sync::RawSyncPrimitivesProvider
+        + litebox::platform::PageManagementProvider<{ litebox::mm::linux::PAGE_SIZE }>,
+>(
+    pm: &litebox::mm::PageManager<Platform, { litebox::mm::linux::PAGE_SIZE }>,
+    old_addr: Platform::RawMutPointer<u8>,
+    old_size: usize,
+    new_size: usize,
+    flags: MRemapFlags,
+    _new_addr: usize,
+) -> Result<Platform::RawMutPointer<u8>, Errno> {
+    if flags.intersects(
+        (MRemapFlags::MREMAP_FIXED | MRemapFlags::MREMAP_MAYMOVE | MRemapFlags::MREMAP_DONTUNMAP)
+            .complement(),
+    ) {
+        return Err(Errno::EINVAL);
+    }
+    if flags.contains(MRemapFlags::MREMAP_FIXED) && !flags.contains(MRemapFlags::MREMAP_MAYMOVE) {
+        return Err(Errno::EINVAL);
+    }
+    /*
+     * MREMAP_DONTUNMAP is always a move and it does not allow resizing
+     * in the process.
+     */
+    if flags.contains(MRemapFlags::MREMAP_DONTUNMAP)
+        && (!flags.contains(MRemapFlags::MREMAP_MAYMOVE) || old_size != new_size)
+    {
+        return Err(Errno::EINVAL);
+    }
+    if old_addr.as_usize() & !PAGE_MASK != 0 {
+        return Err(Errno::EINVAL);
+    }
+
+    let old_size = align_down(old_size, PAGE_SIZE);
+    let new_size = align_down(new_size, PAGE_SIZE);
+    if new_size == 0 {
+        return Err(Errno::EINVAL);
+    }
+
+    if flags.intersects(MRemapFlags::MREMAP_FIXED | MRemapFlags::MREMAP_DONTUNMAP) {
+        todo!("Unsupported flags {:?}", flags);
+    }
+
+    unsafe {
+        pm.remap_pages(
+            old_addr,
+            old_size,
+            new_size,
+            flags.contains(MRemapFlags::MREMAP_MAYMOVE),
+        )
+    }
+    .map_err(Errno::from)
+}
+
+pub fn sys_brk<
+    Platform: litebox::platform::RawPointerProvider
+        + litebox::sync::RawSyncPrimitivesProvider
+        + litebox::platform::PageManagementProvider<{ litebox::mm::linux::PAGE_SIZE }>,
+>(
+    pm: &litebox::mm::PageManager<Platform, { litebox::mm::linux::PAGE_SIZE }>,
+    addr: Platform::RawMutPointer<u8>,
+) -> Result<usize, Errno> {
+    unsafe { pm.brk(addr.as_usize()) }.map_err(Errno::from)
+}
+
+pub fn sys_madvise<
+    Platform: litebox::platform::RawPointerProvider
+        + litebox::sync::RawSyncPrimitivesProvider
+        + litebox::platform::PageManagementProvider<{ litebox::mm::linux::PAGE_SIZE }>,
+>(
+    pm: &litebox::mm::PageManager<Platform, { litebox::mm::linux::PAGE_SIZE }>,
+    addr: Platform::RawMutPointer<u8>,
+    len: usize,
+    advice: crate::MadviseBehavior,
+) -> Result<(), Errno> {
+    if addr.as_usize() & !PAGE_MASK != 0 {
+        return Err(Errno::EINVAL);
+    }
+    if len == 0 {
+        return Ok(());
+    }
+    let aligned_len = len.next_multiple_of(PAGE_SIZE);
+    if aligned_len == 0 {
+        // overflow
+        return Err(Errno::EINVAL);
+    }
+    let Some(_end) = addr.as_usize().checked_add(aligned_len) else {
+        return Err(Errno::EINVAL);
+    };
+
+    match advice {
+        crate::MadviseBehavior::Normal
+        | crate::MadviseBehavior::DontFork
+        | crate::MadviseBehavior::DoFork => {
+            // No-op for now, as we don't support fork yet.
+            Ok(())
+        }
+        crate::MadviseBehavior::DontNeed => {
+            // After a successful MADV_DONTNEED operation, the semantics of memory access in the specified region are changed:
+            // subsequent accesses of pages in the range will succeed, but will result in either repopulating the memory contents
+            // from the up-to-date contents of the underlying mapped file (for shared file mappings, shared anonymous mappings,
+            // and shmem-based techniques such as System V shared memory segments) or zero-fill-on-demand pages for anonymous private mappings.
+            //
+            // Note we do not support shared memory yet, so this is just to discard the pages without removing the mapping.
+            unsafe { pm.reset_pages(addr, len) }.map_err(Errno::from)
+        }
+    }
+}

--- a/litebox_shim_linux/src/syscalls/mm.rs
+++ b/litebox_shim_linux/src/syscalls/mm.rs
@@ -1,10 +1,9 @@
 //! Implementation of memory management related syscalls, eg., `mmap`, `munmap`, etc.
+//! Most of these syscalls which are not backed by files are implemented in [`litebox_common_linux::mm`].
 
 use litebox::{
-    mm::linux::{
-        CreatePagesFlags, MappingError, NonZeroAddress, NonZeroPageSize, PAGE_SIZE, VmemUnmapError,
-    },
-    platform::{RawConstPointer, RawMutPointer, page_mgmt::DeallocationError},
+    mm::linux::{MappingError, PAGE_SIZE},
+    platform::RawMutPointer,
 };
 use litebox_common_linux::{MRemapFlags, MapFlags, ProtFlags, errno::Errno};
 
@@ -25,6 +24,7 @@ fn align_down(addr: usize, align: usize) -> usize {
     addr & !(align - 1)
 }
 
+#[inline]
 fn do_mmap(
     suggested_addr: Option<usize>,
     len: usize,
@@ -33,46 +33,18 @@ fn do_mmap(
     ensure_space_after: bool,
     op: impl FnOnce(MutPtr<u8>) -> Result<usize, MappingError>,
 ) -> Result<MutPtr<u8>, MappingError> {
-    let flags = {
-        let mut create_flags = CreatePagesFlags::empty();
-        create_flags.set(
-            CreatePagesFlags::FIXED_ADDR,
-            flags.contains(MapFlags::MAP_FIXED),
-        );
-        create_flags.set(
-            CreatePagesFlags::POPULATE_PAGES_IMMEDIATELY,
-            flags.contains(MapFlags::MAP_POPULATE),
-        );
-        create_flags.set(CreatePagesFlags::ENSURE_SPACE_AFTER, ensure_space_after);
-        create_flags.set(
-            CreatePagesFlags::MAP_FILE,
-            !flags.contains(MapFlags::MAP_ANONYMOUS),
-        );
-        create_flags
-    };
-    let suggested_addr = match suggested_addr {
-        Some(addr) => Some(NonZeroAddress::new(addr).ok_or(MappingError::UnAligned)?),
-        None => None,
-    };
-    let length = NonZeroPageSize::new(len).ok_or(MappingError::UnAligned)?;
-    let pm = litebox_page_manager();
-    match prot {
-        ProtFlags::PROT_READ_EXEC => unsafe {
-            pm.create_executable_pages(suggested_addr, length, flags, op)
-        },
-        ProtFlags::PROT_READ_WRITE => unsafe {
-            pm.create_writable_pages(suggested_addr, length, flags, op)
-        },
-        ProtFlags::PROT_READ => unsafe {
-            pm.create_readable_pages(suggested_addr, length, flags, op)
-        },
-        ProtFlags::PROT_NONE => unsafe {
-            pm.create_inaccessible_pages(suggested_addr, length, flags, op)
-        },
-        _ => todo!("Unsupported prot flags {:?}", prot),
-    }
+    litebox_common_linux::mm::do_mmap(
+        litebox_page_manager(),
+        suggested_addr,
+        len,
+        prot,
+        flags,
+        ensure_space_after,
+        op,
+    )
 }
 
+#[inline]
 fn do_mmap_anonymous(
     suggested_addr: Option<usize>,
     len: usize,
@@ -183,56 +155,22 @@ pub(crate) fn sys_mmap(
 }
 
 /// Handle syscall `munmap`
+#[inline]
 pub(crate) fn sys_munmap(addr: crate::MutPtr<u8>, len: usize) -> Result<(), Errno> {
-    if addr.as_usize() & !PAGE_MASK != 0 {
-        return Err(Errno::EINVAL);
-    }
-    if len == 0 {
-        return Err(Errno::EINVAL);
-    }
-    let aligned_len = align_up(len, PAGE_SIZE);
-    if addr.as_usize().checked_add(aligned_len).is_none() {
-        return Err(Errno::EINVAL);
-    }
-
-    let pm = litebox_page_manager();
-    match unsafe { pm.remove_pages(addr, aligned_len) } {
-        Err(VmemUnmapError::UnAligned) => Err(Errno::EINVAL),
-        Err(VmemUnmapError::UnmapError(e)) => match e {
-            DeallocationError::Unaligned => Err(Errno::EINVAL),
-            // It is not an error if the indicated range does not contain any mapped pages.
-            DeallocationError::AlreadyUnallocated => Ok(()),
-            _ => unimplemented!(),
-        },
-        Ok(()) => Ok(()),
-    }
+    litebox_common_linux::mm::sys_munmap(litebox_page_manager(), addr, len)
 }
 
 /// Handle syscall `mprotect`
+#[inline]
 pub(crate) fn sys_mprotect(
     addr: crate::MutPtr<u8>,
     len: usize,
     prot: ProtFlags,
 ) -> Result<(), Errno> {
-    if addr.as_usize() & !PAGE_MASK != 0 {
-        return Err(Errno::EINVAL);
-    }
-    if len == 0 {
-        return Ok(());
-    }
-
-    let pm = litebox_page_manager();
-    match prot {
-        ProtFlags::PROT_READ_EXEC => unsafe { pm.make_pages_executable(addr, len) },
-        ProtFlags::PROT_READ_WRITE => unsafe { pm.make_pages_writable(addr, len) },
-        ProtFlags::PROT_READ => unsafe { pm.make_pages_readable(addr, len) },
-        ProtFlags::PROT_NONE => unsafe { pm.make_pages_inaccessible(addr, len) },
-        ProtFlags::PROT_READ_WRITE_EXEC => unsafe { pm.make_pages_rwx(addr, len) },
-        _ => todo!("Unsupported prot flags {:?}", prot),
-    }
-    .map_err(Errno::from)
+    litebox_common_linux::mm::sys_mprotect(litebox_page_manager(), addr, len, prot)
 }
 
+#[inline]
 pub(crate) fn sys_mremap(
     old_addr: crate::MutPtr<u8>,
     old_size: usize,
@@ -240,95 +178,30 @@ pub(crate) fn sys_mremap(
     flags: MRemapFlags,
     new_addr: usize,
 ) -> Result<crate::MutPtr<u8>, Errno> {
-    if flags.intersects(
-        (MRemapFlags::MREMAP_FIXED | MRemapFlags::MREMAP_MAYMOVE | MRemapFlags::MREMAP_DONTUNMAP)
-            .complement(),
-    ) {
-        return Err(Errno::EINVAL);
-    }
-    if flags.contains(MRemapFlags::MREMAP_FIXED) && !flags.contains(MRemapFlags::MREMAP_MAYMOVE) {
-        return Err(Errno::EINVAL);
-    }
-    /*
-     * MREMAP_DONTUNMAP is always a move and it does not allow resizing
-     * in the process.
-     */
-    if flags.contains(MRemapFlags::MREMAP_DONTUNMAP)
-        && (!flags.contains(MRemapFlags::MREMAP_MAYMOVE) || old_size != new_size)
-    {
-        return Err(Errno::EINVAL);
-    }
-    if old_addr.as_usize() & !PAGE_MASK != 0 {
-        return Err(Errno::EINVAL);
-    }
-
-    let old_size = align_down(old_size, PAGE_SIZE);
-    let new_size = align_down(new_size, PAGE_SIZE);
-    if new_size == 0 {
-        return Err(Errno::EINVAL);
-    }
-
-    if flags.intersects(MRemapFlags::MREMAP_FIXED | MRemapFlags::MREMAP_DONTUNMAP) {
-        todo!("Unsupported flags {:?}", flags);
-    }
-
-    let pm = litebox_page_manager();
-    unsafe {
-        pm.remap_pages(
-            old_addr,
-            old_size,
-            new_size,
-            flags.contains(MRemapFlags::MREMAP_MAYMOVE),
-        )
-    }
-    .map_err(Errno::from)
+    litebox_common_linux::mm::sys_mremap(
+        litebox_page_manager(),
+        old_addr,
+        old_size,
+        new_size,
+        flags,
+        new_addr,
+    )
 }
 
 /// Handle syscall `brk`
+#[inline]
 pub(crate) fn sys_brk(addr: MutPtr<u8>) -> Result<usize, Errno> {
-    let pm = litebox_page_manager();
-    unsafe { pm.brk(addr.as_usize()) }.map_err(Errno::from)
+    litebox_common_linux::mm::sys_brk(litebox_page_manager(), addr)
 }
 
 /// Handle syscall `madvise`
+#[inline]
 pub(crate) fn sys_madvise(
     addr: MutPtr<u8>,
     len: usize,
     advice: litebox_common_linux::MadviseBehavior,
 ) -> Result<(), Errno> {
-    if addr.as_usize() & !PAGE_MASK != 0 {
-        return Err(Errno::EINVAL);
-    }
-    if len == 0 {
-        return Ok(());
-    }
-    let aligned_len = len.next_multiple_of(PAGE_SIZE);
-    if aligned_len == 0 {
-        // overflow
-        return Err(Errno::EINVAL);
-    }
-    let Some(end) = addr.as_usize().checked_add(aligned_len) else {
-        return Err(Errno::EINVAL);
-    };
-
-    match advice {
-        litebox_common_linux::MadviseBehavior::Normal
-        | litebox_common_linux::MadviseBehavior::DontFork
-        | litebox_common_linux::MadviseBehavior::DoFork => {
-            // No-op for now, as we don't support fork yet.
-            Ok(())
-        }
-        litebox_common_linux::MadviseBehavior::DontNeed => {
-            // After a successful MADV_DONTNEED operation, the semantics of memory access in the specified region are changed:
-            // subsequent accesses of pages in the range will succeed, but will result in either repopulating the memory contents
-            // from the up-to-date contents of the underlying mapped file (for shared file mappings, shared anonymous mappings,
-            // and shmem-based techniques such as System V shared memory segments) or zero-fill-on-demand pages for anonymous private mappings.
-            //
-            // Note we do not support shared memory yet, so this is just to discard the pages without removing the mapping.
-            unsafe { litebox_page_manager().reset_pages(addr, len) }.map_err(Errno::from)
-        }
-        _ => unimplemented!("unsupported madvise behavior"),
-    }
+    litebox_common_linux::mm::sys_madvise(litebox_page_manager(), addr, len, advice)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR moves memory management syscalls/functions (e.g., `do_mmap`) to `litebox_common_linux` since they are shared between `litebox_shim_linux` and `litebox_shim_optee`. Note that this PR does not cover file-backed `mmap*` functions (e.g., `do_mmap_file`) because `litebox_shim_optee` does not use these functions and they are coupled with `litebox_shim_linux`'s other components.