### PR TITLE
Implement Windows NT event object support

### DIFF
--- a/litebox_shim_windows/src/lib.rs
+++ b/litebox_shim_windows/src/lib.rs
@@ -12,7 +12,8 @@
 extern crate alloc;
 
 use alloc::collections::BTreeMap;
-use alloc::sync::Arc;
+use alloc::string::String;
+use alloc::sync::{Arc, Weak};
 use alloc::vec::Vec;
 use core::marker::PhantomData;
 use core::sync::atomic::{AtomicI32, AtomicU32, Ordering};
@@ -30,6 +31,7 @@ use litebox::sync::RawSyncPrimitivesProvider;
 use litebox_common_windows::NtSysno;
 use litebox_common_windows::loader::{MappingInfo, PAGE_SIZE};
 
+use crate::syscalls::event::{EventHandleObject, EventObject, EventSubsystem};
 use crate::syscalls::file::{FileObject, FileObjectSubsystem};
 use crate::syscalls::registry::{RegistryKeyObject, RegistryKeySubsystem};
 use crate::syscalls::{SyscallRequest, mm};
@@ -75,6 +77,8 @@ pub(crate) type WindowsNlsSectionMappings<Platform> =
     litebox::sync::RwLock<Platform, BTreeMap<(u32, u32), (usize, usize)>>;
 pub(crate) type WindowsVirtualAllocations<Platform> =
     litebox::sync::RwLock<Platform, BTreeMap<usize, WindowsVirtualAllocation>>;
+pub(crate) type WindowsEventNamespace<Platform> =
+    litebox::sync::RwLock<Platform, BTreeMap<String, Weak<EventObject<Platform>>>>;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct WindowsVirtualAllocation {
@@ -309,6 +313,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> WindowsShim<Platform, FS> {
             ntdll_mapping: load_info.ntdll_mapping,
             peb_address: load_info.environment.peb,
             handles: WindowsHandleStore::<Platform>::new(litebox::fd::RawDescriptorStorage::new()),
+            event_namespace: WindowsEventNamespace::<Platform>::new(BTreeMap::new()),
             nls_section_mappings: WindowsNlsSectionMappings::<Platform>::new(BTreeMap::new()),
             virtual_allocations: load_info.virtual_allocations,
             system_lcid: AtomicU32::new(syscalls::nls::DEFAULT_LOCALE_ID),
@@ -345,10 +350,11 @@ struct GlobalState<Platform: ShimPlatform, FS: ShimFS> {
 }
 
 /// Per-process Windows state shared by every thread in the process.
-pub struct Process<Platform: RawSyncPrimitivesProvider> {
+pub struct Process<Platform: ShimPlatform> {
     ntdll_mapping: Option<MappingInfo>,
     peb_address: usize,
     handles: WindowsHandleStore<Platform>,
+    event_namespace: WindowsEventNamespace<Platform>,
     nls_section_mappings: WindowsNlsSectionMappings<Platform>,
     virtual_allocations: WindowsVirtualAllocations<Platform>,
     system_lcid: AtomicU32,
@@ -357,7 +363,7 @@ pub struct Process<Platform: RawSyncPrimitivesProvider> {
     exit_code: AtomicI32,
 }
 
-impl<Platform: RawSyncPrimitivesProvider> Process<Platform> {
+impl<Platform: ShimPlatform> Process<Platform> {
     /// Wait for the process to exit, returning its exit code.
     ///
     /// Currently a placeholder that returns a fixed exit code immediately.
@@ -425,6 +431,76 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         let (result, op) = match req {
             SyscallRequest::NtClose { handle } => {
                 let status = self.sys_nt_close(handle);
+                (status, ContinueOperation::Resume)
+            }
+            SyscallRequest::NtCreateEvent {
+                event_handle,
+                desired_access,
+                object_attributes,
+                event_type,
+                initial_state,
+            } => {
+                let status = self.sys_nt_create_event(
+                    event_handle,
+                    desired_access,
+                    object_attributes,
+                    event_type,
+                    initial_state,
+                );
+                (status, ContinueOperation::Resume)
+            }
+            SyscallRequest::NtOpenEvent {
+                event_handle,
+                desired_access,
+                object_attributes,
+            } => {
+                let status =
+                    self.sys_nt_open_event(event_handle, desired_access, object_attributes);
+                (status, ContinueOperation::Resume)
+            }
+            SyscallRequest::NtSetEvent {
+                event_handle,
+                previous_state,
+            } => {
+                let status = self.sys_nt_set_event(event_handle, previous_state);
+                (status, ContinueOperation::Resume)
+            }
+            SyscallRequest::NtResetEvent {
+                event_handle,
+                previous_state,
+            } => {
+                let status = self.sys_nt_reset_event(event_handle, previous_state);
+                (status, ContinueOperation::Resume)
+            }
+            SyscallRequest::NtClearEvent { event_handle } => {
+                let status = self.sys_nt_clear_event(event_handle);
+                (status, ContinueOperation::Resume)
+            }
+            SyscallRequest::NtPulseEvent {
+                event_handle,
+                previous_state,
+            } => {
+                let status = self.sys_nt_pulse_event(event_handle, previous_state);
+                (status, ContinueOperation::Resume)
+            }
+            SyscallRequest::NtQueryEvent {
+                event_handle,
+                event_information_class,
+                event_information,
+                event_information_length,
+                return_length,
+            } => {
+                let status = self.sys_nt_query_event(
+                    event_handle,
+                    event_information_class,
+                    event_information,
+                    event_information_length,
+                    return_length,
+                );
+                (status, ContinueOperation::Resume)
+            }
+            SyscallRequest::NtSetEventBoostPriority { event_handle } => {
+                let status = self.sys_nt_set_event(event_handle, None);
                 (status, ContinueOperation::Resume)
             }
             SyscallRequest::NtOpenFile {
@@ -683,6 +759,9 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                     (NtStatus::SUCCESS, ContinueOperation::Terminate)
                 }
             }
+            SyscallRequest::NtManageHotPatch => {
+                (NtStatus::NOT_IMPLEMENTED, ContinueOperation::Resume)
+            }
         };
 
         ctx.rax = result.as_raw().cast_unsigned() as usize;
@@ -717,6 +796,14 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         ) {
             return NtStatus::SUCCESS;
         }
+        if remove_raw_handle_by_raw_fd::<Platform, EventSubsystem<Platform>>(
+            &self.global.litebox,
+            &self.process.handles,
+            raw_fd,
+            |event| visitor.event(event),
+        ) {
+            return NtStatus::SUCCESS;
+        }
         NtStatus::INVALID_HANDLE
     }
 
@@ -736,6 +823,8 @@ trait RawHandleVisitor<Platform: ShimPlatform, FS: ShimFS> {
     fn file(&self, file: FileObject<FS>);
 
     fn registry_key(&self, key: RegistryKeyObject<Platform>);
+
+    fn event(&self, event: EventHandleObject<Platform>);
 }
 
 struct CloseRawHandleVisitor<'task, Platform: ShimPlatform, FS: ShimFS> {
@@ -751,6 +840,10 @@ impl<Platform: ShimPlatform, FS: ShimFS> RawHandleVisitor<Platform, FS>
 
     fn registry_key(&self, key: RegistryKeyObject<Platform>) {
         self.task.close_registry_key(key);
+    }
+
+    fn event(&self, event: EventHandleObject<Platform>) {
+        Task::<Platform, FS>::close_event(event);
     }
 }
 

--- a/litebox_shim_windows/src/lib.rs
+++ b/litebox_shim_windows/src/lib.rs
@@ -500,7 +500,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                 (status, ContinueOperation::Resume)
             }
             SyscallRequest::NtSetEventBoostPriority { event_handle } => {
-                let status = self.sys_nt_set_event(event_handle, None);
+                let status = self.sys_nt_set_event_boost_priority(event_handle);
                 (status, ContinueOperation::Resume)
             }
             SyscallRequest::NtOpenFile {

--- a/litebox_shim_windows/src/syscalls/event.rs
+++ b/litebox_shim_windows/src/syscalls/event.rs
@@ -1,0 +1,1034 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//! Windows NT event object syscalls.
+
+use alloc::string::String;
+use alloc::sync::{Arc, Weak};
+use core::marker::PhantomData;
+use core::mem::size_of;
+
+use litebox::event::{Events, IOPollable, observer::Observer, polling::Pollee};
+use litebox::fd::{FdEnabledSubsystem, FdEnabledSubsystemEntry};
+use litebox::platform::{RawConstPointer as _, RawMutPointer as _, RawPointerProvider};
+use litebox::sync::Mutex;
+use litebox_common_windows::nt_status::NtStatus;
+use zerocopy::{FromBytes, Immutable, IntoBytes};
+
+use crate::nt_types::{AccessMask, ObjectAttributes, UnicodeString, read_object_attributes};
+use crate::syscalls::Handle;
+use crate::{
+    ConstPtr, MutPtr, ShimFS, Task, insert_raw_handle, probe_guest_output_preserving_value,
+    raw_handle_entry, remove_raw_handle,
+};
+
+const OBJ_CASE_INSENSITIVE: u32 = 0x0000_0040;
+const OBJ_OPENIF: u32 = 0x0000_0080;
+const OBJ_OPENLINK: u32 = 0x0000_0100;
+
+#[repr(u32)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum EventType {
+    Notification = 0,
+    Synchronization = 1,
+}
+
+impl EventType {
+    fn from_raw(raw: u32) -> Result<Self, NtStatus> {
+        match raw {
+            0 => Ok(Self::Notification),
+            1 => Ok(Self::Synchronization),
+            _ => Err(NtStatus::INVALID_PARAMETER),
+        }
+    }
+
+    const fn as_raw(self) -> u32 {
+        self as u32
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, FromBytes, Immutable, IntoBytes, PartialEq)]
+pub(crate) struct EventBasicInformation {
+    event_type: u32,
+    event_state: i32,
+}
+
+#[repr(u32)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum EventInformationClass {
+    Basic = 0,
+}
+
+impl EventInformationClass {
+    fn from_raw(raw: u32) -> Result<Self, NtStatus> {
+        match raw {
+            0 => Ok(Self::Basic),
+            _ => Err(NtStatus::INVALID_INFO_CLASS),
+        }
+    }
+}
+
+bitflags::bitflags! {
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    pub(crate) struct EventAccess: u32 {
+        const QUERY_STATE = 0x0001;
+        const MODIFY_STATE = 0x0002;
+
+        const READ = AccessMask::STANDARD_RIGHTS_READ.bits() | Self::QUERY_STATE.bits();
+        const WRITE = AccessMask::STANDARD_RIGHTS_WRITE.bits() | Self::MODIFY_STATE.bits();
+        const EXECUTE = AccessMask::STANDARD_RIGHTS_EXECUTE.bits() | AccessMask::SYNCHRONIZE.bits();
+        const ALL_ACCESS = AccessMask::STANDARD_RIGHTS_ALL.bits()
+            | Self::QUERY_STATE.bits()
+            | Self::MODIFY_STATE.bits();
+
+        const _ = !0;
+    }
+}
+
+impl EventAccess {
+    fn from_desired_access(desired_access: u32) -> Self {
+        let mut access = Self::from_bits_retain(desired_access);
+        if desired_access & AccessMask::GENERIC_READ.bits() != 0 {
+            access.insert(Self::READ);
+        }
+        if desired_access & AccessMask::GENERIC_WRITE.bits() != 0 {
+            access.insert(Self::WRITE);
+        }
+        if desired_access & AccessMask::GENERIC_EXECUTE.bits() != 0 {
+            access.insert(Self::EXECUTE);
+        }
+        if desired_access & AccessMask::GENERIC_ALL.bits() != 0 {
+            access.insert(Self::ALL_ACCESS);
+        }
+        access.remove(Self::from_bits_retain(
+            AccessMask::GENERIC_READ.bits()
+                | AccessMask::GENERIC_WRITE.bits()
+                | AccessMask::GENERIC_EXECUTE.bits()
+                | AccessMask::GENERIC_ALL.bits(),
+        ));
+        access
+    }
+
+    fn require(self, required: Self) -> Result<(), NtStatus> {
+        if self.contains(required) {
+            Ok(())
+        } else {
+            Err(NtStatus::ACCESS_DENIED)
+        }
+    }
+}
+
+pub(crate) struct EventSubsystem<Platform>(PhantomData<fn(Platform)>);
+
+impl<Platform: crate::ShimPlatform> FdEnabledSubsystem for EventSubsystem<Platform> {
+    type Entry = EventHandleObject<Platform>;
+}
+
+impl<Platform: crate::ShimPlatform> FdEnabledSubsystemEntry for EventHandleObject<Platform> {}
+
+pub(crate) struct EventHandleObject<Platform: crate::ShimPlatform> {
+    event: Arc<EventObject<Platform>>,
+    granted_access: EventAccess,
+}
+
+pub(crate) struct EventObject<Platform: crate::ShimPlatform> {
+    event_type: EventType,
+    signaled: Mutex<Platform, bool>,
+    pollee: Pollee<Platform>,
+}
+
+impl<Platform: crate::ShimPlatform> EventObject<Platform> {
+    fn new(event_type: EventType, initial_state: bool) -> Self {
+        Self {
+            event_type,
+            signaled: Mutex::new(initial_state),
+            pollee: Pollee::new(),
+        }
+    }
+
+    fn set(&self) -> i32 {
+        let previous = self.replace_state(true);
+        if previous == 0 {
+            self.pollee.notify_observers(Events::IN);
+        }
+        previous
+    }
+
+    fn reset(&self) -> i32 {
+        self.replace_state(false)
+    }
+
+    fn clear(&self) {
+        *self.signaled.lock() = false;
+    }
+
+    fn pulse(&self) -> i32 {
+        self.replace_state(false)
+    }
+
+    fn query(&self) -> EventBasicInformation {
+        EventBasicInformation {
+            event_type: self.event_type.as_raw(),
+            event_state: i32::from(*self.signaled.lock()),
+        }
+    }
+
+    fn replace_state(&self, next: bool) -> i32 {
+        let mut signaled = self.signaled.lock();
+        let previous = i32::from(*signaled);
+        *signaled = next;
+        previous
+    }
+}
+
+impl<Platform: crate::ShimPlatform> IOPollable for EventObject<Platform> {
+    fn register_observer(&self, observer: Weak<dyn Observer<Events>>, mask: Events) {
+        self.pollee.register_observer(observer, mask);
+    }
+
+    fn check_io_events(&self) -> Events {
+        if *self.signaled.lock() {
+            Events::IN
+        } else {
+            Events::empty()
+        }
+    }
+}
+
+struct EventName {
+    key: String,
+}
+
+const EVENT_BASIC_INFORMATION_SIZE_U32: u32 = 8;
+const _: () =
+    assert!(size_of::<EventBasicInformation>() == EVENT_BASIC_INFORMATION_SIZE_U32 as usize);
+
+fn read_event_name<Platform: RawPointerProvider>(
+    object_name: usize,
+    object_attributes: &ObjectAttributes,
+) -> Result<Option<EventName>, NtStatus> {
+    if object_name == 0 {
+        if !object_attributes.root_directory.is_null() {
+            return Err(NtStatus::OBJECT_NAME_INVALID);
+        }
+        return Ok(None);
+    }
+    if !object_attributes.root_directory.is_null() {
+        return Err(NtStatus::OBJECT_PATH_NOT_FOUND);
+    }
+
+    let unicode_string = ConstPtr::<Platform, UnicodeString>::from_usize(object_name)
+        .read_at_offset(0)
+        .ok_or(NtStatus::ACCESS_VIOLATION)?;
+    if unicode_string.length == 0 || !unicode_string.length.is_multiple_of(2) {
+        return Err(NtStatus::OBJECT_NAME_INVALID);
+    }
+    if unicode_string.buffer == 0 {
+        return Err(NtStatus::ACCESS_VIOLATION);
+    }
+    let mut key = unicode_string.read_string::<Platform>()?;
+    if key.is_empty() {
+        return Err(NtStatus::OBJECT_NAME_INVALID);
+    }
+    if object_attributes.attributes & OBJ_CASE_INSENSITIVE != 0 {
+        key = key.to_ascii_lowercase();
+    }
+    Ok(Some(EventName { key }))
+}
+
+fn read_event_object_attributes<Platform: RawPointerProvider>(
+    object_attributes: Option<ConstPtr<Platform, ObjectAttributes>>,
+    require_name: bool,
+) -> Result<(Option<ObjectAttributes>, Option<EventName>), NtStatus> {
+    let Some(object_attributes_ptr) = object_attributes else {
+        if require_name {
+            return Err(NtStatus::INVALID_PARAMETER);
+        }
+        return Ok((None, None));
+    };
+    let object_attributes = read_object_attributes::<Platform>(object_attributes_ptr)?;
+    if object_attributes.attributes & OBJ_OPENLINK != 0 {
+        return Err(NtStatus::INVALID_PARAMETER);
+    }
+    let event_name =
+        read_event_name::<Platform>(object_attributes.object_name, &object_attributes)?;
+    if require_name && event_name.is_none() {
+        return Err(NtStatus::OBJECT_NAME_INVALID);
+    }
+    Ok((Some(object_attributes), event_name))
+}
+
+impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
+    fn event_entry(
+        &self,
+        handle: Handle,
+    ) -> Result<litebox::fd::EntryHandle<Platform, EventSubsystem<Platform>>, NtStatus> {
+        raw_handle_entry::<Platform, EventSubsystem<Platform>>(
+            &self.global.litebox,
+            &self.process.handles,
+            handle,
+        )
+        .ok_or(NtStatus::INVALID_HANDLE)
+    }
+
+    fn insert_event_handle(
+        &self,
+        event: Arc<EventObject<Platform>>,
+        granted_access: EventAccess,
+    ) -> Result<Handle, NtStatus> {
+        let typed = self
+            .global
+            .litebox
+            .descriptor_table_mut()
+            .insert::<EventSubsystem<Platform>>(EventHandleObject {
+                event,
+                granted_access,
+            });
+        insert_raw_handle::<Platform, EventSubsystem<Platform>>(
+            &self.global.litebox,
+            &self.process.handles,
+            typed,
+            drop,
+        )
+    }
+
+    pub(crate) fn close_event_handle(&self, handle: Handle) {
+        remove_raw_handle::<Platform, EventSubsystem<Platform>>(
+            &self.global.litebox,
+            &self.process.handles,
+            handle,
+            drop,
+        );
+    }
+
+    pub(crate) fn close_event(event: EventHandleObject<Platform>) {
+        drop(event);
+    }
+
+    pub(crate) fn sys_nt_create_event(
+        &self,
+        event_handle: MutPtr<Platform, Handle>,
+        desired_access: u32,
+        object_attributes: Option<ConstPtr<Platform, ObjectAttributes>>,
+        event_type: u32,
+        initial_state: u8,
+    ) -> NtStatus {
+        let Ok(event_type) = EventType::from_raw(event_type) else {
+            return NtStatus::INVALID_PARAMETER;
+        };
+        if let Err(status) = probe_guest_output_preserving_value::<Platform, _>(event_handle) {
+            return status;
+        }
+
+        let (object_attributes, event_name) =
+            match read_event_object_attributes::<Platform>(object_attributes, false) {
+                Ok(value) => value,
+                Err(status) => return status,
+            };
+        let granted_access = EventAccess::from_desired_access(desired_access);
+
+        if let Some(event_name) = event_name {
+            let existing = {
+                let mut namespace = self.process.event_namespace.write();
+                if let Some(event) = namespace.get(&event_name.key).and_then(Weak::upgrade) {
+                    Some(event)
+                } else {
+                    namespace.remove(&event_name.key);
+                    None
+                }
+            };
+            if let Some(event) = existing {
+                let Some(object_attributes) = object_attributes else {
+                    return NtStatus::INVALID_PARAMETER;
+                };
+                if object_attributes.attributes & OBJ_OPENIF == 0 {
+                    return NtStatus::OBJECT_NAME_COLLISION;
+                }
+                let Ok(handle) = self.insert_event_handle(event, granted_access) else {
+                    return NtStatus::QUOTA_EXCEEDED;
+                };
+                if event_handle.write_at_offset(0, handle).is_none() {
+                    self.close_event_handle(handle);
+                    return NtStatus::ACCESS_VIOLATION;
+                }
+                return NtStatus::OBJECT_NAME_EXISTS;
+            }
+
+            let event = Arc::new(EventObject::new(event_type, initial_state != 0));
+            let Ok(handle) = self.insert_event_handle(event.clone(), granted_access) else {
+                return NtStatus::QUOTA_EXCEEDED;
+            };
+            {
+                let mut namespace = self.process.event_namespace.write();
+                namespace.insert(event_name.key, Arc::downgrade(&event));
+            }
+            if event_handle.write_at_offset(0, handle).is_none() {
+                self.close_event_handle(handle);
+                return NtStatus::ACCESS_VIOLATION;
+            }
+            return NtStatus::SUCCESS;
+        }
+
+        let event = Arc::new(EventObject::new(event_type, initial_state != 0));
+        let Ok(handle) = self.insert_event_handle(event, granted_access) else {
+            return NtStatus::QUOTA_EXCEEDED;
+        };
+        if event_handle.write_at_offset(0, handle).is_none() {
+            self.close_event_handle(handle);
+            return NtStatus::ACCESS_VIOLATION;
+        }
+        NtStatus::SUCCESS
+    }
+
+    pub(crate) fn sys_nt_open_event(
+        &self,
+        event_handle: MutPtr<Platform, Handle>,
+        desired_access: u32,
+        object_attributes: Option<ConstPtr<Platform, ObjectAttributes>>,
+    ) -> NtStatus {
+        if let Err(status) = probe_guest_output_preserving_value::<Platform, _>(event_handle) {
+            return status;
+        }
+        let event_name = match read_event_object_attributes::<Platform>(object_attributes, true) {
+            Ok((_, Some(event_name))) => event_name,
+            Ok((_, None)) => return NtStatus::OBJECT_NAME_INVALID,
+            Err(status) => return status,
+        };
+        let event = {
+            let mut namespace = self.process.event_namespace.write();
+            if let Some(event) = namespace.get(&event_name.key).and_then(Weak::upgrade) {
+                event
+            } else {
+                namespace.remove(&event_name.key);
+                return NtStatus::OBJECT_NAME_NOT_FOUND;
+            }
+        };
+
+        let Ok(handle) =
+            self.insert_event_handle(event, EventAccess::from_desired_access(desired_access))
+        else {
+            return NtStatus::QUOTA_EXCEEDED;
+        };
+        if event_handle.write_at_offset(0, handle).is_none() {
+            self.close_event_handle(handle);
+            return NtStatus::ACCESS_VIOLATION;
+        }
+        NtStatus::SUCCESS
+    }
+
+    pub(crate) fn sys_nt_set_event(
+        &self,
+        event_handle: Handle,
+        previous_state: Option<MutPtr<Platform, i32>>,
+    ) -> NtStatus {
+        if let Some(previous_state) = previous_state
+            && let Err(status) = probe_guest_output_preserving_value::<Platform, _>(previous_state)
+        {
+            return status;
+        }
+
+        self.modify_event(event_handle, previous_state, EventObject::set)
+    }
+
+    pub(crate) fn sys_nt_reset_event(
+        &self,
+        event_handle: Handle,
+        previous_state: Option<MutPtr<Platform, i32>>,
+    ) -> NtStatus {
+        if let Some(previous_state) = previous_state
+            && let Err(status) = probe_guest_output_preserving_value::<Platform, _>(previous_state)
+        {
+            return status;
+        }
+
+        self.modify_event(event_handle, previous_state, EventObject::reset)
+    }
+
+    pub(crate) fn sys_nt_clear_event(&self, event_handle: Handle) -> NtStatus {
+        let Ok(entry) = self.event_entry(event_handle) else {
+            return NtStatus::INVALID_HANDLE;
+        };
+        entry
+            .with_entry(|entry| {
+                entry
+                    .granted_access
+                    .require(EventAccess::MODIFY_STATE)
+                    .map(|()| entry.event.clear())
+            })
+            .map_or_else(|status| status, |()| NtStatus::SUCCESS)
+    }
+
+    pub(crate) fn sys_nt_pulse_event(
+        &self,
+        event_handle: Handle,
+        previous_state: Option<MutPtr<Platform, i32>>,
+    ) -> NtStatus {
+        if let Some(previous_state) = previous_state
+            && let Err(status) = probe_guest_output_preserving_value::<Platform, _>(previous_state)
+        {
+            return status;
+        }
+
+        self.modify_event(event_handle, previous_state, EventObject::pulse)
+    }
+
+    pub(crate) fn sys_nt_query_event(
+        &self,
+        event_handle: Handle,
+        event_information_class: u32,
+        event_information: MutPtr<Platform, EventBasicInformation>,
+        event_information_length: u32,
+        return_length: Option<MutPtr<Platform, u32>>,
+    ) -> NtStatus {
+        let Ok(EventInformationClass::Basic) =
+            EventInformationClass::from_raw(event_information_class)
+        else {
+            return NtStatus::INVALID_INFO_CLASS;
+        };
+        if event_information_length as usize != size_of::<EventBasicInformation>() {
+            return NtStatus::INFO_LENGTH_MISMATCH;
+        }
+        if let Err(status) = probe_guest_output_preserving_value::<Platform, _>(event_information) {
+            return status;
+        }
+        if let Some(return_length) = return_length
+            && let Err(status) = probe_guest_output_preserving_value::<Platform, _>(return_length)
+        {
+            return status;
+        }
+
+        let Ok(entry) = self.event_entry(event_handle) else {
+            return NtStatus::INVALID_HANDLE;
+        };
+        let query = entry.with_entry(|entry| {
+            entry
+                .granted_access
+                .require(EventAccess::QUERY_STATE)
+                .map(|()| entry.event.query())
+        });
+        let info = match query {
+            Ok(info) => info,
+            Err(status) => return status,
+        };
+        if event_information.write_at_offset(0, info).is_none() {
+            return NtStatus::ACCESS_VIOLATION;
+        }
+        if let Some(return_length) = return_length
+            && return_length
+                .write_at_offset(0, EVENT_BASIC_INFORMATION_SIZE_U32)
+                .is_none()
+        {
+            return NtStatus::ACCESS_VIOLATION;
+        }
+        NtStatus::SUCCESS
+    }
+
+    fn modify_event(
+        &self,
+        event_handle: Handle,
+        previous_state: Option<MutPtr<Platform, i32>>,
+        op: impl FnOnce(&EventObject<Platform>) -> i32,
+    ) -> NtStatus {
+        let Ok(entry) = self.event_entry(event_handle) else {
+            return NtStatus::INVALID_HANDLE;
+        };
+        let previous = entry.with_entry(|entry| {
+            entry
+                .granted_access
+                .require(EventAccess::MODIFY_STATE)
+                .map(|()| op(&entry.event))
+        });
+        let previous = match previous {
+            Ok(previous) => previous,
+            Err(status) => return status,
+        };
+        if let Some(previous_state) = previous_state
+            && previous_state.write_at_offset(0, previous).is_none()
+        {
+            return NtStatus::ACCESS_VIOLATION;
+        }
+        NtStatus::SUCCESS
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec::Vec;
+    use core::mem::size_of;
+
+    use litebox_common_windows::nt_status::NtStatus;
+
+    use super::*;
+    use crate::nt_types::{ObjectAttributes, UnicodeString};
+    use crate::tests::{const_ptr, mut_ptr, test_task};
+
+    const EVENT_QUERY_STATE: u32 = 0x0001;
+    const EVENT_MODIFY_STATE: u32 = 0x0002;
+    const EVENT_ALL_ACCESS: u32 = 0x001f_0003;
+
+    fn event_basic_information_size() -> u32 {
+        u32::try_from(size_of::<EventBasicInformation>())
+            .expect("EVENT_BASIC_INFORMATION fits in ULONG")
+    }
+
+    fn object_attributes_size() -> u32 {
+        u32::try_from(size_of::<ObjectAttributes>()).expect("OBJECT_ATTRIBUTES fits in ULONG")
+    }
+
+    fn unicode_byte_len(units: &[u16]) -> u16 {
+        u16::try_from(core::mem::size_of_val(units)).expect("test name fits in USHORT")
+    }
+
+    #[test]
+    fn create_rejects_invalid_event_type() {
+        let task = test_task();
+        let mut handle = Handle::from_raw(usize::MAX);
+
+        assert_eq!(
+            task.sys_nt_create_event(mut_ptr(&mut handle), EVENT_ALL_ACCESS, None, 2, 0),
+            NtStatus::INVALID_PARAMETER
+        );
+        assert_eq!(handle, Handle::from_raw(usize::MAX));
+    }
+
+    #[test]
+    fn set_reset_clear_pulse_return_previous_state() {
+        let task = test_task();
+        let mut handle = Handle::default();
+        assert_eq!(
+            task.sys_nt_create_event(
+                mut_ptr(&mut handle),
+                EVENT_ALL_ACCESS,
+                None,
+                EventType::Notification.as_raw(),
+                0,
+            ),
+            NtStatus::SUCCESS
+        );
+
+        let mut previous = -1;
+        assert_eq!(
+            task.sys_nt_set_event(handle, Some(mut_ptr(&mut previous))),
+            NtStatus::SUCCESS
+        );
+        assert_eq!(previous, 0);
+        assert_eq!(
+            task.sys_nt_set_event(handle, Some(mut_ptr(&mut previous))),
+            NtStatus::SUCCESS
+        );
+        assert_eq!(previous, 1);
+        assert_eq!(
+            task.sys_nt_reset_event(handle, Some(mut_ptr(&mut previous))),
+            NtStatus::SUCCESS
+        );
+        assert_eq!(previous, 1);
+        assert_eq!(
+            task.sys_nt_reset_event(handle, Some(mut_ptr(&mut previous))),
+            NtStatus::SUCCESS
+        );
+        assert_eq!(previous, 0);
+
+        assert_eq!(task.sys_nt_set_event(handle, None), NtStatus::SUCCESS);
+        assert_eq!(task.sys_nt_clear_event(handle), NtStatus::SUCCESS);
+        assert_eq!(
+            task.sys_nt_pulse_event(handle, Some(mut_ptr(&mut previous))),
+            NtStatus::SUCCESS
+        );
+        assert_eq!(previous, 0);
+    }
+
+    #[test]
+    fn query_event_reports_type_state_and_return_length() {
+        let task = test_task();
+        let mut handle = Handle::default();
+        assert_eq!(
+            task.sys_nt_create_event(
+                mut_ptr(&mut handle),
+                EVENT_ALL_ACCESS,
+                None,
+                EventType::Synchronization.as_raw(),
+                1,
+            ),
+            NtStatus::SUCCESS
+        );
+
+        let mut info = EventBasicInformation {
+            event_type: 99,
+            event_state: -1,
+        };
+        let mut return_length = 0;
+        assert_eq!(
+            task.sys_nt_query_event(
+                handle,
+                EventInformationClass::Basic as u32,
+                mut_ptr(&mut info),
+                event_basic_information_size(),
+                Some(mut_ptr(&mut return_length)),
+            ),
+            NtStatus::SUCCESS
+        );
+        assert_eq!(
+            info,
+            EventBasicInformation {
+                event_type: EventType::Synchronization.as_raw(),
+                event_state: 1,
+            }
+        );
+        assert_eq!(return_length, event_basic_information_size());
+    }
+
+    #[test]
+    fn query_validates_class_and_exact_length() {
+        let task = test_task();
+        let mut handle = Handle::default();
+        assert_eq!(
+            task.sys_nt_create_event(
+                mut_ptr(&mut handle),
+                EVENT_ALL_ACCESS,
+                None,
+                EventType::Notification.as_raw(),
+                0,
+            ),
+            NtStatus::SUCCESS
+        );
+        let mut info = EventBasicInformation {
+            event_type: 0,
+            event_state: 0,
+        };
+
+        assert_eq!(
+            task.sys_nt_query_event(
+                handle,
+                1,
+                mut_ptr(&mut info),
+                event_basic_information_size(),
+                None,
+            ),
+            NtStatus::INVALID_INFO_CLASS
+        );
+        assert_eq!(
+            task.sys_nt_query_event(
+                handle,
+                EventInformationClass::Basic as u32,
+                mut_ptr(&mut info),
+                event_basic_information_size() - 1,
+                None,
+            ),
+            NtStatus::INFO_LENGTH_MISMATCH
+        );
+    }
+
+    #[test]
+    fn handle_access_is_enforced() {
+        let task = test_task();
+        let mut query_only = Handle::default();
+        assert_eq!(
+            task.sys_nt_create_event(
+                mut_ptr(&mut query_only),
+                EVENT_QUERY_STATE,
+                None,
+                EventType::Notification.as_raw(),
+                0,
+            ),
+            NtStatus::SUCCESS
+        );
+        let mut modify_only = Handle::default();
+        assert_eq!(
+            task.sys_nt_create_event(
+                mut_ptr(&mut modify_only),
+                EVENT_MODIFY_STATE,
+                None,
+                EventType::Notification.as_raw(),
+                0,
+            ),
+            NtStatus::SUCCESS
+        );
+
+        assert_eq!(
+            task.sys_nt_set_event(query_only, None),
+            NtStatus::ACCESS_DENIED
+        );
+
+        let mut info = EventBasicInformation {
+            event_type: 0,
+            event_state: 0,
+        };
+        assert_eq!(
+            task.sys_nt_query_event(
+                modify_only,
+                EventInformationClass::Basic as u32,
+                mut_ptr(&mut info),
+                event_basic_information_size(),
+                None,
+            ),
+            NtStatus::ACCESS_DENIED
+        );
+    }
+
+    #[test]
+    fn named_event_open_shares_state() {
+        let task = test_task();
+        let mut name_units: Vec<u16> = "\\BaseNamedObjects\\LiteBoxEvent".encode_utf16().collect();
+        let name = UnicodeString {
+            length: unicode_byte_len(&name_units),
+            maximum_length: unicode_byte_len(&name_units),
+            padding_0: [0; 4],
+            buffer: name_units.as_mut_ptr() as usize,
+        };
+        let attrs = ObjectAttributes {
+            length: object_attributes_size(),
+            root_directory: Handle::default(),
+            object_name: core::ptr::from_ref(&name) as usize,
+            attributes: OBJ_CASE_INSENSITIVE,
+            security_descriptor: 0,
+            security_quality_of_service: 0,
+        };
+
+        let mut created = Handle::default();
+        assert_eq!(
+            task.sys_nt_create_event(
+                mut_ptr(&mut created),
+                EVENT_ALL_ACCESS,
+                Some(const_ptr(&attrs)),
+                EventType::Notification.as_raw(),
+                0,
+            ),
+            NtStatus::SUCCESS
+        );
+
+        let mut opened = Handle::default();
+        assert_eq!(
+            task.sys_nt_open_event(
+                mut_ptr(&mut opened),
+                EVENT_ALL_ACCESS,
+                Some(const_ptr(&attrs))
+            ),
+            NtStatus::SUCCESS
+        );
+        assert_ne!(created, opened);
+
+        assert_eq!(task.sys_nt_set_event(created, None), NtStatus::SUCCESS);
+        let mut info = EventBasicInformation {
+            event_type: 0,
+            event_state: 0,
+        };
+        assert_eq!(
+            task.sys_nt_query_event(
+                opened,
+                EventInformationClass::Basic as u32,
+                mut_ptr(&mut info),
+                event_basic_information_size(),
+                None,
+            ),
+            NtStatus::SUCCESS
+        );
+        assert_eq!(info.event_state, 1);
+    }
+
+    #[test]
+    fn open_event_requires_existing_name() {
+        let task = test_task();
+        let mut handle = Handle::default();
+        assert_eq!(
+            task.sys_nt_open_event(mut_ptr(&mut handle), EVENT_ALL_ACCESS, None),
+            NtStatus::INVALID_PARAMETER
+        );
+
+        let unnamed_attrs = ObjectAttributes {
+            length: object_attributes_size(),
+            root_directory: Handle::default(),
+            object_name: 0,
+            attributes: 0,
+            security_descriptor: 0,
+            security_quality_of_service: 0,
+        };
+        assert_eq!(
+            task.sys_nt_open_event(
+                mut_ptr(&mut handle),
+                EVENT_ALL_ACCESS,
+                Some(const_ptr(&unnamed_attrs)),
+            ),
+            NtStatus::OBJECT_NAME_INVALID
+        );
+    }
+
+    #[test]
+    fn create_openif_existing_named_event_returns_name_exists() {
+        let task = test_task();
+        let mut name_units: Vec<u16> = "\\BaseNamedObjects\\LiteBoxOpenIf".encode_utf16().collect();
+        let name = UnicodeString {
+            length: unicode_byte_len(&name_units),
+            maximum_length: unicode_byte_len(&name_units),
+            padding_0: [0; 4],
+            buffer: name_units.as_mut_ptr() as usize,
+        };
+        let attrs = ObjectAttributes {
+            length: object_attributes_size(),
+            root_directory: Handle::default(),
+            object_name: core::ptr::from_ref(&name) as usize,
+            attributes: OBJ_CASE_INSENSITIVE,
+            security_descriptor: 0,
+            security_quality_of_service: 0,
+        };
+        let openif_attrs = ObjectAttributes {
+            attributes: OBJ_CASE_INSENSITIVE | OBJ_OPENIF,
+            ..attrs
+        };
+
+        let mut first = Handle::default();
+        assert_eq!(
+            task.sys_nt_create_event(
+                mut_ptr(&mut first),
+                EVENT_ALL_ACCESS,
+                Some(const_ptr(&attrs)),
+                EventType::Notification.as_raw(),
+                0,
+            ),
+            NtStatus::SUCCESS
+        );
+        let mut collision = Handle::default();
+        assert_eq!(
+            task.sys_nt_create_event(
+                mut_ptr(&mut collision),
+                EVENT_ALL_ACCESS,
+                Some(const_ptr(&attrs)),
+                EventType::Notification.as_raw(),
+                0,
+            ),
+            NtStatus::OBJECT_NAME_COLLISION
+        );
+        assert_eq!(
+            task.sys_nt_create_event(
+                mut_ptr(&mut collision),
+                EVENT_MODIFY_STATE,
+                Some(const_ptr(&openif_attrs)),
+                EventType::Notification.as_raw(),
+                0,
+            ),
+            NtStatus::OBJECT_NAME_EXISTS
+        );
+        assert_eq!(task.sys_nt_set_event(collision, None), NtStatus::SUCCESS);
+    }
+
+    #[test]
+    fn close_invalidates_event_handle() {
+        let task = test_task();
+        let mut handle = Handle::default();
+        assert_eq!(
+            task.sys_nt_create_event(
+                mut_ptr(&mut handle),
+                EVENT_ALL_ACCESS,
+                None,
+                EventType::Notification.as_raw(),
+                0,
+            ),
+            NtStatus::SUCCESS
+        );
+        assert_eq!(task.sys_nt_close(handle), NtStatus::SUCCESS);
+        assert_eq!(
+            task.sys_nt_set_event(handle, None),
+            NtStatus::INVALID_HANDLE
+        );
+    }
+
+    #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+    #[test]
+    fn host_create_query_reset_fidelity() {
+        use core::ffi::c_void;
+
+        unsafe extern "system" {
+            fn NtCreateEvent(
+                handle: *mut *mut c_void,
+                access: u32,
+                attributes: *const c_void,
+                event_type: u32,
+                initial_state: u8,
+            ) -> i32;
+            fn NtQueryEvent(
+                handle: *mut c_void,
+                event_information_class: u32,
+                event_information: *mut EventBasicInformation,
+                event_information_length: u32,
+                return_length: *mut u32,
+            ) -> i32;
+            fn NtResetEvent(handle: *mut c_void, previous_state: *mut i32) -> i32;
+            fn NtClose(handle: *mut c_void) -> i32;
+        }
+
+        let mut host_handle = core::ptr::null_mut();
+        let mut host_info = EventBasicInformation {
+            event_type: 0,
+            event_state: 0,
+        };
+        let mut host_length = 0;
+        let mut host_previous = 0;
+        // SAFETY: The imported ntdll routines are called with valid output pointers, a null
+        // object-attributes pointer accepted by NtCreateEvent, and the created host handle is
+        // closed before leaving the test.
+        unsafe {
+            assert_eq!(
+                NtCreateEvent(
+                    &raw mut host_handle,
+                    EVENT_ALL_ACCESS,
+                    core::ptr::null(),
+                    EventType::Notification.as_raw(),
+                    1,
+                ),
+                NtStatus::SUCCESS.as_raw()
+            );
+            assert_eq!(
+                NtQueryEvent(
+                    host_handle,
+                    EventInformationClass::Basic as u32,
+                    &raw mut host_info,
+                    event_basic_information_size(),
+                    &raw mut host_length,
+                ),
+                NtStatus::SUCCESS.as_raw()
+            );
+            assert_eq!(
+                NtResetEvent(host_handle, &raw mut host_previous),
+                NtStatus::SUCCESS.as_raw()
+            );
+            assert_eq!(NtClose(host_handle), NtStatus::SUCCESS.as_raw());
+        }
+
+        let task = test_task();
+        let mut shim_handle = Handle::default();
+        assert_eq!(
+            task.sys_nt_create_event(
+                mut_ptr(&mut shim_handle),
+                EVENT_ALL_ACCESS,
+                None,
+                EventType::Notification.as_raw(),
+                1,
+            ),
+            NtStatus::SUCCESS
+        );
+        let mut shim_info = EventBasicInformation {
+            event_type: 0,
+            event_state: 0,
+        };
+        let mut shim_length = 0;
+        let mut shim_previous = 0;
+        assert_eq!(
+            task.sys_nt_query_event(
+                shim_handle,
+                EventInformationClass::Basic as u32,
+                mut_ptr(&mut shim_info),
+                event_basic_information_size(),
+                Some(mut_ptr(&mut shim_length)),
+            ),
+            NtStatus::SUCCESS
+        );
+        assert_eq!(
+            task.sys_nt_reset_event(shim_handle, Some(mut_ptr(&mut shim_previous))),
+            NtStatus::SUCCESS
+        );
+
+        assert_eq!(shim_info, host_info);
+        assert_eq!(shim_length, host_length);
+        assert_eq!(shim_previous, host_previous);
+    }
+}

--- a/litebox_shim_windows/src/syscalls/event.rs
+++ b/litebox_shim_windows/src/syscalls/event.rs
@@ -8,6 +8,7 @@ use alloc::sync::{Arc, Weak};
 use core::marker::PhantomData;
 use core::mem::size_of;
 
+use int_enum::IntEnum;
 use litebox::event::{Events, IOPollable, observer::Observer, polling::Pollee};
 use litebox::fd::{FdEnabledSubsystem, FdEnabledSubsystemEntry};
 use litebox::platform::{RawConstPointer as _, RawMutPointer as _, RawPointerProvider};
@@ -27,24 +28,10 @@ const OBJ_OPENIF: u32 = 0x0000_0080;
 const OBJ_OPENLINK: u32 = 0x0000_0100;
 
 #[repr(u32)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, IntEnum, PartialEq)]
 pub(crate) enum EventType {
     Notification = 0,
     Synchronization = 1,
-}
-
-impl EventType {
-    fn from_raw(raw: u32) -> Result<Self, NtStatus> {
-        match raw {
-            0 => Ok(Self::Notification),
-            1 => Ok(Self::Synchronization),
-            _ => Err(NtStatus::INVALID_PARAMETER),
-        }
-    }
-
-    const fn as_raw(self) -> u32 {
-        self as u32
-    }
 }
 
 #[repr(C)]
@@ -55,18 +42,9 @@ pub(crate) struct EventBasicInformation {
 }
 
 #[repr(u32)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, IntEnum, PartialEq)]
 enum EventInformationClass {
     Basic = 0,
-}
-
-impl EventInformationClass {
-    fn from_raw(raw: u32) -> Result<Self, NtStatus> {
-        match raw {
-            0 => Ok(Self::Basic),
-            _ => Err(NtStatus::INVALID_INFO_CLASS),
-        }
-    }
 }
 
 bitflags::bitflags! {
@@ -155,21 +133,31 @@ impl<Platform: crate::ShimPlatform> EventObject<Platform> {
         previous
     }
 
+    fn set_boost_priority(&self) -> Result<i32, NtStatus> {
+        if self.event_type != EventType::Synchronization {
+            return Err(NtStatus::OBJECT_TYPE_MISMATCH);
+        }
+        Ok(self.set())
+    }
+
     fn reset(&self) -> i32 {
         self.replace_state(false)
     }
 
-    fn clear(&self) {
-        *self.signaled.lock() = false;
+    fn clear(&self) -> i32 {
+        self.replace_state(false)
     }
 
     fn pulse(&self) -> i32 {
-        self.replace_state(false)
+        let previous = self.replace_state(true);
+        self.pollee.notify_observers(Events::IN);
+        self.replace_state(false);
+        previous
     }
 
     fn query(&self) -> EventBasicInformation {
         EventBasicInformation {
-            event_type: self.event_type.as_raw(),
+            event_type: self.event_type as u32,
             event_state: i32::from(*self.signaled.lock()),
         }
     }
@@ -314,7 +302,7 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         event_type: u32,
         initial_state: u8,
     ) -> NtStatus {
-        let Ok(event_type) = EventType::from_raw(event_type) else {
+        let Ok(event_type) = EventType::try_from(event_type) else {
             return NtStatus::INVALID_PARAMETER;
         };
         if let Err(status) = probe_guest_output_preserving_value::<Platform, _>(event_handle) {
@@ -329,15 +317,14 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         let granted_access = EventAccess::from_desired_access(desired_access);
 
         if let Some(event_name) = event_name {
-            let existing = {
-                let mut namespace = self.process.event_namespace.write();
+            let mut namespace = self.process.event_namespace.write();
+            let existing =
                 if let Some(event) = namespace.get(&event_name.key).and_then(Weak::upgrade) {
                     Some(event)
                 } else {
                     namespace.remove(&event_name.key);
                     None
-                }
-            };
+                };
             if let Some(event) = existing {
                 let Some(object_attributes) = object_attributes else {
                     return NtStatus::INVALID_PARAMETER;
@@ -359,14 +346,11 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             let Ok(handle) = self.insert_event_handle(event.clone(), granted_access) else {
                 return NtStatus::QUOTA_EXCEEDED;
             };
-            {
-                let mut namespace = self.process.event_namespace.write();
-                namespace.insert(event_name.key, Arc::downgrade(&event));
-            }
             if event_handle.write_at_offset(0, handle).is_none() {
                 self.close_event_handle(handle);
                 return NtStatus::ACCESS_VIOLATION;
             }
+            namespace.insert(event_name.key, Arc::downgrade(&event));
             return NtStatus::SUCCESS;
         }
 
@@ -428,7 +412,10 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             return status;
         }
 
-        self.modify_event(event_handle, previous_state, EventObject::set)
+        match self.modify_event(event_handle, previous_state, |event| Ok(event.set())) {
+            Ok(()) => NtStatus::SUCCESS,
+            Err(status) => status,
+        }
     }
 
     pub(crate) fn sys_nt_reset_event(
@@ -442,21 +429,17 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             return status;
         }
 
-        self.modify_event(event_handle, previous_state, EventObject::reset)
+        match self.modify_event(event_handle, previous_state, |event| Ok(event.reset())) {
+            Ok(()) => NtStatus::SUCCESS,
+            Err(status) => status,
+        }
     }
 
     pub(crate) fn sys_nt_clear_event(&self, event_handle: Handle) -> NtStatus {
-        let Ok(entry) = self.event_entry(event_handle) else {
-            return NtStatus::INVALID_HANDLE;
-        };
-        entry
-            .with_entry(|entry| {
-                entry
-                    .granted_access
-                    .require(EventAccess::MODIFY_STATE)
-                    .map(|()| entry.event.clear())
-            })
-            .map_or_else(|status| status, |()| NtStatus::SUCCESS)
+        match self.modify_event(event_handle, None, |event| Ok(event.clear())) {
+            Ok(()) => NtStatus::SUCCESS,
+            Err(status) => status,
+        }
     }
 
     pub(crate) fn sys_nt_pulse_event(
@@ -470,7 +453,17 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             return status;
         }
 
-        self.modify_event(event_handle, previous_state, EventObject::pulse)
+        match self.modify_event(event_handle, previous_state, |event| Ok(event.pulse())) {
+            Ok(()) => NtStatus::SUCCESS,
+            Err(status) => status,
+        }
+    }
+
+    pub(crate) fn sys_nt_set_event_boost_priority(&self, event_handle: Handle) -> NtStatus {
+        match self.modify_event(event_handle, None, EventObject::set_boost_priority) {
+            Ok(()) => NtStatus::SUCCESS,
+            Err(status) => status,
+        }
     }
 
     pub(crate) fn sys_nt_query_event(
@@ -482,7 +475,7 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         return_length: Option<MutPtr<Platform, u32>>,
     ) -> NtStatus {
         let Ok(EventInformationClass::Basic) =
-            EventInformationClass::from_raw(event_information_class)
+            EventInformationClass::try_from(event_information_class)
         else {
             return NtStatus::INVALID_INFO_CLASS;
         };
@@ -528,27 +521,19 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         &self,
         event_handle: Handle,
         previous_state: Option<MutPtr<Platform, i32>>,
-        op: impl FnOnce(&EventObject<Platform>) -> i32,
-    ) -> NtStatus {
-        let Ok(entry) = self.event_entry(event_handle) else {
-            return NtStatus::INVALID_HANDLE;
-        };
+        op: impl FnOnce(&EventObject<Platform>) -> Result<i32, NtStatus>,
+    ) -> Result<(), NtStatus> {
+        let entry = self.event_entry(event_handle)?;
         let previous = entry.with_entry(|entry| {
-            entry
-                .granted_access
-                .require(EventAccess::MODIFY_STATE)
-                .map(|()| op(&entry.event))
-        });
-        let previous = match previous {
-            Ok(previous) => previous,
-            Err(status) => return status,
-        };
+            entry.granted_access.require(EventAccess::MODIFY_STATE)?;
+            op(&entry.event)
+        })?;
         if let Some(previous_state) = previous_state
             && previous_state.write_at_offset(0, previous).is_none()
         {
-            return NtStatus::ACCESS_VIOLATION;
+            return Err(NtStatus::ACCESS_VIOLATION);
         }
-        NtStatus::SUCCESS
+        Ok(())
     }
 }
 
@@ -560,8 +545,8 @@ mod tests {
     use litebox_common_windows::nt_status::NtStatus;
 
     use super::*;
-    use crate::nt_types::{ObjectAttributes, UnicodeString};
-    use crate::tests::{const_ptr, mut_ptr, test_task};
+    use crate::nt_types::ObjectAttributes;
+    use crate::tests::{const_ptr, mut_ptr, object_attributes, test_task, unicode_string};
 
     const EVENT_QUERY_STATE: u32 = 0x0001;
     const EVENT_MODIFY_STATE: u32 = 0x0002;
@@ -574,10 +559,6 @@ mod tests {
 
     fn object_attributes_size() -> u32 {
         u32::try_from(size_of::<ObjectAttributes>()).expect("OBJECT_ATTRIBUTES fits in ULONG")
-    }
-
-    fn unicode_byte_len(units: &[u16]) -> u16 {
-        u16::try_from(core::mem::size_of_val(units)).expect("test name fits in USHORT")
     }
 
     #[test]
@@ -601,7 +582,7 @@ mod tests {
                 mut_ptr(&mut handle),
                 EVENT_ALL_ACCESS,
                 None,
-                EventType::Notification.as_raw(),
+                EventType::Notification as u32,
                 0,
             ),
             NtStatus::SUCCESS
@@ -647,7 +628,7 @@ mod tests {
                 mut_ptr(&mut handle),
                 EVENT_ALL_ACCESS,
                 None,
-                EventType::Synchronization.as_raw(),
+                EventType::Synchronization as u32,
                 1,
             ),
             NtStatus::SUCCESS
@@ -671,7 +652,7 @@ mod tests {
         assert_eq!(
             info,
             EventBasicInformation {
-                event_type: EventType::Synchronization.as_raw(),
+                event_type: EventType::Synchronization as u32,
                 event_state: 1,
             }
         );
@@ -687,7 +668,7 @@ mod tests {
                 mut_ptr(&mut handle),
                 EVENT_ALL_ACCESS,
                 None,
-                EventType::Notification.as_raw(),
+                EventType::Notification as u32,
                 0,
             ),
             NtStatus::SUCCESS
@@ -728,7 +709,7 @@ mod tests {
                 mut_ptr(&mut query_only),
                 EVENT_QUERY_STATE,
                 None,
-                EventType::Notification.as_raw(),
+                EventType::Notification as u32,
                 0,
             ),
             NtStatus::SUCCESS
@@ -739,7 +720,7 @@ mod tests {
                 mut_ptr(&mut modify_only),
                 EVENT_MODIFY_STATE,
                 None,
-                EventType::Notification.as_raw(),
+                EventType::Notification as u32,
                 0,
             ),
             NtStatus::SUCCESS
@@ -769,21 +750,9 @@ mod tests {
     #[test]
     fn named_event_open_shares_state() {
         let task = test_task();
-        let mut name_units: Vec<u16> = "\\BaseNamedObjects\\LiteBoxEvent".encode_utf16().collect();
-        let name = UnicodeString {
-            length: unicode_byte_len(&name_units),
-            maximum_length: unicode_byte_len(&name_units),
-            padding_0: [0; 4],
-            buffer: name_units.as_mut_ptr() as usize,
-        };
-        let attrs = ObjectAttributes {
-            length: object_attributes_size(),
-            root_directory: Handle::default(),
-            object_name: core::ptr::from_ref(&name) as usize,
-            attributes: OBJ_CASE_INSENSITIVE,
-            security_descriptor: 0,
-            security_quality_of_service: 0,
-        };
+        let name_units: Vec<u16> = "\\BaseNamedObjects\\LiteBoxEvent".encode_utf16().collect();
+        let name = unicode_string(&name_units);
+        let attrs = object_attributes(&name, OBJ_CASE_INSENSITIVE);
 
         let mut created = Handle::default();
         assert_eq!(
@@ -791,7 +760,7 @@ mod tests {
                 mut_ptr(&mut created),
                 EVENT_ALL_ACCESS,
                 Some(const_ptr(&attrs)),
-                EventType::Notification.as_raw(),
+                EventType::Notification as u32,
                 0,
             ),
             NtStatus::SUCCESS
@@ -856,21 +825,9 @@ mod tests {
     #[test]
     fn create_openif_existing_named_event_returns_name_exists() {
         let task = test_task();
-        let mut name_units: Vec<u16> = "\\BaseNamedObjects\\LiteBoxOpenIf".encode_utf16().collect();
-        let name = UnicodeString {
-            length: unicode_byte_len(&name_units),
-            maximum_length: unicode_byte_len(&name_units),
-            padding_0: [0; 4],
-            buffer: name_units.as_mut_ptr() as usize,
-        };
-        let attrs = ObjectAttributes {
-            length: object_attributes_size(),
-            root_directory: Handle::default(),
-            object_name: core::ptr::from_ref(&name) as usize,
-            attributes: OBJ_CASE_INSENSITIVE,
-            security_descriptor: 0,
-            security_quality_of_service: 0,
-        };
+        let name_units: Vec<u16> = "\\BaseNamedObjects\\LiteBoxOpenIf".encode_utf16().collect();
+        let name = unicode_string(&name_units);
+        let attrs = object_attributes(&name, OBJ_CASE_INSENSITIVE);
         let openif_attrs = ObjectAttributes {
             attributes: OBJ_CASE_INSENSITIVE | OBJ_OPENIF,
             ..attrs
@@ -882,7 +839,7 @@ mod tests {
                 mut_ptr(&mut first),
                 EVENT_ALL_ACCESS,
                 Some(const_ptr(&attrs)),
-                EventType::Notification.as_raw(),
+                EventType::Notification as u32,
                 0,
             ),
             NtStatus::SUCCESS
@@ -893,7 +850,7 @@ mod tests {
                 mut_ptr(&mut collision),
                 EVENT_ALL_ACCESS,
                 Some(const_ptr(&attrs)),
-                EventType::Notification.as_raw(),
+                EventType::Notification as u32,
                 0,
             ),
             NtStatus::OBJECT_NAME_COLLISION
@@ -903,7 +860,7 @@ mod tests {
                 mut_ptr(&mut collision),
                 EVENT_MODIFY_STATE,
                 Some(const_ptr(&openif_attrs)),
-                EventType::Notification.as_raw(),
+                EventType::Notification as u32,
                 0,
             ),
             NtStatus::OBJECT_NAME_EXISTS
@@ -920,7 +877,7 @@ mod tests {
                 mut_ptr(&mut handle),
                 EVENT_ALL_ACCESS,
                 None,
-                EventType::Notification.as_raw(),
+                EventType::Notification as u32,
                 0,
             ),
             NtStatus::SUCCESS
@@ -933,18 +890,30 @@ mod tests {
     }
 
     #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
-    #[test]
-    fn host_create_query_reset_fidelity() {
+    mod host_fidelity {
         use core::ffi::c_void;
 
+        use super::*;
+
+        #[link(name = "ntdll")]
         unsafe extern "system" {
             fn NtCreateEvent(
                 handle: *mut *mut c_void,
                 access: u32,
-                attributes: *const c_void,
+                attributes: *const ObjectAttributes,
                 event_type: u32,
                 initial_state: u8,
             ) -> i32;
+            fn NtOpenEvent(
+                handle: *mut *mut c_void,
+                access: u32,
+                attributes: *const ObjectAttributes,
+            ) -> i32;
+            fn NtSetEvent(handle: *mut c_void, previous_state: *mut i32) -> i32;
+            fn NtResetEvent(handle: *mut c_void, previous_state: *mut i32) -> i32;
+            fn NtClearEvent(handle: *mut c_void) -> i32;
+            fn NtPulseEvent(handle: *mut c_void, previous_state: *mut i32) -> i32;
+            fn NtSetEventBoostPriority(handle: *mut c_void) -> i32;
             fn NtQueryEvent(
                 handle: *mut c_void,
                 event_information_class: u32,
@@ -952,83 +921,278 @@ mod tests {
                 event_information_length: u32,
                 return_length: *mut u32,
             ) -> i32;
-            fn NtResetEvent(handle: *mut c_void, previous_state: *mut i32) -> i32;
             fn NtClose(handle: *mut c_void) -> i32;
         }
 
-        let mut host_handle = core::ptr::null_mut();
-        let mut host_info = EventBasicInformation {
-            event_type: 0,
-            event_state: 0,
-        };
-        let mut host_length = 0;
-        let mut host_previous = 0;
-        // SAFETY: The imported ntdll routines are called with valid output pointers, a null
-        // object-attributes pointer accepted by NtCreateEvent, and the created host handle is
-        // closed before leaving the test.
-        unsafe {
-            assert_eq!(
+        fn assert_status_eq(shim: NtStatus, host: i32) {
+            assert_eq!(shim.as_raw(), host);
+        }
+
+        fn close_host_handle(handle: *mut c_void) {
+            if !handle.is_null() {
+                // SAFETY: The handle was returned by a successful host ntdll call in this test.
+                let status = unsafe { NtClose(handle) };
+                assert_eq!(status, NtStatus::SUCCESS.as_raw());
+            }
+        }
+
+        fn host_query_event(handle: *mut c_void) -> (i32, EventBasicInformation, u32) {
+            let mut info = EventBasicInformation {
+                event_type: 0,
+                event_state: 0,
+            };
+            let mut return_length = 0;
+            // SAFETY: `handle` is a live host event handle and the output pointers reference
+            // stack locals that are valid for the duration of the call.
+            let status = unsafe {
+                NtQueryEvent(
+                    handle,
+                    EventInformationClass::Basic as u32,
+                    &raw mut info,
+                    event_basic_information_size(),
+                    &raw mut return_length,
+                )
+            };
+            (status, info, return_length)
+        }
+
+        fn shim_query_event(
+            task: &Task<crate::tests::TestPlatform, crate::tests::TestFS>,
+            handle: Handle,
+        ) -> (NtStatus, EventBasicInformation, u32) {
+            let mut info = EventBasicInformation {
+                event_type: 0,
+                event_state: 0,
+            };
+            let mut return_length = 0;
+            let status = task.sys_nt_query_event(
+                handle,
+                EventInformationClass::Basic as u32,
+                mut_ptr(&mut info),
+                event_basic_information_size(),
+                Some(mut_ptr(&mut return_length)),
+            );
+            (status, info, return_length)
+        }
+
+        fn assert_queries_match(
+            task: &Task<crate::tests::TestPlatform, crate::tests::TestFS>,
+            host_handle: *mut c_void,
+            shim_handle: Handle,
+        ) {
+            let (host_status, host_info, host_length) = host_query_event(host_handle);
+            let (shim_status, shim_info, shim_length) = shim_query_event(task, shim_handle);
+            assert_status_eq(shim_status, host_status);
+            assert_eq!(shim_info, host_info);
+            assert_eq!(shim_length, host_length);
+        }
+
+        #[test]
+        fn create_query_reset_matches_host_outputs() {
+            let mut host_handle = core::ptr::null_mut();
+            // SAFETY: The output pointer references a live stack local, null object attributes are
+            // accepted by NtCreateEvent, and the handle is closed before the test returns.
+            let host_create_status = unsafe {
                 NtCreateEvent(
                     &raw mut host_handle,
                     EVENT_ALL_ACCESS,
                     core::ptr::null(),
-                    EventType::Notification.as_raw(),
+                    EventType::Notification as u32,
                     1,
-                ),
-                NtStatus::SUCCESS.as_raw()
-            );
-            assert_eq!(
-                NtQueryEvent(
-                    host_handle,
-                    EventInformationClass::Basic as u32,
-                    &raw mut host_info,
-                    event_basic_information_size(),
-                    &raw mut host_length,
-                ),
-                NtStatus::SUCCESS.as_raw()
-            );
-            assert_eq!(
-                NtResetEvent(host_handle, &raw mut host_previous),
-                NtStatus::SUCCESS.as_raw()
-            );
-            assert_eq!(NtClose(host_handle), NtStatus::SUCCESS.as_raw());
-        }
+                )
+            };
+            assert_eq!(host_create_status, NtStatus::SUCCESS.as_raw());
+            let (host_query_status, host_info, host_length) = host_query_event(host_handle);
+            assert_eq!(host_query_status, NtStatus::SUCCESS.as_raw());
+            let mut host_previous = 0;
+            // SAFETY: `host_handle` is a live event handle and `host_previous` is a valid output.
+            let host_reset_status = unsafe { NtResetEvent(host_handle, &raw mut host_previous) };
 
-        let task = test_task();
-        let mut shim_handle = Handle::default();
-        assert_eq!(
-            task.sys_nt_create_event(
+            let task = test_task();
+            let mut shim_handle = Handle::default();
+            let shim_create_status = task.sys_nt_create_event(
                 mut_ptr(&mut shim_handle),
                 EVENT_ALL_ACCESS,
                 None,
-                EventType::Notification.as_raw(),
+                EventType::Notification as u32,
                 1,
-            ),
-            NtStatus::SUCCESS
-        );
-        let mut shim_info = EventBasicInformation {
-            event_type: 0,
-            event_state: 0,
-        };
-        let mut shim_length = 0;
-        let mut shim_previous = 0;
-        assert_eq!(
-            task.sys_nt_query_event(
-                shim_handle,
-                EventInformationClass::Basic as u32,
-                mut_ptr(&mut shim_info),
-                event_basic_information_size(),
-                Some(mut_ptr(&mut shim_length)),
-            ),
-            NtStatus::SUCCESS
-        );
-        assert_eq!(
-            task.sys_nt_reset_event(shim_handle, Some(mut_ptr(&mut shim_previous))),
-            NtStatus::SUCCESS
-        );
+            );
+            assert_status_eq(shim_create_status, host_create_status);
+            let (shim_query_status, shim_info, shim_length) = shim_query_event(&task, shim_handle);
+            assert_status_eq(shim_query_status, host_query_status);
+            let mut shim_previous = 0;
+            let shim_reset_status =
+                task.sys_nt_reset_event(shim_handle, Some(mut_ptr(&mut shim_previous)));
 
-        assert_eq!(shim_info, host_info);
-        assert_eq!(shim_length, host_length);
-        assert_eq!(shim_previous, host_previous);
+            assert_status_eq(shim_reset_status, host_reset_status);
+            assert_eq!(shim_info, host_info);
+            assert_eq!(shim_length, host_length);
+            assert_eq!(shim_previous, host_previous);
+
+            close_host_handle(host_handle);
+        }
+
+        #[test]
+        fn set_clear_pulse_and_boost_match_host_state() {
+            let mut host_handle = core::ptr::null_mut();
+            // SAFETY: The output pointer references a live stack local, null object attributes are
+            // accepted by NtCreateEvent, and the handle is closed before the test returns.
+            let status = unsafe {
+                NtCreateEvent(
+                    &raw mut host_handle,
+                    EVENT_ALL_ACCESS,
+                    core::ptr::null(),
+                    EventType::Notification as u32,
+                    0,
+                )
+            };
+            assert_eq!(status, NtStatus::SUCCESS.as_raw());
+
+            let task = test_task();
+            let mut shim_handle = Handle::default();
+            assert_eq!(
+                task.sys_nt_create_event(
+                    mut_ptr(&mut shim_handle),
+                    EVENT_ALL_ACCESS,
+                    None,
+                    EventType::Notification as u32,
+                    0,
+                ),
+                NtStatus::SUCCESS
+            );
+
+            let mut host_previous = -1;
+            let mut shim_previous = -1;
+            // SAFETY: `host_handle` is a live event handle and `host_previous` is a valid output.
+            let host_status = unsafe { NtSetEvent(host_handle, &raw mut host_previous) };
+            let shim_status = task.sys_nt_set_event(shim_handle, Some(mut_ptr(&mut shim_previous)));
+            assert_status_eq(shim_status, host_status);
+            assert_eq!(shim_previous, host_previous);
+            assert_queries_match(&task, host_handle, shim_handle);
+
+            // SAFETY: `host_handle` is a live event handle.
+            let host_status = unsafe { NtClearEvent(host_handle) };
+            let shim_status = task.sys_nt_clear_event(shim_handle);
+            assert_status_eq(shim_status, host_status);
+            assert_queries_match(&task, host_handle, shim_handle);
+
+            host_previous = -1;
+            shim_previous = -1;
+            // SAFETY: `host_handle` is a live event handle and `host_previous` is a valid output.
+            let host_status = unsafe { NtPulseEvent(host_handle, &raw mut host_previous) };
+            let shim_status =
+                task.sys_nt_pulse_event(shim_handle, Some(mut_ptr(&mut shim_previous)));
+            assert_status_eq(shim_status, host_status);
+            assert_eq!(shim_previous, host_previous);
+            assert_queries_match(&task, host_handle, shim_handle);
+
+            // SAFETY: `host_handle` is a live event handle.
+            let host_status = unsafe { NtSetEventBoostPriority(host_handle) };
+            let shim_status = task.sys_nt_set_event_boost_priority(shim_handle);
+            assert_status_eq(shim_status, host_status);
+            assert_queries_match(&task, host_handle, shim_handle);
+
+            close_host_handle(host_handle);
+        }
+
+        #[test]
+        fn boost_priority_sets_synchronization_event() {
+            let mut host_handle = core::ptr::null_mut();
+            // SAFETY: The output pointer references a live stack local, null object attributes are
+            // accepted by NtCreateEvent, and the handle is closed before the test returns.
+            let status = unsafe {
+                NtCreateEvent(
+                    &raw mut host_handle,
+                    EVENT_ALL_ACCESS,
+                    core::ptr::null(),
+                    EventType::Synchronization as u32,
+                    0,
+                )
+            };
+            assert_eq!(status, NtStatus::SUCCESS.as_raw());
+
+            let task = test_task();
+            let mut shim_handle = Handle::default();
+            assert_eq!(
+                task.sys_nt_create_event(
+                    mut_ptr(&mut shim_handle),
+                    EVENT_ALL_ACCESS,
+                    None,
+                    EventType::Synchronization as u32,
+                    0,
+                ),
+                NtStatus::SUCCESS
+            );
+
+            // SAFETY: `host_handle` is a live synchronization event handle.
+            let host_status = unsafe { NtSetEventBoostPriority(host_handle) };
+            let shim_status = task.sys_nt_set_event_boost_priority(shim_handle);
+            assert_status_eq(shim_status, host_status);
+            assert_queries_match(&task, host_handle, shim_handle);
+
+            close_host_handle(host_handle);
+        }
+
+        #[test]
+        fn named_open_matches_host_state_sharing() {
+            let unique = 0u8;
+            let name_units: Vec<u16> =
+                alloc::format!(r"\BaseNamedObjects\LiteBoxEventFidelity{:p}", &unique,)
+                    .encode_utf16()
+                    .collect();
+            let name = unicode_string(&name_units);
+            let attributes = object_attributes(&name, OBJ_CASE_INSENSITIVE);
+
+            let mut host_created = core::ptr::null_mut();
+            let mut host_opened = core::ptr::null_mut();
+            // SAFETY: Pointers reference live stack locals and ObjectAttributes points to a live
+            // UnicodeString naming a BaseNamedObjects event for the duration of the calls.
+            let host_create_status = unsafe {
+                NtCreateEvent(
+                    &raw mut host_created,
+                    EVENT_ALL_ACCESS,
+                    &raw const attributes,
+                    EventType::Notification as u32,
+                    0,
+                )
+            };
+            assert_eq!(host_create_status, NtStatus::SUCCESS.as_raw());
+            // SAFETY: Same live ObjectAttributes as above, and output pointer is valid.
+            let host_open_status = unsafe {
+                NtOpenEvent(
+                    &raw mut host_opened,
+                    EVENT_MODIFY_STATE,
+                    &raw const attributes,
+                )
+            };
+            assert_eq!(host_open_status, NtStatus::SUCCESS.as_raw());
+
+            let task = test_task();
+            let mut shim_created = Handle::default();
+            let shim_create_status = task.sys_nt_create_event(
+                mut_ptr(&mut shim_created),
+                EVENT_ALL_ACCESS,
+                Some(const_ptr(&attributes)),
+                EventType::Notification as u32,
+                0,
+            );
+            assert_status_eq(shim_create_status, host_create_status);
+            let mut shim_opened = Handle::default();
+            let shim_open_status = task.sys_nt_open_event(
+                mut_ptr(&mut shim_opened),
+                EVENT_MODIFY_STATE,
+                Some(const_ptr(&attributes)),
+            );
+            assert_status_eq(shim_open_status, host_open_status);
+
+            // SAFETY: `host_opened` is a live event handle opened with EVENT_MODIFY_STATE.
+            let host_set_status = unsafe { NtSetEvent(host_opened, core::ptr::null_mut()) };
+            let shim_set_status = task.sys_nt_set_event(shim_opened, None);
+            assert_status_eq(shim_set_status, host_set_status);
+            assert_queries_match(&task, host_created, shim_created);
+
+            close_host_handle(host_opened);
+            close_host_handle(host_created);
+        }
     }
 }

--- a/litebox_shim_windows/src/syscalls/file.rs
+++ b/litebox_shim_windows/src/syscalls/file.rs
@@ -910,7 +910,9 @@ fn map_mkdir_error(error: MkdirError) -> NtStatus {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tests::{TestFS, TestPlatform, const_ptr, mut_ptr, null_mut_ptr};
+    use crate::tests::{
+        TestFS, TestPlatform, const_ptr, mut_ptr, null_mut_ptr, object_attributes, unicode_string,
+    };
     use litebox::fs::FileSystem as _;
 
     extern crate std;
@@ -936,29 +938,8 @@ mod tests {
         <TestPlatform as litebox::platform::ThreadProvider>::run_test_thread(f)
     }
 
-    fn unicode_string(value: &[u16]) -> UnicodeString {
-        let byte_len = u16::try_from(core::mem::size_of_val(value)).unwrap();
-        UnicodeString {
-            length: byte_len,
-            maximum_length: byte_len,
-            padding_0: [0; 4],
-            buffer: value.as_ptr() as usize,
-        }
-    }
-
     fn utf16(value: &str) -> std::vec::Vec<u16> {
         value.encode_utf16().collect()
-    }
-
-    fn object_attributes(name: &UnicodeString) -> ObjectAttributes {
-        ObjectAttributes {
-            length: u32::try_from(core::mem::size_of::<ObjectAttributes>()).unwrap(),
-            root_directory: Handle::default(),
-            object_name: core::ptr::from_ref(name) as usize,
-            attributes: 0,
-            security_descriptor: 0,
-            security_quality_of_service: 0,
-        }
     }
 
     fn open_object_attributes(
@@ -970,7 +951,7 @@ mod tests {
     ) {
         let path = utf16(path);
         let name = std::boxed::Box::new(unicode_string(&path));
-        let attributes = object_attributes(&name);
+        let attributes = object_attributes(&name, 0);
         (path, name, attributes)
     }
 
@@ -1666,7 +1647,7 @@ mod tests {
         }
 
         fn host_object_attributes(name: &UnicodeString) -> ObjectAttributes {
-            object_attributes(name)
+            object_attributes(name, 0)
         }
 
         fn close_host_handle(handle: *mut c_void) {

--- a/litebox_shim_windows/src/syscalls/mod.rs
+++ b/litebox_shim_windows/src/syscalls/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+pub(crate) mod event;
 pub(crate) mod file;
 pub(crate) mod mm;
 pub(crate) mod nls;
@@ -86,6 +87,43 @@ impl ProcessHandle {
 pub(crate) enum SyscallRequest<Platform: RawPointerProvider> {
     NtClose {
         handle: Handle,
+    },
+    NtCreateEvent {
+        event_handle: Platform::RawMutPointer<Handle>,
+        desired_access: u32,
+        object_attributes: Option<Platform::RawConstPointer<nt_types::ObjectAttributes>>,
+        event_type: u32,
+        initial_state: u8,
+    },
+    NtOpenEvent {
+        event_handle: Platform::RawMutPointer<Handle>,
+        desired_access: u32,
+        object_attributes: Option<Platform::RawConstPointer<nt_types::ObjectAttributes>>,
+    },
+    NtSetEvent {
+        event_handle: Handle,
+        previous_state: Option<Platform::RawMutPointer<i32>>,
+    },
+    NtResetEvent {
+        event_handle: Handle,
+        previous_state: Option<Platform::RawMutPointer<i32>>,
+    },
+    NtClearEvent {
+        event_handle: Handle,
+    },
+    NtPulseEvent {
+        event_handle: Handle,
+        previous_state: Option<Platform::RawMutPointer<i32>>,
+    },
+    NtQueryEvent {
+        event_handle: Handle,
+        event_information_class: u32,
+        event_information: Platform::RawMutPointer<event::EventBasicInformation>,
+        event_information_length: u32,
+        return_length: Option<Platform::RawMutPointer<u32>>,
+    },
+    NtSetEventBoostPriority {
+        event_handle: Handle,
     },
     NtOpenFile {
         file_handle: Platform::RawMutPointer<Handle>,
@@ -202,6 +240,8 @@ pub(crate) enum SyscallRequest<Platform: RawPointerProvider> {
         process_handle: ProcessHandle,
         exit_status: i32,
     },
+    /// TODO: not supported yet
+    NtManageHotPatch,
 }
 
 impl<Platform: RawPointerProvider> SyscallRequest<Platform> {
@@ -227,6 +267,43 @@ impl<Platform: RawPointerProvider> SyscallRequest<Platform> {
         match NtSysno::from_raw(pt_regs.orig_rax)? {
             NtSysno::NtClose => Some(sys_req!(NtClose {
                 handle: { Handle::from_raw },
+            })),
+            NtSysno::NtCreateEvent => Some(sys_req!(NtCreateEvent {
+                event_handle:*,
+                desired_access,
+                object_attributes:*,
+                event_type,
+                initial_state,
+            })),
+            NtSysno::NtOpenEvent => Some(sys_req!(NtOpenEvent {
+                event_handle:*,
+                desired_access,
+                object_attributes:*,
+            })),
+            NtSysno::NtSetEvent => Some(sys_req!(NtSetEvent {
+                event_handle:{Handle::from_raw},
+                previous_state:*,
+            })),
+            NtSysno::NtResetEvent => Some(sys_req!(NtResetEvent {
+                event_handle:{Handle::from_raw},
+                previous_state:*,
+            })),
+            NtSysno::NtClearEvent => Some(sys_req!(NtClearEvent {
+                event_handle: { Handle::from_raw },
+            })),
+            NtSysno::NtPulseEvent => Some(sys_req!(NtPulseEvent {
+                event_handle:{Handle::from_raw},
+                previous_state:*,
+            })),
+            NtSysno::NtQueryEvent => Some(sys_req!(NtQueryEvent {
+                event_handle:{Handle::from_raw},
+                event_information_class,
+                event_information:*,
+                event_information_length,
+                return_length:*,
+            })),
+            NtSysno::NtSetEventBoostPriority => Some(sys_req!(NtSetEventBoostPriority {
+                event_handle: { Handle::from_raw },
             })),
             NtSysno::NtOpenFile => Some(sys_req!(NtOpenFile {
                 file_handle:*,
@@ -345,6 +422,7 @@ impl<Platform: RawPointerProvider> SyscallRequest<Platform> {
                 process_handle: { ProcessHandle::from_raw },
                 exit_status,
             })),
+            NtSysno::NtManageHotPatch => Some(SyscallRequest::NtManageHotPatch),
             _ => None,
         }
     }

--- a/litebox_shim_windows/src/syscalls/registry.rs
+++ b/litebox_shim_windows/src/syscalls/registry.rs
@@ -839,7 +839,10 @@ fn map_read_error(error: ReadError) -> NtStatus {
 
 #[cfg(test)]
 mod tests {
-    use crate::tests::{TestFS, TestPlatform, const_ptr, mut_byte_ptr, mut_ptr, test_platform};
+    use crate::tests::{
+        TestFS, TestPlatform, const_ptr, mut_byte_ptr, mut_ptr, object_attributes, test_platform,
+        unicode_string,
+    };
 
     use super::*;
     use core::mem::size_of;
@@ -905,29 +908,8 @@ mod tests {
         fn RegDeleteTreeW(hKey: *mut core::ffi::c_void, lpSubKey: *const u16) -> i32;
     }
 
-    fn unicode_string(value: &[u16]) -> UnicodeString {
-        let byte_len = u16::try_from(core::mem::size_of_val(value)).unwrap();
-        UnicodeString {
-            length: byte_len,
-            maximum_length: byte_len,
-            padding_0: [0; 4],
-            buffer: value.as_ptr() as usize,
-        }
-    }
-
     fn utf16(value: &str) -> std::vec::Vec<u16> {
         value.encode_utf16().collect()
-    }
-
-    fn object_attributes(name: &UnicodeString) -> ObjectAttributes {
-        ObjectAttributes {
-            length: u32::try_from(size_of::<ObjectAttributes>()).unwrap(),
-            root_directory: Handle::default(),
-            object_name: core::ptr::from_ref(name) as usize,
-            attributes: 0,
-            security_descriptor: 0,
-            security_quality_of_service: 0,
-        }
     }
 
     fn test_registry() -> (LiteBox<TestPlatform>, RegistryStore<TestPlatform>) {
@@ -946,7 +928,7 @@ mod tests {
     fn open_code_page_key(task: &Task<TestPlatform, TestFS>) -> Handle {
         let code_page_name = utf16(DEFAULT_CODE_PAGE_KEY);
         let code_page_name = unicode_string(&code_page_name);
-        let object_attributes = object_attributes(&code_page_name);
+        let object_attributes = object_attributes(&code_page_name, 0);
         open_key(task, object_attributes).expect("Failed to open code page key")
     }
 
@@ -1165,13 +1147,13 @@ mod tests {
         let task = crate::tests::test_task();
         let nls_name = utf16("\\Registry\\Machine\\System\\CurrentControlSet\\Control\\Nls");
         let nls_name = unicode_string(&nls_name);
-        let nls_object_attributes = object_attributes(&nls_name);
+        let nls_object_attributes = object_attributes(&nls_name, 0);
         let nls_handle = open_key(&task, nls_object_attributes).expect("Failed to open NLS key");
         assert_ne!(nls_handle, Handle::default());
 
         let code_page_name = utf16("CodePage");
         let code_page_name = unicode_string(&code_page_name);
-        let mut code_page_object_attributes = object_attributes(&code_page_name);
+        let mut code_page_object_attributes = object_attributes(&code_page_name, 0);
         code_page_object_attributes.root_directory = nls_handle;
         let code_page_handle =
             open_key(&task, code_page_object_attributes).expect("Failed to open code page key");
@@ -1183,7 +1165,7 @@ mod tests {
         let task = crate::tests::test_task();
         let name = utf16("\\Registry\\Machine\\Software\\Missing");
         let name = unicode_string(&name);
-        let object_attributes = object_attributes(&name);
+        let object_attributes = object_attributes(&name, 0);
         assert_eq!(
             open_key(&task, object_attributes).unwrap_err(),
             NtStatus::OBJECT_NAME_NOT_FOUND
@@ -1195,7 +1177,7 @@ mod tests {
         let task = crate::tests::test_task();
         let name = utf16("Child");
         let name = unicode_string(&name);
-        let mut object_attributes = object_attributes(&name);
+        let mut object_attributes = object_attributes(&name, 0);
         object_attributes.root_directory = Handle::from_raw(0x1234);
         assert_eq!(
             open_key(&task, object_attributes).unwrap_err(),
@@ -1216,7 +1198,7 @@ mod tests {
 
         let private_name = utf16(private_key);
         let private_name = unicode_string(&private_name);
-        let read_object_attributes = object_attributes(&private_name);
+        let read_object_attributes = object_attributes(&private_name, 0);
         assert_eq!(
             open_key(&task, read_object_attributes).unwrap_err(),
             NtStatus::ACCESS_DENIED
@@ -1224,7 +1206,7 @@ mod tests {
 
         let private_name = utf16(private_key);
         let private_name = unicode_string(&private_name);
-        let write_object_attributes = object_attributes(&private_name);
+        let write_object_attributes = object_attributes(&private_name, 0);
         let handle = task
             .do_nt_open_key(RegistryKeyAccess::SET_VALUE.bits(), write_object_attributes)
             .expect("write-only access should use write filesystem permissions");
@@ -1312,7 +1294,7 @@ mod tests {
         let task = crate::tests::test_task();
         let code_page_name = utf16(DEFAULT_CODE_PAGE_KEY);
         let code_page_name = unicode_string(&code_page_name);
-        let object_attributes = object_attributes(&code_page_name);
+        let object_attributes = object_attributes(&code_page_name, 0);
         let key_handle = task
             .do_nt_open_key(RegistryKeyAccess::SET_VALUE.bits(), object_attributes)
             .expect("write-only open should succeed against the seeded registry store");

--- a/litebox_shim_windows/src/tests.rs
+++ b/litebox_shim_windows/src/tests.rs
@@ -6,12 +6,15 @@ extern crate std;
 use alloc::collections::BTreeMap;
 use alloc::sync::Arc;
 use core::marker::PhantomData;
+use core::mem::size_of;
 use core::sync::atomic::{AtomicI32, AtomicU32};
 use litebox::LiteBox;
 use litebox::fd::RawDescriptorStorage;
 use litebox::fs::{FileSystem as _, Mode, OFlags};
 use litebox::platform::RawConstPointer as _;
 
+use crate::nt_types::{ObjectAttributes, UnicodeString};
+use crate::syscalls::Handle;
 use crate::{
     ConstPtr, DefaultFS, GlobalState, MutPtr, Process, Task, WindowsHandleStore,
     WindowsNlsSectionMappings, WindowsPageManager,
@@ -44,6 +47,28 @@ pub(crate) fn null_const_ptr<T: zerocopy::FromBytes>() -> ConstPtr<TestPlatform,
 pub(crate) fn null_mut_ptr<T: zerocopy::FromBytes + zerocopy::IntoBytes>() -> MutPtr<TestPlatform, T>
 {
     MutPtr::<TestPlatform, T>::from_usize(0)
+}
+
+pub(crate) fn unicode_string(units: &[u16]) -> UnicodeString {
+    let byte_len = u16::try_from(core::mem::size_of_val(units)).expect("test name fits in USHORT");
+    UnicodeString {
+        length: byte_len,
+        maximum_length: byte_len,
+        padding_0: [0; 4],
+        buffer: units.as_ptr() as usize,
+    }
+}
+
+pub(crate) fn object_attributes(name: &UnicodeString, attributes: u32) -> ObjectAttributes {
+    ObjectAttributes {
+        length: u32::try_from(size_of::<ObjectAttributes>())
+            .expect("OBJECT_ATTRIBUTES fits in ULONG"),
+        root_directory: Handle::default(),
+        object_name: core::ptr::from_ref(name) as usize,
+        attributes,
+        security_descriptor: 0,
+        security_quality_of_service: 0,
+    }
 }
 
 pub(crate) fn test_platform() -> &'static TestPlatform {

--- a/litebox_shim_windows/src/tests.rs
+++ b/litebox_shim_windows/src/tests.rs
@@ -122,6 +122,7 @@ pub(crate) fn test_task_with_nls_files(nls_files: &[(&str, &[u8])]) -> Task<Test
             ntdll_mapping: None,
             peb_address: 0,
             handles: WindowsHandleStore::<TestPlatform>::new(RawDescriptorStorage::new()),
+            event_namespace: crate::WindowsEventNamespace::<TestPlatform>::new(BTreeMap::new()),
             nls_section_mappings: WindowsNlsSectionMappings::<TestPlatform>::new(BTreeMap::new()),
             virtual_allocations: crate::WindowsVirtualAllocations::<TestPlatform>::new(
                 BTreeMap::new(),


### PR DESCRIPTION
This adds support for: `NtCreateEvent`, `NtOpenEvent`, `NtSetEvent`, `NtResetEvent`, `NtClearEvent`, `NtPulseEvent`, `NtQueryEvent`, `NtSetEventBoostPriority`.