### PR TITLE
Fix minor issues in network

### DIFF
--- a/litebox/src/net/mod.rs
+++ b/litebox/src/net/mod.rs
@@ -1004,10 +1004,10 @@ where
             Protocol::Raw { protocol: _ } => unimplemented!(),
         };
 
-        if ret.is_ok() {
-            if let Some(proxy) = &socket_handle.proxy {
-                proxy.set_state(socket_channel::SocketState::Connected);
-            }
+        if ret.is_ok()
+            && let Some(proxy) = &socket_handle.proxy
+        {
+            proxy.set_state(socket_channel::SocketState::Connected);
         }
         drop(table_entry);
         drop(descriptor_table);


### PR DESCRIPTION
As mentioned in the [comment](https://github.com/microsoft/litebox/pull/713#issuecomment-4041164086), copilot found two more issues:

1. only set proxy state to `Connected` on successful `connect()`
2. missing `?` to propagate error in `bind` 