### PR TITLE
Enable logger for userland Linux runner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1450,6 +1450,7 @@ dependencies = [
  "buddy_system_allocator",
  "either",
  "hashbrown",
+ "litebox_util_log",
  "rangemap",
  "ringbuf",
  "slabmalloc",
@@ -1623,8 +1624,10 @@ dependencies = [
  "litebox_platform_multiplex",
  "litebox_shim_linux",
  "litebox_syscall_rewriter",
+ "litebox_util_log",
  "memmap2",
  "sha2",
+ "tracing-subscriber",
  "walkdir",
 ]
 

--- a/litebox/Cargo.toml
+++ b/litebox/Cargo.toml
@@ -19,6 +19,7 @@ ringbuf = { version = "0.4.8", default-features = false, features = ["alloc"] }
 buddy_system_allocator = { version = "0.11.0", default-features = false, features = ["use_spin"] }
 # Depend on (currently unreleased) slabmalloc `main`, which contains some fixes on top of `0.11.0`
 slabmalloc = { git = "https://github.com/gz/rust-slabmalloc.git", rev = "19480b2e82704210abafe575fb9699184c1be110" }
+litebox_util_log = { version = "0.1.0", path = "../litebox_util_log" }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.60.2", features = [

--- a/litebox/src/litebox.rs
+++ b/litebox/src/litebox.rs
@@ -64,10 +64,14 @@ impl<Platform: RawSyncPrimitivesProvider> LiteBox<Platform> {
         #[cfg(feature = "lock_tracing")]
         crate::sync::lock_tracing::LockTracker::init(platform);
 
+        let descriptors = RwLock::new(Descriptors::new_from_litebox_creation());
+
+        litebox_util_log::trace!("LiteBox instance initialized");
+
         Self {
             x: Arc::new(LiteBoxX {
                 platform,
-                descriptors: RwLock::new(Descriptors::new_from_litebox_creation()),
+                descriptors,
             }),
         }
     }

--- a/litebox_runner_linux_userland/Cargo.toml
+++ b/litebox_runner_linux_userland/Cargo.toml
@@ -14,6 +14,8 @@ litebox_platform_multiplex = { version = "0.1.0", path = "../litebox_platform_mu
 litebox_shim_linux = { version = "0.1.0", path = "../litebox_shim_linux" }
 litebox_syscall_rewriter = { version = "0.1.0", path = "../litebox_syscall_rewriter" }
 memmap2 = "0.9.8"
+tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
+litebox_util_log = { version = "0.1.0", path = "../litebox_util_log", features = ["backend_tracing"] }
 
 [dev-dependencies]
 sha2 = "0.10"

--- a/litebox_runner_linux_userland/src/lib.rs
+++ b/litebox_runner_linux_userland/src/lib.rs
@@ -12,6 +12,10 @@ use std::path::{Path, PathBuf};
 extern crate alloc;
 
 /// Run Linux programs with LiteBox on unmodified Linux
+///
+/// Detailed logging can be controlled via the `LITEBOX_LOG` environment variable. For example:
+/// - `LITEBOX_LOG=debug` to show debug and higher level logs
+/// - `LITEBOX_LOG=litebox=debug,litebox::fs=trace` for multiple filters at different levels
 #[derive(Parser, Debug)]
 #[allow(clippy::struct_excessive_bools)]
 pub struct CliArgs {
@@ -124,6 +128,16 @@ fn mmapped_file(path: impl AsRef<Path>) -> Result<MmappedFile> {
 /// panic. If it does actually panic, then ping the authors of LiteBox, and likely a better error
 /// message could be thrown instead.
 pub fn run(cli_args: CliArgs) -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_timer(tracing_subscriber::fmt::time::uptime())
+        .with_level(true)
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_env_var("LITEBOX_LOG")
+                .from_env_lossy(),
+        )
+        .init();
+
     if !cli_args.insert_files.is_empty() {
         unimplemented!(
             "this should (hopefully soon) have a nicer interface to support loading in files"


### PR DESCRIPTION
This PR is (effectively) a re-spin of #558.  It resolves #171.

The previous PR (#558) introduced `tracing` directly.  In contrast here, we are using the #665 facade inside `litebox` itself.

This means that by-default `litebox` uses the lighter-weight `log`, which is more suitable for embedded-ish kernel projects.  Runners that wish to have the heavier-weight `tracing` can flip the config flag (this is all primarily due to the work put into #665, this PR is mostly just realizing it).

At the runner, this PR uses `tracing_subscriber` directly and flips the config flag, which gives pretty output :)