### PR TITLE
Reduce `litebox_runner_linux_userland` test execution time

### DIFF
--- a/litebox_runner_linux_userland/tests/common/mod.rs
+++ b/litebox_runner_linux_userland/tests/common/mod.rs
@@ -59,7 +59,7 @@ fn find_rewriter_source_files() -> Vec<PathBuf> {
     if let Ok(cargo_manifest_dir) = std::env::var("CARGO_MANIFEST_DIR") {
         let workspace_root = std::path::Path::new(&cargo_manifest_dir).parent().unwrap();
         let rewriter_dir = workspace_root.join("litebox_syscall_rewriter");
-        let pattern = format!("{}/**/*.rs", rewriter_dir.display());
+        let pattern = format!("{}/src/**/*.rs", rewriter_dir.display());
 
         if let Ok(paths) = glob(&pattern) {
             for path in paths.flatten() {


### PR DESCRIPTION
Not massive in the grand scheme of things, but we were wasting time in each test on unnecessary builds (the builds exist at this point in the test already, so we don't need to re-trigger them, which simply wastes time checking the builds).  This PR speeds that up.

| Test Name                                         | Before (s) | After (s) |
|---------------------------------------------------|------------:|-----------:|
| test_static_exec_with_rewriter                    | 1.523       | 0.360      |
| test_runner_with_ls                               | 1.932       | 0.783      |
| test_dynamic_lib_with_rewriter                    | 2.258       | 0.908      |
| test_node_with_rewriter                           | 7.389       | 6.935      |