### PR TITLE
Remove tid from `TaskParams`

### DIFF
--- a/litebox_common_linux/src/lib.rs
+++ b/litebox_common_linux/src/lib.rs
@@ -1223,8 +1223,6 @@ pub struct TaskParams {
     pub pid: i32,
     /// Parent Process ID
     pub ppid: i32,
-    /// Thread ID
-    pub tid: i32,
     /// The initial uid.
     pub uid: u32,
     /// The initial effective uid.

--- a/litebox_platform_linux_kernel/src/host/snp/snp_impl.rs
+++ b/litebox_platform_linux_kernel/src/host/snp/snp_impl.rs
@@ -97,7 +97,6 @@ impl SnpLinuxKernel {
     ) -> litebox_common_linux::TaskParams {
         litebox_common_linux::TaskParams {
             pid: boot_params.pid,
-            tid: boot_params.pid,
             ppid: boot_params.ppid,
             uid: boot_params.uid,
             gid: boot_params.gid,

--- a/litebox_platform_linux_userland/src/lib.rs
+++ b/litebox_platform_linux_userland/src/lib.rs
@@ -276,7 +276,6 @@ impl LinuxUserland {
             .unwrap();
         litebox_common_linux::TaskParams {
             pid: tid,
-            tid,
             ppid,
             uid: unsafe { syscalls::raw::syscall0(syscalls::Sysno::getuid) }
                 .try_into()

--- a/litebox_platform_lvbs/src/host/lvbs_impl.rs
+++ b/litebox_platform_lvbs/src/host/lvbs_impl.rs
@@ -58,7 +58,6 @@ impl LvbsLinuxKernel {
     pub fn init_task(&self) -> litebox_common_linux::TaskParams {
         litebox_common_linux::TaskParams {
             pid: 1,
-            tid: 1,
             ppid: 1,
             uid: 1000,
             gid: 1000,

--- a/litebox_platform_windows_userland/src/lib.rs
+++ b/litebox_platform_windows_userland/src/lib.rs
@@ -315,7 +315,6 @@ impl WindowsUserland {
         // This is a placeholder for future implementation to use passthrough.
         litebox_common_linux::TaskParams {
             pid: 1000,
-            tid: 1000,
             // TODO: placeholder for actual PPID
             ppid: 0,
             uid: 1000,

--- a/litebox_shim_linux/src/lib.rs
+++ b/litebox_shim_linux/src/lib.rs
@@ -236,7 +236,6 @@ impl LinuxShim {
         let litebox_common_linux::TaskParams {
             pid,
             ppid,
-            tid,
             uid,
             euid,
             gid,
@@ -259,7 +258,7 @@ impl LinuxShim {
                 wait_state: wait::WaitState::new(litebox_platform_multiplex::platform()),
                 pid,
                 ppid,
-                tid,
+                tid: pid,
                 clear_child_tid: None.into(),
                 robust_list: None.into(),
                 credentials: syscalls::process::Credentials {


### PR DESCRIPTION
The process's initial thread's tid is the pid. Remove the tid as an input parameter.