### PR TITLE
Fix pipe edge-case semantics

### DIFF
--- a/litebox/src/pipes.rs
+++ b/litebox/src/pipes.rs
@@ -657,23 +657,6 @@ mod tests {
     }
 
     #[test]
-    fn local_pipe_rejects_operations_on_the_wrong_endpoint() {
-        let platform = crate::platform::mock::MockPlatform::new();
-        let litebox = crate::LiteBox::new(platform);
-        let pipes = super::Pipes::new(&litebox);
-        let (writer, reader) = pipes.create_pipe(2, super::Flags::empty(), None);
-
-        assert!(matches!(
-            pipes.read(&WaitState::new(platform).context(), &writer, &mut [0]),
-            Err(ReadError::NotForReading)
-        ));
-        assert!(matches!(
-            pipes.write(&WaitState::new(platform).context(), &reader, &[1]),
-            Err(WriteError::NotForWriting)
-        ));
-    }
-
-    #[test]
     fn test_blocking_channel() {
         let platform = crate::platform::mock::MockPlatform::new();
         let litebox = &crate::LiteBox::new(platform);
@@ -684,16 +667,11 @@ mod tests {
         std::thread::scope(|scope| {
             scope.spawn(move || {
                 let data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-                let mut i = 0;
-                while i < data.len() {
-                    let ret = pipes
-                        .write(&WaitState::new(platform).context(), &prod, &data[i..])
-                        .unwrap();
-                    assert_eq!(ret, data.len() - i);
-                    i += ret;
-                }
+                let written = pipes
+                    .write(&WaitState::new(platform).context(), &prod, &data)
+                    .unwrap();
+                assert_eq!(written, data.len());
                 pipes.close(&prod).unwrap();
-                assert_eq!(i, data.len());
             });
 
             let mut buf = [0; 10];

--- a/litebox/src/pipes.rs
+++ b/litebox/src/pipes.rs
@@ -403,11 +403,11 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider, T> WriteEnd<Platform, T
         if self.is_shutdown() {
             return Err(TryOpError::Other(PipeError::ThisEndShutdown));
         }
-        if self.is_peer_shutdown() {
-            return Err(TryOpError::Other(PipeError::PeerShutdown));
-        }
         if buf.is_empty() {
             return Ok(0);
+        }
+        if self.is_peer_shutdown() {
+            return Err(TryOpError::Other(PipeError::PeerShutdown));
         }
 
         let write_len = {
@@ -437,15 +437,25 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider, T> WriteEnd<Platform, T
     where
         T: Copy,
     {
-        self.endpoint
-            .pollee
-            .wait(
-                cx,
-                self.get_status().contains(OFlags::NONBLOCK),
-                Events::OUT,
-                || self.try_write(buf),
-            )
-            .map_err(PipeError::from)
+        if self.get_status().contains(OFlags::NONBLOCK) {
+            return self
+                .endpoint
+                .pollee
+                .wait(cx, true, Events::OUT, || self.try_write(buf))
+                .map_err(PipeError::from);
+        }
+
+        let mut total_written = 0;
+        while total_written < buf.len() {
+            match self.endpoint.pollee.wait(cx, false, Events::OUT, || {
+                self.try_write(&buf[total_written..])
+            }) {
+                Ok(written) => total_written += written,
+                Err(_) if total_written != 0 => return Ok(total_written),
+                Err(error) => return Err(PipeError::from(error)),
+            }
+        }
+        Ok(total_written)
     }
 
     common_functions_for_channel!();
@@ -629,6 +639,41 @@ mod tests {
     extern crate std;
 
     #[test]
+    fn local_zero_length_write_succeeds_after_reader_closes() {
+        let platform = crate::platform::mock::MockPlatform::new();
+        let litebox = crate::LiteBox::new(platform);
+        let pipes = super::Pipes::new(&litebox);
+        let (writer, reader) = pipes.create_pipe(2, super::Flags::empty(), None);
+
+        pipes.close(&reader).unwrap();
+
+        assert_eq!(
+            pipes
+                .write(&WaitState::new(platform).context(), &writer, &[])
+                .unwrap(),
+            0
+        );
+        pipes.close(&writer).unwrap();
+    }
+
+    #[test]
+    fn local_pipe_rejects_operations_on_the_wrong_endpoint() {
+        let platform = crate::platform::mock::MockPlatform::new();
+        let litebox = crate::LiteBox::new(platform);
+        let pipes = super::Pipes::new(&litebox);
+        let (writer, reader) = pipes.create_pipe(2, super::Flags::empty(), None);
+
+        assert!(matches!(
+            pipes.read(&WaitState::new(platform).context(), &writer, &mut [0]),
+            Err(ReadError::NotForReading)
+        ));
+        assert!(matches!(
+            pipes.write(&WaitState::new(platform).context(), &reader, &[1]),
+            Err(WriteError::NotForWriting)
+        ));
+    }
+
+    #[test]
     fn test_blocking_channel() {
         let platform = crate::platform::mock::MockPlatform::new();
         let litebox = &crate::LiteBox::new(platform);
@@ -644,6 +689,7 @@ mod tests {
                     let ret = pipes
                         .write(&WaitState::new(platform).context(), &prod, &data[i..])
                         .unwrap();
+                    assert_eq!(ret, data.len() - i);
                     i += ret;
                 }
                 pipes.close(&prod).unwrap();

--- a/litebox_common_linux/src/errno/mod.rs
+++ b/litebox_common_linux/src/errno/mod.rs
@@ -621,20 +621,3 @@ impl From<litebox::fs::errors::TruncateError> for Errno {
         }
     }
 }
-
-#[cfg(test)]
-mod pipe_tests {
-    use super::Errno;
-
-    #[test]
-    fn invalid_pipe_end_operations_use_ebadf() {
-        assert_eq!(
-            Errno::from(litebox::pipes::errors::ReadError::NotForReading),
-            Errno::EBADF
-        );
-        assert_eq!(
-            Errno::from(litebox::pipes::errors::WriteError::NotForWriting),
-            Errno::EBADF
-        );
-    }
-}

--- a/litebox_common_linux/src/errno/mod.rs
+++ b/litebox_common_linux/src/errno/mod.rs
@@ -576,8 +576,8 @@ impl From<litebox::sync::futex::FutexError> for Errno {
 impl From<litebox::pipes::errors::ReadError> for Errno {
     fn from(value: litebox::pipes::errors::ReadError) -> Self {
         match value {
-            litebox::pipes::errors::ReadError::ClosedFd => Errno::EBADFD,
-            litebox::pipes::errors::ReadError::NotForReading => Errno::EINVAL,
+            litebox::pipes::errors::ReadError::ClosedFd
+            | litebox::pipes::errors::ReadError::NotForReading => Errno::EBADF,
             litebox::pipes::errors::ReadError::WouldBlock => Errno::EWOULDBLOCK,
             _ => todo!(),
         }
@@ -589,7 +589,7 @@ impl From<litebox::pipes::errors::WriteError> for Errno {
         match value {
             litebox::pipes::errors::WriteError::ClosedFd => Errno::EBADF,
             litebox::pipes::errors::WriteError::ReadEndClosed => Errno::EPIPE,
-            litebox::pipes::errors::WriteError::NotForWriting => Errno::EINVAL,
+            litebox::pipes::errors::WriteError::NotForWriting => Errno::EBADF,
             litebox::pipes::errors::WriteError::WouldBlock => Errno::EWOULDBLOCK,
             _ => todo!(),
         }
@@ -619,5 +619,22 @@ impl From<litebox::fs::errors::TruncateError> for Errno {
             litebox::fs::errors::TruncateError::ClosedFd => Errno::EBADF,
             litebox::fs::errors::TruncateError::Io => Errno::EIO,
         }
+    }
+}
+
+#[cfg(test)]
+mod pipe_tests {
+    use super::Errno;
+
+    #[test]
+    fn invalid_pipe_end_operations_use_ebadf() {
+        assert_eq!(
+            Errno::from(litebox::pipes::errors::ReadError::NotForReading),
+            Errno::EBADF
+        );
+        assert_eq!(
+            Errno::from(litebox::pipes::errors::WriteError::NotForWriting),
+            Errno::EBADF
+        );
     }
 }


### PR DESCRIPTION
This PR fixes in-process pipe behavior for blocking writes, zero-length writes after peer closure, and operations on the wrong endpoint.