### PR TITLE
Updates for Rust 1.95.0

### DIFF
--- a/litebox_packager/src/lib.rs
+++ b/litebox_packager/src/lib.rs
@@ -341,9 +341,7 @@ fn finalize_tar(
         }
         let data = std::fs::read(&inc.host_path)
             .with_context(|| format!("failed to read included file {}", inc.host_path.display()))?;
-        let mode = std::fs::metadata(&inc.host_path)
-            .map(|m| m.mode())
-            .unwrap_or(0o644);
+        let mode = std::fs::metadata(&inc.host_path).map_or(0o644, |m| m.mode());
         if args.verbose {
             eprintln!(
                 "  including {} as {}",
@@ -379,9 +377,7 @@ fn finalize_tar(
     eprintln!("Creating {}...", args.output.display());
     build_tar(&tar_entries, &args.output)?;
 
-    let tar_size = std::fs::metadata(&args.output)
-        .map(|m| m.len())
-        .unwrap_or(0);
+    let tar_size = std::fs::metadata(&args.output).map_or(0, |m| m.len());
     #[allow(clippy::cast_precision_loss)]
     let tar_size_mb = tar_size as f64 / 1_048_576.0;
     eprintln!(

--- a/litebox_platform_lvbs/src/mshv/vsm.rs
+++ b/litebox_platform_lvbs/src/mshv/vsm.rs
@@ -260,8 +260,8 @@ pub fn mshv_vsm_end_of_boot() -> i64 {
 pub fn mshv_vsm_protect_memory(pa: u64, nranges: u64) -> Result<i64, VsmError> {
     if PhysAddr::try_new(pa)
         .ok()
-        .filter(|p| p.is_aligned(Size4KiB::SIZE))
-        .is_none()
+        .as_ref()
+        .is_none_or(|p| !p.is_aligned(Size4KiB::SIZE))
         || nranges == 0
     {
         return Err(VsmError::InvalidInputAddress);
@@ -338,8 +338,8 @@ fn parse_certs(mut buf: &[u8]) -> Result<Vec<Certificate>, VsmError> {
 pub fn mshv_vsm_load_kdata(pa: u64, nranges: u64) -> Result<i64, VsmError> {
     if PhysAddr::try_new(pa)
         .ok()
-        .filter(|p| p.is_aligned(Size4KiB::SIZE))
-        .is_none()
+        .as_ref()
+        .is_none_or(|p| !p.is_aligned(Size4KiB::SIZE))
         || nranges == 0
     {
         return Err(VsmError::InvalidInputAddress);
@@ -468,8 +468,8 @@ pub fn mshv_vsm_load_kdata(pa: u64, nranges: u64) -> Result<i64, VsmError> {
 pub fn mshv_vsm_validate_guest_module(pa: u64, nranges: u64, _flags: u64) -> Result<i64, VsmError> {
     if PhysAddr::try_new(pa)
         .ok()
-        .filter(|p| p.is_aligned(Size4KiB::SIZE))
-        .is_none()
+        .as_ref()
+        .is_none_or(|p| !p.is_aligned(Size4KiB::SIZE))
         || nranges == 0
     {
         return Err(VsmError::InvalidInputAddress);

--- a/litebox_runner_linux_userland/tests/run.rs
+++ b/litebox_runner_linux_userland/tests/run.rs
@@ -259,7 +259,7 @@ fn run_which(prog: &str) -> std::path::PathBuf {
         .stdout;
     let prog_path_str = String::from_utf8(prog_path_str).unwrap().trim().to_string();
     let prog_path = std::path::PathBuf::from(prog_path_str);
-    assert!(prog_path.exists(), "Program binary not found",);
+    assert!(prog_path.exists(), "Program binary not found");
     prog_path
 }
 

--- a/litebox_shim_linux/src/syscalls/epoll.rs
+++ b/litebox_shim_linux/src/syscalls/epoll.rs
@@ -882,7 +882,7 @@ mod test {
                 Some(&mut rfds),
                 None,
                 None,
-                Some(core::time::Duration::from_secs(60)),
+                Some(core::time::Duration::from_mins(1)),
             )
             .expect("pselect failed");
 

--- a/litebox_shim_linux/src/syscalls/net.rs
+++ b/litebox_shim_linux/src/syscalls/net.rs
@@ -345,7 +345,7 @@ impl<FS: ShimFS> GlobalState<FS> {
                         deferred_tcp_option = Some(if keep_alive {
                             // default time interval is 2 hours
                             litebox::net::TcpOptionData::KEEPALIVE(Some(
-                                core::time::Duration::from_secs(2 * 60 * 60),
+                                core::time::Duration::from_hours(2),
                             ))
                         } else {
                             litebox::net::TcpOptionData::KEEPALIVE(None)
@@ -2208,7 +2208,7 @@ mod tests {
                 ])
                 .output()
         });
-        std::thread::sleep(core::time::Duration::from_millis(1000));
+        std::thread::sleep(core::time::Duration::from_secs(1));
 
         // Client socket
         let client_fd = task
@@ -2446,7 +2446,7 @@ mod tests {
             .expect("Failed to get TCP_CONGESTION");
         assert_eq!(optlen, 4);
         assert_eq!(
-            core::str::from_utf8(&congestion_name[..optlen as usize]).unwrap(),
+            core::str::from_utf8(&congestion_name[..optlen]).unwrap(),
             "none"
         );
 
@@ -2454,7 +2454,7 @@ mod tests {
             sockfd,
             SocketOptionName::TCP(TcpOption::CONGESTION),
             ConstPtr::from_usize(congestion_name.as_ptr() as usize),
-            optlen as usize,
+            optlen,
         )
         .expect("Failed to set TCP_CONGESTION");
 

--- a/litebox_shim_linux/src/syscalls/tests.rs
+++ b/litebox_shim_linux/src/syscalls/tests.rs
@@ -411,7 +411,7 @@ fn test_umask_behavior() {
     let _ = task.sys_umask(orig); // restore original
 
     // We expect the default (from implementation) to be 0o022.
-    assert_eq!(orig, 0o022, "Default umask should be 022 (got {orig:03o})",);
+    assert_eq!(orig, 0o022, "Default umask should be 022 (got {orig:03o})");
 
     // 2. Set a new umask (e.g., 0o077) and verify file creation honors it.
     let prev = task.sys_umask(0o077).bits();


### PR DESCRIPTION
[Rust 1.95.0 released today](https://blog.rust-lang.org/2026/04/16/Rust-1.95.0/). This PR makes some necessary updates due to newly-triggered warnings.