### PR TITLE
Add broker-backed pipes

### DIFF
--- a/litebox/src/broker/error.rs
+++ b/litebox/src/broker/error.rs
@@ -34,6 +34,8 @@ pub(crate) enum BrokerObjectError {
     ResourceExhausted,
     #[error("broker object permission denied")]
     PermissionDenied,
+    #[error("broker memory allocation failed")]
+    OutOfMemory,
 }
 
 impl From<BrokerControlError> for BrokerObjectError {
@@ -53,6 +55,7 @@ impl From<ErrorCode> for BrokerObjectError {
             ErrorCode::PeerClosed => Self::PeerClosed,
             ErrorCode::ResourceExhausted => Self::ResourceExhausted,
             ErrorCode::PolicyDenied => Self::PermissionDenied,
+            ErrorCode::OutOfMemory => Self::OutOfMemory,
             ErrorCode::UnsupportedVersion
             | ErrorCode::MalformedRequest
             | ErrorCode::ProtocolState
@@ -76,7 +79,6 @@ impl From<BrokerObjectError> for TryOpError<EventCounterError> {
     fn from(error: BrokerObjectError) -> Self {
         match error {
             BrokerObjectError::WouldBlock => Self::TryAgain,
-            BrokerObjectError::PeerClosed => Self::Other(EventCounterError::Io),
             error => Self::Other(error.into()),
         }
     }
@@ -86,7 +88,9 @@ impl From<BrokerObjectError> for EventCounterError {
     fn from(error: BrokerObjectError) -> Self {
         match error {
             BrokerObjectError::WouldBlock => Self::WouldBlock,
-            BrokerObjectError::ResourceExhausted => Self::ResourceExhausted,
+            BrokerObjectError::ResourceExhausted | BrokerObjectError::OutOfMemory => {
+                Self::ResourceExhausted
+            }
             BrokerObjectError::PermissionDenied => Self::PermissionDenied,
             BrokerObjectError::Control
             | BrokerObjectError::InvalidObject

--- a/litebox/src/broker/error.rs
+++ b/litebox/src/broker/error.rs
@@ -28,6 +28,8 @@ pub(crate) enum BrokerObjectError {
     InvalidObject,
     #[error("broker object operation would block")]
     WouldBlock,
+    #[error("broker object peer is closed")]
+    PeerClosed,
     #[error("broker object resource exhausted")]
     ResourceExhausted,
     #[error("broker object permission denied")]
@@ -48,6 +50,7 @@ impl From<ErrorCode> for BrokerObjectError {
         match error {
             ErrorCode::InvalidRights | ErrorCode::UnknownObject => Self::InvalidObject,
             ErrorCode::WouldBlock => Self::WouldBlock,
+            ErrorCode::PeerClosed => Self::PeerClosed,
             ErrorCode::ResourceExhausted => Self::ResourceExhausted,
             ErrorCode::PolicyDenied => Self::PermissionDenied,
             ErrorCode::UnsupportedVersion
@@ -73,6 +76,7 @@ impl From<BrokerObjectError> for TryOpError<EventCounterError> {
     fn from(error: BrokerObjectError) -> Self {
         match error {
             BrokerObjectError::WouldBlock => Self::TryAgain,
+            BrokerObjectError::PeerClosed => Self::Other(EventCounterError::Io),
             error => Self::Other(error.into()),
         }
     }
@@ -84,7 +88,9 @@ impl From<BrokerObjectError> for EventCounterError {
             BrokerObjectError::WouldBlock => Self::WouldBlock,
             BrokerObjectError::ResourceExhausted => Self::ResourceExhausted,
             BrokerObjectError::PermissionDenied => Self::PermissionDenied,
-            BrokerObjectError::Control | BrokerObjectError::InvalidObject => Self::Io,
+            BrokerObjectError::Control
+            | BrokerObjectError::InvalidObject
+            | BrokerObjectError::PeerClosed => Self::Io,
         }
     }
 }

--- a/litebox/src/broker/mod.rs
+++ b/litebox/src/broker/mod.rs
@@ -11,6 +11,7 @@ use litebox_broker_local::BrokerLocal;
 use litebox_broker_protocol::ObjectHandle;
 use litebox_broker_protocol::channel::LocalControlChannel;
 use litebox_broker_protocol::event::{ConsumeEventResponse, EventConsumeMode, ReadinessState};
+use litebox_broker_protocol::pipe::{CreatePipeResponse, PipeEndpoint, PipeReadinessState};
 
 use crate::event::{Events, polling::Pollee};
 use crate::platform::TimeProvider;
@@ -51,6 +52,29 @@ pub(crate) trait BrokerControl: Send + Sync {
         mode: EventConsumeMode,
     ) -> core::result::Result<ConsumeEventResponse, BrokerControlError>;
 
+    fn create_pipe(
+        &self,
+        capacity: u64,
+        atomic_write_size: u64,
+    ) -> core::result::Result<CreatePipeResponse, BrokerControlError>;
+
+    fn read_pipe(
+        &self,
+        handle: ObjectHandle,
+        length: u32,
+    ) -> core::result::Result<Vec<u8>, BrokerControlError>;
+
+    fn write_pipe(
+        &self,
+        handle: ObjectHandle,
+        data: &[u8],
+    ) -> core::result::Result<usize, BrokerControlError>;
+
+    fn check_pipe_readiness(
+        &self,
+        handle: ObjectHandle,
+    ) -> core::result::Result<PipeReadinessState, BrokerControlError>;
+
     fn close_object(&self, handle: ObjectHandle) -> core::result::Result<(), BrokerControlError>;
 }
 
@@ -87,16 +111,6 @@ impl<Platform: RawSyncPrimitivesProvider> BrokerHandleRegistry<Platform> {
     where
         Platform: TimeProvider,
     {
-        let mut handles = self.handles.lock();
-        let Some(entry) = handles.get_mut(&handle) else {
-            return;
-        };
-        entry.prune_stale_pollables();
-        if entry.is_empty() {
-            handles.remove(&handle);
-            return;
-        }
-
         let mut events = Events::empty();
         if readiness.read_ready {
             events |= Events::IN;
@@ -104,7 +118,42 @@ impl<Platform: RawSyncPrimitivesProvider> BrokerHandleRegistry<Platform> {
         if readiness.write_ready {
             events |= Events::OUT;
         }
-        if !events.is_empty() {
+        self.notify_events(handle, events);
+    }
+
+    pub(crate) fn notify_pipe_readiness(&self, handle: ObjectHandle, readiness: PipeReadinessState)
+    where
+        Platform: TimeProvider,
+    {
+        let mut events = Events::empty();
+        match readiness.endpoint {
+            PipeEndpoint::Read => {
+                events.set(Events::IN, readiness.ready);
+                events.set(Events::HUP, readiness.peer_closed);
+            }
+            PipeEndpoint::Write => {
+                events.set(Events::OUT, readiness.ready);
+                events.set(Events::ERR, readiness.peer_closed);
+            }
+        }
+        self.notify_events(handle, events);
+    }
+
+    fn notify_events(&self, handle: ObjectHandle, events: Events)
+    where
+        Platform: TimeProvider,
+    {
+        if events.is_empty() {
+            return;
+        }
+        let mut handles = self.handles.lock();
+        let Some(entry) = handles.get_mut(&handle) else {
+            return;
+        };
+        entry.prune_stale_pollables();
+        if entry.is_empty() {
+            handles.remove(&handle);
+        } else {
             entry.notify_pollables(events);
         }
     }
@@ -205,6 +254,37 @@ where
         mode: EventConsumeMode,
     ) -> core::result::Result<ConsumeEventResponse, BrokerControlError> {
         Ok(self.local.lock().consume_event(handle, mode)?)
+    }
+
+    fn create_pipe(
+        &self,
+        capacity: u64,
+        atomic_write_size: u64,
+    ) -> core::result::Result<CreatePipeResponse, BrokerControlError> {
+        Ok(self.local.lock().create_pipe(capacity, atomic_write_size)?)
+    }
+
+    fn read_pipe(
+        &self,
+        handle: ObjectHandle,
+        length: u32,
+    ) -> core::result::Result<Vec<u8>, BrokerControlError> {
+        Ok(self.local.lock().read_pipe(handle, length)?)
+    }
+
+    fn write_pipe(
+        &self,
+        handle: ObjectHandle,
+        data: &[u8],
+    ) -> core::result::Result<usize, BrokerControlError> {
+        Ok(self.local.lock().write_pipe(handle, data)?)
+    }
+
+    fn check_pipe_readiness(
+        &self,
+        handle: ObjectHandle,
+    ) -> core::result::Result<PipeReadinessState, BrokerControlError> {
+        Ok(self.local.lock().check_pipe_readiness(handle)?)
     }
 
     fn close_object(&self, handle: ObjectHandle) -> core::result::Result<(), BrokerControlError> {

--- a/litebox/src/broker/mod.rs
+++ b/litebox/src/broker/mod.rs
@@ -10,8 +10,8 @@ use hashbrown::HashMap;
 use litebox_broker_local::BrokerLocal;
 use litebox_broker_protocol::ObjectHandle;
 use litebox_broker_protocol::channel::LocalControlChannel;
-use litebox_broker_protocol::event::{ConsumeEventResponse, EventConsumeMode, ReadinessState};
-use litebox_broker_protocol::pipe::{CreatePipeResponse, PipeReadinessState};
+use litebox_broker_protocol::event::{ConsumeEventResponse, EventConsumeMode};
+use litebox_broker_protocol::pipe::CreatePipeResponse;
 use litebox_broker_protocol::readiness::ReadinessFlags;
 
 use crate::event::{Events, polling::Pollee};
@@ -39,13 +39,13 @@ pub(crate) trait BrokerControl: Send + Sync {
     fn wait_event(
         &self,
         handle: ObjectHandle,
-    ) -> core::result::Result<ReadinessState, BrokerControlError>;
+    ) -> core::result::Result<ReadinessFlags, BrokerControlError>;
 
     fn add_event(
         &self,
         handle: ObjectHandle,
         value: u64,
-    ) -> core::result::Result<ReadinessState, BrokerControlError>;
+    ) -> core::result::Result<ReadinessFlags, BrokerControlError>;
 
     fn consume_event(
         &self,
@@ -74,7 +74,7 @@ pub(crate) trait BrokerControl: Send + Sync {
     fn check_pipe_readiness(
         &self,
         handle: ObjectHandle,
-    ) -> core::result::Result<PipeReadinessState, BrokerControlError>;
+    ) -> core::result::Result<ReadinessFlags, BrokerControlError>;
 
     fn close_object(&self, handle: ObjectHandle) -> core::result::Result<(), BrokerControlError>;
 }
@@ -112,18 +112,7 @@ impl<Platform: RawSyncPrimitivesProvider> BrokerHandleRegistry<Platform> {
     where
         Platform: TimeProvider,
     {
-        let mut events = Events::empty();
-        events.set(Events::IN, readiness.contains(ReadinessFlags::READ));
-        events.set(Events::OUT, readiness.contains(ReadinessFlags::WRITE));
-        events.set(Events::HUP, readiness.contains(ReadinessFlags::HANGUP));
-        events.set(Events::ERR, readiness.contains(ReadinessFlags::ERROR));
-        self.notify_events(handle, events);
-    }
-
-    fn notify_events(&self, handle: ObjectHandle, events: Events)
-    where
-        Platform: TimeProvider,
-    {
+        let events = readiness_events(readiness);
         if events.is_empty() {
             return;
         }
@@ -217,7 +206,7 @@ where
     fn wait_event(
         &self,
         handle: ObjectHandle,
-    ) -> core::result::Result<ReadinessState, BrokerControlError> {
+    ) -> core::result::Result<ReadinessFlags, BrokerControlError> {
         Ok(self.local.lock().wait_event(handle)?)
     }
 
@@ -225,7 +214,7 @@ where
         &self,
         handle: ObjectHandle,
         value: u64,
-    ) -> core::result::Result<ReadinessState, BrokerControlError> {
+    ) -> core::result::Result<ReadinessFlags, BrokerControlError> {
         Ok(self.local.lock().add_event(handle, value)?)
     }
 
@@ -264,11 +253,20 @@ where
     fn check_pipe_readiness(
         &self,
         handle: ObjectHandle,
-    ) -> core::result::Result<PipeReadinessState, BrokerControlError> {
+    ) -> core::result::Result<ReadinessFlags, BrokerControlError> {
         Ok(self.local.lock().check_pipe_readiness(handle)?)
     }
 
     fn close_object(&self, handle: ObjectHandle) -> core::result::Result<(), BrokerControlError> {
         Ok(self.local.lock().close_object(handle)?)
     }
+}
+
+pub(crate) fn readiness_events(readiness: ReadinessFlags) -> Events {
+    let mut events = Events::empty();
+    events.set(Events::IN, readiness.0 & ReadinessFlags::READ.0 != 0);
+    events.set(Events::OUT, readiness.0 & ReadinessFlags::WRITE.0 != 0);
+    events.set(Events::HUP, readiness.0 & ReadinessFlags::HANGUP.0 != 0);
+    events.set(Events::ERR, readiness.0 & ReadinessFlags::ERROR.0 != 0);
+    events
 }

--- a/litebox/src/broker/mod.rs
+++ b/litebox/src/broker/mod.rs
@@ -11,8 +11,8 @@ use litebox_broker_local::BrokerLocal;
 use litebox_broker_protocol::ObjectHandle;
 use litebox_broker_protocol::channel::LocalControlChannel;
 use litebox_broker_protocol::event::{ConsumeEventResponse, EventConsumeMode, ReadinessState};
-use litebox_broker_protocol::message::ReadinessFlags;
 use litebox_broker_protocol::pipe::{CreatePipeResponse, PipeReadinessState};
+use litebox_broker_protocol::readiness::ReadinessFlags;
 
 use crate::event::{Events, polling::Pollee};
 use crate::platform::TimeProvider;

--- a/litebox/src/broker/mod.rs
+++ b/litebox/src/broker/mod.rs
@@ -5,6 +5,7 @@ use alloc::{
     sync::{Arc, Weak},
     vec::Vec,
 };
+use core::sync::atomic::{AtomicBool, Ordering};
 
 use hashbrown::HashMap;
 use litebox_broker_local::BrokerLocal;
@@ -15,7 +16,6 @@ use litebox_broker_protocol::pipe::CreatePipeResponse;
 use litebox_broker_protocol::readiness::ReadinessFlags;
 
 use crate::event::{Events, polling::Pollee};
-use crate::platform::TimeProvider;
 use crate::sync::{Mutex, RawSyncPrimitivesProvider};
 
 pub(crate) mod error;
@@ -77,6 +77,8 @@ pub(crate) trait BrokerControl: Send + Sync {
     ) -> core::result::Result<ReadinessFlags, BrokerControlError>;
 
     fn close_object(&self, handle: ObjectHandle) -> core::result::Result<(), BrokerControlError>;
+
+    fn fail_connection(&self);
 }
 
 pub(crate) struct BrokerHandleRegistry<Platform: RawSyncPrimitivesProvider> {
@@ -108,23 +110,44 @@ impl<Platform: RawSyncPrimitivesProvider> BrokerHandleRegistry<Platform> {
         }
     }
 
-    pub(crate) fn notify_readiness(&self, handle: ObjectHandle, readiness: ReadinessFlags)
-    where
-        Platform: TimeProvider,
-    {
+    pub(crate) fn notify_readiness(&self, handle: ObjectHandle, readiness: ReadinessFlags) {
         let events = readiness_events(readiness);
         if events.is_empty() {
             return;
         }
-        let mut handles = self.handles.lock();
-        let Some(entry) = handles.get_mut(&handle) else {
-            return;
+        let pollables = {
+            let mut handles = self.handles.lock();
+            let Some(entry) = handles.get_mut(&handle) else {
+                return;
+            };
+            entry.prune_stale_pollables();
+            let pollables = entry
+                .pollables
+                .iter()
+                .filter_map(Weak::upgrade)
+                .collect::<Vec<_>>();
+            if entry.is_empty() {
+                handles.remove(&handle);
+            }
+            pollables
         };
-        entry.prune_stale_pollables();
-        if entry.is_empty() {
-            handles.remove(&handle);
-        } else {
-            entry.notify_pollables(events);
+        for pollee in pollables {
+            pollee.notify_observers(events);
+        }
+    }
+
+    fn notify_all(&self, events: Events) {
+        let pollables = {
+            let mut pollables = Vec::new();
+            self.handles.lock().retain(|_, entry| {
+                entry.prune_stale_pollables();
+                pollables.extend(entry.pollables.iter().filter_map(Weak::upgrade));
+                !entry.is_empty()
+            });
+            pollables
+        };
+        for pollee in pollables {
+            pollee.notify_observers(events);
         }
     }
 }
@@ -157,17 +180,6 @@ impl<Platform: RawSyncPrimitivesProvider> BrokerHandleEntry<Platform> {
             .retain(|registered| registered.strong_count() > 0);
     }
 
-    fn notify_pollables(&self, events: Events)
-    where
-        Platform: TimeProvider,
-    {
-        for registered in &self.pollables {
-            if let Some(pollee) = registered.upgrade() {
-                pollee.notify_observers(events);
-            }
-        }
-    }
-
     fn is_empty(&self) -> bool {
         self.pollables.is_empty()
     }
@@ -176,7 +188,9 @@ pub(crate) struct BrokerLocalControl<
     Platform: RawSyncPrimitivesProvider,
     Channel: LocalControlChannel + Send,
 > {
-    local: Mutex<Platform, BrokerLocal<Channel>>,
+    local: Mutex<Platform, Option<BrokerLocal<Channel>>>,
+    handles: Arc<BrokerHandleRegistry<Platform>>,
+    failed: AtomicBool,
 }
 
 impl<Platform, Channel> BrokerLocalControl<Platform, Channel>
@@ -184,9 +198,53 @@ where
     Platform: RawSyncPrimitivesProvider,
     Channel: LocalControlChannel + Send,
 {
-    pub(crate) const fn new(local: BrokerLocal<Channel>) -> Self {
+    pub(crate) fn new(
+        local: BrokerLocal<Channel>,
+        handles: Arc<BrokerHandleRegistry<Platform>>,
+    ) -> Self {
         Self {
-            local: Mutex::new(local),
+            local: Mutex::new(Some(local)),
+            handles,
+            failed: AtomicBool::new(false),
+        }
+    }
+
+    fn request<T>(
+        &self,
+        request: impl FnOnce(
+            &mut BrokerLocal<Channel>,
+        ) -> litebox_broker_local::Result<T, Channel::Error>,
+    ) -> core::result::Result<T, BrokerControlError> {
+        if self.failed.load(Ordering::Acquire) {
+            return Err(BrokerControlError::Transport);
+        }
+        let (result, notify_failure) = {
+            let mut local = self.local.lock();
+            if self.failed.load(Ordering::Acquire) {
+                return Err(BrokerControlError::Transport);
+            }
+            let result = request(
+                local
+                    .as_mut()
+                    .expect("active broker connection must retain its control channel"),
+            )
+            .map_err(BrokerControlError::from);
+            let notify_failure = matches!(result.as_ref(), Err(BrokerControlError::Transport))
+                && !self.failed.swap(true, Ordering::AcqRel);
+            if matches!(result.as_ref(), Err(BrokerControlError::Transport)) {
+                local.take();
+            }
+            (result, notify_failure)
+        };
+        if notify_failure {
+            self.handles.notify_all(Events::ERR);
+        }
+        result
+    }
+
+    fn mark_failed(&self) {
+        if !self.failed.swap(true, Ordering::AcqRel) {
+            self.handles.notify_all(Events::ERR);
         }
     }
 }
@@ -200,14 +258,14 @@ where
         &self,
         initial_count: u64,
     ) -> core::result::Result<ObjectHandle, BrokerControlError> {
-        Ok(self.local.lock().create_event_with_count(initial_count)?)
+        self.request(|local| local.create_event_with_count(initial_count))
     }
 
     fn wait_event(
         &self,
         handle: ObjectHandle,
     ) -> core::result::Result<ReadinessFlags, BrokerControlError> {
-        Ok(self.local.lock().wait_event(handle)?)
+        self.request(|local| local.wait_event(handle))
     }
 
     fn add_event(
@@ -215,7 +273,7 @@ where
         handle: ObjectHandle,
         value: u64,
     ) -> core::result::Result<ReadinessFlags, BrokerControlError> {
-        Ok(self.local.lock().add_event(handle, value)?)
+        self.request(|local| local.add_event(handle, value))
     }
 
     fn consume_event(
@@ -223,7 +281,7 @@ where
         handle: ObjectHandle,
         mode: EventConsumeMode,
     ) -> core::result::Result<ConsumeEventResponse, BrokerControlError> {
-        Ok(self.local.lock().consume_event(handle, mode)?)
+        self.request(|local| local.consume_event(handle, mode))
     }
 
     fn create_pipe(
@@ -231,7 +289,7 @@ where
         capacity: u64,
         atomic_write_size: u64,
     ) -> core::result::Result<CreatePipeResponse, BrokerControlError> {
-        Ok(self.local.lock().create_pipe(capacity, atomic_write_size)?)
+        self.request(|local| local.create_pipe(capacity, atomic_write_size))
     }
 
     fn read_pipe(
@@ -239,7 +297,7 @@ where
         handle: ObjectHandle,
         length: u32,
     ) -> core::result::Result<Vec<u8>, BrokerControlError> {
-        Ok(self.local.lock().read_pipe(handle, length)?)
+        self.request(|local| local.read_pipe(handle, length))
     }
 
     fn write_pipe(
@@ -247,18 +305,22 @@ where
         handle: ObjectHandle,
         data: &[u8],
     ) -> core::result::Result<usize, BrokerControlError> {
-        Ok(self.local.lock().write_pipe(handle, data)?)
+        self.request(|local| local.write_pipe(handle, data))
     }
 
     fn check_pipe_readiness(
         &self,
         handle: ObjectHandle,
     ) -> core::result::Result<ReadinessFlags, BrokerControlError> {
-        Ok(self.local.lock().check_pipe_readiness(handle)?)
+        self.request(|local| local.check_pipe_readiness(handle))
     }
 
     fn close_object(&self, handle: ObjectHandle) -> core::result::Result<(), BrokerControlError> {
-        Ok(self.local.lock().close_object(handle)?)
+        self.request(|local| local.close_object(handle))
+    }
+
+    fn fail_connection(&self) {
+        self.mark_failed();
     }
 }
 

--- a/litebox/src/broker/mod.rs
+++ b/litebox/src/broker/mod.rs
@@ -11,7 +11,8 @@ use litebox_broker_local::BrokerLocal;
 use litebox_broker_protocol::ObjectHandle;
 use litebox_broker_protocol::channel::LocalControlChannel;
 use litebox_broker_protocol::event::{ConsumeEventResponse, EventConsumeMode, ReadinessState};
-use litebox_broker_protocol::pipe::{CreatePipeResponse, PipeEndpoint, PipeReadinessState};
+use litebox_broker_protocol::message::ReadinessFlags;
+use litebox_broker_protocol::pipe::{CreatePipeResponse, PipeReadinessState};
 
 use crate::event::{Events, polling::Pollee};
 use crate::platform::TimeProvider;
@@ -107,35 +108,15 @@ impl<Platform: RawSyncPrimitivesProvider> BrokerHandleRegistry<Platform> {
         }
     }
 
-    pub(crate) fn notify_readiness(&self, handle: ObjectHandle, readiness: ReadinessState)
+    pub(crate) fn notify_readiness(&self, handle: ObjectHandle, readiness: ReadinessFlags)
     where
         Platform: TimeProvider,
     {
         let mut events = Events::empty();
-        if readiness.read_ready {
-            events |= Events::IN;
-        }
-        if readiness.write_ready {
-            events |= Events::OUT;
-        }
-        self.notify_events(handle, events);
-    }
-
-    pub(crate) fn notify_pipe_readiness(&self, handle: ObjectHandle, readiness: PipeReadinessState)
-    where
-        Platform: TimeProvider,
-    {
-        let mut events = Events::empty();
-        match readiness.endpoint {
-            PipeEndpoint::Read => {
-                events.set(Events::IN, readiness.ready);
-                events.set(Events::HUP, readiness.peer_closed);
-            }
-            PipeEndpoint::Write => {
-                events.set(Events::OUT, readiness.ready);
-                events.set(Events::ERR, readiness.peer_closed);
-            }
-        }
+        events.set(Events::IN, readiness.contains(ReadinessFlags::READ));
+        events.set(Events::OUT, readiness.contains(ReadinessFlags::WRITE));
+        events.set(Events::HUP, readiness.contains(ReadinessFlags::HANGUP));
+        events.set(Events::ERR, readiness.contains(ReadinessFlags::ERROR));
         self.notify_events(handle, events);
     }
 

--- a/litebox/src/event/counter.rs
+++ b/litebox/src/event/counter.rs
@@ -4,8 +4,9 @@
 use alloc::sync::Arc;
 
 use litebox_broker_protocol::ObjectHandle;
+use litebox_broker_protocol::event::ConsumeEventResponse;
 pub use litebox_broker_protocol::event::EventConsumeMode as EventCounterReadMode;
-use litebox_broker_protocol::event::{ConsumeEventResponse, ReadinessState};
+use litebox_broker_protocol::readiness::ReadinessFlags;
 use thiserror::Error;
 
 use crate::{
@@ -13,6 +14,7 @@ use crate::{
     broker::{
         BrokerControl, BrokerHandleRegistry,
         error::{BrokerControlError, BrokerObjectError},
+        readiness_events,
     },
     event::{
         Events, IOPollable, observer::Observer, polling::Pollee, polling::TryOpError,
@@ -86,7 +88,7 @@ where
     ) -> Result<u64, TryOpError<EventCounterError>> {
         self.pollee.wait(cx, nonblock, Events::IN, || {
             let response = self.consume(mode)?;
-            if response.readiness.write_ready {
+            if response.readiness.0 & ReadinessFlags::WRITE.0 != 0 {
                 self.pollee.notify_observers(Events::OUT);
             }
             Ok(response.value)
@@ -105,7 +107,7 @@ where
         }
         self.pollee.wait(cx, nonblock, Events::OUT, || {
             let readiness = self.add(value)?;
-            if value != 0 && readiness.read_ready {
+            if value != 0 && readiness.0 & ReadinessFlags::READ.0 != 0 {
                 self.pollee.notify_observers(Events::IN);
             }
             Ok(core::mem::size_of::<u64>())
@@ -121,7 +123,7 @@ where
             .map_err(|error| self.broker_request_error(error))
     }
 
-    fn add(&self, value: u64) -> Result<ReadinessState, BrokerObjectError> {
+    fn add(&self, value: u64) -> Result<ReadinessFlags, BrokerObjectError> {
         self.broker
             .add_event(self.handle, value)
             .map_err(|error| self.broker_request_error(error))
@@ -164,14 +166,7 @@ where
             Err(BrokerObjectError::WouldBlock) => return Events::empty(),
             Err(_) => return Events::ERR,
         };
-        let mut events = Events::empty();
-        if readiness.read_ready {
-            events |= Events::IN;
-        }
-        if readiness.write_ready {
-            events |= Events::OUT;
-        }
-        events
+        readiness_events(readiness)
     }
 }
 
@@ -185,7 +180,7 @@ mod tests {
     use litebox_broker_local::BrokerLocal;
     use litebox_broker_protocol::channel::LocalControlChannel;
     use litebox_broker_protocol::error::ErrorCode;
-    use litebox_broker_protocol::event::{CreateEventResponse, EventConsumption, ReadinessState};
+    use litebox_broker_protocol::event::{CreateEventResponse, EventConsumption};
     use litebox_broker_protocol::message::{
         BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerNotification, BrokerRequest,
         BrokerResponse, EventRequest, EventResponse, ReadinessNotification,
@@ -298,10 +293,7 @@ mod tests {
                     if self.read_ready.swap(false, Ordering::SeqCst) {
                         BrokerResponse::Event(EventResponse::Consume(EventConsumption {
                             value: 1,
-                            readiness: ReadinessState {
-                                read_ready: false,
-                                write_ready: true,
-                            },
+                            readiness: ReadinessFlags::WRITE,
                         }))
                     } else {
                         BrokerResponse::Error(ErrorCode::WouldBlock)

--- a/litebox/src/event/counter.rs
+++ b/litebox/src/event/counter.rs
@@ -188,8 +188,9 @@ mod tests {
     use litebox_broker_protocol::event::{CreateEventResponse, EventConsumption, ReadinessState};
     use litebox_broker_protocol::message::{
         BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerNotification, BrokerRequest,
-        BrokerResponse, EventRequest, EventResponse, ReadinessFlags, ReadinessNotification,
+        BrokerResponse, EventRequest, EventResponse, ReadinessNotification,
     };
+    use litebox_broker_protocol::readiness::ReadinessFlags;
 
     use super::*;
     use crate::LiteBox;

--- a/litebox/src/event/counter.rs
+++ b/litebox/src/event/counter.rs
@@ -188,7 +188,7 @@ mod tests {
     use litebox_broker_protocol::event::{CreateEventResponse, EventConsumption, ReadinessState};
     use litebox_broker_protocol::message::{
         BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerNotification, BrokerRequest,
-        BrokerResponse, EventReadinessNotification, EventRequest, EventResponse,
+        BrokerResponse, EventRequest, EventResponse, ReadinessFlags, ReadinessNotification,
     };
 
     use super::*;
@@ -234,13 +234,10 @@ mod tests {
             std::thread::yield_now();
         }
         read_ready.store(true, Ordering::SeqCst);
-        litebox.dispatch_broker_notification(BrokerNotification::EventReadiness(
-            EventReadinessNotification {
+        litebox.dispatch_broker_notification(BrokerNotification::Readiness(
+            ReadinessNotification {
                 handle,
-                readiness: ReadinessState {
-                    read_ready: true,
-                    write_ready: true,
-                },
+                events: ReadinessFlags::READ | ReadinessFlags::WRITE,
             },
         ));
 

--- a/litebox/src/event/polling.rs
+++ b/litebox/src/event/polling.rs
@@ -85,13 +85,13 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> WaitContext<'_, Platfor
     }
 }
 
-impl<Platform: RawSyncPrimitivesProvider + TimeProvider> Default for Pollee<Platform> {
+impl<Platform: RawSyncPrimitivesProvider> Default for Pollee<Platform> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<Platform: RawSyncPrimitivesProvider + TimeProvider> Pollee<Platform> {
+impl<Platform: RawSyncPrimitivesProvider> Pollee<Platform> {
     /// Create a new pollee.
     pub fn new() -> Self {
         Self {
@@ -114,7 +114,10 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> Pollee<Platform> {
         nonblock: bool,
         events: Events,
         try_op: impl FnMut() -> Result<R, TryOpError<E>>,
-    ) -> Result<R, TryOpError<E>> {
+    ) -> Result<R, TryOpError<E>>
+    where
+        Platform: TimeProvider,
+    {
         cx.wait_on_events(
             nonblock,
             events,

--- a/litebox/src/litebox.rs
+++ b/litebox/src/litebox.rs
@@ -12,7 +12,6 @@ use litebox_broker_protocol::message::BrokerNotification;
 use crate::{
     broker,
     fd::Descriptors,
-    platform::TimeProvider,
     sync::{RawSyncPrimitivesProvider, RwLock},
 };
 
@@ -36,7 +35,11 @@ impl<Platform: RawSyncPrimitivesProvider> LiteBox<Platform> {
     /// If the `enforce_singleton_litebox_instance` compilation feature has been enabled, and more
     /// than one instance is made, will panic.
     pub fn new(platform: &'static Platform) -> Self {
-        Self::new_inner(platform, None)
+        Self::new_inner(
+            platform,
+            None,
+            Arc::new(broker::BrokerHandleRegistry::new()),
+        )
     }
 
     /// Create a new [`LiteBox`] instance with a negotiated broker-local control adapter installed.
@@ -47,17 +50,18 @@ impl<Platform: RawSyncPrimitivesProvider> LiteBox<Platform> {
     where
         Channel: LocalControlChannel + Send + 'static,
     {
-        Self::new_inner(
-            platform,
-            Some(Arc::new(
-                broker::BrokerLocalControl::<Platform, Channel>::new(broker_local),
-            )),
-        )
+        let broker_handles = Arc::new(broker::BrokerHandleRegistry::new());
+        let broker_control = Arc::new(broker::BrokerLocalControl::<Platform, Channel>::new(
+            broker_local,
+            Arc::clone(&broker_handles),
+        ));
+        Self::new_inner(platform, Some(broker_control), broker_handles)
     }
 
     fn new_inner(
         platform: &'static Platform,
         broker_control: Option<Arc<dyn broker::BrokerControl>>,
+        broker_handles: Arc<broker::BrokerHandleRegistry<Platform>>,
     ) -> Self {
         // This check ensures that there is exactly one `LiteBox` instance in the process.
         //
@@ -102,7 +106,7 @@ impl<Platform: RawSyncPrimitivesProvider> LiteBox<Platform> {
                 platform,
                 descriptors,
                 broker: broker_control,
-                broker_handles: Arc::new(broker::BrokerHandleRegistry::new()),
+                broker_handles,
             }),
         }
     }
@@ -145,10 +149,7 @@ impl<Platform: RawSyncPrimitivesProvider> LiteBox<Platform> {
     }
 
     /// Dispatches one broker notification to the matching local-core object.
-    pub fn dispatch_broker_notification(&self, notification: BrokerNotification)
-    where
-        Platform: TimeProvider,
-    {
+    pub fn dispatch_broker_notification(&self, notification: BrokerNotification) {
         match notification {
             BrokerNotification::Readiness(notification) => self
                 .x
@@ -160,11 +161,21 @@ impl<Platform: RawSyncPrimitivesProvider> LiteBox<Platform> {
     /// Returns a narrow dispatcher for moving broker notification handling into deployment code.
     pub fn broker_notification_dispatcher(&self) -> impl Fn(BrokerNotification) + Send + 'static
     where
-        Platform: TimeProvider + 'static,
+        Platform: 'static,
     {
         let litebox = self.clone();
         move |notification| {
             litebox.dispatch_broker_notification(notification);
+        }
+    }
+
+    /// Returns a dispatcher that fails all broker-backed objects when the association closes.
+    pub fn broker_failure_dispatcher(&self) -> impl Fn() + Send + 'static {
+        let litebox = self.clone();
+        move || {
+            if let Some(broker) = &litebox.x.broker {
+                broker.fail_connection();
+            }
         }
     }
 }

--- a/litebox/src/litebox.rs
+++ b/litebox/src/litebox.rs
@@ -154,6 +154,10 @@ impl<Platform: RawSyncPrimitivesProvider> LiteBox<Platform> {
                 .x
                 .broker_handles
                 .notify_readiness(notification.handle, notification.readiness),
+            BrokerNotification::PipeReadiness(notification) => self
+                .x
+                .broker_handles
+                .notify_pipe_readiness(notification.handle, notification.readiness),
         }
     }
 

--- a/litebox/src/litebox.rs
+++ b/litebox/src/litebox.rs
@@ -150,14 +150,10 @@ impl<Platform: RawSyncPrimitivesProvider> LiteBox<Platform> {
         Platform: TimeProvider,
     {
         match notification {
-            BrokerNotification::EventReadiness(notification) => self
+            BrokerNotification::Readiness(notification) => self
                 .x
                 .broker_handles
-                .notify_readiness(notification.handle, notification.readiness),
-            BrokerNotification::PipeReadiness(notification) => self
-                .x
-                .broker_handles
-                .notify_pipe_readiness(notification.handle, notification.readiness),
+                .notify_readiness(notification.handle, notification.events),
         }
     }
 

--- a/litebox/src/pipes.rs
+++ b/litebox/src/pipes.rs
@@ -14,8 +14,7 @@ use core::{
 use alloc::sync::{Arc, Weak};
 use either::Either;
 use litebox_broker_protocol::{
-    ObjectHandle,
-    pipe::{MAX_PIPE_TRANSFER_SIZE, PipeEndpoint, PipeReadinessState},
+    ObjectHandle, pipe::MAX_PIPE_TRANSFER_SIZE, readiness::ReadinessFlags,
 };
 use ringbuf::{
     HeapCons, HeapProd, HeapRb,
@@ -28,6 +27,7 @@ use crate::{
     broker::{
         BrokerControl, BrokerHandleRegistry,
         error::{BrokerControlError, BrokerObjectError},
+        readiness_events,
     },
     event::{
         Events, IOPollable,
@@ -276,6 +276,8 @@ pub mod errors {
     pub enum CreateError {
         #[error("pipe resource exhausted")]
         ResourceExhausted,
+        #[error("pipe memory allocation failed")]
+        OutOfMemory,
         #[error("pipe permission denied")]
         PermissionDenied,
         #[error("pipe broker I/O failed")]
@@ -428,7 +430,7 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerPipeEnd<Platform>
                     let data = self
                         .broker
                         .read_pipe(self.handle, request_length)
-                        .map_err(broker_pipe_operation_error)?;
+                        .map_err(|error| self.broker_request_error(error))?;
                     if data.len() > length {
                         return Err(TryOpError::Other(PipeError::Io));
                     }
@@ -476,7 +478,7 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerPipeEnd<Platform>
         let written = self
             .broker
             .write_pipe(self.handle, data)
-            .map_err(broker_pipe_operation_error)?;
+            .map_err(|error| self.broker_request_error(error))?;
         if written > data.len() || (written == 0 && !data.is_empty()) {
             return Err(TryOpError::Other(PipeError::Io));
         }
@@ -488,7 +490,15 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerPipeEnd<Platform>
         Ok(written)
     }
 
-    fn readiness(&self) -> Result<PipeReadinessState, BrokerControlError> {
+    fn broker_request_error(&self, error: BrokerControlError) -> BrokerObjectError {
+        let error = error.into();
+        if error != BrokerObjectError::WouldBlock {
+            self.pollee.notify_observers(Events::ERR);
+        }
+        error
+    }
+
+    fn readiness(&self) -> Result<ReadinessFlags, BrokerControlError> {
         self.broker.check_pipe_readiness(self.handle)
     }
 }
@@ -500,7 +510,7 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> IOPollable for BrokerPi
 
     fn check_io_events(&self) -> Events {
         match self.readiness() {
-            Ok(readiness) => pipe_readiness_events(readiness),
+            Ok(readiness) => readiness_events(readiness),
             Err(_) => Events::ERR,
         }
     }
@@ -520,36 +530,25 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> Drop for BrokerPipeEnd<
     }
 }
 
-fn broker_pipe_operation_error(error: BrokerControlError) -> TryOpError<PipeError> {
-    match BrokerObjectError::from(error) {
-        BrokerObjectError::WouldBlock => TryOpError::TryAgain,
-        BrokerObjectError::PeerClosed => TryOpError::Other(PipeError::PeerShutdown),
-        BrokerObjectError::Control
-        | BrokerObjectError::InvalidObject
-        | BrokerObjectError::ResourceExhausted
-        | BrokerObjectError::PermissionDenied => TryOpError::Other(PipeError::Io),
-    }
-}
-
-fn pipe_readiness_events(readiness: PipeReadinessState) -> Events {
-    let mut events = Events::empty();
-    match readiness.endpoint {
-        PipeEndpoint::Read => {
-            events.set(Events::IN, readiness.ready);
-            events.set(Events::HUP, readiness.peer_closed);
-        }
-        PipeEndpoint::Write => {
-            events.set(Events::OUT, readiness.ready);
-            events.set(Events::ERR, readiness.peer_closed);
+impl From<BrokerObjectError> for TryOpError<PipeError> {
+    fn from(error: BrokerObjectError) -> Self {
+        match error {
+            BrokerObjectError::WouldBlock => TryOpError::TryAgain,
+            BrokerObjectError::PeerClosed => TryOpError::Other(PipeError::PeerShutdown),
+            BrokerObjectError::Control
+            | BrokerObjectError::InvalidObject
+            | BrokerObjectError::ResourceExhausted
+            | BrokerObjectError::PermissionDenied
+            | BrokerObjectError::OutOfMemory => TryOpError::Other(PipeError::Io),
         }
     }
-    events
 }
 
 impl From<BrokerObjectError> for errors::CreateError {
     fn from(error: BrokerObjectError) -> Self {
         match error {
             BrokerObjectError::ResourceExhausted => Self::ResourceExhausted,
+            BrokerObjectError::OutOfMemory => Self::OutOfMemory,
             BrokerObjectError::PermissionDenied => Self::PermissionDenied,
             BrokerObjectError::Control
             | BrokerObjectError::InvalidObject
@@ -912,12 +911,107 @@ fn new_pipe<Platform: RawSyncPrimitivesProvider + TimeProvider, T>(
 
 #[cfg(test)]
 mod tests {
+    use core::sync::atomic::{AtomicBool, Ordering};
+
+    use alloc::sync::Arc;
+    use litebox_broker_local::BrokerLocal;
+    use litebox_broker_protocol::channel::LocalControlChannel;
+    use litebox_broker_protocol::message::{
+        BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerRequest, BrokerResponse,
+        PipeRequest, PipeResponse,
+    };
+    use litebox_broker_protocol::pipe::CreatePipeResponse;
+    use litebox_broker_protocol::{BROKER_PROTOCOL_VERSION, ObjectHandle};
+
     use crate::{
-        event::wait::WaitState,
+        event::{Events, observer::Observer, wait::WaitState},
         pipes::errors::{ReadError, WriteError},
     };
 
     extern crate std;
+
+    #[test]
+    fn broker_error_notifies_pipe_observers() {
+        let platform = crate::platform::mock::MockPlatform::new();
+        let local = BrokerLocal::negotiate(FailingPipeChannel { last_request: None }).unwrap();
+        let litebox = crate::LiteBox::new_with_broker_local(platform, local);
+        let pipes = super::Pipes::new(&litebox);
+        let (_writer, reader) = pipes.create_pipe(2, super::Flags::empty(), None).unwrap();
+        let observer = Arc::new(ErrorObserver(AtomicBool::new(false)));
+        let observer_dyn: Arc<dyn Observer<Events>> = observer.clone();
+        pipes
+            .with_iopollable(&reader, |pollable| {
+                pollable.register_observer(Arc::downgrade(&observer_dyn), Events::ERR);
+            })
+            .unwrap();
+
+        let mut value = 0;
+        assert!(matches!(
+            pipes.read(
+                &WaitState::new(platform).context(),
+                &reader,
+                core::slice::from_mut(&mut value),
+            ),
+            Err(ReadError::Io)
+        ));
+        assert!(observer.0.load(Ordering::SeqCst));
+    }
+
+    struct ErrorObserver(AtomicBool);
+
+    impl Observer<Events> for ErrorObserver {
+        fn on_events(&self, events: &Events) {
+            if events.contains(Events::ERR) {
+                self.0.store(true, Ordering::SeqCst);
+            }
+        }
+    }
+
+    #[derive(Debug)]
+    struct FailingPipeChannel {
+        last_request: Option<BrokerRequest>,
+    }
+
+    impl LocalControlChannel for FailingPipeChannel {
+        type Error = ();
+
+        fn send_handshake_request(
+            &mut self,
+            _request: &BrokerHandshakeRequest,
+        ) -> core::result::Result<(), Self::Error> {
+            Ok(())
+        }
+
+        fn recv_handshake_response(
+            &mut self,
+        ) -> core::result::Result<Option<BrokerHandshakeResponse>, Self::Error> {
+            Ok(Some(BrokerHandshakeResponse::Negotiated {
+                broker_protocol_version: BROKER_PROTOCOL_VERSION,
+            }))
+        }
+
+        fn send_request(
+            &mut self,
+            request: &BrokerRequest,
+        ) -> core::result::Result<(), Self::Error> {
+            self.last_request = Some(request.clone());
+            Ok(())
+        }
+
+        fn recv_response(&mut self) -> core::result::Result<Option<BrokerResponse>, Self::Error> {
+            match self.last_request.take().unwrap() {
+                BrokerRequest::Pipe(PipeRequest::Create(_)) => Ok(Some(BrokerResponse::Pipe(
+                    PipeResponse::Create(CreatePipeResponse {
+                        read_handle: ObjectHandle(1),
+                        write_handle: ObjectHandle(2),
+                    }),
+                ))),
+                BrokerRequest::Pipe(PipeRequest::Read(_)) => Err(()),
+                BrokerRequest::CloseObject(_) => Ok(Some(BrokerResponse::ObjectClosed)),
+                request => panic!("unexpected broker request: {request:?}"),
+            }
+        }
+    }
 
     #[test]
     fn test_blocking_channel() {

--- a/litebox/src/pipes.rs
+++ b/litebox/src/pipes.rs
@@ -12,6 +12,11 @@ use core::{
 };
 
 use alloc::sync::{Arc, Weak};
+use either::Either;
+use litebox_broker_protocol::{
+    ObjectHandle,
+    pipe::{MAX_PIPE_TRANSFER_SIZE, PipeEndpoint, PipeReadinessState},
+};
 use ringbuf::{
     HeapCons, HeapProd, HeapRb,
     traits::{Consumer as _, Observer as _, Producer as _, Split as _},
@@ -20,6 +25,10 @@ use thiserror::Error;
 
 use crate::{
     LiteBox,
+    broker::{
+        BrokerControl, BrokerHandleRegistry,
+        error::{BrokerControlError, BrokerObjectError},
+    },
     event::{
         Events, IOPollable,
         observer::Observer,
@@ -65,15 +74,31 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> Pipes<Platform> {
         capacity: usize,
         flags: Flags,
         atomic_slice_guarantee_size: Option<NonZeroUsize>,
-    ) -> (PipeFd<Platform>, PipeFd<Platform>) {
-        let (sender, receiver) =
-            new_pipe::<Platform, u8>(capacity, OFlags::from(flags), atomic_slice_guarantee_size);
-        let sender = PipeEnd::Sender(sender);
-        let receiver = PipeEnd::Receiver(receiver);
+    ) -> Result<(PipeFd<Platform>, PipeFd<Platform>), errors::CreateError> {
+        let (sender, receiver) = if let Some(broker) = self.litebox.broker_control() {
+            let (sender, receiver) = new_broker_pipe(
+                broker,
+                self.litebox.broker_handle_registry(),
+                capacity,
+                OFlags::from(flags),
+                atomic_slice_guarantee_size,
+            )?;
+            (
+                PipeEnd::BrokerSender(sender),
+                PipeEnd::BrokerReceiver(receiver),
+            )
+        } else {
+            let (sender, receiver) = new_pipe::<Platform, u8>(
+                capacity,
+                OFlags::from(flags),
+                atomic_slice_guarantee_size,
+            );
+            (PipeEnd::Sender(sender), PipeEnd::Receiver(receiver))
+        };
         let mut dt = self.litebox.descriptor_table_mut();
         let sender = dt.insert(sender);
         let receiver = dt.insert(receiver);
-        (sender, receiver)
+        Ok((sender, receiver))
     }
 
     /// Close the pipe at `fd`.
@@ -99,11 +124,17 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> Pipes<Platform> {
     ) -> Result<usize, errors::ReadError> {
         let dt = self.litebox.descriptor_table();
         let p = match &dt.get_entry(fd).ok_or(errors::ReadError::ClosedFd)?.entry {
-            PipeEnd::Receiver(p) => Arc::clone(p),
-            PipeEnd::Sender(_) => return Err(errors::ReadError::NotForReading),
+            PipeEnd::Receiver(p) => Either::Left(Arc::clone(p)),
+            PipeEnd::BrokerReceiver(p) => Either::Right(Arc::clone(p)),
+            PipeEnd::Sender(_) | PipeEnd::BrokerSender(_) => {
+                return Err(errors::ReadError::NotForReading);
+            }
         };
         drop(dt);
-        p.read(cx, buf).map_err(From::from)
+        match p {
+            Either::Left(p) => p.read(cx, buf).map_err(From::from),
+            Either::Right(p) => p.read(cx, buf).map_err(From::from),
+        }
     }
 
     /// Write the values in `buf` into the pipe, returning the number of elements written.
@@ -117,11 +148,17 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> Pipes<Platform> {
     ) -> Result<usize, errors::WriteError> {
         let dt = self.litebox.descriptor_table();
         let p = match &dt.get_entry(fd).ok_or(errors::WriteError::ClosedFd)?.entry {
-            PipeEnd::Sender(p) => Arc::clone(p),
-            PipeEnd::Receiver(_) => return Err(errors::WriteError::NotForWriting),
+            PipeEnd::Sender(p) => Either::Left(Arc::clone(p)),
+            PipeEnd::BrokerSender(p) => Either::Right(Arc::clone(p)),
+            PipeEnd::Receiver(_) | PipeEnd::BrokerReceiver(_) => {
+                return Err(errors::WriteError::NotForWriting);
+            }
         };
         drop(dt);
-        p.write(cx, buf).map_err(From::from)
+        match p {
+            Either::Left(p) => p.write(cx, buf).map_err(From::from),
+            Either::Right(p) => p.write(cx, buf).map_err(From::from),
+        }
     }
 
     /// Whether the provided FD points to a reader or a writer end.
@@ -131,8 +168,8 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> Pipes<Platform> {
     ) -> Result<HalfPipeType, errors::ClosedError> {
         let dt = self.litebox.descriptor_table();
         match dt.get_entry(fd).ok_or(errors::ClosedError::ClosedFd)?.entry {
-            PipeEnd::Sender(_) => Ok(HalfPipeType::SenderHalf),
-            PipeEnd::Receiver(_) => Ok(HalfPipeType::ReceiverHalf),
+            PipeEnd::Sender(_) | PipeEnd::BrokerSender(_) => Ok(HalfPipeType::SenderHalf),
+            PipeEnd::Receiver(_) | PipeEnd::BrokerReceiver(_) => Ok(HalfPipeType::ReceiverHalf),
         }
     }
 
@@ -142,6 +179,7 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> Pipes<Platform> {
         let oflags = match &dt.get_entry(fd).ok_or(errors::ClosedError::ClosedFd)?.entry {
             PipeEnd::Receiver(p) => p.get_status(),
             PipeEnd::Sender(p) => p.get_status(),
+            PipeEnd::BrokerReceiver(p) | PipeEnd::BrokerSender(p) => p.get_status(),
         };
         Ok(Flags::from_oflags_truncate(oflags))
     }
@@ -159,6 +197,9 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> Pipes<Platform> {
         match &dt.get_entry(fd).ok_or(errors::ClosedError::ClosedFd)?.entry {
             PipeEnd::Receiver(p) => p.set_status(OFlags::from(mask), on),
             PipeEnd::Sender(p) => p.set_status(OFlags::from(mask), on),
+            PipeEnd::BrokerReceiver(p) | PipeEnd::BrokerSender(p) => {
+                p.set_status(OFlags::from(mask), on);
+            }
         }
         Ok(())
     }
@@ -173,6 +214,7 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> Pipes<Platform> {
         match &dt.get_entry(fd).ok_or(errors::ClosedError::ClosedFd)?.entry {
             PipeEnd::Receiver(p) => Ok(f(p)),
             PipeEnd::Sender(p) => Ok(f(p)),
+            PipeEnd::BrokerReceiver(p) | PipeEnd::BrokerSender(p) => Ok(f(p)),
         }
     }
 }
@@ -187,6 +229,8 @@ pub enum HalfPipeType {
 enum PipeEnd<Platform: RawSyncPrimitivesProvider + TimeProvider> {
     Receiver(Arc<ReadEnd<Platform, u8>>),
     Sender(Arc<WriteEnd<Platform, u8>>),
+    BrokerReceiver(Arc<BrokerPipeEnd<Platform>>),
+    BrokerSender(Arc<BrokerPipeEnd<Platform>>),
 }
 
 bitflags::bitflags! {
@@ -226,6 +270,18 @@ pub mod errors {
 
     use thiserror::Error;
 
+    /// Possible errors from [`Pipes::create_pipe`].
+    #[non_exhaustive]
+    #[derive(Error, Debug)]
+    pub enum CreateError {
+        #[error("pipe resource exhausted")]
+        ResourceExhausted,
+        #[error("pipe permission denied")]
+        PermissionDenied,
+        #[error("pipe broker I/O failed")]
+        Io,
+    }
+
     /// Possible errors from [`Pipes::close`]
     #[non_exhaustive]
     #[derive(Error, Debug)]
@@ -243,6 +299,8 @@ pub mod errors {
         WouldBlock,
         #[error("wait error")]
         WaitError(WaitError),
+        #[error("pipe I/O failed")]
+        Io,
     }
 
     /// Possible errors from [`Pipes::write`]
@@ -259,6 +317,8 @@ pub mod errors {
         WouldBlock,
         #[error("wait error")]
         WaitError(WaitError),
+        #[error("pipe I/O failed")]
+        Io,
     }
 
     /// Possible errors from functions that always succeed unless the descriptor is closed.
@@ -266,6 +326,236 @@ pub mod errors {
     pub enum ClosedError {
         #[error("not an open file descriptor")]
         ClosedFd,
+    }
+}
+
+struct BrokerPipeEnd<Platform: RawSyncPrimitivesProvider + TimeProvider> {
+    broker: Arc<dyn BrokerControl>,
+    handle: ObjectHandle,
+    registry: Arc<BrokerHandleRegistry<Platform>>,
+    pollee: Arc<Pollee<Platform>>,
+    peer: Weak<Self>,
+    endpoint_type: HalfPipeType,
+    status: AtomicU32,
+}
+
+#[expect(
+    clippy::type_complexity,
+    reason = "a type alias would not make the two pipe endpoint result clearer"
+)]
+fn new_broker_pipe<Platform: RawSyncPrimitivesProvider + TimeProvider>(
+    broker: Arc<dyn BrokerControl>,
+    registry: Arc<BrokerHandleRegistry<Platform>>,
+    capacity: usize,
+    flags: OFlags,
+    atomic_slice_guarantee_size: Option<NonZeroUsize>,
+) -> Result<(Arc<BrokerPipeEnd<Platform>>, Arc<BrokerPipeEnd<Platform>>), errors::CreateError> {
+    let atomic_write_size = atomic_slice_guarantee_size
+        .map(NonZeroUsize::get)
+        .unwrap_or_default();
+    if atomic_write_size > MAX_PIPE_TRANSFER_SIZE as usize {
+        return Err(errors::CreateError::ResourceExhausted);
+    }
+    let response = broker
+        .create_pipe(
+            capacity
+                .try_into()
+                .map_err(|_| errors::CreateError::ResourceExhausted)?,
+            atomic_write_size
+                .try_into()
+                .map_err(|_| errors::CreateError::ResourceExhausted)?,
+        )
+        .map_err(BrokerObjectError::from)
+        .map_err(errors::CreateError::from)?;
+
+    let mut writer = Arc::new(BrokerPipeEnd {
+        broker: Arc::clone(&broker),
+        handle: response.write_handle,
+        registry: Arc::clone(&registry),
+        pollee: Arc::new(Pollee::new()),
+        peer: Weak::new(),
+        endpoint_type: HalfPipeType::SenderHalf,
+        status: AtomicU32::new((flags | OFlags::WRONLY).bits()),
+    });
+    let reader = Arc::new_cyclic(|weak_reader| {
+        Arc::get_mut(&mut writer)
+            .expect("new pipe writer must be uniquely owned")
+            .peer = weak_reader.clone();
+        BrokerPipeEnd {
+            broker,
+            handle: response.read_handle,
+            registry: Arc::clone(&registry),
+            pollee: Arc::new(Pollee::new()),
+            peer: Arc::downgrade(&writer),
+            endpoint_type: HalfPipeType::ReceiverHalf,
+            status: AtomicU32::new((flags | OFlags::RDONLY).bits()),
+        }
+    });
+
+    registry.register_pollable(response.write_handle, &writer.pollee);
+    registry.register_pollable(response.read_handle, &reader.pollee);
+    Ok((writer, reader))
+}
+
+impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerPipeEnd<Platform> {
+    fn get_status(&self) -> OFlags {
+        OFlags::from_bits(self.status.load(Relaxed)).unwrap() & OFlags::STATUS_FLAGS_MASK
+    }
+
+    fn set_status(&self, mask: OFlags, on: bool) {
+        if on {
+            self.status.fetch_or(mask.bits(), Relaxed);
+        } else {
+            self.status.fetch_and(mask.complement().bits(), Relaxed);
+        }
+    }
+
+    fn read(&self, cx: &WaitContext<'_, Platform>, buf: &mut [u8]) -> Result<usize, PipeError> {
+        let length = buf.len().min(MAX_PIPE_TRANSFER_SIZE as usize);
+        if length == 0 {
+            return Ok(0);
+        }
+        let request_length = length
+            .try_into()
+            .expect("pipe transfer limit must fit in u32");
+
+        self.pollee
+            .wait(
+                cx,
+                self.get_status().contains(OFlags::NONBLOCK),
+                Events::IN,
+                || {
+                    let data = self
+                        .broker
+                        .read_pipe(self.handle, request_length)
+                        .map_err(broker_pipe_operation_error)?;
+                    if data.len() > length {
+                        return Err(TryOpError::Other(PipeError::Io));
+                    }
+                    buf[..data.len()].copy_from_slice(&data);
+                    if !data.is_empty()
+                        && let Some(peer) = self.peer.upgrade()
+                    {
+                        peer.pollee.notify_observers(Events::OUT);
+                    }
+                    Ok(data.len())
+                },
+            )
+            .map_err(PipeError::from)
+    }
+
+    fn write(&self, cx: &WaitContext<'_, Platform>, buf: &[u8]) -> Result<usize, PipeError> {
+        let nonblock = self.get_status().contains(OFlags::NONBLOCK);
+        if nonblock || buf.is_empty() {
+            let data = &buf[..buf.len().min(MAX_PIPE_TRANSFER_SIZE as usize)];
+            return self
+                .pollee
+                .wait(cx, nonblock, Events::OUT, || self.try_write(data))
+                .map_err(PipeError::from);
+        }
+
+        let mut total_written = 0;
+        while total_written < buf.len() {
+            let end = total_written
+                .saturating_add(MAX_PIPE_TRANSFER_SIZE as usize)
+                .min(buf.len());
+            let data = &buf[total_written..end];
+            match self
+                .pollee
+                .wait(cx, false, Events::OUT, || self.try_write(data))
+            {
+                Ok(written) => total_written += written,
+                Err(_) if total_written != 0 => return Ok(total_written),
+                Err(error) => return Err(PipeError::from(error)),
+            }
+        }
+        Ok(total_written)
+    }
+
+    fn try_write(&self, data: &[u8]) -> Result<usize, TryOpError<PipeError>> {
+        let written = self
+            .broker
+            .write_pipe(self.handle, data)
+            .map_err(broker_pipe_operation_error)?;
+        if written > data.len() || (written == 0 && !data.is_empty()) {
+            return Err(TryOpError::Other(PipeError::Io));
+        }
+        if written != 0
+            && let Some(peer) = self.peer.upgrade()
+        {
+            peer.pollee.notify_observers(Events::IN);
+        }
+        Ok(written)
+    }
+
+    fn readiness(&self) -> Result<PipeReadinessState, BrokerControlError> {
+        self.broker.check_pipe_readiness(self.handle)
+    }
+}
+
+impl<Platform: RawSyncPrimitivesProvider + TimeProvider> IOPollable for BrokerPipeEnd<Platform> {
+    fn register_observer(&self, observer: Weak<dyn Observer<Events>>, filter: Events) {
+        self.pollee.register_observer(observer, filter);
+    }
+
+    fn check_io_events(&self) -> Events {
+        match self.readiness() {
+            Ok(readiness) => pipe_readiness_events(readiness),
+            Err(_) => Events::ERR,
+        }
+    }
+}
+
+impl<Platform: RawSyncPrimitivesProvider + TimeProvider> Drop for BrokerPipeEnd<Platform> {
+    fn drop(&mut self) {
+        self.registry.unregister_pollable(self.handle, &self.pollee);
+        let _ = self.broker.close_object(self.handle);
+        if let Some(peer) = self.peer.upgrade() {
+            let event = match self.endpoint_type {
+                HalfPipeType::SenderHalf => Events::HUP,
+                HalfPipeType::ReceiverHalf => Events::ERR,
+            };
+            peer.pollee.notify_observers(event);
+        }
+    }
+}
+
+fn broker_pipe_operation_error(error: BrokerControlError) -> TryOpError<PipeError> {
+    match BrokerObjectError::from(error) {
+        BrokerObjectError::WouldBlock => TryOpError::TryAgain,
+        BrokerObjectError::PeerClosed => TryOpError::Other(PipeError::PeerShutdown),
+        BrokerObjectError::Control
+        | BrokerObjectError::InvalidObject
+        | BrokerObjectError::ResourceExhausted
+        | BrokerObjectError::PermissionDenied => TryOpError::Other(PipeError::Io),
+    }
+}
+
+fn pipe_readiness_events(readiness: PipeReadinessState) -> Events {
+    let mut events = Events::empty();
+    match readiness.endpoint {
+        PipeEndpoint::Read => {
+            events.set(Events::IN, readiness.ready);
+            events.set(Events::HUP, readiness.peer_closed);
+        }
+        PipeEndpoint::Write => {
+            events.set(Events::OUT, readiness.ready);
+            events.set(Events::ERR, readiness.peer_closed);
+        }
+    }
+    events
+}
+
+impl From<BrokerObjectError> for errors::CreateError {
+    fn from(error: BrokerObjectError) -> Self {
+        match error {
+            BrokerObjectError::ResourceExhausted => Self::ResourceExhausted,
+            BrokerObjectError::PermissionDenied => Self::PermissionDenied,
+            BrokerObjectError::Control
+            | BrokerObjectError::InvalidObject
+            | BrokerObjectError::WouldBlock
+            | BrokerObjectError::PeerClosed => Self::Io,
+        }
     }
 }
 
@@ -351,15 +641,15 @@ enum PipeError {
     WouldBlock,
     #[error("wait error")]
     WaitError(WaitError),
+    #[error("pipe I/O failed")]
+    Io,
 }
 
 impl From<PipeError> for errors::ReadError {
     fn from(err: PipeError) -> Self {
         match err {
             PipeError::ThisEndShutdown => errors::ReadError::ClosedFd,
-            PipeError::PeerShutdown => {
-                unreachable!("unreachable for now; see documentation of `read`")
-            }
+            PipeError::PeerShutdown | PipeError::Io => errors::ReadError::Io,
             PipeError::WouldBlock => errors::ReadError::WouldBlock,
             PipeError::WaitError(e) => errors::ReadError::WaitError(e),
         }
@@ -372,6 +662,7 @@ impl From<PipeError> for errors::WriteError {
             PipeError::PeerShutdown => errors::WriteError::ReadEndClosed,
             PipeError::WouldBlock => errors::WriteError::WouldBlock,
             PipeError::WaitError(e) => errors::WriteError::WaitError(e),
+            PipeError::Io => errors::WriteError::Io,
         }
     }
 }
@@ -634,7 +925,7 @@ mod tests {
         let litebox = &crate::LiteBox::new(platform);
         let pipes = &super::Pipes::new(litebox);
 
-        let (prod, cons) = pipes.create_pipe(2, super::Flags::empty(), None);
+        let (prod, cons) = pipes.create_pipe(2, super::Flags::empty(), None).unwrap();
 
         std::thread::scope(|scope| {
             scope.spawn(move || {
@@ -672,7 +963,9 @@ mod tests {
         let litebox = &crate::LiteBox::new(platform);
         let pipes = &super::Pipes::new(litebox);
 
-        let (prod, cons) = pipes.create_pipe(2, super::Flags::NON_BLOCKING, None);
+        let (prod, cons) = pipes
+            .create_pipe(2, super::Flags::NON_BLOCKING, None)
+            .unwrap();
 
         std::thread::scope(|scope| {
             scope.spawn(move || {

--- a/litebox/src/pipes.rs
+++ b/litebox/src/pipes.rs
@@ -447,8 +447,11 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerPipeEnd<Platform>
     }
 
     fn write(&self, cx: &WaitContext<'_, Platform>, buf: &[u8]) -> Result<usize, PipeError> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
         let nonblock = self.get_status().contains(OFlags::NONBLOCK);
-        if nonblock || buf.is_empty() {
+        if nonblock {
             let data = &buf[..buf.len().min(MAX_PIPE_TRANSFER_SIZE as usize)];
             return self
                 .pollee
@@ -693,11 +696,11 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider, T> WriteEnd<Platform, T
         if self.is_shutdown() {
             return Err(TryOpError::Other(PipeError::ThisEndShutdown));
         }
-        if self.is_peer_shutdown() {
-            return Err(TryOpError::Other(PipeError::PeerShutdown));
-        }
         if buf.is_empty() {
             return Ok(0);
+        }
+        if self.is_peer_shutdown() {
+            return Err(TryOpError::Other(PipeError::PeerShutdown));
         }
 
         let write_len = {
@@ -727,15 +730,25 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider, T> WriteEnd<Platform, T
     where
         T: Copy,
     {
-        self.endpoint
-            .pollee
-            .wait(
-                cx,
-                self.get_status().contains(OFlags::NONBLOCK),
-                Events::OUT,
-                || self.try_write(buf),
-            )
-            .map_err(PipeError::from)
+        if self.get_status().contains(OFlags::NONBLOCK) {
+            return self
+                .endpoint
+                .pollee
+                .wait(cx, true, Events::OUT, || self.try_write(buf))
+                .map_err(PipeError::from);
+        }
+
+        let mut total_written = 0;
+        while total_written < buf.len() {
+            match self.endpoint.pollee.wait(cx, false, Events::OUT, || {
+                self.try_write(&buf[total_written..])
+            }) {
+                Ok(written) => total_written += written,
+                Err(_) if total_written != 0 => return Ok(total_written),
+                Err(error) => return Err(PipeError::from(error)),
+            }
+        }
+        Ok(total_written)
     }
 
     common_functions_for_channel!();
@@ -911,16 +924,18 @@ fn new_pipe<Platform: RawSyncPrimitivesProvider + TimeProvider, T>(
 
 #[cfg(test)]
 mod tests {
-    use core::sync::atomic::{AtomicBool, Ordering};
+    use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     use alloc::sync::Arc;
     use litebox_broker_local::BrokerLocal;
     use litebox_broker_protocol::channel::LocalControlChannel;
+    use litebox_broker_protocol::error::ErrorCode;
     use litebox_broker_protocol::message::{
-        BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerRequest, BrokerResponse,
-        PipeRequest, PipeResponse,
+        BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerNotification, BrokerRequest,
+        BrokerResponse, PipeRequest, PipeResponse, ReadinessNotification,
     };
     use litebox_broker_protocol::pipe::CreatePipeResponse;
+    use litebox_broker_protocol::readiness::ReadinessFlags;
     use litebox_broker_protocol::{BROKER_PROTOCOL_VERSION, ObjectHandle};
 
     use crate::{
@@ -931,17 +946,32 @@ mod tests {
     extern crate std;
 
     #[test]
-    fn broker_error_notifies_pipe_observers() {
+    fn broker_control_failure_notifies_all_pipe_observers() {
         let platform = crate::platform::mock::MockPlatform::new();
-        let local = BrokerLocal::negotiate(FailingPipeChannel { last_request: None }).unwrap();
+        let request_count = Arc::new(AtomicUsize::new(0));
+        let force_transport = Arc::new(AtomicBool::new(false));
+        let local = BrokerLocal::negotiate(FailingPipeChannel {
+            last_request: None,
+            request_count: Arc::clone(&request_count),
+            read_failure: ReadFailure::Transport,
+            force_transport,
+        })
+        .unwrap();
         let litebox = crate::LiteBox::new_with_broker_local(platform, local);
         let pipes = super::Pipes::new(&litebox);
-        let (_writer, reader) = pipes.create_pipe(2, super::Flags::empty(), None).unwrap();
-        let observer = Arc::new(ErrorObserver(AtomicBool::new(false)));
-        let observer_dyn: Arc<dyn Observer<Events>> = observer.clone();
+        let (writer, reader) = pipes.create_pipe(2, super::Flags::empty(), None).unwrap();
+        let writer_observer = Arc::new(ErrorObserver(AtomicBool::new(false)));
+        let writer_observer_dyn: Arc<dyn Observer<Events>> = writer_observer.clone();
+        pipes
+            .with_iopollable(&writer, |pollable| {
+                pollable.register_observer(Arc::downgrade(&writer_observer_dyn), Events::ERR);
+            })
+            .unwrap();
+        let reader_observer = Arc::new(ErrorObserver(AtomicBool::new(false)));
+        let reader_observer_dyn: Arc<dyn Observer<Events>> = reader_observer.clone();
         pipes
             .with_iopollable(&reader, |pollable| {
-                pollable.register_observer(Arc::downgrade(&observer_dyn), Events::ERR);
+                pollable.register_observer(Arc::downgrade(&reader_observer_dyn), Events::ERR);
             })
             .unwrap();
 
@@ -954,7 +984,155 @@ mod tests {
             ),
             Err(ReadError::Io)
         ));
-        assert!(observer.0.load(Ordering::SeqCst));
+        assert_eq!(request_count.load(Ordering::SeqCst), 2);
+        assert!(writer_observer.0.load(Ordering::SeqCst));
+        assert!(reader_observer.0.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn broker_notification_failure_prevents_future_control_requests() {
+        let platform = crate::platform::mock::MockPlatform::new();
+        let request_count = Arc::new(AtomicUsize::new(0));
+        let force_transport = Arc::new(AtomicBool::new(false));
+        let local = BrokerLocal::negotiate(FailingPipeChannel {
+            last_request: None,
+            request_count: Arc::clone(&request_count),
+            read_failure: ReadFailure::Transport,
+            force_transport,
+        })
+        .unwrap();
+        let litebox = crate::LiteBox::new_with_broker_local(platform, local);
+        let pipes = super::Pipes::new(&litebox);
+        let (writer, reader) = pipes.create_pipe(2, super::Flags::empty(), None).unwrap();
+        let writer_observer = Arc::new(ErrorObserver(AtomicBool::new(false)));
+        let writer_observer_dyn: Arc<dyn Observer<Events>> = writer_observer.clone();
+        pipes
+            .with_iopollable(&writer, |pollable| {
+                pollable.register_observer(Arc::downgrade(&writer_observer_dyn), Events::ERR);
+            })
+            .unwrap();
+        let reader_observer = Arc::new(ErrorObserver(AtomicBool::new(false)));
+        let reader_observer_dyn: Arc<dyn Observer<Events>> = reader_observer.clone();
+        pipes
+            .with_iopollable(&reader, |pollable| {
+                pollable.register_observer(Arc::downgrade(&reader_observer_dyn), Events::ERR);
+            })
+            .unwrap();
+
+        litebox.broker_failure_dispatcher()();
+
+        assert!(writer_observer.0.load(Ordering::SeqCst));
+        assert!(reader_observer.0.load(Ordering::SeqCst));
+        assert!(matches!(
+            litebox
+                .broker_control()
+                .unwrap()
+                .read_pipe(ObjectHandle(1), 1),
+            Err(crate::broker::error::BrokerControlError::Transport)
+        ));
+        assert_eq!(request_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn broker_failure_wakes_blocked_pipe_read() {
+        let platform = crate::platform::mock::MockPlatform::new();
+        let request_count = Arc::new(AtomicUsize::new(0));
+        let force_transport = Arc::new(AtomicBool::new(false));
+        let local = BrokerLocal::negotiate(FailingPipeChannel {
+            last_request: None,
+            request_count: Arc::clone(&request_count),
+            read_failure: ReadFailure::WouldBlock,
+            force_transport: Arc::clone(&force_transport),
+        })
+        .unwrap();
+        let litebox = Arc::new(crate::LiteBox::new_with_broker_local(platform, local));
+        let pipes = super::Pipes::new(&litebox);
+        let (writer, reader) = pipes.create_pipe(2, super::Flags::empty(), None).unwrap();
+
+        let (result_sender, result_receiver) = std::sync::mpsc::sync_channel(1);
+        let read_litebox = Arc::clone(&litebox);
+        let read_thread = std::thread::spawn(move || {
+            let pipes = super::Pipes::new(&read_litebox);
+            let mut value = 0;
+            result_sender
+                .send(pipes.read(
+                    &WaitState::new(platform).context(),
+                    &reader,
+                    core::slice::from_mut(&mut value),
+                ))
+                .unwrap();
+        });
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(1);
+        let mut setup_completed = true;
+        while request_count.load(Ordering::SeqCst) < 3 {
+            if std::time::Instant::now() >= deadline {
+                setup_completed = false;
+                force_transport.store(true, Ordering::SeqCst);
+                let _ = pipes.close(&writer);
+                break;
+            }
+            std::thread::yield_now();
+        }
+
+        if setup_completed {
+            litebox.dispatch_broker_notification(BrokerNotification::Readiness(
+                ReadinessNotification {
+                    handle: ObjectHandle(1),
+                    events: ReadinessFlags::READ,
+                },
+            ));
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(1);
+            while request_count.load(Ordering::SeqCst) < 4 {
+                if std::time::Instant::now() >= deadline {
+                    setup_completed = false;
+                    force_transport.store(true, Ordering::SeqCst);
+                    let _ = pipes.close(&writer);
+                    break;
+                }
+                std::thread::yield_now();
+            }
+        }
+
+        if setup_completed {
+            litebox.broker_failure_dispatcher()();
+        }
+
+        let initial_read_result = result_receiver.recv_timeout(std::time::Duration::from_secs(1));
+        let woke_without_cleanup = initial_read_result.is_ok();
+        let mut read_result = initial_read_result.ok();
+        if read_result.is_none() {
+            force_transport.store(true, Ordering::SeqCst);
+            let _ = pipes.close(&writer);
+            read_result = result_receiver
+                .recv_timeout(std::time::Duration::from_secs(1))
+                .ok();
+        }
+        if read_result.is_some() {
+            read_thread.join().unwrap();
+        } else {
+            std::process::abort();
+        }
+
+        assert!(setup_completed);
+        assert!(woke_without_cleanup);
+        assert!(matches!(read_result, Some(Err(ReadError::Io))));
+        assert_eq!(request_count.load(Ordering::SeqCst), 4);
+    }
+
+    #[test]
+    fn local_zero_length_write_succeeds_after_reader_closes() {
+        let platform = crate::platform::mock::MockPlatform::new();
+        let litebox = crate::LiteBox::new(platform);
+        let pipes = super::Pipes::new(&litebox);
+        let (writer, reader) = pipes.create_pipe(2, super::Flags::empty(), None).unwrap();
+
+        pipes.close(&reader).unwrap();
+
+        assert!(matches!(
+            pipes.write(&WaitState::new(platform).context(), &writer, &[]),
+            Ok(0)
+        ));
+        pipes.close(&writer).unwrap();
     }
 
     struct ErrorObserver(AtomicBool);
@@ -970,6 +1148,15 @@ mod tests {
     #[derive(Debug)]
     struct FailingPipeChannel {
         last_request: Option<BrokerRequest>,
+        request_count: Arc<AtomicUsize>,
+        read_failure: ReadFailure,
+        force_transport: Arc<AtomicBool>,
+    }
+
+    #[derive(Clone, Copy, Debug)]
+    enum ReadFailure {
+        Transport,
+        WouldBlock,
     }
 
     impl LocalControlChannel for FailingPipeChannel {
@@ -995,6 +1182,7 @@ mod tests {
             request: &BrokerRequest,
         ) -> core::result::Result<(), Self::Error> {
             self.last_request = Some(request.clone());
+            self.request_count.fetch_add(1, Ordering::SeqCst);
             Ok(())
         }
 
@@ -1006,7 +1194,17 @@ mod tests {
                         write_handle: ObjectHandle(2),
                     }),
                 ))),
-                BrokerRequest::Pipe(PipeRequest::Read(_)) => Err(()),
+                BrokerRequest::Pipe(PipeRequest::Read(_))
+                    if self.force_transport.load(Ordering::SeqCst) =>
+                {
+                    Err(())
+                }
+                BrokerRequest::Pipe(PipeRequest::Read(_)) => match self.read_failure {
+                    ReadFailure::Transport => Err(()),
+                    ReadFailure::WouldBlock => {
+                        Ok(Some(BrokerResponse::Error(ErrorCode::WouldBlock)))
+                    }
+                },
                 BrokerRequest::CloseObject(_) => Ok(Some(BrokerResponse::ObjectClosed)),
                 request => panic!("unexpected broker request: {request:?}"),
             }
@@ -1029,6 +1227,7 @@ mod tests {
                     let ret = pipes
                         .write(&WaitState::new(platform).context(), &prod, &data[i..])
                         .unwrap();
+                    assert_eq!(ret, data.len() - i);
                     i += ret;
                 }
                 pipes.close(&prod).unwrap();

--- a/litebox_broker_core/src/error.rs
+++ b/litebox_broker_core/src/error.rs
@@ -21,6 +21,8 @@ pub enum BrokerError {
     BrokerCoreAlreadyExists,
     #[error("broker operation would block")]
     WouldBlock,
+    #[error("broker object peer is closed")]
+    PeerClosed,
     #[error("unsupported broker operation")]
     UnsupportedOperation,
 }
@@ -34,6 +36,7 @@ impl From<BrokerError> for ErrorCode {
             BrokerError::ResourceExhausted => Self::ResourceExhausted,
             BrokerError::BrokerCoreAlreadyExists => Self::Internal,
             BrokerError::WouldBlock => Self::WouldBlock,
+            BrokerError::PeerClosed => Self::PeerClosed,
             BrokerError::UnsupportedOperation => Self::UnsupportedOperation,
         }
     }

--- a/litebox_broker_core/src/error.rs
+++ b/litebox_broker_core/src/error.rs
@@ -23,6 +23,8 @@ pub enum BrokerError {
     WouldBlock,
     #[error("broker object peer is closed")]
     PeerClosed,
+    #[error("broker memory allocation failed")]
+    OutOfMemory,
     #[error("unsupported broker operation")]
     UnsupportedOperation,
 }
@@ -37,6 +39,7 @@ impl From<BrokerError> for ErrorCode {
             BrokerError::BrokerCoreAlreadyExists => Self::Internal,
             BrokerError::WouldBlock => Self::WouldBlock,
             BrokerError::PeerClosed => Self::PeerClosed,
+            BrokerError::OutOfMemory => Self::OutOfMemory,
             BrokerError::UnsupportedOperation => Self::UnsupportedOperation,
         }
     }

--- a/litebox_broker_core/src/event.rs
+++ b/litebox_broker_core/src/event.rs
@@ -31,6 +31,7 @@ pub fn wait(session: &BrokerSession, handle: ObjectHandle) -> Result<ReadinessSt
             read_ready: event.count > 0,
             write_ready: event.count < MAX_EVENT_COUNT,
         }),
+        _ => Err(BrokerError::InvalidRights),
     })
 }
 
@@ -39,6 +40,7 @@ pub fn add(session: &BrokerSession, handle: ObjectHandle, value: u64) -> Result<
     let required_rights = ObjectRights::WRITE;
     session.with_authorized_object_mut(handle, required_rights, |object| match object {
         ObjectEntry::Event(event) => event.add(value),
+        _ => Err(BrokerError::InvalidRights),
     })
 }
 
@@ -51,6 +53,7 @@ pub fn consume(
     let required_rights = ObjectRights::WAIT;
     session.with_authorized_object_mut(handle, required_rights, |object| match object {
         ObjectEntry::Event(event) => event.consume(mode),
+        _ => Err(BrokerError::InvalidRights),
     })
 }
 

--- a/litebox_broker_core/src/event.rs
+++ b/litebox_broker_core/src/event.rs
@@ -6,7 +6,8 @@
 use crate::session::{ObjectEntry, ObjectRights};
 use crate::{BrokerError, BrokerSession, Result};
 use litebox_broker_protocol::ObjectHandle;
-use litebox_broker_protocol::event::{EventConsumeMode, EventConsumption, ReadinessState};
+use litebox_broker_protocol::event::{EventConsumeMode, EventConsumption};
+use litebox_broker_protocol::readiness::ReadinessFlags;
 
 pub(crate) const MAX_EVENT_COUNT: u64 = u64::MAX - 1;
 
@@ -24,23 +25,20 @@ pub fn create(session: &BrokerSession, initial_count: u64) -> Result<ObjectHandl
 /// Blocking is intentionally outside BrokerCore for the first proof of
 /// concept. Userland or kernel deployments can block on deployment-specific
 /// wait primitives after BrokerCore authorizes and reports readiness state.
-pub fn wait(session: &BrokerSession, handle: ObjectHandle) -> Result<ReadinessState> {
+pub fn wait(session: &BrokerSession, handle: ObjectHandle) -> Result<ReadinessFlags> {
     let required_rights = ObjectRights::WAIT;
     session.with_authorized_object(handle, required_rights, |object| match object {
-        ObjectEntry::Event(event) => Ok(ReadinessState {
-            read_ready: event.count > 0,
-            write_ready: event.count < MAX_EVENT_COUNT,
-        }),
-        _ => Err(BrokerError::InvalidRights),
+        ObjectEntry::Event(event) => Ok(event.readiness()),
+        ObjectEntry::Pipe(_) => Err(BrokerError::InvalidRights),
     })
 }
 
 /// Adds readiness credits to a broker-owned event object.
-pub fn add(session: &BrokerSession, handle: ObjectHandle, value: u64) -> Result<ReadinessState> {
+pub fn add(session: &BrokerSession, handle: ObjectHandle, value: u64) -> Result<ReadinessFlags> {
     let required_rights = ObjectRights::WRITE;
     session.with_authorized_object_mut(handle, required_rights, |object| match object {
         ObjectEntry::Event(event) => event.add(value),
-        _ => Err(BrokerError::InvalidRights),
+        ObjectEntry::Pipe(_) => Err(BrokerError::InvalidRights),
     })
 }
 
@@ -53,7 +51,7 @@ pub fn consume(
     let required_rights = ObjectRights::WAIT;
     session.with_authorized_object_mut(handle, required_rights, |object| match object {
         ObjectEntry::Event(event) => event.consume(mode),
-        _ => Err(BrokerError::InvalidRights),
+        ObjectEntry::Pipe(_) => Err(BrokerError::InvalidRights),
     })
 }
 
@@ -67,16 +65,13 @@ impl EventObject {
         Self { count }
     }
 
-    fn add(&mut self, value: u64) -> Result<ReadinessState> {
+    fn add(&mut self, value: u64) -> Result<ReadinessFlags> {
         self.count = self
             .count
             .checked_add(value)
             .filter(|count| *count <= MAX_EVENT_COUNT)
             .ok_or(BrokerError::WouldBlock)?;
-        Ok(ReadinessState {
-            read_ready: self.count > 0,
-            write_ready: self.count < MAX_EVENT_COUNT,
-        })
+        Ok(self.readiness())
     }
 
     fn consume(&mut self, mode: EventConsumeMode) -> Result<EventConsumption> {
@@ -91,10 +86,18 @@ impl EventObject {
         self.count -= value;
         Ok(EventConsumption {
             value,
-            readiness: ReadinessState {
-                read_ready: self.count > 0,
-                write_ready: self.count < MAX_EVENT_COUNT,
-            },
+            readiness: self.readiness(),
         })
+    }
+
+    fn readiness(self) -> ReadinessFlags {
+        let mut readiness = ReadinessFlags::default();
+        if self.count > 0 {
+            readiness = readiness | ReadinessFlags::READ;
+        }
+        if self.count < MAX_EVENT_COUNT {
+            readiness = readiness | ReadinessFlags::WRITE;
+        }
+        readiness
     }
 }

--- a/litebox_broker_core/src/lib.rs
+++ b/litebox_broker_core/src/lib.rs
@@ -32,7 +32,7 @@ use litebox_broker_protocol::ObjectHandle;
 use spin::rwlock::RwLock;
 
 pub use error::BrokerError;
-pub use policy::{PolicyEngine, PolicyProfile, PrincipalRights};
+pub use policy::{PolicyEngine, PolicyProfile};
 use session::ObjectReference;
 pub use session::{BrokerSession, CallerCredential, ObjectRights};
 
@@ -47,17 +47,30 @@ pub type Result<T> = core::result::Result<T, BrokerError>;
 pub struct BrokerCoreLimits {
     /// Maximum live object references.
     pub max_references: usize,
+    /// Maximum total capacity in bytes reserved by live pipes.
+    pub max_total_pipe_capacity: usize,
 }
 
 impl BrokerCoreLimits {
     /// Conservative default limits for initial broker deployments.
     pub const DEFAULT: Self = Self {
         max_references: 4096,
+        max_total_pipe_capacity: 64 * 1024 * 1024,
     };
 
-    /// Creates a broker core limit set.
+    /// Creates a broker core limit set with the default pipe-capacity limit.
     pub const fn new(max_references: usize) -> Self {
-        Self { max_references }
+        Self {
+            max_references,
+            ..Self::DEFAULT
+        }
+    }
+
+    /// Sets the maximum total capacity in bytes reserved by live pipes.
+    #[must_use]
+    pub const fn with_max_total_pipe_capacity(mut self, max_total_pipe_capacity: usize) -> Self {
+        self.max_total_pipe_capacity = max_total_pipe_capacity;
+        self
     }
 }
 
@@ -79,6 +92,7 @@ pub struct BrokerCore {
     pub(crate) next_session_id: Arc<RwLock<u64>>,
     pub(crate) next_reference_handle: Arc<RwLock<u64>>,
     pub(crate) references: Arc<RwLock<HashMap<ObjectHandle, ObjectReference>>>,
+    pub(crate) reserved_pipe_capacity: Arc<RwLock<usize>>,
 }
 
 static BROKER_CORE_CREATED: AtomicBool = AtomicBool::new(false);
@@ -101,6 +115,7 @@ impl BrokerCore {
             next_session_id: Arc::new(RwLock::new(1)),
             next_reference_handle: Arc::new(RwLock::new(1)),
             references: Arc::new(RwLock::new(HashMap::new())),
+            reserved_pipe_capacity: Arc::new(RwLock::new(0)),
         })
     }
 

--- a/litebox_broker_core/src/lib.rs
+++ b/litebox_broker_core/src/lib.rs
@@ -85,7 +85,6 @@ pub struct BrokerCore {
     pub(crate) next_session_id: Arc<RwLock<u64>>,
     pub(crate) next_reference_handle: Arc<RwLock<u64>>,
     pub(crate) references: Arc<RwLock<HashMap<ObjectHandle, ObjectReference>>>,
-    pub(crate) reserved_references: Arc<RwLock<usize>>,
     pub(crate) reserved_pipe_capacity: Arc<RwLock<usize>>,
 }
 
@@ -109,7 +108,6 @@ impl BrokerCore {
             next_session_id: Arc::new(RwLock::new(1)),
             next_reference_handle: Arc::new(RwLock::new(1)),
             references: Arc::new(RwLock::new(HashMap::new())),
-            reserved_references: Arc::new(RwLock::new(0)),
             reserved_pipe_capacity: Arc::new(RwLock::new(0)),
         })
     }

--- a/litebox_broker_core/src/lib.rs
+++ b/litebox_broker_core/src/lib.rs
@@ -20,6 +20,7 @@ extern crate std;
 
 mod error;
 pub mod event;
+pub mod pipe;
 mod policy;
 mod session;
 

--- a/litebox_broker_core/src/lib.rs
+++ b/litebox_broker_core/src/lib.rs
@@ -92,6 +92,7 @@ pub struct BrokerCore {
     pub(crate) next_session_id: Arc<RwLock<u64>>,
     pub(crate) next_reference_handle: Arc<RwLock<u64>>,
     pub(crate) references: Arc<RwLock<HashMap<ObjectHandle, ObjectReference>>>,
+    pub(crate) reserved_references: Arc<RwLock<usize>>,
     pub(crate) reserved_pipe_capacity: Arc<RwLock<usize>>,
 }
 
@@ -115,6 +116,7 @@ impl BrokerCore {
             next_session_id: Arc::new(RwLock::new(1)),
             next_reference_handle: Arc::new(RwLock::new(1)),
             references: Arc::new(RwLock::new(HashMap::new())),
+            reserved_references: Arc::new(RwLock::new(0)),
             reserved_pipe_capacity: Arc::new(RwLock::new(0)),
         })
     }

--- a/litebox_broker_core/src/lib.rs
+++ b/litebox_broker_core/src/lib.rs
@@ -58,19 +58,12 @@ impl BrokerCoreLimits {
         max_total_pipe_capacity: 64 * 1024 * 1024,
     };
 
-    /// Creates a broker core limit set with the default pipe-capacity limit.
-    pub const fn new(max_references: usize) -> Self {
+    /// Creates a broker core limit set.
+    pub const fn new(max_references: usize, max_total_pipe_capacity: usize) -> Self {
         Self {
             max_references,
-            ..Self::DEFAULT
+            max_total_pipe_capacity,
         }
-    }
-
-    /// Sets the maximum total capacity in bytes reserved by live pipes.
-    #[must_use]
-    pub const fn with_max_total_pipe_capacity(mut self, max_total_pipe_capacity: usize) -> Self {
-        self.max_total_pipe_capacity = max_total_pipe_capacity;
-        self
     }
 }
 

--- a/litebox_broker_core/src/pipe.rs
+++ b/litebox_broker_core/src/pipe.rs
@@ -131,12 +131,12 @@ impl PipeObject {
         if !matches!(self.endpoint, PipeEndpoint::Write) {
             return Err(BrokerError::InvalidRights);
         }
+        if data.is_empty() {
+            return Ok(0);
+        }
         let mut state = self.state.write();
         if !state.read_open {
             return Err(BrokerError::PeerClosed);
-        }
-        if data.is_empty() {
-            return Ok(0);
         }
 
         let available = state.capacity - state.data.len();
@@ -162,9 +162,16 @@ impl PipeObject {
                 }
                 readiness
             }
-            PipeEndpoint::Write if !state.read_open => ReadinessFlags::ERROR,
-            PipeEndpoint::Write if state.data.len() < state.capacity => ReadinessFlags::WRITE,
-            PipeEndpoint::Write => ReadinessFlags::default(),
+            PipeEndpoint::Write => {
+                let mut readiness = ReadinessFlags::default();
+                if state.data.len() < state.capacity {
+                    readiness = readiness | ReadinessFlags::WRITE;
+                }
+                if !state.read_open {
+                    readiness = readiness | ReadinessFlags::ERROR;
+                }
+                readiness
+            }
         }
     }
 }

--- a/litebox_broker_core/src/pipe.rs
+++ b/litebox_broker_core/src/pipe.rs
@@ -1,0 +1,191 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//! Broker-owned byte pipe operations.
+
+use alloc::{collections::VecDeque, sync::Arc, vec::Vec};
+
+use litebox_broker_protocol::ObjectHandle;
+use litebox_broker_protocol::pipe::{MAX_PIPE_TRANSFER_SIZE, PipeEndpoint, PipeReadinessState};
+use spin::rwlock::RwLock;
+
+use crate::session::{ObjectEntry, ObjectRights};
+use crate::{BrokerError, BrokerSession, Result};
+
+/// Maximum capacity accepted by the control-path pipe prototype.
+pub const MAX_PIPE_CAPACITY: usize = 1024 * 1024;
+
+/// Creates a broker-owned pipe and returns its read and write endpoint handles.
+///
+/// # Panics
+///
+/// Panics if rollback of a newly-created read endpoint unexpectedly fails
+/// after write-endpoint creation fails.
+pub fn create(
+    session: &BrokerSession,
+    capacity: u64,
+    atomic_write_size: u64,
+) -> Result<(ObjectHandle, ObjectHandle)> {
+    let capacity = usize::try_from(capacity).map_err(|_| BrokerError::ResourceExhausted)?;
+    let atomic_write_size =
+        usize::try_from(atomic_write_size).map_err(|_| BrokerError::ResourceExhausted)?;
+    if capacity == 0
+        || capacity > MAX_PIPE_CAPACITY
+        || atomic_write_size > capacity
+        || atomic_write_size > MAX_PIPE_TRANSFER_SIZE as usize
+    {
+        return Err(BrokerError::ResourceExhausted);
+    }
+
+    let mut data = VecDeque::new();
+    data.try_reserve_exact(capacity)
+        .map_err(|_| BrokerError::ResourceExhausted)?;
+    let state = Arc::new(RwLock::new(PipeState {
+        data,
+        capacity,
+        atomic_write_size,
+        read_open: true,
+        write_open: true,
+    }));
+
+    let read_handle = session.create_object_reference(ObjectEntry::PipeReader(PipeReadEnd {
+        state: Arc::clone(&state),
+    }))?;
+    let write_handle =
+        match session.create_object_reference(ObjectEntry::PipeWriter(PipeWriteEnd { state })) {
+            Ok(handle) => handle,
+            Err(error) => {
+                session
+                    .close_object_reference(read_handle)
+                    .expect("newly created pipe read handle must be valid");
+                return Err(error);
+            }
+        };
+
+    Ok((read_handle, write_handle))
+}
+
+/// Reads up to `length` bytes from a broker-owned pipe.
+pub fn read(session: &BrokerSession, handle: ObjectHandle, length: u32) -> Result<Vec<u8>> {
+    if length > MAX_PIPE_TRANSFER_SIZE {
+        return Err(BrokerError::ResourceExhausted);
+    }
+    session.with_authorized_object(handle, ObjectRights::WAIT, |object| match object {
+        ObjectEntry::PipeReader(end) => end.read(length as usize),
+        ObjectEntry::Event(_) | ObjectEntry::PipeWriter(_) => Err(BrokerError::InvalidRights),
+    })
+}
+
+/// Writes bytes to a broker-owned pipe.
+pub fn write(session: &BrokerSession, handle: ObjectHandle, data: &[u8]) -> Result<usize> {
+    if data.len() > MAX_PIPE_TRANSFER_SIZE as usize {
+        return Err(BrokerError::ResourceExhausted);
+    }
+    session.with_authorized_object(handle, ObjectRights::WRITE, |object| match object {
+        ObjectEntry::PipeWriter(end) => end.write(data),
+        ObjectEntry::Event(_) | ObjectEntry::PipeReader(_) => Err(BrokerError::InvalidRights),
+    })
+}
+
+/// Returns the current readiness of one pipe endpoint.
+pub fn check_readiness(
+    session: &BrokerSession,
+    handle: ObjectHandle,
+) -> Result<PipeReadinessState> {
+    session.with_authorized_object(handle, ObjectRights::WAIT, |object| match object {
+        ObjectEntry::PipeReader(end) => Ok(end.readiness()),
+        ObjectEntry::PipeWriter(end) => Ok(end.readiness()),
+        ObjectEntry::Event(_) => Err(BrokerError::InvalidRights),
+    })
+}
+
+pub(crate) struct PipeReadEnd {
+    state: Arc<RwLock<PipeState>>,
+}
+
+impl PipeReadEnd {
+    fn read(&self, length: usize) -> Result<Vec<u8>> {
+        if length == 0 {
+            return Ok(Vec::new());
+        }
+
+        let mut state = self.state.write();
+        if state.data.is_empty() {
+            return if state.write_open {
+                Err(BrokerError::WouldBlock)
+            } else {
+                Ok(Vec::new())
+            };
+        }
+
+        let read_len = length.min(state.data.len());
+        let mut data = Vec::new();
+        data.try_reserve_exact(read_len)
+            .map_err(|_| BrokerError::ResourceExhausted)?;
+        data.extend(state.data.drain(..read_len));
+        Ok(data)
+    }
+
+    fn readiness(&self) -> PipeReadinessState {
+        let state = self.state.read();
+        PipeReadinessState {
+            endpoint: PipeEndpoint::Read,
+            ready: !state.data.is_empty(),
+            peer_closed: !state.write_open,
+        }
+    }
+}
+
+impl Drop for PipeReadEnd {
+    fn drop(&mut self) {
+        self.state.write().read_open = false;
+    }
+}
+
+pub(crate) struct PipeWriteEnd {
+    state: Arc<RwLock<PipeState>>,
+}
+
+impl PipeWriteEnd {
+    fn write(&self, data: &[u8]) -> Result<usize> {
+        let mut state = self.state.write();
+        if !state.read_open {
+            return Err(BrokerError::PeerClosed);
+        }
+        if data.is_empty() {
+            return Ok(0);
+        }
+
+        let available = state.capacity - state.data.len();
+        if available == 0 || (data.len() <= state.atomic_write_size && available < data.len()) {
+            return Err(BrokerError::WouldBlock);
+        }
+
+        let write_len = available.min(data.len());
+        state.data.extend(&data[..write_len]);
+        Ok(write_len)
+    }
+
+    fn readiness(&self) -> PipeReadinessState {
+        let state = self.state.read();
+        PipeReadinessState {
+            endpoint: PipeEndpoint::Write,
+            ready: state.read_open && state.data.len() < state.capacity,
+            peer_closed: !state.read_open,
+        }
+    }
+}
+
+impl Drop for PipeWriteEnd {
+    fn drop(&mut self) {
+        self.state.write().write_open = false;
+    }
+}
+
+struct PipeState {
+    data: VecDeque<u8>,
+    capacity: usize,
+    atomic_write_size: usize,
+    read_open: bool,
+    write_open: bool,
+}

--- a/litebox_broker_core/src/pipe.rs
+++ b/litebox_broker_core/src/pipe.rs
@@ -34,24 +34,22 @@ pub fn create(
         return Err(BrokerError::ResourceExhausted);
     }
 
-    session.create_object_reference_pair(|| {
-        let capacity_reservation = PipeCapacityReservation::new(session, capacity)?;
-        let mut data = VecDeque::new();
-        data.try_reserve_exact(capacity)
-            .map_err(|_| BrokerError::OutOfMemory)?;
-        let state = Arc::new(RwLock::new(PipeState {
-            data,
-            capacity,
-            atomic_write_size,
-            read_open: true,
-            write_open: true,
-            _capacity_reservation: capacity_reservation,
-        }));
-        Ok((
-            ObjectEntry::Pipe(PipeObject::reader(Arc::clone(&state))),
-            ObjectEntry::Pipe(PipeObject::writer(state)),
-        ))
-    })
+    let capacity_reservation = PipeCapacityReservation::new(session, capacity)?;
+    let mut data = VecDeque::new();
+    data.try_reserve_exact(capacity)
+        .map_err(|_| BrokerError::OutOfMemory)?;
+    let state = Arc::new(RwLock::new(PipeState {
+        data,
+        capacity,
+        atomic_write_size,
+        read_open: true,
+        write_open: true,
+        _capacity_reservation: capacity_reservation,
+    }));
+    session.create_object_reference_pair(
+        ObjectEntry::Pipe(PipeObject::reader(Arc::clone(&state))),
+        ObjectEntry::Pipe(PipeObject::writer(state)),
+    )
 }
 
 /// Reads up to `length` bytes from a broker-owned pipe.

--- a/litebox_broker_core/src/pipe.rs
+++ b/litebox_broker_core/src/pipe.rs
@@ -34,23 +34,24 @@ pub fn create(
         return Err(BrokerError::ResourceExhausted);
     }
 
-    let capacity_reservation = PipeCapacityReservation::new(session, capacity)?;
-    let mut data = VecDeque::new();
-    data.try_reserve_exact(capacity)
-        .map_err(|_| BrokerError::OutOfMemory)?;
-    let state = Arc::new(RwLock::new(PipeState {
-        data,
-        capacity,
-        atomic_write_size,
-        read_open: true,
-        write_open: true,
-        _capacity_reservation: capacity_reservation,
-    }));
-
-    session.create_object_reference_pair(
-        ObjectEntry::Pipe(PipeObject::reader(Arc::clone(&state))),
-        ObjectEntry::Pipe(PipeObject::writer(state)),
-    )
+    session.create_object_reference_pair(|| {
+        let capacity_reservation = PipeCapacityReservation::new(session, capacity)?;
+        let mut data = VecDeque::new();
+        data.try_reserve_exact(capacity)
+            .map_err(|_| BrokerError::OutOfMemory)?;
+        let state = Arc::new(RwLock::new(PipeState {
+            data,
+            capacity,
+            atomic_write_size,
+            read_open: true,
+            write_open: true,
+            _capacity_reservation: capacity_reservation,
+        }));
+        Ok((
+            ObjectEntry::Pipe(PipeObject::reader(Arc::clone(&state))),
+            ObjectEntry::Pipe(PipeObject::writer(state)),
+        ))
+    })
 }
 
 /// Reads up to `length` bytes from a broker-owned pipe.
@@ -123,7 +124,7 @@ impl PipeObject {
         let read_len = length.min(state.data.len());
         let mut data = Vec::new();
         data.try_reserve_exact(read_len)
-            .map_err(|_| BrokerError::ResourceExhausted)?;
+            .map_err(|_| BrokerError::OutOfMemory)?;
         data.extend(state.data.drain(..read_len));
         Ok(data)
     }

--- a/litebox_broker_core/src/pipe.rs
+++ b/litebox_broker_core/src/pipe.rs
@@ -6,7 +6,8 @@
 use alloc::{collections::VecDeque, sync::Arc, vec::Vec};
 
 use litebox_broker_protocol::ObjectHandle;
-use litebox_broker_protocol::pipe::{MAX_PIPE_TRANSFER_SIZE, PipeEndpoint, PipeReadinessState};
+use litebox_broker_protocol::pipe::MAX_PIPE_TRANSFER_SIZE;
+use litebox_broker_protocol::readiness::ReadinessFlags;
 use spin::rwlock::RwLock;
 
 use crate::session::{ObjectEntry, ObjectRights};
@@ -17,10 +18,6 @@ pub const MAX_PIPE_CAPACITY: usize = 1024 * 1024;
 
 /// Creates a broker-owned pipe and returns its read and write endpoint handles.
 ///
-/// # Panics
-///
-/// Panics if rollback of a newly-created read endpoint unexpectedly fails
-/// after write-endpoint creation fails.
 pub fn create(
     session: &BrokerSession,
     capacity: u64,
@@ -37,32 +34,23 @@ pub fn create(
         return Err(BrokerError::ResourceExhausted);
     }
 
+    let capacity_reservation = PipeCapacityReservation::new(session, capacity)?;
     let mut data = VecDeque::new();
     data.try_reserve_exact(capacity)
-        .map_err(|_| BrokerError::ResourceExhausted)?;
+        .map_err(|_| BrokerError::OutOfMemory)?;
     let state = Arc::new(RwLock::new(PipeState {
         data,
         capacity,
         atomic_write_size,
         read_open: true,
         write_open: true,
+        _capacity_reservation: capacity_reservation,
     }));
 
-    let read_handle = session.create_object_reference(ObjectEntry::PipeReader(PipeReadEnd {
-        state: Arc::clone(&state),
-    }))?;
-    let write_handle =
-        match session.create_object_reference(ObjectEntry::PipeWriter(PipeWriteEnd { state })) {
-            Ok(handle) => handle,
-            Err(error) => {
-                session
-                    .close_object_reference(read_handle)
-                    .expect("newly created pipe read handle must be valid");
-                return Err(error);
-            }
-        };
-
-    Ok((read_handle, write_handle))
+    session.create_object_reference_pair(
+        ObjectEntry::Pipe(PipeObject::reader(Arc::clone(&state))),
+        ObjectEntry::Pipe(PipeObject::writer(state)),
+    )
 }
 
 /// Reads up to `length` bytes from a broker-owned pipe.
@@ -71,8 +59,8 @@ pub fn read(session: &BrokerSession, handle: ObjectHandle, length: u32) -> Resul
         return Err(BrokerError::ResourceExhausted);
     }
     session.with_authorized_object(handle, ObjectRights::WAIT, |object| match object {
-        ObjectEntry::PipeReader(end) => end.read(length as usize),
-        ObjectEntry::Event(_) | ObjectEntry::PipeWriter(_) => Err(BrokerError::InvalidRights),
+        ObjectEntry::Pipe(pipe) => pipe.read(length as usize),
+        ObjectEntry::Event(_) => Err(BrokerError::InvalidRights),
     })
 }
 
@@ -82,29 +70,43 @@ pub fn write(session: &BrokerSession, handle: ObjectHandle, data: &[u8]) -> Resu
         return Err(BrokerError::ResourceExhausted);
     }
     session.with_authorized_object(handle, ObjectRights::WRITE, |object| match object {
-        ObjectEntry::PipeWriter(end) => end.write(data),
-        ObjectEntry::Event(_) | ObjectEntry::PipeReader(_) => Err(BrokerError::InvalidRights),
-    })
-}
-
-/// Returns the current readiness of one pipe endpoint.
-pub fn check_readiness(
-    session: &BrokerSession,
-    handle: ObjectHandle,
-) -> Result<PipeReadinessState> {
-    session.with_authorized_object(handle, ObjectRights::WAIT, |object| match object {
-        ObjectEntry::PipeReader(end) => Ok(end.readiness()),
-        ObjectEntry::PipeWriter(end) => Ok(end.readiness()),
+        ObjectEntry::Pipe(pipe) => pipe.write(data),
         ObjectEntry::Event(_) => Err(BrokerError::InvalidRights),
     })
 }
 
-pub(crate) struct PipeReadEnd {
-    state: Arc<RwLock<PipeState>>,
+/// Returns the current readiness of one pipe endpoint.
+pub fn check_readiness(session: &BrokerSession, handle: ObjectHandle) -> Result<ReadinessFlags> {
+    session.with_authorized_object(handle, ObjectRights::WAIT, |object| match object {
+        ObjectEntry::Pipe(pipe) => Ok(pipe.readiness()),
+        ObjectEntry::Event(_) => Err(BrokerError::InvalidRights),
+    })
 }
 
-impl PipeReadEnd {
+pub(crate) struct PipeObject {
+    state: Arc<RwLock<PipeState>>,
+    endpoint: PipeEndpoint,
+}
+
+impl PipeObject {
+    fn reader(state: Arc<RwLock<PipeState>>) -> Self {
+        Self {
+            state,
+            endpoint: PipeEndpoint::Read,
+        }
+    }
+
+    fn writer(state: Arc<RwLock<PipeState>>) -> Self {
+        Self {
+            state,
+            endpoint: PipeEndpoint::Write,
+        }
+    }
+
     fn read(&self, length: usize) -> Result<Vec<u8>> {
+        if !matches!(self.endpoint, PipeEndpoint::Read) {
+            return Err(BrokerError::InvalidRights);
+        }
         if length == 0 {
             return Ok(Vec::new());
         }
@@ -126,28 +128,10 @@ impl PipeReadEnd {
         Ok(data)
     }
 
-    fn readiness(&self) -> PipeReadinessState {
-        let state = self.state.read();
-        PipeReadinessState {
-            endpoint: PipeEndpoint::Read,
-            ready: !state.data.is_empty(),
-            peer_closed: !state.write_open,
-        }
-    }
-}
-
-impl Drop for PipeReadEnd {
-    fn drop(&mut self) {
-        self.state.write().read_open = false;
-    }
-}
-
-pub(crate) struct PipeWriteEnd {
-    state: Arc<RwLock<PipeState>>,
-}
-
-impl PipeWriteEnd {
     fn write(&self, data: &[u8]) -> Result<usize> {
+        if !matches!(self.endpoint, PipeEndpoint::Write) {
+            return Err(BrokerError::InvalidRights);
+        }
         let mut state = self.state.write();
         if !state.read_open {
             return Err(BrokerError::PeerClosed);
@@ -166,19 +150,69 @@ impl PipeWriteEnd {
         Ok(write_len)
     }
 
-    fn readiness(&self) -> PipeReadinessState {
+    fn readiness(&self) -> ReadinessFlags {
         let state = self.state.read();
-        PipeReadinessState {
-            endpoint: PipeEndpoint::Write,
-            ready: state.read_open && state.data.len() < state.capacity,
-            peer_closed: !state.read_open,
+        match self.endpoint {
+            PipeEndpoint::Read => {
+                let mut readiness = ReadinessFlags::default();
+                if !state.data.is_empty() {
+                    readiness = readiness | ReadinessFlags::READ;
+                }
+                if !state.write_open {
+                    readiness = readiness | ReadinessFlags::HANGUP;
+                }
+                readiness
+            }
+            PipeEndpoint::Write if !state.read_open => ReadinessFlags::ERROR,
+            PipeEndpoint::Write if state.data.len() < state.capacity => ReadinessFlags::WRITE,
+            PipeEndpoint::Write => ReadinessFlags::default(),
         }
     }
 }
 
-impl Drop for PipeWriteEnd {
+impl Drop for PipeObject {
     fn drop(&mut self) {
-        self.state.write().write_open = false;
+        let mut state = self.state.write();
+        match self.endpoint {
+            PipeEndpoint::Read => state.read_open = false,
+            PipeEndpoint::Write => state.write_open = false,
+        }
+    }
+}
+
+enum PipeEndpoint {
+    Read,
+    Write,
+}
+
+struct PipeCapacityReservation {
+    reserved_capacity: Arc<RwLock<usize>>,
+    capacity: usize,
+}
+
+impl PipeCapacityReservation {
+    fn new(session: &BrokerSession, capacity: usize) -> Result<Self> {
+        let reserved_capacity = Arc::clone(&session.core.reserved_pipe_capacity);
+        {
+            let mut reserved = reserved_capacity.write();
+            *reserved = reserved
+                .checked_add(capacity)
+                .filter(|total| *total <= session.core.limits.max_total_pipe_capacity)
+                .ok_or(BrokerError::ResourceExhausted)?;
+        }
+        Ok(Self {
+            reserved_capacity,
+            capacity,
+        })
+    }
+}
+
+impl Drop for PipeCapacityReservation {
+    fn drop(&mut self) {
+        let mut reserved = self.reserved_capacity.write();
+        *reserved = reserved
+            .checked_sub(self.capacity)
+            .expect("reserved pipe capacity must include every live pipe");
     }
 }
 
@@ -188,4 +222,5 @@ struct PipeState {
     atomic_write_size: usize,
     read_open: bool,
     write_open: bool,
+    _capacity_reservation: PipeCapacityReservation,
 }

--- a/litebox_broker_core/src/policy.rs
+++ b/litebox_broker_core/src/policy.rs
@@ -23,6 +23,8 @@ pub enum PolicyProfile {
 pub struct PrincipalRights {
     /// Rights for event objects.
     pub event: ObjectRights,
+    /// Rights for pipe objects.
+    pub pipe: ObjectRights,
 }
 
 impl PrincipalRights {
@@ -30,12 +32,14 @@ impl PrincipalRights {
     pub const fn all() -> Self {
         Self {
             event: ObjectRights::WAIT.union(ObjectRights::WRITE),
+            pipe: ObjectRights::WAIT.union(ObjectRights::WRITE),
         }
     }
 
     fn object_rights(self, object_kind: ObjectKind) -> ObjectRights {
         match object_kind {
             ObjectKind::Event => self.event,
+            ObjectKind::Pipe => self.pipe,
         }
     }
 }
@@ -109,6 +113,7 @@ mod tests {
     fn static_policy_returns_configured_principal_rights() {
         let policy = PolicyEngine::with_unauthenticated_rights(PrincipalRights {
             event: ObjectRights::WAIT,
+            pipe: ObjectRights::empty(),
         });
 
         assert_eq!(
@@ -121,6 +126,7 @@ mod tests {
     fn empty_principal_rights_deny_object_authorization() {
         let policy = PolicyEngine::with_unauthenticated_rights(PrincipalRights {
             event: ObjectRights::empty(),
+            pipe: ObjectRights::empty(),
         });
 
         assert_eq!(

--- a/litebox_broker_core/src/policy.rs
+++ b/litebox_broker_core/src/policy.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-use crate::session::ObjectKind;
 use crate::{BrokerError, CallerCredential, ObjectRights};
 
 /// Configured broker policy.
@@ -13,35 +12,8 @@ pub enum PolicyProfile {
     /// Static rights for known broker principals.
     Static {
         /// Rights for the unauthenticated principal used by the initial POC.
-        unauthenticated: PrincipalRights,
+        unauthenticated: ObjectRights,
     },
-}
-
-/// Rights granted to one broker principal.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[non_exhaustive]
-pub struct PrincipalRights {
-    /// Rights for event objects.
-    pub event: ObjectRights,
-    /// Rights for pipe objects.
-    pub pipe: ObjectRights,
-}
-
-impl PrincipalRights {
-    /// Grants all currently supported object rights.
-    pub const fn all() -> Self {
-        Self {
-            event: ObjectRights::WAIT.union(ObjectRights::WRITE),
-            pipe: ObjectRights::WAIT.union(ObjectRights::WRITE),
-        }
-    }
-
-    fn object_rights(self, object_kind: ObjectKind) -> ObjectRights {
-        match object_kind {
-            ObjectKind::Event => self.event,
-            ObjectKind::Pipe => self.pipe,
-        }
-    }
 }
 
 /// Broker policy decision and audit component.
@@ -66,22 +38,20 @@ impl PolicyEngine {
     }
 
     /// Creates a policy engine with rights for the unauthenticated principal.
-    pub const fn with_unauthenticated_rights(unauthenticated: PrincipalRights) -> Self {
+    pub const fn with_unauthenticated_rights(unauthenticated: ObjectRights) -> Self {
         Self::new(PolicyProfile::Static { unauthenticated })
     }
 
     pub(crate) fn principal_object_rights(
         &self,
         caller_credential: CallerCredential,
-        object_kind: ObjectKind,
     ) -> Result<ObjectRights, BrokerError> {
-        let principal_rights = match (self.profile, caller_credential) {
+        let rights = match (self.profile, caller_credential) {
             (PolicyProfile::Static { unauthenticated }, CallerCredential::Unauthenticated) => {
                 unauthenticated
             }
             (PolicyProfile::DefaultDeny, _) => return Err(BrokerError::PolicyDenied),
         };
-        let rights = principal_rights.object_rights(object_kind);
         if rights.is_empty() {
             return Err(BrokerError::PolicyDenied);
         }
@@ -101,36 +71,30 @@ mod tests {
 
     #[test]
     fn static_policy_allows_configured_principal_rights() {
-        let policy = PolicyEngine::with_unauthenticated_rights(PrincipalRights::all());
+        let policy = PolicyEngine::with_unauthenticated_rights(ObjectRights::all());
 
         assert_eq!(
-            policy.principal_object_rights(CallerCredential::Unauthenticated, ObjectKind::Event),
+            policy.principal_object_rights(CallerCredential::Unauthenticated),
             Ok(ObjectRights::WAIT | ObjectRights::WRITE)
         );
     }
 
     #[test]
     fn static_policy_returns_configured_principal_rights() {
-        let policy = PolicyEngine::with_unauthenticated_rights(PrincipalRights {
-            event: ObjectRights::WAIT,
-            pipe: ObjectRights::empty(),
-        });
+        let policy = PolicyEngine::with_unauthenticated_rights(ObjectRights::WAIT);
 
         assert_eq!(
-            policy.principal_object_rights(CallerCredential::Unauthenticated, ObjectKind::Event),
+            policy.principal_object_rights(CallerCredential::Unauthenticated),
             Ok(ObjectRights::WAIT)
         );
     }
 
     #[test]
     fn empty_principal_rights_deny_object_authorization() {
-        let policy = PolicyEngine::with_unauthenticated_rights(PrincipalRights {
-            event: ObjectRights::empty(),
-            pipe: ObjectRights::empty(),
-        });
+        let policy = PolicyEngine::with_unauthenticated_rights(ObjectRights::empty());
 
         assert_eq!(
-            policy.principal_object_rights(CallerCredential::Unauthenticated, ObjectKind::Event),
+            policy.principal_object_rights(CallerCredential::Unauthenticated),
             Err(BrokerError::PolicyDenied)
         );
     }

--- a/litebox_broker_core/src/session.rs
+++ b/litebox_broker_core/src/session.rs
@@ -4,7 +4,7 @@
 use alloc::sync::Arc;
 
 use crate::event::EventObject;
-use crate::pipe::{PipeReadEnd, PipeWriteEnd};
+use crate::pipe::PipeObject;
 use crate::{BrokerCore, BrokerError, Result};
 use hashbrown::HashMap;
 use litebox_broker_protocol::ObjectHandle;
@@ -46,23 +46,7 @@ pub(crate) struct ObjectReference {
 
 pub(crate) enum ObjectEntry {
     Event(EventObject),
-    PipeReader(PipeReadEnd),
-    PipeWriter(PipeWriteEnd),
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum ObjectKind {
-    Event,
-    Pipe,
-}
-
-impl ObjectEntry {
-    fn kind(&self) -> ObjectKind {
-        match self {
-            Self::Event(_) => ObjectKind::Event,
-            Self::PipeReader(_) | Self::PipeWriter(_) => ObjectKind::Pipe,
-        }
-    }
+    Pipe(PipeObject),
 }
 
 /// Broker-owned authority token for one authenticated caller session.
@@ -96,7 +80,7 @@ impl BrokerSession {
         let rights = self
             .core
             .policy
-            .principal_object_rights(self.caller_credential, object.kind())?;
+            .principal_object_rights(self.caller_credential)?;
         let mut references = self.core.references.write();
         if references.len() >= self.core.limits.max_references {
             return Err(BrokerError::ResourceExhausted);
@@ -112,6 +96,38 @@ impl BrokerSession {
         );
 
         Ok(handle)
+    }
+
+    pub(crate) fn create_object_reference_pair(
+        &self,
+        first: ObjectEntry,
+        second: ObjectEntry,
+    ) -> Result<(ObjectHandle, ObjectHandle)> {
+        let rights = self
+            .core
+            .policy
+            .principal_object_rights(self.caller_credential)?;
+        let mut references = self.core.references.write();
+        if references
+            .len()
+            .checked_add(2)
+            .is_none_or(|count| count > self.core.limits.max_references)
+        {
+            return Err(BrokerError::ResourceExhausted);
+        }
+        let first_handle = self.core.allocate_reference_handle()?;
+        let second_handle = self.core.allocate_reference_handle()?;
+        for (handle, object) in [(first_handle, first), (second_handle, second)] {
+            references.insert(
+                handle,
+                ObjectReference {
+                    object: Arc::new(RwLock::new(object)),
+                    session_id: self.session_id,
+                    rights,
+                },
+            );
+        }
+        Ok((first_handle, second_handle))
     }
 
     pub(crate) fn with_authorized_object<T>(
@@ -182,16 +198,17 @@ impl Drop for BrokerSession {
 #[cfg(test)]
 mod tests {
     use crate::{
-        BrokerCore, BrokerCoreLimits, BrokerError, CallerCredential, PolicyEngine, PrincipalRights,
+        BrokerCore, BrokerCoreLimits, BrokerError, CallerCredential, ObjectRights, PolicyEngine,
     };
     use litebox_broker_protocol::ObjectHandle;
-    use litebox_broker_protocol::event::{EventConsumeMode, EventConsumption, ReadinessState};
+    use litebox_broker_protocol::event::{EventConsumeMode, EventConsumption};
+    use litebox_broker_protocol::readiness::ReadinessFlags;
 
     #[test]
     fn object_reference_lifecycle_uses_public_core_constructor_once() {
         let broker = BrokerCore::new_with_limits(
-            PolicyEngine::with_unauthenticated_rights(PrincipalRights::all()),
-            BrokerCoreLimits::new(2),
+            PolicyEngine::with_unauthenticated_rights(ObjectRights::all()),
+            BrokerCoreLimits::new(2).with_max_total_pipe_capacity(4),
         )
         .unwrap();
         let session = broker
@@ -216,26 +233,17 @@ mod tests {
 
         assert_eq!(
             crate::event::wait(&session, handle),
-            Ok(ReadinessState {
-                read_ready: false,
-                write_ready: true,
-            })
+            Ok(ReadinessFlags::WRITE)
         );
         assert_eq!(
             crate::event::add(&session, handle, 1),
-            Ok(ReadinessState {
-                read_ready: true,
-                write_ready: true,
-            })
+            Ok(ReadinessFlags::READ | ReadinessFlags::WRITE)
         );
         assert_eq!(
             crate::event::consume(&session, handle, EventConsumeMode::One),
             Ok(EventConsumption {
                 value: 1,
-                readiness: ReadinessState {
-                    read_ready: false,
-                    write_ready: true,
-                },
+                readiness: ReadinessFlags::WRITE,
             })
         );
         let second_handle = crate::event::create(&session, 0).unwrap();
@@ -243,6 +251,11 @@ mod tests {
             crate::event::create(&session, 0),
             Err(BrokerError::ResourceExhausted)
         );
+        assert_eq!(
+            crate::pipe::create(&session, 4, 2),
+            Err(BrokerError::ResourceExhausted)
+        );
+        assert_eq!(*broker.reserved_pipe_capacity.read(), 0);
         assert_eq!(session.close_object_reference(second_handle), Ok(()));
 
         assert_eq!(session.close_object_reference(handle), Ok(()));
@@ -274,14 +287,16 @@ mod tests {
         let session = broker
             .create_session(CallerCredential::Unauthenticated)
             .unwrap();
+        assert_eq!(
+            crate::pipe::create(&session, 5, 2),
+            Err(BrokerError::ResourceExhausted)
+        );
+        assert_eq!(*broker.reserved_pipe_capacity.read(), 0);
         let (reader, writer) = crate::pipe::create(&session, 4, 2).unwrap();
+        assert_eq!(*broker.reserved_pipe_capacity.read(), 4);
         assert_eq!(
             crate::pipe::check_readiness(&session, reader),
-            Ok(litebox_broker_protocol::pipe::PipeReadinessState {
-                endpoint: litebox_broker_protocol::pipe::PipeEndpoint::Read,
-                ready: false,
-                peer_closed: false,
-            })
+            Ok(ReadinessFlags::default())
         );
         assert_eq!(
             crate::pipe::read(&session, reader, 1),
@@ -299,13 +314,10 @@ mod tests {
         );
         assert_eq!(crate::pipe::write(&session, writer, &[5, 6]), Ok(2));
         assert_eq!(session.close_object_reference(writer), Ok(()));
+        assert_eq!(*broker.reserved_pipe_capacity.read(), 4);
         assert_eq!(
             crate::pipe::check_readiness(&session, reader),
-            Ok(litebox_broker_protocol::pipe::PipeReadinessState {
-                endpoint: litebox_broker_protocol::pipe::PipeEndpoint::Read,
-                ready: true,
-                peer_closed: true,
-            })
+            Ok(ReadinessFlags::READ | ReadinessFlags::HANGUP)
         );
         assert_eq!(
             crate::pipe::read(&session, reader, 4),
@@ -316,8 +328,10 @@ mod tests {
             Ok(std::vec::Vec::new())
         );
         assert_eq!(session.close_object_reference(reader), Ok(()));
+        assert_eq!(*broker.reserved_pipe_capacity.read(), 0);
 
         let (reader, writer) = crate::pipe::create(&session, 4, 2).unwrap();
+        assert_eq!(*broker.reserved_pipe_capacity.read(), 4);
         assert_eq!(session.close_object_reference(reader), Ok(()));
         assert_eq!(
             crate::pipe::write(&session, writer, &[1]),
@@ -325,13 +339,10 @@ mod tests {
         );
         assert_eq!(
             crate::pipe::check_readiness(&session, writer),
-            Ok(litebox_broker_protocol::pipe::PipeReadinessState {
-                endpoint: litebox_broker_protocol::pipe::PipeEndpoint::Write,
-                ready: false,
-                peer_closed: true,
-            })
+            Ok(ReadinessFlags::ERROR)
         );
         assert_eq!(session.close_object_reference(writer), Ok(()));
+        assert_eq!(*broker.reserved_pipe_capacity.read(), 0);
 
         {
             let mut next_reference_handle = broker.next_reference_handle.write();

--- a/litebox_broker_core/src/session.rs
+++ b/litebox_broker_core/src/session.rs
@@ -82,15 +82,9 @@ impl BrokerSession {
             .policy
             .principal_object_rights(self.caller_credential)?;
         let mut references = self.core.references.write();
-        let reserved_references = self.core.reserved_references.read();
-        if references
-            .len()
-            .checked_add(*reserved_references)
-            .is_none_or(|count| count >= self.core.limits.max_references)
-        {
+        if references.len() >= self.core.limits.max_references {
             return Err(BrokerError::ResourceExhausted);
         }
-        drop(reserved_references);
         let handle = self.core.allocate_reference_handle()?;
         references.insert(
             handle,
@@ -106,19 +100,23 @@ impl BrokerSession {
 
     pub(crate) fn create_object_reference_pair(
         &self,
-        create_objects: impl FnOnce() -> Result<(ObjectEntry, ObjectEntry)>,
+        first: ObjectEntry,
+        second: ObjectEntry,
     ) -> Result<(ObjectHandle, ObjectHandle)> {
         let rights = self
             .core
             .policy
             .principal_object_rights(self.caller_credential)?;
-        let mut reservation = ObjectReferenceReservation::new(&self.core, 2)?;
-        let (first, second) = create_objects()?;
+        let mut references = self.core.references.write();
+        if references
+            .len()
+            .checked_add(2)
+            .is_none_or(|count| count > self.core.limits.max_references)
+        {
+            return Err(BrokerError::ResourceExhausted);
+        }
         let first_handle = self.core.allocate_reference_handle()?;
         let second_handle = self.core.allocate_reference_handle()?;
-        let mut references = self.core.references.write();
-        let mut reserved_references = self.core.reserved_references.write();
-        reservation.consume(&mut reserved_references);
         for (handle, object) in [(first_handle, first), (second_handle, second)] {
             references.insert(
                 handle,
@@ -191,52 +189,6 @@ impl BrokerSession {
     }
 }
 
-struct ObjectReferenceReservation {
-    reserved_references: Arc<RwLock<usize>>,
-    count: usize,
-    active: bool,
-}
-
-impl ObjectReferenceReservation {
-    fn new(core: &BrokerCore, count: usize) -> Result<Self> {
-        let references = core.references.read();
-        let reserved_references = Arc::clone(&core.reserved_references);
-        {
-            let mut reserved = reserved_references.write();
-            let new_total = references
-                .len()
-                .checked_add(*reserved)
-                .and_then(|total| total.checked_add(count))
-                .filter(|total| *total <= core.limits.max_references)
-                .ok_or(BrokerError::ResourceExhausted)?;
-            *reserved = new_total - references.len();
-        }
-        Ok(Self {
-            reserved_references,
-            count,
-            active: true,
-        })
-    }
-
-    fn consume(&mut self, reserved_references: &mut usize) {
-        *reserved_references = reserved_references
-            .checked_sub(self.count)
-            .expect("reserved reference count must include every active reservation");
-        self.active = false;
-    }
-}
-
-impl Drop for ObjectReferenceReservation {
-    fn drop(&mut self) {
-        if self.active {
-            let mut reserved = self.reserved_references.write();
-            *reserved = reserved
-                .checked_sub(self.count)
-                .expect("reserved reference count must include every active reservation");
-        }
-    }
-}
-
 impl Drop for BrokerSession {
     fn drop(&mut self) {
         self.core.close_session(self.session_id);
@@ -303,7 +255,6 @@ mod tests {
             crate::pipe::create(&session, 4, 2),
             Err(BrokerError::ResourceExhausted)
         );
-        assert_eq!(*broker.reserved_references.read(), 0);
         assert_eq!(*broker.reserved_pipe_capacity.read(), 0);
         assert_eq!(session.close_object_reference(second_handle), Ok(()));
 
@@ -340,10 +291,8 @@ mod tests {
             crate::pipe::create(&session, 5, 2),
             Err(BrokerError::ResourceExhausted)
         );
-        assert_eq!(*broker.reserved_references.read(), 0);
         assert_eq!(*broker.reserved_pipe_capacity.read(), 0);
         let (reader, writer) = crate::pipe::create(&session, 4, 2).unwrap();
-        assert_eq!(*broker.reserved_references.read(), 0);
         assert_eq!(*broker.reserved_pipe_capacity.read(), 4);
         assert_eq!(
             crate::pipe::check_readiness(&session, reader),

--- a/litebox_broker_core/src/session.rs
+++ b/litebox_broker_core/src/session.rs
@@ -4,6 +4,7 @@
 use alloc::sync::Arc;
 
 use crate::event::EventObject;
+use crate::pipe::{PipeReadEnd, PipeWriteEnd};
 use crate::{BrokerCore, BrokerError, Result};
 use hashbrown::HashMap;
 use litebox_broker_protocol::ObjectHandle;
@@ -43,20 +44,23 @@ pub(crate) struct ObjectReference {
     pub(crate) rights: ObjectRights,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum ObjectEntry {
     Event(EventObject),
+    PipeReader(PipeReadEnd),
+    PipeWriter(PipeWriteEnd),
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum ObjectKind {
     Event,
+    Pipe,
 }
 
 impl ObjectEntry {
-    fn kind(self) -> ObjectKind {
+    fn kind(&self) -> ObjectKind {
         match self {
             Self::Event(_) => ObjectKind::Event,
+            Self::PipeReader(_) | Self::PipeWriter(_) => ObjectKind::Pipe,
         }
     }
 }
@@ -187,7 +191,7 @@ mod tests {
     fn object_reference_lifecycle_uses_public_core_constructor_once() {
         let broker = BrokerCore::new_with_limits(
             PolicyEngine::with_unauthenticated_rights(PrincipalRights::all()),
-            BrokerCoreLimits::new(1),
+            BrokerCoreLimits::new(2),
         )
         .unwrap();
         let session = broker
@@ -234,10 +238,12 @@ mod tests {
                 },
             })
         );
+        let second_handle = crate::event::create(&session, 0).unwrap();
         assert_eq!(
             crate::event::create(&session, 0),
             Err(BrokerError::ResourceExhausted)
         );
+        assert_eq!(session.close_object_reference(second_handle), Ok(()));
 
         assert_eq!(session.close_object_reference(handle), Ok(()));
         {
@@ -268,6 +274,65 @@ mod tests {
         let session = broker
             .create_session(CallerCredential::Unauthenticated)
             .unwrap();
+        let (reader, writer) = crate::pipe::create(&session, 4, 2).unwrap();
+        assert_eq!(
+            crate::pipe::check_readiness(&session, reader),
+            Ok(litebox_broker_protocol::pipe::PipeReadinessState {
+                endpoint: litebox_broker_protocol::pipe::PipeEndpoint::Read,
+                ready: false,
+                peer_closed: false,
+            })
+        );
+        assert_eq!(
+            crate::pipe::read(&session, reader, 1),
+            Err(BrokerError::WouldBlock)
+        );
+        assert_eq!(crate::pipe::write(&session, writer, &[1, 2]), Ok(2));
+        assert_eq!(crate::pipe::write(&session, writer, &[3, 4, 5]), Ok(2));
+        assert_eq!(
+            crate::pipe::write(&session, writer, &[5]),
+            Err(BrokerError::WouldBlock)
+        );
+        assert_eq!(
+            crate::pipe::read(&session, reader, 3),
+            Ok(std::vec::Vec::from([1, 2, 3]))
+        );
+        assert_eq!(crate::pipe::write(&session, writer, &[5, 6]), Ok(2));
+        assert_eq!(session.close_object_reference(writer), Ok(()));
+        assert_eq!(
+            crate::pipe::check_readiness(&session, reader),
+            Ok(litebox_broker_protocol::pipe::PipeReadinessState {
+                endpoint: litebox_broker_protocol::pipe::PipeEndpoint::Read,
+                ready: true,
+                peer_closed: true,
+            })
+        );
+        assert_eq!(
+            crate::pipe::read(&session, reader, 4),
+            Ok(std::vec::Vec::from([4, 5, 6]))
+        );
+        assert_eq!(
+            crate::pipe::read(&session, reader, 1),
+            Ok(std::vec::Vec::new())
+        );
+        assert_eq!(session.close_object_reference(reader), Ok(()));
+
+        let (reader, writer) = crate::pipe::create(&session, 4, 2).unwrap();
+        assert_eq!(session.close_object_reference(reader), Ok(()));
+        assert_eq!(
+            crate::pipe::write(&session, writer, &[1]),
+            Err(BrokerError::PeerClosed)
+        );
+        assert_eq!(
+            crate::pipe::check_readiness(&session, writer),
+            Ok(litebox_broker_protocol::pipe::PipeReadinessState {
+                endpoint: litebox_broker_protocol::pipe::PipeEndpoint::Write,
+                ready: false,
+                peer_closed: true,
+            })
+        );
+        assert_eq!(session.close_object_reference(writer), Ok(()));
+
         {
             let mut next_reference_handle = broker.next_reference_handle.write();
             *next_reference_handle = u64::MAX;

--- a/litebox_broker_core/src/session.rs
+++ b/litebox_broker_core/src/session.rs
@@ -333,13 +333,14 @@ mod tests {
         let (reader, writer) = crate::pipe::create(&session, 4, 2).unwrap();
         assert_eq!(*broker.reserved_pipe_capacity.read(), 4);
         assert_eq!(session.close_object_reference(reader), Ok(()));
+        assert_eq!(crate::pipe::write(&session, writer, &[]), Ok(0));
         assert_eq!(
             crate::pipe::write(&session, writer, &[1]),
             Err(BrokerError::PeerClosed)
         );
         assert_eq!(
             crate::pipe::check_readiness(&session, writer),
-            Ok(ReadinessFlags::ERROR)
+            Ok(ReadinessFlags::WRITE | ReadinessFlags::ERROR)
         );
         assert_eq!(session.close_object_reference(writer), Ok(()));
         assert_eq!(*broker.reserved_pipe_capacity.read(), 0);

--- a/litebox_broker_core/src/session.rs
+++ b/litebox_broker_core/src/session.rs
@@ -82,9 +82,15 @@ impl BrokerSession {
             .policy
             .principal_object_rights(self.caller_credential)?;
         let mut references = self.core.references.write();
-        if references.len() >= self.core.limits.max_references {
+        let reserved_references = self.core.reserved_references.read();
+        if references
+            .len()
+            .checked_add(*reserved_references)
+            .is_none_or(|count| count >= self.core.limits.max_references)
+        {
             return Err(BrokerError::ResourceExhausted);
         }
+        drop(reserved_references);
         let handle = self.core.allocate_reference_handle()?;
         references.insert(
             handle,
@@ -100,23 +106,19 @@ impl BrokerSession {
 
     pub(crate) fn create_object_reference_pair(
         &self,
-        first: ObjectEntry,
-        second: ObjectEntry,
+        create_objects: impl FnOnce() -> Result<(ObjectEntry, ObjectEntry)>,
     ) -> Result<(ObjectHandle, ObjectHandle)> {
         let rights = self
             .core
             .policy
             .principal_object_rights(self.caller_credential)?;
-        let mut references = self.core.references.write();
-        if references
-            .len()
-            .checked_add(2)
-            .is_none_or(|count| count > self.core.limits.max_references)
-        {
-            return Err(BrokerError::ResourceExhausted);
-        }
+        let mut reservation = ObjectReferenceReservation::new(&self.core, 2)?;
+        let (first, second) = create_objects()?;
         let first_handle = self.core.allocate_reference_handle()?;
         let second_handle = self.core.allocate_reference_handle()?;
+        let mut references = self.core.references.write();
+        let mut reserved_references = self.core.reserved_references.write();
+        reservation.consume(&mut reserved_references);
         for (handle, object) in [(first_handle, first), (second_handle, second)] {
             references.insert(
                 handle,
@@ -189,6 +191,52 @@ impl BrokerSession {
     }
 }
 
+struct ObjectReferenceReservation {
+    reserved_references: Arc<RwLock<usize>>,
+    count: usize,
+    active: bool,
+}
+
+impl ObjectReferenceReservation {
+    fn new(core: &BrokerCore, count: usize) -> Result<Self> {
+        let references = core.references.read();
+        let reserved_references = Arc::clone(&core.reserved_references);
+        {
+            let mut reserved = reserved_references.write();
+            let new_total = references
+                .len()
+                .checked_add(*reserved)
+                .and_then(|total| total.checked_add(count))
+                .filter(|total| *total <= core.limits.max_references)
+                .ok_or(BrokerError::ResourceExhausted)?;
+            *reserved = new_total - references.len();
+        }
+        Ok(Self {
+            reserved_references,
+            count,
+            active: true,
+        })
+    }
+
+    fn consume(&mut self, reserved_references: &mut usize) {
+        *reserved_references = reserved_references
+            .checked_sub(self.count)
+            .expect("reserved reference count must include every active reservation");
+        self.active = false;
+    }
+}
+
+impl Drop for ObjectReferenceReservation {
+    fn drop(&mut self) {
+        if self.active {
+            let mut reserved = self.reserved_references.write();
+            *reserved = reserved
+                .checked_sub(self.count)
+                .expect("reserved reference count must include every active reservation");
+        }
+    }
+}
+
 impl Drop for BrokerSession {
     fn drop(&mut self) {
         self.core.close_session(self.session_id);
@@ -255,6 +303,7 @@ mod tests {
             crate::pipe::create(&session, 4, 2),
             Err(BrokerError::ResourceExhausted)
         );
+        assert_eq!(*broker.reserved_references.read(), 0);
         assert_eq!(*broker.reserved_pipe_capacity.read(), 0);
         assert_eq!(session.close_object_reference(second_handle), Ok(()));
 
@@ -291,8 +340,10 @@ mod tests {
             crate::pipe::create(&session, 5, 2),
             Err(BrokerError::ResourceExhausted)
         );
+        assert_eq!(*broker.reserved_references.read(), 0);
         assert_eq!(*broker.reserved_pipe_capacity.read(), 0);
         let (reader, writer) = crate::pipe::create(&session, 4, 2).unwrap();
+        assert_eq!(*broker.reserved_references.read(), 0);
         assert_eq!(*broker.reserved_pipe_capacity.read(), 4);
         assert_eq!(
             crate::pipe::check_readiness(&session, reader),

--- a/litebox_broker_core/src/session.rs
+++ b/litebox_broker_core/src/session.rs
@@ -256,7 +256,7 @@ mod tests {
     fn object_reference_lifecycle_uses_public_core_constructor_once() {
         let broker = BrokerCore::new_with_limits(
             PolicyEngine::with_unauthenticated_rights(ObjectRights::all()),
-            BrokerCoreLimits::new(2).with_max_total_pipe_capacity(4),
+            BrokerCoreLimits::new(2, 4),
         )
         .unwrap();
         let session = broker

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -21,6 +21,10 @@ use litebox_broker_protocol::error::ErrorCode;
 use litebox_broker_protocol::event::{AddEventResponse, CreateEventResponse, WaitEventResponse};
 use litebox_broker_protocol::message::{
     BrokerHandshakeResponse, BrokerRequest, BrokerResponse, EventRequest, EventResponse,
+    PipeRequest, PipeResponse,
+};
+use litebox_broker_protocol::pipe::{
+    CheckPipeReadinessResponse, CreatePipeResponse, ReadPipeResponse, WritePipeResponse,
 };
 
 mod error;
@@ -119,6 +123,46 @@ fn handle_request(session: &BrokerSession, request: BrokerRequest) -> BrokerResp
             Err(error) => BrokerResponse::Error(error.into()),
         },
         BrokerRequest::Event(request) => handle_event_request(session, request),
+        BrokerRequest::Pipe(request) => handle_pipe_request(session, request),
+    }
+}
+
+fn handle_pipe_request(session: &BrokerSession, request: PipeRequest) -> BrokerResponse {
+    let response = match request {
+        PipeRequest::Create(request) => {
+            litebox_broker_core::pipe::create(session, request.capacity, request.atomic_write_size)
+                .map(|(read_handle, write_handle)| {
+                    PipeResponse::Create(CreatePipeResponse {
+                        read_handle,
+                        write_handle,
+                    })
+                })
+        }
+        PipeRequest::Read(request) => {
+            litebox_broker_core::pipe::read(session, request.handle, request.length)
+                .map(|data| PipeResponse::Read(ReadPipeResponse { data }))
+        }
+        PipeRequest::Write(request) => {
+            litebox_broker_core::pipe::write(session, request.handle, &request.data).and_then(
+                |written| {
+                    Ok(PipeResponse::Write(WritePipeResponse {
+                        written: written
+                            .try_into()
+                            .map_err(|_| litebox_broker_core::BrokerError::ResourceExhausted)?,
+                    }))
+                },
+            )
+        }
+        PipeRequest::CheckReadiness(request) => {
+            litebox_broker_core::pipe::check_readiness(session, request.handle).map(|readiness| {
+                PipeResponse::CheckReadiness(CheckPipeReadinessResponse { readiness })
+            })
+        }
+    };
+
+    match response {
+        Ok(response) => BrokerResponse::Pipe(response),
+        Err(error) => BrokerResponse::Error(error.into()),
     }
 }
 

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -214,7 +214,7 @@ pub enum ConnectionTermination {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use litebox_broker_core::{PolicyEngine, PrincipalRights};
+    use litebox_broker_core::{ObjectRights, PolicyEngine};
     use litebox_broker_protocol::event::{
         AddEventRequest, ConsumeEventRequest, CreateEventRequest, EventConsumeMode,
         WaitEventRequest,
@@ -225,7 +225,7 @@ mod tests {
     #[test]
     fn host_request_handling_uses_one_broker_core() {
         let broker = BrokerCore::new(PolicyEngine::with_unauthenticated_rights(
-            PrincipalRights::all(),
+            ObjectRights::all(),
         ))
         .unwrap();
 
@@ -381,18 +381,13 @@ mod tests {
             &channel.responses[1..],
             [
                 BrokerResponse::Event(EventResponse::Add(AddEventResponse {
-                    readiness: litebox_broker_protocol::event::ReadinessState {
-                        read_ready: true,
-                        write_ready: true,
-                    },
+                    readiness: litebox_broker_protocol::readiness::ReadinessFlags::READ
+                        | litebox_broker_protocol::readiness::ReadinessFlags::WRITE,
                 })),
                 BrokerResponse::Event(EventResponse::Consume(
                     litebox_broker_protocol::event::ConsumeEventResponse {
                         value: 1,
-                        readiness: litebox_broker_protocol::event::ReadinessState {
-                            read_ready: false,
-                            write_ready: true,
-                        },
+                        readiness: litebox_broker_protocol::readiness::ReadinessFlags::WRITE,
                     }
                 )),
             ]

--- a/litebox_broker_local/src/event.rs
+++ b/litebox_broker_local/src/event.rs
@@ -5,11 +5,12 @@ use litebox_broker_protocol::ObjectHandle;
 use litebox_broker_protocol::channel::LocalControlChannel;
 use litebox_broker_protocol::event::{
     AddEventRequest, ConsumeEventRequest, ConsumeEventResponse, CreateEventRequest,
-    EventConsumeMode, ReadinessState, WaitEventRequest,
+    EventConsumeMode, WaitEventRequest,
 };
 use litebox_broker_protocol::message::{
     BrokerRequest, BrokerResponse, EventRequest, EventResponse,
 };
+use litebox_broker_protocol::readiness::ReadinessFlags;
 
 use crate::{BrokerLocal, BrokerLocalError, Result};
 
@@ -38,7 +39,7 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
     ///
     /// Panics if the broker reports an unrecoverable error or returns a protocol
     /// response that does not match the issued event request.
-    pub fn wait_event(&mut self, handle: ObjectHandle) -> Result<ReadinessState, Channel::Error> {
+    pub fn wait_event(&mut self, handle: ObjectHandle) -> Result<ReadinessFlags, Channel::Error> {
         let response = self.request_event(EventRequest::Wait(WaitEventRequest { handle }))?;
         match response {
             EventResponse::Wait(response) => Ok(response.readiness),
@@ -56,7 +57,7 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
         &mut self,
         handle: ObjectHandle,
         value: u64,
-    ) -> Result<ReadinessState, Channel::Error> {
+    ) -> Result<ReadinessFlags, Channel::Error> {
         let response = self.request_event(EventRequest::Add(AddEventRequest { handle, value }))?;
         match response {
             EventResponse::Add(response) => Ok(response.readiness),

--- a/litebox_broker_local/src/event.rs
+++ b/litebox_broker_local/src/event.rs
@@ -87,7 +87,7 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
         match self.request(BrokerRequest::Event(request))? {
             BrokerResponse::Event(response) => Ok(response),
             BrokerResponse::Error(error) => Err(BrokerLocalError::Broker(error)),
-            response @ BrokerResponse::ObjectClosed => {
+            response @ (BrokerResponse::ObjectClosed | BrokerResponse::Pipe(_)) => {
                 panic!("broker returned unexpected event response: {response:?}");
             }
         }

--- a/litebox_broker_local/src/lib.rs
+++ b/litebox_broker_local/src/lib.rs
@@ -107,7 +107,8 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
                 | ErrorCode::InvalidRights
                 | ErrorCode::ResourceExhausted
                 | ErrorCode::WouldBlock
-                | ErrorCode::PeerClosed => Err(BrokerLocalError::Broker(error)),
+                | ErrorCode::PeerClosed
+                | ErrorCode::OutOfMemory => Err(BrokerLocalError::Broker(error)),
                 ErrorCode::UnsupportedVersion
                 | ErrorCode::MalformedRequest
                 | ErrorCode::ProtocolState

--- a/litebox_broker_local/src/lib.rs
+++ b/litebox_broker_local/src/lib.rs
@@ -11,11 +11,14 @@
 
 #![no_std]
 
+extern crate alloc;
+
 #[cfg(test)]
 extern crate std;
 
 mod error;
 mod event;
+mod pipe;
 
 use litebox_broker_protocol::channel::{LocalControlChannel, LocalNotificationChannel};
 use litebox_broker_protocol::error::ErrorCode;
@@ -103,7 +106,8 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
                 | ErrorCode::UnknownObject
                 | ErrorCode::InvalidRights
                 | ErrorCode::ResourceExhausted
-                | ErrorCode::WouldBlock => Err(BrokerLocalError::Broker(error)),
+                | ErrorCode::WouldBlock
+                | ErrorCode::PeerClosed => Err(BrokerLocalError::Broker(error)),
                 ErrorCode::UnsupportedVersion
                 | ErrorCode::MalformedRequest
                 | ErrorCode::ProtocolState
@@ -111,7 +115,9 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
                 | ErrorCode::Internal => panic!("broker returned unrecoverable error: {error}"),
                 _ => panic!("broker returned unsupported error: {error}"),
             },
-            response @ (BrokerResponse::Event(_) | BrokerResponse::ObjectClosed) => Ok(response),
+            response @ (BrokerResponse::Event(_)
+            | BrokerResponse::Pipe(_)
+            | BrokerResponse::ObjectClosed) => Ok(response),
         }
     }
 
@@ -125,7 +131,7 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
         match self.request(BrokerRequest::CloseObject(handle))? {
             BrokerResponse::ObjectClosed => Ok(()),
             BrokerResponse::Error(error) => Err(BrokerLocalError::Broker(error)),
-            response @ BrokerResponse::Event(_) => {
+            response @ (BrokerResponse::Event(_) | BrokerResponse::Pipe(_)) => {
                 panic!("broker returned unexpected close response: {response:?}");
             }
         }

--- a/litebox_broker_local/src/lib.rs
+++ b/litebox_broker_local/src/lib.rs
@@ -163,7 +163,7 @@ mod tests {
     use litebox_broker_protocol::channel::LocalNotificationChannel;
     use litebox_broker_protocol::event::{CreateEventRequest, CreateEventResponse};
     use litebox_broker_protocol::message::{
-        EventReadinessNotification, EventRequest, EventResponse,
+        EventRequest, EventResponse, ReadinessFlags, ReadinessNotification,
     };
 
     #[test]
@@ -254,12 +254,9 @@ mod tests {
 
     #[test]
     fn notification_receiver_returns_broker_notifications() {
-        let notification = BrokerNotification::EventReadiness(EventReadinessNotification {
+        let notification = BrokerNotification::Readiness(ReadinessNotification {
             handle: ObjectHandle(7),
-            readiness: litebox_broker_protocol::event::ReadinessState {
-                read_ready: true,
-                write_ready: false,
-            },
+            events: ReadinessFlags::READ,
         });
         let mut receiver = BrokerNotifications::new(FakeNotificationChannel {
             notification: Some(notification.clone()),

--- a/litebox_broker_local/src/lib.rs
+++ b/litebox_broker_local/src/lib.rs
@@ -162,9 +162,8 @@ mod tests {
     use litebox_broker_protocol::ProtocolVersion;
     use litebox_broker_protocol::channel::LocalNotificationChannel;
     use litebox_broker_protocol::event::{CreateEventRequest, CreateEventResponse};
-    use litebox_broker_protocol::message::{
-        EventRequest, EventResponse, ReadinessFlags, ReadinessNotification,
-    };
+    use litebox_broker_protocol::message::{EventRequest, EventResponse, ReadinessNotification};
+    use litebox_broker_protocol::readiness::ReadinessFlags;
 
     #[test]
     fn negotiate_returns_active_local_connection() {

--- a/litebox_broker_local/src/pipe.rs
+++ b/litebox_broker_local/src/pipe.rs
@@ -7,9 +7,10 @@ use litebox_broker_protocol::ObjectHandle;
 use litebox_broker_protocol::channel::LocalControlChannel;
 use litebox_broker_protocol::message::{BrokerRequest, BrokerResponse, PipeRequest, PipeResponse};
 use litebox_broker_protocol::pipe::{
-    CheckPipeReadinessRequest, CreatePipeRequest, CreatePipeResponse, PipeReadinessState,
-    ReadPipeRequest, WritePipeRequest,
+    CheckPipeReadinessRequest, CreatePipeRequest, CreatePipeResponse, ReadPipeRequest,
+    WritePipeRequest,
 };
+use litebox_broker_protocol::readiness::ReadinessFlags;
 
 use crate::{BrokerLocal, BrokerLocalError, Result};
 
@@ -80,7 +81,7 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
     pub fn check_pipe_readiness(
         &mut self,
         handle: ObjectHandle,
-    ) -> Result<PipeReadinessState, Channel::Error> {
+    ) -> Result<ReadinessFlags, Channel::Error> {
         match self.request_pipe(PipeRequest::CheckReadiness(CheckPipeReadinessRequest {
             handle,
         }))? {

--- a/litebox_broker_local/src/pipe.rs
+++ b/litebox_broker_local/src/pipe.rs
@@ -1,0 +1,101 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+use alloc::vec::Vec;
+
+use litebox_broker_protocol::ObjectHandle;
+use litebox_broker_protocol::channel::LocalControlChannel;
+use litebox_broker_protocol::message::{BrokerRequest, BrokerResponse, PipeRequest, PipeResponse};
+use litebox_broker_protocol::pipe::{
+    CheckPipeReadinessRequest, CreatePipeRequest, CreatePipeResponse, PipeReadinessState,
+    ReadPipeRequest, WritePipeRequest,
+};
+
+use crate::{BrokerLocal, BrokerLocalError, Result};
+
+impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
+    /// Creates a broker-owned byte pipe.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the broker reports an unrecoverable error or returns a
+    /// response that does not match the issued pipe request.
+    pub fn create_pipe(
+        &mut self,
+        capacity: u64,
+        atomic_write_size: u64,
+    ) -> Result<CreatePipeResponse, Channel::Error> {
+        match self.request_pipe(PipeRequest::Create(CreatePipeRequest {
+            capacity,
+            atomic_write_size,
+        }))? {
+            PipeResponse::Create(response) => Ok(response),
+            response => panic!("broker returned unexpected pipe response: {response:?}"),
+        }
+    }
+
+    /// Reads bytes from a broker-owned pipe.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the broker reports an unrecoverable error or returns a
+    /// response that does not match the issued pipe request.
+    pub fn read_pipe(
+        &mut self,
+        handle: ObjectHandle,
+        length: u32,
+    ) -> Result<Vec<u8>, Channel::Error> {
+        match self.request_pipe(PipeRequest::Read(ReadPipeRequest { handle, length }))? {
+            PipeResponse::Read(response) => Ok(response.data),
+            response => panic!("broker returned unexpected pipe response: {response:?}"),
+        }
+    }
+
+    /// Writes bytes to a broker-owned pipe.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the broker reports an unrecoverable error or returns a
+    /// response that does not match the issued pipe request.
+    pub fn write_pipe(
+        &mut self,
+        handle: ObjectHandle,
+        data: &[u8],
+    ) -> Result<usize, Channel::Error> {
+        match self.request_pipe(PipeRequest::Write(WritePipeRequest {
+            handle,
+            data: data.to_vec(),
+        }))? {
+            PipeResponse::Write(response) => Ok(response.written as usize),
+            response => panic!("broker returned unexpected pipe response: {response:?}"),
+        }
+    }
+
+    /// Checks one broker-owned pipe endpoint's readiness.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the broker reports an unrecoverable error or returns a
+    /// response that does not match the issued pipe request.
+    pub fn check_pipe_readiness(
+        &mut self,
+        handle: ObjectHandle,
+    ) -> Result<PipeReadinessState, Channel::Error> {
+        match self.request_pipe(PipeRequest::CheckReadiness(CheckPipeReadinessRequest {
+            handle,
+        }))? {
+            PipeResponse::CheckReadiness(response) => Ok(response.readiness),
+            response => panic!("broker returned unexpected pipe response: {response:?}"),
+        }
+    }
+
+    fn request_pipe(&mut self, request: PipeRequest) -> Result<PipeResponse, Channel::Error> {
+        match self.request(BrokerRequest::Pipe(request))? {
+            BrokerResponse::Pipe(response) => Ok(response),
+            BrokerResponse::Error(error) => Err(BrokerLocalError::Broker(error)),
+            response @ (BrokerResponse::ObjectClosed | BrokerResponse::Event(_)) => {
+                panic!("broker returned unexpected pipe response: {response:?}");
+            }
+        }
+    }
+}

--- a/litebox_broker_protocol/src/error.rs
+++ b/litebox_broker_protocol/src/error.rs
@@ -29,6 +29,8 @@ pub enum ErrorCode {
     WouldBlock,
     #[error("broker object peer is closed")]
     PeerClosed,
+    #[error("broker memory allocation failed")]
+    OutOfMemory,
 }
 
 impl ErrorCode {
@@ -51,6 +53,7 @@ impl ErrorCode {
             9 => Some(Self::ResourceExhausted),
             10 => Some(Self::WouldBlock),
             11 => Some(Self::PeerClosed),
+            12 => Some(Self::OutOfMemory),
             _ => None,
         }
     }
@@ -69,6 +72,7 @@ impl ErrorCode {
             Self::ResourceExhausted => 9,
             Self::WouldBlock => 10,
             Self::PeerClosed => 11,
+            Self::OutOfMemory => 12,
         }
     }
 }

--- a/litebox_broker_protocol/src/error.rs
+++ b/litebox_broker_protocol/src/error.rs
@@ -27,6 +27,8 @@ pub enum ErrorCode {
     ResourceExhausted,
     #[error("broker operation would block")]
     WouldBlock,
+    #[error("broker object peer is closed")]
+    PeerClosed,
 }
 
 impl ErrorCode {
@@ -48,6 +50,7 @@ impl ErrorCode {
             8 => Some(Self::InvalidRights),
             9 => Some(Self::ResourceExhausted),
             10 => Some(Self::WouldBlock),
+            11 => Some(Self::PeerClosed),
             _ => None,
         }
     }
@@ -65,6 +68,7 @@ impl ErrorCode {
             Self::InvalidRights => 8,
             Self::ResourceExhausted => 9,
             Self::WouldBlock => 10,
+            Self::PeerClosed => 11,
         }
     }
 }

--- a/litebox_broker_protocol/src/event.rs
+++ b/litebox_broker_protocol/src/event.rs
@@ -2,15 +2,7 @@
 // Licensed under the MIT license.
 
 use crate::ObjectHandle;
-
-/// Broker-authoritative readiness state for one object.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub struct ReadinessState {
-    /// Whether an event read/consume operation can complete without blocking.
-    pub read_ready: bool,
-    /// Whether an event write/add operation can complete without blocking.
-    pub write_ready: bool,
-}
+use crate::readiness::ReadinessFlags;
 
 /// How a broker event consume operation should remove readiness credits.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -46,7 +38,7 @@ pub struct WaitEventRequest {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct WaitEventResponse {
     /// Current readiness state.
-    pub readiness: ReadinessState,
+    pub readiness: ReadinessFlags,
 }
 
 /// Request to add readiness credits to an event.
@@ -62,7 +54,7 @@ pub struct AddEventRequest {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct AddEventResponse {
     /// Readiness state after adding credits.
-    pub readiness: ReadinessState,
+    pub readiness: ReadinessFlags,
 }
 
 /// Request to consume readiness credits from an event.
@@ -80,7 +72,7 @@ pub struct EventConsumption {
     /// Number of readiness credits consumed.
     pub value: u64,
     /// Readiness state after consuming credits.
-    pub readiness: ReadinessState,
+    pub readiness: ReadinessFlags,
 }
 
 /// Response to an event consume request.

--- a/litebox_broker_protocol/src/lib.rs
+++ b/litebox_broker_protocol/src/lib.rs
@@ -16,6 +16,7 @@ pub mod channel;
 pub mod error;
 pub mod event;
 pub mod message;
+pub mod pipe;
 pub mod wire;
 
 /// Opaque broker object reference handle.
@@ -29,4 +30,4 @@ pub struct ObjectHandle(pub u64);
 pub struct ProtocolVersion(pub u16);
 
 /// Current broker protocol version.
-pub const BROKER_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion(1);
+pub const BROKER_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion(2);

--- a/litebox_broker_protocol/src/lib.rs
+++ b/litebox_broker_protocol/src/lib.rs
@@ -17,6 +17,7 @@ pub mod error;
 pub mod event;
 pub mod message;
 pub mod pipe;
+pub mod readiness;
 pub mod wire;
 
 /// Opaque broker object reference handle.

--- a/litebox_broker_protocol/src/lib.rs
+++ b/litebox_broker_protocol/src/lib.rs
@@ -31,4 +31,4 @@ pub struct ObjectHandle(pub u64);
 pub struct ProtocolVersion(pub u16);
 
 /// Current broker protocol version.
-pub const BROKER_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion(2);
+pub const BROKER_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion(1);

--- a/litebox_broker_protocol/src/message.rs
+++ b/litebox_broker_protocol/src/message.rs
@@ -6,6 +6,10 @@ use crate::event::{
     AddEventRequest, AddEventResponse, ConsumeEventRequest, ConsumeEventResponse,
     CreateEventRequest, CreateEventResponse, ReadinessState, WaitEventRequest, WaitEventResponse,
 };
+use crate::pipe::{
+    CheckPipeReadinessRequest, CheckPipeReadinessResponse, CreatePipeRequest, CreatePipeResponse,
+    PipeReadinessState, ReadPipeRequest, ReadPipeResponse, WritePipeRequest, WritePipeResponse,
+};
 use crate::{ObjectHandle, ProtocolVersion};
 
 /// Broker handshake request sent before the control channel is active.
@@ -22,6 +26,8 @@ pub enum BrokerRequest {
     CloseObject(ObjectHandle),
     /// Event object request family.
     Event(EventRequest),
+    /// Pipe object request family.
+    Pipe(PipeRequest),
 }
 
 /// Broker handshake response sent before the control channel is active.
@@ -61,6 +67,19 @@ pub enum EventRequest {
     Consume(ConsumeEventRequest),
 }
 
+/// Broker-owned pipe object request.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PipeRequest {
+    /// Create a broker-owned byte pipe.
+    Create(CreatePipeRequest),
+    /// Read bytes from a pipe.
+    Read(ReadPipeRequest),
+    /// Write bytes to a pipe.
+    Write(WritePipeRequest),
+    /// Query one endpoint's readiness.
+    CheckReadiness(CheckPipeReadinessRequest),
+}
+
 /// Broker response sent over an active control channel.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum BrokerResponse {
@@ -68,6 +87,8 @@ pub enum BrokerResponse {
     ObjectClosed,
     /// Event object response family.
     Event(EventResponse),
+    /// Pipe object response family.
+    Pipe(PipeResponse),
     /// Operation failed with an ABI-neutral broker error.
     Error(ErrorCode),
 }
@@ -85,6 +106,19 @@ pub enum EventResponse {
     Consume(ConsumeEventResponse),
 }
 
+/// Broker-owned pipe object response.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PipeResponse {
+    /// Create operation response.
+    Create(CreatePipeResponse),
+    /// Read operation response.
+    Read(ReadPipeResponse),
+    /// Write operation response.
+    Write(WritePipeResponse),
+    /// Readiness query response.
+    CheckReadiness(CheckPipeReadinessResponse),
+}
+
 /// Broker-initiated asynchronous notification.
 ///
 /// Notifications are level-triggered snapshots and may be coalesced or
@@ -94,6 +128,8 @@ pub enum EventResponse {
 pub enum BrokerNotification {
     /// Readiness changed or should be re-checked for a broker-owned event object.
     EventReadiness(EventReadinessNotification),
+    /// Readiness changed or should be re-checked for a broker-owned pipe endpoint.
+    PipeReadiness(PipeReadinessNotification),
 }
 
 /// Readiness notification for a broker-owned event object.
@@ -103,4 +139,13 @@ pub struct EventReadinessNotification {
     pub handle: ObjectHandle,
     /// Current broker-authoritative readiness snapshot.
     pub readiness: ReadinessState,
+}
+
+/// Readiness notification for a broker-owned pipe endpoint.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PipeReadinessNotification {
+    /// Pipe endpoint handle.
+    pub handle: ObjectHandle,
+    /// Current broker-authoritative readiness snapshot.
+    pub readiness: PipeReadinessState,
 }

--- a/litebox_broker_protocol/src/message.rs
+++ b/litebox_broker_protocol/src/message.rs
@@ -10,6 +10,7 @@ use crate::pipe::{
     CheckPipeReadinessRequest, CheckPipeReadinessResponse, CreatePipeRequest, CreatePipeResponse,
     ReadPipeRequest, ReadPipeResponse, WritePipeRequest, WritePipeResponse,
 };
+use crate::readiness::ReadinessFlags;
 use crate::{ObjectHandle, ProtocolVersion};
 
 /// Broker handshake request sent before the control channel is active.
@@ -137,43 +138,4 @@ pub struct ReadinessNotification {
     pub handle: ObjectHandle,
     /// Current broker-authoritative readiness snapshot.
     pub events: ReadinessFlags,
-}
-
-/// Object-neutral readiness flags carried by broker notifications.
-#[repr(transparent)]
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub struct ReadinessFlags(u32);
-
-impl ReadinessFlags {
-    /// Reading can complete without blocking.
-    pub const READ: Self = Self(1 << 0);
-    /// Writing can complete without blocking.
-    pub const WRITE: Self = Self(1 << 1);
-    /// A stream or pipe write peer has closed.
-    pub const HANGUP: Self = Self(1 << 2);
-    /// An object has an error condition.
-    pub const ERROR: Self = Self(1 << 3);
-
-    /// Constructs readiness flags while retaining unknown future bits.
-    pub const fn from_bits_retain(bits: u32) -> Self {
-        Self(bits)
-    }
-
-    /// Returns the raw readiness bits.
-    pub const fn bits(self) -> u32 {
-        self.0
-    }
-
-    /// Returns whether all bits in `other` are present.
-    pub const fn contains(self, other: Self) -> bool {
-        self.0 & other.0 == other.0
-    }
-}
-
-impl core::ops::BitOr for ReadinessFlags {
-    type Output = Self;
-
-    fn bitor(self, rhs: Self) -> Self::Output {
-        Self(self.0 | rhs.0)
-    }
 }

--- a/litebox_broker_protocol/src/message.rs
+++ b/litebox_broker_protocol/src/message.rs
@@ -4,11 +4,11 @@
 use crate::error::ErrorCode;
 use crate::event::{
     AddEventRequest, AddEventResponse, ConsumeEventRequest, ConsumeEventResponse,
-    CreateEventRequest, CreateEventResponse, ReadinessState, WaitEventRequest, WaitEventResponse,
+    CreateEventRequest, CreateEventResponse, WaitEventRequest, WaitEventResponse,
 };
 use crate::pipe::{
     CheckPipeReadinessRequest, CheckPipeReadinessResponse, CreatePipeRequest, CreatePipeResponse,
-    PipeReadinessState, ReadPipeRequest, ReadPipeResponse, WritePipeRequest, WritePipeResponse,
+    ReadPipeRequest, ReadPipeResponse, WritePipeRequest, WritePipeResponse,
 };
 use crate::{ObjectHandle, ProtocolVersion};
 
@@ -126,26 +126,54 @@ pub enum PipeResponse {
 /// re-check authoritative state, not as ordered state transitions.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum BrokerNotification {
-    /// Readiness changed or should be re-checked for a broker-owned event object.
-    EventReadiness(EventReadinessNotification),
-    /// Readiness changed or should be re-checked for a broker-owned pipe endpoint.
-    PipeReadiness(PipeReadinessNotification),
+    /// Readiness changed or should be re-checked for a broker-owned object.
+    Readiness(ReadinessNotification),
 }
 
-/// Readiness notification for a broker-owned event object.
+/// Readiness notification for a broker-owned object.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct EventReadinessNotification {
-    /// Event object handle.
+pub struct ReadinessNotification {
+    /// Broker object handle.
     pub handle: ObjectHandle,
     /// Current broker-authoritative readiness snapshot.
-    pub readiness: ReadinessState,
+    pub events: ReadinessFlags,
 }
 
-/// Readiness notification for a broker-owned pipe endpoint.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct PipeReadinessNotification {
-    /// Pipe endpoint handle.
-    pub handle: ObjectHandle,
-    /// Current broker-authoritative readiness snapshot.
-    pub readiness: PipeReadinessState,
+/// Object-neutral readiness flags carried by broker notifications.
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ReadinessFlags(u32);
+
+impl ReadinessFlags {
+    /// Reading can complete without blocking.
+    pub const READ: Self = Self(1 << 0);
+    /// Writing can complete without blocking.
+    pub const WRITE: Self = Self(1 << 1);
+    /// A stream or pipe write peer has closed.
+    pub const HANGUP: Self = Self(1 << 2);
+    /// An object has an error condition.
+    pub const ERROR: Self = Self(1 << 3);
+
+    /// Constructs readiness flags while retaining unknown future bits.
+    pub const fn from_bits_retain(bits: u32) -> Self {
+        Self(bits)
+    }
+
+    /// Returns the raw readiness bits.
+    pub const fn bits(self) -> u32 {
+        self.0
+    }
+
+    /// Returns whether all bits in `other` are present.
+    pub const fn contains(self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
+
+impl core::ops::BitOr for ReadinessFlags {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        Self(self.0 | rhs.0)
+    }
 }

--- a/litebox_broker_protocol/src/pipe.rs
+++ b/litebox_broker_protocol/src/pipe.rs
@@ -1,0 +1,96 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+use alloc::vec::Vec;
+
+use crate::ObjectHandle;
+
+/// Maximum pipe payload carried by one control-path request or response.
+///
+/// This leaves room for the broker envelope and operation metadata within the
+/// smallest currently supported transport frame.
+pub const MAX_PIPE_TRANSFER_SIZE: u32 = 32 * 1024;
+
+/// Request to create a broker-owned byte pipe.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CreatePipeRequest {
+    /// Maximum number of buffered bytes.
+    pub capacity: u64,
+    /// Maximum write size that must be accepted atomically.
+    pub atomic_write_size: u64,
+}
+
+/// Response to a pipe create request.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CreatePipeResponse {
+    /// Handle for the read endpoint.
+    pub read_handle: ObjectHandle,
+    /// Handle for the write endpoint.
+    pub write_handle: ObjectHandle,
+}
+
+/// Request to read bytes from a pipe endpoint.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ReadPipeRequest {
+    /// Read endpoint handle.
+    pub handle: ObjectHandle,
+    /// Maximum number of bytes to return.
+    pub length: u32,
+}
+
+/// Response containing bytes read from a pipe.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReadPipeResponse {
+    /// Bytes removed from the pipe.
+    pub data: Vec<u8>,
+}
+
+/// Request to write bytes to a pipe endpoint.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WritePipeRequest {
+    /// Write endpoint handle.
+    pub handle: ObjectHandle,
+    /// Bytes to append to the pipe.
+    pub data: Vec<u8>,
+}
+
+/// Response describing a completed pipe write.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct WritePipeResponse {
+    /// Number of bytes appended to the pipe.
+    pub written: u32,
+}
+
+/// Request to query one pipe endpoint's readiness.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CheckPipeReadinessRequest {
+    /// Pipe endpoint handle.
+    pub handle: ObjectHandle,
+}
+
+/// Pipe endpoint kind.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PipeEndpoint {
+    /// Read endpoint.
+    Read,
+    /// Write endpoint.
+    Write,
+}
+
+/// Broker-authoritative readiness for one pipe endpoint.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PipeReadinessState {
+    /// Endpoint described by this snapshot.
+    pub endpoint: PipeEndpoint,
+    /// The endpoint's operation can complete without blocking.
+    pub ready: bool,
+    /// The opposite endpoint has closed.
+    pub peer_closed: bool,
+}
+
+/// Response to a pipe readiness query.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CheckPipeReadinessResponse {
+    /// Current endpoint readiness.
+    pub readiness: PipeReadinessState,
+}

--- a/litebox_broker_protocol/src/pipe.rs
+++ b/litebox_broker_protocol/src/pipe.rs
@@ -4,6 +4,7 @@
 use alloc::vec::Vec;
 
 use crate::ObjectHandle;
+use crate::readiness::ReadinessFlags;
 
 /// Maximum pipe payload carried by one control-path request or response.
 ///
@@ -68,29 +69,9 @@ pub struct CheckPipeReadinessRequest {
     pub handle: ObjectHandle,
 }
 
-/// Pipe endpoint kind.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum PipeEndpoint {
-    /// Read endpoint.
-    Read,
-    /// Write endpoint.
-    Write,
-}
-
-/// Broker-authoritative readiness for one pipe endpoint.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct PipeReadinessState {
-    /// Endpoint described by this snapshot.
-    pub endpoint: PipeEndpoint,
-    /// The endpoint's operation can complete without blocking.
-    pub ready: bool,
-    /// The opposite endpoint has closed.
-    pub peer_closed: bool,
-}
-
 /// Response to a pipe readiness query.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct CheckPipeReadinessResponse {
     /// Current endpoint readiness.
-    pub readiness: PipeReadinessState,
+    pub readiness: ReadinessFlags,
 }

--- a/litebox_broker_protocol/src/readiness.rs
+++ b/litebox_broker_protocol/src/readiness.rs
@@ -6,7 +6,7 @@
 /// Object-neutral readiness flags carried by broker notifications.
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub struct ReadinessFlags(u32);
+pub struct ReadinessFlags(pub u32);
 
 impl ReadinessFlags {
     /// Reading can complete without blocking.
@@ -17,21 +17,6 @@ impl ReadinessFlags {
     pub const HANGUP: Self = Self(1 << 2);
     /// An object has an error condition.
     pub const ERROR: Self = Self(1 << 3);
-
-    /// Constructs readiness flags while retaining unknown future bits.
-    pub const fn from_bits_retain(bits: u32) -> Self {
-        Self(bits)
-    }
-
-    /// Returns the raw readiness bits.
-    pub const fn bits(self) -> u32 {
-        self.0
-    }
-
-    /// Returns whether all bits in `other` are present.
-    pub const fn contains(self, other: Self) -> bool {
-        self.0 & other.0 == other.0
-    }
 }
 
 impl core::ops::BitOr for ReadinessFlags {

--- a/litebox_broker_protocol/src/readiness.rs
+++ b/litebox_broker_protocol/src/readiness.rs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//! Object-neutral readiness values shared by broker notifications.
+
+/// Object-neutral readiness flags carried by broker notifications.
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ReadinessFlags(u32);
+
+impl ReadinessFlags {
+    /// Reading can complete without blocking.
+    pub const READ: Self = Self(1 << 0);
+    /// Writing can complete without blocking.
+    pub const WRITE: Self = Self(1 << 1);
+    /// A stream or pipe write peer has closed.
+    pub const HANGUP: Self = Self(1 << 2);
+    /// An object has an error condition.
+    pub const ERROR: Self = Self(1 << 3);
+
+    /// Constructs readiness flags while retaining unknown future bits.
+    pub const fn from_bits_retain(bits: u32) -> Self {
+        Self(bits)
+    }
+
+    /// Returns the raw readiness bits.
+    pub const fn bits(self) -> u32 {
+        self.0
+    }
+
+    /// Returns whether all bits in `other` are present.
+    pub const fn contains(self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
+
+impl core::ops::BitOr for ReadinessFlags {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        Self(self.0 | rhs.0)
+    }
+}

--- a/litebox_broker_protocol/src/wire.rs
+++ b/litebox_broker_protocol/src/wire.rs
@@ -21,7 +21,7 @@ use thiserror::Error;
 use crate::error::ErrorCode;
 use crate::message::{
     BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerNotification, BrokerRequest,
-    BrokerResponse, EventReadinessNotification, PipeReadinessNotification,
+    BrokerResponse, ReadinessFlags, ReadinessNotification,
 };
 
 use primitive::{Decoder, Encoder};
@@ -42,8 +42,7 @@ const RESPONSE_TAG_VERSION_MISMATCH: u8 = 3;
 const RESPONSE_TAG_OBJECT_CLOSED: u8 = 4;
 const RESPONSE_TAG_PIPE: u8 = 5;
 
-const NOTIFICATION_TAG_EVENT_READINESS: u8 = 0;
-const NOTIFICATION_TAG_PIPE_READINESS: u8 = 1;
+const NOTIFICATION_TAG_READINESS: u8 = 0;
 
 /// Error produced while encoding or decoding a broker wire message.
 #[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
@@ -234,15 +233,10 @@ pub fn decode_response(frame: &[u8]) -> Result<BrokerResponse, WireError> {
 pub fn encode_notification(notification: BrokerNotification) -> Vec<u8> {
     let mut encoder = Encoder::default();
     match notification {
-        BrokerNotification::EventReadiness(notification) => {
-            encoder.u8(NOTIFICATION_TAG_EVENT_READINESS);
+        BrokerNotification::Readiness(notification) => {
+            encoder.u8(NOTIFICATION_TAG_READINESS);
             encoder.handle(notification.handle);
-            event::encode_readiness(&mut encoder, notification.readiness);
-        }
-        BrokerNotification::PipeReadiness(notification) => {
-            encoder.u8(NOTIFICATION_TAG_PIPE_READINESS);
-            encoder.handle(notification.handle);
-            pipe::encode_readiness(&mut encoder, notification.readiness);
+            encoder.u32(notification.events.bits());
         }
     }
     encoder.finish()
@@ -253,18 +247,10 @@ pub fn decode_notification(frame: &[u8]) -> Result<BrokerNotification, WireError
     let mut decoder = Decoder::new(frame);
     let tag = decoder.u8()?;
     let notification = match tag {
-        NOTIFICATION_TAG_EVENT_READINESS => {
-            BrokerNotification::EventReadiness(EventReadinessNotification {
-                handle: decoder.handle()?,
-                readiness: event::decode_readiness(&mut decoder)?,
-            })
-        }
-        NOTIFICATION_TAG_PIPE_READINESS => {
-            BrokerNotification::PipeReadiness(PipeReadinessNotification {
-                handle: decoder.handle()?,
-                readiness: pipe::decode_readiness(&mut decoder)?,
-            })
-        }
+        NOTIFICATION_TAG_READINESS => BrokerNotification::Readiness(ReadinessNotification {
+            handle: decoder.handle()?,
+            events: ReadinessFlags::from_bits_retain(decoder.u32()?),
+        }),
         _ => return Err(WireError::InvalidTag),
     };
     decoder.finish()?;
@@ -428,23 +414,10 @@ mod tests {
     #[test]
     fn notification_codec_round_trips_all_variants() {
         let handle = ObjectHandle(13);
-        let notifications = [
-            BrokerNotification::EventReadiness(EventReadinessNotification {
-                handle,
-                readiness: ReadinessState {
-                    read_ready: true,
-                    write_ready: false,
-                },
-            }),
-            BrokerNotification::PipeReadiness(PipeReadinessNotification {
-                handle,
-                readiness: PipeReadinessState {
-                    endpoint: PipeEndpoint::Write,
-                    ready: true,
-                    peer_closed: true,
-                },
-            }),
-        ];
+        let notifications = [BrokerNotification::Readiness(ReadinessNotification {
+            handle,
+            events: ReadinessFlags::READ | ReadinessFlags::HANGUP,
+        })];
 
         for notification in notifications {
             assert_eq!(
@@ -593,34 +566,26 @@ mod tests {
             Err(WireError::InvalidTag)
         );
         assert_eq!(
-            decode_notification(&[NOTIFICATION_TAG_EVENT_READINESS]),
+            decode_notification(&[NOTIFICATION_TAG_READINESS]),
             Err(WireError::TruncatedFrame)
         );
 
-        let mut invalid_bool = encode_notification(BrokerNotification::EventReadiness(
-            EventReadinessNotification {
+        let mut truncated =
+            encode_notification(BrokerNotification::Readiness(ReadinessNotification {
                 handle: ObjectHandle(13),
-                readiness: ReadinessState {
-                    read_ready: true,
-                    write_ready: false,
-                },
-            },
-        ));
-        *invalid_bool.last_mut().unwrap() = 0xff;
+                events: ReadinessFlags::READ,
+            }));
+        truncated.pop();
         assert_eq!(
-            decode_notification(&invalid_bool),
-            Err(WireError::InvalidBoolean)
+            decode_notification(&truncated),
+            Err(WireError::TruncatedFrame)
         );
 
-        let mut trailing = encode_notification(BrokerNotification::EventReadiness(
-            EventReadinessNotification {
+        let mut trailing =
+            encode_notification(BrokerNotification::Readiness(ReadinessNotification {
                 handle: ObjectHandle(13),
-                readiness: ReadinessState {
-                    read_ready: true,
-                    write_ready: false,
-                },
-            },
-        ));
+                events: ReadinessFlags::READ,
+            }));
         trailing.push(0xff);
         assert_eq!(
             decode_notification(&trailing),
@@ -644,18 +609,13 @@ mod tests {
     }
 
     #[test]
-    fn event_readiness_notification_wire_shape_is_pinned() {
+    fn readiness_notification_wire_shape_is_pinned() {
         assert_eq!(
-            encode_notification(BrokerNotification::EventReadiness(
-                EventReadinessNotification {
-                    handle: ObjectHandle(13),
-                    readiness: ReadinessState {
-                        read_ready: true,
-                        write_ready: false,
-                    },
-                }
-            )),
-            [0, 13, 0, 0, 0, 0, 0, 0, 0, 1, 0]
+            encode_notification(BrokerNotification::Readiness(ReadinessNotification {
+                handle: ObjectHandle(13),
+                events: ReadinessFlags::READ | ReadinessFlags::HANGUP,
+            })),
+            [0, 13, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0]
         );
     }
 }

--- a/litebox_broker_protocol/src/wire.rs
+++ b/litebox_broker_protocol/src/wire.rs
@@ -53,8 +53,6 @@ pub enum WireError {
     TruncatedFrame,
     #[error("trailing broker wire bytes")]
     TrailingBytes,
-    #[error("invalid broker wire boolean")]
-    InvalidBoolean,
     #[error("invalid broker wire tag")]
     InvalidTag,
     #[error("broker wire message is not valid in this protocol phase")]
@@ -237,7 +235,7 @@ pub fn encode_notification(notification: BrokerNotification) -> Vec<u8> {
         BrokerNotification::Readiness(notification) => {
             encoder.u8(NOTIFICATION_TAG_READINESS);
             encoder.handle(notification.handle);
-            encoder.u32(notification.events.bits());
+            encoder.u32(notification.events.0);
         }
     }
     encoder.finish()
@@ -250,7 +248,7 @@ pub fn decode_notification(frame: &[u8]) -> Result<BrokerNotification, WireError
     let notification = match tag {
         NOTIFICATION_TAG_READINESS => BrokerNotification::Readiness(ReadinessNotification {
             handle: decoder.handle()?,
-            events: ReadinessFlags::from_bits_retain(decoder.u32()?),
+            events: ReadinessFlags(decoder.u32()?),
         }),
         _ => return Err(WireError::InvalidTag),
     };
@@ -263,14 +261,13 @@ mod tests {
     use super::*;
     use crate::event::{
         AddEventRequest, AddEventResponse, ConsumeEventRequest, CreateEventRequest,
-        CreateEventResponse, EventConsumeMode, EventConsumption, ReadinessState, WaitEventRequest,
+        CreateEventResponse, EventConsumeMode, EventConsumption, WaitEventRequest,
         WaitEventResponse,
     };
     use crate::message::{EventRequest, EventResponse, PipeRequest, PipeResponse};
     use crate::pipe::{
         CheckPipeReadinessRequest, CheckPipeReadinessResponse, CreatePipeRequest,
-        CreatePipeResponse, PipeEndpoint, PipeReadinessState, ReadPipeRequest, ReadPipeResponse,
-        WritePipeRequest, WritePipeResponse,
+        CreatePipeResponse, ReadPipeRequest, ReadPipeResponse, WritePipeRequest, WritePipeResponse,
     };
     use crate::{ObjectHandle, ProtocolVersion};
 
@@ -359,29 +356,17 @@ mod tests {
             BrokerResponse::ObjectClosed,
             BrokerResponse::Event(EventResponse::Create(CreateEventResponse { handle })),
             BrokerResponse::Event(EventResponse::Wait(WaitEventResponse {
-                readiness: ReadinessState {
-                    read_ready: true,
-                    write_ready: false,
-                },
+                readiness: ReadinessFlags::READ,
             })),
             BrokerResponse::Event(EventResponse::Wait(WaitEventResponse {
-                readiness: ReadinessState {
-                    read_ready: false,
-                    write_ready: true,
-                },
+                readiness: ReadinessFlags::WRITE,
             })),
             BrokerResponse::Event(EventResponse::Add(AddEventResponse {
-                readiness: ReadinessState {
-                    read_ready: true,
-                    write_ready: true,
-                },
+                readiness: ReadinessFlags::READ | ReadinessFlags::WRITE,
             })),
             BrokerResponse::Event(EventResponse::Consume(EventConsumption {
                 value: 3,
-                readiness: ReadinessState {
-                    read_ready: false,
-                    write_ready: true,
-                },
+                readiness: ReadinessFlags::WRITE,
             })),
             BrokerResponse::Pipe(PipeResponse::Create(CreatePipeResponse {
                 read_handle: handle,
@@ -392,15 +377,12 @@ mod tests {
             })),
             BrokerResponse::Pipe(PipeResponse::Write(WritePipeResponse { written: 3 })),
             BrokerResponse::Pipe(PipeResponse::CheckReadiness(CheckPipeReadinessResponse {
-                readiness: PipeReadinessState {
-                    endpoint: PipeEndpoint::Read,
-                    ready: true,
-                    peer_closed: true,
-                },
+                readiness: ReadinessFlags::READ | ReadinessFlags::HANGUP,
             })),
             BrokerResponse::Error(ErrorCode::PolicyDenied),
             BrokerResponse::Error(ErrorCode::WouldBlock),
             BrokerResponse::Error(ErrorCode::PeerClosed),
+            BrokerResponse::Error(ErrorCode::OutOfMemory),
             BrokerResponse::Error(ErrorCode::Internal),
         ];
 
@@ -540,22 +522,21 @@ mod tests {
         );
         assert_eq!(
             decode_response(&[1, 1, 0xff]),
-            Err(WireError::InvalidBoolean)
+            Err(WireError::TruncatedFrame)
         );
         assert_eq!(
             decode_response(&[2, 0xff, 0xff]),
             Err(WireError::InvalidTag)
         );
 
-        let mut invalid_bool = [1, 2, 2, 0];
-        assert_eq!(
-            decode_response(&invalid_bool),
-            Err(WireError::InvalidBoolean)
-        );
+        let truncated = [1, 2, 2, 0];
+        assert_eq!(decode_response(&truncated), Err(WireError::TruncatedFrame));
 
-        invalid_bool[2] = 1;
-        invalid_bool[3] = 1;
-        let mut frame = invalid_bool.to_vec();
+        let mut frame = encode_response(BrokerResponse::Event(EventResponse::Add(
+            AddEventResponse {
+                readiness: ReadinessFlags::READ | ReadinessFlags::WRITE,
+            },
+        )));
         frame.push(0xff);
         assert_eq!(decode_response(&frame), Err(WireError::TrailingBytes));
     }
@@ -599,13 +580,10 @@ mod tests {
         assert_eq!(
             encode_response(BrokerResponse::Event(EventResponse::Add(
                 AddEventResponse {
-                    readiness: ReadinessState {
-                        read_ready: true,
-                        write_ready: false,
-                    },
+                    readiness: ReadinessFlags::READ,
                 }
             ))),
-            [1, 2, 1, 0]
+            [1, 2, 1, 0, 0, 0]
         );
     }
 

--- a/litebox_broker_protocol/src/wire.rs
+++ b/litebox_broker_protocol/src/wire.rs
@@ -21,8 +21,9 @@ use thiserror::Error;
 use crate::error::ErrorCode;
 use crate::message::{
     BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerNotification, BrokerRequest,
-    BrokerResponse, ReadinessFlags, ReadinessNotification,
+    BrokerResponse, ReadinessNotification,
 };
+use crate::readiness::ReadinessFlags;
 
 use primitive::{Decoder, Encoder};
 

--- a/litebox_broker_protocol/src/wire.rs
+++ b/litebox_broker_protocol/src/wire.rs
@@ -21,25 +21,29 @@ use thiserror::Error;
 use crate::error::ErrorCode;
 use crate::message::{
     BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerNotification, BrokerRequest,
-    BrokerResponse, EventReadinessNotification,
+    BrokerResponse, EventReadinessNotification, PipeReadinessNotification,
 };
 
 use primitive::{Decoder, Encoder};
 
 mod event;
+mod pipe;
 mod primitive;
 
 const REQUEST_TAG_NEGOTIATE: u8 = 0;
 const REQUEST_TAG_EVENT: u8 = 1;
 const REQUEST_TAG_CLOSE_OBJECT: u8 = 2;
+const REQUEST_TAG_PIPE: u8 = 3;
 
 const RESPONSE_TAG_NEGOTIATED: u8 = 0;
 const RESPONSE_TAG_EVENT: u8 = 1;
 const RESPONSE_TAG_ERROR: u8 = 2;
 const RESPONSE_TAG_VERSION_MISMATCH: u8 = 3;
 const RESPONSE_TAG_OBJECT_CLOSED: u8 = 4;
+const RESPONSE_TAG_PIPE: u8 = 5;
 
 const NOTIFICATION_TAG_EVENT_READINESS: u8 = 0;
+const NOTIFICATION_TAG_PIPE_READINESS: u8 = 1;
 
 /// Error produced while encoding or decoding a broker wire message.
 #[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
@@ -78,7 +82,9 @@ pub fn decode_handshake_request(frame: &[u8]) -> Result<BrokerHandshakeRequest, 
         REQUEST_TAG_NEGOTIATE => BrokerHandshakeRequest {
             protocol_version: decoder.protocol_version()?,
         },
-        REQUEST_TAG_EVENT | REQUEST_TAG_CLOSE_OBJECT => return Err(WireError::WrongMessagePhase),
+        REQUEST_TAG_EVENT | REQUEST_TAG_CLOSE_OBJECT | REQUEST_TAG_PIPE => {
+            return Err(WireError::WrongMessagePhase);
+        }
         _ => return Err(WireError::InvalidTag),
     };
     decoder.finish()?;
@@ -100,6 +106,10 @@ pub fn encode_request(request: BrokerRequest) -> Vec<u8> {
             encoder.u8(REQUEST_TAG_EVENT);
             event::encode_event_request(&mut encoder, request);
         }
+        BrokerRequest::Pipe(request) => {
+            encoder.u8(REQUEST_TAG_PIPE);
+            pipe::encode_pipe_request(&mut encoder, request);
+        }
     }
     encoder.finish()
 }
@@ -112,6 +122,7 @@ pub fn decode_request(frame: &[u8]) -> Result<BrokerRequest, WireError> {
         REQUEST_TAG_NEGOTIATE => return Err(WireError::WrongMessagePhase),
         REQUEST_TAG_CLOSE_OBJECT => BrokerRequest::CloseObject(decoder.handle()?),
         REQUEST_TAG_EVENT => BrokerRequest::Event(event::decode_event_request(&mut decoder)?),
+        REQUEST_TAG_PIPE => BrokerRequest::Pipe(pipe::decode_pipe_request(&mut decoder)?),
         _ => return Err(WireError::InvalidTag),
     };
     decoder.finish()?;
@@ -153,7 +164,7 @@ pub fn decode_handshake_response(frame: &[u8]) -> Result<BrokerHandshakeResponse
         RESPONSE_TAG_NEGOTIATED => BrokerHandshakeResponse::Negotiated {
             broker_protocol_version: decoder.protocol_version()?,
         },
-        RESPONSE_TAG_EVENT | RESPONSE_TAG_OBJECT_CLOSED => {
+        RESPONSE_TAG_EVENT | RESPONSE_TAG_OBJECT_CLOSED | RESPONSE_TAG_PIPE => {
             return Err(WireError::WrongMessagePhase);
         }
         RESPONSE_TAG_VERSION_MISMATCH => BrokerHandshakeResponse::VersionMismatch {
@@ -183,6 +194,10 @@ pub fn encode_response(response: BrokerResponse) -> Vec<u8> {
             encoder.u8(RESPONSE_TAG_EVENT);
             event::encode_event_response(&mut encoder, response);
         }
+        BrokerResponse::Pipe(response) => {
+            encoder.u8(RESPONSE_TAG_PIPE);
+            pipe::encode_pipe_response(&mut encoder, response);
+        }
         BrokerResponse::Error(error) => {
             encoder.u8(RESPONSE_TAG_ERROR);
             encoder.u16(error.as_raw());
@@ -200,6 +215,7 @@ pub fn decode_response(frame: &[u8]) -> Result<BrokerResponse, WireError> {
             return Err(WireError::WrongMessagePhase);
         }
         RESPONSE_TAG_EVENT => BrokerResponse::Event(event::decode_event_response(&mut decoder)?),
+        RESPONSE_TAG_PIPE => BrokerResponse::Pipe(pipe::decode_pipe_response(&mut decoder)?),
         RESPONSE_TAG_ERROR => {
             let error = ErrorCode::from_raw(decoder.u16()?).ok_or(WireError::InvalidTag)?;
             BrokerResponse::Error(error)
@@ -223,6 +239,11 @@ pub fn encode_notification(notification: BrokerNotification) -> Vec<u8> {
             encoder.handle(notification.handle);
             event::encode_readiness(&mut encoder, notification.readiness);
         }
+        BrokerNotification::PipeReadiness(notification) => {
+            encoder.u8(NOTIFICATION_TAG_PIPE_READINESS);
+            encoder.handle(notification.handle);
+            pipe::encode_readiness(&mut encoder, notification.readiness);
+        }
     }
     encoder.finish()
 }
@@ -236,6 +257,12 @@ pub fn decode_notification(frame: &[u8]) -> Result<BrokerNotification, WireError
             BrokerNotification::EventReadiness(EventReadinessNotification {
                 handle: decoder.handle()?,
                 readiness: event::decode_readiness(&mut decoder)?,
+            })
+        }
+        NOTIFICATION_TAG_PIPE_READINESS => {
+            BrokerNotification::PipeReadiness(PipeReadinessNotification {
+                handle: decoder.handle()?,
+                readiness: pipe::decode_readiness(&mut decoder)?,
             })
         }
         _ => return Err(WireError::InvalidTag),
@@ -252,7 +279,12 @@ mod tests {
         CreateEventResponse, EventConsumeMode, EventConsumption, ReadinessState, WaitEventRequest,
         WaitEventResponse,
     };
-    use crate::message::{EventRequest, EventResponse};
+    use crate::message::{EventRequest, EventResponse, PipeRequest, PipeResponse};
+    use crate::pipe::{
+        CheckPipeReadinessRequest, CheckPipeReadinessResponse, CreatePipeRequest,
+        CreatePipeResponse, PipeEndpoint, PipeReadinessState, ReadPipeRequest, ReadPipeResponse,
+        WritePipeRequest, WritePipeResponse,
+    };
     use crate::{ObjectHandle, ProtocolVersion};
 
     #[test]
@@ -289,6 +321,18 @@ mod tests {
             BrokerRequest::Event(EventRequest::Consume(ConsumeEventRequest {
                 handle,
                 mode: EventConsumeMode::One,
+            })),
+            BrokerRequest::Pipe(PipeRequest::Create(CreatePipeRequest {
+                capacity: 4096,
+                atomic_write_size: 512,
+            })),
+            BrokerRequest::Pipe(PipeRequest::Read(ReadPipeRequest { handle, length: 32 })),
+            BrokerRequest::Pipe(PipeRequest::Write(WritePipeRequest {
+                handle,
+                data: Vec::from([1, 2, 3]),
+            })),
+            BrokerRequest::Pipe(PipeRequest::CheckReadiness(CheckPipeReadinessRequest {
+                handle,
             })),
         ];
 
@@ -352,8 +396,24 @@ mod tests {
                     write_ready: true,
                 },
             })),
+            BrokerResponse::Pipe(PipeResponse::Create(CreatePipeResponse {
+                read_handle: handle,
+                write_handle: ObjectHandle(14),
+            })),
+            BrokerResponse::Pipe(PipeResponse::Read(ReadPipeResponse {
+                data: Vec::from([1, 2, 3]),
+            })),
+            BrokerResponse::Pipe(PipeResponse::Write(WritePipeResponse { written: 3 })),
+            BrokerResponse::Pipe(PipeResponse::CheckReadiness(CheckPipeReadinessResponse {
+                readiness: PipeReadinessState {
+                    endpoint: PipeEndpoint::Read,
+                    ready: true,
+                    peer_closed: true,
+                },
+            })),
             BrokerResponse::Error(ErrorCode::PolicyDenied),
             BrokerResponse::Error(ErrorCode::WouldBlock),
+            BrokerResponse::Error(ErrorCode::PeerClosed),
             BrokerResponse::Error(ErrorCode::Internal),
         ];
 
@@ -368,15 +428,23 @@ mod tests {
     #[test]
     fn notification_codec_round_trips_all_variants() {
         let handle = ObjectHandle(13);
-        let notifications = [BrokerNotification::EventReadiness(
-            EventReadinessNotification {
+        let notifications = [
+            BrokerNotification::EventReadiness(EventReadinessNotification {
                 handle,
                 readiness: ReadinessState {
                     read_ready: true,
                     write_ready: false,
                 },
-            },
-        )];
+            }),
+            BrokerNotification::PipeReadiness(PipeReadinessNotification {
+                handle,
+                readiness: PipeReadinessState {
+                    endpoint: PipeEndpoint::Write,
+                    ready: true,
+                    peer_closed: true,
+                },
+            }),
+        ];
 
         for notification in notifications {
             assert_eq!(

--- a/litebox_broker_protocol/src/wire/event.rs
+++ b/litebox_broker_protocol/src/wire/event.rs
@@ -3,10 +3,10 @@
 
 use crate::event::{
     AddEventRequest, AddEventResponse, ConsumeEventRequest, CreateEventRequest,
-    CreateEventResponse, EventConsumeMode, EventConsumption, ReadinessState, WaitEventRequest,
-    WaitEventResponse,
+    CreateEventResponse, EventConsumeMode, EventConsumption, WaitEventRequest, WaitEventResponse,
 };
 use crate::message::{EventRequest, EventResponse};
+use crate::readiness::ReadinessFlags;
 
 use super::WireError;
 use super::primitive::{Decoder, Encoder};
@@ -79,16 +79,16 @@ pub(super) fn encode_event_response(encoder: &mut Encoder, response: EventRespon
         }
         EventResponse::Wait(response) => {
             encoder.u8(EVENT_RESPONSE_TAG_WAITED);
-            encode_readiness(encoder, response.readiness);
+            encoder.u32(response.readiness.0);
         }
         EventResponse::Add(response) => {
             encoder.u8(EVENT_RESPONSE_TAG_ADDED);
-            encode_readiness(encoder, response.readiness);
+            encoder.u32(response.readiness.0);
         }
         EventResponse::Consume(response) => {
             encoder.u8(EVENT_RESPONSE_TAG_CONSUMED);
             encoder.u64(response.value);
-            encode_readiness(encoder, response.readiness);
+            encoder.u32(response.readiness.0);
         }
     }
 }
@@ -99,31 +99,19 @@ pub(super) fn decode_event_response(decoder: &mut Decoder<'_>) -> Result<EventRe
             handle: decoder.handle()?,
         }),
         EVENT_RESPONSE_TAG_WAITED => EventResponse::Wait(WaitEventResponse {
-            readiness: decode_readiness(decoder)?,
+            readiness: ReadinessFlags(decoder.u32()?),
         }),
         EVENT_RESPONSE_TAG_ADDED => EventResponse::Add(AddEventResponse {
-            readiness: decode_readiness(decoder)?,
+            readiness: ReadinessFlags(decoder.u32()?),
         }),
         EVENT_RESPONSE_TAG_CONSUMED => EventResponse::Consume(EventConsumption {
             value: decoder.u64()?,
-            readiness: decode_readiness(decoder)?,
+            readiness: ReadinessFlags(decoder.u32()?),
         }),
         _ => return Err(WireError::InvalidTag),
     };
 
     Ok(response)
-}
-
-pub(super) fn encode_readiness(encoder: &mut Encoder, readiness: ReadinessState) {
-    encoder.bool(readiness.read_ready);
-    encoder.bool(readiness.write_ready);
-}
-
-pub(super) fn decode_readiness(decoder: &mut Decoder<'_>) -> Result<ReadinessState, WireError> {
-    Ok(ReadinessState {
-        read_ready: decoder.bool()?,
-        write_ready: decoder.bool()?,
-    })
 }
 
 fn encode_consume_mode(encoder: &mut Encoder, mode: EventConsumeMode) {

--- a/litebox_broker_protocol/src/wire/pipe.rs
+++ b/litebox_broker_protocol/src/wire/pipe.rs
@@ -1,0 +1,136 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+use crate::message::{PipeRequest, PipeResponse};
+use crate::pipe::{
+    CheckPipeReadinessRequest, CheckPipeReadinessResponse, CreatePipeRequest, CreatePipeResponse,
+    PipeEndpoint, PipeReadinessState, ReadPipeRequest, ReadPipeResponse, WritePipeRequest,
+    WritePipeResponse,
+};
+
+use super::WireError;
+use super::primitive::{Decoder, Encoder};
+
+const PIPE_REQUEST_TAG_CREATE: u8 = 0;
+const PIPE_REQUEST_TAG_READ: u8 = 1;
+const PIPE_REQUEST_TAG_WRITE: u8 = 2;
+const PIPE_REQUEST_TAG_CHECK_READINESS: u8 = 3;
+
+const PIPE_RESPONSE_TAG_CREATED: u8 = 0;
+const PIPE_RESPONSE_TAG_READ: u8 = 1;
+const PIPE_RESPONSE_TAG_WRITTEN: u8 = 2;
+const PIPE_RESPONSE_TAG_READINESS: u8 = 3;
+
+const PIPE_ENDPOINT_TAG_READ: u8 = 0;
+const PIPE_ENDPOINT_TAG_WRITE: u8 = 1;
+
+pub(super) fn encode_pipe_request(encoder: &mut Encoder, request: PipeRequest) {
+    match request {
+        PipeRequest::Create(request) => {
+            encoder.u8(PIPE_REQUEST_TAG_CREATE);
+            encoder.u64(request.capacity);
+            encoder.u64(request.atomic_write_size);
+        }
+        PipeRequest::Read(request) => {
+            encoder.u8(PIPE_REQUEST_TAG_READ);
+            encoder.handle(request.handle);
+            encoder.u32(request.length);
+        }
+        PipeRequest::Write(request) => {
+            encoder.u8(PIPE_REQUEST_TAG_WRITE);
+            encoder.handle(request.handle);
+            encoder.bytes(&request.data);
+        }
+        PipeRequest::CheckReadiness(request) => {
+            encoder.u8(PIPE_REQUEST_TAG_CHECK_READINESS);
+            encoder.handle(request.handle);
+        }
+    }
+}
+
+pub(super) fn decode_pipe_request(decoder: &mut Decoder<'_>) -> Result<PipeRequest, WireError> {
+    match decoder.u8()? {
+        PIPE_REQUEST_TAG_CREATE => Ok(PipeRequest::Create(CreatePipeRequest {
+            capacity: decoder.u64()?,
+            atomic_write_size: decoder.u64()?,
+        })),
+        PIPE_REQUEST_TAG_READ => Ok(PipeRequest::Read(ReadPipeRequest {
+            handle: decoder.handle()?,
+            length: decoder.u32()?,
+        })),
+        PIPE_REQUEST_TAG_WRITE => Ok(PipeRequest::Write(WritePipeRequest {
+            handle: decoder.handle()?,
+            data: decoder.bytes()?,
+        })),
+        PIPE_REQUEST_TAG_CHECK_READINESS => {
+            Ok(PipeRequest::CheckReadiness(CheckPipeReadinessRequest {
+                handle: decoder.handle()?,
+            }))
+        }
+        _ => Err(WireError::InvalidTag),
+    }
+}
+
+pub(super) fn encode_pipe_response(encoder: &mut Encoder, response: PipeResponse) {
+    match response {
+        PipeResponse::Create(response) => {
+            encoder.u8(PIPE_RESPONSE_TAG_CREATED);
+            encoder.handle(response.read_handle);
+            encoder.handle(response.write_handle);
+        }
+        PipeResponse::Read(response) => {
+            encoder.u8(PIPE_RESPONSE_TAG_READ);
+            encoder.bytes(&response.data);
+        }
+        PipeResponse::Write(response) => {
+            encoder.u8(PIPE_RESPONSE_TAG_WRITTEN);
+            encoder.u32(response.written);
+        }
+        PipeResponse::CheckReadiness(response) => {
+            encoder.u8(PIPE_RESPONSE_TAG_READINESS);
+            encode_readiness(encoder, response.readiness);
+        }
+    }
+}
+
+pub(super) fn decode_pipe_response(decoder: &mut Decoder<'_>) -> Result<PipeResponse, WireError> {
+    match decoder.u8()? {
+        PIPE_RESPONSE_TAG_CREATED => Ok(PipeResponse::Create(CreatePipeResponse {
+            read_handle: decoder.handle()?,
+            write_handle: decoder.handle()?,
+        })),
+        PIPE_RESPONSE_TAG_READ => Ok(PipeResponse::Read(ReadPipeResponse {
+            data: decoder.bytes()?,
+        })),
+        PIPE_RESPONSE_TAG_WRITTEN => Ok(PipeResponse::Write(WritePipeResponse {
+            written: decoder.u32()?,
+        })),
+        PIPE_RESPONSE_TAG_READINESS => {
+            Ok(PipeResponse::CheckReadiness(CheckPipeReadinessResponse {
+                readiness: decode_readiness(decoder)?,
+            }))
+        }
+        _ => Err(WireError::InvalidTag),
+    }
+}
+
+pub(super) fn encode_readiness(encoder: &mut Encoder, readiness: PipeReadinessState) {
+    encoder.u8(match readiness.endpoint {
+        PipeEndpoint::Read => PIPE_ENDPOINT_TAG_READ,
+        PipeEndpoint::Write => PIPE_ENDPOINT_TAG_WRITE,
+    });
+    encoder.bool(readiness.ready);
+    encoder.bool(readiness.peer_closed);
+}
+
+pub(super) fn decode_readiness(decoder: &mut Decoder<'_>) -> Result<PipeReadinessState, WireError> {
+    Ok(PipeReadinessState {
+        endpoint: match decoder.u8()? {
+            PIPE_ENDPOINT_TAG_READ => PipeEndpoint::Read,
+            PIPE_ENDPOINT_TAG_WRITE => PipeEndpoint::Write,
+            _ => return Err(WireError::InvalidTag),
+        },
+        ready: decoder.bool()?,
+        peer_closed: decoder.bool()?,
+    })
+}

--- a/litebox_broker_protocol/src/wire/pipe.rs
+++ b/litebox_broker_protocol/src/wire/pipe.rs
@@ -4,9 +4,9 @@
 use crate::message::{PipeRequest, PipeResponse};
 use crate::pipe::{
     CheckPipeReadinessRequest, CheckPipeReadinessResponse, CreatePipeRequest, CreatePipeResponse,
-    PipeEndpoint, PipeReadinessState, ReadPipeRequest, ReadPipeResponse, WritePipeRequest,
-    WritePipeResponse,
+    ReadPipeRequest, ReadPipeResponse, WritePipeRequest, WritePipeResponse,
 };
+use crate::readiness::ReadinessFlags;
 
 use super::WireError;
 use super::primitive::{Decoder, Encoder};
@@ -20,9 +20,6 @@ const PIPE_RESPONSE_TAG_CREATED: u8 = 0;
 const PIPE_RESPONSE_TAG_READ: u8 = 1;
 const PIPE_RESPONSE_TAG_WRITTEN: u8 = 2;
 const PIPE_RESPONSE_TAG_READINESS: u8 = 3;
-
-const PIPE_ENDPOINT_TAG_READ: u8 = 0;
-const PIPE_ENDPOINT_TAG_WRITE: u8 = 1;
 
 pub(super) fn encode_pipe_request(encoder: &mut Encoder, request: PipeRequest) {
     match request {
@@ -88,7 +85,7 @@ pub(super) fn encode_pipe_response(encoder: &mut Encoder, response: PipeResponse
         }
         PipeResponse::CheckReadiness(response) => {
             encoder.u8(PIPE_RESPONSE_TAG_READINESS);
-            encode_readiness(encoder, response.readiness);
+            encoder.u32(response.readiness.0);
         }
     }
 }
@@ -107,30 +104,9 @@ pub(super) fn decode_pipe_response(decoder: &mut Decoder<'_>) -> Result<PipeResp
         })),
         PIPE_RESPONSE_TAG_READINESS => {
             Ok(PipeResponse::CheckReadiness(CheckPipeReadinessResponse {
-                readiness: decode_readiness(decoder)?,
+                readiness: ReadinessFlags(decoder.u32()?),
             }))
         }
         _ => Err(WireError::InvalidTag),
     }
-}
-
-pub(super) fn encode_readiness(encoder: &mut Encoder, readiness: PipeReadinessState) {
-    encoder.u8(match readiness.endpoint {
-        PipeEndpoint::Read => PIPE_ENDPOINT_TAG_READ,
-        PipeEndpoint::Write => PIPE_ENDPOINT_TAG_WRITE,
-    });
-    encoder.bool(readiness.ready);
-    encoder.bool(readiness.peer_closed);
-}
-
-pub(super) fn decode_readiness(decoder: &mut Decoder<'_>) -> Result<PipeReadinessState, WireError> {
-    Ok(PipeReadinessState {
-        endpoint: match decoder.u8()? {
-            PIPE_ENDPOINT_TAG_READ => PipeEndpoint::Read,
-            PIPE_ENDPOINT_TAG_WRITE => PipeEndpoint::Write,
-            _ => return Err(WireError::InvalidTag),
-        },
-        ready: decoder.bool()?,
-        peer_closed: decoder.bool()?,
-    })
 }

--- a/litebox_broker_protocol/src/wire/primitive.rs
+++ b/litebox_broker_protocol/src/wire/primitive.rs
@@ -17,10 +17,6 @@ impl Encoder {
         self.bytes
     }
 
-    pub(super) fn bool(&mut self, value: bool) {
-        self.u8(u8::from(value));
-    }
-
     pub(super) fn u8(&mut self, value: u8) {
         self.bytes.push(value);
     }
@@ -71,14 +67,6 @@ impl<'a> Decoder<'a> {
             Ok(())
         } else {
             Err(WireError::TrailingBytes)
-        }
-    }
-
-    pub(super) fn bool(&mut self) -> Result<bool, WireError> {
-        match self.u8()? {
-            0 => Ok(false),
-            1 => Ok(true),
-            _ => Err(WireError::InvalidBoolean),
         }
     }
 

--- a/litebox_broker_protocol/src/wire/primitive.rs
+++ b/litebox_broker_protocol/src/wire/primitive.rs
@@ -29,8 +29,22 @@ impl Encoder {
         self.bytes.extend_from_slice(&value.to_le_bytes());
     }
 
+    pub(super) fn u32(&mut self, value: u32) {
+        self.bytes.extend_from_slice(&value.to_le_bytes());
+    }
+
     pub(super) fn u64(&mut self, value: u64) {
         self.bytes.extend_from_slice(&value.to_le_bytes());
+    }
+
+    pub(super) fn bytes(&mut self, value: &[u8]) {
+        self.u64(
+            value
+                .len()
+                .try_into()
+                .expect("broker byte payload length exceeds u64"),
+        );
+        self.bytes.extend_from_slice(value);
     }
 
     pub(super) fn protocol_version(&mut self, version: ProtocolVersion) {
@@ -78,11 +92,21 @@ impl<'a> Decoder<'a> {
         Ok(u16::from_le_bytes([bytes[0], bytes[1]]))
     }
 
+    pub(super) fn u32(&mut self) -> Result<u32, WireError> {
+        let bytes = self.take(4)?;
+        Ok(u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]))
+    }
+
     pub(super) fn u64(&mut self) -> Result<u64, WireError> {
         let bytes = self.take(8)?;
         Ok(u64::from_le_bytes([
             bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7],
         ]))
+    }
+
+    pub(super) fn bytes(&mut self) -> Result<Vec<u8>, WireError> {
+        let len = usize::try_from(self.u64()?).map_err(|_| WireError::OffsetOverflow)?;
+        Ok(self.take(len)?.to_vec())
     }
 
     pub(super) fn protocol_version(&mut self) -> Result<ProtocolVersion, WireError> {

--- a/litebox_broker_transport/src/unix_socket.rs
+++ b/litebox_broker_transport/src/unix_socket.rs
@@ -8,6 +8,7 @@
 //! no_std protocol, local, core, and host crates.
 
 use std::io::{Error, ErrorKind, Read, Result as IoResult, Write};
+use std::net::Shutdown;
 use std::os::unix::net::UnixStream;
 use std::path::Path;
 use std::time::{Duration, Instant};
@@ -32,6 +33,11 @@ const MAX_FRAME_LEN: usize = 64 * 1024;
 pub struct UnixStreamLocalControlChannel {
     stream: UnixStream,
     setup_deadline: Option<Instant>,
+}
+
+/// Independently owned handle for interrupting local control-channel I/O.
+pub struct UnixStreamLocalControlCancellation {
+    stream: UnixStream,
 }
 
 impl UnixStreamLocalControlChannel {
@@ -61,6 +67,29 @@ impl UnixStreamLocalControlChannel {
             stream,
             setup_deadline: Some(deadline),
         })
+    }
+
+    /// Creates a handle that can interrupt pending control-channel I/O.
+    pub fn cancellation_handle(&self) -> IoResult<UnixStreamLocalControlCancellation> {
+        self.stream
+            .try_clone()
+            .map(|stream| UnixStreamLocalControlCancellation { stream })
+    }
+}
+
+impl UnixStreamLocalControlCancellation {
+    /// Shuts down the control stream, unblocking pending reads or writes.
+    pub fn cancel(&self) -> IoResult<()> {
+        match self.stream.shutdown(Shutdown::Both) {
+            Err(error) if error.kind() == ErrorKind::NotConnected => Ok(()),
+            result => result,
+        }
+    }
+}
+
+impl Drop for UnixStreamLocalControlChannel {
+    fn drop(&mut self) {
+        let _ = self.stream.shutdown(Shutdown::Both);
     }
 }
 
@@ -401,6 +430,47 @@ mod tests {
             matches!(error.kind(), ErrorKind::WouldBlock | ErrorKind::TimedOut),
             "unexpected timeout error kind: {error:?}"
         );
+    }
+
+    #[test]
+    fn local_control_cancellation_unblocks_response_read() {
+        let (local_stream, _host_stream) = UnixStream::pair().unwrap();
+        let mut channel = UnixStreamLocalControlChannel::from_connected(local_stream);
+        let cancellation = channel.cancellation_handle().unwrap();
+        let completed = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let (started_sender, started_receiver) = std::sync::mpsc::sync_channel(1);
+        let (result_sender, result_receiver) = std::sync::mpsc::sync_channel(1);
+        let reader_completed = completed.clone();
+        let reader = std::thread::spawn(move || {
+            started_sender.send(()).unwrap();
+            result_sender.send(channel.recv_response()).unwrap();
+            reader_completed.store(true, std::sync::atomic::Ordering::Release);
+        });
+
+        started_receiver
+            .recv_timeout(Duration::from_secs(1))
+            .unwrap();
+        std::thread::sleep(Duration::from_millis(50));
+        assert!(!completed.load(std::sync::atomic::Ordering::Acquire));
+        cancellation.cancel().unwrap();
+
+        assert!(result_receiver.recv_timeout(Duration::from_secs(1)).is_ok());
+        reader.join().unwrap();
+    }
+
+    #[test]
+    fn dropping_local_control_closes_connection_with_cancellation_clone() {
+        let (local_stream, mut host_stream) = UnixStream::pair().unwrap();
+        let channel = UnixStreamLocalControlChannel::from_connected(local_stream);
+        let _cancellation = channel.cancellation_handle().unwrap();
+        host_stream
+            .set_read_timeout(Some(Duration::from_secs(1)))
+            .unwrap();
+
+        drop(channel);
+
+        let mut byte = [0];
+        assert_eq!(host_stream.read(&mut byte).unwrap(), 0);
     }
 
     #[test]

--- a/litebox_broker_transport/src/unix_socket.rs
+++ b/litebox_broker_transport/src/unix_socket.rs
@@ -446,7 +446,7 @@ mod tests {
         let notification = BrokerNotification::Readiness(
             litebox_broker_protocol::message::ReadinessNotification {
                 handle: litebox_broker_protocol::ObjectHandle(7),
-                events: litebox_broker_protocol::message::ReadinessFlags::READ,
+                events: litebox_broker_protocol::readiness::ReadinessFlags::READ,
             },
         );
 

--- a/litebox_broker_transport/src/unix_socket.rs
+++ b/litebox_broker_transport/src/unix_socket.rs
@@ -443,13 +443,10 @@ mod tests {
         let (local_stream, host_stream) = UnixStream::pair().unwrap();
         let mut local = UnixStreamLocalNotificationChannel::from_connected(local_stream);
         let mut host = UnixStreamHostNotificationChannel::from_accepted(host_stream);
-        let notification = BrokerNotification::EventReadiness(
-            litebox_broker_protocol::message::EventReadinessNotification {
+        let notification = BrokerNotification::Readiness(
+            litebox_broker_protocol::message::ReadinessNotification {
                 handle: litebox_broker_protocol::ObjectHandle(7),
-                readiness: litebox_broker_protocol::event::ReadinessState {
-                    read_ready: true,
-                    write_ready: false,
-                },
+                events: litebox_broker_protocol::message::ReadinessFlags::READ,
             },
         );
 

--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 use std::process::Command;
 
 use clap::Parser;
-use litebox_broker_core::{BrokerCore, PolicyEngine, PrincipalRights};
+use litebox_broker_core::{BrokerCore, ObjectRights, PolicyEngine};
 use litebox_broker_host::serve_connection;
 use litebox_broker_transport::unix_socket::{
     UnixStreamHostControlChannel, UnixStreamHostNotificationChannel,
@@ -34,7 +34,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let control_listener = UnixListener::bind(&control_socket_path)?;
     let notification_listener = UnixListener::bind(&notification_socket_path)?;
     let broker = BrokerCore::new(PolicyEngine::with_unauthenticated_rights(
-        PrincipalRights::all(),
+        ObjectRights::all(),
     ))?;
 
     let mut runner_command = Command::new(&args.runner);

--- a/litebox_broker_userland/tests/notification_runtime.rs
+++ b/litebox_broker_userland/tests/notification_runtime.rs
@@ -3,10 +3,10 @@
 
 use std::os::unix::net::UnixStream;
 
-use litebox_broker_core::{BrokerCore, PolicyEngine, PrincipalRights};
+use litebox_broker_core::{BrokerCore, ObjectRights, PolicyEngine};
 use litebox_broker_host::{ConnectionTermination, serve_connection};
 use litebox_broker_local::BrokerLocal;
-use litebox_broker_protocol::event::ReadinessState;
+use litebox_broker_protocol::readiness::ReadinessFlags;
 use litebox_broker_transport::unix_socket::{
     UnixStreamHostControlChannel, UnixStreamHostNotificationChannel, UnixStreamLocalControlChannel,
 };
@@ -14,7 +14,7 @@ use litebox_broker_transport::unix_socket::{
 #[test]
 fn host_serves_control_requests_over_paired_userland_channels() {
     let broker = BrokerCore::new(PolicyEngine::with_unauthenticated_rights(
-        PrincipalRights::all(),
+        ObjectRights::all(),
     ))
     .unwrap();
     let (local_control, host_control) = UnixStream::pair().unwrap();
@@ -31,10 +31,7 @@ fn host_serves_control_requests_over_paired_userland_channels() {
             .unwrap();
 
     let handle = local.create_event_with_count(0).unwrap();
-    let readiness = ReadinessState {
-        read_ready: true,
-        write_ready: true,
-    };
+    let readiness = ReadinessFlags::READ | ReadinessFlags::WRITE;
     assert_eq!(local.add_event(handle, 1).unwrap(), readiness);
 
     drop(local);

--- a/litebox_broker_userland/tests/userland_broker.rs
+++ b/litebox_broker_userland/tests/userland_broker.rs
@@ -9,7 +9,7 @@ use std::process::{Child, Command};
 use std::time::{Duration, Instant};
 
 use litebox_broker_local::BrokerLocal;
-use litebox_broker_protocol::event::ReadinessState;
+use litebox_broker_protocol::readiness::ReadinessFlags;
 use litebox_broker_transport::unix_socket::{
     UnixStreamLocalControlChannel, UnixStreamLocalNotificationChannel,
 };
@@ -84,26 +84,14 @@ fn run_fake_runner(args: &[OsString]) {
     let mut local = BrokerLocal::negotiate(control_channel).unwrap();
 
     let handle = local.create_event_with_count(0).unwrap();
-    assert_eq!(
-        local.wait_event(handle).unwrap(),
-        ReadinessState {
-            read_ready: false,
-            write_ready: true,
-        }
-    );
+    assert_eq!(local.wait_event(handle).unwrap(), ReadinessFlags::WRITE);
 
-    let readiness = ReadinessState {
-        read_ready: true,
-        write_ready: true,
-    };
+    let readiness = ReadinessFlags::READ | ReadinessFlags::WRITE;
     assert_eq!(local.add_event(handle, 1).unwrap(), readiness);
 
     assert_eq!(
         local.wait_event(handle).unwrap(),
-        ReadinessState {
-            read_ready: true,
-            write_ready: true,
-        }
+        ReadinessFlags::READ | ReadinessFlags::WRITE
     );
     drop(local);
 

--- a/litebox_common_linux/src/errno/mod.rs
+++ b/litebox_common_linux/src/errno/mod.rs
@@ -609,7 +609,8 @@ impl From<litebox::pipes::errors::WriteError> for Errno {
 impl From<litebox::pipes::errors::CreateError> for Errno {
     fn from(value: litebox::pipes::errors::CreateError) -> Self {
         match value {
-            litebox::pipes::errors::CreateError::ResourceExhausted => Errno::ENOMEM,
+            litebox::pipes::errors::CreateError::ResourceExhausted => Errno::ENFILE,
+            litebox::pipes::errors::CreateError::OutOfMemory => Errno::ENOMEM,
             litebox::pipes::errors::CreateError::PermissionDenied => Errno::EACCES,
             litebox::pipes::errors::CreateError::Io => Errno::EIO,
             _ => todo!(),

--- a/litebox_common_linux/src/errno/mod.rs
+++ b/litebox_common_linux/src/errno/mod.rs
@@ -579,12 +579,12 @@ impl From<litebox::pipes::errors::ReadError> for Errno {
             litebox::pipes::errors::ReadError::ClosedFd => Errno::EBADFD,
             litebox::pipes::errors::ReadError::NotForReading => Errno::EINVAL,
             litebox::pipes::errors::ReadError::WouldBlock => Errno::EWOULDBLOCK,
-            litebox::pipes::errors::ReadError::WaitError(error) => match error {
+            litebox::pipes::errors::ReadError::WaitError(e) => match e {
                 litebox::event::wait::WaitError::Interrupted => Errno::EINTR,
                 litebox::event::wait::WaitError::TimedOut => Errno::ETIMEDOUT,
             },
             litebox::pipes::errors::ReadError::Io => Errno::EIO,
-            _ => Errno::EIO,
+            _ => todo!(),
         }
     }
 }
@@ -596,12 +596,12 @@ impl From<litebox::pipes::errors::WriteError> for Errno {
             litebox::pipes::errors::WriteError::ReadEndClosed => Errno::EPIPE,
             litebox::pipes::errors::WriteError::NotForWriting => Errno::EINVAL,
             litebox::pipes::errors::WriteError::WouldBlock => Errno::EWOULDBLOCK,
-            litebox::pipes::errors::WriteError::WaitError(error) => match error {
+            litebox::pipes::errors::WriteError::WaitError(e) => match e {
                 litebox::event::wait::WaitError::Interrupted => Errno::EINTR,
                 litebox::event::wait::WaitError::TimedOut => Errno::ETIMEDOUT,
             },
             litebox::pipes::errors::WriteError::Io => Errno::EIO,
-            _ => Errno::EIO,
+            _ => todo!(),
         }
     }
 }
@@ -612,7 +612,7 @@ impl From<litebox::pipes::errors::CreateError> for Errno {
             litebox::pipes::errors::CreateError::ResourceExhausted => Errno::ENOMEM,
             litebox::pipes::errors::CreateError::PermissionDenied => Errno::EACCES,
             litebox::pipes::errors::CreateError::Io => Errno::EIO,
-            _ => Errno::EIO,
+            _ => todo!(),
         }
     }
 }

--- a/litebox_common_linux/src/errno/mod.rs
+++ b/litebox_common_linux/src/errno/mod.rs
@@ -579,7 +579,12 @@ impl From<litebox::pipes::errors::ReadError> for Errno {
             litebox::pipes::errors::ReadError::ClosedFd => Errno::EBADFD,
             litebox::pipes::errors::ReadError::NotForReading => Errno::EINVAL,
             litebox::pipes::errors::ReadError::WouldBlock => Errno::EWOULDBLOCK,
-            _ => todo!(),
+            litebox::pipes::errors::ReadError::WaitError(error) => match error {
+                litebox::event::wait::WaitError::Interrupted => Errno::EINTR,
+                litebox::event::wait::WaitError::TimedOut => Errno::ETIMEDOUT,
+            },
+            litebox::pipes::errors::ReadError::Io => Errno::EIO,
+            _ => Errno::EIO,
         }
     }
 }
@@ -591,7 +596,23 @@ impl From<litebox::pipes::errors::WriteError> for Errno {
             litebox::pipes::errors::WriteError::ReadEndClosed => Errno::EPIPE,
             litebox::pipes::errors::WriteError::NotForWriting => Errno::EINVAL,
             litebox::pipes::errors::WriteError::WouldBlock => Errno::EWOULDBLOCK,
-            _ => todo!(),
+            litebox::pipes::errors::WriteError::WaitError(error) => match error {
+                litebox::event::wait::WaitError::Interrupted => Errno::EINTR,
+                litebox::event::wait::WaitError::TimedOut => Errno::ETIMEDOUT,
+            },
+            litebox::pipes::errors::WriteError::Io => Errno::EIO,
+            _ => Errno::EIO,
+        }
+    }
+}
+
+impl From<litebox::pipes::errors::CreateError> for Errno {
+    fn from(value: litebox::pipes::errors::CreateError) -> Self {
+        match value {
+            litebox::pipes::errors::CreateError::ResourceExhausted => Errno::ENOMEM,
+            litebox::pipes::errors::CreateError::PermissionDenied => Errno::EACCES,
+            litebox::pipes::errors::CreateError::Io => Errno::EIO,
+            _ => Errno::EIO,
         }
     }
 }

--- a/litebox_common_linux/src/errno/mod.rs
+++ b/litebox_common_linux/src/errno/mod.rs
@@ -576,8 +576,8 @@ impl From<litebox::sync::futex::FutexError> for Errno {
 impl From<litebox::pipes::errors::ReadError> for Errno {
     fn from(value: litebox::pipes::errors::ReadError) -> Self {
         match value {
-            litebox::pipes::errors::ReadError::ClosedFd => Errno::EBADFD,
-            litebox::pipes::errors::ReadError::NotForReading => Errno::EINVAL,
+            litebox::pipes::errors::ReadError::ClosedFd
+            | litebox::pipes::errors::ReadError::NotForReading => Errno::EBADF,
             litebox::pipes::errors::ReadError::WouldBlock => Errno::EWOULDBLOCK,
             litebox::pipes::errors::ReadError::WaitError(e) => match e {
                 litebox::event::wait::WaitError::Interrupted => Errno::EINTR,
@@ -594,7 +594,7 @@ impl From<litebox::pipes::errors::WriteError> for Errno {
         match value {
             litebox::pipes::errors::WriteError::ClosedFd => Errno::EBADF,
             litebox::pipes::errors::WriteError::ReadEndClosed => Errno::EPIPE,
-            litebox::pipes::errors::WriteError::NotForWriting => Errno::EINVAL,
+            litebox::pipes::errors::WriteError::NotForWriting => Errno::EBADF,
             litebox::pipes::errors::WriteError::WouldBlock => Errno::EWOULDBLOCK,
             litebox::pipes::errors::WriteError::WaitError(e) => match e {
                 litebox::event::wait::WaitError::Interrupted => Errno::EINTR,

--- a/litebox_runner_linux_userland/src/broker.rs
+++ b/litebox_runner_linux_userland/src/broker.rs
@@ -10,7 +10,8 @@ use anyhow::{Context as _, Result};
 use litebox_broker_local::{BrokerLocal, BrokerNotifications};
 use litebox_broker_protocol::message::BrokerNotification;
 use litebox_broker_transport::unix_socket::{
-    UnixStreamLocalControlChannel, UnixStreamLocalNotificationChannel,
+    UnixStreamLocalControlCancellation, UnixStreamLocalControlChannel,
+    UnixStreamLocalNotificationChannel,
 };
 
 const SETUP_TIMEOUT: Duration = Duration::from_secs(5);
@@ -22,6 +23,7 @@ pub(crate) fn connect(
 ) -> Result<(
     BrokerLocal<UnixStreamLocalControlChannel>,
     BrokerNotifications<UnixStreamLocalNotificationChannel>,
+    UnixStreamLocalControlCancellation,
 )> {
     let setup_deadline = Instant::now() + SETUP_TIMEOUT;
     let control_channel = connect_with_retry(
@@ -48,26 +50,40 @@ pub(crate) fn connect(
             notification_socket_path.display()
         )
     })?;
+    let control_cancellation = control_channel
+        .cancellation_handle()
+        .context("failed to create broker control cancellation handle")?;
     let local = BrokerLocal::negotiate(control_channel).context("broker negotiation failed")?;
-    Ok((local, BrokerNotifications::new(notification_channel)))
+    Ok((
+        local,
+        BrokerNotifications::new(notification_channel),
+        control_cancellation,
+    ))
 }
 
 pub(crate) fn start_notification_receiver(
     mut notifications: BrokerNotifications<UnixStreamLocalNotificationChannel>,
+    control_cancellation: UnixStreamLocalControlCancellation,
     dispatch_notification: impl Fn(BrokerNotification) + Send + 'static,
+    dispatch_failure: impl Fn() + Send + 'static,
 ) -> Result<()> {
     std::thread::Builder::new()
         .name("litebox-broker-notifications".to_owned())
         .spawn(move || {
-            loop {
+            let receive_error = loop {
                 match notifications.recv_notification() {
                     Ok(Some(notification)) => dispatch_notification(notification),
-                    Ok(None) => break,
-                    Err(error) => {
-                        eprintln!("failed to receive broker notification: {error}");
-                        break;
-                    }
+                    Ok(None) => break None,
+                    Err(error) => break Some(error),
                 }
+            };
+            let cancellation_error = control_cancellation.cancel().err();
+            dispatch_failure();
+            if let Some(error) = receive_error {
+                eprintln!("failed to receive broker notification: {error}");
+            }
+            if let Some(error) = cancellation_error {
+                eprintln!("failed to cancel broker control channel: {error}");
             }
         })
         .context("failed to start broker notification receiver")?;

--- a/litebox_runner_linux_userland/src/lib.rs
+++ b/litebox_runner_linux_userland/src/lib.rs
@@ -241,14 +241,16 @@ pub fn run(cli_args: CliArgs) -> Result<()> {
     };
 
     let shim_builder = if let Some(broker_connection) = broker_connection {
-        let (broker_local, broker_notifications) = broker_connection;
+        let (broker_local, broker_notifications, broker_control_cancellation) = broker_connection;
         let litebox = litebox::LiteBox::new_with_broker_local(
             litebox_platform_multiplex::platform(),
             broker_local,
         );
         broker::start_notification_receiver(
             broker_notifications,
+            broker_control_cancellation,
             litebox.broker_notification_dispatcher(),
+            litebox.broker_failure_dispatcher(),
         )?;
         litebox_shim_linux::LinuxShimBuilder::new_with_litebox(litebox)
     } else {

--- a/litebox_runner_linux_userland/tests/pipe_broker.c
+++ b/litebox_runner_linux_userland/tests/pipe_broker.c
@@ -7,23 +7,34 @@
 #include <fcntl.h>
 #include <poll.h>
 #include <pthread.h>
+#include <sched.h>
 #include <signal.h>
+#include <stdatomic.h>
 #include <string.h>
+#include <time.h>
 #include <unistd.h>
+
+#define BLOCKING_TEST_DELAY_US 50000
+#define OPERATION_TIMEOUT_SECONDS 2
+#define THREAD_JOIN_TIMEOUT_SECONDS 2
 
 struct io_thread_args {
     int fd;
     unsigned char value;
     int write;
     int result;
+    atomic_int started;
+    atomic_int completed;
 };
 
 static void *io_thread(void *arg) {
     struct io_thread_args *args = arg;
     unsigned char value = args->value;
+    atomic_store_explicit(&args->started, 1, memory_order_release);
     ssize_t result = args->write ? write(args->fd, &value, 1)
                                  : read(args->fd, &value, 1);
     args->result = result == 1 && (args->write || value == args->value) ? 0 : 1;
+    atomic_store_explicit(&args->completed, 1, memory_order_release);
     return NULL;
 }
 
@@ -36,15 +47,32 @@ static int poll_events(int fd, short events, short expected) {
     return ready >= 0 && poll_fd.revents == expected ? 0 : 1;
 }
 
+static int join_thread(pthread_t thread, int wake_fd) {
+    struct timespec deadline;
+    if (clock_gettime(CLOCK_REALTIME, &deadline) == 0) {
+        deadline.tv_sec += THREAD_JOIN_TIMEOUT_SECONDS;
+        if (pthread_timedjoin_np(thread, NULL, &deadline) == 0) {
+            return 0;
+        }
+    }
+    close(wake_fd);
+    _exit(1);
+}
+
 static int test_nonblocking_and_lifecycle(void) {
     int fds[2];
     if (pipe2(fds, O_NONBLOCK | O_CLOEXEC) != 0) {
         return 1;
     }
-    if ((fcntl(fds[0], F_GETFL) & O_NONBLOCK) == 0 ||
-        (fcntl(fds[1], F_GETFL) & O_NONBLOCK) == 0 ||
-        (fcntl(fds[0], F_GETFD) & FD_CLOEXEC) == 0 ||
-        (fcntl(fds[1], F_GETFD) & FD_CLOEXEC) == 0) {
+    int read_status = fcntl(fds[0], F_GETFL);
+    int write_status = fcntl(fds[1], F_GETFL);
+    int read_descriptor_flags = fcntl(fds[0], F_GETFD);
+    int write_descriptor_flags = fcntl(fds[1], F_GETFD);
+    if (read_status < 0 || write_status < 0 || read_descriptor_flags < 0 ||
+        write_descriptor_flags < 0 || (read_status & O_NONBLOCK) == 0 ||
+        (write_status & O_NONBLOCK) == 0 ||
+        (read_descriptor_flags & FD_CLOEXEC) == 0 ||
+        (write_descriptor_flags & FD_CLOEXEC) == 0) {
         return 2;
     }
     if (poll_events(fds[0], POLLIN, 0) != 0 ||
@@ -55,23 +83,31 @@ static int test_nonblocking_and_lifecycle(void) {
     unsigned char data[3] = {1, 2, 3};
     unsigned char output[3] = {0};
     errno = 0;
-    if (read(fds[0], output, sizeof(output)) != -1 || errno != EAGAIN) {
+    if (read(fds[1], output, 0) != -1 || errno != EBADF) {
         return 4;
+    }
+    errno = 0;
+    if (write(fds[0], data, 0) != -1 || errno != EBADF) {
+        return 4;
+    }
+    errno = 0;
+    if (read(fds[0], output, sizeof(output)) != -1 || errno != EAGAIN) {
+        return 5;
     }
     if (write(fds[1], data, sizeof(data)) != sizeof(data) ||
         poll_events(fds[0], POLLIN, POLLIN) != 0 ||
         read(fds[0], output, sizeof(output)) != sizeof(output) ||
         memcmp(data, output, sizeof(data)) != 0) {
-        return 5;
+        return 6;
     }
 
     int duplicate = dup(fds[1]);
     if (duplicate < 0 || close(fds[1]) != 0 ||
         write(duplicate, data, sizeof(data)) != sizeof(data) ||
         read(fds[0], output, sizeof(output)) != sizeof(output)) {
-        return 6;
+        return 7;
     }
-    return close(duplicate) == 0 && close(fds[0]) == 0 ? 0 : 7;
+    return close(duplicate) == 0 && close(fds[0]) == 0 ? 0 : 8;
 }
 
 static int test_blocking_read_wakeup(void) {
@@ -85,24 +121,42 @@ static int test_blocking_read_wakeup(void) {
         .write = 0,
         .result = -1,
     };
+    atomic_init(&args.started, 0);
+    atomic_init(&args.completed, 0);
     pthread_t thread;
     if (pthread_create(&thread, NULL, io_thread, &args) != 0) {
         return 2;
     }
-    usleep(10000);
+    alarm(OPERATION_TIMEOUT_SECONDS);
+    while (!atomic_load_explicit(&args.started, memory_order_acquire)) {
+        sched_yield();
+    }
+    alarm(0);
+    usleep(BLOCKING_TEST_DELAY_US);
+    if (atomic_load_explicit(&args.completed, memory_order_acquire)) {
+        pthread_join(thread, NULL);
+        return 3;
+    }
     unsigned char value = 42;
-    if (write(fds[1], &value, 1) != 1 ||
-        pthread_join(thread, NULL) != 0 || args.result != 0) {
+    alarm(OPERATION_TIMEOUT_SECONDS);
+    ssize_t wake_result = write(fds[1], &value, 1);
+    alarm(0);
+    int join_result = join_thread(thread, fds[1]);
+    if (wake_result != 1 || join_result != 0 || args.result != 0) {
         return 3;
     }
 
     unsigned char input[65536];
     unsigned char output[65536];
     memset(input, 0x5a, sizeof(input));
-    if (write(fds[1], input, sizeof(input)) != sizeof(input)) {
+    alarm(OPERATION_TIMEOUT_SECONDS);
+    ssize_t large_write_result = write(fds[1], input, sizeof(input));
+    alarm(0);
+    if (large_write_result != sizeof(input)) {
         return 4;
     }
     size_t read_size = 0;
+    alarm(OPERATION_TIMEOUT_SECONDS);
     while (read_size < sizeof(output)) {
         ssize_t size =
             read(fds[0], output + read_size, sizeof(output) - read_size);
@@ -111,6 +165,7 @@ static int test_blocking_read_wakeup(void) {
         }
         read_size += (size_t)size;
     }
+    alarm(0);
     if (memcmp(input, output, sizeof(input)) != 0) {
         return 6;
     }
@@ -123,9 +178,18 @@ static int test_blocking_write_wakeup(void) {
         return 1;
     }
     unsigned char data[4096] = {0};
-    while (write(fds[1], data, sizeof(data)) == sizeof(data)) {
+    size_t total_written = 0;
+    ssize_t write_result;
+    alarm(OPERATION_TIMEOUT_SECONDS);
+    while ((write_result = write(fds[1], data, sizeof(data))) == sizeof(data)) {
+        total_written += sizeof(data);
+        if (total_written > 65536) {
+            return 2;
+        }
     }
-    if (errno != EAGAIN || fcntl(fds[1], F_SETFL, 0) != 0) {
+    alarm(0);
+    if (total_written != 65536 || write_result != -1 || errno != EAGAIN ||
+        fcntl(fds[1], F_SETFL, 0) != 0) {
         return 2;
     }
 
@@ -135,14 +199,28 @@ static int test_blocking_write_wakeup(void) {
         .write = 1,
         .result = -1,
     };
+    atomic_init(&args.started, 0);
+    atomic_init(&args.completed, 0);
     pthread_t thread;
     if (pthread_create(&thread, NULL, io_thread, &args) != 0) {
         return 3;
     }
-    usleep(10000);
+    alarm(OPERATION_TIMEOUT_SECONDS);
+    while (!atomic_load_explicit(&args.started, memory_order_acquire)) {
+        sched_yield();
+    }
+    alarm(0);
+    usleep(BLOCKING_TEST_DELAY_US);
+    if (atomic_load_explicit(&args.completed, memory_order_acquire)) {
+        pthread_join(thread, NULL);
+        return 4;
+    }
     unsigned char value;
-    if (read(fds[0], &value, 1) != 1 ||
-        pthread_join(thread, NULL) != 0 || args.result != 0) {
+    alarm(OPERATION_TIMEOUT_SECONDS);
+    ssize_t wake_result = read(fds[0], &value, 1);
+    alarm(0);
+    int join_result = join_thread(thread, fds[0]);
+    if (wake_result != 1 || join_result != 0 || args.result != 0) {
         return 4;
     }
     return close(fds[0]) == 0 && close(fds[1]) == 0 ? 0 : 5;
@@ -159,14 +237,17 @@ static int test_closed_peers(void) {
 
     if (signal(SIGPIPE, SIG_IGN) == SIG_ERR || pipe(fds) != 0 ||
         close(fds[0]) != 0 ||
-        poll_events(fds[1], POLLOUT, POLLERR) != 0) {
+        poll_events(fds[1], POLLOUT, POLLOUT | POLLERR) != 0) {
         return 2;
+    }
+    if (write(fds[1], &value, 0) != 0) {
+        return 3;
     }
     errno = 0;
     if (write(fds[1], &value, 1) != -1 || errno != EPIPE) {
-        return 3;
+        return 4;
     }
-    return close(fds[1]) == 0 ? 0 : 4;
+    return close(fds[1]) == 0 ? 0 : 5;
 }
 
 int main(void) {

--- a/litebox_runner_linux_userland/tests/pipe_broker.c
+++ b/litebox_runner_linux_userland/tests/pipe_broker.c
@@ -1,0 +1,187 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <pthread.h>
+#include <signal.h>
+#include <string.h>
+#include <unistd.h>
+
+struct io_thread_args {
+    int fd;
+    unsigned char value;
+    int write;
+    int result;
+};
+
+static void *io_thread(void *arg) {
+    struct io_thread_args *args = arg;
+    unsigned char value = args->value;
+    ssize_t result = args->write ? write(args->fd, &value, 1)
+                                 : read(args->fd, &value, 1);
+    args->result = result == 1 && (args->write || value == args->value) ? 0 : 1;
+    return NULL;
+}
+
+static int poll_events(int fd, short events, short expected) {
+    struct pollfd poll_fd = {
+        .fd = fd,
+        .events = events,
+    };
+    int ready = poll(&poll_fd, 1, 0);
+    return ready >= 0 && poll_fd.revents == expected ? 0 : 1;
+}
+
+static int test_nonblocking_and_lifecycle(void) {
+    int fds[2];
+    if (pipe2(fds, O_NONBLOCK | O_CLOEXEC) != 0) {
+        return 1;
+    }
+    if ((fcntl(fds[0], F_GETFL) & O_NONBLOCK) == 0 ||
+        (fcntl(fds[1], F_GETFL) & O_NONBLOCK) == 0 ||
+        (fcntl(fds[0], F_GETFD) & FD_CLOEXEC) == 0 ||
+        (fcntl(fds[1], F_GETFD) & FD_CLOEXEC) == 0) {
+        return 2;
+    }
+    if (poll_events(fds[0], POLLIN, 0) != 0 ||
+        poll_events(fds[1], POLLOUT, POLLOUT) != 0) {
+        return 3;
+    }
+
+    unsigned char data[3] = {1, 2, 3};
+    unsigned char output[3] = {0};
+    errno = 0;
+    if (read(fds[0], output, sizeof(output)) != -1 || errno != EAGAIN) {
+        return 4;
+    }
+    if (write(fds[1], data, sizeof(data)) != sizeof(data) ||
+        poll_events(fds[0], POLLIN, POLLIN) != 0 ||
+        read(fds[0], output, sizeof(output)) != sizeof(output) ||
+        memcmp(data, output, sizeof(data)) != 0) {
+        return 5;
+    }
+
+    int duplicate = dup(fds[1]);
+    if (duplicate < 0 || close(fds[1]) != 0 ||
+        write(duplicate, data, sizeof(data)) != sizeof(data) ||
+        read(fds[0], output, sizeof(output)) != sizeof(output)) {
+        return 6;
+    }
+    return close(duplicate) == 0 && close(fds[0]) == 0 ? 0 : 7;
+}
+
+static int test_blocking_read_wakeup(void) {
+    int fds[2];
+    if (pipe(fds) != 0) {
+        return 1;
+    }
+    struct io_thread_args args = {
+        .fd = fds[0],
+        .value = 42,
+        .write = 0,
+        .result = -1,
+    };
+    pthread_t thread;
+    if (pthread_create(&thread, NULL, io_thread, &args) != 0) {
+        return 2;
+    }
+    usleep(10000);
+    unsigned char value = 42;
+    if (write(fds[1], &value, 1) != 1 ||
+        pthread_join(thread, NULL) != 0 || args.result != 0) {
+        return 3;
+    }
+
+    unsigned char input[65536];
+    unsigned char output[65536];
+    memset(input, 0x5a, sizeof(input));
+    if (write(fds[1], input, sizeof(input)) != sizeof(input)) {
+        return 4;
+    }
+    size_t read_size = 0;
+    while (read_size < sizeof(output)) {
+        ssize_t size =
+            read(fds[0], output + read_size, sizeof(output) - read_size);
+        if (size <= 0) {
+            return 5;
+        }
+        read_size += (size_t)size;
+    }
+    if (memcmp(input, output, sizeof(input)) != 0) {
+        return 6;
+    }
+    return close(fds[0]) == 0 && close(fds[1]) == 0 ? 0 : 7;
+}
+
+static int test_blocking_write_wakeup(void) {
+    int fds[2];
+    if (pipe2(fds, O_NONBLOCK) != 0) {
+        return 1;
+    }
+    unsigned char data[4096] = {0};
+    while (write(fds[1], data, sizeof(data)) == sizeof(data)) {
+    }
+    if (errno != EAGAIN || fcntl(fds[1], F_SETFL, 0) != 0) {
+        return 2;
+    }
+
+    struct io_thread_args args = {
+        .fd = fds[1],
+        .value = 7,
+        .write = 1,
+        .result = -1,
+    };
+    pthread_t thread;
+    if (pthread_create(&thread, NULL, io_thread, &args) != 0) {
+        return 3;
+    }
+    usleep(10000);
+    unsigned char value;
+    if (read(fds[0], &value, 1) != 1 ||
+        pthread_join(thread, NULL) != 0 || args.result != 0) {
+        return 4;
+    }
+    return close(fds[0]) == 0 && close(fds[1]) == 0 ? 0 : 5;
+}
+
+static int test_closed_peers(void) {
+    int fds[2];
+    unsigned char value = 1;
+    if (pipe(fds) != 0 || close(fds[1]) != 0 ||
+        poll_events(fds[0], POLLIN, POLLHUP) != 0 ||
+        read(fds[0], &value, 1) != 0 || close(fds[0]) != 0) {
+        return 1;
+    }
+
+    if (signal(SIGPIPE, SIG_IGN) == SIG_ERR || pipe(fds) != 0 ||
+        close(fds[0]) != 0 ||
+        poll_events(fds[1], POLLOUT, POLLERR) != 0) {
+        return 2;
+    }
+    errno = 0;
+    if (write(fds[1], &value, 1) != -1 || errno != EPIPE) {
+        return 3;
+    }
+    return close(fds[1]) == 0 ? 0 : 4;
+}
+
+int main(void) {
+    int result = test_nonblocking_and_lifecycle();
+    if (result != 0) {
+        return 10 + result;
+    }
+    result = test_blocking_read_wakeup();
+    if (result != 0) {
+        return 20 + result;
+    }
+    result = test_blocking_write_wakeup();
+    if (result != 0) {
+        return 30 + result;
+    }
+    result = test_closed_peers();
+    return result == 0 ? 0 : 40 + result;
+}

--- a/litebox_runner_linux_userland/tests/run.rs
+++ b/litebox_runner_linux_userland/tests/run.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 const BROKER_HELPER_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
-const BROKER_ONLY_C_TESTS: &[&str] = &["eventfd.c"];
+const BROKER_ONLY_C_TESTS: &[&str] = &["eventfd.c", "pipe_broker.c"];
 
 #[must_use]
 struct Runner {
@@ -473,6 +473,12 @@ console.log(content);
     let true_path = run_which("true");
     let node_path = run_which("node");
     let target = common::compile("./tests/eventfd.c", "broker_eventfd_rewriter", false, false);
+    let pipe_target = common::compile(
+        "./tests/pipe_broker.c",
+        "broker_pipe_rewriter",
+        false,
+        false,
+    );
     let control_socket_path = unique_test_socket_path("runner-broker-control");
     let notification_socket_path = unique_test_socket_path("runner-broker-notification");
     let broker_thread = spawn_test_broker(
@@ -481,7 +487,7 @@ console.log(content);
         litebox_broker_core::PolicyEngine::with_unauthenticated_rights(
             litebox_broker_core::PrincipalRights::all(),
         ),
-        3,
+        4,
     );
 
     Runner::new(&true_path, "broker_true_rewriter")
@@ -494,6 +500,12 @@ console.log(content);
         .run();
     // eventfd.c creates thirteen eventfd objects; each should release one broker object.
     assert_eq!(broker_thread.next_close_object_count(), 13);
+
+    Runner::new(&pipe_target, "broker_pipe_rewriter")
+        .broker_sockets(&control_socket_path, &notification_socket_path)
+        .run();
+    // pipe_broker.c creates five pipes; each endpoint owns one broker object.
+    assert_eq!(broker_thread.next_close_object_count(), 10);
 
     Runner::new(&node_path, "hello_node_broker_rewriter")
         .broker_sockets(&control_socket_path, &notification_socket_path)

--- a/litebox_runner_linux_userland/tests/run.rs
+++ b/litebox_runner_linux_userland/tests/run.rs
@@ -485,7 +485,7 @@ console.log(content);
         &control_socket_path,
         &notification_socket_path,
         litebox_broker_core::PolicyEngine::with_unauthenticated_rights(
-            litebox_broker_core::PrincipalRights::all(),
+            litebox_broker_core::ObjectRights::all(),
         ),
         4,
     );

--- a/litebox_shim_linux/src/syscalls/epoll.rs
+++ b/litebox_shim_linux/src/syscalls/epoll.rs
@@ -635,10 +635,11 @@ mod test {
     #[test]
     fn test_epoll_with_pipe() {
         let (task, epoll) = setup_epoll();
-        let (producer, consumer) =
-            task.global
-                .pipes
-                .create_pipe(2, litebox::pipes::Flags::empty(), None);
+        let (producer, consumer) = task
+            .global
+            .pipes
+            .create_pipe(2, litebox::pipes::Flags::empty(), None)
+            .unwrap();
         let consumer = Arc::new(consumer);
         let reader = super::EpollDescriptor::Pipe(Arc::clone(&consumer));
         epoll

--- a/litebox_shim_linux/src/syscalls/pipe.rs
+++ b/litebox_shim_linux/src/syscalls/pipe.rs
@@ -19,7 +19,7 @@ use litebox_common_linux::{FileDescriptorFlags, InodeType, errno::Errno};
 
 use crate::{GlobalState, Platform, ShimFS};
 
-const DEFAULT_PIPE_BUF_SIZE: usize = 1024 * 1024;
+const DEFAULT_PIPE_BUF_SIZE: usize = 64 * 1024;
 
 /// Status flags for Linux pipe file descriptions.
 ///

--- a/litebox_shim_linux/src/syscalls/pipe.rs
+++ b/litebox_shim_linux/src/syscalls/pipe.rs
@@ -58,7 +58,7 @@ impl<FS: ShimFS> GlobalState<FS> {
             pipe_flags,
             // See `man 7 pipe` for `PIPE_BUF`. On Linux, this is 4096.
             NonZero::new(4096),
-        );
+        )?;
 
         let initial_status = OFlags::from(pipe_flags);
         {


### PR DESCRIPTION
This PR adds broker-backed pipes, with the broker owning pipe state and endpoint lifetime. The existing in-process pipe remains available when no broker is configured.