### PR TITLE
Clean up LiteBox broker constructors

### DIFF
--- a/litebox/src/broker/error.rs
+++ b/litebox/src/broker/error.rs
@@ -8,7 +8,7 @@ use crate::event::{counter::EventCounterError, polling::TryOpError};
 /// Error returned by the deployment-provided broker control path.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[non_exhaustive]
-pub enum BrokerControlError {
+pub(crate) enum BrokerControlError {
     /// The broker control transport failed.
     Transport,
     /// The broker returned an operation error.

--- a/litebox/src/broker/mod.rs
+++ b/litebox/src/broker/mod.rs
@@ -9,14 +9,14 @@ use litebox_broker_protocol::{CoreRequest, CoreResponse, LocalControlChannel};
 use crate::sync::{Mutex, RawSyncPrimitivesProvider};
 
 pub(crate) mod error;
-pub use error::BrokerControlError;
+use error::BrokerControlError;
 
 /// Local-core access to the negotiated broker control channel.
 ///
 /// LiteBox owns broker-backed local objects and constructs broker protocol
 /// requests. Deployment code owns endpoint selection and supplies the connected
 /// transport behind this protocol-level boundary.
-pub trait BrokerControl: Send + Sync {
+pub(crate) trait BrokerControl: Send + Sync {
     /// Sends one active BrokerCore request and returns its response.
     fn request(
         &self,

--- a/litebox/src/lib.rs
+++ b/litebox/src/lib.rs
@@ -41,4 +41,3 @@ mod utilities;
 pub mod utils;
 
 mod broker;
-pub use broker::{BrokerControl, BrokerControlError};

--- a/litebox/src/litebox.rs
+++ b/litebox/src/litebox.rs
@@ -9,7 +9,7 @@ use litebox_broker_local::BrokerLocal;
 use litebox_broker_protocol::LocalControlChannel;
 
 use crate::{
-    broker::{self, BrokerControl, BrokerState},
+    broker::{self, BrokerState},
     fd::Descriptors,
     sync::{RawSyncPrimitivesProvider, RwLock},
 };
@@ -37,14 +37,6 @@ impl<Platform: RawSyncPrimitivesProvider> LiteBox<Platform> {
         Self::new_inner(platform, None)
     }
 
-    /// Create a new [`LiteBox`] instance with broker control installed.
-    pub fn new_with_broker_control(
-        platform: &'static Platform,
-        broker_control: Arc<dyn BrokerControl>,
-    ) -> Self {
-        Self::new_inner(platform, Some(broker_control))
-    }
-
     /// Create a new [`LiteBox`] instance with a negotiated broker-local control adapter installed.
     pub fn new_with_broker_local<T>(
         platform: &'static Platform,
@@ -63,7 +55,7 @@ impl<Platform: RawSyncPrimitivesProvider> LiteBox<Platform> {
 
     fn new_inner(
         platform: &'static Platform,
-        broker_control: Option<Arc<dyn BrokerControl>>,
+        broker_control: Option<Arc<dyn broker::BrokerControl>>,
     ) -> Self {
         // This check ensures that there is exactly one `LiteBox` instance in the process.
         //
@@ -144,7 +136,7 @@ impl<Platform: RawSyncPrimitivesProvider> LiteBox<Platform> {
         self.x.descriptors.write()
     }
 
-    pub(crate) fn broker_control(&self) -> Option<Arc<dyn BrokerControl>> {
+    pub(crate) fn broker_control(&self) -> Option<Arc<dyn broker::BrokerControl>> {
         self.x.broker.control()
     }
 }


### PR DESCRIPTION
Remove the unused broker-control constructor from LiteBox and keep broker-control plumbing internal to the local core.
