### PR TITLE
Fix: Simplify Shim's ContinueOperation

### DIFF
--- a/litebox/src/shim.rs
+++ b/litebox/src/shim.rs
@@ -85,32 +85,17 @@ pub trait EnterShim {
     /// By default, this implementation just exits the thread because `reenter` is
     /// not supported by all shims.
     fn reenter(&self, _ctx: &mut Self::ExecutionContext) -> ContinueOperation {
-        ContinueOperation::ExitThread
+        ContinueOperation::Terminate
     }
 }
 
 /// The operation to perform after returning from a shim handler
-///
-/// - `ResumeGuest` and `ExitThread` cover the cases where the platform enters the shim
-///   in response to events that occur during guest execution (e.g., a syscall).
-/// - `ResumeKernelPlatform` and `ExceptionFixup` cover the cases where the **kernel platform**
-///   enters the shim in response to events that occur during platform execution
-///   (e.g., a user-space page fault triggered by a syscall handler).
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum ContinueOperation {
-    /// Resume execution of the guest.
-    ResumeGuest,
-    /// Exit the current thread.
-    ExitThread,
-    /// The shim successfully handled an exception which was triggered by
-    /// the kernel platform (e.g., a syscall handler's copy_from_user against
-    /// demand-pageable user memory); Resume the kernel platform's execution.
-    ResumeKernelPlatform,
-    /// The shim failed to handle the exception (e.g., invalid memory access).
-    /// The kernel platform will apply a fixup via
-    /// [`search_exception_tables`](crate::mm::exception_table::search_exception_tables)
-    /// if one exists.
-    ExceptionFixup,
+    /// Resume the interrupted execution.
+    Resume,
+    /// Terminate the interrupted execution.
+    Terminate,
 }
 
 /// Information about a hardware exception.

--- a/litebox_platform_linux_kernel/src/host/snp/snp_impl.rs
+++ b/litebox_platform_linux_kernel/src/host/snp/snp_impl.rs
@@ -196,14 +196,8 @@ pub unsafe fn run_thread(
 
     let shim = tls.shim.get().unwrap().as_ref();
     match shim.init(regs) {
-        litebox::shim::ContinueOperation::ResumeGuest => unsafe { crate::switch_to_guest(regs) },
-        litebox::shim::ContinueOperation::ExitThread => exit_thread(),
-        litebox::shim::ContinueOperation::ResumeKernelPlatform => {
-            panic!("ResumeKernelPlatform not expected in SNP init")
-        }
-        litebox::shim::ContinueOperation::ExceptionFixup => {
-            panic!("ExceptionFixup not expected in SNP init")
-        }
+        litebox::shim::ContinueOperation::Resume => unsafe { crate::switch_to_guest(regs) },
+        litebox::shim::ContinueOperation::Terminate => exit_thread(),
     }
 }
 
@@ -227,14 +221,8 @@ fn exit_thread() -> ! {
 pub fn handle_syscall(pt_regs: &mut litebox_common_linux::PtRegs) -> ! {
     let tls = unsafe { &*get_tls() };
     match tls.shim.get().unwrap().syscall(pt_regs) {
-        litebox::shim::ContinueOperation::ResumeGuest => unsafe { crate::switch_to_guest(pt_regs) },
-        litebox::shim::ContinueOperation::ExitThread => exit_thread(),
-        litebox::shim::ContinueOperation::ResumeKernelPlatform => {
-            panic!("ResumeKernelPlatform not expected in SNP syscall")
-        }
-        litebox::shim::ContinueOperation::ExceptionFixup => {
-            panic!("ExceptionFixup not expected in SNP syscall")
-        }
+        litebox::shim::ContinueOperation::Resume => unsafe { crate::switch_to_guest(pt_regs) },
+        litebox::shim::ContinueOperation::Terminate => exit_thread(),
     }
 }
 

--- a/litebox_platform_linux_userland/src/lib.rs
+++ b/litebox_platform_linux_userland/src/lib.rs
@@ -1631,14 +1631,8 @@ impl ThreadContext<'_> {
         }
         let op = f(self.shim, self.ctx);
         match op {
-            ContinueOperation::ResumeGuest => unsafe { switch_to_guest(self.ctx) },
-            ContinueOperation::ExitThread => {}
-            ContinueOperation::ResumeKernelPlatform => {
-                panic!("ResumeKernelPlatform not expected in linux_userland")
-            }
-            ContinueOperation::ExceptionFixup => {
-                panic!("ExceptionFixup not expected in linux_userland")
-            }
+            ContinueOperation::Resume => unsafe { switch_to_guest(self.ctx) },
+            ContinueOperation::Terminate => {}
         }
     }
 }

--- a/litebox_platform_windows_userland/src/lib.rs
+++ b/litebox_platform_windows_userland/src/lib.rs
@@ -1726,7 +1726,7 @@ unsafe extern "C-unwind" fn interrupt_handler(thread_ctx: &mut ThreadContext<'_>
         } else {
             // We likely got here just to restore fsbase, so don't bother the
             // shim.
-            ContinueOperation::ResumeGuest
+            ContinueOperation::Resume
         }
     });
 }
@@ -1752,14 +1752,8 @@ impl ThreadContext<'_> {
         // before returning.
         let op = f(self.shim, self.ctx, self.tls.interrupt.replace(false));
         match op {
-            ContinueOperation::ResumeGuest => unsafe { switch_to_guest(self.ctx) },
-            ContinueOperation::ExitThread => {}
-            ContinueOperation::ResumeKernelPlatform => {
-                panic!("ResumeKernelPlatform not expected in windows_userland")
-            }
-            ContinueOperation::ExceptionFixup => {
-                panic!("ExceptionFixup not expected in windows_userland")
-            }
+            ContinueOperation::Resume => unsafe { switch_to_guest(self.ctx) },
+            ContinueOperation::Terminate => {}
         }
     }
 }

--- a/litebox_shim_linux/src/lib.rs
+++ b/litebox_shim_linux/src/lib.rs
@@ -107,9 +107,9 @@ impl<FS: ShimFS> litebox::shim::EnterShim for LinuxShimEntrypoints<FS> {
             }
             .is_ok()
             {
-                return ContinueOperation::ResumeKernelPlatform;
+                return ContinueOperation::Resume;
             } else {
-                return ContinueOperation::ExceptionFixup;
+                return ContinueOperation::Terminate;
             }
         }
         self.enter_shim(false, ctx, |task, _ctx| task.handle_exception_request(info))
@@ -132,9 +132,9 @@ impl<FS: ShimFS> LinuxShimEntrypoints<FS> {
         }
         f(&self.task, ctx);
         if self.task.prepare_to_run_guest(ctx) {
-            ContinueOperation::ResumeGuest
+            ContinueOperation::Resume
         } else {
-            ContinueOperation::ExitThread
+            ContinueOperation::Terminate
         }
     }
 }


### PR DESCRIPTION
This PR simplifies Shim's `ContinueOperation`, resolving #667.

Since the caller works with a specific handler (syscall or exception) and its execution mode (guest or kernel), the caller does not need to fully rely on `ContinueOperation` to determine its next operation.