### PR TITLE
Suppress release-mode panics that ldelf/TA can trigger

### DIFF
--- a/litebox_common_optee/src/lib.rs
+++ b/litebox_common_optee/src/lib.rs
@@ -243,7 +243,7 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
             TeeSyscallNr::Unknown => {
                 return Err(Errno::ENOSYS);
             }
-            _ => todo!(),
+            _ => return Err(Errno::ENOSYS),
         };
 
         Ok(dispatcher)
@@ -1180,7 +1180,7 @@ impl<Platform: litebox::platform::RawPointerProvider> LdelfSyscallRequest<Platfo
                 buf: Platform::RawMutPointer::from_usize(ctx.syscall_arg(0)),
                 num_bytes: ctx.syscall_arg(1),
             },
-            _ => todo!("implement ldelf syscall number: {}", sysnr),
+            _ => return Err(Errno::ENOSYS),
         };
 
         Ok(dispatcher)

--- a/litebox_common_optee/src/lib.rs
+++ b/litebox_common_optee/src/lib.rs
@@ -135,7 +135,7 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
     pub fn try_from_raw(syscall_number: usize, ctx: &PtRegs) -> Result<Self, Errno> {
         let ctx = SyscallContext::from_pt_regs(ctx);
         let sysnr = u32::try_from(syscall_number).map_err(|_| Errno::ENOSYS)?;
-        let dispatcher = match TeeSyscallNr::try_from(sysnr).unwrap_or(TeeSyscallNr::Unknown) {
+        let dispatcher = match TeeSyscallNr::try_from(sysnr).map_err(|_| Errno::ENOSYS)? {
             TeeSyscallNr::Return => SyscallRequest::Return {
                 ret: ctx.syscall_arg(0),
             },
@@ -240,9 +240,6 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
                 buf: Platform::RawMutPointer::from_usize(ctx.syscall_arg(0)),
                 blen: ctx.syscall_arg(1),
             },
-            TeeSyscallNr::Unknown => {
-                return Err(Errno::ENOSYS);
-            }
             _ => return Err(Errno::ENOSYS),
         };
 
@@ -1131,7 +1128,7 @@ impl<Platform: litebox::platform::RawPointerProvider> LdelfSyscallRequest<Platfo
     pub fn try_from_raw(syscall_number: usize, ctx: &PtRegs) -> Result<Self, Errno> {
         let ctx = SyscallContext::from_pt_regs(ctx);
         let sysnr = u32::try_from(syscall_number).map_err(|_| Errno::ENOSYS)?;
-        let dispatcher = match LdelfSyscallNr::try_from(sysnr).unwrap_or(LdelfSyscallNr::Unknown) {
+        let dispatcher = match LdelfSyscallNr::try_from(sysnr).map_err(|_| Errno::ENOSYS)? {
             LdelfSyscallNr::Return => LdelfSyscallRequest::Return {
                 ret: ctx.syscall_arg(0),
             },

--- a/litebox_common_optee/src/syscall_nr.rs
+++ b/litebox_common_optee/src/syscall_nr.rs
@@ -125,7 +125,6 @@ pub enum TeeSyscallNr {
     StorageObjSeek = SYSCALL_STORAGE_OBJ_SEEK,
     ObjGenerateKey = SYSCALL_OBJ_GENERATE_KEY,
     CacheOperation = SYSCALL_CACHE_OPERATION,
-    Unknown = 0xffff_ffff,
 }
 
 const LDELF_RETURN: u32 = 0;
@@ -157,5 +156,4 @@ pub enum LdelfSyscallNr {
     SetProt = LDELF_SET_PROT,
     Remap = LDELF_REMAP,
     GenRndNum = LDELF_GEN_RND_NUM,
-    Unknown = 0xffff_ffff,
 }

--- a/litebox_shim_optee/src/lib.rs
+++ b/litebox_shim_optee/src/lib.rs
@@ -389,9 +389,9 @@ impl Task {
                 prop_type,
             } => {
                 if let Some(buf_length) = blen.read_at_offset(0)
-                    && usize::try_from(buf_length).unwrap() <= MAX_KERNEL_BUF_SIZE
+                    && (buf_length as usize) <= MAX_KERNEL_BUF_SIZE
                 {
-                    let mut prop_buf = vec![0u8; usize::try_from(buf_length).unwrap()];
+                    let mut prop_buf = vec![0u8; buf_length as usize];
                     if name.as_usize() != 0 || name_len.as_usize() != 0 {
                         if cfg!(debug_assertions) {
                             todo!("return the name of a given property index");
@@ -751,10 +751,10 @@ impl Task {
             .ok_or(ElfLoaderError::InvalidStackAddr)?;
 
         Ok(ThreadInitState::Ta {
-            cmd_id: usize::try_from(cmd_id.unwrap_or(0)).unwrap(),
+            cmd_id: cmd_id.unwrap_or(0) as usize,
             params_address: ta_stack.get_params_address(),
-            session_id: usize::try_from(session_id.unwrap_or(self.session_id)).unwrap(),
-            func_id: usize::try_from(func_id).unwrap(),
+            session_id: session_id.unwrap_or(self.session_id) as usize,
+            func_id: func_id as usize,
             entry_point: self.get_ta_entry_point(),
             stack_top: ta_stack.get_cur_stack_top(),
         })
@@ -823,7 +823,7 @@ impl Task {
         if let Some(ldelf_arg_address) = ldelf_arg_address {
             let ldelf_arg_ptr = UserConstPtr::<LdelfArg>::from_usize(ldelf_arg_address);
             if let Some(ldef_arg) = ldelf_arg_ptr.read_at_offset(0) {
-                let entry_func = usize::try_from(ldef_arg.entry_func).unwrap();
+                let entry_func = ldef_arg.entry_func.truncate();
                 // If `ldelf` has been successfully executed, it loads the given TA and stores the TA's entry
                 // point into `ldelf_arg.entry_func`.
                 self.set_ta_entry_point(entry_func);
@@ -879,12 +879,12 @@ where
 {
     if let Some(src_slice) = src.to_owned_slice(src_len)
         && let Some(length) = dst_len.read_at_offset(0)
-        && usize::try_from(length).unwrap() <= MAX_KERNEL_BUF_SIZE
+        && TruncateExt::<usize>::truncate(length) <= MAX_KERNEL_BUF_SIZE
     {
-        let mut length = usize::try_from(length).unwrap();
+        let mut length: usize = length.truncate();
         let mut kernel_buf = vec![0u8; length];
         syscall_fn(task, state, &src_slice, &mut kernel_buf, &mut length).and_then(|()| {
-            let _ = dst_len.write_at_offset(0, u64::try_from(length).unwrap());
+            let _ = dst_len.write_at_offset(0, length as u64);
             dst.copy_from_slice(0, &kernel_buf[..length])
                 .ok_or(TeeResult::OutOfMemory)
         })

--- a/litebox_shim_optee/src/lib.rs
+++ b/litebox_shim_optee/src/lib.rs
@@ -393,22 +393,26 @@ impl Task {
                 {
                     let mut prop_buf = vec![0u8; usize::try_from(buf_length).unwrap()];
                     if name.as_usize() != 0 || name_len.as_usize() != 0 {
-                        todo!("return the name of a given property index")
+                        if cfg!(debug_assertions) {
+                            todo!("return the name of a given property index");
+                        }
+                        Err(TeeResult::NotSupported)
+                    } else {
+                        self.sys_get_property(
+                            prop_set,
+                            index,
+                            None,
+                            None,
+                            &mut prop_buf,
+                            blen,
+                            prop_type,
+                        )
+                        .and_then(|()| {
+                            buf.copy_from_slice(0, &prop_buf)
+                                .ok_or(TeeResult::ShortBuffer)?;
+                            Ok(())
+                        })
                     }
-                    self.sys_get_property(
-                        prop_set,
-                        index,
-                        None,
-                        None,
-                        &mut prop_buf,
-                        blen,
-                        prop_type,
-                    )
-                    .and_then(|()| {
-                        buf.copy_from_slice(0, &prop_buf)
-                            .ok_or(TeeResult::ShortBuffer)?;
-                        Ok(())
-                    })
                 } else {
                     Err(TeeResult::BadParameters)
                 }
@@ -534,7 +538,12 @@ impl Task {
                         })
                 }
             }
-            _ => todo!(),
+            _ => {
+                if cfg!(debug_assertions) {
+                    todo!();
+                }
+                Err(TeeResult::NotSupported)
+            }
         };
 
         ctx.rax = match res {
@@ -686,7 +695,7 @@ impl Task {
                         })
                 }
             }
-            _ => todo!(),
+            _ => Err(TeeResult::NotSupported),
         };
 
         ctx.rax = match res {
@@ -974,33 +983,35 @@ impl TeeObjMap {
     ) -> Result<(), TeeResult> {
         let mut inner = self.inner.lock();
         if let Some(tee_obj) = inner.get_mut(&handle) {
-            tee_obj.initialize();
-
             if user_attrs.is_empty() {
+                tee_obj.initialize();
                 return Ok(());
             }
 
             // TODO: support multiple attributes (e.g., two-key crypto algorithms like AES-XTS)
-            match user_attrs[0].attribute_id {
-                TeeAttributeType::SecretValue => {
-                    let key_addr: usize = user_attrs[0].a.truncate();
-                    let key_len: usize = user_attrs[0].b.truncate();
-                    // TODO: revisit buffer size limits based on OP-TEE spec and deployment constraints
-                    if key_len > MAX_KERNEL_BUF_SIZE {
-                        return Err(TeeResult::BadParameters);
-                    }
-                    let key_ptr = UserConstPtr::<u8>::from_usize(key_addr);
-                    let Some(key_box) = key_ptr.to_owned_slice(key_len) else {
-                        return Err(TeeResult::BadParameters);
-                    };
-                    tee_obj.set_key(&key_box);
+            if user_attrs[0].attribute_id == TeeAttributeType::SecretValue {
+                let key_addr: usize = user_attrs[0].a.truncate();
+                let key_len: usize = user_attrs[0].b.truncate();
+                // TODO: revisit buffer size limits based on OP-TEE spec and deployment constraints
+                if key_len > MAX_KERNEL_BUF_SIZE {
+                    return Err(TeeResult::BadParameters);
                 }
-                _ => todo!(
-                    "handle attribute ID: {}",
-                    user_attrs[0].attribute_id.value()
-                ),
+                let key_ptr = UserConstPtr::<u8>::from_usize(key_addr);
+                let Some(key_box) = key_ptr.to_owned_slice(key_len) else {
+                    return Err(TeeResult::BadParameters);
+                };
+                tee_obj.set_key(&key_box);
+            } else {
+                if cfg!(debug_assertions) {
+                    todo!(
+                        "handle attribute ID: {}",
+                        user_attrs[0].attribute_id.value()
+                    );
+                }
+                return Err(TeeResult::NotSupported);
             }
 
+            tee_obj.initialize();
             Ok(())
         } else {
             Err(TeeResult::ItemNotFound)

--- a/litebox_shim_optee/src/lib.rs
+++ b/litebox_shim_optee/src/lib.rs
@@ -393,9 +393,9 @@ impl Task {
                 {
                     let mut prop_buf = vec![0u8; buf_length as usize];
                     if name.as_usize() != 0 || name_len.as_usize() != 0 {
-                        if cfg!(debug_assertions) {
-                            todo!("return the name of a given property index");
-                        }
+                        #[cfg(debug_assertions)]
+                        todo!("return the name of a given property index");
+                        #[cfg(not(debug_assertions))]
                         Err(TeeResult::NotSupported)
                     } else {
                         self.sys_get_property(
@@ -539,9 +539,9 @@ impl Task {
                 }
             }
             _ => {
-                if cfg!(debug_assertions) {
-                    todo!();
-                }
+                #[cfg(debug_assertions)]
+                todo!("unsupported syscall request");
+                #[cfg(not(debug_assertions))]
                 Err(TeeResult::NotSupported)
             }
         };
@@ -879,7 +879,7 @@ where
 {
     if let Some(src_slice) = src.to_owned_slice(src_len)
         && let Some(length) = dst_len.read_at_offset(0)
-        && TruncateExt::<usize>::truncate(length) <= MAX_KERNEL_BUF_SIZE
+        && length <= MAX_KERNEL_BUF_SIZE as u64
     {
         let mut length: usize = length.truncate();
         let mut kernel_buf = vec![0u8; length];
@@ -1002,12 +1002,12 @@ impl TeeObjMap {
                 };
                 tee_obj.set_key(&key_box);
             } else {
-                if cfg!(debug_assertions) {
-                    todo!(
-                        "handle attribute ID: {}",
-                        user_attrs[0].attribute_id.value()
-                    );
-                }
+                #[cfg(debug_assertions)]
+                todo!(
+                    "handle attribute ID: {}",
+                    user_attrs[0].attribute_id.value()
+                );
+                #[cfg(not(debug_assertions))]
                 return Err(TeeResult::NotSupported);
             }
 

--- a/litebox_shim_optee/src/loader/elf.rs
+++ b/litebox_shim_optee/src/loader/elf.rs
@@ -142,7 +142,7 @@ impl litebox_common_linux::loader::MapMemory for ElfFileInMemory<'_> {
 
         self.task
             .sys_mprotect(UserMutPtr::from_usize(mapped_addr), len, prot.flags())
-            .map_err(ElfLoaderError::from)?;
+            .map_err(ElfLoaderError::ProtectError)?;
         Ok(())
     }
 
@@ -265,6 +265,8 @@ pub enum ElfLoaderError {
     LoadError(#[from] litebox_common_linux::loader::ElfLoadError<Errno>),
     #[error("invalid stack")]
     InvalidStackAddr,
+    #[error("failed to set memory protection")]
+    ProtectError(Errno),
     #[error("failed to mmap")]
     MappingError(#[from] MappingError),
     #[error("TA binary UUID does not match expected UUID")]
@@ -274,7 +276,7 @@ pub enum ElfLoaderError {
 impl From<ElfLoaderError> for litebox_common_linux::errno::Errno {
     fn from(value: ElfLoaderError) -> Self {
         match value {
-            ElfLoaderError::OpenError(e) => e,
+            ElfLoaderError::OpenError(e) | ElfLoaderError::ProtectError(e) => e,
             ElfLoaderError::ParseError(e) => e.into(),
             ElfLoaderError::InvalidStackAddr | ElfLoaderError::MappingError(_) => {
                 litebox_common_linux::errno::Errno::ENOMEM

--- a/litebox_shim_optee/src/loader/elf.rs
+++ b/litebox_shim_optee/src/loader/elf.rs
@@ -142,7 +142,7 @@ impl litebox_common_linux::loader::MapMemory for ElfFileInMemory<'_> {
 
         self.task
             .sys_mprotect(UserMutPtr::from_usize(mapped_addr), len, prot.flags())
-            .expect("sys_mprotect failed");
+            .map_err(ElfLoaderError::from)?;
         Ok(())
     }
 

--- a/litebox_shim_optee/src/loader/ta_stack.rs
+++ b/litebox_shim_optee/src/loader/ta_stack.rs
@@ -181,11 +181,7 @@ impl TaStack {
                     }
                     self.push_bytes(bytes)?;
                     self.params
-                        .set_values(
-                            self.num_params,
-                            u64::try_from(self.get_cur_stack_top()).unwrap(),
-                            u64::try_from(len).unwrap(),
-                        )
+                        .set_values(self.num_params, self.get_cur_stack_top() as u64, len as u64)
                         .ok()?;
                 } else {
                     return None;
@@ -194,11 +190,7 @@ impl TaStack {
             TeeParamType::MemrefOutput => {
                 self.pos = self.pos.checked_sub(len)?;
                 self.params
-                    .set_values(
-                        self.num_params,
-                        u64::try_from(self.get_cur_stack_top()).unwrap(),
-                        u64::try_from(len).unwrap(),
-                    )
+                    .set_values(self.num_params, self.get_cur_stack_top() as u64, len as u64)
                     .ok()?;
             }
             _ => {

--- a/litebox_shim_optee/src/msg_handler.rs
+++ b/litebox_shim_optee/src/msg_handler.rs
@@ -686,7 +686,8 @@ impl<const ALIGN: usize> ShmRefMap<ALIGN> {
         if page_offset >= ALIGN as u64 || aligned_size == 0 {
             return Err(OpteeSmcReturnCode::EBadAddr);
         }
-        let num_pages = TruncateExt::<usize>::truncate(aligned_size) / ALIGN;
+        let aligned_size_usize: usize = aligned_size.truncate();
+        let num_pages = aligned_size_usize / ALIGN;
         let mut pages = Vec::with_capacity(num_pages);
         let mut cur_addr: usize = shm_ref_pages_data_phys_addr.truncate();
         loop {

--- a/litebox_shim_optee/src/msg_handler.rs
+++ b/litebox_shim_optee/src/msg_handler.rs
@@ -686,9 +686,9 @@ impl<const ALIGN: usize> ShmRefMap<ALIGN> {
         if page_offset >= ALIGN as u64 || aligned_size == 0 {
             return Err(OpteeSmcReturnCode::EBadAddr);
         }
-        let num_pages = usize::try_from(aligned_size).unwrap() / ALIGN;
+        let num_pages = TruncateExt::<usize>::truncate(aligned_size) / ALIGN;
         let mut pages = Vec::with_capacity(num_pages);
-        let mut cur_addr = usize::try_from(shm_ref_pages_data_phys_addr).unwrap();
+        let mut cur_addr: usize = shm_ref_pages_data_phys_addr.truncate();
         loop {
             let mut cur_ptr = NormalWorldConstPtr::<ShmRefPagesData, ALIGN>::with_usize(cur_addr)
                 .map_err(|_| OpteeSmcReturnCode::EBadAddr)?;
@@ -699,7 +699,7 @@ impl<const ALIGN: usize> ShmRefMap<ALIGN> {
                     break;
                 } else {
                     pages.push(
-                        PhysPageAddr::new(usize::try_from(*page).unwrap())
+                        PhysPageAddr::new((*page).truncate())
                             .ok_or(OpteeSmcReturnCode::EBadAddr)?,
                     );
                 }
@@ -707,16 +707,13 @@ impl<const ALIGN: usize> ShmRefMap<ALIGN> {
             if pages_data.next_page_data == 0 || pages.len() == num_pages {
                 break;
             } else {
-                cur_addr = usize::try_from(pages_data.next_page_data).unwrap();
+                cur_addr = pages_data.next_page_data.truncate();
             }
         }
 
         self.insert(
             shm_ref,
-            ShmInfo::new(
-                pages.into_boxed_slice(),
-                usize::try_from(page_offset).unwrap(),
-            )?,
+            ShmInfo::new(pages.into_boxed_slice(), page_offset.truncate())?,
         )?;
         Ok(())
     }

--- a/litebox_shim_optee/src/syscalls/cryp.rs
+++ b/litebox_shim_optee/src/syscalls/cryp.rs
@@ -119,16 +119,16 @@ impl Task {
             if let Some(handle) = cryp_state.get_object_handle(false)
                 && tee_obj_map.exists(handle)
             {
-                if cfg!(debug_assertions) {
-                    todo!("support two-key algorithms");
-                }
+                #[cfg(debug_assertions)]
+                todo!("support two-key algorithms");
+                #[cfg(not(debug_assertions))]
                 return Err(TeeResult::NotSupported);
             }
 
             let Some(cipher) = create_cipher(cryp_state.algorithm(), key, iv) else {
-                if cfg!(debug_assertions) {
-                    todo!("implement algorithm {}", cryp_state.algorithm() as u32);
-                }
+                #[cfg(debug_assertions)]
+                todo!("implement algorithm {}", cryp_state.algorithm() as u32);
+                #[cfg(not(debug_assertions))]
                 return Err(TeeResult::NotSupported);
             };
             tee_cryp_state_map.set_cipher(state, &cipher)?;
@@ -174,9 +174,9 @@ impl Task {
             // Check last_block before applying the cipher so we don't mutate
             // dst_slice and then return an error.
             if last_block {
-                if cfg!(debug_assertions) {
-                    todo!("support algorithms which have a certain finalization logic");
-                }
+                #[cfg(debug_assertions)]
+                todo!("support algorithms which have a certain finalization logic");
+                #[cfg(not(debug_assertions))]
                 return Err(TeeResult::NotSupported);
             }
             if let Some(state_entry) = map.get_mut(&state)
@@ -195,8 +195,13 @@ impl Task {
                     }
                 }
                 *dst_len = src_slice.len();
+                Ok(())
+            } else {
+                #[cfg(debug_assertions)]
+                todo!("handle unimplemented cipher");
+                #[cfg(not(debug_assertions))]
+                Err(TeeResult::NotImplemented)
             }
-            Ok(())
         } else {
             Err(TeeResult::BadParameters)
         }
@@ -260,9 +265,9 @@ impl Task {
     ) -> Result<(), TeeResult> {
         let tee_obj_map = &self.tee_obj_map;
         if attrs.len() > 1 {
-            if cfg!(debug_assertions) {
-                todo!("handle multiple attributes");
-            }
+            #[cfg(debug_assertions)]
+            todo!("handle multiple attributes");
+            #[cfg(not(debug_assertions))]
             return Err(TeeResult::NotSupported);
         }
         if !tee_obj_map.exists(obj) {

--- a/litebox_shim_optee/src/syscalls/cryp.rs
+++ b/litebox_shim_optee/src/syscalls/cryp.rs
@@ -171,6 +171,14 @@ impl Task {
             return Err(TeeResult::ShortBuffer);
         }
         if let Some(mut map) = tee_cryp_state_map.get_mut(state) {
+            // Check last_block before applying the cipher so we don't mutate
+            // dst_slice and then return an error.
+            if last_block {
+                if cfg!(debug_assertions) {
+                    todo!("support algorithms which have a certain finalization logic");
+                }
+                return Err(TeeResult::NotSupported);
+            }
             if let Some(state_entry) = map.get_mut(&state)
                 && let Some(cipher) = state_entry.get_mut_cipher()
             {
@@ -187,12 +195,6 @@ impl Task {
                     }
                 }
                 *dst_len = src_slice.len();
-            }
-            if last_block {
-                if cfg!(debug_assertions) {
-                    todo!("support algorithms which have a certain finalization logic");
-                }
-                return Err(TeeResult::NotSupported);
             }
             Ok(())
         } else {

--- a/litebox_shim_optee/src/syscalls/cryp.rs
+++ b/litebox_shim_optee/src/syscalls/cryp.rs
@@ -119,11 +119,17 @@ impl Task {
             if let Some(handle) = cryp_state.get_object_handle(false)
                 && tee_obj_map.exists(handle)
             {
-                todo!("support two-key algorithms");
+                if cfg!(debug_assertions) {
+                    todo!("support two-key algorithms");
+                }
+                return Err(TeeResult::NotSupported);
             }
 
             let Some(cipher) = create_cipher(cryp_state.algorithm(), key, iv) else {
-                todo!("implement algorithm {}", cryp_state.algorithm() as u32);
+                if cfg!(debug_assertions) {
+                    todo!("implement algorithm {}", cryp_state.algorithm() as u32);
+                }
+                return Err(TeeResult::NotSupported);
             };
             tee_cryp_state_map.set_cipher(state, &cipher)?;
             Ok(())
@@ -165,7 +171,9 @@ impl Task {
             return Err(TeeResult::ShortBuffer);
         }
         if let Some(mut map) = tee_cryp_state_map.get_mut(state) {
-            if let &mut Some(ref mut cipher) = &mut map.get_mut(&state).unwrap().get_mut_cipher() {
+            if let Some(state_entry) = map.get_mut(&state)
+                && let Some(cipher) = state_entry.get_mut_cipher()
+            {
                 dst_slice.copy_from_slice(src_slice);
                 match cipher {
                     Cipher::Aes128Ctr(aes128ctr) => {
@@ -181,7 +189,10 @@ impl Task {
                 *dst_len = src_slice.len();
             }
             if last_block {
-                todo!("support algorithms which have a certain finalization logic");
+                if cfg!(debug_assertions) {
+                    todo!("support algorithms which have a certain finalization logic");
+                }
+                return Err(TeeResult::NotSupported);
             }
             Ok(())
         } else {
@@ -247,14 +258,15 @@ impl Task {
     ) -> Result<(), TeeResult> {
         let tee_obj_map = &self.tee_obj_map;
         if attrs.len() > 1 {
-            todo!("handle multiple attributes");
+            if cfg!(debug_assertions) {
+                todo!("handle multiple attributes");
+            }
+            return Err(TeeResult::NotSupported);
         }
         if !tee_obj_map.exists(obj) {
             return Err(TeeResult::BadState);
         }
-        tee_obj_map
-            .populate(obj, attrs)
-            .map_err(|_| TeeResult::BadParameters)
+        tee_obj_map.populate(obj, attrs)
     }
 
     pub(crate) fn sys_cryp_obj_copy(

--- a/litebox_shim_optee/src/syscalls/mm.rs
+++ b/litebox_shim_optee/src/syscalls/mm.rs
@@ -60,7 +60,10 @@ impl Task {
                 | MapFlags::MAP_HUGE_2MB
                 | MapFlags::MAP_HUGE_1GB,
         ) {
-            todo!("Unsupported flags {:?}", flags);
+            if cfg!(debug_assertions) {
+                todo!("Unsupported flags {:?}", flags);
+            }
+            return Err(Errno::EINVAL);
         }
 
         let aligned_len = align_up(len, PAGE_SIZE);
@@ -72,12 +75,18 @@ impl Task {
         }
 
         let suggested_addr = if addr == 0 { None } else { Some(addr) };
-        if flags.contains(MapFlags::MAP_ANONYMOUS) {
+        let result = if flags.contains(MapFlags::MAP_ANONYMOUS) {
             self.do_mmap_anonymous(suggested_addr, aligned_len, prot, flags)
         } else {
-            panic!("we don't support file-backed mmap");
-        }
-        .map_err(Errno::from)
+            #[cfg(debug_assertions)]
+            {
+                panic!("we don't support file-backed mmap");
+            }
+
+            #[cfg(not(debug_assertions))]
+            return Err(Errno::EINVAL);
+        };
+        result.map_err(Errno::from)
     }
 
     /// Handle syscall `munmap`

--- a/litebox_shim_optee/src/syscalls/mm.rs
+++ b/litebox_shim_optee/src/syscalls/mm.rs
@@ -60,9 +60,9 @@ impl Task {
                 | MapFlags::MAP_HUGE_2MB
                 | MapFlags::MAP_HUGE_1GB,
         ) {
-            if cfg!(debug_assertions) {
-                todo!("Unsupported flags {:?}", flags);
-            }
+            #[cfg(debug_assertions)]
+            todo!("Unsupported flags {:?}", flags);
+            #[cfg(not(debug_assertions))]
             return Err(Errno::EINVAL);
         }
 

--- a/litebox_shim_optee/src/syscalls/pta.rs
+++ b/litebox_shim_optee/src/syscalls/pta.rs
@@ -136,7 +136,12 @@ impl Task {
                     Err(TeeResult::BadParameters)
                 }
             }
-            _ => todo!("support other system PTA commands {cmd_id}"),
+            _ => {
+                if cfg!(debug_assertions) {
+                    todo!("support other system PTA commands {cmd_id}");
+                }
+                Err(TeeResult::NotSupported)
+            }
         }
     }
 }

--- a/litebox_shim_optee/src/syscalls/pta.rs
+++ b/litebox_shim_optee/src/syscalls/pta.rs
@@ -137,9 +137,9 @@ impl Task {
                 }
             }
             _ => {
-                if cfg!(debug_assertions) {
-                    todo!("support other system PTA commands {cmd_id}");
-                }
+                #[cfg(debug_assertions)]
+                todo!("support other system PTA commands {cmd_id}");
+                #[cfg(not(debug_assertions))]
                 Err(TeeResult::NotSupported)
             }
         }

--- a/litebox_shim_optee/src/syscalls/tee.rs
+++ b/litebox_shim_optee/src/syscalls/tee.rs
@@ -74,9 +74,9 @@ impl Task {
         prop_type: UserMutPtr<u32>,
     ) -> Result<(), TeeResult> {
         if name_buf.is_some() && name_len.is_some() {
-            if cfg!(debug_assertions) {
-                todo!("return the name of a given property index");
-            }
+            #[cfg(debug_assertions)]
+            todo!("return the name of a given property index");
+            #[cfg(not(debug_assertions))]
             return Err(TeeResult::NotSupported);
         }
         match GpdPropertyIndex::try_from(index).unwrap_or(GpdPropertyIndex::None) {
@@ -178,9 +178,9 @@ impl Task {
             // (using its UUID) to leverage its functions.
             // TODO: if this TA hasn't been loaded, we need to load its ELF and prepare its stack (hopefully
             // in a separate page table). We can do this here or at `sys_invoke_ta_command` (in a lazy manner).
-            if cfg!(debug_assertions) {
-                todo!("support inter TA interaction");
-            }
+            #[cfg(debug_assertions)]
+            todo!("support inter TA interaction");
+            #[cfg(not(debug_assertions))]
             Err(TeeResult::NotSupported)
         }
     }
@@ -192,9 +192,9 @@ impl Task {
             close_pta_session(ta_sess_id);
             Ok(())
         } else {
-            if cfg!(debug_assertions) {
-                todo!("support inter TA interaction");
-            }
+            #[cfg(debug_assertions)]
+            todo!("support inter TA interaction");
+            #[cfg(not(debug_assertions))]
             Err(TeeResult::NotSupported)
         }
     }
@@ -216,9 +216,9 @@ impl Task {
             // TODO: check whether `ta_sess_id` is associated with the system PTA.
             self.handle_system_pta_command(cmd_id, &params)
         } else {
-            if cfg!(debug_assertions) {
-                todo!("support inter TA interaction");
-            }
+            #[cfg(debug_assertions)]
+            todo!("support inter TA interaction");
+            #[cfg(not(debug_assertions))]
             Err(TeeResult::NotSupported)
         }
     }

--- a/litebox_shim_optee/src/syscalls/tee.rs
+++ b/litebox_shim_optee/src/syscalls/tee.rs
@@ -7,6 +7,7 @@ use litebox::mm::linux::{NonZeroAddress, NonZeroPageSize, PAGE_SIZE};
 use litebox::path::Arg;
 use litebox::platform::RawMutPointer;
 use litebox::platform::{RawConstPointer, page_mgmt::MemoryRegionPermissions};
+use litebox::utils::TruncateExt;
 use litebox_common_optee::{
     TeeIdentity, TeeMemoryAccessRights, TeeOrigin, TeePropSet, TeeResult, TeeUuid, UserTaPropType,
     UteeParams,
@@ -89,10 +90,7 @@ impl Task {
                 let identity = self.client_identity;
                 prop_buf.copy_from_slice(identity.as_bytes());
                 prop_len
-                    .write_at_offset(
-                        0,
-                        u32::try_from(core::mem::size_of::<TeeIdentity>()).unwrap(),
-                    )
+                    .write_at_offset(0, core::mem::size_of::<TeeIdentity>().truncate())
                     .ok_or(TeeResult::AccessDenied)?;
                 prop_type
                     .write_at_offset(0, UserTaPropType::Identity as u32)
@@ -109,7 +107,7 @@ impl Task {
                 let ta_uuid = self.ta_app_id;
                 prop_buf.copy_from_slice(ta_uuid.as_bytes());
                 prop_len
-                    .write_at_offset(0, u32::try_from(core::mem::size_of::<TeeUuid>()).unwrap())
+                    .write_at_offset(0, core::mem::size_of::<TeeUuid>().truncate())
                     .ok_or(TeeResult::AccessDenied)?;
                 prop_type
                     .write_at_offset(0, UserTaPropType::Uuid as u32)

--- a/litebox_shim_optee/src/syscalls/tee.rs
+++ b/litebox_shim_optee/src/syscalls/tee.rs
@@ -73,7 +73,10 @@ impl Task {
         prop_type: UserMutPtr<u32>,
     ) -> Result<(), TeeResult> {
         if name_buf.is_some() && name_len.is_some() {
-            todo!("return the name of a given property index")
+            if cfg!(debug_assertions) {
+                todo!("return the name of a given property index");
+            }
+            return Err(TeeResult::NotSupported);
         }
         match GpdPropertyIndex::try_from(index).unwrap_or(GpdPropertyIndex::None) {
             GpdPropertyIndex::ClientIdentity => {
@@ -149,7 +152,7 @@ impl Task {
                     Err(TeeResult::BadParameters)
                 }
             }
-            _ => todo!(),
+            _ => Err(TeeResult::ItemNotFound),
         }
     }
 
@@ -177,7 +180,10 @@ impl Task {
             // (using its UUID) to leverage its functions.
             // TODO: if this TA hasn't been loaded, we need to load its ELF and prepare its stack (hopefully
             // in a separate page table). We can do this here or at `sys_invoke_ta_command` (in a lazy manner).
-            todo!("support inter TA interaction")
+            if cfg!(debug_assertions) {
+                todo!("support inter TA interaction");
+            }
+            Err(TeeResult::NotSupported)
         }
     }
 
@@ -188,7 +194,10 @@ impl Task {
             close_pta_session(ta_sess_id);
             Ok(())
         } else {
-            todo!("support inter TA interaction")
+            if cfg!(debug_assertions) {
+                todo!("support inter TA interaction");
+            }
+            Err(TeeResult::NotSupported)
         }
     }
 
@@ -209,7 +218,10 @@ impl Task {
             // TODO: check whether `ta_sess_id` is associated with the system PTA.
             self.handle_system_pta_command(cmd_id, &params)
         } else {
-            todo!("support inter TA interaction")
+            if cfg!(debug_assertions) {
+                todo!("support inter TA interaction");
+            }
+            Err(TeeResult::NotSupported)
         }
     }
 


### PR DESCRIPTION
This PR suppresses some release-mode kernel panics (e.g., panic, todo, expect, unwrap, ...) that ldelf/TA can trigger.