### PR TITLE
Switch `get_local_addr` to fallible

### DIFF
--- a/litebox/src/net/errors.rs
+++ b/litebox/src/net/errors.rs
@@ -42,6 +42,14 @@ pub enum ConnectError {
     Unaddressable,
 }
 
+/// Possible errors from [`Network::get_local_addr`]
+#[non_exhaustive]
+#[derive(Error, Debug)]
+pub enum LocalAddrError {
+    #[error("Not a valid open file descriptor")]
+    InvalidFd,
+}
+
 /// Possible errors from [`Network::bind`]
 #[non_exhaustive]
 #[derive(Error, Debug)]

--- a/litebox/src/net/mod.rs
+++ b/litebox/src/net/mod.rs
@@ -19,8 +19,8 @@ mod phy;
 mod tests;
 
 use errors::{
-    AcceptError, BindError, CloseError, ConnectError, ListenError, ReceiveError, SendError,
-    SocketError,
+    AcceptError, BindError, CloseError, ConnectError, ListenError, LocalAddrError, ReceiveError,
+    SendError, SocketError,
 };
 use local_ports::{LocalPort, LocalPortAllocator};
 
@@ -651,7 +651,7 @@ where
     }
 
     /// Get the local address and port a socket is bound to.
-    pub fn get_local_addr(&self, fd: &SocketFd<Platform>) -> SocketAddr {
+    pub fn get_local_addr(&self, fd: &SocketFd<Platform>) -> Result<SocketAddr, LocalAddrError> {
         let descriptor_table = self.litebox.descriptor_table();
         let mut table_entry = descriptor_table.get_entry_mut(fd);
         let socket_handle = &mut table_entry.entry;
@@ -663,12 +663,12 @@ where
                 let local_endpoint = socket.endpoint();
                 match local_endpoint.addr {
                     Some(smoltcp::wire::IpAddress::Ipv4(ipv4)) => {
-                        SocketAddr::V4(SocketAddrV4::new(ipv4, local_endpoint.port))
+                        Ok(SocketAddr::V4(SocketAddrV4::new(ipv4, local_endpoint.port)))
                     }
-                    None => SocketAddr::V4(SocketAddrV4::new(
+                    None => Ok(SocketAddr::V4(SocketAddrV4::new(
                         Ipv4Addr::UNSPECIFIED,
                         local_endpoint.port,
-                    )),
+                    ))),
                 }
             }
             Protocol::Icmp => unimplemented!(),

--- a/litebox_common_linux/src/errno/mod.rs
+++ b/litebox_common_linux/src/errno/mod.rs
@@ -359,6 +359,15 @@ impl From<litebox::net::errors::ConnectError> for Errno {
     }
 }
 
+impl From<litebox::net::errors::LocalAddrError> for Errno {
+    fn from(value: litebox::net::errors::LocalAddrError) -> Self {
+        match value {
+            litebox::net::errors::LocalAddrError::InvalidFd => Errno::EBADF,
+            _ => unimplemented!(),
+        }
+    }
+}
+
 impl From<litebox::net::errors::ListenError> for Errno {
     fn from(value: litebox::net::errors::ListenError) -> Self {
         match value {

--- a/litebox_shim_linux/src/syscalls/net.rs
+++ b/litebox_shim_linux/src/syscalls/net.rs
@@ -698,7 +698,7 @@ pub(crate) fn sys_getsockname(sockfd: i32) -> Result<SocketAddr, Errno> {
         Descriptor::Socket(socket) => {
             let litebox_net = litebox_net();
             let net = litebox_net.lock();
-            Ok(net.get_local_addr(socket.fd.as_ref().unwrap()))
+            Ok(net.get_local_addr(socket.fd.as_ref().unwrap())?)
         }
         _ => Err(Errno::ENOTSOCK),
     }


### PR DESCRIPTION
#372 introduced `get_local_addr` but it is one of the only infallible functions in the net interface; this changes it to fallible.

Keeping this change separate so that #416's changes stay self-contained (otherwise this would need to be merged into that).