### PR TITLE
Fix mremap

### DIFF
--- a/litebox/src/platform/page_mgmt.rs
+++ b/litebox/src/platform/page_mgmt.rs
@@ -135,12 +135,13 @@ pub trait PageManagementProvider<const ALIGN: usize>: RawPointerProvider {
         let total_len = old_range.len();
         let mut offset = 0;
         while offset < total_len {
+            let chunk_len = (total_len - offset).min(ALIGN);
             let old_ptr =
                 <Self as RawPointerProvider>::RawConstPointer::from_usize(old_range.start + offset);
             new_ptr
                 .write_slice_at_offset(
                     isize::try_from(offset).unwrap(),
-                    &old_ptr.to_owned_slice(old_range.len()).unwrap(),
+                    &old_ptr.to_owned_slice(chunk_len).unwrap(),
                 )
                 .unwrap();
             offset += ALIGN;
@@ -148,7 +149,7 @@ pub trait PageManagementProvider<const ALIGN: usize>: RawPointerProvider {
 
         if temp_permissions != permissions {
             (unsafe { self.update_permissions(new_range.clone(), permissions) })
-                .expect("failed to restore perrmissions on new range");
+                .expect("failed to restore permissions on new range");
         }
 
         (unsafe { self.deallocate_pages(old_range) }).expect("failed to deallocate old range");

--- a/litebox_common_linux/src/mm.rs
+++ b/litebox_common_linux/src/mm.rs
@@ -20,12 +20,6 @@ fn align_up(addr: usize, align: usize) -> usize {
     (addr + align - 1) & !(align - 1)
 }
 
-#[inline]
-fn align_down(addr: usize, align: usize) -> usize {
-    debug_assert!(align.is_power_of_two());
-    addr & !(align - 1)
-}
-
 pub fn do_mmap<
     Platform: litebox::platform::RawPointerProvider
         + litebox::sync::RawSyncPrimitivesProvider
@@ -184,8 +178,8 @@ pub fn sys_mremap<
         return Err(Errno::EINVAL);
     }
 
-    let old_size = align_down(old_size, PAGE_SIZE);
-    let new_size = align_down(new_size, PAGE_SIZE);
+    let old_size = align_up(old_size, PAGE_SIZE);
+    let new_size = align_up(new_size, PAGE_SIZE);
     if new_size == 0 {
         return Err(Errno::EINVAL);
     }

--- a/litebox_common_linux/src/mm.rs
+++ b/litebox_common_linux/src/mm.rs
@@ -14,12 +14,6 @@ use crate::{MRemapFlags, MapFlags, ProtFlags, errno::Errno};
 
 const PAGE_MASK: usize = !(PAGE_SIZE - 1);
 
-#[inline]
-fn align_up(addr: usize, align: usize) -> usize {
-    debug_assert!(align.is_power_of_two());
-    (addr + align - 1) & !(align - 1)
-}
-
 pub fn do_mmap<
     Platform: litebox::platform::RawPointerProvider
         + litebox::sync::RawSyncPrimitivesProvider
@@ -97,7 +91,9 @@ pub fn sys_munmap<
     if len == 0 {
         return Err(Errno::EINVAL);
     }
-    let aligned_len = align_up(len, PAGE_SIZE);
+    let aligned_len = len
+        .checked_next_multiple_of(PAGE_SIZE)
+        .ok_or(Errno::EINVAL)?;
     if addr.as_usize().checked_add(aligned_len).is_none() {
         return Err(Errno::EINVAL);
     }
@@ -178,8 +174,12 @@ pub fn sys_mremap<
         return Err(Errno::EINVAL);
     }
 
-    let old_size = align_up(old_size, PAGE_SIZE);
-    let new_size = align_up(new_size, PAGE_SIZE);
+    let old_size = old_size
+        .checked_next_multiple_of(PAGE_SIZE)
+        .ok_or(Errno::EINVAL)?;
+    let new_size = new_size
+        .checked_next_multiple_of(PAGE_SIZE)
+        .ok_or(Errno::EINVAL)?;
     if new_size == 0 {
         return Err(Errno::EINVAL);
     }

--- a/litebox_platform_linux_kernel/src/lib.rs
+++ b/litebox_platform_linux_kernel/src/lib.rs
@@ -459,7 +459,7 @@ impl<Host: HostInterface, const ALIGN: usize> PageManagementProvider<ALIGN> for 
             .ok_or(litebox::platform::page_mgmt::RemapError::Unaligned)?;
         let new_range = PageRange::new(new_range.start, new_range.end)
             .ok_or(litebox::platform::page_mgmt::RemapError::Unaligned)?;
-        if old_range.start.max(new_range.start) <= old_range.end.min(new_range.end) {
+        if old_range.start.max(new_range.start) < old_range.end.min(new_range.end) {
             return Err(litebox::platform::page_mgmt::RemapError::Overlapping);
         }
         unsafe { self.page_table.remap_pages(old_range, new_range) }

--- a/litebox_platform_lvbs/src/lib.rs
+++ b/litebox_platform_lvbs/src/lib.rs
@@ -1266,7 +1266,7 @@ impl<Host: HostInterface, const ALIGN: usize> PageManagementProvider<ALIGN> for 
             .ok_or(litebox::platform::page_mgmt::RemapError::Unaligned)?;
         let new_range = PageRange::new(new_range.start, new_range.end)
             .ok_or(litebox::platform::page_mgmt::RemapError::Unaligned)?;
-        if old_range.start.max(new_range.start) <= old_range.end.min(new_range.end) {
+        if old_range.start.max(new_range.start) < old_range.end.min(new_range.end) {
             return Err(litebox::platform::page_mgmt::RemapError::Overlapping);
         }
         unsafe {


### PR DESCRIPTION
This PR fixes three issues in `mremap` found by AI.

1. `old_size` and `new_size` are rounded down to page boundary instead of up (Linux expects round-up).
2.  The default impl of `remap_pages` copies wrong chunk size, reading out-of-bounds on multi-page remaps.
3. Fix overlap check in kernel platform.