### PR TITLE
Add tracing support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -796,6 +796,7 @@ dependencies = [
  "spin 0.9.8",
  "tar-no-std",
  "thiserror",
+ "tracing",
  "windows-sys 0.60.2",
 ]
 
@@ -946,6 +947,8 @@ dependencies = [
  "litebox_syscall_rewriter",
  "memmap2",
  "sha2",
+ "tracing",
+ "tracing-subscriber",
  "walkdir",
 ]
 

--- a/litebox/Cargo.toml
+++ b/litebox/Cargo.toml
@@ -18,6 +18,7 @@ ringbuf = { version = "0.4.8", default-features = false, features = ["alloc"] }
 buddy_system_allocator = { version = "0.11.0", default-features = false, features = ["use_spin"] }
 # Depend on (currently unreleased) slabmalloc `main`, which contains some fixes on top of `0.11.0`
 slabmalloc = { git = "https://github.com/gz/rust-slabmalloc.git", rev = "19480b2e82704210abafe575fb9699184c1be110" }
+tracing = { version = "0.1.43", default-features = false }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.60.2", features = [

--- a/litebox/src/litebox.rs
+++ b/litebox/src/litebox.rs
@@ -61,10 +61,14 @@ impl<Platform: RawSyncPrimitivesProvider> LiteBox<Platform> {
         #[cfg(feature = "lock_tracing")]
         crate::sync::lock_tracing::LockTracker::init(platform);
 
+        let descriptors = RwLock::new(Descriptors::new_from_litebox_creation());
+
+        tracing::debug!("LiteBox instance initialized");
+
         Self {
             x: Arc::new(LiteBoxX {
                 platform,
-                descriptors: RwLock::new(Descriptors::new_from_litebox_creation()),
+                descriptors,
             }),
         }
     }

--- a/litebox_runner_linux_userland/Cargo.toml
+++ b/litebox_runner_linux_userland/Cargo.toml
@@ -14,6 +14,8 @@ litebox_platform_multiplex = { version = "0.1.0", path = "../litebox_platform_mu
 litebox_shim_linux = { version = "0.1.0", path = "../litebox_shim_linux" }
 litebox_syscall_rewriter = { version = "0.1.0", path = "../litebox_syscall_rewriter" }
 memmap2 = "0.9.8"
+tracing = "0.1.43"
+tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
 
 [dev-dependencies]
 sha2 = "0.10"

--- a/litebox_runner_linux_userland/src/lib.rs
+++ b/litebox_runner_linux_userland/src/lib.rs
@@ -10,6 +10,14 @@ use std::time::Duration;
 extern crate alloc;
 
 /// Run Linux programs with LiteBox on unmodified Linux
+///
+/// # Tracing
+///
+/// LiteBox supports detailed tracing output controlled by the `LITEBOX_LOG` environment variable.
+///
+/// Examples:
+/// - `LITEBOX_LOG=debug` - Show debug and higher level logs
+/// - `LITEBOX_LOG=litebox=debug,litebox::fs=trace` - Multiple filters at different levels
 #[derive(Parser, Debug)]
 pub struct CliArgs {
     /// The program and arguments passed to it (e.g., `python3 --version`)
@@ -82,6 +90,17 @@ static REQUIRE_RTLD_AUDIT: core::sync::atomic::AtomicBool =
 /// panic. If it does actually panic, then ping the authors of LiteBox, and likely a better error
 /// message could be thrown instead.
 pub fn run(cli_args: CliArgs) -> Result<()> {
+    // Initialize tracing subscriber with LITEBOX_LOG environment variable
+    tracing_subscriber::fmt()
+        .with_timer(tracing_subscriber::fmt::time::uptime())
+        .with_level(true)
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_env_var("LITEBOX_LOG")
+                .from_env_lossy(),
+        )
+        .init();
+
     if !cli_args.insert_files.is_empty() {
         unimplemented!(
             "this should (hopefully soon) have a nicer interface to support loading in files"


### PR DESCRIPTION
Resolves #171.

This PR enables `tracing` for LiteBox, and set up a subscriber for the Linux userland.  Specifically, this adds `LITEBOX_LOG` environment variable to the `litebox_runner_linux_userland`, which can be used like the following:
- `LITEBOX_LOG=debug`: Show debug and higher-level logs for all crates and modules
- `LITEBOX_LOG=litebox::fs=debug`: Specifically `litebox::fs` code at debug and higher-level
- `LITEBOX_LOG=litebox=debug,litebox::fs=trace`: Multiple filters at different levels

This was previously not quite possible because we could not have real Rust thread locals (which `tracing` uses internally), but now that that works, we can enable `tracing`.

Currently, I have not added much in the form of tracing logs/messages much in the code and just added it for `LiteBox` object initialization.  Future PRs will enable it in more places so that we can more easily see a whole bunch more of what is happening easily.

Here's a test output:
```console
$ LITEBOX_LOG=litebox=trace cargo run --bin litebox_runner_linux_userland -- --unstable --interception-backend rewriter target/dev_bench/hello_static_rewritten
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.13s
warning: the following packages contain code that will be rejected by a future version of Rust: num-bigint-dig v0.8.4
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
     Running `target/debug/litebox_runner_linux_userland --unstable --interception-backend rewriter target/dev_bench/hello_static_rewritten`
   0.001065242s DEBUG litebox::litebox: LiteBox instance initialized
argv[0] = target/dev_bench/hello_static_rewritten
envp[0] = LD_AUDIT=/lib/litebox_rtld_audit.so
Elapsed time: 0.088816 seconds
```