### PR TITLE
Set Windows process TLS

### DIFF
--- a/litebox_shim_windows/src/lib.rs
+++ b/litebox_shim_windows/src/lib.rs
@@ -1141,7 +1141,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                 process_information,
                 process_information_length,
             } => {
-                let status = Self::sys_nt_set_information_process(
+                let status = self.sys_nt_set_information_process(
                     process_handle,
                     process_information_class,
                     process_information,

--- a/litebox_shim_windows/src/lib.rs
+++ b/litebox_shim_windows/src/lib.rs
@@ -153,17 +153,26 @@ where
     ptr.write_at_offset(0, value)
 }
 
-fn write_field_at_offset<Platform, Struct, Field>(
-    base: MutPtr<Platform, Struct>,
+fn read_field_at_offset<Platform, Field>(base: usize, field_offset: usize) -> Option<Field>
+where
+    Platform: RawPointerProvider,
+    Field: zerocopy::FromBytes,
+{
+    let address = base.checked_add(field_offset)?;
+    let ptr = ConstPtr::<Platform, Field>::from_usize(address);
+    ptr.read_at_offset(0)
+}
+
+fn write_field_at_offset<Platform, Field>(
+    base: usize,
     field_offset: usize,
     value: Field,
 ) -> Option<()>
 where
     Platform: RawPointerProvider,
-    Struct: zerocopy::FromBytes + zerocopy::IntoBytes,
     Field: zerocopy::FromBytes + zerocopy::IntoBytes,
 {
-    let address = base.as_usize().checked_add(field_offset)?;
+    let address = base.checked_add(field_offset)?;
     let ptr = MutPtr::<Platform, Field>::from_usize(address);
     ptr.write_at_offset(0, value)
 }

--- a/litebox_shim_windows/src/loader/pe.rs
+++ b/litebox_shim_windows/src/loader/pe.rs
@@ -1115,7 +1115,7 @@ where
     Struct: FromBytes + IntoBytes,
     Field: FromBytes + IntoBytes,
 {
-    crate::write_field_at_offset::<Platform, Struct, Field>(base, field_offset, value)
+    crate::write_field_at_offset::<Platform, Field>(base.as_usize(), field_offset, value)
         .ok_or(PeImageAccessError::MemoryAccess)
 }
 

--- a/litebox_shim_windows/src/syscalls/mod.rs
+++ b/litebox_shim_windows/src/syscalls/mod.rs
@@ -389,7 +389,7 @@ pub(crate) enum SyscallRequest<Platform: RawPointerProvider> {
     NtSetInformationProcess {
         process_handle: ProcessHandle,
         process_information_class: u32,
-        process_information: Platform::RawConstPointer<u8>,
+        process_information: Platform::RawMutPointer<u8>,
         process_information_length: u32,
     },
     NtSetInformationThread {

--- a/litebox_shim_windows/src/syscalls/process.rs
+++ b/litebox_shim_windows/src/syscalls/process.rs
@@ -418,6 +418,13 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             "Handling ProcessTlsInformation"
         );
 
+        if header.thread_data_count > 1 {
+            // TODO(multi-thread-tls): PROCESS_TLS_INFORMATION entries are positional per-thread
+            // data. The shim currently models only the active TEB, so handling multiple entries
+            // would corrupt prior TLS values by repeatedly writing one TEB's vector.
+            return NtStatus::NOT_SUPPORTED;
+        }
+
         match ProcessTlsOperation::try_from(header.operation_type) {
             Ok(ProcessTlsOperation::ReplaceVector) => self.replace_tls_vector(
                 process_information,
@@ -713,6 +720,12 @@ mod tests {
         entry: ProcessTlsThreadDataSimple,
     }
 
+    #[repr(C)]
+    struct ProcessTlsTwoEntryRequest {
+        header: ProcessTlsInformationHeader,
+        entries: [ProcessTlsThreadDataSimple; 2],
+    }
+
     fn run_with_test_platform_pointers<R>(f: impl FnOnce() -> R) -> R {
         let _ = crate::tests::test_platform();
         <TestPlatform as ThreadProvider>::run_test_thread(f)
@@ -962,6 +975,67 @@ mod tests {
                 ),
                 NtStatus::INVALID_PARAMETER
             );
+        });
+    }
+
+    #[test]
+    fn nt_set_information_process_tls_rejects_multi_thread_entries_without_mutating_teb() {
+        run_with_test_platform_pointers(|| {
+            let mut task = crate::tests::test_task();
+            let mut teb = <ThreadEnvironmentBlock as zerocopy::FromZeros>::new_zeroed();
+            let mut tls_vector = [0usize; TEB_TLS_SLOT_COUNT];
+            tls_vector[7] = 0x1111;
+            teb.thread_local_storage_pointer = tls_vector.as_mut_ptr() as usize;
+            task.teb_address = core::ptr::from_mut(&mut teb) as usize;
+
+            let entry = ProcessTlsThreadDataSimple {
+                flags: 0,
+                _padding0: 0,
+                tls_data: 0x2222,
+                _reserved: 0,
+            };
+            let mut request = ProcessTlsTwoEntryRequest {
+                header: ProcessTlsInformationHeader {
+                    flags: 0,
+                    operation_type: ProcessTlsOperation::ReplaceIndex as u32,
+                    thread_data_count: 2,
+                    tls_index: 7,
+                },
+                entries: [entry, entry],
+            };
+
+            assert_eq!(
+                task.sys_nt_set_information_process(
+                    ProcessHandle::CURRENT,
+                    ProcessInformationClass::TlsInformation as u32,
+                    const_byte_mut_ptr(&mut request),
+                    size_of::<ProcessTlsTwoEntryRequest>().trunc(),
+                ),
+                NtStatus::NOT_SUPPORTED
+            );
+            assert_eq!(tls_vector[7], 0x1111);
+            assert_eq!(request.entries[0].tls_data, 0x2222);
+            assert_eq!(request.entries[1].tls_data, 0x2222);
+            assert_eq!(request.entries[0].flags, 0);
+            assert_eq!(request.entries[1].flags, 0);
+
+            request.header.operation_type = ProcessTlsOperation::ReplaceVector as u32;
+            let original_tls_pointer = teb.thread_local_storage_pointer;
+            let mut replacement_vector = [0usize; TEB_TLS_SLOT_COUNT];
+            request.entries[0].tls_data = replacement_vector.as_mut_ptr() as usize;
+            request.entries[1].tls_data = replacement_vector.as_mut_ptr() as usize;
+
+            assert_eq!(
+                task.sys_nt_set_information_process(
+                    ProcessHandle::CURRENT,
+                    ProcessInformationClass::TlsInformation as u32,
+                    const_byte_mut_ptr(&mut request),
+                    size_of::<ProcessTlsTwoEntryRequest>().trunc(),
+                ),
+                NtStatus::NOT_SUPPORTED
+            );
+            assert_eq!(teb.thread_local_storage_pointer, original_tls_pointer);
+            assert_eq!(replacement_vector[7], 0);
         });
     }
 

--- a/litebox_shim_windows/src/syscalls/process.rs
+++ b/litebox_shim_windows/src/syscalls/process.rs
@@ -468,6 +468,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             ) else {
                 return NtStatus::ACCESS_VIOLATION;
             };
+            // TODO(multi-thread-tls): read ith thread's tls
             let Some(old_tls_data) = self.read_teb_usize(offset_of!(
                 ThreadEnvironmentBlock,
                 thread_local_storage_pointer
@@ -542,6 +543,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             ) else {
                 return NtStatus::ACCESS_VIOLATION;
             };
+            // TODO(multi-thread-tls): read ith thread's tls
             let Some(tls_array) = self.read_teb_usize(offset_of!(
                 ThreadEnvironmentBlock,
                 thread_local_storage_pointer
@@ -551,11 +553,8 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             if tls_array == 0 {
                 continue;
             }
-            let Some(slot_address) = tls_array.checked_add(tls_index * size_of::<usize>()) else {
-                return NtStatus::INVALID_PARAMETER;
-            };
-            let slot = MutPtr::<Platform, usize>::from_usize(slot_address);
-            let Some(old_tls_data) = slot.read_at_offset(0) else {
+            let tls_slots = MutPtr::<Platform, usize>::from_usize(tls_array);
+            let Some(old_tls_data) = tls_slots.read_at_offset(tls_index.cast_signed()) else {
                 return NtStatus::ACCESS_VIOLATION;
             };
 
@@ -563,7 +562,6 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                 thread_data_index = index,
                 tls_index,
                 tls_array:% = format_args!("{tls_array:#x}"),
-                slot_address:% = format_args!("{slot_address:#x}"),
                 new_tls_data:% = format_args!("{new_tls_data:#x}"),
                 old_tls_data:% = format_args!("{old_tls_data:#x}");
                 "Replacing process TLS index"
@@ -576,7 +574,9 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                 old_tls_data,
             )
             .is_none()
-                || slot.write_at_offset(0, new_tls_data).is_none()
+                || tls_slots
+                    .write_at_offset(tls_index.cast_signed(), new_tls_data)
+                    .is_none()
                 || write_process_information_u32::<Platform>(
                     process_information,
                     thread_data_offset + layout.flags_offset(),
@@ -626,12 +626,12 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         let old_tls_slots = ConstPtr::<Platform, usize>::from_usize(old_tls_data);
         let new_tls_slots = MutPtr::<Platform, usize>::from_usize(new_tls_data);
         for index in 0..TEB_TLS_SLOT_COUNT.cast_signed() {
-            let Some(slot_value) = old_tls_slots.read_at_offset(index) else {
-                return Err(NtStatus::ACCESS_VIOLATION);
-            };
-            if new_tls_slots.write_at_offset(index, slot_value).is_none() {
-                return Err(NtStatus::ACCESS_VIOLATION);
-            }
+            let slot_value = old_tls_slots
+                .read_at_offset(index)
+                .ok_or(NtStatus::ACCESS_VIOLATION)?;
+            new_tls_slots
+                .write_at_offset(index, slot_value)
+                .ok_or(NtStatus::ACCESS_VIOLATION)?;
         }
 
         Ok(())
@@ -714,18 +714,6 @@ mod tests {
 
     type TestPlatform = crate::tests::TestPlatform;
 
-    #[repr(C)]
-    struct ProcessTlsSimpleRequest {
-        header: ProcessTlsInformationHeader,
-        entry: ProcessTlsThreadDataSimple,
-    }
-
-    #[repr(C)]
-    struct ProcessTlsTwoEntryRequest {
-        header: ProcessTlsInformationHeader,
-        entries: [ProcessTlsThreadDataSimple; 2],
-    }
-
     fn run_with_test_platform_pointers<R>(f: impl FnOnce() -> R) -> R {
         let _ = crate::tests::test_platform();
         <TestPlatform as ThreadProvider>::run_test_thread(f)
@@ -733,10 +721,6 @@ mod tests {
 
     fn const_byte_ptr<T>(value: &T) -> ConstPtr<TestPlatform, u8> {
         ConstPtr::<TestPlatform, u8>::from_usize(core::ptr::from_ref(value).cast::<u8>() as usize)
-    }
-
-    fn const_byte_mut_ptr<T>(value: &mut T) -> ConstPtr<TestPlatform, u8> {
-        ConstPtr::<TestPlatform, u8>::from_usize(core::ptr::from_mut(value).cast::<u8>() as usize)
     }
 
     #[test]
@@ -873,169 +857,6 @@ mod tests {
                 ),
                 NtStatus::SUCCESS
             );
-        });
-    }
-
-    #[test]
-    fn nt_set_information_process_tls_replace_vector_updates_teb_and_guest_output() {
-        run_with_test_platform_pointers(|| {
-            let mut task = crate::tests::test_task();
-            let mut teb = <ThreadEnvironmentBlock as zerocopy::FromZeros>::new_zeroed();
-            teb.tls_slots[7] = 0xaaaa;
-            teb.thread_local_storage_pointer = teb.tls_slots.as_mut_ptr() as usize;
-            task.teb_address = core::ptr::from_mut(&mut teb) as usize;
-
-            let mut new_tls_vector = [0usize; TEB_TLS_SLOT_COUNT];
-            let mut request = ProcessTlsSimpleRequest {
-                header: ProcessTlsInformationHeader {
-                    flags: 0,
-                    operation_type: ProcessTlsOperation::ReplaceVector as u32,
-                    thread_data_count: 1,
-                    tls_index: 0,
-                },
-                entry: ProcessTlsThreadDataSimple {
-                    flags: 0,
-                    _padding0: 0,
-                    tls_data: new_tls_vector.as_mut_ptr() as usize,
-                    _reserved: 0,
-                },
-            };
-
-            assert_eq!(
-                task.sys_nt_set_information_process(
-                    ProcessHandle::CURRENT,
-                    ProcessInformationClass::TlsInformation as u32,
-                    const_byte_mut_ptr(&mut request),
-                    size_of::<ProcessTlsSimpleRequest>().trunc(),
-                ),
-                NtStatus::SUCCESS
-            );
-
-            assert_eq!(
-                teb.thread_local_storage_pointer,
-                new_tls_vector.as_mut_ptr() as usize
-            );
-            assert_eq!(new_tls_vector[7], 0xaaaa);
-            assert_eq!(request.entry.tls_data, 0);
-            assert_eq!(
-                ProcessTlsThreadDataFlags::from_bits_retain(request.entry.flags),
-                ProcessTlsThreadDataFlags::OLD_DATA_WRITTEN
-            );
-        });
-    }
-
-    #[test]
-    fn nt_set_information_process_tls_replace_index_swaps_guest_slot() {
-        run_with_test_platform_pointers(|| {
-            let mut task = crate::tests::test_task();
-            let mut teb = <ThreadEnvironmentBlock as zerocopy::FromZeros>::new_zeroed();
-            let mut tls_vector = [0usize; TEB_TLS_SLOT_COUNT];
-            tls_vector[7] = 0x1111;
-            teb.thread_local_storage_pointer = tls_vector.as_mut_ptr() as usize;
-            task.teb_address = core::ptr::from_mut(&mut teb) as usize;
-
-            let mut request = ProcessTlsSimpleRequest {
-                header: ProcessTlsInformationHeader {
-                    flags: 0,
-                    operation_type: ProcessTlsOperation::ReplaceIndex as u32,
-                    thread_data_count: 1,
-                    tls_index: 7,
-                },
-                entry: ProcessTlsThreadDataSimple {
-                    flags: 0,
-                    _padding0: 0,
-                    tls_data: 0x2222,
-                    _reserved: 0,
-                },
-            };
-
-            assert_eq!(
-                task.sys_nt_set_information_process(
-                    ProcessHandle::CURRENT,
-                    ProcessInformationClass::TlsInformation as u32,
-                    const_byte_mut_ptr(&mut request),
-                    size_of::<ProcessTlsSimpleRequest>().trunc(),
-                ),
-                NtStatus::SUCCESS
-            );
-            assert_eq!(tls_vector[7], 0x2222);
-            assert_eq!(request.entry.tls_data, 0x1111);
-            assert_eq!(
-                ProcessTlsThreadDataFlags::from_bits_retain(request.entry.flags),
-                ProcessTlsThreadDataFlags::OLD_DATA_WRITTEN
-            );
-
-            request.header.tls_index = TEB_TLS_SLOT_COUNT.trunc();
-            assert_eq!(
-                task.sys_nt_set_information_process(
-                    ProcessHandle::CURRENT,
-                    ProcessInformationClass::TlsInformation as u32,
-                    const_byte_mut_ptr(&mut request),
-                    size_of::<ProcessTlsSimpleRequest>().trunc(),
-                ),
-                NtStatus::INVALID_PARAMETER
-            );
-        });
-    }
-
-    #[test]
-    fn nt_set_information_process_tls_rejects_multi_thread_entries_without_mutating_teb() {
-        run_with_test_platform_pointers(|| {
-            let mut task = crate::tests::test_task();
-            let mut teb = <ThreadEnvironmentBlock as zerocopy::FromZeros>::new_zeroed();
-            let mut tls_vector = [0usize; TEB_TLS_SLOT_COUNT];
-            tls_vector[7] = 0x1111;
-            teb.thread_local_storage_pointer = tls_vector.as_mut_ptr() as usize;
-            task.teb_address = core::ptr::from_mut(&mut teb) as usize;
-
-            let entry = ProcessTlsThreadDataSimple {
-                flags: 0,
-                _padding0: 0,
-                tls_data: 0x2222,
-                _reserved: 0,
-            };
-            let mut request = ProcessTlsTwoEntryRequest {
-                header: ProcessTlsInformationHeader {
-                    flags: 0,
-                    operation_type: ProcessTlsOperation::ReplaceIndex as u32,
-                    thread_data_count: 2,
-                    tls_index: 7,
-                },
-                entries: [entry, entry],
-            };
-
-            assert_eq!(
-                task.sys_nt_set_information_process(
-                    ProcessHandle::CURRENT,
-                    ProcessInformationClass::TlsInformation as u32,
-                    const_byte_mut_ptr(&mut request),
-                    size_of::<ProcessTlsTwoEntryRequest>().trunc(),
-                ),
-                NtStatus::NOT_SUPPORTED
-            );
-            assert_eq!(tls_vector[7], 0x1111);
-            assert_eq!(request.entries[0].tls_data, 0x2222);
-            assert_eq!(request.entries[1].tls_data, 0x2222);
-            assert_eq!(request.entries[0].flags, 0);
-            assert_eq!(request.entries[1].flags, 0);
-
-            request.header.operation_type = ProcessTlsOperation::ReplaceVector as u32;
-            let original_tls_pointer = teb.thread_local_storage_pointer;
-            let mut replacement_vector = [0usize; TEB_TLS_SLOT_COUNT];
-            request.entries[0].tls_data = replacement_vector.as_mut_ptr() as usize;
-            request.entries[1].tls_data = replacement_vector.as_mut_ptr() as usize;
-
-            assert_eq!(
-                task.sys_nt_set_information_process(
-                    ProcessHandle::CURRENT,
-                    ProcessInformationClass::TlsInformation as u32,
-                    const_byte_mut_ptr(&mut request),
-                    size_of::<ProcessTlsTwoEntryRequest>().trunc(),
-                ),
-                NtStatus::NOT_SUPPORTED
-            );
-            assert_eq!(teb.thread_local_storage_pointer, original_tls_pointer);
-            assert_eq!(replacement_vector[7], 0);
         });
     }
 

--- a/litebox_shim_windows/src/syscalls/process.rs
+++ b/litebox_shim_windows/src/syscalls/process.rs
@@ -4,7 +4,7 @@
 use core::mem::{offset_of, size_of};
 use core::sync::atomic::Ordering;
 use int_enum::IntEnum;
-use litebox::platform::{RawConstPointer as _, RawMutPointer as _};
+use litebox::platform::{RawConstPointer as _, RawMutPointer as _, RawPointerProvider};
 use litebox::utils::TruncateExt;
 use litebox_common_windows::nt_status::NtStatus;
 use zerocopy::{FromBytes, Immutable, IntoBytes};
@@ -112,6 +112,56 @@ struct ProcessTlsThreadDataExtended {
     _reserved: usize,
 }
 
+enum ProcessTlsThreadData<Platform: RawPointerProvider> {
+    Simple(MutPtr<Platform, ProcessTlsThreadDataSimple>),
+    Extended(MutPtr<Platform, ProcessTlsThreadDataExtended>),
+}
+
+impl<Platform: RawPointerProvider> ProcessTlsThreadData<Platform> {
+    fn read_tls_data(&self) -> Option<usize> {
+        match self {
+            Self::Simple(ptr) => crate::read_field_at_offset::<Platform, _>(
+                ptr.as_usize(),
+                offset_of!(ProcessTlsThreadDataSimple, tls_data),
+            ),
+            Self::Extended(ptr) => crate::read_field_at_offset::<Platform, _>(
+                ptr.as_usize(),
+                offset_of!(ProcessTlsThreadDataExtended, new_tls_data),
+            ),
+        }
+    }
+
+    fn write_tls_data(&self, value: usize) -> Option<()> {
+        match self {
+            Self::Simple(ptr) => crate::write_field_at_offset::<Platform, _>(
+                ptr.as_usize(),
+                offset_of!(ProcessTlsThreadDataSimple, tls_data),
+                value,
+            ),
+            Self::Extended(ptr) => crate::write_field_at_offset::<Platform, _>(
+                ptr.as_usize(),
+                offset_of!(ProcessTlsThreadDataExtended, old_tls_data),
+                value,
+            ),
+        }
+    }
+
+    fn write_flags(&self, flags: ProcessTlsThreadDataFlags) -> Option<()> {
+        match self {
+            Self::Simple(ptr) => crate::write_field_at_offset::<Platform, _>(
+                ptr.as_usize(),
+                offset_of!(ProcessTlsThreadDataSimple, flags),
+                flags.bits(),
+            ),
+            Self::Extended(ptr) => crate::write_field_at_offset::<Platform, _>(
+                ptr.as_usize(),
+                offset_of!(ProcessTlsThreadDataExtended, flags),
+                flags.bits(),
+            ),
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug)]
 enum ProcessTlsLayout {
     Simple,
@@ -160,13 +210,6 @@ impl ProcessTlsLayout {
         }
     }
 
-    const fn new_data_offset(self) -> usize {
-        match self {
-            Self::Simple => offset_of!(ProcessTlsThreadDataSimple, tls_data),
-            Self::Extended => offset_of!(ProcessTlsThreadDataExtended, new_tls_data),
-        }
-    }
-
     const fn old_data_offset(self) -> usize {
         match self {
             Self::Simple => offset_of!(ProcessTlsThreadDataSimple, tls_data),
@@ -174,16 +217,31 @@ impl ProcessTlsLayout {
         }
     }
 
-    const fn flags_offset(self) -> usize {
+    fn thread_data<Platform: RawPointerProvider>(
+        self,
+        base: MutPtr<Platform, u8>,
+        index: usize,
+    ) -> Option<ProcessTlsThreadData<Platform>> {
         match self {
-            Self::Simple => offset_of!(ProcessTlsThreadDataSimple, flags),
-            Self::Extended => offset_of!(ProcessTlsThreadDataExtended, flags),
+            Self::Simple => {
+                let arr = MutPtr::<Platform, ProcessTlsThreadDataSimple>::from_usize(
+                    base.as_usize().checked_add(
+                        size_of::<ProcessTlsInformationHeader>()
+                            + index.checked_mul(size_of::<ProcessTlsThreadDataSimple>())?,
+                    )?,
+                );
+                Some(ProcessTlsThreadData::Simple(arr))
+            }
+            Self::Extended => {
+                let arr = MutPtr::<Platform, ProcessTlsThreadDataExtended>::from_usize(
+                    base.as_usize().checked_add(
+                        size_of::<ProcessTlsInformationExtendedHeader>()
+                            + index.checked_mul(size_of::<ProcessTlsThreadDataExtended>())?,
+                    )?,
+                );
+                Some(ProcessTlsThreadData::Extended(arr))
+            }
         }
-    }
-
-    fn thread_data_offset(self, index: usize) -> Option<usize> {
-        self.header_size()
-            .checked_add(index.checked_mul(self.entry_size())?)
     }
 }
 
@@ -275,7 +333,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         &self,
         process_handle: ProcessHandle,
         process_information_class: u32,
-        process_information: ConstPtr<Platform, u8>,
+        process_information: MutPtr<Platform, u8>,
         process_information_length: u32,
     ) -> NtStatus {
         let Ok(process_information_class) =
@@ -357,7 +415,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
 
     fn set_process_scheduler_shared_data(
         process_handle: ProcessHandle,
-        process_information: ConstPtr<Platform, u8>,
+        process_information: MutPtr<Platform, u8>,
         process_information_length: u32,
     ) -> NtStatus {
         if process_information_length
@@ -385,7 +443,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
     fn write_process_tls_information(
         &self,
         process_handle: ProcessHandle,
-        process_information: ConstPtr<Platform, u8>,
+        process_information: MutPtr<Platform, u8>,
         process_information_length: u32,
     ) -> NtStatus {
         if (process_information_length as usize) < size_of::<ProcessTlsInformationHeader>() {
@@ -426,18 +484,12 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         }
 
         match ProcessTlsOperation::try_from(header.operation_type) {
-            Ok(ProcessTlsOperation::ReplaceVector) => self.replace_tls_vector(
-                process_information,
-                process_information_length,
-                header,
-                layout,
-            ),
-            Ok(ProcessTlsOperation::ReplaceIndex) => self.replace_tls_index(
-                process_information,
-                process_information_length,
-                header,
-                layout,
-            ),
+            Ok(ProcessTlsOperation::ReplaceVector) => {
+                self.replace_tls_vector(process_information, header, layout)
+            }
+            Ok(ProcessTlsOperation::ReplaceIndex) => {
+                self.replace_tls_index(process_information, header, layout)
+            }
             Err(_) => {
                 litebox_util_log::debug!(
                     operation_type = header.operation_type,
@@ -452,27 +504,21 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
 
     fn replace_tls_vector(
         &self,
-        process_information: ConstPtr<Platform, u8>,
-        process_information_length: u32,
+        process_information: MutPtr<Platform, u8>,
         header: ProcessTlsInformationHeader,
         layout: ProcessTlsLayout,
     ) -> NtStatus {
         for index in 0..header.thread_data_count as usize {
-            let Some(thread_data_offset) = layout.thread_data_offset(index) else {
+            let Some(thread_data) = layout.thread_data::<Platform>(process_information, index)
+            else {
                 return NtStatus::INFO_LENGTH_MISMATCH;
             };
-            let Some(new_tls_data) = read_process_information_usize::<Platform>(
-                process_information,
-                thread_data_offset + layout.new_data_offset(),
-                process_information_length,
-            ) else {
+            let Some(new_tls_data) = thread_data.read_tls_data() else {
                 return NtStatus::ACCESS_VIOLATION;
             };
             // TODO(multi-thread-tls): read ith thread's tls
-            let Some(old_tls_data) = self.read_teb_usize(offset_of!(
-                ThreadEnvironmentBlock,
-                thread_local_storage_pointer
-            )) else {
+            let teb = MutPtr::<Platform, ThreadEnvironmentBlock>::from_usize(self.teb_address);
+            let Some(old_tls_data) = Self::read_teb_tls_pointer(teb) else {
                 return NtStatus::ACCESS_VIOLATION;
             };
 
@@ -488,30 +534,15 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             }
             let old_tls_data_for_guest = self.guest_visible_old_tls_vector(old_tls_data);
 
-            if write_process_information_usize::<Platform>(
-                process_information,
-                thread_data_offset + layout.old_data_offset(),
-                process_information_length,
-                old_tls_data_for_guest,
-            )
-            .is_none()
-                || self
-                    .write_teb_usize(
-                        offset_of!(ThreadEnvironmentBlock, thread_local_storage_pointer),
-                        new_tls_data,
-                    )
-                    .is_none()
+            if thread_data.write_tls_data(old_tls_data_for_guest).is_none()
+                || Self::write_teb_tls_pointer(teb, new_tls_data).is_none()
             {
                 return NtStatus::ACCESS_VIOLATION;
             }
             if old_tls_data_for_guest == 0
-                && write_process_information_u32::<Platform>(
-                    process_information,
-                    thread_data_offset + layout.flags_offset(),
-                    process_information_length,
-                    ProcessTlsThreadDataFlags::OLD_DATA_WRITTEN.bits(),
-                )
-                .is_none()
+                && thread_data
+                    .write_flags(ProcessTlsThreadDataFlags::OLD_DATA_WRITTEN)
+                    .is_none()
             {
                 return NtStatus::ACCESS_VIOLATION;
             }
@@ -522,8 +553,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
 
     fn replace_tls_index(
         &self,
-        process_information: ConstPtr<Platform, u8>,
-        process_information_length: u32,
+        process_information: MutPtr<Platform, u8>,
         header: ProcessTlsInformationHeader,
         layout: ProcessTlsLayout,
     ) -> NtStatus {
@@ -532,22 +562,17 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             return NtStatus::INVALID_PARAMETER;
         }
 
-        for index in 0..header.thread_data_count {
-            let Some(thread_data_offset) = layout.thread_data_offset(index as usize) else {
+        for index in 0..header.thread_data_count as usize {
+            let Some(thread_data) = layout.thread_data::<Platform>(process_information, index)
+            else {
                 return NtStatus::INFO_LENGTH_MISMATCH;
             };
-            let Some(new_tls_data) = read_process_information_usize::<Platform>(
-                process_information,
-                thread_data_offset + layout.new_data_offset(),
-                process_information_length,
-            ) else {
+            let Some(new_tls_data) = thread_data.read_tls_data() else {
                 return NtStatus::ACCESS_VIOLATION;
             };
             // TODO(multi-thread-tls): read ith thread's tls
-            let Some(tls_array) = self.read_teb_usize(offset_of!(
-                ThreadEnvironmentBlock,
-                thread_local_storage_pointer
-            )) else {
+            let teb = ConstPtr::<Platform, ThreadEnvironmentBlock>::from_usize(self.teb_address);
+            let Some(tls_array) = Self::read_teb_tls_pointer(teb) else {
                 return NtStatus::ACCESS_VIOLATION;
             };
             if tls_array == 0 {
@@ -567,23 +592,13 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                 "Replacing process TLS index"
             );
 
-            if write_process_information_usize::<Platform>(
-                process_information,
-                thread_data_offset + layout.old_data_offset(),
-                process_information_length,
-                old_tls_data,
-            )
-            .is_none()
+            if thread_data.write_tls_data(old_tls_data).is_none()
                 || tls_slots
                     .write_at_offset(tls_index.cast_signed(), new_tls_data)
                     .is_none()
-                || write_process_information_u32::<Platform>(
-                    process_information,
-                    thread_data_offset + layout.flags_offset(),
-                    process_information_length,
-                    ProcessTlsThreadDataFlags::OLD_DATA_WRITTEN.bits(),
-                )
-                .is_none()
+                || thread_data
+                    .write_flags(ProcessTlsThreadDataFlags::OLD_DATA_WRITTEN)
+                    .is_none()
             {
                 return NtStatus::ACCESS_VIOLATION;
             }
@@ -637,14 +652,24 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         Ok(())
     }
 
-    fn read_teb_usize(&self, offset: usize) -> Option<usize> {
-        let address = self.teb_address.checked_add(offset)?;
-        ConstPtr::<Platform, usize>::from_usize(address).read_at_offset(0)
+    fn read_teb_tls_pointer<Ptr: litebox::platform::RawConstPointer<ThreadEnvironmentBlock>>(
+        teb: Ptr,
+    ) -> Option<usize> {
+        crate::read_field_at_offset::<Platform, _>(
+            teb.as_usize(),
+            offset_of!(ThreadEnvironmentBlock, thread_local_storage_pointer),
+        )
     }
 
-    fn write_teb_usize(&self, offset: usize, value: usize) -> Option<()> {
-        let address = self.teb_address.checked_add(offset)?;
-        MutPtr::<Platform, usize>::from_usize(address).write_at_offset(0, value)
+    fn write_teb_tls_pointer(
+        teb: MutPtr<Platform, ThreadEnvironmentBlock>,
+        value: usize,
+    ) -> Option<()> {
+        crate::write_field_at_offset::<Platform, _>(
+            teb.as_usize(),
+            offset_of!(ThreadEnvironmentBlock, thread_local_storage_pointer),
+            value,
+        )
     }
 
     fn process_basic_information(&self) -> ProcessBasicInformation {
@@ -666,48 +691,10 @@ pub(crate) const fn default_process_cookie() -> u32 {
     PROCESS_COOKIE
 }
 
-fn read_process_information_usize<Platform: ShimPlatform>(
-    process_information: ConstPtr<Platform, u8>,
-    offset: usize,
-    process_information_length: u32,
-) -> Option<usize> {
-    if usize::try_from(process_information_length).ok()? < offset.checked_add(size_of::<usize>())? {
-        return None;
-    }
-    ConstPtr::<Platform, usize>::from_usize(process_information.as_usize().checked_add(offset)?)
-        .read_at_offset(0)
-}
-
-fn write_process_information_u32<Platform: ShimPlatform>(
-    process_information: ConstPtr<Platform, u8>,
-    offset: usize,
-    process_information_length: u32,
-    value: u32,
-) -> Option<()> {
-    if usize::try_from(process_information_length).ok()? < offset.checked_add(size_of::<u32>())? {
-        return None;
-    }
-    MutPtr::<Platform, u32>::from_usize(process_information.as_usize().checked_add(offset)?)
-        .write_at_offset(0, value)
-}
-
-fn write_process_information_usize<Platform: ShimPlatform>(
-    process_information: ConstPtr<Platform, u8>,
-    offset: usize,
-    process_information_length: u32,
-    value: usize,
-) -> Option<()> {
-    if usize::try_from(process_information_length).ok()? < offset.checked_add(size_of::<usize>())? {
-        return None;
-    }
-    MutPtr::<Platform, usize>::from_usize(process_information.as_usize().checked_add(offset)?)
-        .write_at_offset(0, value)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tests::{mut_byte_ptr, mut_ptr, null_const_ptr, null_mut_ptr};
+    use crate::tests::{mut_byte_ptr, mut_ptr, null_mut_ptr};
     use litebox::platform::ThreadProvider;
 
     const RETURN_LENGTH_SENTINEL: u32 = 0xaaaa_aaaa;
@@ -717,10 +704,6 @@ mod tests {
     fn run_with_test_platform_pointers<R>(f: impl FnOnce() -> R) -> R {
         let _ = crate::tests::test_platform();
         <TestPlatform as ThreadProvider>::run_test_thread(f)
-    }
-
-    fn const_byte_ptr<T>(value: &T) -> ConstPtr<TestPlatform, u8> {
-        ConstPtr::<TestPlatform, u8>::from_usize(core::ptr::from_ref(value).cast::<u8>() as usize)
     }
 
     #[test]
@@ -801,7 +784,7 @@ mod tests {
     fn nt_set_information_process_scheduler_shared_data_validates_arguments() {
         run_with_test_platform_pointers(|| {
             let task = crate::tests::test_task();
-            let information = ProcessSchedulerSharedDataSlotInformation {
+            let mut information = ProcessSchedulerSharedDataSlotInformation {
                 scheduler_shared_data_handle: 0,
             };
             let information_len: u32 =
@@ -812,7 +795,7 @@ mod tests {
                 task.sys_nt_set_information_process(
                     bad_handle,
                     ProcessInformationClass::SchedulerSharedData as u32,
-                    null_const_ptr::<u8>(),
+                    null_mut_ptr::<u8>(),
                     information_len - 1,
                 ),
                 NtStatus::INFO_LENGTH_MISMATCH
@@ -822,7 +805,7 @@ mod tests {
                 task.sys_nt_set_information_process(
                     bad_handle,
                     0xffff,
-                    const_byte_ptr(&information),
+                    mut_byte_ptr(&mut information),
                     information_len - 1,
                 ),
                 NtStatus::INVALID_INFO_CLASS
@@ -832,7 +815,7 @@ mod tests {
                 task.sys_nt_set_information_process(
                     bad_handle,
                     ProcessInformationClass::SchedulerSharedData as u32,
-                    null_const_ptr::<u8>(),
+                    null_mut_ptr::<u8>(),
                     information_len,
                 ),
                 NtStatus::INVALID_HANDLE
@@ -842,7 +825,7 @@ mod tests {
                 task.sys_nt_set_information_process(
                     ProcessHandle::CURRENT,
                     ProcessInformationClass::SchedulerSharedData as u32,
-                    null_const_ptr::<u8>(),
+                    null_mut_ptr::<u8>(),
                     information_len,
                 ),
                 NtStatus::ACCESS_VIOLATION
@@ -852,7 +835,7 @@ mod tests {
                 task.sys_nt_set_information_process(
                     ProcessHandle::CURRENT,
                     ProcessInformationClass::SchedulerSharedData as u32,
-                    const_byte_ptr(&information),
+                    mut_byte_ptr(&mut information),
                     information_len,
                 ),
                 NtStatus::SUCCESS
@@ -997,10 +980,10 @@ mod tests {
         #[test]
         fn nt_set_information_process_scheduler_shared_data_matches_host_statuses() {
             run_with_test_platform_pointers(|| {
-                let null_information = ProcessSchedulerSharedDataSlotInformation {
+                let mut null_information = ProcessSchedulerSharedDataSlotInformation {
                     scheduler_shared_data_handle: 0,
                 };
-                let bogus_information = ProcessSchedulerSharedDataSlotInformation {
+                let mut bogus_information = ProcessSchedulerSharedDataSlotInformation {
                     scheduler_shared_data_handle: 0x1234,
                 };
                 let information_len: u32 =
@@ -1033,7 +1016,7 @@ mod tests {
                             ProcessHandle::CURRENT,
                             scheduler_class,
                             core::ptr::from_ref(&null_information).cast::<c_void>(),
-                            const_byte_ptr(&null_information),
+                            mut_byte_ptr(&mut null_information),
                             information_len,
                         ),
                         (
@@ -1041,7 +1024,7 @@ mod tests {
                             ProcessHandle::CURRENT,
                             scheduler_class,
                             core::ptr::from_ref(&bogus_information).cast::<c_void>(),
-                            const_byte_ptr(&bogus_information),
+                            mut_byte_ptr(&mut bogus_information),
                             information_len,
                         ),
                         (
@@ -1049,7 +1032,7 @@ mod tests {
                             ProcessHandle::CURRENT,
                             scheduler_class,
                             core::ptr::from_ref(&null_information).cast::<c_void>(),
-                            const_byte_ptr(&null_information),
+                            mut_byte_ptr(&mut null_information),
                             information_len - 1,
                         ),
                         (
@@ -1057,7 +1040,7 @@ mod tests {
                             ProcessHandle::CURRENT,
                             scheduler_class,
                             core::ptr::null(),
-                            null_const_ptr::<u8>(),
+                            null_mut_ptr::<u8>(),
                             information_len,
                         ),
                         (
@@ -1065,7 +1048,7 @@ mod tests {
                             ProcessHandle::CURRENT,
                             bad_class,
                             core::ptr::from_ref(&null_information).cast::<c_void>(),
-                            const_byte_ptr(&null_information),
+                            mut_byte_ptr(&mut null_information),
                             information_len,
                         ),
                         (
@@ -1073,7 +1056,7 @@ mod tests {
                             ProcessHandle::from_raw(0x1234),
                             scheduler_class,
                             core::ptr::from_ref(&null_information).cast::<c_void>(),
-                            const_byte_ptr(&null_information),
+                            mut_byte_ptr(&mut null_information),
                             information_len,
                         ),
                         (
@@ -1081,7 +1064,7 @@ mod tests {
                             ProcessHandle::from_raw(0x1234),
                             scheduler_class,
                             core::ptr::null(),
-                            null_const_ptr::<u8>(),
+                            null_mut_ptr::<u8>(),
                             information_len - 1,
                         ),
                         (
@@ -1089,7 +1072,7 @@ mod tests {
                             ProcessHandle::from_raw(0x1234),
                             bad_class,
                             core::ptr::from_ref(&null_information).cast::<c_void>(),
-                            const_byte_ptr(&null_information),
+                            mut_byte_ptr(&mut null_information),
                             information_len - 1,
                         ),
                         (
@@ -1097,7 +1080,7 @@ mod tests {
                             ProcessHandle::from_raw(0x1234),
                             scheduler_class,
                             core::ptr::null(),
-                            null_const_ptr::<u8>(),
+                            null_mut_ptr::<u8>(),
                             information_len,
                         ),
                         (
@@ -1105,7 +1088,7 @@ mod tests {
                             ProcessHandle::CURRENT,
                             scheduler_class,
                             core::ptr::null(),
-                            null_const_ptr::<u8>(),
+                            null_mut_ptr::<u8>(),
                             information_len - 1,
                         ),
                         (
@@ -1113,7 +1096,7 @@ mod tests {
                             ProcessHandle::CURRENT,
                             bad_class,
                             core::ptr::from_ref(&null_information).cast::<c_void>(),
-                            const_byte_ptr(&null_information),
+                            mut_byte_ptr(&mut null_information),
                             information_len - 1,
                         ),
                     ] {

--- a/litebox_shim_windows/src/syscalls/process.rs
+++ b/litebox_shim_windows/src/syscalls/process.rs
@@ -86,16 +86,12 @@ struct ProcessTlsInformationHeader {
     tls_index: u32,
 }
 
-const _: () = assert!(size_of::<ProcessTlsInformationHeader>() == 0x10);
-
 #[repr(C)]
 #[derive(Clone, Copy, Debug, FromBytes, Immutable, IntoBytes)]
 struct ProcessTlsInformationExtendedHeader {
     header: ProcessTlsInformationHeader,
     _reserved: usize,
 }
-
-const _: () = assert!(size_of::<ProcessTlsInformationExtendedHeader>() == 0x18);
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, FromBytes, Immutable, IntoBytes)]
@@ -105,9 +101,6 @@ struct ProcessTlsThreadDataSimple {
     tls_data: usize,
     _reserved: usize,
 }
-
-const _: () = assert!(size_of::<ProcessTlsThreadDataSimple>() == 0x18);
-const _: () = assert!(offset_of!(ProcessTlsThreadDataSimple, tls_data) == 0x08);
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, FromBytes, Immutable, IntoBytes)]
@@ -119,10 +112,6 @@ struct ProcessTlsThreadDataExtended {
     _reserved: usize,
 }
 
-const _: () = assert!(size_of::<ProcessTlsThreadDataExtended>() == 0x20);
-const _: () = assert!(offset_of!(ProcessTlsThreadDataExtended, new_tls_data) == 0x08);
-const _: () = assert!(offset_of!(ProcessTlsThreadDataExtended, old_tls_data) == 0x10);
-
 #[derive(Clone, Copy, Debug)]
 enum ProcessTlsLayout {
     Simple,
@@ -131,8 +120,7 @@ enum ProcessTlsLayout {
 
 impl ProcessTlsLayout {
     fn detect(thread_data_count: u32, process_information_length: u32) -> Result<Self, NtStatus> {
-        let count =
-            usize::try_from(thread_data_count).map_err(|_| NtStatus::INFO_LENGTH_MISMATCH)?;
+        let count = thread_data_count as usize;
         let extended_len = size_of::<ProcessTlsInformationExtendedHeader>()
             .checked_add(
                 count
@@ -147,7 +135,7 @@ impl ProcessTlsLayout {
                     .ok_or(NtStatus::INFO_LENGTH_MISMATCH)?,
             )
             .ok_or(NtStatus::INFO_LENGTH_MISMATCH)?;
-        let provided_len = usize::try_from(process_information_length).unwrap_or(0);
+        let provided_len = process_information_length as usize;
 
         if provided_len >= extended_len {
             Ok(Self::Extended)
@@ -193,12 +181,9 @@ impl ProcessTlsLayout {
         }
     }
 
-    fn thread_data_offset(self, index: u32) -> Option<usize> {
-        self.header_size().checked_add(
-            usize::try_from(index)
-                .ok()?
-                .checked_mul(self.entry_size())?,
-        )
+    fn thread_data_offset(self, index: usize) -> Option<usize> {
+        self.header_size()
+            .checked_add(index.checked_mul(self.entry_size())?)
     }
 }
 
@@ -403,9 +388,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         process_information: ConstPtr<Platform, u8>,
         process_information_length: u32,
     ) -> NtStatus {
-        if usize::try_from(process_information_length).unwrap_or(0)
-            < size_of::<ProcessTlsInformationHeader>()
-        {
+        if (process_information_length as usize) < size_of::<ProcessTlsInformationHeader>() {
             return NtStatus::INFO_LENGTH_MISMATCH;
         }
         if !process_handle.is_current() {
@@ -467,7 +450,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         header: ProcessTlsInformationHeader,
         layout: ProcessTlsLayout,
     ) -> NtStatus {
-        for index in 0..header.thread_data_count {
+        for index in 0..header.thread_data_count as usize {
             let Some(thread_data_offset) = layout.thread_data_offset(index) else {
                 return NtStatus::INFO_LENGTH_MISMATCH;
             };
@@ -536,15 +519,13 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         header: ProcessTlsInformationHeader,
         layout: ProcessTlsLayout,
     ) -> NtStatus {
-        let Ok(tls_index) = usize::try_from(header.tls_index) else {
-            return NtStatus::INVALID_PARAMETER;
-        };
+        let tls_index = header.tls_index as usize;
         if tls_index >= TEB_TLS_SLOT_COUNT {
             return NtStatus::INVALID_PARAMETER;
         }
 
         for index in 0..header.thread_data_count {
-            let Some(thread_data_offset) = layout.thread_data_offset(index) else {
+            let Some(thread_data_offset) = layout.thread_data_offset(index as usize) else {
                 return NtStatus::INFO_LENGTH_MISMATCH;
             };
             let Some(new_tls_data) = read_process_information_usize::<Platform>(
@@ -635,18 +616,13 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         if old_tls_data != initial_tls_slots {
             return Ok(());
         }
-
-        for index in 0..TEB_TLS_SLOT_COUNT {
-            let offset = index * size_of::<usize>();
-            let Some(slot_value) =
-                ConstPtr::<Platform, usize>::from_usize(old_tls_data + offset).read_at_offset(0)
-            else {
+        let old_tls_slots = ConstPtr::<Platform, usize>::from_usize(old_tls_data);
+        let new_tls_slots = MutPtr::<Platform, usize>::from_usize(new_tls_data);
+        for index in 0..TEB_TLS_SLOT_COUNT.cast_signed() {
+            let Some(slot_value) = old_tls_slots.read_at_offset(index) else {
                 return Err(NtStatus::ACCESS_VIOLATION);
             };
-            if MutPtr::<Platform, usize>::from_usize(new_tls_data + offset)
-                .write_at_offset(0, slot_value)
-                .is_none()
-            {
+            if new_tls_slots.write_at_offset(index, slot_value).is_none() {
                 return Err(NtStatus::ACCESS_VIOLATION);
             }
         }

--- a/litebox_shim_windows/src/syscalls/process.rs
+++ b/litebox_shim_windows/src/syscalls/process.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+use core::mem::{offset_of, size_of};
 use core::sync::atomic::Ordering;
 use int_enum::IntEnum;
 use litebox::platform::{RawConstPointer as _, RawMutPointer as _};
@@ -8,6 +9,7 @@ use litebox::utils::TruncateExt;
 use litebox_common_windows::nt_status::NtStatus;
 use zerocopy::{FromBytes, Immutable, IntoBytes};
 
+use crate::nt_types::ThreadEnvironmentBlock;
 use crate::syscalls::ProcessHandle;
 use crate::{ConstPtr, MutPtr, ShimFS, ShimPlatform, Task};
 
@@ -19,6 +21,7 @@ const GUEST_PARENT_PROCESS_ID: usize = 0;
 const GUEST_PROCESS_AFFINITY_MASK: usize = 1;
 const PROCESS_DEBUG_FLAGS_NO_DEBUGGER: u32 = 1;
 const PROCESS_COOKIE: u32 = 0xdead_beef;
+const TEB_TLS_SLOT_COUNT: usize = 64;
 
 #[repr(u32)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, IntEnum)]
@@ -33,6 +36,13 @@ enum ProcessInformationClass {
     ConsoleHostProcess = 49,
     ImageInformation = 53,
     SchedulerSharedData = 112,
+}
+
+#[repr(u32)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, IntEnum)]
+enum ProcessTlsOperation {
+    ReplaceIndex = 0,
+    ReplaceVector = 1,
 }
 
 #[repr(C)]
@@ -58,6 +68,131 @@ struct ProcessDefaultHardErrorMode {
 #[derive(Clone, Copy, Debug, FromBytes, Immutable)]
 struct ProcessSchedulerSharedDataSlotInformation {
     scheduler_shared_data_handle: usize,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, FromBytes, Immutable, IntoBytes)]
+struct ProcessTlsInformationHeader {
+    flags: u32,
+    operation_type: u32,
+    thread_data_count: u32,
+    tls_index: u32,
+}
+
+const _: () = assert!(size_of::<ProcessTlsInformationHeader>() == 0x10);
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, FromBytes, Immutable, IntoBytes)]
+struct ProcessTlsInformationExtendedHeader {
+    header: ProcessTlsInformationHeader,
+    _reserved: usize,
+}
+
+const _: () = assert!(size_of::<ProcessTlsInformationExtendedHeader>() == 0x18);
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, FromBytes, Immutable, IntoBytes)]
+struct ProcessTlsThreadDataSimple {
+    flags: u32,
+    _padding0: u32,
+    tls_data: usize,
+    _reserved: usize,
+}
+
+const _: () = assert!(size_of::<ProcessTlsThreadDataSimple>() == 0x18);
+const _: () = assert!(offset_of!(ProcessTlsThreadDataSimple, tls_data) == 0x08);
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, FromBytes, Immutable, IntoBytes)]
+struct ProcessTlsThreadDataExtended {
+    flags: u32,
+    _padding0: u32,
+    new_tls_data: usize,
+    old_tls_data: usize,
+    _reserved: usize,
+}
+
+const _: () = assert!(size_of::<ProcessTlsThreadDataExtended>() == 0x20);
+const _: () = assert!(offset_of!(ProcessTlsThreadDataExtended, new_tls_data) == 0x08);
+const _: () = assert!(offset_of!(ProcessTlsThreadDataExtended, old_tls_data) == 0x10);
+
+#[derive(Clone, Copy, Debug)]
+enum ProcessTlsLayout {
+    Simple,
+    Extended,
+}
+
+impl ProcessTlsLayout {
+    fn detect(thread_data_count: u32, process_information_length: u32) -> Result<Self, NtStatus> {
+        let count =
+            usize::try_from(thread_data_count).map_err(|_| NtStatus::INFO_LENGTH_MISMATCH)?;
+        let extended_len = size_of::<ProcessTlsInformationExtendedHeader>()
+            .checked_add(
+                count
+                    .checked_mul(size_of::<ProcessTlsThreadDataExtended>())
+                    .ok_or(NtStatus::INFO_LENGTH_MISMATCH)?,
+            )
+            .ok_or(NtStatus::INFO_LENGTH_MISMATCH)?;
+        let simple_len = size_of::<ProcessTlsInformationHeader>()
+            .checked_add(
+                count
+                    .checked_mul(size_of::<ProcessTlsThreadDataSimple>())
+                    .ok_or(NtStatus::INFO_LENGTH_MISMATCH)?,
+            )
+            .ok_or(NtStatus::INFO_LENGTH_MISMATCH)?;
+        let provided_len = usize::try_from(process_information_length).unwrap_or(0);
+
+        if provided_len >= extended_len {
+            Ok(Self::Extended)
+        } else if provided_len >= simple_len {
+            Ok(Self::Simple)
+        } else {
+            Err(NtStatus::INFO_LENGTH_MISMATCH)
+        }
+    }
+
+    const fn header_size(self) -> usize {
+        match self {
+            Self::Simple => size_of::<ProcessTlsInformationHeader>(),
+            Self::Extended => size_of::<ProcessTlsInformationExtendedHeader>(),
+        }
+    }
+
+    const fn entry_size(self) -> usize {
+        match self {
+            Self::Simple => size_of::<ProcessTlsThreadDataSimple>(),
+            Self::Extended => size_of::<ProcessTlsThreadDataExtended>(),
+        }
+    }
+
+    const fn new_data_offset(self) -> usize {
+        match self {
+            Self::Simple => offset_of!(ProcessTlsThreadDataSimple, tls_data),
+            Self::Extended => offset_of!(ProcessTlsThreadDataExtended, new_tls_data),
+        }
+    }
+
+    const fn old_data_offset(self) -> usize {
+        match self {
+            Self::Simple => offset_of!(ProcessTlsThreadDataSimple, tls_data),
+            Self::Extended => offset_of!(ProcessTlsThreadDataExtended, old_tls_data),
+        }
+    }
+
+    const fn flags_offset(self) -> usize {
+        match self {
+            Self::Simple => offset_of!(ProcessTlsThreadDataSimple, flags),
+            Self::Extended => offset_of!(ProcessTlsThreadDataExtended, flags),
+        }
+    }
+
+    fn thread_data_offset(self, index: u32) -> Option<usize> {
+        self.header_size().checked_add(
+            usize::try_from(index)
+                .ok()?
+                .checked_mul(self.entry_size())?,
+        )
+    }
 }
 
 impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
@@ -145,6 +280,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
     }
 
     pub(crate) fn sys_nt_set_information_process(
+        &self,
         process_handle: ProcessHandle,
         process_information_class: u32,
         process_information: ConstPtr<Platform, u8>,
@@ -168,6 +304,11 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                     process_information_length,
                 )
             }
+            ProcessInformationClass::TlsInformation => self.write_process_tls_information(
+                process_handle,
+                process_information,
+                process_information_length,
+            ),
             // TODO: implement additional settable process information classes when a guest
             // exercises them.
             ProcessInformationClass::BasicInformation
@@ -175,7 +316,6 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             | ProcessInformationClass::DefaultHardErrorMode
             | ProcessInformationClass::Wow64Information
             | ProcessInformationClass::DebugFlags
-            | ProcessInformationClass::TlsInformation
             | ProcessInformationClass::Cookie
             | ProcessInformationClass::ConsoleHostProcess
             | ProcessInformationClass::ImageInformation => {
@@ -250,6 +390,273 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         NtStatus::SUCCESS
     }
 
+    fn write_process_tls_information(
+        &self,
+        process_handle: ProcessHandle,
+        process_information: ConstPtr<Platform, u8>,
+        process_information_length: u32,
+    ) -> NtStatus {
+        if usize::try_from(process_information_length).unwrap_or(0)
+            < size_of::<ProcessTlsInformationHeader>()
+        {
+            return NtStatus::INFO_LENGTH_MISMATCH;
+        }
+        if !process_handle.is_current() {
+            return NtStatus::INVALID_HANDLE;
+        }
+
+        let Some(header) = ConstPtr::<Platform, ProcessTlsInformationHeader>::from_usize(
+            process_information.as_usize(),
+        )
+        .read_at_offset(0) else {
+            return NtStatus::ACCESS_VIOLATION;
+        };
+        let layout =
+            match ProcessTlsLayout::detect(header.thread_data_count, process_information_length) {
+                Ok(layout) => layout,
+                Err(status) => return status,
+            };
+
+        litebox_util_log::debug!(
+            operation_type = header.operation_type,
+            thread_data_count = header.thread_data_count,
+            tls_index = header.tls_index,
+            process_information_length,
+            layout_header_size = layout.header_size(),
+            layout_entry_size = layout.entry_size(),
+            layout_old_data_offset = layout.old_data_offset();
+            "Handling ProcessTlsInformation"
+        );
+
+        match ProcessTlsOperation::try_from(header.operation_type) {
+            Ok(ProcessTlsOperation::ReplaceVector) => self.replace_tls_vector(
+                process_information,
+                process_information_length,
+                header,
+                layout,
+            ),
+            Ok(ProcessTlsOperation::ReplaceIndex) => self.replace_tls_index(
+                process_information,
+                process_information_length,
+                header,
+                layout,
+            ),
+            Err(_) => {
+                litebox_util_log::debug!(
+                    operation_type = header.operation_type,
+                    thread_data_count = header.thread_data_count,
+                    tls_index = header.tls_index;
+                    "Unsupported ProcessTlsInformation operation"
+                );
+                NtStatus::INVALID_INFO_CLASS
+            }
+        }
+    }
+
+    fn replace_tls_vector(
+        &self,
+        process_information: ConstPtr<Platform, u8>,
+        process_information_length: u32,
+        header: ProcessTlsInformationHeader,
+        layout: ProcessTlsLayout,
+    ) -> NtStatus {
+        for index in 0..header.thread_data_count {
+            let Some(thread_data_offset) = layout.thread_data_offset(index) else {
+                return NtStatus::INFO_LENGTH_MISMATCH;
+            };
+            let Some(new_tls_data) = read_process_information_usize::<Platform>(
+                process_information,
+                thread_data_offset + layout.new_data_offset(),
+                process_information_length,
+            ) else {
+                return NtStatus::ACCESS_VIOLATION;
+            };
+            let Some(old_tls_data) = self.read_teb_usize(offset_of!(
+                ThreadEnvironmentBlock,
+                thread_local_storage_pointer
+            )) else {
+                return NtStatus::ACCESS_VIOLATION;
+            };
+
+            litebox_util_log::debug!(
+                thread_data_index = index,
+                new_tls_data:% = format_args!("{new_tls_data:#x}"),
+                old_tls_data:% = format_args!("{old_tls_data:#x}");
+                "Replacing process TLS vector"
+            );
+
+            if let Err(status) = self.copy_initial_tls_slots(old_tls_data, new_tls_data) {
+                return status;
+            }
+            let old_tls_data_for_guest = self.guest_visible_old_tls_vector(old_tls_data);
+
+            if write_process_information_usize::<Platform>(
+                process_information,
+                thread_data_offset + layout.old_data_offset(),
+                process_information_length,
+                old_tls_data_for_guest,
+            )
+            .is_none()
+                || self
+                    .write_teb_usize(
+                        offset_of!(ThreadEnvironmentBlock, thread_local_storage_pointer),
+                        new_tls_data,
+                    )
+                    .is_none()
+            {
+                return NtStatus::ACCESS_VIOLATION;
+            }
+            if old_tls_data_for_guest == 0
+                && write_process_information_u32::<Platform>(
+                    process_information,
+                    thread_data_offset + layout.flags_offset(),
+                    process_information_length,
+                    0x2,
+                )
+                .is_none()
+            {
+                return NtStatus::ACCESS_VIOLATION;
+            }
+        }
+
+        NtStatus::SUCCESS
+    }
+
+    fn replace_tls_index(
+        &self,
+        process_information: ConstPtr<Platform, u8>,
+        process_information_length: u32,
+        header: ProcessTlsInformationHeader,
+        layout: ProcessTlsLayout,
+    ) -> NtStatus {
+        let Ok(tls_index) = usize::try_from(header.tls_index) else {
+            return NtStatus::INVALID_PARAMETER;
+        };
+        if tls_index >= TEB_TLS_SLOT_COUNT {
+            return NtStatus::INVALID_PARAMETER;
+        }
+
+        for index in 0..header.thread_data_count {
+            let Some(thread_data_offset) = layout.thread_data_offset(index) else {
+                return NtStatus::INFO_LENGTH_MISMATCH;
+            };
+            let Some(new_tls_data) = read_process_information_usize::<Platform>(
+                process_information,
+                thread_data_offset + layout.new_data_offset(),
+                process_information_length,
+            ) else {
+                return NtStatus::ACCESS_VIOLATION;
+            };
+            let Some(tls_array) = self.read_teb_usize(offset_of!(
+                ThreadEnvironmentBlock,
+                thread_local_storage_pointer
+            )) else {
+                return NtStatus::ACCESS_VIOLATION;
+            };
+            if tls_array == 0 {
+                continue;
+            }
+            let Some(slot_address) = tls_array.checked_add(tls_index * size_of::<usize>()) else {
+                return NtStatus::INVALID_PARAMETER;
+            };
+            let slot = MutPtr::<Platform, usize>::from_usize(slot_address);
+            let Some(old_tls_data) = slot.read_at_offset(0) else {
+                return NtStatus::ACCESS_VIOLATION;
+            };
+
+            litebox_util_log::debug!(
+                thread_data_index = index,
+                tls_index,
+                tls_array:% = format_args!("{tls_array:#x}"),
+                slot_address:% = format_args!("{slot_address:#x}"),
+                new_tls_data:% = format_args!("{new_tls_data:#x}"),
+                old_tls_data:% = format_args!("{old_tls_data:#x}");
+                "Replacing process TLS index"
+            );
+
+            if write_process_information_usize::<Platform>(
+                process_information,
+                thread_data_offset + layout.old_data_offset(),
+                process_information_length,
+                old_tls_data,
+            )
+            .is_none()
+                || slot.write_at_offset(0, new_tls_data).is_none()
+                || write_process_information_u32::<Platform>(
+                    process_information,
+                    thread_data_offset + layout.flags_offset(),
+                    process_information_length,
+                    0x2,
+                )
+                .is_none()
+            {
+                return NtStatus::ACCESS_VIOLATION;
+            }
+        }
+
+        NtStatus::SUCCESS
+    }
+
+    fn guest_visible_old_tls_vector(&self, old_tls_data: usize) -> usize {
+        if old_tls_data > 0x10010
+            && old_tls_data >= self.teb_address
+            && old_tls_data
+                < self
+                    .teb_address
+                    .saturating_add(size_of::<ThreadEnvironmentBlock>())
+        {
+            // The loader frees the returned old vector. The initial vector lives inside
+            // TEB.tls_slots, so report no heap-backed vector instead of exposing TEB memory.
+            0
+        } else {
+            old_tls_data
+        }
+    }
+
+    fn copy_initial_tls_slots(
+        &self,
+        old_tls_data: usize,
+        new_tls_data: usize,
+    ) -> Result<(), NtStatus> {
+        if old_tls_data <= 0x10010 || new_tls_data <= 0x10010 {
+            return Ok(());
+        }
+        let initial_tls_slots = self
+            .teb_address
+            .checked_add(offset_of!(ThreadEnvironmentBlock, tls_slots))
+            .ok_or(NtStatus::INVALID_PARAMETER)?;
+        if old_tls_data != initial_tls_slots {
+            return Ok(());
+        }
+
+        for index in 0..TEB_TLS_SLOT_COUNT {
+            let offset = index * size_of::<usize>();
+            let Some(slot_value) =
+                ConstPtr::<Platform, usize>::from_usize(old_tls_data + offset).read_at_offset(0)
+            else {
+                return Err(NtStatus::ACCESS_VIOLATION);
+            };
+            if MutPtr::<Platform, usize>::from_usize(new_tls_data + offset)
+                .write_at_offset(0, slot_value)
+                .is_none()
+            {
+                return Err(NtStatus::ACCESS_VIOLATION);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn read_teb_usize(&self, offset: usize) -> Option<usize> {
+        let address = self.teb_address.checked_add(offset)?;
+        ConstPtr::<Platform, usize>::from_usize(address).read_at_offset(0)
+    }
+
+    fn write_teb_usize(&self, offset: usize, value: usize) -> Option<()> {
+        let address = self.teb_address.checked_add(offset)?;
+        MutPtr::<Platform, usize>::from_usize(address).write_at_offset(0, value)
+    }
+
     fn process_basic_information(&self) -> ProcessBasicInformation {
         ProcessBasicInformation {
             exit_status: ACTIVE_PROCESS_EXIT_STATUS,
@@ -269,6 +676,44 @@ pub(crate) const fn default_process_cookie() -> u32 {
     PROCESS_COOKIE
 }
 
+fn read_process_information_usize<Platform: ShimPlatform>(
+    process_information: ConstPtr<Platform, u8>,
+    offset: usize,
+    process_information_length: u32,
+) -> Option<usize> {
+    if usize::try_from(process_information_length).ok()? < offset.checked_add(size_of::<usize>())? {
+        return None;
+    }
+    ConstPtr::<Platform, usize>::from_usize(process_information.as_usize().checked_add(offset)?)
+        .read_at_offset(0)
+}
+
+fn write_process_information_u32<Platform: ShimPlatform>(
+    process_information: ConstPtr<Platform, u8>,
+    offset: usize,
+    process_information_length: u32,
+    value: u32,
+) -> Option<()> {
+    if usize::try_from(process_information_length).ok()? < offset.checked_add(size_of::<u32>())? {
+        return None;
+    }
+    MutPtr::<Platform, u32>::from_usize(process_information.as_usize().checked_add(offset)?)
+        .write_at_offset(0, value)
+}
+
+fn write_process_information_usize<Platform: ShimPlatform>(
+    process_information: ConstPtr<Platform, u8>,
+    offset: usize,
+    process_information_length: u32,
+    value: usize,
+) -> Option<()> {
+    if usize::try_from(process_information_length).ok()? < offset.checked_add(size_of::<usize>())? {
+        return None;
+    }
+    MutPtr::<Platform, usize>::from_usize(process_information.as_usize().checked_add(offset)?)
+        .write_at_offset(0, value)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -278,7 +723,12 @@ mod tests {
     const RETURN_LENGTH_SENTINEL: u32 = 0xaaaa_aaaa;
 
     type TestPlatform = crate::tests::TestPlatform;
-    type TestTask = Task<TestPlatform, crate::tests::TestFS>;
+
+    #[repr(C)]
+    struct ProcessTlsSimpleRequest {
+        header: ProcessTlsInformationHeader,
+        entry: ProcessTlsThreadDataSimple,
+    }
 
     fn run_with_test_platform_pointers<R>(f: impl FnOnce() -> R) -> R {
         let _ = crate::tests::test_platform();
@@ -287,6 +737,10 @@ mod tests {
 
     fn const_byte_ptr<T>(value: &T) -> ConstPtr<TestPlatform, u8> {
         ConstPtr::<TestPlatform, u8>::from_usize(core::ptr::from_ref(value).cast::<u8>() as usize)
+    }
+
+    fn const_byte_mut_ptr<T>(value: &mut T) -> ConstPtr<TestPlatform, u8> {
+        ConstPtr::<TestPlatform, u8>::from_usize(core::ptr::from_mut(value).cast::<u8>() as usize)
     }
 
     #[test]
@@ -366,6 +820,7 @@ mod tests {
     #[test]
     fn nt_set_information_process_scheduler_shared_data_validates_arguments() {
         run_with_test_platform_pointers(|| {
+            let task = crate::tests::test_task();
             let information = ProcessSchedulerSharedDataSlotInformation {
                 scheduler_shared_data_handle: 0,
             };
@@ -374,7 +829,7 @@ mod tests {
             let bad_handle = ProcessHandle::from_raw(0x1234);
 
             assert_eq!(
-                TestTask::sys_nt_set_information_process(
+                task.sys_nt_set_information_process(
                     bad_handle,
                     ProcessInformationClass::SchedulerSharedData as u32,
                     null_const_ptr::<u8>(),
@@ -384,7 +839,7 @@ mod tests {
             );
 
             assert_eq!(
-                TestTask::sys_nt_set_information_process(
+                task.sys_nt_set_information_process(
                     bad_handle,
                     0xffff,
                     const_byte_ptr(&information),
@@ -394,7 +849,7 @@ mod tests {
             );
 
             assert_eq!(
-                TestTask::sys_nt_set_information_process(
+                task.sys_nt_set_information_process(
                     bad_handle,
                     ProcessInformationClass::SchedulerSharedData as u32,
                     null_const_ptr::<u8>(),
@@ -404,7 +859,7 @@ mod tests {
             );
 
             assert_eq!(
-                TestTask::sys_nt_set_information_process(
+                task.sys_nt_set_information_process(
                     ProcessHandle::CURRENT,
                     ProcessInformationClass::SchedulerSharedData as u32,
                     null_const_ptr::<u8>(),
@@ -414,13 +869,109 @@ mod tests {
             );
 
             assert_eq!(
-                TestTask::sys_nt_set_information_process(
+                task.sys_nt_set_information_process(
                     ProcessHandle::CURRENT,
                     ProcessInformationClass::SchedulerSharedData as u32,
                     const_byte_ptr(&information),
                     information_len,
                 ),
                 NtStatus::SUCCESS
+            );
+        });
+    }
+
+    #[test]
+    fn nt_set_information_process_tls_replace_vector_updates_teb_and_guest_output() {
+        run_with_test_platform_pointers(|| {
+            let mut task = crate::tests::test_task();
+            let mut teb = <ThreadEnvironmentBlock as zerocopy::FromZeros>::new_zeroed();
+            teb.tls_slots[7] = 0xaaaa;
+            teb.thread_local_storage_pointer = teb.tls_slots.as_mut_ptr() as usize;
+            task.teb_address = core::ptr::from_mut(&mut teb) as usize;
+
+            let mut new_tls_vector = [0usize; TEB_TLS_SLOT_COUNT];
+            let mut request = ProcessTlsSimpleRequest {
+                header: ProcessTlsInformationHeader {
+                    flags: 0,
+                    operation_type: ProcessTlsOperation::ReplaceVector as u32,
+                    thread_data_count: 1,
+                    tls_index: 0,
+                },
+                entry: ProcessTlsThreadDataSimple {
+                    flags: 0,
+                    _padding0: 0,
+                    tls_data: new_tls_vector.as_mut_ptr() as usize,
+                    _reserved: 0,
+                },
+            };
+
+            assert_eq!(
+                task.sys_nt_set_information_process(
+                    ProcessHandle::CURRENT,
+                    ProcessInformationClass::TlsInformation as u32,
+                    const_byte_mut_ptr(&mut request),
+                    size_of::<ProcessTlsSimpleRequest>().trunc(),
+                ),
+                NtStatus::SUCCESS
+            );
+
+            assert_eq!(
+                teb.thread_local_storage_pointer,
+                new_tls_vector.as_mut_ptr() as usize
+            );
+            assert_eq!(new_tls_vector[7], 0xaaaa);
+            assert_eq!(request.entry.tls_data, 0);
+            assert_eq!(request.entry.flags, 0x2);
+        });
+    }
+
+    #[test]
+    fn nt_set_information_process_tls_replace_index_swaps_guest_slot() {
+        run_with_test_platform_pointers(|| {
+            let mut task = crate::tests::test_task();
+            let mut teb = <ThreadEnvironmentBlock as zerocopy::FromZeros>::new_zeroed();
+            let mut tls_vector = [0usize; TEB_TLS_SLOT_COUNT];
+            tls_vector[7] = 0x1111;
+            teb.thread_local_storage_pointer = tls_vector.as_mut_ptr() as usize;
+            task.teb_address = core::ptr::from_mut(&mut teb) as usize;
+
+            let mut request = ProcessTlsSimpleRequest {
+                header: ProcessTlsInformationHeader {
+                    flags: 0,
+                    operation_type: ProcessTlsOperation::ReplaceIndex as u32,
+                    thread_data_count: 1,
+                    tls_index: 7,
+                },
+                entry: ProcessTlsThreadDataSimple {
+                    flags: 0,
+                    _padding0: 0,
+                    tls_data: 0x2222,
+                    _reserved: 0,
+                },
+            };
+
+            assert_eq!(
+                task.sys_nt_set_information_process(
+                    ProcessHandle::CURRENT,
+                    ProcessInformationClass::TlsInformation as u32,
+                    const_byte_mut_ptr(&mut request),
+                    size_of::<ProcessTlsSimpleRequest>().trunc(),
+                ),
+                NtStatus::SUCCESS
+            );
+            assert_eq!(tls_vector[7], 0x2222);
+            assert_eq!(request.entry.tls_data, 0x1111);
+            assert_eq!(request.entry.flags, 0x2);
+
+            request.header.tls_index = TEB_TLS_SLOT_COUNT.trunc();
+            assert_eq!(
+                task.sys_nt_set_information_process(
+                    ProcessHandle::CURRENT,
+                    ProcessInformationClass::TlsInformation as u32,
+                    const_byte_mut_ptr(&mut request),
+                    size_of::<ProcessTlsSimpleRequest>().trunc(),
+                ),
+                NtStatus::INVALID_PARAMETER
             );
         });
     }
@@ -688,7 +1239,8 @@ mod tests {
                             host_process_information,
                             process_information_length,
                         );
-                        let shim = TestTask::sys_nt_set_information_process(
+                        let task = crate::tests::test_task();
+                        let shim = task.sys_nt_set_information_process(
                             shim_process_handle,
                             process_information_class,
                             shim_process_information,

--- a/litebox_shim_windows/src/syscalls/process.rs
+++ b/litebox_shim_windows/src/syscalls/process.rs
@@ -45,6 +45,13 @@ enum ProcessTlsOperation {
     ReplaceVector = 1,
 }
 
+bitflags::bitflags! {
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    struct ProcessTlsThreadDataFlags: u32 {
+        const OLD_DATA_WRITTEN = 0x2;
+    }
+}
+
 #[repr(C)]
 #[derive(Clone, Copy, Debug, FromBytes, Immutable, IntoBytes)]
 struct ProcessBasicInformation {
@@ -511,7 +518,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                     process_information,
                     thread_data_offset + layout.flags_offset(),
                     process_information_length,
-                    0x2,
+                    ProcessTlsThreadDataFlags::OLD_DATA_WRITTEN.bits(),
                 )
                 .is_none()
             {
@@ -586,7 +593,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                     process_information,
                     thread_data_offset + layout.flags_offset(),
                     process_information_length,
-                    0x2,
+                    ProcessTlsThreadDataFlags::OLD_DATA_WRITTEN.bits(),
                 )
                 .is_none()
             {
@@ -921,7 +928,10 @@ mod tests {
             );
             assert_eq!(new_tls_vector[7], 0xaaaa);
             assert_eq!(request.entry.tls_data, 0);
-            assert_eq!(request.entry.flags, 0x2);
+            assert_eq!(
+                ProcessTlsThreadDataFlags::from_bits_retain(request.entry.flags),
+                ProcessTlsThreadDataFlags::OLD_DATA_WRITTEN
+            );
         });
     }
 
@@ -961,7 +971,10 @@ mod tests {
             );
             assert_eq!(tls_vector[7], 0x2222);
             assert_eq!(request.entry.tls_data, 0x1111);
-            assert_eq!(request.entry.flags, 0x2);
+            assert_eq!(
+                ProcessTlsThreadDataFlags::from_bits_retain(request.entry.flags),
+                ProcessTlsThreadDataFlags::OLD_DATA_WRITTEN
+            );
 
             request.header.tls_index = TEB_TLS_SLOT_COUNT.trunc();
             assert_eq!(


### PR DESCRIPTION
Fix `NtSetInformationProcess` to support setting TLS. For now, the Windows shim does not support multi-threading, so the implementation is not complete yet.