### PR TITLE
Refactor the pointer API to let the `Cow`s out to pasture

### DIFF
--- a/litebox/src/platform/page_mgmt.rs
+++ b/litebox/src/platform/page_mgmt.rs
@@ -139,7 +139,7 @@ pub trait PageManagementProvider<const ALIGN: usize>: RawPointerProvider {
             unsafe {
                 new_ptr.write_slice_at_offset(
                     isize::try_from(offset).unwrap(),
-                    &old_ptr.to_cow_slice(old_range.len()).unwrap(),
+                    &old_ptr.to_owned_slice(old_range.len()).unwrap(),
                 )
             }
             .unwrap();

--- a/litebox/src/sync/futex.rs
+++ b/litebox/src/sync/futex.rs
@@ -107,12 +107,7 @@ impl<Platform: RawSyncPrimitivesProvider + RawPointerProvider + TimeProvider>
 
         // Check the value once. Do this only after inserting into the list so
         // that we don't miss a wakeup.
-        let value = unsafe {
-            futex_addr
-                .read_at_offset(0)
-                .ok_or(FutexError::Fault)?
-                .into_owned()
-        };
+        let value = unsafe { futex_addr.read_at_offset(0).ok_or(FutexError::Fault)? };
         if value != expected_value {
             return Err(FutexError::ImmediatelyWokenBecauseValueMismatch);
         }

--- a/litebox_common_linux/src/lib.rs
+++ b/litebox_common_linux/src/lib.rs
@@ -2895,21 +2895,15 @@ impl<Platform: litebox::platform::RawPointerProvider> TimeParam<Platform> {
                 Duration::from_millis(s)
             }
             TimeParam::TimeVal(tv) => {
-                let tv = unsafe { tv.read_at_offset(0) }
-                    .ok_or(errno::Errno::EFAULT)?
-                    .into_owned();
+                let tv = unsafe { tv.read_at_offset(0) }.ok_or(errno::Errno::EFAULT)?;
                 Duration::try_from(tv).map_err(|_| errno::Errno::EINVAL)?
             }
             TimeParam::Timespec32(ts) => {
-                let ts = unsafe { ts.read_at_offset(0) }
-                    .ok_or(errno::Errno::EFAULT)?
-                    .into_owned();
+                let ts = unsafe { ts.read_at_offset(0) }.ok_or(errno::Errno::EFAULT)?;
                 Duration::try_from(ts).map_err(|_| errno::Errno::EINVAL)?
             }
             TimeParam::Timespec64(ts) => {
-                let ts = unsafe { ts.read_at_offset(0) }
-                    .ok_or(errno::Errno::EFAULT)?
-                    .into_owned();
+                let ts = unsafe { ts.read_at_offset(0) }.ok_or(errno::Errno::EFAULT)?;
                 Duration::try_from(ts).map_err(|_| errno::Errno::EINVAL)?
             }
         };

--- a/litebox_common_linux/src/loader.rs
+++ b/litebox_common_linux/src/loader.rs
@@ -610,7 +610,7 @@ pub trait AccessMemory {
 impl<Platform: RawPointerProvider> AccessMemory for &Platform {
     fn read(&mut self, address: usize, buf: &mut [u8]) -> Result<usize, Fault> {
         let addr = Platform::RawConstPointer::<u8>::from_usize(address);
-        buf.copy_from_slice(&addr.to_owned_slice(buf.len()).ok_or(Fault)?);
+        buf.copy_from_slice(&unsafe { addr.to_owned_slice(buf.len()) }.ok_or(Fault)?);
         Ok(buf.len())
     }
 

--- a/litebox_shim_linux/src/syscalls/mm.rs
+++ b/litebox_shim_linux/src/syscalls/mm.rs
@@ -238,10 +238,7 @@ mod tests {
             )
             .unwrap();
         unsafe { addr.write_slice_at_offset(0, &[0xff; 0x2000]).unwrap() };
-        assert_eq!(
-            unsafe { addr.read_at_offset(0x1000) }.unwrap().into_owned(),
-            0xff,
-        );
+        assert_eq!(unsafe { addr.read_at_offset(0x1000) }.unwrap(), 0xff,);
         task.sys_munmap(addr, 0x2000).unwrap();
     }
 
@@ -266,7 +263,9 @@ mod tests {
             )
             .unwrap();
         assert_eq!(
-            unsafe { addr.to_cow_slice(content.len()).unwrap() },
+            unsafe { addr.to_owned_slice(content.len()) }
+                .unwrap()
+                .as_ref(),
             content.as_slice(),
         );
         task.sys_munmap(addr, 0x1000).unwrap();
@@ -439,11 +438,12 @@ mod tests {
             .is_ok()
         );
 
-        unsafe {
-            addr.to_cow_slice(0x10).unwrap().iter().for_each(|&x| {
+        unsafe { addr.to_owned_slice(0x10) }
+            .unwrap()
+            .iter()
+            .for_each(|&x| {
                 assert_eq!(x, 0); // Should be zeroed after MADV_DONTNEED
             });
-        }
 
         task.sys_munmap(addr, 0x2000).unwrap();
     }

--- a/litebox_shim_linux/src/syscalls/mod.rs
+++ b/litebox_shim_linux/src/syscalls/mod.rs
@@ -65,7 +65,5 @@ fn read_from_user<T: Clone>(
         return Err(litebox_common_linux::errno::Errno::EINVAL);
     }
     let optval: crate::ConstPtr<T> = crate::ConstPtr::from_usize(optval.as_usize());
-    unsafe { optval.read_at_offset(0) }
-        .ok_or(litebox_common_linux::errno::Errno::EFAULT)
-        .map(alloc::borrow::Cow::into_owned)
+    unsafe { optval.read_at_offset(0) }.ok_or(litebox_common_linux::errno::Errno::EFAULT)
 }

--- a/litebox_shim_linux/src/syscalls/process.rs
+++ b/litebox_shim_linux/src/syscalls/process.rs
@@ -346,7 +346,7 @@ impl Task {
                 let mut name_buf = [0u8; litebox_common_linux::TASK_COMM_LEN - 1];
                 // strncpy
                 for (i, byte) in name_buf.iter_mut().enumerate() {
-                    let b = *unsafe { name.read_at_offset(isize::try_from(i).unwrap()) }
+                    let b = unsafe { name.read_at_offset(isize::try_from(i).unwrap()) }
                         .ok_or(Errno::EFAULT)?;
                     if b == 0 {
                         break;
@@ -589,9 +589,7 @@ impl Task {
         ctx: &litebox_common_linux::PtRegs,
         args: ConstPtr<litebox_common_linux::CloneArgs>,
     ) -> Result<usize, Errno> {
-        let args = unsafe { args.read_at_offset(0) }
-            .ok_or(Errno::EFAULT)?
-            .into_owned();
+        let args = unsafe { args.read_at_offset(0) }.ok_or(Errno::EFAULT)?;
         self.do_clone(ctx, &args, true)
     }
 
@@ -681,8 +679,7 @@ impl Task {
                 let desc = unsafe {
                     MutPtr::<litebox_common_linux::UserDesc>::from_usize(addr).read_at_offset(0)
                 }
-                .ok_or(Errno::EFAULT)?
-                .into_owned();
+                .ok_or(Errno::EFAULT)?;
                 // Note that different from `set_thread_area` syscall that returns the allocated entry number
                 // when requested (i.e., `desc.entry_number` is -1), here we just read the descriptor to LiteBox and
                 // assume the entry number is properly set so that we don't need to write it back. This is because
@@ -918,9 +915,7 @@ impl Task {
         }
         let new_limit = match new_rlim {
             Some(rlim) => {
-                let rlim = unsafe { rlim.read_at_offset(0) }
-                    .ok_or(Errno::EINVAL)?
-                    .into_owned();
+                let rlim = unsafe { rlim.read_at_offset(0) }.ok_or(Errno::EINVAL)?;
                 Some(litebox_common_linux::rlimit64_to_rlimit(rlim))
             }
             None => None,
@@ -949,9 +944,7 @@ impl Task {
         resource: litebox_common_linux::RlimitResource,
         rlim: crate::ConstPtr<litebox_common_linux::Rlimit>,
     ) -> Result<(), Errno> {
-        let new_limit = unsafe { rlim.read_at_offset(0) }
-            .ok_or(Errno::EFAULT)?
-            .into_owned();
+        let new_limit = unsafe { rlim.read_at_offset(0) }.ok_or(Errno::EFAULT)?;
         let _ = self.do_prlimit(resource, Some(new_limit))?;
         Ok(())
     }
@@ -1308,7 +1301,7 @@ impl Task {
                 let p: crate::ConstPtr<i8> = unsafe {
                     // read pointer-sized entries
                     match base.read_at_offset(0) {
-                        Some(ptr) => ptr.into_owned(),
+                        Some(ptr) => ptr,
                         None => return Err(Errno::EFAULT),
                     }
                 };

--- a/litebox_shim_linux/src/syscalls/signal/mod.rs
+++ b/litebox_shim_linux/src/syscalls/signal/mod.rs
@@ -375,11 +375,7 @@ impl Task {
             return Err(Errno::EINVAL);
         }
         let set = if let Some(set_ptr) = set_ptr {
-            Some(
-                unsafe { set_ptr.read_at_offset(0) }
-                    .ok_or(Errno::EFAULT)?
-                    .into_owned(),
-            )
+            Some(unsafe { set_ptr.read_at_offset(0) }.ok_or(Errno::EFAULT)?)
         } else {
             None
         };
@@ -428,7 +424,7 @@ impl Task {
             if is_on_stack {
                 return Err(Errno::EPERM);
             }
-            let ss = unsafe { ss_ptr.read_at_offset(0).ok_or(Errno::EFAULT)?.into_owned() };
+            let ss = unsafe { ss_ptr.read_at_offset(0).ok_or(Errno::EFAULT)? };
             self.signals.set_sigaltstack(ss)?;
         }
         Ok(0)
@@ -441,7 +437,6 @@ impl Task {
             self.force_signal(Signal::SIGSEGV, false);
             return Err(Errno::EFAULT);
         };
-        let uctx = uctx.into_owned();
 
         // Restore the alternate signal stack, ignoring errors.
         self.signals.set_sigaltstack(uctx.stack).ok();
@@ -465,11 +460,7 @@ impl Task {
             return Err(Errno::EINVAL);
         }
         let act = if let Some(act_ptr) = act_ptr {
-            Some(
-                unsafe { act_ptr.read_at_offset(0) }
-                    .ok_or(Errno::EFAULT)?
-                    .into_owned(),
-            )
+            Some(unsafe { act_ptr.read_at_offset(0) }.ok_or(Errno::EFAULT)?)
         } else {
             None
         };

--- a/litebox_shim_linux/src/syscalls/signal/x86.rs
+++ b/litebox_shim_linux/src/syscalls/signal/x86.rs
@@ -47,7 +47,6 @@ impl Task {
             self.force_signal(Signal::SIGSEGV, false);
             return Err(Errno::EFAULT);
         };
-        let lctx = lctx.into_owned();
 
         let mask = SigSet::from_u64(
             u64::from(lctx.sigcontext.oldmask) | (u64::from(lctx.extramask) << 32),

--- a/litebox_shim_optee/src/syscalls/ldelf.rs
+++ b/litebox_shim_optee/src/syscalls/ldelf.rs
@@ -38,7 +38,7 @@ impl Task {
             self.global.platform,
             "sys_map_zi: va {:#x} (addr {:#x}), num_bytes {}, flags {:#x}",
             va.as_usize(),
-            *addr,
+            addr,
             num_bytes,
             flags
         );
@@ -54,7 +54,7 @@ impl Task {
             .and_then(|t| t.checked_add(pad_end))
             .ok_or(TeeResult::BadParameters)?
             .next_multiple_of(PAGE_SIZE);
-        if (*addr).checked_add(total_size).is_none() {
+        if addr.checked_add(total_size).is_none() {
             return Err(TeeResult::BadParameters);
         }
         // `sys_map_zi` always creates read/writeable mapping
@@ -65,7 +65,7 @@ impl Task {
         // it targets systems with inefficient CPU and MMU. Instead of reproducing OP-TEE's behavior, we create
         // mappings with `PROT_NONE` for padded regions to prevent others from using them.
         let addr = self
-            .sys_mmap(*addr, total_size, ProtFlags::PROT_NONE, flags, -1, 0)
+            .sys_mmap(addr, total_size, ProtFlags::PROT_NONE, flags, -1, 0)
             .map_err(|_| TeeResult::OutOfMemory)?;
         let padded_start = addr.as_usize() + pad_begin;
         if self
@@ -141,7 +141,7 @@ impl Task {
             self.global.platform,
             "sys_map_bin: va {:#x} (addr {:#x}), num_bytes {}, handle {}, offs {}, pad_begin {}, pad_end {}, flags {:#x}",
             va.as_usize(),
-            *addr,
+            addr,
             num_bytes,
             handle,
             offs,
@@ -177,7 +177,7 @@ impl Task {
             .and_then(|t| t.checked_add(pad_end))
             .ok_or(TeeResult::BadParameters)?
             .next_multiple_of(PAGE_SIZE);
-        if (*addr).checked_add(total_size).is_none() {
+        if addr.checked_add(total_size).is_none() {
             return Err(TeeResult::BadParameters);
         }
         let flags_internal = MapFlags::MAP_PRIVATE | MapFlags::MAP_ANONYMOUS | MapFlags::MAP_FIXED;
@@ -187,7 +187,7 @@ impl Task {
         // the content of the TA binary into it.
         let addr = self
             .sys_mmap(
-                *addr,
+                addr,
                 total_size,
                 ProtFlags::PROT_NONE,
                 flags_internal,


### PR DESCRIPTION
This PR changes the interfaces for raw pointer APIs to remove the `Cow`s that existed, making all the reading operations return the owned variants always.  We already were not using the "borrowed" variants much, and the existence of the borrowed variants makes maintaining the safety contracts quite difficult.

Technically, this _slightly_ increases the number of blocks that require wrapping with `unsafe` but the _vast_ majority of the situations _already_ have a wrapped `unsafe` already, so practically nothing much changes this.  A future PR is going to clean these `unsafe`s up to make things much safer through the use of `zerocopy` traits. Future work _after_ that will work on an even nicer design (see #505).

Along the way, this PR also fixes up a bug in `litebox/src/platform/trivial_providers.rs` where it (under certain sized reads) would ignore the offset counts.