### PR TITLE
Support --rewrite-syscalls in Windows and Linux runners

### DIFF
--- a/litebox_runner_linux_userland/src/lib.rs
+++ b/litebox_runner_linux_userland/src/lib.rs
@@ -105,11 +105,7 @@ pub fn run(cli_args: CliArgs) -> Result<()> {
             .collect();
         let data = std::fs::read(prog).unwrap();
         let data = if cli_args.rewrite_syscalls {
-            // capstone declares a global allocator in conflict with our own.
-            // https://github.com/capstone-rust/capstone-rs/blob/14e855ca58400f454cb7ceb87d2c5e7b635ce498/capstone-rs/src/lib.rs#L16
-            // litebox_syscall_rewriter::hook_syscalls_in_elf(&data, None).unwrap()
-            // Might be a bug in `capstone-rs`: https://github.com/capstone-rust/capstone-rs/pull/171
-            todo!()
+            litebox_syscall_rewriter::hook_syscalls_in_elf(&data, None).unwrap()
         } else {
             data
         };


### PR DESCRIPTION
Now that capstone has been fixed, the Linux runner can rewrite syscalls at load time, as a convenience. Extend this convenience to the Windows runner as well.