### PR TITLE
Updates for Rust 1.94

### DIFF
--- a/litebox_platform_linux_userland/src/lib.rs
+++ b/litebox_platform_linux_userland/src/lib.rs
@@ -1314,7 +1314,7 @@ fn futex_timeout(
     timeout: Option<Duration>,
     uaddr2: Option<&AtomicU32>,
 ) -> Result<usize, syscalls::Errno> {
-    let uaddr: *const AtomicU32 = uaddr as _;
+    let uaddr: *const AtomicU32 = std::ptr::from_ref(uaddr);
     let futex_op: i32 = futex_op as _;
     let timeout = timeout.map(|t| {
         const TEN_POWER_NINE: u128 = 1_000_000_000;
@@ -1368,7 +1368,7 @@ fn futex_val2(
     val2: u32,
     uaddr2: Option<&AtomicU32>,
 ) -> Result<usize, syscalls::Errno> {
-    let uaddr: *const AtomicU32 = uaddr as _;
+    let uaddr: *const AtomicU32 = std::ptr::from_ref(uaddr);
     let futex_op: i32 = futex_op as _;
     let uaddr2: *const AtomicU32 = uaddr2.map_or(std::ptr::null(), |u| u);
     unsafe {
@@ -2011,7 +2011,7 @@ fn signal_handler_exit_guest(
             guest_context_top = out(reg) guest_context_top,
             options(nostack, preserves_flags)
         };
-        Some(guest_context_top.offset(-1))
+        Some(guest_context_top.sub(1))
     }
 }
 

--- a/litebox_platform_lvbs/src/arch/x86/mod.rs
+++ b/litebox_platform_lvbs/src/arch/x86/mod.rs
@@ -26,6 +26,10 @@ pub(crate) use x86_64::structures::paging::mapper::{MappedFrame, TranslateResult
 pub fn get_core_id() -> usize {
     const CPU_VERSION_INFO: u32 = 1;
 
+    #[allow(
+        unused_unsafe,
+        reason = "cpuid_count is safe on stable 1.94+ but unsafe on nightly 1.91"
+    )]
     let result = unsafe { cpuid_count(CPU_VERSION_INFO, 0x0) };
     let apic_id = (result.ebx >> 24) & 0xff;
 
@@ -100,6 +104,10 @@ pub fn write_kernel_gsbase_msr(addr: VirtAddr) {
 #[cfg(target_arch = "x86_64")]
 pub fn enable_dep() {
     // CPUID.80000001h:EDX bit 20 = NX support
+    #[allow(
+        unused_unsafe,
+        reason = "cpuid_count is safe on stable 1.94+ but unsafe on nightly 1.91"
+    )]
     let ext_features = unsafe { cpuid_count(0x8000_0001, 0) };
     assert!(
         ext_features.edx & (1 << 20) != 0,
@@ -127,6 +135,10 @@ pub fn enable_dep() {
 #[cfg(target_arch = "x86_64")]
 pub fn enable_smep_smap() {
     // CPUID.07h:EBX bit 7 = SMEP, bit 20 = SMAP
+    #[allow(
+        unused_unsafe,
+        reason = "cpuid_count is safe on stable 1.94+ but unsafe on nightly 1.91"
+    )]
     let structured_features = unsafe { cpuid_count(0x07, 0) };
     assert!(
         structured_features.ebx & (1 << 7) != 0,

--- a/litebox_platform_lvbs/src/mshv/hvcall.rs
+++ b/litebox_platform_lvbs/src/mshv/hvcall.rs
@@ -56,16 +56,28 @@ fn generate_guest_id(dinfo1: u64, kernver: u64, dinfo2: u64) -> u64 {
 fn check_hyperv() -> Result<(), HypervError> {
     use core::arch::x86_64::__cpuid_count as cpuid_count;
 
+    #[allow(
+        unused_unsafe,
+        reason = "cpuid_count is safe on stable 1.94+ but unsafe on nightly 1.91"
+    )]
     let result = unsafe { cpuid_count(CPU_VERSION_INFO, 0x0) };
     if result.ecx & HYPERV_HYPERVISOR_PRESENT_BIT == 0 {
         return Err(HypervError::NonVirtualized);
     }
 
+    #[allow(
+        unused_unsafe,
+        reason = "cpuid_count is safe on stable 1.94+ but unsafe on nightly 1.91"
+    )]
     let result = unsafe { cpuid_count(HYPERV_CPUID_INTERFACE, 0x0) };
     if result.eax != HV_CPUID_SIGNATURE_EAX {
         return Err(HypervError::NonHyperv);
     }
 
+    #[allow(
+        unused_unsafe,
+        reason = "cpuid_count is safe on stable 1.94+ but unsafe on nightly 1.91"
+    )]
     let result = unsafe { cpuid_count(HYPERV_CPUID_VENDOR_AND_MAX_FUNCTIONS, 0x0) };
     if result.eax < HYPERV_CPUID_IMPLEMENT_LIMITS {
         return Err(HypervError::NoVTLSupport);


### PR DESCRIPTION
[Rust 1.94.0 released today](https://blog.rust-lang.org/2026/03/05/Rust-1.94.0/).  This PR makes some necessary updates due to newly-triggered warnings.