### PR TITLE
LVBS: Use VP index and separate CPU entry points

### DIFF
--- a/dev_tests/src/ratchet.rs
+++ b/dev_tests/src/ratchet.rs
@@ -37,7 +37,7 @@ fn ratchet_globals() -> Result<()> {
             ("litebox/", 9),
             ("litebox_platform_linux_kernel/", 6),
             ("litebox_platform_linux_userland/", 5),
-            ("litebox_platform_lvbs/", 20),
+            ("litebox_platform_lvbs/", 21),
             ("litebox_platform_multiplex/", 1),
             ("litebox_platform_windows_userland/", 7),
             ("litebox_runner_linux_userland/", 1),

--- a/litebox_platform_lvbs/src/mshv/hvcall.rs
+++ b/litebox_platform_lvbs/src/mshv/hvcall.rs
@@ -5,8 +5,8 @@
 
 use crate::{
     arch::{
-        get_core_id,
         instrs::{rdmsr, wrmsr},
+        is_bsp,
     },
     debug_serial_println,
     host::{hv_hypercall_page_address, per_cpu_variables::with_per_cpu_variables},
@@ -110,7 +110,7 @@ pub fn init() -> Result<(), HypervError> {
     if guest_id != rdmsr(HV_X64_MSR_GUEST_OS_ID) {
         return Err(HypervError::InvalidGuestOSID);
     }
-    if get_core_id() == 0 {
+    if is_bsp() {
         debug_serial_println!(
             "HV_X64_MSR_GUEST_OS_ID: {:#x}",
             rdmsr(HV_X64_MSR_GUEST_OS_ID)
@@ -148,7 +148,7 @@ pub fn init() -> Result<(), HypervError> {
     sint.set_auto_eoi(true);
 
     wrmsr(HV_X64_MSR_SINT0, sint.as_uint64());
-    if get_core_id() == 0 {
+    if is_bsp() {
         debug_serial_println!("HV_X64_MSR_SINT0: {:#x}", rdmsr(HV_X64_MSR_SINT0));
     }
 

--- a/litebox_runner_lvbs/src/lib.rs
+++ b/litebox_runner_lvbs/src/lib.rs
@@ -20,7 +20,7 @@ use litebox_common_optee::{
     OpteeSmcReturnCode, TeeOrigin, TeeResult, UteeEntryFunc, UteeParams, optee_msg_args_total_size,
 };
 use litebox_platform_lvbs::{
-    arch::{gdt, get_core_id, instrs::hlt_loop, interrupts},
+    arch::{gdt, instrs::hlt_loop, interrupts, is_bsp},
     debug_serial_println,
     host::{bootparam::get_vtl1_memory_info, per_cpu_variables::allocate_per_cpu_variables},
     mm::MemoryProvider,
@@ -53,7 +53,7 @@ use spin::mutex::SpinMutex;
 pub fn init() -> Option<&'static Platform> {
     let mut ret: Option<&'static Platform> = None;
 
-    if get_core_id() == 0 {
+    if is_bsp() {
         if let Ok((start, size)) = get_vtl1_memory_info() {
             let vtl1_start = x86_64::PhysAddr::new(start);
             let vtl1_end = x86_64::PhysAddr::new(start + size);


### PR DESCRIPTION
This PR make LVBS use VP index instead of CPUID-based APIC ID. This is needed to run LVBS on NUMA machines.