### PR TITLE
Clean up broker helper indirection

### DIFF
--- a/litebox/src/event/counter.rs
+++ b/litebox/src/event/counter.rs
@@ -61,8 +61,8 @@ where
                 CreateEventRequest { initial_count },
             )))
             .map_err(BrokerObjectError::from)
-            .map(event_response_from_core)
             .map_err(EventCounterError::from)?;
+        let CoreResponse::Event(response) = response;
         let EventResponse::Create(response) = response else {
             return Err(BrokerObjectError::UnexpectedResponse.into());
         };
@@ -134,10 +134,11 @@ where
     }
 
     fn request_event(&self, request: EventRequest) -> Result<EventResponse, BrokerObjectError> {
-        self.broker
+        let CoreResponse::Event(response) = self
+            .broker
             .request(CoreRequest::Event(request))
-            .map_err(BrokerObjectError::from)
-            .map(event_response_from_core)
+            .map_err(BrokerObjectError::from)?;
+        Ok(response)
     }
 }
 
@@ -167,11 +168,5 @@ where
             events |= Events::OUT;
         }
         events
-    }
-}
-
-fn event_response_from_core(response: CoreResponse) -> EventResponse {
-    match response {
-        CoreResponse::Event(response) => response,
     }
 }

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -118,44 +118,34 @@ fn handle_core_request(session: &BrokerSession, request: CoreRequest) -> BrokerR
 
 fn handle_event_request(session: &BrokerSession, request: EventRequest) -> BrokerResponse {
     match request {
-        EventRequest::Create(request) => {
-            handle_core_result(event::create(session, request.initial_count), |handle| {
-                BrokerResponse::Core(CoreResponse::Event(EventResponse::Create(
-                    CreateEventResponse { handle },
-                )))
-            })
+        EventRequest::Create(request) => match event::create(session, request.initial_count) {
+            Ok(handle) => BrokerResponse::Core(CoreResponse::Event(EventResponse::Create(
+                CreateEventResponse { handle },
+            ))),
+            Err(error) => BrokerResponse::Error(error.into()),
+        },
+        EventRequest::Wait(request) => match event::wait(session, request.handle) {
+            Ok(readiness) => BrokerResponse::Core(CoreResponse::Event(EventResponse::Wait(
+                WaitEventResponse { readiness },
+            ))),
+            Err(error) => BrokerResponse::Error(error.into()),
+        },
+        EventRequest::Add(request) => {
+            match event::add(session, request.handle, request.value) {
+                Ok(readiness) => BrokerResponse::Core(CoreResponse::Event(EventResponse::Add(
+                    AddEventResponse { readiness },
+                ))),
+                Err(error) => BrokerResponse::Error(error.into()),
+            }
         }
-        EventRequest::Wait(request) => {
-            handle_core_result(event::wait(session, request.handle), |readiness| {
-                BrokerResponse::Core(CoreResponse::Event(EventResponse::Wait(
-                    WaitEventResponse { readiness },
-                )))
-            })
+        EventRequest::Consume(request) => {
+            match event::consume(session, request.handle, request.mode) {
+                Ok(consumption) => {
+                    BrokerResponse::Core(CoreResponse::Event(EventResponse::Consume(consumption)))
+                }
+                Err(error) => BrokerResponse::Error(error.into()),
+            }
         }
-        EventRequest::Add(request) => handle_core_result(
-            event::add(session, request.handle, request.value),
-            |readiness| {
-                BrokerResponse::Core(CoreResponse::Event(EventResponse::Add(AddEventResponse {
-                    readiness,
-                })))
-            },
-        ),
-        EventRequest::Consume(request) => handle_core_result(
-            event::consume(session, request.handle, request.mode),
-            |consumption| {
-                BrokerResponse::Core(CoreResponse::Event(EventResponse::Consume(consumption)))
-            },
-        ),
-    }
-}
-
-fn handle_core_result<T>(
-    result: litebox_broker_core::Result<T>,
-    into_response: impl FnOnce(T) -> BrokerResponse,
-) -> BrokerResponse {
-    match result {
-        Ok(value) => into_response(value),
-        Err(error) => BrokerResponse::Error(error.into()),
     }
 }
 

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -80,19 +80,25 @@ fn handle_request(
             BrokerRequest::Negotiate { protocol_version } => {
                 if protocol_version == BROKER_PROTOCOL_VERSION {
                     *state = ConnectionState::Active;
-                    BrokerDispatch::continue_after(BrokerResponse::Negotiated {
-                        broker_protocol_version: BROKER_PROTOCOL_VERSION,
-                    })
+                    BrokerDispatch {
+                        response: BrokerResponse::Negotiated {
+                            broker_protocol_version: BROKER_PROTOCOL_VERSION,
+                        },
+                        outcome: DispatchOutcome::Continue,
+                    }
                 } else {
-                    BrokerDispatch::continue_after(BrokerResponse::VersionMismatch {
-                        broker_protocol_version: BROKER_PROTOCOL_VERSION,
-                    })
+                    BrokerDispatch {
+                        response: BrokerResponse::VersionMismatch {
+                            broker_protocol_version: BROKER_PROTOCOL_VERSION,
+                        },
+                        outcome: DispatchOutcome::Continue,
+                    }
                 }
             }
-            BrokerRequest::Core(_) => BrokerDispatch::close_after(
-                BrokerResponse::Error(ErrorCode::ProtocolState),
-                CloseReason::ProtocolViolation,
-            ),
+            BrokerRequest::Core(_) => BrokerDispatch {
+                response: BrokerResponse::Error(ErrorCode::ProtocolState),
+                outcome: DispatchOutcome::Close(CloseReason::ProtocolViolation),
+            },
         },
         ConnectionState::Active => handle_active_request(session, request),
     }
@@ -100,19 +106,14 @@ fn handle_request(
 
 fn handle_active_request(session: &BrokerSession, request: BrokerRequest) -> BrokerDispatch {
     match request {
-        BrokerRequest::Negotiate { .. } => BrokerDispatch::close_after(
-            BrokerResponse::Error(ErrorCode::ProtocolState),
-            CloseReason::ProtocolViolation,
-        ),
-        BrokerRequest::Core(request) => {
-            BrokerDispatch::continue_after(handle_core_request(session, request))
-        }
-    }
-}
-
-fn handle_core_request(session: &BrokerSession, request: CoreRequest) -> BrokerResponse {
-    match request {
-        CoreRequest::Event(request) => handle_event_request(session, request),
+        BrokerRequest::Negotiate { .. } => BrokerDispatch {
+            response: BrokerResponse::Error(ErrorCode::ProtocolState),
+            outcome: DispatchOutcome::Close(CloseReason::ProtocolViolation),
+        },
+        BrokerRequest::Core(CoreRequest::Event(request)) => BrokerDispatch {
+            response: handle_event_request(session, request),
+            outcome: DispatchOutcome::Continue,
+        },
     }
 }
 
@@ -165,22 +166,6 @@ struct BrokerDispatch {
 enum DispatchOutcome {
     Continue,
     Close(CloseReason),
-}
-
-impl BrokerDispatch {
-    const fn continue_after(response: BrokerResponse) -> Self {
-        Self {
-            response,
-            outcome: DispatchOutcome::Continue,
-        }
-    }
-
-    const fn close_after(response: BrokerResponse, reason: CloseReason) -> Self {
-        Self {
-            response,
-            outcome: DispatchOutcome::Close(reason),
-        }
-    }
 }
 
 /// Reason the broker host closed the connection after sending a response.


### PR DESCRIPTION
This PR inlines broker-host event result handling, dispatch construction, and local event response extraction at their call sites while preserving existing behavior.