### PR TITLE
Surface broker eventfd poll failures

### DIFF
--- a/litebox/src/event/counter.rs
+++ b/litebox/src/event/counter.rs
@@ -144,11 +144,19 @@ where
         match self
             .broker
             .request(BrokerRequest::Event(request))
-            .map_err(BrokerObjectError::from)?
+            .map_err(BrokerObjectError::from)
+            .map_err(|error| self.handle_request_error(error))?
         {
             BrokerResponse::Event(response) => Ok(response),
-            BrokerResponse::Error(error) => Err(error.into()),
+            BrokerResponse::Error(error) => Err(self.handle_request_error(error.into())),
         }
+    }
+
+    fn handle_request_error(&self, error: BrokerObjectError) -> BrokerObjectError {
+        if error != BrokerObjectError::WouldBlock {
+            self.pollee.notify_observers(Events::ERR);
+        }
+        error
     }
 }
 
@@ -161,10 +169,12 @@ where
     }
 
     fn check_io_events(&self) -> Events {
-        let Ok(response) = self.request_event(EventRequest::Wait(WaitEventRequest {
+        let response = match self.request_event(EventRequest::Wait(WaitEventRequest {
             handle: self.handle,
-        })) else {
-            return Events::empty();
+        })) {
+            Ok(response) => response,
+            Err(BrokerObjectError::WouldBlock) => return Events::empty(),
+            Err(_) => return Events::ERR,
         };
         let EventResponse::Wait(response) = response else {
             panic!("broker returned unexpected event response: {response:?}");

--- a/litebox/src/event/counter.rs
+++ b/litebox/src/event/counter.rs
@@ -145,18 +145,20 @@ where
             .broker
             .request(BrokerRequest::Event(request))
             .map_err(BrokerObjectError::from)
-            .map_err(|error| self.handle_request_error(error))?
-        {
+            .inspect_err(|&error| {
+                if error != BrokerObjectError::WouldBlock {
+                    self.pollee.notify_observers(Events::ERR);
+                }
+            })? {
             BrokerResponse::Event(response) => Ok(response),
-            BrokerResponse::Error(error) => Err(self.handle_request_error(error.into())),
+            BrokerResponse::Error(error) => {
+                let error = error.into();
+                if error != BrokerObjectError::WouldBlock {
+                    self.pollee.notify_observers(Events::ERR);
+                }
+                Err(error)
+            }
         }
-    }
-
-    fn handle_request_error(&self, error: BrokerObjectError) -> BrokerObjectError {
-        if error != BrokerObjectError::WouldBlock {
-            self.pollee.notify_observers(Events::ERR);
-        }
-        error
     }
 }
 


### PR DESCRIPTION
Returns `ERR` from broker-backed eventfd polling when the broker/control request fails with an error other than `WouldBlock`. Notifies registered event observers on those failures so waiters can observe the error state.