### PR TITLE
Clear a future-incompat warning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,11 +935,10 @@ dependencies = [
 
 [[package]]
 name = "getset"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf0fc11e47561d47397154977bc219f4cf809b2974facc3ccb3b89e2436f912"
+checksum = "6cf442baaabe4213ce7d1239afc26c039180b6456da2cededa316ae2c8a77a77"
 dependencies = [
- "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn",


### PR DESCRIPTION
This PR updates a dependency to clear the future-incompat warning for proc-macro-error2 v2.0.1