### PR TITLE
Seed KnownDllPath symbolic link

### DIFF
--- a/litebox_shim_windows/src/syscalls/directory.rs
+++ b/litebox_shim_windows/src/syscalls/directory.rs
@@ -50,6 +50,11 @@ const SEEDED_DIRECTORY_PATHS: &[&str] = &[
     r"\Sessions\BNOLINKS",
 ];
 
+// Wine's wineboot and ReactOS SMSS create KnownDllPath so ntdll can open/query
+// the DOS path prefix for known DLL lookups during loader initialization.
+const SEEDED_SYMLINK_PATHS: &[(&str, &str)] =
+    &[(r"\KnownDlls\KnownDllPath", r"C:\Windows\System32")];
+
 bitflags::bitflags! {
     #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     struct DirectoryAccess: u32 {
@@ -426,6 +431,19 @@ impl<Platform: crate::ShimPlatform> DirectoryNamespace<Platform> {
         assert!(
             status == NtStatus::SUCCESS,
             "seeded NT object directory must have seeded ancestors: {status:?}"
+        );
+    }
+
+    fn seed_symlink(&self, path: &str, target: &str) {
+        let status = self.create_symlink(
+            path,
+            target.to_string(),
+            |_| NtStatus::SUCCESS,
+            |_| NtStatus::SUCCESS,
+        );
+        assert!(
+            status == NtStatus::SUCCESS,
+            "seeded NT object symbolic link must have seeded ancestors: {status:?}"
         );
     }
 
@@ -1064,6 +1082,9 @@ pub(crate) fn seed_directory_namespace<Platform: crate::ShimPlatform>()
     let namespace = DirectoryNamespace::new();
     for path in SEEDED_DIRECTORY_PATHS {
         namespace.seed_directory(path);
+    }
+    for (path, target) in SEEDED_SYMLINK_PATHS {
+        namespace.seed_symlink(path, target);
     }
     namespace
 }

--- a/litebox_shim_windows/src/syscalls/symlink.rs
+++ b/litebox_shim_windows/src/syscalls/symlink.rs
@@ -503,6 +503,24 @@ mod tests {
     }
 
     #[test]
+    fn predefined_known_dll_path_symbolic_link_matches_loader_contract() {
+        run_with_test_platform_pointers(|| {
+            let task = test_task();
+            let opened = open_link(&task, r"\KnownDlls\KnownDllPath");
+            let target = r"C:\Windows\System32";
+            let mut output = alloc::vec![0u16; target.encode_utf16().count() + 1];
+            let (target_string, returned_length) = query_link(&task, opened, &mut output);
+
+            assert_eq!(returned_length, u32::from(target_string.length) + 2);
+            assert_eq!(
+                String::from_utf16_lossy(&output[..target_string.length as usize / 2]),
+                target
+            );
+            assert_eq!(task.sys_nt_close(opened), NtStatus::SUCCESS);
+        });
+    }
+
+    #[test]
     fn create_symbolic_link_rejects_empty_target() {
         run_with_test_platform_pointers(|| {
             let task = test_task();


### PR DESCRIPTION
Predefine `\\KnownDlls\\KnownDllPath` as C:\Windows\System32 so ntdll loader initialization can open and query the known-DLL search path.