### PR TITLE
Support CLOCK_MONOTONIC_COARSE

### DIFF
--- a/litebox_common_linux/src/lib.rs
+++ b/litebox_common_linux/src/lib.rs
@@ -1617,6 +1617,7 @@ pub struct LinuxDirent64 {
 pub enum ClockId {
     RealTime = 0,
     Monotonic = 1,
+    MonotonicCoarse = 6,
 }
 
 bitflags::bitflags! {


### PR DESCRIPTION
`CLOCK_MONOTONIC_COARSE` is designed to be faster than `CLOCK_MONOTONIC` but with lower resolution. For simplicity, we reuse the same monotonic time as `CLOCK_MONOTONIC`.