### PR TITLE
Dispatch broker event readiness notifications

### DIFF
--- a/litebox/src/broker/mod.rs
+++ b/litebox/src/broker/mod.rs
@@ -66,7 +66,7 @@ impl<Platform: RawSyncPrimitivesProvider> BrokerObjectRegistry<Platform> {
         self.pollables.lock().insert(handle, Arc::downgrade(pollee));
     }
 
-    pub(crate) fn unregister(&self, handle: ObjectHandle) {
+    pub(crate) fn unregister_pollable(&self, handle: ObjectHandle) {
         self.pollables.lock().remove(&handle);
     }
 }

--- a/litebox/src/broker/mod.rs
+++ b/litebox/src/broker/mod.rs
@@ -51,11 +51,11 @@ pub(crate) trait BrokerControl: Send + Sync {
     fn close_object(&self, handle: ObjectHandle) -> core::result::Result<(), BrokerControlError>;
 }
 
-pub(crate) struct BrokerObjectRegistry<Platform: RawSyncPrimitivesProvider> {
+pub(crate) struct BrokerPollableRegistry<Platform: RawSyncPrimitivesProvider> {
     pollables: Mutex<Platform, HashMap<ObjectHandle, Weak<Pollee<Platform>>>>,
 }
 
-impl<Platform: RawSyncPrimitivesProvider> BrokerObjectRegistry<Platform> {
+impl<Platform: RawSyncPrimitivesProvider> BrokerPollableRegistry<Platform> {
     pub(crate) fn new() -> Self {
         Self {
             pollables: Mutex::new(HashMap::new()),

--- a/litebox/src/broker/mod.rs
+++ b/litebox/src/broker/mod.rs
@@ -9,7 +9,7 @@ use litebox_broker_protocol::ObjectHandle;
 use litebox_broker_protocol::channel::LocalControlChannel;
 use litebox_broker_protocol::event::{ConsumeEventResponse, EventConsumeMode, ReadinessState};
 
-use crate::event::counter::EventCounterWakeups;
+use crate::event::{Events, polling::Pollee};
 use crate::platform::TimeProvider;
 use crate::sync::{Mutex, RawSyncPrimitivesProvider};
 
@@ -52,7 +52,7 @@ pub(crate) trait BrokerControl: Send + Sync {
 }
 
 pub(crate) struct BrokerEventRegistry<Platform: RawSyncPrimitivesProvider> {
-    events: Mutex<Platform, HashMap<ObjectHandle, Weak<EventCounterWakeups<Platform>>>>,
+    events: Mutex<Platform, HashMap<ObjectHandle, Weak<Pollee<Platform>>>>,
 }
 
 impl<Platform: RawSyncPrimitivesProvider> BrokerEventRegistry<Platform> {
@@ -62,12 +62,8 @@ impl<Platform: RawSyncPrimitivesProvider> BrokerEventRegistry<Platform> {
         }
     }
 
-    pub(crate) fn register_event(
-        &self,
-        handle: ObjectHandle,
-        wakeups: &Arc<EventCounterWakeups<Platform>>,
-    ) {
-        self.events.lock().insert(handle, Arc::downgrade(wakeups));
+    pub(crate) fn register_event(&self, handle: ObjectHandle, pollee: &Arc<Pollee<Platform>>) {
+        self.events.lock().insert(handle, Arc::downgrade(pollee));
     }
 
     pub(crate) fn unregister_event(&self, handle: ObjectHandle) {
@@ -80,17 +76,26 @@ where
     Platform: RawSyncPrimitivesProvider + TimeProvider,
 {
     pub(crate) fn notify_event_readiness(&self, handle: ObjectHandle, readiness: ReadinessState) {
-        let wakeups = {
+        let pollee = {
             let mut events = self.events.lock();
-            if let Some(wakeups) = events.get(&handle).and_then(Weak::upgrade) {
-                Some(wakeups)
+            if let Some(pollee) = events.get(&handle).and_then(Weak::upgrade) {
+                Some(pollee)
             } else {
                 events.remove(&handle);
                 None
             }
         };
-        if let Some(wakeups) = wakeups {
-            wakeups.notify_readiness(readiness);
+        if let Some(pollee) = pollee {
+            let mut events = Events::empty();
+            if readiness.read_ready {
+                events |= Events::IN;
+            }
+            if readiness.write_ready {
+                events |= Events::OUT;
+            }
+            if !events.is_empty() {
+                pollee.notify_observers(events);
+            }
         }
     }
 }

--- a/litebox/src/broker/mod.rs
+++ b/litebox/src/broker/mod.rs
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-use alloc::sync::{Arc, Weak};
+use alloc::{
+    sync::{Arc, Weak},
+    vec::Vec,
+};
 
 use hashbrown::HashMap;
 use litebox_broker_local::BrokerLocal;
@@ -51,39 +54,52 @@ pub(crate) trait BrokerControl: Send + Sync {
     fn close_object(&self, handle: ObjectHandle) -> core::result::Result<(), BrokerControlError>;
 }
 
-pub(crate) struct BrokerPollableRegistry<Platform: RawSyncPrimitivesProvider> {
-    pollables: Mutex<Platform, HashMap<ObjectHandle, Weak<Pollee<Platform>>>>,
+pub(crate) struct BrokerHandleRegistry<Platform: RawSyncPrimitivesProvider> {
+    handles: Mutex<Platform, HashMap<ObjectHandle, BrokerHandleEntry<Platform>>>,
 }
 
-impl<Platform: RawSyncPrimitivesProvider> BrokerPollableRegistry<Platform> {
+impl<Platform: RawSyncPrimitivesProvider> BrokerHandleRegistry<Platform> {
     pub(crate) fn new() -> Self {
         Self {
-            pollables: Mutex::new(HashMap::new()),
+            handles: Mutex::new(HashMap::new()),
         }
     }
 
     pub(crate) fn register_pollable(&self, handle: ObjectHandle, pollee: &Arc<Pollee<Platform>>) {
-        self.pollables.lock().insert(handle, Arc::downgrade(pollee));
+        self.handles
+            .lock()
+            .entry(handle)
+            .or_insert_with(BrokerHandleEntry::new)
+            .register_pollable(pollee);
     }
 
-    pub(crate) fn unregister_pollable(&self, handle: ObjectHandle) {
-        self.pollables.lock().remove(&handle);
+    pub(crate) fn unregister_pollable(&self, handle: ObjectHandle, pollee: &Arc<Pollee<Platform>>) {
+        let mut handles = self.handles.lock();
+        if let Some(entry) = handles.get_mut(&handle) {
+            entry.unregister_pollable(pollee);
+            if entry.is_empty() {
+                handles.remove(&handle);
+            }
+        }
     }
 
     pub(crate) fn notify_readiness(&self, handle: ObjectHandle, readiness: ReadinessState)
     where
         Platform: TimeProvider,
     {
-        let pollee = {
-            let mut pollables = self.pollables.lock();
-            if let Some(pollee) = pollables.get(&handle).and_then(Weak::upgrade) {
-                Some(pollee)
+        let pollables = {
+            let mut handles = self.handles.lock();
+            if let Some(entry) = handles.get_mut(&handle) {
+                let pollables = entry.pollables();
+                if entry.is_empty() {
+                    handles.remove(&handle);
+                }
+                pollables
             } else {
-                pollables.remove(&handle);
-                None
+                Vec::new()
             }
         };
-        if let Some(pollee) = pollee {
+        if !pollables.is_empty() {
             let mut events = Events::empty();
             if readiness.read_ready {
                 events |= Events::IN;
@@ -92,9 +108,52 @@ impl<Platform: RawSyncPrimitivesProvider> BrokerPollableRegistry<Platform> {
                 events |= Events::OUT;
             }
             if !events.is_empty() {
-                pollee.notify_observers(events);
+                for pollee in pollables {
+                    pollee.notify_observers(events);
+                }
             }
         }
+    }
+}
+
+struct BrokerHandleEntry<Platform: RawSyncPrimitivesProvider> {
+    pollables: Vec<Weak<Pollee<Platform>>>,
+}
+
+impl<Platform: RawSyncPrimitivesProvider> BrokerHandleEntry<Platform> {
+    fn new() -> Self {
+        Self {
+            pollables: Vec::new(),
+        }
+    }
+
+    fn register_pollable(&mut self, pollee: &Arc<Pollee<Platform>>) {
+        self.pollables.push(Arc::downgrade(pollee));
+    }
+
+    fn unregister_pollable(&mut self, pollee: &Arc<Pollee<Platform>>) {
+        self.pollables.retain(|registered| {
+            registered
+                .upgrade()
+                .is_some_and(|registered| !Arc::ptr_eq(&registered, pollee))
+        });
+    }
+
+    fn pollables(&mut self) -> Vec<Arc<Pollee<Platform>>> {
+        let mut pollables = Vec::new();
+        self.pollables.retain(|registered| {
+            if let Some(pollee) = registered.upgrade() {
+                pollables.push(pollee);
+                true
+            } else {
+                false
+            }
+        });
+        pollables
+    }
+
+    fn is_empty(&self) -> bool {
+        self.pollables.is_empty()
     }
 }
 

--- a/litebox/src/broker/mod.rs
+++ b/litebox/src/broker/mod.rs
@@ -69,13 +69,11 @@ impl<Platform: RawSyncPrimitivesProvider> BrokerObjectRegistry<Platform> {
     pub(crate) fn unregister_pollable(&self, handle: ObjectHandle) {
         self.pollables.lock().remove(&handle);
     }
-}
 
-impl<Platform> BrokerObjectRegistry<Platform>
-where
-    Platform: RawSyncPrimitivesProvider + TimeProvider,
-{
-    pub(crate) fn notify_readiness(&self, handle: ObjectHandle, readiness: ReadinessState) {
+    pub(crate) fn notify_readiness(&self, handle: ObjectHandle, readiness: ReadinessState)
+    where
+        Platform: TimeProvider,
+    {
         let pollee = {
             let mut pollables = self.pollables.lock();
             if let Some(pollee) = pollables.get(&handle).and_then(Weak::upgrade) {

--- a/litebox/src/broker/mod.rs
+++ b/litebox/src/broker/mod.rs
@@ -1,11 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+use alloc::sync::{Arc, Weak};
+
+use hashbrown::HashMap;
 use litebox_broker_local::BrokerLocal;
 use litebox_broker_protocol::ObjectHandle;
 use litebox_broker_protocol::channel::LocalControlChannel;
 use litebox_broker_protocol::event::{ConsumeEventResponse, EventConsumeMode, ReadinessState};
 
+use crate::event::counter::EventCounterWakeups;
+use crate::platform::TimeProvider;
 use crate::sync::{Mutex, RawSyncPrimitivesProvider};
 
 pub(crate) mod error;
@@ -44,6 +49,50 @@ pub(crate) trait BrokerControl: Send + Sync {
     ) -> core::result::Result<ConsumeEventResponse, BrokerControlError>;
 
     fn close_object(&self, handle: ObjectHandle) -> core::result::Result<(), BrokerControlError>;
+}
+
+pub(crate) struct BrokerEventRegistry<Platform: RawSyncPrimitivesProvider> {
+    events: Mutex<Platform, HashMap<ObjectHandle, Weak<EventCounterWakeups<Platform>>>>,
+}
+
+impl<Platform: RawSyncPrimitivesProvider> BrokerEventRegistry<Platform> {
+    pub(crate) fn new() -> Self {
+        Self {
+            events: Mutex::new(HashMap::new()),
+        }
+    }
+
+    pub(crate) fn register_event(
+        &self,
+        handle: ObjectHandle,
+        wakeups: &Arc<EventCounterWakeups<Platform>>,
+    ) {
+        self.events.lock().insert(handle, Arc::downgrade(wakeups));
+    }
+
+    pub(crate) fn unregister_event(&self, handle: ObjectHandle) {
+        self.events.lock().remove(&handle);
+    }
+}
+
+impl<Platform> BrokerEventRegistry<Platform>
+where
+    Platform: RawSyncPrimitivesProvider + TimeProvider,
+{
+    pub(crate) fn notify_event_readiness(&self, handle: ObjectHandle, readiness: ReadinessState) {
+        let wakeups = {
+            let mut events = self.events.lock();
+            if let Some(wakeups) = events.get(&handle).and_then(Weak::upgrade) {
+                Some(wakeups)
+            } else {
+                events.remove(&handle);
+                None
+            }
+        };
+        if let Some(wakeups) = wakeups {
+            wakeups.notify_readiness(readiness);
+        }
+    }
 }
 
 pub(crate) struct BrokerLocalControl<

--- a/litebox/src/broker/mod.rs
+++ b/litebox/src/broker/mod.rs
@@ -87,31 +87,25 @@ impl<Platform: RawSyncPrimitivesProvider> BrokerHandleRegistry<Platform> {
     where
         Platform: TimeProvider,
     {
-        let pollables = {
-            let mut handles = self.handles.lock();
-            if let Some(entry) = handles.get_mut(&handle) {
-                let pollables = entry.pollables();
-                if entry.is_empty() {
-                    handles.remove(&handle);
-                }
-                pollables
-            } else {
-                Vec::new()
-            }
+        let mut handles = self.handles.lock();
+        let Some(entry) = handles.get_mut(&handle) else {
+            return;
         };
-        if !pollables.is_empty() {
-            let mut events = Events::empty();
-            if readiness.read_ready {
-                events |= Events::IN;
-            }
-            if readiness.write_ready {
-                events |= Events::OUT;
-            }
-            if !events.is_empty() {
-                for pollee in pollables {
-                    pollee.notify_observers(events);
-                }
-            }
+        entry.prune_stale_pollables();
+        if entry.is_empty() {
+            handles.remove(&handle);
+            return;
+        }
+
+        let mut events = Events::empty();
+        if readiness.read_ready {
+            events |= Events::IN;
+        }
+        if readiness.write_ready {
+            events |= Events::OUT;
+        }
+        if !events.is_empty() {
+            entry.notify_pollables(events);
         }
     }
 }
@@ -139,24 +133,26 @@ impl<Platform: RawSyncPrimitivesProvider> BrokerHandleEntry<Platform> {
         });
     }
 
-    fn pollables(&mut self) -> Vec<Arc<Pollee<Platform>>> {
-        let mut pollables = Vec::new();
-        self.pollables.retain(|registered| {
+    fn prune_stale_pollables(&mut self) {
+        self.pollables
+            .retain(|registered| registered.strong_count() > 0);
+    }
+
+    fn notify_pollables(&self, events: Events)
+    where
+        Platform: TimeProvider,
+    {
+        for registered in &self.pollables {
             if let Some(pollee) = registered.upgrade() {
-                pollables.push(pollee);
-                true
-            } else {
-                false
+                pollee.notify_observers(events);
             }
-        });
-        pollables
+        }
     }
 
     fn is_empty(&self) -> bool {
         self.pollables.is_empty()
     }
 }
-
 pub(crate) struct BrokerLocalControl<
     Platform: RawSyncPrimitivesProvider,
     Channel: LocalControlChannel + Send,

--- a/litebox/src/broker/mod.rs
+++ b/litebox/src/broker/mod.rs
@@ -51,37 +51,37 @@ pub(crate) trait BrokerControl: Send + Sync {
     fn close_object(&self, handle: ObjectHandle) -> core::result::Result<(), BrokerControlError>;
 }
 
-pub(crate) struct BrokerEventRegistry<Platform: RawSyncPrimitivesProvider> {
-    events: Mutex<Platform, HashMap<ObjectHandle, Weak<Pollee<Platform>>>>,
+pub(crate) struct BrokerObjectRegistry<Platform: RawSyncPrimitivesProvider> {
+    pollables: Mutex<Platform, HashMap<ObjectHandle, Weak<Pollee<Platform>>>>,
 }
 
-impl<Platform: RawSyncPrimitivesProvider> BrokerEventRegistry<Platform> {
+impl<Platform: RawSyncPrimitivesProvider> BrokerObjectRegistry<Platform> {
     pub(crate) fn new() -> Self {
         Self {
-            events: Mutex::new(HashMap::new()),
+            pollables: Mutex::new(HashMap::new()),
         }
     }
 
-    pub(crate) fn register_event(&self, handle: ObjectHandle, pollee: &Arc<Pollee<Platform>>) {
-        self.events.lock().insert(handle, Arc::downgrade(pollee));
+    pub(crate) fn register_pollable(&self, handle: ObjectHandle, pollee: &Arc<Pollee<Platform>>) {
+        self.pollables.lock().insert(handle, Arc::downgrade(pollee));
     }
 
-    pub(crate) fn unregister_event(&self, handle: ObjectHandle) {
-        self.events.lock().remove(&handle);
+    pub(crate) fn unregister(&self, handle: ObjectHandle) {
+        self.pollables.lock().remove(&handle);
     }
 }
 
-impl<Platform> BrokerEventRegistry<Platform>
+impl<Platform> BrokerObjectRegistry<Platform>
 where
     Platform: RawSyncPrimitivesProvider + TimeProvider,
 {
-    pub(crate) fn notify_event_readiness(&self, handle: ObjectHandle, readiness: ReadinessState) {
+    pub(crate) fn notify_readiness(&self, handle: ObjectHandle, readiness: ReadinessState) {
         let pollee = {
-            let mut events = self.events.lock();
-            if let Some(pollee) = events.get(&handle).and_then(Weak::upgrade) {
+            let mut pollables = self.pollables.lock();
+            if let Some(pollee) = pollables.get(&handle).and_then(Weak::upgrade) {
                 Some(pollee)
             } else {
-                events.remove(&handle);
+                pollables.remove(&handle);
                 None
             }
         };

--- a/litebox/src/event/counter.rs
+++ b/litebox/src/event/counter.rs
@@ -183,13 +183,9 @@ mod tests {
 
     use alloc::sync::Arc;
     use litebox_broker_local::BrokerLocal;
-    use litebox_broker_protocol::BROKER_PROTOCOL_VERSION;
     use litebox_broker_protocol::channel::LocalControlChannel;
     use litebox_broker_protocol::error::ErrorCode;
-    use litebox_broker_protocol::event::{
-        ConsumeEventRequest, CreateEventRequest, CreateEventResponse, EventConsumption,
-        ReadinessState,
-    };
+    use litebox_broker_protocol::event::{CreateEventResponse, EventConsumption, ReadinessState};
     use litebox_broker_protocol::message::{
         BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerNotification, BrokerRequest,
         BrokerResponse, EventReadinessNotification, EventRequest, EventResponse,
@@ -213,9 +209,6 @@ mod tests {
             consume_attempts: consume_attempts.clone(),
             read_ready: read_ready.clone(),
             last_request: None,
-            handshake_response: Some(BrokerHandshakeResponse::Negotiated {
-                broker_protocol_version: BROKER_PROTOCOL_VERSION,
-            }),
         })
         .unwrap();
         let litebox = LiteBox::new_with_broker_local(platform, local);
@@ -236,6 +229,7 @@ mod tests {
             });
         }
         let deadline = Instant::now() + Duration::from_secs(1);
+        // The second consume attempt happens after the waiter has registered its observer.
         while consume_attempts.load(Ordering::SeqCst) < 2 {
             assert!(Instant::now() < deadline);
             std::thread::yield_now();
@@ -265,7 +259,6 @@ mod tests {
         consume_attempts: Arc<AtomicUsize>,
         read_ready: Arc<AtomicBool>,
         last_request: Option<BrokerRequest>,
-        handshake_response: Option<BrokerHandshakeResponse>,
     }
 
     impl LocalControlChannel for FakeLocalControlChannel {
@@ -281,7 +274,9 @@ mod tests {
         fn recv_handshake_response(
             &mut self,
         ) -> core::result::Result<Option<BrokerHandshakeResponse>, Self::Error> {
-            Ok(self.handshake_response.take())
+            Ok(Some(BrokerHandshakeResponse::Negotiated {
+                broker_protocol_version: litebox_broker_protocol::BROKER_PROTOCOL_VERSION,
+            }))
         }
 
         fn send_request(
@@ -294,14 +289,14 @@ mod tests {
 
         fn recv_response(&mut self) -> core::result::Result<Option<BrokerResponse>, Self::Error> {
             let response = match self.last_request.take().unwrap() {
-                BrokerRequest::Event(EventRequest::Create(CreateEventRequest {
-                    initial_count: 0,
-                })) => BrokerResponse::Event(EventResponse::Create(CreateEventResponse {
-                    handle: self.handle,
-                })),
-                BrokerRequest::Event(EventRequest::Consume(ConsumeEventRequest {
-                    handle, ..
-                })) if handle == self.handle => {
+                BrokerRequest::Event(EventRequest::Create(_)) => {
+                    BrokerResponse::Event(EventResponse::Create(CreateEventResponse {
+                        handle: self.handle,
+                    }))
+                }
+                BrokerRequest::Event(EventRequest::Consume(request))
+                    if request.handle == self.handle =>
+                {
                     self.consume_attempts.fetch_add(1, Ordering::SeqCst);
                     if self.read_ready.swap(false, Ordering::SeqCst) {
                         BrokerResponse::Event(EventResponse::Consume(EventConsumption {

--- a/litebox/src/event/counter.rs
+++ b/litebox/src/event/counter.rs
@@ -11,7 +11,7 @@ use thiserror::Error;
 use crate::{
     LiteBox,
     broker::{
-        BrokerControl, BrokerObjectRegistry,
+        BrokerControl, BrokerPollableRegistry,
         error::{BrokerControlError, BrokerObjectError},
     },
     event::{
@@ -44,7 +44,7 @@ pub enum EventCounterError {
 pub struct EventCounter<Platform: RawSyncPrimitivesProvider + TimeProvider> {
     broker: Arc<dyn BrokerControl>,
     handle: ObjectHandle,
-    registry: Arc<BrokerObjectRegistry<Platform>>,
+    registry: Arc<BrokerPollableRegistry<Platform>>,
     pollee: Arc<Pollee<Platform>>,
 }
 
@@ -66,7 +66,7 @@ where
             .create_event_with_count(initial_count)
             .map_err(BrokerObjectError::from)
             .map_err(EventCounterError::from)?;
-        let registry = litebox.broker_object_registry();
+        let registry = litebox.broker_pollable_registry();
         let pollee = Arc::new(Pollee::new());
         registry.register_pollable(handle, &pollee);
         Ok(Self {

--- a/litebox/src/event/counter.rs
+++ b/litebox/src/event/counter.rs
@@ -11,7 +11,7 @@ use thiserror::Error;
 use crate::{
     LiteBox,
     broker::{
-        BrokerControl,
+        BrokerControl, BrokerEventRegistry,
         error::{BrokerControlError, BrokerObjectError},
     },
     event::{
@@ -44,7 +44,36 @@ pub enum EventCounterError {
 pub struct EventCounter<Platform: RawSyncPrimitivesProvider + TimeProvider> {
     broker: Arc<dyn BrokerControl>,
     handle: ObjectHandle,
+    registry: Arc<BrokerEventRegistry<Platform>>,
+    wakeups: Arc<EventCounterWakeups<Platform>>,
+}
+
+pub(crate) struct EventCounterWakeups<Platform: RawSyncPrimitivesProvider> {
     pollee: Pollee<Platform>,
+}
+
+impl<Platform> EventCounterWakeups<Platform>
+where
+    Platform: RawSyncPrimitivesProvider + TimeProvider,
+{
+    fn new() -> Self {
+        Self {
+            pollee: Pollee::new(),
+        }
+    }
+
+    pub(crate) fn notify_readiness(&self, readiness: ReadinessState) {
+        let mut events = Events::empty();
+        if readiness.read_ready {
+            events |= Events::IN;
+        }
+        if readiness.write_ready {
+            events |= Events::OUT;
+        }
+        if !events.is_empty() {
+            self.pollee.notify_observers(events);
+        }
+    }
 }
 
 impl<Platform> EventCounter<Platform>
@@ -65,10 +94,14 @@ where
             .create_event_with_count(initial_count)
             .map_err(BrokerObjectError::from)
             .map_err(EventCounterError::from)?;
+        let registry = litebox.broker_event_registry();
+        let wakeups = Arc::new(EventCounterWakeups::new());
+        registry.register_event(handle, &wakeups);
         Ok(Self {
             broker,
             handle,
-            pollee: Pollee::new(),
+            registry,
+            wakeups,
         })
     }
 
@@ -79,10 +112,10 @@ where
         nonblock: bool,
         mode: EventCounterReadMode,
     ) -> Result<u64, TryOpError<EventCounterError>> {
-        self.pollee.wait(cx, nonblock, Events::IN, || {
+        self.wakeups.pollee.wait(cx, nonblock, Events::IN, || {
             let response = self.consume(mode)?;
             if response.readiness.write_ready {
-                self.pollee.notify_observers(Events::OUT);
+                self.wakeups.pollee.notify_observers(Events::OUT);
             }
             Ok(response.value)
         })
@@ -98,10 +131,10 @@ where
         if value == u64::MAX {
             return Err(TryOpError::Other(EventCounterError::InvalidInput));
         }
-        self.pollee.wait(cx, nonblock, Events::OUT, || {
+        self.wakeups.pollee.wait(cx, nonblock, Events::OUT, || {
             let readiness = self.add(value)?;
             if value != 0 && readiness.read_ready {
-                self.pollee.notify_observers(Events::IN);
+                self.wakeups.pollee.notify_observers(Events::IN);
             }
             Ok(core::mem::size_of::<u64>())
         })
@@ -125,7 +158,7 @@ where
     fn broker_request_error(&self, error: BrokerControlError) -> BrokerObjectError {
         let error = error.into();
         if error != BrokerObjectError::WouldBlock {
-            self.pollee.notify_observers(Events::ERR);
+            self.wakeups.pollee.notify_observers(Events::ERR);
         }
         error
     }
@@ -136,6 +169,7 @@ where
     Platform: RawSyncPrimitivesProvider + TimeProvider,
 {
     fn drop(&mut self) {
+        self.registry.unregister_event(self.handle);
         let _ = self.broker.close_object(self.handle);
     }
 }
@@ -145,7 +179,7 @@ where
     Platform: RawSyncPrimitivesProvider + TimeProvider,
 {
     fn register_observer(&self, observer: alloc::sync::Weak<dyn Observer<Events>>, mask: Events) {
-        self.pollee.register_observer(observer, mask);
+        self.wakeups.pollee.register_observer(observer, mask);
     }
 
     fn check_io_events(&self) -> Events {
@@ -166,5 +200,155 @@ where
             events |= Events::OUT;
         }
         events
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+    use alloc::sync::Arc;
+    use litebox_broker_local::BrokerLocal;
+    use litebox_broker_protocol::BROKER_PROTOCOL_VERSION;
+    use litebox_broker_protocol::channel::LocalControlChannel;
+    use litebox_broker_protocol::error::ErrorCode;
+    use litebox_broker_protocol::event::{
+        ConsumeEventRequest, CreateEventRequest, CreateEventResponse, EventConsumption,
+        ReadinessState,
+    };
+    use litebox_broker_protocol::message::{
+        BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerNotification, BrokerRequest,
+        BrokerResponse, EventReadinessNotification, EventRequest, EventResponse,
+    };
+
+    use super::*;
+    use crate::LiteBox;
+    use crate::event::wait::WaitState;
+    use crate::platform::mock::MockPlatform;
+
+    #[test]
+    fn readiness_notification_wakes_blocked_read() {
+        use std::time::{Duration, Instant};
+
+        let platform = MockPlatform::new();
+        let handle = ObjectHandle(7);
+        let consume_attempts = Arc::new(AtomicUsize::new(0));
+        let read_ready = Arc::new(AtomicBool::new(false));
+        let local = BrokerLocal::negotiate(FakeLocalControlChannel {
+            handle,
+            consume_attempts: consume_attempts.clone(),
+            read_ready: read_ready.clone(),
+            last_request: None,
+            handshake_response: Some(BrokerHandshakeResponse::Negotiated {
+                broker_protocol_version: BROKER_PROTOCOL_VERSION,
+            }),
+        })
+        .unwrap();
+        let litebox = LiteBox::new_with_broker_local(platform, local);
+        let sink = litebox.broker_notification_sink();
+        let counter = Arc::new(EventCounter::new(&litebox, 0).unwrap());
+
+        let (result_sender, result_receiver) = std::sync::mpsc::channel();
+        {
+            let counter = counter.clone();
+            std::thread::spawn(move || {
+                result_sender
+                    .send(counter.read(
+                        &WaitState::new(platform).context(),
+                        false,
+                        EventCounterReadMode::One,
+                    ))
+                    .unwrap();
+            });
+        }
+        let deadline = Instant::now() + Duration::from_secs(1);
+        while consume_attempts.load(Ordering::SeqCst) < 2 {
+            assert!(Instant::now() < deadline);
+            std::thread::yield_now();
+        }
+        read_ready.store(true, Ordering::SeqCst);
+        sink.dispatch(BrokerNotification::EventReadiness(
+            EventReadinessNotification {
+                handle,
+                readiness: ReadinessState {
+                    read_ready: true,
+                    write_ready: true,
+                },
+            },
+        ));
+
+        assert_eq!(
+            result_receiver
+                .recv_timeout(Duration::from_secs(1))
+                .unwrap()
+                .unwrap(),
+            1
+        );
+    }
+
+    struct FakeLocalControlChannel {
+        handle: ObjectHandle,
+        consume_attempts: Arc<AtomicUsize>,
+        read_ready: Arc<AtomicBool>,
+        last_request: Option<BrokerRequest>,
+        handshake_response: Option<BrokerHandshakeResponse>,
+    }
+
+    impl LocalControlChannel for FakeLocalControlChannel {
+        type Error = core::convert::Infallible;
+
+        fn send_handshake_request(
+            &mut self,
+            _request: &BrokerHandshakeRequest,
+        ) -> core::result::Result<(), Self::Error> {
+            Ok(())
+        }
+
+        fn recv_handshake_response(
+            &mut self,
+        ) -> core::result::Result<Option<BrokerHandshakeResponse>, Self::Error> {
+            Ok(self.handshake_response.take())
+        }
+
+        fn send_request(
+            &mut self,
+            request: &BrokerRequest,
+        ) -> core::result::Result<(), Self::Error> {
+            self.last_request = Some(request.clone());
+            Ok(())
+        }
+
+        fn recv_response(&mut self) -> core::result::Result<Option<BrokerResponse>, Self::Error> {
+            let response = match self.last_request.take().unwrap() {
+                BrokerRequest::Event(EventRequest::Create(CreateEventRequest {
+                    initial_count: 0,
+                })) => BrokerResponse::Event(EventResponse::Create(CreateEventResponse {
+                    handle: self.handle,
+                })),
+                BrokerRequest::Event(EventRequest::Consume(ConsumeEventRequest {
+                    handle, ..
+                })) if handle == self.handle => {
+                    self.consume_attempts.fetch_add(1, Ordering::SeqCst);
+                    if self.read_ready.swap(false, Ordering::SeqCst) {
+                        BrokerResponse::Event(EventResponse::Consume(EventConsumption {
+                            value: 1,
+                            readiness: ReadinessState {
+                                read_ready: false,
+                                write_ready: true,
+                            },
+                        }))
+                    } else {
+                        BrokerResponse::Error(ErrorCode::WouldBlock)
+                    }
+                }
+                BrokerRequest::CloseObject(handle) if handle == self.handle => {
+                    BrokerResponse::ObjectClosed
+                }
+                request => panic!("unexpected broker request: {request:?}"),
+            };
+            Ok(Some(response))
+        }
     }
 }

--- a/litebox/src/event/counter.rs
+++ b/litebox/src/event/counter.rs
@@ -11,7 +11,7 @@ use thiserror::Error;
 use crate::{
     LiteBox,
     broker::{
-        BrokerControl, BrokerPollableRegistry,
+        BrokerControl, BrokerHandleRegistry,
         error::{BrokerControlError, BrokerObjectError},
     },
     event::{
@@ -44,7 +44,7 @@ pub enum EventCounterError {
 pub struct EventCounter<Platform: RawSyncPrimitivesProvider + TimeProvider> {
     broker: Arc<dyn BrokerControl>,
     handle: ObjectHandle,
-    registry: Arc<BrokerPollableRegistry<Platform>>,
+    registry: Arc<BrokerHandleRegistry<Platform>>,
     pollee: Arc<Pollee<Platform>>,
 }
 
@@ -66,7 +66,7 @@ where
             .create_event_with_count(initial_count)
             .map_err(BrokerObjectError::from)
             .map_err(EventCounterError::from)?;
-        let registry = litebox.broker_pollable_registry();
+        let registry = litebox.broker_handle_registry();
         let pollee = Arc::new(Pollee::new());
         registry.register_pollable(handle, &pollee);
         Ok(Self {
@@ -141,7 +141,7 @@ where
     Platform: RawSyncPrimitivesProvider + TimeProvider,
 {
     fn drop(&mut self) {
-        self.registry.unregister_pollable(self.handle);
+        self.registry.unregister_pollable(self.handle, &self.pollee);
         let _ = self.broker.close_object(self.handle);
     }
 }

--- a/litebox/src/event/counter.rs
+++ b/litebox/src/event/counter.rs
@@ -141,7 +141,7 @@ where
     Platform: RawSyncPrimitivesProvider + TimeProvider,
 {
     fn drop(&mut self) {
-        self.registry.unregister(self.handle);
+        self.registry.unregister_pollable(self.handle);
         let _ = self.broker.close_object(self.handle);
     }
 }

--- a/litebox/src/event/counter.rs
+++ b/litebox/src/event/counter.rs
@@ -45,35 +45,7 @@ pub struct EventCounter<Platform: RawSyncPrimitivesProvider + TimeProvider> {
     broker: Arc<dyn BrokerControl>,
     handle: ObjectHandle,
     registry: Arc<BrokerEventRegistry<Platform>>,
-    wakeups: Arc<EventCounterWakeups<Platform>>,
-}
-
-pub(crate) struct EventCounterWakeups<Platform: RawSyncPrimitivesProvider> {
-    pollee: Pollee<Platform>,
-}
-
-impl<Platform> EventCounterWakeups<Platform>
-where
-    Platform: RawSyncPrimitivesProvider + TimeProvider,
-{
-    fn new() -> Self {
-        Self {
-            pollee: Pollee::new(),
-        }
-    }
-
-    pub(crate) fn notify_readiness(&self, readiness: ReadinessState) {
-        let mut events = Events::empty();
-        if readiness.read_ready {
-            events |= Events::IN;
-        }
-        if readiness.write_ready {
-            events |= Events::OUT;
-        }
-        if !events.is_empty() {
-            self.pollee.notify_observers(events);
-        }
-    }
+    pollee: Arc<Pollee<Platform>>,
 }
 
 impl<Platform> EventCounter<Platform>
@@ -95,13 +67,13 @@ where
             .map_err(BrokerObjectError::from)
             .map_err(EventCounterError::from)?;
         let registry = litebox.broker_event_registry();
-        let wakeups = Arc::new(EventCounterWakeups::new());
-        registry.register_event(handle, &wakeups);
+        let pollee = Arc::new(Pollee::new());
+        registry.register_event(handle, &pollee);
         Ok(Self {
             broker,
             handle,
             registry,
-            wakeups,
+            pollee,
         })
     }
 
@@ -112,10 +84,10 @@ where
         nonblock: bool,
         mode: EventCounterReadMode,
     ) -> Result<u64, TryOpError<EventCounterError>> {
-        self.wakeups.pollee.wait(cx, nonblock, Events::IN, || {
+        self.pollee.wait(cx, nonblock, Events::IN, || {
             let response = self.consume(mode)?;
             if response.readiness.write_ready {
-                self.wakeups.pollee.notify_observers(Events::OUT);
+                self.pollee.notify_observers(Events::OUT);
             }
             Ok(response.value)
         })
@@ -131,10 +103,10 @@ where
         if value == u64::MAX {
             return Err(TryOpError::Other(EventCounterError::InvalidInput));
         }
-        self.wakeups.pollee.wait(cx, nonblock, Events::OUT, || {
+        self.pollee.wait(cx, nonblock, Events::OUT, || {
             let readiness = self.add(value)?;
             if value != 0 && readiness.read_ready {
-                self.wakeups.pollee.notify_observers(Events::IN);
+                self.pollee.notify_observers(Events::IN);
             }
             Ok(core::mem::size_of::<u64>())
         })
@@ -158,7 +130,7 @@ where
     fn broker_request_error(&self, error: BrokerControlError) -> BrokerObjectError {
         let error = error.into();
         if error != BrokerObjectError::WouldBlock {
-            self.wakeups.pollee.notify_observers(Events::ERR);
+            self.pollee.notify_observers(Events::ERR);
         }
         error
     }
@@ -179,7 +151,7 @@ where
     Platform: RawSyncPrimitivesProvider + TimeProvider,
 {
     fn register_observer(&self, observer: alloc::sync::Weak<dyn Observer<Events>>, mask: Events) {
-        self.wakeups.pollee.register_observer(observer, mask);
+        self.pollee.register_observer(observer, mask);
     }
 
     fn check_io_events(&self) -> Events {

--- a/litebox/src/event/counter.rs
+++ b/litebox/src/event/counter.rs
@@ -11,7 +11,7 @@ use thiserror::Error;
 use crate::{
     LiteBox,
     broker::{
-        BrokerControl, BrokerEventRegistry,
+        BrokerControl, BrokerObjectRegistry,
         error::{BrokerControlError, BrokerObjectError},
     },
     event::{
@@ -44,7 +44,7 @@ pub enum EventCounterError {
 pub struct EventCounter<Platform: RawSyncPrimitivesProvider + TimeProvider> {
     broker: Arc<dyn BrokerControl>,
     handle: ObjectHandle,
-    registry: Arc<BrokerEventRegistry<Platform>>,
+    registry: Arc<BrokerObjectRegistry<Platform>>,
     pollee: Arc<Pollee<Platform>>,
 }
 
@@ -66,9 +66,9 @@ where
             .create_event_with_count(initial_count)
             .map_err(BrokerObjectError::from)
             .map_err(EventCounterError::from)?;
-        let registry = litebox.broker_event_registry();
+        let registry = litebox.broker_object_registry();
         let pollee = Arc::new(Pollee::new());
-        registry.register_event(handle, &pollee);
+        registry.register_pollable(handle, &pollee);
         Ok(Self {
             broker,
             handle,
@@ -141,7 +141,7 @@ where
     Platform: RawSyncPrimitivesProvider + TimeProvider,
 {
     fn drop(&mut self) {
-        self.registry.unregister_event(self.handle);
+        self.registry.unregister(self.handle);
         let _ = self.broker.close_object(self.handle);
     }
 }

--- a/litebox/src/event/counter.rs
+++ b/litebox/src/event/counter.rs
@@ -212,7 +212,6 @@ mod tests {
         })
         .unwrap();
         let litebox = LiteBox::new_with_broker_local(platform, local);
-        let sink = litebox.broker_notification_sink();
         let counter = Arc::new(EventCounter::new(&litebox, 0).unwrap());
 
         let (result_sender, result_receiver) = std::sync::mpsc::channel();
@@ -235,7 +234,7 @@ mod tests {
             std::thread::yield_now();
         }
         read_ready.store(true, Ordering::SeqCst);
-        sink.dispatch(BrokerNotification::EventReadiness(
+        litebox.dispatch_broker_notification(BrokerNotification::EventReadiness(
             EventReadinessNotification {
                 handle,
                 readiness: ReadinessState {

--- a/litebox/src/lib.rs
+++ b/litebox/src/lib.rs
@@ -31,7 +31,7 @@ pub mod tls;
 // The core [`LiteBox`] object itself, re-exported here publicly, just to keep management of the
 // code cleaner.
 mod litebox;
-pub use litebox::{BrokerNotificationSink, LiteBox};
+pub use litebox::LiteBox;
 
 // Explicitly-private, the utilities are not exposed to users of LiteBox, and are intended entirely
 // to contain implementation-internal code.

--- a/litebox/src/lib.rs
+++ b/litebox/src/lib.rs
@@ -31,7 +31,7 @@ pub mod tls;
 // The core [`LiteBox`] object itself, re-exported here publicly, just to keep management of the
 // code cleaner.
 mod litebox;
-pub use litebox::LiteBox;
+pub use litebox::{BrokerNotificationSink, LiteBox};
 
 // Explicitly-private, the utilities are not exposed to users of LiteBox, and are intended entirely
 // to contain implementation-internal code.

--- a/litebox/src/litebox.rs
+++ b/litebox/src/litebox.rs
@@ -111,7 +111,7 @@ impl<Platform: RawSyncPrimitivesProvider> LiteBox<Platform> {
                 platform,
                 descriptors,
                 broker: broker_control,
-                broker_objects: Arc::new(broker::BrokerObjectRegistry::new()),
+                broker_pollables: Arc::new(broker::BrokerPollableRegistry::new()),
             }),
         }
     }
@@ -151,8 +151,8 @@ impl<Platform: RawSyncPrimitivesProvider> LiteBox<Platform> {
         self.x.broker.clone()
     }
 
-    pub(crate) fn broker_object_registry(&self) -> Arc<broker::BrokerObjectRegistry<Platform>> {
-        Arc::clone(&self.x.broker_objects)
+    pub(crate) fn broker_pollable_registry(&self) -> Arc<broker::BrokerPollableRegistry<Platform>> {
+        Arc::clone(&self.x.broker_pollables)
     }
 
     /// Returns a dispatch handle for broker-initiated notifications.
@@ -172,7 +172,7 @@ where
         match notification {
             BrokerNotification::EventReadiness(notification) => self
                 .x
-                .broker_objects
+                .broker_pollables
                 .notify_readiness(notification.handle, notification.readiness),
         }
     }
@@ -183,5 +183,5 @@ pub(crate) struct LiteBoxX<Platform: RawSyncPrimitivesProvider> {
     pub(crate) platform: &'static Platform,
     descriptors: RwLock<Platform, Descriptors<Platform>>,
     broker: Option<Arc<dyn broker::BrokerControl>>,
-    broker_objects: Arc<broker::BrokerObjectRegistry<Platform>>,
+    broker_pollables: Arc<broker::BrokerPollableRegistry<Platform>>,
 }

--- a/litebox/src/litebox.rs
+++ b/litebox/src/litebox.rs
@@ -106,17 +106,6 @@ impl<Platform: RawSyncPrimitivesProvider> LiteBox<Platform> {
             }),
         }
     }
-}
-
-impl<Platform: RawSyncPrimitivesProvider> Clone for LiteBox<Platform> {
-    fn clone(&self) -> Self {
-        Self {
-            x: Arc::clone(&self.x),
-        }
-    }
-}
-
-impl<Platform: RawSyncPrimitivesProvider> LiteBox<Platform> {
     /// Access to the file descriptor table.
     ///
     /// Note: this takes a lock, and thus should ideally not be held on to for too long to prevent
@@ -155,6 +144,14 @@ impl<Platform: RawSyncPrimitivesProvider> LiteBox<Platform> {
                 .x
                 .broker_handles
                 .notify_readiness(notification.handle, notification.readiness),
+        }
+    }
+}
+
+impl<Platform: RawSyncPrimitivesProvider> Clone for LiteBox<Platform> {
+    fn clone(&self) -> Self {
+        Self {
+            x: Arc::clone(&self.x),
         }
     }
 }

--- a/litebox/src/litebox.rs
+++ b/litebox/src/litebox.rs
@@ -111,7 +111,7 @@ impl<Platform: RawSyncPrimitivesProvider> LiteBox<Platform> {
                 platform,
                 descriptors,
                 broker: broker_control,
-                broker_pollables: Arc::new(broker::BrokerPollableRegistry::new()),
+                broker_handles: Arc::new(broker::BrokerHandleRegistry::new()),
             }),
         }
     }
@@ -151,8 +151,8 @@ impl<Platform: RawSyncPrimitivesProvider> LiteBox<Platform> {
         self.x.broker.clone()
     }
 
-    pub(crate) fn broker_pollable_registry(&self) -> Arc<broker::BrokerPollableRegistry<Platform>> {
-        Arc::clone(&self.x.broker_pollables)
+    pub(crate) fn broker_handle_registry(&self) -> Arc<broker::BrokerHandleRegistry<Platform>> {
+        Arc::clone(&self.x.broker_handles)
     }
 
     /// Returns a dispatch handle for broker-initiated notifications.
@@ -172,7 +172,7 @@ where
         match notification {
             BrokerNotification::EventReadiness(notification) => self
                 .x
-                .broker_pollables
+                .broker_handles
                 .notify_readiness(notification.handle, notification.readiness),
         }
     }
@@ -183,5 +183,5 @@ pub(crate) struct LiteBoxX<Platform: RawSyncPrimitivesProvider> {
     pub(crate) platform: &'static Platform,
     descriptors: RwLock<Platform, Descriptors<Platform>>,
     broker: Option<Arc<dyn broker::BrokerControl>>,
-    broker_pollables: Arc<broker::BrokerPollableRegistry<Platform>>,
+    broker_handles: Arc<broker::BrokerHandleRegistry<Platform>>,
 }

--- a/litebox/src/litebox.rs
+++ b/litebox/src/litebox.rs
@@ -7,10 +7,12 @@ use alloc::sync::Arc;
 
 use litebox_broker_local::BrokerLocal;
 use litebox_broker_protocol::channel::LocalControlChannel;
+use litebox_broker_protocol::message::BrokerNotification;
 
 use crate::{
     broker,
     fd::Descriptors,
+    platform::TimeProvider,
     sync::{RawSyncPrimitivesProvider, RwLock},
 };
 
@@ -24,6 +26,15 @@ use crate::{
 /// platform are dependent on the particular subsystems.
 pub struct LiteBox<Platform: RawSyncPrimitivesProvider> {
     pub(crate) x: Arc<LiteBoxX<Platform>>,
+}
+
+/// Dispatch handle for broker-initiated notifications into a [`LiteBox`] instance.
+///
+/// Deployment code that owns a broker notification transport can move this
+/// handle into its receive loop without cloning or exposing the whole
+/// [`LiteBox`] object.
+pub struct BrokerNotificationSink<Platform: RawSyncPrimitivesProvider> {
+    x: Arc<LiteBoxX<Platform>>,
 }
 
 impl<Platform: RawSyncPrimitivesProvider> LiteBox<Platform> {
@@ -100,6 +111,7 @@ impl<Platform: RawSyncPrimitivesProvider> LiteBox<Platform> {
                 platform,
                 descriptors,
                 broker: broker_control,
+                broker_events: Arc::new(broker::BrokerEventRegistry::new()),
             }),
         }
     }
@@ -138,6 +150,32 @@ impl<Platform: RawSyncPrimitivesProvider> LiteBox<Platform> {
     pub(crate) fn broker_control(&self) -> Option<Arc<dyn broker::BrokerControl>> {
         self.x.broker.clone()
     }
+
+    pub(crate) fn broker_event_registry(&self) -> Arc<broker::BrokerEventRegistry<Platform>> {
+        Arc::clone(&self.x.broker_events)
+    }
+
+    /// Returns a dispatch handle for broker-initiated notifications.
+    pub fn broker_notification_sink(&self) -> BrokerNotificationSink<Platform> {
+        BrokerNotificationSink {
+            x: Arc::clone(&self.x),
+        }
+    }
+}
+
+impl<Platform> BrokerNotificationSink<Platform>
+where
+    Platform: RawSyncPrimitivesProvider + TimeProvider,
+{
+    /// Dispatches one broker notification to the matching local-core object.
+    pub fn dispatch(&self, notification: BrokerNotification) {
+        match notification {
+            BrokerNotification::EventReadiness(notification) => self
+                .x
+                .broker_events
+                .notify_event_readiness(notification.handle, notification.readiness),
+        }
+    }
 }
 
 /// The actual body of [`LiteBox`], containing any components that might be shared.
@@ -145,4 +183,5 @@ pub(crate) struct LiteBoxX<Platform: RawSyncPrimitivesProvider> {
     pub(crate) platform: &'static Platform,
     descriptors: RwLock<Platform, Descriptors<Platform>>,
     broker: Option<Arc<dyn broker::BrokerControl>>,
+    broker_events: Arc<broker::BrokerEventRegistry<Platform>>,
 }

--- a/litebox/src/litebox.rs
+++ b/litebox/src/litebox.rs
@@ -111,7 +111,7 @@ impl<Platform: RawSyncPrimitivesProvider> LiteBox<Platform> {
                 platform,
                 descriptors,
                 broker: broker_control,
-                broker_events: Arc::new(broker::BrokerEventRegistry::new()),
+                broker_objects: Arc::new(broker::BrokerObjectRegistry::new()),
             }),
         }
     }
@@ -151,8 +151,8 @@ impl<Platform: RawSyncPrimitivesProvider> LiteBox<Platform> {
         self.x.broker.clone()
     }
 
-    pub(crate) fn broker_event_registry(&self) -> Arc<broker::BrokerEventRegistry<Platform>> {
-        Arc::clone(&self.x.broker_events)
+    pub(crate) fn broker_object_registry(&self) -> Arc<broker::BrokerObjectRegistry<Platform>> {
+        Arc::clone(&self.x.broker_objects)
     }
 
     /// Returns a dispatch handle for broker-initiated notifications.
@@ -172,8 +172,8 @@ where
         match notification {
             BrokerNotification::EventReadiness(notification) => self
                 .x
-                .broker_events
-                .notify_event_readiness(notification.handle, notification.readiness),
+                .broker_objects
+                .notify_readiness(notification.handle, notification.readiness),
         }
     }
 }
@@ -183,5 +183,5 @@ pub(crate) struct LiteBoxX<Platform: RawSyncPrimitivesProvider> {
     pub(crate) platform: &'static Platform,
     descriptors: RwLock<Platform, Descriptors<Platform>>,
     broker: Option<Arc<dyn broker::BrokerControl>>,
-    broker_events: Arc<broker::BrokerEventRegistry<Platform>>,
+    broker_objects: Arc<broker::BrokerObjectRegistry<Platform>>,
 }

--- a/litebox/src/litebox.rs
+++ b/litebox/src/litebox.rs
@@ -106,6 +106,16 @@ impl<Platform: RawSyncPrimitivesProvider> LiteBox<Platform> {
             }),
         }
     }
+
+    /// An explicitly-crate-internal clone method to prevent outside users from cloning the
+    /// [`LiteBox`] object, which could cause confusion as to the intended use. External users must
+    /// only create it via [`Self::new`].
+    pub(crate) fn clone(&self) -> Self {
+        Self {
+            x: Arc::clone(&self.x),
+        }
+    }
+
     /// Access to the file descriptor table.
     ///
     /// Note: this takes a lock, and thus should ideally not be held on to for too long to prevent
@@ -146,12 +156,15 @@ impl<Platform: RawSyncPrimitivesProvider> LiteBox<Platform> {
                 .notify_readiness(notification.handle, notification.readiness),
         }
     }
-}
 
-impl<Platform: RawSyncPrimitivesProvider> Clone for LiteBox<Platform> {
-    fn clone(&self) -> Self {
-        Self {
-            x: Arc::clone(&self.x),
+    /// Returns a narrow dispatcher for moving broker notification handling into deployment code.
+    pub fn broker_notification_dispatcher(&self) -> impl Fn(BrokerNotification) + Send + 'static
+    where
+        Platform: TimeProvider + 'static,
+    {
+        let litebox = self.clone();
+        move |notification| {
+            litebox.dispatch_broker_notification(notification);
         }
     }
 }

--- a/litebox/src/litebox.rs
+++ b/litebox/src/litebox.rs
@@ -28,15 +28,6 @@ pub struct LiteBox<Platform: RawSyncPrimitivesProvider> {
     pub(crate) x: Arc<LiteBoxX<Platform>>,
 }
 
-/// Dispatch handle for broker-initiated notifications into a [`LiteBox`] instance.
-///
-/// Deployment code that owns a broker notification transport can move this
-/// handle into its receive loop without cloning or exposing the whole
-/// [`LiteBox`] object.
-pub struct BrokerNotificationSink<Platform: RawSyncPrimitivesProvider> {
-    x: Arc<LiteBoxX<Platform>>,
-}
-
 impl<Platform: RawSyncPrimitivesProvider> LiteBox<Platform> {
     /// Create a new (empty) [`LiteBox`] instance for the given `platform`.
     ///
@@ -117,16 +108,15 @@ impl<Platform: RawSyncPrimitivesProvider> LiteBox<Platform> {
     }
 }
 
-impl<Platform: RawSyncPrimitivesProvider> LiteBox<Platform> {
-    /// An explicitly-crate-internal clone method to prevent outside users from cloning the
-    /// [`LiteBox`] object, which could cause confusion as to the intended use. External users must
-    /// only create it via [`Self::new`].
-    pub(crate) fn clone(&self) -> Self {
+impl<Platform: RawSyncPrimitivesProvider> Clone for LiteBox<Platform> {
+    fn clone(&self) -> Self {
         Self {
             x: Arc::clone(&self.x),
         }
     }
+}
 
+impl<Platform: RawSyncPrimitivesProvider> LiteBox<Platform> {
     /// Access to the file descriptor table.
     ///
     /// Note: this takes a lock, and thus should ideally not be held on to for too long to prevent
@@ -155,20 +145,11 @@ impl<Platform: RawSyncPrimitivesProvider> LiteBox<Platform> {
         Arc::clone(&self.x.broker_handles)
     }
 
-    /// Returns a dispatch handle for broker-initiated notifications.
-    pub fn broker_notification_sink(&self) -> BrokerNotificationSink<Platform> {
-        BrokerNotificationSink {
-            x: Arc::clone(&self.x),
-        }
-    }
-}
-
-impl<Platform> BrokerNotificationSink<Platform>
-where
-    Platform: RawSyncPrimitivesProvider + TimeProvider,
-{
     /// Dispatches one broker notification to the matching local-core object.
-    pub fn dispatch(&self, notification: BrokerNotification) {
+    pub fn dispatch_broker_notification(&self, notification: BrokerNotification)
+    where
+        Platform: TimeProvider,
+    {
         match notification {
             BrokerNotification::EventReadiness(notification) => self
                 .x

--- a/litebox_runner_linux_userland/src/broker.rs
+++ b/litebox_runner_linux_userland/src/broker.rs
@@ -15,12 +15,10 @@ use litebox_broker_transport::unix_socket::{
 
 const SETUP_TIMEOUT: Duration = Duration::from_secs(5);
 const RETRY_DELAY: Duration = Duration::from_millis(20);
-type Local = BrokerLocal<UnixStreamLocalControlChannel>;
-type Notifications = BrokerNotifications<UnixStreamLocalNotificationChannel>;
 
 pub(crate) struct BrokerConnection {
-    local: Local,
-    notifications: Notifications,
+    local: BrokerLocal<UnixStreamLocalControlChannel>,
+    notifications: BrokerNotifications<UnixStreamLocalNotificationChannel>,
 }
 
 pub(crate) fn connect(
@@ -60,7 +58,7 @@ pub(crate) fn connect(
 }
 
 pub(crate) fn start_notification_receiver(
-    mut notifications: Notifications,
+    mut notifications: BrokerNotifications<UnixStreamLocalNotificationChannel>,
     dispatch_notification: impl Fn(BrokerNotification) + Send + 'static,
 ) -> Result<()> {
     std::thread::Builder::new()
@@ -82,7 +80,12 @@ pub(crate) fn start_notification_receiver(
 }
 
 impl BrokerConnection {
-    pub(crate) fn into_parts(self) -> (Local, Notifications) {
+    pub(crate) fn into_parts(
+        self,
+    ) -> (
+        BrokerLocal<UnixStreamLocalControlChannel>,
+        BrokerNotifications<UnixStreamLocalNotificationChannel>,
+    ) {
         (self.local, self.notifications)
     }
 }

--- a/litebox_runner_linux_userland/src/broker.rs
+++ b/litebox_runner_linux_userland/src/broker.rs
@@ -8,6 +8,7 @@ use std::{
 
 use anyhow::{Context as _, Result};
 use litebox_broker_local::{BrokerLocal, BrokerNotifications};
+use litebox_broker_protocol::message::BrokerNotification;
 use litebox_broker_transport::unix_socket::{
     UnixStreamLocalControlChannel, UnixStreamLocalNotificationChannel,
 };
@@ -58,19 +59,16 @@ pub(crate) fn connect(
     })
 }
 
-pub(crate) fn start_notification_receiver<Platform>(
+pub(crate) fn start_notification_receiver(
     mut notifications: Notifications,
-    litebox: litebox::LiteBox<Platform>,
-) -> Result<()>
-where
-    Platform: litebox::sync::RawSyncPrimitivesProvider + litebox::platform::TimeProvider + 'static,
-{
+    dispatch_notification: impl Fn(BrokerNotification) + Send + 'static,
+) -> Result<()> {
     std::thread::Builder::new()
         .name("litebox-broker-notifications".to_owned())
         .spawn(move || {
             loop {
                 match notifications.recv_notification() {
-                    Ok(Some(notification)) => litebox.dispatch_broker_notification(notification),
+                    Ok(Some(notification)) => dispatch_notification(notification),
                     Ok(None) => break,
                     Err(error) => {
                         eprintln!("failed to receive broker notification: {error}");

--- a/litebox_runner_linux_userland/src/broker.rs
+++ b/litebox_runner_linux_userland/src/broker.rs
@@ -3,7 +3,6 @@
 
 use std::{
     path::Path,
-    thread::JoinHandle,
     time::{Duration, Instant},
 };
 
@@ -16,14 +15,11 @@ use litebox_broker_transport::unix_socket::{
 const SETUP_TIMEOUT: Duration = Duration::from_secs(5);
 const RETRY_DELAY: Duration = Duration::from_millis(20);
 type Local = BrokerLocal<UnixStreamLocalControlChannel>;
+type Notifications = BrokerNotifications<UnixStreamLocalNotificationChannel>;
 
 pub(crate) struct BrokerConnection {
     local: Local,
-    #[expect(
-        dead_code,
-        reason = "keeps the notification receiver thread alive while the broker connection is installed"
-    )]
-    notification_receiver_thread: JoinHandle<()>,
+    notifications: Notifications,
 }
 
 pub(crate) fn connect(
@@ -56,13 +52,25 @@ pub(crate) fn connect(
         )
     })?;
     let local = BrokerLocal::negotiate(control_channel).context("broker negotiation failed")?;
-    let mut notifications = BrokerNotifications::new(notification_channel);
-    let notification_thread = std::thread::Builder::new()
+    Ok(BrokerConnection {
+        local,
+        notifications: BrokerNotifications::new(notification_channel),
+    })
+}
+
+pub(crate) fn start_notification_receiver<Platform>(
+    mut notifications: Notifications,
+    sink: litebox::BrokerNotificationSink<Platform>,
+) -> Result<()>
+where
+    Platform: litebox::sync::RawSyncPrimitivesProvider + litebox::platform::TimeProvider + 'static,
+{
+    std::thread::Builder::new()
         .name("litebox-broker-notifications".to_owned())
         .spawn(move || {
             loop {
                 match notifications.recv_notification() {
-                    Ok(Some(_notification)) => {}
+                    Ok(Some(notification)) => sink.dispatch(notification),
                     Ok(None) => break,
                     Err(error) => {
                         eprintln!("failed to receive broker notification: {error}");
@@ -72,15 +80,12 @@ pub(crate) fn connect(
             }
         })
         .context("failed to start broker notification receiver")?;
-    Ok(BrokerConnection {
-        local,
-        notification_receiver_thread: notification_thread,
-    })
+    Ok(())
 }
 
 impl BrokerConnection {
-    pub(crate) fn into_local(self) -> Local {
-        self.local
+    pub(crate) fn into_parts(self) -> (Local, Notifications) {
+        (self.local, self.notifications)
     }
 }
 

--- a/litebox_runner_linux_userland/src/broker.rs
+++ b/litebox_runner_linux_userland/src/broker.rs
@@ -60,7 +60,7 @@ pub(crate) fn connect(
 
 pub(crate) fn start_notification_receiver<Platform>(
     mut notifications: Notifications,
-    sink: litebox::BrokerNotificationSink<Platform>,
+    litebox: litebox::LiteBox<Platform>,
 ) -> Result<()>
 where
     Platform: litebox::sync::RawSyncPrimitivesProvider + litebox::platform::TimeProvider + 'static,
@@ -70,7 +70,7 @@ where
         .spawn(move || {
             loop {
                 match notifications.recv_notification() {
-                    Ok(Some(notification)) => sink.dispatch(notification),
+                    Ok(Some(notification)) => litebox.dispatch_broker_notification(notification),
                     Ok(None) => break,
                     Err(error) => {
                         eprintln!("failed to receive broker notification: {error}");

--- a/litebox_runner_linux_userland/src/broker.rs
+++ b/litebox_runner_linux_userland/src/broker.rs
@@ -16,15 +16,13 @@ use litebox_broker_transport::unix_socket::{
 const SETUP_TIMEOUT: Duration = Duration::from_secs(5);
 const RETRY_DELAY: Duration = Duration::from_millis(20);
 
-pub(crate) struct BrokerConnection {
-    local: BrokerLocal<UnixStreamLocalControlChannel>,
-    notifications: BrokerNotifications<UnixStreamLocalNotificationChannel>,
-}
-
 pub(crate) fn connect(
     control_socket_path: &Path,
     notification_socket_path: &Path,
-) -> Result<BrokerConnection> {
+) -> Result<(
+    BrokerLocal<UnixStreamLocalControlChannel>,
+    BrokerNotifications<UnixStreamLocalNotificationChannel>,
+)> {
     let setup_deadline = Instant::now() + SETUP_TIMEOUT;
     let control_channel = connect_with_retry(
         control_socket_path,
@@ -51,10 +49,7 @@ pub(crate) fn connect(
         )
     })?;
     let local = BrokerLocal::negotiate(control_channel).context("broker negotiation failed")?;
-    Ok(BrokerConnection {
-        local,
-        notifications: BrokerNotifications::new(notification_channel),
-    })
+    Ok((local, BrokerNotifications::new(notification_channel)))
 }
 
 pub(crate) fn start_notification_receiver(
@@ -77,17 +72,6 @@ pub(crate) fn start_notification_receiver(
         })
         .context("failed to start broker notification receiver")?;
     Ok(())
-}
-
-impl BrokerConnection {
-    pub(crate) fn into_parts(
-        self,
-    ) -> (
-        BrokerLocal<UnixStreamLocalControlChannel>,
-        BrokerNotifications<UnixStreamLocalNotificationChannel>,
-    ) {
-        (self.local, self.notifications)
-    }
 }
 
 fn connect_with_retry<Channel>(

--- a/litebox_runner_linux_userland/src/lib.rs
+++ b/litebox_runner_linux_userland/src/lib.rs
@@ -246,7 +246,10 @@ pub fn run(cli_args: CliArgs) -> Result<()> {
             litebox_platform_multiplex::platform(),
             broker_local,
         );
-        broker::start_notification_receiver(broker_notifications, litebox.clone())?;
+        broker::start_notification_receiver(
+            broker_notifications,
+            litebox.broker_notification_dispatcher(),
+        )?;
         litebox_shim_linux::LinuxShimBuilder::new_with_litebox(litebox)
     } else {
         litebox_shim_linux::LinuxShimBuilder::new()

--- a/litebox_runner_linux_userland/src/lib.rs
+++ b/litebox_runner_linux_userland/src/lib.rs
@@ -246,10 +246,7 @@ pub fn run(cli_args: CliArgs) -> Result<()> {
             litebox_platform_multiplex::platform(),
             broker_local,
         );
-        broker::start_notification_receiver(
-            broker_notifications,
-            litebox.broker_notification_sink(),
-        )?;
+        broker::start_notification_receiver(broker_notifications, litebox.clone())?;
         litebox_shim_linux::LinuxShimBuilder::new_with_litebox(litebox)
     } else {
         litebox_shim_linux::LinuxShimBuilder::new()

--- a/litebox_runner_linux_userland/src/lib.rs
+++ b/litebox_runner_linux_userland/src/lib.rs
@@ -241,7 +241,7 @@ pub fn run(cli_args: CliArgs) -> Result<()> {
     };
 
     let shim_builder = if let Some(broker_connection) = broker_connection {
-        let (broker_local, broker_notifications) = broker_connection.into_parts();
+        let (broker_local, broker_notifications) = broker_connection;
         let litebox = litebox::LiteBox::new_with_broker_local(
             litebox_platform_multiplex::platform(),
             broker_local,

--- a/litebox_runner_linux_userland/src/lib.rs
+++ b/litebox_runner_linux_userland/src/lib.rs
@@ -241,12 +241,16 @@ pub fn run(cli_args: CliArgs) -> Result<()> {
     };
 
     let shim_builder = if let Some(broker_connection) = broker_connection {
-        litebox_shim_linux::LinuxShimBuilder::new_with_litebox(
-            litebox::LiteBox::new_with_broker_local(
-                litebox_platform_multiplex::platform(),
-                broker_connection.into_local(),
-            ),
-        )
+        let (broker_local, broker_notifications) = broker_connection.into_parts();
+        let litebox = litebox::LiteBox::new_with_broker_local(
+            litebox_platform_multiplex::platform(),
+            broker_local,
+        );
+        broker::start_notification_receiver(
+            broker_notifications,
+            litebox.broker_notification_sink(),
+        )?;
+        litebox_shim_linux::LinuxShimBuilder::new_with_litebox(litebox)
     } else {
         litebox_shim_linux::LinuxShimBuilder::new()
     };


### PR DESCRIPTION
Adds a LiteBox broker notification dispatch path and a BrokerHandleRegistry that maps broker object handles to local pollables, so EventReadiness notifications can wake blocked broker-backed event counters. Event counters register/unregister their pollable by handle, and the Linux userland runner now dispatches notification-channel messages through a narrow LiteBox dispatcher instead of only draining them. Includes focused coverage that a broker readiness notification wakes a blocked broker-backed event counter read.