### PR TITLE
Add OP-TEE `GetSystemTime` and revise LVBS platform `Instant`

### DIFF
--- a/dev_tests/src/ratchet.rs
+++ b/dev_tests/src/ratchet.rs
@@ -37,7 +37,7 @@ fn ratchet_globals() -> Result<()> {
             ("litebox/", 9),
             ("litebox_platform_linux_kernel/", 6),
             ("litebox_platform_linux_userland/", 5),
-            ("litebox_platform_lvbs/", 24),
+            ("litebox_platform_lvbs/", 23),
             ("litebox_platform_multiplex/", 1),
             ("litebox_platform_windows_userland/", 8),
             ("litebox_runner_lvbs/", 5),

--- a/litebox_common_optee/src/lib.rs
+++ b/litebox_common_optee/src/lib.rs
@@ -88,6 +88,10 @@ pub enum SyscallRequest<Platform: litebox::platform::RawPointerProvider> {
         buf: Platform::RawConstPointer<u8>,
         len: usize,
     },
+    GetTime {
+        cat: TeeTimeCategory,
+        time: Platform::RawMutPointer<TeeTime>,
+    },
     CrypStateAlloc {
         algo: TeeAlgorithm,
         op_mode: TeeOperationMode,
@@ -201,6 +205,10 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
                 flags: TeeMemoryAccessRights::try_from_usize(ctx.syscall_arg(0))?,
                 buf: Platform::RawConstPointer::from_usize(ctx.syscall_arg(1)),
                 len: ctx.syscall_arg(2),
+            },
+            TeeSyscallNr::GetTime => SyscallRequest::GetTime {
+                cat: TeeTimeCategory::try_from_usize(ctx.syscall_arg(0))?,
+                time: Platform::RawMutPointer::from_usize(ctx.syscall_arg(1)),
             },
             TeeSyscallNr::CrypStateAlloc => SyscallRequest::CrypStateAlloc {
                 algo: TeeAlgorithm::try_from_usize(ctx.syscall_arg(0))?,
@@ -781,6 +789,40 @@ pub struct TeeObjectInfo {
     pub handle_flags: TeeHandleFlag,
 }
 
+/// `TEE_Time` from `optee_os/lib/libutee/include/tee_api_types.h`.
+///
+/// Time since an implementation-defined origin, split into whole seconds plus
+/// a millisecond remainder (`millis` is always in `0..1000`).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, FromBytes, IntoBytes)]
+#[repr(C)]
+pub struct TeeTime {
+    pub seconds: u32,
+    pub millis: u32,
+}
+
+/// `UTEE_TIME_CAT_*` from `optee_os/lib/libutee/include/utee_types.h`, the
+/// time category passed to the `get_time` syscall (`_utee_get_time`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, TryFromPrimitive)]
+#[repr(u32)]
+pub enum TeeTimeCategory {
+    /// `TEE_GetSystemTime`: monotonic time with an arbitrary, per-TA-instance
+    /// origin.
+    System = 0,
+    /// `TEE_GetTAPersistentTime`: persistent, TA-settable time.
+    TaPersistent = 1,
+    /// `TEE_GetREETime`: normal-world (REE) wall-clock time.
+    Ree = 2,
+}
+
+impl TeeTimeCategory {
+    pub fn try_from_usize(value: usize) -> Result<Self, Errno> {
+        u32::try_from(value)
+            .ok()
+            .and_then(|v| Self::try_from(v).ok())
+            .ok_or(Errno::EINVAL)
+    }
+}
+
 /// `TEE_USAGE_*` from `optee_os/lib/libutee/include/tee_api_defines.h`
 #[derive(Clone, Copy, FromBytes, IntoBytes)]
 #[repr(transparent)]
@@ -1101,6 +1143,20 @@ pub enum TeeResult {
 impl From<TeeResult> for u32 {
     fn from(res: TeeResult) -> Self {
         res as u32
+    }
+}
+
+impl From<Errno> for TeeResult {
+    fn from(err: Errno) -> Self {
+        match err {
+            Errno::ENOSYS => Self::NotSupported,
+            Errno::EINVAL => Self::BadParameters,
+            Errno::EFAULT | Errno::EPERM | Errno::EACCES => Self::AccessDenied,
+            Errno::ENOMEM => Self::OutOfMemory,
+            Errno::EOVERFLOW => Self::Overflow,
+            Errno::EBUSY => Self::Busy,
+            _ => Self::GenericError,
+        }
     }
 }
 

--- a/litebox_common_optee/src/lib.rs
+++ b/litebox_common_optee/src/lib.rs
@@ -1146,20 +1146,6 @@ impl From<TeeResult> for u32 {
     }
 }
 
-impl From<Errno> for TeeResult {
-    fn from(err: Errno) -> Self {
-        match err {
-            Errno::ENOSYS => Self::NotSupported,
-            Errno::EINVAL => Self::BadParameters,
-            Errno::EFAULT | Errno::EPERM | Errno::EACCES => Self::AccessDenied,
-            Errno::ENOMEM => Self::OutOfMemory,
-            Errno::EOVERFLOW => Self::Overflow,
-            Errno::EBUSY => Self::Busy,
-            _ => Self::GenericError,
-        }
-    }
-}
-
 const UTEE_ENTRY_FUNC_OPEN_SESSION: u32 = 0;
 const UTEE_ENTRY_FUNC_CLOSE_SESSION: u32 = 1;
 const UTEE_ENTRY_FUNC_INVOKE_COMMAND: u32 = 2;

--- a/litebox_platform_lvbs/src/arch/x86/timer.rs
+++ b/litebox_platform_lvbs/src/arch/x86/timer.rs
@@ -78,6 +78,18 @@ const REF_TICKS_PER_MICRO: u64 = 10;
 /// Quantum as a reference-counter tick count (STIMER deadlines are in ticks).
 const QUANTUM_100NS: u64 = QUANTUM_MICROS * REF_TICKS_PER_MICRO;
 
+/// Nanoseconds per partition reference-counter tick: the counter runs at
+/// 10 MHz (`REF_TICKS_PER_MICRO` ticks per microsecond).
+pub(crate) const REF_COUNTER_TICK_NANOS: u64 = 1_000 / REF_TICKS_PER_MICRO;
+
+/// Read the Hyper-V partition reference counter (`HV_X64_MSR_TIME_REF_COUNT`).
+///
+/// A monotonic, frequency-invariant counter in 100 ns units, normalized by the
+/// hypervisor across TSC scaling and live migration.
+pub(crate) fn reference_time_100ns() -> u64 {
+    rdmsr(HV_X64_MSR_TIME_REF_COUNT)
+}
+
 // TODO: This backend is Hyper-V specific (STIMER direct mode). For non-Hyper-V
 // platforms, add alternative one-shot timer sources behind the same
 // arm/disarm/eoi interface and have `init` pick one per platform:

--- a/litebox_platform_lvbs/src/lib.rs
+++ b/litebox_platform_lvbs/src/lib.rs
@@ -7,10 +7,7 @@
 #![no_std]
 
 use crate::{host::per_cpu_variables::PerCpuVariablesAsm, mshv::vsm::Vtl0KernelInfo};
-use core::{
-    arch::asm,
-    sync::atomic::{AtomicU32, AtomicU64},
-};
+use core::sync::atomic::AtomicU32;
 use hashbrown::HashMap;
 use litebox::platform::{
     ArchSpecificError, ArchSpecificProvider, ArchSpecificRegister, IPInterfaceProvider,
@@ -75,8 +72,6 @@ fn box_new_zeroed<T: FromBytes>() -> alloc::boxed::Box<T> {
     // T: FromBytes guarantees all-zero is a valid bit pattern.
     unsafe { alloc::boxed::Box::from_raw(ptr) }
 }
-
-static CPU_MHZ: AtomicU64 = AtomicU64::new(0);
 
 /// Special page table ID for the base (kernel-only) page table.
 /// No real physical frame has address 0, so this is a safe sentinel.
@@ -615,10 +610,6 @@ impl<Host: HostInterface> LinuxKernel<Host> {
         }))
     }
 
-    pub fn init(&self, cpu_mhz: u64) {
-        CPU_MHZ.store(cpu_mhz, core::sync::atomic::Ordering::Relaxed);
-    }
-
     /// Returns the physical frame range belonging to VTL1.
     pub fn vtl1_phys_frame_range(&self) -> PhysFrameRange<Size4KiB> {
         self.vtl1_phys_frame_range
@@ -1043,7 +1034,10 @@ impl<Host: HostInterface> RawMutex<Host> {
     }
 }
 
-/// An implementation of [`litebox::platform::Instant`]
+/// An implementation of [`litebox::platform::Instant`].
+///
+/// Backed by the Hyper-V partition reference counter, which is monotonic
+/// and normalized by the hypervisor across TSC scaling and live migration.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Instant(u64);
 
@@ -1065,37 +1059,22 @@ impl<Host: HostInterface> TimeProvider for LinuxKernel<Host> {
 
 impl litebox::platform::Instant for Instant {
     fn checked_duration_since(&self, earlier: &Self) -> Option<core::time::Duration> {
-        self.0.checked_sub(earlier.0).map(|v| {
-            core::time::Duration::from_micros(
-                v / CPU_MHZ.load(core::sync::atomic::Ordering::Relaxed),
-            )
-        })
+        let ticks = self.0.checked_sub(earlier.0)?;
+        // Each reference-counter tick is `REF_COUNTER_TICK_NANOS` (100) ns.
+        let nanos = ticks.checked_mul(crate::arch::timer::REF_COUNTER_TICK_NANOS)?;
+        Some(core::time::Duration::from_nanos(nanos))
     }
 
     fn checked_add(&self, duration: core::time::Duration) -> Option<Self> {
-        let duration_micros: u64 = duration.as_micros().try_into().ok()?;
-        Some(Instant(self.0.checked_add(
-            duration_micros.checked_mul(CPU_MHZ.load(core::sync::atomic::Ordering::Relaxed))?,
-        )?))
+        let nanos: u64 = duration.as_nanos().try_into().ok()?;
+        let ticks = nanos / crate::arch::timer::REF_COUNTER_TICK_NANOS;
+        Some(Instant(self.0.checked_add(ticks)?))
     }
 }
 
 impl Instant {
-    fn rdtsc() -> u64 {
-        let lo: u32;
-        let hi: u32;
-        unsafe {
-            asm!(
-                "rdtsc",
-                out("eax") lo,
-                out("edx") hi,
-            );
-        }
-        (u64::from(hi) << 32) | u64::from(lo)
-    }
-
     fn now() -> Self {
-        Instant(Self::rdtsc())
+        Instant(crate::arch::timer::reference_time_100ns())
     }
 }
 

--- a/litebox_shim_optee/src/lib.rs
+++ b/litebox_shim_optee/src/lib.rs
@@ -18,9 +18,9 @@ use hashbrown::{HashMap, HashSet};
 use litebox::{
     LiteBox,
     mm::{PageManager, linux::PAGE_SIZE},
-    platform::{RawConstPointer as _, RawMutPointer as _},
+    platform::{Instant as _, RawConstPointer as _, RawMutPointer as _, TimeProvider},
     shim::ContinueOperation,
-    utils::{ReinterpretUnsignedExt, TruncateExt},
+    utils::TruncateExt,
 };
 use litebox_common_linux::{MapFlags, ProtFlags, errno::Errno};
 use litebox_common_optee::{
@@ -145,6 +145,7 @@ impl OpteeShimBuilder {
     pub fn build(self) -> OpteeShim {
         let global = Arc::new(GlobalState {
             platform: self.platform,
+            boot_instant: TimeProvider::now(self.platform),
             pm: PageManager::new(&self.litebox),
             _litebox: self.litebox,
             ta_uuid_map: TaUuidMap::new(),
@@ -158,6 +159,10 @@ impl OpteeShimBuilder {
 struct GlobalState {
     /// The platform instance used throughout the shim.
     platform: &'static Platform,
+    /// Monotonic baseline captured when this instance was created; the
+    /// arbitrary origin for GP "system time" (`TEE_GetSystemTime`).
+    /// See [`GlobalState::system_time`].
+    boot_instant: <Platform as litebox::platform::TimeProvider>::Instant,
     /// The page manager for managing virtual memory.
     pm: litebox::mm::PageManager<Platform, { PAGE_SIZE }>,
     /// The LiteBox instance used throughout the shim.
@@ -199,6 +204,15 @@ impl GlobalState {
     /// Get the TA flags associated with the given TA UUID.
     pub(crate) fn get_ta_flags(&self, ta_uuid: &TeeUuid) -> TaFlags {
         self.ta_uuid_map.get_flags(ta_uuid).unwrap_or_default()
+    }
+
+    /// Monotonic time elapsed since this instance was created, used as GP
+    /// "system time" (`TEE_GetSystemTime`).
+    ///
+    /// The clock source is the platform's monotonic clock; the origin is
+    /// [`Self::boot_instant`] which is instance private.
+    fn system_time(&self) -> core::time::Duration {
+        TimeProvider::now(self.platform).duration_since(&self.boot_instant)
     }
 
     /// Remove the TA binary associated with the given TA UUID.
@@ -369,8 +383,7 @@ impl Task {
         let request = match SyscallRequest::<Platform>::try_from_raw(ctx.orig_rax, ctx) {
             Ok(request) => request,
             Err(err) => {
-                // TODO: this seems like the wrong kind of error for OPTEE.
-                ctx.rax = (err.as_neg() as isize).reinterpret_as_unsigned();
+                ctx.rax = TeeResult::from(err) as usize;
                 return ContinueOperation::Resume;
             }
         };
@@ -564,6 +577,7 @@ impl Task {
                         })
                 }
             }
+            SyscallRequest::GetTime { cat, time } => self.sys_get_time(cat, time),
             _ => {
                 #[cfg(debug_assertions)]
                 todo!("unsupported syscall request");
@@ -649,8 +663,7 @@ impl Task {
         let request = match LdelfSyscallRequest::<Platform>::try_from_raw(ctx.orig_rax, ctx) {
             Ok(request) => request,
             Err(err) => {
-                // TODO: this seems like the wrong kind of error for OPTEE.
-                ctx.rax = (err.as_neg() as isize).reinterpret_as_unsigned();
+                ctx.rax = TeeResult::from(err) as usize;
                 return ContinueOperation::Resume;
             }
         };

--- a/litebox_shim_optee/src/lib.rs
+++ b/litebox_shim_optee/src/lib.rs
@@ -20,7 +20,7 @@ use litebox::{
     mm::{PageManager, linux::PAGE_SIZE},
     platform::{Instant as _, RawConstPointer as _, RawMutPointer as _, TimeProvider},
     shim::ContinueOperation,
-    utils::TruncateExt,
+    utils::{ReinterpretUnsignedExt, TruncateExt},
 };
 use litebox_common_linux::{MapFlags, ProtFlags, errno::Errno};
 use litebox_common_optee::{
@@ -383,7 +383,8 @@ impl Task {
         let request = match SyscallRequest::<Platform>::try_from_raw(ctx.orig_rax, ctx) {
             Ok(request) => request,
             Err(err) => {
-                ctx.rax = TeeResult::from(err) as usize;
+                // TODO: this seems like the wrong kind of error for OPTEE.
+                ctx.rax = (err.as_neg() as isize).reinterpret_as_unsigned();
                 return ContinueOperation::Resume;
             }
         };
@@ -663,7 +664,8 @@ impl Task {
         let request = match LdelfSyscallRequest::<Platform>::try_from_raw(ctx.orig_rax, ctx) {
             Ok(request) => request,
             Err(err) => {
-                ctx.rax = TeeResult::from(err) as usize;
+                // TODO: this seems like the wrong kind of error for OPTEE.
+                ctx.rax = (err.as_neg() as isize).reinterpret_as_unsigned();
                 return ContinueOperation::Resume;
             }
         };

--- a/litebox_shim_optee/src/syscalls/tee.rs
+++ b/litebox_shim_optee/src/syscalls/tee.rs
@@ -9,8 +9,8 @@ use litebox::platform::RawMutPointer;
 use litebox::platform::{RawConstPointer, page_mgmt::MemoryRegionPermissions};
 use litebox::utils::TruncateExt;
 use litebox_common_optee::{
-    TeeIdentity, TeeMemoryAccessRights, TeeOrigin, TeePropSet, TeeResult, TeeUuid, UserTaPropType,
-    UteeParams,
+    TeeIdentity, TeeMemoryAccessRights, TeeOrigin, TeePropSet, TeeResult, TeeTime, TeeTimeCategory,
+    TeeUuid, UserTaPropType, UteeParams,
 };
 use num_enum::TryFromPrimitive;
 use zerocopy::IntoBytes;
@@ -317,6 +317,35 @@ impl Task {
         } else {
             Err(TeeResult::AccessDenied)
         }
+    }
+
+    /// A system call to read the current time for a category.
+    ///
+    /// Only the GP "system time" category is supported; it is monotonic with a
+    /// per-instance arbitrary origin (see [`crate::GlobalState`]). The
+    /// TA-persistent and REE categories would require secure storage and a
+    /// normal-world RPC respectively, neither of which the shim provides.
+    pub fn sys_get_time(
+        &self,
+        cat: TeeTimeCategory,
+        time: UserMutPtr<TeeTime>,
+    ) -> Result<(), TeeResult> {
+        let tee_time = match cat {
+            TeeTimeCategory::System => {
+                let elapsed = self.global.system_time();
+                TeeTime {
+                    // `seconds` is a u32 in the GP `TEE_Time`; saturate rather than wrap.
+                    seconds: u32::try_from(elapsed.as_secs()).unwrap_or(u32::MAX),
+                    millis: elapsed.subsec_millis(),
+                }
+            }
+            // Persistent time was never set by this TA; report it per the spec.
+            TeeTimeCategory::TaPersistent => return Err(TeeResult::TimeNotSet),
+            // REE (normal-world) time requires an RPC the shim does not issue.
+            TeeTimeCategory::Ree => return Err(TeeResult::NotSupported),
+        };
+        time.write_at_offset(0, tee_time)
+            .ok_or(TeeResult::AccessDenied)
     }
 }
 

--- a/litebox_shim_optee/src/syscalls/tests.rs
+++ b/litebox_shim_optee/src/syscalls/tests.rs
@@ -41,3 +41,28 @@ fn test_cryp_random_number_generate() {
     let result = task.sys_cryp_random_number_generate(&mut buf);
     assert!(result.is_ok() && buf != [0u8; 16]);
 }
+
+#[test]
+fn test_sys_get_time_system_is_monotonic() {
+    use litebox::platform::RawConstPointer as _;
+    use litebox_common_optee::{TeeTime, TeeTimeCategory};
+
+    let task = init_platform();
+
+    let mut first = TeeTime::default();
+    let first_ptr = crate::UserMutPtr::<TeeTime>::from_usize(&raw mut first as usize);
+    task.sys_get_time(TeeTimeCategory::System, first_ptr)
+        .expect("system time should be supported");
+
+    let mut second = TeeTime::default();
+    let second_ptr = crate::UserMutPtr::<TeeTime>::from_usize(&raw mut second as usize);
+    task.sys_get_time(TeeTimeCategory::System, second_ptr)
+        .expect("system time should be supported");
+
+    // `millis` is the sub-second remainder, so always in `0..1000`.
+    assert!(first.millis < 1000 && second.millis < 1000);
+
+    let first_ms = u64::from(first.seconds) * 1000 + u64::from(first.millis);
+    let second_ms = u64::from(second.seconds) * 1000 + u64::from(second.millis);
+    assert!(second_ms >= first_ms, "system time went backwards");
+}


### PR DESCRIPTION
This PR adds OP-TEE `GetSystemTime` and revises the LVBS platform's `Instant`. The OP-TEE system time is per-instance monotonic time. Also, it now uses Hyper-V's partition reference-counter tick that is a monotonic, frequency-invariant counter.