### PR TITLE
Add setitimer/getitimer

### DIFF
--- a/litebox_common_linux/src/lib.rs
+++ b/litebox_common_linux/src/lib.rs
@@ -940,12 +940,31 @@ pub struct TimeVal {
     tv_usec: suseconds_t,
 }
 #[repr(C)]
-#[derive(Clone, FromBytes, IntoBytes)]
+#[derive(Clone, Default, FromBytes, IntoBytes, Immutable)]
 pub struct ItimerVal {
     /// Timer interval
     interval: TimeVal,
     /// Current value
     value: TimeVal,
+}
+
+impl ItimerVal {
+    pub fn new(interval: TimeVal, value: TimeVal) -> Self {
+        Self { interval, value }
+    }
+
+    /// `it_value = duration`, `it_interval = 0` (single-shot timer).
+    pub fn single_shot(duration: Duration) -> Self {
+        Self::new(TimeVal::from(Duration::ZERO), TimeVal::from(duration))
+    }
+
+    pub fn it_interval(&self) -> TimeVal {
+        self.interval
+    }
+
+    pub fn it_value(&self) -> TimeVal {
+        self.value
+    }
 }
 
 impl TryFrom<TimeVal> for Duration {
@@ -2351,8 +2370,12 @@ pub enum SyscallRequest<Platform: litebox::platform::RawPointerProvider> {
     Pause,
     SetITimer {
         which: IntervalTimer,
-        new_value: Platform::RawConstPointer<ItimerVal>,
+        new_value: Option<Platform::RawConstPointer<ItimerVal>>,
         old_value: Option<Platform::RawMutPointer<ItimerVal>>,
+    },
+    GetITimer {
+        which: IntervalTimer,
+        curr_value: Platform::RawMutPointer<ItimerVal>,
     },
     Statx {
         dirfd: i32,
@@ -2828,6 +2851,7 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
             Sysno::alarm => sys_req!(Alarm { seconds }),
             Sysno::pause => SyscallRequest::Pause,
             Sysno::setitimer => sys_req!(SetITimer { which:?, new_value:*, old_value:* }),
+            Sysno::getitimer => sys_req!(GetITimer { which:?, curr_value:* }),
             Sysno::statx => sys_req!(Statx {
                 dirfd,
                 pathname:*,

--- a/litebox_runner_linux_userland/tests/getitimer.c
+++ b/litebox_runner_linux_userland/tests/getitimer.c
@@ -6,40 +6,26 @@
 // Goes through syscall(SYS_getitimer, ...) to exercise the raw kernel surface
 // that LiteBox intercepts rather than the libc wrapper.
 
-#define _GNU_SOURCE
-#include <errno.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <sys/syscall.h>
-#include <sys/time.h>
-#include <unistd.h>
-
-#define TEST_ASSERT(cond, msg)                                                \
-    do {                                                                      \
-        if (!(cond)) {                                                        \
-            fprintf(stderr, "FAIL: %s (line %d): %s (errno=%d: %s)\n",        \
-                    __func__, __LINE__, msg, errno, strerror(errno));         \
-            exit(1);                                                          \
-        }                                                                     \
-    } while (0)
+#include "helpers.h"
 
 static int raw_getitimer(int which, struct itimerval *curr_value) {
     return (int)syscall(SYS_getitimer, which, curr_value);
 }
 
-static void test_getitimer_no_timer_set(void) {
-    // ITIMER_REAL with no timer armed: both substructures must be zero.
-    // Cancel any inherited alarm first so the slate is clean.
-    alarm(0);
+static void expect_unarmed_timer(int which, const char *op) {
     struct itimerval iv;
+
     memset(&iv, 0xff, sizeof(iv));
-    int rc = raw_getitimer(ITIMER_REAL, &iv);
-    TEST_ASSERT(rc == 0, "getitimer(ITIMER_REAL) success");
+    TEST_ASSERT(raw_getitimer(which, &iv) == 0, op);
     TEST_ASSERT(iv.it_value.tv_sec == 0 && iv.it_value.tv_usec == 0,
-                "it_value zero when no timer armed");
+                "it_value zero when timer is unarmed");
     TEST_ASSERT(iv.it_interval.tv_sec == 0 && iv.it_interval.tv_usec == 0,
-                "it_interval zero when no timer armed");
+                "it_interval zero when timer is unarmed");
+}
+
+static void test_getitimer_no_timer_set(void) {
+    alarm(0);
+    expect_unarmed_timer(ITIMER_REAL, "getitimer(ITIMER_REAL) unarmed");
 }
 
 static void test_getitimer_after_alarm(void) {
@@ -55,11 +41,7 @@ static void test_getitimer_after_alarm(void) {
     int rc = raw_getitimer(ITIMER_REAL, &iv);
     TEST_ASSERT(rc == 0, "getitimer success after alarm");
 
-    // it_value should be in (0, 10] seconds — a tv_sec of 9 or 10 with any
-    // microseconds is acceptable, depending on how much wall-clock time
-    // elapsed between alarm() and getitimer().
-    long total_us =
-        (long)iv.it_value.tv_sec * 1000000L + (long)iv.it_value.tv_usec;
+    long total_us = itimer_value_us(&iv);
     TEST_ASSERT(total_us > 0 && total_us <= 10 * 1000000L,
                 "it_value in (0, 10s] after alarm(10)");
     TEST_ASSERT(iv.it_interval.tv_sec == 0 && iv.it_interval.tv_usec == 0,
@@ -69,36 +51,24 @@ static void test_getitimer_after_alarm(void) {
 }
 
 static void test_getitimer_virtual_and_prof_zero(void) {
-    // ITIMER_VIRTUAL and ITIMER_PROF are valid `which` values. When no
-    // setitimer has armed them (and Linux's per-process default is "not
-    // armed"), getitimer reports zeroed itimerval.
     for (int which = ITIMER_VIRTUAL; which <= ITIMER_PROF; which++) {
-        struct itimerval iv;
-        memset(&iv, 0xff, sizeof(iv));
-        int rc = raw_getitimer(which, &iv);
-        TEST_ASSERT(rc == 0, "getitimer ITIMER_VIRTUAL/PROF success");
-        TEST_ASSERT(iv.it_value.tv_sec == 0 && iv.it_value.tv_usec == 0,
-                    "it_value zero for unarmed ITIMER_VIRTUAL/PROF");
-        TEST_ASSERT(iv.it_interval.tv_sec == 0 && iv.it_interval.tv_usec == 0,
-                    "it_interval zero for unarmed ITIMER_VIRTUAL/PROF");
+        expect_unarmed_timer(which, "getitimer ITIMER_VIRTUAL/PROF unarmed");
     }
 }
 
 static void test_getitimer_einval(void) {
-    // `which` outside {0, 1, 2} → EINVAL.
     struct itimerval iv;
     errno = 0;
     int rc = raw_getitimer(99, &iv);
     TEST_ASSERT(rc == -1 && errno == EINVAL,
-                "getitimer with bogus which → EINVAL");
+                "getitimer with bogus which -> EINVAL");
 }
 
 static void test_getitimer_efault(void) {
-    // NULL curr_value pointer → EFAULT.
     errno = 0;
     int rc = raw_getitimer(ITIMER_REAL, NULL);
     TEST_ASSERT(rc == -1 && errno == EFAULT,
-                "getitimer with NULL curr_value → EFAULT");
+                "getitimer with NULL curr_value -> EFAULT");
 }
 
 int main(void) {

--- a/litebox_runner_linux_userland/tests/getitimer.c
+++ b/litebox_runner_linux_userland/tests/getitimer.c
@@ -1,0 +1,113 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// Tests: getitimer happy path + cross-syscall observation (alarm sets the
+// ITIMER_REAL state that getitimer reads back) and error branches.
+// Goes through syscall(SYS_getitimer, ...) to exercise the raw kernel surface
+// that LiteBox intercepts rather than the libc wrapper.
+
+#define _GNU_SOURCE
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+#define TEST_ASSERT(cond, msg)                                                \
+    do {                                                                      \
+        if (!(cond)) {                                                        \
+            fprintf(stderr, "FAIL: %s (line %d): %s (errno=%d: %s)\n",        \
+                    __func__, __LINE__, msg, errno, strerror(errno));         \
+            exit(1);                                                          \
+        }                                                                     \
+    } while (0)
+
+static int raw_getitimer(int which, struct itimerval *curr_value) {
+    return (int)syscall(SYS_getitimer, which, curr_value);
+}
+
+static void test_getitimer_no_timer_set(void) {
+    // ITIMER_REAL with no timer armed: both substructures must be zero.
+    // Cancel any inherited alarm first so the slate is clean.
+    alarm(0);
+    struct itimerval iv;
+    memset(&iv, 0xff, sizeof(iv));
+    int rc = raw_getitimer(ITIMER_REAL, &iv);
+    TEST_ASSERT(rc == 0, "getitimer(ITIMER_REAL) success");
+    TEST_ASSERT(iv.it_value.tv_sec == 0 && iv.it_value.tv_usec == 0,
+                "it_value zero when no timer armed");
+    TEST_ASSERT(iv.it_interval.tv_sec == 0 && iv.it_interval.tv_usec == 0,
+                "it_interval zero when no timer armed");
+}
+
+static void test_getitimer_after_alarm(void) {
+    // alarm(N) is documented as equivalent to setitimer(ITIMER_REAL, {0, N}, NULL).
+    // Setting alarm(10) and immediately reading should show ~10s remaining in
+    // it_value and zero interval.
+    alarm(0);
+    unsigned int prev = alarm(10);
+    TEST_ASSERT(prev == 0, "no prior alarm");
+
+    struct itimerval iv;
+    memset(&iv, 0xff, sizeof(iv));
+    int rc = raw_getitimer(ITIMER_REAL, &iv);
+    TEST_ASSERT(rc == 0, "getitimer success after alarm");
+
+    // it_value should be in (0, 10] seconds — a tv_sec of 9 or 10 with any
+    // microseconds is acceptable, depending on how much wall-clock time
+    // elapsed between alarm() and getitimer().
+    long total_us =
+        (long)iv.it_value.tv_sec * 1000000L + (long)iv.it_value.tv_usec;
+    TEST_ASSERT(total_us > 0 && total_us <= 10 * 1000000L,
+                "it_value in (0, 10s] after alarm(10)");
+    TEST_ASSERT(iv.it_interval.tv_sec == 0 && iv.it_interval.tv_usec == 0,
+                "it_interval zero because alarm() never sets an interval");
+
+    alarm(0);
+}
+
+static void test_getitimer_virtual_and_prof_zero(void) {
+    // ITIMER_VIRTUAL and ITIMER_PROF are valid `which` values. When no
+    // setitimer has armed them (and Linux's per-process default is "not
+    // armed"), getitimer reports zeroed itimerval.
+    for (int which = ITIMER_VIRTUAL; which <= ITIMER_PROF; which++) {
+        struct itimerval iv;
+        memset(&iv, 0xff, sizeof(iv));
+        int rc = raw_getitimer(which, &iv);
+        TEST_ASSERT(rc == 0, "getitimer ITIMER_VIRTUAL/PROF success");
+        TEST_ASSERT(iv.it_value.tv_sec == 0 && iv.it_value.tv_usec == 0,
+                    "it_value zero for unarmed ITIMER_VIRTUAL/PROF");
+        TEST_ASSERT(iv.it_interval.tv_sec == 0 && iv.it_interval.tv_usec == 0,
+                    "it_interval zero for unarmed ITIMER_VIRTUAL/PROF");
+    }
+}
+
+static void test_getitimer_einval(void) {
+    // `which` outside {0, 1, 2} → EINVAL.
+    struct itimerval iv;
+    errno = 0;
+    int rc = raw_getitimer(99, &iv);
+    TEST_ASSERT(rc == -1 && errno == EINVAL,
+                "getitimer with bogus which → EINVAL");
+}
+
+static void test_getitimer_efault(void) {
+    // NULL curr_value pointer → EFAULT.
+    errno = 0;
+    int rc = raw_getitimer(ITIMER_REAL, NULL);
+    TEST_ASSERT(rc == -1 && errno == EFAULT,
+                "getitimer with NULL curr_value → EFAULT");
+}
+
+int main(void) {
+    printf("getitimer tests starting...\n");
+    test_getitimer_no_timer_set();
+    test_getitimer_after_alarm();
+    test_getitimer_virtual_and_prof_zero();
+    test_getitimer_einval();
+    test_getitimer_efault();
+    printf("All getitimer tests passed.\n");
+    return 0;
+}

--- a/litebox_runner_linux_userland/tests/helpers.h
+++ b/litebox_runner_linux_userland/tests/helpers.h
@@ -28,6 +28,10 @@
         }                                                                     \
     } while (0)
 
+static inline long itimer_value_us(const struct itimerval *iv) {
+    return (long)iv->it_value.tv_sec * 1000000L + (long)iv->it_value.tv_usec;
+}
+
 static inline void die(const char *msg) {
     perror(msg);
     exit(1);

--- a/litebox_runner_linux_userland/tests/setitimer.c
+++ b/litebox_runner_linux_userland/tests/setitimer.c
@@ -1,0 +1,213 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// Tests: setitimer(ITIMER_REAL, ...) — arm, disarm, old_value handoff,
+// EINVAL on out-of-range tv_usec, EINVAL on bad `which`, EFAULT on NULL
+// new_value. State changes are observed via getitimer() so the cross-syscall
+// contract is exercised. Uses syscall(SYS_setitimer, ...) directly to hit the
+// raw kernel surface that LiteBox intercepts.
+
+#define _GNU_SOURCE
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+#define TEST_ASSERT(cond, msg)                                                \
+    do {                                                                      \
+        if (!(cond)) {                                                        \
+            fprintf(stderr, "FAIL: %s (line %d): %s (errno=%d: %s)\n",        \
+                    __func__, __LINE__, msg, errno, strerror(errno));         \
+            exit(1);                                                          \
+        }                                                                     \
+    } while (0)
+
+static int raw_setitimer(int which, const struct itimerval *new_value,
+                         struct itimerval *old_value) {
+    return (int)syscall(SYS_setitimer, which, new_value, old_value);
+}
+
+static int raw_getitimer(int which, struct itimerval *curr_value) {
+    return (int)syscall(SYS_getitimer, which, curr_value);
+}
+
+static void clear_alarm(void) {
+    struct itimerval zero = {{0, 0}, {0, 0}};
+    (void)raw_setitimer(ITIMER_REAL, &zero, NULL);
+}
+
+static void test_arm_single_shot(void) {
+    // Arm with it_value={10,0}, it_interval=0.
+    clear_alarm();
+    struct itimerval nv = {{0, 0}, {10, 0}};
+    int rc = raw_setitimer(ITIMER_REAL, &nv, NULL);
+    TEST_ASSERT(rc == 0, "setitimer arm success");
+
+    struct itimerval gv;
+    memset(&gv, 0, sizeof(gv));
+    TEST_ASSERT(raw_getitimer(ITIMER_REAL, &gv) == 0, "getitimer after arm");
+    long total_us = (long)gv.it_value.tv_sec * 1000000L + (long)gv.it_value.tv_usec;
+    TEST_ASSERT(total_us > 0 && total_us <= 10 * 1000000L,
+                "it_value in (0, 10s]");
+    TEST_ASSERT(gv.it_interval.tv_sec == 0 && gv.it_interval.tv_usec == 0,
+                "it_interval zero (single-shot)");
+    clear_alarm();
+}
+
+static void test_disarm(void) {
+    // Arm first, then disarm with all-zero new_value.
+    struct itimerval nv = {{0, 0}, {10, 0}};
+    TEST_ASSERT(raw_setitimer(ITIMER_REAL, &nv, NULL) == 0, "arm precondition");
+
+    struct itimerval zero = {{0, 0}, {0, 0}};
+    TEST_ASSERT(raw_setitimer(ITIMER_REAL, &zero, NULL) == 0, "disarm success");
+
+    struct itimerval gv;
+    memset(&gv, 0xff, sizeof(gv));
+    TEST_ASSERT(raw_getitimer(ITIMER_REAL, &gv) == 0, "getitimer after disarm");
+    TEST_ASSERT(gv.it_value.tv_sec == 0 && gv.it_value.tv_usec == 0,
+                "it_value zero after disarm");
+    TEST_ASSERT(gv.it_interval.tv_sec == 0 && gv.it_interval.tv_usec == 0,
+                "it_interval zero after disarm");
+}
+
+static void test_old_value_returns_previous(void) {
+    // Set a 10s timer, then replace with a 5s timer and capture old_value.
+    clear_alarm();
+    struct itimerval first = {{0, 0}, {10, 0}};
+    TEST_ASSERT(raw_setitimer(ITIMER_REAL, &first, NULL) == 0, "first arm");
+
+    struct itimerval second = {{0, 0}, {5, 0}};
+    struct itimerval old;
+    memset(&old, 0xff, sizeof(old));
+    TEST_ASSERT(raw_setitimer(ITIMER_REAL, &second, &old) == 0, "replace returns old");
+
+    long old_us = (long)old.it_value.tv_sec * 1000000L + (long)old.it_value.tv_usec;
+    TEST_ASSERT(old_us > 0 && old_us <= 10 * 1000000L,
+                "old it_value reflects first arm (<= 10s)");
+    TEST_ASSERT(old.it_interval.tv_sec == 0 && old.it_interval.tv_usec == 0,
+                "old it_interval zero");
+
+    // Replacement should be active now.
+    struct itimerval gv;
+    TEST_ASSERT(raw_getitimer(ITIMER_REAL, &gv) == 0, "getitimer after replace");
+    long now_us = (long)gv.it_value.tv_sec * 1000000L + (long)gv.it_value.tv_usec;
+    TEST_ASSERT(now_us > 0 && now_us <= 5 * 1000000L,
+                "current it_value reflects replacement (<= 5s)");
+    clear_alarm();
+}
+
+static void test_old_value_unarmed_returns_zero(void) {
+    clear_alarm();
+    struct itimerval nv = {{0, 0}, {3, 0}};
+    struct itimerval old;
+    memset(&old, 0xff, sizeof(old));
+    TEST_ASSERT(raw_setitimer(ITIMER_REAL, &nv, &old) == 0, "arm with old_value");
+    TEST_ASSERT(old.it_value.tv_sec == 0 && old.it_value.tv_usec == 0,
+                "old it_value zero when previously unarmed");
+    TEST_ASSERT(old.it_interval.tv_sec == 0 && old.it_interval.tv_usec == 0,
+                "old it_interval zero when previously unarmed");
+    clear_alarm();
+}
+
+static void test_einval_usec_out_of_range(void) {
+    struct itimerval nv = {{0, 0}, {1, 1000000}};
+    errno = 0;
+    int rc = raw_setitimer(ITIMER_REAL, &nv, NULL);
+    TEST_ASSERT(rc == -1 && errno == EINVAL,
+                "tv_usec >= 1000000 in it_value → EINVAL");
+
+    nv = (struct itimerval){{0, 1000000}, {1, 0}};
+    errno = 0;
+    rc = raw_setitimer(ITIMER_REAL, &nv, NULL);
+    TEST_ASSERT(rc == -1 && errno == EINVAL,
+                "tv_usec >= 1000000 in it_interval → EINVAL");
+}
+
+static void test_einval_bad_which(void) {
+    struct itimerval nv = {{0, 0}, {1, 0}};
+    errno = 0;
+    int rc = raw_setitimer(99, &nv, NULL);
+    TEST_ASSERT(rc == -1 && errno == EINVAL, "bad which → EINVAL");
+}
+
+static void test_efault_bad_old_value(void) {
+    // Bad old_value pointer with a valid new_value: Linux returns EFAULT but
+    // the timer state IS still mutated (kernel arms before writing old_value).
+    // Verified by host probe on kernel 6.6: rc=-1, errno=EFAULT, post-state
+    // shows the requested it_value ~5s remaining.
+    clear_alarm();
+    struct itimerval nv = {{0, 0}, {5, 0}};
+    errno = 0;
+    int rc = raw_setitimer(ITIMER_REAL, &nv,
+                           (struct itimerval *)(uintptr_t)0x1);
+    TEST_ASSERT(rc == -1 && errno == EFAULT, "bad old_value → EFAULT");
+
+    struct itimerval gv;
+    TEST_ASSERT(raw_getitimer(ITIMER_REAL, &gv) == 0, "getitimer after EFAULT");
+    long us = (long)gv.it_value.tv_sec * 1000000L + (long)gv.it_value.tv_usec;
+    TEST_ASSERT(us > 0 && us <= 5 * 1000000L,
+                "timer was armed before EFAULT write (state mutated, Linux quirk)");
+    clear_alarm();
+}
+
+static void test_alarm_setitimer_share_state(void) {
+    // alarm(2) and setitimer(ITIMER_REAL, ...) share the same per-process
+    // timer; calls to one must be observable through the other. Verified by
+    // host probe on kernel 6.6 (setitimer(7s) → alarm(0) returns 7;
+    // alarm(10) → setitimer(&old) reports old.it_value ≈ 10s).
+    clear_alarm();
+
+    // Direction 1: setitimer arms; alarm(0) cancels and returns the previous
+    // remaining (rounded up to whole seconds).
+    struct itimerval nv = {{0, 0}, {7, 0}};
+    TEST_ASSERT(raw_setitimer(ITIMER_REAL, &nv, NULL) == 0, "setitimer arm");
+    unsigned int via_alarm = alarm(0);
+    TEST_ASSERT(via_alarm > 0 && via_alarm <= 7,
+                "alarm(0) returns setitimer's remaining seconds, rounded up");
+
+    // Direction 2: alarm arms; setitimer(&old) reports the previous remaining
+    // in old.it_value with it_interval == 0.
+    clear_alarm();
+    TEST_ASSERT(alarm(10) == 0, "alarm(10) on cleared state returns 0");
+    struct itimerval nv2 = {{0, 0}, {3, 0}};
+    struct itimerval old;
+    memset(&old, 0xff, sizeof(old));
+    TEST_ASSERT(raw_setitimer(ITIMER_REAL, &nv2, &old) == 0,
+                "setitimer over alarm-armed state");
+    long us = (long)old.it_value.tv_sec * 1000000L + (long)old.it_value.tv_usec;
+    TEST_ASSERT(us > 0 && us <= 10 * 1000000L,
+                "old.it_value reflects prior alarm(10)");
+    TEST_ASSERT(old.it_interval.tv_sec == 0 && old.it_interval.tv_usec == 0,
+                "old.it_interval zero (alarm() never sets an interval)");
+    clear_alarm();
+}
+
+static void test_efault_null_new_value(void) {
+    errno = 0;
+    int rc = raw_setitimer(ITIMER_REAL, NULL, NULL);
+    // Linux: setitimer(which, NULL, NULL) is treated as "disarm" (per man page,
+    // "this is treated as being equivalent to a call in which the new_value
+    // fields are zero"). So no error. Verify our test asserts what Linux does.
+    TEST_ASSERT(rc == 0, "setitimer with NULL new_value treated as disarm (Linux quirk)");
+}
+
+int main(void) {
+    printf("setitimer tests starting...\n");
+    test_arm_single_shot();
+    test_disarm();
+    test_old_value_returns_previous();
+    test_old_value_unarmed_returns_zero();
+    test_einval_usec_out_of_range();
+    test_einval_bad_which();
+    test_efault_bad_old_value();
+    test_efault_null_new_value();
+    test_alarm_setitimer_share_state();
+    clear_alarm();
+    printf("All setitimer tests passed.\n");
+    return 0;
+}

--- a/litebox_runner_linux_userland/tests/setitimer.c
+++ b/litebox_runner_linux_userland/tests/setitimer.c
@@ -7,24 +7,9 @@
 // contract is exercised. Uses syscall(SYS_setitimer, ...) directly to hit the
 // raw kernel surface that LiteBox intercepts.
 
-#define _GNU_SOURCE
-#include <errno.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <sys/syscall.h>
-#include <sys/time.h>
-#include <unistd.h>
+#include "helpers.h"
 
-#define TEST_ASSERT(cond, msg)                                                \
-    do {                                                                      \
-        if (!(cond)) {                                                        \
-            fprintf(stderr, "FAIL: %s (line %d): %s (errno=%d: %s)\n",        \
-                    __func__, __LINE__, msg, errno, strerror(errno));         \
-            exit(1);                                                          \
-        }                                                                     \
-    } while (0)
+#include <stdint.h>
 
 static int raw_setitimer(int which, const struct itimerval *new_value,
                          struct itimerval *old_value) {
@@ -50,7 +35,7 @@ static void test_arm_single_shot(void) {
     struct itimerval gv;
     memset(&gv, 0, sizeof(gv));
     TEST_ASSERT(raw_getitimer(ITIMER_REAL, &gv) == 0, "getitimer after arm");
-    long total_us = (long)gv.it_value.tv_sec * 1000000L + (long)gv.it_value.tv_usec;
+    long total_us = itimer_value_us(&gv);
     TEST_ASSERT(total_us > 0 && total_us <= 10 * 1000000L,
                 "it_value in (0, 10s]");
     TEST_ASSERT(gv.it_interval.tv_sec == 0 && gv.it_interval.tv_usec == 0,
@@ -75,6 +60,24 @@ static void test_disarm(void) {
                 "it_interval zero after disarm");
 }
 
+static void test_disarm_ignores_interval(void) {
+    struct itimerval nv = {{0, 0}, {10, 0}};
+    TEST_ASSERT(raw_setitimer(ITIMER_REAL, &nv, NULL) == 0, "arm precondition");
+
+    struct itimerval disarm = {{1, 0}, {0, 0}};
+    TEST_ASSERT(raw_setitimer(ITIMER_REAL, &disarm, NULL) == 0,
+                "disarm with nonzero interval success");
+
+    struct itimerval gv;
+    memset(&gv, 0xff, sizeof(gv));
+    TEST_ASSERT(raw_getitimer(ITIMER_REAL, &gv) == 0,
+                "getitimer after interval-only disarm");
+    TEST_ASSERT(gv.it_value.tv_sec == 0 && gv.it_value.tv_usec == 0,
+                "it_value zero after interval-only disarm");
+    TEST_ASSERT(gv.it_interval.tv_sec == 0 && gv.it_interval.tv_usec == 0,
+                "it_interval zero after interval-only disarm");
+}
+
 static void test_old_value_returns_previous(void) {
     // Set a 10s timer, then replace with a 5s timer and capture old_value.
     clear_alarm();
@@ -86,7 +89,7 @@ static void test_old_value_returns_previous(void) {
     memset(&old, 0xff, sizeof(old));
     TEST_ASSERT(raw_setitimer(ITIMER_REAL, &second, &old) == 0, "replace returns old");
 
-    long old_us = (long)old.it_value.tv_sec * 1000000L + (long)old.it_value.tv_usec;
+    long old_us = itimer_value_us(&old);
     TEST_ASSERT(old_us > 0 && old_us <= 10 * 1000000L,
                 "old it_value reflects first arm (<= 10s)");
     TEST_ASSERT(old.it_interval.tv_sec == 0 && old.it_interval.tv_usec == 0,
@@ -95,7 +98,7 @@ static void test_old_value_returns_previous(void) {
     // Replacement should be active now.
     struct itimerval gv;
     TEST_ASSERT(raw_getitimer(ITIMER_REAL, &gv) == 0, "getitimer after replace");
-    long now_us = (long)gv.it_value.tv_sec * 1000000L + (long)gv.it_value.tv_usec;
+    long now_us = itimer_value_us(&gv);
     TEST_ASSERT(now_us > 0 && now_us <= 5 * 1000000L,
                 "current it_value reflects replacement (<= 5s)");
     clear_alarm();
@@ -149,7 +152,7 @@ static void test_efault_bad_old_value(void) {
 
     struct itimerval gv;
     TEST_ASSERT(raw_getitimer(ITIMER_REAL, &gv) == 0, "getitimer after EFAULT");
-    long us = (long)gv.it_value.tv_sec * 1000000L + (long)gv.it_value.tv_usec;
+    long us = itimer_value_us(&gv);
     TEST_ASSERT(us > 0 && us <= 5 * 1000000L,
                 "timer was armed before EFAULT write (state mutated, Linux quirk)");
     clear_alarm();
@@ -179,7 +182,7 @@ static void test_alarm_setitimer_share_state(void) {
     memset(&old, 0xff, sizeof(old));
     TEST_ASSERT(raw_setitimer(ITIMER_REAL, &nv2, &old) == 0,
                 "setitimer over alarm-armed state");
-    long us = (long)old.it_value.tv_sec * 1000000L + (long)old.it_value.tv_usec;
+    long us = itimer_value_us(&old);
     TEST_ASSERT(us > 0 && us <= 10 * 1000000L,
                 "old.it_value reflects prior alarm(10)");
     TEST_ASSERT(old.it_interval.tv_sec == 0 && old.it_interval.tv_usec == 0,
@@ -200,6 +203,7 @@ int main(void) {
     printf("setitimer tests starting...\n");
     test_arm_single_shot();
     test_disarm();
+    test_disarm_ignores_interval();
     test_old_value_returns_previous();
     test_old_value_unarmed_returns_zero();
     test_einval_usec_out_of_range();

--- a/litebox_shim_linux/Cargo.toml
+++ b/litebox_shim_linux/Cargo.toml
@@ -25,6 +25,7 @@ default = ["platform_linux_userland"]
 platform_linux_userland = ["litebox_platform_multiplex/platform_linux_userland_with_linux_syscall"]
 platform_windows_userland = ["litebox_platform_multiplex/platform_windows_userland"]
 platform_linux_snp = ["litebox_platform_multiplex/platform_linux_snp"]
+alarm_fallback = []
 
 [dev-dependencies]
 spin = { version = "0.9.8", default-features = false, features = ["spin_mutex"] }

--- a/litebox_shim_linux/src/lib.rs
+++ b/litebox_shim_linux/src/lib.rs
@@ -1021,6 +1021,15 @@ impl<FS: ShimFS> Task<FS> {
             SyscallRequest::Sigaltstack { ss, old_ss } => self.sys_sigaltstack(ss, old_ss, ctx),
             SyscallRequest::Alarm { seconds } => syscall!(sys_alarm(seconds)),
             SyscallRequest::Pause => syscall!(sys_pause()),
+            SyscallRequest::GetITimer { which, curr_value } => curr_value
+                .write_at_offset(0, self.sys_getitimer(which))
+                .ok_or(Errno::EFAULT)
+                .map(|()| 0),
+            SyscallRequest::SetITimer {
+                which,
+                new_value,
+                old_value,
+            } => syscall!(sys_setitimer(which, new_value, old_value)),
             _ => {
                 log_unsupported!("{request:?}");
                 Err(Errno::ENOSYS)

--- a/litebox_shim_linux/src/lib.rs
+++ b/litebox_shim_linux/src/lib.rs
@@ -1021,10 +1021,9 @@ impl<FS: ShimFS> Task<FS> {
             SyscallRequest::Sigaltstack { ss, old_ss } => self.sys_sigaltstack(ss, old_ss, ctx),
             SyscallRequest::Alarm { seconds } => syscall!(sys_alarm(seconds)),
             SyscallRequest::Pause => syscall!(sys_pause()),
-            SyscallRequest::GetITimer { which, curr_value } => curr_value
-                .write_at_offset(0, self.sys_getitimer(which))
-                .ok_or(Errno::EFAULT)
-                .map(|()| 0),
+            SyscallRequest::GetITimer { which, curr_value } => {
+                syscall!(sys_getitimer(which, curr_value))
+            }
             SyscallRequest::SetITimer {
                 which,
                 new_value,

--- a/litebox_shim_linux/src/syscalls/process.rs
+++ b/litebox_shim_linux/src/syscalls/process.rs
@@ -25,7 +25,8 @@ use litebox::platform::{RawMutPointer as _, TimerHandle, TimerProvider};
 use litebox::sync::Mutex;
 use litebox::utils::TruncateExt as _;
 use litebox_common_linux::{
-    ArchPrctlArg, CloneFlags, FutexArgs, PrctlArg, TimeParam, errno::Errno,
+    ArchPrctlArg, CloneFlags, FutexArgs, IntervalTimer, ItimerVal, PrctlArg, TimeParam,
+    errno::Errno,
 };
 use litebox_platform_multiplex::Platform;
 
@@ -134,6 +135,20 @@ pub(crate) struct Alarm {
     pub(crate) handle: Option<<Platform as litebox::platform::TimerProvider>::TimerHandle>,
     /// The deadline for the alarm.
     pub(crate) deadline: Option<<Platform as litebox::platform::TimeProvider>::Instant>,
+}
+
+impl Alarm {
+    /// Returns the time remaining until [`Self::deadline`], or zero if the
+    /// alarm is not armed or its deadline has already passed.
+    pub(crate) fn remaining(
+        &self,
+        now: <Platform as litebox::platform::TimeProvider>::Instant,
+    ) -> Duration {
+        self.deadline
+            .as_ref()
+            .and_then(|d| d.checked_duration_since(&now))
+            .unwrap_or(Duration::ZERO)
+    }
 }
 
 /// The locked portion of the process state.
@@ -1129,25 +1144,24 @@ impl<FS: ShimFS> Task<FS> {
     ///
     /// The alarm is per-process: all threads share the same alarm timer.
     pub(crate) fn sys_alarm(&self, seconds: u32) -> Result<u32, Errno> {
+        let prev = self.arm_real_timer(Duration::from_secs(u64::from(seconds)))?;
+        // Round remaining time up to whole seconds, saturating to u32::MAX.
+        if prev.is_zero() {
+            Ok(0)
+        } else {
+            let extra = u64::from(prev.subsec_nanos() > 0);
+            Ok(u32::try_from(prev.as_secs() + extra).unwrap_or(u32::MAX))
+        }
+    }
+
+    /// Arm or disarm the per-process `ITIMER_REAL` timer (the state `alarm()`
+    /// and `setitimer(ITIMER_REAL, ...)` both manipulate). Returns the raw
+    /// `Duration` remaining on the previous arming; zero means "was not
+    /// armed". `delay = 0` disarms.
+    fn arm_real_timer(&self, delay: Duration) -> Result<Duration, Errno> {
         let mut alarm = self.process().alarm_timer.lock();
         let now = self.global.platform.now();
-        // Get remaining seconds from any previous alarm (rounded up to second).
-        let remaining = match alarm.deadline {
-            Some(deadline) => {
-                match deadline.checked_duration_since(&now) {
-                    Some(dur) if !dur.is_zero() => {
-                        let secs = dur.as_secs();
-                        let extra = u64::from(dur.subsec_nanos() > 0);
-                        // Saturate to u32::MAX to avoid truncation.
-                        u32::try_from(secs + extra).unwrap_or(u32::MAX)
-                    }
-                    _ => 0, // Deadline already passed or is now.
-                }
-            }
-            None => 0,
-        };
-
-        let delay = Duration::from_secs(u64::from(seconds));
+        let prev = alarm.remaining(now);
         let new_deadline = if delay.is_zero() {
             None
         } else {
@@ -1159,9 +1173,7 @@ impl<FS: ShimFS> Task<FS> {
                 .platform
                 .create_timer(litebox_common_linux::signal::Signal::SIGALRM)
             {
-                Ok(handle) => {
-                    alarm.handle = Some(handle);
-                }
+                Ok(handle) => alarm.handle = Some(handle),
                 Err(litebox::platform::TimerCreationError::Unsupported) => {}
                 Err(_) => unimplemented!(),
             }
@@ -1170,8 +1182,60 @@ impl<FS: ShimFS> Task<FS> {
             handle.set_timer(delay);
         }
         alarm.deadline = new_deadline;
+        Ok(prev)
+    }
 
-        Ok(remaining)
+    /// Handle syscall `setitimer`.
+    pub(crate) fn sys_setitimer(
+        &self,
+        which: IntervalTimer,
+        new_value: Option<ConstPtr<ItimerVal>>,
+        old_value: Option<MutPtr<ItimerVal>>,
+    ) -> Result<(), Errno> {
+        let new = match new_value {
+            Some(ptr) => ptr.read_at_offset(0).ok_or(Errno::EFAULT)?,
+            // Linux supports NULL `new_value` but says it would be removed in the future.
+            None => ItimerVal::default(),
+        };
+        // tv_usec range check is performed by `Duration::try_from(TimeVal)`.
+        let new_interval = Duration::try_from(new.it_interval())?;
+        let new_remaining = Duration::try_from(new.it_value())?;
+
+        let prev = match which {
+            IntervalTimer::Real => {
+                // TODO: support periodic timers
+                if !new_interval.is_zero() {
+                    log_unsupported!("setitimer: nonzero it_interval not supported");
+                    return Err(Errno::ENOSYS);
+                }
+                ItimerVal::single_shot(self.arm_real_timer(new_remaining)?)
+            }
+            IntervalTimer::Virtual | IntervalTimer::Prof => {
+                log_unsupported!("setitimer: ITIMER_VIRTUAL/PROF not supported");
+                return Err(Errno::ENOSYS);
+            }
+        };
+
+        if let Some(out) = old_value {
+            out.write_at_offset(0, prev).ok_or(Errno::EFAULT)?;
+        }
+        Ok(())
+    }
+
+    /// Handle syscall `getitimer`.
+    pub(crate) fn sys_getitimer(&self, which: IntervalTimer) -> ItimerVal {
+        let value = match which {
+            IntervalTimer::Real => {
+                let alarm = self.process().alarm_timer.lock();
+                let now = self.global.platform.now();
+                alarm.remaining(now)
+            }
+            IntervalTimer::Virtual | IntervalTimer::Prof => {
+                log_unsupported!("getitimer: ITIMER_VIRTUAL/PROF not supported");
+                Duration::ZERO
+            }
+        };
+        ItimerVal::single_shot(value)
     }
 
     /// Handle syscall `pause`.

--- a/litebox_shim_linux/src/syscalls/process.rs
+++ b/litebox_shim_linux/src/syscalls/process.rs
@@ -1203,12 +1203,15 @@ impl<FS: ShimFS> Task<FS> {
 
         let prev = match which {
             IntervalTimer::Real => {
-                // TODO: support periodic timers
-                if !new_interval.is_zero() {
+                if new_remaining.is_zero() {
+                    ItimerVal::single_shot(self.arm_real_timer(Duration::ZERO)?)
+                } else if !new_interval.is_zero() {
+                    // TODO: support periodic timers
                     log_unsupported!("setitimer: nonzero it_interval not supported");
                     return Err(Errno::ENOSYS);
+                } else {
+                    ItimerVal::single_shot(self.arm_real_timer(new_remaining)?)
                 }
-                ItimerVal::single_shot(self.arm_real_timer(new_remaining)?)
             }
             IntervalTimer::Virtual | IntervalTimer::Prof => {
                 log_unsupported!("setitimer: ITIMER_VIRTUAL/PROF not supported");
@@ -1223,7 +1226,11 @@ impl<FS: ShimFS> Task<FS> {
     }
 
     /// Handle syscall `getitimer`.
-    pub(crate) fn sys_getitimer(&self, which: IntervalTimer) -> ItimerVal {
+    pub(crate) fn sys_getitimer(
+        &self,
+        which: IntervalTimer,
+        curr_value: MutPtr<ItimerVal>,
+    ) -> Result<(), Errno> {
         let value = match which {
             IntervalTimer::Real => {
                 let alarm = self.process().alarm_timer.lock();
@@ -1235,7 +1242,9 @@ impl<FS: ShimFS> Task<FS> {
                 Duration::ZERO
             }
         };
-        ItimerVal::single_shot(value)
+        curr_value
+            .write_at_offset(0, ItimerVal::single_shot(value))
+            .ok_or(Errno::EFAULT)
     }
 
     /// Handle syscall `pause`.

--- a/litebox_shim_linux/src/syscalls/process.rs
+++ b/litebox_shim_linux/src/syscalls/process.rs
@@ -1154,8 +1154,7 @@ impl<FS: ShimFS> Task<FS> {
         }
     }
 
-    /// Arm or disarm the per-process `ITIMER_REAL` timer (the state `alarm()`
-    /// and `setitimer(ITIMER_REAL, ...)` both manipulate). Returns the raw
+    /// Arm or disarm the per-process `ITIMER_REAL` timer. Returns the raw
     /// `Duration` remaining on the previous arming; zero means "was not
     /// armed". `delay = 0` disarms.
     fn arm_real_timer(&self, delay: Duration) -> Result<Duration, Errno> {

--- a/litebox_shim_linux/src/syscalls/signal/mod.rs
+++ b/litebox_shim_linux/src/syscalls/signal/mod.rs
@@ -613,6 +613,8 @@ impl<FS: ShimFS> Task<FS> {
     /// enqueue `SIGALRM`.
     ///
     /// Note this is a fallback in case the platform does not support timers.
+    #[cfg(feature = "alarm_fallback")]
+    #[inline]
     pub(crate) fn check_alarm_deadline(&self) {
         use litebox::platform::TimeProvider as _;
         let mut alarm = self.process().alarm_timer.lock();
@@ -621,7 +623,6 @@ impl<FS: ShimFS> Task<FS> {
             // to check the deadline here.
             return;
         }
-
         if alarm
             .deadline
             .is_some_and(|deadline| self.global.platform.now() >= deadline)

--- a/litebox_shim_linux/src/wait.rs
+++ b/litebox_shim_linux/src/wait.rs
@@ -41,6 +41,7 @@ impl<FS: ShimFS> Task<FS> {
             self.global.platform.take_pending_signals(|signal| {
                 self.queue_signals(signal);
             });
+            #[cfg(feature = "alarm_fallback")]
             self.check_alarm_deadline();
             self.process_signals(ctx);
             !self.is_exiting()
@@ -54,6 +55,7 @@ impl<FS: ShimFS> litebox::event::wait::CheckForInterrupt for Task<FS> {
         self.global.platform.take_pending_signals(|sig| {
             self.queue_signals(sig);
         });
+        #[cfg(feature = "alarm_fallback")]
         self.check_alarm_deadline();
         self.is_exiting() || self.has_pending_signals()
     }


### PR DESCRIPTION
Implement syscalls `setitimer` and `getitime`, but `setitimer` does not support periodic timers yet (i.e., it is equivalent to `alarm` for now).

Also add a new feature `alarm_fallback` to enable/disable the fallback alarm check.