### PR TITLE
Make `fd_from_raw_integer` not maintain a borrow

### DIFF
--- a/litebox/src/fd/tests.rs
+++ b/litebox/src/fd/tests.rs
@@ -132,7 +132,7 @@ fn test_fd_raw_integer() {
     let fetched_fd = descriptors
         .fd_from_raw_integer::<MockSubsystem>(raw_fd)
         .unwrap();
-    let data = descriptors.with_entry(fetched_fd, |e| e.data.clone());
+    let data = descriptors.with_entry(&fetched_fd.upgrade().unwrap(), |e| e.data.clone());
     assert_eq!(data, "test");
 
     let consumed_fd = descriptors


### PR DESCRIPTION
This PR updates `fd_from_raw_integer` to return a `Weak` instead of maintaining a borrow, so that some upcoming changes can be managed better.  Specifically, this separates the borrow of the descriptor table from the actual descriptors themselves, instead replacing it with a fallible `upgrade` to make sure it is still alive.  This comes with the downside of such upgrades becoming fallible (+ now there is no _static_ guarantee that someone isn't storing the upgrade away; the documentation does mention that people should not do this though). However, it comes with the upside of much simplified lifetime management at the Linux shim layer for upcoming changes.  Otherwise, it can lead to a mess of recursive locks that can become quite problematic (via deadlocks) and would be very hard to untangle.

I believe that a component registry pattern (#24) might make this even nicer, but that particular issue has been open long enough, and I don't think we're solving that too soon, so for now, we live with the explicitly weak reference.

---

This is yet another PR in the series of PRs towards the better FD design (connected to https://github.com/microsoft/litebox/issues/31).