### PR TITLE
Ignore MAP_SHARED

### DIFF
--- a/litebox_shim_linux/src/syscalls/mm.rs
+++ b/litebox_shim_linux/src/syscalls/mm.rs
@@ -114,8 +114,7 @@ pub(crate) fn sys_mmap(
         return Err(Errno::EINVAL);
     }
     if flags.intersects(
-        MapFlags::MAP_SHARED
-            | MapFlags::MAP_32BIT
+        MapFlags::MAP_32BIT
             | MapFlags::MAP_GROWSDOWN
             | MapFlags::MAP_LOCKED
             | MapFlags::MAP_NONBLOCK
@@ -127,6 +126,15 @@ pub(crate) fn sys_mmap(
     ) {
         todo!("Unsupported flags {:?}", flags);
     }
+
+    if flags.contains(MapFlags::MAP_SHARED) {
+        #[cfg(debug_assertions)]
+        litebox::log_println!(
+            litebox_platform_multiplex::platform(),
+            "Warning: MAP_SHARED is not fully supported yet, changes are not reflected to the underlying file.",
+        );
+    }
+    let flags = flags - MapFlags::MAP_SHARED;
 
     let aligned_len = align_up(len, PAGE_SIZE);
     if aligned_len == 0 {


### PR DESCRIPTION
I was trying to run sqlite's [benchmark](https://sqlite.org/cpu.html) but ran into an unsupported feature: shared file mapping.

From strace's log on the test, once the file is mapped, there is no more open/read/write to that file. Thus, we can safely ignore this flag in this case. With this change, I can run the test and get some performance numbers but I'm not 100% sure if they are correct.

Supporting shared file mapping requires significant change; not sure how to do it yet and whether we are going to support it.