### PR TITLE
Treat broker response mismatches as fatal

### DIFF
--- a/litebox/src/broker/error.rs
+++ b/litebox/src/broker/error.rs
@@ -59,9 +59,6 @@ impl<E> From<BrokerLocalError<E>> for BrokerControlError {
         match error {
             BrokerLocalError::Channel(_) | BrokerLocalError::ChannelClosed => Self::Transport,
             BrokerLocalError::Broker(error) => Self::Broker(error),
-            BrokerLocalError::UnexpectedResponse(response) => {
-                panic!("broker returned unexpected response: {response:?}")
-            }
         }
     }
 }

--- a/litebox/src/broker/error.rs
+++ b/litebox/src/broker/error.rs
@@ -14,8 +14,6 @@ pub(crate) enum BrokerControlError {
     Transport,
     #[error("broker returned operation error: {0}")]
     Broker(#[source] ErrorCode),
-    #[error("broker returned unexpected response")]
-    UnexpectedResponse,
 }
 
 /// Internal normalized error for broker-backed object adapters.
@@ -32,8 +30,6 @@ pub(crate) enum BrokerObjectError {
     WouldBlock,
     #[error("broker object resource exhausted")]
     ResourceExhausted,
-    #[error("broker returned unexpected response")]
-    UnexpectedResponse,
     #[error("internal broker object error")]
     Internal,
 }
@@ -43,7 +39,6 @@ impl From<BrokerControlError> for BrokerObjectError {
         match error {
             BrokerControlError::Transport => Self::Control,
             BrokerControlError::Broker(error) => error.into(),
-            BrokerControlError::UnexpectedResponse => Self::UnexpectedResponse,
         }
     }
 }
@@ -64,7 +59,9 @@ impl<E> From<BrokerLocalError<E>> for BrokerControlError {
         match error {
             BrokerLocalError::Channel(_) | BrokerLocalError::ChannelClosed => Self::Transport,
             BrokerLocalError::Broker(error) => Self::Broker(error),
-            BrokerLocalError::UnexpectedResponse(_) => Self::UnexpectedResponse,
+            BrokerLocalError::UnexpectedResponse(response) => {
+                panic!("broker returned unexpected response: {response:?}")
+            }
         }
     }
 }
@@ -83,7 +80,6 @@ impl From<BrokerObjectError> for EventCounterError {
         match error {
             BrokerObjectError::WouldBlock => Self::WouldBlock,
             BrokerObjectError::ResourceExhausted => Self::ResourceExhausted,
-            BrokerObjectError::UnexpectedResponse => Self::UnexpectedResponse,
             BrokerObjectError::Control
             | BrokerObjectError::InvalidObject
             | BrokerObjectError::Internal => Self::Io,

--- a/litebox/src/broker/error.rs
+++ b/litebox/src/broker/error.rs
@@ -30,8 +30,8 @@ pub(crate) enum BrokerObjectError {
     WouldBlock,
     #[error("broker object resource exhausted")]
     ResourceExhausted,
-    #[error("internal broker object error")]
-    Internal,
+    #[error("broker object permission denied")]
+    PermissionDenied,
 }
 
 impl From<BrokerControlError> for BrokerObjectError {
@@ -49,7 +49,13 @@ impl From<ErrorCode> for BrokerObjectError {
             ErrorCode::InvalidRights | ErrorCode::UnknownObject => Self::InvalidObject,
             ErrorCode::WouldBlock => Self::WouldBlock,
             ErrorCode::ResourceExhausted => Self::ResourceExhausted,
-            _ => Self::Internal,
+            ErrorCode::PolicyDenied => Self::PermissionDenied,
+            ErrorCode::UnsupportedVersion
+            | ErrorCode::MalformedRequest
+            | ErrorCode::ProtocolState
+            | ErrorCode::UnsupportedOperation
+            | ErrorCode::Internal => panic!("broker returned unrecoverable error: {error}"),
+            _ => panic!("broker returned unsupported error: {error}"),
         }
     }
 }
@@ -77,9 +83,8 @@ impl From<BrokerObjectError> for EventCounterError {
         match error {
             BrokerObjectError::WouldBlock => Self::WouldBlock,
             BrokerObjectError::ResourceExhausted => Self::ResourceExhausted,
-            BrokerObjectError::Control
-            | BrokerObjectError::InvalidObject
-            | BrokerObjectError::Internal => Self::Io,
+            BrokerObjectError::PermissionDenied => Self::PermissionDenied,
+            BrokerObjectError::Control | BrokerObjectError::InvalidObject => Self::Io,
         }
     }
 }

--- a/litebox/src/event/counter.rs
+++ b/litebox/src/event/counter.rs
@@ -79,11 +79,6 @@ where
     }
 
     /// Reads the event counter.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the broker returns a protocol response that does not match the
-    /// issued event request.
     pub fn read(
         &self,
         cx: &WaitContext<'_, Platform>,
@@ -100,11 +95,6 @@ where
     }
 
     /// Writes readiness credits to the event counter.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the broker returns a protocol response that does not match the
-    /// issued event request.
     pub fn write(
         &self,
         cx: &WaitContext<'_, Platform>,
@@ -165,10 +155,6 @@ where
         self.pollee.register_observer(observer, mask);
     }
 
-    /// # Panics
-    ///
-    /// Panics if the broker returns a protocol response that does not match the
-    /// issued event request.
     fn check_io_events(&self) -> Events {
         let Ok(response) = self.request_event(EventRequest::Wait(WaitEventRequest {
             handle: self.handle,

--- a/litebox/src/event/counter.rs
+++ b/litebox/src/event/counter.rs
@@ -34,8 +34,6 @@ pub enum EventCounterError {
     ResourceExhausted,
     #[error("event counter I/O failed")]
     Io,
-    #[error("event counter received unexpected response")]
-    UnexpectedResponse,
     #[error("event counter backing authority unavailable")]
     Unavailable,
 }
@@ -52,6 +50,11 @@ where
     Platform: RawSyncPrimitivesProvider + TimeProvider,
 {
     /// Creates a local-core event counter.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the broker returns a protocol response that does not match the
+    /// issued event request.
     pub fn new(litebox: &LiteBox<Platform>, initial_count: u64) -> Result<Self, EventCounterError> {
         let Some(broker) = litebox.broker_control() else {
             return Err(EventCounterError::Unavailable);
@@ -64,7 +67,7 @@ where
             .map_err(EventCounterError::from)?;
         let CoreResponse::Event(response) = response;
         let EventResponse::Create(response) = response else {
-            return Err(BrokerObjectError::UnexpectedResponse.into());
+            panic!("broker returned unexpected event response: {response:?}");
         };
         Ok(Self {
             broker,
@@ -74,6 +77,11 @@ where
     }
 
     /// Reads the event counter.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the broker returns a protocol response that does not match the
+    /// issued event request.
     pub fn read(
         &self,
         cx: &WaitContext<'_, Platform>,
@@ -90,6 +98,11 @@ where
     }
 
     /// Writes readiness credits to the event counter.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the broker returns a protocol response that does not match the
+    /// issued event request.
     pub fn write(
         &self,
         cx: &WaitContext<'_, Platform>,
@@ -117,7 +130,7 @@ where
             mode,
         }))?;
         let EventResponse::Consume(response) = response else {
-            return Err(BrokerObjectError::UnexpectedResponse);
+            panic!("broker returned unexpected event response: {response:?}");
         };
         Ok(response)
     }
@@ -128,7 +141,7 @@ where
             value,
         }))?;
         let EventResponse::Add(response) = response else {
-            return Err(BrokerObjectError::UnexpectedResponse);
+            panic!("broker returned unexpected event response: {response:?}");
         };
         Ok(response.readiness)
     }
@@ -150,6 +163,10 @@ where
         self.pollee.register_observer(observer, mask);
     }
 
+    /// # Panics
+    ///
+    /// Panics if the broker returns a protocol response that does not match the
+    /// issued event request.
     fn check_io_events(&self) -> Events {
         let Ok(response) = self.request_event(EventRequest::Wait(WaitEventRequest {
             handle: self.handle,
@@ -157,7 +174,7 @@ where
             return Events::empty();
         };
         let EventResponse::Wait(response) = response else {
-            return Events::empty();
+            panic!("broker returned unexpected event response: {response:?}");
         };
         let readiness = response.readiness;
         let mut events = Events::empty();

--- a/litebox/src/event/counter.rs
+++ b/litebox/src/event/counter.rs
@@ -32,6 +32,8 @@ pub enum EventCounterError {
     WouldBlock,
     #[error("event counter resource exhausted")]
     ResourceExhausted,
+    #[error("event counter permission denied")]
+    PermissionDenied,
     #[error("event counter I/O failed")]
     Io,
     #[error("event counter backing authority unavailable")]

--- a/litebox/src/event/counter.rs
+++ b/litebox/src/event/counter.rs
@@ -55,8 +55,8 @@ where
     ///
     /// # Panics
     ///
-    /// Panics if the broker returns a protocol response that does not match the
-    /// issued event request.
+    /// Panics if the broker reports an unrecoverable error or returns a protocol
+    /// response that does not match the issued event request.
     pub fn new(litebox: &LiteBox<Platform>, initial_count: u64) -> Result<Self, EventCounterError> {
         let Some(broker) = litebox.broker_control() else {
             return Err(EventCounterError::Unavailable);

--- a/litebox_broker_local/src/error.rs
+++ b/litebox_broker_local/src/error.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-use litebox_broker_protocol::{BrokerResponse, ErrorCode};
+use litebox_broker_protocol::ErrorCode;
 use thiserror::Error;
 
 /// Errors returned by active broker-local control requests.
@@ -13,8 +13,6 @@ pub enum BrokerLocalError<E> {
     ChannelClosed,
     #[error("broker rejected request: {0}")]
     Broker(#[source] ErrorCode),
-    #[error("broker returned unexpected response: {0:?}")]
-    UnexpectedResponse(BrokerResponse),
 }
 
 /// Broker-local control adapter result type.

--- a/litebox_broker_local/src/event.rs
+++ b/litebox_broker_local/src/event.rs
@@ -11,11 +11,6 @@ use crate::{BrokerLocal, Result};
 
 impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
     /// Creates a broker-owned event object.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the broker returns a protocol response that does not match the
-    /// issued event request.
     pub fn create_event(&mut self) -> Result<ObjectHandle, Channel::Error> {
         self.create_event_with_count(0)
     }

--- a/litebox_broker_local/src/event.rs
+++ b/litebox_broker_local/src/event.rs
@@ -19,8 +19,8 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
     ///
     /// # Panics
     ///
-    /// Panics if the broker returns a protocol response that does not match the
-    /// issued event request.
+    /// Panics if the broker reports an unrecoverable error or returns a protocol
+    /// response that does not match the issued event request.
     pub fn create_event_with_count(
         &mut self,
         initial_count: u64,
@@ -37,8 +37,8 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
     ///
     /// # Panics
     ///
-    /// Panics if the broker returns a protocol response that does not match the
-    /// issued event request.
+    /// Panics if the broker reports an unrecoverable error or returns a protocol
+    /// response that does not match the issued event request.
     pub fn wait_event(&mut self, handle: ObjectHandle) -> Result<ReadinessState, Channel::Error> {
         let response = self.request_event(EventRequest::Wait(WaitEventRequest { handle }))?;
         match response {
@@ -51,8 +51,8 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
     ///
     /// # Panics
     ///
-    /// Panics if the broker returns a protocol response that does not match the
-    /// issued event request.
+    /// Panics if the broker reports an unrecoverable error or returns a protocol
+    /// response that does not match the issued event request.
     pub fn add_event(
         &mut self,
         handle: ObjectHandle,
@@ -69,8 +69,8 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
     ///
     /// # Panics
     ///
-    /// Panics if the broker returns a protocol response that does not match the
-    /// issued event request.
+    /// Panics if the broker reports an unrecoverable error or returns a protocol
+    /// response that does not match the issued event request.
     pub fn consume_event(
         &mut self,
         handle: ObjectHandle,

--- a/litebox_broker_local/src/event.rs
+++ b/litebox_broker_local/src/event.rs
@@ -2,20 +2,30 @@
 // Licensed under the MIT license.
 
 use litebox_broker_protocol::{
-    AddEventRequest, BrokerResponse, ConsumeEventRequest, ConsumeEventResponse, CoreRequest,
-    CoreResponse, CreateEventRequest, EventConsumeMode, EventRequest, EventResponse,
-    LocalControlChannel, ObjectHandle, ReadinessState, WaitEventRequest,
+    AddEventRequest, ConsumeEventRequest, ConsumeEventResponse, CoreRequest, CoreResponse,
+    CreateEventRequest, EventConsumeMode, EventRequest, EventResponse, LocalControlChannel,
+    ObjectHandle, ReadinessState, WaitEventRequest,
 };
 
-use crate::{BrokerLocal, BrokerLocalError, Result};
+use crate::{BrokerLocal, Result};
 
 impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
     /// Creates a broker-owned event object.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the broker returns a protocol response that does not match the
+    /// issued event request.
     pub fn create_event(&mut self) -> Result<ObjectHandle, Channel::Error> {
         self.create_event_with_count(0)
     }
 
     /// Creates a broker-owned event object with initial readiness credits.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the broker returns a protocol response that does not match the
+    /// issued event request.
     pub fn create_event_with_count(
         &mut self,
         initial_count: u64,
@@ -24,24 +34,30 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
             self.request_event(EventRequest::Create(CreateEventRequest { initial_count }))?;
         match response {
             EventResponse::Create(response) => Ok(response.handle),
-            response => Err(BrokerLocalError::UnexpectedResponse(BrokerResponse::Core(
-                CoreResponse::Event(response),
-            ))),
+            response => panic!("broker returned unexpected event response: {response:?}"),
         }
     }
 
     /// Checks whether an event wait would complete now.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the broker returns a protocol response that does not match the
+    /// issued event request.
     pub fn wait_event(&mut self, handle: ObjectHandle) -> Result<ReadinessState, Channel::Error> {
         let response = self.request_event(EventRequest::Wait(WaitEventRequest { handle }))?;
         match response {
             EventResponse::Wait(response) => Ok(response.readiness),
-            response => Err(BrokerLocalError::UnexpectedResponse(BrokerResponse::Core(
-                CoreResponse::Event(response),
-            ))),
+            response => panic!("broker returned unexpected event response: {response:?}"),
         }
     }
 
     /// Adds readiness credits to a broker-owned event object.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the broker returns a protocol response that does not match the
+    /// issued event request.
     pub fn add_event(
         &mut self,
         handle: ObjectHandle,
@@ -50,13 +66,16 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
         let response = self.request_event(EventRequest::Add(AddEventRequest { handle, value }))?;
         match response {
             EventResponse::Add(response) => Ok(response.readiness),
-            response => Err(BrokerLocalError::UnexpectedResponse(BrokerResponse::Core(
-                CoreResponse::Event(response),
-            ))),
+            response => panic!("broker returned unexpected event response: {response:?}"),
         }
     }
 
     /// Consumes readiness credits from a broker-owned event object.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the broker returns a protocol response that does not match the
+    /// issued event request.
     pub fn consume_event(
         &mut self,
         handle: ObjectHandle,
@@ -66,9 +85,7 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
             self.request_event(EventRequest::Consume(ConsumeEventRequest { handle, mode }))?;
         match response {
             EventResponse::Consume(response) => Ok(response),
-            response => Err(BrokerLocalError::UnexpectedResponse(BrokerResponse::Core(
-                CoreResponse::Event(response),
-            ))),
+            response => panic!("broker returned unexpected event response: {response:?}"),
         }
     }
 

--- a/litebox_broker_local/src/lib.rs
+++ b/litebox_broker_local/src/lib.rs
@@ -34,6 +34,11 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
     }
 
     /// Negotiates the broker protocol over an already-connected control channel.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the broker returns a protocol response that does not match the
+    /// negotiation request.
     pub fn negotiate(mut channel: Channel) -> Result<Self, Channel::Error> {
         let requested = BROKER_PROTOCOL_VERSION;
         match raw_request(
@@ -45,9 +50,10 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
             response @ BrokerResponse::Negotiated {
                 broker_protocol_version,
             } => {
-                if requested != broker_protocol_version {
-                    return Err(BrokerLocalError::UnexpectedResponse(response));
-                }
+                assert_eq!(
+                    requested, broker_protocol_version,
+                    "broker returned unexpected negotiation response: {response:?}"
+                );
                 Ok(Self { channel })
             }
             BrokerResponse::VersionMismatch { .. } => {
@@ -55,17 +61,22 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
             }
             BrokerResponse::Error(error) => Err(BrokerLocalError::Broker(error)),
             response @ BrokerResponse::Core(_) => {
-                Err(BrokerLocalError::UnexpectedResponse(response))
+                panic!("broker returned unexpected negotiation response: {response:?}")
             }
         }
     }
 
     /// Sends one active BrokerCore request.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the broker returns a protocol response that does not match an
+    /// active core request.
     pub fn request(&mut self, request: CoreRequest) -> Result<CoreResponse, Channel::Error> {
         match raw_request(&mut self.channel, BrokerRequest::Core(request))? {
             BrokerResponse::Core(response) => Ok(response),
             BrokerResponse::Error(error) => Err(BrokerLocalError::Broker(error)),
-            response => Err(BrokerLocalError::UnexpectedResponse(response)),
+            response => panic!("broker returned unexpected active response: {response:?}"),
         }
     }
 }
@@ -125,18 +136,14 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "broker returned unexpected negotiation response")]
     fn negotiate_rejects_broker_different_version_response() {
         let broker_protocol_version = ProtocolVersion(BROKER_PROTOCOL_VERSION.0 + 1);
         let channel = FakeControlChannel::new(Some(BrokerResponse::Negotiated {
             broker_protocol_version,
         }));
 
-        assert!(matches!(
-            BrokerLocal::negotiate(channel),
-            Err(BrokerLocalError::UnexpectedResponse(BrokerResponse::Negotiated {
-                broker_protocol_version: broker
-            })) if broker == broker_protocol_version
-        ));
+        let _ = BrokerLocal::negotiate(channel);
     }
 
     #[test]

--- a/litebox_broker_local/src/lib.rs
+++ b/litebox_broker_local/src/lib.rs
@@ -37,8 +37,8 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
     ///
     /// # Panics
     ///
-    /// Panics if the broker returns a protocol response that does not match the
-    /// negotiation request.
+    /// Panics if the broker reports an unrecoverable error or returns a protocol
+    /// response that does not match the negotiation request.
     pub fn negotiate(mut channel: Channel) -> Result<Self, Channel::Error> {
         let requested = BROKER_PROTOCOL_VERSION;
         match raw_request(
@@ -59,7 +59,16 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
             BrokerResponse::VersionMismatch { .. } => {
                 Err(BrokerLocalError::Broker(ErrorCode::UnsupportedVersion))
             }
-            BrokerResponse::Error(error) => Err(BrokerLocalError::Broker(error)),
+            BrokerResponse::Error(error) => match error {
+                ErrorCode::UnsupportedVersion | ErrorCode::PolicyDenied => {
+                    Err(BrokerLocalError::Broker(error))
+                }
+                ErrorCode::MalformedRequest
+                | ErrorCode::ProtocolState
+                | ErrorCode::UnsupportedOperation
+                | ErrorCode::Internal => panic!("broker returned unrecoverable error: {error}"),
+                _ => panic!("broker returned unexpected negotiation error: {error}"),
+            },
             response @ BrokerResponse::Core(_) => {
                 panic!("broker returned unexpected negotiation response: {response:?}")
             }
@@ -70,12 +79,24 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
     ///
     /// # Panics
     ///
-    /// Panics if the broker returns a protocol response that does not match an
-    /// active core request.
+    /// Panics if the broker reports an unrecoverable error or returns a protocol
+    /// response that does not match an active core request.
     pub fn request(&mut self, request: CoreRequest) -> Result<CoreResponse, Channel::Error> {
         match raw_request(&mut self.channel, BrokerRequest::Core(request))? {
             BrokerResponse::Core(response) => Ok(response),
-            BrokerResponse::Error(error) => Err(BrokerLocalError::Broker(error)),
+            BrokerResponse::Error(error) => match error {
+                ErrorCode::PolicyDenied
+                | ErrorCode::UnknownObject
+                | ErrorCode::InvalidRights
+                | ErrorCode::ResourceExhausted
+                | ErrorCode::WouldBlock => Err(BrokerLocalError::Broker(error)),
+                ErrorCode::UnsupportedVersion
+                | ErrorCode::MalformedRequest
+                | ErrorCode::ProtocolState
+                | ErrorCode::UnsupportedOperation
+                | ErrorCode::Internal => panic!("broker returned unrecoverable error: {error}"),
+                _ => panic!("broker returned unsupported error: {error}"),
+            },
             response => panic!("broker returned unexpected active response: {response:?}"),
         }
     }
@@ -136,6 +157,32 @@ mod tests {
     }
 
     #[test]
+    fn active_request_returns_recoverable_broker_error() {
+        let request = CoreRequest::Event(EventRequest::Create(CreateEventRequest {
+            initial_count: 0,
+        }));
+        let channel = FakeControlChannel::new(Some(BrokerResponse::Error(ErrorCode::WouldBlock)));
+        let mut local = BrokerLocal { channel };
+
+        assert!(matches!(
+            local.request(request),
+            Err(BrokerLocalError::Broker(ErrorCode::WouldBlock))
+        ));
+    }
+
+    #[test]
+    #[should_panic(expected = "broker returned unrecoverable error")]
+    fn active_request_panics_on_unrecoverable_broker_error() {
+        let request = CoreRequest::Event(EventRequest::Create(CreateEventRequest {
+            initial_count: 0,
+        }));
+        let channel = FakeControlChannel::new(Some(BrokerResponse::Error(ErrorCode::Internal)));
+        let mut local = BrokerLocal { channel };
+
+        let _ = local.request(request);
+    }
+
+    #[test]
     #[should_panic(expected = "broker returned unexpected negotiation response")]
     fn negotiate_rejects_broker_different_version_response() {
         let broker_protocol_version = ProtocolVersion(BROKER_PROTOCOL_VERSION.0 + 1);
@@ -157,6 +204,14 @@ mod tests {
             BrokerLocal::negotiate(channel),
             Err(BrokerLocalError::Broker(ErrorCode::UnsupportedVersion))
         ));
+    }
+
+    #[test]
+    #[should_panic(expected = "broker returned unrecoverable error")]
+    fn negotiate_panics_on_unrecoverable_broker_error() {
+        let channel = FakeControlChannel::new(Some(BrokerResponse::Error(ErrorCode::Internal)));
+
+        let _ = BrokerLocal::negotiate(channel);
     }
 
     struct FakeControlChannel {

--- a/litebox_common_linux/src/errno/mod.rs
+++ b/litebox_common_linux/src/errno/mod.rs
@@ -542,6 +542,7 @@ impl From<litebox::event::counter::EventCounterError> for Errno {
             litebox::event::counter::EventCounterError::InvalidInput => Errno::EINVAL,
             litebox::event::counter::EventCounterError::WouldBlock
             | litebox::event::counter::EventCounterError::ResourceExhausted => Errno::EAGAIN,
+            litebox::event::counter::EventCounterError::PermissionDenied => Errno::EACCES,
             litebox::event::counter::EventCounterError::Io
             | litebox::event::counter::EventCounterError::Unavailable => Errno::EIO,
             _ => Errno::EIO,

--- a/litebox_common_linux/src/errno/mod.rs
+++ b/litebox_common_linux/src/errno/mod.rs
@@ -543,7 +543,6 @@ impl From<litebox::event::counter::EventCounterError> for Errno {
             litebox::event::counter::EventCounterError::WouldBlock
             | litebox::event::counter::EventCounterError::ResourceExhausted => Errno::EAGAIN,
             litebox::event::counter::EventCounterError::Io
-            | litebox::event::counter::EventCounterError::UnexpectedResponse
             | litebox::event::counter::EventCounterError::Unavailable => Errno::EIO,
             _ => Errno::EIO,
         }


### PR DESCRIPTION
This PR removes `UnexpectedResponse` errors from the local-core and broker-local layers and panics when the broker violates request/response protocol invariants since there is no sensible recovery path for these errors.