### PR TITLE
Implement symlink and symlinkat syscalls

### DIFF
--- a/litebox/src/fs/devices.rs
+++ b/litebox/src/fs/devices.rs
@@ -13,7 +13,8 @@ use crate::{
         FileStatus, FileType, Mode, NodeInfo, OFlags, SeekWhence, UserInfo,
         errors::{
             ChmodError, ChownError, CloseError, FileStatusError, MkdirError, OpenError, PathError,
-            ReadDirError, ReadError, RmdirError, SeekError, TruncateError, UnlinkError, WriteError,
+            ReadDirError, ReadError, ReadlinkError, RmdirError, SeekError, SymlinkError,
+            TruncateError, UnlinkError, WriteError,
         },
     },
     path::Arg,
@@ -355,6 +356,16 @@ impl<
     #[expect(unused_variables, reason = "unimplemented")]
     fn rmdir(&self, path: impl Arg) -> Result<(), RmdirError> {
         unimplemented!()
+    }
+
+    fn symlink(&self, _target: impl Arg, _linkpath: impl Arg) -> Result<(), SymlinkError> {
+        // Device filesystem doesn't support creating symlinks
+        Err(SymlinkError::ReadOnlyFileSystem)
+    }
+
+    fn readlink(&self, _path: impl Arg) -> Result<String, ReadlinkError> {
+        // Device filesystem doesn't have symlinks - return PathError for consistency
+        Err(ReadlinkError::PathError(PathError::NoSuchFileOrDirectory))
     }
 
     fn read_dir(

--- a/litebox/src/fs/errors.rs
+++ b/litebox/src/fs/errors.rs
@@ -73,6 +73,7 @@ pub enum SeekError {
 }
 
 /// Possible errors from [`FileSystem::truncate`]
+#[non_exhaustive]
 #[derive(Error, Debug)]
 pub enum TruncateError {
     #[error("fd has been closed already")]
@@ -163,6 +164,32 @@ pub enum RmdirError {
     PathError(#[from] PathError),
 }
 
+/// Possible errors from [`FileSystem::symlink`]
+#[non_exhaustive]
+#[derive(Error, Debug)]
+pub enum SymlinkError {
+    #[error("the parent directory does not allow write permission")]
+    NoWritePerms,
+    #[error("linkpath already exists")]
+    AlreadyExists,
+    #[error("the named file resides on a read-only filesystem")]
+    ReadOnlyFileSystem,
+    #[error("target is an empty string")]
+    EmptyTarget,
+    #[error(transparent)]
+    PathError(#[from] PathError),
+}
+
+/// Possible errors from [`FileSystem::readlink`]
+#[non_exhaustive]
+#[derive(Error, Debug)]
+pub enum ReadlinkError {
+    #[error("the named file is not a symbolic link")]
+    NotASymlink,
+    #[error(transparent)]
+    PathError(#[from] PathError),
+}
+
 /// Possible errors from [`FileSystem::read_dir`]
 #[non_exhaustive]
 #[derive(Error, Debug)]
@@ -206,5 +233,17 @@ pub enum PathError {
 impl From<crate::path::ConversionError> for PathError {
     fn from(_value: crate::path::ConversionError) -> Self {
         Self::InvalidPathname
+    }
+}
+
+impl From<crate::path::ConversionError> for SymlinkError {
+    fn from(value: crate::path::ConversionError) -> Self {
+        Self::PathError(value.into())
+    }
+}
+
+impl From<crate::path::ConversionError> for ReadlinkError {
+    fn from(value: crate::path::ConversionError) -> Self {
+        Self::PathError(value.into())
     }
 }

--- a/litebox/src/fs/nine_p.rs
+++ b/litebox/src/fs/nine_p.rs
@@ -113,6 +113,21 @@ impl<Platform: platform::Provider + Sync> super::FileSystem for FileSystem<Platf
         todo!()
     }
 
+    fn symlink(
+        &self,
+        target: impl crate::path::Arg,
+        linkpath: impl crate::path::Arg,
+    ) -> Result<(), super::errors::SymlinkError> {
+        todo!()
+    }
+
+    fn readlink(
+        &self,
+        path: impl crate::path::Arg,
+    ) -> Result<alloc::string::String, super::errors::ReadlinkError> {
+        todo!()
+    }
+
     fn read_dir(
         &self,
         fd: &FileFd<Platform>,

--- a/litebox/src/fs/tar_ro.rs
+++ b/litebox/src/fs/tar_ro.rs
@@ -40,7 +40,8 @@ use super::{
     Mode, NodeInfo, OFlags, SeekWhence, UserInfo,
     errors::{
         ChmodError, ChownError, CloseError, MkdirError, OpenError, PathError, ReadDirError,
-        ReadError, RmdirError, SeekError, TruncateError, UnlinkError, WriteError,
+        ReadError, ReadlinkError, RmdirError, SeekError, SymlinkError, TruncateError, UnlinkError,
+        WriteError,
     },
 };
 
@@ -404,6 +405,21 @@ impl<Platform: sync::RawSyncPrimitivesProvider> super::FileSystem for FileSystem
         // TODO: Do we need to do the type of checks that are happening in the other functions, or
         // should the other functions be simplified to this?
         Err(RmdirError::ReadOnlyFileSystem)
+    }
+
+    fn symlink(
+        &self,
+        _target: impl crate::path::Arg,
+        _linkpath: impl crate::path::Arg,
+    ) -> Result<(), SymlinkError> {
+        Err(SymlinkError::ReadOnlyFileSystem)
+    }
+
+    fn readlink(&self, path: impl crate::path::Arg) -> Result<String, ReadlinkError> {
+        let _path = path.as_rust_str()?;
+        // The read-only tar filesystem doesn't currently track symlinks distinctly
+        // from regular files. Return NotASymlink for any existing file.
+        Err(ReadlinkError::NotASymlink)
     }
 
     fn read_dir(&self, fd: &FileFd<Platform>) -> Result<Vec<DirEntry>, ReadDirError> {

--- a/litebox_common_linux/src/errno/mod.rs
+++ b/litebox_common_linux/src/errno/mod.rs
@@ -225,6 +225,29 @@ impl From<litebox::fs::errors::MkdirError> for Errno {
     }
 }
 
+impl From<litebox::fs::errors::SymlinkError> for Errno {
+    fn from(value: litebox::fs::errors::SymlinkError) -> Self {
+        match value {
+            litebox::fs::errors::SymlinkError::PathError(path_error) => path_error.into(),
+            litebox::fs::errors::SymlinkError::AlreadyExists => Errno::EEXIST,
+            litebox::fs::errors::SymlinkError::ReadOnlyFileSystem => Errno::EROFS,
+            litebox::fs::errors::SymlinkError::NoWritePerms => Errno::EACCES,
+            litebox::fs::errors::SymlinkError::EmptyTarget => Errno::ENOENT,
+            _ => unimplemented!(),
+        }
+    }
+}
+
+impl From<litebox::fs::errors::ReadlinkError> for Errno {
+    fn from(value: litebox::fs::errors::ReadlinkError) -> Self {
+        match value {
+            litebox::fs::errors::ReadlinkError::PathError(path_error) => path_error.into(),
+            litebox::fs::errors::ReadlinkError::NotASymlink => Errno::EINVAL,
+            _ => unimplemented!(),
+        }
+    }
+}
+
 impl From<litebox::platform::page_mgmt::AllocationError> for Errno {
     fn from(value: litebox::platform::page_mgmt::AllocationError) -> Self {
         match value {
@@ -555,6 +578,7 @@ impl From<litebox::fs::errors::TruncateError> for Errno {
             litebox::fs::errors::TruncateError::NotForWriting => Errno::EACCES,
             litebox::fs::errors::TruncateError::IsTerminalDevice => Errno::EINVAL,
             litebox::fs::errors::TruncateError::ClosedFd => Errno::EBADF,
+            _ => Errno::EINVAL, // Future non-exhaustive variants
         }
     }
 }

--- a/litebox_common_linux/src/lib.rs
+++ b/litebox_common_linux/src/lib.rs
@@ -2261,6 +2261,11 @@ pub enum SyscallRequest<Platform: litebox::platform::RawPointerProvider> {
         new_value: Platform::RawConstPointer<ItimerVal>,
         old_value: Option<Platform::RawMutPointer<ItimerVal>>,
     },
+    Symlinkat {
+        target: Platform::RawConstPointer<i8>,
+        newdirfd: i32,
+        linkpath: Platform::RawConstPointer<i8>,
+    },
 }
 
 impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
@@ -2713,6 +2718,15 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
                     dirfd: AT_FDCWD,
                     pathname: ctx.sys_req_ptr(0),
                     flags: AtFlags::empty(),
+                }
+            }
+            Sysno::symlinkat => sys_req!(Symlinkat { target:*, newdirfd, linkpath:* }),
+            Sysno::symlink => {
+                // symlink is equivalent to symlinkat with newdirfd AT_FDCWD
+                SyscallRequest::Symlinkat {
+                    target: ctx.sys_req_ptr(0),
+                    newdirfd: AT_FDCWD,
+                    linkpath: ctx.sys_req_ptr(1),
                 }
             }
             Sysno::creat => {

--- a/litebox_shim_linux/src/lib.rs
+++ b/litebox_shim_linux/src/lib.rs
@@ -971,6 +971,15 @@ impl Task {
             } => pathname.to_cstring().map_or(Err(Errno::EFAULT), |path| {
                 syscall!(sys_unlinkat(dirfd, path, flags))
             }),
+            SyscallRequest::Symlinkat {
+                target,
+                newdirfd,
+                linkpath,
+            } => {
+                let target_cstr = target.to_cstring().ok_or(Errno::EFAULT)?;
+                let linkpath_cstr = linkpath.to_cstring().ok_or(Errno::EFAULT)?;
+                syscall!(sys_symlinkat(target_cstr, newdirfd, linkpath_cstr))
+            }
             SyscallRequest::Stat { pathname, buf } => {
                 pathname.to_cstring().map_or(Err(Errno::EFAULT), |path| {
                     self.sys_stat(path).and_then(|stat| {


### PR DESCRIPTION
## Summary

This PR adds support for the `symlink(2)` and `symlinkat(2)` Linux syscalls.

## Changes

### Syscall Parsing (litebox_common_linux)
- Added `Symlinkat` variant to `SyscallRequest` enum
- Added syscall number parsing for `Sysno::symlink` and `Sysno::symlinkat`
- Added `From<SymlinkError>` and `From<ReadlinkError>` for `Errno` conversions

### Filesystem Layer (litebox/src/fs)
- Added `SymlinkError` and `ReadlinkError` error types in `errors.rs`
- Added `FileType::SymbolicLink` variant to `FileType` enum
- Added `symlink()` and `readlink()` methods to `FileSystem` trait
- Implemented in all filesystems:
  - `in_mem.rs`: Full implementation with `Entry::Symlink` and `SymlinkX` types
  - `layered.rs`: Delegates to upper/lower layers appropriately
  - `tar_ro.rs`: Returns `ReadOnlyFileSystem` for symlink, simplified readlink
  - `devices.rs`: Returns error (devices don't support symlinks)

### Syscall Handler (litebox_shim_linux)
- Added `sys_symlink()` and `sys_symlinkat()` methods to `Task`
- Updated `do_readlink()` to check filesystem for symlinks
- Added `SyscallRequest::Symlinkat` dispatch case in main handler

## Testing

- Added 7 unit tests for symlink functionality
- All 182 local tests pass

## Design Notes

Following POSIX/Linux semantics, symlink targets do NOT need to exist at creation time. The target path is validated only when the symlink is followed, not when it's created.
