### PR TITLE
Support syscall alarm

### DIFF
--- a/litebox_common_linux/src/lib.rs
+++ b/litebox_common_linux/src/lib.rs
@@ -1932,6 +1932,9 @@ pub enum SyscallRequest<'a, Platform: litebox::platform::RawPointerProvider> {
     Prctl {
         args: PrctlArg<Platform>,
     },
+    Alarm {
+        seconds: u32,
+    },
     /// A sentinel that is expected to be "handled" by trivially returning its value.
     Ret(errno::Errno),
 }
@@ -2423,6 +2426,7 @@ impl<'a, Platform: litebox::platform::RawPointerProvider> SyscallRequest<'a, Pla
             }
             Sysno::execve => sys_req!(Execve { pathname:*, argv:*, envp:* }),
             Sysno::umask => sys_req!(Umask { mask }),
+            Sysno::alarm => sys_req!(Alarm { seconds }),
             // TODO: support syscall `statfs`
             Sysno::statx | Sysno::io_uring_setup | Sysno::rseq | Sysno::statfs => {
                 SyscallRequest::Ret(errno::Errno::ENOSYS)
@@ -2470,6 +2474,10 @@ pub enum PunchthroughSyscall<Platform: litebox::platform::RawPointerProvider> {
         /// The user stack pointer at the time of the signal.
         stack: usize,
     },
+    /// Arrange for a SIGALRM signal to be delivered to the calling process in `seconds` seconds.
+    /// If `seconds` is zero, any pending alarm is canceled.
+    /// In any event, any previously set alarm() is canceled.
+    Alarm { seconds: u32 },
     /// Set the FS base register to the value in `addr`.
     #[cfg(target_arch = "x86_64")]
     SetFsBase { addr: usize },

--- a/litebox_platform_linux_kernel/src/lib.rs
+++ b/litebox_platform_linux_kernel/src/lib.rs
@@ -72,6 +72,7 @@ impl<Host: HostInterface> PunchthroughToken for LinuxPunchthroughToken<Host> {
                     .map(|()| 0)
                     .ok_or(Errno::EFAULT)
             }
+            PunchthroughSyscall::Alarm { seconds: _ } => todo!(),
         };
         match r {
             Ok(v) => Ok(v),

--- a/litebox_platform_linux_userland/src/lib.rs
+++ b/litebox_platform_linux_userland/src/lib.rs
@@ -935,6 +935,16 @@ impl litebox::platform::PunchthroughToken for PunchthroughToken {
             PunchthroughSyscall::SetThreadArea { user_desc } => {
                 set_thread_area(user_desc).map_err(litebox::platform::PunchthroughError::Failure)
             }
+            PunchthroughSyscall::Alarm { seconds } => unsafe {
+                let remain = syscalls::syscall2(
+                    syscalls::Sysno::alarm,
+                    seconds as usize,
+                    // Unused by the syscall but would be checked by Seccomp filter if enabled.
+                    syscall_intercept::SYSCALL_ARG_MAGIC,
+                )
+                .expect("failed to set alarm");
+                Ok(remain)
+            },
         }
     }
 }

--- a/litebox_platform_linux_userland/src/syscall_intercept/systrap.rs
+++ b/litebox_platform_linux_userland/src/syscall_intercept/systrap.rs
@@ -184,6 +184,7 @@ fn register_seccomp_filter() {
         (libc::SYS_exit_group, vec![backdoor_on_arg(1)]),
         (libc::SYS_tgkill, vec![]),
         (libc::SYS_clone3, vec![backdoor_on_arg(2)]),
+        (libc::SYS_alarm, vec![backdoor_on_arg(1)]),
     ];
     let rule_map: std::collections::BTreeMap<i64, Vec<SeccompRule>> = rules.into_iter().collect();
 

--- a/litebox_shim_linux/src/lib.rs
+++ b/litebox_shim_linux/src/lib.rs
@@ -804,6 +804,7 @@ pub fn handle_syscall_request(request: SyscallRequest<Platform>) -> usize {
             let old_mask = syscalls::file::sys_umask(mask);
             Ok(old_mask.bits() as usize)
         }
+        SyscallRequest::Alarm { seconds } => syscalls::process::sys_alarm(seconds),
         _ => {
             todo!()
         }

--- a/litebox_shim_linux/src/syscalls/process.rs
+++ b/litebox_shim_linux/src/syscalls/process.rs
@@ -957,6 +957,17 @@ pub(crate) fn sys_execve(
     unreachable!("execve callback must not return on success");
 }
 
+/// Handle syscall `alarm`.
+pub(crate) fn sys_alarm(seconds: u32) -> Result<usize, Errno> {
+    let token = litebox_platform_multiplex::platform()
+        .get_punchthrough_token_for(litebox_common_linux::PunchthroughSyscall::Alarm { seconds })
+        .expect("Failed to get punchthrough token for SET_ALARM");
+    token.execute().map_err(|e| match e {
+        litebox::platform::PunchthroughError::Failure(errno) => errno,
+        _ => unimplemented!("Unsupported punchthrough error {:?}", e),
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use core::mem::MaybeUninit;


### PR DESCRIPTION
To run UnixBench, `alarm` is required. We don't have a proper design/support for signal related syscalls yet. This PR adds `alarm` as a punchthrough. We will revisit it later once we have a better understanding of supporting signals on different platforms.