### PR TITLE
Implement syscall unlinkat/unlink

### DIFF
--- a/litebox_common_linux/src/errno/mod.rs
+++ b/litebox_common_linux/src/errno/mod.rs
@@ -133,6 +133,32 @@ impl From<litebox::fs::errors::OpenError> for Errno {
     }
 }
 
+impl From<litebox::fs::errors::UnlinkError> for Errno {
+    fn from(value: litebox::fs::errors::UnlinkError) -> Self {
+        match value {
+            litebox::fs::errors::UnlinkError::NoWritePerms => Errno::EACCES,
+            litebox::fs::errors::UnlinkError::IsADirectory => Errno::EISDIR,
+            litebox::fs::errors::UnlinkError::ReadOnlyFileSystem => Errno::EROFS,
+            litebox::fs::errors::UnlinkError::PathError(path_error) => path_error.into(),
+            _ => unimplemented!(),
+        }
+    }
+}
+
+impl From<litebox::fs::errors::RmdirError> for Errno {
+    fn from(value: litebox::fs::errors::RmdirError) -> Self {
+        match value {
+            litebox::fs::errors::RmdirError::NoWritePerms => Errno::EACCES,
+            litebox::fs::errors::RmdirError::Busy => Errno::EBUSY,
+            litebox::fs::errors::RmdirError::NotEmpty => Errno::ENOTEMPTY,
+            litebox::fs::errors::RmdirError::NotADirectory => Errno::ENOTDIR,
+            litebox::fs::errors::RmdirError::ReadOnlyFileSystem => Errno::EROFS,
+            litebox::fs::errors::RmdirError::PathError(path_error) => path_error.into(),
+            _ => unimplemented!(),
+        }
+    }
+}
+
 impl From<litebox::fs::errors::CloseError> for Errno {
     fn from(value: litebox::fs::errors::CloseError) -> Self {
         #[expect(clippy::match_single_binding)]

--- a/litebox_shim_linux/src/lib.rs
+++ b/litebox_shim_linux/src/lib.rs
@@ -682,6 +682,13 @@ pub fn handle_syscall_request(request: SyscallRequest<Platform>) -> usize {
         SyscallRequest::Ftruncate { fd, length } => {
             syscalls::file::sys_ftruncate(fd, length).map(|()| 0)
         }
+        SyscallRequest::Unlinkat {
+            dirfd,
+            pathname,
+            flags,
+        } => pathname.to_cstring().map_or(Err(Errno::EFAULT), |path| {
+            syscalls::file::sys_unlinkat(dirfd, path, flags).map(|()| 0)
+        }),
         SyscallRequest::Stat { pathname, buf } => {
             pathname.to_cstring().map_or(Err(Errno::EFAULT), |path| {
                 syscalls::file::sys_stat(path).and_then(|stat| {


### PR DESCRIPTION
1. Add support for syscall `unlink`/`unlinkat`.
2. Add basic unit tests implemented by copilot.