### PR TITLE
Make the fs `Backend` dyn-compatible

### DIFF
--- a/litebox/src/fs/backend.rs
+++ b/litebox/src/fs/backend.rs
@@ -3,7 +3,12 @@
 
 //! [`Backend`] for filesystems supported by [`super::resolver`]
 
+use alloc::boxed::Box;
 use alloc::vec::Vec;
+use core::any::{Any, TypeId};
+use core::marker::PhantomData;
+
+use crate::utilities::anymap::AnyCloneSendSync;
 
 use super::errors::{
     ChmodError, ChownError, FileStatusError, MkdirError, OpenError, ReadDirError, ReadError,
@@ -38,18 +43,9 @@ pub(super) mod private {
 }
 
 /// A backend that can be used to support a (full or subset of) a LiteBox filesystem.
-pub trait Backend: private::Sealed + Send + Sync + 'static {
-    /// Supporting walk through the backend
-    type WalkingDirHandle<'a>: 'a;
-
-    /// An owned handle to an open file
-    type FileHandle: Clone + Send + Sync + 'static;
-
-    /// An owned handle to an open directory
-    type DirHandle: Clone + Send + Sync + 'static;
-
+pub trait Backend: private::Sealed + Send + Sync + Any {
     /// Obtain access to the root directory of the backend.
-    fn root(&self) -> Self::WalkingDirHandle<'_>;
+    fn root(&self) -> WalkingDirHandle<'_>;
 
     /// Walk one or more `components` starting from the `from` handle.
     ///
@@ -60,12 +56,12 @@ pub trait Backend: private::Sealed + Send + Sync + 'static {
     /// `WalkStopReason::StoppedAtNonDirectory`.
     fn walk_directories<'a>(
         &'a self,
-        from: Self::WalkingDirHandle<'a>,
+        from: WalkingDirHandle<'a>,
         components: &[&str],
-    ) -> Result<WalkOutcome<Self::WalkingDirHandle<'a>>, WalkError>;
+    ) -> Result<WalkOutcome<WalkingDirHandle<'a>>, WalkError>;
 
     /// Take an owned handle to a `dir` found via a walk.
-    fn owned_dir_at(&self, dir: Self::WalkingDirHandle<'_>) -> Self::DirHandle;
+    fn owned_dir_at(&self, dir: WalkingDirHandle<'_>) -> DirHandle;
 
     /// Obtain a walking handle to an existing owned dir.
     ///
@@ -74,28 +70,27 @@ pub trait Backend: private::Sealed + Send + Sync + 'static {
     ///
     /// XXX(jayb): We will likely migrate away from `Option` here when we do a bit of an overhaul of
     /// the `errors` module in order to more consistently support stale errors everywhere.
-    fn walking_dir_at<'a>(&'a self, dir: &Self::DirHandle) -> Option<Self::WalkingDirHandle<'a>>;
+    fn walking_dir_at<'a>(&'a self, dir: &DirHandle) -> Option<WalkingDirHandle<'a>>;
 
     /// Open an (existing) file at `dir`.
     ///
     /// To create a file, you need [`Self::create_file_at`].
     fn open_file_at(
         &self,
-        dir: Self::WalkingDirHandle<'_>,
+        dir: WalkingDirHandle<'_>,
         name: &str,
         flags: OFlags,
-    ) -> Result<Permissioned<Self::FileHandle>, OpenError>;
+    ) -> Result<Permissioned<FileHandle>, OpenError>;
 
     /// Read directory entries at `dir`.
-    fn list_dir_at(&self, handle: Self::DirHandle) -> Result<Vec<DirEntry>, ReadDirError>;
+    fn list_dir_at(&self, handle: DirHandle) -> Result<Vec<DirEntry>, ReadDirError>;
 
     /// Read at `offset` into `buf`, returning the number of bytes read.
     ///
     /// Backends do not have an internal notion of offsets; instead the resolver maintains offsets
     /// as needed. For files with non-position-based [`SeekBehavior`], such as `stdin`, the resolver
     /// passes zero and the backend should ignore the offset.
-    fn read(&self, h: &Self::FileHandle, buf: &mut [u8], offset: usize)
-    -> Result<usize, ReadError>;
+    fn read(&self, h: &FileHandle, buf: &mut [u8], offset: usize) -> Result<usize, ReadError>;
 
     /// Optional performance hook: get static backing data for a file, if available and supported.
     ///
@@ -104,7 +99,7 @@ pub trait Backend: private::Sealed + Send + Sync + 'static {
     ///
     /// Returns `None` if indicating no static backing data is available/supported.
     #[expect(unused_variables, reason = "default body, non-underscored param names")]
-    fn get_static_backing_data(&self, h: &Self::FileHandle) -> Option<&'static [u8]> {
+    fn get_static_backing_data(&self, h: &FileHandle) -> Option<&'static [u8]> {
         None
     }
 
@@ -116,57 +111,154 @@ pub trait Backend: private::Sealed + Send + Sync + 'static {
     // it ugly on the interface side here. It would be very ugly for us to pass in extra flags, or
     // indeed even need to maintain/handle seeking on every backend; mostly we need some sort of
     // nicer locking discipline, but I don't want to block the MVP for this just yet.
-    fn write(&self, h: &Self::FileHandle, buf: &[u8], offset: usize) -> Result<usize, WriteError>;
+    fn write(&self, h: &FileHandle, buf: &[u8], offset: usize) -> Result<usize, WriteError>;
 
     /// Truncate the file to the specified length.
     ///
     /// If shorter than existing size, extra data is lost. If longer than existing size, resize by
     /// adding `\0`s.
-    fn truncate(&self, h: &Self::FileHandle, length: usize) -> Result<(), TruncateError>;
+    fn truncate(&self, h: &FileHandle, length: usize) -> Result<(), TruncateError>;
 
     /// Describe seek behavior for an open file handle.
-    fn seek_behavior(&self, h: &Self::FileHandle) -> SeekBehavior;
+    fn seek_behavior(&self, h: &FileHandle) -> SeekBehavior;
 
     /// Status of an open file handle.
-    fn file_status(&self, h: &Self::FileHandle) -> Result<FileStatus, FileStatusError>;
+    fn file_status(&self, h: &FileHandle) -> Result<FileStatus, FileStatusError>;
 
     /// Status of an open directory handle.
-    fn dir_status(&self, h: &Self::DirHandle) -> Result<FileStatus, FileStatusError>;
+    fn dir_status(&self, h: &DirHandle) -> Result<FileStatus, FileStatusError>;
 
     /// Create a new file at `parent` with the given `name` and `mode`.
     fn create_file_at(
         &self,
-        dir: Self::DirHandle,
+        dir: DirHandle,
         name: &str,
         mode: Mode,
-    ) -> Result<Self::FileHandle, OpenError>;
+    ) -> Result<FileHandle, OpenError>;
 
     /// Create a new directory at `parent` with the given `name` and `mode`.
-    fn mkdir_at(
-        &self,
-        dir: Self::DirHandle,
-        name: &str,
-        mode: Mode,
-    ) -> Result<Self::DirHandle, MkdirError>;
+    fn mkdir_at(&self, dir: DirHandle, name: &str, mode: Mode) -> Result<DirHandle, MkdirError>;
 
     /// Remove the file `name` at `parent`.
-    fn unlink_at(&self, dir: Self::DirHandle, name: &str) -> Result<(), UnlinkError>;
+    fn unlink_at(&self, dir: DirHandle, name: &str) -> Result<(), UnlinkError>;
 
     /// Remove the directory `name` at `parent`.
     // XXX(jayb): I don't like that unlink and rmdir exist separately, we should probably merge them.
-    fn rmdir_at(&self, dir: Self::DirHandle, name: &str) -> Result<(), RmdirError>;
+    fn rmdir_at(&self, dir: DirHandle, name: &str) -> Result<(), RmdirError>;
 
     /// Update the permissions for the file/dir `name` at `parent`.
-    fn chmod_at(&self, dir: Self::DirHandle, name: &str, mode: Mode) -> Result<(), ChmodError>;
+    fn chmod_at(&self, dir: DirHandle, name: &str, mode: Mode) -> Result<(), ChmodError>;
 
     /// Update the owner/group for the file/dir `name` at `parent`.
     fn chown_at(
         &self,
-        dir: Self::DirHandle,
+        dir: DirHandle,
         name: &str,
         user: Option<u16>,
         group: Option<u16>,
     ) -> Result<(), ChownError>;
+}
+
+/// Concrete handle types used by a backend.
+///
+/// This trait is intentionally separate from [`Backend`]: the dyn-safe [`Backend`] interface keeps
+/// using erased handle wrappers, while concrete backend implementations can use these associated
+/// types at their own boundaries instead of spelling out manual erased-handle downcasts.
+pub(crate) trait BackendHandles {
+    /// Supporting walk through the backend
+    type WalkingDirHandle<'a>: 'a;
+    /// An owned handle to an open file
+    type FileHandle: Clone + Send + Sync + 'static;
+    /// An owned handle to an open directory
+    type DirHandle: Clone + Send + Sync + 'static;
+}
+
+/// Supporting walk through the backend
+pub struct WalkingDirHandle<'a> {
+    backend_type: TypeId,
+    raw: Box<dyn ErasedWalkingDirHandle + 'a>,
+    _invariant: PhantomData<fn(&'a ()) -> &'a ()>,
+}
+
+/// An owned handle to an open file
+#[derive(Clone)]
+pub struct FileHandle {
+    raw: Box<dyn AnyCloneSendSync>,
+}
+
+/// An owned handle to an open directory
+#[derive(Clone)]
+pub struct DirHandle {
+    raw: Box<dyn AnyCloneSendSync>,
+}
+
+trait ErasedWalkingDirHandle {
+    fn into_raw(self: Box<Self>) -> *mut ();
+}
+
+impl<H> ErasedWalkingDirHandle for H {
+    fn into_raw(self: Box<Self>) -> *mut () {
+        Box::into_raw(self).cast()
+    }
+}
+
+impl<'a> WalkingDirHandle<'a> {
+    pub(super) fn from_typed<B: BackendHandles + 'static>(handle: B::WalkingDirHandle<'a>) -> Self {
+        Self {
+            backend_type: TypeId::of::<B>(),
+            raw: Box::new(handle),
+            _invariant: PhantomData,
+        }
+    }
+
+    /// Recover the concrete walking handle stored in this erased handle for `B`.
+    pub(super) fn into_typed<B: BackendHandles + 'static>(self) -> B::WalkingDirHandle<'a> {
+        assert_eq!(
+            self.backend_type,
+            TypeId::of::<B>(),
+            "backend walking directory handle type mismatch"
+        );
+        // SAFETY: `from_typed::<B>` records `TypeId::of::<B>()` and stores a
+        // `B::WalkingDirHandle<'a>`. `WalkingDirHandle<'a>` is invariant in `'a`, so the lifetime
+        // parameter cannot have been changed since construction. The assertion above confirms that
+        // this handle is being recovered for the same backend type, and together these guarantee
+        // that the allocation has the expected concrete type.
+        unsafe { *Box::from_raw(self.raw.into_raw().cast::<B::WalkingDirHandle<'a>>()) }
+    }
+}
+
+impl FileHandle {
+    pub(super) fn from_typed<B: BackendHandles>(handle: B::FileHandle) -> Self {
+        Self {
+            raw: Box::new(handle),
+        }
+    }
+
+    pub(super) fn get_typed<B: BackendHandles>(&self) -> &B::FileHandle {
+        (&*self.raw as &dyn Any)
+            .downcast_ref::<B::FileHandle>()
+            .expect("backend file handle type mismatch")
+    }
+}
+
+impl DirHandle {
+    pub(super) fn from_typed<B: BackendHandles>(handle: B::DirHandle) -> Self {
+        Self {
+            raw: Box::new(handle),
+        }
+    }
+
+    pub(super) fn get_typed<B: BackendHandles>(&self) -> &B::DirHandle {
+        (&*self.raw as &dyn Any)
+            .downcast_ref::<B::DirHandle>()
+            .expect("backend directory handle type mismatch")
+    }
+
+    pub(super) fn into_typed<B: BackendHandles>(self) -> B::DirHandle {
+        let raw: Box<dyn Any> = self.raw;
+        *raw.downcast::<B::DirHandle>()
+            .expect("backend directory handle type mismatch")
+    }
 }
 
 /// A successful walk of directories through the backend
@@ -231,4 +323,16 @@ pub(super) struct WalkedComponent {
 pub(super) struct PermissionInfo {
     pub(super) mode: Mode,
     pub(super) owner: UserInfo,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Backend;
+
+    #[test]
+    fn backend_is_dyn_safe() {
+        fn assert_dyn_safe(_: Option<&dyn Backend>) {}
+
+        assert_dyn_safe(None);
+    }
 }

--- a/litebox/src/fs/devices.rs
+++ b/litebox/src/fs/devices.rs
@@ -15,8 +15,8 @@ use crate::LiteBox;
 use crate::sync::RawSyncPrimitivesProvider;
 
 use super::backend::{
-    Backend, PermissionCheck, Permissioned, SeekBehavior, WalkOutcome, WalkStopReason,
-    WalkedComponent,
+    Backend, BackendHandles, DirHandle, FileHandle, PermissionCheck, Permissioned, SeekBehavior,
+    WalkOutcome, WalkStopReason, WalkedComponent, WalkingDirHandle,
 };
 use super::errors::{
     ChmodError, ChownError, FileStatusError, MkdirError, OpenError, PathError, ReadDirError,
@@ -179,6 +179,18 @@ impl<Platform> super::backend::private::Sealed for Devices<Platform> where
 {
 }
 
+impl<Platform> BackendHandles for Devices<Platform>
+where
+    Platform: RawSyncPrimitivesProvider
+        + crate::platform::StdioProvider
+        + crate::platform::CrngProvider
+        + 'static,
+{
+    type WalkingDirHandle<'a> = DeviceDirHandle;
+    type FileHandle = DeviceFileHandle;
+    type DirHandle = DeviceDirHandle;
+}
+
 impl<Platform> Backend for Devices<Platform>
 where
     Platform: RawSyncPrimitivesProvider
@@ -186,24 +198,18 @@ where
         + crate::platform::CrngProvider
         + 'static,
 {
-    type WalkingDirHandle<'a>
-        = DeviceDirHandle
-    where
-        Self: 'a;
-    type FileHandle = DeviceFileHandle;
-    type DirHandle = DeviceDirHandle;
-
-    fn root(&self) -> Self::WalkingDirHandle<'_> {
-        DeviceDirHandle {
+    fn root(&self) -> WalkingDirHandle<'_> {
+        WalkingDirHandle::from_typed::<Self>(DeviceDirHandle {
             location: Location::Root,
-        }
+        })
     }
 
     fn walk_directories<'a>(
         &'a self,
-        from: Self::WalkingDirHandle<'a>,
+        from: WalkingDirHandle<'a>,
         components: &[&str],
-    ) -> Result<WalkOutcome<Self::WalkingDirHandle<'a>>, WalkError> {
+    ) -> Result<WalkOutcome<WalkingDirHandle<'a>>, WalkError> {
+        let from = from.into_typed::<Self>();
         // This backend only exposes one directory below root. Device files are
         // final path targets, so directory walking must stop before them.
         let mut location = from.location;
@@ -219,7 +225,7 @@ where
                 (Location::Dev, name) if Device::from_name(name).is_some() => {
                     return Ok(WalkOutcome {
                         components: walked_components,
-                        last: DeviceDirHandle { location },
+                        last: WalkingDirHandle::from_typed::<Self>(DeviceDirHandle { location }),
                         stop_reason: WalkStopReason::StoppedAtNonDirectory,
                     });
                 }
@@ -230,25 +236,28 @@ where
         }
         Ok(WalkOutcome {
             components: walked_components,
-            last: DeviceDirHandle { location },
+            last: WalkingDirHandle::from_typed::<Self>(DeviceDirHandle { location }),
             stop_reason: WalkStopReason::CompleteDirectory,
         })
     }
 
-    fn owned_dir_at(&self, dir: Self::WalkingDirHandle<'_>) -> Self::DirHandle {
-        dir
+    fn owned_dir_at(&self, dir: WalkingDirHandle<'_>) -> DirHandle {
+        DirHandle::from_typed::<Self>(dir.into_typed::<Self>())
     }
 
-    fn walking_dir_at<'a>(&'a self, dir: &Self::DirHandle) -> Option<Self::WalkingDirHandle<'a>> {
-        Some(*dir)
+    fn walking_dir_at<'a>(&'a self, dir: &DirHandle) -> Option<WalkingDirHandle<'a>> {
+        Some(WalkingDirHandle::from_typed::<Self>(
+            *dir.get_typed::<Self>(),
+        ))
     }
 
     fn open_file_at(
         &self,
-        dir: Self::WalkingDirHandle<'_>,
+        dir: WalkingDirHandle<'_>,
         name: &str,
         flags: OFlags,
-    ) -> Result<Permissioned<Self::FileHandle>, OpenError> {
+    ) -> Result<Permissioned<FileHandle>, OpenError> {
+        let dir = dir.into_typed::<Self>();
         if dir.location != Location::Dev {
             return Err(OpenError::PathError(PathError::NoSuchFileOrDirectory));
         }
@@ -271,18 +280,22 @@ where
             // Note: matching Linux behavior, this does not actually perform any truncation, and
             // instead, it is silently ignored if you attempt to truncate upon opening stdio.
             debug_assert!(matches!(
-                self.truncate(&DeviceFileHandle { device }, 0),
+                self.truncate(
+                    &FileHandle::from_typed::<Self>(DeviceFileHandle { device }),
+                    0
+                ),
                 Err(TruncateError::IsTerminalDevice)
             ));
         }
 
         Ok(Permissioned {
-            item: DeviceFileHandle { device },
+            item: FileHandle::from_typed::<Self>(DeviceFileHandle { device }),
             permissions: PermissionCheck::ByBackend,
         })
     }
 
-    fn list_dir_at(&self, handle: Self::DirHandle) -> Result<Vec<DirEntry>, ReadDirError> {
+    fn list_dir_at(&self, handle: DirHandle) -> Result<Vec<DirEntry>, ReadDirError> {
+        let handle = handle.into_typed::<Self>();
         match handle.location {
             Location::Root => Ok(alloc::vec![DirEntry {
                 name: String::from("dev"),
@@ -300,12 +313,8 @@ where
         }
     }
 
-    fn read(
-        &self,
-        h: &Self::FileHandle,
-        buf: &mut [u8],
-        _offset: usize,
-    ) -> Result<usize, ReadError> {
+    fn read(&self, h: &FileHandle, buf: &mut [u8], _offset: usize) -> Result<usize, ReadError> {
+        let h = h.get_typed::<Self>();
         match h.device {
             Device::Stdin => self
                 .litebox
@@ -327,7 +336,8 @@ where
         }
     }
 
-    fn write(&self, h: &Self::FileHandle, buf: &[u8], _offset: usize) -> Result<usize, WriteError> {
+    fn write(&self, h: &FileHandle, buf: &[u8], _offset: usize) -> Result<usize, WriteError> {
+        let h = h.get_typed::<Self>();
         let stream = match h.device {
             Device::Stdin => return Err(WriteError::NotForWriting),
             Device::Stdout => crate::platform::StdioOutStream::Stdout,
@@ -353,22 +363,24 @@ where
             })
     }
 
-    fn truncate(&self, _h: &Self::FileHandle, _len: usize) -> Result<(), TruncateError> {
+    fn truncate(&self, _h: &FileHandle, _len: usize) -> Result<(), TruncateError> {
         Err(TruncateError::IsTerminalDevice)
     }
 
-    fn seek_behavior(&self, h: &Self::FileHandle) -> SeekBehavior {
+    fn seek_behavior(&self, h: &FileHandle) -> SeekBehavior {
+        let h = h.get_typed::<Self>();
         match h.device {
             Device::Stdin | Device::Stdout | Device::Stderr => SeekBehavior::NonSeekable,
             Device::Null | Device::URandom => SeekBehavior::ZeroPosition,
         }
     }
 
-    fn file_status(&self, h: &Self::FileHandle) -> Result<FileStatus, FileStatusError> {
-        Ok(h.device.file_status())
+    fn file_status(&self, h: &FileHandle) -> Result<FileStatus, FileStatusError> {
+        Ok(h.get_typed::<Self>().device.file_status())
     }
 
-    fn dir_status(&self, h: &Self::DirHandle) -> Result<FileStatus, FileStatusError> {
+    fn dir_status(&self, h: &DirHandle) -> Result<FileStatus, FileStatusError> {
+        let h = h.get_typed::<Self>();
         Ok(match h.location {
             Location::Root => FileStatus {
                 file_type: FileType::Directory,
@@ -395,37 +407,32 @@ where
 
     fn create_file_at(
         &self,
-        _dir: Self::DirHandle,
+        _dir: DirHandle,
         _name: &str,
         _mode: Mode,
-    ) -> Result<Self::FileHandle, OpenError> {
+    ) -> Result<FileHandle, OpenError> {
         Err(OpenError::ReadOnlyFileSystem)
     }
 
-    fn mkdir_at(
-        &self,
-        _dir: Self::DirHandle,
-        _name: &str,
-        _mode: Mode,
-    ) -> Result<Self::DirHandle, MkdirError> {
+    fn mkdir_at(&self, _dir: DirHandle, _name: &str, _mode: Mode) -> Result<DirHandle, MkdirError> {
         Err(MkdirError::ReadOnlyFileSystem)
     }
 
-    fn unlink_at(&self, _dir: Self::DirHandle, _name: &str) -> Result<(), UnlinkError> {
+    fn unlink_at(&self, _dir: DirHandle, _name: &str) -> Result<(), UnlinkError> {
         Err(UnlinkError::ReadOnlyFileSystem)
     }
 
-    fn rmdir_at(&self, _dir: Self::DirHandle, _name: &str) -> Result<(), RmdirError> {
+    fn rmdir_at(&self, _dir: DirHandle, _name: &str) -> Result<(), RmdirError> {
         Err(RmdirError::ReadOnlyFileSystem)
     }
 
-    fn chmod_at(&self, _dir: Self::DirHandle, _name: &str, _mode: Mode) -> Result<(), ChmodError> {
+    fn chmod_at(&self, _dir: DirHandle, _name: &str, _mode: Mode) -> Result<(), ChmodError> {
         Err(ChmodError::ReadOnlyFileSystem)
     }
 
     fn chown_at(
         &self,
-        _dir: Self::DirHandle,
+        _dir: DirHandle,
         _name: &str,
         _user: Option<u16>,
         _group: Option<u16>,

--- a/litebox/src/fs/resolver.rs
+++ b/litebox/src/fs/resolver.rs
@@ -18,7 +18,10 @@ use super::errors::{
 };
 use super::{
     FileType, Mode, OFlags,
-    backend::{PermissionCheck, PermissionInfo, SeekBehavior, WalkOutcome, WalkStopReason},
+    backend::{
+        DirHandle, FileHandle, PermissionCheck, PermissionInfo, SeekBehavior, WalkOutcome,
+        WalkStopReason, WalkingDirHandle,
+    },
 };
 
 /// The north-facing filesystem entry point, generic over a [`Backend`](super::backend::Backend).
@@ -156,10 +159,10 @@ impl<Platform: sync::RawSyncPrimitivesProvider, Backend: super::backend::Backend
     Resolver<Platform, Backend>
 {
     fn parent_dir_and_name<'a>(
-        &'a self,
+        &self,
         context: &Context,
         path: &'a ResolvedPath,
-    ) -> Result<Option<(Backend::WalkingDirHandle<'a>, &'a str)>, WalkError> {
+    ) -> Result<Option<(WalkingDirHandle<'_>, &'a str)>, WalkError> {
         // Return the walking handle rather than an owned directory handle so backends can keep any
         // locks acquired during path resolution held across the final operation. This lets e.g.
         // "walk parent + mutate child" stay atomic.
@@ -179,10 +182,10 @@ impl<Platform: sync::RawSyncPrimitivesProvider, Backend: super::backend::Backend
     fn walk_to_directory<'a>(
         &'a self,
         context: &Context,
-        from: Backend::WalkingDirHandle<'a>,
+        from: WalkingDirHandle<'a>,
         components: &[&str],
         #[cfg(debug_assertions)] absolute_components: &[&str],
-    ) -> Result<Backend::WalkingDirHandle<'a>, WalkError> {
+    ) -> Result<WalkingDirHandle<'a>, WalkError> {
         if components.is_empty() {
             // TODO(jayb): Decide whether empty walks from a non-root handle need permission checks.
             return Ok(from);
@@ -215,10 +218,10 @@ impl<Platform: sync::RawSyncPrimitivesProvider, Backend: super::backend::Backend
     fn walk_path<'a>(
         &'a self,
         context: &Context,
-        from: Backend::WalkingDirHandle<'a>,
+        from: WalkingDirHandle<'a>,
         components: &[&str],
         #[cfg(debug_assertions)] absolute_components: &[&str],
-    ) -> Result<(WalkOutcome<Backend::WalkingDirHandle<'a>>, usize), WalkError> {
+    ) -> Result<(WalkOutcome<WalkingDirHandle<'a>>, usize), WalkError> {
         assert!(!components.is_empty());
         let outcome = self.backend.walk_directories(from, components)?;
         Self::check_walk_permissions(
@@ -251,7 +254,7 @@ impl<Platform: sync::RawSyncPrimitivesProvider, Backend: super::backend::Backend
     fn check_walk_permissions(
         context: &Context,
         #[cfg(debug_assertions)] absolute_components: &[&str],
-        outcome: &WalkOutcome<Backend::WalkingDirHandle<'_>>,
+        outcome: &WalkOutcome<WalkingDirHandle<'_>>,
     ) -> Result<(), PathError> {
         for (idx, walked) in outcome.components.iter().enumerate() {
             match &walked.permissions {
@@ -317,6 +320,7 @@ impl<Platform: sync::RawSyncPrimitivesProvider, Backend: super::backend::Backend
         let insert = |handle, seek_behavior| {
             self.litebox.descriptor_table_mut().insert(ResolverEntry {
                 handle,
+                _backend: core::marker::PhantomData,
                 read_allowed,
                 write_allowed,
                 position: 0,
@@ -740,9 +744,9 @@ impl<Platform: sync::RawSyncPrimitivesProvider, Backend: super::backend::Backend
 }
 
 /// A file or a directory handle
-enum OwnedHandle<Backend: super::backend::Backend> {
-    File(Backend::FileHandle),
-    Dir(Backend::DirHandle),
+enum OwnedHandle {
+    File(FileHandle),
+    Dir(DirHandle),
 }
 
 #[expect(
@@ -750,7 +754,8 @@ enum OwnedHandle<Backend: super::backend::Backend> {
     reason = "resolver fd entries carry independent descriptor flags"
 )]
 struct ResolverEntry<Backend: super::backend::Backend> {
-    handle: OwnedHandle<Backend>,
+    handle: OwnedHandle,
+    _backend: core::marker::PhantomData<Backend>,
     read_allowed: bool,
     write_allowed: bool,
     position: usize,

--- a/litebox/src/utilities/anymap.rs
+++ b/litebox/src/utilities/anymap.rs
@@ -32,7 +32,7 @@ mod private {
 }
 use private::Tid;
 
-trait AnyCloneSendSync: Any + Send + Sync {
+pub(crate) trait AnyCloneSendSync: Any + Send + Sync {
     fn clone_to_any(&self) -> Box<dyn AnyCloneSendSync>;
 }
 impl<T: Any + Clone + Send + Sync> AnyCloneSendSync for T {


### PR DESCRIPTION
#887 introduced the `Backend` abstraction to the file system, but as I was working on more functionality, I discovered that the better design is to guarantee that `Backend` is [dyn-compatible](https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility), so that the composition of multiple backends can be done without a huge amount of type-level machinery + macros; it also keeps the interfaces more ergonomic for consumers of LiteBox core.  To make things dyn-safe, we need to move out the `Backend`-specific handles; however, rather than the naive handling of this, there's a convenient abstraction such that backend implementations still end up with a largely convenient way to use their own typed handles.