### PR TITLE
Use poll on tun

### DIFF
--- a/litebox_platform_linux_userland/src/lib.rs
+++ b/litebox_platform_linux_userland/src/lib.rs
@@ -291,6 +291,30 @@ impl LinuxUserland {
                 .unwrap(),
         }
     }
+
+    /// Wait until there is data available on the TUN device.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the TUN device is not initialized.
+    pub fn wait_on_tun(&self, timeout: Option<Duration>) {
+        let tun_fd = self.tun_socket_fd.read().unwrap();
+        let mut pfd = libc::pollfd {
+            fd: tun_fd.as_ref().unwrap().as_raw_fd(),
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        let _ = unsafe {
+            libc::poll(
+                &raw mut pfd,
+                1,
+                timeout.map_or(-1, |t| {
+                    let ms = t.as_millis();
+                    i32::try_from(ms).unwrap_or(i32::MAX)
+                }),
+            )
+        };
+    }
 }
 
 impl litebox::platform::Provider for LinuxUserland {}

--- a/litebox_runner_linux_userland/src/lib.rs
+++ b/litebox_runner_linux_userland/src/lib.rs
@@ -5,6 +5,7 @@ use litebox_platform_multiplex::Platform;
 use memmap2::Mmap;
 use std::os::linux::fs::MetadataExt as _;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 extern crate alloc;
 
@@ -218,11 +219,9 @@ pub fn run(cli_args: CliArgs) -> Result<()> {
 
     if cli_args.tun_device_name.is_some() {
         std::thread::spawn(|| {
-            // TODO: use `poll` rather than busy-looping
-            // Also, we need to terminate this thread when the main program exits
             loop {
                 while litebox_shim_linux::perform_network_interaction().call_again_immediately() {}
-                core::hint::spin_loop();
+                litebox_platform_multiplex::platform().wait_on_tun(Some(Duration::from_millis(50)));
             }
         });
     }


### PR DESCRIPTION
Use `poll` instead of busy waiting while waiting for incoming data on tun. It may cause delay for outgoing data, but overall it helps improve the throughput when tested against `iperf3`.