### PR TITLE
Explicitly align stack for tail call at thread start

### DIFF
--- a/litebox_platform_linux_userland/src/lib.rs
+++ b/litebox_platform_linux_userland/src/lib.rs
@@ -422,6 +422,7 @@ impl litebox::platform::ThreadProvider for LinuxUserland {
     type ThreadSpawnError = litebox_common_linux::errno::Errno;
     type ThreadId = usize;
 
+    #[expect(clippy::too_many_lines)]
     unsafe fn spawn_thread(
         &self,
         ctx: &litebox_common_linux::PtRegs,


### PR DESCRIPTION
User code may specify an unaligned stack pointer at start. Since the Linux userland platform runs on the user's stack, it must be aligned to avoid faults when the compiler uses an alignment-sensitive instruction like `movaps`.

Fix this by explicitly aligning the stack before calling into `thread_start`.