### PR TITLE
platform_lvbs: Change from vmcall to jump to hypercall page

### DIFF
--- a/dev_tests/src/ratchet.rs
+++ b/dev_tests/src/ratchet.rs
@@ -29,7 +29,7 @@ fn ratchet_globals() -> Result<()> {
             ("litebox/", 5),
             ("litebox_platform_linux_kernel/", 4),
             ("litebox_platform_linux_userland/", 5),
-            ("litebox_platform_lvbs/", 17),
+            ("litebox_platform_lvbs/", 18),
             ("litebox_platform_multiplex/", 1),
             ("litebox_platform_windows_userland/", 7),
             ("litebox_runner_linux_userland/", 1),

--- a/litebox_platform_lvbs/src/mshv/hvcall_vp.rs
+++ b/litebox_platform_lvbs/src/mshv/hvcall_vp.rs
@@ -98,7 +98,6 @@ fn hvcall_get_vp_registers_internal(
 
 /// Hyper-V Hypercall to get current VTL (i.e., VTL1)'s registers. It can access Hyper-V registers
 /// like `HV_REGISTER_VSM_PARTITION_CONFIG`.
-#[expect(dead_code)]
 #[inline]
 pub fn hvcall_get_vp_registers(reg_name: u32) -> Result<u64, HypervCallError> {
     hvcall_get_vp_registers_internal(reg_name, HvInputVtl::current())

--- a/litebox_platform_lvbs/src/mshv/mod.rs
+++ b/litebox_platform_lvbs/src/mshv/mod.rs
@@ -557,6 +557,21 @@ impl HvRegisterVsmPartitionConfig {
         Self::from_bytes(value.to_le_bytes())
     }
 }
+#[bitfield]
+#[derive(Clone, Copy, Default)]
+#[repr(C)]
+pub struct HvRegisterVsmCodePageOffsets {
+    pub vtl_call_offset: B12,
+    pub vtl_return_offset: B12,
+    #[skip]
+    __: B40,
+}
+
+impl HvRegisterVsmCodePageOffsets {
+    pub fn from_u64(value: u64) -> Self {
+        Self::from_bytes(value.to_le_bytes())
+    }
+}
 
 bitflags::bitflags! {
     #[derive(Debug, PartialEq)]

--- a/litebox_platform_lvbs/src/mshv/vsm.rs
+++ b/litebox_platform_lvbs/src/mshv/vsm.rs
@@ -31,6 +31,7 @@ use crate::{
             validate_kernel_module_against_elf, validate_text_patch,
             verify_kernel_module_signature, verify_kernel_pe_signature,
         },
+        vtl_switch::mshv_vsm_get_code_page_offsets,
         vtl1_mem_layout::{PAGE_SHIFT, PAGE_SIZE},
     },
     serial_println,
@@ -67,6 +68,11 @@ pub(crate) fn init() {
     assert!(
         !(get_core_id() == 0 && mshv_vsm_configure_partition().is_err()),
         "Failed to configure VSM partition"
+    );
+
+    assert!(
+        !(get_core_id() == 0 && mshv_vsm_get_code_page_offsets().is_err()),
+        "Failed to retrieve Hypercall page offsets to execute VTL returns"
     );
 
     assert!(


### PR DESCRIPTION
Use hypercall page and return offset for return back to VTL0 from VTL1 so that the code works on both Amd and Intel platforms without the need to having platform specific return code.