### PR TITLE
Harden HEKI's kernel text patch fuction

### DIFF
--- a/litebox_platform_lvbs/src/mshv/mem_integrity.rs
+++ b/litebox_platform_lvbs/src/mshv/mem_integrity.rs
@@ -626,7 +626,10 @@ const JMP32_INSN_SIZE: u8 = 5;
 /// Refer [Linux](https://elixir.bootlin.com/linux/v6.6.85/source/arch/x86/kernel/alternative.c#L2164)
 pub fn validate_text_poke_bp_batch(patch_data: &HekiPatch, precomputed_patch: &HekiPatch) -> bool {
     // step 1
-    if patch_data.size == 1 && patch_data.code[0] == INT3_INSN_OPCODE {
+    if patch_data.size == 1
+        && patch_data.code[0] == INT3_INSN_OPCODE
+        && patch_data.pa[0] == precomputed_patch.pa[0]
+    {
         return true;
     }
 
@@ -637,7 +640,15 @@ pub fn validate_text_poke_bp_batch(patch_data: &HekiPatch, precomputed_patch: &H
             || (patch_data.pa[0] == precomputed_patch.pa[1]
                 && (precomputed_patch.pa[0] + 1).is_multiple_of(Size4KiB::SIZE)))
     {
-        1 // step 2
+        // step 2. pa[1] is dereferenced by `apply_vtl0_text_patch` only when
+        // `precomputed_patch.pa[0] + 1` is not page-aligned. In that case, it must
+        // equal `precomputed_patch.pa[1]`.
+        if !(precomputed_patch.pa[0] + 1).is_multiple_of(Size4KiB::SIZE)
+            && patch_data.pa[1] != precomputed_patch.pa[1]
+        {
+            return false;
+        }
+        1
     } else {
         return false;
     };

--- a/litebox_platform_lvbs/src/mshv/mem_integrity.rs
+++ b/litebox_platform_lvbs/src/mshv/mem_integrity.rs
@@ -636,14 +636,15 @@ pub fn validate_text_poke_bp_batch(patch_data: &HekiPatch, precomputed_patch: &H
     let offset: usize = if patch_data.size == 1 && patch_data.pa[0] == precomputed_patch.pa[0] {
         0 // step 3
     } else if patch_data.size == precomputed_patch.size - 1 {
-        let Some(precomputed_pa_0_plus_1) = precomputed_patch.pa[0].checked_add(1) else {
+        let Some(precomputed_patch_second_byte_pa) = precomputed_patch.pa[0].checked_add(1) else {
             return false;
         };
-        let precomputed_pa_0_plus_1_aligned =
-            precomputed_pa_0_plus_1.is_multiple_of(Size4KiB::SIZE);
+        let precomputed_patch_second_byte_pa_aligned =
+            precomputed_patch_second_byte_pa.is_multiple_of(Size4KiB::SIZE);
 
-        if patch_data.pa[0] != precomputed_pa_0_plus_1
-            && !(patch_data.pa[0] == precomputed_patch.pa[1] && precomputed_pa_0_plus_1_aligned)
+        if patch_data.pa[0] != precomputed_patch_second_byte_pa
+            && !(patch_data.pa[0] == precomputed_patch.pa[1]
+                && precomputed_patch_second_byte_pa_aligned)
         {
             return false;
         }
@@ -651,7 +652,8 @@ pub fn validate_text_poke_bp_batch(patch_data: &HekiPatch, precomputed_patch: &H
         // step 2. `apply_vtl0_text_patch` uses `patch_data.pa[1]` only when
         // `patch_data.pa[0]` leaves the remainder of the patch on the next page.
         // For a legitimate step 2, that next page is the precomputed patch's pa[1].
-        if !precomputed_pa_0_plus_1_aligned && patch_data.pa[1] != precomputed_patch.pa[1] {
+        if !precomputed_patch_second_byte_pa_aligned && patch_data.pa[1] != precomputed_patch.pa[1]
+        {
             return false;
         }
         1

--- a/litebox_platform_lvbs/src/mshv/mem_integrity.rs
+++ b/litebox_platform_lvbs/src/mshv/mem_integrity.rs
@@ -690,7 +690,7 @@ mod tests {
     fn patch(pa: [u64; 2], code: &[u8]) -> HekiPatch {
         let mut patch = HekiPatch::default();
         patch.pa = pa;
-        patch.size = code.len() as u8;
+        patch.size = u8::try_from(code.len()).expect("test patch code is too length");
         patch.code[..code.len()].copy_from_slice(code);
         patch
     }

--- a/litebox_platform_lvbs/src/mshv/mem_integrity.rs
+++ b/litebox_platform_lvbs/src/mshv/mem_integrity.rs
@@ -635,17 +635,23 @@ pub fn validate_text_poke_bp_batch(patch_data: &HekiPatch, precomputed_patch: &H
 
     let offset: usize = if patch_data.size == 1 && patch_data.pa[0] == precomputed_patch.pa[0] {
         0 // step 3
-    } else if patch_data.size == precomputed_patch.size - 1
-        && (patch_data.pa[0] == precomputed_patch.pa[0] + 1
-            || (patch_data.pa[0] == precomputed_patch.pa[1]
-                && (precomputed_patch.pa[0] + 1).is_multiple_of(Size4KiB::SIZE)))
-    {
-        // step 2. pa[1] is dereferenced by `apply_vtl0_text_patch` only when
-        // `precomputed_patch.pa[0] + 1` is not page-aligned. In that case, it must
-        // equal `precomputed_patch.pa[1]`.
-        if !(precomputed_patch.pa[0] + 1).is_multiple_of(Size4KiB::SIZE)
-            && patch_data.pa[1] != precomputed_patch.pa[1]
+    } else if patch_data.size == precomputed_patch.size - 1 {
+        let Some(precomputed_pa_0_plus_1) = precomputed_patch.pa[0].checked_add(1) else {
+            return false;
+        };
+        let precomputed_pa_0_plus_1_aligned =
+            precomputed_pa_0_plus_1.is_multiple_of(Size4KiB::SIZE);
+
+        if patch_data.pa[0] != precomputed_pa_0_plus_1
+            && !(patch_data.pa[0] == precomputed_patch.pa[1] && precomputed_pa_0_plus_1_aligned)
         {
+            return false;
+        }
+
+        // step 2. `apply_vtl0_text_patch` uses `patch_data.pa[1]` only when
+        // `patch_data.pa[0]` leaves the remainder of the patch on the next page.
+        // For a legitimate step 2, that next page is the precomputed patch's pa[1].
+        if !precomputed_pa_0_plus_1_aligned && patch_data.pa[1] != precomputed_patch.pa[1] {
             return false;
         }
         1
@@ -675,6 +681,35 @@ pub fn validate_text_poke_bp_batch(patch_data: &HekiPatch, precomputed_patch: &H
 pub fn validate_text_patch(patch_data: &HekiPatch, precomputed_patch: &HekiPatch) -> bool {
     validate_text_poke_bp_batch(patch_data, precomputed_patch)
     // TODO: support other patching methods
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn patch(pa: [u64; 2], code: &[u8]) -> HekiPatch {
+        let mut patch = HekiPatch::default();
+        patch.pa = pa;
+        patch.size = code.len() as u8;
+        patch.code[..code.len()].copy_from_slice(code);
+        patch
+    }
+
+    #[test]
+    fn validate_text_poke_bp_batch_accepts_step_2_starting_on_second_page() {
+        let precomputed = patch([0x1fff, 0x2000], &[0xe9, 0x01, 0x02, 0x03, 0x04]);
+        let patch_data = patch([precomputed.pa[1], 0], &[0x01, 0x02, 0x03, 0x04]);
+
+        assert!(validate_text_poke_bp_batch(&patch_data, &precomputed));
+    }
+
+    #[test]
+    fn validate_text_poke_bp_batch_rejects_straddling_step_2_wrong_pa_1() {
+        let precomputed = patch([0x1ffe, 0x2000], &[0xe9, 0x01, 0x02]);
+        let patch_data = patch([precomputed.pa[0] + 1, 0x3000], &[0x01, 0x02]);
+
+        assert!(!validate_text_poke_bp_batch(&patch_data, &precomputed));
+    }
 }
 
 /// Errors for kernel ELF validation and relocation.

--- a/litebox_platform_lvbs/src/mshv/vsm.rs
+++ b/litebox_platform_lvbs/src/mshv/vsm.rs
@@ -1107,9 +1107,15 @@ impl Vtl0KernelInfo {
         self.system_certs.get().map(|b| &**b)
     }
 
-    // This function finds the precomputed patch data corresponding to the input patch data.
-    // We need this because each step of `mshv_vsm_patch_data`/`text_poke_bp_batch` only
-    // provides a part of the patch data and addresses (`patch[0]` or `patch[1..patch_size-1]`).
+    /// This function finds the precomputed patch data corresponding to the input patch data.
+    ///
+    /// Each step of `text_poke_bp_batch` only exposes a portion of the target's address range,
+    /// so we look up in the precomputed map by two keys derived from `patch_data.pa[0]`:
+    /// - `pa[0]` matches step 1 or 3 (target's first byte) and, for a precomputed patch that
+    ///   straddles at offset 1, step 2.
+    /// - `pa[0] - 1` matches step 2 where `patch.pa[0] == precomputed.pa[0] + 1`.
+    ///
+    /// No legitimate step requires looking up by `patch.pa[1]`.
     pub fn find_precomputed_patch(&self, patch_data: &HekiPatch) -> Option<HekiPatch> {
         // `HekiPatch::is_valid` already validated both physical addresses.
         let patch_pa_0 = PhysAddr::new(patch_data.pa[0]);

--- a/litebox_platform_lvbs/src/mshv/vsm.rs
+++ b/litebox_platform_lvbs/src/mshv/vsm.rs
@@ -833,12 +833,12 @@ fn copy_heki_patch_from_vtl0(patch_pa_0: u64, patch_pa_1: u64) -> Result<HekiPat
         return Err(VsmError::InvalidInputAddress);
     }
 
-    if patch_pa_1.is_null()
+    let heki_patch = if patch_pa_1.is_null()
         || (patch_pa_0.align_up(Size4KiB::SIZE) == patch_pa_1.align_down(Size4KiB::SIZE))
     {
         unsafe { crate::platform_low().copy_from_vtl0_phys::<HekiPatch>(patch_pa_0) }
             .map(|boxed| *boxed)
-            .ok_or(VsmError::Vtl0CopyFailed)
+            .ok_or(VsmError::Vtl0CopyFailed)?
     } else {
         let mut heki_patch = HekiPatch::new_zeroed();
         let heki_patch_bytes = heki_patch.as_mut_bytes();
@@ -853,11 +853,13 @@ fn copy_heki_patch_from_vtl0(patch_pa_0: u64, patch_pa_1: u64) -> Result<HekiPat
                 return Err(VsmError::Vtl0CopyFailed);
             }
         }
-        if heki_patch.is_valid() {
-            Ok(heki_patch)
-        } else {
-            Err(VsmError::InvalidInputAddress)
-        }
+        heki_patch
+    };
+
+    if heki_patch.is_valid() {
+        Ok(heki_patch)
+    } else {
+        Err(VsmError::InvalidInputAddress)
     }
 }
 

--- a/litebox_platform_lvbs/src/mshv/vsm.rs
+++ b/litebox_platform_lvbs/src/mshv/vsm.rs
@@ -838,7 +838,7 @@ fn copy_heki_patch_from_vtl0(patch_pa_0: u64, patch_pa_1: u64) -> Result<HekiPat
     {
         unsafe { crate::platform_low().copy_from_vtl0_phys::<HekiPatch>(patch_pa_0) }
             .map(|boxed| *boxed)
-            .ok_or(VsmError::Vtl0CopyFailed)?
+            .ok_or(VsmError::Vtl0CopyFailed)
     } else {
         let mut heki_patch = HekiPatch::new_zeroed();
         let heki_patch_bytes = heki_patch.as_mut_bytes();
@@ -853,8 +853,8 @@ fn copy_heki_patch_from_vtl0(patch_pa_0: u64, patch_pa_1: u64) -> Result<HekiPat
                 return Err(VsmError::Vtl0CopyFailed);
             }
         }
-        heki_patch
-    };
+        Ok(heki_patch)
+    }?;
 
     if heki_patch.is_valid() {
         Ok(heki_patch)
@@ -1122,12 +1122,10 @@ impl Vtl0KernelInfo {
         // `HekiPatch::is_valid` already validated both physical addresses.
         let patch_pa_0 = PhysAddr::new(patch_data.pa[0]);
         let patch_pa_0_prev = patch_data.pa[0].checked_sub(1).map(PhysAddr::new);
-        let patch_pa_1 = PhysAddr::new(patch_data.pa[1]);
 
         self.precomputed_patches
             .get(patch_pa_0)
             .or_else(|| patch_pa_0_prev.and_then(|pa| self.precomputed_patches.get(pa)))
-            .or_else(|| self.precomputed_patches.get(patch_pa_1))
             .or(None)
     }
 }


### PR DESCRIPTION
This PR hardens HEKI's kernel text patch function. In particular, the current implementation (`validate_text_poke_bp_batch`) allows a malicious VTL0 kernel to write `0xcc` to some write-protected kernel memory addresses through VTL1. This PR adds an explicit address check.