### PR TITLE
Update semver-checks CI to handle non-main branch

### DIFF
--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -21,15 +21,17 @@ jobs:
     name: Check SemVer Correctness
     runs-on: ubuntu-latest
     steps:
-      - name: Fail if PR base is not main
-        if: github.event.pull_request.base.ref != 'main' && github.event_name == 'pull_request'
-        run: |
-          echo "This PR does not target the 'main' branch. Exiting."
-          exit 1
       - name: Check out repo
         uses: actions/checkout@v6
-      - name: Ensure that the main branch is fetched
-        run: git fetch origin main:main
+      - name: Determine baseline ref
+        id: baseline
+        run: |
+          BASE_REF="${{ github.event.pull_request.base.ref }}"
+          # Fallback for merge_group / workflow_dispatch where base.ref is empty
+          BASE_REF="${BASE_REF:-main}"
+          echo "ref=$BASE_REF" >> "$GITHUB_OUTPUT"
+      - name: Fetch baseline branch
+        run: git fetch origin "${{ steps.baseline.outputs.ref }}:${{ steps.baseline.outputs.ref }}"
       - name: Set up Rust
         run: |
           rustup toolchain install $(awk -F'"' '/channel/{print $2}' rust-toolchain.toml) --profile minimal --no-self-update
@@ -37,14 +39,14 @@ jobs:
         run: |
           curl -L --proto '=https' --tlsv1.2 -sSf https://github.com/obi1kenobi/cargo-semver-checks/releases/latest/download/cargo-semver-checks-x86_64-unknown-linux-gnu.tar.gz | tar xzvf -
           mv cargo-semver-checks ~/.cargo/bin
-      - name: Check semver match against the main branch
+      - name: Check semver match against the baseline branch
         id: semver_check
         run: |
           # TODO(jayb): we are temporarily preventing a failure in semver-checks
           # from showing up as a `X`, but instead triggering a comment on the
           # PR. Once things go public, we will likely switch this out to make it
           # actually complain as usual, possibly still keeping in the comment bot?
-          if cargo semver-checks --baseline-rev main --color=never >/tmp/semver-checks-stdout; then
+          if cargo semver-checks --baseline-rev "${{ steps.baseline.outputs.ref }}" --color=never >/tmp/semver-checks-stdout; then
             cat /tmp/semver-checks-stdout
             echo "Semver check succeeded."
             echo "reaction=hooray" >> "$GITHUB_OUTPUT"
@@ -85,10 +87,14 @@ jobs:
       - name: Add a new issue comment if needed
         if: github.event_name == 'pull_request'
         run: |
+          BASE_NOTE=""
+          if [ "${{ steps.baseline.outputs.ref }}" != "main" ]; then
+            BASE_NOTE=":information_source: **Note:** This semver check was run against the \`${{ steps.baseline.outputs.ref }}\` branch, not \`main\`.\n\n"
+          fi
           curl -L \
           -X POST \
           -H "Accept: application/vnd.github+json" \
           -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
           https://api.github.com/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/issues/${{ github.event.number }}/comments \
-          -d "$(if [ -s /tmp/semver-checks-stdout ]; then echo -e ':robot: SemverChecks :robot: :warning: Potential breaking API changes detected :warning:\n\n<details><summary>Click for details</summary>\n\n```'"$(cat /tmp/semver-checks-stdout)"'\n```\n</details>'; else echo -e ':robot: SemverChecks :robot: No breaking API changes detected\n\nNote: this does not mean API is unchanged, or even that there are no breaking changes; simply, none of the detections triggered.'; fi | jq -sR '{body: .}')"
+          -d "$(if [ -s /tmp/semver-checks-stdout ]; then echo -e "${BASE_NOTE}"':robot: SemverChecks :robot: :warning: Potential breaking API changes detected :warning:\n\n<details><summary>Click for details</summary>\n\n```'"$(cat /tmp/semver-checks-stdout)"'\n```\n</details>'; else echo -e "${BASE_NOTE}"':robot: SemverChecks :robot: No breaking API changes detected\n\nNote: this does not mean API is unchanged, or even that there are no breaking changes; simply, none of the detections triggered.'; fi | jq -sR '{body: .}')"


### PR DESCRIPTION
To help understand stacked PRs better, it seems helpful to allow semver-checks on non-main-targeted branches too.  This PR tweaks the semver-checks CI to do exactly this.