### PR TITLE
Add RawMessageProvider trait and expand SendError/ReceiveError variants

### DIFF
--- a/litebox/src/net/phy.rs
+++ b/litebox/src/net/phy.rs
@@ -51,7 +51,11 @@ impl<Platform: platform::IPInterfaceProvider> smoltcp::phy::Device for Device<Pl
                     buffer: &mut self.send_buffer,
                 },
             )),
-            Err(platform::ReceiveError::WouldBlock) => None,
+            Err(
+                platform::ReceiveError::WouldBlock
+                | platform::ReceiveError::ProtocolError
+                | platform::ReceiveError::Eof,
+            ) => None,
         }
     }
 

--- a/litebox/src/platform/mock.rs
+++ b/litebox/src/platform/mock.rs
@@ -59,6 +59,8 @@ impl MockPlatform {
 
 impl Provider for MockPlatform {}
 
+impl RawMessageProvider for MockPlatform {}
+
 pub(crate) struct MockRawMutex {
     inner: AtomicU32,
     internal_state: std::sync::RwLock<MockRawMutexInternalState>,

--- a/litebox/src/platform/mod.rs
+++ b/litebox/src/platform/mod.rs
@@ -43,6 +43,7 @@ macro_rules! log_println {
 pub trait Provider:
     RawMutexProvider
     + IPInterfaceProvider
+    + RawMessageProvider
     + TimeProvider
     + PunchthroughProvider
     + DebugLogProvider
@@ -382,17 +383,54 @@ pub trait IPInterfaceProvider {
     fn receive_ip_packet(&self, packet: &mut [u8]) -> Result<usize, ReceiveError>;
 }
 
-/// A non-exhaustive list of errors that can be thrown by [`IPInterfaceProvider::send_ip_packet`].
+/// Errors from send operations on [`IPInterfaceProvider`] and [`RawMessageProvider`].
 #[derive(Error, Debug)]
 #[non_exhaustive]
-pub enum SendError {}
+pub enum SendError {
+    /// The underlying device returned an I/O error. The packet was not sent.
+    #[error("I/O error on send: errno {0}")]
+    Io(i32),
+    /// The channel is not available on this platform.
+    #[error("send channel unavailable")]
+    Unavailable,
+}
 
-/// A non-exhaustive list of errors that can be thrown by [`IPInterfaceProvider::receive_ip_packet`].
+/// Errors from receive operations on [`IPInterfaceProvider`] and [`RawMessageProvider`].
 #[derive(Error, Debug)]
 #[non_exhaustive]
 pub enum ReceiveError {
     #[error("Receive operation would block")]
     WouldBlock,
+    #[error("IPC protocol error: oversized frame")]
+    ProtocolError,
+    #[error("Channel closed (EOF)")]
+    Eof,
+}
+
+/// A raw byte-stream channel for direct message passing between the guest and
+/// the host (bypassing the IP network stack).
+///
+/// When available, this provides a fast path for protocols like 9P that would
+/// otherwise pay the overhead of traversing two smoltcp stacks.
+///
+/// The default implementation returns [`ReceiveError::WouldBlock`] /
+/// [`SendError::Unavailable`], indicating the channel is not available.
+/// Platforms that support direct messaging override these methods.
+pub trait RawMessageProvider {
+    /// Send bytes to the host over the raw channel.
+    ///
+    /// Returns `Ok(n)` with the number of bytes sent, or an error.
+    fn send_raw_message(&self, _data: &[u8]) -> Result<usize, SendError> {
+        Err(SendError::Unavailable)
+    }
+
+    /// Receive bytes from the host over the raw channel.
+    ///
+    /// Returns `Ok(n)` with the number of bytes read into `buf`, or
+    /// [`ReceiveError::WouldBlock`] if no data is available yet.
+    fn recv_raw_message(&self, _buf: &mut [u8]) -> Result<usize, ReceiveError> {
+        Err(ReceiveError::WouldBlock)
+    }
 }
 
 /// An interface to understanding time.

--- a/litebox_platform_linux_kernel/src/lib.rs
+++ b/litebox_platform_linux_kernel/src/lib.rs
@@ -85,6 +85,8 @@ impl<'a, Host: HostInterface> PunchthroughToken for LinuxPunchthroughToken<'a, H
 
 impl<Host: HostInterface> Provider for LinuxKernel<Host> {}
 
+impl<Host: HostInterface> litebox::platform::RawMessageProvider for LinuxKernel<Host> {}
+
 // TODO: implement pointer validation to ensure the pointers are in user space.
 type UserConstPtr<T> = litebox::platform::common_providers::userspace_pointers::UserConstPtr<
     litebox::platform::common_providers::userspace_pointers::NoValidation,

--- a/litebox_platform_linux_userland/src/lib.rs
+++ b/litebox_platform_linux_userland/src/lib.rs
@@ -445,6 +445,8 @@ impl LinuxUserland {
 
 impl litebox::platform::Provider for LinuxUserland {}
 
+impl litebox::platform::RawMessageProvider for LinuxUserland {}
+
 impl litebox::platform::SignalProvider for LinuxUserland {
     type Signal = litebox_common_linux::signal::Signal;
 

--- a/litebox_platform_lvbs/src/lib.rs
+++ b/litebox_platform_lvbs/src/lib.rs
@@ -1351,6 +1351,8 @@ impl<Host: HostInterface> litebox::platform::SystemInfoProvider for LinuxKernel<
     }
 }
 
+impl<Host: HostInterface> litebox::platform::RawMessageProvider for LinuxKernel<Host> {}
+
 #[cfg(feature = "optee_syscall")]
 /// Checks whether the given physical addresses are contiguous with respect to ALIGN.
 fn is_contiguous<const ALIGN: usize>(addrs: &[PhysPageAddr<ALIGN>]) -> bool {

--- a/litebox_platform_windows_userland/src/lib.rs
+++ b/litebox_platform_windows_userland/src/lib.rs
@@ -331,6 +331,8 @@ impl WindowsUserland {
     }
 }
 
+impl litebox::platform::RawMessageProvider for WindowsUserland {}
+
 impl litebox::platform::Provider for WindowsUserland {}
 
 impl litebox::platform::SignalProvider for WindowsUserland {


### PR DESCRIPTION
## Summary

- Add `RawMessageProvider` trait for direct guest-host byte channels that bypass the IP stack. Default impl returns `Err(Unavailable)`.
- Add `Provider` supertrait bound `+ RawMessageProvider`.
- Expand `SendError` with `Io(i32)` and `Unavailable` variants; expand `ReceiveError` with `ProtocolError` and `Eof` variants. Update doc strings for shared usage across `IPInterfaceProvider` and `RawMessageProvider`.
- Add stub impls in all platform crates (linux kernel, linux userland, LVBS, Windows userland) and the mock.

Split from #743.