### PR TITLE
Ignore OFlags::NOFOLLOW

### DIFF
--- a/litebox/src/fs/devices/stdio.rs
+++ b/litebox/src/fs/devices/stdio.rs
@@ -97,8 +97,8 @@ impl<Platform: crate::sync::RawSyncPrimitivesProvider + crate::platform::StdioPr
         let flags = flags - OFlags::DIRECTORY;
         let nonblocking = flags.contains(OFlags::NONBLOCK);
         let flags = flags - OFlags::NONBLOCK;
-        // ignore NOCTTY
-        let flags = flags - OFlags::NOCTTY;
+        // ignore NOCTTY and NOFOLLOW
+        let flags = flags - OFlags::NOCTTY - OFlags::NOFOLLOW;
         let truncate = flags.contains(OFlags::TRUNC);
         let flags = flags - OFlags::TRUNC;
         let path = self.absolute_path(path)?;

--- a/litebox/src/fs/in_mem.rs
+++ b/litebox/src/fs/in_mem.rs
@@ -147,7 +147,8 @@ impl<Platform: sync::RawSyncPrimitivesProvider> super::FileSystem for FileSystem
             | OFlags::EXCL
             | OFlags::DIRECTORY
             | OFlags::NONBLOCK
-            | OFlags::LARGEFILE;
+            | OFlags::LARGEFILE
+            | OFlags::NOFOLLOW;
         if flags.intersects(currently_supported_oflags.complement()) {
             unimplemented!("{flags:?}")
         }

--- a/litebox/src/fs/layered.rs
+++ b/litebox/src/fs/layered.rs
@@ -448,7 +448,8 @@ impl<
             | OFlags::NOCTTY
             | OFlags::DIRECTORY
             | OFlags::NONBLOCK
-            | OFlags::LARGEFILE;
+            | OFlags::LARGEFILE
+            | OFlags::NOFOLLOW;
         if flags.intersects(currently_supported_oflags.complement()) {
             unimplemented!("{flags:?}")
         }

--- a/litebox/src/fs/tar_ro.rs
+++ b/litebox/src/fs/tar_ro.rs
@@ -153,7 +153,8 @@ impl<Platform: sync::RawSyncPrimitivesProvider> super::FileSystem for FileSystem
             | OFlags::NOCTTY
             | OFlags::DIRECTORY
             | OFlags::NONBLOCK
-            | OFlags::LARGEFILE;
+            | OFlags::LARGEFILE
+            | OFlags::NOFOLLOW;
         if flags.intersects(currently_supported_oflags.complement()) {
             unimplemented!("{flags:?}")
         }


### PR DESCRIPTION
```
O_NOFOLLOW
              If the trailing component (i.e., basename) of path is a
              symbolic link, then the open fails, with the error ELOOP.
```

Since we don't support symbolic links, we can ignore this flag.