### PR TITLE
Make Linux eventfd broker-backed

### DIFF
--- a/litebox_runner_linux_userland/tests/eventfd.c
+++ b/litebox_runner_linux_userland/tests/eventfd.c
@@ -10,7 +10,15 @@
 #include <sys/epoll.h>
 #include <sys/eventfd.h>
 #include <sys/ioctl.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
 #include <unistd.h>
+
+#define SENDFILE_DST_PATH "/tmp/lb_eventfd_sendfile_dst"
+
+static ssize_t sys_sendfile(int out_fd, int in_fd, off_t *offset, size_t count) {
+    return (ssize_t)syscall(SYS_sendfile, out_fd, in_fd, offset, count);
+}
 
 static int expect_eagain_read(int fd) {
     uint64_t value = 0;
@@ -220,6 +228,34 @@ static int test_epoll_wakeup(void) {
         return 8;
     }
     return expect_close(fd) == 0 ? 0 : 9;
+}
+
+static int test_sendfile_in_fd(void) {
+    int fd = eventfd(7, 0);
+    if (fd < 0) {
+        return 1;
+    }
+    int dst = open(SENDFILE_DST_PATH, O_RDWR | O_CREAT | O_TRUNC, 0644);
+    if (dst < 0) {
+        return 2;
+    }
+
+    errno = 0;
+    if (sys_sendfile(dst, fd, NULL, 4) != -1 || errno != EINVAL) {
+        return 3;
+    }
+
+    off_t off = 0;
+    errno = 0;
+    if (sys_sendfile(dst, fd, &off, 4) != -1 || errno != ESPIPE) {
+        return 4;
+    }
+
+    if (expect_close(dst) != 0) {
+        return 5;
+    }
+    unlink(SENDFILE_DST_PATH);
+    return expect_close(fd) == 0 ? 0 : 6;
 }
 
 int main(void) {
@@ -463,6 +499,9 @@ int main(void) {
     }
     if (test_epoll_wakeup() != 0) {
         return 142;
+    }
+    if (test_sendfile_in_fd() != 0) {
+        return 143;
     }
 
     alarm(0);

--- a/litebox_runner_linux_userland/tests/eventfd.c
+++ b/litebox_runner_linux_userland/tests/eventfd.c
@@ -95,6 +95,14 @@ static int expect_nonblock(int fd, int expected) {
     return ((flags & O_NONBLOCK) != 0) == expected ? 0 : 2;
 }
 
+static int expect_cloexec(int fd, int expected) {
+    int flags = fcntl(fd, F_GETFD);
+    if (flags < 0) {
+        return 1;
+    }
+    return ((flags & FD_CLOEXEC) != 0) == expected ? 0 : 2;
+}
+
 static int expect_ebadf_close(int fd) {
     errno = 0;
     if (close(fd) != -1) {
@@ -256,6 +264,23 @@ static int test_sendfile_in_fd(void) {
     }
     unlink(SENDFILE_DST_PATH);
     return expect_close(fd) == 0 ? 0 : 6;
+}
+
+static int test_cloexec_flag(void) {
+    int fd = eventfd(0, EFD_CLOEXEC);
+    if (fd < 0) {
+        return 1;
+    }
+    if (expect_cloexec(fd, 1) != 0) {
+        return 2;
+    }
+    if (fcntl(fd, F_SETFD, 0) != 0) {
+        return 3;
+    }
+    if (expect_cloexec(fd, 0) != 0) {
+        return 4;
+    }
+    return expect_close(fd) == 0 ? 0 : 5;
 }
 
 int main(void) {
@@ -502,6 +527,9 @@ int main(void) {
     }
     if (test_sendfile_in_fd() != 0) {
         return 143;
+    }
+    if (test_cloexec_flag() != 0) {
+        return 144;
     }
 
     alarm(0);

--- a/litebox_runner_linux_userland/tests/execve.c
+++ b/litebox_runner_linux_userland/tests/execve.c
@@ -4,7 +4,7 @@
 // Test execve behavior:
 //
 // Phase 1:
-//   - Create two eventfds: one with EFD_CLOEXEC, one without.
+//   - Create two pipe descriptors: one with O_CLOEXEC, one without.
 //   - Exec self, passing their numeric values as argv[1] (cloexec) and argv[2] (keep).
 // Phase 2 (after exec):
 //   - Verify the CLOEXEC fd is closed (fcntl -> EBADF).
@@ -19,7 +19,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <sys/eventfd.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 
@@ -39,10 +38,12 @@ int main(int argc, char *argv[], char *envp[]) {
 
     if (!phase) {
         // Phase 1: set up descriptors and exec self.
-        int fd_clo = eventfd(0, EFD_CLOEXEC);
-        if (fd_clo < 0) die("eventfd cloexec");
-        int fd_keep = eventfd(0, 0);
-        if (fd_keep < 0) die("eventfd keep");
+        int clo_pipe[2];
+        if (pipe2(clo_pipe, O_CLOEXEC) != 0) die("pipe2 cloexec");
+        int keep_pipe[2];
+        if (pipe(keep_pipe) != 0) die("pipe keep");
+        int fd_clo = clo_pipe[0];
+        int fd_keep = keep_pipe[0];
 
         char clo_buf[32], keep_buf[32];
         snprintf(clo_buf, sizeof clo_buf, "%d", fd_clo);

--- a/litebox_runner_linux_userland/tests/run.rs
+++ b/litebox_runner_linux_userland/tests/run.rs
@@ -484,8 +484,8 @@ fn test_runner_broker_integration_with_rewriter() {
     Runner::new(&target, "broker_eventfd_rewriter")
         .broker_sockets(&control_socket_path, &notification_socket_path)
         .run();
-    // eventfd.c creates twelve eventfd objects; each should release one broker object.
-    assert_eq!(broker_thread.next_close_object_count(), 12);
+    // eventfd.c creates thirteen eventfd objects; each should release one broker object.
+    assert_eq!(broker_thread.next_close_object_count(), 13);
 
     broker_thread.join();
 }

--- a/litebox_runner_linux_userland/tests/run.rs
+++ b/litebox_runner_linux_userland/tests/run.rs
@@ -463,7 +463,15 @@ impl<Channel: litebox_broker_protocol::channel::HostControlChannel>
 #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
 #[test]
 fn test_runner_broker_integration_with_rewriter() {
+    const HELLO_WORLD_JS: &str = r"
+const fs = require('node:fs');
+
+const content = 'Hello World!';
+console.log(content);
+";
+
     let true_path = run_which("true");
+    let node_path = run_which("node");
     let target = common::compile("./tests/eventfd.c", "broker_eventfd_rewriter", false, false);
     let control_socket_path = unique_test_socket_path("runner-broker-control");
     let notification_socket_path = unique_test_socket_path("runner-broker-notification");
@@ -473,7 +481,7 @@ fn test_runner_broker_integration_with_rewriter() {
         litebox_broker_core::PolicyEngine::with_unauthenticated_rights(
             litebox_broker_core::PrincipalRights::all(),
         ),
-        2,
+        3,
     );
 
     Runner::new(&true_path, "broker_true_rewriter")
@@ -487,27 +495,16 @@ fn test_runner_broker_integration_with_rewriter() {
     // eventfd.c creates thirteen eventfd objects; each should release one broker object.
     assert_eq!(broker_thread.next_close_object_count(), 13);
 
-    broker_thread.join();
-}
-
-#[cfg(target_arch = "x86_64")]
-#[test]
-fn test_node_with_rewriter() {
-    const HELLO_WORLD_JS: &str = r"
-const fs = require('node:fs');
-
-const content = 'Hello World!';
-console.log(content);
-";
-
-    let node_path = run_which("node");
-    Runner::new(&node_path, "hello_node_rewriter")
+    Runner::new(&node_path, "hello_node_broker_rewriter")
+        .broker_sockets(&control_socket_path, &notification_socket_path)
         .arg("/out/hello_world.js")
         .with_fs_path(|out_dir| {
-            // write the test js file to the output directory
             std::fs::write(out_dir.join("out/hello_world.js"), HELLO_WORLD_JS).unwrap();
         })
         .run();
+    assert!(broker_thread.next_close_object_count() > 0);
+
+    broker_thread.join();
 }
 
 #[cfg(target_arch = "x86_64")]

--- a/litebox_runner_linux_userland/tests/run.rs
+++ b/litebox_runner_linux_userland/tests/run.rs
@@ -484,8 +484,8 @@ fn test_runner_broker_integration_with_rewriter() {
     Runner::new(&target, "broker_eventfd_rewriter")
         .broker_sockets(&control_socket_path, &notification_socket_path)
         .run();
-    // eventfd.c creates eleven eventfd objects; each should release one broker object.
-    assert_eq!(broker_thread.next_close_object_count(), 11);
+    // eventfd.c creates twelve eventfd objects; each should release one broker object.
+    assert_eq!(broker_thread.next_close_object_count(), 12);
 
     broker_thread.join();
 }

--- a/litebox_runner_linux_userland/tests/sendfile.c
+++ b/litebox_runner_linux_userland/tests/sendfile.c
@@ -5,7 +5,6 @@
 #include "helpers.h"
 
 #include <fcntl.h>
-#include <sys/eventfd.h>
 
 #define SRC_PATH "/tmp/lb_sendfile_src"
 #define DST_PATH "/tmp/lb_sendfile_dst"
@@ -340,13 +339,6 @@ static void test_pipe_in_fd(void) {
     close(pfd[1]);
 }
 
-static void test_eventfd_in_fd(void) {
-    int efd = eventfd(7, 0);
-    if (efd < 0) die("eventfd");
-    expect_einval_espipe_in_fd(efd, "eventfd in_fd");
-    close(efd);
-}
-
 static void test_unix_stream_in_fd(void) {
     int sv[2];
     if (socketpair(AF_UNIX, SOCK_STREAM, 0, sv) != 0) die("socketpair stream");
@@ -382,7 +374,6 @@ int main(void) {
     test_partial_nonblocking_pipe_error_is_deferred();
     test_file_to_pipe_with_offset();
     test_pipe_in_fd();
-    test_eventfd_in_fd();
     test_unix_stream_in_fd();
     test_unix_dgram_in_fd();
 

--- a/litebox_shim_linux/src/syscalls/epoll.rs
+++ b/litebox_shim_linux/src/syscalls/epoll.rs
@@ -617,7 +617,7 @@ mod test {
     use alloc::sync::Arc;
     use litebox::event::Events;
     use litebox::event::wait::WaitState;
-    use litebox_common_linux::{EfdFlags, EpollEvent};
+    use litebox_common_linux::EpollEvent;
     use litebox_platform_multiplex::platform;
 
     use super::EpollFile;
@@ -630,58 +630,6 @@ mod test {
 
         let epoll = EpollFile::new();
         (task, epoll)
-    }
-
-    #[test]
-    fn test_epoll_with_eventfd() {
-        let (task, epoll) = setup_epoll();
-        let eventfd = task
-            .global
-            .create_linux_eventfd(0, EfdFlags::CLOEXEC)
-            .unwrap();
-        let typed = task
-            .global
-            .litebox
-            .descriptor_table_mut()
-            .insert::<crate::syscalls::eventfd::EventfdSubsystem>(eventfd);
-        let files = Arc::new(FilesState::new(task.files.borrow().fs.clone()));
-        let Ok(raw_fd) = files.insert_raw_fd(typed) else {
-            unreachable!()
-        };
-        let descriptor = super::EpollDescriptor::try_from(&files, raw_fd).unwrap();
-        epoll
-            .add_interest(
-                &task.global,
-                10,
-                &descriptor,
-                EpollEvent {
-                    events: Events::IN.bits(),
-                    data: 0,
-                },
-            )
-            .unwrap();
-
-        let writer = {
-            let global = task.global.clone();
-            let files = Arc::clone(&files);
-            std::thread::spawn(move || {
-                let typed = files
-                    .raw_descriptor_store
-                    .read()
-                    .fd_from_raw_integer::<crate::syscalls::eventfd::EventfdSubsystem>(raw_fd)
-                    .unwrap();
-                let _ = global
-                    .litebox
-                    .descriptor_table()
-                    .with_entry(&typed, |entry| {
-                        entry.write(&WaitState::new(platform()).context(), 1)
-                    });
-            })
-        };
-        epoll
-            .wait(&task.global, &WaitState::new(platform()).context(), 1024)
-            .unwrap();
-        writer.join().unwrap();
     }
 
     #[test]
@@ -733,23 +681,14 @@ mod test {
         let task = crate::syscalls::tests::init_platform(None);
 
         let mut set = super::PollSet::with_capacity(0);
-        let eventfd = task
-            .global
-            .create_linux_eventfd(0, EfdFlags::empty())
-            .unwrap();
-
-        let typed = task
-            .global
-            .litebox
-            .descriptor_table_mut()
-            .insert::<crate::syscalls::eventfd::EventfdSubsystem>(eventfd);
+        let (rfd_u, wfd_u) = task
+            .sys_pipe2(litebox::fs::OFlags::empty())
+            .expect("pipe2 failed");
+        let rfd = i32::try_from(rfd_u).unwrap();
+        let wfd = i32::try_from(wfd_u).unwrap();
         let no_fds = FilesState::new(task.files.borrow().fs.clone());
-        let fds = Arc::new(FilesState::new(task.files.borrow().fs.clone()));
-        let Ok(raw_fd) = fds.insert_raw_fd(typed) else {
-            unreachable!()
-        };
-        let fd = i32::try_from(raw_fd).unwrap();
-        set.add_fd(fd, Events::IN);
+        let fds = task.files.borrow().clone();
+        set.add_fd(rfd, Events::IN);
 
         let revents = |set: &super::PollSet| {
             let revents: std::vec::Vec<_> = set.revents().collect();
@@ -761,36 +700,14 @@ mod test {
             .unwrap();
         assert_eq!(revents(&set), Events::NVAL);
 
-        {
-            let typed = fds
-                .raw_descriptor_store
-                .read()
-                .fd_from_raw_integer::<crate::syscalls::eventfd::EventfdSubsystem>(raw_fd)
-                .unwrap();
-            task.global
-                .litebox
-                .descriptor_table()
-                .with_entry(&typed, |entry| {
-                    entry.write(&WaitState::new(platform()).context(), 1)
-                });
-        }
+        task.sys_write(wfd, &[1], None).unwrap();
         set.wait(&task.global, &WaitState::new(platform()).context(), &fds)
             .unwrap();
         assert_eq!(revents(&set), Events::IN);
 
-        {
-            let typed = fds
-                .raw_descriptor_store
-                .read()
-                .fd_from_raw_integer::<crate::syscalls::eventfd::EventfdSubsystem>(raw_fd)
-                .unwrap();
-            task.global
-                .litebox
-                .descriptor_table()
-                .with_entry(&typed, |entry| {
-                    entry.read(&WaitState::new(platform()).context())
-                });
-        }
+        let mut buf = [0; 1];
+        assert_eq!(task.sys_read(rfd, &mut buf, None).unwrap(), 1);
+        assert_eq!(buf, [1]);
         set.wait(
             &task.global,
             &WaitState::new(platform())
@@ -801,27 +718,17 @@ mod test {
         .unwrap_err();
         assert!(revents(&set).is_empty());
 
-        // spawn a thread to write to the eventfd
-        let global = task.global.clone();
-        let fds_for_thread = Arc::clone(&fds);
-        std::thread::spawn(move || {
-            let typed = fds_for_thread
-                .raw_descriptor_store
-                .read()
-                .fd_from_raw_integer::<crate::syscalls::eventfd::EventfdSubsystem>(raw_fd)
-                .unwrap();
-            let handle = global
-                .litebox
-                .descriptor_table()
-                .entry_handle(&typed)
-                .unwrap();
-            let _ =
-                handle.with_entry(|entry| entry.write(&WaitState::new(platform()).context(), 1));
+        task.spawn_clone_for_test(move |task| {
+            std::thread::sleep(core::time::Duration::from_millis(100));
+            assert_eq!(task.sys_write(wfd, &[1], None).unwrap(), 1);
         });
 
         set.wait(&task.global, &WaitState::new(platform()).context(), &fds)
             .unwrap();
         assert_eq!(revents(&set), Events::IN);
+
+        let _ = task.sys_close(rfd);
+        let _ = task.sys_close(wfd);
     }
 
     #[test]

--- a/litebox_shim_linux/src/syscalls/eventfd.rs
+++ b/litebox_shim_linux/src/syscalls/eventfd.rs
@@ -8,15 +8,14 @@ use core::sync::atomic::AtomicU32;
 use litebox::{
     event::{
         Events, IOPollable,
-        counter::{EventCounter, EventCounterError, EventCounterReadMode},
+        counter::{EventCounter, EventCounterReadMode},
         observer::Observer,
-        polling::{Pollee, TryOpError},
         wait::WaitContext,
     },
     fd::{FdEnabledSubsystem, FdEnabledSubsystemEntry},
     fs::OFlags,
     platform::TimeProvider,
-    sync::{Mutex, RawSyncPrimitivesProvider},
+    sync::RawSyncPrimitivesProvider,
 };
 use litebox_common_linux::{EfdFlags, errno::Errno};
 
@@ -28,140 +27,15 @@ impl FdEnabledSubsystem for EventfdSubsystem {
 }
 impl FdEnabledSubsystemEntry for EventFile<Platform> {}
 
-/// Backing counter for a Linux eventfd file description.
-///
-enum EventFileCounter<Platform: RawSyncPrimitivesProvider + TimeProvider> {
-    ShimLocal {
-        count: Mutex<Platform, u64>,
-        pollee: Pollee<Platform>,
-    },
-    BrokerBacked(EventCounter<Platform>),
-}
-
 pub(crate) struct EventFile<Platform: RawSyncPrimitivesProvider + TimeProvider> {
-    counter: EventFileCounter<Platform>,
+    counter: EventCounter<Platform>,
     /// File status flags (see [`OFlags::STATUS_FLAGS_MASK`])
     status: AtomicU32,
     semaphore: bool,
 }
 
-impl<Platform: RawSyncPrimitivesProvider + TimeProvider> EventFileCounter<Platform> {
-    fn shim_local(count: u64) -> Self {
-        Self::ShimLocal {
-            count: Mutex::new(count),
-            pollee: Pollee::new(),
-        }
-    }
-
-    fn read(
-        &self,
-        cx: &WaitContext<'_, Platform>,
-        nonblock: bool,
-        semaphore: bool,
-    ) -> Result<u64, Errno> {
-        match self {
-            Self::ShimLocal { count, pollee } => pollee
-                .wait(cx, nonblock, Events::IN, || {
-                    Self::try_read_local(count, pollee, semaphore)
-                })
-                .map_err(Errno::from),
-            Self::BrokerBacked(counter) => counter
-                .read(
-                    cx,
-                    nonblock,
-                    if semaphore {
-                        EventCounterReadMode::One
-                    } else {
-                        EventCounterReadMode::All
-                    },
-                )
-                .map_err(Errno::from),
-        }
-    }
-
-    fn write(
-        &self,
-        cx: &WaitContext<'_, Platform>,
-        nonblock: bool,
-        value: u64,
-    ) -> Result<usize, Errno> {
-        match self {
-            Self::ShimLocal { count, pollee } => pollee
-                .wait(cx, nonblock, Events::OUT, || {
-                    Self::try_write_local(count, pollee, value)
-                })
-                .map_err(Errno::from),
-            Self::BrokerBacked(counter) => counter.write(cx, nonblock, value).map_err(Errno::from),
-        }
-    }
-
-    fn try_read_local(
-        count: &Mutex<Platform, u64>,
-        pollee: &Pollee<Platform>,
-        semaphore: bool,
-    ) -> Result<u64, TryOpError<Errno>> {
-        let mut count = count.lock();
-        if *count == 0 {
-            return Err(TryOpError::TryAgain);
-        }
-
-        let res = if semaphore { 1 } else { *count };
-        *count -= res;
-
-        drop(count);
-        pollee.notify_observers(Events::OUT);
-        Ok(res)
-    }
-
-    fn try_write_local(
-        count: &Mutex<Platform, u64>,
-        pollee: &Pollee<Platform>,
-        value: u64,
-    ) -> Result<usize, TryOpError<Errno>> {
-        if value == u64::MAX {
-            return Err(TryOpError::Other(Errno::EINVAL));
-        }
-
-        let mut count = count.lock();
-        if let Some(new_value) = (*count).checked_add(value)
-            && new_value != u64::MAX
-        {
-            *count = new_value;
-            drop(count);
-            pollee.notify_observers(Events::IN);
-            return Ok(core::mem::size_of::<u64>());
-        }
-
-        Err(TryOpError::TryAgain)
-    }
-
-    fn check_io_events(&self) -> Events {
-        match self {
-            Self::ShimLocal { count, .. } => {
-                let count = count.lock();
-                let mut events = Events::empty();
-                if *count != 0 {
-                    events |= Events::IN;
-                }
-                if *count < u64::MAX - 1 {
-                    events |= Events::OUT;
-                }
-                events
-            }
-            Self::BrokerBacked(counter) => counter.check_io_events(),
-        }
-    }
-
-    fn register_observer(&self, observer: alloc::sync::Weak<dyn Observer<Events>>, mask: Events) {
-        match self {
-            Self::ShimLocal { pollee, .. } => pollee.register_observer(observer, mask),
-            Self::BrokerBacked(counter) => counter.register_observer(observer, mask),
-        }
-    }
-}
-
 impl<Platform: RawSyncPrimitivesProvider + TimeProvider> EventFile<Platform> {
-    fn new(counter: EventFileCounter<Platform>, flags: EfdFlags) -> Self {
+    fn new(counter: EventCounter<Platform>, flags: EfdFlags) -> Self {
         let mut status = OFlags::RDWR;
         status.set(OFlags::NONBLOCK, flags.contains(EfdFlags::NONBLOCK));
         Self {
@@ -172,11 +46,23 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> EventFile<Platform> {
     }
 
     pub(crate) fn read(&self, cx: &WaitContext<'_, Platform>) -> Result<u64, Errno> {
-        self.counter.read(cx, self.is_nonblocking(), self.semaphore)
+        self.counter
+            .read(
+                cx,
+                self.is_nonblocking(),
+                if self.semaphore {
+                    EventCounterReadMode::One
+                } else {
+                    EventCounterReadMode::All
+                },
+            )
+            .map_err(Errno::from)
     }
 
     pub(crate) fn write(&self, cx: &WaitContext<'_, Platform>, value: u64) -> Result<usize, Errno> {
-        self.counter.write(cx, self.is_nonblocking(), value)
+        self.counter
+            .write(cx, self.is_nonblocking(), value)
+            .map_err(Errno::from)
     }
 
     super::common_functions_for_file_status!();
@@ -209,131 +95,22 @@ impl<FS: ShimFS> GlobalState<FS> {
         }
 
         let count = u64::from(initval);
-        let counter = match EventCounter::new(&self.litebox, count) {
-            Ok(counter) => EventFileCounter::BrokerBacked(counter),
-            Err(EventCounterError::Unavailable) => EventFileCounter::shim_local(count),
-            Err(error) => return Err(error.into()),
-        };
+        let counter = EventCounter::new(&self.litebox, count).map_err(Errno::from)?;
         Ok(EventFile::new(counter, flags))
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use litebox::event::wait::WaitState;
     use litebox_common_linux::{EfdFlags, errno::Errno};
-    use litebox_platform_multiplex::platform;
-
-    extern crate std;
 
     #[test]
-    fn test_semaphore_eventfd() {
-        let _task = crate::syscalls::tests::init_platform(None);
-
-        let eventfd = alloc::sync::Arc::new(super::EventFile::new(
-            super::EventFileCounter::shim_local(0),
-            EfdFlags::SEMAPHORE,
-        ));
-        let total = 8;
-        let handles: std::vec::Vec<_> = (0..total)
-            .map(|_| {
-                let copied_eventfd = eventfd.clone();
-                std::thread::spawn(move || {
-                    copied_eventfd
-                        .read(&WaitState::new(platform()).context())
-                        .unwrap();
-                })
-            })
-            .collect();
-
-        std::thread::sleep(core::time::Duration::from_millis(500));
-        eventfd
-            .write(&WaitState::new(platform()).context(), total)
-            .unwrap();
-        for handle in handles {
-            handle.join().unwrap();
-        }
-    }
-
-    #[test]
-    fn test_blocking_eventfd() {
-        let _task = crate::syscalls::tests::init_platform(None);
-
-        let eventfd = alloc::sync::Arc::new(super::EventFile::new(
-            super::EventFileCounter::shim_local(0),
-            EfdFlags::empty(),
-        ));
-        let copied_eventfd = eventfd.clone();
-        std::thread::spawn(move || {
-            copied_eventfd
-                .write(&WaitState::new(platform()).context(), 1)
-                .unwrap();
-            // block until the first read finishes
-            copied_eventfd
-                .write(&WaitState::new(platform()).context(), u64::MAX - 1)
-                .unwrap();
-        });
-
-        // block until the first write
-        let ret = eventfd.read(&WaitState::new(platform()).context()).unwrap();
-        assert_eq!(ret, 1);
-
-        // block until the second write
-        let ret = eventfd.read(&WaitState::new(platform()).context()).unwrap();
-        assert_eq!(ret, u64::MAX - 1);
-    }
-
-    #[test]
-    fn test_blocking_eventfd_no_race_on_massive_readwrite() {
-        let _task = crate::syscalls::tests::init_platform(None);
-
-        let eventfd = alloc::sync::Arc::new(super::EventFile::new(
-            super::EventFileCounter::shim_local(0),
-            EfdFlags::empty(),
-        ));
-        let copied_eventfd = eventfd.clone();
-        std::thread::spawn(move || {
-            for _ in 0..10000 {
-                copied_eventfd
-                    .write(&WaitState::new(platform()).context(), u64::MAX - 1)
-                    .unwrap();
-            }
-        });
-
-        for _ in 0..10000 {
-            let ret = eventfd.read(&WaitState::new(platform()).context()).unwrap();
-            assert_eq!(ret, u64::MAX - 1);
-        }
-    }
-
-    #[test]
-    fn test_eventfd_uses_shim_local_without_broker_control() {
+    fn test_eventfd_requires_broker_control() {
         let task = crate::syscalls::tests::init_platform(None);
 
-        let nonblocking_eventfd = task
-            .global
-            .create_linux_eventfd(0, EfdFlags::NONBLOCK)
-            .unwrap();
-        assert_eq!(
-            nonblocking_eventfd.read(&WaitState::new(platform()).context()),
-            Err(Errno::EAGAIN)
-        );
-        assert_eq!(
-            nonblocking_eventfd.write(&WaitState::new(platform()).context(), 1),
-            Ok(8)
-        );
-        assert_eq!(
-            nonblocking_eventfd.read(&WaitState::new(platform()).context()),
-            Ok(1)
-        );
-
-        let blocking_eventfd = task
-            .global
-            .create_linux_eventfd(1, EfdFlags::empty())
-            .unwrap();
-        assert_eq!(
-            blocking_eventfd.read(&WaitState::new(platform()).context()),
-            Ok(1)
-        );
+        assert!(matches!(
+            task.global.create_linux_eventfd(0, EfdFlags::NONBLOCK),
+            Err(Errno::EIO)
+        ));
     }
 }

--- a/litebox_shim_linux/src/syscalls/eventfd.rs
+++ b/litebox_shim_linux/src/syscalls/eventfd.rs
@@ -35,7 +35,7 @@ enum EventFileCounter<Platform: RawSyncPrimitivesProvider + TimeProvider> {
         count: Mutex<Platform, u64>,
         pollee: Pollee<Platform>,
     },
-    LocalCore(EventCounter<Platform>),
+    BrokerBacked(EventCounter<Platform>),
 }
 
 pub(crate) struct EventFile<Platform: RawSyncPrimitivesProvider + TimeProvider> {
@@ -65,7 +65,7 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> EventFileCounter<Platfo
                     Self::try_read_local(count, pollee, semaphore)
                 })
                 .map_err(Errno::from),
-            Self::LocalCore(counter) => counter
+            Self::BrokerBacked(counter) => counter
                 .read(
                     cx,
                     nonblock,
@@ -91,7 +91,7 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> EventFileCounter<Platfo
                     Self::try_write_local(count, pollee, value)
                 })
                 .map_err(Errno::from),
-            Self::LocalCore(counter) => counter.write(cx, nonblock, value).map_err(Errno::from),
+            Self::BrokerBacked(counter) => counter.write(cx, nonblock, value).map_err(Errno::from),
         }
     }
 
@@ -148,14 +148,14 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> EventFileCounter<Platfo
                 }
                 events
             }
-            Self::LocalCore(counter) => counter.check_io_events(),
+            Self::BrokerBacked(counter) => counter.check_io_events(),
         }
     }
 
     fn register_observer(&self, observer: alloc::sync::Weak<dyn Observer<Events>>, mask: Events) {
         match self {
             Self::ShimLocal { pollee, .. } => pollee.register_observer(observer, mask),
-            Self::LocalCore(counter) => counter.register_observer(observer, mask),
+            Self::BrokerBacked(counter) => counter.register_observer(observer, mask),
         }
     }
 }
@@ -210,7 +210,7 @@ impl<FS: ShimFS> GlobalState<FS> {
 
         let count = u64::from(initval);
         let counter = match EventCounter::new(&self.litebox, count) {
-            Ok(counter) => EventFileCounter::LocalCore(counter),
+            Ok(counter) => EventFileCounter::BrokerBacked(counter),
             Err(EventCounterError::Unavailable) => EventFileCounter::shim_local(count),
             Err(error) => return Err(error.into()),
         };
@@ -307,21 +307,33 @@ mod tests {
     }
 
     #[test]
-    fn test_nonblocking_eventfd_uses_shim_local_without_broker_control() {
+    fn test_eventfd_uses_shim_local_without_broker_control() {
         let task = crate::syscalls::tests::init_platform(None);
 
-        let eventfd = task
+        let nonblocking_eventfd = task
             .global
             .create_linux_eventfd(0, EfdFlags::NONBLOCK)
             .unwrap();
         assert_eq!(
-            eventfd.read(&WaitState::new(platform()).context()),
+            nonblocking_eventfd.read(&WaitState::new(platform()).context()),
             Err(Errno::EAGAIN)
         );
         assert_eq!(
-            eventfd.write(&WaitState::new(platform()).context(), 1),
+            nonblocking_eventfd.write(&WaitState::new(platform()).context(), 1),
             Ok(8)
         );
-        assert_eq!(eventfd.read(&WaitState::new(platform()).context()), Ok(1));
+        assert_eq!(
+            nonblocking_eventfd.read(&WaitState::new(platform()).context()),
+            Ok(1)
+        );
+
+        let blocking_eventfd = task
+            .global
+            .create_linux_eventfd(1, EfdFlags::empty())
+            .unwrap();
+        assert_eq!(
+            blocking_eventfd.read(&WaitState::new(platform()).context()),
+            Ok(1)
+        );
     }
 }

--- a/litebox_shim_linux/src/syscalls/tests.rs
+++ b/litebox_shim_linux/src/syscalls/tests.rs
@@ -86,15 +86,14 @@ fn test_fcntl() {
     let write_fd = i32::try_from(write_fd).unwrap();
     check(write_fd, OFlags::WRONLY | OFlags::NONBLOCK, OFlags::WRONLY);
 
-    // Test eventfd
-    let eventfd = task
-        .sys_eventfd2(
+    // Eventfd requires broker control in this shim configuration.
+    assert_eq!(
+        task.sys_eventfd2(
             0,
             EfdFlags::CLOEXEC | EfdFlags::SEMAPHORE | EfdFlags::NONBLOCK,
-        )
-        .expect("Failed to create eventfd");
-    let eventfd = i32::try_from(eventfd).unwrap();
-    check(eventfd, OFlags::RDWR | OFlags::NONBLOCK, OFlags::RDWR);
+        ),
+        Err(Errno::EIO)
+    );
 
     // Test fcntl with DUPFD
     let fd = task


### PR DESCRIPTION
Makes the Linux eventfd syscall path use the broker-backed EventCounter implementation and removes the shim-local Linux eventfd fallback. Non-broker Linux shim and runner tests now either expect eventfd creation to fail without broker control or use pipes for non-eventfd-specific fd coverage. Broker-backed Linux eventfd coverage remains in the broker runner integration test, including blocking/nonblocking behavior, poll/epoll readiness, sendfile in_fd errno behavior, and EFD_CLOEXEC/FD_CLOEXEC handling.