### PR TITLE
Support syscall execve

### DIFF
--- a/litebox/src/mm/mod.rs
+++ b/litebox/src/mm/mod.rs
@@ -345,6 +345,11 @@ where
         Ok(brk)
     }
 
+    pub unsafe fn reset_brk(&self) {
+        let mut vmem = self.vmem.write();
+        vmem.brk = 0;
+    }
+
     /// Expands (or shrinks) an existing memory mapping
     ///
     /// `old_addr` is the old address of the virtual memory block that you want to expand (or shrink).

--- a/litebox/src/platform/mod.rs
+++ b/litebox/src/platform/mod.rs
@@ -24,7 +24,7 @@ macro_rules! log_println {
     ($platform:expr, $($tt:tt)*) => {{
         use core::fmt::Write as _;
         use $crate::platform::DebugLogProvider as _;
-        let mut t: arrayvec::ArrayString<4096> = arrayvec::ArrayString::new();
+        let mut t: arrayvec::ArrayString<8192> = arrayvec::ArrayString::new();
         writeln!(t, $($tt)*).unwrap();
         $platform.debug_log_print(&t);
     }};

--- a/litebox/src/platform/mod.rs
+++ b/litebox/src/platform/mod.rs
@@ -671,4 +671,7 @@ pub trait ThreadLocalStorageProvider {
     /// Panics if TLS is not set yet.
     /// Panics if TLS is being used by [`Self::with_thread_local_storage_mut`].
     fn release_thread_local_storage(&self) -> Self::ThreadLocalStorage;
+
+    #[cfg(target_arch = "x86")]
+    fn clear_guest_thread_local_storage(&self);
 }

--- a/litebox/src/platform/mod.rs
+++ b/litebox/src/platform/mod.rs
@@ -672,6 +672,9 @@ pub trait ThreadLocalStorageProvider {
     /// Panics if TLS is being used by [`Self::with_thread_local_storage_mut`].
     fn release_thread_local_storage(&self) -> Self::ThreadLocalStorage;
 
-    #[cfg(target_arch = "x86")]
+    /// Clear any guest thread-local storage state for the current thread.
+    ///
+    /// This is used to help emulate certain syscalls (e.g., `execve`) that clear TLS,
+    /// which is necessary for some platforms (e.g., x86 Linux).
     fn clear_guest_thread_local_storage(&self);
 }

--- a/litebox/src/platform/mod.rs
+++ b/litebox/src/platform/mod.rs
@@ -24,7 +24,7 @@ macro_rules! log_println {
     ($platform:expr, $($tt:tt)*) => {{
         use core::fmt::Write as _;
         use $crate::platform::DebugLogProvider as _;
-        let mut t: arrayvec::ArrayString<8192> = arrayvec::ArrayString::new();
+        let mut t: arrayvec::ArrayString<4096> = arrayvec::ArrayString::new();
         writeln!(t, $($tt)*).unwrap();
         $platform.debug_log_print(&t);
     }};

--- a/litebox_common_linux/src/lib.rs
+++ b/litebox_common_linux/src/lib.rs
@@ -2043,6 +2043,13 @@ impl<'a, Platform: litebox::platform::RawPointerProvider> SyscallRequest<'a, Pla
                 fd: ctx.sys_req_arg(0),
                 arg: FcntlArg::from(ctx.sys_req_arg(1), ctx.sys_req_arg(2)),
             },
+            // TODO: fcntl64 is identical to fcntl except certain commands (e.g., `F_OFD_SETLK`)
+            // that we don't support yet.
+            #[cfg(target_arch = "x86")]
+            Sysno::fcntl64 => SyscallRequest::Fcntl {
+                fd: ctx.sys_req_arg(0),
+                arg: FcntlArg::from(ctx.sys_req_arg(1), ctx.sys_req_arg(2)),
+            },
             Sysno::gettimeofday => sys_req!(Gettimeofday { tv:*, tz:* }),
             #[cfg(target_arch = "x86_64")]
             Sysno::clock_gettime => sys_req!(ClockGettime { clockid, tp:* }),

--- a/litebox_platform_freebsd_userland/src/lib.rs
+++ b/litebox_platform_freebsd_userland/src/lib.rs
@@ -47,9 +47,10 @@ impl FreeBSDUserland {
         let platform = Self {
             reserved_pages: Self::read_proc_self_maps(),
         };
+        let platform = Box::leak(Box::new(platform));
 
-        platform.set_init_tls();
-        Box::leak(Box::new(platform))
+        platform.set_init_tls(&litebox::LiteBox::new(platform));
+        platform
     }
 
     /// Register the syscall handler (provided by the Linux shim)
@@ -181,7 +182,7 @@ impl FreeBSDUserland {
         }
     }
 
-    fn set_init_tls(&self) {
+    fn set_init_tls(&self, litebox: &litebox::LiteBox<FreeBSDUserland>) {
         let mut tid: isize = 0;
         unsafe {
             syscalls::syscall1(syscalls::Sysno::ThrSelf, &mut tid as *mut isize as usize)
@@ -199,6 +200,7 @@ impl FreeBSDUserland {
             clear_child_tid: None,
             robust_list: None,
             credentials: alloc::sync::Arc::new(Self::get_user_info()),
+            page_manager: alloc::sync::Arc::new(litebox::mm::PageManager::new(litebox)),
         });
 
         let tls = litebox_common_linux::ThreadLocalStorage::new(task);

--- a/litebox_platform_freebsd_userland/src/lib.rs
+++ b/litebox_platform_freebsd_userland/src/lib.rs
@@ -1017,6 +1017,8 @@ impl litebox::platform::ThreadLocalStorageProvider for FreeBSDUserland {
         tls.borrowed = false; // Mark as not borrowed anymore
         res
     }
+
+    fn clear_guest_thread_local_storage(&self) {}
 }
 
 #[cfg(test)]

--- a/litebox_platform_linux_kernel/src/host/snp/snp_impl.rs
+++ b/litebox_platform_linux_kernel/src/host/snp/snp_impl.rs
@@ -91,7 +91,11 @@ fn current() -> Option<&'static mut bindings::vsbox_task> {
 }
 
 impl SnpLinuxKernel {
-    pub fn set_init_tls(&self, boot_params: &bindings::vmpl2_boot_params) {
+    pub fn set_init_tls(
+        &self,
+        boot_params: &bindings::vmpl2_boot_params,
+        litebox: &litebox::LiteBox<Self>,
+    ) {
         let task = ::alloc::boxed::Box::new(litebox_common_linux::Task {
             pid: boot_params.pid,
             tid: boot_params.pid,
@@ -104,6 +108,7 @@ impl SnpLinuxKernel {
                 euid: boot_params.euid as usize,
                 egid: boot_params.egid as usize,
             }),
+            page_manager: ::alloc::sync::Arc::new(litebox::mm::PageManager::new(litebox)),
         });
         let tls = litebox_common_linux::ThreadLocalStorage::new(task);
         self.set_thread_local_storage(tls);
@@ -290,7 +295,7 @@ const fn is_err_value(x: u64) -> bool {
     x >= !MAX_ERRNO
 }
 
-const PAGE_SIZE: u64 = 4096;
+const PAGE_SIZE: u64 = litebox::mm::linux::PAGE_SIZE as u64;
 /// Max physical address
 const PHYS_ADDR_MAX: u64 = 0x10_0000_0000u64; // 64GB
 

--- a/litebox_platform_linux_kernel/src/host/snp/snp_impl.rs
+++ b/litebox_platform_linux_kernel/src/host/snp/snp_impl.rs
@@ -146,6 +146,8 @@ impl litebox::platform::ThreadLocalStorageProvider for SnpLinuxKernel {
         current_task.tls = ::core::ptr::null_mut();
         *tls
     }
+
+    fn clear_guest_thread_local_storage(&self) {}
 }
 
 core::arch::global_asm!(include_str!("entry.S"));

--- a/litebox_platform_linux_userland/src/lib.rs
+++ b/litebox_platform_linux_userland/src/lib.rs
@@ -1298,8 +1298,7 @@ syscall_callback:
 
     add  rsp, 24         /* skip orig_rax, rip, cs */
     popfq
-    pop  rsp
-    add  rsp, 8         /* skip ss */
+    add  rsp, 16         /* skip rsp, ss */
 
     /* Return to the caller */
     ret

--- a/litebox_platform_linux_userland/src/lib.rs
+++ b/litebox_platform_linux_userland/src/lib.rs
@@ -55,6 +55,12 @@ pub struct LinuxUserland {
     tls_entry_number: AtomicU32,
 }
 
+impl core::fmt::Debug for LinuxUserland {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("LinuxUserland").finish_non_exhaustive()
+    }
+}
+
 const IF_NAMESIZE: usize = 16;
 /// Use TUN device
 const IFF_TUN: i32 = 0x0001;
@@ -1290,7 +1296,8 @@ syscall_callback:
 
     add  rsp, 24         /* skip orig_rax, rip, cs */
     popfq
-    add  rsp, 16         /* skip rsp, ss */
+    pop  rsp
+    add  rsp, 8         /* skip ss */
 
     /* Return to the caller */
     ret

--- a/litebox_platform_linux_userland/src/lib.rs
+++ b/litebox_platform_linux_userland/src/lib.rs
@@ -767,6 +767,26 @@ fn set_thread_area(
     )
 }
 
+#[cfg(target_arch = "x86")]
+fn clear_thread_area(entry_number: u32) {
+    if entry_number == u32::MAX {
+        return;
+    }
+
+    let flags = litebox_common_linux::UserDescFlags(0);
+    let mut user_desc = litebox_common_linux::UserDesc {
+        entry_number,
+        base_addr: 0,
+        limit: 0,
+        flags,
+    };
+    let user_desc_ptr = litebox::platform::trivial_providers::TransparentMutPtr {
+        inner: &raw mut user_desc,
+    };
+
+    set_thread_area(user_desc_ptr).expect("failed to clear TLS entry");
+}
+
 pub struct PunchthroughToken {
     punchthrough: PunchthroughSyscall<LinuxUserland>,
 }
@@ -1546,6 +1566,11 @@ impl litebox::platform::ThreadLocalStorageProvider for LinuxUserland {
         assert!(!tls.is_null(), "TLS must be set before releasing it");
         Self::set_fs_selector(0); // reset fs selector
 
+        clear_thread_area(
+            self.tls_entry_number
+                .swap(u32::MAX, core::sync::atomic::Ordering::SeqCst),
+        );
+
         let tls = unsafe { Box::from_raw(tls) };
         assert!(!tls.borrowed, "TLS must not be borrowed when releasing it");
         *tls
@@ -1563,6 +1588,23 @@ impl litebox::platform::ThreadLocalStorageProvider for LinuxUserland {
         let ret = f(tls);
         tls.borrowed = false; // mark as not borrowed anymore
         ret
+    }
+
+    #[cfg(target_arch = "x86")]
+    fn clear_guest_thread_local_storage(&self) {
+        const GDT_ENTRY_TLS_ENTRIES: u32 = 3;
+        const GDT_ENTRY_TLS_MIN: u32 = 12;
+        const GDT_ENTRY_TLS_MAX: u32 = GDT_ENTRY_TLS_MIN + GDT_ENTRY_TLS_ENTRIES - 1;
+
+        // Each thread has GDT_ENTRY_TLS_ENTRIES (3) entries in the GDT for TLS.
+        // LiteBox itself uses the first one or two slots, depending on whether it is `no_std` or not.
+        // Only the last one is available for guest use. Hence, we only clear the last one here.
+        debug_assert_ne!(
+            self.tls_entry_number
+                .load(core::sync::atomic::Ordering::Relaxed),
+            GDT_ENTRY_TLS_MAX
+        );
+        clear_thread_area(GDT_ENTRY_TLS_MAX);
     }
 }
 

--- a/litebox_platform_linux_userland/src/lib.rs
+++ b/litebox_platform_linux_userland/src/lib.rs
@@ -1590,6 +1590,9 @@ impl litebox::platform::ThreadLocalStorageProvider for LinuxUserland {
         ret
     }
 
+    #[cfg(target_arch = "x86_64")]
+    fn clear_guest_thread_local_storage(&self) {}
+
     #[cfg(target_arch = "x86")]
     fn clear_guest_thread_local_storage(&self) {
         const GDT_ENTRY_TLS_ENTRIES: u32 = 3;

--- a/litebox_platform_windows_userland/src/lib.rs
+++ b/litebox_platform_windows_userland/src/lib.rs
@@ -1241,6 +1241,8 @@ impl litebox::platform::ThreadLocalStorageProvider for WindowsUserland {
         tls.borrowed = false;
         ret
     }
+
+    fn clear_guest_thread_local_storage(&self) {}
 }
 
 #[cfg(test)]

--- a/litebox_platform_windows_userland/src/lib.rs
+++ b/litebox_platform_windows_userland/src/lib.rs
@@ -209,7 +209,8 @@ impl WindowsUserland {
             reserved_pages,
             sys_info: std::sync::RwLock::new(sys_info),
         };
-        platform.set_init_tls();
+        let platform = Box::leak(Box::new(platform));
+        platform.set_init_tls(&litebox::LiteBox::new(platform));
 
         // Initialize it's own fs-base (for the main thread)
         WindowsUserland::init_thread_fs_base();
@@ -220,7 +221,7 @@ impl WindowsUserland {
             let _ = AddVectoredExceptionHandler(0, Some(exception_handler));
         }
 
-        Box::leak(Box::new(platform))
+        platform
     }
 
     /// Register the syscall handler (provided by the Linux shim)
@@ -291,7 +292,7 @@ impl WindowsUserland {
         x % gran == 0
     }
 
-    fn set_init_tls(&self) {
+    fn set_init_tls(&self, litebox: &litebox::LiteBox<WindowsUserland>) {
         // TODO: Currently we are using a static thread ID and credentials (faked).
         // This is a placeholder for future implementation to use passthrough.
         let creds = litebox_common_linux::Credentials {
@@ -308,6 +309,7 @@ impl WindowsUserland {
             clear_child_tid: None,
             robust_list: None,
             credentials: alloc::sync::Arc::new(creds),
+            page_manager: alloc::sync::Arc::new(litebox::mm::PageManager::new(litebox)),
         });
         let tls = litebox_common_linux::ThreadLocalStorage::new(task);
         self.set_thread_local_storage(tls);

--- a/litebox_runner_linux_userland/Cargo.toml
+++ b/litebox_runner_linux_userland/Cargo.toml
@@ -8,6 +8,7 @@ anyhow = "1.0.97"
 clap = { version = "4.5.33", features = ["derive"] }
 libc = { version = "0.2.169", default-features = false }
 litebox = { version = "0.1.0", path = "../litebox" }
+litebox_common_linux = { version = "0.1.0", path = "../litebox_common_linux" }
 litebox_platform_linux_userland = { version = "0.1.0", path = "../litebox_platform_linux_userland" }
 litebox_platform_multiplex = { version = "0.1.0", path = "../litebox_platform_multiplex", default-features = false, features = ["platform_linux_userland", "systrap_backend"] }
 litebox_shim_linux = { version = "0.1.0", path = "../litebox_shim_linux" }

--- a/litebox_runner_linux_userland/src/lib.rs
+++ b/litebox_runner_linux_userland/src/lib.rs
@@ -250,7 +250,7 @@ fn load_program_wrapper(
 fn load_program(
     path: &str,
     argv: alloc::vec::Vec<alloc::ffi::CString>,
-    envp: alloc::vec::Vec<alloc::ffi::CString>,
+    mut envp: alloc::vec::Vec<alloc::ffi::CString>,
 ) -> Result<(), litebox_common_linux::errno::Errno> {
     let mut aux = litebox_shim_linux::loader::auxv::init_auxv();
     if litebox_platform_multiplex::platform()
@@ -278,6 +278,8 @@ fn load_program(
             );
         }
     }
+    // Enable the audit library to load trampoline code for rewritten binaries.
+    envp.push(c"LD_AUDIT=/lib/litebox_rtld_audit.so".into());
     let loaded_program = litebox_shim_linux::loader::load_program(path, argv, envp, aux).unwrap();
     unsafe {
         trampoline::jump_to_entry_point(loaded_program.entry_point, loaded_program.user_stack_top)

--- a/litebox_runner_linux_userland/src/lib.rs
+++ b/litebox_runner_linux_userland/src/lib.rs
@@ -64,7 +64,8 @@ pub enum InterceptionBackend {
     Rewriter,
 }
 
-const REQUIRE_RTLD_AUDIT: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
+static REQUIRE_RTLD_AUDIT: core::sync::atomic::AtomicBool =
+    core::sync::atomic::AtomicBool::new(false);
 
 /// Run Linux programs with LiteBox on unmodified Linux
 ///

--- a/litebox_runner_linux_userland/src/lib.rs
+++ b/litebox_runner_linux_userland/src/lib.rs
@@ -7,6 +7,8 @@ use litebox_platform_multiplex::Platform;
 use std::os::linux::fs::MetadataExt as _;
 use std::path::PathBuf;
 
+extern crate alloc;
+
 /// Run Linux programs with LiteBox on unmodified Linux
 #[derive(Parser, Debug)]
 pub struct CliArgs {
@@ -199,6 +201,7 @@ pub fn run(cli_args: CliArgs) -> Result<()> {
     };
     litebox_shim_linux::set_fs(initial_file_system);
     litebox_platform_multiplex::set_platform(platform);
+    litebox_shim_linux::syscalls::process::set_execve_callback(load_program_wrapper);
     platform.register_syscall_handler(litebox_shim_linux::handle_syscall_request);
     match cli_args.interception_backend {
         InterceptionBackend::Seccomp => platform.enable_seccomp_based_syscall_interception(),
@@ -231,6 +234,24 @@ pub fn run(cli_args: CliArgs) -> Result<()> {
         envp
     };
 
+    load_program(&cli_args.program_and_arguments[0], argv, envp).expect("failed to load program");
+    Ok(())
+}
+
+fn load_program_wrapper(
+    _ctx: &mut litebox_common_linux::PtRegs,
+    path: &str,
+    argv: alloc::vec::Vec<alloc::ffi::CString>,
+    envp: alloc::vec::Vec<alloc::ffi::CString>,
+) -> Result<(), litebox_common_linux::errno::Errno> {
+    load_program(path, argv, envp)
+}
+
+fn load_program(
+    path: &str,
+    argv: alloc::vec::Vec<alloc::ffi::CString>,
+    envp: alloc::vec::Vec<alloc::ffi::CString>,
+) -> Result<(), litebox_common_linux::errno::Errno> {
     let mut aux = litebox_shim_linux::loader::auxv::init_auxv();
     if litebox_platform_multiplex::platform()
         .get_vdso_address()
@@ -257,14 +278,7 @@ pub fn run(cli_args: CliArgs) -> Result<()> {
             );
         }
     }
-    let loaded_program = litebox_shim_linux::loader::load_program(
-        &cli_args.program_and_arguments[0],
-        argv,
-        envp,
-        aux,
-    )
-    .unwrap();
-
+    let loaded_program = litebox_shim_linux::loader::load_program(path, argv, envp, aux).unwrap();
     unsafe {
         trampoline::jump_to_entry_point(loaded_program.entry_point, loaded_program.user_stack_top)
     }

--- a/litebox_runner_linux_userland/tests/run.rs
+++ b/litebox_runner_linux_userland/tests/run.rs
@@ -212,15 +212,6 @@ fn test_runner_with_dynamic_lib(
         "--initial-files",
         tar_file.to_str().unwrap(),
     ];
-    match backend {
-        Backend::Rewriter => {
-            args.push("--env");
-            args.push("LD_AUDIT=/lib/litebox_rtld_audit.so");
-        }
-        Backend::Seccomp => {
-            // No need to set LD_AUDIT for seccomp backend
-        }
-    }
     args.push(path.to_str().unwrap());
     args.extend_from_slice(cmd_args);
     println!("Running `cargo {}`", args.join(" "));

--- a/litebox_runner_snp/src/main.rs
+++ b/litebox_runner_snp/src/main.rs
@@ -92,7 +92,7 @@ pub extern "C" fn sandbox_process_init(
             & !(litebox::mm::linux::PAGE_SIZE as u64 - 1),
     );
     let platform = litebox_platform_linux_kernel::host::snp::snp_impl::SnpLinuxKernel::new(pgd);
-    platform.set_init_tls(boot_params);
+    platform.set_init_tls(boot_params, &litebox::LiteBox::new(platform));
     litebox::log_println!(platform, "sandbox_process_init called");
 
     let litebox = litebox::LiteBox::new(platform);

--- a/litebox_shim_linux/src/lib.rs
+++ b/litebox_shim_linux/src/lib.rs
@@ -97,9 +97,10 @@ pub fn litebox_fs<'a>() -> &'a LinuxFS {
 }
 
 /// Get the global page manager
-pub fn litebox_page_manager<'a>() -> &'a PageManager<Platform, PAGE_SIZE> {
-    static VMEM: OnceBox<PageManager<Platform, PAGE_SIZE>> = OnceBox::new();
-    VMEM.get_or_init(|| alloc::boxed::Box::new(PageManager::new(litebox())))
+pub fn litebox_page_manager() -> alloc::sync::Arc<PageManager<Platform, { PAGE_SIZE }>> {
+    use litebox::platform::ThreadLocalStorageProvider;
+    litebox_platform_multiplex::platform()
+        .with_thread_local_storage_mut(|tls| tls.current_task.page_manager.clone())
 }
 
 pub(crate) fn litebox_net<'a>()

--- a/litebox_shim_linux/src/loader/elf.rs
+++ b/litebox_shim_linux/src/loader/elf.rs
@@ -405,6 +405,7 @@ impl ElfLoader {
             let init_brk =
                 core::cmp::max((base + brk).next_multiple_of(PAGE_SIZE), end_of_trampoline);
             unsafe { litebox_page_manager().brk(init_brk) }.expect("failed to set brk");
+            crate::syscalls::file::sys_close(file_fd).expect("failed to close fd");
             elf
         };
         let interp: Option<Elf> = if let Some(interp_name) = elf.interp() {
@@ -420,6 +421,7 @@ impl ElfLoader {
             if let Some(trampoline) = trampoline {
                 load_trampoline(trampoline, interp.base(), file_fd);
             }
+            crate::syscalls::file::sys_close(file_fd).expect("failed to close fd");
             Some(interp)
         } else {
             None

--- a/litebox_shim_linux/src/syscalls/file.rs
+++ b/litebox_shim_linux/src/syscalls/file.rs
@@ -226,7 +226,7 @@ pub fn sys_lseek(fd: i32, offset: isize, whence: i32) -> Result<usize, Errno> {
     }
 }
 
-fn do_close(desc: Descriptor) -> Result<(), Errno> {
+pub(crate) fn do_close(desc: Descriptor) -> Result<(), Errno> {
     match desc {
         Descriptor::File(file) => litebox_fs().close(file).map_err(Errno::from),
         Descriptor::Stdio(crate::stdio::StdioFile { inner, .. }) => {
@@ -505,6 +505,26 @@ impl Descriptor {
         };
         Ok(fstat)
     }
+
+    pub(crate) fn get_file_descriptor_flags(&self) -> FileDescriptorFlags {
+        match self {
+            Descriptor::File(file) => litebox_fs()
+                .with_metadata(file, |flags: &FileDescriptorFlags| *flags)
+                .unwrap_or(FileDescriptorFlags::empty()),
+            Descriptor::Socket(socket) => todo!(),
+            Descriptor::PipeReader { close_on_exec, .. }
+            | Descriptor::PipeWriter { close_on_exec, .. }
+            | Descriptor::Eventfd { close_on_exec, .. }
+            | Descriptor::Epoll { close_on_exec, .. }
+            | Descriptor::Stdio(crate::stdio::StdioFile { close_on_exec, .. }) => {
+                if close_on_exec.load(core::sync::atomic::Ordering::Relaxed) {
+                    FileDescriptorFlags::FD_CLOEXEC
+                } else {
+                    FileDescriptorFlags::empty()
+                }
+            }
+        }
+    }
 }
 
 fn do_stat(pathname: impl path::Arg, follow_symlink: bool) -> Result<FileStat, Errno> {
@@ -586,27 +606,12 @@ pub fn sys_fcntl(fd: i32, arg: FcntlArg) -> Result<u32, Errno> {
     let locked_file_descriptors = file_descriptors().read();
     let desc = locked_file_descriptors.get_fd(fd).ok_or(Errno::EBADF)?;
     match arg {
-        FcntlArg::GETFD => {
-            let flags: FileDescriptorFlags =
-                match file_descriptors().read().get_fd(fd).ok_or(Errno::EBADF)? {
-                    Descriptor::File(file) => litebox_fs()
-                        .with_metadata(file, |flags: &FileDescriptorFlags| *flags)
-                        .unwrap_or(FileDescriptorFlags::empty()),
-                    Descriptor::Socket(socket) => todo!(),
-                    Descriptor::PipeReader { close_on_exec, .. }
-                    | Descriptor::PipeWriter { close_on_exec, .. }
-                    | Descriptor::Eventfd { close_on_exec, .. }
-                    | Descriptor::Epoll { close_on_exec, .. }
-                    | Descriptor::Stdio(crate::stdio::StdioFile { close_on_exec, .. }) => {
-                        if close_on_exec.load(core::sync::atomic::Ordering::Relaxed) {
-                            FileDescriptorFlags::FD_CLOEXEC
-                        } else {
-                            FileDescriptorFlags::empty()
-                        }
-                    }
-                };
-            Ok(flags.bits())
-        }
+        FcntlArg::GETFD => Ok(file_descriptors()
+            .read()
+            .get_fd(fd)
+            .ok_or(Errno::EBADF)?
+            .get_file_descriptor_flags()
+            .bits()),
         FcntlArg::SETFD(flags) => {
             match file_descriptors().read().get_fd(fd).ok_or(Errno::EBADF)? {
                 Descriptor::File(file) => {

--- a/litebox_shim_linux/src/syscalls/mm.rs
+++ b/litebox_shim_linux/src/syscalls/mm.rs
@@ -31,7 +31,7 @@ fn do_mmap(
     op: impl FnOnce(MutPtr<u8>) -> Result<usize, MappingError>,
 ) -> Result<MutPtr<u8>, MappingError> {
     litebox_common_linux::mm::do_mmap(
-        litebox_page_manager(),
+        &litebox_page_manager(),
         suggested_addr,
         len,
         prot,
@@ -148,7 +148,7 @@ pub(crate) fn sys_mmap(
 /// Handle syscall `munmap`
 #[inline]
 pub(crate) fn sys_munmap(addr: crate::MutPtr<u8>, len: usize) -> Result<(), Errno> {
-    litebox_common_linux::mm::sys_munmap(litebox_page_manager(), addr, len)
+    litebox_common_linux::mm::sys_munmap(&litebox_page_manager(), addr, len)
 }
 
 /// Handle syscall `mprotect`
@@ -158,7 +158,7 @@ pub(crate) fn sys_mprotect(
     len: usize,
     prot: ProtFlags,
 ) -> Result<(), Errno> {
-    litebox_common_linux::mm::sys_mprotect(litebox_page_manager(), addr, len, prot)
+    litebox_common_linux::mm::sys_mprotect(&litebox_page_manager(), addr, len, prot)
 }
 
 #[inline]
@@ -170,7 +170,7 @@ pub(crate) fn sys_mremap(
     new_addr: usize,
 ) -> Result<crate::MutPtr<u8>, Errno> {
     litebox_common_linux::mm::sys_mremap(
-        litebox_page_manager(),
+        &litebox_page_manager(),
         old_addr,
         old_size,
         new_size,
@@ -182,7 +182,7 @@ pub(crate) fn sys_mremap(
 /// Handle syscall `brk`
 #[inline]
 pub(crate) fn sys_brk(addr: MutPtr<u8>) -> Result<usize, Errno> {
-    litebox_common_linux::mm::sys_brk(litebox_page_manager(), addr)
+    litebox_common_linux::mm::sys_brk(&litebox_page_manager(), addr)
 }
 
 /// Handle syscall `madvise`
@@ -192,7 +192,7 @@ pub(crate) fn sys_madvise(
     len: usize,
     advice: litebox_common_linux::MadviseBehavior,
 ) -> Result<(), Errno> {
-    litebox_common_linux::mm::sys_madvise(litebox_page_manager(), addr, len, advice)
+    litebox_common_linux::mm::sys_madvise(&litebox_page_manager(), addr, len, advice)
 }
 
 #[cfg(test)]

--- a/litebox_shim_linux/src/syscalls/mod.rs
+++ b/litebox_shim_linux/src/syscalls/mod.rs
@@ -6,7 +6,7 @@ pub mod file;
 pub(crate) mod misc;
 pub(crate) mod mm;
 pub(crate) mod net;
-pub(crate) mod process;
+pub mod process;
 
 #[cfg(test)]
 pub(crate) mod tests;

--- a/litebox_shim_linux/src/syscalls/process.rs
+++ b/litebox_shim_linux/src/syscalls/process.rs
@@ -809,9 +809,11 @@ pub(crate) fn sys_execve(
             tls.current_task.page_manager.release_memory(release);
         };
     });
+    #[cfg(target_arch = "x86")]
+    litebox_platform_multiplex::platform().clear_guest_thread_local_storage();
 
     if let Some(callback) = EXECVE_CALLBACK.get() {
-        callback(ctx, path, argv_vec, envp_vec);
+        callback(ctx, path, argv_vec, envp_vec).expect("we already released memory above");
     }
 
     Ok(())

--- a/litebox_shim_linux/src/syscalls/process.rs
+++ b/litebox_shim_linux/src/syscalls/process.rs
@@ -806,7 +806,7 @@ pub(crate) fn sys_execve(
             true
         };
         unsafe {
-            tls.current_task.page_manager.release_mappings(release);
+            tls.current_task.page_manager.release_memory(release);
         };
     });
 

--- a/litebox_shim_linux/src/syscalls/process.rs
+++ b/litebox_shim_linux/src/syscalls/process.rs
@@ -1,8 +1,10 @@
 //! Process/thread related syscalls.
 
 use core::mem::offset_of;
+use core::ops::Range;
 
 use alloc::boxed::Box;
+use litebox::mm::linux::VmFlags;
 use litebox::platform::{ExitProvider as _, RawMutPointer as _, ThreadProvider as _};
 use litebox::platform::{Instant as _, SystemTime as _, TimeProvider};
 use litebox::platform::{
@@ -12,8 +14,6 @@ use litebox::platform::{
 use litebox::utils::TruncateExt as _;
 use litebox_common_linux::{ArchPrctlArg, errno::Errno};
 use litebox_common_linux::{CloneFlags, FutexArgs};
-
-use crate::litebox_page_manager;
 
 /// A global counter for the number of threads in the system.
 pub(super) static NR_THREADS: core::sync::atomic::AtomicU16 = core::sync::atomic::AtomicU16::new(1);
@@ -301,13 +301,15 @@ pub(crate) fn sys_clone(
     }
 
     let platform = litebox_platform_multiplex::platform();
-    let (credentials, pid, parent_proc_id) = platform.with_thread_local_storage_mut(|tls| {
-        (
-            tls.current_task.credentials.clone(),
-            tls.current_task.pid,
-            tls.current_task.ppid,
-        )
-    });
+    let (credentials, pid, parent_proc_id, page_manager) =
+        platform.with_thread_local_storage_mut(|tls| {
+            (
+                tls.current_task.credentials.clone(),
+                tls.current_task.pid,
+                tls.current_task.ppid,
+                tls.current_task.page_manager.clone(),
+            )
+        });
     let child_tid = unsafe {
         platform.spawn_thread(
             ctx,
@@ -332,6 +334,7 @@ pub(crate) fn sys_clone(
                     },
                     robust_list: None,
                     credentials,
+                    page_manager,
                 }),
                 callback: new_thread_callback,
             }),
@@ -677,6 +680,20 @@ pub(crate) fn sys_futex(
     Ok(res)
 }
 
+pub type ExecveCallback = fn(
+    ctx: &mut litebox_common_linux::PtRegs,
+    path: &str,
+    argv: alloc::vec::Vec<alloc::ffi::CString>,
+    envp: alloc::vec::Vec<alloc::ffi::CString>,
+) -> Result<(), Errno>;
+static EXECVE_CALLBACK: once_cell::race::OnceBox<ExecveCallback> = once_cell::race::OnceBox::new();
+
+pub fn set_execve_callback(callback: ExecveCallback) {
+    EXECVE_CALLBACK
+        .set(Box::new(callback))
+        .expect("execve callback already set");
+}
+
 const MAX_VEC: usize = 4096; // limit count
 const MAX_TOTAL_BYTES: usize = 256 * 1024; // size cap
 
@@ -745,32 +762,57 @@ pub(crate) fn sys_execve(
     // 3. Close CLOEXEC descriptors
     crate::file_descriptors().write().close_on_exec();
 
-    // 4. (TODO) Reset signal dispositions, clear robust list, etc.
-    unsafe { litebox_page_manager().reset_brk() };
+    // unmmap all memory mappings and reset brk
+    litebox_platform_multiplex::platform().with_thread_local_storage_mut(|tls| {
+        tls.current_task.robust_list = None;
 
-    // 5. Build auxv
-    let mut aux = crate::loader::auxv::init_auxv();
+        if let Some(robust_list) = tls.current_task.robust_list.take() {
+            let _ = wake_robust_list(robust_list);
+        }
 
-    // 6. Load new image
-    let info = crate::loader::load_program(path, argv_vec, envp_vec, aux)
-        .map_err::<Errno, _>(Into::into)?;
+        // Check if we are the only thread in the process
+        assert_eq!(
+            alloc::sync::Arc::strong_count(&tls.current_task.page_manager),
+            1,
+            "execve when multiple threads exist is not supported yet"
+        );
+        let release = |r: Range<usize>, vm: VmFlags| {
+            // Reserved mappings
+            if vm.is_empty() {
+                return false;
+            }
+            if vm.contains(VmFlags::VM_GROWSDOWN) {
+                // Stack we are currently running on, don't unmap it.
+                // This happens when litebox runs in user space.
+                let rsp: usize;
+                #[cfg(target_arch = "x86_64")]
+                unsafe {
+                    core::arch::asm!(
+                        "mov {}, rsp",
+                        out(reg) rsp,
+                    );
+                }
+                #[cfg(target_arch = "x86")]
+                unsafe {
+                    core::arch::asm!(
+                        "mov {}, esp",
+                        out(reg) rsp,
+                    );
+                }
+                if r.start <= rsp && rsp < r.end {
+                    return false;
+                }
+            }
+            true
+        };
+        unsafe {
+            tls.current_task.page_manager.release_mappings(release);
+        };
+    });
 
-    // 7. Rewrite register state: new IP/SP, zero rax so caller never resumes old path
-    #[cfg(target_arch = "x86_64")]
-    {
-        ctx.rip = info.entry_point;
-        ctx.rsp = info.user_stack_top;
-        ctx.rdx = 0;
+    if let Some(callback) = EXECVE_CALLBACK.get() {
+        callback(ctx, path, argv_vec, envp_vec);
     }
-    #[cfg(target_arch = "x86")]
-    {
-        ctx.eip = info.entry_point;
-        ctx.esp = info.user_stack_top;
-        ctx.edx = 0;
-    }
-
-    // 8. (Optional) clear general-purpose regs for a cleaner start (GNU ld-linux doesn’t require)
-    // Leave others as-is for now.
 
     Ok(())
 }
@@ -779,13 +821,8 @@ pub(crate) fn sys_execve(
 mod tests {
     use core::mem::MaybeUninit;
 
-    use litebox::{
-        fs::FileSystem, mm::linux::PAGE_SIZE, path::Arg, platform::RawConstPointer as _,
-        utils::TruncateExt as _,
-    };
+    use litebox::{mm::linux::PAGE_SIZE, platform::RawConstPointer as _, utils::TruncateExt as _};
     use litebox_common_linux::{CloneFlags, MapFlags, ProtFlags};
-
-    use crate::syscalls::tests::compile;
 
     #[cfg(target_arch = "x86_64")]
     #[test]
@@ -1081,154 +1118,5 @@ mod tests {
             .map(|b| b.count_ones() as usize)
             .sum();
         assert_eq!(ones, super::NR_CPUS);
-    }
-
-    #[cfg(target_arch = "x86_64")]
-    core::arch::global_asm!(
-        "
-        .text
-        .align	4
-        .globl	trampoline
-        .type	trampoline,@function
-    trampoline:
-        xor rdx, rdx
-        mov	rsp, rsi
-        jmp	rdi
-        /* Should not reach. */
-        hlt"
-    );
-    #[cfg(target_arch = "x86")]
-    core::arch::global_asm!(
-        "
-        .text
-        .align  4
-        .globl  trampoline
-        .type   trampoline,@function
-    trampoline:
-        xor     edx, edx
-        mov     ebx, [esp + 4]
-        mov     eax, [esp + 8]
-        mov     esp, eax
-        jmp     ebx
-        /* Should not reach. */
-        hlt"
-    );
-
-    unsafe extern "C" {
-        fn trampoline(entry: usize, sp: usize) -> !;
-    }
-
-    const EXECVE_TARGET_PROGRAM: &str = r#"
-#include <stdio.h>
-
-int main(int argc, char *argv[]) {
-    printf("Hello from execve_test!\n");
-    return 0;
-}
-    "#;
-
-    #[test]
-    fn test_execve() {
-        extern crate std;
-
-        let dir_path = std::env::var("OUT_DIR").unwrap();
-        // let dir_path = "../target/debug".to_string();
-        let src_path = std::path::Path::new(dir_path.as_str()).join("execve_test.c");
-        let bin_path = std::path::Path::new(dir_path.as_str()).join("execve_test");
-        std::fs::write(&src_path, EXECVE_TARGET_PROGRAM).expect("Failed to write test program");
-        compile(
-            src_path.to_str().unwrap(),
-            bin_path.to_str().unwrap(),
-            true,
-            false,
-        );
-        let executable_data = std::fs::read(bin_path.clone()).unwrap();
-
-        crate::syscalls::tests::init_platform(None);
-
-        let target_prog = "/execve_test";
-        let fd = crate::litebox_fs()
-            .open(
-                target_prog,
-                litebox::fs::OFlags::CREAT | litebox::fs::OFlags::WRONLY,
-                litebox::fs::Mode::RWXG | litebox::fs::Mode::RWXO | litebox::fs::Mode::RWXU,
-            )
-            .unwrap();
-        crate::litebox_fs()
-            .write(&fd, &executable_data, None)
-            .unwrap();
-        crate::litebox_fs().close(fd).unwrap();
-
-        // Build C-style argument strings (must be NUL-terminated).
-        let prog_c = target_prog.to_c_str().unwrap();
-        let path = crate::ConstPtr {
-            inner: prog_c.as_ptr().cast_mut(),
-        };
-        let argv_data = [prog_c.as_ptr() as *const i8, core::ptr::null()];
-        let argv = crate::ConstPtr {
-            inner: argv_data.as_ptr() as *mut crate::ConstPtr<i8>,
-        };
-        let envp_data = [c"PATH=/bin".as_ptr() as *const i8, core::ptr::null()];
-        let envp = crate::ConstPtr {
-            inner: envp_data.as_ptr() as *mut crate::ConstPtr<i8>,
-        };
-
-        #[cfg(target_arch = "x86_64")]
-        let mut pt_regs = litebox_common_linux::PtRegs {
-            r15: 0,
-            r14: 0,
-            r13: 0,
-            r12: 0,
-            rbp: 0,
-            rbx: 0,
-            r11: 0,
-            r10: 0,
-            r9: 0,
-            r8: 0,
-            rax: 0,
-            rcx: 0,
-            rdx: 0,
-            rsi: 0,
-            rdi: 0,
-            orig_rax: syscalls::Sysno::execve as usize,
-            rip: 0,
-            cs: 0x33, // __USER_CS
-            eflags: 0,
-            rsp: 0,
-            ss: 0x2b, // __USER_DS
-        };
-        #[cfg(target_arch = "x86")]
-        let mut pt_regs = litebox_common_linux::PtRegs {
-            ebx: 0,
-            ecx: 0,
-            edx: 0,
-            esi: 0,
-            edi: 0,
-            ebp: 0,
-            eax: 0,
-            xds: 0,
-            xes: 0,
-            xfs: 0,
-            xgs: 0,
-            orig_eax: syscalls::Sysno::execve as usize,
-            eip: 0,
-            xcs: 0x23, // __USER_CS
-            eflags: 0,
-            esp: 0,
-            xss: 0x2b, // __USER_DS
-        };
-
-        super::sys_execve(path, argv, envp, &mut pt_regs).expect("sys_execve failed");
-
-        #[cfg(target_arch = "x86_64")]
-        unsafe {
-            trampoline(pt_regs.rip, pt_regs.rsp)
-        };
-        #[cfg(target_arch = "x86")]
-        unsafe {
-            trampoline(pt_regs.eip, pt_regs.esp)
-        };
-
-        unreachable!();
     }
 }


### PR DESCRIPTION
This PR makes the following changes to support `execve`:

1. Similar to Linux, `PageManager` is moved to per-thread `Task` and shared across threads. Network and Filesystem remain as global static singleton, which might be changed in the future.
2. `execve` supposes to clear all TLS slots on x86, we reserve two for LiteBox and only the last one (only 3 slots are available).
3. Split `execve` into two parts: 1) the shim layer only prepares all the arguments and resets some states (e.g., unmap memory, close files); and 2) the runner is responsible for loading the target program (runner already has this functionality; it just needs to register it to the shim layer).