### PR TITLE
Remove unknown broker message envelopes

### DIFF
--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -18,7 +18,7 @@ use litebox_broker_core::{BrokerCore, BrokerError, BrokerSession, CallerCredenti
 use litebox_broker_protocol::{
     AddEventResponse, BROKER_PROTOCOL_VERSION, BrokerRequest, BrokerResponse, CoreRequest,
     CoreResponse, CreateEventResponse, ErrorCode, EventRequest, EventResponse, HostControlChannel,
-    PeerCredential, ReceivedBrokerRequest, WaitEventResponse,
+    PeerCredential, WaitEventResponse,
 };
 
 mod error;
@@ -54,11 +54,11 @@ where
 {
     let mut state = ConnectionState::AwaitingNegotiation;
     loop {
-        let Some(received) = channel.recv_request().map_err(BrokerHostError::Channel)? else {
+        let Some(request) = channel.recv_request().map_err(BrokerHostError::Channel)? else {
             break;
         };
 
-        let dispatch = handle_received_request(session, &mut state, received);
+        let dispatch = handle_request(session, &mut state, request);
         channel
             .send_response(&dispatch.response)
             .map_err(BrokerHostError::Channel)?;
@@ -77,17 +77,6 @@ fn caller_credential_from_peer(
         Ok(CallerCredential::Unauthenticated)
     } else {
         Err(())
-    }
-}
-
-fn handle_received_request(
-    session: &BrokerSession,
-    state: &mut ConnectionState,
-    received: ReceivedBrokerRequest,
-) -> BrokerDispatch {
-    match received {
-        ReceivedBrokerRequest::Request(request) => handle_request(session, state, request),
-        _ => handle_unknown_request(*state),
     }
 }
 
@@ -170,17 +159,6 @@ fn handle_event_request(session: &BrokerSession, request: EventRequest) -> Broke
             },
         ),
         _ => BrokerResponse::Error(ErrorCode::UnsupportedOperation),
-    }
-}
-
-fn handle_unknown_request(state: ConnectionState) -> BrokerDispatch {
-    if state == ConnectionState::AwaitingNegotiation {
-        BrokerDispatch::close_after(
-            BrokerResponse::Error(ErrorCode::ProtocolState),
-            CloseReason::ProtocolViolation,
-        )
-    } else {
-        BrokerDispatch::continue_after(BrokerResponse::Error(ErrorCode::UnsupportedOperation))
     }
 }
 
@@ -286,14 +264,10 @@ mod tests {
 
     fn serve_connection_negotiates_routes_one_request_and_returns_peer_closed(broker: &BrokerCore) {
         let mut channel = FakeHostControlChannel::new(std::vec::Vec::from([
-            Ok(Some(ReceivedBrokerRequest::Request(
-                BrokerRequest::Negotiate {
-                    protocol_version: BROKER_PROTOCOL_VERSION,
-                },
-            ))),
-            Ok(Some(ReceivedBrokerRequest::Request(event_create_request(
-                0,
-            )))),
+            Ok(Some(BrokerRequest::Negotiate {
+                protocol_version: BROKER_PROTOCOL_VERSION,
+            })),
+            Ok(Some(event_create_request(0))),
             Ok(None),
         ]));
 
@@ -318,14 +292,10 @@ mod tests {
 
     fn serve_connection_closes_after_protocol_violation(broker: &BrokerCore) {
         let mut channel = FakeHostControlChannel::new(std::vec::Vec::from([
-            Ok(Some(ReceivedBrokerRequest::Request(event_create_request(
-                0,
-            )))),
-            Ok(Some(ReceivedBrokerRequest::Request(
-                BrokerRequest::Negotiate {
-                    protocol_version: BROKER_PROTOCOL_VERSION,
-                },
-            ))),
+            Ok(Some(event_create_request(0))),
+            Ok(Some(BrokerRequest::Negotiate {
+                protocol_version: BROKER_PROTOCOL_VERSION,
+            })),
         ]));
 
         assert_eq!(
@@ -341,9 +311,9 @@ mod tests {
 
     fn serve_connection_returns_channel_error_when_response_send_fails(broker: &BrokerCore) {
         let mut channel = FakeHostControlChannel::new(std::vec::Vec::from([Ok(Some(
-            ReceivedBrokerRequest::Request(BrokerRequest::Negotiate {
+            BrokerRequest::Negotiate {
                 protocol_version: BROKER_PROTOCOL_VERSION,
-            }),
+            },
         ))]));
         channel.send_error = true;
 
@@ -363,15 +333,13 @@ mod tests {
     }
 
     struct FakeHostControlChannel {
-        requests: std::vec::Vec<core::result::Result<Option<ReceivedBrokerRequest>, ()>>,
+        requests: std::vec::Vec<core::result::Result<Option<BrokerRequest>, ()>>,
         responses: std::vec::Vec<BrokerResponse>,
         send_error: bool,
     }
 
     impl FakeHostControlChannel {
-        fn new(
-            requests: std::vec::Vec<core::result::Result<Option<ReceivedBrokerRequest>, ()>>,
-        ) -> Self {
+        fn new(requests: std::vec::Vec<core::result::Result<Option<BrokerRequest>, ()>>) -> Self {
             Self {
                 requests,
                 responses: std::vec::Vec::new(),
@@ -387,9 +355,7 @@ mod tests {
             Ok(PeerCredential::Unauthenticated)
         }
 
-        fn recv_request(
-            &mut self,
-        ) -> core::result::Result<Option<ReceivedBrokerRequest>, Self::Error> {
+        fn recv_request(&mut self) -> core::result::Result<Option<BrokerRequest>, Self::Error> {
             if self.requests.is_empty() {
                 Ok(None)
             } else {

--- a/litebox_broker_local/src/error.rs
+++ b/litebox_broker_local/src/error.rs
@@ -16,8 +16,6 @@ pub enum BrokerLocalError<E> {
     AlreadyNegotiated,
     #[error("broker closed the channel")]
     ChannelClosed,
-    #[error("unknown broker response")]
-    UnknownResponse,
     #[error(
         "broker accepted incompatible protocol negotiation: requested {requested:?}, broker supports {broker_protocol_version:?}"
     )]

--- a/litebox_broker_local/src/lib.rs
+++ b/litebox_broker_local/src/lib.rs
@@ -17,7 +17,6 @@ mod event;
 
 use litebox_broker_protocol::{
     BROKER_PROTOCOL_VERSION, BrokerRequest, BrokerResponse, LocalControlChannel,
-    ReceivedBrokerResponse,
 };
 
 pub use error::{BrokerLocalError, Result};
@@ -105,15 +104,10 @@ impl<T: LocalControlChannel> BrokerLocal<T> {
         self.channel
             .send_request(&request)
             .map_err(BrokerLocalError::Channel)?;
-        match self
-            .channel
+        self.channel
             .recv_response()
             .map_err(BrokerLocalError::Channel)?
-            .ok_or(BrokerLocalError::ChannelClosed)?
-        {
-            ReceivedBrokerResponse::Response(response) => Ok(response),
-            _ => Err(BrokerLocalError::UnknownResponse),
-        }
+            .ok_or(BrokerLocalError::ChannelClosed)
     }
 }
 
@@ -247,10 +241,8 @@ mod tests {
             Ok(())
         }
 
-        fn recv_response(
-            &mut self,
-        ) -> core::result::Result<Option<ReceivedBrokerResponse>, Self::Error> {
-            Ok(self.response.take().map(ReceivedBrokerResponse::Response))
+        fn recv_response(&mut self) -> core::result::Result<Option<BrokerResponse>, Self::Error> {
+            Ok(self.response.take())
         }
     }
 }

--- a/litebox_broker_protocol/src/channel.rs
+++ b/litebox_broker_protocol/src/channel.rs
@@ -20,38 +20,6 @@ pub enum PeerCredential {
     Unauthenticated,
 }
 
-/// Broker authority request received from a control channel.
-#[derive(Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
-pub enum ReceivedBrokerRequest {
-    /// A request understood by the current protocol crate.
-    Request(BrokerRequest),
-    /// A request emitted by a newer peer and not understood by this process.
-    Unknown,
-}
-
-impl From<BrokerRequest> for ReceivedBrokerRequest {
-    fn from(request: BrokerRequest) -> Self {
-        Self::Request(request)
-    }
-}
-
-/// Broker authority response received from a control channel.
-#[derive(Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
-pub enum ReceivedBrokerResponse {
-    /// A response understood by the current protocol crate.
-    Response(BrokerResponse),
-    /// A response emitted by a newer broker and not understood by this process.
-    Unknown,
-}
-
-impl From<BrokerResponse> for ReceivedBrokerResponse {
-    fn from(response: BrokerResponse) -> Self {
-        Self::Response(response)
-    }
-}
-
 /// Local-side control channel for broker authority calls.
 pub trait LocalControlChannel {
     /// Channel-specific error type.
@@ -64,7 +32,7 @@ pub trait LocalControlChannel {
     ///
     /// Returns `Ok(None)` when the broker closed the channel cleanly before
     /// starting another response frame.
-    fn recv_response(&mut self) -> Result<Option<ReceivedBrokerResponse>, Self::Error>;
+    fn recv_response(&mut self) -> Result<Option<BrokerResponse>, Self::Error>;
 }
 
 /// Host-side control channel for broker authority calls.
@@ -79,7 +47,7 @@ pub trait HostControlChannel {
     ///
     /// Returns `Ok(None)` when the peer closed the channel cleanly before
     /// starting another request frame.
-    fn recv_request(&mut self) -> Result<Option<ReceivedBrokerRequest>, Self::Error>;
+    fn recv_request(&mut self) -> Result<Option<BrokerRequest>, Self::Error>;
 
     /// Sends one broker response.
     fn send_response(&mut self, response: &BrokerResponse) -> Result<(), Self::Error>;

--- a/litebox_broker_protocol/src/lib.rs
+++ b/litebox_broker_protocol/src/lib.rs
@@ -18,10 +18,7 @@ pub mod event;
 pub mod message;
 pub mod wire;
 
-pub use channel::{
-    HostControlChannel, LocalControlChannel, PeerCredential, ReceivedBrokerRequest,
-    ReceivedBrokerResponse,
-};
+pub use channel::{HostControlChannel, LocalControlChannel, PeerCredential};
 pub use error::ErrorCode;
 pub use event::{
     AddEventRequest, AddEventResponse, ConsumeEventRequest, ConsumeEventResponse,

--- a/litebox_broker_protocol/src/wire.rs
+++ b/litebox_broker_protocol/src/wire.rs
@@ -19,9 +19,7 @@
 use alloc::vec::Vec;
 use thiserror::Error;
 
-use crate::{
-    BrokerRequest, BrokerResponse, ErrorCode, ReceivedBrokerRequest, ReceivedBrokerResponse,
-};
+use crate::{BrokerRequest, BrokerResponse, ErrorCode};
 
 use primitive::{Decoder, Encoder};
 
@@ -47,6 +45,8 @@ pub enum WireError {
     TrailingBytes,
     #[error("invalid broker wire boolean")]
     InvalidBoolean,
+    #[error("invalid broker wire tag")]
+    InvalidTag,
     #[error("broker wire offset overflow")]
     OffsetOverflow,
 }
@@ -71,21 +71,18 @@ pub fn encode_request(request: BrokerRequest) -> Vec<u8> {
 }
 
 /// Decodes a broker request body.
-pub fn decode_request(frame: &[u8]) -> Result<ReceivedBrokerRequest, WireError> {
+pub fn decode_request(frame: &[u8]) -> Result<BrokerRequest, WireError> {
     let mut decoder = Decoder::new(frame);
     let tag = decoder.u8()?;
     let request = match tag {
         REQUEST_TAG_NEGOTIATE => BrokerRequest::Negotiate {
             protocol_version: decoder.protocol_version()?,
         },
-        REQUEST_TAG_CORE => match core_message::decode_core_request(&mut decoder)? {
-            Some(request) => BrokerRequest::Core(request),
-            None => return Ok(ReceivedBrokerRequest::Unknown),
-        },
-        _ => return Ok(ReceivedBrokerRequest::Unknown),
+        REQUEST_TAG_CORE => BrokerRequest::Core(core_message::decode_core_request(&mut decoder)?),
+        _ => return Err(WireError::InvalidTag),
     };
     decoder.finish()?;
-    Ok(ReceivedBrokerRequest::Request(request))
+    Ok(request)
 }
 
 /// Encodes a broker response body.
@@ -120,7 +117,7 @@ pub fn encode_response(response: BrokerResponse) -> Vec<u8> {
 }
 
 /// Decodes a broker response body.
-pub fn decode_response(frame: &[u8]) -> Result<ReceivedBrokerResponse, WireError> {
+pub fn decode_response(frame: &[u8]) -> Result<BrokerResponse, WireError> {
     let mut decoder = Decoder::new(frame);
     let tag = decoder.u8()?;
     let response = match tag {
@@ -130,18 +127,17 @@ pub fn decode_response(frame: &[u8]) -> Result<ReceivedBrokerResponse, WireError
         RESPONSE_TAG_VERSION_MISMATCH => BrokerResponse::VersionMismatch {
             broker_protocol_version: decoder.protocol_version()?,
         },
-        RESPONSE_TAG_CORE => match core_message::decode_core_response(&mut decoder)? {
-            Some(response) => BrokerResponse::Core(response),
-            None => return Ok(ReceivedBrokerResponse::Unknown),
-        },
+        RESPONSE_TAG_CORE => {
+            BrokerResponse::Core(core_message::decode_core_response(&mut decoder)?)
+        }
         RESPONSE_TAG_ERROR => {
             let error = ErrorCode::from_raw(decoder.u16()?);
             BrokerResponse::Error(error)
         }
-        _ => return Ok(ReceivedBrokerResponse::Unknown),
+        _ => return Err(WireError::InvalidTag),
     };
     decoder.finish()?;
-    Ok(ReceivedBrokerResponse::Response(response))
+    Ok(response)
 }
 
 #[cfg(test)]
@@ -178,7 +174,7 @@ mod tests {
         for request in requests {
             assert_eq!(
                 decode_request(&encode_request(request.clone())).unwrap(),
-                ReceivedBrokerRequest::Request(request)
+                request
             );
         }
     }
@@ -215,24 +211,21 @@ mod tests {
         for response in responses {
             assert_eq!(
                 decode_response(&encode_response(response.clone())).unwrap(),
-                ReceivedBrokerResponse::Response(response)
+                response
             );
         }
     }
 
     #[test]
     fn decode_rejects_malformed_request_frames() {
-        assert_eq!(
-            decode_request(&[0xff, 1, 2, 3]),
-            Ok(ReceivedBrokerRequest::Unknown)
-        );
+        assert_eq!(decode_request(&[0xff, 1, 2, 3]), Err(WireError::InvalidTag));
         let mut unknown_consume_mode = encode_request(event_request(EventRequest::Consume(
             ConsumeEventRequest::new(sample_handle(), EventConsumeMode::All),
         )));
         *unknown_consume_mode.last_mut().unwrap() = 0xff;
         assert_eq!(
             decode_request(&unknown_consume_mode),
-            Ok(ReceivedBrokerRequest::Unknown)
+            Err(WireError::InvalidTag)
         );
         assert_eq!(decode_request(&[0, 1]), Err(WireError::TruncatedFrame));
         let mut frame = encode_request(event_request(EventRequest::Create(
@@ -246,17 +239,15 @@ mod tests {
     fn decode_rejects_malformed_response_frames() {
         assert_eq!(
             decode_response(&[0xff, 1, 2, 3]),
-            Ok(ReceivedBrokerResponse::Unknown)
+            Err(WireError::InvalidTag)
         );
         assert_eq!(
             decode_response(&[1, 0, 1, 0xff]),
-            Ok(ReceivedBrokerResponse::Unknown)
+            Err(WireError::InvalidTag)
         );
         assert_eq!(
             decode_response(&[2, 0xff, 0xff]),
-            Ok(ReceivedBrokerResponse::Response(BrokerResponse::Error(
-                ErrorCode::Unknown(0xffff)
-            )))
+            Ok(BrokerResponse::Error(ErrorCode::Unknown(0xffff)))
         );
 
         let mut invalid_bool = [1, 0, 2, 2, 0];

--- a/litebox_broker_protocol/src/wire/core_message.rs
+++ b/litebox_broker_protocol/src/wire/core_message.rs
@@ -21,18 +21,13 @@ pub(super) fn encode_core_request(encoder: &mut Encoder, request: CoreRequest) {
     }
 }
 
-pub(super) fn decode_core_request(
-    decoder: &mut Decoder<'_>,
-) -> Result<Option<CoreRequest>, WireError> {
+pub(super) fn decode_core_request(decoder: &mut Decoder<'_>) -> Result<CoreRequest, WireError> {
     let request = match decoder.u8()? {
-        CORE_REQUEST_TAG_EVENT => match event::decode_event_request(decoder)? {
-            Some(request) => CoreRequest::Event(request),
-            None => return Ok(None),
-        },
-        _ => return Ok(None),
+        CORE_REQUEST_TAG_EVENT => CoreRequest::Event(event::decode_event_request(decoder)?),
+        _ => return Err(WireError::InvalidTag),
     };
 
-    Ok(Some(request))
+    Ok(request)
 }
 
 pub(super) fn encode_core_response(encoder: &mut Encoder, response: CoreResponse) {
@@ -44,16 +39,11 @@ pub(super) fn encode_core_response(encoder: &mut Encoder, response: CoreResponse
     }
 }
 
-pub(super) fn decode_core_response(
-    decoder: &mut Decoder<'_>,
-) -> Result<Option<CoreResponse>, WireError> {
+pub(super) fn decode_core_response(decoder: &mut Decoder<'_>) -> Result<CoreResponse, WireError> {
     let response = match decoder.u8()? {
-        CORE_RESPONSE_TAG_EVENT => match event::decode_event_response(decoder)? {
-            Some(response) => CoreResponse::Event(response),
-            None => return Ok(None),
-        },
-        _ => return Ok(None),
+        CORE_RESPONSE_TAG_EVENT => CoreResponse::Event(event::decode_event_response(decoder)?),
+        _ => return Err(WireError::InvalidTag),
     };
 
-    Ok(Some(response))
+    Ok(response)
 }

--- a/litebox_broker_protocol/src/wire/event.rs
+++ b/litebox_broker_protocol/src/wire/event.rs
@@ -50,9 +50,7 @@ pub(super) fn encode_event_request(encoder: &mut Encoder, request: EventRequest)
     }
 }
 
-pub(super) fn decode_event_request(
-    decoder: &mut Decoder<'_>,
-) -> Result<Option<EventRequest>, WireError> {
+pub(super) fn decode_event_request(decoder: &mut Decoder<'_>) -> Result<EventRequest, WireError> {
     let request = match decoder.u8()? {
         EVENT_REQUEST_TAG_CREATE => EventRequest::Create(CreateEventRequest::new(decoder.u64()?)),
         EVENT_REQUEST_TAG_WAIT => EventRequest::Wait(WaitEventRequest::new(decoder.handle()?)),
@@ -61,15 +59,12 @@ pub(super) fn decode_event_request(
         }
         EVENT_REQUEST_TAG_CONSUME => EventRequest::Consume(ConsumeEventRequest::new(
             decoder.handle()?,
-            match decode_consume_mode(decoder)? {
-                Some(mode) => mode,
-                None => return Ok(None),
-            },
+            decode_consume_mode(decoder)?,
         )),
-        _ => return Ok(None),
+        _ => return Err(WireError::InvalidTag),
     };
 
-    Ok(Some(request))
+    Ok(request)
 }
 
 pub(super) fn encode_event_response(encoder: &mut Encoder, response: EventResponse) {
@@ -94,19 +89,14 @@ pub(super) fn encode_event_response(encoder: &mut Encoder, response: EventRespon
     }
 }
 
-pub(super) fn decode_event_response(
-    decoder: &mut Decoder<'_>,
-) -> Result<Option<EventResponse>, WireError> {
+pub(super) fn decode_event_response(decoder: &mut Decoder<'_>) -> Result<EventResponse, WireError> {
     let response = match decoder.u8()? {
         EVENT_RESPONSE_TAG_CREATED => {
             EventResponse::Create(CreateEventResponse::new(decoder.handle()?))
         }
-        EVENT_RESPONSE_TAG_WAITED => EventResponse::Wait(WaitEventResponse::new(
-            match decode_wait_outcome(decoder)? {
-                Some(outcome) => outcome,
-                None => return Ok(None),
-            },
-        )),
+        EVENT_RESPONSE_TAG_WAITED => {
+            EventResponse::Wait(WaitEventResponse::new(decode_wait_outcome(decoder)?))
+        }
         EVENT_RESPONSE_TAG_ADDED => {
             EventResponse::Add(AddEventResponse::new(decode_readiness(decoder)?))
         }
@@ -114,10 +104,10 @@ pub(super) fn decode_event_response(
             decoder.u64()?,
             decode_readiness(decoder)?,
         )),
-        _ => return Ok(None),
+        _ => return Err(WireError::InvalidTag),
     };
 
-    Ok(Some(response))
+    Ok(response)
 }
 
 fn encode_wait_outcome(encoder: &mut Encoder, outcome: WaitOutcome) {
@@ -133,13 +123,11 @@ fn encode_wait_outcome(encoder: &mut Encoder, outcome: WaitOutcome) {
     }
 }
 
-fn decode_wait_outcome(decoder: &mut Decoder<'_>) -> Result<Option<WaitOutcome>, WireError> {
+fn decode_wait_outcome(decoder: &mut Decoder<'_>) -> Result<WaitOutcome, WireError> {
     match decoder.u8()? {
-        WAIT_OUTCOME_TAG_READY => Ok(Some(WaitOutcome::Ready(decode_readiness(decoder)?))),
-        WAIT_OUTCOME_TAG_WOULD_BLOCK => {
-            Ok(Some(WaitOutcome::WouldBlock(decode_readiness(decoder)?)))
-        }
-        _ => Ok(None),
+        WAIT_OUTCOME_TAG_READY => Ok(WaitOutcome::Ready(decode_readiness(decoder)?)),
+        WAIT_OUTCOME_TAG_WOULD_BLOCK => Ok(WaitOutcome::WouldBlock(decode_readiness(decoder)?)),
+        _ => Err(WireError::InvalidTag),
     }
 }
 
@@ -163,10 +151,10 @@ fn encode_consume_mode(encoder: &mut Encoder, mode: EventConsumeMode) {
     }
 }
 
-fn decode_consume_mode(decoder: &mut Decoder<'_>) -> Result<Option<EventConsumeMode>, WireError> {
+fn decode_consume_mode(decoder: &mut Decoder<'_>) -> Result<EventConsumeMode, WireError> {
     match decoder.u8()? {
-        EVENT_CONSUME_MODE_TAG_ALL => Ok(Some(EventConsumeMode::All)),
-        EVENT_CONSUME_MODE_TAG_ONE => Ok(Some(EventConsumeMode::One)),
-        _ => Ok(None),
+        EVENT_CONSUME_MODE_TAG_ALL => Ok(EventConsumeMode::All),
+        EVENT_CONSUME_MODE_TAG_ONE => Ok(EventConsumeMode::One),
+        _ => Err(WireError::InvalidTag),
     }
 }

--- a/litebox_broker_transport/src/unix_socket.rs
+++ b/litebox_broker_transport/src/unix_socket.rs
@@ -17,7 +17,6 @@ use litebox_broker_protocol::wire::{
 };
 use litebox_broker_protocol::{
     BrokerRequest, BrokerResponse, HostControlChannel, LocalControlChannel, PeerCredential,
-    ReceivedBrokerRequest, ReceivedBrokerResponse,
 };
 
 const MAX_FRAME_LEN: usize = 64 * 1024;
@@ -135,7 +134,7 @@ impl LocalControlChannel for UnixStreamLocalControlChannel {
         result
     }
 
-    fn recv_response(&mut self) -> io::Result<Option<ReceivedBrokerResponse>> {
+    fn recv_response(&mut self) -> io::Result<Option<BrokerResponse>> {
         let deadline = self.current_deadline()?;
         let result = match read_frame_with_deadline(&mut self.stream, deadline)? {
             Some(frame) => decode_response(&frame).map(Some).map_err(wire_error),
@@ -155,7 +154,7 @@ impl HostControlChannel for UnixStreamHostControlChannel {
         Ok(PeerCredential::Unauthenticated)
     }
 
-    fn recv_request(&mut self) -> io::Result<Option<ReceivedBrokerRequest>> {
+    fn recv_request(&mut self) -> io::Result<Option<BrokerRequest>> {
         let Some(frame) = read_frame_with_deadline(&mut self.stream, self.io_deadline)? else {
             return Ok(None);
         };

--- a/litebox_runner_linux_userland/tests/run.rs
+++ b/litebox_runner_linux_userland/tests/run.rs
@@ -391,19 +391,17 @@ where
 
     fn recv_request(
         &mut self,
-    ) -> Result<Option<litebox_broker_protocol::ReceivedBrokerRequest>, Self::Error> {
-        let received = self.inner.recv_request()?;
+    ) -> Result<Option<litebox_broker_protocol::BrokerRequest>, Self::Error> {
+        let request = self.inner.recv_request()?;
         if matches!(
-            received,
-            Some(litebox_broker_protocol::ReceivedBrokerRequest::Request(
-                litebox_broker_protocol::BrokerRequest::Core(
-                    litebox_broker_protocol::CoreRequest::Event(_)
-                )
+            request,
+            Some(litebox_broker_protocol::BrokerRequest::Core(
+                litebox_broker_protocol::CoreRequest::Event(_)
             ))
         ) {
             self.event_request_count += 1;
         }
-        Ok(received)
+        Ok(request)
     }
 
     fn send_response(


### PR DESCRIPTION
This PR removes the `Unknown` request/response envelopes from the broker protocol channel API. 