### PR TITLE
Enable `x86_64` Linux stack guard for OP-TEE TAs

### DIFF
--- a/litebox_shim_optee/src/lib.rs
+++ b/litebox_shim_optee/src/lib.rs
@@ -269,6 +269,7 @@ impl OpteeShim {
                 ta_entry_point: Cell::new(0),
                 ta_stack_base_addr: Cell::new(0),
                 ta_prepared: Cell::new(false),
+                #[cfg(target_arch = "x86_64")]
                 stack_guard_page_addr: Cell::new(0),
             },
         };
@@ -836,6 +837,11 @@ impl Task {
     }
 
     /// Allocate and initialize the page backing the x86-64 stack-guard slot.
+    ///
+    /// The x86-64 toolchain emits stack-protector accesses to `%fs:0x28`.
+    /// Normally glibc or musl initializes that ABI slot before application code
+    /// runs. OP-TEE TAs use neither runtime, so the shim must provide and
+    /// initialize the slot before entering a protected TA.
     fn allocate_stack_guard_page(&self) -> Result<(), ElfLoaderError> {
         use litebox::platform::CrngProvider as _;
 
@@ -853,6 +859,9 @@ impl Task {
             })?;
         let mut guard = [0u8; core::mem::size_of::<usize>()];
         self.global.platform.fill_bytes_crng(&mut guard);
+        // Terminator-canary convention (matches glibc `_dl_setup_stack_chk_guard`):
+        // zero the lowest-addressed byte of the guard to stop the overflow by C string func.
+        guard[0] = 0;
         page.copy_from_slice(loader::ta_stack::ABI_STACK_GUARD_FS_OFFSET, &guard)
             .ok_or(ElfLoaderError::InvalidStackAddr)?;
         self.sys_mprotect(page, PAGE_SIZE, ProtFlags::PROT_READ)
@@ -1348,6 +1357,7 @@ struct Task {
     /// Whether the TA has been prepared
     ta_prepared: Cell<bool>,
     /// Base address of the read-only page containing the stack guard.
+    #[cfg(target_arch = "x86_64")]
     stack_guard_page_addr: Cell<usize>,
     // TODO: OP-TEE supports global, persistent objects across sessions. Add these maps if needed.
 }
@@ -1513,6 +1523,7 @@ mod test_utils {
                 ta_entry_point: Cell::new(0),
                 ta_stack_base_addr: Cell::new(0),
                 ta_prepared: Cell::new(false),
+                #[cfg(target_arch = "x86_64")]
                 stack_guard_page_addr: Cell::new(0),
             }
         }

--- a/litebox_shim_optee/src/lib.rs
+++ b/litebox_shim_optee/src/lib.rs
@@ -269,8 +269,6 @@ impl OpteeShim {
                 ta_entry_point: Cell::new(0),
                 ta_stack_base_addr: Cell::new(0),
                 ta_prepared: Cell::new(false),
-                #[cfg(target_arch = "x86_64")]
-                tls_base_addr: Cell::new(0),
             },
         };
         if let Some(ta_bin) = ta_bin
@@ -783,14 +781,8 @@ impl Task {
             let ta_entry_point = self.get_ta_entry_point();
             let mut elf_loader = loader::elf::ElfLoader::new(self, &ta_bin, false)?;
             elf_loader.load_ta_trampoline(ta_entry_point)?;
-            self.allocate_guest_tls(None).map_err(|_| {
-                ElfLoaderError::MappingError(litebox::mm::linux::MappingError::OutOfMemory)
-            })?;
             self.ta_prepared.set(true);
         }
-
-        #[cfg(target_arch = "x86_64")]
-        self.restore_guest_tls();
 
         let mut ta_stack =
             crate::loader::ta_stack::allocate_stack(self, self.get_ta_stack_base_addr()).ok_or(
@@ -799,6 +791,18 @@ impl Task {
         ta_stack
             .init(self.global.platform, params)
             .ok_or(ElfLoaderError::InvalidStackAddr)?;
+
+        // Point the FS base at the TA stack canary so the compiler's
+        // stack-guard reads resolve to it. Must run after
+        // `ta_stack.init` (which pushes the canary) and on every entry,
+        // because the guest FS base does not persist across shim<->guest
+        // transitions (see `set_guest_stack_guard_fs_base`).
+        #[cfg(target_arch = "x86_64")]
+        Self::set_guest_stack_guard_fs_base(
+            ta_stack
+                .canary_addr()
+                .ok_or(ElfLoaderError::InvalidStackAddr)?,
+        )?;
 
         Ok(ThreadInitState::Ta {
             cmd_id: cmd_id.unwrap_or(0) as usize,
@@ -839,52 +843,31 @@ impl Task {
         }
     }
 
-    /// Allocate the guest TLS for an OP-TEE TA.
+    /// Point the guest FS base at the TA stack canary so the compiler's stack
+    /// guard read resolves onto it.
     ///
-    /// This function is required to overcome the compatibility issue coming from
-    /// system and build toolchain differences. OP-TEE OS only supports a single thread and
-    /// thus does not explicitly set up the TLS area. In contrast, we do use an x86 toolchain to
-    /// compile OP-TEE TAs and this toolchain assumes there is a valid TLS areas for various purposes
-    /// including stack protection. To this end, the toolchain generates binaries using
-    /// the `FS` register for TLS access.
-    /// This function allocates a TLS area on behalf of the TA to satisfy the toolchain's assumption.
-    /// Instead of using this function, we could change the flags of the toolchain to not use TLS
-    /// (e.g., `-fno-stack-protector`), but this might be insecure. Also, the toolchain might have
-    /// other features relying on TLS.
-    #[cfg(target_arch = "x86_64")]
-    fn allocate_guest_tls(
-        &self,
-        tls_size: Option<usize>,
-    ) -> Result<(), litebox_common_linux::errno::Errno> {
-        let tls_size = tls_size.unwrap_or(PAGE_SIZE).next_multiple_of(PAGE_SIZE);
-        let addr = self.sys_mmap(
-            0,
-            tls_size,
-            ProtFlags::PROT_READ | ProtFlags::PROT_WRITE,
-            MapFlags::MAP_PRIVATE | MapFlags::MAP_ANONYMOUS,
-            -1,
-            0,
-        )?;
-        // Store TLS address for later restoration
-        self.tls_base_addr.set(addr.as_usize());
-        self.restore_guest_tls();
-        Ok(())
-    }
-
-    /// Restore the guest TLS (FS base) before entering the TA.
+    /// OP-TEE TAs are single-threaded and have no TLS block, but the x86-64
+    /// toolchain still emits stack-protector reads of `%fs:0x28`. To satisfy
+    /// those reads without allocating a TLS area, we set the FS base to
+    /// `canary_addr - ABI_STACK_GUARD_FS_OFFSET` (an ABI-fixed offset, not a
+    /// tunable), so the compiler's guard read lands on the TA stack canary.
     ///
-    /// FS base is cleared across VTL switches, so we must restore it before
-    /// every TA entry.
+    /// This must be called on every TA entry: the guest FS base is not
+    /// guaranteed to persist across a shim<->guest transition. Re-establishing
+    /// it here keeps the shim platform-agnostic.
+    ///
+    /// Returns [`ElfLoaderError::InvalidStackAddr`] if `canary_addr` is below
+    /// `ABI_STACK_GUARD_FS_OFFSET`.
     #[cfg(target_arch = "x86_64")]
-    fn restore_guest_tls(&self) {
+    fn set_guest_stack_guard_fs_base(canary_addr: usize) -> Result<(), ElfLoaderError> {
         use litebox::platform::ArchSpecificProvider as _;
-        let addr = self.tls_base_addr.get();
-        if addr == 0 {
-            return; // TLS not allocated yet
-        }
+        let fs_base = canary_addr
+            .checked_sub(crate::loader::ta_stack::ABI_STACK_GUARD_FS_OFFSET)
+            .ok_or(ElfLoaderError::InvalidStackAddr)?;
         litebox_platform_multiplex::platform()
-            .set_arch_specific_register(&litebox::platform::ArchSpecificRegister::FsBase, addr)
+            .set_arch_specific_register(&litebox::platform::ArchSpecificRegister::FsBase, fs_base)
             .expect("requires guaranteed platform support for FsBase");
+        Ok(())
     }
 
     /// Retrieve the result of the `ldelf` execution.
@@ -1363,9 +1346,6 @@ struct Task {
     ta_stack_base_addr: Cell<usize>,
     /// Whether the TA has been prepared
     ta_prepared: Cell<bool>,
-    /// TLS base address for x86_64 (stored to restore FS before each TA entry)
-    #[cfg(target_arch = "x86_64")]
-    tls_base_addr: Cell<usize>,
     // TODO: OP-TEE supports global, persistent objects across sessions. Add these maps if needed.
 }
 
@@ -1530,8 +1510,6 @@ mod test_utils {
                 ta_entry_point: Cell::new(0),
                 ta_stack_base_addr: Cell::new(0),
                 ta_prepared: Cell::new(false),
-                #[cfg(target_arch = "x86_64")]
-                tls_base_addr: Cell::new(0),
             }
         }
     }

--- a/litebox_shim_optee/src/lib.rs
+++ b/litebox_shim_optee/src/lib.rs
@@ -849,8 +849,8 @@ impl Task {
     /// OP-TEE TAs are single-threaded and have no TLS block, but the x86-64
     /// toolchain still emits stack-protector reads of `%fs:0x28`. To satisfy
     /// those reads without allocating a TLS area, we set the FS base to
-    /// `canary_addr - ABI_STACK_GUARD_FS_OFFSET` (an ABI-fixed offset, not a
-    /// tunable), so the compiler's guard read lands on the TA stack canary.
+    /// `canary_addr - ABI_STACK_GUARD_FS_OFFSET` (shared by GCC, Clang, glibc,
+    /// and musl), so the compiler's guard read lands on the TA stack canary.
     ///
     /// This must be called on every TA entry: the guest FS base is not
     /// guaranteed to persist across a shim<->guest transition. Re-establishing

--- a/litebox_shim_optee/src/lib.rs
+++ b/litebox_shim_optee/src/lib.rs
@@ -22,7 +22,7 @@ use litebox::{
     shim::ContinueOperation,
     utils::TruncateExt,
 };
-use litebox_common_linux::{MapFlags, ProtFlags, errno::Errno, vmap::GlobalVmapManager};
+use litebox_common_linux::{errno::Errno, vmap::GlobalVmapManager};
 use litebox_common_optee::{
     LdelfArg, LdelfSyscallRequest, SyscallRequest, TaFlags, TeeAlgorithm, TeeAlgorithmClass,
     TeeAttributeType, TeeCrypStateHandle, TeeHandleFlag, TeeIdentity, TeeLogin, TeeObjHandle,

--- a/litebox_shim_optee/src/lib.rs
+++ b/litebox_shim_optee/src/lib.rs
@@ -22,7 +22,7 @@ use litebox::{
     shim::ContinueOperation,
     utils::TruncateExt,
 };
-use litebox_common_linux::{errno::Errno, vmap::GlobalVmapManager};
+use litebox_common_linux::{MapFlags, ProtFlags, errno::Errno, vmap::GlobalVmapManager};
 use litebox_common_optee::{
     LdelfArg, LdelfSyscallRequest, SyscallRequest, TaFlags, TeeAlgorithm, TeeAlgorithmClass,
     TeeAttributeType, TeeCrypStateHandle, TeeHandleFlag, TeeIdentity, TeeLogin, TeeObjHandle,
@@ -269,6 +269,7 @@ impl OpteeShim {
                 ta_entry_point: Cell::new(0),
                 ta_stack_base_addr: Cell::new(0),
                 ta_prepared: Cell::new(false),
+                stack_guard_page_addr: Cell::new(0),
             },
         };
         if let Some(ta_bin) = ta_bin
@@ -781,8 +782,11 @@ impl Task {
             let ta_entry_point = self.get_ta_entry_point();
             let mut elf_loader = loader::elf::ElfLoader::new(self, &ta_bin, false)?;
             elf_loader.load_ta_trampoline(ta_entry_point)?;
+            self.allocate_stack_guard_page()?;
             self.ta_prepared.set(true);
         }
+
+        self.restore_stack_guard_fs_base();
 
         let mut ta_stack =
             crate::loader::ta_stack::allocate_stack(self, self.get_ta_stack_base_addr()).ok_or(
@@ -791,18 +795,6 @@ impl Task {
         ta_stack
             .init(self.global.platform, params)
             .ok_or(ElfLoaderError::InvalidStackAddr)?;
-
-        // Point the FS base at the TA stack canary so the compiler's
-        // stack-guard reads resolve to it. Must run after
-        // `ta_stack.init` (which pushes the canary) and on every entry,
-        // because the guest FS base does not persist across shim<->guest
-        // transitions (see `set_guest_stack_guard_fs_base`).
-        #[cfg(target_arch = "x86_64")]
-        Self::set_guest_stack_guard_fs_base(
-            ta_stack
-                .canary_addr()
-                .ok_or(ElfLoaderError::InvalidStackAddr)?,
-        )?;
 
         Ok(ThreadInitState::Ta {
             cmd_id: cmd_id.unwrap_or(0) as usize,
@@ -843,31 +835,40 @@ impl Task {
         }
     }
 
-    /// Point the guest FS base at the TA stack canary so the compiler's stack
-    /// guard read resolves onto it.
-    ///
-    /// OP-TEE TAs are single-threaded and have no TLS block, but the x86-64
-    /// toolchain still emits stack-protector reads of `%fs:0x28`. To satisfy
-    /// those reads without allocating a TLS area, we set the FS base to
-    /// `canary_addr - ABI_STACK_GUARD_FS_OFFSET` (shared by GCC, Clang, glibc,
-    /// and musl), so the compiler's guard read lands on the TA stack canary.
-    ///
-    /// This must be called on every TA entry: the guest FS base is not
-    /// guaranteed to persist across a shim<->guest transition. Re-establishing
-    /// it here keeps the shim platform-agnostic.
-    ///
-    /// Returns [`ElfLoaderError::InvalidStackAddr`] if `canary_addr` is below
-    /// `ABI_STACK_GUARD_FS_OFFSET`.
-    #[cfg(target_arch = "x86_64")]
-    fn set_guest_stack_guard_fs_base(canary_addr: usize) -> Result<(), ElfLoaderError> {
-        use litebox::platform::ArchSpecificProvider as _;
-        let fs_base = canary_addr
-            .checked_sub(crate::loader::ta_stack::ABI_STACK_GUARD_FS_OFFSET)
+    /// Allocate and initialize the page backing the x86-64 stack-guard slot.
+    fn allocate_stack_guard_page(&self) -> Result<(), ElfLoaderError> {
+        use litebox::platform::CrngProvider as _;
+
+        let page = self
+            .sys_mmap(
+                0,
+                PAGE_SIZE,
+                ProtFlags::PROT_READ_WRITE,
+                MapFlags::MAP_PRIVATE | MapFlags::MAP_ANONYMOUS | MapFlags::MAP_POPULATE,
+                -1,
+                0,
+            )
+            .map_err(|_| {
+                ElfLoaderError::MappingError(litebox::mm::linux::MappingError::OutOfMemory)
+            })?;
+        let mut guard = [0u8; core::mem::size_of::<usize>()];
+        self.global.platform.fill_bytes_crng(&mut guard);
+        page.copy_from_slice(loader::ta_stack::ABI_STACK_GUARD_FS_OFFSET, &guard)
             .ok_or(ElfLoaderError::InvalidStackAddr)?;
+        self.sys_mprotect(page, PAGE_SIZE, ProtFlags::PROT_READ)
+            .map_err(ElfLoaderError::ProtectError)?;
+        self.stack_guard_page_addr.set(page.as_usize());
+        Ok(())
+    }
+
+    /// Restore the guest FS base so `%fs:0x28` reads the stack guard page.
+    fn restore_stack_guard_fs_base(&self) {
+        use litebox::platform::ArchSpecificProvider as _;
+        let fs_base = self.stack_guard_page_addr.get();
+        debug_assert_ne!(fs_base, 0);
         litebox_platform_multiplex::platform()
             .set_arch_specific_register(&litebox::platform::ArchSpecificRegister::FsBase, fs_base)
             .expect("requires guaranteed platform support for FsBase");
-        Ok(())
     }
 
     /// Retrieve the result of the `ldelf` execution.
@@ -1346,6 +1347,8 @@ struct Task {
     ta_stack_base_addr: Cell<usize>,
     /// Whether the TA has been prepared
     ta_prepared: Cell<bool>,
+    /// Base address of the read-only page containing the stack guard.
+    stack_guard_page_addr: Cell<usize>,
     // TODO: OP-TEE supports global, persistent objects across sessions. Add these maps if needed.
 }
 
@@ -1510,6 +1513,7 @@ mod test_utils {
                 ta_entry_point: Cell::new(0),
                 ta_stack_base_addr: Cell::new(0),
                 ta_prepared: Cell::new(false),
+                stack_guard_page_addr: Cell::new(0),
             }
         }
     }

--- a/litebox_shim_optee/src/loader/ta_stack.rs
+++ b/litebox_shim_optee/src/loader/ta_stack.rs
@@ -24,9 +24,8 @@ use crate::{Platform, UserMutPtr};
 /// The guard itself is a single pointer-sized word, i.e., **8 bytes** on x86-64.
 /// The read therefore spans `[%fs:0x28 .. %fs:0x30)`.
 ///
-/// OP-TEE TAs have no TLS block, so the shim sets the guest FS base to
-/// `canary_addr - ABI_STACK_GUARD_FS_OFFSET`, making that read resolve onto the
-/// CRNG canary pushed by [`TaStack::init`].
+/// OP-TEE TAs have no TLS block, so the shim provides a dedicated stack-guard
+/// page whose guard word is stored at this offset.
 #[cfg(target_arch = "x86_64")]
 pub(crate) const ABI_STACK_GUARD_FS_OFFSET: usize = 0x28;
 
@@ -126,6 +125,7 @@ impl TaStack {
     /// Get the address of the TA stack canary pushed by [`Self::init`].
     /// Returns `None` if no canary has been pushed yet.
     #[cfg(target_arch = "x86_64")]
+    #[expect(dead_code, reason = "retained with the existing stack canary")]
     pub(crate) fn canary_addr(&self) -> Option<usize> {
         self.canary_pos.map(|pos| self.stack_top.as_usize() + pos)
     }

--- a/litebox_shim_optee/src/loader/ta_stack.rs
+++ b/litebox_shim_optee/src/loader/ta_stack.rs
@@ -12,6 +12,22 @@ use zerocopy::IntoBytes;
 
 use crate::{Platform, UserMutPtr};
 
+/// ABI-mandated offset of the stack-protector guard from the x86-64 thread
+/// pointer (`%fs`). This is a fixed ABI constant, **not** a tunable.
+///
+/// On x86-64, GCC and Clang hardcode the stack-guard access as `%fs:0x28` when
+/// using the default TLS-based stack protector. This offset is a fixed part of
+/// that codegen ABI, independent of the C library.
+///
+/// The guard itself is a single pointer-sized word, i.e., **8 bytes** on x86-64.
+/// The read therefore spans `[%fs:0x28 .. %fs:0x30)`.
+///
+/// OP-TEE TAs have no TLS block, so the shim sets the guest FS base to
+/// `canary_addr - ABI_STACK_GUARD_FS_OFFSET`, making that read resolve onto the
+/// CRNG canary pushed by [`TaStack::init`].
+#[cfg(target_arch = "x86_64")]
+pub(crate) const ABI_STACK_GUARD_FS_OFFSET: usize = 0x28;
+
 #[inline]
 fn align_down(addr: usize, align: usize) -> usize {
     debug_assert!(align.is_power_of_two());
@@ -62,6 +78,9 @@ pub struct TaStack {
     num_params: usize,
     /// Position where LdelfArg was pushed (if any)
     ldelf_arg_pos: Option<usize>,
+    #[cfg(target_arch = "x86_64")]
+    /// Position where the TA stack canary was pushed (if any).
+    canary_pos: Option<usize>,
 }
 
 impl TaStack {
@@ -84,6 +103,7 @@ impl TaStack {
             params: UteeParams::new(),
             num_params: 0,
             ldelf_arg_pos: None,
+            canary_pos: None,
         })
     }
 
@@ -99,6 +119,13 @@ impl TaStack {
     /// Get the address of `UteeParams` on the stack.
     pub(crate) fn get_params_address(&self) -> usize {
         self.stack_top.as_usize() + self.len - core::mem::size_of::<UteeParams>()
+    }
+
+    /// Get the address of the TA stack canary pushed by [`Self::init`].
+    /// Returns `None` if no canary has been pushed yet.
+    #[cfg(target_arch = "x86_64")]
+    pub(crate) fn canary_addr(&self) -> Option<usize> {
+        self.canary_pos.map(|pos| self.stack_top.as_usize() + pos)
     }
 
     /// Get the address of `LdelfArg` on the stack.
@@ -121,6 +148,16 @@ impl TaStack {
     fn push_bytes(&mut self, bytes: &[u8]) -> Option<()> {
         self.pos = self.pos.checked_sub(bytes.len())?;
         self.stack_top.copy_from_slice(self.pos, bytes)?;
+        Some(())
+    }
+
+    /// Push the TA stack canary and record its address.
+    fn push_canary(&mut self, canary: &[u8; 16]) -> Option<()> {
+        self.push_bytes(canary)?;
+        #[cfg(target_arch = "x86_64")]
+        {
+            self.canary_pos = Some(self.pos);
+        }
         Some(())
     }
 
@@ -259,7 +296,7 @@ impl TaStack {
         // Random 16-byte stack canary
         let mut canary = [0u8; 16];
         <Platform as litebox::platform::CrngProvider>::fill_bytes_crng(platform, &mut canary);
-        self.push_bytes(&canary)?;
+        self.push_canary(&canary)?;
 
         // `reenter_thread` *jumps* into the TA entry point (which is a function) rather than
         // calls it. Adjust the stack pointer to ensure post-call stack alignment.

--- a/litebox_shim_optee/src/loader/ta_stack.rs
+++ b/litebox_shim_optee/src/loader/ta_stack.rs
@@ -12,12 +12,14 @@ use zerocopy::IntoBytes;
 
 use crate::{Platform, UserMutPtr};
 
-/// ABI-mandated offset of the stack-protector guard from the x86-64 thread
-/// pointer (`%fs`). This is a fixed ABI constant, **not** a tunable.
+/// Offset of the stack-protector guard from the x86-64 thread pointer (`%fs`).
 ///
-/// On x86-64, GCC and Clang hardcode the stack-guard access as `%fs:0x28` when
-/// using the default TLS-based stack protector. This offset is a fixed part of
-/// that codegen ABI, independent of the C library.
+/// This is a compiler + C-library convention: when using the default TLS-based
+/// stack protector, both GCC and Clang emit the stack-guard access as
+/// `%fs:0x28`, matching the `stack_guard` slot in the glibc/musl `tcbhead_t`.
+/// The offset is nominally tunable via `-mstack-protector-guard-offset`, but
+/// `0x28` is the fixed default across GCC, Clang, glibc, and musl on x86-64,
+/// so we treat it as a constant here.
 ///
 /// The guard itself is a single pointer-sized word, i.e., **8 bytes** on x86-64.
 /// The read therefore spans `[%fs:0x28 .. %fs:0x30)`.

--- a/litebox_shim_optee/src/loader/ta_stack.rs
+++ b/litebox_shim_optee/src/loader/ta_stack.rs
@@ -79,9 +79,6 @@ pub struct TaStack {
     num_params: usize,
     /// Position where LdelfArg was pushed (if any)
     ldelf_arg_pos: Option<usize>,
-    #[cfg(target_arch = "x86_64")]
-    /// Position where the TA stack canary was pushed (if any).
-    canary_pos: Option<usize>,
 }
 
 impl TaStack {
@@ -104,7 +101,6 @@ impl TaStack {
             params: UteeParams::new(),
             num_params: 0,
             ldelf_arg_pos: None,
-            canary_pos: None,
         })
     }
 
@@ -120,14 +116,6 @@ impl TaStack {
     /// Get the address of `UteeParams` on the stack.
     pub(crate) fn get_params_address(&self) -> usize {
         self.stack_top.as_usize() + self.len - core::mem::size_of::<UteeParams>()
-    }
-
-    /// Get the address of the TA stack canary pushed by [`Self::init`].
-    /// Returns `None` if no canary has been pushed yet.
-    #[cfg(target_arch = "x86_64")]
-    #[expect(dead_code, reason = "retained with the existing stack canary")]
-    pub(crate) fn canary_addr(&self) -> Option<usize> {
-        self.canary_pos.map(|pos| self.stack_top.as_usize() + pos)
     }
 
     /// Get the address of `LdelfArg` on the stack.
@@ -150,16 +138,6 @@ impl TaStack {
     fn push_bytes(&mut self, bytes: &[u8]) -> Option<()> {
         self.pos = self.pos.checked_sub(bytes.len())?;
         self.stack_top.copy_from_slice(self.pos, bytes)?;
-        Some(())
-    }
-
-    /// Push the TA stack canary and record its address.
-    fn push_canary(&mut self, canary: &[u8; 16]) -> Option<()> {
-        self.push_bytes(canary)?;
-        #[cfg(target_arch = "x86_64")]
-        {
-            self.canary_pos = Some(self.pos);
-        }
         Some(())
     }
 
@@ -298,7 +276,7 @@ impl TaStack {
         // Random 16-byte stack canary
         let mut canary = [0u8; 16];
         <Platform as litebox::platform::CrngProvider>::fill_bytes_crng(platform, &mut canary);
-        self.push_canary(&canary)?;
+        self.push_bytes(&canary)?;
 
         // `reenter_thread` *jumps* into the TA entry point (which is a function) rather than
         // calls it. Adjust the stack pointer to ensure post-call stack alignment.

--- a/litebox_shim_optee/src/syscalls/tests.rs
+++ b/litebox_shim_optee/src/syscalls/tests.rs
@@ -43,24 +43,6 @@ fn test_cryp_random_number_generate() {
 }
 
 #[test]
-fn test_stack_guard_page_is_initialized() {
-    use litebox::platform::RawConstPointer as _;
-
-    let task = init_platform();
-    task.allocate_stack_guard_page().unwrap();
-
-    let base = task.stack_guard_page_addr.get();
-    assert_ne!(base, 0);
-    assert_eq!(base % litebox::mm::linux::PAGE_SIZE, 0);
-    let guard = crate::UserConstPtr::<usize>::from_usize(
-        base + crate::loader::ta_stack::ABI_STACK_GUARD_FS_OFFSET,
-    )
-    .read_at_offset(0)
-    .unwrap();
-    assert_ne!(guard, 0);
-}
-
-#[test]
 fn test_sys_get_time_system_is_monotonic() {
     use litebox::platform::RawConstPointer as _;
     use litebox_common_optee::{TeeTime, TeeTimeCategory};

--- a/litebox_shim_optee/src/syscalls/tests.rs
+++ b/litebox_shim_optee/src/syscalls/tests.rs
@@ -43,6 +43,24 @@ fn test_cryp_random_number_generate() {
 }
 
 #[test]
+fn test_stack_guard_page_is_initialized() {
+    use litebox::platform::RawConstPointer as _;
+
+    let task = init_platform();
+    task.allocate_stack_guard_page().unwrap();
+
+    let base = task.stack_guard_page_addr.get();
+    assert_ne!(base, 0);
+    assert_eq!(base % litebox::mm::linux::PAGE_SIZE, 0);
+    let guard = crate::UserConstPtr::<usize>::from_usize(
+        base + crate::loader::ta_stack::ABI_STACK_GUARD_FS_OFFSET,
+    )
+    .read_at_offset(0)
+    .unwrap();
+    assert_ne!(guard, 0);
+}
+
+#[test]
 fn test_sys_get_time_system_is_monotonic() {
     use litebox::platform::RawConstPointer as _;
     use litebox_common_optee::{TeeTime, TeeTimeCategory};


### PR DESCRIPTION
This PR enables stack guard for OP-TEE TAs. Currently, we use `x86_64` Linux toolchains to build OP-TEE TA binaries with `-fstack-protector` (enabled by default), which expects glibc/musl stores a stack canary value in `%fs:0x28`. However, OP-TEE TAs don't use glibc/musl such that no code prepares memory for this. This PR lets the OP-TEE shim allocate, initialize (with a random number), and protect a stack guard page.