### PR TITLE
Support sendmsg

### DIFF
--- a/litebox_common_linux/src/errno/mod.rs
+++ b/litebox_common_linux/src/errno/mod.rs
@@ -420,7 +420,7 @@ impl From<litebox::net::errors::SendError> for Errno {
     fn from(value: litebox::net::errors::SendError) -> Self {
         match value {
             litebox::net::errors::SendError::InvalidFd => Errno::EBADF,
-            litebox::net::errors::SendError::SocketInInvalidState => Errno::ENOTCONN,
+            litebox::net::errors::SendError::SocketInInvalidState => Errno::EPIPE,
             litebox::net::errors::SendError::Unaddressable => Errno::EDESTADDRREQ,
             litebox::net::errors::SendError::BufferFull => Errno::EAGAIN,
             litebox::net::errors::SendError::PortAllocationFailure(e) => e.into(),

--- a/litebox_shim_linux/src/lib.rs
+++ b/litebox_shim_linux/src/lib.rs
@@ -799,6 +799,9 @@ impl Task {
                 .map(|addr| syscalls::net::read_sockaddr_from_user(addr, addrlen as usize))
                 .transpose()
                 .and_then(|sockaddr| self.sys_sendto(sockfd, buf, len, flags, sockaddr)),
+            SyscallRequest::Sendmsg { sockfd, msg, flags } => unsafe { msg.read_at_offset(0) }
+                .ok_or(Errno::EFAULT)
+                .and_then(|msg| self.sys_sendmsg(sockfd, &msg, flags)),
             SyscallRequest::Recvfrom {
                 sockfd,
                 buf,


### PR DESCRIPTION
Add support for syscall `sendmsg` with some TODO lefts:
1. Sending ancillary data is not supported yet.
2. Sending the SIGPIPE signal upon EPIPE is not supported yet.