### PR TITLE
Add sched_getaffinity

### DIFF
--- a/litebox_shim_linux/Cargo.toml
+++ b/litebox_shim_linux/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 arrayvec = { version = "0.7.6", default-features = false }
+bitvec = { version = "1.0.1", default-features = false, features = ["alloc"] }
 bitflags = "2.9.0"
 litebox = { path = "../litebox/", version = "0.1.0" }
 litebox_common_linux = { path = "../litebox_common_linux/", version = "0.1.0" }

--- a/litebox_shim_linux/src/lib.rs
+++ b/litebox_shim_linux/src/lib.rs
@@ -700,6 +700,19 @@ pub fn handle_syscall_request(request: SyscallRequest<Platform>) -> isize {
         SyscallRequest::GetDirent64 { fd, dirp, count } => {
             syscalls::file::sys_getdirent64(fd, dirp, count)
         }
+        SyscallRequest::SchedGetAffinity { pid, len, mask } => {
+            const BITS_PER_BYTE: usize = 8;
+            let cpuset = syscalls::process::sys_sched_getaffinity(pid);
+            if len * BITS_PER_BYTE < cpuset.len() || len & (core::mem::size_of::<usize>() - 1) != 0
+            {
+                Err(Errno::EINVAL)
+            } else {
+                let raw_bytes = cpuset.as_bytes();
+                unsafe { mask.copy_from_slice(0, raw_bytes) }
+                    .map(|()| raw_bytes.len())
+                    .ok_or(Errno::EFAULT)
+            }
+        }
         _ => {
             todo!()
         }

--- a/litebox_shim_linux/src/syscalls/process.rs
+++ b/litebox_shim_linux/src/syscalls/process.rs
@@ -488,6 +488,34 @@ pub(crate) fn sys_getegid() -> usize {
         .with_thread_local_storage_mut(|tls| tls.current_task.credentials.egid)
 }
 
+/// Number of CPUs
+const NR_CPUS: usize = 2;
+
+pub(crate) struct CpuSet {
+    bits: bitvec::vec::BitVec<u8>,
+}
+
+impl CpuSet {
+    pub(crate) fn len(&self) -> usize {
+        self.bits.len()
+    }
+    pub(crate) fn as_bytes(&self) -> &[u8] {
+        self.bits.as_raw_slice()
+    }
+}
+
+/// Handle syscall `sched_getaffinity`.
+///
+/// Note this is a dummy implementation that always returns the same CPU set
+pub(crate) fn sys_sched_getaffinity(pid: Option<i32>) -> CpuSet {
+    if pid.is_some() {
+        unimplemented!("Getting CPU affinity for a specific PID is not supported yet");
+    }
+    let mut cpuset = bitvec::bitvec![u8, bitvec::order::Lsb0; 0; NR_CPUS];
+    cpuset.iter_mut().for_each(|mut b| *b = true);
+    CpuSet { bits: cpuset }
+}
+
 #[cfg(test)]
 mod tests {
     use core::mem::MaybeUninit;
@@ -727,5 +755,20 @@ mod tests {
             result,
             "Parent TID mismatch"
         );
+    }
+
+    #[test]
+    fn test_sched_getaffinity() {
+        crate::syscalls::tests::init_platform(None);
+
+        let cpuset = super::sys_sched_getaffinity(None);
+        assert_eq!(cpuset.bits.len(), super::NR_CPUS);
+        cpuset.bits.iter().for_each(|b| assert!(*b));
+        let ones: usize = cpuset
+            .as_bytes()
+            .iter()
+            .map(|b| b.count_ones() as usize)
+            .sum();
+        assert_eq!(ones, super::NR_CPUS);
     }
 }


### PR DESCRIPTION
Add a dummy implementation for syscall `sched_getaffinity`. This is used by node to get the total number of CPUs: see https://github.com/nodejs/node/blob/7178e9141ae83a28e5742c38594a1068314a88bf/deps/uv/src/unix/core.c#L1984