### PR TITLE
Support some 32-bit syscalls

### DIFF
--- a/litebox_common_linux/src/lib.rs
+++ b/litebox_common_linux/src/lib.rs
@@ -1983,8 +1983,14 @@ impl<'a, Platform: litebox::platform::RawPointerProvider> SyscallRequest<'a, Pla
                 arg: FcntlArg::from(ctx.sys_req_arg(1), ctx.sys_req_arg(2)),
             },
             Sysno::gettimeofday => sys_req!(Gettimeofday { tv:*, tz:* }),
+            #[cfg(target_arch = "x86_64")]
             Sysno::clock_gettime => sys_req!(ClockGettime { clockid, tp:* }),
+            #[cfg(target_arch = "x86")]
+            Sysno::clock_gettime64 => sys_req!(ClockGettime { clockid, tp:* }),
+            #[cfg(target_arch = "x86_64")]
             Sysno::clock_getres => sys_req!(ClockGetres { clockid, res:* }),
+            #[cfg(target_arch = "x86")]
+            Sysno::clock_getres_time64 => sys_req!(ClockGetres { clockid, res:* }),
             Sysno::time => sys_req!(Time { tloc:* }),
             Sysno::getcwd => sys_req!(Getcwd { buf:*, size }),
             Sysno::readlink => sys_req!(Readlink { pathname:*, buf:* ,bufsiz }),


### PR DESCRIPTION
x86 and x86_64 have different syscall numbers (see https://elixir.bootlin.com/linux/v5.19.17/source/arch/x86/entry/syscalls/syscall_32.tbl and https://elixir.bootlin.com/linux/v5.19.17/source/arch/x86/entry/syscalls/syscall_64.tbl)

Add `clock_gettime64` and `clock_getres_time64` for x86.