### PR TITLE
Add noreserve parameter to allocate_pages and fix copy_pages chunk length

### DIFF
--- a/litebox/src/mm/linux.rs
+++ b/litebox/src/mm/linux.rs
@@ -509,6 +509,7 @@ impl<Platform: PageManagementProvider<ALIGN> + 'static, const ALIGN: usize> Vmem
                 MemoryRegionPermissions::from_bits(permissions).unwrap(),
                 vma.flags.contains(VmFlags::VM_GROWSDOWN),
                 populate_pages_immediately,
+                false,
                 platform_fixed_address_behavior,
             )
             .map_err(|err| match err {

--- a/litebox/src/mm/tests.rs
+++ b/litebox/src/mm/tests.rs
@@ -43,6 +43,7 @@ impl crate::platform::PageManagementProvider<PAGE_SIZE> for DummyVmemBackend {
         initial_permissions: crate::platform::page_mgmt::MemoryRegionPermissions,
         can_grow_down: bool,
         populate_pages_immediately: bool,
+        _noreserve: bool,
         fixed_address_behavior: crate::platform::page_mgmt::FixedAddressBehavior,
     ) -> Result<Self::RawMutPointer<u8>, crate::platform::page_mgmt::AllocationError> {
         Ok(TransparentMutPtr::from_usize(suggested_range.start))

--- a/litebox/src/platform/page_mgmt.rs
+++ b/litebox/src/platform/page_mgmt.rs
@@ -49,6 +49,8 @@ pub trait PageManagementProvider<const ALIGN: usize>: RawPointerProvider {
     ///   a page fault.
     /// - `populate_pages_immediately`: If `true`, the pages are populated immediately; otherwise,
     ///   they are populated lazily.
+    /// - `noreserve`: If `true`, request a sparse reservation that avoids reserving swap/commit
+    ///   upfront when the platform supports it.
     /// - `fixed_address_behavior`: Specifies the required semantics of `suggested_range`.
     ///
     /// # Returns
@@ -64,6 +66,7 @@ pub trait PageManagementProvider<const ALIGN: usize>: RawPointerProvider {
         initial_permissions: MemoryRegionPermissions,
         can_grow_down: bool,
         populate_pages_immediately: bool,
+        noreserve: bool,
         fixed_address_behavior: FixedAddressBehavior,
     ) -> Result<Self::RawMutPointer<u8>, AllocationError>;
 
@@ -108,6 +111,7 @@ pub trait PageManagementProvider<const ALIGN: usize>: RawPointerProvider {
                 temp_permissions,
                 false,
                 true,
+                false,
                 FixedAddressBehavior::NoReplace,
             )
             .map_err(|e| match e {
@@ -135,12 +139,13 @@ pub trait PageManagementProvider<const ALIGN: usize>: RawPointerProvider {
         let total_len = old_range.len();
         let mut offset = 0;
         while offset < total_len {
+            let chunk_len = (total_len - offset).min(ALIGN);
             let old_ptr =
                 <Self as RawPointerProvider>::RawConstPointer::from_usize(old_range.start + offset);
             new_ptr
                 .write_slice_at_offset(
                     isize::try_from(offset).unwrap(),
-                    &old_ptr.to_owned_slice(old_range.len()).unwrap(),
+                    &old_ptr.to_owned_slice(chunk_len).unwrap(),
                 )
                 .unwrap();
             offset += ALIGN;
@@ -148,7 +153,7 @@ pub trait PageManagementProvider<const ALIGN: usize>: RawPointerProvider {
 
         if temp_permissions != permissions {
             (unsafe { self.update_permissions(new_range.clone(), permissions) })
-                .expect("failed to restore perrmissions on new range");
+                .expect("failed to restore permissions on new range");
         }
 
         (unsafe { self.deallocate_pages(old_range) }).expect("failed to deallocate old range");

--- a/litebox_platform_linux_kernel/src/lib.rs
+++ b/litebox_platform_linux_kernel/src/lib.rs
@@ -424,6 +424,7 @@ impl<Host: HostInterface, const ALIGN: usize> PageManagementProvider<ALIGN> for 
         initial_permissions: litebox::platform::page_mgmt::MemoryRegionPermissions,
         can_grow_down: bool,
         populate_pages_immediately: bool,
+        _noreserve: bool,
         fixed_address_behavior: FixedAddressBehavior,
     ) -> Result<Self::RawMutPointer<u8>, litebox::platform::page_mgmt::AllocationError> {
         let range = PageRange::new(suggested_range.start, suggested_range.end)

--- a/litebox_platform_linux_userland/src/lib.rs
+++ b/litebox_platform_linux_userland/src/lib.rs
@@ -1703,6 +1703,7 @@ impl<const ALIGN: usize> litebox::platform::PageManagementProvider<ALIGN> for Li
         initial_permissions: MemoryRegionPermissions,
         can_grow_down: bool,
         populate_pages_immediately: bool,
+        noreserve: bool,
         fixed_address_behavior: FixedAddressBehavior,
     ) -> Result<Self::RawMutPointer<u8>, litebox::platform::page_mgmt::AllocationError> {
         let flags = MapFlags::MAP_PRIVATE
@@ -1719,6 +1720,11 @@ impl<const ALIGN: usize> litebox::platform::PageManagementProvider<ALIGN> for Li
             }
             | if populate_pages_immediately {
                 MapFlags::MAP_POPULATE
+            } else {
+                MapFlags::empty()
+            }
+            | if noreserve {
+                MapFlags::MAP_NORESERVE
             } else {
                 MapFlags::empty()
             };

--- a/litebox_platform_lvbs/src/lib.rs
+++ b/litebox_platform_lvbs/src/lib.rs
@@ -1228,6 +1228,7 @@ impl<Host: HostInterface, const ALIGN: usize> PageManagementProvider<ALIGN> for 
         initial_permissions: litebox::platform::page_mgmt::MemoryRegionPermissions,
         can_grow_down: bool,
         populate_pages_immediately: bool,
+        _noreserve: bool,
         fixed_address_behavior: FixedAddressBehavior,
     ) -> Result<Self::RawMutPointer<u8>, litebox::platform::page_mgmt::AllocationError> {
         let range = PageRange::new(suggested_range.start, suggested_range.end)

--- a/litebox_platform_windows_userland/src/lib.rs
+++ b/litebox_platform_windows_userland/src/lib.rs
@@ -1647,6 +1647,7 @@ impl<const ALIGN: usize> litebox::platform::PageManagementProvider<ALIGN> for Wi
         initial_permissions: MemoryRegionPermissions,
         can_grow_down: bool,
         populate_pages_immediately: bool,
+        _noreserve: bool,
         fixed_address_behavior: FixedAddressBehavior,
     ) -> Result<Self::RawMutPointer<u8>, AllocationError> {
         debug_assert!(ALIGN.is_multiple_of(self.sys_info.read().unwrap().dwPageSize as usize));
@@ -2166,6 +2167,7 @@ mod tests {
             MemoryRegionPermissions::WRITE,
             false,
             true,
+            false,
             FixedAddressBehavior::Hint,
         )
         .unwrap()
@@ -2192,6 +2194,7 @@ mod tests {
             MemoryRegionPermissions::WRITE,
             false,
             true,
+            false,
             FixedAddressBehavior::Hint,
         )
         .unwrap()
@@ -2224,6 +2227,7 @@ mod tests {
             MemoryRegionPermissions::WRITE,
             false,
             true,
+            false,
             FixedAddressBehavior::Hint,
         )
         .unwrap()


### PR DESCRIPTION
## Summary

- Add `noreserve: bool` parameter to `PageManagementProvider::allocate_pages()`. When true, Linux userland uses `MAP_NORESERVE` for sparse memory reservations. Kernel, LVBS, and Windows platforms accept but ignore it. All current callers pass `false` (no behavior change).
- Fix a bug in the default `remap_pages()` copy loop: `to_owned_slice()` was using `old_range.len()` (the entire range) instead of per-chunk length, reading beyond each chunk boundary.

Split from #743.