### PR TITLE
fix lseek/getdirent64 for dir

### DIFF
--- a/litebox/src/fs/mod.rs
+++ b/litebox/src/fs/mod.rs
@@ -272,6 +272,7 @@ bitflags! {
 }
 
 /// The `whence` directive to [`FileSystem::seek`]
+#[derive(Copy, Clone)]
 pub enum SeekWhence {
     /// The file offset is set to `offset` bytes.
     RelativeToBeginning,

--- a/litebox_shim_linux/src/syscalls/file.rs
+++ b/litebox_shim_linux/src/syscalls/file.rs
@@ -2091,6 +2091,10 @@ impl<FS: ShimFS> Task<FS> {
                         .next_multiple_of(align_of::<litebox_common_linux::LinuxDirent64>());
                     if nbytes + len > count {
                         // not enough space
+                        if nbytes == 0 {
+                            // not enough space for even a single entry
+                            return Err(Errno::EINVAL);
+                        }
                         break;
                     }
                     let dirent64 = litebox_common_linux::LinuxDirent64 {
@@ -2126,11 +2130,11 @@ impl<FS: ShimFS> Task<FS> {
                     .set_fd_metadata(file, Diroff(dir_off));
                 Ok(nbytes)
             },
-            |_fd| todo!("net"),
-            |_fd| todo!("pipes"),
-            |_fd| Err(Errno::EBADF),
-            |_fd| Err(Errno::EBADF),
-            |_fd| Err(Errno::EBADF),
+            |_fd| Err(Errno::ENOTDIR),
+            |_fd| Err(Errno::ENOTDIR),
+            |_fd| Err(Errno::ENOTDIR),
+            |_fd| Err(Errno::ENOTDIR),
+            |_fd| Err(Errno::ENOTDIR),
         )?
     }
 }

--- a/litebox_shim_linux/src/syscalls/file.rs
+++ b/litebox_shim_linux/src/syscalls/file.rs
@@ -458,7 +458,30 @@ impl<FS: ShimFS> Task<FS> {
         files
             .run_on_raw_fd(
                 raw_fd,
-                |fd| files.fs.seek(fd, offset, whence).map_err(Errno::from),
+                |fd| match files.fs.seek(fd, offset, whence) {
+                    Ok(pos) => Ok(pos),
+                    Err(litebox::fs::errors::SeekError::NotAFile) => {
+                        let base: usize = match whence {
+                            SeekWhence::RelativeToBeginning => 0,
+                            SeekWhence::RelativeToCurrentOffset => self
+                                .global
+                                .litebox
+                                .descriptor_table()
+                                .with_metadata(fd, |off: &Diroff| off.0)
+                                .unwrap_or(0),
+                            SeekWhence::RelativeToEnd => {
+                                return Err(Errno::EINVAL);
+                            }
+                        };
+                        let new_pos = base.checked_add_signed(offset).ok_or(Errno::EINVAL)?;
+                        self.global
+                            .litebox
+                            .descriptor_table_mut()
+                            .set_fd_metadata(fd, Diroff(new_pos));
+                        Ok(new_pos)
+                    }
+                    Err(e) => Err(Errno::from(e)),
+                },
                 |_| Err(Errno::ESPIPE),
                 |_| Err(Errno::ESPIPE),
                 |_| Err(Errno::ESPIPE),

--- a/litebox_shim_linux/src/syscalls/tests.rs
+++ b/litebox_shim_linux/src/syscalls/tests.rs
@@ -327,7 +327,11 @@ fn test_getdent64() {
 
     // Test 5: Zero-length buffer
     let result = task.sys_getdirent64(dir_fd, MutPtr::from_usize(buffer.as_mut_ptr() as usize), 0);
-    assert_eq!(result, Ok(0), "Should return 0 for zero-length buffer");
+    assert_eq!(
+        result,
+        Err(Errno::EINVAL),
+        "Should return EINVAL for zero-length buffer"
+    );
 
     task.sys_close(dir_fd).expect("Failed to close directory");
 


### PR DESCRIPTION
`lseek` should also work on directory fd, though `offset` of a directory is opaque to user. The common use case should be resetting offset to zero. Setting offset to arbitrary value is a undefined behavior.

Also fix `sys_getdirent64` to return correct error code.