### PR TITLE
Initialize more Windows PEB fields

### DIFF
--- a/litebox_common_windows/src/loader.rs
+++ b/litebox_common_windows/src/loader.rs
@@ -54,6 +54,8 @@ pub struct PeImageInfo {
 pub struct MappingInfo {
     pub base_addr: usize,
     pub image_size: usize,
+    /// image_size + trampoline size
+    pub mapping_size: usize,
     pub entry_point: usize,
 }
 
@@ -112,6 +114,195 @@ pub struct KiUserInvertedFunctionTableEntry {
     pub image_base: usize,
     pub image_size: u32,
     pub size_of_table: u32,
+}
+
+pub const API_SET_NAMESPACE_VERSION: u32 = 6;
+pub const API_SET_NAMESPACE_HASH_FACTOR: u32 = 31;
+pub const MAX_API_SET_NAMESPACE_SIZE: usize = 16 * 1024 * 1024;
+const API_SET_NAMESPACE_ENTRY_FLAGS: u32 = 1;
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, FromBytes, Immutable, IntoBytes)]
+pub struct ApiSetNamespace {
+    pub version: u32,
+    pub size: u32,
+    pub flags: u32,
+    pub count: u32,
+    pub entry_offset: u32,
+    pub hash_offset: u32,
+    pub hash_factor: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, FromBytes, Immutable, IntoBytes)]
+pub struct ApiSetNamespaceEntry {
+    pub flags: u32,
+    pub name_offset: u32,
+    pub name_length: u32,
+    pub hashed_length: u32,
+    pub value_offset: u32,
+    pub value_count: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, FromBytes, Immutable, IntoBytes)]
+pub struct ApiSetValueEntry {
+    pub flags: u32,
+    pub name_offset: u32,
+    pub name_length: u32,
+    pub value_offset: u32,
+    pub value_length: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, FromBytes, Immutable, IntoBytes)]
+pub struct ApiSetHashEntry {
+    pub hash: u32,
+    pub index: u32,
+}
+
+#[derive(Debug, Error)]
+pub enum ApiSetNamespaceBuildError {
+    #[error("API-set namespace field overflow")]
+    Overflow,
+    #[error("API-set namespace is too large")]
+    TooLarge,
+}
+
+pub fn build_api_set_namespace(
+    mappings: &[(&str, &str)],
+) -> Result<Vec<u8>, ApiSetNamespaceBuildError> {
+    let mut mappings = mappings.to_vec();
+    mappings.sort_by_key(|mapping| mapping.0);
+
+    let count = mappings.len();
+    let entry_offset = size_of::<ApiSetNamespace>();
+    let value_offset = api_set_checked_add(
+        entry_offset,
+        api_set_checked_mul(count, size_of::<ApiSetNamespaceEntry>())?,
+    )?;
+    let strings_offset = api_set_checked_add(
+        value_offset,
+        api_set_checked_mul(count, size_of::<ApiSetValueEntry>())?,
+    )?;
+    let mut string_data = Vec::new();
+    let mut entries = Vec::with_capacity(count);
+    let mut values = Vec::with_capacity(count);
+    let mut hashes = Vec::with_capacity(count);
+
+    for (index, (contract, host_dll)) in mappings.iter().enumerate() {
+        let name = utf16_bytes(contract)?;
+        let host = utf16_bytes(host_dll)?;
+        let name_offset = api_set_checked_add(strings_offset, string_data.len())?;
+        string_data.extend_from_slice(&name);
+        let host_offset = api_set_checked_add(strings_offset, string_data.len())?;
+        string_data.extend_from_slice(&host);
+        let value_entry_offset = api_set_checked_add(
+            value_offset,
+            api_set_checked_mul(index, size_of::<ApiSetValueEntry>())?,
+        )?;
+        entries.push(ApiSetNamespaceEntry {
+            flags: API_SET_NAMESPACE_ENTRY_FLAGS,
+            name_offset: api_set_to_u32(name_offset)?,
+            name_length: api_set_to_u32(name.len())?,
+            hashed_length: api_set_to_u32(
+                api_set_hashed_name_len(contract)
+                    .checked_mul(size_of::<u16>())
+                    .ok_or(ApiSetNamespaceBuildError::Overflow)?,
+            )?,
+            value_offset: api_set_to_u32(value_entry_offset)?,
+            value_count: 1,
+        });
+        values.push(ApiSetValueEntry {
+            flags: 0,
+            name_offset: 0,
+            name_length: 0,
+            value_offset: api_set_to_u32(host_offset)?,
+            value_length: api_set_to_u32(host.len())?,
+        });
+        hashes.push(ApiSetHashEntry {
+            hash: api_set_hash(contract),
+            index: api_set_to_u32(index)?,
+        });
+    }
+
+    let hash_offset =
+        api_set_checked_add(strings_offset, string_data.len())?.next_multiple_of(size_of::<u32>());
+    let size = api_set_checked_add(
+        hash_offset,
+        api_set_checked_mul(count, size_of::<ApiSetHashEntry>())?,
+    )?;
+    if size > MAX_API_SET_NAMESPACE_SIZE {
+        return Err(ApiSetNamespaceBuildError::TooLarge);
+    }
+    hashes.sort_by_key(|entry| (entry.hash, entry.index));
+
+    let namespace = ApiSetNamespace {
+        version: API_SET_NAMESPACE_VERSION,
+        size: api_set_to_u32(size)?,
+        flags: 0,
+        count: api_set_to_u32(count)?,
+        entry_offset: api_set_to_u32(entry_offset)?,
+        hash_offset: api_set_to_u32(hash_offset)?,
+        hash_factor: API_SET_NAMESPACE_HASH_FACTOR,
+    };
+
+    let mut bytes = Vec::with_capacity(size);
+    bytes.extend_from_slice(namespace.as_bytes());
+    for entry in &entries {
+        bytes.extend_from_slice(entry.as_bytes());
+    }
+    for value in &values {
+        bytes.extend_from_slice(value.as_bytes());
+    }
+    bytes.extend_from_slice(&string_data);
+    bytes.resize(hash_offset, 0);
+    for hash in &hashes {
+        bytes.extend_from_slice(hash.as_bytes());
+    }
+    debug_assert_eq!(bytes.len(), size);
+    Ok(bytes)
+}
+
+#[must_use]
+pub fn api_set_hash(name: &str) -> u32 {
+    name[..api_set_hashed_name_len(name)]
+        .bytes()
+        .fold(0, |hash, byte| {
+            hash.wrapping_mul(API_SET_NAMESPACE_HASH_FACTOR)
+                .wrapping_add(u32::from(byte.to_ascii_lowercase()))
+        })
+}
+
+fn api_set_hashed_name_len(name: &str) -> usize {
+    name.rfind('-').unwrap_or(name.len())
+}
+
+fn utf16_bytes(value: &str) -> Result<Vec<u8>, ApiSetNamespaceBuildError> {
+    let mut bytes = Vec::with_capacity(
+        value
+            .len()
+            .checked_mul(size_of::<u16>())
+            .ok_or(ApiSetNamespaceBuildError::Overflow)?,
+    );
+    for unit in value.encode_utf16() {
+        bytes.extend_from_slice(&unit.to_le_bytes());
+    }
+    Ok(bytes)
+}
+
+fn api_set_checked_add(left: usize, right: usize) -> Result<usize, ApiSetNamespaceBuildError> {
+    left.checked_add(right)
+        .ok_or(ApiSetNamespaceBuildError::Overflow)
+}
+
+fn api_set_checked_mul(left: usize, right: usize) -> Result<usize, ApiSetNamespaceBuildError> {
+    left.checked_mul(right)
+        .ok_or(ApiSetNamespaceBuildError::Overflow)
+}
+
+fn api_set_to_u32(value: usize) -> Result<u32, ApiSetNamespaceBuildError> {
+    u32::try_from(value).map_err(|_| ApiSetNamespaceBuildError::Overflow)
 }
 
 /// Errors that can occur when parsing a PE file.
@@ -217,6 +408,12 @@ impl PeParsedFile {
     #[must_use]
     pub fn image_size(&self) -> usize {
         self.image.size_of_image
+    }
+
+    /// Returns the PE entry-point RVA from the optional header.
+    #[must_use]
+    pub fn entry_point_rva(&self) -> usize {
+        self.image.entry_point_rva
     }
 
     /// Returns the preferred image base from the optional header.
@@ -375,8 +572,8 @@ impl PeParsedFile {
                 .map_err(PeLoadError::Map)?;
         }
 
-        if self.trampoline.is_some() {
-            self.load_trampoline(mapper, mem, base_addr)?;
+        if let Some(trampoline) = &self.trampoline {
+            Self::load_trampoline(mapper, mem, base_addr, trampoline)?;
         }
 
         let entry_point = checked_add!(
@@ -387,7 +584,8 @@ impl PeParsedFile {
 
         Ok(MappingInfo {
             base_addr,
-            image_size: mapping_size,
+            image_size,
+            mapping_size,
             entry_point,
         })
     }
@@ -589,12 +787,14 @@ impl PeParsedFile {
     }
 
     fn load_trampoline<M: MapMemory>(
-        &self,
         mapper: &mut M,
         mem: &mut impl AccessMemory,
         base_addr: usize,
+        trampoline: &PeTrampolineInfo,
     ) -> Result<(), PeLoadError<M::Error>> {
-        let trampoline = self.trampoline.as_ref().unwrap();
+        if trampoline.size == 0 {
+            return Ok(());
+        }
         let trampoline_start = base_addr
             .checked_add(trampoline.rva)
             .ok_or(PeLoadError::InvalidImage)?;

--- a/litebox_common_windows/src/loader.rs
+++ b/litebox_common_windows/src/loader.rs
@@ -161,19 +161,69 @@ pub struct ApiSetHashEntry {
     pub index: u32,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ApiSetMapping<'a> {
+    /// API-set contract name, such as `api-ms-win-core-file-l1-2-3`.
+    pub contract: &'a str,
+    /// Host DLL name used as the default namespace value for the contract.
+    pub host_dll: &'a str,
+    /// Optional exact contract prefix used when computing the namespace hash.
+    pub hashed_prefix: Option<&'a str>,
+}
+
+impl<'a> ApiSetMapping<'a> {
+    /// Creates a mapping whose hash prefix is derived by trimming the last dash suffix.
+    #[must_use]
+    pub const fn new(contract: &'a str, host_dll: &'a str) -> Self {
+        Self {
+            contract,
+            host_dll,
+            hashed_prefix: None,
+        }
+    }
+
+    /// Creates a mapping with an explicit hash prefix for contracts that do not follow the
+    /// usual version-suffix naming pattern.
+    #[must_use]
+    pub const fn with_hashed_prefix(
+        contract: &'a str,
+        host_dll: &'a str,
+        hashed_prefix: &'a str,
+    ) -> Self {
+        Self {
+            contract,
+            host_dll,
+            hashed_prefix: Some(hashed_prefix),
+        }
+    }
+}
+
 #[derive(Debug, Error)]
 pub enum ApiSetNamespaceBuildError {
     #[error("API-set namespace field overflow")]
     Overflow,
     #[error("API-set namespace is too large")]
     TooLarge,
+    #[error("API-set namespace mapping has an invalid hashed prefix")]
+    InvalidHashedPrefix,
 }
 
 pub fn build_api_set_namespace(
     mappings: &[(&str, &str)],
 ) -> Result<Vec<u8>, ApiSetNamespaceBuildError> {
+    let mappings = mappings
+        .iter()
+        .map(|&(contract, host_dll)| ApiSetMapping::new(contract, host_dll))
+        .collect::<Vec<_>>();
+    build_api_set_namespace_from_mappings(&mappings)
+}
+
+/// Builds an API-set namespace from mappings that can carry explicit hash prefixes.
+pub fn build_api_set_namespace_from_mappings(
+    mappings: &[ApiSetMapping<'_>],
+) -> Result<Vec<u8>, ApiSetNamespaceBuildError> {
     let mut mappings = mappings.to_vec();
-    mappings.sort_by_key(|mapping| mapping.0);
+    mappings.sort_by(|left, right| left.contract.cmp(right.contract));
 
     let count = mappings.len();
     let entry_offset = size_of::<ApiSetNamespace>();
@@ -190,7 +240,16 @@ pub fn build_api_set_namespace(
     let mut values = Vec::with_capacity(count);
     let mut hashes = Vec::with_capacity(count);
 
-    for (index, (contract, host_dll)) in mappings.iter().enumerate() {
+    for (index, mapping) in mappings.iter().enumerate() {
+        let contract = mapping.contract;
+        let host_dll = mapping.host_dll;
+        let hashed_prefix = mapping
+            .hashed_prefix
+            .unwrap_or_else(|| &contract[..api_set_hashed_name_len(contract)]);
+        if !hashed_prefix.is_ascii() || !contract.starts_with(hashed_prefix) {
+            return Err(ApiSetNamespaceBuildError::InvalidHashedPrefix);
+        }
+
         let name = utf16_bytes(contract)?;
         let host = utf16_bytes(host_dll)?;
         let name_offset = api_set_checked_add(strings_offset, string_data.len())?;
@@ -205,11 +264,7 @@ pub fn build_api_set_namespace(
             flags: API_SET_NAMESPACE_ENTRY_FLAGS,
             name_offset: api_set_to_u32(name_offset)?,
             name_length: api_set_to_u32(name.len())?,
-            hashed_length: api_set_to_u32(
-                api_set_hashed_name_len(contract)
-                    .checked_mul(size_of::<u16>())
-                    .ok_or(ApiSetNamespaceBuildError::Overflow)?,
-            )?,
+            hashed_length: api_set_to_u32(utf16_byte_len(hashed_prefix)?)?,
             value_offset: api_set_to_u32(value_entry_offset)?,
             value_count: 1,
         });
@@ -221,7 +276,7 @@ pub fn build_api_set_namespace(
             value_length: api_set_to_u32(host.len())?,
         });
         hashes.push(ApiSetHashEntry {
-            hash: api_set_hash(contract),
+            hash: api_set_hash_prefix(hashed_prefix),
             index: api_set_to_u32(index)?,
         });
     }
@@ -266,12 +321,16 @@ pub fn build_api_set_namespace(
 
 #[must_use]
 pub fn api_set_hash(name: &str) -> u32 {
-    name[..api_set_hashed_name_len(name)]
-        .bytes()
-        .fold(0, |hash, byte| {
-            hash.wrapping_mul(API_SET_NAMESPACE_HASH_FACTOR)
-                .wrapping_add(u32::from(byte.to_ascii_lowercase()))
-        })
+    api_set_hash_prefix(&name[..api_set_hashed_name_len(name)])
+}
+
+/// Computes the API-set hash for an already selected contract prefix.
+#[must_use]
+pub fn api_set_hash_prefix(prefix: &str) -> u32 {
+    prefix.bytes().fold(0, |hash, byte| {
+        hash.wrapping_mul(API_SET_NAMESPACE_HASH_FACTOR)
+            .wrapping_add(u32::from(byte.to_ascii_lowercase()))
+    })
 }
 
 fn api_set_hashed_name_len(name: &str) -> usize {
@@ -289,6 +348,14 @@ fn utf16_bytes(value: &str) -> Result<Vec<u8>, ApiSetNamespaceBuildError> {
         bytes.extend_from_slice(&unit.to_le_bytes());
     }
     Ok(bytes)
+}
+
+fn utf16_byte_len(value: &str) -> Result<usize, ApiSetNamespaceBuildError> {
+    value
+        .encode_utf16()
+        .count()
+        .checked_mul(size_of::<u16>())
+        .ok_or(ApiSetNamespaceBuildError::Overflow)
 }
 
 fn api_set_checked_add(left: usize, right: usize) -> Result<usize, ApiSetNamespaceBuildError> {

--- a/litebox_common_windows/src/nt_status.rs
+++ b/litebox_common_windows/src/nt_status.rs
@@ -87,6 +87,7 @@ impl NtStatus {
                 "STATUS_WAIT_3: Caller specified WaitAny and one of the dispatcher objects was set"
             }
             0x00000102 => "STATUS_TIMEOUT: The given timeout interval expired",
+            0x00000103 => "STATUS_PENDING: The operation that was requested is pending completion",
             0x00010001 => "DBG_EXCEPTION_HANDLED: Exception handled by debugger",
             0x00010002 => "DBG_CONTINUE: Continue from exception",
             0x40000000 => "STATUS_OBJECT_NAME_EXISTS: The object name already exists",
@@ -209,6 +210,9 @@ impl NtStatus {
 
     /// STATUS_SUCCESS
     pub const SUCCESS: Self = Self::from_raw(0x00000000);
+
+    /// STATUS_PENDING
+    pub const PENDING: Self = Self::from_raw(0x00000103);
 
     /// STATUS_WAIT_1
     pub const WAIT_1: Self = Self::from_raw(0x00000001);

--- a/litebox_shim_windows/src/lib.rs
+++ b/litebox_shim_windows/src/lib.rs
@@ -304,11 +304,11 @@ impl<Platform: ShimPlatform, FS: ShimFS> WindowsShim<Platform, FS> {
         &self,
         fs: Arc<FS>,
         path: &str,
-        _argv: Vec<alloc::ffi::CString>,
-        _envp: Vec<alloc::ffi::CString>,
+        argv: Vec<alloc::ffi::CString>,
+        envp: Vec<alloc::ffi::CString>,
     ) -> Result<LoadedProgram<Platform, FS>, loader::WindowsLoadError> {
-        let load_info =
-            loader::PeLoader::new(self.0.platform, fs.clone(), &self.0.page_manager).load(path)?;
+        let load_info = loader::PeLoader::new(self.0.platform, fs.clone(), &self.0.page_manager)
+            .load(path, &argv, &envp)?;
         let process = Arc::new(Process {
             ntdll_mapping: load_info.ntdll_mapping,
             peb_address: load_info.environment.peb,

--- a/litebox_shim_windows/src/lib.rs
+++ b/litebox_shim_windows/src/lib.rs
@@ -116,6 +116,21 @@ where
     ptr.write_at_offset(0, value)
 }
 
+fn write_field_at_offset<Platform, Struct, Field>(
+    base: MutPtr<Platform, Struct>,
+    field_offset: usize,
+    value: Field,
+) -> Option<()>
+where
+    Platform: RawPointerProvider,
+    Struct: zerocopy::FromBytes + zerocopy::IntoBytes,
+    Field: zerocopy::FromBytes + zerocopy::IntoBytes,
+{
+    let address = base.as_usize().checked_add(field_offset)?;
+    let ptr = MutPtr::<Platform, Field>::from_usize(address);
+    ptr.write_at_offset(0, value)
+}
+
 fn write_slice<Platform, T>(address: usize, values: &[T]) -> Option<()>
 where
     Platform: RawPointerProvider,

--- a/litebox_shim_windows/src/lib.rs
+++ b/litebox_shim_windows/src/lib.rs
@@ -313,8 +313,6 @@ pub struct WindowsShim<Platform: ShimPlatform, FS: ShimFS>(Arc<GlobalState<Platf
 
 impl<Platform: ShimPlatform, FS: ShimFS> WindowsShim<Platform, FS> {
     /// Loads the program at `path` as the shim's initial task.
-    ///
-    /// TODO: PEB/TEB setup and initial handle table state are not yet implemented.
     pub fn load_program(
         &self,
         fs: Arc<FS>,

--- a/litebox_shim_windows/src/loader/pe.rs
+++ b/litebox_shim_windows/src/loader/pe.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 use alloc::collections::btree_map::BTreeMap;
-use alloc::{string::String, sync::Arc, vec::Vec};
+use alloc::{ffi::CString, string::String, sync::Arc, vec::Vec};
 use core::{marker::PhantomData, mem::size_of};
 use litebox::platform::{RawConstPointer as _, RawMutPointer as _};
 use litebox::utils::TruncateExt as _;
@@ -16,7 +16,8 @@ use litebox::{
 use litebox_common_windows::loader::{
     AccessMemory, Fault, KiUserInvertedFunctionTableEntry, KiUserInvertedFunctionTableHeader,
     MAXIMUM_INVERTED_FUNCTION_TABLE_SIZE, MapMemory, MappingInfo, PAGE_SIZE, PeExportError,
-    PeLoadError, PeParseError, PeParsedFile, Protection, ReadAt, page_align_down,
+    PeLoadError, PeParseError, PeParsedFile, Protection, ReadAt, build_api_set_namespace,
+    page_align_down,
 };
 use rangemap::RangeMap;
 use thiserror::Error;
@@ -38,10 +39,8 @@ const INITIAL_STACK_SIZE: usize = 1024 * 1024;
 const WINDOWS_SHARED_SECTION_SIZE: usize = 0x1_0000;
 const CSR_SERVER_DLL_MAX: usize = 4;
 const BASESRV_SERVERDLL_INDEX: usize = 1;
-// TODO: this is an artificial offset and should be replaced with the actual offset
-const WINDOWS_STATIC_SERVER_DATA_TABLE_OFFSET: usize = 0x750;
-const WINDOWS_BASE_STATIC_SERVER_DATA_OFFSET: usize =
-    WINDOWS_STATIC_SERVER_DATA_TABLE_OFFSET + CSR_SERVER_DLL_MAX * core::mem::size_of::<usize>();
+const WINDOWS_DIRECTORY: &str = r"C:\Windows";
+const WINDOWS_SYSTEM_DIRECTORY: &str = r"C:\Windows\System32";
 const WINDOWS_OS_MAJOR_VERSION: u32 = 10;
 const WINDOWS_OS_MINOR_VERSION: u32 = 0;
 const WINDOWS_OS_BUILD_NUMBER: u16 = 19041;
@@ -54,10 +53,6 @@ const WINDOWS_HEAP_DECOMMIT_FREE_BLOCK_THRESHOLD: u64 = PAGE_SIZE as u64;
 const WINDOWS_NT_TIB_VERSION: usize = 30 << 8;
 const INITIAL_PROCESS_ID: usize = 1;
 const INITIAL_THREAD_ID: usize = 1;
-const API_SET_NAMESPACE_VERSION: u32 = 6;
-const API_SET_NAMESPACE_ENTRY_FLAGS: u32 = 1;
-const API_SET_NAMESPACE_HASH_FACTOR: u32 = 31;
-const MAX_API_SET_NAMESPACE_SIZE: usize = 16 * 1024 * 1024;
 
 pub(crate) struct WindowsProcessEnvironment {
     pub(crate) peb: usize,
@@ -71,6 +66,16 @@ pub(crate) struct PeLoadInfo<Platform: crate::ShimPlatform> {
     pub(crate) ntdll_mapping: Option<MappingInfo>,
     pub(crate) virtual_allocations: crate::WindowsVirtualAllocations<Platform>,
     pub(crate) environment: WindowsProcessEnvironment,
+}
+
+struct ProcessEnvironmentInput<'a> {
+    image: &'a PeParsedFile,
+    image_base_address: usize,
+    image_path: &'a str,
+    argv: &'a [CString],
+    envp: &'a [CString],
+    stack_base: usize,
+    stack_allocation_top: usize,
 }
 
 pub(crate) struct PeLoader<'a, Platform: crate::ShimPlatform, FS: ShimFS> {
@@ -92,15 +97,15 @@ impl<'a, Platform: crate::ShimPlatform, FS: ShimFS> PeLoader<'a, Platform, FS> {
         }
     }
 
-    pub(crate) fn load(&self, path: &str) -> Result<PeLoadInfo<Platform>, WindowsLoadError> {
+    pub(crate) fn load(
+        &self,
+        path: &str,
+        argv: &[CString],
+        envp: &[CString],
+    ) -> Result<PeLoadInfo<Platform>, WindowsLoadError> {
         let image = load_image(self.platform, self.fs.clone(), path, self.page_manager)?;
         let application_entry_point = image.mapping.entry_point;
-        let ntdll = load_ntdll(
-            self.platform,
-            self.fs.clone(),
-            self.page_manager,
-            NTDLL_PATHS,
-        )?;
+        let ntdll = load_ntdll(self.platform, self.fs.clone(), self.page_manager)?;
 
         let entry_point = if let Some(ntdll) = &ntdll {
             if !ntdll.image.parsed.has_trampoline() {
@@ -119,25 +124,27 @@ impl<'a, Platform: crate::ShimPlatform, FS: ShimFS> PeLoader<'a, Platform, FS> {
         let stack_base = unsafe {
             self.page_manager
                 .create_stack_pages(None, length, CreatePagesFlags::empty())
-                .map_err(PeImageAccessError::Mapping)?
-        };
-        let stack_top = stack_base
+        }
+        .map_err(PeImageAccessError::Mapping)?;
+        let stack_allocation_top = stack_base
             .as_usize()
             .checked_add(INITIAL_STACK_SIZE)
             .ok_or(PeImageAccessError::AddressOverflow)?;
-        let stack_top = if stack_top.is_multiple_of(16) {
-            stack_top - core::mem::size_of::<usize>()
+        let stack_top = if stack_allocation_top.is_multiple_of(16) {
+            stack_allocation_top - core::mem::size_of::<usize>()
         } else {
-            stack_top
+            stack_allocation_top
         };
 
-        let environment = self.create_process_environment(
-            &image.parsed,
-            image.mapping.base_addr,
-            path,
-            stack_base.as_usize(),
-            stack_top,
-        )?;
+        let environment = self.create_process_environment(ProcessEnvironmentInput {
+            image: &image.parsed,
+            image_base_address: image.mapping.base_addr,
+            image_path: path,
+            argv,
+            envp,
+            stack_base: stack_base.as_usize(),
+            stack_allocation_top,
+        })?;
         if let Some(ntdll) = &ntdll {
             let context = X64Context::initial_thread_context(
                 ntdll.exports.rtl_user_thread_start,
@@ -209,16 +216,14 @@ impl<'a, Platform: crate::ShimPlatform, FS: ShimFS> PeLoader<'a, Platform, FS> {
 
     fn create_process_environment(
         &self,
-        image: &PeParsedFile,
-        image_base_address: usize,
-        image_path: &str,
-        stack_base: usize,
-        stack_top: usize,
+        input: ProcessEnvironmentInput<'_>,
     ) -> Result<WindowsProcessEnvironment, WindowsLoadError> {
         let create_pages = |size: usize| -> Result<usize, PeImageAccessError> {
             let aligned_length = size.next_multiple_of(PAGE_SIZE);
             let length =
                 NonZeroPageSize::new(aligned_length).ok_or(PeImageAccessError::AddressOverflow)?;
+            // SAFETY: `suggested_address` is `None` and `CreatePagesFlags::empty()` leaves address
+            // selection to the page manager, so this cannot replace an existing mapping.
             let ptr = unsafe {
                 self.page_manager.create_writable_pages(
                     None,
@@ -227,27 +232,34 @@ impl<'a, Platform: crate::ShimPlatform, FS: ShimFS> PeLoader<'a, Platform, FS> {
                     |_| Ok(0),
                 )
             }?;
-            let base = ptr.as_usize();
-            Ok(base)
+            Ok(ptr.as_usize())
         };
-        let teb_ptr = create_pages(core::mem::size_of::<ThreadEnvironmentBlock>())?;
-        let peb_ptr = create_pages(core::mem::size_of::<ProcessEnvironmentBlock>())?;
-        let api_set_map = build_api_set_namespace()?;
+        let teb_ptr = create_pages(size_of::<ThreadEnvironmentBlock>())?;
+        let peb_ptr = create_pages(size_of::<ProcessEnvironmentBlock>())?;
+        let api_set_map = build_api_set_namespace(API_SET_MAPPINGS)
+            .map_err(|_| PeImageAccessError::AddressOverflow)?;
         let api_set_map_ptr = create_pages(api_set_map.len())?;
         crate::write_slice::<Platform, _>(api_set_map_ptr, &api_set_map)
             .ok_or(PeImageAccessError::MemoryAccess)?;
-        let ctx_ptr = create_pages(core::mem::size_of::<X64Context>())?;
+        let ctx_ptr = create_pages(size_of::<X64Context>())?;
 
-        let dos_image_path = dos_image_path(image_path);
+        let win32_image_path = win32_image_path(input.image_path);
+        let dos_image_path = dos_image_path(input.image_path);
         let current_directory_path = Utf16StringBuffer::new(r"C:\")?;
         let dll_path = Utf16StringBuffer::new(r"C:\Windows\System32;C:\")?;
         let image_path_name = Utf16StringBuffer::new(&dos_image_path)?;
-        let command_line = Utf16StringBuffer::new(&dos_image_path)?;
+        let command_line =
+            Utf16StringBuffer::new(&windows_command_line(&win32_image_path, input.argv))?;
         let window_title = Utf16StringBuffer::new(&dos_image_path)?;
         let desktop_info = Utf16StringBuffer::new("")?;
         let shell_info = Utf16StringBuffer::new("")?;
         let runtime_data = Utf16StringBuffer::new("")?;
         let redirection_dll_name = Utf16StringBuffer::new("")?;
+        let environment_block = windows_environment_block(input.envp);
+        let environment_size = checked_mul(environment_block.len(), size_of::<u16>())?;
+        let environment_ptr = create_pages(environment_size)?;
+        crate::write_slice::<Platform, _>(environment_ptr, &environment_block)
+            .ok_or(PeImageAccessError::MemoryAccess)?;
         let process_parameter_strings = [
             &current_directory_path,
             &dll_path,
@@ -260,7 +272,7 @@ impl<'a, Platform: crate::ShimPlatform, FS: ShimFS> PeLoader<'a, Platform, FS> {
             &redirection_dll_name,
         ];
         let process_parameters_length = process_parameter_strings.iter().try_fold(
-            core::mem::size_of::<RtlUserProcessParameters>(),
+            size_of::<RtlUserProcessParameters>(),
             |length, string| {
                 length
                     .checked_add(usize::from(string.maximum_length))
@@ -272,35 +284,34 @@ impl<'a, Platform: crate::ShimPlatform, FS: ShimFS> PeLoader<'a, Platform, FS> {
         let process_parameters_ptr = create_pages(process_parameters_length)?;
 
         let mut process_parameters = RtlUserProcessParameters::new_zeroed();
-        process_parameters.maximum_length = u32::try_from(process_parameters_allocation_length)
-            .map_err(|_| PeImageAccessError::AddressOverflow)?;
-        process_parameters.length = u32::try_from(process_parameters_length)
-            .map_err(|_| PeImageAccessError::AddressOverflow)?;
+        process_parameters.maximum_length = to_u32(process_parameters_allocation_length)?;
+        process_parameters.length = to_u32(process_parameters_length)?;
         process_parameters.flags = RtlUserProcFlags::NORMALIZED.bits();
+        process_parameters.environment = environment_ptr;
+        process_parameters.environment_size =
+            u64::try_from(environment_size).map_err(|_| PeImageAccessError::AddressOverflow)?;
         let mut process_parameter_tail = process_parameters_ptr
-            .checked_add(core::mem::size_of::<RtlUserProcessParameters>())
+            .checked_add(size_of::<RtlUserProcessParameters>())
             .ok_or(PeImageAccessError::AddressOverflow)?;
-        process_parameters.current_directory.dos_path = write_process_parameter_string::<Platform>(
+        process_parameters.current_directory.dos_path = write_tail_utf16_string::<Platform>(
             &mut process_parameter_tail,
             &current_directory_path,
         )?;
         process_parameters.dll_path =
-            write_process_parameter_string::<Platform>(&mut process_parameter_tail, &dll_path)?;
-        process_parameters.image_path_name = write_process_parameter_string::<Platform>(
-            &mut process_parameter_tail,
-            &image_path_name,
-        )?;
+            write_tail_utf16_string::<Platform>(&mut process_parameter_tail, &dll_path)?;
+        process_parameters.image_path_name =
+            write_tail_utf16_string::<Platform>(&mut process_parameter_tail, &image_path_name)?;
         process_parameters.command_line =
-            write_process_parameter_string::<Platform>(&mut process_parameter_tail, &command_line)?;
+            write_tail_utf16_string::<Platform>(&mut process_parameter_tail, &command_line)?;
         process_parameters.window_title =
-            write_process_parameter_string::<Platform>(&mut process_parameter_tail, &window_title)?;
+            write_tail_utf16_string::<Platform>(&mut process_parameter_tail, &window_title)?;
         process_parameters.desktop_info =
-            write_process_parameter_string::<Platform>(&mut process_parameter_tail, &desktop_info)?;
+            write_tail_utf16_string::<Platform>(&mut process_parameter_tail, &desktop_info)?;
         process_parameters.shell_info =
-            write_process_parameter_string::<Platform>(&mut process_parameter_tail, &shell_info)?;
+            write_tail_utf16_string::<Platform>(&mut process_parameter_tail, &shell_info)?;
         process_parameters.runtime_data =
-            write_process_parameter_string::<Platform>(&mut process_parameter_tail, &runtime_data)?;
-        process_parameters.redirection_dll_name = write_process_parameter_string::<Platform>(
+            write_tail_utf16_string::<Platform>(&mut process_parameter_tail, &runtime_data)?;
+        process_parameters.redirection_dll_name = write_tail_utf16_string::<Platform>(
             &mut process_parameter_tail,
             &redirection_dll_name,
         )?;
@@ -308,26 +319,25 @@ impl<'a, Platform: crate::ShimPlatform, FS: ShimFS> PeLoader<'a, Platform, FS> {
             .ok_or(PeImageAccessError::MemoryAccess)?;
 
         let read_only_shared_memory_base = create_pages(WINDOWS_SHARED_SECTION_SIZE)?;
-        let read_only_static_server_data = read_only_shared_memory_base
-            .checked_add(WINDOWS_STATIC_SERVER_DATA_TABLE_OFFSET)
-            .ok_or(PeImageAccessError::AddressOverflow)?;
-        let base_static_server_data = read_only_shared_memory_base
-            .checked_add(WINDOWS_BASE_STATIC_SERVER_DATA_OFFSET)
-            .ok_or(PeImageAccessError::AddressOverflow)?;
-        let base_static_server_data_entry = read_only_static_server_data
-            .checked_add(BASESRV_SERVERDLL_INDEX * core::mem::size_of::<usize>())
-            .ok_or(PeImageAccessError::AddressOverflow)?;
-        crate::write_value::<Platform, _>(base_static_server_data_entry, base_static_server_data)
-            .ok_or(PeImageAccessError::MemoryAccess)?;
-
+        let read_only_static_server_data =
+            initialize_windows_static_server_data::<Platform>(read_only_shared_memory_base)?;
         let mut peb = ProcessEnvironmentBlock::new_zeroed();
-        peb.image_base_address = image_base_address;
-        if image_base_address != image.image_base() || image.has_dynamic_base() {
+        peb.image_base_address = input.image_base_address;
+        if input.image_base_address != input.image.image_base() || input.image.has_dynamic_base() {
             peb.bit_field = PebBitField::IS_IMAGE_DYNAMICALLY_RELOCATED.bits();
         }
         let process_heaps = initial_process_heaps_array(peb_ptr)?;
+        let fast_peb_lock = create_pages(size_of::<RtlCriticalSection>())?;
+        crate::write_value::<Platform, _>(fast_peb_lock, RtlCriticalSection::initialized(0))
+            .ok_or(PeImageAccessError::MemoryAccess)?;
+        let loader_lock = create_pages(size_of::<RtlCriticalSection>())?;
+        crate::write_value::<Platform, _>(loader_lock, RtlCriticalSection::initialized(0))
+            .ok_or(PeImageAccessError::MemoryAccess)?;
+
         peb.api_set_map = api_set_map_ptr;
         peb.process_parameters = process_parameters_ptr;
+        peb.fast_peb_lock = fast_peb_lock;
+        peb.shared_data = read_only_shared_memory_base;
         peb.number_of_processors = 1;
         peb.critical_section_timeout = WINDOWS_CRITICAL_SECTION_TIMEOUT_100NS;
         peb.heap_segment_reserve = WINDOWS_HEAP_SEGMENT_RESERVE;
@@ -336,14 +346,15 @@ impl<'a, Platform: crate::ShimPlatform, FS: ShimFS> PeLoader<'a, Platform, FS> {
         peb.heap_de_commit_free_block_threshold = WINDOWS_HEAP_DECOMMIT_FREE_BLOCK_THRESHOLD;
         peb.maximum_number_of_heaps = process_heaps.maximum_number_of_heaps;
         peb.process_heaps = process_heaps.address;
+        peb.loader_lock = loader_lock;
         peb.active_process_affinity_mask = 1;
         peb.os_major_version = WINDOWS_OS_MAJOR_VERSION;
         peb.os_minor_version = WINDOWS_OS_MINOR_VERSION;
         peb.os_build_number = WINDOWS_OS_BUILD_NUMBER;
         peb.os_platform_id = WINDOWS_OS_PLATFORM_WIN32_NT;
-        peb.image_subsystem = u32::from(image.subsystem());
-        peb.image_subsystem_major_version = u32::from(image.major_subsystem_version());
-        peb.image_subsystem_minor_version = u32::from(image.minor_subsystem_version());
+        peb.image_subsystem = u32::from(input.image.subsystem());
+        peb.image_subsystem_major_version = u32::from(input.image.major_subsystem_version());
+        peb.image_subsystem_minor_version = u32::from(input.image.minor_subsystem_version());
         peb.read_only_shared_memory_base = read_only_shared_memory_base;
         peb.read_only_static_server_data = read_only_static_server_data;
         peb.csr_server_read_only_shared_memory_base = read_only_shared_memory_base as u64;
@@ -351,8 +362,8 @@ impl<'a, Platform: crate::ShimPlatform, FS: ShimFS> PeLoader<'a, Platform, FS> {
 
         let mut teb = ThreadEnvironmentBlock::new_zeroed();
         teb.nt_tib.exception_list = 0;
-        teb.nt_tib.stack_base = stack_top;
-        teb.nt_tib.stack_limit = stack_base;
+        teb.nt_tib.stack_base = input.stack_allocation_top;
+        teb.nt_tib.stack_limit = input.stack_base;
         teb.nt_tib.fiber_data_or_version = WINDOWS_NT_TIB_VERSION;
         teb.nt_tib.self_pointer = teb_ptr;
         // TODO: set real ID
@@ -368,7 +379,7 @@ impl<'a, Platform: crate::ShimPlatform, FS: ShimFS> PeLoader<'a, Platform, FS> {
             teb_ptr + core::mem::offset_of!(ThreadEnvironmentBlock, activation_stack);
         teb.static_unicode_string =
             initial_teb_static_unicode_string(teb_ptr, &teb.static_unicode_buffer)?;
-        teb.deallocation_stack = stack_base;
+        teb.deallocation_stack = input.stack_base;
         crate::write_value::<Platform, _>(teb_ptr, teb).ok_or(PeImageAccessError::MemoryAccess)?;
         Ok(WindowsProcessEnvironment {
             peb: peb_ptr,
@@ -376,6 +387,71 @@ impl<'a, Platform: crate::ShimPlatform, FS: ShimFS> PeLoader<'a, Platform, FS> {
             context: ctx_ptr,
         })
     }
+}
+
+fn initialize_windows_static_server_data<Platform: RawPointerProvider>(
+    read_only_shared_memory_base: usize,
+) -> Result<usize, PeImageAccessError> {
+    let read_only_static_server_data =
+        SyntheticReadOnlySharedMemory::static_server_data_table_address(
+            read_only_shared_memory_base,
+        )?;
+    let client_base_static_server_data =
+        SyntheticReadOnlySharedMemory::base_static_server_data_address(
+            read_only_shared_memory_base,
+        )?;
+    initialize_static_server_data::<Platform>(
+        read_only_static_server_data,
+        client_base_static_server_data,
+    )?;
+    Ok(read_only_static_server_data)
+}
+
+fn initialize_static_server_data<Platform: RawPointerProvider>(
+    static_server_data_table: usize,
+    base_static_server_data: usize,
+) -> Result<(), PeImageAccessError> {
+    for server_index in [0, BASESRV_SERVERDLL_INDEX] {
+        let entry =
+            SyntheticStaticServerDataTable::entry_address(static_server_data_table, server_index)?;
+        crate::write_value::<Platform, _>(entry, base_static_server_data)
+            .ok_or(PeImageAccessError::MemoryAccess)?;
+    }
+
+    write_static_server_unicode_string::<Platform>(
+        SyntheticBaseStaticServerData::windows_directory_address(base_static_server_data)?,
+        SyntheticBaseStaticServerData::windows_directory_string_address(base_static_server_data)?,
+        WINDOWS_DIRECTORY,
+    )?;
+    write_static_server_unicode_string::<Platform>(
+        SyntheticBaseStaticServerData::system_directory_address(base_static_server_data)?,
+        SyntheticBaseStaticServerData::system_directory_string_address(base_static_server_data)?,
+        WINDOWS_SYSTEM_DIRECTORY,
+    )?;
+
+    let rebase_anchor =
+        SyntheticBaseStaticServerData::rebase_anchor_address(base_static_server_data)?;
+    crate::write_value::<Platform, _>(rebase_anchor, base_static_server_data)
+        .ok_or(PeImageAccessError::MemoryAccess)
+}
+
+fn write_static_server_unicode_string<Platform: RawPointerProvider>(
+    string_address: usize,
+    buffer: usize,
+    value: &str,
+) -> Result<(), PeImageAccessError> {
+    let string = Utf16StringBuffer::new(value)?;
+    crate::write_slice::<Platform, _>(buffer, &string.units)
+        .ok_or(PeImageAccessError::MemoryAccess)?;
+
+    let unicode_string = UnicodeString {
+        length: string.length,
+        maximum_length: string.maximum_length,
+        padding_0: [0; 4],
+        buffer,
+    };
+    crate::write_value::<Platform, _>(string_address, unicode_string)
+        .ok_or(PeImageAccessError::MemoryAccess)
 }
 
 fn register_image_virtual_allocation<Platform: crate::ShimPlatform>(
@@ -387,7 +463,7 @@ fn register_image_virtual_allocation<Platform: crate::ShimPlatform>(
         mapping.base_addr,
         crate::WindowsVirtualAllocation {
             base: mapping.base_addr,
-            size: mapping.image_size,
+            size: mapping.mapping_size,
             allocation_protect: PageProtection::PAGE_EXECUTE_WRITECOPY,
             type_: MemoryType::MEM_IMAGE,
             pages,
@@ -435,43 +511,115 @@ impl LoadedImage {
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, FromBytes, Immutable, IntoBytes, KnownLayout)]
-struct ApiSetNamespace {
-    version: u32,
-    size: u32,
-    flags: u32,
-    count: u32,
-    entry_offset: u32,
-    hash_offset: u32,
-    hash_factor: u32,
+struct RtlCriticalSection {
+    debug_info: usize,
+    lock_count: i32,
+    recursion_count: u32,
+    owning_thread: usize,
+    lock_semaphore: usize,
+    spin_count: usize,
+}
+
+impl RtlCriticalSection {
+    const fn initialized(spin_count: usize) -> Self {
+        Self {
+            debug_info: usize::MAX,
+            lock_count: -1,
+            recursion_count: 0,
+            owning_thread: 0,
+            lock_semaphore: 0,
+            spin_count,
+        }
+    }
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq, FromBytes, Immutable, IntoBytes, KnownLayout)]
-struct ApiSetNamespaceEntry {
-    flags: u32,
-    name_offset: u32,
-    name_length: u32,
-    hashed_length: u32,
-    value_offset: u32,
-    value_count: u32,
+struct SyntheticReadOnlySharedMemory {
+    _padding_to_static_server_data_table:
+        [u8; SyntheticReadOnlySharedMemory::STATIC_SERVER_DATA_TABLE_PADDING_BYTES],
+    static_server_data_table: SyntheticStaticServerDataTable,
+    base_static_server_data: SyntheticBaseStaticServerData,
+}
+
+impl SyntheticReadOnlySharedMemory {
+    const STATIC_SERVER_DATA_TABLE_PADDING_BYTES: usize = 0x750;
+    const STATIC_SERVER_DATA_TABLE_OFFSET: usize =
+        core::mem::offset_of!(Self, static_server_data_table);
+    const BASE_STATIC_SERVER_DATA_OFFSET: usize =
+        core::mem::offset_of!(Self, base_static_server_data);
+
+    fn static_server_data_table_address(base: usize) -> Result<usize, PeImageAccessError> {
+        checked_add(base, Self::STATIC_SERVER_DATA_TABLE_OFFSET)
+    }
+
+    fn base_static_server_data_address(base: usize) -> Result<usize, PeImageAccessError> {
+        checked_add(base, Self::BASE_STATIC_SERVER_DATA_OFFSET)
+    }
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq, FromBytes, Immutable, IntoBytes, KnownLayout)]
-struct ApiSetValueEntry {
-    flags: u32,
-    name_offset: u32,
-    name_length: u32,
-    value_offset: u32,
-    value_length: u32,
+struct SyntheticStaticServerDataTable {
+    entries: [usize; CSR_SERVER_DLL_MAX],
+}
+
+impl SyntheticStaticServerDataTable {
+    fn entry_address(table: usize, server_index: usize) -> Result<usize, PeImageAccessError> {
+        checked_add(table, checked_mul(server_index, size_of::<usize>())?)
+    }
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq, FromBytes, Immutable, IntoBytes, KnownLayout)]
-struct ApiSetHashEntry {
-    hash: u32,
-    index: u32,
+struct SyntheticBaseStaticServerData {
+    windows_directory: UnicodeString,
+    system_directory: UnicodeString,
+    _padding_to_rebase_anchor: [u8; SyntheticBaseStaticServerData::REBASE_ANCHOR_LAYOUT_OFFSET
+        - 2 * size_of::<UnicodeString>()],
+    rebase_anchor: usize,
+    _padding_to_windows_directory_string: [u8;
+        SyntheticBaseStaticServerData::WINDOWS_DIRECTORY_STRING_LAYOUT_OFFSET
+            - SyntheticBaseStaticServerData::REBASE_ANCHOR_LAYOUT_OFFSET
+            - size_of::<usize>()],
+    windows_directory_string: [u8;
+        SyntheticBaseStaticServerData::SYSTEM_DIRECTORY_STRING_LAYOUT_OFFSET
+            - SyntheticBaseStaticServerData::WINDOWS_DIRECTORY_STRING_LAYOUT_OFFSET],
+    system_directory_string: [u8; SyntheticBaseStaticServerData::SYSTEM_DIRECTORY_STRING_BYTES],
 }
+
+impl SyntheticBaseStaticServerData {
+    const REBASE_ANCHOR_LAYOUT_OFFSET: usize = 0x9e8;
+    const WINDOWS_DIRECTORY_STRING_LAYOUT_OFFSET: usize = 0xa00;
+    const SYSTEM_DIRECTORY_STRING_LAYOUT_OFFSET: usize = 0xa40;
+    const SYSTEM_DIRECTORY_STRING_BYTES: usize = 0x40;
+    const WINDOWS_DIRECTORY_OFFSET: usize = core::mem::offset_of!(Self, windows_directory);
+    const SYSTEM_DIRECTORY_OFFSET: usize = core::mem::offset_of!(Self, system_directory);
+    const REBASE_ANCHOR_OFFSET: usize = core::mem::offset_of!(Self, rebase_anchor);
+    const WINDOWS_DIRECTORY_STRING_OFFSET: usize =
+        core::mem::offset_of!(Self, windows_directory_string);
+    const SYSTEM_DIRECTORY_STRING_OFFSET: usize =
+        core::mem::offset_of!(Self, system_directory_string);
+
+    fn windows_directory_address(base: usize) -> Result<usize, PeImageAccessError> {
+        checked_add(base, Self::WINDOWS_DIRECTORY_OFFSET)
+    }
+
+    fn system_directory_address(base: usize) -> Result<usize, PeImageAccessError> {
+        checked_add(base, Self::SYSTEM_DIRECTORY_OFFSET)
+    }
+
+    fn rebase_anchor_address(base: usize) -> Result<usize, PeImageAccessError> {
+        checked_add(base, Self::REBASE_ANCHOR_OFFSET)
+    }
+
+    fn windows_directory_string_address(base: usize) -> Result<usize, PeImageAccessError> {
+        checked_add(base, Self::WINDOWS_DIRECTORY_STRING_OFFSET)
+    }
+
+    fn system_directory_string_address(base: usize) -> Result<usize, PeImageAccessError> {
+        checked_add(base, Self::SYSTEM_DIRECTORY_STRING_OFFSET)
+    }
+}
+
+const _: () = assert!(size_of::<SyntheticReadOnlySharedMemory>() <= WINDOWS_SHARED_SECTION_SIZE);
 
 const API_SET_MAPPINGS: &[(&str, &str)] = &[
     ("api-ms-win-core-apiquery-l1-1-0", "ntdll.dll"),
@@ -533,7 +681,7 @@ const API_SET_MAPPINGS: &[(&str, &str)] = &[
     ("api-ms-win-core-heap-l2-1-0", "kernelbase.dll"),
     ("api-ms-win-core-interlocked-l1-1-1", "kernelbase.dll"),
     ("api-ms-win-core-io-l1-1-0", "kernelbase.dll"),
-    ("api-ms-win-core-io-l1-1-1", "kernelbase.dll"),
+    ("api-ms-win-core-io-l1-1-1", "kernel32.dll"),
     ("api-ms-win-core-job-l1-1-0", "kernelbase.dll"),
     ("api-ms-win-core-largeinteger-l1-1-0", "kernelbase.dll"),
     ("api-ms-win-core-libraryloader-l1-1-1", "kernelbase.dll"),
@@ -638,7 +786,7 @@ const API_SET_MAPPINGS: &[(&str, &str)] = &[
     ("api-ms-win-eventing-consumer-l1-1-0", "sechost.dll"),
     ("api-ms-win-eventing-consumer-l1-1-1", "sechost.dll"),
     ("api-ms-win-eventing-controller-l1-1-0", "sechost.dll"),
-    ("api-ms-win-eventing-provider-l1-1-0", "advapi32.dll"),
+    ("api-ms-win-eventing-provider-l1-1-0", "kernelbase.dll"),
     ("api-ms-win-security-audit-l1-1-0", "sechost.dll"),
     ("api-ms-win-security-audit-l1-1-1", "sechost.dll"),
     ("api-ms-win-security-appcontainer-l1-1-0", "kernelbase.dll"),
@@ -658,137 +806,14 @@ const API_SET_MAPPINGS: &[(&str, &str)] = &[
     ("api-ms-win-service-winsvc-l1-1-0", "sechost.dll"),
     ("ext-ms-win-appcompat-apphelp-l1-1-2", "apphelp.dll"),
     ("ext-ms-win-authz-context-l1-1-0", "authz.dll"),
-    ("ext-ms-win-core-winrt-remote-l1-1-0", "rpcrtremote.dll"),
-    ("ext-ms-win-oobe-query-l1-1-0", "kernelbase.dll"),
+    ("ext-ms-win-core-winrt-remote-l1-1-0", ""),
+    ("ext-ms-win-oobe-query-l1-1-0", ""),
     (
         "ext-ms-win-packagevirtualizationcontext-l1-1-0",
-        "kernelbase.dll",
+        "daxexec.dll",
     ),
     ("ext-ms-win-rpc-ssl-l1-1-0", "rpcrtremote.dll"),
 ];
-
-fn build_api_set_namespace() -> Result<Vec<u8>, PeImageAccessError> {
-    let mut mappings = API_SET_MAPPINGS.to_vec();
-    mappings.sort_by_key(|mapping| mapping.0);
-
-    let count = mappings.len();
-    let entry_offset = size_of::<ApiSetNamespace>();
-    let value_offset = checked_add(
-        entry_offset,
-        checked_mul(count, size_of::<ApiSetNamespaceEntry>())?,
-    )?;
-    let strings_offset = checked_add(
-        value_offset,
-        checked_mul(count, size_of::<ApiSetValueEntry>())?,
-    )?;
-    let mut string_data = Vec::new();
-    let mut entries = Vec::with_capacity(count);
-    let mut values = Vec::with_capacity(count);
-    let mut hashes = Vec::with_capacity(count);
-
-    for (index, (contract, host_dll)) in mappings.iter().enumerate() {
-        let name = utf16_bytes(contract)?;
-        let host = utf16_bytes(host_dll)?;
-        let name_offset = checked_add(strings_offset, string_data.len())?;
-        string_data.extend_from_slice(&name);
-        let host_offset = checked_add(strings_offset, string_data.len())?;
-        string_data.extend_from_slice(&host);
-        let value_entry_offset = checked_add(
-            value_offset,
-            checked_mul(index, size_of::<ApiSetValueEntry>())?,
-        )?;
-        entries.push(ApiSetNamespaceEntry {
-            flags: API_SET_NAMESPACE_ENTRY_FLAGS,
-            name_offset: to_u32(name_offset)?,
-            name_length: to_u32(name.len())?,
-            hashed_length: to_u32(
-                api_set_hashed_name_len(contract)
-                    .checked_mul(size_of::<u16>())
-                    .ok_or(PeImageAccessError::AddressOverflow)?,
-            )?,
-            value_offset: to_u32(value_entry_offset)?,
-            value_count: 1,
-        });
-        values.push(ApiSetValueEntry {
-            flags: 0,
-            name_offset: 0,
-            name_length: 0,
-            value_offset: to_u32(host_offset)?,
-            value_length: to_u32(host.len())?,
-        });
-        hashes.push(ApiSetHashEntry {
-            hash: api_set_hash(contract),
-            index: to_u32(index)?,
-        });
-    }
-
-    let hash_offset =
-        checked_add(strings_offset, string_data.len())?.next_multiple_of(size_of::<u32>());
-    let size = checked_add(
-        hash_offset,
-        checked_mul(count, size_of::<ApiSetHashEntry>())?,
-    )?;
-    if size > MAX_API_SET_NAMESPACE_SIZE {
-        return Err(PeImageAccessError::AddressOverflow);
-    }
-    hashes.sort_by_key(|entry| (entry.hash, entry.index));
-
-    let namespace = ApiSetNamespace {
-        version: API_SET_NAMESPACE_VERSION,
-        size: to_u32(size)?,
-        flags: 0,
-        count: to_u32(count)?,
-        entry_offset: to_u32(entry_offset)?,
-        hash_offset: to_u32(hash_offset)?,
-        hash_factor: API_SET_NAMESPACE_HASH_FACTOR,
-    };
-
-    let mut bytes = Vec::with_capacity(size);
-    append_struct(&mut bytes, &namespace);
-    for entry in &entries {
-        append_struct(&mut bytes, entry);
-    }
-    for value in &values {
-        append_struct(&mut bytes, value);
-    }
-    bytes.extend_from_slice(&string_data);
-    bytes.resize(hash_offset, 0);
-    for hash in &hashes {
-        append_struct(&mut bytes, hash);
-    }
-    debug_assert_eq!(bytes.len(), size);
-    Ok(bytes)
-}
-
-fn append_struct<T: IntoBytes + Immutable>(bytes: &mut Vec<u8>, value: &T) {
-    bytes.extend_from_slice(value.as_bytes());
-}
-
-fn utf16_bytes(value: &str) -> Result<Vec<u8>, PeImageAccessError> {
-    let mut bytes = Vec::with_capacity(
-        value
-            .len()
-            .checked_mul(size_of::<u16>())
-            .ok_or(PeImageAccessError::AddressOverflow)?,
-    );
-    for unit in value.encode_utf16() {
-        bytes.extend_from_slice(&unit.to_le_bytes());
-    }
-    Ok(bytes)
-}
-
-fn api_set_hashed_name_len(name: &str) -> usize {
-    name.rfind('-').unwrap_or(name.len())
-}
-
-fn api_set_hash(name: &str) -> u32 {
-    name[..api_set_hashed_name_len(name)]
-        .bytes()
-        .fold(0, |hash, byte| {
-            hash.wrapping_mul(API_SET_NAMESPACE_HASH_FACTOR)
-                .wrapping_add(u32::from(byte.to_ascii_lowercase()))
-        })
-}
 
 fn checked_add(left: usize, right: usize) -> Result<usize, PeImageAccessError> {
     left.checked_add(right)
@@ -823,9 +848,8 @@ fn load_ntdll<Platform: crate::ShimPlatform, FS: crate::ShimFS>(
     platform: &'static Platform,
     fs: Arc<FS>,
     page_manager: &crate::WindowsPageManager<Platform>,
-    ntdll_paths: &[&str],
 ) -> Result<Option<LoadedNtDll>, WindowsLoadError> {
-    for path in ntdll_paths {
+    for path in NTDLL_PATHS {
         match load_image_with_writable_sections(
             fs.clone(),
             path,
@@ -1047,6 +1071,16 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> PeImageMapper<'_, Platform, FS> 
         self.pages.insert(start..end, protect);
         Ok(())
     }
+
+    fn protect_and_record_pages(
+        &mut self,
+        address: usize,
+        len: usize,
+        prot: Protection,
+    ) -> Result<(), PeImageAccessError> {
+        protect_pages(self.page_manager, address, len, prot)?;
+        self.record_pages(address, len, page_protection_from_loader_protection(prot))
+    }
 }
 
 impl<Platform: crate::ShimPlatform, FS: ShimFS> MapMemory for PeImageMapper<'_, Platform, FS> {
@@ -1096,8 +1130,7 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> MapMemory for PeImageMapper<'_, 
                 .ok_or(PeImageAccessError::MemoryAccess)?;
             written += chunk;
         }
-        protect_pages(self.page_manager, address, len, *prot)?;
-        self.record_pages(address, len, page_protection_from_loader_protection(*prot))
+        self.protect_and_record_pages(address, len, *prot)
     }
 
     fn map_file(
@@ -1126,8 +1159,7 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> MapMemory for PeImageMapper<'_, 
                 .ok_or(PeImageAccessError::MemoryAccess)?;
             read += n;
         }
-        protect_pages(self.page_manager, address, len, *prot)?;
-        self.record_pages(address, len, page_protection_from_loader_protection(*prot))
+        self.protect_and_record_pages(address, len, *prot)
     }
 
     fn protect(
@@ -1136,8 +1168,7 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> MapMemory for PeImageMapper<'_, 
         len: usize,
         prot: &Protection,
     ) -> Result<(), Self::Error> {
-        protect_pages(self.page_manager, address, len, *prot)?;
-        self.record_pages(address, len, page_protection_from_loader_protection(*prot))
+        self.protect_and_record_pages(address, len, *prot)
     }
 }
 
@@ -1244,33 +1275,93 @@ fn page_range(address: usize, len: usize) -> Result<(usize, usize), PeImageAcces
     Ok((start, end - start))
 }
 
-fn dos_image_path(path: &str) -> String {
-    let mut dos_path = String::from(r"\??\C:");
+fn win32_image_path(path: &str) -> String {
+    let mut win32_path = String::from("C:");
     if !path.starts_with('/') && !path.starts_with('\\') {
-        dos_path.push('\\');
+        win32_path.push('\\');
     }
     for ch in path.chars() {
-        dos_path.push(if ch == '/' { '\\' } else { ch });
+        win32_path.push(if ch == '/' { '\\' } else { ch });
     }
+    win32_path
+}
+
+fn dos_image_path(path: &str) -> String {
+    let mut dos_path = String::from(r"\??\");
+    dos_path.push_str(&win32_image_path(path));
     dos_path
 }
 
-fn write_process_parameter_string<Platform: RawPointerProvider>(
-    process_parameter_tail: &mut usize,
-    string: &Utf16StringBuffer,
-) -> Result<UnicodeString, PeImageAccessError> {
-    let buffer = *process_parameter_tail;
-    crate::write_slice::<Platform, _>(buffer, &string.units)
-        .ok_or(PeImageAccessError::MemoryAccess)?;
-    *process_parameter_tail = (*process_parameter_tail)
-        .checked_add(usize::from(string.maximum_length))
-        .ok_or(PeImageAccessError::AddressOverflow)?;
-    Ok(UnicodeString {
-        length: string.length,
-        maximum_length: string.maximum_length,
-        padding_0: [0; 4],
-        buffer,
-    })
+fn windows_command_line(image_path: &str, argv: &[CString]) -> String {
+    let mut command_line = String::new();
+    if let Some(arg0) = argv.first() {
+        push_windows_quoted_arg(&mut command_line, &cstring_to_string(arg0));
+    } else {
+        push_windows_quoted_arg(&mut command_line, image_path);
+    }
+    for arg in argv.iter().skip(1) {
+        command_line.push(' ');
+        push_windows_quoted_arg(&mut command_line, &cstring_to_string(arg));
+    }
+    command_line
+}
+
+fn push_windows_quoted_arg(command_line: &mut String, arg: &str) {
+    if !arg.is_empty() && !arg.contains([' ', '\t', '"']) {
+        command_line.push_str(arg);
+        return;
+    }
+
+    command_line.push('"');
+    let mut backslashes = 0;
+    for ch in arg.chars() {
+        if ch == '\\' {
+            backslashes += 1;
+        } else if ch == '"' {
+            for _ in 0..=backslashes * 2 {
+                command_line.push('\\');
+            }
+            command_line.push('"');
+            backslashes = 0;
+        } else {
+            for _ in 0..backslashes {
+                command_line.push('\\');
+            }
+            command_line.push(ch);
+            backslashes = 0;
+        }
+    }
+    for _ in 0..backslashes * 2 {
+        command_line.push('\\');
+    }
+    command_line.push('"');
+}
+
+fn windows_environment_block(envp: &[CString]) -> Vec<u16> {
+    let mut variables = envp.iter().map(cstring_to_string).collect::<Vec<_>>();
+    variables.sort_by(|left, right| {
+        left.bytes()
+            .map(|byte| byte.to_ascii_uppercase())
+            .cmp(right.bytes().map(|byte| byte.to_ascii_uppercase()))
+    });
+
+    let mut block = Vec::new();
+    for variable in variables {
+        block.extend(variable.encode_utf16());
+        block.push(0);
+    }
+    block.push(0);
+    if envp.is_empty() {
+        block.push(0);
+    }
+    block
+}
+
+fn cstring_to_string(value: &CString) -> String {
+    match core::str::from_utf8(value.as_bytes()) {
+        Ok(value) => String::from(value),
+        Err(_) => String::from_utf8_lossy(value.as_bytes()).into_owned(),
+    }
 }
 
 struct InitialProcessHeaps {
@@ -1288,6 +1379,22 @@ fn initial_process_heaps_array(peb_ptr: usize) -> Result<InitialProcessHeaps, Pe
     Ok(InitialProcessHeaps {
         address,
         maximum_number_of_heaps: maximum_number_of_heaps.trunc(),
+    })
+}
+
+fn write_tail_utf16_string<Platform: RawPointerProvider>(
+    tail: &mut usize,
+    string: &Utf16StringBuffer,
+) -> Result<UnicodeString, PeImageAccessError> {
+    let buffer = *tail;
+    crate::write_slice::<Platform, _>(buffer, &string.units)
+        .ok_or(PeImageAccessError::MemoryAccess)?;
+    *tail = checked_add(*tail, usize::from(string.maximum_length))?;
+    Ok(UnicodeString {
+        length: string.length,
+        maximum_length: string.maximum_length,
+        padding_0: [0; 4],
+        buffer,
     })
 }
 
@@ -1343,6 +1450,10 @@ mod tests {
 
     use alloc::{string::String, vec, vec::Vec};
     use litebox::platform::{RawConstPointer as _, RawPointerProvider};
+    use litebox_common_windows::loader::{
+        ApiSetHashEntry, ApiSetNamespace, ApiSetNamespaceEntry, ApiSetValueEntry,
+        MAX_API_SET_NAMESPACE_SIZE, api_set_hash,
+    };
 
     use super::*;
     use crate::nt_types::{ProcessEnvironmentBlock, ThreadEnvironmentBlock, UnicodeString};
@@ -1401,32 +1512,8 @@ mod tests {
         };
     }
 
-    impl ApiSetValueEntry {
-        fn parse(bytes: &[u8], offset: usize) -> Option<Self> {
-            Some(Self::read_from_prefix(bytes.get(offset..)?).ok()?.0)
-        }
-
-        fn name(self, bytes: &[u8]) -> Option<String> {
-            read_utf16_string(bytes, self.name_offset, self.name_length)
-        }
-
-        fn value(self, bytes: &[u8]) -> Option<String> {
-            read_utf16_string(bytes, self.value_offset, self.value_length)
-        }
-    }
-
-    impl ApiSetHashEntry {
-        fn parse(bytes: &[u8], offset: usize) -> Option<Self> {
-            Some(Self::read_from_prefix(bytes.get(offset..)?).ok()?.0)
-        }
-    }
-
     fn table_offset(base: u32, index: u32, entry_size: usize) -> Option<usize> {
         (base as usize).checked_add((index as usize).checked_mul(entry_size)?)
-    }
-
-    fn checked_table_end(base: u32, count: u32, entry_size: usize) -> Option<usize> {
-        table_offset(base, count, entry_size)
     }
 
     fn read_utf16_string(bytes: &[u8], offset: u32, len: u32) -> Option<String> {
@@ -1445,140 +1532,116 @@ mod tests {
         Some(String::from_utf16_lossy(&units))
     }
 
-    impl ApiSetNamespaceEntry {
-        fn parse(bytes: &[u8], offset: usize) -> Option<Self> {
-            Some(Self::read_from_prefix(bytes.get(offset..)?).ok()?.0)
-        }
-
-        fn name(self, bytes: &[u8]) -> Option<String> {
-            read_utf16_string(bytes, self.name_offset, self.name_length)
-        }
-
-        fn value(self, bytes: &[u8], index: u32) -> Option<ApiSetValueEntry> {
-            if index >= self.value_count {
-                return None;
-            }
-            ApiSetValueEntry::parse(
-                bytes,
-                table_offset(self.value_offset, index, size_of::<ApiSetValueEntry>())?,
-            )
-        }
+    fn parse_api_set_value_entry(bytes: &[u8], offset: usize) -> Option<ApiSetValueEntry> {
+        Some(
+            ApiSetValueEntry::read_from_prefix(bytes.get(offset..)?)
+                .ok()?
+                .0,
+        )
     }
 
-    impl ApiSetNamespace {
-        fn parse(bytes: &[u8]) -> Option<Self> {
-            let namespace = Self::read_from_prefix(bytes).ok()?.0;
-            let size = namespace.size as usize;
-            if size != bytes.len()
-                || !(size_of::<Self>()..=MAX_API_SET_NAMESPACE_SIZE).contains(&size)
-            {
-                return None;
-            }
-            if checked_table_end(
+    fn api_set_value_entry_value(entry: ApiSetValueEntry, bytes: &[u8]) -> Option<String> {
+        read_utf16_string(bytes, entry.value_offset, entry.value_length)
+    }
+
+    fn api_set_value_entry_name(entry: ApiSetValueEntry, bytes: &[u8]) -> Option<String> {
+        read_utf16_string(bytes, entry.name_offset, entry.name_length)
+    }
+
+    fn parse_api_set_hash_entry(bytes: &[u8], offset: usize) -> Option<ApiSetHashEntry> {
+        Some(
+            ApiSetHashEntry::read_from_prefix(bytes.get(offset..)?)
+                .ok()?
+                .0,
+        )
+    }
+
+    fn parse_api_set_namespace_entry(bytes: &[u8], offset: usize) -> Option<ApiSetNamespaceEntry> {
+        Some(
+            ApiSetNamespaceEntry::read_from_prefix(bytes.get(offset..)?)
+                .ok()?
+                .0,
+        )
+    }
+
+    fn api_set_namespace_entry_name(entry: ApiSetNamespaceEntry, bytes: &[u8]) -> Option<String> {
+        read_utf16_string(bytes, entry.name_offset, entry.name_length)
+    }
+
+    fn api_set_namespace_entry_value(
+        entry: ApiSetNamespaceEntry,
+        bytes: &[u8],
+        index: u32,
+    ) -> Option<ApiSetValueEntry> {
+        if index >= entry.value_count {
+            return None;
+        }
+        parse_api_set_value_entry(
+            bytes,
+            table_offset(entry.value_offset, index, size_of::<ApiSetValueEntry>())?,
+        )
+    }
+
+    fn parse_api_set_namespace(bytes: &[u8]) -> Option<ApiSetNamespace> {
+        let namespace = ApiSetNamespace::read_from_prefix(bytes).ok()?.0;
+        let size = namespace.size as usize;
+        if size != bytes.len()
+            || !(size_of::<ApiSetNamespace>()..=MAX_API_SET_NAMESPACE_SIZE).contains(&size)
+        {
+            return None;
+        }
+        if table_offset(
+            namespace.entry_offset,
+            namespace.count,
+            size_of::<ApiSetNamespaceEntry>(),
+        )? > size
+        {
+            return None;
+        }
+        if table_offset(
+            namespace.hash_offset,
+            namespace.count,
+            size_of::<ApiSetHashEntry>(),
+        )? > size
+        {
+            return None;
+        }
+        Some(namespace)
+    }
+
+    fn api_set_namespace_entry(
+        namespace: ApiSetNamespace,
+        bytes: &[u8],
+        index: u32,
+    ) -> Option<ApiSetNamespaceEntry> {
+        if index >= namespace.count {
+            return None;
+        }
+        parse_api_set_namespace_entry(
+            bytes,
+            table_offset(
                 namespace.entry_offset,
-                namespace.count,
+                index,
                 size_of::<ApiSetNamespaceEntry>(),
-            )? > size
-            {
-                return None;
-            }
-            if checked_table_end(
-                namespace.hash_offset,
-                namespace.count,
-                size_of::<ApiSetHashEntry>(),
-            )? > size
-            {
-                return None;
-            }
-            Some(namespace)
-        }
-
-        fn entry(self, bytes: &[u8], index: u32) -> Option<ApiSetNamespaceEntry> {
-            if index >= self.count {
-                return None;
-            }
-            ApiSetNamespaceEntry::parse(
-                bytes,
-                table_offset(self.entry_offset, index, size_of::<ApiSetNamespaceEntry>())?,
-            )
-        }
-
-        fn hash_entry(self, bytes: &[u8], index: u32) -> Option<ApiSetHashEntry> {
-            if index >= self.count {
-                return None;
-            }
-            ApiSetHashEntry::parse(
-                bytes,
-                table_offset(self.hash_offset, index, size_of::<ApiSetHashEntry>())?,
-            )
-        }
+            )?,
+        )
     }
 
-    fn dump_api_set_entries(bytes: &[u8], namespace: ApiSetNamespace) {
-        std::println!("entries:");
-        for index in 0..namespace.count {
-            let entry = namespace.entry(bytes, index).expect("namespace entry");
-            std::println!(
-                "  {index:04} name={} flags={:#x} hashed_len={} values={}",
-                entry
-                    .name(bytes)
-                    .unwrap_or_else(|| String::from("<invalid>")),
-                entry.flags,
-                entry.hashed_length,
-                entry.value_count
-            );
-            for value_index in 0..entry.value_count {
-                let value = entry.value(bytes, value_index).expect("namespace value");
-                let name = value.name(bytes).unwrap_or_default();
-                let value_name = value
-                    .value(bytes)
-                    .unwrap_or_else(|| String::from("<invalid>"));
-                std::println!(
-                    "       [{value_index}] name={} value={} flags={:#x}",
-                    if name.is_empty() { "<default>" } else { &name },
-                    value_name,
-                    value.flags
-                );
-            }
+    fn api_set_namespace_hash_entry(
+        namespace: ApiSetNamespace,
+        bytes: &[u8],
+        index: u32,
+    ) -> Option<ApiSetHashEntry> {
+        if index >= namespace.count {
+            return None;
         }
+        parse_api_set_hash_entry(
+            bytes,
+            table_offset(namespace.hash_offset, index, size_of::<ApiSetHashEntry>())?,
+        )
     }
 
-    fn dump_api_set_hash_entries(bytes: &[u8], namespace: ApiSetNamespace) {
-        std::println!("hash entries:");
-        for index in 0..namespace.count {
-            let entry = namespace.hash_entry(bytes, index).expect("hash entry");
-            std::println!(
-                "  {index:04} hash={:#010x} index={}",
-                entry.hash,
-                entry.index
-            );
-        }
-    }
-
-    fn dump_api_set_namespace(label: &str, ptr: usize, bytes: &[u8]) {
-        let api_set_map = ApiSetNamespace::parse(bytes).expect("valid API_SET_NAMESPACE");
-        std::println!("{label}");
-        std::println!(
-            "API_SET_NAMESPACE ptr={:#x} len={:#x} ({})",
-            ptr,
-            bytes.len(),
-            bytes.len()
-        );
-        std::println!("     version: {:#010x}", api_set_map.version);
-        std::println!("        size: {:#010x}", api_set_map.size);
-        std::println!("       flags: {:#010x}", api_set_map.flags);
-        std::println!("       count: {:#010x}", api_set_map.count);
-        std::println!("entry_offset: {:#010x}", api_set_map.entry_offset);
-        std::println!(" hash_offset: {:#010x}", api_set_map.hash_offset);
-        std::println!(" hash_factor: {:#010x}", api_set_map.hash_factor);
-        std::println!();
-        dump_api_set_entries(bytes, api_set_map);
-        std::println!();
-        dump_api_set_hash_entries(bytes, api_set_map);
-        std::println!();
-    }
-
-    fn dump_host_api_set_namespace_impl() {
+    fn host_api_set_namespace_bytes() -> Vec<u8> {
         let peb = unsafe {
             // SAFETY: `RtlGetCurrentPeb` returns the current process PEB pointer on Windows.
             RtlGetCurrentPeb().as_ref()
@@ -1601,43 +1664,183 @@ mod tests {
             // host API-set namespace is immutable process-wide data owned by ntdll.
             core::slice::from_raw_parts(peb.api_set_map as *const u8, size)
         };
-        dump_api_set_namespace("Host API_SET_NAMESPACE", peb.api_set_map, bytes);
+        bytes.to_vec()
+    }
+
+    fn api_set_default_value(bytes: &[u8], contract: &str) -> Option<String> {
+        let namespace = parse_api_set_namespace(bytes)?;
+        for index in 0..namespace.count {
+            let entry = api_set_namespace_entry(namespace, bytes, index)?;
+            if api_set_namespace_entry_name(entry, bytes)?.eq_ignore_ascii_case(contract) {
+                let value = api_set_namespace_entry_value(entry, bytes, 0)?;
+                return api_set_value_entry_value(value, bytes);
+            }
+        }
+        None
+    }
+
+    fn assert_api_set_hash_table(bytes: &[u8]) {
+        let namespace = parse_api_set_namespace(bytes).expect("valid API_SET_NAMESPACE");
+        let mut previous = None;
+        for hash_index in 0..namespace.count {
+            let hash_entry =
+                api_set_namespace_hash_entry(namespace, bytes, hash_index).expect("hash entry");
+            let entry = api_set_namespace_entry(namespace, bytes, hash_entry.index)
+                .expect("hash entry target");
+            let name = api_set_namespace_entry_name(entry, bytes).expect("hash entry target name");
+            let expected_hash = api_set_hash(&name);
+            assert_eq!(hash_entry.hash, expected_hash, "hash for {name}");
+            if let Some((previous_hash, previous_index)) = previous {
+                assert!(
+                    (previous_hash, previous_index) <= (hash_entry.hash, hash_entry.index),
+                    "API-set hash table is not sorted"
+                );
+            }
+            previous = Some((hash_entry.hash, hash_entry.index));
+        }
+    }
+
+    fn dump_api_set_entries(bytes: &[u8], namespace: ApiSetNamespace) {
+        std::println!("entries:");
+        for index in 0..namespace.count {
+            let entry = api_set_namespace_entry(namespace, bytes, index).expect("namespace entry");
+            std::println!(
+                "  {index:04} name={} flags={:#x} hashed_len={} values={}",
+                api_set_namespace_entry_name(entry, bytes)
+                    .unwrap_or_else(|| String::from("<invalid>")),
+                entry.flags,
+                entry.hashed_length,
+                entry.value_count
+            );
+            for value_index in 0..entry.value_count {
+                let value = api_set_namespace_entry_value(entry, bytes, value_index)
+                    .expect("namespace value");
+                let name = api_set_value_entry_name(value, bytes).unwrap_or_default();
+                let value_name = api_set_value_entry_value(value, bytes)
+                    .unwrap_or_else(|| String::from("<invalid>"));
+                std::println!(
+                    "       [{value_index}] name={} value={} flags={:#x}",
+                    if name.is_empty() { "<default>" } else { &name },
+                    value_name,
+                    value.flags
+                );
+            }
+        }
+    }
+
+    fn dump_api_set_hash_entries(bytes: &[u8], namespace: ApiSetNamespace) {
+        std::println!("hash entries:");
+        for index in 0..namespace.count {
+            let entry = api_set_namespace_hash_entry(namespace, bytes, index).expect("hash entry");
+            std::println!(
+                "  {index:04} hash={:#010x} index={}",
+                entry.hash,
+                entry.index
+            );
+        }
+    }
+
+    fn dump_api_set_namespace(api_set_map: ApiSetNamespace, bytes: &[u8], label: &str) {
+        std::println!("{label}");
+        std::println!("API_SET_NAMESPACE len={:#x}", bytes.len(),);
+        std::println!("     version: {:#010x}", api_set_map.version);
+        std::println!("        size: {:#010x}", api_set_map.size);
+        std::println!("       flags: {:#010x}", api_set_map.flags);
+        std::println!("       count: {:#010x}", api_set_map.count);
+        std::println!("entry_offset: {:#010x}", api_set_map.entry_offset);
+        std::println!(" hash_offset: {:#010x}", api_set_map.hash_offset);
+        std::println!(" hash_factor: {:#010x}", api_set_map.hash_factor);
+        std::println!();
+        dump_api_set_entries(bytes, api_set_map);
+        std::println!();
+        dump_api_set_hash_entries(bytes, api_set_map);
+        std::println!();
     }
 
     #[test]
     fn dump_host_api_set_namespace() {
-        dump_host_api_set_namespace_impl();
-
-        let namespace = build_api_set_namespace().expect("LiteBox API_SET_NAMESPACE builds");
-        dump_api_set_namespace(
-            "LiteBox synthetic API_SET_NAMESPACE",
-            namespace.as_ptr() as usize,
-            &namespace,
-        );
+        let host_bytes = host_api_set_namespace_bytes();
+        let host = parse_api_set_namespace(&host_bytes).expect("valid host API_SET_NAMESPACE");
+        dump_api_set_namespace(host, &host_bytes, "host");
     }
 
-    #[allow(clippy::similar_names)]
+    #[test]
+    fn api_set_namespace_matches_host_invariants() {
+        let host_bytes = host_api_set_namespace_bytes();
+        let host = parse_api_set_namespace(&host_bytes).expect("valid host API_SET_NAMESPACE");
+        let synthetic_bytes =
+            build_api_set_namespace(API_SET_MAPPINGS).expect("LiteBox API_SET_NAMESPACE builds");
+        let synthetic =
+            parse_api_set_namespace(&synthetic_bytes).expect("valid synthetic API_SET_NAMESPACE");
+
+        assert_eq!(synthetic.version, host.version);
+        assert_eq!(synthetic.hash_factor, host.hash_factor);
+        assert_eq!(synthetic.flags, 0);
+        assert_api_set_hash_table(&host_bytes);
+        assert_api_set_hash_table(&synthetic_bytes);
+
+        let mut host_checked = 0;
+        let mut host_mismatches = Vec::new();
+        for &(contract, expected_host) in API_SET_MAPPINGS {
+            let synthetic_host = api_set_default_value(&synthetic_bytes, contract);
+            assert_eq!(
+                synthetic_host.as_deref(),
+                Some(expected_host),
+                "synthetic mapping for {contract}"
+            );
+            if let Some(host_value) = api_set_default_value(&host_bytes, contract) {
+                if !host_value.eq_ignore_ascii_case(expected_host) {
+                    host_mismatches.push(std::format!(
+                        "{contract}: expected {expected_host}, got {host_value}"
+                    ));
+                }
+                host_checked += 1;
+            }
+        }
+        assert!(
+            host_mismatches.is_empty(),
+            "host API-set mapping mismatches:\n{}",
+            host_mismatches.join("\n")
+        );
+        assert!(
+            host_checked >= 3,
+            "expected at least three synthetic API-set contracts on the host, found {host_checked}"
+        );
+
+        for (contract, expected_host) in [
+            ("api-ms-win-core-rtlsupport-l1-1-0", "ntdll.dll"),
+            ("api-ms-win-core-file-l1-2-3", "kernelbase.dll"),
+            ("api-ms-win-eventing-consumer-l1-1-0", "sechost.dll"),
+        ] {
+            assert_eq!(
+                api_set_default_value(&synthetic_bytes, contract).as_deref(),
+                Some(expected_host),
+                "synthetic mapping for {contract}"
+            );
+        }
+    }
+
     #[test]
     fn prints_created_teb_host_diff() {
-        let created = created_process_environment_snapshot();
-        let host_teb = host_teb_snapshot();
-        let host_teb_address = host_teb_address();
-        let host_peb_address = host_peb_address();
+        let synthetic = created_process_environment_snapshot();
+        let current_teb = host_teb_snapshot();
+        let teb_self = host_teb_address();
+        let peb_address = host_peb_address();
 
-        assert_eq!(created.teb.nt_tib.self_pointer, created.environment.teb);
-        assert_eq!(host_teb.nt_tib.self_pointer, host_teb_address);
+        assert_eq!(synthetic.teb.nt_tib.self_pointer, synthetic.environment.teb);
+        assert_eq!(current_teb.nt_tib.self_pointer, teb_self);
         assert_eq!(
-            created.teb.process_environment_block,
-            created.environment.peb
+            synthetic.teb.process_environment_block,
+            synthetic.environment.peb
         );
-        assert_eq!(host_teb.process_environment_block, host_peb_address);
-        assert_eq!(host_teb.client_id, host_client_id());
+        assert_eq!(current_teb.process_environment_block, peb_address);
+        assert_eq!(current_teb.client_id, host_client_id());
 
         print_diff_header("synthetic TEB vs host TEB");
         print_diff_fields!(
             "TEB.NtTib",
-            created.teb.nt_tib,
-            host_teb.nt_tib,
+            synthetic.teb.nt_tib,
+            current_teb.nt_tib,
             [
                 exception_list,
                 stack_base,
@@ -1650,8 +1853,8 @@ mod tests {
         );
         print_diff_fields!(
             "TEB",
-            created.teb,
-            host_teb,
+            synthetic.teb,
+            current_teb,
             [
                 environment_pointer,
                 client_id,
@@ -1784,11 +1987,13 @@ mod tests {
         assert_eq!(created.peb.image_base_address, created.image_base_address);
         assert_eq!(
             created.peb.read_only_static_server_data,
-            created.peb.read_only_shared_memory_base + WINDOWS_STATIC_SERVER_DATA_TABLE_OFFSET
+            created.peb.read_only_shared_memory_base
+                + SyntheticReadOnlySharedMemory::STATIC_SERVER_DATA_TABLE_OFFSET
         );
         assert_eq!(
             base_static_server_data,
-            created.peb.read_only_shared_memory_base + WINDOWS_BASE_STATIC_SERVER_DATA_OFFSET
+            created.peb.read_only_shared_memory_base
+                + SyntheticReadOnlySharedMemory::BASE_STATIC_SERVER_DATA_OFFSET
         );
         assert_ne!(host_peb.image_base_address, 0);
 
@@ -1914,6 +2119,29 @@ mod tests {
     }
 
     #[test]
+    fn process_parameters_include_argv_and_environment() {
+        let created = created_process_environment_snapshot();
+
+        // `RTL_USER_PROCESS_PARAMETERS.CommandLine` stores the original command line for
+        // `CommandLineToArgvW`, and the environment is a sorted UTF-16 `name=value\0...\0\0`
+        // block as documented for `GetEnvironmentStringsW`.
+        assert_eq!(
+            decode_guest_unicode_string(created.process_parameters.command_line),
+            "test.exe \"arg with space\" \"quote\\\"arg\""
+        );
+        assert_ne!(created.process_parameters.environment, 0);
+        assert_eq!(
+            read_guest_utf16_units(
+                created.process_parameters.environment,
+                usize::try_from(created.process_parameters.environment_size)
+                    .expect("environment size fits usize")
+                    / size_of::<u16>(),
+            ),
+            utf16_environment_units(&["a=one", "B=two", "c=three"])
+        );
+    }
+
+    #[test]
     fn ntdll_exports_finds_ki_user_inverted_function_table() {
         let ntdll = ntdll_module_base();
         let loaded_ntdll = loaded_module_image(ntdll);
@@ -1984,6 +2212,7 @@ mod tests {
         environment: WindowsProcessEnvironment,
         peb: ProcessEnvironmentBlock,
         teb: ThreadEnvironmentBlock,
+        process_parameters: RtlUserProcessParameters,
         image_base_address: usize,
     }
 
@@ -1996,22 +2225,56 @@ mod tests {
         let image = loaded_module_image(application_module_base());
 
         let image_base_address = image.mapping.base_addr;
+        let argv = [
+            CString::new("test.exe").expect("valid argv[0]"),
+            CString::new("arg with space").expect("valid argv[1]"),
+            CString::new("quote\"arg").expect("valid argv[2]"),
+        ];
+        let envp = [
+            CString::new("c=three").expect("valid envp[0]"),
+            CString::new("B=two").expect("valid envp[1]"),
+            CString::new("a=one").expect("valid envp[2]"),
+        ];
         let environment = loader
-            .create_process_environment(
-                &image.parsed,
+            .create_process_environment(ProcessEnvironmentInput {
+                image: &image.parsed,
                 image_base_address,
-                "test.exe",
-                TEST_STACK_BASE,
-                TEST_STACK_TOP,
-            )
+                image_path: "test.exe",
+                argv: &argv,
+                envp: &envp,
+                stack_base: TEST_STACK_BASE,
+                stack_allocation_top: TEST_STACK_TOP,
+            })
             .expect("failed to create synthetic Windows process environment");
+        let peb = read_guest_value::<ProcessEnvironmentBlock>(environment.peb);
 
         CreatedProcessEnvironmentSnapshot {
-            peb: read_guest_value(environment.peb),
+            process_parameters: read_guest_value(peb.process_parameters),
+            peb,
             teb: read_guest_value(environment.teb),
             environment,
             image_base_address,
         }
+    }
+
+    fn read_guest_utf16_units(address: usize, units: usize) -> Vec<u16> {
+        let ptr =
+            <crate::tests::TestPlatform as RawPointerProvider>::RawConstPointer::<u16>::from_usize(
+                address,
+            );
+        ptr.to_owned_slice(units)
+            .expect("guest UTF-16 block is readable")
+            .to_vec()
+    }
+
+    fn utf16_environment_units(vars: &[&str]) -> Vec<u16> {
+        let mut units = Vec::new();
+        for var in vars {
+            units.extend(var.encode_utf16());
+            units.push(0);
+        }
+        units.push(0);
+        units
     }
 
     fn print_field_diff<T>(field: &str, synthetic: T, host: T)
@@ -2181,7 +2444,7 @@ mod tests {
     }
 
     unsafe fn read_host_value<T: Copy>(address: *const T) -> T {
-        // SAFETY: The caller guarantees `address` points into a live host PEB/TEB object.
+        // SAFETY: The caller guarantees `address` points into live host loader/PEB/TEB state.
         unsafe { core::ptr::read_volatile(address) }
     }
 
@@ -2243,7 +2506,10 @@ mod tests {
             mapping: MappingInfo {
                 base_addr,
                 image_size: parsed.image_size(),
-                entry_point: base_addr,
+                mapping_size: parsed.image_size(),
+                entry_point: base_addr
+                    .checked_add(parsed.entry_point_rva())
+                    .expect("module entry point address fits usize"),
             },
             pages: RangeMap::new(),
             parsed,

--- a/litebox_shim_windows/src/loader/pe.rs
+++ b/litebox_shim_windows/src/loader/pe.rs
@@ -1452,7 +1452,7 @@ mod tests {
     use litebox::platform::{RawConstPointer as _, RawPointerProvider};
     use litebox_common_windows::loader::{
         ApiSetHashEntry, ApiSetNamespace, ApiSetNamespaceEntry, ApiSetValueEntry,
-        MAX_API_SET_NAMESPACE_SIZE, api_set_hash,
+        MAX_API_SET_NAMESPACE_SIZE, api_set_hash_prefix,
     };
 
     use super::*;
@@ -1688,7 +1688,8 @@ mod tests {
             let entry = api_set_namespace_entry(namespace, bytes, hash_entry.index)
                 .expect("hash entry target");
             let name = api_set_namespace_entry_name(entry, bytes).expect("hash entry target name");
-            let expected_hash = api_set_hash(&name);
+            let expected_hash = api_set_hash_with_hashed_length(&name, entry.hashed_length)
+                .expect("valid API-set hashed length");
             assert_eq!(hash_entry.hash, expected_hash, "hash for {name}");
             if let Some((previous_hash, previous_index)) = previous {
                 assert!(
@@ -1698,6 +1699,16 @@ mod tests {
             }
             previous = Some((hash_entry.hash, hash_entry.index));
         }
+    }
+
+    fn api_set_hash_with_hashed_length(name: &str, hashed_length: u32) -> Option<u32> {
+        let code_unit_bytes = u32::try_from(size_of::<u16>()).ok()?;
+        if !name.is_ascii() || !hashed_length.is_multiple_of(code_unit_bytes) {
+            return None;
+        }
+        let hashed_units = usize::try_from(hashed_length / code_unit_bytes).ok()?;
+        let prefix = name.get(..hashed_units)?;
+        Some(api_set_hash_prefix(prefix))
     }
 
     fn dump_api_set_entries(bytes: &[u8], namespace: ApiSetNamespace) {

--- a/litebox_shim_windows/src/loader/pe.rs
+++ b/litebox_shim_windows/src/loader/pe.rs
@@ -61,7 +61,7 @@ const INITIAL_THREAD_ID: usize = 1;
 
 macro_rules! write_static_server_data_field {
     ($platform:ty, $base:expr, $field:ident, $value:expr $(,)?) => {
-        crate::write_field_at_offset::<$platform, _, _>(
+        write_guest_field_at_offset::<$platform, _, _>(
             $base,
             core::mem::offset_of!(BaseStaticServerData, $field),
             $value,
@@ -167,8 +167,7 @@ impl<'a, Platform: crate::ShimPlatform, FS: ShimFS> PeLoader<'a, Platform, FS> {
                 stack_top,
                 environment.peb,
             );
-            crate::write_slice::<Platform, _>(environment.context, context.as_bytes())
-                .ok_or(PeImageAccessError::MemoryAccess)?;
+            write_guest_slice::<Platform, _>(environment.context, context.as_bytes())?;
         }
 
         let virtual_allocations =
@@ -213,13 +212,11 @@ impl<'a, Platform: crate::ShimPlatform, FS: ShimFS> PeLoader<'a, Platform, FS> {
         };
 
         // `KI_USER_INVERTED_FUNCTION_TABLE` lives in ntdll's writable `.mrdata` section.
-        crate::write_value::<Platform, _>(table_address, header)
-            .ok_or(PeImageAccessError::MemoryAccess)?;
+        write_guest_value::<Platform, _>(table_address, header)?;
         let entries_address = table_address
             .checked_add(core::mem::size_of::<KiUserInvertedFunctionTableHeader>())
             .ok_or(PeImageAccessError::AddressOverflow)?;
-        crate::write_slice::<Platform, _>(entries_address, &entries)
-            .ok_or(PeImageAccessError::MemoryAccess)?;
+        write_guest_slice::<Platform, _>(entries_address, &entries)?;
 
         litebox_util_log::debug!(
             table:% = format_args!("{table_address:#x}");
@@ -254,8 +251,7 @@ impl<'a, Platform: crate::ShimPlatform, FS: ShimFS> PeLoader<'a, Platform, FS> {
         let api_set_map = build_api_set_namespace(API_SET_MAPPINGS)
             .map_err(|_| PeImageAccessError::AddressOverflow)?;
         let api_set_map_ptr = create_pages(api_set_map.len())?;
-        crate::write_slice::<Platform, _>(api_set_map_ptr, &api_set_map)
-            .ok_or(PeImageAccessError::MemoryAccess)?;
+        write_guest_slice::<Platform, _>(api_set_map_ptr, &api_set_map)?;
         let ctx_ptr = create_pages(size_of::<X64Context>())?;
 
         let win32_image_path = win32_image_path(input.image_path);
@@ -273,8 +269,7 @@ impl<'a, Platform: crate::ShimPlatform, FS: ShimFS> PeLoader<'a, Platform, FS> {
         let environment_block = windows_environment_block(input.envp);
         let environment_size = checked_mul(environment_block.len(), size_of::<u16>())?;
         let environment_ptr = create_pages(environment_size)?;
-        crate::write_slice::<Platform, _>(environment_ptr, &environment_block)
-            .ok_or(PeImageAccessError::MemoryAccess)?;
+        write_guest_slice::<Platform, _>(environment_ptr, &environment_block)?;
         let process_parameter_strings = [
             &current_directory_path,
             &dll_path,
@@ -361,11 +356,9 @@ impl<'a, Platform: crate::ShimPlatform, FS: ShimFS> PeLoader<'a, Platform, FS> {
         }
         let process_heaps = initial_process_heaps_array(peb_ptr)?;
         let fast_peb_lock = create_pages(size_of::<RtlCriticalSection>())?;
-        crate::write_value::<Platform, _>(fast_peb_lock, RtlCriticalSection::initialized(0))
-            .ok_or(PeImageAccessError::MemoryAccess)?;
+        write_guest_value::<Platform, _>(fast_peb_lock, RtlCriticalSection::initialized(0))?;
         let loader_lock = create_pages(size_of::<RtlCriticalSection>())?;
-        crate::write_value::<Platform, _>(loader_lock, RtlCriticalSection::initialized(0))
-            .ok_or(PeImageAccessError::MemoryAccess)?;
+        write_guest_value::<Platform, _>(loader_lock, RtlCriticalSection::initialized(0))?;
 
         peb.api_set_map = api_set_map_ptr;
         peb.process_parameters = process_parameters_ptr;
@@ -391,7 +384,7 @@ impl<'a, Platform: crate::ShimPlatform, FS: ShimFS> PeLoader<'a, Platform, FS> {
         peb.read_only_shared_memory_base = read_only_shared_memory_base;
         peb.read_only_static_server_data = read_only_static_server_data;
         peb.csr_server_read_only_shared_memory_base = read_only_shared_memory_base as u64;
-        crate::write_value::<Platform, _>(peb_ptr, peb).ok_or(PeImageAccessError::MemoryAccess)?;
+        write_guest_value::<Platform, _>(peb_ptr, peb)?;
 
         let mut teb = ThreadEnvironmentBlock::new_zeroed();
         teb.nt_tib.exception_list = 0;
@@ -413,7 +406,7 @@ impl<'a, Platform: crate::ShimPlatform, FS: ShimFS> PeLoader<'a, Platform, FS> {
         teb.static_unicode_string =
             initial_teb_static_unicode_string(teb_ptr, &teb.static_unicode_buffer)?;
         teb.deallocation_stack = input.stack_base;
-        crate::write_value::<Platform, _>(teb_ptr, teb).ok_or(PeImageAccessError::MemoryAccess)?;
+        write_guest_value::<Platform, _>(teb_ptr, teb)?;
         Ok(WindowsProcessEnvironment {
             peb: peb_ptr,
             teb: teb_ptr,
@@ -451,8 +444,7 @@ fn initialize_static_server_data<Platform: RawPointerProvider>(
         base_static_server_data,
         windows_directory,
         windows_directory,
-    )
-    .ok_or(PeImageAccessError::MemoryAccess)?;
+    )?;
     let windows_system_directory =
         allocate_guest_unicode_string_from_str::<Platform>(shared_heap, WINDOWS_SYSTEM_DIRECTORY)?;
     write_static_server_data_field!(
@@ -460,8 +452,7 @@ fn initialize_static_server_data<Platform: RawPointerProvider>(
         base_static_server_data,
         windows_system_directory,
         windows_system_directory,
-    )
-    .ok_or(PeImageAccessError::MemoryAccess)?;
+    )?;
     let named_object_directory = allocate_guest_unicode_string_from_str::<Platform>(
         shared_heap,
         WINDOWS_NAMED_OBJECT_DIRECTORY,
@@ -471,29 +462,25 @@ fn initialize_static_server_data<Platform: RawPointerProvider>(
         base_static_server_data,
         named_object_directory,
         named_object_directory,
-    )
-    .ok_or(PeImageAccessError::MemoryAccess)?;
+    )?;
     write_static_server_data_field!(
         Platform,
         base_static_server_data,
         windows_major_version,
         WINDOWS_OS_MAJOR_VERSION,
-    )
-    .ok_or(PeImageAccessError::MemoryAccess)?;
+    )?;
     write_static_server_data_field!(
         Platform,
         base_static_server_data,
         windows_minor_version,
         WINDOWS_OS_MINOR_VERSION,
-    )
-    .ok_or(PeImageAccessError::MemoryAccess)?;
+    )?;
     write_static_server_data_field!(
         Platform,
         base_static_server_data,
         build_number,
         WINDOWS_OS_BUILD_NUMBER,
-    )
-    .ok_or(PeImageAccessError::MemoryAccess)?;
+    )?;
 
     let ini_file_mapping = shared_heap
         .allocate::<Platform, IniFileMapping>()?
@@ -503,15 +490,13 @@ fn initialize_static_server_data<Platform: RawPointerProvider>(
         base_static_server_data,
         ini_file_mapping,
         ini_file_mapping,
-    )
-    .ok_or(PeImageAccessError::MemoryAccess)?;
+    )?;
     write_static_server_data_field!(
         Platform,
         base_static_server_data,
         termsrv_client_time_zone_id,
         WINDOWS_TIME_ZONE_ID_INVALID,
-    )
-    .ok_or(PeImageAccessError::MemoryAccess)?;
+    )?;
     Ok(())
 }
 
@@ -635,7 +620,10 @@ impl GuestMemoryAllocator {
         alignment: usize,
     ) -> Result<usize, PeImageAccessError> {
         debug_assert!(alignment.is_power_of_two());
-        let address = self.cursor.checked_next_multiple_of(alignment).ok_or(PeImageAccessError::AddressOverflow)?;
+        let address = self
+            .cursor
+            .checked_next_multiple_of(alignment)
+            .ok_or(PeImageAccessError::AddressOverflow)?;
         let cursor = checked_add(address, size)?;
         if cursor > self.end {
             return Err(PeImageAccessError::AddressOverflow);
@@ -1011,6 +999,36 @@ fn checked_mul(left: usize, right: usize) -> Result<usize, PeImageAccessError> {
 
 fn to_u32(value: usize) -> Result<u32, PeImageAccessError> {
     u32::try_from(value).map_err(|_| PeImageAccessError::AddressOverflow)
+}
+
+fn write_guest_value<Platform, T>(address: usize, value: T) -> Result<(), PeImageAccessError>
+where
+    Platform: RawPointerProvider,
+    T: FromBytes + IntoBytes,
+{
+    crate::write_value::<Platform, T>(address, value).ok_or(PeImageAccessError::MemoryAccess)
+}
+
+fn write_guest_field_at_offset<Platform, Struct, Field>(
+    base: MutPtr<Platform, Struct>,
+    field_offset: usize,
+    value: Field,
+) -> Result<(), PeImageAccessError>
+where
+    Platform: RawPointerProvider,
+    Struct: FromBytes + IntoBytes,
+    Field: FromBytes + IntoBytes,
+{
+    crate::write_field_at_offset::<Platform, Struct, Field>(base, field_offset, value)
+        .ok_or(PeImageAccessError::MemoryAccess)
+}
+
+fn write_guest_slice<Platform, T>(address: usize, values: &[T]) -> Result<(), PeImageAccessError>
+where
+    Platform: RawPointerProvider,
+    T: Copy + FromBytes + IntoBytes,
+{
+    crate::write_slice::<Platform, T>(address, values).ok_or(PeImageAccessError::MemoryAccess)
 }
 
 struct LoadedNtDll {

--- a/litebox_shim_windows/src/loader/pe.rs
+++ b/litebox_shim_windows/src/loader/pe.rs
@@ -3,7 +3,7 @@
 
 use alloc::collections::btree_map::BTreeMap;
 use alloc::{string::String, sync::Arc, vec::Vec};
-use core::marker::PhantomData;
+use core::{marker::PhantomData, mem::size_of};
 use litebox::platform::{RawConstPointer as _, RawMutPointer as _};
 use litebox::utils::TruncateExt as _;
 use litebox::{
@@ -20,7 +20,7 @@ use litebox_common_windows::loader::{
 };
 use rangemap::RangeMap;
 use thiserror::Error;
-use zerocopy::{FromZeros, IntoBytes};
+use zerocopy::{FromBytes, FromZeros, Immutable, IntoBytes, KnownLayout};
 
 use crate::ShimFS;
 use crate::nt_types::{
@@ -54,6 +54,10 @@ const WINDOWS_HEAP_DECOMMIT_FREE_BLOCK_THRESHOLD: u64 = PAGE_SIZE as u64;
 const WINDOWS_NT_TIB_VERSION: usize = 30 << 8;
 const INITIAL_PROCESS_ID: usize = 1;
 const INITIAL_THREAD_ID: usize = 1;
+const API_SET_NAMESPACE_VERSION: u32 = 6;
+const API_SET_NAMESPACE_ENTRY_FLAGS: u32 = 1;
+const API_SET_NAMESPACE_HASH_FACTOR: u32 = 31;
+const MAX_API_SET_NAMESPACE_SIZE: usize = 16 * 1024 * 1024;
 
 pub(crate) struct WindowsProcessEnvironment {
     pub(crate) peb: usize,
@@ -111,8 +115,7 @@ impl<'a, Platform: crate::ShimPlatform, FS: ShimFS> PeLoader<'a, Platform, FS> {
         let length =
             NonZeroPageSize::new(INITIAL_STACK_SIZE).ok_or(PeImageAccessError::AddressOverflow)?;
         // SAFETY: `suggested_address` is `None` and `CreatePagesFlags::empty()` does not set
-        // `fixed_addr`, so the page manager picks an unused region — there is no overlapping-
-        // mapping precondition for the caller to uphold.
+        // `fixed_addr`, so the page manager picks an unused region and cannot replace a mapping.
         let stack_base = unsafe {
             self.page_manager
                 .create_stack_pages(None, length, CreatePagesFlags::empty())
@@ -229,6 +232,10 @@ impl<'a, Platform: crate::ShimPlatform, FS: ShimFS> PeLoader<'a, Platform, FS> {
         };
         let teb_ptr = create_pages(core::mem::size_of::<ThreadEnvironmentBlock>())?;
         let peb_ptr = create_pages(core::mem::size_of::<ProcessEnvironmentBlock>())?;
+        let api_set_map = build_api_set_namespace()?;
+        let api_set_map_ptr = create_pages(api_set_map.len())?;
+        crate::write_slice::<Platform, _>(api_set_map_ptr, &api_set_map)
+            .ok_or(PeImageAccessError::MemoryAccess)?;
         let ctx_ptr = create_pages(core::mem::size_of::<X64Context>())?;
 
         let dos_image_path = dos_image_path(image_path);
@@ -319,6 +326,7 @@ impl<'a, Platform: crate::ShimPlatform, FS: ShimFS> PeLoader<'a, Platform, FS> {
             peb.bit_field = PebBitField::IS_IMAGE_DYNAMICALLY_RELOCATED.bits();
         }
         let process_heaps = initial_process_heaps_array(peb_ptr)?;
+        peb.api_set_map = api_set_map_ptr;
         peb.process_parameters = process_parameters_ptr;
         peb.number_of_processors = 1;
         peb.critical_section_timeout = WINDOWS_CRITICAL_SECTION_TIMEOUT_100NS;
@@ -423,6 +431,377 @@ impl LoadedImage {
                 .map_err(|_| PeImageAccessError::AddressOverflow)?,
         }))
     }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, FromBytes, Immutable, IntoBytes, KnownLayout)]
+struct ApiSetNamespace {
+    version: u32,
+    size: u32,
+    flags: u32,
+    count: u32,
+    entry_offset: u32,
+    hash_offset: u32,
+    hash_factor: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, FromBytes, Immutable, IntoBytes, KnownLayout)]
+struct ApiSetNamespaceEntry {
+    flags: u32,
+    name_offset: u32,
+    name_length: u32,
+    hashed_length: u32,
+    value_offset: u32,
+    value_count: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, FromBytes, Immutable, IntoBytes, KnownLayout)]
+struct ApiSetValueEntry {
+    flags: u32,
+    name_offset: u32,
+    name_length: u32,
+    value_offset: u32,
+    value_length: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, FromBytes, Immutable, IntoBytes, KnownLayout)]
+struct ApiSetHashEntry {
+    hash: u32,
+    index: u32,
+}
+
+const API_SET_MAPPINGS: &[(&str, &str)] = &[
+    ("api-ms-win-core-apiquery-l1-1-0", "ntdll.dll"),
+    ("api-ms-win-core-apiquery-l1-1-2", "ntdll.dll"),
+    ("api-ms-win-core-apiquery-l2-1-1", "kernelbase.dll"),
+    ("api-ms-win-core-appcompat-l1-1-0", "kernelbase.dll"),
+    ("api-ms-win-core-appcompat-l1-1-1", "kernelbase.dll"),
+    ("api-ms-win-core-appinit-l1-1-0", "kernel32.dll"),
+    ("api-ms-win-core-atoms-l1-1-0", "kernel32.dll"),
+    ("api-ms-win-core-backgroundtask-l1-1-0", "kernelbase.dll"),
+    ("api-ms-win-core-calendar-l1-1-0", "kernel32.dll"),
+    ("api-ms-win-core-comm-l1-1-0", "kernelbase.dll"),
+    ("api-ms-win-core-comm-l1-1-2", "kernelbase.dll"),
+    ("api-ms-win-core-commandlinetoargv-l1-1-0", "kernelbase.dll"),
+    ("api-ms-win-core-console-ansi-l2-1-0", "kernel32.dll"),
+    ("api-ms-win-core-console-internal-l1-1-0", "kernelbase.dll"),
+    ("api-ms-win-core-console-l1-1-0", "kernelbase.dll"),
+    ("api-ms-win-core-console-l1-2-0", "kernelbase.dll"),
+    ("api-ms-win-core-console-l1-2-1", "kernelbase.dll"),
+    ("api-ms-win-core-console-l1-2-2", "kernelbase.dll"),
+    ("api-ms-win-core-console-l2-1-0", "kernelbase.dll"),
+    ("api-ms-win-core-console-l2-2-0", "kernelbase.dll"),
+    ("api-ms-win-core-console-l3-1-0", "kernelbase.dll"),
+    ("api-ms-win-core-console-l3-2-0", "kernelbase.dll"),
+    ("api-ms-win-core-crt-l1-1-0", "ntdll.dll"),
+    ("api-ms-win-core-crt-l2-1-0", "kernelbase.dll"),
+    ("api-ms-win-core-datetime-l1-1-0", "kernelbase.dll"),
+    ("api-ms-win-core-datetime-l1-1-1", "kernelbase.dll"),
+    ("api-ms-win-core-datetime-l1-1-2", "kernelbase.dll"),
+    ("api-ms-win-core-debug-l1-1-0", "kernelbase.dll"),
+    ("api-ms-win-core-debug-l1-1-1", "kernelbase.dll"),
+    ("api-ms-win-core-debug-l1-1-2", "kernelbase.dll"),
+    ("api-ms-win-core-delayload-l1-1-0", "kernelbase.dll"),
+    ("api-ms-win-core-delayload-l1-1-1", "kernelbase.dll"),
+    ("api-ms-win-downlevel-shlwapi-l1-1-0", "kernelbase.dll"),
+    ("api-ms-win-core-errorhandling-l1-1-0", "kernelbase.dll"),
+    ("api-ms-win-core-errorhandling-l1-1-2", "kernelbase.dll"),
+    ("api-ms-win-core-errorhandling-l1-1-3", "kernelbase.dll"),
+    ("api-ms-win-core-fibers-l1-1-0", "kernelbase.dll"),
+    ("api-ms-win-core-fibers-l1-1-2", "kernelbase.dll"),
+    ("api-ms-win-core-fibers-l2-1-0", "kernelbase.dll"),
+    ("api-ms-win-core-fibers-l2-1-1", "kernelbase.dll"),
+    ("api-ms-win-core-file-l1-1-0", "kernelbase.dll"),
+    ("api-ms-win-core-file-l1-1-1", "kernelbase.dll"),
+    ("api-ms-win-core-file-l1-2-0", "kernelbase.dll"),
+    ("api-ms-win-core-file-l1-2-1", "kernelbase.dll"),
+    ("api-ms-win-core-file-l1-2-2", "kernelbase.dll"),
+    ("api-ms-win-core-file-l1-2-3", "kernelbase.dll"),
+    ("api-ms-win-core-file-l1-2-5", "kernelbase.dll"),
+    ("api-ms-win-core-file-l2-1-0", "kernelbase.dll"),
+    ("api-ms-win-core-file-l2-1-1", "kernelbase.dll"),
+    ("api-ms-win-core-file-l2-1-2", "kernelbase.dll"),
+    ("api-ms-win-core-file-l2-1-3", "kernelbase.dll"),
+    ("api-ms-win-core-file-l2-1-4", "kernelbase.dll"),
+    ("api-ms-win-core-handle-l1-1-0", "kernelbase.dll"),
+    ("api-ms-win-core-heap-obsolete-l1-1-0", "kernelbase.dll"),
+    ("api-ms-win-core-heap-l1-1-0", "kernelbase.dll"),
+    ("api-ms-win-core-heap-l1-2-0", "kernelbase.dll"),
+    ("api-ms-win-core-heap-l2-1-0", "kernelbase.dll"),
+    ("api-ms-win-core-interlocked-l1-1-1", "kernelbase.dll"),
+    ("api-ms-win-core-io-l1-1-0", "kernelbase.dll"),
+    ("api-ms-win-core-io-l1-1-1", "kernelbase.dll"),
+    ("api-ms-win-core-job-l1-1-0", "kernelbase.dll"),
+    ("api-ms-win-core-largeinteger-l1-1-0", "kernelbase.dll"),
+    ("api-ms-win-core-libraryloader-l1-1-1", "kernelbase.dll"),
+    ("api-ms-win-core-libraryloader-l1-2-0", "kernelbase.dll"),
+    ("api-ms-win-core-libraryloader-l1-2-1", "kernelbase.dll"),
+    ("api-ms-win-core-libraryloader-l1-2-2", "kernelbase.dll"),
+    ("api-ms-win-core-libraryloader-l1-2-3", "kernelbase.dll"),
+    ("api-ms-win-core-libraryloader-l2-1-0", "kernelbase.dll"),
+    ("api-ms-win-core-localization-l1-1-0", "kernelbase.dll"),
+    ("api-ms-win-core-localization-l1-2-0", "kernelbase.dll"),
+    ("api-ms-win-core-localization-l1-2-4", "kernelbase.dll"),
+    ("api-ms-win-core-localization-l2-1-0", "kernelbase.dll"),
+    (
+        "api-ms-win-core-localization-private-l1-1-0",
+        "kernelbase.dll",
+    ),
+    ("api-ms-win-core-localregistry-l1-1-0", "kernelbase.dll"),
+    ("api-ms-win-core-memory-l1-1-0", "kernelbase.dll"),
+    ("api-ms-win-core-memory-l1-1-1", "kernelbase.dll"),
+    ("api-ms-win-core-memory-l1-1-2", "kernelbase.dll"),
+    ("api-ms-win-core-memory-l1-1-9", "kernelbase.dll"),
+    ("api-ms-win-core-misc-l1-1-0", "kernelbase.dll"),
+    ("api-ms-win-core-namedpipe-l1-1-0", "kernelbase.dll"),
+    ("api-ms-win-core-namedpipe-l1-2-1", "kernelbase.dll"),
+    ("api-ms-win-core-namedpipe-l1-2-2", "kernelbase.dll"),
+    ("api-ms-win-core-namespace-l1-1-0", "kernelbase.dll"),
+    ("api-ms-win-core-normalization-l1-1-0", "kernelbase.dll"),
+    ("api-ms-win-core-path-l1-1-0", "kernelbase.dll"),
+    (
+        "api-ms-win-core-processenvironment-l1-1-0",
+        "kernelbase.dll",
+    ),
+    (
+        "api-ms-win-core-processenvironment-l1-1-1",
+        "kernelbase.dll",
+    ),
+    (
+        "api-ms-win-core-processenvironment-l1-2-0",
+        "kernelbase.dll",
+    ),
+    ("api-ms-win-core-processsnapshot-l1-1-0", "kernelbase.dll"),
+    ("api-ms-win-core-processthreads-l1-1-0", "kernelbase.dll"),
+    ("api-ms-win-core-processthreads-l1-1-1", "kernelbase.dll"),
+    ("api-ms-win-core-processthreads-l1-1-2", "kernelbase.dll"),
+    ("api-ms-win-core-processthreads-l1-1-3", "kernelbase.dll"),
+    ("api-ms-win-core-processthreads-l1-1-8", "kernel32.dll"),
+    ("api-ms-win-core-processtopology-l1-1-0", "kernelbase.dll"),
+    ("api-ms-win-core-profile-l1-1-0", "kernelbase.dll"),
+    ("api-ms-win-core-pcw-l1-1-0", "kernelbase.dll"),
+    ("api-ms-win-core-psapi-ansi-l1-1-0", "kernelbase.dll"),
+    ("api-ms-win-core-psapi-l1-1-0", "kernelbase.dll"),
+    ("api-ms-win-core-realtime-l1-1-0", "kernelbase.dll"),
+    ("api-ms-win-core-registry-l1-1-0", "kernelbase.dll"),
+    ("api-ms-win-core-rtlsupport-l1-1-0", "ntdll.dll"),
+    ("api-ms-win-core-rtlsupport-l1-1-1", "ntdll.dll"),
+    ("api-ms-win-core-rtlsupport-l1-2-2", "ntdll.dll"),
+    ("api-ms-win-core-sidebyside-l1-1-0", "kernelbase.dll"),
+    ("api-ms-win-core-string-l1-1-0", "kernelbase.dll"),
+    ("api-ms-win-core-string-l2-1-1", "kernelbase.dll"),
+    ("api-ms-win-core-synch-l1-1-0", "kernelbase.dll"),
+    ("api-ms-win-core-synch-l1-1-1", "kernelbase.dll"),
+    ("api-ms-win-core-synch-l1-2-0", "kernelbase.dll"),
+    ("api-ms-win-core-synch-l1-2-1", "kernelbase.dll"),
+    ("api-ms-win-core-sysinfo-l1-1-0", "kernelbase.dll"),
+    ("api-ms-win-core-sysinfo-l1-1-1", "kernelbase.dll"),
+    ("api-ms-win-core-sysinfo-l1-2-0", "kernelbase.dll"),
+    ("api-ms-win-core-sysinfo-l1-2-1", "kernelbase.dll"),
+    ("api-ms-win-core-sysinfo-l1-2-3", "kernelbase.dll"),
+    ("api-ms-win-core-sysinfo-l1-2-8", "kernelbase.dll"),
+    ("api-ms-win-core-systemtopology-l1-1-0", "kernelbase.dll"),
+    ("api-ms-win-core-systemtopology-l1-1-1", "kernelbase.dll"),
+    ("api-ms-win-core-threadpool-legacy-l1-1-0", "kernelbase.dll"),
+    ("api-ms-win-core-threadpool-l1-2-0", "kernelbase.dll"),
+    (
+        "api-ms-win-core-threadpool-private-l1-1-0",
+        "kernelbase.dll",
+    ),
+    ("api-ms-win-core-timezone-l1-1-0", "kernelbase.dll"),
+    ("api-ms-win-core-util-l1-1-0", "kernelbase.dll"),
+    (
+        "api-ms-win-core-windowserrorreporting-l1-1-0",
+        "kernelbase.dll",
+    ),
+    (
+        "api-ms-win-core-windowserrorreporting-l1-1-1",
+        "kernelbase.dll",
+    ),
+    (
+        "api-ms-win-core-windowserrorreporting-l1-1-2",
+        "kernelbase.dll",
+    ),
+    (
+        "api-ms-win-core-windowserrorreporting-l1-1-3",
+        "kernelbase.dll",
+    ),
+    ("api-ms-win-core-wow64-l1-1-0", "kernelbase.dll"),
+    ("api-ms-win-core-wow64-l1-1-1", "kernelbase.dll"),
+    ("api-ms-win-core-wow64-l1-1-3", "kernelbase.dll"),
+    ("api-ms-win-core-xstate-l2-1-0", "kernelbase.dll"),
+    ("api-ms-win-core-xstate-l2-1-1", "kernelbase.dll"),
+    ("api-ms-win-core-xstate-l2-1-2", "kernelbase.dll"),
+    ("api-ms-win-eventing-consumer-l1-1-0", "sechost.dll"),
+    ("api-ms-win-eventing-consumer-l1-1-1", "sechost.dll"),
+    ("api-ms-win-eventing-controller-l1-1-0", "sechost.dll"),
+    ("api-ms-win-eventing-provider-l1-1-0", "advapi32.dll"),
+    ("api-ms-win-security-audit-l1-1-0", "sechost.dll"),
+    ("api-ms-win-security-audit-l1-1-1", "sechost.dll"),
+    ("api-ms-win-security-appcontainer-l1-1-0", "kernelbase.dll"),
+    ("api-ms-win-security-base-l1-1-0", "kernelbase.dll"),
+    ("api-ms-win-security-base-l1-2-0", "kernelbase.dll"),
+    ("api-ms-win-security-base-private-l1-1-0", "kernelbase.dll"),
+    ("api-ms-win-security-lsalookup-l1-1-0", "sechost.dll"),
+    ("api-ms-win-security-sddl-l1-1-0", "sechost.dll"),
+    ("api-ms-win-service-core-l1-1-0", "sechost.dll"),
+    ("api-ms-win-service-core-l1-1-1", "sechost.dll"),
+    ("api-ms-win-service-core-l1-1-2", "sechost.dll"),
+    ("api-ms-win-service-management-l1-1-0", "sechost.dll"),
+    ("api-ms-win-service-management-l2-1-0", "sechost.dll"),
+    ("api-ms-win-service-private-l1-1-0", "sechost.dll"),
+    ("api-ms-win-service-private-l1-1-2", "sechost.dll"),
+    ("api-ms-win-service-private-l1-1-3", "sechost.dll"),
+    ("api-ms-win-service-winsvc-l1-1-0", "sechost.dll"),
+    ("ext-ms-win-appcompat-apphelp-l1-1-2", "apphelp.dll"),
+    ("ext-ms-win-authz-context-l1-1-0", "authz.dll"),
+    ("ext-ms-win-core-winrt-remote-l1-1-0", "rpcrtremote.dll"),
+    ("ext-ms-win-oobe-query-l1-1-0", "kernelbase.dll"),
+    (
+        "ext-ms-win-packagevirtualizationcontext-l1-1-0",
+        "kernelbase.dll",
+    ),
+    ("ext-ms-win-rpc-ssl-l1-1-0", "rpcrtremote.dll"),
+];
+
+fn build_api_set_namespace() -> Result<Vec<u8>, PeImageAccessError> {
+    let mut mappings = API_SET_MAPPINGS.to_vec();
+    mappings.sort_by_key(|mapping| mapping.0);
+
+    let count = mappings.len();
+    let entry_offset = size_of::<ApiSetNamespace>();
+    let value_offset = checked_add(
+        entry_offset,
+        checked_mul(count, size_of::<ApiSetNamespaceEntry>())?,
+    )?;
+    let strings_offset = checked_add(
+        value_offset,
+        checked_mul(count, size_of::<ApiSetValueEntry>())?,
+    )?;
+    let mut string_data = Vec::new();
+    let mut entries = Vec::with_capacity(count);
+    let mut values = Vec::with_capacity(count);
+    let mut hashes = Vec::with_capacity(count);
+
+    for (index, (contract, host_dll)) in mappings.iter().enumerate() {
+        let name = utf16_bytes(contract)?;
+        let host = utf16_bytes(host_dll)?;
+        let name_offset = checked_add(strings_offset, string_data.len())?;
+        string_data.extend_from_slice(&name);
+        let host_offset = checked_add(strings_offset, string_data.len())?;
+        string_data.extend_from_slice(&host);
+        let value_entry_offset = checked_add(
+            value_offset,
+            checked_mul(index, size_of::<ApiSetValueEntry>())?,
+        )?;
+        entries.push(ApiSetNamespaceEntry {
+            flags: API_SET_NAMESPACE_ENTRY_FLAGS,
+            name_offset: to_u32(name_offset)?,
+            name_length: to_u32(name.len())?,
+            hashed_length: to_u32(
+                api_set_hashed_name_len(contract)
+                    .checked_mul(size_of::<u16>())
+                    .ok_or(PeImageAccessError::AddressOverflow)?,
+            )?,
+            value_offset: to_u32(value_entry_offset)?,
+            value_count: 1,
+        });
+        values.push(ApiSetValueEntry {
+            flags: 0,
+            name_offset: 0,
+            name_length: 0,
+            value_offset: to_u32(host_offset)?,
+            value_length: to_u32(host.len())?,
+        });
+        hashes.push(ApiSetHashEntry {
+            hash: api_set_hash(contract),
+            index: to_u32(index)?,
+        });
+    }
+
+    let hash_offset =
+        checked_add(strings_offset, string_data.len())?.next_multiple_of(size_of::<u32>());
+    let size = checked_add(
+        hash_offset,
+        checked_mul(count, size_of::<ApiSetHashEntry>())?,
+    )?;
+    if size > MAX_API_SET_NAMESPACE_SIZE {
+        return Err(PeImageAccessError::AddressOverflow);
+    }
+    hashes.sort_by_key(|entry| (entry.hash, entry.index));
+
+    let namespace = ApiSetNamespace {
+        version: API_SET_NAMESPACE_VERSION,
+        size: to_u32(size)?,
+        flags: 0,
+        count: to_u32(count)?,
+        entry_offset: to_u32(entry_offset)?,
+        hash_offset: to_u32(hash_offset)?,
+        hash_factor: API_SET_NAMESPACE_HASH_FACTOR,
+    };
+
+    let mut bytes = Vec::with_capacity(size);
+    append_struct(&mut bytes, &namespace);
+    for entry in &entries {
+        append_struct(&mut bytes, entry);
+    }
+    for value in &values {
+        append_struct(&mut bytes, value);
+    }
+    bytes.extend_from_slice(&string_data);
+    bytes.resize(hash_offset, 0);
+    for hash in &hashes {
+        append_struct(&mut bytes, hash);
+    }
+    debug_assert_eq!(bytes.len(), size);
+    Ok(bytes)
+}
+
+fn append_struct<T: IntoBytes + Immutable>(bytes: &mut Vec<u8>, value: &T) {
+    bytes.extend_from_slice(value.as_bytes());
+}
+
+fn utf16_bytes(value: &str) -> Result<Vec<u8>, PeImageAccessError> {
+    let mut bytes = Vec::with_capacity(
+        value
+            .len()
+            .checked_mul(size_of::<u16>())
+            .ok_or(PeImageAccessError::AddressOverflow)?,
+    );
+    for unit in value.encode_utf16() {
+        bytes.extend_from_slice(&unit.to_le_bytes());
+    }
+    Ok(bytes)
+}
+
+fn api_set_hashed_name_len(name: &str) -> usize {
+    name.rfind('-').unwrap_or(name.len())
+}
+
+fn api_set_hash(name: &str) -> u32 {
+    name[..api_set_hashed_name_len(name)]
+        .bytes()
+        .fold(0, |hash, byte| {
+            hash.wrapping_mul(API_SET_NAMESPACE_HASH_FACTOR)
+                .wrapping_add(u32::from(byte.to_ascii_lowercase()))
+        })
+}
+
+fn checked_add(left: usize, right: usize) -> Result<usize, PeImageAccessError> {
+    left.checked_add(right)
+        .ok_or(PeImageAccessError::AddressOverflow)
+}
+
+fn checked_mul(left: usize, right: usize) -> Result<usize, PeImageAccessError> {
+    left.checked_mul(right)
+        .ok_or(PeImageAccessError::AddressOverflow)
+}
+
+fn to_u32(value: usize) -> Result<u32, PeImageAccessError> {
+    u32::try_from(value).map_err(|_| PeImageAccessError::AddressOverflow)
 }
 
 struct LoadedNtDll {
@@ -986,6 +1365,7 @@ mod tests {
             lp_filename: *mut u16,
             n_size: u32,
         ) -> u32;
+        fn RtlGetCurrentPeb() -> *const ProcessEnvironmentBlock;
     }
 
     macro_rules! print_diff_fields {
@@ -1004,6 +1384,7 @@ mod tests {
                 ($host).csd_version,
             );
         };
+
         ($prefix:literal, $synthetic:expr, $host:expr, static_unicode_string) => {
             print_unicode_string_diff(
                 concat!($prefix, ".", stringify!(static_unicode_string)),
@@ -1018,6 +1399,221 @@ mod tests {
                 ($host).$field,
             );
         };
+    }
+
+    impl ApiSetValueEntry {
+        fn parse(bytes: &[u8], offset: usize) -> Option<Self> {
+            Some(Self::read_from_prefix(bytes.get(offset..)?).ok()?.0)
+        }
+
+        fn name(self, bytes: &[u8]) -> Option<String> {
+            read_utf16_string(bytes, self.name_offset, self.name_length)
+        }
+
+        fn value(self, bytes: &[u8]) -> Option<String> {
+            read_utf16_string(bytes, self.value_offset, self.value_length)
+        }
+    }
+
+    impl ApiSetHashEntry {
+        fn parse(bytes: &[u8], offset: usize) -> Option<Self> {
+            Some(Self::read_from_prefix(bytes.get(offset..)?).ok()?.0)
+        }
+    }
+
+    fn table_offset(base: u32, index: u32, entry_size: usize) -> Option<usize> {
+        (base as usize).checked_add((index as usize).checked_mul(entry_size)?)
+    }
+
+    fn checked_table_end(base: u32, count: u32, entry_size: usize) -> Option<usize> {
+        table_offset(base, count, entry_size)
+    }
+
+    fn read_utf16_string(bytes: &[u8], offset: u32, len: u32) -> Option<String> {
+        let offset = offset as usize;
+        let len = len as usize;
+        let end = offset.checked_add(len)?;
+        let bytes = bytes.get(offset..end)?;
+        let mut chunks = bytes.chunks_exact(size_of::<u16>());
+        if !chunks.remainder().is_empty() {
+            return None;
+        }
+        let units = chunks
+            .by_ref()
+            .map(|chunk| u16::from_le_bytes(chunk.try_into().expect("u16 byte chunk")))
+            .collect::<Vec<_>>();
+        Some(String::from_utf16_lossy(&units))
+    }
+
+    impl ApiSetNamespaceEntry {
+        fn parse(bytes: &[u8], offset: usize) -> Option<Self> {
+            Some(Self::read_from_prefix(bytes.get(offset..)?).ok()?.0)
+        }
+
+        fn name(self, bytes: &[u8]) -> Option<String> {
+            read_utf16_string(bytes, self.name_offset, self.name_length)
+        }
+
+        fn value(self, bytes: &[u8], index: u32) -> Option<ApiSetValueEntry> {
+            if index >= self.value_count {
+                return None;
+            }
+            ApiSetValueEntry::parse(
+                bytes,
+                table_offset(self.value_offset, index, size_of::<ApiSetValueEntry>())?,
+            )
+        }
+    }
+
+    impl ApiSetNamespace {
+        fn parse(bytes: &[u8]) -> Option<Self> {
+            let namespace = Self::read_from_prefix(bytes).ok()?.0;
+            let size = namespace.size as usize;
+            if size != bytes.len()
+                || !(size_of::<Self>()..=MAX_API_SET_NAMESPACE_SIZE).contains(&size)
+            {
+                return None;
+            }
+            if checked_table_end(
+                namespace.entry_offset,
+                namespace.count,
+                size_of::<ApiSetNamespaceEntry>(),
+            )? > size
+            {
+                return None;
+            }
+            if checked_table_end(
+                namespace.hash_offset,
+                namespace.count,
+                size_of::<ApiSetHashEntry>(),
+            )? > size
+            {
+                return None;
+            }
+            Some(namespace)
+        }
+
+        fn entry(self, bytes: &[u8], index: u32) -> Option<ApiSetNamespaceEntry> {
+            if index >= self.count {
+                return None;
+            }
+            ApiSetNamespaceEntry::parse(
+                bytes,
+                table_offset(self.entry_offset, index, size_of::<ApiSetNamespaceEntry>())?,
+            )
+        }
+
+        fn hash_entry(self, bytes: &[u8], index: u32) -> Option<ApiSetHashEntry> {
+            if index >= self.count {
+                return None;
+            }
+            ApiSetHashEntry::parse(
+                bytes,
+                table_offset(self.hash_offset, index, size_of::<ApiSetHashEntry>())?,
+            )
+        }
+    }
+
+    fn dump_api_set_entries(bytes: &[u8], namespace: ApiSetNamespace) {
+        std::println!("entries:");
+        for index in 0..namespace.count {
+            let entry = namespace.entry(bytes, index).expect("namespace entry");
+            std::println!(
+                "  {index:04} name={} flags={:#x} hashed_len={} values={}",
+                entry
+                    .name(bytes)
+                    .unwrap_or_else(|| String::from("<invalid>")),
+                entry.flags,
+                entry.hashed_length,
+                entry.value_count
+            );
+            for value_index in 0..entry.value_count {
+                let value = entry.value(bytes, value_index).expect("namespace value");
+                let name = value.name(bytes).unwrap_or_default();
+                let value_name = value
+                    .value(bytes)
+                    .unwrap_or_else(|| String::from("<invalid>"));
+                std::println!(
+                    "       [{value_index}] name={} value={} flags={:#x}",
+                    if name.is_empty() { "<default>" } else { &name },
+                    value_name,
+                    value.flags
+                );
+            }
+        }
+    }
+
+    fn dump_api_set_hash_entries(bytes: &[u8], namespace: ApiSetNamespace) {
+        std::println!("hash entries:");
+        for index in 0..namespace.count {
+            let entry = namespace.hash_entry(bytes, index).expect("hash entry");
+            std::println!(
+                "  {index:04} hash={:#010x} index={}",
+                entry.hash,
+                entry.index
+            );
+        }
+    }
+
+    fn dump_api_set_namespace(label: &str, ptr: usize, bytes: &[u8]) {
+        let api_set_map = ApiSetNamespace::parse(bytes).expect("valid API_SET_NAMESPACE");
+        std::println!("{label}");
+        std::println!(
+            "API_SET_NAMESPACE ptr={:#x} len={:#x} ({})",
+            ptr,
+            bytes.len(),
+            bytes.len()
+        );
+        std::println!("     version: {:#010x}", api_set_map.version);
+        std::println!("        size: {:#010x}", api_set_map.size);
+        std::println!("       flags: {:#010x}", api_set_map.flags);
+        std::println!("       count: {:#010x}", api_set_map.count);
+        std::println!("entry_offset: {:#010x}", api_set_map.entry_offset);
+        std::println!(" hash_offset: {:#010x}", api_set_map.hash_offset);
+        std::println!(" hash_factor: {:#010x}", api_set_map.hash_factor);
+        std::println!();
+        dump_api_set_entries(bytes, api_set_map);
+        std::println!();
+        dump_api_set_hash_entries(bytes, api_set_map);
+        std::println!();
+    }
+
+    fn dump_host_api_set_namespace_impl() {
+        let peb = unsafe {
+            // SAFETY: `RtlGetCurrentPeb` returns the current process PEB pointer on Windows.
+            RtlGetCurrentPeb().as_ref()
+        }
+        .expect("host PEB");
+        let namespace_ptr = peb.api_set_map as *const ApiSetNamespace;
+        let namespace = unsafe {
+            // SAFETY: `ApiSetMap` points at the host process API_SET_NAMESPACE while the
+            // process is alive; we read only the fixed header first to learn its size.
+            namespace_ptr.as_ref()
+        }
+        .expect("host API_SET_NAMESPACE header");
+        let size = namespace.size as usize;
+        assert!(
+            (size_of::<ApiSetNamespace>()..=MAX_API_SET_NAMESPACE_SIZE).contains(&size),
+            "host API_SET_NAMESPACE has unexpected size {size:#x}"
+        );
+        let bytes = unsafe {
+            // SAFETY: The size was read from the validated namespace header above, and the
+            // host API-set namespace is immutable process-wide data owned by ntdll.
+            core::slice::from_raw_parts(peb.api_set_map as *const u8, size)
+        };
+        dump_api_set_namespace("Host API_SET_NAMESPACE", peb.api_set_map, bytes);
+    }
+
+    #[test]
+    fn dump_host_api_set_namespace() {
+        dump_host_api_set_namespace_impl();
+
+        let namespace = build_api_set_namespace().expect("LiteBox API_SET_NAMESPACE builds");
+        dump_api_set_namespace(
+            "LiteBox synthetic API_SET_NAMESPACE",
+            namespace.as_ptr() as usize,
+            &namespace,
+        );
     }
 
     #[allow(clippy::similar_names)]

--- a/litebox_shim_windows/src/loader/pe.rs
+++ b/litebox_shim_windows/src/loader/pe.rs
@@ -3,7 +3,10 @@
 
 use alloc::collections::btree_map::BTreeMap;
 use alloc::{ffi::CString, string::String, sync::Arc, vec::Vec};
-use core::{marker::PhantomData, mem::size_of};
+use core::{
+    marker::PhantomData,
+    mem::{align_of, size_of},
+};
 use litebox::platform::{RawConstPointer as _, RawMutPointer as _};
 use litebox::utils::TruncateExt as _;
 use litebox::{
@@ -23,12 +26,12 @@ use rangemap::RangeMap;
 use thiserror::Error;
 use zerocopy::{FromBytes, FromZeros, Immutable, IntoBytes, KnownLayout};
 
-use crate::ShimFS;
 use crate::nt_types::{
     ClientId, PebBitField, ProcessEnvironmentBlock, RtlUserProcFlags, RtlUserProcessParameters,
     ThreadEnvironmentBlock, UnicodeString, X64Context,
 };
 use crate::syscalls::mm::{MemoryType, PageProtection};
+use crate::{MutPtr, ShimFS};
 
 const NTDLL_WRITABLE_SECTIONS: &[&[u8]] = &[b".mrdata"];
 const NTDLL_PATHS: &[&str] = &["/Windows/System32/ntdll.dll", "/windows/system32/ntdll.dll"];
@@ -41,10 +44,12 @@ const CSR_SERVER_DLL_MAX: usize = 4;
 const BASESRV_SERVERDLL_INDEX: usize = 1;
 const WINDOWS_DIRECTORY: &str = r"C:\Windows";
 const WINDOWS_SYSTEM_DIRECTORY: &str = r"C:\Windows\System32";
-const WINDOWS_OS_MAJOR_VERSION: u32 = 10;
-const WINDOWS_OS_MINOR_VERSION: u32 = 0;
+const WINDOWS_NAMED_OBJECT_DIRECTORY: &str = r"\BaseNamedObjects";
+const WINDOWS_OS_MAJOR_VERSION: u16 = 10;
+const WINDOWS_OS_MINOR_VERSION: u16 = 0;
 const WINDOWS_OS_BUILD_NUMBER: u16 = 19041;
 const WINDOWS_OS_PLATFORM_WIN32_NT: u32 = 2;
+const WINDOWS_TIME_ZONE_ID_INVALID: u32 = u32::MAX;
 const WINDOWS_CRITICAL_SECTION_TIMEOUT_100NS: i64 = -150 * 10_000_000;
 const WINDOWS_HEAP_SEGMENT_RESERVE: u64 = 1024 * 1024;
 const WINDOWS_HEAP_SEGMENT_COMMIT: u64 = 2 * PAGE_SIZE as u64;
@@ -53,6 +58,16 @@ const WINDOWS_HEAP_DECOMMIT_FREE_BLOCK_THRESHOLD: u64 = PAGE_SIZE as u64;
 const WINDOWS_NT_TIB_VERSION: usize = 30 << 8;
 const INITIAL_PROCESS_ID: usize = 1;
 const INITIAL_THREAD_ID: usize = 1;
+
+macro_rules! write_static_server_data_field {
+    ($platform:ty, $base:expr, $field:ident, $value:expr $(,)?) => {
+        crate::write_field_at_offset::<$platform, _, _>(
+            $base,
+            core::mem::offset_of!(BaseStaticServerData, $field),
+            $value,
+        )
+    };
+}
 
 pub(crate) struct WindowsProcessEnvironment {
     pub(crate) peb: usize,
@@ -290,37 +305,55 @@ impl<'a, Platform: crate::ShimPlatform, FS: ShimFS> PeLoader<'a, Platform, FS> {
         process_parameters.environment = environment_ptr;
         process_parameters.environment_size =
             u64::try_from(environment_size).map_err(|_| PeImageAccessError::AddressOverflow)?;
-        let mut process_parameter_tail = process_parameters_ptr
-            .checked_add(size_of::<RtlUserProcessParameters>())
-            .ok_or(PeImageAccessError::AddressOverflow)?;
-        process_parameters.current_directory.dos_path = write_tail_utf16_string::<Platform>(
-            &mut process_parameter_tail,
+        let mut process_parameters_allocation =
+            GuestMemoryAllocator::new(process_parameters_ptr, process_parameters_length)?;
+        let guest_process_parameters =
+            process_parameters_allocation.allocate::<Platform, RtlUserProcessParameters>()?;
+        process_parameters.current_directory.dos_path = allocate_guest_unicode_string::<Platform>(
+            &mut process_parameters_allocation,
             &current_directory_path,
         )?;
-        process_parameters.dll_path =
-            write_tail_utf16_string::<Platform>(&mut process_parameter_tail, &dll_path)?;
-        process_parameters.image_path_name =
-            write_tail_utf16_string::<Platform>(&mut process_parameter_tail, &image_path_name)?;
-        process_parameters.command_line =
-            write_tail_utf16_string::<Platform>(&mut process_parameter_tail, &command_line)?;
-        process_parameters.window_title =
-            write_tail_utf16_string::<Platform>(&mut process_parameter_tail, &window_title)?;
-        process_parameters.desktop_info =
-            write_tail_utf16_string::<Platform>(&mut process_parameter_tail, &desktop_info)?;
-        process_parameters.shell_info =
-            write_tail_utf16_string::<Platform>(&mut process_parameter_tail, &shell_info)?;
-        process_parameters.runtime_data =
-            write_tail_utf16_string::<Platform>(&mut process_parameter_tail, &runtime_data)?;
-        process_parameters.redirection_dll_name = write_tail_utf16_string::<Platform>(
-            &mut process_parameter_tail,
+        process_parameters.dll_path = allocate_guest_unicode_string::<Platform>(
+            &mut process_parameters_allocation,
+            &dll_path,
+        )?;
+        process_parameters.image_path_name = allocate_guest_unicode_string::<Platform>(
+            &mut process_parameters_allocation,
+            &image_path_name,
+        )?;
+        process_parameters.command_line = allocate_guest_unicode_string::<Platform>(
+            &mut process_parameters_allocation,
+            &command_line,
+        )?;
+        process_parameters.window_title = allocate_guest_unicode_string::<Platform>(
+            &mut process_parameters_allocation,
+            &window_title,
+        )?;
+        process_parameters.desktop_info = allocate_guest_unicode_string::<Platform>(
+            &mut process_parameters_allocation,
+            &desktop_info,
+        )?;
+        process_parameters.shell_info = allocate_guest_unicode_string::<Platform>(
+            &mut process_parameters_allocation,
+            &shell_info,
+        )?;
+        process_parameters.runtime_data = allocate_guest_unicode_string::<Platform>(
+            &mut process_parameters_allocation,
+            &runtime_data,
+        )?;
+        process_parameters.redirection_dll_name = allocate_guest_unicode_string::<Platform>(
+            &mut process_parameters_allocation,
             &redirection_dll_name,
         )?;
-        crate::write_value::<Platform, _>(process_parameters_ptr, process_parameters)
+        guest_process_parameters
+            .write_at_offset(0, process_parameters)
             .ok_or(PeImageAccessError::MemoryAccess)?;
 
         let read_only_shared_memory_base = create_pages(WINDOWS_SHARED_SECTION_SIZE)?;
+        let mut shared_heap =
+            GuestMemoryAllocator::new(read_only_shared_memory_base, WINDOWS_SHARED_SECTION_SIZE)?;
         let read_only_static_server_data =
-            initialize_windows_static_server_data::<Platform>(read_only_shared_memory_base)?;
+            initialize_windows_static_server_data::<Platform>(&mut shared_heap)?;
         let mut peb = ProcessEnvironmentBlock::new_zeroed();
         peb.image_base_address = input.image_base_address;
         if input.image_base_address != input.image.image_base() || input.image.has_dynamic_base() {
@@ -348,8 +381,8 @@ impl<'a, Platform: crate::ShimPlatform, FS: ShimFS> PeLoader<'a, Platform, FS> {
         peb.process_heaps = process_heaps.address;
         peb.loader_lock = loader_lock;
         peb.active_process_affinity_mask = 1;
-        peb.os_major_version = WINDOWS_OS_MAJOR_VERSION;
-        peb.os_minor_version = WINDOWS_OS_MINOR_VERSION;
+        peb.os_major_version = u32::from(WINDOWS_OS_MAJOR_VERSION);
+        peb.os_minor_version = u32::from(WINDOWS_OS_MINOR_VERSION);
         peb.os_build_number = WINDOWS_OS_BUILD_NUMBER;
         peb.os_platform_id = WINDOWS_OS_PLATFORM_WIN32_NT;
         peb.image_subsystem = u32::from(input.image.subsystem());
@@ -390,68 +423,96 @@ impl<'a, Platform: crate::ShimPlatform, FS: ShimFS> PeLoader<'a, Platform, FS> {
 }
 
 fn initialize_windows_static_server_data<Platform: RawPointerProvider>(
-    read_only_shared_memory_base: usize,
+    shared_heap: &mut GuestMemoryAllocator,
 ) -> Result<usize, PeImageAccessError> {
     let read_only_static_server_data =
-        SyntheticReadOnlySharedMemory::static_server_data_table_address(
-            read_only_shared_memory_base,
-        )?;
+        shared_heap.allocate_array::<Platform, usize>(CSR_SERVER_DLL_MAX)?;
     let client_base_static_server_data =
-        SyntheticReadOnlySharedMemory::base_static_server_data_address(
-            read_only_shared_memory_base,
-        )?;
-    initialize_static_server_data::<Platform>(
-        read_only_static_server_data,
-        client_base_static_server_data,
-    )?;
-    Ok(read_only_static_server_data)
+        shared_heap.allocate::<Platform, BaseStaticServerData>()?;
+    initialize_static_server_data::<Platform>(shared_heap, client_base_static_server_data)?;
+
+    read_only_static_server_data
+        .write_at_offset(
+            BASESRV_SERVERDLL_INDEX.cast_signed(),
+            client_base_static_server_data.as_usize(),
+        )
+        .ok_or(PeImageAccessError::MemoryAccess)?;
+    Ok(read_only_static_server_data.as_usize())
 }
 
 fn initialize_static_server_data<Platform: RawPointerProvider>(
-    static_server_data_table: usize,
-    base_static_server_data: usize,
+    shared_heap: &mut GuestMemoryAllocator,
+    base_static_server_data: MutPtr<Platform, BaseStaticServerData>,
 ) -> Result<(), PeImageAccessError> {
-    for server_index in [0, BASESRV_SERVERDLL_INDEX] {
-        let entry =
-            SyntheticStaticServerDataTable::entry_address(static_server_data_table, server_index)?;
-        crate::write_value::<Platform, _>(entry, base_static_server_data)
-            .ok_or(PeImageAccessError::MemoryAccess)?;
-    }
-
-    write_static_server_unicode_string::<Platform>(
-        SyntheticBaseStaticServerData::windows_directory_address(base_static_server_data)?,
-        SyntheticBaseStaticServerData::windows_directory_string_address(base_static_server_data)?,
-        WINDOWS_DIRECTORY,
+    let windows_directory =
+        allocate_guest_unicode_string_from_str::<Platform>(shared_heap, WINDOWS_DIRECTORY)?;
+    write_static_server_data_field!(
+        Platform,
+        base_static_server_data,
+        windows_directory,
+        windows_directory,
+    )
+    .ok_or(PeImageAccessError::MemoryAccess)?;
+    let windows_system_directory =
+        allocate_guest_unicode_string_from_str::<Platform>(shared_heap, WINDOWS_SYSTEM_DIRECTORY)?;
+    write_static_server_data_field!(
+        Platform,
+        base_static_server_data,
+        windows_system_directory,
+        windows_system_directory,
+    )
+    .ok_or(PeImageAccessError::MemoryAccess)?;
+    let named_object_directory = allocate_guest_unicode_string_from_str::<Platform>(
+        shared_heap,
+        WINDOWS_NAMED_OBJECT_DIRECTORY,
     )?;
-    write_static_server_unicode_string::<Platform>(
-        SyntheticBaseStaticServerData::system_directory_address(base_static_server_data)?,
-        SyntheticBaseStaticServerData::system_directory_string_address(base_static_server_data)?,
-        WINDOWS_SYSTEM_DIRECTORY,
-    )?;
+    write_static_server_data_field!(
+        Platform,
+        base_static_server_data,
+        named_object_directory,
+        named_object_directory,
+    )
+    .ok_or(PeImageAccessError::MemoryAccess)?;
+    write_static_server_data_field!(
+        Platform,
+        base_static_server_data,
+        windows_major_version,
+        WINDOWS_OS_MAJOR_VERSION,
+    )
+    .ok_or(PeImageAccessError::MemoryAccess)?;
+    write_static_server_data_field!(
+        Platform,
+        base_static_server_data,
+        windows_minor_version,
+        WINDOWS_OS_MINOR_VERSION,
+    )
+    .ok_or(PeImageAccessError::MemoryAccess)?;
+    write_static_server_data_field!(
+        Platform,
+        base_static_server_data,
+        build_number,
+        WINDOWS_OS_BUILD_NUMBER,
+    )
+    .ok_or(PeImageAccessError::MemoryAccess)?;
 
-    let rebase_anchor =
-        SyntheticBaseStaticServerData::rebase_anchor_address(base_static_server_data)?;
-    crate::write_value::<Platform, _>(rebase_anchor, base_static_server_data)
-        .ok_or(PeImageAccessError::MemoryAccess)
-}
-
-fn write_static_server_unicode_string<Platform: RawPointerProvider>(
-    string_address: usize,
-    buffer: usize,
-    value: &str,
-) -> Result<(), PeImageAccessError> {
-    let string = Utf16StringBuffer::new(value)?;
-    crate::write_slice::<Platform, _>(buffer, &string.units)
-        .ok_or(PeImageAccessError::MemoryAccess)?;
-
-    let unicode_string = UnicodeString {
-        length: string.length,
-        maximum_length: string.maximum_length,
-        padding_0: [0; 4],
-        buffer,
-    };
-    crate::write_value::<Platform, _>(string_address, unicode_string)
-        .ok_or(PeImageAccessError::MemoryAccess)
+    let ini_file_mapping = shared_heap
+        .allocate::<Platform, IniFileMapping>()?
+        .as_usize();
+    write_static_server_data_field!(
+        Platform,
+        base_static_server_data,
+        ini_file_mapping,
+        ini_file_mapping,
+    )
+    .ok_or(PeImageAccessError::MemoryAccess)?;
+    write_static_server_data_field!(
+        Platform,
+        base_static_server_data,
+        termsrv_client_time_zone_id,
+        WINDOWS_TIME_ZONE_ID_INVALID,
+    )
+    .ok_or(PeImageAccessError::MemoryAccess)?;
+    Ok(())
 }
 
 fn register_image_virtual_allocation<Platform: crate::ShimPlatform>(
@@ -533,93 +594,216 @@ impl RtlCriticalSection {
     }
 }
 
-#[repr(C)]
-struct SyntheticReadOnlySharedMemory {
-    _padding_to_static_server_data_table:
-        [u8; SyntheticReadOnlySharedMemory::STATIC_SERVER_DATA_TABLE_PADDING_BYTES],
-    static_server_data_table: SyntheticStaticServerDataTable,
-    base_static_server_data: SyntheticBaseStaticServerData,
+struct GuestMemoryAllocator {
+    cursor: usize,
+    end: usize,
 }
 
-impl SyntheticReadOnlySharedMemory {
-    const STATIC_SERVER_DATA_TABLE_PADDING_BYTES: usize = 0x750;
-    const STATIC_SERVER_DATA_TABLE_OFFSET: usize =
-        core::mem::offset_of!(Self, static_server_data_table);
-    const BASE_STATIC_SERVER_DATA_OFFSET: usize =
-        core::mem::offset_of!(Self, base_static_server_data);
-
-    fn static_server_data_table_address(base: usize) -> Result<usize, PeImageAccessError> {
-        checked_add(base, Self::STATIC_SERVER_DATA_TABLE_OFFSET)
+impl GuestMemoryAllocator {
+    fn new(base: usize, size: usize) -> Result<Self, PeImageAccessError> {
+        let cursor = base;
+        let end = checked_add(base, size)?;
+        if cursor > end {
+            return Err(PeImageAccessError::AddressOverflow);
+        }
+        Ok(Self { cursor, end })
     }
 
-    fn base_static_server_data_address(base: usize) -> Result<usize, PeImageAccessError> {
-        checked_add(base, Self::BASE_STATIC_SERVER_DATA_OFFSET)
+    fn allocate<Platform, T>(&mut self) -> Result<MutPtr<Platform, T>, PeImageAccessError>
+    where
+        Platform: RawPointerProvider,
+        T: FromBytes + IntoBytes,
+    {
+        self.allocate_array::<Platform, T>(1)
+    }
+
+    fn allocate_array<Platform, T>(
+        &mut self,
+        count: usize,
+    ) -> Result<MutPtr<Platform, T>, PeImageAccessError>
+    where
+        Platform: RawPointerProvider,
+        T: FromBytes + IntoBytes,
+    {
+        let address = self.allocate_bytes(checked_mul(size_of::<T>(), count)?, align_of::<T>())?;
+        Ok(MutPtr::<Platform, T>::from_usize(address))
+    }
+
+    fn allocate_bytes(
+        &mut self,
+        size: usize,
+        alignment: usize,
+    ) -> Result<usize, PeImageAccessError> {
+        debug_assert!(alignment.is_power_of_two());
+        let address = self.cursor.checked_next_multiple_of(alignment).ok_or(PeImageAccessError::AddressOverflow)?;
+        let cursor = checked_add(address, size)?;
+        if cursor > self.end {
+            return Err(PeImageAccessError::AddressOverflow);
+        }
+        self.cursor = cursor;
+        Ok(address)
     }
 }
 
+// Reference layout from ReactOS `sdk/include/reactos/subsys/win/base.h`.
 #[repr(C)]
-struct SyntheticStaticServerDataTable {
-    entries: [usize; CSR_SERVER_DLL_MAX],
-}
-
-impl SyntheticStaticServerDataTable {
-    fn entry_address(table: usize, server_index: usize) -> Result<usize, PeImageAccessError> {
-        checked_add(table, checked_mul(server_index, size_of::<usize>())?)
-    }
-}
-
-#[repr(C)]
-struct SyntheticBaseStaticServerData {
+#[derive(FromBytes, IntoBytes)]
+struct BaseStaticServerData {
     windows_directory: UnicodeString,
-    system_directory: UnicodeString,
-    _padding_to_rebase_anchor: [u8; SyntheticBaseStaticServerData::REBASE_ANCHOR_LAYOUT_OFFSET
-        - 2 * size_of::<UnicodeString>()],
-    rebase_anchor: usize,
-    _padding_to_windows_directory_string: [u8;
-        SyntheticBaseStaticServerData::WINDOWS_DIRECTORY_STRING_LAYOUT_OFFSET
-            - SyntheticBaseStaticServerData::REBASE_ANCHOR_LAYOUT_OFFSET
-            - size_of::<usize>()],
-    windows_directory_string: [u8;
-        SyntheticBaseStaticServerData::SYSTEM_DIRECTORY_STRING_LAYOUT_OFFSET
-            - SyntheticBaseStaticServerData::WINDOWS_DIRECTORY_STRING_LAYOUT_OFFSET],
-    system_directory_string: [u8; SyntheticBaseStaticServerData::SYSTEM_DIRECTORY_STRING_BYTES],
+    windows_system_directory: UnicodeString,
+    named_object_directory: UnicodeString,
+    windows_major_version: u16,
+    windows_minor_version: u16,
+    build_number: u16,
+    csd_number: u16,
+    rc_number: u16,
+    csd_version: [u16; 128],
+    padding_0: [u8; 6],
+    sys_info: SystemBasicInformation,
+    time_of_day: SystemTimeOfDayInformation,
+    ini_file_mapping: usize,
+    nls_user_info: NlsUserInfo,
+    default_separate_vdm: u8,
+    is_wow_task_ready: u8,
+    padding_1: [u8; 6],
+    windows_sys32_x86_directory: UnicodeString,
+    f_termsrv_app_install_mode: u8,
+    padding_2: [u8; 3],
+    tzi_termsrv_client_time_zone: TimeZoneInformation,
+    kt_termsrv_client_bias: KSystemTime,
+    termsrv_client_time_zone_id: u32,
+    luid_device_maps_enabled: u8,
+    padding_3: [u8; 3],
+    termsrv_client_time_zone_change_num: u32,
 }
 
-impl SyntheticBaseStaticServerData {
-    const REBASE_ANCHOR_LAYOUT_OFFSET: usize = 0x9e8;
-    const WINDOWS_DIRECTORY_STRING_LAYOUT_OFFSET: usize = 0xa00;
-    const SYSTEM_DIRECTORY_STRING_LAYOUT_OFFSET: usize = 0xa40;
-    const SYSTEM_DIRECTORY_STRING_BYTES: usize = 0x40;
-    const WINDOWS_DIRECTORY_OFFSET: usize = core::mem::offset_of!(Self, windows_directory);
-    const SYSTEM_DIRECTORY_OFFSET: usize = core::mem::offset_of!(Self, system_directory);
-    const REBASE_ANCHOR_OFFSET: usize = core::mem::offset_of!(Self, rebase_anchor);
-    const WINDOWS_DIRECTORY_STRING_OFFSET: usize =
-        core::mem::offset_of!(Self, windows_directory_string);
-    const SYSTEM_DIRECTORY_STRING_OFFSET: usize =
-        core::mem::offset_of!(Self, system_directory_string);
-
-    fn windows_directory_address(base: usize) -> Result<usize, PeImageAccessError> {
-        checked_add(base, Self::WINDOWS_DIRECTORY_OFFSET)
-    }
-
-    fn system_directory_address(base: usize) -> Result<usize, PeImageAccessError> {
-        checked_add(base, Self::SYSTEM_DIRECTORY_OFFSET)
-    }
-
-    fn rebase_anchor_address(base: usize) -> Result<usize, PeImageAccessError> {
-        checked_add(base, Self::REBASE_ANCHOR_OFFSET)
-    }
-
-    fn windows_directory_string_address(base: usize) -> Result<usize, PeImageAccessError> {
-        checked_add(base, Self::WINDOWS_DIRECTORY_STRING_OFFSET)
-    }
-
-    fn system_directory_string_address(base: usize) -> Result<usize, PeImageAccessError> {
-        checked_add(base, Self::SYSTEM_DIRECTORY_STRING_OFFSET)
-    }
+#[allow(clippy::struct_field_names)]
+#[repr(C)]
+#[derive(FromBytes, IntoBytes)]
+struct IniFileMapping {
+    file_names: usize,
+    default_file_name_mapping: usize,
+    win_ini_file_mapping: usize,
+    reserved: u32,
+    padding: [u8; 4],
 }
 
-const _: () = assert!(size_of::<SyntheticReadOnlySharedMemory>() <= WINDOWS_SHARED_SECTION_SIZE);
+#[repr(C)]
+#[derive(FromBytes, IntoBytes)]
+struct SystemBasicInformation {
+    reserved: u32,
+    timer_resolution: u32,
+    page_size: u32,
+    number_of_physical_pages: u32,
+    lowest_physical_page_number: u32,
+    highest_physical_page_number: u32,
+    allocation_granularity: u32,
+    padding_0: [u8; 4],
+    minimum_user_mode_address: usize,
+    maximum_user_mode_address: usize,
+    active_processors_affinity_mask: usize,
+    number_of_processors: u8,
+    padding_1: [u8; 7],
+}
+
+#[repr(C)]
+#[derive(FromBytes, IntoBytes)]
+struct SystemTimeOfDayInformation {
+    boot_time: i64,
+    current_time: i64,
+    time_zone_bias: i64,
+    time_zone_id: u32,
+    reserved: u32,
+    boot_time_bias: u64,
+    sleep_time_bias: u64,
+}
+
+#[repr(C)]
+#[derive(FromBytes, IntoBytes)]
+struct NlsUserInfo {
+    s_language: [u16; 80],
+    i_country: [u16; 80],
+    s_country: [u16; 80],
+    s_list: [u16; 80],
+    i_measure: [u16; 80],
+    i_paper_size: [u16; 80],
+    s_decimal: [u16; 80],
+    s_thousand: [u16; 80],
+    s_grouping: [u16; 80],
+    i_digits: [u16; 80],
+    i_l_zero: [u16; 80],
+    i_neg_number: [u16; 80],
+    s_native_digits: [u16; 80],
+    num_shape: [u16; 80],
+    s_currency: [u16; 80],
+    s_mon_dec_sep: [u16; 80],
+    s_mon_thou_sep: [u16; 80],
+    s_mon_grouping: [u16; 80],
+    i_curr_digits: [u16; 80],
+    i_currency: [u16; 80],
+    i_neg_curr: [u16; 80],
+    s_positive_sign: [u16; 80],
+    s_negative_sign: [u16; 80],
+    s_time_format: [u16; 80],
+    s_time: [u16; 80],
+    i_time: [u16; 80],
+    i_tl_zero: [u16; 80],
+    i_time_prefix: [u16; 80],
+    s_1159: [u16; 80],
+    s_2359: [u16; 80],
+    s_short_date: [u16; 80],
+    s_date: [u16; 80],
+    i_date: [u16; 80],
+    s_year_month: [u16; 80],
+    s_long_date: [u16; 80],
+    i_cal_type: [u16; 80],
+    i_first_day_of_week: [u16; 80],
+    i_first_week_of_year: [u16; 80],
+    locale: [u16; 80],
+    user_locale_id: u32,
+    interactive_user_luid: Luid,
+    ul_cache_update_count: u32,
+}
+
+#[repr(C)]
+#[derive(FromBytes, IntoBytes)]
+struct Luid {
+    low_part: u32,
+    high_part: i32,
+}
+
+#[repr(C)]
+#[derive(FromBytes, IntoBytes)]
+struct TimeZoneInformation {
+    bias: i32,
+    standard_name: [u16; 32],
+    standard_date: SystemTime,
+    standard_bias: i32,
+    daylight_name: [u16; 32],
+    daylight_date: SystemTime,
+    daylight_bias: i32,
+}
+
+#[repr(C)]
+#[derive(FromBytes, IntoBytes)]
+struct SystemTime {
+    year: u16,
+    month: u16,
+    day_of_week: u16,
+    day: u16,
+    hour: u16,
+    minute: u16,
+    second: u16,
+    milliseconds: u16,
+}
+
+#[repr(C)]
+#[derive(FromBytes, IntoBytes)]
+struct KSystemTime {
+    low_part: u32,
+    high_1_time: i32,
+    high_2_time: i32,
+}
 
 const API_SET_MAPPINGS: &[(&str, &str)] = &[
     ("api-ms-win-core-apiquery-l1-1-0", "ntdll.dll"),
@@ -1382,19 +1566,27 @@ fn initial_process_heaps_array(peb_ptr: usize) -> Result<InitialProcessHeaps, Pe
     })
 }
 
-fn write_tail_utf16_string<Platform: RawPointerProvider>(
-    tail: &mut usize,
+fn allocate_guest_unicode_string_from_str<Platform: RawPointerProvider>(
+    shared_heap: &mut GuestMemoryAllocator,
+    value: &str,
+) -> Result<UnicodeString, PeImageAccessError> {
+    let string = Utf16StringBuffer::new(value)?;
+    allocate_guest_unicode_string::<Platform>(shared_heap, &string)
+}
+
+fn allocate_guest_unicode_string<Platform: RawPointerProvider>(
+    allocation: &mut GuestMemoryAllocator,
     string: &Utf16StringBuffer,
 ) -> Result<UnicodeString, PeImageAccessError> {
-    let buffer = *tail;
-    crate::write_slice::<Platform, _>(buffer, &string.units)
+    let buffer = allocation.allocate_array::<Platform, u16>(string.units.len())?;
+    buffer
+        .write_slice_at_offset(0, &string.units)
         .ok_or(PeImageAccessError::MemoryAccess)?;
-    *tail = checked_add(*tail, usize::from(string.maximum_length))?;
     Ok(UnicodeString {
         length: string.length,
         maximum_length: string.maximum_length,
         padding_0: [0; 4],
-        buffer,
+        buffer: buffer.as_usize(),
     })
 }
 
@@ -1990,22 +2182,8 @@ mod tests {
     fn prints_created_peb_host_diff() {
         let created = created_process_environment_snapshot();
         let host_peb = host_peb_snapshot();
-        let base_static_server_data: usize = read_guest_value(
-            created.peb.read_only_static_server_data
-                + BASESRV_SERVERDLL_INDEX * core::mem::size_of::<usize>(),
-        );
 
         assert_eq!(created.peb.image_base_address, created.image_base_address);
-        assert_eq!(
-            created.peb.read_only_static_server_data,
-            created.peb.read_only_shared_memory_base
-                + SyntheticReadOnlySharedMemory::STATIC_SERVER_DATA_TABLE_OFFSET
-        );
-        assert_eq!(
-            base_static_server_data,
-            created.peb.read_only_shared_memory_base
-                + SyntheticReadOnlySharedMemory::BASE_STATIC_SERVER_DATA_OFFSET
-        );
         assert_ne!(host_peb.image_base_address, 0);
 
         print_diff_header("synthetic PEB vs host PEB");

--- a/litebox_shim_windows/src/nt_types.rs
+++ b/litebox_shim_windows/src/nt_types.rs
@@ -713,5 +713,6 @@ pub struct RtlUserProcessParameters {
 
 const _: [(); 0x1878] = [(); core::mem::size_of::<ThreadEnvironmentBlock>()];
 const _: [(); 0x7d0] = [(); core::mem::size_of::<ProcessEnvironmentBlock>()];
+const _: () = assert!(offset_of!(ProcessEnvironmentBlock, api_set_map) == 0x68);
 const _: [(); 0x4d0] = [(); core::mem::size_of::<X64Context>()];
 const _: [(); 0x448] = [(); core::mem::size_of::<RtlUserProcessParameters>()];

--- a/litebox_shim_windows/src/nt_types.rs
+++ b/litebox_shim_windows/src/nt_types.rs
@@ -713,6 +713,5 @@ pub struct RtlUserProcessParameters {
 
 const _: [(); 0x1878] = [(); core::mem::size_of::<ThreadEnvironmentBlock>()];
 const _: [(); 0x7d0] = [(); core::mem::size_of::<ProcessEnvironmentBlock>()];
-const _: () = assert!(offset_of!(ProcessEnvironmentBlock, api_set_map) == 0x68);
 const _: [(); 0x4d0] = [(); core::mem::size_of::<X64Context>()];
 const _: [(); 0x448] = [(); core::mem::size_of::<RtlUserProcessParameters>()];


### PR DESCRIPTION
This PR fills in more of the synthetic Windows process startup state.

- Build and install a synthetic API-set namespace in `PEB.ApiSetMap`. **Note** that it is synthetic (i.e., a subset of what my host machine has).
- Pass runner `argv`/`envp` into the Windows PE loader and populate them to guest.
- Initialize additional PEB startup fields including process parameters, heap metadata, `FastPebLock`, loader lock, OS/subsystem metadata, `ReadOnlySharedMemoryBase`, and `ReadOnlyStaticServerData`.
- Model the read-only shared server-data region enough to provide base server static data, Windows/System32 directory strings, and the rebase anchor expected by startup code. **Note** that they are modeled from a real Windows CDB probe and the actual struct layout is still unknown.