### PR TITLE
Support PR_CAPBSET_READ

### DIFF
--- a/litebox_common_linux/src/lib.rs
+++ b/litebox_common_linux/src/lib.rs
@@ -1483,6 +1483,56 @@ pub struct Sysinfo {
     pub _f: [u8; 20 - 2 * core::mem::size_of::<usize>() - core::mem::size_of::<u32>()],
 }
 
+bitflags::bitflags! {
+    /// Represents a set of Linux capabilities.
+    pub struct CapSet: u64 {
+        const CHOWN = 1 << 0;
+        const DAC_OVERRIDE = 1 << 1;
+        const DAC_READ_SEARCH = 1 << 2;
+        const FOWNER = 1 << 3;
+        const FSETID = 1 << 4;
+        const KILL = 1 << 5;
+        const SETGID = 1 << 6;
+        const SETUID = 1 << 7;
+        const SETPCAP = 1 << 8;
+        const LINUX_IMMUTABLE = 1 << 9;
+        const NET_BIND_SERVICE = 1 << 10;
+        const NET_BROADCAST = 1 << 11;
+        const NET_ADMIN = 1 << 12;
+        const NET_RAW = 1 << 13;
+        const IPC_LOCK = 1 << 14;
+        const IPC_OWNER = 1 << 15;
+        const SYS_MODULE = 1 << 16;
+        const SYS_RAWIO = 1 << 17;
+        const SYS_CHROOT = 1 << 18;
+        const SYS_PTRACE = 1 << 19;
+        const SYS_PACCT = 1 << 20;
+        const SYS_ADMIN = 1 << 21;
+        const SYS_BOOT = 1 << 22;
+        const SYS_NICE = 1 << 23;
+        const SYS_RESOURCE = 1 << 24;
+        const SYS_TIME = 1 << 25;
+        const SYS_TTY_CONFIG = 1 << 26;
+        const MKNOD = 1 << 27;
+        const LEASE = 1 << 28;
+        const AUDIT_WRITE = 1 << 29;
+        const AUDIT_CONTROL = 1 << 30;
+        const SETFCAP = 1 << 31;
+        const MAC_OVERRIDE = 1 << 32;
+        const MAC_ADMIN = 1 << 33;
+        const SYSLOG = 1 << 34;
+        const WAKE_ALARM = 1 << 35;
+        const BLOCK_SUSPEND = 1 << 36;
+        const AUDIT_READ = 1 << 37;
+        const PERFMON = 1 << 38;
+        const BPF = 1 << 39;
+        const CHECKPOINT_RESTORE = 1u64 << 40;
+
+        const LAST_CAP = Self::CHECKPOINT_RESTORE.bits();
+        const _ = !0; // Externally defined flags
+    }
+}
+
 /// Header structure used for the `capget` and `capset` syscalls.
 #[repr(C)]
 #[derive(Clone, Debug)]
@@ -1609,6 +1659,7 @@ pub enum PrctlOption {
     SetEndian = 20,
     GetSeccomp = 21,
     SetSeccomp = 22,
+    /// PR_CAPBSET_READ: read the calling thread's capability bounding set
     CapBSetRead = 23,
     CapBSetDrop = 24,
     GetTSC = 25,
@@ -1642,6 +1693,7 @@ pub enum PrctlOption {
 pub enum PrctlArg<Platform: litebox::platform::RawPointerProvider> {
     SetName(Platform::RawConstPointer<u8>),
     GetName(Platform::RawMutPointer<u8>),
+    CapBSetRead(usize),
 }
 
 /// Request to syscall handler
@@ -2369,6 +2421,9 @@ impl<'a, Platform: litebox::platform::RawPointerProvider> SyscallRequest<'a, Pla
                         },
                         PrctlOption::GetName => SyscallRequest::Prctl {
                             args: PrctlArg::GetName(ctx.sys_req_ptr(1)),
+                        },
+                        PrctlOption::CapBSetRead => SyscallRequest::Prctl {
+                            args: PrctlArg::CapBSetRead(ctx.sys_req_arg(1)),
                         },
                         _ => {
                             // We don't yet support any other prctl operations.

--- a/litebox_shim_linux/src/syscalls/process.rs
+++ b/litebox_shim_linux/src/syscalls/process.rs
@@ -51,6 +51,19 @@ pub(crate) fn sys_prctl(
             set_task_comm(&name_buf);
             Ok(0)
         }
+        PrctlArg::CapBSetRead(cap) => {
+            // Return 1 if the capability specified in cap is in the calling
+            // thread's capability bounding set, or 0 if it is not.
+            if cap
+                > litebox_common_linux::CapSet::LAST_CAP
+                    .bits()
+                    .trailing_zeros() as usize
+            {
+                return Err(Errno::EINVAL);
+            }
+            // Note we don't support capabilities in LiteBox, so we always return 0.
+            Ok(0)
+        }
         _ => unimplemented!(),
     }
 }


### PR DESCRIPTION
Support one more option `PR_CAPBSET_READ` for `prctl`. Similar to #236, it is a dummy implementation that always returns zero (i.e., no capability).