### PR TITLE
Support mounting file systems & migrate devices to use mounts

### DIFF
--- a/litebox/src/fs/backend.rs
+++ b/litebox/src/fs/backend.rs
@@ -211,7 +211,10 @@ impl<'a> WalkingDirHandle<'a> {
         }
     }
 
-    /// Recover the concrete walking handle stored in this erased handle for `B`.
+    /// Recover the concrete handle stored in this erased handle.
+    ///
+    /// Intended to be called by backend implementations as `handle.into_typed::<Self>()` on
+    /// handles that the resolver passed back to the same backend; it may panic otherwise.
     pub(super) fn into_typed<B: BackendHandles + 'static>(self) -> B::WalkingDirHandle<'a> {
         assert_eq!(
             self.backend_type,
@@ -234,6 +237,10 @@ impl FileHandle {
         }
     }
 
+    /// Borrow the concrete handle stored in this erased handle.
+    ///
+    /// Intended to be called by backend implementations as `handle.get_typed::<Self>()` on handles
+    /// that the resolver passed back to the same backend; it may panic otherwise.
     pub(super) fn get_typed<B: BackendHandles>(&self) -> &B::FileHandle {
         (&*self.raw as &dyn Any)
             .downcast_ref::<B::FileHandle>()
@@ -248,12 +255,20 @@ impl DirHandle {
         }
     }
 
+    /// Borrow the concrete handle stored in this erased handle.
+    ///
+    /// Intended to be called by backend implementations as `handle.get_typed::<Self>()` on handles
+    /// that the resolver passed back to the same backend; it may panic otherwise.
     pub(super) fn get_typed<B: BackendHandles>(&self) -> &B::DirHandle {
         (&*self.raw as &dyn Any)
             .downcast_ref::<B::DirHandle>()
             .expect("backend directory handle type mismatch")
     }
 
+    /// Recover the concrete handle stored in this erased handle.
+    ///
+    /// Intended to be called by backend implementations as `handle.into_typed::<Self>()` on
+    /// handles that the resolver passed back to the same backend; it may panic otherwise.
     pub(super) fn into_typed<B: BackendHandles>(self) -> B::DirHandle {
         let raw: Box<dyn Any> = self.raw;
         *raw.downcast::<B::DirHandle>()

--- a/litebox/src/fs/composer.rs
+++ b/litebox/src/fs/composer.rs
@@ -56,6 +56,8 @@ struct VirtualDir {
 /// Composer construction errors.
 #[derive(Error, Debug, Clone, PartialEq, Eq)]
 pub enum BuildError {
+    #[error("composer must have at least one mount")]
+    NoMounts,
     #[error("mount paths must be absolute normalized paths")]
     InvalidMountPath,
     #[error("two backends were mounted at the same path")]
@@ -92,6 +94,10 @@ impl ComposerBuilder {
 
     /// Validate mount paths and finalize the composer.
     pub fn build(self) -> Result<Composer, BuildError> {
+        if self.mounts.is_empty() {
+            return Err(BuildError::NoMounts);
+        }
+
         let mut mounts = vec![];
         let mut paths = vec![];
         for (raw, backend) in self.mounts {

--- a/litebox/src/fs/composer.rs
+++ b/litebox/src/fs/composer.rs
@@ -1,0 +1,763 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//! Support for composing [`Backend`]s by mounting them.
+
+use alloc::boxed::Box;
+use alloc::format;
+use alloc::string::{String, ToString};
+use alloc::vec;
+use alloc::vec::Vec;
+
+use super::backend::{
+    Backend, BackendHandles, DirHandle, FileHandle, PermissionCheck, Permissioned, SeekBehavior,
+    WalkOutcome, WalkStopReason, WalkedComponent, WalkingDirHandle,
+};
+use super::errors::{
+    ChmodError, ChownError, FileStatusError, MkdirError, OpenError, PathError, ReadDirError,
+    ReadError, RmdirError, TruncateError, UnlinkError, WalkError, WriteError,
+};
+use super::inode_allocator::InodeAllocator;
+use super::{DirEntry, FileStatus, FileType, Mode, NodeInfo, OFlags, UserInfo};
+use crate::path::Arg;
+use thiserror::Error;
+
+// XXX(jayb): consider removing this via a runtime reserved device ID?
+const VIRTUAL_DIR_DEVICE_ID: u64 = 0x436f_6d70;
+
+/// A [`Backend`] composed from mounted [`Backend`]s at various paths.
+pub struct Composer {
+    mounts: Vec<Mount>,
+    // TODO(jayb): We have these to account for `/mnt` in something like mounting `/mnt/foo`; I am
+    // not certain this is the best design (maybe we should have something _explicitly_ make
+    // `/mnt`), but for now, this is the design I've chosen.
+    virtual_dirs: Vec<VirtualDir>,
+}
+
+/// A [`Composer`] builder.
+pub struct ComposerBuilder {
+    mounts: Vec<(Option<String>, Box<dyn Backend>)>,
+    next_backend_device_id: u64,
+}
+
+/// A mounted backend.
+struct Mount {
+    path: Vec<String>,
+    backend: Box<dyn Backend>,
+}
+
+/// Synthetic directory needed to connect mount points.
+#[derive(Clone)]
+struct VirtualDir {
+    path: Vec<String>,
+    node_info: NodeInfo,
+}
+
+/// Composer construction errors.
+#[derive(Error, Debug, Clone, PartialEq, Eq)]
+pub enum BuildError {
+    #[error("mount paths must be absolute normalized paths")]
+    InvalidMountPath,
+    #[error("two backends were mounted at the same path")]
+    DuplicateMountPath,
+}
+
+impl Composer {
+    /// Start building an empty composer.
+    #[must_use]
+    pub fn builder() -> ComposerBuilder {
+        ComposerBuilder {
+            mounts: vec![],
+            next_backend_device_id: 1,
+        }
+    }
+}
+
+impl ComposerBuilder {
+    /// Add a backend mounted at `path`.
+    #[must_use]
+    pub fn mount<B: Backend>(
+        mut self,
+        path: impl Arg,
+        backend: impl FnOnce(InodeAllocator) -> B,
+    ) -> Self {
+        let backend_device_id = self.next_backend_device_id;
+        // TODO(jayb): Decide whether we need a fallible version of closure-based mount.
+        let backend = backend(InodeAllocator::for_device(backend_device_id));
+        self.mounts
+            .push((path.as_rust_str().map(Into::into).ok(), Box::new(backend)));
+        self.next_backend_device_id = backend_device_id + 1;
+        self
+    }
+
+    /// Validate mount paths and finalize the composer.
+    pub fn build(self) -> Result<Composer, BuildError> {
+        let mut mounts = vec![];
+        let mut paths = vec![];
+        for (raw, backend) in self.mounts {
+            let raw = raw.ok_or(BuildError::InvalidMountPath)?;
+            if !raw.starts_with('/') {
+                return Err(BuildError::InvalidMountPath);
+            }
+            let path: Vec<String> = raw
+                .split('/')
+                .skip(1)
+                .filter(|component| !component.is_empty())
+                .map(ToString::to_string)
+                .collect();
+            if path
+                .iter()
+                .any(|component| component == "." || component == "..")
+            {
+                return Err(BuildError::InvalidMountPath);
+            }
+            if raw != format!("/{}", path.join("/")) {
+                // Just confirming that it is absolute + canonical
+                return Err(BuildError::InvalidMountPath);
+            }
+            paths.push(path.clone());
+            mounts.push(Mount { path, backend });
+        }
+
+        let sorted_paths = {
+            let mut p = paths.clone();
+            p.sort();
+            p
+        };
+        if sorted_paths.array_windows().any(|[a, b]| a == b) {
+            return Err(BuildError::DuplicateMountPath);
+        }
+
+        // TODO(jayb): Decide whether mounting a deep path should implicitly synthesize
+        // missing ancestor directories like `/mnt` and `/mnt/foo`.
+        let virtual_dir_allocator = InodeAllocator::for_device(VIRTUAL_DIR_DEVICE_ID);
+        let mut virtual_dirs = vec![];
+        for mount_path in paths {
+            for len in 0..mount_path.len() {
+                let path = mount_path[..len].to_vec();
+                if MountRelation::of(&mounts, &path) == MountRelation::Exact
+                    || virtual_dirs.iter().any(|dir: &VirtualDir| dir.path == path)
+                {
+                    continue;
+                }
+                virtual_dirs.push(VirtualDir {
+                    path,
+                    node_info: virtual_dir_allocator.next(),
+                });
+            }
+        }
+
+        // TODO(jayb): Validate mounted backend device IDs once backends expose that cheaply.
+        Ok(Composer {
+            mounts,
+            virtual_dirs,
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum MountRelation {
+    Exact,
+    AncestorOfMount,
+    Unrelated,
+}
+
+impl MountRelation {
+    fn of(mounts: &[Mount], path: &[String]) -> Self {
+        for mount in mounts {
+            if mount.path == path {
+                return MountRelation::Exact;
+            }
+            if path.len() < mount.path.len() && mount.path.starts_with(path) {
+                return MountRelation::AncestorOfMount;
+            }
+        }
+        MountRelation::Unrelated
+    }
+}
+
+impl Composer {
+    fn mount_relation(&self, path: &[String]) -> MountRelation {
+        MountRelation::of(&self.mounts, path)
+    }
+
+    /// This function exists primarily to simplify + mark implementations of mutating operations
+    /// where the mutation semantics of exact mount points have not been fully figured out. This is
+    /// equivalnet to `Ok(path + [name])`, but errors out if anything is either a mount point or an
+    /// ancestor of a mount point.
+    fn checked_child_path<E>(
+        &self,
+        mut path: Vec<String>,
+        name: &str,
+        error: E,
+    ) -> Result<Vec<String>, E> {
+        path.push(name.to_string());
+        if self.mount_relation(&path) != MountRelation::Unrelated {
+            // TODO(jayb): Define mutation semantics for exact mount points.
+            return Err(error);
+        }
+        Ok(path)
+    }
+
+    /// Returns child names from mount paths only; mounted backend contents are not inspected.
+    fn immediate_mount_children(&self, path: &[String]) -> Vec<String> {
+        let mut children = vec![];
+        for mount in &self.mounts {
+            if path.len() < mount.path.len() && mount.path.starts_with(path) {
+                let child = mount.path[path.len()].clone();
+                if !children.contains(&child) {
+                    children.push(child);
+                }
+            }
+        }
+        children
+    }
+
+    fn list_mount_children(&self, path: &[String]) -> Vec<DirEntry> {
+        self.immediate_mount_children(path)
+            .into_iter()
+            .map(|name| DirEntry {
+                name,
+                file_type: FileType::Directory,
+                // TODO(jayb): set up proper inode info for these
+                ino_info: None,
+            })
+            .collect()
+    }
+
+    fn merge_mount_children(&self, mut entries: Vec<DirEntry>, path: &[String]) -> Vec<DirEntry> {
+        for child in self.list_mount_children(path) {
+            entries.retain(|entry| entry.name != child.name);
+            entries.push(child);
+        }
+        entries
+    }
+
+    fn exact_mount_root(&self, path: &[String]) -> Option<(usize, WalkingDirHandle<'_>)> {
+        self.mounts
+            .iter()
+            .enumerate()
+            .find(|(_, mount)| mount.path == path)
+            .map(|(index, mount)| (index, mount.backend.root()))
+    }
+
+    fn root_handle(&self) -> ComposerWalkingDirHandle<'_> {
+        if let Some((mount_index, handle)) = self.exact_mount_root(&[]) {
+            ComposerWalkingDirHandleInner::Mounted {
+                path: vec![],
+                mount_index,
+                handle,
+            }
+            .into()
+        } else {
+            ComposerWalkingDirHandleInner::Virtual { path: vec![] }.into()
+        }
+    }
+
+    fn virtual_dir_status(&self, path: &[String]) -> FileStatus {
+        let node_info = self
+            .virtual_dirs
+            .iter()
+            .find(|dir| dir.path == path)
+            .map(|dir| dir.node_info.clone())
+            .expect("virtual directory is precomputed");
+        FileStatus {
+            file_type: FileType::Directory,
+            // rwxr-xr-x for virtual dirs
+            mode: Mode::RWXU | Mode::RGRP | Mode::XGRP | Mode::ROTH | Mode::XOTH,
+            size: super::DEFAULT_DIRECTORY_SIZE,
+            owner: UserInfo::ROOT,
+            node_info,
+            blksize: super::DEFAULT_DIRECTORY_SIZE,
+        }
+    }
+
+    /// Returns how many components can be walked before reaching another mount boundary.
+    fn mounted_walk_prefix_len(&self, path: &[String], components: &[&str]) -> usize {
+        let mut next_path = path.to_vec();
+        for (idx, component) in components.iter().enumerate() {
+            next_path.push((*component).to_string());
+            if self.mount_relation(&next_path) != MountRelation::Unrelated {
+                return idx;
+            }
+        }
+        components.len()
+    }
+}
+
+/// Borrowed directory handle in a composed filesystem namespace.
+pub struct ComposerWalkingDirHandle<'a> {
+    inner: ComposerWalkingDirHandleInner<'a>,
+}
+
+enum ComposerWalkingDirHandleInner<'a> {
+    Virtual {
+        path: Vec<String>,
+    },
+    Mounted {
+        path: Vec<String>,
+        mount_index: usize,
+        handle: WalkingDirHandle<'a>,
+    },
+}
+
+impl<'a> From<ComposerWalkingDirHandleInner<'a>> for ComposerWalkingDirHandle<'a> {
+    fn from(inner: ComposerWalkingDirHandleInner<'a>) -> Self {
+        Self { inner }
+    }
+}
+
+/// File handle in a composed filesystem namespace.
+pub struct ComposerFileHandle {
+    mount_index: usize,
+    handle: FileHandle,
+}
+
+/// Owned directory handle in a composed filesystem namespace.
+pub struct ComposerDirHandle {
+    inner: ComposerDirHandleInner,
+}
+
+enum ComposerDirHandleInner {
+    Virtual {
+        path: Vec<String>,
+    },
+    Mounted {
+        path: Vec<String>,
+        mount_index: usize,
+        handle: DirHandle,
+    },
+}
+
+impl From<ComposerDirHandleInner> for ComposerDirHandle {
+    fn from(inner: ComposerDirHandleInner) -> Self {
+        Self { inner }
+    }
+}
+
+impl Clone for ComposerFileHandle {
+    fn clone(&self) -> Self {
+        Self {
+            mount_index: self.mount_index,
+            handle: self.handle.clone(),
+        }
+    }
+}
+
+impl Clone for ComposerDirHandle {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+impl Clone for ComposerDirHandleInner {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Virtual { path } => Self::Virtual { path: path.clone() },
+            Self::Mounted {
+                path,
+                mount_index,
+                handle,
+            } => Self::Mounted {
+                path: path.clone(),
+                mount_index: *mount_index,
+                handle: handle.clone(),
+            },
+        }
+    }
+}
+
+impl super::backend::private::Sealed for Composer {}
+
+impl BackendHandles for Composer {
+    type WalkingDirHandle<'a> = ComposerWalkingDirHandle<'a>;
+    type FileHandle = ComposerFileHandle;
+    type DirHandle = ComposerDirHandle;
+}
+
+impl Backend for Composer {
+    fn root(&self) -> WalkingDirHandle<'_> {
+        WalkingDirHandle::from_typed::<Self>(self.root_handle())
+    }
+
+    fn walk_directories<'a>(
+        &'a self,
+        from: WalkingDirHandle<'a>,
+        components: &[&str],
+    ) -> Result<WalkOutcome<WalkingDirHandle<'a>>, WalkError> {
+        const BY_BACKEND: WalkedComponent = WalkedComponent {
+            permissions: PermissionCheck::ByBackend,
+        };
+        let mut current = from.into_typed::<Self>();
+        let mut walked_components = Vec::with_capacity(components.len());
+        let mut index = 0;
+        while index < components.len() {
+            let component = components[index];
+            match current.inner {
+                ComposerWalkingDirHandleInner::Virtual { mut path } => {
+                    path.push(component.to_string());
+                    if let Some((mount_index, handle)) = self.exact_mount_root(&path) {
+                        walked_components.push(BY_BACKEND);
+                        current = ComposerWalkingDirHandleInner::Mounted {
+                            path,
+                            mount_index,
+                            handle,
+                        }
+                        .into();
+                    } else if self.mount_relation(&path) == MountRelation::AncestorOfMount {
+                        walked_components.push(BY_BACKEND);
+                        current = ComposerWalkingDirHandleInner::Virtual { path }.into();
+                    } else {
+                        return Err(WalkError::PathError(PathError::NoSuchFileOrDirectory));
+                    }
+                    index += 1;
+                }
+                ComposerWalkingDirHandleInner::Mounted {
+                    path,
+                    mount_index,
+                    handle,
+                } => {
+                    let mut child_path = path.clone();
+                    child_path.push(component.to_string());
+                    if let Some((child_mount_index, child_handle)) =
+                        self.exact_mount_root(&child_path)
+                    {
+                        walked_components.push(BY_BACKEND);
+                        current = ComposerWalkingDirHandleInner::Mounted {
+                            path: child_path,
+                            mount_index: child_mount_index,
+                            handle: child_handle,
+                        }
+                        .into();
+                        index += 1;
+                    } else if self.mount_relation(&child_path) == MountRelation::AncestorOfMount {
+                        walked_components.push(BY_BACKEND);
+                        current =
+                            ComposerWalkingDirHandleInner::Virtual { path: child_path }.into();
+                        index += 1;
+                    } else {
+                        // TODO(jayb): Decide whether future backends need absolute-ish namespace
+                        // views instead of this mount-root-relative suffix view. POSIX `..` across
+                        // mount roots is also deferred; the resolver normalizes it before walking.
+                        let prefix_len = self.mounted_walk_prefix_len(&path, &components[index..]);
+                        assert!(prefix_len > 0);
+                        let outcome = self.mounts[mount_index]
+                            .backend
+                            .walk_directories(handle, &components[index..index + prefix_len])?;
+                        let walked_len = outcome.components.len();
+                        assert!(
+                            outcome.stop_reason != WalkStopReason::CompleteDirectory
+                                || walked_len == prefix_len
+                        );
+                        walked_components.extend(outcome.components);
+                        let last = ComposerWalkingDirHandleInner::Mounted {
+                            path: path
+                                .into_iter()
+                                .chain(
+                                    components[index..index + walked_len]
+                                        .iter()
+                                        .map(ToString::to_string),
+                                )
+                                .collect(),
+                            mount_index,
+                            handle: outcome.last,
+                        }
+                        .into();
+                        match outcome.stop_reason {
+                            WalkStopReason::CompleteDirectory => {
+                                index += walked_len;
+                                current = last;
+                            }
+                            WalkStopReason::StoppedAtNonDirectory | WalkStopReason::Continue => {
+                                return Ok(WalkOutcome {
+                                    components: walked_components,
+                                    last: WalkingDirHandle::from_typed::<Self>(last),
+                                    stop_reason: outcome.stop_reason,
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(WalkOutcome {
+            components: walked_components,
+            last: WalkingDirHandle::from_typed::<Self>(current),
+            stop_reason: WalkStopReason::CompleteDirectory,
+        })
+    }
+
+    fn owned_dir_at(&self, dir: WalkingDirHandle<'_>) -> DirHandle {
+        let dir = dir.into_typed::<Self>();
+        DirHandle::from_typed::<Self>(ComposerDirHandle {
+            inner: match dir.inner {
+                ComposerWalkingDirHandleInner::Virtual { path } => {
+                    ComposerDirHandleInner::Virtual { path }
+                }
+                ComposerWalkingDirHandleInner::Mounted {
+                    path,
+                    mount_index,
+                    handle,
+                } => ComposerDirHandleInner::Mounted {
+                    path,
+                    mount_index,
+                    handle: self.mounts[mount_index].backend.owned_dir_at(handle),
+                },
+            },
+        })
+    }
+
+    fn walking_dir_at<'a>(&'a self, dir: &DirHandle) -> Option<WalkingDirHandle<'a>> {
+        let dir = dir.get_typed::<Self>();
+        match &dir.inner {
+            ComposerDirHandleInner::Virtual { path } => Some(WalkingDirHandle::from_typed::<Self>(
+                ComposerWalkingDirHandleInner::Virtual { path: path.clone() }.into(),
+            )),
+            ComposerDirHandleInner::Mounted {
+                path,
+                mount_index,
+                handle,
+            } => self.mounts[*mount_index]
+                .backend
+                .walking_dir_at(handle)
+                .map(|handle| {
+                    WalkingDirHandle::from_typed::<Self>(
+                        ComposerWalkingDirHandleInner::Mounted {
+                            path: path.clone(),
+                            mount_index: *mount_index,
+                            handle,
+                        }
+                        .into(),
+                    )
+                }),
+        }
+    }
+
+    fn open_file_at(
+        &self,
+        dir: WalkingDirHandle<'_>,
+        name: &str,
+        flags: OFlags,
+    ) -> Result<Permissioned<FileHandle>, OpenError> {
+        let dir = dir.into_typed::<Self>();
+        match dir.inner {
+            ComposerWalkingDirHandleInner::Virtual { .. } => {
+                Err(OpenError::PathError(PathError::NoSuchFileOrDirectory))
+            }
+            ComposerWalkingDirHandleInner::Mounted {
+                path,
+                mount_index,
+                handle,
+            } => {
+                self.checked_child_path(
+                    path,
+                    name,
+                    OpenError::PathError(PathError::NoSuchFileOrDirectory),
+                )?;
+                self.mounts[mount_index]
+                    .backend
+                    .open_file_at(handle, name, flags)
+                    .map(|file| Permissioned {
+                        item: FileHandle::from_typed::<Self>(ComposerFileHandle {
+                            mount_index,
+                            handle: file.item,
+                        }),
+                        permissions: file.permissions,
+                    })
+            }
+        }
+    }
+
+    fn list_dir_at(&self, handle: DirHandle) -> Result<Vec<DirEntry>, ReadDirError> {
+        let handle = handle.into_typed::<Self>();
+        match handle.inner {
+            ComposerDirHandleInner::Virtual { path } => Ok(self.list_mount_children(&path)),
+            ComposerDirHandleInner::Mounted {
+                path,
+                mount_index,
+                handle,
+            } => {
+                let entries = self.mounts[mount_index].backend.list_dir_at(handle)?;
+                Ok(self.merge_mount_children(entries, &path))
+            }
+        }
+    }
+
+    fn read(&self, h: &FileHandle, buf: &mut [u8], offset: usize) -> Result<usize, ReadError> {
+        let h = h.get_typed::<Self>();
+        self.mounts[h.mount_index]
+            .backend
+            .read(&h.handle, buf, offset)
+    }
+
+    fn get_static_backing_data(&self, h: &FileHandle) -> Option<&'static [u8]> {
+        let h = h.get_typed::<Self>();
+        self.mounts[h.mount_index]
+            .backend
+            .get_static_backing_data(&h.handle)
+    }
+
+    fn write(&self, h: &FileHandle, buf: &[u8], offset: usize) -> Result<usize, WriteError> {
+        let h = h.get_typed::<Self>();
+        self.mounts[h.mount_index]
+            .backend
+            .write(&h.handle, buf, offset)
+    }
+
+    fn truncate(&self, h: &FileHandle, length: usize) -> Result<(), TruncateError> {
+        let h = h.get_typed::<Self>();
+        self.mounts[h.mount_index]
+            .backend
+            .truncate(&h.handle, length)
+    }
+
+    fn seek_behavior(&self, h: &FileHandle) -> SeekBehavior {
+        let h = h.get_typed::<Self>();
+        self.mounts[h.mount_index].backend.seek_behavior(&h.handle)
+    }
+
+    fn file_status(&self, h: &FileHandle) -> Result<FileStatus, FileStatusError> {
+        let h = h.get_typed::<Self>();
+        self.mounts[h.mount_index].backend.file_status(&h.handle)
+    }
+
+    fn dir_status(&self, h: &DirHandle) -> Result<FileStatus, FileStatusError> {
+        let h = h.get_typed::<Self>();
+        match &h.inner {
+            ComposerDirHandleInner::Virtual { path } => Ok(self.virtual_dir_status(path)),
+            ComposerDirHandleInner::Mounted {
+                mount_index,
+                handle,
+                ..
+            } => self.mounts[*mount_index].backend.dir_status(handle),
+        }
+    }
+
+    fn create_file_at(
+        &self,
+        dir: DirHandle,
+        name: &str,
+        mode: Mode,
+    ) -> Result<FileHandle, OpenError> {
+        let dir = dir.into_typed::<Self>();
+        match dir.inner {
+            ComposerDirHandleInner::Virtual { .. } => Err(OpenError::ReadOnlyFileSystem),
+            ComposerDirHandleInner::Mounted {
+                path,
+                mount_index,
+                handle,
+            } => {
+                self.checked_child_path(path, name, OpenError::ReadOnlyFileSystem)?;
+                self.mounts[mount_index]
+                    .backend
+                    .create_file_at(handle, name, mode)
+                    .map(|handle| {
+                        FileHandle::from_typed::<Self>(ComposerFileHandle {
+                            mount_index,
+                            handle,
+                        })
+                    })
+            }
+        }
+    }
+
+    fn mkdir_at(&self, dir: DirHandle, name: &str, mode: Mode) -> Result<DirHandle, MkdirError> {
+        let dir = dir.into_typed::<Self>();
+        match dir.inner {
+            ComposerDirHandleInner::Virtual { .. } => Err(MkdirError::ReadOnlyFileSystem),
+            ComposerDirHandleInner::Mounted {
+                path,
+                mount_index,
+                handle,
+            } => {
+                let path = self.checked_child_path(path, name, MkdirError::ReadOnlyFileSystem)?;
+                self.mounts[mount_index]
+                    .backend
+                    .mkdir_at(handle, name, mode)
+                    .map(|handle| {
+                        DirHandle::from_typed::<Self>(
+                            ComposerDirHandleInner::Mounted {
+                                path,
+                                mount_index,
+                                handle,
+                            }
+                            .into(),
+                        )
+                    })
+            }
+        }
+    }
+
+    fn unlink_at(&self, dir: DirHandle, name: &str) -> Result<(), UnlinkError> {
+        let dir = dir.into_typed::<Self>();
+        match dir.inner {
+            ComposerDirHandleInner::Virtual { .. } => Err(UnlinkError::ReadOnlyFileSystem),
+            ComposerDirHandleInner::Mounted {
+                path,
+                mount_index,
+                handle,
+            } => {
+                self.checked_child_path(path, name, UnlinkError::ReadOnlyFileSystem)?;
+                self.mounts[mount_index].backend.unlink_at(handle, name)
+            }
+        }
+    }
+
+    fn rmdir_at(&self, dir: DirHandle, name: &str) -> Result<(), RmdirError> {
+        let dir = dir.into_typed::<Self>();
+        match dir.inner {
+            ComposerDirHandleInner::Virtual { .. } => Err(RmdirError::ReadOnlyFileSystem),
+            ComposerDirHandleInner::Mounted {
+                path,
+                mount_index,
+                handle,
+            } => {
+                self.checked_child_path(path, name, RmdirError::ReadOnlyFileSystem)?;
+                self.mounts[mount_index].backend.rmdir_at(handle, name)
+            }
+        }
+    }
+
+    fn chmod_at(&self, dir: DirHandle, name: &str, mode: Mode) -> Result<(), ChmodError> {
+        let dir = dir.into_typed::<Self>();
+        match dir.inner {
+            ComposerDirHandleInner::Virtual { .. } => Err(ChmodError::ReadOnlyFileSystem),
+            ComposerDirHandleInner::Mounted {
+                path,
+                mount_index,
+                handle,
+            } => {
+                self.checked_child_path(path, name, ChmodError::ReadOnlyFileSystem)?;
+                self.mounts[mount_index]
+                    .backend
+                    .chmod_at(handle, name, mode)
+            }
+        }
+    }
+
+    fn chown_at(
+        &self,
+        dir: DirHandle,
+        name: &str,
+        user: Option<u16>,
+        group: Option<u16>,
+    ) -> Result<(), ChownError> {
+        let dir = dir.into_typed::<Self>();
+        match dir.inner {
+            ComposerDirHandleInner::Virtual { .. } => Err(ChownError::ReadOnlyFileSystem),
+            ComposerDirHandleInner::Mounted {
+                path,
+                mount_index,
+                handle,
+            } => {
+                self.checked_child_path(path, name, ChownError::ReadOnlyFileSystem)?;
+                self.mounts[mount_index]
+                    .backend
+                    .chown_at(handle, name, user, group)
+            }
+        }
+    }
+}

--- a/litebox/src/fs/composer.rs
+++ b/litebox/src/fs/composer.rs
@@ -439,10 +439,55 @@ impl Backend for Composer {
                         .into();
                         index += 1;
                     } else if self.mount_relation(&child_path) == MountRelation::AncestorOfMount {
-                        walked_components.push(BY_BACKEND);
-                        current =
-                            ComposerWalkingDirHandleInner::Virtual { path: child_path }.into();
-                        index += 1;
+                        match self.mounts[mount_index]
+                            .backend
+                            .walk_directories(handle, &[component])
+                        {
+                            Ok(outcome) => {
+                                let walked_len = outcome.components.len();
+                                assert!(walked_len <= 1);
+                                assert!(
+                                    outcome.stop_reason != WalkStopReason::CompleteDirectory
+                                        || walked_len == 1
+                                );
+                                walked_components.extend(outcome.components);
+                                let last = ComposerWalkingDirHandleInner::Mounted {
+                                    path: path
+                                        .into_iter()
+                                        .chain(
+                                            components[index..index + walked_len]
+                                                .iter()
+                                                .map(ToString::to_string),
+                                        )
+                                        .collect(),
+                                    mount_index,
+                                    handle: outcome.last,
+                                }
+                                .into();
+                                match outcome.stop_reason {
+                                    WalkStopReason::CompleteDirectory => {
+                                        index += walked_len;
+                                        current = last;
+                                    }
+                                    WalkStopReason::StoppedAtNonDirectory
+                                    | WalkStopReason::Continue => {
+                                        return Ok(WalkOutcome {
+                                            components: walked_components,
+                                            last: WalkingDirHandle::from_typed::<Self>(last),
+                                            stop_reason: outcome.stop_reason,
+                                        });
+                                    }
+                                }
+                            }
+                            Err(WalkError::PathError(PathError::NoSuchFileOrDirectory)) => {
+                                walked_components.push(BY_BACKEND);
+                                current =
+                                    ComposerWalkingDirHandleInner::Virtual { path: child_path }
+                                        .into();
+                                index += 1;
+                            }
+                            Err(error) => return Err(error),
+                        }
                     } else {
                         // TODO(jayb): Decide whether future backends need absolute-ish namespace
                         // views instead of this mount-root-relative suffix view. POSIX `..` across

--- a/litebox/src/fs/composer.rs
+++ b/litebox/src/fs/composer.rs
@@ -182,6 +182,11 @@ impl MountRelation {
     }
 }
 
+fn append_components(mut path: Vec<String>, components: &[&str]) -> Vec<String> {
+    path.extend(components.iter().map(|component| (*component).to_string()));
+    path
+}
+
 impl Composer {
     fn mount_relation(&self, path: &[String]) -> MountRelation {
         MountRelation::of(&self.mounts, path)
@@ -193,11 +198,11 @@ impl Composer {
     /// ancestor of a mount point.
     fn checked_child_path<E>(
         &self,
-        mut path: Vec<String>,
+        path: Vec<String>,
         name: &str,
         error: E,
     ) -> Result<Vec<String>, E> {
-        path.push(name.to_string());
+        let path = append_components(path, &[name]);
         if self.mount_relation(&path) != MountRelation::Unrelated {
             // TODO(jayb): Define mutation semantics for exact mount points.
             return Err(error);
@@ -282,7 +287,7 @@ impl Composer {
     fn mounted_walk_prefix_len(&self, path: &[String], components: &[&str]) -> usize {
         let mut next_path = path.to_vec();
         for (idx, component) in components.iter().enumerate() {
-            next_path.push((*component).to_string());
+            next_path = append_components(next_path, &[*component]);
             if self.mount_relation(&next_path) != MountRelation::Unrelated {
                 return idx;
             }
@@ -402,8 +407,8 @@ impl Backend for Composer {
         while index < components.len() {
             let component = components[index];
             match current.inner {
-                ComposerWalkingDirHandleInner::Virtual { mut path } => {
-                    path.push(component.to_string());
+                ComposerWalkingDirHandleInner::Virtual { path } => {
+                    let path = append_components(path, &[component]);
                     if let Some((mount_index, handle)) = self.exact_mount_root(&path) {
                         walked_components.push(BY_BACKEND);
                         current = ComposerWalkingDirHandleInner::Mounted {
@@ -425,8 +430,7 @@ impl Backend for Composer {
                     mount_index,
                     handle,
                 } => {
-                    let mut child_path = path.clone();
-                    child_path.push(component.to_string());
+                    let child_path = append_components(path.clone(), &[component]);
                     if let Some((child_mount_index, child_handle)) =
                         self.exact_mount_root(&child_path)
                     {
@@ -452,14 +456,10 @@ impl Backend for Composer {
                                 );
                                 walked_components.extend(outcome.components);
                                 let last = ComposerWalkingDirHandleInner::Mounted {
-                                    path: path
-                                        .into_iter()
-                                        .chain(
-                                            components[index..index + walked_len]
-                                                .iter()
-                                                .map(ToString::to_string),
-                                        )
-                                        .collect(),
+                                    path: append_components(
+                                        path,
+                                        &components[index..index + walked_len],
+                                    ),
                                     mount_index,
                                     handle: outcome.last,
                                 }
@@ -504,14 +504,7 @@ impl Backend for Composer {
                         );
                         walked_components.extend(outcome.components);
                         let last = ComposerWalkingDirHandleInner::Mounted {
-                            path: path
-                                .into_iter()
-                                .chain(
-                                    components[index..index + walked_len]
-                                        .iter()
-                                        .map(ToString::to_string),
-                                )
-                                .collect(),
+                            path: append_components(path, &components[index..index + walked_len]),
                             mount_index,
                             handle: outcome.last,
                         }

--- a/litebox/src/fs/devices.rs
+++ b/litebox/src/fs/devices.rs
@@ -135,19 +135,13 @@ where
 {
     /// Construct a new `Devices` backend.
     #[must_use]
-    pub(crate) fn new(litebox: &LiteBox<Platform>, allocator: InodeAllocator) -> Self {
+    pub fn new(litebox: &LiteBox<Platform>, allocator: InodeAllocator) -> Self {
         let dev_dir_inode = allocator.next();
         Self {
             litebox: litebox.clone(),
             dev_dir_inode,
             _alloc: allocator,
         }
-    }
-
-    /// Migration helper.  This function will disappear soon.
-    #[must_use]
-    pub fn migration_helper_standalone_new(litebox: &LiteBox<Platform>) -> Self {
-        Self::new(litebox, InodeAllocator::standalone())
     }
 }
 

--- a/litebox/src/fs/devices.rs
+++ b/litebox/src/fs/devices.rs
@@ -3,12 +3,10 @@
 
 //! Unix-y devices [`super::backend::Backend`].
 //!
-//! Provides `/dev/{stdin,stdout,null,urandom,...}`.
-
-// XXX(jayb): soon this will switch to just being {stdin,stdout,...}, so that it is _mounted_ at
-// `/dev/` rather than associated at `/`, but that will be later.
+//! Provides `{stdin,stdout,null,urandom,...}` entries, intended to be mounted at `/dev`.
 
 use alloc::string::String;
+use alloc::vec;
 use alloc::vec::Vec;
 
 use crate::LiteBox;
@@ -16,7 +14,7 @@ use crate::sync::RawSyncPrimitivesProvider;
 
 use super::backend::{
     Backend, BackendHandles, DirHandle, FileHandle, PermissionCheck, Permissioned, SeekBehavior,
-    WalkOutcome, WalkStopReason, WalkedComponent, WalkingDirHandle,
+    WalkOutcome, WalkStopReason, WalkingDirHandle,
 };
 use super::errors::{
     ChmodError, ChownError, FileStatusError, MkdirError, OpenError, PathError, ReadDirError,
@@ -121,8 +119,8 @@ where
         + 'static,
 {
     litebox: LiteBox<Platform>,
-    /// Stable inode info for `/dev`.
-    dev_dir_inode: NodeInfo,
+    /// Stable inode info for this backend's root directory.
+    root_inode: NodeInfo,
     _alloc: InodeAllocator,
 }
 
@@ -136,19 +134,13 @@ where
     /// Construct a new `Devices` backend.
     #[must_use]
     pub fn new(litebox: &LiteBox<Platform>, allocator: InodeAllocator) -> Self {
-        let dev_dir_inode = allocator.next();
+        let root_inode = allocator.next();
         Self {
             litebox: litebox.clone(),
-            dev_dir_inode,
+            root_inode,
             _alloc: allocator,
         }
     }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum Location {
-    Root,
-    Dev,
 }
 
 /// Owned file handle; identifies which device backs this fd.
@@ -161,9 +153,7 @@ pub struct DeviceFileHandle {
 // For devices, since no borrows are needed, we reuse this struct for both the walking handles as
 // well as the dir handles.
 #[derive(Debug, Clone, Copy)]
-pub struct DeviceDirHandle {
-    location: Location,
-}
+pub struct DeviceDirHandle;
 
 impl<Platform> super::backend::private::Sealed for Devices<Platform> where
     Platform: RawSyncPrimitivesProvider
@@ -193,9 +183,7 @@ where
         + 'static,
 {
     fn root(&self) -> WalkingDirHandle<'_> {
-        WalkingDirHandle::from_typed::<Self>(DeviceDirHandle {
-            location: Location::Root,
-        })
+        WalkingDirHandle::from_typed::<Self>(DeviceDirHandle)
     }
 
     fn walk_directories<'a>(
@@ -204,33 +192,20 @@ where
         components: &[&str],
     ) -> Result<WalkOutcome<WalkingDirHandle<'a>>, WalkError> {
         let from = from.into_typed::<Self>();
-        // This backend only exposes one directory below root. Device files are
-        // final path targets, so directory walking must stop before them.
-        let mut location = from.location;
-        let mut walked_components: Vec<WalkedComponent> = Vec::with_capacity(components.len());
-        for &c in components {
-            match (location, c) {
-                (Location::Root, "dev") => {
-                    walked_components.push(WalkedComponent {
-                        permissions: PermissionCheck::ByBackend,
-                    });
-                    location = Location::Dev;
-                }
-                (Location::Dev, name) if Device::from_name(name).is_some() => {
-                    return Ok(WalkOutcome {
-                        components: walked_components,
-                        last: WalkingDirHandle::from_typed::<Self>(DeviceDirHandle { location }),
-                        stop_reason: WalkStopReason::StoppedAtNonDirectory,
-                    });
-                }
-                _ => {
-                    return Err(WalkError::PathError(PathError::NoSuchFileOrDirectory));
-                }
+        // Device files are final path targets, so directory walking must stop before them.
+        if let Some(&component) = components.first() {
+            if Device::from_name(component).is_some() {
+                return Ok(WalkOutcome {
+                    components: vec![],
+                    last: WalkingDirHandle::from_typed::<Self>(from),
+                    stop_reason: WalkStopReason::StoppedAtNonDirectory,
+                });
             }
+            return Err(WalkError::PathError(PathError::NoSuchFileOrDirectory));
         }
         Ok(WalkOutcome {
-            components: walked_components,
-            last: WalkingDirHandle::from_typed::<Self>(DeviceDirHandle { location }),
+            components: vec![],
+            last: WalkingDirHandle::from_typed::<Self>(from),
             stop_reason: WalkStopReason::CompleteDirectory,
         })
     }
@@ -251,10 +226,7 @@ where
         name: &str,
         flags: OFlags,
     ) -> Result<Permissioned<FileHandle>, OpenError> {
-        let dir = dir.into_typed::<Self>();
-        if dir.location != Location::Dev {
-            return Err(OpenError::PathError(PathError::NoSuchFileOrDirectory));
-        }
+        let _dir = dir.into_typed::<Self>();
         let device = Device::from_name(name)
             .ok_or(OpenError::PathError(PathError::NoSuchFileOrDirectory))?;
 
@@ -289,22 +261,15 @@ where
     }
 
     fn list_dir_at(&self, handle: DirHandle) -> Result<Vec<DirEntry>, ReadDirError> {
-        let handle = handle.into_typed::<Self>();
-        match handle.location {
-            Location::Root => Ok(alloc::vec![DirEntry {
-                name: String::from("dev"),
-                file_type: FileType::Directory,
-                ino_info: Some(self.dev_dir_inode.clone()),
-            }]),
-            Location::Dev => Ok(Device::ALL
-                .iter()
-                .map(|(n, d)| DirEntry {
-                    name: String::from(*n),
-                    file_type: FileType::CharacterDevice,
-                    ino_info: Some(d.file_status().node_info),
-                })
-                .collect()),
-        }
+        let _handle = handle.into_typed::<Self>();
+        Ok(Device::ALL
+            .iter()
+            .map(|(n, d)| DirEntry {
+                name: String::from(*n),
+                file_type: FileType::CharacterDevice,
+                ino_info: Some(d.file_status().node_info),
+            })
+            .collect())
     }
 
     fn read(&self, h: &FileHandle, buf: &mut [u8], _offset: usize) -> Result<usize, ReadError> {
@@ -374,28 +339,14 @@ where
     }
 
     fn dir_status(&self, h: &DirHandle) -> Result<FileStatus, FileStatusError> {
-        let h = h.get_typed::<Self>();
-        Ok(match h.location {
-            Location::Root => FileStatus {
-                file_type: FileType::Directory,
-                mode: Mode::RWXU | Mode::RGRP | Mode::XGRP | Mode::ROTH | Mode::XOTH,
-                size: super::DEFAULT_DIRECTORY_SIZE,
-                owner: UserInfo::ROOT,
-                node_info: NodeInfo {
-                    dev: self.dev_dir_inode.dev,
-                    ino: 0,
-                    rdev: None,
-                },
-                blksize: super::DEFAULT_DIRECTORY_SIZE,
-            },
-            Location::Dev => FileStatus {
-                file_type: FileType::Directory,
-                mode: Mode::RWXU | Mode::RGRP | Mode::XGRP | Mode::ROTH | Mode::XOTH,
-                size: super::DEFAULT_DIRECTORY_SIZE,
-                owner: UserInfo::ROOT,
-                node_info: self.dev_dir_inode.clone(),
-                blksize: super::DEFAULT_DIRECTORY_SIZE,
-            },
+        let _h = h.get_typed::<Self>();
+        Ok(FileStatus {
+            file_type: FileType::Directory,
+            mode: Mode::RWXU | Mode::RGRP | Mode::XGRP | Mode::ROTH | Mode::XOTH,
+            size: super::DEFAULT_DIRECTORY_SIZE,
+            owner: UserInfo::ROOT,
+            node_info: self.root_inode.clone(),
+            blksize: super::DEFAULT_DIRECTORY_SIZE,
         })
     }
 

--- a/litebox/src/fs/mod.rs
+++ b/litebox/src/fs/mod.rs
@@ -13,6 +13,7 @@ use core::ffi::c_uint;
 use core::num::NonZeroUsize;
 
 pub mod backend;
+pub mod composer;
 pub mod devices;
 pub mod errors;
 pub mod in_mem;

--- a/litebox/src/fs/tests.rs
+++ b/litebox/src/fs/tests.rs
@@ -1991,7 +1991,7 @@ mod stdio {
         let fs = Resolver::new(
             &litebox,
             crate::fs::composer::Composer::builder()
-                .mount("/", |allocator| Devices::new(&litebox, allocator))
+                .mount("/dev", |allocator| Devices::new(&litebox, allocator))
                 .build()
                 .unwrap(),
         );
@@ -2042,7 +2042,7 @@ mod stdio {
         let fs = Resolver::new(
             &litebox,
             crate::fs::composer::Composer::builder()
-                .mount("/", |allocator| Devices::new(&litebox, allocator))
+                .mount("/dev", |allocator| Devices::new(&litebox, allocator))
                 .build()
                 .unwrap(),
         );
@@ -2079,7 +2079,7 @@ mod layered_stdio {
             Resolver::new(
                 &litebox,
                 crate::fs::composer::Composer::builder()
-                    .mount("/", |allocator| Devices::new(&litebox, allocator))
+                    .mount("/dev", |allocator| Devices::new(&litebox, allocator))
                     .build()
                     .unwrap(),
             ),
@@ -2149,7 +2149,7 @@ mod layered_stdio {
             Resolver::new(
                 &litebox,
                 crate::fs::composer::Composer::builder()
-                    .mount("/", |allocator| Devices::new(&litebox, allocator))
+                    .mount("/dev", |allocator| Devices::new(&litebox, allocator))
                     .build()
                     .unwrap(),
             ),

--- a/litebox/src/fs/tests.rs
+++ b/litebox/src/fs/tests.rs
@@ -1988,7 +1988,13 @@ mod stdio {
     fn stdio_open_read_write() {
         let platform = MockPlatform::new();
         let litebox = LiteBox::new(platform);
-        let fs = Resolver::new(&litebox, Devices::migration_helper_standalone_new(&litebox));
+        let fs = Resolver::new(
+            &litebox,
+            crate::fs::composer::Composer::builder()
+                .mount("/", |allocator| Devices::new(&litebox, allocator))
+                .build()
+                .unwrap(),
+        );
 
         // Test opening and writing to /dev/stdout
         let fd_stdout = fs
@@ -2033,7 +2039,13 @@ mod stdio {
     #[test]
     fn non_dev_path_fails() {
         let litebox = LiteBox::new(MockPlatform::new());
-        let fs = Resolver::new(&litebox, Devices::migration_helper_standalone_new(&litebox));
+        let fs = Resolver::new(
+            &litebox,
+            crate::fs::composer::Composer::builder()
+                .mount("/", |allocator| Devices::new(&litebox, allocator))
+                .build()
+                .unwrap(),
+        );
 
         // Attempt to open a non-/dev/* path
         let result = fs.open("foo", OFlags::RDONLY, Mode::empty());
@@ -2048,10 +2060,11 @@ mod stdio {
 
 mod layered_stdio {
     use crate::LiteBox;
+    use crate::fs::devices::Devices;
     use crate::fs::layered::LayeringSemantics;
     use crate::fs::resolver::Resolver;
     use crate::fs::{FileSystem as _, Mode, OFlags};
-    use crate::fs::{devices, in_mem, layered};
+    use crate::fs::{in_mem, layered};
     use crate::platform::mock::MockPlatform;
     use alloc::vec;
     extern crate std;
@@ -2065,7 +2078,10 @@ mod layered_stdio {
             in_mem::FileSystem::new(&litebox),
             Resolver::new(
                 &litebox,
-                devices::Devices::migration_helper_standalone_new(&litebox),
+                crate::fs::composer::Composer::builder()
+                    .mount("/", |allocator| Devices::new(&litebox, allocator))
+                    .build()
+                    .unwrap(),
             ),
             LayeringSemantics::LowerLayerWritableFiles,
         );
@@ -2132,7 +2148,10 @@ mod layered_stdio {
             in_mem,
             Resolver::new(
                 &litebox,
-                devices::Devices::migration_helper_standalone_new(&litebox),
+                crate::fs::composer::Composer::builder()
+                    .mount("/", |allocator| Devices::new(&litebox, allocator))
+                    .build()
+                    .unwrap(),
             ),
             LayeringSemantics::LowerLayerWritableFiles,
         );

--- a/litebox_runner_snp/src/main.rs
+++ b/litebox_runner_snp/src/main.rs
@@ -240,7 +240,7 @@ pub extern "C" fn sandbox_process_init(
     let dev_stdio = litebox::fs::resolver::Resolver::new(
         litebox,
         litebox::fs::composer::Composer::builder()
-            .mount("/", |allocator| {
+            .mount("/dev", |allocator| {
                 litebox::fs::devices::Devices::new(litebox, allocator)
             })
             .build()

--- a/litebox_runner_snp/src/main.rs
+++ b/litebox_runner_snp/src/main.rs
@@ -42,7 +42,7 @@ type DefaultFS = litebox::fs::layered::FileSystem<
     litebox::fs::in_mem::FileSystem<Platform>,
     litebox::fs::layered::FileSystem<
         Platform,
-        litebox::fs::resolver::Resolver<Platform, litebox::fs::devices::Devices<Platform>>,
+        litebox::fs::resolver::Resolver<Platform, litebox::fs::composer::Composer>,
         litebox::fs::nine_p::FileSystem<Platform, litebox_shim_linux::transport::ShimTransport>,
     >,
 >;
@@ -239,7 +239,12 @@ pub extern "C" fn sandbox_process_init(
     };
     let dev_stdio = litebox::fs::resolver::Resolver::new(
         litebox,
-        litebox::fs::devices::Devices::migration_helper_standalone_new(litebox),
+        litebox::fs::composer::Composer::builder()
+            .mount("/", |allocator| {
+                litebox::fs::devices::Devices::new(litebox, allocator)
+            })
+            .build()
+            .unwrap(),
     );
     let default_fs = litebox::fs::layered::FileSystem::new(
         litebox,

--- a/litebox_runner_snp/src/main.rs
+++ b/litebox_runner_snp/src/main.rs
@@ -237,15 +237,17 @@ pub extern "C" fn sandbox_process_init(
             globals::SM_TERM_GENERAL,
         );
     };
-    let dev_stdio = litebox::fs::resolver::Resolver::new(
-        litebox,
-        litebox::fs::composer::Composer::builder()
-            .mount("/dev", |allocator| {
-                litebox::fs::devices::Devices::new(litebox, allocator)
-            })
-            .build()
-            .unwrap(),
-    );
+    let dev_stdio_composer = litebox::fs::composer::Composer::builder()
+        .mount("/dev", |allocator| {
+            litebox::fs::devices::Devices::new(litebox, allocator)
+        })
+        .build()
+        .unwrap_or_else(
+            |(litebox::fs::composer::BuildError::NoMounts
+             | litebox::fs::composer::BuildError::InvalidMountPath
+             | litebox::fs::composer::BuildError::DuplicateMountPath)| unreachable!(),
+        );
+    let dev_stdio = litebox::fs::resolver::Resolver::new(litebox, dev_stdio_composer);
     let default_fs = litebox::fs::layered::FileSystem::new(
         litebox,
         in_mem_fs,

--- a/litebox_shim_linux/src/lib.rs
+++ b/litebox_shim_linux/src/lib.rs
@@ -57,7 +57,7 @@ pub(crate) type LinuxFS = litebox::fs::layered::FileSystem<
     litebox::fs::in_mem::FileSystem<Platform>,
     litebox::fs::layered::FileSystem<
         Platform,
-        litebox::fs::resolver::Resolver<Platform, litebox::fs::devices::Devices<Platform>>,
+        litebox::fs::resolver::Resolver<Platform, litebox::fs::composer::Composer>,
         litebox::fs::tar_ro::FileSystem<Platform>,
     >,
 >;
@@ -336,7 +336,12 @@ fn default_fs(
 ) -> LinuxFS {
     let dev_stdio = litebox::fs::resolver::Resolver::new(
         litebox,
-        litebox::fs::devices::Devices::migration_helper_standalone_new(litebox),
+        litebox::fs::composer::Composer::builder()
+            .mount("/", |allocator| {
+                litebox::fs::devices::Devices::new(litebox, allocator)
+            })
+            .build()
+            .unwrap(),
     );
     litebox::fs::layered::FileSystem::new(
         litebox,

--- a/litebox_shim_linux/src/lib.rs
+++ b/litebox_shim_linux/src/lib.rs
@@ -337,7 +337,7 @@ fn default_fs(
     let dev_stdio = litebox::fs::resolver::Resolver::new(
         litebox,
         litebox::fs::composer::Composer::builder()
-            .mount("/", |allocator| {
+            .mount("/dev", |allocator| {
                 litebox::fs::devices::Devices::new(litebox, allocator)
             })
             .build()


### PR DESCRIPTION
This PR introduces the `Composer`, which acts as a mount point for the new core file system design (see #887).  It maintains a runtime list of dyn-safe `Backend` objects for each mount point, using as much walking as feasible under the mount points.

To exercise the `Composer` and demonstrate how it works, I've also switched `Devices` to stop being hardcoded to `/dev` _inside_ the backend but instead be a flat list of devices that is _mounted_ at `/dev`.

While this PR does not expose/use it this way yet, with this PR, finally LiteBox core now has some of the fundamental machinery needed to eventually support `mount(2)` family of syscalls in the Linux shim.

Future PRs will continue migrating more backends over, eventually allowing for the old layered file system to disappear, and replaced with this mount composition + (upcoming) overlay file system to support union mounting.