### PR TITLE
Implement SIGPIPE delivery on EPIPE

### DIFF
--- a/litebox_shim_linux/src/syscalls/file.rs
+++ b/litebox_shim_linux/src/syscalls/file.rs
@@ -22,7 +22,7 @@ use litebox_common_linux::{
 };
 use litebox_platform_multiplex::Platform;
 
-use crate::{ConstPtr, GlobalState, MutPtr, ShimFS, Task, syscalls::signal::siginfo_kill};
+use crate::{ConstPtr, GlobalState, MutPtr, ShimFS, Task, syscalls::signal};
 use core::sync::atomic::{AtomicUsize, Ordering};
 
 /// Task state shared by `CLONE_FS`.
@@ -504,7 +504,7 @@ impl<FS: ShimFS> Task<FS> {
             )
             .flatten();
         if let Err(Errno::EPIPE) = res {
-            self.send_signal(Signal::SIGPIPE, siginfo_kill(Signal::SIGPIPE));
+            self.send_signal(Signal::SIGPIPE, signal::siginfo_kill(Signal::SIGPIPE));
         }
         res
     }
@@ -788,7 +788,7 @@ impl<FS: ShimFS> Task<FS> {
             )
             .flatten();
         if let Err(Errno::EPIPE) = res {
-            self.send_signal(Signal::SIGPIPE, siginfo_kill(Signal::SIGPIPE));
+            self.send_signal(Signal::SIGPIPE, signal::siginfo_kill(Signal::SIGPIPE));
         }
         res
     }

--- a/litebox_shim_linux/src/syscalls/file.rs
+++ b/litebox_shim_linux/src/syscalls/file.rs
@@ -18,11 +18,11 @@ use litebox::{
 };
 use litebox_common_linux::{
     AtFlags, EfdFlags, EpollCreateFlags, FcntlArg, FileDescriptorFlags, FileStat, InodeType,
-    IoReadVec, IoWriteVec, IoctlArg, TimeParam, errno::Errno,
+    IoReadVec, IoWriteVec, IoctlArg, TimeParam, errno::Errno, signal::Signal,
 };
 use litebox_platform_multiplex::Platform;
 
-use crate::{ConstPtr, GlobalState, MutPtr, ShimFS, Task};
+use crate::{ConstPtr, GlobalState, MutPtr, ShimFS, Task, syscalls::signal::siginfo_kill};
 use core::sync::atomic::{AtomicUsize, Ordering};
 
 /// Task state shared by `CLONE_FS`.
@@ -504,7 +504,7 @@ impl<FS: ShimFS> Task<FS> {
             )
             .flatten();
         if let Err(Errno::EPIPE) = res {
-            unimplemented!("send SIGPIPE to the current task");
+            self.send_signal(Signal::SIGPIPE, siginfo_kill(Signal::SIGPIPE));
         }
         res
     }
@@ -788,7 +788,7 @@ impl<FS: ShimFS> Task<FS> {
             )
             .flatten();
         if let Err(Errno::EPIPE) = res {
-            unimplemented!("send SIGPIPE to the current task");
+            self.send_signal(Signal::SIGPIPE, siginfo_kill(Signal::SIGPIPE));
         }
         res
     }

--- a/litebox_shim_linux/src/syscalls/file.rs
+++ b/litebox_shim_linux/src/syscalls/file.rs
@@ -722,22 +722,36 @@ impl<FS: ShimFS> Task<FS> {
     }
 }
 
-fn write_to_iovec<F>(iovs: &[IoWriteVec<ConstPtr<u8>>], write_fn: F) -> Result<usize, Errno>
+pub(super) fn write_to_iovec<P, I, F>(iovs: I, write_fn: F) -> Result<usize, Errno>
 where
+    P: RawConstPointer<u8>,
+    I: IntoIterator<Item = (P, usize)>,
     F: Fn(&[u8]) -> Result<usize, Errno>,
 {
     let mut total_written = 0;
-    for iov in iovs {
-        if iov.iov_len == 0 {
+    for (iov_base, iov_len) in iovs {
+        if iov_len == 0 {
             continue;
         }
-        let slice = iov
-            .iov_base
-            .to_owned_slice(iov.iov_len)
-            .ok_or(Errno::EFAULT)?;
-        let size = write_fn(&slice)?;
+        let Some(slice) = iov_base.to_owned_slice(iov_len) else {
+            return if total_written > 0 {
+                Ok(total_written)
+            } else {
+                Err(Errno::EFAULT)
+            };
+        };
+        let size = match write_fn(&slice) {
+            Ok(size) => size,
+            Err(err) => {
+                return if total_written > 0 {
+                    Ok(total_written)
+                } else {
+                    Err(err)
+                };
+            }
+        };
         total_written += size;
-        if size < iov.iov_len {
+        if size < iov_len {
             // Okay to transfer fewer bytes than requested
             break;
         }
@@ -766,12 +780,12 @@ impl<FS: ShimFS> Task<FS> {
             .run_on_raw_fd(
                 raw_fd,
                 |fd| {
-                    write_to_iovec(iovs, |buf: &[u8]| {
+                    write_to_iovec(iovs.iter().map(|iov| (iov.iov_base, iov.iov_len)), |buf| {
                         files.fs.write(fd, buf, None).map_err(Errno::from)
                     })
                 },
                 |fd| {
-                    write_to_iovec(iovs, |buf| {
+                    write_to_iovec(iovs.iter().map(|iov| (iov.iov_base, iov.iov_len)), |buf| {
                         self.global.sendto(
                             &self.wait_cx(),
                             fd,
@@ -2256,9 +2270,42 @@ impl<FS: ShimFS> Task<FS> {
 mod tests {
     use super::*;
     use alloc::string::String;
+    use core::cell::Cell;
     use litebox::fs::Mode;
 
     extern crate std;
+
+    #[test]
+    fn write_to_iovec_returns_partial_after_later_error() {
+        let first = b"first";
+        let second = b"second";
+        let iovs = [
+            IoWriteVec {
+                iov_base: ConstPtr::from_usize(first.as_ptr().expose_provenance()),
+                iov_len: first.len(),
+            },
+            IoWriteVec {
+                iov_base: ConstPtr::from_usize(second.as_ptr().expose_provenance()),
+                iov_len: second.len(),
+            },
+        ];
+        let calls = Cell::new(0);
+
+        let result = write_to_iovec(iovs.iter().map(|iov| (iov.iov_base, iov.iov_len)), |buf| {
+            let call = calls.get();
+            calls.set(call + 1);
+            if call == 0 {
+                assert_eq!(buf, first);
+                Ok(buf.len())
+            } else {
+                assert_eq!(buf, second);
+                Err(Errno::EPIPE)
+            }
+        });
+
+        assert_eq!(result, Ok(first.len()));
+        assert_eq!(calls.get(), 2);
+    }
 
     #[test]
     fn fspath_new() {

--- a/litebox_shim_linux/src/syscalls/net.rs
+++ b/litebox_shim_linux/src/syscalls/net.rs
@@ -32,7 +32,7 @@ use litebox_common_linux::{
 };
 use zerocopy::{FromBytes, Immutable, IntoBytes};
 
-use crate::{ConstPtr, MutPtr, syscalls::signal::siginfo_kill};
+use crate::{ConstPtr, MutPtr, syscalls::signal};
 use crate::{GlobalState, ShimFS, Task};
 use crate::{
     Platform,
@@ -1358,7 +1358,7 @@ impl<FS: ShimFS> Task<FS> {
         if let Err(Errno::EPIPE) = res
             && !flags.contains(SendFlags::NOSIGNAL)
         {
-            self.send_signal(Signal::SIGPIPE, siginfo_kill(Signal::SIGPIPE));
+            self.send_signal(Signal::SIGPIPE, signal::siginfo_kill(Signal::SIGPIPE));
         }
         res
     }
@@ -1447,7 +1447,7 @@ impl<FS: ShimFS> Task<FS> {
         if let Err(Errno::EPIPE) = res
             && !flags.contains(SendFlags::NOSIGNAL)
         {
-            self.send_signal(Signal::SIGPIPE, siginfo_kill(Signal::SIGPIPE));
+            self.send_signal(Signal::SIGPIPE, signal::siginfo_kill(Signal::SIGPIPE));
         }
         res
     }

--- a/litebox_shim_linux/src/syscalls/net.rs
+++ b/litebox_shim_linux/src/syscalls/net.rs
@@ -28,11 +28,11 @@ use litebox::{
 };
 use litebox_common_linux::{
     AddressFamily, FileDescriptorFlags, IPProtocol, ReceiveFlags, SendFlags, SockFlags, SockType,
-    SocketOption, SocketOptionName, TcpOption, UnixProtocol, errno::Errno,
+    SocketOption, SocketOptionName, TcpOption, UnixProtocol, errno::Errno, signal::Signal,
 };
 use zerocopy::{FromBytes, Immutable, IntoBytes};
 
-use crate::{ConstPtr, MutPtr};
+use crate::{ConstPtr, MutPtr, syscalls::signal::siginfo_kill};
 use crate::{GlobalState, ShimFS, Task};
 use crate::{
     Platform,
@@ -737,7 +737,8 @@ impl<FS: ShimFS> GlobalState<FS> {
         }
 
         // Convert `SendFlags` to `litebox::net::SendFlags`
-        // `DONTWAIT` and `NOSIGNAL` are handled in this function so we don't convert them.
+        // `DONTWAIT` is handled in this function and `NOSIGNAL` should be handled by caller,
+        // so we don't convert them.
         let new_flags = convert_flags!(
             flags,
             SendFlags,
@@ -753,8 +754,7 @@ impl<FS: ShimFS> GlobalState<FS> {
         let is_nonblock =
             self.get_status(fd).contains(OFlags::NONBLOCK) || flags.contains(SendFlags::DONTWAIT);
 
-        let ret = cx
-            .with_timeout(timeout)
+        cx.with_timeout(timeout)
             .wait_on_events(
                 is_nonblock,
                 Events::OUT,
@@ -768,13 +768,7 @@ impl<FS: ShimFS> GlobalState<FS> {
                     Err(e) => Err(TryOpError::Other(Errno::from(e))),
                 },
             )
-            .map_err(Errno::from);
-        if let Err(Errno::EPIPE) = ret
-            && !flags.contains(SendFlags::NOSIGNAL)
-        {
-            unimplemented!("send signal SIGPIPE on EPIPE");
-        }
-        ret
+            .map_err(Errno::from)
     }
 
     /// Receive data via socket channel (lock-free path).
@@ -1342,7 +1336,7 @@ impl<FS: ShimFS> Task<FS> {
         flags: SendFlags,
         sockaddr: Option<SocketAddress>,
     ) -> Result<usize, Errno> {
-        self.files.borrow().with_socket(
+        let res = self.files.borrow().with_socket(
             &self.global,
             sockfd,
             |fd| {
@@ -1360,7 +1354,13 @@ impl<FS: ShimFS> Task<FS> {
                     .transpose()?;
                 file.sendto(self, buf, flags, addr)
             },
-        )
+        );
+        if let Err(Errno::EPIPE) = res
+            && !flags.contains(SendFlags::NOSIGNAL)
+        {
+            self.send_signal(Signal::SIGPIPE, siginfo_kill(Signal::SIGPIPE));
+        }
+        res
     }
 
     /// Handle syscall `sendmsg`
@@ -1402,7 +1402,7 @@ impl<FS: ShimFS> Task<FS> {
             .msg_iov
             .to_owned_slice(msg.msg_iovlen)
             .ok_or(Errno::EFAULT)?;
-        self.files.borrow().with_socket(
+        let res = self.files.borrow().with_socket(
             &self.global,
             sockfd,
             |fd| {
@@ -1443,7 +1443,13 @@ impl<FS: ShimFS> Task<FS> {
                 }
                 Ok(total_sent)
             },
-        )
+        );
+        if let Err(Errno::EPIPE) = res
+            && !flags.contains(SendFlags::NOSIGNAL)
+        {
+            self.send_signal(Signal::SIGPIPE, siginfo_kill(Signal::SIGPIPE));
+        }
+        res
     }
 
     /// Handle syscall `recvfrom`

--- a/litebox_shim_linux/src/syscalls/net.rs
+++ b/litebox_shim_linux/src/syscalls/net.rs
@@ -1410,38 +1410,23 @@ impl<FS: ShimFS> Task<FS> {
                     .clone()
                     .map(|addr| addr.inet().ok_or(Errno::EAFNOSUPPORT))
                     .transpose()?;
-                let mut total_sent = 0;
-                for iov in &iovs {
-                    if iov.iov_len == 0 {
-                        continue;
-                    }
-                    let buf = iov
-                        .iov_base
-                        .to_owned_slice(iov.iov_len)
-                        .ok_or(Errno::EFAULT)?;
-                    total_sent +=
+                super::file::write_to_iovec(
+                    iovs.iter().map(|iov| (iov.iov_base, iov.iov_len)),
+                    |buf| {
                         self.global
-                            .sendto(&self.wait_cx(), fd, &buf, flags, sock_addr)?;
-                }
-                Ok(total_sent)
+                            .sendto(&self.wait_cx(), fd, buf, flags, sock_addr)
+                    },
+                )
             },
             |file| {
                 let unix_addr = sock_addr
                     .clone()
                     .map(|addr| addr.unix().ok_or(Errno::EAFNOSUPPORT))
                     .transpose()?;
-                let mut total_sent = 0;
-                for iov in &iovs {
-                    if iov.iov_len == 0 {
-                        continue;
-                    }
-                    let buf = iov
-                        .iov_base
-                        .to_owned_slice(iov.iov_len)
-                        .ok_or(Errno::EFAULT)?;
-                    total_sent += file.sendto(self, &buf, flags, unix_addr.clone())?;
-                }
-                Ok(total_sent)
+                super::file::write_to_iovec(
+                    iovs.iter().map(|iov| (iov.iov_base, iov.iov_len)),
+                    |buf| file.sendto(self, buf, flags, unix_addr.clone()),
+                )
             },
         );
         if let Err(Errno::EPIPE) = res

--- a/litebox_shim_linux/src/syscalls/unix.rs
+++ b/litebox_shim_linux/src/syscalls/unix.rs
@@ -1215,21 +1215,14 @@ impl<FS: ShimFS> UnixSocket<FS> {
         let is_nonblocking =
             flags.contains(SendFlags::DONTWAIT) || self.get_status().contains(OFlags::NONBLOCK);
         let timeout = self.options.lock().send_timeout;
-        let ret = match &self.inner {
+        match &self.inner {
             UnixSocketInner::Stream(stream) => {
                 stream.sendto(&task.wait_cx(), timeout, buf, is_nonblocking, addr)
             }
             UnixSocketInner::Datagram(datagram) => {
                 datagram.sendto(task, timeout, buf, is_nonblocking, addr)
             }
-        };
-        if let Err(Errno::EPIPE) = ret
-            && !flags.contains(SendFlags::NOSIGNAL)
-        {
-            // TODO: send SIGPIPE signal
-            unimplemented!("send SIGPIPE on EPIPE");
         }
-        ret
     }
 
     pub(super) fn recvfrom(


### PR DESCRIPTION
handle EPIPE error for various syscalls like `write` and `sendto`.

Also fixed the partial send issue where we incorrectly return an error code.