### PR TITLE
Misc cleanup: pub(crate) mock fields, log_println allow, current_processor_number, stdin guard

### DIFF
--- a/litebox/src/platform/mock.rs
+++ b/litebox/src/platform/mock.rs
@@ -210,7 +210,7 @@ impl IPInterfaceProvider for MockPlatform {
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) struct MockInstant {
-    time: u64,
+    pub(crate) time: u64,
 }
 
 impl Instant for MockInstant {
@@ -230,7 +230,7 @@ impl Instant for MockInstant {
 }
 
 pub(crate) struct MockSystemTime {
-    time: u64,
+    pub(crate) time: u64,
 }
 
 impl SystemTime for MockSystemTime {
@@ -290,6 +290,9 @@ impl RawPointerProvider for MockPlatform {
 
 impl StdioProvider for MockPlatform {
     fn read_from_stdin(&self, buf: &mut [u8]) -> Result<usize, StdioReadError> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
         let Some(front) = self.stdin_queue.write().unwrap().pop_front() else {
             return Err(StdioReadError::Closed);
         };

--- a/litebox/src/platform/mod.rs
+++ b/litebox/src/platform/mod.rs
@@ -23,11 +23,13 @@ pub use page_mgmt::PageManagementProvider;
 #[macro_export]
 macro_rules! log_println {
     ($platform:expr, $s:expr) => {{
+        #[allow(unused_imports)]
         use $crate::platform::DebugLogProvider as _;
         $platform.debug_log_print($s);
     }};
     ($platform:expr, $($tt:tt)*) => {{
         use core::fmt::Write as _;
+        #[allow(unused_imports)]
         use $crate::platform::DebugLogProvider as _;
         let mut t: arrayvec::ArrayString<8192> = arrayvec::ArrayString::new();
         writeln!(t, $($tt)*).unwrap();
@@ -666,6 +668,16 @@ pub trait SystemInfoProvider {
     /// Return `Some(address)` if the VDSO is available on the platform, or `None`
     /// if the platform does not support or provide a VDSO.
     fn get_vdso_address(&self) -> Option<usize>;
+
+    /// Returns the current processor number, used to emulate `getcpu`-family
+    /// syscalls and related VDSO interfaces.
+    ///
+    /// Platforms that do not expose a stable processor identifier, or that
+    /// virtualize CPU topology, may return `0`. Callers arrive in subsequent
+    /// stacked PRs.
+    fn current_processor_number(&self) -> u32 {
+        0
+    }
 }
 
 /// A provider for thread-local storage.


### PR DESCRIPTION
## Summary

- Make `MockPlatform` fields `pub(crate)` instead of fully public, since the mock is only used within the crate's test infrastructure.
- Add `#[allow(unused_imports)]` for `log_println!` macro import (used conditionally).
- Add `current_processor_number()` to `SystemInfoProvider` with a default returning `0`, for `getcpu`-family syscall emulation.
- Add a `Drop` guard to `MockPlatform::read_stdin()` to clear the stdin buffer on return.

Split from #743.