### PR TITLE
Windows shim support for NtConnectPort

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,7 +163,7 @@ version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
  "itertools",
@@ -211,9 +211,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "bitvec"
@@ -1439,7 +1439,7 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "libc",
  "plain",
  "redox_syscall",
@@ -1456,7 +1456,7 @@ name = "litebox"
 version = "0.1.0"
 dependencies = [
  "arrayvec",
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "buddy_system_allocator",
  "either",
  "hashbrown",
@@ -1480,7 +1480,7 @@ dependencies = [
 name = "litebox_broker_core"
 version = "0.1.0"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "hashbrown",
  "litebox_broker_protocol",
  "spin 0.9.8",
@@ -1537,7 +1537,7 @@ name = "litebox_common_linux"
 version = "0.1.0"
 dependencies = [
  "bitfield",
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "cfg-if",
  "elf",
  "int-enum",
@@ -1551,7 +1551,7 @@ dependencies = [
 name = "litebox_common_optee"
 version = "0.1.0"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "elf",
  "litebox",
  "litebox_common_linux",
@@ -1592,7 +1592,7 @@ version = "0.1.0"
 dependencies = [
  "arrayvec",
  "bindgen",
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "litebox",
  "litebox_common_linux",
  "litebox_util_log",
@@ -1629,7 +1629,7 @@ dependencies = [
  "aligned-vec",
  "arrayvec",
  "authenticode",
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "cms",
  "const-oid",
  "digest",
@@ -1812,7 +1812,7 @@ name = "litebox_shim_linux"
 version = "0.1.0"
 dependencies = [
  "arrayvec",
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "bitvec",
  "libc",
  "litebox",
@@ -1859,7 +1859,7 @@ dependencies = [
 name = "litebox_shim_windows"
 version = "0.1.0"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "int-enum",
  "litebox",
  "litebox_common_linux",
@@ -2203,7 +2203,7 @@ version = "0.10.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2469,7 +2469,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -2498,7 +2498,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -2611,7 +2611,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2678,7 +2678,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3074,7 +3074,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac9ee8b664c9f1740cd813fea422116f8ba29997bb7c878d1940424889802897"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "log",
  "num-traits",
 ]
@@ -3216,7 +3216,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "bytes",
  "futures-util",
  "http",
@@ -3810,7 +3810,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f042214de98141e9c8706e8192b73f56494087cc55ebec28ce10f26c5c364ae"
 dependencies = [
  "bit_field",
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "rustversion",
  "volatile",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,7 +163,7 @@ version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
  "itertools",
@@ -211,9 +211,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "bitvec"
@@ -1439,7 +1439,7 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "libc",
  "plain",
  "redox_syscall",
@@ -1456,7 +1456,7 @@ name = "litebox"
 version = "0.1.0"
 dependencies = [
  "arrayvec",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "buddy_system_allocator",
  "either",
  "hashbrown",
@@ -1480,7 +1480,7 @@ dependencies = [
 name = "litebox_broker_core"
 version = "0.1.0"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "hashbrown",
  "litebox_broker_protocol",
  "spin 0.9.8",
@@ -1537,7 +1537,7 @@ name = "litebox_common_linux"
 version = "0.1.0"
 dependencies = [
  "bitfield",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "cfg-if",
  "elf",
  "int-enum",
@@ -1551,7 +1551,7 @@ dependencies = [
 name = "litebox_common_optee"
 version = "0.1.0"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "elf",
  "litebox",
  "litebox_common_linux",
@@ -1592,7 +1592,7 @@ version = "0.1.0"
 dependencies = [
  "arrayvec",
  "bindgen",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "litebox",
  "litebox_common_linux",
  "litebox_util_log",
@@ -1629,7 +1629,7 @@ dependencies = [
  "aligned-vec",
  "arrayvec",
  "authenticode",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "cms",
  "const-oid",
  "digest",
@@ -1812,7 +1812,7 @@ name = "litebox_shim_linux"
 version = "0.1.0"
 dependencies = [
  "arrayvec",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "bitvec",
  "libc",
  "litebox",
@@ -1859,7 +1859,7 @@ dependencies = [
 name = "litebox_shim_windows"
 version = "0.1.0"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "int-enum",
  "litebox",
  "litebox_common_linux",
@@ -2203,7 +2203,7 @@ version = "0.10.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2469,7 +2469,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -2498,7 +2498,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -2611,7 +2611,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2678,7 +2678,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3074,7 +3074,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac9ee8b664c9f1740cd813fea422116f8ba29997bb7c878d1940424889802897"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "log",
  "num-traits",
 ]
@@ -3216,7 +3216,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "bytes",
  "futures-util",
  "http",
@@ -3810,7 +3810,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f042214de98141e9c8706e8192b73f56494087cc55ebec28ce10f26c5c364ae"
 dependencies = [
  "bit_field",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "rustversion",
  "volatile",
 ]

--- a/litebox_shim_windows/src/lib.rs
+++ b/litebox_shim_windows/src/lib.rs
@@ -33,6 +33,7 @@ use litebox_common_windows::loader::{MappingInfo, PAGE_SIZE};
 use crate::syscalls::event::{EventHandleObject, EventSubsystem};
 use crate::syscalls::file::{FileObject, FileObjectSubsystem};
 use crate::syscalls::iocp::{IoCompletionHandleObject, IoCompletionSubsystem};
+use crate::syscalls::lpc::{LpcPortHandleObject, LpcPortSubsystem};
 use crate::syscalls::object_manager::{
     DirectoryHandleObject, DirectoryObjectSubsystem, ObjectManager,
 };
@@ -404,6 +405,7 @@ fn windows_user_shared_data() -> nt_types::KUserSharedData {
     shared_data
 }
 
+#[cfg(test)]
 fn map_csr_server_shared_memory<Platform: crate::ShimPlatform>(
     page_manager: &crate::WindowsPageManager<Platform>,
 ) -> Option<usize> {
@@ -439,13 +441,18 @@ impl<Platform: ShimPlatform, FS: ShimFS> WindowsShim<Platform, FS> {
         #[cfg(not(target_os = "windows"))]
         let _ = map_windows_user_shared_data::<Platform>(&self.0.page_manager)
             .ok_or(loader::WindowsLoadError::MapSharedMemory)?;
-        let windows_shared_section_addr = map_csr_server_shared_memory(&self.0.page_manager)
-            .ok_or(loader::WindowsLoadError::MapSharedMemory)?;
-        let windows_shared_section =
-            crate::syscalls::section::load_time_windows_shared_section(windows_shared_section_addr);
-
         let load_info = loader::PeLoader::new(self.0.platform, fs.clone(), &self.0.page_manager)
             .load(path, &argv, &envp)?;
+        let windows_shared_section_addr = read_field_at_offset::<Platform, usize>(
+            load_info.environment.peb,
+            core::mem::offset_of!(
+                crate::nt_types::ProcessEnvironmentBlock,
+                read_only_shared_memory_base
+            ),
+        )
+        .ok_or(loader::WindowsLoadError::MemoryAccess)?;
+        let windows_shared_section =
+            crate::syscalls::section::load_time_windows_shared_section(windows_shared_section_addr);
         let mut process =
             Process::default(Some(load_info.virtual_allocations), windows_shared_section);
         process.ntdll_mapping = load_info.ntdll_mapping;
@@ -813,6 +820,34 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                     number_of_concurrent_threads,
                 );
                 (status, ContinueOperation::Resume)
+            }
+            SyscallRequest::NtConnectPort {
+                port_handle,
+                port_name,
+                security_qos,
+                client_view,
+                server_view,
+                max_message_length,
+                connection_information,
+                connection_information_length,
+            } => {
+                let status = self.sys_nt_connect_port(syscalls::lpc::ConnectPortParameters {
+                    port_handle,
+                    port_name,
+                    security_qos,
+                    client_view,
+                    server_view,
+                    max_message_length,
+                    connection_information,
+                    connection_information_length,
+                });
+                (status, ContinueOperation::Resume)
+            }
+            SyscallRequest::NtSecureConnectPort => {
+                litebox_util_log::debug!(
+                    "Rejected NtSecureConnectPort; only the CSR NtConnectPort subset is modeled"
+                );
+                (NtStatus::NOT_SUPPORTED, ContinueOperation::Resume)
             }
             SyscallRequest::NtCreateSection {
                 section_handle,
@@ -1604,6 +1639,14 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         ) {
             return NtStatus::SUCCESS;
         }
+        if remove_raw_handle_by_raw_fd::<Platform, LpcPortSubsystem<Platform>>(
+            &self.global.litebox,
+            &self.process.handles,
+            raw_fd,
+            |lpc_port| visitor.lpc_port(lpc_port),
+        ) {
+            return NtStatus::SUCCESS;
+        }
         if remove_raw_handle_by_raw_fd::<Platform, TimerSubsystem<Platform>>(
             &self.global.litebox,
             &self.process.handles,
@@ -1664,6 +1707,8 @@ trait RawHandleVisitor<Platform: ShimPlatform, FS: ShimFS> {
 
     fn io_completion(&self, io_completion: IoCompletionHandleObject<Platform>);
 
+    fn lpc_port(&self, lpc_port: LpcPortHandleObject);
+
     fn timer(&self, timer: TimerHandleObject<Platform>);
 
     fn wait_completion_packet(
@@ -1705,6 +1750,10 @@ impl<Platform: ShimPlatform, FS: ShimFS> RawHandleVisitor<Platform, FS>
 
     fn io_completion(&self, io_completion: IoCompletionHandleObject<Platform>) {
         Task::<Platform, FS>::close_io_completion(io_completion);
+    }
+
+    fn lpc_port(&self, lpc_port: LpcPortHandleObject) {
+        Task::<Platform, FS>::close_lpc_port(lpc_port);
     }
 
     fn timer(&self, timer: TimerHandleObject<Platform>) {

--- a/litebox_shim_windows/src/lib.rs
+++ b/litebox_shim_windows/src/lib.rs
@@ -450,6 +450,16 @@ impl<Platform: ShimPlatform, FS: ShimFS> WindowsShim<Platform, FS> {
             Process::default(Some(load_info.virtual_allocations), windows_shared_section);
         process.ntdll_mapping = load_info.ntdll_mapping;
         process.peb_address = load_info.environment.peb;
+        write_field_at_offset::<Platform, _>(
+            process.peb_address,
+            core::mem::offset_of!(
+                crate::nt_types::ProcessEnvironmentBlock,
+                csr_server_read_only_shared_memory_base
+            ),
+            u64::try_from(load_info.environment.windows_shared_section)
+                .map_err(|_| loader::WindowsLoadError::MemoryAccess)?,
+        )
+        .ok_or(loader::WindowsLoadError::MemoryAccess)?;
         let process = Arc::new(process);
         Ok(LoadedProgram {
             entrypoints: WindowsShimEntrypoints {

--- a/litebox_shim_windows/src/lib.rs
+++ b/litebox_shim_windows/src/lib.rs
@@ -405,27 +405,6 @@ fn windows_user_shared_data() -> nt_types::KUserSharedData {
     shared_data
 }
 
-#[cfg(test)]
-fn map_csr_server_shared_memory<Platform: crate::ShimPlatform>(
-    page_manager: &crate::WindowsPageManager<Platform>,
-) -> Option<usize> {
-    let length = litebox::mm::linux::NonZeroPageSize::new(
-        crate::syscalls::section::WINDOWS_SHARED_SECTION_SIZE,
-    )?;
-    // SAFETY: `suggested_address` is `None` and `CreatePagesFlags::empty()` leaves address
-    // selection to the page manager, so this cannot replace an existing mapping.
-    unsafe {
-        page_manager.create_writable_pages(
-            None,
-            length,
-            litebox::mm::linux::CreatePagesFlags::empty(),
-            |_| Ok(0),
-        )
-    }
-    .map(|mapping| mapping.as_usize())
-    .ok()
-}
-
 pub struct WindowsShim<Platform: ShimPlatform, FS: ShimFS>(Arc<GlobalState<Platform, FS>>);
 
 impl<Platform: ShimPlatform, FS: ShimFS> WindowsShim<Platform, FS> {

--- a/litebox_shim_windows/src/lib.rs
+++ b/litebox_shim_windows/src/lib.rs
@@ -650,9 +650,9 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
 
     fn handle_syscall_request(&self, ctx: &mut litebox_common_linux::PtRegs) -> ContinueOperation {
         let Some(req) = SyscallRequest::<Platform>::try_from_raw(ctx) else {
-            litebox_util_log::debug!(
+            litebox_util_log::error!(
                 syscall:? = NtSysno::from_raw(ctx.orig_rax);
-                "Unsupported Windows syscall"
+                "Unsupported Windows syscall; terminating Windows guest"
             );
             return ContinueOperation::Terminate;
         };

--- a/litebox_shim_windows/src/lib.rs
+++ b/litebox_shim_windows/src/lib.rs
@@ -629,8 +629,17 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
 
     fn handle_syscall_request(&self, ctx: &mut litebox_common_linux::PtRegs) -> ContinueOperation {
         let Some(req) = SyscallRequest::<Platform>::try_from_raw(ctx) else {
+            let caller = ConstPtr::<Platform, usize>::from_usize(ctx.rsp)
+                .read_at_offset(0)
+                .unwrap_or_default();
             litebox_util_log::error!(
-                syscall:? = NtSysno::from_raw(ctx.orig_rax);
+                syscall:? = NtSysno::from_raw(ctx.orig_rax),
+                rip:% = format_args!("{:#x}", ctx.rip),
+                caller:% = format_args!("{caller:#x}"),
+                arg0:% = format_args!("{:#x}", ctx.r10),
+                arg1:% = format_args!("{:#x}", ctx.rdx),
+                arg2:% = format_args!("{:#x}", ctx.r8),
+                arg3:% = format_args!("{:#x}", ctx.r9);
                 "Unsupported Windows syscall; terminating Windows guest"
             );
             return ContinueOperation::Terminate;

--- a/litebox_shim_windows/src/lib.rs
+++ b/litebox_shim_windows/src/lib.rs
@@ -443,9 +443,18 @@ impl<Platform: ShimPlatform, FS: ShimFS> WindowsShim<Platform, FS> {
             .ok_or(loader::WindowsLoadError::MapSharedMemory)?;
         let load_info = loader::PeLoader::new(self.0.platform, fs.clone(), &self.0.page_manager)
             .load(path, &argv, &envp)?;
-        let windows_shared_section = crate::syscalls::section::load_time_windows_shared_section(
-            load_info.environment.windows_shared_section,
-        );
+        let windows_shared_section_addr = read_field_at_offset::<Platform, usize>(
+            load_info.environment.peb,
+            core::mem::offset_of!(
+                crate::nt_types::ProcessEnvironmentBlock,
+                read_only_shared_memory_base
+            ),
+        )
+        .ok_or(loader::WindowsLoadError::MemoryAccess)?;
+        // TODO(csr-shared-section): model shared backing with distinct client and CSRSS
+        // virtual addresses instead of aliasing both PEB bases to this single mapping.
+        let windows_shared_section =
+            crate::syscalls::section::load_time_windows_shared_section(windows_shared_section_addr);
         let mut process =
             Process::default(Some(load_info.virtual_allocations), windows_shared_section);
         process.ntdll_mapping = load_info.ntdll_mapping;
@@ -456,7 +465,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> WindowsShim<Platform, FS> {
                 crate::nt_types::ProcessEnvironmentBlock,
                 csr_server_read_only_shared_memory_base
             ),
-            u64::try_from(load_info.environment.windows_shared_section)
+            u64::try_from(windows_shared_section_addr)
                 .map_err(|_| loader::WindowsLoadError::MemoryAccess)?,
         )
         .ok_or(loader::WindowsLoadError::MemoryAccess)?;

--- a/litebox_shim_windows/src/lib.rs
+++ b/litebox_shim_windows/src/lib.rs
@@ -443,29 +443,13 @@ impl<Platform: ShimPlatform, FS: ShimFS> WindowsShim<Platform, FS> {
             .ok_or(loader::WindowsLoadError::MapSharedMemory)?;
         let load_info = loader::PeLoader::new(self.0.platform, fs.clone(), &self.0.page_manager)
             .load(path, &argv, &envp)?;
-        let windows_shared_section_addr = read_field_at_offset::<Platform, usize>(
-            load_info.environment.peb,
-            core::mem::offset_of!(
-                crate::nt_types::ProcessEnvironmentBlock,
-                read_only_shared_memory_base
-            ),
-        )
-        .ok_or(loader::WindowsLoadError::MemoryAccess)?;
-        let windows_shared_section =
-            crate::syscalls::section::load_time_windows_shared_section(windows_shared_section_addr);
+        let windows_shared_section = crate::syscalls::section::load_time_windows_shared_section(
+            load_info.environment.windows_shared_section,
+        );
         let mut process =
             Process::default(Some(load_info.virtual_allocations), windows_shared_section);
         process.ntdll_mapping = load_info.ntdll_mapping;
         process.peb_address = load_info.environment.peb;
-        write_field_at_offset::<Platform, _>(
-            process.peb_address,
-            core::mem::offset_of!(
-                crate::nt_types::ProcessEnvironmentBlock,
-                csr_server_read_only_shared_memory_base
-            ),
-            windows_shared_section_addr,
-        )
-        .ok_or(loader::WindowsLoadError::MemoryAccess)?;
         let process = Arc::new(process);
         Ok(LoadedProgram {
             entrypoints: WindowsShimEntrypoints {

--- a/litebox_shim_windows/src/lib.rs
+++ b/litebox_shim_windows/src/lib.rs
@@ -443,32 +443,14 @@ impl<Platform: ShimPlatform, FS: ShimFS> WindowsShim<Platform, FS> {
             .ok_or(loader::WindowsLoadError::MapSharedMemory)?;
         let load_info = loader::PeLoader::new(self.0.platform, fs.clone(), &self.0.page_manager)
             .load(path, &argv, &envp)?;
-        let windows_shared_section_addr = read_field_at_offset::<Platform, usize>(
-            load_info.environment.peb,
-            core::mem::offset_of!(
-                crate::nt_types::ProcessEnvironmentBlock,
-                read_only_shared_memory_base
-            ),
-        )
-        .ok_or(loader::WindowsLoadError::MemoryAccess)?;
-        // TODO(csr-shared-section): model shared backing with distinct client and CSRSS
-        // virtual addresses instead of aliasing both PEB bases to this single mapping.
-        let windows_shared_section =
-            crate::syscalls::section::load_time_windows_shared_section(windows_shared_section_addr);
+        // TODO: shared section should be only created once and shared across all processes, not created per-process.
+        let windows_shared_section = crate::syscalls::section::load_time_windows_shared_section(
+            load_info.environment.windows_shared_section,
+        );
         let mut process =
             Process::default(Some(load_info.virtual_allocations), windows_shared_section);
         process.ntdll_mapping = load_info.ntdll_mapping;
         process.peb_address = load_info.environment.peb;
-        write_field_at_offset::<Platform, _>(
-            process.peb_address,
-            core::mem::offset_of!(
-                crate::nt_types::ProcessEnvironmentBlock,
-                csr_server_read_only_shared_memory_base
-            ),
-            u64::try_from(windows_shared_section_addr)
-                .map_err(|_| loader::WindowsLoadError::MemoryAccess)?,
-        )
-        .ok_or(loader::WindowsLoadError::MemoryAccess)?;
         let process = Arc::new(process);
         Ok(LoadedProgram {
             entrypoints: WindowsShimEntrypoints {

--- a/litebox_shim_windows/src/lib.rs
+++ b/litebox_shim_windows/src/lib.rs
@@ -1575,94 +1575,34 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         raw_fd: usize,
         visitor: impl RawHandleVisitor<Platform, FS>,
     ) -> NtStatus {
-        if remove_raw_handle_by_raw_fd::<Platform, FileObjectSubsystem<FS>>(
-            &self.global.litebox,
-            &self.process.handles,
-            raw_fd,
-            |file| visitor.file(file),
-        ) {
-            return NtStatus::SUCCESS;
+        macro_rules! try_close {
+            ($subsystem:ty, $visit:ident) => {
+                if remove_raw_handle_by_raw_fd::<Platform, $subsystem>(
+                    &self.global.litebox,
+                    &self.process.handles,
+                    raw_fd,
+                    |entry| visitor.$visit(entry),
+                ) {
+                    return NtStatus::SUCCESS;
+                }
+            };
         }
-        if remove_raw_handle_by_raw_fd::<Platform, RegistryKeySubsystem<Platform>>(
-            &self.global.litebox,
-            &self.process.handles,
-            raw_fd,
-            |key| visitor.registry_key(key),
-        ) {
-            return NtStatus::SUCCESS;
-        }
-        if remove_raw_handle_by_raw_fd::<Platform, EventSubsystem<Platform>>(
-            &self.global.litebox,
-            &self.process.handles,
-            raw_fd,
-            |event| visitor.event(event),
-        ) {
-            return NtStatus::SUCCESS;
-        }
-        if remove_raw_handle_by_raw_fd::<Platform, DirectoryObjectSubsystem<Platform>>(
-            &self.global.litebox,
-            &self.process.handles,
-            raw_fd,
-            |directory| visitor.directory(directory),
-        ) {
-            return NtStatus::SUCCESS;
-        }
-        if remove_raw_handle_by_raw_fd::<Platform, SymbolicLinkSubsystem<Platform>>(
-            &self.global.litebox,
-            &self.process.handles,
-            raw_fd,
-            |link| visitor.symbolic_link(link),
-        ) {
-            return NtStatus::SUCCESS;
-        }
-        if remove_raw_handle_by_raw_fd::<Platform, IoCompletionSubsystem<Platform>>(
-            &self.global.litebox,
-            &self.process.handles,
-            raw_fd,
-            |io_completion| visitor.io_completion(io_completion),
-        ) {
-            return NtStatus::SUCCESS;
-        }
-        if remove_raw_handle_by_raw_fd::<Platform, LpcPortSubsystem<Platform>>(
-            &self.global.litebox,
-            &self.process.handles,
-            raw_fd,
-            |lpc_port| visitor.lpc_port(lpc_port),
-        ) {
-            return NtStatus::SUCCESS;
-        }
-        if remove_raw_handle_by_raw_fd::<Platform, TimerSubsystem<Platform>>(
-            &self.global.litebox,
-            &self.process.handles,
-            raw_fd,
-            |timer| visitor.timer(timer),
-        ) {
-            return NtStatus::SUCCESS;
-        }
-        if remove_raw_handle_by_raw_fd::<Platform, WaitCompletionPacketSubsystem<Platform>>(
-            &self.global.litebox,
-            &self.process.handles,
-            raw_fd,
-            |wait_completion_packet| visitor.wait_completion_packet(wait_completion_packet),
-        ) {
-            return NtStatus::SUCCESS;
-        }
-        if remove_raw_handle_by_raw_fd::<Platform, WorkerFactorySubsystem<Platform>>(
-            &self.global.litebox,
-            &self.process.handles,
-            raw_fd,
-            |worker_factory| visitor.worker_factory(worker_factory),
-        ) {
-            return NtStatus::SUCCESS;
-        }
-        if remove_raw_handle_by_raw_fd::<Platform, SectionSubsystem<Platform>>(
-            &self.global.litebox,
-            &self.process.handles,
-            raw_fd,
-            |section| visitor.section(section),
-        ) {
-            return NtStatus::SUCCESS;
-        }
+
+        try_close!(FileObjectSubsystem<FS>, file);
+        try_close!(RegistryKeySubsystem<Platform>, registry_key);
+        try_close!(EventSubsystem<Platform>, event);
+        try_close!(DirectoryObjectSubsystem<Platform>, directory);
+        try_close!(SymbolicLinkSubsystem<Platform>, symbolic_link);
+        try_close!(IoCompletionSubsystem<Platform>, io_completion);
+        try_close!(LpcPortSubsystem<Platform>, lpc_port);
+        try_close!(TimerSubsystem<Platform>, timer);
+        try_close!(
+            WaitCompletionPacketSubsystem<Platform>,
+            wait_completion_packet
+        );
+        try_close!(WorkerFactorySubsystem<Platform>, worker_factory);
+        try_close!(SectionSubsystem<Platform>, section);
+
         NtStatus::INVALID_HANDLE
     }
 

--- a/litebox_shim_windows/src/loader/pe.rs
+++ b/litebox_shim_windows/src/loader/pe.rs
@@ -416,6 +416,8 @@ fn initialize_windows_static_server_data<Platform: RawPointerProvider>(
 ) -> Result<usize, PeImageAccessError> {
     let read_only_static_server_data =
         shared_heap.allocate_array::<Platform, usize>(CSR_SERVER_DLL_MAX)?;
+    // TODO(csr-server-dlls): populate CSRSRV (0), CONSRV (2), and USERSRV (3)
+    // when their shared static server data is modeled.
     let client_base_static_server_data =
         shared_heap.allocate::<Platform, BaseStaticServerData>()?;
     initialize_static_server_data::<Platform>(shared_heap, client_base_static_server_data)?;

--- a/litebox_shim_windows/src/loader/pe.rs
+++ b/litebox_shim_windows/src/loader/pe.rs
@@ -64,6 +64,7 @@ pub(crate) struct WindowsProcessEnvironment {
     pub(crate) peb: usize,
     pub(crate) teb: usize,
     pub(crate) context: usize,
+    pub(crate) windows_shared_section: usize,
 }
 
 pub(crate) struct PeLoadInfo<Platform: crate::ShimPlatform> {
@@ -340,6 +341,12 @@ impl<'a, Platform: crate::ShimPlatform, FS: ShimFS> PeLoader<'a, Platform, FS> {
             GuestMemoryAllocator::new(read_only_shared_memory_base, WINDOWS_SHARED_SECTION_SIZE)?;
         let read_only_static_server_data =
             initialize_windows_static_server_data::<Platform>(&mut shared_heap)?;
+        // Windows reports distinct client and CSRSS addresses for the shared section.
+        // LiteBox materializes both views because shared backing is not modeled yet.
+        let windows_shared_section = create_pages(WINDOWS_SHARED_SECTION_SIZE)?;
+        let mut server_shared_heap =
+            GuestMemoryAllocator::new(windows_shared_section, WINDOWS_SHARED_SECTION_SIZE)?;
+        initialize_windows_static_server_data::<Platform>(&mut server_shared_heap)?;
         let mut peb = ProcessEnvironmentBlock::new_zeroed();
         peb.image_base_address = input.image_base_address;
         if input.image_base_address != input.image.image_base() || input.image.has_dynamic_base() {
@@ -374,6 +381,8 @@ impl<'a, Platform: crate::ShimPlatform, FS: ShimFS> PeLoader<'a, Platform, FS> {
         peb.image_subsystem_minor_version = u32::from(input.image.minor_subsystem_version());
         peb.read_only_shared_memory_base = read_only_shared_memory_base;
         peb.read_only_static_server_data = read_only_static_server_data;
+        peb.csr_server_read_only_shared_memory_base = u64::try_from(windows_shared_section)
+            .map_err(|_| PeImageAccessError::AddressOverflow)?;
 
         write_guest_value::<Platform, _>(peb_ptr, peb)?;
 
@@ -402,6 +411,7 @@ impl<'a, Platform: crate::ShimPlatform, FS: ShimFS> PeLoader<'a, Platform, FS> {
             peb: peb_ptr,
             teb: teb_ptr,
             context: ctx_ptr,
+            windows_shared_section,
         })
     }
 }
@@ -2386,6 +2396,26 @@ mod tests {
                     / size_of::<u16>(),
             ),
             utf16_environment_units(&["a=one", "B=two", "c=three"])
+        );
+    }
+
+    #[test]
+    fn csr_client_and_server_shared_memory_bases_are_distinct() {
+        let created = created_process_environment_snapshot();
+        let server_base = usize::try_from(created.peb.csr_server_read_only_shared_memory_base)
+            .expect("the CSR server base fits in the guest address space");
+
+        assert_ne!(created.peb.read_only_shared_memory_base, server_base);
+        assert_eq!(created.environment.windows_shared_section, server_base);
+        assert!(
+            (created.peb.read_only_shared_memory_base
+                ..created.peb.read_only_shared_memory_base + WINDOWS_SHARED_SECTION_SIZE)
+                .contains(&created.peb.read_only_static_server_data)
+        );
+        let base_server_data =
+            read_guest_value::<usize>(server_base + BASESRV_SERVERDLL_INDEX * size_of::<usize>());
+        assert!(
+            (server_base..server_base + WINDOWS_SHARED_SECTION_SIZE).contains(&base_server_data)
         );
     }
 

--- a/litebox_shim_windows/src/loader/pe.rs
+++ b/litebox_shim_windows/src/loader/pe.rs
@@ -341,8 +341,6 @@ impl<'a, Platform: crate::ShimPlatform, FS: ShimFS> PeLoader<'a, Platform, FS> {
             GuestMemoryAllocator::new(read_only_shared_memory_base, WINDOWS_SHARED_SECTION_SIZE)?;
         let read_only_static_server_data =
             initialize_windows_static_server_data::<Platform>(&mut shared_heap)?;
-        // Windows reports distinct client and CSRSS addresses for the shared section.
-        // LiteBox materializes both views because shared backing is not modeled yet.
         let windows_shared_section = create_pages(WINDOWS_SHARED_SECTION_SIZE)?;
         let mut server_shared_heap =
             GuestMemoryAllocator::new(windows_shared_section, WINDOWS_SHARED_SECTION_SIZE)?;
@@ -381,8 +379,6 @@ impl<'a, Platform: crate::ShimPlatform, FS: ShimFS> PeLoader<'a, Platform, FS> {
         peb.image_subsystem_minor_version = u32::from(input.image.minor_subsystem_version());
         peb.read_only_shared_memory_base = read_only_shared_memory_base;
         peb.read_only_static_server_data = read_only_static_server_data;
-        peb.csr_server_read_only_shared_memory_base = u64::try_from(windows_shared_section)
-            .map_err(|_| PeImageAccessError::AddressOverflow)?;
 
         write_guest_value::<Platform, _>(peb_ptr, peb)?;
 
@@ -2396,26 +2392,6 @@ mod tests {
                     / size_of::<u16>(),
             ),
             utf16_environment_units(&["a=one", "B=two", "c=three"])
-        );
-    }
-
-    #[test]
-    fn csr_client_and_server_shared_memory_bases_are_distinct() {
-        let created = created_process_environment_snapshot();
-        let server_base = usize::try_from(created.peb.csr_server_read_only_shared_memory_base)
-            .expect("the CSR server base fits in the guest address space");
-
-        assert_ne!(created.peb.read_only_shared_memory_base, server_base);
-        assert_eq!(created.environment.windows_shared_section, server_base);
-        assert!(
-            (created.peb.read_only_shared_memory_base
-                ..created.peb.read_only_shared_memory_base + WINDOWS_SHARED_SECTION_SIZE)
-                .contains(&created.peb.read_only_static_server_data)
-        );
-        let base_server_data =
-            read_guest_value::<usize>(server_base + BASESRV_SERVERDLL_INDEX * size_of::<usize>());
-        assert!(
-            (server_base..server_base + WINDOWS_SHARED_SECTION_SIZE).contains(&base_server_data)
         );
     }
 

--- a/litebox_shim_windows/src/loader/pe.rs
+++ b/litebox_shim_windows/src/loader/pe.rs
@@ -2004,7 +2004,7 @@ mod tests {
 
     fn dump_api_set_namespace(api_set_map: ApiSetNamespace, bytes: &[u8], label: &str) {
         std::println!("{label}");
-        std::println!("API_SET_NAMESPACE len={:#x}", bytes.len(),);
+        std::println!("API_SET_NAMESPACE len={:#x}", bytes.len());
         std::println!("     version: {:#010x}", api_set_map.version);
         std::println!("        size: {:#010x}", api_set_map.size);
         std::println!("       flags: {:#010x}", api_set_map.flags);

--- a/litebox_shim_windows/src/loader/pe.rs
+++ b/litebox_shim_windows/src/loader/pe.rs
@@ -64,6 +64,7 @@ pub(crate) struct WindowsProcessEnvironment {
     pub(crate) peb: usize,
     pub(crate) teb: usize,
     pub(crate) context: usize,
+    pub(crate) windows_shared_section: usize,
 }
 
 pub(crate) struct PeLoadInfo<Platform: crate::ShimPlatform> {
@@ -374,6 +375,9 @@ impl<'a, Platform: crate::ShimPlatform, FS: ShimFS> PeLoader<'a, Platform, FS> {
         peb.image_subsystem_minor_version = u32::from(input.image.minor_subsystem_version());
         peb.read_only_shared_memory_base = read_only_shared_memory_base;
         peb.read_only_static_server_data = read_only_static_server_data;
+        // TODO(csr-shared-section): model shared backing with distinct client and CSRSS
+        // virtual addresses instead of aliasing both PEB bases to this single mapping.
+        peb.csr_server_read_only_shared_memory_base = read_only_shared_memory_base as u64;
 
         write_guest_value::<Platform, _>(peb_ptr, peb)?;
 
@@ -402,6 +406,7 @@ impl<'a, Platform: crate::ShimPlatform, FS: ShimFS> PeLoader<'a, Platform, FS> {
             peb: peb_ptr,
             teb: teb_ptr,
             context: ctx_ptr,
+            windows_shared_section: read_only_shared_memory_base,
         })
     }
 }

--- a/litebox_shim_windows/src/loader/pe.rs
+++ b/litebox_shim_windows/src/loader/pe.rs
@@ -64,7 +64,6 @@ pub(crate) struct WindowsProcessEnvironment {
     pub(crate) peb: usize,
     pub(crate) teb: usize,
     pub(crate) context: usize,
-    pub(crate) windows_shared_section: usize,
 }
 
 pub(crate) struct PeLoadInfo<Platform: crate::ShimPlatform> {
@@ -341,10 +340,6 @@ impl<'a, Platform: crate::ShimPlatform, FS: ShimFS> PeLoader<'a, Platform, FS> {
             GuestMemoryAllocator::new(read_only_shared_memory_base, WINDOWS_SHARED_SECTION_SIZE)?;
         let read_only_static_server_data =
             initialize_windows_static_server_data::<Platform>(&mut shared_heap)?;
-        let windows_shared_section = create_pages(WINDOWS_SHARED_SECTION_SIZE)?;
-        let mut server_shared_heap =
-            GuestMemoryAllocator::new(windows_shared_section, WINDOWS_SHARED_SECTION_SIZE)?;
-        initialize_windows_static_server_data::<Platform>(&mut server_shared_heap)?;
         let mut peb = ProcessEnvironmentBlock::new_zeroed();
         peb.image_base_address = input.image_base_address;
         if input.image_base_address != input.image.image_base() || input.image.has_dynamic_base() {
@@ -407,7 +402,6 @@ impl<'a, Platform: crate::ShimPlatform, FS: ShimFS> PeLoader<'a, Platform, FS> {
             peb: peb_ptr,
             teb: teb_ptr,
             context: ctx_ptr,
-            windows_shared_section,
         })
     }
 }

--- a/litebox_shim_windows/src/syscalls/lpc.rs
+++ b/litebox_shim_windows/src/syscalls/lpc.rs
@@ -1,0 +1,746 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+use alloc::string::String;
+use core::marker::PhantomData;
+use core::mem::size_of;
+
+use litebox::fd::{FdEnabledSubsystem, FdEnabledSubsystemEntry};
+use litebox::platform::{RawConstPointer as _, RawMutPointer as _};
+use litebox_common_windows::nt_status::NtStatus;
+use zerocopy::{FromBytes, Immutable, IntoBytes};
+
+use super::Handle;
+use crate::nt_types::{ProcessEnvironmentBlock, ThreadEnvironmentBlock, UnicodeString};
+use crate::{ConstPtr, MutPtr, ShimFS, ShimPlatform, Task, probe_guest_output_preserving_value};
+
+const WINDOWS_API_PORT: &str = r"\Windows\ApiPort";
+const CSR_API_CONNECTINFO_SIZE: usize = 0x30;
+const CSR_API_CONNECTINFO_SIZE_U32: u32 = 0x30;
+const CSR_MAX_MESSAGE_LENGTH: u32 = 0x148;
+const CSR_SERVER_PROCESS_ID: usize = 1;
+const CSR_SERVER_DLL_NAMES: u32 = 2;
+
+pub(crate) struct LpcPortSubsystem<Platform>(PhantomData<fn(Platform)>);
+
+impl<Platform: ShimPlatform> FdEnabledSubsystem for LpcPortSubsystem<Platform> {
+    type Entry = LpcPortHandleObject;
+}
+
+impl FdEnabledSubsystemEntry for LpcPortHandleObject {}
+
+pub(crate) struct LpcPortHandleObject {
+    _port_name: String,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, FromBytes, Immutable, IntoBytes)]
+pub(crate) struct SecurityQualityOfService {
+    length: u32,
+    impersonation_level: u32,
+    context_tracking_mode: u8,
+    effective_only: u8,
+    padding: [u8; 2],
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, FromBytes, Immutable, IntoBytes)]
+pub(crate) struct PortView {
+    length: u32,
+    padding: u32,
+    section_handle: Handle,
+    section_offset: u64,
+    view_size: usize,
+    view_base: usize,
+    view_remote_base: usize,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, FromBytes, Immutable, IntoBytes)]
+pub(crate) struct RemotePortView {
+    length: u32,
+    padding: u32,
+    view_size: usize,
+    view_base: usize,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, FromBytes, Immutable, IntoBytes)]
+struct CsrApiConnectInfo {
+    shared_section_base: usize,
+    shared_static_server_data: usize,
+    shared_section_heap: usize,
+    debug_flags: u32,
+    size_of_peb_data: u32,
+    size_of_teb_data: u32,
+    number_of_server_dll_names: u32,
+    server_process_id: usize,
+}
+
+const _: () = assert!(size_of::<SecurityQualityOfService>() == 12);
+const _: () = assert!(size_of::<PortView>() == 48);
+const _: () = assert!(size_of::<RemotePortView>() == 24);
+const _: () = assert!(size_of::<CsrApiConnectInfo>() == CSR_API_CONNECTINFO_SIZE);
+
+pub(crate) struct ConnectPortParameters<Platform: ShimPlatform> {
+    pub(crate) port_handle: MutPtr<Platform, Handle>,
+    pub(crate) port_name: ConstPtr<Platform, UnicodeString>,
+    pub(crate) security_qos: ConstPtr<Platform, SecurityQualityOfService>,
+    pub(crate) client_view: Option<MutPtr<Platform, PortView>>,
+    pub(crate) server_view: Option<MutPtr<Platform, RemotePortView>>,
+    pub(crate) max_message_length: Option<MutPtr<Platform, u32>>,
+    pub(crate) connection_information: Option<MutPtr<Platform, u8>>,
+    pub(crate) connection_information_length: Option<MutPtr<Platform, u32>>,
+}
+
+impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
+    pub(crate) fn sys_nt_connect_port(&self, params: ConnectPortParameters<Platform>) -> NtStatus {
+        if params.security_qos.read_at_offset(0).is_none() {
+            return NtStatus::ACCESS_VIOLATION;
+        }
+        let port_name = match params
+            .port_name
+            .read_at_offset(0)
+            .ok_or(NtStatus::ACCESS_VIOLATION)
+            .and_then(UnicodeString::read_string::<Platform>)
+        {
+            Ok(name) => name,
+            Err(status) => return status,
+        };
+        if !is_csr_api_port(&port_name) {
+            return NtStatus::OBJECT_NAME_NOT_FOUND;
+        }
+
+        let Some(client_view) = params.client_view else {
+            return NtStatus::INVALID_PARAMETER;
+        };
+        let Some(connection_information) = params.connection_information else {
+            return NtStatus::INVALID_PARAMETER;
+        };
+        let Some(connection_information_length) = params.connection_information_length else {
+            return NtStatus::INVALID_PARAMETER;
+        };
+
+        let Some(client_view_value) = client_view.read_at_offset(0) else {
+            return NtStatus::ACCESS_VIOLATION;
+        };
+        if client_view_value.length as usize != size_of::<PortView>()
+            || client_view_value.section_offset != 0
+            || client_view_value.view_size == 0
+        {
+            return NtStatus::INVALID_PARAMETER;
+        }
+        let server_view_value = match params.server_view {
+            Some(server_view) => match server_view.read_at_offset(0) {
+                Some(view) if view.length as usize == size_of::<RemotePortView>() => Some(view),
+                Some(_) => return NtStatus::INVALID_PARAMETER,
+                None => return NtStatus::ACCESS_VIOLATION,
+            },
+            None => None,
+        };
+
+        let connection_info_len = match connection_information_length.read_at_offset(0) {
+            Some(length) => length as usize,
+            None => return NtStatus::ACCESS_VIOLATION,
+        };
+        if connection_info_len != size_of::<CsrApiConnectInfo>() {
+            return NtStatus::INFO_LENGTH_MISMATCH;
+        }
+
+        if let Err(status) = probe_lpc_outputs::<Platform>(
+            params.port_handle,
+            client_view,
+            params.server_view,
+            params.max_message_length,
+            connection_information,
+            connection_information_length,
+            connection_info_len,
+        ) {
+            return status;
+        }
+
+        let Some(connect_info) = self.csr_api_connect_info() else {
+            return NtStatus::ACCESS_VIOLATION;
+        };
+        let mapped_view = match self.map_client_port_section(
+            client_view_value.section_handle,
+            client_view_value.view_size,
+        ) {
+            Ok(mapped_view) => mapped_view,
+            Err(status) => return status,
+        };
+        let port = LpcPortHandleObject {
+            _port_name: port_name.clone(),
+        };
+        let handle = match self.insert_typed_handle::<LpcPortSubsystem<Platform>>(port, drop) {
+            Ok(handle) => handle,
+            Err(status) => {
+                self.rollback_client_port_section_view(mapped_view.base);
+                return status;
+            }
+        };
+
+        let mut written_client_view = client_view_value;
+        written_client_view.view_size = mapped_view.view_size;
+        written_client_view.view_base = mapped_view.base;
+        written_client_view.view_remote_base = mapped_view.base;
+
+        let write_failed = client_view
+            .write_at_offset(0, written_client_view)
+            .is_none()
+            || params
+                .max_message_length
+                .is_some_and(|ptr| ptr.write_at_offset(0, CSR_MAX_MESSAGE_LENGTH).is_none())
+            || write_process_output::<Platform, CsrApiConnectInfo>(
+                connection_information,
+                connect_info,
+            )
+            .is_none()
+            || connection_information_length
+                .write_at_offset(0, CSR_API_CONNECTINFO_SIZE_U32)
+                .is_none()
+            || params.port_handle.write_at_offset(0, handle).is_none();
+        if write_failed {
+            self.close_lpc_port_handle(handle);
+            self.rollback_client_port_section_view(mapped_view.base);
+            return NtStatus::ACCESS_VIOLATION;
+        }
+
+        if let (Some(server_view), Some(mut server_view_value)) =
+            (params.server_view, server_view_value)
+        {
+            server_view_value.view_size = mapped_view.mapped_size;
+            server_view_value.view_base = mapped_view.base;
+            if server_view.write_at_offset(0, server_view_value).is_none() {
+                self.close_lpc_port_handle(handle);
+                self.rollback_client_port_section_view(mapped_view.base);
+                return NtStatus::ACCESS_VIOLATION;
+            }
+        }
+
+        litebox_util_log::debug!(
+            port_name:% = port_name,
+            handle:% = format_args!("{:#x}", handle.as_raw()),
+            client_view_base:% = format_args!("{:#x}", mapped_view.base),
+            client_view_size = mapped_view.view_size;
+            "Handled NtConnectPort for CSR API port"
+        );
+        NtStatus::SUCCESS
+    }
+
+    pub(crate) fn close_lpc_port_handle(&self, handle: Handle) {
+        self.close_typed_handle::<LpcPortSubsystem<Platform>>(handle, drop);
+    }
+
+    pub(crate) fn close_lpc_port(port: LpcPortHandleObject) {
+        drop(port);
+    }
+
+    fn csr_api_connect_info(&self) -> Option<CsrApiConnectInfo> {
+        let peb =
+            ConstPtr::<Platform, ProcessEnvironmentBlock>::from_usize(self.process.peb_address)
+                .read_at_offset(0)?;
+        Some(CsrApiConnectInfo {
+            shared_section_base: peb.read_only_shared_memory_base,
+            shared_static_server_data: peb.read_only_static_server_data,
+            shared_section_heap: peb.read_only_shared_memory_base,
+            debug_flags: 0,
+            size_of_peb_data: size_u32::<ProcessEnvironmentBlock>()?,
+            size_of_teb_data: size_u32::<ThreadEnvironmentBlock>()?,
+            number_of_server_dll_names: CSR_SERVER_DLL_NAMES,
+            server_process_id: CSR_SERVER_PROCESS_ID,
+        })
+    }
+}
+
+fn is_csr_api_port(port_name: &str) -> bool {
+    port_name.eq_ignore_ascii_case(WINDOWS_API_PORT)
+}
+
+fn size_u32<T>() -> Option<u32> {
+    u32::try_from(size_of::<T>()).ok()
+}
+
+fn probe_lpc_outputs<Platform: ShimPlatform>(
+    port_handle: MutPtr<Platform, Handle>,
+    client_view: MutPtr<Platform, PortView>,
+    server_view: Option<MutPtr<Platform, RemotePortView>>,
+    max_message_length: Option<MutPtr<Platform, u32>>,
+    connection_information: MutPtr<Platform, u8>,
+    connection_information_length: MutPtr<Platform, u32>,
+    connection_information_len: usize,
+) -> Result<(), NtStatus> {
+    probe_guest_output_preserving_value::<Platform, Handle>(port_handle)?;
+    probe_guest_output_preserving_value::<Platform, PortView>(client_view)?;
+    if let Some(server_view) = server_view {
+        probe_guest_output_preserving_value::<Platform, RemotePortView>(server_view)?;
+    }
+    if let Some(max_message_length) = max_message_length {
+        probe_guest_output_preserving_value::<Platform, u32>(max_message_length)?;
+    }
+    probe_guest_byte_buffer_preserving::<Platform>(
+        connection_information,
+        connection_information_len,
+        CSR_API_CONNECTINFO_SIZE,
+    )?;
+    probe_guest_output_preserving_value::<Platform, u32>(connection_information_length)
+}
+
+fn probe_guest_byte_buffer_preserving<Platform: ShimPlatform>(
+    ptr: MutPtr<Platform, u8>,
+    len: usize,
+    max_len: usize,
+) -> Result<(), NtStatus> {
+    if len > max_len {
+        return Err(NtStatus::INFO_LENGTH_MISMATCH);
+    }
+    let bytes = ptr.to_owned_slice(len).ok_or(NtStatus::ACCESS_VIOLATION)?;
+    ptr.write_slice_at_offset(0, bytes.as_ref())
+        .ok_or(NtStatus::ACCESS_VIOLATION)
+}
+
+fn write_process_output<Platform: ShimPlatform, T: FromBytes + IntoBytes + Immutable>(
+    ptr: MutPtr<Platform, u8>,
+    value: T,
+) -> Option<()> {
+    ptr.write_slice_at_offset(0, value.as_bytes())
+}
+
+#[cfg(test)]
+mod tests {
+    use zerocopy::FromZeros as _;
+
+    use super::*;
+    use crate::syscalls::ProcessHandle;
+    use crate::syscalls::mm::PageProtection;
+    use crate::tests::{
+        TestFS, TestPlatform, const_ptr, mut_byte_ptr, mut_ptr, test_task, unicode_string,
+        utf16_units,
+    };
+
+    const SECTION_MAP_WRITE: u32 = 0x0002;
+    const SECTION_MAP_READ: u32 = 0x0004;
+    const SEC_COMMIT: u32 = 0x0800_0000;
+
+    fn task_with_peb(peb: &mut ProcessEnvironmentBlock) -> Task<TestPlatform, TestFS> {
+        let mut task = test_task();
+        alloc::sync::Arc::get_mut(&mut task.process)
+            .expect("test task has a unique process reference")
+            .peb_address = core::ptr::from_mut(peb) as usize;
+        task
+    }
+
+    fn security_qos() -> SecurityQualityOfService {
+        SecurityQualityOfService {
+            length: test_size_u32::<SecurityQualityOfService>(),
+            impersonation_level: 2,
+            context_tracking_mode: 0,
+            effective_only: 1,
+            padding: [0; 2],
+        }
+    }
+
+    fn api_port_name(value: &str) -> (alloc::vec::Vec<u16>, UnicodeString) {
+        let units = utf16_units(value);
+        let unicode = unicode_string(&units);
+        (units, unicode)
+    }
+
+    fn empty_connect_info() -> CsrApiConnectInfo {
+        CsrApiConnectInfo {
+            shared_section_base: 0,
+            shared_static_server_data: 0,
+            shared_section_heap: 0,
+            debug_flags: 0,
+            size_of_peb_data: 0,
+            size_of_teb_data: 0,
+            number_of_server_dll_names: 0,
+            server_process_id: 0,
+        }
+    }
+
+    fn test_size_u32<T>() -> u32 {
+        size_u32::<T>().expect("Windows ABI test structure size fits in u32")
+    }
+
+    fn create_client_section(task: &Task<TestPlatform, TestFS>, access: u32) -> Handle {
+        create_client_section_with_size(task, access, crate::PAGE_SIZE)
+    }
+
+    fn create_client_section_with_size(
+        task: &Task<TestPlatform, TestFS>,
+        access: u32,
+        size: usize,
+    ) -> Handle {
+        let mut handle = Handle::default();
+        let size = i64::try_from(size).expect("test section size fits in i64");
+        assert_eq!(
+            task.sys_nt_create_section(
+                mut_ptr(&mut handle),
+                access,
+                None,
+                Some(const_ptr(&size)),
+                PageProtection::PAGE_READWRITE.bits(),
+                SEC_COMMIT,
+                Handle::default(),
+            ),
+            NtStatus::SUCCESS
+        );
+        handle
+    }
+
+    fn connect_csr_api_port(
+        task: &Task<TestPlatform, TestFS>,
+        peb: &ProcessEnvironmentBlock,
+        section_handle: Handle,
+    ) -> (Handle, PortView) {
+        let (_name_units, name) = api_port_name(WINDOWS_API_PORT);
+        let qos = security_qos();
+        let mut handle = Handle::default();
+        let mut client_view = PortView {
+            length: test_size_u32::<PortView>(),
+            padding: 0,
+            section_handle,
+            section_offset: 0,
+            view_size: crate::PAGE_SIZE,
+            view_base: 0,
+            view_remote_base: 0,
+        };
+        let mut connection_info = empty_connect_info();
+        let mut connection_info_len = test_size_u32::<CsrApiConnectInfo>();
+
+        assert_eq!(
+            task.sys_nt_connect_port(ConnectPortParameters {
+                port_handle: mut_ptr(&mut handle),
+                port_name: const_ptr(&name),
+                security_qos: const_ptr(&qos),
+                client_view: Some(mut_ptr(&mut client_view)),
+                server_view: None,
+                max_message_length: None,
+                connection_information: Some(mut_byte_ptr(&mut connection_info)),
+                connection_information_length: Some(mut_ptr(&mut connection_info_len)),
+            }),
+            NtStatus::SUCCESS
+        );
+        assert_eq!(
+            connection_info.shared_section_base,
+            peb.read_only_shared_memory_base
+        );
+        assert_eq!(
+            connection_info.shared_static_server_data,
+            peb.read_only_static_server_data
+        );
+        (handle, client_view)
+    }
+
+    #[test]
+    fn nt_connect_port_fills_csr_info_and_maps_client_section() {
+        let mut peb = ProcessEnvironmentBlock::new_zeroed();
+        peb.read_only_shared_memory_base = 0x7000_0000;
+        peb.read_only_static_server_data = 0x7000_1000;
+        let task = task_with_peb(&mut peb);
+        let (_name_units, name) = api_port_name(WINDOWS_API_PORT);
+        let qos = security_qos();
+        let section_handle = create_client_section(&task, SECTION_MAP_READ | SECTION_MAP_WRITE);
+        let mut handle = Handle::default();
+        let mut client_view = PortView {
+            length: test_size_u32::<PortView>(),
+            padding: 0,
+            section_handle,
+            section_offset: 0,
+            view_size: crate::PAGE_SIZE,
+            view_base: 0,
+            view_remote_base: 0,
+        };
+        let mut max_message_length = 0u32;
+        let mut connection_info = empty_connect_info();
+        let mut connection_info_len = test_size_u32::<CsrApiConnectInfo>();
+
+        assert_eq!(
+            task.sys_nt_connect_port(ConnectPortParameters {
+                port_handle: mut_ptr(&mut handle),
+                port_name: const_ptr(&name),
+                security_qos: const_ptr(&qos),
+                client_view: Some(mut_ptr(&mut client_view)),
+                server_view: None,
+                max_message_length: Some(mut_ptr(&mut max_message_length)),
+                connection_information: Some(mut_byte_ptr(&mut connection_info)),
+                connection_information_length: Some(mut_ptr(&mut connection_info_len)),
+            }),
+            NtStatus::SUCCESS
+        );
+
+        assert!(!handle.is_null());
+        assert_ne!(client_view.view_base, 0);
+        assert_eq!(client_view.view_remote_base, client_view.view_base);
+        assert_eq!(max_message_length, CSR_MAX_MESSAGE_LENGTH);
+        assert_eq!(
+            connection_info.shared_section_base,
+            peb.read_only_shared_memory_base
+        );
+        assert_eq!(
+            connection_info.shared_static_server_data,
+            peb.read_only_static_server_data
+        );
+        assert_eq!(
+            connection_info.size_of_peb_data,
+            test_size_u32::<ProcessEnvironmentBlock>()
+        );
+        assert_eq!(
+            connection_info.size_of_teb_data,
+            test_size_u32::<ThreadEnvironmentBlock>()
+        );
+    }
+
+    #[test]
+    fn nt_connect_port_rejects_api_port_suffix_match() {
+        let mut peb = ProcessEnvironmentBlock::new_zeroed();
+        let task = task_with_peb(&mut peb);
+        let (_name_units, name) = api_port_name(r"\NotWindows\ApiPort");
+        let qos = security_qos();
+        let mut handle = Handle::default();
+        let mut client_view = PortView {
+            length: test_size_u32::<PortView>(),
+            padding: 0,
+            section_handle: Handle::default(),
+            section_offset: 0,
+            view_size: crate::PAGE_SIZE,
+            view_base: 0,
+            view_remote_base: 0,
+        };
+        let mut connection_info = empty_connect_info();
+        let mut connection_info_len = test_size_u32::<CsrApiConnectInfo>();
+
+        assert_eq!(
+            task.sys_nt_connect_port(ConnectPortParameters {
+                port_handle: mut_ptr(&mut handle),
+                port_name: const_ptr(&name),
+                security_qos: const_ptr(&qos),
+                client_view: Some(mut_ptr(&mut client_view)),
+                server_view: None,
+                max_message_length: None,
+                connection_information: Some(mut_byte_ptr(&mut connection_info)),
+                connection_information_length: Some(mut_ptr(&mut connection_info_len)),
+            }),
+            NtStatus::OBJECT_NAME_NOT_FOUND
+        );
+        assert!(handle.is_null());
+    }
+
+    #[test]
+    fn nt_connect_port_requires_bounded_connect_info_length() {
+        let mut peb = ProcessEnvironmentBlock::new_zeroed();
+        let task = task_with_peb(&mut peb);
+        let (_name_units, name) = api_port_name(WINDOWS_API_PORT);
+        let qos = security_qos();
+        let section_handle = create_client_section(&task, SECTION_MAP_READ | SECTION_MAP_WRITE);
+        let mut handle = Handle::default();
+        let mut client_view = PortView {
+            length: test_size_u32::<PortView>(),
+            padding: 0,
+            section_handle,
+            section_offset: 0,
+            view_size: crate::PAGE_SIZE,
+            view_base: 0,
+            view_remote_base: 0,
+        };
+        let mut connection_info = empty_connect_info();
+        let mut connection_info_len = CSR_API_CONNECTINFO_SIZE_U32 + 1;
+
+        assert_eq!(
+            task.sys_nt_connect_port(ConnectPortParameters {
+                port_handle: mut_ptr(&mut handle),
+                port_name: const_ptr(&name),
+                security_qos: const_ptr(&qos),
+                client_view: Some(mut_ptr(&mut client_view)),
+                server_view: None,
+                max_message_length: None,
+                connection_information: Some(mut_byte_ptr(&mut connection_info)),
+                connection_information_length: Some(mut_ptr(&mut connection_info_len)),
+            }),
+            NtStatus::INFO_LENGTH_MISMATCH
+        );
+        assert_eq!(
+            task.map_client_port_section(section_handle, crate::PAGE_SIZE)
+                .map(|_| ()),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn nt_connect_port_rejects_oversized_client_view_before_allocating() {
+        let mut peb = ProcessEnvironmentBlock::new_zeroed();
+        peb.read_only_shared_memory_base = 0x7000_0000;
+        peb.read_only_static_server_data = 0x7000_1000;
+        let task = task_with_peb(&mut peb);
+        let (_name_units, name) = api_port_name(WINDOWS_API_PORT);
+        let qos = security_qos();
+        let oversized = crate::syscalls::section::WINDOWS_SHARED_SECTION_SIZE + crate::PAGE_SIZE;
+        let section_handle =
+            create_client_section_with_size(&task, SECTION_MAP_READ | SECTION_MAP_WRITE, oversized);
+        let mut handle = Handle::default();
+        let mut client_view = PortView {
+            length: test_size_u32::<PortView>(),
+            padding: 0,
+            section_handle,
+            section_offset: 0,
+            view_size: oversized,
+            view_base: 0,
+            view_remote_base: 0,
+        };
+        let mut connection_info = empty_connect_info();
+        let mut connection_info_len = test_size_u32::<CsrApiConnectInfo>();
+        let section_view_count = task.process.section_views.read().len();
+        let virtual_allocation_count = task.process.virtual_allocations.read().len();
+
+        assert_eq!(
+            task.sys_nt_connect_port(ConnectPortParameters {
+                port_handle: mut_ptr(&mut handle),
+                port_name: const_ptr(&name),
+                security_qos: const_ptr(&qos),
+                client_view: Some(mut_ptr(&mut client_view)),
+                server_view: None,
+                max_message_length: None,
+                connection_information: Some(mut_byte_ptr(&mut connection_info)),
+                connection_information_length: Some(mut_ptr(&mut connection_info_len)),
+            }),
+            NtStatus::INVALID_VIEW_SIZE
+        );
+
+        assert!(handle.is_null());
+        assert_eq!(client_view.view_base, 0);
+        assert_eq!(task.process.section_views.read().len(), section_view_count);
+        assert_eq!(
+            task.process.virtual_allocations.read().len(),
+            virtual_allocation_count
+        );
+    }
+
+    #[test]
+    fn nt_connect_port_requires_section_read_and_write_access() {
+        let mut peb = ProcessEnvironmentBlock::new_zeroed();
+        peb.read_only_shared_memory_base = 0x7000_0000;
+        peb.read_only_static_server_data = 0x7000_1000;
+        let task = task_with_peb(&mut peb);
+        let (_name_units, name) = api_port_name(WINDOWS_API_PORT);
+        let qos = security_qos();
+        let section_handle = create_client_section(&task, SECTION_MAP_WRITE);
+        let mut handle = Handle::default();
+        let mut client_view = PortView {
+            length: test_size_u32::<PortView>(),
+            padding: 0,
+            section_handle,
+            section_offset: 0,
+            view_size: crate::PAGE_SIZE,
+            view_base: 0,
+            view_remote_base: 0,
+        };
+        let mut connection_info = empty_connect_info();
+        let mut connection_info_len = test_size_u32::<CsrApiConnectInfo>();
+
+        assert_eq!(
+            task.sys_nt_connect_port(ConnectPortParameters {
+                port_handle: mut_ptr(&mut handle),
+                port_name: const_ptr(&name),
+                security_qos: const_ptr(&qos),
+                client_view: Some(mut_ptr(&mut client_view)),
+                server_view: None,
+                max_message_length: None,
+                connection_information: Some(mut_byte_ptr(&mut connection_info)),
+                connection_information_length: Some(mut_ptr(&mut connection_info_len)),
+            }),
+            NtStatus::ACCESS_DENIED
+        );
+        assert!(handle.is_null());
+    }
+
+    #[test]
+    fn nt_connect_port_client_view_unmaps_owned_pages() {
+        let mut peb = ProcessEnvironmentBlock::new_zeroed();
+        peb.read_only_shared_memory_base = 0x7000_0000;
+        peb.read_only_static_server_data = 0x7000_1000;
+        let task = task_with_peb(&mut peb);
+        let section_handle = create_client_section(&task, SECTION_MAP_READ | SECTION_MAP_WRITE);
+        let (_handle, client_view) = connect_csr_api_port(&task, &peb, section_handle);
+
+        assert!(
+            task.process
+                .section_views
+                .read()
+                .contains_key(&client_view.view_base)
+        );
+        assert!(
+            task.process
+                .virtual_allocations
+                .read()
+                .contains_key(&client_view.view_base)
+        );
+
+        assert_eq!(
+            task.sys_nt_unmap_view_of_section(ProcessHandle::CURRENT, client_view.view_base),
+            NtStatus::SUCCESS
+        );
+        assert!(
+            !task
+                .process
+                .section_views
+                .read()
+                .contains_key(&client_view.view_base)
+        );
+        assert!(
+            !task
+                .process
+                .virtual_allocations
+                .read()
+                .contains_key(&client_view.view_base)
+        );
+    }
+
+    #[test]
+    fn nt_connect_port_second_connect_on_same_section_does_not_allocate() {
+        let mut peb = ProcessEnvironmentBlock::new_zeroed();
+        peb.read_only_shared_memory_base = 0x7000_0000;
+        peb.read_only_static_server_data = 0x7000_1000;
+        let task = task_with_peb(&mut peb);
+        let section_handle = create_client_section(&task, SECTION_MAP_READ | SECTION_MAP_WRITE);
+        let (_first_handle, _first_client_view) = connect_csr_api_port(&task, &peb, section_handle);
+        let (_name_units, name) = api_port_name(WINDOWS_API_PORT);
+        let qos = security_qos();
+        let mut second_handle = Handle::default();
+        let mut second_client_view = PortView {
+            length: test_size_u32::<PortView>(),
+            padding: 0,
+            section_handle,
+            section_offset: 0,
+            view_size: crate::PAGE_SIZE,
+            view_base: 0,
+            view_remote_base: 0,
+        };
+        let mut connection_info = empty_connect_info();
+        let mut connection_info_len = test_size_u32::<CsrApiConnectInfo>();
+        let section_view_count = task.process.section_views.read().len();
+        let virtual_allocation_count = task.process.virtual_allocations.read().len();
+
+        assert_eq!(
+            task.sys_nt_connect_port(ConnectPortParameters {
+                port_handle: mut_ptr(&mut second_handle),
+                port_name: const_ptr(&name),
+                security_qos: const_ptr(&qos),
+                client_view: Some(mut_ptr(&mut second_client_view)),
+                server_view: None,
+                max_message_length: None,
+                connection_information: Some(mut_byte_ptr(&mut connection_info)),
+                connection_information_length: Some(mut_ptr(&mut connection_info_len)),
+            }),
+            NtStatus::NOT_SUPPORTED
+        );
+
+        assert!(second_handle.is_null());
+        assert_eq!(second_client_view.view_base, 0);
+        assert_eq!(task.process.section_views.read().len(), section_view_count);
+        assert_eq!(
+            task.process.virtual_allocations.read().len(),
+            virtual_allocation_count
+        );
+    }
+}

--- a/litebox_shim_windows/src/syscalls/lpc.rs
+++ b/litebox_shim_windows/src/syscalls/lpc.rs
@@ -169,7 +169,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         let handle = match self.insert_typed_handle::<LpcPortSubsystem<Platform>>(port, drop) {
             Ok(handle) => handle,
             Err(status) => {
-                self.rollback_client_port_section_view(mapped_view.base);
+                self.rollback_pagefile_section_view(mapped_view.base);
                 return status;
             }
         };
@@ -196,7 +196,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             || params.port_handle.write_at_offset(0, handle).is_none();
         if write_failed {
             self.close_lpc_port_handle(handle);
-            self.rollback_client_port_section_view(mapped_view.base);
+            self.rollback_pagefile_section_view(mapped_view.base);
             return NtStatus::ACCESS_VIOLATION;
         }
 
@@ -207,7 +207,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             server_view_value.view_base = mapped_view.base;
             if server_view.write_at_offset(0, server_view_value).is_none() {
                 self.close_lpc_port_handle(handle);
-                self.rollback_client_port_section_view(mapped_view.base);
+                self.rollback_pagefile_section_view(mapped_view.base);
                 return NtStatus::ACCESS_VIOLATION;
             }
         }
@@ -360,16 +360,8 @@ mod tests {
     }
 
     fn create_client_section(task: &Task<TestPlatform, TestFS>, access: u32) -> Handle {
-        create_client_section_with_size(task, access, crate::PAGE_SIZE)
-    }
-
-    fn create_client_section_with_size(
-        task: &Task<TestPlatform, TestFS>,
-        access: u32,
-        size: usize,
-    ) -> Handle {
         let mut handle = Handle::default();
-        let size = i64::try_from(size).expect("test section size fits in i64");
+        let size = i64::try_from(crate::PAGE_SIZE).expect("test section size fits in i64");
         assert_eq!(
             task.sys_nt_create_section(
                 mut_ptr(&mut handle),
@@ -600,55 +592,6 @@ mod tests {
             task.map_client_port_section(section_handle, crate::PAGE_SIZE)
                 .map(|_| ()),
             Ok(())
-        );
-    }
-
-    #[test]
-    fn nt_connect_port_rejects_oversized_client_view_before_allocating() {
-        let mut peb = ProcessEnvironmentBlock::new_zeroed();
-        peb.read_only_shared_memory_base = 0x7000_0000;
-        peb.read_only_static_server_data = 0x7000_1000;
-        let task = task_with_peb(&mut peb);
-        let (_name_units, name) = api_port_name(WINDOWS_API_PORT);
-        let qos = security_qos();
-        let oversized = crate::syscalls::section::WINDOWS_SHARED_SECTION_SIZE + crate::PAGE_SIZE;
-        let section_handle =
-            create_client_section_with_size(&task, SECTION_MAP_READ | SECTION_MAP_WRITE, oversized);
-        let mut handle = Handle::default();
-        let mut client_view = PortView {
-            length: test_size_u32::<PortView>(),
-            padding: 0,
-            section_handle,
-            section_offset: 0,
-            view_size: oversized,
-            view_base: 0,
-            view_remote_base: 0,
-        };
-        let mut connection_info = empty_connect_info();
-        let mut connection_info_len = test_size_u32::<CsrApiConnectInfo>();
-        let section_view_count = task.process.section_views.read().len();
-        let virtual_allocation_count = task.process.virtual_allocations.read().len();
-
-        assert_eq!(
-            task.sys_nt_connect_port(ConnectPortParameters {
-                port_handle: mut_ptr(&mut handle),
-                port_name: const_ptr(&name),
-                security_qos: const_ptr(&qos),
-                client_view: Some(mut_ptr(&mut client_view)),
-                server_view: None,
-                max_message_length: None,
-                connection_information: Some(mut_byte_ptr(&mut connection_info)),
-                connection_information_length: Some(mut_ptr(&mut connection_info_len)),
-            }),
-            NtStatus::INVALID_VIEW_SIZE
-        );
-
-        assert!(handle.is_null());
-        assert_eq!(client_view.view_base, 0);
-        assert_eq!(task.process.section_views.read().len(), section_view_count);
-        assert_eq!(
-            task.process.virtual_allocations.read().len(),
-            virtual_allocation_count
         );
     }
 

--- a/litebox_shim_windows/src/syscalls/lpc.rs
+++ b/litebox_shim_windows/src/syscalls/lpc.rs
@@ -438,6 +438,7 @@ mod tests {
         let mut peb = ProcessEnvironmentBlock::new_zeroed();
         peb.read_only_shared_memory_base = 0x7000_0000;
         peb.read_only_static_server_data = 0x7000_1000;
+        peb.csr_server_read_only_shared_memory_base = 0x7100_0000;
         let task = task_with_peb(&mut peb);
         let (_name_units, name) = api_port_name(WINDOWS_API_PORT);
         let qos = security_qos();
@@ -481,6 +482,10 @@ mod tests {
         assert_eq!(
             connection_info.shared_static_server_data,
             peb.read_only_static_server_data
+        );
+        assert_ne!(
+            u64::try_from(connection_info.shared_section_base).unwrap(),
+            peb.csr_server_read_only_shared_memory_base
         );
         assert_eq!(
             connection_info.size_of_peb_data,

--- a/litebox_shim_windows/src/syscalls/lpc.rs
+++ b/litebox_shim_windows/src/syscalls/lpc.rs
@@ -237,13 +237,18 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
     }
 
     fn csr_api_connect_info(&self) -> Option<CsrApiConnectInfo> {
-        let peb =
-            ConstPtr::<Platform, ProcessEnvironmentBlock>::from_usize(self.process.peb_address)
-                .read_at_offset(0)?;
+        let read_only_shared_memory_base = crate::read_field_at_offset::<Platform, usize>(
+            self.process.peb_address,
+            core::mem::offset_of!(ProcessEnvironmentBlock, read_only_shared_memory_base),
+        )?;
+        let read_only_static_server_data = crate::read_field_at_offset::<Platform, usize>(
+            self.process.peb_address,
+            core::mem::offset_of!(ProcessEnvironmentBlock, read_only_static_server_data),
+        )?;
         Some(CsrApiConnectInfo {
-            shared_section_base: peb.read_only_shared_memory_base,
-            shared_static_server_data: peb.read_only_static_server_data,
-            shared_section_heap: peb.read_only_shared_memory_base,
+            shared_section_base: read_only_shared_memory_base,
+            shared_static_server_data: read_only_static_server_data,
+            shared_section_heap: read_only_shared_memory_base,
             debug_flags: 0,
             size_of_peb_data: size_u32::<ProcessEnvironmentBlock>()?,
             size_of_teb_data: size_u32::<ThreadEnvironmentBlock>()?,

--- a/litebox_shim_windows/src/syscalls/lpc.rs
+++ b/litebox_shim_windows/src/syscalls/lpc.rs
@@ -77,11 +77,6 @@ struct CsrApiConnectInfo {
     server_process_id: usize,
 }
 
-const _: () = assert!(size_of::<SecurityQualityOfService>() == 12);
-const _: () = assert!(size_of::<PortView>() == 48);
-const _: () = assert!(size_of::<RemotePortView>() == 24);
-const _: () = assert!(size_of::<CsrApiConnectInfo>() == CSR_API_CONNECTINFO_SIZE);
-
 pub(crate) struct ConnectPortParameters<Platform: ShimPlatform> {
     pub(crate) port_handle: MutPtr<Platform, Handle>,
     pub(crate) port_name: ConstPtr<Platform, UnicodeString>,

--- a/litebox_shim_windows/src/syscalls/lpc.rs
+++ b/litebox_shim_windows/src/syscalls/lpc.rs
@@ -5,9 +5,9 @@ use alloc::string::String;
 use core::marker::PhantomData;
 use core::mem::size_of;
 
-use litebox::utils::TruncateExt as _;
 use litebox::fd::{FdEnabledSubsystem, FdEnabledSubsystemEntry};
 use litebox::platform::{RawConstPointer as _, RawMutPointer as _};
+use litebox::utils::TruncateExt as _;
 use litebox_common_windows::nt_status::NtStatus;
 use zerocopy::{FromBytes, Immutable, IntoBytes};
 
@@ -17,7 +17,8 @@ use crate::{ConstPtr, MutPtr, ShimFS, ShimPlatform, Task, probe_guest_output_pre
 
 const CSR_MAX_MESSAGE_LENGTH: u32 = 0x148;
 const CSR_SERVER_PROCESS_ID: usize = 1;
-const CSR_SERVER_DLL_NAMES: u32 = 2;
+// TODO(csr-server-dll-names): report names once the CSR connect contract models them.
+const CSR_NUMBER_OF_SERVER_DLL_NAMES: u32 = 0;
 
 pub(crate) struct LpcPortSubsystem<Platform>(PhantomData<fn(Platform)>);
 
@@ -243,7 +244,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             debug_flags: 0,
             size_of_peb_data: size_of::<ProcessEnvironmentBlock>().trunc(),
             size_of_teb_data: size_of::<ThreadEnvironmentBlock>().trunc(),
-            number_of_server_dll_names: CSR_SERVER_DLL_NAMES,
+            number_of_server_dll_names: CSR_NUMBER_OF_SERVER_DLL_NAMES,
             server_process_id: CSR_SERVER_PROCESS_ID,
         })
     }

--- a/litebox_shim_windows/src/syscalls/lpc.rs
+++ b/litebox_shim_windows/src/syscalls/lpc.rs
@@ -14,7 +14,6 @@ use super::Handle;
 use crate::nt_types::{ProcessEnvironmentBlock, ThreadEnvironmentBlock, UnicodeString};
 use crate::{ConstPtr, MutPtr, ShimFS, ShimPlatform, Task, probe_guest_output_preserving_value};
 
-const WINDOWS_API_PORT: &str = r"\Windows\ApiPort";
 const CSR_API_CONNECTINFO_SIZE: usize = 0x30;
 const CSR_API_CONNECTINFO_SIZE_U32: u32 = 0x30;
 const CSR_MAX_MESSAGE_LENGTH: u32 = 0x148;
@@ -102,8 +101,8 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             Ok(name) => name,
             Err(status) => return status,
         };
-        if !is_csr_api_port(&port_name) {
-            return NtStatus::OBJECT_NAME_NOT_FOUND;
+        if let Err(status) = self.process.object_manager.resolve_port(&port_name) {
+            return status;
         }
 
         let Some(client_view) = params.client_view else {
@@ -253,10 +252,6 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
     }
 }
 
-fn is_csr_api_port(port_name: &str) -> bool {
-    port_name == WINDOWS_API_PORT
-}
-
 fn size_u32<T>() -> Option<u32> {
     u32::try_from(size_of::<T>()).ok()
 }
@@ -313,6 +308,7 @@ mod tests {
     use super::*;
     use crate::syscalls::ProcessHandle;
     use crate::syscalls::mm::PageProtection;
+    use crate::syscalls::object_manager::WINDOWS_API_PORT;
     use crate::tests::{
         TestFS, TestPlatform, const_ptr, mut_byte_ptr, mut_ptr, test_task, unicode_string,
         utf16_units,
@@ -527,7 +523,7 @@ mod tests {
                 connection_information: Some(mut_byte_ptr(&mut connection_info)),
                 connection_information_length: Some(mut_ptr(&mut connection_info_len)),
             }),
-            NtStatus::OBJECT_NAME_NOT_FOUND
+            NtStatus::OBJECT_PATH_NOT_FOUND
         );
         assert!(handle.is_null());
     }

--- a/litebox_shim_windows/src/syscalls/lpc.rs
+++ b/litebox_shim_windows/src/syscalls/lpc.rs
@@ -254,7 +254,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
 }
 
 fn is_csr_api_port(port_name: &str) -> bool {
-    port_name.eq_ignore_ascii_case(WINDOWS_API_PORT)
+    port_name == WINDOWS_API_PORT
 }
 
 fn size_u32<T>() -> Option<u32> {
@@ -497,6 +497,41 @@ mod tests {
         let mut peb = ProcessEnvironmentBlock::new_zeroed();
         let task = task_with_peb(&mut peb);
         let (_name_units, name) = api_port_name(r"\NotWindows\ApiPort");
+        let qos = security_qos();
+        let mut handle = Handle::default();
+        let mut client_view = PortView {
+            length: test_size_u32::<PortView>(),
+            padding: 0,
+            section_handle: Handle::default(),
+            section_offset: 0,
+            view_size: crate::PAGE_SIZE,
+            view_base: 0,
+            view_remote_base: 0,
+        };
+        let mut connection_info = empty_connect_info();
+        let mut connection_info_len = test_size_u32::<CsrApiConnectInfo>();
+
+        assert_eq!(
+            task.sys_nt_connect_port(ConnectPortParameters {
+                port_handle: mut_ptr(&mut handle),
+                port_name: const_ptr(&name),
+                security_qos: const_ptr(&qos),
+                client_view: Some(mut_ptr(&mut client_view)),
+                server_view: None,
+                max_message_length: None,
+                connection_information: Some(mut_byte_ptr(&mut connection_info)),
+                connection_information_length: Some(mut_ptr(&mut connection_info_len)),
+            }),
+            NtStatus::OBJECT_NAME_NOT_FOUND
+        );
+        assert!(handle.is_null());
+    }
+
+    #[test]
+    fn nt_connect_port_rejects_api_port_case_variant() {
+        let mut peb = ProcessEnvironmentBlock::new_zeroed();
+        let task = task_with_peb(&mut peb);
+        let (_name_units, name) = api_port_name(r"\WINDOWS\APIPORT");
         let qos = security_qos();
         let mut handle = Handle::default();
         let mut client_view = PortView {

--- a/litebox_shim_windows/src/syscalls/lpc.rs
+++ b/litebox_shim_windows/src/syscalls/lpc.rs
@@ -5,6 +5,7 @@ use alloc::string::String;
 use core::marker::PhantomData;
 use core::mem::size_of;
 
+use litebox::utils::TruncateExt as _;
 use litebox::fd::{FdEnabledSubsystem, FdEnabledSubsystemEntry};
 use litebox::platform::{RawConstPointer as _, RawMutPointer as _};
 use litebox_common_windows::nt_status::NtStatus;
@@ -14,8 +15,6 @@ use super::Handle;
 use crate::nt_types::{ProcessEnvironmentBlock, ThreadEnvironmentBlock, UnicodeString};
 use crate::{ConstPtr, MutPtr, ShimFS, ShimPlatform, Task, probe_guest_output_preserving_value};
 
-const CSR_API_CONNECTINFO_SIZE: usize = 0x30;
-const CSR_API_CONNECTINFO_SIZE_U32: u32 = 0x30;
 const CSR_MAX_MESSAGE_LENGTH: u32 = 0x148;
 const CSR_SERVER_PROCESS_ID: usize = 1;
 const CSR_SERVER_DLL_NAMES: u32 = 2;
@@ -185,13 +184,11 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             || params
                 .max_message_length
                 .is_some_and(|ptr| ptr.write_at_offset(0, CSR_MAX_MESSAGE_LENGTH).is_none())
-            || write_process_output::<Platform, CsrApiConnectInfo>(
-                connection_information,
-                connect_info,
-            )
-            .is_none()
+            || connection_information
+                .write_slice_at_offset(0, connect_info.as_bytes())
+                .is_none()
             || connection_information_length
-                .write_at_offset(0, CSR_API_CONNECTINFO_SIZE_U32)
+                .write_at_offset(0, size_of::<CsrApiConnectInfo>().trunc())
                 .is_none()
             || params.port_handle.write_at_offset(0, handle).is_none();
         if write_failed {
@@ -244,16 +241,12 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             shared_static_server_data: read_only_static_server_data,
             shared_section_heap: read_only_shared_memory_base,
             debug_flags: 0,
-            size_of_peb_data: size_u32::<ProcessEnvironmentBlock>()?,
-            size_of_teb_data: size_u32::<ThreadEnvironmentBlock>()?,
+            size_of_peb_data: size_of::<ProcessEnvironmentBlock>().trunc(),
+            size_of_teb_data: size_of::<ThreadEnvironmentBlock>().trunc(),
             number_of_server_dll_names: CSR_SERVER_DLL_NAMES,
             server_process_id: CSR_SERVER_PROCESS_ID,
         })
     }
-}
-
-fn size_u32<T>() -> Option<u32> {
-    u32::try_from(size_of::<T>()).ok()
 }
 
 fn probe_lpc_outputs<Platform: ShimPlatform>(
@@ -276,7 +269,7 @@ fn probe_lpc_outputs<Platform: ShimPlatform>(
     probe_guest_byte_buffer_preserving::<Platform>(
         connection_information,
         connection_information_len,
-        CSR_API_CONNECTINFO_SIZE,
+        size_of::<CsrApiConnectInfo>(),
     )?;
     probe_guest_output_preserving_value::<Platform, u32>(connection_information_length)
 }
@@ -294,19 +287,11 @@ fn probe_guest_byte_buffer_preserving<Platform: ShimPlatform>(
         .ok_or(NtStatus::ACCESS_VIOLATION)
 }
 
-fn write_process_output<Platform: ShimPlatform, T: FromBytes + IntoBytes + Immutable>(
-    ptr: MutPtr<Platform, u8>,
-    value: T,
-) -> Option<()> {
-    ptr.write_slice_at_offset(0, value.as_bytes())
-}
-
 #[cfg(test)]
 mod tests {
     use zerocopy::FromZeros as _;
 
     use super::*;
-    use crate::syscalls::ProcessHandle;
     use crate::syscalls::mm::PageProtection;
     use crate::syscalls::object_manager::WINDOWS_API_PORT;
     use crate::tests::{
@@ -328,7 +313,7 @@ mod tests {
 
     fn security_qos() -> SecurityQualityOfService {
         SecurityQualityOfService {
-            length: test_size_u32::<SecurityQualityOfService>(),
+            length: size_of::<SecurityQualityOfService>().trunc(),
             impersonation_level: 2,
             context_tracking_mode: 0,
             effective_only: 1,
@@ -355,10 +340,6 @@ mod tests {
         }
     }
 
-    fn test_size_u32<T>() -> u32 {
-        size_u32::<T>().expect("Windows ABI test structure size fits in u32")
-    }
-
     fn create_client_section(task: &Task<TestPlatform, TestFS>, access: u32) -> Handle {
         let mut handle = Handle::default();
         let size = i64::try_from(crate::PAGE_SIZE).expect("test section size fits in i64");
@@ -377,50 +358,6 @@ mod tests {
         handle
     }
 
-    fn connect_csr_api_port(
-        task: &Task<TestPlatform, TestFS>,
-        peb: &ProcessEnvironmentBlock,
-        section_handle: Handle,
-    ) -> (Handle, PortView) {
-        let (_name_units, name) = api_port_name(WINDOWS_API_PORT);
-        let qos = security_qos();
-        let mut handle = Handle::default();
-        let mut client_view = PortView {
-            length: test_size_u32::<PortView>(),
-            padding: 0,
-            section_handle,
-            section_offset: 0,
-            view_size: crate::PAGE_SIZE,
-            view_base: 0,
-            view_remote_base: 0,
-        };
-        let mut connection_info = empty_connect_info();
-        let mut connection_info_len = test_size_u32::<CsrApiConnectInfo>();
-
-        assert_eq!(
-            task.sys_nt_connect_port(ConnectPortParameters {
-                port_handle: mut_ptr(&mut handle),
-                port_name: const_ptr(&name),
-                security_qos: const_ptr(&qos),
-                client_view: Some(mut_ptr(&mut client_view)),
-                server_view: None,
-                max_message_length: None,
-                connection_information: Some(mut_byte_ptr(&mut connection_info)),
-                connection_information_length: Some(mut_ptr(&mut connection_info_len)),
-            }),
-            NtStatus::SUCCESS
-        );
-        assert_eq!(
-            connection_info.shared_section_base,
-            peb.read_only_shared_memory_base
-        );
-        assert_eq!(
-            connection_info.shared_static_server_data,
-            peb.read_only_static_server_data
-        );
-        (handle, client_view)
-    }
-
     #[test]
     fn nt_connect_port_fills_csr_info_and_maps_client_section() {
         let mut peb = ProcessEnvironmentBlock::new_zeroed();
@@ -433,7 +370,7 @@ mod tests {
         let section_handle = create_client_section(&task, SECTION_MAP_READ | SECTION_MAP_WRITE);
         let mut handle = Handle::default();
         let mut client_view = PortView {
-            length: test_size_u32::<PortView>(),
+            length: size_of::<PortView>().trunc(),
             padding: 0,
             section_handle,
             section_offset: 0,
@@ -443,7 +380,7 @@ mod tests {
         };
         let mut max_message_length = 0u32;
         let mut connection_info = empty_connect_info();
-        let mut connection_info_len = test_size_u32::<CsrApiConnectInfo>();
+        let mut connection_info_len = size_of::<CsrApiConnectInfo>().trunc();
 
         assert_eq!(
             task.sys_nt_connect_port(ConnectPortParameters {
@@ -477,249 +414,11 @@ mod tests {
         );
         assert_eq!(
             connection_info.size_of_peb_data,
-            test_size_u32::<ProcessEnvironmentBlock>()
+            size_of::<ProcessEnvironmentBlock>().trunc()
         );
         assert_eq!(
             connection_info.size_of_teb_data,
-            test_size_u32::<ThreadEnvironmentBlock>()
-        );
-    }
-
-    #[test]
-    fn nt_connect_port_rejects_api_port_suffix_match() {
-        let mut peb = ProcessEnvironmentBlock::new_zeroed();
-        let task = task_with_peb(&mut peb);
-        let (_name_units, name) = api_port_name(r"\NotWindows\ApiPort");
-        let qos = security_qos();
-        let mut handle = Handle::default();
-        let mut client_view = PortView {
-            length: test_size_u32::<PortView>(),
-            padding: 0,
-            section_handle: Handle::default(),
-            section_offset: 0,
-            view_size: crate::PAGE_SIZE,
-            view_base: 0,
-            view_remote_base: 0,
-        };
-        let mut connection_info = empty_connect_info();
-        let mut connection_info_len = test_size_u32::<CsrApiConnectInfo>();
-
-        assert_eq!(
-            task.sys_nt_connect_port(ConnectPortParameters {
-                port_handle: mut_ptr(&mut handle),
-                port_name: const_ptr(&name),
-                security_qos: const_ptr(&qos),
-                client_view: Some(mut_ptr(&mut client_view)),
-                server_view: None,
-                max_message_length: None,
-                connection_information: Some(mut_byte_ptr(&mut connection_info)),
-                connection_information_length: Some(mut_ptr(&mut connection_info_len)),
-            }),
-            NtStatus::OBJECT_PATH_NOT_FOUND
-        );
-        assert!(handle.is_null());
-    }
-
-    #[test]
-    fn nt_connect_port_rejects_api_port_case_variant() {
-        let mut peb = ProcessEnvironmentBlock::new_zeroed();
-        let task = task_with_peb(&mut peb);
-        let (_name_units, name) = api_port_name(r"\WINDOWS\APIPORT");
-        let qos = security_qos();
-        let mut handle = Handle::default();
-        let mut client_view = PortView {
-            length: test_size_u32::<PortView>(),
-            padding: 0,
-            section_handle: Handle::default(),
-            section_offset: 0,
-            view_size: crate::PAGE_SIZE,
-            view_base: 0,
-            view_remote_base: 0,
-        };
-        let mut connection_info = empty_connect_info();
-        let mut connection_info_len = test_size_u32::<CsrApiConnectInfo>();
-
-        assert_eq!(
-            task.sys_nt_connect_port(ConnectPortParameters {
-                port_handle: mut_ptr(&mut handle),
-                port_name: const_ptr(&name),
-                security_qos: const_ptr(&qos),
-                client_view: Some(mut_ptr(&mut client_view)),
-                server_view: None,
-                max_message_length: None,
-                connection_information: Some(mut_byte_ptr(&mut connection_info)),
-                connection_information_length: Some(mut_ptr(&mut connection_info_len)),
-            }),
-            NtStatus::OBJECT_NAME_NOT_FOUND
-        );
-        assert!(handle.is_null());
-    }
-
-    #[test]
-    fn nt_connect_port_requires_bounded_connect_info_length() {
-        let mut peb = ProcessEnvironmentBlock::new_zeroed();
-        let task = task_with_peb(&mut peb);
-        let (_name_units, name) = api_port_name(WINDOWS_API_PORT);
-        let qos = security_qos();
-        let section_handle = create_client_section(&task, SECTION_MAP_READ | SECTION_MAP_WRITE);
-        let mut handle = Handle::default();
-        let mut client_view = PortView {
-            length: test_size_u32::<PortView>(),
-            padding: 0,
-            section_handle,
-            section_offset: 0,
-            view_size: crate::PAGE_SIZE,
-            view_base: 0,
-            view_remote_base: 0,
-        };
-        let mut connection_info = empty_connect_info();
-        let mut connection_info_len = CSR_API_CONNECTINFO_SIZE_U32 + 1;
-
-        assert_eq!(
-            task.sys_nt_connect_port(ConnectPortParameters {
-                port_handle: mut_ptr(&mut handle),
-                port_name: const_ptr(&name),
-                security_qos: const_ptr(&qos),
-                client_view: Some(mut_ptr(&mut client_view)),
-                server_view: None,
-                max_message_length: None,
-                connection_information: Some(mut_byte_ptr(&mut connection_info)),
-                connection_information_length: Some(mut_ptr(&mut connection_info_len)),
-            }),
-            NtStatus::INFO_LENGTH_MISMATCH
-        );
-        assert_eq!(
-            task.map_client_port_section(section_handle, crate::PAGE_SIZE)
-                .map(|_| ()),
-            Ok(())
-        );
-    }
-
-    #[test]
-    fn nt_connect_port_requires_section_read_and_write_access() {
-        let mut peb = ProcessEnvironmentBlock::new_zeroed();
-        peb.read_only_shared_memory_base = 0x7000_0000;
-        peb.read_only_static_server_data = 0x7000_1000;
-        let task = task_with_peb(&mut peb);
-        let (_name_units, name) = api_port_name(WINDOWS_API_PORT);
-        let qos = security_qos();
-        let section_handle = create_client_section(&task, SECTION_MAP_WRITE);
-        let mut handle = Handle::default();
-        let mut client_view = PortView {
-            length: test_size_u32::<PortView>(),
-            padding: 0,
-            section_handle,
-            section_offset: 0,
-            view_size: crate::PAGE_SIZE,
-            view_base: 0,
-            view_remote_base: 0,
-        };
-        let mut connection_info = empty_connect_info();
-        let mut connection_info_len = test_size_u32::<CsrApiConnectInfo>();
-
-        assert_eq!(
-            task.sys_nt_connect_port(ConnectPortParameters {
-                port_handle: mut_ptr(&mut handle),
-                port_name: const_ptr(&name),
-                security_qos: const_ptr(&qos),
-                client_view: Some(mut_ptr(&mut client_view)),
-                server_view: None,
-                max_message_length: None,
-                connection_information: Some(mut_byte_ptr(&mut connection_info)),
-                connection_information_length: Some(mut_ptr(&mut connection_info_len)),
-            }),
-            NtStatus::ACCESS_DENIED
-        );
-        assert!(handle.is_null());
-    }
-
-    #[test]
-    fn nt_connect_port_client_view_unmaps_owned_pages() {
-        let mut peb = ProcessEnvironmentBlock::new_zeroed();
-        peb.read_only_shared_memory_base = 0x7000_0000;
-        peb.read_only_static_server_data = 0x7000_1000;
-        let task = task_with_peb(&mut peb);
-        let section_handle = create_client_section(&task, SECTION_MAP_READ | SECTION_MAP_WRITE);
-        let (_handle, client_view) = connect_csr_api_port(&task, &peb, section_handle);
-
-        assert!(
-            task.process
-                .section_views
-                .read()
-                .contains_key(&client_view.view_base)
-        );
-        assert!(
-            task.process
-                .virtual_allocations
-                .read()
-                .contains_key(&client_view.view_base)
-        );
-
-        assert_eq!(
-            task.sys_nt_unmap_view_of_section(ProcessHandle::CURRENT, client_view.view_base),
-            NtStatus::SUCCESS
-        );
-        assert!(
-            !task
-                .process
-                .section_views
-                .read()
-                .contains_key(&client_view.view_base)
-        );
-        assert!(
-            !task
-                .process
-                .virtual_allocations
-                .read()
-                .contains_key(&client_view.view_base)
-        );
-    }
-
-    #[test]
-    fn nt_connect_port_second_connect_on_same_section_does_not_allocate() {
-        let mut peb = ProcessEnvironmentBlock::new_zeroed();
-        peb.read_only_shared_memory_base = 0x7000_0000;
-        peb.read_only_static_server_data = 0x7000_1000;
-        let task = task_with_peb(&mut peb);
-        let section_handle = create_client_section(&task, SECTION_MAP_READ | SECTION_MAP_WRITE);
-        let (_first_handle, _first_client_view) = connect_csr_api_port(&task, &peb, section_handle);
-        let (_name_units, name) = api_port_name(WINDOWS_API_PORT);
-        let qos = security_qos();
-        let mut second_handle = Handle::default();
-        let mut second_client_view = PortView {
-            length: test_size_u32::<PortView>(),
-            padding: 0,
-            section_handle,
-            section_offset: 0,
-            view_size: crate::PAGE_SIZE,
-            view_base: 0,
-            view_remote_base: 0,
-        };
-        let mut connection_info = empty_connect_info();
-        let mut connection_info_len = test_size_u32::<CsrApiConnectInfo>();
-        let section_view_count = task.process.section_views.read().len();
-        let virtual_allocation_count = task.process.virtual_allocations.read().len();
-
-        assert_eq!(
-            task.sys_nt_connect_port(ConnectPortParameters {
-                port_handle: mut_ptr(&mut second_handle),
-                port_name: const_ptr(&name),
-                security_qos: const_ptr(&qos),
-                client_view: Some(mut_ptr(&mut second_client_view)),
-                server_view: None,
-                max_message_length: None,
-                connection_information: Some(mut_byte_ptr(&mut connection_info)),
-                connection_information_length: Some(mut_ptr(&mut connection_info_len)),
-            }),
-            NtStatus::NOT_SUPPORTED
-        );
-
-        assert!(second_handle.is_null());
-        assert_eq!(second_client_view.view_base, 0);
-        assert_eq!(task.process.section_views.read().len(), section_view_count);
-        assert_eq!(
-            task.process.virtual_allocations.read().len(),
-            virtual_allocation_count
+            size_of::<ThreadEnvironmentBlock>().trunc()
         );
     }
 }

--- a/litebox_shim_windows/src/syscalls/mod.rs
+++ b/litebox_shim_windows/src/syscalls/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod event;
 pub(crate) mod file;
 pub(crate) mod file_path;
 pub(crate) mod iocp;
+pub(crate) mod lpc;
 pub(crate) mod mm;
 pub(crate) mod nls;
 pub(crate) mod object_manager;
@@ -183,6 +184,19 @@ pub(crate) enum SyscallRequest<Platform: RawPointerProvider> {
         object_attributes: Option<Platform::RawConstPointer<nt_types::ObjectAttributes>>,
         number_of_concurrent_threads: u32,
     },
+    NtConnectPort {
+        port_handle: Platform::RawMutPointer<Handle>,
+        port_name: Platform::RawConstPointer<nt_types::UnicodeString>,
+        security_qos: Platform::RawConstPointer<lpc::SecurityQualityOfService>,
+        client_view: Option<Platform::RawMutPointer<lpc::PortView>>,
+        server_view: Option<Platform::RawMutPointer<lpc::RemotePortView>>,
+        max_message_length: Option<Platform::RawMutPointer<u32>>,
+        connection_information: Option<Platform::RawMutPointer<u8>>,
+        connection_information_length: Option<Platform::RawMutPointer<u32>>,
+    },
+    /// `NtSecureConnectPort` carries SID and server-view semantics that are
+    /// deliberately outside the current CSR `NtConnectPort` subset.
+    NtSecureConnectPort,
     NtCreateSection {
         section_handle: Platform::RawMutPointer<Handle>,
         desired_access: u32,
@@ -601,6 +615,17 @@ impl<Platform: RawPointerProvider> SyscallRequest<Platform> {
                 object_attributes:*,
                 number_of_concurrent_threads,
             })),
+            NtSysno::NtConnectPort => Some(sys_req!(NtConnectPort {
+                port_handle:*,
+                port_name:*,
+                security_qos:*,
+                client_view:*,
+                server_view:*,
+                max_message_length:*,
+                connection_information:*,
+                connection_information_length:*,
+            })),
+            NtSysno::NtSecureConnectPort => Some(SyscallRequest::NtSecureConnectPort),
             NtSysno::NtCreateSection => Some(sys_req!(NtCreateSection {
                 section_handle:*,
                 desired_access,

--- a/litebox_shim_windows/src/syscalls/object_manager.rs
+++ b/litebox_shim_windows/src/syscalls/object_manager.rs
@@ -28,6 +28,7 @@ use crate::syscalls::section::{
 use crate::{ConstPtr, MutPtr, ShimFS, Task, probe_guest_output_preserving_value};
 
 const MAX_SYMLINK_REPARSE_DEPTH: usize = 64;
+pub(crate) const WINDOWS_API_PORT: &str = r"\Windows\ApiPort";
 const STANDARD_RIGHTS_REQUIRED: u32 = AccessMask::DELETE.bits()
     | AccessMask::READ_CONTROL.bits()
     | AccessMask::WRITE_DAC.bits()
@@ -162,6 +163,7 @@ enum NamedObject<Platform: crate::ShimPlatform> {
     FileDevice {
         device: FileDeviceObject,
     },
+    Port,
 }
 
 pub(super) enum ObjectLeafLookup<T> {
@@ -331,6 +333,7 @@ impl<Platform: crate::ShimPlatform> ObjectNode<Platform> {
         new_event(event: Weak<EventObject<Platform>>) => NamedObject::Event { event };
         new_section(section: Weak<SectionObject<Platform>>) => NamedObject::Section { section };
         new_file_device(device: FileDeviceObject) => NamedObject::FileDevice { device };
+        new_port() => NamedObject::Port;
     }
 
     fn child(&self, name: &str) -> Option<Arc<Self>> {
@@ -375,6 +378,7 @@ impl<Platform: crate::ShimPlatform> ObjectNode<Platform> {
         event_object, ObjectLeafLookup<Arc<EventObject<Platform>>>, NamedObject::Event { event } => ObjectLeafLookup::from_weak(event);
         section_object, ObjectLeafLookup<Arc<SectionObject<Platform>>>, NamedObject::Section { section } => ObjectLeafLookup::from_weak(section);
         file_device_object, ObjectLeafLookup<FileDeviceObject>, NamedObject::FileDevice { device } => ObjectLeafLookup::Live(device.clone());
+        port_object, ObjectLeafLookup<()>, NamedObject::Port => ObjectLeafLookup::Live(());
     }
 
     fn type_name(&self) -> Option<&'static str> {
@@ -384,6 +388,7 @@ impl<Platform: crate::ShimPlatform> ObjectNode<Platform> {
             NamedObject::Event { event } => event.upgrade().map(|_| "Event"),
             NamedObject::Section { section } => section.upgrade().map(|_| "Section"),
             NamedObject::FileDevice { .. } => Some("Device"),
+            NamedObject::Port => Some("Port"),
         }
     }
 
@@ -505,6 +510,17 @@ impl<Platform: crate::ShimPlatform> ObjectManager<Platform> {
         )
     }
 
+    fn create_port(&self, path: &str) -> NtStatus {
+        self.create_child(
+            path,
+            |node| node.port_object(),
+            ObjectNode::new_port,
+            NtStatus::OBJECT_TYPE_MISMATCH,
+            |()| NtStatus::OBJECT_NAME_EXISTS,
+            |_| NtStatus::SUCCESS,
+        )
+    }
+
     fn create_child<T>(
         &self,
         path: &str,
@@ -622,6 +638,16 @@ impl<Platform: crate::ShimPlatform> ObjectManager<Platform> {
         }
     }
 
+    pub(crate) fn resolve_port(&self, path: &str) -> Result<(), NtStatus> {
+        self.resolve_object_leaf(path, false, |node| {
+            if node.path == path {
+                node.port_object()
+            } else {
+                ObjectLeafLookup::Stale
+            }
+        })
+    }
+
     fn resolve_object_leaf<T>(
         &self,
         path: &str,
@@ -666,6 +692,14 @@ impl<Platform: crate::ShimPlatform> ObjectManager<Platform> {
         assert!(
             status == NtStatus::SUCCESS,
             "seeded NT file device must have seeded ancestors: {status:?}"
+        );
+    }
+
+    fn seed_port(&self, path: &str) {
+        let status = self.create_port(path);
+        assert!(
+            status == NtStatus::SUCCESS,
+            "seeded NT port must have seeded ancestors: {status:?}"
         );
     }
 
@@ -1327,6 +1361,7 @@ pub(crate) fn seed_object_manager<Platform: crate::ShimPlatform>()
         },
     );
     object_manager.seed_file_device(r"\Device\ConDrv", FileDeviceObject::ConsoleDriver);
+    object_manager.seed_port(WINDOWS_API_PORT);
     for (path, target) in SEEDED_SYMLINK_PATHS {
         object_manager.seed_symlink(path, target);
     }

--- a/litebox_shim_windows/src/syscalls/section.rs
+++ b/litebox_shim_windows/src/syscalls/section.rs
@@ -89,6 +89,12 @@ pub(crate) struct MapViewOfSectionParameters<Platform: ShimPlatform> {
     pub(crate) page_protection: u32,
 }
 
+pub(super) struct ClientPortSectionView {
+    pub(super) base: usize,
+    pub(super) mapped_size: usize,
+    pub(super) view_size: usize,
+}
+
 bitflags::bitflags! {
     #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     struct SectionAllocationAttributes: u32 {
@@ -705,6 +711,102 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             },
         );
         NtStatus::SUCCESS
+    }
+
+    pub(super) fn map_client_port_section(
+        &self,
+        section_handle: Handle,
+        requested_view_size: usize,
+    ) -> Result<ClientPortSectionView, NtStatus> {
+        let entry = self.section_entry(section_handle)?;
+        let section = entry.with_entry(|entry| {
+            entry
+                .granted_access
+                .require(SectionAccess::MAP_READ | SectionAccess::MAP_WRITE)
+                .map(|()| Arc::clone(&entry.section))
+        })?;
+        let view_size = if requested_view_size == 0 {
+            section.size
+        } else {
+            requested_view_size
+        };
+        if view_size == 0 || view_size > section.size {
+            return Err(NtStatus::INVALID_VIEW_SIZE);
+        }
+        let Some(mapped_size) = view_size.checked_next_multiple_of(PAGE_SIZE) else {
+            return Err(NtStatus::INVALID_VIEW_SIZE);
+        };
+        if mapped_size > WINDOWS_SHARED_SECTION_SIZE {
+            return Err(NtStatus::INVALID_VIEW_SIZE);
+        }
+        let Some(length) = NonZeroPageSize::<PAGE_SIZE>::new(mapped_size) else {
+            return Err(NtStatus::INVALID_VIEW_SIZE);
+        };
+        match section.backing {
+            SectionBacking::Pagefile => {}
+            SectionBacking::CsrSharedSection { .. } | SectionBacking::ImageFile => {
+                return Err(NtStatus::INVALID_FILE_FOR_SECTION);
+            }
+        }
+        let page_protection = PageProtection::PAGE_READWRITE;
+        let Some((_, permissions)) = parse_page_protection(page_protection.bits()) else {
+            return Err(NtStatus::INVALID_PAGE_PROTECTION);
+        };
+        if !pagefile_view_protection_is_compatible(section.protection, page_protection) {
+            return Err(NtStatus::SECTION_PROTECTION);
+        }
+        if section.pagefile_view_active.swap(true, Ordering::AcqRel) {
+            return Err(NtStatus::NOT_SUPPORTED);
+        }
+        let mapping = create_pages(
+            &self.global.page_manager,
+            None,
+            length,
+            CreatePagesFlags::empty(),
+            permissions,
+            |_| Ok(0),
+        )
+        .map_err(|_| {
+            section.pagefile_view_active.store(false, Ordering::Release);
+            NtStatus::NO_MEMORY
+        })?;
+        let base = mapping.as_usize();
+        self.process.section_views.write().insert(
+            base,
+            WindowsSectionView {
+                size: mapped_size,
+                section_offset: 0,
+                section: Some(Arc::clone(&section)),
+            },
+        );
+        self.process.virtual_allocations.write().insert(
+            base,
+            crate::WindowsVirtualAllocation {
+                base,
+                size: mapped_size,
+                allocation_protect: section.protection,
+                type_: MemoryType::MEM_MAPPED,
+                pages: committed_pages(base, mapped_size, page_protection),
+            },
+        );
+        Ok(ClientPortSectionView {
+            base,
+            mapped_size,
+            view_size,
+        })
+    }
+
+    pub(super) fn rollback_client_port_section_view(&self, base_address: usize) {
+        let Some((view_base, view)) = self.remove_section_view_for_address(base_address) else {
+            return;
+        };
+        if let Some(section) = &view.section
+            && matches!(section.backing, SectionBacking::Pagefile)
+        {
+            section.pagefile_view_active.store(false, Ordering::Release);
+        }
+        let _ = remove_view_pages::<Platform>(&self.global.page_manager, view_base, view.size);
+        self.process.virtual_allocations.write().remove(&view_base);
     }
 
     fn map_csr_shared_section(

--- a/litebox_shim_windows/src/syscalls/section.rs
+++ b/litebox_shim_windows/src/syscalls/section.rs
@@ -89,7 +89,7 @@ pub(crate) struct MapViewOfSectionParameters<Platform: ShimPlatform> {
     pub(crate) page_protection: u32,
 }
 
-pub(super) struct ClientPortSectionView {
+pub(super) struct MappedPagefileSectionView {
     pub(super) base: usize,
     pub(super) mapped_size: usize,
     pub(super) view_size: usize,
@@ -629,8 +629,66 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         page_protection: PageProtection,
         permissions: MemoryRegionPermissions,
     ) -> NtStatus {
+        let mapped_view = match self.map_pagefile_section_view(
+            section,
+            requested_view_size,
+            section_offset,
+            page_protection,
+            permissions,
+        ) {
+            Ok(mapped_view) => mapped_view,
+            Err(status) => return status,
+        };
+        if request
+            .base_address
+            .write_at_offset(0, mapped_view.base)
+            .is_none()
+            || request
+                .view_size
+                .write_at_offset(0, mapped_view.view_size)
+                .is_none()
+        {
+            self.rollback_pagefile_section_view(mapped_view.base);
+            return NtStatus::ACCESS_VIOLATION;
+        }
+        NtStatus::SUCCESS
+    }
+
+    pub(super) fn map_client_port_section(
+        &self,
+        section_handle: Handle,
+        requested_view_size: usize,
+    ) -> Result<MappedPagefileSectionView, NtStatus> {
+        let entry = self.section_entry(section_handle)?;
+        let section = entry.with_entry(|entry| {
+            entry
+                .granted_access
+                .require(SectionAccess::MAP_READ | SectionAccess::MAP_WRITE)
+                .map(|()| Arc::clone(&entry.section))
+        })?;
+        let page_protection = PageProtection::PAGE_READWRITE;
+        let Some((_, permissions)) = parse_page_protection(page_protection.bits()) else {
+            return Err(NtStatus::INVALID_PAGE_PROTECTION);
+        };
+        self.map_pagefile_section_view(
+            &section,
+            requested_view_size,
+            0,
+            page_protection,
+            permissions,
+        )
+    }
+
+    fn map_pagefile_section_view(
+        &self,
+        section: &Arc<SectionObject<Platform>>,
+        requested_view_size: usize,
+        section_offset: usize,
+        page_protection: PageProtection,
+        permissions: MemoryRegionPermissions,
+    ) -> Result<MappedPagefileSectionView, NtStatus> {
         if section_offset > section.size {
-            return NtStatus::INVALID_VIEW_SIZE;
+            return Err(NtStatus::INVALID_VIEW_SIZE);
         }
         let remaining = section.size - section_offset;
         let view_size = if requested_view_size == 0 {
@@ -639,18 +697,17 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             requested_view_size
         };
         if view_size == 0 || view_size > remaining {
-            return NtStatus::INVALID_VIEW_SIZE;
+            return Err(NtStatus::INVALID_VIEW_SIZE);
         }
-        let Some(mapped_size) = view_size.checked_next_multiple_of(PAGE_SIZE) else {
-            return NtStatus::INVALID_VIEW_SIZE;
-        };
-        let Some(length) = NonZeroPageSize::<PAGE_SIZE>::new(mapped_size) else {
-            return NtStatus::INVALID_VIEW_SIZE;
-        };
+        let mapped_size = view_size
+            .checked_next_multiple_of(PAGE_SIZE)
+            .ok_or(NtStatus::INVALID_VIEW_SIZE)?;
+        let length =
+            NonZeroPageSize::<PAGE_SIZE>::new(mapped_size).ok_or(NtStatus::INVALID_VIEW_SIZE)?;
         match section.backing {
             SectionBacking::Pagefile => {}
             SectionBacking::CsrSharedSection { .. } | SectionBacking::ImageFile => {
-                return NtStatus::INVALID_FILE_FOR_SECTION;
+                return Err(NtStatus::INVALID_FILE_FOR_SECTION);
             }
         }
         if !pagefile_view_protection_is_compatible(section.protection, page_protection) {
@@ -659,7 +716,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                 page_protection:% = format_args!("{:#x}", page_protection.bits());
                 "Rejected pagefile section view protection incompatible with section protection"
             );
-            return NtStatus::SECTION_PROTECTION;
+            return Err(NtStatus::SECTION_PROTECTION);
         }
         if section.pagefile_view_active.swap(true, Ordering::AcqRel) {
             litebox_util_log::debug!(
@@ -671,91 +728,6 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             // Host 25H2 allows repeated and simultaneous pagefile views. LiteBox
             // returns NOT_SUPPORTED until PageManager has first-class shared
             // anonymous backing that avoids kernel-side content storage.
-            return NtStatus::NOT_SUPPORTED;
-        }
-        let Ok(mapping) = create_pages(
-            &self.global.page_manager,
-            None,
-            length,
-            CreatePagesFlags::empty(),
-            permissions,
-            |_| Ok(0),
-        ) else {
-            section.pagefile_view_active.store(false, Ordering::Release);
-            return NtStatus::NO_MEMORY;
-        };
-        let base = mapping.as_usize();
-        if request.base_address.write_at_offset(0, base).is_none()
-            || request.view_size.write_at_offset(0, view_size).is_none()
-        {
-            let _ = remove_view_pages::<Platform>(&self.global.page_manager, base, mapped_size);
-            section.pagefile_view_active.store(false, Ordering::Release);
-            return NtStatus::ACCESS_VIOLATION;
-        }
-        self.process.section_views.write().insert(
-            base,
-            WindowsSectionView {
-                size: mapped_size,
-                section_offset,
-                section: Some(Arc::clone(section)),
-            },
-        );
-        self.process.virtual_allocations.write().insert(
-            base,
-            crate::WindowsVirtualAllocation {
-                base,
-                size: mapped_size,
-                allocation_protect: section.protection,
-                type_: MemoryType::MEM_MAPPED,
-                pages: committed_pages(base, mapped_size, page_protection),
-            },
-        );
-        NtStatus::SUCCESS
-    }
-
-    pub(super) fn map_client_port_section(
-        &self,
-        section_handle: Handle,
-        requested_view_size: usize,
-    ) -> Result<ClientPortSectionView, NtStatus> {
-        let entry = self.section_entry(section_handle)?;
-        let section = entry.with_entry(|entry| {
-            entry
-                .granted_access
-                .require(SectionAccess::MAP_READ | SectionAccess::MAP_WRITE)
-                .map(|()| Arc::clone(&entry.section))
-        })?;
-        let view_size = if requested_view_size == 0 {
-            section.size
-        } else {
-            requested_view_size
-        };
-        if view_size == 0 || view_size > section.size {
-            return Err(NtStatus::INVALID_VIEW_SIZE);
-        }
-        let Some(mapped_size) = view_size.checked_next_multiple_of(PAGE_SIZE) else {
-            return Err(NtStatus::INVALID_VIEW_SIZE);
-        };
-        if mapped_size > WINDOWS_SHARED_SECTION_SIZE {
-            return Err(NtStatus::INVALID_VIEW_SIZE);
-        }
-        let Some(length) = NonZeroPageSize::<PAGE_SIZE>::new(mapped_size) else {
-            return Err(NtStatus::INVALID_VIEW_SIZE);
-        };
-        match section.backing {
-            SectionBacking::Pagefile => {}
-            SectionBacking::CsrSharedSection { .. } | SectionBacking::ImageFile => {
-                return Err(NtStatus::INVALID_FILE_FOR_SECTION);
-            }
-        }
-        let page_protection = PageProtection::PAGE_READWRITE;
-        let Some((_, permissions)) = parse_page_protection(page_protection.bits()) else {
-            return Err(NtStatus::INVALID_PAGE_PROTECTION);
-        };
-        if !pagefile_view_protection_is_compatible(section.protection, page_protection) {
-            return Err(NtStatus::SECTION_PROTECTION);
-        }
-        if section.pagefile_view_active.swap(true, Ordering::AcqRel) {
             return Err(NtStatus::NOT_SUPPORTED);
         }
         let mapping = create_pages(
@@ -775,8 +747,8 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             base,
             WindowsSectionView {
                 size: mapped_size,
-                section_offset: 0,
-                section: Some(Arc::clone(&section)),
+                section_offset,
+                section: Some(Arc::clone(section)),
             },
         );
         self.process.virtual_allocations.write().insert(
@@ -789,14 +761,14 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                 pages: committed_pages(base, mapped_size, page_protection),
             },
         );
-        Ok(ClientPortSectionView {
+        Ok(MappedPagefileSectionView {
             base,
             mapped_size,
             view_size,
         })
     }
 
-    pub(super) fn rollback_client_port_section_view(&self, base_address: usize) {
+    pub(super) fn rollback_pagefile_section_view(&self, base_address: usize) {
         let Some((view_base, view)) = self.remove_section_view_for_address(base_address) else {
             return;
         };

--- a/litebox_shim_windows/src/syscalls/sysinfo.rs
+++ b/litebox_shim_windows/src/syscalls/sysinfo.rs
@@ -777,7 +777,7 @@ mod tests {
     extern crate std;
 
     const QPC_SLEEP_DURATION: Duration = Duration::from_millis(25);
-    const QPC_SLEEP_TOLERANCE: Duration = Duration::from_millis(10);
+    const QPC_SLEEP_TOLERANCE: Duration = Duration::from_millis(15);
 
     type TestPlatform = crate::tests::TestPlatform;
     type TestTask = Task<TestPlatform, crate::tests::TestFS>;

--- a/litebox_shim_windows/src/tests.rs
+++ b/litebox_shim_windows/src/tests.rs
@@ -82,6 +82,25 @@ pub(crate) fn test_platform() -> &'static TestPlatform {
     })
 }
 
+fn map_csr_server_shared_memory(
+    page_manager: &crate::WindowsPageManager<TestPlatform>,
+) -> Option<usize> {
+    let length = litebox::mm::linux::NonZeroPageSize::new(
+        crate::syscalls::section::WINDOWS_SHARED_SECTION_SIZE,
+    )?;
+    // SAFETY: address selection is left to the page manager, so this cannot replace a mapping.
+    unsafe {
+        page_manager.create_writable_pages(
+            None,
+            length,
+            litebox::mm::linux::CreatePagesFlags::empty(),
+            |_| Ok(0),
+        )
+    }
+    .map(|mapping| mapping.as_usize())
+    .ok()
+}
+
 pub(crate) fn test_task() -> Task<TestPlatform, TestFS> {
     test_task_with_nls_files(&[])
 }
@@ -135,7 +154,7 @@ pub(crate) fn test_task_with_nls_files(nls_files: &[(&str, &[u8])]) -> Task<Test
     let shim = shim_builder.build();
     let WindowsShim(global) = shim;
 
-    let windows_shared_section_base = crate::map_csr_server_shared_memory(&global.page_manager)
+    let windows_shared_section_base = map_csr_server_shared_memory(&global.page_manager)
         .expect("mapping shared memory should succeed");
     let windows_shared_section =
         crate::syscalls::section::load_time_windows_shared_section(windows_shared_section_base);


### PR DESCRIPTION
Implement the CSR `NtConnectPort` startup handshake so Windows guests can connect to `\Windows\ApiPort`, receive CSR connection data, and map their client section.

CSR client and CSRSS bases currently alias one mapping; distinct virtual mappings over shared backing remain TODO. Also, only BASESRV static-data slot 1 is populated; CSRSRV (0), CONSRV (2), USERSRV (3) remain TODO.