### PR TITLE
Fix deadlock in layered FS for migrated files

### DIFF
--- a/litebox/src/fs/layered.rs
+++ b/litebox/src/fs/layered.rs
@@ -267,11 +267,12 @@ impl<Platform: sync::RawSyncPrimitivesProvider, Upper: super::FileSystem, Lower:
         }
         // After migrating the data, we also use these FDs to migrate the node-info over, so that
         // any caller that tries to get the inode before/after the migration sees the same inode.
-        if let Some(&layered_id) = self
+        let found = self
             .node_info_lookup
             .read()
             .get(&self.lower.fd_file_status(&lower_fd).unwrap().node_info)
-        {
+            .copied();
+        if let Some(layered_id) = found {
             let old = self.node_info_lookup.write().insert(
                 self.upper
                     .fd_file_status(upper_fd.as_ref().unwrap())

--- a/litebox/src/fs/tests.rs
+++ b/litebox/src/fs/tests.rs
@@ -1934,6 +1934,45 @@ mod layered {
             Err(RmdirError::NotADirectory)
         ));
     }
+
+    #[test]
+    fn migrate_file_up_does_not_deadlock() {
+        use std::sync::mpsc;
+        use std::thread;
+        use std::time::Duration;
+
+        let litebox = LiteBox::new(MockPlatform::new());
+
+        let mut in_mem_fs = in_mem::FileSystem::new(&litebox);
+        in_mem_fs.with_root_privileges(|fs| {
+            fs.chmod("/", Mode::RWXU | Mode::RWXG | Mode::RWXO)
+                .expect("Failed to chmod /");
+        });
+
+        let fs = layered::FileSystem::new(
+            &litebox,
+            in_mem_fs,
+            tar_ro::FileSystem::new(&litebox, TEST_TAR_FILE.into()),
+            layered::LayeringSemantics::LowerLayerReadOnly,
+        );
+
+        fs.file_status("foo").expect("Failed to stat foo");
+
+        // Writing to the lower-layer file triggers copy-on-write migration via
+        // `migrate_file_up`. Run it on a worker thread.
+        let (tx, rx) = mpsc::channel();
+        thread::spawn(move || {
+            let fd = fs
+                .open("foo", OFlags::WRONLY, Mode::RWXU)
+                .expect("Failed to open file for writing");
+            fs.write(&fd, b"x", None).expect("Failed to write to file");
+            fs.close(&fd).expect("Failed to close file");
+            let _ = tx.send(());
+        });
+
+        rx.recv_timeout(Duration::from_secs(2))
+            .expect("migrate_file_up deadlocked");
+    }
 }
 
 mod stdio {


### PR DESCRIPTION
Fix deadlock in layered FS where the `node_info_lookup` lock is read-acquired and then write-acquired