### PR TITLE
Fix rewriter output in some edge cases

### DIFF
--- a/litebox_syscall_rewriter/src/lib.rs
+++ b/litebox_syscall_rewriter/src/lib.rs
@@ -221,10 +221,6 @@ pub fn hook_syscalls_in_elf(input_binary: &[u8], trampoline: Option<usize>) -> R
     builder.sections.get_mut(trampoline_section).sh_size = trampoline_vec.len() as u64;
     builder.sections.get_mut(trampoline_section).data =
         object::build::elf::SectionData::Data(trampoline_vec.into());
-    builder
-        .segments
-        .get_mut(last_segment_id)
-        .recalculate_ranges(&builder.sections);
 
     let mut out = vec![];
     builder


### PR DESCRIPTION
The rewriter calls into `object` to recomputes PT_LOAD segment sizes from the section headers before writing the new binary; in some cases, this truncates out data at the beginning of the segment that is not included in any sections. Specifically, if the trampoline section gets put in the first segment, this sometimes strips out the program headers, preventing the binary from being loaded by Linux.

Fix this by skipping the recomputation. The segment length is already extended by `object` when the trampoline section is added, so this recomputation is not necessary.