### PR TITLE
Windows PE rewriter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1497,6 +1497,7 @@ version = "0.1.0"
 dependencies = [
  "object",
  "thiserror",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1708,6 +1709,7 @@ dependencies = [
  "litebox_platform_multiplex",
  "litebox_platform_windows_userland",
  "litebox_shim_windows",
+ "litebox_syscall_rewriter",
  "litebox_util_log",
  "tracing-subscriber",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1711,6 +1711,7 @@ dependencies = [
  "litebox_shim_windows",
  "litebox_syscall_rewriter",
  "litebox_util_log",
+ "tar",
  "tracing-subscriber",
 ]
 

--- a/litebox_common_windows/Cargo.toml
+++ b/litebox_common_windows/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 object = { version = "0.36.7", default-features = false, features = ["pe", "read_core"] }
 thiserror = { version = "2.0.6", default-features = false }
+zerocopy = { version = "0.8", features = ["derive"] }
 
 [lints]
 workspace = true

--- a/litebox_common_windows/src/loader.rs
+++ b/litebox_common_windows/src/loader.rs
@@ -8,6 +8,7 @@
 use alloc::vec::Vec;
 use core::cmp;
 use core::mem::size_of;
+use zerocopy::{FromBytes, IntoBytes};
 
 use object::endian::LittleEndian as LE;
 use object::pe;
@@ -24,11 +25,12 @@ const MAX_SECTIONS: usize = 96;
 #[derive(Debug)]
 pub struct PeParsedFile {
     /// Basic image metadata from the PE optional and COFF headers.
-    pub image: PeImageInfo,
+    image: PeImageInfo,
     /// Raw PE section headers in file order.
-    pub sections: Vec<pe::ImageSectionHeader>,
+    sections: Vec<pe::ImageSectionHeader>,
     /// Data directory entries indexed by `IMAGE_DIRECTORY_ENTRY_*`.
-    pub data_directories: Vec<PeDataDirectory>,
+    data_directories: Vec<PeDataDirectory>,
+    trampoline: Option<PeTrampolineInfo>,
 }
 
 /// Basic PE image metadata needed by the Windows shim loader.
@@ -56,6 +58,25 @@ pub struct MappingInfo {
     pub entry_point: usize,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PeTrampolineInfo {
+    rva: usize,
+    size: usize,
+    file_offset: u64,
+    syscall_entry_point: usize,
+}
+
+#[repr(C, packed)]
+#[derive(Debug, Clone, Copy, FromBytes, IntoBytes)]
+struct TrampolineHeader64 {
+    magic: [u8; 8],
+    file_offset: u64,
+    rva: u64,
+    trampoline_size: u64,
+}
+
+const TRAMPOLINE_MAGIC: [u8; 8] = *b"LITEBOX0";
+
 /// A PE data directory entry.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PeDataDirectory {
@@ -72,6 +93,12 @@ pub enum PeParseError<E> {
     /// The file is not a supported Windows executable image.
     #[error("unsupported PE image")]
     UnsupportedImage,
+    /// The LiteBox trampoline footer is malformed.
+    #[error("bad LiteBox trampoline")]
+    BadTrampoline,
+    /// The LiteBox trampoline footer has an unsupported version.
+    #[error("invalid LiteBox trampoline version")]
+    BadTrampolineVersion,
     /// A PE field overflowed the host representation used by this parser.
     #[error("PE field overflow")]
     Overflow,
@@ -136,6 +163,7 @@ impl PeParsedFile {
             image,
             sections,
             data_directories,
+            trampoline: None,
         })
     }
 
@@ -159,13 +187,15 @@ impl PeParsedFile {
         if image_size == 0 {
             return Err(PeLoadError::InvalidImage);
         }
+        let mapping_size = self.mapping_size::<M::Error>(image_size)?;
 
         let base_addr = mapper
-            .reserve(preferred_base, image_size, PAGE_SIZE)
+            .reserve(preferred_base, mapping_size, PAGE_SIZE)
             .map_err(PeLoadError::Map)?;
         let image_end = checked_add_invalid!(base_addr, image_size)?;
 
         let headers_size = self.image.size_of_headers;
+
         if headers_size > image_size {
             return Err(PeLoadError::InvalidImage);
         }
@@ -246,6 +276,10 @@ impl PeParsedFile {
                 .map_err(PeLoadError::Map)?;
         }
 
+        if self.trampoline.is_some() {
+            self.load_trampoline(mapper, mem, base_addr)?;
+        }
+
         let entry_point = checked_add!(
             base_addr,
             self.image.entry_point_rva,
@@ -254,9 +288,133 @@ impl PeParsedFile {
 
         Ok(MappingInfo {
             base_addr,
-            image_size,
+            image_size: mapping_size,
             entry_point,
         })
+    }
+
+    /// Parse the LiteBox PE trampoline footer, if present.
+    ///
+    /// The trampoline RVA is relative to the image base. The first pointer-sized
+    /// word of the mapped trampoline is patched with `syscall_entry_point` when
+    /// the image is loaded.
+    #[expect(
+        clippy::missing_panics_doc,
+        reason = "cannot panic: array slices are always the correct size"
+    )]
+    pub fn parse_trampoline<F: ReadAt>(
+        &mut self,
+        file: &mut F,
+        syscall_entry_point: usize,
+    ) -> Result<(), PeParseError<F::Error>> {
+        if syscall_entry_point == 0 {
+            return Ok(());
+        }
+
+        let file_size = file.size().map_err(PeParseError::Io)?;
+        let header_size = size_of::<TrampolineHeader64>();
+        if file_size < header_size as u64 {
+            return Ok(());
+        }
+
+        let header_offset = file_size - header_size as u64;
+        let mut header_buf = [0u8; size_of::<TrampolineHeader64>()];
+        file.read_at(header_offset, &mut header_buf)
+            .map_err(PeParseError::Io)?;
+        let header = TrampolineHeader64::read_from_bytes(&header_buf)
+            .map_err(|_| PeParseError::BadTrampoline)?;
+        let magic = header.magic;
+        if magic != TRAMPOLINE_MAGIC {
+            if &magic[0..7] == b"LITEBOX" {
+                return Err(PeParseError::BadTrampolineVersion);
+            }
+            return Ok(());
+        }
+
+        let file_offset = header.file_offset;
+        let rva = usize_from_u64(header.rva)?;
+        let trampoline_size = usize_from_u64(header.trampoline_size)?;
+        let image_size = checked_next_multiple_of!(
+            self.image.size_of_image,
+            PAGE_SIZE,
+            PeParseError::BadTrampoline
+        )?;
+
+        if trampoline_size == 0
+            || !file_offset.is_multiple_of(PAGE_SIZE as u64)
+            || !rva.is_multiple_of(PAGE_SIZE)
+            || rva < image_size
+            || file_offset
+                .checked_add(trampoline_size as u64)
+                .ok_or(PeParseError::BadTrampoline)?
+                != header_offset
+        {
+            return Err(PeParseError::BadTrampoline);
+        }
+
+        self.trampoline = Some(PeTrampolineInfo {
+            rva,
+            size: trampoline_size,
+            file_offset,
+            syscall_entry_point,
+        });
+        Ok(())
+    }
+
+    fn mapping_size<E>(&self, image_size: usize) -> Result<usize, PeLoadError<E>> {
+        let Some(trampoline) = &self.trampoline else {
+            return Ok(image_size);
+        };
+
+        trampoline
+            .rva
+            .checked_add(trampoline.size)
+            .and_then(|trampoline_end| trampoline_end.checked_next_multiple_of(PAGE_SIZE))
+            .map(|trampoline_end| image_size.max(trampoline_end))
+            .ok_or(PeLoadError::InvalidImage)
+    }
+
+    fn load_trampoline<M: MapMemory>(
+        &self,
+        mapper: &mut M,
+        mem: &mut impl AccessMemory,
+        base_addr: usize,
+    ) -> Result<(), PeLoadError<M::Error>> {
+        let trampoline = self.trampoline.as_ref().unwrap();
+        let trampoline_start = base_addr
+            .checked_add(trampoline.rva)
+            .ok_or(PeLoadError::InvalidImage)?;
+        let trampoline_size =
+            checked_next_multiple_of!(trampoline.size, PAGE_SIZE, PeLoadError::InvalidImage)?;
+        mapper
+            .map_file(
+                trampoline_start,
+                trampoline_size,
+                trampoline.file_offset,
+                &Protection {
+                    read: true,
+                    write: true,
+                    execute: false,
+                },
+            )
+            .map_err(PeLoadError::Map)?;
+
+        mem.write(
+            trampoline_start,
+            &trampoline.syscall_entry_point.to_ne_bytes(),
+        )?;
+
+        mapper
+            .protect(
+                trampoline_start,
+                trampoline_size,
+                &Protection {
+                    read: true,
+                    write: false,
+                    execute: true,
+                },
+            )
+            .map_err(PeLoadError::Map)
     }
 
     fn apply_base_relocations<E>(

--- a/litebox_common_windows/src/loader.rs
+++ b/litebox_common_windows/src/loader.rs
@@ -636,12 +636,6 @@ fn parse_headers<F: ReadAt>(
             }
         })
         .collect();
-    for dir in &data_directories {
-        let end = checked_add!(dir.virtual_address, dir.size, PeParseError::Overflow)?;
-        if (end as usize) > image.size_of_image {
-            return Err(PeParseError::UnsupportedImage);
-        }
-    }
 
     // Section headers sit at `nt_offset + 4 (signature) + size_of::<ImageFileHeader>() + size_of_optional_header`.
     let num_sections = nt.file_header.number_of_sections.get(LE) as usize;

--- a/litebox_common_windows/src/loader.rs
+++ b/litebox_common_windows/src/loader.rs
@@ -25,11 +25,11 @@ const MAX_SECTIONS: usize = 96;
 #[derive(Debug)]
 pub struct PeParsedFile {
     /// Basic image metadata from the PE optional and COFF headers.
-    image: PeImageInfo,
+    pub image: PeImageInfo,
     /// Raw PE section headers in file order.
     sections: Vec<pe::ImageSectionHeader>,
     /// Data directory entries indexed by `IMAGE_DIRECTORY_ENTRY_*`.
-    data_directories: Vec<PeDataDirectory>,
+    pub data_directories: Vec<PeDataDirectory>,
     trampoline: Option<PeTrampolineInfo>,
 }
 
@@ -167,6 +167,12 @@ impl PeParsedFile {
         })
     }
 
+    /// Returns whether the image has a parsed LiteBox syscall trampoline.
+    #[must_use]
+    pub fn has_trampoline(&self) -> bool {
+        self.trampoline.is_some()
+    }
+
     /// Load the PE image into memory.
     ///
     /// This maps PE headers and sections into their image locations,
@@ -177,6 +183,18 @@ impl PeParsedFile {
         &self,
         mapper: &mut M,
         mem: &mut impl AccessMemory,
+    ) -> Result<MappingInfo, PeLoadError<M::Error>> {
+        self.load_with_writable_sections(mapper, mem, &[])
+    }
+
+    /// Load the PE image into memory, keeping selected sections writable.
+    ///
+    /// This is intended for target-specific loader data such as ntdll's `.mrdata`.
+    pub fn load_with_writable_sections<M: MapMemory>(
+        &self,
+        mapper: &mut M,
+        mem: &mut impl AccessMemory,
+        writable_section_names: &[&[u8]],
     ) -> Result<MappingInfo, PeLoadError<M::Error>> {
         let preferred_base = self.image.image_base;
         let image_size = checked_next_multiple_of!(
@@ -271,7 +289,7 @@ impl PeParsedFile {
                 .protect(
                     protect_start,
                     protect_end - protect_start,
-                    &Protection::from_section_characteristics(section.characteristics.get(LE)),
+                    &Protection::from_section(section, writable_section_names),
                 )
                 .map_err(PeLoadError::Map)?;
         }
@@ -298,10 +316,6 @@ impl PeParsedFile {
     /// The trampoline RVA is relative to the image base. The first pointer-sized
     /// word of the mapped trampoline is patched with `syscall_entry_point` when
     /// the image is loaded.
-    #[expect(
-        clippy::missing_panics_doc,
-        reason = "cannot panic: array slices are always the correct size"
-    )]
     pub fn parse_trampoline<F: ReadAt>(
         &mut self,
         file: &mut F,
@@ -768,8 +782,10 @@ pub trait MapMemory {
 
 /// Trait for reading and writing memory that has been mapped via [`MapMemory`].
 pub trait AccessMemory {
+    /// Read from memory.
     fn read(&mut self, address: usize, buf: &mut [u8]) -> Result<(), Fault>;
 
+    /// Write to memory.
     fn write(&mut self, address: usize, data: &[u8]) -> Result<(), Fault>;
 }
 
@@ -800,11 +816,29 @@ impl Protection {
         execute: false,
     };
 
-    fn from_section_characteristics(characteristics: u32) -> Self {
-        Self {
-            read: characteristics & pe::IMAGE_SCN_MEM_READ != 0,
-            write: characteristics & pe::IMAGE_SCN_MEM_WRITE != 0,
-            execute: characteristics & pe::IMAGE_SCN_MEM_EXECUTE != 0,
+    fn from_section(section: &pe::ImageSectionHeader, writable_section_names: &[&[u8]]) -> Self {
+        let characteristics = section.characteristics.get(LE);
+        let mut protection = Self {
+            read: characteristics & object::pe::IMAGE_SCN_MEM_READ != 0,
+            write: characteristics & object::pe::IMAGE_SCN_MEM_WRITE != 0,
+            execute: characteristics & object::pe::IMAGE_SCN_MEM_EXECUTE != 0,
+        };
+        if writable_section_names
+            .iter()
+            .any(|name| section_name_eq(section, name))
+        {
+            protection.write = true;
         }
+
+        protection
     }
+}
+
+fn section_name_eq(section: &pe::ImageSectionHeader, name: &[u8]) -> bool {
+    let end = section
+        .name
+        .iter()
+        .position(|byte| *byte == 0)
+        .unwrap_or(section.name.len());
+    &section.name[..end] == name
 }

--- a/litebox_runner_windows_userland/Cargo.toml
+++ b/litebox_runner_windows_userland/Cargo.toml
@@ -16,6 +16,7 @@ tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
 
 [dev-dependencies]
 litebox_syscall_rewriter = { version = "0.1.0", path = "../litebox_syscall_rewriter" }
+tar = "0.4"
 
 [lints]
 workspace = true

--- a/litebox_runner_windows_userland/Cargo.toml
+++ b/litebox_runner_windows_userland/Cargo.toml
@@ -14,5 +14,8 @@ litebox_shim_windows = { version = "0.1.0", path = "../litebox_shim_windows", de
 litebox_util_log = { version = "0.1.0", path = "../litebox_util_log", features = ["backend_tracing"] }
 tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
 
+[dev-dependencies]
+litebox_syscall_rewriter = { version = "0.1.0", path = "../litebox_syscall_rewriter" }
+
 [lints]
 workspace = true

--- a/litebox_runner_windows_userland/tests/run.rs
+++ b/litebox_runner_windows_userland/tests/run.rs
@@ -19,9 +19,15 @@ fn loads_minimal_pe_without_imports() {
         "Built rewritten no-import PE fixture at `{}`",
         pe_path.display()
     );
-
-    let tar_path = test_dir.join("no_import.tar");
-    create_tar_with_exe(&test_dir, &tar_path, "no_import.exe");
+    for dll_name in ["ntdll.dll", "kernel32.dll", "kernelbase.dll"] {
+        let dll_path = build_rewritten_system_dll(&test_dir, dll_name);
+        println!(
+            "Built rewritten {dll_name} fixture at `{}`",
+            dll_path.display()
+        );
+    }
+    let tar_path = std::path::PathBuf::from(env!("CARGO_TARGET_TMPDIR")).join("no_import.tar");
+    create_tar_with_dir(&test_dir, &tar_path);
 
     let mut command =
         std::process::Command::new(env!("CARGO_BIN_EXE_litebox_runner_windows_userland"));
@@ -154,22 +160,85 @@ fn nt_terminate_process_syscall_number() -> u32 {
     )
 }
 
-fn create_tar_with_exe(test_dir: &std::path::Path, tar_path: &std::path::Path, exe_name: &str) {
-    let output = std::process::Command::new("tar.exe")
-        .args([
-            "-cf",
-            tar_path.to_str().unwrap(),
-            "-C",
-            test_dir.to_str().unwrap(),
-            exe_name,
-        ])
-        .output()
-        .expect("failed to run tar.exe for the no-import Windows PE fixture");
+fn build_rewritten_system_dll(test_dir: &std::path::Path, dll_name: &str) -> std::path::PathBuf {
+    let system32_dir = test_dir.join("Windows").join("System32");
+    std::fs::create_dir_all(&system32_dir).unwrap();
+    let dll_path = system32_dir.join(dll_name);
+    let host_dll = std::fs::read(host_system32_dll_path(dll_name))
+        .unwrap_or_else(|error| panic!("failed to read host {dll_name}: {error}"));
+    let rewritten = match litebox_syscall_rewriter::rewrite_binary(&host_dll, None) {
+        Ok(rewritten) => rewritten,
+        Err(litebox_syscall_rewriter::Error::UnpatchableSyscalls(_)) => panic!(
+            "failed to rewrite host {dll_name}; required support: patch dense ntdll syscall stubs or provide a pre-rewritten guest DLL"
+        ),
+        Err(error) => panic!("failed to rewrite host {dll_name}: {error}"),
+    };
+    std::fs::write(&dll_path, rewritten).unwrap();
+    dll_path
+}
 
-    assert!(
-        output.status.success(),
-        "failed to create tar for no-import Windows PE fixture\nstdout:\n{}\nstderr:\n{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
+fn host_system32_dll_path(dll_name: &str) -> std::path::PathBuf {
+    std::env::var_os("SystemRoot")
+        .map_or_else(
+            || std::path::PathBuf::from(r"C:\Windows"),
+            std::path::PathBuf::from,
+        )
+        .join("System32")
+        .join(dll_name)
+}
+
+fn create_tar_with_dir(test_dir: &std::path::Path, tar_path: &std::path::Path) {
+    let output_file = std::fs::File::create(tar_path)
+        .expect("failed to create tar for the no-import Windows PE fixture");
+    let mut builder = tar::Builder::new(output_file);
+    append_regular_files_to_ustar(&mut builder, test_dir, test_dir);
+    builder
+        .finish()
+        .expect("failed to finalize tar for the no-import Windows PE fixture");
+}
+
+fn append_regular_files_to_ustar(
+    builder: &mut tar::Builder<std::fs::File>,
+    root: &std::path::Path,
+    dir: &std::path::Path,
+) {
+    for entry in std::fs::read_dir(dir).unwrap() {
+        let entry = entry.unwrap();
+        let path = entry.path();
+        if path.is_dir() {
+            append_regular_files_to_ustar(builder, root, &path);
+            continue;
+        }
+
+        // Avoid nesting tar files from previous runs into the fixture archive.
+        if path
+            .extension()
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("tar"))
+        {
+            continue;
+        }
+
+        let data = std::fs::read(&path).unwrap_or_else(|error| {
+            panic!("failed to read fixture file {}: {error}", path.display())
+        });
+        let mut header = tar::Header::new_ustar();
+        header.set_size(data.len() as u64);
+        header.set_mode(0o644);
+        header.set_uid(1000);
+        header.set_gid(1000);
+        header.set_mtime(0);
+        header.set_entry_type(tar::EntryType::Regular);
+        header.set_cksum();
+
+        let relative = path.strip_prefix(root).unwrap();
+        let relative = relative.to_string_lossy().replace('\\', "/");
+        builder
+            .append_data(&mut header, relative, data.as_slice())
+            .unwrap_or_else(|error| {
+                panic!(
+                    "failed to append fixture file {} to tar: {error}",
+                    path.display()
+                )
+            });
+    }
 }

--- a/litebox_runner_windows_userland/tests/run.rs
+++ b/litebox_runner_windows_userland/tests/run.rs
@@ -15,7 +15,10 @@ fn loads_minimal_pe_without_imports() {
     let test_dir = std::path::PathBuf::from(env!("CARGO_TARGET_TMPDIR")).join("no_import");
     std::fs::create_dir_all(&test_dir).unwrap();
     let pe_path = build_no_import_pe(&test_dir);
-    println!("Built no-import PE fixture at `{}`", pe_path.display());
+    println!(
+        "Built rewritten no-import PE fixture at `{}`",
+        pe_path.display()
+    );
 
     let tar_path = test_dir.join("no_import.tar");
     create_tar_with_exe(&test_dir, &tar_path, "no_import.exe");
@@ -43,6 +46,7 @@ fn loads_minimal_pe_without_imports() {
 
 fn build_no_import_pe(test_dir: &std::path::Path) -> std::path::PathBuf {
     let source_path = test_dir.join("no_import.rs");
+    let raw_exe_path = test_dir.join("no_import.raw.exe");
     let exe_path = test_dir.join("no_import.exe");
     let syscall_number = nt_terminate_process_syscall_number();
     println!("Using NtTerminateProcess syscall number `{syscall_number:#x}`");
@@ -66,7 +70,7 @@ fn build_no_import_pe(test_dir: &std::path::Path) -> std::path::PathBuf {
             "-C",
             "link-arg=/NODEFAULTLIB",
             "-o",
-            exe_path.to_str().unwrap(),
+            raw_exe_path.to_str().unwrap(),
         ])
         .output()
         .expect("failed to run rustc for the no-import Windows PE fixture");
@@ -77,6 +81,11 @@ fn build_no_import_pe(test_dir: &std::path::Path) -> std::path::PathBuf {
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
+
+    let rewritten =
+        litebox_syscall_rewriter::rewrite_binary(&std::fs::read(raw_exe_path).unwrap(), None)
+            .expect("failed to rewrite no-import Windows PE fixture");
+    std::fs::write(&exe_path, rewritten).unwrap();
     exe_path
 }
 

--- a/litebox_runner_windows_userland/tests/run.rs
+++ b/litebox_runner_windows_userland/tests/run.rs
@@ -13,6 +13,7 @@ unsafe extern "system" {
 #[test]
 fn loads_minimal_pe_without_imports() {
     let test_dir = std::path::PathBuf::from(env!("CARGO_TARGET_TMPDIR")).join("no_import");
+    let _ = std::fs::remove_dir_all(&test_dir);
     std::fs::create_dir_all(&test_dir).unwrap();
     let pe_path = build_no_import_pe(&test_dir);
     println!(
@@ -26,11 +27,19 @@ fn loads_minimal_pe_without_imports() {
             dll_path.display()
         );
     }
+    // ntdll's NLS init opens these locale tables before reaching the test's
+    // `NtTerminateProcess` syscall; copy them verbatim from the host.
+    for nls_name in ["c_1252.nls", "c_437.nls", "c_10000.nls", "locale.nls"] {
+        let nls_path = copy_host_system32_file(&test_dir, nls_name);
+        println!("Copied {nls_name} fixture at `{}`", nls_path.display());
+    }
     let tar_path = std::path::PathBuf::from(env!("CARGO_TARGET_TMPDIR")).join("no_import.tar");
     create_tar_with_dir(&test_dir, &tar_path);
 
     let mut command =
         std::process::Command::new(env!("CARGO_BIN_EXE_litebox_runner_windows_userland"));
+    // Verbose log for failure triage; not load-bearing for any assertion.
+    command.env("LITEBOX_LOG", "debug");
     command.args([
         "--initial-files",
         tar_path.to_str().unwrap(),
@@ -161,10 +170,8 @@ fn nt_terminate_process_syscall_number() -> u32 {
 }
 
 fn build_rewritten_system_dll(test_dir: &std::path::Path, dll_name: &str) -> std::path::PathBuf {
-    let system32_dir = test_dir.join("Windows").join("System32");
-    std::fs::create_dir_all(&system32_dir).unwrap();
-    let dll_path = system32_dir.join(dll_name);
-    let host_dll = std::fs::read(host_system32_dll_path(dll_name))
+    let dll_path = fixture_system32_path(test_dir, dll_name);
+    let host_dll = std::fs::read(host_system32_file_path(dll_name))
         .unwrap_or_else(|error| panic!("failed to read host {dll_name}: {error}"));
     let rewritten = match litebox_syscall_rewriter::rewrite_binary(&host_dll, None) {
         Ok(rewritten) => rewritten,
@@ -177,14 +184,27 @@ fn build_rewritten_system_dll(test_dir: &std::path::Path, dll_name: &str) -> std
     dll_path
 }
 
-fn host_system32_dll_path(dll_name: &str) -> std::path::PathBuf {
+fn copy_host_system32_file(test_dir: &std::path::Path, file_name: &str) -> std::path::PathBuf {
+    let fixture_path = fixture_system32_path(test_dir, file_name);
+    std::fs::copy(host_system32_file_path(file_name), &fixture_path)
+        .unwrap_or_else(|error| panic!("failed to copy host {file_name}: {error}"));
+    fixture_path
+}
+
+fn fixture_system32_path(test_dir: &std::path::Path, file_name: &str) -> std::path::PathBuf {
+    let system32_dir = test_dir.join("Windows").join("System32");
+    std::fs::create_dir_all(&system32_dir).unwrap();
+    system32_dir.join(file_name)
+}
+
+fn host_system32_file_path(file_name: &str) -> std::path::PathBuf {
     std::env::var_os("SystemRoot")
         .map_or_else(
             || std::path::PathBuf::from(r"C:\Windows"),
             std::path::PathBuf::from,
         )
         .join("System32")
-        .join(dll_name)
+        .join(file_name)
 }
 
 fn create_tar_with_dir(test_dir: &std::path::Path, tar_path: &std::path::Path) {

--- a/litebox_shim_windows/src/lib.rs
+++ b/litebox_shim_windows/src/lib.rs
@@ -16,28 +16,17 @@ use alloc::vec::Vec;
 use core::marker::PhantomData;
 use core::sync::atomic::{AtomicI32, Ordering};
 
-use litebox::fd::TypedFd;
-use litebox::fs::{Mode, OFlags};
+use litebox::LiteBox;
 use litebox::mm::PageManager;
-use litebox::mm::linux::{
-    CreatePagesFlags, MappingError, NonZeroAddress, NonZeroPageSize, VmemProtectError,
-};
-use litebox::platform::{RawConstPointer as _, RawMutPointer as _, SystemInfoProvider as _};
 use litebox::shim::{ContinueOperation, EnterShim, ExceptionInfo};
-use litebox::{LiteBox, platform::RawPointerProvider};
-use litebox_common_windows::loader::{
-    AccessMemory, Fault, MapMemory, MappingInfo, PAGE_SIZE, PeLoadError, PeParseError,
-    PeParsedFile, Protection, ReadAt, page_align_down,
-};
+use litebox_common_windows::loader::{MappingInfo, PAGE_SIZE};
 use litebox_platform_multiplex::Platform;
-use thiserror::Error;
 
-const INITIAL_STACK_SIZE: usize = 1024 * 1024;
+mod loader;
+
 const DEFAULT_PROCESS_EXIT_CODE: i32 = 1;
-const ZERO_CHUNK: [u8; PAGE_SIZE] = [0; PAGE_SIZE];
-const FILE_CHUNK_BYTES: usize = 64 * 1024;
 
-type WindowsPageManager = PageManager<Platform, PAGE_SIZE>;
+pub(crate) type WindowsPageManager = PageManager<Platform, PAGE_SIZE>;
 
 pub type DefaultFS = WindowsFS;
 
@@ -92,21 +81,15 @@ impl WindowsShimBuilder {
 
     #[must_use]
     pub fn build<FS: ShimFS>(self) -> WindowsShim<FS> {
-        let page_manager = Arc::new(PageManager::new(&self.litebox));
-        WindowsShim {
-            litebox: Arc::new(self.litebox),
-            page_manager,
+        let global = Arc::new(GlobalState {
+            page_manager: PageManager::new(&self.litebox),
             _fs: PhantomData,
-        }
+        });
+        WindowsShim(global)
     }
 }
 
-/// A placeholder Windows shim.
-pub struct WindowsShim<FS: ShimFS> {
-    litebox: Arc<LiteBox<Platform>>,
-    page_manager: Arc<WindowsPageManager>,
-    _fs: PhantomData<FS>,
-}
+pub struct WindowsShim<FS: ShimFS>(Arc<GlobalState<FS>>);
 
 impl<FS: ShimFS> WindowsShim<FS> {
     /// Loads the program at `path` as the shim's initial task.
@@ -118,86 +101,84 @@ impl<FS: ShimFS> WindowsShim<FS> {
         path: &str,
         _argv: Vec<alloc::ffi::CString>,
         _envp: Vec<alloc::ffi::CString>,
-    ) -> Result<LoadedProgram<FS>, WindowsLoadError> {
-        let mapping = self.load_image(fs.clone(), path)?;
-        let entry_point = mapping.entry_point;
-
-        let length =
-            NonZeroPageSize::new(INITIAL_STACK_SIZE).ok_or(PeImageAccessError::AddressOverflow)?;
-        // SAFETY: `suggested_address` is `None` and `CreatePagesFlags::empty()` does not set
-        // `fixed_addr`, so the kernel picks a free range — no existing mapping can be displaced.
-        let stack_base = unsafe {
-            self.page_manager
-                .create_stack_pages(None, length, CreatePagesFlags::empty())
-                .map_err(PeImageAccessError::Mapping)?
-        };
-        let stack_top = stack_base
-            .as_usize()
-            .checked_add(INITIAL_STACK_SIZE)
-            .ok_or(PeImageAccessError::AddressOverflow)?;
-        let exit_code = Arc::new(AtomicI32::new(DEFAULT_PROCESS_EXIT_CODE));
-
+    ) -> Result<LoadedProgram<FS>, loader::WindowsLoadError> {
+        let load_info = loader::PeLoader::new(fs, &self.0.page_manager).load(path)?;
+        let process = Arc::new(Process {
+            ntdll_mapping: load_info.ntdll_mapping,
+            exit_code: AtomicI32::new(DEFAULT_PROCESS_EXIT_CODE),
+        });
         Ok(LoadedProgram {
             entrypoints: WindowsShimEntrypoints {
-                entry_point,
-                stack_top,
-                exit_code: exit_code.clone(),
-                _fs: PhantomData,
+                task: Task {
+                    process: process.clone(),
+                    entry_point: load_info.entry_point,
+                    stack_top: load_info.stack_top,
+                    _phantom: PhantomData,
+                },
+                _not_send: PhantomData,
             },
-            process: WindowsShimProcess { mapping, exit_code },
+            process,
         })
-    }
-
-    fn load_image(&self, fs: Arc<FS>, path: &str) -> Result<MappingInfo, WindowsLoadError> {
-        let file = PeImageFile::open(fs, path)?;
-        let mut parsed = PeParsedFile::parse(&mut &file).map_err(WindowsLoadError::Parse)?;
-        parsed
-            .parse_trampoline(
-                &mut &file,
-                litebox_platform_multiplex::platform().get_syscall_entry_point(),
-            )
-            .map_err(WindowsLoadError::Parse)?;
-        let mut mapper = PeImageMapper {
-            file: &file,
-            page_manager: &self.page_manager,
-            chunk: alloc::vec![0u8; FILE_CHUNK_BYTES],
-        };
-        let mut memory = PeImageMemory;
-        parsed
-            .load(&mut mapper, &mut memory)
-            .map_err(WindowsLoadError::Load)
-    }
-
-    #[must_use]
-    pub fn litebox(&self) -> &LiteBox<Platform> {
-        &self.litebox
     }
 }
 
-/// The shim entrypoint object passed to the platform.
-pub struct WindowsShimEntrypoints<FS: ShimFS> {
-    entry_point: usize,
-    stack_top: usize,
-    exit_code: Arc<AtomicI32>,
+/// Global shim state shared by all Windows tasks loaded by this shim.
+struct GlobalState<FS: ShimFS> {
+    page_manager: WindowsPageManager,
     _fs: PhantomData<FS>,
 }
 
-impl<FS: ShimFS> EnterShim for WindowsShimEntrypoints<FS> {
-    type ExecutionContext = litebox_common_linux::PtRegs;
+/// Per-process Windows state shared by every thread in the process.
+pub struct Process {
+    ntdll_mapping: Option<MappingInfo>,
+    exit_code: AtomicI32,
+}
 
-    fn init(&self, ctx: &mut Self::ExecutionContext) -> ContinueOperation {
+impl Process {
+    /// Wait for the process to exit, returning its exit code.
+    ///
+    /// Currently a placeholder that returns a fixed exit code immediately.
+    /// Once NT process lifecycle exists, this will actually block.
+    #[must_use]
+    pub fn wait(&self) -> i32 {
+        // TODO: Wait for the NT process object once process lifecycle exists.
+        self.exit_code.load(Ordering::Relaxed)
+    }
+}
+
+struct Task<FS: ShimFS> {
+    process: Arc<Process>,
+    entry_point: usize,
+    stack_top: usize,
+    _phantom: PhantomData<FS>,
+}
+
+impl<FS: ShimFS> Task<FS> {
+    fn init(&self, ctx: &mut litebox_common_linux::PtRegs) -> ContinueOperation {
         ctx.rip = self.entry_point;
-        ctx.rsp = self.stack_top;
+        let stack_top_alignment = self.stack_top % 16;
+        debug_assert!(stack_top_alignment == 0 || stack_top_alignment == 8);
+        ctx.rsp = if stack_top_alignment == 0 {
+            self.stack_top - core::mem::size_of::<usize>()
+        } else {
+            self.stack_top
+        };
         ctx.eflags = 0x202;
+        ctx.rdx = self
+            .process
+            .ntdll_mapping
+            .as_ref()
+            .map_or(0, |mapping| mapping.base_addr);
         litebox_util_log::debug!(
             entry_point:% = format_args!("{:#x}", self.entry_point),
             stack_top:% = format_args!("{:#x}", self.stack_top);
             "Starting initial Windows guest thread"
         );
+
         ContinueOperation::Resume
     }
 
-    fn syscall(&self, ctx: &mut Self::ExecutionContext) -> ContinueOperation {
+    fn handle_syscall_request(&self, ctx: &mut litebox_common_linux::PtRegs) -> ContinueOperation {
         // TODO: Decode the NT syscall number and dispatch only NtTerminateProcess here.
         litebox_util_log::debug!(
             syscall_number = ctx.orig_rax,
@@ -205,9 +186,39 @@ impl<FS: ShimFS> EnterShim for WindowsShimEntrypoints<FS> {
             exit_status:% = format_args!("{:#x}", ctx.rdx);
             "Handling temporary NtTerminateProcess syscall"
         );
-        self.exit_code
+        self.process
+            .exit_code
             .store(windows_exit_status_to_i32(ctx.rdx), Ordering::Relaxed);
         ContinueOperation::Terminate
+    }
+
+    fn handle_interrupt_request(
+        &self,
+        _ctx: &mut litebox_common_linux::PtRegs,
+    ) -> ContinueOperation {
+        litebox_util_log::debug!(
+            stack_top:% = format_args!("{:#x}", self.stack_top);
+            "Windows guest interrupt"
+        );
+        ContinueOperation::Resume
+    }
+}
+
+/// The shim entrypoint object passed to the platform.
+pub struct WindowsShimEntrypoints<FS: ShimFS> {
+    task: Task<FS>,
+    _not_send: PhantomData<*const ()>,
+}
+
+impl<FS: ShimFS> EnterShim for WindowsShimEntrypoints<FS> {
+    type ExecutionContext = litebox_common_linux::PtRegs;
+
+    fn init(&self, ctx: &mut Self::ExecutionContext) -> ContinueOperation {
+        self.task.init(ctx)
+    }
+
+    fn syscall(&self, ctx: &mut Self::ExecutionContext) -> ContinueOperation {
+        self.task.handle_syscall_request(ctx)
     }
 
     fn exception(
@@ -225,9 +236,8 @@ impl<FS: ShimFS> EnterShim for WindowsShimEntrypoints<FS> {
         ContinueOperation::Terminate
     }
 
-    fn interrupt(&self, _ctx: &mut Self::ExecutionContext) -> ContinueOperation {
-        // TODO: Handle host interrupts for Windows guest waits/APCs.
-        ContinueOperation::Terminate
+    fn interrupt(&self, ctx: &mut Self::ExecutionContext) -> ContinueOperation {
+        self.task.handle_interrupt_request(ctx)
     }
 }
 
@@ -241,290 +251,7 @@ pub struct LoadedProgram<FS: ShimFS> {
     /// The initial-thread entrypoint state passed to the platform's `run_thread`.
     pub entrypoints: WindowsShimEntrypoints<FS>,
     /// Handle used to wait for the loaded program to exit.
-    pub process: WindowsShimProcess,
-}
-
-/// A placeholder handle to a process loaded via [`WindowsShim::load_program`].
-pub struct WindowsShimProcess {
-    mapping: MappingInfo,
-    exit_code: Arc<AtomicI32>,
-}
-
-impl WindowsShimProcess {
-    /// Wait for the process to exit, returning its exit code.
-    ///
-    /// Currently a placeholder that returns a fixed exit code immediately.
-    /// Once NT process lifecycle exists, this will actually block.
-    #[must_use]
-    pub fn wait(&self) -> i32 {
-        // TODO: Wait for the NT process object once process lifecycle exists.
-        self.exit_code.load(Ordering::Relaxed)
-    }
-}
-
-/// Errors that can occur while opening, parsing, and mapping a Windows PE image.
-#[derive(Debug, Error)]
-pub enum WindowsLoadError {
-    /// PE parsing failed.
-    #[error("failed to parse PE image")]
-    Parse(#[source] PeParseError<PeImageAccessError>),
-    /// PE image mapping failed.
-    #[error("failed to load PE image")]
-    Load(#[source] PeLoadError<PeImageAccessError>),
-    /// Opening the PE image failed.
-    #[error(transparent)]
-    Access(#[from] PeImageAccessError),
-}
-
-/// Errors from the shim-side PE image backing file and memory mapper.
-#[derive(Debug, Error)]
-pub enum PeImageAccessError {
-    /// Opening the executable failed.
-    #[error("failed to open PE image")]
-    Open(#[from] litebox::fs::errors::OpenError),
-    /// Reading the executable failed.
-    #[error("failed to read PE image")]
-    Read(#[from] litebox::fs::errors::ReadError),
-    /// Reading file metadata failed.
-    #[error("failed to read PE image metadata")]
-    FileStatus(#[from] litebox::fs::errors::FileStatusError),
-    /// The backing file ended before the requested range was read.
-    #[error("short read from PE image")]
-    ShortRead,
-    /// A PE file offset or image address overflowed this host representation.
-    #[error("PE image address overflow")]
-    AddressOverflow,
-    /// A memory mapping operation failed.
-    #[error(transparent)]
-    Mapping(#[from] MappingError),
-    /// A memory protection operation failed.
-    #[error(transparent)]
-    Protect(#[from] VmemProtectError),
-    /// A mapped memory access failed.
-    #[error("mapped PE image memory access failed")]
-    MemoryAccess,
-}
-
-struct PeImageFile<FS: ShimFS> {
-    fs: Arc<FS>,
-    fd: TypedFd<FS>,
-}
-
-impl<FS: ShimFS> PeImageFile<FS> {
-    fn open(fs: Arc<FS>, path: &str) -> Result<Self, PeImageAccessError> {
-        let fd = fs.open(path, OFlags::RDONLY, Mode::empty())?;
-        Ok(Self { fs, fd })
-    }
-
-    fn read_exact_at(
-        &self,
-        mut offset: usize,
-        mut buf: &mut [u8],
-    ) -> Result<(), PeImageAccessError> {
-        while !buf.is_empty() {
-            let bytes_read = self.fs.read(&self.fd, buf, Some(offset))?;
-            if bytes_read == 0 {
-                return Err(PeImageAccessError::ShortRead);
-            }
-            offset = offset
-                .checked_add(bytes_read)
-                .ok_or(PeImageAccessError::AddressOverflow)?;
-            buf = &mut buf[bytes_read..];
-        }
-        Ok(())
-    }
-}
-
-impl<FS: ShimFS> Drop for PeImageFile<FS> {
-    fn drop(&mut self) {
-        if let Err(e) = self.fs.close(&self.fd) {
-            litebox_util_log::warn!(error:? = e; "failed to close PE image file");
-        }
-    }
-}
-
-impl<FS: ShimFS> ReadAt for &'_ PeImageFile<FS> {
-    type Error = PeImageAccessError;
-
-    fn read_at(&mut self, offset: u64, buf: &mut [u8]) -> Result<(), Self::Error> {
-        self.read_exact_at(
-            offset
-                .try_into()
-                .map_err(|_| PeImageAccessError::AddressOverflow)?,
-            buf,
-        )
-    }
-
-    fn size(&mut self) -> Result<u64, Self::Error> {
-        self.fs
-            .fd_file_status(&self.fd)?
-            .size
-            .try_into()
-            .map_err(|_| PeImageAccessError::AddressOverflow)
-    }
-}
-
-struct PeImageMapper<'a, FS: ShimFS> {
-    file: &'a PeImageFile<FS>,
-    page_manager: &'a WindowsPageManager,
-    /// Reusable per-call I/O staging buffer for [`MapMemory::map_file`].
-    chunk: Vec<u8>,
-}
-
-impl<FS: ShimFS> MapMemory for PeImageMapper<'_, FS> {
-    type Error = PeImageAccessError;
-
-    fn reserve(
-        &mut self,
-        preferred_base: usize,
-        len: usize,
-        _align: usize,
-    ) -> Result<usize, Self::Error> {
-        let length = NonZeroPageSize::new(len).ok_or(PeImageAccessError::AddressOverflow)?;
-        let suggested_address = if preferred_base == 0 {
-            None
-        } else {
-            Some(NonZeroAddress::new(preferred_base).ok_or(PeImageAccessError::AddressOverflow)?)
-        };
-
-        // SAFETY: `CreatePagesFlags::empty()` does not set `fixed_addr`, so the kernel
-        // treats `suggested_address` as a hint and never silently unmaps an existing
-        // mapping; the documented overlap precondition therefore does not apply.
-        let ptr = unsafe {
-            self.page_manager.create_inaccessible_pages(
-                suggested_address,
-                length,
-                CreatePagesFlags::empty(),
-                |_| Ok(0),
-            )?
-        };
-        Ok(ptr.as_usize())
-    }
-
-    fn map_zero(
-        &mut self,
-        address: usize,
-        len: usize,
-        prot: &Protection,
-    ) -> Result<(), Self::Error> {
-        make_pages_writable(self.page_manager, address, len)?;
-        let ptr = <Platform as RawPointerProvider>::RawMutPointer::<u8>::from_usize(address);
-        let mut written = 0;
-        while written < len {
-            let chunk = (len - written).min(ZERO_CHUNK.len());
-            ptr.copy_from_slice(written, &ZERO_CHUNK[..chunk])
-                .ok_or(PeImageAccessError::MemoryAccess)?;
-            written += chunk;
-        }
-        protect_pages(self.page_manager, address, len, *prot)
-    }
-
-    fn map_file(
-        &mut self,
-        address: usize,
-        len: usize,
-        offset: u64,
-        prot: &Protection,
-    ) -> Result<(), Self::Error> {
-        make_pages_writable(self.page_manager, address, len)?;
-        let ptr = <Platform as RawPointerProvider>::RawMutPointer::<u8>::from_usize(address);
-        let file_offset: usize = offset
-            .try_into()
-            .map_err(|_| PeImageAccessError::AddressOverflow)?;
-        let mut read = 0;
-        while read < len {
-            let remaining = len - read;
-            let n = remaining.min(self.chunk.len());
-            self.file.read_exact_at(
-                file_offset
-                    .checked_add(read)
-                    .ok_or(PeImageAccessError::AddressOverflow)?,
-                &mut self.chunk[..n],
-            )?;
-            ptr.copy_from_slice(read, &self.chunk[..n])
-                .ok_or(PeImageAccessError::MemoryAccess)?;
-            read += n;
-        }
-        protect_pages(self.page_manager, address, len, *prot)
-    }
-
-    fn protect(
-        &mut self,
-        address: usize,
-        len: usize,
-        prot: &Protection,
-    ) -> Result<(), Self::Error> {
-        protect_pages(self.page_manager, address, len, *prot)
-    }
-}
-
-struct PeImageMemory;
-
-impl AccessMemory for PeImageMemory {
-    fn read(&mut self, address: usize, buf: &mut [u8]) -> Result<(), Fault> {
-        let ptr = <Platform as RawPointerProvider>::RawConstPointer::<u8>::from_usize(address);
-        buf.copy_from_slice(&ptr.to_owned_slice(buf.len()).ok_or(Fault)?);
-        Ok(())
-    }
-
-    fn write(&mut self, address: usize, data: &[u8]) -> Result<(), Fault> {
-        let ptr = <Platform as RawPointerProvider>::RawMutPointer::<u8>::from_usize(address);
-        ptr.copy_from_slice(0, data).ok_or(Fault)
-    }
-}
-
-fn make_pages_writable(
-    page_manager: &WindowsPageManager,
-    address: usize,
-    len: usize,
-) -> Result<(), PeImageAccessError> {
-    let (start, len) = page_range(address, len)?;
-    if len == 0 {
-        return Ok(());
-    }
-    let ptr = <Platform as RawPointerProvider>::RawMutPointer::<u8>::from_usize(start);
-    // SAFETY: Loading happens before the initial guest thread is allowed to execute.
-    unsafe { page_manager.make_pages_writable(ptr, len)? };
-    Ok(())
-}
-
-fn protect_pages(
-    page_manager: &WindowsPageManager,
-    address: usize,
-    len: usize,
-    prot: Protection,
-) -> Result<(), PeImageAccessError> {
-    let (start, len) = page_range(address, len)?;
-    if len == 0 {
-        return Ok(());
-    }
-    let ptr = <Platform as RawPointerProvider>::RawMutPointer::<u8>::from_usize(start);
-    // SAFETY: All `make_pages_*` calls happen during PE load, before the initial
-    // guest thread starts, so there is no concurrent read/write/execute on these
-    // pages. The RWX arm is only reached when a section's COFF characteristics
-    // demand WRITE|EXECUTE; the bytes copied into the section come from the
-    // attacker-controlled PE file and are not executed until protections are set,
-    // so this is no looser than running the same PE under the real Windows loader.
-    match (prot.read, prot.write, prot.execute) {
-        (_, true, true) => unsafe { page_manager.make_pages_rwx(ptr, len)? },
-        (_, true, false) => unsafe { page_manager.make_pages_writable(ptr, len)? },
-        (_, false, true) => unsafe { page_manager.make_pages_executable(ptr, len)? },
-        (true, false, false) => unsafe { page_manager.make_pages_readable(ptr, len)? },
-        (false, false, false) => unsafe { page_manager.make_pages_inaccessible(ptr, len)? },
-    }
-    Ok(())
-}
-
-fn page_range(address: usize, len: usize) -> Result<(usize, usize), PeImageAccessError> {
-    if len == 0 {
-        return Ok((address, 0));
-    }
-    let start = page_align_down(address);
-    let end = address
-        .checked_add(len)
-        .and_then(|v| v.checked_next_multiple_of(PAGE_SIZE))
-        .ok_or(PeImageAccessError::AddressOverflow)?;
-    Ok((start, end - start))
+    pub process: Arc<Process>,
 }
 
 fn default_fs(

--- a/litebox_shim_windows/src/lib.rs
+++ b/litebox_shim_windows/src/lib.rs
@@ -14,6 +14,7 @@ extern crate alloc;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::marker::PhantomData;
+use core::sync::atomic::{AtomicI32, Ordering};
 
 use litebox::fd::TypedFd;
 use litebox::fs::{Mode, OFlags};
@@ -21,18 +22,18 @@ use litebox::mm::PageManager;
 use litebox::mm::linux::{
     CreatePagesFlags, MappingError, NonZeroAddress, NonZeroPageSize, VmemProtectError,
 };
-use litebox::platform::{RawConstPointer as _, RawMutPointer as _};
+use litebox::platform::{RawConstPointer as _, RawMutPointer as _, SystemInfoProvider as _};
 use litebox::shim::{ContinueOperation, EnterShim, ExceptionInfo};
 use litebox::{LiteBox, platform::RawPointerProvider};
 use litebox_common_windows::loader::{
-    AccessMemory, Fault, MapMemory, PAGE_SIZE, PeLoadError, PeParseError, PeParsedFile, Protection,
-    ReadAt, page_align_down,
+    AccessMemory, Fault, MapMemory, MappingInfo, PAGE_SIZE, PeLoadError, PeParseError,
+    PeParsedFile, Protection, ReadAt, page_align_down,
 };
 use litebox_platform_multiplex::Platform;
 use thiserror::Error;
 
 const INITIAL_STACK_SIZE: usize = 1024 * 1024;
-const PLACEHOLDER_EXIT_CODE: i32 = 1;
+const DEFAULT_PROCESS_EXIT_CODE: i32 = 1;
 const ZERO_CHUNK: [u8; PAGE_SIZE] = [0; PAGE_SIZE];
 const FILE_CHUNK_BYTES: usize = 64 * 1024;
 
@@ -118,21 +119,7 @@ impl<FS: ShimFS> WindowsShim<FS> {
         _argv: Vec<alloc::ffi::CString>,
         _envp: Vec<alloc::ffi::CString>,
     ) -> Result<LoadedProgram<FS>, WindowsLoadError> {
-        let file = PeImageFile::open(fs, path)?;
-        let parsed = PeParsedFile::parse(&mut &file).map_err(|e| match e {
-            PeParseError::Io(io) => WindowsLoadError::Access(io),
-            other => WindowsLoadError::Parse(other),
-        })?;
-        let mut mapper = PeImageMapper {
-            file: &file,
-            page_manager: &self.page_manager,
-            chunk: alloc::vec![0u8; FILE_CHUNK_BYTES],
-        };
-        let mut memory = PeImageMemory;
-        let mapping = parsed.load(&mut mapper, &mut memory).map_err(|e| match e {
-            PeLoadError::Map(access) => WindowsLoadError::Access(access),
-            other => WindowsLoadError::Load(other),
-        })?;
+        let mapping = self.load_image(fs.clone(), path)?;
         let entry_point = mapping.entry_point;
 
         let length =
@@ -148,15 +135,37 @@ impl<FS: ShimFS> WindowsShim<FS> {
             .as_usize()
             .checked_add(INITIAL_STACK_SIZE)
             .ok_or(PeImageAccessError::AddressOverflow)?;
+        let exit_code = Arc::new(AtomicI32::new(DEFAULT_PROCESS_EXIT_CODE));
 
         Ok(LoadedProgram {
             entrypoints: WindowsShimEntrypoints {
                 entry_point,
                 stack_top,
+                exit_code: exit_code.clone(),
                 _fs: PhantomData,
             },
-            process: WindowsShimProcess,
+            process: WindowsShimProcess { mapping, exit_code },
         })
+    }
+
+    fn load_image(&self, fs: Arc<FS>, path: &str) -> Result<MappingInfo, WindowsLoadError> {
+        let file = PeImageFile::open(fs, path)?;
+        let mut parsed = PeParsedFile::parse(&mut &file).map_err(WindowsLoadError::Parse)?;
+        parsed
+            .parse_trampoline(
+                &mut &file,
+                litebox_platform_multiplex::platform().get_syscall_entry_point(),
+            )
+            .map_err(WindowsLoadError::Parse)?;
+        let mut mapper = PeImageMapper {
+            file: &file,
+            page_manager: &self.page_manager,
+            chunk: alloc::vec![0u8; FILE_CHUNK_BYTES],
+        };
+        let mut memory = PeImageMemory;
+        parsed
+            .load(&mut mapper, &mut memory)
+            .map_err(WindowsLoadError::Load)
     }
 
     #[must_use]
@@ -169,6 +178,7 @@ impl<FS: ShimFS> WindowsShim<FS> {
 pub struct WindowsShimEntrypoints<FS: ShimFS> {
     entry_point: usize,
     stack_top: usize,
+    exit_code: Arc<AtomicI32>,
     _fs: PhantomData<FS>,
 }
 
@@ -187,8 +197,16 @@ impl<FS: ShimFS> EnterShim for WindowsShimEntrypoints<FS> {
         ContinueOperation::Resume
     }
 
-    fn syscall(&self, _ctx: &mut Self::ExecutionContext) -> ContinueOperation {
-        // TODO: Decode and dispatch NT syscalls.
+    fn syscall(&self, ctx: &mut Self::ExecutionContext) -> ContinueOperation {
+        // TODO: Decode the NT syscall number and dispatch only NtTerminateProcess here.
+        litebox_util_log::debug!(
+            syscall_number = ctx.orig_rax,
+            process_handle:% = format_args!("{:#x}", ctx.r10),
+            exit_status:% = format_args!("{:#x}", ctx.rdx);
+            "Handling temporary NtTerminateProcess syscall"
+        );
+        self.exit_code
+            .store(windows_exit_status_to_i32(ctx.rdx), Ordering::Relaxed);
         ContinueOperation::Terminate
     }
 
@@ -213,6 +231,11 @@ impl<FS: ShimFS> EnterShim for WindowsShimEntrypoints<FS> {
     }
 }
 
+fn windows_exit_status_to_i32(status: usize) -> i32 {
+    let low_bits = u32::try_from(status & 0xffff_ffff).unwrap_or_default();
+    i32::from_ne_bytes(low_bits.to_ne_bytes())
+}
+
 /// A loaded Windows program and the process handle used to wait for it.
 pub struct LoadedProgram<FS: ShimFS> {
     /// The initial-thread entrypoint state passed to the platform's `run_thread`.
@@ -222,7 +245,10 @@ pub struct LoadedProgram<FS: ShimFS> {
 }
 
 /// A placeholder handle to a process loaded via [`WindowsShim::load_program`].
-pub struct WindowsShimProcess;
+pub struct WindowsShimProcess {
+    mapping: MappingInfo,
+    exit_code: Arc<AtomicI32>,
+}
 
 impl WindowsShimProcess {
     /// Wait for the process to exit, returning its exit code.
@@ -231,7 +257,8 @@ impl WindowsShimProcess {
     /// Once NT process lifecycle exists, this will actually block.
     #[must_use]
     pub fn wait(&self) -> i32 {
-        PLACEHOLDER_EXIT_CODE
+        // TODO: Wait for the NT process object once process lifecycle exists.
+        self.exit_code.load(Ordering::Relaxed)
     }
 }
 

--- a/litebox_shim_windows/src/loader/mod.rs
+++ b/litebox_shim_windows/src/loader/mod.rs
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+mod pe;
+
+pub(crate) use pe::PeLoader;
+
+pub use pe::WindowsLoadError;

--- a/litebox_shim_windows/src/loader/pe.rs
+++ b/litebox_shim_windows/src/loader/pe.rs
@@ -1,0 +1,425 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+use alloc::{sync::Arc, vec::Vec};
+use litebox::platform::{RawConstPointer as _, RawMutPointer as _, SystemInfoProvider as _};
+use litebox::{
+    fs::{Mode, OFlags},
+    mm::linux::{
+        CreatePagesFlags, MappingError, NonZeroAddress, NonZeroPageSize, VmemProtectError,
+    },
+    platform::RawPointerProvider,
+};
+use litebox_common_windows::loader::{
+    AccessMemory, Fault, MapMemory, MappingInfo, PAGE_SIZE, PeLoadError, PeParseError,
+    PeParsedFile, Protection, ReadAt, page_align_down,
+};
+use litebox_platform_multiplex::Platform;
+use thiserror::Error;
+
+use crate::ShimFS;
+
+const NTDLL_WRITABLE_SECTIONS: &[&[u8]] = &[b".mrdata"];
+const NTDLL_PATHS: &[&str] = &["/Windows/System32/ntdll.dll", "/windows/system32/ntdll.dll"];
+const ZERO_CHUNK: [u8; PAGE_SIZE] = [0; PAGE_SIZE];
+const FILE_CHUNK_BYTES: usize = 64 * 1024;
+const INITIAL_STACK_SIZE: usize = 1024 * 1024;
+
+/// Struct to hold the information needed to start the program.
+pub(crate) struct PeLoadInfo {
+    pub(crate) entry_point: usize,
+    pub(crate) stack_top: usize,
+    pub(crate) ntdll_mapping: Option<MappingInfo>,
+}
+
+/// Loader for Windows PE files.
+pub(crate) struct PeLoader<'a, FS: ShimFS> {
+    fs: Arc<FS>,
+    page_manager: &'a crate::WindowsPageManager,
+}
+
+impl<'a, FS: ShimFS> PeLoader<'a, FS> {
+    pub(crate) fn new(fs: Arc<FS>, page_manager: &'a crate::WindowsPageManager) -> Self {
+        Self { fs, page_manager }
+    }
+
+    pub(crate) fn load(&self, path: &str) -> Result<PeLoadInfo, WindowsLoadError> {
+        let image = load_image(self.fs.clone(), path, self.page_manager)?;
+        let application_entry_point = image.mapping.entry_point;
+        let ntdll = load_ntdll(self.fs.clone(), self.page_manager, NTDLL_PATHS)?;
+
+        let length =
+            NonZeroPageSize::new(INITIAL_STACK_SIZE).ok_or(PeImageAccessError::AddressOverflow)?;
+        let stack_base = unsafe {
+            self.page_manager
+                .create_stack_pages(None, length, CreatePagesFlags::empty())
+                .map_err(PeImageAccessError::Mapping)?
+        };
+        let stack_top = stack_base
+            .as_usize()
+            .checked_add(INITIAL_STACK_SIZE)
+            .ok_or(PeImageAccessError::AddressOverflow)?;
+        let stack_top = if stack_top.is_multiple_of(16) {
+            stack_top - core::mem::size_of::<usize>()
+        } else {
+            stack_top
+        };
+
+        Ok(PeLoadInfo {
+            entry_point: application_entry_point,
+            stack_top,
+            ntdll_mapping: ntdll.map(|image| image.mapping),
+        })
+    }
+}
+
+struct LoadedImage {
+    mapping: MappingInfo,
+}
+
+fn load_ntdll<FS: crate::ShimFS>(
+    fs: Arc<FS>,
+    page_manager: &crate::WindowsPageManager,
+    ntdll_paths: &[&str],
+) -> Result<Option<LoadedImage>, WindowsLoadError> {
+    for path in ntdll_paths {
+        match load_image_with_writable_sections(
+            fs.clone(),
+            path,
+            page_manager,
+            NTDLL_WRITABLE_SECTIONS,
+        ) {
+            Ok(image) => {
+                litebox_util_log::debug!(path:% = path; "Loaded guest ntdll.dll");
+                return Ok(Some(image));
+            }
+            Err(error) if is_missing_file_error(&error) => {}
+            Err(error) => return Err(error),
+        }
+    }
+
+    litebox_util_log::debug!("Guest ntdll.dll was not found in the initial filesystem");
+    Ok(None)
+}
+
+fn load_image<FS: ShimFS>(
+    fs: Arc<FS>,
+    path: &str,
+    page_manager: &crate::WindowsPageManager,
+) -> Result<LoadedImage, WindowsLoadError> {
+    load_image_with_writable_sections(fs, path, page_manager, &[])
+}
+
+fn load_image_with_writable_sections<FS: ShimFS>(
+    fs: Arc<FS>,
+    path: &str,
+    page_manager: &crate::WindowsPageManager,
+    writable_section_names: &[&[u8]],
+) -> Result<LoadedImage, WindowsLoadError> {
+    let file = PeImageFile::open(fs, path)?;
+    let mut parsed = PeParsedFile::parse(&mut &file).map_err(WindowsLoadError::Parse)?;
+    parsed
+        .parse_trampoline(
+            &mut &file,
+            litebox_platform_multiplex::platform().get_syscall_entry_point(),
+        )
+        .map_err(WindowsLoadError::Parse)?;
+    let mut mapper = PeImageMapper {
+        file: &file,
+        page_manager,
+        chunk: alloc::vec![0u8; FILE_CHUNK_BYTES],
+    };
+    let mut memory = PeImageMemory;
+    let mapping = parsed
+        .load_with_writable_sections(&mut mapper, &mut memory, writable_section_names)
+        .map_err(WindowsLoadError::Load)?;
+    Ok(LoadedImage { mapping })
+}
+
+/// Errors that can occur while opening, parsing, and mapping a Windows PE image.
+#[derive(Debug, Error)]
+pub enum WindowsLoadError {
+    /// PE parsing failed.
+    #[error("failed to parse PE image")]
+    Parse(#[source] PeParseError<PeImageAccessError>),
+    /// PE image mapping failed.
+    #[error("failed to load PE image")]
+    Load(#[source] PeLoadError<PeImageAccessError>),
+    /// Opening the PE image failed.
+    #[error(transparent)]
+    Access(#[from] PeImageAccessError),
+    /// Guest ntdll.dll does not export LdrInitializeThunk.
+    #[error("guest ntdll.dll does not export LdrInitializeThunk")]
+    MissingNtDllLoaderEntrypoint,
+    /// Guest ntdll.dll does not export RtlUserThreadStart.
+    #[error("guest ntdll.dll does not export RtlUserThreadStart")]
+    MissingNtDllThreadEntrypoint,
+    /// Guest ntdll.dll has not been rewritten for LiteBox syscall/GS handling.
+    #[error("guest ntdll.dll must be rewritten for LiteBox before entering its loader")]
+    UnrewrittenNtDll,
+}
+
+fn is_missing_file_error(error: &WindowsLoadError) -> bool {
+    let WindowsLoadError::Access(PeImageAccessError::Open(error)) = error else {
+        return false;
+    };
+
+    matches!(
+        error,
+        litebox::fs::errors::OpenError::PathError(
+            litebox::fs::errors::PathError::NoSuchFileOrDirectory
+                | litebox::fs::errors::PathError::MissingComponent
+        )
+    )
+}
+
+struct PeImageFile<FS: ShimFS> {
+    fs: Arc<FS>,
+    fd: litebox::fd::TypedFd<FS>,
+}
+
+impl<FS: ShimFS> PeImageFile<FS> {
+    fn open(fs: Arc<FS>, path: &str) -> Result<Self, PeImageAccessError> {
+        let fd = fs.open(path, OFlags::RDONLY, Mode::empty())?;
+        Ok(Self { fs, fd })
+    }
+
+    fn read_exact_at(
+        &self,
+        mut offset: usize,
+        mut buf: &mut [u8],
+    ) -> Result<(), PeImageAccessError> {
+        while !buf.is_empty() {
+            let bytes_read = self.fs.read(&self.fd, buf, Some(offset))?;
+            if bytes_read == 0 {
+                return Err(PeImageAccessError::ShortRead);
+            }
+            offset = offset
+                .checked_add(bytes_read)
+                .ok_or(PeImageAccessError::AddressOverflow)?;
+            buf = &mut buf[bytes_read..];
+        }
+        Ok(())
+    }
+}
+
+impl<FS: ShimFS> Drop for PeImageFile<FS> {
+    fn drop(&mut self) {
+        if let Err(e) = self.fs.close(&self.fd) {
+            litebox_util_log::warn!(error:? = e; "failed to close PE image file");
+        }
+    }
+}
+
+impl<FS: ShimFS> ReadAt for &'_ PeImageFile<FS> {
+    type Error = PeImageAccessError;
+
+    fn read_at(&mut self, offset: u64, buf: &mut [u8]) -> Result<(), Self::Error> {
+        self.read_exact_at(
+            offset
+                .try_into()
+                .map_err(|_| PeImageAccessError::AddressOverflow)?,
+            buf,
+        )
+    }
+
+    fn size(&mut self) -> Result<u64, Self::Error> {
+        self.fs
+            .fd_file_status(&self.fd)?
+            .size
+            .try_into()
+            .map_err(|_| PeImageAccessError::AddressOverflow)
+    }
+}
+
+struct PeImageMapper<'a, FS: ShimFS> {
+    file: &'a PeImageFile<FS>,
+    page_manager: &'a crate::WindowsPageManager,
+    /// Reusable per-call I/O staging buffer for [`MapMemory::map_file`].
+    chunk: Vec<u8>,
+}
+
+impl<FS: ShimFS> MapMemory for PeImageMapper<'_, FS> {
+    type Error = PeImageAccessError;
+
+    fn reserve(
+        &mut self,
+        preferred_base: usize,
+        len: usize,
+        _align: usize,
+    ) -> Result<usize, Self::Error> {
+        let length = NonZeroPageSize::new(len).ok_or(PeImageAccessError::AddressOverflow)?;
+        let suggested_address = if preferred_base == 0 {
+            None
+        } else {
+            Some(NonZeroAddress::new(preferred_base).ok_or(PeImageAccessError::AddressOverflow)?)
+        };
+
+        // SAFETY: `CreatePagesFlags::empty()` does not set `fixed_addr`, so the kernel
+        // treats `suggested_address` as a hint and never silently unmaps an existing
+        // mapping; the documented overlap precondition therefore does not apply.
+        let ptr = unsafe {
+            self.page_manager.create_inaccessible_pages(
+                suggested_address,
+                length,
+                CreatePagesFlags::empty(),
+                |_| Ok(0),
+            )?
+        };
+        Ok(ptr.as_usize())
+    }
+
+    fn map_zero(
+        &mut self,
+        address: usize,
+        len: usize,
+        prot: &Protection,
+    ) -> Result<(), Self::Error> {
+        make_pages_writable(self.page_manager, address, len)?;
+        let ptr = <Platform as RawPointerProvider>::RawMutPointer::<u8>::from_usize(address);
+        let mut written = 0;
+        while written < len {
+            let chunk = (len - written).min(ZERO_CHUNK.len());
+            ptr.copy_from_slice(written, &ZERO_CHUNK[..chunk])
+                .ok_or(PeImageAccessError::MemoryAccess)?;
+            written += chunk;
+        }
+        protect_pages(self.page_manager, address, len, *prot)
+    }
+
+    fn map_file(
+        &mut self,
+        address: usize,
+        len: usize,
+        offset: u64,
+        prot: &Protection,
+    ) -> Result<(), Self::Error> {
+        make_pages_writable(self.page_manager, address, len)?;
+        let ptr = <Platform as RawPointerProvider>::RawMutPointer::<u8>::from_usize(address);
+        let file_offset: usize = offset
+            .try_into()
+            .map_err(|_| PeImageAccessError::AddressOverflow)?;
+        let mut read = 0;
+        while read < len {
+            let remaining = len - read;
+            let n = remaining.min(self.chunk.len());
+            self.file.read_exact_at(
+                file_offset
+                    .checked_add(read)
+                    .ok_or(PeImageAccessError::AddressOverflow)?,
+                &mut self.chunk[..n],
+            )?;
+            ptr.copy_from_slice(read, &self.chunk[..n])
+                .ok_or(PeImageAccessError::MemoryAccess)?;
+            read += n;
+        }
+        protect_pages(self.page_manager, address, len, *prot)
+    }
+
+    fn protect(
+        &mut self,
+        address: usize,
+        len: usize,
+        prot: &Protection,
+    ) -> Result<(), Self::Error> {
+        protect_pages(self.page_manager, address, len, *prot)
+    }
+}
+
+/// Errors from the shim-side PE image backing file and memory mapper.
+#[derive(Debug, Error)]
+pub enum PeImageAccessError {
+    /// Opening the executable failed.
+    #[error("failed to open PE image")]
+    Open(#[from] litebox::fs::errors::OpenError),
+    /// Reading the executable failed.
+    #[error("failed to read PE image")]
+    Read(#[from] litebox::fs::errors::ReadError),
+    /// Reading file metadata failed.
+    #[error("failed to read PE image metadata")]
+    FileStatus(#[from] litebox::fs::errors::FileStatusError),
+    /// The backing file ended before the requested range was read.
+    #[error("short read from PE image")]
+    ShortRead,
+    /// A PE file offset or image address overflowed this host representation.
+    #[error("PE image address overflow")]
+    AddressOverflow,
+    /// A memory mapping operation failed.
+    #[error(transparent)]
+    Mapping(#[from] MappingError),
+    /// A memory protection operation failed.
+    #[error(transparent)]
+    Protect(#[from] VmemProtectError),
+    /// A mapped memory access failed.
+    #[error("mapped PE image memory access failed")]
+    MemoryAccess,
+}
+
+struct PeImageMemory;
+
+impl AccessMemory for PeImageMemory {
+    fn read(&mut self, address: usize, buf: &mut [u8]) -> Result<(), Fault> {
+        let ptr = <Platform as RawPointerProvider>::RawConstPointer::<u8>::from_usize(address);
+        buf.copy_from_slice(&ptr.to_owned_slice(buf.len()).ok_or(Fault)?);
+        Ok(())
+    }
+
+    fn write(&mut self, address: usize, data: &[u8]) -> Result<(), Fault> {
+        let ptr = <Platform as RawPointerProvider>::RawMutPointer::<u8>::from_usize(address);
+        ptr.copy_from_slice(0, data).ok_or(Fault)
+    }
+}
+
+fn make_pages_writable(
+    page_manager: &crate::WindowsPageManager,
+    address: usize,
+    len: usize,
+) -> Result<(), PeImageAccessError> {
+    let (start, len) = page_range(address, len)?;
+    if len == 0 {
+        return Ok(());
+    }
+    let ptr = <Platform as RawPointerProvider>::RawMutPointer::<u8>::from_usize(start);
+    // SAFETY: Loading happens before the initial guest thread is allowed to execute.
+    unsafe { page_manager.make_pages_writable(ptr, len)? };
+    Ok(())
+}
+
+fn protect_pages(
+    page_manager: &crate::WindowsPageManager,
+    address: usize,
+    len: usize,
+    prot: Protection,
+) -> Result<(), PeImageAccessError> {
+    let (start, len) = page_range(address, len)?;
+    if len == 0 {
+        return Ok(());
+    }
+    let ptr = <Platform as RawPointerProvider>::RawMutPointer::<u8>::from_usize(start);
+    // SAFETY: All `make_pages_*` calls happen during PE load, before the initial
+    // guest thread starts, so there is no concurrent read/write/execute on these
+    // pages. The RWX arm is only reached when a section's COFF characteristics
+    // demand WRITE|EXECUTE; the bytes copied into the section come from the
+    // attacker-controlled PE file and are not executed until protections are set,
+    // so this is no looser than running the same PE under the real Windows loader.
+    match (prot.read, prot.write, prot.execute) {
+        (_, true, true) => unsafe { page_manager.make_pages_rwx(ptr, len)? },
+        (_, true, false) => unsafe { page_manager.make_pages_writable(ptr, len)? },
+        (_, false, true) => unsafe { page_manager.make_pages_executable(ptr, len)? },
+        (true, false, false) => unsafe { page_manager.make_pages_readable(ptr, len)? },
+        (false, false, false) => unsafe { page_manager.make_pages_inaccessible(ptr, len)? },
+    }
+    Ok(())
+}
+
+fn page_range(address: usize, len: usize) -> Result<(usize, usize), PeImageAccessError> {
+    if len == 0 {
+        return Ok((address, 0));
+    }
+    let start = page_align_down(address);
+    let end = address
+        .checked_add(len)
+        .and_then(|v| v.checked_next_multiple_of(PAGE_SIZE))
+        .ok_or(PeImageAccessError::AddressOverflow)?;
+    Ok((start, end - start))
+}

--- a/litebox_syscall_rewriter/Cargo.toml
+++ b/litebox_syscall_rewriter/Cargo.toml
@@ -11,7 +11,7 @@ clap = ["dep:clap"]
 
 [dependencies]
 iced-x86 = { version = "1.21", default-features = false, features = ["no_std", "decoder", "encoder", "instr_info"] }
-object = { version = "0.36.7", default-features = false, features = ["elf", "read_core"] }
+object = { version = "0.36.7", default-features = false, features = ["elf", "pe", "read_core"] }
 thiserror = { version = "2.0.6", default-features = false }
 zerocopy = { version = "0.8", default-features = false, features = ["derive"] }
 

--- a/litebox_syscall_rewriter/src/lib.rs
+++ b/litebox_syscall_rewriter/src/lib.rs
@@ -271,6 +271,16 @@ pub fn rewrite_pe_for_litebox(input_binary: &[u8], trampoline: Option<u64>) -> R
     }
 
     let mut trampoline_data = Vec::from(trampoline.unwrap_or(0).to_le_bytes());
+    // Windows ntdll packs some syscall stubs too tightly for the generic
+    // five-byte jump patcher; keep that PE-specific shape out of the generic path.
+    let patched_dense_windows_stubs = patch_dense_windows_syscall_stubs_in_sections(
+        Arch::X86_64,
+        buf,
+        &text_sections,
+        trampoline_base_addr,
+        trampoline_base_addr,
+        &mut trampoline_data,
+    )?;
     let patch_result = patch_syscalls_in_sections(
         Arch::X86_64,
         buf,
@@ -280,7 +290,7 @@ pub fn rewrite_pe_for_litebox(input_binary: &[u8], trampoline: Option<u64>) -> R
         &mut trampoline_data,
     )?;
 
-    if !patch_result.found_syscall {
+    if !patched_dense_windows_stubs && !patch_result.found_syscall {
         return Ok(buf.to_vec());
     }
 
@@ -402,6 +412,41 @@ fn patch_syscalls_in_sections(
         found_syscall,
         skipped_addrs,
     })
+}
+
+fn patch_dense_windows_syscall_stubs_in_sections(
+    arch: Arch,
+    buf: &mut [u8],
+    text_sections: &[TextSectionInfo],
+    trampoline_base_addr: u64,
+    syscall_entry_addr: u64,
+    trampoline_data: &mut Vec<u8>,
+) -> Result<bool> {
+    let control_transfer_targets = get_control_transfer_targets(arch, &*buf, text_sections)?;
+    let mut patched_any = false;
+
+    for section in text_sections {
+        let section_data = section_slice_mut(buf, section)?;
+        let instructions = decode_section_instructions(arch, section_data, section.vaddr)?;
+        for (i, inst) in instructions.iter().enumerate() {
+            if inst.code() != iced_x86::Code::Syscall {
+                continue;
+            }
+
+            patched_any |= patch_dense_windows_syscall_stub(
+                &control_transfer_targets,
+                section.vaddr,
+                section_data,
+                trampoline_base_addr,
+                syscall_entry_addr,
+                trampoline_data,
+                &instructions,
+                i,
+            )?;
+        }
+    }
+
+    Ok(patched_any)
 }
 
 fn append_trampoline_footer(
@@ -571,18 +616,6 @@ fn hook_syscalls_in_section(
             ) {
                 Ok(()) => {}
                 Err(InternalError::InsufficientBytesBeforeOrAfter) => {
-                    if hook_dense_windows_syscall_stub(
-                        control_transfer_targets,
-                        section_base_addr,
-                        section_data,
-                        trampoline_base_addr,
-                        syscall_entry_addr,
-                        trampoline_data,
-                        &instructions,
-                        i,
-                    )? {
-                        continue;
-                    }
                     // Replace the unpatchable syscall with ICEBP;HLT so it
                     // traps instead of escaping to the host kernel.
                     replace_with_trap(section_data, section_base_addr, inst);
@@ -830,7 +863,7 @@ fn replace_with_trap(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn hook_dense_windows_syscall_stub(
+fn patch_dense_windows_syscall_stub(
     control_transfer_targets: &BTreeSet<u64>,
     section_base_addr: u64,
     section_data: &mut [u8],
@@ -839,7 +872,7 @@ fn hook_dense_windows_syscall_stub(
     trampoline_data: &mut Vec<u8>,
     instructions: &[iced_x86::Instruction],
     inst_index: usize,
-) -> core::result::Result<bool, InternalError> {
+) -> Result<bool> {
     if inst_index < 2 {
         return Ok(false);
     }

--- a/litebox_syscall_rewriter/src/lib.rs
+++ b/litebox_syscall_rewriter/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-//! Rewrite ELF files to hook syscalls
+//! Rewrite binaries for LiteBox execution.
 //!
 //! This crate sets up a trampoline point for every `syscall` instruction in its input binary,
 //! allowing for conveniently taking control of a binary without ptrace/systrap/seccomp/...
@@ -12,7 +12,8 @@
 //! However, as an explicit goal, it is intended to provide low-overhead hooking of syscalls,
 //! without needing to undergo a user-kernel transition.
 //!
-//! This crate currently only supports x86-64 (i.e., amd64) ELFs.
+//! This crate currently supports x86-64 ELFs for syscall hooking and x86-64 PEs for syscall
+//! hooking plus rewriting Windows TEB accesses from GS segment overrides to FS segment overrides.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 extern crate alloc;
@@ -23,7 +24,9 @@ use alloc::string::{String, ToString};
 use alloc::vec;
 use alloc::vec::Vec;
 
+use object::pe::{IMAGE_SCN_CNT_CODE, IMAGE_SCN_MEM_EXECUTE};
 use object::read::elf::{ElfFile, ProgramHeader as _};
+use object::read::pe::{ImageNtHeaders as _, ImageOptionalHeader as _, PeFile64};
 use object::read::{Object as _, ObjectSection as _};
 use thiserror::Error;
 use zerocopy::{FromBytes, Immutable, IntoBytes};
@@ -73,6 +76,19 @@ const BUN_FOOTER_MARKER: &[u8] = b"\n---- Bun! ----\n";
 /// This is checked by the loader to verify that the trampoline is valid.
 pub const TRAMPOLINE_MAGIC: &[u8; 8] = b"LITEBOX0";
 
+/// Rewrite a supported binary for LiteBox.
+///
+/// ELF64 inputs are passed through [`hook_syscalls_in_elf`]. PE64 inputs have
+/// executable-section GS segment overrides rewritten to FS and `syscall`
+/// instructions redirected through a LiteBox trampoline footer.
+pub fn rewrite_binary(input_binary: &[u8], trampoline: Option<u64>) -> Result<Vec<u8>> {
+    if is_pe_binary(input_binary) {
+        rewrite_pe_for_litebox(input_binary, trampoline)
+    } else {
+        hook_syscalls_in_elf(input_binary, trampoline)
+    }
+}
+
 /// Trampoline header for 64-bit: 8 (magic) + 8 (file_offset) + 8 (vaddr) + 8 (size) = 32 bytes
 #[repr(C, packed)]
 #[derive(FromBytes, IntoBytes, Immutable)]
@@ -83,7 +99,7 @@ struct TrampolineHeader64 {
     trampoline_size: u64,
 }
 
-/// Metadata about an executable section, extracted from the read-only ELF parse.
+/// Metadata about an executable section, extracted from a read-only object parse.
 struct TextSectionInfo {
     /// Virtual address of the section
     vaddr: u64,
@@ -91,6 +107,11 @@ struct TextSectionInfo {
     file_offset: u64,
     /// Size of the section data in bytes
     size: u64,
+}
+
+struct SyscallPatchResult {
+    found_syscall: bool,
+    skipped_addrs: Vec<u64>,
 }
 
 /// Update the `input_binary` with a call to `trampoline` instead of any `syscall` instructions.
@@ -153,7 +174,7 @@ pub fn hook_syscalls_in_elf(input_binary: &[u8], trampoline: Option<u64>) -> Res
     fixup_phdr_alignment(buf);
 
     // Parse the ELF and extract all metadata we need, then drop the borrow so we can mutate buf.
-    let (arch, text_sections, control_transfer_targets, trampoline_base_addr) = {
+    let (arch, text_sections, trampoline_base_addr) = {
         let file = object::File::parse(&*buf).map_err(|e| Error::ParseError(e.to_string()))?;
 
         let arch = match file {
@@ -172,72 +193,243 @@ pub fn hook_syscalls_in_elf(input_binary: &[u8], trampoline: Option<u64>) -> Res
             return Ok(input_binary.to_vec());
         }
 
-        let control_transfer_targets = get_control_transfer_targets(arch, &*buf, &text_sections)?;
-
         let trampoline_base_addr = find_addr_for_trampoline_code(&file)?;
 
-        (
-            arch,
-            text_sections,
-            control_transfer_targets,
-            trampoline_base_addr,
-        )
+        (arch, text_sections, trampoline_base_addr)
     };
 
-    // Build the trampoline code (without header - header goes at the end)
-    // The code starts with the syscall entry point placeholder (8 bytes for x86-64)
-    let mut trampoline_data = vec![];
-    let trampoline = trampoline.unwrap_or(0);
-    trampoline_data.extend_from_slice(&trampoline.to_le_bytes());
-    // Patch syscalls in-place in buf
+    let mut trampoline_data = Vec::from(trampoline.unwrap_or(0).to_le_bytes());
+    let patch_result = patch_syscalls_in_sections(
+        arch,
+        buf,
+        &text_sections,
+        trampoline_base_addr,
+        trampoline_base_addr,
+        &mut trampoline_data,
+    )?;
+
+    // Build output: [patched ELF][padding to page boundary][trampoline code][header]
+    let mut out = buf.to_vec();
+    append_trampoline_footer(&mut out, &mut trampoline_data, trampoline_base_addr, false);
+
+    if !patch_result.skipped_addrs.is_empty() {
+        return Err(Error::UnpatchableSyscalls(format!(
+            "{} unpatchable syscall instruction(s) at {skipped_addrs:?}",
+            patch_result.skipped_addrs.len(),
+            skipped_addrs = patch_result.skipped_addrs,
+        )));
+    }
+    Ok(out)
+}
+
+/// Rewrite an x86-64 PE for LiteBox's current Windows shim.
+///
+/// The PE file layout is preserved, but executable-section GS segment overrides
+/// are rewritten to FS and `syscall` instructions are redirected through a
+/// LiteBox trampoline appended as a file overlay. The Windows shim loader maps
+/// that overlay by reading the footer this function appends.
+pub fn rewrite_pe_for_litebox(input_binary: &[u8], trampoline: Option<u64>) -> Result<Vec<u8>> {
+    if is_already_hooked(input_binary, Arch::X86_64) {
+        return Ok(input_binary.to_vec());
+    }
+
+    let mut backing = vec![0u64; input_binary.len().div_ceil(8)];
+    let buf: &mut [u8] = zerocopy::IntoBytes::as_mut_bytes(backing.as_mut_slice());
+    buf[..input_binary.len()].copy_from_slice(input_binary);
+    let buf = &mut buf[..input_binary.len()];
+
+    let (text_sections, trampoline_base_rva, trampoline_base_addr) = {
+        let pe = PeFile64::parse(&*buf).map_err(|e| Error::ParseError(e.to_string()))?;
+        let optional_header = pe.nt_headers().optional_header();
+        let size_of_image = u64::from(optional_header.size_of_image());
+        let trampoline_base_rva =
+            checked_add_u64(size_of_image, 0xfff, "PE trampoline base")? & !0xfff;
+        let trampoline_base_addr = checked_add_u64(
+            optional_header.image_base(),
+            trampoline_base_rva,
+            "PE trampoline virtual address",
+        )?;
+
+        let file = object::File::parse(&*buf).map_err(|e| Error::ParseError(e.to_string()))?;
+        match file {
+            object::File::Pe64(_) if file.architecture() == object::Architecture::X86_64 => {}
+            _ => return Ok(input_binary.to_vec()),
+        }
+
+        let text_sections = match pe_text_sections(&file) {
+            Ok(sections) => sections,
+            Err(InternalError::NoTextSectionFound) => return Ok(input_binary.to_vec()),
+            Err(InternalError::Public(e)) => return Err(e),
+            Err(e) => unreachable!("unexpected internal error: {e:?}"),
+        };
+        (text_sections, trampoline_base_rva, trampoline_base_addr)
+    };
+
+    for section in &text_sections {
+        let section_data = section_slice_mut(buf, section)?;
+        rewrite_gs_to_fs_in_section(Arch::X86_64, section.vaddr, section_data)?;
+    }
+
+    let mut trampoline_data = Vec::from(trampoline.unwrap_or(0).to_le_bytes());
+    let patch_result = patch_syscalls_in_sections(
+        Arch::X86_64,
+        buf,
+        &text_sections,
+        trampoline_base_addr,
+        trampoline_base_addr,
+        &mut trampoline_data,
+    )?;
+
+    if !patch_result.found_syscall {
+        return Ok(buf.to_vec());
+    }
+
+    let mut out = buf.to_vec();
+    append_trampoline_footer(&mut out, &mut trampoline_data, trampoline_base_rva, true);
+
+    if !patch_result.skipped_addrs.is_empty() {
+        return Err(Error::UnpatchableSyscalls(format!(
+            "{} unpatchable syscall instruction(s) at {skipped_addrs:?}",
+            patch_result.skipped_addrs.len(),
+            skipped_addrs = patch_result.skipped_addrs,
+        )));
+    }
+
+    Ok(out)
+}
+
+fn is_pe_binary(input_binary: &[u8]) -> bool {
+    if input_binary.len() < 0x40 || &input_binary[..2] != b"MZ" {
+        return false;
+    }
+    let pe_offset = u32::from_le_bytes(input_binary[0x3c..0x40].try_into().unwrap()) as usize;
+    input_binary
+        .get(pe_offset..pe_offset.saturating_add(4))
+        .is_some_and(|magic| magic == b"PE\0\0")
+}
+
+fn pe_text_sections(
+    file: &object::File<'_>,
+) -> core::result::Result<Vec<TextSectionInfo>, InternalError> {
+    let text_sections: Vec<_> = file
+        .sections()
+        .filter_map(|section| {
+            let object::SectionFlags::Coff { characteristics } = section.flags() else {
+                return None;
+            };
+            if characteristics & IMAGE_SCN_CNT_CODE == 0 {
+                return None;
+            }
+            if characteristics & IMAGE_SCN_MEM_EXECUTE == 0 {
+                return None;
+            }
+            let (file_offset, size) = section.file_range()?;
+            Some(TextSectionInfo {
+                vaddr: section.address(),
+                file_offset,
+                size,
+            })
+        })
+        .collect();
+    if text_sections.is_empty() {
+        return Err(InternalError::NoTextSectionFound);
+    }
+    Ok(text_sections)
+}
+
+fn rewrite_gs_to_fs_in_section(
+    arch: Arch,
+    section_base_addr: u64,
+    section_data: &mut [u8],
+) -> Result<usize> {
+    let instructions = decode_section_instructions(arch, section_data, section_base_addr)?;
+    let mut rewritten = 0;
+
+    for instruction in &instructions {
+        if instruction.memory_segment() != iced_x86::Register::GS {
+            continue;
+        }
+
+        let offset = usize::try_from(instruction.ip() - section_base_addr).unwrap();
+        let instruction_bytes = &mut section_data[offset..offset + instruction.len()];
+        let Some(segment_prefix) = instruction_bytes.iter_mut().find(|byte| **byte == 0x65) else {
+            return Err(Error::DisassemblyFailure(format!(
+                "GS memory operand at {:#x} has no GS segment prefix",
+                instruction.ip()
+            )));
+        };
+        *segment_prefix = 0x64;
+        rewritten += 1;
+    }
+
+    Ok(rewritten)
+}
+
+fn patch_syscalls_in_sections(
+    arch: Arch,
+    buf: &mut [u8],
+    text_sections: &[TextSectionInfo],
+    trampoline_base_addr: u64,
+    syscall_entry_addr: u64,
+    trampoline_data: &mut Vec<u8>,
+) -> Result<SyscallPatchResult> {
+    let control_transfer_targets = get_control_transfer_targets(arch, &*buf, text_sections)?;
+    let mut found_syscall = false;
     let mut skipped_addrs = Vec::new();
-    for s in &text_sections {
-        let section_data = section_slice_mut(buf, s)?;
+
+    for section in text_sections {
+        let section_data = section_slice_mut(buf, section)?;
         match hook_syscalls_in_section(
             arch,
             &control_transfer_targets,
-            s.vaddr,
+            section.vaddr,
             section_data,
             trampoline_base_addr,
-            trampoline_base_addr, // entry point is at offset 0 of trampoline
-            &mut trampoline_data,
+            syscall_entry_addr,
+            trampoline_data,
         ) {
-            Ok(addrs) => skipped_addrs.extend(addrs),
+            Ok(addrs) => {
+                found_syscall = true;
+                skipped_addrs.extend(addrs);
+            }
             Err(InternalError::NoSyscallInstructionsFound) => {}
             Err(InternalError::Public(e)) => return Err(e),
             Err(e) => unreachable!("unexpected internal error: {e:?}"),
         }
     }
 
-    // Build output: [patched ELF][padding to page boundary][trampoline code][header]
-    let mut out = buf.to_vec();
+    Ok(SyscallPatchResult {
+        found_syscall,
+        skipped_addrs,
+    })
+}
+
+fn append_trampoline_footer(
+    out: &mut Vec<u8>,
+    trampoline_data: &mut Vec<u8>,
+    header_vaddr: u64,
+    align_trampoline_size: bool,
+) {
     let remain = out.len() % 0x1000;
     out.extend_from_slice(&vec![0; if remain == 0 { 0 } else { 0x1000 - remain }]);
 
-    // Calculate file offset where trampoline code starts
     let trampoline_file_offset = out.len() as u64;
+    if align_trampoline_size {
+        let trampoline_size = trampoline_data.len().next_multiple_of(0x1000);
+        trampoline_data.extend_from_slice(&vec![0; trampoline_size - trampoline_data.len()]);
+    }
     let trampoline_size = trampoline_data.len();
+    out.extend_from_slice(trampoline_data);
 
-    // Append trampoline code
-    out.extend_from_slice(&trampoline_data);
-
-    // Build the header (goes at the end of the file)
-    // The entry point placeholder is at offset 0 of the trampoline code, not in the header.
     let header = TrampolineHeader64 {
         magic: *TRAMPOLINE_MAGIC,
         file_offset: trampoline_file_offset,
-        vaddr: trampoline_base_addr,
+        vaddr: header_vaddr,
         trampoline_size: trampoline_size as u64,
     };
     out.extend_from_slice(header.as_bytes());
-    if !skipped_addrs.is_empty() {
-        return Err(Error::UnpatchableSyscalls(format!(
-            "{} unpatchable syscall instruction(s) at {skipped_addrs:?}",
-            skipped_addrs.len(),
-        )));
-    }
-    Ok(out)
 }
+
 /// (private) Get metadata for executable sections
 fn text_sections(
     file: &object::File<'_>,
@@ -379,6 +571,18 @@ fn hook_syscalls_in_section(
             ) {
                 Ok(()) => {}
                 Err(InternalError::InsufficientBytesBeforeOrAfter) => {
+                    if hook_dense_windows_syscall_stub(
+                        control_transfer_targets,
+                        section_base_addr,
+                        section_data,
+                        trampoline_base_addr,
+                        syscall_entry_addr,
+                        trampoline_data,
+                        &instructions,
+                        i,
+                    )? {
+                        continue;
+                    }
                     // Replace the unpatchable syscall with ICEBP;HLT so it
                     // traps instead of escaping to the host kernel.
                     replace_with_trap(section_data, section_base_addr, inst);
@@ -625,6 +829,131 @@ fn replace_with_trap(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
+fn hook_dense_windows_syscall_stub(
+    control_transfer_targets: &BTreeSet<u64>,
+    section_base_addr: u64,
+    section_data: &mut [u8],
+    trampoline_base_addr: u64,
+    syscall_entry_addr: u64,
+    trampoline_data: &mut Vec<u8>,
+    instructions: &[iced_x86::Instruction],
+    inst_index: usize,
+) -> core::result::Result<bool, InternalError> {
+    if inst_index < 2 {
+        return Ok(false);
+    }
+
+    let test_inst = &instructions[inst_index - 2];
+    let jne_inst = &instructions[inst_index - 1];
+    let syscall_inst = &instructions[inst_index];
+
+    if !is_dense_windows_syscall_stub_sequence(test_inst, jne_inst, section_base_addr, section_data)
+    {
+        return Ok(false);
+    }
+
+    let stub_addr = test_inst.ip();
+    let fallback_addr = checked_add_u64(
+        jne_inst.ip(),
+        DENSE_WINDOWS_SYSCALL_STUB_TAIL_FALLBACK_OFFSET as u64,
+        "dense Windows syscall fallback address",
+    )?;
+    let stub_end_addr = checked_add_u64(
+        jne_inst.ip(),
+        DENSE_WINDOWS_SYSCALL_STUB_TAIL.len() as u64,
+        "dense Windows syscall stub end address",
+    )?;
+    if control_transfer_targets
+        .iter()
+        .any(|target| (stub_addr..stub_end_addr).contains(target) && *target != fallback_addr)
+    {
+        return Ok(false);
+    }
+
+    let target_addr = checked_add_u64(
+        trampoline_base_addr,
+        trampoline_data.len() as u64,
+        "dense Windows syscall trampoline target",
+    )?;
+
+    let return_addr = syscall_inst.next_ip();
+    let jmp_back_base = checked_add_u64(
+        trampoline_base_addr,
+        trampoline_data.len() as u64 + 7,
+        "dense Windows syscall trampoline return base",
+    )?;
+    // lea rcx, [rip + disp32]
+    trampoline_data.extend_from_slice(&[0x48, 0x8D, 0x0D]);
+    trampoline_data.extend_from_slice(&rel32_bytes(
+        return_addr,
+        jmp_back_base,
+        "dense Windows syscall trampoline return",
+    )?);
+
+    // jmp qword ptr [rip + disp32]
+    trampoline_data.extend_from_slice(&[0xFF, 0x25]);
+    let entry_base = checked_add_u64(
+        trampoline_base_addr,
+        trampoline_data.len() as u64 + 4,
+        "dense Windows syscall trampoline entry base",
+    )?;
+    trampoline_data.extend_from_slice(&rel32_bytes(
+        syscall_entry_addr,
+        entry_base,
+        "dense Windows syscall trampoline entry",
+    )?);
+
+    let stub_offset = usize::try_from(stub_addr - section_base_addr).unwrap();
+    section_data[stub_offset] = 0xe9;
+    let patch_base = checked_add_u64(stub_addr, 5, "dense Windows syscall patch jump base")?;
+    section_data[stub_offset + 1..stub_offset + 5].copy_from_slice(&rel32_bytes(
+        target_addr,
+        patch_base,
+        "dense Windows syscall patch jump",
+    )?);
+
+    let syscall_end_offset = usize::try_from(syscall_inst.next_ip() - section_base_addr).unwrap();
+    for byte in &mut section_data[stub_offset + 5..syscall_end_offset] {
+        *byte = 0x90;
+    }
+
+    let fallback_offset = usize::try_from(fallback_addr - section_base_addr).unwrap();
+    section_data[fallback_offset] = 0xeb;
+    section_data[fallback_offset + 1] =
+        i8::try_from(i128::from(stub_addr) - i128::from(fallback_addr + 2))
+            .map_err(|_| {
+                Error::AddressOverflow("dense Windows syscall fallback jump out of range".into())
+            })?
+            .to_ne_bytes()[0];
+
+    Ok(true)
+}
+
+fn is_dense_windows_syscall_stub_sequence(
+    test_inst: &iced_x86::Instruction,
+    jne_inst: &iced_x86::Instruction,
+    section_base_addr: u64,
+    section_data: &[u8],
+) -> bool {
+    if !matches!(
+        test_inst.code(),
+        iced_x86::Code::Test_rm8_imm8 | iced_x86::Code::Test_rm8_imm8_F6r1
+    ) || test_inst.immediate8() != 1
+    {
+        return false;
+    }
+
+    let Ok(tail_offset) = usize::try_from(jne_inst.ip() - section_base_addr) else {
+        return false;
+    };
+    let Some(tail_end) = tail_offset.checked_add(DENSE_WINDOWS_SYSCALL_STUB_TAIL.len()) else {
+        return false;
+    };
+
+    section_data.get(tail_offset..tail_end) == Some(DENSE_WINDOWS_SYSCALL_STUB_TAIL)
+}
+
 fn checked_add_u64(base: u64, addend: u64, context: &'static str) -> Result<u64> {
     base.checked_add(addend)
         .ok_or_else(|| Error::AddressOverflow(format!("{context} address overflow")))
@@ -751,6 +1080,9 @@ fn get_control_transfer_targets(
 const MAX_X86_INSTRUCTION_LEN: usize = 15;
 const CHUNK_OVERLAP_LEN: usize = MAX_X86_INSTRUCTION_LEN - 1;
 const TARGET_DECODE_CHUNK_LEN: usize = 8 * 1024 * 1024;
+// jne +3; syscall; ret; int 0x2e; ret
+const DENSE_WINDOWS_SYSCALL_STUB_TAIL: &[u8] = &[0x75, 0x03, 0x0f, 0x05, 0xc3, 0xcd, 0x2e, 0xc3];
+const DENSE_WINDOWS_SYSCALL_STUB_TAIL_FALLBACK_OFFSET: usize = 5;
 
 fn bytes_until_next_4g_boundary(ptr: *const u8) -> usize {
     let low = (ptr as u64) & 0xFFFF_FFFF;

--- a/litebox_syscall_rewriter/src/main.rs
+++ b/litebox_syscall_rewriter/src/main.rs
@@ -10,10 +10,10 @@ use std::io::Write as _;
 use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
 use std::path::PathBuf;
 
-/// Rewrite ELF files to hook syscalls
+/// Rewrite ELF files to hook syscalls, or PE files to hook syscalls and change GS TEB accesses to FS.
 #[derive(Parser, Debug)]
 struct CliArgs {
-    /// Path to input ELF binary
+    /// Path to input binary
     input_binary: PathBuf,
     /// Path to output the generated binary (default = <INPUT_BINARY>.hooked)
     #[arg(short = 'o', long = "output")]
@@ -47,10 +47,8 @@ fn main() -> anyhow::Result<()> {
     let mut input_binary = std::fs::File::open(&cli_args.input_binary)?;
     let mut input_binary_bytes = vec![];
     input_binary.read_to_end(&mut input_binary_bytes)?;
-    let output_binary = litebox_syscall_rewriter::hook_syscalls_in_elf(
-        &input_binary_bytes,
-        cli_args.trampoline_addr,
-    )?;
+    let output_binary =
+        litebox_syscall_rewriter::rewrite_binary(&input_binary_bytes, cli_args.trampoline_addr)?;
     let output_path = cli_args.output_binary.unwrap_or_else(|| {
         cli_args.input_binary.with_file_name(
             cli_args


### PR DESCRIPTION
This PR supports rewriting PE and loading its trampoline. For syscall rewriting, there is a common pattern that the previous rewriter cannot handle:
```
test byte ptr [...], 1
jne +3
syscall
ret
int 0x2e
ret
```
Adds a heuristic to rewrite it to:
```
1:
jmp to trampoline code
ret
nop
...
jmp 1b
```

It also rewrites all gs based instructions to fs-based ones.

For now, the guest program still starts with the main executable instead of ntdll because of lack of set up of PEB/TEB.