### PR TITLE
Support getpeername for UNIX socket

### DIFF
--- a/litebox_shim_linux/src/syscalls/net.rs
+++ b/litebox_shim_linux/src/syscalls/net.rs
@@ -1601,6 +1601,10 @@ impl Task {
                     .map(SocketAddress::Inet)
                     .map_err(Errno::from)
             }),
+            Descriptor::Unix { file, .. } => file
+                .get_peer_addr()
+                .ok_or(Errno::ENOTCONN)
+                .map(SocketAddress::Unix),
             _ => Err(Errno::ENOTSOCK),
         }
     }
@@ -2985,5 +2989,156 @@ mod unix_tests {
     fn test_unix_socket_recv_timeout() {
         unix_socket_recv_timeout(SockType::Stream);
         unix_socket_recv_timeout(SockType::Datagram);
+    }
+
+    #[test]
+    fn test_unix_stream_addr() {
+        let task = init_platform(None);
+        let server_path = "/unix_stream_sockname.sock";
+        let server_fd = create_unix_server_socket(&task, server_path, SockFlags::empty()).unwrap();
+
+        // Server socket should have its bound address
+        let server_addr = task.do_getsockname(server_fd).unwrap();
+        assert_eq!(
+            server_addr,
+            SocketAddress::Unix(UnixSocketAddr::Path(server_path.to_string()))
+        );
+
+        // Create client and connect
+        let client_fd = create_unix_socket(&task, SockType::Stream, SockFlags::empty());
+
+        // Before connect, client should have unnamed address
+        let client_addr = task.do_getsockname(client_fd).unwrap();
+        assert!(matches!(
+            client_addr,
+            SocketAddress::Unix(UnixSocketAddr::Unnamed)
+        ));
+
+        // Connect client to server
+        task.do_connect(
+            client_fd,
+            SocketAddress::Unix(UnixSocketAddr::Path(server_path.to_string())),
+        )
+        .unwrap();
+
+        // After connect, client's getsockname should still be unnamed
+        let client_local_addr = task.do_getsockname(client_fd).unwrap();
+        assert!(matches!(
+            client_local_addr,
+            SocketAddress::Unix(UnixSocketAddr::Unnamed)
+        ));
+
+        // Client's getpeername should return server's address
+        let client_peer_addr = task.do_getpeername(client_fd).unwrap();
+        assert_eq!(
+            client_peer_addr,
+            SocketAddress::Unix(UnixSocketAddr::Path(server_path.to_string()))
+        );
+
+        // Accept connection on server
+        let server_conn = task.do_accept(server_fd, None, SockFlags::empty()).unwrap();
+
+        // Server connection's local address should be the server's bound address
+        let server_conn_local = task.do_getsockname(server_conn).unwrap();
+        assert_eq!(
+            server_conn_local,
+            SocketAddress::Unix(UnixSocketAddr::Path(server_path.to_string()))
+        );
+
+        // Server connection's peer address should be unnamed (client didn't bind)
+        let server_conn_peer = task.do_getpeername(server_conn).unwrap();
+        assert!(matches!(
+            server_conn_peer,
+            SocketAddress::Unix(UnixSocketAddr::Unnamed)
+        ));
+
+        close_socket(&task, client_fd);
+        close_socket(&task, server_conn);
+        close_socket(&task, server_fd);
+        task.sys_unlinkat(-1, server_path, AtFlags::empty())
+            .unwrap();
+    }
+
+    #[test]
+    fn test_unix_datagram_addr() {
+        let task = init_platform(None);
+        let server_path = "/unix_datagram_sockname_server.sock";
+        let client_path = "/unix_datagram_sockname_client.sock";
+
+        let server_fd = create_unix_socket(&task, SockType::Datagram, SockFlags::empty());
+        let client_fd = create_unix_socket(&task, SockType::Datagram, SockFlags::empty());
+
+        // Before bind, both should have unnamed addresses
+        let server_addr = task.do_getsockname(server_fd).unwrap();
+        assert!(matches!(
+            server_addr,
+            SocketAddress::Unix(UnixSocketAddr::Unnamed)
+        ));
+
+        let client_addr = task.do_getsockname(client_fd).unwrap();
+        assert!(matches!(
+            client_addr,
+            SocketAddress::Unix(UnixSocketAddr::Unnamed)
+        ));
+
+        // Bind server
+        task.do_bind(
+            server_fd,
+            SocketAddress::Unix(UnixSocketAddr::Path(server_path.to_string())),
+        )
+        .unwrap();
+
+        // After bind, server should have its bound address
+        let server_local = task.do_getsockname(server_fd).unwrap();
+        assert_eq!(
+            server_local,
+            SocketAddress::Unix(UnixSocketAddr::Path(server_path.to_string()))
+        );
+
+        // Bind client
+        task.do_bind(
+            client_fd,
+            SocketAddress::Unix(UnixSocketAddr::Path(client_path.to_string())),
+        )
+        .unwrap();
+
+        // After bind, client should have its bound address
+        let client_local = task.do_getsockname(client_fd).unwrap();
+        assert_eq!(
+            client_local,
+            SocketAddress::Unix(UnixSocketAddr::Path(client_path.to_string()))
+        );
+
+        // Connect client to server
+        task.do_connect(
+            client_fd,
+            SocketAddress::Unix(UnixSocketAddr::Path(server_path.to_string())),
+        )
+        .unwrap();
+
+        // After connect, getsockname should still return client's bound address
+        let client_local_after_connect = task.do_getsockname(client_fd).unwrap();
+        assert_eq!(
+            client_local_after_connect,
+            SocketAddress::Unix(UnixSocketAddr::Path(client_path.to_string()))
+        );
+
+        // getpeername should return server's address
+        let client_peer = task.do_getpeername(client_fd).unwrap();
+        assert_eq!(
+            client_peer,
+            SocketAddress::Unix(UnixSocketAddr::Path(server_path.to_string()))
+        );
+
+        // Server hasn't connected, so getpeername should fail with ENOTCONN
+        let server_peer_result = task.do_getpeername(server_fd);
+        assert_eq!(server_peer_result.unwrap_err(), Errno::ENOTCONN);
+
+        close_socket(&task, server_fd);
+        close_socket(&task, client_fd);
+        task.sys_unlinkat(-1, server_path, AtFlags::empty())
+            .unwrap();
+        task.sys_unlinkat(-1, client_path, AtFlags::empty())
+            .unwrap();
     }
 }

--- a/litebox_shim_linux/src/syscalls/unix.rs
+++ b/litebox_shim_linux/src/syscalls/unix.rs
@@ -769,12 +769,18 @@ impl UnixStream {
 
     fn get_local_addr(&self) -> UnixSocketAddr {
         self.with_state_ref(|state| match state {
-            UnixStreamState::Init(init) => match &init.addr {
-                Some(addr) => UnixSocketAddr::from(addr),
-                None => UnixSocketAddr::Unnamed,
-            },
+            UnixStreamState::Init(init) => init
+                .addr
+                .as_ref()
+                .map_or(UnixSocketAddr::Unnamed, UnixSocketAddr::from),
             UnixStreamState::Listen(listen) => UnixSocketAddr::from(listen.get_local_addr()),
             UnixStreamState::Connected(connect) => connect.get_local_addr(),
+        })
+    }
+    fn get_peer_addr(&self) -> Option<UnixSocketAddr> {
+        self.with_state_ref(|state| match state {
+            UnixStreamState::Init(_) | UnixStreamState::Listen(_) => None,
+            UnixStreamState::Connected(connect) => Some(connect.get_peer_addr()),
         })
     }
 
@@ -902,7 +908,7 @@ struct UnixDatagramInner {
     recv_channel: Option<ReadEnd<DatagramMessage>>,
     /// The write end of the connected peer socket for sending messages.
     /// Set when the socket is connected via `connect` or `new_pair`.
-    connected_send_channel: Option<WriteEnd<DatagramMessage>>,
+    connected_send_channel: Option<(WriteEnd<DatagramMessage>, UnixSocketAddr)>,
     pollee: Arc<Pollee<crate::Platform>>,
 }
 /// Represents a Unix datagram socket.
@@ -979,7 +985,7 @@ impl UnixDatagram {
                 inner: RwLock::new(UnixDatagramInner {
                     addr: None,
                     recv_channel: Some(recv_channel),
-                    connected_send_channel: Some(send_channel_peer),
+                    connected_send_channel: Some((send_channel_peer, UnixSocketAddr::Unnamed)),
                     pollee: pollee1,
                 }),
             },
@@ -987,7 +993,7 @@ impl UnixDatagram {
                 inner: RwLock::new(UnixDatagramInner {
                     addr: None,
                     recv_channel: Some(recv_channel_peer),
-                    connected_send_channel: Some(send_channel),
+                    connected_send_channel: Some((send_channel, UnixSocketAddr::Unnamed)),
                     pollee: pollee2,
                 }),
             },
@@ -1024,7 +1030,7 @@ impl UnixDatagram {
     ///
     /// Subsequent sends without an address will use this peer.
     fn connect(&self, task: &Task, addr: UnixSocketAddr) -> Result<(), Errno> {
-        self.inner.write().connected_send_channel = Some(self.lookup(task, addr)?);
+        self.inner.write().connected_send_channel = Some((self.lookup(task, addr.clone())?, addr));
         Ok(())
     }
 
@@ -1070,7 +1076,8 @@ impl UnixDatagram {
         let source = self.get_local_addr();
         let send_channel = if let Some(addr) = addr {
             self.lookup(task, addr)?
-        } else if let Some(connected_send_channel) = &self.inner.read().connected_send_channel {
+        } else if let Some((connected_send_channel, _)) = &self.inner.read().connected_send_channel
+        {
             connected_send_channel.clone()
         } else {
             return Err(Errno::ENOTCONN);
@@ -1088,11 +1095,20 @@ impl UnixDatagram {
     }
 
     fn get_local_addr(&self) -> UnixSocketAddr {
-        if let Some((addr, _)) = &self.inner.read().addr {
-            UnixSocketAddr::from(addr)
-        } else {
-            UnixSocketAddr::Unnamed
-        }
+        self.inner
+            .read()
+            .addr
+            .as_ref()
+            .map_or(UnixSocketAddr::Unnamed, |(addr, _)| {
+                UnixSocketAddr::from(addr)
+            })
+    }
+    fn get_peer_addr(&self) -> Option<UnixSocketAddr> {
+        self.inner
+            .read()
+            .connected_send_channel
+            .as_ref()
+            .map(|(_, addr)| addr.clone())
     }
 
     fn check_io_events(&self) -> Events {
@@ -1104,7 +1120,7 @@ impl UnixDatagram {
                 events |= Events::IN;
             }
         }
-        if let Some(connected_send_channel) = &self.inner.read().connected_send_channel {
+        if let Some((connected_send_channel, _)) = &self.inner.read().connected_send_channel {
             if !connected_send_channel.is_full() {
                 events |= Events::OUT;
             }
@@ -1259,6 +1275,12 @@ impl UnixSocket {
         match &self.inner {
             UnixSocketInner::Stream(stream) => stream.get_local_addr(),
             UnixSocketInner::Datagram(datagram) => datagram.get_local_addr(),
+        }
+    }
+    pub(super) fn get_peer_addr(&self) -> Option<UnixSocketAddr> {
+        match &self.inner {
+            UnixSocketInner::Stream(stream) => stream.get_peer_addr(),
+            UnixSocketInner::Datagram(datagram) => datagram.get_peer_addr(),
         }
     }
 


### PR DESCRIPTION
This PR supports syscall `getpeername` for UNIX sockets and adds some basic tests.