### PR TITLE
Add support for multiple PTAs

### DIFF
--- a/litebox_shim_optee/src/lib.rs
+++ b/litebox_shim_optee/src/lib.rs
@@ -165,8 +165,13 @@ struct GlobalState {
     _litebox: litebox::LiteBox<Platform>,
     /// The TA UUID to binary map for TA loading.
     ta_uuid_map: TaUuidMap,
-    /// Maintain whether non-concurrent PTAs (i.e., PTAs w/o `TaFlags::CONCURRENT`)
-    /// are busy or not to serialize their command invocation
+    /// Tracks which non-concurrent PTAs (i.e., PTAs w/o `TaFlags::CONCURRENT`)
+    /// are currently busy. A busy PTA is *rejected* with `TeeResult::Busy`
+    /// rather than queued.
+    ///
+    /// TODO: OP-TEE serializes concurrent access to a non-concurrent PTA by
+    /// blocking/queuing the caller until the PTA is free. We currently reject
+    /// instead of serialize; revisit if a PTA needs true serialization.
     pta_busy: spin::mutex::SpinMutex<HashSet<PseudoTa>>,
 }
 

--- a/litebox_shim_optee/src/lib.rs
+++ b/litebox_shim_optee/src/lib.rs
@@ -14,7 +14,7 @@ use aes::{Aes128, Aes192, Aes256};
 use alloc::{sync::Arc, vec};
 use core::cell::Cell;
 use ctr::Ctr128BE;
-use hashbrown::HashMap;
+use hashbrown::{HashMap, HashSet};
 use litebox::{
     LiteBox,
     mm::{PageManager, linux::PAGE_SIZE},
@@ -149,6 +149,7 @@ impl OpteeShimBuilder {
             pm: PageManager::new(&self.litebox),
             _litebox: self.litebox,
             ta_uuid_map: TaUuidMap::new(),
+            pta_busy: spin::mutex::SpinMutex::new(HashSet::new()),
         });
         OpteeShim(global)
     }
@@ -164,6 +165,8 @@ struct GlobalState {
     _litebox: litebox::LiteBox<Platform>,
     /// The TA UUID to binary map for TA loading.
     ta_uuid_map: TaUuidMap,
+    /// Non-concurrent PTAs currently entered in this shim instance.
+    pta_busy: spin::mutex::SpinMutex<HashSet<PseudoTa>>,
 }
 
 impl GlobalState {

--- a/litebox_shim_optee/src/lib.rs
+++ b/litebox_shim_optee/src/lib.rs
@@ -9,6 +9,7 @@
 extern crate alloc;
 
 use crate::loader::elf::ElfLoaderError;
+use crate::syscalls::pta::PseudoTa;
 use aes::{Aes128, Aes192, Aes256};
 use alloc::{sync::Arc, vec};
 use core::cell::Cell;
@@ -244,6 +245,7 @@ impl OpteeShim {
                 tee_cryp_state_map: TeeCrypStateMap::new(),
                 tee_obj_map: TeeObjMap::new(),
                 ta_handle_map: TaHandleMap::new(),
+                pta_sessions: spin::mutex::SpinMutex::new(HashMap::new()),
                 ta_entry_point: Cell::new(0),
                 ta_stack_base_addr: Cell::new(0),
                 ta_prepared: Cell::new(false),
@@ -439,7 +441,7 @@ impl Task {
                 if let Some(ta_uuid) = ta_uuid.read_at_offset(0)
                     && let Some(usr_params) = usr_params.read_at_offset(0)
                 {
-                    Task::sys_open_ta_session(
+                    self.sys_open_ta_session(
                         ta_uuid,
                         cancel_req_to,
                         usr_params,
@@ -450,7 +452,7 @@ impl Task {
                     Err(TeeResult::BadParameters)
                 }
             }
-            SyscallRequest::CloseTaSession { ta_sess_id } => Task::sys_close_ta_session(ta_sess_id),
+            SyscallRequest::CloseTaSession { ta_sess_id } => self.sys_close_ta_session(ta_sess_id),
             SyscallRequest::InvokeTaCommand {
                 ta_sess_id,
                 cancel_req_to,
@@ -1281,6 +1283,8 @@ struct Task {
     tee_obj_map: TeeObjMap,
     /// TA handle to UUID map
     ta_handle_map: TaHandleMap,
+    /// PTA sessions opened by this TA task.
+    pta_sessions: spin::mutex::SpinMutex<HashMap<u32, PseudoTa>>,
     /// TA entry point
     ta_entry_point: Cell<usize>,
     /// TA stack base address
@@ -1306,6 +1310,12 @@ impl ThreadState {
             init_state: Cell::new(ThreadInitState::None),
             initialized: Cell::new(false),
         }
+    }
+}
+
+impl Drop for Task {
+    fn drop(&mut self) {
+        self.close_all_pta_sessions();
     }
 }
 
@@ -1337,8 +1347,7 @@ pub(crate) enum ThreadInitState {
 /// With MAX_RECYCLABLE_SESSION_ID = 65536:
 /// - Bitmap memory usage: 65536 bits = 8 KB
 /// - Recyclable IDs: 1..=65536 (65536 IDs)
-/// - Fallback (non-recyclable) IDs: 65537..=0xffff_fffd (~4.3B IDs, excluding PTA_SESSION_ID)
-/// - PTA_SESSION_ID (0xffff_fffe) is reserved and never allocated
+/// - Fallback (non-recyclable) IDs: 65537..=u32::MAX (~4.3B IDs)
 ///
 /// Design notes:
 /// - A single TA instance can serve many concurrent sessions (no per-instance cap),
@@ -1353,6 +1362,8 @@ pub(crate) struct SessionIdPool {
     pool: litebox::utils::id_pool::IdPool,
     /// Next one-time ID when the recyclable pool is exhausted.
     fallback_next: u32,
+    /// Whether all fallback IDs have been issued.
+    fallback_exhausted: bool,
 }
 
 fn session_id_pool() -> &'static spin::mutex::SpinMutex<SessionIdPool> {
@@ -1363,6 +1374,7 @@ fn session_id_pool() -> &'static spin::mutex::SpinMutex<SessionIdPool> {
                 SessionIdPool::MAX_RECYCLABLE_SESSION_ID,
             ),
             fallback_next: SessionIdPool::MAX_RECYCLABLE_SESSION_ID + 1,
+            fallback_exhausted: false,
         })
     })
 }
@@ -1370,27 +1382,32 @@ fn session_id_pool() -> &'static spin::mutex::SpinMutex<SessionIdPool> {
 impl SessionIdPool {
     /// Maximum recyclable session ID tracked by the bitmap.
     const MAX_RECYCLABLE_SESSION_ID: u32 = 65536;
-    /// Reserved session ID for PTA.
-    const PTA_SESSION_ID: u32 = 0xffff_fffe;
-
     /// Allocate a new session ID.
     ///
     /// Returns `None` if all recyclable session IDs are currently in use and
     /// the fallback one-time IDs are exhausted.
     pub fn allocate() -> Option<u32> {
         let mut pool = session_id_pool().lock();
+        pool.allocate_inner()
+    }
 
+    fn allocate_inner(&mut self) -> Option<u32> {
         // Try recyclable pool first (pool ID 0 → session ID 1, etc.)
-        if let Some(id) = pool.pool.allocate() {
+        if let Some(id) = self.pool.allocate() {
             return Some(id + 1);
         }
 
         // Bitmap exhausted - use fallback one-time IDs if available
-        let fallback_id = pool.fallback_next;
-        if fallback_id >= Self::PTA_SESSION_ID {
+        if self.fallback_exhausted {
             return None;
         }
-        pool.fallback_next = fallback_id + 1;
+
+        let fallback_id = self.fallback_next;
+        if fallback_id == u32::MAX {
+            self.fallback_exhausted = true;
+        } else {
+            self.fallback_next = fallback_id + 1;
+        }
         Some(fallback_id)
     }
 
@@ -1401,10 +1418,6 @@ impl SessionIdPool {
         }
 
         session_id_pool().lock().pool.recycle(session_id - 1);
-    }
-
-    pub fn get_pta_session_id() -> u32 {
-        Self::PTA_SESSION_ID
     }
 }
 
@@ -1430,6 +1443,7 @@ mod test_utils {
                 tee_cryp_state_map: TeeCrypStateMap::new(),
                 tee_obj_map: TeeObjMap::new(),
                 ta_handle_map: TaHandleMap::new(),
+                pta_sessions: spin::mutex::SpinMutex::new(HashMap::new()),
                 ta_entry_point: Cell::new(0),
                 ta_stack_base_addr: Cell::new(0),
                 ta_prepared: Cell::new(false),

--- a/litebox_shim_optee/src/lib.rs
+++ b/litebox_shim_optee/src/lib.rs
@@ -165,7 +165,8 @@ struct GlobalState {
     _litebox: litebox::LiteBox<Platform>,
     /// The TA UUID to binary map for TA loading.
     ta_uuid_map: TaUuidMap,
-    /// Non-concurrent PTAs currently entered in this shim instance.
+    /// Maintain whether non-concurrent PTAs (i.e., PTAs w/o `TaFlags::CONCURRENT`)
+    /// are busy or not to serialize their command invocation
     pta_busy: spin::mutex::SpinMutex<HashSet<PseudoTa>>,
 }
 

--- a/litebox_shim_optee/src/lib.rs
+++ b/litebox_shim_optee/src/lib.rs
@@ -9,7 +9,7 @@
 extern crate alloc;
 
 use crate::loader::elf::ElfLoaderError;
-use crate::syscalls::pta::PseudoTa;
+use crate::syscalls::pta::{PseudoTa, PtaSession};
 use aes::{Aes128, Aes192, Aes256};
 use alloc::{sync::Arc, vec};
 use core::cell::Cell;
@@ -1288,7 +1288,7 @@ struct Task {
     /// TA handle to UUID map
     ta_handle_map: TaHandleMap,
     /// PTA sessions opened by this TA task.
-    pta_sessions: spin::mutex::SpinMutex<HashMap<u32, PseudoTa>>,
+    pta_sessions: spin::mutex::SpinMutex<HashMap<u32, PtaSession>>,
     /// TA entry point
     ta_entry_point: Cell<usize>,
     /// TA stack base address

--- a/litebox_shim_optee/src/lib.rs
+++ b/litebox_shim_optee/src/lib.rs
@@ -9,7 +9,7 @@
 extern crate alloc;
 
 use crate::loader::elf::ElfLoaderError;
-use crate::syscalls::pta::{PseudoTa, PtaSession};
+use crate::syscalls::pta::PseudoTa;
 use aes::{Aes128, Aes192, Aes256};
 use alloc::{sync::Arc, vec};
 use core::cell::Cell;
@@ -1287,8 +1287,8 @@ struct Task {
     tee_obj_map: TeeObjMap,
     /// TA handle to UUID map
     ta_handle_map: TaHandleMap,
-    /// PTA sessions opened by this TA task.
-    pta_sessions: spin::mutex::SpinMutex<HashMap<u32, PtaSession>>,
+    /// PTA sessions opened by this TA task, mapping each session ID to its PTA.
+    pta_sessions: spin::mutex::SpinMutex<HashMap<u32, PseudoTa>>,
     /// TA entry point
     ta_entry_point: Cell<usize>,
     /// TA stack base address

--- a/litebox_shim_optee/src/syscalls/pta.rs
+++ b/litebox_shim_optee/src/syscalls/pta.rs
@@ -22,6 +22,9 @@ use zeroize::{Zeroize, Zeroizing};
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub(crate) struct SystemPta;
 
+/// A common interface to interact with various PTAs including the system PTA.
+///
+/// Add new PTAs here as needed.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub(crate) enum PseudoTa {
     System(SystemPta),
@@ -174,7 +177,8 @@ impl Task {
         Some(pta)
     }
 
-    pub(crate) fn pta_for_inter_ta_session(&self, ta_sess_id: u32) -> Option<PseudoTa> {
+    /// Get the PTA associated with a session (if exists).
+    pub(crate) fn pta_for_session(&self, ta_sess_id: u32) -> Option<PseudoTa> {
         self.pta_sessions.lock().get(&ta_sess_id).copied()
     }
 
@@ -212,7 +216,9 @@ impl SystemPta {
         crate::SessionIdPool::allocate().ok_or(TeeResult::Busy)
     }
 
-    fn close_session(_task: &Task, _session_id: u32) {}
+    fn close_session(_task: &Task, _session_id: u32) {
+        // System PTA has no per-session state
+    }
 
     /// Handle a command of the system PTA.
     fn invoke_command(task: &Task, cmd_id: u32, params: &UteeParams) -> Result<(), TeeResult> {

--- a/litebox_shim_optee/src/syscalls/pta.rs
+++ b/litebox_shim_optee/src/syscalls/pta.rs
@@ -19,7 +19,7 @@ use num_enum::TryFromPrimitive;
 use sha2::Sha256;
 use zeroize::{Zeroize, Zeroizing};
 
-pub(crate) struct SystemPta;
+struct SystemPta;
 
 /// A common interface to interact with various PTAs including the system PTA.
 ///
@@ -111,7 +111,7 @@ const TA_DERIVED_EXTRA_DATA_MAX_SIZE: usize = 1024;
 /// `PTA_SYSTEM_*` command ID from `optee_os/lib/libutee/include/pta_system.h`
 #[derive(Clone, Copy, TryFromPrimitive)]
 #[repr(u32)]
-pub(crate) enum PtaSystemCommandId {
+enum PtaSystemCommandId {
     AddRngEntropy = PTA_SYSTEM_ADD_RNG_ENTROPY,
     DeriveTaUniqueKey = PTA_SYSTEM_DERIVE_TA_UNIQUE_KEY,
     MapZi = PTA_SYSTEM_MAP_ZI,

--- a/litebox_shim_optee/src/syscalls/pta.rs
+++ b/litebox_shim_optee/src/syscalls/pta.rs
@@ -13,16 +13,16 @@ use litebox::platform::{
 };
 use litebox::utils::TruncateExt;
 use litebox_common_optee::{
-    HUK_SUBKEY_MAX_LEN, HukSubkeyUsage, TeeParamType, TeeResult, TeeUuid, UteeParams,
+    HUK_SUBKEY_MAX_LEN, HukSubkeyUsage, TaFlags, TeeParamType, TeeResult, TeeUuid, UteeParams,
 };
 use num_enum::TryFromPrimitive;
 use sha2::Sha256;
 use zeroize::{Zeroize, Zeroizing};
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub(crate) struct SystemPta;
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub(crate) enum PseudoTa {
     System(SystemPta),
 }
@@ -48,6 +48,7 @@ impl PseudoTa {
         cmd_id: u32,
         params: &UteeParams,
     ) -> Result<(), TeeResult> {
+        let _busy = task.enter_pta(self)?;
         match self {
             Self::System(_) => SystemPta::invoke_command(task, cmd_id, params),
         }
@@ -57,6 +58,27 @@ impl PseudoTa {
         match self {
             Self::System(_) => SystemPta::close_session(task, session_id),
         }
+    }
+
+    fn flags(self) -> TaFlags {
+        match self {
+            Self::System(_) => SystemPta::FLAGS,
+        }
+    }
+}
+
+const PTA_DEFAULT_FLAGS: TaFlags = TaFlags::SINGLE_INSTANCE
+    .union(TaFlags::MULTI_SESSION)
+    .union(TaFlags::INSTANCE_KEEP_ALIVE);
+
+struct PtaBusyGuard<'a> {
+    task: &'a Task,
+    pta: PseudoTa,
+}
+
+impl Drop for PtaBusyGuard<'_> {
+    fn drop(&mut self) {
+        self.task.global.pta_busy.lock().remove(&self.pta);
     }
 }
 
@@ -105,11 +127,26 @@ pub(crate) enum PtaSystemCommandId {
 type HmacSha256 = Hmac<Sha256>;
 
 impl Task {
+    fn enter_pta(&self, pta: PseudoTa) -> Result<Option<PtaBusyGuard<'_>>, TeeResult> {
+        if pta.flags().contains(TaFlags::CONCURRENT) {
+            return Ok(None);
+        }
+
+        let mut busy = self.global.pta_busy.lock();
+        if busy.contains(&pta) {
+            return Err(TeeResult::Busy);
+        }
+
+        busy.insert(pta);
+        Ok(Some(PtaBusyGuard { task: self, pta }))
+    }
+
     pub(crate) fn open_pta_session(
         &self,
         pta: PseudoTa,
         params: &UteeParams,
     ) -> Result<u32, TeeResult> {
+        let _busy = self.enter_pta(pta)?;
         let mut pta_sessions = self.pta_sessions.lock();
         // OP-TEE OS permits multiple sessions to the same PTA. We intentionally
         // cap this shim at one session per PTA per TA task to prevent a TA
@@ -153,6 +190,8 @@ impl Task {
 }
 
 impl SystemPta {
+    const FLAGS: TaFlags = PTA_DEFAULT_FLAGS.union(TaFlags::CONCURRENT);
+
     const UUID: TeeUuid = TeeUuid {
         time_low: 0x3a2f_8978,
         time_mid: 0x5dc0,

--- a/litebox_shim_optee/src/syscalls/pta.rs
+++ b/litebox_shim_optee/src/syscalls/pta.rs
@@ -30,11 +30,6 @@ pub(crate) enum PseudoTa {
     System(SystemPta),
 }
 
-pub(crate) struct PtaSession {
-    pub(crate) pta: PseudoTa,
-    pub(crate) owner_session_id: u32,
-}
-
 impl PseudoTa {
     pub(crate) fn from_uuid(uuid: &TeeUuid) -> Option<Self> {
         match *uuid {
@@ -79,7 +74,7 @@ const PTA_DEFAULT_FLAGS: TaFlags = TaFlags::SINGLE_INSTANCE
     .union(TaFlags::MULTI_SESSION)
     .union(TaFlags::INSTANCE_KEEP_ALIVE);
 
-const MAX_PTA_SESSIONS_PER_TASK: usize = 20;
+const MAX_PTA_SESSIONS_PER_TASK: usize = 100;
 
 struct PtaBusyGuard<'a> {
     task: &'a Task,
@@ -158,20 +153,15 @@ impl Task {
     ) -> Result<u32, TeeResult> {
         let _busy = self.enter_pta(pta)?;
         let mut pta_sessions = self.pta_sessions.lock();
-        // OP-TEE OS permits multiple sessions to the same PTA. We cap this shim
-        // to prevent a TA from exhausting session IDs or memory.
+        // OP-TEE OS permits multiple sessions to the same PTA. We cap the number
+        // of PTA sessions per TA instance to prevent a TA from exhausting session
+        // IDs or memory.
         if pta_sessions.len() >= MAX_PTA_SESSIONS_PER_TASK {
             return Err(TeeResult::Busy);
         }
 
         let session_id = pta.open_session(params)?;
-        let prev = pta_sessions.insert(
-            session_id,
-            PtaSession {
-                pta,
-                owner_session_id: self.session_id,
-            },
-        );
+        let prev = pta_sessions.insert(session_id, pta);
         debug_assert!(
             prev.is_none(),
             "freshly allocated session ID collided with an existing PTA session",
@@ -181,13 +171,8 @@ impl Task {
 
     pub(crate) fn close_pta_session(&self, ta_session_id: u32) -> Option<PseudoTa> {
         let mut pta_sessions = self.pta_sessions.lock();
-        if pta_sessions.get(&ta_session_id)?.owner_session_id != self.session_id {
-            return None;
-        }
-
-        let session = pta_sessions.remove(&ta_session_id)?;
+        let pta = pta_sessions.remove(&ta_session_id)?;
         drop(pta_sessions);
-        let pta = session.pta;
         pta.close_session(self, ta_session_id);
         crate::SessionIdPool::recycle(ta_session_id);
         Some(pta)
@@ -195,20 +180,14 @@ impl Task {
 
     /// Get the PTA associated with a session (if exists).
     pub(crate) fn pta_for_session(&self, ta_sess_id: u32) -> Option<PseudoTa> {
-        self.pta_sessions
-            .lock()
-            .get(&ta_sess_id)
-            .filter(|s| s.owner_session_id == self.session_id)
-            .map(|s| s.pta)
+        self.pta_sessions.lock().get(&ta_sess_id).copied()
     }
 
     pub(crate) fn close_all_pta_sessions(&self) {
         // Drain into a local buffer and release the lock before invoking
         // `close_session` to avoid potential dead locks.
-        let sessions: alloc::vec::Vec<(u32, PtaSession)> =
-            self.pta_sessions.lock().drain().collect();
-        for (session_id, session) in sessions {
-            let pta = session.pta;
+        let sessions: alloc::vec::Vec<(u32, PseudoTa)> = self.pta_sessions.lock().drain().collect();
+        for (session_id, pta) in sessions {
             pta.close_session(self, session_id);
             crate::SessionIdPool::recycle(session_id);
         }
@@ -372,43 +351,4 @@ fn huk_subkey_derive_inner(huk: &[u8], params: KDFParams<'_>) -> Result<(), TeeR
     params.output.copy_from_slice(&hmac_bytes[..subkey_len]);
     hmac_bytes.zeroize();
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::syscalls::tests::init_platform;
-
-    #[test]
-    fn pta_session_tracks_owner_ta_session() {
-        let task = init_platform();
-        let params = UteeParams::default();
-
-        let session_id = task
-            .open_pta_session(PseudoTa::System(SystemPta), &params)
-            .unwrap();
-
-        let sessions = task.pta_sessions.lock();
-        let session = sessions.get(&session_id).unwrap();
-        assert_eq!(session.owner_session_id, task.session_id);
-    }
-
-    #[test]
-    fn pta_session_rejects_non_owner_session() {
-        let task = init_platform();
-        let session_id = crate::SessionIdPool::allocate().unwrap();
-        task.pta_sessions.lock().insert(
-            session_id,
-            PtaSession {
-                pta: PseudoTa::System(SystemPta),
-                owner_session_id: task.session_id + 1,
-            },
-        );
-
-        assert_eq!(task.pta_for_session(session_id), None);
-        assert_eq!(task.close_pta_session(session_id), None);
-
-        task.pta_sessions.lock().remove(&session_id);
-        crate::SessionIdPool::recycle(session_id);
-    }
 }

--- a/litebox_shim_optee/src/syscalls/pta.rs
+++ b/litebox_shim_optee/src/syscalls/pta.rs
@@ -50,7 +50,7 @@ impl PseudoTa {
         cmd_id: u32,
         params: &UteeParams,
     ) -> Result<(), TeeResult> {
-        let _busy = task.enter_pta(self)?;
+        let _busy = task.try_set_busy(self)?;
         match self {
             Self::System => SystemPta::invoke_command(task, cmd_id, params),
         }
@@ -131,13 +131,13 @@ pub(crate) enum PtaSystemCommandId {
 type HmacSha256 = Hmac<Sha256>;
 
 impl Task {
-    /// Mark a non-concurrent PTA as busy for the duration of the returned guard,
-    /// gating both `open_pta_session` and command invocation.
+    /// Try to mark a non-concurrent PTA as busy, returning a guard that clears
+    /// the busy state on drop. This gates both session opening and command
+    /// invocation.
     ///
     /// Returns `Ok(None)` for PTAs flagged `TaFlags::CONCURRENT` (no gating).
-    /// For a non-concurrent PTA that is already busy, returns `Err(Busy)`
-    /// immediately rather than blocking/queuing the caller as OP-TEE does.
-    fn enter_pta(&self, pta: PseudoTa) -> Result<Option<PtaBusyGuard<'_>>, TeeResult> {
+    /// For a non-concurrent PTA that is busy, returns `Err(Busy)` immediately.
+    fn try_set_busy(&self, pta: PseudoTa) -> Result<Option<PtaBusyGuard<'_>>, TeeResult> {
         if pta.flags().contains(TaFlags::CONCURRENT) {
             return Ok(None);
         }
@@ -156,7 +156,7 @@ impl Task {
         pta: PseudoTa,
         params: &UteeParams,
     ) -> Result<u32, TeeResult> {
-        let _busy = self.enter_pta(pta)?;
+        let _busy = self.try_set_busy(pta)?;
 
         // OP-TEE OS permits multiple sessions to the same PTA. We cap the number
         // of PTA sessions per TA instance to prevent a TA from exhausting session

--- a/litebox_shim_optee/src/syscalls/pta.rs
+++ b/litebox_shim_optee/src/syscalls/pta.rs
@@ -131,6 +131,12 @@ pub(crate) enum PtaSystemCommandId {
 type HmacSha256 = Hmac<Sha256>;
 
 impl Task {
+    /// Mark a non-concurrent PTA as busy for the duration of the returned guard,
+    /// gating both `open_pta_session` and command invocation.
+    ///
+    /// Returns `Ok(None)` for PTAs flagged `TaFlags::CONCURRENT` (no gating).
+    /// For a non-concurrent PTA that is already busy, returns `Err(Busy)`
+    /// immediately rather than blocking/queuing the caller as OP-TEE does.
     fn enter_pta(&self, pta: PseudoTa) -> Result<Option<PtaBusyGuard<'_>>, TeeResult> {
         if pta.flags().contains(TaFlags::CONCURRENT) {
             return Ok(None);
@@ -151,16 +157,24 @@ impl Task {
         params: &UteeParams,
     ) -> Result<u32, TeeResult> {
         let _busy = self.enter_pta(pta)?;
-        let mut pta_sessions = self.pta_sessions.lock();
+
         // OP-TEE OS permits multiple sessions to the same PTA. We cap the number
         // of PTA sessions per TA instance to prevent a TA from exhausting session
-        // IDs or memory.
-        if pta_sessions.len() >= MAX_PTA_SESSIONS_PER_TASK {
-            return Err(TeeResult::Busy);
+        // IDs or memory. The cap is checked while holding the lock, then the lock
+        // is released before `open_session` runs.
+        {
+            let pta_sessions = self.pta_sessions.lock();
+            if pta_sessions.len() >= MAX_PTA_SESSIONS_PER_TASK {
+                return Err(TeeResult::Busy);
+            }
         }
 
+        // Run the PTA hook without holding `pta_sessions`. OP-TEE `Task` is
+        // single-threaded, so nothing else mutates `pta_sessions` in the meantime.
+        // Keeping the hook outside the lock to avoid a self deadlock.
         let session_id = pta.open_session(params)?;
-        let prev = pta_sessions.insert(session_id, pta);
+
+        let prev = self.pta_sessions.lock().insert(session_id, pta);
         debug_assert!(
             prev.is_none(),
             "freshly allocated session ID collided with an existing PTA session",
@@ -185,7 +199,7 @@ impl Task {
     pub(crate) fn close_all_pta_sessions(&self) {
         // Drain into a local buffer and release the lock before invoking
         // `close_session` to avoid potential dead locks.
-        let sessions: alloc::vec::Vec<(u32, PseudoTa)> = self.pta_sessions.lock().drain().collect();
+        let sessions: Vec<(u32, PseudoTa)> = self.pta_sessions.lock().drain().collect();
         for (session_id, pta) in sessions {
             pta.close_session(self, session_id);
             crate::SessionIdPool::recycle(session_id);

--- a/litebox_shim_optee/src/syscalls/pta.rs
+++ b/litebox_shim_optee/src/syscalls/pta.rs
@@ -19,7 +19,6 @@ use num_enum::TryFromPrimitive;
 use sha2::Sha256;
 use zeroize::{Zeroize, Zeroizing};
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub(crate) struct SystemPta;
 
 /// A common interface to interact with various PTAs including the system PTA.
@@ -27,13 +26,13 @@ pub(crate) struct SystemPta;
 /// Add new PTAs here as needed.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub(crate) enum PseudoTa {
-    System(SystemPta),
+    System,
 }
 
 impl PseudoTa {
     pub(crate) fn from_uuid(uuid: &TeeUuid) -> Option<Self> {
         match *uuid {
-            SystemPta::UUID => Some(Self::System(SystemPta)),
+            SystemPta::UUID => Some(Self::System),
             _ => None,
         }
     }
@@ -41,7 +40,7 @@ impl PseudoTa {
     /// Open a session to this PTA, returning the allocated session ID.
     fn open_session(self, params: &UteeParams) -> Result<u32, TeeResult> {
         match self {
-            Self::System(_) => SystemPta::open_session(params),
+            Self::System => SystemPta::open_session(params),
         }
     }
 
@@ -53,19 +52,19 @@ impl PseudoTa {
     ) -> Result<(), TeeResult> {
         let _busy = task.enter_pta(self)?;
         match self {
-            Self::System(_) => SystemPta::invoke_command(task, cmd_id, params),
+            Self::System => SystemPta::invoke_command(task, cmd_id, params),
         }
     }
 
     fn close_session(self, task: &Task, session_id: u32) {
         match self {
-            Self::System(_) => SystemPta::close_session(task, session_id),
+            Self::System => SystemPta::close_session(task, session_id),
         }
     }
 
     fn flags(self) -> TaFlags {
         match self {
-            Self::System(_) => SystemPta::FLAGS,
+            Self::System => SystemPta::FLAGS,
         }
     }
 }

--- a/litebox_shim_optee/src/syscalls/pta.rs
+++ b/litebox_shim_optee/src/syscalls/pta.rs
@@ -19,10 +19,10 @@ use num_enum::TryFromPrimitive;
 use sha2::Sha256;
 use zeroize::{Zeroize, Zeroizing};
 
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub(crate) struct SystemPta;
 
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub(crate) enum PseudoTa {
     System(SystemPta),
 }

--- a/litebox_shim_optee/src/syscalls/pta.rs
+++ b/litebox_shim_optee/src/syscalls/pta.rs
@@ -30,6 +30,11 @@ pub(crate) enum PseudoTa {
     System(SystemPta),
 }
 
+pub(crate) struct PtaSession {
+    pub(crate) pta: PseudoTa,
+    pub(crate) owner_session_id: u32,
+}
+
 impl PseudoTa {
     pub(crate) fn from_uuid(uuid: &TeeUuid) -> Option<Self> {
         match *uuid {
@@ -73,6 +78,8 @@ impl PseudoTa {
 const PTA_DEFAULT_FLAGS: TaFlags = TaFlags::SINGLE_INSTANCE
     .union(TaFlags::MULTI_SESSION)
     .union(TaFlags::INSTANCE_KEEP_ALIVE);
+
+const MAX_PTA_SESSIONS_PER_TASK: usize = 20;
 
 struct PtaBusyGuard<'a> {
     task: &'a Task,
@@ -151,18 +158,20 @@ impl Task {
     ) -> Result<u32, TeeResult> {
         let _busy = self.enter_pta(pta)?;
         let mut pta_sessions = self.pta_sessions.lock();
-        // OP-TEE OS permits multiple sessions to the same PTA. We intentionally
-        // cap this shim at one session per PTA per TA task to prevent a TA
-        // from exhausting session IDs or memory.
-        if pta_sessions
-            .values()
-            .any(|existing_pta| *existing_pta == pta)
-        {
+        // OP-TEE OS permits multiple sessions to the same PTA. We cap this shim
+        // to prevent a TA from exhausting session IDs or memory.
+        if pta_sessions.len() >= MAX_PTA_SESSIONS_PER_TASK {
             return Err(TeeResult::Busy);
         }
 
         let session_id = pta.open_session(params)?;
-        let prev = pta_sessions.insert(session_id, pta);
+        let prev = pta_sessions.insert(
+            session_id,
+            PtaSession {
+                pta,
+                owner_session_id: self.session_id,
+            },
+        );
         debug_assert!(
             prev.is_none(),
             "freshly allocated session ID collided with an existing PTA session",
@@ -171,7 +180,14 @@ impl Task {
     }
 
     pub(crate) fn close_pta_session(&self, ta_session_id: u32) -> Option<PseudoTa> {
-        let pta = self.pta_sessions.lock().remove(&ta_session_id)?;
+        let mut pta_sessions = self.pta_sessions.lock();
+        if pta_sessions.get(&ta_session_id)?.owner_session_id != self.session_id {
+            return None;
+        }
+
+        let session = pta_sessions.remove(&ta_session_id)?;
+        drop(pta_sessions);
+        let pta = session.pta;
         pta.close_session(self, ta_session_id);
         crate::SessionIdPool::recycle(ta_session_id);
         Some(pta)
@@ -179,14 +195,20 @@ impl Task {
 
     /// Get the PTA associated with a session (if exists).
     pub(crate) fn pta_for_session(&self, ta_sess_id: u32) -> Option<PseudoTa> {
-        self.pta_sessions.lock().get(&ta_sess_id).copied()
+        self.pta_sessions
+            .lock()
+            .get(&ta_sess_id)
+            .filter(|s| s.owner_session_id == self.session_id)
+            .map(|s| s.pta)
     }
 
     pub(crate) fn close_all_pta_sessions(&self) {
         // Drain into a local buffer and release the lock before invoking
         // `close_session` to avoid potential dead locks.
-        let sessions: alloc::vec::Vec<(u32, PseudoTa)> = self.pta_sessions.lock().drain().collect();
-        for (session_id, pta) in sessions {
+        let sessions: alloc::vec::Vec<(u32, PtaSession)> =
+            self.pta_sessions.lock().drain().collect();
+        for (session_id, session) in sessions {
+            let pta = session.pta;
             pta.close_session(self, session_id);
             crate::SessionIdPool::recycle(session_id);
         }
@@ -350,4 +372,43 @@ fn huk_subkey_derive_inner(huk: &[u8], params: KDFParams<'_>) -> Result<(), TeeR
     params.output.copy_from_slice(&hmac_bytes[..subkey_len]);
     hmac_bytes.zeroize();
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::syscalls::tests::init_platform;
+
+    #[test]
+    fn pta_session_tracks_owner_ta_session() {
+        let task = init_platform();
+        let params = UteeParams::default();
+
+        let session_id = task
+            .open_pta_session(PseudoTa::System(SystemPta), &params)
+            .unwrap();
+
+        let sessions = task.pta_sessions.lock();
+        let session = sessions.get(&session_id).unwrap();
+        assert_eq!(session.owner_session_id, task.session_id);
+    }
+
+    #[test]
+    fn pta_session_rejects_non_owner_session() {
+        let task = init_platform();
+        let session_id = crate::SessionIdPool::allocate().unwrap();
+        task.pta_sessions.lock().insert(
+            session_id,
+            PtaSession {
+                pta: PseudoTa::System(SystemPta),
+                owner_session_id: task.session_id + 1,
+            },
+        );
+
+        assert_eq!(task.pta_for_session(session_id), None);
+        assert_eq!(task.close_pta_session(session_id), None);
+
+        task.pta_sessions.lock().remove(&session_id);
+        crate::SessionIdPool::recycle(session_id);
+    }
 }

--- a/litebox_shim_optee/src/syscalls/pta.rs
+++ b/litebox_shim_optee/src/syscalls/pta.rs
@@ -19,12 +19,46 @@ use num_enum::TryFromPrimitive;
 use sha2::Sha256;
 use zeroize::{Zeroize, Zeroizing};
 
-pub const PTA_SYSTEM_UUID: TeeUuid = TeeUuid {
-    time_low: 0x3a2f_8978,
-    time_mid: 0x5dc0,
-    time_hi_and_version: 0x11e8,
-    clock_seq_and_node: [0x9c, 0x2d, 0xfa, 0x7a, 0xe0, 0x1b, 0xbe, 0xbc],
-};
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct SystemPta;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum PseudoTa {
+    System(SystemPta),
+}
+
+impl PseudoTa {
+    pub(crate) fn from_uuid(uuid: &TeeUuid) -> Option<Self> {
+        match *uuid {
+            SystemPta::UUID => Some(Self::System(SystemPta)),
+            _ => None,
+        }
+    }
+
+    /// Open a session to this PTA, returning the allocated session ID.
+    fn open_session(self, params: &UteeParams) -> Result<u32, TeeResult> {
+        match self {
+            Self::System(_) => SystemPta::open_session(params),
+        }
+    }
+
+    pub(crate) fn invoke_command(
+        self,
+        task: &Task,
+        cmd_id: u32,
+        params: &UteeParams,
+    ) -> Result<(), TeeResult> {
+        match self {
+            Self::System(_) => SystemPta::invoke_command(task, cmd_id, params),
+        }
+    }
+
+    fn close_session(self, task: &Task, session_id: u32) {
+        match self {
+            Self::System(_) => SystemPta::close_session(task, session_id),
+        }
+    }
+}
 
 const PTA_SYSTEM_ADD_RNG_ENTROPY: u32 = 0;
 const PTA_SYSTEM_DERIVE_TA_UNIQUE_KEY: u32 = 1;
@@ -51,7 +85,7 @@ const TA_DERIVED_EXTRA_DATA_MAX_SIZE: usize = 1024;
 /// `PTA_SYSTEM_*` command ID from `optee_os/lib/libutee/include/pta_system.h`
 #[derive(Clone, Copy, TryFromPrimitive)]
 #[repr(u32)]
-pub enum PtaSystemCommandId {
+pub(crate) enum PtaSystemCommandId {
     AddRngEntropy = PTA_SYSTEM_ADD_RNG_ENTROPY,
     DeriveTaUniqueKey = PTA_SYSTEM_DERIVE_TA_UNIQUE_KEY,
     MapZi = PTA_SYSTEM_MAP_ZI,
@@ -68,36 +102,84 @@ pub enum PtaSystemCommandId {
     SuppPluginInvoke = PTA_SYSTEM_SUPP_PLUGIN_INVOKE,
 }
 
-/// Checks whether a given TA is a (system) PTA and its parameter is valid.
-pub fn is_pta(ta_uuid: &TeeUuid, params: &UteeParams) -> bool {
-    // TODO: consider other PTAs
-    *ta_uuid == PTA_SYSTEM_UUID
-        && params.get_type(0).is_ok_and(|t| t == TeeParamType::None)
-        && params.get_type(1).is_ok_and(|t| t == TeeParamType::None)
-        && params.get_type(2).is_ok_and(|t| t == TeeParamType::None)
-        && params.get_type(3).is_ok_and(|t| t == TeeParamType::None)
-}
-
-// TODO: replace it with a proper implementation.
-pub fn close_pta_session(_ta_session_id: u32) {}
-
-/// Check whether a given session ID is associated with a PTA.
-pub fn is_pta_session(ta_sess_id: u32) -> bool {
-    ta_sess_id == crate::SessionIdPool::get_pta_session_id()
-}
-
 type HmacSha256 = Hmac<Sha256>;
 
 impl Task {
-    /// Handle a command of the system PTA.
-    pub fn handle_system_pta_command(
+    pub(crate) fn open_pta_session(
         &self,
-        cmd_id: u32,
+        pta: PseudoTa,
         params: &UteeParams,
-    ) -> Result<(), TeeResult> {
+    ) -> Result<u32, TeeResult> {
+        let mut pta_sessions = self.pta_sessions.lock();
+        // OP-TEE OS permits multiple sessions to the same PTA. We intentionally
+        // cap this shim at one session per PTA per TA task to prevent a TA
+        // from exhausting session IDs or memory.
+        if pta_sessions
+            .values()
+            .any(|existing_pta| *existing_pta == pta)
+        {
+            return Err(TeeResult::Busy);
+        }
+
+        let session_id = pta.open_session(params)?;
+        let prev = pta_sessions.insert(session_id, pta);
+        debug_assert!(
+            prev.is_none(),
+            "freshly allocated session ID collided with an existing PTA session",
+        );
+        Ok(session_id)
+    }
+
+    pub(crate) fn close_pta_session(&self, ta_session_id: u32) -> Option<PseudoTa> {
+        let pta = self.pta_sessions.lock().remove(&ta_session_id)?;
+        pta.close_session(self, ta_session_id);
+        crate::SessionIdPool::recycle(ta_session_id);
+        Some(pta)
+    }
+
+    pub(crate) fn pta_for_inter_ta_session(&self, ta_sess_id: u32) -> Option<PseudoTa> {
+        self.pta_sessions.lock().get(&ta_sess_id).copied()
+    }
+
+    pub(crate) fn close_all_pta_sessions(&self) {
+        // Drain into a local buffer and release the lock before invoking
+        // `close_session` to avoid potential dead locks.
+        let sessions: alloc::vec::Vec<(u32, PseudoTa)> = self.pta_sessions.lock().drain().collect();
+        for (session_id, pta) in sessions {
+            pta.close_session(self, session_id);
+            crate::SessionIdPool::recycle(session_id);
+        }
+    }
+}
+
+impl SystemPta {
+    const UUID: TeeUuid = TeeUuid {
+        time_low: 0x3a2f_8978,
+        time_mid: 0x5dc0,
+        time_hi_and_version: 0x11e8,
+        clock_seq_and_node: [0x9c, 0x2d, 0xfa, 0x7a, 0xe0, 0x1b, 0xbe, 0xbc],
+    };
+
+    fn open_session(params: &UteeParams) -> Result<u32, TeeResult> {
+        if !params.has_types([
+            TeeParamType::None,
+            TeeParamType::None,
+            TeeParamType::None,
+            TeeParamType::None,
+        ]) {
+            return Err(TeeResult::BadParameters);
+        }
+
+        crate::SessionIdPool::allocate().ok_or(TeeResult::Busy)
+    }
+
+    fn close_session(_task: &Task, _session_id: u32) {}
+
+    /// Handle a command of the system PTA.
+    fn invoke_command(task: &Task, cmd_id: u32, params: &UteeParams) -> Result<(), TeeResult> {
         #[allow(clippy::single_match_else)]
         match PtaSystemCommandId::try_from(cmd_id).map_err(|_| TeeResult::BadParameters)? {
-            PtaSystemCommandId::DeriveTaUniqueKey => self.derive_ta_unique_key(params),
+            PtaSystemCommandId::DeriveTaUniqueKey => Self::derive_ta_unique_key(task, params),
             _ => {
                 #[cfg(debug_assertions)]
                 todo!("support other system PTA commands {cmd_id}");
@@ -111,7 +193,7 @@ impl Task {
     ///
     /// This follows the OP-TEE `system_derive_ta_unique_key` implementation from
     /// `core/pta/system.c`.
-    fn derive_ta_unique_key(&self, params: &UteeParams) -> Result<(), TeeResult> {
+    fn derive_ta_unique_key(task: &Task, params: &UteeParams) -> Result<(), TeeResult> {
         use TeeParamType::{MemrefInput, MemrefOutput, None};
 
         if !params.has_types([MemrefInput, MemrefOutput, None, None]) {
@@ -153,9 +235,10 @@ impl Task {
         let subkey_ptr = UserMutPtr::<u8>::from_usize(subkey_addr.trunc());
 
         // subkey = KDF(huk, usage || ta_uuid || extra_data)
-        let ta_uuid_bytes = self.ta_app_id.to_le_bytes();
+        let ta_uuid_bytes = task.ta_app_id.to_le_bytes();
         let mut subkey_buf = Zeroizing::new(vec![0u8; subkey_size]);
-        self.huk_subkey_derive(
+        Self::huk_subkey_derive(
+            task,
             HukSubkeyUsage::UniqueTa,
             &[&ta_uuid_bytes, &extra_data],
             &mut subkey_buf,
@@ -171,7 +254,7 @@ impl Task {
     ///
     /// This follows the OP-TEE `huk_subkey_derive` interface from `core/kernel/huk_subkey.c`.
     fn huk_subkey_derive(
-        &self,
+        task: &Task,
         usage: HukSubkeyUsage,
         const_data: &[&[u8]],
         subkey: &mut [u8],
@@ -193,7 +276,7 @@ impl Task {
             output: subkey,
         };
 
-        self.global
+        task.global
             .platform
             .derive_key(Some(huk_subkey_derive_inner), kdf_params)
             .map_err(|err| match err {

--- a/litebox_shim_optee/src/syscalls/tee.rs
+++ b/litebox_shim_optee/src/syscalls/tee.rs
@@ -177,9 +177,10 @@ impl Task {
             // `open_ta_session` syscall lets a user-mode TA open a session to a PTA which provides
             // several import services (it works as a proxy for extra system calls).
             let session_id = self.open_pta_session(pta, &usr_params)?;
-            ta_sess_id
-                .write_at_offset(0, session_id)
-                .ok_or(TeeResult::AccessDenied)?;
+            if ta_sess_id.write_at_offset(0, session_id).is_none() {
+                self.close_pta_session(session_id);
+                return Err(TeeResult::AccessDenied);
+            }
             Ok(())
         } else {
             // `open_ta_session` syscall lets a user-mode TA open a session to another user-mode TA
@@ -219,7 +220,7 @@ impl Task {
         ret_orig
             .write_at_offset(0, TeeOrigin::Tee)
             .ok_or(TeeResult::AccessDenied)?;
-        if let Some(pta) = self.pta_for_inter_ta_session(ta_sess_id) {
+        if let Some(pta) = self.pta_for_session(ta_sess_id) {
             pta.invoke_command(self, cmd_id, &params)
         } else {
             #[cfg(debug_assertions)]

--- a/litebox_shim_optee/src/syscalls/tee.rs
+++ b/litebox_shim_optee/src/syscalls/tee.rs
@@ -15,10 +15,7 @@ use litebox_common_optee::{
 use num_enum::TryFromPrimitive;
 use zerocopy::IntoBytes;
 
-use crate::{
-    Task, UserConstPtr, UserMutPtr,
-    syscalls::pta::{close_pta_session, is_pta, is_pta_session},
-};
+use crate::{Task, UserConstPtr, UserMutPtr, syscalls::pta::PseudoTa};
 
 #[inline]
 fn align_up(addr: usize, align: usize) -> Option<usize> {
@@ -165,6 +162,7 @@ impl Task {
 
     /// A system call to open a session with a PTA or another user-mode TA.
     pub fn sys_open_ta_session(
+        &self,
         ta_uuid: TeeUuid,
         _cancel_req_to: u32,
         usr_params: UteeParams,
@@ -175,11 +173,12 @@ impl Task {
         ret_orig
             .write_at_offset(0, TeeOrigin::Tee)
             .ok_or(TeeResult::AccessDenied)?;
-        if is_pta(&ta_uuid, &usr_params) {
+        if let Some(pta) = PseudoTa::from_uuid(&ta_uuid) {
             // `open_ta_session` syscall lets a user-mode TA open a session to a PTA which provides
             // several import services (it works as a proxy for extra system calls).
+            let session_id = self.open_pta_session(pta, &usr_params)?;
             ta_sess_id
-                .write_at_offset(0, crate::SessionIdPool::get_pta_session_id())
+                .write_at_offset(0, session_id)
                 .ok_or(TeeResult::AccessDenied)?;
             Ok(())
         } else {
@@ -196,9 +195,8 @@ impl Task {
 
     /// A system call to close an opened session.
     #[allow(clippy::unnecessary_wraps)]
-    pub fn sys_close_ta_session(ta_sess_id: u32) -> Result<(), TeeResult> {
-        if is_pta_session(ta_sess_id) {
-            close_pta_session(ta_sess_id);
+    pub fn sys_close_ta_session(&self, ta_sess_id: u32) -> Result<(), TeeResult> {
+        if self.close_pta_session(ta_sess_id).is_some() {
             Ok(())
         } else {
             #[cfg(debug_assertions)]
@@ -221,9 +219,8 @@ impl Task {
         ret_orig
             .write_at_offset(0, TeeOrigin::Tee)
             .ok_or(TeeResult::AccessDenied)?;
-        if is_pta_session(ta_sess_id) {
-            // TODO: check whether `ta_sess_id` is associated with the system PTA.
-            self.handle_system_pta_command(cmd_id, &params)
+        if let Some(pta) = self.pta_for_inter_ta_session(ta_sess_id) {
+            pta.invoke_command(self, cmd_id, &params)
         } else {
             #[cfg(debug_assertions)]
             todo!("support inter TA interaction");


### PR DESCRIPTION
This PR adds support for multiple PTAs to manage them through common interfaces. It lets a TA open and interact with PTAs using their unique (PTA) session IDs.