### PR TITLE
Use COM1 as serial port on Azure

### DIFF
--- a/litebox_platform_lvbs/Cargo.toml
+++ b/litebox_platform_lvbs/Cargo.toml
@@ -44,6 +44,7 @@ litebox_util_log = { version = "0.1.0", path = "../litebox_util_log" }
 default = ["optee_syscall"]
 optee_syscall = []
 linux_syscall = []
+devbox = []
 
 [lints]
 workspace = true

--- a/litebox_platform_lvbs/src/arch/x86/ioport.rs
+++ b/litebox_platform_lvbs/src/arch/x86/ioport.rs
@@ -7,8 +7,13 @@ use crate::mshv::ringbuffer::ringbuffer;
 use core::{arch::asm, fmt};
 use spin::{Mutex, Once};
 
-// LVBS uses COM PORT 2 for printing out debug messages
-const COM_PORT_2: u16 = 0x2F8;
+// devbox uses COM PORT 2
+#[cfg(feature = "devbox")]
+const DEST_COM_PORT: u16 = 0x2F8;
+
+// all other configurations use COM PORT 1
+#[cfg(not(feature = "devbox"))]
+const DEST_COM_PORT: u16 = 0x3F8;
 
 const INTERRUPT_ENABLE_OFFSET: u16 = 1;
 const OUT_FIFO_CONTROL_OFFSET: u16 = 2;
@@ -136,7 +141,7 @@ impl ComPort {
 fn com() -> &'static Mutex<ComPort> {
     static COM_ONCE: Once<Mutex<ComPort>> = Once::new();
     COM_ONCE.call_once(|| {
-        let mut com_port = ComPort::new(COM_PORT_2);
+        let mut com_port = ComPort::new(DEST_COM_PORT);
         com_port.init();
         Mutex::new(com_port)
     })

--- a/litebox_runner_lvbs/Cargo.toml
+++ b/litebox_runner_lvbs/Cargo.toml
@@ -19,5 +19,8 @@ once_cell = { version = "1.21.3", default-features = false, features = ["race", 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 x86_64 = { version = "0.15.2", default-features = false, features = ["instructions"] }
 
+[features]
+devbox = ["litebox_platform_lvbs/devbox"]
+
 [lints]
 workspace = true


### PR DESCRIPTION
Azure VMs do not support COM2 port. So set the default serial port to COM1.

If built with `--devbox` (the newly introduced) feature, LiteBox will use COM2 as the serial port.