### PR TITLE
Improve reliability of nextest install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  NEXTEST_VERSION: 0.9.114
 
 jobs:
   build_and_test:
@@ -35,8 +36,9 @@ jobs:
         run: |
           rustup toolchain install $(awk -F'"' '/channel/{print $2}' rust-toolchain.toml) --profile minimal --no-self-update --component rustfmt,clippy --target x86_64-unknown-linux-gnu
       - name: Set up Nextest
-        run: |
-          curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest@${{ env.NEXTEST_VERSION }}
       - name: Set up tun
         run: |
           sudo ./litebox_platform_linux_userland/scripts/tun-setup.sh
@@ -82,8 +84,9 @@ jobs:
         run: |
           rustup toolchain install $(awk -F'"' '/channel/{print $2}' rust-toolchain.toml) --profile minimal --no-self-update --component rustfmt,clippy --target i686-unknown-linux-gnu
       - name: Set up Nextest
-        run: |
-          curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest@${{ env.NEXTEST_VERSION }}
       - name: Set up tun
         run: |
           sudo ./litebox_platform_linux_userland/scripts/tun-setup.sh
@@ -119,8 +122,9 @@ jobs:
           rustup override set ${RUST_CHANNEL}
           rustup show
       - name: Set up Nextest
-        run: |
-          curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest@${{ env.NEXTEST_VERSION }}
       - name: Set up tun
         run: |
           sudo ./litebox_platform_linux_userland/scripts/tun-setup.sh
@@ -157,7 +161,9 @@ jobs:
         run: |
           rustup toolchain install $(awk -F'"' '/channel/{print $2}' rust-toolchain.toml) --profile minimal --no-self-update --component rustfmt,clippy --target x86_64-pc-windows-msvc
       - name: Set up Nextest
-        uses: taiki-e/install-action@nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest@${{ env.NEXTEST_VERSION }}
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --locked --verbose --all-targets --all-features -p litebox_runner_linux_on_windows_userland
       - run: cargo build --locked --verbose -p litebox_runner_linux_on_windows_userland


### PR DESCRIPTION
Consistently use a GitHub action to install nextest across Windows and Linux, and pin the version while we're at it.

This should fix the spurious failures we are seeing when downloading manually with curl.