### PR TITLE
Use OnceRef<'static, T> instead of OnceBox<&'static T>

### DIFF
--- a/litebox_platform_lvbs/src/lib.rs
+++ b/litebox_platform_lvbs/src/lib.rs
@@ -765,14 +765,10 @@ static PLATFORM_LOW: once_cell::race::OnceRef<'static, Platform> = once_cell::ra
 /// # Panics
 ///
 /// Panics if invoked more than once
-#[expect(
-    clippy::match_wild_err_arm,
-    reason = "the platform itself is not Debug thus we cannot use `expect`"
-)]
 pub fn set_platform_low(platform: &'static Platform) {
     match PLATFORM_LOW.set(platform) {
         Ok(()) => {}
-        Err(_) => panic!("set_platform should only be called once per crate"),
+        Err(()) => panic!("set_platform should only be called once per crate"),
     }
 }
 

--- a/litebox_platform_multiplex/src/lib.rs
+++ b/litebox_platform_multiplex/src/lib.rs
@@ -49,14 +49,10 @@ static PLATFORM: once_cell::race::OnceRef<'static, Platform> = once_cell::race::
 /// # Panics
 ///
 /// Panics if invoked more than once
-#[expect(
-    clippy::match_wild_err_arm,
-    reason = "the platform itself is not Debug thus we cannot use `expect`"
-)]
 pub fn set_platform(platform: &'static Platform) {
     match PLATFORM.set(platform) {
         Ok(()) => {}
-        Err(_) => panic!("set_platform should only be called once per crate"),
+        Err(()) => panic!("set_platform should only be called once per crate"),
     }
 }
 


### PR DESCRIPTION
This saves an allocation and a dereference.