### PR TITLE
Shebang support

### DIFF
--- a/litebox/src/fd/mod.rs
+++ b/litebox/src/fd/mod.rs
@@ -624,7 +624,7 @@ impl RawDescriptorStorage {
         // If this assertion failure is hit in practice, we might need to be more defensive via the
         // HashMap, rather than just silently allow big growth
         assert!(
-            raw_fd < self.stored_fds.len() + 100,
+            raw_fd < self.stored_fds.len() + 256,
             "explicit upper bound restriction for now; see implementation details"
         );
         if self.stored_fds.get(raw_fd).is_some_and(Option::is_some) {

--- a/litebox_runner_linux_userland/tests/run.rs
+++ b/litebox_runner_linux_userland/tests/run.rs
@@ -112,6 +112,13 @@ impl Runner {
         self
     }
 
+    #[cfg(target_arch = "x86_64")]
+    fn program_from_tar(&mut self, guest_path: &str) -> &mut Self {
+        self.command.arg("--program-from-tar");
+        self.cmd_path = PathBuf::from(guest_path);
+        self
+    }
+
     #[cfg_attr(not(target_arch = "x86_64"), expect(dead_code))]
     fn with_fs_path(&mut self, f: impl FnOnce(&Path)) -> &mut Self {
         f(&self.tar_dir);
@@ -566,4 +573,34 @@ fn test_tun_with_curl() {
 
     let output_str = String::from_utf8_lossy(&output);
     assert!(output_str.contains(RESPONSE_BODY), "Unexpected curl output");
+}
+
+#[cfg(target_arch = "x86_64")]
+#[test]
+fn test_shebang() {
+    let bash_path = run_which("bash");
+
+    let output = Runner::new(Backend::Rewriter, &bash_path, "shebang_rewriter")
+        .with_fs_path(|out_dir| {
+            // Place a rewritten copy of bash inside the guest filesystem so the
+            // shebang interpreter path resolves.
+            let guest_bash = out_dir.join("out/bash");
+            let success = common::rewrite_with_cache(&bash_path, &guest_bash, &[]);
+            assert!(success, "failed to rewrite bash for guest FS");
+
+            // Create a shebang script pointing to the guest bash.
+            std::fs::write(
+                out_dir.join("out/script.sh"),
+                "#!/out/bash\necho shebang_test_passed\n",
+            )
+            .unwrap();
+        })
+        .program_from_tar("/out/script.sh")
+        .output();
+
+    let output_str = String::from_utf8_lossy(&output);
+    assert!(
+        output_str.contains("shebang_test_passed"),
+        "shebang test failed, output: {output_str}"
+    );
 }

--- a/litebox_runner_linux_userland/tests/run.rs
+++ b/litebox_runner_linux_userland/tests/run.rs
@@ -580,7 +580,7 @@ fn test_tun_with_curl() {
 fn test_shebang() {
     let bash_path = run_which("bash");
 
-    let output = Runner::new(Backend::Rewriter, &bash_path, "shebang_rewriter")
+    let output = Runner::new(&bash_path, "shebang_rewriter")
         .with_fs_path(|out_dir| {
             // Place a rewritten copy of bash inside the guest filesystem so the
             // shebang interpreter path resolves.

--- a/litebox_shim_linux/src/lib.rs
+++ b/litebox_shim_linux/src/lib.rs
@@ -257,8 +257,6 @@ impl<FS: ShimFS> LinuxShim<FS> {
             },
         };
 
-        // Shebang (#!) detection: if the target file starts with "#!", rewrite
-        // path/argv to the interpreter, matching sys_execve behaviour.
         let (path, argv) = entrypoints
             .task
             .resolve_shebang(alloc::string::String::from(path), argv)

--- a/litebox_shim_linux/src/lib.rs
+++ b/litebox_shim_linux/src/lib.rs
@@ -256,8 +256,16 @@ impl<FS: ShimFS> LinuxShim<FS> {
                 signals: syscalls::signal::SignalState::new_process(),
             },
         };
+
+        // Shebang (#!) detection: if the target file starts with "#!", rewrite
+        // path/argv to the interpreter, matching sys_execve behaviour.
+        let (path, argv) = entrypoints
+            .task
+            .resolve_shebang(alloc::string::String::from(path), argv)
+            .map_err(loader::elf::ElfLoaderError::OpenError)?;
+
         entrypoints.task.load_program(
-            loader::elf::ElfLoader::new(&entrypoints.task, path)?,
+            loader::elf::ElfLoader::new(&entrypoints.task, &path)?,
             argv,
             envp,
         )?;

--- a/litebox_shim_linux/src/syscalls/file.rs
+++ b/litebox_shim_linux/src/syscalls/file.rs
@@ -1588,9 +1588,8 @@ impl<FS: ShimFS> Task<FS> {
                 |_fd| Err(Errno::ENOTTY),
             )?,
             _ => {
-                #[cfg(debug_assertions)]
-                litebox_util_log::debug!(arg:? = arg; "unhandled ioctl");
-                todo!()
+                log_unsupported!("ioctl with arg {:?}", arg);
+                Err(Errno::EINVAL)
             }
         }
     }

--- a/litebox_shim_linux/src/syscalls/file.rs
+++ b/litebox_shim_linux/src/syscalls/file.rs
@@ -289,16 +289,24 @@ impl<FS: ShimFS> Task<FS> {
     /// `offset` is an optional offset to read from. If `None`, it will read from the current file position.
     /// If `Some`, it will read from the specified offset without changing the current file position.
     pub fn sys_read(&self, fd: i32, buf: &mut [u8], offset: Option<usize>) -> Result<usize, Errno> {
-        let Ok(raw_fd) = u32::try_from(fd).and_then(usize::try_from) else {
+        let Ok(raw_fd) = u32::try_from(fd) else {
             return Err(Errno::EBADF);
         };
+        self.do_read(raw_fd, buf, offset)
+    }
+    pub(crate) fn do_read(
+        &self,
+        fd: u32,
+        buf: &mut [u8],
+        offset: Option<usize>,
+    ) -> Result<usize, Errno> {
         let files = self.files.borrow();
         // We need to do this cell dance because otherwise Rust can't recognize that the two
         // closures are mutually exclusive.
         let buf: core::cell::RefCell<&mut [u8]> = core::cell::RefCell::new(buf);
         files
             .run_on_raw_fd(
-                raw_fd,
+                fd as usize,
                 |fd| {
                     files
                         .fs

--- a/litebox_shim_linux/src/syscalls/process.rs
+++ b/litebox_shim_linux/src/syscalls/process.rs
@@ -1307,7 +1307,7 @@ impl<FS: ShimFS> Task<FS> {
 const MAX_VEC: usize = 4096; // limit count
 const MAX_TOTAL_BYTES: usize = 256 * 1024; // size cap
 
-/// Maximum shebang (#!) recursion depth, matching Linux `BINPRM_MAX_RECURSION`.
+/// Maximum shebang (#!) recursion depth
 const SHEBANG_MAX_RECURSION: u32 = 4;
 
 /// Maximum length of a shebang line that we inspect. Matches Linux `BINPRM_BUF_SIZE`.

--- a/litebox_shim_linux/src/syscalls/process.rs
+++ b/litebox_shim_linux/src/syscalls/process.rs
@@ -1307,8 +1307,8 @@ impl<FS: ShimFS> Task<FS> {
 const MAX_VEC: usize = 4096; // limit count
 const MAX_TOTAL_BYTES: usize = 256 * 1024; // size cap
 
-/// Maximum shebang (#!) recursion depth
-const SHEBANG_MAX_RECURSION: u32 = 4;
+/// Maximum shebang (#!) recursion depth (from Linux's `exec_binprm`)
+const SHEBANG_MAX_RECURSION: u32 = 6;
 
 /// Maximum length of a shebang line that we inspect. Matches Linux `BINPRM_BUF_SIZE`.
 const SHEBANG_MAX_LINE: usize = 256;

--- a/litebox_shim_linux/src/syscalls/process.rs
+++ b/litebox_shim_linux/src/syscalls/process.rs
@@ -835,7 +835,10 @@ impl<FS: ShimFS> Task<FS> {
             | litebox_common_linux::RlimitResource::STACK => {
                 self.thread.process.limits.get_rlimit(resource)
             }
-            _ => unimplemented!("Unsupported resource for get_rlimit: {:?}", resource),
+            _ => {
+                log_unsupported!("Unsupported resource for get_rlimit: {:?}", resource);
+                return Err(Errno::EINVAL);
+            }
         };
         if let Some(new_limit) = new_limit {
             if new_limit.rlim_cur > new_limit.rlim_max {
@@ -1340,6 +1343,64 @@ fn parse_shebang(buf: &[u8]) -> Option<(&str, Option<&str>)> {
 }
 
 impl<FS: ShimFS> Task<FS> {
+    /// Resolve shebang (`#!`) chains for the given path and argv.
+    ///
+    /// Opens the file at `path`, reads its header, and—if it begins with a
+    /// `#!` shebang line—rewrites `path` and `argv` to reference the
+    /// interpreter. This loops up to [`SHEBANG_MAX_RECURSION`] times to
+    /// support chained shebangs (e.g. a script whose interpreter is itself a
+    /// script). Returns the final (path, argv) once an ELF (or other
+    /// non-shebang) binary is reached.
+    pub(crate) fn resolve_shebang(
+        &self,
+        mut path: alloc::string::String,
+        mut argv: alloc::vec::Vec<alloc::ffi::CString>,
+    ) -> Result<(alloc::string::String, alloc::vec::Vec<alloc::ffi::CString>), Errno> {
+        let mut depth = 0u32;
+        loop {
+            let fd = {
+                use litebox::utils::ReinterpretSignedExt as _;
+                self.sys_open(
+                    path.as_str(),
+                    litebox::fs::OFlags::RDONLY,
+                    litebox::fs::Mode::empty(),
+                )?
+                .reinterpret_as_signed()
+            };
+            let mut header = [0u8; SHEBANG_MAX_LINE];
+            let n = match self.sys_read(fd, &mut header, Some(0)) {
+                Ok(n) => n,
+                Err(e) => {
+                    let _ = self.sys_close(fd);
+                    return Err(e);
+                }
+            };
+            let _ = self.sys_close(fd);
+
+            match parse_shebang(&header[..n]) {
+                Some((interp, opt_arg)) => {
+                    if depth >= SHEBANG_MAX_RECURSION {
+                        return Err(Errno::ELOOP);
+                    }
+                    let mut new_argv = alloc::vec::Vec::new();
+                    new_argv.push(alloc::ffi::CString::new(interp).map_err(|_| Errno::EINVAL)?);
+                    if let Some(arg) = opt_arg {
+                        new_argv.push(alloc::ffi::CString::new(arg).map_err(|_| Errno::EINVAL)?);
+                    }
+                    new_argv
+                        .push(alloc::ffi::CString::new(path.as_str()).map_err(|_| Errno::EINVAL)?);
+                    if argv.len() > 1 {
+                        new_argv.extend_from_slice(&argv[1..]);
+                    }
+                    path = alloc::string::String::from(interp);
+                    argv = new_argv;
+                    depth += 1;
+                }
+                None => return Ok((path, argv)),
+            }
+        }
+    }
+
     /// Handle syscall `execve`.
     pub(crate) fn sys_execve(
         &self,
@@ -1398,64 +1459,9 @@ impl<FS: ShimFS> Task<FS> {
         };
 
         // --- Shebang (#!) detection and rewriting ---
-        //
-        // If the target file begins with "#!", it is an interpreter script.
-        // We parse the interpreter path (and optional single argument) from the
-        // first line, then rewrite argv to:
-        //
-        //   [interpreter, optional_arg?, script_path, original_argv[1:]]
-        //
-        // and retry with the interpreter as the new executable. This matches
-        // Linux kernel binfmt_script semantics. We loop (up to
-        // SHEBANG_MAX_RECURSION times) to handle chained shebangs (e.g., a
-        // script whose interpreter is itself a script).
-        let mut path = alloc::string::String::from(path);
-        let mut argv_vec = argv_vec;
-        let mut shebang_depth = 0u32;
-        loop {
-            let fd = {
-                use litebox::utils::ReinterpretSignedExt as _;
-                self.sys_open(
-                    path.as_str(),
-                    litebox::fs::OFlags::RDONLY,
-                    litebox::fs::Mode::empty(),
-                )?
-                .reinterpret_as_signed()
-            };
-            let mut header = [0u8; SHEBANG_MAX_LINE];
-            let n = match self.sys_read(fd, &mut header, Some(0)) {
-                Ok(n) => n,
-                Err(e) => {
-                    let _ = self.sys_close(fd);
-                    return Err(e);
-                }
-            };
-            let _ = self.sys_close(fd);
+        let (path, argv_vec) = self.resolve_shebang(alloc::string::String::from(path), argv_vec)?;
 
-            match parse_shebang(&header[..n]) {
-                Some((interp, opt_arg)) => {
-                    if shebang_depth >= SHEBANG_MAX_RECURSION {
-                        return Err(Errno::ELOOP);
-                    }
-                    let mut new_argv = alloc::vec::Vec::new();
-                    new_argv.push(alloc::ffi::CString::new(interp).map_err(|_| Errno::EINVAL)?);
-                    if let Some(arg) = opt_arg {
-                        new_argv.push(alloc::ffi::CString::new(arg).map_err(|_| Errno::EINVAL)?);
-                    }
-                    new_argv
-                        .push(alloc::ffi::CString::new(path.as_str()).map_err(|_| Errno::EINVAL)?);
-                    if argv_vec.len() > 1 {
-                        new_argv.extend_from_slice(&argv_vec[1..]);
-                    }
-                    path = alloc::string::String::from(interp);
-                    argv_vec = new_argv;
-                    shebang_depth += 1;
-                }
-                None => break,
-            }
-        }
-
-        let loader = crate::loader::elf::ElfLoader::new(self, &path).map_err(Errno::from)?;
+        let loader = crate::loader::elf::ElfLoader::new(self, &path)?;
 
         // After this point, the old program is torn down and failures must terminate the process.
 

--- a/litebox_shim_linux/src/syscalls/process.rs
+++ b/litebox_shim_linux/src/syscalls/process.rs
@@ -1316,8 +1316,7 @@ const SHEBANG_MAX_LINE: usize = 256;
 /// Parse a `#!interpreter [optional-arg]` line from a file header buffer.
 ///
 /// Returns `Some((interpreter, optional_arg))` when `buf` starts with `#!` and
-/// contains a non-empty interpreter path. The interpreter and optional argument
-/// are borrowed from `buf`. The optional argument, if present, is everything
+/// contains a non-empty interpreter path. The optional argument, if present, is everything
 /// between the first whitespace after the interpreter and the end of the line
 /// (trimmed), treated as a single token — matching Linux kernel semantics.
 fn parse_shebang(buf: &[u8]) -> Option<(&str, Option<&str>)> {
@@ -1343,45 +1342,31 @@ fn parse_shebang(buf: &[u8]) -> Option<(&str, Option<&str>)> {
 }
 
 impl<FS: ShimFS> Task<FS> {
-    /// Resolve shebang (`#!`) chains for the given path and argv.
-    ///
-    /// Opens the file at `path`, reads its header, and—if it begins with a
-    /// `#!` shebang line—rewrites `path` and `argv` to reference the
-    /// interpreter. This loops up to [`SHEBANG_MAX_RECURSION`] times to
-    /// support chained shebangs (e.g. a script whose interpreter is itself a
-    /// script). Returns the final (path, argv) once an ELF (or other
-    /// non-shebang) binary is reached.
+    /// Resolve shebang (`#!`) chains for the given path and argv if the file starts with a shebang line.
+    /// Otherwise, returns the original path and argv.
     pub(crate) fn resolve_shebang(
         &self,
         mut path: alloc::string::String,
         mut argv: alloc::vec::Vec<alloc::ffi::CString>,
     ) -> Result<(alloc::string::String, alloc::vec::Vec<alloc::ffi::CString>), Errno> {
-        let mut depth = 0u32;
-        loop {
-            let fd = {
-                use litebox::utils::ReinterpretSignedExt as _;
-                self.sys_open(
-                    path.as_str(),
-                    litebox::fs::OFlags::RDONLY,
-                    litebox::fs::Mode::empty(),
-                )?
-                .reinterpret_as_signed()
-            };
+        for _ in 0..SHEBANG_MAX_RECURSION {
+            let fd = self.sys_open(
+                path.as_str(),
+                litebox::fs::OFlags::RDONLY,
+                litebox::fs::Mode::empty(),
+            )?;
             let mut header = [0u8; SHEBANG_MAX_LINE];
-            let n = match self.sys_read(fd, &mut header, Some(0)) {
+            let n = match self.do_read(fd, &mut header, Some(0)) {
                 Ok(n) => n,
                 Err(e) => {
-                    let _ = self.sys_close(fd);
+                    let _ = self.do_close(fd as usize);
                     return Err(e);
                 }
             };
-            let _ = self.sys_close(fd);
+            let _ = self.do_close(fd as usize);
 
             match parse_shebang(&header[..n]) {
                 Some((interp, opt_arg)) => {
-                    if depth >= SHEBANG_MAX_RECURSION {
-                        return Err(Errno::ELOOP);
-                    }
                     let mut new_argv = alloc::vec::Vec::new();
                     new_argv.push(alloc::ffi::CString::new(interp).map_err(|_| Errno::EINVAL)?);
                     if let Some(arg) = opt_arg {
@@ -1394,11 +1379,11 @@ impl<FS: ShimFS> Task<FS> {
                     }
                     path = alloc::string::String::from(interp);
                     argv = new_argv;
-                    depth += 1;
                 }
                 None => return Ok((path, argv)),
             }
         }
+        Err(Errno::ELOOP)
     }
 
     /// Handle syscall `execve`.

--- a/litebox_shim_linux/src/syscalls/process.rs
+++ b/litebox_shim_linux/src/syscalls/process.rs
@@ -1443,7 +1443,6 @@ impl<FS: ShimFS> Task<FS> {
             copy_vector(envp, "envp")?
         };
 
-        // --- Shebang (#!) detection and rewriting ---
         let (path, argv_vec) = self.resolve_shebang(alloc::string::String::from(path), argv_vec)?;
 
         let loader = crate::loader::elf::ElfLoader::new(self, &path)?;

--- a/litebox_shim_linux/src/syscalls/process.rs
+++ b/litebox_shim_linux/src/syscalls/process.rs
@@ -1304,6 +1304,41 @@ impl<FS: ShimFS> Task<FS> {
 const MAX_VEC: usize = 4096; // limit count
 const MAX_TOTAL_BYTES: usize = 256 * 1024; // size cap
 
+/// Maximum shebang (#!) recursion depth, matching Linux `BINPRM_MAX_RECURSION`.
+const SHEBANG_MAX_RECURSION: u32 = 4;
+
+/// Maximum length of a shebang line that we inspect. Matches Linux `BINPRM_BUF_SIZE`.
+const SHEBANG_MAX_LINE: usize = 256;
+
+/// Parse a `#!interpreter [optional-arg]` line from a file header buffer.
+///
+/// Returns `Some((interpreter, optional_arg))` when `buf` starts with `#!` and
+/// contains a non-empty interpreter path. The interpreter and optional argument
+/// are borrowed from `buf`. The optional argument, if present, is everything
+/// between the first whitespace after the interpreter and the end of the line
+/// (trimmed), treated as a single token — matching Linux kernel semantics.
+fn parse_shebang(buf: &[u8]) -> Option<(&str, Option<&str>)> {
+    if buf.len() < 2 || buf[0] != b'#' || buf[1] != b'!' {
+        return None;
+    }
+    let line_end = buf[2..]
+        .iter()
+        .position(|&b| b == b'\n')
+        .map_or(buf.len(), |p| p + 2);
+    let line = core::str::from_utf8(&buf[2..line_end]).ok()?;
+    let line = line.trim();
+    if line.is_empty() {
+        return None;
+    }
+    match line.find([' ', '\t']) {
+        Some(i) => {
+            let arg = line[i..].trim();
+            Some((&line[..i], if arg.is_empty() { None } else { Some(arg) }))
+        }
+        None => Some((line, None)),
+    }
+}
+
 impl<FS: ShimFS> Task<FS> {
     /// Handle syscall `execve`.
     pub(crate) fn sys_execve(
@@ -1362,7 +1397,65 @@ impl<FS: ShimFS> Task<FS> {
             copy_vector(envp, "envp")?
         };
 
-        let loader = crate::loader::elf::ElfLoader::new(self, path)?;
+        // --- Shebang (#!) detection and rewriting ---
+        //
+        // If the target file begins with "#!", it is an interpreter script.
+        // We parse the interpreter path (and optional single argument) from the
+        // first line, then rewrite argv to:
+        //
+        //   [interpreter, optional_arg?, script_path, original_argv[1:]]
+        //
+        // and retry with the interpreter as the new executable. This matches
+        // Linux kernel binfmt_script semantics. We loop (up to
+        // SHEBANG_MAX_RECURSION times) to handle chained shebangs (e.g., a
+        // script whose interpreter is itself a script).
+        let mut path = alloc::string::String::from(path);
+        let mut argv_vec = argv_vec;
+        let mut shebang_depth = 0u32;
+        loop {
+            let fd = {
+                use litebox::utils::ReinterpretSignedExt as _;
+                self.sys_open(
+                    path.as_str(),
+                    litebox::fs::OFlags::RDONLY,
+                    litebox::fs::Mode::empty(),
+                )?
+                .reinterpret_as_signed()
+            };
+            let mut header = [0u8; SHEBANG_MAX_LINE];
+            let n = match self.sys_read(fd, &mut header, Some(0)) {
+                Ok(n) => n,
+                Err(e) => {
+                    let _ = self.sys_close(fd);
+                    return Err(e);
+                }
+            };
+            let _ = self.sys_close(fd);
+
+            match parse_shebang(&header[..n]) {
+                Some((interp, opt_arg)) => {
+                    if shebang_depth >= SHEBANG_MAX_RECURSION {
+                        return Err(Errno::ELOOP);
+                    }
+                    let mut new_argv = alloc::vec::Vec::new();
+                    new_argv.push(alloc::ffi::CString::new(interp).map_err(|_| Errno::EINVAL)?);
+                    if let Some(arg) = opt_arg {
+                        new_argv.push(alloc::ffi::CString::new(arg).map_err(|_| Errno::EINVAL)?);
+                    }
+                    new_argv
+                        .push(alloc::ffi::CString::new(path.as_str()).map_err(|_| Errno::EINVAL)?);
+                    if argv_vec.len() > 1 {
+                        new_argv.extend_from_slice(&argv_vec[1..]);
+                    }
+                    path = alloc::string::String::from(interp);
+                    argv_vec = new_argv;
+                    shebang_depth += 1;
+                }
+                None => break,
+            }
+        }
+
+        let loader = crate::loader::elf::ElfLoader::new(self, &path).map_err(Errno::from)?;
 
         // After this point, the old program is torn down and failures must terminate the process.
 
@@ -1870,5 +1963,53 @@ mod tests {
             // Clean up the timer.
             handle.delete_timer();
         });
+    }
+
+    #[test]
+    fn test_parse_shebang_basic() {
+        use super::parse_shebang;
+
+        // Basic interpreter only
+        assert_eq!(
+            parse_shebang(b"#!/bin/bash\necho hello\n"),
+            Some(("/bin/bash", None))
+        );
+
+        // Interpreter with single argument
+        assert_eq!(
+            parse_shebang(b"#!/usr/bin/env python3\nimport sys\n"),
+            Some(("/usr/bin/env", Some("python3")))
+        );
+
+        // Leading spaces after #!
+        assert_eq!(parse_shebang(b"#!  /bin/sh\n"), Some(("/bin/sh", None)));
+
+        // Trailing spaces
+        assert_eq!(parse_shebang(b"#!/bin/sh  \n"), Some(("/bin/sh", None)));
+
+        // Argument with extra whitespace
+        assert_eq!(
+            parse_shebang(b"#!/usr/bin/env  -S python3\n"),
+            Some(("/usr/bin/env", Some("-S python3")))
+        );
+
+        // No newline (truncated line — still valid)
+        assert_eq!(parse_shebang(b"#!/bin/bash"), Some(("/bin/bash", None)));
+
+        // Not a shebang
+        assert_eq!(parse_shebang(b"\x7fELF"), None);
+
+        // Empty after #!
+        assert_eq!(parse_shebang(b"#!\n"), None);
+
+        // Too short
+        assert_eq!(parse_shebang(b"#"), None);
+        assert_eq!(parse_shebang(b""), None);
+
+        // Tab separator
+        assert_eq!(
+            parse_shebang(b"#!/usr/bin/env\tpython3\n"),
+            Some(("/usr/bin/env", Some("python3")))
+        );
     }
 }


### PR DESCRIPTION
Add shebang support for `execve` and the initial program to run.

To make the test run, I changed some `unimplemented` and `todo` to log + returning `EINVAL`.