### PR TITLE
Add minimal AArch64 support (scaffolding)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,28 @@ jobs:
       - name: Build documentation (fail on warnings)
         run: ./.github/tools/github_actions_run_cargo doc --no-deps --all-features --document-private-items --workspace --exclude litebox_runner_lvbs --exclude litebox_runner_snp
 
+  build_and_test_arm64:
+    name: Build and Test (AArch64)
+    runs-on: ubuntu-24.04-arm
+    env:
+      RUSTFLAGS: -Dwarnings
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v6
+      - name: Set up Rust
+        run: |
+          rustup toolchain install $(awk -F'"' '/channel/{print $2}' rust-toolchain.toml) --profile minimal --no-self-update --component clippy
+      - name: Set up Nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest@${{ env.NEXTEST_VERSION }}
+      - uses: Swatinem/rust-cache@v2
+      - run: ./.github/tools/github_actions_run_cargo fmt
+      - run: |
+          ./.github/tools/github_actions_run_cargo clippy --all-targets --all-features -p litebox -p litebox_common_linux
+          ./.github/tools/github_actions_run_cargo build -p litebox -p litebox_common_linux
+          ./.github/tools/github_actions_run_cargo nextest -p litebox -p litebox_common_linux -- --skip nine_p
+
   build_and_test_lvbs:
     name: Build and Test LVBS
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
         uses: actions/checkout@v6
       - name: Set up Rust
         run: |
-          rustup toolchain install $(awk -F'"' '/channel/{print $2}' rust-toolchain.toml) --profile minimal --no-self-update --component clippy
+          rustup toolchain install $(awk -F'"' '/channel/{print $2}' rust-toolchain.toml) --profile minimal --no-self-update --component rustfmt,clippy
       - name: Set up Nextest
         uses: taiki-e/install-action@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,12 +93,15 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: nextest@${{ env.NEXTEST_VERSION }}
+      - name: Install diod
+        run: |
+          sudo apt install -y diod
       - uses: Swatinem/rust-cache@v2
       - run: ./.github/tools/github_actions_run_cargo fmt
       - run: |
           ./.github/tools/github_actions_run_cargo clippy --all-targets --all-features -p litebox -p litebox_common_linux
           ./.github/tools/github_actions_run_cargo build -p litebox -p litebox_common_linux
-          ./.github/tools/github_actions_run_cargo nextest -p litebox -p litebox_common_linux -- --skip nine_p
+          ./.github/tools/github_actions_run_cargo nextest -p litebox -p litebox_common_linux
 
   build_and_test_lvbs:
     name: Build and Test LVBS

--- a/litebox/src/fs/mod.rs
+++ b/litebox/src/fs/mod.rs
@@ -222,22 +222,34 @@ bitflags! {
         /// `O_CREAT`: if path does not exist, create it as a regular file
         const CREAT = 0x40;
         /// `O_DIRECT`: try to minimize cache effects of I/O for this file
+        #[cfg(target_arch = "x86_64")]
         const DIRECT = 0x4000;
+        #[cfg(target_arch = "aarch64")]
+        const DIRECT = 0x10000;
         /// `O_DIRECTORY`: fail if not a directory
+        #[cfg(target_arch = "x86_64")]
         const DIRECTORY = 0x10000;
+        #[cfg(target_arch = "aarch64")]
+        const DIRECTORY = 0x4000;
         /// `O_DSYNC`: write operations on the file will complete according to the requirements of
         /// synchronized I/O *data* integrity completion.
         const DSYNC = 0x1000;
         /// `O_EXCL`: exclusive use
         const EXCL = 0x80;
         /// `O_LARGEFILE`: allow large file support
+        #[cfg(target_arch = "x86_64")]
         const LARGEFILE = 0x8000;
+        #[cfg(target_arch = "aarch64")]
+        const LARGEFILE = 0x20000;
         /// `O_NOATIME`: do not update access time
         const NOATIME = 0x40000;
         /// `O_NOCTTY`: do not assign controlling terminal
         const NOCTTY = 0x100;
         /// `O_NOFOLLOW`: fail if the path does not point to a regular file
+        #[cfg(target_arch = "x86_64")]
         const NOFOLLOW = 0x20000;
+        #[cfg(target_arch = "aarch64")]
+        const NOFOLLOW = 0x8000;
         /// `O_NDELAY`: non-blocking mode (same as NONBLOCK)
         const NDELAY = 0x800;
         /// `O_NONBLOCK`: non-blocking mode (same as NDELAY)
@@ -249,7 +261,10 @@ bitflags! {
         /// integrity completion provided by `O_DSYNC`.)
         const SYNC = 0x101000;
         /// `O_TMPFILE`: create an unnamed temporary file
+        #[cfg(target_arch = "x86_64")]
         const TMPFILE = 0x410000;
+        #[cfg(target_arch = "aarch64")]
+        const TMPFILE = 0x404000;
         /// `O_TRUNC`: truncate the file to zero length
         const TRUNC = 0x200;
         /// <https://docs.rs/bitflags/*/bitflags/#externally-defined-flags>

--- a/litebox/src/mm/exception_table.rs
+++ b/litebox/src/mm/exception_table.rs
@@ -98,12 +98,12 @@ pub unsafe fn memcpy_fallible(dst: *mut u8, src: *const u8, size: usize) -> Resu
             "cmp {size}, #16",
             "b.lo 20f",
             // 16-byte chunk loop.
-            "10:",
+            "30:",
             "ldp {t1}, {t2}, [{src}], #16",
             "stp {t1}, {t2}, [{dst}], #16",
             "sub {size}, {size}, #16",
             "cmp {size}, #16",
-            "b.hs 10b",
+            "b.hs 30b",
             // Byte tail (0..15 bytes remaining).
             "20:",
             "cbz {size}, 3f",

--- a/litebox/src/mm/exception_table.rs
+++ b/litebox/src/mm/exception_table.rs
@@ -83,10 +83,50 @@ pub unsafe fn memcpy_fallible(dst: *mut u8, src: *const u8, size: usize) -> Resu
             fault = label { return Err(Fault) }
         }
     }
+    #[cfg(target_arch = "aarch64")]
+    unsafe {
+        // Bulk-copy 16 bytes at a time via ldp/stp, then a byte tail for the
+        // remaining 0..15 bytes. aarch64 permits unaligned access on normal
+        // memory, so no alignment prologue is needed.
+        //
+        // Every faulting load/store must be covered by the [2:, 3:) exception
+        // table range; non-memory instructions (cmp/sub/branch) within the
+        // range never fault. On fault, the partially-copied destination is
+        // observable to the caller, matching the x86_64 `rep movsb` behavior.
+        core::arch::asm! {
+            "2:",
+            "cmp {size}, #16",
+            "b.lo 20f",
+            // 16-byte chunk loop.
+            "10:",
+            "ldp {t1}, {t2}, [{src}], #16",
+            "stp {t1}, {t2}, [{dst}], #16",
+            "sub {size}, {size}, #16",
+            "cmp {size}, #16",
+            "b.hs 10b",
+            // Byte tail (0..15 bytes remaining).
+            "20:",
+            "cbz {size}, 3f",
+            "21:",
+            "ldrb {t1:w}, [{src}], #1",
+            "strb {t1:w}, [{dst}], #1",
+            "subs {size}, {size}, #1",
+            "b.ne 21b",
+            "3:",
+            ex_table_entry!("2b", "3b", "{fault}"),
+            dst = inout(reg) dst => _,
+            src = inout(reg) src => _,
+            size = inout(reg) size => _,
+            t1 = out(reg) _,
+            t2 = out(reg) _,
+            fault = label { return Err(Fault) }
+        }
+    }
 
     Ok(())
 }
 
+#[cfg(target_arch = "x86_64")]
 macro_rules! read_fn {
     ($name:ident, $ty:ty, $mov_instr:expr) => {
         /// Reads a value from the given `src` pointer in a fallible manner.
@@ -121,12 +161,57 @@ macro_rules! read_fn {
     };
 }
 
+#[cfg(target_arch = "x86_64")]
 read_fn!(read_u8_fallible, u8, "movzx {dest:e}, byte ptr [{src}]");
+#[cfg(target_arch = "x86_64")]
 read_fn!(read_u16_fallible, u16, "movzx {dest:e}, word ptr [{src}]");
+#[cfg(target_arch = "x86_64")]
 read_fn!(read_u32_fallible, u32, "mov {dest:e}, dword ptr [{src}]");
-#[cfg(target_pointer_width = "64")]
+#[cfg(target_arch = "x86_64")]
 read_fn!(read_u64_fallible, u64, "mov {dest:r}, qword ptr [{src}]");
 
+#[cfg(target_arch = "aarch64")]
+macro_rules! read_fn {
+    ($name:ident, $ty:ty, $load_instr:expr) => {
+        /// Reads a value from the given `src` pointer in a fallible manner.
+        ///
+        /// # Safety
+        /// `src` must be valid for reads or a pointer that's guaranteed to be
+        /// in non-Rust memory.
+        pub unsafe fn $name(src: *const $ty) -> Result<$ty, Fault> {
+            let value: usize;
+            let failed: u32;
+            unsafe {
+                core::arch::asm! {
+                    "2:",
+                    $load_instr,
+                    "mov {failed:w}, wzr",
+                    "3:",
+                    ex_table_entry!("2b", "3b", "3b"),
+                    src = in(reg) src,
+                    dest = out(reg) value,
+                    failed = inout(reg) 1u32 => failed,
+                }
+            }
+            if failed == 0 {
+                Ok((value as u64).trunc())
+            } else {
+                Err(Fault)
+            }
+        }
+    };
+}
+
+#[cfg(target_arch = "aarch64")]
+read_fn!(read_u8_fallible, u8, "ldrb {dest:w}, [{src}]");
+#[cfg(target_arch = "aarch64")]
+read_fn!(read_u16_fallible, u16, "ldrh {dest:w}, [{src}]");
+#[cfg(target_arch = "aarch64")]
+read_fn!(read_u32_fallible, u32, "ldr {dest:w}, [{src}]");
+#[cfg(target_arch = "aarch64")]
+read_fn!(read_u64_fallible, u64, "ldr {dest}, [{src}]");
+
+#[cfg(target_arch = "x86_64")]
 macro_rules! write_fn {
     ($name:ident, $ty:ty, $mov_instr:expr) => {
         /// Writes a value to the given `dest` pointer in a fallible manner.
@@ -155,10 +240,56 @@ macro_rules! write_fn {
 
 #[cfg(target_arch = "x86_64")]
 write_fn!(write_u8_fallible, u8, "mov byte ptr [{dest}], {src:l}");
+#[cfg(target_arch = "x86_64")]
 write_fn!(write_u16_fallible, u16, "mov word ptr [{dest}], {src:x}");
+#[cfg(target_arch = "x86_64")]
 write_fn!(write_u32_fallible, u32, "mov dword ptr [{dest}], {src:e}");
-#[cfg(target_pointer_width = "64")]
+#[cfg(target_arch = "x86_64")]
 write_fn!(write_u64_fallible, u64, "mov qword ptr [{dest}], {src:r}");
+
+#[cfg(target_arch = "aarch64")]
+macro_rules! write_fn {
+    ($name:ident, $ty:ty, $store_instr:expr, $convert:expr) => {
+        /// Writes a value to the given `dest` pointer in a fallible manner.
+        ///
+        /// # Safety
+        /// `dest` must be valid for writes or a pointer that's guaranteed to be
+        /// in non-Rust memory.
+        pub unsafe fn $name(dest: *mut $ty, value: $ty) -> Result<(), Fault> {
+            unsafe {
+                core::arch::asm! {
+                    "2:",
+                    $store_instr,
+                    "3:",
+                    ex_table_entry!("2b", "3b", "{fault}"),
+                    src = in(reg) $convert(value),
+                    dest = in(reg) dest,
+                    fault = label { return Err(Fault) }
+                }
+            }
+            Ok(())
+        }
+    };
+}
+
+#[cfg(target_arch = "aarch64")]
+write_fn!(write_u8_fallible, u8, "strb {src:w}, [{dest}]", u32::from);
+#[cfg(target_arch = "aarch64")]
+write_fn!(write_u16_fallible, u16, "strh {src:w}, [{dest}]", u32::from);
+#[cfg(target_arch = "aarch64")]
+write_fn!(
+    write_u32_fallible,
+    u32,
+    "str {src:w}, [{dest}]",
+    core::convert::identity
+);
+#[cfg(target_arch = "aarch64")]
+write_fn!(
+    write_u64_fallible,
+    u64,
+    "str {src}, [{dest}]",
+    core::convert::identity
+);
 
 /// Exception table entry with relative offsets
 #[repr(C)]

--- a/litebox/src/mm/tests.rs
+++ b/litebox/src/mm/tests.rs
@@ -34,6 +34,8 @@ impl crate::platform::PageManagementProvider<PAGE_SIZE> for DummyVmemBackend {
     const TASK_ADDR_MIN: usize = 0x1_0000; // default linux config
     #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
     const TASK_ADDR_MAX: usize = 0x7FFF_FFFF_F000; // (1 << 47) - PAGE_SIZE;
+    #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+    const TASK_ADDR_MAX: usize = 0xFFFF_FFFF_F000; // 48-bit VA space
 
     fn allocate_pages(
         &self,

--- a/litebox/src/platform/arch.rs
+++ b/litebox/src/platform/arch.rs
@@ -3,13 +3,12 @@
 
 //! Architecture-specific platform interfaces.
 //!
-//! As it currently stands, the interfaces here are only considered for x86-64, in the future other
+//! As it currently stands, the interfaces here are mostly considered for x86-64, in the future other
 //! architectures might be supported.
 
 use thiserror::Error;
 
 /// A provider of architecture-specific functionality.
-#[cfg(target_arch = "x86_64")]
 pub trait ArchSpecificProvider {
     /// Get the architecture-specific `reg`, for the current guest context.
     ///
@@ -44,6 +43,11 @@ pub enum ArchSpecificRegister {
     FsBase,
     GsBase,
 }
+
+/// Architecture-specific registers for AArch64.
+#[cfg(target_arch = "aarch64")]
+#[non_exhaustive]
+pub enum ArchSpecificRegister {}
 
 /// Errors that can be produced by a [`ArchSpecificProvider`] operation.
 #[non_exhaustive]

--- a/litebox/src/platform/arch.rs
+++ b/litebox/src/platform/arch.rs
@@ -3,8 +3,8 @@
 
 //! Architecture-specific platform interfaces.
 //!
-//! As it currently stands, the interfaces here are mostly considered for x86-64, in the future other
-//! architectures might be supported.
+//! As it currently stands, the interfaces here are only considered for x86-64 and aarch64, in
+//! the future other architectures might be supported.
 
 use thiserror::Error;
 
@@ -48,9 +48,7 @@ pub enum ArchSpecificRegister {
 /// Architecture-specific registers for AArch64.
 #[cfg(target_arch = "aarch64")]
 #[non_exhaustive]
-pub enum ArchSpecificRegister {
-    TpidrEl0,
-}
+pub enum ArchSpecificRegister {}
 
 /// Errors that can be produced by a [`ArchSpecificProvider`] operation.
 #[non_exhaustive]

--- a/litebox/src/platform/arch.rs
+++ b/litebox/src/platform/arch.rs
@@ -9,6 +9,7 @@
 use thiserror::Error;
 
 /// A provider of architecture-specific functionality.
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 pub trait ArchSpecificProvider {
     /// Get the architecture-specific `reg`, for the current guest context.
     ///
@@ -47,7 +48,9 @@ pub enum ArchSpecificRegister {
 /// Architecture-specific registers for AArch64.
 #[cfg(target_arch = "aarch64")]
 #[non_exhaustive]
-pub enum ArchSpecificRegister {}
+pub enum ArchSpecificRegister {
+    TpidrEl0,
+}
 
 /// Errors that can be produced by a [`ArchSpecificProvider`] operation.
 #[non_exhaustive]

--- a/litebox/src/platform/mod.rs
+++ b/litebox/src/platform/mod.rs
@@ -376,6 +376,9 @@ where
         // safe (it probably is fine, but the following sequence of steps ensures we are
         // staying in a very safe subset).
         let bytes: *mut [c_char] = Box::into_raw(bytes);
+        // SAFETY: c_char and u8 have the same size and alignment. The cast is a no-op on
+        // targets where c_char is u8 (e.g. aarch64), hence the `unnecessary_cast` allow.
+        #[allow(clippy::unnecessary_cast)]
         let bytes: *mut [u8] = bytes as *mut [u8];
         let bytes: Box<[u8]> = unsafe { Box::from_raw(bytes) };
         let bytes: Vec<u8> = Vec::from(bytes);

--- a/litebox/src/shim.rs
+++ b/litebox/src/shim.rs
@@ -114,6 +114,20 @@ pub struct ExceptionInfo {
     pub kernel_mode: bool,
 }
 
+/// Information about a hardware exception on aarch64.
+#[cfg(target_arch = "aarch64")]
+#[derive(Copy, Clone, Debug)]
+pub struct ExceptionInfo {
+    /// The aarch64 exception class from ESR_EL1[31:26].
+    pub exception: Exception,
+    /// The fault address (FAR_EL1).
+    pub fault_address: usize,
+    /// The exception syndrome register value (ESR_EL1).
+    pub esr: u64,
+    /// Whether the exception occurred in kernel mode.
+    pub kernel_mode: bool,
+}
+
 /// An x86 exception type.
 #[cfg(target_arch = "x86_64")]
 #[repr(transparent)]
@@ -132,4 +146,28 @@ impl Exception {
     pub const GENERAL_PROTECTION_FAULT: Self = Self(13);
     /// #PF
     pub const PAGE_FAULT: Self = Self(14);
+}
+
+/// An aarch64 exception class from ESR_EL1[31:26].
+#[cfg(target_arch = "aarch64")]
+#[repr(transparent)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct Exception(pub u8);
+
+#[cfg(target_arch = "aarch64")]
+impl Exception {
+    /// Breakpoint exception from a lower exception level.
+    pub const BREAKPOINT_LOWER_EL: Self = Self(0x30);
+    /// Breakpoint exception taken without a change in exception level.
+    pub const BREAKPOINT_CURRENT_EL: Self = Self(0x31);
+    /// BRK instruction trap from AArch64 state.
+    pub const BRK64: Self = Self(0x3c);
+    /// Instruction abort taken without a change in exception level.
+    pub const INSTRUCTION_ABORT_CURRENT_EL: Self = Self(0x21);
+    /// Instruction abort taken from a lower exception level.
+    pub const INSTRUCTION_ABORT_LOWER_EL: Self = Self(0x20);
+    /// Data abort taken without a change in exception level.
+    pub const DATA_ABORT_CURRENT_EL: Self = Self(0x25);
+    /// Data abort taken from a lower exception level.
+    pub const DATA_ABORT_LOWER_EL: Self = Self(0x24);
 }

--- a/litebox_common_linux/src/lib.rs
+++ b/litebox_common_linux/src/lib.rs
@@ -3221,6 +3221,22 @@ pub mod arch {
         | EFLAGS_ID;
 }
 
+#[cfg(target_arch = "aarch64")]
+pub mod arch {
+    // User returns must not target the null-guard region.
+    pub const USER_ADDR_MIN: usize = 0x0000_0000_0001_0000;
+    // Exclusive upper bound; keep the final low-userspace page reserved as a guard page.
+    pub const USER_ADDR_END: usize = 0x0000_ffff_ffff_f000;
+    /// PSTATE condition flags (N, Z, C, V) — guest-controllable arithmetic state.
+    pub const PSR_NZCV_MASK: u64 = 0b1111 << 28;
+    /// Speculative Store Bypass Safe bit — a benign, user-settable mitigation bit.
+    pub const PSR_SSBS_BIT: u64 = 1 << 12;
+    /// Data Independent Timing bit — a benign, user-settable mitigation bit.
+    pub const PSR_DIT_BIT: u64 = 1 << 24;
+    /// PSTATE bits a guest may keep when returning to EL0.
+    pub const SAFE_USER_PSTATE: u64 = PSR_NZCV_MASK | PSR_SSBS_BIT | PSR_DIT_BIT;
+}
+
 impl PtRegs {
     /// Returns whether `rip` and `rsp` are in the x86_64 Linux user address range.
     #[cfg(target_arch = "x86_64")]
@@ -3245,6 +3261,31 @@ impl PtRegs {
         self.eflags = (self.eflags & arch::SAFE_USER_EFLAGS) | arch::EFLAGS_FIXED | arch::EFLAGS_IF;
         self.cs = arch::USER_CS;
         self.ss = arch::USER_DS;
+        true
+    }
+
+    /// Returns whether `pc` and `sp` are in the aarch64 Linux user address range.
+    #[cfg(target_arch = "aarch64")]
+    #[must_use]
+    pub fn has_user_return_addresses(&self) -> bool {
+        (arch::USER_ADDR_MIN..arch::USER_ADDR_END).contains(&self.pc)
+            && (arch::USER_ADDR_MIN..arch::USER_ADDR_END).contains(&self.sp)
+    }
+
+    /// Sanitizes CPU state and normalizes the context to the aarch64 Linux user ABI.
+    ///
+    /// Returns `false` if `pc` or `sp` are outside the aarch64 Linux user address
+    /// range. On success, `pstate` is coerced to a clean AArch64 EL0t state: the
+    /// guest keeps only the condition flags and benign mitigation bits. Every
+    /// other bit is cleared, forcing EL0t, AArch64 execution state, unmasked
+    /// exceptions, and no illegal-state or single-step.
+    #[cfg(target_arch = "aarch64")]
+    #[must_use]
+    pub fn sanitize_for_user_return(&mut self) -> bool {
+        if !self.has_user_return_addresses() {
+            return false;
+        }
+        self.pstate &= arch::SAFE_USER_PSTATE;
         true
     }
 

--- a/litebox_common_linux/src/lib.rs
+++ b/litebox_common_linux/src/lib.rs
@@ -32,56 +32,6 @@ extern crate alloc;
 #[cfg(target_arch = "aarch64")]
 pub const AARCH64_GENERAL_REGISTER_COUNT: usize = 31;
 
-/// AArch64 PSTATE/SPSR value saved by Linux in `user_pt_regs`.
-#[cfg(target_arch = "aarch64")]
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
-#[repr(transparent)]
-pub struct Aarch64Pstate(usize);
-
-#[cfg(target_arch = "aarch64")]
-bitflags::bitflags! {
-    impl Aarch64Pstate: usize {
-        /// Current exception level and stack pointer selector.
-        const MODE_MASK = 0xf;
-        /// EL0 using SP_EL0.
-        const MODE_EL0T = 0x0;
-        /// EL1 using SP_EL0.
-        const MODE_EL1T = 0x4;
-        /// EL1 using SP_EL1.
-        const MODE_EL1H = 0x5;
-        /// FIQ mask bit.
-        const F = 0x40;
-        /// IRQ mask bit.
-        const I = 0x80;
-        /// SError mask bit.
-        const A = 0x100;
-        /// Debug exception mask bit.
-        const D = 0x200;
-        /// Branch target identification state mask.
-        const BTYPE_MASK = 0xc00;
-        /// Speculative store bypass safe bit.
-        const SSBS = 0x1000;
-        /// Privileged access never bit.
-        const PAN = 0x400000;
-        /// User access override bit.
-        const UAO = 0x800000;
-        /// Data independent timing bit.
-        const DIT = 0x1000000;
-        /// Tag check override bit.
-        const TCO = 0x2000000;
-        /// Overflow condition flag.
-        const V = 0x10000000;
-        /// Carry condition flag.
-        const C = 0x20000000;
-        /// Zero condition flag.
-        const Z = 0x40000000;
-        /// Negative condition flag.
-        const N = 0x80000000;
-
-        const _ = !0;
-    }
-}
-
 // TODO(jayb): Should errno::Errno be publicly re-exported?
 
 pub const STDIN_FILENO: i32 = 0;
@@ -3219,7 +3169,7 @@ pub struct PtRegs {
 ///
 /// pt_regs from [Linux](https://elixir.bootlin.com/linux/v5.19.17/source/arch/arm64/include/asm/ptrace.h#L178)
 #[cfg(target_arch = "aarch64")]
-#[repr(C)]
+#[repr(C, align(16))]
 #[derive(Clone, Debug, Default)]
 pub struct PtRegs {
     /// General-purpose registers x0-x30.
@@ -3229,7 +3179,14 @@ pub struct PtRegs {
     /// Program counter.
     pub pc: usize,
     /// Saved processor state (PSTATE/SPSR).
-    pub pstate: Aarch64Pstate,
+    pub pstate: u64,
+
+    pub orig_x0: usize,
+
+    // little endian
+    pub syscallno: i32,
+    pub unused2: u32,
+    /* add remaining fields if needed */
 }
 
 #[cfg(target_arch = "x86_64")]

--- a/litebox_common_linux/src/lib.rs
+++ b/litebox_common_linux/src/lib.rs
@@ -6,6 +6,7 @@
 #![no_std]
 #![allow(non_camel_case_types)]
 
+use core::ffi::c_char;
 use core::time::Duration;
 use int_enum::IntEnum;
 use litebox::{
@@ -25,6 +26,61 @@ pub mod signal;
 pub mod vmap;
 
 extern crate alloc;
+
+/// Number of AArch64 general-purpose registers saved by the Linux user ABI
+/// (`x0` through `x30`).
+#[cfg(target_arch = "aarch64")]
+pub const AARCH64_GENERAL_REGISTER_COUNT: usize = 31;
+
+/// AArch64 PSTATE/SPSR value saved by Linux in `user_pt_regs`.
+#[cfg(target_arch = "aarch64")]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct Aarch64Pstate(usize);
+
+#[cfg(target_arch = "aarch64")]
+bitflags::bitflags! {
+    impl Aarch64Pstate: usize {
+        /// Current exception level and stack pointer selector.
+        const MODE_MASK = 0xf;
+        /// EL0 using SP_EL0.
+        const MODE_EL0T = 0x0;
+        /// EL1 using SP_EL0.
+        const MODE_EL1T = 0x4;
+        /// EL1 using SP_EL1.
+        const MODE_EL1H = 0x5;
+        /// FIQ mask bit.
+        const F = 0x40;
+        /// IRQ mask bit.
+        const I = 0x80;
+        /// SError mask bit.
+        const A = 0x100;
+        /// Debug exception mask bit.
+        const D = 0x200;
+        /// Branch target identification state mask.
+        const BTYPE_MASK = 0xc00;
+        /// Speculative store bypass safe bit.
+        const SSBS = 0x1000;
+        /// Privileged access never bit.
+        const PAN = 0x400000;
+        /// User access override bit.
+        const UAO = 0x800000;
+        /// Data independent timing bit.
+        const DIT = 0x1000000;
+        /// Tag check override bit.
+        const TCO = 0x2000000;
+        /// Overflow condition flag.
+        const V = 0x10000000;
+        /// Carry condition flag.
+        const C = 0x20000000;
+        /// Zero condition flag.
+        const Z = 0x40000000;
+        /// Negative condition flag.
+        const N = 0x80000000;
+
+        const _ = !0;
+    }
+}
 
 // TODO(jayb): Should errno::Errno be publicly re-exported?
 
@@ -306,6 +362,36 @@ pub struct FileStat {
     pub __unused: [i64; 3],
 }
 
+/// Linux's `stat` struct for aarch64.
+/// Uses the generic `struct stat` layout from <asm-generic/stat.h>.
+#[cfg(target_arch = "aarch64")]
+#[repr(C)]
+#[derive(Clone, Default, PartialEq, Debug, FromBytes, IntoBytes)]
+pub struct FileStat {
+    pub st_dev: u64,
+    pub st_ino: u64,
+    pub st_mode: u32,
+    pub st_nlink: u32,
+    pub st_uid: u32,
+    pub st_gid: u32,
+    pub st_rdev: u64,
+    #[expect(clippy::pub_underscore_fields)]
+    pub __pad1: u64,
+    pub st_size: i64,
+    pub st_blksize: i32,
+    #[expect(clippy::pub_underscore_fields)]
+    pub __pad2: i32,
+    pub st_blocks: i64,
+    pub st_atime: i64,
+    pub st_atime_nsec: i64,
+    pub st_mtime: i64,
+    pub st_mtime_nsec: i64,
+    pub st_ctime: i64,
+    pub st_ctime_nsec: i64,
+    #[expect(clippy::pub_underscore_fields)]
+    pub __unused: [u32; 2],
+}
+
 /// Linux's `iovec` struct for `writev`
 #[derive(FromBytes, IntoBytes)]
 #[repr(C, packed)]
@@ -363,9 +449,17 @@ impl From<litebox::fs::FileStatus> for FileStat {
             st_rdev: rdev
                 .map(|r| <_>::try_from(r.get()).unwrap())
                 .unwrap_or_default(),
+            #[cfg(target_arch = "x86_64")]
             #[allow(clippy::cast_possible_wrap)]
             st_size: size,
+            #[cfg(target_arch = "aarch64")]
+            #[allow(clippy::cast_possible_wrap)]
+            st_size: size as i64,
+            #[cfg(target_arch = "x86_64")]
             st_blksize: blksize,
+            #[cfg(target_arch = "aarch64")]
+            #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+            st_blksize: blksize as i32,
             st_blocks: 0,
             ..Default::default()
         }
@@ -518,13 +612,19 @@ impl From<FileStat> for Statx {
     fn from(value: FileStat) -> Self {
         Self {
             stx_mask: StatxMask::STATX_BASIC_STATS.bits(),
+            #[cfg(target_arch = "x86_64")]
             stx_blksize: value.st_blksize.trunc(),
+            #[cfg(target_arch = "aarch64")]
+            stx_blksize: value.st_blksize.reinterpret_as_unsigned(),
             stx_nlink: value.st_nlink.trunc(),
             stx_uid: value.st_uid,
             stx_gid: value.st_gid,
             stx_mode: value.st_mode.trunc(),
             stx_ino: value.st_ino,
+            #[cfg(target_arch = "x86_64")]
             stx_size: value.st_size as u64,
+            #[cfg(target_arch = "aarch64")]
+            stx_size: value.st_size.reinterpret_as_unsigned(),
             stx_blocks: value.st_blocks.reinterpret_as_unsigned(),
             stx_atime: statx_timestamp(value.st_atime, value.st_atime_nsec),
             stx_ctime: statx_timestamp(value.st_ctime, value.st_ctime_nsec),
@@ -852,7 +952,7 @@ pub struct Ucred {
 // `suseconds_t` is i64 on riscv32:
 // https://github.com/rust-lang/libc/blob/151c3a971e423c76e7acb54aa2d21a6e2706c4e6/src/unix/linux_like/linux/gnu/b32/mod.rs#L22
 cfg_if::cfg_if! {
-    if #[cfg(target_arch = "x86_64")] {
+    if #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))] {
         pub type time_t = i64;
         pub type suseconds_t = u64;
     } else {
@@ -1944,7 +2044,7 @@ pub enum SyscallRequest<Platform: litebox::platform::RawPointerProvider> {
         fd: i32,
     },
     Stat {
-        pathname: Platform::RawConstPointer<i8>,
+        pathname: Platform::RawConstPointer<c_char>,
         buf: Platform::RawMutPointer<FileStat>,
     },
     Fstat {
@@ -1952,16 +2052,19 @@ pub enum SyscallRequest<Platform: litebox::platform::RawPointerProvider> {
         buf: Platform::RawMutPointer<FileStat>,
     },
     Lstat {
-        pathname: Platform::RawConstPointer<i8>,
+        pathname: Platform::RawConstPointer<c_char>,
         buf: Platform::RawMutPointer<FileStat>,
     },
     Mkdirat {
         dirfd: i32,
-        pathname: Platform::RawConstPointer<i8>,
+        pathname: Platform::RawConstPointer<c_char>,
+    },
+    Mkdir {
+        pathname: Platform::RawConstPointer<c_char>,
         mode: u32,
     },
     Chdir {
-        pathname: Platform::RawConstPointer<i8>,
+        pathname: Platform::RawConstPointer<c_char>,
     },
     Mmap {
         addr: usize,
@@ -2068,7 +2171,7 @@ pub enum SyscallRequest<Platform: litebox::platform::RawPointerProvider> {
     },
     Faccessat {
         dirfd: i32,
-        pathname: Platform::RawConstPointer<i8>,
+        pathname: Platform::RawConstPointer<c_char>,
         mode: AccessFlags,
         flags: AtFlags,
     },
@@ -2228,19 +2331,19 @@ pub enum SyscallRequest<Platform: litebox::platform::RawPointerProvider> {
         arg: ArchPrctlArg<Platform>,
     },
     Readlink {
-        pathname: Platform::RawConstPointer<i8>,
+        pathname: Platform::RawConstPointer<c_char>,
         buf: Platform::RawMutPointer<u8>,
         bufsiz: usize,
     },
     Readlinkat {
         dirfd: i32,
-        pathname: Platform::RawConstPointer<i8>,
+        pathname: Platform::RawConstPointer<c_char>,
         buf: Platform::RawMutPointer<u8>,
         bufsiz: usize,
     },
     Openat {
         dirfd: i32,
-        pathname: Platform::RawConstPointer<i8>,
+        pathname: Platform::RawConstPointer<c_char>,
         flags: litebox::fs::OFlags,
         mode: litebox::fs::Mode,
     },
@@ -2250,19 +2353,19 @@ pub enum SyscallRequest<Platform: litebox::platform::RawPointerProvider> {
     },
     Mknodat {
         dirfd: i32,
-        pathname: Platform::RawConstPointer<i8>,
+        pathname: Platform::RawConstPointer<c_char>,
         mode_and_type: u32,
         dev: u32,
     },
     Unlinkat {
         dirfd: i32,
-        pathname: Platform::RawConstPointer<i8>,
+        pathname: Platform::RawConstPointer<c_char>,
         flags: AtFlags,
     },
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     Newfstatat {
         dirfd: i32,
-        pathname: Platform::RawConstPointer<i8>,
+        pathname: Platform::RawConstPointer<c_char>,
         buf: Platform::RawMutPointer<FileStat>,
         flags: AtFlags,
     },
@@ -2370,9 +2473,9 @@ pub enum SyscallRequest<Platform: litebox::platform::RawPointerProvider> {
         args: FutexArgs<Platform>,
     },
     Execve {
-        pathname: Platform::RawConstPointer<i8>,
-        argv: Platform::RawConstPointer<Platform::RawConstPointer<i8>>,
-        envp: Platform::RawConstPointer<Platform::RawConstPointer<i8>>,
+        pathname: Platform::RawConstPointer<c_char>,
+        argv: Platform::RawConstPointer<Platform::RawConstPointer<c_char>>,
+        envp: Platform::RawConstPointer<Platform::RawConstPointer<c_char>>,
     },
     Umask {
         mask: u32,
@@ -2395,7 +2498,7 @@ pub enum SyscallRequest<Platform: litebox::platform::RawPointerProvider> {
     },
     Statx {
         dirfd: i32,
-        pathname: Option<Platform::RawConstPointer<i8>>,
+        pathname: Option<Platform::RawConstPointer<c_char>>,
         flags: AtFlags,
         mask: StatxMask,
         statxbuf: Platform::RawMutPointer<Statx>,
@@ -2495,8 +2598,10 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
             Sysno::write => sys_req!(Write { fd, buf:*, count }),
             Sysno::close => sys_req!(Close { fd }),
             Sysno::lseek => sys_req!(Lseek { fd, offset, whence }),
+            #[cfg(not(target_arch = "aarch64"))]
             Sysno::stat => sys_req!(Stat { pathname:*, buf:* }),
             Sysno::fstat => sys_req!(Fstat { fd, buf:* }),
+            #[cfg(not(target_arch = "aarch64"))]
             Sysno::lstat => sys_req!(Lstat { pathname:*, buf:* }),
             Sysno::mkdir => SyscallRequest::Mkdirat {
                 dirfd: AT_FDCWD,
@@ -2504,8 +2609,9 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
                 mode: ctx.sys_req_arg(1),
             },
             Sysno::mkdirat => sys_req!(Mkdirat { dirfd, pathname:*, mode }),
+            #[cfg(not(target_arch = "aarch64"))]
+            Sysno::mkdir => sys_req!(Mkdir { pathname:*, mode }),
             Sysno::chdir => sys_req!(Chdir { pathname:* }),
-            #[cfg(target_arch = "x86_64")]
             Sysno::mmap => sys_req!(Mmap {
                 addr,
                 length,
@@ -2553,14 +2659,12 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
                     }
                 },
             },
-            #[cfg(target_arch = "x86_64")]
             Sysno::pread64 => sys_req!(Pread64 {
                 fd,
                 buf:*,
                 count,
                 offset
             }),
-            #[cfg(target_arch = "x86_64")]
             Sysno::pwrite64 => sys_req!(Pwrite64 {
                 fd,
                 buf:*,
@@ -2572,6 +2676,7 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
             Sysno::writev => sys_req!(Writev { fd, iovec:*, iovcnt }),
             Sysno::preadv => sys_req!(Preadv { fd, iovec:*, iovcnt, pos_l, pos_h }),
             Sysno::pwritev => sys_req!(Pwritev { fd, iovec:*, iovcnt, pos_l, pos_h }),
+            #[cfg(not(target_arch = "aarch64"))]
             Sysno::access => SyscallRequest::Faccessat {
                 dirfd: AT_FDCWD,
                 pathname: ctx.sys_req_ptr(0),
@@ -2585,6 +2690,7 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
                 flags: AtFlags::empty(),
             },
             Sysno::faccessat2 => sys_req!(Faccessat { dirfd, pathname:*, mode, flags }),
+            #[cfg(not(target_arch = "aarch64"))]
             Sysno::pipe => sys_req!(Pipe2 { pipefd:*, flags: { litebox::fs::OFlags::empty() } }),
             Sysno::pipe2 => sys_req!(Pipe2 { pipefd:* ,flags }),
             Sysno::madvise => sys_req!(Madvise { addr:*, length, behavior:? }),
@@ -2593,6 +2699,7 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
                 newfd: None,
                 flags: None,
             },
+            #[cfg(not(target_arch = "aarch64"))]
             Sysno::dup2 => SyscallRequest::Dup {
                 oldfd: ctx.sys_req_arg(0),
                 newfd: Some(ctx.sys_req_arg(1)),
@@ -2615,7 +2722,6 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
                 sockvec: *,
             }),
             Sysno::connect => sys_req!(Connect { sockfd, sockaddr:*, addrlen }),
-            #[cfg(target_arch = "x86_64")]
             Sysno::accept => sys_req!(Accept {
                 sockfd,
                 addr:*,
@@ -2688,11 +2794,12 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
                 clockid: { ClockId::Monotonic.into() },
                 flags: { TimerFlags::empty() },
             }),
+            #[cfg(not(target_arch = "aarch64"))]
             Sysno::time => sys_req!(Time { tloc:* }),
             Sysno::getcwd => sys_req!(Getcwd { buf:*, size }),
+            #[cfg(not(target_arch = "aarch64"))]
             Sysno::readlink => sys_req!(Readlink { pathname:*, buf:* ,bufsiz }),
             Sysno::readlinkat => sys_req!(Readlinkat { dirfd, pathname:*, buf:*, bufsiz }),
-            #[cfg(target_arch = "x86_64")]
             Sysno::getrlimit => sys_req!(Getrlimit { resource:?, rlim:* }),
             Sysno::setrlimit => sys_req!(Setrlimit { resource:?, rlim:* }),
             Sysno::prlimit64 => sys_req!(Prlimit { pid, resource:?, new_limit:*, old_limit:* }),
@@ -2703,12 +2810,14 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
             Sysno::geteuid => SyscallRequest::Geteuid,
             Sysno::getegid => SyscallRequest::Getegid,
             Sysno::epoll_ctl => sys_req!(EpollCtl { epfd, op:?, fd, event:* }),
+            #[cfg(not(target_arch = "aarch64"))]
             Sysno::epoll_wait => {
                 sys_req!(EpollPwait { epfd, events:*, maxevents, timeout, sigmask: { None }, sigsetsize: { 0 }, })
             }
             Sysno::epoll_pwait => {
                 sys_req!(EpollPwait { epfd, events:*, maxevents, timeout, sigmask:*, sigsetsize })
             }
+            #[cfg(not(target_arch = "aarch64"))]
             Sysno::epoll_create => sys_req!(EpollCreate {
                 size,
                 flags: { EpollCreateFlags::empty() }
@@ -2717,10 +2826,11 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
             Sysno::ppoll => {
                 sys_req!(Ppoll { fds:*, nfds, timeout: { =*> TimeParam::timespec_old }, sigmask:*, sigsetsize })
             }
+            #[cfg(not(target_arch = "aarch64"))]
             Sysno::poll => {
                 sys_req!(Ppoll { fds:*, nfds, timeout: { => TimeParam::Milliseconds }, sigmask: { None }, sigsetsize: { 0 } })
             }
-            #[cfg(target_arch = "x86_64")]
+            #[cfg(not(target_arch = "aarch64"))]
             Sysno::select => {
                 sys_req!(Pselect {
                     nfds,
@@ -2731,7 +2841,6 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
                     sigsetpack: { None },
                 })
             }
-            #[cfg(target_arch = "x86_64")]
             Sysno::pselect6 => {
                 sys_req!(Pselect {
                     nfds,
@@ -2763,6 +2872,7 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
                     return Err(errno::Errno::EINVAL);
                 }
             }
+            #[cfg(not(target_arch = "aarch64"))]
             Sysno::arch_prctl => {
                 let code: u32 = ctx.sys_req_arg(0);
                 let code = ArchPrctlCode::try_from(code)
@@ -2779,9 +2889,11 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
                 SyscallRequest::ArchPrctl { arg }
             }
             Sysno::gettid => SyscallRequest::Gettid,
+            #[cfg(not(target_arch = "aarch64"))]
             Sysno::set_thread_area => sys_req!(SetThreadArea { user_desc:* }),
             Sysno::set_tid_address => sys_req!(SetTidAddress { tidptr:* }),
             Sysno::openat => sys_req!(Openat { dirfd,pathname:*,flags,mode }),
+            #[cfg(not(target_arch = "aarch64"))]
             Sysno::open => {
                 // open is equivalent to openat with dirfd AT_FDCWD
                 SyscallRequest::Openat {
@@ -2792,6 +2904,7 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
                 }
             }
             Sysno::mknodat => sys_req!(Mknodat { dirfd,pathname:*,mode_and_type,dev }),
+            #[cfg(not(target_arch = "aarch64"))]
             Sysno::mknod => SyscallRequest::Mknodat {
                 dirfd: AT_FDCWD,
                 pathname: ctx.sys_req_ptr(0),
@@ -2799,6 +2912,7 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
                 dev: ctx.sys_req_arg(2),
             },
             Sysno::unlinkat => sys_req!(Unlinkat { dirfd,pathname:*,flags }),
+            #[cfg(not(target_arch = "aarch64"))]
             Sysno::unlink => {
                 // unlink is equivalent to unlinkat with dirfd AT_FDCWD and flags 0
                 SyscallRequest::Unlinkat {
@@ -2807,6 +2921,7 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
                     flags: AtFlags::empty(),
                 }
             }
+            #[cfg(not(target_arch = "aarch64"))]
             Sysno::rmdir => {
                 // rmdir is equivalent to unlinkat with dirfd AT_FDCWD and AT_REMOVEDIR
                 SyscallRequest::Unlinkat {
@@ -2815,6 +2930,7 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
                     flags: AtFlags::AT_REMOVEDIR,
                 }
             }
+            #[cfg(not(target_arch = "aarch64"))]
             Sysno::creat => {
                 // creat is equivalent to open with flags O_CREAT|O_WRONLY|O_TRUNC
                 SyscallRequest::Openat {
@@ -2827,8 +2943,11 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
                 }
             }
             Sysno::ftruncate => sys_req!(Ftruncate { fd, length }),
-            #[cfg(target_arch = "x86_64")]
+            #[cfg(not(target_arch = "aarch64"))]
             Sysno::newfstatat => sys_req!(Newfstatat { dirfd,pathname:*,buf:*,flags }),
+            #[cfg(target_arch = "aarch64")]
+            Sysno::fstatat => sys_req!(Newfstatat { dirfd,pathname:*,buf:*,flags }),
+            #[cfg(not(target_arch = "aarch64"))]
             Sysno::eventfd => SyscallRequest::Eventfd2 {
                 initval: ctx.sys_req_arg(0),
                 flags: EfdFlags::empty(),
@@ -2841,8 +2960,22 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
                     flags: CloneFlags::from_bits_retain(ctx.syscall_arg(0) as u64 & 0xffffff00),
                     stack: ctx.sys_req_arg(1),
                     parent_tid: ctx.sys_req_arg(2),
-                    child_tid: ctx.sys_req_arg(if cfg!(target_arch = "x86_64") { 3 } else { 4 }),
-                    tls: ctx.sys_req_arg(if cfg!(target_arch = "x86_64") { 4 } else { 3 }),
+                    // The order of the `child_tid` and `tls` arguments depends on
+                    // CONFIG_CLONE_BACKWARDS (see kernel/fork.c): when set, the layout
+                    // is (..., tls=arg3, child_tid=arg4); otherwise it is
+                    // (..., child_tid=arg3, tls=arg4). arm64 selects CLONE_BACKWARDS
+                    // (arch/arm64/Kconfig), whereas x86_64 does not (only X86_32 does,
+                    // arch/x86/Kconfig), so the indices are swapped between the arches.
+                    child_tid: ctx.sys_req_arg(if cfg!(not(target_arch = "aarch64")) {
+                        3
+                    } else {
+                        4
+                    }),
+                    tls: ctx.sys_req_arg(if cfg!(not(target_arch = "aarch64")) {
+                        4
+                    } else {
+                        3
+                    }),
                     pidfd: ctx.sys_req_arg(2), // aliases parent_tid
                     exit_signal: ctx.syscall_arg(0) as u64 & 0xff,
                     stack_size: 0,
@@ -2892,7 +3025,9 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
             Sysno::futex => Self::parse_futex(ctx, TimeParam::timespec_old, unsupported_einval)?,
             Sysno::execve => sys_req!(Execve { pathname:*, argv:*, envp:* }),
             Sysno::umask => sys_req!(Umask { mask }),
+            #[cfg(not(target_arch = "aarch64"))]
             Sysno::alarm => sys_req!(Alarm { seconds }),
+            #[cfg(not(target_arch = "aarch64"))]
             Sysno::pause => SyscallRequest::Pause,
             Sysno::setitimer => sys_req!(SetITimer { which:?, new_value:*, old_value:* }),
             Sysno::getitimer => sys_req!(GetITimer { which:?, curr_value:* }),
@@ -2976,7 +3111,6 @@ impl<Platform: litebox::platform::RawPointerProvider> TimeParam<Platform> {
 
     /// Return a `TimeParam` for the old timespec pointer type, which is
     /// architecture dependent.
-    #[cfg(target_arch = "x86_64")]
     pub fn timespec_old(tp: Option<Platform::RawMutPointer<Timespec>>) -> Self {
         Self::timespec64(tp)
     }
@@ -3081,6 +3215,23 @@ pub struct PtRegs {
     /* top of stack page */
 }
 
+/// Context saved when entering the kernel.
+///
+/// pt_regs from [Linux](https://elixir.bootlin.com/linux/v5.19.17/source/arch/arm64/include/asm/ptrace.h#L178)
+#[cfg(target_arch = "aarch64")]
+#[repr(C)]
+#[derive(Clone, Debug, Default)]
+pub struct PtRegs {
+    /// General-purpose registers x0-x30.
+    pub regs: [usize; AARCH64_GENERAL_REGISTER_COUNT],
+    /// Stack pointer.
+    pub sp: usize,
+    /// Program counter.
+    pub pc: usize,
+    /// Saved processor state (PSTATE/SPSR).
+    pub pstate: Aarch64Pstate,
+}
+
 #[cfg(target_arch = "x86_64")]
 pub mod arch {
     // User returns must not target the null-guard region.
@@ -3158,6 +3309,20 @@ impl PtRegs {
         }
     }
 
+    /// Get the `idx`th syscall argument.
+    ///
+    /// # Panics
+    ///
+    /// If `idx` is greater than 5, this function will panic.
+    #[cfg(target_arch = "aarch64")]
+    pub fn syscall_arg(&self, idx: usize) -> usize {
+        if idx < 6 {
+            self.regs[idx]
+        } else {
+            panic!("Invalid syscall argument index: {idx}")
+        }
+    }
+
     // (Private-only, only to be used via `SyscallRequest::try_from_raw`), get the `idx`th syscall
     // argument, reinterpret-truncated to the necessary type.
     fn sys_req_arg<T: ReinterpretTruncatedFromUsize>(&self, idx: usize) -> T {
@@ -3173,6 +3338,12 @@ impl PtRegs {
     #[cfg(target_arch = "x86_64")]
     pub fn get_ip(&self) -> usize {
         self.rip
+    }
+
+    /// Get the instruction pointer (IP)
+    #[cfg(target_arch = "aarch64")]
+    pub fn get_ip(&self) -> usize {
+        self.pc
     }
 }
 

--- a/litebox_common_linux/src/lib.rs
+++ b/litebox_common_linux/src/lib.rs
@@ -2008,9 +2008,6 @@ pub enum SyscallRequest<Platform: litebox::platform::RawPointerProvider> {
     Mkdirat {
         dirfd: i32,
         pathname: Platform::RawConstPointer<c_char>,
-    },
-    Mkdir {
-        pathname: Platform::RawConstPointer<c_char>,
         mode: u32,
     },
     Chdir {
@@ -2312,7 +2309,6 @@ pub enum SyscallRequest<Platform: litebox::platform::RawPointerProvider> {
         pathname: Platform::RawConstPointer<c_char>,
         flags: AtFlags,
     },
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     Newfstatat {
         dirfd: i32,
         pathname: Platform::RawConstPointer<c_char>,
@@ -2548,19 +2544,18 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
             Sysno::write => sys_req!(Write { fd, buf:*, count }),
             Sysno::close => sys_req!(Close { fd }),
             Sysno::lseek => sys_req!(Lseek { fd, offset, whence }),
-            #[cfg(not(target_arch = "aarch64"))]
+            #[cfg(target_arch = "x86_64")]
             Sysno::stat => sys_req!(Stat { pathname:*, buf:* }),
             Sysno::fstat => sys_req!(Fstat { fd, buf:* }),
-            #[cfg(not(target_arch = "aarch64"))]
+            #[cfg(target_arch = "x86_64")]
             Sysno::lstat => sys_req!(Lstat { pathname:*, buf:* }),
+            #[cfg(target_arch = "x86_64")]
             Sysno::mkdir => SyscallRequest::Mkdirat {
                 dirfd: AT_FDCWD,
                 pathname: ctx.sys_req_ptr(0),
                 mode: ctx.sys_req_arg(1),
             },
             Sysno::mkdirat => sys_req!(Mkdirat { dirfd, pathname:*, mode }),
-            #[cfg(not(target_arch = "aarch64"))]
-            Sysno::mkdir => sys_req!(Mkdir { pathname:*, mode }),
             Sysno::chdir => sys_req!(Chdir { pathname:* }),
             Sysno::mmap => sys_req!(Mmap {
                 addr,
@@ -2626,7 +2621,7 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
             Sysno::writev => sys_req!(Writev { fd, iovec:*, iovcnt }),
             Sysno::preadv => sys_req!(Preadv { fd, iovec:*, iovcnt, pos_l, pos_h }),
             Sysno::pwritev => sys_req!(Pwritev { fd, iovec:*, iovcnt, pos_l, pos_h }),
-            #[cfg(not(target_arch = "aarch64"))]
+            #[cfg(target_arch = "x86_64")]
             Sysno::access => SyscallRequest::Faccessat {
                 dirfd: AT_FDCWD,
                 pathname: ctx.sys_req_ptr(0),
@@ -2640,7 +2635,7 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
                 flags: AtFlags::empty(),
             },
             Sysno::faccessat2 => sys_req!(Faccessat { dirfd, pathname:*, mode, flags }),
-            #[cfg(not(target_arch = "aarch64"))]
+            #[cfg(target_arch = "x86_64")]
             Sysno::pipe => sys_req!(Pipe2 { pipefd:*, flags: { litebox::fs::OFlags::empty() } }),
             Sysno::pipe2 => sys_req!(Pipe2 { pipefd:* ,flags }),
             Sysno::madvise => sys_req!(Madvise { addr:*, length, behavior:? }),
@@ -2649,7 +2644,7 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
                 newfd: None,
                 flags: None,
             },
-            #[cfg(not(target_arch = "aarch64"))]
+            #[cfg(target_arch = "x86_64")]
             Sysno::dup2 => SyscallRequest::Dup {
                 oldfd: ctx.sys_req_arg(0),
                 newfd: Some(ctx.sys_req_arg(1)),
@@ -2744,10 +2739,10 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
                 clockid: { ClockId::Monotonic.into() },
                 flags: { TimerFlags::empty() },
             }),
-            #[cfg(not(target_arch = "aarch64"))]
+            #[cfg(target_arch = "x86_64")]
             Sysno::time => sys_req!(Time { tloc:* }),
             Sysno::getcwd => sys_req!(Getcwd { buf:*, size }),
-            #[cfg(not(target_arch = "aarch64"))]
+            #[cfg(target_arch = "x86_64")]
             Sysno::readlink => sys_req!(Readlink { pathname:*, buf:* ,bufsiz }),
             Sysno::readlinkat => sys_req!(Readlinkat { dirfd, pathname:*, buf:*, bufsiz }),
             Sysno::getrlimit => sys_req!(Getrlimit { resource:?, rlim:* }),
@@ -2760,14 +2755,14 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
             Sysno::geteuid => SyscallRequest::Geteuid,
             Sysno::getegid => SyscallRequest::Getegid,
             Sysno::epoll_ctl => sys_req!(EpollCtl { epfd, op:?, fd, event:* }),
-            #[cfg(not(target_arch = "aarch64"))]
+            #[cfg(target_arch = "x86_64")]
             Sysno::epoll_wait => {
                 sys_req!(EpollPwait { epfd, events:*, maxevents, timeout, sigmask: { None }, sigsetsize: { 0 }, })
             }
             Sysno::epoll_pwait => {
                 sys_req!(EpollPwait { epfd, events:*, maxevents, timeout, sigmask:*, sigsetsize })
             }
-            #[cfg(not(target_arch = "aarch64"))]
+            #[cfg(target_arch = "x86_64")]
             Sysno::epoll_create => sys_req!(EpollCreate {
                 size,
                 flags: { EpollCreateFlags::empty() }
@@ -2776,11 +2771,11 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
             Sysno::ppoll => {
                 sys_req!(Ppoll { fds:*, nfds, timeout: { =*> TimeParam::timespec_old }, sigmask:*, sigsetsize })
             }
-            #[cfg(not(target_arch = "aarch64"))]
+            #[cfg(target_arch = "x86_64")]
             Sysno::poll => {
                 sys_req!(Ppoll { fds:*, nfds, timeout: { => TimeParam::Milliseconds }, sigmask: { None }, sigsetsize: { 0 } })
             }
-            #[cfg(not(target_arch = "aarch64"))]
+            #[cfg(target_arch = "x86_64")]
             Sysno::select => {
                 sys_req!(Pselect {
                     nfds,
@@ -2822,7 +2817,7 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
                     return Err(errno::Errno::EINVAL);
                 }
             }
-            #[cfg(not(target_arch = "aarch64"))]
+            #[cfg(target_arch = "x86_64")]
             Sysno::arch_prctl => {
                 let code: u32 = ctx.sys_req_arg(0);
                 let code = ArchPrctlCode::try_from(code)
@@ -2839,11 +2834,11 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
                 SyscallRequest::ArchPrctl { arg }
             }
             Sysno::gettid => SyscallRequest::Gettid,
-            #[cfg(not(target_arch = "aarch64"))]
+            #[cfg(target_arch = "x86_64")]
             Sysno::set_thread_area => sys_req!(SetThreadArea { user_desc:* }),
             Sysno::set_tid_address => sys_req!(SetTidAddress { tidptr:* }),
             Sysno::openat => sys_req!(Openat { dirfd,pathname:*,flags,mode }),
-            #[cfg(not(target_arch = "aarch64"))]
+            #[cfg(target_arch = "x86_64")]
             Sysno::open => {
                 // open is equivalent to openat with dirfd AT_FDCWD
                 SyscallRequest::Openat {
@@ -2854,7 +2849,7 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
                 }
             }
             Sysno::mknodat => sys_req!(Mknodat { dirfd,pathname:*,mode_and_type,dev }),
-            #[cfg(not(target_arch = "aarch64"))]
+            #[cfg(target_arch = "x86_64")]
             Sysno::mknod => SyscallRequest::Mknodat {
                 dirfd: AT_FDCWD,
                 pathname: ctx.sys_req_ptr(0),
@@ -2862,7 +2857,7 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
                 dev: ctx.sys_req_arg(2),
             },
             Sysno::unlinkat => sys_req!(Unlinkat { dirfd,pathname:*,flags }),
-            #[cfg(not(target_arch = "aarch64"))]
+            #[cfg(target_arch = "x86_64")]
             Sysno::unlink => {
                 // unlink is equivalent to unlinkat with dirfd AT_FDCWD and flags 0
                 SyscallRequest::Unlinkat {
@@ -2871,7 +2866,7 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
                     flags: AtFlags::empty(),
                 }
             }
-            #[cfg(not(target_arch = "aarch64"))]
+            #[cfg(target_arch = "x86_64")]
             Sysno::rmdir => {
                 // rmdir is equivalent to unlinkat with dirfd AT_FDCWD and AT_REMOVEDIR
                 SyscallRequest::Unlinkat {
@@ -2880,7 +2875,7 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
                     flags: AtFlags::AT_REMOVEDIR,
                 }
             }
-            #[cfg(not(target_arch = "aarch64"))]
+            #[cfg(target_arch = "x86_64")]
             Sysno::creat => {
                 // creat is equivalent to open with flags O_CREAT|O_WRONLY|O_TRUNC
                 SyscallRequest::Openat {
@@ -2893,11 +2888,11 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
                 }
             }
             Sysno::ftruncate => sys_req!(Ftruncate { fd, length }),
-            #[cfg(not(target_arch = "aarch64"))]
+            #[cfg(target_arch = "x86_64")]
             Sysno::newfstatat => sys_req!(Newfstatat { dirfd,pathname:*,buf:*,flags }),
             #[cfg(target_arch = "aarch64")]
             Sysno::fstatat => sys_req!(Newfstatat { dirfd,pathname:*,buf:*,flags }),
-            #[cfg(not(target_arch = "aarch64"))]
+            #[cfg(target_arch = "x86_64")]
             Sysno::eventfd => SyscallRequest::Eventfd2 {
                 initval: ctx.sys_req_arg(0),
                 flags: EfdFlags::empty(),
@@ -2916,16 +2911,8 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
                     // (..., child_tid=arg3, tls=arg4). arm64 selects CLONE_BACKWARDS
                     // (arch/arm64/Kconfig), whereas x86_64 does not (only X86_32 does,
                     // arch/x86/Kconfig), so the indices are swapped between the arches.
-                    child_tid: ctx.sys_req_arg(if cfg!(not(target_arch = "aarch64")) {
-                        3
-                    } else {
-                        4
-                    }),
-                    tls: ctx.sys_req_arg(if cfg!(not(target_arch = "aarch64")) {
-                        4
-                    } else {
-                        3
-                    }),
+                    child_tid: ctx.sys_req_arg(if cfg!(target_arch = "x86_64") { 3 } else { 4 }),
+                    tls: ctx.sys_req_arg(if cfg!(target_arch = "x86_64") { 4 } else { 3 }),
                     pidfd: ctx.sys_req_arg(2), // aliases parent_tid
                     exit_signal: ctx.syscall_arg(0) as u64 & 0xff,
                     stack_size: 0,
@@ -2975,9 +2962,9 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
             Sysno::futex => Self::parse_futex(ctx, TimeParam::timespec_old, unsupported_einval)?,
             Sysno::execve => sys_req!(Execve { pathname:*, argv:*, envp:* }),
             Sysno::umask => sys_req!(Umask { mask }),
-            #[cfg(not(target_arch = "aarch64"))]
+            #[cfg(target_arch = "x86_64")]
             Sysno::alarm => sys_req!(Alarm { seconds }),
-            #[cfg(not(target_arch = "aarch64"))]
+            #[cfg(target_arch = "x86_64")]
             Sysno::pause => SyscallRequest::Pause,
             Sysno::setitimer => sys_req!(SetITimer { which:?, new_value:*, old_value:* }),
             Sysno::getitimer => sys_req!(GetITimer { which:?, curr_value:* }),

--- a/litebox_common_linux/src/loader.rs
+++ b/litebox_common_linux/src/loader.rs
@@ -101,6 +101,8 @@ const CLASS: elf::file::Class = if cfg!(target_pointer_width = "64") {
 
 const MACHINE: u16 = if cfg!(target_arch = "x86_64") {
     elf::abi::EM_X86_64
+} else if cfg!(target_arch = "aarch64") {
+    elf::abi::EM_AARCH64
 } else {
     panic!("unsupported arch")
 };

--- a/litebox_common_linux/src/signal/aarch64.rs
+++ b/litebox_common_linux/src/signal/aarch64.rs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//! Definitions for aarch64 signal context structures.
+
+use crate::AARCH64_GENERAL_REGISTER_COUNT;
+use zerocopy::{FromBytes, IntoBytes};
+
+/// AArch64 PSTATE value stored in the signal context ABI.
+pub type Pstate = u64;
+
+/// sigcontext for aarch64.
+/// See: <https://elixir.bootlin.com/linux/v5.19.17/source/arch/arm64/include/uapi/asm/sigcontext.h>
+///
+/// The kernel declares `__u8 __reserved[4096] __attribute__((__aligned__(16)))`,
+/// which forces both the struct's alignment to 16 and `__reserved` to a 16-byte
+/// boundary. The natural offset of `__reserved` is 280 (8-aligned), so the kernel
+/// inserts 8 bytes of padding to place it at offset 288 (size 4384). We reproduce
+/// this with an explicit padding field and `align(16)` so the layout matches
+/// exactly (explicit padding also keeps `IntoBytes` valid, unlike implicit padding).
+#[repr(C, align(16))]
+#[derive(Clone, FromBytes, IntoBytes)]
+#[allow(clippy::pub_underscore_fields)]
+pub struct Sigcontext {
+    pub fault_address: u64,
+    pub regs: [u64; AARCH64_GENERAL_REGISTER_COUNT],
+    pub sp: u64,
+    pub pc: u64,
+    pub pstate: Pstate,
+    /// Padding to align `__reserved` to a 16-byte boundary (matches the kernel's
+    /// `__attribute__((__aligned__(16)))` on this field).
+    pub __reserved_pad: [u8; 8],
+    /// 4K reserved for FP/SIMD state and future extensions.
+    pub __reserved: [u8; 4096],
+}

--- a/litebox_common_linux/src/signal/aarch64.rs
+++ b/litebox_common_linux/src/signal/aarch64.rs
@@ -6,9 +6,6 @@
 use crate::AARCH64_GENERAL_REGISTER_COUNT;
 use zerocopy::{FromBytes, IntoBytes};
 
-/// AArch64 PSTATE value stored in the signal context ABI.
-pub type Pstate = u64;
-
 /// sigcontext for aarch64.
 /// See: <https://elixir.bootlin.com/linux/v5.19.17/source/arch/arm64/include/uapi/asm/sigcontext.h>
 ///
@@ -26,7 +23,7 @@ pub struct Sigcontext {
     pub regs: [u64; AARCH64_GENERAL_REGISTER_COUNT],
     pub sp: u64,
     pub pc: u64,
-    pub pstate: Pstate,
+    pub pstate: u64,
     /// Padding to align `__reserved` to a 16-byte boundary (matches the kernel's
     /// `__attribute__((__aligned__(16)))` on this field).
     pub __reserved_pad: [u8; 8],

--- a/litebox_common_linux/src/signal/mod.rs
+++ b/litebox_common_linux/src/signal/mod.rs
@@ -3,8 +3,13 @@
 
 //! Linux signal handling definitions.
 
+#[cfg(target_arch = "aarch64")]
+pub mod aarch64;
+#[cfg(target_arch = "x86_64")]
 pub mod x86_64;
 
+#[cfg(target_arch = "aarch64")]
+use aarch64::Sigcontext;
 #[cfg(target_arch = "x86_64")]
 use x86_64::Sigcontext;
 
@@ -314,6 +319,7 @@ pub const SI_TKILL: i32 = -6;
 pub const SI_DETHREAD: i32 = -7;
 pub const SI_ASYNCNL: i32 = -60;
 
+#[cfg(target_arch = "x86_64")]
 #[repr(C)]
 #[derive(Clone, FromBytes, IntoBytes)]
 pub struct Ucontext {
@@ -322,6 +328,23 @@ pub struct Ucontext {
     pub stack: SigAltStack,
     pub mcontext: Sigcontext,
     pub sigmask: SigSet,
+}
+
+/// On aarch64, the `uc_sigmask` field comes before `uc_mcontext`.
+#[cfg(target_arch = "aarch64")]
+#[repr(C)]
+#[derive(Clone, FromBytes, IntoBytes)]
+#[allow(clippy::pub_underscore_fields)]
+pub struct Ucontext {
+    pub flags: usize,
+    pub link: usize, // *mut Ucontext,
+    pub stack: SigAltStack,
+    pub sigmask: SigSet,
+    /// Padding: glibc uses a 1024-bit sigset_t (128 bytes), kernel uses 64-bit (8 bytes).
+    pub __unused: [u8; 1024 / 8 - core::mem::size_of::<SigSet>()],
+    /// Alignment padding: mcontext (Sigcontext) requires 16-byte alignment.
+    pub __align_pad: [u8; 8],
+    pub mcontext: Sigcontext,
 }
 
 #[repr(C)]


### PR DESCRIPTION
This PR introduces minimal AArch64 support to the LiteBox core and Linux common crates. It includes essential architecture-specific data structures and data fields as well as fallible memory copy assembly blocks. It also updates CI to build and test the two crates with an AArch64 host.