### PR TITLE
Ignore O_LARGEFILE in open calls

### DIFF
--- a/litebox/src/fs/in_mem.rs
+++ b/litebox/src/fs/in_mem.rs
@@ -148,9 +148,10 @@ impl<Platform: sync::RawSyncPrimitivesProvider> super::FileSystem for FileSystem
             | OFlags::NOCTTY
             | OFlags::EXCL
             | OFlags::DIRECTORY
-            | OFlags::NONBLOCK;
+            | OFlags::NONBLOCK
+            | OFlags::LARGEFILE;
         if flags.intersects(currently_supported_oflags.complement()) {
-            unimplemented!()
+            unimplemented!("{flags:?}")
         }
         let path = self.absolute_path(path)?;
         let entry = if flags.contains(OFlags::CREAT) {

--- a/litebox/src/fs/layered.rs
+++ b/litebox/src/fs/layered.rs
@@ -447,9 +447,10 @@ impl<
             | OFlags::TRUNC
             | OFlags::NOCTTY
             | OFlags::DIRECTORY
-            | OFlags::NONBLOCK;
+            | OFlags::NONBLOCK
+            | OFlags::LARGEFILE;
         if flags.intersects(currently_supported_oflags.complement()) {
-            unimplemented!()
+            unimplemented!("{flags:?}")
         }
         let path = self.absolute_path(path)?;
         if flags.contains(OFlags::CREAT) {

--- a/litebox/src/fs/tar_ro.rs
+++ b/litebox/src/fs/tar_ro.rs
@@ -153,9 +153,10 @@ impl<Platform: sync::RawSyncPrimitivesProvider> super::FileSystem for FileSystem
             | OFlags::TRUNC
             | OFlags::NOCTTY
             | OFlags::DIRECTORY
-            | OFlags::NONBLOCK;
+            | OFlags::NONBLOCK
+            | OFlags::LARGEFILE;
         if flags.intersects(currently_supported_oflags.complement()) {
-            unimplemented!()
+            unimplemented!("{flags:?}")
         }
         if flags.contains(OFlags::CREAT) {
             return Err(OpenError::ReadOnlyFileSystem);


### PR DESCRIPTION
musl libc passes `O_LARGEFILE` on all opens, indicating it can handle 64-bit file offsets. Ignore this flag in all the fs implementations for now; proper support can be added if ancient 32-bit code support is ever important.