### PR TITLE
Handle seek for stdio

### DIFF
--- a/litebox/src/fs/devices.rs
+++ b/litebox/src/fs/devices.rs
@@ -248,7 +248,7 @@ impl<Platform: crate::sync::RawSyncPrimitivesProvider + crate::platform::StdioPr
             .ok_or(SeekError::ClosedFd)?
             .entry
         {
-            Device::Stdin | Device::Stdout | Device::Stderr => unimplemented!(),
+            Device::Stdin | Device::Stdout | Device::Stderr => Err(SeekError::NonSeekable),
             Device::Null => {
                 // Linux allows lseek on /dev/null and returns position 0 (or sets to length 0).
                 Ok(0)

--- a/litebox/src/fs/errors.rs
+++ b/litebox/src/fs/errors.rs
@@ -65,6 +65,8 @@ pub enum SeekError {
     NotAFile,
     #[error("would seek to an invalid (negative or past end) of seekable positions")]
     InvalidOffset,
+    #[error("non-seekable file")]
+    NonSeekable,
 }
 
 /// Possible errors from [`FileSystem::truncate`]

--- a/litebox_common_linux/src/errno/mod.rs
+++ b/litebox_common_linux/src/errno/mod.rs
@@ -200,8 +200,11 @@ impl From<litebox::fs::errors::WriteError> for Errno {
 impl From<litebox::fs::errors::SeekError> for Errno {
     fn from(value: litebox::fs::errors::SeekError) -> Self {
         match value {
-            litebox::fs::errors::SeekError::NotAFile => Errno::EBADF,
+            litebox::fs::errors::SeekError::NotAFile | litebox::fs::errors::SeekError::ClosedFd => {
+                Errno::EBADF
+            }
             litebox::fs::errors::SeekError::InvalidOffset => Errno::EINVAL,
+            litebox::fs::errors::SeekError::NonSeekable => Errno::ESPIPE,
             _ => unimplemented!(),
         }
     }


### PR DESCRIPTION
Return an error when calling `seek` on stdio.