### PR TITLE
Harden `ARCH_SET_FS` against invalid FS base

### DIFF
--- a/litebox/src/platform/arch.rs
+++ b/litebox/src/platform/arch.rs
@@ -58,4 +58,6 @@ pub enum ArchSpecificError {
     RegisterUnsupported,
     #[error("register is reserved by the platform and access is not allowed")]
     RegisterReserved,
+    #[error("register value is outside the permitted range")]
+    RegisterUnpermittedValue,
 }

--- a/litebox_common_linux/src/errno/mod.rs
+++ b/litebox_common_linux/src/errno/mod.rs
@@ -619,6 +619,7 @@ impl From<litebox::platform::ArchSpecificError> for Errno {
                 unimplemented!()
             }
             litebox::platform::ArchSpecificError::RegisterReserved => Errno::EINVAL,
+            litebox::platform::ArchSpecificError::RegisterUnpermittedValue => Errno::EPERM,
             _ => unimplemented!(),
         }
     }

--- a/litebox_common_linux/src/lib.rs
+++ b/litebox_common_linux/src/lib.rs
@@ -3206,6 +3206,16 @@ pub mod arch {
         | EFLAGS_OF
         | EFLAGS_RF
         | EFLAGS_ID;
+
+    /// Returns whether `base` is a valid x86_64 Linux user FS-segment base.
+    ///
+    /// A user FS base is valid iff it is below the top of the user address
+    /// space. `wrfsbase` with an invalid (i.e., non-canonical) value can
+    /// result in #GP. This check is based on Linux kernel's `do_arch_prctl_64`.
+    #[must_use]
+    pub fn is_valid_user_fs_base(base: usize) -> bool {
+        base < USER_ADDR_END
+    }
 }
 
 #[cfg(target_arch = "aarch64")]

--- a/litebox_common_linux/src/lib.rs
+++ b/litebox_common_linux/src/lib.rs
@@ -3210,8 +3210,9 @@ pub mod arch {
     /// Returns whether `base` is a valid x86_64 Linux user FS-segment base.
     ///
     /// A user FS base is valid iff it is below the top of the user address
-    /// space. `wrfsbase` with an invalid (i.e., non-canonical) value can
-    /// result in #GP. This check is based on Linux kernel's `do_arch_prctl_64`.
+    /// space. Especially, if a given address is non-canonical, `wrfsbase`
+    /// can result in a #GP fault. This check is based on Linux kernel's
+    /// `do_arch_prctl_64`.
     #[must_use]
     pub fn is_valid_user_fs_base(base: usize) -> bool {
         base < USER_ADDR_END

--- a/litebox_platform_linux_kernel/src/lib.rs
+++ b/litebox_platform_linux_kernel/src/lib.rs
@@ -79,8 +79,12 @@ impl<Host: HostInterface> ArchSpecificProvider for LinuxKernel<Host> {
     ) -> Result<(), ArchSpecificError> {
         match reg {
             ArchSpecificRegister::FsBase => {
-                unsafe { litebox_common_linux::wrfsbase(val) };
-                Ok(())
+                if litebox_common_linux::arch::is_valid_user_fs_base(val) {
+                    unsafe { litebox_common_linux::wrfsbase(val) };
+                    Ok(())
+                } else {
+                    Err(ArchSpecificError::RegisterUnpermittedValue)
+                }
             }
             ArchSpecificRegister::GsBase => {
                 // See https://github.com/microsoft/litebox/pull/806#discussion_r3210873538

--- a/litebox_platform_linux_userland/src/lib.rs
+++ b/litebox_platform_linux_userland/src/lib.rs
@@ -1295,8 +1295,12 @@ impl litebox::platform::ArchSpecificProvider for LinuxUserland {
     ) -> Result<(), litebox::platform::ArchSpecificError> {
         match reg {
             litebox::platform::ArchSpecificRegister::FsBase => {
-                set_guest_fsbase(val);
-                Ok(())
+                if litebox_common_linux::arch::is_valid_user_fs_base(val) {
+                    set_guest_fsbase(val);
+                    Ok(())
+                } else {
+                    Err(litebox::platform::ArchSpecificError::RegisterUnpermittedValue)
+                }
             }
             litebox::platform::ArchSpecificRegister::GsBase => {
                 // GS base is used internally by this platform to hold the host

--- a/litebox_platform_lvbs/src/lib.rs
+++ b/litebox_platform_lvbs/src/lib.rs
@@ -467,8 +467,12 @@ impl<Host: HostInterface> ArchSpecificProvider for LinuxKernel<Host> {
     ) -> Result<(), ArchSpecificError> {
         match reg {
             ArchSpecificRegister::FsBase => {
-                unsafe { litebox_common_linux::wrfsbase(val) };
-                Ok(())
+                if litebox_common_linux::arch::is_valid_user_fs_base(val) {
+                    unsafe { litebox_common_linux::wrfsbase(val) };
+                    Ok(())
+                } else {
+                    Err(ArchSpecificError::RegisterUnpermittedValue)
+                }
             }
             ArchSpecificRegister::GsBase => {
                 // See https://github.com/microsoft/litebox/pull/806#discussion_r3210873538

--- a/litebox_platform_windows_userland/src/lib.rs
+++ b/litebox_platform_windows_userland/src/lib.rs
@@ -1480,9 +1480,13 @@ impl litebox::platform::ArchSpecificProvider for WindowsUserland {
     ) -> Result<(), litebox::platform::ArchSpecificError> {
         match reg {
             litebox::platform::ArchSpecificRegister::FsBase => {
-                // Use WindowsUserland's per-thread FS base management system
-                Self::set_thread_fs_base(val);
-                Ok(())
+                if litebox_common_linux::arch::is_valid_user_fs_base(val) {
+                    // Use WindowsUserland's per-thread FS base management system
+                    Self::set_thread_fs_base(val);
+                    Ok(())
+                } else {
+                    Err(litebox::platform::ArchSpecificError::RegisterUnpermittedValue)
+                }
             }
             litebox::platform::ArchSpecificRegister::GsBase => {
                 // Windows uses GS for its own thread environment block

--- a/litebox_shim_linux/src/syscalls/process.rs
+++ b/litebox_shim_linux/src/syscalls/process.rs
@@ -656,6 +656,13 @@ impl<FS: ShimFS> Task<FS> {
         let tls = if flags.contains(CloneFlags::SETTLS) {
             let addr = tls.trunc();
             #[cfg(target_arch = "x86_64")]
+            {
+                // Validate the user-controlled TLS base before spawning the thread.
+                if !litebox_common_linux::arch::is_valid_user_fs_base(addr) {
+                    return Err(Errno::EPERM);
+                }
+            }
+            #[cfg(target_arch = "x86_64")]
             let desc = MutPtr::from_usize(addr);
             Some(desc)
         } else {


### PR DESCRIPTION
This PR hardens `ARCH_SET_FS` against invalid FS base values including kernel addresses and non-canonical values. Non-canonical values are particularly dangerous because they can result in a GP fault. This PR checks the value before writing it to the register.