### PR TITLE
Document broker POC design limits

### DIFF
--- a/litebox/src/broker/mod.rs
+++ b/litebox/src/broker/mod.rs
@@ -15,6 +15,10 @@ use error::BrokerControlError;
 /// LiteBox owns broker-backed local objects and constructs broker protocol
 /// requests. Deployment code owns endpoint selection and supplies the connected
 /// transport behind this protocol-level boundary.
+///
+/// The current interface is intentionally blocking for the initial broker POC.
+/// Longer-term broker integrations should move away from blocking control calls
+/// once the local-core wait and notification model supports that shape.
 pub(crate) trait BrokerControl: Send + Sync {
     /// Sends one active broker request and returns its response.
     fn request(

--- a/litebox_broker_core/src/policy.rs
+++ b/litebox_broker_core/src/policy.rs
@@ -41,6 +41,10 @@ impl PrincipalRights {
 }
 
 /// Broker policy decision and audit component.
+///
+/// This initial engine is a placeholder static policy surface for the broker
+/// POC. A fuller policy model is intentionally deferred until the broker needs
+/// authenticated principals, richer rules, and audit integration.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PolicyEngine {
     profile: PolicyProfile,


### PR DESCRIPTION
Clarifies two intentional limits in the initial broker PR #880: the policy engine is a placeholder static policy surface, and broker control calls are currently blocking. Notes that richer policy and non-blocking broker integration will be added later.