### PR TITLE
Add secure random number generator to LVBS platform

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1576,6 +1576,8 @@ dependencies = [
  "num_enum",
  "object",
  "once_cell",
+ "rand_chacha",
+ "rand_core",
  "rangemap",
  "raw-cpuid",
  "rsa",

--- a/litebox_platform_lvbs/Cargo.toml
+++ b/litebox_platform_lvbs/Cargo.toml
@@ -31,6 +31,8 @@ object = { version = "0.36.7", default-features = false, features = ["pe"] }
 digest = { version = "0.10.7", default-features = false }
 aligned-vec = { version = "0.6.4", default-features = false }
 raw-cpuid = "11.6.0"
+rand_chacha = { version = "0.3.1", default-features = false }
+rand_core = { version = "0.6.4", default-features = false }
 zerocopy = { version = "0.8", default-features = false, features = ["derive"] }
 zeroize = { version = "1.8", default-features = false }
 

--- a/litebox_platform_lvbs/src/host/lvbs_impl.rs
+++ b/litebox_platform_lvbs/src/host/lvbs_impl.rs
@@ -232,7 +232,7 @@ fn rdrand_seed() -> Option<CrngSeed> {
         if !ok {
             return None;
         }
-        chunk.copy_from_slice(&word.to_ne_bytes()[..chunk.len()]);
+        chunk.copy_from_slice(&word.to_le_bytes()[..chunk.len()]);
     }
     Some(seed)
 }
@@ -307,5 +307,33 @@ impl HostInterface for HostLvbsInterface {
 
     fn switch(_result: u64) -> ! {
         unimplemented!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec;
+
+    const TEST_PRK: [u8; PRK_LEN] = [0x42; PRK_LEN];
+    const INIT_SEED: CrngSeed = [0xA5; 32];
+    const RESEED_SEED: CrngSeed = [0x5A; 32];
+
+    #[test]
+    fn crosses_reseed_boundary_twice_with_accurate_budget() {
+        let mut crng = LvbsCrng::new(&TEST_PRK, INIT_SEED);
+        let mut buf = vec![0u8; CRNG_RESEED_INTERVAL_BYTES * 2 + 7];
+        crng.fill_bytes(&mut buf, || Some(RESEED_SEED));
+        assert_eq!(crng.reseed_counter, 2);
+        assert_eq!(crng.bytes_until_reseed, CRNG_RESEED_INTERVAL_BYTES - 7);
+    }
+
+    #[test]
+    fn rdrand_failure_engages_backoff_without_reseed() {
+        let mut crng = LvbsCrng::new(&TEST_PRK, INIT_SEED);
+        let mut buf = vec![0u8; CRNG_RESEED_INTERVAL_BYTES];
+        crng.fill_bytes(&mut buf, || None);
+        assert_eq!(crng.reseed_counter, 0);
+        assert_eq!(crng.bytes_until_reseed, CRNG_RESEED_BACKOFF_BYTES);
     }
 }

--- a/litebox_platform_lvbs/src/host/lvbs_impl.rs
+++ b/litebox_platform_lvbs/src/host/lvbs_impl.rs
@@ -7,6 +7,7 @@ use crate::{
     Errno, HostInterface, arch::ioport::serial_print_string,
     host::per_cpu_variables::with_per_cpu_variables,
 };
+use rand_core::{RngCore, SeedableRng};
 use zeroize::Zeroizing;
 
 pub type LvbsLinuxKernel = crate::LinuxKernel<HostLvbsInterface>;
@@ -103,15 +104,13 @@ unsafe impl litebox::platform::ThreadLocalStorageProvider for LvbsLinuxKernel {
 
 impl litebox::platform::CrngProvider for LvbsLinuxKernel {
     fn fill_bytes_crng(&self, buf: &mut [u8]) {
-        // FIXME: generate real random data.
-        static RANDOM: spin::mutex::SpinMutex<litebox::utils::rng::FastRng> =
-            spin::mutex::SpinMutex::new(litebox::utils::rng::FastRng::new_from_seed(
-                core::num::NonZeroU64::new(0x4d595df4d0f33173).unwrap(),
-            ));
+        static RANDOM: spin::mutex::SpinMutex<Option<rand_chacha::ChaCha20Rng>> =
+            spin::mutex::SpinMutex::new(None);
+
         let mut random = RANDOM.lock();
-        for b in buf.chunks_mut(8) {
-            b.copy_from_slice(&random.next_u64().to_ne_bytes()[..b.len()]);
-        }
+        random
+            .get_or_insert_with(|| rand_chacha::ChaCha20Rng::from_seed(rdrand_seed()))
+            .fill_bytes(buf);
     }
 }
 
@@ -154,6 +153,23 @@ impl litebox::platform::DerivedKeyProvider for LvbsLinuxKernel {
             Some(kdf) => Ok(kdf(prk, params)?),
         }
     }
+}
+
+fn rdrand_seed() -> <rand_chacha::ChaCha20Rng as SeedableRng>::Seed {
+    let mut seed = <rand_chacha::ChaCha20Rng as SeedableRng>::Seed::default();
+    for chunk in seed.chunks_mut(8) {
+        let mut word = 0;
+        loop {
+            // Safety: `RDRAND` is available on the LVBS target CPUs. A false
+            // carry flag means random data is temporarily unavailable.
+            if unsafe { core::arch::x86_64::_rdrand64_step(&mut word) } == 1 {
+                break;
+            }
+            core::hint::spin_loop();
+        }
+        chunk.copy_from_slice(&word.to_ne_bytes()[..chunk.len()]);
+    }
+    seed
 }
 
 pub struct HostLvbsInterface;

--- a/litebox_platform_lvbs/src/host/lvbs_impl.rs
+++ b/litebox_platform_lvbs/src/host/lvbs_impl.rs
@@ -231,11 +231,12 @@ fn crng_seed_from_prk_and_rdrand(
     prk: &[u8; PRK_LEN],
     rdrand_seed: <rand_chacha::ChaCha20Rng as SeedableRng>::Seed,
 ) -> <rand_chacha::ChaCha20Rng as SeedableRng>::Seed {
-    let mut hasher = sha2::Sha256::new();
-    hasher.update(b"litebox-lvbs-crng-seed-v1");
-    hasher.update(prk);
-    hasher.update(rdrand_seed);
-    hasher.finalize().into()
+    sha2::Sha256::new()
+        .chain_update(b"litebox-lvbs-crng-seed-v1")
+        .chain_update(prk)
+        .chain_update(rdrand_seed)
+        .finalize()
+        .into()
 }
 
 fn crng_reseed_from_rdrand_and_state(
@@ -243,12 +244,13 @@ fn crng_reseed_from_rdrand_and_state(
     reseed_counter: usize,
     current_state: &[u8; CRNG_RESEED_STATE_BYTES],
 ) -> <rand_chacha::ChaCha20Rng as SeedableRng>::Seed {
-    let mut hasher = sha2::Sha256::new();
-    hasher.update(b"litebox-lvbs-crng-reseed-v1");
-    hasher.update(rdrand_seed);
-    hasher.update(reseed_counter.to_le_bytes());
-    hasher.update(current_state);
-    hasher.finalize().into()
+    sha2::Sha256::new()
+        .chain_update(b"litebox-lvbs-crng-reseed-v1")
+        .chain_update(rdrand_seed)
+        .chain_update(reseed_counter.to_le_bytes())
+        .chain_update(current_state)
+        .finalize()
+        .into()
 }
 
 pub struct HostLvbsInterface;

--- a/litebox_platform_lvbs/src/host/lvbs_impl.rs
+++ b/litebox_platform_lvbs/src/host/lvbs_impl.rs
@@ -109,13 +109,22 @@ impl litebox::platform::CrngProvider for LvbsLinuxKernel {
 
         let mut random = RANDOM.lock();
         random
-            .get_or_insert_with(|| LvbsCrng::new(PRK_ONCE.wait(), rdrand_seed()))
+            .get_or_insert_with(|| {
+                LvbsCrng::new(
+                    PRK_ONCE.get().expect("Platform root key not initialized"),
+                    rdrand_seed().expect("RDRAND unavailable during CRNG initialization"),
+                )
+            })
             .fill_bytes(buf, rdrand_seed);
     }
 }
 
+type CrngSeed = <rand_chacha::ChaCha20Rng as SeedableRng>::Seed;
+
 const CRNG_RESEED_INTERVAL_BYTES: usize = 1024 * 1024;
+const CRNG_RESEED_BACKOFF_BYTES: usize = 64 * 1024;
 const CRNG_RESEED_STATE_BYTES: usize = 32;
+const RDRAND_RETRY_ATTEMPTS: u32 = 10;
 
 struct LvbsCrng {
     random: rand_chacha::ChaCha20Rng,
@@ -124,10 +133,7 @@ struct LvbsCrng {
 }
 
 impl LvbsCrng {
-    fn new(
-        prk: &[u8; PRK_LEN],
-        rdrand_seed: <rand_chacha::ChaCha20Rng as SeedableRng>::Seed,
-    ) -> Self {
+    fn new(prk: &[u8; PRK_LEN], rdrand_seed: CrngSeed) -> Self {
         Self {
             random: rand_chacha::ChaCha20Rng::from_seed(crng_seed_from_prk_and_rdrand(
                 prk,
@@ -138,11 +144,7 @@ impl LvbsCrng {
         }
     }
 
-    fn fill_bytes(
-        &mut self,
-        mut buf: &mut [u8],
-        rdrand_seed: impl Fn() -> <rand_chacha::ChaCha20Rng as SeedableRng>::Seed,
-    ) {
+    fn fill_bytes(&mut self, mut buf: &mut [u8], rdrand_seed: impl Fn() -> Option<CrngSeed>) {
         while !buf.is_empty() {
             let len = buf.len().min(self.bytes_until_reseed);
             let (chunk, rest) = buf.split_at_mut(len);
@@ -151,12 +153,15 @@ impl LvbsCrng {
             self.bytes_until_reseed -= len;
 
             if self.bytes_until_reseed == 0 {
-                self.reseed(rdrand_seed());
+                match rdrand_seed() {
+                    Some(seed) => self.reseed(seed),
+                    None => self.bytes_until_reseed = CRNG_RESEED_BACKOFF_BYTES,
+                }
             }
         }
     }
 
-    fn reseed(&mut self, rdrand_seed: <rand_chacha::ChaCha20Rng as SeedableRng>::Seed) {
+    fn reseed(&mut self, rdrand_seed: CrngSeed) {
         self.reseed_counter += 1;
         let mut current_state = Zeroizing::new([0u8; CRNG_RESEED_STATE_BYTES]);
         self.random.fill_bytes(&mut *current_state);
@@ -210,27 +215,29 @@ impl litebox::platform::DerivedKeyProvider for LvbsLinuxKernel {
     }
 }
 
-fn rdrand_seed() -> <rand_chacha::ChaCha20Rng as SeedableRng>::Seed {
-    let mut seed = <rand_chacha::ChaCha20Rng as SeedableRng>::Seed::default();
+fn rdrand_seed() -> Option<CrngSeed> {
+    let mut seed = CrngSeed::default();
     for chunk in seed.chunks_mut(8) {
         let mut word = 0;
-        loop {
+        let mut ok = false;
+        for _ in 0..RDRAND_RETRY_ATTEMPTS {
             // Safety: `RDRAND` is available on the LVBS target CPUs. A false
             // carry flag means random data is temporarily unavailable.
             if unsafe { core::arch::x86_64::_rdrand64_step(&mut word) } == 1 {
+                ok = true;
                 break;
             }
             core::hint::spin_loop();
         }
+        if !ok {
+            return None;
+        }
         chunk.copy_from_slice(&word.to_ne_bytes()[..chunk.len()]);
     }
-    seed
+    Some(seed)
 }
 
-fn crng_seed_from_prk_and_rdrand(
-    prk: &[u8; PRK_LEN],
-    rdrand_seed: <rand_chacha::ChaCha20Rng as SeedableRng>::Seed,
-) -> <rand_chacha::ChaCha20Rng as SeedableRng>::Seed {
+fn crng_seed_from_prk_and_rdrand(prk: &[u8; PRK_LEN], rdrand_seed: CrngSeed) -> CrngSeed {
     sha2::Sha256::new()
         .chain_update(b"litebox-lvbs-crng-seed-v1")
         .chain_update(prk)
@@ -240,10 +247,10 @@ fn crng_seed_from_prk_and_rdrand(
 }
 
 fn crng_reseed_from_rdrand_and_state(
-    rdrand_seed: <rand_chacha::ChaCha20Rng as SeedableRng>::Seed,
+    rdrand_seed: CrngSeed,
     reseed_counter: usize,
     current_state: &[u8; CRNG_RESEED_STATE_BYTES],
-) -> <rand_chacha::ChaCha20Rng as SeedableRng>::Seed {
+) -> CrngSeed {
     sha2::Sha256::new()
         .chain_update(b"litebox-lvbs-crng-reseed-v1")
         .chain_update(rdrand_seed)

--- a/litebox_platform_lvbs/src/host/lvbs_impl.rs
+++ b/litebox_platform_lvbs/src/host/lvbs_impl.rs
@@ -7,6 +7,7 @@ use crate::{
     Errno, HostInterface, arch::ioport::serial_print_string,
     host::per_cpu_variables::with_per_cpu_variables,
 };
+use digest::Digest;
 use rand_core::{RngCore, SeedableRng};
 use zeroize::Zeroizing;
 
@@ -104,13 +105,67 @@ unsafe impl litebox::platform::ThreadLocalStorageProvider for LvbsLinuxKernel {
 
 impl litebox::platform::CrngProvider for LvbsLinuxKernel {
     fn fill_bytes_crng(&self, buf: &mut [u8]) {
-        static RANDOM: spin::mutex::SpinMutex<Option<rand_chacha::ChaCha20Rng>> =
-            spin::mutex::SpinMutex::new(None);
+        static RANDOM: spin::mutex::SpinMutex<Option<LvbsCrng>> = spin::mutex::SpinMutex::new(None);
 
         let mut random = RANDOM.lock();
         random
-            .get_or_insert_with(|| rand_chacha::ChaCha20Rng::from_seed(rdrand_seed()))
-            .fill_bytes(buf);
+            .get_or_insert_with(|| LvbsCrng::new(PRK_ONCE.wait(), rdrand_seed()))
+            .fill_bytes(buf, rdrand_seed);
+    }
+}
+
+const CRNG_RESEED_INTERVAL_BYTES: usize = 1024 * 1024;
+const CRNG_RESEED_STATE_BYTES: usize = 32;
+
+struct LvbsCrng {
+    random: rand_chacha::ChaCha20Rng,
+    bytes_until_reseed: usize,
+    reseed_counter: usize,
+}
+
+impl LvbsCrng {
+    fn new(
+        prk: &[u8; PRK_LEN],
+        rdrand_seed: <rand_chacha::ChaCha20Rng as SeedableRng>::Seed,
+    ) -> Self {
+        Self {
+            random: rand_chacha::ChaCha20Rng::from_seed(crng_seed_from_prk_and_rdrand(
+                prk,
+                rdrand_seed,
+            )),
+            bytes_until_reseed: CRNG_RESEED_INTERVAL_BYTES,
+            reseed_counter: 0,
+        }
+    }
+
+    fn fill_bytes(
+        &mut self,
+        mut buf: &mut [u8],
+        rdrand_seed: impl Fn() -> <rand_chacha::ChaCha20Rng as SeedableRng>::Seed,
+    ) {
+        while !buf.is_empty() {
+            let len = buf.len().min(self.bytes_until_reseed);
+            let (chunk, rest) = buf.split_at_mut(len);
+            self.random.fill_bytes(chunk);
+            buf = rest;
+            self.bytes_until_reseed -= len;
+
+            if self.bytes_until_reseed == 0 {
+                self.reseed(rdrand_seed());
+            }
+        }
+    }
+
+    fn reseed(&mut self, rdrand_seed: <rand_chacha::ChaCha20Rng as SeedableRng>::Seed) {
+        self.reseed_counter += 1;
+        let mut current_state = Zeroizing::new([0u8; CRNG_RESEED_STATE_BYTES]);
+        self.random.fill_bytes(&mut *current_state);
+        self.random = rand_chacha::ChaCha20Rng::from_seed(crng_reseed_from_rdrand_and_state(
+            rdrand_seed,
+            self.reseed_counter,
+            &current_state,
+        ));
+        self.bytes_until_reseed = CRNG_RESEED_INTERVAL_BYTES;
     }
 }
 
@@ -170,6 +225,30 @@ fn rdrand_seed() -> <rand_chacha::ChaCha20Rng as SeedableRng>::Seed {
         chunk.copy_from_slice(&word.to_ne_bytes()[..chunk.len()]);
     }
     seed
+}
+
+fn crng_seed_from_prk_and_rdrand(
+    prk: &[u8; PRK_LEN],
+    rdrand_seed: <rand_chacha::ChaCha20Rng as SeedableRng>::Seed,
+) -> <rand_chacha::ChaCha20Rng as SeedableRng>::Seed {
+    let mut hasher = sha2::Sha256::new();
+    hasher.update(b"litebox-lvbs-crng-seed-v1");
+    hasher.update(prk);
+    hasher.update(rdrand_seed);
+    hasher.finalize().into()
+}
+
+fn crng_reseed_from_rdrand_and_state(
+    rdrand_seed: <rand_chacha::ChaCha20Rng as SeedableRng>::Seed,
+    reseed_counter: usize,
+    current_state: &[u8; CRNG_RESEED_STATE_BYTES],
+) -> <rand_chacha::ChaCha20Rng as SeedableRng>::Seed {
+    let mut hasher = sha2::Sha256::new();
+    hasher.update(b"litebox-lvbs-crng-reseed-v1");
+    hasher.update(rdrand_seed);
+    hasher.update(reseed_counter.to_le_bytes());
+    hasher.update(current_state);
+    hasher.finalize().into()
 }
 
 pub struct HostLvbsInterface;

--- a/litebox_shim_optee/src/lib.rs
+++ b/litebox_shim_optee/src/lib.rs
@@ -750,7 +750,7 @@ impl Task {
                 ElfLoaderError::MappingError(litebox::mm::linux::MappingError::OutOfMemory),
             )?;
         ta_stack
-            .init(self, params)
+            .init(self.global.platform, params)
             .ok_or(ElfLoaderError::InvalidStackAddr)?;
 
         Ok(ThreadInitState::Ta {

--- a/litebox_shim_optee/src/lib.rs
+++ b/litebox_shim_optee/src/lib.rs
@@ -750,7 +750,7 @@ impl Task {
                 ElfLoaderError::MappingError(litebox::mm::linux::MappingError::OutOfMemory),
             )?;
         ta_stack
-            .init(params)
+            .init(self, params)
             .ok_or(ElfLoaderError::InvalidStackAddr)?;
 
         Ok(ThreadInitState::Ta {

--- a/litebox_shim_optee/src/loader/ta_stack.rs
+++ b/litebox_shim_optee/src/loader/ta_stack.rs
@@ -226,7 +226,7 @@ impl TaStack {
         Some(())
     }
 
-    pub(crate) fn init(&mut self, params: &[UteeParamOwned]) -> Option<()> {
+    pub(crate) fn init(&mut self, task: &crate::Task, params: &[UteeParamOwned]) -> Option<()> {
         if params.len() > UteeParams::TEE_NUM_PARAMS {
             return None;
         }
@@ -259,11 +259,13 @@ impl TaStack {
 
         self.set_utee_params()?;
 
-        // TODO: generate a random value
-        self.push_bytes(&[
-            0xDE, 0xAD, 0xBE, 0xEF, 0xDE, 0xAD, 0xBE, 0xEF, 0xDE, 0xAD, 0xBE, 0xEF, 0xDE, 0xAD,
-            0xBE, 0xEF,
-        ])?;
+        // Random 16-byte stack canary
+        let mut canary = [0u8; 16];
+        <crate::Platform as litebox::platform::CrngProvider>::fill_bytes_crng(
+            task.global.platform,
+            &mut canary,
+        );
+        self.push_bytes(&canary)?;
 
         // ensure stack is aligned
         self.pos = align_down(self.pos, Self::STACK_ALIGNMENT);

--- a/litebox_shim_optee/src/loader/ta_stack.rs
+++ b/litebox_shim_optee/src/loader/ta_stack.rs
@@ -10,7 +10,7 @@ use litebox::{
 use litebox_common_optee::{LdelfArg, TeeParamType, UteeParamOwned, UteeParams};
 use zerocopy::IntoBytes;
 
-use crate::UserMutPtr;
+use crate::{Platform, UserMutPtr};
 
 #[inline]
 fn align_down(addr: usize, align: usize) -> usize {
@@ -226,7 +226,7 @@ impl TaStack {
         Some(())
     }
 
-    pub(crate) fn init(&mut self, task: &crate::Task, params: &[UteeParamOwned]) -> Option<()> {
+    pub(crate) fn init(&mut self, platform: &Platform, params: &[UteeParamOwned]) -> Option<()> {
         if params.len() > UteeParams::TEE_NUM_PARAMS {
             return None;
         }
@@ -261,10 +261,7 @@ impl TaStack {
 
         // Random 16-byte stack canary
         let mut canary = [0u8; 16];
-        <crate::Platform as litebox::platform::CrngProvider>::fill_bytes_crng(
-            task.global.platform,
-            &mut canary,
-        );
+        <Platform as litebox::platform::CrngProvider>::fill_bytes_crng(platform, &mut canary);
         self.push_bytes(&canary)?;
 
         // ensure stack is aligned

--- a/litebox_shim_optee/src/syscalls/cryp.rs
+++ b/litebox_shim_optee/src/syscalls/cryp.rs
@@ -304,14 +304,14 @@ impl Task {
         Ok(())
     }
 
+    #[allow(clippy::unnecessary_wraps)]
     pub(crate) fn sys_cryp_random_number_generate(&self, buf: &mut [u8]) -> Result<(), TeeResult> {
-        if buf.is_empty() {
-            return Err(TeeResult::BadParameters);
+        if !buf.is_empty() {
+            <crate::Platform as litebox::platform::CrngProvider>::fill_bytes_crng(
+                self.global.platform,
+                buf,
+            );
         }
-        <crate::Platform as litebox::platform::CrngProvider>::fill_bytes_crng(
-            self.global.platform,
-            buf,
-        );
         Ok(())
     }
 }


### PR DESCRIPTION
This PR adds Cryptographically Secure Pseudo-Random Number Generator (CSPRNG) to the LVBS platform. Userland applications (e.g., TAs) can use this CSPRNG using `fill_bytes_crng` though the shim. For now, it uses ChaCha20, so this is not for applications/scenarios demanding FIPS certification.