### PR TITLE
Fix broker-backed eventfd lifecycle semantics

### DIFF
--- a/litebox/src/broker/mod.rs
+++ b/litebox/src/broker/mod.rs
@@ -2,8 +2,9 @@
 // Licensed under the MIT license.
 
 use litebox_broker_local::BrokerLocal;
+use litebox_broker_protocol::ObjectHandle;
 use litebox_broker_protocol::channel::LocalControlChannel;
-use litebox_broker_protocol::message::{BrokerRequest, BrokerResponse};
+use litebox_broker_protocol::event::{ConsumeEventResponse, EventConsumeMode, ReadinessState};
 
 use crate::sync::{Mutex, RawSyncPrimitivesProvider};
 
@@ -20,11 +21,29 @@ use error::BrokerControlError;
 /// Longer-term broker integrations should move away from blocking control calls
 /// once the local-core wait and notification model supports that shape.
 pub(crate) trait BrokerControl: Send + Sync {
-    /// Sends one active broker request and returns its response.
-    fn request(
+    fn create_event_with_count(
         &self,
-        request: BrokerRequest,
-    ) -> core::result::Result<BrokerResponse, BrokerControlError>;
+        initial_count: u64,
+    ) -> core::result::Result<ObjectHandle, BrokerControlError>;
+
+    fn wait_event(
+        &self,
+        handle: ObjectHandle,
+    ) -> core::result::Result<ReadinessState, BrokerControlError>;
+
+    fn add_event(
+        &self,
+        handle: ObjectHandle,
+        value: u64,
+    ) -> core::result::Result<ReadinessState, BrokerControlError>;
+
+    fn consume_event(
+        &self,
+        handle: ObjectHandle,
+        mode: EventConsumeMode,
+    ) -> core::result::Result<ConsumeEventResponse, BrokerControlError>;
+
+    fn close_object(&self, handle: ObjectHandle) -> core::result::Result<(), BrokerControlError>;
 }
 
 pub(crate) struct BrokerLocalControl<
@@ -51,10 +70,37 @@ where
     Platform: RawSyncPrimitivesProvider,
     Channel: LocalControlChannel + Send,
 {
-    fn request(
+    fn create_event_with_count(
         &self,
-        request: BrokerRequest,
-    ) -> core::result::Result<BrokerResponse, BrokerControlError> {
-        Ok(self.local.lock().request(request)?)
+        initial_count: u64,
+    ) -> core::result::Result<ObjectHandle, BrokerControlError> {
+        Ok(self.local.lock().create_event_with_count(initial_count)?)
+    }
+
+    fn wait_event(
+        &self,
+        handle: ObjectHandle,
+    ) -> core::result::Result<ReadinessState, BrokerControlError> {
+        Ok(self.local.lock().wait_event(handle)?)
+    }
+
+    fn add_event(
+        &self,
+        handle: ObjectHandle,
+        value: u64,
+    ) -> core::result::Result<ReadinessState, BrokerControlError> {
+        Ok(self.local.lock().add_event(handle, value)?)
+    }
+
+    fn consume_event(
+        &self,
+        handle: ObjectHandle,
+        mode: EventConsumeMode,
+    ) -> core::result::Result<ConsumeEventResponse, BrokerControlError> {
+        Ok(self.local.lock().consume_event(handle, mode)?)
+    }
+
+    fn close_object(&self, handle: ObjectHandle) -> core::result::Result<(), BrokerControlError> {
+        Ok(self.local.lock().close_object(handle)?)
     }
 }

--- a/litebox/src/event/counter.rs
+++ b/litebox/src/event/counter.rs
@@ -158,7 +158,19 @@ where
                 }
                 Err(error)
             }
+            response @ BrokerResponse::ObjectClosed => {
+                panic!("broker returned unexpected event response: {response:?}");
+            }
         }
+    }
+}
+
+impl<Platform> Drop for EventCounter<Platform>
+where
+    Platform: RawSyncPrimitivesProvider + TimeProvider,
+{
+    fn drop(&mut self) {
+        let _ = self.broker.request(BrokerRequest::CloseObject(self.handle));
     }
 }
 

--- a/litebox/src/event/counter.rs
+++ b/litebox/src/event/counter.rs
@@ -5,18 +5,15 @@ use alloc::sync::Arc;
 
 use litebox_broker_protocol::ObjectHandle;
 pub use litebox_broker_protocol::event::EventConsumeMode as EventCounterReadMode;
-use litebox_broker_protocol::event::{
-    AddEventRequest, ConsumeEventRequest, ConsumeEventResponse, CreateEventRequest, ReadinessState,
-    WaitEventRequest,
-};
-use litebox_broker_protocol::message::{
-    BrokerRequest, BrokerResponse, EventRequest, EventResponse,
-};
+use litebox_broker_protocol::event::{ConsumeEventResponse, ReadinessState};
 use thiserror::Error;
 
 use crate::{
     LiteBox,
-    broker::{BrokerControl, error::BrokerObjectError},
+    broker::{
+        BrokerControl,
+        error::{BrokerControlError, BrokerObjectError},
+    },
     event::{
         Events, IOPollable, observer::Observer, polling::Pollee, polling::TryOpError,
         wait::WaitContext,
@@ -64,18 +61,13 @@ where
         let Some(broker) = litebox.broker_control() else {
             return Err(EventCounterError::Unavailable);
         };
-        let response = broker
-            .request(BrokerRequest::Event(EventRequest::Create(
-                CreateEventRequest { initial_count },
-            )))
+        let handle = broker
+            .create_event_with_count(initial_count)
             .map_err(BrokerObjectError::from)
             .map_err(EventCounterError::from)?;
-        let BrokerResponse::Event(EventResponse::Create(response)) = response else {
-            panic!("broker returned unexpected event response: {response:?}");
-        };
         Ok(Self {
             broker,
-            handle: response.handle,
+            handle,
             pollee: Pollee::new(),
         })
     }
@@ -119,49 +111,23 @@ where
         &self,
         mode: EventCounterReadMode,
     ) -> Result<ConsumeEventResponse, BrokerObjectError> {
-        let response = self.request_event(EventRequest::Consume(ConsumeEventRequest {
-            handle: self.handle,
-            mode,
-        }))?;
-        let EventResponse::Consume(response) = response else {
-            panic!("broker returned unexpected event response: {response:?}");
-        };
-        Ok(response)
+        self.broker
+            .consume_event(self.handle, mode)
+            .map_err(|error| self.broker_request_error(error))
     }
 
     fn add(&self, value: u64) -> Result<ReadinessState, BrokerObjectError> {
-        let response = self.request_event(EventRequest::Add(AddEventRequest {
-            handle: self.handle,
-            value,
-        }))?;
-        let EventResponse::Add(response) = response else {
-            panic!("broker returned unexpected event response: {response:?}");
-        };
-        Ok(response.readiness)
+        self.broker
+            .add_event(self.handle, value)
+            .map_err(|error| self.broker_request_error(error))
     }
 
-    fn request_event(&self, request: EventRequest) -> Result<EventResponse, BrokerObjectError> {
-        match self
-            .broker
-            .request(BrokerRequest::Event(request))
-            .map_err(BrokerObjectError::from)
-            .inspect_err(|&error| {
-                if error != BrokerObjectError::WouldBlock {
-                    self.pollee.notify_observers(Events::ERR);
-                }
-            })? {
-            BrokerResponse::Event(response) => Ok(response),
-            BrokerResponse::Error(error) => {
-                let error = error.into();
-                if error != BrokerObjectError::WouldBlock {
-                    self.pollee.notify_observers(Events::ERR);
-                }
-                Err(error)
-            }
-            response @ BrokerResponse::ObjectClosed => {
-                panic!("broker returned unexpected event response: {response:?}");
-            }
+    fn broker_request_error(&self, error: BrokerControlError) -> BrokerObjectError {
+        let error = error.into();
+        if error != BrokerObjectError::WouldBlock {
+            self.pollee.notify_observers(Events::ERR);
         }
+        error
     }
 }
 
@@ -170,7 +136,7 @@ where
     Platform: RawSyncPrimitivesProvider + TimeProvider,
 {
     fn drop(&mut self) {
-        let _ = self.broker.request(BrokerRequest::CloseObject(self.handle));
+        let _ = self.broker.close_object(self.handle);
     }
 }
 
@@ -183,17 +149,15 @@ where
     }
 
     fn check_io_events(&self) -> Events {
-        let response = match self.request_event(EventRequest::Wait(WaitEventRequest {
-            handle: self.handle,
-        })) {
-            Ok(response) => response,
+        let readiness = match self
+            .broker
+            .wait_event(self.handle)
+            .map_err(|error| self.broker_request_error(error))
+        {
+            Ok(readiness) => readiness,
             Err(BrokerObjectError::WouldBlock) => return Events::empty(),
             Err(_) => return Events::ERR,
         };
-        let EventResponse::Wait(response) = response else {
-            panic!("broker returned unexpected event response: {response:?}");
-        };
-        let readiness = response.readiness;
         let mut events = Events::empty();
         if readiness.read_ready {
             events |= Events::IN;

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -110,6 +110,10 @@ where
 
 fn handle_request(session: &BrokerSession, request: BrokerRequest) -> BrokerResponse {
     match request {
+        BrokerRequest::CloseObject(handle) => match session.close_object_reference(handle) {
+            Ok(()) => BrokerResponse::ObjectClosed,
+            Err(error) => BrokerResponse::Error(error.into()),
+        },
         BrokerRequest::Event(request) => handle_event_request(session, request),
     }
 }
@@ -163,9 +167,9 @@ pub enum ConnectionTermination {
 mod tests {
     use super::*;
     use litebox_broker_core::{PolicyEngine, PrincipalRights};
-    use litebox_broker_protocol::ProtocolVersion;
-    use litebox_broker_protocol::event::CreateEventRequest;
+    use litebox_broker_protocol::event::{CreateEventRequest, WaitEventRequest};
     use litebox_broker_protocol::message::BrokerHandshakeRequest;
+    use litebox_broker_protocol::{ObjectHandle, ProtocolVersion};
 
     #[test]
     fn host_request_handling_uses_one_broker_core() {
@@ -179,6 +183,7 @@ mod tests {
         serve_connection_rejects_active_request_before_negotiation(&broker);
         serve_connection_rejects_handshake_request_after_negotiation(&broker);
         serve_connection_returns_channel_error_when_response_send_fails(&broker);
+        active_request_closes_object_reference(&broker);
     }
 
     fn serve_connection_negotiates_routes_one_request_and_returns_peer_closed(broker: &BrokerCore) {
@@ -296,6 +301,41 @@ mod tests {
             result => panic!("unexpected serve result: {result:?}"),
         }
         assert!(channel.handshake_responses.is_empty());
+    }
+
+    fn active_request_closes_object_reference(broker: &BrokerCore) {
+        let session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let response = handle_request(
+            &session,
+            BrokerRequest::Event(EventRequest::Create(CreateEventRequest {
+                initial_count: 0,
+            })),
+        );
+        let BrokerResponse::Event(EventResponse::Create(response)) = response else {
+            panic!("unexpected create response: {response:?}");
+        };
+        let handle = response.handle;
+
+        assert_eq!(
+            handle_request(&session, BrokerRequest::CloseObject(handle)),
+            BrokerResponse::ObjectClosed
+        );
+        assert_eq!(
+            handle_request(
+                &session,
+                BrokerRequest::Event(EventRequest::Wait(WaitEventRequest { handle }))
+            ),
+            BrokerResponse::Error(ErrorCode::UnknownObject)
+        );
+        assert_eq!(
+            handle_request(
+                &session,
+                BrokerRequest::CloseObject(ObjectHandle(handle.0 + 1))
+            ),
+            BrokerResponse::Error(ErrorCode::UnknownObject)
+        );
     }
 
     struct FakeHostControlChannel {

--- a/litebox_broker_local/src/event.rs
+++ b/litebox_broker_local/src/event.rs
@@ -87,6 +87,9 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
         match self.request(BrokerRequest::Event(request))? {
             BrokerResponse::Event(response) => Ok(response),
             BrokerResponse::Error(error) => Err(BrokerLocalError::Broker(error)),
+            response @ BrokerResponse::ObjectClosed => {
+                panic!("broker returned unexpected event response: {response:?}");
+            }
         }
     }
 }

--- a/litebox_broker_local/src/lib.rs
+++ b/litebox_broker_local/src/lib.rs
@@ -103,7 +103,7 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
                 | ErrorCode::Internal => panic!("broker returned unrecoverable error: {error}"),
                 _ => panic!("broker returned unsupported error: {error}"),
             },
-            response @ BrokerResponse::Event(_) => Ok(response),
+            response @ (BrokerResponse::Event(_) | BrokerResponse::ObjectClosed) => Ok(response),
         }
     }
 }
@@ -142,6 +142,18 @@ mod tests {
             initial_count: 0,
         }));
         let response = BrokerResponse::Event(EventResponse::Create(CreateEventResponse { handle }));
+        let channel = FakeControlChannel::new(None, Some(response.clone()));
+        let mut local = BrokerLocal { channel };
+
+        assert_eq!(local.request(request.clone()).unwrap(), response);
+        assert_eq!(local.channel.sent_request, Some(request));
+    }
+
+    #[test]
+    fn active_request_sends_close_object_request() {
+        let handle = ObjectHandle(7);
+        let request = BrokerRequest::CloseObject(handle);
+        let response = BrokerResponse::ObjectClosed;
         let channel = FakeControlChannel::new(None, Some(response.clone()));
         let mut local = BrokerLocal { channel };
 

--- a/litebox_broker_local/src/lib.rs
+++ b/litebox_broker_local/src/lib.rs
@@ -15,12 +15,12 @@ extern crate std;
 mod error;
 mod event;
 
-use litebox_broker_protocol::BROKER_PROTOCOL_VERSION;
 use litebox_broker_protocol::channel::LocalControlChannel;
 use litebox_broker_protocol::error::ErrorCode;
 use litebox_broker_protocol::message::{
     BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerRequest, BrokerResponse,
 };
+use litebox_broker_protocol::{BROKER_PROTOCOL_VERSION, ObjectHandle};
 
 pub use error::{BrokerLocalError, Result};
 
@@ -106,6 +106,22 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
             response @ (BrokerResponse::Event(_) | BrokerResponse::ObjectClosed) => Ok(response),
         }
     }
+
+    /// Closes one broker object reference.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the broker reports an unrecoverable error or returns a protocol
+    /// response that does not match an object close request.
+    pub fn close_object(&mut self, handle: ObjectHandle) -> Result<(), Channel::Error> {
+        match self.request(BrokerRequest::CloseObject(handle))? {
+            BrokerResponse::ObjectClosed => Ok(()),
+            BrokerResponse::Error(error) => Err(BrokerLocalError::Broker(error)),
+            response @ BrokerResponse::Event(_) => {
+                panic!("broker returned unexpected close response: {response:?}");
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -150,14 +166,14 @@ mod tests {
     }
 
     #[test]
-    fn active_request_sends_close_object_request() {
+    fn close_object_sends_close_object_request() {
         let handle = ObjectHandle(7);
         let request = BrokerRequest::CloseObject(handle);
         let response = BrokerResponse::ObjectClosed;
         let channel = FakeControlChannel::new(None, Some(response.clone()));
         let mut local = BrokerLocal { channel };
 
-        assert_eq!(local.request(request.clone()).unwrap(), response);
+        assert!(local.close_object(handle).is_ok());
         assert_eq!(local.channel.sent_request, Some(request));
     }
 

--- a/litebox_broker_protocol/src/message.rs
+++ b/litebox_broker_protocol/src/message.rs
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-use crate::ProtocolVersion;
 use crate::error::ErrorCode;
 use crate::event::{
     AddEventRequest, AddEventResponse, ConsumeEventRequest, ConsumeEventResponse,
     CreateEventRequest, CreateEventResponse, WaitEventRequest, WaitEventResponse,
 };
+use crate::{ObjectHandle, ProtocolVersion};
 
 /// Broker handshake request sent before the control channel is active.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -18,6 +18,8 @@ pub struct BrokerHandshakeRequest {
 /// Broker request sent over an active control channel.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum BrokerRequest {
+    /// Close one broker object reference.
+    CloseObject(ObjectHandle),
     /// Event object request family.
     Event(EventRequest),
 }
@@ -62,6 +64,8 @@ pub enum EventRequest {
 /// Broker response sent over an active control channel.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum BrokerResponse {
+    /// Object close operation completed.
+    ObjectClosed,
     /// Event object response family.
     Event(EventResponse),
     /// Operation failed with an ABI-neutral broker error.

--- a/litebox_broker_protocol/src/wire.rs
+++ b/litebox_broker_protocol/src/wire.rs
@@ -30,11 +30,13 @@ mod primitive;
 
 const REQUEST_TAG_NEGOTIATE: u8 = 0;
 const REQUEST_TAG_EVENT: u8 = 1;
+const REQUEST_TAG_CLOSE_OBJECT: u8 = 2;
 
 const RESPONSE_TAG_NEGOTIATED: u8 = 0;
 const RESPONSE_TAG_EVENT: u8 = 1;
 const RESPONSE_TAG_ERROR: u8 = 2;
 const RESPONSE_TAG_VERSION_MISMATCH: u8 = 3;
+const RESPONSE_TAG_OBJECT_CLOSED: u8 = 4;
 
 /// Error produced while encoding or decoding a broker wire message.
 #[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
@@ -73,7 +75,7 @@ pub fn decode_handshake_request(frame: &[u8]) -> Result<BrokerHandshakeRequest, 
         REQUEST_TAG_NEGOTIATE => BrokerHandshakeRequest {
             protocol_version: decoder.protocol_version()?,
         },
-        REQUEST_TAG_EVENT => return Err(WireError::WrongMessagePhase),
+        REQUEST_TAG_EVENT | REQUEST_TAG_CLOSE_OBJECT => return Err(WireError::WrongMessagePhase),
         _ => return Err(WireError::InvalidTag),
     };
     decoder.finish()?;
@@ -87,6 +89,10 @@ pub fn decode_handshake_request(frame: &[u8]) -> Result<BrokerHandshakeRequest, 
 pub fn encode_request(request: BrokerRequest) -> Vec<u8> {
     let mut encoder = Encoder::default();
     match request {
+        BrokerRequest::CloseObject(handle) => {
+            encoder.u8(REQUEST_TAG_CLOSE_OBJECT);
+            encoder.handle(handle);
+        }
         BrokerRequest::Event(request) => {
             encoder.u8(REQUEST_TAG_EVENT);
             event::encode_event_request(&mut encoder, request);
@@ -101,6 +107,7 @@ pub fn decode_request(frame: &[u8]) -> Result<BrokerRequest, WireError> {
     let tag = decoder.u8()?;
     let request = match tag {
         REQUEST_TAG_NEGOTIATE => return Err(WireError::WrongMessagePhase),
+        REQUEST_TAG_CLOSE_OBJECT => BrokerRequest::CloseObject(decoder.handle()?),
         REQUEST_TAG_EVENT => BrokerRequest::Event(event::decode_event_request(&mut decoder)?),
         _ => return Err(WireError::InvalidTag),
     };
@@ -143,7 +150,9 @@ pub fn decode_handshake_response(frame: &[u8]) -> Result<BrokerHandshakeResponse
         RESPONSE_TAG_NEGOTIATED => BrokerHandshakeResponse::Negotiated {
             broker_protocol_version: decoder.protocol_version()?,
         },
-        RESPONSE_TAG_EVENT => return Err(WireError::WrongMessagePhase),
+        RESPONSE_TAG_EVENT | RESPONSE_TAG_OBJECT_CLOSED => {
+            return Err(WireError::WrongMessagePhase);
+        }
         RESPONSE_TAG_VERSION_MISMATCH => BrokerHandshakeResponse::VersionMismatch {
             broker_protocol_version: decoder.protocol_version()?,
         },
@@ -164,6 +173,9 @@ pub fn decode_handshake_response(frame: &[u8]) -> Result<BrokerHandshakeResponse
 pub fn encode_response(response: BrokerResponse) -> Vec<u8> {
     let mut encoder = Encoder::default();
     match response {
+        BrokerResponse::ObjectClosed => {
+            encoder.u8(RESPONSE_TAG_OBJECT_CLOSED);
+        }
         BrokerResponse::Event(response) => {
             encoder.u8(RESPONSE_TAG_EVENT);
             event::encode_event_response(&mut encoder, response);
@@ -189,6 +201,7 @@ pub fn decode_response(frame: &[u8]) -> Result<BrokerResponse, WireError> {
             let error = ErrorCode::from_raw(decoder.u16()?).ok_or(WireError::InvalidTag)?;
             BrokerResponse::Error(error)
         }
+        RESPONSE_TAG_OBJECT_CLOSED => BrokerResponse::ObjectClosed,
         _ => return Err(WireError::InvalidTag),
     };
     decoder.finish()?;
@@ -224,6 +237,7 @@ mod tests {
     fn request_codec_round_trips_all_variants() {
         let handle = ObjectHandle(13);
         let requests = [
+            BrokerRequest::CloseObject(handle),
             BrokerRequest::Event(EventRequest::Create(CreateEventRequest {
                 initial_count: 0,
             })),
@@ -275,6 +289,7 @@ mod tests {
     fn response_codec_round_trips_all_variants() {
         let handle = ObjectHandle(13);
         let responses = [
+            BrokerResponse::ObjectClosed,
             BrokerResponse::Event(EventResponse::Create(CreateEventResponse { handle })),
             BrokerResponse::Event(EventResponse::Wait(WaitEventResponse {
                 readiness: ReadinessState {
@@ -327,6 +342,12 @@ mod tests {
         assert_eq!(
             decode_handshake_request(&encode_request(BrokerRequest::Event(EventRequest::Create(
                 CreateEventRequest { initial_count: 0 },
+            )))),
+            Err(WireError::WrongMessagePhase)
+        );
+        assert_eq!(
+            decode_handshake_request(&encode_request(BrokerRequest::CloseObject(ObjectHandle(
+                13
             )))),
             Err(WireError::WrongMessagePhase)
         );
@@ -387,6 +408,10 @@ mod tests {
                     handle: ObjectHandle(13),
                 }),
             ))),
+            Err(WireError::WrongMessagePhase)
+        );
+        assert_eq!(
+            decode_handshake_response(&encode_response(BrokerResponse::ObjectClosed)),
             Err(WireError::WrongMessagePhase)
         );
 

--- a/litebox_shim_linux/src/syscalls/eventfd.rs
+++ b/litebox_shim_linux/src/syscalls/eventfd.rs
@@ -30,10 +30,9 @@ impl FdEnabledSubsystemEntry for EventFile<Platform> {}
 
 /// Backing counter for a Linux eventfd file description.
 ///
-/// New blocking eventfds still use the shim-local implementation to keep the
-/// initial broker-backed scope narrow. Broker-backed nonblocking eventfds can
-/// still be switched to blocking mode because the local-core counter can block
-/// through LiteBox-local readiness notifications.
+/// New blocking eventfds use the shim-local path. Broker-backed counters stay
+/// nonblocking even if file status flags are later changed, until broker
+/// readiness notifications can wake local waiters.
 enum EventFileCounter<Platform: RawSyncPrimitivesProvider + TimeProvider> {
     ShimLocal {
         count: Mutex<Platform, u64>,
@@ -72,7 +71,9 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> EventFileCounter<Platfo
             Self::LocalCore(counter) => counter
                 .read(
                     cx,
-                    nonblock,
+                    // Broker-backed eventfds cannot safely park local waiters
+                    // until broker readiness notifications exist.
+                    true,
                     if semaphore {
                         EventCounterReadMode::One
                     } else {
@@ -95,7 +96,8 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> EventFileCounter<Platfo
                     Self::try_write_local(count, pollee, value)
                 })
                 .map_err(Errno::from),
-            Self::LocalCore(counter) => counter.write(cx, nonblock, value).map_err(Errno::from),
+            // See the matching LocalCore read path for why this stays nonblocking.
+            Self::LocalCore(counter) => counter.write(cx, true, value).map_err(Errno::from),
         }
     }
 


### PR DESCRIPTION
Adds an explicit broker object close request and uses it when broker-backed event counters are dropped, so closed eventfds release their broker object references before session teardown. Keeps broker-backed eventfd operations nonblocking even if file status flags are later changed, until broker readiness notifications can safely wake local waiters.

Fixes #966.