### PR TITLE
LVBS: Fix intermittent release-build crash caused by stale `cur_kernel_sp` dereference

### DIFF
--- a/litebox_platform_lvbs/src/host/bootparam.rs
+++ b/litebox_platform_lvbs/src/host/bootparam.rs
@@ -3,15 +3,15 @@
 
 //! VTL1 kernel boot parameters (compatible with Linux kernel's boot_params structure and command line)
 
-use crate::{
-    debug_serial_println,
-    mshv::vtl1_mem_layout::{
-        VTL1_BOOT_PARAMS_PAGE, VTL1_CMDLINE_PAGE, VtlMemoryError, get_address_of_special_page,
-    },
+use crate::mshv::vtl1_mem_layout::{
+    VTL1_BOOT_PARAMS_PAGE, VTL1_CMDLINE_PAGE, VtlMemoryError, get_address_of_special_page,
 };
 use core::ffi::{CStr, c_char};
 use num_enum::TryFromPrimitive;
 use spin::Once;
+
+#[cfg(debug_assertions)]
+use crate::debug_serial_println;
 
 // This module defines a simplified Linux boot params structure
 // (based on arch/x86/include/uapi/asm/bootparam.h and
@@ -120,7 +120,7 @@ fn dump_cmdline() {
     }
 
     if let Some(cmdline_str) = unsafe { CStr::from_ptr(cmdline).to_str().ok() } {
-        debug_serial_println!("{}", cmdline_str);
+        crate::debug_serial_println!("{}", cmdline_str);
     }
 }
 

--- a/litebox_platform_lvbs/src/host/per_cpu_variables.rs
+++ b/litebox_platform_lvbs/src/host/per_cpu_variables.rs
@@ -20,7 +20,7 @@ use x86_64::VirtAddr;
 
 pub const DOUBLE_FAULT_STACK_SIZE: usize = 2 * PAGE_SIZE;
 pub const EXCEPTION_STACK_SIZE: usize = PAGE_SIZE;
-pub const KERNEL_STACK_SIZE: usize = 10 * PAGE_SIZE;
+pub const KERNEL_STACK_SIZE: usize = 32 * PAGE_SIZE;
 
 /// Per-CPU VTL1 kernel variables
 #[repr(C, align(4096))]
@@ -293,6 +293,10 @@ pub struct PerCpuVariablesAsm {
     vtl1_user_xsaved: Cell<u8>,
     /// Exception info: exception vector number
     exception_trapno: Cell<u8>,
+    /// Set to 1 while inside `run_thread_arch` where TA is running or
+    /// handling its syscalls/exceptions. Analogous to
+    /// `is_in_guest` on the userland platforms.
+    is_in_user: Cell<u8>,
 }
 
 impl PerCpuVariablesAsm {
@@ -395,6 +399,9 @@ impl PerCpuVariablesAsm {
     }
     pub const fn exception_trapno_offset() -> usize {
         offset_of!(PerCpuVariablesAsm, exception_trapno)
+    }
+    pub const fn is_in_user_offset() -> usize {
+        offset_of!(PerCpuVariablesAsm, is_in_user)
     }
     pub fn get_exception(&self) -> litebox::shim::Exception {
         litebox::shim::Exception(self.exception_trapno.get())

--- a/litebox_platform_lvbs/src/lib.rs
+++ b/litebox_platform_lvbs/src/lib.rs
@@ -434,17 +434,22 @@ impl litebox::platform::common_providers::userspace_pointers::ValidateAccess
     #[inline]
     fn with_user_memory_access<R>(f: impl FnOnce() -> R) -> R {
         // STAC: Set AC flag to temporarily allow supervisor access to user pages.
-        // Safety: STAC is a privileged instruction that only modifies the AC flag
+        // Safety: STAC is a privileged instruction that modifies the AC flag
         // in RFLAGS. It has no side effects beyond enabling SMAP bypass.
+        //
+        // Note:
+        // - `preserves_flags` is omitted because STAC modifies RFLAGS.AC.
+        // - `nomem` is omitted. to prevent reordering across the SMAP boundary.
         unsafe {
-            core::arch::asm!("stac", options(nomem, nostack, preserves_flags));
+            core::arch::asm!("stac", options(nostack));
         }
         let result = f();
         // CLAC: Clear AC flag to re-enable SMAP protection.
-        // Safety: CLAC is a privileged instruction that only modifies the AC flag
+        // Safety: CLAC is a privileged instruction that modifies the AC flag
         // in RFLAGS. It has no side effects beyond re-enabling SMAP enforcement.
+        // Note: `preserves_flags` and `nomem` are intentionally omitted.
         unsafe {
-            core::arch::asm!("clac", options(nomem, nostack, preserves_flags));
+            core::arch::asm!("clac", options(nostack));
         }
         result
     }
@@ -1900,6 +1905,9 @@ unsafe extern "C" fn run_thread_arch(
         "mov gs:[{cur_kernel_bp_off}], rbp",
         "lea r8, [rsi + {USER_CONTEXT_SIZE}]",
         "mov gs:[{user_context_top_off}], r8",
+        // Mark that we are inside a user/TA context so that
+        // kernel_exception_callback knows a valid ThreadContext exists.
+        "mov byte ptr gs:[{is_in_user_off}], 1",
         // Call init_handler or reenter_handler based on reenter flag (in dl)
         "test r9b, r9b",
         "jnz 1f",
@@ -1963,14 +1971,30 @@ unsafe extern "C" fn run_thread_arch(
         SAVE_CPU_CONTEXT_ASM!(),
         "mov rbp, rsp",
         "and rsp, -16",
-        // Pass exception info via registers (SysV ABI args 1-5)
+        // Check if we are inside a user/TA context (is_in_user flag).
+        // When is_in_user is set, a valid ThreadContext exists on the
+        // kernel stack at [gs:cur_kernel_sp] and we can attempt demand
+        // paging through the shim.  When clear, the page fault occurred
+        // outside run_thread_arch and only exception-table fixup is available.
+        "cmp byte ptr gs:[{is_in_user_off}], 0",
+        "je 6f",
+        // In-user path: load ThreadContext and call full exception_handler.
         "mov rdi, gs:[{cur_kernel_sp_off}]",
+        // Pass exception info via registers (SysV ABI args 1-5)
         "mov rdi, [rdi]",                   // arg1: thread_ctx
         "mov esi, 1",                       // arg2: kernel_mode = true
         "mov rdx, cr2",                     // arg3: cr2 (fault address)
         "mov ecx, [rbp + 120]",             // arg4: error_code (orig_rax slot)
         "mov r8, [rbp + 128]",              // arg5: faulting RIP (iret frame)
         "call {exception_handler}",
+        "jmp 7f",
+        // No thread context: only exception table fixup is possible.
+        "6:",
+        "mov rdi, cr2",                     // arg1: cr2
+        "mov esi, [rbp + 120]",             // arg2: error_code
+        "mov rdx, [rbp + 128]",             // arg3: faulting RIP
+        "call {kernel_exception_handler_no_ctx}",
+        "7:",
         // If demand paging failed, rax contains the exception table fixup
         // address. Patch the saved RIP on the ISR stack so iretq resumes
         // at the fixup instead of re-faulting.
@@ -1985,8 +2009,14 @@ unsafe extern "C" fn run_thread_arch(
         "interrupt_callback:",
         "jmp done",
         "done:",
+        // We are leaving the user/TA context. Clear is_in_user first
+        // so that any kernel-mode page fault from this point on takes the
+        // exception-table-only path in kernel_exception_callback.
+        "mov byte ptr gs:[{is_in_user_off}], 0",
         "mov rbp, gs:[{cur_kernel_bp_off}]",
         "mov rsp, gs:[{cur_kernel_sp_off}]",
+        // Zero cur_kernel_sp as defence in depth
+        "mov qword ptr gs:[{cur_kernel_sp_off}], 0",
         XRSTOR_VTL1_ASM!({vtl1_kernel_xsave_area_off}, {vtl1_xsave_mask_lo_off}, {vtl1_xsave_mask_hi_off}, {vtl1_kernel_xsaved_off}),
         RESTORE_CALLEE_SAVED_REGISTERS_ASM!(),
         "ret",
@@ -2002,10 +2032,12 @@ unsafe extern "C" fn run_thread_arch(
         USER_CONTEXT_SIZE = const core::mem::size_of::<litebox_common_linux::PtRegs>(),
         scratch_off = const { PerCpuVariablesAsm::scratch_offset() },
         exception_trapno_off = const { PerCpuVariablesAsm::exception_trapno_offset() },
+        is_in_user_off = const { PerCpuVariablesAsm::is_in_user_offset() },
         init_handler = sym init_handler,
         reenter_handler = sym reenter_handler,
         syscall_handler = sym syscall_handler,
         exception_handler = sym exception_handler,
+        kernel_exception_handler_no_ctx = sym kernel_exception_handler_no_ctx,
     );
 }
 
@@ -2033,6 +2065,29 @@ unsafe extern "C" fn syscall_handler(thread_ctx: &mut ThreadContext) {
         ContinueOperation::Resume => unsafe { switch_to_user(thread_ctx.ctx) },
         ContinueOperation::Terminate => {}
     }
+}
+
+/// Handles a kernel-mode page fault that occurs outside `run_thread_arch`
+/// (i.e., when `cur_kernel_sp` is zero). Without a valid `ThreadContext`
+/// we cannot call into the shim for demand paging, so the only option is
+/// exception-table fixup (or panic).
+///
+/// Returns the fixup address on success (to be patched into the saved RIP)
+/// or panics if no fixup entry is found.
+unsafe extern "C" fn kernel_exception_handler_no_ctx(
+    cr2: usize,
+    error_code: usize,
+    faulting_rip: usize,
+) -> usize {
+    litebox::mm::exception_table::search_exception_tables(faulting_rip).unwrap_or_else(|| {
+        panic!(
+            "EXCEPTION: PAGE FAULT outside run_thread_arch (no ThreadContext)\n\
+             Accessed Address: {:#x}\n\
+             Error Code: {:#x}\n\
+             Faulting RIP: {:#x}",
+            cr2, error_code, faulting_rip,
+        )
+    })
 }
 
 /// Handles exceptions and routes to the shim's exception handler via `call_shim`.

--- a/litebox_platform_lvbs/src/mshv/hvcall.rs
+++ b/litebox_platform_lvbs/src/mshv/hvcall.rs
@@ -204,7 +204,13 @@ pub fn hv_do_hypercall(
         asm!(
             "call rax",
             in("rax") hv_hypercall_page_address(), in("rcx") control, in("rdx") input_gpa,
-            in("r8") output_gpa, lateout("rax") status, options(nostack)
+            in("r8") output_gpa, lateout("rax") status,
+            // call rax uses the stack (pushes return address), so nostack must NOT be used.
+            // The hypercall page follows Windows x64 ABI: r9, r10, r11, and xmm0-xmm5
+            // are volatile (caller-saved), and flags are clobbered by the call.
+            out("r9") _, out("r10") _, out("r11") _,
+            out("xmm0") _, out("xmm1") _, out("xmm2") _,
+            out("xmm3") _, out("xmm4") _, out("xmm5") _,
         );
     }
 

--- a/litebox_platform_lvbs/src/mshv/mem_integrity.rs
+++ b/litebox_platform_lvbs/src/mshv/mem_integrity.rs
@@ -4,7 +4,6 @@
 //! Functions for checking the memory integrity of VTL0 kernel image and modules
 
 use crate::{
-    debug_serial_println,
     host::linux::ModuleSignature,
     mshv::{
         heki::{HekiPatch, POKE_MAX_OPCODE_SIZE},
@@ -38,6 +37,9 @@ use x509_cert::{
     der::{Decode, Encode, oid::ObjectIdentifier},
 };
 use zerocopy::FromBytes;
+
+#[cfg(debug_assertions)]
+use crate::debug_serial_println;
 
 /// This function validates the memory content of a loaded kernel module against the original ELF file.
 /// In particular, it checks whether the non-relocatable/patchable bytes of certain sections
@@ -115,7 +117,7 @@ pub fn validate_kernel_module_against_elf(
         )?;
 
         // load relocated/patched section
-        let section_in_memory = &section_memory_container[..];
+        let section_in_memory = &section_memory_container[..section_from_elf.len()];
 
         // check whether non-relocatable bytes are modified
         #[cfg(not(debug_assertions))]
@@ -124,7 +126,7 @@ pub fn validate_kernel_module_against_elf(
                 section_from_elf[reloc.clone()].copy_from_slice(&section_in_memory[reloc.clone()]);
             }
             if section_from_elf != section_in_memory {
-                debug_serial_println!(
+                crate::serial_println!(
                     "Found {} mismatches in {target_section_name}",
                     target_section_name
                 );

--- a/litebox_platform_lvbs/src/mshv/vsm.rs
+++ b/litebox_platform_lvbs/src/mshv/vsm.rs
@@ -7,7 +7,7 @@
 use crate::mshv::mem_integrity::parse_modinfo;
 use crate::mshv::ringbuffer::set_ringbuffer;
 use crate::{
-    debug_serial_print, debug_serial_println,
+    debug_serial_println,
     host::{
         bootparam::get_vtl1_memory_info,
         linux::{CpuMask, KEXEC_SEGMENT_MAX, Kimage},
@@ -126,11 +126,14 @@ pub fn mshv_vsm_boot_aps(cpu_online_mask_pfn: u64, boot_signal_pfn: u64) -> Resu
         return Err(VsmError::CpuOnlineMaskCopyFailed);
     };
 
-    debug_serial_print!("cpu_online_mask: ");
-    cpu_mask.for_each_cpu(|cpu_id| {
-        debug_serial_print!("{}, ", cpu_id);
-    });
-    debug_serial_println!("");
+    #[cfg(debug_assertions)]
+    {
+        crate::debug_serial_print!("cpu_online_mask: ");
+        cpu_mask.for_each_cpu(|cpu_id| {
+            crate::debug_serial_print!("{}, ", cpu_id);
+        });
+        debug_serial_println!("");
+    }
 
     // boot_signal is an array of bytes whose length is the number of possible cores. Copy the entire page for now.
     let Some(mut boot_signal_page_buf) = (unsafe {

--- a/litebox_platform_lvbs/src/mshv/vsm_intercept.rs
+++ b/litebox_platform_lvbs/src/mshv/vsm_intercept.rs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 
 use crate::{
-    debug_serial_println,
     host::per_cpu_variables::with_per_cpu_variables,
     mshv::{
         DEFAULT_REG_PIN_MASK, HV_REGISTER_PENDING_EVENT0, HV_X64_REGISTER_APIC_BASE,
@@ -10,10 +9,10 @@ use crate::{
         HV_X64_REGISTER_GDTR, HV_X64_REGISTER_IDTR, HV_X64_REGISTER_LDTR, HV_X64_REGISTER_LSTAR,
         HV_X64_REGISTER_RIP, HV_X64_REGISTER_SFMASK, HV_X64_REGISTER_STAR,
         HV_X64_REGISTER_SYSENTER_CS, HV_X64_REGISTER_SYSENTER_EIP, HV_X64_REGISTER_SYSENTER_ESP,
-        HV_X64_REGISTER_TR, HvInterceptMessage, HvInterceptMessageHeader, HvMemInterceptMessage,
-        HvMessageType, HvMsrInterceptMessage, HvPendingExceptionEvent, MSR_CSTAR, MSR_EFER,
-        MSR_IA32_APICBASE, MSR_IA32_SYSENTER_CS, MSR_IA32_SYSENTER_EIP, MSR_IA32_SYSENTER_ESP,
-        MSR_LSTAR, MSR_STAR, MSR_SYSCALL_MASK, X86Cr0Flags, X86Cr4Flags, hvcall::HypervCallError,
+        HV_X64_REGISTER_TR, HvInterceptMessage, HvInterceptMessageHeader, HvMessageType,
+        HvMsrInterceptMessage, HvPendingExceptionEvent, MSR_CSTAR, MSR_EFER, MSR_IA32_APICBASE,
+        MSR_IA32_SYSENTER_CS, MSR_IA32_SYSENTER_EIP, MSR_IA32_SYSENTER_ESP, MSR_LSTAR, MSR_STAR,
+        MSR_SYSCALL_MASK, X86Cr0Flags, X86Cr4Flags, hvcall::HypervCallError,
         hvcall_vp::hvcall_set_vp_vtl0_registers,
     },
 };
@@ -61,13 +60,16 @@ pub fn vsm_handle_intercept() {
 
     match HvMessageType::try_from(msg.header.message_type).unwrap() {
         HvMessageType::GpaIntercept => {
-            let int_msg = unsafe {
-                let ptr = core::ptr::addr_of!(msg.payload).cast::<HvMemInterceptMessage>();
-                &*ptr
-            };
-
-            let gpa = int_msg.gpa;
-            debug_serial_println!("VSM: GPA intercept on {gpa:#x}");
+            #[cfg(debug_assertions)]
+            {
+                let int_msg = unsafe {
+                    let ptr = core::ptr::addr_of!(msg.payload)
+                        .cast::<crate::mshv::HvMemInterceptMessage>();
+                    &*ptr
+                };
+                let gpa = int_msg.gpa;
+                crate::debug_serial_println!("VSM: GPA intercept on {gpa:#x}");
+            }
             raise_vtl0_gp_fault().expect("Failed to raise VTL0 GP fault on GPA intercept");
         }
         HvMessageType::MsrIntercept => {
@@ -137,8 +139,10 @@ pub fn vsm_handle_intercept() {
             }
         }
         _ => {
+            #[cfg(debug_assertions)]
             let msg_type = msg.header.message_type;
-            debug_serial_println!(
+            #[cfg(debug_assertions)]
+            crate::debug_serial_println!(
                 "VSM: Ignore unknown synthetic interrupt message type {msg_type:#x}"
             );
         }
@@ -180,7 +184,10 @@ fn validate_and_continue_vtl0_register_write(
             hvcall_set_vp_vtl0_registers(reg_name, value).expect("Failed to write VTL0 register");
             advance_vtl0_rip(int_msg_hdr).expect("Failed to advance VTL0 RIP");
         } else {
-            debug_serial_println!("VSM: Writing {value:#x} to reg {reg_name:#x} is disallowed");
+            #[cfg(debug_assertions)]
+            crate::debug_serial_println!(
+                "VSM: Writing {value:#x} to reg {reg_name:#x} is disallowed"
+            );
             raise_vtl0_gp_fault().expect("Failed to raise VTL0 GP fault");
         }
     } else {

--- a/litebox_shim_optee/src/syscalls/tee.rs
+++ b/litebox_shim_optee/src/syscalls/tee.rs
@@ -34,6 +34,7 @@ fn align_down(addr: usize, align: usize) -> usize {
 impl Task {
     /// A system call to return to the kernel. A TA calls this function when
     /// it finishes its job delivered through a TA command invocation.
+    #[allow(clippy::unused_self)]
     pub fn sys_return(&self, ret: usize) -> usize {
         #[cfg(debug_assertions)]
         litebox::log_println!(self.global.platform, "sys_return: ret {}", ret);


### PR DESCRIPTION
This PR fixes an intermittent release-build bug. Kernel-mode page faults occurring outside `run_thread_arch` would unconditionally dereference `cur_kernel_sp` to obtain a `ThreadContext`. In release builds, `cur_kernel_sp` retained a stale value from the last TA invocation, causing the exception handler to read invalid memory.

Introduce `is_in_user` per-CPU flag (like `is_in_guest` of userland platforms): A new byte field in `PerCpuVariablesAsm` is set to 1 on entry to `run_thread_arch` and cleared on exit. `kernel_exception_callback` checks this flag to do either demand paging via the shim or calling `kernel_exception_handler_no_ctx`.

Additionally, this PR corrects some inline assembly to ensure memory ordering and register clobbers and increase the kernel stack size (to satisfy release build's requirements).