### PR TITLE
Support NtQueryPerformanceCounter

### DIFF
--- a/litebox_common_windows/src/nt_status.rs
+++ b/litebox_common_windows/src/nt_status.rs
@@ -171,6 +171,7 @@ impl NtStatus {
             0xC00000AD => "STATUS_INVALID_PIPE_STATE: Invalid pipe state",
             0xC00000AE => "STATUS_PIPE_BUSY: Pipe busy",
             0xC00000B0 => "STATUS_PIPE_DISCONNECTED: Pipe disconnected",
+            0xC00000BB => "STATUS_NOT_SUPPORTED: The request is not supported",
             0xC00000E6 => "STATUS_GENERIC_NOT_MAPPED: Generic not mapped",
             0xC00000EF => "STATUS_INVALID_PARAMETER_1: Invalid parameter 1",
             0xC00000FD => "STATUS_STACK_OVERFLOW: Stack overflow",
@@ -471,6 +472,9 @@ impl NtStatus {
 
     /// STATUS_PIPE_DISCONNECTED
     pub const PIPE_DISCONNECTED: Self = Self::from_raw(0xC00000B0);
+
+    /// STATUS_NOT_SUPPORTED
+    pub const NOT_SUPPORTED: Self = Self::from_raw(0xC00000BB);
 
     /// STATUS_GENERIC_NOT_MAPPED
     pub const GENERIC_NOT_MAPPED: Self = Self::from_raw(0xC00000E6);

--- a/litebox_shim_windows/src/lib.rs
+++ b/litebox_shim_windows/src/lib.rs
@@ -23,7 +23,7 @@ use litebox::mm::PageManager;
 use litebox::platform::{
     CrngProvider, PageManagementProvider, PunchthroughProvider, PunchthroughToken,
     RawConstPointer as _, RawMutPointer as _, RawPointerProvider, StdioProvider,
-    SystemInfoProvider,
+    SystemInfoProvider, TimeProvider,
 };
 use litebox::shim::{ContinueOperation, EnterShim, ExceptionInfo};
 use litebox::sync::RawSyncPrimitivesProvider;
@@ -49,6 +49,7 @@ pub trait ShimPlatform:
     + RawPointerProvider
     + PageManagementProvider<PAGE_SIZE>
     + SystemInfoProvider
+    + TimeProvider
     + 'static
 {
 }
@@ -58,6 +59,7 @@ impl<T> ShimPlatform for T where
         + RawPointerProvider
         + PageManagementProvider<PAGE_SIZE>
         + SystemInfoProvider
+        + TimeProvider
         + 'static
 {
 }
@@ -269,6 +271,7 @@ impl<Platform: ShimPlatform> WindowsShimBuilder<Platform> {
             platform: self.platform,
             page_manager: PageManager::new(&self.litebox),
             registry: syscalls::registry::RegistryStore::new(&self.litebox),
+            qpc_boot_instant: TimeProvider::now(self.platform),
             litebox: self.litebox,
             _fs: PhantomData,
         });
@@ -324,6 +327,7 @@ struct GlobalState<Platform: ShimPlatform, FS: ShimFS> {
     platform: &'static Platform,
     page_manager: WindowsPageManager<Platform>,
     registry: syscalls::registry::RegistryStore<Platform>,
+    qpc_boot_instant: <Platform as TimeProvider>::Instant,
     litebox: LiteBox<Platform>,
     _fs: PhantomData<FS>,
 }
@@ -540,6 +544,28 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                 install_ui_language,
             } => {
                 let status = self.sys_nt_query_install_ui_language(install_ui_language);
+                (status, ContinueOperation::Resume)
+            }
+            SyscallRequest::NtQueryPerformanceCounter {
+                performance_counter,
+                performance_frequency,
+            } => {
+                let status = self
+                    .sys_nt_query_performance_counter(performance_counter, performance_frequency);
+                (status, ContinueOperation::Resume)
+            }
+            SyscallRequest::NtConvertBetweenAuxiliaryCounterAndPerformanceCounter {
+                flag,
+                source,
+                destination,
+                conversion_error,
+            } => {
+                let status = Self::sys_nt_convert_between_auxiliary_counter_and_performance_counter(
+                    flag,
+                    source,
+                    destination,
+                    conversion_error,
+                );
                 (status, ContinueOperation::Resume)
             }
             SyscallRequest::NtAllocateVirtualMemory {

--- a/litebox_shim_windows/src/syscalls/file.rs
+++ b/litebox_shim_windows/src/syscalls/file.rs
@@ -910,9 +910,8 @@ fn map_mkdir_error(error: MkdirError) -> NtStatus {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tests::{TestFS, TestPlatform};
+    use crate::tests::{TestFS, TestPlatform, const_ptr, mut_ptr, null_mut_ptr};
     use litebox::fs::FileSystem as _;
-    use zerocopy::{FromBytes, IntoBytes};
 
     extern crate std;
 
@@ -931,18 +930,6 @@ mod tests {
     const FILE_OPEN: u32 = 2;
     const FILE_CREATE: u32 = 1;
     const FILE_OVERWRITE: u32 = 4;
-
-    fn const_ptr<T: FromBytes>(value: &T) -> ConstPtr<TestPlatform, T> {
-        ConstPtr::<TestPlatform, T>::from_usize(core::ptr::from_ref(value).cast::<u8>() as usize)
-    }
-
-    fn mut_ptr<T: FromBytes + IntoBytes>(value: &mut T) -> MutPtr<TestPlatform, T> {
-        MutPtr::<TestPlatform, T>::from_usize(core::ptr::from_mut(value).cast::<u8>() as usize)
-    }
-
-    fn null_mut_ptr<T: FromBytes + IntoBytes>() -> MutPtr<TestPlatform, T> {
-        MutPtr::<TestPlatform, T>::from_usize(0)
-    }
 
     fn run_with_test_platform_pointers<R>(f: impl FnOnce() -> R) -> R {
         let _ = crate::tests::test_platform();

--- a/litebox_shim_windows/src/syscalls/mod.rs
+++ b/litebox_shim_windows/src/syscalls/mod.rs
@@ -4,6 +4,7 @@
 pub(crate) mod file;
 pub(crate) mod nls;
 pub(crate) mod registry;
+pub(crate) mod sysinfo;
 
 use litebox::platform::{RawConstPointer as _, RawPointerProvider};
 use litebox::utils::TruncateExt as _;
@@ -153,6 +154,16 @@ pub(crate) enum SyscallRequest<Platform: RawPointerProvider> {
     NtQueryInstallUILanguage {
         install_ui_language: Platform::RawMutPointer<u16>,
     },
+    NtQueryPerformanceCounter {
+        performance_counter: Platform::RawMutPointer<i64>,
+        performance_frequency: Option<Platform::RawMutPointer<i64>>,
+    },
+    NtConvertBetweenAuxiliaryCounterAndPerformanceCounter {
+        flag: u32,
+        source: Platform::RawConstPointer<u64>,
+        destination: Platform::RawMutPointer<u64>,
+        conversion_error: Option<Platform::RawMutPointer<u64>>,
+    },
     NtAllocateVirtualMemory {
         process_handle: ProcessHandle,
         base_address: Platform::RawMutPointer<usize>,
@@ -254,6 +265,18 @@ impl<Platform: RawPointerProvider> SyscallRequest<Platform> {
             NtSysno::NtQueryInstallUILanguage => Some(sys_req!(NtQueryInstallUILanguage {
                 install_ui_language:*,
             })),
+            NtSysno::NtQueryPerformanceCounter => Some(sys_req!(NtQueryPerformanceCounter {
+                performance_counter:*,
+                performance_frequency:*,
+            })),
+            NtSysno::NtConvertBetweenAuxiliaryCounterAndPerformanceCounter => Some(
+                sys_req!(NtConvertBetweenAuxiliaryCounterAndPerformanceCounter {
+                    flag,
+                    source:*,
+                    destination:*,
+                    conversion_error:*,
+                }),
+            ),
             NtSysno::NtAllocateVirtualMemory => Some(sys_req!(NtAllocateVirtualMemory {
                 process_handle: { ProcessHandle::from_raw },
                 base_address:*,

--- a/litebox_shim_windows/src/syscalls/nls.rs
+++ b/litebox_shim_windows/src/syscalls/nls.rs
@@ -549,9 +549,9 @@ fn map_nls_read_error(error: ReadError) -> NtStatus {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tests::mut_ptr;
     use alloc::vec;
     use litebox::platform::RawPointerProvider;
-    use zerocopy::{FromBytes, IntoBytes};
 
     extern crate std;
 
@@ -578,10 +578,6 @@ mod tests {
         fn NtQueryDefaultUILanguage(default_ui_language: *mut u16) -> i32;
 
         fn NtQueryInstallUILanguage(install_ui_language: *mut u16) -> i32;
-    }
-
-    fn mut_ptr<T: FromBytes + IntoBytes>(value: &mut T) -> MutPtr<TestPlatform, T> {
-        MutPtr::<TestPlatform, T>::from_usize(core::ptr::from_mut(value).cast::<u8>() as usize)
     }
 
     #[cfg(all(target_os = "windows", target_arch = "x86_64"))]

--- a/litebox_shim_windows/src/syscalls/registry.rs
+++ b/litebox_shim_windows/src/syscalls/registry.rs
@@ -839,12 +839,11 @@ fn map_read_error(error: ReadError) -> NtStatus {
 
 #[cfg(test)]
 mod tests {
-    use crate::tests::{TestFS, TestPlatform, test_platform};
+    use crate::tests::{TestFS, TestPlatform, const_ptr, mut_byte_ptr, mut_ptr, test_platform};
 
     use super::*;
     use core::mem::size_of;
     use litebox::LiteBox;
-    use zerocopy::{FromBytes, IntoBytes};
 
     extern crate std;
 
@@ -904,18 +903,6 @@ mod tests {
         ) -> i32;
         fn RegCloseKey(hKey: *mut core::ffi::c_void) -> i32;
         fn RegDeleteTreeW(hKey: *mut core::ffi::c_void, lpSubKey: *const u16) -> i32;
-    }
-
-    fn const_ptr<T: FromBytes>(value: &T) -> ConstPtr<TestPlatform, T> {
-        ConstPtr::<TestPlatform, T>::from_usize(core::ptr::from_ref(value).cast::<u8>() as usize)
-    }
-
-    fn mut_ptr<T: FromBytes + IntoBytes>(value: &mut T) -> MutPtr<TestPlatform, T> {
-        MutPtr::<TestPlatform, T>::from_usize(core::ptr::from_mut(value).cast::<u8>() as usize)
-    }
-
-    fn mut_byte_ptr<T>(value: &mut T) -> MutPtr<TestPlatform, u8> {
-        MutPtr::<TestPlatform, u8>::from_usize(core::ptr::from_mut(value).cast::<u8>() as usize)
     }
 
     fn unicode_string(value: &[u16]) -> UnicodeString {

--- a/litebox_shim_windows/src/syscalls/sysinfo.rs
+++ b/litebox_shim_windows/src/syscalls/sysinfo.rs
@@ -1,0 +1,322 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+use litebox::platform::{Instant as _, RawConstPointer as _, RawMutPointer as _};
+use litebox_common_windows::nt_status::NtStatus;
+
+use crate::{ConstPtr, MutPtr, ShimFS, ShimPlatform, Task};
+
+const QPC_FREQUENCY_HZ: i64 = 1_000_000_000;
+
+impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
+    pub(crate) fn sys_nt_query_performance_counter(
+        &self,
+        performance_counter: MutPtr<Platform, i64>,
+        performance_frequency: Option<MutPtr<Platform, i64>>,
+    ) -> NtStatus {
+        let elapsed = self
+            .global
+            .platform
+            .now()
+            .duration_since(&self.global.qpc_boot_instant);
+        let ticks = duration_as_qpc_ticks(elapsed);
+
+        if performance_counter.write_at_offset(0, ticks).is_none() {
+            return NtStatus::ACCESS_VIOLATION;
+        }
+        if let Some(performance_frequency) = performance_frequency
+            && performance_frequency
+                .write_at_offset(0, QPC_FREQUENCY_HZ)
+                .is_none()
+        {
+            return NtStatus::ACCESS_VIOLATION;
+        }
+
+        litebox_util_log::debug!(
+            performance_counter = ticks,
+            performance_frequency = QPC_FREQUENCY_HZ;
+            "Handled NtQueryPerformanceCounter syscall"
+        );
+        NtStatus::SUCCESS
+    }
+
+    pub(crate) fn sys_nt_convert_between_auxiliary_counter_and_performance_counter(
+        _flag: u32,
+        source: ConstPtr<Platform, u64>,
+        _destination: MutPtr<Platform, u64>,
+        _conversion_error: Option<MutPtr<Platform, u64>>,
+    ) -> NtStatus {
+        if source.as_usize() == 0 {
+            return NtStatus::ACCESS_VIOLATION;
+        }
+
+        // Wine reports auxiliary counter conversion as unsupported after validating the source.
+        NtStatus::NOT_SUPPORTED
+    }
+}
+
+fn duration_as_qpc_ticks(duration: core::time::Duration) -> i64 {
+    i64::try_from(core::cmp::min(duration.as_nanos(), i64::MAX as u128)).unwrap_or(i64::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tests::{const_ptr, mut_ptr, null_const_ptr, null_mut_ptr};
+    use core::time::Duration;
+    use litebox::platform::ThreadProvider;
+
+    extern crate std;
+
+    const QPC_SLEEP_DURATION: Duration = Duration::from_millis(25);
+    const QPC_SLEEP_TOLERANCE: Duration = Duration::from_millis(10);
+
+    type TestPlatform = crate::tests::TestPlatform;
+
+    #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+    unsafe extern "system" {
+        fn NtQueryPerformanceCounter(counter: *mut i64, frequency: *mut i64) -> i32;
+
+        fn NtConvertBetweenAuxiliaryCounterAndPerformanceCounter(
+            flag: u32,
+            source: *const u64,
+            destination: *mut u64,
+            conversion_error: *mut u64,
+        ) -> i32;
+    }
+
+    fn run_with_test_platform_pointers<R>(f: impl FnOnce() -> R) -> R {
+        let _ = crate::tests::test_platform();
+        <TestPlatform as ThreadProvider>::run_test_thread(f)
+    }
+
+    fn sys_nt_convert_between_auxiliary_counter_and_performance_counter(
+        flag: u32,
+        source: ConstPtr<TestPlatform, u64>,
+        destination: MutPtr<TestPlatform, u64>,
+        conversion_error: Option<MutPtr<TestPlatform, u64>>,
+    ) -> NtStatus {
+        Task::<TestPlatform, crate::tests::TestFS>::sys_nt_convert_between_auxiliary_counter_and_performance_counter(
+            flag,
+            source,
+            destination,
+            conversion_error,
+        )
+    }
+
+    #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+    fn host_status(status: i32) -> NtStatus {
+        NtStatus::from_raw(u32::from_ne_bytes(status.to_ne_bytes()))
+    }
+
+    fn qpc_delta_nanos(start: i64, end: i64) -> u128 {
+        assert!(end >= start);
+        u128::try_from(end - start).unwrap()
+    }
+
+    #[test]
+    fn nt_query_performance_counter_writes_monotonic_counter_and_frequency() {
+        run_with_test_platform_pointers(|| {
+            let task = crate::tests::test_task();
+            let mut first_counter = -1i64;
+            let mut second_counter = -1i64;
+            let mut frequency = 0i64;
+
+            assert_eq!(
+                task.sys_nt_query_performance_counter(
+                    mut_ptr(&mut first_counter),
+                    Some(mut_ptr(&mut frequency)),
+                ),
+                NtStatus::SUCCESS
+            );
+            assert_eq!(frequency, QPC_FREQUENCY_HZ);
+            assert!(first_counter >= 0);
+
+            assert_eq!(
+                task.sys_nt_query_performance_counter(mut_ptr(&mut second_counter), None),
+                NtStatus::SUCCESS
+            );
+            assert!(second_counter >= first_counter);
+        });
+    }
+
+    #[test]
+    fn nt_query_performance_counter_rejects_null_counter() {
+        run_with_test_platform_pointers(|| {
+            let task = crate::tests::test_task();
+            let mut frequency = 0i64;
+
+            assert_eq!(
+                task.sys_nt_query_performance_counter(
+                    null_mut_ptr(),
+                    Some(mut_ptr(&mut frequency)),
+                ),
+                NtStatus::ACCESS_VIOLATION
+            );
+        });
+    }
+
+    #[test]
+    fn nt_convert_between_auxiliary_counter_and_performance_counter_is_not_supported() {
+        run_with_test_platform_pointers(|| {
+            let source = 0u64;
+            let mut destination = 0u64;
+            let mut conversion_error = 0u64;
+
+            assert_eq!(
+                sys_nt_convert_between_auxiliary_counter_and_performance_counter(
+                    0,
+                    null_const_ptr(),
+                    mut_ptr(&mut destination),
+                    Some(mut_ptr(&mut conversion_error)),
+                ),
+                NtStatus::ACCESS_VIOLATION
+            );
+            assert_eq!(
+                sys_nt_convert_between_auxiliary_counter_and_performance_counter(
+                    0,
+                    const_ptr(&source),
+                    mut_ptr(&mut destination),
+                    Some(mut_ptr(&mut conversion_error)),
+                ),
+                NtStatus::NOT_SUPPORTED
+            );
+        });
+    }
+
+    #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+    #[test]
+    fn nt_query_performance_counter_status_matches_host_ntdll() {
+        run_with_test_platform_pointers(|| {
+            let task = crate::tests::test_task();
+            let mut host_counter = 0i64;
+            let mut host_frequency = 0i64;
+            let mut guest_counter = 0i64;
+            let mut guest_frequency = 0i64;
+
+            // SAFETY: This Windows-only test calls the process ntdll export with valid local
+            // output pointers and checks only the returned status and written scalar values.
+            let host_valid_status = unsafe {
+                host_status(NtQueryPerformanceCounter(
+                    &raw mut host_counter,
+                    &raw mut host_frequency,
+                ))
+            };
+            let guest_status = task.sys_nt_query_performance_counter(
+                mut_ptr(&mut guest_counter),
+                Some(mut_ptr(&mut guest_frequency)),
+            );
+
+            assert_eq!(guest_status, host_valid_status);
+            assert!(guest_counter >= 0);
+            assert!(guest_frequency > 0);
+            assert!(host_counter >= 0);
+            assert!(host_frequency > 0);
+
+            // SAFETY: Passing a null counter pointer intentionally probes host ntdll's invalid
+            // output behavior; the non-null frequency pointer is a valid local output.
+            let host_null_counter_status = unsafe {
+                host_status(NtQueryPerformanceCounter(
+                    core::ptr::null_mut(),
+                    &raw mut host_frequency,
+                ))
+            };
+            let guest_null_counter_status = task.sys_nt_query_performance_counter(
+                null_mut_ptr(),
+                Some(mut_ptr(&mut guest_frequency)),
+            );
+            assert_eq!(guest_null_counter_status, host_null_counter_status);
+        });
+    }
+
+    #[test]
+    fn nt_query_performance_counter_duration_tracks_sleep_duration() {
+        run_with_test_platform_pointers(|| {
+            let task = crate::tests::test_task();
+            let mut guest_frequency = 0i64;
+            let mut guest_start = 0i64;
+            let mut guest_end = 0i64;
+
+            let guest_start_status = task.sys_nt_query_performance_counter(
+                mut_ptr(&mut guest_start),
+                Some(mut_ptr(&mut guest_frequency)),
+            );
+
+            std::thread::sleep(QPC_SLEEP_DURATION);
+
+            let guest_end_status = task.sys_nt_query_performance_counter(
+                mut_ptr(&mut guest_end),
+                Some(mut_ptr(&mut guest_frequency)),
+            );
+
+            assert_eq!(guest_start_status, NtStatus::SUCCESS);
+            assert_eq!(guest_end_status, NtStatus::SUCCESS);
+            assert_eq!(guest_frequency, QPC_FREQUENCY_HZ);
+
+            let guest_duration_nanos = qpc_delta_nanos(guest_start, guest_end);
+            let minimum_duration_nanos = QPC_SLEEP_DURATION
+                .saturating_sub(QPC_SLEEP_TOLERANCE)
+                .as_nanos();
+            let maximum_duration_nanos = QPC_SLEEP_DURATION
+                .saturating_add(QPC_SLEEP_TOLERANCE)
+                .as_nanos();
+
+            assert!(
+                guest_duration_nanos >= minimum_duration_nanos,
+                "guest duration {guest_duration_nanos}ns was shorter than requested sleep minus tolerance {minimum_duration_nanos}ns",
+            );
+            assert!(
+                guest_duration_nanos <= maximum_duration_nanos,
+                "guest duration {guest_duration_nanos}ns was longer than requested sleep plus tolerance {maximum_duration_nanos}ns",
+            );
+        });
+    }
+
+    #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+    #[test]
+    fn nt_convert_between_auxiliary_counter_status_matches_host_ntdll() {
+        run_with_test_platform_pointers(|| {
+            let source = 0u64;
+            let mut destination = 0u64;
+            let mut conversion_error = 0u64;
+
+            // SAFETY: Passing a null source pointer intentionally probes host ntdll's invalid
+            // input behavior; the output pointers are valid local scalars for the duration.
+            let host_null_source_status = unsafe {
+                host_status(NtConvertBetweenAuxiliaryCounterAndPerformanceCounter(
+                    0,
+                    core::ptr::null(),
+                    &raw mut destination,
+                    &raw mut conversion_error,
+                ))
+            };
+            let guest_null_source_status =
+                sys_nt_convert_between_auxiliary_counter_and_performance_counter(
+                    0,
+                    null_const_ptr(),
+                    mut_ptr(&mut destination),
+                    Some(mut_ptr(&mut conversion_error)),
+                );
+            assert_eq!(guest_null_source_status, host_null_source_status);
+
+            // SAFETY: All pointers passed to host ntdll point at local scalar variables that live
+            // for the whole call; the function does not retain them.
+            let host_valid_source_status = unsafe {
+                host_status(NtConvertBetweenAuxiliaryCounterAndPerformanceCounter(
+                    0,
+                    &raw const source,
+                    &raw mut destination,
+                    &raw mut conversion_error,
+                ))
+            };
+            let guest_valid_source_status =
+                sys_nt_convert_between_auxiliary_counter_and_performance_counter(
+                    0,
+                    const_ptr(&source),
+                    mut_ptr(&mut destination),
+                    Some(mut_ptr(&mut conversion_error)),
+                );
+            assert_eq!(guest_valid_source_status, host_valid_source_status);
+        });
+    }
+}

--- a/litebox_shim_windows/src/tests.rs
+++ b/litebox_shim_windows/src/tests.rs
@@ -10,10 +10,11 @@ use core::sync::atomic::{AtomicI32, AtomicU32};
 use litebox::LiteBox;
 use litebox::fd::RawDescriptorStorage;
 use litebox::fs::{FileSystem as _, Mode, OFlags};
+use litebox::platform::RawConstPointer as _;
 
 use crate::{
-    DefaultFS, GlobalState, Process, Task, WindowsHandleStore, WindowsNlsSectionMappings,
-    WindowsPageManager,
+    ConstPtr, DefaultFS, GlobalState, MutPtr, Process, Task, WindowsHandleStore,
+    WindowsNlsSectionMappings, WindowsPageManager,
 };
 
 #[cfg(target_os = "linux")]
@@ -21,6 +22,29 @@ pub(crate) type TestPlatform = litebox_platform_linux_userland::LinuxUserland;
 #[cfg(target_os = "windows")]
 pub(crate) type TestPlatform = litebox_platform_windows_userland::WindowsUserland;
 pub(crate) type TestFS = DefaultFS<TestPlatform>;
+
+pub(crate) fn const_ptr<T: zerocopy::FromBytes>(value: &T) -> ConstPtr<TestPlatform, T> {
+    ConstPtr::<TestPlatform, T>::from_usize(core::ptr::from_ref(value).cast::<u8>() as usize)
+}
+
+pub(crate) fn mut_ptr<T: zerocopy::FromBytes + zerocopy::IntoBytes>(
+    value: &mut T,
+) -> MutPtr<TestPlatform, T> {
+    MutPtr::<TestPlatform, T>::from_usize(core::ptr::from_mut(value).cast::<u8>() as usize)
+}
+
+pub(crate) fn mut_byte_ptr<T>(value: &mut T) -> MutPtr<TestPlatform, u8> {
+    MutPtr::<TestPlatform, u8>::from_usize(core::ptr::from_mut(value).cast::<u8>() as usize)
+}
+
+pub(crate) fn null_const_ptr<T: zerocopy::FromBytes>() -> ConstPtr<TestPlatform, T> {
+    ConstPtr::<TestPlatform, T>::from_usize(0)
+}
+
+pub(crate) fn null_mut_ptr<T: zerocopy::FromBytes + zerocopy::IntoBytes>() -> MutPtr<TestPlatform, T>
+{
+    MutPtr::<TestPlatform, T>::from_usize(0)
+}
 
 pub(crate) fn test_platform() -> &'static TestPlatform {
     static PLATFORM: std::sync::OnceLock<&'static TestPlatform> = std::sync::OnceLock::new();
@@ -89,6 +113,7 @@ pub(crate) fn test_task_with_nls_files(nls_files: &[(&str, &[u8])]) -> Task<Test
         global: Arc::new(GlobalState {
             platform,
             registry: crate::syscalls::registry::RegistryStore::new(&litebox),
+            qpc_boot_instant: litebox::platform::TimeProvider::now(platform),
             litebox,
             page_manager,
             _fs: PhantomData,


### PR DESCRIPTION
This PR adds Windows shim support for NtQueryPerformanceCounter, which uses the platform `TimeProvider` to return a monotonic counter relative to the shim startup, with a fixed frequency.