### PR TITLE
Implement StdioProvider for LinuxKernel

### DIFF
--- a/litebox_platform_linux_kernel/src/host/mock.rs
+++ b/litebox_platform_linux_kernel/src/host/mock.rs
@@ -96,4 +96,15 @@ impl HostInterface for MockHostInterface {
     ) -> Result<usize, crate::Errno> {
         todo!()
     }
+
+    fn read_from_stdin(_buf: &mut [u8]) -> Result<usize, litebox_common_linux::errno::Errno> {
+        todo!()
+    }
+
+    fn write_to(
+        _stream: litebox::platform::StdioOutStream,
+        _buf: &[u8],
+    ) -> Result<usize, litebox_common_linux::errno::Errno> {
+        todo!()
+    }
 }


### PR DESCRIPTION
1. For stdio read/write, redirect it to host.
2. Also fixed the `StdioProvider` implementation for `LinuxUserland` to avoid `std` (use raw syscalls instead).