### PR TITLE
Use From for broker error conversions

### DIFF
--- a/litebox/src/broker/error.rs
+++ b/litebox/src/broker/error.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+use litebox_broker_local::BrokerLocalError;
 use litebox_broker_protocol::ErrorCode;
 use thiserror::Error;
 
@@ -58,13 +59,22 @@ impl From<ErrorCode> for BrokerObjectError {
     }
 }
 
-pub(crate) fn map_broker_object_result<T>(
-    result: Result<T, BrokerObjectError>,
-) -> Result<T, TryOpError<EventCounterError>> {
-    match result {
-        Ok(value) => Ok(value),
-        Err(BrokerObjectError::WouldBlock) => Err(TryOpError::TryAgain),
-        Err(error) => Err(TryOpError::Other(error.into())),
+impl<E> From<BrokerLocalError<E>> for BrokerControlError {
+    fn from(error: BrokerLocalError<E>) -> Self {
+        match error {
+            BrokerLocalError::Channel(_) | BrokerLocalError::ChannelClosed => Self::Transport,
+            BrokerLocalError::Broker(error) => Self::Broker(error),
+            BrokerLocalError::UnexpectedResponse(_) => Self::UnexpectedResponse,
+        }
+    }
+}
+
+impl From<BrokerObjectError> for TryOpError<EventCounterError> {
+    fn from(error: BrokerObjectError) -> Self {
+        match error {
+            BrokerObjectError::WouldBlock => Self::TryAgain,
+            error => Self::Other(error.into()),
+        }
     }
 }
 

--- a/litebox/src/broker/mod.rs
+++ b/litebox/src/broker/mod.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-use litebox_broker_local::{BrokerLocal, BrokerLocalError};
+use litebox_broker_local::BrokerLocal;
 use litebox_broker_protocol::{CoreRequest, CoreResponse, LocalControlChannel};
 
 use crate::sync::{Mutex, RawSyncPrimitivesProvider};
@@ -46,17 +46,6 @@ where
         &self,
         request: CoreRequest,
     ) -> core::result::Result<CoreResponse, BrokerControlError> {
-        let response = self
-            .local
-            .lock()
-            .request(request)
-            .map_err(|error| match error {
-                BrokerLocalError::Channel(_) | BrokerLocalError::ChannelClosed => {
-                    BrokerControlError::Transport
-                }
-                BrokerLocalError::Broker(error) => BrokerControlError::Broker(error),
-                BrokerLocalError::UnexpectedResponse(_) => BrokerControlError::UnexpectedResponse,
-            })?;
-        Ok(response)
+        Ok(self.local.lock().request(request)?)
     }
 }

--- a/litebox/src/event/counter.rs
+++ b/litebox/src/event/counter.rs
@@ -13,10 +13,7 @@ use thiserror::Error;
 
 use crate::{
     LiteBox,
-    broker::{
-        BrokerControl,
-        error::{BrokerObjectError, map_broker_object_result},
-    },
+    broker::{BrokerControl, error::BrokerObjectError},
     event::{
         Events, IOPollable, observer::Observer, polling::Pollee, polling::TryOpError,
         wait::WaitContext,
@@ -84,7 +81,7 @@ where
         mode: EventCounterReadMode,
     ) -> Result<u64, TryOpError<EventCounterError>> {
         self.pollee.wait(cx, nonblock, Events::IN, || {
-            let response = map_broker_object_result(self.consume(mode))?;
+            let response = self.consume(mode)?;
             if response.readiness.write_ready {
                 self.pollee.notify_observers(Events::OUT);
             }
@@ -103,7 +100,7 @@ where
             return Err(TryOpError::Other(EventCounterError::InvalidInput));
         }
         self.pollee.wait(cx, nonblock, Events::OUT, || {
-            let readiness = map_broker_object_result(self.add(value))?;
+            let readiness = self.add(value)?;
             if value != 0 && readiness.read_ready {
                 self.pollee.notify_observers(Events::IN);
             }

--- a/litebox_broker_core/src/error.rs
+++ b/litebox_broker_core/src/error.rs
@@ -3,6 +3,8 @@
 
 use thiserror::Error;
 
+use litebox_broker_protocol::ErrorCode;
+
 /// Broker authority error category.
 #[derive(Clone, Copy, Debug, Error, PartialEq, Eq, Hash)]
 #[non_exhaustive]
@@ -21,4 +23,18 @@ pub enum BrokerError {
     WouldBlock,
     #[error("unsupported broker operation")]
     UnsupportedOperation,
+}
+
+impl From<BrokerError> for ErrorCode {
+    fn from(error: BrokerError) -> Self {
+        match error {
+            BrokerError::PolicyDenied => Self::PolicyDenied,
+            BrokerError::UnknownObject => Self::UnknownObject,
+            BrokerError::InvalidRights => Self::InvalidRights,
+            BrokerError::ResourceExhausted => Self::ResourceExhausted,
+            BrokerError::BrokerCoreAlreadyExists => Self::Internal,
+            BrokerError::WouldBlock => Self::WouldBlock,
+            BrokerError::UnsupportedOperation => Self::UnsupportedOperation,
+        }
+    }
 }

--- a/litebox_broker_host/src/error.rs
+++ b/litebox_broker_host/src/error.rs
@@ -1,16 +1,24 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+use litebox_broker_core::BrokerError;
+use litebox_broker_protocol::ErrorCode;
 use thiserror::Error;
 
 /// Errors returned by a broker-host receive/send loop.
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum BrokerHostError<E> {
-    #[error("broker association setup failed")]
-    AssociationSetup,
     #[error("broker channel failed: {0}")]
     Channel(#[source] E),
+    #[error("broker setup failed: {0}")]
+    Broker(#[source] ErrorCode),
+}
+
+impl<E> From<BrokerError> for BrokerHostError<E> {
+    fn from(error: BrokerError) -> Self {
+        Self::Broker(error.into())
+    }
 }
 
 /// Broker-host receive/send loop result type.

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -36,11 +36,8 @@ where
     let peer_credential = channel
         .peer_credential()
         .map_err(BrokerHostError::Channel)?;
-    let caller_credential = caller_credential_from_peer(peer_credential)
-        .map_err(|()| BrokerHostError::AssociationSetup)?;
-    let session = core
-        .create_session(caller_credential)
-        .map_err(|_error| BrokerHostError::AssociationSetup)?;
+    let caller_credential = caller_credential_from_peer(peer_credential);
+    let session = core.create_session(caller_credential)?;
 
     serve_request_loop(channel, &session)
 }
@@ -70,13 +67,11 @@ where
     Ok(ConnectionTermination::PeerClosed)
 }
 
-fn caller_credential_from_peer(
-    peer_credential: PeerCredential,
-) -> core::result::Result<CallerCredential, ()> {
+fn caller_credential_from_peer(peer_credential: PeerCredential) -> CallerCredential {
     if peer_credential == PeerCredential::Unauthenticated {
-        Ok(CallerCredential::Unauthenticated)
+        CallerCredential::Unauthenticated
     } else {
-        Err(())
+        panic!("channel returned an unsupported broker peer credential")
     }
 }
 

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -14,7 +14,7 @@ extern crate std;
 
 use core::fmt;
 
-use litebox_broker_core::{BrokerCore, BrokerError, BrokerSession, CallerCredential, event};
+use litebox_broker_core::{BrokerCore, BrokerSession, CallerCredential, event};
 use litebox_broker_protocol::{
     AddEventResponse, BROKER_PROTOCOL_VERSION, BrokerRequest, BrokerResponse, CoreRequest,
     CoreResponse, CreateEventResponse, ErrorCode, EventRequest, EventResponse, HostControlChannel,
@@ -165,19 +165,7 @@ fn handle_core_result<T>(
 ) -> BrokerResponse {
     match result {
         Ok(value) => into_response(value),
-        Err(error) => BrokerResponse::Error(to_protocol_error(error)),
-    }
-}
-
-fn to_protocol_error(error: BrokerError) -> ErrorCode {
-    match error {
-        BrokerError::PolicyDenied => ErrorCode::PolicyDenied,
-        BrokerError::UnknownObject => ErrorCode::UnknownObject,
-        BrokerError::InvalidRights => ErrorCode::InvalidRights,
-        BrokerError::ResourceExhausted => ErrorCode::ResourceExhausted,
-        BrokerError::WouldBlock => ErrorCode::WouldBlock,
-        BrokerError::UnsupportedOperation => ErrorCode::UnsupportedOperation,
-        _ => ErrorCode::Internal,
+        Err(error) => BrokerResponse::Error(error.into()),
     }
 }
 

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -36,7 +36,10 @@ where
     let peer_credential = channel
         .peer_credential()
         .map_err(BrokerHostError::Channel)?;
-    let caller_credential = caller_credential_from_peer(peer_credential);
+    let caller_credential = match peer_credential {
+        PeerCredential::Unauthenticated => CallerCredential::Unauthenticated,
+        _ => return Err(BrokerHostError::Broker(ErrorCode::PolicyDenied)),
+    };
     let session = core.create_session(caller_credential)?;
 
     serve_request_loop(channel, &session)
@@ -65,14 +68,6 @@ where
     }
 
     Ok(ConnectionTermination::PeerClosed)
-}
-
-fn caller_credential_from_peer(peer_credential: PeerCredential) -> CallerCredential {
-    if peer_credential == PeerCredential::Unauthenticated {
-        CallerCredential::Unauthenticated
-    } else {
-        panic!("channel returned an unsupported broker peer credential")
-    }
 }
 
 fn handle_request(


### PR DESCRIPTION
Replace ad hoc broker error mapping helpers with `From` conversions.

Remove stale broker host association setup errors and let broker setup failures flow through normal broker error conversion.