### PR TITLE
Disable python test

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -8,6 +8,8 @@ status-level = "all"
 failure-output = "immediate-final"
 # Any tests that take longer than 10 minutes should be killed as a failure
 slow-timeout = { period = "60s", terminate-after = 10 }
+# Skip the Python test on CI before we figure out why it failed.
+default-filter = 'not test(test_runner_with_python)'
 
 [test-groups]
 # ensure only one test accessing tun at a time


### PR DESCRIPTION
For unknown reason, the python test suddenly became flaky (see https://github.com/microsoft/litebox/actions/runs/19259493948/job/55060800289). It looks like the test was cancelled for some unknown reason (resource limit maybe?). Before we figure out the root case, disable it on CI.