### PR TITLE
Use thiserror for broker errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1483,6 +1483,7 @@ dependencies = [
  "bitflags 2.11.0",
  "litebox_broker_protocol",
  "slotmap",
+ "thiserror",
 ]
 
 [[package]]
@@ -1491,6 +1492,7 @@ version = "0.1.0"
 dependencies = [
  "litebox_broker_core",
  "litebox_broker_protocol",
+ "thiserror",
 ]
 
 [[package]]
@@ -1498,11 +1500,15 @@ name = "litebox_broker_local"
 version = "0.1.0"
 dependencies = [
  "litebox_broker_protocol",
+ "thiserror",
 ]
 
 [[package]]
 name = "litebox_broker_protocol"
 version = "0.1.0"
+dependencies = [
+ "thiserror",
+]
 
 [[package]]
 name = "litebox_broker_transport"

--- a/litebox/src/broker/error.rs
+++ b/litebox/src/broker/error.rs
@@ -2,18 +2,19 @@
 // Licensed under the MIT license.
 
 use litebox_broker_protocol::ErrorCode;
+use thiserror::Error;
 
 use crate::event::{counter::EventCounterError, polling::TryOpError};
 
 /// Error returned by the deployment-provided broker control path.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
 #[non_exhaustive]
 pub(crate) enum BrokerControlError {
-    /// The broker control transport failed.
+    #[error("broker control transport failed")]
     Transport,
-    /// The broker returned an operation error.
-    Broker(ErrorCode),
-    /// The broker returned a response shape that does not match the request.
+    #[error("broker returned operation error: {0}")]
+    Broker(#[source] ErrorCode),
+    #[error("broker returned unexpected response")]
     UnexpectedResponse,
 }
 
@@ -21,19 +22,19 @@ pub(crate) enum BrokerControlError {
 ///
 /// This keeps protocol/control-channel failures separate from the public
 /// object-specific API error exposed by each local-core facade.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
 pub(crate) enum BrokerObjectError {
-    /// The deployment-provided broker control path failed.
+    #[error("broker control failed")]
     Control,
-    /// The broker rejected the cached object handle, type, or rights.
+    #[error("invalid broker object")]
     InvalidObject,
-    /// The object operation would block in its current broker-side state.
+    #[error("broker object operation would block")]
     WouldBlock,
-    /// The object or broker-side state cannot grow further.
+    #[error("broker object resource exhausted")]
     ResourceExhausted,
-    /// The broker returned a response shape that does not match the request.
+    #[error("broker returned unexpected response")]
     UnexpectedResponse,
-    /// The broker reported a non-recoverable or unsupported object error.
+    #[error("internal broker object error")]
     Internal,
 }
 

--- a/litebox/src/event/counter.rs
+++ b/litebox/src/event/counter.rs
@@ -9,6 +9,7 @@ use litebox_broker_protocol::{
     CreateEventRequest, EventRequest, EventResponse, ObjectHandle, ReadinessState,
     WaitEventRequest, WaitOutcome,
 };
+use thiserror::Error;
 
 use crate::{
     LiteBox,
@@ -25,20 +26,20 @@ use crate::{
 };
 
 /// Errors returned by local-core event counters.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum EventCounterError {
-    /// The requested operation is invalid for this event counter.
+    #[error("invalid event counter input")]
     InvalidInput,
-    /// The operation would block.
+    #[error("event counter operation would block")]
     WouldBlock,
-    /// The event counter cannot accept more state.
+    #[error("event counter resource exhausted")]
     ResourceExhausted,
-    /// The backing authority or transport failed.
+    #[error("event counter I/O failed")]
     Io,
-    /// The backing authority returned a response shape that does not match the request.
+    #[error("event counter received unexpected response")]
     UnexpectedResponse,
-    /// No backing authority is available for this event counter.
+    #[error("event counter backing authority unavailable")]
     Unavailable,
 }
 

--- a/litebox_broker_core/Cargo.toml
+++ b/litebox_broker_core/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 bitflags = { version = "2.9.0", default-features = false }
 litebox_broker_protocol = { path = "../litebox_broker_protocol", version = "0.1.0" }
 slotmap = { version = "1.1.1", default-features = false }
+thiserror = { version = "2.0.6", default-features = false }
 
 [lints]
 workspace = true

--- a/litebox_broker_core/src/error.rs
+++ b/litebox_broker_core/src/error.rs
@@ -1,40 +1,24 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-use core::fmt;
+use thiserror::Error;
 
 /// Broker authority error category.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, Error, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum BrokerError {
-    /// Policy denied the operation.
+    #[error("broker policy denied the operation")]
     PolicyDenied,
-    /// The referenced object does not exist.
+    #[error("unknown broker object")]
     UnknownObject,
-    /// The caller lacks the required broker rights.
+    #[error("invalid broker rights")]
     InvalidRights,
-    /// Broker-side resource exhaustion.
+    #[error("broker resource exhausted")]
     ResourceExhausted,
-    /// A broker core has already been created in this process.
+    #[error("broker core already exists")]
     BrokerCoreAlreadyExists,
-    /// The operation would block in the current object state.
+    #[error("broker operation would block")]
     WouldBlock,
-    /// The operation is not implemented by this BrokerCore.
+    #[error("unsupported broker operation")]
     UnsupportedOperation,
 }
-
-impl fmt::Display for BrokerError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::PolicyDenied => f.write_str("broker policy denied the operation"),
-            Self::UnknownObject => f.write_str("unknown broker object"),
-            Self::InvalidRights => f.write_str("invalid broker rights"),
-            Self::ResourceExhausted => f.write_str("broker resource exhausted"),
-            Self::BrokerCoreAlreadyExists => f.write_str("broker core already exists"),
-            Self::WouldBlock => f.write_str("broker operation would block"),
-            Self::UnsupportedOperation => f.write_str("unsupported broker operation"),
-        }
-    }
-}
-
-impl core::error::Error for BrokerError {}

--- a/litebox_broker_host/Cargo.toml
+++ b/litebox_broker_host/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 litebox_broker_core = { path = "../litebox_broker_core", version = "0.1.0" }
 litebox_broker_protocol = { path = "../litebox_broker_protocol", version = "0.1.0" }
+thiserror = { version = "2.0.6", default-features = false }
 
 [lints]
 workspace = true

--- a/litebox_broker_host/src/error.rs
+++ b/litebox_broker_host/src/error.rs
@@ -1,37 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-use core::fmt;
+use thiserror::Error;
 
 /// Errors returned by a broker-host receive/send loop.
-#[derive(Debug)]
+#[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum BrokerHostError<E> {
-    /// The host could not authenticate the peer or allocate broker association state.
+    #[error("broker association setup failed")]
     AssociationSetup,
-    /// The concrete channel failed.
-    Channel(E),
-}
-
-impl<E: fmt::Display> fmt::Display for BrokerHostError<E> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::AssociationSetup => f.write_str("broker association setup failed"),
-            Self::Channel(error) => write!(f, "broker channel failed: {error}"),
-        }
-    }
-}
-
-impl<E> core::error::Error for BrokerHostError<E>
-where
-    E: core::error::Error + 'static,
-{
-    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
-        match self {
-            Self::AssociationSetup => None,
-            Self::Channel(error) => Some(error),
-        }
-    }
+    #[error("broker channel failed: {0}")]
+    Channel(#[source] E),
 }
 
 /// Broker-host receive/send loop result type.

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -382,10 +382,10 @@ mod tests {
                 protocol_version: HOST_PROTOCOL_VERSION,
             }),
         ))]));
-        channel.send_error = Some(FakeChannelError::Send);
+        channel.send_error = true;
 
         match serve_connection(core, &mut channel) {
-            Err(BrokerHostError::Channel(FakeChannelError::Send)) => {}
+            Err(BrokerHostError::Channel(())) => {}
             result => panic!("unexpected serve result: {result:?}"),
         }
         assert!(channel.responses.is_empty());
@@ -399,44 +399,26 @@ mod tests {
         event_request(EventRequest::Create(CreateEventRequest::new(initial_count)))
     }
 
-    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-    enum FakeChannelError {
-        Send,
-    }
-
-    impl fmt::Display for FakeChannelError {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            match self {
-                Self::Send => f.write_str("fake send error"),
-            }
-        }
-    }
-
-    impl core::error::Error for FakeChannelError {}
-
     struct FakeHostControlChannel {
-        requests:
-            std::vec::Vec<core::result::Result<Option<ReceivedBrokerRequest>, FakeChannelError>>,
+        requests: std::vec::Vec<core::result::Result<Option<ReceivedBrokerRequest>, ()>>,
         responses: std::vec::Vec<BrokerResponse>,
-        send_error: Option<FakeChannelError>,
+        send_error: bool,
     }
 
     impl FakeHostControlChannel {
         fn new(
-            requests: std::vec::Vec<
-                core::result::Result<Option<ReceivedBrokerRequest>, FakeChannelError>,
-            >,
+            requests: std::vec::Vec<core::result::Result<Option<ReceivedBrokerRequest>, ()>>,
         ) -> Self {
             Self {
                 requests,
                 responses: std::vec::Vec::new(),
-                send_error: None,
+                send_error: false,
             }
         }
     }
 
     impl HostControlChannel for FakeHostControlChannel {
-        type Error = FakeChannelError;
+        type Error = ();
 
         fn peer_credential(&self) -> core::result::Result<PeerCredential, Self::Error> {
             Ok(PeerCredential::Unauthenticated)
@@ -456,8 +438,8 @@ mod tests {
             &mut self,
             response: &BrokerResponse,
         ) -> core::result::Result<(), Self::Error> {
-            if let Some(error) = self.send_error {
-                return Err(error);
+            if self.send_error {
+                return Err(());
             }
             self.responses.push(response.clone());
             Ok(())

--- a/litebox_broker_local/Cargo.toml
+++ b/litebox_broker_local/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 litebox_broker_protocol = { path = "../litebox_broker_protocol", version = "0.1.0" }
+thiserror = { version = "2.0.6", default-features = false }
 
 [lints]
 workspace = true

--- a/litebox_broker_local/src/error.rs
+++ b/litebox_broker_local/src/error.rs
@@ -1,126 +1,63 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-use core::fmt;
-
 use litebox_broker_protocol::{BrokerResponse, ErrorCode, ProtocolVersion};
+use thiserror::Error;
 
 /// Errors returned by the broker-local control adapter.
-#[derive(Debug)]
+#[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum BrokerLocalError<E> {
-    /// The control channel failed.
-    Channel(E),
-    /// An operation requiring an active broker session was called before negotiation.
+    #[error("broker channel failed: {0}")]
+    Channel(#[source] E),
+    #[error("broker local adapter has not negotiated protocol version")]
     NotNegotiated,
-    /// Negotiation was requested after the local adapter was already active.
+    #[error("broker local adapter already negotiated")]
     AlreadyNegotiated,
-    /// The broker closed the channel before returning a response.
+    #[error("broker closed the channel")]
     ChannelClosed,
-    /// The broker returned a response this local adapter does not understand.
+    #[error("unknown broker response")]
     UnknownResponse,
-    /// The broker accepted negotiation with a version that cannot serve the request.
+    #[error(
+        "broker accepted incompatible protocol negotiation: requested {requested:?}, broker supports {broker_protocol_version:?}"
+    )]
     IncompatibleNegotiation {
         /// Protocol version requested by this local adapter.
         requested: ProtocolVersion,
         /// Protocol version advertised by the broker.
         broker_protocol_version: ProtocolVersion,
     },
-    /// This local adapter cannot speak the requested protocol version.
+    #[error(
+        "broker local adapter cannot request protocol version {requested:?}; local adapter supports {local_protocol_version:?}"
+    )]
     UnsupportedLocalVersion {
         /// Protocol version requested by the caller.
         requested: ProtocolVersion,
         /// Protocol version supported by this local implementation.
         local_protocol_version: ProtocolVersion,
     },
-    /// The active broker session cannot serve an operation requiring a newer version.
+    #[error(
+        "broker session protocol version {negotiated_protocol_version:?} does not support required version {required:?}"
+    )]
     UnsupportedNegotiatedVersion {
         /// Protocol version required by the operation.
         required: ProtocolVersion,
         /// Effective protocol version negotiated for this connection.
         negotiated_protocol_version: ProtocolVersion,
     },
-    /// The broker does not support the requested protocol version.
+    #[error(
+        "broker does not support requested protocol version {requested:?}; broker supports {broker_protocol_version:?}"
+    )]
     UnsupportedVersion {
         /// Protocol version requested by this local adapter.
         requested: ProtocolVersion,
         /// Protocol version advertised by the broker.
         broker_protocol_version: ProtocolVersion,
     },
-    /// The broker rejected the request.
-    Broker(ErrorCode),
-    /// The broker returned a response type that does not match the request.
+    #[error("broker rejected request: {0}")]
+    Broker(#[source] ErrorCode),
+    #[error("broker returned unexpected response: {0:?}")]
     UnexpectedResponse(BrokerResponse),
-}
-
-impl<E: fmt::Display> fmt::Display for BrokerLocalError<E> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Channel(error) => write!(f, "broker channel failed: {error}"),
-            Self::NotNegotiated => {
-                write!(
-                    f,
-                    "broker local adapter has not negotiated protocol version"
-                )
-            }
-            Self::AlreadyNegotiated => f.write_str("broker local adapter already negotiated"),
-            Self::ChannelClosed => write!(f, "broker closed the channel"),
-            Self::UnknownResponse => f.write_str("unknown broker response"),
-            Self::IncompatibleNegotiation {
-                requested,
-                broker_protocol_version,
-            } => write!(
-                f,
-                "broker accepted incompatible protocol negotiation: requested {requested:?}, broker supports {broker_protocol_version:?}"
-            ),
-            Self::UnsupportedLocalVersion {
-                requested,
-                local_protocol_version,
-            } => write!(
-                f,
-                "broker local adapter cannot request protocol version {requested:?}; local adapter supports {local_protocol_version:?}"
-            ),
-            Self::UnsupportedNegotiatedVersion {
-                required,
-                negotiated_protocol_version,
-            } => write!(
-                f,
-                "broker session protocol version {negotiated_protocol_version:?} does not support required version {required:?}"
-            ),
-            Self::UnsupportedVersion {
-                requested,
-                broker_protocol_version,
-            } => write!(
-                f,
-                "broker does not support requested protocol version {requested:?}; broker supports {broker_protocol_version:?}"
-            ),
-            Self::Broker(error) => write!(f, "broker rejected request: {error}"),
-            Self::UnexpectedResponse(response) => {
-                write!(f, "broker returned unexpected response: {response:?}")
-            }
-        }
-    }
-}
-
-impl<E> core::error::Error for BrokerLocalError<E>
-where
-    E: core::error::Error + 'static,
-{
-    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
-        match self {
-            Self::Channel(error) => Some(error),
-            Self::Broker(error) => Some(error),
-            Self::NotNegotiated
-            | Self::AlreadyNegotiated
-            | Self::ChannelClosed
-            | Self::UnknownResponse
-            | Self::IncompatibleNegotiation { .. }
-            | Self::UnsupportedLocalVersion { .. }
-            | Self::UnsupportedNegotiatedVersion { .. }
-            | Self::UnsupportedVersion { .. }
-            | Self::UnexpectedResponse(_) => None,
-        }
-    }
 }
 
 /// Broker-local control adapter result type.

--- a/litebox_broker_protocol/Cargo.toml
+++ b/litebox_broker_protocol/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+thiserror = { version = "2.0.6", default-features = false }
 
 [lints]
 workspace = true

--- a/litebox_broker_protocol/src/error.rs
+++ b/litebox_broker_protocol/src/error.rs
@@ -1,36 +1,37 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-use core::fmt;
+use thiserror::Error;
 
 /// ABI-neutral broker error category.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, Error, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum ErrorCode {
-    /// The requested protocol version is unsupported.
+    #[error("unsupported broker protocol version")]
     UnsupportedVersion,
-    /// The request is structurally invalid.
+    #[error("malformed broker request")]
     MalformedRequest,
-    /// The request is validly encoded but violates the connection state machine.
+    #[error("broker protocol state violation")]
     ProtocolState,
-    /// The request is unsupported by this broker protocol implementation.
+    #[error("unsupported broker operation")]
     UnsupportedOperation,
-    /// Broker hit an internal condition or an error category this protocol cannot represent.
+    #[error("internal broker error")]
     Internal,
-    /// Policy denied the operation.
+    #[error("broker policy denied the operation")]
     PolicyDenied,
-    /// The referenced object does not exist.
+    #[error("unknown broker object")]
     UnknownObject,
-    /// The caller lacks the required broker rights.
+    #[error("invalid broker rights")]
     InvalidRights,
-    /// Broker-side resource exhaustion.
+    #[error("broker resource exhausted")]
     ResourceExhausted,
-    /// The operation would block in the current event state.
+    #[error("broker operation would block")]
     WouldBlock,
     /// Error code emitted by a newer broker and not understood by this local peer.
     ///
     /// This variant is reserved for raw codes not assigned by this protocol
     /// version.
+    #[error("unknown broker error code {0}")]
     Unknown(u16),
 }
 
@@ -75,23 +76,3 @@ impl ErrorCode {
         }
     }
 }
-
-impl fmt::Display for ErrorCode {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::UnsupportedVersion => f.write_str("unsupported broker protocol version"),
-            Self::MalformedRequest => f.write_str("malformed broker request"),
-            Self::ProtocolState => f.write_str("broker protocol state violation"),
-            Self::UnsupportedOperation => f.write_str("unsupported broker operation"),
-            Self::Internal => f.write_str("internal broker error"),
-            Self::PolicyDenied => f.write_str("broker policy denied the operation"),
-            Self::UnknownObject => f.write_str("unknown broker object"),
-            Self::InvalidRights => f.write_str("invalid broker rights"),
-            Self::ResourceExhausted => f.write_str("broker resource exhausted"),
-            Self::WouldBlock => f.write_str("broker operation would block"),
-            Self::Unknown(raw) => write!(f, "unknown broker error code {raw}"),
-        }
-    }
-}
-
-impl core::error::Error for ErrorCode {}

--- a/litebox_broker_protocol/src/wire.rs
+++ b/litebox_broker_protocol/src/wire.rs
@@ -16,9 +16,8 @@
 //! changing fields is an ABI change, so prefer a new operation tag or explicit
 //! negotiated-version gate for payload evolution.
 
-use core::fmt;
-
 use alloc::vec::Vec;
+use thiserror::Error;
 
 use crate::{
     BrokerRequest, BrokerResponse, ErrorCode, ReceivedBrokerRequest, ReceivedBrokerResponse,
@@ -39,31 +38,18 @@ const RESPONSE_TAG_ERROR: u8 = 2;
 const RESPONSE_TAG_VERSION_MISMATCH: u8 = 3;
 
 /// Error produced while encoding or decoding a broker wire message.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum WireError {
-    /// The frame ended before a complete field could be decoded.
+    #[error("truncated broker wire frame")]
     TruncatedFrame,
-    /// The frame contained bytes after the decoded message.
+    #[error("trailing broker wire bytes")]
     TrailingBytes,
-    /// A boolean field was not encoded as 0 or 1.
+    #[error("invalid broker wire boolean")]
     InvalidBoolean,
-    /// A decoder offset overflowed.
+    #[error("broker wire offset overflow")]
     OffsetOverflow,
 }
-
-impl fmt::Display for WireError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::TruncatedFrame => f.write_str("truncated broker wire frame"),
-            Self::TrailingBytes => f.write_str("trailing broker wire bytes"),
-            Self::InvalidBoolean => f.write_str("invalid broker wire boolean"),
-            Self::OffsetOverflow => f.write_str("broker wire offset overflow"),
-        }
-    }
-}
-
-impl core::error::Error for WireError {}
 
 /// Encodes a broker request body.
 ///


### PR DESCRIPTION
This PR converts the broker error enums to use thiserror-derived Display/Error implementations.