### PR TITLE
Support tgkill

### DIFF
--- a/litebox_common_linux/src/lib.rs
+++ b/litebox_common_linux/src/lib.rs
@@ -1939,6 +1939,11 @@ pub enum SyscallRequest<'a, Platform: litebox::platform::RawPointerProvider> {
     Alarm {
         seconds: u32,
     },
+    ThreadKill {
+        tgid: i32,
+        tid: i32,
+        sig: i32,
+    },
     /// A sentinel that is expected to be "handled" by trivially returning its value.
     Ret(errno::Errno),
 }
@@ -2446,6 +2451,7 @@ impl<'a, Platform: litebox::platform::RawPointerProvider> SyscallRequest<'a, Pla
             Sysno::execve => sys_req!(Execve { pathname:*, argv:*, envp:* }),
             Sysno::umask => sys_req!(Umask { mask }),
             Sysno::alarm => sys_req!(Alarm { seconds }),
+            Sysno::tgkill => sys_req!(ThreadKill { tgid, tid, sig }),
             // TODO: support syscall `statfs`
             Sysno::statx | Sysno::io_uring_setup | Sysno::rseq | Sysno::statfs => {
                 SyscallRequest::Ret(errno::Errno::ENOSYS)
@@ -2497,6 +2503,12 @@ pub enum PunchthroughSyscall<Platform: litebox::platform::RawPointerProvider> {
     /// If `seconds` is zero, any pending alarm is canceled.
     /// In any event, any previously set alarm() is canceled.
     Alarm { seconds: u32 },
+    /// Sends the signal `sig` to the thread with the thread ID `tid` in the thread group `tgid`.
+    ThreadKill {
+        thread_group_id: i32,
+        thread_id: i32,
+        sig: Signal,
+    },
     /// Set the FS base register to the value in `addr`.
     #[cfg(target_arch = "x86_64")]
     SetFsBase { addr: usize },

--- a/litebox_platform_linux_kernel/src/lib.rs
+++ b/litebox_platform_linux_kernel/src/lib.rs
@@ -61,6 +61,7 @@ impl<Host: HostInterface> PunchthroughToken for LinuxPunchthroughToken<Host> {
                 oldact: _,
             } => todo!(),
             PunchthroughSyscall::RtSigreturn { stack: _ } => todo!(),
+            PunchthroughSyscall::ThreadKill { .. } => todo!(),
             PunchthroughSyscall::SetFsBase { addr } => {
                 unsafe { litebox_common_linux::wrfsbase(addr) };
                 Ok(0)

--- a/litebox_shim_linux/src/lib.rs
+++ b/litebox_shim_linux/src/lib.rs
@@ -808,6 +808,11 @@ pub fn handle_syscall_request(request: SyscallRequest<Platform>) -> usize {
             Ok(old_mask.bits() as usize)
         }
         SyscallRequest::Alarm { seconds } => syscalls::process::sys_alarm(seconds),
+        SyscallRequest::ThreadKill { tgid, tid, sig } => {
+            litebox_common_linux::Signal::try_from(sig)
+                .map_err(|_| Errno::EINVAL)
+                .and_then(|sig| syscalls::process::sys_tgkill(tgid, tid, sig).map(|()| 0))
+        }
         _ => {
             todo!()
         }


### PR DESCRIPTION
Currently all signal related syscalls are punchthroughs. We may want to have a dedicated provider for it?