### PR TITLE
Fix futex test

### DIFF
--- a/litebox/src/sync/futex.rs
+++ b/litebox/src/sync/futex.rs
@@ -346,12 +346,11 @@ mod tests {
         for waiter in waiters {
             let result = waiter.join().unwrap();
             match result {
-                Ok(()) | Err(FutexError::WaitError(_)) => {}
-                Err(
-                    FutexError::ImmediatelyWokenBecauseValueMismatch
-                    | FutexError::NotAligned
-                    | FutexError::Fault,
-                ) => {
+                Ok(())
+                | Err(
+                    FutexError::WaitError(_) | FutexError::ImmediatelyWokenBecauseValueMismatch,
+                ) => {}
+                Err(FutexError::NotAligned | FutexError::Fault) => {
                     unreachable!()
                 }
             }


### PR DESCRIPTION
The intention of the test was that all waiters are blocked and waiting for a wake up and then the main thread wake all of them up. However, it only uses `sleep` to ensure all waiters have called `futex` with wait operation, which may not hold, resulting in some waiters return immediately without being blocked. The fix is simple; some waiters may return `ImmediatelyWokenBecauseValueMismatch` and we just need to account for it.