### PR TITLE
Avoid broker socket timeout syscalls

### DIFF
--- a/litebox_broker_transport/src/unix_socket.rs
+++ b/litebox_broker_transport/src/unix_socket.rs
@@ -82,13 +82,6 @@ impl UnixStreamLocalControlChannel {
         self.active_request_deadline = Some(deadline);
         Ok(Some(deadline))
     }
-
-    fn clear_active_request_deadline(&mut self) -> IoResult<()> {
-        if self.io_deadline.is_none() && self.active_request_deadline.take().is_some() {
-            self.set_stream_io_timeout(self.io_timeout)?;
-        }
-        Ok(())
-    }
 }
 
 /// Host-side Unix-domain-socket control channel for the hosted userland POC.
@@ -139,7 +132,9 @@ impl LocalControlChannel for UnixStreamLocalControlChannel {
             Some(frame) => decode_response(&frame).map(Some).map_err(wire_error),
             None => Ok(None),
         };
-        self.clear_active_request_deadline()?;
+        if self.io_deadline.is_none() && self.active_request_deadline.take().is_some() {
+            self.set_stream_io_timeout(self.io_timeout)?;
+        }
         result
     }
 }

--- a/litebox_broker_transport/src/unix_socket.rs
+++ b/litebox_broker_transport/src/unix_socket.rs
@@ -84,8 +84,7 @@ impl UnixStreamLocalControlChannel {
     }
 
     fn clear_active_request_deadline(&mut self) -> IoResult<()> {
-        if self.io_deadline.is_none() {
-            self.active_request_deadline = None;
+        if self.io_deadline.is_none() && self.active_request_deadline.take().is_some() {
             self.set_stream_io_timeout(self.io_timeout)?;
         }
         Ok(())

--- a/litebox_platform_linux_userland/src/lib.rs
+++ b/litebox_platform_linux_userland/src/lib.rs
@@ -481,48 +481,6 @@ impl LinuxUserland {
                     .unwrap(),
                 ],
             ),
-            // Broker control-channel I/O runs through a host Unix socket in the
-            // current POC. The transport refreshes read/write timeouts around
-            // each request.
-            (
-                libc::SYS_setsockopt,
-                vec![
-                    SeccompRule::new(vec![
-                        SeccompCondition::new(
-                            1,
-                            SeccompCmpArgLen::Dword,
-                            SeccompCmpOp::Eq,
-                            libc::SOL_SOCKET as u64,
-                        )
-                        .unwrap(),
-                        SeccompCondition::new(
-                            2,
-                            SeccompCmpArgLen::Dword,
-                            SeccompCmpOp::Eq,
-                            libc::SO_RCVTIMEO as u64,
-                        )
-                        .unwrap(),
-                    ])
-                    .unwrap(),
-                    SeccompRule::new(vec![
-                        SeccompCondition::new(
-                            1,
-                            SeccompCmpArgLen::Dword,
-                            SeccompCmpOp::Eq,
-                            libc::SOL_SOCKET as u64,
-                        )
-                        .unwrap(),
-                        SeccompCondition::new(
-                            2,
-                            SeccompCmpArgLen::Dword,
-                            SeccompCmpOp::Eq,
-                            libc::SO_SNDTIMEO as u64,
-                        )
-                        .unwrap(),
-                    ])
-                    .unwrap(),
-                ],
-            ),
             // Connected UnixStream I/O may use sendto/recvfrom rather than raw
             // read/write. Limit these rules to connected-socket calls that do
             // not name a peer address.

--- a/litebox_runner_linux_userland/src/broker.rs
+++ b/litebox_runner_linux_userland/src/broker.rs
@@ -41,8 +41,16 @@ fn connect_to_endpoint(socket_path: &Path) -> Result<BrokerConnection> {
 fn connect_with_retry(socket_path: &Path, setup_deadline: Instant) -> Result<Local> {
     loop {
         match UnixStreamLocalControlChannel::connect(socket_path) {
-            Ok(channel) => {
-                let local = BrokerLocal::negotiate(channel).context("broker negotiation failed")?;
+            Ok(mut channel) => {
+                channel
+                    .set_io_deadline(Some(setup_deadline))
+                    .context("failed to configure broker setup deadline")?;
+                let mut local =
+                    BrokerLocal::negotiate(channel).context("broker negotiation failed")?;
+                local
+                    .control_channel_mut()
+                    .set_io_deadline(None)
+                    .context("failed to clear broker setup deadline")?;
                 return Ok(local);
             }
             Err(error) => {

--- a/litebox_runner_linux_userland/src/broker.rs
+++ b/litebox_runner_linux_userland/src/broker.rs
@@ -11,7 +11,6 @@ use litebox_broker_local::BrokerLocal;
 use litebox_broker_transport::unix_socket::UnixStreamLocalControlChannel;
 
 const SETUP_TIMEOUT: Duration = Duration::from_secs(5);
-const ACTIVE_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 const RETRY_DELAY: Duration = Duration::from_millis(20);
 type Local = BrokerLocal<UnixStreamLocalControlChannel>;
 
@@ -34,22 +33,15 @@ impl BrokerConnection {
 
 fn connect_to_endpoint(socket_path: &Path) -> Result<BrokerConnection> {
     let setup_deadline = Instant::now() + SETUP_TIMEOUT;
-    let mut local = connect_with_retry(socket_path, setup_deadline)
+    let local = connect_with_retry(socket_path, setup_deadline)
         .with_context(|| format!("failed to connect to broker at {}", socket_path.display()))?;
-    local
-        .control_channel_mut()
-        .set_io_timeout(Some(ACTIVE_REQUEST_TIMEOUT))
-        .context("failed to configure broker active request timeout")?;
     Ok(BrokerConnection { local })
 }
 
 fn connect_with_retry(socket_path: &Path, setup_deadline: Instant) -> Result<Local> {
     loop {
         match UnixStreamLocalControlChannel::connect(socket_path) {
-            Ok(mut channel) => {
-                channel
-                    .set_io_deadline(Some(setup_deadline))
-                    .context("failed to configure broker setup deadline")?;
+            Ok(channel) => {
                 let local = BrokerLocal::negotiate(channel).context("broker negotiation failed")?;
                 return Ok(local);
             }


### PR DESCRIPTION
This PR avoids weakening the Linux userland seccomp filter for broker socket timeouts. The runner now uses a setup-only broker negotiation deadline, clears it before active broker requests, and no longer needs `setsockopt(SO_RCVTIMEO/SO_SNDTIMEO)` in the seccomp allowlist.