### PR TITLE
Simplify broker principal rights

### DIFF
--- a/litebox_broker_core/src/lib.rs
+++ b/litebox_broker_core/src/lib.rs
@@ -31,7 +31,7 @@ use litebox_broker_protocol::ObjectHandle;
 use spin::rwlock::RwLock;
 
 pub use error::BrokerError;
-pub use policy::{PolicyEngine, PolicyProfile, PrincipalRights};
+pub use policy::{PolicyEngine, PolicyProfile};
 use session::ObjectReference;
 pub use session::{BrokerSession, CallerCredential, ObjectRights};
 

--- a/litebox_broker_core/src/policy.rs
+++ b/litebox_broker_core/src/policy.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-use crate::session::ObjectKind;
 use crate::{BrokerError, CallerCredential, ObjectRights};
 
 /// Configured broker policy.
@@ -13,31 +12,8 @@ pub enum PolicyProfile {
     /// Static rights for known broker principals.
     Static {
         /// Rights for the unauthenticated principal used by the initial POC.
-        unauthenticated: PrincipalRights,
+        unauthenticated: ObjectRights,
     },
-}
-
-/// Rights granted to one broker principal.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[non_exhaustive]
-pub struct PrincipalRights {
-    /// Rights for event objects.
-    pub event: ObjectRights,
-}
-
-impl PrincipalRights {
-    /// Grants all currently supported object rights.
-    pub const fn all() -> Self {
-        Self {
-            event: ObjectRights::WAIT.union(ObjectRights::WRITE),
-        }
-    }
-
-    fn object_rights(self, object_kind: ObjectKind) -> ObjectRights {
-        match object_kind {
-            ObjectKind::Event => self.event,
-        }
-    }
 }
 
 /// Broker policy decision and audit component.
@@ -62,22 +38,20 @@ impl PolicyEngine {
     }
 
     /// Creates a policy engine with rights for the unauthenticated principal.
-    pub const fn with_unauthenticated_rights(unauthenticated: PrincipalRights) -> Self {
+    pub const fn with_unauthenticated_rights(unauthenticated: ObjectRights) -> Self {
         Self::new(PolicyProfile::Static { unauthenticated })
     }
 
     pub(crate) fn principal_object_rights(
         &self,
         caller_credential: CallerCredential,
-        object_kind: ObjectKind,
     ) -> Result<ObjectRights, BrokerError> {
-        let principal_rights = match (self.profile, caller_credential) {
+        let rights = match (self.profile, caller_credential) {
             (PolicyProfile::Static { unauthenticated }, CallerCredential::Unauthenticated) => {
                 unauthenticated
             }
             (PolicyProfile::DefaultDeny, _) => return Err(BrokerError::PolicyDenied),
         };
-        let rights = principal_rights.object_rights(object_kind);
         if rights.is_empty() {
             return Err(BrokerError::PolicyDenied);
         }
@@ -97,34 +71,30 @@ mod tests {
 
     #[test]
     fn static_policy_allows_configured_principal_rights() {
-        let policy = PolicyEngine::with_unauthenticated_rights(PrincipalRights::all());
+        let policy = PolicyEngine::with_unauthenticated_rights(ObjectRights::all());
 
         assert_eq!(
-            policy.principal_object_rights(CallerCredential::Unauthenticated, ObjectKind::Event),
+            policy.principal_object_rights(CallerCredential::Unauthenticated),
             Ok(ObjectRights::WAIT | ObjectRights::WRITE)
         );
     }
 
     #[test]
     fn static_policy_returns_configured_principal_rights() {
-        let policy = PolicyEngine::with_unauthenticated_rights(PrincipalRights {
-            event: ObjectRights::WAIT,
-        });
+        let policy = PolicyEngine::with_unauthenticated_rights(ObjectRights::WAIT);
 
         assert_eq!(
-            policy.principal_object_rights(CallerCredential::Unauthenticated, ObjectKind::Event),
+            policy.principal_object_rights(CallerCredential::Unauthenticated),
             Ok(ObjectRights::WAIT)
         );
     }
 
     #[test]
     fn empty_principal_rights_deny_object_authorization() {
-        let policy = PolicyEngine::with_unauthenticated_rights(PrincipalRights {
-            event: ObjectRights::empty(),
-        });
+        let policy = PolicyEngine::with_unauthenticated_rights(ObjectRights::empty());
 
         assert_eq!(
-            policy.principal_object_rights(CallerCredential::Unauthenticated, ObjectKind::Event),
+            policy.principal_object_rights(CallerCredential::Unauthenticated),
             Err(BrokerError::PolicyDenied)
         );
     }

--- a/litebox_broker_core/src/session.rs
+++ b/litebox_broker_core/src/session.rs
@@ -48,19 +48,6 @@ pub(crate) enum ObjectEntry {
     Event(EventObject),
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum ObjectKind {
-    Event,
-}
-
-impl ObjectEntry {
-    fn kind(self) -> ObjectKind {
-        match self {
-            Self::Event(_) => ObjectKind::Event,
-        }
-    }
-}
-
 /// Broker-owned authority token for one authenticated caller session.
 ///
 /// User mode does not choose this value. The broker entry layer authenticates
@@ -92,7 +79,7 @@ impl BrokerSession {
         let rights = self
             .core
             .policy
-            .principal_object_rights(self.caller_credential, object.kind())?;
+            .principal_object_rights(self.caller_credential)?;
         let mut references = self.core.references.write();
         if references.len() >= self.core.limits.max_references {
             return Err(BrokerError::ResourceExhausted);
@@ -178,7 +165,7 @@ impl Drop for BrokerSession {
 #[cfg(test)]
 mod tests {
     use crate::{
-        BrokerCore, BrokerCoreLimits, BrokerError, CallerCredential, PolicyEngine, PrincipalRights,
+        BrokerCore, BrokerCoreLimits, BrokerError, CallerCredential, ObjectRights, PolicyEngine,
     };
     use litebox_broker_protocol::ObjectHandle;
     use litebox_broker_protocol::event::{EventConsumeMode, EventConsumption, ReadinessState};
@@ -186,7 +173,7 @@ mod tests {
     #[test]
     fn object_reference_lifecycle_uses_public_core_constructor_once() {
         let broker = BrokerCore::new_with_limits(
-            PolicyEngine::with_unauthenticated_rights(PrincipalRights::all()),
+            PolicyEngine::with_unauthenticated_rights(ObjectRights::all()),
             BrokerCoreLimits::new(1),
         )
         .unwrap();

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -170,7 +170,7 @@ pub enum ConnectionTermination {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use litebox_broker_core::{PolicyEngine, PrincipalRights};
+    use litebox_broker_core::{ObjectRights, PolicyEngine};
     use litebox_broker_protocol::event::{
         AddEventRequest, ConsumeEventRequest, CreateEventRequest, EventConsumeMode,
         WaitEventRequest,
@@ -181,7 +181,7 @@ mod tests {
     #[test]
     fn host_request_handling_uses_one_broker_core() {
         let broker = BrokerCore::new(PolicyEngine::with_unauthenticated_rights(
-            PrincipalRights::all(),
+            ObjectRights::all(),
         ))
         .unwrap();
 

--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 use std::process::Command;
 
 use clap::Parser;
-use litebox_broker_core::{BrokerCore, PolicyEngine, PrincipalRights};
+use litebox_broker_core::{BrokerCore, ObjectRights, PolicyEngine};
 use litebox_broker_host::serve_connection;
 use litebox_broker_transport::unix_socket::{
     UnixStreamHostControlChannel, UnixStreamHostNotificationChannel,
@@ -34,7 +34,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let control_listener = UnixListener::bind(&control_socket_path)?;
     let notification_listener = UnixListener::bind(&notification_socket_path)?;
     let broker = BrokerCore::new(PolicyEngine::with_unauthenticated_rights(
-        PrincipalRights::all(),
+        ObjectRights::all(),
     ))?;
 
     let mut runner_command = Command::new(&args.runner);

--- a/litebox_broker_userland/tests/notification_runtime.rs
+++ b/litebox_broker_userland/tests/notification_runtime.rs
@@ -3,7 +3,7 @@
 
 use std::os::unix::net::UnixStream;
 
-use litebox_broker_core::{BrokerCore, PolicyEngine, PrincipalRights};
+use litebox_broker_core::{BrokerCore, ObjectRights, PolicyEngine};
 use litebox_broker_host::{ConnectionTermination, serve_connection};
 use litebox_broker_local::BrokerLocal;
 use litebox_broker_protocol::event::ReadinessState;
@@ -14,7 +14,7 @@ use litebox_broker_transport::unix_socket::{
 #[test]
 fn host_serves_control_requests_over_paired_userland_channels() {
     let broker = BrokerCore::new(PolicyEngine::with_unauthenticated_rights(
-        PrincipalRights::all(),
+        ObjectRights::all(),
     ))
     .unwrap();
     let (local_control, host_control) = UnixStream::pair().unwrap();

--- a/litebox_runner_linux_userland/tests/run.rs
+++ b/litebox_runner_linux_userland/tests/run.rs
@@ -479,7 +479,7 @@ console.log(content);
         &control_socket_path,
         &notification_socket_path,
         litebox_broker_core::PolicyEngine::with_unauthenticated_rights(
-            litebox_broker_core::PrincipalRights::all(),
+            litebox_broker_core::ObjectRights::all(),
         ),
         3,
     );


### PR DESCRIPTION
This PR replaces per-object principal rights with one object-rights set for each principal. It keeps the static policy surface simple before adding more broker object types.