### PR TITLE
Implement link and linkat syscalls

### DIFF
--- a/litebox/src/fs/devices.rs
+++ b/litebox/src/fs/devices.rs
@@ -12,8 +12,9 @@ use crate::{
     fs::{
         FileStatus, FileType, Mode, NodeInfo, OFlags, SeekWhence, UserInfo,
         errors::{
-            ChmodError, ChownError, CloseError, FileStatusError, MkdirError, OpenError, PathError,
-            ReadDirError, ReadError, RmdirError, SeekError, TruncateError, UnlinkError, WriteError,
+            ChmodError, ChownError, CloseError, FileStatusError, LinkError, MkdirError, OpenError,
+            PathError, ReadDirError, ReadError, RmdirError, SeekError, TruncateError, UnlinkError,
+            WriteError,
         },
     },
     path::Arg,
@@ -344,6 +345,12 @@ impl<
 
     #[expect(unused_variables, reason = "unimplemented")]
     fn unlink(&self, path: impl Arg) -> Result<(), UnlinkError> {
+        unimplemented!()
+    }
+
+    #[expect(unused_variables, reason = "unimplemented")]
+    fn link(&self, oldpath: impl Arg, newpath: impl Arg) -> Result<(), LinkError> {
+        // Device files cannot have hard links created
         unimplemented!()
     }
 

--- a/litebox/src/fs/errors.rs
+++ b/litebox/src/fs/errors.rs
@@ -183,6 +183,26 @@ pub enum FileStatusError {
     PathError(#[from] PathError),
 }
 
+/// Possible errors from [`FileSystem::link`]
+#[non_exhaustive]
+#[derive(Error, Debug)]
+pub enum LinkError {
+    #[error("the parent directory does not allow write permission")]
+    NoWritePerms,
+    #[error("newpath already exists")]
+    AlreadyExists,
+    #[error("oldpath is a directory")]
+    IsADirectory,
+    #[error("the named file resides on a read-only filesystem")]
+    ReadOnlyFileSystem,
+    #[error("oldpath and newpath are not on the same mounted filesystem")]
+    CrossDeviceLink,
+    #[error("too many links to the file")]
+    TooManyLinks,
+    #[error(transparent)]
+    PathError(#[from] PathError),
+}
+
 /// Possible errors in any file-system function due to path errors.
 #[derive(Error, Debug)]
 pub enum PathError {

--- a/litebox/src/fs/mod.rs
+++ b/litebox/src/fs/mod.rs
@@ -23,8 +23,8 @@ pub mod tar_ro;
 mod tests;
 
 use errors::{
-    ChmodError, ChownError, CloseError, FileStatusError, MkdirError, OpenError, ReadDirError,
-    ReadError, RmdirError, SeekError, TruncateError, UnlinkError, WriteError,
+    ChmodError, ChownError, CloseError, FileStatusError, LinkError, MkdirError, OpenError,
+    ReadDirError, ReadError, RmdirError, SeekError, TruncateError, UnlinkError, WriteError,
 };
 
 /// A private module, to help support writing sealed traits. This module should _itself_ never be
@@ -119,6 +119,20 @@ pub trait FileSystem: private::Sealed + FdEnabledSubsystem {
 
     /// Unlink a file
     fn unlink(&self, path: impl path::Arg) -> Result<(), UnlinkError>;
+
+    /// Create a hard link to an existing file
+    ///
+    /// Creates a new directory entry `newpath` that refers to the same file as `oldpath`.
+    /// After a successful call, both paths refer to the same file and the link count is
+    /// incremented.
+    ///
+    /// # Errors
+    /// - `LinkError::IsADirectory` if `oldpath` is a directory
+    /// - `LinkError::AlreadyExists` if `newpath` already exists
+    /// - `LinkError::NoWritePerms` if the directory containing `newpath` is not writable
+    /// - `LinkError::CrossDeviceLink` if `oldpath` and `newpath` are on different filesystems
+    /// - `LinkError::TooManyLinks` if the maximum number of links to `oldpath` would be exceeded
+    fn link(&self, oldpath: impl path::Arg, newpath: impl path::Arg) -> Result<(), LinkError>;
 
     /// Create a new directory
     fn mkdir(&self, path: impl path::Arg, mode: Mode) -> Result<(), MkdirError>;

--- a/litebox/src/fs/nine_p.rs
+++ b/litebox/src/fs/nine_p.rs
@@ -101,6 +101,14 @@ impl<Platform: platform::Provider + Sync> super::FileSystem for FileSystem<Platf
         todo!()
     }
 
+    fn link(
+        &self,
+        oldpath: impl crate::path::Arg,
+        newpath: impl crate::path::Arg,
+    ) -> Result<(), super::errors::LinkError> {
+        todo!()
+    }
+
     fn mkdir(
         &self,
         path: impl crate::path::Arg,

--- a/litebox/src/fs/tar_ro.rs
+++ b/litebox/src/fs/tar_ro.rs
@@ -39,8 +39,8 @@ use crate::{
 use super::{
     Mode, NodeInfo, OFlags, SeekWhence, UserInfo,
     errors::{
-        ChmodError, ChownError, CloseError, MkdirError, OpenError, PathError, ReadDirError,
-        ReadError, RmdirError, SeekError, TruncateError, UnlinkError, WriteError,
+        ChmodError, ChownError, CloseError, LinkError, MkdirError, OpenError, PathError,
+        ReadDirError, ReadError, RmdirError, SeekError, TruncateError, UnlinkError, WriteError,
     },
 };
 
@@ -392,6 +392,14 @@ impl<Platform: sync::RawSyncPrimitivesProvider> super::FileSystem for FileSystem
             }
             Some(_) => Err(UnlinkError::ReadOnlyFileSystem),
         }
+    }
+
+    fn link(
+        &self,
+        _oldpath: impl crate::path::Arg,
+        _newpath: impl crate::path::Arg,
+    ) -> Result<(), LinkError> {
+        Err(LinkError::ReadOnlyFileSystem)
     }
 
     fn mkdir(&self, _path: impl crate::path::Arg, _mode: Mode) -> Result<(), MkdirError> {

--- a/litebox_common_linux/src/errno/mod.rs
+++ b/litebox_common_linux/src/errno/mod.rs
@@ -148,6 +148,21 @@ impl From<litebox::fs::errors::UnlinkError> for Errno {
     }
 }
 
+impl From<litebox::fs::errors::LinkError> for Errno {
+    fn from(value: litebox::fs::errors::LinkError) -> Self {
+        match value {
+            litebox::fs::errors::LinkError::NoWritePerms => Errno::EACCES,
+            litebox::fs::errors::LinkError::AlreadyExists => Errno::EEXIST,
+            litebox::fs::errors::LinkError::IsADirectory => Errno::EPERM,
+            litebox::fs::errors::LinkError::ReadOnlyFileSystem => Errno::EROFS,
+            litebox::fs::errors::LinkError::CrossDeviceLink => Errno::EXDEV,
+            litebox::fs::errors::LinkError::TooManyLinks => Errno::EMLINK,
+            litebox::fs::errors::LinkError::PathError(path_error) => path_error.into(),
+            _ => unimplemented!(),
+        }
+    }
+}
+
 impl From<litebox::fs::errors::RmdirError> for Errno {
     fn from(value: litebox::fs::errors::RmdirError) -> Self {
         match value {

--- a/litebox_common_linux/src/lib.rs
+++ b/litebox_common_linux/src/lib.rs
@@ -2125,6 +2125,14 @@ pub enum SyscallRequest<Platform: litebox::platform::RawPointerProvider> {
         pathname: Platform::RawConstPointer<i8>,
         flags: AtFlags,
     },
+    /// Create a hard link to an existing file
+    Linkat {
+        olddirfd: i32,
+        oldpath: Platform::RawConstPointer<i8>,
+        newdirfd: i32,
+        newpath: Platform::RawConstPointer<i8>,
+        flags: AtFlags,
+    },
     #[cfg(target_arch = "x86_64")]
     Newfstatat {
         dirfd: i32,
@@ -2712,6 +2720,23 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
                 SyscallRequest::Unlinkat {
                     dirfd: AT_FDCWD,
                     pathname: ctx.sys_req_ptr(0),
+                    flags: AtFlags::empty(),
+                }
+            }
+            Sysno::linkat => SyscallRequest::Linkat {
+                olddirfd: ctx.sys_req_arg(0),
+                oldpath: ctx.sys_req_ptr(1),
+                newdirfd: ctx.sys_req_arg(2),
+                newpath: ctx.sys_req_ptr(3),
+                flags: ctx.sys_req_arg(4),
+            },
+            Sysno::link => {
+                // link is equivalent to linkat with olddirfd/newdirfd AT_FDCWD and flags 0
+                SyscallRequest::Linkat {
+                    olddirfd: AT_FDCWD,
+                    oldpath: ctx.sys_req_ptr(0),
+                    newdirfd: AT_FDCWD,
+                    newpath: ctx.sys_req_ptr(1),
                     flags: AtFlags::empty(),
                 }
             }

--- a/litebox_runner_linux_userland/tests/link_test.c
+++ b/litebox_runner_linux_userland/tests/link_test.c
@@ -1,0 +1,248 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// Integration test for link(2) and linkat(2) syscalls
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <sys/stat.h>
+
+#define TEST_FILE "/tmp/link_test_original"
+#define LINK_FILE "/tmp/link_test_linked"
+#define TEST_DIR "/tmp/link_test_dir"
+
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define ASSERT(cond, msg) do { \
+    if (!(cond)) { \
+        printf("FAIL: %s (line %d): %s\n", msg, __LINE__, strerror(errno)); \
+        tests_failed++; \
+        return; \
+    } \
+} while(0)
+
+#define ASSERT_ERRNO(cond, expected_errno, msg) do { \
+    if (!(cond)) { \
+        printf("FAIL: %s (line %d): expected errno %d, got %d (%s)\n", \
+               msg, __LINE__, expected_errno, errno, strerror(errno)); \
+        tests_failed++; \
+        return; \
+    } \
+} while(0)
+
+#define TEST_PASS(name) do { \
+    printf("PASS: %s\n", name); \
+    tests_passed++; \
+} while(0)
+
+// Cleanup function
+static void cleanup(void) {
+    unlink(TEST_FILE);
+    unlink(LINK_FILE);
+    // Note: rmdir not yet implemented in litebox
+    // rmdir(TEST_DIR);
+}
+
+// Test basic link creation
+static void test_link_basic(void) {
+    cleanup();
+
+    // Create a file
+    int fd = open(TEST_FILE, O_CREAT | O_WRONLY, 0644);
+    ASSERT(fd >= 0, "create original file");
+
+    const char *data = "test data for link";
+    ssize_t written = write(fd, data, strlen(data));
+    ASSERT(written == (ssize_t)strlen(data), "write to original file");
+    close(fd);
+
+    // Create hard link
+    int ret = link(TEST_FILE, LINK_FILE);
+    ASSERT(ret == 0, "create hard link");
+
+    // Verify both files exist and have the same content
+    char buf[64] = {0};
+    fd = open(LINK_FILE, O_RDONLY);
+    ASSERT(fd >= 0, "open linked file");
+
+    ssize_t bytes_read = read(fd, buf, sizeof(buf) - 1);
+    ASSERT(bytes_read == (ssize_t)strlen(data), "read from linked file");
+    ASSERT(strcmp(buf, data) == 0, "content matches");
+    close(fd);
+
+    // Verify inode is the same (hard link property)
+    struct stat stat_original, stat_linked;
+    ASSERT(stat(TEST_FILE, &stat_original) == 0, "stat original");
+    ASSERT(stat(LINK_FILE, &stat_linked) == 0, "stat linked");
+    ASSERT(stat_original.st_ino == stat_linked.st_ino, "same inode");
+    // Note: nlink tracking not yet fully implemented in litebox
+    // ASSERT(stat_original.st_nlink >= 2, "nlink >= 2");
+
+    cleanup();
+    TEST_PASS("test_link_basic");
+}
+
+// Test that modifications through link are visible via original
+static void test_link_shared_data(void) {
+    cleanup();
+
+    // Create a file
+    int fd = open(TEST_FILE, O_CREAT | O_WRONLY, 0644);
+    ASSERT(fd >= 0, "create original file");
+    write(fd, "original", 8);
+    close(fd);
+
+    // Create hard link
+    ASSERT(link(TEST_FILE, LINK_FILE) == 0, "create hard link");
+
+    // Modify through link
+    fd = open(LINK_FILE, O_WRONLY);
+    ASSERT(fd >= 0, "open linked file for write");
+    write(fd, "modified", 8);
+    close(fd);
+
+    // Read through original
+    char buf[64] = {0};
+    fd = open(TEST_FILE, O_RDONLY);
+    ASSERT(fd >= 0, "open original file");
+    read(fd, buf, sizeof(buf) - 1);
+    close(fd);
+
+    ASSERT(strcmp(buf, "modified") == 0, "data modified through link visible via original");
+
+    cleanup();
+    TEST_PASS("test_link_shared_data");
+}
+
+// Test unlinking original preserves data via link
+static void test_link_unlink_original(void) {
+    cleanup();
+
+    // Create a file
+    int fd = open(TEST_FILE, O_CREAT | O_WRONLY, 0644);
+    ASSERT(fd >= 0, "create original file");
+    write(fd, "preserved", 9);
+    close(fd);
+
+    // Create hard link
+    ASSERT(link(TEST_FILE, LINK_FILE) == 0, "create hard link");
+
+    // Unlink original
+    ASSERT(unlink(TEST_FILE) == 0, "unlink original");
+
+    // Verify linked file still has data
+    char buf[64] = {0};
+    fd = open(LINK_FILE, O_RDONLY);
+    ASSERT(fd >= 0, "open linked file after unlink original");
+    read(fd, buf, sizeof(buf) - 1);
+    close(fd);
+
+    ASSERT(strcmp(buf, "preserved") == 0, "data preserved via link");
+
+    // Verify original is gone
+    ASSERT(access(TEST_FILE, F_OK) == -1, "original file should not exist");
+    ASSERT(errno == ENOENT, "errno should be ENOENT");
+
+    cleanup();
+    TEST_PASS("test_link_unlink_original");
+}
+
+// Test linking to directory fails
+static void test_link_directory_fails(void) {
+    cleanup();
+
+    // Create a directory
+    ASSERT(mkdir(TEST_DIR, 0755) == 0, "create directory");
+
+    // Attempt to link to directory - should fail with EPERM
+    int ret = link(TEST_DIR, LINK_FILE);
+    ASSERT_ERRNO(ret == -1 && errno == EPERM, EPERM, "link to directory should fail with EPERM");
+
+    // Note: rmdir not yet implemented, clean up with unlink (will fail but cleanup file)
+    unlink(TEST_DIR);
+    cleanup();
+    TEST_PASS("test_link_directory_fails");
+}
+
+// Test linking to existing file fails
+static void test_link_exists_fails(void) {
+    cleanup();
+
+    // Create two files
+    int fd = open(TEST_FILE, O_CREAT | O_WRONLY, 0644);
+    ASSERT(fd >= 0, "create first file");
+    close(fd);
+
+    fd = open(LINK_FILE, O_CREAT | O_WRONLY, 0644);
+    ASSERT(fd >= 0, "create second file");
+    close(fd);
+
+    // Attempt to link - should fail with EEXIST
+    int ret = link(TEST_FILE, LINK_FILE);
+    ASSERT_ERRNO(ret == -1 && errno == EEXIST, EEXIST, "link to existing file should fail with EEXIST");
+
+    cleanup();
+    TEST_PASS("test_link_exists_fails");
+}
+
+// Test linking nonexistent file fails
+static void test_link_nonexistent_fails(void) {
+    cleanup();
+
+    // Attempt to link nonexistent file - should fail with ENOENT
+    int ret = link("/tmp/nonexistent_file_for_link_test", LINK_FILE);
+    ASSERT_ERRNO(ret == -1 && errno == ENOENT, ENOENT, "link to nonexistent file should fail with ENOENT");
+
+    cleanup();
+    TEST_PASS("test_link_nonexistent_fails");
+}
+
+// Test linkat with AT_FDCWD
+static void test_linkat_fdcwd(void) {
+    cleanup();
+
+    // Create a file
+    int fd = open(TEST_FILE, O_CREAT | O_WRONLY, 0644);
+    ASSERT(fd >= 0, "create original file");
+    write(fd, "linkat test", 11);
+    close(fd);
+
+    // Create hard link using linkat with AT_FDCWD
+    int ret = linkat(AT_FDCWD, TEST_FILE, AT_FDCWD, LINK_FILE, 0);
+    ASSERT(ret == 0, "linkat with AT_FDCWD");
+
+    // Verify link was created by reading its content
+    char buf[64] = {0};
+    fd = open(LINK_FILE, O_RDONLY);
+    ASSERT(fd >= 0, "open linked file");
+    ssize_t bytes_read = read(fd, buf, sizeof(buf) - 1);
+    ASSERT(bytes_read == 11, "read from linked file");
+    ASSERT(strcmp(buf, "linkat test") == 0, "content matches");
+    close(fd);
+
+    cleanup();
+    TEST_PASS("test_linkat_fdcwd");
+}
+
+int main(void) {
+    printf("===== link/linkat syscall tests =====\n\n");
+
+    test_link_basic();
+    test_link_shared_data();
+    test_link_unlink_original();
+    test_link_directory_fails();
+    test_link_exists_fails();
+    test_link_nonexistent_fails();
+    test_linkat_fdcwd();
+
+    printf("\n===== Results =====\n");
+    printf("Passed: %d\n", tests_passed);
+    printf("Failed: %d\n", tests_failed);
+
+    return tests_failed > 0 ? 1 : 0;
+}

--- a/litebox_shim_linux/src/lib.rs
+++ b/litebox_shim_linux/src/lib.rs
@@ -971,6 +971,17 @@ impl Task {
             } => pathname.to_cstring().map_or(Err(Errno::EFAULT), |path| {
                 syscall!(sys_unlinkat(dirfd, path, flags))
             }),
+            SyscallRequest::Linkat {
+                olddirfd,
+                oldpath,
+                newdirfd,
+                newpath,
+                flags,
+            } => {
+                let oldpath = oldpath.to_cstring().ok_or(Errno::EFAULT)?;
+                let newpath = newpath.to_cstring().ok_or(Errno::EFAULT)?;
+                syscall!(sys_linkat(olddirfd, oldpath, newdirfd, newpath, flags))
+            }
             SyscallRequest::Stat { pathname, buf } => {
                 pathname.to_cstring().map_or(Err(Errno::EFAULT), |path| {
                     self.sys_stat(path).and_then(|stat| {


### PR DESCRIPTION
## Summary

This PR adds support for creating hard links via the `link(2)` and `linkat(2)` syscalls.

### Changes
- Add `LinkError` enum to `litebox/src/fs/errors.rs`
- Add `link()` method to `FileSystem` trait
- Implement `link()` in all filesystem implementations:
  - `in_mem`: Full implementation using Arc cloning for shared file data
  - `layered`: Migrates lower-layer files to upper layer before linking
  - `tar_ro`: Returns `ReadOnlyFileSystem` error
  - `devices`: Returns `unimplemented!()` (device files don't support hard links)
  - `nine_p`: Returns `todo!()` (9p not yet implemented)
- Add syscall parsing for `link` and `linkat` in `litebox_common_linux`
- Add `From<LinkError> for Errno` conversion
- Implement `sys_linkat()` handler in `litebox_shim_linux`

### Supported Flags
- `AT_SYMLINK_FOLLOW` (0x400): Follow symlinks when resolving oldpath
- `AT_EMPTY_PATH`: Returns `EINVAL` (not supported, requires `CAP_DAC_READ_SEARCH`)

### Error Handling
| Error | Condition |
|-------|-----------|
| `EACCES` | Write access to directory containing newpath denied |
| `EEXIST` | newpath already exists |
| `ENOENT` | oldpath does not exist, or newpath's directory doesn't exist |
| `EPERM` | oldpath is a directory |
| `EXDEV` | oldpath and newpath are on different filesystems |
| `EROFS` | Filesystem is read-only |
| `EINVAL` | Invalid flags |

### Known Limitations
- `st_nlink` in `FileStatus` is not yet tracked, so `stat()` will show `nlink=1` even for hard-linked files. This can be added in a future PR.

## Test Plan
- [x] Rust unit tests in `litebox/src/fs/tests.rs`:
  - `link_basic`: Create hard link and verify data access
  - `link_shared_data`: Verify writes through one path visible via the other
  - `link_unlink_original_preserves_data`: Data persists after unlinking original
  - `link_directory_fails`: Linking to directories returns EPERM
  - `link_already_exists_fails`: Linking to existing path returns EEXIST
  - `link_nonexistent_fails`: Linking nonexistent file returns ENOENT

- [x] C integration test (`link_test.c`):
  - All basic link functionality tests
  - `linkat` with `AT_FDCWD` test

🤖 Generated with [Claude Code](https://claude.com/claude-code)