### PR TITLE
Fix: Adjust max log level for LVBS

### DIFF
--- a/litebox_runner_lvbs/src/main.rs
+++ b/litebox_runner_lvbs/src/main.rs
@@ -449,7 +449,7 @@ unsafe extern "C" fn kernel_main(is_bsp: bool) -> ! {
         #[cfg(debug_assertions)]
         log::set_max_level(log::LevelFilter::Debug);
         #[cfg(not(debug_assertions))]
-        log::set_max_level(log::LevelFilter::Info);
+        log::set_max_level(log::LevelFilter::Warn);
 
         serial_println!("==============================");
         serial_println!(" Hello from LiteBox for LVBS! ");

--- a/litebox_runner_lvbs/src/main.rs
+++ b/litebox_runner_lvbs/src/main.rs
@@ -446,7 +446,10 @@ pub unsafe extern "C" fn _start() -> ! {
 unsafe extern "C" fn kernel_main(is_bsp: bool) -> ! {
     if is_bsp {
         let _ = log::set_logger(&HOST_LOGGER);
-        log::set_max_level(log::LevelFilter::Trace);
+        #[cfg(debug_assertions)]
+        log::set_max_level(log::LevelFilter::Debug);
+        #[cfg(not(debug_assertions))]
+        log::set_max_level(log::LevelFilter::Info);
 
         serial_println!("==============================");
         serial_println!(" Hello from LiteBox for LVBS! ");


### PR DESCRIPTION
This PR adjusts the max log level for LVBS. In particular, `log::LevelFilter::Trace` generates too many logs for LVBS, resulting in VTL0 kernel panic due to CPU stuck (the VTL0 kernel cannot interrupt the VTL1 kernel.)