### PR TITLE
Harden VTL memory protection function

### DIFF
--- a/litebox_platform_lvbs/src/host/bootparam.rs
+++ b/litebox_platform_lvbs/src/host/bootparam.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+use crate::mshv::vtl1_mem_layout::PAGE_SIZE;
 use litebox_common_linux::errno::Errno;
 use spin::Once;
 
@@ -26,7 +27,11 @@ pub fn get_num_possible_cpus() -> Result<u32, Errno> {
 }
 
 fn save_vtl1_memory_info(start: u64, size: u64) -> Result<(), Errno> {
-    if start > 0 && size > 0 {
+    if start > 0
+        && start.is_multiple_of(PAGE_SIZE as u64)
+        && size > 0
+        && size.is_multiple_of(PAGE_SIZE as u64)
+    {
         VTL1_MEMORY_INFO.call_once(|| (start, size));
         return Ok(());
     }

--- a/litebox_platform_lvbs/src/lib.rs
+++ b/litebox_platform_lvbs/src/lib.rs
@@ -627,6 +627,11 @@ impl<Host: HostInterface> LinuxKernel<Host> {
         CPU_MHZ.store(cpu_mhz, core::sync::atomic::Ordering::Relaxed);
     }
 
+    /// Returns the physical frame range belonging to VTL1.
+    pub fn vtl1_phys_frame_range(&self) -> PhysFrameRange<Size4KiB> {
+        self.vtl1_phys_frame_range
+    }
+
     /// This function maps VTL0 physical page frames containing the physical addresses
     /// from `phys_start` to `phys_end` to the VTL1 kernel page table. It internally page aligns
     /// the input addresses to ensure the mapped memory area covers the entire input addresses

--- a/litebox_platform_lvbs/src/mshv/error.rs
+++ b/litebox_platform_lvbs/src/mshv/error.rs
@@ -44,6 +44,9 @@ pub enum VsmError {
     #[error("invalid physical address")]
     InvalidPhysicalAddress,
 
+    #[error("physical address range overlaps with VTL1 memory")]
+    Vtl1MemoryOverlap,
+
     // Memory/Data Errors
     #[error("invalid memory attributes")]
     MemoryAttributeInvalid,
@@ -175,7 +178,8 @@ impl From<VsmError> for Errno {
             | VsmError::BootSignalWriteFailed
             | VsmError::CpuOnlineMaskCopyFailed
             | VsmError::HekiPagesCopyFailed
-            | VsmError::Vtl0CopyFailed => Errno::EFAULT,
+            | VsmError::Vtl0CopyFailed
+            | VsmError::Vtl1MemoryOverlap => Errno::EFAULT,
 
             // Not found errors
             VsmError::SystemCertificatesNotFound

--- a/litebox_platform_lvbs/src/mshv/vsm.rs
+++ b/litebox_platform_lvbs/src/mshv/vsm.rs
@@ -96,8 +96,10 @@ pub(crate) fn init(is_bsp: bool) {
             };
             let start = PhysAddr::new(start);
             if protect_vtl1_physical_memory_range(PhysFrame::range(
-                PhysFrame::containing_address(start),
-                PhysFrame::containing_address(end),
+                PhysFrame::from_start_address(start)
+                    .expect("VTL1 memory start address is not page-aligned"),
+                PhysFrame::from_start_address(end)
+                    .expect("VTL1 memory end address is not page-aligned"),
             ))
             .is_err()
             {
@@ -359,7 +361,7 @@ pub fn mshv_vsm_load_kdata(pa: u64, nranges: u64) -> Result<i64, VsmError> {
                     .extend_range(heki_range)
                     .map_err(|_| VsmError::InvalidInputAddress)?,
                 HekiKdataType::KexecTrampoline => {
-                    kexec_trampoline_metadata.insert_heki_range(heki_range);
+                    kexec_trampoline_metadata.insert_heki_range(heki_range)?;
                 }
                 HekiKdataType::PatchInfo => patch_info_mem
                     .extend_range(heki_range)
@@ -718,7 +720,7 @@ pub fn mshv_vsm_kexec_validate(pa: u64, nranges: u64, crash: u64) -> Result<i64,
         for heki_range in heki_page {
             match heki_range.heki_kexec_type() {
                 HekiKexecType::KexecImage => {
-                    kexec_memory_metadata.insert_heki_range(heki_range);
+                    kexec_memory_metadata.insert_heki_range(heki_range)?;
                     kexec_image
                         .extend_range(heki_range)
                         .map_err(|_| VsmError::InvalidInputAddress)?;
@@ -731,7 +733,7 @@ pub fn mshv_vsm_kexec_validate(pa: u64, nranges: u64, crash: u64) -> Result<i64,
                         .map_err(|_| VsmError::InvalidInputAddress)?;
                 }
 
-                HekiKexecType::KexecPages => kexec_memory_metadata.insert_heki_range(heki_range),
+                HekiKexecType::KexecPages => kexec_memory_metadata.insert_heki_range(heki_range)?,
                 HekiKexecType::Unknown => {
                     return Err(VsmError::KexecTypeInvalid);
                 }
@@ -902,14 +904,15 @@ fn mshv_vsm_allocate_ringbuffer_memory(phys_addr: u64, size: usize) -> Result<i6
         .ok_or(VsmError::IntegerOverflow)
         .and_then(|end| PhysAddr::try_new(end).map_err(|_| VsmError::InvalidPhysicalAddress))?;
     let phys_addr = PhysAddr::new(phys_addr);
-    set_ringbuffer(phys_addr, size);
     protect_physical_memory_range(
         PhysFrame::range(
-            PhysFrame::containing_address(phys_addr),
-            PhysFrame::containing_address(end),
+            PhysFrame::from_start_address(phys_addr)
+                .map_err(|_| VsmError::AddressNotPageAligned)?,
+            PhysFrame::from_start_address(end).map_err(|_| VsmError::AddressNotPageAligned)?,
         ),
         MemAttr::MEM_ATTR_READ,
     )?;
+    set_ringbuffer(phys_addr, size);
     debug_serial_println!("VSM: Ring buffer allocated");
     Ok(0)
 }
@@ -1394,7 +1397,7 @@ pub(crate) fn protect_physical_memory_range(
 /// before the kernel platform data structure is initialized. To this end, one might call this function with
 /// a VTL0 physical memory range which only restricts access to the range.
 #[inline]
-pub(crate) fn protect_vtl1_physical_memory_range(
+fn protect_vtl1_physical_memory_range(
     phys_frame_range: PhysFrameRange<Size4KiB>,
 ) -> Result<(), VsmError> {
     let pa = phys_frame_range.start.start_address().as_u64();
@@ -1672,12 +1675,16 @@ impl KexecMemoryMetadata {
     }
 
     #[inline]
-    pub(crate) fn insert_heki_range(&mut self, heki_range: &HekiRange) {
+    pub(crate) fn insert_heki_range(&mut self, heki_range: &HekiRange) -> Result<(), VsmError> {
         // `HekiRange::is_valid` already validated these addresses.
+        if !heki_range.is_aligned(Size4KiB::SIZE) {
+            return Err(VsmError::AddressNotPageAligned);
+        }
         let va = heki_range.va;
         let pa = heki_range.pa;
         let epa = heki_range.epa;
         self.insert_memory_range(KexecMemoryRange::new_checked(va, pa, epa));
+        Ok(())
     }
 
     #[inline]
@@ -1738,22 +1745,25 @@ impl KexecMemoryRange {
         Self {
             virt_addr: VirtAddr::new(virt_addr),
             phys_frame_range: PhysFrame::range(
-                PhysFrame::containing_address(phys_start),
-                PhysFrame::containing_address(phys_end),
+                PhysFrame::from_start_address(phys_start)
+                    .expect("validated kexec memory start address is page-aligned"),
+                PhysFrame::from_start_address(phys_end)
+                    .expect("validated kexec memory end address is page-aligned"),
             ),
         }
     }
 
     pub fn new(virt_addr: u64, phys_start: u64, phys_end: u64) -> Result<Self, VsmError> {
+        let phys_start =
+            PhysAddr::try_new(phys_start).map_err(|_| VsmError::InvalidPhysicalAddress)?;
+        let phys_end = PhysAddr::try_new(phys_end).map_err(|_| VsmError::InvalidPhysicalAddress)?;
         Ok(Self {
             virt_addr: VirtAddr::try_new(virt_addr).map_err(|_| VsmError::InvalidVirtualAddress)?,
             phys_frame_range: PhysFrame::range(
-                PhysFrame::containing_address(
-                    PhysAddr::try_new(phys_start).map_err(|_| VsmError::InvalidPhysicalAddress)?,
-                ),
-                PhysFrame::containing_address(
-                    PhysAddr::try_new(phys_end).map_err(|_| VsmError::InvalidPhysicalAddress)?,
-                ),
+                PhysFrame::from_start_address(phys_start)
+                    .map_err(|_| VsmError::AddressNotPageAligned)?,
+                PhysFrame::from_start_address(phys_end)
+                    .map_err(|_| VsmError::AddressNotPageAligned)?,
             ),
         })
     }

--- a/litebox_platform_lvbs/src/mshv/vsm.rs
+++ b/litebox_platform_lvbs/src/mshv/vsm.rs
@@ -1366,19 +1366,49 @@ fn copy_heki_pages_from_vtl0(pa: u64, nranges: u64) -> Option<Vec<HekiPage>> {
     Some(heki_pages)
 }
 
-/// This function protects a physical memory range. It is a safe wrapper for `hv_modify_vtl_protection_mask`.
-/// `phys_frame_range` specifies the physical frame range to protect
-/// `mem_attr` specifies the memory attributes to be applied to the range
+/// This function protects a VTL0 physical memory range from potentially compromised VTL0 by
+/// restricting its access permissions using VTL protection mask (e.g., kernel code integrity).
+/// It is a safe wrapper for `hv_modify_vtl_protection_mask`. `phys_frame_range` specifies the
+/// physical frame range to protect (must belong to VTL0) `mem_attr` specifies the memory
+/// attributes (VTL0's allowed access) to be applied to the range
 #[inline]
 pub(crate) fn protect_physical_memory_range(
     phys_frame_range: PhysFrameRange<Size4KiB>,
     mem_attr: MemAttr,
 ) -> Result<(), VsmError> {
+    let vtl1_range = crate::platform_low().vtl1_phys_frame_range();
+    if phys_frame_range.start < vtl1_range.end && vtl1_range.start < phys_frame_range.end {
+        return Err(VsmError::Vtl1MemoryOverlap);
+    }
     let pa = phys_frame_range.start.start_address().as_u64();
     let num_pages = phys_frame_range.count() as u64;
     if num_pages > 0 {
         hv_modify_vtl_protection_mask(pa, num_pages, mem_attr_to_hv_page_prot_flags(mem_attr))
             .map_err(VsmError::HypercallFailed)?;
+    }
+    Ok(())
+}
+
+/// This function is a variant of [`protect_physical_memory_range`] to protect a VTL1 physical memory range.
+/// Unlike [`protect_physical_memory_range`], this is intended exclusively for securing VTL1's own pages.
+/// VTL0 should never access VTL1 memory, so the memory attribute is always empty (no read, write, or execute).
+///
+/// Note. This function doesn't check whether `phys_frame_range` belongs to VTL1 because it is called by BSP
+/// before the kernel platform data structure is initialized. To this end, one might call this function with
+/// a VTL0 physical memory range which only restricts access to the range.
+#[inline]
+pub(crate) fn protect_vtl1_physical_memory_range(
+    phys_frame_range: PhysFrameRange<Size4KiB>,
+) -> Result<(), VsmError> {
+    let pa = phys_frame_range.start.start_address().as_u64();
+    let num_pages = phys_frame_range.count() as u64;
+    if num_pages > 0 {
+        hv_modify_vtl_protection_mask(
+            pa,
+            num_pages,
+            mem_attr_to_hv_page_prot_flags(MemAttr::empty()),
+        )
+        .map_err(VsmError::HypercallFailed)?;
     }
     Ok(())
 }

--- a/litebox_platform_lvbs/src/mshv/vsm.rs
+++ b/litebox_platform_lvbs/src/mshv/vsm.rs
@@ -95,13 +95,10 @@ pub(crate) fn init(is_bsp: bool) {
                 panic!("Failed to protect VTL1 memory");
             };
             let start = PhysAddr::new(start);
-            if protect_physical_memory_range(
-                PhysFrame::range(
-                    PhysFrame::containing_address(start),
-                    PhysFrame::containing_address(end),
-                ),
-                MemAttr::empty(),
-            )
+            if protect_vtl1_physical_memory_range(PhysFrame::range(
+                PhysFrame::containing_address(start),
+                PhysFrame::containing_address(end),
+            ))
             .is_err()
             {
                 panic!("Failed to protect VTL1 memory");


### PR DESCRIPTION
This PR hardens the VTL memory protection function(s). Currently, the VTL memory protection function doesn't check whether the given physical memory range belongs to VTL0 or VTL1. This potentially lets the adversary tamper with the VTL1's memory protection.