### PR TITLE
Make syscall_callback global on Windows platform

### DIFF
--- a/litebox_platform_windows_userland/src/lib.rs
+++ b/litebox_platform_windows_userland/src/lib.rs
@@ -462,6 +462,7 @@ unsafe extern "C-unwind" fn run_thread_inner(
     // At entry, the register context is the guest context with the
     // return address in rcx. r11 is an available scratch register (it would
     // contain rflags if the syscall instruction had actually been issued).
+    .globl  syscall_callback
 syscall_callback:
     // Get the TLS state from the TLS slot and clear the in-guest flag.
     mov     r11d, DWORD PTR [rip + {TLS_INDEX}]


### PR DESCRIPTION
This PR fixes the release build of `litebox_runner_linux_on_windows_userland`.