### PR TITLE
Harden physical-page linked-list traversal (LVBS/OP-TEE)

### DIFF
--- a/litebox_platform_lvbs/src/mshv/heki.rs
+++ b/litebox_platform_lvbs/src/mshv/heki.rs
@@ -214,12 +214,15 @@ impl HekiPage {
     }
 
     pub fn is_valid(&self) -> bool {
-        if PhysAddr::try_new(self.next_pa).is_err() {
+        if PhysAddr::try_new(self.next_pa)
+            .ok()
+            .is_none_or(|next_pa| self.next_pa != 0 && !next_pa.is_aligned(Size4KiB::SIZE))
+        {
             return false;
         }
         let Some(nranges) = usize::try_from(self.nranges)
             .ok()
-            .filter(|&n| n <= HEKI_MAX_RANGES)
+            .filter(|&n| (1..=HEKI_MAX_RANGES).contains(&n))
         else {
             return false;
         };

--- a/litebox_platform_lvbs/src/mshv/vsm.rs
+++ b/litebox_platform_lvbs/src/mshv/vsm.rs
@@ -1364,18 +1364,16 @@ impl<'a> ModuleMemoryMetadataIters<'a> {
 /// This function copies `HekiPage` structures from VTL0 and returns a vector of them.
 /// `pa` and `nranges` specify the physical address range containing one or more than one `HekiPage` structures.
 fn copy_heki_pages_from_vtl0(pa: u64, nranges: u64) -> Option<Vec<HekiPage>> {
-    let mut next_pa = PhysAddr::try_new(pa).ok()?;
     let mut heki_pages = Vec::with_capacity(nranges.truncate());
     let mut visited_pages = HashSet::new();
     let mut range: u64 = 0;
 
+    let mut cur_pa = PhysAddr::try_new(pa).ok()?;
     while range < nranges {
-        let cur_pa = next_pa;
         if visited_pages.contains(&cur_pa.as_u64()) {
             return None;
         }
-        let heki_page =
-            (unsafe { crate::platform_low().copy_from_vtl0_phys::<HekiPage>(next_pa) })?;
+        let heki_page = (unsafe { crate::platform_low().copy_from_vtl0_phys::<HekiPage>(cur_pa) })?;
         if !heki_page.is_valid() {
             return None;
         }
@@ -1387,7 +1385,7 @@ fn copy_heki_pages_from_vtl0(pa: u64, nranges: u64) -> Option<Vec<HekiPage>> {
             return None;
         }
         // `HekiPage::is_valid` already validated `next_pa`.
-        next_pa = PhysAddr::new(heki_page.next_pa);
+        cur_pa = PhysAddr::new(heki_page.next_pa);
         heki_pages.push(*heki_page);
     }
 

--- a/litebox_platform_lvbs/src/mshv/vsm.rs
+++ b/litebox_platform_lvbs/src/mshv/vsm.rs
@@ -1382,10 +1382,7 @@ fn copy_heki_pages_from_vtl0(pa: u64, nranges: u64) -> Option<Vec<HekiPage>> {
         visited_pages.insert(cur_pa.as_u64());
 
         range = range.checked_add(heki_page.nranges)?;
-        if range < nranges
-            && (heki_page.next_pa == 0
-                || heki_page.next_pa == cur_pa.as_u64()
-                || visited_pages.contains(&heki_page.next_pa))
+        if range < nranges && (heki_page.next_pa == 0 || visited_pages.contains(&heki_page.next_pa))
         {
             return None;
         }

--- a/litebox_platform_lvbs/src/mshv/vsm.rs
+++ b/litebox_platform_lvbs/src/mshv/vsm.rs
@@ -47,7 +47,7 @@ use core::{
     ops::Range,
     sync::atomic::{AtomicBool, AtomicI64, Ordering},
 };
-use hashbrown::HashMap;
+use hashbrown::{HashMap, HashSet};
 use litebox::utils::TruncateExt;
 use litebox_common_linux::errno::Errno;
 use spin::Once;
@@ -1366,16 +1366,29 @@ impl<'a> ModuleMemoryMetadataIters<'a> {
 fn copy_heki_pages_from_vtl0(pa: u64, nranges: u64) -> Option<Vec<HekiPage>> {
     let mut next_pa = PhysAddr::try_new(pa).ok()?;
     let mut heki_pages = Vec::with_capacity(nranges.truncate());
+    let mut visited_pages = HashSet::new();
     let mut range: u64 = 0;
 
     while range < nranges {
+        let cur_pa = next_pa;
+        if visited_pages.contains(&cur_pa.as_u64()) {
+            return None;
+        }
         let heki_page =
             (unsafe { crate::platform_low().copy_from_vtl0_phys::<HekiPage>(next_pa) })?;
         if !heki_page.is_valid() {
             return None;
         }
+        visited_pages.insert(cur_pa.as_u64());
 
         range = range.checked_add(heki_page.nranges)?;
+        if range < nranges
+            && (heki_page.next_pa == 0
+                || heki_page.next_pa == cur_pa.as_u64()
+                || visited_pages.contains(&heki_page.next_pa))
+        {
+            return None;
+        }
         // `HekiPage::is_valid` already validated `next_pa`.
         next_pa = PhysAddr::new(heki_page.next_pa);
         heki_pages.push(*heki_page);

--- a/litebox_shim_optee/src/msg_handler.rs
+++ b/litebox_shim_optee/src/msg_handler.rs
@@ -18,7 +18,7 @@
 use crate::{NormalWorldConstPtr, NormalWorldMutPtr};
 use alloc::{boxed::Box, vec::Vec};
 use core::mem::size_of;
-use hashbrown::HashMap;
+use hashbrown::{HashMap, HashSet};
 use litebox::{mm::linux::PAGE_SIZE, platform::RawConstPointer, utils::TruncateExt};
 use litebox_common_linux::vmap::PhysPageAddr;
 use litebox_common_optee::{
@@ -250,7 +250,10 @@ pub fn handle_optee_smc_args(
             if page_index >= shm_info.page_addrs.len() {
                 return Err(OpteeSmcReturnCode::EBadAddr);
             }
-            let msg_args_addr = shm_info.page_addrs[page_index].as_usize() + offset_in_page;
+            let msg_args_addr = shm_info.page_addrs[page_index]
+                .as_usize()
+                .checked_add(offset_in_page)
+                .ok_or(OpteeSmcReturnCode::EBadAddr)?;
 
             Ok(OpteeSmcResult::CallWithArg {
                 msg_args,
@@ -324,7 +327,10 @@ pub fn handle_optee_msg_args(msg_args: &OpteeMsgArgs) -> Result<(), OpteeSmcRetu
             // - The physical page address of the first `ShmRefPagesData`
             // - The page offset of the first shared memory page (`pages_list[0]`)
             let shm_ref_pages_data_phys_addr = page_align_down(tmem.buf_ptr);
-            let page_offset = tmem.buf_ptr - shm_ref_pages_data_phys_addr;
+            let page_offset = tmem
+                .buf_ptr
+                .checked_sub(shm_ref_pages_data_phys_addr)
+                .ok_or(OpteeSmcReturnCode::EBadAddr)?;
             let size = page_offset
                 .checked_add(tmem.size)
                 .ok_or(OpteeSmcReturnCode::ENomem)?;
@@ -771,18 +777,18 @@ impl<const ALIGN: usize> ShmRefMap<ALIGN> {
         }
         let num_pages = aligned_size_usize / ALIGN;
         let mut pages = Vec::with_capacity(num_pages);
+        let mut visited_pages_data = HashSet::new();
         let mut cur_addr: usize = shm_ref_pages_data_phys_addr.truncate();
-        let mut num_nodes = 0;
         loop {
-            if num_nodes > num_pages {
+            if visited_pages_data.contains(&cur_addr) {
                 return Err(OpteeSmcReturnCode::EBadAddr);
             }
-            num_nodes += 1;
-            let prev_len = pages.len();
+            visited_pages_data.insert(cur_addr);
             let mut cur_ptr = NormalWorldConstPtr::<ShmRefPagesData, ALIGN>::with_usize(cur_addr)
                 .map_err(|_| OpteeSmcReturnCode::EBadAddr)?;
             let pages_data =
                 unsafe { cur_ptr.read_at_offset(0) }.map_err(|_| OpteeSmcReturnCode::EBadAddr)?;
+            let pages_len_before = pages.len();
             for page in &pages_data.pages_list {
                 if *page == 0 || pages.len() == num_pages {
                     break;
@@ -793,13 +799,16 @@ impl<const ALIGN: usize> ShmRefMap<ALIGN> {
                     );
                 }
             }
-            if pages.len() == prev_len {
+            if pages.len() == num_pages {
+                break;
+            }
+            if pages.len() == pages_len_before || pages_data.next_page_data == 0 {
                 return Err(OpteeSmcReturnCode::EBadAddr);
             }
-            if pages_data.next_page_data == 0 || pages.len() == num_pages {
-                break;
-            } else {
+            if pages_data.next_page_data.is_multiple_of(ALIGN as u64) {
                 cur_addr = pages_data.next_page_data.truncate();
+            } else {
+                return Err(OpteeSmcReturnCode::EBadAddr);
             }
         }
 
@@ -847,7 +856,10 @@ fn get_shm_info_from_optee_msg_param_tmem(
     let mut page_addrs = Vec::with_capacity(num_pages);
     for i in 0..num_pages {
         let page_addr = aligned_addr
-            .checked_add((i * PAGE_SIZE) as u64)
+            .checked_add(
+                i.checked_mul(PAGE_SIZE)
+                    .ok_or(OpteeSmcReturnCode::EBadAddr)? as u64,
+            )
             .ok_or(OpteeSmcReturnCode::EBadAddr)?;
         page_addrs
             .push(PhysPageAddr::new(page_addr.truncate()).ok_or(OpteeSmcReturnCode::EBadAddr)?);


### PR DESCRIPTION
This PR hardens physical-page linked-list traversal in both LVBS (HEKI) and OP-TEE shim. Each implementation uses a page linked list to share data across non-contiguous physical pages. This PR adds additional validation to ensure these linked lists are well formed.