### PR TITLE
Make guest_fsbase symbol globally visible

### DIFF
--- a/litebox_platform_linux_userland/src/lib.rs
+++ b/litebox_platform_linux_userland/src/lib.rs
@@ -325,6 +325,7 @@ host_bp:
     .quad 0
 guest_context_top:
     .quad 0
+.globl guest_fsbase
 guest_fsbase:
     .quad 0
     "


### PR DESCRIPTION
Tried to build a release version of `litebox_runner_linux_userland` but encountered the following error: `error: undefined symbol: guest_fsbase`. It is used by `ThreadLocalStorageProvider::clear_guest_thread_local_storage` which is used by other crates. This PR fixes it by making it global.