### PR TITLE
Support F_DUPFD/F_DUPFD_CLOEXEC

### DIFF
--- a/litebox_common_linux/src/lib.rs
+++ b/litebox_common_linux/src/lib.rs
@@ -470,6 +470,8 @@ pub enum FcntlArg<Platform: litebox::platform::RawPointerProvider> {
     SETLK(Platform::RawConstPointer<Flock>),
     /// Set a file lock and wait if blocked
     SETLKW(Platform::RawConstPointer<Flock>),
+    /// Duplicate file descriptor
+    DUPFD { cloexec: bool, min_fd: u32 },
 }
 
 #[repr(i16)]
@@ -498,6 +500,8 @@ pub struct Flock {
     pub pid: i32,
 }
 
+const F_DUPFD: i32 = 0;
+const F_DUPFD_CLOEXEC: i32 = 1030;
 const F_GETFD: i32 = 1;
 const F_SETFD: i32 = 2;
 const F_GETFL: i32 = 3;
@@ -526,6 +530,14 @@ impl<Platform: litebox::platform::RawPointerProvider> FcntlArg<Platform> {
             F_GETLK => Self::GETLK(Platform::RawMutPointer::from_usize(arg)),
             F_SETLK => Self::SETLK(Platform::RawConstPointer::from_usize(arg)),
             F_SETLKW => Self::SETLKW(Platform::RawConstPointer::from_usize(arg)),
+            F_DUPFD => Self::DUPFD {
+                cloexec: false,
+                min_fd: arg.truncate(),
+            },
+            F_DUPFD_CLOEXEC => Self::DUPFD {
+                cloexec: true,
+                min_fd: arg.truncate(),
+            },
             _ => return None,
         })
     }

--- a/litebox_shim_linux/src/syscalls/epoll.rs
+++ b/litebox_shim_linux/src/syscalls/epoll.rs
@@ -695,9 +695,11 @@ mod test {
 
         let no_fds = FilesState::new();
         let fds = FilesState::new();
-        fds.file_descriptors
-            .write()
-            .insert_at(descriptor, fd.reinterpret_as_unsigned() as usize);
+        let _ = fds.file_descriptors.write().insert_at(
+            &task,
+            descriptor,
+            fd.reinterpret_as_unsigned() as usize,
+        );
         set.add_fd(fd, Events::IN);
 
         let revents = |set: &super::PollSet| {

--- a/litebox_shim_linux/src/syscalls/file.rs
+++ b/litebox_shim_linux/src/syscalls/file.rs
@@ -805,6 +805,41 @@ impl Descriptor {
             ),
         }
     }
+    fn set_file_descriptor_flags(
+        &self,
+        global: &GlobalState,
+        files: &FilesState,
+        flags: FileDescriptorFlags,
+    ) -> Result<(), Errno> {
+        fn set_flags<S: FdEnabledSubsystem>(
+            global: &GlobalState,
+            fd: &TypedFd<S>,
+            flags: FileDescriptorFlags,
+        ) {
+            let _old = global
+                .litebox
+                .descriptor_table_mut()
+                .set_fd_metadata(fd, flags);
+        }
+
+        match self {
+            Descriptor::LiteBoxRawFd(raw_fd) => files.run_on_raw_fd(
+                *raw_fd,
+                |fd| set_flags(global, fd, flags),
+                |fd| set_flags(global, fd, flags),
+                |fd| set_flags(global, fd, flags),
+            )?,
+            Descriptor::Eventfd { close_on_exec, .. }
+            | Descriptor::Epoll { close_on_exec, .. }
+            | Descriptor::Unix { close_on_exec, .. } => {
+                close_on_exec.store(
+                    flags.contains(FileDescriptorFlags::FD_CLOEXEC),
+                    core::sync::atomic::Ordering::Relaxed,
+                );
+            }
+        }
+        Ok(())
+    }
 }
 
 impl Task {
@@ -897,43 +932,11 @@ impl Task {
                 .ok_or(Errno::EBADF)?
                 .get_file_descriptor_flags(&self.global, &files)?
                 .bits()),
-            FcntlArg::SETFD(flags) => {
-                match locked_file_descriptors.get_fd(fd).ok_or(Errno::EBADF)? {
-                    Descriptor::LiteBoxRawFd(raw_fd) => files.run_on_raw_fd(
-                        *raw_fd,
-                        |fd| {
-                            let _old = self
-                                .global
-                                .litebox
-                                .descriptor_table_mut()
-                                .set_fd_metadata(fd, flags);
-                        },
-                        |fd| {
-                            let _old = self
-                                .global
-                                .litebox
-                                .descriptor_table_mut()
-                                .set_fd_metadata(fd, flags);
-                        },
-                        |fd| {
-                            let _old = self
-                                .global
-                                .litebox
-                                .descriptor_table_mut()
-                                .set_fd_metadata(fd, flags);
-                        },
-                    )?,
-                    Descriptor::Eventfd { close_on_exec, .. }
-                    | Descriptor::Epoll { close_on_exec, .. }
-                    | Descriptor::Unix { close_on_exec, .. } => {
-                        close_on_exec.store(
-                            flags.contains(FileDescriptorFlags::FD_CLOEXEC),
-                            core::sync::atomic::Ordering::Relaxed,
-                        );
-                    }
-                }
-                Ok(0)
-            }
+            FcntlArg::SETFD(flags) => locked_file_descriptors
+                .get_fd(fd)
+                .ok_or(Errno::EBADF)?
+                .set_file_descriptor_flags(&self.global, &files, flags)
+                .map(|()| 0),
             FcntlArg::GETFL => match desc {
                 Descriptor::LiteBoxRawFd(raw_fd) => Ok(files
                     .run_on_raw_fd(
@@ -1107,6 +1110,29 @@ impl Task {
                         |_fd| todo!("pipes"),
                     )
                     .flatten()
+            }
+            FcntlArg::DUPFD { cloexec, min_fd } => {
+                let new_file = self.do_dup(
+                    desc,
+                    if cloexec {
+                        OFlags::CLOEXEC
+                    } else {
+                        OFlags::empty()
+                    },
+                )?;
+                let max_fd = self
+                    .process()
+                    .limits
+                    .get_rlimit_cur(litebox_common_linux::RlimitResource::NOFILE);
+                if min_fd as usize >= max_fd {
+                    return Err(Errno::EINVAL);
+                }
+                drop(locked_file_descriptors); // drop before acquiring write lock
+                files
+                    .file_descriptors
+                    .write()
+                    .insert_in_range(new_file, min_fd as usize, max_fd)
+                    .map_err(|desc| self.do_close(desc).err().unwrap_or(Errno::EMFILE))
             }
             _ => unimplemented!(),
         }
@@ -1782,23 +1808,23 @@ self.global.pipes                                .update_flags(fd, litebox::pipe
                     Ok(oldfd)
                 };
             }
-            if newfd as usize
-                > self
-                    .process()
-                    .limits
-                    .get_rlimit_cur(litebox_common_linux::RlimitResource::NOFILE)
-            {
-                return Err(Errno::EBADF);
-            }
-
-            if let Some(old_file) = files
+            match files
                 .file_descriptors
                 .write()
-                .insert_at(new_file, newfd as usize)
+                .insert_at(self, new_file, newfd as usize)
             {
-                self.do_close(old_file)?;
+                Ok(old_file) => {
+                    // replace an existing file descriptor
+                    if let Some(old_file) = old_file {
+                        self.do_close(old_file)?;
+                    }
+                    Ok(newfd)
+                }
+                Err(new_file) => {
+                    // failed to insert due to file limit
+                    Err(self.do_close(new_file).err().unwrap_or(Errno::EMFILE))
+                }
             }
-            Ok(newfd)
         } else {
             // dup
             files


### PR DESCRIPTION
Add support for ` F_DUPFD/F_DUPFD_CLOEXEC`, which is similar to `dup` (see https://man7.org/linux/man-pages/man2/F_DUPFD.2const.html for more detail).