### PR TITLE
Simplify via `zerocopy::FromZeros::new_box_zeroed`

### DIFF
--- a/litebox_common_linux/Cargo.toml
+++ b/litebox_common_linux/Cargo.toml
@@ -11,7 +11,7 @@ litebox = { path = "../litebox/", version = "0.1.0" }
 thiserror = { version = "2.0.6", default-features = false }
 int-enum = "1.2.0"
 syscalls = { version = "0.6", default-features = false }
-zerocopy = { version = "0.8", features = ["derive"] }
+zerocopy = { version = "0.8", features = ["derive", "alloc"] }
 
 [lints]
 workspace = true

--- a/litebox_common_linux/src/physical_pointers.rs
+++ b/litebox_common_linux/src/physical_pointers.rs
@@ -44,28 +44,6 @@ use zerocopy::{FromBytes, IntoBytes};
 type MapInfoOf<V, const ALIGN: usize> =
     <<V as GlobalVmapManager<ALIGN>>::Manager as VmapManager<ALIGN>>::MapInfo;
 
-/// Allocate a zeroed `Box<T>` on the heap.
-///
-/// # Panics
-///
-/// Panics if `T` is a zero-sized type, since `alloc_zeroed` with a zero-sized
-/// layout is undefined behavior.
-fn box_new_zeroed<T: FromBytes>() -> alloc::boxed::Box<T> {
-    assert!(
-        core::mem::size_of::<T>() > 0,
-        "box_new_zeroed does not support zero-sized types"
-    );
-    let layout = core::alloc::Layout::new::<T>();
-    // Safety: layout has a non-zero size and correct alignment for T.
-    let ptr = unsafe { alloc::alloc::alloc_zeroed(layout) }.cast::<T>();
-    if ptr.is_null() {
-        alloc::alloc::handle_alloc_error(layout);
-    }
-    // Safety: ptr is a valid, zeroed, properly aligned heap allocation for T.
-    // T: FromBytes guarantees all-zero is a valid bit pattern.
-    unsafe { alloc::boxed::Box::from_raw(ptr) }
-}
-
 #[inline]
 fn align_down(address: usize, align: usize) -> usize {
     address & !(align - 1)
@@ -216,7 +194,13 @@ where
             core::mem::size_of::<T>(),
             PhysPageMapPermissions::READ,
         )?;
-        let mut boxed = box_new_zeroed::<T>();
+        let mut boxed = <T as zerocopy::FromZeros>::new_box_zeroed().map_err(
+            |_err: zerocopy::AllocError| {
+                // zerocopy::AllocError is a ZST and carries no other information we
+                // could forward
+                PhysPointerError::AllocError
+            },
+        )?;
         // SAFETY: `boxed` is a freshly allocated `T` and is thus valid for writes
         // of `size_of::<T>()` bytes, which is the guard's mapped size.
         unsafe { guard.copy_out(core::ptr::from_mut::<T>(boxed.as_mut()).cast::<u8>())? };

--- a/litebox_common_linux/src/vmap.rs
+++ b/litebox_common_linux/src/vmap.rs
@@ -250,4 +250,6 @@ pub enum PhysPointerError {
     VaSpaceExhausted,
     #[error("Page-table frame allocation failed (out of memory)")]
     FrameAllocationFailed,
+    #[error("Rust object allocation failed (out of memory)")]
+    AllocError,
 }


### PR DESCRIPTION
The existing implementation of `box_new_zeroed` was unnecessarily complex.  This PR simplifies it.