### PR TITLE
Syscall rewriter improvement: API/error handling clean up, no-std support and bug fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1734,7 +1734,6 @@ dependencies = [
  "clap",
  "iced-x86",
  "insta",
- "memmap2",
  "object",
  "similar",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1734,6 +1734,7 @@ dependencies = [
  "clap",
  "iced-x86",
  "insta",
+ "litebox_util_log",
  "object",
  "similar",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1734,7 +1734,6 @@ dependencies = [
  "clap",
  "iced-x86",
  "insta",
- "litebox_util_log",
  "object",
  "similar",
  "tempfile",

--- a/litebox_packager/src/lib.rs
+++ b/litebox_packager/src/lib.rs
@@ -565,9 +565,8 @@ fn rewrite_elf(data: &[u8], path: &Path, verbose: bool) -> anyhow::Result<Vec<u8
         return Ok(data.to_vec());
     }
 
-    let mut skipped_addrs = Vec::new();
-    match litebox_syscall_rewriter::hook_syscalls_in_elf(data, None, &mut skipped_addrs) {
-        Ok(rewritten) => {
+    match litebox_syscall_rewriter::hook_syscalls_in_elf(data, None) {
+        Ok((rewritten, skipped_addrs)) => {
             if !skipped_addrs.is_empty() {
                 eprintln!(
                     "  warning: {} has {} unpatchable syscall instruction(s) at {:?}",
@@ -597,7 +596,7 @@ fn rewrite_elf(data: &[u8], path: &Path, verbose: bool) -> anyhow::Result<Vec<u8
             }
             Ok(data.to_vec())
         }
-        Err(litebox_syscall_rewriter::Error::UnsupportedObjectFile) => {
+        Err(litebox_syscall_rewriter::Error::UnsupportedObjectFile(_)) => {
             if verbose {
                 eprintln!(
                     "  warning: {} is not a supported ELF, including as-is",
@@ -615,7 +614,7 @@ fn rewrite_elf(data: &[u8], path: &Path, verbose: bool) -> anyhow::Result<Vec<u8
             }
             Ok(data.to_vec())
         }
-        Err(litebox_syscall_rewriter::Error::UnsupportedBunExecutable) => {
+        Err(litebox_syscall_rewriter::Error::UnsupportedExecutable(_)) => {
             anyhow::bail!(
                 "{} is a Bun-packaged executable and cannot be safely packaged without syscall rewriting",
                 path.display()

--- a/litebox_packager/src/lib.rs
+++ b/litebox_packager/src/lib.rs
@@ -567,56 +567,15 @@ fn rewrite_elf(data: &[u8], path: &Path, verbose: bool) -> anyhow::Result<Vec<u8
 
     match litebox_syscall_rewriter::hook_syscalls_in_elf(data, None) {
         Ok((rewritten, skipped_addrs)) => {
-            if !skipped_addrs.is_empty() {
-                eprintln!(
-                    "  warning: {} has {} unpatchable syscall instruction(s) at {:?}",
-                    path.display(),
-                    skipped_addrs.len(),
-                    skipped_addrs,
-                );
-            }
+            litebox_syscall_rewriter::warn_skipped(&path.display().to_string(), &skipped_addrs);
             if verbose {
                 eprintln!("  {} (rewritten)", path.display());
             }
             Ok(rewritten)
         }
-        Err(litebox_syscall_rewriter::Error::AlreadyHooked) => {
-            eprintln!(
-                "  warning: {} is already hooked, using as-is",
-                path.display()
-            );
-            Ok(data.to_vec())
-        }
-        Err(litebox_syscall_rewriter::Error::NoSyscallInstructionsFound) => {
-            if verbose {
-                eprintln!(
-                    "  warning: {} has no syscall instructions, using as-is",
-                    path.display()
-                );
-            }
-            Ok(data.to_vec())
-        }
-        Err(litebox_syscall_rewriter::Error::UnsupportedObjectFile(_)) => {
-            if verbose {
-                eprintln!(
-                    "  warning: {} is not a supported ELF, including as-is",
-                    path.display()
-                );
-            }
-            Ok(data.to_vec())
-        }
-        Err(litebox_syscall_rewriter::Error::NoTextSectionFound) => {
-            if verbose {
-                eprintln!(
-                    "  warning: {} has no .text section, using as-is",
-                    path.display()
-                );
-            }
-            Ok(data.to_vec())
-        }
         Err(litebox_syscall_rewriter::Error::UnsupportedExecutable(_)) => {
             anyhow::bail!(
-                "{} is a Bun-packaged executable and cannot be safely packaged without syscall rewriting",
+                "{} is an executable that cannot be safely patched by syscall rewriting",
                 path.display()
             )
         }

--- a/litebox_packager/src/lib.rs
+++ b/litebox_packager/src/lib.rs
@@ -566,11 +566,7 @@ fn rewrite_elf(data: &[u8], path: &Path, verbose: bool) -> anyhow::Result<Vec<u8
     }
 
     match litebox_syscall_rewriter::hook_syscalls_in_elf(data, None) {
-        Ok((rewritten, skipped_addrs)) => {
-            litebox_syscall_rewriter::ensure_all_patched(
-                &path.display().to_string(),
-                &skipped_addrs,
-            )?;
+        Ok(rewritten) => {
             if verbose {
                 eprintln!("  {} (rewritten)", path.display());
             }

--- a/litebox_packager/src/lib.rs
+++ b/litebox_packager/src/lib.rs
@@ -565,8 +565,17 @@ fn rewrite_elf(data: &[u8], path: &Path, verbose: bool) -> anyhow::Result<Vec<u8
         return Ok(data.to_vec());
     }
 
-    match litebox_syscall_rewriter::hook_syscalls_in_elf(data, None) {
+    let mut skipped_addrs = Vec::new();
+    match litebox_syscall_rewriter::hook_syscalls_in_elf(data, None, &mut skipped_addrs) {
         Ok(rewritten) => {
+            if !skipped_addrs.is_empty() {
+                eprintln!(
+                    "  warning: {} has {} unpatchable syscall instruction(s) at {:?}",
+                    path.display(),
+                    skipped_addrs.len(),
+                    skipped_addrs,
+                );
+            }
             if verbose {
                 eprintln!("  {} (rewritten)", path.display());
             }
@@ -601,6 +610,15 @@ fn rewrite_elf(data: &[u8], path: &Path, verbose: bool) -> anyhow::Result<Vec<u8
             if verbose {
                 eprintln!(
                     "  warning: {} has no .text section, using as-is",
+                    path.display()
+                );
+            }
+            Ok(data.to_vec())
+        }
+        Err(litebox_syscall_rewriter::Error::UnsupportedBunExecutable) => {
+            if verbose {
+                eprintln!(
+                    "  warning: {} is a Bun-packaged executable, using as-is",
                     path.display()
                 );
             }

--- a/litebox_packager/src/lib.rs
+++ b/litebox_packager/src/lib.rs
@@ -616,13 +616,10 @@ fn rewrite_elf(data: &[u8], path: &Path, verbose: bool) -> anyhow::Result<Vec<u8
             Ok(data.to_vec())
         }
         Err(litebox_syscall_rewriter::Error::UnsupportedBunExecutable) => {
-            if verbose {
-                eprintln!(
-                    "  warning: {} is a Bun-packaged executable, using as-is",
-                    path.display()
-                );
-            }
-            Ok(data.to_vec())
+            anyhow::bail!(
+                "{} is a Bun-packaged executable and cannot be safely packaged without syscall rewriting",
+                path.display()
+            )
         }
         Err(e) => Err(e).with_context(|| format!("failed to rewrite {}", path.display())),
     }

--- a/litebox_packager/src/lib.rs
+++ b/litebox_packager/src/lib.rs
@@ -567,7 +567,10 @@ fn rewrite_elf(data: &[u8], path: &Path, verbose: bool) -> anyhow::Result<Vec<u8
 
     match litebox_syscall_rewriter::hook_syscalls_in_elf(data, None) {
         Ok((rewritten, skipped_addrs)) => {
-            litebox_syscall_rewriter::warn_skipped(&path.display().to_string(), &skipped_addrs);
+            litebox_syscall_rewriter::ensure_all_patched(
+                &path.display().to_string(),
+                &skipped_addrs,
+            )?;
             if verbose {
                 eprintln!("  {} (rewritten)", path.display());
             }

--- a/litebox_packager/src/lib.rs
+++ b/litebox_packager/src/lib.rs
@@ -572,12 +572,6 @@ fn rewrite_elf(data: &[u8], path: &Path, verbose: bool) -> anyhow::Result<Vec<u8
             }
             Ok(rewritten)
         }
-        Err(litebox_syscall_rewriter::Error::UnsupportedExecutable(_)) => {
-            anyhow::bail!(
-                "{} is an executable that cannot be safely patched by syscall rewriting",
-                path.display()
-            )
-        }
         Err(e) => Err(e).with_context(|| format!("failed to rewrite {}", path.display())),
     }
 }

--- a/litebox_runner_linux_userland/src/lib.rs
+++ b/litebox_runner_linux_userland/src/lib.rs
@@ -169,14 +169,8 @@ pub fn run(cli_args: CliArgs) -> Result<()> {
             .collect();
         let file = mmapped_file(&prog)?;
         let data = if cli_args.rewrite_syscalls {
-            let (rewritten, skipped_addrs) =
-                litebox_syscall_rewriter::hook_syscalls_in_elf(file.data, None)
-                    .with_context(|| format!("failed to rewrite {}", prog.display()))?;
-            litebox_syscall_rewriter::ensure_all_patched(
-                &prog.display().to_string(),
-                &skipped_addrs,
-            )
-            .with_context(|| format!("failed to rewrite {}", prog.display()))?;
+            let rewritten = litebox_syscall_rewriter::hook_syscalls_in_elf(file.data, None)
+                .with_context(|| format!("failed to rewrite {}", prog.display()))?;
             rewritten.into()
         } else {
             let data = file.data.into();

--- a/litebox_runner_linux_userland/src/lib.rs
+++ b/litebox_runner_linux_userland/src/lib.rs
@@ -172,13 +172,7 @@ pub fn run(cli_args: CliArgs) -> Result<()> {
             let (rewritten, skipped_addrs) =
                 litebox_syscall_rewriter::hook_syscalls_in_elf(file.data, None)
                     .with_context(|| format!("failed to rewrite {}", prog.display()))?;
-            if !skipped_addrs.is_empty() {
-                eprintln!(
-                    "warning: program has {} unpatchable syscall instruction(s) at {:?}",
-                    skipped_addrs.len(),
-                    skipped_addrs,
-                );
-            }
+            litebox_syscall_rewriter::warn_skipped(&prog.display().to_string(), &skipped_addrs);
             rewritten.into()
         } else {
             let data = file.data.into();

--- a/litebox_runner_linux_userland/src/lib.rs
+++ b/litebox_runner_linux_userland/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-use anyhow::{Result, anyhow};
+use anyhow::{Context as _, Result, anyhow};
 use clap::Parser;
 use litebox::fs::{FileSystem as _, Mode};
 use litebox_platform_multiplex::Platform;
@@ -172,7 +172,7 @@ pub fn run(cli_args: CliArgs) -> Result<()> {
             let mut skipped_addrs = Vec::new();
             let rewritten =
                 litebox_syscall_rewriter::hook_syscalls_in_elf(file.data, None, &mut skipped_addrs)
-                    .unwrap();
+                    .with_context(|| format!("failed to rewrite {}", prog.display()))?;
             if !skipped_addrs.is_empty() {
                 eprintln!(
                     "warning: program has {} unpatchable syscall instruction(s) at {:?}",

--- a/litebox_runner_linux_userland/src/lib.rs
+++ b/litebox_runner_linux_userland/src/lib.rs
@@ -169,9 +169,18 @@ pub fn run(cli_args: CliArgs) -> Result<()> {
             .collect();
         let file = mmapped_file(&prog)?;
         let data = if cli_args.rewrite_syscalls {
-            litebox_syscall_rewriter::hook_syscalls_in_elf(file.data, None)
-                .unwrap()
-                .into()
+            let mut skipped_addrs = Vec::new();
+            let rewritten =
+                litebox_syscall_rewriter::hook_syscalls_in_elf(file.data, None, &mut skipped_addrs)
+                    .unwrap();
+            if !skipped_addrs.is_empty() {
+                eprintln!(
+                    "warning: program has {} unpatchable syscall instruction(s) at {:?}",
+                    skipped_addrs.len(),
+                    skipped_addrs,
+                );
+            }
+            rewritten.into()
         } else {
             let data = file.data.into();
             cow_eligible_regions.push(file);

--- a/litebox_runner_linux_userland/src/lib.rs
+++ b/litebox_runner_linux_userland/src/lib.rs
@@ -172,7 +172,11 @@ pub fn run(cli_args: CliArgs) -> Result<()> {
             let (rewritten, skipped_addrs) =
                 litebox_syscall_rewriter::hook_syscalls_in_elf(file.data, None)
                     .with_context(|| format!("failed to rewrite {}", prog.display()))?;
-            litebox_syscall_rewriter::warn_skipped(&prog.display().to_string(), &skipped_addrs);
+            litebox_syscall_rewriter::ensure_all_patched(
+                &prog.display().to_string(),
+                &skipped_addrs,
+            )
+            .with_context(|| format!("failed to rewrite {}", prog.display()))?;
             rewritten.into()
         } else {
             let data = file.data.into();

--- a/litebox_runner_linux_userland/src/lib.rs
+++ b/litebox_runner_linux_userland/src/lib.rs
@@ -169,9 +169,8 @@ pub fn run(cli_args: CliArgs) -> Result<()> {
             .collect();
         let file = mmapped_file(&prog)?;
         let data = if cli_args.rewrite_syscalls {
-            let mut skipped_addrs = Vec::new();
-            let rewritten =
-                litebox_syscall_rewriter::hook_syscalls_in_elf(file.data, None, &mut skipped_addrs)
+            let (rewritten, skipped_addrs) =
+                litebox_syscall_rewriter::hook_syscalls_in_elf(file.data, None)
                     .with_context(|| format!("failed to rewrite {}", prog.display()))?;
             if !skipped_addrs.is_empty() {
                 eprintln!(

--- a/litebox_runner_optee_on_linux_userland/src/lib.rs
+++ b/litebox_runner_optee_on_linux_userland/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-use anyhow::Result;
+use anyhow::{Context as _, Result};
 use clap::Parser;
 use litebox_common_optee::{TeeUuid, UteeEntryFunc, UteeParamOwned};
 use litebox_platform_multiplex::Platform;
@@ -56,12 +56,13 @@ pub fn run(cli_args: CliArgs) -> Result<()> {
 
     let ldelf_data: Vec<u8> = {
         let ldelf = PathBuf::from(&cli_args.ldelf);
-        let data = std::fs::read(ldelf).unwrap();
+        let data =
+            std::fs::read(&ldelf).with_context(|| format!("failed to read {}", cli_args.ldelf))?;
         if cli_args.rewrite_syscalls {
             let mut skipped_addrs = Vec::new();
             let rewritten =
                 litebox_syscall_rewriter::hook_syscalls_in_elf(&data, None, &mut skipped_addrs)
-                    .unwrap();
+                    .with_context(|| format!("failed to rewrite {}", cli_args.ldelf))?;
             if !skipped_addrs.is_empty() {
                 eprintln!(
                     "warning: {} has {} unpatchable syscall instruction(s) at {:?}",
@@ -78,12 +79,13 @@ pub fn run(cli_args: CliArgs) -> Result<()> {
 
     let prog_data: Vec<u8> = {
         let prog = PathBuf::from(&cli_args.program);
-        let data = std::fs::read(prog).unwrap();
+        let data =
+            std::fs::read(&prog).with_context(|| format!("failed to read {}", cli_args.program))?;
         if cli_args.rewrite_syscalls {
             let mut skipped_addrs = Vec::new();
             let rewritten =
                 litebox_syscall_rewriter::hook_syscalls_in_elf(&data, None, &mut skipped_addrs)
-                    .unwrap();
+                    .with_context(|| format!("failed to rewrite {}", cli_args.program))?;
             if !skipped_addrs.is_empty() {
                 eprintln!(
                     "warning: {} has {} unpatchable syscall instruction(s) at {:?}",

--- a/litebox_runner_optee_on_linux_userland/src/lib.rs
+++ b/litebox_runner_optee_on_linux_userland/src/lib.rs
@@ -58,7 +58,19 @@ pub fn run(cli_args: CliArgs) -> Result<()> {
         let ldelf = PathBuf::from(&cli_args.ldelf);
         let data = std::fs::read(ldelf).unwrap();
         if cli_args.rewrite_syscalls {
-            litebox_syscall_rewriter::hook_syscalls_in_elf(&data, None).unwrap()
+            let mut skipped_addrs = Vec::new();
+            let rewritten =
+                litebox_syscall_rewriter::hook_syscalls_in_elf(&data, None, &mut skipped_addrs)
+                    .unwrap();
+            if !skipped_addrs.is_empty() {
+                eprintln!(
+                    "warning: {} has {} unpatchable syscall instruction(s) at {:?}",
+                    cli_args.ldelf,
+                    skipped_addrs.len(),
+                    skipped_addrs,
+                );
+            }
+            rewritten
         } else {
             data
         }
@@ -68,7 +80,19 @@ pub fn run(cli_args: CliArgs) -> Result<()> {
         let prog = PathBuf::from(&cli_args.program);
         let data = std::fs::read(prog).unwrap();
         if cli_args.rewrite_syscalls {
-            litebox_syscall_rewriter::hook_syscalls_in_elf(&data, None).unwrap()
+            let mut skipped_addrs = Vec::new();
+            let rewritten =
+                litebox_syscall_rewriter::hook_syscalls_in_elf(&data, None, &mut skipped_addrs)
+                    .unwrap();
+            if !skipped_addrs.is_empty() {
+                eprintln!(
+                    "warning: {} has {} unpatchable syscall instruction(s) at {:?}",
+                    cli_args.program,
+                    skipped_addrs.len(),
+                    skipped_addrs,
+                );
+            }
+            rewritten
         } else {
             data
         }

--- a/litebox_runner_optee_on_linux_userland/src/lib.rs
+++ b/litebox_runner_optee_on_linux_userland/src/lib.rs
@@ -59,9 +59,8 @@ pub fn run(cli_args: CliArgs) -> Result<()> {
         let data =
             std::fs::read(&ldelf).with_context(|| format!("failed to read {}", cli_args.ldelf))?;
         if cli_args.rewrite_syscalls {
-            let mut skipped_addrs = Vec::new();
-            let rewritten =
-                litebox_syscall_rewriter::hook_syscalls_in_elf(&data, None, &mut skipped_addrs)
+            let (rewritten, skipped_addrs) =
+                litebox_syscall_rewriter::hook_syscalls_in_elf(&data, None)
                     .with_context(|| format!("failed to rewrite {}", cli_args.ldelf))?;
             if !skipped_addrs.is_empty() {
                 eprintln!(
@@ -82,9 +81,8 @@ pub fn run(cli_args: CliArgs) -> Result<()> {
         let data =
             std::fs::read(&prog).with_context(|| format!("failed to read {}", cli_args.program))?;
         if cli_args.rewrite_syscalls {
-            let mut skipped_addrs = Vec::new();
-            let rewritten =
-                litebox_syscall_rewriter::hook_syscalls_in_elf(&data, None, &mut skipped_addrs)
+            let (rewritten, skipped_addrs) =
+                litebox_syscall_rewriter::hook_syscalls_in_elf(&data, None)
                     .with_context(|| format!("failed to rewrite {}", cli_args.program))?;
             if !skipped_addrs.is_empty() {
                 eprintln!(

--- a/litebox_runner_optee_on_linux_userland/src/lib.rs
+++ b/litebox_runner_optee_on_linux_userland/src/lib.rs
@@ -62,14 +62,7 @@ pub fn run(cli_args: CliArgs) -> Result<()> {
             let (rewritten, skipped_addrs) =
                 litebox_syscall_rewriter::hook_syscalls_in_elf(&data, None)
                     .with_context(|| format!("failed to rewrite {}", cli_args.ldelf))?;
-            if !skipped_addrs.is_empty() {
-                eprintln!(
-                    "warning: {} has {} unpatchable syscall instruction(s) at {:?}",
-                    cli_args.ldelf,
-                    skipped_addrs.len(),
-                    skipped_addrs,
-                );
-            }
+            litebox_syscall_rewriter::warn_skipped(&cli_args.ldelf, &skipped_addrs);
             rewritten
         } else {
             data
@@ -84,14 +77,7 @@ pub fn run(cli_args: CliArgs) -> Result<()> {
             let (rewritten, skipped_addrs) =
                 litebox_syscall_rewriter::hook_syscalls_in_elf(&data, None)
                     .with_context(|| format!("failed to rewrite {}", cli_args.program))?;
-            if !skipped_addrs.is_empty() {
-                eprintln!(
-                    "warning: {} has {} unpatchable syscall instruction(s) at {:?}",
-                    cli_args.program,
-                    skipped_addrs.len(),
-                    skipped_addrs,
-                );
-            }
+            litebox_syscall_rewriter::warn_skipped(&cli_args.program, &skipped_addrs);
             rewritten
         } else {
             data

--- a/litebox_runner_optee_on_linux_userland/src/lib.rs
+++ b/litebox_runner_optee_on_linux_userland/src/lib.rs
@@ -62,7 +62,8 @@ pub fn run(cli_args: CliArgs) -> Result<()> {
             let (rewritten, skipped_addrs) =
                 litebox_syscall_rewriter::hook_syscalls_in_elf(&data, None)
                     .with_context(|| format!("failed to rewrite {}", cli_args.ldelf))?;
-            litebox_syscall_rewriter::warn_skipped(&cli_args.ldelf, &skipped_addrs);
+            litebox_syscall_rewriter::ensure_all_patched(&cli_args.ldelf, &skipped_addrs)
+                .with_context(|| format!("failed to rewrite {}", cli_args.ldelf))?;
             rewritten
         } else {
             data
@@ -77,7 +78,8 @@ pub fn run(cli_args: CliArgs) -> Result<()> {
             let (rewritten, skipped_addrs) =
                 litebox_syscall_rewriter::hook_syscalls_in_elf(&data, None)
                     .with_context(|| format!("failed to rewrite {}", cli_args.program))?;
-            litebox_syscall_rewriter::warn_skipped(&cli_args.program, &skipped_addrs);
+            litebox_syscall_rewriter::ensure_all_patched(&cli_args.program, &skipped_addrs)
+                .with_context(|| format!("failed to rewrite {}", cli_args.program))?;
             rewritten
         } else {
             data

--- a/litebox_runner_optee_on_linux_userland/src/lib.rs
+++ b/litebox_runner_optee_on_linux_userland/src/lib.rs
@@ -59,12 +59,8 @@ pub fn run(cli_args: CliArgs) -> Result<()> {
         let data =
             std::fs::read(&ldelf).with_context(|| format!("failed to read {}", cli_args.ldelf))?;
         if cli_args.rewrite_syscalls {
-            let (rewritten, skipped_addrs) =
-                litebox_syscall_rewriter::hook_syscalls_in_elf(&data, None)
-                    .with_context(|| format!("failed to rewrite {}", cli_args.ldelf))?;
-            litebox_syscall_rewriter::ensure_all_patched(&cli_args.ldelf, &skipped_addrs)
-                .with_context(|| format!("failed to rewrite {}", cli_args.ldelf))?;
-            rewritten
+            litebox_syscall_rewriter::hook_syscalls_in_elf(&data, None)
+                .with_context(|| format!("failed to rewrite {}", cli_args.ldelf))?
         } else {
             data
         }
@@ -75,12 +71,8 @@ pub fn run(cli_args: CliArgs) -> Result<()> {
         let data =
             std::fs::read(&prog).with_context(|| format!("failed to read {}", cli_args.program))?;
         if cli_args.rewrite_syscalls {
-            let (rewritten, skipped_addrs) =
-                litebox_syscall_rewriter::hook_syscalls_in_elf(&data, None)
-                    .with_context(|| format!("failed to rewrite {}", cli_args.program))?;
-            litebox_syscall_rewriter::ensure_all_patched(&cli_args.program, &skipped_addrs)
-                .with_context(|| format!("failed to rewrite {}", cli_args.program))?;
-            rewritten
+            litebox_syscall_rewriter::hook_syscalls_in_elf(&data, None)
+                .with_context(|| format!("failed to rewrite {}", cli_args.program))?
         } else {
             data
         }

--- a/litebox_syscall_rewriter/Cargo.toml
+++ b/litebox_syscall_rewriter/Cargo.toml
@@ -11,7 +11,6 @@ clap = ["dep:clap"]
 
 [dependencies]
 iced-x86 = { version = "1.21", default-features = false, features = ["no_std", "decoder", "encoder", "instr_info"] }
-litebox_util_log = { version = "0.1.0", path = "../litebox_util_log" }
 object = { version = "0.36.7", default-features = false, features = ["elf", "read_core"] }
 thiserror = { version = "2.0.6", default-features = false }
 zerocopy = { version = "0.8", default-features = false, features = ["derive"] }

--- a/litebox_syscall_rewriter/Cargo.toml
+++ b/litebox_syscall_rewriter/Cargo.toml
@@ -3,14 +3,23 @@ name = "litebox_syscall_rewriter"
 version = "0.1.0"
 edition = "2024"
 
+[features]
+default = ["std", "anyhow", "clap"]
+std = []
+
 [dependencies]
-anyhow = "1.0"
-clap = { version = "4.5.32", features = ["derive"] }
-iced-x86 = "1.21"
-memmap2 = "0.9"
-object = { version = "0.36.7", default-features = false, features = ["elf", "read", "std"] }
+iced-x86 = { version = "1.21", default-features = false, features = ["no_std", "decoder", "encoder", "instr_info"] }
+object = { version = "0.36.7", default-features = false, features = ["elf", "read_core"] }
 thiserror = { version = "2.0.6", default-features = false }
-zerocopy = { version = "0.8", features = ["derive"] }
+zerocopy = { version = "0.8", default-features = false, features = ["derive"] }
+
+# Binary-only dependencies
+anyhow = { version = "1.0", optional = true }
+clap = { version = "4.5.32", features = ["derive"], optional = true }
+
+[[bin]]
+name = "litebox_syscall_rewriter"
+required-features = ["std", "anyhow", "clap"]
 
 [lints]
 workspace = true

--- a/litebox_syscall_rewriter/Cargo.toml
+++ b/litebox_syscall_rewriter/Cargo.toml
@@ -11,6 +11,7 @@ clap = ["dep:clap"]
 
 [dependencies]
 iced-x86 = { version = "1.21", default-features = false, features = ["no_std", "decoder", "encoder", "instr_info"] }
+litebox_util_log = { version = "0.1.0", path = "../litebox_util_log" }
 object = { version = "0.36.7", default-features = false, features = ["elf", "read_core"] }
 thiserror = { version = "2.0.6", default-features = false }
 zerocopy = { version = "0.8", default-features = false, features = ["derive"] }

--- a/litebox_syscall_rewriter/Cargo.toml
+++ b/litebox_syscall_rewriter/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2024"
 [features]
 default = ["std", "anyhow", "clap"]
 std = []
+anyhow = ["dep:anyhow"]
+clap = ["dep:clap"]
 
 [dependencies]
 iced-x86 = { version = "1.21", default-features = false, features = ["no_std", "decoder", "encoder", "instr_info"] }

--- a/litebox_syscall_rewriter/src/lib.rs
+++ b/litebox_syscall_rewriter/src/lib.rs
@@ -58,6 +58,21 @@ type Result<T> = core::result::Result<T, Error>;
 
 const BUN_FOOTER_MARKER: &[u8] = b"\n---- Bun! ----\n";
 
+/// Log a standardized warning about unpatchable syscall instructions.
+///
+/// Call this after [`hook_syscalls_in_elf`] or [`patch_code_segment`] when the
+/// returned `skipped_addrs` list is non-empty.
+pub fn warn_skipped(path: &str, skipped_addrs: &[u64]) {
+    if !skipped_addrs.is_empty() {
+        litebox_util_log::warn!(
+            path:% = path,
+            count:% = skipped_addrs.len(),
+            addrs:? = skipped_addrs;
+            "unpatchable syscall instruction(s)"
+        );
+    }
+}
+
 /// The magic bytes used to identify the trampoline data.
 /// This is checked by the loader to verify that the trampoline is valid.
 pub const TRAMPOLINE_MAGIC: &[u8; 8] = b"LITEBOX0";
@@ -115,6 +130,13 @@ struct TextSectionInfo {
 /// addresses are syscall instructions that could not be patched because there
 /// is not enough space around the instruction (replaced with `icebp; hlt` so
 /// they trap instead of escaping to the host kernel).
+///
+/// Binaries that cannot or do not need to be patched (relocatable objects,
+/// non-ELF files, already-hooked binaries, binaries without executable
+/// sections or syscall instructions) are returned unchanged with an empty
+/// skipped list — these are not errors. Only genuinely broken inputs
+/// (corrupt ELF, unsupported executables like Bun, arithmetic overflow)
+/// produce `Err`.
 pub fn hook_syscalls_in_elf(
     input_binary: &[u8],
     trampoline: Option<u64>,
@@ -132,10 +154,7 @@ pub fn hook_syscalls_in_elf(
     if input_binary.len() >= 18 {
         let e_type = u16::from_le_bytes([input_binary[16], input_binary[17]]);
         if e_type == object::elf::ET_REL {
-            // ET_REL — relocatable object file
-            return Err(Error::UnsupportedObjectFile(
-                "relocatable object file".into(),
-            ));
+            return Ok((input_binary.to_vec(), Vec::new()));
         }
     }
 
@@ -159,7 +178,7 @@ pub fn hook_syscalls_in_elf(
         let arch = match file {
             object::File::Elf64(_) => Arch::X86_64,
             object::File::Elf32(_) => Arch::X86_32,
-            _ => return Err(Error::UnsupportedObjectFile("not an ELF file".into())),
+            _ => return Ok((input_binary.to_vec(), Vec::new())),
         };
 
         let dl_sysinfo_int80 = if arch == Arch::X86_32 {
@@ -168,10 +187,14 @@ pub fn hook_syscalls_in_elf(
             None
         };
 
-        let text_sections = text_sections(&file)?;
+        let text_sections = match text_sections(&file) {
+            Ok(sections) => sections,
+            Err(Error::NoTextSectionFound) => return Ok((input_binary.to_vec(), Vec::new())),
+            Err(e) => return Err(e),
+        };
 
         if is_already_hooked(&*buf, arch) {
-            return Err(Error::AlreadyHooked);
+            return Ok((input_binary.to_vec(), Vec::new()));
         }
 
         let control_transfer_targets = get_control_transfer_targets(arch, &*buf, &text_sections)?;

--- a/litebox_syscall_rewriter/src/lib.rs
+++ b/litebox_syscall_rewriter/src/lib.rs
@@ -95,8 +95,8 @@ struct TextSectionInfo {
 /// The `trampoline` must be an absolute address if specified; if unspecified, it will be set to
 /// zeros, and it is the caller's decision to overwrite it at loading time.
 ///
-/// If it succeeds, it produces an executable with trampoline code appended at a page-aligned
-/// offset after the ELF file. The file layout is:
+/// If rewriting emits trampoline stubs, the returned executable has trampoline code appended at a
+/// page-aligned offset after the ELF file. The file layout is:
 /// `[original ELF][padding to page boundary][trampoline code][header]`
 ///
 /// The header at the end contains:
@@ -105,7 +105,9 @@ struct TextSectionInfo {
 /// - trampoline virtual address (8 bytes for 64-bit, 4 bytes for 32-bit)
 /// - trampoline size (8 bytes for 64-bit, 4 bytes for 32-bit)
 ///
-/// This layout allows loaders to read just the last 32/20 bytes to get the metadata.
+/// This layout allows loaders to read just the last 32/20 bytes to get the metadata. Even when
+/// no syscall instructions are patched, the rewriter still appends the header and the initial
+/// syscall-entry placeholder so the loader/audit path can tell the binary was processed.
 ///
 /// `skipped_addrs` receives the virtual addresses of any `syscall`
 /// instructions that could not be patched (replaced with `UD2` so they
@@ -175,7 +177,7 @@ pub fn hook_syscalls_in_elf(
 
         let control_transfer_targets = get_control_transfer_targets(arch, &*buf, &text_sections)?;
 
-        let trampoline_base_addr = find_addr_for_trampoline_code(&file);
+        let trampoline_base_addr = find_addr_for_trampoline_code(&file)?;
 
         let fork_to_vfork_patch = find_fork_vfork_patch(&file, &text_sections);
 
@@ -199,7 +201,6 @@ pub fn hook_syscalls_in_elf(
         let trampoline = u32::try_from(trampoline).map_err(|_| Error::TrampolineAddressTooLarge)?;
         trampoline_data.extend_from_slice(&trampoline.to_le_bytes());
     }
-
     // Patch syscalls in-place in buf
     for s in &text_sections {
         let section_data = section_slice_mut(buf, s)?;
@@ -222,16 +223,18 @@ pub fn hook_syscalls_in_elf(
     // Patch fork → vfork: overwrite the first bytes of __libc_fork with a
     // JMP to __libc_vfork. This prevents glibc's fork wrapper from running
     // post-fork handlers that corrupt shared state under vfork semantics.
-    if let Some((fork_file_offset, rel32)) = fork_to_vfork_patch {
+    if let Some((fork_file_offset, fork_patch_end, rel32)) = fork_to_vfork_patch {
         #[allow(clippy::cast_possible_truncation)]
         let off = fork_file_offset as usize;
-        if off + 5 <= buf.len() {
+        #[allow(clippy::cast_possible_truncation)]
+        let patch_end = fork_patch_end as usize;
+        if off + 5 <= buf.len() && patch_end <= buf.len() && off + 5 <= patch_end {
             buf[off] = 0xE9; // JMP rel32
             buf[off + 1..off + 5].copy_from_slice(&rel32.to_le_bytes());
         } else {
             return Err(Error::ParseError(format!(
-                "fork→vfork patch offset {off:#x} + 5 exceeds buffer length {}",
-                buf.len()
+                "fork→vfork patch range {off:#x}..{patch_end:#x} is invalid for buffer length {}",
+                buf.len(),
             )));
         }
     }
@@ -453,7 +456,11 @@ fn hook_syscalls_in_section(
         let replace_start = replace_start.unwrap();
         let replace_len = usize::try_from(replace_end - replace_start).unwrap();
 
-        let target_addr = trampoline_base_addr + trampoline_data.len() as u64;
+        let target_addr = checked_add_u64(
+            trampoline_base_addr,
+            trampoline_data.len() as u64,
+            "syscall trampoline target",
+        )?;
 
         // Copy the original instructions to the trampoline
         if replace_start < inst.ip() {
@@ -466,54 +473,81 @@ fn hook_syscalls_in_section(
         let return_addr = inst.next_ip();
         if arch == Arch::X86_64 {
             // Put jump back location into rcx.
-            let jmp_back_offset = i64::try_from(return_addr).unwrap()
-                - i64::try_from(trampoline_base_addr + trampoline_data.len() as u64 + 7).unwrap();
+            let jmp_back_base = checked_add_u64(
+                trampoline_base_addr,
+                trampoline_data.len() as u64,
+                "x86_64 trampoline jump-back base",
+            )?;
+            let jmp_back_base =
+                checked_add_u64(jmp_back_base, 7, "x86_64 trampoline jump-back base")?;
             trampoline_data.extend_from_slice(&[0x48, 0x8D, 0x0D]); // LEA RCX, [RIP + disp32]
-            trampoline_data
-                .extend_from_slice(&(i32::try_from(jmp_back_offset).unwrap().to_le_bytes()));
+            trampoline_data.extend_from_slice(&rel32_bytes(
+                return_addr,
+                jmp_back_base,
+                "x86_64 trampoline jump-back",
+            )?);
 
             // Add jmp [rip + offset_to_entry_point]
             trampoline_data.extend_from_slice(&[0xFF, 0x25]);
             // RIP after this instruction = trampoline_base_addr + trampoline_data.len() + 4
             // We want: RIP + disp32 = syscall_entry_addr
-            #[allow(clippy::cast_possible_wrap)]
-            let disp32 = i64::try_from(syscall_entry_addr).unwrap()
-                - i64::try_from(trampoline_base_addr).unwrap()
-                - trampoline_data.len() as i64
-                - 4;
-            trampoline_data.extend_from_slice(&(i32::try_from(disp32).unwrap().to_le_bytes()));
+            let entry_base = checked_add_u64(
+                trampoline_base_addr,
+                trampoline_data.len() as u64,
+                "x86_64 trampoline entry base",
+            )?;
+            let entry_base = checked_add_u64(entry_base, 4, "x86_64 trampoline entry base")?;
+            trampoline_data.extend_from_slice(&rel32_bytes(
+                syscall_entry_addr,
+                entry_base,
+                "x86_64 trampoline entry",
+            )?);
         } else {
             // For 32-bit, use a different approach to simulate indirect call
             trampoline_data.push(0x50); // PUSH EAX
             trampoline_data.extend_from_slice(&[0xE8, 0x0, 0x0, 0x0, 0x0]); // CALL next instruction
             trampoline_data.push(0x58); // POP EAX (effectively store IP in EAX)
             trampoline_data.extend_from_slice(&[0xFF, 0x90]); // CALL [EAX + offset]
-            // EAX = trampoline_base_addr + (trampoline_data.len() - 3)
-            // We want: EAX + offset = syscall_entry_addr
-            #[allow(clippy::cast_possible_wrap)]
-            let disp32 = i64::try_from(syscall_entry_addr).unwrap()
-                - i64::try_from(trampoline_base_addr).unwrap()
-                - trampoline_data.len() as i64
-                + 3;
-            trampoline_data.extend_from_slice(&(i32::try_from(disp32).unwrap().to_le_bytes()));
+                                                              // EAX = trampoline_base_addr + (trampoline_data.len() - 3)
+                                                              // We want: EAX + offset = syscall_entry_addr
+            let call_base = checked_add_u64(
+                trampoline_base_addr,
+                trampoline_data.len() as u64,
+                "x86 trampoline entry base",
+            )?;
+            let call_base = checked_sub_u64(call_base, 3, "x86 trampoline entry base")?;
+            trampoline_data.extend_from_slice(&rel32_bytes(
+                syscall_entry_addr,
+                call_base,
+                "x86 trampoline entry",
+            )?);
             // Note we skip `POP EAX` here as it is done by the callback `syscall_callback`
             // from litebox_shim_linux/src/lib.rs, which helps reduce the size of the trampoline.
 
             // Add jmp back to original after syscall
-            let jmp_back_offset = i64::try_from(return_addr).unwrap()
-                - i64::try_from(trampoline_base_addr + trampoline_data.len() as u64 + 5).unwrap();
+            let jmp_back_base = checked_add_u64(
+                trampoline_base_addr,
+                trampoline_data.len() as u64,
+                "x86 trampoline jump-back base",
+            )?;
+            let jmp_back_base = checked_add_u64(jmp_back_base, 5, "x86 trampoline jump-back base")?;
             trampoline_data.push(0xE9);
-            trampoline_data
-                .extend_from_slice(&(i32::try_from(jmp_back_offset).unwrap().to_le_bytes()));
+            trampoline_data.extend_from_slice(&rel32_bytes(
+                return_addr,
+                jmp_back_base,
+                "x86 trampoline jump-back",
+            )?);
         }
 
         // Replace original instructions with jump to trampoline
         let replace_offset = usize::try_from(replace_start - section_base_addr).unwrap();
         section_data[replace_offset] = 0xE9; // JMP rel32
-        let jump_offset =
-            i64::try_from(target_addr).unwrap() - i64::try_from(replace_start + 5).unwrap();
-        section_data[replace_offset + 1..replace_offset + 5]
-            .copy_from_slice(&(i32::try_from(jump_offset).unwrap().to_le_bytes()));
+        let patch_base = checked_add_u64(replace_start, 5, "syscall patch jump base")?;
+        section_data[replace_offset + 1..replace_offset + 5].copy_from_slice(&rel32_bytes(
+            target_addr,
+            patch_base,
+            "syscall patch jump",
+        )?);
 
         // Fill remaining bytes with NOP
         for idx in 5..replace_len {
@@ -560,17 +594,38 @@ fn fixup_phdr_alignment(buf: &mut [u8]) {
         return; // already aligned
     }
 
-    let phdr_size = e_phentsize * e_phnum;
-    let old_start = usize::try_from(e_phoff).expect("e_phoff must fit in usize");
-    let old_end = old_start + usize::try_from(phdr_size).expect("phdr_size must fit in usize");
+    let Some(phdr_size) = e_phentsize.checked_mul(e_phnum) else {
+        return;
+    };
+    let Ok(old_start) = usize::try_from(e_phoff) else {
+        return;
+    };
+    let Ok(phdr_size) = usize::try_from(phdr_size) else {
+        return;
+    };
+    let Some(old_end) = old_start.checked_add(phdr_size) else {
+        return;
+    };
 
     // Shift forward to align: new offset is the next 8-byte boundary.
-    let padding = usize::try_from(8 - misalignment).expect("padding must fit in usize");
-    let new_start = old_start + padding;
-    let new_end = new_start + usize::try_from(phdr_size).expect("phdr_size must fit in usize");
+    let Ok(padding) = usize::try_from(8 - misalignment) else {
+        return;
+    };
+    let Some(new_start) = old_start.checked_add(padding) else {
+        return;
+    };
+    let Some(new_end) = new_start.checked_add(phdr_size) else {
+        return;
+    };
 
     if old_end > buf.len() || new_end > buf.len() {
         return; // corrupt phdr table or not enough room
+    }
+
+    // Only relocate when the overwritten bytes are padding. Otherwise this would corrupt the file
+    // by destroying whatever payload follows the existing program header table.
+    if !buf[old_end..new_end].iter().all(|&byte| byte == 0) {
+        return;
     }
 
     // Move the phdr table forward (use copy_within since src and dst overlap).
@@ -582,10 +637,16 @@ fn fixup_phdr_alignment(buf: &mut [u8]) {
 
     // Also update the PHDR segment's p_offset if present, so it matches.
     // PT_PHDR = 6, each Elf64_Phdr is e_phentsize bytes, p_type at offset 0, p_offset at offset 8.
-    for i in 0..e_phnum {
-        let entry_off = new_start
-            + usize::try_from(i).expect("i must fit in usize")
-                * usize::try_from(e_phentsize).expect("e_phentsize must fit in usize");
+    let Ok(e_phentsize_usize) = usize::try_from(e_phentsize) else {
+        return;
+    };
+    let Ok(e_phnum_usize) = usize::try_from(e_phnum) else {
+        return;
+    };
+    for i in 0..e_phnum_usize {
+        let Some(entry_off) = new_start.checked_add(i.saturating_mul(e_phentsize_usize)) else {
+            break;
+        };
         if entry_off + 16 > buf.len() {
             break;
         }
@@ -610,23 +671,40 @@ fn fixup_phdr_alignment(buf: &mut [u8]) {
 fn find_fork_vfork_patch(
     file: &object::File<'_>,
     text_sections: &[TextSectionInfo],
-) -> Option<(u64, i32)> {
+) -> Option<(u64, u64, i32)> {
     use object::ObjectSymbol as _;
 
-    // Search both .dynsym and .symtab for fork/vfork.
     let mut fork_vaddr = None;
     let mut vfork_vaddr = None;
 
-    for sym in file.dynamic_symbols().chain(file.symbols()) {
+    // Restrict this rewrite to libc-specific symbols. Plain `fork`/`vfork` names may belong to
+    // arbitrary DSOs or user code, and retargeting them would silently change unrelated behavior.
+    for sym in file.dynamic_symbols() {
         if sym.kind() != object::SymbolKind::Text {
             continue;
         }
         let Ok(name) = sym.name() else { continue };
         match name {
-            "fork" | "__libc_fork" if fork_vaddr.is_none() => {
+            "__libc_fork" if fork_vaddr.is_none() => {
                 fork_vaddr = Some(sym.address());
             }
-            "vfork" | "__libc_vfork" | "__vfork" if vfork_vaddr.is_none() => {
+            "__libc_vfork" | "__vfork" if vfork_vaddr.is_none() => {
+                vfork_vaddr = Some(sym.address());
+            }
+            _ => {}
+        }
+    }
+
+    for sym in file.symbols() {
+        if sym.kind() != object::SymbolKind::Text {
+            continue;
+        }
+        let Ok(name) = sym.name() else { continue };
+        match name {
+            "__libc_fork" if fork_vaddr.is_none() => {
+                fork_vaddr = Some(sym.address());
+            }
+            "__libc_vfork" | "__vfork" if vfork_vaddr.is_none() => {
                 vfork_vaddr = Some(sym.address());
             }
             _ => {}
@@ -635,12 +713,22 @@ fn find_fork_vfork_patch(
 
     let fork_vaddr = fork_vaddr?;
     let vfork_vaddr = vfork_vaddr?;
+    if fork_vaddr == 0 || vfork_vaddr == 0 {
+        return None;
+    }
 
     // Convert fork's vaddr to a file offset using the text sections.
-    let fork_file_offset = text_sections.iter().find_map(|s| {
+    let (fork_file_offset, fork_patch_end) = text_sections.iter().find_map(|s| {
         let section_end = s.vaddr + s.size;
-        if fork_vaddr >= s.vaddr && fork_vaddr < section_end {
-            Some(s.file_offset + (fork_vaddr - s.vaddr))
+        if fork_vaddr >= s.vaddr
+            && fork_vaddr < section_end
+            && fork_vaddr
+                .checked_add(5)
+                .is_some_and(|end| end <= section_end)
+        {
+            let file_offset = s.file_offset + (fork_vaddr - s.vaddr);
+            let file_end = s.file_offset + s.size;
+            Some((file_offset, file_end))
         } else {
             None
         }
@@ -654,7 +742,7 @@ fn find_fork_vfork_patch(
         .checked_sub(i64::try_from(fork_vaddr).ok()? + 5)?;
     let rel32 = i32::try_from(rel32).ok()?;
 
-    Some((fork_file_offset, rel32))
+    Some((fork_file_offset, fork_patch_end, rel32))
 }
 
 /// Check if the input binary has the Bun footer marker at the end.
@@ -679,6 +767,26 @@ fn replace_with_ud2(section_data: &mut [u8], section_base_addr: u64, inst: &iced
     for b in &mut section_data[offset + 2..offset + len] {
         *b = 0x90;
     }
+}
+
+fn checked_add_u64(base: u64, addend: u64, context: &'static str) -> Result<u64> {
+    base.checked_add(addend)
+        .ok_or_else(|| Error::ParseError(format!("{context} address overflow")))
+}
+
+fn checked_sub_u64(base: u64, subtrahend: u64, context: &'static str) -> Result<u64> {
+    base.checked_sub(subtrahend)
+        .ok_or_else(|| Error::ParseError(format!("{context} address underflow")))
+}
+
+fn rel32_bytes(target: u64, base: u64, context: &'static str) -> Result<[u8; 4]> {
+    let disp = i128::from(target) - i128::from(base);
+    let disp = i32::try_from(disp).map_err(|_| {
+        Error::ParseError(format!(
+            "{context} displacement out of range: target {target:#x}, base {base:#x}"
+        ))
+    })?;
+    Ok(disp.to_le_bytes())
 }
 
 /// Patch a single mapped code segment in-place, returning trampoline stubs.
@@ -743,20 +851,21 @@ pub fn patch_code_segment(
     }
 }
 
-fn find_addr_for_trampoline_code(file: &object::File<'_>) -> u64 {
+fn find_addr_for_trampoline_code(file: &object::File<'_>) -> Result<u64> {
     // Find the highest virtual address among all PT_LOAD segments
     let max_virtual_addr = match file {
         object::File::Elf64(elf) => max_load_segment_end(elf),
         object::File::Elf32(elf) => max_load_segment_end(elf),
         _ => unreachable!(),
-    };
+    }
+    .ok_or_else(|| Error::ParseError("no PT_LOAD segments found".into()))?;
 
     // Round up to the nearest page (assume 0x1000 page size)
-    max_virtual_addr.next_multiple_of(0x1000)
+    checked_add_u64(max_virtual_addr, 0xFFF, "trampoline base").map(|addr| addr & !0xFFF)
 }
 
 /// Returns the highest `p_vaddr + p_memsz` among all `PT_LOAD` segments.
-fn max_load_segment_end<Elf: object::read::elf::FileHeader>(elf: &ElfFile<'_, Elf>) -> u64
+fn max_load_segment_end<Elf: object::read::elf::FileHeader>(elf: &ElfFile<'_, Elf>) -> Option<u64>
 where
     Elf::Word: Into<u64>,
 {
@@ -764,9 +873,12 @@ where
     elf.elf_program_headers()
         .iter()
         .filter(|ph| ph.p_type(endian) == object::elf::PT_LOAD)
-        .map(|ph| ph.p_vaddr(endian).into() + ph.p_memsz(endian).into())
+        .filter_map(|ph| {
+            ph.p_vaddr(endian)
+                .into()
+                .checked_add(ph.p_memsz(endian).into())
+        })
         .max()
-        .unwrap()
 }
 
 fn get_symbols(file: &object::File<'_>) -> Option<u64> {
@@ -947,7 +1059,11 @@ fn hook_syscall_and_after(
 
     let replace_end = replace_end.unwrap();
 
-    let target_addr = trampoline_base_addr + trampoline_data.len() as u64;
+    let target_addr = checked_add_u64(
+        trampoline_base_addr,
+        trampoline_data.len() as u64,
+        "syscall trampoline target",
+    )?;
 
     if arch == Arch::X86_64 {
         // Put jump back location into rcx, via lea rcx, [next instruction]
@@ -957,26 +1073,36 @@ fn hook_syscall_and_after(
         trampoline_data.extend_from_slice(&[0xFF, 0x25]);
         // RIP after this instruction = trampoline_base_addr + trampoline_data.len() + 4
         // We want: RIP + disp32 = syscall_entry_addr
-        #[allow(clippy::cast_possible_wrap)]
-        let disp32 = i64::try_from(syscall_entry_addr).unwrap()
-            - i64::try_from(trampoline_base_addr).unwrap()
-            - trampoline_data.len() as i64
-            - 4;
-        trampoline_data.extend_from_slice(&(i32::try_from(disp32).unwrap().to_le_bytes()));
+        let entry_base = checked_add_u64(
+            trampoline_base_addr,
+            trampoline_data.len() as u64,
+            "x86_64 trampoline entry base",
+        )?;
+        let entry_base = checked_add_u64(entry_base, 4, "x86_64 trampoline entry base")?;
+        trampoline_data.extend_from_slice(&rel32_bytes(
+            syscall_entry_addr,
+            entry_base,
+            "x86_64 trampoline entry",
+        )?);
     } else {
         // For 32-bit, use a different approach to simulate indirect call
         trampoline_data.push(0x50); // PUSH EAX
         trampoline_data.extend_from_slice(&[0xE8, 0x0, 0x0, 0x0, 0x0]); // CALL next instruction
         trampoline_data.push(0x58); // POP EAX (effectively store IP in EAX)
         trampoline_data.extend_from_slice(&[0xFF, 0x90]); // CALL [EAX + offset]
-        // EAX = trampoline_base_addr + (trampoline_data.len() - 3)
-        // We want: EAX + offset = syscall_entry_addr
-        #[allow(clippy::cast_possible_wrap)]
-        let disp32 = i64::try_from(syscall_entry_addr).unwrap()
-            - i64::try_from(trampoline_base_addr).unwrap()
-            - trampoline_data.len() as i64
-            + 3;
-        trampoline_data.extend_from_slice(&(i32::try_from(disp32).unwrap().to_le_bytes()));
+                                                          // EAX = trampoline_base_addr + (trampoline_data.len() - 3)
+                                                          // We want: EAX + offset = syscall_entry_addr
+        let call_base = checked_add_u64(
+            trampoline_base_addr,
+            trampoline_data.len() as u64,
+            "x86 trampoline entry base",
+        )?;
+        let call_base = checked_sub_u64(call_base, 3, "x86 trampoline entry base")?;
+        trampoline_data.extend_from_slice(&rel32_bytes(
+            syscall_entry_addr,
+            call_base,
+            "x86 trampoline entry",
+        )?);
         // Note we skip `POP EAX` here as it is done by the callback `syscall_callback`
         // from litebox_shim_linux/src/lib.rs, which helps reduce the size of the trampoline.
     }
@@ -991,18 +1117,28 @@ fn hook_syscall_and_after(
     }
 
     // Add jmp back to original after syscall
-    let jmp_back_offset = i64::try_from(replace_end).unwrap()
-        - i64::try_from(trampoline_base_addr + trampoline_data.len() as u64 + 5).unwrap();
+    let jmp_back_base = checked_add_u64(
+        trampoline_base_addr,
+        trampoline_data.len() as u64,
+        "trampoline jump-back base",
+    )?;
+    let jmp_back_base = checked_add_u64(jmp_back_base, 5, "trampoline jump-back base")?;
     trampoline_data.push(0xE9);
-    trampoline_data.extend_from_slice(&(i32::try_from(jmp_back_offset).unwrap().to_le_bytes()));
+    trampoline_data.extend_from_slice(&rel32_bytes(
+        replace_end,
+        jmp_back_base,
+        "trampoline jump-back",
+    )?);
 
     // Replace original instructions with jump to trampoline
     let replace_offset = usize::try_from(replace_start - section_base_addr).unwrap();
     section_data[replace_offset] = 0xE9; // JMP rel32
-    let jump_offset =
-        i64::try_from(target_addr).unwrap() - i64::try_from(replace_start + 5).unwrap();
-    section_data[replace_offset + 1..replace_offset + 5]
-        .copy_from_slice(&(i32::try_from(jump_offset).unwrap().to_le_bytes()));
+    let patch_base = checked_add_u64(replace_start, 5, "syscall patch jump base")?;
+    section_data[replace_offset + 1..replace_offset + 5].copy_from_slice(&rel32_bytes(
+        target_addr,
+        patch_base,
+        "syscall patch jump",
+    )?);
 
     // Fill remaining bytes with NOP
     let replace_len = usize::try_from(replace_end - replace_start).unwrap();
@@ -1080,7 +1216,11 @@ fn hook_syscall_before_and_after(
         }
     };
 
-    let target_addr = trampoline_base_addr + trampoline_data.len() as u64;
+    let target_addr = checked_add_u64(
+        trampoline_base_addr,
+        trampoline_data.len() as u64,
+        "syscall trampoline target",
+    )?;
     let replace_start = prev_inst.ip();
     let replace_len = usize::try_from(next_inst.next_ip() - replace_start).unwrap();
 
@@ -1095,14 +1235,19 @@ fn hook_syscall_before_and_after(
     trampoline_data.extend_from_slice(&[0xE8, 0x0, 0x0, 0x0, 0x0]); // CALL next instruction
     trampoline_data.push(0x58); // POP EAX (effectively store IP in EAX)
     trampoline_data.extend_from_slice(&[0xFF, 0x90]); // CALL [EAX + offset]
-    // EAX = trampoline_base_addr + (trampoline_data.len() - 3)
-    // We want: EAX + offset = syscall_entry_addr
-    #[allow(clippy::cast_possible_wrap)]
-    let disp32 = i64::try_from(syscall_entry_addr).unwrap()
-        - i64::try_from(trampoline_base_addr).unwrap()
-        - trampoline_data.len() as i64
-        + 3;
-    trampoline_data.extend_from_slice(&(i32::try_from(disp32).unwrap().to_le_bytes()));
+                                                      // EAX = trampoline_base_addr + (trampoline_data.len() - 3)
+                                                      // We want: EAX + offset = syscall_entry_addr
+    let call_base = checked_add_u64(
+        trampoline_base_addr,
+        trampoline_data.len() as u64,
+        "x86 trampoline entry base",
+    )?;
+    let call_base = checked_sub_u64(call_base, 3, "x86 trampoline entry base")?;
+    trampoline_data.extend_from_slice(&rel32_bytes(
+        syscall_entry_addr,
+        call_base,
+        "x86 trampoline entry",
+    )?);
     // Note we skip `POP EAX` here as it is done by the callback `syscall_callback`
     // from litebox_shim_linux/src/lib.rs, which helps reduce the size of the trampoline.
 
@@ -1115,19 +1260,29 @@ fn hook_syscall_before_and_after(
     // Add jmp back to original after syscall if needed
     if need_jump_back {
         let return_addr = next_inst.next_ip();
-        let jmp_back_offset = i64::try_from(return_addr).unwrap()
-            - i64::try_from(trampoline_base_addr + trampoline_data.len() as u64 + 5).unwrap();
+        let jmp_back_base = checked_add_u64(
+            trampoline_base_addr,
+            trampoline_data.len() as u64,
+            "x86 trampoline jump-back base",
+        )?;
+        let jmp_back_base = checked_add_u64(jmp_back_base, 5, "x86 trampoline jump-back base")?;
         trampoline_data.push(0xE9);
-        trampoline_data.extend_from_slice(&(i32::try_from(jmp_back_offset).unwrap().to_le_bytes()));
+        trampoline_data.extend_from_slice(&rel32_bytes(
+            return_addr,
+            jmp_back_base,
+            "x86 trampoline jump-back",
+        )?);
     }
 
     // Replace original instructions with jump to trampoline
     let replace_offset = usize::try_from(replace_start - section_base_addr).unwrap();
     section_data[replace_offset] = 0xE9; // JMP rel32
-    let jump_offset =
-        i64::try_from(target_addr).unwrap() - i64::try_from(replace_start + 5).unwrap();
-    section_data[replace_offset + 1..replace_offset + 5]
-        .copy_from_slice(&(i32::try_from(jump_offset).unwrap().to_le_bytes()));
+    let patch_base = checked_add_u64(replace_start, 5, "syscall patch jump base")?;
+    section_data[replace_offset + 1..replace_offset + 5].copy_from_slice(&rel32_bytes(
+        target_addr,
+        patch_base,
+        "syscall patch jump",
+    )?);
 
     // Fill remaining bytes with NOP
     for idx in 5..replace_len {

--- a/litebox_syscall_rewriter/src/lib.rs
+++ b/litebox_syscall_rewriter/src/lib.rs
@@ -608,8 +608,9 @@ fn fixup_phdr_alignment(buf: &mut [u8]) {
     let new_phoff = (e_phoff + padding as u64).to_le_bytes();
     buf[32..40].copy_from_slice(&new_phoff);
 
-    // Also update the PHDR segment's p_offset if present, so it matches.
-    // PT_PHDR = 6, each Elf64_Phdr is e_phentsize bytes, p_type at offset 0, p_offset at offset 8.
+    // Also update the PHDR segment's p_offset, p_vaddr, and p_paddr if present, so they match.
+    // ELF64 Elf64_Phdr layout: p_type (0, 4B), p_flags (4, 4B), p_offset (8, 8B),
+    // p_vaddr (16, 8B), p_paddr (24, 8B), p_filesz (32, 8B), p_memsz (40, 8B), p_align (48, 8B).
     let Ok(e_phentsize_usize) = usize::try_from(e_phentsize) else {
         return;
     };
@@ -620,18 +621,19 @@ fn fixup_phdr_alignment(buf: &mut [u8]) {
         let Some(entry_off) = new_start.checked_add(i.saturating_mul(e_phentsize_usize)) else {
             break;
         };
-        if entry_off + 16 > buf.len() {
+        if entry_off + 32 > buf.len() {
             break;
         }
         let p_type = u32::from_le_bytes(buf[entry_off..entry_off + 4].try_into().unwrap());
         if p_type == object::elf::PT_PHDR {
-            // PT_PHDR — update p_offset to match new location
-            let p_offset_off = entry_off + 8;
-            let old_p_offset =
-                u64::from_le_bytes(buf[p_offset_off..p_offset_off + 8].try_into().unwrap());
-            if old_p_offset == e_phoff {
-                let new_p_offset = (old_p_offset + padding as u64).to_le_bytes();
-                buf[p_offset_off..p_offset_off + 8].copy_from_slice(&new_p_offset);
+            // PT_PHDR — update p_offset, p_vaddr, and p_paddr to match new location
+            for field_off in [8usize, 16, 24] {
+                let off = entry_off + field_off;
+                let old_val = u64::from_le_bytes(buf[off..off + 8].try_into().unwrap());
+                if old_val == e_phoff {
+                    let new_val = (old_val + padding as u64).to_le_bytes();
+                    buf[off..off + 8].copy_from_slice(&new_val);
+                }
             }
             // The PHDR segment size should match the phdr table; no change needed.
         }
@@ -644,7 +646,7 @@ fn fixup_phdr_alignment(buf: &mut [u8]) {
 /// We avoid `UD2` (`0F 0B`) because it commonly appears in binaries to mark
 /// `unreachable!()` paths.  The `ICEBP; HLT` sequence is a strong, distinctive
 /// indicator of "this syscall was intentionally poisoned" — `ICEBP` alone does
-/// not trap on Linux in userspace, but `HLT` does (SIGILL in ring 3), and the
+/// not trap on Linux in userspace, but `HLT` does (SIGSEGV in ring 3), and the
 /// `F1` prefix makes it easy for a signal handler to distinguish an
 /// intentional break from a spurious one.
 ///

--- a/litebox_syscall_rewriter/src/lib.rs
+++ b/litebox_syscall_rewriter/src/lib.rs
@@ -223,12 +223,12 @@ pub fn hook_syscalls_in_elf(
     // Patch fork → vfork: overwrite the first bytes of __libc_fork with a
     // JMP to __libc_vfork. This prevents glibc's fork wrapper from running
     // post-fork handlers that corrupt shared state under vfork semantics.
-    if let Some((fork_file_offset, fork_patch_end, mut rel32)) = fork_to_vfork_patch {
+    if let Some((fork_file_offset, fork_func_end, mut rel32)) = fork_to_vfork_patch {
         const ENDBR64: [u8; 4] = [0xF3, 0x0F, 0x1E, 0xFA];
         #[allow(clippy::cast_possible_truncation)]
         let mut off = fork_file_offset as usize;
         #[allow(clippy::cast_possible_truncation)]
-        let patch_end = fork_patch_end as usize;
+        let func_end = fork_func_end as usize;
 
         // If fork starts with endbr64 (F3 0F 1E FA), preserve it by placing
         // the JMP after it. This keeps CET/IBT indirect-branch targets valid.
@@ -237,17 +237,17 @@ pub fn hook_syscalls_in_elf(
             rel32 = rel32.wrapping_sub(4); // JMP is now 4 bytes later, adjust displacement
         }
 
-        if off + 5 <= buf.len() && patch_end <= buf.len() && off + 5 <= patch_end {
+        if off + 5 <= func_end && func_end <= buf.len() {
             buf[off] = 0xE9; // JMP rel32
             buf[off + 1..off + 5].copy_from_slice(&rel32.to_le_bytes());
-            // NOP-fill remaining bytes between end of JMP and the patch boundary
+            // NOP-fill remaining bytes of the fork function body after the JMP
             // to avoid leaving stale instructions that could be jumped into.
-            for b in &mut buf[off + 5..patch_end] {
+            for b in &mut buf[off + 5..func_end] {
                 *b = 0x90; // NOP
             }
         } else {
             return Err(Error::ParseError(format!(
-                "fork→vfork patch range {off:#x}..{patch_end:#x} is invalid for buffer length {}",
+                "fork→vfork patch range {off:#x}..{func_end:#x} is invalid for buffer length {}",
                 buf.len(),
             )));
         }
@@ -675,8 +675,12 @@ fn fixup_phdr_alignment(buf: &mut [u8]) {
 }
 
 /// Find fork and vfork symbols in the ELF and compute the patch needed to
-/// redirect fork -> vfork. Returns `Some((fork_file_offset, jmp_rel32))` if
+/// redirect fork -> vfork. Returns `Some((fork_file_offset, fork_func_end, jmp_rel32))` if
 /// both symbols are found, or `None` if this binary doesn't export fork.
+///
+/// `fork_func_end` is the file offset of the end of the fork function (based on
+/// the symbol's size), clamped to the section boundary. This is used to NOP-fill
+/// only the fork function body after the JMP, not the rest of the section.
 fn find_fork_vfork_patch(
     file: &object::File<'_>,
     text_sections: &[TextSectionInfo],
@@ -684,6 +688,7 @@ fn find_fork_vfork_patch(
     use object::ObjectSymbol as _;
 
     let mut fork_vaddr = None;
+    let mut fork_size = None;
     let mut vfork_vaddr = None;
 
     // Restrict this rewrite to libc-specific symbols. Plain `fork`/`vfork` names may belong to
@@ -696,6 +701,7 @@ fn find_fork_vfork_patch(
         match name {
             "__libc_fork" if fork_vaddr.is_none() => {
                 fork_vaddr = Some(sym.address());
+                fork_size = Some(sym.size());
             }
             "__libc_vfork" | "__vfork" if vfork_vaddr.is_none() => {
                 vfork_vaddr = Some(sym.address());
@@ -712,6 +718,7 @@ fn find_fork_vfork_patch(
         match name {
             "__libc_fork" if fork_vaddr.is_none() => {
                 fork_vaddr = Some(sym.address());
+                fork_size = Some(sym.size());
             }
             "__libc_vfork" | "__vfork" if vfork_vaddr.is_none() => {
                 vfork_vaddr = Some(sym.address());
@@ -721,13 +728,14 @@ fn find_fork_vfork_patch(
     }
 
     let fork_vaddr = fork_vaddr?;
+    let fork_size = fork_size?;
     let vfork_vaddr = vfork_vaddr?;
     if fork_vaddr == 0 || vfork_vaddr == 0 {
         return None;
     }
 
     // Convert fork's vaddr to a file offset using the text sections.
-    let (fork_file_offset, fork_patch_end) = text_sections.iter().find_map(|s| {
+    let (fork_file_offset, fork_func_end) = text_sections.iter().find_map(|s| {
         let section_end = s.vaddr + s.size;
         if fork_vaddr >= s.vaddr
             && fork_vaddr < section_end
@@ -736,8 +744,15 @@ fn find_fork_vfork_patch(
                 .is_some_and(|end| end <= section_end)
         {
             let file_offset = s.file_offset + (fork_vaddr - s.vaddr);
-            let file_end = s.file_offset + s.size;
-            Some((file_offset, file_end))
+            let section_file_end = s.file_offset + s.size;
+            // Compute the end of the fork function, clamped to the section boundary.
+            let func_file_end = if fork_size > 0 {
+                (file_offset + fork_size).min(section_file_end)
+            } else {
+                // No size info — only NOP-fill the JMP itself (no extra NOPs).
+                file_offset + 5
+            };
+            Some((file_offset, func_file_end))
         } else {
             None
         }
@@ -751,7 +766,7 @@ fn find_fork_vfork_patch(
         .checked_sub(i64::try_from(fork_vaddr).ok()? + 5)?;
     let rel32 = i32::try_from(rel32).ok()?;
 
-    Some((fork_file_offset, fork_patch_end, rel32))
+    Some((fork_file_offset, fork_func_end, rel32))
 }
 
 /// Check if the input binary has the Bun footer marker at the end.

--- a/litebox_syscall_rewriter/src/lib.rs
+++ b/litebox_syscall_rewriter/src/lib.rs
@@ -724,59 +724,6 @@ fn rel32_bytes(target: u64, base: u64, context: &'static str) -> Result<[u8; 4]>
     Ok(disp.to_le_bytes())
 }
 
-/// Patch a single mapped code segment in-place, returning trampoline stubs.
-///
-/// This is the runtime counterpart to [`hook_syscalls_in_elf`]. Instead of
-/// processing a whole ELF file, it operates on a single already-mapped code
-/// region — the caller is responsible for making the region writable before
-/// calling and restoring permissions afterwards. The caller must copy the
-/// returned stubs to `trampoline_write_vaddr`.
-///
-/// Returns `Err` if any syscall instructions could not be patched.
-pub fn patch_code_segment(
-    code: &mut [u8],
-    code_vaddr: u64,
-    trampoline_write_vaddr: u64,
-    syscall_entry_addr: u64,
-) -> Result<Vec<u8>> {
-    let arch = Arch::X86_64; // runtime patching is x86-64 only
-
-    // Build control-transfer targets for this segment.
-    let instructions = decode_section_instructions(arch, code, code_vaddr)?;
-    let mut control_transfer_targets = BTreeSet::new();
-    for inst in &instructions {
-        let target = inst.near_branch_target();
-        if target != 0 {
-            control_transfer_targets.insert(target);
-        }
-    }
-
-    let mut trampoline_data = Vec::new();
-    match hook_syscalls_in_section(
-        arch,
-        &control_transfer_targets,
-        code_vaddr,
-        code,
-        trampoline_write_vaddr,
-        syscall_entry_addr,
-        None, // dl_sysinfo_int80 — not applicable on x86-64
-        &mut trampoline_data,
-    ) {
-        Ok(skipped_addrs) => {
-            if !skipped_addrs.is_empty() {
-                return Err(Error::UnpatchableSyscalls(format!(
-                    "{} unpatchable syscall instruction(s) at {skipped_addrs:?}",
-                    skipped_addrs.len(),
-                )));
-            }
-            Ok(trampoline_data)
-        }
-        Err(InternalError::NoSyscallInstructionsFound) => Ok(Vec::new()),
-        Err(InternalError::Public(e)) => Err(e),
-        Err(e) => unreachable!("unexpected internal error: {e:?}"),
-    }
-}
-
 fn find_addr_for_trampoline_code(file: &object::File<'_>) -> Result<u64> {
     // Find the highest virtual address among all PT_LOAD segments
     let max_virtual_addr = match file {

--- a/litebox_syscall_rewriter/src/lib.rs
+++ b/litebox_syscall_rewriter/src/lib.rs
@@ -127,7 +127,7 @@ pub fn hook_syscalls_in_elf(
     // Check the ELF e_type field (bytes 16..18) before doing any work.
     if input_binary.len() >= 18 {
         let e_type = u16::from_le_bytes([input_binary[16], input_binary[17]]);
-        if e_type == 1 {
+        if e_type == object::elf::ET_REL {
             // ET_REL — relocatable object file
             return Err(Error::UnsupportedObjectFile);
         }
@@ -223,14 +223,28 @@ pub fn hook_syscalls_in_elf(
     // Patch fork → vfork: overwrite the first bytes of __libc_fork with a
     // JMP to __libc_vfork. This prevents glibc's fork wrapper from running
     // post-fork handlers that corrupt shared state under vfork semantics.
-    if let Some((fork_file_offset, fork_patch_end, rel32)) = fork_to_vfork_patch {
+    if let Some((fork_file_offset, fork_patch_end, mut rel32)) = fork_to_vfork_patch {
+        const ENDBR64: [u8; 4] = [0xF3, 0x0F, 0x1E, 0xFA];
         #[allow(clippy::cast_possible_truncation)]
-        let off = fork_file_offset as usize;
+        let mut off = fork_file_offset as usize;
         #[allow(clippy::cast_possible_truncation)]
         let patch_end = fork_patch_end as usize;
+
+        // If fork starts with endbr64 (F3 0F 1E FA), preserve it by placing
+        // the JMP after it. This keeps CET/IBT indirect-branch targets valid.
+        if off + 4 <= buf.len() && buf[off..off + 4] == ENDBR64 {
+            off += 4;
+            rel32 = rel32.wrapping_sub(4); // JMP is now 4 bytes later, adjust displacement
+        }
+
         if off + 5 <= buf.len() && patch_end <= buf.len() && off + 5 <= patch_end {
             buf[off] = 0xE9; // JMP rel32
             buf[off + 1..off + 5].copy_from_slice(&rel32.to_le_bytes());
+            // NOP-fill remaining bytes between end of JMP and the patch boundary
+            // to avoid leaving stale instructions that could be jumped into.
+            for b in &mut buf[off + 5..patch_end] {
+                *b = 0x90; // NOP
+            }
         } else {
             return Err(Error::ParseError(format!(
                 "fork→vfork patch range {off:#x}..{patch_end:#x} is invalid for buffer length {}",
@@ -475,11 +489,9 @@ fn hook_syscalls_in_section(
             // Put jump back location into rcx.
             let jmp_back_base = checked_add_u64(
                 trampoline_base_addr,
-                trampoline_data.len() as u64,
+                trampoline_data.len() as u64 + 7,
                 "x86_64 trampoline jump-back base",
             )?;
-            let jmp_back_base =
-                checked_add_u64(jmp_back_base, 7, "x86_64 trampoline jump-back base")?;
             trampoline_data.extend_from_slice(&[0x48, 0x8D, 0x0D]); // LEA RCX, [RIP + disp32]
             trampoline_data.extend_from_slice(&rel32_bytes(
                 return_addr,
@@ -493,10 +505,9 @@ fn hook_syscalls_in_section(
             // We want: RIP + disp32 = syscall_entry_addr
             let entry_base = checked_add_u64(
                 trampoline_base_addr,
-                trampoline_data.len() as u64,
+                trampoline_data.len() as u64 + 4,
                 "x86_64 trampoline entry base",
             )?;
-            let entry_base = checked_add_u64(entry_base, 4, "x86_64 trampoline entry base")?;
             trampoline_data.extend_from_slice(&rel32_bytes(
                 syscall_entry_addr,
                 entry_base,
@@ -512,10 +523,9 @@ fn hook_syscalls_in_section(
             // We want: EAX + offset = syscall_entry_addr
             let call_base = checked_add_u64(
                 trampoline_base_addr,
-                trampoline_data.len() as u64,
+                trampoline_data.len() as u64 - 3,
                 "x86 trampoline entry base",
             )?;
-            let call_base = checked_sub_u64(call_base, 3, "x86 trampoline entry base")?;
             trampoline_data.extend_from_slice(&rel32_bytes(
                 syscall_entry_addr,
                 call_base,
@@ -527,10 +537,9 @@ fn hook_syscalls_in_section(
             // Add jmp back to original after syscall
             let jmp_back_base = checked_add_u64(
                 trampoline_base_addr,
-                trampoline_data.len() as u64,
+                trampoline_data.len() as u64 + 5,
                 "x86 trampoline jump-back base",
             )?;
-            let jmp_back_base = checked_add_u64(jmp_back_base, 5, "x86 trampoline jump-back base")?;
             trampoline_data.push(0xE9);
             trampoline_data.extend_from_slice(&rel32_bytes(
                 return_addr,
@@ -651,7 +660,7 @@ fn fixup_phdr_alignment(buf: &mut [u8]) {
             break;
         }
         let p_type = u32::from_le_bytes(buf[entry_off..entry_off + 4].try_into().unwrap());
-        if p_type == 6 {
+        if p_type == object::elf::PT_PHDR {
             // PT_PHDR — update p_offset to match new location
             let p_offset_off = entry_off + 8;
             let old_p_offset =
@@ -747,8 +756,7 @@ fn find_fork_vfork_patch(
 
 /// Check if the input binary has the Bun footer marker at the end.
 fn has_bun_footer_marker(input_binary: &[u8]) -> bool {
-    input_binary.len() >= BUN_FOOTER_MARKER.len()
-        && input_binary[input_binary.len() - BUN_FOOTER_MARKER.len()..] == *BUN_FOOTER_MARKER
+    input_binary.ends_with(BUN_FOOTER_MARKER)
 }
 
 /// Replace an unpatchable syscall instruction with `UD2` (`0F 0B`) so that
@@ -1075,10 +1083,9 @@ fn hook_syscall_and_after(
         // We want: RIP + disp32 = syscall_entry_addr
         let entry_base = checked_add_u64(
             trampoline_base_addr,
-            trampoline_data.len() as u64,
+            trampoline_data.len() as u64 + 4,
             "x86_64 trampoline entry base",
         )?;
-        let entry_base = checked_add_u64(entry_base, 4, "x86_64 trampoline entry base")?;
         trampoline_data.extend_from_slice(&rel32_bytes(
             syscall_entry_addr,
             entry_base,
@@ -1119,10 +1126,9 @@ fn hook_syscall_and_after(
     // Add jmp back to original after syscall
     let jmp_back_base = checked_add_u64(
         trampoline_base_addr,
-        trampoline_data.len() as u64,
+        trampoline_data.len() as u64 + 5,
         "trampoline jump-back base",
     )?;
-    let jmp_back_base = checked_add_u64(jmp_back_base, 5, "trampoline jump-back base")?;
     trampoline_data.push(0xE9);
     trampoline_data.extend_from_slice(&rel32_bytes(
         replace_end,
@@ -1262,10 +1268,9 @@ fn hook_syscall_before_and_after(
         let return_addr = next_inst.next_ip();
         let jmp_back_base = checked_add_u64(
             trampoline_base_addr,
-            trampoline_data.len() as u64,
+            trampoline_data.len() as u64 + 5,
             "x86 trampoline jump-back base",
         )?;
-        let jmp_back_base = checked_add_u64(jmp_back_base, 5, "x86 trampoline jump-back base")?;
         trampoline_data.push(0xE9);
         trampoline_data.extend_from_slice(&rel32_bytes(
             return_addr,

--- a/litebox_syscall_rewriter/src/lib.rs
+++ b/litebox_syscall_rewriter/src/lib.rs
@@ -34,10 +34,10 @@ use zerocopy::{FromBytes, Immutable, IntoBytes};
 pub enum Error {
     #[error("failed to parse: {0}")]
     ParseError(String),
-    #[error("unsupported executable")]
-    UnsupportedObjectFile,
-    #[error("unsupported Bun-packaged executable")]
-    UnsupportedBunExecutable,
+    #[error("unsupported object file: {0}")]
+    UnsupportedObjectFile(String),
+    #[error("unsupported executable: {0}")]
+    UnsupportedExecutable(String),
     #[error("executable is already hooked with trampoline")]
     AlreadyHooked,
     #[error("no .text section found")]
@@ -50,6 +50,8 @@ pub enum Error {
     InsufficientBytesBeforeOrAfter(u64),
     #[error("provided trampoline address is too large for 32-bit executable")]
     TrampolineAddressTooLarge,
+    #[error("patch failed: {0}")]
+    PatchError(String),
 }
 
 type Result<T> = core::result::Result<T, Error>;
@@ -109,16 +111,18 @@ struct TextSectionInfo {
 /// no syscall instructions are patched, the rewriter still appends the header and the initial
 /// syscall-entry placeholder so the loader/audit path can tell the binary was processed.
 ///
-/// `skipped_addrs` receives the virtual addresses of any `syscall`
-/// instructions that could not be patched (replaced with `UD2` so they
-/// trap instead of escaping to the host kernel).
+/// Returns a tuple of (rewritten binary, skipped syscall addresses). Skipped
+/// addresses are syscall instructions that could not be patched because there
+/// is not enough space around the instruction (replaced with `icebp; hlt` so
+/// they trap instead of escaping to the host kernel).
 pub fn hook_syscalls_in_elf(
     input_binary: &[u8],
     trampoline: Option<u64>,
-    skipped_addrs: &mut Vec<u64>,
-) -> Result<Vec<u8>> {
-    if has_bun_footer_marker(input_binary) {
-        return Err(Error::UnsupportedBunExecutable);
+) -> Result<(Vec<u8>, Vec<u64>)> {
+    if input_binary.ends_with(BUN_FOOTER_MARKER) {
+        return Err(Error::UnsupportedExecutable(
+            "Bun-packaged executable".into(),
+        ));
     }
 
     // Relocatable object files (.o) must not be patched: they are linker
@@ -129,7 +133,9 @@ pub fn hook_syscalls_in_elf(
         let e_type = u16::from_le_bytes([input_binary[16], input_binary[17]]);
         if e_type == object::elf::ET_REL {
             // ET_REL — relocatable object file
-            return Err(Error::UnsupportedObjectFile);
+            return Err(Error::UnsupportedObjectFile(
+                "relocatable object file".into(),
+            ));
         }
     }
 
@@ -153,7 +159,7 @@ pub fn hook_syscalls_in_elf(
         let arch = match file {
             object::File::Elf64(_) => Arch::X86_64,
             object::File::Elf32(_) => Arch::X86_32,
-            _ => return Err(Error::UnsupportedObjectFile),
+            _ => return Err(Error::UnsupportedObjectFile("not an ELF file".into())),
         };
 
         let dl_sysinfo_int80 = if arch == Arch::X86_32 {
@@ -192,6 +198,7 @@ pub fn hook_syscalls_in_elf(
         trampoline_data.extend_from_slice(&trampoline.to_le_bytes());
     }
     // Patch syscalls in-place in buf
+    let mut skipped_addrs = Vec::new();
     for s in &text_sections {
         let section_data = section_slice_mut(buf, s)?;
         match hook_syscalls_in_section(
@@ -203,9 +210,9 @@ pub fn hook_syscalls_in_elf(
             trampoline_base_addr, // entry point is at offset 0 of trampoline
             dl_sysinfo_int80,
             &mut trampoline_data,
-            skipped_addrs,
         ) {
-            Ok(()) | Err(Error::NoSyscallInstructionsFound) => {}
+            Ok(addrs) => skipped_addrs.extend(addrs),
+            Err(Error::NoSyscallInstructionsFound) => {}
             Err(e) => return Err(e),
         }
     }
@@ -246,7 +253,7 @@ pub fn hook_syscalls_in_elf(
         };
         out.extend_from_slice(header.as_bytes());
     }
-    Ok(out)
+    Ok((out, skipped_addrs))
 }
 
 /// (private) Get metadata for executable sections
@@ -350,10 +357,10 @@ fn hook_syscalls_in_section(
     syscall_entry_addr: u64,
     dl_sysinfo_int80: Option<u64>,
     trampoline_data: &mut Vec<u8>,
-    skipped_addrs: &mut Vec<u64>,
-) -> Result<()> {
+) -> Result<Vec<u64>> {
     let instructions = decode_section_instructions(arch, section_data, section_base_addr)?;
     let mut found_any = false;
+    let mut skipped_addrs = Vec::new();
     for (i, inst) in instructions.iter().enumerate() {
         // Forward search for `syscall` / `int 0x80` / `call DWORD PTR gs:0x10`
         match arch {
@@ -414,9 +421,9 @@ fn hook_syscalls_in_section(
             ) {
                 Ok(()) => {}
                 Err(Error::InsufficientBytesBeforeOrAfter(_)) => {
-                    // Replace the unpatchable syscall with UD2 so it traps
-                    // instead of escaping to the host kernel.
-                    replace_with_ud2(section_data, section_base_addr, inst);
+                    // Replace the unpatchable syscall with ICEBP;HLT so it
+                    // traps instead of escaping to the host kernel.
+                    replace_with_trap(section_data, section_base_addr, inst);
                     skipped_addrs.push(inst.ip());
                 }
                 Err(e) => return Err(e),
@@ -522,7 +529,7 @@ fn hook_syscalls_in_section(
     }
 
     if found_any {
-        Ok(())
+        Ok(skipped_addrs)
     } else {
         Err(Error::NoSyscallInstructionsFound)
     }
@@ -631,23 +638,29 @@ fn fixup_phdr_alignment(buf: &mut [u8]) {
     }
 }
 
-/// Check if the input binary has the Bun footer marker at the end.
-fn has_bun_footer_marker(input_binary: &[u8]) -> bool {
-    input_binary.ends_with(BUN_FOOTER_MARKER)
-}
-
-/// Replace an unpatchable syscall instruction with `UD2` (`0F 0B`) so that
-/// reaching it triggers SIGILL instead of silently escaping to the host kernel.
+/// Replace an unpatchable syscall instruction with `ICEBP; HLT` (`F1 F4`) so
+/// that reaching it traps instead of silently escaping to the host kernel.
+///
+/// We avoid `UD2` (`0F 0B`) because it commonly appears in binaries to mark
+/// `unreachable!()` paths.  The `ICEBP; HLT` sequence is a strong, distinctive
+/// indicator of "this syscall was intentionally poisoned" — `ICEBP` alone does
+/// not trap on Linux in userspace, but `HLT` does (SIGILL in ring 3), and the
+/// `F1` prefix makes it easy for a signal handler to distinguish an
+/// intentional break from a spurious one.
 ///
 /// `syscall` (0F 05) and `int 0x80` (CD 80) are both 2 bytes — same size as
-/// `ud2`. For `call DWORD PTR gs:0x10` (7 bytes), the remaining 5 bytes are
-/// filled with NOPs.
-fn replace_with_ud2(section_data: &mut [u8], section_base_addr: u64, inst: &iced_x86::Instruction) {
+/// `ICEBP; HLT`.  For `call DWORD PTR gs:0x10` (7 bytes), the remaining 5
+/// bytes are filled with NOPs.
+fn replace_with_trap(
+    section_data: &mut [u8],
+    section_base_addr: u64,
+    inst: &iced_x86::Instruction,
+) {
     let offset = usize::try_from(inst.ip() - section_base_addr).unwrap();
     let len = inst.len();
-    // UD2 = 0F 0B
-    section_data[offset] = 0x0F;
-    section_data[offset + 1] = 0x0B;
+    // ICEBP (F1) + HLT (F4): traps in userspace, easy to identify in a handler.
+    section_data[offset] = 0xF1;
+    section_data[offset + 1] = 0xF4;
     // Fill any remaining bytes (e.g. 7-byte `call gs:0x10`) with NOPs.
     for b in &mut section_data[offset + 2..offset + len] {
         *b = 0x90;
@@ -656,56 +669,40 @@ fn replace_with_ud2(section_data: &mut [u8], section_base_addr: u64, inst: &iced
 
 fn checked_add_u64(base: u64, addend: u64, context: &'static str) -> Result<u64> {
     base.checked_add(addend)
-        .ok_or_else(|| Error::ParseError(format!("{context} address overflow")))
+        .ok_or_else(|| Error::PatchError(format!("{context} address overflow")))
 }
 
 fn checked_sub_u64(base: u64, subtrahend: u64, context: &'static str) -> Result<u64> {
     base.checked_sub(subtrahend)
-        .ok_or_else(|| Error::ParseError(format!("{context} address underflow")))
+        .ok_or_else(|| Error::PatchError(format!("{context} address underflow")))
 }
 
 fn rel32_bytes(target: u64, base: u64, context: &'static str) -> Result<[u8; 4]> {
     let disp = i128::from(target) - i128::from(base);
     let disp = i32::try_from(disp).map_err(|_| {
-        Error::ParseError(format!(
+        Error::PatchError(format!(
             "{context} displacement out of range: target {target:#x}, base {base:#x}"
         ))
     })?;
     Ok(disp.to_le_bytes())
 }
 
-/// Patch a single mapped code segment in-place, returning trampoline stubs.
+/// Patch a single mapped code segment in-place, returning trampoline stubs and
+/// the addresses of any syscall instructions that could not be patched
+/// (replaced with `ICEBP; HLT` so they trap instead of escaping to the host
+/// kernel).
 ///
 /// This is the runtime counterpart to [`hook_syscalls_in_elf`]. Instead of
 /// processing a whole ELF file, it operates on a single already-mapped code
 /// region — the caller is responsible for making the region writable before
-/// calling and restoring permissions afterwards.
-///
-/// # Arguments
-///
-/// * `code` — mutable slice of the mapped code segment.
-/// * `code_vaddr` — virtual address of `code[0]` in guest memory.
-/// * `trampoline_write_vaddr` — virtual address where the returned stub bytes
-///   will be placed by the caller.
-/// * `syscall_entry_addr` — address of the 8-byte entry-point value that
-///   each stub's indirect jump targets.
-///
-/// # Returns
-///
-/// The trampoline stub bytes. The caller must copy them to
-/// `trampoline_write_vaddr`. Returns an empty `Vec` if no syscall
-/// instructions are found in `code`.
-///
-/// `skipped_addrs` receives the virtual addresses of any `syscall`
-/// instructions that could not be patched (replaced with `UD2` so they
-/// trap instead of escaping to the host kernel).
+/// calling and restoring permissions afterwards. The caller must copy the
+/// returned stubs to `trampoline_write_vaddr`.
 pub fn patch_code_segment(
     code: &mut [u8],
     code_vaddr: u64,
     trampoline_write_vaddr: u64,
     syscall_entry_addr: u64,
-    skipped_addrs: &mut Vec<u64>,
-) -> Result<Vec<u8>> {
+) -> Result<(Vec<u8>, Vec<u64>)> {
     let arch = Arch::X86_64; // runtime patching is x86-64 only
 
     // Build control-transfer targets for this segment.
@@ -728,10 +725,9 @@ pub fn patch_code_segment(
         syscall_entry_addr,
         None, // dl_sysinfo_int80 — not applicable on x86-64
         &mut trampoline_data,
-        skipped_addrs,
     ) {
-        Ok(()) => Ok(trampoline_data),
-        Err(Error::NoSyscallInstructionsFound) => Ok(Vec::new()),
+        Ok(skipped_addrs) => Ok((trampoline_data, skipped_addrs)),
+        Err(Error::NoSyscallInstructionsFound) => Ok((Vec::new(), Vec::new())),
         Err(e) => Err(e),
     }
 }

--- a/litebox_syscall_rewriter/src/lib.rs
+++ b/litebox_syscall_rewriter/src/lib.rs
@@ -58,19 +58,25 @@ type Result<T> = core::result::Result<T, Error>;
 
 const BUN_FOOTER_MARKER: &[u8] = b"\n---- Bun! ----\n";
 
-/// Log a standardized warning about unpatchable syscall instructions.
+/// Check for unpatchable syscall instructions and return an error if any exist.
 ///
-/// Call this after [`hook_syscalls_in_elf`] or [`patch_code_segment`] when the
-/// returned `skipped_addrs` list is non-empty.
-pub fn warn_skipped(path: &str, skipped_addrs: &[u64]) {
-    if !skipped_addrs.is_empty() {
-        litebox_util_log::warn!(
-            path:% = path,
-            count:% = skipped_addrs.len(),
-            addrs:? = skipped_addrs;
-            "unpatchable syscall instruction(s)"
-        );
+/// Call this after [`hook_syscalls_in_elf`] or [`patch_code_segment`] to ensure
+/// all syscall instructions were successfully patched. Logs the skipped
+/// addresses as a warning before returning the error.
+pub fn ensure_all_patched(path: &str, skipped_addrs: &[u64]) -> Result<()> {
+    if skipped_addrs.is_empty() {
+        return Ok(());
     }
+    litebox_util_log::warn!(
+        path:% = path,
+        count:% = skipped_addrs.len(),
+        addrs:? = skipped_addrs;
+        "unpatchable syscall instruction(s)"
+    );
+    Err(Error::PatchError(format!(
+        "{path} has {} unpatchable syscall instruction(s) at {skipped_addrs:?}",
+        skipped_addrs.len(),
+    )))
 }
 
 /// The magic bytes used to identify the trampoline data.

--- a/litebox_syscall_rewriter/src/lib.rs
+++ b/litebox_syscall_rewriter/src/lib.rs
@@ -14,7 +14,14 @@
 //!
 //! This crate currently only supports x86-64 (i.e., amd64) ELFs.
 
-use std::collections::HashSet;
+#![cfg_attr(not(feature = "std"), no_std)]
+extern crate alloc;
+
+use alloc::collections::BTreeSet;
+use alloc::format;
+use alloc::string::{String, ToString};
+use alloc::vec;
+use alloc::vec::Vec;
 
 use object::read::elf::{ElfFile, ProgramHeader as _};
 use object::read::{Object as _, ObjectSection as _, ObjectSymbol as _};
@@ -29,6 +36,8 @@ pub enum Error {
     ParseError(String),
     #[error("unsupported executable")]
     UnsupportedObjectFile,
+    #[error("unsupported Bun-packaged executable")]
+    UnsupportedBunExecutable,
     #[error("executable is already hooked with trampoline")]
     AlreadyHooked,
     #[error("no .text section found")]
@@ -43,7 +52,9 @@ pub enum Error {
     TrampolineAddressTooLarge,
 }
 
-type Result<T> = std::result::Result<T, Error>;
+type Result<T> = core::result::Result<T, Error>;
+
+const BUN_FOOTER_MARKER: &[u8] = b"\n---- Bun! ----\n";
 
 /// The magic bytes used to identify the trampoline data.
 /// This is checked by the loader to verify that the trampoline is valid.
@@ -95,7 +106,31 @@ struct TextSectionInfo {
 /// - trampoline size (8 bytes for 64-bit, 4 bytes for 32-bit)
 ///
 /// This layout allows loaders to read just the last 32/20 bytes to get the metadata.
-pub fn hook_syscalls_in_elf(input_binary: &[u8], trampoline: Option<u64>) -> Result<Vec<u8>> {
+///
+/// `skipped_addrs` receives the virtual addresses of any `syscall`
+/// instructions that could not be patched (replaced with `UD2` so they
+/// trap instead of escaping to the host kernel).
+pub fn hook_syscalls_in_elf(
+    input_binary: &[u8],
+    trampoline: Option<u64>,
+    skipped_addrs: &mut Vec<u64>,
+) -> Result<Vec<u8>> {
+    if has_bun_footer_marker(input_binary) {
+        return Err(Error::UnsupportedBunExecutable);
+    }
+
+    // Relocatable object files (.o) must not be patched: they are linker
+    // input, not executable code. Rewriting instructions or appending
+    // trampoline data would corrupt the object file for the linker.
+    // Check the ELF e_type field (bytes 16..18) before doing any work.
+    if input_binary.len() >= 18 {
+        let e_type = u16::from_le_bytes([input_binary[16], input_binary[17]]);
+        if e_type == 1 {
+            // ET_REL — relocatable object file
+            return Err(Error::UnsupportedObjectFile);
+        }
+    }
+
     // Make a single mutable, 8-byte-aligned copy of the input binary. This serves as both the
     // parse buffer (object::File::parse requires 8-byte alignment) and the output buffer for
     // in-place patching. We use a Vec<u64> to guarantee alignment, then view it as bytes.
@@ -104,8 +139,20 @@ pub fn hook_syscalls_in_elf(input_binary: &[u8], trampoline: Option<u64>) -> Res
     buf[..input_binary.len()].copy_from_slice(input_binary);
     let buf = &mut buf[..input_binary.len()];
 
+    // Some ELF files (e.g. Node.js SEA binaries) have a program header table at an offset that
+    // is not 8-byte aligned, which the `object` crate rejects. Fix this by relocating the phdr
+    // table within our mutable copy so it sits at an 8-byte aligned offset.
+    fixup_phdr_alignment(buf);
+
     // Parse the ELF and extract all metadata we need, then drop the borrow so we can mutate buf.
-    let (arch, dl_sysinfo_int80, text_sections, control_transfer_targets, trampoline_base_addr) = {
+    let (
+        arch,
+        dl_sysinfo_int80,
+        text_sections,
+        control_transfer_targets,
+        trampoline_base_addr,
+        fork_to_vfork_patch,
+    ) = {
         let file = object::File::parse(&*buf).map_err(|e| Error::ParseError(e.to_string()))?;
 
         let arch = match file {
@@ -130,12 +177,15 @@ pub fn hook_syscalls_in_elf(input_binary: &[u8], trampoline: Option<u64>) -> Res
 
         let trampoline_base_addr = find_addr_for_trampoline_code(&file);
 
+        let fork_to_vfork_patch = find_fork_vfork_patch(&file, &text_sections);
+
         (
             arch,
             dl_sysinfo_int80,
             text_sections,
             control_transfer_targets,
             trampoline_base_addr,
+            fork_to_vfork_patch,
         )
     };
 
@@ -151,7 +201,6 @@ pub fn hook_syscalls_in_elf(input_binary: &[u8], trampoline: Option<u64>) -> Res
     }
 
     // Patch syscalls in-place in buf
-    let mut syscall_insns_found = false;
     for s in &text_sections {
         let section_data = section_slice_mut(buf, s)?;
         match hook_syscalls_in_section(
@@ -160,19 +209,31 @@ pub fn hook_syscalls_in_elf(input_binary: &[u8], trampoline: Option<u64>) -> Res
             s.vaddr,
             section_data,
             trampoline_base_addr,
+            trampoline_base_addr, // entry point is at offset 0 of trampoline
             dl_sysinfo_int80,
             &mut trampoline_data,
+            skipped_addrs,
         ) {
-            Ok(()) => {
-                syscall_insns_found = true;
-            }
-            Err(Error::NoSyscallInstructionsFound) => {}
+            Ok(()) | Err(Error::NoSyscallInstructionsFound) => {}
             Err(e) => return Err(e),
         }
     }
 
-    if !syscall_insns_found {
-        return Err(Error::NoSyscallInstructionsFound);
+    // Patch fork → vfork: overwrite the first bytes of __libc_fork with a
+    // JMP to __libc_vfork. This prevents glibc's fork wrapper from running
+    // post-fork handlers that corrupt shared state under vfork semantics.
+    if let Some((fork_file_offset, rel32)) = fork_to_vfork_patch {
+        #[allow(clippy::cast_possible_truncation)]
+        let off = fork_file_offset as usize;
+        if off + 5 <= buf.len() {
+            buf[off] = 0xE9; // JMP rel32
+            buf[off + 1..off + 5].copy_from_slice(&rel32.to_le_bytes());
+        } else {
+            return Err(Error::ParseError(format!(
+                "fork→vfork patch offset {off:#x} + 5 exceeds buffer length {}",
+                buf.len()
+            )));
+        }
     }
 
     // Build output: [patched ELF][padding to page boundary][trampoline code][header]
@@ -301,17 +362,24 @@ enum Arch {
 }
 
 /// (private) Hook all syscalls in `section`, possibly extending `trampoline_data` to do so.
+///
+/// `trampoline_base_addr` is the virtual address corresponding to `trampoline_data[0]`.
+/// `syscall_entry_addr` is the address of the 8-byte entry-point value that each trampoline
+/// stub jumps to (via `JMP [RIP+disp32]` on x86-64 or `CALL [EAX+disp32]` on x86-32).
 #[allow(clippy::too_many_arguments)]
 fn hook_syscalls_in_section(
     arch: Arch,
-    control_transfer_targets: &HashSet<u64>,
+    control_transfer_targets: &BTreeSet<u64>,
     section_base_addr: u64,
     section_data: &mut [u8],
     trampoline_base_addr: u64,
+    syscall_entry_addr: u64,
     dl_sysinfo_int80: Option<u64>,
     trampoline_data: &mut Vec<u8>,
+    skipped_addrs: &mut Vec<u64>,
 ) -> Result<()> {
     let instructions = decode_section_instructions(arch, section_data, section_base_addr)?;
+    let mut found_any = false;
     for (i, inst) in instructions.iter().enumerate() {
         // Forward search for `syscall` / `int 0x80` / `call DWORD PTR gs:0x10`
         match arch {
@@ -335,6 +403,7 @@ fn hook_syscalls_in_section(
             }
         }
 
+        found_any = true;
         let replace_end = inst.next_ip();
 
         let mut replace_start = None;
@@ -358,16 +427,26 @@ fn hook_syscalls_in_section(
         }
 
         if replace_start.is_none() {
-            hook_syscall_and_after(
+            match hook_syscall_and_after(
                 arch,
                 control_transfer_targets,
                 section_base_addr,
                 section_data,
                 trampoline_base_addr,
+                syscall_entry_addr,
                 trampoline_data,
                 &instructions,
                 i,
-            )?;
+            ) {
+                Ok(()) => {}
+                Err(Error::InsufficientBytesBeforeOrAfter(_)) => {
+                    // Replace the unpatchable syscall with UD2 so it traps
+                    // instead of escaping to the host kernel.
+                    replace_with_ud2(section_data, section_base_addr, inst);
+                    skipped_addrs.push(inst.ip());
+                }
+                Err(e) => return Err(e),
+            }
             continue;
         }
 
@@ -394,28 +473,29 @@ fn hook_syscalls_in_section(
                 .extend_from_slice(&(i32::try_from(jmp_back_offset).unwrap().to_le_bytes()));
 
             // Add jmp [rip + offset_to_entry_point]
-            // Entry point is at offset 0 of trampoline_data
             trampoline_data.extend_from_slice(&[0xFF, 0x25]);
-            // disp32 points to offset 0 (entry point) from current RIP
             // RIP after this instruction = trampoline_base_addr + trampoline_data.len() + 4
-            // We want: RIP + disp32 = trampoline_base_addr + 0
-            // So: disp32 = -(trampoline_data.len() + 4)
-            let disp32 = -(i32::try_from(trampoline_data.len()).unwrap() + 4);
-            trampoline_data.extend_from_slice(&disp32.to_le_bytes());
+            // We want: RIP + disp32 = syscall_entry_addr
+            #[allow(clippy::cast_possible_wrap)]
+            let disp32 = i64::try_from(syscall_entry_addr).unwrap()
+                - i64::try_from(trampoline_base_addr).unwrap()
+                - trampoline_data.len() as i64
+                - 4;
+            trampoline_data.extend_from_slice(&(i32::try_from(disp32).unwrap().to_le_bytes()));
         } else {
             // For 32-bit, use a different approach to simulate indirect call
-            // Entry point is at offset 0 of trampoline_data
             trampoline_data.push(0x50); // PUSH EAX
             trampoline_data.extend_from_slice(&[0xE8, 0x0, 0x0, 0x0, 0x0]); // CALL next instruction
             trampoline_data.push(0x58); // POP EAX (effectively store IP in EAX)
             trampoline_data.extend_from_slice(&[0xFF, 0x90]); // CALL [EAX + offset]
-            // The offset should point to the entry at offset 0
-            // After PUSH(1) + CALL(5) + POP(1) + opcode(2) = 9 bytes
-            // EAX = base + (len_before_PUSH + 6) = base + (current_len - 9 + 6) = base + (current_len - 3)
-            // We want: EAX + offset = base + 0
-            // So: offset = -(current_len - 3)
-            let disp32 = -(i32::try_from(trampoline_data.len()).unwrap() - 3);
-            trampoline_data.extend_from_slice(&disp32.to_le_bytes());
+            // EAX = trampoline_base_addr + (trampoline_data.len() - 3)
+            // We want: EAX + offset = syscall_entry_addr
+            #[allow(clippy::cast_possible_wrap)]
+            let disp32 = i64::try_from(syscall_entry_addr).unwrap()
+                - i64::try_from(trampoline_base_addr).unwrap()
+                - trampoline_data.len() as i64
+                + 3;
+            trampoline_data.extend_from_slice(&(i32::try_from(disp32).unwrap().to_le_bytes()));
             // Note we skip `POP EAX` here as it is done by the callback `syscall_callback`
             // from litebox_shim_linux/src/lib.rs, which helps reduce the size of the trampoline.
 
@@ -441,7 +521,226 @@ fn hook_syscalls_in_section(
         }
     }
 
-    Ok(())
+    if found_any {
+        Ok(())
+    } else {
+        Err(Error::NoSyscallInstructionsFound)
+    }
+}
+
+/// If the ELF64 program header table offset (`e_phoff`) is not 8-byte aligned, shift the table
+/// forward by the necessary padding so the `object` crate can parse it. This is needed for
+/// binaries like Node.js SEA executables where post-link tools append data and relocate the
+/// program headers to a non-aligned offset.
+///
+/// The function modifies the buffer in-place: it moves the phdr table contents and updates
+/// `e_phoff` in the ELF header. Only ELF64 files are handled (ELF32 requires 4-byte alignment
+/// which is always satisfied when `e_phoff` is within a valid file).
+fn fixup_phdr_alignment(buf: &mut [u8]) {
+    // Minimum ELF header size for ELF64
+    if buf.len() < 64 {
+        return;
+    }
+
+    // Check ELF magic and class (must be ELF64)
+    if &buf[0..4] != b"\x7fELF" || buf[4] != 2 {
+        return;
+    }
+
+    let e_phoff = u64::from_le_bytes(buf[32..40].try_into().unwrap());
+    let e_phentsize = u64::from(u16::from_le_bytes(buf[54..56].try_into().unwrap()));
+    let e_phnum = u64::from(u16::from_le_bytes(buf[56..58].try_into().unwrap()));
+
+    if e_phoff == 0 || e_phnum == 0 || e_phentsize == 0 {
+        return;
+    }
+
+    let misalignment = e_phoff % 8;
+    if misalignment == 0 {
+        return; // already aligned
+    }
+
+    let phdr_size = e_phentsize * e_phnum;
+    let old_start = usize::try_from(e_phoff).expect("e_phoff must fit in usize");
+    let old_end = old_start + usize::try_from(phdr_size).expect("phdr_size must fit in usize");
+
+    // Shift forward to align: new offset is the next 8-byte boundary.
+    let padding = usize::try_from(8 - misalignment).expect("padding must fit in usize");
+    let new_start = old_start + padding;
+    let new_end = new_start + usize::try_from(phdr_size).expect("phdr_size must fit in usize");
+
+    if old_end > buf.len() || new_end > buf.len() {
+        return; // corrupt phdr table or not enough room
+    }
+
+    // Move the phdr table forward (use copy_within since src and dst overlap).
+    buf.copy_within(old_start..old_end, new_start);
+
+    // Update e_phoff in the ELF header.
+    let new_phoff = (e_phoff + padding as u64).to_le_bytes();
+    buf[32..40].copy_from_slice(&new_phoff);
+
+    // Also update the PHDR segment's p_offset if present, so it matches.
+    // PT_PHDR = 6, each Elf64_Phdr is e_phentsize bytes, p_type at offset 0, p_offset at offset 8.
+    for i in 0..e_phnum {
+        let entry_off = new_start
+            + usize::try_from(i).expect("i must fit in usize")
+                * usize::try_from(e_phentsize).expect("e_phentsize must fit in usize");
+        if entry_off + 16 > buf.len() {
+            break;
+        }
+        let p_type = u32::from_le_bytes(buf[entry_off..entry_off + 4].try_into().unwrap());
+        if p_type == 6 {
+            // PT_PHDR — update p_offset to match new location
+            let p_offset_off = entry_off + 8;
+            let old_p_offset =
+                u64::from_le_bytes(buf[p_offset_off..p_offset_off + 8].try_into().unwrap());
+            if old_p_offset == e_phoff {
+                let new_p_offset = (old_p_offset + padding as u64).to_le_bytes();
+                buf[p_offset_off..p_offset_off + 8].copy_from_slice(&new_p_offset);
+            }
+            // The PHDR segment size should match the phdr table; no change needed.
+        }
+    }
+}
+
+/// Find fork and vfork symbols in the ELF and compute the patch needed to
+/// redirect fork -> vfork. Returns `Some((fork_file_offset, jmp_rel32))` if
+/// both symbols are found, or `None` if this binary doesn't export fork.
+fn find_fork_vfork_patch(
+    file: &object::File<'_>,
+    text_sections: &[TextSectionInfo],
+) -> Option<(u64, i32)> {
+    use object::ObjectSymbol as _;
+
+    // Search both .dynsym and .symtab for fork/vfork.
+    let mut fork_vaddr = None;
+    let mut vfork_vaddr = None;
+
+    for sym in file.dynamic_symbols().chain(file.symbols()) {
+        if sym.kind() != object::SymbolKind::Text {
+            continue;
+        }
+        let Ok(name) = sym.name() else { continue };
+        match name {
+            "fork" | "__libc_fork" if fork_vaddr.is_none() => {
+                fork_vaddr = Some(sym.address());
+            }
+            "vfork" | "__libc_vfork" | "__vfork" if vfork_vaddr.is_none() => {
+                vfork_vaddr = Some(sym.address());
+            }
+            _ => {}
+        }
+    }
+
+    let fork_vaddr = fork_vaddr?;
+    let vfork_vaddr = vfork_vaddr?;
+
+    // Convert fork's vaddr to a file offset using the text sections.
+    let fork_file_offset = text_sections.iter().find_map(|s| {
+        let section_end = s.vaddr + s.size;
+        if fork_vaddr >= s.vaddr && fork_vaddr < section_end {
+            Some(s.file_offset + (fork_vaddr - s.vaddr))
+        } else {
+            None
+        }
+    })?;
+
+    // Compute the relative offset for a JMP rel32 instruction.
+    // JMP rel32 encodes: target = rip_after_jmp + rel32
+    // rip_after_jmp = fork_vaddr + 5 (size of JMP rel32 instruction)
+    let rel32 = i64::try_from(vfork_vaddr)
+        .ok()?
+        .checked_sub(i64::try_from(fork_vaddr).ok()? + 5)?;
+    let rel32 = i32::try_from(rel32).ok()?;
+
+    Some((fork_file_offset, rel32))
+}
+
+/// Check if the input binary has the Bun footer marker at the end.
+fn has_bun_footer_marker(input_binary: &[u8]) -> bool {
+    input_binary.len() >= BUN_FOOTER_MARKER.len()
+        && input_binary[input_binary.len() - BUN_FOOTER_MARKER.len()..] == *BUN_FOOTER_MARKER
+}
+
+/// Replace an unpatchable syscall instruction with `UD2` (`0F 0B`) so that
+/// reaching it triggers SIGILL instead of silently escaping to the host kernel.
+///
+/// `syscall` (0F 05) and `int 0x80` (CD 80) are both 2 bytes — same size as
+/// `ud2`. For `call DWORD PTR gs:0x10` (7 bytes), the remaining 5 bytes are
+/// filled with NOPs.
+fn replace_with_ud2(section_data: &mut [u8], section_base_addr: u64, inst: &iced_x86::Instruction) {
+    let offset = usize::try_from(inst.ip() - section_base_addr).unwrap();
+    let len = inst.len();
+    // UD2 = 0F 0B
+    section_data[offset] = 0x0F;
+    section_data[offset + 1] = 0x0B;
+    // Fill any remaining bytes (e.g. 7-byte `call gs:0x10`) with NOPs.
+    for b in &mut section_data[offset + 2..offset + len] {
+        *b = 0x90;
+    }
+}
+
+/// Patch a single mapped code segment in-place, returning trampoline stubs.
+///
+/// This is the runtime counterpart to [`hook_syscalls_in_elf`]. Instead of
+/// processing a whole ELF file, it operates on a single already-mapped code
+/// region — the caller is responsible for making the region writable before
+/// calling and restoring permissions afterwards.
+///
+/// # Arguments
+///
+/// * `code` — mutable slice of the mapped code segment.
+/// * `code_vaddr` — virtual address of `code[0]` in guest memory.
+/// * `trampoline_write_vaddr` — virtual address where the returned stub bytes
+///   will be placed by the caller.
+/// * `syscall_entry_addr` — address of the 8-byte entry-point value that
+///   each stub's indirect jump targets.
+///
+/// # Returns
+///
+/// The trampoline stub bytes. The caller must copy them to
+/// `trampoline_write_vaddr`. Returns an empty `Vec` if no syscall
+/// instructions are found in `code`.
+///
+/// `skipped_addrs` receives the virtual addresses of any `syscall`
+/// instructions that could not be patched (replaced with `UD2` so they
+/// trap instead of escaping to the host kernel).
+pub fn patch_code_segment(
+    code: &mut [u8],
+    code_vaddr: u64,
+    trampoline_write_vaddr: u64,
+    syscall_entry_addr: u64,
+    skipped_addrs: &mut Vec<u64>,
+) -> Result<Vec<u8>> {
+    let arch = Arch::X86_64; // runtime patching is x86-64 only
+
+    // Build control-transfer targets for this segment.
+    let instructions = decode_section_instructions(arch, code, code_vaddr)?;
+    let mut control_transfer_targets = BTreeSet::new();
+    for inst in &instructions {
+        let target = inst.near_branch_target();
+        if target != 0 {
+            control_transfer_targets.insert(target);
+        }
+    }
+
+    let mut trampoline_data = Vec::new();
+    match hook_syscalls_in_section(
+        arch,
+        &control_transfer_targets,
+        code_vaddr,
+        code,
+        trampoline_write_vaddr,
+        syscall_entry_addr,
+        None, // dl_sysinfo_int80 — not applicable on x86-64
+        &mut trampoline_data,
+        skipped_addrs,
+    ) {
+        Ok(()) => Ok(trampoline_data),
+        Err(Error::NoSyscallInstructionsFound) => Ok(Vec::new()),
+        Err(e) => Err(e),
+    }
 }
 
 fn find_addr_for_trampoline_code(file: &object::File<'_>) -> u64 {
@@ -485,8 +784,8 @@ fn get_control_transfer_targets(
     arch: Arch,
     input_binary: &[u8],
     text_sections: &[TextSectionInfo],
-) -> Result<HashSet<u64>> {
-    let mut control_transfer_targets = HashSet::new();
+) -> Result<BTreeSet<u64>> {
+    let mut control_transfer_targets = BTreeSet::new();
     for s in text_sections {
         let section_data = section_slice(input_binary, s)?;
         let instructions = decode_section_instructions(arch, section_data, s.vaddr)?;
@@ -595,10 +894,11 @@ fn section_slice_mut<'a>(buf: &'a mut [u8], section: &TextSectionInfo) -> Result
 #[allow(clippy::too_many_arguments)]
 fn hook_syscall_and_after(
     arch: Arch,
-    control_transfer_targets: &HashSet<u64>,
+    control_transfer_targets: &BTreeSet<u64>,
     section_base_addr: u64,
     section_data: &mut [u8],
     trampoline_base_addr: u64,
+    syscall_entry_addr: u64,
     trampoline_data: &mut Vec<u8>,
     instructions: &[iced_x86::Instruction],
     inst_index: usize,
@@ -613,7 +913,6 @@ fn hook_syscall_and_after(
             && control_transfer_targets.contains(&next_inst.ip())
         {
             // If the next instruction is a control transfer target, we don't want to cross it
-            println!("Skipping control transfer target at {:#x}", next_inst.ip());
             break;
         }
         // Check if the instruction does control transfer
@@ -639,6 +938,7 @@ fn hook_syscall_and_after(
             section_base_addr,
             section_data,
             trampoline_base_addr,
+            syscall_entry_addr,
             trampoline_data,
             instructions,
             inst_index,
@@ -654,28 +954,29 @@ fn hook_syscall_and_after(
         trampoline_data.extend_from_slice(&[0x48, 0x8D, 0x0D]); // LEA RCX, [RIP + disp32]
         trampoline_data.extend_from_slice(&6u32.to_le_bytes());
         // Add jmp [rip + offset_to_entry_point]
-        // Entry point is at offset 0 of trampoline_data
         trampoline_data.extend_from_slice(&[0xFF, 0x25]);
-        // disp32 points to offset 0 (entry point) from current RIP
         // RIP after this instruction = trampoline_base_addr + trampoline_data.len() + 4
-        // We want: RIP + disp32 = trampoline_base_addr + 0
-        // So: disp32 = -(trampoline_data.len() + 4)
-        let disp32 = -(i32::try_from(trampoline_data.len()).unwrap() + 4);
-        trampoline_data.extend_from_slice(&disp32.to_le_bytes());
+        // We want: RIP + disp32 = syscall_entry_addr
+        #[allow(clippy::cast_possible_wrap)]
+        let disp32 = i64::try_from(syscall_entry_addr).unwrap()
+            - i64::try_from(trampoline_base_addr).unwrap()
+            - trampoline_data.len() as i64
+            - 4;
+        trampoline_data.extend_from_slice(&(i32::try_from(disp32).unwrap().to_le_bytes()));
     } else {
         // For 32-bit, use a different approach to simulate indirect call
-        // Entry point is at offset 0 of trampoline_data
         trampoline_data.push(0x50); // PUSH EAX
         trampoline_data.extend_from_slice(&[0xE8, 0x0, 0x0, 0x0, 0x0]); // CALL next instruction
         trampoline_data.push(0x58); // POP EAX (effectively store IP in EAX)
         trampoline_data.extend_from_slice(&[0xFF, 0x90]); // CALL [EAX + offset]
-        // The offset should point to the entry at offset 0
-        // After PUSH(1) + CALL(5) + POP(1) + opcode(2) = 9 bytes
-        // EAX = base + (len_before_PUSH + 6) = base + (current_len - 9 + 6) = base + (current_len - 3)
-        // We want: EAX + offset = base + 0
-        // So: offset = -(current_len - 3)
-        let disp32 = -(i32::try_from(trampoline_data.len()).unwrap() - 3);
-        trampoline_data.extend_from_slice(&disp32.to_le_bytes());
+        // EAX = trampoline_base_addr + (trampoline_data.len() - 3)
+        // We want: EAX + offset = syscall_entry_addr
+        #[allow(clippy::cast_possible_wrap)]
+        let disp32 = i64::try_from(syscall_entry_addr).unwrap()
+            - i64::try_from(trampoline_base_addr).unwrap()
+            - trampoline_data.len() as i64
+            + 3;
+        trampoline_data.extend_from_slice(&(i32::try_from(disp32).unwrap().to_le_bytes()));
         // Note we skip `POP EAX` here as it is done by the callback `syscall_callback`
         // from litebox_shim_linux/src/lib.rs, which helps reduce the size of the trampoline.
     }
@@ -715,10 +1016,11 @@ fn hook_syscall_and_after(
 #[allow(clippy::too_many_arguments)]
 fn hook_syscall_before_and_after(
     arch: Arch,
-    control_transfer_targets: &HashSet<u64>,
+    control_transfer_targets: &BTreeSet<u64>,
     section_base_addr: u64,
     section_data: &mut [u8],
     trampoline_base_addr: u64,
+    syscall_entry_addr: u64,
     trampoline_data: &mut Vec<u8>,
     instructions: &[iced_x86::Instruction],
     inst_index: usize,
@@ -793,13 +1095,14 @@ fn hook_syscall_before_and_after(
     trampoline_data.extend_from_slice(&[0xE8, 0x0, 0x0, 0x0, 0x0]); // CALL next instruction
     trampoline_data.push(0x58); // POP EAX (effectively store IP in EAX)
     trampoline_data.extend_from_slice(&[0xFF, 0x90]); // CALL [EAX + offset]
-    // The offset should point to the entry at offset 0
-    // After PUSH(1) + CALL(5) + POP(1) + opcode(2) = 9 bytes
-    // EAX = base + (len_before_PUSH + 6) = base + (current_len - 9 + 6) = base + (current_len - 3)
-    // We want: EAX + offset = base + 0
-    // So: offset = -(current_len - 3)
-    let disp32 = -(i32::try_from(trampoline_data.len()).unwrap() - 3);
-    trampoline_data.extend_from_slice(&disp32.to_le_bytes());
+    // EAX = trampoline_base_addr + (trampoline_data.len() - 3)
+    // We want: EAX + offset = syscall_entry_addr
+    #[allow(clippy::cast_possible_wrap)]
+    let disp32 = i64::try_from(syscall_entry_addr).unwrap()
+        - i64::try_from(trampoline_base_addr).unwrap()
+        - trampoline_data.len() as i64
+        + 3;
+    trampoline_data.extend_from_slice(&(i32::try_from(disp32).unwrap().to_le_bytes()));
     // Note we skip `POP EAX` here as it is done by the callback `syscall_callback`
     // from litebox_shim_linux/src/lib.rs, which helps reduce the size of the trampoline.
 

--- a/litebox_syscall_rewriter/src/lib.rs
+++ b/litebox_syscall_rewriter/src/lib.rs
@@ -121,7 +121,7 @@ struct TextSectionInfo {
 /// - trampoline size (8 bytes for 64-bit, 4 bytes for 32-bit)
 ///
 /// This layout allows loaders to read just the last 32/20 bytes to get the metadata. Even when
-/// no syscall instructions are patched, the rewriter still appends the header and the initial
+/// there is no syscall instruction in the binary, the rewriter still appends the header and the initial
 /// syscall-entry placeholder so the loader/audit path can tell the binary was processed.
 ///
 /// Returns the rewritten binary. Binaries that cannot or do not need to be

--- a/litebox_syscall_rewriter/src/lib.rs
+++ b/litebox_syscall_rewriter/src/lib.rs
@@ -34,24 +34,37 @@ use zerocopy::{FromBytes, Immutable, IntoBytes};
 pub enum Error {
     #[error("failed to parse: {0}")]
     ParseError(String),
-    #[error("unsupported object file: {0}")]
-    UnsupportedObjectFile(String),
     #[error("unsupported executable: {0}")]
     UnsupportedExecutable(String),
-    #[error("executable is already hooked with trampoline")]
-    AlreadyHooked,
-    #[error("no .text section found")]
-    NoTextSectionFound,
-    #[error("no syscall instructions found")]
-    NoSyscallInstructionsFound,
     #[error("failed to disassemble: {0}")]
     DisassemblyFailure(String),
-    #[error("insufficient bytes before or after syscall at {0:#x}")]
-    InsufficientBytesBeforeOrAfter(u64),
     #[error("provided trampoline address is too large for 32-bit executable")]
     TrampolineAddressTooLarge,
-    #[error("patch failed: {0}")]
-    PatchError(String),
+    #[error("address overflow: {0}")]
+    AddressOverflow(String),
+    #[error("unpatchable syscall instruction(s): {0}")]
+    UnpatchableSyscalls(String),
+}
+
+/// Internal-only error variants used for control flow within the crate.
+/// These are never exposed to callers — they are caught and handled (or
+/// converted to [`Error`]) before reaching the public API boundary.
+#[derive(Debug)]
+enum InternalError {
+    /// A public error that should be propagated as-is.
+    Public(Error),
+    /// No executable `.text` section was found.
+    NoTextSectionFound,
+    /// No `syscall`/`int 0x80`/`call gs:0x10` instructions were found.
+    NoSyscallInstructionsFound,
+    /// Insufficient space around a syscall instruction to patch it.
+    InsufficientBytesBeforeOrAfter,
+}
+
+impl From<Error> for InternalError {
+    fn from(e: Error) -> Self {
+        InternalError::Public(e)
+    }
 }
 
 type Result<T> = core::result::Result<T, Error>;
@@ -169,8 +182,9 @@ pub fn hook_syscalls_in_elf(input_binary: &[u8], trampoline: Option<u64>) -> Res
 
         let text_sections = match text_sections(&file) {
             Ok(sections) => sections,
-            Err(Error::NoTextSectionFound) => return Ok(input_binary.to_vec()),
-            Err(e) => return Err(e),
+            Err(InternalError::NoTextSectionFound) => return Ok(input_binary.to_vec()),
+            Err(InternalError::Public(e)) => return Err(e),
+            Err(e) => unreachable!("unexpected internal error: {e:?}"),
         };
 
         if is_already_hooked(&*buf, arch) {
@@ -215,8 +229,9 @@ pub fn hook_syscalls_in_elf(input_binary: &[u8], trampoline: Option<u64>) -> Res
             &mut trampoline_data,
         ) {
             Ok(addrs) => skipped_addrs.extend(addrs),
-            Err(Error::NoSyscallInstructionsFound) => {}
-            Err(e) => return Err(e),
+            Err(InternalError::NoSyscallInstructionsFound) => {}
+            Err(InternalError::Public(e)) => return Err(e),
+            Err(e) => unreachable!("unexpected internal error: {e:?}"),
         }
     }
 
@@ -257,7 +272,7 @@ pub fn hook_syscalls_in_elf(input_binary: &[u8], trampoline: Option<u64>) -> Res
         out.extend_from_slice(header.as_bytes());
     }
     if !skipped_addrs.is_empty() {
-        return Err(Error::PatchError(format!(
+        return Err(Error::UnpatchableSyscalls(format!(
             "{} unpatchable syscall instruction(s) at {skipped_addrs:?}",
             skipped_addrs.len(),
         )));
@@ -265,7 +280,9 @@ pub fn hook_syscalls_in_elf(input_binary: &[u8], trampoline: Option<u64>) -> Res
     Ok(out)
 }
 /// (private) Get metadata for executable sections
-fn text_sections(file: &object::File<'_>) -> Result<Vec<TextSectionInfo>> {
+fn text_sections(
+    file: &object::File<'_>,
+) -> core::result::Result<Vec<TextSectionInfo>, InternalError> {
     let text_sections: Vec<_> = file
         .sections()
         .filter_map(|s| {
@@ -290,7 +307,7 @@ fn text_sections(file: &object::File<'_>) -> Result<Vec<TextSectionInfo>> {
         })
         .collect();
     if text_sections.is_empty() {
-        return Err(Error::NoTextSectionFound);
+        return Err(InternalError::NoTextSectionFound);
     }
     Ok(text_sections)
 }
@@ -365,7 +382,7 @@ fn hook_syscalls_in_section(
     syscall_entry_addr: u64,
     dl_sysinfo_int80: Option<u64>,
     trampoline_data: &mut Vec<u8>,
-) -> Result<Vec<u64>> {
+) -> core::result::Result<Vec<u64>, InternalError> {
     let instructions = decode_section_instructions(arch, section_data, section_base_addr)?;
     let mut found_any = false;
     let mut skipped_addrs = Vec::new();
@@ -428,7 +445,7 @@ fn hook_syscalls_in_section(
                 i,
             ) {
                 Ok(()) => {}
-                Err(Error::InsufficientBytesBeforeOrAfter(_)) => {
+                Err(InternalError::InsufficientBytesBeforeOrAfter) => {
                     // Replace the unpatchable syscall with ICEBP;HLT so it
                     // traps instead of escaping to the host kernel.
                     replace_with_trap(section_data, section_base_addr, inst);
@@ -539,7 +556,7 @@ fn hook_syscalls_in_section(
     if found_any {
         Ok(skipped_addrs)
     } else {
-        Err(Error::NoSyscallInstructionsFound)
+        Err(InternalError::NoSyscallInstructionsFound)
     }
 }
 
@@ -651,12 +668,9 @@ fn fixup_phdr_alignment(buf: &mut [u8]) {
 /// Replace an unpatchable syscall instruction with `ICEBP; HLT` (`F1 F4`) so
 /// that reaching it traps instead of silently escaping to the host kernel.
 ///
-/// We avoid `UD2` (`0F 0B`) because it commonly appears in binaries to mark
-/// `unreachable!()` paths.  The `ICEBP; HLT` sequence is a strong, distinctive
-/// indicator of "this syscall was intentionally poisoned" — `ICEBP` alone does
-/// not trap on Linux in userspace, but `HLT` does (SIGSEGV in ring 3), and the
-/// `F1` prefix makes it easy for a signal handler to distinguish an
-/// intentional break from a spurious one.
+/// `ICEBP` alone does not trap on Linux in userspace, but `HLT` does
+/// (SIGSEGV in ring 3), and the `F1` prefix makes it easy for a signal
+/// handler to identify an intentionally poisoned syscall.
 ///
 /// `syscall` (0F 05) and `int 0x80` (CD 80) are both 2 bytes — same size as
 /// `ICEBP; HLT`.  For `call DWORD PTR gs:0x10` (7 bytes), the remaining 5
@@ -679,18 +693,18 @@ fn replace_with_trap(
 
 fn checked_add_u64(base: u64, addend: u64, context: &'static str) -> Result<u64> {
     base.checked_add(addend)
-        .ok_or_else(|| Error::PatchError(format!("{context} address overflow")))
+        .ok_or_else(|| Error::AddressOverflow(format!("{context} address overflow")))
 }
 
 fn checked_sub_u64(base: u64, subtrahend: u64, context: &'static str) -> Result<u64> {
     base.checked_sub(subtrahend)
-        .ok_or_else(|| Error::PatchError(format!("{context} address underflow")))
+        .ok_or_else(|| Error::AddressOverflow(format!("{context} address underflow")))
 }
 
 fn rel32_bytes(target: u64, base: u64, context: &'static str) -> Result<[u8; 4]> {
     let disp = i128::from(target) - i128::from(base);
     let disp = i32::try_from(disp).map_err(|_| {
-        Error::PatchError(format!(
+        Error::AddressOverflow(format!(
             "{context} displacement out of range: target {target:#x}, base {base:#x}"
         ))
     })?;
@@ -737,15 +751,16 @@ pub fn patch_code_segment(
     ) {
         Ok(skipped_addrs) => {
             if !skipped_addrs.is_empty() {
-                return Err(Error::PatchError(format!(
+                return Err(Error::UnpatchableSyscalls(format!(
                     "{} unpatchable syscall instruction(s) at {skipped_addrs:?}",
                     skipped_addrs.len(),
                 )));
             }
             Ok(trampoline_data)
         }
-        Err(Error::NoSyscallInstructionsFound) => Ok(Vec::new()),
-        Err(e) => Err(e),
+        Err(InternalError::NoSyscallInstructionsFound) => Ok(Vec::new()),
+        Err(InternalError::Public(e)) => Err(e),
+        Err(e) => unreachable!("unexpected internal error: {e:?}"),
     }
 }
 
@@ -912,7 +927,7 @@ fn hook_syscall_and_after(
     trampoline_data: &mut Vec<u8>,
     instructions: &[iced_x86::Instruction],
     inst_index: usize,
-) -> Result<()> {
+) -> core::result::Result<(), InternalError> {
     let syscall_inst = &instructions[inst_index];
 
     let replace_start = syscall_inst.ip();
@@ -1056,18 +1071,18 @@ fn hook_syscall_before_and_after(
     trampoline_data: &mut Vec<u8>,
     instructions: &[iced_x86::Instruction],
     inst_index: usize,
-) -> Result<()> {
+) -> core::result::Result<(), InternalError> {
     let syscall_inst = &instructions[inst_index];
     let syscall_inst_addr = syscall_inst.ip();
     // We only support this case for x86
     if arch != Arch::X86_32 {
-        return Err(Error::InsufficientBytesBeforeOrAfter(syscall_inst_addr));
+        return Err(InternalError::InsufficientBytesBeforeOrAfter);
     }
 
     // We expect at least one instruction before and one instruction
     // after the syscall instruction
     if inst_index == 0 || inst_index + 1 >= instructions.len() {
-        return Err(Error::InsufficientBytesBeforeOrAfter(syscall_inst_addr));
+        return Err(InternalError::InsufficientBytesBeforeOrAfter);
     }
 
     let prev_inst = &instructions[inst_index - 1];
@@ -1075,19 +1090,19 @@ fn hook_syscall_before_and_after(
 
     // Make sure we have enough space
     if prev_inst.len() + syscall_inst.len() + next_inst.len() < 5 {
-        return Err(Error::InsufficientBytesBeforeOrAfter(syscall_inst_addr));
+        return Err(InternalError::InsufficientBytesBeforeOrAfter);
     }
 
     // Both the syscall and its following instructions cannot be a control transfer target
     if control_transfer_targets.contains(&syscall_inst_addr)
         || control_transfer_targets.contains(&next_inst.ip())
     {
-        return Err(Error::InsufficientBytesBeforeOrAfter(syscall_inst_addr));
+        return Err(InternalError::InsufficientBytesBeforeOrAfter);
     }
 
     // We don't support the case when the previous instruction is a control transfer instruction
     if prev_inst.flow_control() != iced_x86::FlowControl::Next {
-        return Err(Error::InsufficientBytesBeforeOrAfter(syscall_inst_addr));
+        return Err(InternalError::InsufficientBytesBeforeOrAfter);
     }
 
     // We currently only support relative jmp or ret instructions
@@ -1097,7 +1112,7 @@ fn hook_syscall_before_and_after(
         iced_x86::FlowControl::Return => false,
         iced_x86::FlowControl::UnconditionalBranch => {
             if next_inst.near_branch_target() != prev_inst.ip() {
-                return Err(Error::InsufficientBytesBeforeOrAfter(syscall_inst_addr));
+                return Err(InternalError::InsufficientBytesBeforeOrAfter);
             }
             false
         }
@@ -1108,7 +1123,7 @@ fn hook_syscall_before_and_after(
         | iced_x86::FlowControl::Interrupt
         | iced_x86::FlowControl::XbeginXabortXend
         | iced_x86::FlowControl::Exception => {
-            return Err(Error::InsufficientBytesBeforeOrAfter(syscall_inst_addr));
+            return Err(InternalError::InsufficientBytesBeforeOrAfter);
         }
     };
 

--- a/litebox_syscall_rewriter/src/lib.rs
+++ b/litebox_syscall_rewriter/src/lib.rs
@@ -58,27 +58,6 @@ type Result<T> = core::result::Result<T, Error>;
 
 const BUN_FOOTER_MARKER: &[u8] = b"\n---- Bun! ----\n";
 
-/// Check for unpatchable syscall instructions and return an error if any exist.
-///
-/// Call this after [`hook_syscalls_in_elf`] or [`patch_code_segment`] to ensure
-/// all syscall instructions were successfully patched. Logs the skipped
-/// addresses as a warning before returning the error.
-pub fn ensure_all_patched(path: &str, skipped_addrs: &[u64]) -> Result<()> {
-    if skipped_addrs.is_empty() {
-        return Ok(());
-    }
-    litebox_util_log::warn!(
-        path:% = path,
-        count:% = skipped_addrs.len(),
-        addrs:? = skipped_addrs;
-        "unpatchable syscall instruction(s)"
-    );
-    Err(Error::PatchError(format!(
-        "{path} has {} unpatchable syscall instruction(s) at {skipped_addrs:?}",
-        skipped_addrs.len(),
-    )))
-}
-
 /// The magic bytes used to identify the trampoline data.
 /// This is checked by the loader to verify that the trampoline is valid.
 pub const TRAMPOLINE_MAGIC: &[u8; 8] = b"LITEBOX0";
@@ -132,21 +111,16 @@ struct TextSectionInfo {
 /// no syscall instructions are patched, the rewriter still appends the header and the initial
 /// syscall-entry placeholder so the loader/audit path can tell the binary was processed.
 ///
-/// Returns a tuple of (rewritten binary, skipped syscall addresses). Skipped
-/// addresses are syscall instructions that could not be patched because there
-/// is not enough space around the instruction (replaced with `icebp; hlt` so
-/// they trap instead of escaping to the host kernel).
+/// Returns the rewritten binary. Binaries that cannot or do not need to be
+/// patched (relocatable objects, non-ELF files, already-hooked binaries,
+/// binaries without executable sections or syscall instructions) are returned
+/// unchanged — these are not errors.
 ///
-/// Binaries that cannot or do not need to be patched (relocatable objects,
-/// non-ELF files, already-hooked binaries, binaries without executable
-/// sections or syscall instructions) are returned unchanged with an empty
-/// skipped list — these are not errors. Only genuinely broken inputs
-/// (corrupt ELF, unsupported executables like Bun, arithmetic overflow)
-/// produce `Err`.
-pub fn hook_syscalls_in_elf(
-    input_binary: &[u8],
-    trampoline: Option<u64>,
-) -> Result<(Vec<u8>, Vec<u64>)> {
+/// Returns `Err` for genuinely broken inputs (corrupt ELF, unsupported
+/// executables like Bun, arithmetic overflow) and for binaries that contain
+/// syscall instructions that could not be patched (replaced with `icebp; hlt`
+/// so they trap instead of escaping to the host kernel).
+pub fn hook_syscalls_in_elf(input_binary: &[u8], trampoline: Option<u64>) -> Result<Vec<u8>> {
     if input_binary.ends_with(BUN_FOOTER_MARKER) {
         return Err(Error::UnsupportedExecutable(
             "Bun-packaged executable".into(),
@@ -160,7 +134,7 @@ pub fn hook_syscalls_in_elf(
     if input_binary.len() >= 18 {
         let e_type = u16::from_le_bytes([input_binary[16], input_binary[17]]);
         if e_type == object::elf::ET_REL {
-            return Ok((input_binary.to_vec(), Vec::new()));
+            return Ok(input_binary.to_vec());
         }
     }
 
@@ -184,7 +158,7 @@ pub fn hook_syscalls_in_elf(
         let arch = match file {
             object::File::Elf64(_) => Arch::X86_64,
             object::File::Elf32(_) => Arch::X86_32,
-            _ => return Ok((input_binary.to_vec(), Vec::new())),
+            _ => return Ok(input_binary.to_vec()),
         };
 
         let dl_sysinfo_int80 = if arch == Arch::X86_32 {
@@ -195,12 +169,12 @@ pub fn hook_syscalls_in_elf(
 
         let text_sections = match text_sections(&file) {
             Ok(sections) => sections,
-            Err(Error::NoTextSectionFound) => return Ok((input_binary.to_vec(), Vec::new())),
+            Err(Error::NoTextSectionFound) => return Ok(input_binary.to_vec()),
             Err(e) => return Err(e),
         };
 
         if is_already_hooked(&*buf, arch) {
-            return Ok((input_binary.to_vec(), Vec::new()));
+            return Ok(input_binary.to_vec());
         }
 
         let control_transfer_targets = get_control_transfer_targets(arch, &*buf, &text_sections)?;
@@ -282,9 +256,14 @@ pub fn hook_syscalls_in_elf(
         };
         out.extend_from_slice(header.as_bytes());
     }
-    Ok((out, skipped_addrs))
+    if !skipped_addrs.is_empty() {
+        return Err(Error::PatchError(format!(
+            "{} unpatchable syscall instruction(s) at {skipped_addrs:?}",
+            skipped_addrs.len(),
+        )));
+    }
+    Ok(out)
 }
-
 /// (private) Get metadata for executable sections
 fn text_sections(file: &object::File<'_>) -> Result<Vec<TextSectionInfo>> {
     let text_sections: Vec<_> = file
@@ -718,22 +697,21 @@ fn rel32_bytes(target: u64, base: u64, context: &'static str) -> Result<[u8; 4]>
     Ok(disp.to_le_bytes())
 }
 
-/// Patch a single mapped code segment in-place, returning trampoline stubs and
-/// the addresses of any syscall instructions that could not be patched
-/// (replaced with `ICEBP; HLT` so they trap instead of escaping to the host
-/// kernel).
+/// Patch a single mapped code segment in-place, returning trampoline stubs.
 ///
 /// This is the runtime counterpart to [`hook_syscalls_in_elf`]. Instead of
 /// processing a whole ELF file, it operates on a single already-mapped code
 /// region — the caller is responsible for making the region writable before
 /// calling and restoring permissions afterwards. The caller must copy the
 /// returned stubs to `trampoline_write_vaddr`.
+///
+/// Returns `Err` if any syscall instructions could not be patched.
 pub fn patch_code_segment(
     code: &mut [u8],
     code_vaddr: u64,
     trampoline_write_vaddr: u64,
     syscall_entry_addr: u64,
-) -> Result<(Vec<u8>, Vec<u64>)> {
+) -> Result<Vec<u8>> {
     let arch = Arch::X86_64; // runtime patching is x86-64 only
 
     // Build control-transfer targets for this segment.
@@ -757,8 +735,16 @@ pub fn patch_code_segment(
         None, // dl_sysinfo_int80 — not applicable on x86-64
         &mut trampoline_data,
     ) {
-        Ok(skipped_addrs) => Ok((trampoline_data, skipped_addrs)),
-        Err(Error::NoSyscallInstructionsFound) => Ok((Vec::new(), Vec::new())),
+        Ok(skipped_addrs) => {
+            if !skipped_addrs.is_empty() {
+                return Err(Error::PatchError(format!(
+                    "{} unpatchable syscall instruction(s) at {skipped_addrs:?}",
+                    skipped_addrs.len(),
+                )));
+            }
+            Ok(trampoline_data)
+        }
+        Err(Error::NoSyscallInstructionsFound) => Ok(Vec::new()),
         Err(e) => Err(e),
     }
 }

--- a/litebox_syscall_rewriter/src/lib.rs
+++ b/litebox_syscall_rewriter/src/lib.rs
@@ -147,14 +147,7 @@ pub fn hook_syscalls_in_elf(
     fixup_phdr_alignment(buf);
 
     // Parse the ELF and extract all metadata we need, then drop the borrow so we can mutate buf.
-    let (
-        arch,
-        dl_sysinfo_int80,
-        text_sections,
-        control_transfer_targets,
-        trampoline_base_addr,
-        fork_to_vfork_patch,
-    ) = {
+    let (arch, dl_sysinfo_int80, text_sections, control_transfer_targets, trampoline_base_addr) = {
         let file = object::File::parse(&*buf).map_err(|e| Error::ParseError(e.to_string()))?;
 
         let arch = match file {
@@ -179,15 +172,12 @@ pub fn hook_syscalls_in_elf(
 
         let trampoline_base_addr = find_addr_for_trampoline_code(&file)?;
 
-        let fork_to_vfork_patch = find_fork_vfork_patch(&file, &text_sections);
-
         (
             arch,
             dl_sysinfo_int80,
             text_sections,
             control_transfer_targets,
             trampoline_base_addr,
-            fork_to_vfork_patch,
         )
     };
 
@@ -217,39 +207,6 @@ pub fn hook_syscalls_in_elf(
         ) {
             Ok(()) | Err(Error::NoSyscallInstructionsFound) => {}
             Err(e) => return Err(e),
-        }
-    }
-
-    // Patch fork → vfork: overwrite the first bytes of __libc_fork with a
-    // JMP to __libc_vfork. This prevents glibc's fork wrapper from running
-    // post-fork handlers that corrupt shared state under vfork semantics.
-    if let Some((fork_file_offset, fork_func_end, mut rel32)) = fork_to_vfork_patch {
-        const ENDBR64: [u8; 4] = [0xF3, 0x0F, 0x1E, 0xFA];
-        #[allow(clippy::cast_possible_truncation)]
-        let mut off = fork_file_offset as usize;
-        #[allow(clippy::cast_possible_truncation)]
-        let func_end = fork_func_end as usize;
-
-        // If fork starts with endbr64 (F3 0F 1E FA), preserve it by placing
-        // the JMP after it. This keeps CET/IBT indirect-branch targets valid.
-        if off + 4 <= buf.len() && buf[off..off + 4] == ENDBR64 {
-            off += 4;
-            rel32 = rel32.wrapping_sub(4); // JMP is now 4 bytes later, adjust displacement
-        }
-
-        if off + 5 <= func_end && func_end <= buf.len() {
-            buf[off] = 0xE9; // JMP rel32
-            buf[off + 1..off + 5].copy_from_slice(&rel32.to_le_bytes());
-            // NOP-fill remaining bytes of the fork function body after the JMP
-            // to avoid leaving stale instructions that could be jumped into.
-            for b in &mut buf[off + 5..func_end] {
-                *b = 0x90; // NOP
-            }
-        } else {
-            return Err(Error::ParseError(format!(
-                "fork→vfork patch range {off:#x}..{func_end:#x} is invalid for buffer length {}",
-                buf.len(),
-            )));
         }
     }
 
@@ -672,101 +629,6 @@ fn fixup_phdr_alignment(buf: &mut [u8]) {
             // The PHDR segment size should match the phdr table; no change needed.
         }
     }
-}
-
-/// Find fork and vfork symbols in the ELF and compute the patch needed to
-/// redirect fork -> vfork. Returns `Some((fork_file_offset, fork_func_end, jmp_rel32))` if
-/// both symbols are found, or `None` if this binary doesn't export fork.
-///
-/// `fork_func_end` is the file offset of the end of the fork function (based on
-/// the symbol's size), clamped to the section boundary. This is used to NOP-fill
-/// only the fork function body after the JMP, not the rest of the section.
-fn find_fork_vfork_patch(
-    file: &object::File<'_>,
-    text_sections: &[TextSectionInfo],
-) -> Option<(u64, u64, i32)> {
-    use object::ObjectSymbol as _;
-
-    let mut fork_vaddr = None;
-    let mut fork_size = None;
-    let mut vfork_vaddr = None;
-
-    // Restrict this rewrite to libc-specific symbols. Plain `fork`/`vfork` names may belong to
-    // arbitrary DSOs or user code, and retargeting them would silently change unrelated behavior.
-    for sym in file.dynamic_symbols() {
-        if sym.kind() != object::SymbolKind::Text {
-            continue;
-        }
-        let Ok(name) = sym.name() else { continue };
-        match name {
-            "__libc_fork" if fork_vaddr.is_none() => {
-                fork_vaddr = Some(sym.address());
-                fork_size = Some(sym.size());
-            }
-            "__libc_vfork" | "__vfork" if vfork_vaddr.is_none() => {
-                vfork_vaddr = Some(sym.address());
-            }
-            _ => {}
-        }
-    }
-
-    for sym in file.symbols() {
-        if sym.kind() != object::SymbolKind::Text {
-            continue;
-        }
-        let Ok(name) = sym.name() else { continue };
-        match name {
-            "__libc_fork" if fork_vaddr.is_none() => {
-                fork_vaddr = Some(sym.address());
-                fork_size = Some(sym.size());
-            }
-            "__libc_vfork" | "__vfork" if vfork_vaddr.is_none() => {
-                vfork_vaddr = Some(sym.address());
-            }
-            _ => {}
-        }
-    }
-
-    let fork_vaddr = fork_vaddr?;
-    let fork_size = fork_size?;
-    let vfork_vaddr = vfork_vaddr?;
-    if fork_vaddr == 0 || vfork_vaddr == 0 {
-        return None;
-    }
-
-    // Convert fork's vaddr to a file offset using the text sections.
-    let (fork_file_offset, fork_func_end) = text_sections.iter().find_map(|s| {
-        let section_end = s.vaddr + s.size;
-        if fork_vaddr >= s.vaddr
-            && fork_vaddr < section_end
-            && fork_vaddr
-                .checked_add(5)
-                .is_some_and(|end| end <= section_end)
-        {
-            let file_offset = s.file_offset + (fork_vaddr - s.vaddr);
-            let section_file_end = s.file_offset + s.size;
-            // Compute the end of the fork function, clamped to the section boundary.
-            let func_file_end = if fork_size > 0 {
-                (file_offset + fork_size).min(section_file_end)
-            } else {
-                // No size info — only NOP-fill the JMP itself (no extra NOPs).
-                file_offset + 5
-            };
-            Some((file_offset, func_file_end))
-        } else {
-            None
-        }
-    })?;
-
-    // Compute the relative offset for a JMP rel32 instruction.
-    // JMP rel32 encodes: target = rip_after_jmp + rel32
-    // rip_after_jmp = fork_vaddr + 5 (size of JMP rel32 instruction)
-    let rel32 = i64::try_from(vfork_vaddr)
-        .ok()?
-        .checked_sub(i64::try_from(fork_vaddr).ok()? + 5)?;
-    let rel32 = i32::try_from(rel32).ok()?;
-
-    Some((fork_file_offset, fork_func_end, rel32))
 }
 
 /// Check if the input binary has the Bun footer marker at the end.

--- a/litebox_syscall_rewriter/src/lib.rs
+++ b/litebox_syscall_rewriter/src/lib.rs
@@ -508,8 +508,8 @@ fn hook_syscalls_in_section(
             trampoline_data.extend_from_slice(&[0xE8, 0x0, 0x0, 0x0, 0x0]); // CALL next instruction
             trampoline_data.push(0x58); // POP EAX (effectively store IP in EAX)
             trampoline_data.extend_from_slice(&[0xFF, 0x90]); // CALL [EAX + offset]
-                                                              // EAX = trampoline_base_addr + (trampoline_data.len() - 3)
-                                                              // We want: EAX + offset = syscall_entry_addr
+            // EAX = trampoline_base_addr + (trampoline_data.len() - 3)
+            // We want: EAX + offset = syscall_entry_addr
             let call_base = checked_add_u64(
                 trampoline_base_addr,
                 trampoline_data.len() as u64,
@@ -1090,8 +1090,8 @@ fn hook_syscall_and_after(
         trampoline_data.extend_from_slice(&[0xE8, 0x0, 0x0, 0x0, 0x0]); // CALL next instruction
         trampoline_data.push(0x58); // POP EAX (effectively store IP in EAX)
         trampoline_data.extend_from_slice(&[0xFF, 0x90]); // CALL [EAX + offset]
-                                                          // EAX = trampoline_base_addr + (trampoline_data.len() - 3)
-                                                          // We want: EAX + offset = syscall_entry_addr
+        // EAX = trampoline_base_addr + (trampoline_data.len() - 3)
+        // We want: EAX + offset = syscall_entry_addr
         let call_base = checked_add_u64(
             trampoline_base_addr,
             trampoline_data.len() as u64,
@@ -1235,8 +1235,8 @@ fn hook_syscall_before_and_after(
     trampoline_data.extend_from_slice(&[0xE8, 0x0, 0x0, 0x0, 0x0]); // CALL next instruction
     trampoline_data.push(0x58); // POP EAX (effectively store IP in EAX)
     trampoline_data.extend_from_slice(&[0xFF, 0x90]); // CALL [EAX + offset]
-                                                      // EAX = trampoline_base_addr + (trampoline_data.len() - 3)
-                                                      // We want: EAX + offset = syscall_entry_addr
+    // EAX = trampoline_base_addr + (trampoline_data.len() - 3)
+    // We want: EAX + offset = syscall_entry_addr
     let call_base = checked_add_u64(
         trampoline_base_addr,
         trampoline_data.len() as u64,

--- a/litebox_syscall_rewriter/src/lib.rs
+++ b/litebox_syscall_rewriter/src/lib.rs
@@ -48,7 +48,7 @@ pub enum Error {
 
 /// Internal-only error variants used for control flow within the crate.
 /// These are never exposed to callers — they are caught and handled (or
-/// converted to [`Error`]) before reaching the public API boundary.
+/// converted to [`enum@Error`]) before reaching the public API boundary.
 #[derive(Debug)]
 enum InternalError {
     /// A public error that should be propagated as-is.
@@ -574,8 +574,8 @@ fn fixup_phdr_alignment(buf: &mut [u8]) {
         return;
     }
 
-    // Check ELF magic and class (must be ELF64)
-    if &buf[0..4] != b"\x7fELF" || buf[4] != 2 {
+    // Check ELF magic, class (must be ELF64), and byte order (must be little-endian).
+    if &buf[0..4] != b"\x7fELF" || buf[4] != 2 || buf[5] != 1 {
         return;
     }
 
@@ -629,13 +629,18 @@ fn fixup_phdr_alignment(buf: &mut [u8]) {
     // Move the phdr table forward (use copy_within since src and dst overlap).
     buf.copy_within(old_start..old_end, new_start);
 
+    // Zero the gap left behind so stale phdr bytes don't linger.
+    for b in &mut buf[old_start..old_start + padding] {
+        *b = 0;
+    }
+
     // Update e_phoff in the ELF header.
     let new_phoff = (e_phoff + padding as u64).to_le_bytes();
     buf[32..40].copy_from_slice(&new_phoff);
 
-    // Also update the PHDR segment's p_offset, p_vaddr, and p_paddr if present, so they match.
-    // ELF64 Elf64_Phdr layout: p_type (0, 4B), p_flags (4, 4B), p_offset (8, 8B),
-    // p_vaddr (16, 8B), p_paddr (24, 8B), p_filesz (32, 8B), p_memsz (40, 8B), p_align (48, 8B).
+    // Also update the PHDR segment's p_offset, p_vaddr, and p_paddr if present.
+    // Shifting the phdr table forward in the file shifts it within the PT_LOAD
+    // mapping by the same amount, so all three fields need the same adjustment.
     let Ok(e_phentsize_usize) = usize::try_from(e_phentsize) else {
         return;
     };
@@ -643,7 +648,10 @@ fn fixup_phdr_alignment(buf: &mut [u8]) {
         return;
     };
     for i in 0..e_phnum_usize {
-        let Some(entry_off) = new_start.checked_add(i.saturating_mul(e_phentsize_usize)) else {
+        let Some(i_times_size) = i.checked_mul(e_phentsize_usize) else {
+            break;
+        };
+        let Some(entry_off) = new_start.checked_add(i_times_size) else {
             break;
         };
         if entry_off + 32 > buf.len() {
@@ -651,14 +659,19 @@ fn fixup_phdr_alignment(buf: &mut [u8]) {
         }
         let p_type = u32::from_le_bytes(buf[entry_off..entry_off + 4].try_into().unwrap());
         if p_type == object::elf::PT_PHDR {
-            // PT_PHDR — update p_offset, p_vaddr, and p_paddr to match new location
-            for field_off in [8usize, 16, 24] {
+            use core::mem::offset_of;
+            use object::elf::ProgramHeader64;
+            use object::endian::LittleEndian;
+            // PT_PHDR — shift p_offset, p_vaddr, and p_paddr by `padding`.
+            for field_off in [
+                offset_of!(ProgramHeader64<LittleEndian>, p_offset),
+                offset_of!(ProgramHeader64<LittleEndian>, p_vaddr),
+                offset_of!(ProgramHeader64<LittleEndian>, p_paddr),
+            ] {
                 let off = entry_off + field_off;
                 let old_val = u64::from_le_bytes(buf[off..off + 8].try_into().unwrap());
-                if old_val == e_phoff {
-                    let new_val = (old_val + padding as u64).to_le_bytes();
-                    buf[off..off + 8].copy_from_slice(&new_val);
-                }
+                let new_val = (old_val + padding as u64).to_le_bytes();
+                buf[off..off + 8].copy_from_slice(&new_val);
             }
             // The PHDR segment size should match the phdr table; no change needed.
         }

--- a/litebox_syscall_rewriter/src/main.rs
+++ b/litebox_syscall_rewriter/src/main.rs
@@ -47,19 +47,17 @@ fn main() -> anyhow::Result<()> {
     let mut input_binary = std::fs::File::open(&cli_args.input_binary)?;
     let mut input_binary_bytes = vec![];
     input_binary.read_to_end(&mut input_binary_bytes)?;
-    let mut skipped_addrs = Vec::new();
-    let output_binary = match litebox_syscall_rewriter::hook_syscalls_in_elf(
+    let (output_binary, skipped_addrs) = match litebox_syscall_rewriter::hook_syscalls_in_elf(
         &input_binary_bytes,
         cli_args.trampoline_addr,
-        &mut skipped_addrs,
     ) {
-        Ok(output_binary) => output_binary,
+        Ok((output_binary, skipped_addrs)) => (output_binary, skipped_addrs),
         Err(litebox_syscall_rewriter::Error::NoSyscallInstructionsFound) => {
             eprintln!(
                 "warning: {} has no syscall instructions, copying as-is",
                 cli_args.input_binary.display()
             );
-            input_binary_bytes.clone()
+            (input_binary_bytes.clone(), Vec::new())
         }
         Err(err) => return Err(err.into()),
     };

--- a/litebox_syscall_rewriter/src/main.rs
+++ b/litebox_syscall_rewriter/src/main.rs
@@ -51,10 +51,10 @@ fn main() -> anyhow::Result<()> {
         &input_binary_bytes,
         cli_args.trampoline_addr,
     )?;
-    litebox_syscall_rewriter::warn_skipped(
+    litebox_syscall_rewriter::ensure_all_patched(
         &cli_args.input_binary.display().to_string(),
         &skipped_addrs,
-    );
+    )?;
     let output_path = cli_args.output_binary.unwrap_or_else(|| {
         cli_args.input_binary.with_file_name(
             cli_args

--- a/litebox_syscall_rewriter/src/main.rs
+++ b/litebox_syscall_rewriter/src/main.rs
@@ -47,27 +47,14 @@ fn main() -> anyhow::Result<()> {
     let mut input_binary = std::fs::File::open(&cli_args.input_binary)?;
     let mut input_binary_bytes = vec![];
     input_binary.read_to_end(&mut input_binary_bytes)?;
-    let (output_binary, skipped_addrs) = match litebox_syscall_rewriter::hook_syscalls_in_elf(
+    let (output_binary, skipped_addrs) = litebox_syscall_rewriter::hook_syscalls_in_elf(
         &input_binary_bytes,
         cli_args.trampoline_addr,
-    ) {
-        Ok((output_binary, skipped_addrs)) => (output_binary, skipped_addrs),
-        Err(litebox_syscall_rewriter::Error::NoSyscallInstructionsFound) => {
-            eprintln!(
-                "warning: {} has no syscall instructions, copying as-is",
-                cli_args.input_binary.display()
-            );
-            (input_binary_bytes.clone(), Vec::new())
-        }
-        Err(err) => return Err(err.into()),
-    };
-    if !skipped_addrs.is_empty() {
-        eprintln!(
-            "warning: {} unpatchable syscall instruction(s) at {:?}",
-            skipped_addrs.len(),
-            skipped_addrs,
-        );
-    }
+    )?;
+    litebox_syscall_rewriter::warn_skipped(
+        &cli_args.input_binary.display().to_string(),
+        &skipped_addrs,
+    );
     let output_path = cli_args.output_binary.unwrap_or_else(|| {
         cli_args.input_binary.with_file_name(
             cli_args

--- a/litebox_syscall_rewriter/src/main.rs
+++ b/litebox_syscall_rewriter/src/main.rs
@@ -48,11 +48,21 @@ fn main() -> anyhow::Result<()> {
     let mut input_binary_bytes = vec![];
     input_binary.read_to_end(&mut input_binary_bytes)?;
     let mut skipped_addrs = Vec::new();
-    let output_binary = litebox_syscall_rewriter::hook_syscalls_in_elf(
+    let output_binary = match litebox_syscall_rewriter::hook_syscalls_in_elf(
         &input_binary_bytes,
         cli_args.trampoline_addr,
         &mut skipped_addrs,
-    )?;
+    ) {
+        Ok(output_binary) => output_binary,
+        Err(litebox_syscall_rewriter::Error::NoSyscallInstructionsFound) => {
+            eprintln!(
+                "warning: {} has no syscall instructions, copying as-is",
+                cli_args.input_binary.display()
+            );
+            input_binary_bytes.clone()
+        }
+        Err(err) => return Err(err.into()),
+    };
     if !skipped_addrs.is_empty() {
         eprintln!(
             "warning: {} unpatchable syscall instruction(s) at {:?}",

--- a/litebox_syscall_rewriter/src/main.rs
+++ b/litebox_syscall_rewriter/src/main.rs
@@ -47,10 +47,19 @@ fn main() -> anyhow::Result<()> {
     let mut input_binary = std::fs::File::open(&cli_args.input_binary)?;
     let mut input_binary_bytes = vec![];
     input_binary.read_to_end(&mut input_binary_bytes)?;
+    let mut skipped_addrs = Vec::new();
     let output_binary = litebox_syscall_rewriter::hook_syscalls_in_elf(
         &input_binary_bytes,
         cli_args.trampoline_addr,
+        &mut skipped_addrs,
     )?;
+    if !skipped_addrs.is_empty() {
+        eprintln!(
+            "warning: {} unpatchable syscall instruction(s) at {:?}",
+            skipped_addrs.len(),
+            skipped_addrs,
+        );
+    }
     let output_path = cli_args.output_binary.unwrap_or_else(|| {
         cli_args.input_binary.with_file_name(
             cli_args

--- a/litebox_syscall_rewriter/src/main.rs
+++ b/litebox_syscall_rewriter/src/main.rs
@@ -47,13 +47,9 @@ fn main() -> anyhow::Result<()> {
     let mut input_binary = std::fs::File::open(&cli_args.input_binary)?;
     let mut input_binary_bytes = vec![];
     input_binary.read_to_end(&mut input_binary_bytes)?;
-    let (output_binary, skipped_addrs) = litebox_syscall_rewriter::hook_syscalls_in_elf(
+    let output_binary = litebox_syscall_rewriter::hook_syscalls_in_elf(
         &input_binary_bytes,
         cli_args.trampoline_addr,
-    )?;
-    litebox_syscall_rewriter::ensure_all_patched(
-        &cli_args.input_binary.display().to_string(),
-        &skipped_addrs,
     )?;
     let output_path = cli_args.output_binary.unwrap_or_else(|| {
         cli_args.input_binary.with_file_name(

--- a/litebox_syscall_rewriter/tests/snapshot_tests.rs
+++ b/litebox_syscall_rewriter/tests/snapshot_tests.rs
@@ -86,8 +86,7 @@ const HELLO_INPUT_64: &[u8] = include_bytes!("hello");
 const HELLO_INPUT_32: &[u8] = include_bytes!("hello-32");
 
 fn run_snapshot_test(input: &[u8], snapshot: &str) {
-    let (output, _skipped_addrs) =
-        litebox_syscall_rewriter::hook_syscalls_in_elf(input, None).unwrap();
+    let output = litebox_syscall_rewriter::hook_syscalls_in_elf(input, None).unwrap();
     let diff = similar::udiff::unified_diff(
         similar::Algorithm::Myers,
         &objdump(input),

--- a/litebox_syscall_rewriter/tests/snapshot_tests.rs
+++ b/litebox_syscall_rewriter/tests/snapshot_tests.rs
@@ -86,8 +86,8 @@ const HELLO_INPUT_64: &[u8] = include_bytes!("hello");
 const HELLO_INPUT_32: &[u8] = include_bytes!("hello-32");
 
 fn run_snapshot_test(input: &[u8], snapshot: &str) {
-    let output =
-        litebox_syscall_rewriter::hook_syscalls_in_elf(input, None, &mut Vec::new()).unwrap();
+    let (output, _skipped_addrs) =
+        litebox_syscall_rewriter::hook_syscalls_in_elf(input, None).unwrap();
     let diff = similar::udiff::unified_diff(
         similar::Algorithm::Myers,
         &objdump(input),

--- a/litebox_syscall_rewriter/tests/snapshot_tests.rs
+++ b/litebox_syscall_rewriter/tests/snapshot_tests.rs
@@ -6,6 +6,7 @@ fn objdump(binary: &[u8]) -> String {
     use std::process::Command;
     use tempfile::NamedTempFile;
 
+    let trampoline_range = trampoline_range(binary);
     let mut temp_file = NamedTempFile::new().unwrap();
     temp_file.write_all(binary).unwrap();
 
@@ -19,16 +20,74 @@ fn objdump(binary: &[u8]) -> String {
     String::from_utf8_lossy(&output.stdout)
         .lines()
         .filter(|l| !l.contains("/tmp/"))
-        .map(str::trim_end)
+        .map(|line| normalize_objdump_line(line, trampoline_range.as_ref()))
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+fn trampoline_range(binary: &[u8]) -> Option<std::ops::Range<u64>> {
+    const MAGIC: &[u8; 8] = litebox_syscall_rewriter::TRAMPOLINE_MAGIC;
+
+    if binary.len() < 20 {
+        return None;
+    }
+
+    match binary.get(4).copied() {
+        Some(2) if binary.len() >= 32 => {
+            let header = &binary[binary.len() - 32..];
+            if &header[..8] != MAGIC {
+                return None;
+            }
+            let vaddr = u64::from_le_bytes(header[16..24].try_into().unwrap());
+            let size = u64::from_le_bytes(header[24..32].try_into().unwrap());
+            (size != 0).then_some(vaddr..vaddr.checked_add(size)?)
+        }
+        Some(1) => {
+            let header = &binary[binary.len() - 20..];
+            if &header[..8] != MAGIC {
+                return None;
+            }
+            let vaddr = u64::from(u32::from_le_bytes(header[12..16].try_into().unwrap()));
+            let size = u64::from(u32::from_le_bytes(header[16..20].try_into().unwrap()));
+            (size != 0).then_some(vaddr..vaddr.checked_add(size)?)
+        }
+        _ => None,
+    }
+}
+
+fn normalize_objdump_line(line: &str, trampoline_range: Option<&std::ops::Range<u64>>) -> String {
+    let Some(trampoline_range) = trampoline_range else {
+        return line.trim_end().to_owned();
+    };
+    let Some((address, rest)) = line.split_once(':') else {
+        return line.trim_end().to_owned();
+    };
+    let tokens: Vec<_> = rest.split_whitespace().collect();
+    let Some((mnemonic_idx, mnemonic)) = tokens
+        .iter()
+        .enumerate()
+        .find(|(_, token)| !token.chars().all(|ch| ch.is_ascii_hexdigit()))
+    else {
+        return line.trim_end().to_owned();
+    };
+    if *mnemonic == "jmp"
+        && let Some(target) = tokens
+            .get(mnemonic_idx + 1)
+            .and_then(|token| u64::from_str_radix(token.trim_start_matches("0x"), 16).ok())
+        && trampoline_range.contains(&target)
+    {
+        let offset = target - trampoline_range.start;
+        return format!("{address}:\t<trampoline-jmp+0x{offset:x}>");
+    }
+    line.trim_end().to_owned()
 }
 
 const HELLO_INPUT_64: &[u8] = include_bytes!("hello");
 const HELLO_INPUT_32: &[u8] = include_bytes!("hello-32");
 
 fn run_snapshot_test(input: &[u8], snapshot: &str) {
-    let output = litebox_syscall_rewriter::hook_syscalls_in_elf(input, None).unwrap();
+    let output =
+        litebox_syscall_rewriter::hook_syscalls_in_elf(input, None, &mut Vec::new()).unwrap();
     let diff = similar::udiff::unified_diff(
         similar::Algorithm::Myers,
         &objdump(input),

--- a/litebox_syscall_rewriter/tests/snapshots/snapshot_tests__hello-32-diff.snap
+++ b/litebox_syscall_rewriter/tests/snapshots/snapshot_tests__hello-32-diff.snap
@@ -1,5 +1,6 @@
 ---
 source: litebox_syscall_rewriter/tests/snapshot_tests.rs
+assertion_line: 99
 expression: diff
 ---
 --- original
@@ -9,7 +10,7 @@ expression: diff
   8049142:	c7 85 d0 39 00 00 01 	movl   $0x1,0x39d0(%ebp)
   8049149:	00 00 00
 - 804914c:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 804914c:	e9 b3 de 09 00       	jmp    80e7004 <_end+0x3bc>
++ 804914c:	<trampoline-jmp+0x4>
 + 8049151:	90                   	nop
 + 8049152:	90                   	nop
   8049153:	8b 85 d0 39 00 00    	mov    0x39d0(%ebp),%eax
@@ -22,7 +23,7 @@ expression: diff
 - 8049e00:	89 d0                	mov    %edx,%eax
 - 8049e02:	cd 80                	int    $0x80
 - 8049e04:	eb fa                	jmp    8049e00 <__libc_start_call_main+0x90>
-+ 8049e00:	e9 11 d2 09 00       	jmp    80e7016 <_end+0x3ce>
++ 8049e00:	<trampoline-jmp+0x16>
 + 8049e05:	90                   	nop
   8049e06:	31 c0                	xor    %eax,%eax
   8049e08:	eb d0                	jmp    8049dda <__libc_start_call_main+0x6a>
@@ -34,7 +35,7 @@ expression: diff
 - 804bf8c:	c7 44 24 4c 51 00 00 	movl   $0x51,0x4c(%esp)
 - 804bf93:	00
 - 804bf94:	cd 80                	int    $0x80
-+ 804bf8c:	e9 96 b0 09 00       	jmp    80e7027 <_end+0x3df>
++ 804bf8c:	<trampoline-jmp+0x27>
 + 804bf91:	90                   	nop
 + 804bf92:	90                   	nop
 + 804bf93:	90                   	nop
@@ -48,13 +49,13 @@ expression: diff
   804bfab:	8d 8e 20 e6 fc ff    	lea    -0x319e0(%esi),%ecx
 - 804bfb1:	ba 2d 00 00 00       	mov    $0x2d,%edx
 - 804bfb6:	cd 80                	int    $0x80
-+ 804bfb1:	e9 8b b0 09 00       	jmp    80e7041 <_end+0x3f9>
++ 804bfb1:	<trampoline-jmp+0x41>
 + 804bfb6:	90                   	nop
 + 804bfb7:	90                   	nop
   804bfb8:	b8 fc 00 00 00       	mov    $0xfc,%eax
 - 804bfbd:	bb 7f 00 00 00       	mov    $0x7f,%ebx
 - 804bfc2:	cd 80                	int    $0x80
-+ 804bfbd:	e9 96 b0 09 00       	jmp    80e7058 <_end+0x410>
++ 804bfbd:	<trampoline-jmp+0x58>
 + 804bfc2:	90                   	nop
 + 804bfc3:	90                   	nop
   804bfc4:	e8 67 ff 00 00       	call   805bf30 <__tls_init_tp>
@@ -66,13 +67,13 @@ expression: diff
   804c082:	8d 8e 20 e6 fc ff    	lea    -0x319e0(%esi),%ecx
 - 804c088:	ba 2d 00 00 00       	mov    $0x2d,%edx
 - 804c08d:	cd 80                	int    $0x80
-+ 804c088:	e9 e2 af 09 00       	jmp    80e706f <_end+0x427>
++ 804c088:	<trampoline-jmp+0x6f>
 + 804c08d:	90                   	nop
 + 804c08e:	90                   	nop
   804c08f:	b8 fc 00 00 00       	mov    $0xfc,%eax
 - 804c094:	bb 7f 00 00 00       	mov    $0x7f,%ebx
 - 804c099:	cd 80                	int    $0x80
-+ 804c094:	e9 ed af 09 00       	jmp    80e7086 <_end+0x43e>
++ 804c094:	<trampoline-jmp+0x86>
 + 804c099:	90                   	nop
 + 804c09a:	90                   	nop
   804c09b:	e9 46 fe ff ff       	jmp    804bee6 <__libc_setup_tls+0x126>
@@ -83,7 +84,7 @@ expression: diff
   8050f61:	8d b4 26 00 00 00 00 	lea    0x0(%esi,%eiz,1),%esi
   8050f68:	b8 92 00 00 00       	mov    $0x92,%eax
 - 8050f6d:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 8050f6d:	e9 2b 61 09 00       	jmp    80e709d <_end+0x455>
++ 8050f6d:	<trampoline-jmp+0x9d>
 + 8050f72:	90                   	nop
 + 8050f73:	90                   	nop
   8050f74:	83 f8 fc             	cmp    $0xfffffffc,%eax
@@ -94,7 +95,7 @@ expression: diff
   805118e:	ba 02 00 00 00       	mov    $0x2,%edx
   8051193:	31 f6                	xor    %esi,%esi
 - 8051195:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 8051195:	e9 15 5f 09 00       	jmp    80e70af <_end+0x467>
++ 8051195:	<trampoline-jmp+0xaf>
 + 805119a:	90                   	nop
 + 805119b:	90                   	nop
   805119c:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -105,7 +106,7 @@ expression: diff
   8051202:	31 f6                	xor    %esi,%esi
   8051204:	80 f1 80             	xor    $0x80,%cl
 - 8051207:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 8051207:	e9 b5 5e 09 00       	jmp    80e70c1 <_end+0x479>
++ 8051207:	<trampoline-jmp+0xc1>
 + 805120c:	90                   	nop
 + 805120d:	90                   	nop
   805120e:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -116,7 +117,7 @@ expression: diff
   8051251:	31 f6                	xor    %esi,%esi
   8051253:	8b 5c 24 0c          	mov    0xc(%esp),%ebx
 - 8051257:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 8051257:	e9 77 5e 09 00       	jmp    80e70d3 <_end+0x48b>
++ 8051257:	<trampoline-jmp+0xd3>
 + 805125c:	90                   	nop
 + 805125d:	90                   	nop
   805125e:	5b                   	pop    %ebx
@@ -127,7 +128,7 @@ expression: diff
   8051282:	8b 5c 24 0c          	mov    0xc(%esp),%ebx
   8051286:	80 f1 81             	xor    $0x81,%cl
 - 8051289:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 8051289:	e9 57 5e 09 00       	jmp    80e70e5 <_end+0x49d>
++ 8051289:	<trampoline-jmp+0xe5>
 + 805128e:	90                   	nop
 + 805128f:	90                   	nop
   8051290:	5b                   	pop    %ebx
@@ -138,7 +139,7 @@ expression: diff
   805215c:	c6 86 fc 35 00 00 01 	movb   $0x1,0x35fc(%esi)
   8052163:	8d 9e f4 35 00 00    	lea    0x35f4(%esi),%ebx
 - 8052169:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 8052169:	e9 89 4f 09 00       	jmp    80e70f7 <_end+0x4af>
++ 8052169:	<trampoline-jmp+0xf7>
 + 805216e:	90                   	nop
 + 805216f:	90                   	nop
   8052170:	8d 7c 24 0c          	lea    0xc(%esp),%edi
@@ -149,7 +150,7 @@ expression: diff
   8059916:	b8 93 01 00 00       	mov    $0x193,%eax
   805991b:	89 f9                	mov    %edi,%ecx
 - 805991d:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 805991d:	e9 e7 d7 08 00       	jmp    80e7109 <_end+0x4c1>
++ 805991d:	<trampoline-jmp+0x109>
 + 8059922:	90                   	nop
 + 8059923:	90                   	nop
   8059924:	85 c0                	test   %eax,%eax
@@ -159,7 +160,7 @@ expression: diff
   805992d:	8d 4c 24 04          	lea    0x4(%esp),%ecx
   8059931:	b8 09 01 00 00       	mov    $0x109,%eax
 - 8059936:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 8059936:	e9 e0 d7 08 00       	jmp    80e711b <_end+0x4d3>
++ 8059936:	<trampoline-jmp+0x11b>
 + 805993b:	90                   	nop
 + 805993c:	90                   	nop
   805993d:	85 c0                	test   %eax,%eax
@@ -170,7 +171,7 @@ expression: diff
   8059a70:	f4                   	hlt
   8059a71:	89 d0                	mov    %edx,%eax
 - 8059a73:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 8059a73:	e9 b5 d6 08 00       	jmp    80e712d <_end+0x4e5>
++ 8059a73:	<trampoline-jmp+0x12d>
 + 8059a78:	90                   	nop
 + 8059a79:	90                   	nop
   8059a7a:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -181,7 +182,7 @@ expression: diff
   8059bd0:	31 c0                	xor    %eax,%eax
   8059bd2:	b8 7f 01 00 00       	mov    $0x17f,%eax
 - 8059bd7:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 8059bd7:	e9 63 d5 08 00       	jmp    80e713f <_end+0x4f7>
++ 8059bd7:	<trampoline-jmp+0x13f>
 + 8059bdc:	90                   	nop
 + 8059bdd:	90                   	nop
   8059bde:	89 c6                	mov    %eax,%esi
@@ -192,7 +193,7 @@ expression: diff
   8059dc2:	8d 54 24 2c          	lea    0x2c(%esp),%edx
   8059dc6:	b8 2c 01 00 00       	mov    $0x12c,%eax
 - 8059dcb:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 8059dcb:	e9 81 d3 08 00       	jmp    80e7151 <_end+0x509>
++ 8059dcb:	<trampoline-jmp+0x151>
 + 8059dd0:	90                   	nop
 + 8059dd1:	90                   	nop
   8059dd2:	89 c2                	mov    %eax,%edx
@@ -203,7 +204,7 @@ expression: diff
   8059f5c:	b8 06 00 00 00       	mov    $0x6,%eax
   8059f61:	8b 5c 24 08          	mov    0x8(%esp),%ebx
 - 8059f65:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 8059f65:	e9 f9 d1 08 00       	jmp    80e7163 <_end+0x51b>
++ 8059f65:	<trampoline-jmp+0x163>
 + 8059f6a:	90                   	nop
 + 8059f6b:	90                   	nop
   8059f6c:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -214,7 +215,7 @@ expression: diff
   8059fb9:	8b 5c 24 20          	mov    0x20(%esp),%ebx
   8059fbd:	b8 dd 00 00 00       	mov    $0xdd,%eax
 - 8059fc2:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 8059fc2:	e9 ae d1 08 00       	jmp    80e7175 <_end+0x52d>
++ 8059fc2:	<trampoline-jmp+0x175>
 + 8059fc7:	90                   	nop
 + 8059fc8:	90                   	nop
   8059fc9:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -225,7 +226,7 @@ expression: diff
   8059ff0:	b8 dd 00 00 00       	mov    $0xdd,%eax
   8059ff5:	b9 10 00 00 00       	mov    $0x10,%ecx
 - 8059ffa:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 8059ffa:	e9 88 d1 08 00       	jmp    80e7187 <_end+0x53f>
++ 8059ffa:	<trampoline-jmp+0x187>
 + 8059fff:	90                   	nop
 + 805a000:	90                   	nop
   805a001:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -236,7 +237,7 @@ expression: diff
   805a069:	8b 5c 24 20          	mov    0x20(%esp),%ebx
   805a06d:	b8 dd 00 00 00       	mov    $0xdd,%eax
 - 805a072:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 805a072:	e9 22 d1 08 00       	jmp    80e7199 <_end+0x551>
++ 805a072:	<trampoline-jmp+0x199>
 + 805a077:	90                   	nop
 + 805a078:	90                   	nop
   805a079:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -247,7 +248,7 @@ expression: diff
   805a0a0:	b8 dd 00 00 00       	mov    $0xdd,%eax
   805a0a5:	b9 10 00 00 00       	mov    $0x10,%ecx
 - 805a0aa:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 805a0aa:	e9 fc d0 08 00       	jmp    80e71ab <_end+0x563>
++ 805a0aa:	<trampoline-jmp+0x1ab>
 + 805a0af:	90                   	nop
 + 805a0b0:	90                   	nop
   805a0b1:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -258,7 +259,7 @@ expression: diff
   805a118:	b8 27 01 00 00       	mov    $0x127,%eax
   805a11d:	bb 9c ff ff ff       	mov    $0xffffff9c,%ebx
 - 805a122:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 805a122:	e9 96 d0 08 00       	jmp    80e71bd <_end+0x575>
++ 805a122:	<trampoline-jmp+0x1bd>
 + 805a127:	90                   	nop
 + 805a128:	90                   	nop
   805a129:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -269,7 +270,7 @@ expression: diff
   805a176:	8b 54 24 14          	mov    0x14(%esp),%edx
   805a17a:	8b 5c 24 0c          	mov    0xc(%esp),%ebx
 - 805a17e:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 805a17e:	e9 4c d0 08 00       	jmp    80e71cf <_end+0x587>
++ 805a17e:	<trampoline-jmp+0x1cf>
 + 805a183:	90                   	nop
 + 805a184:	90                   	nop
   805a185:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -281,7 +282,7 @@ expression: diff
   805a30c:	b8 2d 00 00 00       	mov    $0x2d,%eax
 - 805a311:	8b 5c 24 08          	mov    0x8(%esp),%ebx
 - 805a315:	cd 80                	int    $0x80
-+ 805a311:	e9 cb ce 08 00       	jmp    80e71e1 <_end+0x599>
++ 805a311:	<trampoline-jmp+0x1e1>
 + 805a316:	90                   	nop
   805a317:	89 82 28 36 00 00    	mov    %eax,0x3628(%edx)
   805a31d:	39 d8                	cmp    %ebx,%eax
@@ -291,7 +292,7 @@ expression: diff
   805a750:	8d 54 24 0c          	lea    0xc(%esp),%edx
   805a754:	b8 f2 00 00 00       	mov    $0xf2,%eax
 - 805a759:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 805a759:	e9 99 ca 08 00       	jmp    80e71f7 <_end+0x5af>
++ 805a759:	<trampoline-jmp+0x1f7>
 + 805a75e:	90                   	nop
 + 805a75f:	90                   	nop
   805a760:	85 c0                	test   %eax,%eax
@@ -302,7 +303,7 @@ expression: diff
   805a959:	8b 5c 24 08          	mov    0x8(%esp),%ebx
   805a95d:	b8 db 00 00 00       	mov    $0xdb,%eax
 - 805a962:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 805a962:	e9 a2 c8 08 00       	jmp    80e7209 <_end+0x5c1>
++ 805a962:	<trampoline-jmp+0x209>
 + 805a967:	90                   	nop
 + 805a968:	90                   	nop
   805a969:	5b                   	pop    %ebx
@@ -313,7 +314,7 @@ expression: diff
   805aa29:	8b 5c 24 08          	mov    0x8(%esp),%ebx
   805aa2d:	b8 7d 00 00 00       	mov    $0x7d,%eax
 - 805aa32:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 805aa32:	e9 e4 c7 08 00       	jmp    80e721b <_end+0x5d3>
++ 805aa32:	<trampoline-jmp+0x21b>
 + 805aa37:	90                   	nop
 + 805aa38:	90                   	nop
   805aa39:	5b                   	pop    %ebx
@@ -324,7 +325,7 @@ expression: diff
   805aa56:	8b 5c 24 04          	mov    0x4(%esp),%ebx
   805aa5a:	b8 5b 00 00 00       	mov    $0x5b,%eax
 - 805aa5f:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 805aa5f:	e9 c9 c7 08 00       	jmp    80e722d <_end+0x5e5>
++ 805aa5f:	<trampoline-jmp+0x22d>
 + 805aa64:	90                   	nop
 + 805aa65:	90                   	nop
   805aa66:	89 d3                	mov    %edx,%ebx
@@ -335,7 +336,7 @@ expression: diff
   805ab29:	b8 a3 00 00 00       	mov    $0xa3,%eax
   805ab2e:	8b 5c 24 14          	mov    0x14(%esp),%ebx
 - 805ab32:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 805ab32:	e9 08 c7 08 00       	jmp    80e723f <_end+0x5f7>
++ 805ab32:	<trampoline-jmp+0x23f>
 + 805ab37:	90                   	nop
 + 805ab38:	90                   	nop
   805ab39:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -346,7 +347,7 @@ expression: diff
   805abdb:	bb 41 4d 56 53       	mov    $0x53564d41,%ebx
   805abe0:	31 c9                	xor    %ecx,%ecx
 - 805abe2:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 805abe2:	e9 6a c6 08 00       	jmp    80e7251 <_end+0x609>
++ 805abe2:	<trampoline-jmp+0x251>
 + 805abe7:	90                   	nop
 + 805abe8:	90                   	nop
   805abe9:	83 f8 ea             	cmp    $0xffffffea,%eax
@@ -357,7 +358,7 @@ expression: diff
   805ac02:	8b 5c 24 04          	mov    0x4(%esp),%ebx
   805ac06:	b8 74 00 00 00       	mov    $0x74,%eax
 - 805ac0b:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 805ac0b:	e9 53 c6 08 00       	jmp    80e7263 <_end+0x61b>
++ 805ac0b:	<trampoline-jmp+0x263>
 + 805ac10:	90                   	nop
 + 805ac11:	90                   	nop
   805ac12:	89 d3                	mov    %edx,%ebx
@@ -368,7 +369,7 @@ expression: diff
   805bf5e:	8d 5e 68             	lea    0x68(%esi),%ebx
   805bf61:	b8 02 01 00 00       	mov    $0x102,%eax
 - 805bf66:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 805bf66:	e9 0a b3 08 00       	jmp    80e7275 <_end+0x62d>
++ 805bf66:	<trampoline-jmp+0x275>
 + 805bf6b:	90                   	nop
 + 805bf6c:	90                   	nop
   805bf6d:	89 46 68             	mov    %eax,0x68(%esi)
@@ -379,7 +380,7 @@ expression: diff
   805bfa0:	b9 0c 00 00 00       	mov    $0xc,%ecx
   805bfa5:	89 5e 6c             	mov    %ebx,0x6c(%esi)
 - 805bfa8:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 805bfa8:	e9 da b2 08 00       	jmp    80e7287 <_end+0x63f>
++ 805bfa8:	<trampoline-jmp+0x287>
 + 805bfad:	90                   	nop
 + 805bfae:	90                   	nop
   805bfaf:	6a 00                	push   $0x0
@@ -390,7 +391,7 @@ expression: diff
   805bfda:	31 d2                	xor    %edx,%edx
   805bfdc:	be 53 30 05 53       	mov    $0x53053053,%esi
 - 805bfe1:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 805bfe1:	e9 b3 b2 08 00       	jmp    80e7299 <_end+0x651>
++ 805bfe1:	<trampoline-jmp+0x299>
 + 805bfe6:	90                   	nop
 + 805bfe7:	90                   	nop
   805bfe8:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -403,13 +404,13 @@ expression: diff
 - 805c9b5:	31 db                	xor    %ebx,%ebx
 - 805c9b7:	89 c8                	mov    %ecx,%eax
 - 805c9b9:	cd 80                	int    $0x80
-+ 805c9b5:	e9 f1 a8 08 00       	jmp    80e72ab <_end+0x663>
++ 805c9b5:	<trampoline-jmp+0x2ab>
 + 805c9ba:	90                   	nop
   805c9bb:	89 c2                	mov    %eax,%edx
 - 805c9bd:	8d 1c 28             	lea    (%eax,%ebp,1),%ebx
 - 805c9c0:	89 c8                	mov    %ecx,%eax
 - 805c9c2:	cd 80                	int    $0x80
-+ 805c9bd:	e9 ff a8 08 00       	jmp    80e72c1 <_end+0x679>
++ 805c9bd:	<trampoline-jmp+0x2c1>
 + 805c9c2:	90                   	nop
 + 805c9c3:	90                   	nop
   805c9c4:	39 c2                	cmp    %eax,%edx
@@ -420,7 +421,7 @@ expression: diff
   807afc1:	f7 d1                	not    %ecx
   807afc3:	81 e1 80 00 00 00    	and    $0x80,%ecx
 - 807afc9:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 807afc9:	e9 0a c3 06 00       	jmp    80e72d8 <_end+0x690>
++ 807afc9:	<trampoline-jmp+0x2d8>
 + 807afce:	90                   	nop
 + 807afcf:	90                   	nop
   807afd0:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -431,7 +432,7 @@ expression: diff
   807b172:	b8 f0 00 00 00       	mov    $0xf0,%eax
   807b177:	89 ce                	mov    %ecx,%esi
 - 807b179:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 807b179:	e9 6c c1 06 00       	jmp    80e72ea <_end+0x6a2>
++ 807b179:	<trampoline-jmp+0x2ea>
 + 807b17e:	90                   	nop
 + 807b17f:	90                   	nop
   807b180:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -442,7 +443,7 @@ expression: diff
   807b340:	b9 07 00 00 00       	mov    $0x7,%ecx
   807b345:	89 d6                	mov    %edx,%esi
 - 807b347:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 807b347:	e9 b0 bf 06 00       	jmp    80e72fc <_end+0x6b4>
++ 807b347:	<trampoline-jmp+0x2fc>
 + 807b34c:	90                   	nop
 + 807b34d:	90                   	nop
   807b34e:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -453,7 +454,7 @@ expression: diff
   807b8fe:	81 e1 80 00 00 00    	and    $0x80,%ecx
   807b904:	80 f1 81             	xor    $0x81,%cl
 - 807b907:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 807b907:	e9 02 ba 06 00       	jmp    80e730e <_end+0x6c6>
++ 807b907:	<trampoline-jmp+0x30e>
 + 807b90c:	90                   	nop
 + 807b90d:	90                   	nop
   807b90e:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -464,7 +465,7 @@ expression: diff
   807bb85:	b8 f0 00 00 00       	mov    $0xf0,%eax
   807bb8a:	89 d1                	mov    %edx,%ecx
 - 807bb8c:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 807bb8c:	e9 8f b7 06 00       	jmp    80e7320 <_end+0x6d8>
++ 807bb8c:	<trampoline-jmp+0x320>
 + 807bb91:	90                   	nop
 + 807bb92:	90                   	nop
   807bb93:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -475,7 +476,7 @@ expression: diff
   807bbb5:	b8 f0 00 00 00       	mov    $0xf0,%eax
   807bbba:	89 d6                	mov    %edx,%esi
 - 807bbbc:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 807bbbc:	e9 71 b7 06 00       	jmp    80e7332 <_end+0x6ea>
++ 807bbbc:	<trampoline-jmp+0x332>
 + 807bbc1:	90                   	nop
 + 807bbc2:	90                   	nop
   807bbc3:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -486,7 +487,7 @@ expression: diff
   807bddf:	b9 80 00 00 00       	mov    $0x80,%ecx
   807bde4:	89 fb                	mov    %edi,%ebx
 - 807bde6:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 807bde6:	e9 59 b5 06 00       	jmp    80e7344 <_end+0x6fc>
++ 807bde6:	<trampoline-jmp+0x344>
 + 807bdeb:	90                   	nop
 + 807bdec:	90                   	nop
   807bded:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -497,7 +498,7 @@ expression: diff
   807be90:	89 fb                	mov    %edi,%ebx
   807be92:	c7 07 02 00 00 00    	movl   $0x2,(%edi)
 - 807be98:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 807be98:	e9 b9 b4 06 00       	jmp    80e7356 <_end+0x70e>
++ 807be98:	<trampoline-jmp+0x356>
 + 807be9d:	90                   	nop
 + 807be9e:	90                   	nop
   807be9f:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -508,7 +509,7 @@ expression: diff
   807bf1f:	8b 5c 24 10          	mov    0x10(%esp),%ebx
   807bf23:	c7 03 00 00 00 00    	movl   $0x0,(%ebx)
 - 807bf29:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 807bf29:	e9 3a b4 06 00       	jmp    80e7368 <_end+0x720>
++ 807bf29:	<trampoline-jmp+0x368>
 + 807bf2e:	90                   	nop
 + 807bf2f:	90                   	nop
   807bf30:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -519,7 +520,7 @@ expression: diff
   807c11e:	c1 e1 07             	shl    $0x7,%ecx
   807c121:	80 f1 81             	xor    $0x81,%cl
 - 807c124:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 807c124:	e9 51 b2 06 00       	jmp    80e737a <_end+0x732>
++ 807c124:	<trampoline-jmp+0x37a>
 + 807c129:	90                   	nop
 + 807c12a:	90                   	nop
   807c12b:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -530,7 +531,7 @@ expression: diff
   807c295:	89 eb                	mov    %ebp,%ebx
   807c297:	80 f1 81             	xor    $0x81,%cl
 - 807c29a:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 807c29a:	e9 ed b0 06 00       	jmp    80e738c <_end+0x744>
++ 807c29a:	<trampoline-jmp+0x38c>
 + 807c29f:	90                   	nop
 + 807c2a0:	90                   	nop
   807c2a1:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -541,7 +542,7 @@ expression: diff
   807c2f4:	31 f6                	xor    %esi,%esi
   807c2f6:	80 f1 81             	xor    $0x81,%cl
 - 807c2f9:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 807c2f9:	e9 a0 b0 06 00       	jmp    80e739e <_end+0x756>
++ 807c2f9:	<trampoline-jmp+0x39e>
 + 807c2fe:	90                   	nop
 + 807c2ff:	90                   	nop
   807c300:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -552,7 +553,7 @@ expression: diff
   807c385:	89 fb                	mov    %edi,%ebx
   807c387:	80 f1 81             	xor    $0x81,%cl
 - 807c38a:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 807c38a:	e9 21 b0 06 00       	jmp    80e73b0 <_end+0x768>
++ 807c38a:	<trampoline-jmp+0x3b0>
 + 807c38f:	90                   	nop
 + 807c390:	90                   	nop
   807c391:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -563,7 +564,7 @@ expression: diff
   807c3fa:	ba ff ff ff 7f       	mov    $0x7fffffff,%edx
   807c3ff:	80 f1 81             	xor    $0x81,%cl
 - 807c402:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 807c402:	e9 bb af 06 00       	jmp    80e73c2 <_end+0x77a>
++ 807c402:	<trampoline-jmp+0x3c2>
 + 807c407:	90                   	nop
 + 807c408:	90                   	nop
   807c409:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -574,7 +575,7 @@ expression: diff
   807c6af:	ba 01 00 00 00       	mov    $0x1,%edx
   807c6b4:	80 f1 81             	xor    $0x81,%cl
 - 807c6b7:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 807c6b7:	e9 18 ad 06 00       	jmp    80e73d4 <_end+0x78c>
++ 807c6b7:	<trampoline-jmp+0x3d4>
 + 807c6bc:	90                   	nop
 + 807c6bd:	90                   	nop
   807c6be:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -585,7 +586,7 @@ expression: diff
   807c6de:	89 fb                	mov    %edi,%ebx
   807c6e0:	80 f1 81             	xor    $0x81,%cl
 - 807c6e3:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 807c6e3:	e9 fe ac 06 00       	jmp    80e73e6 <_end+0x79e>
++ 807c6e3:	<trampoline-jmp+0x3e6>
 + 807c6e8:	90                   	nop
 + 807c6e9:	90                   	nop
   807c6ea:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -596,7 +597,7 @@ expression: diff
   807c75d:	31 f6                	xor    %esi,%esi
   807c75f:	80 f1 81             	xor    $0x81,%cl
 - 807c762:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 807c762:	e9 91 ac 06 00       	jmp    80e73f8 <_end+0x7b0>
++ 807c762:	<trampoline-jmp+0x3f8>
 + 807c767:	90                   	nop
 + 807c768:	90                   	nop
   807c769:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -607,7 +608,7 @@ expression: diff
   808a570:	0f 47 d0             	cmova  %eax,%edx
   808a573:	b8 dc 00 00 00       	mov    $0xdc,%eax
 - 808a578:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 808a578:	e9 8d ce 05 00       	jmp    80e740a <_end+0x7c2>
++ 808a578:	<trampoline-jmp+0x40a>
 + 808a57d:	90                   	nop
 + 808a57e:	90                   	nop
   808a57f:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -618,7 +619,7 @@ expression: diff
   808a706:	8b 5c 24 04          	mov    0x4(%esp),%ebx
   808a70a:	b8 9b 00 00 00       	mov    $0x9b,%eax
 - 808a70f:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 808a70f:	e9 08 cd 05 00       	jmp    80e741c <_end+0x7d4>
++ 808a70f:	<trampoline-jmp+0x41c>
 + 808a714:	90                   	nop
 + 808a715:	90                   	nop
   808a716:	89 d3                	mov    %edx,%ebx
@@ -629,7 +630,7 @@ expression: diff
   808a732:	8b 5c 24 04          	mov    0x4(%esp),%ebx
   808a736:	b8 9d 00 00 00       	mov    $0x9d,%eax
 - 808a73b:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 808a73b:	e9 ee cc 05 00       	jmp    80e742e <_end+0x7e6>
++ 808a73b:	<trampoline-jmp+0x42e>
 + 808a740:	90                   	nop
 + 808a741:	90                   	nop
   808a742:	89 d3                	mov    %edx,%ebx
@@ -640,7 +641,7 @@ expression: diff
   808a752:	8b 5c 24 04          	mov    0x4(%esp),%ebx
   808a756:	b8 9f 00 00 00       	mov    $0x9f,%eax
 - 808a75b:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 808a75b:	e9 e0 cc 05 00       	jmp    80e7440 <_end+0x7f8>
++ 808a75b:	<trampoline-jmp+0x440>
 + 808a760:	90                   	nop
 + 808a761:	90                   	nop
   808a762:	89 d3                	mov    %edx,%ebx
@@ -651,7 +652,7 @@ expression: diff
   808a772:	8b 5c 24 04          	mov    0x4(%esp),%ebx
   808a776:	b8 a0 00 00 00       	mov    $0xa0,%eax
 - 808a77b:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 808a77b:	e9 d2 cc 05 00       	jmp    80e7452 <_end+0x80a>
++ 808a77b:	<trampoline-jmp+0x452>
 + 808a780:	90                   	nop
 + 808a781:	90                   	nop
   808a782:	89 d3                	mov    %edx,%ebx
@@ -662,7 +663,7 @@ expression: diff
   808a799:	8b 5c 24 08          	mov    0x8(%esp),%ebx
   808a79d:	b8 9c 00 00 00       	mov    $0x9c,%eax
 - 808a7a2:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 808a7a2:	e9 bd cc 05 00       	jmp    80e7464 <_end+0x81c>
++ 808a7a2:	<trampoline-jmp+0x464>
 + 808a7a7:	90                   	nop
 + 808a7a8:	90                   	nop
   808a7a9:	5b                   	pop    %ebx
@@ -673,7 +674,7 @@ expression: diff
   808a837:	b8 b7 00 00 00       	mov    $0xb7,%eax
   808a83c:	89 f1                	mov    %esi,%ecx
 - 808a83e:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 808a83e:	e9 33 cc 05 00       	jmp    80e7476 <_end+0x82e>
++ 808a83e:	<trampoline-jmp+0x476>
 + 808a843:	90                   	nop
 + 808a844:	90                   	nop
   808a845:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -684,7 +685,7 @@ expression: diff
   808b0ac:	8b 7c 24 3c          	mov    0x3c(%esp),%edi
   808b0b0:	b8 8c 00 00 00       	mov    $0x8c,%eax
 - 808b0b5:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 808b0b5:	e9 ce c3 05 00       	jmp    80e7488 <_end+0x840>
++ 808b0b5:	<trampoline-jmp+0x488>
 + 808b0ba:	90                   	nop
 + 808b0bb:	90                   	nop
   808b0bc:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -695,7 +696,7 @@ expression: diff
   808b1fe:	bb 9c ff ff ff       	mov    $0xffffff9c,%ebx
   808b203:	89 ea                	mov    %ebp,%edx
 - 808b205:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 808b205:	e9 90 c2 05 00       	jmp    80e749a <_end+0x852>
++ 808b205:	<trampoline-jmp+0x49a>
 + 808b20a:	90                   	nop
 + 808b20b:	90                   	nop
   808b20c:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -706,7 +707,7 @@ expression: diff
   808b242:	89 44 24 08          	mov    %eax,0x8(%esp)
   808b246:	b8 27 01 00 00       	mov    $0x127,%eax
 - 808b24b:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 808b24b:	e9 5c c2 05 00       	jmp    80e74ac <_end+0x864>
++ 808b24b:	<trampoline-jmp+0x4ac>
 + 808b250:	90                   	nop
 + 808b251:	90                   	nop
   808b252:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -717,7 +718,7 @@ expression: diff
   808b2f0:	b8 27 01 00 00       	mov    $0x127,%eax
   808b2f5:	89 ea                	mov    %ebp,%edx
 - 808b2f7:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 808b2f7:	e9 c2 c1 05 00       	jmp    80e74be <_end+0x876>
++ 808b2f7:	<trampoline-jmp+0x4be>
 + 808b2fc:	90                   	nop
 + 808b2fd:	90                   	nop
   808b2fe:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -728,7 +729,7 @@ expression: diff
   808b331:	89 44 24 08          	mov    %eax,0x8(%esp)
   808b335:	b8 27 01 00 00       	mov    $0x127,%eax
 - 808b33a:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 808b33a:	e9 91 c1 05 00       	jmp    80e74d0 <_end+0x888>
++ 808b33a:	<trampoline-jmp+0x4d0>
 + 808b33f:	90                   	nop
 + 808b340:	90                   	nop
   808b341:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -739,7 +740,7 @@ expression: diff
   808b3c3:	b8 03 00 00 00       	mov    $0x3,%eax
   808b3c8:	8b 54 24 28          	mov    0x28(%esp),%edx
 - 808b3cc:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 808b3cc:	e9 11 c1 05 00       	jmp    80e74e2 <_end+0x89a>
++ 808b3cc:	<trampoline-jmp+0x4e2>
 + 808b3d1:	90                   	nop
 + 808b3d2:	90                   	nop
   808b3d3:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -750,7 +751,7 @@ expression: diff
   808b3f9:	8b 54 24 28          	mov    0x28(%esp),%edx
   808b3fd:	b8 03 00 00 00       	mov    $0x3,%eax
 - 808b402:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 808b402:	e9 ed c0 05 00       	jmp    80e74f4 <_end+0x8ac>
++ 808b402:	<trampoline-jmp+0x4f4>
 + 808b407:	90                   	nop
 + 808b408:	90                   	nop
   808b409:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -761,7 +762,7 @@ expression: diff
   808b483:	b8 04 00 00 00       	mov    $0x4,%eax
   808b488:	8b 54 24 28          	mov    0x28(%esp),%edx
 - 808b48c:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 808b48c:	e9 75 c0 05 00       	jmp    80e7506 <_end+0x8be>
++ 808b48c:	<trampoline-jmp+0x506>
 + 808b491:	90                   	nop
 + 808b492:	90                   	nop
   808b493:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -772,7 +773,7 @@ expression: diff
   808b4b9:	8b 54 24 28          	mov    0x28(%esp),%edx
   808b4bd:	b8 04 00 00 00       	mov    $0x4,%eax
 - 808b4c2:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 808b4c2:	e9 51 c0 05 00       	jmp    80e7518 <_end+0x8d0>
++ 808b4c2:	<trampoline-jmp+0x518>
 + 808b4c7:	90                   	nop
 + 808b4c8:	90                   	nop
   808b4c9:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -783,7 +784,7 @@ expression: diff
   808b525:	8b 6f 08             	mov    0x8(%edi),%ebp
   808b528:	8b 7f 04             	mov    0x4(%edi),%edi
 - 808b52b:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 808b52b:	e9 fa bf 05 00       	jmp    80e752a <_end+0x8e2>
++ 808b52b:	<trampoline-jmp+0x52a>
 + 808b530:	90                   	nop
 + 808b531:	90                   	nop
   808b532:	5d                   	pop    %ebp
@@ -795,7 +796,7 @@ expression: diff
   808b545:	8b 6f 08             	mov    0x8(%edi),%ebp
 - 808b548:	8b 7f 04             	mov    0x4(%edi),%edi
 - 808b54b:	cd 80                	int    $0x80
-+ 808b548:	e9 ef bf 05 00       	jmp    80e753c <_end+0x8f4>
++ 808b548:	<trampoline-jmp+0x53c>
   808b54d:	5d                   	pop    %ebp
   808b54e:	5f                   	pop    %edi
   808b54f:	5b                   	pop    %ebx
@@ -804,7 +805,7 @@ expression: diff
   808b58b:	b8 27 01 00 00       	mov    $0x127,%eax
   808b590:	bb 9c ff ff ff       	mov    $0xffffff9c,%ebx
 - 808b595:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 808b595:	e9 b7 bf 05 00       	jmp    80e7551 <_end+0x909>
++ 808b595:	<trampoline-jmp+0x551>
 + 808b59a:	90                   	nop
 + 808b59b:	90                   	nop
   808b59c:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -815,7 +816,7 @@ expression: diff
   808b608:	8b 5c 24 10          	mov    0x10(%esp),%ebx
   808b60c:	b8 27 01 00 00       	mov    $0x127,%eax
 - 808b611:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 808b611:	e9 4d bf 05 00       	jmp    80e7563 <_end+0x91b>
++ 808b611:	<trampoline-jmp+0x563>
 + 808b616:	90                   	nop
 + 808b617:	90                   	nop
   808b618:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -826,7 +827,7 @@ expression: diff
   808b670:	8b 74 24 20          	mov    0x20(%esp),%esi
   808b674:	8b 7c 24 24          	mov    0x24(%esp),%edi
 - 808b678:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 808b678:	e9 f8 be 05 00       	jmp    80e7575 <_end+0x92d>
++ 808b678:	<trampoline-jmp+0x575>
 + 808b67d:	90                   	nop
 + 808b67e:	90                   	nop
   808b67f:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -837,7 +838,7 @@ expression: diff
   808b6c6:	8b 54 24 14          	mov    0x14(%esp),%edx
   808b6ca:	8b 5c 24 0c          	mov    0xc(%esp),%ebx
 - 808b6ce:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 808b6ce:	e9 b4 be 05 00       	jmp    80e7587 <_end+0x93f>
++ 808b6ce:	<trampoline-jmp+0x587>
 + 808b6d3:	90                   	nop
 + 808b6d4:	90                   	nop
   808b6d5:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -848,7 +849,7 @@ expression: diff
   808b72a:	8d 54 24 08          	lea    0x8(%esp),%edx
   808b72e:	b8 36 00 00 00       	mov    $0x36,%eax
 - 808b733:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 808b733:	e9 61 be 05 00       	jmp    80e7599 <_end+0x951>
++ 808b733:	<trampoline-jmp+0x599>
 + 808b738:	90                   	nop
 + 808b739:	90                   	nop
   808b73a:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -859,7 +860,7 @@ expression: diff
   808b801:	8b 4c 24 0c          	mov    0xc(%esp),%ecx
   808b805:	8b 5c 24 08          	mov    0x8(%esp),%ebx
 - 808b809:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 808b809:	e9 9d bd 05 00       	jmp    80e75ab <_end+0x963>
++ 808b809:	<trampoline-jmp+0x5ab>
 + 808b80e:	90                   	nop
 + 808b80f:	90                   	nop
   808b810:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -870,7 +871,7 @@ expression: diff
   8092201:	8d 58 1c             	lea    0x1c(%eax),%ebx
   8092204:	b8 f0 00 00 00       	mov    $0xf0,%eax
 - 8092209:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 8092209:	e9 af 53 05 00       	jmp    80e75bd <_end+0x975>
++ 8092209:	<trampoline-jmp+0x5bd>
 + 809220e:	90                   	nop
 + 809220f:	90                   	nop
   8092210:	83 ec 0c             	sub    $0xc,%esp
@@ -881,7 +882,7 @@ expression: diff
   8092e5f:	8d 8d ea dc fc ff    	lea    -0x32316(%ebp),%ecx
   8092e65:	89 fa                	mov    %edi,%edx
 - 8092e67:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 8092e67:	e9 63 47 05 00       	jmp    80e75cf <_end+0x987>
++ 8092e67:	<trampoline-jmp+0x5cf>
 + 8092e6c:	90                   	nop
 + 8092e6d:	90                   	nop
   8092e6e:	85 c0                	test   %eax,%eax
@@ -893,7 +894,7 @@ expression: diff
   80930a6:	8d 4c 24 30          	lea    0x30(%esp),%ecx
 - 80930aa:	b8 92 00 00 00       	mov    $0x92,%eax
 - 80930af:	cd 80                	int    $0x80
-+ 80930aa:	e9 32 45 05 00       	jmp    80e75e1 <_end+0x999>
++ 80930aa:	<trampoline-jmp+0x5e1>
 + 80930af:	90                   	nop
 + 80930b0:	90                   	nop
   80930b1:	81 c4 bc 04 00 00    	add    $0x4bc,%esp
@@ -904,7 +905,7 @@ expression: diff
   809521e:	31 f6                	xor    %esi,%esi
   8095220:	89 f8                	mov    %edi,%eax
 - 8095222:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 8095222:	e9 d1 23 05 00       	jmp    80e75f8 <_end+0x9b0>
++ 8095222:	<trampoline-jmp+0x5f8>
 + 8095227:	90                   	nop
 + 8095228:	90                   	nop
   8095229:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -915,7 +916,7 @@ expression: diff
   80952b6:	31 f6                	xor    %esi,%esi
   80952b8:	89 f8                	mov    %edi,%eax
 - 80952ba:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 80952ba:	e9 4b 23 05 00       	jmp    80e760a <_end+0x9c2>
++ 80952ba:	<trampoline-jmp+0x60a>
 + 80952bf:	90                   	nop
 + 80952c0:	90                   	nop
   80952c1:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -927,7 +928,7 @@ expression: diff
  08098e30 <__restore_rt>:
 - 8098e30:	b8 ad 00 00 00       	mov    $0xad,%eax
 - 8098e35:	cd 80                	int    $0x80
-+ 8098e30:	e9 e7 e7 04 00       	jmp    80e761c <_end+0x9d4>
++ 8098e30:	<trampoline-jmp+0x61c>
 + 8098e35:	90                   	nop
 + 8098e36:	90                   	nop
   8098e37:	90                   	nop
@@ -936,7 +937,7 @@ expression: diff
   8098e38:	58                   	pop    %eax
 - 8098e39:	b8 77 00 00 00       	mov    $0x77,%eax
 - 8098e3e:	cd 80                	int    $0x80
-+ 8098e39:	e9 f5 e7 04 00       	jmp    80e7633 <_end+0x9eb>
++ 8098e39:	<trampoline-jmp+0x633>
 + 8098e3e:	90                   	nop
 + 8098e3f:	90                   	nop
  
@@ -947,7 +948,7 @@ expression: diff
   8098eca:	be 08 00 00 00       	mov    $0x8,%esi
   8098ecf:	8d 94 24 a0 00 00 00 	lea    0xa0(%esp),%edx
 - 8098ed6:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 8098ed6:	e9 6f e7 04 00       	jmp    80e764a <_end+0xa02>
++ 8098ed6:	<trampoline-jmp+0x64a>
 + 8098edb:	90                   	nop
 + 8098edc:	90                   	nop
   8098edd:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -958,7 +959,7 @@ expression: diff
   8098f6c:	be 08 00 00 00       	mov    $0x8,%esi
   8098f71:	89 ea                	mov    %ebp,%edx
 - 8098f73:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 8098f73:	e9 e4 e6 04 00       	jmp    80e765c <_end+0xa14>
++ 8098f73:	<trampoline-jmp+0x65c>
 + 8098f78:	90                   	nop
 + 8098f79:	90                   	nop
   8098f7a:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -969,7 +970,7 @@ expression: diff
   809e209:	31 f6                	xor    %esi,%esi
   809e20b:	89 e8                	mov    %ebp,%eax
 - 809e20d:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 809e20d:	e9 5c 94 04 00       	jmp    80e766e <_end+0xa26>
++ 809e20d:	<trampoline-jmp+0x66e>
 + 809e212:	90                   	nop
 + 809e213:	90                   	nop
   809e214:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -980,7 +981,7 @@ expression: diff
   809e753:	b8 a6 01 00 00       	mov    $0x1a6,%eax
   809e758:	31 d2                	xor    %edx,%edx
 - 809e75a:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 809e75a:	e9 21 8f 04 00       	jmp    80e7680 <_end+0xa38>
++ 809e75a:	<trampoline-jmp+0x680>
 + 809e75f:	90                   	nop
 + 809e760:	90                   	nop
   809e761:	83 f8 da             	cmp    $0xffffffda,%eax
@@ -991,7 +992,7 @@ expression: diff
   809e7f3:	b8 f0 00 00 00       	mov    $0xf0,%eax
   809e7f8:	31 d2                	xor    %edx,%edx
 - 809e7fa:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 809e7fa:	e9 93 8e 04 00       	jmp    80e7692 <_end+0xa4a>
++ 809e7fa:	<trampoline-jmp+0x692>
 + 809e7ff:	90                   	nop
 + 809e800:	90                   	nop
   809e801:	83 f8 da             	cmp    $0xffffffda,%eax
@@ -1002,7 +1003,7 @@ expression: diff
   809eae1:	89 54 24 08          	mov    %edx,0x8(%esp)
   809eae5:	8d 8d dc 73 fe ff    	lea    -0x18c24(%ebp),%ecx
 - 809eaeb:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 809eaeb:	e9 b4 8b 04 00       	jmp    80e76a4 <_end+0xa5c>
++ 809eaeb:	<trampoline-jmp+0x6a4>
 + 809eaf0:	90                   	nop
 + 809eaf1:	90                   	nop
   809eaf2:	ba 01 00 00 00       	mov    $0x1,%edx
@@ -1013,7 +1014,7 @@ expression: diff
   809eb2d:	8b 4c 24 08          	mov    0x8(%esp),%ecx
   809eb31:	be 08 00 00 00       	mov    $0x8,%esi
 - 809eb36:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 809eb36:	e9 7b 8b 04 00       	jmp    80e76b6 <_end+0xa6e>
++ 809eb36:	<trampoline-jmp+0x6b6>
 + 809eb3b:	90                   	nop
 + 809eb3c:	90                   	nop
   809eb3d:	8b 44 24 1c          	mov    0x1c(%esp),%eax
@@ -1024,7 +1025,7 @@ expression: diff
   809eb6e:	89 c3                	mov    %eax,%ebx
   809eb70:	b8 0e 01 00 00       	mov    $0x10e,%eax
 - 809eb75:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 809eb75:	e9 4e 8b 04 00       	jmp    80e76c8 <_end+0xa80>
++ 809eb75:	<trampoline-jmp+0x6c8>
 + 809eb7a:	90                   	nop
 + 809eb7b:	90                   	nop
   809eb7c:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -1035,7 +1036,7 @@ expression: diff
   809eb89:	8d b4 26 00 00 00 00 	lea    0x0(%esi,%eiz,1),%esi
   809eb90:	b8 e0 00 00 00       	mov    $0xe0,%eax
 - 809eb95:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 809eb95:	e9 40 8b 04 00       	jmp    80e76da <_end+0xa92>
++ 809eb95:	<trampoline-jmp+0x6da>
 + 809eb9a:	90                   	nop
 + 809eb9b:	90                   	nop
   809eb9c:	89 eb                	mov    %ebp,%ebx
@@ -1046,7 +1047,7 @@ expression: diff
   809ebab:	89 c3                	mov    %eax,%ebx
   809ebad:	b8 0e 01 00 00       	mov    $0x10e,%eax
 - 809ebb2:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 809ebb2:	e9 35 8b 04 00       	jmp    80e76ec <_end+0xaa4>
++ 809ebb2:	<trampoline-jmp+0x6ec>
 + 809ebb7:	90                   	nop
 + 809ebb8:	90                   	nop
   809ebb9:	89 c7                	mov    %eax,%edi
@@ -1057,7 +1058,7 @@ expression: diff
   809ec91:	b8 af 00 00 00       	mov    $0xaf,%eax
   809ec96:	be 08 00 00 00       	mov    $0x8,%esi
 - 809ec9b:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 809ec9b:	e9 5e 8a 04 00       	jmp    80e76fe <_end+0xab6>
++ 809ec9b:	<trampoline-jmp+0x6fe>
 + 809eca0:	90                   	nop
 + 809eca1:	90                   	nop
   809eca2:	89 c2                	mov    %eax,%edx
@@ -1068,7 +1069,7 @@ expression: diff
  0809f8e0 <__getpid>:
   809f8e0:	b8 14 00 00 00       	mov    $0x14,%eax
 - 809f8e5:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 809f8e5:	e9 26 7e 04 00       	jmp    80e7710 <_end+0xac8>
++ 809f8e5:	<trampoline-jmp+0x710>
 + 809f8ea:	90                   	nop
 + 809f8eb:	90                   	nop
   809f8ec:	c3                   	ret
@@ -1079,7 +1080,7 @@ expression: diff
   80a009b:	b8 8c 00 00 00       	mov    $0x8c,%eax
   80a00a0:	8b 4c 24 0c          	mov    0xc(%esp),%ecx
 - 80a00a4:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 80a00a4:	e9 79 76 04 00       	jmp    80e7722 <_end+0xada>
++ 80a00a4:	<trampoline-jmp+0x722>
 + 80a00a9:	90                   	nop
 + 80a00aa:	90                   	nop
   80a00ab:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -1090,7 +1091,7 @@ expression: diff
   80a3578:	8d 58 1c             	lea    0x1c(%eax),%ebx
   80a357b:	b8 f0 00 00 00       	mov    $0xf0,%eax
 - 80a3580:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 80a3580:	e9 af 41 04 00       	jmp    80e7734 <_end+0xaec>
++ 80a3580:	<trampoline-jmp+0x734>
 + 80a3585:	90                   	nop
 + 80a3586:	90                   	nop
   80a3587:	eb 87                	jmp    80a3510 <_dl_fixup+0xf0>
@@ -1101,7 +1102,7 @@ expression: diff
   80a718c:	8d 58 1c             	lea    0x1c(%eax),%ebx
   80a718f:	b8 f0 00 00 00       	mov    $0xf0,%eax
 - 80a7194:	65 ff 15 10 00 00 00 	call   *%gs:0x10
-+ 80a7194:	e9 ad 05 04 00       	jmp    80e7746 <_end+0xafe>
++ 80a7194:	<trampoline-jmp+0x746>
 + 80a7199:	90                   	nop
 + 80a719a:	90                   	nop
   80a719b:	8b 44 24 1c          	mov    0x1c(%esp),%eax

--- a/litebox_syscall_rewriter/tests/snapshots/snapshot_tests__hello-diff.snap
+++ b/litebox_syscall_rewriter/tests/snapshots/snapshot_tests__hello-diff.snap
@@ -1,5 +1,6 @@
 ---
 source: litebox_syscall_rewriter/tests/snapshot_tests.rs
+assertion_line: 99
 expression: diff
 ---
 --- original
@@ -10,7 +11,7 @@ expression: diff
    401222:	bf 01 00 00 00       	mov    $0x1,%edi
 -  401227:	b8 0e 00 00 00       	mov    $0xe,%eax
 -  40122c:	0f 05                	syscall
-+  401227:	e9 dc 0d 0b 00       	jmp    4b2008 <_end+0xde0>
++  401227:	<trampoline-jmp+0x8>
 +  40122c:	90                   	nop
 +  40122d:	90                   	nop
    40122e:	8b 05 0c fc 0a 00    	mov    0xafc0c(%rip),%eax        # 4b0e40 <stage>
@@ -23,7 +24,7 @@ expression: diff
 -  401e78:	31 ff                	xor    %edi,%edi
 -  401e7a:	89 d0                	mov    %edx,%eax
 -  401e7c:	0f 05                	syscall
-+  401e78:	e9 9d 01 0b 00       	jmp    4b201a <_end+0xdf2>
++  401e78:	<trampoline-jmp+0x1a>
 +  401e7d:	90                   	nop
    401e7e:	eb f8                	jmp    401e78 <__libc_start_call_main+0x88>
    401e80:	31 c0                	xor    %eax,%eax
@@ -34,7 +35,7 @@ expression: diff
    403ee0:	bf 01 50 00 00       	mov    $0x5001,%edi
 -  403ee5:	b8 9e 00 00 00       	mov    $0x9e,%eax
 -  403eea:	0f 05                	syscall
-+  403ee5:	e9 41 e1 0a 00       	jmp    4b202b <_end+0xe03>
++  403ee5:	<trampoline-jmp+0x2b>
 +  403eea:	90                   	nop
 +  403eeb:	90                   	nop
    403eec:	44 89 ef             	mov    %r13d,%edi
@@ -46,7 +47,7 @@ expression: diff
    4043ce:	48 89 36             	mov    %rsi,(%rsi)
 -  4043d1:	48 89 76 10          	mov    %rsi,0x10(%rsi)
 -  4043d5:	0f 05                	syscall
-+  4043d1:	e9 67 dc 0a 00       	jmp    4b203d <_end+0xe15>
++  4043d1:	<trampoline-jmp+0x3d>
 +  4043d6:	90                   	nop
    4043d7:	85 c0                	test   %eax,%eax
    4043d9:	74 24                	je     4043ff <__libc_setup_tls+0x1df>
@@ -55,7 +56,7 @@ expression: diff
    4043e5:	b8 01 00 00 00       	mov    $0x1,%eax
 -  4043ea:	48 8d 35 c7 d1 07 00 	lea    0x7d1c7(%rip),%rsi        # 4815b8 <slashdot.0+0x76b>
 -  4043f1:	0f 05                	syscall
-+  4043ea:	e9 5f dc 0a 00       	jmp    4b204e <_end+0xe26>
++  4043ea:	<trampoline-jmp+0x4e>
 +  4043ef:	90                   	nop
 +  4043f0:	90                   	nop
 +  4043f1:	90                   	nop
@@ -63,7 +64,7 @@ expression: diff
    4043f3:	bf 7f 00 00 00       	mov    $0x7f,%edi
 -  4043f8:	b8 e7 00 00 00       	mov    $0xe7,%eax
 -  4043fd:	0f 05                	syscall
-+  4043f8:	e9 65 dc 0a 00       	jmp    4b2062 <_end+0xe3a>
++  4043f8:	<trampoline-jmp+0x62>
 +  4043fd:	90                   	nop
 +  4043fe:	90                   	nop
    4043ff:	e8 dc ba 01 00       	call   41fee0 <__tls_init_tp>
@@ -75,7 +76,7 @@ expression: diff
    4044ba:	b8 01 00 00 00       	mov    $0x1,%eax
 -  4044bf:	48 8d 35 f2 d0 07 00 	lea    0x7d0f2(%rip),%rsi        # 4815b8 <slashdot.0+0x76b>
 -  4044c6:	0f 05                	syscall
-+  4044bf:	e9 b0 db 0a 00       	jmp    4b2074 <_end+0xe4c>
++  4044bf:	<trampoline-jmp+0x74>
 +  4044c4:	90                   	nop
 +  4044c5:	90                   	nop
 +  4044c6:	90                   	nop
@@ -83,7 +84,7 @@ expression: diff
    4044c8:	bf 7f 00 00 00       	mov    $0x7f,%edi
 -  4044cd:	b8 e7 00 00 00       	mov    $0xe7,%eax
 -  4044d2:	0f 05                	syscall
-+  4044cd:	e9 b6 db 0a 00       	jmp    4b2088 <_end+0xe60>
++  4044cd:	<trampoline-jmp+0x88>
 +  4044d2:	90                   	nop
 +  4044d3:	90                   	nop
    4044d4:	e9 70 fe ff ff       	jmp    404349 <__libc_setup_tls+0x129>
@@ -95,7 +96,7 @@ expression: diff
    40a3e7:	bf 02 00 00 00       	mov    $0x2,%edi
 -  40a3ec:	44 89 c8             	mov    %r9d,%eax
 -  40a3ef:	0f 05                	syscall
-+  40a3ec:	e9 a9 7c 0a 00       	jmp    4b209a <_end+0xe72>
++  40a3ec:	<trampoline-jmp+0x9a>
    40a3f1:	48 83 f8 fc          	cmp    $0xfffffffffffffffc,%rax
    40a3f5:	74 e9                	je     40a3e0 <__libc_message_impl+0x150>
    40a3f7:	45 31 c9             	xor    %r9d,%r9d
@@ -105,7 +106,7 @@ expression: diff
    40a5cf:	be 80 00 00 00       	mov    $0x80,%esi
 -  40a5d4:	b8 ca 00 00 00       	mov    $0xca,%eax
 -  40a5d9:	0f 05                	syscall
-+  40a5d4:	e9 d1 7a 0a 00       	jmp    4b20aa <_end+0xe82>
++  40a5d4:	<trampoline-jmp+0xaa>
 +  40a5d9:	90                   	nop
 +  40a5da:	90                   	nop
    40a5db:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
@@ -117,7 +118,7 @@ expression: diff
    40a635:	b8 ca 00 00 00       	mov    $0xca,%eax
 -  40a63a:	40 80 f6 80          	xor    $0x80,%sil
 -  40a63e:	0f 05                	syscall
-+  40a63a:	e9 7d 7a 0a 00       	jmp    4b20bc <_end+0xe94>
++  40a63a:	<trampoline-jmp+0xbc>
 +  40a63f:	90                   	nop
    40a640:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
    40a646:	76 d6                	jbe    40a61e <__lll_lock_wait+0xe>
@@ -128,7 +129,7 @@ expression: diff
    40a67c:	be 81 00 00 00       	mov    $0x81,%esi
 -  40a681:	b8 ca 00 00 00       	mov    $0xca,%eax
 -  40a686:	0f 05                	syscall
-+  40a681:	e9 47 7a 0a 00       	jmp    4b20cd <_end+0xea5>
++  40a681:	<trampoline-jmp+0xcd>
 +  40a686:	90                   	nop
 +  40a687:	90                   	nop
    40a688:	c3                   	ret
@@ -140,7 +141,7 @@ expression: diff
    40a69b:	ba 01 00 00 00       	mov    $0x1,%edx
 -  40a6a0:	b8 ca 00 00 00       	mov    $0xca,%eax
 -  40a6a5:	0f 05                	syscall
-+  40a6a0:	e9 3a 7a 0a 00       	jmp    4b20df <_end+0xeb7>
++  40a6a0:	<trampoline-jmp+0xdf>
 +  40a6a5:	90                   	nop
 +  40a6a6:	90                   	nop
    40a6a7:	c3                   	ret
@@ -152,7 +153,7 @@ expression: diff
    40bbdb:	c6 05 3e 4c 0a 00 01 	movb   $0x1,0xa4c3e(%rip)        # 4b0820 <__malloc_initialized>
 -  40bbe2:	b8 3e 01 00 00       	mov    $0x13e,%eax
 -  40bbe7:	0f 05                	syscall
-+  40bbe2:	e9 0a 65 0a 00       	jmp    4b20f1 <_end+0xec9>
++  40bbe2:	<trampoline-jmp+0xf1>
 +  40bbe7:	90                   	nop
 +  40bbe8:	90                   	nop
    40bbe9:	48 8d 5d d0          	lea    -0x30(%rbp),%rbx
@@ -164,7 +165,7 @@ expression: diff
    4181de:	66 90                	xchg   %ax,%ax
 -  4181e0:	b8 e4 00 00 00       	mov    $0xe4,%eax
 -  4181e5:	0f 05                	syscall
-+  4181e0:	e9 1e 9f 09 00       	jmp    4b2103 <_end+0xedb>
++  4181e0:	<trampoline-jmp+0x103>
 +  4181e5:	90                   	nop
 +  4181e6:	90                   	nop
    4181e7:	85 c0                	test   %eax,%eax
@@ -176,7 +177,7 @@ expression: diff
    418249:	89 d0                	mov    %edx,%eax
 -  41824b:	0f 05                	syscall
 -  41824d:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
-+  41824b:	e9 c5 9e 09 00       	jmp    4b2115 <_end+0xeed>
++  41824b:	<trampoline-jmp+0x115>
 +  418250:	90                   	nop
 +  418251:	90                   	nop
 +  418252:	90                   	nop
@@ -189,7 +190,7 @@ expression: diff
    418260:	f3 0f 1e fa          	endbr64
 -  418264:	b8 05 00 00 00       	mov    $0x5,%eax
 -  418269:	0f 05                	syscall
-+  418264:	e9 c4 9e 09 00       	jmp    4b212d <_end+0xf05>
++  418264:	<trampoline-jmp+0x12d>
 +  418269:	90                   	nop
 +  41826a:	90                   	nop
    41826b:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
@@ -201,7 +202,7 @@ expression: diff
    418290:	f3 0f 1e fa          	endbr64
 -  418294:	b8 03 00 00 00       	mov    $0x3,%eax
 -  418299:	0f 05                	syscall
-+  418294:	e9 a6 9e 09 00       	jmp    4b213f <_end+0xf17>
++  418294:	<trampoline-jmp+0x13f>
 +  418299:	90                   	nop
 +  41829a:	90                   	nop
    41829b:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
@@ -213,7 +214,7 @@ expression: diff
    4182f9:	74 25                	je     418320 <__fcntl64_nocancel+0x60>
 -  4182fb:	b8 48 00 00 00       	mov    $0x48,%eax
 -  418300:	0f 05                	syscall
-+  4182fb:	e9 51 9e 09 00       	jmp    4b2151 <_end+0xf29>
++  4182fb:	<trampoline-jmp+0x151>
 +  418300:	90                   	nop
 +  418301:	90                   	nop
    418302:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
@@ -225,7 +226,7 @@ expression: diff
    418324:	be 10 00 00 00       	mov    $0x10,%esi
 -  418329:	b8 48 00 00 00       	mov    $0x48,%eax
 -  41832e:	0f 05                	syscall
-+  418329:	e9 35 9e 09 00       	jmp    4b2163 <_end+0xf3b>
++  418329:	<trampoline-jmp+0x163>
 +  41832e:	90                   	nop
 +  41832f:	90                   	nop
    418330:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -237,7 +238,7 @@ expression: diff
    41837e:	74 20                	je     4183a0 <__fcntl64_nocancel_adjusted+0x40>
 -  418380:	b8 48 00 00 00       	mov    $0x48,%eax
 -  418385:	0f 05                	syscall
-+  418380:	e9 f0 9d 09 00       	jmp    4b2175 <_end+0xf4d>
++  418380:	<trampoline-jmp+0x175>
 +  418385:	90                   	nop
 +  418386:	90                   	nop
    418387:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
@@ -249,7 +250,7 @@ expression: diff
    4183a4:	be 10 00 00 00       	mov    $0x10,%esi
 -  4183a9:	b8 48 00 00 00       	mov    $0x48,%eax
 -  4183ae:	0f 05                	syscall
-+  4183a9:	e9 d9 9d 09 00       	jmp    4b2187 <_end+0xf5f>
++  4183a9:	<trampoline-jmp+0x187>
 +  4183ae:	90                   	nop
 +  4183af:	90                   	nop
    4183b0:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -261,7 +262,7 @@ expression: diff
    41841a:	48 89 fe             	mov    %rdi,%rsi
 -  41841d:	bf 9c ff ff ff       	mov    $0xffffff9c,%edi
 -  418422:	0f 05                	syscall
-+  41841d:	e9 77 9d 09 00       	jmp    4b2199 <_end+0xf71>
++  41841d:	<trampoline-jmp+0x199>
 +  418422:	90                   	nop
 +  418423:	90                   	nop
    418424:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
@@ -274,7 +275,7 @@ expression: diff
 -  418480:	f3 0f 1e fa          	endbr64
 -  418484:	31 c0                	xor    %eax,%eax
 -  418486:	0f 05                	syscall
-+  418480:	e9 26 9d 09 00       	jmp    4b21ab <_end+0xf83>
++  418480:	<trampoline-jmp+0x1ab>
 +  418485:	90                   	nop
 +  418486:	90                   	nop
 +  418487:	90                   	nop
@@ -287,7 +288,7 @@ expression: diff
    4184b0:	f3 0f 1e fa          	endbr64
 -  4184b4:	b8 0c 00 00 00       	mov    $0xc,%eax
 -  4184b9:	0f 05                	syscall
-+  4184b4:	e9 05 9d 09 00       	jmp    4b21be <_end+0xf96>
++  4184b4:	<trampoline-jmp+0x1be>
 +  4184b9:	90                   	nop
 +  4184ba:	90                   	nop
    4184bb:	48 89 05 96 83 09 00 	mov    %rax,0x98396(%rip)        # 4b0858 <__curbrk>
@@ -299,7 +300,7 @@ expression: diff
    41871a:	48 8d 95 f0 ef ff ff 	lea    -0x1010(%rbp),%rdx
 -  418721:	b8 cc 00 00 00       	mov    $0xcc,%eax
 -  418726:	0f 05                	syscall
-+  418721:	e9 aa 9a 09 00       	jmp    4b21d0 <_end+0xfa8>
++  418721:	<trampoline-jmp+0x1d0>
 +  418726:	90                   	nop
 +  418727:	90                   	nop
    418728:	85 c0                	test   %eax,%eax
@@ -311,7 +312,7 @@ expression: diff
    418b40:	f3 0f 1e fa          	endbr64
 -  418b44:	b8 1c 00 00 00       	mov    $0x1c,%eax
 -  418b49:	0f 05                	syscall
-+  418b44:	e9 99 96 09 00       	jmp    4b21e2 <_end+0xfba>
++  418b44:	<trampoline-jmp+0x1e2>
 +  418b49:	90                   	nop
 +  418b4a:	90                   	nop
    418b4b:	48 3d 01 f0 ff ff    	cmp    $0xfffffffffffff001,%rax
@@ -323,7 +324,7 @@ expression: diff
    418b92:	48 89 df             	mov    %rbx,%rdi
 -  418b95:	b8 09 00 00 00       	mov    $0x9,%eax
 -  418b9a:	0f 05                	syscall
-+  418b95:	e9 5a 96 09 00       	jmp    4b21f4 <_end+0xfcc>
++  418b95:	<trampoline-jmp+0x1f4>
 +  418b9a:	90                   	nop
 +  418b9b:	90                   	nop
    418b9c:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
@@ -335,7 +336,7 @@ expression: diff
    418bed:	b8 09 00 00 00       	mov    $0x9,%eax
 -  418bf2:	41 83 ca 40          	or     $0x40,%r10d
 -  418bf6:	0f 05                	syscall
-+  418bf2:	e9 0f 96 09 00       	jmp    4b2206 <_end+0xfde>
++  418bf2:	<trampoline-jmp+0x206>
 +  418bf7:	90                   	nop
    418bf8:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
    418bfe:	76 a4                	jbe    418ba4 <__mmap64+0x34>
@@ -346,7 +347,7 @@ expression: diff
    418c30:	f3 0f 1e fa          	endbr64
 -  418c34:	b8 0a 00 00 00       	mov    $0xa,%eax
 -  418c39:	0f 05                	syscall
-+  418c34:	e9 de 95 09 00       	jmp    4b2217 <_end+0xfef>
++  418c34:	<trampoline-jmp+0x217>
 +  418c39:	90                   	nop
 +  418c3a:	90                   	nop
    418c3b:	48 3d 01 f0 ff ff    	cmp    $0xfffffffffffff001,%rax
@@ -358,7 +359,7 @@ expression: diff
    418c60:	f3 0f 1e fa          	endbr64
 -  418c64:	b8 0b 00 00 00       	mov    $0xb,%eax
 -  418c69:	0f 05                	syscall
-+  418c64:	e9 c0 95 09 00       	jmp    4b2229 <_end+0x1001>
++  418c64:	<trampoline-jmp+0x229>
 +  418c69:	90                   	nop
 +  418c6a:	90                   	nop
    418c6b:	48 3d 01 f0 ff ff    	cmp    $0xfffffffffffff001,%rax
@@ -370,7 +371,7 @@ expression: diff
    418d47:	45 31 c0             	xor    %r8d,%r8d
 -  418d4a:	b8 19 00 00 00       	mov    $0x19,%eax
 -  418d4f:	0f 05                	syscall
-+  418d4a:	e9 ec 94 09 00       	jmp    4b223b <_end+0x1013>
++  418d4a:	<trampoline-jmp+0x23b>
 +  418d4f:	90                   	nop
 +  418d50:	90                   	nop
    418d51:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
@@ -382,7 +383,7 @@ expression: diff
    418e23:	bf 41 4d 56 53       	mov    $0x53564d41,%edi
 -  418e28:	b8 9d 00 00 00       	mov    $0x9d,%eax
 -  418e2d:	0f 05                	syscall
-+  418e28:	e9 20 94 09 00       	jmp    4b224d <_end+0x1025>
++  418e28:	<trampoline-jmp+0x24d>
 +  418e2d:	90                   	nop
 +  418e2e:	90                   	nop
    418e2f:	83 f8 ea             	cmp    $0xffffffea,%eax
@@ -394,7 +395,7 @@ expression: diff
    418e50:	f3 0f 1e fa          	endbr64
 -  418e54:	b8 63 00 00 00       	mov    $0x63,%eax
 -  418e59:	0f 05                	syscall
-+  418e54:	e9 06 94 09 00       	jmp    4b225f <_end+0x1037>
++  418e54:	<trampoline-jmp+0x25f>
 +  418e59:	90                   	nop
 +  418e5a:	90                   	nop
    418e5b:	48 3d 01 f0 ff ff    	cmp    $0xfffffffffffff001,%rax
@@ -406,7 +407,7 @@ expression: diff
    41e494:	48 8d 9d e0 ef ff ff 	lea    -0x1020(%rbp),%rbx
 -  41e49b:	48 89 da             	mov    %rbx,%rdx
 -  41e49e:	0f 05                	syscall
-+  41e49b:	e9 d1 3d 09 00       	jmp    4b2271 <_end+0x1049>
++  41e49b:	<trampoline-jmp+0x271>
    41e4a0:	85 c0                	test   %eax,%eax
    41e4a2:	7e 5c                	jle    41e500 <_dl_get_origin+0xa0>
    41e4a4:	0f b6 95 e0 ef ff ff 	movzbl -0x1020(%rbp),%edx
@@ -416,7 +417,7 @@ expression: diff
    41e6db:	48 8d b5 d0 f6 ff ff 	lea    -0x930(%rbp),%rsi
 -  41e6e2:	b8 14 00 00 00       	mov    $0x14,%eax
 -  41e6e7:	0f 05                	syscall
-+  41e6e2:	e9 9a 3b 09 00       	jmp    4b2281 <_end+0x1059>
++  41e6e2:	<trampoline-jmp+0x281>
 +  41e6e7:	90                   	nop
 +  41e6e8:	90                   	nop
    41e6e9:	48 81 c4 38 09 00 00 	add    $0x938,%rsp
@@ -428,7 +429,7 @@ expression: diff
    41ff24:	48 8d bb d0 02 00 00 	lea    0x2d0(%rbx),%rdi
 -  41ff2b:	b8 da 00 00 00       	mov    $0xda,%eax
 -  41ff30:	0f 05                	syscall
-+  41ff2b:	e9 63 23 09 00       	jmp    4b2293 <_end+0x106b>
++  41ff2b:	<trampoline-jmp+0x293>
 +  41ff30:	90                   	nop
 +  41ff31:	90                   	nop
    41ff32:	89 83 d0 02 00 00    	mov    %eax,0x2d0(%rbx)
@@ -440,7 +441,7 @@ expression: diff
    41ff81:	66 0f 6c c0          	punpcklqdq %xmm0,%xmm0
 -  41ff85:	0f 11 83 d8 02 00 00 	movups %xmm0,0x2d8(%rbx)
 -  41ff8c:	0f 05                	syscall
-+  41ff85:	e9 1b 23 09 00       	jmp    4b22a5 <_end+0x107d>
++  41ff85:	<trampoline-jmp+0x2a5>
 +  41ff8a:	90                   	nop
 +  41ff8b:	90                   	nop
 +  41ff8c:	90                   	nop
@@ -454,7 +455,7 @@ expression: diff
    41fff4:	48 89 df             	mov    %rbx,%rdi
 -  41fff7:	b8 4e 01 00 00       	mov    $0x14e,%eax
 -  41fffc:	0f 05                	syscall
-+  41fff7:	e9 bd 22 09 00       	jmp    4b22b9 <_end+0x1091>
++  41fff7:	<trampoline-jmp+0x2b9>
 +  41fffc:	90                   	nop
 +  41fffd:	90                   	nop
    41fffe:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -466,7 +467,7 @@ expression: diff
    421344:	bf 02 50 00 00       	mov    $0x5002,%edi
 -  421349:	b8 9e 00 00 00       	mov    $0x9e,%eax
 -  42134e:	0f 05                	syscall
-+  421349:	e9 7d 0f 09 00       	jmp    4b22cb <_end+0x10a3>
++  421349:	<trampoline-jmp+0x2cb>
 +  42134e:	90                   	nop
 +  42134f:	90                   	nop
    421350:	89 c7                	mov    %eax,%edi
@@ -478,7 +479,7 @@ expression: diff
    4213a5:	48 89 e5             	mov    %rsp,%rbp
 -  4213a8:	48 8d 75 f8          	lea    -0x8(%rbp),%rsi
 -  4213ac:	0f 05                	syscall
-+  4213a8:	e9 30 0f 09 00       	jmp    4b22dd <_end+0x10b5>
++  4213a8:	<trampoline-jmp+0x2dd>
 +  4213ad:	90                   	nop
    4213ae:	48 85 c0             	test   %rax,%rax
    4213b1:	74 15                	je     4213c8 <_dl_cet_setup_features+0x38>
@@ -490,7 +491,7 @@ expression: diff
 -  4213f7:	bf 03 50 00 00       	mov    $0x5003,%edi
 -  4213fc:	89 d0                	mov    %edx,%eax
 -  4213fe:	0f 05                	syscall
-+  4213f7:	e9 f2 0e 09 00       	jmp    4b22ee <_end+0x10c6>
++  4213f7:	<trampoline-jmp+0x2ee>
 +  4213fc:	90                   	nop
 +  4213fd:	90                   	nop
 +  4213fe:	90                   	nop
@@ -505,13 +506,13 @@ expression: diff
 -  421455:	31 ff                	xor    %edi,%edi
 -  421457:	89 f0                	mov    %esi,%eax
 -  421459:	0f 05                	syscall
-+  421455:	e9 a8 0e 09 00       	jmp    4b2302 <_end+0x10da>
++  421455:	<trampoline-jmp+0x302>
 +  42145a:	90                   	nop
    42145b:	48 89 c2             	mov    %rax,%rdx
 -  42145e:	48 8d 3c 18          	lea    (%rax,%rbx,1),%rdi
 -  421462:	89 f0                	mov    %esi,%eax
 -  421464:	0f 05                	syscall
-+  42145e:	e9 b0 0e 09 00       	jmp    4b2313 <_end+0x10eb>
++  42145e:	<trampoline-jmp+0x313>
 +  421463:	90                   	nop
 +  421464:	90                   	nop
 +  421465:	90                   	nop
@@ -524,7 +525,7 @@ expression: diff
    421481:	48 89 de             	mov    %rbx,%rsi
 -  421484:	b8 09 00 00 00       	mov    $0x9,%eax
 -  421489:	0f 05                	syscall
-+  421484:	e9 9d 0e 09 00       	jmp    4b2326 <_end+0x10fe>
++  421484:	<trampoline-jmp+0x326>
 +  421489:	90                   	nop
 +  42148a:	90                   	nop
    42148b:	31 d2                	xor    %edx,%edx
@@ -536,7 +537,7 @@ expression: diff
    444c16:	48 8d 35 b3 0a 04 00 	lea    0x40ab3(%rip),%rsi        # 4856d0 <sigall_set>
 -  444c1d:	b8 0e 00 00 00       	mov    $0xe,%eax
 -  444c22:	0f 05                	syscall
-+  444c1d:	e9 16 d7 06 00       	jmp    4b2338 <_end+0x1110>
++  444c1d:	<trampoline-jmp+0x338>
 +  444c22:	90                   	nop
 +  444c23:	90                   	nop
    444c24:	31 c0                	xor    %eax,%eax
@@ -548,7 +549,7 @@ expression: diff
    444c63:	bf 02 00 00 00       	mov    $0x2,%edi
 -  444c68:	b8 0e 00 00 00       	mov    $0xe,%eax
 -  444c6d:	0f 05                	syscall
-+  444c68:	e9 dd d6 06 00       	jmp    4b234a <_end+0x1122>
++  444c68:	<trampoline-jmp+0x34a>
 +  444c6d:	90                   	nop
 +  444c6e:	90                   	nop
    444c6f:	48 8b 45 d8          	mov    -0x28(%rbp),%rax
@@ -560,7 +561,7 @@ expression: diff
    444ca8:	89 de                	mov    %ebx,%esi
 -  444caa:	b8 ea 00 00 00       	mov    $0xea,%eax
 -  444caf:	0f 05                	syscall
-+  444caa:	e9 ad d6 06 00       	jmp    4b235c <_end+0x1134>
++  444caa:	<trampoline-jmp+0x35c>
 +  444caf:	90                   	nop
 +  444cb0:	90                   	nop
    444cb1:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -571,7 +572,7 @@ expression: diff
    444cbe:	66 90                	xchg   %ax,%ax
 -  444cc0:	b8 ba 00 00 00       	mov    $0xba,%eax
 -  444cc5:	0f 05                	syscall
-+  444cc0:	e9 a9 d6 06 00       	jmp    4b236e <_end+0x1146>
++  444cc0:	<trampoline-jmp+0x36e>
 +  444cc5:	90                   	nop
 +  444cc6:	90                   	nop
    444cc7:	89 c3                	mov    %eax,%ebx
@@ -581,7 +582,7 @@ expression: diff
    444cd3:	89 c7                	mov    %eax,%edi
 -  444cd5:	b8 ea 00 00 00       	mov    $0xea,%eax
 -  444cda:	0f 05                	syscall
-+  444cd5:	e9 a6 d6 06 00       	jmp    4b2380 <_end+0x1158>
++  444cd5:	<trampoline-jmp+0x380>
 +  444cda:	90                   	nop
 +  444cdb:	90                   	nop
    444cdc:	89 c3                	mov    %eax,%ebx
@@ -593,7 +594,7 @@ expression: diff
    444d78:	4c 89 fa             	mov    %r15,%rdx
 -  444d7b:	48 8d 35 4e 09 04 00 	lea    0x4094e(%rip),%rsi        # 4856d0 <sigall_set>
 -  444d82:	0f 05                	syscall
-+  444d7b:	e9 12 d6 06 00       	jmp    4b2392 <_end+0x116a>
++  444d7b:	<trampoline-jmp+0x392>
 +  444d80:	90                   	nop
 +  444d81:	90                   	nop
 +  444d82:	90                   	nop
@@ -607,7 +608,7 @@ expression: diff
    444dc4:	bf 02 00 00 00       	mov    $0x2,%edi
 -  444dc9:	b8 0e 00 00 00       	mov    $0xe,%eax
 -  444dce:	0f 05                	syscall
-+  444dc9:	e9 d8 d5 06 00       	jmp    4b23a6 <_end+0x117e>
++  444dc9:	<trampoline-jmp+0x3a6>
 +  444dce:	90                   	nop
 +  444dcf:	90                   	nop
    444dd0:	48 8b 45 c8          	mov    -0x38(%rbp),%rax
@@ -619,7 +620,7 @@ expression: diff
    444e08:	89 de                	mov    %ebx,%esi
 -  444e0a:	b8 ea 00 00 00       	mov    $0xea,%eax
 -  444e0f:	0f 05                	syscall
-+  444e0a:	e9 a9 d5 06 00       	jmp    4b23b8 <_end+0x1190>
++  444e0a:	<trampoline-jmp+0x3b8>
 +  444e0f:	90                   	nop
 +  444e10:	90                   	nop
    444e11:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -629,7 +630,7 @@ expression: diff
    444e1e:	eb 8a                	jmp    444daa <__pthread_kill+0x8a>
 -  444e20:	b8 ba 00 00 00       	mov    $0xba,%eax
 -  444e25:	0f 05                	syscall
-+  444e20:	e9 a5 d5 06 00       	jmp    4b23ca <_end+0x11a2>
++  444e20:	<trampoline-jmp+0x3ca>
 +  444e25:	90                   	nop
 +  444e26:	90                   	nop
    444e27:	89 c3                	mov    %eax,%ebx
@@ -639,7 +640,7 @@ expression: diff
    444e33:	89 c7                	mov    %eax,%edi
 -  444e35:	b8 ea 00 00 00       	mov    $0xea,%eax
 -  444e3a:	0f 05                	syscall
-+  444e35:	e9 a2 d5 06 00       	jmp    4b23dc <_end+0x11b4>
++  444e35:	<trampoline-jmp+0x3dc>
 +  444e3a:	90                   	nop
 +  444e3b:	90                   	nop
    444e3c:	41 89 c6             	mov    %eax,%r14d
@@ -651,7 +652,7 @@ expression: diff
    445107:	f7 d6                	not    %esi
 -  445109:	81 e6 80 00 00 00    	and    $0x80,%esi
 -  44510f:	0f 05                	syscall
-+  445109:	e9 e0 d2 06 00       	jmp    4b23ee <_end+0x11c6>
++  445109:	<trampoline-jmp+0x3ee>
 +  44510e:	90                   	nop
 +  44510f:	90                   	nop
 +  445110:	90                   	nop
@@ -664,7 +665,7 @@ expression: diff
    4452e4:	48 89 df             	mov    %rbx,%rdi
 -  4452e7:	b8 ca 00 00 00       	mov    $0xca,%eax
 -  4452ec:	0f 05                	syscall
-+  4452e7:	e9 15 d1 06 00       	jmp    4b2401 <_end+0x11d9>
++  4452e7:	<trampoline-jmp+0x401>
 +  4452ec:	90                   	nop
 +  4452ed:	90                   	nop
    4452ee:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
@@ -676,7 +677,7 @@ expression: diff
    4454ff:	be 07 00 00 00       	mov    $0x7,%esi
 -  445504:	b8 ca 00 00 00       	mov    $0xca,%eax
 -  445509:	0f 05                	syscall
-+  445504:	e9 0a cf 06 00       	jmp    4b2413 <_end+0x11eb>
++  445504:	<trampoline-jmp+0x413>
 +  445509:	90                   	nop
 +  44550a:	90                   	nop
    44550b:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
@@ -688,7 +689,7 @@ expression: diff
    445aa9:	81 e6 80 00 00 00    	and    $0x80,%esi
 -  445aaf:	40 80 f6 81          	xor    $0x81,%sil
 -  445ab3:	0f 05                	syscall
-+  445aaf:	e9 71 c9 06 00       	jmp    4b2425 <_end+0x11fd>
++  445aaf:	<trampoline-jmp+0x425>
 +  445ab4:	90                   	nop
    445ab5:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
    445abb:	0f 87 0e 02 00 00    	ja     445ccf <__pthread_mutex_unlock_full+0x3bf>
@@ -699,7 +700,7 @@ expression: diff
    445cfd:	4c 89 c7             	mov    %r8,%rdi
 -  445d00:	b8 ca 00 00 00       	mov    $0xca,%eax
 -  445d05:	0f 05                	syscall
-+  445d00:	e9 31 c7 06 00       	jmp    4b2436 <_end+0x120e>
++  445d00:	<trampoline-jmp+0x436>
 +  445d05:	90                   	nop
 +  445d06:	90                   	nop
    445d07:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
@@ -711,7 +712,7 @@ expression: diff
    445d29:	4c 89 c7             	mov    %r8,%rdi
 -  445d2c:	b8 ca 00 00 00       	mov    $0xca,%eax
 -  445d31:	0f 05                	syscall
-+  445d2c:	e9 17 c7 06 00       	jmp    4b2448 <_end+0x1220>
++  445d2c:	<trampoline-jmp+0x448>
 +  445d31:	90                   	nop
 +  445d32:	90                   	nop
    445d33:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
@@ -723,7 +724,7 @@ expression: diff
    44600f:	48 89 df             	mov    %rbx,%rdi
 -  446012:	b8 ca 00 00 00       	mov    $0xca,%eax
 -  446017:	0f 05                	syscall
-+  446012:	e9 43 c4 06 00       	jmp    4b245a <_end+0x1232>
++  446012:	<trampoline-jmp+0x45a>
 +  446017:	90                   	nop
 +  446018:	90                   	nop
    446019:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
@@ -735,7 +736,7 @@ expression: diff
    4460b0:	48 89 df             	mov    %rbx,%rdi
 -  4460b3:	b8 ca 00 00 00       	mov    $0xca,%eax
 -  4460b8:	0f 05                	syscall
-+  4460b3:	e9 b4 c3 06 00       	jmp    4b246c <_end+0x1244>
++  4460b3:	<trampoline-jmp+0x46c>
 +  4460b8:	90                   	nop
 +  4460b9:	90                   	nop
    4460ba:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
@@ -747,7 +748,7 @@ expression: diff
    446142:	be 81 00 00 00       	mov    $0x81,%esi
 -  446147:	b8 ca 00 00 00       	mov    $0xca,%eax
 -  44614c:	0f 05                	syscall
-+  446147:	e9 32 c3 06 00       	jmp    4b247e <_end+0x1256>
++  446147:	<trampoline-jmp+0x47e>
 +  44614c:	90                   	nop
 +  44614d:	90                   	nop
    44614e:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
@@ -759,7 +760,7 @@ expression: diff
    4462e3:	c1 e6 07             	shl    $0x7,%esi
 -  4462e6:	40 80 f6 81          	xor    $0x81,%sil
 -  4462ea:	0f 05                	syscall
-+  4462e6:	e9 a5 c1 06 00       	jmp    4b2490 <_end+0x1268>
++  4462e6:	<trampoline-jmp+0x490>
 +  4462eb:	90                   	nop
    4462ec:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
    4462f2:	0f 86 2e ff ff ff    	jbe    446226 <___pthread_rwlock_rdlock+0x46>
@@ -770,7 +771,7 @@ expression: diff
    446437:	40 80 f6 81          	xor    $0x81,%sil
 -  44643b:	b8 ca 00 00 00       	mov    $0xca,%eax
 -  446440:	0f 05                	syscall
-+  44643b:	e9 61 c0 06 00       	jmp    4b24a1 <_end+0x1279>
++  44643b:	<trampoline-jmp+0x4a1>
 +  446440:	90                   	nop
 +  446441:	90                   	nop
    446442:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
@@ -782,7 +783,7 @@ expression: diff
    44648a:	b8 ca 00 00 00       	mov    $0xca,%eax
 -  44648f:	40 80 f6 81          	xor    $0x81,%sil
 -  446493:	0f 05                	syscall
-+  44648f:	e9 1f c0 06 00       	jmp    4b24b3 <_end+0x128b>
++  44648f:	<trampoline-jmp+0x4b3>
 +  446494:	90                   	nop
    446495:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
    44649b:	76 83                	jbe    446420 <___pthread_rwlock_unlock+0x50>
@@ -793,7 +794,7 @@ expression: diff
    446511:	40 80 f6 81          	xor    $0x81,%sil
 -  446515:	b8 ca 00 00 00       	mov    $0xca,%eax
 -  44651a:	0f 05                	syscall
-+  446515:	e9 aa bf 06 00       	jmp    4b24c4 <_end+0x129c>
++  446515:	<trampoline-jmp+0x4c4>
 +  44651a:	90                   	nop
 +  44651b:	90                   	nop
    44651c:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
@@ -805,7 +806,7 @@ expression: diff
    446577:	b8 ca 00 00 00       	mov    $0xca,%eax
 -  44657c:	40 80 f6 81          	xor    $0x81,%sil
 -  446580:	0f 05                	syscall
-+  44657c:	e9 55 bf 06 00       	jmp    4b24d6 <_end+0x12ae>
++  44657c:	<trampoline-jmp+0x4d6>
 +  446581:	90                   	nop
    446582:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
    446588:	0f 86 6c ff ff ff    	jbe    4464fa <___pthread_rwlock_unlock+0x12a>
@@ -816,7 +817,7 @@ expression: diff
    446855:	40 80 f6 81          	xor    $0x81,%sil
 -  446859:	b8 ca 00 00 00       	mov    $0xca,%eax
 -  44685e:	0f 05                	syscall
-+  446859:	e9 89 bc 06 00       	jmp    4b24e7 <_end+0x12bf>
++  446859:	<trampoline-jmp+0x4e7>
 +  44685e:	90                   	nop
 +  44685f:	90                   	nop
    446860:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
@@ -828,7 +829,7 @@ expression: diff
    446880:	40 80 f6 81          	xor    $0x81,%sil
 -  446884:	b8 ca 00 00 00       	mov    $0xca,%eax
 -  446889:	0f 05                	syscall
-+  446884:	e9 70 bc 06 00       	jmp    4b24f9 <_end+0x12d1>
++  446884:	<trampoline-jmp+0x4f9>
 +  446889:	90                   	nop
 +  44688a:	90                   	nop
    44688b:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
@@ -840,7 +841,7 @@ expression: diff
    446924:	40 80 f6 81          	xor    $0x81,%sil
 -  446928:	b8 ca 00 00 00       	mov    $0xca,%eax
 -  44692d:	0f 05                	syscall
-+  446928:	e9 de bb 06 00       	jmp    4b250b <_end+0x12e3>
++  446928:	<trampoline-jmp+0x50b>
 +  44692d:	90                   	nop
 +  44692e:	90                   	nop
    44692f:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
@@ -852,7 +853,7 @@ expression: diff
    446a0b:	41 ba 08 00 00 00    	mov    $0x8,%r10d
 -  446a11:	b8 0e 00 00 00       	mov    $0xe,%eax
 -  446a16:	0f 05                	syscall
-+  446a11:	e9 07 bb 06 00       	jmp    4b251d <_end+0x12f5>
++  446a11:	<trampoline-jmp+0x51d>
 +  446a16:	90                   	nop
 +  446a17:	90                   	nop
    446a18:	89 c2                	mov    %eax,%edx
@@ -864,7 +865,7 @@ expression: diff
    45ba2c:	48 0f 47 d0          	cmova  %rax,%rdx
 -  45ba30:	b8 d9 00 00 00       	mov    $0xd9,%eax
 -  45ba35:	0f 05                	syscall
-+  45ba30:	e9 fa 6a 05 00       	jmp    4b252f <_end+0x1307>
++  45ba30:	<trampoline-jmp+0x52f>
 +  45ba35:	90                   	nop
 +  45ba36:	90                   	nop
    45ba37:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
@@ -876,7 +877,7 @@ expression: diff
    45bb50:	f3 0f 1e fa          	endbr64
 -  45bb54:	b8 27 00 00 00       	mov    $0x27,%eax
 -  45bb59:	0f 05                	syscall
-+  45bb54:	e9 e8 69 05 00       	jmp    4b2541 <_end+0x1319>
++  45bb54:	<trampoline-jmp+0x541>
 +  45bb59:	90                   	nop
 +  45bb5a:	90                   	nop
    45bb5b:	c3                   	ret
@@ -888,7 +889,7 @@ expression: diff
    45bba0:	f3 0f 1e fa          	endbr64
 -  45bba4:	b8 8f 00 00 00       	mov    $0x8f,%eax
 -  45bba9:	0f 05                	syscall
-+  45bba4:	e9 aa 69 05 00       	jmp    4b2553 <_end+0x132b>
++  45bba4:	<trampoline-jmp+0x553>
 +  45bba9:	90                   	nop
 +  45bbaa:	90                   	nop
    45bbab:	48 3d 01 f0 ff ff    	cmp    $0xfffffffffffff001,%rax
@@ -900,7 +901,7 @@ expression: diff
    45bbd0:	f3 0f 1e fa          	endbr64
 -  45bbd4:	b8 91 00 00 00       	mov    $0x91,%eax
 -  45bbd9:	0f 05                	syscall
-+  45bbd4:	e9 8c 69 05 00       	jmp    4b2565 <_end+0x133d>
++  45bbd4:	<trampoline-jmp+0x565>
 +  45bbd9:	90                   	nop
 +  45bbda:	90                   	nop
    45bbdb:	48 3d 01 f0 ff ff    	cmp    $0xfffffffffffff001,%rax
@@ -912,7 +913,7 @@ expression: diff
    45bc00:	f3 0f 1e fa          	endbr64
 -  45bc04:	b8 92 00 00 00       	mov    $0x92,%eax
 -  45bc09:	0f 05                	syscall
-+  45bc04:	e9 6e 69 05 00       	jmp    4b2577 <_end+0x134f>
++  45bc04:	<trampoline-jmp+0x577>
 +  45bc09:	90                   	nop
 +  45bc0a:	90                   	nop
    45bc0b:	48 3d 01 f0 ff ff    	cmp    $0xfffffffffffff001,%rax
@@ -924,7 +925,7 @@ expression: diff
    45bc30:	f3 0f 1e fa          	endbr64
 -  45bc34:	b8 93 00 00 00       	mov    $0x93,%eax
 -  45bc39:	0f 05                	syscall
-+  45bc34:	e9 50 69 05 00       	jmp    4b2589 <_end+0x1361>
++  45bc34:	<trampoline-jmp+0x589>
 +  45bc39:	90                   	nop
 +  45bc3a:	90                   	nop
    45bc3b:	48 3d 01 f0 ff ff    	cmp    $0xfffffffffffff001,%rax
@@ -936,7 +937,7 @@ expression: diff
    45bc60:	f3 0f 1e fa          	endbr64
 -  45bc64:	b8 90 00 00 00       	mov    $0x90,%eax
 -  45bc69:	0f 05                	syscall
-+  45bc64:	e9 32 69 05 00       	jmp    4b259b <_end+0x1373>
++  45bc64:	<trampoline-jmp+0x59b>
 +  45bc69:	90                   	nop
 +  45bc6a:	90                   	nop
    45bc6b:	48 3d 01 f0 ff ff    	cmp    $0xfffffffffffff001,%rax
@@ -948,7 +949,7 @@ expression: diff
    45bd0d:	48 8b bd 08 ff ff ff 	mov    -0xf8(%rbp),%rdi
 -  45bd14:	b8 4f 00 00 00       	mov    $0x4f,%eax
 -  45bd19:	0f 05                	syscall
-+  45bd14:	e9 94 68 05 00       	jmp    4b25ad <_end+0x1385>
++  45bd14:	<trampoline-jmp+0x5ad>
 +  45bd19:	90                   	nop
 +  45bd1a:	90                   	nop
    45bd1b:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
@@ -960,7 +961,7 @@ expression: diff
    45c510:	f3 0f 1e fa          	endbr64
 -  45c514:	b8 08 00 00 00       	mov    $0x8,%eax
 -  45c519:	0f 05                	syscall
-+  45c514:	e9 a6 60 05 00       	jmp    4b25bf <_end+0x1397>
++  45c514:	<trampoline-jmp+0x5bf>
 +  45c519:	90                   	nop
 +  45c51a:	90                   	nop
    45c51b:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
@@ -972,7 +973,7 @@ expression: diff
    45c5a9:	bf 9c ff ff ff       	mov    $0xffffff9c,%edi
 -  45c5ae:	b8 01 01 00 00       	mov    $0x101,%eax
 -  45c5b3:	0f 05                	syscall
-+  45c5ae:	e9 1e 60 05 00       	jmp    4b25d1 <_end+0x13a9>
++  45c5ae:	<trampoline-jmp+0x5d1>
 +  45c5b3:	90                   	nop
 +  45c5b4:	90                   	nop
    45c5b5:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
@@ -984,7 +985,7 @@ expression: diff
    45c619:	bf 9c ff ff ff       	mov    $0xffffff9c,%edi
 -  45c61e:	b8 01 01 00 00       	mov    $0x101,%eax
 -  45c623:	0f 05                	syscall
-+  45c61e:	e9 c0 5f 05 00       	jmp    4b25e3 <_end+0x13bb>
++  45c61e:	<trampoline-jmp+0x5e3>
 +  45c623:	90                   	nop
 +  45c624:	90                   	nop
    45c625:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
@@ -996,7 +997,7 @@ expression: diff
    45c6b9:	74 51                	je     45c70c <__libc_openat64+0x8c>
 -  45c6bb:	b8 01 01 00 00       	mov    $0x101,%eax
 -  45c6c0:	0f 05                	syscall
-+  45c6bb:	e9 35 5f 05 00       	jmp    4b25f5 <_end+0x13cd>
++  45c6bb:	<trampoline-jmp+0x5f5>
 +  45c6c0:	90                   	nop
 +  45c6c1:	90                   	nop
    45c6c2:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
@@ -1008,7 +1009,7 @@ expression: diff
    45c72d:	8b 7d a8             	mov    -0x58(%rbp),%edi
 -  45c730:	b8 01 01 00 00       	mov    $0x101,%eax
 -  45c735:	0f 05                	syscall
-+  45c730:	e9 d2 5e 05 00       	jmp    4b2607 <_end+0x13df>
++  45c730:	<trampoline-jmp+0x607>
 +  45c735:	90                   	nop
 +  45c736:	90                   	nop
    45c737:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
@@ -1020,7 +1021,7 @@ expression: diff
    45c79d:	31 c0                	xor    %eax,%eax
 -  45c79f:	0f 05                	syscall
 -  45c7a1:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
-+  45c79f:	e9 75 5e 05 00       	jmp    4b2619 <_end+0x13f1>
++  45c79f:	<trampoline-jmp+0x619>
 +  45c7a4:	90                   	nop
 +  45c7a5:	90                   	nop
 +  45c7a6:	90                   	nop
@@ -1034,7 +1035,7 @@ expression: diff
 -  45c7d3:	8b 7d f8             	mov    -0x8(%rbp),%edi
 -  45c7d6:	31 c0                	xor    %eax,%eax
 -  45c7d8:	0f 05                	syscall
-+  45c7d3:	e9 59 5e 05 00       	jmp    4b2631 <_end+0x1409>
++  45c7d3:	<trampoline-jmp+0x631>
 +  45c7d8:	90                   	nop
 +  45c7d9:	90                   	nop
    45c7da:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
@@ -1046,7 +1047,7 @@ expression: diff
    45c85b:	74 13                	je     45c870 <__libc_write+0x20>
 -  45c85d:	b8 01 00 00 00       	mov    $0x1,%eax
 -  45c862:	0f 05                	syscall
-+  45c85d:	e9 e1 5d 05 00       	jmp    4b2643 <_end+0x141b>
++  45c85d:	<trampoline-jmp+0x643>
 +  45c862:	90                   	nop
 +  45c863:	90                   	nop
    45c864:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
@@ -1058,7 +1059,7 @@ expression: diff
    45c893:	8b 7d f8             	mov    -0x8(%rbp),%edi
 -  45c896:	b8 01 00 00 00       	mov    $0x1,%eax
 -  45c89b:	0f 05                	syscall
-+  45c896:	e9 ba 5d 05 00       	jmp    4b2655 <_end+0x142d>
++  45c896:	<trampoline-jmp+0x655>
 +  45c89b:	90                   	nop
 +  45c89c:	90                   	nop
    45c89d:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
@@ -1070,7 +1071,7 @@ expression: diff
    45c920:	74 26                	je     45c948 <__openat64_nocancel+0x58>
 -  45c922:	b8 01 01 00 00       	mov    $0x101,%eax
 -  45c927:	0f 05                	syscall
-+  45c922:	e9 40 5d 05 00       	jmp    4b2667 <_end+0x143f>
++  45c922:	<trampoline-jmp+0x667>
 +  45c927:	90                   	nop
 +  45c928:	90                   	nop
    45c929:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
@@ -1082,7 +1083,7 @@ expression: diff
    45c984:	49 89 ca             	mov    %rcx,%r10
 -  45c987:	b8 11 00 00 00       	mov    $0x11,%eax
 -  45c98c:	0f 05                	syscall
-+  45c987:	e9 ed 5c 05 00       	jmp    4b2679 <_end+0x1451>
++  45c987:	<trampoline-jmp+0x679>
 +  45c98c:	90                   	nop
 +  45c98d:	90                   	nop
    45c98e:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
@@ -1094,7 +1095,7 @@ expression: diff
    45c9c0:	f3 0f 1e fa          	endbr64
 -  45c9c4:	b8 01 00 00 00       	mov    $0x1,%eax
 -  45c9c9:	0f 05                	syscall
-+  45c9c4:	e9 c2 5c 05 00       	jmp    4b268b <_end+0x1463>
++  45c9c4:	<trampoline-jmp+0x68b>
 +  45c9c9:	90                   	nop
 +  45c9ca:	90                   	nop
    45c9cb:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
@@ -1106,7 +1107,7 @@ expression: diff
    45ca13:	48 8d 55 d0          	lea    -0x30(%rbp),%rdx
 -  45ca17:	b8 10 00 00 00       	mov    $0x10,%eax
 -  45ca1c:	0f 05                	syscall
-+  45ca17:	e9 81 5c 05 00       	jmp    4b269d <_end+0x1475>
++  45ca17:	<trampoline-jmp+0x69d>
 +  45ca1c:	90                   	nop
 +  45ca1d:	90                   	nop
    45ca1e:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
@@ -1119,7 +1120,7 @@ expression: diff
 -  45cabb:	b8 2e 01 00 00       	mov    $0x12e,%eax
 -  45cac0:	31 ff                	xor    %edi,%edi
 -  45cac2:	0f 05                	syscall
-+  45cabb:	e9 ef 5b 05 00       	jmp    4b26af <_end+0x1487>
++  45cabb:	<trampoline-jmp+0x6af>
 +  45cac0:	90                   	nop
 +  45cac1:	90                   	nop
 +  45cac2:	90                   	nop
@@ -1133,7 +1134,7 @@ expression: diff
    45ffa0:	48 8d 78 1c          	lea    0x1c(%rax),%rdi
 -  45ffa4:	b8 ca 00 00 00       	mov    $0xca,%eax
 -  45ffa9:	0f 05                	syscall
-+  45ffa4:	e9 1a 27 05 00       	jmp    4b26c3 <_end+0x149b>
++  45ffa4:	<trampoline-jmp+0x6c3>
 +  45ffa9:	90                   	nop
 +  45ffaa:	90                   	nop
    45ffab:	48 8d 3d 6e ab 04 00 	lea    0x4ab6e(%rip),%rdi        # 4aab20 <_dl_load_lock>
@@ -1145,7 +1146,7 @@ expression: diff
    46306a:	be 80 00 00 00       	mov    $0x80,%esi
 -  46306f:	44 89 c8             	mov    %r9d,%eax
 -  463072:	0f 05                	syscall
-+  46306f:	e9 61 f6 04 00       	jmp    4b26d5 <_end+0x14ad>
++  46306f:	<trampoline-jmp+0x6d5>
    463074:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
    46307a:	76 dc                	jbe    463058 <__thread_gscope_wait+0x88>
    46307c:	83 f8 f5             	cmp    $0xfffffff5,%eax
@@ -1155,7 +1156,7 @@ expression: diff
    46310a:	be 80 00 00 00       	mov    $0x80,%esi
 -  46310f:	44 89 c8             	mov    %r9d,%eax
 -  463112:	0f 05                	syscall
-+  46310f:	e9 d1 f5 04 00       	jmp    4b26e5 <_end+0x14bd>
++  46310f:	<trampoline-jmp+0x6e5>
    463114:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
    46311a:	76 dc                	jbe    4630f8 <__thread_gscope_wait+0x128>
    46311c:	83 f8 f5             	cmp    $0xfffffff5,%eax
@@ -1165,7 +1166,7 @@ expression: diff
  00000000004669d0 <__restore_rt>:
 -  4669d0:	48 c7 c0 0f 00 00 00 	mov    $0xf,%rax
 -  4669d7:	0f 05                	syscall
-+  4669d0:	e9 20 bd 04 00       	jmp    4b26f5 <_end+0x14cd>
++  4669d0:	<trampoline-jmp+0x6f5>
 +  4669d5:	90                   	nop
 +  4669d6:	90                   	nop
 +  4669d7:	90                   	nop
@@ -1179,7 +1180,7 @@ expression: diff
    466aad:	41 ba 08 00 00 00    	mov    $0x8,%r10d
 -  466ab3:	b8 0d 00 00 00       	mov    $0xd,%eax
 -  466ab8:	0f 05                	syscall
-+  466ab3:	e9 51 bc 04 00       	jmp    4b2709 <_end+0x14e1>
++  466ab3:	<trampoline-jmp+0x709>
 +  466ab8:	90                   	nop
 +  466ab9:	90                   	nop
    466aba:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
@@ -1191,7 +1192,7 @@ expression: diff
    46cb16:	be 80 00 00 00       	mov    $0x80,%esi
 -  46cb1b:	44 89 c0             	mov    %r8d,%eax
 -  46cb1e:	0f 05                	syscall
-+  46cb1b:	e9 fb 5b 04 00       	jmp    4b271b <_end+0x14f3>
++  46cb1b:	<trampoline-jmp+0x71b>
    46cb20:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
    46cb26:	77 0d                	ja     46cb35 <__pthread_disable_asynccancel+0x65>
    46cb28:	8b 0f                	mov    (%rdi),%ecx
@@ -1201,7 +1202,7 @@ expression: diff
    46ccdf:	44 31 c6             	xor    %r8d,%esi
 -  46cce2:	45 31 c0             	xor    %r8d,%r8d
 -  46cce5:	0f 05                	syscall
-+  46cce2:	e9 44 5a 04 00       	jmp    4b272b <_end+0x1503>
++  46cce2:	<trampoline-jmp+0x72b>
    46cce7:	85 c0                	test   %eax,%eax
    46cce9:	7f 27                	jg     46cd12 <__futex_abstimed_wait64+0x62>
    46cceb:	83 f8 ea             	cmp    $0xffffffea,%eax
@@ -1211,7 +1212,7 @@ expression: diff
    46cd89:	44 89 e2             	mov    %r12d,%edx
 -  46cd8c:	b8 ca 00 00 00       	mov    $0xca,%eax
 -  46cd91:	0f 05                	syscall
-+  46cd8c:	e9 aa 59 04 00       	jmp    4b273b <_end+0x1513>
++  46cd8c:	<trampoline-jmp+0x73b>
 +  46cd91:	90                   	nop
 +  46cd92:	90                   	nop
    46cd93:	48 89 c3             	mov    %rax,%rbx
@@ -1223,7 +1224,7 @@ expression: diff
    46ce17:	44 89 e2             	mov    %r12d,%edx
 -  46ce1a:	b8 ca 00 00 00       	mov    $0xca,%eax
 -  46ce1f:	0f 05                	syscall
-+  46ce1a:	e9 2e 59 04 00       	jmp    4b274d <_end+0x1525>
++  46ce1a:	<trampoline-jmp+0x74d>
 +  46ce1f:	90                   	nop
 +  46ce20:	90                   	nop
    46ce21:	44 89 ef             	mov    %r13d,%edi
@@ -1235,7 +1236,7 @@ expression: diff
    46ce6c:	31 d2                	xor    %edx,%edx
 -  46ce6e:	b8 ca 00 00 00       	mov    $0xca,%eax
 -  46ce73:	0f 05                	syscall
-+  46ce6e:	e9 ec 58 04 00       	jmp    4b275f <_end+0x1537>
++  46ce6e:	<trampoline-jmp+0x75f>
 +  46ce73:	90                   	nop
 +  46ce74:	90                   	nop
    46ce75:	83 f8 da             	cmp    $0xffffffda,%eax
@@ -1247,7 +1248,7 @@ expression: diff
    46f344:	41 89 ca             	mov    %ecx,%r10d
 -  46f347:	b8 06 01 00 00       	mov    $0x106,%eax
 -  46f34c:	0f 05                	syscall
-+  46f347:	e9 25 34 04 00       	jmp    4b2771 <_end+0x1549>
++  46f347:	<trampoline-jmp+0x771>
 +  46f34c:	90                   	nop
 +  46f34d:	90                   	nop
    46f34e:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
@@ -1259,7 +1260,7 @@ expression: diff
    472975:	48 8d 78 1c          	lea    0x1c(%rax),%rdi
 -  472979:	b8 ca 00 00 00       	mov    $0xca,%eax
 -  47297e:	0f 05                	syscall
-+  472979:	e9 05 fe 03 00       	jmp    4b2783 <_end+0x155b>
++  472979:	<trampoline-jmp+0x783>
 +  47297e:	90                   	nop
 +  47297f:	90                   	nop
    472980:	eb 8c                	jmp    47290e <_dl_fixup+0x10e>
@@ -1271,7 +1272,7 @@ expression: diff
    476c10:	48 8d 78 1c          	lea    0x1c(%rax),%rdi
 -  476c14:	b8 ca 00 00 00       	mov    $0xca,%eax
 -  476c19:	0f 05                	syscall
-+  476c14:	e9 7c bb 03 00       	jmp    4b2795 <_end+0x156d>
++  476c14:	<trampoline-jmp+0x795>
 +  476c19:	90                   	nop
 +  476c1a:	90                   	nop
    476c1b:	48 83 7d 98 00       	cmpq   $0x0,-0x68(%rbp)
@@ -1283,7 +1284,7 @@ expression: diff
    476e4a:	48 8d 78 1c          	lea    0x1c(%rax),%rdi
 -  476e4e:	b8 ca 00 00 00       	mov    $0xca,%eax
 -  476e53:	0f 05                	syscall
-+  476e4e:	e9 54 b9 03 00       	jmp    4b27a7 <_end+0x157f>
++  476e4e:	<trampoline-jmp+0x7a7>
 +  476e53:	90                   	nop
 +  476e54:	90                   	nop
    476e55:	48 83 7d 98 00       	cmpq   $0x0,-0x68(%rbp)


### PR DESCRIPTION
This PR improves `litebox_syscall_rewriter` by cleaning up the public API, hardening error handling, adding `no_std` support and fixing several bugs.