### PR TITLE
Parse Windows PE exports and initialize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1771,6 +1771,7 @@ dependencies = [
  "litebox_platform_multiplex",
  "litebox_util_log",
  "thiserror",
+ "zerocopy",
 ]
 
 [[package]]

--- a/litebox_common_windows/src/loader.rs
+++ b/litebox_common_windows/src/loader.rs
@@ -159,6 +159,11 @@ macro_rules! checked_add {
         $a.checked_add($b).ok_or($e)
     };
 }
+macro_rules! checked_mul {
+    ($a:expr, $b:expr, $e:expr) => {
+        $a.checked_mul($b).ok_or($e)
+    };
+}
 macro_rules! checked_add_invalid {
     ($a:expr, $b:expr) => {
         checked_add!($a, $b, PeLoadError::InvalidImage)
@@ -364,37 +369,28 @@ impl PeParsedFile {
         mem: &mut impl AccessMemory,
         names: &[&str],
     ) -> Result<Vec<Option<usize>>, PeExportError> {
-        let mut addresses = Vec::new();
-        addresses.resize(names.len(), None);
+        let mut addresses = alloc::vec![None; names.len()];
         if names.is_empty() {
             return Ok(addresses);
         }
+        checked_add!(base_addr, self.image.size_of_image, PeExportError::Overflow)?;
 
-        let Some(export_dir) = self
-            .data_directories
-            .get(pe::IMAGE_DIRECTORY_ENTRY_EXPORT)
-            .filter(|directory| directory.rva != 0 && directory.size != 0)
-        else {
+        let Some(export_dir) = self.data_directory(pe::IMAGE_DIRECTORY_ENTRY_EXPORT) else {
             return Ok(addresses);
         };
-
         let export_rva = export_dir.rva;
         let export_size = export_dir.size;
         if export_size < size_of::<pe::ImageExportDirectory>() {
             return Err(PeExportError::InvalidImage);
         }
-        let export_end_rva = checked_add_export(export_rva, export_size)?;
+        let export_end_rva = checked_add!(export_rva, export_size, PeExportError::Overflow)?;
         if export_end_rva > self.image.size_of_image {
             return Err(PeExportError::InvalidImage);
         }
 
-        let directory_address = image_address(
-            base_addr,
-            self.image.size_of_image,
-            export_rva,
-            size_of::<pe::ImageExportDirectory>(),
-        )?;
-        let directory: pe::ImageExportDirectory = mem_read_pod(mem, directory_address)?;
+        let directory_address = base_addr + export_rva;
+        let directory: pe::ImageExportDirectory =
+            mem_read_pod::<_, PeExportError>(mem, directory_address)?;
 
         let function_count = directory.number_of_functions.get(LE) as usize;
         let name_count = directory.number_of_names.get(LE) as usize;
@@ -408,7 +404,7 @@ impl PeParsedFile {
         validate_image_range(
             self.image.size_of_image,
             address_table_rva,
-            checked_mul_export(function_count, size_of::<u32>())?,
+            checked_mul!(function_count, size_of::<u32>(), PeExportError::Overflow)?,
         )?;
         if name_count == 0 {
             return Ok(addresses);
@@ -419,25 +415,20 @@ impl PeParsedFile {
         validate_image_range(
             self.image.size_of_image,
             name_table_rva,
-            checked_mul_export(name_count, size_of::<u32>())?,
+            checked_mul!(name_count, size_of::<u32>(), PeExportError::Overflow)?,
         )?;
         validate_image_range(
             self.image.size_of_image,
             name_ordinal_table_rva,
-            checked_mul_export(name_count, size_of::<u16>())?,
+            checked_mul!(name_count, size_of::<u16>(), PeExportError::Overflow)?,
         )?;
 
         let mut found = 0;
         for name_index in 0..name_count {
-            let name_pointer_address = image_address(
-                base_addr,
-                self.image.size_of_image,
-                checked_add_export(name_table_rva, name_index * size_of::<u32>())?,
-                size_of::<u32>(),
-            )?;
-            let name_rva = mem_read_u32(mem, name_pointer_address)? as usize;
+            let name_pointer_address = base_addr + name_table_rva + name_index * size_of::<u32>();
+            let name_rva = mem_read_pod::<u32, PeExportError>(mem, name_pointer_address)? as usize;
             let export_name =
-                read_c_string_at_rva(base_addr, self.image.size_of_image, mem, name_rva, None)?;
+                read_c_string_at_rva(base_addr, self.image.size_of_image, mem, name_rva)?;
             let Some(requested_index) = names.iter().position(|name| *name == export_name) else {
                 continue;
             };
@@ -445,24 +436,17 @@ impl PeParsedFile {
                 continue;
             }
 
-            let ordinal_index_address = image_address(
-                base_addr,
-                self.image.size_of_image,
-                checked_add_export(name_ordinal_table_rva, name_index * size_of::<u16>())?,
-                size_of::<u16>(),
-            )?;
-            let ordinal_index = mem_read_export_u16(mem, ordinal_index_address)? as usize;
+            let ordinal_index_address =
+                base_addr + name_ordinal_table_rva + name_index * size_of::<u16>();
+            let ordinal_index =
+                mem_read_pod::<u16, PeExportError>(mem, ordinal_index_address)? as usize;
             if ordinal_index >= function_count {
                 return Err(PeExportError::InvalidImage);
             }
 
-            let function_rva_address = image_address(
-                base_addr,
-                self.image.size_of_image,
-                checked_add_export(address_table_rva, ordinal_index * size_of::<u32>())?,
-                size_of::<u32>(),
-            )?;
-            let function_rva = mem_read_u32(mem, function_rva_address)?;
+            let function_rva_address =
+                base_addr + address_table_rva + ordinal_index * size_of::<u32>();
+            let function_rva = mem_read_pod::<u32, PeExportError>(mem, function_rva_address)?;
             if let Some(address) = export_address(
                 base_addr,
                 self.image.size_of_image,
@@ -640,10 +624,7 @@ impl PeParsedFile {
 
         let mut cursor = dir_addr;
         while cursor < dir_end {
-            let mut header_bytes = [0u8; size_of::<pe::ImageBaseRelocation>()];
-            mem.read(cursor, &mut header_bytes)?;
-            let (header, _) = object::pod::from_bytes::<pe::ImageBaseRelocation>(&header_bytes)
-                .map_err(|()| PeLoadError::InvalidImage)?;
+            let header: pe::ImageBaseRelocation = mem_read_pod::<_, PeLoadError<E>>(mem, cursor)?;
             let page_rva = header.virtual_address.get(LE);
             let block_size = header.size_of_block.get(LE) as usize;
             if block_size < size_of::<pe::ImageBaseRelocation>() || !block_size.is_multiple_of(2) {
@@ -657,7 +638,7 @@ impl PeParsedFile {
             let mut entry_addr =
                 checked_add_invalid!(cursor, size_of::<pe::ImageBaseRelocation>())?;
             while entry_addr < block_end {
-                let entry = mem_read_u16(mem, entry_addr)?;
+                let entry: u16 = mem_read_pod::<_, PeLoadError<E>>(mem, entry_addr)?;
                 let typ = entry >> 12;
                 let entry_offset = u32::from(entry & 0x0fff);
                 match typ {
@@ -670,7 +651,8 @@ impl PeParsedFile {
                         if relocation_end > image_end {
                             return Err(PeLoadError::InvalidImage);
                         }
-                        let value = mem_read_u64(mem, relocation_address)?;
+                        let value: u64 =
+                            mem_read_pod::<_, PeLoadError<E>>(mem, relocation_address)?;
                         let relocated = value.wrapping_add_signed(delta_i64);
                         mem.write(relocation_address, &relocated.to_le_bytes())?;
                     }
@@ -701,7 +683,8 @@ fn export_address(
         return Ok(None);
     }
 
-    image_address(base_addr, image_size, function_rva, 1).map(Some)
+    validate_image_range(image_size, function_rva, 1)?;
+    Ok(Some(base_addr + function_rva))
 }
 
 fn read_c_string_at_rva(
@@ -709,17 +692,15 @@ fn read_c_string_at_rva(
     image_size: usize,
     mem: &mut impl AccessMemory,
     rva: usize,
-    end_rva: Option<usize>,
 ) -> Result<String, PeExportError> {
-    let end_rva = end_rva.unwrap_or(image_size);
-    if rva >= end_rva || end_rva > image_size {
+    if rva >= image_size {
         return Err(PeExportError::InvalidImage);
     }
 
     let mut bytes = Vec::new();
-    for current_rva in rva..end_rva {
-        let address = image_address(base_addr, image_size, current_rva, 1)?;
-        let byte = mem_read_u8(mem, address)?;
+    for current_rva in rva..image_size {
+        let address = base_addr + current_rva;
+        let byte: u8 = mem_read_pod::<_, PeExportError>(mem, address)?;
         if byte == 0 {
             return String::from_utf8(bytes).map_err(|_| PeExportError::InvalidImage);
         }
@@ -729,68 +710,38 @@ fn read_c_string_at_rva(
     Err(PeExportError::InvalidImage)
 }
 
-fn mem_read_pod<T: Pod>(mem: &mut impl AccessMemory, address: usize) -> Result<T, PeExportError> {
+trait MemReadPodError: From<Fault> {
+    fn invalid_pod() -> Self;
+}
+
+impl MemReadPodError for PeExportError {
+    fn invalid_pod() -> Self {
+        Self::InvalidImage
+    }
+}
+
+impl<E> MemReadPodError for PeLoadError<E> {
+    fn invalid_pod() -> Self {
+        Self::InvalidImage
+    }
+}
+
+fn mem_read_pod<T: Pod, E: MemReadPodError>(
+    mem: &mut impl AccessMemory,
+    address: usize,
+) -> Result<T, E> {
     let mut buf = alloc::vec![0u8; size_of::<T>()];
-    mem.read(address, &mut buf)?;
-    let (value, _) =
-        object::pod::from_bytes::<T>(&buf).map_err(|()| PeExportError::InvalidImage)?;
+    mem.read(address, &mut buf).map_err(E::from)?;
+    let (value, _) = object::pod::from_bytes::<T>(&buf).map_err(|()| E::invalid_pod())?;
     Ok(*value)
 }
 
-fn mem_read_u8(mem: &mut impl AccessMemory, address: usize) -> Result<u8, PeExportError> {
-    let mut buf = [0u8; size_of::<u8>()];
-    mem.read(address, &mut buf)?;
-    Ok(buf[0])
-}
-
-fn mem_read_u32(mem: &mut impl AccessMemory, address: usize) -> Result<u32, PeExportError> {
-    let mut buf = [0u8; size_of::<u32>()];
-    mem.read(address, &mut buf)?;
-    Ok(u32::from_le_bytes(buf))
-}
-
-fn mem_read_export_u16(mem: &mut impl AccessMemory, address: usize) -> Result<u16, PeExportError> {
-    let mut buf = [0u8; size_of::<u16>()];
-    mem.read(address, &mut buf)?;
-    Ok(u16::from_le_bytes(buf))
-}
-
-fn image_address(
-    base_addr: usize,
-    image_size: usize,
-    rva: usize,
-    len: usize,
-) -> Result<usize, PeExportError> {
-    validate_image_range(image_size, rva, len)?;
-    checked_add_export(base_addr, rva)
-}
-
 fn validate_image_range(image_size: usize, rva: usize, len: usize) -> Result<(), PeExportError> {
-    let end = checked_add_export(rva, len)?;
+    let end = checked_add!(rva, len, PeExportError::Overflow)?;
     if end > image_size {
         return Err(PeExportError::InvalidImage);
     }
     Ok(())
-}
-
-fn checked_add_export(left: usize, right: usize) -> Result<usize, PeExportError> {
-    left.checked_add(right).ok_or(PeExportError::Overflow)
-}
-
-fn checked_mul_export(left: usize, right: usize) -> Result<usize, PeExportError> {
-    left.checked_mul(right).ok_or(PeExportError::Overflow)
-}
-
-fn mem_read_u16<E>(mem: &mut impl AccessMemory, address: usize) -> Result<u16, PeLoadError<E>> {
-    let mut buf = [0u8; size_of::<u16>()];
-    mem.read(address, &mut buf)?;
-    Ok(u16::from_le_bytes(buf))
-}
-
-fn mem_read_u64<E>(mem: &mut impl AccessMemory, address: usize) -> Result<u64, PeLoadError<E>> {
-    let mut buf = [0u8; size_of::<u64>()];
-    mem.read(address, &mut buf)?;
-    Ok(u64::from_le_bytes(buf))
 }
 
 type ParsedHeaders = (
@@ -805,7 +756,10 @@ type ParsedHeaders = (
 /// `#[repr(transparent)]` byte-array wrappers), so the byte buffer's alignment
 /// trivially satisfies `from_bytes`'s check and the transmute happens inside
 /// `object::pod` rather than here.
-fn read_pod<F: ReadAt, T: Pod>(file: &mut F, offset: u64) -> Result<T, PeParseError<F::Error>> {
+fn file_read_pod<F: ReadAt, T: Pod>(
+    file: &mut F,
+    offset: u64,
+) -> Result<T, PeParseError<F::Error>> {
     let mut buf = alloc::vec![0u8; size_of::<T>()];
     file.read_at(offset, &mut buf).map_err(PeParseError::Io)?;
     let (val, _) =
@@ -814,7 +768,7 @@ fn read_pod<F: ReadAt, T: Pod>(file: &mut F, offset: u64) -> Result<T, PeParseEr
 }
 
 /// Read `count` POD structs of type `T` from `file` starting at `offset`.
-fn read_pod_vec<F: ReadAt, T: Pod>(
+fn file_read_pod_vec<F: ReadAt, T: Pod>(
     file: &mut F,
     offset: u64,
     count: usize,
@@ -837,7 +791,7 @@ fn parse_headers<F: ReadAt>(
     if file_size < size_of::<pe::ImageDosHeader>() {
         return Err(PeParseError::UnsupportedImage);
     }
-    let dos: pe::ImageDosHeader = read_pod(file, 0)?;
+    let dos: pe::ImageDosHeader = file_read_pod(file, 0)?;
     if dos.e_magic.get(LE) != pe::IMAGE_DOS_SIGNATURE {
         return Err(PeParseError::UnsupportedImage);
     }
@@ -848,7 +802,7 @@ fn parse_headers<F: ReadAt>(
     if nt_end > file_size as u64 {
         return Err(PeParseError::UnsupportedImage);
     }
-    let nt: pe::ImageNtHeaders64 = read_pod(file, nt_offset)?;
+    let nt: pe::ImageNtHeaders64 = file_read_pod(file, nt_offset)?;
     if nt.signature.get(LE) != pe::IMAGE_NT_SIGNATURE {
         return Err(PeParseError::UnsupportedImage);
     }
@@ -902,7 +856,7 @@ fn parse_headers<F: ReadAt>(
     if num_rva_and_sizes > pe::IMAGE_NUMBEROF_DIRECTORY_ENTRIES {
         return Err(PeParseError::UnsupportedImage);
     }
-    let raw_dirs: Vec<pe::ImageDataDirectory> = read_pod_vec(file, nt_end, num_rva_and_sizes)?;
+    let raw_dirs: Vec<pe::ImageDataDirectory> = file_read_pod_vec(file, nt_end, num_rva_and_sizes)?;
     let data_directories: Vec<_> = raw_dirs
         .iter()
         .map(|dir| {
@@ -929,7 +883,8 @@ fn parse_headers<F: ReadAt>(
     if sections_end > file_size as u64 {
         return Err(PeParseError::UnsupportedImage);
     }
-    let sections: Vec<pe::ImageSectionHeader> = read_pod_vec(file, sections_offset, num_sections)?;
+    let sections: Vec<pe::ImageSectionHeader> =
+        file_read_pod_vec(file, sections_offset, num_sections)?;
     validate_sections(&image, &sections, file_size)?;
 
     Ok((image, sections, data_directories))
@@ -999,7 +954,7 @@ pub fn page_align_down(address: usize) -> usize {
 pub trait ReadAt {
     type Error;
 
-    /// Read `buf.len()` bytes at `offset`. Short reads are not permitted.
+    /// Read `buf.len()` bytes at `offset`.
     fn read_at(&mut self, offset: u64, buf: &mut [u8]) -> Result<(), Self::Error>;
 
     fn size(&mut self) -> Result<u64, Self::Error>;
@@ -1104,160 +1059,4 @@ fn section_name_eq(section: &pe::ImageSectionHeader, name: &[u8]) -> bool {
         .position(|byte| *byte == 0)
         .unwrap_or(section.name.len());
     &section.name[..end] == name
-}
-
-#[cfg(test)]
-mod tests {
-    use alloc::{vec, vec::Vec};
-
-    use super::*;
-
-    const TEST_BASE: usize = 0x1000_0000;
-    const TEST_IMAGE_SIZE: usize = 0x5000;
-    const EXPORT_RVA: usize = 0x2000;
-    const EXPORT_RVA_U32: u32 = 0x2000;
-
-    struct TestMemory {
-        base_addr: usize,
-        data: Vec<u8>,
-    }
-
-    impl TestMemory {
-        fn new(base_addr: usize, len: usize) -> Self {
-            Self {
-                base_addr,
-                data: vec![0; len],
-            }
-        }
-
-        fn put_u16(&mut self, rva: usize, value: u16) {
-            self.put_bytes(rva, &value.to_le_bytes());
-        }
-
-        fn put_u32(&mut self, rva: usize, value: u32) {
-            self.put_bytes(rva, &value.to_le_bytes());
-        }
-
-        fn put_bytes(&mut self, rva: usize, bytes: &[u8]) {
-            let end = rva + bytes.len();
-            self.data[rva..end].copy_from_slice(bytes);
-        }
-    }
-
-    impl AccessMemory for TestMemory {
-        fn read(&mut self, address: usize, buf: &mut [u8]) -> Result<(), Fault> {
-            let offset = address.checked_sub(self.base_addr).ok_or(Fault)?;
-            let end = offset.checked_add(buf.len()).ok_or(Fault)?;
-            let data = self.data.get(offset..end).ok_or(Fault)?;
-            buf.copy_from_slice(data);
-            Ok(())
-        }
-
-        fn write(&mut self, address: usize, data: &[u8]) -> Result<(), Fault> {
-            let offset = address.checked_sub(self.base_addr).ok_or(Fault)?;
-            let end = offset.checked_add(data.len()).ok_or(Fault)?;
-            let dst = self.data.get_mut(offset..end).ok_or(Fault)?;
-            dst.copy_from_slice(data);
-            Ok(())
-        }
-    }
-
-    fn parsed_file_with_export_directory(export_rva: u32, export_size: u32) -> PeParsedFile {
-        PeParsedFile {
-            image: PeImageInfo {
-                machine: pe::IMAGE_FILE_MACHINE_AMD64,
-                characteristics: pe::IMAGE_FILE_EXECUTABLE_IMAGE,
-                image_base: TEST_BASE,
-                entry_point_rva: 0x1000,
-                size_of_image: TEST_IMAGE_SIZE,
-                size_of_headers: PAGE_SIZE,
-                section_alignment: PAGE_SIZE,
-                file_alignment: 0x200,
-                subsystem: 0,
-                dll_characteristics: 0,
-                size_of_heap_reserve: 0,
-                size_of_heap_commit: 0,
-            },
-            sections: Vec::new(),
-            data_directories: vec![PeDataDirectory {
-                rva: export_rva as usize,
-                size: export_size as usize,
-            }],
-            trampoline: None,
-        }
-    }
-
-    fn write_export_directory(memory: &mut TestMemory) {
-        memory.put_u32(EXPORT_RVA + 16, 1);
-        memory.put_u32(EXPORT_RVA + 20, 2);
-        memory.put_u32(EXPORT_RVA + 24, 2);
-        memory.put_u32(EXPORT_RVA + 28, 0x2040);
-        memory.put_u32(EXPORT_RVA + 32, 0x2050);
-        memory.put_u32(EXPORT_RVA + 36, 0x2058);
-
-        memory.put_u32(0x2040, 0x1100);
-        memory.put_u32(0x2044, 0x2060);
-        memory.put_u32(0x2050, 0x2070);
-        memory.put_u32(0x2054, 0x2080);
-        memory.put_u16(0x2058, 0);
-        memory.put_u16(0x205a, 1);
-        memory.put_bytes(0x2060, b"KERNEL32.Sleep\0");
-        memory.put_bytes(0x2070, b"LocalFunction\0");
-        memory.put_bytes(0x2080, b"ForwardedFunction\0");
-    }
-
-    #[test]
-    fn find_export_addresses_returns_missing_entries_without_export_directory() {
-        let parsed = parsed_file_with_export_directory(0, 0);
-        let mut memory = TestMemory::new(TEST_BASE, TEST_IMAGE_SIZE);
-
-        let addresses = parsed
-            .find_export_addresses(TEST_BASE, &mut memory, &["LocalFunction"])
-            .unwrap();
-
-        assert_eq!(addresses, vec![None]);
-    }
-
-    #[test]
-    fn find_export_addresses_returns_requested_addresses_in_order() {
-        let parsed = parsed_file_with_export_directory(EXPORT_RVA_U32, 0x100);
-        let mut memory = TestMemory::new(TEST_BASE, TEST_IMAGE_SIZE);
-        write_export_directory(&mut memory);
-
-        let addresses = parsed
-            .find_export_addresses(
-                TEST_BASE,
-                &mut memory,
-                &["ForwardedFunction", "Missing", "LocalFunction"],
-            )
-            .unwrap();
-
-        assert_eq!(addresses, vec![None, None, Some(TEST_BASE + 0x1100)]);
-    }
-
-    #[test]
-    fn find_export_addresses_rejects_bad_name_ordinal() {
-        let parsed = parsed_file_with_export_directory(EXPORT_RVA_U32, 0x100);
-        let mut memory = TestMemory::new(TEST_BASE, TEST_IMAGE_SIZE);
-        write_export_directory(&mut memory);
-        memory.put_u16(0x2058, 2);
-
-        let error = parsed
-            .find_export_addresses(TEST_BASE, &mut memory, &["LocalFunction"])
-            .unwrap_err();
-
-        assert!(matches!(error, PeExportError::InvalidImage));
-    }
-
-    #[test]
-    fn find_export_addresses_rejects_short_export_directory() {
-        let parsed = parsed_file_with_export_directory(EXPORT_RVA_U32, 1);
-        let mut memory = TestMemory::new(TEST_BASE, TEST_IMAGE_SIZE);
-
-        let error = parsed
-            .find_export_addresses(TEST_BASE, &mut memory, &["LocalFunction"])
-            .unwrap_err();
-
-        assert!(matches!(error, PeExportError::InvalidImage));
-    }
 }

--- a/litebox_common_windows/src/loader.rs
+++ b/litebox_common_windows/src/loader.rs
@@ -4,11 +4,10 @@
 //! PE loader-facing parser and mapper.
 //!
 //! This module parses PE metadata and maps images through platform-provided traits.
-
-use alloc::vec::Vec;
+use alloc::{string::String, vec::Vec};
 use core::cmp;
 use core::mem::size_of;
-use zerocopy::{FromBytes, IntoBytes};
+use zerocopy::{FromBytes, Immutable, IntoBytes};
 
 use object::endian::LittleEndian as LE;
 use object::pe;
@@ -73,9 +72,41 @@ struct TrampolineHeader64 {
 const TRAMPOLINE_MAGIC: [u8; 8] = *b"LITEBOX0";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct PeDataDirectory {
-    virtual_address: u32,
-    size: u32,
+pub struct PeDataDirectory {
+    /// Relative virtual address
+    pub rva: usize,
+    pub size: usize,
+}
+
+/// Maximum number of entries in `ntdll!KiUserInvertedFunctionTable`.
+pub const MAXIMUM_INVERTED_FUNCTION_TABLE_SIZE: u32 = 512;
+
+/// Memory layout of this struct:
+///
+/// ```text
+/// +-----------------------------------+
+/// | KiUserInvertedFunctionTableHeader |
+/// +-----------------------------------+
+/// | KiUserInvertedFunctionTableEntry[MAXIMUM_INVERTED_FUNCTION_TABLE_SIZE] |
+/// +-----------------------------------+
+/// ```
+#[repr(C)]
+#[derive(Clone, Copy, Debug, FromBytes, IntoBytes, Immutable)]
+pub struct KiUserInvertedFunctionTableHeader {
+    pub current_size: u32,
+    pub maximum_size: u32,
+    pub epoch: u32,
+    pub overflow: u8,
+    pub padding_0: [u8; 3],
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, FromBytes, IntoBytes, Immutable)]
+pub struct KiUserInvertedFunctionTableEntry {
+    pub exception_directory_address: usize,
+    pub image_base: usize,
+    pub image_size: u32,
+    pub size_of_table: u32,
 }
 
 /// Errors that can occur when parsing a PE file.
@@ -107,6 +138,18 @@ pub enum PeLoadError<E> {
     RelocationRequired,
     #[error("unsupported PE base relocation type {0}")]
     UnsupportedRelocation(u16),
+    #[error(transparent)]
+    Fault(#[from] Fault),
+}
+
+/// Errors that can occur when parsing the export table of a loaded PE image.
+#[derive(Debug, Error)]
+pub enum PeExportError {
+    #[error("invalid PE export table")]
+    InvalidImage,
+    /// A PE export field overflowed the host's `usize` representation.
+    #[error("PE export field overflow")]
+    Overflow,
     #[error(transparent)]
     Fault(#[from] Fault),
 }
@@ -158,6 +201,18 @@ impl PeParsedFile {
     #[must_use]
     pub fn has_trampoline(&self) -> bool {
         self.trampoline.is_some()
+    }
+
+    /// Returns the PE image size from the optional header.
+    #[must_use]
+    pub fn image_size(&self) -> usize {
+        self.image.size_of_image
+    }
+
+    /// Returns the exception directory, if present.
+    #[must_use]
+    pub fn exception_directory(&self) -> Option<PeDataDirectory> {
+        self.data_directory(pe::IMAGE_DIRECTORY_ENTRY_EXCEPTION)
     }
 
     /// Load the PE image into memory.
@@ -298,6 +353,146 @@ impl PeParsedFile {
         })
     }
 
+    /// Look up selected named exports from an already-loaded PE image.
+    ///
+    /// The export name table is scanned once. The returned vector has the same
+    /// order as `names`; entries are `None` when the image does not export that
+    /// name as a concrete address.
+    pub fn find_export_addresses(
+        &self,
+        base_addr: usize,
+        mem: &mut impl AccessMemory,
+        names: &[&str],
+    ) -> Result<Vec<Option<usize>>, PeExportError> {
+        let mut addresses = Vec::new();
+        addresses.resize(names.len(), None);
+        if names.is_empty() {
+            return Ok(addresses);
+        }
+
+        let Some(export_dir) = self
+            .data_directories
+            .get(pe::IMAGE_DIRECTORY_ENTRY_EXPORT)
+            .filter(|directory| directory.rva != 0 && directory.size != 0)
+        else {
+            return Ok(addresses);
+        };
+
+        let export_rva = export_dir.rva;
+        let export_size = export_dir.size;
+        if export_size < size_of::<pe::ImageExportDirectory>() {
+            return Err(PeExportError::InvalidImage);
+        }
+        let export_end_rva = checked_add_export(export_rva, export_size)?;
+        if export_end_rva > self.image.size_of_image {
+            return Err(PeExportError::InvalidImage);
+        }
+
+        let directory_address = image_address(
+            base_addr,
+            self.image.size_of_image,
+            export_rva,
+            size_of::<pe::ImageExportDirectory>(),
+        )?;
+        let directory: pe::ImageExportDirectory = mem_read_pod(mem, directory_address)?;
+
+        let function_count = directory.number_of_functions.get(LE) as usize;
+        let name_count = directory.number_of_names.get(LE) as usize;
+        let address_table_rva = directory.address_of_functions.get(LE) as usize;
+        let name_table_rva = directory.address_of_names.get(LE) as usize;
+        let name_ordinal_table_rva = directory.address_of_name_ordinals.get(LE) as usize;
+
+        if function_count != 0 && address_table_rva == 0 {
+            return Err(PeExportError::InvalidImage);
+        }
+        validate_image_range(
+            self.image.size_of_image,
+            address_table_rva,
+            checked_mul_export(function_count, size_of::<u32>())?,
+        )?;
+        if name_count == 0 {
+            return Ok(addresses);
+        }
+        if name_table_rva == 0 || name_ordinal_table_rva == 0 {
+            return Err(PeExportError::InvalidImage);
+        }
+        validate_image_range(
+            self.image.size_of_image,
+            name_table_rva,
+            checked_mul_export(name_count, size_of::<u32>())?,
+        )?;
+        validate_image_range(
+            self.image.size_of_image,
+            name_ordinal_table_rva,
+            checked_mul_export(name_count, size_of::<u16>())?,
+        )?;
+
+        let mut found = 0;
+        for name_index in 0..name_count {
+            let name_pointer_address = image_address(
+                base_addr,
+                self.image.size_of_image,
+                checked_add_export(name_table_rva, name_index * size_of::<u32>())?,
+                size_of::<u32>(),
+            )?;
+            let name_rva = mem_read_u32(mem, name_pointer_address)? as usize;
+            let export_name =
+                read_c_string_at_rva(base_addr, self.image.size_of_image, mem, name_rva, None)?;
+            let Some(requested_index) = names.iter().position(|name| *name == export_name) else {
+                continue;
+            };
+            if addresses[requested_index].is_some() {
+                continue;
+            }
+
+            let ordinal_index_address = image_address(
+                base_addr,
+                self.image.size_of_image,
+                checked_add_export(name_ordinal_table_rva, name_index * size_of::<u16>())?,
+                size_of::<u16>(),
+            )?;
+            let ordinal_index = mem_read_export_u16(mem, ordinal_index_address)? as usize;
+            if ordinal_index >= function_count {
+                return Err(PeExportError::InvalidImage);
+            }
+
+            let function_rva_address = image_address(
+                base_addr,
+                self.image.size_of_image,
+                checked_add_export(address_table_rva, ordinal_index * size_of::<u32>())?,
+                size_of::<u32>(),
+            )?;
+            let function_rva = mem_read_u32(mem, function_rva_address)?;
+            if let Some(address) = export_address(
+                base_addr,
+                self.image.size_of_image,
+                export_rva,
+                export_end_rva,
+                function_rva,
+            )? {
+                addresses[requested_index] = Some(address);
+                found += 1;
+                if found == names.len() {
+                    break;
+                }
+            }
+        }
+
+        Ok(addresses)
+    }
+
+    fn data_directory(&self, index: usize) -> Option<PeDataDirectory> {
+        let directory = self
+            .data_directories
+            .get(index)
+            .filter(|directory| directory.rva != 0 && directory.size != 0)?;
+        directory
+            .rva
+            .checked_add(directory.size)
+            .filter(|end| *end <= self.image.size_of_image)?;
+        Some(*directory)
+    }
+
     /// Parse the LiteBox PE trampoline footer, if present.
     ///
     /// The trampoline RVA is relative to the image base. The first pointer-sized
@@ -436,8 +631,8 @@ impl PeParsedFile {
             .ok_or(PeLoadError::RelocationRequired)?;
 
         let image_end = checked_add_invalid!(base_addr, self.image.size_of_image)?;
-        let dir_addr = checked_add_invalid!(base_addr, reloc_dir.virtual_address as usize)?;
-        let dir_end = checked_add_invalid!(dir_addr, reloc_dir.size as usize)?;
+        let dir_addr = checked_add_invalid!(base_addr, reloc_dir.rva)?;
+        let dir_end = checked_add_invalid!(dir_addr, reloc_dir.size)?;
 
         // `delta` represents a possibly-negative offset via two's-complement
         // wrap in `usize`; the signed cast preserves the sign for `wrapping_add_signed`.
@@ -488,6 +683,102 @@ impl PeParsedFile {
 
         Ok(())
     }
+}
+
+fn export_address(
+    base_addr: usize,
+    image_size: usize,
+    export_rva: usize,
+    export_end_rva: usize,
+    function_rva: u32,
+) -> Result<Option<usize>, PeExportError> {
+    if function_rva == 0 {
+        return Ok(None);
+    }
+
+    let function_rva = function_rva as usize;
+    if function_rva >= export_rva && function_rva < export_end_rva {
+        return Ok(None);
+    }
+
+    image_address(base_addr, image_size, function_rva, 1).map(Some)
+}
+
+fn read_c_string_at_rva(
+    base_addr: usize,
+    image_size: usize,
+    mem: &mut impl AccessMemory,
+    rva: usize,
+    end_rva: Option<usize>,
+) -> Result<String, PeExportError> {
+    let end_rva = end_rva.unwrap_or(image_size);
+    if rva >= end_rva || end_rva > image_size {
+        return Err(PeExportError::InvalidImage);
+    }
+
+    let mut bytes = Vec::new();
+    for current_rva in rva..end_rva {
+        let address = image_address(base_addr, image_size, current_rva, 1)?;
+        let byte = mem_read_u8(mem, address)?;
+        if byte == 0 {
+            return String::from_utf8(bytes).map_err(|_| PeExportError::InvalidImage);
+        }
+        bytes.push(byte);
+    }
+
+    Err(PeExportError::InvalidImage)
+}
+
+fn mem_read_pod<T: Pod>(mem: &mut impl AccessMemory, address: usize) -> Result<T, PeExportError> {
+    let mut buf = alloc::vec![0u8; size_of::<T>()];
+    mem.read(address, &mut buf)?;
+    let (value, _) =
+        object::pod::from_bytes::<T>(&buf).map_err(|()| PeExportError::InvalidImage)?;
+    Ok(*value)
+}
+
+fn mem_read_u8(mem: &mut impl AccessMemory, address: usize) -> Result<u8, PeExportError> {
+    let mut buf = [0u8; size_of::<u8>()];
+    mem.read(address, &mut buf)?;
+    Ok(buf[0])
+}
+
+fn mem_read_u32(mem: &mut impl AccessMemory, address: usize) -> Result<u32, PeExportError> {
+    let mut buf = [0u8; size_of::<u32>()];
+    mem.read(address, &mut buf)?;
+    Ok(u32::from_le_bytes(buf))
+}
+
+fn mem_read_export_u16(mem: &mut impl AccessMemory, address: usize) -> Result<u16, PeExportError> {
+    let mut buf = [0u8; size_of::<u16>()];
+    mem.read(address, &mut buf)?;
+    Ok(u16::from_le_bytes(buf))
+}
+
+fn image_address(
+    base_addr: usize,
+    image_size: usize,
+    rva: usize,
+    len: usize,
+) -> Result<usize, PeExportError> {
+    validate_image_range(image_size, rva, len)?;
+    checked_add_export(base_addr, rva)
+}
+
+fn validate_image_range(image_size: usize, rva: usize, len: usize) -> Result<(), PeExportError> {
+    let end = checked_add_export(rva, len)?;
+    if end > image_size {
+        return Err(PeExportError::InvalidImage);
+    }
+    Ok(())
+}
+
+fn checked_add_export(left: usize, right: usize) -> Result<usize, PeExportError> {
+    left.checked_add(right).ok_or(PeExportError::Overflow)
+}
+
+fn checked_mul_export(left: usize, right: usize) -> Result<usize, PeExportError> {
+    left.checked_mul(right).ok_or(PeExportError::Overflow)
 }
 
 fn mem_read_u16<E>(mem: &mut impl AccessMemory, address: usize) -> Result<u16, PeLoadError<E>> {
@@ -615,12 +906,9 @@ fn parse_headers<F: ReadAt>(
     let data_directories: Vec<_> = raw_dirs
         .iter()
         .map(|dir| {
-            let virtual_address = dir.virtual_address.get(LE);
-            let size = dir.size.get(LE);
-            PeDataDirectory {
-                virtual_address,
-                size,
-            }
+            let rva = dir.virtual_address.get(LE) as usize;
+            let size = dir.size.get(LE) as usize;
+            PeDataDirectory { rva, size }
         })
         .collect();
 
@@ -816,4 +1104,160 @@ fn section_name_eq(section: &pe::ImageSectionHeader, name: &[u8]) -> bool {
         .position(|byte| *byte == 0)
         .unwrap_or(section.name.len());
     &section.name[..end] == name
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::{vec, vec::Vec};
+
+    use super::*;
+
+    const TEST_BASE: usize = 0x1000_0000;
+    const TEST_IMAGE_SIZE: usize = 0x5000;
+    const EXPORT_RVA: usize = 0x2000;
+    const EXPORT_RVA_U32: u32 = 0x2000;
+
+    struct TestMemory {
+        base_addr: usize,
+        data: Vec<u8>,
+    }
+
+    impl TestMemory {
+        fn new(base_addr: usize, len: usize) -> Self {
+            Self {
+                base_addr,
+                data: vec![0; len],
+            }
+        }
+
+        fn put_u16(&mut self, rva: usize, value: u16) {
+            self.put_bytes(rva, &value.to_le_bytes());
+        }
+
+        fn put_u32(&mut self, rva: usize, value: u32) {
+            self.put_bytes(rva, &value.to_le_bytes());
+        }
+
+        fn put_bytes(&mut self, rva: usize, bytes: &[u8]) {
+            let end = rva + bytes.len();
+            self.data[rva..end].copy_from_slice(bytes);
+        }
+    }
+
+    impl AccessMemory for TestMemory {
+        fn read(&mut self, address: usize, buf: &mut [u8]) -> Result<(), Fault> {
+            let offset = address.checked_sub(self.base_addr).ok_or(Fault)?;
+            let end = offset.checked_add(buf.len()).ok_or(Fault)?;
+            let data = self.data.get(offset..end).ok_or(Fault)?;
+            buf.copy_from_slice(data);
+            Ok(())
+        }
+
+        fn write(&mut self, address: usize, data: &[u8]) -> Result<(), Fault> {
+            let offset = address.checked_sub(self.base_addr).ok_or(Fault)?;
+            let end = offset.checked_add(data.len()).ok_or(Fault)?;
+            let dst = self.data.get_mut(offset..end).ok_or(Fault)?;
+            dst.copy_from_slice(data);
+            Ok(())
+        }
+    }
+
+    fn parsed_file_with_export_directory(export_rva: u32, export_size: u32) -> PeParsedFile {
+        PeParsedFile {
+            image: PeImageInfo {
+                machine: pe::IMAGE_FILE_MACHINE_AMD64,
+                characteristics: pe::IMAGE_FILE_EXECUTABLE_IMAGE,
+                image_base: TEST_BASE,
+                entry_point_rva: 0x1000,
+                size_of_image: TEST_IMAGE_SIZE,
+                size_of_headers: PAGE_SIZE,
+                section_alignment: PAGE_SIZE,
+                file_alignment: 0x200,
+                subsystem: 0,
+                dll_characteristics: 0,
+                size_of_heap_reserve: 0,
+                size_of_heap_commit: 0,
+            },
+            sections: Vec::new(),
+            data_directories: vec![PeDataDirectory {
+                rva: export_rva as usize,
+                size: export_size as usize,
+            }],
+            trampoline: None,
+        }
+    }
+
+    fn write_export_directory(memory: &mut TestMemory) {
+        memory.put_u32(EXPORT_RVA + 16, 1);
+        memory.put_u32(EXPORT_RVA + 20, 2);
+        memory.put_u32(EXPORT_RVA + 24, 2);
+        memory.put_u32(EXPORT_RVA + 28, 0x2040);
+        memory.put_u32(EXPORT_RVA + 32, 0x2050);
+        memory.put_u32(EXPORT_RVA + 36, 0x2058);
+
+        memory.put_u32(0x2040, 0x1100);
+        memory.put_u32(0x2044, 0x2060);
+        memory.put_u32(0x2050, 0x2070);
+        memory.put_u32(0x2054, 0x2080);
+        memory.put_u16(0x2058, 0);
+        memory.put_u16(0x205a, 1);
+        memory.put_bytes(0x2060, b"KERNEL32.Sleep\0");
+        memory.put_bytes(0x2070, b"LocalFunction\0");
+        memory.put_bytes(0x2080, b"ForwardedFunction\0");
+    }
+
+    #[test]
+    fn find_export_addresses_returns_missing_entries_without_export_directory() {
+        let parsed = parsed_file_with_export_directory(0, 0);
+        let mut memory = TestMemory::new(TEST_BASE, TEST_IMAGE_SIZE);
+
+        let addresses = parsed
+            .find_export_addresses(TEST_BASE, &mut memory, &["LocalFunction"])
+            .unwrap();
+
+        assert_eq!(addresses, vec![None]);
+    }
+
+    #[test]
+    fn find_export_addresses_returns_requested_addresses_in_order() {
+        let parsed = parsed_file_with_export_directory(EXPORT_RVA_U32, 0x100);
+        let mut memory = TestMemory::new(TEST_BASE, TEST_IMAGE_SIZE);
+        write_export_directory(&mut memory);
+
+        let addresses = parsed
+            .find_export_addresses(
+                TEST_BASE,
+                &mut memory,
+                &["ForwardedFunction", "Missing", "LocalFunction"],
+            )
+            .unwrap();
+
+        assert_eq!(addresses, vec![None, None, Some(TEST_BASE + 0x1100)]);
+    }
+
+    #[test]
+    fn find_export_addresses_rejects_bad_name_ordinal() {
+        let parsed = parsed_file_with_export_directory(EXPORT_RVA_U32, 0x100);
+        let mut memory = TestMemory::new(TEST_BASE, TEST_IMAGE_SIZE);
+        write_export_directory(&mut memory);
+        memory.put_u16(0x2058, 2);
+
+        let error = parsed
+            .find_export_addresses(TEST_BASE, &mut memory, &["LocalFunction"])
+            .unwrap_err();
+
+        assert!(matches!(error, PeExportError::InvalidImage));
+    }
+
+    #[test]
+    fn find_export_addresses_rejects_short_export_directory() {
+        let parsed = parsed_file_with_export_directory(EXPORT_RVA_U32, 1);
+        let mut memory = TestMemory::new(TEST_BASE, TEST_IMAGE_SIZE);
+
+        let error = parsed
+            .find_export_addresses(TEST_BASE, &mut memory, &["LocalFunction"])
+            .unwrap_err();
+
+        assert!(matches!(error, PeExportError::InvalidImage));
+    }
 }

--- a/litebox_shim_windows/Cargo.toml
+++ b/litebox_shim_windows/Cargo.toml
@@ -10,6 +10,7 @@ litebox_common_windows = { path = "../litebox_common_windows/", version = "0.1.0
 litebox_platform_multiplex = { path = "../litebox_platform_multiplex/", version = "0.1.0", default-features = false }
 litebox_util_log = { path = "../litebox_util_log", version = "0.1.0" }
 thiserror = { version = "2.0.6", default-features = false }
+zerocopy = { version = "0.8", default-features = false, features = ["derive"] }
 
 [features]
 default = ["platform_windows_userland"]

--- a/litebox_shim_windows/src/lib.rs
+++ b/litebox_shim_windows/src/lib.rs
@@ -46,6 +46,31 @@ pub(crate) type WindowsFS = litebox::fs::layered::FileSystem<
 pub trait ShimFS: litebox::fs::FileSystem + Send + Sync + 'static {}
 impl<T: litebox::fs::FileSystem + Send + Sync + 'static> ShimFS for T {}
 
+fn write_value<T>(address: usize, value: T) -> Option<()>
+where
+    T: zerocopy::FromBytes + zerocopy::IntoBytes,
+{
+    use litebox::platform::{RawConstPointer as _, RawMutPointer as _};
+    let ptr = <Platform as litebox::platform::RawPointerProvider>::RawMutPointer::<T>::from_usize(
+        address,
+    );
+    ptr.write_at_offset(0, value)
+}
+
+fn write_slice<T>(address: usize, values: &[T]) -> Option<()>
+where
+    T: Copy + zerocopy::FromBytes + zerocopy::IntoBytes,
+{
+    use litebox::platform::{RawConstPointer as _, RawMutPointer as _};
+    let ptr = <Platform as litebox::platform::RawPointerProvider>::RawMutPointer::<T>::from_usize(
+        address,
+    );
+    for (index, value) in values.iter().copied().enumerate() {
+        ptr.write_at_offset(index.try_into().ok()?, value)?;
+    }
+    Some(())
+}
+
 /// Builds a Windows NT shim instance.
 pub struct WindowsShimBuilder {
     litebox: LiteBox<Platform>,

--- a/litebox_shim_windows/src/loader/pe.rs
+++ b/litebox_shim_windows/src/loader/pe.rs
@@ -3,6 +3,7 @@
 
 use alloc::{sync::Arc, vec::Vec};
 use litebox::platform::{RawConstPointer as _, RawMutPointer as _, SystemInfoProvider as _};
+use litebox::utils::TruncateExt;
 use litebox::{
     fs::{Mode, OFlags},
     mm::linux::{
@@ -11,8 +12,9 @@ use litebox::{
     platform::RawPointerProvider,
 };
 use litebox_common_windows::loader::{
-    AccessMemory, Fault, MapMemory, MappingInfo, PAGE_SIZE, PeLoadError, PeParseError,
-    PeParsedFile, Protection, ReadAt, page_align_down,
+    AccessMemory, Fault, KiUserInvertedFunctionTableEntry, KiUserInvertedFunctionTableHeader,
+    MAXIMUM_INVERTED_FUNCTION_TABLE_SIZE, MapMemory, MappingInfo, PAGE_SIZE, PeExportError,
+    PeLoadError, PeParseError, PeParsedFile, Protection, ReadAt, page_align_down,
 };
 use litebox_platform_multiplex::Platform;
 use thiserror::Error;
@@ -21,6 +23,15 @@ use crate::ShimFS;
 
 const NTDLL_WRITABLE_SECTIONS: &[&[u8]] = &[b".mrdata"];
 const NTDLL_PATHS: &[&str] = &["/Windows/System32/ntdll.dll", "/windows/system32/ntdll.dll"];
+const NTDLL_EXPORT_NAMES: &[&str] = &[
+    "LdrInitializeThunk",
+    "RtlUserThreadStart",
+    "KiUserInvertedFunctionTable",
+];
+const NTDLL_LDR_INITIALIZE_THUNK_EXPORT: usize = 0;
+const NTDLL_RTL_USER_THREAD_START_EXPORT: usize = 1;
+const NTDLL_KI_USER_INVERTED_FUNCTION_TABLE_EXPORT: usize = 2;
+const RUNTIME_FUNCTION_ENTRY_SIZE: usize = 12;
 const ZERO_CHUNK: [u8; PAGE_SIZE] = [0; PAGE_SIZE];
 const FILE_CHUNK_BYTES: usize = 64 * 1024;
 const INITIAL_STACK_SIZE: usize = 1024 * 1024;
@@ -46,6 +57,13 @@ impl<'a, FS: ShimFS> PeLoader<'a, FS> {
         let application_entry_point = image.mapping.entry_point;
         let ntdll = load_ntdll(self.fs.clone(), self.page_manager, NTDLL_PATHS)?;
 
+        if let Some(ntdll) = &ntdll {
+            if !ntdll.image.parsed.has_trampoline() {
+                return Err(WindowsLoadError::UnrewrittenNtDll);
+            }
+            Self::initialize_ki_user_inverted_function_table(&image, ntdll)?;
+        }
+
         let length =
             NonZeroPageSize::new(INITIAL_STACK_SIZE).ok_or(PeImageAccessError::AddressOverflow)?;
         // SAFETY: `suggested_address` is `None` and `CreatePagesFlags::empty()` does not set
@@ -69,20 +87,99 @@ impl<'a, FS: ShimFS> PeLoader<'a, FS> {
         Ok(PeLoadInfo {
             entry_point: application_entry_point,
             stack_top,
-            ntdll_mapping: ntdll.map(|image| image.mapping),
+            ntdll_mapping: ntdll.map(|ntdll| ntdll.image.mapping),
         })
+    }
+
+    fn initialize_ki_user_inverted_function_table(
+        application: &LoadedImage,
+        ntdll: &LoadedNtDll,
+    ) -> Result<(), WindowsLoadError> {
+        let table_address = ntdll.exports.ki_user_inverted_function_table;
+
+        let mut entries = Vec::new();
+        for image in [&ntdll.image, application] {
+            if let Some(entry) = image.inverted_function_table_entry()? {
+                entries.push(entry);
+            }
+        }
+
+        let header = KiUserInvertedFunctionTableHeader {
+            current_size: entries.len().truncate(),
+            maximum_size: MAXIMUM_INVERTED_FUNCTION_TABLE_SIZE,
+            epoch: 0,
+            overflow: 0,
+            padding_0: [0; 3],
+        };
+
+        // `KI_USER_INVERTED_FUNCTION_TABLE` lives in ntdll's writable `.mrdata` section.
+        crate::write_value(table_address, header).ok_or(PeImageAccessError::MemoryAccess)?;
+        let entries_address = table_address
+            .checked_add(core::mem::size_of::<KiUserInvertedFunctionTableHeader>())
+            .ok_or(PeImageAccessError::AddressOverflow)?;
+        crate::write_slice(entries_address, &entries).ok_or(PeImageAccessError::MemoryAccess)?;
+
+        litebox_util_log::debug!(
+            table:% = format_args!("{table_address:#x}");
+            "Initialized ntdll!KiUserInvertedFunctionTable"
+        );
+
+        Ok(())
     }
 }
 
 struct LoadedImage {
     mapping: MappingInfo,
+    parsed: PeParsedFile,
+}
+
+impl LoadedImage {
+    fn inverted_function_table_entry(
+        &self,
+    ) -> Result<Option<KiUserInvertedFunctionTableEntry>, WindowsLoadError> {
+        let Some(exception_directory) = self.parsed.exception_directory() else {
+            return Ok(None);
+        };
+        if !exception_directory
+            .size
+            .is_multiple_of(RUNTIME_FUNCTION_ENTRY_SIZE)
+        {
+            return Err(WindowsLoadError::InvalidNtDllExceptionDirectory);
+        }
+
+        let exception_directory_address = self
+            .mapping
+            .base_addr
+            .checked_add(exception_directory.rva)
+            .ok_or(PeImageAccessError::AddressOverflow)?;
+        let size_of_image = u32::try_from(self.parsed.image_size())
+            .map_err(|_| PeImageAccessError::AddressOverflow)?;
+
+        Ok(Some(KiUserInvertedFunctionTableEntry {
+            exception_directory_address,
+            image_base: self.mapping.base_addr,
+            image_size: size_of_image,
+            size_of_table: u32::try_from(exception_directory.size)
+                .map_err(|_| PeImageAccessError::AddressOverflow)?,
+        }))
+    }
+}
+
+struct LoadedNtDll {
+    image: LoadedImage,
+    exports: NtDllExports,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct NtDllExports {
+    ki_user_inverted_function_table: usize,
 }
 
 fn load_ntdll<FS: crate::ShimFS>(
     fs: Arc<FS>,
     page_manager: &crate::WindowsPageManager,
     ntdll_paths: &[&str],
-) -> Result<Option<LoadedImage>, WindowsLoadError> {
+) -> Result<Option<LoadedNtDll>, WindowsLoadError> {
     for path in ntdll_paths {
         match load_image_with_writable_sections(
             fs.clone(),
@@ -91,8 +188,9 @@ fn load_ntdll<FS: crate::ShimFS>(
             NTDLL_WRITABLE_SECTIONS,
         ) {
             Ok(image) => {
+                let exports = ntdll_exports(&image)?;
                 litebox_util_log::debug!(path:% = path; "Loaded guest ntdll.dll");
-                return Ok(Some(image));
+                return Ok(Some(LoadedNtDll { image, exports }));
             }
             Err(error) if is_missing_file_error(&error) => {}
             Err(error) => return Err(error),
@@ -134,7 +232,35 @@ fn load_image_with_writable_sections<FS: ShimFS>(
     let mapping = parsed
         .load_with_writable_sections(&mut mapper, &mut memory, writable_section_names)
         .map_err(WindowsLoadError::Load)?;
-    Ok(LoadedImage { mapping })
+    Ok(LoadedImage { mapping, parsed })
+}
+
+fn ntdll_exports(image: &LoadedImage) -> Result<NtDllExports, WindowsLoadError> {
+    let mut memory = PeImageMemory;
+    let addresses = image
+        .parsed
+        .find_export_addresses(image.mapping.base_addr, &mut memory, NTDLL_EXPORT_NAMES)
+        .map_err(WindowsLoadError::Export)?;
+
+    addresses
+        .get(NTDLL_LDR_INITIALIZE_THUNK_EXPORT)
+        .copied()
+        .flatten()
+        .ok_or(WindowsLoadError::MissingNtDllLoaderEntrypoint)?;
+    addresses
+        .get(NTDLL_RTL_USER_THREAD_START_EXPORT)
+        .copied()
+        .flatten()
+        .ok_or(WindowsLoadError::MissingNtDllThreadEntrypoint)?;
+    let ki_user_inverted_function_table = addresses
+        .get(NTDLL_KI_USER_INVERTED_FUNCTION_TABLE_EXPORT)
+        .copied()
+        .flatten()
+        .ok_or(WindowsLoadError::MissingNtDllInvertedFunctionTable)?;
+
+    Ok(NtDllExports {
+        ki_user_inverted_function_table,
+    })
 }
 
 /// Errors that can occur while opening, parsing, and mapping a Windows PE image.
@@ -144,6 +270,8 @@ pub enum WindowsLoadError {
     Parse(#[source] PeParseError<PeImageAccessError>),
     #[error("failed to load PE image")]
     Load(#[source] PeLoadError<PeImageAccessError>),
+    #[error("failed to parse PE export table")]
+    Export(#[source] PeExportError),
     /// Accessing the PE backing file or its mapped memory failed.
     #[error(transparent)]
     Access(#[from] PeImageAccessError),
@@ -153,6 +281,12 @@ pub enum WindowsLoadError {
     /// Guest ntdll.dll does not export RtlUserThreadStart.
     #[error("guest ntdll.dll does not export RtlUserThreadStart")]
     MissingNtDllThreadEntrypoint,
+    /// Guest ntdll.dll does not export KiUserInvertedFunctionTable.
+    #[error("guest ntdll.dll does not export KiUserInvertedFunctionTable")]
+    MissingNtDllInvertedFunctionTable,
+    /// Guest ntdll.dll has an invalid exception directory.
+    #[error("guest ntdll.dll has an invalid exception directory")]
+    InvalidNtDllExceptionDirectory,
     /// Guest ntdll.dll has not been rewritten for LiteBox syscall/GS handling.
     #[error("guest ntdll.dll must be rewritten for LiteBox before entering its loader")]
     UnrewrittenNtDll,
@@ -415,4 +549,249 @@ fn page_range(address: usize, len: usize) -> Result<(usize, usize), PeImageAcces
         .and_then(|v| v.checked_next_multiple_of(PAGE_SIZE))
         .ok_or(PeImageAccessError::AddressOverflow)?;
     Ok((start, end - start))
+}
+
+#[cfg(all(test, target_os = "windows", target_arch = "x86_64"))]
+mod tests {
+    extern crate std;
+
+    use alloc::{string::String, vec, vec::Vec};
+
+    use super::*;
+
+    #[allow(non_snake_case)]
+    #[link(name = "kernel32")]
+    unsafe extern "system" {
+        fn GetModuleHandleW(lp_module_name: *const u16) -> *mut core::ffi::c_void;
+        fn GetProcAddress(
+            h_module: *mut core::ffi::c_void,
+            lp_proc_name: *const core::ffi::c_char,
+        ) -> *mut core::ffi::c_void;
+        fn GetModuleFileNameW(
+            h_module: *mut core::ffi::c_void,
+            lp_filename: *mut u16,
+            n_size: u32,
+        ) -> u32;
+    }
+
+    #[test]
+    fn ntdll_exports_finds_ki_user_inverted_function_table() {
+        let ntdll = ntdll_module_base();
+        let loaded_ntdll = loaded_module_image(ntdll);
+
+        let exports = ntdll_exports(&loaded_ntdll).expect("failed to parse ntdll exports");
+        let expected_table = own_inverted_function_table() as usize;
+
+        assert_eq!(
+            exports.ki_user_inverted_function_table, expected_table,
+            "ntdll export lookup returned the wrong KiUserInvertedFunctionTable address"
+        );
+    }
+
+    #[test]
+    fn dumps_own_inverted_function_table() {
+        assert_eq!(
+            core::mem::size_of::<KiUserInvertedFunctionTableHeader>(),
+            16
+        );
+        assert_eq!(core::mem::size_of::<KiUserInvertedFunctionTableEntry>(), 24);
+
+        let table = own_inverted_function_table();
+        // SAFETY: `own_inverted_function_table` resolves a live data export from the
+        // current process's already-loaded ntdll. The header is copied immediately.
+        let header = unsafe { read_table_value::<KiUserInvertedFunctionTableHeader>(table) };
+
+        std::println!(
+            "ntdll!KiUserInvertedFunctionTable @ {:#x}: current_size={} maximum_size={} epoch={} overflow={}",
+            table as usize,
+            header.current_size,
+            header.maximum_size,
+            header.epoch,
+            header.overflow
+        );
+
+        assert!(header.maximum_size > 0);
+        assert!(header.maximum_size <= MAXIMUM_INVERTED_FUNCTION_TABLE_SIZE);
+        assert!(header.current_size <= header.maximum_size);
+        assert!(header.current_size > 0);
+
+        let entries = read_inverted_function_table_entries(table, header.current_size);
+        for (index, entry) in entries.iter().enumerate() {
+            let binary_name = module_name_from_base(entry.image_base);
+            std::println!(
+                "  [{index}] binary=\"{}\" exception_directory={:#x} image_base={:#x} image_size={:#x} size_of_table={:#x}",
+                binary_name,
+                entry.exception_directory_address,
+                entry.image_base,
+                entry.image_size,
+                entry.size_of_table
+            );
+        }
+
+        assert_table_contains_entry(
+            &entries,
+            "ntdll.dll",
+            module_inverted_function_table_entry(ntdll_module_base()),
+        );
+        assert_table_contains_entry(
+            &entries,
+            "the test executable",
+            module_inverted_function_table_entry(application_module_base()),
+        );
+    }
+
+    fn own_inverted_function_table() -> *const u8 {
+        let ntdll = ntdll_module_base();
+
+        // SAFETY: The module handle was returned by `GetModuleHandleW`, and the
+        // symbol name is a valid NUL-terminated C string literal.
+        let table = unsafe { GetProcAddress(ntdll, c"KiUserInvertedFunctionTable".as_ptr()) };
+        assert!(
+            !table.is_null(),
+            "ntdll.dll does not export KiUserInvertedFunctionTable"
+        );
+
+        table.cast::<u8>()
+    }
+
+    fn ntdll_module_base() -> *mut core::ffi::c_void {
+        module_base(Some("ntdll.dll"))
+    }
+
+    fn application_module_base() -> *mut core::ffi::c_void {
+        module_base(None)
+    }
+
+    fn module_base(name: Option<&str>) -> *mut core::ffi::c_void {
+        let module_name: Option<Vec<u16>> = name.map(|name| {
+            let mut name: Vec<u16> = name.encode_utf16().collect();
+            name.push(0);
+            name
+        });
+        let module_name_ptr = module_name.as_ref().map_or(core::ptr::null(), Vec::as_ptr);
+        // SAFETY: The string is NUL-terminated and points to a process-owned buffer
+        // that remains alive for the duration of the call. A null pointer asks for
+        // the current process's executable module.
+        let module = unsafe { GetModuleHandleW(module_name_ptr) };
+        assert!(!module.is_null(), "module is not loaded in this process");
+
+        module
+    }
+
+    fn module_inverted_function_table_entry(
+        module: *mut core::ffi::c_void,
+    ) -> KiUserInvertedFunctionTableEntry {
+        let loaded_module = loaded_module_image(module);
+        loaded_module
+            .inverted_function_table_entry()
+            .expect("failed to build inverted function table entry")
+            .expect("loaded PE image has no exception directory")
+    }
+
+    fn loaded_module_image(module: *mut core::ffi::c_void) -> LoadedImage {
+        let base_addr = module as usize;
+        let mut module_memory = ModuleMemory {
+            base: base_addr as *const u8,
+        };
+        let parsed = PeParsedFile::parse(&mut module_memory)
+            .expect("failed to parse loaded PE image from memory");
+        LoadedImage {
+            mapping: MappingInfo {
+                base_addr,
+                image_size: parsed.image_size(),
+                entry_point: base_addr,
+            },
+            parsed,
+        }
+    }
+
+    fn module_name_from_base(image_base: usize) -> String {
+        let module = image_base as *mut core::ffi::c_void;
+        let mut buffer = vec![0u16; 260];
+        loop {
+            // SAFETY: `module` is the image base reported by ntdll's table, which is
+            // also the HMODULE for the loaded image. `buffer` is valid for `len` UTF-16
+            // code units and remains alive for the duration of the call.
+            let len = unsafe {
+                GetModuleFileNameW(
+                    module,
+                    buffer.as_mut_ptr(),
+                    u32::try_from(buffer.len()).unwrap(),
+                )
+            } as usize;
+            if len == 0 {
+                return String::from("<unknown>");
+            }
+            if len < buffer.len() {
+                return String::from_utf16_lossy(&buffer[..len]);
+            }
+            buffer.resize(buffer.len() * 2, 0);
+        }
+    }
+
+    fn read_inverted_function_table_entries(
+        table: *const u8,
+        current_size: u32,
+    ) -> Vec<KiUserInvertedFunctionTableEntry> {
+        let entries = table.wrapping_add(core::mem::size_of::<KiUserInvertedFunctionTableHeader>());
+        (0..current_size as usize)
+            .map(|index| {
+                let entry_address = entries
+                    .wrapping_add(index * core::mem::size_of::<KiUserInvertedFunctionTableEntry>());
+                // SAFETY: The header just read from ntdll says `current_size` entries are
+                // initialized immediately after the header in this same exported table.
+                unsafe { read_table_value::<KiUserInvertedFunctionTableEntry>(entry_address) }
+            })
+            .collect()
+    }
+
+    fn assert_table_contains_entry(
+        entries: &[KiUserInvertedFunctionTableEntry],
+        name: &str,
+        expected: KiUserInvertedFunctionTableEntry,
+    ) {
+        let actual = entries
+            .iter()
+            .find(|entry| entry.image_base == expected.image_base)
+            .unwrap_or_else(|| {
+                panic!("{name} was not present in the host inverted function table")
+            });
+
+        assert_eq!(
+            actual.exception_directory_address,
+            expected.exception_directory_address
+        );
+        assert_eq!(actual.image_size, expected.image_size);
+        assert_eq!(actual.size_of_table, expected.size_of_table);
+    }
+
+    unsafe fn read_table_value<T: zerocopy::FromBytes>(address: *const u8) -> T {
+        // SAFETY: The caller guarantees that `address` points to at least
+        // `size_of::<T>()` readable bytes.
+        let bytes = unsafe { core::slice::from_raw_parts(address, core::mem::size_of::<T>()) };
+        T::read_from_bytes(bytes).expect("failed to read table value")
+    }
+
+    struct ModuleMemory {
+        base: *const u8,
+    }
+
+    impl ReadAt for ModuleMemory {
+        type Error = core::convert::Infallible;
+
+        fn read_at(&mut self, offset: u64, buf: &mut [u8]) -> Result<(), Self::Error> {
+            let offset: usize = offset.try_into().unwrap();
+            // SAFETY: The test only constructs `ModuleMemory` from live module image
+            // bases returned by `GetModuleHandleW`. `PeParsedFile::parse` reads PE
+            // headers and section headers, which remain mapped in loaded images.
+            unsafe {
+                core::ptr::copy_nonoverlapping(self.base.add(offset), buf.as_mut_ptr(), buf.len());
+            }
+            Ok(())
+        }
+
+        fn size(&mut self) -> Result<u64, Self::Error> {
+            Ok(u64::MAX)
+        }
+    }
 }

--- a/litebox_shim_windows/src/loader/pe.rs
+++ b/litebox_shim_windows/src/loader/pe.rs
@@ -3,7 +3,7 @@
 
 use alloc::{sync::Arc, vec::Vec};
 use litebox::platform::{RawConstPointer as _, RawMutPointer as _, SystemInfoProvider as _};
-use litebox::utils::TruncateExt;
+use litebox::utils::TruncateExt as _;
 use litebox::{
     fs::{Mode, OFlags},
     mm::linux::{
@@ -23,14 +23,6 @@ use crate::ShimFS;
 
 const NTDLL_WRITABLE_SECTIONS: &[&[u8]] = &[b".mrdata"];
 const NTDLL_PATHS: &[&str] = &["/Windows/System32/ntdll.dll", "/windows/system32/ntdll.dll"];
-const NTDLL_EXPORT_NAMES: &[&str] = &[
-    "LdrInitializeThunk",
-    "RtlUserThreadStart",
-    "KiUserInvertedFunctionTable",
-];
-const NTDLL_LDR_INITIALIZE_THUNK_EXPORT: usize = 0;
-const NTDLL_RTL_USER_THREAD_START_EXPORT: usize = 1;
-const NTDLL_KI_USER_INVERTED_FUNCTION_TABLE_EXPORT: usize = 2;
 const RUNTIME_FUNCTION_ENTRY_SIZE: usize = 12;
 const ZERO_CHUNK: [u8; PAGE_SIZE] = [0; PAGE_SIZE];
 const FILE_CHUNK_BYTES: usize = 64 * 1024;
@@ -236,26 +228,27 @@ fn load_image_with_writable_sections<FS: ShimFS>(
 }
 
 fn ntdll_exports(image: &LoadedImage) -> Result<NtDllExports, WindowsLoadError> {
+    let export_names = [
+        "LdrInitializeThunk",
+        "RtlUserThreadStart",
+        "KiUserInvertedFunctionTable",
+    ];
     let mut memory = PeImageMemory;
     let addresses = image
         .parsed
-        .find_export_addresses(image.mapping.base_addr, &mut memory, NTDLL_EXPORT_NAMES)
+        .find_export_addresses(image.mapping.base_addr, &mut memory, &export_names)
         .map_err(WindowsLoadError::Export)?;
+    let [
+        ldr_initialize_thunk,
+        rtl_user_thread_start,
+        ki_user_inverted_function_table,
+    ]: [Option<usize>; 3] = addresses
+        .try_into()
+        .map_err(|_| WindowsLoadError::MissingNtDllInvertedFunctionTable)?;
 
-    addresses
-        .get(NTDLL_LDR_INITIALIZE_THUNK_EXPORT)
-        .copied()
-        .flatten()
-        .ok_or(WindowsLoadError::MissingNtDllLoaderEntrypoint)?;
-    addresses
-        .get(NTDLL_RTL_USER_THREAD_START_EXPORT)
-        .copied()
-        .flatten()
-        .ok_or(WindowsLoadError::MissingNtDllThreadEntrypoint)?;
-    let ki_user_inverted_function_table = addresses
-        .get(NTDLL_KI_USER_INVERTED_FUNCTION_TABLE_EXPORT)
-        .copied()
-        .flatten()
+    ldr_initialize_thunk.ok_or(WindowsLoadError::MissingNtDllLoaderEntrypoint)?;
+    rtl_user_thread_start.ok_or(WindowsLoadError::MissingNtDllThreadEntrypoint)?;
+    let ki_user_inverted_function_table = ki_user_inverted_function_table
         .ok_or(WindowsLoadError::MissingNtDllInvertedFunctionTable)?;
 
     Ok(NtDllExports {
@@ -681,8 +674,7 @@ mod tests {
     fn module_inverted_function_table_entry(
         module: *mut core::ffi::c_void,
     ) -> KiUserInvertedFunctionTableEntry {
-        let loaded_module = loaded_module_image(module);
-        loaded_module
+        loaded_module_image(module)
             .inverted_function_table_entry()
             .expect("failed to build inverted function table entry")
             .expect("loaded PE image has no exception directory")
@@ -734,10 +726,10 @@ mod tests {
         current_size: u32,
     ) -> Vec<KiUserInvertedFunctionTableEntry> {
         let entries = table.wrapping_add(core::mem::size_of::<KiUserInvertedFunctionTableHeader>());
+        let entry_size = core::mem::size_of::<KiUserInvertedFunctionTableEntry>();
         (0..current_size as usize)
             .map(|index| {
-                let entry_address = entries
-                    .wrapping_add(index * core::mem::size_of::<KiUserInvertedFunctionTableEntry>());
+                let entry_address = entries.wrapping_add(index * entry_size);
                 // SAFETY: The header just read from ntdll says `current_size` entries are
                 // initialized immediately after the header in this same exported table.
                 unsafe { read_table_value::<KiUserInvertedFunctionTableEntry>(entry_address) }


### PR DESCRIPTION
This PR extends the Windows PE loader to parse export table so the shim can discover and initialize `ntdll!KiUserInvertedFunctionTable` for rewritten guest ntdll startup.

Adds Windows-only shim tests that compare against the host ntdll table:
- verifies our export lookup finds the real KiUserInvertedFunctionTable address;
- dumps the host inverted function table;
- parses host-loaded ntdll and the test executable from memory and compares expected entries against the actual table.