### PR TITLE
Fix sigreturn for x86

### DIFF
--- a/litebox_shim_linux/src/syscalls/signal/mod.rs
+++ b/litebox_shim_linux/src/syscalls/signal/mod.rs
@@ -355,7 +355,7 @@ impl SignalState {
             sp
         };
 
-        let frame_addr = arch::get_signal_frame(sp, action).ok_or(DeliverFault)?;
+        let frame_addr = arch::get_signal_frame(sp, action);
 
         if (switch_stacks || on_alt_stack) && !is_on_stack(&altstack, frame_addr) {
             return Err(DeliverFault);

--- a/litebox_shim_linux/src/syscalls/signal/x86.rs
+++ b/litebox_shim_linux/src/syscalls/signal/x86.rs
@@ -69,21 +69,21 @@ pub(super) fn sp(ctx: &PtRegs) -> usize {
     ctx.esp
 }
 
-pub(super) fn get_signal_frame(sp: usize, action: &SigAction) -> Option<usize> {
+pub(super) fn get_signal_frame(sp: usize, action: &SigAction) -> usize {
     let mut frame_addr = sp;
 
     // Space for the signal frame.
     if action.flags.contains(SaFlags::SIGINFO) {
-        frame_addr = frame_addr.checked_sub(core::mem::size_of::<SignalFrameRt>())?;
+        frame_addr = frame_addr.wrapping_sub(core::mem::size_of::<SignalFrameRt>());
     } else {
-        frame_addr = frame_addr.checked_sub(core::mem::size_of::<SignalFrame>())?;
+        frame_addr = frame_addr.wrapping_sub(core::mem::size_of::<SignalFrame>());
     }
 
     // Align the frame (offset by 4 bytes for return address).
     frame_addr &= !15;
-    frame_addr = frame_addr.checked_sub(4)?;
+    frame_addr = frame_addr.wrapping_sub(4);
 
-    Some(frame_addr)
+    frame_addr
 }
 
 impl SignalState {

--- a/litebox_shim_linux/src/syscalls/signal/x86_64.rs
+++ b/litebox_shim_linux/src/syscalls/signal/x86_64.rs
@@ -28,20 +28,20 @@ pub(super) fn sp(ctx: &PtRegs) -> usize {
     ctx.rsp
 }
 
-pub(super) fn get_signal_frame(sp: usize, _action: &SigAction) -> Option<usize> {
+pub(super) fn get_signal_frame(sp: usize, _action: &SigAction) -> usize {
     let mut frame_addr = sp;
 
     // Skip the redzone.
-    frame_addr = frame_addr.checked_sub(128)?;
+    frame_addr = frame_addr.wrapping_sub(128);
 
     // Space for the signal frame.
-    frame_addr = frame_addr.checked_sub(core::mem::size_of::<SignalFrame>())?;
+    frame_addr = frame_addr.wrapping_sub(core::mem::size_of::<SignalFrame>());
 
     // Align the frame (offset by 8 bytes for return address)
     frame_addr &= !15;
-    frame_addr = frame_addr.checked_sub(8)?;
+    frame_addr = frame_addr.wrapping_sub(8);
 
-    Some(frame_addr)
+    frame_addr
 }
 
 impl SignalState {


### PR DESCRIPTION
According to [Linux](https://elixir.bootlin.com/linux/v5.19.17/source/arch/x86/kernel/signal.c#L633), `esp - 8` should point to `SignalFrame` instead of `LegacyContext`. We could also remove the ` - 8` and following `wrapping_add` directly but keep it just to be consistent with Linux.

There are some potential overflow issues where we perform some arithmetic operations on user provided input. We should always use `checked_*` or `wrapping_*`. There are likely more similar issues in the codebase, and this PR only fixes the ones related to `sigreturn`.