### PR TITLE
Add syscall shutdown for unix sockets

### DIFF
--- a/litebox_common_linux/src/lib.rs
+++ b/litebox_common_linux/src/lib.rs
@@ -1740,12 +1740,12 @@ pub enum ShutdownHow {
 impl ShutdownHow {
     /// Returns `true` when this `how` disables the receive side (`SHUT_RD` or `SHUT_RDWR`).
     #[must_use]
-    pub fn shuts_down_read(self) -> bool {
+    pub fn is_shutdown_read(self) -> bool {
         matches!(self, Self::Read | Self::Both)
     }
     /// Returns `true` when this `how` disables the send side (`SHUT_WR` or `SHUT_RDWR`).
     #[must_use]
-    pub fn shuts_down_write(self) -> bool {
+    pub fn is_shutdown_write(self) -> bool {
         matches!(self, Self::Write | Self::Both)
     }
 }

--- a/litebox_common_linux/src/lib.rs
+++ b/litebox_common_linux/src/lib.rs
@@ -1738,12 +1738,14 @@ pub enum ShutdownHow {
 }
 
 impl ShutdownHow {
+    /// Returns `true` when this `how` disables the receive side (`SHUT_RD` or `SHUT_RDWR`).
     #[must_use]
-    pub fn affects_read(self) -> bool {
+    pub fn shuts_down_read(self) -> bool {
         matches!(self, Self::Read | Self::Both)
     }
+    /// Returns `true` when this `how` disables the send side (`SHUT_WR` or `SHUT_RDWR`).
     #[must_use]
-    pub fn affects_write(self) -> bool {
+    pub fn shuts_down_write(self) -> bool {
         matches!(self, Self::Write | Self::Both)
     }
 }

--- a/litebox_common_linux/src/lib.rs
+++ b/litebox_common_linux/src/lib.rs
@@ -1725,12 +1725,33 @@ pub enum SocketcallType {
     Sendmmsg = 20,
 }
 
+/// `how` argument to the `shutdown(2)` syscall.
+///
+/// Discriminants match Linux's `SHUT_RD` (0), `SHUT_WR` (1), `SHUT_RDWR` (2) ABI.
 #[repr(i32)]
-#[derive(Debug, IntEnum)]
+#[derive(Debug, Clone, Copy, IntEnum)]
 pub enum ShutdownHow {
+    /// `SHUT_RD`: disallow further receives. Already-queued data may still be drained;
+    /// once empty, subsequent reads observe EOF and the peer's writes fail with `EPIPE`.
     Read = 0,
+    /// `SHUT_WR`: disallow further sends. Subsequent local writes fail with `EPIPE`;
+    /// the peer keeps reading anything still in flight.
     Write = 1,
+    /// `SHUT_RDWR`: union of `Read` and `Write`.
     Both = 2,
+}
+
+impl ShutdownHow {
+    /// Whether `self` shuts the read side down.
+    #[must_use]
+    pub fn affects_read(self) -> bool {
+        matches!(self, Self::Read | Self::Both)
+    }
+    /// Whether `self` shuts the write side down.
+    #[must_use]
+    pub fn affects_write(self) -> bool {
+        matches!(self, Self::Write | Self::Both)
+    }
 }
 
 /// Request to syscall handler
@@ -2353,7 +2374,6 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
                 newfd: Some(ctx.sys_req_arg(1)),
                 flags: Some(ctx.sys_req_arg(2)),
             },
-            Sysno::shutdown => sys_req!(Shutdown { sockfd, how }),
             Sysno::socket => sys_req!(Socket {
                 domain,
                 type_and_flags,
@@ -2378,6 +2398,7 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
             Sysno::sendmsg => sys_req!(Sendmsg { sockfd, msg:*, flags }),
             Sysno::recvfrom => sys_req!(Recvfrom { sockfd, buf:*, len, flags, addr:*, addrlen:*, }),
             Sysno::recvmsg => sys_req!(Recvmsg { sockfd, msg:*, flags }),
+            Sysno::shutdown => sys_req!(Shutdown { sockfd, how }),
             Sysno::bind => sys_req!(Bind { sockfd, sockaddr:*, addrlen }),
             Sysno::listen => sys_req!(Listen { sockfd, backlog }),
             Sysno::setsockopt => sys_req!(Setsockopt {

--- a/litebox_common_linux/src/lib.rs
+++ b/litebox_common_linux/src/lib.rs
@@ -1725,6 +1725,14 @@ pub enum SocketcallType {
     Sendmmsg = 20,
 }
 
+#[repr(i32)]
+#[derive(Debug, IntEnum)]
+pub enum ShutdownHow {
+    Read = 0,
+    Write = 1,
+    Both = 2,
+}
+
 /// Request to syscall handler
 #[non_exhaustive]
 #[derive(Debug)]
@@ -1916,6 +1924,10 @@ pub enum SyscallRequest<Platform: litebox::platform::RawPointerProvider> {
         sockfd: i32,
         msg: Platform::RawMutPointer<UserMsgHdr<Platform>>,
         flags: ReceiveFlags,
+    },
+    Shutdown {
+        sockfd: i32,
+        how: i32,
     },
     Bind {
         sockfd: i32,
@@ -2341,6 +2353,7 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
                 newfd: Some(ctx.sys_req_arg(1)),
                 flags: Some(ctx.sys_req_arg(2)),
             },
+            Sysno::shutdown => sys_req!(Shutdown { sockfd, how }),
             Sysno::socket => sys_req!(Socket {
                 domain,
                 type_and_flags,

--- a/litebox_common_linux/src/lib.rs
+++ b/litebox_common_linux/src/lib.rs
@@ -1726,28 +1726,22 @@ pub enum SocketcallType {
 }
 
 /// `how` argument to the `shutdown(2)` syscall.
-///
-/// Discriminants match Linux's `SHUT_RD` (0), `SHUT_WR` (1), `SHUT_RDWR` (2) ABI.
 #[repr(i32)]
 #[derive(Debug, Clone, Copy, IntEnum)]
 pub enum ShutdownHow {
-    /// `SHUT_RD`: disallow further receives. Already-queued data may still be drained;
-    /// once empty, subsequent reads observe EOF and the peer's writes fail with `EPIPE`.
+    /// `SHUT_RD`.
     Read = 0,
-    /// `SHUT_WR`: disallow further sends. Subsequent local writes fail with `EPIPE`;
-    /// the peer keeps reading anything still in flight.
+    /// `SHUT_WR`.
     Write = 1,
-    /// `SHUT_RDWR`: union of `Read` and `Write`.
+    /// `SHUT_RDWR`.
     Both = 2,
 }
 
 impl ShutdownHow {
-    /// Whether `self` shuts the read side down.
     #[must_use]
     pub fn affects_read(self) -> bool {
         matches!(self, Self::Read | Self::Both)
     }
-    /// Whether `self` shuts the write side down.
     #[must_use]
     pub fn affects_write(self) -> bool {
         matches!(self, Self::Write | Self::Both)

--- a/litebox_runner_linux_userland/tests/common/mod.rs
+++ b/litebox_runner_linux_userland/tests/common/mod.rs
@@ -120,9 +120,20 @@ pub fn compile(src_path: &str, unique_name: &str, exec_or_lib: bool, nolibc: boo
     command_parts.extend_from_slice(&args);
     let command = command_parts.join(" ");
 
-    // Check cache first
+    // Check cache first. Include any sibling `.h` files in the source's directory
+    // so cache invalidation tracks shared headers (e.g. test helper headers).
     let src_path_buf = Path::new(src_path);
-    let input_paths = vec![src_path_buf];
+    let mut sibling_headers: Vec<PathBuf> = src_path_buf
+        .parent()
+        .and_then(|d| std::fs::read_dir(d).ok())
+        .into_iter()
+        .flatten()
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("h"))
+        .collect();
+    sibling_headers.sort();
+    let mut input_paths: Vec<&Path> = vec![src_path_buf];
+    input_paths.extend(sibling_headers.iter().map(PathBuf::as_path));
 
     if let Ok(true) = crate::cache::is_cached_and_valid(&input_paths, &path, &command) {
         println!("Using cached compilation result for: {unique_name}");

--- a/litebox_runner_linux_userland/tests/helpers.h
+++ b/litebox_runner_linux_userland/tests/helpers.h
@@ -1,0 +1,179 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// Shared helpers for the C tests in this directory. `static inline` so each
+// translation unit gets its own copy without a link step; the test runner's
+// compile cache tracks sibling `.h` files for invalidation.
+
+#ifndef LITEBOX_TESTS_HELPERS_H
+#define LITEBOX_TESTS_HELPERS_H
+
+#define _GNU_SOURCE
+#include <errno.h>
+#include <poll.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/syscall.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+static inline void die(const char *msg) {
+    perror(msg);
+    exit(1);
+}
+
+static inline void fail_errno(const char *op, int expected_errno) {
+    fprintf(stderr, "FAIL: %s expected errno=%d (%s), got errno=%d (%s)\n",
+            op, expected_errno, strerror(expected_errno), errno, strerror(errno));
+    exit(1);
+}
+
+static inline void expect_sys_shutdown(int fd, int how, const char *op) {
+    errno = 0;
+    if (syscall(SYS_shutdown, fd, how) != 0) {
+        die(op);
+    }
+}
+
+static inline void expect_sys_shutdown_errno(int fd, int how, int expected_errno, const char *op) {
+    errno = 0;
+    long ret = syscall(SYS_shutdown, fd, how);
+    if (ret != -1) {
+        fprintf(stderr, "FAIL: %s expected failure, got %ld\n", op, ret);
+        exit(1);
+    }
+    if (errno != expected_errno) {
+        fail_errno(op, expected_errno);
+    }
+}
+
+static inline void expect_send_errno(int fd, int expected_errno, const char *op) {
+    errno = 0;
+    ssize_t n = send(fd, "x", 1, MSG_DONTWAIT | MSG_NOSIGNAL);
+    if (n != -1) {
+        fprintf(stderr, "FAIL: %s expected failure, got %zd\n", op, n);
+        exit(1);
+    }
+    if (errno != expected_errno) {
+        fail_errno(op, expected_errno);
+    }
+}
+
+// Blocking recv (no MSG_DONTWAIT) that we expect to time out via SO_RCVTIMEO. Distinct from
+// expect_recv_errno because we want to observe that the kernel kept blocking until the
+// timer expired, not that it gave up immediately with the same errno.
+static inline void expect_blocking_recv_eagain(int fd, const char *op) {
+    char buf[32];
+
+    errno = 0;
+    ssize_t n = recv(fd, buf, sizeof(buf), 0);
+    if (n != -1) {
+        fprintf(stderr, "FAIL: %s expected timeout failure, got %zd\n", op, n);
+        exit(1);
+    }
+    if (errno != EAGAIN) {
+        fail_errno(op, EAGAIN);
+    }
+}
+
+static inline void expect_recv_errno(int fd, int expected_errno, const char *op) {
+    char buf[32];
+
+    errno = 0;
+    ssize_t n = recv(fd, buf, sizeof(buf), MSG_DONTWAIT);
+    if (n != -1) {
+        fprintf(stderr, "FAIL: %s expected failure, got %zd\n", op, n);
+        exit(1);
+    }
+    if (errno != expected_errno) {
+        fail_errno(op, expected_errno);
+    }
+}
+
+static inline void expect_recv_eof(int fd, const char *op) {
+    char buf[32];
+
+    errno = 0;
+    ssize_t n = recv(fd, buf, sizeof(buf), 0);
+    if (n < 0) {
+        die(op);
+    }
+    if (n != 0) {
+        fprintf(stderr, "FAIL: %s expected EOF, got %zd\n", op, n);
+        exit(1);
+    }
+}
+
+static inline void expect_recv_string(int fd, const char *expected, const char *op) {
+    char buf[64];
+    size_t expected_len = strlen(expected);
+
+    memset(buf, 0, sizeof(buf));
+    errno = 0;
+    ssize_t n = recv(fd, buf, sizeof(buf), MSG_DONTWAIT);
+    if (n < 0) {
+        die(op);
+    }
+    if ((size_t)n != expected_len || memcmp(buf, expected, expected_len) != 0) {
+        fprintf(stderr, "FAIL: %s expected '%s' (%zu bytes), got '%.*s' (%zd bytes)\n",
+                op, expected, expected_len, (int)n, buf, n);
+        exit(1);
+    }
+}
+
+static inline void make_socket_pair(int type, int sv[2]) {
+    if (socketpair(AF_UNIX, type, 0, sv) != 0) {
+        die("socketpair(AF_UNIX)");
+    }
+}
+
+static inline void set_recv_timeout(int fd) {
+    struct timeval timeout = { .tv_sec = 0, .tv_usec = 100000 };
+
+    if (setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)) != 0) {
+        die("setsockopt(SO_RCVTIMEO)");
+    }
+}
+
+static inline void close_pair(int sv[2]) {
+    close(sv[0]);
+    close(sv[1]);
+}
+
+// Single-shot poll(2) for level-triggered checks. Asserts `r=1` (revents
+// present) and that the bits in `expected_set` are all set; ignores any
+// additional bits the kernel reports.
+static inline void expect_poll_has(int fd, short events_mask, short expected_set, const char *op) {
+    struct pollfd pfd = { .fd = fd, .events = events_mask };
+    errno = 0;
+    int r = poll(&pfd, 1, 0);
+    if (r < 0) {
+        die(op);
+    }
+    if (r != 1 || (pfd.revents & expected_set) != expected_set) {
+        fprintf(stderr,
+                "FAIL: %s expected revents to include 0x%04x, got r=%d revents=0x%04x\n",
+                op, (unsigned)expected_set, r, (unsigned)pfd.revents);
+        exit(1);
+    }
+}
+
+// Assert the given bits are NOT set in the poll revents.
+static inline void expect_poll_lacks(int fd, short events_mask, short forbidden, const char *op) {
+    struct pollfd pfd = { .fd = fd, .events = events_mask };
+    errno = 0;
+    int r = poll(&pfd, 1, 0);
+    if (r < 0) {
+        die(op);
+    }
+    if (pfd.revents & forbidden) {
+        fprintf(stderr,
+                "FAIL: %s expected revents to exclude 0x%04x, got revents=0x%04x\n",
+                op, (unsigned)forbidden, (unsigned)pfd.revents);
+        exit(1);
+    }
+}
+
+#endif // LITEBOX_TESTS_HELPERS_H

--- a/litebox_runner_linux_userland/tests/unix_dgram_shutdown.c
+++ b/litebox_runner_linux_userland/tests/unix_dgram_shutdown.c
@@ -3,9 +3,28 @@
 
 #include "helpers.h"
 #include <fcntl.h>
+#include <sys/un.h>
 
 static void make_dgram_pair(int sv[2]) {
     make_socket_pair(SOCK_DGRAM, sv);
+}
+
+static void make_addr(struct sockaddr_un *addr, const char *name) {
+    memset(addr, 0, sizeof(*addr));
+    addr->sun_family = AF_UNIX;
+    snprintf(addr->sun_path, sizeof(addr->sun_path), "/tmp/lb_dgram_%s_%d", name, getpid());
+    unlink(addr->sun_path);
+}
+
+static int bind_dgram_addr(const struct sockaddr_un *addr, const char *op) {
+    int fd = socket(AF_UNIX, SOCK_DGRAM, 0);
+    if (fd < 0) {
+        die("socket(AF_UNIX, SOCK_DGRAM)");
+    }
+    if (bind(fd, (const struct sockaddr *)addr, sizeof(*addr)) != 0) {
+        die(op);
+    }
+    return fd;
 }
 
 // SHUT_RD on a connected datagram socket: queued datagrams remain readable; once the queue
@@ -108,7 +127,7 @@ static void test_shutdown_both_combines_read_and_write_rules(void) {
     close_pair(sv);
 }
 
-// When the peer calls shutdown(SHUT_WR), Linux does NOT synthesize EOF on the local recv —
+// When the peer calls shutdown(SHUT_WR), Linux does NOT synthesize EOF on the local recv;
 // unlike a local SHUT_RD, the socket is still connected and could in principle receive
 // from another sender, so a blocking recv keeps blocking (we observe EAGAIN via RCVTIMEO).
 // Queued datagrams must still drain first.
@@ -128,6 +147,59 @@ static void test_peer_shutdown_write_drains_then_blocks(void) {
     expect_blocking_recv_eagain(sv[0], "blocking recv after peer SHUT_WR with empty queue");
 
     close_pair(sv);
+}
+
+static void test_pre_connect_shutdown_write_blocks_future_sends(void) {
+    struct sockaddr_un server_addr;
+    make_addr(&server_addr, "pre_wr_server");
+    int server = bind_dgram_addr(&server_addr, "bind(server)");
+
+    int sender = socket(AF_UNIX, SOCK_DGRAM, 0);
+    if (sender < 0) {
+        die("socket(sender)");
+    }
+    expect_sys_shutdown(sender, SHUT_WR, "pre-sendto shutdown(SHUT_WR)");
+
+    errno = 0;
+    ssize_t n = sendto(sender, "x", 1, MSG_DONTWAIT | MSG_NOSIGNAL,
+                       (struct sockaddr *)&server_addr, sizeof(server_addr));
+    if (n != -1) {
+        fprintf(stderr, "FAIL: sendto after pre-connect SHUT_WR expected failure, got %zd\n", n);
+        exit(1);
+    }
+    if (errno != EPIPE) {
+        fail_errno("sendto after pre-connect SHUT_WR", EPIPE);
+    }
+
+    if (connect(sender, (struct sockaddr *)&server_addr, sizeof(server_addr)) != 0) {
+        die("connect after pre-connect SHUT_WR");
+    }
+    expect_send_errno(sender, EPIPE, "send after connect with pre-connect SHUT_WR");
+
+    close(sender);
+    close(server);
+    unlink(server_addr.sun_path);
+}
+
+static void test_pre_bind_shutdown_read_blocks_future_recvs(void) {
+    struct sockaddr_un receiver_addr;
+    make_addr(&receiver_addr, "pre_rd_receiver");
+
+    int receiver = socket(AF_UNIX, SOCK_DGRAM, 0);
+    if (receiver < 0) {
+        die("socket(receiver)");
+    }
+    set_recv_timeout(receiver);
+
+    expect_sys_shutdown(receiver, SHUT_RD, "pre-bind shutdown(SHUT_RD)");
+    if (bind(receiver, (struct sockaddr *)&receiver_addr, sizeof(receiver_addr)) != 0) {
+        die("bind(receiver) after pre-bind SHUT_RD");
+    }
+
+    expect_recv_eof(receiver, "blocking recv after bind with pre-bind SHUT_RD");
+
+    close(receiver);
+    unlink(receiver_addr.sun_path);
 }
 
 static void test_shutdown_invalid_how_returns_einval(void) {
@@ -175,6 +247,8 @@ int main(void) {
     test_shutdown_write_keeps_receive_side_open();
     test_shutdown_both_combines_read_and_write_rules();
     test_peer_shutdown_write_drains_then_blocks();
+    test_pre_connect_shutdown_write_blocks_future_sends();
+    test_pre_bind_shutdown_read_blocks_future_recvs();
     test_shutdown_invalid_how_returns_einval();
     test_shutdown_fd_validated_before_how();
 

--- a/litebox_runner_linux_userland/tests/unix_dgram_shutdown.c
+++ b/litebox_runner_linux_userland/tests/unix_dgram_shutdown.c
@@ -1,125 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-#define _GNU_SOURCE
-#include <errno.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <sys/socket.h>
-#include <sys/syscall.h>
-#include <sys/time.h>
-#include <unistd.h>
-
-static void die(const char *msg) {
-    perror(msg);
-    exit(1);
-}
-
-static void fail_errno(const char *op, int expected_errno) {
-    fprintf(stderr, "FAIL: %s expected errno=%d (%s), got errno=%d (%s)\n",
-            op, expected_errno, strerror(expected_errno), errno, strerror(errno));
-    exit(1);
-}
-
-static void expect_sys_shutdown(int fd, int how, const char *op) {
-    errno = 0;
-    if (syscall(SYS_shutdown, fd, how) != 0) {
-        die(op);
-    }
-}
-
-static void expect_send_errno(int fd, int expected_errno, const char *op) {
-    errno = 0;
-    ssize_t n = send(fd, "x", 1, MSG_DONTWAIT | MSG_NOSIGNAL);
-    if (n != -1) {
-        fprintf(stderr, "FAIL: %s expected failure, got %zd\n", op, n);
-        exit(1);
-    }
-    if (errno != expected_errno) {
-        fail_errno(op, expected_errno);
-    }
-}
-
-// Blocking recv (no MSG_DONTWAIT) that we expect to time out via SO_RCVTIMEO. Distinct from
-// expect_recv_errno because we want to observe that the kernel kept blocking until the
-// timer expired, not that it gave up immediately with the same errno.
-static void expect_blocking_recv_eagain(int fd, const char *op) {
-    char buf[32];
-
-    errno = 0;
-    ssize_t n = recv(fd, buf, sizeof(buf), 0);
-    if (n != -1) {
-        fprintf(stderr, "FAIL: %s expected timeout failure, got %zd\n", op, n);
-        exit(1);
-    }
-    if (errno != EAGAIN) {
-        fail_errno(op, EAGAIN);
-    }
-}
-
-static void expect_recv_errno(int fd, int expected_errno, const char *op) {
-    char buf[32];
-
-    errno = 0;
-    ssize_t n = recv(fd, buf, sizeof(buf), MSG_DONTWAIT);
-    if (n != -1) {
-        fprintf(stderr, "FAIL: %s expected failure, got %zd\n", op, n);
-        exit(1);
-    }
-    if (errno != expected_errno) {
-        fail_errno(op, expected_errno);
-    }
-}
-
-static void expect_recv_eof(int fd, const char *op) {
-    char buf[32];
-
-    errno = 0;
-    ssize_t n = recv(fd, buf, sizeof(buf), 0);
-    if (n < 0) {
-        die(op);
-    }
-    if (n != 0) {
-        fprintf(stderr, "FAIL: %s expected EOF, got %zd\n", op, n);
-        exit(1);
-    }
-}
-
-static void expect_recv_string(int fd, const char *expected, const char *op) {
-    char buf[64];
-    size_t expected_len = strlen(expected);
-
-    memset(buf, 0, sizeof(buf));
-    errno = 0;
-    ssize_t n = recv(fd, buf, sizeof(buf), MSG_DONTWAIT);
-    if (n < 0) {
-        die(op);
-    }
-    if ((size_t)n != expected_len || memcmp(buf, expected, expected_len) != 0) {
-        fprintf(stderr, "FAIL: %s expected '%s' (%zu bytes), got '%.*s' (%zd bytes)\n",
-                op, expected, expected_len, (int)n, buf, n);
-        exit(1);
-    }
-}
+#include "helpers.h"
+#include <fcntl.h>
 
 static void make_dgram_pair(int sv[2]) {
-    if (socketpair(AF_UNIX, SOCK_DGRAM, 0, sv) != 0) {
-        die("socketpair(AF_UNIX, SOCK_DGRAM)");
-    }
-}
-
-static void set_recv_timeout(int fd) {
-    struct timeval timeout = { .tv_sec = 0, .tv_usec = 100000 };
-
-    if (setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)) != 0) {
-        die("setsockopt(SO_RCVTIMEO)");
-    }
-}
-
-static void close_pair(int sv[2]) {
-    close(sv[0]);
-    close(sv[1]);
+    make_socket_pair(SOCK_DGRAM, sv);
 }
 
 // SHUT_RD on a connected datagram socket: queued datagrams remain readable; once the queue
@@ -137,6 +23,13 @@ static void test_shutdown_read_keeps_queued_datagram(void) {
     }
 
     expect_sys_shutdown(sv[0], SHUT_RD, "shutdown(SHUT_RD)");
+
+    // Local SHUT_RD on a dgram fd reports IN|OUT|RDHUP but NOT HUP (HUP only when
+    // both sides are shut). Probed on host Linux.
+    expect_poll_has(sv[0], POLLIN | POLLOUT | POLLRDHUP,
+                    POLLIN | POLLOUT | POLLRDHUP, "poll(fd0) after SHUT_RD");
+    expect_poll_lacks(sv[0], POLLIN | POLLOUT | POLLRDHUP, POLLHUP,
+                      "poll(fd0) after SHUT_RD must not include HUP");
 
     expect_recv_string(sv[0], queued, "recv queued datagram after SHUT_RD");
     expect_send_errno(sv[1], EPIPE, "peer send after SHUT_RD");
@@ -168,6 +61,11 @@ static void test_shutdown_write_keeps_receive_side_open(void) {
 
     expect_sys_shutdown(sv[0], SHUT_WR, "shutdown(SHUT_WR)");
 
+    // Local SHUT_WR alone on a dgram fd reports only OUT — no HUP, no RDHUP.
+    // Probed on host Linux: HUP only fires when BOTH sides are shut.
+    expect_poll_lacks(sv[0], POLLIN | POLLOUT | POLLRDHUP, POLLHUP | POLLRDHUP,
+                      "poll(fd0) after SHUT_WR only must exclude HUP/RDHUP");
+
     expect_send_errno(sv[0], EPIPE, "local send after SHUT_WR");
     if (send(sv[1], inbound, strlen(inbound), MSG_NOSIGNAL) < 0) {
         die("peer send after SHUT_WR");
@@ -188,6 +86,19 @@ static void test_shutdown_both_combines_read_and_write_rules(void) {
     }
 
     expect_sys_shutdown(sv[0], SHUT_RDWR, "shutdown(SHUT_RDWR)");
+
+    // SHUT_RDWR on a dgram fd reports IN|OUT|HUP|RDHUP (HUP appears now that both
+    // sides are shut). Level-triggered: re-poll several times to confirm bits
+    // stay set without consuming the queued datagram.
+    for (int i = 0; i < 3; i++) {
+        expect_poll_has(sv[0], POLLIN | POLLOUT | POLLRDHUP,
+                        POLLIN | POLLOUT | POLLHUP | POLLRDHUP,
+                        "poll(fd0) after SHUT_RDWR (level-triggered repeat)");
+    }
+    // Peer (fd1) of a dgram socket sees no change when fd0 shuts down both sides —
+    // dgrams are connectionless. Probed on host Linux.
+    expect_poll_lacks(sv[1], POLLIN | POLLOUT | POLLRDHUP, POLLHUP | POLLRDHUP,
+                      "poll(fd1) peer of SHUT_RDWR dgram must exclude HUP/RDHUP");
 
     expect_send_errno(sv[0], EPIPE, "local send after SHUT_RDWR");
     expect_recv_string(sv[0], queued, "recv queued datagram after SHUT_RDWR");
@@ -237,6 +148,25 @@ static void test_shutdown_invalid_how_returns_einval(void) {
     close_pair(sv);
 }
 
+// Linux validates the fd before `how`, so a bad fd combined with a bad `how`
+// must surface EBADF / ENOTSOCK — not EINVAL. Probed on host Linux:
+//   shutdown(-1, 99)              -> EBADF
+//   shutdown(<closed_fd>, 99)     -> EBADF
+//   shutdown(<regular_file>, 99)  -> ENOTSOCK
+static void test_shutdown_fd_validated_before_how(void) {
+    expect_sys_shutdown_errno(-1, 99, EBADF, "shutdown(-1, 99) must be EBADF");
+    // Use a high-numbered fd that is unlikely to be opened by any test runner.
+    expect_sys_shutdown_errno(99999, 99, EBADF, "shutdown(<closed_fd>, 99) must be EBADF");
+
+    int regular = open("/dev/null", O_RDWR);
+    if (regular < 0) {
+        die("open(/dev/null)");
+    }
+    expect_sys_shutdown_errno(regular, 99, ENOTSOCK,
+                              "shutdown(<regular_file>, 99) must be ENOTSOCK");
+    close(regular);
+}
+
 int main(void) {
     printf("== unix datagram shutdown syscall tests ==\n");
 
@@ -246,6 +176,7 @@ int main(void) {
     test_shutdown_both_combines_read_and_write_rules();
     test_peer_shutdown_write_drains_then_blocks();
     test_shutdown_invalid_how_returns_einval();
+    test_shutdown_fd_validated_before_how();
 
     printf("All unix datagram shutdown tests passed.\n");
     return 0;

--- a/litebox_runner_linux_userland/tests/unix_dgram_shutdown.c
+++ b/litebox_runner_linux_userland/tests/unix_dgram_shutdown.c
@@ -1,0 +1,190 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#define _GNU_SOURCE
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/syscall.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+static void die(const char *msg) {
+    perror(msg);
+    exit(1);
+}
+
+static void fail_errno(const char *op, int expected_errno) {
+    fprintf(stderr, "FAIL: %s expected errno=%d (%s), got errno=%d (%s)\n",
+            op, expected_errno, strerror(expected_errno), errno, strerror(errno));
+    exit(1);
+}
+
+static void expect_sys_shutdown(int fd, int how, const char *op) {
+    errno = 0;
+    if (syscall(SYS_shutdown, fd, how) != 0) {
+        die(op);
+    }
+}
+
+static void expect_send_errno(int fd, int expected_errno, const char *op) {
+    errno = 0;
+    ssize_t n = send(fd, "x", 1, MSG_DONTWAIT | MSG_NOSIGNAL);
+    if (n != -1) {
+        fprintf(stderr, "FAIL: %s expected failure, got %zd\n", op, n);
+        exit(1);
+    }
+    if (errno != expected_errno) {
+        fail_errno(op, expected_errno);
+    }
+}
+
+static void expect_recv_errno(int fd, int expected_errno, const char *op) {
+    char buf[32];
+
+    errno = 0;
+    ssize_t n = recv(fd, buf, sizeof(buf), MSG_DONTWAIT);
+    if (n != -1) {
+        fprintf(stderr, "FAIL: %s expected failure, got %zd\n", op, n);
+        exit(1);
+    }
+    if (errno != expected_errno) {
+        fail_errno(op, expected_errno);
+    }
+}
+
+static void expect_recv_eof(int fd, const char *op) {
+    char buf[32];
+
+    errno = 0;
+    ssize_t n = recv(fd, buf, sizeof(buf), 0);
+    if (n < 0) {
+        die(op);
+    }
+    if (n != 0) {
+        fprintf(stderr, "FAIL: %s expected EOF, got %zd\n", op, n);
+        exit(1);
+    }
+}
+
+static void expect_recv_string(int fd, const char *expected, const char *op) {
+    char buf[64];
+    size_t expected_len = strlen(expected);
+
+    memset(buf, 0, sizeof(buf));
+    errno = 0;
+    ssize_t n = recv(fd, buf, sizeof(buf), MSG_DONTWAIT);
+    if (n < 0) {
+        die(op);
+    }
+    if ((size_t)n != expected_len || memcmp(buf, expected, expected_len) != 0) {
+        fprintf(stderr, "FAIL: %s expected '%s' (%zu bytes), got '%.*s' (%zd bytes)\n",
+                op, expected, expected_len, (int)n, buf, n);
+        exit(1);
+    }
+}
+
+static void make_dgram_pair(int sv[2]) {
+    if (socketpair(AF_UNIX, SOCK_DGRAM, 0, sv) != 0) {
+        die("socketpair(AF_UNIX, SOCK_DGRAM)");
+    }
+}
+
+static void set_recv_timeout(int fd) {
+    struct timeval timeout = { .tv_sec = 0, .tv_usec = 100000 };
+
+    if (setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)) != 0) {
+        die("setsockopt(SO_RCVTIMEO)");
+    }
+}
+
+static void close_pair(int sv[2]) {
+    close(sv[0]);
+    close(sv[1]);
+}
+
+static void test_shutdown_read_keeps_queued_datagram(void) {
+    int sv[2];
+    const char *queued = "queued-before-read-shutdown";
+
+    make_dgram_pair(sv);
+    set_recv_timeout(sv[0]);
+
+    if (send(sv[1], queued, strlen(queued), MSG_NOSIGNAL) < 0) {
+        die("send queued datagram before SHUT_RD");
+    }
+
+    expect_sys_shutdown(sv[0], SHUT_RD, "shutdown(SHUT_RD)");
+
+    expect_recv_string(sv[0], queued, "recv queued datagram after SHUT_RD");
+    expect_send_errno(sv[1], EPIPE, "peer send after SHUT_RD");
+    expect_recv_errno(sv[0], EAGAIN, "empty nonblocking recv after SHUT_RD");
+    expect_recv_eof(sv[0], "empty blocking recv after SHUT_RD");
+
+    close_pair(sv);
+}
+
+static void test_shutdown_read_empty_blocking_recv_returns_eof(void) {
+    int sv[2];
+
+    make_dgram_pair(sv);
+    set_recv_timeout(sv[0]);
+
+    expect_sys_shutdown(sv[0], SHUT_RD, "shutdown(SHUT_RD) before recv");
+
+    expect_recv_eof(sv[0], "blocking recv after empty SHUT_RD");
+    expect_send_errno(sv[1], EPIPE, "peer send after empty SHUT_RD");
+
+    close_pair(sv);
+}
+
+static void test_shutdown_write_keeps_receive_side_open(void) {
+    int sv[2];
+    const char *inbound = "still-readable-after-write-shutdown";
+
+    make_dgram_pair(sv);
+
+    expect_sys_shutdown(sv[0], SHUT_WR, "shutdown(SHUT_WR)");
+
+    expect_send_errno(sv[0], EPIPE, "local send after SHUT_WR");
+    if (send(sv[1], inbound, strlen(inbound), MSG_NOSIGNAL) < 0) {
+        die("peer send after SHUT_WR");
+    }
+    expect_recv_string(sv[0], inbound, "local recv after SHUT_WR");
+
+    close_pair(sv);
+}
+
+static void test_shutdown_both_combines_read_and_write_rules(void) {
+    int sv[2];
+    const char *queued = "queued-before-rdwr-shutdown";
+
+    make_dgram_pair(sv);
+
+    if (send(sv[1], queued, strlen(queued), MSG_NOSIGNAL) < 0) {
+        die("send queued datagram before SHUT_RDWR");
+    }
+
+    expect_sys_shutdown(sv[0], SHUT_RDWR, "shutdown(SHUT_RDWR)");
+
+    expect_send_errno(sv[0], EPIPE, "local send after SHUT_RDWR");
+    expect_recv_string(sv[0], queued, "recv queued datagram after SHUT_RDWR");
+    expect_send_errno(sv[1], EPIPE, "peer send after SHUT_RDWR");
+    expect_recv_errno(sv[0], EAGAIN, "empty nonblocking recv after SHUT_RDWR");
+
+    close_pair(sv);
+}
+
+int main(void) {
+    printf("== unix datagram shutdown syscall tests ==\n");
+
+    test_shutdown_read_keeps_queued_datagram();
+    test_shutdown_read_empty_blocking_recv_returns_eof();
+    test_shutdown_write_keeps_receive_side_open();
+    test_shutdown_both_combines_read_and_write_rules();
+
+    printf("All unix datagram shutdown tests passed.\n");
+    return 0;
+}

--- a/litebox_runner_linux_userland/tests/unix_dgram_shutdown.c
+++ b/litebox_runner_linux_userland/tests/unix_dgram_shutdown.c
@@ -41,6 +41,23 @@ static void expect_send_errno(int fd, int expected_errno, const char *op) {
     }
 }
 
+// Blocking recv (no MSG_DONTWAIT) that we expect to time out via SO_RCVTIMEO. Distinct from
+// expect_recv_errno because we want to observe that the kernel kept blocking until the
+// timer expired, not that it gave up immediately with the same errno.
+static void expect_blocking_recv_eagain(int fd, const char *op) {
+    char buf[32];
+
+    errno = 0;
+    ssize_t n = recv(fd, buf, sizeof(buf), 0);
+    if (n != -1) {
+        fprintf(stderr, "FAIL: %s expected timeout failure, got %zd\n", op, n);
+        exit(1);
+    }
+    if (errno != EAGAIN) {
+        fail_errno(op, EAGAIN);
+    }
+}
+
 static void expect_recv_errno(int fd, int expected_errno, const char *op) {
     char buf[32];
 
@@ -180,6 +197,28 @@ static void test_shutdown_both_combines_read_and_write_rules(void) {
     close_pair(sv);
 }
 
+// When the peer calls shutdown(SHUT_WR), Linux does NOT synthesize EOF on the local recv —
+// unlike a local SHUT_RD, the socket is still connected and could in principle receive
+// from another sender, so a blocking recv keeps blocking (we observe EAGAIN via RCVTIMEO).
+// Queued datagrams must still drain first.
+static void test_peer_shutdown_write_drains_then_blocks(void) {
+    int sv[2];
+    const char *queued = "dgram-before-peer-shut-wr";
+
+    make_dgram_pair(sv);
+    set_recv_timeout(sv[0]);
+
+    if (send(sv[1], queued, strlen(queued), MSG_NOSIGNAL) < 0) {
+        die("peer send before peer SHUT_WR");
+    }
+    expect_sys_shutdown(sv[1], SHUT_WR, "peer shutdown(SHUT_WR)");
+
+    expect_recv_string(sv[0], queued, "recv queued datagram after peer SHUT_WR");
+    expect_blocking_recv_eagain(sv[0], "blocking recv after peer SHUT_WR with empty queue");
+
+    close_pair(sv);
+}
+
 static void test_shutdown_invalid_how_returns_einval(void) {
     int sv[2];
 
@@ -205,6 +244,7 @@ int main(void) {
     test_shutdown_read_empty_blocking_recv_returns_eof();
     test_shutdown_write_keeps_receive_side_open();
     test_shutdown_both_combines_read_and_write_rules();
+    test_peer_shutdown_write_drains_then_blocks();
     test_shutdown_invalid_how_returns_einval();
 
     printf("All unix datagram shutdown tests passed.\n");

--- a/litebox_runner_linux_userland/tests/unix_dgram_shutdown.c
+++ b/litebox_runner_linux_userland/tests/unix_dgram_shutdown.c
@@ -105,6 +105,9 @@ static void close_pair(int sv[2]) {
     close(sv[1]);
 }
 
+// SHUT_RD on a connected datagram socket: queued datagrams remain readable; once the queue
+// drains, a non-blocking recv returns EAGAIN (datagram quirk) while a blocking recv returns
+// EOF, and the peer's send fails with EPIPE.
 static void test_shutdown_read_keeps_queued_datagram(void) {
     int sv[2];
     const char *queued = "queued-before-read-shutdown";
@@ -177,6 +180,24 @@ static void test_shutdown_both_combines_read_and_write_rules(void) {
     close_pair(sv);
 }
 
+static void test_shutdown_invalid_how_returns_einval(void) {
+    int sv[2];
+
+    make_dgram_pair(sv);
+
+    errno = 0;
+    long ret = syscall(SYS_shutdown, sv[0], 99);
+    if (ret != -1) {
+        fprintf(stderr, "FAIL: shutdown(invalid how) expected failure, got %ld\n", ret);
+        exit(1);
+    }
+    if (errno != EINVAL) {
+        fail_errno("shutdown(invalid how)", EINVAL);
+    }
+
+    close_pair(sv);
+}
+
 int main(void) {
     printf("== unix datagram shutdown syscall tests ==\n");
 
@@ -184,6 +205,7 @@ int main(void) {
     test_shutdown_read_empty_blocking_recv_returns_eof();
     test_shutdown_write_keeps_receive_side_open();
     test_shutdown_both_combines_read_and_write_rules();
+    test_shutdown_invalid_how_returns_einval();
 
     printf("All unix datagram shutdown tests passed.\n");
     return 0;

--- a/litebox_runner_linux_userland/tests/unix_stream_shutdown.c
+++ b/litebox_runner_linux_userland/tests/unix_stream_shutdown.c
@@ -1,110 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-#define _GNU_SOURCE
-#include <errno.h>
+#include "helpers.h"
 #include <fcntl.h>
-#include <poll.h>
 #include <pthread.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <sys/socket.h>
-#include <sys/syscall.h>
-#include <sys/time.h>
 #include <sys/un.h>
-#include <unistd.h>
-
-static void die(const char *msg) {
-    perror(msg);
-    exit(1);
-}
-
-static void fail_errno(const char *op, int expected_errno) {
-    fprintf(stderr, "FAIL: %s expected errno=%d (%s), got errno=%d (%s)\n",
-            op, expected_errno, strerror(expected_errno), errno, strerror(errno));
-    exit(1);
-}
-
-static void expect_sys_shutdown(int fd, int how, const char *op) {
-    errno = 0;
-    if (syscall(SYS_shutdown, fd, how) != 0) {
-        die(op);
-    }
-}
-
-static void expect_sys_shutdown_errno(int fd, int how, int expected_errno, const char *op) {
-    errno = 0;
-    long ret = syscall(SYS_shutdown, fd, how);
-    if (ret != -1) {
-        fprintf(stderr, "FAIL: %s expected failure, got %ld\n", op, ret);
-        exit(1);
-    }
-    if (errno != expected_errno) {
-        fail_errno(op, expected_errno);
-    }
-}
-
-static void expect_send_errno(int fd, int expected_errno, const char *op) {
-    errno = 0;
-    ssize_t n = send(fd, "x", 1, MSG_DONTWAIT | MSG_NOSIGNAL);
-    if (n != -1) {
-        fprintf(stderr, "FAIL: %s expected failure, got %zd\n", op, n);
-        exit(1);
-    }
-    if (errno != expected_errno) {
-        fail_errno(op, expected_errno);
-    }
-}
-
-static void expect_recv_eof(int fd, const char *op) {
-    char buf[32];
-
-    errno = 0;
-    ssize_t n = recv(fd, buf, sizeof(buf), 0);
-    if (n < 0) {
-        die(op);
-    }
-    if (n != 0) {
-        fprintf(stderr, "FAIL: %s expected EOF, got %zd\n", op, n);
-        exit(1);
-    }
-}
-
-static void expect_recv_string(int fd, const char *expected, const char *op) {
-    char buf[64];
-    size_t expected_len = strlen(expected);
-
-    memset(buf, 0, sizeof(buf));
-    errno = 0;
-    ssize_t n = recv(fd, buf, sizeof(buf), MSG_DONTWAIT);
-    if (n < 0) {
-        die(op);
-    }
-    if ((size_t)n != expected_len || memcmp(buf, expected, expected_len) != 0) {
-        fprintf(stderr, "FAIL: %s expected '%s' (%zu bytes), got '%.*s' (%zd bytes)\n",
-                op, expected, expected_len, (int)n, buf, n);
-        exit(1);
-    }
-}
 
 static void make_stream_pair(int sv[2]) {
-    if (socketpair(AF_UNIX, SOCK_STREAM, 0, sv) != 0) {
-        die("socketpair(AF_UNIX, SOCK_STREAM)");
-    }
-}
-
-static void set_recv_timeout(int fd) {
-    struct timeval timeout = { .tv_sec = 0, .tv_usec = 100000 };
-
-    if (setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)) != 0) {
-        die("setsockopt(SO_RCVTIMEO)");
-    }
-}
-
-static void close_pair(int sv[2]) {
-    close(sv[0]);
-    close(sv[1]);
+    make_socket_pair(SOCK_STREAM, sv);
 }
 
 static void test_shutdown_read_drains_then_returns_eof(void) {

--- a/litebox_runner_linux_userland/tests/unix_stream_shutdown.c
+++ b/litebox_runner_linux_userland/tests/unix_stream_shutdown.c
@@ -10,6 +10,24 @@ static void make_stream_pair(int sv[2]) {
     make_socket_pair(SOCK_STREAM, sv);
 }
 
+static int make_listen_socket(struct sockaddr_un *sa, const char *name) {
+    int fd = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (fd < 0) {
+        die("socket(listen)");
+    }
+    memset(sa, 0, sizeof(*sa));
+    sa->sun_family = AF_UNIX;
+    snprintf(sa->sun_path, sizeof(sa->sun_path), "/tmp/lb_shut_%s_%d", name, getpid());
+    unlink(sa->sun_path);
+    if (bind(fd, (struct sockaddr *)sa, sizeof(*sa)) != 0) {
+        die("bind(listen)");
+    }
+    if (listen(fd, 4) != 0) {
+        die("listen()");
+    }
+    return fd;
+}
+
 static void test_shutdown_read_drains_then_returns_eof(void) {
     int sv[2];
     const char *queued = "before-shut-rd";
@@ -76,7 +94,7 @@ static void test_shutdown_both_combines_read_and_write_rules(void) {
     close_pair(sv);
 }
 
-// shutdown() on an unconnected (Init) AF_UNIX stream socket succeeds silently on Linux —
+// shutdown() on an unconnected (Init) AF_UNIX stream socket succeeds silently on Linux;
 // unlike inet sockets, unix_shutdown does not enforce ENOTCONN. Lock this in so the silent
 // success path in UnixStream::shutdown stays honest.
 static void test_shutdown_unconnected_succeeds(void) {
@@ -92,19 +110,8 @@ static void test_shutdown_unconnected_succeeds(void) {
 // the socket transitions to Connected: a `shutdown(SHUT_WR)` on a freshly-created Init socket
 // must cause the post-connect `send()` to fail with EPIPE.
 static void test_init_shutdown_persists_to_connected(void) {
-    int srv = socket(AF_UNIX, SOCK_STREAM, 0);
-    if (srv < 0) {
-        die("socket(server)");
-    }
-    struct sockaddr_un sa = { .sun_family = AF_UNIX };
-    snprintf(sa.sun_path, sizeof(sa.sun_path), "/tmp/lb_shut_init_%d", getpid());
-    unlink(sa.sun_path);
-    if (bind(srv, (struct sockaddr *)&sa, sizeof(sa)) != 0) {
-        die("bind(server)");
-    }
-    if (listen(srv, 4) != 0) {
-        die("listen(server)");
-    }
+    struct sockaddr_un sa;
+    int srv = make_listen_socket(&sa, "init");
 
     int c = socket(AF_UNIX, SOCK_STREAM, 0);
     if (c < 0) {
@@ -122,7 +129,7 @@ static void test_init_shutdown_persists_to_connected(void) {
 }
 
 // A fresh Init Unix-stream socket polls as OUT|HUP (HUP because it's not connected).
-// After shutdown(SHUT_RD) — even pre-connect — Linux additionally reports POLLIN because
+// After shutdown(SHUT_RD), even pre-connect, Linux additionally reports POLLIN because
 // a recv would return EOF immediately. SHUT_WR alone leaves the poll output unchanged.
 static void test_init_shutdown_read_makes_poll_in_ready(void) {
     int fd = socket(AF_UNIX, SOCK_STREAM, 0);
@@ -158,19 +165,8 @@ static void test_init_shutdown_read_makes_poll_in_ready(void) {
 // accept returns EINVAL (not tested here to avoid pthreads), and poll reports both POLLIN
 // and POLLHUP.
 static void test_listen_shutdown_signals_in_and_hup(void) {
-    int fd = socket(AF_UNIX, SOCK_STREAM, 0);
-    if (fd < 0) {
-        die("socket(listen)");
-    }
-    struct sockaddr_un sa = { .sun_family = AF_UNIX };
-    snprintf(sa.sun_path, sizeof(sa.sun_path), "/tmp/lb_shut_listen_%d", getpid());
-    unlink(sa.sun_path);
-    if (bind(fd, (struct sockaddr *)&sa, sizeof(sa)) != 0) {
-        die("bind(listen)");
-    }
-    if (listen(fd, 4) != 0) {
-        die("listen()");
-    }
+    struct sockaddr_un sa;
+    int fd = make_listen_socket(&sa, "listen");
     expect_sys_shutdown(fd, SHUT_RDWR, "shutdown(listen, SHUT_RDWR)");
 
     struct pollfd pfd = { .fd = fd, .events = POLLIN };
@@ -191,22 +187,11 @@ static void test_listen_shutdown_signals_in_and_hup(void) {
     unlink(sa.sun_path);
 }
 
-// Non-blocking accept on a shut-down listen socket returns EAGAIN on Linux (not EINVAL —
+// Non-blocking accept on a shut-down listen socket returns EAGAIN on Linux (not EINVAL;
 // the empty-queue fast path runs before the shutdown check kicks in).
 static void test_listen_shutdown_nonblocking_accept_returns_eagain(void) {
-    int fd = socket(AF_UNIX, SOCK_STREAM, 0);
-    if (fd < 0) {
-        die("socket(listen)");
-    }
-    struct sockaddr_un sa = { .sun_family = AF_UNIX };
-    snprintf(sa.sun_path, sizeof(sa.sun_path), "/tmp/lb_shut_nbacc_%d", getpid());
-    unlink(sa.sun_path);
-    if (bind(fd, (struct sockaddr *)&sa, sizeof(sa)) != 0) {
-        die("bind(listen)");
-    }
-    if (listen(fd, 4) != 0) {
-        die("listen()");
-    }
+    struct sockaddr_un sa;
+    int fd = make_listen_socket(&sa, "nbacc");
     if (fcntl(fd, F_SETFL, fcntl(fd, F_GETFL) | O_NONBLOCK) != 0) {
         die("fcntl O_NONBLOCK");
     }
@@ -244,19 +229,8 @@ static void *blocking_accept_thread(void *arg) {
 }
 
 static void test_listen_shutdown_blocking_accept_returns_einval(void) {
-    int fd = socket(AF_UNIX, SOCK_STREAM, 0);
-    if (fd < 0) {
-        die("socket(listen)");
-    }
-    struct sockaddr_un sa = { .sun_family = AF_UNIX };
-    snprintf(sa.sun_path, sizeof(sa.sun_path), "/tmp/lb_shut_blkacc_%d", getpid());
-    unlink(sa.sun_path);
-    if (bind(fd, (struct sockaddr *)&sa, sizeof(sa)) != 0) {
-        die("bind(listen)");
-    }
-    if (listen(fd, 4) != 0) {
-        die("listen()");
-    }
+    struct sockaddr_un sa;
+    int fd = make_listen_socket(&sa, "blkacc");
 
     struct blocking_accept_ctx ctx = { .fd = fd, .ret = 0, .err = 0 };
     pthread_t t;
@@ -285,8 +259,84 @@ static void test_listen_shutdown_blocking_accept_returns_einval(void) {
     unlink(sa.sun_path);
 }
 
+static void test_listen_shutdown_write_keeps_accepting(void) {
+    struct sockaddr_un sa;
+    int fd = make_listen_socket(&sa, "listen_wr");
+
+    expect_sys_shutdown(fd, SHUT_WR, "shutdown(listen, SHUT_WR)");
+
+    int client = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (client < 0) {
+        die("socket(client)");
+    }
+    if (connect(client, (struct sockaddr *)&sa, sizeof(sa)) != 0) {
+        die("connect after listen SHUT_WR");
+    }
+    int accepted = accept(fd, NULL, NULL);
+    if (accepted < 0) {
+        die("accept after listen SHUT_WR");
+    }
+
+    close(accepted);
+    close(client);
+    close(fd);
+    unlink(sa.sun_path);
+}
+
+static void test_listen_shutdown_read_preserves_queued_connections(void) {
+    struct sockaddr_un sa;
+    int fd = make_listen_socket(&sa, "listen_rd");
+    if (fcntl(fd, F_SETFL, fcntl(fd, F_GETFL) | O_NONBLOCK) != 0) {
+        die("fcntl O_NONBLOCK");
+    }
+
+    int queued_client = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (queued_client < 0) {
+        die("socket(queued client)");
+    }
+    if (connect(queued_client, (struct sockaddr *)&sa, sizeof(sa)) != 0) {
+        die("queued connect before listen SHUT_RD");
+    }
+
+    expect_sys_shutdown(fd, SHUT_RD, "shutdown(listen, SHUT_RD)");
+
+    int refused_client = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (refused_client < 0) {
+        die("socket(refused client)");
+    }
+    errno = 0;
+    if (connect(refused_client, (struct sockaddr *)&sa, sizeof(sa)) != -1) {
+        fprintf(stderr, "FAIL: connect after listen SHUT_RD expected failure\n");
+        exit(1);
+    }
+    if (errno != ECONNREFUSED) {
+        fail_errno("connect after listen SHUT_RD", ECONNREFUSED);
+    }
+
+    int accepted = accept(fd, NULL, NULL);
+    if (accepted < 0) {
+        die("accept queued connection after listen SHUT_RD");
+    }
+
+    errno = 0;
+    int drained = accept(fd, NULL, NULL);
+    if (drained != -1) {
+        fprintf(stderr, "FAIL: drained accept after listen SHUT_RD expected -1, got %d\n", drained);
+        exit(1);
+    }
+    if (errno != EAGAIN) {
+        fail_errno("drained accept after listen SHUT_RD", EAGAIN);
+    }
+
+    close(accepted);
+    close(refused_client);
+    close(queued_client);
+    close(fd);
+    unlink(sa.sun_path);
+}
+
 // When the *peer* calls shutdown(SHUT_WR), the local recv side must drain any queued bytes
-// first, then observe EOF on a subsequent recv — same behavior as a local SHUT_RD, just
+// first, then observe EOF on a subsequent recv: same behavior as a local SHUT_RD, just
 // triggered from the other side. Locks in the channel-layer "peer shutdown" drain path.
 static void test_peer_shutdown_write_drains_then_returns_eof(void) {
     int sv[2];
@@ -302,6 +352,31 @@ static void test_peer_shutdown_write_drains_then_returns_eof(void) {
 
     expect_recv_string(sv[0], queued, "recv queued bytes after peer SHUT_WR");
     expect_recv_eof(sv[0], "blocking recv after peer SHUT_WR queue drained");
+
+    close_pair(sv);
+}
+
+static void test_peer_shutdown_write_reports_read_ready(void) {
+    int sv[2];
+
+    make_stream_pair(sv);
+
+    expect_sys_shutdown(sv[1], SHUT_WR, "peer shutdown(SHUT_WR)");
+
+    struct pollfd pfd = { .fd = sv[0], .events = POLLIN | POLLRDHUP };
+    int r = poll(&pfd, 1, 0);
+    if (r != 1) {
+        fprintf(stderr, "FAIL: poll after peer SHUT_WR expected 1, got %d (errno=%d)\n",
+                r, errno);
+        exit(1);
+    }
+    if (!(pfd.revents & POLLIN) || !(pfd.revents & POLLRDHUP)) {
+        fprintf(stderr,
+                "FAIL: poll after peer SHUT_WR expected POLLIN|POLLRDHUP, got revents=0x%x\n",
+                pfd.revents);
+        exit(1);
+    }
+    expect_recv_eof(sv[0], "recv after peer SHUT_WR readiness");
 
     close_pair(sv);
 }
@@ -329,7 +404,10 @@ int main(void) {
     test_listen_shutdown_signals_in_and_hup();
     test_listen_shutdown_nonblocking_accept_returns_eagain();
     test_listen_shutdown_blocking_accept_returns_einval();
+    test_listen_shutdown_write_keeps_accepting();
+    test_listen_shutdown_read_preserves_queued_connections();
     test_peer_shutdown_write_drains_then_returns_eof();
+    test_peer_shutdown_write_reports_read_ready();
     test_shutdown_invalid_how_returns_einval();
 
     printf("All unix stream shutdown tests passed.\n");

--- a/litebox_runner_linux_userland/tests/unix_stream_shutdown.c
+++ b/litebox_runner_linux_userland/tests/unix_stream_shutdown.c
@@ -253,6 +253,27 @@ static void test_listen_shutdown_signals_hup(void) {
     unlink(sa.sun_path);
 }
 
+// When the *peer* calls shutdown(SHUT_WR), the local recv side must drain any queued bytes
+// first, then observe EOF on a subsequent recv — same behavior as a local SHUT_RD, just
+// triggered from the other side. Locks in the channel-layer "peer shutdown" drain path.
+static void test_peer_shutdown_write_drains_then_returns_eof(void) {
+    int sv[2];
+    const char *queued = "bytes-before-peer-shut-wr";
+
+    make_stream_pair(sv);
+    set_recv_timeout(sv[0]);
+
+    if (send(sv[1], queued, strlen(queued), MSG_NOSIGNAL) < 0) {
+        die("peer send before peer SHUT_WR");
+    }
+    expect_sys_shutdown(sv[1], SHUT_WR, "peer shutdown(SHUT_WR)");
+
+    expect_recv_string(sv[0], queued, "recv queued bytes after peer SHUT_WR");
+    expect_recv_eof(sv[0], "blocking recv after peer SHUT_WR queue drained");
+
+    close_pair(sv);
+}
+
 static void test_shutdown_invalid_how_returns_einval(void) {
     int sv[2];
 
@@ -273,6 +294,7 @@ int main(void) {
     test_shutdown_unconnected_succeeds();
     test_init_shutdown_persists_to_connected();
     test_listen_shutdown_signals_hup();
+    test_peer_shutdown_write_drains_then_returns_eof();
     test_shutdown_invalid_how_returns_einval();
 
     printf("All unix stream shutdown tests passed.\n");

--- a/litebox_runner_linux_userland/tests/unix_stream_shutdown.c
+++ b/litebox_runner_linux_userland/tests/unix_stream_shutdown.c
@@ -1,0 +1,280 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#define _GNU_SOURCE
+#include <errno.h>
+#include <poll.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/syscall.h>
+#include <sys/time.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+static void die(const char *msg) {
+    perror(msg);
+    exit(1);
+}
+
+static void fail_errno(const char *op, int expected_errno) {
+    fprintf(stderr, "FAIL: %s expected errno=%d (%s), got errno=%d (%s)\n",
+            op, expected_errno, strerror(expected_errno), errno, strerror(errno));
+    exit(1);
+}
+
+static void expect_sys_shutdown(int fd, int how, const char *op) {
+    errno = 0;
+    if (syscall(SYS_shutdown, fd, how) != 0) {
+        die(op);
+    }
+}
+
+static void expect_sys_shutdown_errno(int fd, int how, int expected_errno, const char *op) {
+    errno = 0;
+    long ret = syscall(SYS_shutdown, fd, how);
+    if (ret != -1) {
+        fprintf(stderr, "FAIL: %s expected failure, got %ld\n", op, ret);
+        exit(1);
+    }
+    if (errno != expected_errno) {
+        fail_errno(op, expected_errno);
+    }
+}
+
+static void expect_send_errno(int fd, int expected_errno, const char *op) {
+    errno = 0;
+    ssize_t n = send(fd, "x", 1, MSG_DONTWAIT | MSG_NOSIGNAL);
+    if (n != -1) {
+        fprintf(stderr, "FAIL: %s expected failure, got %zd\n", op, n);
+        exit(1);
+    }
+    if (errno != expected_errno) {
+        fail_errno(op, expected_errno);
+    }
+}
+
+static void expect_recv_eof(int fd, const char *op) {
+    char buf[32];
+
+    errno = 0;
+    ssize_t n = recv(fd, buf, sizeof(buf), 0);
+    if (n < 0) {
+        die(op);
+    }
+    if (n != 0) {
+        fprintf(stderr, "FAIL: %s expected EOF, got %zd\n", op, n);
+        exit(1);
+    }
+}
+
+static void expect_recv_string(int fd, const char *expected, const char *op) {
+    char buf[64];
+    size_t expected_len = strlen(expected);
+
+    memset(buf, 0, sizeof(buf));
+    errno = 0;
+    ssize_t n = recv(fd, buf, sizeof(buf), MSG_DONTWAIT);
+    if (n < 0) {
+        die(op);
+    }
+    if ((size_t)n != expected_len || memcmp(buf, expected, expected_len) != 0) {
+        fprintf(stderr, "FAIL: %s expected '%s' (%zu bytes), got '%.*s' (%zd bytes)\n",
+                op, expected, expected_len, (int)n, buf, n);
+        exit(1);
+    }
+}
+
+static void make_stream_pair(int sv[2]) {
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, sv) != 0) {
+        die("socketpair(AF_UNIX, SOCK_STREAM)");
+    }
+}
+
+static void set_recv_timeout(int fd) {
+    struct timeval timeout = { .tv_sec = 0, .tv_usec = 100000 };
+
+    if (setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)) != 0) {
+        die("setsockopt(SO_RCVTIMEO)");
+    }
+}
+
+static void close_pair(int sv[2]) {
+    close(sv[0]);
+    close(sv[1]);
+}
+
+static void test_shutdown_read_drains_then_returns_eof(void) {
+    int sv[2];
+    const char *queued = "before-shut-rd";
+
+    make_stream_pair(sv);
+    set_recv_timeout(sv[0]);
+
+    if (send(sv[1], queued, strlen(queued), MSG_NOSIGNAL) < 0) {
+        die("peer send before SHUT_RD");
+    }
+
+    expect_sys_shutdown(sv[0], SHUT_RD, "shutdown(SHUT_RD)");
+
+    expect_recv_string(sv[0], queued, "recv queued bytes after SHUT_RD");
+    expect_recv_eof(sv[0], "blocking recv after queue drained");
+    expect_send_errno(sv[1], EPIPE, "peer send after SHUT_RD");
+
+    close_pair(sv);
+}
+
+static void test_shutdown_read_empty_returns_eof(void) {
+    int sv[2];
+
+    make_stream_pair(sv);
+    set_recv_timeout(sv[0]);
+
+    expect_sys_shutdown(sv[0], SHUT_RD, "shutdown(SHUT_RD) on empty queue");
+
+    expect_recv_eof(sv[0], "blocking recv on empty SHUT_RD queue");
+    expect_send_errno(sv[1], EPIPE, "peer send after empty SHUT_RD");
+
+    close_pair(sv);
+}
+
+static void test_shutdown_write_keeps_receive_side_open(void) {
+    int sv[2];
+    const char *inbound = "still-readable-after-write-shutdown";
+
+    make_stream_pair(sv);
+
+    expect_sys_shutdown(sv[0], SHUT_WR, "shutdown(SHUT_WR)");
+
+    expect_send_errno(sv[0], EPIPE, "local send after SHUT_WR");
+    if (send(sv[1], inbound, strlen(inbound), MSG_NOSIGNAL) < 0) {
+        die("peer send after SHUT_WR");
+    }
+    expect_recv_string(sv[0], inbound, "local recv after SHUT_WR");
+
+    close_pair(sv);
+}
+
+static void test_shutdown_both_combines_read_and_write_rules(void) {
+    int sv[2];
+
+    make_stream_pair(sv);
+    set_recv_timeout(sv[0]);
+
+    expect_sys_shutdown(sv[0], SHUT_RDWR, "shutdown(SHUT_RDWR)");
+
+    expect_send_errno(sv[0], EPIPE, "local send after SHUT_RDWR");
+    expect_recv_eof(sv[0], "blocking recv after SHUT_RDWR");
+    expect_send_errno(sv[1], EPIPE, "peer send after SHUT_RDWR");
+
+    close_pair(sv);
+}
+
+// shutdown() on an unconnected (Init) AF_UNIX stream socket succeeds silently on Linux —
+// unlike inet sockets, unix_shutdown does not enforce ENOTCONN. Lock this in so the silent
+// success path in UnixStream::shutdown stays honest.
+static void test_shutdown_unconnected_succeeds(void) {
+    int fd = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (fd < 0) {
+        die("socket(AF_UNIX, SOCK_STREAM)");
+    }
+    expect_sys_shutdown(fd, SHUT_RDWR, "shutdown(SHUT_RDWR) on unconnected unix stream");
+    close(fd);
+}
+
+// Linux records pre-connect shutdown flags on the unix_sock structure and applies them once
+// the socket transitions to Connected: a `shutdown(SHUT_WR)` on a freshly-created Init socket
+// must cause the post-connect `send()` to fail with EPIPE.
+static void test_init_shutdown_persists_to_connected(void) {
+    int srv = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (srv < 0) {
+        die("socket(server)");
+    }
+    struct sockaddr_un sa = { .sun_family = AF_UNIX };
+    snprintf(sa.sun_path, sizeof(sa.sun_path), "/tmp/lb_shut_init_%d", getpid());
+    unlink(sa.sun_path);
+    if (bind(srv, (struct sockaddr *)&sa, sizeof(sa)) != 0) {
+        die("bind(server)");
+    }
+    if (listen(srv, 4) != 0) {
+        die("listen(server)");
+    }
+
+    int c = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (c < 0) {
+        die("socket(client)");
+    }
+    expect_sys_shutdown(c, SHUT_WR, "pre-connect shutdown(SHUT_WR)");
+    if (connect(c, (struct sockaddr *)&sa, sizeof(sa)) != 0) {
+        die("connect after pre-connect shutdown");
+    }
+    expect_send_errno(c, EPIPE, "post-connect send must observe pre-connect SHUT_WR");
+
+    close(c);
+    close(srv);
+    unlink(sa.sun_path);
+}
+
+// Linux's `shutdown(SHUT_RDWR)` on a listening socket is observable two ways: a blocking
+// accept returns EINVAL (not tested here to avoid pthreads), and poll reports POLLIN|POLLHUP.
+// We use the poll signal to confirm the listen state changed.
+static void test_listen_shutdown_signals_hup(void) {
+    int fd = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (fd < 0) {
+        die("socket(listen)");
+    }
+    struct sockaddr_un sa = { .sun_family = AF_UNIX };
+    snprintf(sa.sun_path, sizeof(sa.sun_path), "/tmp/lb_shut_listen_%d", getpid());
+    unlink(sa.sun_path);
+    if (bind(fd, (struct sockaddr *)&sa, sizeof(sa)) != 0) {
+        die("bind(listen)");
+    }
+    if (listen(fd, 4) != 0) {
+        die("listen()");
+    }
+    expect_sys_shutdown(fd, SHUT_RDWR, "shutdown(listen, SHUT_RDWR)");
+
+    struct pollfd pfd = { .fd = fd, .events = POLLIN };
+    int r = poll(&pfd, 1, 100);
+    if (r != 1) {
+        fprintf(stderr, "FAIL: poll after listen-shutdown expected 1, got %d (errno=%d)\n",
+                r, errno);
+        exit(1);
+    }
+    if (!(pfd.revents & POLLHUP)) {
+        fprintf(stderr,
+                "FAIL: poll after listen-shutdown expected POLLHUP, got revents=0x%x\n",
+                pfd.revents);
+        exit(1);
+    }
+
+    close(fd);
+    unlink(sa.sun_path);
+}
+
+static void test_shutdown_invalid_how_returns_einval(void) {
+    int sv[2];
+
+    make_stream_pair(sv);
+
+    expect_sys_shutdown_errno(sv[0], 99, EINVAL, "shutdown(invalid how)");
+
+    close_pair(sv);
+}
+
+int main(void) {
+    printf("== unix stream shutdown syscall tests ==\n");
+
+    test_shutdown_read_drains_then_returns_eof();
+    test_shutdown_read_empty_returns_eof();
+    test_shutdown_write_keeps_receive_side_open();
+    test_shutdown_both_combines_read_and_write_rules();
+    test_shutdown_unconnected_succeeds();
+    test_init_shutdown_persists_to_connected();
+    test_listen_shutdown_signals_hup();
+    test_shutdown_invalid_how_returns_einval();
+
+    printf("All unix stream shutdown tests passed.\n");
+    return 0;
+}

--- a/litebox_runner_linux_userland/tests/unix_stream_shutdown.c
+++ b/litebox_runner_linux_userland/tests/unix_stream_shutdown.c
@@ -3,7 +3,9 @@
 
 #define _GNU_SOURCE
 #include <errno.h>
+#include <fcntl.h>
 #include <poll.h>
+#include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -216,10 +218,43 @@ static void test_init_shutdown_persists_to_connected(void) {
     unlink(sa.sun_path);
 }
 
+// A fresh Init Unix-stream socket polls as OUT|HUP (HUP because it's not connected).
+// After shutdown(SHUT_RD) — even pre-connect — Linux additionally reports POLLIN because
+// a recv would return EOF immediately. SHUT_WR alone leaves the poll output unchanged.
+static void test_init_shutdown_read_makes_poll_in_ready(void) {
+    int fd = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (fd < 0) {
+        die("socket(AF_UNIX, SOCK_STREAM)");
+    }
+    struct pollfd pfd = { .fd = fd, .events = POLLIN | POLLOUT };
+    int r = poll(&pfd, 1, 0);
+    if (r != 1 || (pfd.revents & POLLIN)) {
+        fprintf(stderr,
+                "FAIL: fresh Init poll expected !POLLIN, got r=%d revents=0x%x\n",
+                r, pfd.revents);
+        exit(1);
+    }
+
+    expect_sys_shutdown(fd, SHUT_RD, "shutdown(SHUT_RD) on Init");
+    // POLLIN must be level-triggered: every subsequent poll on the same socket should keep
+    // reporting it until the state changes. Probe three iterations to lock that in.
+    for (int i = 0; i < 3; i++) {
+        pfd.revents = 0;
+        r = poll(&pfd, 1, 0);
+        if (r != 1 || !(pfd.revents & POLLIN) || !(pfd.revents & POLLHUP)) {
+            fprintf(stderr,
+                    "FAIL: Init+SHUT_RD poll #%d expected POLLIN|POLLHUP, got r=%d revents=0x%x\n",
+                    i, r, pfd.revents);
+            exit(1);
+        }
+    }
+    close(fd);
+}
+
 // Linux's `shutdown(SHUT_RDWR)` on a listening socket is observable two ways: a blocking
-// accept returns EINVAL (not tested here to avoid pthreads), and poll reports POLLIN|POLLHUP.
-// We use the poll signal to confirm the listen state changed.
-static void test_listen_shutdown_signals_hup(void) {
+// accept returns EINVAL (not tested here to avoid pthreads), and poll reports both POLLIN
+// and POLLHUP.
+static void test_listen_shutdown_signals_in_and_hup(void) {
     int fd = socket(AF_UNIX, SOCK_STREAM, 0);
     if (fd < 0) {
         die("socket(listen)");
@@ -242,10 +277,104 @@ static void test_listen_shutdown_signals_hup(void) {
                 r, errno);
         exit(1);
     }
-    if (!(pfd.revents & POLLHUP)) {
+    if (!(pfd.revents & POLLIN) || !(pfd.revents & POLLHUP)) {
         fprintf(stderr,
-                "FAIL: poll after listen-shutdown expected POLLHUP, got revents=0x%x\n",
+                "FAIL: poll after listen-shutdown expected POLLIN|POLLHUP, got revents=0x%x\n",
                 pfd.revents);
+        exit(1);
+    }
+
+    close(fd);
+    unlink(sa.sun_path);
+}
+
+// Non-blocking accept on a shut-down listen socket returns EAGAIN on Linux (not EINVAL —
+// the empty-queue fast path runs before the shutdown check kicks in).
+static void test_listen_shutdown_nonblocking_accept_returns_eagain(void) {
+    int fd = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (fd < 0) {
+        die("socket(listen)");
+    }
+    struct sockaddr_un sa = { .sun_family = AF_UNIX };
+    snprintf(sa.sun_path, sizeof(sa.sun_path), "/tmp/lb_shut_nbacc_%d", getpid());
+    unlink(sa.sun_path);
+    if (bind(fd, (struct sockaddr *)&sa, sizeof(sa)) != 0) {
+        die("bind(listen)");
+    }
+    if (listen(fd, 4) != 0) {
+        die("listen()");
+    }
+    if (fcntl(fd, F_SETFL, fcntl(fd, F_GETFL) | O_NONBLOCK) != 0) {
+        die("fcntl O_NONBLOCK");
+    }
+    expect_sys_shutdown(fd, SHUT_RDWR, "shutdown(listen, SHUT_RDWR)");
+
+    errno = 0;
+    int a = accept(fd, NULL, NULL);
+    if (a != -1) {
+        fprintf(stderr, "FAIL: nonblocking accept on shut-down listen expected -1, got %d\n", a);
+        exit(1);
+    }
+    if (errno != EAGAIN) {
+        fail_errno("nonblocking accept on shut-down listen", EAGAIN);
+    }
+
+    close(fd);
+    unlink(sa.sun_path);
+}
+
+// Blocking accept on a shut-down listen socket returns EINVAL. We start a thread that
+// enters blocking accept, then shut the listen socket down from the main thread and
+// observe the thread's return code.
+struct blocking_accept_ctx {
+    int fd;
+    int ret;
+    int err;
+};
+
+static void *blocking_accept_thread(void *arg) {
+    struct blocking_accept_ctx *ctx = arg;
+    errno = 0;
+    ctx->ret = accept(ctx->fd, NULL, NULL);
+    ctx->err = errno;
+    return NULL;
+}
+
+static void test_listen_shutdown_blocking_accept_returns_einval(void) {
+    int fd = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (fd < 0) {
+        die("socket(listen)");
+    }
+    struct sockaddr_un sa = { .sun_family = AF_UNIX };
+    snprintf(sa.sun_path, sizeof(sa.sun_path), "/tmp/lb_shut_blkacc_%d", getpid());
+    unlink(sa.sun_path);
+    if (bind(fd, (struct sockaddr *)&sa, sizeof(sa)) != 0) {
+        die("bind(listen)");
+    }
+    if (listen(fd, 4) != 0) {
+        die("listen()");
+    }
+
+    struct blocking_accept_ctx ctx = { .fd = fd, .ret = 0, .err = 0 };
+    pthread_t t;
+    if (pthread_create(&t, NULL, blocking_accept_thread, &ctx) != 0) {
+        die("pthread_create");
+    }
+    // Give the thread a moment to enter blocking accept().
+    usleep(100 * 1000);
+
+    expect_sys_shutdown(fd, SHUT_RDWR, "shutdown(listen, SHUT_RDWR)");
+
+    pthread_join(t, NULL);
+    if (ctx.ret != -1) {
+        fprintf(stderr, "FAIL: blocking accept on shut-down listen expected -1, got %d\n",
+                ctx.ret);
+        exit(1);
+    }
+    if (ctx.err != EINVAL) {
+        fprintf(stderr,
+                "FAIL: blocking accept on shut-down listen expected errno=%d (EINVAL), got %d (%s)\n",
+                EINVAL, ctx.err, strerror(ctx.err));
         exit(1);
     }
 
@@ -293,7 +422,10 @@ int main(void) {
     test_shutdown_both_combines_read_and_write_rules();
     test_shutdown_unconnected_succeeds();
     test_init_shutdown_persists_to_connected();
-    test_listen_shutdown_signals_hup();
+    test_init_shutdown_read_makes_poll_in_ready();
+    test_listen_shutdown_signals_in_and_hup();
+    test_listen_shutdown_nonblocking_accept_returns_eagain();
+    test_listen_shutdown_blocking_accept_returns_einval();
     test_peer_shutdown_write_drains_then_returns_eof();
     test_shutdown_invalid_how_returns_einval();
 

--- a/litebox_shim_linux/src/channel.rs
+++ b/litebox_shim_linux/src/channel.rs
@@ -20,8 +20,7 @@ macro_rules! common_functions_for_channel {
         }
 
         /// Shut this channel down.
-        #[expect(dead_code)]
-        fn shutdown(&self) {
+        pub(crate) fn shutdown(&self) {
             self.endpoint.shutdown();
         }
 

--- a/litebox_shim_linux/src/channel.rs
+++ b/litebox_shim_linux/src/channel.rs
@@ -33,7 +33,8 @@ macro_rules! common_functions_for_channel {
             }
         }
 
-        fn is_peer_shutdown(&self) -> bool {
+        /// Has the peer (i.e., other end) been shut down?
+        pub(crate) fn is_peer_shutdown(&self) -> bool {
             if let Some(peer) = self.peer.upgrade() {
                 peer.is_shutdown()
             } else {
@@ -98,7 +99,8 @@ impl<T> ReadEnd<T> {
     ) -> Result<R, Errno> {
         // Linux preserves bytes already queued when the read side is shut down
         // (via shutdown(SHUT_RD) or peer close), so consult the buffer before
-        // returning ESHUTDOWN — the caller observes EOF only once the queue drains.
+        // returning ESHUTDOWN; the caller observes EOF only once the queue drains.
+        let is_shutdown = self.is_shutdown() || self.is_peer_shutdown();
         let mut guard = self.endpoint.rb.lock();
         if let Some(item) = guard.first_mut() {
             let (should_consume, ret) = f(item)?;
@@ -110,9 +112,7 @@ impl<T> ReadEnd<T> {
             }
             return Ok(ret);
         }
-        drop(guard);
-
-        if self.is_shutdown() || self.is_peer_shutdown() {
+        if is_shutdown {
             return Err(Errno::ESHUTDOWN);
         }
 
@@ -289,7 +289,7 @@ mod tests {
             Channel::<u32>::new(4, writer_pollee.clone(), reader_pollee).split();
         let flag = Arc::new(AtomicBool::new(false));
         let observer: Arc<FlagOnNotify> = Arc::new(FlagOnNotify(flag.clone()));
-        // The peer of `reader` is the writer's endpoint, whose pollee is `writer_pollee` —
+        // The peer of `reader` is the writer's endpoint, whose pollee is `writer_pollee`;
         // register the observer there to detect that `reader.shutdown()` reaches it.
         writer_pollee.register_observer(
             Arc::downgrade(&observer) as Weak<dyn Observer<Events>>,

--- a/litebox_shim_linux/src/channel.rs
+++ b/litebox_shim_linux/src/channel.rs
@@ -14,14 +14,13 @@ use ringbuf::traits::{Consumer as _, Observer as _, Producer as _};
 
 macro_rules! common_functions_for_channel {
     () => {
-        /// Has this been shut down?
         pub(crate) fn is_shutdown(&self) -> bool {
             self.endpoint.is_shutdown()
         }
 
-        /// Shut this channel down.
-        ///
-        /// On the first transition, wakes the peer's pollee so a
+        /// Shuts the endpoint down. Returns `true` only on the call that
+        /// effected the transition (idempotent thereafter — not a fallibility
+        /// signal). The first transition also wakes the peer's pollee so a
         /// peer blocked in send/recv unblocks immediately.
         pub(crate) fn shutdown(&self) -> bool {
             if self.endpoint.shutdown() {
@@ -34,7 +33,6 @@ macro_rules! common_functions_for_channel {
             }
         }
 
-        /// Has the peer (i.e., other end) been shut down?
         fn is_peer_shutdown(&self) -> bool {
             if let Some(peer) = self.peer.upgrade() {
                 peer.is_shutdown()
@@ -64,8 +62,10 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider, T> EndPointer<Platform,
         self.is_shutdown.load(Ordering::Acquire)
     }
 
-    /// Transition the endpoint to the shut-down state. Returns `true` on the first
-    /// transition so callers can gate one-shot side-effects (e.g. peer wake-ups).
+    /// Returns `true` on the call that effected the transition so callers can
+    /// gate one-shot side-effects (e.g. peer wake-ups); idempotent thereafter.
+    /// The boolean reports newness, not fallibility — the state is always shut
+    /// after this call.
     fn shutdown(&self) -> bool {
         !self.is_shutdown.swap(true, Ordering::Release)
     }

--- a/litebox_shim_linux/src/channel.rs
+++ b/litebox_shim_linux/src/channel.rs
@@ -63,10 +63,10 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider, T> EndPointer<Platform,
         self.is_shutdown.load(Ordering::Acquire)
     }
 
-    /// Returns `true` on the call that effected the transition so callers can
+    /// Returns `true` on the call that affected the transition so callers can
     /// gate one-shot side-effects (e.g. peer wake-ups); idempotent thereafter.
     /// The boolean reports newness, not fallibility — the state is always shut
-    /// after this call.
+    /// down after this call.
     fn shutdown(&self) -> bool {
         !self.is_shutdown.swap(true, Ordering::Release)
     }

--- a/litebox_shim_linux/src/channel.rs
+++ b/litebox_shim_linux/src/channel.rs
@@ -23,11 +23,14 @@ macro_rules! common_functions_for_channel {
         ///
         /// On the first transition, wakes the peer's pollee so a
         /// peer blocked in send/recv unblocks immediately.
-        pub(crate) fn shutdown(&self) {
+        pub(crate) fn shutdown(&self) -> bool {
             if self.endpoint.shutdown() {
                 if let Some(peer) = self.peer.upgrade() {
                     peer.pollee.notify_observers(litebox::event::Events::HUP);
                 }
+                true
+            } else {
+                false
             }
         }
 

--- a/litebox_shim_linux/src/channel.rs
+++ b/litebox_shim_linux/src/channel.rs
@@ -20,8 +20,17 @@ macro_rules! common_functions_for_channel {
         }
 
         /// Shut this channel down.
+        ///
+        /// On the first transition only, wakes any observer on the peer's pollee so a
+        /// peer blocked in send/recv notices the new state immediately. `HUP` is in
+        /// `Events::ALWAYS_POLLED`, so the notification reaches every observer
+        /// regardless of the mask they registered with.
         pub(crate) fn shutdown(&self) {
-            self.endpoint.shutdown();
+            if self.endpoint.shutdown() {
+                if let Some(peer) = self.peer.upgrade() {
+                    peer.pollee.notify_observers(litebox::event::Events::HUP);
+                }
+            }
         }
 
         /// Has the peer (i.e., other end) been shut down?
@@ -54,8 +63,10 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider, T> EndPointer<Platform,
         self.is_shutdown.load(Ordering::Acquire)
     }
 
-    fn shutdown(&self) {
-        self.is_shutdown.store(true, Ordering::Release);
+    /// Transition the endpoint to the shut-down state. Returns `true` on the first
+    /// transition so callers can gate one-shot side-effects (e.g. peer wake-ups).
+    fn shutdown(&self) -> bool {
+        !self.is_shutdown.swap(true, Ordering::Release)
     }
 }
 
@@ -84,11 +95,9 @@ impl<T> ReadEnd<T> {
         &self,
         mut f: impl FnMut(&mut T) -> Result<(bool, R), Errno>,
     ) -> Result<R, Errno> {
-        if self.is_shutdown() {
-            return Err(Errno::ESHUTDOWN);
-        }
-
-        let is_peer_shutdown = self.is_peer_shutdown();
+        // Linux preserves bytes already queued when the read side is shut down
+        // (via shutdown(SHUT_RD) or peer close), so consult the buffer before
+        // returning ESHUTDOWN — the caller observes EOF only once the queue drains.
         let mut guard = self.endpoint.rb.lock();
         if let Some(item) = guard.first_mut() {
             let (should_consume, ret) = f(item)?;
@@ -102,7 +111,7 @@ impl<T> ReadEnd<T> {
         }
         drop(guard);
 
-        if is_peer_shutdown {
+        if self.is_shutdown() || self.is_peer_shutdown() {
             return Err(Errno::ESHUTDOWN);
         }
 
@@ -189,5 +198,107 @@ impl<T> Channel<T> {
     pub(crate) fn split(self) -> (WriteEnd<T>, ReadEnd<T>) {
         let Channel { writer, reader } = self;
         (writer, reader)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::sync::atomic::{AtomicBool, Ordering};
+    use litebox::event::observer::Observer;
+
+    fn split_pair<T>() -> (WriteEnd<T>, ReadEnd<T>) {
+        Channel::<T>::new(4, Arc::new(Pollee::new()), Arc::new(Pollee::new())).split()
+    }
+
+    /// Test observer that flips a flag the first time it is notified.
+    struct FlagOnNotify(Arc<AtomicBool>);
+    impl Observer<Events> for FlagOnNotify {
+        fn on_events(&self, _events: &Events) {
+            self.0.store(true, Ordering::Release);
+        }
+    }
+
+    #[test]
+    fn peek_and_consume_one_drains_queue_after_self_shutdown() {
+        let (writer, reader) = split_pair::<u32>();
+        writer.try_write_one(42).unwrap();
+        reader.shutdown();
+        // Queued bytes must remain readable after shutdown(SHUT_RD): we should
+        // get the 42 first, ESHUTDOWN only once the buffer is empty.
+        let got = reader
+            .peek_and_consume_one(|x| Ok((true, *x)))
+            .expect("queued item must be returned even after self shutdown");
+        assert_eq!(got, 42);
+        let err = reader
+            .peek_and_consume_one(|x: &mut u32| Ok((true, *x)))
+            .unwrap_err();
+        assert_eq!(err, Errno::ESHUTDOWN);
+    }
+
+    #[test]
+    fn peek_and_consume_one_drains_queue_after_peer_shutdown() {
+        let (writer, reader) = split_pair::<u32>();
+        writer.try_write_one(7).unwrap();
+        writer.shutdown();
+        let got = reader
+            .peek_and_consume_one(|x| Ok((true, *x)))
+            .expect("queued item must be returned even after peer shutdown");
+        assert_eq!(got, 7);
+        let err = reader
+            .peek_and_consume_one(|x: &mut u32| Ok((true, *x)))
+            .unwrap_err();
+        assert_eq!(err, Errno::ESHUTDOWN);
+    }
+
+    #[test]
+    fn peek_and_consume_one_returns_eagain_when_empty_and_alive() {
+        let (_writer, reader) = split_pair::<u32>();
+        let err = reader
+            .peek_and_consume_one(|x: &mut u32| Ok((true, *x)))
+            .unwrap_err();
+        assert_eq!(err, Errno::EAGAIN);
+    }
+
+    #[test]
+    fn try_write_one_returns_epipe_after_self_shutdown() {
+        let (writer, _reader) = split_pair::<u32>();
+        writer.shutdown();
+        let (_val, err) = writer.try_write_one(1).unwrap_err();
+        assert_eq!(err, Errno::EPIPE);
+    }
+
+    #[test]
+    fn try_write_one_returns_epipe_after_peer_shutdown() {
+        let (writer, reader) = split_pair::<u32>();
+        reader.shutdown();
+        let (_val, err) = writer.try_write_one(1).unwrap_err();
+        assert_eq!(err, Errno::EPIPE);
+    }
+
+    /// Regression: `shutdown()` must wake observers on the peer's pollee so a peer blocked
+    /// in send/recv notices the new state without waiting for an unrelated event. HUP is in
+    /// `Events::ALWAYS_POLLED`, so any observer (even one registered with a different mask)
+    /// must be notified.
+    #[test]
+    fn shutdown_notifies_peer_pollee_hup() {
+        let writer_pollee = Arc::new(Pollee::new());
+        let reader_pollee = Arc::new(Pollee::new());
+        let (_writer, reader) =
+            Channel::<u32>::new(4, writer_pollee.clone(), reader_pollee).split();
+        let flag = Arc::new(AtomicBool::new(false));
+        let observer: Arc<FlagOnNotify> = Arc::new(FlagOnNotify(flag.clone()));
+        // The peer of `reader` is the writer's endpoint, whose pollee is `writer_pollee` —
+        // register the observer there to detect that `reader.shutdown()` reaches it.
+        writer_pollee.register_observer(
+            Arc::downgrade(&observer) as Weak<dyn Observer<Events>>,
+            Events::OUT,
+        );
+        assert!(!flag.load(Ordering::Acquire), "observer must start cleared");
+        reader.shutdown();
+        assert!(
+            flag.load(Ordering::Acquire),
+            "shutdown(ReadEnd) must wake peer pollee observers"
+        );
     }
 }

--- a/litebox_shim_linux/src/channel.rs
+++ b/litebox_shim_linux/src/channel.rs
@@ -21,10 +21,8 @@ macro_rules! common_functions_for_channel {
 
         /// Shut this channel down.
         ///
-        /// On the first transition only, wakes any observer on the peer's pollee so a
-        /// peer blocked in send/recv notices the new state immediately. `HUP` is in
-        /// `Events::ALWAYS_POLLED`, so the notification reaches every observer
-        /// regardless of the mask they registered with.
+        /// On the first transition, wakes the peer's pollee so a
+        /// peer blocked in send/recv unblocks immediately.
         pub(crate) fn shutdown(&self) {
             if self.endpoint.shutdown() {
                 if let Some(peer) = self.peer.upgrade() {

--- a/litebox_shim_linux/src/lib.rs
+++ b/litebox_shim_linux/src/lib.rs
@@ -661,6 +661,7 @@ impl<FS: ShimFS> Task<FS> {
                 newfd,
                 flags,
             } => syscall!(sys_dup(oldfd, newfd, flags)),
+            SyscallRequest::Shutdown { sockfd, how } => syscall!(sys_shutdown(sockfd, how)),
             SyscallRequest::Socket {
                 domain,
                 type_and_flags,

--- a/litebox_shim_linux/src/lib.rs
+++ b/litebox_shim_linux/src/lib.rs
@@ -661,7 +661,6 @@ impl<FS: ShimFS> Task<FS> {
                 newfd,
                 flags,
             } => syscall!(sys_dup(oldfd, newfd, flags)),
-            SyscallRequest::Shutdown { sockfd, how } => syscall!(sys_shutdown(sockfd, how)),
             SyscallRequest::Socket {
                 domain,
                 type_and_flags,
@@ -702,6 +701,7 @@ impl<FS: ShimFS> Task<FS> {
                 addrlen,
             } => self.sys_recvfrom(sockfd, buf, len, flags, addr, addrlen),
             SyscallRequest::Recvmsg { sockfd, msg, flags } => self.sys_recvmsg(sockfd, msg, flags),
+            SyscallRequest::Shutdown { sockfd, how } => syscall!(sys_shutdown(sockfd, how)),
             SyscallRequest::Bind {
                 sockfd,
                 sockaddr,

--- a/litebox_shim_linux/src/syscalls/net.rs
+++ b/litebox_shim_linux/src/syscalls/net.rs
@@ -1804,20 +1804,22 @@ impl<FS: ShimFS> Task<FS> {
         let Ok(sockfd) = u32::try_from(sockfd) else {
             return Err(Errno::EBADF);
         };
-        let how = ShutdownHow::try_from(how).map_err(|_| Errno::EINVAL)?;
         self.do_shutdown(sockfd, how)
     }
-    fn do_shutdown(&self, sockfd: u32, how: ShutdownHow) -> Result<(), Errno> {
+    fn do_shutdown(&self, sockfd: u32, how: i32) -> Result<(), Errno> {
+        // Linux validates the fd (EBADF, ENOTSOCK) before `how` (EINVAL),
+        // so resolve the socket through `with_socket` first and validate `how`
+        // only inside the matching branch.
         self.files.borrow().with_socket(
             &self.global,
             sockfd,
             |_fd| {
-                // Half-close on inet sockets needs a hook through the smoltcp-backed
-                // Network that does not exist yet.
+                ShutdownHow::try_from(how).map_err(|_| Errno::EINVAL)?;
                 log_unsupported!("shutdown on inet socket");
                 Err(Errno::EOPNOTSUPP)
             },
             |file| {
+                let how = ShutdownHow::try_from(how).map_err(|_| Errno::EINVAL)?;
                 file.shutdown(how);
                 Ok(())
             },

--- a/litebox_shim_linux/src/syscalls/net.rs
+++ b/litebox_shim_linux/src/syscalls/net.rs
@@ -1762,7 +1762,7 @@ impl<FS: ShimFS> Task<FS> {
                     .map(SocketAddress::Inet)
                     .map_err(Errno::from)
             },
-            |file| Ok(SocketAddress::Unix(file.get_local_addr())),
+            |unix| Ok(SocketAddress::Unix(unix.get_local_addr())),
         )
     }
 

--- a/litebox_shim_linux/src/syscalls/net.rs
+++ b/litebox_shim_linux/src/syscalls/net.rs
@@ -1797,6 +1797,26 @@ impl<FS: ShimFS> Task<FS> {
             },
         )
     }
+
+    pub(crate) fn sys_shutdown(&self, sockfd: i32, how: i32) -> Result<(), Errno> {
+        let Ok(sockfd) = u32::try_from(sockfd) else {
+            return Err(Errno::EBADF);
+        };
+        let how = litebox_common_linux::ShutdownHow::try_from(how).map_err(|_| Errno::EINVAL)?;
+        self.do_shutdown(sockfd, how)
+    }
+    fn do_shutdown(
+        &self,
+        sockfd: u32,
+        how: litebox_common_linux::ShutdownHow,
+    ) -> Result<(), Errno> {
+        self.files.borrow().with_socket(
+            &self.global,
+            sockfd,
+            |fd| todo!(),
+            |file| file.shutdown(how),
+        )
+    }
 }
 
 #[cfg(target_os = "linux")]

--- a/litebox_shim_linux/src/syscalls/net.rs
+++ b/litebox_shim_linux/src/syscalls/net.rs
@@ -3097,7 +3097,8 @@ mod unix_tests {
             .do_recvfrom(sock1, &mut buf, ReceiveFlags::empty(), None)
             .unwrap_err();
         let elapsed = start.elapsed();
-        assert_eq!(err, Errno::ETIMEDOUT);
+        // Linux returns EAGAIN (not ETIMEDOUT) when SO_RCVTIMEO expires on a blocking recv.
+        assert_eq!(err, Errno::EAGAIN);
         // Allow a small tolerance (5ms) for timing imprecision
         let tolerance = Duration::from_millis(5);
         assert!(

--- a/litebox_shim_linux/src/syscalls/net.rs
+++ b/litebox_shim_linux/src/syscalls/net.rs
@@ -27,8 +27,9 @@ use litebox::{
     utils::TruncateExt as _,
 };
 use litebox_common_linux::{
-    AddressFamily, FileDescriptorFlags, IPProtocol, ReceiveFlags, SendFlags, SockFlags, SockType,
-    SocketOption, SocketOptionName, TcpOption, UnixProtocol, errno::Errno, signal::Signal,
+    AddressFamily, FileDescriptorFlags, IPProtocol, ReceiveFlags, SendFlags, ShutdownHow,
+    SockFlags, SockType, SocketOption, SocketOptionName, TcpOption, UnixProtocol, errno::Errno,
+    signal::Signal,
 };
 use zerocopy::{FromBytes, Immutable, IntoBytes};
 
@@ -1798,23 +1799,28 @@ impl<FS: ShimFS> Task<FS> {
         )
     }
 
+    /// Handle syscall `shutdown`
     pub(crate) fn sys_shutdown(&self, sockfd: i32, how: i32) -> Result<(), Errno> {
         let Ok(sockfd) = u32::try_from(sockfd) else {
             return Err(Errno::EBADF);
         };
-        let how = litebox_common_linux::ShutdownHow::try_from(how).map_err(|_| Errno::EINVAL)?;
+        let how = ShutdownHow::try_from(how).map_err(|_| Errno::EINVAL)?;
         self.do_shutdown(sockfd, how)
     }
-    fn do_shutdown(
-        &self,
-        sockfd: u32,
-        how: litebox_common_linux::ShutdownHow,
-    ) -> Result<(), Errno> {
+    fn do_shutdown(&self, sockfd: u32, how: ShutdownHow) -> Result<(), Errno> {
         self.files.borrow().with_socket(
             &self.global,
             sockfd,
-            |fd| todo!(),
-            |file| file.shutdown(how),
+            |_fd| {
+                // Half-close on inet sockets needs a hook through the smoltcp-backed
+                // Network that does not exist yet.
+                log_unsupported!("shutdown on inet socket");
+                Err(Errno::EOPNOTSUPP)
+            },
+            |file| {
+                file.shutdown(how);
+                Ok(())
+            },
         )
     }
 }

--- a/litebox_shim_linux/src/syscalls/unix.rs
+++ b/litebox_shim_linux/src/syscalls/unix.rs
@@ -209,10 +209,10 @@ impl<FS: ShimFS> UnixInitStream<FS> {
     }
 
     fn shutdown(&self, how: ShutdownHow) {
-        if how.shuts_down_read() && !self.read_shutdown.swap(true, Ordering::Release) {
+        if how.is_shutdown_read() && !self.read_shutdown.swap(true, Ordering::Release) {
             self.pollee.notify_observers(Events::IN);
         }
-        if how.shuts_down_write() {
+        if how.is_shutdown_write() {
             self.write_shutdown.store(true, Ordering::Release);
         }
     }
@@ -577,10 +577,10 @@ impl<FS: ShimFS> UnixConnectedStream<FS> {
 
     fn shutdown(&self, how: ShutdownHow) {
         let mut events = Events::empty();
-        if how.shuts_down_read() && self.recv_channel.shutdown() {
+        if how.is_shutdown_read() && self.recv_channel.shutdown() {
             events |= Events::IN | Events::RDHUP;
         }
-        if how.shuts_down_write() && self.connected_send_channel.shutdown() {
+        if how.is_shutdown_write() && self.connected_send_channel.shutdown() {
             events |= Events::OUT | Events::HUP;
         }
         self.pollee.notify_observers(events);
@@ -901,7 +901,7 @@ impl<FS: ShimFS> UnixStream<FS> {
         self.with_state_ref(|state| match state {
             UnixStreamState::Init(init) => init.shutdown(how),
             UnixStreamState::Listen(listen) => {
-                if how.shuts_down_read() {
+                if how.is_shutdown_read() {
                     listen.backlog.shutdown();
                 }
             }
@@ -1050,14 +1050,14 @@ impl<FS: ShimFS> UnixDatagramInner<FS> {
 
     fn shutdown(&mut self, how: ShutdownHow) {
         let mut events = Events::empty();
-        if how.shuts_down_read() {
+        if how.is_shutdown_read() {
             self.read_shutdown = true;
             if let Some(recv_channel) = &self.recv_channel {
                 recv_channel.shutdown();
             }
             events |= Events::IN | Events::RDHUP;
         }
-        if how.shuts_down_write() {
+        if how.is_shutdown_write() {
             self.write_shutdown = true;
             if let Some((connected_send_channel, _)) = &self.connected_send_channel {
                 connected_send_channel.shutdown();
@@ -1253,36 +1253,27 @@ impl<FS: ShimFS> UnixDatagram<FS> {
     fn check_io_events(&self) -> Events {
         let mut events = Events::empty();
         let inner = self.inner.read();
-        let recv_shutdown = inner.read_shutdown
-            || inner
-                .recv_channel
-                .as_ref()
-                .is_some_and(ReadEnd::is_shutdown);
-        let send_shutdown = inner.write_shutdown
-            || inner
-                .connected_send_channel
-                .as_ref()
-                .is_some_and(|(c, _)| c.is_shutdown());
-        if let Some(recv_channel) = &inner.recv_channel {
-            if recv_shutdown {
-                events |= Events::IN | Events::RDHUP;
-            } else if !recv_channel.is_empty() {
-                events |= Events::IN;
-            }
-        } else if recv_shutdown {
+        let recv_shutdown = inner.read_shutdown;
+        let send_shutdown = inner.write_shutdown;
+
+        if recv_shutdown {
             events |= Events::IN | Events::RDHUP;
+        } else if let Some(recv_channel) = &inner.recv_channel
+            && !recv_channel.is_empty()
+        {
+            events |= Events::IN;
         }
+
         if let Some((connected_send_channel, _)) = &inner.connected_send_channel {
             if !connected_send_channel.is_full() {
                 events |= Events::OUT;
             }
-        } else if !inner.write_shutdown {
+        } else if !send_shutdown {
             // If not connected, allow to sendto any address?
             events |= Events::OUT;
         }
         // Linux reports POLLHUP on a dgram fd only when *both* local directions are
         // shut down (peer-side shutdown is invisible since dgrams are connectionless).
-        // Matches `UnixConnectedStream::check_io_events`.
         if recv_shutdown && send_shutdown {
             events |= Events::HUP;
         }

--- a/litebox_shim_linux/src/syscalls/unix.rs
+++ b/litebox_shim_linux/src/syscalls/unix.rs
@@ -1036,6 +1036,23 @@ impl<FS: ShimFS> UnixDatagramInner<FS> {
         self.recv_channel = Some(recv_channel);
         Ok(())
     }
+
+    fn shutdown(&self, how: ShutdownHow) {
+        let mut events = Events::empty();
+        if how.affects_read()
+            && let Some(recv_channel) = &self.recv_channel
+            && recv_channel.shutdown()
+        {
+            events |= Events::IN | Events::RDHUP;
+        }
+        if how.affects_write()
+            && let Some((connected_send_channel, _)) = &self.connected_send_channel
+            && connected_send_channel.shutdown()
+        {
+            events |= Events::OUT | Events::HUP;
+        }
+        self.pollee.notify_observers(events);
+    }
 }
 
 impl<FS: ShimFS> UnixDatagram<FS> {
@@ -1220,21 +1237,7 @@ impl<FS: ShimFS> UnixDatagram<FS> {
     }
 
     fn shutdown(&self, how: ShutdownHow) {
-        let inner = self.inner.read();
-        let mut events = Events::empty();
-        if how.affects_read()
-            && let Some(recv_channel) = &inner.recv_channel
-        {
-            recv_channel.shutdown();
-            events |= Events::IN | Events::RDHUP;
-        }
-        if how.affects_write()
-            && let Some((connected_send_channel, _)) = &inner.connected_send_channel
-        {
-            connected_send_channel.shutdown();
-            events |= Events::OUT | Events::HUP;
-        }
-        inner.pollee.notify_observers(events);
+        self.inner.read().shutdown(how);
     }
 }
 

--- a/litebox_shim_linux/src/syscalls/unix.rs
+++ b/litebox_shim_linux/src/syscalls/unix.rs
@@ -40,6 +40,7 @@ pub(crate) struct UnixSocketSubsystem<FS: ShimFS>(core::marker::PhantomData<FS>)
 impl<FS: ShimFS> FdEnabledSubsystem for UnixSocketSubsystem<FS> {
     type Entry = UnixSocket<FS>;
 }
+
 impl<FS: ShimFS> FdEnabledSubsystemEntry for UnixSocket<FS> {}
 
 /// C-compatible structure for Unix socket addresses.
@@ -193,10 +194,8 @@ struct UnixInitStream<FS: ShimFS> {
     /// Optional bound address for this socket
     addr: Option<UnixBoundSocketAddr<FS>>,
     pollee: Pollee<crate::Platform>,
-    /// Whether the read side of this socket is pending shutdown
-    pending_read_shutdown: AtomicBool,
-    /// Whether the write side of this socket is pending shutdown
-    pending_write_shutdown: AtomicBool,
+    read_shutdown: AtomicBool,
+    write_shutdown: AtomicBool,
 }
 
 impl<FS: ShimFS> UnixInitStream<FS> {
@@ -204,17 +203,17 @@ impl<FS: ShimFS> UnixInitStream<FS> {
         Self {
             addr: None,
             pollee: Pollee::new(),
-            pending_read_shutdown: AtomicBool::new(false),
-            pending_write_shutdown: AtomicBool::new(false),
+            read_shutdown: AtomicBool::new(false),
+            write_shutdown: AtomicBool::new(false),
         }
     }
 
     fn shutdown(&self, how: ShutdownHow) {
-        if how.affects_read() && !self.pending_read_shutdown.swap(true, Ordering::Release) {
+        if how.shuts_down_read() && !self.read_shutdown.swap(true, Ordering::Release) {
             self.pollee.notify_observers(Events::IN);
         }
-        if how.affects_write() {
-            self.pending_write_shutdown.store(true, Ordering::Release);
+        if how.shuts_down_write() {
+            self.write_shutdown.store(true, Ordering::Release);
         }
     }
 
@@ -263,15 +262,15 @@ impl<FS: ShimFS> UnixInitStream<FS> {
         let UnixInitStream {
             addr,
             pollee,
-            pending_read_shutdown,
-            pending_write_shutdown,
+            read_shutdown,
+            write_shutdown,
         } = self;
         UnixConnectedStream::new_pair(
             addr.map(Arc::new),
             Some(Arc::new(pollee)),
             Some(peer_addr),
-            pending_read_shutdown.load(Ordering::Acquire),
-            pending_write_shutdown.load(Ordering::Acquire),
+            read_shutdown.load(Ordering::Acquire),
+            write_shutdown.load(Ordering::Acquire),
         )
     }
 }
@@ -466,7 +465,9 @@ const UNIX_BUF_SIZE: usize = 65536;
 impl<FS: ShimFS> UnixConnectedStream<FS> {
     /// Creates a pair of connected Unix stream sockets.
     ///
-    /// `read_shutdown` and `write_shutdown` half-close the corresponding sides of the stream.
+    /// `read_shutdown` and `write_shutdown` half-close the corresponding sides of the
+    /// *first* returned socket only (used to carry pre-connect shutdown flags from
+    /// `UnixInitStream` across `connect(2)` into the connected state).
     fn new_pair(
         addr: Option<Arc<UnixBoundSocketAddr<FS>>>,
         pollee: Option<Arc<Pollee<crate::Platform>>>,
@@ -572,12 +573,10 @@ impl<FS: ShimFS> UnixConnectedStream<FS> {
 
     fn shutdown(&self, how: ShutdownHow) {
         let mut events = Events::empty();
-        if how.affects_read() {
-            self.recv_channel.shutdown();
+        if how.shuts_down_read() && self.recv_channel.shutdown() {
             events |= Events::IN | Events::RDHUP;
         }
-        if how.affects_write() {
-            self.connected_send_channel.shutdown();
+        if how.shuts_down_write() && self.connected_send_channel.shutdown() {
             events |= Events::OUT | Events::HUP;
         }
         self.pollee.notify_observers(events);
@@ -839,8 +838,8 @@ impl<FS: ShimFS> UnixStream<FS> {
                 },
             )
             .map_err(Errno::from);
-        // SO_RCVTIMEO expiry: Linux returns EAGAIN, not ETIMEDOUT.
         match res {
+            // Linux SO_RCVTIMEO expiry surfaces as `EAGAIN`, not `ETIMEDOUT`
             Err(Errno::ETIMEDOUT) => Err(Errno::EAGAIN),
             other => other,
         }
@@ -884,7 +883,7 @@ impl<FS: ShimFS> UnixStream<FS> {
                 // (a recv would return EOF immediately). SHUT_WR has no observable
                 // effect on Init's poll output.
                 let mut events = Events::OUT | Events::HUP;
-                if init.pending_read_shutdown.load(Ordering::Acquire) {
+                if init.read_shutdown.load(Ordering::Acquire) {
                     events |= Events::IN;
                 }
                 events
@@ -1039,13 +1038,13 @@ impl<FS: ShimFS> UnixDatagramInner<FS> {
 
     fn shutdown(&self, how: ShutdownHow) {
         let mut events = Events::empty();
-        if how.affects_read()
+        if how.shuts_down_read()
             && let Some(recv_channel) = &self.recv_channel
             && recv_channel.shutdown()
         {
             events |= Events::IN | Events::RDHUP;
         }
-        if how.affects_write()
+        if how.shuts_down_write()
             && let Some((connected_send_channel, _)) = &self.connected_send_channel
             && connected_send_channel.shutdown()
         {
@@ -1155,12 +1154,12 @@ impl<FS: ShimFS> UnixDatagram<FS> {
                 },
             )
             .map_err(Errno::from);
-        // - Non-blocking + self-shutdown(SHUT_RD) with empty queue: Linux returns EAGAIN
-        //   instead of EOF (datagram boundaries — no message synthesized for the absent peer).
-        // - SO_RCVTIMEO expiry on a blocking recv: Linux returns EAGAIN, not ETIMEDOUT
-        //   (the latter is reserved for connect-style timeouts).
+        // Non-blocking + self-shutdown(SHUT_RD) on an empty queue: Linux returns
+        // EAGAIN instead of EOF — datagram boundaries mean no zero-length message
+        // can be synthesized for the absent peer.
         match res {
             Err(Errno::ESHUTDOWN) if is_nonblocking => Err(Errno::EAGAIN),
+            // Linux SO_RCVTIMEO expiry surfaces as `EAGAIN`, not `ETIMEDOUT`
             Err(Errno::ETIMEDOUT) => Err(Errno::EAGAIN),
             other => other,
         }
@@ -1218,20 +1217,34 @@ impl<FS: ShimFS> UnixDatagram<FS> {
 
     fn check_io_events(&self) -> Events {
         let mut events = Events::empty();
-        if let Some(recv_channel) = &self.inner.read().recv_channel {
-            if recv_channel.is_shutdown() {
+        let inner = self.inner.read();
+        let recv_shutdown = inner
+            .recv_channel
+            .as_ref()
+            .is_some_and(ReadEnd::is_shutdown);
+        let send_shutdown = inner
+            .connected_send_channel
+            .as_ref()
+            .is_some_and(|(c, _)| c.is_shutdown());
+        if let Some(recv_channel) = &inner.recv_channel {
+            if recv_shutdown {
                 events |= Events::IN | Events::RDHUP;
             } else if !recv_channel.is_empty() {
                 events |= Events::IN;
             }
         }
-        if let Some((connected_send_channel, _)) = &self.inner.read().connected_send_channel {
+        if let Some((connected_send_channel, _)) = &inner.connected_send_channel {
             if !connected_send_channel.is_full() {
                 events |= Events::OUT;
             }
         } else {
-            // If not connected, allow to sendto any address?
             events |= Events::OUT;
+        }
+        // Linux reports POLLHUP on a dgram fd only when *both* local directions are
+        // shut down (peer-side shutdown is invisible since dgrams are connectionless).
+        // Matches `UnixConnectedStream::check_io_events`.
+        if recv_shutdown && send_shutdown {
+            events |= Events::HUP;
         }
         events
     }

--- a/litebox_shim_linux/src/syscalls/unix.rs
+++ b/litebox_shim_linux/src/syscalls/unix.rs
@@ -4,7 +4,7 @@
 //! Unix domain socket implementation for the Linux shim layer.
 
 use core::{
-    sync::atomic::{AtomicBool, AtomicU16, AtomicU32, Ordering},
+    sync::atomic::{AtomicBool, AtomicU32, Ordering},
     time::Duration,
 };
 
@@ -281,26 +281,33 @@ impl<FS: ShimFS> UnixInitStream<FS> {
 struct Backlog<FS: ShimFS> {
     /// The address this socket is listening on
     addr: Arc<UnixBoundSocketAddr<FS>>,
-    /// Maximum number of pending connections
-    limit: AtomicU16,
-    /// Queue of pending connections (None when shut down)
-    sockets: Mutex<crate::Platform, Option<VecDeque<UnixConnectedStream<FS>>>>,
+    state: Mutex<crate::Platform, BacklogState<FS>>,
     pollee: Pollee<crate::Platform>,
+}
+
+struct BacklogState<FS: ShimFS> {
+    sockets: VecDeque<UnixConnectedStream<FS>>,
+    /// Maximum number of pending connections
+    limit: u16,
+    is_shutdown: bool,
 }
 
 impl<FS: ShimFS> Backlog<FS> {
     fn new(addr: UnixBoundSocketAddr<FS>, backlog: u16, pollee: Pollee<crate::Platform>) -> Self {
         Self {
             addr: Arc::new(addr),
-            limit: AtomicU16::new(backlog),
-            sockets: litebox::sync::Mutex::new(Some(VecDeque::new())),
+            state: litebox::sync::Mutex::new(BacklogState {
+                sockets: VecDeque::new(),
+                limit: backlog,
+                is_shutdown: false,
+            }),
             pollee,
         }
     }
 
     /// Updates the maximum backlog size.
     fn set_backlog(&self, backlog: u16) {
-        self.limit.store(backlog, Ordering::Relaxed);
+        self.state.lock().limit = backlog;
     }
 
     /// Attempts to establish a connection without blocking.
@@ -308,19 +315,17 @@ impl<FS: ShimFS> Backlog<FS> {
         &self,
         init: UnixInitStream<FS>,
     ) -> Result<UnixConnectedStream<FS>, (UnixInitStream<FS>, Errno)> {
-        let mut sockets = self.sockets.lock();
-        let Some(sockets) = &mut *sockets else {
-            // the server socket is shutdown
+        let mut state = self.state.lock();
+        if state.is_shutdown {
             return Err((init, Errno::ECONNREFUSED));
-        };
+        }
 
-        let limit = self.limit.load(Ordering::Relaxed);
-        if sockets.len() >= limit as usize {
+        if state.sockets.len() >= state.limit as usize {
             return Err((init, Errno::EAGAIN));
         }
 
         let (client, server) = init.into_connected(self.addr.clone());
-        sockets.push_back(server);
+        state.sockets.push_back(server);
 
         self.pollee.notify_observers(Events::IN);
         Ok(client)
@@ -328,30 +333,28 @@ impl<FS: ShimFS> Backlog<FS> {
 
     /// Attempts to accept a pending connection without blocking.
     fn try_accept(&self) -> Result<UnixConnectedStream<FS>, TryOpError<Errno>> {
-        let mut sockets = self.sockets.lock();
-        let Some(sockets) = &mut *sockets else {
-            return Err(TryOpError::Other(Errno::ESHUTDOWN));
-        };
-
-        match sockets.pop_front() {
+        let mut state = self.state.lock();
+        match state.sockets.pop_front() {
             Some(stream) => {
-                self.pollee.notify_observers(Events::OUT);
+                if !state.is_shutdown {
+                    self.pollee.notify_observers(Events::OUT);
+                }
                 Ok(stream)
             }
+            None if state.is_shutdown => Err(TryOpError::Other(Errno::ESHUTDOWN)),
             None => Err(TryOpError::TryAgain),
         }
     }
 
     fn check_io_events(&self) -> Events {
-        let sockets = self.sockets.lock();
-        let Some(sockets) = &*sockets else {
-            return Events::IN | Events::HUP;
-        };
+        let state = self.state.lock();
         let mut events = Events::empty();
-        if !sockets.is_empty() {
+        if !state.sockets.is_empty() {
             events |= Events::IN;
         }
-        if sockets.len() < self.limit.load(Ordering::Relaxed) as usize {
+        if state.is_shutdown {
+            events |= Events::IN | Events::HUP;
+        } else if state.sockets.len() < state.limit as usize {
             events |= Events::OUT;
         }
         events
@@ -359,9 +362,9 @@ impl<FS: ShimFS> Backlog<FS> {
 
     /// Shuts down this backlog, preventing new connections.
     fn shutdown(&self) {
-        let mut sockets = self.sockets.lock();
-        if sockets.is_some() {
-            *sockets = None;
+        let mut state = self.state.lock();
+        if !state.is_shutdown {
+            state.is_shutdown = true;
             self.pollee.notify_observers(Events::HUP);
         }
     }
@@ -555,8 +558,9 @@ impl<FS: ShimFS> UnixConnectedStream<FS> {
     fn check_io_events(&self) -> Events {
         let mut events = Events::empty();
         let is_read_shutdown = self.recv_channel.is_shutdown();
+        let is_peer_write_shutdown = self.recv_channel.is_peer_shutdown();
         let is_write_shutdown = self.connected_send_channel.is_shutdown();
-        if is_read_shutdown {
+        if is_read_shutdown || is_peer_write_shutdown {
             events |= Events::RDHUP | Events::IN;
             if is_write_shutdown {
                 events |= Events::HUP;
@@ -896,7 +900,11 @@ impl<FS: ShimFS> UnixStream<FS> {
     fn shutdown(&self, how: ShutdownHow) {
         self.with_state_ref(|state| match state {
             UnixStreamState::Init(init) => init.shutdown(how),
-            UnixStreamState::Listen(listen) => listen.backlog.shutdown(),
+            UnixStreamState::Listen(listen) => {
+                if how.shuts_down_read() {
+                    listen.backlog.shutdown();
+                }
+            }
             UnixStreamState::Connected(conn) => conn.shutdown(how),
         });
     }
@@ -986,6 +994,8 @@ struct UnixDatagramInner<FS: ShimFS> {
     /// The write end of the connected peer socket for sending messages.
     /// Set when the socket is connected via `connect` or `new_pair`.
     connected_send_channel: Option<(WriteEnd<DatagramMessage>, UnixSocketAddr)>,
+    read_shutdown: bool,
+    write_shutdown: bool,
     pollee: Arc<Pollee<crate::Platform>>,
 }
 /// Represents a Unix datagram socket.
@@ -1013,11 +1023,10 @@ impl<FS: ShimFS> UnixDatagramInner<FS> {
     /// Binds this socket to the given address.
     fn bind(&mut self, task: &Task<FS>, addr: UnixSocketAddr) -> Result<(), Errno> {
         if self.addr.is_some() {
-            return if addr.is_unnamed() {
-                Ok(())
-            } else {
-                Err(Errno::EINVAL)
-            };
+            if addr.is_unnamed() {
+                return Ok(());
+            }
+            return Err(Errno::EINVAL);
         }
 
         let bound_addr = addr.bind(task, true)?;
@@ -1032,22 +1041,27 @@ impl<FS: ShimFS> UnixDatagramInner<FS> {
             .write()
             .insert(key, UnixEntry(UnixEntryInner::Datagram(send_channel)));
         self.addr = Some((bound_addr, task.global.clone()));
+        if self.read_shutdown {
+            recv_channel.shutdown();
+        }
         self.recv_channel = Some(recv_channel);
         Ok(())
     }
 
-    fn shutdown(&self, how: ShutdownHow) {
+    fn shutdown(&mut self, how: ShutdownHow) {
         let mut events = Events::empty();
-        if how.shuts_down_read()
-            && let Some(recv_channel) = &self.recv_channel
-            && recv_channel.shutdown()
-        {
+        if how.shuts_down_read() {
+            self.read_shutdown = true;
+            if let Some(recv_channel) = &self.recv_channel {
+                recv_channel.shutdown();
+            }
             events |= Events::IN | Events::RDHUP;
         }
-        if how.shuts_down_write()
-            && let Some((connected_send_channel, _)) = &self.connected_send_channel
-            && connected_send_channel.shutdown()
-        {
+        if how.shuts_down_write() {
+            self.write_shutdown = true;
+            if let Some((connected_send_channel, _)) = &self.connected_send_channel {
+                connected_send_channel.shutdown();
+            }
             events |= Events::OUT | Events::HUP;
         }
         self.pollee.notify_observers(events);
@@ -1061,6 +1075,8 @@ impl<FS: ShimFS> UnixDatagram<FS> {
                 addr: None,
                 recv_channel: None,
                 connected_send_channel: None,
+                read_shutdown: false,
+                write_shutdown: false,
                 pollee: Arc::new(Pollee::new()),
             }),
         }
@@ -1080,6 +1096,8 @@ impl<FS: ShimFS> UnixDatagram<FS> {
                     addr: None,
                     recv_channel: Some(recv_channel),
                     connected_send_channel: Some((send_channel_peer, UnixSocketAddr::Unnamed)),
+                    read_shutdown: false,
+                    write_shutdown: false,
                     pollee: pollee1,
                 }),
             },
@@ -1088,6 +1106,8 @@ impl<FS: ShimFS> UnixDatagram<FS> {
                     addr: None,
                     recv_channel: Some(recv_channel_peer),
                     connected_send_channel: Some((send_channel, UnixSocketAddr::Unnamed)),
+                    read_shutdown: false,
+                    write_shutdown: false,
                     pollee: pollee2,
                 }),
             },
@@ -1124,7 +1144,12 @@ impl<FS: ShimFS> UnixDatagram<FS> {
     ///
     /// Subsequent sends without an address will use this peer.
     fn connect(&self, task: &Task<FS>, addr: UnixSocketAddr) -> Result<(), Errno> {
-        self.inner.write().connected_send_channel = Some((self.lookup(task, addr.clone())?, addr));
+        let send_channel = self.lookup(task, addr.clone())?;
+        let mut inner = self.inner.write();
+        if inner.write_shutdown {
+            send_channel.shutdown();
+        }
+        inner.connected_send_channel = Some((send_channel, addr));
         Ok(())
     }
 
@@ -1154,12 +1179,12 @@ impl<FS: ShimFS> UnixDatagram<FS> {
                 },
             )
             .map_err(Errno::from);
-        // Non-blocking + self-shutdown(SHUT_RD) on an empty queue: Linux returns
-        // EAGAIN instead of EOF — datagram boundaries mean no zero-length message
-        // can be synthesized for the absent peer.
+        // - Non-blocking + self-shutdown(SHUT_RD) with empty queue: Linux returns EAGAIN
+        //   instead of EOF (datagram boundaries; no message synthesized for the absent peer).
+        // - SO_RCVTIMEO expiry on a blocking recv: Linux returns EAGAIN, not ETIMEDOUT
+        //   (the latter is reserved for connect-style timeouts).
         match res {
             Err(Errno::ESHUTDOWN) if is_nonblocking => Err(Errno::EAGAIN),
-            // Linux SO_RCVTIMEO expiry surfaces as `EAGAIN`, not `ETIMEDOUT`
             Err(Errno::ETIMEDOUT) => Err(Errno::EAGAIN),
             other => other,
         }
@@ -1178,11 +1203,21 @@ impl<FS: ShimFS> UnixDatagram<FS> {
         addr: Option<UnixSocketAddr>,
     ) -> Result<usize, Errno> {
         let source = self.get_local_addr();
+        let connected_send_channel = {
+            let inner = self.inner.read();
+            if inner.write_shutdown {
+                return Err(Errno::EPIPE);
+            }
+            inner
+                .connected_send_channel
+                .as_ref()
+                .map(|(send_channel, _)| send_channel.clone())
+        };
+
         let send_channel = if let Some(addr) = addr {
             self.lookup(task, addr)?
-        } else if let Some((connected_send_channel, _)) = &self.inner.read().connected_send_channel
-        {
-            connected_send_channel.clone()
+        } else if let Some(connected_send_channel) = connected_send_channel {
+            connected_send_channel
         } else {
             return Err(Errno::ENOTCONN);
         };
@@ -1218,26 +1253,31 @@ impl<FS: ShimFS> UnixDatagram<FS> {
     fn check_io_events(&self) -> Events {
         let mut events = Events::empty();
         let inner = self.inner.read();
-        let recv_shutdown = inner
-            .recv_channel
-            .as_ref()
-            .is_some_and(ReadEnd::is_shutdown);
-        let send_shutdown = inner
-            .connected_send_channel
-            .as_ref()
-            .is_some_and(|(c, _)| c.is_shutdown());
+        let recv_shutdown = inner.read_shutdown
+            || inner
+                .recv_channel
+                .as_ref()
+                .is_some_and(ReadEnd::is_shutdown);
+        let send_shutdown = inner.write_shutdown
+            || inner
+                .connected_send_channel
+                .as_ref()
+                .is_some_and(|(c, _)| c.is_shutdown());
         if let Some(recv_channel) = &inner.recv_channel {
             if recv_shutdown {
                 events |= Events::IN | Events::RDHUP;
             } else if !recv_channel.is_empty() {
                 events |= Events::IN;
             }
+        } else if recv_shutdown {
+            events |= Events::IN | Events::RDHUP;
         }
         if let Some((connected_send_channel, _)) = &inner.connected_send_channel {
             if !connected_send_channel.is_full() {
                 events |= Events::OUT;
             }
-        } else {
+        } else if !inner.write_shutdown {
+            // If not connected, allow to sendto any address?
             events |= Events::OUT;
         }
         // Linux reports POLLHUP on a dgram fd only when *both* local directions are
@@ -1250,7 +1290,8 @@ impl<FS: ShimFS> UnixDatagram<FS> {
     }
 
     fn shutdown(&self, how: ShutdownHow) {
-        self.inner.read().shutdown(how);
+        let mut inner = self.inner.write();
+        inner.shutdown(how);
     }
 }
 

--- a/litebox_shim_linux/src/syscalls/unix.rs
+++ b/litebox_shim_linux/src/syscalls/unix.rs
@@ -1120,6 +1120,31 @@ impl<FS: ShimFS> UnixDatagram<FS> {
         }
         events
     }
+
+    fn shutdown(&self, how: litebox_common_linux::ShutdownHow) -> Result<(), Errno> {
+        let inner = self.inner.read();
+        match how {
+            litebox_common_linux::ShutdownHow::Read | litebox_common_linux::ShutdownHow::Both => {
+                // TODO: set the recv channel to None to prevent further reads?
+                if let Some(recv_channel) = &inner.recv_channel {
+                    recv_channel.shutdown();
+                    inner.pollee.notify_observers(Events::HUP);
+                }
+            }
+            _ => {}
+        }
+        match how {
+            litebox_common_linux::ShutdownHow::Write | litebox_common_linux::ShutdownHow::Both => {
+                // TODO: set the send channel to None to prevent further writes?
+                if let Some((connected_send_channel, _)) = &inner.connected_send_channel {
+                    connected_send_channel.shutdown();
+                    inner.pollee.notify_observers(Events::ERR);
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
 }
 
 enum UnixSocketInner<FS: ShimFS> {
@@ -1426,6 +1451,13 @@ impl<FS: ShimFS> UnixSocket<FS> {
             SocketOptionName::TCP(_) => return Err(Errno::EOPNOTSUPP),
         };
         super::write_to_user(val, optval, len)
+    }
+
+    pub(crate) fn shutdown(&self, how: litebox_common_linux::ShutdownHow) -> Result<(), Errno> {
+        match &self.inner {
+            UnixSocketInner::Stream(_stream) => todo!(),
+            UnixSocketInner::Datagram(datagram) => datagram.shutdown(how),
+        }
     }
 
     super::common_functions_for_file_status!();

--- a/litebox_shim_linux/src/syscalls/unix.rs
+++ b/litebox_shim_linux/src/syscalls/unix.rs
@@ -816,7 +816,8 @@ impl<FS: ShimFS> UnixStream<FS> {
         is_nonblocking: bool,
         mut source_addr: Option<&mut Option<UnixSocketAddr>>,
     ) -> Result<usize, Errno> {
-        cx.with_timeout(timeout)
+        let res = cx
+            .with_timeout(timeout)
             .wait_on_events(
                 is_nonblocking,
                 Events::IN,
@@ -841,7 +842,12 @@ impl<FS: ShimFS> UnixStream<FS> {
                     })
                 },
             )
-            .map_err(Errno::from)
+            .map_err(Errno::from);
+        // SO_RCVTIMEO expiry: Linux returns EAGAIN, not ETIMEDOUT.
+        match res {
+            Err(Errno::ETIMEDOUT) => Err(Errno::EAGAIN),
+            other => other,
+        }
     }
 
     fn get_local_addr(&self) -> UnixSocketAddr {
@@ -948,6 +954,7 @@ impl ReadEnd<DatagramMessage> {
         buf: &mut [u8],
         mut source_addr: Option<&mut Option<UnixSocketAddr>>,
     ) -> Result<usize, TryOpError<Errno>> {
+        let is_self_shutdown = self.is_shutdown();
         self.peek_and_consume_one(|msg| {
             let copy_len = buf.len().min(msg.data.len());
             buf[..copy_len].copy_from_slice(&msg.data[..copy_len]);
@@ -959,6 +966,12 @@ impl ReadEnd<DatagramMessage> {
         })
         .map_err(|e| match e {
             Errno::EAGAIN => TryOpError::TryAgain,
+            // ESHUTDOWN from the channel layer collapses two distinct conditions: our own
+            // SHUT_RD (caller wants EOF) and peer SHUT_WR (Linux keeps the socket
+            // receivable in principle, since other senders could still target it). For
+            // datagram, only the self case synthesizes EOF; peer-shutdown looks like
+            // "empty queue, try again".
+            Errno::ESHUTDOWN if !is_self_shutdown => TryOpError::TryAgain,
             other => TryOpError::Other(other),
         })
     }
@@ -1124,12 +1137,13 @@ impl<FS: ShimFS> UnixDatagram<FS> {
                 },
             )
             .map_err(Errno::from);
-        // Linux datagram quirk: after shutdown(SHUT_RD) with an empty queue, a non-blocking
-        // recv returns EAGAIN (datagram boundaries mean we don't synthesize EOF when caller
-        // explicitly asked not to block). Blocking recv still returns 0 via the ESHUTDOWN ->
-        // EOF mapping at the UnixSocket layer.
+        // - Non-blocking + self-shutdown(SHUT_RD) with empty queue: Linux returns EAGAIN
+        //   instead of EOF (datagram boundaries — no message synthesized for the absent peer).
+        // - SO_RCVTIMEO expiry on a blocking recv: Linux returns EAGAIN, not ETIMEDOUT
+        //   (the latter is reserved for connect-style timeouts).
         match res {
             Err(Errno::ESHUTDOWN) if is_nonblocking => Err(Errno::EAGAIN),
+            Err(Errno::ETIMEDOUT) => Err(Errno::EAGAIN),
             other => other,
         }
     }

--- a/litebox_shim_linux/src/syscalls/unix.rs
+++ b/litebox_shim_linux/src/syscalls/unix.rs
@@ -4,7 +4,7 @@
 //! Unix domain socket implementation for the Linux shim layer.
 
 use core::{
-    sync::atomic::{AtomicU8, AtomicU16, AtomicU32, Ordering},
+    sync::atomic::{AtomicBool, AtomicU16, AtomicU32, Ordering},
     time::Duration,
 };
 
@@ -189,17 +189,14 @@ impl<FS: ShimFS> From<&UnixBoundSocketAddr<FS>> for UnixSocketAddr {
 ///
 /// This is the state immediately after socket creation, before the socket
 /// has been connected, or put into listening mode.
-/// Bit 0 = read shutdown pending, bit 1 = write shutdown pending.
-const PENDING_READ_SHUTDOWN: u8 = 1 << 0;
-const PENDING_WRITE_SHUTDOWN: u8 = 1 << 1;
-
 struct UnixInitStream<FS: ShimFS> {
     /// Optional bound address for this socket
     addr: Option<UnixBoundSocketAddr<FS>>,
     pollee: Pollee<crate::Platform>,
-    /// Linux preserves `shutdown(2)` flags set before `connect(2)` and applies them
-    /// once the socket transitions to Connected. We record them here.
-    pending_shutdown: AtomicU8,
+    /// Whether the read side of this socket is pending shutdown
+    pending_read_shutdown: AtomicBool,
+    /// Whether the write side of this socket is pending shutdown
+    pending_write_shutdown: AtomicBool,
 }
 
 impl<FS: ShimFS> UnixInitStream<FS> {
@@ -207,19 +204,18 @@ impl<FS: ShimFS> UnixInitStream<FS> {
         Self {
             addr: None,
             pollee: Pollee::new(),
-            pending_shutdown: AtomicU8::new(0),
+            pending_read_shutdown: AtomicBool::new(false),
+            pending_write_shutdown: AtomicBool::new(false),
         }
     }
 
-    fn record_pending_shutdown(&self, how: ShutdownHow) {
-        let mut bits = 0;
-        if how.affects_read() {
-            bits |= PENDING_READ_SHUTDOWN;
+    fn shutdown(&self, how: ShutdownHow) {
+        if how.affects_read() && !self.pending_read_shutdown.swap(true, Ordering::Release) {
+            self.pollee.notify_observers(Events::IN);
         }
         if how.affects_write() {
-            bits |= PENDING_WRITE_SHUTDOWN;
+            self.pending_write_shutdown.store(true, Ordering::Release);
         }
-        self.pending_shutdown.fetch_or(bits, Ordering::Release);
     }
 
     /// Binds this socket to the given address.
@@ -260,9 +256,6 @@ impl<FS: ShimFS> UnixInitStream<FS> {
     }
 
     /// Converts this initial socket into a connected stream pair.
-    ///
-    /// Any half-close flags recorded by a pre-connect `shutdown(2)` are applied to the
-    /// returned *client* stream (the caller side); the server side starts fresh.
     fn into_connected(
         self,
         peer_addr: Arc<UnixBoundSocketAddr<FS>>,
@@ -270,27 +263,16 @@ impl<FS: ShimFS> UnixInitStream<FS> {
         let UnixInitStream {
             addr,
             pollee,
-            pending_shutdown,
+            pending_read_shutdown,
+            pending_write_shutdown,
         } = self;
-        let (client, server) = UnixConnectedStream::new_pair(
+        UnixConnectedStream::new_pair(
             addr.map(Arc::new),
             Some(Arc::new(pollee)),
             Some(peer_addr),
-        );
-        let pending = pending_shutdown.load(Ordering::Acquire);
-        let how = match (
-            pending & PENDING_READ_SHUTDOWN != 0,
-            pending & PENDING_WRITE_SHUTDOWN != 0,
-        ) {
-            (true, true) => Some(ShutdownHow::Both),
-            (true, false) => Some(ShutdownHow::Read),
-            (false, true) => Some(ShutdownHow::Write),
-            (false, false) => None,
-        };
-        if let Some(how) = how {
-            client.shutdown(how);
-        }
-        (client, server)
+            pending_read_shutdown.load(Ordering::Acquire),
+            pending_write_shutdown.load(Ordering::Acquire),
+        )
     }
 }
 
@@ -349,8 +331,7 @@ impl<FS: ShimFS> Backlog<FS> {
     fn try_accept(&self) -> Result<UnixConnectedStream<FS>, TryOpError<Errno>> {
         let mut sockets = self.sockets.lock();
         let Some(sockets) = &mut *sockets else {
-            // Linux returns EINVAL from accept(2) on a listening socket that was shut down.
-            return Err(TryOpError::Other(Errno::EINVAL));
+            return Err(TryOpError::Other(Errno::ESHUTDOWN));
         };
 
         match sockets.pop_front() {
@@ -365,7 +346,7 @@ impl<FS: ShimFS> Backlog<FS> {
     fn check_io_events(&self) -> Events {
         let sockets = self.sockets.lock();
         let Some(sockets) = &*sockets else {
-            return Events::HUP;
+            return Events::IN | Events::HUP;
         };
         let mut events = Events::empty();
         if !sockets.is_empty() {
@@ -377,8 +358,7 @@ impl<FS: ShimFS> Backlog<FS> {
         events
     }
 
-    /// Shuts down this backlog, preventing new connections. Wakes any pending pollers
-    /// so they observe the new HUP state without having to retry.
+    /// Shuts down this backlog, preventing new connections.
     fn shutdown(&self) {
         let mut sockets = self.sockets.lock();
         if sockets.is_some() {
@@ -485,10 +465,14 @@ struct UnixConnectedStream<FS: ShimFS> {
 const UNIX_BUF_SIZE: usize = 65536;
 impl<FS: ShimFS> UnixConnectedStream<FS> {
     /// Creates a pair of connected Unix stream sockets.
+    ///
+    /// `read_shutdown` and `write_shutdown` half-close the corresponding sides of the stream.
     fn new_pair(
         addr: Option<Arc<UnixBoundSocketAddr<FS>>>,
         pollee: Option<Arc<Pollee<crate::Platform>>>,
         peer: Option<Arc<UnixBoundSocketAddr<FS>>>,
+        read_shutdown: bool,
+        write_shutdown: bool,
     ) -> (Self, Self) {
         let (addr1, addr2) = AddrView::new_pair(addr, peer);
         let pollee1 = pollee.unwrap_or(Arc::new(Pollee::new()));
@@ -497,21 +481,25 @@ impl<FS: ShimFS> UnixConnectedStream<FS> {
             crate::channel::Channel::new(UNIX_BUF_SIZE, pollee2.clone(), pollee1.clone()).split();
         let (send_channel_peer, recv_channel_peer) =
             crate::channel::Channel::new(UNIX_BUF_SIZE, pollee1.clone(), pollee2.clone()).split();
-        (
-            // Cross-wire: each socket keeps the other side's send channel.
-            UnixConnectedStream {
-                addr: addr1,
-                recv_channel,
-                connected_send_channel: send_channel_peer,
-                pollee: pollee1,
-            },
-            UnixConnectedStream {
-                addr: addr2,
-                recv_channel: recv_channel_peer,
-                connected_send_channel: send_channel,
-                pollee: pollee2,
-            },
-        )
+        let first = UnixConnectedStream {
+            addr: addr1,
+            recv_channel,
+            connected_send_channel: send_channel_peer,
+            pollee: pollee1,
+        };
+        let second = UnixConnectedStream {
+            addr: addr2,
+            recv_channel: recv_channel_peer,
+            connected_send_channel: send_channel,
+            pollee: pollee2,
+        };
+        if read_shutdown {
+            first.recv_channel.shutdown();
+        }
+        if write_shutdown {
+            first.connected_send_channel.shutdown();
+        }
+        (first, second)
     }
 
     fn get_local_addr(&self) -> UnixSocketAddr {
@@ -746,24 +734,32 @@ impl<FS: ShimFS> UnixStream<FS> {
             let listen = state.listen().ok_or(Errno::EINVAL)?;
             Ok(listen.backlog.clone())
         })?;
-        cx.wait_on_events(
-            is_nonblocking,
-            Events::IN,
-            |observer, mask| {
-                backlog.pollee.register_observer(observer, mask);
-                Ok(())
-            },
-            || {
-                let accepted = backlog.try_accept()?;
-                if let Some(peer) = peer.as_deref_mut() {
-                    *peer = accepted.get_peer_addr();
-                }
-                Ok(UnixSocketInner::Stream(UnixStream::new(
-                    UnixStreamState::Connected(accepted),
-                )))
-            },
-        )
-        .map_err(Errno::from)
+        let res = cx
+            .wait_on_events(
+                is_nonblocking,
+                Events::IN,
+                |observer, mask| {
+                    backlog.pollee.register_observer(observer, mask);
+                    Ok(())
+                },
+                || {
+                    let accepted = backlog.try_accept()?;
+                    if let Some(peer) = peer.as_deref_mut() {
+                        *peer = accepted.get_peer_addr();
+                    }
+                    Ok(UnixSocketInner::Stream(UnixStream::new(
+                        UnixStreamState::Connected(accepted),
+                    )))
+                },
+            )
+            .map_err(Errno::from);
+        // accept on a shut-down listen: Linux returns EAGAIN for non-blocking, EINVAL
+        // for blocking. try_accept signals shutdown via ESHUTDOWN; translate here.
+        match res {
+            Err(Errno::ESHUTDOWN) if is_nonblocking => Err(Errno::EAGAIN),
+            Err(Errno::ESHUTDOWN) => Err(Errno::EINVAL),
+            other => other,
+        }
     }
 
     fn sendto(
@@ -882,7 +878,17 @@ impl<FS: ShimFS> UnixStream<FS> {
     }
     fn check_io_events(&self) -> Events {
         self.with_state_ref(|state| match state {
-            UnixStreamState::Init(_) => Events::OUT | Events::HUP,
+            UnixStreamState::Init(init) => {
+                // Fresh Init reports OUT|HUP (HUP because not connected). After a
+                // shutdown(SHUT_RD) on an Init socket, Linux additionally reports IN
+                // (a recv would return EOF immediately). SHUT_WR has no observable
+                // effect on Init's poll output.
+                let mut events = Events::OUT | Events::HUP;
+                if init.pending_read_shutdown.load(Ordering::Acquire) {
+                    events |= Events::IN;
+                }
+                events
+            }
             UnixStreamState::Listen(listen) => listen.backlog.check_io_events(),
             UnixStreamState::Connected(conn) => conn.check_io_events(),
         })
@@ -890,12 +896,7 @@ impl<FS: ShimFS> UnixStream<FS> {
 
     fn shutdown(&self, how: ShutdownHow) {
         self.with_state_ref(|state| match state {
-            // Linux records pre-connect shutdown flags on the unix_sock and applies them
-            // post-connect; we mirror that by stashing the bits on UnixInitStream.
-            UnixStreamState::Init(init) => init.record_pending_shutdown(how),
-            // Linux sets SOCK_RCV_SHUTDOWN on a listening socket, after which a blocking
-            // accept returns EINVAL and poll reports POLLIN | POLLHUP. The existing backlog
-            // machinery uses `sockets = None` as that signal.
+            UnixStreamState::Init(init) => init.shutdown(how),
             UnixStreamState::Listen(listen) => listen.backlog.shutdown(),
             UnixStreamState::Connected(conn) => conn.shutdown(how),
         });
@@ -1388,7 +1389,7 @@ impl<FS: ShimFS> UnixSocket<FS> {
     ) -> Option<(UnixSocket<FS>, UnixSocket<FS>)> {
         match ty {
             SockType::Stream => {
-                let (conn1, conn2) = UnixConnectedStream::new_pair(None, None, None);
+                let (conn1, conn2) = UnixConnectedStream::new_pair(None, None, None, false, false);
                 Some((
                     UnixSocket::new_with_inner(
                         UnixSocketInner::Stream(UnixStream::new(UnixStreamState::Connected(conn1))),

--- a/litebox_shim_linux/src/syscalls/unix.rs
+++ b/litebox_shim_linux/src/syscalls/unix.rs
@@ -4,7 +4,7 @@
 //! Unix domain socket implementation for the Linux shim layer.
 
 use core::{
-    sync::atomic::{AtomicU16, AtomicU32, Ordering},
+    sync::atomic::{AtomicU8, AtomicU16, AtomicU32, Ordering},
     time::Duration,
 };
 
@@ -26,8 +26,8 @@ use litebox::{
     utils::TruncateExt as _,
 };
 use litebox_common_linux::{
-    IpOption, ReceiveFlags, SendFlags, SockFlags, SockType, SocketOption, SocketOptionName,
-    errno::Errno,
+    IpOption, ReceiveFlags, SendFlags, ShutdownHow, SockFlags, SockType, SocketOption,
+    SocketOptionName, errno::Errno,
 };
 
 use crate::{
@@ -189,10 +189,17 @@ impl<FS: ShimFS> From<&UnixBoundSocketAddr<FS>> for UnixSocketAddr {
 ///
 /// This is the state immediately after socket creation, before the socket
 /// has been connected, or put into listening mode.
+/// Bit 0 = read shutdown pending, bit 1 = write shutdown pending.
+const PENDING_READ_SHUTDOWN: u8 = 1 << 0;
+const PENDING_WRITE_SHUTDOWN: u8 = 1 << 1;
+
 struct UnixInitStream<FS: ShimFS> {
     /// Optional bound address for this socket
     addr: Option<UnixBoundSocketAddr<FS>>,
     pollee: Pollee<crate::Platform>,
+    /// Linux preserves `shutdown(2)` flags set before `connect(2)` and applies them
+    /// once the socket transitions to Connected. We record them here.
+    pending_shutdown: AtomicU8,
 }
 
 impl<FS: ShimFS> UnixInitStream<FS> {
@@ -200,7 +207,19 @@ impl<FS: ShimFS> UnixInitStream<FS> {
         Self {
             addr: None,
             pollee: Pollee::new(),
+            pending_shutdown: AtomicU8::new(0),
         }
+    }
+
+    fn record_pending_shutdown(&self, how: ShutdownHow) {
+        let mut bits = 0;
+        if how.affects_read() {
+            bits |= PENDING_READ_SHUTDOWN;
+        }
+        if how.affects_write() {
+            bits |= PENDING_WRITE_SHUTDOWN;
+        }
+        self.pending_shutdown.fetch_or(bits, Ordering::Release);
     }
 
     /// Binds this socket to the given address.
@@ -241,12 +260,37 @@ impl<FS: ShimFS> UnixInitStream<FS> {
     }
 
     /// Converts this initial socket into a connected stream pair.
+    ///
+    /// Any half-close flags recorded by a pre-connect `shutdown(2)` are applied to the
+    /// returned *client* stream (the caller side); the server side starts fresh.
     fn into_connected(
         self,
         peer_addr: Arc<UnixBoundSocketAddr<FS>>,
     ) -> (UnixConnectedStream<FS>, UnixConnectedStream<FS>) {
-        let UnixInitStream { addr, pollee } = self;
-        UnixConnectedStream::new_pair(addr.map(Arc::new), Some(Arc::new(pollee)), Some(peer_addr))
+        let UnixInitStream {
+            addr,
+            pollee,
+            pending_shutdown,
+        } = self;
+        let (client, server) = UnixConnectedStream::new_pair(
+            addr.map(Arc::new),
+            Some(Arc::new(pollee)),
+            Some(peer_addr),
+        );
+        let pending = pending_shutdown.load(Ordering::Acquire);
+        let how = match (
+            pending & PENDING_READ_SHUTDOWN != 0,
+            pending & PENDING_WRITE_SHUTDOWN != 0,
+        ) {
+            (true, true) => Some(ShutdownHow::Both),
+            (true, false) => Some(ShutdownHow::Read),
+            (false, true) => Some(ShutdownHow::Write),
+            (false, false) => None,
+        };
+        if let Some(how) = how {
+            client.shutdown(how);
+        }
+        (client, server)
     }
 }
 
@@ -305,8 +349,8 @@ impl<FS: ShimFS> Backlog<FS> {
     fn try_accept(&self) -> Result<UnixConnectedStream<FS>, TryOpError<Errno>> {
         let mut sockets = self.sockets.lock();
         let Some(sockets) = &mut *sockets else {
-            // the server socket is shutdown
-            return Err(TryOpError::Other(Errno::ECONNREFUSED));
+            // Linux returns EINVAL from accept(2) on a listening socket that was shut down.
+            return Err(TryOpError::Other(Errno::EINVAL));
         };
 
         match sockets.pop_front() {
@@ -333,10 +377,14 @@ impl<FS: ShimFS> Backlog<FS> {
         events
     }
 
-    /// Shuts down this backlog, preventing new connections.
+    /// Shuts down this backlog, preventing new connections. Wakes any pending pollers
+    /// so they observe the new HUP state without having to retry.
     fn shutdown(&self) {
         let mut sockets = self.sockets.lock();
-        *sockets = None;
+        if sockets.is_some() {
+            *sockets = None;
+            self.pollee.notify_observers(Events::HUP);
+        }
     }
 }
 
@@ -532,6 +580,19 @@ impl<FS: ShimFS> UnixConnectedStream<FS> {
             events |= Events::OUT;
         }
         events
+    }
+
+    fn shutdown(&self, how: ShutdownHow) {
+        let mut events = Events::empty();
+        if how.affects_read() {
+            self.recv_channel.shutdown();
+            events |= Events::IN | Events::RDHUP;
+        }
+        if how.affects_write() {
+            self.connected_send_channel.shutdown();
+            events |= Events::OUT | Events::HUP;
+        }
+        self.pollee.notify_observers(events);
     }
 }
 
@@ -820,6 +881,19 @@ impl<FS: ShimFS> UnixStream<FS> {
             UnixStreamState::Connected(conn) => conn.check_io_events(),
         })
     }
+
+    fn shutdown(&self, how: ShutdownHow) {
+        self.with_state_ref(|state| match state {
+            // Linux records pre-connect shutdown flags on the unix_sock and applies them
+            // post-connect; we mirror that by stashing the bits on UnixInitStream.
+            UnixStreamState::Init(init) => init.record_pending_shutdown(how),
+            // Linux sets SOCK_RCV_SHUTDOWN on a listening socket, after which a blocking
+            // accept returns EINVAL and poll reports POLLIN | POLLHUP. The existing backlog
+            // machinery uses `sockets = None` as that signal.
+            UnixStreamState::Listen(listen) => listen.backlog.shutdown(),
+            UnixStreamState::Connected(conn) => conn.shutdown(how),
+        });
+    }
 }
 
 /// A datagram message with source address information
@@ -1032,7 +1106,8 @@ impl<FS: ShimFS> UnixDatagram<FS> {
         is_nonblocking: bool,
         mut source_addr: Option<&mut Option<UnixSocketAddr>>,
     ) -> Result<usize, Errno> {
-        cx.with_timeout(timeout)
+        let res = cx
+            .with_timeout(timeout)
             .wait_on_events(
                 is_nonblocking,
                 Events::IN,
@@ -1048,7 +1123,15 @@ impl<FS: ShimFS> UnixDatagram<FS> {
                     recv_channel.try_read(buf, source_addr.as_deref_mut())
                 },
             )
-            .map_err(Errno::from)
+            .map_err(Errno::from);
+        // Linux datagram quirk: after shutdown(SHUT_RD) with an empty queue, a non-blocking
+        // recv returns EAGAIN (datagram boundaries mean we don't synthesize EOF when caller
+        // explicitly asked not to block). Blocking recv still returns 0 via the ESHUTDOWN ->
+        // EOF mapping at the UnixSocket layer.
+        match res {
+            Err(Errno::ESHUTDOWN) if is_nonblocking => Err(Errno::EAGAIN),
+            other => other,
+        }
     }
 
     // Sends data to the specified or connected peer.
@@ -1121,29 +1204,22 @@ impl<FS: ShimFS> UnixDatagram<FS> {
         events
     }
 
-    fn shutdown(&self, how: litebox_common_linux::ShutdownHow) -> Result<(), Errno> {
+    fn shutdown(&self, how: ShutdownHow) {
         let inner = self.inner.read();
-        match how {
-            litebox_common_linux::ShutdownHow::Read | litebox_common_linux::ShutdownHow::Both => {
-                // TODO: set the recv channel to None to prevent further reads?
-                if let Some(recv_channel) = &inner.recv_channel {
-                    recv_channel.shutdown();
-                    inner.pollee.notify_observers(Events::HUP);
-                }
-            }
-            _ => {}
+        let mut events = Events::empty();
+        if how.affects_read()
+            && let Some(recv_channel) = &inner.recv_channel
+        {
+            recv_channel.shutdown();
+            events |= Events::IN | Events::RDHUP;
         }
-        match how {
-            litebox_common_linux::ShutdownHow::Write | litebox_common_linux::ShutdownHow::Both => {
-                // TODO: set the send channel to None to prevent further writes?
-                if let Some((connected_send_channel, _)) = &inner.connected_send_channel {
-                    connected_send_channel.shutdown();
-                    inner.pollee.notify_observers(Events::ERR);
-                }
-            }
-            _ => {}
+        if how.affects_write()
+            && let Some((connected_send_channel, _)) = &inner.connected_send_channel
+        {
+            connected_send_channel.shutdown();
+            events |= Events::OUT | Events::HUP;
         }
-        Ok(())
+        inner.pollee.notify_observers(events);
     }
 }
 
@@ -1453,9 +1529,9 @@ impl<FS: ShimFS> UnixSocket<FS> {
         super::write_to_user(val, optval, len)
     }
 
-    pub(crate) fn shutdown(&self, how: litebox_common_linux::ShutdownHow) -> Result<(), Errno> {
+    pub(super) fn shutdown(&self, how: ShutdownHow) {
         match &self.inner {
-            UnixSocketInner::Stream(_stream) => todo!(),
+            UnixSocketInner::Stream(stream) => stream.shutdown(how),
             UnixSocketInner::Datagram(datagram) => datagram.shutdown(how),
         }
     }


### PR DESCRIPTION
Implement syscasll `shutdown` for unix socket only; will complete inet socket in a separate PR.