### PR TITLE
Add a ratchet for `MaybeUninit`

### DIFF
--- a/dev_tests/src/ratchet.rs
+++ b/dev_tests/src/ratchet.rs
@@ -55,6 +55,26 @@ fn ratchet_globals() -> Result<()> {
     )
 }
 
+#[test]
+fn ratchet_maybe_uninit() -> Result<()> {
+    ratchet(
+        &[
+            ("dev_tests/", 1),
+            ("litebox_platform_freebsd_userland/", 3),
+            ("litebox_platform_linux_kernel/", 1),
+            ("litebox_platform_linux_userland/", 3),
+            ("litebox_platform_lvbs/", 8),
+            ("litebox_shim_linux/", 8),
+        ],
+        |file| {
+            Ok(file
+                .lines()
+                .filter(|line| line.as_ref().unwrap().contains("MaybeUninit"))
+                .count())
+        },
+    )
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 /// Convenience function to set up a ratchet test, see below for examples.
@@ -123,7 +143,7 @@ fn ratchet(expected: &[(&str, usize)], f: impl Fn(BufReader<File>) -> Result<usi
             }
             std::cmp::Ordering::Greater => {
                 bail!(
-                    "Ratcheted count for paths starting with '{prefix}' increased by {} :(\n\nYou might be using a feature that is ratcheted.\nTips:\n\tTry if you can work without using this feature.\n\tIf you think the heuristic detection is incorrect, you might need to update the ratchet's heuristic.\n\tIf the heuristic is correct, you might need to update the count.",
+                    "Ratcheted count for paths starting with '{prefix}' increased by {} :(\n\nYou might be using a feature that is ratcheted (i.e., we are aiming to reduce usage of in the codebase).\nTips:\n\tTry if you can work without using this feature.\n\tIf you think the heuristic detection is incorrect, you might need to update the ratchet's heuristic.\n\tIf the heuristic is correct, you might need to update the count.",
                     count - expected_count
                 )
             }


### PR DESCRIPTION
`MaybeUninit` has a bunch of footguns that make it quite dangerous in general (_technically_ it is the `assume_init` and other methods on `MaybeUninit` that are dangerous, but I am using it as a shorthand for its methods) and require careful review around any time it is used. 

Often, zero/default-initializing a value is _very_ cheap anyways that it is rarely worth the danger `MaybeUninit` poses.

Our codebase already has added a few `MaybeUninit`s around that I don't think carry their own weight. Thus, this PR introduces a ratchet for `MaybeUninit` so that we do not increase its usage, and eventually cut down on its usage in future PRs.