### PR TITLE
Unify broker readiness representation

### DIFF
--- a/litebox/src/broker/mod.rs
+++ b/litebox/src/broker/mod.rs
@@ -10,10 +10,10 @@ use hashbrown::HashMap;
 use litebox_broker_local::BrokerLocal;
 use litebox_broker_protocol::ObjectHandle;
 use litebox_broker_protocol::channel::LocalControlChannel;
-use litebox_broker_protocol::event::{ConsumeEventResponse, EventConsumeMode, ReadinessState};
+use litebox_broker_protocol::event::{ConsumeEventResponse, EventConsumeMode};
+use litebox_broker_protocol::readiness::ReadinessFlags;
 
 use crate::event::{Events, polling::Pollee};
-use crate::platform::TimeProvider;
 use crate::sync::{Mutex, RawSyncPrimitivesProvider};
 
 pub(crate) mod error;
@@ -37,13 +37,13 @@ pub(crate) trait BrokerControl: Send + Sync {
     fn wait_event(
         &self,
         handle: ObjectHandle,
-    ) -> core::result::Result<ReadinessState, BrokerControlError>;
+    ) -> core::result::Result<ReadinessFlags, BrokerControlError>;
 
     fn add_event(
         &self,
         handle: ObjectHandle,
         value: u64,
-    ) -> core::result::Result<ReadinessState, BrokerControlError>;
+    ) -> core::result::Result<ReadinessFlags, BrokerControlError>;
 
     fn consume_event(
         &self,
@@ -83,29 +83,29 @@ impl<Platform: RawSyncPrimitivesProvider> BrokerHandleRegistry<Platform> {
         }
     }
 
-    pub(crate) fn notify_readiness(&self, handle: ObjectHandle, readiness: ReadinessState)
-    where
-        Platform: TimeProvider,
-    {
-        let mut handles = self.handles.lock();
-        let Some(entry) = handles.get_mut(&handle) else {
+    pub(crate) fn notify_readiness(&self, handle: ObjectHandle, readiness: ReadinessFlags) {
+        let events = readiness_events(readiness);
+        if events.is_empty() {
             return;
+        }
+        let pollables = {
+            let mut handles = self.handles.lock();
+            let Some(entry) = handles.get_mut(&handle) else {
+                return;
+            };
+            entry.prune_stale_pollables();
+            let pollables = entry
+                .pollables
+                .iter()
+                .filter_map(Weak::upgrade)
+                .collect::<Vec<_>>();
+            if entry.is_empty() {
+                handles.remove(&handle);
+            }
+            pollables
         };
-        entry.prune_stale_pollables();
-        if entry.is_empty() {
-            handles.remove(&handle);
-            return;
-        }
-
-        let mut events = Events::empty();
-        if readiness.read_ready {
-            events |= Events::IN;
-        }
-        if readiness.write_ready {
-            events |= Events::OUT;
-        }
-        if !events.is_empty() {
-            entry.notify_pollables(events);
+        for pollee in pollables {
+            pollee.notify_observers(events);
         }
     }
 }
@@ -136,17 +136,6 @@ impl<Platform: RawSyncPrimitivesProvider> BrokerHandleEntry<Platform> {
     fn prune_stale_pollables(&mut self) {
         self.pollables
             .retain(|registered| registered.strong_count() > 0);
-    }
-
-    fn notify_pollables(&self, events: Events)
-    where
-        Platform: TimeProvider,
-    {
-        for registered in &self.pollables {
-            if let Some(pollee) = registered.upgrade() {
-                pollee.notify_observers(events);
-            }
-        }
     }
 
     fn is_empty(&self) -> bool {
@@ -187,7 +176,7 @@ where
     fn wait_event(
         &self,
         handle: ObjectHandle,
-    ) -> core::result::Result<ReadinessState, BrokerControlError> {
+    ) -> core::result::Result<ReadinessFlags, BrokerControlError> {
         Ok(self.local.lock().wait_event(handle)?)
     }
 
@@ -195,7 +184,7 @@ where
         &self,
         handle: ObjectHandle,
         value: u64,
-    ) -> core::result::Result<ReadinessState, BrokerControlError> {
+    ) -> core::result::Result<ReadinessFlags, BrokerControlError> {
         Ok(self.local.lock().add_event(handle, value)?)
     }
 
@@ -210,4 +199,13 @@ where
     fn close_object(&self, handle: ObjectHandle) -> core::result::Result<(), BrokerControlError> {
         Ok(self.local.lock().close_object(handle)?)
     }
+}
+
+pub(crate) fn readiness_events(readiness: ReadinessFlags) -> Events {
+    let mut events = Events::empty();
+    events.set(Events::IN, readiness.0 & ReadinessFlags::READ.0 != 0);
+    events.set(Events::OUT, readiness.0 & ReadinessFlags::WRITE.0 != 0);
+    events.set(Events::HUP, readiness.0 & ReadinessFlags::HANGUP.0 != 0);
+    events.set(Events::ERR, readiness.0 & ReadinessFlags::ERROR.0 != 0);
+    events
 }

--- a/litebox/src/broker/mod.rs
+++ b/litebox/src/broker/mod.rs
@@ -14,6 +14,7 @@ use litebox_broker_protocol::event::{ConsumeEventResponse, EventConsumeMode};
 use litebox_broker_protocol::readiness::ReadinessFlags;
 
 use crate::event::{Events, polling::Pollee};
+use crate::platform::TimeProvider;
 use crate::sync::{Mutex, RawSyncPrimitivesProvider};
 
 pub(crate) mod error;
@@ -77,13 +78,16 @@ impl<Platform: RawSyncPrimitivesProvider> BrokerHandleRegistry<Platform> {
         let mut handles = self.handles.lock();
         if let Some(entry) = handles.get_mut(&handle) {
             entry.unregister_pollable(pollee);
-            if entry.is_empty() {
+            if entry.pollables.is_empty() {
                 handles.remove(&handle);
             }
         }
     }
 
-    pub(crate) fn notify_readiness(&self, handle: ObjectHandle, readiness: ReadinessFlags) {
+    pub(crate) fn notify_readiness(&self, handle: ObjectHandle, readiness: ReadinessFlags)
+    where
+        Platform: TimeProvider,
+    {
         let events = readiness_events(readiness);
         if events.is_empty() {
             return;
@@ -99,7 +103,7 @@ impl<Platform: RawSyncPrimitivesProvider> BrokerHandleRegistry<Platform> {
                 .iter()
                 .filter_map(Weak::upgrade)
                 .collect::<Vec<_>>();
-            if entry.is_empty() {
+            if entry.pollables.is_empty() {
                 handles.remove(&handle);
             }
             pollables
@@ -136,10 +140,6 @@ impl<Platform: RawSyncPrimitivesProvider> BrokerHandleEntry<Platform> {
     fn prune_stale_pollables(&mut self) {
         self.pollables
             .retain(|registered| registered.strong_count() > 0);
-    }
-
-    fn is_empty(&self) -> bool {
-        self.pollables.is_empty()
     }
 }
 pub(crate) struct BrokerLocalControl<

--- a/litebox/src/event/counter.rs
+++ b/litebox/src/event/counter.rs
@@ -233,7 +233,7 @@ mod tests {
         litebox.dispatch_broker_notification(BrokerNotification::Readiness(
             ReadinessNotification {
                 handle,
-                events: ReadinessFlags::READ | ReadinessFlags::WRITE,
+                readiness: ReadinessFlags::READ | ReadinessFlags::WRITE,
             },
         ));
 

--- a/litebox/src/event/counter.rs
+++ b/litebox/src/event/counter.rs
@@ -4,8 +4,9 @@
 use alloc::sync::Arc;
 
 use litebox_broker_protocol::ObjectHandle;
+use litebox_broker_protocol::event::ConsumeEventResponse;
 pub use litebox_broker_protocol::event::EventConsumeMode as EventCounterReadMode;
-use litebox_broker_protocol::event::{ConsumeEventResponse, ReadinessState};
+use litebox_broker_protocol::readiness::ReadinessFlags;
 use thiserror::Error;
 
 use crate::{
@@ -13,6 +14,7 @@ use crate::{
     broker::{
         BrokerControl, BrokerHandleRegistry,
         error::{BrokerControlError, BrokerObjectError},
+        readiness_events,
     },
     event::{
         Events, IOPollable, observer::Observer, polling::Pollee, polling::TryOpError,
@@ -86,7 +88,7 @@ where
     ) -> Result<u64, TryOpError<EventCounterError>> {
         self.pollee.wait(cx, nonblock, Events::IN, || {
             let response = self.consume(mode)?;
-            if response.readiness.write_ready {
+            if response.readiness.0 & ReadinessFlags::WRITE.0 != 0 {
                 self.pollee.notify_observers(Events::OUT);
             }
             Ok(response.value)
@@ -105,7 +107,7 @@ where
         }
         self.pollee.wait(cx, nonblock, Events::OUT, || {
             let readiness = self.add(value)?;
-            if value != 0 && readiness.read_ready {
+            if value != 0 && readiness.0 & ReadinessFlags::READ.0 != 0 {
                 self.pollee.notify_observers(Events::IN);
             }
             Ok(core::mem::size_of::<u64>())
@@ -121,7 +123,7 @@ where
             .map_err(|error| self.broker_request_error(error))
     }
 
-    fn add(&self, value: u64) -> Result<ReadinessState, BrokerObjectError> {
+    fn add(&self, value: u64) -> Result<ReadinessFlags, BrokerObjectError> {
         self.broker
             .add_event(self.handle, value)
             .map_err(|error| self.broker_request_error(error))
@@ -164,14 +166,7 @@ where
             Err(BrokerObjectError::WouldBlock) => return Events::empty(),
             Err(_) => return Events::ERR,
         };
-        let mut events = Events::empty();
-        if readiness.read_ready {
-            events |= Events::IN;
-        }
-        if readiness.write_ready {
-            events |= Events::OUT;
-        }
-        events
+        readiness_events(readiness)
     }
 }
 
@@ -185,11 +180,12 @@ mod tests {
     use litebox_broker_local::BrokerLocal;
     use litebox_broker_protocol::channel::LocalControlChannel;
     use litebox_broker_protocol::error::ErrorCode;
-    use litebox_broker_protocol::event::{CreateEventResponse, EventConsumption, ReadinessState};
+    use litebox_broker_protocol::event::{CreateEventResponse, EventConsumption};
     use litebox_broker_protocol::message::{
         BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerNotification, BrokerRequest,
-        BrokerResponse, EventReadinessNotification, EventRequest, EventResponse,
+        BrokerResponse, EventRequest, EventResponse, ReadinessNotification,
     };
+    use litebox_broker_protocol::readiness::ReadinessFlags;
 
     use super::*;
     use crate::LiteBox;
@@ -234,13 +230,10 @@ mod tests {
             std::thread::yield_now();
         }
         read_ready.store(true, Ordering::SeqCst);
-        litebox.dispatch_broker_notification(BrokerNotification::EventReadiness(
-            EventReadinessNotification {
+        litebox.dispatch_broker_notification(BrokerNotification::Readiness(
+            ReadinessNotification {
                 handle,
-                readiness: ReadinessState {
-                    read_ready: true,
-                    write_ready: true,
-                },
+                events: ReadinessFlags::READ | ReadinessFlags::WRITE,
             },
         ));
 
@@ -300,10 +293,7 @@ mod tests {
                     if self.read_ready.swap(false, Ordering::SeqCst) {
                         BrokerResponse::Event(EventResponse::Consume(EventConsumption {
                             value: 1,
-                            readiness: ReadinessState {
-                                read_ready: false,
-                                write_ready: true,
-                            },
+                            readiness: ReadinessFlags::WRITE,
                         }))
                     } else {
                         BrokerResponse::Error(ErrorCode::WouldBlock)

--- a/litebox/src/event/polling.rs
+++ b/litebox/src/event/polling.rs
@@ -85,13 +85,13 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> WaitContext<'_, Platfor
     }
 }
 
-impl<Platform: RawSyncPrimitivesProvider> Default for Pollee<Platform> {
+impl<Platform: RawSyncPrimitivesProvider + TimeProvider> Default for Pollee<Platform> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<Platform: RawSyncPrimitivesProvider> Pollee<Platform> {
+impl<Platform: RawSyncPrimitivesProvider + TimeProvider> Pollee<Platform> {
     /// Create a new pollee.
     pub fn new() -> Self {
         Self {
@@ -114,10 +114,7 @@ impl<Platform: RawSyncPrimitivesProvider> Pollee<Platform> {
         nonblock: bool,
         events: Events,
         try_op: impl FnMut() -> Result<R, TryOpError<E>>,
-    ) -> Result<R, TryOpError<E>>
-    where
-        Platform: TimeProvider,
-    {
+    ) -> Result<R, TryOpError<E>> {
         cx.wait_on_events(
             nonblock,
             events,

--- a/litebox/src/event/polling.rs
+++ b/litebox/src/event/polling.rs
@@ -85,13 +85,13 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> WaitContext<'_, Platfor
     }
 }
 
-impl<Platform: RawSyncPrimitivesProvider + TimeProvider> Default for Pollee<Platform> {
+impl<Platform: RawSyncPrimitivesProvider> Default for Pollee<Platform> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<Platform: RawSyncPrimitivesProvider + TimeProvider> Pollee<Platform> {
+impl<Platform: RawSyncPrimitivesProvider> Pollee<Platform> {
     /// Create a new pollee.
     pub fn new() -> Self {
         Self {
@@ -114,7 +114,10 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> Pollee<Platform> {
         nonblock: bool,
         events: Events,
         try_op: impl FnMut() -> Result<R, TryOpError<E>>,
-    ) -> Result<R, TryOpError<E>> {
+    ) -> Result<R, TryOpError<E>>
+    where
+        Platform: TimeProvider,
+    {
         cx.wait_on_events(
             nonblock,
             events,

--- a/litebox/src/litebox.rs
+++ b/litebox/src/litebox.rs
@@ -153,7 +153,7 @@ impl<Platform: RawSyncPrimitivesProvider> LiteBox<Platform> {
             BrokerNotification::Readiness(notification) => self
                 .x
                 .broker_handles
-                .notify_readiness(notification.handle, notification.events),
+                .notify_readiness(notification.handle, notification.readiness),
         }
     }
 

--- a/litebox/src/litebox.rs
+++ b/litebox/src/litebox.rs
@@ -12,7 +12,6 @@ use litebox_broker_protocol::message::BrokerNotification;
 use crate::{
     broker,
     fd::Descriptors,
-    platform::TimeProvider,
     sync::{RawSyncPrimitivesProvider, RwLock},
 };
 
@@ -145,22 +144,19 @@ impl<Platform: RawSyncPrimitivesProvider> LiteBox<Platform> {
     }
 
     /// Dispatches one broker notification to the matching local-core object.
-    pub fn dispatch_broker_notification(&self, notification: BrokerNotification)
-    where
-        Platform: TimeProvider,
-    {
+    pub fn dispatch_broker_notification(&self, notification: BrokerNotification) {
         match notification {
-            BrokerNotification::EventReadiness(notification) => self
+            BrokerNotification::Readiness(notification) => self
                 .x
                 .broker_handles
-                .notify_readiness(notification.handle, notification.readiness),
+                .notify_readiness(notification.handle, notification.events),
         }
     }
 
     /// Returns a narrow dispatcher for moving broker notification handling into deployment code.
     pub fn broker_notification_dispatcher(&self) -> impl Fn(BrokerNotification) + Send + 'static
     where
-        Platform: TimeProvider + 'static,
+        Platform: 'static,
     {
         let litebox = self.clone();
         move |notification| {

--- a/litebox/src/litebox.rs
+++ b/litebox/src/litebox.rs
@@ -12,6 +12,7 @@ use litebox_broker_protocol::message::BrokerNotification;
 use crate::{
     broker,
     fd::Descriptors,
+    platform::TimeProvider,
     sync::{RawSyncPrimitivesProvider, RwLock},
 };
 
@@ -144,7 +145,10 @@ impl<Platform: RawSyncPrimitivesProvider> LiteBox<Platform> {
     }
 
     /// Dispatches one broker notification to the matching local-core object.
-    pub fn dispatch_broker_notification(&self, notification: BrokerNotification) {
+    pub fn dispatch_broker_notification(&self, notification: BrokerNotification)
+    where
+        Platform: TimeProvider,
+    {
         match notification {
             BrokerNotification::Readiness(notification) => self
                 .x
@@ -156,7 +160,7 @@ impl<Platform: RawSyncPrimitivesProvider> LiteBox<Platform> {
     /// Returns a narrow dispatcher for moving broker notification handling into deployment code.
     pub fn broker_notification_dispatcher(&self) -> impl Fn(BrokerNotification) + Send + 'static
     where
-        Platform: 'static,
+        Platform: TimeProvider + 'static,
     {
         let litebox = self.clone();
         move |notification| {

--- a/litebox_broker_core/src/event.rs
+++ b/litebox_broker_core/src/event.rs
@@ -6,7 +6,8 @@
 use crate::session::{ObjectEntry, ObjectRights};
 use crate::{BrokerError, BrokerSession, Result};
 use litebox_broker_protocol::ObjectHandle;
-use litebox_broker_protocol::event::{EventConsumeMode, EventConsumption, ReadinessState};
+use litebox_broker_protocol::event::{EventConsumeMode, EventConsumption};
+use litebox_broker_protocol::readiness::ReadinessFlags;
 
 pub(crate) const MAX_EVENT_COUNT: u64 = u64::MAX - 1;
 
@@ -24,18 +25,15 @@ pub fn create(session: &BrokerSession, initial_count: u64) -> Result<ObjectHandl
 /// Blocking is intentionally outside BrokerCore for the first proof of
 /// concept. Userland or kernel deployments can block on deployment-specific
 /// wait primitives after BrokerCore authorizes and reports readiness state.
-pub fn wait(session: &BrokerSession, handle: ObjectHandle) -> Result<ReadinessState> {
+pub fn wait(session: &BrokerSession, handle: ObjectHandle) -> Result<ReadinessFlags> {
     let required_rights = ObjectRights::WAIT;
     session.with_authorized_object(handle, required_rights, |object| match object {
-        ObjectEntry::Event(event) => Ok(ReadinessState {
-            read_ready: event.count > 0,
-            write_ready: event.count < MAX_EVENT_COUNT,
-        }),
+        ObjectEntry::Event(event) => Ok(event.readiness()),
     })
 }
 
 /// Adds readiness credits to a broker-owned event object.
-pub fn add(session: &BrokerSession, handle: ObjectHandle, value: u64) -> Result<ReadinessState> {
+pub fn add(session: &BrokerSession, handle: ObjectHandle, value: u64) -> Result<ReadinessFlags> {
     let required_rights = ObjectRights::WRITE;
     session.with_authorized_object_mut(handle, required_rights, |object| match object {
         ObjectEntry::Event(event) => event.add(value),
@@ -64,16 +62,13 @@ impl EventObject {
         Self { count }
     }
 
-    fn add(&mut self, value: u64) -> Result<ReadinessState> {
+    fn add(&mut self, value: u64) -> Result<ReadinessFlags> {
         self.count = self
             .count
             .checked_add(value)
             .filter(|count| *count <= MAX_EVENT_COUNT)
             .ok_or(BrokerError::WouldBlock)?;
-        Ok(ReadinessState {
-            read_ready: self.count > 0,
-            write_ready: self.count < MAX_EVENT_COUNT,
-        })
+        Ok(self.readiness())
     }
 
     fn consume(&mut self, mode: EventConsumeMode) -> Result<EventConsumption> {
@@ -88,10 +83,18 @@ impl EventObject {
         self.count -= value;
         Ok(EventConsumption {
             value,
-            readiness: ReadinessState {
-                read_ready: self.count > 0,
-                write_ready: self.count < MAX_EVENT_COUNT,
-            },
+            readiness: self.readiness(),
         })
+    }
+
+    fn readiness(self) -> ReadinessFlags {
+        let mut readiness = ReadinessFlags::default();
+        if self.count > 0 {
+            readiness = readiness | ReadinessFlags::READ;
+        }
+        if self.count < MAX_EVENT_COUNT {
+            readiness = readiness | ReadinessFlags::WRITE;
+        }
+        readiness
     }
 }

--- a/litebox_broker_core/src/session.rs
+++ b/litebox_broker_core/src/session.rs
@@ -168,7 +168,8 @@ mod tests {
         BrokerCore, BrokerCoreLimits, BrokerError, CallerCredential, ObjectRights, PolicyEngine,
     };
     use litebox_broker_protocol::ObjectHandle;
-    use litebox_broker_protocol::event::{EventConsumeMode, EventConsumption, ReadinessState};
+    use litebox_broker_protocol::event::{EventConsumeMode, EventConsumption};
+    use litebox_broker_protocol::readiness::ReadinessFlags;
 
     #[test]
     fn object_reference_lifecycle_uses_public_core_constructor_once() {
@@ -199,26 +200,17 @@ mod tests {
 
         assert_eq!(
             crate::event::wait(&session, handle),
-            Ok(ReadinessState {
-                read_ready: false,
-                write_ready: true,
-            })
+            Ok(ReadinessFlags::WRITE)
         );
         assert_eq!(
             crate::event::add(&session, handle, 1),
-            Ok(ReadinessState {
-                read_ready: true,
-                write_ready: true,
-            })
+            Ok(ReadinessFlags::READ | ReadinessFlags::WRITE)
         );
         assert_eq!(
             crate::event::consume(&session, handle, EventConsumeMode::One),
             Ok(EventConsumption {
                 value: 1,
-                readiness: ReadinessState {
-                    read_ready: false,
-                    write_ready: true,
-                },
+                readiness: ReadinessFlags::WRITE,
             })
         );
         assert_eq!(

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -337,18 +337,13 @@ mod tests {
             &channel.responses[1..],
             [
                 BrokerResponse::Event(EventResponse::Add(AddEventResponse {
-                    readiness: litebox_broker_protocol::event::ReadinessState {
-                        read_ready: true,
-                        write_ready: true,
-                    },
+                    readiness: litebox_broker_protocol::readiness::ReadinessFlags::READ
+                        | litebox_broker_protocol::readiness::ReadinessFlags::WRITE,
                 })),
                 BrokerResponse::Event(EventResponse::Consume(
                     litebox_broker_protocol::event::ConsumeEventResponse {
                         value: 1,
-                        readiness: litebox_broker_protocol::event::ReadinessState {
-                            read_ready: false,
-                            write_ready: true,
-                        },
+                        readiness: litebox_broker_protocol::readiness::ReadinessFlags::WRITE,
                     }
                 )),
             ]

--- a/litebox_broker_local/src/event.rs
+++ b/litebox_broker_local/src/event.rs
@@ -5,11 +5,12 @@ use litebox_broker_protocol::ObjectHandle;
 use litebox_broker_protocol::channel::LocalControlChannel;
 use litebox_broker_protocol::event::{
     AddEventRequest, ConsumeEventRequest, ConsumeEventResponse, CreateEventRequest,
-    EventConsumeMode, ReadinessState, WaitEventRequest,
+    EventConsumeMode, WaitEventRequest,
 };
 use litebox_broker_protocol::message::{
     BrokerRequest, BrokerResponse, EventRequest, EventResponse,
 };
+use litebox_broker_protocol::readiness::ReadinessFlags;
 
 use crate::{BrokerLocal, BrokerLocalError, Result};
 
@@ -38,7 +39,7 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
     ///
     /// Panics if the broker reports an unrecoverable error or returns a protocol
     /// response that does not match the issued event request.
-    pub fn wait_event(&mut self, handle: ObjectHandle) -> Result<ReadinessState, Channel::Error> {
+    pub fn wait_event(&mut self, handle: ObjectHandle) -> Result<ReadinessFlags, Channel::Error> {
         let response = self.request_event(EventRequest::Wait(WaitEventRequest { handle }))?;
         match response {
             EventResponse::Wait(response) => Ok(response.readiness),
@@ -56,7 +57,7 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
         &mut self,
         handle: ObjectHandle,
         value: u64,
-    ) -> Result<ReadinessState, Channel::Error> {
+    ) -> Result<ReadinessFlags, Channel::Error> {
         let response = self.request_event(EventRequest::Add(AddEventRequest { handle, value }))?;
         match response {
             EventResponse::Add(response) => Ok(response.readiness),

--- a/litebox_broker_local/src/lib.rs
+++ b/litebox_broker_local/src/lib.rs
@@ -156,9 +156,8 @@ mod tests {
     use litebox_broker_protocol::ProtocolVersion;
     use litebox_broker_protocol::channel::LocalNotificationChannel;
     use litebox_broker_protocol::event::{CreateEventRequest, CreateEventResponse};
-    use litebox_broker_protocol::message::{
-        EventReadinessNotification, EventRequest, EventResponse,
-    };
+    use litebox_broker_protocol::message::{EventRequest, EventResponse, ReadinessNotification};
+    use litebox_broker_protocol::readiness::ReadinessFlags;
 
     #[test]
     fn negotiate_returns_active_local_connection() {
@@ -248,12 +247,9 @@ mod tests {
 
     #[test]
     fn notification_receiver_returns_broker_notifications() {
-        let notification = BrokerNotification::EventReadiness(EventReadinessNotification {
+        let notification = BrokerNotification::Readiness(ReadinessNotification {
             handle: ObjectHandle(7),
-            readiness: litebox_broker_protocol::event::ReadinessState {
-                read_ready: true,
-                write_ready: false,
-            },
+            events: ReadinessFlags::READ,
         });
         let mut receiver = BrokerNotifications::new(FakeNotificationChannel {
             notification: Some(notification.clone()),

--- a/litebox_broker_local/src/lib.rs
+++ b/litebox_broker_local/src/lib.rs
@@ -249,7 +249,7 @@ mod tests {
     fn notification_receiver_returns_broker_notifications() {
         let notification = BrokerNotification::Readiness(ReadinessNotification {
             handle: ObjectHandle(7),
-            events: ReadinessFlags::READ,
+            readiness: ReadinessFlags::READ,
         });
         let mut receiver = BrokerNotifications::new(FakeNotificationChannel {
             notification: Some(notification.clone()),

--- a/litebox_broker_protocol/src/event.rs
+++ b/litebox_broker_protocol/src/event.rs
@@ -2,15 +2,7 @@
 // Licensed under the MIT license.
 
 use crate::ObjectHandle;
-
-/// Broker-authoritative readiness state for one object.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub struct ReadinessState {
-    /// Whether an event read/consume operation can complete without blocking.
-    pub read_ready: bool,
-    /// Whether an event write/add operation can complete without blocking.
-    pub write_ready: bool,
-}
+use crate::readiness::ReadinessFlags;
 
 /// How a broker event consume operation should remove readiness credits.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -46,7 +38,7 @@ pub struct WaitEventRequest {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct WaitEventResponse {
     /// Current readiness state.
-    pub readiness: ReadinessState,
+    pub readiness: ReadinessFlags,
 }
 
 /// Request to add readiness credits to an event.
@@ -62,7 +54,7 @@ pub struct AddEventRequest {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct AddEventResponse {
     /// Readiness state after adding credits.
-    pub readiness: ReadinessState,
+    pub readiness: ReadinessFlags,
 }
 
 /// Request to consume readiness credits from an event.
@@ -80,7 +72,7 @@ pub struct EventConsumption {
     /// Number of readiness credits consumed.
     pub value: u64,
     /// Readiness state after consuming credits.
-    pub readiness: ReadinessState,
+    pub readiness: ReadinessFlags,
 }
 
 /// Response to an event consume request.

--- a/litebox_broker_protocol/src/lib.rs
+++ b/litebox_broker_protocol/src/lib.rs
@@ -16,6 +16,7 @@ pub mod channel;
 pub mod error;
 pub mod event;
 pub mod message;
+pub mod readiness;
 pub mod wire;
 
 /// Opaque broker object reference handle.

--- a/litebox_broker_protocol/src/message.rs
+++ b/litebox_broker_protocol/src/message.rs
@@ -103,5 +103,5 @@ pub struct ReadinessNotification {
     /// Broker object handle.
     pub handle: ObjectHandle,
     /// Current broker-authoritative readiness snapshot.
-    pub events: ReadinessFlags,
+    pub readiness: ReadinessFlags,
 }

--- a/litebox_broker_protocol/src/message.rs
+++ b/litebox_broker_protocol/src/message.rs
@@ -4,8 +4,9 @@
 use crate::error::ErrorCode;
 use crate::event::{
     AddEventRequest, AddEventResponse, ConsumeEventRequest, ConsumeEventResponse,
-    CreateEventRequest, CreateEventResponse, ReadinessState, WaitEventRequest, WaitEventResponse,
+    CreateEventRequest, CreateEventResponse, WaitEventRequest, WaitEventResponse,
 };
+use crate::readiness::ReadinessFlags;
 use crate::{ObjectHandle, ProtocolVersion};
 
 /// Broker handshake request sent before the control channel is active.
@@ -92,15 +93,15 @@ pub enum EventResponse {
 /// re-check authoritative state, not as ordered state transitions.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum BrokerNotification {
-    /// Readiness changed or should be re-checked for a broker-owned event object.
-    EventReadiness(EventReadinessNotification),
+    /// Readiness changed or should be re-checked for a broker-owned object.
+    Readiness(ReadinessNotification),
 }
 
-/// Readiness notification for a broker-owned event object.
+/// Readiness notification for a broker-owned object.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct EventReadinessNotification {
-    /// Event object handle.
+pub struct ReadinessNotification {
+    /// Broker object handle.
     pub handle: ObjectHandle,
     /// Current broker-authoritative readiness snapshot.
-    pub readiness: ReadinessState,
+    pub events: ReadinessFlags,
 }

--- a/litebox_broker_protocol/src/readiness.rs
+++ b/litebox_broker_protocol/src/readiness.rs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/// ABI-neutral broker object readiness flags.
+///
+/// Unknown bits are preserved so protocol peers can ignore readiness kinds they
+/// do not understand.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ReadinessFlags(pub u32);
+
+impl ReadinessFlags {
+    /// Data can be read without blocking.
+    pub const READ: Self = Self(1 << 0);
+    /// Data can be written without blocking.
+    pub const WRITE: Self = Self(1 << 1);
+    /// The peer closed its write side.
+    pub const HANGUP: Self = Self(1 << 2);
+    /// The object is in an error state.
+    pub const ERROR: Self = Self(1 << 3);
+}
+
+impl core::ops::BitOr for ReadinessFlags {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        Self(self.0 | rhs.0)
+    }
+}

--- a/litebox_broker_protocol/src/wire.rs
+++ b/litebox_broker_protocol/src/wire.rs
@@ -21,8 +21,9 @@ use thiserror::Error;
 use crate::error::ErrorCode;
 use crate::message::{
     BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerNotification, BrokerRequest,
-    BrokerResponse, EventReadinessNotification,
+    BrokerResponse, ReadinessNotification,
 };
+use crate::readiness::ReadinessFlags;
 
 use primitive::{Decoder, Encoder};
 
@@ -39,7 +40,7 @@ const RESPONSE_TAG_ERROR: u8 = 2;
 const RESPONSE_TAG_VERSION_MISMATCH: u8 = 3;
 const RESPONSE_TAG_OBJECT_CLOSED: u8 = 4;
 
-const NOTIFICATION_TAG_EVENT_READINESS: u8 = 0;
+const NOTIFICATION_TAG_READINESS: u8 = 0;
 
 /// Error produced while encoding or decoding a broker wire message.
 #[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
@@ -49,8 +50,6 @@ pub enum WireError {
     TruncatedFrame,
     #[error("trailing broker wire bytes")]
     TrailingBytes,
-    #[error("invalid broker wire boolean")]
-    InvalidBoolean,
     #[error("invalid broker wire tag")]
     InvalidTag,
     #[error("broker wire message is not valid in this protocol phase")]
@@ -218,10 +217,10 @@ pub fn decode_response(frame: &[u8]) -> Result<BrokerResponse, WireError> {
 pub fn encode_notification(notification: BrokerNotification) -> Vec<u8> {
     let mut encoder = Encoder::default();
     match notification {
-        BrokerNotification::EventReadiness(notification) => {
-            encoder.u8(NOTIFICATION_TAG_EVENT_READINESS);
+        BrokerNotification::Readiness(notification) => {
+            encoder.u8(NOTIFICATION_TAG_READINESS);
             encoder.handle(notification.handle);
-            event::encode_readiness(&mut encoder, notification.readiness);
+            encoder.u32(notification.events.0);
         }
     }
     encoder.finish()
@@ -232,12 +231,10 @@ pub fn decode_notification(frame: &[u8]) -> Result<BrokerNotification, WireError
     let mut decoder = Decoder::new(frame);
     let tag = decoder.u8()?;
     let notification = match tag {
-        NOTIFICATION_TAG_EVENT_READINESS => {
-            BrokerNotification::EventReadiness(EventReadinessNotification {
-                handle: decoder.handle()?,
-                readiness: event::decode_readiness(&mut decoder)?,
-            })
-        }
+        NOTIFICATION_TAG_READINESS => BrokerNotification::Readiness(ReadinessNotification {
+            handle: decoder.handle()?,
+            events: ReadinessFlags(decoder.u32()?),
+        }),
         _ => return Err(WireError::InvalidTag),
     };
     decoder.finish()?;
@@ -249,7 +246,7 @@ mod tests {
     use super::*;
     use crate::event::{
         AddEventRequest, AddEventResponse, ConsumeEventRequest, CreateEventRequest,
-        CreateEventResponse, EventConsumeMode, EventConsumption, ReadinessState, WaitEventRequest,
+        CreateEventResponse, EventConsumeMode, EventConsumption, WaitEventRequest,
         WaitEventResponse,
     };
     use crate::message::{EventRequest, EventResponse};
@@ -328,29 +325,17 @@ mod tests {
             BrokerResponse::ObjectClosed,
             BrokerResponse::Event(EventResponse::Create(CreateEventResponse { handle })),
             BrokerResponse::Event(EventResponse::Wait(WaitEventResponse {
-                readiness: ReadinessState {
-                    read_ready: true,
-                    write_ready: false,
-                },
+                readiness: ReadinessFlags::READ,
             })),
             BrokerResponse::Event(EventResponse::Wait(WaitEventResponse {
-                readiness: ReadinessState {
-                    read_ready: false,
-                    write_ready: true,
-                },
+                readiness: ReadinessFlags::WRITE,
             })),
             BrokerResponse::Event(EventResponse::Add(AddEventResponse {
-                readiness: ReadinessState {
-                    read_ready: true,
-                    write_ready: true,
-                },
+                readiness: ReadinessFlags::READ | ReadinessFlags::WRITE,
             })),
             BrokerResponse::Event(EventResponse::Consume(EventConsumption {
                 value: 3,
-                readiness: ReadinessState {
-                    read_ready: false,
-                    write_ready: true,
-                },
+                readiness: ReadinessFlags::WRITE,
             })),
             BrokerResponse::Error(ErrorCode::PolicyDenied),
             BrokerResponse::Error(ErrorCode::WouldBlock),
@@ -368,15 +353,10 @@ mod tests {
     #[test]
     fn notification_codec_round_trips_all_variants() {
         let handle = ObjectHandle(13);
-        let notifications = [BrokerNotification::EventReadiness(
-            EventReadinessNotification {
-                handle,
-                readiness: ReadinessState {
-                    read_ready: true,
-                    write_ready: false,
-                },
-            },
-        )];
+        let notifications = [BrokerNotification::Readiness(ReadinessNotification {
+            handle,
+            events: ReadinessFlags::READ | ReadinessFlags::HANGUP,
+        })];
 
         for notification in notifications {
             assert_eq!(
@@ -498,22 +478,21 @@ mod tests {
         );
         assert_eq!(
             decode_response(&[1, 1, 0xff]),
-            Err(WireError::InvalidBoolean)
+            Err(WireError::TruncatedFrame)
         );
         assert_eq!(
             decode_response(&[2, 0xff, 0xff]),
             Err(WireError::InvalidTag)
         );
 
-        let mut invalid_bool = [1, 2, 2, 0];
-        assert_eq!(
-            decode_response(&invalid_bool),
-            Err(WireError::InvalidBoolean)
-        );
+        let truncated = [1, 2, 2, 0];
+        assert_eq!(decode_response(&truncated), Err(WireError::TruncatedFrame));
 
-        invalid_bool[2] = 1;
-        invalid_bool[3] = 1;
-        let mut frame = invalid_bool.to_vec();
+        let mut frame = encode_response(BrokerResponse::Event(EventResponse::Add(
+            AddEventResponse {
+                readiness: ReadinessFlags::READ | ReadinessFlags::WRITE,
+            },
+        )));
         frame.push(0xff);
         assert_eq!(decode_response(&frame), Err(WireError::TrailingBytes));
     }
@@ -525,34 +504,26 @@ mod tests {
             Err(WireError::InvalidTag)
         );
         assert_eq!(
-            decode_notification(&[NOTIFICATION_TAG_EVENT_READINESS]),
+            decode_notification(&[NOTIFICATION_TAG_READINESS]),
             Err(WireError::TruncatedFrame)
         );
 
-        let mut invalid_bool = encode_notification(BrokerNotification::EventReadiness(
-            EventReadinessNotification {
+        let mut truncated =
+            encode_notification(BrokerNotification::Readiness(ReadinessNotification {
                 handle: ObjectHandle(13),
-                readiness: ReadinessState {
-                    read_ready: true,
-                    write_ready: false,
-                },
-            },
-        ));
-        *invalid_bool.last_mut().unwrap() = 0xff;
+                events: ReadinessFlags::READ,
+            }));
+        truncated.pop();
         assert_eq!(
-            decode_notification(&invalid_bool),
-            Err(WireError::InvalidBoolean)
+            decode_notification(&truncated),
+            Err(WireError::TruncatedFrame)
         );
 
-        let mut trailing = encode_notification(BrokerNotification::EventReadiness(
-            EventReadinessNotification {
+        let mut trailing =
+            encode_notification(BrokerNotification::Readiness(ReadinessNotification {
                 handle: ObjectHandle(13),
-                readiness: ReadinessState {
-                    read_ready: true,
-                    write_ready: false,
-                },
-            },
-        ));
+                events: ReadinessFlags::READ,
+            }));
         trailing.push(0xff);
         assert_eq!(
             decode_notification(&trailing),
@@ -565,29 +536,21 @@ mod tests {
         assert_eq!(
             encode_response(BrokerResponse::Event(EventResponse::Add(
                 AddEventResponse {
-                    readiness: ReadinessState {
-                        read_ready: true,
-                        write_ready: false,
-                    },
+                    readiness: ReadinessFlags::READ,
                 }
             ))),
-            [1, 2, 1, 0]
+            [1, 2, 1, 0, 0, 0]
         );
     }
 
     #[test]
-    fn event_readiness_notification_wire_shape_is_pinned() {
+    fn readiness_notification_wire_shape_is_pinned() {
         assert_eq!(
-            encode_notification(BrokerNotification::EventReadiness(
-                EventReadinessNotification {
-                    handle: ObjectHandle(13),
-                    readiness: ReadinessState {
-                        read_ready: true,
-                        write_ready: false,
-                    },
-                }
-            )),
-            [0, 13, 0, 0, 0, 0, 0, 0, 0, 1, 0]
+            encode_notification(BrokerNotification::Readiness(ReadinessNotification {
+                handle: ObjectHandle(13),
+                events: ReadinessFlags::READ | ReadinessFlags::HANGUP,
+            })),
+            [0, 13, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0]
         );
     }
 }

--- a/litebox_broker_protocol/src/wire.rs
+++ b/litebox_broker_protocol/src/wire.rs
@@ -220,7 +220,7 @@ pub fn encode_notification(notification: BrokerNotification) -> Vec<u8> {
         BrokerNotification::Readiness(notification) => {
             encoder.u8(NOTIFICATION_TAG_READINESS);
             encoder.handle(notification.handle);
-            encoder.u32(notification.events.0);
+            encoder.u32(notification.readiness.0);
         }
     }
     encoder.finish()
@@ -233,7 +233,7 @@ pub fn decode_notification(frame: &[u8]) -> Result<BrokerNotification, WireError
     let notification = match tag {
         NOTIFICATION_TAG_READINESS => BrokerNotification::Readiness(ReadinessNotification {
             handle: decoder.handle()?,
-            events: ReadinessFlags(decoder.u32()?),
+            readiness: ReadinessFlags(decoder.u32()?),
         }),
         _ => return Err(WireError::InvalidTag),
     };
@@ -355,7 +355,7 @@ mod tests {
         let handle = ObjectHandle(13);
         let notifications = [BrokerNotification::Readiness(ReadinessNotification {
             handle,
-            events: ReadinessFlags::READ | ReadinessFlags::HANGUP,
+            readiness: ReadinessFlags::READ | ReadinessFlags::HANGUP,
         })];
 
         for notification in notifications {
@@ -511,7 +511,7 @@ mod tests {
         let mut truncated =
             encode_notification(BrokerNotification::Readiness(ReadinessNotification {
                 handle: ObjectHandle(13),
-                events: ReadinessFlags::READ,
+                readiness: ReadinessFlags::READ,
             }));
         truncated.pop();
         assert_eq!(
@@ -522,7 +522,7 @@ mod tests {
         let mut trailing =
             encode_notification(BrokerNotification::Readiness(ReadinessNotification {
                 handle: ObjectHandle(13),
-                events: ReadinessFlags::READ,
+                readiness: ReadinessFlags::READ,
             }));
         trailing.push(0xff);
         assert_eq!(
@@ -548,7 +548,7 @@ mod tests {
         assert_eq!(
             encode_notification(BrokerNotification::Readiness(ReadinessNotification {
                 handle: ObjectHandle(13),
-                events: ReadinessFlags::READ | ReadinessFlags::HANGUP,
+                readiness: ReadinessFlags::READ | ReadinessFlags::HANGUP,
             })),
             [0, 13, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0]
         );

--- a/litebox_broker_protocol/src/wire/event.rs
+++ b/litebox_broker_protocol/src/wire/event.rs
@@ -3,10 +3,10 @@
 
 use crate::event::{
     AddEventRequest, AddEventResponse, ConsumeEventRequest, CreateEventRequest,
-    CreateEventResponse, EventConsumeMode, EventConsumption, ReadinessState, WaitEventRequest,
-    WaitEventResponse,
+    CreateEventResponse, EventConsumeMode, EventConsumption, WaitEventRequest, WaitEventResponse,
 };
 use crate::message::{EventRequest, EventResponse};
+use crate::readiness::ReadinessFlags;
 
 use super::WireError;
 use super::primitive::{Decoder, Encoder};
@@ -79,16 +79,16 @@ pub(super) fn encode_event_response(encoder: &mut Encoder, response: EventRespon
         }
         EventResponse::Wait(response) => {
             encoder.u8(EVENT_RESPONSE_TAG_WAITED);
-            encode_readiness(encoder, response.readiness);
+            encoder.u32(response.readiness.0);
         }
         EventResponse::Add(response) => {
             encoder.u8(EVENT_RESPONSE_TAG_ADDED);
-            encode_readiness(encoder, response.readiness);
+            encoder.u32(response.readiness.0);
         }
         EventResponse::Consume(response) => {
             encoder.u8(EVENT_RESPONSE_TAG_CONSUMED);
             encoder.u64(response.value);
-            encode_readiness(encoder, response.readiness);
+            encoder.u32(response.readiness.0);
         }
     }
 }
@@ -99,31 +99,19 @@ pub(super) fn decode_event_response(decoder: &mut Decoder<'_>) -> Result<EventRe
             handle: decoder.handle()?,
         }),
         EVENT_RESPONSE_TAG_WAITED => EventResponse::Wait(WaitEventResponse {
-            readiness: decode_readiness(decoder)?,
+            readiness: ReadinessFlags(decoder.u32()?),
         }),
         EVENT_RESPONSE_TAG_ADDED => EventResponse::Add(AddEventResponse {
-            readiness: decode_readiness(decoder)?,
+            readiness: ReadinessFlags(decoder.u32()?),
         }),
         EVENT_RESPONSE_TAG_CONSUMED => EventResponse::Consume(EventConsumption {
             value: decoder.u64()?,
-            readiness: decode_readiness(decoder)?,
+            readiness: ReadinessFlags(decoder.u32()?),
         }),
         _ => return Err(WireError::InvalidTag),
     };
 
     Ok(response)
-}
-
-pub(super) fn encode_readiness(encoder: &mut Encoder, readiness: ReadinessState) {
-    encoder.bool(readiness.read_ready);
-    encoder.bool(readiness.write_ready);
-}
-
-pub(super) fn decode_readiness(decoder: &mut Decoder<'_>) -> Result<ReadinessState, WireError> {
-    Ok(ReadinessState {
-        read_ready: decoder.bool()?,
-        write_ready: decoder.bool()?,
-    })
 }
 
 fn encode_consume_mode(encoder: &mut Encoder, mode: EventConsumeMode) {

--- a/litebox_broker_protocol/src/wire/primitive.rs
+++ b/litebox_broker_protocol/src/wire/primitive.rs
@@ -17,15 +17,15 @@ impl Encoder {
         self.bytes
     }
 
-    pub(super) fn bool(&mut self, value: bool) {
-        self.u8(u8::from(value));
-    }
-
     pub(super) fn u8(&mut self, value: u8) {
         self.bytes.push(value);
     }
 
     pub(super) fn u16(&mut self, value: u16) {
+        self.bytes.extend_from_slice(&value.to_le_bytes());
+    }
+
+    pub(super) fn u32(&mut self, value: u32) {
         self.bytes.extend_from_slice(&value.to_le_bytes());
     }
 
@@ -60,14 +60,6 @@ impl<'a> Decoder<'a> {
         }
     }
 
-    pub(super) fn bool(&mut self) -> Result<bool, WireError> {
-        match self.u8()? {
-            0 => Ok(false),
-            1 => Ok(true),
-            _ => Err(WireError::InvalidBoolean),
-        }
-    }
-
     pub(super) fn u8(&mut self) -> Result<u8, WireError> {
         let bytes = self.take(1)?;
         Ok(bytes[0])
@@ -76,6 +68,11 @@ impl<'a> Decoder<'a> {
     pub(super) fn u16(&mut self) -> Result<u16, WireError> {
         let bytes = self.take(2)?;
         Ok(u16::from_le_bytes([bytes[0], bytes[1]]))
+    }
+
+    pub(super) fn u32(&mut self) -> Result<u32, WireError> {
+        let bytes = self.take(4)?;
+        Ok(u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]))
     }
 
     pub(super) fn u64(&mut self) -> Result<u64, WireError> {

--- a/litebox_broker_transport/src/unix_socket.rs
+++ b/litebox_broker_transport/src/unix_socket.rs
@@ -446,7 +446,7 @@ mod tests {
         let notification = BrokerNotification::Readiness(
             litebox_broker_protocol::message::ReadinessNotification {
                 handle: litebox_broker_protocol::ObjectHandle(7),
-                events: litebox_broker_protocol::readiness::ReadinessFlags::READ,
+                readiness: litebox_broker_protocol::readiness::ReadinessFlags::READ,
             },
         );
 

--- a/litebox_broker_transport/src/unix_socket.rs
+++ b/litebox_broker_transport/src/unix_socket.rs
@@ -443,13 +443,10 @@ mod tests {
         let (local_stream, host_stream) = UnixStream::pair().unwrap();
         let mut local = UnixStreamLocalNotificationChannel::from_connected(local_stream);
         let mut host = UnixStreamHostNotificationChannel::from_accepted(host_stream);
-        let notification = BrokerNotification::EventReadiness(
-            litebox_broker_protocol::message::EventReadinessNotification {
+        let notification = BrokerNotification::Readiness(
+            litebox_broker_protocol::message::ReadinessNotification {
                 handle: litebox_broker_protocol::ObjectHandle(7),
-                readiness: litebox_broker_protocol::event::ReadinessState {
-                    read_ready: true,
-                    write_ready: false,
-                },
+                events: litebox_broker_protocol::readiness::ReadinessFlags::READ,
             },
         );
 

--- a/litebox_broker_userland/tests/notification_runtime.rs
+++ b/litebox_broker_userland/tests/notification_runtime.rs
@@ -6,7 +6,7 @@ use std::os::unix::net::UnixStream;
 use litebox_broker_core::{BrokerCore, ObjectRights, PolicyEngine};
 use litebox_broker_host::{ConnectionTermination, serve_connection};
 use litebox_broker_local::BrokerLocal;
-use litebox_broker_protocol::event::ReadinessState;
+use litebox_broker_protocol::readiness::ReadinessFlags;
 use litebox_broker_transport::unix_socket::{
     UnixStreamHostControlChannel, UnixStreamHostNotificationChannel, UnixStreamLocalControlChannel,
 };
@@ -31,10 +31,7 @@ fn host_serves_control_requests_over_paired_userland_channels() {
             .unwrap();
 
     let handle = local.create_event_with_count(0).unwrap();
-    let readiness = ReadinessState {
-        read_ready: true,
-        write_ready: true,
-    };
+    let readiness = ReadinessFlags::READ | ReadinessFlags::WRITE;
     assert_eq!(local.add_event(handle, 1).unwrap(), readiness);
 
     drop(local);

--- a/litebox_broker_userland/tests/userland_broker.rs
+++ b/litebox_broker_userland/tests/userland_broker.rs
@@ -9,7 +9,7 @@ use std::process::{Child, Command};
 use std::time::{Duration, Instant};
 
 use litebox_broker_local::BrokerLocal;
-use litebox_broker_protocol::event::ReadinessState;
+use litebox_broker_protocol::readiness::ReadinessFlags;
 use litebox_broker_transport::unix_socket::{
     UnixStreamLocalControlChannel, UnixStreamLocalNotificationChannel,
 };
@@ -84,26 +84,14 @@ fn run_fake_runner(args: &[OsString]) {
     let mut local = BrokerLocal::negotiate(control_channel).unwrap();
 
     let handle = local.create_event_with_count(0).unwrap();
-    assert_eq!(
-        local.wait_event(handle).unwrap(),
-        ReadinessState {
-            read_ready: false,
-            write_ready: true,
-        }
-    );
+    assert_eq!(local.wait_event(handle).unwrap(), ReadinessFlags::WRITE);
 
-    let readiness = ReadinessState {
-        read_ready: true,
-        write_ready: true,
-    };
+    let readiness = ReadinessFlags::READ | ReadinessFlags::WRITE;
     assert_eq!(local.add_event(handle, 1).unwrap(), readiness);
 
     assert_eq!(
         local.wait_event(handle).unwrap(),
-        ReadinessState {
-            read_ready: true,
-            write_ready: true,
-        }
+        ReadinessFlags::READ | ReadinessFlags::WRITE
     );
     drop(local);
 


### PR DESCRIPTION
This PR gives broker-backed objects one shared readiness flag representation across control responses and asynchronous notifications. Existing event counters are migrated to the object-neutral format.