### PR TITLE
Support MSG_TRUNC for tcp and udp

### DIFF
--- a/litebox_common_linux/src/lib.rs
+++ b/litebox_common_linux/src/lib.rs
@@ -6,7 +6,6 @@
 use int_enum::IntEnum;
 use litebox::{
     fs::OFlags,
-    net::{ReceiveFlags, SendFlags},
     platform::{RawConstPointer, RawMutPointer},
     utils::{ReinterpretSignedExt as _, TruncateExt},
 };
@@ -1769,6 +1768,52 @@ pub enum IntervalTimer {
     Prof = 2,
 }
 
+bitflags::bitflags! {
+    /// Flags for the `receive` function.
+    #[derive(Clone, Copy, Debug)]
+    pub struct ReceiveFlags: u32 {
+        /// `MSG_CMSG_CLOEXEC`: close-on-exec for the associated file descriptor
+        const CMSG_CLOEXEC = 0x40000000;
+        /// `MSG_DONTWAIT`: non-blocking operation
+        const DONTWAIT = 0x40;
+        /// `MSG_ERRQUEUE`: destination for error messages
+        const ERRQUEUE = 0x2000;
+        /// `MSG_OOB`: requests receipt of out-of-band data
+        const OOB = 0x1;
+        /// `MSG_PEEK`: requests to peek at incoming messages
+        const PEEK = 0x2;
+        /// `MSG_TRUNC`: truncate the message
+        const TRUNC = 0x20;
+        /// `MSG_WAITALL`: wait for the full amount of data
+        const WAITALL = 0x100;
+        /// <https://docs.rs/bitflags/*/bitflags/#externally-defined-flags>
+        const _ = !0;
+    }
+}
+
+bitflags::bitflags! {
+    /// Flags for the `send` function.
+    #[derive(Clone, Copy, Debug)]
+    pub struct SendFlags: u32 {
+        /// `MSG_CONFIRM`: requests confirmation of the message delivery.
+        const CONFIRM = 0x800;
+        /// `MSG_DONTROUTE`: send the message directly to the interface, bypassing routing.
+        const DONTROUTE = 0x4;
+        /// `MSG_DONTWAIT`: non-blocking operation, do not wait for buffer space to become available.
+        const DONTWAIT = 0x40;
+        /// `MSG_EOR`: indicates the end of a record for message-oriented sockets.
+        const EOR = 0x80;
+        /// `MSG_MORE`: indicates that more data will follow.
+        const MORE = 0x8000;
+        /// `MSG_NOSIGNAL`: prevents the sending of SIGPIPE signals when writing to a socket that is closed.
+        const NOSIGNAL = 0x4000;
+        /// `MSG_OOB`: sends out-of-band data.
+        const OOB = 0x1;
+        /// <https://docs.rs/bitflags/*/bitflags/#externally-defined-flags>
+        const _ = !0;
+    }
+}
+
 /// Request to syscall handler
 #[non_exhaustive]
 #[derive(Debug)]
@@ -3008,8 +3053,8 @@ reinterpret_truncated_from_usize_for! {
         litebox::fs::OFlags,
         AtFlags,
         SockFlags,
-        litebox::net::SendFlags,
-        litebox::net::ReceiveFlags,
+        SendFlags,
+        ReceiveFlags,
         EpollCreateFlags,
         EfdFlags,
         RngFlags,

--- a/litebox_shim_linux/src/syscalls/file.rs
+++ b/litebox_shim_linux/src/syscalls/file.rs
@@ -179,7 +179,7 @@ pub fn sys_read(fd: i32, buf: &mut [u8], offset: Option<usize>) -> Result<usize,
         Descriptor::Socket(socket) => {
             let socket = socket.clone();
             drop(file_table);
-            socket.receive(buf, litebox::net::ReceiveFlags::empty(), None)
+            socket.receive(buf, litebox_common_linux::ReceiveFlags::empty(), None)
         }
         Descriptor::PipeReader { consumer, .. } => {
             let consumer = consumer.clone();
@@ -220,7 +220,7 @@ pub fn sys_write(fd: i32, buf: &[u8], offset: Option<usize>) -> Result<usize, Er
         Descriptor::Socket(socket) => {
             let socket = socket.clone();
             drop(file_table);
-            socket.sendto(buf, litebox::net::SendFlags::empty(), None)
+            socket.sendto(buf, litebox_common_linux::SendFlags::empty(), None)
         }
         Descriptor::PipeReader { .. } | Descriptor::Epoll { .. } => Err(Errno::EINVAL),
         Descriptor::PipeWriter { producer, .. } => {
@@ -472,7 +472,7 @@ pub fn sys_writev(
             let socket = socket.clone();
             drop(locked_file_descriptors);
             write_to_iovec(iovs, |buf: &[u8]| {
-                socket.sendto(buf, litebox::net::SendFlags::empty(), None)
+                socket.sendto(buf, litebox_common_linux::SendFlags::empty(), None)
             })
         }
         Descriptor::PipeReader { .. } | Descriptor::Epoll { .. } => Err(Errno::EINVAL),


### PR DESCRIPTION
This PR adds support for `MSG_TRUNC`. `MSG_TRUNC` behaves differently for TCP vs datagram (UDP) sockets.

[TCP](https://www.man7.org/linux/man-pages/man7/tcp.7.html):
    Since Linux 2.4, Linux supports the use of MSG_TRUNC in the flags
       argument of [recv(2)](https://www.man7.org/linux/man-pages/man2/recv.2.html) (and [recvmsg(2)](https://www.man7.org/linux/man-pages/man2/recvmsg.2.html)).  This flag causes the
       received bytes of data to be discarded, rather than passed back in
       a caller-supplied buffer.

[UDP](https://www.man7.org/linux/man-pages/man2/recv.2.html):
    For raw (AF_PACKET), Internet datagram (since Linux
    2.4.27/2.6.8), netlink (since Linux 2.6.22), and UNIX
    datagram as well as sequenced-packet (since Linux 3.4)
    sockets: return the real size of the packet or datagram,
    even when it was longer than the passed buffer.