### PR TITLE
Handle timing imprecision

### DIFF
--- a/litebox_shim_linux/src/syscalls/net.rs
+++ b/litebox_shim_linux/src/syscalls/net.rs
@@ -2976,9 +2976,11 @@ mod unix_tests {
             .unwrap_err();
         let elapsed = start.elapsed();
         assert_eq!(err, Errno::ETIMEDOUT);
+        // Allow a small tolerance (5ms) for timing imprecision
+        let tolerance = Duration::from_millis(5);
         assert!(
-            elapsed >= timeout,
-            "elapsed: {elapsed:?} < timeout: {timeout:?}"
+            elapsed + tolerance >= timeout,
+            "elapsed: {elapsed:?} < timeout: {timeout:?} (with {tolerance:?} tolerance)"
         );
     }
     #[test]


### PR DESCRIPTION
Looks like the [test](https://github.com/microsoft/litebox/actions/runs/21187035744/job/60944298690?pr=565) failed because of imprecise timer on Windows. Give some timing tolerance (5ms) to fix it.