### PR TITLE
Clean up broker module imports

### DIFF
--- a/litebox_broker_core/src/session.rs
+++ b/litebox_broker_core/src/session.rs
@@ -179,7 +179,6 @@ impl Drop for BrokerSession {
 mod tests {
     use crate::{
         BrokerCore, BrokerCoreLimits, BrokerError, CallerCredential, PolicyEngine, PrincipalRights,
-        event,
     };
     use litebox_broker_protocol::{
         EventConsumeMode, EventConsumption, ObjectHandle, ReadinessState,
@@ -198,12 +197,12 @@ mod tests {
         let other = broker
             .create_session(CallerCredential::Unauthenticated)
             .unwrap();
-        let handle = event::create(&session, 0).unwrap();
+        let handle = crate::event::create(&session, 0).unwrap();
         let unknown_handle = ObjectHandle(handle.0 + 1);
 
         assert_ne!(unknown_handle, handle);
         assert_eq!(
-            event::wait(&session, unknown_handle),
+            crate::event::wait(&session, unknown_handle),
             Err(BrokerError::UnknownObject)
         );
 
@@ -213,21 +212,21 @@ mod tests {
         );
 
         assert_eq!(
-            event::wait(&session, handle),
+            crate::event::wait(&session, handle),
             Ok(ReadinessState {
                 read_ready: false,
                 write_ready: true,
             })
         );
         assert_eq!(
-            event::add(&session, handle, 1),
+            crate::event::add(&session, handle, 1),
             Ok(ReadinessState {
                 read_ready: true,
                 write_ready: true,
             })
         );
         assert_eq!(
-            event::consume(&session, handle, EventConsumeMode::One),
+            crate::event::consume(&session, handle, EventConsumeMode::One),
             Ok(EventConsumption {
                 value: 1,
                 readiness: ReadinessState {
@@ -237,7 +236,7 @@ mod tests {
             })
         );
         assert_eq!(
-            event::create(&session, 0),
+            crate::event::create(&session, 0),
             Err(BrokerError::ResourceExhausted)
         );
 
@@ -254,7 +253,7 @@ mod tests {
         let session = broker
             .create_session(CallerCredential::Unauthenticated)
             .unwrap();
-        let _handle = event::create(&session, 0).unwrap();
+        let _handle = crate::event::create(&session, 0).unwrap();
         {
             let references = broker.references.read();
             assert_eq!(references.len(), 1);
@@ -275,7 +274,7 @@ mod tests {
             *next_reference_handle = u64::MAX;
         }
         assert_eq!(
-            event::create(&session, 0),
+            crate::event::create(&session, 0),
             Err(BrokerError::ResourceExhausted)
         );
         let references = broker.references.read();

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -12,9 +12,9 @@
 #[cfg(test)]
 extern crate std;
 
-use core::fmt;
+use core::fmt::{Display, Formatter, Result as FmtResult};
 
-use litebox_broker_core::{BrokerCore, BrokerSession, CallerCredential, event};
+use litebox_broker_core::{BrokerCore, BrokerSession, CallerCredential};
 use litebox_broker_protocol::{
     AddEventResponse, BROKER_PROTOCOL_VERSION, BrokerRequest, BrokerResponse, CoreRequest,
     CoreResponse, CreateEventResponse, ErrorCode, EventRequest, EventResponse, HostControlChannel,
@@ -119,20 +119,24 @@ fn handle_active_request(session: &BrokerSession, request: BrokerRequest) -> Bro
 
 fn handle_event_request(session: &BrokerSession, request: EventRequest) -> BrokerResponse {
     match request {
-        EventRequest::Create(request) => match event::create(session, request.initial_count) {
-            Ok(handle) => BrokerResponse::Core(CoreResponse::Event(EventResponse::Create(
-                CreateEventResponse { handle },
-            ))),
-            Err(error) => BrokerResponse::Error(error.into()),
-        },
-        EventRequest::Wait(request) => match event::wait(session, request.handle) {
-            Ok(readiness) => BrokerResponse::Core(CoreResponse::Event(EventResponse::Wait(
-                WaitEventResponse { readiness },
-            ))),
-            Err(error) => BrokerResponse::Error(error.into()),
-        },
+        EventRequest::Create(request) => {
+            match litebox_broker_core::event::create(session, request.initial_count) {
+                Ok(handle) => BrokerResponse::Core(CoreResponse::Event(EventResponse::Create(
+                    CreateEventResponse { handle },
+                ))),
+                Err(error) => BrokerResponse::Error(error.into()),
+            }
+        }
+        EventRequest::Wait(request) => {
+            match litebox_broker_core::event::wait(session, request.handle) {
+                Ok(readiness) => BrokerResponse::Core(CoreResponse::Event(EventResponse::Wait(
+                    WaitEventResponse { readiness },
+                ))),
+                Err(error) => BrokerResponse::Error(error.into()),
+            }
+        }
         EventRequest::Add(request) => {
-            match event::add(session, request.handle, request.value) {
+            match litebox_broker_core::event::add(session, request.handle, request.value) {
                 Ok(readiness) => BrokerResponse::Core(CoreResponse::Event(EventResponse::Add(
                     AddEventResponse { readiness },
                 ))),
@@ -140,7 +144,7 @@ fn handle_event_request(session: &BrokerSession, request: EventRequest) -> Broke
             }
         }
         EventRequest::Consume(request) => {
-            match event::consume(session, request.handle, request.mode) {
+            match litebox_broker_core::event::consume(session, request.handle, request.mode) {
                 Ok(consumption) => {
                     BrokerResponse::Core(CoreResponse::Event(EventResponse::Consume(consumption)))
                 }
@@ -176,8 +180,8 @@ pub enum CloseReason {
     ProtocolViolation,
 }
 
-impl fmt::Display for CloseReason {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl Display for CloseReason {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
             Self::ProtocolViolation => f.write_str("protocol violation"),
         }

--- a/litebox_broker_protocol/src/wire/core_message.rs
+++ b/litebox_broker_protocol/src/wire/core_message.rs
@@ -4,7 +4,6 @@
 use crate::{CoreRequest, CoreResponse};
 
 use super::WireError;
-use super::event;
 use super::primitive::{Decoder, Encoder};
 
 // Core tags select object-family codecs. Add new object families here, then
@@ -16,14 +15,14 @@ pub(super) fn encode_core_request(encoder: &mut Encoder, request: CoreRequest) {
     match request {
         CoreRequest::Event(request) => {
             encoder.u8(CORE_REQUEST_TAG_EVENT);
-            event::encode_event_request(encoder, request);
+            super::event::encode_event_request(encoder, request);
         }
     }
 }
 
 pub(super) fn decode_core_request(decoder: &mut Decoder<'_>) -> Result<CoreRequest, WireError> {
     let request = match decoder.u8()? {
-        CORE_REQUEST_TAG_EVENT => CoreRequest::Event(event::decode_event_request(decoder)?),
+        CORE_REQUEST_TAG_EVENT => CoreRequest::Event(super::event::decode_event_request(decoder)?),
         _ => return Err(WireError::InvalidTag),
     };
 
@@ -34,14 +33,16 @@ pub(super) fn encode_core_response(encoder: &mut Encoder, response: CoreResponse
     match response {
         CoreResponse::Event(response) => {
             encoder.u8(CORE_RESPONSE_TAG_EVENT);
-            event::encode_event_response(encoder, response);
+            super::event::encode_event_response(encoder, response);
         }
     }
 }
 
 pub(super) fn decode_core_response(decoder: &mut Decoder<'_>) -> Result<CoreResponse, WireError> {
     let response = match decoder.u8()? {
-        CORE_RESPONSE_TAG_EVENT => CoreResponse::Event(event::decode_event_response(decoder)?),
+        CORE_RESPONSE_TAG_EVENT => {
+            CoreResponse::Event(super::event::decode_event_response(decoder)?)
+        }
         _ => return Err(WireError::InvalidTag),
     };
 

--- a/litebox_broker_transport/src/unix_socket.rs
+++ b/litebox_broker_transport/src/unix_socket.rs
@@ -7,7 +7,7 @@
 //! framing are hosted userland concerns. Portable broker interfaces live in the
 //! no_std protocol, local, core, and host crates.
 
-use std::io::{self, Read, Write};
+use std::io::{Error, ErrorKind, Read, Result as IoResult, Write};
 use std::os::unix::net::UnixStream;
 use std::path::Path;
 use std::time::{Duration, Instant};
@@ -41,12 +41,12 @@ impl UnixStreamLocalControlChannel {
     }
 
     /// Connects to a userland broker Unix socket.
-    pub fn connect(path: impl AsRef<Path>) -> io::Result<Self> {
+    pub fn connect(path: impl AsRef<Path>) -> IoResult<Self> {
         UnixStream::connect(path).map(Self::from_connected)
     }
 
     /// Sets the read and write timeout for broker control-channel operations.
-    pub fn set_io_timeout(&mut self, timeout: Option<Duration>) -> io::Result<()> {
+    pub fn set_io_timeout(&mut self, timeout: Option<Duration>) -> IoResult<()> {
         self.io_timeout = timeout;
         self.io_deadline = None;
         self.active_request_deadline = None;
@@ -54,7 +54,7 @@ impl UnixStreamLocalControlChannel {
     }
 
     /// Sets a wall-clock deadline for broker control-channel operations.
-    pub fn set_io_deadline(&mut self, deadline: Option<Instant>) -> io::Result<()> {
+    pub fn set_io_deadline(&mut self, deadline: Option<Instant>) -> IoResult<()> {
         self.io_deadline = deadline;
         self.active_request_deadline = None;
         match deadline {
@@ -63,12 +63,12 @@ impl UnixStreamLocalControlChannel {
         }
     }
 
-    fn set_stream_io_timeout(&self, timeout: Option<Duration>) -> io::Result<()> {
+    fn set_stream_io_timeout(&self, timeout: Option<Duration>) -> IoResult<()> {
         self.stream.set_read_timeout(timeout)?;
         self.stream.set_write_timeout(timeout)
     }
 
-    fn current_deadline(&mut self) -> io::Result<Option<Instant>> {
+    fn current_deadline(&mut self) -> IoResult<Option<Instant>> {
         if let Some(deadline) = self.io_deadline {
             return Ok(Some(deadline));
         }
@@ -83,7 +83,7 @@ impl UnixStreamLocalControlChannel {
         Ok(Some(deadline))
     }
 
-    fn clear_active_request_deadline(&mut self) -> io::Result<()> {
+    fn clear_active_request_deadline(&mut self) -> IoResult<()> {
         if self.io_deadline.is_none() {
             self.active_request_deadline = None;
             self.set_stream_io_timeout(self.io_timeout)?;
@@ -108,7 +108,7 @@ impl UnixStreamHostControlChannel {
     }
 
     /// Sets a wall-clock deadline for all broker control-channel operations.
-    pub fn set_io_deadline(&mut self, deadline: Option<Instant>) -> io::Result<()> {
+    pub fn set_io_deadline(&mut self, deadline: Option<Instant>) -> IoResult<()> {
         self.io_deadline = deadline;
         if let Some(deadline) = deadline {
             let timeout = io_timeout_for_deadline(deadline)?;
@@ -122,9 +122,9 @@ impl UnixStreamHostControlChannel {
 }
 
 impl LocalControlChannel for UnixStreamLocalControlChannel {
-    type Error = io::Error;
+    type Error = Error;
 
-    fn send_request(&mut self, request: &BrokerRequest) -> io::Result<()> {
+    fn send_request(&mut self, request: &BrokerRequest) -> IoResult<()> {
         let frame = encode_request(request.clone());
         let deadline = self.current_deadline()?;
         let result = write_frame_with_deadline(&mut self.stream, &frame, deadline);
@@ -134,7 +134,7 @@ impl LocalControlChannel for UnixStreamLocalControlChannel {
         result
     }
 
-    fn recv_response(&mut self) -> io::Result<Option<BrokerResponse>> {
+    fn recv_response(&mut self) -> IoResult<Option<BrokerResponse>> {
         let deadline = self.current_deadline()?;
         let result = match read_frame_with_deadline(&mut self.stream, deadline)? {
             Some(frame) => decode_response(&frame).map(Some).map_err(wire_error),
@@ -146,22 +146,22 @@ impl LocalControlChannel for UnixStreamLocalControlChannel {
 }
 
 impl HostControlChannel for UnixStreamHostControlChannel {
-    type Error = io::Error;
+    type Error = Error;
 
-    fn peer_credential(&self) -> io::Result<PeerCredential> {
+    fn peer_credential(&self) -> IoResult<PeerCredential> {
         // TODO(broker): replace the PoC placeholder with Unix peer credential extraction
         // before this channel is used as an authenticated deployment boundary.
         Ok(PeerCredential::Unauthenticated)
     }
 
-    fn recv_request(&mut self) -> io::Result<Option<BrokerRequest>> {
+    fn recv_request(&mut self) -> IoResult<Option<BrokerRequest>> {
         let Some(frame) = read_frame_with_deadline(&mut self.stream, self.io_deadline)? else {
             return Ok(None);
         };
         decode_request(&frame).map(Some).map_err(wire_error)
     }
 
-    fn send_response(&mut self, response: &BrokerResponse) -> io::Result<()> {
+    fn send_response(&mut self, response: &BrokerResponse) -> IoResult<()> {
         write_frame_with_deadline(
             &mut self.stream,
             &encode_response(response.clone()),
@@ -173,7 +173,7 @@ impl HostControlChannel for UnixStreamHostControlChannel {
 fn read_frame_with_deadline(
     stream: &mut UnixStream,
     deadline: Option<Instant>,
-) -> io::Result<Option<Vec<u8>>> {
+) -> IoResult<Option<Vec<u8>>> {
     let mut len_buf = [0; 4];
     let mut read = 0;
     while read < len_buf.len() {
@@ -182,7 +182,7 @@ fn read_frame_with_deadline(
             Ok(0) if read == 0 => return Ok(None),
             Ok(0) => return Err(invalid_data("truncated broker frame length")),
             Ok(len) => read += len,
-            Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
+            Err(error) if error.kind() == ErrorKind::Interrupted => {}
             Err(error) => return Err(error),
         }
     }
@@ -199,7 +199,7 @@ fn read_frame_with_deadline(
         match stream.read(&mut frame[read..]) {
             Ok(0) => return Err(invalid_data("truncated broker frame")),
             Ok(len) => read += len,
-            Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
+            Err(error) if error.kind() == ErrorKind::Interrupted => {}
             Err(error) => return Err(error),
         }
     }
@@ -210,7 +210,7 @@ fn write_frame_with_deadline(
     stream: &mut UnixStream,
     frame: &[u8],
     deadline: Option<Instant>,
-) -> io::Result<()> {
+) -> IoResult<()> {
     if frame.is_empty() || frame.len() > MAX_FRAME_LEN {
         return Err(invalid_data("invalid broker frame length"));
     }
@@ -223,25 +223,25 @@ fn write_all_with_deadline(
     stream: &mut UnixStream,
     mut buffer: &[u8],
     deadline: Option<Instant>,
-) -> io::Result<()> {
+) -> IoResult<()> {
     while !buffer.is_empty() {
         refresh_stream_io_deadline(stream, deadline)?;
         match stream.write(buffer) {
             Ok(0) => {
-                return Err(io::Error::new(
-                    io::ErrorKind::WriteZero,
+                return Err(Error::new(
+                    ErrorKind::WriteZero,
                     "failed to write broker frame",
                 ));
             }
             Ok(written) => buffer = &buffer[written..],
-            Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
+            Err(error) if error.kind() == ErrorKind::Interrupted => {}
             Err(error) => return Err(error),
         }
     }
     Ok(())
 }
 
-fn refresh_stream_io_deadline(stream: &UnixStream, deadline: Option<Instant>) -> io::Result<()> {
+fn refresh_stream_io_deadline(stream: &UnixStream, deadline: Option<Instant>) -> IoResult<()> {
     if let Some(deadline) = deadline {
         let timeout = io_timeout_for_deadline(deadline)?;
         stream.set_read_timeout(Some(timeout))?;
@@ -250,27 +250,27 @@ fn refresh_stream_io_deadline(stream: &UnixStream, deadline: Option<Instant>) ->
     Ok(())
 }
 
-fn io_timeout_for_deadline(deadline: Instant) -> io::Result<Duration> {
+fn io_timeout_for_deadline(deadline: Instant) -> IoResult<Duration> {
     let timeout = deadline
         .checked_duration_since(Instant::now())
         .filter(|timeout| !timeout.is_zero())
-        .ok_or_else(|| io::Error::new(io::ErrorKind::TimedOut, "broker I/O deadline expired"))?;
+        .ok_or_else(|| Error::new(ErrorKind::TimedOut, "broker I/O deadline expired"))?;
     Ok(timeout)
 }
 
-fn deadline_after(timeout: Duration) -> io::Result<Instant> {
+fn deadline_after(timeout: Duration) -> IoResult<Instant> {
     Instant::now()
         .checked_add(timeout)
-        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "broker I/O timeout overflow"))
+        .ok_or_else(|| Error::new(ErrorKind::InvalidInput, "broker I/O timeout overflow"))
 }
 
-fn invalid_data(message: &'static str) -> io::Error {
-    io::Error::new(io::ErrorKind::InvalidData, message)
+fn invalid_data(message: &'static str) -> Error {
+    Error::new(ErrorKind::InvalidData, message)
 }
 
-fn wire_error(error: WireError) -> io::Error {
-    io::Error::new(
-        io::ErrorKind::InvalidData,
+fn wire_error(error: WireError) -> Error {
+    Error::new(
+        ErrorKind::InvalidData,
         format!("invalid broker wire message: {error}"),
     )
 }
@@ -313,7 +313,7 @@ mod tests {
             read_frame_with_deadline(&mut reader, None)
                 .unwrap_err()
                 .kind(),
-            io::ErrorKind::InvalidData
+            ErrorKind::InvalidData
         );
 
         let (mut writer, mut reader) = UnixStream::pair().unwrap();
@@ -322,7 +322,7 @@ mod tests {
             read_frame_with_deadline(&mut reader, None)
                 .unwrap_err()
                 .kind(),
-            io::ErrorKind::InvalidData
+            ErrorKind::InvalidData
         );
 
         let (mut writer, mut reader) = UnixStream::pair().unwrap();
@@ -333,7 +333,7 @@ mod tests {
             read_frame_with_deadline(&mut reader, None)
                 .unwrap_err()
                 .kind(),
-            io::ErrorKind::InvalidData
+            ErrorKind::InvalidData
         );
 
         let (mut writer, mut reader) = UnixStream::pair().unwrap();
@@ -344,7 +344,7 @@ mod tests {
             read_frame_with_deadline(&mut reader, None)
                 .unwrap_err()
                 .kind(),
-            io::ErrorKind::InvalidData
+            ErrorKind::InvalidData
         );
     }
 
@@ -367,10 +367,7 @@ mod tests {
 
         let error = reader.join().expect("timeout reader panicked");
         assert!(
-            matches!(
-                error.kind(),
-                io::ErrorKind::WouldBlock | io::ErrorKind::TimedOut
-            ),
+            matches!(error.kind(), ErrorKind::WouldBlock | ErrorKind::TimedOut),
             "unexpected timeout error kind: {error:?}"
         );
     }

--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -6,7 +6,6 @@ use std::ffi::OsString;
 use std::os::unix::net::UnixListener;
 use std::path::PathBuf;
 use std::process::Command;
-use std::thread;
 
 use clap::Parser;
 use litebox_broker_core::{BrokerCore, PolicyEngine, PrincipalRights};
@@ -41,7 +40,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .arg(&socket_path)
         .args(&args.runner_arguments);
     let mut runner = runner_command.spawn()?;
-    let _runner_waiter = thread::spawn(move || {
+    let _runner_waiter = std::thread::spawn(move || {
         if let Err(error) = runner.wait() {
             eprintln!("failed to wait for local runner: {error}");
         }

--- a/litebox_broker_userland/tests/userland_broker.rs
+++ b/litebox_broker_userland/tests/userland_broker.rs
@@ -1,13 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-use std::env;
 use std::ffi::{OsStr, OsString};
-use std::io;
+use std::io::{Error, ErrorKind, Result};
 use std::os::unix::process::ExitStatusExt;
 use std::path::Path;
 use std::process::{Child, Command};
-use std::thread;
 use std::time::{Duration, Instant};
 
 use litebox_broker_local::BrokerLocal;
@@ -17,7 +15,7 @@ use litebox_broker_transport::unix_socket::UnixStreamLocalControlChannel;
 const RUNNER_ARGUMENT: &str = "broker-userland-test-runner";
 
 fn main() {
-    let args = env::args_os().skip(1).collect::<Vec<_>>();
+    let args = std::env::args_os().skip(1).collect::<Vec<_>>();
     if args
         .first()
         .is_some_and(|arg| arg == OsStr::new("--unstable"))
@@ -39,7 +37,7 @@ fn run_parent_test() {
     let mut broker = ChildGuard {
         child: Command::new(env!("CARGO_BIN_EXE_litebox-broker-userland"))
             .arg("--runner")
-            .arg(env::current_exe().unwrap())
+            .arg(std::env::current_exe().unwrap())
             .arg(RUNNER_ARGUMENT)
             .spawn()
             .unwrap(),
@@ -51,7 +49,7 @@ fn run_parent_test() {
             assert_eq!(status.signal(), Some(libc::SIGTERM));
             return;
         }
-        thread::sleep(Duration::from_millis(10));
+        std::thread::sleep(Duration::from_millis(10));
     }
     panic!("timed out waiting for broker to stop");
 }
@@ -112,7 +110,7 @@ fn run_fake_runner(args: &[OsString]) {
         kill_result,
         0,
         "failed to stop broker: {}",
-        io::Error::last_os_error()
+        Error::last_os_error()
     );
 }
 
@@ -129,18 +127,18 @@ impl Drop for ChildGuard {
     }
 }
 
-fn connect_with_retry(socket_path: &Path) -> io::Result<UnixStreamLocalControlChannel> {
+fn connect_with_retry(socket_path: &Path) -> Result<UnixStreamLocalControlChannel> {
     let deadline = Instant::now() + Duration::from_secs(5);
     loop {
         match UnixStreamLocalControlChannel::connect(socket_path) {
             Ok(channel) => return Ok(channel),
             Err(error) if Instant::now() < deadline => {
-                if error.kind() != io::ErrorKind::NotFound
-                    && error.kind() != io::ErrorKind::ConnectionRefused
+                if error.kind() != ErrorKind::NotFound
+                    && error.kind() != ErrorKind::ConnectionRefused
                 {
                     return Err(error);
                 }
-                thread::sleep(Duration::from_millis(10));
+                std::thread::sleep(Duration::from_millis(10));
             }
             Err(error) => return Err(error),
         }

--- a/litebox_runner_linux_userland/src/broker.rs
+++ b/litebox_runner_linux_userland/src/broker.rs
@@ -3,7 +3,6 @@
 
 use std::{
     path::Path,
-    thread,
     time::{Duration, Instant},
 };
 
@@ -61,6 +60,6 @@ fn connect_with_retry(socket_path: &Path, setup_deadline: Instant) -> Result<Loc
             }
         }
         let remaining = setup_deadline.saturating_duration_since(Instant::now());
-        thread::sleep(RETRY_DELAY.min(remaining));
+        std::thread::sleep(RETRY_DELAY.min(remaining));
     }
 }


### PR DESCRIPTION
This PR cleans up broker-related imports to avoid directly importing modules such as `std::env`, `std::thread`, `std::io`, and broker `event` modules. It switches affected code to direct type/trait/const imports or explicit fully-qualified paths, improving readability without changing behavior.