### PR TITLE
Introduce Windows handle

### DIFF
--- a/litebox_shim_windows/src/lib.rs
+++ b/litebox_shim_windows/src/lib.rs
@@ -33,6 +33,8 @@ mod syscalls;
 const DEFAULT_PROCESS_EXIT_CODE: i32 = 1;
 
 pub(crate) type WindowsPageManager = PageManager<Platform, PAGE_SIZE>;
+pub(crate) type WindowsHandleStore =
+    litebox::sync::RwLock<Platform, litebox::fd::RawDescriptorStorage>;
 
 pub type DefaultFS = WindowsFS;
 
@@ -73,6 +75,57 @@ where
         ptr.write_at_offset(index.try_into().ok()?, value)?;
     }
     Some(())
+}
+
+#[expect(dead_code, reason = "handle helpers are staged for NT object syscalls")]
+pub(crate) fn insert_raw_handle<Subsystem: litebox::fd::FdEnabledSubsystem>(
+    litebox: &LiteBox<Platform>,
+    handles: &WindowsHandleStore,
+    typed: litebox::fd::TypedFd<Subsystem>,
+) -> Result<syscalls::Handle, NtStatus> {
+    let mut handles = handles.write();
+    let raw_fd = handles.fd_into_raw_integer(typed);
+    let Some(handle) = syscalls::Handle::from_raw_fd(raw_fd) else {
+        let typed = handles.fd_consume_raw_integer::<Subsystem>(raw_fd).ok();
+        drop(handles);
+        if let Some(typed) = typed {
+            let _ = litebox.descriptor_table_mut().remove(&typed);
+        }
+        return Err(NtStatus::QUOTA_EXCEEDED);
+    };
+    Ok(handle)
+}
+
+#[expect(dead_code, reason = "handle helpers are staged for NT object syscalls")]
+pub(crate) fn raw_handle_entry<Subsystem: litebox::fd::FdEnabledSubsystem>(
+    litebox: &LiteBox<Platform>,
+    handles: &WindowsHandleStore,
+    handle: syscalls::Handle,
+) -> Option<litebox::fd::EntryHandle<Platform, Subsystem>> {
+    let raw_fd = handle.raw_fd()?;
+    let typed = {
+        let handles = handles.read();
+        handles.fd_from_raw_integer::<Subsystem>(raw_fd).ok()
+    }?;
+    litebox.descriptor_table().entry_handle(&typed)
+}
+
+#[expect(dead_code, reason = "handle helpers are staged for NT object syscalls")]
+pub(crate) fn remove_raw_handle<Subsystem: litebox::fd::FdEnabledSubsystem>(
+    litebox: &LiteBox<Platform>,
+    handles: &WindowsHandleStore,
+    handle: syscalls::Handle,
+) {
+    let Some(raw_fd) = handle.raw_fd() else {
+        return;
+    };
+    let typed = {
+        let mut handles = handles.write();
+        handles.fd_consume_raw_integer::<Subsystem>(raw_fd).ok()
+    };
+    if let Some(typed) = typed {
+        let _ = litebox.descriptor_table_mut().remove(&typed);
+    }
 }
 
 /// Builds a Windows NT shim instance.
@@ -226,14 +279,15 @@ impl<FS: ShimFS> Task<FS> {
                 process_handle,
                 exit_status,
             } => {
-                litebox_util_log::debug!(
-                    syscall_number = ctx.orig_rax,
-                    process_handle:% = format_args!("{:#x}", process_handle),
-                    exit_status:% = format_args!("{:#x}", exit_status);
-                    "Handling NtTerminateProcess syscall"
-                );
-                self.process.exit_code.store(exit_status, Ordering::Relaxed);
-                (NtStatus::SUCCESS, ContinueOperation::Terminate)
+                if !process_handle.is_null() && !process_handle.is_current() {
+                    // TODO: allow terminating other processes
+                    litebox_util_log::error!("Terminating other processes is not yet supported");
+                    (NtStatus::INVALID_HANDLE, ContinueOperation::Resume)
+                } else {
+                    // TODO: Terminate all threads except the calling one if process_handle is zero.
+                    self.process.exit_code.store(exit_status, Ordering::Relaxed);
+                    (NtStatus::SUCCESS, ContinueOperation::Terminate)
+                }
             }
             SyscallRequest::NtAllocateVirtualMemory {
                 process_handle,
@@ -245,7 +299,7 @@ impl<FS: ShimFS> Task<FS> {
             } => {
                 // TODO: placeholder for NtAllocateVirtualMemory
                 litebox_util_log::debug!(
-                    process_handle:% = format_args!("{:#x}", process_handle),
+                    process_handle:% = format_args!("{:#x}", process_handle.as_raw()),
                     base_address:% = format_args!("{:#x}", base_address.as_usize()),
                     zero_bits:% = format_args!("{:#x}", zero_bits),
                     region_size:% = format_args!("{:#x}", region_size.as_usize()),

--- a/litebox_shim_windows/src/syscalls/mod.rs
+++ b/litebox_shim_windows/src/syscalls/mod.rs
@@ -5,17 +5,87 @@ use litebox::platform::{RawConstPointer as _, RawPointerProvider};
 use litebox::utils::TruncateExt as _;
 use litebox_common_windows::NtSysno;
 use litebox_common_windows::nt_status::NtStatus;
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 const FIRST_STACK_ARGUMENT_OFFSET: usize = 0x28;
+const HANDLE_SHIFT: u32 = 2;
+const HANDLE_TAG_MASK: usize = (1usize << HANDLE_SHIFT) - 1;
+
+#[repr(transparent)]
+#[derive(
+    Clone, Copy, Debug, Default, Eq, PartialEq, FromBytes, IntoBytes, Immutable, KnownLayout,
+)]
+pub(crate) struct Handle(usize);
+
+impl Handle {
+    #[must_use]
+    pub(crate) const fn from_raw(raw: usize) -> Self {
+        Self(raw)
+    }
+
+    #[must_use]
+    pub(crate) fn from_raw_fd(raw_fd: usize) -> Option<Self> {
+        raw_fd
+            .checked_add(1)?
+            .checked_mul(1usize << HANDLE_SHIFT)
+            .map(Self)
+    }
+
+    #[must_use]
+    pub(crate) fn raw_fd(self) -> Option<usize> {
+        if self.0 & HANDLE_TAG_MASK != 0 {
+            return None;
+        }
+        (self.0 >> HANDLE_SHIFT).checked_sub(1)
+    }
+
+    #[must_use]
+    pub(crate) const fn as_raw(self) -> usize {
+        self.0
+    }
+
+    #[must_use]
+    pub(crate) const fn is_null(self) -> bool {
+        self.as_raw() == 0
+    }
+}
+
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct ProcessHandle(Handle);
+
+impl ProcessHandle {
+    pub(crate) const CURRENT: Self = Self::from_raw(usize::MAX);
+
+    #[must_use]
+    pub(crate) const fn from_raw(raw: usize) -> Self {
+        Self(Handle::from_raw(raw))
+    }
+
+    #[must_use]
+    pub(crate) const fn as_raw(self) -> usize {
+        self.0.as_raw()
+    }
+
+    #[must_use]
+    pub(crate) const fn is_null(self) -> bool {
+        self.0.is_null()
+    }
+
+    #[must_use]
+    pub(crate) fn is_current(self) -> bool {
+        self == Self::CURRENT
+    }
+}
 
 #[derive(Debug)]
 pub(crate) enum SyscallRequest<Platform: RawPointerProvider> {
     NtTerminateProcess {
-        process_handle: usize,
+        process_handle: ProcessHandle,
         exit_status: i32,
     },
     NtAllocateVirtualMemory {
-        process_handle: usize,
+        process_handle: ProcessHandle,
         base_address: Platform::RawMutPointer<usize>,
         zero_bits: usize,
         region_size: Platform::RawMutPointer<usize>,
@@ -46,11 +116,11 @@ impl<Platform: RawPointerProvider> SyscallRequest<Platform> {
 
         match NtSysno::from_raw(pt_regs.orig_rax)? {
             NtSysno::NtTerminateProcess => Some(sys_req!(NtTerminateProcess {
-                process_handle,
+                process_handle: { ProcessHandle::from_raw },
                 exit_status,
             })),
             NtSysno::NtAllocateVirtualMemory => Some(sys_req!(NtAllocateVirtualMemory {
-                process_handle,
+                process_handle: { ProcessHandle::from_raw },
                 base_address:*,
                 zero_bits,
                 region_size:*,
@@ -180,5 +250,36 @@ impl<T: zerocopy::FromBytes, P: litebox::platform::RawConstPointer<T>>
         } else {
             Some(P::from_usize(value))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn handle_encodes_raw_fds_and_rejects_invalid_values() {
+        let first_handle = Handle::from_raw_fd(0).expect("raw fd 0 should encode");
+        assert_eq!(first_handle, Handle::from_raw(1usize << HANDLE_SHIFT));
+        assert_eq!(first_handle.raw_fd(), Some(0));
+
+        let max_raw_fd = (usize::MAX >> HANDLE_SHIFT) - 1;
+        for raw_fd in [1, 42, max_raw_fd] {
+            let handle = Handle::from_raw_fd(raw_fd).expect("raw fd should encode");
+            assert_eq!(handle.raw_fd(), Some(raw_fd));
+        }
+
+        assert_eq!(Handle::from_raw(0).raw_fd(), None);
+
+        for tag in 1..=HANDLE_TAG_MASK {
+            assert_eq!(Handle::from_raw(tag).raw_fd(), None);
+            assert_eq!(
+                Handle::from_raw((2usize << HANDLE_SHIFT) | tag).raw_fd(),
+                None
+            );
+        }
+
+        assert_eq!(Handle::from_raw_fd(usize::MAX >> HANDLE_SHIFT), None);
+        assert_eq!(Handle::from_raw_fd(usize::MAX), None);
     }
 }


### PR DESCRIPTION
Adds typed Windows handle wrappers to the Windows shim and starts routing syscall process handles through those types instead of plain `usize` values.

This PR also adds helper plumbing for converting LiteBox raw descriptors into Windows-style handles, including lookup and removal helpers that will be used by future NT object syscalls.