### PR TITLE
LVBS: Fix patch size calculation

### DIFF
--- a/litebox_platform_lvbs/src/mshv/heki.rs
+++ b/litebox_platform_lvbs/src/mshv/heki.rs
@@ -267,14 +267,17 @@ impl HekiPatch {
         let bytes_in_first_page = if pa_0.is_aligned(Size4KiB::SIZE) {
             core::cmp::min(PAGE_SIZE, usize::from(self.size))
         } else {
-            usize::try_from(pa_0.align_up(Size4KiB::SIZE) - pa_0).unwrap()
+            core::cmp::min(
+                usize::try_from(pa_0.align_up(Size4KiB::SIZE) - pa_0).unwrap(),
+                usize::from(self.size),
+            )
         };
 
         !(self.size == 0
             || usize::from(self.size) > POKE_MAX_OPCODE_SIZE
             || (pa_0 == pa_1)
             || (bytes_in_first_page < usize::from(self.size) && pa_1.is_null())
-            || (bytes_in_first_page >= usize::from(self.size) && !pa_1.is_null()))
+            || (bytes_in_first_page == usize::from(self.size) && !pa_1.is_null()))
     }
 }
 

--- a/litebox_platform_lvbs/src/mshv/vsm.rs
+++ b/litebox_platform_lvbs/src/mshv/vsm.rs
@@ -864,11 +864,14 @@ fn copy_heki_patch_from_vtl0(patch_pa_0: u64, patch_pa_1: u64) -> Result<HekiPat
     let bytes_in_first_page = if patch_pa_0.is_aligned(Size4KiB::SIZE) {
         core::cmp::min(PAGE_SIZE, core::mem::size_of::<HekiPatch>())
     } else {
-        usize::try_from(patch_pa_0.align_up(Size4KiB::SIZE) - patch_pa_0).unwrap()
+        core::cmp::min(
+            usize::try_from(patch_pa_0.align_up(Size4KiB::SIZE) - patch_pa_0).unwrap(),
+            core::mem::size_of::<HekiPatch>(),
+        )
     };
 
     if (bytes_in_first_page < core::mem::size_of::<HekiPatch>() && patch_pa_1.is_null())
-        || (bytes_in_first_page >= core::mem::size_of::<HekiPatch>() && !patch_pa_1.is_null())
+        || (bytes_in_first_page == core::mem::size_of::<HekiPatch>() && !patch_pa_1.is_null())
     {
         return Err(Errno::EINVAL);
     }


### PR DESCRIPTION
This PR fixes the patch size calculation bug found by @athvu .
`align_up()` is no-op if an address is already aligned, which
results in incorrect calculation of `bytes_in_first_page`.