### PR TITLE
Add Windows shim support for system information

### DIFF
--- a/litebox_shim_windows/src/lib.rs
+++ b/litebox_shim_windows/src/lib.rs
@@ -643,6 +643,20 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                     .sys_nt_query_performance_counter(performance_counter, performance_frequency);
                 (status, ContinueOperation::Resume)
             }
+            SyscallRequest::NtQuerySystemInformation {
+                system_information_class,
+                system_information,
+                system_information_length,
+                return_length,
+            } => {
+                let status = Self::sys_nt_query_system_information(
+                    system_information_class,
+                    system_information,
+                    system_information_length,
+                    return_length,
+                );
+                (status, ContinueOperation::Resume)
+            }
             SyscallRequest::NtConvertBetweenAuxiliaryCounterAndPerformanceCounter {
                 flag,
                 source,

--- a/litebox_shim_windows/src/lib.rs
+++ b/litebox_shim_windows/src/lib.rs
@@ -657,6 +657,24 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                 );
                 (status, ContinueOperation::Resume)
             }
+            SyscallRequest::NtQuerySystemInformationEx {
+                system_information_class,
+                input_buffer,
+                input_buffer_length,
+                system_information,
+                system_information_length,
+                return_length,
+            } => {
+                let status = Self::sys_nt_query_system_information_ex(
+                    system_information_class,
+                    input_buffer,
+                    input_buffer_length,
+                    system_information,
+                    system_information_length,
+                    return_length,
+                );
+                (status, ContinueOperation::Resume)
+            }
             SyscallRequest::NtConvertBetweenAuxiliaryCounterAndPerformanceCounter {
                 flag,
                 source,

--- a/litebox_shim_windows/src/syscalls/mm.rs
+++ b/litebox_shim_windows/src/syscalls/mm.rs
@@ -17,7 +17,7 @@ use crate::{
     WindowsVirtualAllocation, WindowsVirtualAllocations,
 };
 
-const ALLOCATION_GRANULARITY: usize = 0x1_0000;
+pub(super) const ALLOCATION_GRANULARITY: usize = 0x1_0000;
 const ALLOCATION_SEARCH_ATTEMPTS: usize = 8;
 const MEMORY_WORKING_SET_LIST_MIN_SIZE: usize = 16;
 const MEM_EXTENDED_PARAMETER_TYPE_MASK: u64 = 0xff;

--- a/litebox_shim_windows/src/syscalls/mod.rs
+++ b/litebox_shim_windows/src/syscalls/mod.rs
@@ -198,6 +198,14 @@ pub(crate) enum SyscallRequest<Platform: RawPointerProvider> {
         system_information_length: u32,
         return_length: Option<Platform::RawMutPointer<u32>>,
     },
+    NtQuerySystemInformationEx {
+        system_information_class: u32,
+        input_buffer: Option<Platform::RawConstPointer<u8>>,
+        input_buffer_length: u32,
+        system_information: Platform::RawMutPointer<u8>,
+        system_information_length: u32,
+        return_length: Option<Platform::RawMutPointer<u32>>,
+    },
     NtConvertBetweenAuxiliaryCounterAndPerformanceCounter {
         flag: u32,
         source: Platform::RawConstPointer<u64>,
@@ -380,6 +388,14 @@ impl<Platform: RawPointerProvider> SyscallRequest<Platform> {
             })),
             NtSysno::NtQuerySystemInformation => Some(sys_req!(NtQuerySystemInformation {
                 system_information_class,
+                system_information:*,
+                system_information_length,
+                return_length:*,
+            })),
+            NtSysno::NtQuerySystemInformationEx => Some(sys_req!(NtQuerySystemInformationEx {
+                system_information_class,
+                input_buffer:*,
+                input_buffer_length,
                 system_information:*,
                 system_information_length,
                 return_length:*,

--- a/litebox_shim_windows/src/syscalls/mod.rs
+++ b/litebox_shim_windows/src/syscalls/mod.rs
@@ -192,6 +192,12 @@ pub(crate) enum SyscallRequest<Platform: RawPointerProvider> {
         performance_counter: Platform::RawMutPointer<i64>,
         performance_frequency: Option<Platform::RawMutPointer<i64>>,
     },
+    NtQuerySystemInformation {
+        system_information_class: u32,
+        system_information: Platform::RawMutPointer<u8>,
+        system_information_length: u32,
+        return_length: Option<Platform::RawMutPointer<u32>>,
+    },
     NtConvertBetweenAuxiliaryCounterAndPerformanceCounter {
         flag: u32,
         source: Platform::RawConstPointer<u64>,
@@ -371,6 +377,12 @@ impl<Platform: RawPointerProvider> SyscallRequest<Platform> {
             NtSysno::NtQueryPerformanceCounter => Some(sys_req!(NtQueryPerformanceCounter {
                 performance_counter:*,
                 performance_frequency:*,
+            })),
+            NtSysno::NtQuerySystemInformation => Some(sys_req!(NtQuerySystemInformation {
+                system_information_class,
+                system_information:*,
+                system_information_length,
+                return_length:*,
             })),
             NtSysno::NtConvertBetweenAuxiliaryCounterAndPerformanceCounter => Some(
                 sys_req!(NtConvertBetweenAuxiliaryCounterAndPerformanceCounter {

--- a/litebox_shim_windows/src/syscalls/mod.rs
+++ b/litebox_shim_windows/src/syscalls/mod.rs
@@ -6,7 +6,7 @@ pub(crate) mod file;
 pub(crate) mod mm;
 pub(crate) mod nls;
 pub(crate) mod registry;
-pub(crate) mod sysinfo;
+mod sysinfo;
 
 use litebox::platform::{RawConstPointer as _, RawPointerProvider};
 use litebox::utils::TruncateExt as _;

--- a/litebox_shim_windows/src/syscalls/sysinfo.rs
+++ b/litebox_shim_windows/src/syscalls/sysinfo.rs
@@ -15,12 +15,18 @@ use crate::{ConstPtr, MutPtr, PAGE_SIZE, ShimFS, ShimPlatform, Task};
 
 const QPC_FREQUENCY_HZ: i64 = 1_000_000_000;
 const MAXIMUM_NODE_COUNT: usize = 0x40;
+const SYSTEM_FEATURE_CONFIGURATION_SECTION_TYPE_COUNT: usize = 4;
 const TIMER_RESOLUTION_100NS: u32 = 156_250;
 const ALLOCATION_GRANULARITY: u32 = 0x1_0000;
 const DEFAULT_PHYSICAL_PAGES: u32 = 1024 * 1024;
 const NUMBER_OF_PROCESSORS: u8 = 1;
 const SUPPORTED_FLUSH_METHODS: u32 = 0x7;
 const SUPPORTED_FLUSH_PROCESSOR_FEATURES: u32 = 0x40;
+const LOGICAL_PROCESSOR_RELATION_ALL: u32 = u32::MAX;
+const LOGICAL_PROCESSOR_RELATION_PROCESSOR_CORE: u32 = 0;
+const LOGICAL_PROCESSOR_RELATION_NUMA_NODE: u32 = 1;
+const LOGICAL_PROCESSOR_RELATION_PROCESSOR_PACKAGE: u32 = 3;
+const LOGICAL_PROCESSOR_RELATION_GROUP: u32 = 4;
 
 #[repr(u32)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, IntEnum)]
@@ -29,8 +35,10 @@ enum SystemInformationClass {
     Verifier = 50,
     NumaProcessorMap = 55,
     EmulationBasic = 62,
+    LogicalProcessorAndGroup = 107,
     Flush = 192,
     HypervisorSharedPage = 197,
+    FeatureConfigurationSection = 211,
     ProcessorFeaturesBitMap = 250,
 }
 
@@ -84,6 +92,88 @@ struct SystemProcessorFeaturesBitMapInformation {
 #[derive(Clone, Copy, Debug, FromBytes, Immutable, IntoBytes)]
 struct SystemVerifierInformation {
     flags: u64,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, FromBytes, Immutable, IntoBytes)]
+struct ProcessorRelationship {
+    flags: u8,
+    efficiency_class: u8,
+    reserved: [u8; 20],
+    group_count: u16,
+    group_mask: [GroupAffinity; 1],
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, FromBytes, Immutable, IntoBytes)]
+struct NumaNodeRelationship {
+    node_number: u32,
+    reserved: [u8; 20],
+    group_mask: GroupAffinity,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, FromBytes, Immutable, IntoBytes)]
+struct ProcessorGroupInfo {
+    maximum_processor_count: u8,
+    active_processor_count: u8,
+    reserved: [u8; 38],
+    active_processor_mask: usize,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, FromBytes, Immutable, IntoBytes)]
+struct GroupRelationship {
+    maximum_group_count: u16,
+    active_group_count: u16,
+    reserved: [u8; 20],
+    group_info: [ProcessorGroupInfo; 1],
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, FromBytes, Immutable, IntoBytes)]
+struct ProcessorRelationshipInformation {
+    relationship: u32,
+    size: u32,
+    processor: ProcessorRelationship,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, FromBytes, Immutable, IntoBytes)]
+struct NumaNodeRelationshipInformation {
+    relationship: u32,
+    size: u32,
+    numa_node: NumaNodeRelationship,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, FromBytes, Immutable, IntoBytes)]
+struct GroupRelationshipInformation {
+    relationship: u32,
+    size: u32,
+    group: GroupRelationship,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, FromBytes, Immutable, IntoBytes)]
+struct SystemFeatureConfigurationSectionsRequest {
+    previous_change_stamps: [u64; SYSTEM_FEATURE_CONFIGURATION_SECTION_TYPE_COUNT],
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, FromBytes, Immutable, IntoBytes)]
+struct SystemFeatureConfigurationSectionsInformationEntry {
+    change_stamp: u64,
+    section_handle: usize,
+    size: usize,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, FromBytes, Immutable, IntoBytes)]
+struct SystemFeatureConfigurationSectionsInformation {
+    overall_change_stamp: u64,
+    descriptors: [SystemFeatureConfigurationSectionsInformationEntry;
+        SYSTEM_FEATURE_CONFIGURATION_SECTION_TYPE_COUNT],
 }
 
 impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
@@ -146,6 +236,8 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                     feature_bits: [0; 2],
                 },
             ),
+            SystemInformationClass::LogicalProcessorAndGroup
+            | SystemInformationClass::FeatureConfigurationSection => NtStatus::INVALID_INFO_CLASS,
         };
 
         if status == NtStatus::SUCCESS {
@@ -157,6 +249,154 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         }
 
         status
+    }
+
+    pub(crate) fn sys_nt_query_system_information_ex(
+        system_information_class: u32,
+        input_buffer: Option<ConstPtr<Platform, u8>>,
+        input_buffer_length: u32,
+        system_information: MutPtr<Platform, u8>,
+        system_information_length: u32,
+        return_length: Option<MutPtr<Platform, u32>>,
+    ) -> NtStatus {
+        if input_buffer_length < u32::try_from(size_of::<u32>()).expect("DWORD fits in ULONG") {
+            return NtStatus::INVALID_PARAMETER;
+        }
+        let Some(input_buffer) = input_buffer else {
+            return NtStatus::INVALID_PARAMETER;
+        };
+
+        let Ok(system_information_class) =
+            SystemInformationClass::try_from(system_information_class)
+        else {
+            litebox_util_log::debug!(
+                system_information_class = system_information_class;
+                "Unsupported NtQuerySystemInformationEx class"
+            );
+            return NtStatus::INVALID_INFO_CLASS;
+        };
+
+        let status = match system_information_class {
+            SystemInformationClass::LogicalProcessorAndGroup => {
+                Self::write_logical_processor_and_group_information(
+                    input_buffer,
+                    system_information,
+                    system_information_length,
+                    return_length,
+                )
+            }
+            SystemInformationClass::FeatureConfigurationSection => {
+                Self::write_feature_configuration_section_information(
+                    input_buffer,
+                    input_buffer_length,
+                    system_information,
+                    system_information_length,
+                    return_length,
+                )
+            }
+            _ => {
+                litebox_util_log::debug!(
+                    system_information_class:? = system_information_class;
+                    "Unsupported NtQuerySystemInformationEx class"
+                );
+                NtStatus::INVALID_INFO_CLASS
+            }
+        };
+
+        if status == NtStatus::SUCCESS {
+            litebox_util_log::debug!(
+                system_information_class:? = system_information_class,
+                system_information_length = system_information_length;
+                "Handled NtQuerySystemInformationEx syscall"
+            );
+        }
+
+        status
+    }
+
+    fn write_logical_processor_and_group_information(
+        input_buffer: ConstPtr<Platform, u8>,
+        system_information: MutPtr<Platform, u8>,
+        system_information_length: u32,
+        return_length: Option<MutPtr<Platform, u32>>,
+    ) -> NtStatus {
+        let input_buffer = ConstPtr::<Platform, u32>::from_usize(input_buffer.as_usize());
+        let Some(relationship) = input_buffer.read_at_offset(0) else {
+            return NtStatus::ACCESS_VIOLATION;
+        };
+
+        let core = processor_relationship_information(LOGICAL_PROCESSOR_RELATION_PROCESSOR_CORE);
+        let numa = numa_node_relationship_information();
+        let package =
+            processor_relationship_information(LOGICAL_PROCESSOR_RELATION_PROCESSOR_PACKAGE);
+        let group = group_relationship_information();
+
+        let mut records = [&[][..]; 4];
+        let mut record_count = 0;
+        push_logical_processor_record(
+            relationship,
+            LOGICAL_PROCESSOR_RELATION_PROCESSOR_CORE,
+            core.as_bytes(),
+            &mut records,
+            &mut record_count,
+        );
+        push_logical_processor_record(
+            relationship,
+            LOGICAL_PROCESSOR_RELATION_NUMA_NODE,
+            numa.as_bytes(),
+            &mut records,
+            &mut record_count,
+        );
+        push_logical_processor_record(
+            relationship,
+            LOGICAL_PROCESSOR_RELATION_PROCESSOR_PACKAGE,
+            package.as_bytes(),
+            &mut records,
+            &mut record_count,
+        );
+        push_logical_processor_record(
+            relationship,
+            LOGICAL_PROCESSOR_RELATION_GROUP,
+            group.as_bytes(),
+            &mut records,
+            &mut record_count,
+        );
+
+        Self::write_system_information_records(
+            system_information,
+            system_information_length,
+            return_length,
+            &records[..record_count],
+        )
+    }
+
+    fn write_feature_configuration_section_information(
+        input_buffer: ConstPtr<Platform, u8>,
+        input_buffer_length: u32,
+        system_information: MutPtr<Platform, u8>,
+        system_information_length: u32,
+        return_length: Option<MutPtr<Platform, u32>>,
+    ) -> NtStatus {
+        if input_buffer_length
+            < u32::try_from(size_of::<SystemFeatureConfigurationSectionsRequest>())
+                .expect("feature configuration sections request length fits in ULONG")
+        {
+            return NtStatus::INVALID_PARAMETER;
+        }
+        let input_buffer =
+            ConstPtr::<Platform, SystemFeatureConfigurationSectionsRequest>::from_usize(
+                input_buffer.as_usize(),
+            );
+        if input_buffer.read_at_offset(0).is_none() {
+            return NtStatus::ACCESS_VIOLATION;
+        }
+
+        Self::write_system_information(
+            system_information,
+            system_information_length,
+            return_length,
+            &system_feature_configuration_sections_information(),
+        )
     }
 
     fn write_system_information<T: Immutable + IntoBytes>(
@@ -179,6 +419,42 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             .is_none()
         {
             return NtStatus::ACCESS_VIOLATION;
+        }
+
+        NtStatus::SUCCESS
+    }
+
+    fn write_system_information_records(
+        system_information: MutPtr<Platform, u8>,
+        system_information_length: u32,
+        return_length: Option<MutPtr<Platform, u32>>,
+        records: &[&[u8]],
+    ) -> NtStatus {
+        let required_len = records.iter().try_fold(0u32, |total, record| {
+            total.checked_add(u32::try_from(record.len()).ok()?)
+        });
+        let Some(required_len) = required_len else {
+            return NtStatus::INVALID_PARAMETER;
+        };
+
+        if let Some(return_length) = return_length
+            && return_length.write_at_offset(0, required_len).is_none()
+        {
+            return NtStatus::ACCESS_VIOLATION;
+        }
+        if system_information_length < required_len {
+            return NtStatus::INFO_LENGTH_MISMATCH;
+        }
+
+        let mut offset = 0;
+        for record in records {
+            if system_information
+                .write_slice_at_offset(offset, record)
+                .is_none()
+            {
+                return NtStatus::ACCESS_VIOLATION;
+            }
+            offset += isize::try_from(record.len()).expect("record length fits in isize");
         }
 
         NtStatus::SUCCESS
@@ -273,6 +549,88 @@ fn system_flush_information() -> SystemFlushInformation {
     }
 }
 
+fn processor_group_affinity() -> GroupAffinity {
+    GroupAffinity {
+        mask: usize::from(NUMBER_OF_PROCESSORS),
+        group: 0,
+        reserved: [0; 3],
+    }
+}
+
+fn processor_relationship_information(relationship: u32) -> ProcessorRelationshipInformation {
+    ProcessorRelationshipInformation {
+        relationship,
+        size: u32::try_from(size_of::<ProcessorRelationshipInformation>())
+            .expect("processor relationship information length fits in ULONG"),
+        processor: ProcessorRelationship {
+            flags: 0,
+            efficiency_class: 0,
+            reserved: [0; 20],
+            group_count: 1,
+            group_mask: [processor_group_affinity()],
+        },
+    }
+}
+
+fn numa_node_relationship_information() -> NumaNodeRelationshipInformation {
+    NumaNodeRelationshipInformation {
+        relationship: LOGICAL_PROCESSOR_RELATION_NUMA_NODE,
+        size: u32::try_from(size_of::<NumaNodeRelationshipInformation>())
+            .expect("NUMA node relationship information length fits in ULONG"),
+        numa_node: NumaNodeRelationship {
+            node_number: 0,
+            reserved: [0; 20],
+            group_mask: processor_group_affinity(),
+        },
+    }
+}
+
+fn group_relationship_information() -> GroupRelationshipInformation {
+    GroupRelationshipInformation {
+        relationship: LOGICAL_PROCESSOR_RELATION_GROUP,
+        size: u32::try_from(size_of::<GroupRelationshipInformation>())
+            .expect("group relationship information length fits in ULONG"),
+        group: GroupRelationship {
+            maximum_group_count: 1,
+            active_group_count: 1,
+            reserved: [0; 20],
+            group_info: [ProcessorGroupInfo {
+                maximum_processor_count: NUMBER_OF_PROCESSORS,
+                active_processor_count: NUMBER_OF_PROCESSORS,
+                reserved: [0; 38],
+                active_processor_mask: usize::from(NUMBER_OF_PROCESSORS),
+            }],
+        },
+    }
+}
+
+fn push_logical_processor_record<'a>(
+    requested_relationship: u32,
+    record_relationship: u32,
+    record: &'a [u8],
+    records: &mut [&'a [u8]; 4],
+    record_count: &mut usize,
+) {
+    if requested_relationship == record_relationship
+        || requested_relationship == LOGICAL_PROCESSOR_RELATION_ALL
+    {
+        records[*record_count] = record;
+        *record_count += 1;
+    }
+}
+
+fn system_feature_configuration_sections_information()
+-> SystemFeatureConfigurationSectionsInformation {
+    SystemFeatureConfigurationSectionsInformation {
+        overall_change_stamp: 0,
+        descriptors: [SystemFeatureConfigurationSectionsInformationEntry {
+            change_stamp: 0,
+            section_handle: 0,
+            size: 0,
+        }; SYSTEM_FEATURE_CONFIGURATION_SECTION_TYPE_COUNT],
+    }
+}
+
 fn duration_as_qpc_ticks(duration: core::time::Duration) -> i64 {
     i64::try_from(core::cmp::min(duration.as_nanos(), i64::MAX as u128)).unwrap_or(i64::MAX)
 }
@@ -281,6 +639,7 @@ fn duration_as_qpc_ticks(duration: core::time::Duration) -> i64 {
 mod tests {
     use super::*;
     use crate::tests::{const_ptr, mut_byte_ptr, mut_ptr, null_const_ptr, null_mut_ptr};
+    use core::mem::align_of;
     use core::time::Duration;
     use litebox::platform::ThreadProvider;
 
@@ -373,6 +732,271 @@ mod tests {
             system_information_length,
             return_length,
         )
+    }
+
+    fn sys_nt_query_system_information_ex(
+        system_information_class: u32,
+        input_buffer: Option<ConstPtr<TestPlatform, u8>>,
+        input_buffer_length: u32,
+        system_information: MutPtr<TestPlatform, u8>,
+        system_information_length: u32,
+        return_length: Option<MutPtr<TestPlatform, u32>>,
+    ) -> NtStatus {
+        Task::<TestPlatform, crate::tests::TestFS>::sys_nt_query_system_information_ex(
+            system_information_class,
+            input_buffer,
+            input_buffer_length,
+            system_information,
+            system_information_length,
+            return_length,
+        )
+    }
+
+    fn const_byte_ptr<T>(value: &T) -> ConstPtr<TestPlatform, u8> {
+        ConstPtr::<TestPlatform, u8>::from_usize(core::ptr::from_ref(value).cast::<u8>() as usize)
+    }
+
+    #[test]
+    fn system_information_ex_layout_matches_windows_abi() {
+        assert_eq!(
+            class_value(SystemInformationClass::LogicalProcessorAndGroup),
+            107
+        );
+        assert_eq!(
+            class_value(SystemInformationClass::FeatureConfigurationSection),
+            211
+        );
+        assert_eq!(size_of::<ProcessorRelationshipInformation>(), 48);
+        assert_eq!(align_of::<ProcessorRelationshipInformation>(), 8);
+        assert_eq!(size_of::<NumaNodeRelationshipInformation>(), 48);
+        assert_eq!(align_of::<NumaNodeRelationshipInformation>(), 8);
+        assert_eq!(size_of::<GroupRelationshipInformation>(), 80);
+        assert_eq!(align_of::<GroupRelationshipInformation>(), 8);
+        assert_eq!(size_of::<SystemFeatureConfigurationSectionsRequest>(), 32);
+        assert_eq!(align_of::<SystemFeatureConfigurationSectionsRequest>(), 8);
+        assert_eq!(
+            size_of::<SystemFeatureConfigurationSectionsInformation>(),
+            104
+        );
+        assert_eq!(
+            align_of::<SystemFeatureConfigurationSectionsInformation>(),
+            8
+        );
+    }
+
+    #[test]
+    fn nt_query_system_information_ex_validates_query_input() {
+        run_with_test_platform_pointers(|| {
+            let relationship = LOGICAL_PROCESSOR_RELATION_ALL;
+            let mut output = [0u8; size_of::<ProcessorRelationshipInformation>()];
+            let mut return_length = 0;
+
+            assert_eq!(
+                sys_nt_query_system_information_ex(
+                    class_value(SystemInformationClass::LogicalProcessorAndGroup),
+                    None,
+                    u32::try_from(size_of::<u32>()).unwrap(),
+                    mut_byte_ptr(&mut output),
+                    u32::try_from(output.len()).unwrap(),
+                    Some(mut_ptr(&mut return_length)),
+                ),
+                NtStatus::INVALID_PARAMETER
+            );
+            assert_eq!(return_length, 0);
+
+            assert_eq!(
+                sys_nt_query_system_information_ex(
+                    class_value(SystemInformationClass::LogicalProcessorAndGroup),
+                    Some(const_byte_ptr(&relationship)),
+                    u32::try_from(size_of::<u32>() - 1).unwrap(),
+                    mut_byte_ptr(&mut output),
+                    u32::try_from(output.len()).unwrap(),
+                    Some(mut_ptr(&mut return_length)),
+                ),
+                NtStatus::INVALID_PARAMETER
+            );
+
+            assert_eq!(
+                sys_nt_query_system_information_ex(
+                    class_value(SystemInformationClass::LogicalProcessorAndGroup),
+                    Some(null_const_ptr()),
+                    u32::try_from(size_of::<u32>()).unwrap(),
+                    mut_byte_ptr(&mut output),
+                    u32::try_from(output.len()).unwrap(),
+                    Some(mut_ptr(&mut return_length)),
+                ),
+                NtStatus::ACCESS_VIOLATION
+            );
+        });
+    }
+
+    #[test]
+    fn nt_query_system_information_ex_rejects_unsupported_classes() {
+        run_with_test_platform_pointers(|| {
+            let query = LOGICAL_PROCESSOR_RELATION_ALL;
+            let mut output = [0u8; size_of::<ProcessorRelationshipInformation>()];
+
+            assert_eq!(
+                sys_nt_query_system_information_ex(
+                    class_value(SystemInformationClass::Basic),
+                    Some(const_byte_ptr(&query)),
+                    u32::try_from(size_of::<u32>()).unwrap(),
+                    mut_byte_ptr(&mut output),
+                    u32::try_from(output.len()).unwrap(),
+                    None,
+                ),
+                NtStatus::INVALID_INFO_CLASS
+            );
+
+            assert_eq!(
+                sys_nt_query_system_information_ex(
+                    u32::MAX,
+                    Some(const_byte_ptr(&query)),
+                    u32::try_from(size_of::<u32>()).unwrap(),
+                    mut_byte_ptr(&mut output),
+                    u32::try_from(output.len()).unwrap(),
+                    None,
+                ),
+                NtStatus::INVALID_INFO_CLASS
+            );
+        });
+    }
+
+    #[test]
+    fn nt_query_system_information_ex_reports_required_logical_processor_length() {
+        run_with_test_platform_pointers(|| {
+            let relationship = LOGICAL_PROCESSOR_RELATION_ALL;
+            let mut output = [0u8; 1];
+            let mut return_length = 0;
+            let expected_len = size_of::<ProcessorRelationshipInformation>() * 2
+                + size_of::<NumaNodeRelationshipInformation>()
+                + size_of::<GroupRelationshipInformation>();
+
+            assert_eq!(
+                sys_nt_query_system_information_ex(
+                    class_value(SystemInformationClass::LogicalProcessorAndGroup),
+                    Some(const_byte_ptr(&relationship)),
+                    u32::try_from(size_of::<u32>()).unwrap(),
+                    mut_byte_ptr(&mut output),
+                    0,
+                    Some(mut_ptr(&mut return_length)),
+                ),
+                NtStatus::INFO_LENGTH_MISMATCH
+            );
+            assert_eq!(return_length, u32::try_from(expected_len).unwrap());
+        });
+    }
+
+    #[test]
+    fn nt_query_system_information_ex_filters_logical_processor_relationships() {
+        run_with_test_platform_pointers(|| {
+            let relationship = LOGICAL_PROCESSOR_RELATION_PROCESSOR_CORE;
+            let mut info = processor_relationship_information(LOGICAL_PROCESSOR_RELATION_GROUP);
+            let mut return_length = 0;
+
+            assert_eq!(
+                sys_nt_query_system_information_ex(
+                    class_value(SystemInformationClass::LogicalProcessorAndGroup),
+                    Some(const_byte_ptr(&relationship)),
+                    u32::try_from(size_of::<u32>()).unwrap(),
+                    mut_byte_ptr(&mut info),
+                    u32::try_from(size_of::<ProcessorRelationshipInformation>()).unwrap(),
+                    Some(mut_ptr(&mut return_length)),
+                ),
+                NtStatus::SUCCESS
+            );
+
+            assert_eq!(info.relationship, LOGICAL_PROCESSOR_RELATION_PROCESSOR_CORE);
+            assert_eq!(
+                info.size,
+                u32::try_from(size_of::<ProcessorRelationshipInformation>()).unwrap()
+            );
+            assert_eq!(info.processor.group_count, 1);
+            assert_eq!(info.processor.group_mask[0].mask, 1);
+            assert_eq!(return_length, info.size);
+        });
+    }
+
+    #[test]
+    fn nt_query_system_information_ex_writes_all_logical_processor_records() {
+        run_with_test_platform_pointers(|| {
+            let relationship = LOGICAL_PROCESSOR_RELATION_ALL;
+            let mut output = [0u8; size_of::<ProcessorRelationshipInformation>() * 2
+                + size_of::<NumaNodeRelationshipInformation>()
+                + size_of::<GroupRelationshipInformation>()];
+            let mut return_length = 0;
+
+            assert_eq!(
+                sys_nt_query_system_information_ex(
+                    class_value(SystemInformationClass::LogicalProcessorAndGroup),
+                    Some(const_byte_ptr(&relationship)),
+                    u32::try_from(size_of::<u32>()).unwrap(),
+                    mut_byte_ptr(&mut output),
+                    u32::try_from(output.len()).unwrap(),
+                    Some(mut_ptr(&mut return_length)),
+                ),
+                NtStatus::SUCCESS
+            );
+            assert_eq!(return_length, u32::try_from(output.len()).unwrap());
+
+            let mut offset = 0;
+            let expected_relationships = [
+                LOGICAL_PROCESSOR_RELATION_PROCESSOR_CORE,
+                LOGICAL_PROCESSOR_RELATION_NUMA_NODE,
+                LOGICAL_PROCESSOR_RELATION_PROCESSOR_PACKAGE,
+                LOGICAL_PROCESSOR_RELATION_GROUP,
+            ];
+            for expected_relationship in expected_relationships {
+                let relationship =
+                    u32::from_ne_bytes(output[offset..offset + 4].try_into().unwrap());
+                let size = u32::from_ne_bytes(output[offset + 4..offset + 8].try_into().unwrap());
+                assert_eq!(relationship, expected_relationship);
+                assert!(size > 0);
+                offset += usize::try_from(size).unwrap();
+            }
+            assert_eq!(offset, output.len());
+        });
+    }
+
+    #[test]
+    fn nt_query_system_information_ex_reports_feature_configuration_sections() {
+        run_with_test_platform_pointers(|| {
+            let request = SystemFeatureConfigurationSectionsRequest {
+                previous_change_stamps: [u64::MAX; SYSTEM_FEATURE_CONFIGURATION_SECTION_TYPE_COUNT],
+            };
+            let mut info = SystemFeatureConfigurationSectionsInformation {
+                overall_change_stamp: u64::MAX,
+                descriptors: [SystemFeatureConfigurationSectionsInformationEntry {
+                    change_stamp: u64::MAX,
+                    section_handle: usize::MAX,
+                    size: usize::MAX,
+                }; SYSTEM_FEATURE_CONFIGURATION_SECTION_TYPE_COUNT],
+            };
+            let mut return_length = 0;
+
+            assert_eq!(
+                sys_nt_query_system_information_ex(
+                    class_value(SystemInformationClass::FeatureConfigurationSection),
+                    Some(const_byte_ptr(&request)),
+                    u32::try_from(size_of::<SystemFeatureConfigurationSectionsRequest>()).unwrap(),
+                    mut_byte_ptr(&mut info),
+                    u32::try_from(size_of::<SystemFeatureConfigurationSectionsInformation>())
+                        .unwrap(),
+                    Some(mut_ptr(&mut return_length)),
+                ),
+                NtStatus::SUCCESS
+            );
+            assert_eq!(
+                return_length,
+                u32::try_from(size_of::<SystemFeatureConfigurationSectionsInformation>()).unwrap()
+            );
+            assert_eq!(info.overall_change_stamp, 0);
+            assert!(info.descriptors.iter().all(|descriptor| {
+                descriptor.change_stamp == 0
+                    && descriptor.section_handle == 0
+                    && descriptor.size == 0
+            }));
+        });
     }
 
     #[test]

--- a/litebox_shim_windows/src/syscalls/sysinfo.rs
+++ b/litebox_shim_windows/src/syscalls/sysinfo.rs
@@ -7,32 +7,42 @@ use int_enum::IntEnum;
 use litebox::platform::{
     Instant as _, PageManagementProvider, RawConstPointer as _, RawMutPointer as _,
 };
+use litebox::utils::TruncateExt as _;
 use litebox_common_windows::nt_status::NtStatus;
 use zerocopy::{FromBytes, Immutable, IntoBytes};
 
 use crate::nt_types::GroupAffinity;
+use crate::syscalls::mm::ALLOCATION_GRANULARITY;
 use crate::{ConstPtr, MutPtr, PAGE_SIZE, ShimFS, ShimPlatform, Task};
 
 const QPC_FREQUENCY_HZ: i64 = 1_000_000_000;
-const MAXIMUM_NODE_COUNT: usize = 0x40;
-const SYSTEM_FEATURE_CONFIGURATION_SECTION_TYPE_COUNT: usize = 4;
+// These fixed values are deterministic sandbox answers: a default 15.625 ms
+// timer tick, one synthetic processor, and a stable 4 GiB physical-memory view.
+// They avoid leaking host topology while satisfying Windows CRT/environment
+// probes that require plausible system-information success outputs.
 const TIMER_RESOLUTION_100NS: u32 = 156_250;
-const ALLOCATION_GRANULARITY: u32 = 0x1_0000;
 const DEFAULT_PHYSICAL_PAGES: u32 = 1024 * 1024;
 const NUMBER_OF_PROCESSORS: u8 = 1;
+const PROCESSOR_AFFINITY_MASK: usize = (1usize << NUMBER_OF_PROCESSORS) - 1;
+// SystemFlushInformation values observed from host ntdll on Windows 11 24H2.
+// LiteBox keeps them fixed because they describe the synthetic CPU contract.
 const SUPPORTED_FLUSH_METHODS: u32 = 0x7;
 const SUPPORTED_FLUSH_PROCESSOR_FEATURES: u32 = 0x40;
-const LOGICAL_PROCESSOR_RELATION_ALL: u32 = u32::MAX;
-const LOGICAL_PROCESSOR_RELATION_PROCESSOR_CORE: u32 = 0;
-const LOGICAL_PROCESSOR_RELATION_NUMA_NODE: u32 = 1;
-const LOGICAL_PROCESSOR_RELATION_PROCESSOR_PACKAGE: u32 = 3;
-const LOGICAL_PROCESSOR_RELATION_GROUP: u32 = 4;
+const CACHE_UNIFIED: u32 = 0;
+const DWORD_SIZE_U32: u32 = 4;
+const NUMA_NODE_COUNT: usize = NUMBER_OF_PROCESSORS as usize;
+const PROCESSOR_ARCHITECTURE_AMD64: u16 = 9;
+const SYSTEM_VERIFIER_INFORMATION_LENGTH: u32 = 0x90;
+const SYSTEM_VERIFIER_INFORMATION_LENGTH_USIZE: usize = 0x90;
+const X64_SYSTEM_RANGE_START: usize = 0xffff_8000_0000_0000;
 
 #[repr(u32)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, IntEnum)]
 enum SystemInformationClass {
     Basic = 0,
-    Verifier = 50,
+    Processor = 1,
+    RangeStart = 50,
+    Verifier = 51,
     NumaProcessorMap = 55,
     EmulationBasic = 62,
     LogicalProcessorAndGroup = 107,
@@ -40,6 +50,17 @@ enum SystemInformationClass {
     HypervisorSharedPage = 197,
     FeatureConfigurationSection = 211,
     ProcessorFeaturesBitMap = 250,
+}
+
+#[repr(u32)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, IntEnum)]
+enum LogicalProcessorRelationship {
+    ProcessorCore = 0,
+    NumaNode = 1,
+    Cache = 2,
+    ProcessorPackage = 3,
+    Group = 4,
+    All = 0xffff,
 }
 
 #[repr(C)]
@@ -62,10 +83,20 @@ struct SystemBasicInformation {
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, FromBytes, Immutable, IntoBytes)]
+struct SystemProcessorInformation {
+    processor_architecture: u16,
+    processor_level: u16,
+    processor_revision: u16,
+    maximum_processors: u16,
+    processor_feature_bits: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, FromBytes, Immutable, IntoBytes)]
 struct SystemNumaInformation {
     highest_node_number: u32,
     reserved: u32,
-    active_processors_group_affinity: [GroupAffinity; MAXIMUM_NODE_COUNT],
+    active_processors_group_affinity: [GroupAffinity; NUMA_NODE_COUNT],
 }
 
 #[repr(C)]
@@ -84,14 +115,14 @@ struct SystemHypervisorSharedPageInformation {
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, FromBytes, Immutable, IntoBytes)]
-struct SystemProcessorFeaturesBitMapInformation {
-    feature_bits: [u64; 2],
+struct SystemRangeStartInformation {
+    system_range_start: usize,
 }
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, FromBytes, Immutable, IntoBytes)]
-struct SystemVerifierInformation {
-    flags: u64,
+struct SystemProcessorFeaturesBitMapInformation {
+    feature_bits: [u64; 2],
 }
 
 #[repr(C)]
@@ -108,7 +139,21 @@ struct ProcessorRelationship {
 #[derive(Clone, Copy, Debug, FromBytes, Immutable, IntoBytes)]
 struct NumaNodeRelationship {
     node_number: u32,
-    reserved: [u8; 20],
+    reserved: [u8; 18],
+    group_count: u16,
+    group_mask: GroupAffinity,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, FromBytes, Immutable, IntoBytes)]
+struct CacheRelationship {
+    level: u8,
+    associativity: u8,
+    line_size: u16,
+    cache_size: u32,
+    cache_type: u32,
+    reserved: [u8; 18],
+    group_count: u16,
     group_mask: GroupAffinity,
 }
 
@@ -148,32 +193,18 @@ struct NumaNodeRelationshipInformation {
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, FromBytes, Immutable, IntoBytes)]
+struct CacheRelationshipInformation {
+    relationship: u32,
+    size: u32,
+    cache: CacheRelationship,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, FromBytes, Immutable, IntoBytes)]
 struct GroupRelationshipInformation {
     relationship: u32,
     size: u32,
     group: GroupRelationship,
-}
-
-#[repr(C)]
-#[derive(Clone, Copy, Debug, FromBytes, Immutable, IntoBytes)]
-struct SystemFeatureConfigurationSectionsRequest {
-    previous_change_stamps: [u64; SYSTEM_FEATURE_CONFIGURATION_SECTION_TYPE_COUNT],
-}
-
-#[repr(C)]
-#[derive(Clone, Copy, Debug, FromBytes, Immutable, IntoBytes)]
-struct SystemFeatureConfigurationSectionsInformationEntry {
-    change_stamp: u64,
-    section_handle: usize,
-    size: usize,
-}
-
-#[repr(C)]
-#[derive(Clone, Copy, Debug, FromBytes, Immutable, IntoBytes)]
-struct SystemFeatureConfigurationSectionsInformation {
-    overall_change_stamp: u64,
-    descriptors: [SystemFeatureConfigurationSectionsInformationEntry;
-        SYSTEM_FEATURE_CONFIGURATION_SECTION_TYPE_COUNT],
 }
 
 impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
@@ -195,24 +226,36 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
 
         let status = match system_information_class {
             SystemInformationClass::Basic | SystemInformationClass::EmulationBasic => {
-                Self::write_system_information(
+                Self::write_exact_system_information(
                     system_information,
                     system_information_length,
                     return_length,
                     &system_basic_information::<Platform>(),
                 )
             }
-            SystemInformationClass::Verifier => Self::write_system_information(
+            SystemInformationClass::Processor => Self::write_system_information(
                 system_information,
                 system_information_length,
                 return_length,
-                &SystemVerifierInformation { flags: 0 },
+                &system_processor_information(),
             ),
-            SystemInformationClass::NumaProcessorMap => Self::write_system_information(
+            SystemInformationClass::RangeStart => Self::write_exact_system_information(
                 system_information,
                 system_information_length,
                 return_length,
-                &system_numa_information(),
+                &SystemRangeStartInformation {
+                    system_range_start: X64_SYSTEM_RANGE_START,
+                },
+            ),
+            SystemInformationClass::Verifier => Self::write_system_verifier_information(
+                system_information,
+                system_information_length,
+                return_length,
+            ),
+            SystemInformationClass::NumaProcessorMap => Self::write_numa_processor_map_information(
+                system_information,
+                system_information_length,
+                return_length,
             ),
             SystemInformationClass::Flush => Self::write_system_information(
                 system_information,
@@ -259,7 +302,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         system_information_length: u32,
         return_length: Option<MutPtr<Platform, u32>>,
     ) -> NtStatus {
-        if input_buffer_length < u32::try_from(size_of::<u32>()).expect("DWORD fits in ULONG") {
+        if input_buffer_length < DWORD_SIZE_U32 {
             return NtStatus::INVALID_PARAMETER;
         }
         let Some(input_buffer) = input_buffer else {
@@ -285,15 +328,9 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                     return_length,
                 )
             }
-            SystemInformationClass::FeatureConfigurationSection => {
-                Self::write_feature_configuration_section_information(
-                    input_buffer,
-                    input_buffer_length,
-                    system_information,
-                    system_information_length,
-                    return_length,
-                )
-            }
+            // TODO: Windows returns section handles for this class. LiteBox does not yet model those
+            // NT section objects, so do not publish a fabricated success payload.
+            SystemInformationClass::FeatureConfigurationSection => NtStatus::INVALID_INFO_CLASS,
             _ => {
                 litebox_util_log::debug!(
                     system_information_class:? = system_information_class;
@@ -325,78 +362,82 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             return NtStatus::ACCESS_VIOLATION;
         };
 
-        let core = processor_relationship_information(LOGICAL_PROCESSOR_RELATION_PROCESSOR_CORE);
-        let numa = numa_node_relationship_information();
-        let package =
-            processor_relationship_information(LOGICAL_PROCESSOR_RELATION_PROCESSOR_PACKAGE);
-        let group = group_relationship_information();
+        let Ok(relationship) = LogicalProcessorRelationship::try_from(relationship) else {
+            return NtStatus::UNSUCCESSFUL;
+        };
 
-        let mut records = [&[][..]; 4];
-        let mut record_count = 0;
-        push_logical_processor_record(
-            relationship,
-            LOGICAL_PROCESSOR_RELATION_PROCESSOR_CORE,
-            core.as_bytes(),
-            &mut records,
-            &mut record_count,
-        );
-        push_logical_processor_record(
-            relationship,
-            LOGICAL_PROCESSOR_RELATION_NUMA_NODE,
-            numa.as_bytes(),
-            &mut records,
-            &mut record_count,
-        );
-        push_logical_processor_record(
-            relationship,
-            LOGICAL_PROCESSOR_RELATION_PROCESSOR_PACKAGE,
-            package.as_bytes(),
-            &mut records,
-            &mut record_count,
-        );
-        push_logical_processor_record(
-            relationship,
-            LOGICAL_PROCESSOR_RELATION_GROUP,
-            group.as_bytes(),
-            &mut records,
-            &mut record_count,
-        );
+        match relationship {
+            LogicalProcessorRelationship::ProcessorCore => Self::write_system_information(
+                system_information,
+                system_information_length,
+                return_length,
+                &processor_relationship_information(LogicalProcessorRelationship::ProcessorCore),
+            ),
+            LogicalProcessorRelationship::NumaNode => Self::write_system_information(
+                system_information,
+                system_information_length,
+                return_length,
+                &numa_node_relationship_information(),
+            ),
+            LogicalProcessorRelationship::Cache => Self::write_system_information(
+                system_information,
+                system_information_length,
+                return_length,
+                &cache_relationship_information(),
+            ),
+            LogicalProcessorRelationship::ProcessorPackage => Self::write_system_information(
+                system_information,
+                system_information_length,
+                return_length,
+                &processor_relationship_information(LogicalProcessorRelationship::ProcessorPackage),
+            ),
+            LogicalProcessorRelationship::Group => Self::write_system_information(
+                system_information,
+                system_information_length,
+                return_length,
+                &group_relationship_information(),
+            ),
+            LogicalProcessorRelationship::All => {
+                let core =
+                    processor_relationship_information(LogicalProcessorRelationship::ProcessorCore);
+                let numa = numa_node_relationship_information();
+                let cache = cache_relationship_information();
+                let package = processor_relationship_information(
+                    LogicalProcessorRelationship::ProcessorPackage,
+                );
+                let group = group_relationship_information();
+                let records = [
+                    core.as_bytes(),
+                    numa.as_bytes(),
+                    cache.as_bytes(),
+                    package.as_bytes(),
+                    group.as_bytes(),
+                ];
+                let required_len = records.iter().try_fold(0u32, |total, record| {
+                    total.checked_add(u32::try_from(record.len()).ok()?)
+                });
+                let Some(required_len) = required_len else {
+                    return NtStatus::INVALID_PARAMETER;
+                };
 
-        Self::write_system_information_records(
-            system_information,
-            system_information_length,
-            return_length,
-            &records[..record_count],
-        )
-    }
-
-    fn write_feature_configuration_section_information(
-        input_buffer: ConstPtr<Platform, u8>,
-        input_buffer_length: u32,
-        system_information: MutPtr<Platform, u8>,
-        system_information_length: u32,
-        return_length: Option<MutPtr<Platform, u32>>,
-    ) -> NtStatus {
-        if input_buffer_length
-            < u32::try_from(size_of::<SystemFeatureConfigurationSectionsRequest>())
-                .expect("feature configuration sections request length fits in ULONG")
-        {
-            return NtStatus::INVALID_PARAMETER;
+                Self::write_sized_system_information(
+                    system_information,
+                    system_information_length,
+                    return_length,
+                    required_len,
+                    move |system_information| {
+                        let mut offset = 0;
+                        for record in records {
+                            system_information
+                                .write_slice_at_offset(offset, record)
+                                .ok_or(NtStatus::ACCESS_VIOLATION)?;
+                            offset = offset.wrapping_add_unsigned(record.len());
+                        }
+                        Ok(())
+                    },
+                )
+            }
         }
-        let input_buffer =
-            ConstPtr::<Platform, SystemFeatureConfigurationSectionsRequest>::from_usize(
-                input_buffer.as_usize(),
-            );
-        if input_buffer.read_at_offset(0).is_none() {
-            return NtStatus::ACCESS_VIOLATION;
-        }
-
-        Self::write_system_information(
-            system_information,
-            system_information_length,
-            return_length,
-            &system_feature_configuration_sections_information(),
-        )
     }
 
     fn write_system_information<T: Immutable + IntoBytes>(
@@ -405,59 +446,135 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         return_length: Option<MutPtr<Platform, u32>>,
         information: &T,
     ) -> NtStatus {
-        let required_len = u32::try_from(size_of::<T>()).expect("system information fits in ULONG");
-        if let Some(return_length) = return_length
-            && return_length.write_at_offset(0, required_len).is_none()
+        let required_len = size_of::<T>().trunc();
+        Self::write_sized_system_information(
+            system_information,
+            system_information_length,
+            return_length,
+            required_len,
+            |system_information| {
+                system_information
+                    .write_slice_at_offset(0, information.as_bytes())
+                    .ok_or(NtStatus::ACCESS_VIOLATION)
+            },
+        )
+    }
+
+    fn write_exact_system_information<T: Immutable + IntoBytes>(
+        system_information: MutPtr<Platform, u8>,
+        system_information_length: u32,
+        return_length: Option<MutPtr<Platform, u32>>,
+        information: &T,
+    ) -> NtStatus {
+        let required_len = size_of::<T>().trunc();
+        if system_information_length != required_len {
+            return Self::write_return_length_for_short_buffer(return_length, required_len);
+        }
+
+        Self::write_system_information(
+            system_information,
+            system_information_length,
+            return_length,
+            information,
+        )
+    }
+
+    fn write_numa_processor_map_information(
+        system_information: MutPtr<Platform, u8>,
+        system_information_length: u32,
+        return_length: Option<MutPtr<Platform, u32>>,
+    ) -> NtStatus {
+        if system_information_length < DWORD_SIZE_U32 {
+            return Self::write_return_length_for_short_buffer(return_length, DWORD_SIZE_U32);
+        }
+
+        if system_information_length < size_of::<SystemNumaInformation>().trunc() {
+            let highest_node_number =
+                MutPtr::<Platform, u32>::from_usize(system_information.as_usize());
+            if highest_node_number.write_at_offset(0, 0).is_none() {
+                return NtStatus::ACCESS_VIOLATION;
+            }
+            if Self::write_return_length(return_length, DWORD_SIZE_U32).is_err() {
+                return NtStatus::ACCESS_VIOLATION;
+            }
+            return NtStatus::SUCCESS;
+        }
+
+        Self::write_system_information(
+            system_information,
+            system_information_length,
+            return_length,
+            &system_numa_information(),
+        )
+    }
+
+    fn write_system_verifier_information(
+        system_information: MutPtr<Platform, u8>,
+        system_information_length: u32,
+        return_length: Option<MutPtr<Platform, u32>>,
+    ) -> NtStatus {
+        if system_information_length < SYSTEM_VERIFIER_INFORMATION_LENGTH {
+            return Self::write_return_length_for_short_buffer(
+                return_length,
+                SYSTEM_VERIFIER_INFORMATION_LENGTH,
+            );
+        }
+
+        let verifier_information = [0u8; SYSTEM_VERIFIER_INFORMATION_LENGTH_USIZE];
+        if system_information
+            .write_slice_at_offset(0, &verifier_information)
+            .is_none()
         {
             return NtStatus::ACCESS_VIOLATION;
         }
-        if system_information_length < required_len {
-            return NtStatus::INFO_LENGTH_MISMATCH;
-        }
-        if system_information
-            .write_slice_at_offset(0, information.as_bytes())
-            .is_none()
-        {
+        if Self::write_return_length(return_length, 0).is_err() {
             return NtStatus::ACCESS_VIOLATION;
         }
 
         NtStatus::SUCCESS
     }
 
-    fn write_system_information_records(
+    fn write_sized_system_information(
         system_information: MutPtr<Platform, u8>,
         system_information_length: u32,
         return_length: Option<MutPtr<Platform, u32>>,
-        records: &[&[u8]],
+        required_len: u32,
+        write_payload: impl FnOnce(MutPtr<Platform, u8>) -> Result<(), NtStatus>,
     ) -> NtStatus {
-        let required_len = records.iter().try_fold(0u32, |total, record| {
-            total.checked_add(u32::try_from(record.len()).ok()?)
-        });
-        let Some(required_len) = required_len else {
-            return NtStatus::INVALID_PARAMETER;
-        };
-
-        if let Some(return_length) = return_length
-            && return_length.write_at_offset(0, required_len).is_none()
-        {
-            return NtStatus::ACCESS_VIOLATION;
-        }
         if system_information_length < required_len {
-            return NtStatus::INFO_LENGTH_MISMATCH;
+            return Self::write_return_length_for_short_buffer(return_length, required_len);
         }
-
-        let mut offset = 0;
-        for record in records {
-            if system_information
-                .write_slice_at_offset(offset, record)
-                .is_none()
-            {
-                return NtStatus::ACCESS_VIOLATION;
-            }
-            offset += isize::try_from(record.len()).expect("record length fits in isize");
+        if let Err(status) = write_payload(system_information) {
+            return status;
+        }
+        if Self::write_return_length(return_length, required_len).is_err() {
+            return NtStatus::ACCESS_VIOLATION;
         }
 
         NtStatus::SUCCESS
+    }
+
+    fn write_return_length_for_short_buffer(
+        return_length: Option<MutPtr<Platform, u32>>,
+        required_len: u32,
+    ) -> NtStatus {
+        if Self::write_return_length(return_length, required_len).is_err() {
+            return NtStatus::ACCESS_VIOLATION;
+        }
+
+        NtStatus::INFO_LENGTH_MISMATCH
+    }
+
+    fn write_return_length(
+        return_length: Option<MutPtr<Platform, u32>>,
+        required_len: u32,
+    ) -> Result<(), NtStatus> {
+        if let Some(return_length) = return_length
+            && return_length.write_at_offset(0, required_len).is_none()
+        {
+            return Err(NtStatus::ACCESS_VIOLATION);
+        }
+        Ok(())
     }
 
     pub(crate) fn sys_nt_query_performance_counter(
@@ -516,13 +633,25 @@ fn system_basic_information<Platform: ShimPlatform>() -> SystemBasicInformation 
         number_of_physical_pages: DEFAULT_PHYSICAL_PAGES,
         lowest_physical_page_number: 0,
         highest_physical_page_number: DEFAULT_PHYSICAL_PAGES.saturating_sub(1),
-        allocation_granularity: ALLOCATION_GRANULARITY,
+        allocation_granularity: ALLOCATION_GRANULARITY.trunc(),
         _padding0: 0,
         minimum_user_mode_address: <Platform as PageManagementProvider<PAGE_SIZE>>::TASK_ADDR_MIN,
         maximum_user_mode_address,
-        active_processors_affinity_mask: usize::from(NUMBER_OF_PROCESSORS),
+        active_processors_affinity_mask: PROCESSOR_AFFINITY_MASK,
         number_of_processors: NUMBER_OF_PROCESSORS,
         _padding1: [0; 7],
+    }
+}
+
+fn system_processor_information() -> SystemProcessorInformation {
+    // TODO: x64 Windows reports AMD64 architecture with family/level 6 for modern
+    // x86-64 CPUs. The revision and feature bitmap are synthetic.
+    SystemProcessorInformation {
+        processor_architecture: PROCESSOR_ARCHITECTURE_AMD64,
+        processor_level: 6,
+        processor_revision: 0,
+        maximum_processors: u16::from(NUMBER_OF_PROCESSORS),
+        processor_feature_bits: 0,
     }
 }
 
@@ -531,8 +660,8 @@ fn system_numa_information() -> SystemNumaInformation {
         mask: 0,
         group: 0,
         reserved: [0; 3],
-    }; MAXIMUM_NODE_COUNT];
-    active_processors_group_affinity[0].mask = usize::from(NUMBER_OF_PROCESSORS);
+    }; NUMA_NODE_COUNT];
+    active_processors_group_affinity[0] = processor_group_affinity();
 
     SystemNumaInformation {
         highest_node_number: 0,
@@ -551,17 +680,18 @@ fn system_flush_information() -> SystemFlushInformation {
 
 fn processor_group_affinity() -> GroupAffinity {
     GroupAffinity {
-        mask: usize::from(NUMBER_OF_PROCESSORS),
+        mask: PROCESSOR_AFFINITY_MASK,
         group: 0,
         reserved: [0; 3],
     }
 }
 
-fn processor_relationship_information(relationship: u32) -> ProcessorRelationshipInformation {
+fn processor_relationship_information(
+    relationship: LogicalProcessorRelationship,
+) -> ProcessorRelationshipInformation {
     ProcessorRelationshipInformation {
-        relationship,
-        size: u32::try_from(size_of::<ProcessorRelationshipInformation>())
-            .expect("processor relationship information length fits in ULONG"),
+        relationship: relationship as u32,
+        size: size_of::<ProcessorRelationshipInformation>().trunc(),
         processor: ProcessorRelationship {
             flags: 0,
             efficiency_class: 0,
@@ -574,12 +704,31 @@ fn processor_relationship_information(relationship: u32) -> ProcessorRelationshi
 
 fn numa_node_relationship_information() -> NumaNodeRelationshipInformation {
     NumaNodeRelationshipInformation {
-        relationship: LOGICAL_PROCESSOR_RELATION_NUMA_NODE,
-        size: u32::try_from(size_of::<NumaNodeRelationshipInformation>())
-            .expect("NUMA node relationship information length fits in ULONG"),
+        relationship: LogicalProcessorRelationship::NumaNode as u32,
+        size: size_of::<NumaNodeRelationshipInformation>().trunc(),
         numa_node: NumaNodeRelationship {
             node_number: 0,
-            reserved: [0; 20],
+            reserved: [0; 18],
+            group_count: 1,
+            group_mask: processor_group_affinity(),
+        },
+    }
+}
+
+fn cache_relationship_information() -> CacheRelationshipInformation {
+    // Deliberate sandbox topology: one generic L1 unified cache for one synthetic processor.
+    // The relationship ABI follows WDK winnt.h; the field values avoid leaking host cache details.
+    CacheRelationshipInformation {
+        relationship: LogicalProcessorRelationship::Cache as u32,
+        size: size_of::<CacheRelationshipInformation>().trunc(),
+        cache: CacheRelationship {
+            level: 1,
+            associativity: 0xff,
+            line_size: 64,
+            cache_size: 32 * 1024,
+            cache_type: CACHE_UNIFIED,
+            reserved: [0; 18],
+            group_count: 1,
             group_mask: processor_group_affinity(),
         },
     }
@@ -587,9 +736,8 @@ fn numa_node_relationship_information() -> NumaNodeRelationshipInformation {
 
 fn group_relationship_information() -> GroupRelationshipInformation {
     GroupRelationshipInformation {
-        relationship: LOGICAL_PROCESSOR_RELATION_GROUP,
-        size: u32::try_from(size_of::<GroupRelationshipInformation>())
-            .expect("group relationship information length fits in ULONG"),
+        relationship: LogicalProcessorRelationship::Group as u32,
+        size: size_of::<GroupRelationshipInformation>().trunc(),
         group: GroupRelationship {
             maximum_group_count: 1,
             active_group_count: 1,
@@ -598,48 +746,20 @@ fn group_relationship_information() -> GroupRelationshipInformation {
                 maximum_processor_count: NUMBER_OF_PROCESSORS,
                 active_processor_count: NUMBER_OF_PROCESSORS,
                 reserved: [0; 38],
-                active_processor_mask: usize::from(NUMBER_OF_PROCESSORS),
+                active_processor_mask: PROCESSOR_AFFINITY_MASK,
             }],
         },
     }
 }
 
-fn push_logical_processor_record<'a>(
-    requested_relationship: u32,
-    record_relationship: u32,
-    record: &'a [u8],
-    records: &mut [&'a [u8]; 4],
-    record_count: &mut usize,
-) {
-    if requested_relationship == record_relationship
-        || requested_relationship == LOGICAL_PROCESSOR_RELATION_ALL
-    {
-        records[*record_count] = record;
-        *record_count += 1;
-    }
-}
-
-fn system_feature_configuration_sections_information()
--> SystemFeatureConfigurationSectionsInformation {
-    SystemFeatureConfigurationSectionsInformation {
-        overall_change_stamp: 0,
-        descriptors: [SystemFeatureConfigurationSectionsInformationEntry {
-            change_stamp: 0,
-            section_handle: 0,
-            size: 0,
-        }; SYSTEM_FEATURE_CONFIGURATION_SECTION_TYPE_COUNT],
-    }
-}
-
 fn duration_as_qpc_ticks(duration: core::time::Duration) -> i64 {
-    i64::try_from(core::cmp::min(duration.as_nanos(), i64::MAX as u128)).unwrap_or(i64::MAX)
+    i64::try_from(duration.as_nanos().min(i64::MAX as u128)).unwrap_or(i64::MAX)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::tests::{const_ptr, mut_byte_ptr, mut_ptr, null_const_ptr, null_mut_ptr};
-    use core::mem::align_of;
     use core::time::Duration;
     use litebox::platform::ThreadProvider;
 
@@ -649,11 +769,27 @@ mod tests {
     const QPC_SLEEP_TOLERANCE: Duration = Duration::from_millis(10);
 
     type TestPlatform = crate::tests::TestPlatform;
+    type TestTask = Task<TestPlatform, crate::tests::TestFS>;
+
+    const LOGICAL_PROCESSOR_ALL_INFORMATION_SIZE: usize =
+        size_of::<ProcessorRelationshipInformation>() * 2
+            + size_of::<NumaNodeRelationshipInformation>()
+            + size_of::<CacheRelationshipInformation>()
+            + size_of::<GroupRelationshipInformation>();
 
     #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
     unsafe extern "system" {
         fn NtQuerySystemInformation(
             system_information_class: u32,
+            system_information: *mut core::ffi::c_void,
+            system_information_length: u32,
+            return_length: *mut u32,
+        ) -> i32;
+
+        fn NtQuerySystemInformationEx(
+            system_information_class: u32,
+            input_buffer: *const core::ffi::c_void,
+            input_buffer_length: u32,
             system_information: *mut core::ffi::c_void,
             system_information_length: u32,
             return_length: *mut u32,
@@ -672,20 +808,6 @@ mod tests {
     fn run_with_test_platform_pointers<R>(f: impl FnOnce() -> R) -> R {
         let _ = crate::tests::test_platform();
         <TestPlatform as ThreadProvider>::run_test_thread(f)
-    }
-
-    fn sys_nt_convert_between_auxiliary_counter_and_performance_counter(
-        flag: u32,
-        source: ConstPtr<TestPlatform, u64>,
-        destination: MutPtr<TestPlatform, u64>,
-        conversion_error: Option<MutPtr<TestPlatform, u64>>,
-    ) -> NtStatus {
-        Task::<TestPlatform, crate::tests::TestFS>::sys_nt_convert_between_auxiliary_counter_and_performance_counter(
-            flag,
-            source,
-            destination,
-            conversion_error,
-        )
     }
 
     #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
@@ -716,86 +838,22 @@ mod tests {
         }
     }
 
-    fn class_value(class: SystemInformationClass) -> u32 {
-        class as u32
-    }
-
-    fn sys_nt_query_system_information(
-        system_information_class: u32,
-        system_information: MutPtr<TestPlatform, u8>,
-        system_information_length: u32,
-        return_length: Option<MutPtr<TestPlatform, u32>>,
-    ) -> NtStatus {
-        Task::<TestPlatform, crate::tests::TestFS>::sys_nt_query_system_information(
-            system_information_class,
-            system_information,
-            system_information_length,
-            return_length,
-        )
-    }
-
-    fn sys_nt_query_system_information_ex(
-        system_information_class: u32,
-        input_buffer: Option<ConstPtr<TestPlatform, u8>>,
-        input_buffer_length: u32,
-        system_information: MutPtr<TestPlatform, u8>,
-        system_information_length: u32,
-        return_length: Option<MutPtr<TestPlatform, u32>>,
-    ) -> NtStatus {
-        Task::<TestPlatform, crate::tests::TestFS>::sys_nt_query_system_information_ex(
-            system_information_class,
-            input_buffer,
-            input_buffer_length,
-            system_information,
-            system_information_length,
-            return_length,
-        )
-    }
-
     fn const_byte_ptr<T>(value: &T) -> ConstPtr<TestPlatform, u8> {
         ConstPtr::<TestPlatform, u8>::from_usize(core::ptr::from_ref(value).cast::<u8>() as usize)
     }
 
     #[test]
-    fn system_information_ex_layout_matches_windows_abi() {
-        assert_eq!(
-            class_value(SystemInformationClass::LogicalProcessorAndGroup),
-            107
-        );
-        assert_eq!(
-            class_value(SystemInformationClass::FeatureConfigurationSection),
-            211
-        );
-        assert_eq!(size_of::<ProcessorRelationshipInformation>(), 48);
-        assert_eq!(align_of::<ProcessorRelationshipInformation>(), 8);
-        assert_eq!(size_of::<NumaNodeRelationshipInformation>(), 48);
-        assert_eq!(align_of::<NumaNodeRelationshipInformation>(), 8);
-        assert_eq!(size_of::<GroupRelationshipInformation>(), 80);
-        assert_eq!(align_of::<GroupRelationshipInformation>(), 8);
-        assert_eq!(size_of::<SystemFeatureConfigurationSectionsRequest>(), 32);
-        assert_eq!(align_of::<SystemFeatureConfigurationSectionsRequest>(), 8);
-        assert_eq!(
-            size_of::<SystemFeatureConfigurationSectionsInformation>(),
-            104
-        );
-        assert_eq!(
-            align_of::<SystemFeatureConfigurationSectionsInformation>(),
-            8
-        );
-    }
-
-    #[test]
     fn nt_query_system_information_ex_validates_query_input() {
         run_with_test_platform_pointers(|| {
-            let relationship = LOGICAL_PROCESSOR_RELATION_ALL;
+            let relationship = LogicalProcessorRelationship::All as u32;
             let mut output = [0u8; size_of::<ProcessorRelationshipInformation>()];
             let mut return_length = 0;
 
             assert_eq!(
-                sys_nt_query_system_information_ex(
-                    class_value(SystemInformationClass::LogicalProcessorAndGroup),
+                TestTask::sys_nt_query_system_information_ex(
+                    SystemInformationClass::LogicalProcessorAndGroup as u32,
                     None,
-                    u32::try_from(size_of::<u32>()).unwrap(),
+                    DWORD_SIZE_U32,
                     mut_byte_ptr(&mut output),
                     u32::try_from(output.len()).unwrap(),
                     Some(mut_ptr(&mut return_length)),
@@ -805,10 +863,10 @@ mod tests {
             assert_eq!(return_length, 0);
 
             assert_eq!(
-                sys_nt_query_system_information_ex(
-                    class_value(SystemInformationClass::LogicalProcessorAndGroup),
+                TestTask::sys_nt_query_system_information_ex(
+                    SystemInformationClass::LogicalProcessorAndGroup as u32,
                     Some(const_byte_ptr(&relationship)),
-                    u32::try_from(size_of::<u32>() - 1).unwrap(),
+                    DWORD_SIZE_U32 - 1,
                     mut_byte_ptr(&mut output),
                     u32::try_from(output.len()).unwrap(),
                     Some(mut_ptr(&mut return_length)),
@@ -817,10 +875,10 @@ mod tests {
             );
 
             assert_eq!(
-                sys_nt_query_system_information_ex(
-                    class_value(SystemInformationClass::LogicalProcessorAndGroup),
+                TestTask::sys_nt_query_system_information_ex(
+                    SystemInformationClass::LogicalProcessorAndGroup as u32,
                     Some(null_const_ptr()),
-                    u32::try_from(size_of::<u32>()).unwrap(),
+                    DWORD_SIZE_U32,
                     mut_byte_ptr(&mut output),
                     u32::try_from(output.len()).unwrap(),
                     Some(mut_ptr(&mut return_length)),
@@ -833,14 +891,14 @@ mod tests {
     #[test]
     fn nt_query_system_information_ex_rejects_unsupported_classes() {
         run_with_test_platform_pointers(|| {
-            let query = LOGICAL_PROCESSOR_RELATION_ALL;
+            let query = LogicalProcessorRelationship::All as u32;
             let mut output = [0u8; size_of::<ProcessorRelationshipInformation>()];
 
             assert_eq!(
-                sys_nt_query_system_information_ex(
-                    class_value(SystemInformationClass::Basic),
+                TestTask::sys_nt_query_system_information_ex(
+                    SystemInformationClass::Basic as u32,
                     Some(const_byte_ptr(&query)),
-                    u32::try_from(size_of::<u32>()).unwrap(),
+                    DWORD_SIZE_U32,
                     mut_byte_ptr(&mut output),
                     u32::try_from(output.len()).unwrap(),
                     None,
@@ -849,10 +907,34 @@ mod tests {
             );
 
             assert_eq!(
-                sys_nt_query_system_information_ex(
+                TestTask::sys_nt_query_system_information_ex(
+                    SystemInformationClass::FeatureConfigurationSection as u32,
+                    Some(const_byte_ptr(&query)),
+                    DWORD_SIZE_U32,
+                    mut_byte_ptr(&mut output),
+                    u32::try_from(output.len()).unwrap(),
+                    None,
+                ),
+                NtStatus::INVALID_INFO_CLASS
+            );
+
+            assert_eq!(
+                TestTask::sys_nt_query_system_information_ex(
+                    u32::MAX,
+                    None,
+                    0,
+                    mut_byte_ptr(&mut output),
+                    u32::try_from(output.len()).unwrap(),
+                    None,
+                ),
+                NtStatus::INVALID_PARAMETER
+            );
+
+            assert_eq!(
+                TestTask::sys_nt_query_system_information_ex(
                     u32::MAX,
                     Some(const_byte_ptr(&query)),
-                    u32::try_from(size_of::<u32>()).unwrap(),
+                    DWORD_SIZE_U32,
                     mut_byte_ptr(&mut output),
                     u32::try_from(output.len()).unwrap(),
                     None,
@@ -865,137 +947,24 @@ mod tests {
     #[test]
     fn nt_query_system_information_ex_reports_required_logical_processor_length() {
         run_with_test_platform_pointers(|| {
-            let relationship = LOGICAL_PROCESSOR_RELATION_ALL;
+            let relationship = LogicalProcessorRelationship::All as u32;
             let mut output = [0u8; 1];
             let mut return_length = 0;
-            let expected_len = size_of::<ProcessorRelationshipInformation>() * 2
-                + size_of::<NumaNodeRelationshipInformation>()
-                + size_of::<GroupRelationshipInformation>();
-
             assert_eq!(
-                sys_nt_query_system_information_ex(
-                    class_value(SystemInformationClass::LogicalProcessorAndGroup),
+                TestTask::sys_nt_query_system_information_ex(
+                    SystemInformationClass::LogicalProcessorAndGroup as u32,
                     Some(const_byte_ptr(&relationship)),
-                    u32::try_from(size_of::<u32>()).unwrap(),
+                    DWORD_SIZE_U32,
                     mut_byte_ptr(&mut output),
                     0,
                     Some(mut_ptr(&mut return_length)),
                 ),
                 NtStatus::INFO_LENGTH_MISMATCH
             );
-            assert_eq!(return_length, u32::try_from(expected_len).unwrap());
-        });
-    }
-
-    #[test]
-    fn nt_query_system_information_ex_filters_logical_processor_relationships() {
-        run_with_test_platform_pointers(|| {
-            let relationship = LOGICAL_PROCESSOR_RELATION_PROCESSOR_CORE;
-            let mut info = processor_relationship_information(LOGICAL_PROCESSOR_RELATION_GROUP);
-            let mut return_length = 0;
-
-            assert_eq!(
-                sys_nt_query_system_information_ex(
-                    class_value(SystemInformationClass::LogicalProcessorAndGroup),
-                    Some(const_byte_ptr(&relationship)),
-                    u32::try_from(size_of::<u32>()).unwrap(),
-                    mut_byte_ptr(&mut info),
-                    u32::try_from(size_of::<ProcessorRelationshipInformation>()).unwrap(),
-                    Some(mut_ptr(&mut return_length)),
-                ),
-                NtStatus::SUCCESS
-            );
-
-            assert_eq!(info.relationship, LOGICAL_PROCESSOR_RELATION_PROCESSOR_CORE);
-            assert_eq!(
-                info.size,
-                u32::try_from(size_of::<ProcessorRelationshipInformation>()).unwrap()
-            );
-            assert_eq!(info.processor.group_count, 1);
-            assert_eq!(info.processor.group_mask[0].mask, 1);
-            assert_eq!(return_length, info.size);
-        });
-    }
-
-    #[test]
-    fn nt_query_system_information_ex_writes_all_logical_processor_records() {
-        run_with_test_platform_pointers(|| {
-            let relationship = LOGICAL_PROCESSOR_RELATION_ALL;
-            let mut output = [0u8; size_of::<ProcessorRelationshipInformation>() * 2
-                + size_of::<NumaNodeRelationshipInformation>()
-                + size_of::<GroupRelationshipInformation>()];
-            let mut return_length = 0;
-
-            assert_eq!(
-                sys_nt_query_system_information_ex(
-                    class_value(SystemInformationClass::LogicalProcessorAndGroup),
-                    Some(const_byte_ptr(&relationship)),
-                    u32::try_from(size_of::<u32>()).unwrap(),
-                    mut_byte_ptr(&mut output),
-                    u32::try_from(output.len()).unwrap(),
-                    Some(mut_ptr(&mut return_length)),
-                ),
-                NtStatus::SUCCESS
-            );
-            assert_eq!(return_length, u32::try_from(output.len()).unwrap());
-
-            let mut offset = 0;
-            let expected_relationships = [
-                LOGICAL_PROCESSOR_RELATION_PROCESSOR_CORE,
-                LOGICAL_PROCESSOR_RELATION_NUMA_NODE,
-                LOGICAL_PROCESSOR_RELATION_PROCESSOR_PACKAGE,
-                LOGICAL_PROCESSOR_RELATION_GROUP,
-            ];
-            for expected_relationship in expected_relationships {
-                let relationship =
-                    u32::from_ne_bytes(output[offset..offset + 4].try_into().unwrap());
-                let size = u32::from_ne_bytes(output[offset + 4..offset + 8].try_into().unwrap());
-                assert_eq!(relationship, expected_relationship);
-                assert!(size > 0);
-                offset += usize::try_from(size).unwrap();
-            }
-            assert_eq!(offset, output.len());
-        });
-    }
-
-    #[test]
-    fn nt_query_system_information_ex_reports_feature_configuration_sections() {
-        run_with_test_platform_pointers(|| {
-            let request = SystemFeatureConfigurationSectionsRequest {
-                previous_change_stamps: [u64::MAX; SYSTEM_FEATURE_CONFIGURATION_SECTION_TYPE_COUNT],
-            };
-            let mut info = SystemFeatureConfigurationSectionsInformation {
-                overall_change_stamp: u64::MAX,
-                descriptors: [SystemFeatureConfigurationSectionsInformationEntry {
-                    change_stamp: u64::MAX,
-                    section_handle: usize::MAX,
-                    size: usize::MAX,
-                }; SYSTEM_FEATURE_CONFIGURATION_SECTION_TYPE_COUNT],
-            };
-            let mut return_length = 0;
-
-            assert_eq!(
-                sys_nt_query_system_information_ex(
-                    class_value(SystemInformationClass::FeatureConfigurationSection),
-                    Some(const_byte_ptr(&request)),
-                    u32::try_from(size_of::<SystemFeatureConfigurationSectionsRequest>()).unwrap(),
-                    mut_byte_ptr(&mut info),
-                    u32::try_from(size_of::<SystemFeatureConfigurationSectionsInformation>())
-                        .unwrap(),
-                    Some(mut_ptr(&mut return_length)),
-                ),
-                NtStatus::SUCCESS
-            );
             assert_eq!(
                 return_length,
-                u32::try_from(size_of::<SystemFeatureConfigurationSectionsInformation>()).unwrap()
+                u32::try_from(LOGICAL_PROCESSOR_ALL_INFORMATION_SIZE).unwrap()
             );
-            assert_eq!(info.overall_change_stamp, 0);
-            assert!(info.descriptors.iter().all(|descriptor| {
-                descriptor.change_stamp == 0
-                    && descriptor.section_handle == 0
-                    && descriptor.size == 0
-            }));
         });
     }
 
@@ -1006,21 +975,21 @@ mod tests {
             let mut return_length = 0;
 
             assert_eq!(
-                sys_nt_query_system_information(
-                    class_value(SystemInformationClass::Basic),
+                TestTask::sys_nt_query_system_information(
+                    SystemInformationClass::Basic as u32,
                     mut_byte_ptr(&mut info),
-                    u32::try_from(size_of::<SystemBasicInformation>()).unwrap(),
+                    size_of::<SystemBasicInformation>().trunc(),
                     Some(mut_ptr(&mut return_length)),
                 ),
                 NtStatus::SUCCESS
             );
 
-            assert_eq!(
-                return_length,
-                u32::try_from(size_of::<SystemBasicInformation>()).unwrap()
-            );
+            assert_eq!(return_length, size_of::<SystemBasicInformation>().trunc());
             assert_eq!(info.page_size, u32::try_from(PAGE_SIZE).unwrap());
-            assert_eq!(info.allocation_granularity, ALLOCATION_GRANULARITY);
+            assert_eq!(
+                info.allocation_granularity,
+                u32::try_from(ALLOCATION_GRANULARITY).unwrap()
+            );
             assert_eq!(info.number_of_processors, NUMBER_OF_PROCESSORS);
             assert_eq!(
                 info.minimum_user_mode_address,
@@ -1034,140 +1003,63 @@ mod tests {
     }
 
     #[test]
-    fn nt_query_system_information_reports_selected_fixed_information() {
-        run_with_test_platform_pointers(|| {
-            let mut emulation = empty_basic_information();
-            let mut numa = SystemNumaInformation {
-                highest_node_number: u32::MAX,
-                reserved: u32::MAX,
-                active_processors_group_affinity: [GroupAffinity {
-                    mask: usize::MAX,
-                    group: u16::MAX,
-                    reserved: [u16::MAX; 3],
-                }; MAXIMUM_NODE_COUNT],
-            };
-            let mut flush = SystemFlushInformation {
-                supported_flush_methods: 0,
-                processor_features: 0,
-                reserved: [u32::MAX; 6],
-            };
-            let mut hypervisor = SystemHypervisorSharedPageInformation {
-                hypervisor_shared_user_va: usize::MAX,
-            };
-            let mut features = SystemProcessorFeaturesBitMapInformation {
-                feature_bits: [u64::MAX; 2],
-            };
-            let mut verifier = SystemVerifierInformation { flags: u64::MAX };
-
-            assert_eq!(
-                sys_nt_query_system_information(
-                    class_value(SystemInformationClass::EmulationBasic),
-                    mut_byte_ptr(&mut emulation),
-                    u32::try_from(size_of::<SystemBasicInformation>()).unwrap(),
-                    None,
-                ),
-                NtStatus::SUCCESS
-            );
-            assert_eq!(emulation.page_size, u32::try_from(PAGE_SIZE).unwrap());
-
-            assert_eq!(
-                sys_nt_query_system_information(
-                    class_value(SystemInformationClass::NumaProcessorMap),
-                    mut_byte_ptr(&mut numa),
-                    u32::try_from(size_of::<SystemNumaInformation>()).unwrap(),
-                    None,
-                ),
-                NtStatus::SUCCESS
-            );
-            assert_eq!(numa.highest_node_number, 0);
-            assert_eq!(numa.reserved, 0);
-            assert_eq!(
-                numa.active_processors_group_affinity[0].mask,
-                usize::from(NUMBER_OF_PROCESSORS)
-            );
-            assert!(
-                numa.active_processors_group_affinity[1..]
-                    .iter()
-                    .all(|affinity| affinity.mask == 0 && affinity.group == 0)
-            );
-
-            assert_eq!(
-                sys_nt_query_system_information(
-                    class_value(SystemInformationClass::Flush),
-                    mut_byte_ptr(&mut flush),
-                    u32::try_from(size_of::<SystemFlushInformation>()).unwrap(),
-                    None,
-                ),
-                NtStatus::SUCCESS
-            );
-            assert_eq!(flush.supported_flush_methods, SUPPORTED_FLUSH_METHODS);
-            assert_eq!(flush.processor_features, SUPPORTED_FLUSH_PROCESSOR_FEATURES);
-            assert_eq!(flush.reserved, [0; 6]);
-
-            assert_eq!(
-                sys_nt_query_system_information(
-                    class_value(SystemInformationClass::HypervisorSharedPage),
-                    mut_byte_ptr(&mut hypervisor),
-                    u32::try_from(size_of::<SystemHypervisorSharedPageInformation>()).unwrap(),
-                    None,
-                ),
-                NtStatus::SUCCESS
-            );
-            assert_eq!(hypervisor.hypervisor_shared_user_va, 0);
-
-            assert_eq!(
-                sys_nt_query_system_information(
-                    class_value(SystemInformationClass::ProcessorFeaturesBitMap),
-                    mut_byte_ptr(&mut features),
-                    u32::try_from(size_of::<SystemProcessorFeaturesBitMapInformation>()).unwrap(),
-                    None,
-                ),
-                NtStatus::SUCCESS
-            );
-            assert_eq!(features.feature_bits, [0; 2]);
-
-            assert_eq!(
-                sys_nt_query_system_information(
-                    class_value(SystemInformationClass::Verifier),
-                    mut_byte_ptr(&mut verifier),
-                    u32::try_from(size_of::<SystemVerifierInformation>()).unwrap(),
-                    None,
-                ),
-                NtStatus::SUCCESS
-            );
-            assert_eq!(verifier.flags, 0);
-        });
-    }
-
-    #[test]
     fn nt_query_system_information_validates_class_and_buffer_length() {
         run_with_test_platform_pointers(|| {
             let mut info = [0u8; size_of::<SystemBasicInformation>()];
             let mut return_length = 0;
+            let basic_len: u32 = size_of::<SystemBasicInformation>().trunc();
 
             assert_eq!(
-                sys_nt_query_system_information(
-                    class_value(SystemInformationClass::Basic),
+                TestTask::sys_nt_query_system_information(
+                    SystemInformationClass::Basic as u32,
                     mut_byte_ptr(&mut info),
-                    u32::try_from(size_of::<SystemBasicInformation>() - 1).unwrap(),
+                    basic_len - 1,
                     Some(mut_ptr(&mut return_length)),
                 ),
                 NtStatus::INFO_LENGTH_MISMATCH
             );
-            assert_eq!(
-                return_length,
-                u32::try_from(size_of::<SystemBasicInformation>()).unwrap()
-            );
+            assert_eq!(return_length, basic_len);
 
             assert_eq!(
-                sys_nt_query_system_information(
-                    1,
+                TestTask::sys_nt_query_system_information(
+                    SystemInformationClass::Basic as u32,
+                    mut_byte_ptr(&mut info),
+                    basic_len + 1,
+                    Some(mut_ptr(&mut return_length)),
+                ),
+                NtStatus::INFO_LENGTH_MISMATCH
+            );
+            assert_eq!(return_length, basic_len);
+
+            assert_eq!(
+                TestTask::sys_nt_query_system_information(
+                    u32::MAX,
                     mut_byte_ptr(&mut info),
                     u32::try_from(info.len()).unwrap(),
                     None,
                 ),
                 NtStatus::INVALID_INFO_CLASS
             );
+        });
+    }
+
+    #[test]
+    fn nt_query_system_information_reports_partial_numa_processor_map() {
+        run_with_test_platform_pointers(|| {
+            let mut highest_node_number = u32::MAX;
+            let mut return_length = 0;
+
+            assert_eq!(
+                TestTask::sys_nt_query_system_information(
+                    SystemInformationClass::NumaProcessorMap as u32,
+                    mut_byte_ptr(&mut highest_node_number),
+                    DWORD_SIZE_U32,
+                    Some(mut_ptr(&mut return_length)),
+                ),
+                NtStatus::SUCCESS
+            );
+            assert_eq!(highest_node_number, 0);
+            assert_eq!(return_length, DWORD_SIZE_U32);
         });
     }
 
@@ -1179,20 +1071,20 @@ mod tests {
             let mut host_return_length = 0;
             let mut guest_info = empty_basic_information();
             let mut guest_return_length = 0;
-            let information_length = u32::try_from(size_of::<SystemBasicInformation>()).unwrap();
+            let information_length = size_of::<SystemBasicInformation>().trunc();
 
             // SAFETY: The output buffer and return-length pointer are valid locals and ntdll does
             // not retain them.
             let host_basic_status = unsafe {
                 host_status(NtQuerySystemInformation(
-                    class_value(SystemInformationClass::Basic),
+                    SystemInformationClass::Basic as u32,
                     host_info.as_mut_ptr().cast(),
                     information_length,
                     &raw mut host_return_length,
                 ))
             };
-            let guest_status = sys_nt_query_system_information(
-                class_value(SystemInformationClass::Basic),
+            let guest_status = TestTask::sys_nt_query_system_information(
+                SystemInformationClass::Basic as u32,
                 mut_byte_ptr(&mut guest_info),
                 information_length,
                 Some(mut_ptr(&mut guest_return_length)),
@@ -1200,7 +1092,10 @@ mod tests {
             assert_eq!(guest_status, host_basic_status);
             assert_eq!(guest_return_length, host_return_length);
             assert_eq!(guest_info.page_size, u32::try_from(PAGE_SIZE).unwrap());
-            assert_eq!(guest_info.allocation_granularity, ALLOCATION_GRANULARITY);
+            assert_eq!(
+                guest_info.allocation_granularity,
+                u32::try_from(ALLOCATION_GRANULARITY).unwrap()
+            );
 
             let mut host_short_return_length = 0;
             let mut guest_short_return_length = 0;
@@ -1208,20 +1103,371 @@ mod tests {
             // pointers are valid local variables.
             let host_short_status = unsafe {
                 host_status(NtQuerySystemInformation(
-                    class_value(SystemInformationClass::Basic),
+                    SystemInformationClass::Basic as u32,
                     host_info.as_mut_ptr().cast(),
                     information_length - 1,
                     &raw mut host_short_return_length,
                 ))
             };
-            let guest_short_status = sys_nt_query_system_information(
-                class_value(SystemInformationClass::Basic),
+            let guest_short_status = TestTask::sys_nt_query_system_information(
+                SystemInformationClass::Basic as u32,
                 mut_byte_ptr(&mut guest_info),
                 information_length - 1,
                 Some(mut_ptr(&mut guest_short_return_length)),
             );
             assert_eq!(guest_short_status, host_short_status);
             assert_eq!(guest_short_return_length, host_short_return_length);
+        });
+    }
+
+    #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+    #[test]
+    fn nt_query_system_information_fixed_class_lengths_match_host_ntdll() {
+        fn query_host(
+            class: SystemInformationClass,
+            output: &mut [u8],
+            return_length: &mut u32,
+        ) -> NtStatus {
+            // SAFETY: The output buffer and return-length pointer are valid locals and ntdll does
+            // not retain them.
+            unsafe {
+                host_status(NtQuerySystemInformation(
+                    class as u32,
+                    output.as_mut_ptr().cast(),
+                    u32::try_from(output.len()).unwrap(),
+                    return_length,
+                ))
+            }
+        }
+
+        run_with_test_platform_pointers(|| {
+            let cases = [
+                (
+                    SystemInformationClass::Processor,
+                    size_of::<SystemProcessorInformation>(),
+                ),
+                (
+                    SystemInformationClass::RangeStart,
+                    size_of::<SystemRangeStartInformation>(),
+                ),
+                (
+                    SystemInformationClass::Verifier,
+                    SYSTEM_VERIFIER_INFORMATION_LENGTH_USIZE,
+                ),
+                (
+                    SystemInformationClass::NumaProcessorMap,
+                    size_of::<SystemNumaInformation>(),
+                ),
+                (
+                    SystemInformationClass::EmulationBasic,
+                    size_of::<SystemBasicInformation>(),
+                ),
+                (
+                    SystemInformationClass::Flush,
+                    size_of::<SystemFlushInformation>(),
+                ),
+                (
+                    SystemInformationClass::HypervisorSharedPage,
+                    size_of::<SystemHypervisorSharedPageInformation>(),
+                ),
+                (
+                    SystemInformationClass::ProcessorFeaturesBitMap,
+                    size_of::<SystemProcessorFeaturesBitMapInformation>(),
+                ),
+            ];
+
+            for (class, length) in cases {
+                let mut host_output = std::vec![0u8; length];
+                let mut guest_output = std::vec![0u8; length];
+                let mut host_return_length = 0;
+                let mut guest_return_length = 0;
+                let information_length = u32::try_from(length).unwrap();
+
+                let host_status = query_host(class, &mut host_output, &mut host_return_length);
+                let guest_status = TestTask::sys_nt_query_system_information(
+                    class as u32,
+                    mut_byte_ptr(&mut guest_output[0]),
+                    information_length,
+                    Some(mut_ptr(&mut guest_return_length)),
+                );
+
+                assert_eq!(guest_status, host_status, "{class:?}");
+                assert_eq!(guest_return_length, host_return_length, "{class:?}");
+            }
+
+            let exact_length_cases = [
+                (
+                    SystemInformationClass::Basic,
+                    size_of::<SystemBasicInformation>(),
+                ),
+                (
+                    SystemInformationClass::EmulationBasic,
+                    size_of::<SystemBasicInformation>(),
+                ),
+                (
+                    SystemInformationClass::RangeStart,
+                    size_of::<SystemRangeStartInformation>(),
+                ),
+            ];
+
+            for (class, length) in exact_length_cases {
+                let mut host_output = std::vec![0u8; length + 1];
+                let mut guest_output = std::vec![0u8; length + 1];
+                let mut host_return_length = 0;
+                let mut guest_return_length = 0;
+                let information_length = u32::try_from(length + 1).unwrap();
+
+                let host_status = query_host(class, &mut host_output, &mut host_return_length);
+                let guest_status = TestTask::sys_nt_query_system_information(
+                    class as u32,
+                    mut_byte_ptr(&mut guest_output[0]),
+                    information_length,
+                    Some(mut_ptr(&mut guest_return_length)),
+                );
+
+                assert_eq!(guest_status, host_status, "{class:?}");
+                assert_eq!(guest_return_length, host_return_length, "{class:?}");
+            }
+        });
+    }
+
+    #[test]
+    fn nt_query_system_information_does_not_publish_return_length_before_output_probe() {
+        run_with_test_platform_pointers(|| {
+            let mut return_length = u32::MAX;
+
+            assert_eq!(
+                TestTask::sys_nt_query_system_information(
+                    SystemInformationClass::Basic as u32,
+                    null_mut_ptr(),
+                    size_of::<SystemBasicInformation>().trunc(),
+                    Some(mut_ptr(&mut return_length)),
+                ),
+                NtStatus::ACCESS_VIOLATION
+            );
+            assert_eq!(return_length, u32::MAX);
+        });
+    }
+
+    #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+    #[test]
+    fn nt_query_system_information_null_output_return_length_order_matches_host_ntdll() {
+        run_with_test_platform_pointers(|| {
+            let mut host_return_length = u32::MAX;
+            let mut guest_return_length = u32::MAX;
+            let information_length = size_of::<SystemBasicInformation>().trunc();
+
+            // SAFETY: This intentionally passes a null output buffer to probe host ntdll's
+            // NTSTATUS and return-length ordering; the return-length pointer is a valid local.
+            let host_status = unsafe {
+                host_status(NtQuerySystemInformation(
+                    SystemInformationClass::Basic as u32,
+                    core::ptr::null_mut(),
+                    information_length,
+                    &raw mut host_return_length,
+                ))
+            };
+            let guest_status = TestTask::sys_nt_query_system_information(
+                SystemInformationClass::Basic as u32,
+                null_mut_ptr(),
+                information_length,
+                Some(mut_ptr(&mut guest_return_length)),
+            );
+
+            assert_eq!(guest_status, host_status);
+            assert_eq!(guest_return_length, host_return_length);
+        });
+    }
+
+    #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+    #[test]
+    fn nt_query_system_information_ex_input_validation_order_matches_host_ntdll() {
+        run_with_test_platform_pointers(|| {
+            let query = LogicalProcessorRelationship::All as u32;
+            let mut host_output = [0u8; size_of::<ProcessorRelationshipInformation>()];
+            let mut guest_output = [0u8; size_of::<ProcessorRelationshipInformation>()];
+            let mut host_return_length = u32::MAX;
+            let mut guest_return_length = u32::MAX;
+
+            // SAFETY: This intentionally passes a null input buffer to probe host ntdll's
+            // validation order. Output and return-length pointers are valid locals.
+            let host_null_status = unsafe {
+                host_status(NtQuerySystemInformationEx(
+                    SystemInformationClass::Basic as u32,
+                    core::ptr::null(),
+                    0,
+                    host_output.as_mut_ptr().cast(),
+                    u32::try_from(host_output.len()).unwrap(),
+                    &raw mut host_return_length,
+                ))
+            };
+            let guest_null_status = TestTask::sys_nt_query_system_information_ex(
+                SystemInformationClass::Basic as u32,
+                None,
+                0,
+                mut_byte_ptr(&mut guest_output),
+                u32::try_from(guest_output.len()).unwrap(),
+                Some(mut_ptr(&mut guest_return_length)),
+            );
+            assert_eq!(guest_null_status, host_null_status);
+            assert_eq!(guest_null_status, NtStatus::INVALID_PARAMETER);
+            assert_eq!(guest_return_length, u32::MAX);
+
+            // SAFETY: This uses a valid input DWORD and local output buffers to confirm that
+            // class validation still happens after the required input-buffer check succeeds.
+            let host_unknown_status = unsafe {
+                host_status(NtQuerySystemInformationEx(
+                    u32::MAX,
+                    core::ptr::from_ref(&query).cast(),
+                    DWORD_SIZE_U32,
+                    host_output.as_mut_ptr().cast(),
+                    u32::try_from(host_output.len()).unwrap(),
+                    &raw mut host_return_length,
+                ))
+            };
+            let guest_unknown_status = TestTask::sys_nt_query_system_information_ex(
+                u32::MAX,
+                Some(const_byte_ptr(&query)),
+                DWORD_SIZE_U32,
+                mut_byte_ptr(&mut guest_output),
+                u32::try_from(guest_output.len()).unwrap(),
+                Some(mut_ptr(&mut guest_return_length)),
+            );
+            assert_eq!(guest_unknown_status, host_unknown_status);
+            assert_eq!(guest_unknown_status, NtStatus::INVALID_INFO_CLASS);
+            assert_eq!(guest_return_length, u32::MAX);
+        });
+    }
+
+    #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+    #[test]
+    fn nt_query_system_information_ex_logical_processor_status_matches_host_ntdll() {
+        fn query_host(relationship: u32, output: &mut [u8], return_length: &mut u32) -> NtStatus {
+            // SAFETY: This Windows-only test passes valid local input, output, and length pointers
+            // to ntdll and ntdll does not retain them.
+            unsafe {
+                host_status(NtQuerySystemInformationEx(
+                    SystemInformationClass::LogicalProcessorAndGroup as u32,
+                    core::ptr::from_ref(&relationship).cast(),
+                    DWORD_SIZE_U32,
+                    output.as_mut_ptr().cast(),
+                    u32::try_from(output.len()).unwrap(),
+                    return_length,
+                ))
+            }
+        }
+
+        run_with_test_platform_pointers(|| {
+            let mut host_output = [0u8; 4096];
+            let mut guest_output = [0u8; LOGICAL_PROCESSOR_ALL_INFORMATION_SIZE];
+            let mut host_return_length = 0;
+            let mut guest_return_length = 0;
+
+            let host_all_status = query_host(
+                LogicalProcessorRelationship::All as u32,
+                &mut host_output,
+                &mut host_return_length,
+            );
+            let all_relationship = LogicalProcessorRelationship::All as u32;
+            let guest_all_status = TestTask::sys_nt_query_system_information_ex(
+                SystemInformationClass::LogicalProcessorAndGroup as u32,
+                Some(const_byte_ptr(&all_relationship)),
+                DWORD_SIZE_U32,
+                mut_byte_ptr(&mut guest_output),
+                u32::try_from(guest_output.len()).unwrap(),
+                Some(mut_ptr(&mut guest_return_length)),
+            );
+            assert_eq!(guest_all_status, host_all_status);
+            assert_eq!(guest_all_status, NtStatus::SUCCESS);
+            assert!(host_return_length > 0);
+            assert_eq!(
+                guest_return_length,
+                u32::try_from(guest_output.len()).unwrap()
+            );
+
+            host_return_length = 0;
+            guest_return_length = 0;
+            let host_cache_status = query_host(
+                LogicalProcessorRelationship::Cache as u32,
+                &mut host_output,
+                &mut host_return_length,
+            );
+            let cache_relationship = LogicalProcessorRelationship::Cache as u32;
+            let guest_cache_status = TestTask::sys_nt_query_system_information_ex(
+                SystemInformationClass::LogicalProcessorAndGroup as u32,
+                Some(const_byte_ptr(&cache_relationship)),
+                DWORD_SIZE_U32,
+                mut_byte_ptr(&mut guest_output),
+                u32::try_from(guest_output.len()).unwrap(),
+                Some(mut_ptr(&mut guest_return_length)),
+            );
+            assert_eq!(guest_cache_status, host_cache_status);
+            assert_eq!(guest_cache_status, NtStatus::SUCCESS);
+            assert!(host_return_length >= size_of::<CacheRelationshipInformation>().trunc());
+            assert_eq!(
+                guest_return_length,
+                size_of::<CacheRelationshipInformation>().trunc()
+            );
+
+            host_return_length = u32::MAX;
+            guest_return_length = u32::MAX;
+            let host_unknown_status =
+                query_host(u32::MAX, &mut host_output, &mut host_return_length);
+            let guest_unknown_status = TestTask::sys_nt_query_system_information_ex(
+                SystemInformationClass::LogicalProcessorAndGroup as u32,
+                Some(const_byte_ptr(&u32::MAX)),
+                DWORD_SIZE_U32,
+                mut_byte_ptr(&mut guest_output),
+                u32::try_from(guest_output.len()).unwrap(),
+                Some(mut_ptr(&mut guest_return_length)),
+            );
+            assert_eq!(guest_unknown_status, host_unknown_status);
+            assert_eq!(guest_return_length, u32::MAX);
+        });
+    }
+
+    #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+    #[test]
+    fn nt_query_system_information_ex_feature_configuration_section_is_not_fabricated() {
+        run_with_test_platform_pointers(|| {
+            let request = [0u64; 4];
+            let mut host_output = [0u8; 0x68];
+            let mut guest_output = [0u8; 0x68];
+            let mut host_return_length = 0;
+            let mut guest_return_length = u32::MAX;
+
+            // SAFETY: This Windows-only test passes valid local input, output, and length pointers
+            // to ntdll and ntdll does not retain them.
+            let host_status = unsafe {
+                host_status(NtQuerySystemInformationEx(
+                    SystemInformationClass::FeatureConfigurationSection as u32,
+                    core::ptr::from_ref(&request).cast(),
+                    u32::try_from(core::mem::size_of_val(&request)).unwrap(),
+                    host_output.as_mut_ptr().cast(),
+                    u32::try_from(host_output.len()).unwrap(),
+                    &raw mut host_return_length,
+                ))
+            };
+            if host_status == NtStatus::SUCCESS {
+                assert_eq!(
+                    host_return_length,
+                    u32::try_from(host_output.len()).unwrap()
+                );
+                assert!(host_output.iter().any(|byte| *byte != 0));
+            }
+
+            assert_eq!(
+                TestTask::sys_nt_query_system_information_ex(
+                    SystemInformationClass::FeatureConfigurationSection as u32,
+                    Some(const_byte_ptr(&request)),
+                    u32::try_from(core::mem::size_of_val(&request)).unwrap(),
+                    mut_byte_ptr(&mut guest_output),
+                    u32::try_from(guest_output.len()).unwrap(),
+                    Some(mut_ptr(&mut guest_return_length)),
+                ),
+                NtStatus::INVALID_INFO_CLASS
+            );
+            assert_eq!(guest_return_length, u32::MAX);
         });
     }
 
@@ -1275,7 +1521,7 @@ mod tests {
             let mut conversion_error = 0u64;
 
             assert_eq!(
-                sys_nt_convert_between_auxiliary_counter_and_performance_counter(
+                TestTask::sys_nt_convert_between_auxiliary_counter_and_performance_counter(
                     0,
                     null_const_ptr(),
                     mut_ptr(&mut destination),
@@ -1284,7 +1530,7 @@ mod tests {
                 NtStatus::ACCESS_VIOLATION
             );
             assert_eq!(
-                sys_nt_convert_between_auxiliary_counter_and_performance_counter(
+                TestTask::sys_nt_convert_between_auxiliary_counter_and_performance_counter(
                     0,
                     const_ptr(&source),
                     mut_ptr(&mut destination),
@@ -1402,7 +1648,7 @@ mod tests {
                 ))
             };
             let guest_null_source_status =
-                sys_nt_convert_between_auxiliary_counter_and_performance_counter(
+                TestTask::sys_nt_convert_between_auxiliary_counter_and_performance_counter(
                     0,
                     null_const_ptr(),
                     mut_ptr(&mut destination),
@@ -1421,7 +1667,7 @@ mod tests {
                 ))
             };
             let guest_valid_source_status =
-                sys_nt_convert_between_auxiliary_counter_and_performance_counter(
+                TestTask::sys_nt_convert_between_auxiliary_counter_and_performance_counter(
                     0,
                     const_ptr(&source),
                     mut_ptr(&mut destination),

--- a/litebox_shim_windows/src/syscalls/sysinfo.rs
+++ b/litebox_shim_windows/src/syscalls/sysinfo.rs
@@ -1,14 +1,189 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-use litebox::platform::{Instant as _, RawConstPointer as _, RawMutPointer as _};
-use litebox_common_windows::nt_status::NtStatus;
+use core::mem::size_of;
 
-use crate::{ConstPtr, MutPtr, ShimFS, ShimPlatform, Task};
+use int_enum::IntEnum;
+use litebox::platform::{
+    Instant as _, PageManagementProvider, RawConstPointer as _, RawMutPointer as _,
+};
+use litebox_common_windows::nt_status::NtStatus;
+use zerocopy::{FromBytes, Immutable, IntoBytes};
+
+use crate::nt_types::GroupAffinity;
+use crate::{ConstPtr, MutPtr, PAGE_SIZE, ShimFS, ShimPlatform, Task};
 
 const QPC_FREQUENCY_HZ: i64 = 1_000_000_000;
+const MAXIMUM_NODE_COUNT: usize = 0x40;
+const TIMER_RESOLUTION_100NS: u32 = 156_250;
+const ALLOCATION_GRANULARITY: u32 = 0x1_0000;
+const DEFAULT_PHYSICAL_PAGES: u32 = 1024 * 1024;
+const NUMBER_OF_PROCESSORS: u8 = 1;
+const SUPPORTED_FLUSH_METHODS: u32 = 0x7;
+const SUPPORTED_FLUSH_PROCESSOR_FEATURES: u32 = 0x40;
+
+#[repr(u32)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, IntEnum)]
+enum SystemInformationClass {
+    Basic = 0,
+    Verifier = 50,
+    NumaProcessorMap = 55,
+    EmulationBasic = 62,
+    Flush = 192,
+    HypervisorSharedPage = 197,
+    ProcessorFeaturesBitMap = 250,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, FromBytes, Immutable, IntoBytes)]
+struct SystemBasicInformation {
+    reserved: u32,
+    timer_resolution: u32,
+    page_size: u32,
+    number_of_physical_pages: u32,
+    lowest_physical_page_number: u32,
+    highest_physical_page_number: u32,
+    allocation_granularity: u32,
+    _padding0: u32,
+    minimum_user_mode_address: usize,
+    maximum_user_mode_address: usize,
+    active_processors_affinity_mask: usize,
+    number_of_processors: u8,
+    _padding1: [u8; 7],
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, FromBytes, Immutable, IntoBytes)]
+struct SystemNumaInformation {
+    highest_node_number: u32,
+    reserved: u32,
+    active_processors_group_affinity: [GroupAffinity; MAXIMUM_NODE_COUNT],
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, FromBytes, Immutable, IntoBytes)]
+struct SystemFlushInformation {
+    supported_flush_methods: u32,
+    processor_features: u32,
+    reserved: [u32; 6],
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, FromBytes, Immutable, IntoBytes)]
+struct SystemHypervisorSharedPageInformation {
+    hypervisor_shared_user_va: usize,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, FromBytes, Immutable, IntoBytes)]
+struct SystemProcessorFeaturesBitMapInformation {
+    feature_bits: [u64; 2],
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, FromBytes, Immutable, IntoBytes)]
+struct SystemVerifierInformation {
+    flags: u64,
+}
 
 impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
+    pub(crate) fn sys_nt_query_system_information(
+        system_information_class: u32,
+        system_information: MutPtr<Platform, u8>,
+        system_information_length: u32,
+        return_length: Option<MutPtr<Platform, u32>>,
+    ) -> NtStatus {
+        let Ok(system_information_class) =
+            SystemInformationClass::try_from(system_information_class)
+        else {
+            litebox_util_log::debug!(
+                system_information_class = system_information_class;
+                "Unsupported NtQuerySystemInformation class"
+            );
+            return NtStatus::INVALID_INFO_CLASS;
+        };
+
+        let status = match system_information_class {
+            SystemInformationClass::Basic | SystemInformationClass::EmulationBasic => {
+                Self::write_system_information(
+                    system_information,
+                    system_information_length,
+                    return_length,
+                    &system_basic_information::<Platform>(),
+                )
+            }
+            SystemInformationClass::Verifier => Self::write_system_information(
+                system_information,
+                system_information_length,
+                return_length,
+                &SystemVerifierInformation { flags: 0 },
+            ),
+            SystemInformationClass::NumaProcessorMap => Self::write_system_information(
+                system_information,
+                system_information_length,
+                return_length,
+                &system_numa_information(),
+            ),
+            SystemInformationClass::Flush => Self::write_system_information(
+                system_information,
+                system_information_length,
+                return_length,
+                &system_flush_information(),
+            ),
+            SystemInformationClass::HypervisorSharedPage => Self::write_system_information(
+                system_information,
+                system_information_length,
+                return_length,
+                &SystemHypervisorSharedPageInformation {
+                    hypervisor_shared_user_va: 0,
+                },
+            ),
+            SystemInformationClass::ProcessorFeaturesBitMap => Self::write_system_information(
+                system_information,
+                system_information_length,
+                return_length,
+                &SystemProcessorFeaturesBitMapInformation {
+                    feature_bits: [0; 2],
+                },
+            ),
+        };
+
+        if status == NtStatus::SUCCESS {
+            litebox_util_log::debug!(
+                system_information_class:? = system_information_class,
+                system_information_length = system_information_length;
+                "Handled NtQuerySystemInformation syscall"
+            );
+        }
+
+        status
+    }
+
+    fn write_system_information<T: Immutable + IntoBytes>(
+        system_information: MutPtr<Platform, u8>,
+        system_information_length: u32,
+        return_length: Option<MutPtr<Platform, u32>>,
+        information: &T,
+    ) -> NtStatus {
+        let required_len = u32::try_from(size_of::<T>()).expect("system information fits in ULONG");
+        if let Some(return_length) = return_length
+            && return_length.write_at_offset(0, required_len).is_none()
+        {
+            return NtStatus::ACCESS_VIOLATION;
+        }
+        if system_information_length < required_len {
+            return NtStatus::INFO_LENGTH_MISMATCH;
+        }
+        if system_information
+            .write_slice_at_offset(0, information.as_bytes())
+            .is_none()
+        {
+            return NtStatus::ACCESS_VIOLATION;
+        }
+
+        NtStatus::SUCCESS
+    }
+
     pub(crate) fn sys_nt_query_performance_counter(
         &self,
         performance_counter: MutPtr<Platform, i64>,
@@ -55,6 +230,49 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
     }
 }
 
+fn system_basic_information<Platform: ShimPlatform>() -> SystemBasicInformation {
+    let maximum_user_mode_address =
+        <Platform as PageManagementProvider<PAGE_SIZE>>::TASK_ADDR_MAX.saturating_sub(1);
+    SystemBasicInformation {
+        reserved: 0,
+        timer_resolution: TIMER_RESOLUTION_100NS,
+        page_size: u32::try_from(PAGE_SIZE).expect("PAGE_SIZE fits in ULONG"),
+        number_of_physical_pages: DEFAULT_PHYSICAL_PAGES,
+        lowest_physical_page_number: 0,
+        highest_physical_page_number: DEFAULT_PHYSICAL_PAGES.saturating_sub(1),
+        allocation_granularity: ALLOCATION_GRANULARITY,
+        _padding0: 0,
+        minimum_user_mode_address: <Platform as PageManagementProvider<PAGE_SIZE>>::TASK_ADDR_MIN,
+        maximum_user_mode_address,
+        active_processors_affinity_mask: usize::from(NUMBER_OF_PROCESSORS),
+        number_of_processors: NUMBER_OF_PROCESSORS,
+        _padding1: [0; 7],
+    }
+}
+
+fn system_numa_information() -> SystemNumaInformation {
+    let mut active_processors_group_affinity = [GroupAffinity {
+        mask: 0,
+        group: 0,
+        reserved: [0; 3],
+    }; MAXIMUM_NODE_COUNT];
+    active_processors_group_affinity[0].mask = usize::from(NUMBER_OF_PROCESSORS);
+
+    SystemNumaInformation {
+        highest_node_number: 0,
+        reserved: 0,
+        active_processors_group_affinity,
+    }
+}
+
+fn system_flush_information() -> SystemFlushInformation {
+    SystemFlushInformation {
+        supported_flush_methods: SUPPORTED_FLUSH_METHODS,
+        processor_features: SUPPORTED_FLUSH_PROCESSOR_FEATURES,
+        reserved: [0; 6],
+    }
+}
+
 fn duration_as_qpc_ticks(duration: core::time::Duration) -> i64 {
     i64::try_from(core::cmp::min(duration.as_nanos(), i64::MAX as u128)).unwrap_or(i64::MAX)
 }
@@ -62,7 +280,7 @@ fn duration_as_qpc_ticks(duration: core::time::Duration) -> i64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tests::{const_ptr, mut_ptr, null_const_ptr, null_mut_ptr};
+    use crate::tests::{const_ptr, mut_byte_ptr, mut_ptr, null_const_ptr, null_mut_ptr};
     use core::time::Duration;
     use litebox::platform::ThreadProvider;
 
@@ -75,6 +293,13 @@ mod tests {
 
     #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
     unsafe extern "system" {
+        fn NtQuerySystemInformation(
+            system_information_class: u32,
+            system_information: *mut core::ffi::c_void,
+            system_information_length: u32,
+            return_length: *mut u32,
+        ) -> i32;
+
         fn NtQueryPerformanceCounter(counter: *mut i64, frequency: *mut i64) -> i32;
 
         fn NtConvertBetweenAuxiliaryCounterAndPerformanceCounter(
@@ -112,6 +337,268 @@ mod tests {
     fn qpc_delta_nanos(start: i64, end: i64) -> u128 {
         assert!(end >= start);
         u128::try_from(end - start).unwrap()
+    }
+
+    fn empty_basic_information() -> SystemBasicInformation {
+        SystemBasicInformation {
+            reserved: u32::MAX,
+            timer_resolution: 0,
+            page_size: 0,
+            number_of_physical_pages: 0,
+            lowest_physical_page_number: 0,
+            highest_physical_page_number: 0,
+            allocation_granularity: 0,
+            _padding0: 0,
+            minimum_user_mode_address: 0,
+            maximum_user_mode_address: 0,
+            active_processors_affinity_mask: 0,
+            number_of_processors: 0,
+            _padding1: [0; 7],
+        }
+    }
+
+    fn class_value(class: SystemInformationClass) -> u32 {
+        class as u32
+    }
+
+    fn sys_nt_query_system_information(
+        system_information_class: u32,
+        system_information: MutPtr<TestPlatform, u8>,
+        system_information_length: u32,
+        return_length: Option<MutPtr<TestPlatform, u32>>,
+    ) -> NtStatus {
+        Task::<TestPlatform, crate::tests::TestFS>::sys_nt_query_system_information(
+            system_information_class,
+            system_information,
+            system_information_length,
+            return_length,
+        )
+    }
+
+    #[test]
+    fn nt_query_system_information_reports_basic_information() {
+        run_with_test_platform_pointers(|| {
+            let mut info = empty_basic_information();
+            let mut return_length = 0;
+
+            assert_eq!(
+                sys_nt_query_system_information(
+                    class_value(SystemInformationClass::Basic),
+                    mut_byte_ptr(&mut info),
+                    u32::try_from(size_of::<SystemBasicInformation>()).unwrap(),
+                    Some(mut_ptr(&mut return_length)),
+                ),
+                NtStatus::SUCCESS
+            );
+
+            assert_eq!(
+                return_length,
+                u32::try_from(size_of::<SystemBasicInformation>()).unwrap()
+            );
+            assert_eq!(info.page_size, u32::try_from(PAGE_SIZE).unwrap());
+            assert_eq!(info.allocation_granularity, ALLOCATION_GRANULARITY);
+            assert_eq!(info.number_of_processors, NUMBER_OF_PROCESSORS);
+            assert_eq!(
+                info.minimum_user_mode_address,
+                <TestPlatform as PageManagementProvider<PAGE_SIZE>>::TASK_ADDR_MIN
+            );
+            assert_eq!(
+                info.maximum_user_mode_address,
+                <TestPlatform as PageManagementProvider<PAGE_SIZE>>::TASK_ADDR_MAX - 1
+            );
+        });
+    }
+
+    #[test]
+    fn nt_query_system_information_reports_selected_fixed_information() {
+        run_with_test_platform_pointers(|| {
+            let mut emulation = empty_basic_information();
+            let mut numa = SystemNumaInformation {
+                highest_node_number: u32::MAX,
+                reserved: u32::MAX,
+                active_processors_group_affinity: [GroupAffinity {
+                    mask: usize::MAX,
+                    group: u16::MAX,
+                    reserved: [u16::MAX; 3],
+                }; MAXIMUM_NODE_COUNT],
+            };
+            let mut flush = SystemFlushInformation {
+                supported_flush_methods: 0,
+                processor_features: 0,
+                reserved: [u32::MAX; 6],
+            };
+            let mut hypervisor = SystemHypervisorSharedPageInformation {
+                hypervisor_shared_user_va: usize::MAX,
+            };
+            let mut features = SystemProcessorFeaturesBitMapInformation {
+                feature_bits: [u64::MAX; 2],
+            };
+            let mut verifier = SystemVerifierInformation { flags: u64::MAX };
+
+            assert_eq!(
+                sys_nt_query_system_information(
+                    class_value(SystemInformationClass::EmulationBasic),
+                    mut_byte_ptr(&mut emulation),
+                    u32::try_from(size_of::<SystemBasicInformation>()).unwrap(),
+                    None,
+                ),
+                NtStatus::SUCCESS
+            );
+            assert_eq!(emulation.page_size, u32::try_from(PAGE_SIZE).unwrap());
+
+            assert_eq!(
+                sys_nt_query_system_information(
+                    class_value(SystemInformationClass::NumaProcessorMap),
+                    mut_byte_ptr(&mut numa),
+                    u32::try_from(size_of::<SystemNumaInformation>()).unwrap(),
+                    None,
+                ),
+                NtStatus::SUCCESS
+            );
+            assert_eq!(numa.highest_node_number, 0);
+            assert_eq!(numa.reserved, 0);
+            assert_eq!(
+                numa.active_processors_group_affinity[0].mask,
+                usize::from(NUMBER_OF_PROCESSORS)
+            );
+            assert!(
+                numa.active_processors_group_affinity[1..]
+                    .iter()
+                    .all(|affinity| affinity.mask == 0 && affinity.group == 0)
+            );
+
+            assert_eq!(
+                sys_nt_query_system_information(
+                    class_value(SystemInformationClass::Flush),
+                    mut_byte_ptr(&mut flush),
+                    u32::try_from(size_of::<SystemFlushInformation>()).unwrap(),
+                    None,
+                ),
+                NtStatus::SUCCESS
+            );
+            assert_eq!(flush.supported_flush_methods, SUPPORTED_FLUSH_METHODS);
+            assert_eq!(flush.processor_features, SUPPORTED_FLUSH_PROCESSOR_FEATURES);
+            assert_eq!(flush.reserved, [0; 6]);
+
+            assert_eq!(
+                sys_nt_query_system_information(
+                    class_value(SystemInformationClass::HypervisorSharedPage),
+                    mut_byte_ptr(&mut hypervisor),
+                    u32::try_from(size_of::<SystemHypervisorSharedPageInformation>()).unwrap(),
+                    None,
+                ),
+                NtStatus::SUCCESS
+            );
+            assert_eq!(hypervisor.hypervisor_shared_user_va, 0);
+
+            assert_eq!(
+                sys_nt_query_system_information(
+                    class_value(SystemInformationClass::ProcessorFeaturesBitMap),
+                    mut_byte_ptr(&mut features),
+                    u32::try_from(size_of::<SystemProcessorFeaturesBitMapInformation>()).unwrap(),
+                    None,
+                ),
+                NtStatus::SUCCESS
+            );
+            assert_eq!(features.feature_bits, [0; 2]);
+
+            assert_eq!(
+                sys_nt_query_system_information(
+                    class_value(SystemInformationClass::Verifier),
+                    mut_byte_ptr(&mut verifier),
+                    u32::try_from(size_of::<SystemVerifierInformation>()).unwrap(),
+                    None,
+                ),
+                NtStatus::SUCCESS
+            );
+            assert_eq!(verifier.flags, 0);
+        });
+    }
+
+    #[test]
+    fn nt_query_system_information_validates_class_and_buffer_length() {
+        run_with_test_platform_pointers(|| {
+            let mut info = [0u8; size_of::<SystemBasicInformation>()];
+            let mut return_length = 0;
+
+            assert_eq!(
+                sys_nt_query_system_information(
+                    class_value(SystemInformationClass::Basic),
+                    mut_byte_ptr(&mut info),
+                    u32::try_from(size_of::<SystemBasicInformation>() - 1).unwrap(),
+                    Some(mut_ptr(&mut return_length)),
+                ),
+                NtStatus::INFO_LENGTH_MISMATCH
+            );
+            assert_eq!(
+                return_length,
+                u32::try_from(size_of::<SystemBasicInformation>()).unwrap()
+            );
+
+            assert_eq!(
+                sys_nt_query_system_information(
+                    1,
+                    mut_byte_ptr(&mut info),
+                    u32::try_from(info.len()).unwrap(),
+                    None,
+                ),
+                NtStatus::INVALID_INFO_CLASS
+            );
+        });
+    }
+
+    #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+    #[test]
+    fn nt_query_system_information_basic_status_matches_host_ntdll() {
+        run_with_test_platform_pointers(|| {
+            let mut host_info = [0u8; size_of::<SystemBasicInformation>()];
+            let mut host_return_length = 0;
+            let mut guest_info = empty_basic_information();
+            let mut guest_return_length = 0;
+            let information_length = u32::try_from(size_of::<SystemBasicInformation>()).unwrap();
+
+            // SAFETY: The output buffer and return-length pointer are valid locals and ntdll does
+            // not retain them.
+            let host_basic_status = unsafe {
+                host_status(NtQuerySystemInformation(
+                    class_value(SystemInformationClass::Basic),
+                    host_info.as_mut_ptr().cast(),
+                    information_length,
+                    &raw mut host_return_length,
+                ))
+            };
+            let guest_status = sys_nt_query_system_information(
+                class_value(SystemInformationClass::Basic),
+                mut_byte_ptr(&mut guest_info),
+                information_length,
+                Some(mut_ptr(&mut guest_return_length)),
+            );
+            assert_eq!(guest_status, host_basic_status);
+            assert_eq!(guest_return_length, host_return_length);
+            assert_eq!(guest_info.page_size, u32::try_from(PAGE_SIZE).unwrap());
+            assert_eq!(guest_info.allocation_granularity, ALLOCATION_GRANULARITY);
+
+            let mut host_short_return_length = 0;
+            let mut guest_short_return_length = 0;
+            // SAFETY: Passing a short valid output buffer probes host ntdll's length handling; all
+            // pointers are valid local variables.
+            let host_short_status = unsafe {
+                host_status(NtQuerySystemInformation(
+                    class_value(SystemInformationClass::Basic),
+                    host_info.as_mut_ptr().cast(),
+                    information_length - 1,
+                    &raw mut host_short_return_length,
+                ))
+            };
+            let guest_short_status = sys_nt_query_system_information(
+                class_value(SystemInformationClass::Basic),
+                mut_byte_ptr(&mut guest_info),
+                information_length - 1,
+                Some(mut_ptr(&mut guest_short_return_length)),
+            );
+            assert_eq!(guest_short_status, host_short_status);
+            assert_eq!(guest_short_return_length, host_short_return_length);
+        });
     }
 
     #[test]


### PR DESCRIPTION
Add Windows shim support for `NtQuerySystemInformation` and `NtQuerySystemInformationEx`. The implementation models a stable synthetic environment instead of exposing host topology: one processor, one NUMA entry, fixed memory/CPU/cache/flush values.
