### PR TITLE
Implement EPOLL_CTL_MOD support

### DIFF
--- a/litebox_runner_linux_userland/tests/epoll_test.c
+++ b/litebox_runner_linux_userland/tests/epoll_test.c
@@ -188,12 +188,151 @@ void test_epoll_ctl_mod_update_data(void) {
     TEST_PASS(test_name);
 }
 
+void test_epoll_ctl_mod_oneshot_rearm(void) {
+    const char *test_name = "epoll_ctl_mod_oneshot_rearm";
+
+    // Create epoll instance
+    int epfd = epoll_create1(0);
+    if (epfd < 0) {
+        TEST_FAIL(test_name, "epoll_create1 failed");
+    }
+
+    // Create eventfd (writable by default when counter < max)
+    int efd = eventfd(0, EFD_NONBLOCK);
+    if (efd < 0) {
+        close(epfd);
+        TEST_FAIL(test_name, "eventfd failed");
+    }
+
+    // Add eventfd with EPOLLOUT | EPOLLONESHOT
+    struct epoll_event ev;
+    ev.events = EPOLLOUT | EPOLLONESHOT;
+    ev.data.u64 = 42;
+    if (epoll_ctl(epfd, EPOLL_CTL_ADD, efd, &ev) < 0) {
+        close(efd);
+        close(epfd);
+        TEST_FAIL(test_name, "EPOLL_CTL_ADD failed");
+    }
+
+    // First wait should return the event
+    struct epoll_event events[1];
+    int nfds = epoll_wait(epfd, events, 1, 100);
+    if (nfds != 1) {
+        close(efd);
+        close(epfd);
+        TEST_FAIL(test_name, "first epoll_wait should return 1 event");
+    }
+    if (events[0].data.u64 != 42) {
+        close(efd);
+        close(epfd);
+        TEST_FAIL(test_name, "first event should have data=42");
+    }
+
+    // Second wait should timeout (ONESHOT disabled the entry)
+    nfds = epoll_wait(epfd, events, 1, 50);
+    if (nfds != 0) {
+        close(efd);
+        close(epfd);
+        TEST_FAIL(test_name, "second epoll_wait should timeout (entry disabled)");
+    }
+
+    // Re-arm with EPOLL_CTL_MOD
+    ev.events = EPOLLOUT | EPOLLONESHOT;
+    ev.data.u64 = 99;
+    if (epoll_ctl(epfd, EPOLL_CTL_MOD, efd, &ev) < 0) {
+        close(efd);
+        close(epfd);
+        TEST_FAIL(test_name, "EPOLL_CTL_MOD to re-arm failed");
+    }
+
+    // Third wait should return the event (re-armed)
+    nfds = epoll_wait(epfd, events, 1, 100);
+    if (nfds != 1) {
+        close(efd);
+        close(epfd);
+        TEST_FAIL(test_name, "third epoll_wait should return 1 event after re-arm");
+    }
+    if (events[0].data.u64 != 99) {
+        close(efd);
+        close(epfd);
+        TEST_FAIL(test_name, "re-armed event should have data=99");
+    }
+
+    close(efd);
+    close(epfd);
+    TEST_PASS(test_name);
+}
+
+void test_epoll_ctl_mod_edge_triggered(void) {
+    const char *test_name = "epoll_ctl_mod_edge_triggered";
+
+    // Create epoll instance
+    int epfd = epoll_create1(0);
+    if (epfd < 0) {
+        TEST_FAIL(test_name, "epoll_create1 failed");
+    }
+
+    // Create eventfd
+    int efd = eventfd(0, EFD_NONBLOCK);
+    if (efd < 0) {
+        close(epfd);
+        TEST_FAIL(test_name, "eventfd failed");
+    }
+
+    // Add with level-triggered EPOLLOUT
+    struct epoll_event ev;
+    ev.events = EPOLLOUT;
+    ev.data.u64 = 42;
+    if (epoll_ctl(epfd, EPOLL_CTL_ADD, efd, &ev) < 0) {
+        close(efd);
+        close(epfd);
+        TEST_FAIL(test_name, "EPOLL_CTL_ADD failed");
+    }
+
+    // Modify to edge-triggered
+    ev.events = EPOLLOUT | EPOLLET;
+    ev.data.u64 = 99;
+    if (epoll_ctl(epfd, EPOLL_CTL_MOD, efd, &ev) < 0) {
+        close(efd);
+        close(epfd);
+        TEST_FAIL(test_name, "EPOLL_CTL_MOD to edge-triggered failed");
+    }
+
+    // First wait should return the event
+    struct epoll_event events[1];
+    int nfds = epoll_wait(epfd, events, 1, 100);
+    if (nfds != 1) {
+        close(efd);
+        close(epfd);
+        TEST_FAIL(test_name, "first epoll_wait should return 1 event");
+    }
+    if (events[0].data.u64 != 99) {
+        close(efd);
+        close(epfd);
+        TEST_FAIL(test_name, "event should have updated data=99");
+    }
+
+    // Second wait should timeout (edge-triggered, no new edge)
+    nfds = epoll_wait(epfd, events, 1, 50);
+    if (nfds != 0) {
+        close(efd);
+        close(epfd);
+        TEST_FAIL(test_name, "second epoll_wait should timeout (edge-triggered)");
+    }
+
+    close(efd);
+    close(epfd);
+    TEST_PASS(test_name);
+}
+
 int main(void) {
     printf("=== EPOLL_CTL_MOD Tests ===\n");
 
     test_epoll_ctl_mod_basic();
     test_epoll_ctl_mod_not_found();
     test_epoll_ctl_mod_update_data();
+    test_epoll_ctl_mod_oneshot_rearm();
+    test_epoll_ctl_mod_edge_triggered();
 
     printf("=== All EPOLL_CTL_MOD tests passed ===\n");
     return 0;


### PR DESCRIPTION
## Summary

Enable the `EPOLL_CTL_MOD` operation for modifying events on file descriptors already registered with an epoll instance. This is critical for event-driven applications like Node.js and Python asyncio.

The implementation was already present as dead code (`mod_interest` function) - this PR connects it to the `epoll_ctl` dispatch and adds comprehensive tests.

## Changes

- Remove `#[expect(dead_code)]` from `mod_interest` function
- Wire `EPOLL_CTL_MOD` to call `mod_interest` in `epoll_ctl`
- Add 3 unit tests for MOD operation:
  - `test_epoll_ctl_mod_basic` - Basic modification of events and data
  - `test_epoll_ctl_mod_not_found` - ENOENT when fd not registered
  - `test_epoll_ctl_mod_exclusive_not_allowed` - EINVAL when EPOLLEXCLUSIVE in flags
- Add C integration test (`epoll_test.c`)

## Test plan

- [x] Unit tests pass locally (9/9 epoll tests)
- [x] `cargo clippy` - no warnings
- [x] `cargo fmt` - no changes needed
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)