### PR TITLE
Fix OP-TEE TA reentry stack alignment

### DIFF
--- a/litebox_shim_optee/src/loader/ta_stack.rs
+++ b/litebox_shim_optee/src/loader/ta_stack.rs
@@ -264,9 +264,14 @@ impl TaStack {
         <Platform as litebox::platform::CrngProvider>::fill_bytes_crng(platform, &mut canary);
         self.push_bytes(&canary)?;
 
-        // ensure stack is aligned
+        // `reenter_thread` *jumps* into the TA entry point (which is a function) rather than
+        // calls it. Adjust the stack pointer to ensure post-call stack alignment.
         self.pos = align_down(self.pos, Self::STACK_ALIGNMENT);
-        assert_eq!(self.pos, align_down(self.pos, Self::STACK_ALIGNMENT));
+        self.pos = self.pos.checked_sub(core::mem::size_of::<usize>())?;
+        assert_eq!(
+            self.pos % Self::STACK_ALIGNMENT,
+            core::mem::size_of::<usize>()
+        );
         Some(())
     }
 


### PR DESCRIPTION
This PR fixes OP-TEE TA's stack alignment for reentry (`reenter_thread`). In particular, `reenter_thread` uses `jmp` to enter the TA entry point function (`__ta_entry`) which is a normal function and thus suffers a function stack alignment issue.