### PR TITLE
fix: correct smoltcp time computation in Network::now()

### DIFF
--- a/litebox/src/net/mod.rs
+++ b/litebox/src/net/mod.rs
@@ -685,8 +685,10 @@ where
             // microseconds is roughly 250 years. If a system has been up for that long, then it
             // deserves to panic.
             i64::try_from(
-                self.zero_time
-                    .duration_since(&self.device.platform.now())
+                self.device
+                    .platform
+                    .now()
+                    .duration_since(&self.zero_time)
                     .as_micros(),
             )
             .unwrap(),


### PR DESCRIPTION
Swap the arguments in `Network::now()` from `zero_time.duration_since(now)` to `now.duration_since(zero_time)`. The reversed subtraction always returned `Duration::ZERO`, so smoltcp permanently saw time=0 and no timer-dependent TCP behavior (delayed ACKs, retransmits, keep-alives) ever fired.