### PR TITLE
Improve network throughput

### DIFF
--- a/litebox/src/net/tests.rs
+++ b/litebox/src/net/tests.rs
@@ -36,9 +36,13 @@ fn bidi_tcp_comms(mut network: Network<MockPlatform>, comms: fn(&mut Network<Moc
     comms(&mut network);
 
     // Accept the connection on the listening socket
-    let server_fd = network
-        .accept(&listener_fd, None)
-        .expect("Failed to accept connection");
+    let server_fd = loop {
+        match network.accept(&listener_fd, None) {
+            Ok(fd) => break fd,
+            Err(AcceptError::NoConnectionsReady) => {}
+            Err(other) => panic!("Unexpected accept error: {other:?}"),
+        }
+    };
 
     // Send data from client to server
     let client_to_server_data = b"Hello from client!";
@@ -92,10 +96,7 @@ fn test_bidirectional_tcp_communication_manual() {
     let mut network = Network::new(&litebox);
     network.set_platform_interaction(PlatformInteraction::Manual);
     bidi_tcp_comms(network, |nw| {
-        while nw
-            .perform_platform_interaction(crate::net::PollDirection::Both)
-            .call_again_immediately()
-        {}
+        while nw.perform_platform_interaction().call_again_immediately() {}
     });
 }
 

--- a/litebox_shim_linux/src/syscalls/net.rs
+++ b/litebox_shim_linux/src/syscalls/net.rs
@@ -1769,7 +1769,7 @@ mod tests {
                 while global
                     .net
                     .lock()
-                    .perform_platform_interaction(litebox::net::PollDirection::Both)
+                    .perform_platform_interaction()
                     .call_again_immediately()
                 {}
                 core::hint::spin_loop();


### PR DESCRIPTION
1. Instead of using a fixed timeout value (50ms), call `poll_at` from smoltcp which would determine when the next network operation should occur.
2. Instead of only acquiring lock once at the beginning of `perform_platform_interaction`, now each network operation would acquire and release the lock so that concurrent syscalls (e.g., read) won't get blocked for too long.
3. `perform_platform_interaction` now processes multiple ingress packets before processing egress packets to avoid unnecessary egress processing (e.g. fewer ACK packets).

With the above change, the throughput can be improved from 22.2 Mbits/sec to 141 Mbits/sec. It's still 50x slower than native. ~~One big factor is the receive window (i.e., socket buffer size). smoltcp does not support dynamically increasing the socket buffer size and the default value we set is 64KB. When testing on Linux, the window size can be as large as 6MB.~~

 4. In addition to the network background worker that processes network in a loop, before and after each network related syscalls like `send` and `receive`, we perform some network operations in automatic mode (it's disabled in manual mode when we have a separate network worker). I found that if we do both, it helps increase the throughput to 272 Mbits/sec. My hypothesis is that those are the points where we have packets to process immediately.
 5. Double the socket buffer size could further increase the throughput to 360 Mbits/sec, but I'm not sure if it is the right move.