### PR TITLE
Implement sched_yield as a no-op

### DIFF
--- a/litebox_common_linux/src/lib.rs
+++ b/litebox_common_linux/src/lib.rs
@@ -2152,6 +2152,7 @@ pub enum SyscallRequest<'a, Platform: litebox::platform::RawPointerProvider> {
         len: usize,
         mask: Platform::RawMutPointer<u8>,
     },
+    SchedYield,
     Futex {
         args: FutexArgs<Platform>,
     },
@@ -2684,6 +2685,7 @@ impl<'a, Platform: litebox::platform::RawPointerProvider> SyscallRequest<'a, Pla
                     mask: ctx.sys_req_ptr(2),
                 }
             }
+            Sysno::sched_yield => SyscallRequest::SchedYield,
             Sysno::futex => {
                 let addr = ctx.sys_req_ptr(0);
                 let op: i32 = ctx.sys_req_arg(1);

--- a/litebox_shim_linux/src/lib.rs
+++ b/litebox_shim_linux/src/lib.rs
@@ -899,6 +899,11 @@ pub fn handle_syscall_request(request: SyscallRequest<Platform>) -> ContinueOper
                     .ok_or(Errno::EFAULT)
             }
         }
+        SyscallRequest::SchedYield => {
+            // Do nothing until we have more scheduler integration with the
+            // platform.
+            Ok(0)
+        }
         SyscallRequest::Futex { args } => syscalls::process::sys_futex(args),
         SyscallRequest::Umask { mask } => {
             let old_mask = syscalls::file::sys_umask(mask);


### PR DESCRIPTION
Node seems to issue this syscall sometimes. No-op it for now, at least until there is some platform scheduler integration.