### PR TITLE
lvbs: Move max cpus and VTL1 memory parsing to one time during boot

### DIFF
--- a/litebox_runner_lvbs/src/main.rs
+++ b/litebox_runner_lvbs/src/main.rs
@@ -9,7 +9,7 @@ use litebox_platform_lvbs::{
 };
 
 #[cfg(debug_assertions)]
-use litebox_platform_lvbs::host::bootparam::{dump_boot_params, dump_cmdline};
+use litebox_platform_lvbs::host::bootparam::parse_boot_info;
 
 #[expect(clippy::missing_safety_doc)]
 #[unsafe(no_mangle)]
@@ -37,11 +37,7 @@ pub fn kernel_main() -> ! {
         serial_println!(" Hello from LiteBox for LVBS! ");
         serial_println!("==============================");
 
-        #[cfg(debug_assertions)]
-        dump_boot_params();
-
-        #[cfg(debug_assertions)]
-        dump_cmdline();
+        parse_boot_info();
     }
 
     let platform = litebox_runner_lvbs::init();


### PR DESCRIPTION
Parse command line and bootparams to extract maximum possible cpus and the VTL1 memory ranges once during initial boot and store them. Use these values from then on. This will later allow boot page to be used as regular memory. It also paves way to use the max cpus to dynamically allocate per cpu memory and to support different memory ranges for VTL1.