### PR TITLE
Support recvmsg

### DIFF
--- a/litebox/src/net/local_ports.rs
+++ b/litebox/src/net/local_ports.rs
@@ -114,6 +114,13 @@ impl LocalPortAllocator {
             }
         }
     }
+
+    /// Deallocate a port number tracked by this allocator.
+    pub(crate) fn deallocate_port(&mut self, port: u16) {
+        if let Some(port) = NonZeroU16::new(port) {
+            self.deallocate(LocalPort { port });
+        }
+    }
 }
 
 /// A token expressing ownership over a specific local port.

--- a/litebox/src/net/mod.rs
+++ b/litebox/src/net/mod.rs
@@ -923,6 +923,8 @@ where
                 else {
                     unreachable!()
                 };
+                self.local_port_allocator
+                    .deallocate_port(socket.endpoint().port);
                 socket.close();
             }
             Protocol::Tcp => {
@@ -1190,13 +1192,13 @@ where
                     port: lp.port(),
                 };
                 let socket: &mut udp::Socket = self.socket_set.get_mut(socket_handle.handle);
-                socket.bind(local_endpoint).map_err(|e| {
+                if let Err(e) = socket.bind(local_endpoint) {
                     self.local_port_allocator.deallocate(lp);
-                    match e {
+                    return Err(match e {
                         udp::BindError::InvalidState => BindError::AlreadyBound,
                         udp::BindError::Unaddressable => unreachable!(),
-                    }
-                })?;
+                    });
+                }
             }
             Protocol::Icmp => unimplemented!(),
             Protocol::Raw { protocol: _ } => unimplemented!(),
@@ -1426,14 +1428,15 @@ where
                 };
                 let udp_socket: &mut udp::Socket = self.socket_set.get_mut(socket_handle.handle);
                 if !udp_socket.is_open() {
-                    let Ok(()) = udp_socket.bind(smoltcp::wire::IpListenEndpoint {
-                        addr: None,
-                        port: self
-                            .local_port_allocator
-                            .ephemeral_port()
-                            .map_err(SendError::PortAllocationFailure)?
-                            .port(),
-                    }) else {
+                    let local_port = self
+                        .local_port_allocator
+                        .ephemeral_port()
+                        .map_err(SendError::PortAllocationFailure)?;
+                    let port = local_port.port();
+                    let Ok(()) =
+                        udp_socket.bind(smoltcp::wire::IpListenEndpoint { addr: None, port })
+                    else {
+                        self.local_port_allocator.deallocate(local_port);
                         unreachable!("binding to a free port cannot fail")
                     };
                 }

--- a/litebox/src/net/socket_channel.rs
+++ b/litebox/src/net/socket_channel.rs
@@ -1358,7 +1358,7 @@ mod tests {
         let read = channel
             .try_read(&mut buf, super::super::ReceiveFlags::empty(), None)
             .unwrap();
-        assert_eq!(read, 10); // Only returns what fits in buffer
+        assert_eq!(read, data.len());
     }
 
     #[test]

--- a/litebox/src/net/socket_channel.rs
+++ b/litebox/src/net/socket_channel.rs
@@ -785,6 +785,7 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> DatagramSocketChannel<P
     ///
     /// Copies the datagram payload into `buf` and optionally returns the source address.
     /// If the datagram is larger than `buf`, behavior depends on `flags`.
+    /// Returns the original message size (which may exceed `buf.len()`).
     pub fn try_read(
         &self,
         buf: &mut [u8],
@@ -798,21 +799,12 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> DatagramSocketChannel<P
             if let Some(source_addr) = source_addr {
                 *source_addr = addr;
             }
-            let n = if flags.contains(ReceiveFlags::DISCARD) {
-                data.len()
-            } else {
+            if !flags.contains(ReceiveFlags::DISCARD) {
                 let to_copy = core::cmp::min(buf.len(), data.len());
                 buf[..to_copy].copy_from_slice(&data[..to_copy]);
-                if flags.contains(ReceiveFlags::TRUNC) {
-                    // return the real size of the packet or datagram,
-                    // even when it was longer than the passed buffer.
-                    data.len()
-                } else {
-                    to_copy
-                }
-            };
+            }
             self.inner.rx_count.fetch_sub(1, Ordering::Release);
-            Ok(n)
+            Ok(data.len())
         } else {
             Ok(0)
         }

--- a/litebox_common_linux/src/lib.rs
+++ b/litebox_common_linux/src/lib.rs
@@ -1674,7 +1674,7 @@ pub struct UserMsgHdr<Platform: litebox::platform::RawPointerProvider> {
     /// number of bytes of ancillary data
     pub msg_controllen: usize,
     /// flags on received message
-    pub msg_flags: SendFlags,
+    pub msg_flags: ReceiveFlags,
     /// Explicit trailing padding to match the 4-byte gap after `msg_flags` in
     /// Linux's naturally-aligned `struct user_msghdr` on 64-bit (total size 56).
     #[cfg(target_pointer_width = "64")]
@@ -1910,6 +1910,11 @@ pub enum SyscallRequest<Platform: litebox::platform::RawPointerProvider> {
         flags: ReceiveFlags,
         addr: Option<Platform::RawMutPointer<u8>>,
         addrlen: Platform::RawMutPointer<u32>,
+    },
+    Recvmsg {
+        sockfd: i32,
+        msg: Platform::RawMutPointer<UserMsgHdr<Platform>>,
+        flags: ReceiveFlags,
     },
     Bind {
         sockfd: i32,
@@ -2352,6 +2357,7 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
             Sysno::sendto => sys_req!(Sendto { sockfd, buf:*, len, flags, addr:*, addrlen }),
             Sysno::sendmsg => sys_req!(Sendmsg { sockfd, msg:*, flags }),
             Sysno::recvfrom => sys_req!(Recvfrom { sockfd, buf:*, len, flags, addr:*, addrlen:*, }),
+            Sysno::recvmsg => sys_req!(Recvmsg { sockfd, msg:*, flags }),
             Sysno::bind => sys_req!(Bind { sockfd, sockaddr:*, addrlen }),
             Sysno::listen => sys_req!(Listen { sockfd, backlog }),
             Sysno::setsockopt => sys_req!(Setsockopt {

--- a/litebox_common_linux/src/lib.rs
+++ b/litebox_common_linux/src/lib.rs
@@ -1658,7 +1658,7 @@ pub struct SigSetPack {
 #[repr(C, packed)]
 pub struct UserMsgHdr<Platform: litebox::platform::RawPointerProvider> {
     /// ptr to socket address structure
-    pub msg_name: Platform::RawConstPointer<u8>,
+    pub msg_name: Platform::RawMutPointer<u8>,
     /// size of socket address structure
     pub msg_namelen: u32,
     /// Explicit padding to match the 4-byte gap that Linux's naturally-aligned

--- a/litebox_runner_linux_userland/tests/recvmsg.c
+++ b/litebox_runner_linux_userland/tests/recvmsg.c
@@ -1,0 +1,189 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/uio.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#define SEND_LEN 100
+
+static int g_fail = 0;
+
+static void check(int cond, const char *what) {
+    if (cond) {
+        printf("  PASS: %s\n", what);
+    } else {
+        printf("  FAIL: %s\n", what);
+        g_fail = 1;
+    }
+}
+
+// Bind a SOCK_DGRAM AF_UNIX socket to an abstract address so the peer has
+// a real source address to deliver in msg_name. (LiteBox does not yet
+// support unnamed-path autobind via addrlen == sizeof(sun_family).)
+static int make_bound_dgram(void) {
+    static int counter = 0;
+    int fd = socket(AF_UNIX, SOCK_DGRAM, 0);
+    if (fd < 0) {
+        perror("socket");
+        exit(2);
+    }
+    struct sockaddr_un sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sun_family = AF_UNIX;
+    int n = snprintf(sa.sun_path + 1, sizeof(sa.sun_path) - 1,
+                     "litebox-recvmsg-test-%d-%d", getpid(), counter++);
+    socklen_t addrlen = (socklen_t)(offsetof(struct sockaddr_un, sun_path) + 1 + n);
+    if (bind(fd, (struct sockaddr *)&sa, addrlen) < 0) {
+        perror("bind");
+        exit(2);
+    }
+    return fd;
+}
+
+static void send_one(int from, int to, size_t len) {
+    struct sockaddr_un to_addr;
+    socklen_t to_len = sizeof(to_addr);
+    if (getsockname(to, (struct sockaddr *)&to_addr, &to_len) < 0) {
+        perror("getsockname");
+        exit(2);
+    }
+    char *buf = calloc(1, len);
+    memset(buf, 'A', len);
+    ssize_t n = sendto(from, buf, len, 0, (struct sockaddr *)&to_addr, to_len);
+    if (n != (ssize_t)len) {
+        perror("sendto");
+        exit(2);
+    }
+    free(buf);
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: truncated datagram must set MSG_TRUNC in msg_flags.
+// ---------------------------------------------------------------------------
+static void test_trunc_flag(void) {
+    puts("Test 1: recvmsg sets MSG_TRUNC on truncated datagram");
+
+    int sv[2];
+    if (socketpair(AF_UNIX, SOCK_DGRAM, 0, sv) < 0) {
+        perror("socketpair");
+        exit(2);
+    }
+
+    char sbuf[SEND_LEN];
+    memset(sbuf, 'A', sizeof(sbuf));
+    if (send(sv[0], sbuf, sizeof(sbuf), 0) != (ssize_t)sizeof(sbuf)) {
+        perror("send");
+        exit(2);
+    }
+
+    char rbuf[10];
+    struct iovec iov = { .iov_base = rbuf, .iov_len = sizeof(rbuf) };
+    struct msghdr msg = {0};
+    msg.msg_iov = &iov;
+    msg.msg_iovlen = 1;
+
+    ssize_t n = recvmsg(sv[1], &msg, 0);
+    printf("  recvmsg returned %zd, msg_flags = 0x%x\n", n, msg.msg_flags);
+    check(n == (ssize_t)sizeof(rbuf), "returned copied byte count (10)");
+    check((msg.msg_flags & MSG_TRUNC) != 0,
+          "MSG_TRUNC set in msg_flags (datagram > iovec capacity)");
+
+    close(sv[0]);
+    close(sv[1]);
+}
+
+// ---------------------------------------------------------------------------
+// Test 2a: msg_iovlen == 0 must not return EINVAL; must dequeue and set
+// MSG_TRUNC.
+// ---------------------------------------------------------------------------
+static void test_zero_iovlen(void) {
+    puts("Test 2a: recvmsg with msg_iovlen == 0 dequeues a datagram");
+
+    int rx = make_bound_dgram();
+    int tx = socket(AF_UNIX, SOCK_DGRAM, 0);
+    if (tx < 0) { perror("socket"); exit(2); }
+    send_one(tx, rx, SEND_LEN);
+
+    struct sockaddr_un name;
+    memset(&name, 0xAB, sizeof(name));
+    struct msghdr msg = {0};
+    msg.msg_name = &name;
+    msg.msg_namelen = sizeof(name);
+    msg.msg_iov = NULL;
+    msg.msg_iovlen = 0;
+
+    errno = 0;
+    ssize_t n = recvmsg(rx, &msg, 0);
+    printf("  recvmsg returned %zd (errno=%d %s), msg_flags=0x%x, "
+           "msg_namelen=%u\n",
+           n, errno, n < 0 ? strerror(errno) : "-", msg.msg_flags,
+           (unsigned)msg.msg_namelen);
+    check(n == 0, "returned 0 (not -1/EINVAL)");
+    check((msg.msg_flags & MSG_TRUNC) != 0,
+          "MSG_TRUNC set (whole datagram discarded)");
+
+    // Datagram should have been consumed: a non-blocking peek must now
+    // report no data.
+    char tmp[1];
+    ssize_t m = recv(rx, tmp, sizeof(tmp), MSG_DONTWAIT);
+    check(m < 0 && (errno == EAGAIN || errno == EWOULDBLOCK),
+          "datagram was actually dequeued");
+
+    close(rx);
+    close(tx);
+}
+
+// ---------------------------------------------------------------------------
+// Test 2b: single iovec with iov_len == 0 must dequeue and set MSG_TRUNC,
+// not silently return 0 leaving the datagram queued.
+// ---------------------------------------------------------------------------
+static void test_zero_capacity_iov(void) {
+    puts("Test 2b: recvmsg with single zero-length iovec dequeues a datagram");
+
+    int rx = make_bound_dgram();
+    int tx = socket(AF_UNIX, SOCK_DGRAM, 0);
+    if (tx < 0) { perror("socket"); exit(2); }
+    send_one(tx, rx, SEND_LEN);
+
+    struct iovec iov = { .iov_base = NULL, .iov_len = 0 };
+    struct msghdr msg = {0};
+    msg.msg_iov = &iov;
+    msg.msg_iovlen = 1;
+
+    errno = 0;
+    ssize_t n = recvmsg(rx, &msg, 0);
+    printf("  recvmsg returned %zd (errno=%d %s), msg_flags=0x%x\n",
+           n, errno, n < 0 ? strerror(errno) : "-", msg.msg_flags);
+    check(n == 0, "returned 0");
+    check((msg.msg_flags & MSG_TRUNC) != 0,
+          "MSG_TRUNC set (whole datagram discarded)");
+
+    char tmp[1];
+    ssize_t m = recv(rx, tmp, sizeof(tmp), MSG_DONTWAIT);
+    check(m < 0 && (errno == EAGAIN || errno == EWOULDBLOCK),
+          "datagram was actually dequeued");
+
+    close(rx);
+    close(tx);
+}
+
+int main(void) {
+    test_trunc_flag();
+    test_zero_iovlen();
+    test_zero_capacity_iov();
+
+    if (g_fail) {
+        puts("\nRESULT: BUG(S) REPRODUCED");
+        return 1;
+    }
+    puts("\nRESULT: OK (Linux behavior)");
+    return 0;
+}

--- a/litebox_runner_linux_userland/tests/recvmsg.c
+++ b/litebox_runner_linux_userland/tests/recvmsg.c
@@ -85,16 +85,22 @@ static void test_trunc_flag(void) {
     }
 
     char rbuf[10];
+    char control[64];
     struct iovec iov = { .iov_base = rbuf, .iov_len = sizeof(rbuf) };
     struct msghdr msg = {0};
     msg.msg_iov = &iov;
     msg.msg_iovlen = 1;
+    msg.msg_control = control;
+    msg.msg_controllen = sizeof(control);
 
     ssize_t n = recvmsg(sv[1], &msg, 0);
-    printf("  recvmsg returned %zd, msg_flags = 0x%x\n", n, msg.msg_flags);
+    printf("  recvmsg returned %zd, msg_flags = 0x%x, msg_controllen=%zu\n",
+           n, msg.msg_flags, msg.msg_controllen);
     check(n == (ssize_t)sizeof(rbuf), "returned copied byte count (10)");
     check((msg.msg_flags & MSG_TRUNC) != 0,
           "MSG_TRUNC set in msg_flags (datagram > iovec capacity)");
+    check(msg.msg_controllen == 0,
+          "msg_controllen zeroed when no control messages delivered");
 
     close(sv[0]);
     close(sv[1]);
@@ -113,22 +119,27 @@ static void test_zero_iovlen(void) {
     send_one(tx, rx, SEND_LEN);
 
     struct sockaddr_un name;
+    char control[64];
     memset(&name, 0xAB, sizeof(name));
     struct msghdr msg = {0};
     msg.msg_name = &name;
     msg.msg_namelen = sizeof(name);
     msg.msg_iov = NULL;
     msg.msg_iovlen = 0;
+    msg.msg_control = control;
+    msg.msg_controllen = sizeof(control);
 
     errno = 0;
     ssize_t n = recvmsg(rx, &msg, 0);
     printf("  recvmsg returned %zd (errno=%d %s), msg_flags=0x%x, "
-           "msg_namelen=%u\n",
+           "msg_namelen=%u, msg_controllen=%zu\n",
            n, errno, n < 0 ? strerror(errno) : "-", msg.msg_flags,
-           (unsigned)msg.msg_namelen);
+           (unsigned)msg.msg_namelen, msg.msg_controllen);
     check(n == 0, "returned 0 (not -1/EINVAL)");
     check((msg.msg_flags & MSG_TRUNC) != 0,
           "MSG_TRUNC set (whole datagram discarded)");
+    check(msg.msg_controllen == 0,
+          "msg_controllen zeroed when no control messages delivered");
 
     // Datagram should have been consumed: a non-blocking peek must now
     // report no data.
@@ -153,18 +164,25 @@ static void test_zero_capacity_iov(void) {
     if (tx < 0) { perror("socket"); exit(2); }
     send_one(tx, rx, SEND_LEN);
 
+    char control[64];
     struct iovec iov = { .iov_base = NULL, .iov_len = 0 };
     struct msghdr msg = {0};
     msg.msg_iov = &iov;
     msg.msg_iovlen = 1;
+    msg.msg_control = control;
+    msg.msg_controllen = sizeof(control);
 
     errno = 0;
     ssize_t n = recvmsg(rx, &msg, 0);
-    printf("  recvmsg returned %zd (errno=%d %s), msg_flags=0x%x\n",
-           n, errno, n < 0 ? strerror(errno) : "-", msg.msg_flags);
+    printf("  recvmsg returned %zd (errno=%d %s), msg_flags=0x%x, "
+           "msg_controllen=%zu\n",
+           n, errno, n < 0 ? strerror(errno) : "-", msg.msg_flags,
+           msg.msg_controllen);
     check(n == 0, "returned 0");
     check((msg.msg_flags & MSG_TRUNC) != 0,
           "MSG_TRUNC set (whole datagram discarded)");
+    check(msg.msg_controllen == 0,
+          "msg_controllen zeroed when no control messages delivered");
 
     char tmp[1];
     ssize_t m = recv(rx, tmp, sizeof(tmp), MSG_DONTWAIT);

--- a/litebox_shim_linux/src/lib.rs
+++ b/litebox_shim_linux/src/lib.rs
@@ -698,6 +698,7 @@ impl<FS: ShimFS> Task<FS> {
                 addr,
                 addrlen,
             } => self.sys_recvfrom(sockfd, buf, len, flags, addr, addrlen),
+            SyscallRequest::Recvmsg { sockfd, msg, flags } => self.sys_recvmsg(sockfd, msg, flags),
             SyscallRequest::Bind {
                 sockfd,
                 sockaddr,

--- a/litebox_shim_linux/src/syscalls/file.rs
+++ b/litebox_shim_linux/src/syscalls/file.rs
@@ -304,7 +304,7 @@ impl<FS: ShimFS> Task<FS> {
         // We need to do this cell dance because otherwise Rust can't recognize that the two
         // closures are mutually exclusive.
         let buf: core::cell::RefCell<&mut [u8]> = core::cell::RefCell::new(buf);
-        files
+        let n = files
             .run_on_raw_fd(
                 fd as usize,
                 |fd| {
@@ -367,7 +367,11 @@ impl<FS: ShimFS> Task<FS> {
                     })
                 },
             )
-            .flatten()
+            .flatten()?;
+        // For datagrams, the returned size represents the actual size of the message,
+        // which may be larger than the buffer size.
+        let capped_size = n.min(buf.borrow().len());
+        Ok(capped_size)
     }
 
     /// Handle syscall `write`

--- a/litebox_shim_linux/src/syscalls/net.rs
+++ b/litebox_shim_linux/src/syscalls/net.rs
@@ -1545,8 +1545,7 @@ impl<FS: ShimFS> Task<FS> {
         let Ok(sockfd) = u32::try_from(fd) else {
             return Err(Errno::EBADF);
         };
-        let msg =
-            ConstPtr::<litebox_common_linux::UserMsgHdr<Platform>>::from_usize(msg_ptr.as_usize())
+        let msg = msg_ptr
                 .read_at_offset(0)
                 .ok_or(Errno::EFAULT)?;
 
@@ -1557,7 +1556,7 @@ impl<FS: ShimFS> Task<FS> {
         let msg_controllen = msg.msg_controllen;
 
         if msg_controllen != 0 {
-            unimplemented!("ancillary data is not supported");
+            log_unsupported!("ancillary data is not supported");
         }
         if msg_iovlen == 0 || msg_iovlen > 1024 {
             return Err(Errno::EINVAL);

--- a/litebox_shim_linux/src/syscalls/net.rs
+++ b/litebox_shim_linux/src/syscalls/net.rs
@@ -1470,15 +1470,29 @@ impl<FS: ShimFS> Task<FS> {
                 None
             },
         )?;
-        buf.copy_from_slice(0, &recv_buf[..size.min(recv_buf.len())])
+        let capped_size = size.min(recv_buf.len());
+        buf.copy_from_slice(0, &recv_buf[..capped_size])
             .ok_or(Errno::EFAULT)?;
         if let Some(src_addr) = source_addr
             && let Some(sock_ptr) = addr
         {
             write_sockaddr_to_user(src_addr, sock_ptr, addrlen)?;
         }
-        Ok(size)
+
+        if flags.contains(ReceiveFlags::TRUNC) {
+            // the actual message size
+            Ok(size)
+        } else {
+            // the number of bytes copied
+            Ok(capped_size)
+        }
     }
+    /// Receive data from a socket.
+    ///
+    /// `source_addr` can be provided to receive the source address if available.
+    ///
+    /// On success, returns the number of bytes received. Note that for datagram sockets,
+    /// this may be larger than the provided buffer length as the excessive data will be truncated.
     fn do_recvfrom(
         &self,
         sockfd: u32,
@@ -1609,7 +1623,13 @@ impl<FS: ShimFS> Task<FS> {
             offset += chunk;
         }
 
-        let total_received = size;
+        let total_received = if flags.contains(ReceiveFlags::TRUNC) {
+            // the actual message size
+            size
+        } else {
+            // the number of bytes copied
+            size.min(total_iov_capacity)
+        };
 
         // Write back source address if requested.
         if want_source {

--- a/litebox_shim_linux/src/syscalls/net.rs
+++ b/litebox_shim_linux/src/syscalls/net.rs
@@ -1533,6 +1533,97 @@ impl<FS: ShimFS> Task<FS> {
         Ok(size)
     }
 
+    /// Handle syscall `recvmsg`
+    pub(crate) fn sys_recvmsg(
+        &self,
+        fd: i32,
+        msg_ptr: MutPtr<litebox_common_linux::UserMsgHdr<Platform>>,
+        flags: ReceiveFlags,
+    ) -> Result<usize, Errno> {
+        const MAX_LEN: usize = 4096;
+
+        let Ok(sockfd) = u32::try_from(fd) else {
+            return Err(Errno::EBADF);
+        };
+        let msg =
+            ConstPtr::<litebox_common_linux::UserMsgHdr<Platform>>::from_usize(msg_ptr.as_usize())
+                .read_at_offset(0)
+                .ok_or(Errno::EFAULT)?;
+
+        // Copy fields out of the packed struct to avoid unaligned references.
+        let msg_name = msg.msg_name;
+        let msg_iov = msg.msg_iov;
+        let msg_iovlen = msg.msg_iovlen;
+        let msg_controllen = msg.msg_controllen;
+
+        if msg_controllen != 0 {
+            unimplemented!("ancillary data is not supported");
+        }
+        if msg_iovlen == 0 || msg_iovlen > 1024 {
+            return Err(Errno::EINVAL);
+        }
+
+        let iovs = msg_iov.to_owned_slice(msg_iovlen).ok_or(Errno::EFAULT)?;
+
+        // Receive into the first non-empty iov buffer.
+        let want_source = msg_name.as_usize() != 0;
+        let mut source_addr = None;
+        let mut total_received = 0usize;
+        let mut ret_flags = ReceiveFlags::empty();
+
+        for iov in &iovs {
+            if iov.iov_len == 0 {
+                continue;
+            }
+            let recv_len = iov.iov_len.min(MAX_LEN);
+            let mut buffer = [0u8; MAX_LEN];
+            let recv_buf = &mut buffer[..recv_len];
+            let size = self.do_recvfrom(
+                sockfd,
+                recv_buf,
+                flags,
+                if want_source && source_addr.is_none() {
+                    Some(&mut source_addr)
+                } else {
+                    None
+                },
+            )?;
+            let copy_len = size.min(iov.iov_len);
+            iov.iov_base
+                .copy_from_slice(0, &recv_buf[..copy_len.min(recv_len)])
+                .ok_or(Errno::EFAULT)?;
+            total_received += size;
+            // Set MSG_TRUNC if the received datagram was larger than the buffer.
+            if size > iov.iov_len {
+                ret_flags |= ReceiveFlags::TRUNC;
+            }
+            // Unlike sendmsg which sends all iovecs, recvmsg fills until one
+            // recv returns — a single datagram/message is received.
+            break;
+        }
+
+        // Write back source address if requested.
+        if let Some(src_addr) = source_addr {
+            let addr_ptr = MutPtr::<u8>::from_usize(msg_name.as_usize());
+            let addrlen_ptr = MutPtr::<u32>::from_usize(
+                msg_ptr.as_usize()
+                    + core::mem::offset_of!(
+                        litebox_common_linux::UserMsgHdr<Platform>,
+                        msg_namelen
+                    ),
+            );
+            write_sockaddr_to_user(src_addr, addr_ptr, addrlen_ptr)?;
+        }
+
+        // Write back msg_flags with any status flags (e.g. MSG_TRUNC).
+        let flags_offset =
+            core::mem::offset_of!(litebox_common_linux::UserMsgHdr<Platform>, msg_flags);
+        let flags_ptr = MutPtr::<ReceiveFlags>::from_usize(msg_ptr.as_usize() + flags_offset);
+        let _ = flags_ptr.write_at_offset(0, ret_flags);
+
+        Ok(total_received)
+    }
+
     pub(crate) fn sys_setsockopt(
         &self,
         sockfd: i32,

--- a/litebox_shim_linux/src/syscalls/net.rs
+++ b/litebox_shim_linux/src/syscalls/net.rs
@@ -1545,9 +1545,7 @@ impl<FS: ShimFS> Task<FS> {
         let Ok(sockfd) = u32::try_from(fd) else {
             return Err(Errno::EBADF);
         };
-        let msg = msg_ptr
-                .read_at_offset(0)
-                .ok_or(Errno::EFAULT)?;
+        let msg = msg_ptr.read_at_offset(0).ok_or(Errno::EFAULT)?;
 
         // Copy fields out of the packed struct to avoid unaligned references.
         let msg_name = msg.msg_name;
@@ -1602,8 +1600,7 @@ impl<FS: ShimFS> Task<FS> {
         }
 
         // Write back source address if requested.
-        if let Some(src_addr) = source_addr {
-            let addr_ptr = MutPtr::<u8>::from_usize(msg_name.as_usize());
+        if want_source {
             let addrlen_ptr = MutPtr::<u32>::from_usize(
                 msg_ptr.as_usize()
                     + core::mem::offset_of!(
@@ -1611,7 +1608,13 @@ impl<FS: ShimFS> Task<FS> {
                         msg_namelen
                     ),
             );
-            write_sockaddr_to_user(src_addr, addr_ptr, addrlen_ptr)?;
+            if let Some(src_addr) = source_addr {
+                let addr_ptr = MutPtr::<u8>::from_usize(msg_name.as_usize());
+                write_sockaddr_to_user(src_addr, addr_ptr, addrlen_ptr)?;
+            } else {
+                // No source address (e.g. connected stream socket) — zero out msg_namelen.
+                let _ = addrlen_ptr.write_at_offset(0, 0u32);
+            }
         }
 
         // Write back msg_flags with any status flags (e.g. MSG_TRUNC).

--- a/litebox_shim_linux/src/syscalls/net.rs
+++ b/litebox_shim_linux/src/syscalls/net.rs
@@ -1550,8 +1550,6 @@ impl<FS: ShimFS> Task<FS> {
         msg_ptr: MutPtr<litebox_common_linux::UserMsgHdr<Platform>>,
         flags: ReceiveFlags,
     ) -> Result<usize, Errno> {
-        const MAX_LEN: usize = 65536;
-
         let Ok(sockfd) = u32::try_from(fd) else {
             return Err(Errno::EBADF);
         };
@@ -1579,12 +1577,9 @@ impl<FS: ShimFS> Task<FS> {
 
         let iovs = msg_iov.to_owned_slice(msg_iovlen).ok_or(Errno::EFAULT)?;
 
-        // Compute total buffer capacity across all non-empty iovecs, capped at MAX_LEN.
-        let total_iov_capacity: usize = iovs
-            .iter()
-            .map(|iov| iov.iov_len)
-            .fold(0usize, usize::saturating_add)
-            .min(MAX_LEN);
+        let total_iov_capacity = iovs.iter().try_fold(0usize, |capacity, iov| {
+            capacity.checked_add(iov.iov_len).ok_or(Errno::EINVAL)
+        })?;
 
         // Perform a single recv into a contiguous buffer.
         let want_source = msg_name.as_usize() != 0;
@@ -1592,7 +1587,11 @@ impl<FS: ShimFS> Task<FS> {
         let mut ret_flags = ReceiveFlags::empty();
 
         // Heap-allocate the recv buffer to avoid stack overflow for large iovecs.
-        let mut buffer = alloc::vec![0u8; total_iov_capacity];
+        let mut buffer = alloc::vec::Vec::new();
+        buffer
+            .try_reserve_exact(total_iov_capacity)
+            .map_err(|_| Errno::ENOMEM)?;
+        buffer.resize(total_iov_capacity, 0);
         let recv_buf = &mut buffer[..];
         let size = self.do_recvfrom(
             sockfd,

--- a/litebox_shim_linux/src/syscalls/net.rs
+++ b/litebox_shim_linux/src/syscalls/net.rs
@@ -1565,7 +1565,7 @@ impl<FS: ShimFS> Task<FS> {
         if msg_controllen != 0 {
             log_unsupported!("ancillary data is not supported");
         }
-        if msg_iovlen == 0 || msg_iovlen > 1024 {
+        if msg_iovlen > 1024 {
             return Err(Errno::EINVAL);
         }
 
@@ -1577,10 +1577,6 @@ impl<FS: ShimFS> Task<FS> {
             .map(|iov| iov.iov_len)
             .fold(0usize, usize::saturating_add)
             .min(MAX_LEN);
-
-        if total_iov_capacity == 0 {
-            return Ok(0);
-        }
 
         // Perform a single recv into a contiguous buffer.
         let want_source = msg_name.as_usize() != 0;

--- a/litebox_shim_linux/src/syscalls/net.rs
+++ b/litebox_shim_linux/src/syscalls/net.rs
@@ -1522,11 +1522,6 @@ impl<FS: ShimFS> Task<FS> {
             )?
         };
 
-        if !flags.contains(ReceiveFlags::TRUNC) {
-            let len = buf.len();
-            assert!(size <= len, "{size} should be smaller than {len}");
-        }
-
         if let (Some(source_addr), Some(addr)) = (source_addr, addr) {
             *source_addr = Some(addr);
         }
@@ -1540,7 +1535,7 @@ impl<FS: ShimFS> Task<FS> {
         msg_ptr: MutPtr<litebox_common_linux::UserMsgHdr<Platform>>,
         flags: ReceiveFlags,
     ) -> Result<usize, Errno> {
-        const MAX_LEN: usize = 4096;
+        const MAX_LEN: usize = 65536;
 
         let Ok(sockfd) = u32::try_from(fd) else {
             return Err(Errno::EBADF);
@@ -1562,42 +1557,59 @@ impl<FS: ShimFS> Task<FS> {
 
         let iovs = msg_iov.to_owned_slice(msg_iovlen).ok_or(Errno::EFAULT)?;
 
-        // Receive into the first non-empty iov buffer.
+        // Compute total buffer capacity across all non-empty iovecs, capped at MAX_LEN.
+        let total_iov_capacity: usize = iovs
+            .iter()
+            .map(|iov| iov.iov_len)
+            .fold(0usize, |acc, len| acc.saturating_add(len))
+            .min(MAX_LEN);
+
+        if total_iov_capacity == 0 {
+            return Ok(0);
+        }
+
+        // Perform a single recv into a contiguous buffer.
         let want_source = msg_name.as_usize() != 0;
         let mut source_addr = None;
-        let mut total_received = 0usize;
         let mut ret_flags = ReceiveFlags::empty();
 
+        // Heap-allocate the recv buffer to avoid stack overflow for large iovecs.
+        let mut buffer = alloc::vec![0u8; total_iov_capacity];
+        let recv_buf = &mut buffer[..];
+        let size = self.do_recvfrom(
+            sockfd,
+            recv_buf,
+            flags,
+            if want_source {
+                Some(&mut source_addr)
+            } else {
+                None
+            },
+        )?;
+
+        // Set MSG_TRUNC if the received message was larger than the total buffer.
+        if size > total_iov_capacity {
+            ret_flags |= ReceiveFlags::TRUNC;
+        }
+
+        // Scatter the received data across iovecs sequentially.
+        let data_to_copy = size.min(total_iov_capacity);
+        let mut offset = 0usize;
         for iov in &iovs {
+            if offset >= data_to_copy {
+                break;
+            }
             if iov.iov_len == 0 {
                 continue;
             }
-            let recv_len = iov.iov_len.min(MAX_LEN);
-            let mut buffer = [0u8; MAX_LEN];
-            let recv_buf = &mut buffer[..recv_len];
-            let size = self.do_recvfrom(
-                sockfd,
-                recv_buf,
-                flags,
-                if want_source && source_addr.is_none() {
-                    Some(&mut source_addr)
-                } else {
-                    None
-                },
-            )?;
-            let copy_len = size.min(iov.iov_len);
+            let chunk = (data_to_copy - offset).min(iov.iov_len);
             iov.iov_base
-                .copy_from_slice(0, &recv_buf[..copy_len.min(recv_len)])
+                .copy_from_slice(0, &recv_buf[offset..offset + chunk])
                 .ok_or(Errno::EFAULT)?;
-            total_received += size;
-            // Set MSG_TRUNC if the received datagram was larger than the buffer.
-            if size > iov.iov_len {
-                ret_flags |= ReceiveFlags::TRUNC;
-            }
-            // Unlike sendmsg which sends all iovecs, recvmsg fills until one
-            // recv returns — a single datagram/message is received.
-            break;
+            offset += chunk;
         }
+
+        let total_received = size;
 
         // Write back source address if requested.
         if want_source {

--- a/litebox_shim_linux/src/syscalls/net.rs
+++ b/litebox_shim_linux/src/syscalls/net.rs
@@ -1561,7 +1561,7 @@ impl<FS: ShimFS> Task<FS> {
         let total_iov_capacity: usize = iovs
             .iter()
             .map(|iov| iov.iov_len)
-            .fold(0usize, |acc, len| acc.saturating_add(len))
+            .fold(0usize, usize::saturating_add)
             .min(MAX_LEN);
 
         if total_iov_capacity == 0 {
@@ -1789,6 +1789,7 @@ mod tests {
         AddressFamily, ReceiveFlags, SendFlags, SockFlags, SockType, SocketOption,
         SocketOptionName, TcpOption, errno::Errno,
     };
+    use zerocopy::FromZeros as _;
 
     use super::SocketAddress;
     use crate::{ConstPtr, MutPtr, syscalls::tests::init_platform};
@@ -1909,7 +1910,7 @@ mod tests {
                     ])
                     .stdout(std::process::Stdio::piped())
                     .output(),
-                "recvfrom" => std::process::Command::new("sh")
+                "recvfrom" | "recvmsg" => std::process::Command::new("sh")
                     .args([
                         "-c",
                         &alloc::format!(
@@ -1979,7 +1980,6 @@ mod tests {
                     },
                 ];
                 let hdr = {
-                    use zerocopy::FromZeros as _;
                     let mut h = litebox_common_linux::UserMsgHdr::<crate::Platform>::new_zeroed();
                     h.msg_iov = ConstPtr::from_usize(iovec.as_ptr() as usize);
                     h.msg_iovlen = iovec.len();
@@ -1997,7 +1997,7 @@ mod tests {
                 let stdout = alloc::string::String::from_utf8_lossy(&output.stdout);
                 assert_eq!(stdout, alloc::format!("{buf1}{buf2}"));
             }
-            "recvfrom" => {
+            "recvfrom" | "recvmsg" => {
                 if is_nonblocking {
                     epoll_add(task, epfd, client_fd, litebox::event::Events::IN);
                     let mut events = [litebox_common_linux::EpollEvent { events: 0, data: 0 }; 2];
@@ -2009,18 +2009,30 @@ mod tests {
                     }
                 }
                 let mut recv_buf = [0u8; 48];
-                let n = task
-                    .do_recvfrom(
-                        client_fd,
-                        &mut recv_buf,
-                        if test_trunc {
-                            ReceiveFlags::TRUNC
-                        } else {
-                            ReceiveFlags::empty()
-                        },
-                        None,
-                    )
-                    .expect("Failed to receive data");
+                let flags = if test_trunc {
+                    ReceiveFlags::TRUNC
+                } else {
+                    ReceiveFlags::empty()
+                };
+                let n = match option {
+                    "recvfrom" => task
+                        .do_recvfrom(client_fd, &mut recv_buf, flags, None)
+                        .expect("Failed to receive data"),
+                    "recvmsg" => {
+                        let iovec = [litebox_common_linux::IoVec {
+                            iov_base: MutPtr::from_usize(recv_buf.as_mut_ptr().expose_provenance()),
+                            iov_len: recv_buf.len(),
+                        }];
+                        let mut msg_hdr =
+                            litebox_common_linux::UserMsgHdr::<crate::Platform>::new_zeroed();
+                        msg_hdr.msg_iov = ConstPtr::from_usize(iovec.as_ptr() as usize);
+                        msg_hdr.msg_iovlen = iovec.len();
+                        let msg_ptr = MutPtr::from_usize(&raw mut msg_hdr as usize);
+                        task.sys_recvmsg(i32::try_from(client_fd).unwrap(), msg_ptr, flags)
+                            .expect("failed to recvmsg")
+                    }
+                    _ => unreachable!(),
+                };
                 if test_trunc {
                     assert!(recv_buf.iter().all(|&b| b == 0)); // buf remains unchanged
                 } else {
@@ -2036,14 +2048,24 @@ mod tests {
         close_socket(task, server);
     }
 
-    fn test_tcp_socket_with_external_client(
-        port: u16,
-        is_nonblocking: bool,
-        test_trunc: bool,
-        option: &'static str,
-    ) {
+    fn test_tcp_socket_with_external_client(port: u16, is_nonblocking: bool, test_trunc: bool) {
         let task = init_platform(Some(TUN_DEVICE_NAME));
-        test_tcp_socket_as_server(&task, TUN_IP_ADDR, port, is_nonblocking, test_trunc, option);
+        test_tcp_socket_as_server(
+            &task,
+            TUN_IP_ADDR,
+            port,
+            is_nonblocking,
+            test_trunc,
+            "recvfrom",
+        );
+        test_tcp_socket_as_server(
+            &task,
+            TUN_IP_ADDR,
+            port,
+            is_nonblocking,
+            test_trunc,
+            "recvmsg",
+        );
     }
 
     fn test_tcp_socket_send(is_nonblocking: bool, test_trunc: bool) {
@@ -2078,17 +2100,17 @@ mod tests {
 
     #[test]
     fn test_tun_blocking_recvfrom_tcp_socket() {
-        test_tcp_socket_with_external_client(SERVER_PORT, false, false, "recvfrom");
+        test_tcp_socket_with_external_client(SERVER_PORT, false, false);
     }
 
     #[test]
     fn test_tun_nonblocking_recvfrom_tcp_socket() {
-        test_tcp_socket_with_external_client(SERVER_PORT, true, false, "recvfrom");
+        test_tcp_socket_with_external_client(SERVER_PORT, true, false);
     }
 
     #[test]
     fn test_tun_blocking_recvfrom_tcp_socket_with_truncation() {
-        test_tcp_socket_with_external_client(SERVER_PORT, false, true, "recvfrom");
+        test_tcp_socket_with_external_client(SERVER_PORT, false, true);
     }
 
     #[test]

--- a/litebox_shim_linux/src/syscalls/net.rs
+++ b/litebox_shim_linux/src/syscalls/net.rs
@@ -1383,14 +1383,15 @@ impl<FS: ShimFS> Task<FS> {
         let msg_name = msg.msg_name;
         let sock_addr = if msg_name.as_usize() != 0 {
             Some(read_sockaddr_from_user(
-                msg.msg_name,
+                ConstPtr::from_usize(msg_name.as_usize()),
                 msg.msg_namelen as usize,
             )?)
         } else {
             None
         };
         if msg.msg_controllen != 0 {
-            unimplemented!("ancillary data is not supported");
+            log_unsupported!("ancillary data is not supported");
+            return Err(Errno::EINVAL);
         }
         if msg.msg_iovlen == 0 || msg.msg_iovlen > 1024 {
             return Err(Errno::EINVAL);
@@ -1554,6 +1555,13 @@ impl<FS: ShimFS> Task<FS> {
         let Ok(sockfd) = u32::try_from(fd) else {
             return Err(Errno::EBADF);
         };
+
+        let supported_flags = ReceiveFlags::DONTWAIT | ReceiveFlags::TRUNC;
+        if flags.intersects(supported_flags.complement()) {
+            log_unsupported!("Unsupported recvmsg flags: {:?}", flags);
+            return Err(Errno::EINVAL);
+        }
+
         let msg = msg_ptr.read_at_offset(0).ok_or(Errno::EFAULT)?;
 
         // Copy fields out of the packed struct to avoid unaligned references.
@@ -1597,9 +1605,8 @@ impl<FS: ShimFS> Task<FS> {
             },
         )?;
 
-        // Set MSG_TRUNC if the received message was larger than the total buffer.
         if size > total_iov_capacity {
-            ret_flags |= ReceiveFlags::TRUNC;
+            ret_flags.insert(ReceiveFlags::TRUNC);
         }
 
         // Scatter the received data across iovecs sequentially.
@@ -1637,19 +1644,26 @@ impl<FS: ShimFS> Task<FS> {
                     ),
             );
             if let Some(src_addr) = source_addr {
-                let addr_ptr = MutPtr::<u8>::from_usize(msg_name.as_usize());
-                write_sockaddr_to_user(src_addr, addr_ptr, addrlen_ptr)?;
+                write_sockaddr_to_user(src_addr, msg_name, addrlen_ptr)?;
             } else {
                 // No source address (e.g. connected stream socket) — zero out msg_namelen.
-                let _ = addrlen_ptr.write_at_offset(0, 0u32);
+                addrlen_ptr.write_at_offset(0, 0u32).ok_or(Errno::EFAULT)?;
             }
         }
+
+        // Ancillary data is not supported, so report that no control bytes were delivered.
+        let controllen_offset =
+            core::mem::offset_of!(litebox_common_linux::UserMsgHdr<Platform>, msg_controllen);
+        let controllen_ptr = MutPtr::<usize>::from_usize(msg_ptr.as_usize() + controllen_offset);
+        controllen_ptr.write_at_offset(0, 0).ok_or(Errno::EFAULT)?;
 
         // Write back msg_flags with any status flags (e.g. MSG_TRUNC).
         let flags_offset =
             core::mem::offset_of!(litebox_common_linux::UserMsgHdr<Platform>, msg_flags);
         let flags_ptr = MutPtr::<ReceiveFlags>::from_usize(msg_ptr.as_usize() + flags_offset);
-        let _ = flags_ptr.write_at_offset(0, ret_flags);
+        flags_ptr
+            .write_at_offset(0, ret_flags)
+            .ok_or(Errno::EFAULT)?;
 
         Ok(total_received)
     }
@@ -1808,7 +1822,13 @@ mod tests {
     use zerocopy::FromZeros as _;
 
     use super::SocketAddress;
-    use crate::{ConstPtr, MutPtr, syscalls::tests::init_platform};
+    use crate::{
+        ConstPtr, MutPtr,
+        syscalls::{
+            net::{CSockInetAddr, read_sockaddr_from_user},
+            tests::init_platform,
+        },
+    };
 
     extern crate alloc;
     extern crate std;
@@ -2221,9 +2241,13 @@ mod tests {
         assert_eq!(stdout, buf);
     }
 
-    fn blocking_udp_server_socket(test_trunc: bool, is_nonblocking: bool) {
-        let task = init_platform(Some(TUN_DEVICE_NAME));
-
+    fn blocking_udp_server_socket(
+        task: &crate::Task<crate::DefaultFS>,
+        test_trunc: bool,
+        set_trunc_flag: bool,
+        is_nonblocking: bool,
+        op: &str,
+    ) {
         // Server socket and bind
         let server_fd = task
             .do_socket(
@@ -2253,7 +2277,7 @@ mod tests {
             .sys_epoll_create(litebox_common_linux::EpollCreateFlags::empty())
             .expect("failed to create epoll");
         let epfd = i32::try_from(epfd).unwrap();
-        epoll_add(&task, epfd, server_fd, litebox::event::Events::IN);
+        epoll_add(task, epfd, server_fd, litebox::event::Events::IN);
 
         let msg = "Hello from client";
         let mut child = std::process::Command::new("nc")
@@ -2282,14 +2306,13 @@ mod tests {
 
         // Server receives and inspects sender addr
         let mut recv_buf = [0u8; 48];
-        let mut sender_addr = None;
         let mut recv_flags = ReceiveFlags::empty();
-        if test_trunc {
+        if test_trunc && set_trunc_flag {
             recv_flags.insert(ReceiveFlags::TRUNC);
         }
         if is_nonblocking {
             let mut events = [litebox_common_linux::EpollEvent { events: 0, data: 0 }; 2];
-            let n = epoll_wait(&task, epfd, &mut events);
+            let n = epoll_wait(task, epfd, &mut events);
             assert_eq!(n, 1);
             for ev in &events[..n] {
                 assert!(ev.events & litebox::event::Events::IN.bits() != 0);
@@ -2302,18 +2325,56 @@ mod tests {
         } else {
             recv_buf.len()
         };
-        let n = task
-            .do_recvfrom(
-                server_fd,
-                &mut recv_buf[..recv_len],
-                recv_flags,
-                Some(&mut sender_addr),
-            )
-            .expect("recvfrom failed");
-        if test_trunc {
+        let source_addr = [0u8; core::mem::size_of::<CSockInetAddr>()];
+        let n = match op {
+            "recvfrom" => {
+                let mut addrlen = core::mem::size_of::<CSockInetAddr>();
+                task.sys_recvfrom(
+                    i32::try_from(server_fd).unwrap(),
+                    MutPtr::from_usize(recv_buf.as_mut_ptr() as usize),
+                    recv_len,
+                    recv_flags,
+                    Some(MutPtr::from_usize(source_addr.as_ptr() as usize)),
+                    MutPtr::from_usize(&raw mut addrlen as usize),
+                )
+                .expect("recvfrom failed")
+            }
+            "recvmsg" => {
+                let iovec = [litebox_common_linux::IoVec {
+                    iov_base: MutPtr::from_usize(recv_buf.as_mut_ptr() as usize),
+                    iov_len: recv_len,
+                }];
+                let mut msg_hdr = litebox_common_linux::UserMsgHdr::<crate::Platform>::new_zeroed();
+                msg_hdr.msg_iov = ConstPtr::from_usize(iovec.as_ptr() as usize);
+                msg_hdr.msg_iovlen = iovec.len();
+                msg_hdr.msg_name = MutPtr::from_usize(source_addr.as_ptr() as usize);
+                msg_hdr.msg_namelen = source_addr.len().truncate();
+                let msg_ptr = MutPtr::from_usize(&raw mut msg_hdr as usize);
+                let n = task
+                    .sys_recvmsg(i32::try_from(server_fd).unwrap(), msg_ptr, recv_flags)
+                    .expect("recvmsg failed");
+                if test_trunc {
+                    let flags = msg_hdr.msg_flags;
+                    assert!(flags.contains(ReceiveFlags::TRUNC));
+                }
+                n
+            }
+            _ => panic!("Unknown operation"),
+        };
+        let sender_addr = read_sockaddr_from_user(
+            ConstPtr::from_usize(source_addr.as_ptr() as usize),
+            source_addr.len(),
+        )
+        .ok();
+        if test_trunc && set_trunc_flag {
             assert_eq!(n, msg.len()); // return the actual length of the datagram rather than the received length
             assert_eq!(recv_buf[..8], msg.as_bytes()[..8]); // only part of the message is received
-        } else {
+        }
+        if test_trunc && !set_trunc_flag {
+            assert_eq!(n, 8); // returns the size of the copied data, not the actual message length
+            assert_eq!(recv_buf[..n], msg.as_bytes()[..n]);
+        }
+        if !test_trunc {
             assert_eq!(n, msg.len());
             assert_eq!(recv_buf[..n], msg.as_bytes()[..n]);
         }
@@ -2322,24 +2383,31 @@ mod tests {
         };
         assert_eq!(sender_addr.port(), CLIENT_PORT);
 
-        close_socket(&task, server_fd);
+        close_socket(task, server_fd);
 
         child.wait().expect("Failed to wait for client");
     }
 
     #[test]
     fn test_tun_blocking_udp_server_socket() {
-        blocking_udp_server_socket(false, false);
+        let task = init_platform(Some(TUN_DEVICE_NAME));
+        blocking_udp_server_socket(&task, false, false, false, "recvfrom");
+        blocking_udp_server_socket(&task, false, false, false, "recvmsg");
     }
 
     #[test]
     fn test_tun_nonblocking_udp_server_socket() {
-        blocking_udp_server_socket(false, true);
+        let task = init_platform(Some(TUN_DEVICE_NAME));
+        blocking_udp_server_socket(&task, false, false, true, "recvfrom");
+        blocking_udp_server_socket(&task, false, false, true, "recvmsg");
     }
 
     #[test]
     fn test_tun_blocking_udp_server_socket_with_truncation() {
-        blocking_udp_server_socket(true, false);
+        let task = init_platform(Some(TUN_DEVICE_NAME));
+        blocking_udp_server_socket(&task, true, true, false, "recvfrom");
+        blocking_udp_server_socket(&task, true, true, false, "recvmsg");
+        blocking_udp_server_socket(&task, true, false, false, "recvmsg");
     }
 
     #[test]

--- a/litebox_shim_linux/src/syscalls/unix.rs
+++ b/litebox_shim_linux/src/syscalls/unix.rs
@@ -874,19 +874,20 @@ impl ReadEnd<DatagramMessage> {
         buf: &mut [u8],
         mut source_addr: Option<&mut Option<UnixSocketAddr>>,
     ) -> Result<usize, TryOpError<Errno>> {
-        let msg_len = self.peek_and_consume_one(|msg| {
-            let copy_len = buf.len().min(msg.data.len());
-            buf[..copy_len].copy_from_slice(&msg.data[..copy_len]);
-            if let Some(source_addr) = source_addr.as_deref_mut() {
-                *source_addr = Some(msg.source.clone());
-            }
-            // Always consume the entire message to preserve boundaries.
-            Ok((true, msg.data.len()))
-        })
-        .map_err(|e| match e {
-            Errno::EAGAIN => TryOpError::TryAgain,
-            other => TryOpError::Other(other),
-        })?;
+        let msg_len = self
+            .peek_and_consume_one(|msg| {
+                let copy_len = buf.len().min(msg.data.len());
+                buf[..copy_len].copy_from_slice(&msg.data[..copy_len]);
+                if let Some(source_addr) = source_addr.as_deref_mut() {
+                    *source_addr = Some(msg.source.clone());
+                }
+                // Always consume the entire message to preserve boundaries.
+                Ok((true, msg.data.len()))
+            })
+            .map_err(|e| match e {
+                Errno::EAGAIN => TryOpError::TryAgain,
+                other => TryOpError::Other(other),
+            })?;
         Ok(msg_len)
     }
 }

--- a/litebox_shim_linux/src/syscalls/unix.rs
+++ b/litebox_shim_linux/src/syscalls/unix.rs
@@ -874,21 +874,19 @@ impl ReadEnd<DatagramMessage> {
         buf: &mut [u8],
         mut source_addr: Option<&mut Option<UnixSocketAddr>>,
     ) -> Result<usize, TryOpError<Errno>> {
-        let msg_len = self
-            .peek_and_consume_one(|msg| {
-                let copy_len = buf.len().min(msg.data.len());
-                buf[..copy_len].copy_from_slice(&msg.data[..copy_len]);
-                if let Some(source_addr) = source_addr.as_deref_mut() {
-                    *source_addr = Some(msg.source.clone());
-                }
-                // Always consume the entire message to preserve boundaries.
-                Ok((true, msg.data.len()))
-            })
-            .map_err(|e| match e {
-                Errno::EAGAIN => TryOpError::TryAgain,
-                other => TryOpError::Other(other),
-            })?;
-        Ok(msg_len)
+        self.peek_and_consume_one(|msg| {
+            let copy_len = buf.len().min(msg.data.len());
+            buf[..copy_len].copy_from_slice(&msg.data[..copy_len]);
+            if let Some(source_addr) = source_addr.as_deref_mut() {
+                *source_addr = Some(msg.source.clone());
+            }
+            // Always consume the entire message to preserve boundaries.
+            Ok((true, msg.data.len()))
+        })
+        .map_err(|e| match e {
+            Errno::EAGAIN => TryOpError::TryAgain,
+            other => TryOpError::Other(other),
+        })
     }
 }
 

--- a/litebox_shim_linux/src/syscalls/unix.rs
+++ b/litebox_shim_linux/src/syscalls/unix.rs
@@ -864,55 +864,30 @@ impl WriteEnd<DatagramMessage> {
     }
 }
 impl ReadEnd<DatagramMessage> {
-    /// Attempts to read datagram messages without blocking.
+    /// Attempts to read a single datagram message without blocking.
     ///
-    /// Reads multiple messages from the same source address until the buffer
-    /// is full or a message from a different source is encountered.
+    /// Reads exactly one message, preserving message boundaries. If the buffer
+    /// is smaller than the message, the excess data is discarded (truncated).
+    /// Returns the original message size (which may exceed `buf.len()`).
     fn try_read(
         &self,
-        mut buf: &mut [u8],
-        source_addr: Option<&mut Option<UnixSocketAddr>>,
+        buf: &mut [u8],
+        mut source_addr: Option<&mut Option<UnixSocketAddr>>,
     ) -> Result<usize, TryOpError<Errno>> {
-        let mut src = None;
-        let mut total_read = 0;
-        let mut stop = false;
-        while !buf.is_empty() {
-            let n = match self.peek_and_consume_one(|msg| {
-                if src.as_ref().is_some_and(|addr| *addr != msg.source) {
-                    stop = true;
-                    return Ok((false, 0));
-                }
-                if src.is_none() {
-                    src.replace(msg.source.clone());
-                }
-                if buf.len() >= msg.data.len() {
-                    buf[..msg.data.len()].copy_from_slice(&msg.data);
-                    Ok((true, msg.data.len()))
-                } else {
-                    buf.copy_from_slice(&msg.data[..buf.len()]);
-                    msg.data = msg.data.split_off(buf.len());
-                    Ok((false, buf.len()))
-                }
-            }) {
-                Ok(0) if stop => break,
-                Ok(n) => n,
-                Err(e) => {
-                    if total_read > 0 {
-                        break;
-                    }
-                    return match e {
-                        Errno::EAGAIN => Err(TryOpError::TryAgain),
-                        other => Err(TryOpError::Other(other)),
-                    };
-                }
-            };
-            total_read += n;
-            buf = &mut buf[n..];
-        }
-        if let (Some(src), Some(source_addr)) = (src, source_addr) {
-            *source_addr = Some(src);
-        }
-        Ok(total_read)
+        let msg_len = self.peek_and_consume_one(|msg| {
+            let copy_len = buf.len().min(msg.data.len());
+            buf[..copy_len].copy_from_slice(&msg.data[..copy_len]);
+            if let Some(source_addr) = source_addr.as_deref_mut() {
+                *source_addr = Some(msg.source.clone());
+            }
+            // Always consume the entire message to preserve boundaries.
+            Ok((true, msg.data.len()))
+        })
+        .map_err(|e| match e {
+            Errno::EAGAIN => TryOpError::TryAgain,
+            other => TryOpError::Other(other),
+        })?;
+        Ok(msg_len)
     }
 }
 

--- a/litebox_shim_linux/src/syscalls/unix.rs
+++ b/litebox_shim_linux/src/syscalls/unix.rs
@@ -1241,7 +1241,7 @@ impl<FS: ShimFS> UnixSocket<FS> {
         flags: ReceiveFlags,
         source_addr: Option<&mut Option<UnixSocketAddr>>,
     ) -> Result<usize, Errno> {
-        let supported_flags = ReceiveFlags::DONTWAIT;
+        let supported_flags = ReceiveFlags::DONTWAIT | ReceiveFlags::TRUNC;
         if flags.intersects(supported_flags.complement()) {
             log_unsupported!("Unsupported recvfrom flags: {:?}", flags);
             return Err(Errno::EINVAL);


### PR DESCRIPTION
Support syscall [`recvmsg`](https://man7.org/linux/man-pages/man3/recvmsg.3p.html).

Some flags like `MSG_PEEK` is not supported yet but can be added when needed.

Also fix a message boundary issue for datagram unix socket, i.e., one read should only read one message.