### PR TITLE
Use checked arithmetic against VTL0-controllable integers

### DIFF
--- a/litebox_platform_lvbs/src/lib.rs
+++ b/litebox_platform_lvbs/src/lib.rs
@@ -680,14 +680,18 @@ impl<Host: HostInterface> LinuxKernel<Host> {
         if page_addr.page_offset() != PageOffset::new(0) {
             return Err(DeallocationError::Unaligned);
         }
+        let end = x86_64::VirtAddr::try_new(
+            page_addr
+                .as_u64()
+                .checked_add(length as u64)
+                .ok_or(DeallocationError::Unaligned)?,
+        )
+        .map_err(|_| DeallocationError::Unaligned)?;
         unsafe {
             self.page_table_manager.current_page_table().unmap_pages(
                 PageRange::<PAGE_SIZE>::new(
                     page_addr.as_u64().truncate(),
-                    (page_addr + length as u64)
-                        .align_up(Size4KiB::SIZE)
-                        .as_u64()
-                        .truncate(),
+                    end.align_up(Size4KiB::SIZE).as_u64().truncate(),
                 )
                 .ok_or(DeallocationError::Unaligned)?,
                 false,
@@ -704,9 +708,12 @@ impl<Host: HostInterface> LinuxKernel<Host> {
         size: u64,
         flags: PageTableFlags,
     ) -> Option<Vtl0MappedGuard<'_, Host>> {
-        let (page_addr, page_aligned_length) = self
-            .map_vtl0_phys_range(phys_addr, phys_addr + size, flags)
-            .ok()?;
+        let phys_end = phys_addr
+            .as_u64()
+            .checked_add(size)
+            .and_then(|end| x86_64::PhysAddr::try_new(end).ok())?;
+        let (page_addr, page_aligned_length) =
+            self.map_vtl0_phys_range(phys_addr, phys_end, flags).ok()?;
         let page_offset: usize = (phys_addr - phys_addr.align_down(Size4KiB::SIZE)).truncate();
         Some(Vtl0MappedGuard {
             owner: self,

--- a/litebox_platform_lvbs/src/mshv/error.rs
+++ b/litebox_platform_lvbs/src/mshv/error.rs
@@ -27,6 +27,9 @@ pub enum VsmError {
     #[error("code page offset overflow when computing VTL return address")]
     CodePageOffsetOverflow,
 
+    #[error("integer overflow while processing VTL0-controlled range data")]
+    IntegerOverflow,
+
     // End-of-Boot Restriction Errors
     #[error("{0} not allowed after end of boot")]
     OperationAfterEndOfBoot(&'static str),
@@ -195,6 +198,7 @@ impl From<VsmError> for Errno {
             | VsmError::KexecSegmentRangeInvalid
             | VsmError::ModuleElfSizeExceeded { .. }
             | VsmError::CodePageOffsetOverflow
+            | VsmError::IntegerOverflow
             | VsmError::SymbolNameTooLong
             | VsmError::SymbolTableOutOfRange => Errno::ERANGE,
 

--- a/litebox_platform_lvbs/src/mshv/vsm.rs
+++ b/litebox_platform_lvbs/src/mshv/vsm.rs
@@ -87,15 +87,18 @@ pub(crate) fn init(is_bsp: bool) {
 
     if is_bsp {
         if let Ok((start, size)) = get_vtl1_memory_info() {
-            let end = start
-                .checked_add(size)
-                .ok_or(VsmError::IntegerOverflow)
-                .expect("VTL1 memory range overflow while protecting startup memory");
+            let Some(end) = start.checked_add(size) else {
+                panic!("Failed to protect VTL1 memory");
+            };
             debug_serial_println!("VSM: Protect GPAs from {:#x} to {:#x}", start, end);
+            let Ok(end) = PhysAddr::try_new(end) else {
+                panic!("Failed to protect VTL1 memory");
+            };
+            let start = PhysAddr::new(start);
             if protect_physical_memory_range(
                 PhysFrame::range(
-                    PhysFrame::containing_address(PhysAddr::new(start)),
-                    PhysFrame::containing_address(PhysAddr::new(end)),
+                    PhysFrame::containing_address(start),
+                    PhysFrame::containing_address(end),
                 ),
                 MemAttr::empty(),
             )
@@ -121,8 +124,10 @@ pub fn mshv_vsm_enable_aps(_cpu_present_mask_pfn: u64) -> Result<i64, VsmError> 
 /// `cpu_online_mask_pfn` indicates the page containing the VTL0's CPU online mask.
 pub fn mshv_vsm_boot_aps(cpu_online_mask_pfn: u64) -> Result<i64, VsmError> {
     debug_serial_println!("VSM: Boot APs");
-    let cpu_online_mask_page_addr = PhysAddr::try_new(cpu_online_mask_pfn << PAGE_SHIFT)
-        .map_err(|_| VsmError::InvalidPhysicalAddress)?;
+    let cpu_online_mask_page_addr = cpu_online_mask_pfn
+        .checked_shl(PAGE_SHIFT.truncate())
+        .and_then(|pa| PhysAddr::try_new(pa).ok())
+        .ok_or(VsmError::InvalidPhysicalAddress)?;
 
     let Some(cpu_mask) = (unsafe {
         crate::platform_low().copy_from_vtl0_phys::<CpuMask>(cpu_online_mask_page_addr)
@@ -283,8 +288,13 @@ pub fn mshv_vsm_protect_memory(pa: u64, nranges: u64) -> Result<i64, VsmError> {
                 epa - pa
             );
 
+            if pa == epa {
+                continue;
+            }
+
             protect_physical_memory_range(
                 PhysFrame::range(
+                    // `HekiRange::is_valid` already validated both physical addresses.
                     PhysFrame::containing_address(PhysAddr::new(pa)),
                     PhysFrame::containing_address(PhysAddr::new(epa)),
                 ),
@@ -750,7 +760,7 @@ pub fn mshv_vsm_kexec_validate(pa: u64, nranges: u64, crash: u64) -> Result<i64,
             let va = kimage.segment[i].buf;
             let pa = kimage.segment[i].mem;
             if let Some(epa) = pa.checked_add(kimage.segment[i].memsz) {
-                kexec_memory_metadata.insert_memory_range(KexecMemoryRange::new(va, pa, epa));
+                kexec_memory_metadata.insert_memory_range(KexecMemoryRange::new(va, pa, epa)?);
             } else {
                 return Err(VsmError::KexecSegmentRangeInvalid);
             }
@@ -855,6 +865,7 @@ fn copy_heki_patch_from_vtl0(patch_pa_0: u64, patch_pa_1: u64) -> Result<HekiPat
 /// This function apply the given `HekiPatch` patch data to VTL0 text.
 /// It assumes the caller has confirmed the validity of `HekiPatch` by invoking the `is_valid()` member function.
 fn apply_vtl0_text_patch(heki_patch: HekiPatch) -> Result<(), VsmError> {
+    // `HekiPatch::is_valid` already validated both physical addresses.
     let heki_patch_pa_0 = PhysAddr::new(heki_patch.pa[0]);
     let heki_patch_pa_1 = PhysAddr::new(heki_patch.pa[1]);
 
@@ -891,12 +902,14 @@ fn apply_vtl0_text_patch(heki_patch: HekiPatch) -> Result<(), VsmError> {
 fn mshv_vsm_allocate_ringbuffer_memory(phys_addr: u64, size: usize) -> Result<i64, VsmError> {
     let end = phys_addr
         .checked_add(size as u64)
-        .ok_or(VsmError::IntegerOverflow)?;
-    set_ringbuffer(PhysAddr::new(phys_addr), size);
+        .ok_or(VsmError::IntegerOverflow)
+        .and_then(|end| PhysAddr::try_new(end).map_err(|_| VsmError::InvalidPhysicalAddress))?;
+    let phys_addr = PhysAddr::new(phys_addr);
+    set_ringbuffer(phys_addr, size);
     protect_physical_memory_range(
         PhysFrame::range(
-            PhysFrame::containing_address(PhysAddr::new(phys_addr)),
-            PhysFrame::containing_address(PhysAddr::new(end)),
+            PhysFrame::containing_address(phys_addr),
+            PhysFrame::containing_address(end),
         ),
         MemAttr::MEM_ATTR_READ,
     )?;
@@ -1098,16 +1111,15 @@ impl Vtl0KernelInfo {
     // We need this because each step of `mshv_vsm_patch_data`/`text_poke_bp_batch` only
     // provides a part of the patch data and addresses (`patch[0]` or `patch[1..patch_size-1]`).
     pub fn find_precomputed_patch(&self, patch_data: &HekiPatch) -> Option<HekiPatch> {
+        // `HekiPatch::is_valid` already validated both physical addresses.
+        let patch_pa_0 = PhysAddr::new(patch_data.pa[0]);
+        let patch_pa_0_prev = patch_data.pa[0].checked_sub(1).map(PhysAddr::new);
+        let patch_pa_1 = PhysAddr::new(patch_data.pa[1]);
+
         self.precomputed_patches
-            .get(PhysAddr::new(patch_data.pa[0]))
-            .or_else(|| {
-                self.precomputed_patches
-                    .get(PhysAddr::new(patch_data.pa[0].saturating_sub(1)))
-            })
-            .or_else(|| {
-                self.precomputed_patches
-                    .get(PhysAddr::new(patch_data.pa[1]))
-            })
+            .get(patch_pa_0)
+            .or_else(|| patch_pa_0_prev.and_then(|pa| self.precomputed_patches.get(pa)))
+            .or_else(|| self.precomputed_patches.get(patch_pa_1))
             .or(None)
     }
 }
@@ -1133,10 +1145,11 @@ impl ModuleMemoryMetadata {
 
     #[inline]
     pub(crate) fn insert_heki_range(&mut self, heki_range: &HekiRange) {
+        // `HekiRange::is_valid` already validated these addresses.
         let va = heki_range.va;
         let pa = heki_range.pa;
         let epa = heki_range.epa;
-        self.insert_memory_range(ModuleMemoryRange::new(
+        self.insert_memory_range(ModuleMemoryRange::new_checked(
             va,
             pa,
             epa,
@@ -1192,21 +1205,56 @@ pub struct ModuleMemoryRange {
 }
 
 impl ModuleMemoryRange {
-    pub fn new(virt_addr: u64, phys_start: u64, phys_end: u64, mod_mem_type: ModMemType) -> Self {
+    /// Create a memory range from values which are already validated.
+    pub(crate) fn new_checked(
+        virt_addr: u64,
+        phys_start: u64,
+        phys_end: u64,
+        mod_mem_type: ModMemType,
+    ) -> Self {
+        let phys_start = PhysAddr::new(phys_start);
+        let phys_end = PhysAddr::new(phys_end);
         Self {
             virt_addr: VirtAddr::new(virt_addr),
             phys_frame_range: PhysFrame::range(
-                PhysFrame::containing_address(PhysAddr::new(phys_start)),
-                PhysFrame::containing_address(PhysAddr::new(phys_end)),
+                PhysFrame::containing_address(phys_start),
+                PhysFrame::containing_address(phys_end),
             ),
             mod_mem_type,
         }
+    }
+
+    pub fn new(
+        virt_addr: u64,
+        phys_start: u64,
+        phys_end: u64,
+        mod_mem_type: ModMemType,
+    ) -> Result<Self, VsmError> {
+        Ok(Self {
+            virt_addr: VirtAddr::try_new(virt_addr).map_err(|_| VsmError::InvalidVirtualAddress)?,
+            phys_frame_range: PhysFrame::range(
+                PhysFrame::containing_address(
+                    PhysAddr::try_new(phys_start).map_err(|_| VsmError::InvalidPhysicalAddress)?,
+                ),
+                PhysFrame::containing_address(
+                    PhysAddr::try_new(phys_end).map_err(|_| VsmError::InvalidPhysicalAddress)?,
+                ),
+            ),
+            mod_mem_type,
+        })
     }
 }
 
 impl Default for ModuleMemoryRange {
     fn default() -> Self {
-        Self::new(0, 0, 0, ModMemType::Unknown)
+        Self {
+            virt_addr: VirtAddr::zero(),
+            phys_frame_range: PhysFrame::range(
+                PhysFrame::containing_address(PhysAddr::zero()),
+                PhysFrame::containing_address(PhysAddr::zero()),
+            ),
+            mod_mem_type: ModMemType::Unknown,
+        }
     }
 }
 
@@ -1298,7 +1346,7 @@ impl<'a> ModuleMemoryMetadataIters<'a> {
 /// This function copies `HekiPage` structures from VTL0 and returns a vector of them.
 /// `pa` and `nranges` specify the physical address range containing one or more than one `HekiPage` structures.
 fn copy_heki_pages_from_vtl0(pa: u64, nranges: u64) -> Option<Vec<HekiPage>> {
-    let mut next_pa = PhysAddr::new(pa);
+    let mut next_pa = PhysAddr::try_new(pa).ok()?;
     let mut heki_pages = Vec::with_capacity(nranges.truncate());
     let mut range: u64 = 0;
 
@@ -1310,6 +1358,7 @@ fn copy_heki_pages_from_vtl0(pa: u64, nranges: u64) -> Option<Vec<HekiPage>> {
         }
 
         range = range.checked_add(heki_page.nranges)?;
+        // `HekiPage::is_valid` already validated `next_pa`.
         next_pa = PhysAddr::new(heki_page.next_pa);
         heki_pages.push(*heki_page);
     }
@@ -1444,13 +1493,10 @@ impl MemoryContainer {
     }
 
     pub(crate) fn extend_range(&mut self, heki_range: &HekiRange) -> Result<(), VsmError> {
-        let addr = VirtAddr::try_new(heki_range.va).map_err(|_| VsmError::InvalidVirtualAddress)?;
-        let phys_addr =
-            PhysAddr::try_new(heki_range.pa).map_err(|_| VsmError::InvalidPhysicalAddress)?;
-        let len = heki_range
-            .epa
-            .checked_sub(heki_range.pa)
-            .ok_or(VsmError::IntegerOverflow)?;
+        // `HekiRange::is_valid` already validated the addresses and `pa <= epa`.
+        let addr = VirtAddr::new(heki_range.va);
+        let phys_addr = PhysAddr::new(heki_range.pa);
+        let len = heki_range.epa - heki_range.pa;
         if let Some(last_range) = self.range.last()
             && VirtAddr::try_new(
                 last_range
@@ -1600,10 +1646,11 @@ impl KexecMemoryMetadata {
 
     #[inline]
     pub(crate) fn insert_heki_range(&mut self, heki_range: &HekiRange) {
+        // `HekiRange::is_valid` already validated these addresses.
         let va = heki_range.va;
         let pa = heki_range.pa;
         let epa = heki_range.epa;
-        self.insert_memory_range(KexecMemoryRange::new(va, pa, epa));
+        self.insert_memory_range(KexecMemoryRange::new_checked(va, pa, epa));
     }
 
     #[inline]
@@ -1657,20 +1704,43 @@ pub struct KexecMemoryRange {
 }
 
 impl KexecMemoryRange {
-    pub fn new(virt_addr: u64, phys_start: u64, phys_end: u64) -> Self {
+    /// Create a memory range from values which are already validated.
+    pub(crate) fn new_checked(virt_addr: u64, phys_start: u64, phys_end: u64) -> Self {
+        let phys_start = PhysAddr::new(phys_start);
+        let phys_end = PhysAddr::new(phys_end);
         Self {
             virt_addr: VirtAddr::new(virt_addr),
             phys_frame_range: PhysFrame::range(
-                PhysFrame::containing_address(PhysAddr::new(phys_start)),
-                PhysFrame::containing_address(PhysAddr::new(phys_end)),
+                PhysFrame::containing_address(phys_start),
+                PhysFrame::containing_address(phys_end),
             ),
         }
+    }
+
+    pub fn new(virt_addr: u64, phys_start: u64, phys_end: u64) -> Result<Self, VsmError> {
+        Ok(Self {
+            virt_addr: VirtAddr::try_new(virt_addr).map_err(|_| VsmError::InvalidVirtualAddress)?,
+            phys_frame_range: PhysFrame::range(
+                PhysFrame::containing_address(
+                    PhysAddr::try_new(phys_start).map_err(|_| VsmError::InvalidPhysicalAddress)?,
+                ),
+                PhysFrame::containing_address(
+                    PhysAddr::try_new(phys_end).map_err(|_| VsmError::InvalidPhysicalAddress)?,
+                ),
+            ),
+        })
     }
 }
 
 impl Default for KexecMemoryRange {
     fn default() -> Self {
-        Self::new(0, 0, 0)
+        Self {
+            virt_addr: VirtAddr::zero(),
+            phys_frame_range: PhysFrame::range(
+                PhysFrame::containing_address(PhysAddr::zero()),
+                PhysFrame::containing_address(PhysAddr::zero()),
+            ),
+        }
     }
 }
 
@@ -1748,6 +1818,7 @@ impl PatchDataMap {
                 .map(HekiPatch::try_from_bytes)
             {
                 let patch = patch.ok_or(PatchDataMapError::InvalidHekiPatch)?;
+                // `HekiPatch::try_from_bytes` already validated both physical addresses.
                 let patch_target_pa_0 = PhysAddr::new(patch.pa[0]);
                 let patch_target_pa_1 = PhysAddr::new(patch.pa[1]);
 

--- a/litebox_platform_lvbs/src/mshv/vsm.rs
+++ b/litebox_platform_lvbs/src/mshv/vsm.rs
@@ -87,11 +87,15 @@ pub(crate) fn init(is_bsp: bool) {
 
     if is_bsp {
         if let Ok((start, size)) = get_vtl1_memory_info() {
-            debug_serial_println!("VSM: Protect GPAs from {:#x} to {:#x}", start, start + size);
+            let end = start
+                .checked_add(size)
+                .ok_or(VsmError::IntegerOverflow)
+                .expect("VTL1 memory range overflow while protecting startup memory");
+            debug_serial_println!("VSM: Protect GPAs from {:#x} to {:#x}", start, end);
             if protect_physical_memory_range(
                 PhysFrame::range(
                     PhysFrame::containing_address(PhysAddr::new(start)),
-                    PhysFrame::containing_address(PhysAddr::new(start + size)),
+                    PhysFrame::containing_address(PhysAddr::new(end)),
                 ),
                 MemAttr::empty(),
             )
@@ -885,11 +889,14 @@ fn apply_vtl0_text_patch(heki_patch: HekiPatch) -> Result<(), VsmError> {
 }
 
 fn mshv_vsm_allocate_ringbuffer_memory(phys_addr: u64, size: usize) -> Result<i64, VsmError> {
+    let end = phys_addr
+        .checked_add(size as u64)
+        .ok_or(VsmError::IntegerOverflow)?;
     set_ringbuffer(PhysAddr::new(phys_addr), size);
     protect_physical_memory_range(
         PhysFrame::range(
             PhysFrame::containing_address(PhysAddr::new(phys_addr)),
-            PhysFrame::containing_address(PhysAddr::new(phys_addr + (size as u64))),
+            PhysFrame::containing_address(PhysAddr::new(end)),
         ),
         MemAttr::MEM_ATTR_READ,
     )?;
@@ -1302,7 +1309,7 @@ fn copy_heki_pages_from_vtl0(pa: u64, nranges: u64) -> Option<Vec<HekiPage>> {
             return None;
         }
 
-        range += heki_page.nranges;
+        range = range.checked_add(heki_page.nranges)?;
         next_pa = PhysAddr::new(heki_page.next_pa);
         heki_pages.push(*heki_page);
     }
@@ -1429,9 +1436,10 @@ impl MemoryContainer {
     pub fn get_range(&self) -> Option<Range<VirtAddr>> {
         let start_range = self.range.first()?;
         let end_range = self.range.last()?;
+        let end = end_range.addr.as_u64().checked_add(end_range.len)?;
         Some(Range {
             start: start_range.addr,
-            end: end_range.addr + end_range.len,
+            end: VirtAddr::try_new(end).ok()?,
         })
     }
 
@@ -1439,8 +1447,20 @@ impl MemoryContainer {
         let addr = VirtAddr::try_new(heki_range.va).map_err(|_| VsmError::InvalidVirtualAddress)?;
         let phys_addr =
             PhysAddr::try_new(heki_range.pa).map_err(|_| VsmError::InvalidPhysicalAddress)?;
+        let len = heki_range
+            .epa
+            .checked_sub(heki_range.pa)
+            .ok_or(VsmError::IntegerOverflow)?;
         if let Some(last_range) = self.range.last()
-            && last_range.addr + last_range.len != addr
+            && VirtAddr::try_new(
+                last_range
+                    .addr
+                    .as_u64()
+                    .checked_add(last_range.len)
+                    .ok_or(VsmError::IntegerOverflow)?,
+            )
+            .map_err(|_| VsmError::InvalidVirtualAddress)?
+                != addr
         {
             debug_serial_println!("Discontiguous address found {heki_range:?}");
             // NOTE: Intentionally not returning an error here.
@@ -1450,7 +1470,7 @@ impl MemoryContainer {
         self.range.push(MemoryRange {
             addr,
             phys_addr,
-            len: heki_range.epa - heki_range.pa,
+            len,
         });
         Ok(())
     }
@@ -1462,14 +1482,22 @@ impl MemoryContainer {
         if self.buf.is_empty() {
             for range in &self.range {
                 let range_len: usize = range.len.truncate();
-                len += range_len;
+                len = len
+                    .checked_add(range_len)
+                    .ok_or(MemoryContainerError::Overflow)?;
             }
             self.buf.reserve_exact(len);
         }
 
         let range = self.range.clone();
         for range in range {
-            self.write_vtl0_phys_bytes(range.phys_addr, range.phys_addr + range.len)?;
+            let phys_end = range
+                .phys_addr
+                .as_u64()
+                .checked_add(range.len)
+                .and_then(|end| PhysAddr::try_new(end).ok())
+                .ok_or(MemoryContainerError::Overflow)?;
+            self.write_vtl0_phys_bytes(range.phys_addr, phys_end)?;
         }
         Ok(())
     }
@@ -1496,7 +1524,11 @@ impl MemoryContainer {
             let src = &page.0[src_offset..src_offset + src_len];
 
             self.buf.extend_from_slice(src);
-            phys_cur += src_len as u64;
+            phys_cur = phys_cur
+                .as_u64()
+                .checked_add(src_len as u64)
+                .and_then(|next| PhysAddr::try_new(next).ok())
+                .ok_or(MemoryContainerError::Overflow)?;
             bytes_to_copy -= src_len;
         }
         Ok(())
@@ -1517,6 +1549,8 @@ impl core::ops::Deref for MemoryContainer {
 pub enum MemoryContainerError {
     #[error("failed to copy data from VTL0")]
     CopyFromVtl0Failed,
+    #[error("integer overflow while processing VTL0 memory")]
+    Overflow,
 }
 
 pub struct KexecMemoryMetadataWrapper {
@@ -1737,7 +1771,11 @@ impl PatchDataMap {
                             // Step 2 of `text_poke_bp_batch` where we only know the second to last bytes of the patch such
                             // that cannot know the address of the first page. Details are in `validate_text_poke_bp_batch`.
                             if !patch_target_pa_1.is_null()
-                                && (patch_target_pa_0 + 1).is_aligned(Size4KiB::SIZE)
+                                && patch_target_pa_0
+                                    .as_u64()
+                                    .checked_add(1)
+                                    .and_then(|next| PhysAddr::try_new(next).ok())
+                                    .is_some_and(|next| next.is_aligned(Size4KiB::SIZE))
                             {
                                 mod_mem_meta.insert_patch_target(patch_target_pa_1);
                                 inner.insert(patch_target_pa_1, patch);
@@ -1748,7 +1786,11 @@ impl PatchDataMap {
                 } else {
                     inner.insert(patch_target_pa_0, patch);
                     if !patch_target_pa_1.is_null()
-                        && (patch_target_pa_0 + 1).is_aligned(Size4KiB::SIZE)
+                        && patch_target_pa_0
+                            .as_u64()
+                            .checked_add(1)
+                            .and_then(|next| PhysAddr::try_new(next).ok())
+                            .is_some_and(|next| next.is_aligned(Size4KiB::SIZE))
                     {
                         inner.insert(patch_target_pa_1, patch);
                     }

--- a/litebox_platform_lvbs/src/mshv/vsm_intercept.rs
+++ b/litebox_platform_lvbs/src/mshv/vsm_intercept.rs
@@ -151,7 +151,12 @@ pub fn vsm_handle_intercept() {
 
 #[inline]
 fn advance_vtl0_rip(int_msg_hdr: &HvInterceptMessageHeader) -> Result<u64, HypervCallError> {
-    let new_vtl0_rip = int_msg_hdr.rip + u64::from(int_msg_hdr.instruction_length);
+    let Some(new_vtl0_rip) = int_msg_hdr
+        .rip
+        .checked_add(u64::from(int_msg_hdr.instruction_length))
+    else {
+        return raise_vtl0_gp_fault();
+    };
     hvcall_set_vp_vtl0_registers(HV_X64_REGISTER_RIP, new_vtl0_rip)
 }
 

--- a/litebox_runner_lvbs/src/lib.rs
+++ b/litebox_runner_lvbs/src/lib.rs
@@ -99,8 +99,18 @@ pub fn seed_initial_heap() {
 pub fn init(is_bsp: bool) -> Option<&'static Platform> {
     let ret = if is_bsp {
         let (start, size) = get_vtl1_memory_info().expect("Failed to get memory info");
+        let min_vtl1_size = ((VTL1_REMAP_PDE_PAGE + 1) * PAGE_SIZE) as u64;
+        assert!(
+            size >= min_vtl1_size,
+            "VTL1 memory size is too small for fixed boot layout"
+        );
         let vtl1_start = x86_64::PhysAddr::new(start);
-        let vtl1_end = x86_64::PhysAddr::new(start + size);
+        // this `checked_add` covers all `vtl1_start + offset` calculations within this function.
+        let vtl1_end = x86_64::PhysAddr::new(
+            start
+                .checked_add(size)
+                .expect("VTL1 memory range overflow in init()"),
+        );
 
         // Re-compute the pre-populated region bounds needed for the
         // remaining-memory add after `Platform::new()` below.
@@ -184,8 +194,10 @@ pub fn init(is_bsp: bool) -> Option<&'static Platform> {
 
         // Add the rest of the VTL1 memory to the global allocator once they are mapped to the base page table.
         let mem_fill_start = mem_fill_start + mem_fill_size;
+        let vtl1_base_va = Platform::pa_to_va(vtl1_start).as_u64();
         let mem_fill_size = TruncateExt::<usize>::truncate(
-            size - (mem_fill_start as u64 - Platform::pa_to_va(vtl1_start).as_u64()),
+            size.checked_sub((mem_fill_start as u64) - vtl1_base_va)
+                .expect("remaining VTL1 memory size underflow in init()"),
         );
         unsafe {
             Platform::mem_fill_pages(mem_fill_start, mem_fill_size);
@@ -261,7 +273,9 @@ fn optee_smc_handler_entry_inner(
     smc_args_pfn: u64,
 ) -> Result<i64, litebox_common_linux::errno::Errno> {
     let smc_args_pfn: usize = smc_args_pfn.truncate();
-    let smc_args_addr = smc_args_pfn << litebox_platform_lvbs::mshv::vtl1_mem_layout::PAGE_SHIFT;
+    let smc_args_addr = smc_args_pfn
+        .checked_mul(1usize << litebox_platform_lvbs::mshv::vtl1_mem_layout::PAGE_SHIFT)
+        .ok_or(litebox_common_linux::errno::Errno::EINVAL)?;
     let smc_args_updated = optee_smc_handler(smc_args_addr);
 
     // Write back the SMC arguments page to normal world memory.
@@ -1287,8 +1301,9 @@ fn write_rpc_args_to_normal_world(
     let mut blob = vec![0u8; rpc_args_size];
     rpc_args.serialize(&mut blob)?;
 
-    let rpc_pa: usize =
-        <u64 as litebox::utils::TruncateExt<usize>>::truncate(msg_args_phys_addr) + msg_args_size; // RPC args are placed right after the main msg_args blob
+    let rpc_pa: usize = <u64 as litebox::utils::TruncateExt<usize>>::truncate(msg_args_phys_addr)
+        .checked_add(msg_args_size)
+        .ok_or(OpteeSmcReturnCode::EBadAddr)?; // RPC args are placed right after the main msg_args blob
     let mut ptr = NormalWorldMutPtr::<u8, PAGE_SIZE>::with_contiguous_pages(rpc_pa, rpc_args_size)?;
     // SAFETY: Writing rpc_args back to normal world memory at a valid physical address.
     // The blob contains the serialized variable-length optee_msg_arg structure(s).


### PR DESCRIPTION
This PR uses checked arithmetic against VTL0-controllable integers to avoid potential attacks via integer overflows or underflows.