### PR TITLE
Fix integer overflow panics on guest-derived usize arithmetic (#3)

### DIFF
--- a/litebox_shim_linux/src/syscalls/mm.rs
+++ b/litebox_shim_linux/src/syscalls/mm.rs
@@ -17,7 +17,7 @@ use crate::Task;
 #[inline]
 fn align_up(addr: usize, align: usize) -> usize {
     debug_assert!(align.is_power_of_two());
-    (addr + align - 1) & !(align - 1)
+    addr.wrapping_add(align - 1) & !(align - 1)
 }
 
 #[expect(

--- a/litebox_shim_optee/src/syscalls/ldelf.rs
+++ b/litebox_shim_optee/src/syscalls/ldelf.rs
@@ -52,8 +52,8 @@ impl Task {
         let total_size = num_bytes
             .checked_add(pad_begin)
             .and_then(|t| t.checked_add(pad_end))
-            .ok_or(TeeResult::BadParameters)?
-            .next_multiple_of(PAGE_SIZE);
+            .and_then(|t| t.checked_next_multiple_of(PAGE_SIZE))
+            .ok_or(TeeResult::BadParameters)?;
         if addr.checked_add(total_size).is_none() {
             return Err(TeeResult::BadParameters);
         }
@@ -178,8 +178,8 @@ impl Task {
         let total_size = num_bytes
             .checked_add(pad_begin)
             .and_then(|t| t.checked_add(pad_end))
-            .ok_or(TeeResult::BadParameters)?
-            .next_multiple_of(PAGE_SIZE);
+            .and_then(|t| t.checked_next_multiple_of(PAGE_SIZE))
+            .ok_or(TeeResult::BadParameters)?;
         if addr.checked_add(total_size).is_none() {
             return Err(TeeResult::BadParameters);
         }


### PR DESCRIPTION
Fix integer overflow vulnerabilities in guest-derived arithmetic.

As mentioned in #668, I created an agentic workflow to scan the codebase to find and fix all potential integer overflows on a daily basis (see https://github.com/CvvT/litebox/actions/workflows/integer-overflow-scanner.lock.yml). So far it has submitted 3 issues and this PR fixes one of them. I have reviewed this one. This is a trivial PR as replacing existing `+` with `wrapping_add` is safe (in most if not all cases).