### PR TITLE
Clear out manually-handled `File` descriptors from shim

### DIFF
--- a/litebox_shim_linux/src/lib.rs
+++ b/litebox_shim_linux/src/lib.rs
@@ -84,6 +84,7 @@ pub fn set_fs(fs: LinuxFS) {
     FS.set(alloc::boxed::Box::new(fs))
         .map_err(|_| {})
         .expect("fs is already set");
+    initialize_stdio_in_shared_descriptors_table();
 }
 
 /// Create a default layered file system with the given in-memory and tar read-only layers.
@@ -174,11 +175,6 @@ struct Descriptors {
 
 impl Descriptors {
     fn new() -> Self {
-        // TODO(jayb): We are initializing the stdio files into the shared descriptor table here
-        // mostly because the old `StdioFile` and Descriptor interface was here. It will be moved
-        // out when this `Descriptors` struct is removed from this crate (one of the last few bits
-        // of the shared PR series).
-        initialize_stdio_in_shared_descriptors_table();
         Self {
             descriptors: vec![
                 Some(Descriptor::LiteBoxRawFd(0)),
@@ -219,18 +215,6 @@ impl Descriptors {
         let fd = fd as usize;
         self.descriptors.get_mut(fd)?.take()
     }
-    fn remove_file(&mut self, fd: u32) -> Option<FileFd> {
-        let fd = fd as usize;
-        if let Some(Descriptor::File(file_fd)) = self
-            .descriptors
-            .get_mut(fd)?
-            .take_if(|v| matches!(v, Descriptor::File(_)))
-        {
-            Some(file_fd)
-        } else {
-            None
-        }
-    }
     fn remove_socket(&mut self, fd: u32) -> Option<alloc::sync::Arc<crate::syscalls::net::Socket>> {
         let fd = fd as usize;
         if let Some(Descriptor::Socket(socket_fd)) = self
@@ -245,13 +229,6 @@ impl Descriptors {
     }
     fn get_fd(&self, fd: u32) -> Option<&Descriptor> {
         self.descriptors.get(fd as usize)?.as_ref()
-    }
-    fn get_file_fd(&self, fd: u32) -> Option<&FileFd> {
-        if let Descriptor::File(file_fd) = self.descriptors.get(fd as usize)?.as_ref()? {
-            Some(file_fd)
-        } else {
-            None
-        }
     }
     fn get_socket_fd(&self, fd: u32) -> Option<&crate::syscalls::net::Socket> {
         if let Descriptor::Socket(socket_fd) = self.descriptors.get(fd as usize)?.as_ref()? {
@@ -278,7 +255,6 @@ impl Descriptors {
 
 enum Descriptor {
     LiteBoxRawFd(usize),
-    File(FileFd),
     // Note we are using `Arc` here so that we can hold a reference to the socket
     // without holding a lock on the file descriptor (see `sys_accept` for an example).
     // TODO: this could be addressed by #120.

--- a/litebox_shim_linux/src/syscalls/epoll.rs
+++ b/litebox_shim_linux/src/syscalls/epoll.rs
@@ -82,7 +82,6 @@ impl Descriptor {
             Descriptor::PipeWriter { producer, .. } => producer,
             Descriptor::Eventfd { file, .. } => file,
             Descriptor::Socket(socket) => socket,
-            Descriptor::File(typed_fd) => todo!(),
             Descriptor::LiteBoxRawFd(fd) => return Events::OUT & mask, // TODO: handle properly
             Descriptor::Epoll { file, .. } => todo!(),
         };
@@ -232,12 +231,12 @@ struct EpollEntryKey(u32, *const ());
 impl EpollEntryKey {
     fn new(fd: u32, desc: &Descriptor) -> Self {
         let ptr = match desc {
+            Descriptor::LiteBoxRawFd(raw_fd) => *raw_fd as _,
             Descriptor::PipeReader { consumer, .. } => Arc::as_ptr(consumer).cast(),
             Descriptor::PipeWriter { producer, .. } => Arc::as_ptr(producer).cast(),
             Descriptor::Eventfd { file, .. } => Arc::as_ptr(file).cast(),
             Descriptor::Socket(socket) => Arc::as_ptr(socket).cast(),
-            Descriptor::File(file) => core::ptr::from_ref(file).cast(),
-            _ => todo!(),
+            Descriptor::Epoll { .. } => todo!(),
         };
         Self(fd, ptr)
     }


### PR DESCRIPTION
This PR clears out the manually handled `File` Descriptors from the shim.  It also updates the stdio initialization to do it eagerly rather than on-demand.  The moment we have an FS, we can initialize FDs 0, 1, and 2.

---

This is yet another PR in the series of PRs towards the better FD design
 (connected to #31).