### PR TITLE
Fix dup

### DIFF
--- a/litebox_runner_linux_userland/tests/dup.c
+++ b/litebox_runner_linux_userland/tests/dup.c
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// Tests: fd-duplication errno behavior around RLIMIT_NOFILE.
+
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/resource.h>
+#include <unistd.h>
+
+#define TEST_ASSERT(cond, msg)                                                \
+    do {                                                                      \
+        if (!(cond)) {                                                        \
+            fprintf(stderr, "FAIL: %s (line %d): %s (errno=%d: %s)\n",       \
+                    __func__, __LINE__, msg, errno, strerror(errno));         \
+            return 1;                                                         \
+        }                                                                     \
+    } while (0)
+
+static int set_nofile_soft_limit(rlim_t soft_limit) {
+    struct rlimit old_limit;
+    TEST_ASSERT(getrlimit(RLIMIT_NOFILE, &old_limit) == 0, "getrlimit failed");
+    TEST_ASSERT(old_limit.rlim_max == RLIM_INFINITY || old_limit.rlim_max >= soft_limit,
+                "hard RLIMIT_NOFILE is too low for test");
+
+    struct rlimit new_limit = old_limit;
+    new_limit.rlim_cur = soft_limit;
+    TEST_ASSERT(setrlimit(RLIMIT_NOFILE, &new_limit) == 0, "setrlimit failed");
+    return 0;
+}
+
+int main(void) {
+    const rlim_t soft_limit = 16;
+    if (set_nofile_soft_limit(soft_limit) != 0) {
+        return 1;
+    }
+
+    int valid_fd = open("/dev/null", O_RDONLY);
+    TEST_ASSERT(valid_fd >= 0, "open /dev/null failed");
+    int over_limit_fd = (int)soft_limit + 1;
+
+    errno = 0;
+    int ret = fcntl(valid_fd, F_DUPFD, (int)soft_limit);
+    TEST_ASSERT(ret == -1 && errno == EINVAL,
+                "valid fd with min_fd >= RLIMIT_NOFILE should fail with EINVAL");
+
+    errno = 0;
+    ret = dup2(valid_fd, over_limit_fd);
+    TEST_ASSERT(ret == -1 && errno == EBADF,
+                "dup2 with target fd > RLIMIT_NOFILE should fail with EBADF");
+
+    errno = 0;
+    ret = dup3(valid_fd, over_limit_fd, O_CLOEXEC);
+    TEST_ASSERT(ret == -1 && errno == EBADF,
+                "dup3 with target fd > RLIMIT_NOFILE should fail with EBADF");
+
+    int bad_fd = valid_fd;
+    TEST_ASSERT(close(valid_fd) == 0, "close valid_fd failed");
+
+    errno = 0;
+    ret = fcntl(bad_fd, F_DUPFD, (int)soft_limit);
+    TEST_ASSERT(ret == -1 && errno == EBADF,
+                "bad fd with min_fd >= RLIMIT_NOFILE should fail with EBADF");
+
+    errno = 0;
+    ret = dup2(bad_fd, over_limit_fd);
+    TEST_ASSERT(ret == -1 && errno == EBADF,
+                "dup2 with bad fd and target fd > RLIMIT_NOFILE should fail with EBADF");
+
+    errno = 0;
+    ret = dup3(bad_fd, over_limit_fd, O_CLOEXEC);
+    TEST_ASSERT(ret == -1 && errno == EBADF,
+                "dup3 with bad fd and target fd > RLIMIT_NOFILE should fail with EBADF");
+
+    printf("fd duplication RLIMIT_NOFILE errno ordering: PASS\n");
+    return 0;
+}

--- a/litebox_shim_linux/src/syscalls/file.rs
+++ b/litebox_shim_linux/src/syscalls/file.rs
@@ -2090,6 +2090,20 @@ impl<FS: ShimFS> Task<FS> {
             close_on_exec: bool,
             target: DupFdRequest,
         ) -> Result<usize, DupFdError> {
+            let max_fd = task
+                .process()
+                .limits
+                .get_rlimit_cur(litebox_common_linux::RlimitResource::NOFILE);
+            match target {
+                DupFdRequest::Exact(target) if target >= max_fd => {
+                    return Err(DupFdError::TargetFdExceedsLimit);
+                }
+                DupFdRequest::LowestAtOrAbove(min_fd) if min_fd >= max_fd => {
+                    return Err(DupFdError::TargetFdExceedsLimit);
+                }
+                _ => {}
+            }
+
             let mut dt = task.global.litebox.descriptor_table_mut();
             let fd: TypedFd<_> = dt.duplicate(fd).ok_or(DupFdError::BadFd)?;
             if close_on_exec {
@@ -2097,14 +2111,15 @@ impl<FS: ShimFS> Task<FS> {
                 assert!(old.is_none());
             }
             drop(dt);
-            match target {
+
+            let new_fd = match target {
                 DupFdRequest::Exact(target) => {
                     let _ = task.do_close_and_replace(target, Some(fd));
-                    Ok(target)
+                    target
                 }
                 DupFdRequest::LowestAvailable => {
                     let rds = &mut *files.raw_descriptor_store.write();
-                    Ok(rds.fd_into_raw_integer(fd))
+                    rds.fd_into_raw_integer(fd)
                 }
                 DupFdRequest::LowestAtOrAbove(min_fd) => {
                     let rds = &mut *files.raw_descriptor_store.write();
@@ -2117,26 +2132,19 @@ impl<FS: ShimFS> Task<FS> {
                     }
                     let success = rds.fd_into_specific_raw_integer(fd, raw_fd);
                     assert!(success);
-                    Ok(raw_fd)
+                    raw_fd
                 }
+            };
+            if new_fd >= max_fd {
+                let _ = task.do_close(new_fd);
+                return Err(DupFdError::TooManyFiles);
             }
+            Ok(new_fd)
         }
-        let max_fd = self
-            .process()
-            .limits
-            .get_rlimit_cur(litebox_common_linux::RlimitResource::NOFILE);
-        match target {
-            DupFdRequest::Exact(fd) if fd >= max_fd => {
-                return Err(DupFdError::TargetFdExceedsLimit);
-            }
-            DupFdRequest::LowestAtOrAbove(min_fd) if min_fd >= max_fd => {
-                return Err(DupFdError::TargetFdExceedsLimit);
-            }
-            _ => {}
-        }
+
         let close_on_exec = flags.contains(OFlags::CLOEXEC);
         let files = self.files.borrow();
-        let new_fd = files
+        files
             .run_on_raw_fd(
                 file,
                 |fd| dup(self, &files, fd, close_on_exec, target),
@@ -2146,12 +2154,7 @@ impl<FS: ShimFS> Task<FS> {
                 |fd| dup(self, &files, fd, close_on_exec, target),
                 |fd| dup(self, &files, fd, close_on_exec, target),
             )
-            .map_err(|_| DupFdError::BadFd)??;
-        if new_fd >= max_fd {
-            let _ = self.do_close(new_fd);
-            return Err(DupFdError::TooManyFiles);
-        }
-        Ok(new_fd)
+            .map_err(|_| DupFdError::BadFd)?
     }
 
     /// Handle syscall `dup/dup2/dup3`

--- a/litebox_shim_linux/src/syscalls/file.rs
+++ b/litebox_shim_linux/src/syscalls/file.rs
@@ -21,6 +21,7 @@ use litebox_common_linux::{
     IoReadVec, IoWriteVec, IoctlArg, TimeParam, errno::Errno,
 };
 use litebox_platform_multiplex::Platform;
+use thiserror::Error;
 
 use crate::{ConstPtr, GlobalState, MutPtr, ShimFS, Task};
 use core::sync::atomic::{AtomicUsize, Ordering};
@@ -598,64 +599,114 @@ impl<FS: ShimFS> Task<FS> {
     }
 
     pub(crate) fn do_close(&self, raw_fd: usize) -> Result<(), Errno> {
+        self.do_close_and_replace::<FS>(raw_fd, None)
+    }
+
+    /// Close the file at `raw_fd` and optionally place a new file in the same slot.
+    ///
+    /// This function ensure `close` and `insert` are done atomically.
+    fn do_close_and_replace<S: FdEnabledSubsystem>(
+        &self,
+        raw_fd: usize,
+        replace: Option<TypedFd<S>>,
+    ) -> Result<(), Errno> {
+        enum ConsumedFd<FS: ShimFS> {
+            Fs(alloc::sync::Arc<TypedFd<FS>>),
+            Network(alloc::sync::Arc<TypedFd<litebox::net::Network<Platform>>>),
+            Pipes(alloc::sync::Arc<TypedFd<litebox::pipes::Pipes<Platform>>>),
+            Eventfd(alloc::sync::Arc<TypedFd<super::eventfd::EventfdSubsystem>>),
+            Epoll(alloc::sync::Arc<TypedFd<super::epoll::EpollSubsystem<FS>>>),
+            Unix(alloc::sync::Arc<TypedFd<super::unix::UnixSocketSubsystem<FS>>>),
+        }
+
         let files = self.files.borrow();
         let mut rds = files.raw_descriptor_store.write();
-        match rds.fd_consume_raw_integer(raw_fd) {
-            Ok(fd) => {
-                drop(rds);
-                return files.fs.close(&fd).map_err(Errno::from);
-            }
+        let consumed: ConsumedFd<FS> = match rds.fd_consume_raw_integer::<FS>(raw_fd) {
+            Ok(fd) => ConsumedFd::Fs(fd),
             Err(litebox::fd::ErrRawIntFd::NotFound) => {
+                if let Some(new_fd) = replace {
+                    let success = rds.fd_into_specific_raw_integer(new_fd, raw_fd);
+                    assert!(success, "raw_fd slot is empty, so insert must succeed");
+                }
                 return Err(Errno::EBADF);
             }
             Err(litebox::fd::ErrRawIntFd::InvalidSubsystem) => {
-                // fallthrough
+                if let Ok(fd) =
+                    rds.fd_consume_raw_integer::<litebox::net::Network<Platform>>(raw_fd)
+                {
+                    ConsumedFd::Network(fd)
+                } else if let Ok(fd) =
+                    rds.fd_consume_raw_integer::<litebox::pipes::Pipes<Platform>>(raw_fd)
+                {
+                    ConsumedFd::Pipes(fd)
+                } else if let Ok(fd) =
+                    rds.fd_consume_raw_integer::<super::eventfd::EventfdSubsystem>(raw_fd)
+                {
+                    ConsumedFd::Eventfd(fd)
+                } else if let Ok(fd) =
+                    rds.fd_consume_raw_integer::<super::epoll::EpollSubsystem<FS>>(raw_fd)
+                {
+                    ConsumedFd::Epoll(fd)
+                } else if let Ok(fd) =
+                    rds.fd_consume_raw_integer::<super::unix::UnixSocketSubsystem<FS>>(raw_fd)
+                {
+                    ConsumedFd::Unix(fd)
+                } else {
+                    unreachable!("all subsystems covered")
+                }
+            }
+        };
+
+        // Insert the replacement into the now-vacated slot while still holding the lock.
+        if let Some(new_fd) = replace {
+            let success = rds.fd_into_specific_raw_integer(new_fd, raw_fd);
+            assert!(
+                success,
+                "we just consumed this raw_fd, so it must be available"
+            );
+        }
+        drop(rds);
+
+        if let Ok(fd) = i32::try_from(raw_fd) {
+            self.finalize_elf_patch(fd);
+        }
+
+        match consumed {
+            ConsumedFd::Fs(fd) => files.fs.close(&fd).map_err(Errno::from),
+            ConsumedFd::Network(fd) => self.global.close_socket(&self.wait_cx(), fd),
+            ConsumedFd::Pipes(fd) => self.global.pipes.close(&fd).map_err(Errno::from),
+            ConsumedFd::Eventfd(fd) => {
+                let entry = {
+                    let mut dt = self.global.litebox.descriptor_table_mut();
+                    dt.remove(&fd)
+                };
+                // do not hold any locks while dropping the entry
+                drop(entry);
+                Ok(())
+            }
+            ConsumedFd::Epoll(fd) => {
+                let entry = {
+                    let mut dt = self.global.litebox.descriptor_table_mut();
+                    dt.remove(&fd)
+                };
+                // do not hold any locks while dropping the entry
+                drop(entry);
+                Ok(())
+            }
+            ConsumedFd::Unix(fd) => {
+                let entry = {
+                    let mut dt = self.global.litebox.descriptor_table_mut();
+                    dt.remove(&fd)
+                };
+                // do not hold any locks while dropping the entry
+                drop(entry);
+                Ok(())
             }
         }
-        if let Ok(fd) = rds.fd_consume_raw_integer(raw_fd) {
-            drop(rds);
-            return self.global.close_socket(&self.wait_cx(), fd);
-        }
-        if let Ok(fd) = rds.fd_consume_raw_integer(raw_fd) {
-            drop(rds);
-            return self.global.pipes.close(&fd).map_err(Errno::from);
-        }
-        if let Ok(fd) = rds.fd_consume_raw_integer::<super::eventfd::EventfdSubsystem>(raw_fd) {
-            drop(rds);
-            let entry = {
-                let mut dt = self.global.litebox.descriptor_table_mut();
-                dt.remove(&fd)
-            };
-            drop(entry);
-            return Ok(());
-        }
-        if let Ok(fd) = rds.fd_consume_raw_integer::<super::epoll::EpollSubsystem<FS>>(raw_fd) {
-            drop(rds);
-            let entry = {
-                let mut dt = self.global.litebox.descriptor_table_mut();
-                dt.remove(&fd)
-            };
-            drop(entry);
-            return Ok(());
-        }
-        if let Ok(fd) = rds.fd_consume_raw_integer::<super::unix::UnixSocketSubsystem<FS>>(raw_fd) {
-            drop(rds);
-            let entry = {
-                let mut dt = self.global.litebox.descriptor_table_mut();
-                dt.remove(&fd)
-            };
-            drop(entry);
-            return Ok(());
-        }
-        // All the above cases should cover all the known subsystems, and we've already
-        // early-handled the "raw FD not found" case.
-        unreachable!()
     }
 
     /// Handle syscall `close`
     pub(crate) fn sys_close(&self, fd: i32) -> Result<(), Errno> {
-        self.finalize_elf_patch(fd);
-
         let Ok(raw_fd) = u32::try_from(fd).and_then(usize::try_from) else {
             return Err(Errno::EBADF);
         };
@@ -1306,22 +1357,21 @@ impl<FS: ShimFS> Task<FS> {
                     .flatten()
             }
             FcntlArg::DUPFD { cloexec, min_fd } => {
-                let max_fd = self
-                    .process()
-                    .limits
-                    .get_rlimit_cur(litebox_common_linux::RlimitResource::NOFILE);
-                if min_fd as usize >= max_fd {
-                    return Err(Errno::EINVAL);
-                }
-                let new_file = self.do_dup_inner(
-                    desc,
-                    if cloexec {
-                        OFlags::CLOEXEC
-                    } else {
-                        OFlags::empty()
-                    },
-                    DupFdRequest::LowestAtOrAbove(min_fd as usize),
-                )?;
+                let new_file = self
+                    .do_dup_inner(
+                        desc,
+                        if cloexec {
+                            OFlags::CLOEXEC
+                        } else {
+                            OFlags::empty()
+                        },
+                        DupFdRequest::LowestAtOrAbove(min_fd as usize),
+                    )
+                    .map_err(|e| match e {
+                        DupFdError::BadFd => Errno::EBADF,
+                        DupFdError::TooManyFiles => Errno::EMFILE,
+                        DupFdError::TargetFdExceedsLimit => Errno::EINVAL,
+                    })?;
                 Ok(new_file.try_into().unwrap())
             }
             _ => unimplemented!(),
@@ -2022,7 +2072,7 @@ impl<FS: ShimFS> Task<FS> {
         Ok(count)
     }
 
-    fn do_dup(&self, file: usize, flags: OFlags) -> Result<usize, Errno> {
+    fn do_dup(&self, file: usize, flags: OFlags) -> Result<usize, DupFdError> {
         self.do_dup_inner(file, flags, DupFdRequest::LowestAvailable)
     }
 
@@ -2031,30 +2081,32 @@ impl<FS: ShimFS> Task<FS> {
         file: usize,
         flags: OFlags,
         target: DupFdRequest,
-    ) -> Result<usize, Errno> {
+    ) -> Result<usize, DupFdError> {
         fn dup<FS: ShimFS, S: FdEnabledSubsystem>(
-            global: &GlobalState<FS>,
+            task: &Task<FS>,
             files: &FilesState<FS>,
             fd: &TypedFd<S>,
             close_on_exec: bool,
             target: DupFdRequest,
-        ) -> Result<usize, Errno> {
-            let mut dt = global.litebox.descriptor_table_mut();
-            let fd: TypedFd<_> = dt.duplicate(fd).ok_or(Errno::EBADF)?;
+        ) -> Result<usize, DupFdError> {
+            let mut dt = task.global.litebox.descriptor_table_mut();
+            let fd: TypedFd<_> = dt.duplicate(fd).ok_or(DupFdError::BadFd)?;
             if close_on_exec {
                 let old = dt.set_fd_metadata(&fd, FileDescriptorFlags::FD_CLOEXEC);
                 assert!(old.is_none());
             }
-            let mut rds = files.raw_descriptor_store.write();
+            drop(dt);
             match target {
                 DupFdRequest::Exact(target) => {
-                    if !rds.fd_into_specific_raw_integer(fd, target) {
-                        return Err(Errno::EBADF);
-                    }
+                    let _ = task.do_close_and_replace(target, Some(fd));
                     Ok(target)
                 }
-                DupFdRequest::LowestAvailable => Ok(rds.fd_into_raw_integer(fd)),
+                DupFdRequest::LowestAvailable => {
+                    let rds = &mut *files.raw_descriptor_store.write();
+                    Ok(rds.fd_into_raw_integer(fd))
+                }
                 DupFdRequest::LowestAtOrAbove(min_fd) => {
+                    let rds = &mut *files.raw_descriptor_store.write();
                     let mut raw_fd = min_fd;
                     for occupied_raw_fd in rds.iter_alive().skip_while(|&fd| fd < min_fd) {
                         if occupied_raw_fd != raw_fd {
@@ -2068,29 +2120,35 @@ impl<FS: ShimFS> Task<FS> {
                 }
             }
         }
+        let max_fd = self
+            .process()
+            .limits
+            .get_rlimit_cur(litebox_common_linux::RlimitResource::NOFILE);
+        match target {
+            DupFdRequest::Exact(fd) if fd >= max_fd => {
+                return Err(DupFdError::TargetFdExceedsLimit);
+            }
+            DupFdRequest::LowestAtOrAbove(min_fd) if min_fd >= max_fd => {
+                return Err(DupFdError::TargetFdExceedsLimit);
+            }
+            _ => {}
+        }
         let close_on_exec = flags.contains(OFlags::CLOEXEC);
         let files = self.files.borrow();
-        let new_fd = files.run_on_raw_fd(
-            file,
-            |fd| dup(&self.global, &files, fd, close_on_exec, target),
-            |fd| dup(&self.global, &files, fd, close_on_exec, target),
-            |fd| dup(&self.global, &files, fd, close_on_exec, target),
-            |fd| dup(&self.global, &files, fd, close_on_exec, target),
-            |fd| dup(&self.global, &files, fd, close_on_exec, target),
-            |fd| dup(&self.global, &files, fd, close_on_exec, target),
-        )??;
-        if matches!(
-            target,
-            DupFdRequest::LowestAvailable | DupFdRequest::LowestAtOrAbove(_)
-        ) {
-            let max_fd = self
-                .process()
-                .limits
-                .get_rlimit_cur(litebox_common_linux::RlimitResource::NOFILE);
-            if new_fd >= max_fd {
-                self.do_close(new_fd)?;
-                return Err(Errno::EMFILE);
-            }
+        let new_fd = files
+            .run_on_raw_fd(
+                file,
+                |fd| dup(self, &files, fd, close_on_exec, target),
+                |fd| dup(self, &files, fd, close_on_exec, target),
+                |fd| dup(self, &files, fd, close_on_exec, target),
+                |fd| dup(self, &files, fd, close_on_exec, target),
+                |fd| dup(self, &files, fd, close_on_exec, target),
+                |fd| dup(self, &files, fd, close_on_exec, target),
+            )
+            .map_err(|_| DupFdError::BadFd)??;
+        if new_fd >= max_fd {
+            let _ = self.do_close(new_fd);
+            return Err(DupFdError::TooManyFiles);
         }
         Ok(new_fd)
     }
@@ -2135,26 +2193,21 @@ impl<FS: ShimFS> Task<FS> {
                     Ok(oldfd)
                 };
             }
-            // Close whatever is at newfd before duping into it.
-            // Finalize any in-progress ELF patching for the target fd first,
-            // since dup2/dup3 implicitly closes it without going through
-            // sys_close.
             let newfd_usize = usize::try_from(newfd).or(Err(Errno::EBADF))?;
-            if let Ok(fd) = i32::try_from(newfd) {
-                self.finalize_elf_patch(fd);
-            }
-            let _ = self.do_close(newfd_usize);
             self.do_dup_inner(
                 oldfd_usize,
                 flags.unwrap_or(OFlags::empty()),
                 DupFdRequest::Exact(newfd_usize),
-            )?;
-            Ok(newfd)
+            )
         } else {
             // dup
-            let new_file = self.do_dup(oldfd_usize, flags.unwrap_or(OFlags::empty()))?;
-            Ok(u32::try_from(new_file).unwrap())
+            self.do_dup(oldfd_usize, flags.unwrap_or(OFlags::empty()))
         }
+        .map_err(|e| match e {
+            DupFdError::BadFd | DupFdError::TargetFdExceedsLimit => Errno::EBADF,
+            DupFdError::TooManyFiles => Errno::EMFILE,
+        })
+        .map(|new_fd| u32::try_from(new_fd).unwrap())
     }
 }
 
@@ -2162,7 +2215,18 @@ impl<FS: ShimFS> Task<FS> {
 enum DupFdRequest {
     LowestAvailable,
     LowestAtOrAbove(usize),
+    /// Duplicate to the specified fd, closing it first if it's open.
     Exact(usize),
+}
+
+#[derive(Error, Debug)]
+enum DupFdError {
+    #[error("Bad file descriptor")]
+    BadFd,
+    #[error("Too many open files")]
+    TooManyFiles,
+    #[error("Target fd exceeds process limit")]
+    TargetFdExceedsLimit,
 }
 
 #[derive(Clone, Copy, Debug, Default)]

--- a/litebox_shim_linux/src/syscalls/file.rs
+++ b/litebox_shim_linux/src/syscalls/file.rs
@@ -167,7 +167,7 @@ impl<FS: ShimFS> Task<FS> {
     }
 
     /// Resolve a path against the current working directory.
-    fn resolve_path(&self, path: impl path::Arg) -> Result<CString, Errno> {
+    pub(crate) fn resolve_path(&self, path: impl path::Arg) -> Result<CString, Errno> {
         let path_str = path.as_rust_str().map_err(|_| Errno::EINVAL)?;
         if path_str.is_empty() {
             return Err(Errno::ENOENT);
@@ -197,7 +197,7 @@ impl<FS: ShimFS> Task<FS> {
         }
     }
 
-    fn do_open(
+    pub(crate) fn do_open(
         &self,
         path: impl path::Arg,
         flags: OFlags,
@@ -667,12 +667,13 @@ impl<FS: ShimFS> Task<FS> {
         }
         drop(rds);
 
-        if let Ok(fd) = i32::try_from(raw_fd) {
-            self.finalize_elf_patch(fd);
-        }
-
         match consumed {
-            ConsumedFd::Fs(fd) => files.fs.close(&fd).map_err(Errno::from),
+            ConsumedFd::Fs(fd) => {
+                if let Ok(raw_fd) = i32::try_from(raw_fd) {
+                    self.finalize_elf_patch(raw_fd);
+                }
+                files.fs.close(&fd).map_err(Errno::from)
+            }
             ConsumedFd::Network(fd) => self.global.close_socket(&self.wait_cx(), fd),
             ConsumedFd::Pipes(fd) => self.global.pipes.close(&fd).map_err(Errno::from),
             ConsumedFd::Eventfd(fd) => {

--- a/litebox_shim_linux/src/syscalls/process.rs
+++ b/litebox_shim_linux/src/syscalls/process.rs
@@ -1350,20 +1350,22 @@ impl<FS: ShimFS> Task<FS> {
         mut argv: alloc::vec::Vec<alloc::ffi::CString>,
     ) -> Result<(alloc::string::String, alloc::vec::Vec<alloc::ffi::CString>), Errno> {
         for _ in 0..SHEBANG_MAX_RECURSION {
-            let fd = self.sys_open(
-                path.as_str(),
+            let full_path = self.resolve_path(&path)?;
+            let file = self.do_open(
+                full_path,
                 litebox::fs::OFlags::RDONLY,
                 litebox::fs::Mode::empty(),
             )?;
             let mut header = [0u8; SHEBANG_MAX_LINE];
-            let n = match self.do_read(fd, &mut header, Some(0)) {
+            let files = self.files.borrow();
+            let n = match files.fs.read(&file, &mut header, Some(0)) {
                 Ok(n) => n,
                 Err(e) => {
-                    let _ = self.do_close(fd as usize);
-                    return Err(e);
+                    let _ = files.fs.close(&file);
+                    return Err(Errno::from(e));
                 }
             };
-            let _ = self.do_close(fd as usize);
+            let _ = files.fs.close(&file);
 
             match parse_shebang(&header[..n]) {
                 Some((interp, opt_arg)) => {


### PR DESCRIPTION
Looks like `dup` and `fcntl` with `F_DUPFD` return different error codes when the specified fd is larger than the process file limit.

Also fix a race issue in `dup` where the specified fd needs to to be closed and then reused, which requires performing `close` and `insert` in an atomic manner. Otherwise, in between these two operations, the fd might be taken by another thread.