### PR TITLE
Add key-value field visitor to HostLogger

### DIFF
--- a/litebox_runner_lvbs/src/main.rs
+++ b/litebox_runner_lvbs/src/main.rs
@@ -30,9 +30,8 @@ impl log::Log for HostLogger {
     }
 
     fn log(&self, record: &log::Record) {
-        use core::fmt::Write;
         let mut buf: arrayvec::ArrayString<1024> = arrayvec::ArrayString::new();
-        let _ = writeln!(buf, "[{}] {}", record.level(), record.args());
+        let _ = litebox_util_log::format_record(&mut buf, record);
         litebox_platform_lvbs::arch::ioport::serial_print_string(&buf);
     }
 

--- a/litebox_runner_snp/src/main.rs
+++ b/litebox_runner_snp/src/main.rs
@@ -26,9 +26,8 @@ impl log::Log for HostLogger {
     }
 
     fn log(&self, record: &log::Record) {
-        use core::fmt::Write;
         let mut buf: arrayvec::ArrayString<1024> = arrayvec::ArrayString::new();
-        let _ = writeln!(buf, "[{}] {}", record.level(), record.args());
+        let _ = litebox_util_log::format_record(&mut buf, record);
         ghcb_prints(&buf);
     }
 

--- a/litebox_util_log/src/backend_log.rs
+++ b/litebox_util_log/src/backend_log.rs
@@ -27,32 +27,6 @@ impl crate::Level {
     }
 }
 
-struct FieldVisitor<'a, W>(&'a mut W);
-
-impl<W: core::fmt::Write> log::kv::VisitSource<'_> for FieldVisitor<'_, W> {
-    fn visit_pair(
-        &mut self,
-        key: log::kv::Key<'_>,
-        value: log::kv::Value<'_>,
-    ) -> Result<(), log::kv::Error> {
-        write!(self.0, " {key}={value}")?;
-        Ok(())
-    }
-}
-
-/// Converts a [`log::Record`] into the compact host-console format.
-pub fn format_record<W: core::fmt::Write>(
-    writer: &mut W,
-    record: &log::Record<'_>,
-) -> core::fmt::Result {
-    write!(writer, "[{}] {}", record.level(), record.args())?;
-    record
-        .key_values()
-        .visit(&mut FieldVisitor(writer))
-        .map_err(|_| core::fmt::Error)?;
-    writeln!(writer)
-}
-
 /// RAII guard that logs span exit when dropped.
 ///
 /// This type is returned by span macros (e.g., [`info_span!`](crate::info_span)) when

--- a/litebox_util_log/src/backend_log.rs
+++ b/litebox_util_log/src/backend_log.rs
@@ -27,6 +27,32 @@ impl crate::Level {
     }
 }
 
+struct FieldVisitor<'a, W>(&'a mut W);
+
+impl<W: core::fmt::Write> log::kv::VisitSource<'_> for FieldVisitor<'_, W> {
+    fn visit_pair(
+        &mut self,
+        key: log::kv::Key<'_>,
+        value: log::kv::Value<'_>,
+    ) -> Result<(), log::kv::Error> {
+        write!(self.0, " {key}={value}")?;
+        Ok(())
+    }
+}
+
+/// Converts a [`log::Record`] into the compact host-console format.
+pub fn format_record<W: core::fmt::Write>(
+    writer: &mut W,
+    record: &log::Record<'_>,
+) -> core::fmt::Result {
+    write!(writer, "[{}] {}", record.level(), record.args())?;
+    record
+        .key_values()
+        .visit(&mut FieldVisitor(writer))
+        .map_err(|_| core::fmt::Error)?;
+    writeln!(writer)
+}
+
 /// RAII guard that logs span exit when dropped.
 ///
 /// This type is returned by span macros (e.g., [`info_span!`](crate::info_span)) when

--- a/litebox_util_log/src/lib.rs
+++ b/litebox_util_log/src/lib.rs
@@ -93,11 +93,38 @@ pub enum Level {
 
 #[cfg(all(feature = "backend_log", not(feature = "backend_tracing")))]
 pub use backend_log::SpanGuard;
-#[cfg(all(feature = "backend_log", not(feature = "backend_tracing")))]
-pub use backend_log::format_record;
 
 #[cfg(feature = "backend_tracing")]
 pub use backend_tracing::SpanGuard;
+
+/// Converts a [`log::Record`] into the compact host-console format.
+///
+/// Formats the record as `[LEVEL] message key=value ...\n` into `writer`.
+#[cfg(feature = "backend_log")]
+pub fn format_record<W: core::fmt::Write>(
+    writer: &mut W,
+    record: &log::Record<'_>,
+) -> core::fmt::Result {
+    struct FieldVisitor<'a, W>(&'a mut W);
+
+    impl<W: core::fmt::Write> log::kv::VisitSource<'_> for FieldVisitor<'_, W> {
+        fn visit_pair(
+            &mut self,
+            key: log::kv::Key<'_>,
+            value: log::kv::Value<'_>,
+        ) -> Result<(), log::kv::Error> {
+            write!(self.0, " {key}={value}")?;
+            Ok(())
+        }
+    }
+
+    write!(writer, "[{}] {}", record.level(), record.args())?;
+    record
+        .key_values()
+        .visit(&mut FieldVisitor(writer))
+        .map_err(|_| core::fmt::Error)?;
+    writeln!(writer)
+}
 
 /// Internal module exposing backend types for use by exported macros.
 ///

--- a/litebox_util_log/src/lib.rs
+++ b/litebox_util_log/src/lib.rs
@@ -93,6 +93,8 @@ pub enum Level {
 
 #[cfg(all(feature = "backend_log", not(feature = "backend_tracing")))]
 pub use backend_log::SpanGuard;
+#[cfg(all(feature = "backend_log", not(feature = "backend_tracing")))]
+pub use backend_log::format_record;
 
 #[cfg(feature = "backend_tracing")]
 pub use backend_tracing::SpanGuard;

--- a/litebox_util_log/tests/facade.rs
+++ b/litebox_util_log/tests/facade.rs
@@ -193,3 +193,18 @@ fn test_instrument() {
     nested();
     TestStruct { value: 7 }.instrumented_method();
 }
+
+#[test]
+fn test_format_record_includes_key_values() {
+    let key_values = [("count", 42), ("name", 7)];
+    let record = log::Record::builder()
+        .level(log::Level::Info)
+        .args(format_args!("hello"))
+        .key_values(&key_values)
+        .build();
+    let mut output = String::new();
+
+    litebox_util_log::format_record(&mut output, &record).unwrap();
+
+    assert_eq!(output, "[INFO] hello count=42 name=7\n");
+}

--- a/litebox_util_log/tests/facade.rs
+++ b/litebox_util_log/tests/facade.rs
@@ -194,6 +194,7 @@ fn test_instrument() {
     TestStruct { value: 7 }.instrumented_method();
 }
 
+#[cfg(all(feature = "backend_log", not(feature = "backend_tracing")))]
 #[test]
 fn test_format_record_includes_key_values() {
     let key_values = [("count", 42), ("name", 7)];

--- a/litebox_util_log/tests/facade.rs
+++ b/litebox_util_log/tests/facade.rs
@@ -194,7 +194,7 @@ fn test_instrument() {
     TestStruct { value: 7 }.instrumented_method();
 }
 
-#[cfg(all(feature = "backend_log", not(feature = "backend_tracing")))]
+#[cfg(feature = "backend_log")]
 #[test]
 fn test_format_record_includes_key_values() {
     let key_values = [("count", 42), ("name", 7)];


### PR DESCRIPTION
This PR implements a simple key-value field visitor for host logging.