### PR TITLE
Running python3 on Windows

### DIFF
--- a/litebox_platform_windows_userland/src/lib.rs
+++ b/litebox_platform_windows_userland/src/lib.rs
@@ -462,6 +462,7 @@ unsafe extern "C-unwind" fn run_thread_inner(
     // At entry, the register context is the guest context with the
     // return address in rcx. r11 is an available scratch register (it would
     // contain rflags if the syscall instruction had actually been issued).
+    .globl  syscall_callback
 syscall_callback:
     // Get the TLS state from the TLS slot and clear the in-guest flag.
     mov     r11d, DWORD PTR [rip + {TLS_INDEX}]

--- a/litebox_platform_windows_userland/src/lib.rs
+++ b/litebox_platform_windows_userland/src/lib.rs
@@ -929,6 +929,15 @@ impl litebox::platform::PunchthroughToken for PunchthroughToken {
                 eprintln!("WARNING: ignoring RtSigprocmask punchthrough");
                 Ok(0)
             }
+            PunchthroughSyscall::RtSigaction {
+                signum,
+                act: _,
+                oldact: _,
+            } => {
+                // Ignored for now.
+                eprintln!("WARNING: ignoring RtSigaction punchthrough for signum={signum:?}");
+                Ok(0)
+            }
             p => {
                 unimplemented!("unimplemented PunchthroughToken for WindowsUserland: {p:?}");
             }


### PR DESCRIPTION
This PR adds a dummy implementation for `rt_sigaction` so that we could run `python3` on Windows.

1. Run the test [test_runner_with_python](https://github.com/microsoft/litebox/blob/be159cf945e741c966b4a13353e5f80ba78d10e2/litebox_runner_linux_userland/tests/run.rs#L358) on Linux to create the rootfs tar file and rewritten binary of `python3`.
2. Copy the files (`rootfs_python3_rewriter.tar` and `python3.hooked`) to Windows
3. `cargo run -p litebox_runner_linux_on_windows_userland --release -- --unstable --env LD_LIBRARY_PATH=/lib64:/lib32:/lib --env HOME=/ --initial-files rootfs_python3_rewriter.tar --env PYTHONHOME=/usr --env PYTHONPATH=:/usr/lib/python310.zip:/usr/lib/python3.10:/usr/lib/python3.10/lib-dynload:/usr/local/lib/python3.10/dist-packages:/usr/lib/python3/dist-packages --env PYTHONDONTWRITEBYTECODE=1 --env LD_AUDIT=/lib/litebox_rtld_audit.so .\python3.hooked`