### PR TITLE
Further reduce unsafe from shim via zerocopy

### DIFF
--- a/dev_tests/src/ratchet.rs
+++ b/dev_tests/src/ratchet.rs
@@ -71,7 +71,6 @@ fn ratchet_maybe_uninit() -> Result<()> {
             ("dev_tests/", 1),
             ("litebox/", 1),
             ("litebox_platform_linux_userland/", 2),
-            ("litebox_shim_linux/", 5),
         ],
         |file| {
             Ok(file

--- a/litebox_common_linux/src/lib.rs
+++ b/litebox_common_linux/src/lib.rs
@@ -14,7 +14,7 @@ use litebox::{
     utils::{ReinterpretSignedExt as _, TruncateExt},
 };
 use syscalls::Sysno;
-use zerocopy::{FromBytes, IntoBytes};
+use zerocopy::{FromBytes, Immutable, IntoBytes};
 
 use crate::signal::SigSet;
 
@@ -757,7 +757,7 @@ impl SocketOptionName {
     }
 }
 
-#[derive(Debug, Clone, Copy, FromBytes, IntoBytes)]
+#[derive(Debug, Clone, Copy, FromBytes, IntoBytes, Immutable)]
 #[repr(C)]
 pub struct Ucred {
     pub pid: u32,
@@ -853,7 +853,7 @@ impl From<Duration> for Timespec32 {
 }
 
 #[repr(C)]
-#[derive(Default, Clone, Copy, FromBytes, IntoBytes)]
+#[derive(Default, Clone, Copy, FromBytes, IntoBytes, Immutable)]
 pub struct TimeVal {
     tv_sec: time_t,
     tv_usec: suseconds_t,

--- a/litebox_shim_linux/src/syscalls/misc.rs
+++ b/litebox_shim_linux/src/syscalls/misc.rs
@@ -166,9 +166,8 @@ impl<FS: ShimFS> Task<FS> {
 
 #[cfg(test)]
 mod tests {
-    use core::mem::MaybeUninit;
-
     use crate::syscalls::tests::init_platform;
+    use zerocopy::FromZeros as _;
 
     #[test]
     fn test_getrandom() {
@@ -193,10 +192,9 @@ mod tests {
     fn test_uname() {
         let task = init_platform(None);
 
-        let mut utsname = MaybeUninit::<litebox_common_linux::Utsname>::uninit();
-        let ptr = crate::MutPtr::from_ptr(utsname.as_mut_ptr());
+        let mut utsname = litebox_common_linux::Utsname::new_zeroed();
+        let ptr = crate::MutPtr::from_ptr(&raw mut utsname);
         task.sys_uname(ptr).expect("uname failed");
-        let utsname = unsafe { utsname.assume_init() };
 
         assert_eq!(utsname.sysname, super::SYS_INFO.sysname);
         assert_eq!(utsname.nodename, super::SYS_INFO.nodename);

--- a/litebox_shim_linux/src/syscalls/mod.rs
+++ b/litebox_shim_linux/src/syscalls/mod.rs
@@ -39,18 +39,18 @@ macro_rules! common_functions_for_file_status {
 }
 
 pub(crate) use common_functions_for_file_status;
-use zerocopy::{FromBytes, IntoBytes};
+use zerocopy::{FromBytes, Immutable, IntoBytes};
 
 /// Helper function to write a value of type T to user memory.
 /// If the buffer size (i.e., provided `len`) is smaller than `size_of::<T>()`, only write up to `len` bytes.
-fn write_to_user<T: FromBytes + IntoBytes>(
+fn write_to_user<T: FromBytes + IntoBytes + Immutable>(
     val: T,
     optval: crate::MutPtr<u8>,
     len: u32,
 ) -> Result<usize, litebox_common_linux::errno::Errno> {
     use litebox::platform::RawMutPointer as _;
     let length = core::mem::size_of::<T>().min(len as usize);
-    let data = unsafe { core::slice::from_raw_parts((&raw const val).cast::<u8>(), length) };
+    let data = &val.as_bytes()[..length];
     optval
         .write_slice_at_offset(0, data)
         .ok_or(litebox_common_linux::errno::Errno::EFAULT)?;

--- a/litebox_shim_linux/src/syscalls/net.rs
+++ b/litebox_shim_linux/src/syscalls/net.rs
@@ -30,7 +30,7 @@ use litebox_common_linux::{
     AddressFamily, FileDescriptorFlags, IPProtocol, ReceiveFlags, SendFlags, SockFlags, SockType,
     SocketOption, SocketOptionName, TcpOption, UnixProtocol, errno::Errno,
 };
-use zerocopy::{FromBytes, IntoBytes};
+use zerocopy::{FromBytes, Immutable, IntoBytes};
 
 use crate::{ConstPtr, MutPtr};
 use crate::{GlobalState, ShimFS, Task};
@@ -98,7 +98,7 @@ impl<FS: ShimFS> super::file::FilesState<FS> {
     }
 }
 
-#[derive(Clone, Copy, FromBytes, IntoBytes)]
+#[derive(Clone, Copy, FromBytes, IntoBytes, Immutable)]
 #[repr(C, packed)]
 struct CSockInetAddr {
     family: i16,
@@ -1110,12 +1110,7 @@ pub(crate) fn write_sockaddr_to_user(
         SocketAddress::Inet(SocketAddr::V4(v4_addr)) => {
             let addrlen_val = size_of::<CSockInetAddr>().min(addrlen_val as usize);
             let c_addr: CSockInetAddr = v4_addr.into();
-            let bytes: &[u8] = unsafe {
-                core::slice::from_raw_parts(
-                    (&raw const c_addr).cast::<u8>(),
-                    size_of::<CSockInetAddr>(),
-                )
-            };
+            let bytes: &[u8] = c_addr.as_bytes();
             addr.write_slice_at_offset(0, &bytes[..addrlen_val])
                 .ok_or(Errno::EFAULT)?;
             size_of::<CSockInetAddr>()

--- a/litebox_shim_linux/src/syscalls/process.rs
+++ b/litebox_shim_linux/src/syscalls/process.rs
@@ -1583,18 +1583,16 @@ mod tests {
     #[test]
     fn test_arch_prctl() {
         use crate::{MutPtr, syscalls::tests::init_platform};
-        use core::mem::MaybeUninit;
         use litebox::platform::RawConstPointer;
         use litebox_common_linux::ArchPrctlArg;
 
         let task = init_platform(None);
 
         // Save old FS base
-        let mut old_fs_base = MaybeUninit::<usize>::uninit();
-        let ptr = MutPtr::from_ptr(old_fs_base.as_mut_ptr());
+        let mut old_fs_base: usize = 0;
+        let ptr = MutPtr::from_ptr(&raw mut old_fs_base);
         task.sys_arch_prctl(ArchPrctlArg::GetFs(ptr))
             .expect("Failed to get FS base");
-        let old_fs_base = unsafe { old_fs_base.assume_init() };
 
         // Set new FS base
         let mut new_fs_base: [u8; 16] = [0; 16];
@@ -1603,11 +1601,10 @@ mod tests {
             .expect("Failed to set FS base");
 
         // Verify new FS base
-        let mut current_fs_base = MaybeUninit::<usize>::uninit();
-        let ptr = MutPtr::from_ptr(current_fs_base.as_mut_ptr());
+        let mut current_fs_base: usize = 0;
+        let ptr = MutPtr::from_ptr(&raw mut current_fs_base);
         task.sys_arch_prctl(ArchPrctlArg::GetFs(ptr))
             .expect("Failed to get FS base");
-        let current_fs_base = unsafe { current_fs_base.assume_init() };
         assert_eq!(current_fs_base, new_fs_base.as_ptr() as usize);
 
         // Restore old FS base


### PR DESCRIPTION
This PR removes some more of the `unsafe` from our shim.  With this, the last of the maybe-uninit from our shim is also gone.