### PR TITLE
bump bitflags to 2.13.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,7 +163,7 @@ version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
  "itertools",
@@ -191,9 +191,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bitvec"
@@ -1418,7 +1418,7 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "libc",
  "plain",
  "redox_syscall",
@@ -1435,7 +1435,7 @@ name = "litebox"
 version = "0.1.0"
 dependencies = [
  "arrayvec",
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "buddy_system_allocator",
  "either",
  "hashbrown",
@@ -1457,7 +1457,7 @@ dependencies = [
 name = "litebox_common_linux"
 version = "0.1.0"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "elf",
  "int-enum",
@@ -1471,7 +1471,7 @@ dependencies = [
 name = "litebox_common_optee"
 version = "0.1.0"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "elf",
  "litebox",
  "litebox_common_linux",
@@ -1503,7 +1503,7 @@ version = "0.1.0"
 dependencies = [
  "arrayvec",
  "bindgen",
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "litebox",
  "litebox_common_linux",
  "litebox_util_log",
@@ -1540,7 +1540,7 @@ dependencies = [
  "aligned-vec",
  "arrayvec",
  "authenticode",
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "cms",
  "const-oid",
  "digest",
@@ -1685,7 +1685,7 @@ name = "litebox_shim_linux"
 version = "0.1.0"
 dependencies = [
  "arrayvec",
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "bitvec",
  "libc",
  "litebox",
@@ -2058,7 +2058,7 @@ version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2324,7 +2324,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -2353,7 +2353,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -2466,7 +2466,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2533,7 +2533,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2929,7 +2929,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac9ee8b664c9f1740cd813fea422116f8ba29997bb7c878d1940424889802897"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "log",
  "num-traits",
 ]
@@ -3071,7 +3071,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "bytes",
  "futures-util",
  "http",
@@ -3665,7 +3665,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f042214de98141e9c8706e8192b73f56494087cc55ebec28ce10f26c5c364ae"
 dependencies = [
  "bit_field",
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "rustversion",
  "volatile",
 ]

--- a/litebox/Cargo.toml
+++ b/litebox/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [dependencies]
 arrayvec = { version = "0.7.6", default-features = false, optional = true }
-bitflags = "2.6.0"
+bitflags = "2.13.1"
 either = { version = "1.13.0", default-features = false }
 hashbrown = "0.15.2"
 smallvec = "1.13.2"

--- a/litebox_platform_linux_kernel/Cargo.toml
+++ b/litebox_platform_linux_kernel/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2024"
 bindgen = "0.71.0"
 
 [dependencies]
-bitflags = "2.9.0"
+bitflags = "2.13.1"
 litebox = { path = "../litebox/", version = "0.1.0" }
 litebox_common_linux = { path = "../litebox_common_linux/", version = "0.1.0" }
 litebox_util_log = { version = "0.1.0", path = "../litebox_util_log" }

--- a/litebox_shim_linux/Cargo.toml
+++ b/litebox_shim_linux/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 arrayvec = { version = "0.7.6", default-features = false }
 bitvec = { version = "1.0.1", default-features = false, features = ["alloc"] }
-bitflags = "2.9.0"
+bitflags = "2.13.1"
 litebox = { path = "../litebox/", version = "0.1.0" }
 litebox_common_linux = { path = "../litebox_common_linux/", version = "0.1.0" }
 litebox_platform_multiplex = { path = "../litebox_platform_multiplex/", version = "0.1.0", default-features = false }


### PR DESCRIPTION
The build failed on Windows after I updated Rust (`rustc 1.97.0 (2d8144b78 2026-07-07`). Bump bitflags to the latest version to fix it.