### PR TITLE
Fix suseconds_t type signedness for Linux ABI compatibility

### DIFF
--- a/litebox_common_linux/src/lib.rs
+++ b/litebox_common_linux/src/lib.rs
@@ -771,10 +771,10 @@ pub struct Ucred {
 cfg_if::cfg_if! {
     if #[cfg(all(target_arch = "x86"))] {
         pub type time_t = i32;
-        pub type suseconds_t = u32;
+        pub type suseconds_t = i32;
     } else if #[cfg(all(target_arch = "x86_64"))] {
         pub type time_t = i64;
-        pub type suseconds_t = u64;
+        pub type suseconds_t = i64;
     } else {
         compile_error!("Unsupported architecture");
     }


### PR DESCRIPTION
## Summary
Fix `suseconds_t` type to be signed (`i32`/`i64`) instead of unsigned (`u32`/`u64`) to match Linux kernel ABI.

## Changes
- Change `suseconds_t` from `u32` to `i32` on x86
- Change `suseconds_t` from `u64` to `i64` on x86_64

Fixes #608