### PR TITLE
Improve stdio tty ioctl + polling behavior

### DIFF
--- a/litebox_shim_linux/src/lib.rs
+++ b/litebox_shim_linux/src/lib.rs
@@ -377,10 +377,16 @@ impl<FS: ShimFS> syscalls::file::FilesState<FS> {
             .unwrap();
         let mut dt = global.litebox.descriptor_table_mut();
         let mut rds = self.raw_descriptor_store.write();
-        for (raw_fd, fd) in [(0, stdin), (1, stdout), (2, stderr)] {
+        for (raw_fd, fd, stream) in [
+            (0, stdin, litebox::platform::StdioStream::Stdin),
+            (1, stdout, litebox::platform::StdioStream::Stdout),
+            (2, stderr, litebox::platform::StdioStream::Stderr),
+        ] {
             let status_flags = OFlags::APPEND | OFlags::RDWR;
             debug_assert_eq!(OFlags::STATUS_FLAGS_MASK & status_flags, status_flags);
             let old = dt.set_entry_metadata(&fd, StdioStatusFlags(status_flags));
+            assert!(old.is_none());
+            let old = dt.set_entry_metadata(&fd, stream);
             assert!(old.is_none());
             let success = rds.fd_into_specific_raw_integer(fd, raw_fd);
             assert!(success);

--- a/litebox_shim_linux/src/syscalls/epoll.rs
+++ b/litebox_shim_linux/src/syscalls/epoll.rs
@@ -129,9 +129,21 @@ impl<FS: ShimFS> EpollDescriptor<FS> {
                 Some(handle.with_entry(|entry| poll(entry)))
             }
             EpollDescriptor::Epoll(_file) => unimplemented!(),
-            EpollDescriptor::File(_file) => {
-                // TODO: probably polling on stdio files, return dummy events for now
-                Some(Events::OUT & mask)
+            EpollDescriptor::File(file) => {
+                // TODO: File polling returns dummy events for now, but distinguish stdio enough for REPLs.
+                let events = match global
+                    .litebox
+                    .descriptor_table()
+                    .with_metadata(file, |stream: &litebox::platform::StdioStream| *stream)
+                {
+                    Ok(litebox::platform::StdioStream::Stdin) => Events::IN,
+                    Ok(
+                        litebox::platform::StdioStream::Stdout
+                        | litebox::platform::StdioStream::Stderr,
+                    )
+                    | Err(_) => Events::OUT,
+                };
+                Some(events & mask)
             }
             EpollDescriptor::Socket(fd) => {
                 let proxy = match global.get_proxy(fd) {

--- a/litebox_shim_linux/src/syscalls/file.rs
+++ b/litebox_shim_linux/src/syscalls/file.rs
@@ -1954,7 +1954,16 @@ impl<FS: ShimFS> Task<FS> {
                             .litebox
                             .descriptor_table()
                             .with_metadata(fd, |stream: &StdioStream| *stream)
-                            .map_err(|_| Errno::ENOTTY)?;
+                            .map_err(|_| {
+                                // TODO: Handle missing `StdioStream` metadata (could happen if
+                                // `/dev/stdin`, `/dev/stdout`, or `/dev/stderr` was reopened).
+                                // XXX(jayb): likely we might want to have some backend-specific
+                                // metadata layer in our file system?
+                                litebox_util_log::error!(
+                                    "standard stream is missing StdioStream metadata"
+                                );
+                                Errno::ENOTTY
+                            })?;
                         if self.global.platform.is_a_tty(stream) {
                             self.stdio_ioctl(&arg)
                         } else {

--- a/litebox_shim_linux/src/syscalls/file.rs
+++ b/litebox_shim_linux/src/syscalls/file.rs
@@ -14,7 +14,7 @@ use litebox::{
     fs::{Mode, OFlags, SeekWhence},
     mm::linux::PAGE_SIZE,
     path,
-    platform::{RawConstPointer, RawMutPointer},
+    platform::{RawConstPointer, RawMutPointer, StdioProvider, StdioStream},
     utils::{ReinterpretSignedExt as _, ReinterpretUnsignedExt as _, TruncateExt as _},
 };
 use litebox_common_linux::{
@@ -1949,7 +1949,17 @@ impl<FS: ShimFS> Task<FS> {
                 desc,
                 |fd| {
                     if self.is_stdio(&files.fs, fd)? {
-                        self.stdio_ioctl(&arg)
+                        let stream = self
+                            .global
+                            .litebox
+                            .descriptor_table()
+                            .with_metadata(fd, |stream: &StdioStream| *stream)
+                            .map_err(|_| Errno::ENOTTY)?;
+                        if self.global.platform.is_a_tty(stream) {
+                            self.stdio_ioctl(&arg)
+                        } else {
+                            Err(Errno::ENOTTY)
+                        }
                     } else {
                         Err(Errno::ENOTTY)
                     }


### PR DESCRIPTION
This PR tracks stdio stream identity to better manage ioctl (scoped only to tty now), and to better handle polling of the streams