### PR TITLE
Add basic AArch64 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,21 @@ jobs:
       - name: Build documentation (fail on warnings)
         run: ./.github/tools/github_actions_run_cargo doc --no-deps --all-features --document-private-items --workspace --exclude litebox_runner_lvbs --exclude litebox_runner_snp
 
+  build_and_test_arm64:
+    name: Build and Test (AArch64)
+    runs-on: ubuntu-24.04-arm
+    env:
+      RUSTFLAGS: -Dwarnings
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v6
+      - name: Set up Rust
+        run: |
+          rustup toolchain install $(awk -F'"' '/channel/{print $2}' rust-toolchain.toml) --profile minimal --no-self-update --component clippy
+      - uses: Swatinem/rust-cache@v2
+      - run: ./.github/tools/github_actions_run_cargo clippy --all-targets --all-features -p litebox -p litebox_common_linux
+      - run: ./.github/tools/github_actions_run_cargo build -p litebox -p litebox_common_linux
+
   build_and_test_lvbs:
     name: Build and Test LVBS
     runs-on: ubuntu-latest

--- a/litebox/src/fs/mod.rs
+++ b/litebox/src/fs/mod.rs
@@ -222,22 +222,34 @@ bitflags! {
         /// `O_CREAT`: if path does not exist, create it as a regular file
         const CREAT = 0x40;
         /// `O_DIRECT`: try to minimize cache effects of I/O for this file
+        #[cfg(target_arch = "x86_64")]
         const DIRECT = 0x4000;
+        #[cfg(target_arch = "aarch64")]
+        const DIRECT = 0x10000;
         /// `O_DIRECTORY`: fail if not a directory
+        #[cfg(target_arch = "x86_64")]
         const DIRECTORY = 0x10000;
+        #[cfg(target_arch = "aarch64")]
+        const DIRECTORY = 0x4000;
         /// `O_DSYNC`: write operations on the file will complete according to the requirements of
         /// synchronized I/O *data* integrity completion.
         const DSYNC = 0x1000;
         /// `O_EXCL`: exclusive use
         const EXCL = 0x80;
         /// `O_LARGEFILE`: allow large file support
+        #[cfg(target_arch = "x86_64")]
         const LARGEFILE = 0x8000;
+        #[cfg(target_arch = "aarch64")]
+        const LARGEFILE = 0x20000;
         /// `O_NOATIME`: do not update access time
         const NOATIME = 0x40000;
         /// `O_NOCTTY`: do not assign controlling terminal
         const NOCTTY = 0x100;
         /// `O_NOFOLLOW`: fail if the path does not point to a regular file
+        #[cfg(target_arch = "x86_64")]
         const NOFOLLOW = 0x20000;
+        #[cfg(target_arch = "aarch64")]
+        const NOFOLLOW = 0x8000;
         /// `O_NDELAY`: non-blocking mode (same as NONBLOCK)
         const NDELAY = 0x800;
         /// `O_NONBLOCK`: non-blocking mode (same as NDELAY)
@@ -249,7 +261,10 @@ bitflags! {
         /// integrity completion provided by `O_DSYNC`.)
         const SYNC = 0x101000;
         /// `O_TMPFILE`: create an unnamed temporary file
+        #[cfg(target_arch = "x86_64")]
         const TMPFILE = 0x410000;
+        #[cfg(target_arch = "aarch64")]
+        const TMPFILE = 0x404000;
         /// `O_TRUNC`: truncate the file to zero length
         const TRUNC = 0x200;
         /// <https://docs.rs/bitflags/*/bitflags/#externally-defined-flags>

--- a/litebox/src/mm/exception_table.rs
+++ b/litebox/src/mm/exception_table.rs
@@ -83,10 +83,50 @@ pub unsafe fn memcpy_fallible(dst: *mut u8, src: *const u8, size: usize) -> Resu
             fault = label { return Err(Fault) }
         }
     }
+    #[cfg(target_arch = "aarch64")]
+    unsafe {
+        // Bulk-copy 16 bytes at a time via ldp/stp, then a byte tail for the
+        // remaining 0..15 bytes. aarch64 permits unaligned access on normal
+        // memory, so no alignment prologue is needed.
+        //
+        // Every faulting load/store must be covered by the [2:, 3:) exception
+        // table range; non-memory instructions (cmp/sub/branch) within the
+        // range never fault. On fault, the partially-copied destination is
+        // observable to the caller, matching the x86_64 `rep movsb` behavior.
+        core::arch::asm! {
+            "2:",
+            "cmp {size}, #16",
+            "b.lo 20f",
+            // 16-byte chunk loop.
+            "10:",
+            "ldp {t1}, {t2}, [{src}], #16",
+            "stp {t1}, {t2}, [{dst}], #16",
+            "sub {size}, {size}, #16",
+            "cmp {size}, #16",
+            "b.hs 10b",
+            // Byte tail (0..15 bytes remaining).
+            "20:",
+            "cbz {size}, 3f",
+            "21:",
+            "ldrb {t1:w}, [{src}], #1",
+            "strb {t1:w}, [{dst}], #1",
+            "subs {size}, {size}, #1",
+            "b.ne 21b",
+            "3:",
+            ex_table_entry!("2b", "3b", "{fault}"),
+            dst = inout(reg) dst => _,
+            src = inout(reg) src => _,
+            size = inout(reg) size => _,
+            t1 = out(reg) _,
+            t2 = out(reg) _,
+            fault = label { return Err(Fault) }
+        }
+    }
 
     Ok(())
 }
 
+#[cfg(target_arch = "x86_64")]
 macro_rules! read_fn {
     ($name:ident, $ty:ty, $mov_instr:expr) => {
         /// Reads a value from the given `src` pointer in a fallible manner.
@@ -121,12 +161,57 @@ macro_rules! read_fn {
     };
 }
 
+#[cfg(target_arch = "x86_64")]
 read_fn!(read_u8_fallible, u8, "movzx {dest:e}, byte ptr [{src}]");
+#[cfg(target_arch = "x86_64")]
 read_fn!(read_u16_fallible, u16, "movzx {dest:e}, word ptr [{src}]");
+#[cfg(target_arch = "x86_64")]
 read_fn!(read_u32_fallible, u32, "mov {dest:e}, dword ptr [{src}]");
-#[cfg(target_pointer_width = "64")]
+#[cfg(target_arch = "x86_64")]
 read_fn!(read_u64_fallible, u64, "mov {dest:r}, qword ptr [{src}]");
 
+#[cfg(target_arch = "aarch64")]
+macro_rules! read_fn {
+    ($name:ident, $ty:ty, $load_instr:expr) => {
+        /// Reads a value from the given `src` pointer in a fallible manner.
+        ///
+        /// # Safety
+        /// `src` must be valid for reads or a pointer that's guaranteed to be
+        /// in non-Rust memory.
+        pub unsafe fn $name(src: *const $ty) -> Result<$ty, Fault> {
+            let value: usize;
+            let failed: u32;
+            unsafe {
+                core::arch::asm! {
+                    "2:",
+                    $load_instr,
+                    "mov {failed:w}, wzr",
+                    "3:",
+                    ex_table_entry!("2b", "3b", "3b"),
+                    src = in(reg) src,
+                    dest = out(reg) value,
+                    failed = inout(reg) 1u32 => failed,
+                }
+            }
+            if failed == 0 {
+                Ok((value as u64).trunc())
+            } else {
+                Err(Fault)
+            }
+        }
+    };
+}
+
+#[cfg(target_arch = "aarch64")]
+read_fn!(read_u8_fallible, u8, "ldrb {dest:w}, [{src}]");
+#[cfg(target_arch = "aarch64")]
+read_fn!(read_u16_fallible, u16, "ldrh {dest:w}, [{src}]");
+#[cfg(target_arch = "aarch64")]
+read_fn!(read_u32_fallible, u32, "ldr {dest:w}, [{src}]");
+#[cfg(target_arch = "aarch64")]
+read_fn!(read_u64_fallible, u64, "ldr {dest}, [{src}]");
+
+#[cfg(target_arch = "x86_64")]
 macro_rules! write_fn {
     ($name:ident, $ty:ty, $mov_instr:expr) => {
         /// Writes a value to the given `dest` pointer in a fallible manner.
@@ -155,10 +240,56 @@ macro_rules! write_fn {
 
 #[cfg(target_arch = "x86_64")]
 write_fn!(write_u8_fallible, u8, "mov byte ptr [{dest}], {src:l}");
+#[cfg(target_arch = "x86_64")]
 write_fn!(write_u16_fallible, u16, "mov word ptr [{dest}], {src:x}");
+#[cfg(target_arch = "x86_64")]
 write_fn!(write_u32_fallible, u32, "mov dword ptr [{dest}], {src:e}");
-#[cfg(target_pointer_width = "64")]
+#[cfg(target_arch = "x86_64")]
 write_fn!(write_u64_fallible, u64, "mov qword ptr [{dest}], {src:r}");
+
+#[cfg(target_arch = "aarch64")]
+macro_rules! write_fn {
+    ($name:ident, $ty:ty, $store_instr:expr, $convert:expr) => {
+        /// Writes a value to the given `dest` pointer in a fallible manner.
+        ///
+        /// # Safety
+        /// `dest` must be valid for writes or a pointer that's guaranteed to be
+        /// in non-Rust memory.
+        pub unsafe fn $name(dest: *mut $ty, value: $ty) -> Result<(), Fault> {
+            unsafe {
+                core::arch::asm! {
+                    "2:",
+                    $store_instr,
+                    "3:",
+                    ex_table_entry!("2b", "3b", "{fault}"),
+                    src = in(reg) $convert(value),
+                    dest = in(reg) dest,
+                    fault = label { return Err(Fault) }
+                }
+            }
+            Ok(())
+        }
+    };
+}
+
+#[cfg(target_arch = "aarch64")]
+write_fn!(write_u8_fallible, u8, "strb {src:w}, [{dest}]", u32::from);
+#[cfg(target_arch = "aarch64")]
+write_fn!(write_u16_fallible, u16, "strh {src:w}, [{dest}]", u32::from);
+#[cfg(target_arch = "aarch64")]
+write_fn!(
+    write_u32_fallible,
+    u32,
+    "str {src:w}, [{dest}]",
+    core::convert::identity
+);
+#[cfg(target_arch = "aarch64")]
+write_fn!(
+    write_u64_fallible,
+    u64,
+    "str {src}, [{dest}]",
+    core::convert::identity
+);
 
 /// Exception table entry with relative offsets
 #[repr(C)]

--- a/litebox/src/mm/tests.rs
+++ b/litebox/src/mm/tests.rs
@@ -34,6 +34,8 @@ impl crate::platform::PageManagementProvider<PAGE_SIZE> for DummyVmemBackend {
     const TASK_ADDR_MIN: usize = 0x1_0000; // default linux config
     #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
     const TASK_ADDR_MAX: usize = 0x7FFF_FFFF_F000; // (1 << 47) - PAGE_SIZE;
+    #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+    const TASK_ADDR_MAX: usize = 0xFFFF_FFFF_F000; // 48-bit VA space
 
     fn allocate_pages(
         &self,

--- a/litebox/src/platform/mod.rs
+++ b/litebox/src/platform/mod.rs
@@ -495,6 +495,9 @@ where
         // safe (it probably is fine, but the following sequence of steps ensures we are
         // staying in a very safe subset).
         let bytes: *mut [c_char] = Box::into_raw(bytes);
+        // SAFETY: c_char and u8 have the same size and alignment. The cast is a no-op on
+        // targets where c_char is u8 (e.g. aarch64), hence the `unnecessary_cast` allow.
+        #[allow(clippy::unnecessary_cast)]
         let bytes: *mut [u8] = bytes as *mut [u8];
         let bytes: Box<[u8]> = unsafe { Box::from_raw(bytes) };
         let bytes: Vec<u8> = Vec::from(bytes);

--- a/litebox/src/shim.rs
+++ b/litebox/src/shim.rs
@@ -114,6 +114,16 @@ pub struct ExceptionInfo {
     pub kernel_mode: bool,
 }
 
+/// Information about a hardware exception on aarch64.
+#[cfg(target_arch = "aarch64")]
+#[derive(Copy, Clone, Debug)]
+pub struct ExceptionInfo {
+    /// The fault address (FAR_EL1).
+    pub fault_address: usize,
+    /// The exception syndrome register value (ESR_EL1).
+    pub esr: u64,
+}
+
 /// An x86 exception type.
 #[cfg(target_arch = "x86_64")]
 #[repr(transparent)]

--- a/litebox_common_linux/src/lib.rs
+++ b/litebox_common_linux/src/lib.rs
@@ -6,6 +6,7 @@
 #![no_std]
 #![allow(non_camel_case_types)]
 
+use core::ffi::c_char;
 use core::time::Duration;
 use int_enum::IntEnum;
 use litebox::{
@@ -306,6 +307,36 @@ pub struct FileStat {
     pub __unused: [i64; 3],
 }
 
+/// Linux's `stat` struct for aarch64.
+/// Uses the generic `struct stat` layout from <asm-generic/stat.h>.
+#[cfg(target_arch = "aarch64")]
+#[repr(C)]
+#[derive(Clone, Default, PartialEq, Debug, FromBytes, IntoBytes)]
+pub struct FileStat {
+    pub st_dev: u64,
+    pub st_ino: u64,
+    pub st_mode: u32,
+    pub st_nlink: u32,
+    pub st_uid: u32,
+    pub st_gid: u32,
+    pub st_rdev: u64,
+    #[expect(clippy::pub_underscore_fields)]
+    pub __pad1: u64,
+    pub st_size: i64,
+    pub st_blksize: i32,
+    #[expect(clippy::pub_underscore_fields)]
+    pub __pad2: i32,
+    pub st_blocks: i64,
+    pub st_atime: i64,
+    pub st_atime_nsec: i64,
+    pub st_mtime: i64,
+    pub st_mtime_nsec: i64,
+    pub st_ctime: i64,
+    pub st_ctime_nsec: i64,
+    #[expect(clippy::pub_underscore_fields)]
+    pub __unused: [u32; 2],
+}
+
 /// Linux's `iovec` struct for `writev`
 #[derive(FromBytes, IntoBytes)]
 #[repr(C, packed)]
@@ -365,9 +396,17 @@ impl From<litebox::fs::FileStatus> for FileStat {
             st_rdev: rdev
                 .map(|r| <_>::try_from(r.get()).unwrap())
                 .unwrap_or_default(),
+            #[cfg(target_arch = "x86_64")]
             #[allow(clippy::cast_possible_wrap)]
             st_size: size,
+            #[cfg(target_arch = "aarch64")]
+            #[allow(clippy::cast_possible_wrap)]
+            st_size: size as i64,
+            #[cfg(target_arch = "x86_64")]
             st_blksize: blksize,
+            #[cfg(target_arch = "aarch64")]
+            #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+            st_blksize: blksize as i32,
             st_blocks: 0,
             ..Default::default()
         }
@@ -520,13 +559,19 @@ impl From<FileStat> for Statx {
     fn from(value: FileStat) -> Self {
         Self {
             stx_mask: StatxMask::STATX_BASIC_STATS.bits(),
+            #[cfg(target_arch = "x86_64")]
             stx_blksize: value.st_blksize.trunc(),
+            #[cfg(target_arch = "aarch64")]
+            stx_blksize: value.st_blksize.reinterpret_as_unsigned(),
             stx_nlink: value.st_nlink.trunc(),
             stx_uid: value.st_uid,
             stx_gid: value.st_gid,
             stx_mode: value.st_mode.trunc(),
             stx_ino: value.st_ino,
+            #[cfg(target_arch = "x86_64")]
             stx_size: value.st_size as u64,
+            #[cfg(target_arch = "aarch64")]
+            stx_size: value.st_size.reinterpret_as_unsigned(),
             stx_blocks: value.st_blocks.reinterpret_as_unsigned(),
             stx_atime: statx_timestamp(value.st_atime, value.st_atime_nsec),
             stx_ctime: statx_timestamp(value.st_ctime, value.st_ctime_nsec),
@@ -854,7 +899,7 @@ pub struct Ucred {
 // `suseconds_t` is i64 on riscv32:
 // https://github.com/rust-lang/libc/blob/151c3a971e423c76e7acb54aa2d21a6e2706c4e6/src/unix/linux_like/linux/gnu/b32/mod.rs#L22
 cfg_if::cfg_if! {
-    if #[cfg(target_arch = "x86_64")] {
+    if #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))] {
         pub type time_t = i64;
         pub type suseconds_t = u64;
     } else {
@@ -1964,7 +2009,7 @@ pub enum SyscallRequest<Platform: litebox::platform::RawPointerProvider> {
         fd: i32,
     },
     Stat {
-        pathname: Platform::RawConstPointer<i8>,
+        pathname: Platform::RawConstPointer<c_char>,
         buf: Platform::RawMutPointer<FileStat>,
     },
     Fstat {
@@ -1972,15 +2017,15 @@ pub enum SyscallRequest<Platform: litebox::platform::RawPointerProvider> {
         buf: Platform::RawMutPointer<FileStat>,
     },
     Lstat {
-        pathname: Platform::RawConstPointer<i8>,
+        pathname: Platform::RawConstPointer<c_char>,
         buf: Platform::RawMutPointer<FileStat>,
     },
     Mkdir {
-        pathname: Platform::RawConstPointer<i8>,
+        pathname: Platform::RawConstPointer<c_char>,
         mode: u32,
     },
     Chdir {
-        pathname: Platform::RawConstPointer<i8>,
+        pathname: Platform::RawConstPointer<c_char>,
     },
     Mmap {
         addr: usize,
@@ -2066,7 +2111,7 @@ pub enum SyscallRequest<Platform: litebox::platform::RawPointerProvider> {
         iovcnt: usize,
     },
     Access {
-        pathname: Platform::RawConstPointer<i8>,
+        pathname: Platform::RawConstPointer<c_char>,
         mode: AccessFlags,
     },
     Madvise {
@@ -2212,19 +2257,19 @@ pub enum SyscallRequest<Platform: litebox::platform::RawPointerProvider> {
         arg: ArchPrctlArg<Platform>,
     },
     Readlink {
-        pathname: Platform::RawConstPointer<i8>,
+        pathname: Platform::RawConstPointer<c_char>,
         buf: Platform::RawMutPointer<u8>,
         bufsiz: usize,
     },
     Readlinkat {
         dirfd: i32,
-        pathname: Platform::RawConstPointer<i8>,
+        pathname: Platform::RawConstPointer<c_char>,
         buf: Platform::RawMutPointer<u8>,
         bufsiz: usize,
     },
     Openat {
         dirfd: i32,
-        pathname: Platform::RawConstPointer<i8>,
+        pathname: Platform::RawConstPointer<c_char>,
         flags: litebox::fs::OFlags,
         mode: litebox::fs::Mode,
     },
@@ -2234,19 +2279,19 @@ pub enum SyscallRequest<Platform: litebox::platform::RawPointerProvider> {
     },
     Mknodat {
         dirfd: i32,
-        pathname: Platform::RawConstPointer<i8>,
+        pathname: Platform::RawConstPointer<c_char>,
         mode_and_type: u32,
         dev: u32,
     },
     Unlinkat {
         dirfd: i32,
-        pathname: Platform::RawConstPointer<i8>,
+        pathname: Platform::RawConstPointer<c_char>,
         flags: AtFlags,
     },
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     Newfstatat {
         dirfd: i32,
-        pathname: Platform::RawConstPointer<i8>,
+        pathname: Platform::RawConstPointer<c_char>,
         buf: Platform::RawMutPointer<FileStat>,
         flags: AtFlags,
     },
@@ -2354,9 +2399,9 @@ pub enum SyscallRequest<Platform: litebox::platform::RawPointerProvider> {
         args: FutexArgs<Platform>,
     },
     Execve {
-        pathname: Platform::RawConstPointer<i8>,
-        argv: Platform::RawConstPointer<Platform::RawConstPointer<i8>>,
-        envp: Platform::RawConstPointer<Platform::RawConstPointer<i8>>,
+        pathname: Platform::RawConstPointer<c_char>,
+        argv: Platform::RawConstPointer<Platform::RawConstPointer<c_char>>,
+        envp: Platform::RawConstPointer<Platform::RawConstPointer<c_char>>,
     },
     Umask {
         mask: u32,
@@ -2379,7 +2424,7 @@ pub enum SyscallRequest<Platform: litebox::platform::RawPointerProvider> {
     },
     Statx {
         dirfd: i32,
-        pathname: Option<Platform::RawConstPointer<i8>>,
+        pathname: Option<Platform::RawConstPointer<c_char>>,
         flags: AtFlags,
         mask: StatxMask,
         statxbuf: Platform::RawMutPointer<Statx>,
@@ -2479,12 +2524,15 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
             Sysno::write => sys_req!(Write { fd, buf:*, count }),
             Sysno::close => sys_req!(Close { fd }),
             Sysno::lseek => sys_req!(Lseek { fd, offset, whence }),
+            #[cfg(not(target_arch = "aarch64"))]
             Sysno::stat => sys_req!(Stat { pathname:*, buf:* }),
             Sysno::fstat => sys_req!(Fstat { fd, buf:* }),
+            #[cfg(not(target_arch = "aarch64"))]
             Sysno::lstat => sys_req!(Lstat { pathname:*, buf:* }),
+            #[cfg(not(target_arch = "aarch64"))]
             Sysno::mkdir => sys_req!(Mkdir { pathname:*, mode }),
             Sysno::chdir => sys_req!(Chdir { pathname:* }),
-            #[cfg(target_arch = "x86_64")]
+            #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
             Sysno::mmap => sys_req!(Mmap {
                 addr,
                 length,
@@ -2532,14 +2580,14 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
                     }
                 },
             },
-            #[cfg(target_arch = "x86_64")]
+            #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
             Sysno::pread64 => sys_req!(Pread64 {
                 fd,
                 buf:*,
                 count,
                 offset
             }),
-            #[cfg(target_arch = "x86_64")]
+            #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
             Sysno::pwrite64 => sys_req!(Pwrite64 {
                 fd,
                 buf:*,
@@ -2548,7 +2596,9 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
             }),
             Sysno::readv => sys_req!(Readv { fd, iovec:*, iovcnt }),
             Sysno::writev => sys_req!(Writev { fd, iovec:*, iovcnt }),
+            #[cfg(not(target_arch = "aarch64"))]
             Sysno::access => sys_req!(Access { pathname:*, mode }),
+            #[cfg(not(target_arch = "aarch64"))]
             Sysno::pipe => sys_req!(Pipe2 { pipefd:*, flags: { litebox::fs::OFlags::empty() } }),
             Sysno::pipe2 => sys_req!(Pipe2 { pipefd:* ,flags }),
             Sysno::madvise => sys_req!(Madvise { addr:*, length, behavior:? }),
@@ -2557,6 +2607,7 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
                 newfd: None,
                 flags: None,
             },
+            #[cfg(not(target_arch = "aarch64"))]
             Sysno::dup2 => SyscallRequest::Dup {
                 oldfd: ctx.sys_req_arg(0),
                 newfd: Some(ctx.sys_req_arg(1)),
@@ -2579,7 +2630,7 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
                 sockvec: *,
             }),
             Sysno::connect => sys_req!(Connect { sockfd, sockaddr:*, addrlen }),
-            #[cfg(target_arch = "x86_64")]
+            #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
             Sysno::accept => sys_req!(Accept {
                 sockfd,
                 addr:*,
@@ -2644,11 +2695,13 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
                 clockid: { ClockId::Monotonic.into() },
                 flags: { TimerFlags::empty() },
             }),
+            #[cfg(not(target_arch = "aarch64"))]
             Sysno::time => sys_req!(Time { tloc:* }),
             Sysno::getcwd => sys_req!(Getcwd { buf:*, size }),
+            #[cfg(not(target_arch = "aarch64"))]
             Sysno::readlink => sys_req!(Readlink { pathname:*, buf:* ,bufsiz }),
             Sysno::readlinkat => sys_req!(Readlinkat { dirfd, pathname:*, buf:*, bufsiz }),
-            #[cfg(target_arch = "x86_64")]
+            #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
             Sysno::getrlimit => sys_req!(Getrlimit { resource:?, rlim:* }),
             Sysno::setrlimit => sys_req!(Setrlimit { resource:?, rlim:* }),
             Sysno::prlimit64 => sys_req!(Prlimit { pid, resource:?, new_limit:*, old_limit:* }),
@@ -2659,12 +2712,14 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
             Sysno::geteuid => SyscallRequest::Geteuid,
             Sysno::getegid => SyscallRequest::Getegid,
             Sysno::epoll_ctl => sys_req!(EpollCtl { epfd, op:?, fd, event:* }),
+            #[cfg(not(target_arch = "aarch64"))]
             Sysno::epoll_wait => {
                 sys_req!(EpollPwait { epfd, events:*, maxevents, timeout, sigmask: { None }, sigsetsize: { 0 }, })
             }
             Sysno::epoll_pwait => {
                 sys_req!(EpollPwait { epfd, events:*, maxevents, timeout, sigmask:*, sigsetsize })
             }
+            #[cfg(not(target_arch = "aarch64"))]
             Sysno::epoll_create => sys_req!(EpollCreate {
                 size,
                 flags: { EpollCreateFlags::empty() }
@@ -2673,6 +2728,7 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
             Sysno::ppoll => {
                 sys_req!(Ppoll { fds:*, nfds, timeout: { =*> TimeParam::timespec_old }, sigmask:*, sigsetsize })
             }
+            #[cfg(not(target_arch = "aarch64"))]
             Sysno::poll => {
                 sys_req!(Ppoll { fds:*, nfds, timeout: { => TimeParam::Milliseconds }, sigmask: { None }, sigsetsize: { 0 } })
             }
@@ -2687,7 +2743,7 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
                     sigsetpack: { None },
                 })
             }
-            #[cfg(target_arch = "x86_64")]
+            #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
             Sysno::pselect6 => {
                 sys_req!(Pselect {
                     nfds,
@@ -2719,6 +2775,7 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
                     return Err(errno::Errno::EINVAL);
                 }
             }
+            #[cfg(not(target_arch = "aarch64"))]
             Sysno::arch_prctl => {
                 let code: u32 = ctx.sys_req_arg(0);
                 let code = ArchPrctlCode::try_from(code)
@@ -2735,9 +2792,11 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
                 SyscallRequest::ArchPrctl { arg }
             }
             Sysno::gettid => SyscallRequest::Gettid,
+            #[cfg(not(target_arch = "aarch64"))]
             Sysno::set_thread_area => sys_req!(SetThreadArea { user_desc:* }),
             Sysno::set_tid_address => sys_req!(SetTidAddress { tidptr:* }),
             Sysno::openat => sys_req!(Openat { dirfd,pathname:*,flags,mode }),
+            #[cfg(not(target_arch = "aarch64"))]
             Sysno::open => {
                 // open is equivalent to openat with dirfd AT_FDCWD
                 SyscallRequest::Openat {
@@ -2748,6 +2807,7 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
                 }
             }
             Sysno::mknodat => sys_req!(Mknodat { dirfd,pathname:*,mode_and_type,dev }),
+            #[cfg(not(target_arch = "aarch64"))]
             Sysno::mknod => SyscallRequest::Mknodat {
                 dirfd: AT_FDCWD,
                 pathname: ctx.sys_req_ptr(0),
@@ -2755,6 +2815,7 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
                 dev: ctx.sys_req_arg(2),
             },
             Sysno::unlinkat => sys_req!(Unlinkat { dirfd,pathname:*,flags }),
+            #[cfg(not(target_arch = "aarch64"))]
             Sysno::unlink => {
                 // unlink is equivalent to unlinkat with dirfd AT_FDCWD and flags 0
                 SyscallRequest::Unlinkat {
@@ -2763,6 +2824,7 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
                     flags: AtFlags::empty(),
                 }
             }
+            #[cfg(not(target_arch = "aarch64"))]
             Sysno::rmdir => {
                 // rmdir is equivalent to unlinkat with dirfd AT_FDCWD and AT_REMOVEDIR
                 SyscallRequest::Unlinkat {
@@ -2771,6 +2833,7 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
                     flags: AtFlags::AT_REMOVEDIR,
                 }
             }
+            #[cfg(not(target_arch = "aarch64"))]
             Sysno::creat => {
                 // creat is equivalent to open with flags O_CREAT|O_WRONLY|O_TRUNC
                 SyscallRequest::Openat {
@@ -2785,6 +2848,9 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
             Sysno::ftruncate => sys_req!(Ftruncate { fd, length }),
             #[cfg(target_arch = "x86_64")]
             Sysno::newfstatat => sys_req!(Newfstatat { dirfd,pathname:*,buf:*,flags }),
+            #[cfg(target_arch = "aarch64")]
+            Sysno::fstatat => sys_req!(Newfstatat { dirfd,pathname:*,buf:*,flags }),
+            #[cfg(not(target_arch = "aarch64"))]
             Sysno::eventfd => SyscallRequest::Eventfd2 {
                 initval: ctx.sys_req_arg(0),
                 flags: EfdFlags::empty(),
@@ -2848,7 +2914,9 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
             Sysno::futex => Self::parse_futex(ctx, TimeParam::timespec_old, unsupported_einval)?,
             Sysno::execve => sys_req!(Execve { pathname:*, argv:*, envp:* }),
             Sysno::umask => sys_req!(Umask { mask }),
+            #[cfg(not(target_arch = "aarch64"))]
             Sysno::alarm => sys_req!(Alarm { seconds }),
+            #[cfg(not(target_arch = "aarch64"))]
             Sysno::pause => SyscallRequest::Pause,
             Sysno::setitimer => sys_req!(SetITimer { which:?, new_value:*, old_value:* }),
             Sysno::getitimer => sys_req!(GetITimer { which:?, curr_value:* }),
@@ -2956,7 +3024,7 @@ impl<Platform: litebox::platform::RawPointerProvider> TimeParam<Platform> {
 
     /// Return a `TimeParam` for the old timespec pointer type, which is
     /// architecture dependent.
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     pub fn timespec_old(tp: Option<Platform::RawMutPointer<Timespec>>) -> Self {
         Self::timespec64(tp)
     }
@@ -3068,6 +3136,23 @@ pub struct PtRegs {
     /* top of stack page */
 }
 
+/// Context saved when entering the kernel.
+///
+/// pt_regs from [Linux](https://elixir.bootlin.com/linux/v5.19.17/source/arch/arm64/include/asm/ptrace.h#L178)
+#[cfg(target_arch = "aarch64")]
+#[repr(C)]
+#[derive(Clone, Debug, Default)]
+pub struct PtRegs {
+    /// General-purpose registers x0-x30.
+    pub regs: [usize; 31],
+    /// Stack pointer.
+    pub sp: usize,
+    /// Program counter.
+    pub pc: usize,
+    /// Processor state.
+    pub pstate: usize,
+}
+
 #[cfg(target_arch = "x86_64")]
 pub const EFLAGS_DF: usize = 0x400;
 
@@ -3090,6 +3175,20 @@ impl PtRegs {
         }
     }
 
+    /// Get the `idx`th syscall argument.
+    ///
+    /// # Panics
+    ///
+    /// If `idx` is greater than 5, this function will panic.
+    #[cfg(target_arch = "aarch64")]
+    pub fn syscall_arg(&self, idx: usize) -> usize {
+        if idx < 6 {
+            self.regs[idx]
+        } else {
+            panic!("Invalid syscall argument index: {idx}")
+        }
+    }
+
     // (Private-only, only to be used via `SyscallRequest::try_from_raw`), get the `idx`th syscall
     // argument, reinterpret-truncated to the necessary type.
     fn sys_req_arg<T: ReinterpretTruncatedFromUsize>(&self, idx: usize) -> T {
@@ -3105,6 +3204,12 @@ impl PtRegs {
     #[cfg(target_arch = "x86_64")]
     pub fn get_ip(&self) -> usize {
         self.rip
+    }
+
+    /// Get the instruction pointer (IP)
+    #[cfg(target_arch = "aarch64")]
+    pub fn get_ip(&self) -> usize {
+        self.pc
     }
 }
 

--- a/litebox_common_linux/src/loader.rs
+++ b/litebox_common_linux/src/loader.rs
@@ -101,6 +101,8 @@ const CLASS: elf::file::Class = if cfg!(target_pointer_width = "64") {
 
 const MACHINE: u16 = if cfg!(target_arch = "x86_64") {
     elf::abi::EM_X86_64
+} else if cfg!(target_arch = "aarch64") {
+    elf::abi::EM_AARCH64
 } else {
     panic!("unsupported arch")
 };

--- a/litebox_common_linux/src/signal/aarch64.rs
+++ b/litebox_common_linux/src/signal/aarch64.rs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//! Definitions for aarch64 signal context structures.
+
+use zerocopy::{FromBytes, IntoBytes};
+
+/// sigcontext for aarch64.
+/// See: <https://elixir.bootlin.com/linux/v5.19.17/source/arch/arm64/include/uapi/asm/sigcontext.h>
+#[repr(C)]
+#[derive(Clone, FromBytes, IntoBytes)]
+#[allow(clippy::pub_underscore_fields)]
+pub struct Sigcontext {
+    pub fault_address: u64,
+    pub regs: [u64; 31],
+    pub sp: u64,
+    pub pc: u64,
+    pub pstate: u64,
+    /// 4K reserved for FP/SIMD state and future extensions.
+    pub __reserved: [u8; 4096],
+}

--- a/litebox_common_linux/src/signal/mod.rs
+++ b/litebox_common_linux/src/signal/mod.rs
@@ -3,8 +3,11 @@
 
 //! Linux signal handling definitions.
 
+pub mod aarch64;
 pub mod x86_64;
 
+#[cfg(target_arch = "aarch64")]
+use aarch64::Sigcontext;
 #[cfg(target_arch = "x86_64")]
 use x86_64::Sigcontext;
 
@@ -314,6 +317,7 @@ pub const SI_TKILL: i32 = -6;
 pub const SI_DETHREAD: i32 = -7;
 pub const SI_ASYNCNL: i32 = -60;
 
+#[cfg(target_arch = "x86_64")]
 #[repr(C)]
 #[derive(Clone, FromBytes, IntoBytes)]
 pub struct Ucontext {
@@ -322,6 +326,24 @@ pub struct Ucontext {
     pub stack: SigAltStack,
     pub mcontext: Sigcontext,
     pub sigmask: SigSet,
+}
+
+/// On aarch64, the `uc_sigmask` field comes before `uc_mcontext`, and there
+/// is padding to accommodate glibc's 1024-bit sigset_t.
+#[cfg(target_arch = "aarch64")]
+#[repr(C)]
+#[derive(Clone, FromBytes, IntoBytes)]
+#[allow(clippy::pub_underscore_fields)]
+pub struct Ucontext {
+    pub flags: usize,
+    pub link: usize, // *mut Ucontext,
+    pub stack: SigAltStack,
+    pub sigmask: SigSet,
+    /// Padding: glibc uses a 1024-bit sigset_t (128 bytes), kernel uses 64-bit (8 bytes).
+    pub __unused: [u8; 1024 / 8 - core::mem::size_of::<SigSet>()],
+    /// Alignment padding: mcontext (Sigcontext) requires 16-byte alignment.
+    pub __align_pad: [u8; 8],
+    pub mcontext: Sigcontext,
 }
 
 #[repr(C)]

--- a/litebox_shim_linux/src/lib.rs
+++ b/litebox_shim_linux/src/lib.rs
@@ -889,7 +889,6 @@ impl<FS: ShimFS> Task<FS> {
                     .ok_or(Errno::EFAULT)
                     .map(|()| 0)
             }),
-            #[cfg(target_arch = "x86_64")]
             SyscallRequest::Newfstatat {
                 dirfd,
                 pathname,

--- a/litebox_shim_linux/src/syscalls/process.rs
+++ b/litebox_shim_linux/src/syscalls/process.rs
@@ -1471,19 +1471,23 @@ impl<FS: ShimFS> Task<FS> {
     /// Handle syscall `execve`.
     pub(crate) fn sys_execve(
         &self,
-        pathname: crate::ConstPtr<i8>,
-        argv: crate::ConstPtr<crate::ConstPtr<i8>>,
-        envp: crate::ConstPtr<crate::ConstPtr<i8>>,
+        #[cfg(target_arch = "x86_64")] pathname: crate::ConstPtr<i8>,
+        #[cfg(target_arch = "aarch64")] pathname: crate::ConstPtr<u8>,
+        #[cfg(target_arch = "x86_64")] argv: crate::ConstPtr<crate::ConstPtr<i8>>,
+        #[cfg(target_arch = "aarch64")] argv: crate::ConstPtr<crate::ConstPtr<u8>>,
+        #[cfg(target_arch = "x86_64")] envp: crate::ConstPtr<crate::ConstPtr<i8>>,
+        #[cfg(target_arch = "aarch64")] envp: crate::ConstPtr<crate::ConstPtr<u8>>,
         ctx: &mut litebox_common_linux::PtRegs,
     ) -> Result<usize, Errno> {
         fn copy_vector(
-            mut base: crate::ConstPtr<crate::ConstPtr<i8>>,
+            #[cfg(target_arch = "x86_64")] mut base: crate::ConstPtr<crate::ConstPtr<i8>>,
+            #[cfg(target_arch = "aarch64")] mut base: crate::ConstPtr<crate::ConstPtr<u8>>,
             _which: &str,
         ) -> Result<alloc::vec::Vec<alloc::ffi::CString>, Errno> {
             let mut out = alloc::vec::Vec::new();
             let mut total = 0usize;
             for _ in 0..MAX_VEC {
-                let p: crate::ConstPtr<i8> = {
+                let p = {
                     // read pointer-sized entries
                     match base.read_at_offset(0) {
                         Some(ptr) => ptr,


### PR DESCRIPTION
This PR adds basic AArch64 support to the LiteBox core.  AArch64 and x86_64 have differences including assembly code, exception info, address space size, `c_char` (`i8` on x86_64 whereas `u8` on AArch64), and bitflags. Subsequent PRs (for Linux common, shim, platform, runner, and rewriter) are needed to run AArch64 Linux guests.