### PR TITLE
Add HOME env

### DIFF
--- a/litebox_runner_linux_userland/tests/common/mod.rs
+++ b/litebox_runner_linux_userland/tests/common/mod.rs
@@ -144,7 +144,10 @@ pub fn test_load_exec_common(executable_path: &str) {
         CString::new(executable_path).unwrap(),
         CString::new("hello").unwrap(),
     ];
-    let envp = vec![CString::new("PATH=/bin").unwrap()];
+    let envp = vec![
+        CString::new("PATH=/bin").unwrap(),
+        CString::new("HOME=/").unwrap(),
+    ];
     let mut aux = litebox_shim_linux::loader::auxv::init_auxv();
     if litebox_platform_multiplex::platform()
         .get_vdso_address()

--- a/litebox_runner_linux_userland/tests/run.rs
+++ b/litebox_runner_linux_userland/tests/run.rs
@@ -210,6 +210,8 @@ fn test_runner_with_dynamic_lib(
         // Alternatively, we could add a `/etc/ld.so.cache` file to the rootfs.
         "--env",
         "LD_LIBRARY_PATH=/lib64:/lib32:/lib",
+        "--env",
+        "HOME=/",
         "--initial-files",
         tar_file.to_str().unwrap(),
     ];


### PR DESCRIPTION
See one example from node where the HOME environment variable is used: https://github.com/nodejs/node/blob/f993fca4e476c514f5a97f8a61287fc7f94df26f/deps/uv/src/unix/core.c#L1203

If it is not set, it would use unix socket which we don't support yet.