### PR TITLE
Fix error code return for OP-TEE syscall dispatch

### DIFF
--- a/litebox_common_optee/src/lib.rs
+++ b/litebox_common_optee/src/lib.rs
@@ -1146,6 +1146,20 @@ impl From<TeeResult> for u32 {
     }
 }
 
+impl From<Errno> for TeeResult {
+    fn from(err: Errno) -> Self {
+        match err {
+            Errno::ENOSYS => Self::NotSupported,
+            Errno::EINVAL | Errno::EFAULT => Self::BadParameters,
+            Errno::EPERM | Errno::EACCES => Self::AccessDenied,
+            Errno::ENOMEM => Self::OutOfMemory,
+            Errno::EOVERFLOW => Self::Overflow,
+            Errno::EBUSY => Self::Busy,
+            _ => Self::GenericError,
+        }
+    }
+}
+
 const UTEE_ENTRY_FUNC_OPEN_SESSION: u32 = 0;
 const UTEE_ENTRY_FUNC_CLOSE_SESSION: u32 = 1;
 const UTEE_ENTRY_FUNC_INVOKE_COMMAND: u32 = 2;

--- a/litebox_shim_optee/src/lib.rs
+++ b/litebox_shim_optee/src/lib.rs
@@ -20,7 +20,7 @@ use litebox::{
     mm::{PageManager, linux::PAGE_SIZE},
     platform::{Instant as _, RawConstPointer as _, RawMutPointer as _, TimeProvider},
     shim::ContinueOperation,
-    utils::{ReinterpretUnsignedExt, TruncateExt},
+    utils::TruncateExt,
 };
 use litebox_common_linux::{MapFlags, ProtFlags, errno::Errno};
 use litebox_common_optee::{
@@ -383,8 +383,7 @@ impl Task {
         let request = match SyscallRequest::<Platform>::try_from_raw(ctx.orig_rax, ctx) {
             Ok(request) => request,
             Err(err) => {
-                // TODO: this seems like the wrong kind of error for OPTEE.
-                ctx.rax = (err.as_neg() as isize).reinterpret_as_unsigned();
+                ctx.rax = TeeResult::from(err) as usize;
                 return ContinueOperation::Resume;
             }
         };
@@ -664,8 +663,7 @@ impl Task {
         let request = match LdelfSyscallRequest::<Platform>::try_from_raw(ctx.orig_rax, ctx) {
             Ok(request) => request,
             Err(err) => {
-                // TODO: this seems like the wrong kind of error for OPTEE.
-                ctx.rax = (err.as_neg() as isize).reinterpret_as_unsigned();
+                ctx.rax = TeeResult::from(err) as usize;
                 return ContinueOperation::Resume;
             }
         };


### PR DESCRIPTION
This PR fixes the error code return of OP-TEE syscall dispatching. Instead of returning `Errno` (Linux), it now returns `TeeResult` (OP-TEE) to the TA/ldelf if its syscall request is invalid (e.g., nonexistent/unsupported syscall, invalid arguments, ...).