### PR TITLE
Add syscall mkdirat

### DIFF
--- a/litebox_common_linux/src/lib.rs
+++ b/litebox_common_linux/src/lib.rs
@@ -1987,7 +1987,8 @@ pub enum SyscallRequest<Platform: litebox::platform::RawPointerProvider> {
         pathname: Platform::RawConstPointer<i8>,
         buf: Platform::RawMutPointer<FileStat>,
     },
-    Mkdir {
+    Mkdirat {
+        dirfd: i32,
         pathname: Platform::RawConstPointer<i8>,
         mode: u32,
     },
@@ -2529,7 +2530,12 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
             Sysno::stat => sys_req!(Stat { pathname:*, buf:* }),
             Sysno::fstat => sys_req!(Fstat { fd, buf:* }),
             Sysno::lstat => sys_req!(Lstat { pathname:*, buf:* }),
-            Sysno::mkdir => sys_req!(Mkdir { pathname:*, mode }),
+            Sysno::mkdir => SyscallRequest::Mkdirat {
+                dirfd: AT_FDCWD,
+                pathname: ctx.sys_req_ptr(0),
+                mode: ctx.sys_req_arg(1),
+            },
+            Sysno::mkdirat => sys_req!(Mkdirat { dirfd, pathname:*, mode }),
             Sysno::chdir => sys_req!(Chdir { pathname:* }),
             #[cfg(target_arch = "x86_64")]
             Sysno::mmap => sys_req!(Mmap {

--- a/litebox_runner_linux_userland/tests/mkdirat.c
+++ b/litebox_runner_linux_userland/tests/mkdirat.c
@@ -1,0 +1,127 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include "helpers.h"
+
+#ifndef SYS_mkdirat
+#error SYS_mkdirat is not defined on this build host
+#endif
+
+static long raw_mkdirat(int dirfd, const char *pathname, mode_t mode) {
+    return syscall(SYS_mkdirat, dirfd, pathname, mode);
+}
+
+static void expect_mkdirat_success(int dirfd, const char *pathname, mode_t mode,
+                                   const char *msg) {
+    errno = 0;
+    long ret = raw_mkdirat(dirfd, pathname, mode);
+    if (ret != 0) {
+        FAIL(msg);
+    }
+}
+
+static void expect_mkdirat_errno(int dirfd, const char *pathname, mode_t mode,
+                                 int expected_errno, const char *msg) {
+    errno = 0;
+    long ret = raw_mkdirat(dirfd, pathname, mode);
+    if (ret != -1) {
+        fprintf(stderr, "FAIL: %s expected failure, got %ld\n", msg, ret);
+        exit(1);
+    }
+    if (errno != expected_errno) {
+        fail_errno(msg, expected_errno);
+    }
+}
+
+static void expect_directory_mode(const char *path, mode_t mode, const char *msg) {
+    struct stat st;
+
+    errno = 0;
+    EXPECT(stat(path, &st) == 0, msg);
+    EXPECT(S_ISDIR(st.st_mode), "stat should observe a directory");
+    if ((st.st_mode & 0777) != mode) {
+        fprintf(stderr, "FAIL: %s expected mode %03o, got %03o\n", msg,
+                (unsigned)mode, (unsigned)(st.st_mode & 0777));
+        exit(1);
+    }
+}
+
+static void test_at_fdcwd_relative_success(void) {
+    const char *name = "lb_mkdirat_relative";
+    const char *path = "/tmp/lb_mkdirat_relative";
+    char old_cwd[4096];
+
+    rmdir(path);
+    EXPECT(getcwd(old_cwd, sizeof(old_cwd)) != NULL, "getcwd failed");
+    EXPECT(chdir("/tmp") == 0, "chdir /tmp failed");
+
+    expect_mkdirat_success(AT_FDCWD, name, 0777,
+                           "mkdirat AT_FDCWD relative should succeed");
+    expect_directory_mode(path, 0755,
+                          "stat should observe mkdirat AT_FDCWD relative result");
+
+    EXPECT(chdir(old_cwd) == 0, "restore cwd failed");
+    EXPECT(rmdir(path) == 0, "cleanup relative directory failed");
+}
+
+static void test_absolute_path_ignores_dirfd(void) {
+    const char *path = "/tmp/lb_mkdirat_absolute";
+
+    rmdir(path);
+    expect_mkdirat_success(-2, path, 0700,
+                           "mkdirat absolute path should ignore invalid dirfd");
+    expect_directory_mode(path, 0700,
+                          "stat should observe mkdirat absolute path result");
+    EXPECT(rmdir(path) == 0, "cleanup absolute directory failed");
+}
+
+static void test_existing_path_eexist(void) {
+    const char *path = "/tmp/lb_mkdirat_existing";
+
+    rmdir(path);
+    EXPECT(mkdir(path, 0700) == 0, "setup existing directory failed");
+    expect_mkdirat_errno(AT_FDCWD, path, 0700, EEXIST,
+                         "mkdirat existing path should fail with EEXIST");
+    EXPECT(rmdir(path) == 0, "cleanup existing directory failed");
+}
+
+static void test_missing_parent_enoent(void) {
+    const char *parent = "/tmp/lb_mkdirat_missing_parent";
+    const char *path = "/tmp/lb_mkdirat_missing_parent/child";
+
+    rmdir(path);
+    rmdir(parent);
+    expect_mkdirat_errno(AT_FDCWD, path, 0700, ENOENT,
+                         "mkdirat missing parent should fail with ENOENT");
+}
+
+static void test_component_not_directory_enotdir(void) {
+    const char *file = "/tmp/lb_mkdirat_file";
+    const char *path = "/tmp/lb_mkdirat_file/child";
+
+    unlink(file);
+    create_test_file(file, 0600);
+    expect_mkdirat_errno(AT_FDCWD, path, 0700, ENOTDIR,
+                         "mkdirat through regular file should fail with ENOTDIR");
+    EXPECT(unlink(file) == 0, "cleanup regular file failed");
+}
+
+static void test_empty_path_enoent(void) {
+    expect_mkdirat_errno(AT_FDCWD, "", 0700, ENOENT,
+                         "mkdirat empty path should fail with ENOENT");
+}
+
+int main(void) {
+    mode_t old_umask = umask(0022);
+
+    printf("===== mkdirat tests =====\n");
+    test_at_fdcwd_relative_success();
+    test_absolute_path_ignores_dirfd();
+    test_existing_path_eexist();
+    test_missing_parent_enoent();
+    test_component_not_directory_enotdir();
+    test_empty_path_enoent();
+    umask(old_umask);
+    printf("All mkdirat tests passed.\n");
+    return 0;
+}

--- a/litebox_runner_linux_userland/tests/mkdirat.c
+++ b/litebox_runner_linux_userland/tests/mkdirat.c
@@ -3,6 +3,9 @@
 
 #include "helpers.h"
 
+#include <fcntl.h>
+#include <sys/stat.h>
+
 #ifndef SYS_mkdirat
 #error SYS_mkdirat is not defined on this build host
 #endif
@@ -15,35 +18,30 @@ static void expect_mkdirat_success(int dirfd, const char *pathname, mode_t mode,
                                    const char *msg) {
     errno = 0;
     long ret = raw_mkdirat(dirfd, pathname, mode);
-    if (ret != 0) {
-        FAIL(msg);
-    }
+    TEST_ASSERT(ret == 0, msg);
 }
 
 static void expect_mkdirat_errno(int dirfd, const char *pathname, mode_t mode,
                                  int expected_errno, const char *msg) {
     errno = 0;
     long ret = raw_mkdirat(dirfd, pathname, mode);
-    if (ret != -1) {
-        fprintf(stderr, "FAIL: %s expected failure, got %ld\n", msg, ret);
-        exit(1);
-    }
-    if (errno != expected_errno) {
-        fail_errno(msg, expected_errno);
-    }
+    TEST_ASSERT(ret == -1, msg);
+    TEST_ASSERT(errno == expected_errno, msg);
 }
 
 static void expect_directory_mode(const char *path, mode_t mode, const char *msg) {
     struct stat st;
 
     errno = 0;
-    EXPECT(stat(path, &st) == 0, msg);
-    EXPECT(S_ISDIR(st.st_mode), "stat should observe a directory");
-    if ((st.st_mode & 0777) != mode) {
-        fprintf(stderr, "FAIL: %s expected mode %03o, got %03o\n", msg,
-                (unsigned)mode, (unsigned)(st.st_mode & 0777));
-        exit(1);
-    }
+    TEST_ASSERT(stat(path, &st) == 0, msg);
+    TEST_ASSERT(S_ISDIR(st.st_mode), "stat should observe a directory");
+    TEST_ASSERT((st.st_mode & 0777) == mode, msg);
+}
+
+static void create_regular_file(const char *path) {
+    int fd = open(path, O_CREAT | O_WRONLY | O_TRUNC, 0600);
+    TEST_ASSERT(fd >= 0, "create test file failed");
+    TEST_ASSERT(close(fd) == 0, "close test file failed");
 }
 
 static void test_at_fdcwd_relative_success(void) {
@@ -52,16 +50,16 @@ static void test_at_fdcwd_relative_success(void) {
     char old_cwd[4096];
 
     rmdir(path);
-    EXPECT(getcwd(old_cwd, sizeof(old_cwd)) != NULL, "getcwd failed");
-    EXPECT(chdir("/tmp") == 0, "chdir /tmp failed");
+    TEST_ASSERT(getcwd(old_cwd, sizeof(old_cwd)) != NULL, "getcwd failed");
+    TEST_ASSERT(chdir("/tmp") == 0, "chdir /tmp failed");
 
     expect_mkdirat_success(AT_FDCWD, name, 0777,
                            "mkdirat AT_FDCWD relative should succeed");
     expect_directory_mode(path, 0755,
                           "stat should observe mkdirat AT_FDCWD relative result");
 
-    EXPECT(chdir(old_cwd) == 0, "restore cwd failed");
-    EXPECT(rmdir(path) == 0, "cleanup relative directory failed");
+    TEST_ASSERT(chdir(old_cwd) == 0, "restore cwd failed");
+    TEST_ASSERT(rmdir(path) == 0, "cleanup relative directory failed");
 }
 
 static void test_absolute_path_ignores_dirfd(void) {
@@ -72,17 +70,17 @@ static void test_absolute_path_ignores_dirfd(void) {
                            "mkdirat absolute path should ignore invalid dirfd");
     expect_directory_mode(path, 0700,
                           "stat should observe mkdirat absolute path result");
-    EXPECT(rmdir(path) == 0, "cleanup absolute directory failed");
+    TEST_ASSERT(rmdir(path) == 0, "cleanup absolute directory failed");
 }
 
 static void test_existing_path_eexist(void) {
     const char *path = "/tmp/lb_mkdirat_existing";
 
     rmdir(path);
-    EXPECT(mkdir(path, 0700) == 0, "setup existing directory failed");
+    TEST_ASSERT(mkdir(path, 0700) == 0, "setup existing directory failed");
     expect_mkdirat_errno(AT_FDCWD, path, 0700, EEXIST,
                          "mkdirat existing path should fail with EEXIST");
-    EXPECT(rmdir(path) == 0, "cleanup existing directory failed");
+    TEST_ASSERT(rmdir(path) == 0, "cleanup existing directory failed");
 }
 
 static void test_missing_parent_enoent(void) {
@@ -100,10 +98,10 @@ static void test_component_not_directory_enotdir(void) {
     const char *path = "/tmp/lb_mkdirat_file/child";
 
     unlink(file);
-    create_test_file(file, 0600);
+    create_regular_file(file);
     expect_mkdirat_errno(AT_FDCWD, path, 0700, ENOTDIR,
                          "mkdirat through regular file should fail with ENOTDIR");
-    EXPECT(unlink(file) == 0, "cleanup regular file failed");
+    TEST_ASSERT(unlink(file) == 0, "cleanup regular file failed");
 }
 
 static void test_empty_path_enoent(void) {

--- a/litebox_shim_linux/src/lib.rs
+++ b/litebox_shim_linux/src/lib.rs
@@ -593,9 +593,13 @@ impl<FS: ShimFS> Task<FS> {
                     .map_err(|_| Errno::EINVAL)
                     .and_then(|seekwhence| self.sys_lseek(fd, offset, seekwhence))
             }
-            SyscallRequest::Mkdir { pathname, mode } => pathname
-                .to_cstring()
-                .map_or(Err(Errno::EINVAL), |path| syscall!(sys_mkdir(path, mode))),
+            SyscallRequest::Mkdirat {
+                dirfd,
+                pathname,
+                mode,
+            } => pathname.to_cstring().map_or(Err(Errno::EFAULT), |path| {
+                syscall!(sys_mkdirat(dirfd, path, mode))
+            }),
             SyscallRequest::Chdir { pathname } => pathname
                 .to_cstring()
                 .map_or(Err(Errno::EINVAL), |path| syscall!(sys_chdir(path))),

--- a/litebox_shim_linux/src/syscalls/file.rs
+++ b/litebox_shim_linux/src/syscalls/file.rs
@@ -2907,7 +2907,7 @@ mod tests {
         )
         .unwrap();
 
-        // ── sys_mkdir: create a subdirectory via relative path ──
+        // ── create a subdirectory via relative path ──
         task.sys_mkdirat(litebox_common_linux::AT_FDCWD, "subdir", 0o777)
             .unwrap();
         task.sys_stat("/cwd_test/subdir").unwrap(); // verify via absolute

--- a/litebox_shim_linux/src/syscalls/file.rs
+++ b/litebox_shim_linux/src/syscalls/file.rs
@@ -718,15 +718,24 @@ impl<FS: ShimFS> Task<FS> {
             .flatten()
     }
 
-    /// Handle syscall `mkdir`
-    pub fn sys_mkdir(&self, pathname: impl path::Arg, mode: u32) -> Result<(), Errno> {
-        let pathname = self.resolve_path(pathname)?;
+    fn do_mkdir(&self, pathname: impl path::Arg, mode: u32) -> Result<(), Errno> {
         let mode = Mode::from_bits_retain(mode) & !self.get_umask();
         self.files
             .borrow()
             .fs
             .mkdir(pathname, mode)
             .map_err(Errno::from)
+    }
+
+    /// Handle syscall `mkdirat`
+    pub(crate) fn sys_mkdirat(
+        &self,
+        dirfd: i32,
+        pathname: impl path::Arg,
+        mode: u32,
+    ) -> Result<(), Errno> {
+        let pathname = self.resolve_path_at(dirfd, pathname)?;
+        self.do_mkdir(pathname, mode)
     }
 
     pub(crate) fn do_close(&self, raw_fd: usize) -> Result<(), Errno> {
@@ -2726,7 +2735,8 @@ mod tests {
         assert_eq!(cwd, "/");
 
         // chdir + getcwd round trip.
-        task.sys_mkdir("/test_chdir_dir", 0o777).unwrap();
+        task.sys_mkdirat(litebox_common_linux::AT_FDCWD, "/test_chdir_dir", 0o777)
+            .unwrap();
         task.sys_chdir("/test_chdir_dir").unwrap();
         let len = task.sys_getcwd(&mut buf).unwrap();
         let cwd = core::str::from_utf8(&buf[..len - 1]).unwrap();
@@ -2762,8 +2772,14 @@ mod tests {
         let task = crate::syscalls::tests::init_platform(None);
 
         // Create nested dirs: /rel_parent/rel_child
-        task.sys_mkdir("/rel_parent", 0o777).unwrap();
-        task.sys_mkdir("/rel_parent/rel_child", 0o777).unwrap();
+        task.sys_mkdirat(litebox_common_linux::AT_FDCWD, "/rel_parent", 0o777)
+            .unwrap();
+        task.sys_mkdirat(
+            litebox_common_linux::AT_FDCWD,
+            "/rel_parent/rel_child",
+            0o777,
+        )
+        .unwrap();
 
         // chdir to /rel_parent first, then relative chdir into child.
         task.sys_chdir("/rel_parent").unwrap();
@@ -2831,7 +2847,11 @@ mod tests {
                 .unwrap_err(),
             Errno::ENOENT
         );
-        assert_eq!(task.sys_mkdir("", 0o755).unwrap_err(), Errno::ENOENT);
+        assert_eq!(
+            task.sys_mkdirat(litebox_common_linux::AT_FDCWD, "", 0o755)
+                .unwrap_err(),
+            Errno::ENOENT
+        );
         assert_eq!(
             task.sys_mknodat(
                 litebox_common_linux::AT_FDCWD,
@@ -2858,7 +2878,8 @@ mod tests {
         let task = crate::syscalls::tests::init_platform(None);
 
         // Set up: mkdir + chdir into /cwd_test/.
-        task.sys_mkdir("/cwd_test", 0o777).unwrap();
+        task.sys_mkdirat(litebox_common_linux::AT_FDCWD, "/cwd_test", 0o777)
+            .unwrap();
         task.sys_chdir("/cwd_test").unwrap();
 
         // ── sys_open: create a file via relative path ──
@@ -2887,7 +2908,8 @@ mod tests {
         .unwrap();
 
         // ── sys_mkdir: create a subdirectory via relative path ──
-        task.sys_mkdir("subdir", 0o777).unwrap();
+        task.sys_mkdirat(litebox_common_linux::AT_FDCWD, "subdir", 0o777)
+            .unwrap();
         task.sys_stat("/cwd_test/subdir").unwrap(); // verify via absolute
 
         // ── sys_openat (AT_FDCWD + relative): open inside the new subdir ──

--- a/litebox_shim_linux/src/syscalls/file.rs
+++ b/litebox_shim_linux/src/syscalls/file.rs
@@ -718,8 +718,8 @@ impl<FS: ShimFS> Task<FS> {
             .flatten()
     }
 
-    fn do_mkdir(&self, pathname: impl path::Arg, mode: u32) -> Result<(), Errno> {
-        let mode = Mode::from_bits_retain(mode) & !self.get_umask();
+    fn do_mkdir(&self, pathname: impl path::Arg, mode: Mode) -> Result<(), Errno> {
+        let mode = mode & !self.get_umask();
         self.files
             .borrow()
             .fs
@@ -735,7 +735,7 @@ impl<FS: ShimFS> Task<FS> {
         mode: u32,
     ) -> Result<(), Errno> {
         let pathname = self.resolve_path_at(dirfd, pathname)?;
-        self.do_mkdir(pathname, mode)
+        self.do_mkdir(pathname, Mode::from_bits_retain(mode))
     }
 
     pub(crate) fn do_close(&self, raw_fd: usize) -> Result<(), Errno> {

--- a/litebox_shim_linux/src/syscalls/tests.rs
+++ b/litebox_shim_linux/src/syscalls/tests.rs
@@ -433,7 +433,7 @@ fn test_umask_behavior() {
     // 3. Create a directory with mode 0o777; with umask 0o077 should become 0o700.
     let dir_mode = (Mode::RWXU | Mode::RWXG | Mode::RWXO).bits();
     let test_dir = "/umask_rs_test_dir";
-    task.sys_mkdir(test_dir, dir_mode)
+    task.sys_mkdirat(litebox_common_linux::AT_FDCWD, test_dir, dir_mode)
         .expect("Failed to create test directory");
 
     let stat_dir = task
@@ -536,7 +536,7 @@ fn test_unlinkat() {
     // 2. Create a directory and attempt to unlink without AT_REMOVEDIR -> EISDIR.
     let dir_path = "/unlink_dir";
     let dir_mode = (Mode::RWXU | Mode::RWXG | Mode::RWXO).bits();
-    task.sys_mkdir(dir_path, dir_mode)
+    task.sys_mkdirat(litebox_common_linux::AT_FDCWD, dir_path, dir_mode)
         .expect("Failed to create directory");
     assert_eq!(
         task.sys_unlinkat(0, dir_path, AtFlags::empty()),
@@ -546,7 +546,7 @@ fn test_unlinkat() {
 
     // 3. Create a non-empty directory and remove with AT_REMOVEDIR -> ENOTEMPTY.
     let nonempty_dir = "/unlink_dir_nonempty";
-    task.sys_mkdir(nonempty_dir, dir_mode)
+    task.sys_mkdirat(litebox_common_linux::AT_FDCWD, nonempty_dir, dir_mode)
         .expect("Failed to create non-empty directory");
     let inner_file_fd = task
         .sys_open(
@@ -585,7 +585,7 @@ fn test_unlinkat() {
 
     // 6. Create and remove another empty directory to ensure repeatability.
     let empty_dir2 = "/unlink_empty_dir";
-    task.sys_mkdir(empty_dir2, dir_mode)
+    task.sys_mkdirat(litebox_common_linux::AT_FDCWD, empty_dir2, dir_mode)
         .expect("Failed to create second empty directory");
     task.sys_unlinkat(0, empty_dir2, AtFlags::AT_REMOVEDIR)
         .expect("Should remove second empty directory");


### PR DESCRIPTION
Add support for syscall `mkdirat` but ignore `dirfd` (i.e., fd relative path).