### PR TITLE
Harden `switch_to_user` (LVBS)

### DIFF
--- a/litebox_platform_lvbs/src/lib.rs
+++ b/litebox_platform_lvbs/src/lib.rs
@@ -150,6 +150,13 @@ const USER_ADDR_MAX: usize = 0x0000_7FFF_FFFF_F000;
 /// <https://cateee.net/lkddb/web-lkddb/LSM_MMAP_MIN_ADDR.html>
 const USER_ADDR_MIN: usize = 0x0000_0000_0001_0000;
 
+/// check whether a user RSP is valid, which should be a canonical, userspace address.
+/// For simplicity, this function checks whether it is within `USER_ADDR_*`.
+#[inline]
+fn is_valid_user_rsp(rsp: usize) -> bool {
+    (USER_ADDR_MIN..USER_ADDR_MAX).contains(&rsp)
+}
+
 /// Manages base and task page tables.
 ///
 /// This struct maintains:
@@ -2055,22 +2062,32 @@ unsafe extern "C" fn run_thread_arch(
 
 unsafe extern "C" fn init_handler(thread_ctx: &mut ThreadContext) {
     match thread_ctx.call_shim(|shim, ctx| shim.init(ctx)) {
-        ContinueOperation::Resume => unsafe { switch_to_user(thread_ctx.ctx) },
-        ContinueOperation::Terminate => {}
+        ContinueOperation::Resume if is_valid_user_rsp(thread_ctx.ctx.rsp) => unsafe {
+            switch_to_user(thread_ctx.ctx)
+        },
+        ContinueOperation::Terminate | ContinueOperation::Resume => {}
     }
 }
 
 unsafe extern "C" fn reenter_handler(thread_ctx: &mut ThreadContext) {
     match thread_ctx.call_shim(|shim, ctx| shim.reenter(ctx)) {
-        ContinueOperation::Resume => unsafe { switch_to_user(thread_ctx.ctx) },
-        ContinueOperation::Terminate => {}
+        ContinueOperation::Resume if is_valid_user_rsp(thread_ctx.ctx.rsp) => unsafe {
+            switch_to_user(thread_ctx.ctx)
+        },
+        ContinueOperation::Terminate | ContinueOperation::Resume => {}
     }
 }
 
 unsafe extern "C" fn syscall_handler(thread_ctx: &mut ThreadContext) {
+    if !is_valid_user_rsp(thread_ctx.ctx.rsp) {
+        return;
+    }
+
     match thread_ctx.call_shim(|shim, ctx| shim.syscall(ctx)) {
-        ContinueOperation::Resume => unsafe { switch_to_user(thread_ctx.ctx) },
-        ContinueOperation::Terminate => {}
+        ContinueOperation::Resume if is_valid_user_rsp(thread_ctx.ctx.rsp) => unsafe {
+            switch_to_user(thread_ctx.ctx)
+        },
+        ContinueOperation::Terminate | ContinueOperation::Resume => {}
     }
 }
 
@@ -2141,7 +2158,11 @@ unsafe extern "C" fn exception_handler(
                 0
             } else {
                 // User-mode exception handled; resume user execution.
-                unsafe { switch_to_user(thread_ctx.ctx) }
+                if is_valid_user_rsp(thread_ctx.ctx.rsp) {
+                    unsafe { switch_to_user(thread_ctx.ctx) }
+                } else {
+                    0
+                }
             }
         }
         ContinueOperation::Terminate => {

--- a/litebox_platform_lvbs/src/lib.rs
+++ b/litebox_platform_lvbs/src/lib.rs
@@ -150,11 +150,16 @@ const USER_ADDR_MAX: usize = 0x0000_7FFF_FFFF_F000;
 /// <https://cateee.net/lkddb/web-lkddb/LSM_MMAP_MIN_ADDR.html>
 const USER_ADDR_MIN: usize = 0x0000_0000_0001_0000;
 
-/// check whether a user RSP is valid, which should be a canonical, userspace address.
-/// For simplicity, this function checks whether it is within `USER_ADDR_*`.
 #[inline]
-fn is_valid_user_rsp(rsp: usize) -> bool {
-    (USER_ADDR_MIN..USER_ADDR_MAX).contains(&rsp)
+fn is_valid_user_addr(addr: usize) -> bool {
+    (USER_ADDR_MIN..USER_ADDR_MAX).contains(&addr)
+}
+
+/// Checks whether a user context is valid for switching to user mode, i.e.,
+/// both `rsp` and `rip` are within the user-space address range.
+#[inline]
+fn is_valid_user_ctx(ctx: &litebox_common_linux::PtRegs) -> bool {
+    is_valid_user_addr(ctx.rsp) && is_valid_user_addr(ctx.rip)
 }
 
 /// Manages base and task page tables.
@@ -2062,7 +2067,7 @@ unsafe extern "C" fn run_thread_arch(
 
 unsafe extern "C" fn init_handler(thread_ctx: &mut ThreadContext) {
     match thread_ctx.call_shim(|shim, ctx| shim.init(ctx)) {
-        ContinueOperation::Resume if is_valid_user_rsp(thread_ctx.ctx.rsp) => unsafe {
+        ContinueOperation::Resume if is_valid_user_ctx(thread_ctx.ctx) => unsafe {
             switch_to_user(thread_ctx.ctx)
         },
         ContinueOperation::Terminate | ContinueOperation::Resume => {}
@@ -2071,7 +2076,7 @@ unsafe extern "C" fn init_handler(thread_ctx: &mut ThreadContext) {
 
 unsafe extern "C" fn reenter_handler(thread_ctx: &mut ThreadContext) {
     match thread_ctx.call_shim(|shim, ctx| shim.reenter(ctx)) {
-        ContinueOperation::Resume if is_valid_user_rsp(thread_ctx.ctx.rsp) => unsafe {
+        ContinueOperation::Resume if is_valid_user_ctx(thread_ctx.ctx) => unsafe {
             switch_to_user(thread_ctx.ctx)
         },
         ContinueOperation::Terminate | ContinueOperation::Resume => {}
@@ -2079,12 +2084,12 @@ unsafe extern "C" fn reenter_handler(thread_ctx: &mut ThreadContext) {
 }
 
 unsafe extern "C" fn syscall_handler(thread_ctx: &mut ThreadContext) {
-    if !is_valid_user_rsp(thread_ctx.ctx.rsp) {
+    if !is_valid_user_ctx(thread_ctx.ctx) {
         return;
     }
 
     match thread_ctx.call_shim(|shim, ctx| shim.syscall(ctx)) {
-        ContinueOperation::Resume if is_valid_user_rsp(thread_ctx.ctx.rsp) => unsafe {
+        ContinueOperation::Resume if is_valid_user_ctx(thread_ctx.ctx) => unsafe {
             switch_to_user(thread_ctx.ctx)
         },
         ContinueOperation::Terminate | ContinueOperation::Resume => {}
@@ -2158,7 +2163,7 @@ unsafe extern "C" fn exception_handler(
                 0
             } else {
                 // User-mode exception handled; resume user execution.
-                if is_valid_user_rsp(thread_ctx.ctx.rsp) {
+                if is_valid_user_ctx(thread_ctx.ctx) {
                     unsafe { switch_to_user(thread_ctx.ctx) }
                 } else {
                     0


### PR DESCRIPTION
This PR hardens LVBS's `switch_to_user` by checking whether a given user `rsp` is valid before switching back to the userspace. A user `rsp` should be a canonical userspace address. If not, `iretq` could end up with a kernel exception.