### PR TITLE
Support syscall creat

### DIFF
--- a/litebox_shim_linux/src/syscalls/file.rs
+++ b/litebox_shim_linux/src/syscalls/file.rs
@@ -34,9 +34,6 @@ enum FsPath<P: path::Arg> {
 
 /// Maximum size of a file path
 pub const PATH_MAX: usize = 4096;
-/// Special value `libc::AT_FDCWD` used to indicate openat should use
-/// the current working directory.
-pub const AT_FDCWD: i32 = -100;
 
 impl<P: path::Arg> FsPath<P> {
     fn new(dirfd: i32, path: P) -> Result<Self, Errno> {
@@ -53,7 +50,7 @@ impl<P: path::Arg> FsPath<P> {
             } else {
                 FsPath::FdRelative { fd: dirfd, path }
             }
-        } else if dirfd == AT_FDCWD {
+        } else if dirfd == litebox_common_linux::AT_FDCWD {
             if path_str.is_empty() {
                 FsPath::Cwd
             } else {
@@ -422,7 +419,7 @@ fn do_readlink(fullpath: &str) -> Result<String, Errno> {
 
 /// Handle syscall `readlink`
 pub fn sys_readlink(pathname: impl path::Arg, buf: &mut [u8]) -> Result<usize, Errno> {
-    sys_readlinkat(AT_FDCWD, pathname, buf)
+    sys_readlinkat(litebox_common_linux::AT_FDCWD, pathname, buf)
 }
 
 /// Handle syscall `readlinkat`


### PR DESCRIPTION

```
The creat() function shall behave as if it is implemented as follows:

           int creat(const char *path, mode_t mode)
           {
               return open(path, O_WRONLY|O_CREAT|O_TRUNC, mode);
           }
```