### PR TITLE
Fix futex manager

### DIFF
--- a/litebox/src/sync/futex.rs
+++ b/litebox/src/sync/futex.rs
@@ -331,7 +331,6 @@ impl<Platform: RawSyncPrimitivesProvider + RawPointerProvider + TimeProvider>
         }
         // We can now reset the mask out, and return the number that actually woke up.
         if let Some(lockable) = self.lockables.write().get_mut(&addr) {
-            lockable.latest_wake_bitset = None;
             // Allow waiters to start waiting again
             // Note it is possible that we get a new `lockable` here if all waiters got
             // woken up (hence removed it) and a new waiter came in after that. This ensure


### PR DESCRIPTION
Not sure if it is the same bug I found in #330. I can reproduce a race condition issue by running `test_node_with_seccomp` multiple times ( > 50). LiteBox failed at this line:

https://github.com/microsoft/litebox/blob/c9bae0ac2bd72e48c0941b4f29af3fabe87f9d71/litebox/src/sync/futex.rs#L331

The root cause was that a waker may operate on different `lockable` objects while it is waiting for waiters to wake up. This PR addresses it by assigning a unique number to a `lockable` so that the waker can know whether it gets the same `lockable` object or not.