### PR TITLE
Support syscall faccessat/faccessat2

### DIFF
--- a/litebox/src/fs/in_mem.rs
+++ b/litebox/src/fs/in_mem.rs
@@ -52,24 +52,15 @@ impl<Platform: sync::RawSyncPrimitivesProvider> FileSystem<Platform> {
     /// system.
     #[must_use]
     pub fn new(litebox: &LiteBox<Platform>) -> Self {
-        Self::new_with_user(
-            litebox,
-            UserInfo {
-                user: 1000,
-                group: 1000,
-            },
-        )
-    }
-
-    /// Construct a new `FileSystem` instance with the given initial user.
-    #[must_use]
-    pub fn new_with_user(litebox: &LiteBox<Platform>, current_user: UserInfo) -> Self {
         let litebox = litebox.clone();
         let root = sync::RwLock::new(RootDir::new());
         Self {
             litebox,
             root,
-            current_user,
+            current_user: UserInfo {
+                user: 1000,
+                group: 1000,
+            },
             current_working_dir: "/".into(),
             unique_id_freshness: 1.into(), // the root dir gets unique ID of 0
         }

--- a/litebox/src/fs/in_mem.rs
+++ b/litebox/src/fs/in_mem.rs
@@ -52,15 +52,24 @@ impl<Platform: sync::RawSyncPrimitivesProvider> FileSystem<Platform> {
     /// system.
     #[must_use]
     pub fn new(litebox: &LiteBox<Platform>) -> Self {
+        Self::new_with_user(
+            litebox,
+            UserInfo {
+                user: 1000,
+                group: 1000,
+            },
+        )
+    }
+
+    /// Construct a new `FileSystem` instance with the given initial user.
+    #[must_use]
+    pub fn new_with_user(litebox: &LiteBox<Platform>, current_user: UserInfo) -> Self {
         let litebox = litebox.clone();
         let root = sync::RwLock::new(RootDir::new());
         Self {
             litebox,
             root,
-            current_user: UserInfo {
-                user: 1000,
-                group: 1000,
-            },
+            current_user,
             current_working_dir: "/".into(),
             unique_id_freshness: 1.into(), // the root dir gets unique ID of 0
         }

--- a/litebox_common_linux/src/lib.rs
+++ b/litebox_common_linux/src/lib.rs
@@ -2097,9 +2097,11 @@ pub enum SyscallRequest<Platform: litebox::platform::RawPointerProvider> {
         pos_l: usize,
         pos_h: usize,
     },
-    Access {
+    Faccessat {
+        dirfd: i32,
         pathname: Platform::RawConstPointer<i8>,
         mode: AccessFlags,
+        flags: AtFlags,
     },
     Madvise {
         addr: Platform::RawMutPointer<u8>,
@@ -2596,7 +2598,19 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
             Sysno::writev => sys_req!(Writev { fd, iovec:*, iovcnt }),
             Sysno::preadv => sys_req!(Preadv { fd, iovec:*, iovcnt, pos_l, pos_h }),
             Sysno::pwritev => sys_req!(Pwritev { fd, iovec:*, iovcnt, pos_l, pos_h }),
-            Sysno::access => sys_req!(Access { pathname:*, mode }),
+            Sysno::access => SyscallRequest::Faccessat {
+                dirfd: AT_FDCWD,
+                pathname: ctx.sys_req_ptr(0),
+                mode: ctx.sys_req_arg(1),
+                flags: AtFlags::empty(),
+            },
+            Sysno::faccessat => SyscallRequest::Faccessat {
+                dirfd: ctx.sys_req_arg(0),
+                pathname: ctx.sys_req_ptr(1),
+                mode: ctx.sys_req_arg(2),
+                flags: AtFlags::empty(),
+            },
+            Sysno::faccessat2 => sys_req!(Faccessat { dirfd, pathname:*, mode, flags }),
             Sysno::pipe => sys_req!(Pipe2 { pipefd:*, flags: { litebox::fs::OFlags::empty() } }),
             Sysno::pipe2 => sys_req!(Pipe2 { pipefd:* ,flags }),
             Sysno::madvise => sys_req!(Madvise { addr:*, length, behavior:? }),

--- a/litebox_runner_linux_userland/src/lib.rs
+++ b/litebox_runner_linux_userland/src/lib.rs
@@ -11,6 +11,11 @@ use std::path::{Path, PathBuf};
 
 extern crate alloc;
 
+// Use a stable non-root guest identity instead of mirroring the host user. This keeps shim
+// credentials aligned with the in-memory filesystem default user and avoids truncating high host IDs.
+const DEFAULT_GUEST_UID: u16 = 1000;
+const DEFAULT_GUEST_GID: u16 = 1000;
+
 /// Run Linux programs with LiteBox on unmodified Linux
 ///
 /// Detailed logging can be controlled via the `LITEBOX_LOG` environment variable. For example:
@@ -198,13 +203,22 @@ pub fn run(cli_args: CliArgs) -> Result<()> {
     litebox_platform_multiplex::set_platform(platform);
     let shim_builder = litebox_shim_linux::LinuxShimBuilder::new();
     let litebox = shim_builder.litebox();
-    let task_params = platform.init_task();
-    let fs_user = litebox::fs::UserInfo {
-        user: task_params.euid.try_into()?,
-        group: task_params.egid.try_into()?,
+    // SAFETY: `gettid` takes no pointer arguments and has no Rust-side aliasing requirements.
+    let tid = unsafe { libc::syscall(libc::SYS_gettid) }
+        .try_into()
+        .context("failed to convert gettid result to i32")?;
+    // SAFETY: `getppid` takes no arguments and has no Rust-side aliasing requirements.
+    let ppid = unsafe { libc::getppid() };
+    let task_params = litebox_common_linux::TaskParams {
+        pid: tid,
+        ppid,
+        uid: u32::from(DEFAULT_GUEST_UID),
+        euid: u32::from(DEFAULT_GUEST_UID),
+        gid: u32::from(DEFAULT_GUEST_GID),
+        egid: u32::from(DEFAULT_GUEST_GID),
     };
     let initial_file_system = {
-        let mut in_mem = litebox::fs::in_mem::FileSystem::new_with_user(litebox, fs_user);
+        let mut in_mem = litebox::fs::in_mem::FileSystem::new(litebox);
 
         // When loading the program from the tar, we don't need to create ancestor
         // directories or write the program binary into the in-memory FS -- the program
@@ -216,8 +230,8 @@ pub fn run(cli_args: CliArgs) -> Result<()> {
                                          path: &Path| {
                 fs.chown(
                     path.to_str().unwrap(),
-                    Some(fs_user.user),
-                    Some(fs_user.group),
+                    Some(DEFAULT_GUEST_UID),
+                    Some(DEFAULT_GUEST_GID),
                 )
                 .unwrap();
             };
@@ -234,7 +248,7 @@ pub fn run(cli_args: CliArgs) -> Result<()> {
                     in_mem.with_root_privileges(|fs| {
                         fs.mkdir(path.to_str().unwrap(), mode_and_user.0).unwrap();
                         if mode_and_user.1 != 0 {
-                            chown_to_initial_user(fs, path);
+                            chown_to_initial_user(fs, &prog);
                         }
                     });
                 } else {

--- a/litebox_runner_linux_userland/src/lib.rs
+++ b/litebox_runner_linux_userland/src/lib.rs
@@ -198,8 +198,13 @@ pub fn run(cli_args: CliArgs) -> Result<()> {
     litebox_platform_multiplex::set_platform(platform);
     let shim_builder = litebox_shim_linux::LinuxShimBuilder::new();
     let litebox = shim_builder.litebox();
+    let task_params = platform.init_task();
+    let fs_user = litebox::fs::UserInfo {
+        user: task_params.euid.try_into()?,
+        group: task_params.egid.try_into()?,
+    };
     let initial_file_system = {
-        let mut in_mem = litebox::fs::in_mem::FileSystem::new(litebox);
+        let mut in_mem = litebox::fs::in_mem::FileSystem::new_with_user(litebox, fs_user);
 
         // When loading the program from the tar, we don't need to create ancestor
         // directories or write the program binary into the in-memory FS -- the program
@@ -207,6 +212,15 @@ pub fn run(cli_args: CliArgs) -> Result<()> {
         if let Some(prog_data) = prog_data {
             let prog = std::path::absolute(Path::new(&cli_args.program_and_arguments[0])).unwrap();
             let ancestors: Vec<_> = prog.ancestors().collect();
+            let chown_to_initial_user = |fs: &mut litebox::fs::in_mem::FileSystem<Platform>,
+                                         path: &Path| {
+                fs.chown(
+                    path.to_str().unwrap(),
+                    Some(fs_user.user),
+                    Some(fs_user.group),
+                )
+                .unwrap();
+            };
             let mut prev_user = 0;
             for (path, &mode_and_user) in ancestors
                 .into_iter()
@@ -220,9 +234,7 @@ pub fn run(cli_args: CliArgs) -> Result<()> {
                     in_mem.with_root_privileges(|fs| {
                         fs.mkdir(path.to_str().unwrap(), mode_and_user.0).unwrap();
                         if mode_and_user.1 != 0 {
-                            // This file is owned by a non-root user, so we need to set the ownership to our default user
-                            fs.chown(path.to_str().unwrap(), Some(1000), Some(1000))
-                                .unwrap();
+                            chown_to_initial_user(fs, path);
                         }
                     });
                 } else {
@@ -254,9 +266,7 @@ pub fn run(cli_args: CliArgs) -> Result<()> {
                 in_mem.with_root_privileges(|fs| {
                     open_file(fs, prog.to_str().unwrap(), last.0);
                     if last.1 != 0 {
-                        // This file is owned by a non-root user, so we need to set the ownership to our default user
-                        fs.chown(prog.to_str().unwrap(), Some(1000), Some(1000))
-                            .unwrap();
+                        chown_to_initial_user(fs, &prog);
                     }
                 });
             } else {
@@ -356,8 +366,6 @@ pub fn run(cli_args: CliArgs) -> Result<()> {
     } else {
         envp
     };
-
-    let task_params = platform.init_task();
 
     #[cfg(target_arch = "x86_64")]
     litebox_platform_linux_userland::LinuxUserland::enable_seccomp_filter();

--- a/litebox_runner_linux_userland/src/lib.rs
+++ b/litebox_runner_linux_userland/src/lib.rs
@@ -248,7 +248,7 @@ pub fn run(cli_args: CliArgs) -> Result<()> {
                     in_mem.with_root_privileges(|fs| {
                         fs.mkdir(path.to_str().unwrap(), mode_and_user.0).unwrap();
                         if mode_and_user.1 != 0 {
-                            chown_to_initial_user(fs, &prog);
+                            chown_to_initial_user(fs, path);
                         }
                     });
                 } else {

--- a/litebox_runner_linux_userland/tests/faccessat.c
+++ b/litebox_runner_linux_userland/tests/faccessat.c
@@ -1,44 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-#define _GNU_SOURCE
-#include <errno.h>
-#include <fcntl.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <sys/stat.h>
-#include <sys/syscall.h>
-#include <unistd.h>
-
-#define FAIL(msg)                                                              \
-    do {                                                                       \
-        fprintf(stderr, "FAIL: %s (line %d): %s (errno=%d: %s)\n", __func__,   \
-                __LINE__, (msg), errno, strerror(errno));                      \
-        exit(1);                                                               \
-    } while (0)
-
-#define EXPECT(cond, msg)                                                      \
-    do {                                                                       \
-        if (!(cond)) {                                                         \
-            FAIL(msg);                                                         \
-        }                                                                      \
-    } while (0)
+#include "helpers.h"
 
 static long raw_faccessat(int dirfd, const char *pathname, int mode) {
     return syscall(SYS_faccessat, dirfd, pathname, mode);
 }
 
-static void create_file(const char *path, mode_t mode) {
-    int fd = open(path, O_RDONLY | O_CREAT, mode);
-    EXPECT(fd >= 0, "create test file failed");
-    EXPECT(close(fd) == 0, "close test file failed");
-}
-
 static void test_at_fdcwd_success(void) {
     const char *path = "/tmp/lb_faccessat_success";
     unlink(path);
-    create_file(path, 0600);
+    create_test_file(path, 0600);
 
     errno = 0;
     long ret = raw_faccessat(AT_FDCWD, path, F_OK);
@@ -67,7 +39,7 @@ static void test_missing_path_enoent(void) {
 static void test_mode_permission_denied(void) {
     const char *path = "/tmp/lb_faccessat_readonly";
     unlink(path);
-    create_file(path, 0400);
+    create_test_file(path, 0400);
 
     errno = 0;
     long ret = raw_faccessat(AT_FDCWD, path, W_OK);
@@ -85,7 +57,7 @@ static void test_mode_permission_denied(void) {
 static void test_invalid_mode_einval(void) {
     const char *path = "/tmp/lb_faccessat_invalid_mode";
     unlink(path);
-    create_file(path, 0600);
+    create_test_file(path, 0600);
 
     errno = 0;
     long ret = raw_faccessat(AT_FDCWD, path, R_OK | 8);

--- a/litebox_runner_linux_userland/tests/faccessat.c
+++ b/litebox_runner_linux_userland/tests/faccessat.c
@@ -7,21 +7,29 @@ static long raw_faccessat(int dirfd, const char *pathname, int mode) {
     return syscall(SYS_faccessat, dirfd, pathname, mode);
 }
 
+static void expect_faccessat_ok(int dirfd, const char *pathname, int mode, const char *op) {
+    errno = 0;
+    TEST_ASSERT(raw_faccessat(dirfd, pathname, mode) == 0, op);
+}
+
+static void expect_faccessat_errno(int dirfd, const char *pathname, int mode,
+                                   int expected_errno, const char *op) {
+    errno = 0;
+    long ret = raw_faccessat(dirfd, pathname, mode);
+    TEST_ASSERT(ret == -1 && errno == expected_errno, op);
+}
+
 static void test_at_fdcwd_success(void) {
     const char *path = "/tmp/lb_faccessat_success";
     unlink(path);
     create_test_file(path, 0600);
 
-    errno = 0;
-    long ret = raw_faccessat(AT_FDCWD, path, F_OK);
-    EXPECT(ret == 0, "faccessat AT_FDCWD F_OK should succeed");
-
-    errno = 0;
-    ret = raw_faccessat(AT_FDCWD, path, R_OK | W_OK);
-    EXPECT(ret == 0, "faccessat AT_FDCWD R_OK|W_OK should succeed");
+    expect_faccessat_ok(AT_FDCWD, path, F_OK, "faccessat AT_FDCWD F_OK should succeed");
+    expect_faccessat_ok(AT_FDCWD, path, R_OK | W_OK,
+                        "faccessat AT_FDCWD R_OK|W_OK should succeed");
 
     struct stat st;
-    EXPECT(stat(path, &st) == 0, "stat should observe file after faccessat");
+    TEST_ASSERT(stat(path, &st) == 0, "stat should observe file after faccessat");
 
     unlink(path);
 }
@@ -30,10 +38,8 @@ static void test_missing_path_enoent(void) {
     const char *path = "/tmp/lb_faccessat_missing";
     unlink(path);
 
-    errno = 0;
-    long ret = raw_faccessat(AT_FDCWD, path, F_OK);
-    EXPECT(ret == -1 && errno == ENOENT,
-           "faccessat on a missing path should fail with ENOENT");
+    expect_faccessat_errno(AT_FDCWD, path, F_OK, ENOENT,
+                           "faccessat on a missing path should fail with ENOENT");
 }
 
 static void test_mode_permission_denied(void) {
@@ -41,15 +47,13 @@ static void test_mode_permission_denied(void) {
     unlink(path);
     create_test_file(path, 0400);
 
-    errno = 0;
-    long ret = raw_faccessat(AT_FDCWD, path, W_OK);
-    EXPECT(ret == -1 && errno == EACCES,
-           "faccessat W_OK on read-only file should fail with EACCES");
+    expect_faccessat_errno(AT_FDCWD, path, W_OK, EACCES,
+                           "faccessat W_OK on read-only file should fail with EACCES");
 
     errno = 0;
-    ret = open(path, O_RDONLY);
-    EXPECT(ret >= 0, "open should observe that the file still exists");
-    close((int)ret);
+    int fd = open(path, O_RDONLY);
+    TEST_ASSERT(fd >= 0, "open should observe that the file still exists");
+    close(fd);
 
     unlink(path);
 }
@@ -59,10 +63,8 @@ static void test_invalid_mode_einval(void) {
     unlink(path);
     create_test_file(path, 0600);
 
-    errno = 0;
-    long ret = raw_faccessat(AT_FDCWD, path, R_OK | 8);
-    EXPECT(ret == -1 && errno == EINVAL,
-           "faccessat with invalid mode bits should fail with EINVAL");
+    expect_faccessat_errno(AT_FDCWD, path, R_OK | 8, EINVAL,
+                           "faccessat with invalid mode bits should fail with EINVAL");
 
     unlink(path);
 }

--- a/litebox_runner_linux_userland/tests/faccessat.c
+++ b/litebox_runner_linux_userland/tests/faccessat.c
@@ -1,0 +1,106 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#define FAIL(msg)                                                              \
+    do {                                                                       \
+        fprintf(stderr, "FAIL: %s (line %d): %s (errno=%d: %s)\n", __func__,   \
+                __LINE__, (msg), errno, strerror(errno));                      \
+        exit(1);                                                               \
+    } while (0)
+
+#define EXPECT(cond, msg)                                                      \
+    do {                                                                       \
+        if (!(cond)) {                                                         \
+            FAIL(msg);                                                         \
+        }                                                                      \
+    } while (0)
+
+static long raw_faccessat(int dirfd, const char *pathname, int mode) {
+    return syscall(SYS_faccessat, dirfd, pathname, mode);
+}
+
+static void create_file(const char *path, mode_t mode) {
+    int fd = open(path, O_RDONLY | O_CREAT, mode);
+    EXPECT(fd >= 0, "create test file failed");
+    EXPECT(close(fd) == 0, "close test file failed");
+}
+
+static void test_at_fdcwd_success(void) {
+    const char *path = "/tmp/lb_faccessat_success";
+    unlink(path);
+    create_file(path, 0600);
+
+    errno = 0;
+    long ret = raw_faccessat(AT_FDCWD, path, F_OK);
+    EXPECT(ret == 0, "faccessat AT_FDCWD F_OK should succeed");
+
+    errno = 0;
+    ret = raw_faccessat(AT_FDCWD, path, R_OK | W_OK);
+    EXPECT(ret == 0, "faccessat AT_FDCWD R_OK|W_OK should succeed");
+
+    struct stat st;
+    EXPECT(stat(path, &st) == 0, "stat should observe file after faccessat");
+
+    unlink(path);
+}
+
+static void test_missing_path_enoent(void) {
+    const char *path = "/tmp/lb_faccessat_missing";
+    unlink(path);
+
+    errno = 0;
+    long ret = raw_faccessat(AT_FDCWD, path, F_OK);
+    EXPECT(ret == -1 && errno == ENOENT,
+           "faccessat on a missing path should fail with ENOENT");
+}
+
+static void test_mode_permission_denied(void) {
+    const char *path = "/tmp/lb_faccessat_readonly";
+    unlink(path);
+    create_file(path, 0400);
+
+    errno = 0;
+    long ret = raw_faccessat(AT_FDCWD, path, W_OK);
+    EXPECT(ret == -1 && errno == EACCES,
+           "faccessat W_OK on read-only file should fail with EACCES");
+
+    errno = 0;
+    ret = open(path, O_RDONLY);
+    EXPECT(ret >= 0, "open should observe that the file still exists");
+    close((int)ret);
+
+    unlink(path);
+}
+
+static void test_invalid_mode_einval(void) {
+    const char *path = "/tmp/lb_faccessat_invalid_mode";
+    unlink(path);
+    create_file(path, 0600);
+
+    errno = 0;
+    long ret = raw_faccessat(AT_FDCWD, path, R_OK | 8);
+    EXPECT(ret == -1 && errno == EINVAL,
+           "faccessat with invalid mode bits should fail with EINVAL");
+
+    unlink(path);
+}
+
+int main(void) {
+    printf("===== faccessat tests =====\n");
+    test_at_fdcwd_success();
+    test_missing_path_enoent();
+    test_mode_permission_denied();
+    test_invalid_mode_einval();
+    printf("All faccessat tests passed.\n");
+    return 0;
+}

--- a/litebox_runner_linux_userland/tests/faccessat2.c
+++ b/litebox_runner_linux_userland/tests/faccessat2.c
@@ -11,38 +11,47 @@ static long raw_faccessat2(int dirfd, const char *pathname, int mode, int flags)
     return syscall(SYS_faccessat2, dirfd, pathname, mode, flags);
 }
 
+static void expect_faccessat2_ok(int dirfd, const char *pathname, int mode, int flags,
+                                 const char *op) {
+    errno = 0;
+    TEST_ASSERT(raw_faccessat2(dirfd, pathname, mode, flags) == 0, op);
+}
+
+static void expect_faccessat2_errno(int dirfd, const char *pathname, int mode, int flags,
+                                    int expected_errno, const char *op) {
+    errno = 0;
+    long ret = raw_faccessat2(dirfd, pathname, mode, flags);
+    TEST_ASSERT(ret == -1 && errno == expected_errno, op);
+}
+
 static void test_at_fdcwd_success(void) {
     const char *path = "/tmp/lb_faccessat2_success";
     unlink(path);
     create_test_file(path, 0600);
 
-    errno = 0;
-    long ret = raw_faccessat2(AT_FDCWD, path, F_OK, 0);
-    EXPECT(ret == 0, "faccessat2 AT_FDCWD F_OK should succeed");
-
-    errno = 0;
-    ret = raw_faccessat2(AT_FDCWD, path, R_OK | W_OK, 0);
-    EXPECT(ret == 0, "faccessat2 AT_FDCWD R_OK|W_OK should succeed");
+    expect_faccessat2_ok(AT_FDCWD, path, F_OK, 0,
+                         "faccessat2 AT_FDCWD F_OK should succeed");
+    expect_faccessat2_ok(AT_FDCWD, path, R_OK | W_OK, 0,
+                         "faccessat2 AT_FDCWD R_OK|W_OK should succeed");
 
     struct stat st;
-    EXPECT(stat(path, &st) == 0, "stat should observe file after faccessat2");
+    TEST_ASSERT(stat(path, &st) == 0, "stat should observe file after faccessat2");
 
     unlink(path);
 }
 
-static void test_supported_flags_regular_file(void) {
+static void test_accepted_flags_regular_file(void) {
     const char *path = "/tmp/lb_faccessat2_flags";
     unlink(path);
     create_test_file(path, 0600);
 
-    errno = 0;
-    long ret = raw_faccessat2(AT_FDCWD, path, F_OK, AT_EACCESS);
-    EXPECT(ret == 0, "faccessat2 AT_EACCESS should succeed for accessible file");
+    expect_faccessat2_ok(AT_FDCWD, path, F_OK, AT_EACCESS,
+                         "faccessat2 AT_EACCESS should succeed for accessible file");
 
-    errno = 0;
-    ret = raw_faccessat2(AT_FDCWD, path, F_OK, AT_SYMLINK_NOFOLLOW);
-    EXPECT(ret == 0,
-           "faccessat2 AT_SYMLINK_NOFOLLOW should succeed for regular file");
+    // TODO: Add symlink follow/no-follow coverage once LiteBox file systems can
+    // distinguish stat and lstat semantics for symlink targets.
+    expect_faccessat2_ok(AT_FDCWD, path, F_OK, AT_SYMLINK_NOFOLLOW,
+                         "faccessat2 AT_SYMLINK_NOFOLLOW should succeed for regular file");
 
     unlink(path);
 }
@@ -55,19 +64,12 @@ static void test_owner_bits_take_precedence(void) {
     create_test_file(other_read_path, 0004);
     create_test_file(owner_read_path, 0400);
 
-    errno = 0;
-    long ret = raw_faccessat2(AT_FDCWD, other_read_path, R_OK, 0);
-    EXPECT(ret == -1 && errno == EACCES,
-           "owner read should not fall through to other read bit");
-
-    errno = 0;
-    ret = raw_faccessat2(AT_FDCWD, other_read_path, R_OK, AT_EACCESS);
-    EXPECT(ret == -1 && errno == EACCES,
-           "AT_EACCESS owner read should not fall through to other read bit");
-
-    errno = 0;
-    ret = raw_faccessat2(AT_FDCWD, owner_read_path, R_OK, AT_EACCESS);
-    EXPECT(ret == 0, "AT_EACCESS owner read bit should allow R_OK");
+    expect_faccessat2_errno(AT_FDCWD, other_read_path, R_OK, 0, EACCES,
+                            "owner read should not fall through to other read bit");
+    expect_faccessat2_errno(AT_FDCWD, other_read_path, R_OK, AT_EACCESS, EACCES,
+                            "AT_EACCESS owner read should not fall through to other read bit");
+    expect_faccessat2_ok(AT_FDCWD, owner_read_path, R_OK, AT_EACCESS,
+                         "AT_EACCESS owner read bit should allow R_OK");
 
     unlink(other_read_path);
     unlink(owner_read_path);
@@ -79,19 +81,15 @@ static void test_empty_path_success(void) {
     create_test_file(path, 0400);
 
     int fd = open(path, O_RDONLY);
-    EXPECT(fd >= 0, "open test file failed");
+    TEST_ASSERT(fd >= 0, "open test file failed");
 
-    errno = 0;
-    long ret = raw_faccessat2(fd, "", R_OK, AT_EMPTY_PATH);
-    EXPECT(ret == 0, "faccessat2 AT_EMPTY_PATH R_OK should succeed on fd");
-
-    errno = 0;
-    ret = raw_faccessat2(fd, "", W_OK, AT_EMPTY_PATH);
-    EXPECT(ret == -1 && errno == EACCES,
-           "faccessat2 AT_EMPTY_PATH W_OK should fail with EACCES");
+    expect_faccessat2_ok(fd, "", R_OK, AT_EMPTY_PATH,
+                         "faccessat2 AT_EMPTY_PATH R_OK should succeed on fd");
+    expect_faccessat2_errno(fd, "", W_OK, AT_EMPTY_PATH, EACCES,
+                            "faccessat2 AT_EMPTY_PATH W_OK should fail with EACCES");
 
     struct stat st;
-    EXPECT(fstat(fd, &st) == 0, "fstat should observe fd after faccessat2");
+    TEST_ASSERT(fstat(fd, &st) == 0, "fstat should observe fd after faccessat2");
 
     close(fd);
     unlink(path);
@@ -101,10 +99,8 @@ static void test_missing_path_enoent(void) {
     const char *path = "/tmp/lb_faccessat2_missing";
     unlink(path);
 
-    errno = 0;
-    long ret = raw_faccessat2(AT_FDCWD, path, F_OK, 0);
-    EXPECT(ret == -1 && errno == ENOENT,
-           "faccessat2 on a missing path should fail with ENOENT");
+    expect_faccessat2_errno(AT_FDCWD, path, F_OK, 0, ENOENT,
+                            "faccessat2 on a missing path should fail with ENOENT");
 }
 
 static void test_mode_permission_denied(void) {
@@ -112,15 +108,13 @@ static void test_mode_permission_denied(void) {
     unlink(path);
     create_test_file(path, 0400);
 
-    errno = 0;
-    long ret = raw_faccessat2(AT_FDCWD, path, W_OK, 0);
-    EXPECT(ret == -1 && errno == EACCES,
-           "faccessat2 W_OK on read-only file should fail with EACCES");
+    expect_faccessat2_errno(AT_FDCWD, path, W_OK, 0, EACCES,
+                            "faccessat2 W_OK on read-only file should fail with EACCES");
 
     errno = 0;
-    ret = open(path, O_RDONLY);
-    EXPECT(ret >= 0, "open should observe that the file still exists");
-    close((int)ret);
+    int fd = open(path, O_RDONLY);
+    TEST_ASSERT(fd >= 0, "open should observe that the file still exists");
+    close(fd);
 
     unlink(path);
 }
@@ -130,10 +124,8 @@ static void test_invalid_mode_einval(void) {
     unlink(path);
     create_test_file(path, 0600);
 
-    errno = 0;
-    long ret = raw_faccessat2(AT_FDCWD, path, R_OK | 8, 0);
-    EXPECT(ret == -1 && errno == EINVAL,
-           "faccessat2 with invalid mode bits should fail with EINVAL");
+    expect_faccessat2_errno(AT_FDCWD, path, R_OK | 8, 0, EINVAL,
+                            "faccessat2 with invalid mode bits should fail with EINVAL");
 
     unlink(path);
 }
@@ -143,10 +135,8 @@ static void test_invalid_flags_einval(void) {
     unlink(path);
     create_test_file(path, 0600);
 
-    errno = 0;
-    long ret = raw_faccessat2(AT_FDCWD, path, F_OK, 0x40000000);
-    EXPECT(ret == -1 && errno == EINVAL,
-           "faccessat2 with invalid flags should fail with EINVAL");
+    expect_faccessat2_errno(AT_FDCWD, path, F_OK, 0x40000000, EINVAL,
+                            "faccessat2 with invalid flags should fail with EINVAL");
 
     unlink(path);
 }
@@ -154,7 +144,7 @@ static void test_invalid_flags_einval(void) {
 int main(void) {
     printf("===== faccessat2 tests =====\n");
     test_at_fdcwd_success();
-    test_supported_flags_regular_file();
+    test_accepted_flags_regular_file();
     test_owner_bits_take_precedence();
     test_empty_path_success();
     test_missing_path_enoent();

--- a/litebox_runner_linux_userland/tests/faccessat2.c
+++ b/litebox_runner_linux_userland/tests/faccessat2.c
@@ -1,48 +1,20 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-#define _GNU_SOURCE
-#include <errno.h>
-#include <fcntl.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <sys/stat.h>
-#include <sys/syscall.h>
-#include <unistd.h>
+#include "helpers.h"
 
 #ifndef SYS_faccessat2
 #error SYS_faccessat2 is not defined on this build host
 #endif
 
-#define FAIL(msg)                                                              \
-    do {                                                                       \
-        fprintf(stderr, "FAIL: %s (line %d): %s (errno=%d: %s)\n", __func__,   \
-                __LINE__, (msg), errno, strerror(errno));                      \
-        exit(1);                                                               \
-    } while (0)
-
-#define EXPECT(cond, msg)                                                      \
-    do {                                                                       \
-        if (!(cond)) {                                                         \
-            FAIL(msg);                                                         \
-        }                                                                      \
-    } while (0)
-
 static long raw_faccessat2(int dirfd, const char *pathname, int mode, int flags) {
     return syscall(SYS_faccessat2, dirfd, pathname, mode, flags);
-}
-
-static void create_file(const char *path, mode_t mode) {
-    int fd = open(path, O_RDONLY | O_CREAT, mode);
-    EXPECT(fd >= 0, "create test file failed");
-    EXPECT(close(fd) == 0, "close test file failed");
 }
 
 static void test_at_fdcwd_success(void) {
     const char *path = "/tmp/lb_faccessat2_success";
     unlink(path);
-    create_file(path, 0600);
+    create_test_file(path, 0600);
 
     errno = 0;
     long ret = raw_faccessat2(AT_FDCWD, path, F_OK, 0);
@@ -61,7 +33,7 @@ static void test_at_fdcwd_success(void) {
 static void test_supported_flags_regular_file(void) {
     const char *path = "/tmp/lb_faccessat2_flags";
     unlink(path);
-    create_file(path, 0600);
+    create_test_file(path, 0600);
 
     errno = 0;
     long ret = raw_faccessat2(AT_FDCWD, path, F_OK, AT_EACCESS);
@@ -80,8 +52,8 @@ static void test_owner_bits_take_precedence(void) {
     const char *owner_read_path = "/tmp/lb_faccessat2_owner_read";
     unlink(other_read_path);
     unlink(owner_read_path);
-    create_file(other_read_path, 0004);
-    create_file(owner_read_path, 0400);
+    create_test_file(other_read_path, 0004);
+    create_test_file(owner_read_path, 0400);
 
     errno = 0;
     long ret = raw_faccessat2(AT_FDCWD, other_read_path, R_OK, 0);
@@ -104,7 +76,7 @@ static void test_owner_bits_take_precedence(void) {
 static void test_empty_path_success(void) {
     const char *path = "/tmp/lb_faccessat2_empty_path";
     unlink(path);
-    create_file(path, 0400);
+    create_test_file(path, 0400);
 
     int fd = open(path, O_RDONLY);
     EXPECT(fd >= 0, "open test file failed");
@@ -138,7 +110,7 @@ static void test_missing_path_enoent(void) {
 static void test_mode_permission_denied(void) {
     const char *path = "/tmp/lb_faccessat2_readonly";
     unlink(path);
-    create_file(path, 0400);
+    create_test_file(path, 0400);
 
     errno = 0;
     long ret = raw_faccessat2(AT_FDCWD, path, W_OK, 0);
@@ -156,7 +128,7 @@ static void test_mode_permission_denied(void) {
 static void test_invalid_mode_einval(void) {
     const char *path = "/tmp/lb_faccessat2_invalid_mode";
     unlink(path);
-    create_file(path, 0600);
+    create_test_file(path, 0600);
 
     errno = 0;
     long ret = raw_faccessat2(AT_FDCWD, path, R_OK | 8, 0);
@@ -169,7 +141,7 @@ static void test_invalid_mode_einval(void) {
 static void test_invalid_flags_einval(void) {
     const char *path = "/tmp/lb_faccessat2_invalid_flags";
     unlink(path);
-    create_file(path, 0600);
+    create_test_file(path, 0600);
 
     errno = 0;
     long ret = raw_faccessat2(AT_FDCWD, path, F_OK, 0x40000000);

--- a/litebox_runner_linux_userland/tests/faccessat2.c
+++ b/litebox_runner_linux_userland/tests/faccessat2.c
@@ -1,0 +1,194 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#ifndef SYS_faccessat2
+#error SYS_faccessat2 is not defined on this build host
+#endif
+
+#define FAIL(msg)                                                              \
+    do {                                                                       \
+        fprintf(stderr, "FAIL: %s (line %d): %s (errno=%d: %s)\n", __func__,   \
+                __LINE__, (msg), errno, strerror(errno));                      \
+        exit(1);                                                               \
+    } while (0)
+
+#define EXPECT(cond, msg)                                                      \
+    do {                                                                       \
+        if (!(cond)) {                                                         \
+            FAIL(msg);                                                         \
+        }                                                                      \
+    } while (0)
+
+static long raw_faccessat2(int dirfd, const char *pathname, int mode, int flags) {
+    return syscall(SYS_faccessat2, dirfd, pathname, mode, flags);
+}
+
+static void create_file(const char *path, mode_t mode) {
+    int fd = open(path, O_RDONLY | O_CREAT, mode);
+    EXPECT(fd >= 0, "create test file failed");
+    EXPECT(close(fd) == 0, "close test file failed");
+}
+
+static void test_at_fdcwd_success(void) {
+    const char *path = "/tmp/lb_faccessat2_success";
+    unlink(path);
+    create_file(path, 0600);
+
+    errno = 0;
+    long ret = raw_faccessat2(AT_FDCWD, path, F_OK, 0);
+    EXPECT(ret == 0, "faccessat2 AT_FDCWD F_OK should succeed");
+
+    errno = 0;
+    ret = raw_faccessat2(AT_FDCWD, path, R_OK | W_OK, 0);
+    EXPECT(ret == 0, "faccessat2 AT_FDCWD R_OK|W_OK should succeed");
+
+    struct stat st;
+    EXPECT(stat(path, &st) == 0, "stat should observe file after faccessat2");
+
+    unlink(path);
+}
+
+static void test_supported_flags_regular_file(void) {
+    const char *path = "/tmp/lb_faccessat2_flags";
+    unlink(path);
+    create_file(path, 0600);
+
+    errno = 0;
+    long ret = raw_faccessat2(AT_FDCWD, path, F_OK, AT_EACCESS);
+    EXPECT(ret == 0, "faccessat2 AT_EACCESS should succeed for accessible file");
+
+    errno = 0;
+    ret = raw_faccessat2(AT_FDCWD, path, F_OK, AT_SYMLINK_NOFOLLOW);
+    EXPECT(ret == 0,
+           "faccessat2 AT_SYMLINK_NOFOLLOW should succeed for regular file");
+
+    unlink(path);
+}
+
+static void test_owner_bits_take_precedence(void) {
+    const char *other_read_path = "/tmp/lb_faccessat2_other_read";
+    const char *owner_read_path = "/tmp/lb_faccessat2_owner_read";
+    unlink(other_read_path);
+    unlink(owner_read_path);
+    create_file(other_read_path, 0004);
+    create_file(owner_read_path, 0400);
+
+    errno = 0;
+    long ret = raw_faccessat2(AT_FDCWD, other_read_path, R_OK, 0);
+    EXPECT(ret == -1 && errno == EACCES,
+           "owner read should not fall through to other read bit");
+
+    errno = 0;
+    ret = raw_faccessat2(AT_FDCWD, other_read_path, R_OK, AT_EACCESS);
+    EXPECT(ret == -1 && errno == EACCES,
+           "AT_EACCESS owner read should not fall through to other read bit");
+
+    errno = 0;
+    ret = raw_faccessat2(AT_FDCWD, owner_read_path, R_OK, AT_EACCESS);
+    EXPECT(ret == 0, "AT_EACCESS owner read bit should allow R_OK");
+
+    unlink(other_read_path);
+    unlink(owner_read_path);
+}
+
+static void test_empty_path_success(void) {
+    const char *path = "/tmp/lb_faccessat2_empty_path";
+    unlink(path);
+    create_file(path, 0400);
+
+    int fd = open(path, O_RDONLY);
+    EXPECT(fd >= 0, "open test file failed");
+
+    errno = 0;
+    long ret = raw_faccessat2(fd, "", R_OK, AT_EMPTY_PATH);
+    EXPECT(ret == 0, "faccessat2 AT_EMPTY_PATH R_OK should succeed on fd");
+
+    errno = 0;
+    ret = raw_faccessat2(fd, "", W_OK, AT_EMPTY_PATH);
+    EXPECT(ret == -1 && errno == EACCES,
+           "faccessat2 AT_EMPTY_PATH W_OK should fail with EACCES");
+
+    struct stat st;
+    EXPECT(fstat(fd, &st) == 0, "fstat should observe fd after faccessat2");
+
+    close(fd);
+    unlink(path);
+}
+
+static void test_missing_path_enoent(void) {
+    const char *path = "/tmp/lb_faccessat2_missing";
+    unlink(path);
+
+    errno = 0;
+    long ret = raw_faccessat2(AT_FDCWD, path, F_OK, 0);
+    EXPECT(ret == -1 && errno == ENOENT,
+           "faccessat2 on a missing path should fail with ENOENT");
+}
+
+static void test_mode_permission_denied(void) {
+    const char *path = "/tmp/lb_faccessat2_readonly";
+    unlink(path);
+    create_file(path, 0400);
+
+    errno = 0;
+    long ret = raw_faccessat2(AT_FDCWD, path, W_OK, 0);
+    EXPECT(ret == -1 && errno == EACCES,
+           "faccessat2 W_OK on read-only file should fail with EACCES");
+
+    errno = 0;
+    ret = open(path, O_RDONLY);
+    EXPECT(ret >= 0, "open should observe that the file still exists");
+    close((int)ret);
+
+    unlink(path);
+}
+
+static void test_invalid_mode_einval(void) {
+    const char *path = "/tmp/lb_faccessat2_invalid_mode";
+    unlink(path);
+    create_file(path, 0600);
+
+    errno = 0;
+    long ret = raw_faccessat2(AT_FDCWD, path, R_OK | 8, 0);
+    EXPECT(ret == -1 && errno == EINVAL,
+           "faccessat2 with invalid mode bits should fail with EINVAL");
+
+    unlink(path);
+}
+
+static void test_invalid_flags_einval(void) {
+    const char *path = "/tmp/lb_faccessat2_invalid_flags";
+    unlink(path);
+    create_file(path, 0600);
+
+    errno = 0;
+    long ret = raw_faccessat2(AT_FDCWD, path, F_OK, 0x40000000);
+    EXPECT(ret == -1 && errno == EINVAL,
+           "faccessat2 with invalid flags should fail with EINVAL");
+
+    unlink(path);
+}
+
+int main(void) {
+    printf("===== faccessat2 tests =====\n");
+    test_at_fdcwd_success();
+    test_supported_flags_regular_file();
+    test_owner_bits_take_precedence();
+    test_empty_path_success();
+    test_missing_path_enoent();
+    test_mode_permission_denied();
+    test_invalid_mode_einval();
+    test_invalid_flags_einval();
+    printf("All faccessat2 tests passed.\n");
+    return 0;
+}

--- a/litebox_runner_linux_userland/tests/helpers.h
+++ b/litebox_runner_linux_userland/tests/helpers.h
@@ -10,12 +10,14 @@
 
 #define _GNU_SOURCE
 #include <errno.h>
+#include <fcntl.h>
 #include <poll.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/socket.h>
 #include <sys/syscall.h>
+#include <sys/stat.h>
 #include <sys/time.h>
 #include <unistd.h>
 
@@ -35,6 +37,12 @@ static inline long itimer_value_us(const struct itimerval *iv) {
 static inline void die(const char *msg) {
     perror(msg);
     exit(1);
+}
+
+static inline void create_test_file(const char *path, mode_t mode) {
+    int fd = open(path, O_RDONLY | O_CREAT, mode);
+    TEST_ASSERT(fd >= 0, "create test file failed");
+    TEST_ASSERT(close(fd) == 0, "close test file failed");
 }
 
 static inline void expect_sys_shutdown(int fd, int how, const char *op) {

--- a/litebox_shim_linux/src/lib.rs
+++ b/litebox_shim_linux/src/lib.rs
@@ -674,9 +674,14 @@ impl<FS: ShimFS> Task<FS> {
                 pos_l,
                 pos_h,
             } => self.sys_pwritev(fd, iovec, iovcnt, preadv_pwritev_offset(pos_l, pos_h)),
-            SyscallRequest::Access { pathname, mode } => pathname
-                .to_cstring()
-                .map_or(Err(Errno::EFAULT), |path| syscall!(sys_access(path, mode))),
+            SyscallRequest::Faccessat {
+                dirfd,
+                pathname,
+                mode,
+                flags,
+            } => pathname.to_cstring().map_or(Err(Errno::EFAULT), |path| {
+                syscall!(sys_faccessat(dirfd, path, mode, flags))
+            }),
             SyscallRequest::Madvise {
                 addr,
                 length,

--- a/litebox_shim_linux/src/syscalls/file.rs
+++ b/litebox_shim_linux/src/syscalls/file.rs
@@ -1093,17 +1093,18 @@ impl<FS: ShimFS> Task<FS> {
         Ok(())
     }
 
-    fn access_user(&self, flags: &AtFlags) -> AccessUserInfo {
+    fn access_user(&self, flags: &AtFlags, owner: AccessUserInfo) -> AccessUserInfo {
         if flags.contains(AtFlags::AT_EACCESS) {
             AccessUserInfo {
                 user: self.credentials.euid,
                 group: self.credentials.egid,
             }
         } else {
-            AccessUserInfo {
-                user: self.credentials.uid,
-                group: self.credentials.gid,
-            }
+            // TODO: the check supposes to use the calling process's UID and GID.
+            // However, our FS currently uses fixed UID and GID that might be different from
+            // the ones we use (i.e., the real UID/GID from host).
+            // Here we assume the caller owns the file.
+            owner
         }
     }
 
@@ -1111,10 +1112,11 @@ impl<FS: ShimFS> Task<FS> {
         &self,
         pathname: impl path::Arg,
         mode: AccessFlags,
-        caller: AccessUserInfo,
+        flags: &AtFlags,
     ) -> Result<(), Errno> {
         let status = self.files.borrow().fs.file_status(pathname)?;
-        Self::do_access_mode(status.mode, status.owner.into(), caller, &mode)
+        let owner = status.owner.into();
+        Self::do_access_mode(status.mode, owner, self.access_user(flags, owner), &mode)
     }
 
     /// Handle syscall `faccessat`
@@ -1132,23 +1134,23 @@ impl<FS: ShimFS> Task<FS> {
         }
 
         Self::validate_access_mode(&mode)?;
-        let caller = self.access_user(&flags);
         let cwd = self.fs.borrow().cwd.read().clone();
         let fs_path = FsPath::new(dirfd, pathname, || cwd.clone())?;
         match fs_path {
-            FsPath::Absolute { path } => self.do_access(path, mode, caller),
+            FsPath::Absolute { path } => self.do_access(path, mode, &flags),
             FsPath::Cwd if flags.contains(AtFlags::AT_EMPTY_PATH) => {
-                self.do_access(cwd, mode, caller)
+                self.do_access(cwd, mode, &flags)
             }
             FsPath::Fd(fd) if flags.contains(AtFlags::AT_EMPTY_PATH) => {
                 let stat = descriptor_stat(fd as usize, self)?;
+                let owner = AccessUserInfo {
+                    user: stat.st_uid,
+                    group: stat.st_gid,
+                };
                 Self::do_access_mode(
                     Mode::from_bits_retain(stat.st_mode),
-                    AccessUserInfo {
-                        user: stat.st_uid,
-                        group: stat.st_gid,
-                    },
-                    caller,
+                    owner,
+                    self.access_user(&flags, owner),
                     &mode,
                 )
             }

--- a/litebox_shim_linux/src/syscalls/file.rs
+++ b/litebox_shim_linux/src/syscalls/file.rs
@@ -18,8 +18,8 @@ use litebox::{
     utils::{ReinterpretSignedExt as _, ReinterpretUnsignedExt as _, TruncateExt as _},
 };
 use litebox_common_linux::{
-    AtFlags, EfdFlags, EpollCreateFlags, FcntlArg, FileDescriptorFlags, FileStat, InodeType,
-    IoReadVec, IoWriteVec, IoctlArg, Statx, StatxMask, TimeParam, errno::Errno, signal::Signal,
+    AccessFlags, AtFlags, EfdFlags, EpollCreateFlags, FcntlArg, FileDescriptorFlags, FileStat,
+    InodeType, IoReadVec, IoWriteVec, IoctlArg, Statx, StatxMask, TimeParam, errno::Errno, signal::Signal,
 };
 use litebox_platform_multiplex::Platform;
 use thiserror::Error;
@@ -1057,10 +1057,8 @@ impl<FS: ShimFS> Task<FS> {
         write_to_iovec(iovs, |buf, _total| self.sys_write(fd, buf, None))
     }
 
-    fn validate_access_mode(mode: &litebox_common_linux::AccessFlags) -> Result<(), Errno> {
-        let valid_mode = litebox_common_linux::AccessFlags::R_OK
-            | litebox_common_linux::AccessFlags::W_OK
-            | litebox_common_linux::AccessFlags::X_OK;
+    fn validate_access_mode(mode: &AccessFlags) -> Result<(), Errno> {
+        let valid_mode = AccessFlags::R_OK | AccessFlags::W_OK | AccessFlags::X_OK;
         if mode.intersects(valid_mode.complement()) {
             return Err(Errno::EINVAL);
         }
@@ -1068,10 +1066,10 @@ impl<FS: ShimFS> Task<FS> {
     }
 
     fn do_access_mode(
-        mode: litebox::fs::Mode,
+        mode: Mode,
         owner: AccessUserInfo,
         caller: AccessUserInfo,
-        access_mode: &litebox_common_linux::AccessFlags,
+        access_mode: &AccessFlags,
     ) -> Result<(), Errno> {
         if access_mode.is_empty() {
             return Ok(());
@@ -1083,14 +1081,13 @@ impl<FS: ShimFS> Task<FS> {
         } else {
             (Mode::ROTH, Mode::WOTH, Mode::XOTH)
         };
-        if access_mode.contains(litebox_common_linux::AccessFlags::R_OK) && !mode.contains(read) {
+        if access_mode.contains(AccessFlags::R_OK) && !mode.contains(read) {
             return Err(Errno::EACCES);
         }
-        if access_mode.contains(litebox_common_linux::AccessFlags::W_OK) && !mode.contains(write) {
+        if access_mode.contains(AccessFlags::W_OK) && !mode.contains(write) {
             return Err(Errno::EACCES);
         }
-        if access_mode.contains(litebox_common_linux::AccessFlags::X_OK) && !mode.contains(execute)
-        {
+        if access_mode.contains(AccessFlags::X_OK) && !mode.contains(execute) {
             return Err(Errno::EACCES);
         }
         Ok(())
@@ -1113,10 +1110,9 @@ impl<FS: ShimFS> Task<FS> {
     fn do_access(
         &self,
         pathname: impl path::Arg,
-        mode: litebox_common_linux::AccessFlags,
+        mode: AccessFlags,
         caller: AccessUserInfo,
     ) -> Result<(), Errno> {
-        Self::validate_access_mode(&mode)?;
         let status = self.files.borrow().fs.file_status(pathname)?;
         Self::do_access_mode(status.mode, status.owner.into(), caller, &mode)
     }
@@ -1126,7 +1122,7 @@ impl<FS: ShimFS> Task<FS> {
         &self,
         dirfd: i32,
         pathname: impl path::Arg,
-        mode: litebox_common_linux::AccessFlags,
+        mode: AccessFlags,
         flags: AtFlags,
     ) -> Result<(), Errno> {
         let supported_flags =

--- a/litebox_shim_linux/src/syscalls/file.rs
+++ b/litebox_shim_linux/src/syscalls/file.rs
@@ -27,6 +27,21 @@ use thiserror::Error;
 use crate::{ConstPtr, GlobalState, MutPtr, ShimFS, Task, syscalls::signal};
 use core::sync::atomic::{AtomicUsize, Ordering};
 
+#[derive(Clone, Copy)]
+struct AccessUserInfo {
+    user: u32,
+    group: u32,
+}
+
+impl From<litebox::fs::UserInfo> for AccessUserInfo {
+    fn from(value: litebox::fs::UserInfo) -> Self {
+        Self {
+            user: u32::from(value.user),
+            group: u32::from(value.group),
+        }
+    }
+}
+
 /// Task state shared by `CLONE_FS`.
 pub(crate) struct FsState {
     umask: core::sync::atomic::AtomicU32,
@@ -1042,35 +1057,111 @@ impl<FS: ShimFS> Task<FS> {
         write_to_iovec(iovs, |buf, _total| self.sys_write(fd, buf, None))
     }
 
-    /// Handle syscall `access`
-    pub fn sys_access(
-        &self,
-        pathname: impl path::Arg,
-        mode: litebox_common_linux::AccessFlags,
+    fn validate_access_mode(mode: &litebox_common_linux::AccessFlags) -> Result<(), Errno> {
+        let valid_mode = litebox_common_linux::AccessFlags::R_OK
+            | litebox_common_linux::AccessFlags::W_OK
+            | litebox_common_linux::AccessFlags::X_OK;
+        if mode.intersects(valid_mode.complement()) {
+            return Err(Errno::EINVAL);
+        }
+        Ok(())
+    }
+
+    fn do_access_mode(
+        mode: litebox::fs::Mode,
+        owner: AccessUserInfo,
+        caller: AccessUserInfo,
+        access_mode: &litebox_common_linux::AccessFlags,
     ) -> Result<(), Errno> {
-        let pathname = self.resolve_path(pathname)?;
-        let status = self.files.borrow().fs.file_status(pathname)?;
-        if mode == litebox_common_linux::AccessFlags::F_OK {
+        if access_mode.is_empty() {
             return Ok(());
         }
-        // TODO: the check is done using the calling process's real UID and GID.
-        // Here we assume the caller owns the file.
-        if mode.contains(litebox_common_linux::AccessFlags::R_OK)
-            && !status.mode.contains(litebox::fs::Mode::RUSR)
-        {
+        let (read, write, execute) = if caller.user == owner.user {
+            (Mode::RUSR, Mode::WUSR, Mode::XUSR)
+        } else if caller.group == owner.group {
+            (Mode::RGRP, Mode::WGRP, Mode::XGRP)
+        } else {
+            (Mode::ROTH, Mode::WOTH, Mode::XOTH)
+        };
+        if access_mode.contains(litebox_common_linux::AccessFlags::R_OK) && !mode.contains(read) {
             return Err(Errno::EACCES);
         }
-        if mode.contains(litebox_common_linux::AccessFlags::W_OK)
-            && !status.mode.contains(litebox::fs::Mode::WUSR)
-        {
+        if access_mode.contains(litebox_common_linux::AccessFlags::W_OK) && !mode.contains(write) {
             return Err(Errno::EACCES);
         }
-        if mode.contains(litebox_common_linux::AccessFlags::X_OK)
-            && !status.mode.contains(litebox::fs::Mode::XUSR)
+        if access_mode.contains(litebox_common_linux::AccessFlags::X_OK) && !mode.contains(execute)
         {
             return Err(Errno::EACCES);
         }
         Ok(())
+    }
+
+    fn access_user(&self, flags: &AtFlags) -> AccessUserInfo {
+        if flags.contains(AtFlags::AT_EACCESS) {
+            AccessUserInfo {
+                user: self.credentials.euid,
+                group: self.credentials.egid,
+            }
+        } else {
+            AccessUserInfo {
+                user: self.credentials.uid,
+                group: self.credentials.gid,
+            }
+        }
+    }
+
+    fn do_access(
+        &self,
+        pathname: impl path::Arg,
+        mode: litebox_common_linux::AccessFlags,
+        caller: AccessUserInfo,
+    ) -> Result<(), Errno> {
+        Self::validate_access_mode(&mode)?;
+        let status = self.files.borrow().fs.file_status(pathname)?;
+        Self::do_access_mode(status.mode, status.owner.into(), caller, &mode)
+    }
+
+    /// Handle syscall `faccessat`
+    pub(crate) fn sys_faccessat(
+        &self,
+        dirfd: i32,
+        pathname: impl path::Arg,
+        mode: litebox_common_linux::AccessFlags,
+        flags: AtFlags,
+    ) -> Result<(), Errno> {
+        let supported_flags =
+            AtFlags::AT_EACCESS | AtFlags::AT_SYMLINK_NOFOLLOW | AtFlags::AT_EMPTY_PATH;
+        if flags.intersects(supported_flags.complement()) {
+            return Err(Errno::EINVAL);
+        }
+
+        Self::validate_access_mode(&mode)?;
+        let caller = self.access_user(&flags);
+        let cwd = self.fs.borrow().cwd.read().clone();
+        let fs_path = FsPath::new(dirfd, pathname, || cwd.clone())?;
+        match fs_path {
+            FsPath::Absolute { path } => self.do_access(path, mode, caller),
+            FsPath::Cwd if flags.contains(AtFlags::AT_EMPTY_PATH) => {
+                self.do_access(cwd, mode, caller)
+            }
+            FsPath::Fd(fd) if flags.contains(AtFlags::AT_EMPTY_PATH) => {
+                let stat = descriptor_stat(fd as usize, self)?;
+                Self::do_access_mode(
+                    Mode::from_bits_retain(stat.st_mode),
+                    AccessUserInfo {
+                        user: stat.st_uid,
+                        group: stat.st_gid,
+                    },
+                    caller,
+                    &mode,
+                )
+            }
+            FsPath::Cwd | FsPath::Fd(_) => Err(Errno::ENOENT),
+            FsPath::FdRelative { .. } => {
+                log_unsupported!("fd-relative faccessat is not supported yet");
+                Err(Errno::EINVAL)
+            }
+        }
     }
 
     /// Read the target of a symbolic link
@@ -2774,8 +2865,14 @@ mod tests {
         // ── sys_lstat: lstat the relative file ──
         task.sys_lstat("file.txt").unwrap();
 
-        // ── sys_access: check relative file is accessible ──
-        task.sys_access("file.txt", AccessFlags::F_OK).unwrap();
+        // ── sys_faccessat: check relative file is accessible ──
+        task.sys_faccessat(
+            litebox_common_linux::AT_FDCWD,
+            "file.txt",
+            AccessFlags::F_OK,
+            AtFlags::empty(),
+        )
+        .unwrap();
 
         // ── sys_mkdir: create a subdirectory via relative path ──
         task.sys_mkdir("subdir", 0o777).unwrap();

--- a/litebox_shim_linux/src/syscalls/file.rs
+++ b/litebox_shim_linux/src/syscalls/file.rs
@@ -1093,18 +1093,17 @@ impl<FS: ShimFS> Task<FS> {
         Ok(())
     }
 
-    fn access_user(&self, flags: &AtFlags, owner: AccessUserInfo) -> AccessUserInfo {
+    fn access_user(&self, flags: &AtFlags) -> AccessUserInfo {
         if flags.contains(AtFlags::AT_EACCESS) {
             AccessUserInfo {
                 user: self.credentials.euid,
                 group: self.credentials.egid,
             }
         } else {
-            // TODO: the check supposes to use the calling process's UID and GID.
-            // However, our FS currently uses fixed UID and GID that might be different from
-            // the ones we use (i.e., the real UID/GID from host).
-            // Here we assume the caller owns the file.
-            owner
+            AccessUserInfo {
+                user: self.credentials.uid,
+                group: self.credentials.gid,
+            }
         }
     }
 
@@ -1112,11 +1111,11 @@ impl<FS: ShimFS> Task<FS> {
         &self,
         pathname: impl path::Arg,
         mode: AccessFlags,
-        flags: &AtFlags,
+        caller: AccessUserInfo,
     ) -> Result<(), Errno> {
         let status = self.files.borrow().fs.file_status(pathname)?;
         let owner = status.owner.into();
-        Self::do_access_mode(status.mode, owner, self.access_user(flags, owner), &mode)
+        Self::do_access_mode(status.mode, owner, caller, &mode)
     }
 
     /// Handle syscall `faccessat`
@@ -1134,12 +1133,13 @@ impl<FS: ShimFS> Task<FS> {
         }
 
         Self::validate_access_mode(&mode)?;
+        let caller = self.access_user(&flags);
         let cwd = self.fs.borrow().cwd.read().clone();
         let fs_path = FsPath::new(dirfd, pathname, || cwd.clone())?;
         match fs_path {
-            FsPath::Absolute { path } => self.do_access(path, mode, &flags),
+            FsPath::Absolute { path } => self.do_access(path, mode, caller),
             FsPath::Cwd if flags.contains(AtFlags::AT_EMPTY_PATH) => {
-                self.do_access(cwd, mode, &flags)
+                self.do_access(cwd, mode, caller)
             }
             FsPath::Fd(fd) if flags.contains(AtFlags::AT_EMPTY_PATH) => {
                 let stat = descriptor_stat(fd as usize, self)?;
@@ -1147,12 +1147,7 @@ impl<FS: ShimFS> Task<FS> {
                     user: stat.st_uid,
                     group: stat.st_gid,
                 };
-                Self::do_access_mode(
-                    Mode::from_bits_retain(stat.st_mode),
-                    owner,
-                    self.access_user(&flags, owner),
-                    &mode,
-                )
+                Self::do_access_mode(Mode::from_bits_retain(stat.st_mode), owner, caller, &mode)
             }
             FsPath::Cwd | FsPath::Fd(_) => Err(Errno::ENOENT),
             FsPath::FdRelative { .. } => {

--- a/litebox_shim_linux/src/syscalls/file.rs
+++ b/litebox_shim_linux/src/syscalls/file.rs
@@ -19,7 +19,8 @@ use litebox::{
 };
 use litebox_common_linux::{
     AccessFlags, AtFlags, EfdFlags, EpollCreateFlags, FcntlArg, FileDescriptorFlags, FileStat,
-    InodeType, IoReadVec, IoWriteVec, IoctlArg, Statx, StatxMask, TimeParam, errno::Errno, signal::Signal,
+    InodeType, IoReadVec, IoWriteVec, IoctlArg, Statx, StatxMask, TimeParam, errno::Errno,
+    signal::Signal,
 };
 use litebox_platform_multiplex::Platform;
 use thiserror::Error;
@@ -1074,6 +1075,16 @@ impl<FS: ShimFS> Task<FS> {
         if access_mode.is_empty() {
             return Ok(());
         }
+        if caller.user == 0 {
+            if access_mode.contains(AccessFlags::X_OK)
+                && !mode.intersects(Mode::XUSR | Mode::XGRP | Mode::XOTH)
+            {
+                return Err(Errno::EACCES);
+            }
+            return Ok(());
+        }
+        // TODO: Linux also uses group bits when `owner.group` is in the caller's supplementary
+        // group list. `AccessUserInfo` only carries the real/effective primary group today.
         let (read, write, execute) = if caller.user == owner.user {
             (Mode::RUSR, Mode::WUSR, Mode::XUSR)
         } else if caller.group == owner.group {
@@ -1128,26 +1139,34 @@ impl<FS: ShimFS> Task<FS> {
     ) -> Result<(), Errno> {
         let supported_flags =
             AtFlags::AT_EACCESS | AtFlags::AT_SYMLINK_NOFOLLOW | AtFlags::AT_EMPTY_PATH;
+        // TODO: `AT_SYMLINK_NOFOLLOW` is accepted for Linux compatibility, but LiteBox file
+        // status lookups do not currently follow symlinks in any backend.
         if flags.intersects(supported_flags.complement()) {
             return Err(Errno::EINVAL);
         }
 
         Self::validate_access_mode(&mode)?;
         let caller = self.access_user(&flags);
-        let cwd = self.fs.borrow().cwd.read().clone();
-        let fs_path = FsPath::new(dirfd, pathname, || cwd.clone())?;
+        let get_cwd = || self.fs.borrow().cwd.read().clone();
+        let fs_path = FsPath::new(dirfd, pathname, get_cwd)?;
         match fs_path {
             FsPath::Absolute { path } => self.do_access(path, mode, caller),
             FsPath::Cwd if flags.contains(AtFlags::AT_EMPTY_PATH) => {
+                let cwd = get_cwd();
                 self.do_access(cwd, mode, caller)
             }
             FsPath::Fd(fd) if flags.contains(AtFlags::AT_EMPTY_PATH) => {
-                let stat = descriptor_stat(fd as usize, self)?;
+                let stat: FileStat = descriptor_stat(fd as usize, self)?;
                 let owner = AccessUserInfo {
                     user: stat.st_uid,
                     group: stat.st_gid,
                 };
-                Self::do_access_mode(Mode::from_bits_retain(stat.st_mode), owner, caller, &mode)
+                Self::do_access_mode(
+                    Mode::from_bits_truncate(stat.st_mode & 0o7777),
+                    owner,
+                    caller,
+                    &mode,
+                )
             }
             FsPath::Cwd | FsPath::Fd(_) => Err(Errno::ENOENT),
             FsPath::FdRelative { .. } => {


### PR DESCRIPTION
Support syscalls `faccessat` and `faccessat2`, Similar to other `*at` syscalls, it does not support fd relative path yet.

To match the fixed UID/GID in in-mem fs, update runner to use the same UID/GID.