### PR TITLE
Migrate Tar-RO file system to new backend

### DIFF
--- a/litebox/src/fs/backend.rs
+++ b/litebox/src/fs/backend.rs
@@ -318,10 +318,6 @@ pub(super) enum PermissionCheck {
     /// The backend is self-enforcing permissions for this item.
     ByBackend,
     /// The resolver should check this permission metadata.
-    #[expect(
-        dead_code,
-        reason = "only backend-self-enforced devices exist during migration"
-    )]
     ByResolver(PermissionInfo),
 }
 

--- a/litebox/src/fs/backend.rs
+++ b/litebox/src/fs/backend.rs
@@ -60,8 +60,12 @@ pub trait Backend: private::Sealed + Send + Sync + Any {
         components: &[&str],
     ) -> Result<WalkOutcome<WalkingDirHandle<'a>>, WalkError>;
 
-    /// Take an owned handle to a `dir` found via a walk.
-    fn owned_dir_at(&self, dir: WalkingDirHandle<'_>) -> DirHandle;
+    /// Take an owned handle to a `dir` found via a walk, validating any open `flags`.
+    fn owned_dir_at(
+        &self,
+        dir: WalkingDirHandle<'_>,
+        flags: OFlags,
+    ) -> Result<DirHandle, OpenError>;
 
     /// Obtain a walking handle to an existing owned dir.
     ///

--- a/litebox/src/fs/composer.rs
+++ b/litebox/src/fs/composer.rs
@@ -534,24 +534,29 @@ impl Backend for Composer {
         })
     }
 
-    fn owned_dir_at(&self, dir: WalkingDirHandle<'_>) -> DirHandle {
+    fn owned_dir_at(
+        &self,
+        dir: WalkingDirHandle<'_>,
+        flags: OFlags,
+    ) -> Result<DirHandle, OpenError> {
         let dir = dir.into_typed::<Self>();
-        DirHandle::from_typed::<Self>(ComposerDirHandle {
-            inner: match dir.inner {
-                ComposerWalkingDirHandleInner::Virtual { path } => {
-                    ComposerDirHandleInner::Virtual { path }
-                }
-                ComposerWalkingDirHandleInner::Mounted {
-                    path,
-                    mount_index,
-                    handle,
-                } => ComposerDirHandleInner::Mounted {
-                    path,
-                    mount_index,
-                    handle: self.mounts[mount_index].backend.owned_dir_at(handle),
-                },
+        let inner = match dir.inner {
+            ComposerWalkingDirHandleInner::Virtual { path } => {
+                ComposerDirHandleInner::Virtual { path }
+            }
+            ComposerWalkingDirHandleInner::Mounted {
+                path,
+                mount_index,
+                handle,
+            } => ComposerDirHandleInner::Mounted {
+                path,
+                mount_index,
+                handle: self.mounts[mount_index]
+                    .backend
+                    .owned_dir_at(handle, flags)?,
             },
-        })
+        };
+        Ok(DirHandle::from_typed::<Self>(ComposerDirHandle { inner }))
     }
 
     fn walking_dir_at<'a>(&'a self, dir: &DirHandle) -> Option<WalkingDirHandle<'a>> {

--- a/litebox/src/fs/devices.rs
+++ b/litebox/src/fs/devices.rs
@@ -210,8 +210,12 @@ where
         })
     }
 
-    fn owned_dir_at(&self, dir: WalkingDirHandle<'_>) -> DirHandle {
-        DirHandle::from_typed::<Self>(dir.into_typed::<Self>())
+    fn owned_dir_at(
+        &self,
+        dir: WalkingDirHandle<'_>,
+        _flags: OFlags,
+    ) -> Result<DirHandle, OpenError> {
+        Ok(DirHandle::from_typed::<Self>(dir.into_typed::<Self>()))
     }
 
     fn walking_dir_at<'a>(&'a self, dir: &DirHandle) -> Option<WalkingDirHandle<'a>> {

--- a/litebox/src/fs/inode_allocator.rs
+++ b/litebox/src/fs/inode_allocator.rs
@@ -19,7 +19,7 @@ impl InodeAllocator {
     pub fn for_device(device_id: u64) -> Self {
         Self {
             device_id,
-            counter: AtomicU64::new(0),
+            counter: AtomicU64::new(1),
         }
     }
 

--- a/litebox/src/fs/resolver.rs
+++ b/litebox/src/fs/resolver.rs
@@ -179,6 +179,18 @@ impl<Platform: sync::RawSyncPrimitivesProvider, Backend: super::backend::Backend
         Ok(Some((parent, name)))
     }
 
+    fn owned_parent_dir(&self, dir: WalkingDirHandle<'_>) -> Result<DirHandle, WalkError> {
+        self.backend
+            .owned_dir_at(dir, OFlags::PATH)
+            .map_err(|error| match error {
+                OpenError::PathError(PathError::NoSuchFileOrDirectory) => {
+                    PathError::MissingComponent.into()
+                }
+                OpenError::PathError(error) => error.into(),
+                _ => WalkError::Io,
+            })
+    }
+
     fn walk_to_directory<'a>(
         &'a self,
         context: &Context,
@@ -191,7 +203,15 @@ impl<Platform: sync::RawSyncPrimitivesProvider, Backend: super::backend::Backend
             return Ok(from);
         }
 
-        let outcome = self.backend.walk_directories(from, components)?;
+        let outcome =
+            self.backend
+                .walk_directories(from, components)
+                .map_err(|error| match error {
+                    WalkError::PathError(PathError::NoSuchFileOrDirectory) => {
+                        PathError::MissingComponent.into()
+                    }
+                    error => error,
+                })?;
         Self::check_walk_permissions(
             context,
             #[cfg(debug_assertions)]
@@ -335,7 +355,7 @@ impl<Platform: sync::RawSyncPrimitivesProvider, Backend: super::backend::Backend
                 return Err(OpenError::AlreadyExists);
             }
             return Ok(insert(
-                OwnedHandle::Dir(self.backend.owned_dir_at(self.backend.root())),
+                OwnedHandle::Dir(self.backend.owned_dir_at(self.backend.root(), flags)?),
                 SeekBehavior::NonSeekable,
             ));
         }
@@ -354,7 +374,7 @@ impl<Platform: sync::RawSyncPrimitivesProvider, Backend: super::backend::Backend
                     return Err(OpenError::AlreadyExists);
                 }
                 Ok(insert(
-                    OwnedHandle::Dir(self.backend.owned_dir_at(outcome.last)),
+                    OwnedHandle::Dir(self.backend.owned_dir_at(outcome.last, flags)?),
                     SeekBehavior::NonSeekable,
                 ))
             }
@@ -400,7 +420,10 @@ impl<Platform: sync::RawSyncPrimitivesProvider, Backend: super::backend::Backend
                         WalkError::Io => OpenError::Io,
                         WalkError::PathError(error) => error.into(),
                     })?;
-                let parent = self.backend.owned_dir_at(parent);
+                let parent = self.owned_parent_dir(parent).map_err(|error| match error {
+                    WalkError::Io => OpenError::Io,
+                    WalkError::PathError(error) => error.into(),
+                })?;
                 let file = self.backend.create_file_at(parent, name, mode)?;
                 let seek_behavior = self.backend.seek_behavior(&file);
                 Ok(insert(OwnedHandle::File(file), seek_behavior))
@@ -594,8 +617,11 @@ impl<Platform: sync::RawSyncPrimitivesProvider, Backend: super::backend::Backend
             // TODO(jayb): Add backend support for mutating the root directory itself.
             unimplemented!("chmod root directory")
         };
-        self.backend
-            .chmod_at(self.backend.owned_dir_at(parent), name, mode)
+        let parent = self.owned_parent_dir(parent).map_err(|error| match error {
+            WalkError::Io => ChmodError::Io,
+            WalkError::PathError(error) => error.into(),
+        })?;
+        self.backend.chmod_at(parent, name, mode)
     }
 
     fn chown(
@@ -616,8 +642,11 @@ impl<Platform: sync::RawSyncPrimitivesProvider, Backend: super::backend::Backend
             // TODO(jayb): Add backend support for mutating the root directory itself.
             unimplemented!("chown root directory")
         };
-        self.backend
-            .chown_at(self.backend.owned_dir_at(parent), name, user, group)
+        let parent = self.owned_parent_dir(parent).map_err(|error| match error {
+            WalkError::Io => ChownError::Io,
+            WalkError::PathError(error) => error.into(),
+        })?;
+        self.backend.chown_at(parent, name, user, group)
     }
 
     fn unlink(&self, path: impl Arg) -> Result<(), UnlinkError> {
@@ -632,8 +661,11 @@ impl<Platform: sync::RawSyncPrimitivesProvider, Backend: super::backend::Backend
         else {
             return Err(UnlinkError::IsADirectory);
         };
-        self.backend
-            .unlink_at(self.backend.owned_dir_at(parent), name)
+        let parent = self.owned_parent_dir(parent).map_err(|error| match error {
+            WalkError::Io => UnlinkError::Io,
+            WalkError::PathError(error) => error.into(),
+        })?;
+        self.backend.unlink_at(parent, name)
     }
 
     fn mkdir(&self, path: impl Arg, mode: Mode) -> Result<(), MkdirError> {
@@ -648,9 +680,11 @@ impl<Platform: sync::RawSyncPrimitivesProvider, Backend: super::backend::Backend
         else {
             return Err(MkdirError::AlreadyExists);
         };
-        self.backend
-            .mkdir_at(self.backend.owned_dir_at(parent), name, mode)
-            .map(|_| ())
+        let parent = self.owned_parent_dir(parent).map_err(|error| match error {
+            WalkError::Io => MkdirError::Io,
+            WalkError::PathError(error) => error.into(),
+        })?;
+        self.backend.mkdir_at(parent, name, mode).map(|_| ())
     }
 
     fn rmdir(&self, path: impl Arg) -> Result<(), RmdirError> {
@@ -665,8 +699,11 @@ impl<Platform: sync::RawSyncPrimitivesProvider, Backend: super::backend::Backend
         else {
             return Err(RmdirError::Busy);
         };
-        self.backend
-            .rmdir_at(self.backend.owned_dir_at(parent), name)
+        let parent = self.owned_parent_dir(parent).map_err(|error| match error {
+            WalkError::Io => RmdirError::Io,
+            WalkError::PathError(error) => error.into(),
+        })?;
+        self.backend.rmdir_at(parent, name)
     }
 
     fn read_dir(&self, fd: &TypedFd<Self>) -> Result<Vec<super::DirEntry>, ReadDirError> {

--- a/litebox/src/fs/resolver.rs
+++ b/litebox/src/fs/resolver.rs
@@ -739,10 +739,8 @@ impl<Platform: sync::RawSyncPrimitivesProvider, Backend: super::backend::Backend
     }
 
     fn file_status(&self, path: impl Arg) -> Result<super::FileStatus, FileStatusError> {
-        // TODO(jayb): Improve this. Opening just to stat forces the resolver to choose open flags,
-        // but stat itself should be access-neutral.
         let fd = self
-            .open(path, OFlags::RDONLY, Mode::empty())
+            .open(path, OFlags::PATH, Mode::empty())
             .map_err(|error| match error {
                 OpenError::PathError(error) => error.into(),
                 OpenError::Io

--- a/litebox/src/fs/tar_ro.rs
+++ b/litebox/src/fs/tar_ro.rs
@@ -32,7 +32,6 @@ use hashbrown::HashMap;
 use crate::{
     LiteBox,
     fs::{DirEntry, FileType},
-    path::Arg as _,
     sync,
 };
 
@@ -332,9 +331,7 @@ impl super::backend::Backend for TarRo {
 /// a read-only `.tar` file.
 pub struct FileSystem<Platform: sync::RawSyncPrimitivesProvider> {
     litebox: LiteBox<Platform>,
-    tar_index: TarIndex,
-    // cwd invariant: always ends with a `/`
-    current_working_dir: String,
+    resolver: super::resolver::Resolver<Platform, TarRo>,
 }
 
 /// An empty tar file to support an empty file system.
@@ -353,27 +350,12 @@ impl<Platform: sync::RawSyncPrimitivesProvider> FileSystem<Platform> {
     /// Panics if the provided `tar_data` is found to be an invalid `.tar` file.
     #[must_use]
     pub fn new(litebox: &LiteBox<Platform>, tar_data: alloc::borrow::Cow<'static, [u8]>) -> Self {
-        // TODO DO NOT COMMIT migrate this over to just being a wrap around the backend
         Self {
             litebox: litebox.clone(),
-            tar_index: TarIndex::new(tar_data, InodeAllocator::standalone()),
-            current_working_dir: "/".into(),
-        }
-    }
-
-    /// Gives the absolute path for `path`, resolving any `.` or `..`s, and making sure to account
-    /// for any relative paths from current working directory.
-    ///
-    /// Note: does NOT account for symlinks.
-    fn absolute_path(&self, path: impl crate::path::Arg) -> Result<String, PathError> {
-        assert!(self.current_working_dir.ends_with('/'));
-        let path = path.as_rust_str()?;
-        if path.starts_with('/') {
-            // Absolute path
-            Ok(path.normalized()?)
-        } else {
-            // Relative path
-            Ok((self.current_working_dir.clone() + path.as_rust_str()?).normalized()?)
+            resolver: super::resolver::Resolver::new(
+                litebox,
+                TarRo::new(tar_data, InodeAllocator::standalone()),
+            ),
         }
     }
 }
@@ -399,9 +381,11 @@ enum IndexedChild {
 struct TarIndex {
     tar_data: alloc::borrow::Cow<'static, [u8]>,
     files: Vec<IndexedFile>,
-    files_by_path: HashMap<String, usize>,
     dirs: Vec<IndexedDir>,
-    dirs_by_path: HashMap<String, usize>,
+    #[expect(
+        dead_code,
+        reason = "jayb: will be used soon before PR is made, DO NOT COMMIT"
+    )]
     inode_allocator: InodeAllocator,
 }
 
@@ -490,9 +474,7 @@ impl TarIndex {
         Self {
             tar_data,
             files,
-            files_by_path,
             dirs,
-            dirs_by_path,
             inode_allocator,
         }
     }
@@ -500,16 +482,6 @@ impl TarIndex {
     fn file_data(&self, file_idx: usize) -> &[u8] {
         let range = self.files[file_idx].data_range.clone();
         &self.tar_data[range]
-    }
-
-    fn file_by_path(&self, path: &str) -> Option<(usize, &IndexedFile)> {
-        let file_idx = *self.files_by_path.get(path)?;
-        Some((file_idx, &self.files[file_idx]))
-    }
-
-    fn dir_by_path(&self, path: &str) -> Option<(usize, &IndexedDir)> {
-        let dir_idx = *self.dirs_by_path.get(path)?;
-        Some((dir_idx, &self.dirs[dir_idx]))
     }
 }
 
@@ -527,117 +499,52 @@ impl<Platform: sync::RawSyncPrimitivesProvider> super::FileSystem for FileSystem
         &self,
         path: impl crate::path::Arg,
         flags: OFlags,
-        _mode: Mode,
+        mode: Mode,
     ) -> Result<FileFd<Platform>, OpenError> {
-        use super::OFlags;
-        let currently_supported_oflags: OFlags = OFlags::RDONLY
-            | OFlags::WRONLY
-            | OFlags::RDWR
-            | OFlags::CREAT
-            | OFlags::EXCL
-            | OFlags::TRUNC
-            | OFlags::NOCTTY
-            | OFlags::DIRECTORY
-            | OFlags::NONBLOCK
-            | OFlags::LARGEFILE
-            | OFlags::NOFOLLOW
-            | OFlags::APPEND;
-        if flags.intersects(currently_supported_oflags.complement()) {
-            unimplemented!("{flags:?}")
-        }
-        if flags.contains(OFlags::CREAT) {
-            return Err(OpenError::ReadOnlyFileSystem);
-        }
-        let path = self.absolute_path(path)?;
-        if path.is_empty() {
-            // We are at the root directory, we should just return early.
-            let (idx, _) = self
-                .tar_index
-                .dir_by_path("")
-                .expect("root directory always exists");
-            return Ok(self
-                .litebox
-                .descriptor_table_mut()
-                .insert(Descriptor::Dir { idx }));
-        }
-        assert!(path.starts_with('/'));
-        let path = &path[1..];
-        if flags.contains(OFlags::RDWR) || flags.contains(OFlags::WRONLY) {
-            return Err(OpenError::ReadOnlyFileSystem);
-        }
-        assert!(flags.contains(OFlags::RDONLY));
-        let fd = if let Some((idx, _)) = self.tar_index.file_by_path(path) {
-            if flags.contains(OFlags::DIRECTORY) {
-                return Err(OpenError::PathError(PathError::ComponentNotADirectory));
-            }
-            self.litebox
-                .descriptor_table_mut()
-                .insert(Descriptor::File { idx, position: 0 })
-        } else if let Some((idx, _)) = self.tar_index.dir_by_path(path) {
-            self.litebox
-                .descriptor_table_mut()
-                .insert(Descriptor::Dir { idx })
-        } else {
-            return Err(PathError::NoSuchFileOrDirectory)?;
-        };
-        if flags.contains(OFlags::TRUNC) {
-            match self.truncate(&fd, 0, true) {
-                Ok(()) => {}
-                Err(e) => {
-                    self.close(&fd).unwrap();
-                    return Err(e.into());
-                }
-            }
-        }
-        Ok(fd)
+        let fd = super::FileSystem::open(&self.resolver, path, flags, mode)?;
+        Ok(self
+            .litebox
+            .descriptor_table_mut()
+            .insert(Descriptor { fd }))
     }
 
     fn close(&self, fd: &FileFd<Platform>) -> Result<(), CloseError> {
-        self.litebox.descriptor_table_mut().remove(fd);
-        Ok(())
+        let Some(descriptor) = self.litebox.descriptor_table_mut().remove(fd) else {
+            return Ok(());
+        };
+        super::FileSystem::close(&self.resolver, &descriptor.entry.fd)
     }
 
     fn read(
         &self,
         fd: &FileFd<Platform>,
         buf: &mut [u8],
-        mut offset: Option<usize>,
+        offset: Option<usize>,
     ) -> Result<usize, ReadError> {
-        let descriptor_table = self.litebox.descriptor_table();
-        let Descriptor::File { idx, position } = &mut descriptor_table
-            .get_entry_mut(fd)
-            .ok_or(ReadError::ClosedFd)?
-            .entry
-        else {
-            return Err(ReadError::NotAFile);
-        };
-        let position = offset.as_mut().unwrap_or(position);
-        let file = self.tar_index.file_data(*idx);
-        let start = (*position).min(file.len());
-        let end = position.checked_add(buf.len()).unwrap().min(file.len());
-        debug_assert!(start <= end);
-        let retlen = end - start;
-        buf[..retlen].copy_from_slice(&file[start..end]);
-        *position = end;
-        Ok(retlen)
+        let descriptor = self
+            .litebox
+            .descriptor_table()
+            .entry_handle(fd)
+            .ok_or(ReadError::ClosedFd)?;
+        descriptor.with_entry(|descriptor| {
+            super::FileSystem::read(&self.resolver, &descriptor.entry.fd, buf, offset)
+        })
     }
 
     fn write(
         &self,
         fd: &FileFd<Platform>,
-        _buf: &[u8],
-        _offset: Option<usize>,
+        buf: &[u8],
+        offset: Option<usize>,
     ) -> Result<usize, WriteError> {
-        match self
+        let descriptor = self
             .litebox
             .descriptor_table()
-            .get_entry(fd)
-            .ok_or(WriteError::ClosedFd)?
-            .entry
-        {
-            Descriptor::File { .. } => Err(WriteError::NotForWriting),
-            Descriptor::Dir { .. } => Err(WriteError::NotAFile),
-        }
+            .entry_handle(fd)
+            .ok_or(WriteError::ClosedFd)?;
+        descriptor.with_entry(|descriptor| {
+            super::FileSystem::write(&self.resolver, &descriptor.entry.fd, buf, offset)
+        })
     }
 
     fn seek(
@@ -646,243 +553,94 @@ impl<Platform: sync::RawSyncPrimitivesProvider> super::FileSystem for FileSystem
         offset: isize,
         whence: SeekWhence,
     ) -> Result<usize, SeekError> {
-        let descriptor_table = self.litebox.descriptor_table();
-        let Descriptor::File { idx, position } = &mut descriptor_table
-            .get_entry_mut(fd)
-            .ok_or(SeekError::ClosedFd)?
-            .entry
-        else {
-            return Err(SeekError::NotAFile);
-        };
-        let file_len = self.tar_index.files[*idx].data_range.len();
-        let base = match whence {
-            SeekWhence::RelativeToBeginning => 0,
-            SeekWhence::RelativeToCurrentOffset => *position,
-            SeekWhence::RelativeToEnd => file_len,
-        };
-        let new_posn = base
-            .checked_add_signed(offset)
-            .ok_or(SeekError::InvalidOffset)?;
-        if new_posn > file_len {
-            Err(SeekError::InvalidOffset)
-        } else {
-            *position = new_posn;
-            Ok(new_posn)
-        }
+        let descriptor = self
+            .litebox
+            .descriptor_table()
+            .entry_handle(fd)
+            .ok_or(SeekError::ClosedFd)?;
+        descriptor.with_entry(|descriptor| {
+            super::FileSystem::seek(&self.resolver, &descriptor.entry.fd, offset, whence)
+        })
     }
 
     fn truncate(
         &self,
         fd: &FileFd<Platform>,
-        _length: usize,
-        _reset_offset: bool,
+        length: usize,
+        reset_offset: bool,
     ) -> Result<(), TruncateError> {
-        match self
+        let descriptor = self
             .litebox
             .descriptor_table()
-            .get_entry(fd)
-            .ok_or(TruncateError::ClosedFd)?
-            .entry
-        {
-            Descriptor::File { .. } => Err(TruncateError::NotForWriting),
-            Descriptor::Dir { .. } => Err(TruncateError::IsDirectory),
-        }
+            .entry_handle(fd)
+            .ok_or(TruncateError::ClosedFd)?;
+        descriptor.with_entry(|descriptor| {
+            super::FileSystem::truncate(&self.resolver, &descriptor.entry.fd, length, reset_offset)
+        })
     }
 
-    fn chmod(&self, path: impl crate::path::Arg, _mode: Mode) -> Result<(), ChmodError> {
-        let path = self.absolute_path(path)?;
-        assert!(path.starts_with('/'));
-        let path = &path[1..];
-        if self.tar_index.file_by_path(path).is_some() || self.tar_index.dir_by_path(path).is_some()
-        {
-            Err(ChmodError::ReadOnlyFileSystem)
-        } else {
-            Err(PathError::NoSuchFileOrDirectory)?
-        }
+    fn chmod(&self, path: impl crate::path::Arg, mode: Mode) -> Result<(), ChmodError> {
+        super::FileSystem::chmod(&self.resolver, path, mode)
     }
 
     fn chown(
         &self,
         path: impl crate::path::Arg,
-        _user: Option<u16>,
-        _group: Option<u16>,
+        user: Option<u16>,
+        group: Option<u16>,
     ) -> Result<(), ChownError> {
-        let path = self.absolute_path(path)?;
-        assert!(path.starts_with('/'));
-        let path = &path[1..];
-        if self.tar_index.file_by_path(path).is_some() || self.tar_index.dir_by_path(path).is_some()
-        {
-            Err(ChownError::ReadOnlyFileSystem)
-        } else {
-            Err(PathError::NoSuchFileOrDirectory)?
-        }
+        super::FileSystem::chown(&self.resolver, path, user, group)
     }
 
     fn unlink(&self, path: impl crate::path::Arg) -> Result<(), UnlinkError> {
-        let path = self.absolute_path(path)?;
-        assert!(path.starts_with('/'));
-        let path = &path[1..];
-        if self.tar_index.file_by_path(path).is_some() {
-            Err(UnlinkError::ReadOnlyFileSystem)
-        } else if self.tar_index.dir_by_path(path).is_some() {
-            Err(UnlinkError::IsADirectory)
-        } else {
-            Err(PathError::NoSuchFileOrDirectory)?
-        }
+        super::FileSystem::unlink(&self.resolver, path)
     }
 
-    fn mkdir(&self, _path: impl crate::path::Arg, _mode: Mode) -> Result<(), MkdirError> {
-        // TODO: Do we need to do the type of checks that are happening in the other functions, or
-        // should the other functions be simplified to this?
-        Err(MkdirError::ReadOnlyFileSystem)
+    fn mkdir(&self, path: impl crate::path::Arg, mode: Mode) -> Result<(), MkdirError> {
+        super::FileSystem::mkdir(&self.resolver, path, mode)
     }
 
-    fn rmdir(&self, _path: impl crate::path::Arg) -> Result<(), RmdirError> {
-        // TODO: Do we need to do the type of checks that are happening in the other functions, or
-        // should the other functions be simplified to this?
-        Err(RmdirError::ReadOnlyFileSystem)
+    fn rmdir(&self, path: impl crate::path::Arg) -> Result<(), RmdirError> {
+        super::FileSystem::rmdir(&self.resolver, path)
     }
 
     fn read_dir(&self, fd: &FileFd<Platform>) -> Result<Vec<DirEntry>, ReadDirError> {
-        let descriptor_table = self.litebox.descriptor_table();
-        let Descriptor::Dir { idx } = &descriptor_table
-            .get_entry(fd)
-            .ok_or(ReadDirError::ClosedFd)?
-            .entry
-        else {
-            return Err(ReadDirError::NotADirectory);
-        };
-        let dir = &self.tar_index.dirs[*idx];
-
-        // Add "." and ".." entries first.
-        // In this read-only tar FS we don't maintain distinct inode numbers per-dir,
-        // so use the same directory inode constant for directories (including root).
-        let mut out: Vec<DirEntry> = Vec::new();
-
-        out.push(DirEntry {
-            name: ".".into(),
-            file_type: FileType::Directory,
-            ino_info: Some(NodeInfo {
-                dev: DEVICE_ID,
-                ino: TEMPORARY_DEFAULT_CONSTANT_INODE_NUMBER,
-                rdev: None,
-            }),
-        });
-
-        out.push(DirEntry {
-            name: "..".into(),
-            file_type: FileType::Directory,
-            ino_info: Some(NodeInfo {
-                dev: DEVICE_ID,
-                ino: TEMPORARY_DEFAULT_CONSTANT_INODE_NUMBER,
-                rdev: None,
-            }),
-        });
-
-        out.extend(dir.children.iter().map(|(name, child)| {
-            let (file_type, ino) = match *child {
-                IndexedChild::File(idx) => (FileType::RegularFile, self.tar_index.files[idx].ino),
-                IndexedChild::Dir(_) => {
-                    (FileType::Directory, TEMPORARY_DEFAULT_CONSTANT_INODE_NUMBER)
-                }
-            };
-            DirEntry {
-                name: name.clone(),
-                file_type,
-                ino_info: Some(NodeInfo {
-                    dev: DEVICE_ID,
-                    ino,
-                    rdev: None,
-                }),
-            }
-        }));
-        Ok(out)
+        let descriptor = self
+            .litebox
+            .descriptor_table()
+            .entry_handle(fd)
+            .ok_or(ReadDirError::ClosedFd)?;
+        descriptor.with_entry(|descriptor| {
+            super::FileSystem::read_dir(&self.resolver, &descriptor.entry.fd)
+        })
     }
 
     fn file_status(
         &self,
         path: impl crate::path::Arg,
     ) -> Result<super::FileStatus, super::errors::FileStatusError> {
-        let path = self.absolute_path(path)?;
-        let path = if path.is_empty() {
-            ""
-        } else {
-            assert!(path.starts_with('/'));
-            &path[1..]
-        };
-        if let Some((_, file)) = self.tar_index.file_by_path(path) {
-            Ok(super::FileStatus {
-                file_type: super::FileType::RegularFile,
-                mode: file.mode,
-                size: file.data_range.len(),
-                owner: file.owner,
-                node_info: NodeInfo {
-                    dev: DEVICE_ID,
-                    ino: file.ino,
-                    rdev: None,
-                },
-                blksize: BLOCK_SIZE,
-            })
-        } else if let Some((_, dir)) = self.tar_index.dir_by_path(path) {
-            Ok(super::FileStatus {
-                file_type: super::FileType::Directory,
-                mode: DEFAULT_DIR_MODE,
-                size: super::DEFAULT_DIRECTORY_SIZE,
-                owner: dir.owner.unwrap_or(DEFAULT_DIRECTORY_OWNER),
-                node_info: NodeInfo {
-                    dev: DEVICE_ID,
-                    ino: TEMPORARY_DEFAULT_CONSTANT_INODE_NUMBER,
-                    rdev: None,
-                },
-                blksize: BLOCK_SIZE,
-            })
-        } else {
-            Err(PathError::NoSuchFileOrDirectory)?
-        }
+        super::FileSystem::file_status(&self.resolver, path)
     }
 
     fn fd_file_status(
         &self,
         fd: &FileFd<Platform>,
     ) -> Result<super::FileStatus, super::errors::FileStatusError> {
-        match &self
+        let descriptor = self
             .litebox
             .descriptor_table()
-            .get_entry(fd)
-            .ok_or(super::errors::FileStatusError::ClosedFd)?
-            .entry
-        {
-            Descriptor::File { idx, .. } => {
-                let file = &self.tar_index.files[*idx];
-                Ok(super::FileStatus {
-                    file_type: super::FileType::RegularFile,
-                    mode: file.mode,
-                    size: file.data_range.len(),
-                    owner: file.owner,
-                    node_info: NodeInfo {
-                        dev: DEVICE_ID,
-                        ino: file.ino,
-                        rdev: None,
-                    },
-                    blksize: BLOCK_SIZE,
-                })
-            }
-            Descriptor::Dir { idx } => {
-                let dir = &self.tar_index.dirs[*idx];
-                Ok(super::FileStatus {
-                    file_type: super::FileType::Directory,
-                    mode: DEFAULT_DIR_MODE,
-                    size: super::DEFAULT_DIRECTORY_SIZE,
-                    owner: dir.owner.unwrap_or(DEFAULT_DIRECTORY_OWNER),
-                    node_info: NodeInfo {
-                        dev: DEVICE_ID,
-                        ino: TEMPORARY_DEFAULT_CONSTANT_INODE_NUMBER,
-                        rdev: None,
-                    },
-                    blksize: BLOCK_SIZE,
-                })
-            }
-        }
+            .entry_handle(fd)
+            .ok_or(super::errors::FileStatusError::ClosedFd)?;
+        descriptor.with_entry(|descriptor| {
+            super::FileSystem::fd_file_status(&self.resolver, &descriptor.entry.fd)
+        })
+    }
+
+    fn get_static_backing_data(&self, fd: &FileFd<Platform>) -> Option<&'static [u8]> {
+        let descriptor = self.litebox.descriptor_table().entry_handle(fd)?;
+        descriptor.with_entry(|descriptor| {
+            super::FileSystem::get_static_backing_data(&self.resolver, &descriptor.entry.fd)
+        })
     }
 }
 
@@ -916,14 +674,15 @@ fn owner_from_posix_header(posix_header: &tar_no_std::PosixHeader) -> UserInfo {
     }
 }
 
-enum Descriptor {
-    File { idx: usize, position: usize },
-    Dir { idx: usize },
+// TODO(jayb): migrate away from these as soon as the wrapper is cleaned up
+struct Descriptor<Platform: sync::RawSyncPrimitivesProvider> {
+    fd: super::resolver::ResolverFd<Platform, TarRo>,
 }
 
 crate::fd::enable_fds_for_subsystem! {
     @ Platform: { sync::RawSyncPrimitivesProvider };
     FileSystem<Platform>;
-    Descriptor;
+    @ Platform: { sync::RawSyncPrimitivesProvider };
+    Descriptor<Platform>;
     -> FileFd<Platform>;
 }

--- a/litebox/src/fs/tar_ro.rs
+++ b/litebox/src/fs/tar_ro.rs
@@ -29,18 +29,14 @@ use alloc::vec::Vec;
 use core::ops::Range;
 use hashbrown::HashMap;
 
-use crate::{
-    LiteBox,
-    fs::{DirEntry, FileType},
-    sync,
-};
+use crate::fs::{DirEntry, FileType};
 
 use super::{
-    Mode, NodeInfo, OFlags, SeekWhence, UserInfo,
+    Mode, NodeInfo, OFlags, UserInfo,
     backend::{DirHandle, FileHandle, WalkingDirHandle},
     errors::{
-        ChmodError, ChownError, CloseError, MkdirError, OpenError, PathError, ReadDirError,
-        ReadError, RmdirError, SeekError, TruncateError, UnlinkError, WalkError, WriteError,
+        ChmodError, ChownError, MkdirError, OpenError, PathError, ReadDirError, ReadError,
+        RmdirError, TruncateError, UnlinkError, WalkError, WriteError,
     },
     inode_allocator::InodeAllocator,
 };
@@ -308,38 +304,8 @@ impl super::backend::Backend for TarRo {
     }
 }
 
-/// A backing implementation for [`FileSystem`](super::FileSystem), storing all files in-memory, via
-/// a read-only `.tar` file.
-pub struct FileSystem<Platform: sync::RawSyncPrimitivesProvider> {
-    litebox: LiteBox<Platform>,
-    resolver: super::resolver::Resolver<Platform, TarRo>,
-}
-
 /// An empty tar file to support an empty file system.
 pub const EMPTY_TAR_FILE: &[u8] = &[0u8; 10240];
-
-impl<Platform: sync::RawSyncPrimitivesProvider> FileSystem<Platform> {
-    /// Construct a new `FileSystem` instance from provided `tar_data`.
-    ///
-    /// The filesystem stores the provided bytes and builds an index up-front for O(1) lookups.
-    /// Using `Cow` avoids an unnecessary copy while allowing either borrowed or owned input.
-    ///
-    /// Use [`EMPTY_TAR_FILE`] if you need an empty file system.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the provided `tar_data` is found to be an invalid `.tar` file.
-    #[must_use]
-    pub fn new(litebox: &LiteBox<Platform>, tar_data: alloc::borrow::Cow<'static, [u8]>) -> Self {
-        Self {
-            litebox: litebox.clone(),
-            resolver: super::resolver::Resolver::new(
-                litebox,
-                TarRo::new(tar_data, InodeAllocator::standalone()),
-            ),
-        }
-    }
-}
 
 struct IndexedFile {
     data_range: Range<usize>,
@@ -462,163 +428,11 @@ impl TarIndex {
     }
 }
 
-impl<Platform: sync::RawSyncPrimitivesProvider> super::private::Sealed for FileSystem<Platform> {}
-
 /// Strip the `./` prefix from tar filenames if present.
 ///
 /// This is helpful for tar files that have been created via `tar cvf foo.tar .`
 fn normalize_tar_filename(filename: &str) -> &str {
     filename.strip_prefix("./").unwrap_or(filename)
-}
-
-impl<Platform: sync::RawSyncPrimitivesProvider> super::FileSystem for FileSystem<Platform> {
-    fn open(
-        &self,
-        path: impl crate::path::Arg,
-        flags: OFlags,
-        mode: Mode,
-    ) -> Result<FileFd<Platform>, OpenError> {
-        let fd = super::FileSystem::open(&self.resolver, path, flags, mode)?;
-        Ok(self
-            .litebox
-            .descriptor_table_mut()
-            .insert(Descriptor { fd }))
-    }
-
-    fn close(&self, fd: &FileFd<Platform>) -> Result<(), CloseError> {
-        let Some(descriptor) = self.litebox.descriptor_table_mut().remove(fd) else {
-            return Ok(());
-        };
-        super::FileSystem::close(&self.resolver, &descriptor.entry.fd)
-    }
-
-    fn read(
-        &self,
-        fd: &FileFd<Platform>,
-        buf: &mut [u8],
-        offset: Option<usize>,
-    ) -> Result<usize, ReadError> {
-        let descriptor = self
-            .litebox
-            .descriptor_table()
-            .entry_handle(fd)
-            .ok_or(ReadError::ClosedFd)?;
-        descriptor.with_entry(|descriptor| {
-            super::FileSystem::read(&self.resolver, &descriptor.entry.fd, buf, offset)
-        })
-    }
-
-    fn write(
-        &self,
-        fd: &FileFd<Platform>,
-        buf: &[u8],
-        offset: Option<usize>,
-    ) -> Result<usize, WriteError> {
-        let descriptor = self
-            .litebox
-            .descriptor_table()
-            .entry_handle(fd)
-            .ok_or(WriteError::ClosedFd)?;
-        descriptor.with_entry(|descriptor| {
-            super::FileSystem::write(&self.resolver, &descriptor.entry.fd, buf, offset)
-        })
-    }
-
-    fn seek(
-        &self,
-        fd: &FileFd<Platform>,
-        offset: isize,
-        whence: SeekWhence,
-    ) -> Result<usize, SeekError> {
-        let descriptor = self
-            .litebox
-            .descriptor_table()
-            .entry_handle(fd)
-            .ok_or(SeekError::ClosedFd)?;
-        descriptor.with_entry(|descriptor| {
-            super::FileSystem::seek(&self.resolver, &descriptor.entry.fd, offset, whence)
-        })
-    }
-
-    fn truncate(
-        &self,
-        fd: &FileFd<Platform>,
-        length: usize,
-        reset_offset: bool,
-    ) -> Result<(), TruncateError> {
-        let descriptor = self
-            .litebox
-            .descriptor_table()
-            .entry_handle(fd)
-            .ok_or(TruncateError::ClosedFd)?;
-        descriptor.with_entry(|descriptor| {
-            super::FileSystem::truncate(&self.resolver, &descriptor.entry.fd, length, reset_offset)
-        })
-    }
-
-    fn chmod(&self, path: impl crate::path::Arg, mode: Mode) -> Result<(), ChmodError> {
-        super::FileSystem::chmod(&self.resolver, path, mode)
-    }
-
-    fn chown(
-        &self,
-        path: impl crate::path::Arg,
-        user: Option<u16>,
-        group: Option<u16>,
-    ) -> Result<(), ChownError> {
-        super::FileSystem::chown(&self.resolver, path, user, group)
-    }
-
-    fn unlink(&self, path: impl crate::path::Arg) -> Result<(), UnlinkError> {
-        super::FileSystem::unlink(&self.resolver, path)
-    }
-
-    fn mkdir(&self, path: impl crate::path::Arg, mode: Mode) -> Result<(), MkdirError> {
-        super::FileSystem::mkdir(&self.resolver, path, mode)
-    }
-
-    fn rmdir(&self, path: impl crate::path::Arg) -> Result<(), RmdirError> {
-        super::FileSystem::rmdir(&self.resolver, path)
-    }
-
-    fn read_dir(&self, fd: &FileFd<Platform>) -> Result<Vec<DirEntry>, ReadDirError> {
-        let descriptor = self
-            .litebox
-            .descriptor_table()
-            .entry_handle(fd)
-            .ok_or(ReadDirError::ClosedFd)?;
-        descriptor.with_entry(|descriptor| {
-            super::FileSystem::read_dir(&self.resolver, &descriptor.entry.fd)
-        })
-    }
-
-    fn file_status(
-        &self,
-        path: impl crate::path::Arg,
-    ) -> Result<super::FileStatus, super::errors::FileStatusError> {
-        super::FileSystem::file_status(&self.resolver, path)
-    }
-
-    fn fd_file_status(
-        &self,
-        fd: &FileFd<Platform>,
-    ) -> Result<super::FileStatus, super::errors::FileStatusError> {
-        let descriptor = self
-            .litebox
-            .descriptor_table()
-            .entry_handle(fd)
-            .ok_or(super::errors::FileStatusError::ClosedFd)?;
-        descriptor.with_entry(|descriptor| {
-            super::FileSystem::fd_file_status(&self.resolver, &descriptor.entry.fd)
-        })
-    }
-
-    fn get_static_backing_data(&self, fd: &FileFd<Platform>) -> Option<&'static [u8]> {
-        let descriptor = self.litebox.descriptor_table().entry_handle(fd)?;
-        descriptor.with_entry(|descriptor| {
-            super::FileSystem::get_static_backing_data(&self.resolver, &descriptor.entry.fd)
-        })
-    }
 }
 
 const DEFAULT_DIR_MODE: Mode =
@@ -649,17 +463,4 @@ fn owner_from_posix_header(posix_header: &tar_no_std::PosixHeader) -> UserInfo {
         user: posix_header.uid.as_number().unwrap(),
         group: posix_header.gid.as_number().unwrap(),
     }
-}
-
-// TODO(jayb): migrate away from these as soon as the wrapper is cleaned up
-struct Descriptor<Platform: sync::RawSyncPrimitivesProvider> {
-    fd: super::resolver::ResolverFd<Platform, TarRo>,
-}
-
-crate::fd::enable_fds_for_subsystem! {
-    @ Platform: { sync::RawSyncPrimitivesProvider };
-    FileSystem<Platform>;
-    @ Platform: { sync::RawSyncPrimitivesProvider };
-    Descriptor<Platform>;
-    -> FileFd<Platform>;
 }

--- a/litebox/src/fs/tar_ro.rs
+++ b/litebox/src/fs/tar_ro.rs
@@ -124,8 +124,15 @@ impl super::backend::Backend for TarRo {
         })
     }
 
-    fn owned_dir_at(&self, dir: WalkingDirHandle<'_>) -> DirHandle {
-        DirHandle::from_typed::<Self>(dir.into_typed::<Self>())
+    fn owned_dir_at(
+        &self,
+        dir: WalkingDirHandle<'_>,
+        flags: OFlags,
+    ) -> Result<DirHandle, OpenError> {
+        if flags.intersects(OFlags::CREAT | OFlags::TRUNC | OFlags::WRONLY | OFlags::RDWR) {
+            return Err(OpenError::ReadOnlyFileSystem);
+        }
+        Ok(DirHandle::from_typed::<Self>(dir.into_typed::<Self>()))
     }
 
     fn walking_dir_at<'a>(&'a self, dir: &DirHandle) -> Option<WalkingDirHandle<'a>> {

--- a/litebox/src/fs/tar_ro.rs
+++ b/litebox/src/fs/tar_ro.rs
@@ -38,10 +38,12 @@ use crate::{
 
 use super::{
     Mode, NodeInfo, OFlags, SeekWhence, UserInfo,
+    backend::{DirHandle, FileHandle, WalkingDirHandle},
     errors::{
         ChmodError, ChownError, CloseError, MkdirError, OpenError, PathError, ReadDirError,
-        ReadError, RmdirError, SeekError, TruncateError, UnlinkError, WriteError,
+        ReadError, RmdirError, SeekError, TruncateError, UnlinkError, WalkError, WriteError,
     },
+    inode_allocator::InodeAllocator,
 };
 
 /// Just a random constant that is distinct from other file systems. In this case, it is
@@ -56,6 +58,275 @@ const TEMPORARY_DEFAULT_CONSTANT_INODE_NUMBER: usize = 0xFACE;
 /// Block size for file system I/O operations
 // TODO(jayb): Determine appropriate block size
 const BLOCK_SIZE: usize = 0;
+
+/// A [`super::backend::Backend`] that stores all files in-memory, via a read-only `.tar` file.
+pub struct TarRo {
+    tar_index: TarIndex,
+}
+
+impl TarRo {
+    /// Construct a tar backend using a caller-provided inode allocator.
+    #[must_use]
+    pub fn new(
+        tar_data: alloc::borrow::Cow<'static, [u8]>,
+        inode_allocator: InodeAllocator,
+    ) -> Self {
+        Self {
+            tar_index: TarIndex::new(tar_data, inode_allocator),
+        }
+    }
+}
+
+impl super::backend::private::Sealed for TarRo {}
+
+/// Directory handle
+#[derive(Clone)]
+pub struct TarRoDirHandle {
+    idx: usize,
+}
+/// File handle
+#[derive(Clone)]
+pub struct TarRoFileHandle {
+    idx: usize,
+}
+impl super::backend::BackendHandles for TarRo {
+    type WalkingDirHandle<'a> = TarRoDirHandle;
+    type FileHandle = TarRoFileHandle;
+    type DirHandle = TarRoDirHandle;
+}
+
+impl super::backend::Backend for TarRo {
+    fn root(&self) -> WalkingDirHandle<'_> {
+        WalkingDirHandle::from_typed::<Self>(TarRoDirHandle { idx: 0 })
+    }
+
+    fn walk_directories<'a>(
+        &'a self,
+        from: WalkingDirHandle<'a>,
+        components: &[&str],
+    ) -> Result<super::backend::WalkOutcome<WalkingDirHandle<'a>>, WalkError> {
+        let mut current = from.into_typed::<Self>();
+        let mut walked_components = Vec::with_capacity(components.len());
+        for component in components {
+            let child = self.tar_index.dirs[current.idx]
+                .children
+                .get(*component)
+                .ok_or(WalkError::PathError(PathError::NoSuchFileOrDirectory))?;
+            let IndexedChild::Dir(child_idx) = *child else {
+                return Ok(super::backend::WalkOutcome {
+                    components: walked_components,
+                    last: WalkingDirHandle::from_typed::<Self>(current),
+                    stop_reason: super::backend::WalkStopReason::StoppedAtNonDirectory,
+                });
+            };
+
+            let child = &self.tar_index.dirs[child_idx];
+            walked_components.push(super::backend::WalkedComponent {
+                permissions: super::backend::PermissionCheck::ByResolver(
+                    super::backend::PermissionInfo {
+                        mode: DEFAULT_DIR_MODE,
+                        owner: child.owner.unwrap_or(DEFAULT_DIRECTORY_OWNER),
+                    },
+                ),
+            });
+            current = TarRoDirHandle { idx: child_idx };
+        }
+        Ok(super::backend::WalkOutcome {
+            components: walked_components,
+            last: WalkingDirHandle::from_typed::<Self>(current),
+            stop_reason: super::backend::WalkStopReason::CompleteDirectory,
+        })
+    }
+
+    fn owned_dir_at(&self, dir: WalkingDirHandle<'_>) -> DirHandle {
+        DirHandle::from_typed::<Self>(dir.into_typed::<Self>())
+    }
+
+    fn walking_dir_at<'a>(&'a self, dir: &DirHandle) -> Option<WalkingDirHandle<'a>> {
+        Some(WalkingDirHandle::from_typed::<Self>(
+            dir.get_typed::<Self>().clone(),
+        ))
+    }
+
+    fn open_file_at(
+        &self,
+        dir: WalkingDirHandle<'_>,
+        name: &str,
+        flags: OFlags,
+    ) -> Result<super::backend::Permissioned<FileHandle>, OpenError> {
+        let dir = dir.into_typed::<Self>();
+        let child = self.tar_index.dirs[dir.idx]
+            .children
+            .get(name)
+            .ok_or(OpenError::PathError(PathError::NoSuchFileOrDirectory))?;
+        let IndexedChild::File(file_idx) = *child else {
+            return Err(OpenError::PathError(PathError::ComponentNotADirectory));
+        };
+        if flags.contains(OFlags::DIRECTORY) {
+            return Err(OpenError::PathError(PathError::ComponentNotADirectory));
+        }
+        if !(flags.contains(OFlags::CREAT) && flags.contains(OFlags::EXCL))
+            && (flags.contains(OFlags::CREAT)
+                || flags.contains(OFlags::TRUNC)
+                || flags.contains(OFlags::WRONLY)
+                || flags.contains(OFlags::RDWR))
+        {
+            return Err(OpenError::ReadOnlyFileSystem);
+        }
+        let file = &self.tar_index.files[file_idx];
+        Ok(super::backend::Permissioned {
+            item: FileHandle::from_typed::<Self>(TarRoFileHandle { idx: file_idx }),
+            permissions: super::backend::PermissionCheck::ByResolver(
+                super::backend::PermissionInfo {
+                    mode: file.mode,
+                    owner: file.owner,
+                },
+            ),
+        })
+    }
+
+    fn list_dir_at(&self, handle: DirHandle) -> Result<Vec<DirEntry>, ReadDirError> {
+        let handle = handle.into_typed::<Self>();
+        Ok(self.tar_index.dirs[handle.idx]
+            .children
+            .iter()
+            .map(|(name, child)| {
+                let (file_type, ino) = match *child {
+                    IndexedChild::File(idx) => {
+                        (FileType::RegularFile, self.tar_index.files[idx].ino)
+                    }
+                    IndexedChild::Dir(_) => {
+                        (FileType::Directory, TEMPORARY_DEFAULT_CONSTANT_INODE_NUMBER)
+                    }
+                };
+                DirEntry {
+                    name: name.clone(),
+                    file_type,
+                    ino_info: Some(NodeInfo {
+                        dev: DEVICE_ID,
+                        ino,
+                        rdev: None,
+                    }),
+                }
+            })
+            .collect())
+    }
+
+    fn read(&self, h: &FileHandle, buf: &mut [u8], offset: usize) -> Result<usize, ReadError> {
+        let file = self.tar_index.file_data(h.get_typed::<Self>().idx);
+        let start = offset.min(file.len());
+        let end = offset.checked_add(buf.len()).unwrap().min(file.len());
+        debug_assert!(start <= end);
+        let len = end - start;
+        buf[..len].copy_from_slice(&file[start..end]);
+        Ok(len)
+    }
+
+    fn write(&self, _h: &FileHandle, _buf: &[u8], _offset: usize) -> Result<usize, WriteError> {
+        Err(WriteError::NotForWriting)
+    }
+
+    fn truncate(&self, _h: &FileHandle, _length: usize) -> Result<(), TruncateError> {
+        Err(TruncateError::NotForWriting)
+    }
+
+    fn seek_behavior(&self, _h: &FileHandle) -> super::backend::SeekBehavior {
+        super::backend::SeekBehavior::PositionBased
+    }
+
+    fn file_status(
+        &self,
+        h: &FileHandle,
+    ) -> Result<super::FileStatus, super::errors::FileStatusError> {
+        let file = &self.tar_index.files[h.get_typed::<Self>().idx];
+        Ok(super::FileStatus {
+            file_type: FileType::RegularFile,
+            mode: file.mode,
+            size: file.data_range.len(),
+            owner: file.owner,
+            node_info: NodeInfo {
+                dev: DEVICE_ID,
+                ino: file.ino,
+                rdev: None,
+            },
+            blksize: BLOCK_SIZE,
+        })
+    }
+
+    fn dir_status(
+        &self,
+        h: &DirHandle,
+    ) -> Result<super::FileStatus, super::errors::FileStatusError> {
+        let dir = &self.tar_index.dirs[h.get_typed::<Self>().idx];
+        Ok(super::FileStatus {
+            file_type: FileType::Directory,
+            mode: DEFAULT_DIR_MODE,
+            size: super::DEFAULT_DIRECTORY_SIZE,
+            owner: dir.owner.unwrap_or(DEFAULT_DIRECTORY_OWNER),
+            node_info: NodeInfo {
+                dev: DEVICE_ID,
+                ino: TEMPORARY_DEFAULT_CONSTANT_INODE_NUMBER,
+                rdev: None,
+            },
+            blksize: BLOCK_SIZE,
+        })
+    }
+
+    fn create_file_at(
+        &self,
+        _dir: DirHandle,
+        _name: &str,
+        _mode: Mode,
+    ) -> Result<FileHandle, OpenError> {
+        Err(OpenError::ReadOnlyFileSystem)
+    }
+
+    fn mkdir_at(&self, _dir: DirHandle, _name: &str, _mode: Mode) -> Result<DirHandle, MkdirError> {
+        Err(MkdirError::ReadOnlyFileSystem)
+    }
+
+    fn unlink_at(&self, dir: DirHandle, name: &str) -> Result<(), UnlinkError> {
+        let dir = dir.into_typed::<Self>();
+        match self.tar_index.dirs[dir.idx].children.get(name) {
+            Some(IndexedChild::Dir(_)) => Err(UnlinkError::IsADirectory),
+            Some(IndexedChild::File(_)) => Err(UnlinkError::ReadOnlyFileSystem),
+            None => Err(PathError::NoSuchFileOrDirectory.into()),
+        }
+    }
+
+    fn rmdir_at(&self, dir: DirHandle, name: &str) -> Result<(), RmdirError> {
+        let dir = dir.into_typed::<Self>();
+        match self.tar_index.dirs[dir.idx].children.get(name) {
+            Some(IndexedChild::Dir(_)) => Err(RmdirError::ReadOnlyFileSystem),
+            Some(IndexedChild::File(_)) => Err(RmdirError::NotADirectory),
+            None => Err(PathError::NoSuchFileOrDirectory.into()),
+        }
+    }
+
+    fn chmod_at(&self, dir: DirHandle, name: &str, _mode: Mode) -> Result<(), ChmodError> {
+        let dir = dir.into_typed::<Self>();
+        if self.tar_index.dirs[dir.idx].children.contains_key(name) {
+            Err(ChmodError::ReadOnlyFileSystem)
+        } else {
+            Err(PathError::NoSuchFileOrDirectory.into())
+        }
+    }
+
+    fn chown_at(
+        &self,
+        dir: DirHandle,
+        name: &str,
+        _user: Option<u16>,
+        _group: Option<u16>,
+    ) -> Result<(), ChownError> {
+        let dir = dir.into_typed::<Self>();
+        if self.tar_index.dirs[dir.idx].children.contains_key(name) {
+            Err(ChownError::ReadOnlyFileSystem)
+        } else {
+            Err(PathError::NoSuchFileOrDirectory.into())
+        }
+    }
+}
 
 /// A backing implementation for [`FileSystem`](super::FileSystem), storing all files in-memory, via
 /// a read-only `.tar` file.
@@ -82,9 +353,10 @@ impl<Platform: sync::RawSyncPrimitivesProvider> FileSystem<Platform> {
     /// Panics if the provided `tar_data` is found to be an invalid `.tar` file.
     #[must_use]
     pub fn new(litebox: &LiteBox<Platform>, tar_data: alloc::borrow::Cow<'static, [u8]>) -> Self {
+        // TODO DO NOT COMMIT migrate this over to just being a wrap around the backend
         Self {
             litebox: litebox.clone(),
-            tar_index: TarIndex::new(tar_data),
+            tar_index: TarIndex::new(tar_data, InodeAllocator::standalone()),
             current_working_dir: "/".into(),
         }
     }
@@ -115,7 +387,13 @@ struct IndexedFile {
 
 struct IndexedDir {
     owner: Option<UserInfo>,
-    children: HashMap<String, (FileType, usize)>,
+    children: HashMap<String, IndexedChild>,
+}
+
+#[derive(Clone, Copy)]
+enum IndexedChild {
+    File(usize),
+    Dir(usize),
 }
 
 struct TarIndex {
@@ -124,10 +402,11 @@ struct TarIndex {
     files_by_path: HashMap<String, usize>,
     dirs: Vec<IndexedDir>,
     dirs_by_path: HashMap<String, usize>,
+    inode_allocator: InodeAllocator,
 }
 
 impl TarIndex {
-    fn new(tar_data: alloc::borrow::Cow<'static, [u8]>) -> Self {
+    fn new(tar_data: alloc::borrow::Cow<'static, [u8]>, inode_allocator: InodeAllocator) -> Self {
         let archive = tar_no_std::TarArchiveRef::new(tar_data.as_ref()).expect("invalid tar data");
         let base_ptr = tar_data.as_ptr() as usize;
 
@@ -178,18 +457,12 @@ impl TarIndex {
             let mut parent_dir_idx = 0;
             for (component_idx, component) in components.iter().enumerate() {
                 let is_last_component = component_idx + 1 == components.len();
-                let (file_type, ino) = if is_last_component {
-                    (FileType::RegularFile, file.ino)
-                } else {
-                    (FileType::Directory, TEMPORARY_DEFAULT_CONSTANT_INODE_NUMBER)
-                };
-
                 dirs[parent_dir_idx].owner.get_or_insert(file.owner);
-                dirs[parent_dir_idx]
-                    .children
-                    .insert((*component).into(), (file_type, ino));
 
                 if is_last_component {
+                    dirs[parent_dir_idx]
+                        .children
+                        .insert((*component).into(), IndexedChild::File(file_idx));
                     break;
                 }
 
@@ -206,6 +479,9 @@ impl TarIndex {
                     });
                     dirs.len() - 1
                 });
+                dirs[parent_dir_idx]
+                    .children
+                    .insert((*component).into(), IndexedChild::Dir(child_dir_idx));
                 dirs[child_dir_idx].owner.get_or_insert(file.owner);
                 parent_dir_idx = child_dir_idx;
             }
@@ -217,6 +493,7 @@ impl TarIndex {
             files_by_path,
             dirs,
             dirs_by_path,
+            inode_allocator,
         }
     }
 
@@ -502,19 +779,23 @@ impl<Platform: sync::RawSyncPrimitivesProvider> super::FileSystem for FileSystem
             }),
         });
 
-        out.extend(
-            dir.children
-                .iter()
-                .map(|(name, (file_type, ino))| DirEntry {
-                    name: name.clone(),
-                    file_type: file_type.clone(),
-                    ino_info: Some(NodeInfo {
-                        dev: DEVICE_ID,
-                        ino: *ino,
-                        rdev: None,
-                    }),
+        out.extend(dir.children.iter().map(|(name, child)| {
+            let (file_type, ino) = match *child {
+                IndexedChild::File(idx) => (FileType::RegularFile, self.tar_index.files[idx].ino),
+                IndexedChild::Dir(_) => {
+                    (FileType::Directory, TEMPORARY_DEFAULT_CONSTANT_INODE_NUMBER)
+                }
+            };
+            DirEntry {
+                name: name.clone(),
+                file_type,
+                ino_info: Some(NodeInfo {
+                    dev: DEVICE_ID,
+                    ino,
+                    rdev: None,
                 }),
-        );
+            }
+        }));
         Ok(out)
     }
 

--- a/litebox/src/fs/tar_ro.rs
+++ b/litebox/src/fs/tar_ro.rs
@@ -45,15 +45,6 @@ use super::{
     inode_allocator::InodeAllocator,
 };
 
-/// Just a random constant that is distinct from other file systems. In this case, it is
-/// `b'Taro'.hex()`.
-const DEVICE_ID: usize = 0x5461726f;
-
-/// TODO(jayb): Replace this proper auto-incrementing inode number storage (although that will
-/// currently only applies to directories and can be revisited when/if something is actually
-/// checking for directory inodes.
-const TEMPORARY_DEFAULT_CONSTANT_INODE_NUMBER: usize = 0xFACE;
-
 /// Block size for file system I/O operations
 // TODO(jayb): Determine appropriate block size
 const BLOCK_SIZE: usize = 0;
@@ -190,22 +181,20 @@ impl super::backend::Backend for TarRo {
             .children
             .iter()
             .map(|(name, child)| {
-                let (file_type, ino) = match *child {
-                    IndexedChild::File(idx) => {
-                        (FileType::RegularFile, self.tar_index.files[idx].ino)
-                    }
-                    IndexedChild::Dir(_) => {
-                        (FileType::Directory, TEMPORARY_DEFAULT_CONSTANT_INODE_NUMBER)
-                    }
+                let (file_type, node_info) = match *child {
+                    IndexedChild::File(idx) => (
+                        FileType::RegularFile,
+                        self.tar_index.files[idx].node_info.clone(),
+                    ),
+                    IndexedChild::Dir(idx) => (
+                        FileType::Directory,
+                        self.tar_index.dirs[idx].node_info.clone(),
+                    ),
                 };
                 DirEntry {
                     name: name.clone(),
                     file_type,
-                    ino_info: Some(NodeInfo {
-                        dev: DEVICE_ID,
-                        ino,
-                        rdev: None,
-                    }),
+                    ino_info: Some(node_info),
                 }
             })
             .collect())
@@ -243,11 +232,7 @@ impl super::backend::Backend for TarRo {
             mode: file.mode,
             size: file.data_range.len(),
             owner: file.owner,
-            node_info: NodeInfo {
-                dev: DEVICE_ID,
-                ino: file.ino,
-                rdev: None,
-            },
+            node_info: file.node_info.clone(),
             blksize: BLOCK_SIZE,
         })
     }
@@ -262,11 +247,7 @@ impl super::backend::Backend for TarRo {
             mode: DEFAULT_DIR_MODE,
             size: super::DEFAULT_DIRECTORY_SIZE,
             owner: dir.owner.unwrap_or(DEFAULT_DIRECTORY_OWNER),
-            node_info: NodeInfo {
-                dev: DEVICE_ID,
-                ino: TEMPORARY_DEFAULT_CONSTANT_INODE_NUMBER,
-                rdev: None,
-            },
+            node_info: dir.node_info.clone(),
             blksize: BLOCK_SIZE,
         })
     }
@@ -364,11 +345,12 @@ struct IndexedFile {
     data_range: Range<usize>,
     mode: Mode,
     owner: UserInfo,
-    ino: usize,
+    node_info: NodeInfo,
 }
 
 struct IndexedDir {
     owner: Option<UserInfo>,
+    node_info: NodeInfo,
     children: HashMap<String, IndexedChild>,
 }
 
@@ -382,11 +364,6 @@ struct TarIndex {
     tar_data: alloc::borrow::Cow<'static, [u8]>,
     files: Vec<IndexedFile>,
     dirs: Vec<IndexedDir>,
-    #[expect(
-        dead_code,
-        reason = "jayb: will be used soon before PR is made, DO NOT COMMIT"
-    )]
-    inode_allocator: InodeAllocator,
 }
 
 impl TarIndex {
@@ -396,7 +373,7 @@ impl TarIndex {
 
         let mut files = Vec::new();
         let mut files_by_path: HashMap<String, usize> = HashMap::new();
-        for (idx, entry) in archive.entries().enumerate() {
+        for entry in archive.entries() {
             let filename = entry.filename();
             let Ok(path) = filename.as_str() else {
                 continue;
@@ -412,8 +389,7 @@ impl TarIndex {
                 data_range: start..end,
                 mode: mode_of_modeflags(entry.posix_header().mode.to_flags().unwrap()),
                 owner: owner_from_posix_header(entry.posix_header()),
-                // ino starts at 1 (zero represents deleted file)
-                ino: idx + 1,
+                node_info: inode_allocator.next(),
             };
 
             let file_idx = files.len();
@@ -427,6 +403,7 @@ impl TarIndex {
 
         let mut dirs = alloc::vec![IndexedDir {
             owner: None,
+            node_info: inode_allocator.next(),
             children: HashMap::new(),
         }];
         let mut dirs_by_path: HashMap<String, usize> = [(String::new(), 0)].into_iter().collect();
@@ -459,6 +436,7 @@ impl TarIndex {
                 let child_dir_idx = *dirs_by_path.entry(parent.clone()).or_insert_with(|| {
                     dirs.push(IndexedDir {
                         owner: Some(file.owner),
+                        node_info: inode_allocator.next(),
                         children: HashMap::new(),
                     });
                     dirs.len() - 1
@@ -475,7 +453,6 @@ impl TarIndex {
             tar_data,
             files,
             dirs,
-            inode_allocator,
         }
     }
 

--- a/litebox/src/fs/tests.rs
+++ b/litebox/src/fs/tests.rs
@@ -1029,7 +1029,12 @@ mod tar_ro {
                 "bar" | "." | ".." => assert_eq!(entry.file_type, crate::fs::FileType::Directory),
                 _ => panic!("Unexpected entry: {}", entry.name),
             }
-            assert!(entry.ino_info.is_some(), "Inode info should be present");
+            if entry.name != "." && entry.name != ".." {
+                assert!(entry.ino_info.is_some(), "Inode info should be present");
+            } else {
+                // TODO(jayb): Re-enable this assertion once Composer handles `.` and `..` inode
+                // information better.
+            }
         }
 
         // Read `bar` directory

--- a/litebox/src/fs/tests.rs
+++ b/litebox/src/fs/tests.rs
@@ -1014,6 +1014,19 @@ mod tar_ro {
     }
 
     #[test]
+    fn write_or_truncate_open_of_directory_fails() {
+        let litebox = LiteBox::new(MockPlatform::new());
+        let fs = super::tar_ro_fs(&litebox, TEST_TAR_FILE.into());
+
+        for flags in [OFlags::WRONLY, OFlags::RDWR, OFlags::TRUNC] {
+            assert!(matches!(
+                fs.open("bar", flags, Mode::empty()),
+                Err(crate::fs::errors::OpenError::ReadOnlyFileSystem)
+            ));
+        }
+    }
+
+    #[test]
     fn read_dir_subdirectory() {
         let litebox = LiteBox::new(MockPlatform::new());
         let fs = super::tar_ro_fs(&litebox, TEST_TAR_FILE.into());

--- a/litebox/src/fs/tests.rs
+++ b/litebox/src/fs/tests.rs
@@ -1,6 +1,19 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+fn tar_ro_fs(
+    litebox: &crate::LiteBox<crate::platform::mock::MockPlatform>,
+    tar_data: alloc::borrow::Cow<'static, [u8]>,
+) -> crate::fs::resolver::Resolver<crate::platform::mock::MockPlatform, crate::fs::tar_ro::TarRo> {
+    crate::fs::resolver::Resolver::new(
+        litebox,
+        crate::fs::tar_ro::TarRo::new(
+            tar_data,
+            crate::fs::inode_allocator::InodeAllocator::standalone(),
+        ),
+    )
+}
+
 mod in_mem {
     use crate::LiteBox;
     use crate::fs::in_mem;
@@ -912,7 +925,6 @@ mod in_mem {
 
 mod tar_ro {
     use crate::LiteBox;
-    use crate::fs::tar_ro;
     use crate::fs::{FileSystem as _, Mode, OFlags};
     use crate::platform::mock::MockPlatform;
     use alloc::vec;
@@ -924,7 +936,7 @@ mod tar_ro {
     #[test]
     fn file_read() {
         let litebox = LiteBox::new(MockPlatform::new());
-        let fs = tar_ro::FileSystem::new(&litebox, TEST_TAR_FILE.into());
+        let fs = super::tar_ro_fs(&litebox, TEST_TAR_FILE.into());
         let fd = fs
             .open("foo", OFlags::RDONLY, Mode::RWXU)
             .expect("Failed to open file");
@@ -948,7 +960,7 @@ mod tar_ro {
     #[test]
     fn dir_and_nonexist_checks() {
         let litebox = LiteBox::new(MockPlatform::new());
-        let fs = tar_ro::FileSystem::new(&litebox, TEST_TAR_FILE.into());
+        let fs = super::tar_ro_fs(&litebox, TEST_TAR_FILE.into());
         assert!(matches!(
             fs.open("bar/ba", OFlags::RDONLY, Mode::empty()),
             Err(crate::fs::errors::OpenError::PathError(
@@ -964,7 +976,7 @@ mod tar_ro {
     #[test]
     fn o_directory_flag_tests() {
         let litebox = LiteBox::new(MockPlatform::new());
-        let fs = tar_ro::FileSystem::new(&litebox, TEST_TAR_FILE.into());
+        let fs = super::tar_ro_fs(&litebox, TEST_TAR_FILE.into());
 
         // Test O_DIRECTORY on a directory (should succeed)
         let fd = fs
@@ -1004,7 +1016,7 @@ mod tar_ro {
     #[test]
     fn read_dir_subdirectory() {
         let litebox = LiteBox::new(MockPlatform::new());
-        let fs = tar_ro::FileSystem::new(&litebox, TEST_TAR_FILE.into());
+        let fs = super::tar_ro_fs(&litebox, TEST_TAR_FILE.into());
 
         // Read root directory
         let fd = fs
@@ -1053,7 +1065,7 @@ mod tar_ro {
     #[test]
     fn read_dir_file_not_directory() {
         let litebox = LiteBox::new(MockPlatform::new());
-        let fs = tar_ro::FileSystem::new(&litebox, TEST_TAR_FILE.into());
+        let fs = super::tar_ro_fs(&litebox, TEST_TAR_FILE.into());
 
         let fd = fs
             .open("foo", OFlags::RDONLY, Mode::empty())
@@ -1071,7 +1083,7 @@ mod tar_ro {
 mod layered {
     use crate::LiteBox;
     use crate::fs::{FileSystem as _, FileType, Mode, OFlags};
-    use crate::fs::{in_mem, layered, tar_ro};
+    use crate::fs::{in_mem, layered};
     use crate::platform::mock::MockPlatform;
     use alloc::vec;
     use alloc::vec::Vec;
@@ -1085,7 +1097,7 @@ mod layered {
         let fs = layered::FileSystem::new(
             &litebox,
             in_mem::FileSystem::new(&litebox),
-            tar_ro::FileSystem::new(&litebox, TEST_TAR_FILE.into()),
+            super::tar_ro_fs(&litebox, TEST_TAR_FILE.into()),
             layered::LayeringSemantics::LowerLayerReadOnly,
         );
         let fd = fs
@@ -1125,7 +1137,7 @@ mod layered {
         let fs = layered::FileSystem::new(
             &litebox,
             in_mem::FileSystem::new(&litebox),
-            tar_ro::FileSystem::new(&litebox, TEST_TAR_FILE.into()),
+            super::tar_ro_fs(&litebox, TEST_TAR_FILE.into()),
             layered::LayeringSemantics::LowerLayerReadOnly,
         );
         assert!(matches!(
@@ -1161,7 +1173,7 @@ mod layered {
         let fs = layered::FileSystem::new(
             &litebox,
             in_mem_fs,
-            tar_ro::FileSystem::new(&litebox, TEST_TAR_FILE.into()),
+            super::tar_ro_fs(&litebox, TEST_TAR_FILE.into()),
             layered::LayeringSemantics::LowerLayerReadOnly,
         );
         let fd1 = fs
@@ -1212,7 +1224,7 @@ mod layered {
         let fs = layered::FileSystem::new(
             &litebox,
             in_mem_fs,
-            tar_ro::FileSystem::new(&litebox, TEST_TAR_FILE.into()),
+            super::tar_ro_fs(&litebox, TEST_TAR_FILE.into()),
             layered::LayeringSemantics::LowerLayerReadOnly,
         );
         let fd1 = fs
@@ -1248,7 +1260,7 @@ mod layered {
         let fs = layered::FileSystem::new(
             &litebox,
             in_mem::FileSystem::new(&litebox),
-            tar_ro::FileSystem::new(&litebox, TEST_TAR_FILE.into()),
+            super::tar_ro_fs(&litebox, TEST_TAR_FILE.into()),
             layered::LayeringSemantics::LowerLayerReadOnly,
         );
         let fd = fs
@@ -1305,7 +1317,7 @@ mod layered {
         let fs = layered::FileSystem::new(
             &litebox,
             in_mem_fs,
-            tar_ro::FileSystem::new(&litebox, TEST_TAR_FILE.into()),
+            super::tar_ro_fs(&litebox, TEST_TAR_FILE.into()),
             layered::LayeringSemantics::LowerLayerReadOnly,
         );
 
@@ -1380,7 +1392,7 @@ mod layered {
         let fs = layered::FileSystem::new(
             &litebox,
             in_mem_fs,
-            tar_ro::FileSystem::new(&litebox, TEST_TAR_FILE.into()),
+            super::tar_ro_fs(&litebox, TEST_TAR_FILE.into()),
             layered::LayeringSemantics::LowerLayerReadOnly,
         );
         let fd = fs
@@ -1401,7 +1413,7 @@ mod layered {
         let fs = layered::FileSystem::new(
             &litebox,
             in_mem::FileSystem::new(&litebox),
-            tar_ro::FileSystem::new(&litebox, TEST_TAR_FILE.into()),
+            super::tar_ro_fs(&litebox, TEST_TAR_FILE.into()),
             layered::LayeringSemantics::LowerLayerReadOnly,
         );
 
@@ -1444,7 +1456,7 @@ mod layered {
         let fs = layered::FileSystem::new(
             &litebox,
             in_mem_fs,
-            tar_ro::FileSystem::new(&litebox, TEST_TAR_FILE.into()),
+            super::tar_ro_fs(&litebox, TEST_TAR_FILE.into()),
             layered::LayeringSemantics::LowerLayerReadOnly,
         );
 
@@ -1503,7 +1515,7 @@ mod layered {
         let fs = layered::FileSystem::new(
             &litebox,
             in_mem_fs,
-            tar_ro::FileSystem::new(&litebox, TEST_TAR_FILE.into()),
+            super::tar_ro_fs(&litebox, TEST_TAR_FILE.into()),
             layered::LayeringSemantics::LowerLayerReadOnly,
         );
 
@@ -1614,7 +1626,7 @@ mod layered {
                 .expect("Failed to chmod / in upper layer");
         });
 
-        let lower = tar_ro::FileSystem::new(&litebox, TEST_TAR_FILE.into());
+        let lower = super::tar_ro_fs(&litebox, TEST_TAR_FILE.into());
         let fs = layered::FileSystem::new(
             &litebox,
             upper,
@@ -1658,7 +1670,7 @@ mod layered {
                 .expect("Failed to chmod / in upper layer");
         });
 
-        let lower = tar_ro::FileSystem::new(&litebox, TEST_TAR_FILE.into());
+        let lower = super::tar_ro_fs(&litebox, TEST_TAR_FILE.into());
         let fs = layered::FileSystem::new(
             &litebox,
             upper,
@@ -1706,7 +1718,7 @@ mod layered {
                 .expect("Failed to chmod / in upper layer");
         });
 
-        let lower = tar_ro::FileSystem::new(&litebox, TEST_TAR_FILE.into());
+        let lower = super::tar_ro_fs(&litebox, TEST_TAR_FILE.into());
         let fs = layered::FileSystem::new(
             &litebox,
             upper,
@@ -1749,7 +1761,7 @@ mod layered {
     fn open_with_trunc() {
         let litebox = LiteBox::new(MockPlatform::new());
 
-        let lower = tar_ro::FileSystem::new(&litebox, TEST_TAR_FILE.into());
+        let lower = super::tar_ro_fs(&litebox, TEST_TAR_FILE.into());
         let mut upper = in_mem::FileSystem::new(&litebox);
         // Set up write permissions on the upper layer
         upper.with_root_privileges(|fs| {
@@ -1806,7 +1818,7 @@ mod layered {
                 .expect("chmod / failed");
         });
 
-        let lower = tar_ro::FileSystem::new(&litebox, TEST_TAR_FILE.into());
+        let lower = super::tar_ro_fs(&litebox, TEST_TAR_FILE.into());
         let fs = layered::FileSystem::new(
             &litebox,
             upper,
@@ -1847,7 +1859,7 @@ mod layered {
         upper.with_root_privileges(|fs| {
             fs.chmod("/", Mode::RWXU | Mode::RWXG | Mode::RWXO).unwrap();
         });
-        let lower = tar_ro::FileSystem::new(&litebox, TEST_TAR_FILE.into());
+        let lower = super::tar_ro_fs(&litebox, TEST_TAR_FILE.into());
         let fs = layered::FileSystem::new(
             &litebox,
             upper,
@@ -1893,7 +1905,7 @@ mod layered {
 
         let litebox = LiteBox::new(MockPlatform::new());
         let upper = in_mem::FileSystem::new(&litebox); // empty
-        let lower = tar_ro::FileSystem::new(&litebox, TEST_TAR_FILE.into());
+        let lower = super::tar_ro_fs(&litebox, TEST_TAR_FILE.into());
         let fs = layered::FileSystem::new(
             &litebox,
             upper,
@@ -1915,7 +1927,7 @@ mod layered {
         upper.with_root_privileges(|fs| {
             fs.chmod("/", Mode::RWXU | Mode::RWXG | Mode::RWXO).unwrap();
         });
-        let lower = tar_ro::FileSystem::new(&litebox, TEST_TAR_FILE.into());
+        let lower = super::tar_ro_fs(&litebox, TEST_TAR_FILE.into());
         let fs = layered::FileSystem::new(
             &litebox,
             upper,
@@ -1957,7 +1969,7 @@ mod layered {
         let fs = layered::FileSystem::new(
             &litebox,
             in_mem_fs,
-            tar_ro::FileSystem::new(&litebox, TEST_TAR_FILE.into()),
+            super::tar_ro_fs(&litebox, TEST_TAR_FILE.into()),
             layered::LayeringSemantics::LowerLayerReadOnly,
         );
 

--- a/litebox_runner_linux_on_windows_userland/src/lib.rs
+++ b/litebox_runner_linux_on_windows_userland/src/lib.rs
@@ -87,8 +87,7 @@ pub fn run(cli_args: CliArgs) -> Result<()> {
             fs.chown("/tmp", Some(1000), Some(1000)).unwrap();
         });
 
-        let tar_ro = litebox::fs::tar_ro::FileSystem::new(litebox, tar_data.into());
-        shim_builder.default_fs(in_mem, tar_ro)
+        shim_builder.default_fs(in_mem, tar_data.into())
     };
     let initial_file_system = std::sync::Arc::new(initial_file_system);
 

--- a/litebox_runner_linux_on_windows_userland/tests/common/mod.rs
+++ b/litebox_runner_linux_on_windows_userland/tests/common/mod.rs
@@ -29,15 +29,12 @@ impl TestLauncher {
             fs.chmod("/", Mode::RWXU | Mode::RWXG | Mode::RWXO)
                 .expect("Failed to set permissions on root");
         });
-        let tar_ro_fs = litebox::fs::tar_ro::FileSystem::new(
-            litebox,
-            if tar_data.is_empty() {
-                litebox::fs::tar_ro::EMPTY_TAR_FILE.into()
-            } else {
-                tar_data.into()
-            },
-        );
-        let fs = shim_builder.default_fs(in_mem_fs, tar_ro_fs);
+        let tar_data = if tar_data.is_empty() {
+            litebox::fs::tar_ro::EMPTY_TAR_FILE.into()
+        } else {
+            tar_data.into()
+        };
+        let fs = shim_builder.default_fs(in_mem_fs, tar_data);
         let mut this = Self {
             platform,
             shim_builder,

--- a/litebox_runner_linux_userland/src/lib.rs
+++ b/litebox_runner_linux_userland/src/lib.rs
@@ -295,8 +295,7 @@ pub fn run(cli_args: CliArgs) -> Result<()> {
             }
         });
 
-        let tar_ro = litebox::fs::tar_ro::FileSystem::new(litebox, tar_data.into());
-        shim_builder.default_fs(in_mem, tar_ro)
+        shim_builder.default_fs(in_mem, tar_data.into())
     };
 
     // We need to get the file path before enabling seccomp.

--- a/litebox_runner_linux_userland/tests/loader.rs
+++ b/litebox_runner_linux_userland/tests/loader.rs
@@ -30,15 +30,12 @@ impl TestLauncher {
             fs.chmod("/", Mode::RWXU | Mode::RWXG | Mode::RWXO)
                 .expect("Failed to set permissions on root");
         });
-        let tar_ro_fs = litebox::fs::tar_ro::FileSystem::new(
-            litebox,
-            if tar_data.is_empty() {
-                litebox::fs::tar_ro::EMPTY_TAR_FILE.into()
-            } else {
-                tar_data.into()
-            },
-        );
-        let fs = shim_builder.default_fs(in_mem_fs, tar_ro_fs);
+        let tar_data = if tar_data.is_empty() {
+            litebox::fs::tar_ro::EMPTY_TAR_FILE.into()
+        } else {
+            tar_data.into()
+        };
+        let fs = shim_builder.default_fs(in_mem_fs, tar_data);
         let mut this = Self {
             platform,
             shim_builder,

--- a/litebox_shim_linux/src/lib.rs
+++ b/litebox_shim_linux/src/lib.rs
@@ -15,6 +15,7 @@
 
 extern crate alloc;
 
+use alloc::borrow::Cow;
 use alloc::vec;
 use alloc::vec::Vec;
 
@@ -62,7 +63,7 @@ pub(crate) type LinuxFS<Platform> = litebox::fs::layered::FileSystem<
     litebox::fs::layered::FileSystem<
         Platform,
         litebox::fs::resolver::Resolver<Platform, litebox::fs::composer::Composer>,
-        litebox::fs::tar_ro::FileSystem<Platform>,
+        litebox::fs::resolver::Resolver<Platform, litebox::fs::composer::Composer>,
     >,
 >;
 
@@ -217,13 +218,13 @@ impl<Platform: ShimPlatform> LinuxShimBuilder<Platform> {
         &self.litebox
     }
 
-    /// Create a default layered file system with the given in-memory and tar read-only layers.
+    /// Create a default layered file system with the given in-memory layer and tar data.
     pub fn default_fs(
         &self,
         in_mem_fs: litebox::fs::in_mem::FileSystem<Platform>,
-        tar_ro_fs: litebox::fs::tar_ro::FileSystem<Platform>,
+        tar_data: Cow<'static, [u8]>,
     ) -> DefaultFS<Platform> {
-        default_fs(&self.litebox, in_mem_fs, tar_ro_fs)
+        default_fs(&self.litebox, in_mem_fs, tar_data)
     }
 
     /// Build the shim.
@@ -374,11 +375,11 @@ impl<Platform: ShimPlatform> LinuxShimProcess<Platform> {
     }
 }
 
-/// Create a default layered file system with the given in-memory and tar read-only layers.
+/// Create a default layered file system with the given in-memory layer and tar data.
 fn default_fs<Platform: ShimPlatform>(
     litebox: &LiteBox<Platform>,
     in_mem_fs: litebox::fs::in_mem::FileSystem<Platform>,
-    tar_ro_fs: litebox::fs::tar_ro::FileSystem<Platform>,
+    tar_data: Cow<'static, [u8]>,
 ) -> LinuxFS<Platform> {
     let dev_stdio = litebox::fs::resolver::Resolver::new(
         litebox,
@@ -389,13 +390,22 @@ fn default_fs<Platform: ShimPlatform>(
             .build()
             .unwrap(),
     );
+    let tar_ro = litebox::fs::resolver::Resolver::new(
+        litebox,
+        litebox::fs::composer::Composer::builder()
+            .mount("/", |allocator| {
+                litebox::fs::tar_ro::TarRo::new(tar_data, allocator)
+            })
+            .build()
+            .unwrap(),
+    );
     litebox::fs::layered::FileSystem::new(
         litebox,
         in_mem_fs,
         litebox::fs::layered::FileSystem::new(
             litebox,
             dev_stdio,
-            tar_ro_fs,
+            tar_ro,
             litebox::fs::layered::LayeringSemantics::LowerLayerReadOnly,
         ),
         litebox::fs::layered::LayeringSemantics::LowerLayerWritableFiles,

--- a/litebox_shim_linux/src/syscalls/tests.rs
+++ b/litebox_shim_linux/src/syscalls/tests.rs
@@ -51,8 +51,7 @@ pub(crate) fn init_platform(
         fs.chmod("/", Mode::RWXU | Mode::RWXG | Mode::RWXO)
             .expect("Failed to set permissions on root");
     });
-    let tar_ro_fs = litebox::fs::tar_ro::FileSystem::new(litebox, TEST_TAR_FILE.into());
-    let fs = alloc::sync::Arc::new(shim_builder.default_fs(in_mem_fs, tar_ro_fs));
+    let fs = alloc::sync::Arc::new(shim_builder.default_fs(in_mem_fs, TEST_TAR_FILE.into()));
     let task = shim_builder.build().0.new_test_task(fs);
 
     if tun_device_name.is_some() {


### PR DESCRIPTION
This PR switches our Tar-RO filesystem to the new core file system design (see #887).  Concretely, it adds a `TarRo` backend, migrates all old usage of `tar_ro::FileSystem` to a resolver-backed one to use the new `TarRo` backend, and then removes the old `tar_ro::FileSystem`.  It also makes minor tweaks to the `Backend` interface to correctly account for read-only file systems.  Interestingly, this move to the backend-based handling also gives us a chance to clean up the hardcoded dir stuff inside the tar-ro to instead properly use inode numbering :)