### PR TITLE
Use descriptive broker channel generics

### DIFF
--- a/litebox/src/broker/mod.rs
+++ b/litebox/src/broker/mod.rs
@@ -22,25 +22,29 @@ pub(crate) trait BrokerControl: Send + Sync {
     ) -> core::result::Result<CoreResponse, BrokerControlError>;
 }
 
-pub(crate) struct BrokerLocalControl<Platform: RawSyncPrimitivesProvider, T> {
-    local: Mutex<Platform, BrokerLocal<T>>,
+pub(crate) struct BrokerLocalControl<
+    Platform: RawSyncPrimitivesProvider,
+    Channel: LocalControlChannel + Send,
+> {
+    local: Mutex<Platform, BrokerLocal<Channel>>,
 }
 
-impl<Platform, T> BrokerLocalControl<Platform, T>
+impl<Platform, Channel> BrokerLocalControl<Platform, Channel>
 where
     Platform: RawSyncPrimitivesProvider,
+    Channel: LocalControlChannel + Send,
 {
-    pub(crate) const fn new(local: BrokerLocal<T>) -> Self {
+    pub(crate) const fn new(local: BrokerLocal<Channel>) -> Self {
         Self {
             local: Mutex::new(local),
         }
     }
 }
 
-impl<Platform, T> BrokerControl for BrokerLocalControl<Platform, T>
+impl<Platform, Channel> BrokerControl for BrokerLocalControl<Platform, Channel>
 where
     Platform: RawSyncPrimitivesProvider,
-    T: LocalControlChannel + Send,
+    Channel: LocalControlChannel + Send,
 {
     fn request(
         &self,

--- a/litebox/src/litebox.rs
+++ b/litebox/src/litebox.rs
@@ -38,18 +38,18 @@ impl<Platform: RawSyncPrimitivesProvider> LiteBox<Platform> {
     }
 
     /// Create a new [`LiteBox`] instance with a negotiated broker-local control adapter installed.
-    pub fn new_with_broker_local<T>(
+    pub fn new_with_broker_local<Channel>(
         platform: &'static Platform,
-        broker_local: BrokerLocal<T>,
+        broker_local: BrokerLocal<Channel>,
     ) -> Self
     where
-        T: LocalControlChannel + Send + 'static,
+        Channel: LocalControlChannel + Send + 'static,
     {
         Self::new_inner(
             platform,
-            Some(Arc::new(broker::BrokerLocalControl::<Platform, T>::new(
-                broker_local,
-            ))),
+            Some(Arc::new(
+                broker::BrokerLocalControl::<Platform, Channel>::new(broker_local),
+            )),
         )
     }
 

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -26,12 +26,12 @@ mod error;
 pub use error::{BrokerHostError, Result};
 
 /// Serves one broker connection over the provided connected control channel.
-pub fn serve_connection<T>(
+pub fn serve_connection<Channel>(
     core: &BrokerCore,
-    channel: &mut T,
-) -> Result<ConnectionTermination, T::Error>
+    channel: &mut Channel,
+) -> Result<ConnectionTermination, Channel::Error>
 where
-    T: HostControlChannel,
+    Channel: HostControlChannel,
 {
     let peer_credential = channel
         .peer_credential()
@@ -45,12 +45,12 @@ where
     serve_request_loop(channel, &session)
 }
 
-fn serve_request_loop<T>(
-    channel: &mut T,
+fn serve_request_loop<Channel>(
+    channel: &mut Channel,
     session: &BrokerSession,
-) -> Result<ConnectionTermination, T::Error>
+) -> Result<ConnectionTermination, Channel::Error>
 where
-    T: HostControlChannel,
+    Channel: HostControlChannel,
 {
     let mut state = ConnectionState::AwaitingNegotiation;
     loop {

--- a/litebox_broker_local/src/event.rs
+++ b/litebox_broker_local/src/event.rs
@@ -9,9 +9,9 @@ use litebox_broker_protocol::{
 
 use crate::{BrokerLocal, BrokerLocalError, Result};
 
-impl<T: LocalControlChannel> BrokerLocal<T> {
+impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
     /// Creates a broker-owned event object.
-    pub fn create_event(&mut self) -> Result<ObjectHandle, T::Error> {
+    pub fn create_event(&mut self) -> Result<ObjectHandle, Channel::Error> {
         self.create_event_with_count(0)
     }
 
@@ -19,7 +19,7 @@ impl<T: LocalControlChannel> BrokerLocal<T> {
     pub fn create_event_with_count(
         &mut self,
         initial_count: u64,
-    ) -> Result<ObjectHandle, T::Error> {
+    ) -> Result<ObjectHandle, Channel::Error> {
         let response =
             self.request_event(EventRequest::Create(CreateEventRequest { initial_count }))?;
         match response {
@@ -31,7 +31,7 @@ impl<T: LocalControlChannel> BrokerLocal<T> {
     }
 
     /// Checks whether an event wait would complete now.
-    pub fn wait_event(&mut self, handle: ObjectHandle) -> Result<ReadinessState, T::Error> {
+    pub fn wait_event(&mut self, handle: ObjectHandle) -> Result<ReadinessState, Channel::Error> {
         let response = self.request_event(EventRequest::Wait(WaitEventRequest { handle }))?;
         match response {
             EventResponse::Wait(response) => Ok(response.readiness),
@@ -46,7 +46,7 @@ impl<T: LocalControlChannel> BrokerLocal<T> {
         &mut self,
         handle: ObjectHandle,
         value: u64,
-    ) -> Result<ReadinessState, T::Error> {
+    ) -> Result<ReadinessState, Channel::Error> {
         let response = self.request_event(EventRequest::Add(AddEventRequest { handle, value }))?;
         match response {
             EventResponse::Add(response) => Ok(response.readiness),
@@ -61,7 +61,7 @@ impl<T: LocalControlChannel> BrokerLocal<T> {
         &mut self,
         handle: ObjectHandle,
         mode: EventConsumeMode,
-    ) -> Result<ConsumeEventResponse, T::Error> {
+    ) -> Result<ConsumeEventResponse, Channel::Error> {
         let response =
             self.request_event(EventRequest::Consume(ConsumeEventRequest { handle, mode }))?;
         match response {
@@ -72,7 +72,7 @@ impl<T: LocalControlChannel> BrokerLocal<T> {
         }
     }
 
-    fn request_event(&mut self, request: EventRequest) -> Result<EventResponse, T::Error> {
+    fn request_event(&mut self, request: EventRequest) -> Result<EventResponse, Channel::Error> {
         let CoreResponse::Event(response) = self.request(CoreRequest::Event(request))?;
         Ok(response)
     }

--- a/litebox_broker_local/src/lib.rs
+++ b/litebox_broker_local/src/lib.rs
@@ -23,18 +23,18 @@ use litebox_broker_protocol::{
 pub use error::{BrokerLocalError, Result};
 
 /// Typed broker-local control adapter for broker operations.
-pub struct BrokerLocal<T> {
-    channel: T,
+pub struct BrokerLocal<Channel: LocalControlChannel> {
+    channel: Channel,
 }
 
-impl<T: LocalControlChannel> BrokerLocal<T> {
+impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
     /// Returns the underlying control channel for deployment-specific configuration.
-    pub fn control_channel_mut(&mut self) -> &mut T {
+    pub fn control_channel_mut(&mut self) -> &mut Channel {
         &mut self.channel
     }
 
     /// Negotiates the broker protocol over an already-connected control channel.
-    pub fn negotiate(mut channel: T) -> Result<Self, T::Error> {
+    pub fn negotiate(mut channel: Channel) -> Result<Self, Channel::Error> {
         let requested = BROKER_PROTOCOL_VERSION;
         match raw_request(
             &mut channel,
@@ -61,7 +61,7 @@ impl<T: LocalControlChannel> BrokerLocal<T> {
     }
 
     /// Sends one active BrokerCore request.
-    pub fn request(&mut self, request: CoreRequest) -> Result<CoreResponse, T::Error> {
+    pub fn request(&mut self, request: CoreRequest) -> Result<CoreResponse, Channel::Error> {
         match raw_request(&mut self.channel, BrokerRequest::Core(request))? {
             BrokerResponse::Core(response) => Ok(response),
             BrokerResponse::Error(error) => Err(BrokerLocalError::Broker(error)),
@@ -70,10 +70,10 @@ impl<T: LocalControlChannel> BrokerLocal<T> {
     }
 }
 
-fn raw_request<T: LocalControlChannel>(
-    channel: &mut T,
+fn raw_request<Channel: LocalControlChannel>(
+    channel: &mut Channel,
     request: BrokerRequest,
-) -> Result<BrokerResponse, T::Error> {
+) -> Result<BrokerResponse, Channel::Error> {
     channel
         .send_request(&request)
         .map_err(BrokerLocalError::Channel)?;

--- a/litebox_runner_linux_userland/tests/run.rs
+++ b/litebox_runner_linux_userland/tests/run.rs
@@ -359,14 +359,14 @@ fn spawn_test_broker(
 }
 
 #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
-struct CountingHostControlChannel<T> {
-    inner: T,
+struct CountingHostControlChannel<Channel: litebox_broker_protocol::HostControlChannel> {
+    inner: Channel,
     event_request_count: usize,
 }
 
 #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
-impl<T> CountingHostControlChannel<T> {
-    const fn new(inner: T) -> Self {
+impl<Channel: litebox_broker_protocol::HostControlChannel> CountingHostControlChannel<Channel> {
+    const fn new(inner: Channel) -> Self {
         Self {
             inner,
             event_request_count: 0,
@@ -379,11 +379,10 @@ impl<T> CountingHostControlChannel<T> {
 }
 
 #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
-impl<T> litebox_broker_protocol::HostControlChannel for CountingHostControlChannel<T>
-where
-    T: litebox_broker_protocol::HostControlChannel,
+impl<Channel: litebox_broker_protocol::HostControlChannel>
+    litebox_broker_protocol::HostControlChannel for CountingHostControlChannel<Channel>
 {
-    type Error = T::Error;
+    type Error = Channel::Error;
 
     fn peer_credential(&self) -> Result<litebox_broker_protocol::PeerCredential, Self::Error> {
         self.inner.peer_credential()


### PR DESCRIPTION
Addresses PR #880 feedback by using descriptive `Channel` generic names for broker channel-bound APIs.

This also moves channel trait bounds onto the broker-local wrapper structs where the type is only usable with those bounds.