### PR TITLE
Use explicit broker protocol DTO literals

### DIFF
--- a/litebox/src/event/counter.rs
+++ b/litebox/src/event/counter.rs
@@ -61,7 +61,7 @@ where
         };
         let response = broker
             .request(CoreRequest::Event(EventRequest::Create(
-                CreateEventRequest::new(initial_count),
+                CreateEventRequest { initial_count },
             )))
             .map_err(BrokerObjectError::from)
             .and_then(event_response_from_core)
@@ -115,10 +115,10 @@ where
         &self,
         mode: EventCounterReadMode,
     ) -> Result<ConsumeEventResponse, BrokerObjectError> {
-        let response = self.request_event(EventRequest::Consume(ConsumeEventRequest::new(
-            self.handle,
+        let response = self.request_event(EventRequest::Consume(ConsumeEventRequest {
+            handle: self.handle,
             mode,
-        )))?;
+        }))?;
         let EventResponse::Consume(response) = response else {
             return Err(BrokerObjectError::UnexpectedResponse);
         };
@@ -126,8 +126,10 @@ where
     }
 
     fn add(&self, value: u64) -> Result<ReadinessState, BrokerObjectError> {
-        let response =
-            self.request_event(EventRequest::Add(AddEventRequest::new(self.handle, value)))?;
+        let response = self.request_event(EventRequest::Add(AddEventRequest {
+            handle: self.handle,
+            value,
+        }))?;
         let EventResponse::Add(response) = response else {
             return Err(BrokerObjectError::UnexpectedResponse);
         };
@@ -151,9 +153,9 @@ where
     }
 
     fn check_io_events(&self) -> Events {
-        let Ok(response) =
-            self.request_event(EventRequest::Wait(WaitEventRequest::new(self.handle)))
-        else {
+        let Ok(response) = self.request_event(EventRequest::Wait(WaitEventRequest {
+            handle: self.handle,
+        })) else {
             return Events::empty();
         };
         let EventResponse::Wait(response) = response else {

--- a/litebox_broker_core/src/event.rs
+++ b/litebox_broker_core/src/event.rs
@@ -95,12 +95,12 @@ impl EventObject {
             _ => return Err(BrokerError::UnsupportedOperation),
         };
         self.count -= value;
-        Ok(EventConsumption::new(
+        Ok(EventConsumption {
             value,
-            ReadinessState {
+            readiness: ReadinessState {
                 read_ready: self.count > 0,
                 write_ready: self.count < MAX_EVENT_COUNT,
             },
-        ))
+        })
     }
 }

--- a/litebox_broker_core/src/event.rs
+++ b/litebox_broker_core/src/event.rs
@@ -29,7 +29,10 @@ pub fn wait(session: &BrokerSession, handle: ObjectHandle) -> Result<WaitOutcome
     let required_rights = ObjectRights::WAIT;
     session.with_authorized_object(handle, required_rights, |object| match object {
         ObjectEntry::Event(event) => {
-            let readiness = ReadinessState::new(event.count > 0, event.count < MAX_EVENT_COUNT);
+            let readiness = ReadinessState {
+                read_ready: event.count > 0,
+                write_ready: event.count < MAX_EVENT_COUNT,
+            };
             Ok(if readiness.read_ready {
                 WaitOutcome::Ready(readiness)
             } else {
@@ -75,10 +78,10 @@ impl EventObject {
             .checked_add(value)
             .filter(|count| *count <= MAX_EVENT_COUNT)
             .ok_or(BrokerError::WouldBlock)?;
-        Ok(ReadinessState::new(
-            self.count > 0,
-            self.count < MAX_EVENT_COUNT,
-        ))
+        Ok(ReadinessState {
+            read_ready: self.count > 0,
+            write_ready: self.count < MAX_EVENT_COUNT,
+        })
     }
 
     fn consume(&mut self, mode: EventConsumeMode) -> Result<EventConsumption> {
@@ -94,7 +97,10 @@ impl EventObject {
         self.count -= value;
         Ok(EventConsumption::new(
             value,
-            ReadinessState::new(self.count > 0, self.count < MAX_EVENT_COUNT),
+            ReadinessState {
+                read_ready: self.count > 0,
+                write_ready: self.count < MAX_EVENT_COUNT,
+            },
         ))
     }
 }

--- a/litebox_broker_core/src/session.rs
+++ b/litebox_broker_core/src/session.rs
@@ -228,13 +228,13 @@ mod tests {
         );
         assert_eq!(
             event::consume(&session, handle, EventConsumeMode::One),
-            Ok(EventConsumption::new(
-                1,
-                ReadinessState {
+            Ok(EventConsumption {
+                value: 1,
+                readiness: ReadinessState {
                     read_ready: false,
                     write_ready: true,
-                }
-            ))
+                },
+            })
         );
         assert_eq!(
             event::create(&session, 0),

--- a/litebox_broker_core/src/session.rs
+++ b/litebox_broker_core/src/session.rs
@@ -214,15 +214,27 @@ mod tests {
 
         assert_eq!(
             event::wait(&session, handle),
-            Ok(WaitOutcome::WouldBlock(ReadinessState::new(false, true)))
+            Ok(WaitOutcome::WouldBlock(ReadinessState {
+                read_ready: false,
+                write_ready: true,
+            }))
         );
         assert_eq!(
             event::add(&session, handle, 1),
-            Ok(ReadinessState::new(true, true))
+            Ok(ReadinessState {
+                read_ready: true,
+                write_ready: true,
+            })
         );
         assert_eq!(
             event::consume(&session, handle, EventConsumeMode::One),
-            Ok(EventConsumption::new(1, ReadinessState::new(false, true)))
+            Ok(EventConsumption::new(
+                1,
+                ReadinessState {
+                    read_ready: false,
+                    write_ready: true,
+                }
+            ))
         );
         assert_eq!(
             event::create(&session, 0),

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -133,23 +133,23 @@ fn handle_event_request(session: &BrokerSession, request: EventRequest) -> Broke
         EventRequest::Create(request) => {
             handle_core_result(event::create(session, request.initial_count), |handle| {
                 BrokerResponse::Core(CoreResponse::Event(EventResponse::Create(
-                    CreateEventResponse::new(handle),
+                    CreateEventResponse { handle },
                 )))
             })
         }
         EventRequest::Wait(request) => {
             handle_core_result(event::wait(session, request.handle), |outcome| {
                 BrokerResponse::Core(CoreResponse::Event(EventResponse::Wait(
-                    WaitEventResponse::new(outcome),
+                    WaitEventResponse { outcome },
                 )))
             })
         }
         EventRequest::Add(request) => handle_core_result(
             event::add(session, request.handle, request.value),
             |readiness| {
-                BrokerResponse::Core(CoreResponse::Event(EventResponse::Add(
-                    AddEventResponse::new(readiness),
-                )))
+                BrokerResponse::Core(CoreResponse::Event(EventResponse::Add(AddEventResponse {
+                    readiness,
+                })))
             },
         ),
         EventRequest::Consume(request) => handle_core_result(
@@ -329,7 +329,7 @@ mod tests {
     }
 
     const fn event_create_request(initial_count: u64) -> BrokerRequest {
-        event_request(EventRequest::Create(CreateEventRequest::new(initial_count)))
+        event_request(EventRequest::Create(CreateEventRequest { initial_count }))
     }
 
     struct FakeHostControlChannel {

--- a/litebox_broker_local/src/event.rs
+++ b/litebox_broker_local/src/event.rs
@@ -20,9 +20,9 @@ impl<T: LocalControlChannel> BrokerLocal<T> {
         &mut self,
         initial_count: u64,
     ) -> Result<ObjectHandle, T::Error> {
-        match self.request(event_request(EventRequest::Create(
-            CreateEventRequest::new(initial_count),
-        )))? {
+        match self.request(event_request(EventRequest::Create(CreateEventRequest {
+            initial_count,
+        })))? {
             BrokerResponse::Core(CoreResponse::Event(EventResponse::Create(response))) => {
                 Ok(response.handle)
             }
@@ -32,9 +32,9 @@ impl<T: LocalControlChannel> BrokerLocal<T> {
 
     /// Checks whether an event wait would complete now.
     pub fn wait_event(&mut self, handle: ObjectHandle) -> Result<WaitOutcome, T::Error> {
-        match self.request(event_request(EventRequest::Wait(WaitEventRequest::new(
+        match self.request(event_request(EventRequest::Wait(WaitEventRequest {
             handle,
-        ))))? {
+        })))? {
             BrokerResponse::Core(CoreResponse::Event(EventResponse::Wait(response))) => {
                 Ok(response.outcome)
             }
@@ -48,9 +48,10 @@ impl<T: LocalControlChannel> BrokerLocal<T> {
         handle: ObjectHandle,
         value: u64,
     ) -> Result<ReadinessState, T::Error> {
-        match self.request(event_request(EventRequest::Add(AddEventRequest::new(
-            handle, value,
-        ))))? {
+        match self.request(event_request(EventRequest::Add(AddEventRequest {
+            handle,
+            value,
+        })))? {
             BrokerResponse::Core(CoreResponse::Event(EventResponse::Add(response))) => {
                 Ok(response.readiness)
             }
@@ -64,9 +65,10 @@ impl<T: LocalControlChannel> BrokerLocal<T> {
         handle: ObjectHandle,
         mode: EventConsumeMode,
     ) -> Result<ConsumeEventResponse, T::Error> {
-        match self.request(event_request(EventRequest::Consume(
-            ConsumeEventRequest::new(handle, mode),
-        )))? {
+        match self.request(event_request(EventRequest::Consume(ConsumeEventRequest {
+            handle,
+            mode,
+        })))? {
             BrokerResponse::Core(CoreResponse::Event(EventResponse::Consume(response))) => {
                 Ok(response)
             }

--- a/litebox_broker_protocol/src/event.rs
+++ b/litebox_broker_protocol/src/event.rs
@@ -39,25 +39,11 @@ pub struct CreateEventRequest {
     pub initial_count: u64,
 }
 
-impl CreateEventRequest {
-    /// Creates an event create request.
-    pub const fn new(initial_count: u64) -> Self {
-        Self { initial_count }
-    }
-}
-
 /// Response to an event create request.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct CreateEventResponse {
     /// Created event handle.
     pub handle: ObjectHandle,
-}
-
-impl CreateEventResponse {
-    /// Creates an event create response.
-    pub const fn new(handle: ObjectHandle) -> Self {
-        Self { handle }
-    }
 }
 
 /// Request to check whether an event wait would complete now.
@@ -67,25 +53,11 @@ pub struct WaitEventRequest {
     pub handle: ObjectHandle,
 }
 
-impl WaitEventRequest {
-    /// Creates an event wait request.
-    pub const fn new(handle: ObjectHandle) -> Self {
-        Self { handle }
-    }
-}
-
 /// Response to an event wait request.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct WaitEventResponse {
     /// Current wait outcome.
     pub outcome: WaitOutcome,
-}
-
-impl WaitEventResponse {
-    /// Creates an event wait response.
-    pub const fn new(outcome: WaitOutcome) -> Self {
-        Self { outcome }
-    }
 }
 
 /// Request to add readiness credits to an event.
@@ -97,25 +69,11 @@ pub struct AddEventRequest {
     pub value: u64,
 }
 
-impl AddEventRequest {
-    /// Creates an event add request.
-    pub const fn new(handle: ObjectHandle, value: u64) -> Self {
-        Self { handle, value }
-    }
-}
-
 /// Response to an event add request.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct AddEventResponse {
     /// Readiness state after adding credits.
     pub readiness: ReadinessState,
-}
-
-impl AddEventResponse {
-    /// Creates an event add response.
-    pub const fn new(readiness: ReadinessState) -> Self {
-        Self { readiness }
-    }
 }
 
 /// Request to consume readiness credits from an event.
@@ -127,13 +85,6 @@ pub struct ConsumeEventRequest {
     pub mode: EventConsumeMode,
 }
 
-impl ConsumeEventRequest {
-    /// Creates an event consume request.
-    pub const fn new(handle: ObjectHandle, mode: EventConsumeMode) -> Self {
-        Self { handle, mode }
-    }
-}
-
 /// Result of consuming readiness credits from a broker-owned event object.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct EventConsumption {
@@ -141,13 +92,6 @@ pub struct EventConsumption {
     pub value: u64,
     /// Readiness state after consuming credits.
     pub readiness: ReadinessState,
-}
-
-impl EventConsumption {
-    /// Creates an event consumption result.
-    pub const fn new(value: u64, readiness: ReadinessState) -> Self {
-        Self { value, readiness }
-    }
 }
 
 /// Response to an event consume request.

--- a/litebox_broker_protocol/src/event.rs
+++ b/litebox_broker_protocol/src/event.rs
@@ -12,16 +12,6 @@ pub struct ReadinessState {
     pub write_ready: bool,
 }
 
-impl ReadinessState {
-    /// Creates a readiness state.
-    pub const fn new(read_ready: bool, write_ready: bool) -> Self {
-        Self {
-            read_ready,
-            write_ready,
-        }
-    }
-}
-
 /// Result of checking whether a broker event read wait would complete now.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[non_exhaustive]

--- a/litebox_broker_protocol/src/lib.rs
+++ b/litebox_broker_protocol/src/lib.rs
@@ -39,12 +39,5 @@ pub struct ObjectHandle(pub u64);
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ProtocolVersion(pub u16);
 
-impl ProtocolVersion {
-    /// Creates a protocol version.
-    pub const fn new(version: u16) -> Self {
-        Self(version)
-    }
-}
-
 /// Current broker protocol version.
-pub const BROKER_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::new(1);
+pub const BROKER_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion(1);

--- a/litebox_broker_protocol/src/wire.rs
+++ b/litebox_broker_protocol/src/wire.rs
@@ -144,8 +144,8 @@ pub fn decode_response(frame: &[u8]) -> Result<BrokerResponse, WireError> {
 mod tests {
     use super::*;
     use crate::{
-        AddEventRequest, AddEventResponse, ConsumeEventRequest, ConsumeEventResponse, CoreRequest,
-        CoreResponse, CreateEventRequest, CreateEventResponse, EventConsumeMode, EventRequest,
+        AddEventRequest, AddEventResponse, ConsumeEventRequest, CoreRequest, CoreResponse,
+        CreateEventRequest, CreateEventResponse, EventConsumeMode, EventConsumption, EventRequest,
         EventResponse, ObjectHandle, ProtocolVersion, ReadinessState, WaitEventRequest,
         WaitEventResponse, WaitOutcome,
     };
@@ -155,20 +155,24 @@ mod tests {
         let handle = sample_handle();
         let requests = [
             BrokerRequest::Negotiate {
-                protocol_version: ProtocolVersion::new(1),
+                protocol_version: ProtocolVersion(1),
             },
-            event_request(EventRequest::Create(CreateEventRequest::new(0))),
-            event_request(EventRequest::Create(CreateEventRequest::new(7))),
-            event_request(EventRequest::Wait(WaitEventRequest::new(handle))),
-            event_request(EventRequest::Add(AddEventRequest::new(handle, 3))),
-            event_request(EventRequest::Consume(ConsumeEventRequest::new(
+            event_request(EventRequest::Create(CreateEventRequest {
+                initial_count: 0,
+            })),
+            event_request(EventRequest::Create(CreateEventRequest {
+                initial_count: 7,
+            })),
+            event_request(EventRequest::Wait(WaitEventRequest { handle })),
+            event_request(EventRequest::Add(AddEventRequest { handle, value: 3 })),
+            event_request(EventRequest::Consume(ConsumeEventRequest {
                 handle,
-                EventConsumeMode::All,
-            ))),
-            event_request(EventRequest::Consume(ConsumeEventRequest::new(
+                mode: EventConsumeMode::All,
+            })),
+            event_request(EventRequest::Consume(ConsumeEventRequest {
                 handle,
-                EventConsumeMode::One,
-            ))),
+                mode: EventConsumeMode::One,
+            })),
         ];
 
         for request in requests {
@@ -184,35 +188,37 @@ mod tests {
         let handle = sample_handle();
         let responses = [
             BrokerResponse::Negotiated {
-                broker_protocol_version: ProtocolVersion::new(1),
+                broker_protocol_version: ProtocolVersion(1),
             },
             BrokerResponse::VersionMismatch {
-                broker_protocol_version: ProtocolVersion::new(1),
+                broker_protocol_version: ProtocolVersion(1),
             },
-            event_response(EventResponse::Create(CreateEventResponse::new(handle))),
-            event_response(EventResponse::Wait(WaitEventResponse::new(
-                WaitOutcome::Ready(ReadinessState {
+            event_response(EventResponse::Create(CreateEventResponse { handle })),
+            event_response(EventResponse::Wait(WaitEventResponse {
+                outcome: WaitOutcome::Ready(ReadinessState {
                     read_ready: true,
                     write_ready: false,
                 }),
-            ))),
-            event_response(EventResponse::Wait(WaitEventResponse::new(
-                WaitOutcome::WouldBlock(ReadinessState {
+            })),
+            event_response(EventResponse::Wait(WaitEventResponse {
+                outcome: WaitOutcome::WouldBlock(ReadinessState {
                     read_ready: false,
                     write_ready: true,
                 }),
-            ))),
-            event_response(EventResponse::Add(AddEventResponse::new(ReadinessState {
-                read_ready: true,
-                write_ready: true,
-            }))),
-            event_response(EventResponse::Consume(ConsumeEventResponse::new(
-                3,
-                ReadinessState {
+            })),
+            event_response(EventResponse::Add(AddEventResponse {
+                readiness: ReadinessState {
+                    read_ready: true,
+                    write_ready: true,
+                },
+            })),
+            event_response(EventResponse::Consume(EventConsumption {
+                value: 3,
+                readiness: ReadinessState {
                     read_ready: false,
                     write_ready: true,
                 },
-            ))),
+            })),
             BrokerResponse::Error(ErrorCode::PolicyDenied),
             BrokerResponse::Error(ErrorCode::WouldBlock),
             BrokerResponse::Error(ErrorCode::Internal),
@@ -229,18 +235,20 @@ mod tests {
     #[test]
     fn decode_rejects_malformed_request_frames() {
         assert_eq!(decode_request(&[0xff, 1, 2, 3]), Err(WireError::InvalidTag));
-        let mut unknown_consume_mode = encode_request(event_request(EventRequest::Consume(
-            ConsumeEventRequest::new(sample_handle(), EventConsumeMode::All),
-        )));
+        let mut unknown_consume_mode =
+            encode_request(event_request(EventRequest::Consume(ConsumeEventRequest {
+                handle: sample_handle(),
+                mode: EventConsumeMode::All,
+            })));
         *unknown_consume_mode.last_mut().unwrap() = 0xff;
         assert_eq!(
             decode_request(&unknown_consume_mode),
             Err(WireError::InvalidTag)
         );
         assert_eq!(decode_request(&[0, 1]), Err(WireError::TruncatedFrame));
-        let mut frame = encode_request(event_request(EventRequest::Create(
-            CreateEventRequest::new(0),
-        )));
+        let mut frame = encode_request(event_request(EventRequest::Create(CreateEventRequest {
+            initial_count: 0,
+        })));
         frame.push(0xff);
         assert_eq!(decode_request(&frame), Err(WireError::TrailingBytes));
     }
@@ -276,12 +284,12 @@ mod tests {
     #[test]
     fn event_add_response_wire_shape_is_pinned() {
         assert_eq!(
-            encode_response(event_response(EventResponse::Add(AddEventResponse::new(
-                ReadinessState {
+            encode_response(event_response(EventResponse::Add(AddEventResponse {
+                readiness: ReadinessState {
                     read_ready: true,
                     write_ready: false,
-                }
-            )))),
+                },
+            }))),
             [1, 0, 2, 1, 0]
         );
     }

--- a/litebox_broker_protocol/src/wire.rs
+++ b/litebox_broker_protocol/src/wire.rs
@@ -191,17 +191,27 @@ mod tests {
             },
             event_response(EventResponse::Create(CreateEventResponse::new(handle))),
             event_response(EventResponse::Wait(WaitEventResponse::new(
-                WaitOutcome::Ready(ReadinessState::new(true, false)),
+                WaitOutcome::Ready(ReadinessState {
+                    read_ready: true,
+                    write_ready: false,
+                }),
             ))),
             event_response(EventResponse::Wait(WaitEventResponse::new(
-                WaitOutcome::WouldBlock(ReadinessState::new(false, true)),
+                WaitOutcome::WouldBlock(ReadinessState {
+                    read_ready: false,
+                    write_ready: true,
+                }),
             ))),
-            event_response(EventResponse::Add(AddEventResponse::new(
-                ReadinessState::new(true, true),
-            ))),
+            event_response(EventResponse::Add(AddEventResponse::new(ReadinessState {
+                read_ready: true,
+                write_ready: true,
+            }))),
             event_response(EventResponse::Consume(ConsumeEventResponse::new(
                 3,
-                ReadinessState::new(false, true),
+                ReadinessState {
+                    read_ready: false,
+                    write_ready: true,
+                },
             ))),
             BrokerResponse::Error(ErrorCode::PolicyDenied),
             BrokerResponse::Error(ErrorCode::WouldBlock),
@@ -267,7 +277,10 @@ mod tests {
     fn event_add_response_wire_shape_is_pinned() {
         assert_eq!(
             encode_response(event_response(EventResponse::Add(AddEventResponse::new(
-                ReadinessState::new(true, false)
+                ReadinessState {
+                    read_ready: true,
+                    write_ready: false,
+                }
             )))),
             [1, 0, 2, 1, 0]
         );

--- a/litebox_broker_protocol/src/wire/event.rs
+++ b/litebox_broker_protocol/src/wire/event.rs
@@ -137,7 +137,10 @@ fn encode_readiness(encoder: &mut Encoder, readiness: ReadinessState) {
 }
 
 fn decode_readiness(decoder: &mut Decoder<'_>) -> Result<ReadinessState, WireError> {
-    Ok(ReadinessState::new(decoder.bool()?, decoder.bool()?))
+    Ok(ReadinessState {
+        read_ready: decoder.bool()?,
+        write_ready: decoder.bool()?,
+    })
 }
 
 fn encode_consume_mode(encoder: &mut Encoder, mode: EventConsumeMode) {

--- a/litebox_broker_protocol/src/wire/event.rs
+++ b/litebox_broker_protocol/src/wire/event.rs
@@ -2,8 +2,8 @@
 // Licensed under the MIT license.
 
 use crate::{
-    AddEventRequest, AddEventResponse, ConsumeEventRequest, ConsumeEventResponse,
-    CreateEventRequest, CreateEventResponse, EventConsumeMode, EventRequest, EventResponse,
+    AddEventRequest, AddEventResponse, ConsumeEventRequest, CreateEventRequest,
+    CreateEventResponse, EventConsumeMode, EventConsumption, EventRequest, EventResponse,
     ReadinessState, WaitEventRequest, WaitEventResponse, WaitOutcome,
 };
 
@@ -52,15 +52,20 @@ pub(super) fn encode_event_request(encoder: &mut Encoder, request: EventRequest)
 
 pub(super) fn decode_event_request(decoder: &mut Decoder<'_>) -> Result<EventRequest, WireError> {
     let request = match decoder.u8()? {
-        EVENT_REQUEST_TAG_CREATE => EventRequest::Create(CreateEventRequest::new(decoder.u64()?)),
-        EVENT_REQUEST_TAG_WAIT => EventRequest::Wait(WaitEventRequest::new(decoder.handle()?)),
-        EVENT_REQUEST_TAG_ADD => {
-            EventRequest::Add(AddEventRequest::new(decoder.handle()?, decoder.u64()?))
-        }
-        EVENT_REQUEST_TAG_CONSUME => EventRequest::Consume(ConsumeEventRequest::new(
-            decoder.handle()?,
-            decode_consume_mode(decoder)?,
-        )),
+        EVENT_REQUEST_TAG_CREATE => EventRequest::Create(CreateEventRequest {
+            initial_count: decoder.u64()?,
+        }),
+        EVENT_REQUEST_TAG_WAIT => EventRequest::Wait(WaitEventRequest {
+            handle: decoder.handle()?,
+        }),
+        EVENT_REQUEST_TAG_ADD => EventRequest::Add(AddEventRequest {
+            handle: decoder.handle()?,
+            value: decoder.u64()?,
+        }),
+        EVENT_REQUEST_TAG_CONSUME => EventRequest::Consume(ConsumeEventRequest {
+            handle: decoder.handle()?,
+            mode: decode_consume_mode(decoder)?,
+        }),
         _ => return Err(WireError::InvalidTag),
     };
 
@@ -91,19 +96,19 @@ pub(super) fn encode_event_response(encoder: &mut Encoder, response: EventRespon
 
 pub(super) fn decode_event_response(decoder: &mut Decoder<'_>) -> Result<EventResponse, WireError> {
     let response = match decoder.u8()? {
-        EVENT_RESPONSE_TAG_CREATED => {
-            EventResponse::Create(CreateEventResponse::new(decoder.handle()?))
-        }
-        EVENT_RESPONSE_TAG_WAITED => {
-            EventResponse::Wait(WaitEventResponse::new(decode_wait_outcome(decoder)?))
-        }
-        EVENT_RESPONSE_TAG_ADDED => {
-            EventResponse::Add(AddEventResponse::new(decode_readiness(decoder)?))
-        }
-        EVENT_RESPONSE_TAG_CONSUMED => EventResponse::Consume(ConsumeEventResponse::new(
-            decoder.u64()?,
-            decode_readiness(decoder)?,
-        )),
+        EVENT_RESPONSE_TAG_CREATED => EventResponse::Create(CreateEventResponse {
+            handle: decoder.handle()?,
+        }),
+        EVENT_RESPONSE_TAG_WAITED => EventResponse::Wait(WaitEventResponse {
+            outcome: decode_wait_outcome(decoder)?,
+        }),
+        EVENT_RESPONSE_TAG_ADDED => EventResponse::Add(AddEventResponse {
+            readiness: decode_readiness(decoder)?,
+        }),
+        EVENT_RESPONSE_TAG_CONSUMED => EventResponse::Consume(EventConsumption {
+            value: decoder.u64()?,
+            readiness: decode_readiness(decoder)?,
+        }),
         _ => return Err(WireError::InvalidTag),
     };
 

--- a/litebox_broker_protocol/src/wire/primitive.rs
+++ b/litebox_broker_protocol/src/wire/primitive.rs
@@ -86,7 +86,7 @@ impl<'a> Decoder<'a> {
     }
 
     pub(super) fn protocol_version(&mut self) -> Result<ProtocolVersion, WireError> {
-        Ok(ProtocolVersion::new(self.u16()?))
+        Ok(ProtocolVersion(self.u16()?))
     }
 
     pub(super) fn handle(&mut self) -> Result<ObjectHandle, WireError> {

--- a/litebox_broker_userland/tests/userland_broker.rs
+++ b/litebox_broker_userland/tests/userland_broker.rs
@@ -39,17 +39,26 @@ fn separate_process_broker_serves_event_object_requests() {
     let handle = local.create_event().unwrap();
     assert_eq!(
         local.wait_event(handle).unwrap(),
-        WaitOutcome::WouldBlock(ReadinessState::new(false, true))
+        WaitOutcome::WouldBlock(ReadinessState {
+            read_ready: false,
+            write_ready: true,
+        })
     );
 
     assert_eq!(
         local.add_event(handle, 1).unwrap(),
-        ReadinessState::new(true, true)
+        ReadinessState {
+            read_ready: true,
+            write_ready: true,
+        }
     );
 
     assert_eq!(
         local.wait_event(handle).unwrap(),
-        WaitOutcome::Ready(ReadinessState::new(true, true))
+        WaitOutcome::Ready(ReadinessState {
+            read_ready: true,
+            write_ready: true,
+        })
     );
     drop(local);
     assert!(child.wait().unwrap().success());


### PR DESCRIPTION
This PR removes trivial `new()` constructors from public-field broker protocol DTOs. Call sites now use tuple or field literals so the values being set are explicit at construction time.