### PR TITLE
Add OP-TEE ShortBuffer required-size handling

### DIFF
--- a/litebox_shim_optee/src/lib.rs
+++ b/litebox_shim_optee/src/lib.rs
@@ -478,23 +478,35 @@ impl Task {
                 ret_orig,
             } => {
                 if let Some(mut params_copied) = params.read_at_offset(0) {
-                    self.sys_invoke_ta_command(
+                    let result = self.sys_invoke_ta_command(
                         ta_sess_id,
                         cancel_req_to,
                         cmd_id,
                         &mut params_copied,
                         ret_orig,
-                    )
-                    .and_then(|cleanup| {
-                        if !params_copied.needs_copy_back()
-                            || params.write_at_offset(0, params_copied).is_some()
-                        {
-                            Ok(())
-                        } else {
-                            cleanup.run(self);
-                            Err(TeeResult::AccessDenied)
+                    );
+                    match result {
+                        Ok(cleanup) => {
+                            if !params_copied.needs_copy_back()
+                                || params.write_at_offset(0, params_copied).is_some()
+                            {
+                                Ok(())
+                            } else {
+                                cleanup.run(self);
+                                Err(TeeResult::AccessDenied)
+                            }
                         }
-                    })
+                        Err(TeeResult::ShortBuffer) => {
+                            if !params_copied.needs_copy_back()
+                                || params.write_at_offset(0, params_copied).is_some()
+                            {
+                                Err(TeeResult::ShortBuffer)
+                            } else {
+                                Err(TeeResult::AccessDenied)
+                            }
+                        }
+                        Err(error) => Err(error),
+                    }
                 } else {
                     Err(TeeResult::BadParameters)
                 }
@@ -958,11 +970,23 @@ where
     {
         let mut length: usize = length.trunc();
         let mut kernel_buf = vec![0u8; length];
-        syscall_fn(task, state, &src_slice, &mut kernel_buf, &mut length).and_then(|()| {
-            let _ = dst_len.write_at_offset(0, length as u64);
-            dst.copy_from_slice(0, &kernel_buf[..length])
-                .ok_or(TeeResult::OutOfMemory)
-        })
+        let result = syscall_fn(task, state, &src_slice, &mut kernel_buf, &mut length);
+        match result {
+            Ok(()) => {
+                dst_len
+                    .write_at_offset(0, length as u64)
+                    .ok_or(TeeResult::AccessDenied)?;
+                dst.copy_from_slice(0, &kernel_buf[..length])
+                    .ok_or(TeeResult::OutOfMemory)
+            }
+            Err(TeeResult::ShortBuffer) => {
+                dst_len
+                    .write_at_offset(0, length as u64)
+                    .ok_or(TeeResult::AccessDenied)?;
+                Err(TeeResult::ShortBuffer)
+            }
+            Err(error) => Err(error),
+        }
     } else {
         Err(TeeResult::BadParameters)
     }

--- a/litebox_shim_optee/src/lib.rs
+++ b/litebox_shim_optee/src/lib.rs
@@ -973,11 +973,11 @@ where
         let result = syscall_fn(task, state, &src_slice, &mut kernel_buf, &mut length);
         match result {
             Ok(()) => {
+                dst.copy_from_slice(0, &kernel_buf[..length])
+                    .ok_or(TeeResult::OutOfMemory)?;
                 dst_len
                     .write_at_offset(0, length as u64)
-                    .ok_or(TeeResult::AccessDenied)?;
-                dst.copy_from_slice(0, &kernel_buf[..length])
-                    .ok_or(TeeResult::OutOfMemory)
+                    .ok_or(TeeResult::AccessDenied)
             }
             Err(TeeResult::ShortBuffer) => {
                 dst_len

--- a/litebox_shim_optee/src/syscalls/cryp.rs
+++ b/litebox_shim_optee/src/syscalls/cryp.rs
@@ -168,6 +168,7 @@ impl Task {
     ) -> Result<(), TeeResult> {
         let tee_cryp_state_map = &self.tee_cryp_state_map;
         if dst_slice.len() < src_slice.len() {
+            *dst_len = src_slice.len();
             return Err(TeeResult::ShortBuffer);
         }
         if let Some(mut map) = tee_cryp_state_map.get_mut(state) {

--- a/litebox_shim_optee/src/syscalls/cryp.rs
+++ b/litebox_shim_optee/src/syscalls/cryp.rs
@@ -167,44 +167,43 @@ impl Task {
         last_block: bool,
     ) -> Result<(), TeeResult> {
         let tee_cryp_state_map = &self.tee_cryp_state_map;
+        let Some(mut map) = tee_cryp_state_map.get_mut(state) else {
+            return Err(TeeResult::BadParameters);
+        };
         if dst_slice.len() < src_slice.len() {
             *dst_len = src_slice.len();
             return Err(TeeResult::ShortBuffer);
         }
-        if let Some(mut map) = tee_cryp_state_map.get_mut(state) {
-            // Check last_block before applying the cipher so we don't mutate
-            // dst_slice and then return an error.
-            if last_block {
-                #[cfg(debug_assertions)]
-                todo!("support algorithms which have a certain finalization logic");
-                #[cfg(not(debug_assertions))]
-                return Err(TeeResult::NotSupported);
-            }
-            if let Some(state_entry) = map.get_mut(&state)
-                && let Some(cipher) = state_entry.get_mut_cipher()
-            {
-                dst_slice[..src_slice.len()].copy_from_slice(src_slice);
-                match cipher {
-                    Cipher::Aes128Ctr(aes128ctr) => {
-                        aes128ctr.apply_keystream(&mut dst_slice[..src_slice.len()]);
-                    }
-                    Cipher::Aes192Ctr(aes192ctr) => {
-                        aes192ctr.apply_keystream(&mut dst_slice[..src_slice.len()]);
-                    }
-                    Cipher::Aes256Ctr(aes256ctr) => {
-                        aes256ctr.apply_keystream(&mut dst_slice[..src_slice.len()]);
-                    }
+        // Check last_block before applying the cipher so we don't mutate
+        // dst_slice and then return an error.
+        if last_block {
+            #[cfg(debug_assertions)]
+            todo!("support algorithms which have a certain finalization logic");
+            #[cfg(not(debug_assertions))]
+            return Err(TeeResult::NotSupported);
+        }
+        if let Some(state_entry) = map.get_mut(&state)
+            && let Some(cipher) = state_entry.get_mut_cipher()
+        {
+            dst_slice[..src_slice.len()].copy_from_slice(src_slice);
+            match cipher {
+                Cipher::Aes128Ctr(aes128ctr) => {
+                    aes128ctr.apply_keystream(&mut dst_slice[..src_slice.len()]);
                 }
-                *dst_len = src_slice.len();
-                Ok(())
-            } else {
-                #[cfg(debug_assertions)]
-                todo!("handle unimplemented cipher");
-                #[cfg(not(debug_assertions))]
-                Err(TeeResult::NotImplemented)
+                Cipher::Aes192Ctr(aes192ctr) => {
+                    aes192ctr.apply_keystream(&mut dst_slice[..src_slice.len()]);
+                }
+                Cipher::Aes256Ctr(aes256ctr) => {
+                    aes256ctr.apply_keystream(&mut dst_slice[..src_slice.len()]);
+                }
             }
+            *dst_len = src_slice.len();
+            Ok(())
         } else {
-            Err(TeeResult::BadParameters)
+            #[cfg(debug_assertions)]
+            todo!("handle unimplemented cipher");
+            #[cfg(not(debug_assertions))]
+            Err(TeeResult::NotImplemented)
         }
     }
 

--- a/litebox_shim_optee/src/syscalls/tee.rs
+++ b/litebox_shim_optee/src/syscalls/tee.rs
@@ -264,7 +264,7 @@ impl Task {
             let result = pta.invoke_command(self, cmd_id, params);
             // Best-effort write-back of the return origin, matching OP-TEE OS
             // (`syscall_invoke_ta_command`): the copy result is ignored.
-            let _ = ret_orig.write_at_offset(0, TeeOrigin::Tee);
+            let _ = ret_orig.write_at_offset(0, TeeOrigin::TrustedApp);
             result
         } else {
             #[cfg(debug_assertions)]

--- a/litebox_shim_optee/src/syscalls/tee.rs
+++ b/litebox_shim_optee/src/syscalls/tee.rs
@@ -92,7 +92,13 @@ impl Task {
                 if prop_set != TeePropSet::CurrentClient {
                     return Err(TeeResult::BadParameters);
                 }
+                prop_type
+                    .write_at_offset(0, UserTaPropType::Identity as u32)
+                    .ok_or(TeeResult::AccessDenied)?;
                 if prop_buf.len() < core::mem::size_of::<TeeIdentity>() {
+                    prop_len
+                        .write_at_offset(0, core::mem::size_of::<TeeIdentity>().trunc())
+                        .ok_or(TeeResult::AccessDenied)?;
                     return Err(TeeResult::ShortBuffer);
                 }
                 let identity = self.current_client_identity();
@@ -101,9 +107,6 @@ impl Task {
                 prop_len
                     .write_at_offset(0, core::mem::size_of::<TeeIdentity>().trunc())
                     .ok_or(TeeResult::AccessDenied)?;
-                prop_type
-                    .write_at_offset(0, UserTaPropType::Identity as u32)
-                    .ok_or(TeeResult::AccessDenied)?;
                 Ok(())
             }
             GpdPropertyIndex::ClientEndian => {
@@ -111,7 +114,13 @@ impl Task {
                 if prop_set != TeePropSet::CurrentClient {
                     return Err(TeeResult::BadParameters);
                 }
+                prop_type
+                    .write_at_offset(0, UserTaPropType::U32 as u32)
+                    .ok_or(TeeResult::AccessDenied)?;
                 if prop_buf.len() < core::mem::size_of::<u32>() {
+                    prop_len
+                        .write_at_offset(0, core::mem::size_of::<u32>().trunc())
+                        .ok_or(TeeResult::AccessDenied)?;
                     return Err(TeeResult::ShortBuffer);
                 }
                 prop_buf[..core::mem::size_of::<u32>()]
@@ -119,25 +128,25 @@ impl Task {
                 prop_len
                     .write_at_offset(0, core::mem::size_of::<u32>().trunc())
                     .ok_or(TeeResult::AccessDenied)?;
-                prop_type
-                    .write_at_offset(0, UserTaPropType::U32 as u32)
-                    .ok_or(TeeResult::AccessDenied)?;
                 Ok(())
             }
             GpdPropertyIndex::CurrentTaUuid => {
                 if prop_set != TeePropSet::CurrentTa {
                     return Err(TeeResult::BadParameters);
                 }
+                prop_type
+                    .write_at_offset(0, UserTaPropType::Uuid as u32)
+                    .ok_or(TeeResult::AccessDenied)?;
                 if prop_buf.len() < core::mem::size_of::<TeeUuid>() {
+                    prop_len
+                        .write_at_offset(0, core::mem::size_of::<TeeUuid>().trunc())
+                        .ok_or(TeeResult::AccessDenied)?;
                     return Err(TeeResult::ShortBuffer);
                 }
                 let ta_uuid = self.ta_app_id;
                 prop_buf[..core::mem::size_of::<TeeUuid>()].copy_from_slice(ta_uuid.as_bytes());
                 prop_len
                     .write_at_offset(0, core::mem::size_of::<TeeUuid>().trunc())
-                    .ok_or(TeeResult::AccessDenied)?;
-                prop_type
-                    .write_at_offset(0, UserTaPropType::Uuid as u32)
                     .ok_or(TeeResult::AccessDenied)?;
                 Ok(())
             }
@@ -252,11 +261,11 @@ impl Task {
     ) -> Result<Cleanup, TeeResult> {
         // `cancel_req_to` is a timeout value. Ignore it for now.
         if let Some(pta) = self.pta_for_session(ta_sess_id) {
-            let cleanup = pta.invoke_command(self, cmd_id, params)?;
+            let result = pta.invoke_command(self, cmd_id, params);
             // Best-effort write-back of the return origin, matching OP-TEE OS
             // (`syscall_invoke_ta_command`): the copy result is ignored.
             let _ = ret_orig.write_at_offset(0, TeeOrigin::Tee);
-            Ok(cleanup)
+            result
         } else {
             #[cfg(debug_assertions)]
             todo!("support inter TA interaction");


### PR DESCRIPTION
This PR adds the required-size handling for OP-TEE ShortBuffer error paths. OP-TEE OS returns a required buffer size when it returns a ShortBuffer error to a TA, but the current OP-TEE shim doesn't return this information.