### PR TITLE
.gitignore: ignore direnv files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,3 +193,7 @@ venv/
 dev_bench/unixbench/prepared/
 dev_bench/unixbench/byte-unixbench-*/
 dev_bench/unixbench/*.zip
+
+### Direnv ###
+.direnv
+.envrc


### PR DESCRIPTION
Ignores direnv-specific files. Direnv is useful to set up dynamic development environments, but there is not a single canonical configuration that should be upstreamed. Adding it to `.gitignore` prevents contributors from accidentally including their particular configuration.
