### PR TITLE
Ignore CLONE_DETACHED flag to clone

### DIFF
--- a/litebox_common_linux/src/lib.rs
+++ b/litebox_common_linux/src/lib.rs
@@ -1167,6 +1167,8 @@ bitflags::bitflags! {
         const PARENT_SETTID  = 0x00100000;
         /// Clear the TID in the child
         const CHILD_CLEARTID = 0x00200000;
+        /// Ignored.
+        const DETACHED      = 0x00400000;
         /// Set if the tracing process can't force CLONE_PTRACE on this clone
         const UNTRACED       = 0x00800000;
         /// Set the TID in the child

--- a/litebox_shim_linux/src/syscalls/process.rs
+++ b/litebox_shim_linux/src/syscalls/process.rs
@@ -418,7 +418,7 @@ impl Task {
         const MAX_SIGNAL_NUMBER: u64 = 64;
 
         let litebox_common_linux::CloneArgs {
-            flags,
+            mut flags,
             pidfd: _,
             child_tid,
             parent_tid,
@@ -430,6 +430,12 @@ impl Task {
             set_tid_size,
             cgroup,
         } = *args;
+
+        // `CLONE_DETACHED` is ignored but has been reserved for reuse with
+        // `clone3` or in combination with `CLONE_PIDFD`.
+        if !clone3 && !flags.contains(CloneFlags::PIDFD) {
+            flags.remove(CloneFlags::DETACHED);
+        }
 
         let required_clone_flags =
             CloneFlags::VM | CloneFlags::THREAD | CloneFlags::SIGHAND | CloneFlags::FILES;


### PR DESCRIPTION
`CLONE_DETACHED` is usually ignored by Linux, but musl passes it in `pthread_create` for whatever reason. Ignore it.