### PR TITLE
Add IDK_S PTA

### DIFF
--- a/litebox_common_optee/src/lib.rs
+++ b/litebox_common_optee/src/lib.rs
@@ -726,6 +726,11 @@ bitflags::bitflags! {
     }
 }
 
+/// Default flags for a single-instance, multi-session, keep-alive pseudo-TA.
+pub const PTA_DEFAULT_FLAGS: TaFlags = TaFlags::SINGLE_INSTANCE
+    .union(TaFlags::MULTI_SESSION)
+    .union(TaFlags::INSTANCE_KEEP_ALIVE);
+
 impl TaFlags {
     /// Returns true if this TA should only have one instance.
     pub fn is_single_instance(&self) -> bool {

--- a/litebox_common_optee/src/lib.rs
+++ b/litebox_common_optee/src/lib.rs
@@ -726,11 +726,6 @@ bitflags::bitflags! {
     }
 }
 
-/// Default flags for a single-instance, multi-session, keep-alive pseudo-TA.
-pub const PTA_DEFAULT_FLAGS: TaFlags = TaFlags::SINGLE_INSTANCE
-    .union(TaFlags::MULTI_SESSION)
-    .union(TaFlags::INSTANCE_KEEP_ALIVE);
-
 impl TaFlags {
     /// Returns true if this TA should only have one instance.
     pub fn is_single_instance(&self) -> bool {

--- a/litebox_shim_optee/Cargo.toml
+++ b/litebox_shim_optee/Cargo.toml
@@ -26,6 +26,7 @@ p384 = { version = "0.13.1", default-features = false, features = ["arithmetic",
 
 [features]
 default = ["platform_lvbs"]
+idks-production = []
 platform_linux_userland = ["litebox_platform_multiplex/platform_linux_userland_with_optee_syscall"]
 platform_lvbs = ["litebox_platform_multiplex/platform_lvbs_with_optee_syscall"]
 

--- a/litebox_shim_optee/src/idk.rs
+++ b/litebox_shim_optee/src/idk.rs
@@ -1,11 +1,23 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-use crate::NormalWorldMutPtr;
-use litebox::{mm::linux::PAGE_SIZE, platform::CrngProvider, utils::TruncateExt};
+use crate::{NormalWorldMutPtr, Task, UserConstPtr, UserMutPtr, syscalls::Cleanup};
+use alloc::vec::Vec;
+use litebox::{
+    mm::linux::PAGE_SIZE,
+    platform::{CrngProvider, RawConstPointer as _, RawMutPointer as _},
+    utils::TruncateExt,
+};
 use litebox_common_linux::errno::Errno;
+use litebox_common_optee::{
+    PTA_DEFAULT_FLAGS, TaFlags, TeeParamType, TeeResult, TeeUuid, UteeParams,
+};
 use num_enum::TryFromPrimitive;
-use p384::{NonZeroScalar, elliptic_curve::sec1::ToEncodedPoint};
+use p384::{
+    NonZeroScalar,
+    ecdsa::{Signature, SigningKey, signature::Signer},
+    elliptic_curve::sec1::ToEncodedPoint,
+};
 use spin::Once;
 use zeroize::Zeroizing;
 
@@ -15,11 +27,148 @@ const KEY_ALGORITHM_MASK: u64 = 0xff00;
 const KEY_VARIANT_MASK: u64 = 0xff;
 const KEY_ALGORITHM_VALUE_MASK: u64 = KEY_ALGORITHM_MASK | KEY_VARIANT_MASK;
 const MAX_KEYGEN_ATTEMPT: usize = 256;
+const IDKS_ENDORSEMENT_DATA_MAX_SIZE: usize = 8 * 1024 * 1024;
+const IDKS_ENDORSEMENT_MAGIC: &[u8; 4] = b"IDKS";
+const IDKS_ENDORSEMENT_VERSION: u32 = 1;
+#[cfg(not(feature = "idks-production"))]
+const IDKS_DEBUG_FLAG: u8 = 1;
+#[cfg(feature = "idks-production")]
+const IDKS_DEBUG_FLAG: u8 = 0;
+const ISOLATION_SOLUTION: &[u8] = b"LVBS";
+pub(crate) const IDKS_ENDORSEMENT_SIGNATURE_LEN: usize = 96;
+const IDKS_ENDORSEMENT_METADATA_LEN: usize = IDKS_ENDORSEMENT_MAGIC.len()
+    + size_of::<u32>()
+    + size_of::<TeeUuid>()
+    + size_of::<u32>()
+    + size_of::<u8>()
+    + ISOLATION_SOLUTION.len();
+pub(crate) struct IdksPta;
+
+#[derive(Clone, Copy, TryFromPrimitive)]
+#[repr(u32)]
+pub(crate) enum IdksCommandId {
+    EndorseData = 0,
+}
+
+impl IdksPta {
+    pub(crate) const FLAGS: TaFlags = PTA_DEFAULT_FLAGS.union(TaFlags::CONCURRENT);
+    pub(crate) const UUID: TeeUuid = TeeUuid {
+        time_low: 0xfd79_8211,
+        time_mid: 0x38a3,
+        time_hi_and_version: 0x474a,
+        clock_seq_and_node: [0xab, 0x6c, 0x75, 0x61, 0x0d, 0x45, 0x35, 0x93],
+    };
+
+    pub(crate) fn open_session(params: &UteeParams) -> Result<u32, TeeResult> {
+        crate::syscalls::pta::open_default_pta_session(params)
+    }
+
+    pub(crate) fn close_session(_task: &Task, _session_id: u32) {}
+
+    pub(crate) fn invoke_command(
+        task: &Task,
+        cmd_id: u32,
+        params: &mut UteeParams,
+    ) -> Result<Cleanup, TeeResult> {
+        match IdksCommandId::try_from(cmd_id).map_err(|_| TeeResult::BadParameters)? {
+            IdksCommandId::EndorseData => Self::endorse_data(task, params).map(|()| Cleanup::None),
+        }
+    }
+
+    fn endorse_data(task: &Task, params: &mut UteeParams) -> Result<(), TeeResult> {
+        use TeeParamType::{MemrefInput, MemrefOutput, None};
+
+        if !params.has_types([MemrefInput, MemrefOutput, None, None]) {
+            return Err(TeeResult::BadParameters);
+        }
+
+        let (ta_data_addr, ta_data_size) = params
+            .get_values(0)
+            .map_err(|_| TeeResult::BadParameters)?
+            .ok_or(TeeResult::BadParameters)?;
+        let ta_data_size = usize::try_from(ta_data_size).map_err(|_| TeeResult::BadParameters)?;
+        if ta_data_size > IDKS_ENDORSEMENT_DATA_MAX_SIZE {
+            return Err(TeeResult::BadParameters);
+        }
+        if ta_data_size > 0 && ta_data_addr == 0 {
+            return Err(TeeResult::BadParameters);
+        }
+
+        let (endorsement_addr, endorsement_size) = params
+            .get_values(1)
+            .map_err(|_| TeeResult::BadParameters)?
+            .ok_or(TeeResult::BadParameters)?;
+        let required_endorsement_size = ta_data_size
+            .checked_add(IDKS_ENDORSEMENT_METADATA_LEN)
+            .and_then(|size| size.checked_add(IDKS_ENDORSEMENT_SIGNATURE_LEN))
+            .ok_or(TeeResult::BadParameters)?;
+        let required_endorsement_size_u64 =
+            u64::try_from(required_endorsement_size).map_err(|_| TeeResult::BadParameters)?;
+        if endorsement_size < required_endorsement_size_u64 {
+            params
+                .set_values(1, endorsement_addr, required_endorsement_size_u64)
+                .map_err(|_| TeeResult::BadParameters)?;
+            return Err(TeeResult::ShortBuffer);
+        }
+        if endorsement_addr == 0 {
+            return Err(TeeResult::BadParameters);
+        }
+
+        let ta_data = if ta_data_size == 0 {
+            Vec::new().into_boxed_slice()
+        } else {
+            UserConstPtr::<u8>::from_usize(
+                usize::try_from(ta_data_addr).map_err(|_| TeeResult::BadParameters)?,
+            )
+            .to_owned_slice(ta_data_size)
+            .ok_or(TeeResult::BadParameters)?
+        };
+        let mut endorsement = build_endorsement_data(&ta_data, &task.ta_app_id, task.ta_svn)
+            .ok_or(TeeResult::BadParameters)?;
+        let key_pair = get_identity_signing_key_pair().map_err(|_| TeeResult::GenericError)?;
+        let signature =
+            endorse_data_with(&endorsement, &key_pair.private_key)
+                .map_err(|_| TeeResult::GenericError)?;
+        endorsement.extend_from_slice(&signature);
+        UserMutPtr::<u8>::from_usize(
+            usize::try_from(endorsement_addr).map_err(|_| TeeResult::BadParameters)?,
+        )
+        .copy_from_slice(0, &endorsement)
+        .ok_or(TeeResult::AccessDenied)?;
+        params
+            .set_values(1, endorsement_addr, required_endorsement_size_u64)
+            .map_err(|_| TeeResult::BadParameters)
+    }
+}
+
+fn build_endorsement_data(ta_data: &[u8], ta_uuid: &TeeUuid, ta_svn: u32) -> Option<Vec<u8>> {
+    // MAGIC || VERSION || TA_DATA || TA_UUID || TA_SVN || DEBUG || ISOLATION_SOLUTION
+    let capacity = ta_data.len().checked_add(IDKS_ENDORSEMENT_METADATA_LEN)?;
+    let mut endorsement = Vec::with_capacity(capacity);
+    endorsement.extend_from_slice(IDKS_ENDORSEMENT_MAGIC);
+    endorsement.extend_from_slice(&IDKS_ENDORSEMENT_VERSION.to_le_bytes());
+    endorsement.extend_from_slice(ta_data);
+    endorsement.extend_from_slice(&ta_uuid.to_le_bytes());
+    endorsement.extend_from_slice(&ta_svn.to_le_bytes());
+    endorsement.push(IDKS_DEBUG_FLAG);
+    endorsement.extend_from_slice(ISOLATION_SOLUTION);
+    Some(endorsement)
+}
+
+fn endorse_data_with(
+    endorsement_data: &[u8],
+    private_key: &[u8; IDENTITY_SIGNING_PRIVATE_KEY_LEN],
+) -> Result<[u8; IDKS_ENDORSEMENT_SIGNATURE_LEN], Errno> {
+    let signing_key = SigningKey::from_slice(private_key).map_err(|_| Errno::EINVAL)?;
+    let signature: Signature = signing_key.sign(endorsement_data);
+    let mut signature_bytes = [0u8; IDKS_ENDORSEMENT_SIGNATURE_LEN];
+    signature_bytes.copy_from_slice(&signature.to_bytes());
+    Ok(signature_bytes)
+}
 
 static IDENTITY_SIGNING_KEY_PAIR: Once<IdentitySigningKeyPair> = Once::new();
 
 struct IdentitySigningKeyPair {
-    #[allow(dead_code, reason = "retained for future IDK_S signing operations")]
     private_key: Zeroizing<[u8; IDENTITY_SIGNING_PRIVATE_KEY_LEN]>,
     public_key: [u8; IDENTITY_SIGNING_PUBLIC_KEY_LEN],
 }
@@ -150,24 +299,39 @@ mod tests {
     use super::*;
 
     #[test]
-    fn identity_signing_private_key_signs_and_verifies_message() {
-        use crate::syscalls::tests::init_platform;
-        use p384::ecdsa::{
-            Signature, SigningKey, VerifyingKey,
-            signature::{Signer, Verifier},
+    fn endorsement_signature_covers_plaintext_layout() {
+        use p384::ecdsa::{Signature, VerifyingKey, signature::Verifier};
+
+        let mut private_key = [0u8; IDENTITY_SIGNING_PRIVATE_KEY_LEN];
+        private_key[IDENTITY_SIGNING_PRIVATE_KEY_LEN - 1] = 1;
+        let ta_data = b"TA public key";
+        let ta_uuid = TeeUuid {
+            time_low: 0x1122_3344,
+            time_mid: 0x5566,
+            time_hi_and_version: 0x7788,
+            clock_seq_and_node: [0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00],
         };
 
-        let message = b"IDK_S signing test message";
+        let ta_svn = 7u32;
+        let expected_plaintext = build_endorsement_data(ta_data, &ta_uuid, ta_svn).unwrap();
 
-        let _task = init_platform();
-        let private_key = generate_identity_signing_private_key().unwrap();
-        assert!(is_valid_identity_signing_private_key(&private_key));
-        let signing_key = SigningKey::from_slice(&private_key[..]).unwrap();
+        let signature = endorse_data_with(&expected_plaintext, &private_key).unwrap();
         let public_key = identity_signing_public_key_from_private_key(&private_key).unwrap();
         let verifying_key = VerifyingKey::from_sec1_bytes(&public_key).unwrap();
+        let signature = Signature::from_slice(&signature).unwrap();
 
-        let signature: Signature = signing_key.sign(message);
+        verifying_key
+            .verify(&expected_plaintext, &signature)
+            .unwrap();
+        let other_uuid = TeeUuid {
+            time_low: ta_uuid.time_low.wrapping_add(1),
+            ..ta_uuid
+        };
+        let mut other_plaintext = Vec::from(ta_data.as_slice());
+        other_plaintext.extend_from_slice(&other_uuid.to_le_bytes());
+        other_plaintext.extend_from_slice(&ta_svn.to_le_bytes());
+        other_plaintext.extend_from_slice(ISOLATION_SOLUTION);
 
-        verifying_key.verify(message, &signature).unwrap();
+        assert!(verifying_key.verify(&other_plaintext, &signature).is_err());
     }
 }

--- a/litebox_shim_optee/src/idk.rs
+++ b/litebox_shim_optee/src/idk.rs
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-use crate::{NormalWorldMutPtr, Task, UserConstPtr, UserMutPtr, syscalls::Cleanup};
+use crate::syscalls::pta::PTA_DEFAULT_FLAGS;
+use crate::{
+    NormalWorldMutPtr, TA_DIGEST_LEN, TaDigest, Task, UserConstPtr, UserMutPtr, syscalls::Cleanup,
+};
 use alloc::vec::Vec;
 use litebox::{
     mm::linux::PAGE_SIZE,
@@ -9,9 +12,7 @@ use litebox::{
     utils::TruncateExt,
 };
 use litebox_common_linux::errno::Errno;
-use litebox_common_optee::{
-    PTA_DEFAULT_FLAGS, TaFlags, TeeParamType, TeeResult, TeeUuid, UteeParams,
-};
+use litebox_common_optee::{TaFlags, TeeParamType, TeeResult, TeeUuid, UteeParams};
 use num_enum::TryFromPrimitive;
 use p384::{
     NonZeroScalar,
@@ -40,6 +41,7 @@ const IDKS_ENDORSEMENT_METADATA_LEN: usize = IDKS_ENDORSEMENT_MAGIC.len()
     + size_of::<u32>()
     + size_of::<TeeUuid>()
     + size_of::<u32>()
+    + TA_DIGEST_LEN
     + size_of::<u8>()
     + ISOLATION_SOLUTION.len();
 pub(crate) struct IdksPta;
@@ -123,12 +125,12 @@ impl IdksPta {
             .to_owned_slice(ta_data_size)
             .ok_or(TeeResult::BadParameters)?
         };
-        let mut endorsement = build_endorsement_data(&ta_data, &task.ta_app_id, task.ta_svn)
-            .ok_or(TeeResult::BadParameters)?;
+        let mut endorsement =
+            build_endorsement_data(&ta_data, &task.ta_app_id, task.ta_svn, &task.ta_digest)
+                .ok_or(TeeResult::BadParameters)?;
         let key_pair = get_identity_signing_key_pair().map_err(|_| TeeResult::GenericError)?;
-        let signature =
-            endorse_data_with(&endorsement, &key_pair.private_key)
-                .map_err(|_| TeeResult::GenericError)?;
+        let signature = endorse_data_with(&endorsement, &key_pair.private_key)
+            .map_err(|_| TeeResult::GenericError)?;
         endorsement.extend_from_slice(&signature);
         UserMutPtr::<u8>::from_usize(
             usize::try_from(endorsement_addr).map_err(|_| TeeResult::BadParameters)?,
@@ -141,8 +143,13 @@ impl IdksPta {
     }
 }
 
-fn build_endorsement_data(ta_data: &[u8], ta_uuid: &TeeUuid, ta_svn: u32) -> Option<Vec<u8>> {
-    // MAGIC || VERSION || TA_DATA || TA_UUID || TA_SVN || DEBUG || ISOLATION_SOLUTION
+fn build_endorsement_data(
+    ta_data: &[u8],
+    ta_uuid: &TeeUuid,
+    ta_svn: u32,
+    ta_digest: &TaDigest,
+) -> Option<Vec<u8>> {
+    // MAGIC || VERSION || TA_DATA || TA_UUID || TA_SVN || TA_DIGEST || DEBUG || ISOLATION_SOLUTION
     let capacity = ta_data.len().checked_add(IDKS_ENDORSEMENT_METADATA_LEN)?;
     let mut endorsement = Vec::with_capacity(capacity);
     endorsement.extend_from_slice(IDKS_ENDORSEMENT_MAGIC);
@@ -150,6 +157,7 @@ fn build_endorsement_data(ta_data: &[u8], ta_uuid: &TeeUuid, ta_svn: u32) -> Opt
     endorsement.extend_from_slice(ta_data);
     endorsement.extend_from_slice(&ta_uuid.to_le_bytes());
     endorsement.extend_from_slice(&ta_svn.to_le_bytes());
+    endorsement.extend_from_slice(ta_digest);
     endorsement.push(IDKS_DEBUG_FLAG);
     endorsement.extend_from_slice(ISOLATION_SOLUTION);
     Some(endorsement)
@@ -313,7 +321,13 @@ mod tests {
         };
 
         let ta_svn = 7u32;
-        let expected_plaintext = build_endorsement_data(ta_data, &ta_uuid, ta_svn).unwrap();
+        let ta_digest = [
+            0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd,
+            0xee, 0xff, 0xf0, 0xe1, 0xd2, 0xc3, 0xb4, 0xa5, 0x96, 0x87, 0x78, 0x69, 0x5a, 0x4b,
+            0x3c, 0x2d, 0x1e, 0x0f,
+        ];
+        let expected_plaintext =
+            build_endorsement_data(ta_data, &ta_uuid, ta_svn, &ta_digest).unwrap();
 
         let signature = endorse_data_with(&expected_plaintext, &private_key).unwrap();
         let public_key = identity_signing_public_key_from_private_key(&private_key).unwrap();
@@ -323,15 +337,5 @@ mod tests {
         verifying_key
             .verify(&expected_plaintext, &signature)
             .unwrap();
-        let other_uuid = TeeUuid {
-            time_low: ta_uuid.time_low.wrapping_add(1),
-            ..ta_uuid
-        };
-        let mut other_plaintext = Vec::from(ta_data.as_slice());
-        other_plaintext.extend_from_slice(&other_uuid.to_le_bytes());
-        other_plaintext.extend_from_slice(&ta_svn.to_le_bytes());
-        other_plaintext.extend_from_slice(ISOLATION_SOLUTION);
-
-        assert!(verifying_key.verify(&other_plaintext, &signature).is_err());
     }
 }

--- a/litebox_shim_optee/src/lib.rs
+++ b/litebox_shim_optee/src/lib.rs
@@ -36,7 +36,6 @@ pub(crate) mod syscalls;
 
 pub mod msg_handler;
 
-#[cfg(feature = "platform_lvbs")]
 pub mod idk;
 
 // Re-export session management types for convenience
@@ -265,6 +264,8 @@ impl OpteeShim {
                 global: self.0.clone(),
                 thread: ThreadState::new(),
                 ta_app_id: ta_uuid,
+                // TODO: Populate this from trusted TA version metadata when available.
+                ta_svn: 0,
                 tee_cryp_state_map: TeeCrypStateMap::new(),
                 tee_obj_map: TeeObjMap::new(),
                 ta_handle_map: TaHandleMap::new(),
@@ -1376,6 +1377,8 @@ struct Task {
     thread: ThreadState,
     /// TA UUID
     ta_app_id: TeeUuid,
+    /// TA security version number
+    ta_svn: u32,
     /// TEE cryptography state map
     tee_cryp_state_map: TeeCrypStateMap,
     /// TEE object map
@@ -1550,6 +1553,7 @@ mod test_utils {
                 global: self.clone(),
                 thread: ThreadState::new(),
                 ta_app_id: TeeUuid::default(),
+                ta_svn: 0,
                 tee_cryp_state_map: TeeCrypStateMap::new(),
                 tee_obj_map: TeeObjMap::new(),
                 ta_handle_map: TaHandleMap::new(),

--- a/litebox_shim_optee/src/lib.rs
+++ b/litebox_shim_optee/src/lib.rs
@@ -29,6 +29,7 @@ use litebox_common_optee::{
     TeeObjectInfo, TeeObjectType, TeeOperationMode, TeeResult, TeeUuid, UteeAttribute,
 };
 use litebox_platform_multiplex::Platform;
+use sha2::{Digest, Sha256};
 
 pub mod loader;
 pub mod session;
@@ -42,6 +43,8 @@ pub mod idk;
 pub use session::{OpenSessionTarget, SessionManager, SessionToken, TaInstance};
 
 const MAX_KERNEL_BUF_SIZE: usize = 0x80_000;
+pub(crate) const TA_DIGEST_LEN: usize = 32;
+pub(crate) type TaDigest = [u8; TA_DIGEST_LEN];
 
 pub struct OpteeShimEntrypoints {
     task: Task,
@@ -202,11 +205,6 @@ impl GlobalState {
         }
     }
 
-    /// Get the TA flags associated with the given TA UUID.
-    pub(crate) fn get_ta_flags(&self, ta_uuid: &TeeUuid) -> TaFlags {
-        self.ta_uuid_map.get_flags(ta_uuid).unwrap_or_default()
-    }
-
     /// Monotonic time elapsed since this instance was created, used as GP
     /// "system time" (`TEE_GetSystemTime`).
     ///
@@ -258,6 +256,16 @@ impl OpteeShim {
         ta_uuid: TeeUuid,
         ta_bin: Option<&[u8]>,
     ) -> Result<LoadedProgram, loader::elf::ElfLoaderError> {
+        if let Some(ta_bin) = ta_bin
+            && !self.0.store_ta_bin(&ta_uuid, ta_bin)
+        {
+            return Err(loader::elf::ElfLoaderError::InvalidUuid);
+        }
+        let (ta_flags, ta_digest) = self
+            .0
+            .ta_uuid_map
+            .get_metadata(&ta_uuid)
+            .ok_or(loader::elf::ElfLoaderError::OpenError(Errno::ENOENT))?;
         let entrypoints = crate::OpteeShimEntrypoints {
             _not_send: core::marker::PhantomData,
             task: Task {
@@ -266,6 +274,7 @@ impl OpteeShim {
                 ta_app_id: ta_uuid,
                 // TODO: Populate this from trusted TA version metadata when available.
                 ta_svn: 0,
+                ta_digest,
                 tee_cryp_state_map: TeeCrypStateMap::new(),
                 tee_obj_map: TeeObjMap::new(),
                 ta_handle_map: TaHandleMap::new(),
@@ -277,11 +286,6 @@ impl OpteeShim {
                 tls_base_addr: Cell::new(0),
             },
         };
-        if let Some(ta_bin) = ta_bin
-            && !entrypoints.task.global.store_ta_bin(&ta_uuid, ta_bin)
-        {
-            return Err(loader::elf::ElfLoaderError::InvalidUuid);
-        }
         let elf_loader = loader::elf::ElfLoader::new(&entrypoints.task, ldelf_bin, true)?;
         entrypoints.task.load_ldelf(elf_loader, ta_uuid)?;
         let params_address = if entrypoints.task.get_ta_stack_base_addr().is_some() {
@@ -296,8 +300,6 @@ impl OpteeShim {
         } else {
             None
         };
-        // Get TA flags from the stored binary
-        let ta_flags = entrypoints.task.global.get_ta_flags(&ta_uuid);
         Ok(LoadedProgram {
             entrypoints: Some(entrypoints),
             params_address,
@@ -1318,6 +1320,8 @@ struct TaInfo {
     binary: alloc::boxed::Box<[u8]>,
     /// Parsed TA flags from .ta_head section
     flags: TaFlags,
+    /// SHA-256 digest of the raw TA binary
+    digest: TaDigest,
 }
 
 /// Data structure to maintain a mapping from TA UUIDs to their binary data and flags.
@@ -1343,12 +1347,14 @@ impl TaUuidMap {
             return false;
         }
 
+        let digest = Sha256::digest(&ta_bin).into();
         let mut inner = self.inner.lock();
         inner.insert(
             uuid,
             TaInfo {
                 binary: ta_bin,
                 flags: ta_head.flags,
+                digest,
             },
         );
         true
@@ -1358,9 +1364,11 @@ impl TaUuidMap {
         self.inner.lock().get(uuid).map(|info| info.binary.clone())
     }
 
-    /// Get the TA flags for a given UUID.
-    pub(crate) fn get_flags(&self, uuid: &TeeUuid) -> Option<TaFlags> {
-        self.inner.lock().get(uuid).map(|info| info.flags)
+    fn get_metadata(&self, uuid: &TeeUuid) -> Option<(TaFlags, TaDigest)> {
+        self.inner
+            .lock()
+            .get(uuid)
+            .map(|info| (info.flags, info.digest))
     }
 
     // Lazy removal of TA binaries when they are no longer needed.
@@ -1379,6 +1387,8 @@ struct Task {
     ta_app_id: TeeUuid,
     /// TA security version number
     ta_svn: u32,
+    /// SHA-256 digest of the raw TA binary.
+    ta_digest: TaDigest,
     /// TEE cryptography state map
     tee_cryp_state_map: TeeCrypStateMap,
     /// TEE object map
@@ -1554,6 +1564,7 @@ mod test_utils {
                 thread: ThreadState::new(),
                 ta_app_id: TeeUuid::default(),
                 ta_svn: 0,
+                ta_digest: [0; TA_DIGEST_LEN],
                 tee_cryp_state_map: TeeCrypStateMap::new(),
                 tee_obj_map: TeeObjMap::new(),
                 ta_handle_map: TaHandleMap::new(),

--- a/litebox_shim_optee/src/syscalls/ldelf.rs
+++ b/litebox_shim_optee/src/syscalls/ldelf.rs
@@ -168,7 +168,7 @@ impl Task {
             "sys_open_bin"
         );
 
-        if self.global.get_ta_bin(&ta_uuid).is_none() {
+        if ta_uuid != self.ta_app_id && self.global.get_ta_bin(&ta_uuid).is_none() {
             return Err(TeeResult::ItemNotFound);
         }
         let new_handle = self.ta_handle_map.insert(ta_uuid);
@@ -398,15 +398,11 @@ impl Task {
         offset: usize,
         count: usize,
     ) -> Option<()> {
-        if let Some(ta_uuid) = self.ta_handle_map.get(handle)
-            && let Some(ta_bin) = self.global.get_ta_bin(&ta_uuid)
-        {
+        if let Some(ta_uuid) = self.ta_handle_map.get(handle) {
             let end_offset = offset.checked_add(count)?;
-            if end_offset <= ta_bin.len() {
-                dst.copy_from_slice(0, &ta_bin[offset..end_offset])
-            } else {
-                None
-            }
+            let ta_bin = self.global.get_ta_bin(&ta_uuid)?;
+            (end_offset <= ta_bin.len())
+                .then(|| dst.copy_from_slice(0, &ta_bin[offset..end_offset]))?
         } else {
             None
         }

--- a/litebox_shim_optee/src/syscalls/pta.rs
+++ b/litebox_shim_optee/src/syscalls/pta.rs
@@ -14,8 +14,8 @@ use litebox::platform::{
 };
 use litebox::utils::TruncateExt;
 use litebox_common_optee::{
-    HUK_SUBKEY_MAX_LEN, HukSubkeyUsage, LdelfMapFlags, PTA_DEFAULT_FLAGS, TaFlags, TeeParamType,
-    TeeResult, TeeUuid, UteeParams,
+    HUK_SUBKEY_MAX_LEN, HukSubkeyUsage, LdelfMapFlags, TaFlags, TeeParamType, TeeResult, TeeUuid,
+    UteeParams,
 };
 use num_enum::TryFromPrimitive;
 use sha2::Sha256;
@@ -75,6 +75,10 @@ impl PseudoTa {
         }
     }
 }
+
+pub(crate) const PTA_DEFAULT_FLAGS: TaFlags = TaFlags::SINGLE_INSTANCE
+    .union(TaFlags::MULTI_SESSION)
+    .union(TaFlags::INSTANCE_KEEP_ALIVE);
 
 const MAX_PTA_SESSIONS_PER_TASK: usize = 100;
 

--- a/litebox_shim_optee/src/syscalls/pta.rs
+++ b/litebox_shim_optee/src/syscalls/pta.rs
@@ -4,8 +4,7 @@
 //! Implementation of pseudo TAs (PTAs) which export system services as
 //! the functions of built-in TAs.
 
-use crate::syscalls::Cleanup;
-use crate::{Task, UserConstPtr, UserMutPtr};
+use crate::{Task, UserConstPtr, UserMutPtr, idk::IdksPta, syscalls::Cleanup};
 use alloc::vec;
 use alloc::vec::Vec;
 use hmac::{Hmac, Mac};
@@ -15,27 +14,28 @@ use litebox::platform::{
 };
 use litebox::utils::TruncateExt;
 use litebox_common_optee::{
-    HUK_SUBKEY_MAX_LEN, HukSubkeyUsage, LdelfMapFlags, TaFlags, TeeParamType, TeeResult, TeeUuid,
-    UteeParams,
+    HUK_SUBKEY_MAX_LEN, HukSubkeyUsage, LdelfMapFlags, PTA_DEFAULT_FLAGS, TaFlags, TeeParamType,
+    TeeResult, TeeUuid, UteeParams,
 };
 use num_enum::TryFromPrimitive;
 use sha2::Sha256;
 use zeroize::{Zeroize, Zeroizing};
 
 struct SystemPta;
-
 /// A common interface to interact with various PTAs including the system PTA.
 ///
 /// Add new PTAs here as needed.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub(crate) enum PseudoTa {
     System,
+    Idks,
 }
 
 impl PseudoTa {
     pub(crate) fn from_uuid(uuid: &TeeUuid) -> Option<Self> {
         match *uuid {
             SystemPta::UUID => Some(Self::System),
+            IdksPta::UUID => Some(Self::Idks),
             _ => None,
         }
     }
@@ -44,6 +44,7 @@ impl PseudoTa {
     fn open_session(self, params: &UteeParams) -> Result<u32, TeeResult> {
         match self {
             Self::System => SystemPta::open_session(params),
+            Self::Idks => IdksPta::open_session(params),
         }
     }
 
@@ -56,27 +57,39 @@ impl PseudoTa {
         let _busy = task.try_set_busy(self)?;
         match self {
             Self::System => SystemPta::invoke_command(task, cmd_id, params),
+            Self::Idks => IdksPta::invoke_command(task, cmd_id, params),
         }
     }
 
     fn close_session(self, task: &Task, session_id: u32) {
         match self {
             Self::System => SystemPta::close_session(task, session_id),
+            Self::Idks => IdksPta::close_session(task, session_id),
         }
     }
 
     fn flags(self) -> TaFlags {
         match self {
             Self::System => SystemPta::FLAGS,
+            Self::Idks => IdksPta::FLAGS,
         }
     }
 }
 
-const PTA_DEFAULT_FLAGS: TaFlags = TaFlags::SINGLE_INSTANCE
-    .union(TaFlags::MULTI_SESSION)
-    .union(TaFlags::INSTANCE_KEEP_ALIVE);
-
 const MAX_PTA_SESSIONS_PER_TASK: usize = 100;
+
+pub(crate) fn open_default_pta_session(params: &UteeParams) -> Result<u32, TeeResult> {
+    if !params.has_types([
+        TeeParamType::None,
+        TeeParamType::None,
+        TeeParamType::None,
+        TeeParamType::None,
+    ]) {
+        return Err(TeeResult::BadParameters);
+    }
+
+    crate::SessionIdPool::allocate().ok_or(TeeResult::Busy)
+}
 
 struct PtaBusyGuard<'a> {
     task: &'a Task,
@@ -221,16 +234,7 @@ impl SystemPta {
     };
 
     fn open_session(params: &UteeParams) -> Result<u32, TeeResult> {
-        if !params.has_types([
-            TeeParamType::None,
-            TeeParamType::None,
-            TeeParamType::None,
-            TeeParamType::None,
-        ]) {
-            return Err(TeeResult::BadParameters);
-        }
-
-        crate::SessionIdPool::allocate().ok_or(TeeResult::Busy)
+        open_default_pta_session(params)
     }
 
     fn close_session(_task: &Task, _session_id: u32) {


### PR DESCRIPTION
This PR introduces the IDK_S PTA. It provides one method which endorses TA-provided data with a flat structure signed by an IDK_S key. A wire format is `MAGIC || VERSION || TA_DATA_LEN || TA_DATA || TA_UUID || TA_SVN || TA_DIGEST || TA_DYNAMIC || DEBUG || ISOLATION_SOLUTION || TA_SIGNING_CERT_LEN || TA_SIGNING_CERT_DER || SIGNATURE`, where `SIGNATURE` covers all preceding bytes, and integers are UUID are little-endian.