### PR TITLE
Handle pselect signal masks

### DIFF
--- a/litebox_common_linux/src/lib.rs
+++ b/litebox_common_linux/src/lib.rs
@@ -1851,11 +1851,11 @@ bitflags::bitflags! {
     }
 }
 
-/// Packaged sigset with its size, used by `pselect` syscall
-#[derive(Clone, Copy, FromBytes, IntoBytes)]
+/// Packaged sigset pointer with its size, used by `pselect6` syscall.
+#[derive(Clone, Copy, FromBytes)]
 #[repr(C)]
-pub struct SigSetPack {
-    pub sigset: SigSet,
+pub struct SigSetPack<Platform: litebox::platform::RawPointerProvider> {
+    pub sigset: Platform::RawConstPointer<SigSet>,
     pub size: usize,
 }
 
@@ -2272,7 +2272,7 @@ pub enum SyscallRequest<Platform: litebox::platform::RawPointerProvider> {
         writefds: Option<Platform::RawMutPointer<usize>>,
         exceptfds: Option<Platform::RawMutPointer<usize>>,
         timeout: TimeParam<Platform>,
-        sigsetpack: Option<Platform::RawConstPointer<SigSetPack>>,
+        sigsetpack: Option<Platform::RawConstPointer<SigSetPack<Platform>>>,
     },
     ArchPrctl {
         arg: ArchPrctlArg<Platform>,

--- a/litebox_shim_linux/src/syscalls/file.rs
+++ b/litebox_shim_linux/src/syscalls/file.rs
@@ -2248,11 +2248,17 @@ impl<FS: ShimFS> Task<FS> {
         writefds: Option<MutPtr<usize>>,
         exceptfds: Option<MutPtr<usize>>,
         timeout: TimeParam<Platform>,
-        sigsetpack: Option<ConstPtr<litebox_common_linux::SigSetPack>>,
+        sigsetpack: Option<ConstPtr<litebox_common_linux::SigSetPack<Platform>>>,
     ) -> Result<usize, Errno> {
-        if sigsetpack.is_some() {
-            unimplemented!("no sigsetpack support yet");
-        }
+        let sigmask = if let Some(sigsetpack) = sigsetpack {
+            let sigsetpack = sigsetpack.read_at_offset(0).ok_or(Errno::EFAULT)?;
+            if sigsetpack.size != core::mem::size_of::<litebox_common_linux::signal::SigSet>() {
+                return Err(Errno::EINVAL);
+            }
+            Some(sigsetpack.sigset.read_at_offset(0).ok_or(Errno::EFAULT)?)
+        } else {
+            None
+        };
         let timeout = timeout.read()?;
         if nfds >= i32::MAX as u32
             || nfds as usize
@@ -2277,13 +2283,20 @@ impl<FS: ShimFS> Task<FS> {
             .transpose()?
             .map(|fds| bitvec::vec::BitVec::from_vec(fds.into_vec()));
 
-        let count = self.do_pselect(
-            nfds,
-            kreadfds.as_mut(),
-            kwritefds.as_mut(),
-            kexceptfds.as_mut(),
-            timeout,
-        )?;
+        let mut do_pselect = || {
+            self.do_pselect(
+                nfds,
+                kreadfds.as_mut(),
+                kwritefds.as_mut(),
+                kexceptfds.as_mut(),
+                timeout,
+            )
+        };
+        let count = if let Some(sigmask) = sigmask {
+            self.with_temporary_signal_mask(sigmask, do_pselect)
+        } else {
+            do_pselect()
+        }?;
 
         if let Some(fds) = kreadfds {
             readfds

--- a/litebox_shim_linux/src/syscalls/signal/mod.rs
+++ b/litebox_shim_linux/src/syscalls/signal/mod.rs
@@ -381,6 +381,14 @@ impl SignalState {
 struct DeliverFault;
 
 impl<FS: ShimFS> Task<FS> {
+    pub(crate) fn with_temporary_signal_mask<R>(&self, mask: SigSet, f: impl FnOnce() -> R) -> R {
+        let old = self.signals.blocked.get();
+        self.signals.set_signal_mask(mask);
+        let result = f();
+        self.signals.set_signal_mask(old);
+        result
+    }
+
     pub(crate) fn sys_rt_sigprocmask(
         &self,
         how: SigmaskHow,


### PR DESCRIPTION
This PR fixes the type of `SigSetPack` to actually use the pointer (see the [`pselect6` part of `man 2 pselect`](https://linux.die.net/man/2/pselect#:~:text=The%20final%20argument,a%20system%20call.)), and adds support for its use as a temporary signal mask.