### PR TITLE
Fix OP-TEE ELF loading without trampoline bug

### DIFF
--- a/litebox_platform_lvbs/src/lib.rs
+++ b/litebox_platform_lvbs/src/lib.rs
@@ -1343,7 +1343,9 @@ impl<Host: HostInterface> StdioProvider for LinuxKernel<Host> {
 
 impl<Host: HostInterface> litebox::platform::SystemInfoProvider for LinuxKernel<Host> {
     fn get_syscall_entry_point(&self) -> usize {
-        syscall_callback as *const () as usize
+        // Currently this is only used in ELF loader to fix trampoline code.
+        // When running in kernel mode, we don't need a syscall trampoline.
+        0
     }
 
     fn get_vdso_address(&self) -> Option<usize> {
@@ -2039,11 +2041,6 @@ unsafe extern "C" fn run_thread_arch(
         exception_handler = sym exception_handler,
         kernel_exception_handler_no_ctx = sym kernel_exception_handler_no_ctx,
     );
-}
-
-unsafe extern "C" {
-    // Defined in asm blocks above
-    fn syscall_callback() -> isize;
 }
 
 unsafe extern "C" fn init_handler(thread_ctx: &mut ThreadContext) {

--- a/litebox_shim_optee/src/loader/elf.rs
+++ b/litebox_shim_optee/src/loader/elf.rs
@@ -23,7 +23,11 @@ use litebox::{
     platform::{RawConstPointer as _, RawMutPointer as _, SystemInfoProvider as _},
     utils::TruncateExt,
 };
-use litebox_common_linux::{MapFlags, ProtFlags, errno::Errno, loader::ElfParsedFile};
+use litebox_common_linux::{
+    MapFlags, ProtFlags,
+    errno::Errno,
+    loader::{ElfParseError, ElfParsedFile},
+};
 use litebox_common_optee::LdelfArg;
 use thiserror::Error;
 
@@ -195,7 +199,10 @@ impl<'a> FileAndParsed<'a> {
         let file = ElfFileInMemory::new(task, elf_buf);
         let mut parsed = litebox_common_linux::loader::ElfParsedFile::parse(&mut &file)
             .map_err(ElfLoaderError::ParseError)?;
-        parsed.parse_trampoline(&mut &file, task.global.platform.get_syscall_entry_point())?;
+        match parsed.parse_trampoline(&mut &file, task.global.platform.get_syscall_entry_point()) {
+            Ok(()) | Err(ElfParseError::UnpatchedBinary) => {}
+            Err(e) => return Err(e.into()),
+        }
         Ok(Self { file, parsed })
     }
 }


### PR DESCRIPTION
The return values of `parse_trampoline` have changed (i.e., it returns `UnpatchedBinary` for an ELF binary without trampoline), but litebox_shim_optee has not been updated accordingly.

Issue #839 