### PR TITLE
Scrub OP-TEE TA stack

### DIFF
--- a/litebox_shim_optee/src/loader/ta_stack.rs
+++ b/litebox_shim_optee/src/loader/ta_stack.rs
@@ -125,11 +125,12 @@ impl TaStack {
     }
 
     /// Zero the unused stack region before a new session writes its parameters,
-    /// to avoid leaking leftover data from a prior session whose pages were recycled.
+    /// to avoid leaking leftover data from a prior session whose stack region was recycled.
     /// The trailing `UteeParams` slot is left untouched here because
     /// `set_utee_params` overwrites it in full.
     fn scrub(&mut self) -> Option<()> {
-        const ZERO_CHUNK: [u8; 4096] = [0; 4096];
+        use litebox::mm::linux::PAGE_SIZE;
+        const ZERO_CHUNK: [u8; PAGE_SIZE] = [0; PAGE_SIZE];
 
         for offset in (0..self.pos).step_by(ZERO_CHUNK.len()) {
             let len = ZERO_CHUNK.len().min(self.pos - offset);

--- a/litebox_shim_optee/src/loader/ta_stack.rs
+++ b/litebox_shim_optee/src/loader/ta_stack.rs
@@ -124,6 +124,21 @@ impl TaStack {
         Some(())
     }
 
+    /// Zero the unused stack region before a new session writes its parameters,
+    /// to avoid leaking leftover data from a prior session whose pages were recycled.
+    /// The trailing `UteeParams` slot is left untouched here because
+    /// `set_utee_params` overwrites it in full.
+    fn scrub(&mut self) -> Option<()> {
+        const ZERO_CHUNK: [u8; 4096] = [0; 4096];
+
+        for offset in (0..self.pos).step_by(ZERO_CHUNK.len()) {
+            let len = ZERO_CHUNK.len().min(self.pos - offset);
+            self.stack_top.copy_from_slice(offset, &ZERO_CHUNK[..len])?;
+        }
+
+        Some(())
+    }
+
     /// Push a parameter whose type is `TeeParamType::None` to the stack.
     fn push_param_none(&mut self) -> Option<()> {
         if self.num_params >= UteeParams::TEE_NUM_PARAMS {
@@ -214,6 +229,9 @@ impl TaStack {
         if params.len() > UteeParams::TEE_NUM_PARAMS {
             return None;
         }
+
+        self.scrub()?;
+
         for param in params {
             match param {
                 UteeParamOwned::ValueInput { value_a, value_b } => {


### PR DESCRIPTION
This PR scrubs the OP-TEE TA stack at the initialization. This prevents potential information leakage because the TA stack is recycled across different sessions of the same single-instance TA.