### PR TITLE
Implement copy_file_range syscall

### DIFF
--- a/litebox_common_linux/src/lib.rs
+++ b/litebox_common_linux/src/lib.rs
@@ -2261,6 +2261,14 @@ pub enum SyscallRequest<Platform: litebox::platform::RawPointerProvider> {
         new_value: Platform::RawConstPointer<ItimerVal>,
         old_value: Option<Platform::RawMutPointer<ItimerVal>>,
     },
+    CopyFileRange {
+        fd_in: i32,
+        off_in: Option<Platform::RawMutPointer<i64>>,
+        fd_out: i32,
+        off_out: Option<Platform::RawMutPointer<i64>>,
+        len: usize,
+        flags: u32,
+    },
 }
 
 impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
@@ -2800,6 +2808,14 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
             Sysno::umask => sys_req!(Umask { mask }),
             Sysno::alarm => sys_req!(Alarm { seconds }),
             Sysno::setitimer => sys_req!(SetITimer { which:?, new_value:*, old_value:* }),
+            Sysno::copy_file_range => SyscallRequest::CopyFileRange {
+                fd_in: ctx.sys_req_arg(0),
+                off_in: ctx.sys_req_ptr(1),
+                fd_out: ctx.sys_req_arg(2),
+                off_out: ctx.sys_req_ptr(3),
+                len: ctx.sys_req_arg(4),
+                flags: ctx.sys_req_arg(5),
+            },
             // Noisy unsupported syscalls.
             Sysno::statx | Sysno::io_uring_setup | Sysno::rseq | Sysno::statfs => {
                 return Err(errno::Errno::ENOSYS);

--- a/litebox_shim_linux/src/lib.rs
+++ b/litebox_shim_linux/src/lib.rs
@@ -1130,6 +1130,16 @@ impl Task {
             SyscallRequest::Tkill { tid, sig } => self.sys_tkill(tid, sig),
             SyscallRequest::Tgkill { tgid, tid, sig } => self.sys_tgkill(tgid, tid, sig),
             SyscallRequest::Sigaltstack { ss, old_ss } => self.sys_sigaltstack(ss, old_ss, ctx),
+            SyscallRequest::CopyFileRange {
+                fd_in,
+                off_in,
+                fd_out,
+                off_out,
+                len,
+                flags,
+            } => syscall!(sys_copy_file_range(
+                fd_in, off_in, fd_out, off_out, len, flags
+            )),
             _ => {
                 log_unsupported!("{request:?}");
                 Err(Errno::ENOSYS)


### PR DESCRIPTION
## Summary
This PR adds support for the `copy_file_range` syscall (syscall number 326 on x86_64, 377 on x86).

## Changes

### litebox_common_linux
- Added `CopyFileRange` variant to `SyscallRequest` enum
- Added syscall parsing for `copy_file_range`

### litebox_shim_linux  
- Added syscall dispatch case for `CopyFileRange`
- Implemented `sys_copy_file_range()` method with full semantics:
  - Uses 4KB intermediate buffer for copying (matching sendfile pattern)
  - Supports explicit offset pointers and file position updates  
  - Validates fd_in != fd_out for overlapping range checks
  - Handles partial reads/writes correctly
  - Returns appropriate error codes (EINVAL, EBADF, EFAULT, etc.)
  - Maximum transfer size limited to 0x7ffff000 bytes (Linux MAX_RW_COUNT)

### Tests
Added 6 unit tests:
- `test_copy_file_range_basic`: Basic file copy
- `test_copy_file_range_partial`: Partial copy with limited count  
- `test_copy_file_range_with_offsets`: Explicit offset pointer handling
- `test_copy_file_range_invalid_fd`: EBADF error handling
- `test_copy_file_range_invalid_flags`: EINVAL for non-zero flags
- `test_copy_file_range_zero_len`: Zero-length copy (noop)

## Linux man page
https://man7.org/linux/man-pages/man2/copy_file_range.2.html

## References
- Linux kernel implementation: fs/read_write.c
- Asterinas implementation for reference patterns