### PR TITLE
Refactor pipe code in the Linux shim

### DIFF
--- a/litebox/src/pipes.rs
+++ b/litebox/src/pipes.rs
@@ -31,11 +31,7 @@ use crate::{
     sync::{Mutex, RawSyncPrimitivesProvider},
 };
 
-/// Generic in-process support for unidirectional byte channels.
-///
-/// This module owns pipe buffering, endpoint lifetime, and readiness mechanics.
-/// Guest ABI details such as raw fd numbers, `pipe2` flags, and Linux errno
-/// mapping belong in the shim that exposes that ABI.
+/// Support for unidirectional communication channels
 pub struct Pipes<Platform: RawSyncPrimitivesProvider + TimeProvider> {
     litebox: LiteBox<Platform>,
 }

--- a/litebox/src/pipes.rs
+++ b/litebox/src/pipes.rs
@@ -31,7 +31,11 @@ use crate::{
     sync::{Mutex, RawSyncPrimitivesProvider},
 };
 
-/// Support for unidirectional communication channels
+/// Generic in-process support for unidirectional byte channels.
+///
+/// This module owns pipe buffering, endpoint lifetime, and readiness mechanics.
+/// Guest ABI details such as raw fd numbers, `pipe2` flags, and Linux errno
+/// mapping belong in the shim that exposes that ABI.
 pub struct Pipes<Platform: RawSyncPrimitivesProvider + TimeProvider> {
     litebox: LiteBox<Platform>,
 }

--- a/litebox_shim_linux/src/lib.rs
+++ b/litebox_shim_linux/src/lib.rs
@@ -342,10 +342,6 @@ fn default_fs(
 #[derive(Clone)]
 pub(crate) struct StdioStatusFlags(litebox::fs::OFlags);
 
-/// Status flags for pipes
-#[derive(Clone)]
-pub(crate) struct PipeStatusFlags(pub litebox::fs::OFlags);
-
 impl<FS: ShimFS> syscalls::file::FilesState<FS> {
     fn initialize_stdio_in_shared_descriptors_table(&self, global: &GlobalState<FS>) {
         use litebox::fs::{Mode, OFlags};

--- a/litebox_shim_linux/src/syscalls/epoll.rs
+++ b/litebox_shim_linux/src/syscalls/epoll.rs
@@ -143,7 +143,7 @@ impl<FS: ShimFS> EpollDescriptor<FS> {
                 };
                 Some(poll(&proxy))
             }
-            EpollDescriptor::Pipe(fd) => global.pipes.with_iopollable(fd, poll).ok(),
+            EpollDescriptor::Pipe(fd) => global.with_linux_pipe_iopollable(fd, poll).ok(),
             EpollDescriptor::Unix(fd) => {
                 let handle = global.litebox.descriptor_table().entry_handle(fd)?;
                 Some(handle.with_entry(|entry| poll(entry)))

--- a/litebox_shim_linux/src/syscalls/file.rs
+++ b/litebox_shim_linux/src/syscalls/file.rs
@@ -391,9 +391,7 @@ impl<FS: ShimFS> Task<FS> {
                 |fd| {
                     espipe_for_non_seekable_offset(offset)?;
                     self.global
-                        .pipes
-                        .read(&self.wait_cx(), fd, &mut buf.borrow_mut())
-                        .map_err(Errno::from)
+                        .read_linux_pipe(&self.wait_cx(), fd, &mut buf.borrow_mut())
                 },
                 |fd| {
                     let handle = self
@@ -464,10 +462,7 @@ impl<FS: ShimFS> Task<FS> {
                 },
                 |fd| {
                     espipe_for_non_seekable_offset(offset)?;
-                    self.global
-                        .pipes
-                        .write(&self.wait_cx(), fd, buf)
-                        .map_err(Errno::from)
+                    self.global.write_linux_pipe(&self.wait_cx(), fd, buf)
                 },
                 |fd| {
                     let handle = self
@@ -675,7 +670,7 @@ impl<FS: ShimFS> Task<FS> {
                 files.fs.close(&fd).map_err(Errno::from)
             }
             ConsumedFd::Network(fd) => self.global.close_socket(&self.wait_cx(), fd),
-            ConsumedFd::Pipes(fd) => self.global.pipes.close(&fd).map_err(Errno::from),
+            ConsumedFd::Pipes(fd) => self.global.close_linux_pipe(&fd),
             ConsumedFd::Eventfd(fd) => {
                 let entry = {
                     let mut dt = self.global.litebox.descriptor_table_mut();
@@ -966,14 +961,10 @@ where
             },
             |_fd| Ok(T::from(synthetic(socket_mode, 4096))),
             |fd| {
-                let half_pipe_type = task.global.pipes.half_pipe_type(fd)?;
-                let read_write_mode = match half_pipe_type {
-                    litebox::pipes::HalfPipeType::SenderHalf => Mode::WUSR,
-                    litebox::pipes::HalfPipeType::ReceiverHalf => Mode::RUSR,
-                };
-                let pipe_mode =
-                    read_write_mode.bits() | litebox_common_linux::InodeType::NamedPipe as u32;
-                Ok(T::from(synthetic(pipe_mode, 4096)))
+                Ok(T::from(synthetic(
+                    task.global.linux_pipe_mode_bits(fd)?,
+                    4096,
+                )))
             },
             |_fd| Ok(T::from(synthetic(rw_user_mode, 4096))),
             |_fd| Ok(T::from(synthetic(rw_user_mode, 0))),
@@ -1207,7 +1198,7 @@ impl<FS: ShimFS> Task<FS> {
                         desc,
                         |fd| getfl_from_metadata!(fd, crate::StdioStatusFlags),
                         |fd| getfl_from_metadata!(fd, crate::syscalls::net::SocketOFlags),
-                        |fd| getfl_from_metadata!(fd, crate::PipeStatusFlags),
+                        |fd| self.global.linux_pipe_status_flags(fd),
                         |fd| getfl_from_handle!(fd),
                         |fd| getfl_from_handle!(fd),
                         |fd| getfl_from_handle!(fd),
@@ -1281,22 +1272,8 @@ impl<FS: ShimFS> Task<FS> {
                         )
                     },
                     |fd| {
-                        // Update the actual pipe non-blocking behavior
                         self.global
-                            .pipes
-                            .update_flags(
-                                fd,
-                                litebox::pipes::Flags::NON_BLOCKING,
-                                flags.intersects(OFlags::NONBLOCK),
-                            )
-                            .map_err(Errno::from)?;
-                        // Record all status flags in metadata for F_GETFL
-                        setfl_in_metadata!(
-                            fd,
-                            crate::PipeStatusFlags,
-                            unreachable!("all pipes have PipeStatusFlags when created"),
-                            |_| {}
-                        )
+                            .set_linux_pipe_status_flags(fd, flags, setfl_mask)
                     },
                     |fd| {
                         toggle_flags!(fd);
@@ -1436,70 +1413,24 @@ impl<FS: ShimFS> Task<FS> {
     }
 }
 
-const DEFAULT_PIPE_BUF_SIZE: usize = 1024 * 1024;
-
 impl<FS: ShimFS> Task<FS> {
     /// Handle syscall `pipe2`
     pub fn sys_pipe2(&self, flags: OFlags) -> Result<(u32, u32), Errno> {
-        let (pipe_flags, cloexec) = {
-            use litebox::pipes::Flags;
-            let mut f = Flags::empty();
-            if flags.intersects((OFlags::CLOEXEC | OFlags::NONBLOCK | OFlags::DIRECT).complement())
-            {
-                return Err(Errno::EINVAL);
-            }
-            f.set(Flags::NON_BLOCKING, flags.contains(OFlags::NONBLOCK));
-            if flags.contains(OFlags::DIRECT) {
-                todo!("O_DIRECT not supported");
-            }
-            (f, flags.contains(OFlags::CLOEXEC))
-        };
-
-        let (writer, reader) = self.global.pipes.create_pipe(
-            DEFAULT_PIPE_BUF_SIZE,
-            pipe_flags,
-            // See `man 7 pipe` for `PIPE_BUF`. On Linux, this is 4096.
-            core::num::NonZero::new(4096),
-        );
-
-        {
-            let initial_status = OFlags::from(pipe_flags);
-            let mut dt = self.global.litebox.descriptor_table_mut();
-            let old = dt.set_entry_metadata(
-                &writer,
-                crate::PipeStatusFlags(initial_status | OFlags::WRONLY),
-            );
-            assert!(old.is_none());
-            let old = dt.set_entry_metadata(
-                &reader,
-                crate::PipeStatusFlags(initial_status | OFlags::RDONLY),
-            );
-            assert!(old.is_none());
-        }
-
-        if cloexec {
-            let mut dt = self.global.litebox.descriptor_table_mut();
-            let None = dt.set_fd_metadata(&writer, FileDescriptorFlags::FD_CLOEXEC) else {
-                unreachable!()
-            };
-            let None = dt.set_fd_metadata(&reader, FileDescriptorFlags::FD_CLOEXEC) else {
-                unreachable!()
-            };
-        }
+        let pipe = self.global.create_linux_pipe(flags)?;
 
         let files = self.files.borrow();
-        let wr_raw_fd = files.insert_raw_fd(writer).map_err(|writer| {
-            self.global.pipes.close(&writer).unwrap();
+        let wr_raw_fd = files.insert_raw_fd(pipe.writer).map_err(|writer| {
+            self.global.close_linux_pipe(&writer).unwrap();
             Errno::EMFILE
         })?;
-        let rd_raw_fd = files.insert_raw_fd(reader).map_err(|reader| {
+        let rd_raw_fd = files.insert_raw_fd(pipe.reader).map_err(|reader| {
             let writer = files
                 .raw_descriptor_store
                 .write()
                 .fd_consume_raw_integer(wr_raw_fd)
                 .unwrap();
-            self.global.pipes.close(&writer).unwrap();
-            self.global.pipes.close(&reader).unwrap();
+            self.global.close_linux_pipe(&writer).unwrap();
+            self.global.close_linux_pipe(&reader).unwrap();
             Errno::EMFILE
         })?;
         Ok((rd_raw_fd.try_into().unwrap(), wr_raw_fd.try_into().unwrap()))

--- a/litebox_shim_linux/src/syscalls/mod.rs
+++ b/litebox_shim_linux/src/syscalls/mod.rs
@@ -9,6 +9,7 @@ pub mod file;
 pub(crate) mod misc;
 pub(crate) mod mm;
 pub(crate) mod net;
+pub(crate) mod pipe;
 pub mod process;
 pub(crate) mod unix;
 

--- a/litebox_shim_linux/src/syscalls/pipe.rs
+++ b/litebox_shim_linux/src/syscalls/pipe.rs
@@ -1,0 +1,163 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//! Linux ABI glue for the generic LiteBox pipe subsystem.
+//!
+//! `litebox::pipes` owns the in-process pipe buffer, endpoint, and readiness
+//! mechanics. This module owns Linux-specific presentation: `pipe2` flags,
+//! raw-fd metadata, `fcntl` status flags, and errno mapping.
+
+use core::num::NonZero;
+
+use litebox::{
+    event::{IOPollable, wait::WaitContext},
+    fd::MetadataError,
+    fs::{Mode, OFlags},
+    pipes::{HalfPipeType, PipeFd},
+};
+use litebox_common_linux::{FileDescriptorFlags, InodeType, errno::Errno};
+
+use crate::{GlobalState, Platform, ShimFS};
+
+const DEFAULT_PIPE_BUF_SIZE: usize = 1024 * 1024;
+
+/// Status flags for Linux pipe file descriptions.
+///
+/// Access mode and Linux status flags are shim ABI state. The generic pipe
+/// backend only needs the subset that affects pipe behavior, such as
+/// nonblocking mode.
+#[derive(Clone)]
+pub(crate) struct PipeStatusFlags(OFlags);
+
+pub(crate) struct LinuxPipeEnds {
+    pub(crate) reader: PipeFd<Platform>,
+    pub(crate) writer: PipeFd<Platform>,
+}
+
+impl<FS: ShimFS> GlobalState<FS> {
+    pub(crate) fn create_linux_pipe(&self, flags: OFlags) -> Result<LinuxPipeEnds, Errno> {
+        let (pipe_flags, cloexec) = {
+            use litebox::pipes::Flags;
+
+            let mut pipe_flags = Flags::empty();
+            if flags.intersects((OFlags::CLOEXEC | OFlags::NONBLOCK | OFlags::DIRECT).complement())
+            {
+                return Err(Errno::EINVAL);
+            }
+            pipe_flags.set(Flags::NON_BLOCKING, flags.contains(OFlags::NONBLOCK));
+            if flags.contains(OFlags::DIRECT) {
+                todo!("O_DIRECT not supported");
+            }
+            (pipe_flags, flags.contains(OFlags::CLOEXEC))
+        };
+
+        let (writer, reader) = self.pipes.create_pipe(
+            DEFAULT_PIPE_BUF_SIZE,
+            pipe_flags,
+            // See `man 7 pipe` for `PIPE_BUF`. On Linux, this is 4096.
+            NonZero::new(4096),
+        );
+
+        let initial_status = OFlags::from(pipe_flags);
+        {
+            let mut dt = self.litebox.descriptor_table_mut();
+            let old =
+                dt.set_entry_metadata(&writer, PipeStatusFlags(initial_status | OFlags::WRONLY));
+            assert!(old.is_none());
+            let old =
+                dt.set_entry_metadata(&reader, PipeStatusFlags(initial_status | OFlags::RDONLY));
+            assert!(old.is_none());
+        }
+
+        if cloexec {
+            let mut dt = self.litebox.descriptor_table_mut();
+            let None = dt.set_fd_metadata(&writer, FileDescriptorFlags::FD_CLOEXEC) else {
+                unreachable!()
+            };
+            let None = dt.set_fd_metadata(&reader, FileDescriptorFlags::FD_CLOEXEC) else {
+                unreachable!()
+            };
+        }
+
+        Ok(LinuxPipeEnds { reader, writer })
+    }
+
+    pub(crate) fn close_linux_pipe(&self, fd: &PipeFd<Platform>) -> Result<(), Errno> {
+        self.pipes.close(fd).map_err(Errno::from)
+    }
+
+    pub(crate) fn read_linux_pipe(
+        &self,
+        cx: &WaitContext<'_, Platform>,
+        fd: &PipeFd<Platform>,
+        buf: &mut [u8],
+    ) -> Result<usize, Errno> {
+        self.pipes.read(cx, fd, buf).map_err(Errno::from)
+    }
+
+    pub(crate) fn write_linux_pipe(
+        &self,
+        cx: &WaitContext<'_, Platform>,
+        fd: &PipeFd<Platform>,
+        buf: &[u8],
+    ) -> Result<usize, Errno> {
+        self.pipes.write(cx, fd, buf).map_err(Errno::from)
+    }
+
+    pub(crate) fn linux_pipe_status_flags(&self, fd: &PipeFd<Platform>) -> Result<OFlags, Errno> {
+        self.litebox
+            .descriptor_table()
+            .with_metadata(fd, |PipeStatusFlags(flags)| {
+                *flags & OFlags::STATUS_FLAGS_MASK
+            })
+            .map_err(metadata_to_errno)
+    }
+
+    pub(crate) fn set_linux_pipe_status_flags(
+        &self,
+        fd: &PipeFd<Platform>,
+        flags: OFlags,
+        setfl_mask: OFlags,
+    ) -> Result<(), Errno> {
+        self.pipes
+            .update_flags(
+                fd,
+                litebox::pipes::Flags::NON_BLOCKING,
+                flags.intersects(OFlags::NONBLOCK),
+            )
+            .map_err(Errno::from)?;
+
+        self.litebox
+            .descriptor_table_mut()
+            .with_metadata_mut(fd, |PipeStatusFlags(current)| {
+                let diff = (*current & setfl_mask) ^ flags;
+                current.toggle(diff);
+            })
+            .map_err(metadata_to_errno)
+    }
+
+    pub(crate) fn linux_pipe_mode_bits(&self, fd: &PipeFd<Platform>) -> Result<u32, Errno> {
+        let read_write_mode = match self.pipes.half_pipe_type(fd)? {
+            HalfPipeType::SenderHalf => Mode::WUSR,
+            HalfPipeType::ReceiverHalf => Mode::RUSR,
+        };
+        Ok(read_write_mode.bits() | InodeType::NamedPipe as u32)
+    }
+
+    pub(crate) fn with_linux_pipe_iopollable<R>(
+        &self,
+        fd: &PipeFd<Platform>,
+        f: impl FnOnce(&dyn IOPollable) -> R,
+    ) -> Result<R, Errno> {
+        self.pipes.with_iopollable(fd, f).map_err(Errno::from)
+    }
+}
+
+fn metadata_to_errno(err: MetadataError) -> Errno {
+    match err {
+        MetadataError::ClosedFd => Errno::EBADF,
+        MetadataError::NoSuchMetadata => {
+            unreachable!("Linux pipe descriptors always carry PipeStatusFlags")
+        }
+    }
+}

--- a/litebox_shim_linux/src/syscalls/pipe.rs
+++ b/litebox_shim_linux/src/syscalls/pipe.rs
@@ -122,11 +122,7 @@ impl<FS: ShimFS> GlobalState<FS> {
         setfl_mask: OFlags,
     ) -> Result<(), Errno> {
         self.pipes
-            .update_flags(
-                fd,
-                Flags::NON_BLOCKING,
-                flags.intersects(OFlags::NONBLOCK),
-            )
+            .update_flags(fd, Flags::NON_BLOCKING, flags.intersects(OFlags::NONBLOCK))
             .map_err(Errno::from)?;
 
         self.litebox

--- a/litebox_shim_linux/src/syscalls/pipe.rs
+++ b/litebox_shim_linux/src/syscalls/pipe.rs
@@ -119,6 +119,8 @@ impl<FS: ShimFS> GlobalState<FS> {
         flags: OFlags,
         setfl_mask: OFlags,
     ) -> Result<(), Errno> {
+        let flags = flags & setfl_mask;
+
         self.pipes
             .update_flags(
                 fd,
@@ -131,6 +133,9 @@ impl<FS: ShimFS> GlobalState<FS> {
             .descriptor_table_mut()
             .with_metadata_mut(fd, |PipeStatusFlags(current)| {
                 let diff = (*current & setfl_mask) ^ flags;
+                if diff.intersects(OFlags::APPEND | OFlags::DIRECT | OFlags::NOATIME) {
+                    log_unsupported!("unsupported flags");
+                }
                 current.toggle(diff);
             })
             .map_err(metadata_to_errno)

--- a/litebox_shim_linux/src/syscalls/pipe.rs
+++ b/litebox_shim_linux/src/syscalls/pipe.rs
@@ -13,7 +13,7 @@ use litebox::{
     event::{IOPollable, wait::WaitContext},
     fd::MetadataError,
     fs::{Mode, OFlags},
-    pipes::{HalfPipeType, PipeFd},
+    pipes::{Flags, HalfPipeType, PipeFd},
 };
 use litebox_common_linux::{FileDescriptorFlags, InodeType, errno::Errno};
 
@@ -29,6 +29,10 @@ const DEFAULT_PIPE_BUF_SIZE: usize = 1024 * 1024;
 #[derive(Clone)]
 pub(crate) struct PipeStatusFlags(OFlags);
 
+/// Both ends of a freshly created Linux pipe.
+///
+/// `PipeFd` does not release the pipe on `Drop`; ends must either be inserted
+/// into the fd table or explicitly released via [`GlobalState::close_linux_pipe`].
 pub(crate) struct LinuxPipeEnds {
     pub(crate) reader: PipeFd<Platform>,
     pub(crate) writer: PipeFd<Platform>,
@@ -37,8 +41,6 @@ pub(crate) struct LinuxPipeEnds {
 impl<FS: ShimFS> GlobalState<FS> {
     pub(crate) fn create_linux_pipe(&self, flags: OFlags) -> Result<LinuxPipeEnds, Errno> {
         let (pipe_flags, cloexec) = {
-            use litebox::pipes::Flags;
-
             let mut pipe_flags = Flags::empty();
             if flags.intersects((OFlags::CLOEXEC | OFlags::NONBLOCK | OFlags::DIRECT).complement())
             {
@@ -119,12 +121,10 @@ impl<FS: ShimFS> GlobalState<FS> {
         flags: OFlags,
         setfl_mask: OFlags,
     ) -> Result<(), Errno> {
-        let flags = flags & setfl_mask;
-
         self.pipes
             .update_flags(
                 fd,
-                litebox::pipes::Flags::NON_BLOCKING,
+                Flags::NON_BLOCKING,
                 flags.intersects(OFlags::NONBLOCK),
             )
             .map_err(Errno::from)?;


### PR DESCRIPTION
This PR refactors the pipe related code in the Linux shim by moving related code into the newly-created pipe.rs file.