### PR TITLE
Add broker-backed pipes

### DIFF
--- a/litebox/src/broker/error.rs
+++ b/litebox/src/broker/error.rs
@@ -28,10 +28,14 @@ pub(crate) enum BrokerObjectError {
     InvalidObject,
     #[error("broker object operation would block")]
     WouldBlock,
+    #[error("broker object peer is closed")]
+    PeerClosed,
     #[error("broker object resource exhausted")]
     ResourceExhausted,
     #[error("broker object permission denied")]
     PermissionDenied,
+    #[error("broker memory allocation failed")]
+    OutOfMemory,
 }
 
 impl From<BrokerControlError> for BrokerObjectError {
@@ -48,8 +52,10 @@ impl From<ErrorCode> for BrokerObjectError {
         match error {
             ErrorCode::InvalidRights | ErrorCode::UnknownObject => Self::InvalidObject,
             ErrorCode::WouldBlock => Self::WouldBlock,
+            ErrorCode::PeerClosed => Self::PeerClosed,
             ErrorCode::ResourceExhausted => Self::ResourceExhausted,
             ErrorCode::PolicyDenied => Self::PermissionDenied,
+            ErrorCode::OutOfMemory => Self::OutOfMemory,
             ErrorCode::UnsupportedVersion
             | ErrorCode::MalformedRequest
             | ErrorCode::ProtocolState
@@ -82,9 +88,13 @@ impl From<BrokerObjectError> for EventCounterError {
     fn from(error: BrokerObjectError) -> Self {
         match error {
             BrokerObjectError::WouldBlock => Self::WouldBlock,
-            BrokerObjectError::ResourceExhausted => Self::ResourceExhausted,
+            BrokerObjectError::ResourceExhausted | BrokerObjectError::OutOfMemory => {
+                Self::ResourceExhausted
+            }
             BrokerObjectError::PermissionDenied => Self::PermissionDenied,
-            BrokerObjectError::Control | BrokerObjectError::InvalidObject => Self::Io,
+            BrokerObjectError::Control
+            | BrokerObjectError::InvalidObject
+            | BrokerObjectError::PeerClosed => Self::Io,
         }
     }
 }

--- a/litebox/src/broker/mod.rs
+++ b/litebox/src/broker/mod.rs
@@ -36,7 +36,7 @@ pub(crate) trait BrokerControl: Send + Sync {
         initial_count: u64,
     ) -> core::result::Result<ObjectHandle, BrokerControlError>;
 
-    fn wait_event(
+    fn check_readiness(
         &self,
         handle: ObjectHandle,
     ) -> core::result::Result<ReadinessFlags, BrokerControlError>;
@@ -70,11 +70,6 @@ pub(crate) trait BrokerControl: Send + Sync {
         handle: ObjectHandle,
         data: &[u8],
     ) -> core::result::Result<usize, BrokerControlError>;
-
-    fn check_pipe_readiness(
-        &self,
-        handle: ObjectHandle,
-    ) -> core::result::Result<ReadinessFlags, BrokerControlError>;
 
     fn close_object(&self, handle: ObjectHandle) -> core::result::Result<(), BrokerControlError>;
 
@@ -209,11 +204,11 @@ where
         self.request(|local| local.create_event_with_count(initial_count))
     }
 
-    fn wait_event(
+    fn check_readiness(
         &self,
         handle: ObjectHandle,
     ) -> core::result::Result<ReadinessFlags, BrokerControlError> {
-        self.request(|local| local.wait_event(handle))
+        self.request(|local| local.check_readiness(handle))
     }
 
     fn add_event(
@@ -254,13 +249,6 @@ where
         data: &[u8],
     ) -> core::result::Result<usize, BrokerControlError> {
         self.request(|local| local.write_pipe(handle, data))
-    }
-
-    fn check_pipe_readiness(
-        &self,
-        handle: ObjectHandle,
-    ) -> core::result::Result<ReadinessFlags, BrokerControlError> {
-        self.request(|local| local.check_pipe_readiness(handle))
     }
 
     fn close_object(&self, handle: ObjectHandle) -> core::result::Result<(), BrokerControlError> {

--- a/litebox/src/broker/mod.rs
+++ b/litebox/src/broker/mod.rs
@@ -11,6 +11,7 @@ use litebox_broker_local::BrokerLocal;
 use litebox_broker_protocol::ObjectHandle;
 use litebox_broker_protocol::channel::LocalControlChannel;
 use litebox_broker_protocol::event::{ConsumeEventResponse, EventConsumeMode};
+use litebox_broker_protocol::pipe::CreatePipeResponse;
 use litebox_broker_protocol::readiness::ReadinessFlags;
 
 use crate::event::{Events, polling::Pollee};
@@ -51,6 +52,29 @@ pub(crate) trait BrokerControl: Send + Sync {
         handle: ObjectHandle,
         mode: EventConsumeMode,
     ) -> core::result::Result<ConsumeEventResponse, BrokerControlError>;
+
+    fn create_pipe(
+        &self,
+        capacity: u64,
+        atomic_write_size: u64,
+    ) -> core::result::Result<CreatePipeResponse, BrokerControlError>;
+
+    fn read_pipe(
+        &self,
+        handle: ObjectHandle,
+        length: u32,
+    ) -> core::result::Result<Vec<u8>, BrokerControlError>;
+
+    fn write_pipe(
+        &self,
+        handle: ObjectHandle,
+        data: &[u8],
+    ) -> core::result::Result<usize, BrokerControlError>;
+
+    fn check_pipe_readiness(
+        &self,
+        handle: ObjectHandle,
+    ) -> core::result::Result<ReadinessFlags, BrokerControlError>;
 
     fn close_object(&self, handle: ObjectHandle) -> core::result::Result<(), BrokerControlError>;
 
@@ -206,6 +230,37 @@ where
         mode: EventConsumeMode,
     ) -> core::result::Result<ConsumeEventResponse, BrokerControlError> {
         self.request(|local| local.consume_event(handle, mode))
+    }
+
+    fn create_pipe(
+        &self,
+        capacity: u64,
+        atomic_write_size: u64,
+    ) -> core::result::Result<CreatePipeResponse, BrokerControlError> {
+        self.request(|local| local.create_pipe(capacity, atomic_write_size))
+    }
+
+    fn read_pipe(
+        &self,
+        handle: ObjectHandle,
+        length: u32,
+    ) -> core::result::Result<Vec<u8>, BrokerControlError> {
+        self.request(|local| local.read_pipe(handle, length))
+    }
+
+    fn write_pipe(
+        &self,
+        handle: ObjectHandle,
+        data: &[u8],
+    ) -> core::result::Result<usize, BrokerControlError> {
+        self.request(|local| local.write_pipe(handle, data))
+    }
+
+    fn check_pipe_readiness(
+        &self,
+        handle: ObjectHandle,
+    ) -> core::result::Result<ReadinessFlags, BrokerControlError> {
+        self.request(|local| local.check_pipe_readiness(handle))
     }
 
     fn close_object(&self, handle: ObjectHandle) -> core::result::Result<(), BrokerControlError> {

--- a/litebox/src/event/counter.rs
+++ b/litebox/src/event/counter.rs
@@ -450,7 +450,7 @@ mod tests {
                     }
                 }
                 BrokerRequest::CloseObject(_) => BrokerResponse::ObjectClosed,
-                request @ BrokerRequest::Event(_) => {
+                request @ (BrokerRequest::Event(_) | BrokerRequest::Pipe(_)) => {
                     panic!("unexpected broker request: {request:?}")
                 }
             };

--- a/litebox/src/event/counter.rs
+++ b/litebox/src/event/counter.rs
@@ -159,7 +159,7 @@ where
     fn check_io_events(&self) -> Events {
         let readiness = match self
             .broker
-            .wait_event(self.handle)
+            .check_readiness(self.handle)
             .map_err(|error| self.broker_request_error(error))
         {
             Ok(readiness) => readiness,
@@ -450,6 +450,9 @@ mod tests {
                     }
                 }
                 BrokerRequest::CloseObject(_) => BrokerResponse::ObjectClosed,
+                BrokerRequest::CheckReadiness(_) => {
+                    BrokerResponse::Readiness(ReadinessFlags::WRITE)
+                }
                 request @ (BrokerRequest::Event(_) | BrokerRequest::Pipe(_)) => {
                     panic!("unexpected broker request: {request:?}")
                 }

--- a/litebox/src/pipes.rs
+++ b/litebox/src/pipes.rs
@@ -25,7 +25,7 @@ use thiserror::Error;
 use crate::{
     LiteBox,
     broker::{
-        BrokerControl, BrokerHandleRegistry,
+        BrokerControl, BrokerPollableRegistry,
         error::{BrokerControlError, BrokerObjectError},
         readiness_events,
     },
@@ -78,7 +78,7 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> Pipes<Platform> {
         let (sender, receiver) = if let Some(broker) = self.litebox.broker_control() {
             let (sender, receiver) = new_broker_pipe(
                 broker,
-                self.litebox.broker_handle_registry(),
+                self.litebox.broker_pollable_registry(),
                 capacity,
                 OFlags::from(flags),
                 atomic_slice_guarantee_size,
@@ -334,7 +334,7 @@ pub mod errors {
 struct BrokerPipeEnd<Platform: RawSyncPrimitivesProvider + TimeProvider> {
     broker: Arc<dyn BrokerControl>,
     handle: ObjectHandle,
-    registry: Arc<BrokerHandleRegistry<Platform>>,
+    pollable_registry: Arc<BrokerPollableRegistry<Platform>>,
     pollee: Arc<Pollee<Platform>>,
     peer: Weak<Self>,
     endpoint_type: HalfPipeType,
@@ -347,7 +347,7 @@ struct BrokerPipeEnd<Platform: RawSyncPrimitivesProvider + TimeProvider> {
 )]
 fn new_broker_pipe<Platform: RawSyncPrimitivesProvider + TimeProvider>(
     broker: Arc<dyn BrokerControl>,
-    registry: Arc<BrokerHandleRegistry<Platform>>,
+    pollable_registry: Arc<BrokerPollableRegistry<Platform>>,
     capacity: usize,
     flags: OFlags,
     atomic_slice_guarantee_size: Option<NonZeroUsize>,
@@ -373,7 +373,7 @@ fn new_broker_pipe<Platform: RawSyncPrimitivesProvider + TimeProvider>(
     let mut writer = Arc::new(BrokerPipeEnd {
         broker: Arc::clone(&broker),
         handle: response.write_handle,
-        registry: Arc::clone(&registry),
+        pollable_registry: Arc::clone(&pollable_registry),
         pollee: Arc::new(Pollee::new()),
         peer: Weak::new(),
         endpoint_type: HalfPipeType::SenderHalf,
@@ -386,7 +386,7 @@ fn new_broker_pipe<Platform: RawSyncPrimitivesProvider + TimeProvider>(
         BrokerPipeEnd {
             broker,
             handle: response.read_handle,
-            registry: Arc::clone(&registry),
+            pollable_registry: Arc::clone(&pollable_registry),
             pollee: Arc::new(Pollee::new()),
             peer: Arc::downgrade(&writer),
             endpoint_type: HalfPipeType::ReceiverHalf,
@@ -394,8 +394,8 @@ fn new_broker_pipe<Platform: RawSyncPrimitivesProvider + TimeProvider>(
         }
     });
 
-    registry.register_pollable(response.write_handle, &writer.pollee);
-    registry.register_pollable(response.read_handle, &reader.pollee);
+    pollable_registry.register_pollable(response.write_handle, &writer.pollee);
+    pollable_registry.register_pollable(response.read_handle, &reader.pollee);
     Ok((writer, reader))
 }
 
@@ -521,7 +521,7 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> IOPollable for BrokerPi
 
 impl<Platform: RawSyncPrimitivesProvider + TimeProvider> Drop for BrokerPipeEnd<Platform> {
     fn drop(&mut self) {
-        self.registry.unregister_pollable(self.handle, &self.pollee);
+        self.pollable_registry.unregister_pollable(self.handle);
         let _ = self.broker.close_object(self.handle);
         if let Some(peer) = self.peer.upgrade() {
             let event = match self.endpoint_type {
@@ -1078,7 +1078,7 @@ mod tests {
             litebox.dispatch_broker_notification(BrokerNotification::Readiness(
                 ReadinessNotification {
                     handle: ObjectHandle(1),
-                    events: ReadinessFlags::READ,
+                    readiness: ReadinessFlags::READ,
                 },
             ));
             let deadline = std::time::Instant::now() + std::time::Duration::from_secs(1);
@@ -1206,7 +1206,9 @@ mod tests {
                     }
                 },
                 BrokerRequest::CloseObject(_) => Ok(Some(BrokerResponse::ObjectClosed)),
-                request => panic!("unexpected broker request: {request:?}"),
+                request @ (BrokerRequest::Pipe(_) | BrokerRequest::Event(_)) => {
+                    panic!("unexpected broker request: {request:?}")
+                }
             }
         }
     }

--- a/litebox/src/pipes.rs
+++ b/litebox/src/pipes.rs
@@ -502,7 +502,7 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerPipeEnd<Platform>
     }
 
     fn readiness(&self) -> Result<ReadinessFlags, BrokerControlError> {
-        self.broker.check_pipe_readiness(self.handle)
+        self.broker.check_readiness(self.handle)
     }
 }
 
@@ -1206,6 +1206,9 @@ mod tests {
                     }
                 },
                 BrokerRequest::CloseObject(_) => Ok(Some(BrokerResponse::ObjectClosed)),
+                BrokerRequest::CheckReadiness(_) => {
+                    Ok(Some(BrokerResponse::Readiness(ReadinessFlags::default())))
+                }
                 request @ (BrokerRequest::Pipe(_) | BrokerRequest::Event(_)) => {
                     panic!("unexpected broker request: {request:?}")
                 }

--- a/litebox/src/pipes.rs
+++ b/litebox/src/pipes.rs
@@ -12,6 +12,10 @@ use core::{
 };
 
 use alloc::sync::{Arc, Weak};
+use either::Either;
+use litebox_broker_protocol::{
+    ObjectHandle, pipe::MAX_PIPE_TRANSFER_SIZE, readiness::ReadinessFlags,
+};
 use ringbuf::{
     HeapCons, HeapProd, HeapRb,
     traits::{Consumer as _, Observer as _, Producer as _, Split as _},
@@ -20,6 +24,11 @@ use thiserror::Error;
 
 use crate::{
     LiteBox,
+    broker::{
+        BrokerControl, BrokerHandleRegistry,
+        error::{BrokerControlError, BrokerObjectError},
+        readiness_events,
+    },
     event::{
         Events, IOPollable,
         observer::Observer,
@@ -65,15 +74,31 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> Pipes<Platform> {
         capacity: usize,
         flags: Flags,
         atomic_slice_guarantee_size: Option<NonZeroUsize>,
-    ) -> (PipeFd<Platform>, PipeFd<Platform>) {
-        let (sender, receiver) =
-            new_pipe::<Platform, u8>(capacity, OFlags::from(flags), atomic_slice_guarantee_size);
-        let sender = PipeEnd::Sender(sender);
-        let receiver = PipeEnd::Receiver(receiver);
+    ) -> Result<(PipeFd<Platform>, PipeFd<Platform>), errors::CreateError> {
+        let (sender, receiver) = if let Some(broker) = self.litebox.broker_control() {
+            let (sender, receiver) = new_broker_pipe(
+                broker,
+                self.litebox.broker_handle_registry(),
+                capacity,
+                OFlags::from(flags),
+                atomic_slice_guarantee_size,
+            )?;
+            (
+                PipeEnd::BrokerSender(sender),
+                PipeEnd::BrokerReceiver(receiver),
+            )
+        } else {
+            let (sender, receiver) = new_pipe::<Platform, u8>(
+                capacity,
+                OFlags::from(flags),
+                atomic_slice_guarantee_size,
+            );
+            (PipeEnd::Sender(sender), PipeEnd::Receiver(receiver))
+        };
         let mut dt = self.litebox.descriptor_table_mut();
         let sender = dt.insert(sender);
         let receiver = dt.insert(receiver);
-        (sender, receiver)
+        Ok((sender, receiver))
     }
 
     /// Close the pipe at `fd`.
@@ -99,11 +124,17 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> Pipes<Platform> {
     ) -> Result<usize, errors::ReadError> {
         let dt = self.litebox.descriptor_table();
         let p = match &dt.get_entry(fd).ok_or(errors::ReadError::ClosedFd)?.entry {
-            PipeEnd::Receiver(p) => Arc::clone(p),
-            PipeEnd::Sender(_) => return Err(errors::ReadError::NotForReading),
+            PipeEnd::Receiver(p) => Either::Left(Arc::clone(p)),
+            PipeEnd::BrokerReceiver(p) => Either::Right(Arc::clone(p)),
+            PipeEnd::Sender(_) | PipeEnd::BrokerSender(_) => {
+                return Err(errors::ReadError::NotForReading);
+            }
         };
         drop(dt);
-        p.read(cx, buf).map_err(From::from)
+        match p {
+            Either::Left(p) => p.read(cx, buf).map_err(From::from),
+            Either::Right(p) => p.read(cx, buf).map_err(From::from),
+        }
     }
 
     /// Write the values in `buf` into the pipe, returning the number of elements written.
@@ -117,11 +148,17 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> Pipes<Platform> {
     ) -> Result<usize, errors::WriteError> {
         let dt = self.litebox.descriptor_table();
         let p = match &dt.get_entry(fd).ok_or(errors::WriteError::ClosedFd)?.entry {
-            PipeEnd::Sender(p) => Arc::clone(p),
-            PipeEnd::Receiver(_) => return Err(errors::WriteError::NotForWriting),
+            PipeEnd::Sender(p) => Either::Left(Arc::clone(p)),
+            PipeEnd::BrokerSender(p) => Either::Right(Arc::clone(p)),
+            PipeEnd::Receiver(_) | PipeEnd::BrokerReceiver(_) => {
+                return Err(errors::WriteError::NotForWriting);
+            }
         };
         drop(dt);
-        p.write(cx, buf).map_err(From::from)
+        match p {
+            Either::Left(p) => p.write(cx, buf).map_err(From::from),
+            Either::Right(p) => p.write(cx, buf).map_err(From::from),
+        }
     }
 
     /// Whether the provided FD points to a reader or a writer end.
@@ -131,8 +168,8 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> Pipes<Platform> {
     ) -> Result<HalfPipeType, errors::ClosedError> {
         let dt = self.litebox.descriptor_table();
         match dt.get_entry(fd).ok_or(errors::ClosedError::ClosedFd)?.entry {
-            PipeEnd::Sender(_) => Ok(HalfPipeType::SenderHalf),
-            PipeEnd::Receiver(_) => Ok(HalfPipeType::ReceiverHalf),
+            PipeEnd::Sender(_) | PipeEnd::BrokerSender(_) => Ok(HalfPipeType::SenderHalf),
+            PipeEnd::Receiver(_) | PipeEnd::BrokerReceiver(_) => Ok(HalfPipeType::ReceiverHalf),
         }
     }
 
@@ -142,6 +179,7 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> Pipes<Platform> {
         let oflags = match &dt.get_entry(fd).ok_or(errors::ClosedError::ClosedFd)?.entry {
             PipeEnd::Receiver(p) => p.get_status(),
             PipeEnd::Sender(p) => p.get_status(),
+            PipeEnd::BrokerReceiver(p) | PipeEnd::BrokerSender(p) => p.get_status(),
         };
         Ok(Flags::from_oflags_truncate(oflags))
     }
@@ -159,6 +197,9 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> Pipes<Platform> {
         match &dt.get_entry(fd).ok_or(errors::ClosedError::ClosedFd)?.entry {
             PipeEnd::Receiver(p) => p.set_status(OFlags::from(mask), on),
             PipeEnd::Sender(p) => p.set_status(OFlags::from(mask), on),
+            PipeEnd::BrokerReceiver(p) | PipeEnd::BrokerSender(p) => {
+                p.set_status(OFlags::from(mask), on);
+            }
         }
         Ok(())
     }
@@ -173,6 +214,7 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> Pipes<Platform> {
         match &dt.get_entry(fd).ok_or(errors::ClosedError::ClosedFd)?.entry {
             PipeEnd::Receiver(p) => Ok(f(p)),
             PipeEnd::Sender(p) => Ok(f(p)),
+            PipeEnd::BrokerReceiver(p) | PipeEnd::BrokerSender(p) => Ok(f(p)),
         }
     }
 }
@@ -187,6 +229,8 @@ pub enum HalfPipeType {
 enum PipeEnd<Platform: RawSyncPrimitivesProvider + TimeProvider> {
     Receiver(Arc<ReadEnd<Platform, u8>>),
     Sender(Arc<WriteEnd<Platform, u8>>),
+    BrokerReceiver(Arc<BrokerPipeEnd<Platform>>),
+    BrokerSender(Arc<BrokerPipeEnd<Platform>>),
 }
 
 bitflags::bitflags! {
@@ -226,6 +270,20 @@ pub mod errors {
 
     use thiserror::Error;
 
+    /// Possible errors from [`Pipes::create_pipe`].
+    #[non_exhaustive]
+    #[derive(Error, Debug)]
+    pub enum CreateError {
+        #[error("pipe resource exhausted")]
+        ResourceExhausted,
+        #[error("pipe memory allocation failed")]
+        OutOfMemory,
+        #[error("pipe permission denied")]
+        PermissionDenied,
+        #[error("pipe broker I/O failed")]
+        Io,
+    }
+
     /// Possible errors from [`Pipes::close`]
     #[non_exhaustive]
     #[derive(Error, Debug)]
@@ -243,6 +301,8 @@ pub mod errors {
         WouldBlock,
         #[error("wait error")]
         WaitError(WaitError),
+        #[error("pipe I/O failed")]
+        Io,
     }
 
     /// Possible errors from [`Pipes::write`]
@@ -259,6 +319,8 @@ pub mod errors {
         WouldBlock,
         #[error("wait error")]
         WaitError(WaitError),
+        #[error("pipe I/O failed")]
+        Io,
     }
 
     /// Possible errors from functions that always succeed unless the descriptor is closed.
@@ -266,6 +328,236 @@ pub mod errors {
     pub enum ClosedError {
         #[error("not an open file descriptor")]
         ClosedFd,
+    }
+}
+
+struct BrokerPipeEnd<Platform: RawSyncPrimitivesProvider + TimeProvider> {
+    broker: Arc<dyn BrokerControl>,
+    handle: ObjectHandle,
+    registry: Arc<BrokerHandleRegistry<Platform>>,
+    pollee: Arc<Pollee<Platform>>,
+    peer: Weak<Self>,
+    endpoint_type: HalfPipeType,
+    status: AtomicU32,
+}
+
+#[expect(
+    clippy::type_complexity,
+    reason = "a type alias would not make the two pipe endpoint result clearer"
+)]
+fn new_broker_pipe<Platform: RawSyncPrimitivesProvider + TimeProvider>(
+    broker: Arc<dyn BrokerControl>,
+    registry: Arc<BrokerHandleRegistry<Platform>>,
+    capacity: usize,
+    flags: OFlags,
+    atomic_slice_guarantee_size: Option<NonZeroUsize>,
+) -> Result<(Arc<BrokerPipeEnd<Platform>>, Arc<BrokerPipeEnd<Platform>>), errors::CreateError> {
+    let atomic_write_size = atomic_slice_guarantee_size
+        .map(NonZeroUsize::get)
+        .unwrap_or_default();
+    if atomic_write_size > MAX_PIPE_TRANSFER_SIZE as usize {
+        return Err(errors::CreateError::ResourceExhausted);
+    }
+    let response = broker
+        .create_pipe(
+            capacity
+                .try_into()
+                .map_err(|_| errors::CreateError::ResourceExhausted)?,
+            atomic_write_size
+                .try_into()
+                .map_err(|_| errors::CreateError::ResourceExhausted)?,
+        )
+        .map_err(BrokerObjectError::from)
+        .map_err(errors::CreateError::from)?;
+
+    let mut writer = Arc::new(BrokerPipeEnd {
+        broker: Arc::clone(&broker),
+        handle: response.write_handle,
+        registry: Arc::clone(&registry),
+        pollee: Arc::new(Pollee::new()),
+        peer: Weak::new(),
+        endpoint_type: HalfPipeType::SenderHalf,
+        status: AtomicU32::new((flags | OFlags::WRONLY).bits()),
+    });
+    let reader = Arc::new_cyclic(|weak_reader| {
+        Arc::get_mut(&mut writer)
+            .expect("new pipe writer must be uniquely owned")
+            .peer = weak_reader.clone();
+        BrokerPipeEnd {
+            broker,
+            handle: response.read_handle,
+            registry: Arc::clone(&registry),
+            pollee: Arc::new(Pollee::new()),
+            peer: Arc::downgrade(&writer),
+            endpoint_type: HalfPipeType::ReceiverHalf,
+            status: AtomicU32::new((flags | OFlags::RDONLY).bits()),
+        }
+    });
+
+    registry.register_pollable(response.write_handle, &writer.pollee);
+    registry.register_pollable(response.read_handle, &reader.pollee);
+    Ok((writer, reader))
+}
+
+impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerPipeEnd<Platform> {
+    fn get_status(&self) -> OFlags {
+        OFlags::from_bits(self.status.load(Relaxed)).unwrap() & OFlags::STATUS_FLAGS_MASK
+    }
+
+    fn set_status(&self, mask: OFlags, on: bool) {
+        if on {
+            self.status.fetch_or(mask.bits(), Relaxed);
+        } else {
+            self.status.fetch_and(mask.complement().bits(), Relaxed);
+        }
+    }
+
+    fn read(&self, cx: &WaitContext<'_, Platform>, buf: &mut [u8]) -> Result<usize, PipeError> {
+        let length = buf.len().min(MAX_PIPE_TRANSFER_SIZE as usize);
+        if length == 0 {
+            return Ok(0);
+        }
+        let request_length = length
+            .try_into()
+            .expect("pipe transfer limit must fit in u32");
+
+        self.pollee
+            .wait(
+                cx,
+                self.get_status().contains(OFlags::NONBLOCK),
+                Events::IN,
+                || {
+                    let data = self
+                        .broker
+                        .read_pipe(self.handle, request_length)
+                        .map_err(|error| self.broker_request_error(error))?;
+                    if data.len() > length {
+                        return Err(TryOpError::Other(PipeError::Io));
+                    }
+                    buf[..data.len()].copy_from_slice(&data);
+                    if !data.is_empty()
+                        && let Some(peer) = self.peer.upgrade()
+                    {
+                        peer.pollee.notify_observers(Events::OUT);
+                    }
+                    Ok(data.len())
+                },
+            )
+            .map_err(PipeError::from)
+    }
+
+    fn write(&self, cx: &WaitContext<'_, Platform>, buf: &[u8]) -> Result<usize, PipeError> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+        let nonblock = self.get_status().contains(OFlags::NONBLOCK);
+        if nonblock {
+            let data = &buf[..buf.len().min(MAX_PIPE_TRANSFER_SIZE as usize)];
+            return self
+                .pollee
+                .wait(cx, nonblock, Events::OUT, || self.try_write(data))
+                .map_err(PipeError::from);
+        }
+
+        let mut total_written = 0;
+        while total_written < buf.len() {
+            let end = total_written
+                .saturating_add(MAX_PIPE_TRANSFER_SIZE as usize)
+                .min(buf.len());
+            let data = &buf[total_written..end];
+            match self
+                .pollee
+                .wait(cx, false, Events::OUT, || self.try_write(data))
+            {
+                Ok(written) => total_written += written,
+                Err(_) if total_written != 0 => return Ok(total_written),
+                Err(error) => return Err(PipeError::from(error)),
+            }
+        }
+        Ok(total_written)
+    }
+
+    fn try_write(&self, data: &[u8]) -> Result<usize, TryOpError<PipeError>> {
+        let written = self
+            .broker
+            .write_pipe(self.handle, data)
+            .map_err(|error| self.broker_request_error(error))?;
+        if written > data.len() || (written == 0 && !data.is_empty()) {
+            return Err(TryOpError::Other(PipeError::Io));
+        }
+        if written != 0
+            && let Some(peer) = self.peer.upgrade()
+        {
+            peer.pollee.notify_observers(Events::IN);
+        }
+        Ok(written)
+    }
+
+    fn broker_request_error(&self, error: BrokerControlError) -> BrokerObjectError {
+        let error = error.into();
+        if error != BrokerObjectError::WouldBlock {
+            self.pollee.notify_observers(Events::ERR);
+        }
+        error
+    }
+
+    fn readiness(&self) -> Result<ReadinessFlags, BrokerControlError> {
+        self.broker.check_pipe_readiness(self.handle)
+    }
+}
+
+impl<Platform: RawSyncPrimitivesProvider + TimeProvider> IOPollable for BrokerPipeEnd<Platform> {
+    fn register_observer(&self, observer: Weak<dyn Observer<Events>>, filter: Events) {
+        self.pollee.register_observer(observer, filter);
+    }
+
+    fn check_io_events(&self) -> Events {
+        match self.readiness() {
+            Ok(readiness) => readiness_events(readiness),
+            Err(_) => Events::ERR,
+        }
+    }
+}
+
+impl<Platform: RawSyncPrimitivesProvider + TimeProvider> Drop for BrokerPipeEnd<Platform> {
+    fn drop(&mut self) {
+        self.registry.unregister_pollable(self.handle, &self.pollee);
+        let _ = self.broker.close_object(self.handle);
+        if let Some(peer) = self.peer.upgrade() {
+            let event = match self.endpoint_type {
+                HalfPipeType::SenderHalf => Events::HUP,
+                HalfPipeType::ReceiverHalf => Events::ERR,
+            };
+            peer.pollee.notify_observers(event);
+        }
+    }
+}
+
+impl From<BrokerObjectError> for TryOpError<PipeError> {
+    fn from(error: BrokerObjectError) -> Self {
+        match error {
+            BrokerObjectError::WouldBlock => TryOpError::TryAgain,
+            BrokerObjectError::PeerClosed => TryOpError::Other(PipeError::PeerShutdown),
+            BrokerObjectError::Control
+            | BrokerObjectError::InvalidObject
+            | BrokerObjectError::ResourceExhausted
+            | BrokerObjectError::PermissionDenied
+            | BrokerObjectError::OutOfMemory => TryOpError::Other(PipeError::Io),
+        }
+    }
+}
+
+impl From<BrokerObjectError> for errors::CreateError {
+    fn from(error: BrokerObjectError) -> Self {
+        match error {
+            BrokerObjectError::ResourceExhausted => Self::ResourceExhausted,
+            BrokerObjectError::OutOfMemory => Self::OutOfMemory,
+            BrokerObjectError::PermissionDenied => Self::PermissionDenied,
+            BrokerObjectError::Control
+            | BrokerObjectError::InvalidObject
+            | BrokerObjectError::WouldBlock
+            | BrokerObjectError::PeerClosed => Self::Io,
+        }
     }
 }
 
@@ -351,15 +643,15 @@ enum PipeError {
     WouldBlock,
     #[error("wait error")]
     WaitError(WaitError),
+    #[error("pipe I/O failed")]
+    Io,
 }
 
 impl From<PipeError> for errors::ReadError {
     fn from(err: PipeError) -> Self {
         match err {
             PipeError::ThisEndShutdown => errors::ReadError::ClosedFd,
-            PipeError::PeerShutdown => {
-                unreachable!("unreachable for now; see documentation of `read`")
-            }
+            PipeError::PeerShutdown | PipeError::Io => errors::ReadError::Io,
             PipeError::WouldBlock => errors::ReadError::WouldBlock,
             PipeError::WaitError(e) => errors::ReadError::WaitError(e),
         }
@@ -372,6 +664,7 @@ impl From<PipeError> for errors::WriteError {
             PipeError::PeerShutdown => errors::WriteError::ReadEndClosed,
             PipeError::WouldBlock => errors::WriteError::WouldBlock,
             PipeError::WaitError(e) => errors::WriteError::WaitError(e),
+            PipeError::Io => errors::WriteError::Io,
         }
     }
 }
@@ -631,29 +924,291 @@ fn new_pipe<Platform: RawSyncPrimitivesProvider + TimeProvider, T>(
 
 #[cfg(test)]
 mod tests {
+    use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+    use alloc::sync::Arc;
+    use litebox_broker_local::BrokerLocal;
+    use litebox_broker_protocol::channel::LocalControlChannel;
+    use litebox_broker_protocol::error::ErrorCode;
+    use litebox_broker_protocol::message::{
+        BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerNotification, BrokerRequest,
+        BrokerResponse, PipeRequest, PipeResponse, ReadinessNotification,
+    };
+    use litebox_broker_protocol::pipe::CreatePipeResponse;
+    use litebox_broker_protocol::readiness::ReadinessFlags;
+    use litebox_broker_protocol::{BROKER_PROTOCOL_VERSION, ObjectHandle};
+
     use crate::{
-        event::wait::WaitState,
+        event::{Events, observer::Observer, wait::WaitState},
         pipes::errors::{ReadError, WriteError},
     };
 
     extern crate std;
 
     #[test]
+    fn broker_control_failure_notifies_all_pipe_observers() {
+        let platform = crate::platform::mock::MockPlatform::new();
+        let request_count = Arc::new(AtomicUsize::new(0));
+        let force_transport = Arc::new(AtomicBool::new(false));
+        let local = BrokerLocal::negotiate(FailingPipeChannel {
+            last_request: None,
+            request_count: Arc::clone(&request_count),
+            read_failure: ReadFailure::Transport,
+            force_transport,
+        })
+        .unwrap();
+        let litebox = crate::LiteBox::new_with_broker_local(platform, local);
+        let pipes = super::Pipes::new(&litebox);
+        let (writer, reader) = pipes.create_pipe(2, super::Flags::empty(), None).unwrap();
+        let writer_observer = Arc::new(ErrorObserver(AtomicBool::new(false)));
+        let writer_observer_dyn: Arc<dyn Observer<Events>> = writer_observer.clone();
+        pipes
+            .with_iopollable(&writer, |pollable| {
+                pollable.register_observer(Arc::downgrade(&writer_observer_dyn), Events::ERR);
+            })
+            .unwrap();
+        let reader_observer = Arc::new(ErrorObserver(AtomicBool::new(false)));
+        let reader_observer_dyn: Arc<dyn Observer<Events>> = reader_observer.clone();
+        pipes
+            .with_iopollable(&reader, |pollable| {
+                pollable.register_observer(Arc::downgrade(&reader_observer_dyn), Events::ERR);
+            })
+            .unwrap();
+
+        let mut value = 0;
+        assert!(matches!(
+            pipes.read(
+                &WaitState::new(platform).context(),
+                &reader,
+                core::slice::from_mut(&mut value),
+            ),
+            Err(ReadError::Io)
+        ));
+        assert_eq!(request_count.load(Ordering::SeqCst), 2);
+        assert!(writer_observer.0.load(Ordering::SeqCst));
+        assert!(reader_observer.0.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn broker_notification_failure_prevents_future_control_requests() {
+        let platform = crate::platform::mock::MockPlatform::new();
+        let request_count = Arc::new(AtomicUsize::new(0));
+        let force_transport = Arc::new(AtomicBool::new(false));
+        let local = BrokerLocal::negotiate(FailingPipeChannel {
+            last_request: None,
+            request_count: Arc::clone(&request_count),
+            read_failure: ReadFailure::Transport,
+            force_transport,
+        })
+        .unwrap();
+        let litebox = crate::LiteBox::new_with_broker_local(platform, local);
+        let pipes = super::Pipes::new(&litebox);
+        let (writer, reader) = pipes.create_pipe(2, super::Flags::empty(), None).unwrap();
+        let writer_observer = Arc::new(ErrorObserver(AtomicBool::new(false)));
+        let writer_observer_dyn: Arc<dyn Observer<Events>> = writer_observer.clone();
+        pipes
+            .with_iopollable(&writer, |pollable| {
+                pollable.register_observer(Arc::downgrade(&writer_observer_dyn), Events::ERR);
+            })
+            .unwrap();
+        let reader_observer = Arc::new(ErrorObserver(AtomicBool::new(false)));
+        let reader_observer_dyn: Arc<dyn Observer<Events>> = reader_observer.clone();
+        pipes
+            .with_iopollable(&reader, |pollable| {
+                pollable.register_observer(Arc::downgrade(&reader_observer_dyn), Events::ERR);
+            })
+            .unwrap();
+
+        litebox.broker_failure_dispatcher()();
+
+        assert!(writer_observer.0.load(Ordering::SeqCst));
+        assert!(reader_observer.0.load(Ordering::SeqCst));
+        assert!(matches!(
+            litebox
+                .broker_control()
+                .unwrap()
+                .read_pipe(ObjectHandle(1), 1),
+            Err(crate::broker::error::BrokerControlError::Transport)
+        ));
+        assert_eq!(request_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn broker_failure_wakes_blocked_pipe_read() {
+        let platform = crate::platform::mock::MockPlatform::new();
+        let request_count = Arc::new(AtomicUsize::new(0));
+        let force_transport = Arc::new(AtomicBool::new(false));
+        let local = BrokerLocal::negotiate(FailingPipeChannel {
+            last_request: None,
+            request_count: Arc::clone(&request_count),
+            read_failure: ReadFailure::WouldBlock,
+            force_transport: Arc::clone(&force_transport),
+        })
+        .unwrap();
+        let litebox = Arc::new(crate::LiteBox::new_with_broker_local(platform, local));
+        let pipes = super::Pipes::new(&litebox);
+        let (writer, reader) = pipes.create_pipe(2, super::Flags::empty(), None).unwrap();
+
+        let (result_sender, result_receiver) = std::sync::mpsc::sync_channel(1);
+        let read_litebox = Arc::clone(&litebox);
+        let read_thread = std::thread::spawn(move || {
+            let pipes = super::Pipes::new(&read_litebox);
+            let mut value = 0;
+            result_sender
+                .send(pipes.read(
+                    &WaitState::new(platform).context(),
+                    &reader,
+                    core::slice::from_mut(&mut value),
+                ))
+                .unwrap();
+        });
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(1);
+        let mut setup_completed = true;
+        while request_count.load(Ordering::SeqCst) < 3 {
+            if std::time::Instant::now() >= deadline {
+                setup_completed = false;
+                force_transport.store(true, Ordering::SeqCst);
+                let _ = pipes.close(&writer);
+                break;
+            }
+            std::thread::yield_now();
+        }
+
+        if setup_completed {
+            litebox.dispatch_broker_notification(BrokerNotification::Readiness(
+                ReadinessNotification {
+                    handle: ObjectHandle(1),
+                    events: ReadinessFlags::READ,
+                },
+            ));
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(1);
+            while request_count.load(Ordering::SeqCst) < 4 {
+                if std::time::Instant::now() >= deadline {
+                    setup_completed = false;
+                    force_transport.store(true, Ordering::SeqCst);
+                    let _ = pipes.close(&writer);
+                    break;
+                }
+                std::thread::yield_now();
+            }
+        }
+
+        if setup_completed {
+            litebox.broker_failure_dispatcher()();
+        }
+
+        let initial_read_result = result_receiver.recv_timeout(std::time::Duration::from_secs(1));
+        let woke_without_cleanup = initial_read_result.is_ok();
+        let mut read_result = initial_read_result.ok();
+        if read_result.is_none() {
+            force_transport.store(true, Ordering::SeqCst);
+            let _ = pipes.close(&writer);
+            read_result = result_receiver
+                .recv_timeout(std::time::Duration::from_secs(1))
+                .ok();
+        }
+        if read_result.is_some() {
+            read_thread.join().unwrap();
+        } else {
+            std::process::abort();
+        }
+
+        assert!(setup_completed);
+        assert!(woke_without_cleanup);
+        assert!(matches!(read_result, Some(Err(ReadError::Io))));
+        assert_eq!(request_count.load(Ordering::SeqCst), 4);
+    }
+
+    #[test]
     fn local_zero_length_write_succeeds_after_reader_closes() {
         let platform = crate::platform::mock::MockPlatform::new();
         let litebox = crate::LiteBox::new(platform);
         let pipes = super::Pipes::new(&litebox);
-        let (writer, reader) = pipes.create_pipe(2, super::Flags::empty(), None);
+        let (writer, reader) = pipes.create_pipe(2, super::Flags::empty(), None).unwrap();
 
         pipes.close(&reader).unwrap();
 
-        assert_eq!(
-            pipes
-                .write(&WaitState::new(platform).context(), &writer, &[])
-                .unwrap(),
-            0
-        );
+        assert!(matches!(
+            pipes.write(&WaitState::new(platform).context(), &writer, &[]),
+            Ok(0)
+        ));
         pipes.close(&writer).unwrap();
+    }
+
+    struct ErrorObserver(AtomicBool);
+
+    impl Observer<Events> for ErrorObserver {
+        fn on_events(&self, events: &Events) {
+            if events.contains(Events::ERR) {
+                self.0.store(true, Ordering::SeqCst);
+            }
+        }
+    }
+
+    #[derive(Debug)]
+    struct FailingPipeChannel {
+        last_request: Option<BrokerRequest>,
+        request_count: Arc<AtomicUsize>,
+        read_failure: ReadFailure,
+        force_transport: Arc<AtomicBool>,
+    }
+
+    #[derive(Clone, Copy, Debug)]
+    enum ReadFailure {
+        Transport,
+        WouldBlock,
+    }
+
+    impl LocalControlChannel for FailingPipeChannel {
+        type Error = ();
+
+        fn send_handshake_request(
+            &mut self,
+            _request: &BrokerHandshakeRequest,
+        ) -> core::result::Result<(), Self::Error> {
+            Ok(())
+        }
+
+        fn recv_handshake_response(
+            &mut self,
+        ) -> core::result::Result<Option<BrokerHandshakeResponse>, Self::Error> {
+            Ok(Some(BrokerHandshakeResponse::Negotiated {
+                broker_protocol_version: BROKER_PROTOCOL_VERSION,
+            }))
+        }
+
+        fn send_request(
+            &mut self,
+            request: &BrokerRequest,
+        ) -> core::result::Result<(), Self::Error> {
+            self.last_request = Some(request.clone());
+            self.request_count.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+
+        fn recv_response(&mut self) -> core::result::Result<Option<BrokerResponse>, Self::Error> {
+            match self.last_request.take().unwrap() {
+                BrokerRequest::Pipe(PipeRequest::Create(_)) => Ok(Some(BrokerResponse::Pipe(
+                    PipeResponse::Create(CreatePipeResponse {
+                        read_handle: ObjectHandle(1),
+                        write_handle: ObjectHandle(2),
+                    }),
+                ))),
+                BrokerRequest::Pipe(PipeRequest::Read(_))
+                    if self.force_transport.load(Ordering::SeqCst) =>
+                {
+                    Err(())
+                }
+                BrokerRequest::Pipe(PipeRequest::Read(_)) => match self.read_failure {
+                    ReadFailure::Transport => Err(()),
+                    ReadFailure::WouldBlock => {
+                        Ok(Some(BrokerResponse::Error(ErrorCode::WouldBlock)))
+                    }
+                },
+                BrokerRequest::CloseObject(_) => Ok(Some(BrokerResponse::ObjectClosed)),
+                request => panic!("unexpected broker request: {request:?}"),
+            }
+        }
     }
 
     #[test]
@@ -662,7 +1217,7 @@ mod tests {
         let litebox = &crate::LiteBox::new(platform);
         let pipes = &super::Pipes::new(litebox);
 
-        let (prod, cons) = pipes.create_pipe(2, super::Flags::empty(), None);
+        let (prod, cons) = pipes.create_pipe(2, super::Flags::empty(), None).unwrap();
 
         std::thread::scope(|scope| {
             scope.spawn(move || {
@@ -696,7 +1251,9 @@ mod tests {
         let litebox = &crate::LiteBox::new(platform);
         let pipes = &super::Pipes::new(litebox);
 
-        let (prod, cons) = pipes.create_pipe(2, super::Flags::NON_BLOCKING, None);
+        let (prod, cons) = pipes
+            .create_pipe(2, super::Flags::NON_BLOCKING, None)
+            .unwrap();
 
         std::thread::scope(|scope| {
             scope.spawn(move || {

--- a/litebox/src/pipes.rs
+++ b/litebox/src/pipes.rs
@@ -990,50 +990,6 @@ mod tests {
     }
 
     #[test]
-    fn broker_notification_failure_prevents_future_control_requests() {
-        let platform = crate::platform::mock::MockPlatform::new();
-        let request_count = Arc::new(AtomicUsize::new(0));
-        let force_transport = Arc::new(AtomicBool::new(false));
-        let local = BrokerLocal::negotiate(FailingPipeChannel {
-            last_request: None,
-            request_count: Arc::clone(&request_count),
-            read_failure: ReadFailure::Transport,
-            force_transport,
-        })
-        .unwrap();
-        let litebox = crate::LiteBox::new_with_broker_local(platform, local);
-        let pipes = super::Pipes::new(&litebox);
-        let (writer, reader) = pipes.create_pipe(2, super::Flags::empty(), None).unwrap();
-        let writer_observer = Arc::new(ErrorObserver(AtomicBool::new(false)));
-        let writer_observer_dyn: Arc<dyn Observer<Events>> = writer_observer.clone();
-        pipes
-            .with_iopollable(&writer, |pollable| {
-                pollable.register_observer(Arc::downgrade(&writer_observer_dyn), Events::ERR);
-            })
-            .unwrap();
-        let reader_observer = Arc::new(ErrorObserver(AtomicBool::new(false)));
-        let reader_observer_dyn: Arc<dyn Observer<Events>> = reader_observer.clone();
-        pipes
-            .with_iopollable(&reader, |pollable| {
-                pollable.register_observer(Arc::downgrade(&reader_observer_dyn), Events::ERR);
-            })
-            .unwrap();
-
-        litebox.broker_failure_dispatcher()();
-
-        assert!(writer_observer.0.load(Ordering::SeqCst));
-        assert!(reader_observer.0.load(Ordering::SeqCst));
-        assert!(matches!(
-            litebox
-                .broker_control()
-                .unwrap()
-                .read_pipe(ObjectHandle(1), 1),
-            Err(crate::broker::error::BrokerControlError::Transport)
-        ));
-        assert_eq!(request_count.load(Ordering::SeqCst), 1);
-    }
-
-    #[test]
     fn broker_failure_wakes_blocked_pipe_read() {
         let platform = crate::platform::mock::MockPlatform::new();
         let request_count = Arc::new(AtomicUsize::new(0));
@@ -1128,10 +1084,12 @@ mod tests {
 
         pipes.close(&reader).unwrap();
 
-        assert!(matches!(
-            pipes.write(&WaitState::new(platform).context(), &writer, &[]),
-            Ok(0)
-        ));
+        assert_eq!(
+            pipes
+                .write(&WaitState::new(platform).context(), &writer, &[])
+                .unwrap(),
+            0
+        );
         pipes.close(&writer).unwrap();
     }
 

--- a/litebox_broker_core/src/error.rs
+++ b/litebox_broker_core/src/error.rs
@@ -21,6 +21,10 @@ pub enum BrokerError {
     BrokerCoreAlreadyExists,
     #[error("broker operation would block")]
     WouldBlock,
+    #[error("broker object peer is closed")]
+    PeerClosed,
+    #[error("broker memory allocation failed")]
+    OutOfMemory,
     #[error("unsupported broker operation")]
     UnsupportedOperation,
 }
@@ -34,6 +38,8 @@ impl From<BrokerError> for ErrorCode {
             BrokerError::ResourceExhausted => Self::ResourceExhausted,
             BrokerError::BrokerCoreAlreadyExists => Self::Internal,
             BrokerError::WouldBlock => Self::WouldBlock,
+            BrokerError::PeerClosed => Self::PeerClosed,
+            BrokerError::OutOfMemory => Self::OutOfMemory,
             BrokerError::UnsupportedOperation => Self::UnsupportedOperation,
         }
     }

--- a/litebox_broker_core/src/event.rs
+++ b/litebox_broker_core/src/event.rs
@@ -20,19 +20,6 @@ pub fn create(session: &BrokerSession, initial_count: u64) -> Result<ObjectHandl
     session.create_object_reference(ObjectEntry::Event(EventObject::new(initial_count)))
 }
 
-/// Checks whether an event wait would complete now.
-///
-/// Blocking is intentionally outside BrokerCore for the first proof of
-/// concept. Userland or kernel deployments can block on deployment-specific
-/// wait primitives after BrokerCore authorizes and reports readiness state.
-pub fn wait(session: &BrokerSession, handle: ObjectHandle) -> Result<ReadinessFlags> {
-    let required_rights = ObjectRights::WAIT;
-    session.with_authorized_object(handle, required_rights, |object| match object {
-        ObjectEntry::Event(event) => Ok(event.readiness()),
-        ObjectEntry::Pipe(_) => Err(BrokerError::InvalidRights),
-    })
-}
-
 /// Adds readiness credits to a broker-owned event object.
 pub fn add(session: &BrokerSession, handle: ObjectHandle, value: u64) -> Result<ReadinessFlags> {
     let required_rights = ObjectRights::WRITE;
@@ -90,7 +77,7 @@ impl EventObject {
         })
     }
 
-    fn readiness(self) -> ReadinessFlags {
+    pub(crate) fn readiness(self) -> ReadinessFlags {
         let mut readiness = ReadinessFlags::default();
         if self.count > 0 {
             readiness = readiness | ReadinessFlags::READ;

--- a/litebox_broker_core/src/event.rs
+++ b/litebox_broker_core/src/event.rs
@@ -29,6 +29,7 @@ pub fn wait(session: &BrokerSession, handle: ObjectHandle) -> Result<ReadinessFl
     let required_rights = ObjectRights::WAIT;
     session.with_authorized_object(handle, required_rights, |object| match object {
         ObjectEntry::Event(event) => Ok(event.readiness()),
+        ObjectEntry::Pipe(_) => Err(BrokerError::InvalidRights),
     })
 }
 
@@ -37,6 +38,7 @@ pub fn add(session: &BrokerSession, handle: ObjectHandle, value: u64) -> Result<
     let required_rights = ObjectRights::WRITE;
     session.with_authorized_object_mut(handle, required_rights, |object| match object {
         ObjectEntry::Event(event) => event.add(value),
+        ObjectEntry::Pipe(_) => Err(BrokerError::InvalidRights),
     })
 }
 
@@ -49,6 +51,7 @@ pub fn consume(
     let required_rights = ObjectRights::WAIT;
     session.with_authorized_object_mut(handle, required_rights, |object| match object {
         ObjectEntry::Event(event) => event.consume(mode),
+        ObjectEntry::Pipe(_) => Err(BrokerError::InvalidRights),
     })
 }
 

--- a/litebox_broker_core/src/lib.rs
+++ b/litebox_broker_core/src/lib.rs
@@ -122,6 +122,22 @@ impl BrokerCore {
         Ok(handle)
     }
 
+    pub(crate) fn allocate_reference_handle_pair(&self) -> Result<(ObjectHandle, ObjectHandle)> {
+        let mut next_reference_handle = self.next_reference_handle.write();
+        let first = ObjectHandle(*next_reference_handle);
+        let second = ObjectHandle(
+            first
+                .0
+                .checked_add(1)
+                .ok_or(BrokerError::ResourceExhausted)?,
+        );
+        *next_reference_handle = second
+            .0
+            .checked_add(1)
+            .ok_or(BrokerError::ResourceExhausted)?;
+        Ok((first, second))
+    }
+
     /// Allocates broker authority state for one authenticated caller session.
     pub fn create_session(&self, caller_credential: CallerCredential) -> Result<BrokerSession> {
         let mut next_session_id = self.next_session_id.write();

--- a/litebox_broker_core/src/lib.rs
+++ b/litebox_broker_core/src/lib.rs
@@ -25,7 +25,7 @@ mod policy;
 mod session;
 
 use alloc::sync::Arc;
-use core::sync::atomic::{AtomicBool, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 use hashbrown::HashMap;
 use litebox_broker_protocol::ObjectHandle;
@@ -85,7 +85,7 @@ pub struct BrokerCore {
     pub(crate) next_session_id: Arc<RwLock<u64>>,
     pub(crate) next_reference_handle: Arc<RwLock<u64>>,
     pub(crate) references: Arc<RwLock<HashMap<ObjectHandle, ObjectReference>>>,
-    pub(crate) reserved_pipe_capacity: Arc<RwLock<usize>>,
+    pub(crate) reserved_pipe_capacity: Arc<AtomicUsize>,
 }
 
 static BROKER_CORE_CREATED: AtomicBool = AtomicBool::new(false);
@@ -108,7 +108,7 @@ impl BrokerCore {
             next_session_id: Arc::new(RwLock::new(1)),
             next_reference_handle: Arc::new(RwLock::new(1)),
             references: Arc::new(RwLock::new(HashMap::new())),
-            reserved_pipe_capacity: Arc::new(RwLock::new(0)),
+            reserved_pipe_capacity: Arc::new(AtomicUsize::new(0)),
         })
     }
 

--- a/litebox_broker_core/src/lib.rs
+++ b/litebox_broker_core/src/lib.rs
@@ -20,6 +20,7 @@ extern crate std;
 
 mod error;
 pub mod event;
+pub mod pipe;
 mod policy;
 mod session;
 
@@ -46,17 +47,23 @@ pub type Result<T> = core::result::Result<T, BrokerError>;
 pub struct BrokerCoreLimits {
     /// Maximum live object references.
     pub max_references: usize,
+    /// Maximum total capacity in bytes reserved by live pipes.
+    pub max_total_pipe_capacity: usize,
 }
 
 impl BrokerCoreLimits {
     /// Conservative default limits for initial broker deployments.
     pub const DEFAULT: Self = Self {
         max_references: 4096,
+        max_total_pipe_capacity: 64 * 1024 * 1024,
     };
 
     /// Creates a broker core limit set.
-    pub const fn new(max_references: usize) -> Self {
-        Self { max_references }
+    pub const fn new(max_references: usize, max_total_pipe_capacity: usize) -> Self {
+        Self {
+            max_references,
+            max_total_pipe_capacity,
+        }
     }
 }
 
@@ -78,6 +85,7 @@ pub struct BrokerCore {
     pub(crate) next_session_id: Arc<RwLock<u64>>,
     pub(crate) next_reference_handle: Arc<RwLock<u64>>,
     pub(crate) references: Arc<RwLock<HashMap<ObjectHandle, ObjectReference>>>,
+    pub(crate) reserved_pipe_capacity: Arc<RwLock<usize>>,
 }
 
 static BROKER_CORE_CREATED: AtomicBool = AtomicBool::new(false);
@@ -100,6 +108,7 @@ impl BrokerCore {
             next_session_id: Arc::new(RwLock::new(1)),
             next_reference_handle: Arc::new(RwLock::new(1)),
             references: Arc::new(RwLock::new(HashMap::new())),
+            reserved_pipe_capacity: Arc::new(RwLock::new(0)),
         })
     }
 

--- a/litebox_broker_core/src/pipe.rs
+++ b/litebox_broker_core/src/pipe.rs
@@ -4,6 +4,7 @@
 //! Broker-owned byte pipe operations.
 
 use alloc::{collections::VecDeque, sync::Arc, vec::Vec};
+use core::sync::atomic::{AtomicUsize, Ordering};
 
 use litebox_broker_protocol::ObjectHandle;
 use litebox_broker_protocol::pipe::MAX_PIPE_TRANSFER_SIZE;
@@ -192,20 +193,20 @@ enum PipeEndpoint {
 }
 
 struct PipeCapacityReservation {
-    reserved_capacity: Arc<RwLock<usize>>,
+    reserved_capacity: Arc<AtomicUsize>,
     capacity: usize,
 }
 
 impl PipeCapacityReservation {
     fn new(session: &BrokerSession, capacity: usize) -> Result<Self> {
         let reserved_capacity = Arc::clone(&session.core.reserved_pipe_capacity);
-        {
-            let mut reserved = reserved_capacity.write();
-            *reserved = reserved
-                .checked_add(capacity)
-                .filter(|total| *total <= session.core.limits.max_total_pipe_capacity)
-                .ok_or(BrokerError::ResourceExhausted)?;
-        }
+        reserved_capacity
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |reserved| {
+                reserved
+                    .checked_add(capacity)
+                    .filter(|total| *total <= session.core.limits.max_total_pipe_capacity)
+            })
+            .map_err(|_| BrokerError::ResourceExhausted)?;
         Ok(Self {
             reserved_capacity,
             capacity,
@@ -215,9 +216,10 @@ impl PipeCapacityReservation {
 
 impl Drop for PipeCapacityReservation {
     fn drop(&mut self) {
-        let mut reserved = self.reserved_capacity.write();
-        *reserved = reserved
-            .checked_sub(self.capacity)
+        self.reserved_capacity
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |reserved| {
+                reserved.checked_sub(self.capacity)
+            })
             .expect("reserved pipe capacity must include every live pipe");
     }
 }

--- a/litebox_broker_core/src/pipe.rs
+++ b/litebox_broker_core/src/pipe.rs
@@ -75,14 +75,6 @@ pub fn write(session: &BrokerSession, handle: ObjectHandle, data: &[u8]) -> Resu
     })
 }
 
-/// Returns the current readiness of one pipe endpoint.
-pub fn check_readiness(session: &BrokerSession, handle: ObjectHandle) -> Result<ReadinessFlags> {
-    session.with_authorized_object(handle, ObjectRights::WAIT, |object| match object {
-        ObjectEntry::Pipe(pipe) => Ok(pipe.readiness()),
-        ObjectEntry::Event(_) => Err(BrokerError::InvalidRights),
-    })
-}
-
 pub(crate) struct PipeObject {
     state: Arc<RwLock<PipeState>>,
     endpoint: PipeEndpoint,
@@ -150,7 +142,7 @@ impl PipeObject {
         Ok(write_len)
     }
 
-    fn readiness(&self) -> ReadinessFlags {
+    pub(crate) fn readiness(&self) -> ReadinessFlags {
         let state = self.state.read();
         match self.endpoint {
             PipeEndpoint::Read => {

--- a/litebox_broker_core/src/pipe.rs
+++ b/litebox_broker_core/src/pipe.rs
@@ -1,0 +1,232 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//! Broker-owned byte pipe operations.
+
+use alloc::{collections::VecDeque, sync::Arc, vec::Vec};
+
+use litebox_broker_protocol::ObjectHandle;
+use litebox_broker_protocol::pipe::MAX_PIPE_TRANSFER_SIZE;
+use litebox_broker_protocol::readiness::ReadinessFlags;
+use spin::rwlock::RwLock;
+
+use crate::session::{ObjectEntry, ObjectRights};
+use crate::{BrokerError, BrokerSession, Result};
+
+/// Maximum capacity accepted by the control-path pipe prototype.
+pub const MAX_PIPE_CAPACITY: usize = 1024 * 1024;
+
+/// Creates a broker-owned pipe and returns its read and write endpoint handles.
+///
+pub fn create(
+    session: &BrokerSession,
+    capacity: u64,
+    atomic_write_size: u64,
+) -> Result<(ObjectHandle, ObjectHandle)> {
+    let capacity = usize::try_from(capacity).map_err(|_| BrokerError::ResourceExhausted)?;
+    let atomic_write_size =
+        usize::try_from(atomic_write_size).map_err(|_| BrokerError::ResourceExhausted)?;
+    if capacity == 0
+        || capacity > MAX_PIPE_CAPACITY
+        || atomic_write_size > capacity
+        || atomic_write_size > MAX_PIPE_TRANSFER_SIZE as usize
+    {
+        return Err(BrokerError::ResourceExhausted);
+    }
+
+    let capacity_reservation = PipeCapacityReservation::new(session, capacity)?;
+    let mut data = VecDeque::new();
+    data.try_reserve_exact(capacity)
+        .map_err(|_| BrokerError::OutOfMemory)?;
+    let state = Arc::new(RwLock::new(PipeState {
+        data,
+        capacity,
+        atomic_write_size,
+        read_open: true,
+        write_open: true,
+        _capacity_reservation: capacity_reservation,
+    }));
+    session.create_object_reference_pair(
+        ObjectEntry::Pipe(PipeObject::reader(Arc::clone(&state))),
+        ObjectEntry::Pipe(PipeObject::writer(state)),
+    )
+}
+
+/// Reads up to `length` bytes from a broker-owned pipe.
+pub fn read(session: &BrokerSession, handle: ObjectHandle, length: u32) -> Result<Vec<u8>> {
+    if length > MAX_PIPE_TRANSFER_SIZE {
+        return Err(BrokerError::ResourceExhausted);
+    }
+    session.with_authorized_object(handle, ObjectRights::WAIT, |object| match object {
+        ObjectEntry::Pipe(pipe) => pipe.read(length as usize),
+        ObjectEntry::Event(_) => Err(BrokerError::InvalidRights),
+    })
+}
+
+/// Writes bytes to a broker-owned pipe.
+pub fn write(session: &BrokerSession, handle: ObjectHandle, data: &[u8]) -> Result<usize> {
+    if data.len() > MAX_PIPE_TRANSFER_SIZE as usize {
+        return Err(BrokerError::ResourceExhausted);
+    }
+    session.with_authorized_object(handle, ObjectRights::WRITE, |object| match object {
+        ObjectEntry::Pipe(pipe) => pipe.write(data),
+        ObjectEntry::Event(_) => Err(BrokerError::InvalidRights),
+    })
+}
+
+/// Returns the current readiness of one pipe endpoint.
+pub fn check_readiness(session: &BrokerSession, handle: ObjectHandle) -> Result<ReadinessFlags> {
+    session.with_authorized_object(handle, ObjectRights::WAIT, |object| match object {
+        ObjectEntry::Pipe(pipe) => Ok(pipe.readiness()),
+        ObjectEntry::Event(_) => Err(BrokerError::InvalidRights),
+    })
+}
+
+pub(crate) struct PipeObject {
+    state: Arc<RwLock<PipeState>>,
+    endpoint: PipeEndpoint,
+}
+
+impl PipeObject {
+    fn reader(state: Arc<RwLock<PipeState>>) -> Self {
+        Self {
+            state,
+            endpoint: PipeEndpoint::Read,
+        }
+    }
+
+    fn writer(state: Arc<RwLock<PipeState>>) -> Self {
+        Self {
+            state,
+            endpoint: PipeEndpoint::Write,
+        }
+    }
+
+    fn read(&self, length: usize) -> Result<Vec<u8>> {
+        if !matches!(self.endpoint, PipeEndpoint::Read) {
+            return Err(BrokerError::InvalidRights);
+        }
+        if length == 0 {
+            return Ok(Vec::new());
+        }
+
+        let mut state = self.state.write();
+        if state.data.is_empty() {
+            return if state.write_open {
+                Err(BrokerError::WouldBlock)
+            } else {
+                Ok(Vec::new())
+            };
+        }
+
+        let read_len = length.min(state.data.len());
+        let mut data = Vec::new();
+        data.try_reserve_exact(read_len)
+            .map_err(|_| BrokerError::OutOfMemory)?;
+        data.extend(state.data.drain(..read_len));
+        Ok(data)
+    }
+
+    fn write(&self, data: &[u8]) -> Result<usize> {
+        if !matches!(self.endpoint, PipeEndpoint::Write) {
+            return Err(BrokerError::InvalidRights);
+        }
+        if data.is_empty() {
+            return Ok(0);
+        }
+        let mut state = self.state.write();
+        if !state.read_open {
+            return Err(BrokerError::PeerClosed);
+        }
+
+        let available = state.capacity - state.data.len();
+        if available == 0 || (data.len() <= state.atomic_write_size && available < data.len()) {
+            return Err(BrokerError::WouldBlock);
+        }
+
+        let write_len = available.min(data.len());
+        state.data.extend(&data[..write_len]);
+        Ok(write_len)
+    }
+
+    fn readiness(&self) -> ReadinessFlags {
+        let state = self.state.read();
+        match self.endpoint {
+            PipeEndpoint::Read => {
+                let mut readiness = ReadinessFlags::default();
+                if !state.data.is_empty() {
+                    readiness = readiness | ReadinessFlags::READ;
+                }
+                if !state.write_open {
+                    readiness = readiness | ReadinessFlags::HANGUP;
+                }
+                readiness
+            }
+            PipeEndpoint::Write => {
+                let mut readiness = ReadinessFlags::default();
+                if state.data.len() < state.capacity {
+                    readiness = readiness | ReadinessFlags::WRITE;
+                }
+                if !state.read_open {
+                    readiness = readiness | ReadinessFlags::ERROR;
+                }
+                readiness
+            }
+        }
+    }
+}
+
+impl Drop for PipeObject {
+    fn drop(&mut self) {
+        let mut state = self.state.write();
+        match self.endpoint {
+            PipeEndpoint::Read => state.read_open = false,
+            PipeEndpoint::Write => state.write_open = false,
+        }
+    }
+}
+
+enum PipeEndpoint {
+    Read,
+    Write,
+}
+
+struct PipeCapacityReservation {
+    reserved_capacity: Arc<RwLock<usize>>,
+    capacity: usize,
+}
+
+impl PipeCapacityReservation {
+    fn new(session: &BrokerSession, capacity: usize) -> Result<Self> {
+        let reserved_capacity = Arc::clone(&session.core.reserved_pipe_capacity);
+        {
+            let mut reserved = reserved_capacity.write();
+            *reserved = reserved
+                .checked_add(capacity)
+                .filter(|total| *total <= session.core.limits.max_total_pipe_capacity)
+                .ok_or(BrokerError::ResourceExhausted)?;
+        }
+        Ok(Self {
+            reserved_capacity,
+            capacity,
+        })
+    }
+}
+
+impl Drop for PipeCapacityReservation {
+    fn drop(&mut self) {
+        let mut reserved = self.reserved_capacity.write();
+        *reserved = reserved
+            .checked_sub(self.capacity)
+            .expect("reserved pipe capacity must include every live pipe");
+    }
+}
+
+struct PipeState {
+    data: VecDeque<u8>,
+    capacity: usize,
+    atomic_write_size: usize,
+    read_open: bool,
+    write_open: bool,
+    _capacity_reservation: PipeCapacityReservation,
+}

--- a/litebox_broker_core/src/session.rs
+++ b/litebox_broker_core/src/session.rs
@@ -4,6 +4,7 @@
 use alloc::sync::Arc;
 
 use crate::event::EventObject;
+use crate::pipe::PipeObject;
 use crate::{BrokerCore, BrokerError, Result};
 use hashbrown::HashMap;
 use litebox_broker_protocol::ObjectHandle;
@@ -43,9 +44,9 @@ pub(crate) struct ObjectReference {
     pub(crate) rights: ObjectRights,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum ObjectEntry {
     Event(EventObject),
+    Pipe(PipeObject),
 }
 
 /// Broker-owned authority token for one authenticated caller session.
@@ -95,6 +96,38 @@ impl BrokerSession {
         );
 
         Ok(handle)
+    }
+
+    pub(crate) fn create_object_reference_pair(
+        &self,
+        first: ObjectEntry,
+        second: ObjectEntry,
+    ) -> Result<(ObjectHandle, ObjectHandle)> {
+        let rights = self
+            .core
+            .policy
+            .principal_object_rights(self.caller_credential)?;
+        let mut references = self.core.references.write();
+        if references
+            .len()
+            .checked_add(2)
+            .is_none_or(|count| count > self.core.limits.max_references)
+        {
+            return Err(BrokerError::ResourceExhausted);
+        }
+        let first_handle = self.core.allocate_reference_handle()?;
+        let second_handle = self.core.allocate_reference_handle()?;
+        for (handle, object) in [(first_handle, first), (second_handle, second)] {
+            references.insert(
+                handle,
+                ObjectReference {
+                    object: Arc::new(RwLock::new(object)),
+                    session_id: self.session_id,
+                    rights,
+                },
+            );
+        }
+        Ok((first_handle, second_handle))
     }
 
     pub(crate) fn with_authorized_object<T>(
@@ -175,7 +208,7 @@ mod tests {
     fn object_reference_lifecycle_uses_public_core_constructor_once() {
         let broker = BrokerCore::new_with_limits(
             PolicyEngine::with_unauthenticated_rights(ObjectRights::all()),
-            BrokerCoreLimits::new(1),
+            BrokerCoreLimits::new(2, 4),
         )
         .unwrap();
         let session = broker
@@ -213,10 +246,17 @@ mod tests {
                 readiness: ReadinessFlags::WRITE,
             })
         );
+        let second_handle = crate::event::create(&session, 0).unwrap();
         assert_eq!(
             crate::event::create(&session, 0),
             Err(BrokerError::ResourceExhausted)
         );
+        assert_eq!(
+            crate::pipe::create(&session, 4, 2),
+            Err(BrokerError::ResourceExhausted)
+        );
+        assert_eq!(*broker.reserved_pipe_capacity.read(), 0);
+        assert_eq!(session.close_object_reference(second_handle), Ok(()));
 
         assert_eq!(session.close_object_reference(handle), Ok(()));
         {
@@ -247,6 +287,64 @@ mod tests {
         let session = broker
             .create_session(CallerCredential::Unauthenticated)
             .unwrap();
+        assert_eq!(
+            crate::pipe::create(&session, 5, 2),
+            Err(BrokerError::ResourceExhausted)
+        );
+        assert_eq!(*broker.reserved_pipe_capacity.read(), 0);
+        let (reader, writer) = crate::pipe::create(&session, 4, 2).unwrap();
+        assert_eq!(*broker.reserved_pipe_capacity.read(), 4);
+        assert_eq!(
+            crate::pipe::check_readiness(&session, reader),
+            Ok(ReadinessFlags::default())
+        );
+        assert_eq!(
+            crate::pipe::read(&session, reader, 1),
+            Err(BrokerError::WouldBlock)
+        );
+        assert_eq!(crate::pipe::write(&session, writer, &[1, 2]), Ok(2));
+        assert_eq!(crate::pipe::write(&session, writer, &[3, 4, 5]), Ok(2));
+        assert_eq!(
+            crate::pipe::write(&session, writer, &[5]),
+            Err(BrokerError::WouldBlock)
+        );
+        assert_eq!(
+            crate::pipe::read(&session, reader, 3),
+            Ok(std::vec::Vec::from([1, 2, 3]))
+        );
+        assert_eq!(crate::pipe::write(&session, writer, &[5, 6]), Ok(2));
+        assert_eq!(session.close_object_reference(writer), Ok(()));
+        assert_eq!(*broker.reserved_pipe_capacity.read(), 4);
+        assert_eq!(
+            crate::pipe::check_readiness(&session, reader),
+            Ok(ReadinessFlags::READ | ReadinessFlags::HANGUP)
+        );
+        assert_eq!(
+            crate::pipe::read(&session, reader, 4),
+            Ok(std::vec::Vec::from([4, 5, 6]))
+        );
+        assert_eq!(
+            crate::pipe::read(&session, reader, 1),
+            Ok(std::vec::Vec::new())
+        );
+        assert_eq!(session.close_object_reference(reader), Ok(()));
+        assert_eq!(*broker.reserved_pipe_capacity.read(), 0);
+
+        let (reader, writer) = crate::pipe::create(&session, 4, 2).unwrap();
+        assert_eq!(*broker.reserved_pipe_capacity.read(), 4);
+        assert_eq!(session.close_object_reference(reader), Ok(()));
+        assert_eq!(crate::pipe::write(&session, writer, &[]), Ok(0));
+        assert_eq!(
+            crate::pipe::write(&session, writer, &[1]),
+            Err(BrokerError::PeerClosed)
+        );
+        assert_eq!(
+            crate::pipe::check_readiness(&session, writer),
+            Ok(ReadinessFlags::WRITE | ReadinessFlags::ERROR)
+        );
+        assert_eq!(session.close_object_reference(writer), Ok(()));
+        assert_eq!(*broker.reserved_pipe_capacity.read(), 0);
+
         {
             let mut next_reference_handle = broker.next_reference_handle.write();
             *next_reference_handle = u64::MAX;

--- a/litebox_broker_core/src/session.rs
+++ b/litebox_broker_core/src/session.rs
@@ -8,6 +8,7 @@ use crate::pipe::PipeObject;
 use crate::{BrokerCore, BrokerError, Result};
 use hashbrown::HashMap;
 use litebox_broker_protocol::ObjectHandle;
+use litebox_broker_protocol::readiness::ReadinessFlags;
 use spin::rwlock::RwLock;
 
 /// Caller identity information supplied by the broker entry layer.
@@ -157,6 +158,16 @@ impl BrokerSession {
         f(&mut object)
     }
 
+    /// Returns the current readiness of a broker-owned object.
+    pub fn check_readiness(&self, handle: ObjectHandle) -> Result<ReadinessFlags> {
+        self.with_authorized_object(handle, ObjectRights::WAIT, |object| {
+            Ok(match object {
+                ObjectEntry::Event(event) => event.readiness(),
+                ObjectEntry::Pipe(pipe) => pipe.readiness(),
+            })
+        })
+    }
+
     fn authorize_use_object(
         &self,
         references: &HashMap<ObjectHandle, ObjectReference>,
@@ -234,7 +245,7 @@ mod tests {
 
         assert_ne!(unknown_handle, handle);
         assert_eq!(
-            crate::event::wait(&session, unknown_handle),
+            session.check_readiness(unknown_handle),
             Err(BrokerError::UnknownObject)
         );
 
@@ -243,10 +254,7 @@ mod tests {
             Err(BrokerError::UnknownObject)
         );
 
-        assert_eq!(
-            crate::event::wait(&session, handle),
-            Ok(ReadinessFlags::WRITE)
-        );
+        assert_eq!(session.check_readiness(handle), Ok(ReadinessFlags::WRITE));
         assert_eq!(
             crate::event::add(&session, handle, 1),
             Ok(ReadinessFlags::READ | ReadinessFlags::WRITE)
@@ -311,7 +319,7 @@ mod tests {
         let (reader, writer) = crate::pipe::create(&session, 4, 2).unwrap();
         assert_eq!(broker.reserved_pipe_capacity.load(Ordering::Relaxed), 4);
         assert_eq!(
-            crate::pipe::check_readiness(&session, reader),
+            session.check_readiness(reader),
             Ok(ReadinessFlags::default())
         );
         assert_eq!(
@@ -332,7 +340,7 @@ mod tests {
         assert_eq!(session.close_object_reference(writer), Ok(()));
         assert_eq!(broker.reserved_pipe_capacity.load(Ordering::Relaxed), 4);
         assert_eq!(
-            crate::pipe::check_readiness(&session, reader),
+            session.check_readiness(reader),
             Ok(ReadinessFlags::READ | ReadinessFlags::HANGUP)
         );
         assert_eq!(
@@ -360,7 +368,7 @@ mod tests {
             Err(BrokerError::PeerClosed)
         );
         assert_eq!(
-            crate::pipe::check_readiness(&session, writer),
+            session.check_readiness(writer),
             Ok(ReadinessFlags::WRITE | ReadinessFlags::ERROR)
         );
         assert_eq!(session.close_object_reference(writer), Ok(()));

--- a/litebox_broker_core/src/session.rs
+++ b/litebox_broker_core/src/session.rs
@@ -197,6 +197,8 @@ impl Drop for BrokerSession {
 
 #[cfg(test)]
 mod tests {
+    use core::sync::atomic::Ordering;
+
     use crate::{
         BrokerCore, BrokerCoreLimits, BrokerError, CallerCredential, ObjectRights, PolicyEngine,
     };
@@ -255,7 +257,7 @@ mod tests {
             crate::pipe::create(&session, 4, 2),
             Err(BrokerError::ResourceExhausted)
         );
-        assert_eq!(*broker.reserved_pipe_capacity.read(), 0);
+        assert_eq!(broker.reserved_pipe_capacity.load(Ordering::Relaxed), 0);
         assert_eq!(session.close_object_reference(second_handle), Ok(()));
 
         assert_eq!(session.close_object_reference(handle), Ok(()));
@@ -291,9 +293,9 @@ mod tests {
             crate::pipe::create(&session, 5, 2),
             Err(BrokerError::ResourceExhausted)
         );
-        assert_eq!(*broker.reserved_pipe_capacity.read(), 0);
+        assert_eq!(broker.reserved_pipe_capacity.load(Ordering::Relaxed), 0);
         let (reader, writer) = crate::pipe::create(&session, 4, 2).unwrap();
-        assert_eq!(*broker.reserved_pipe_capacity.read(), 4);
+        assert_eq!(broker.reserved_pipe_capacity.load(Ordering::Relaxed), 4);
         assert_eq!(
             crate::pipe::check_readiness(&session, reader),
             Ok(ReadinessFlags::default())
@@ -314,7 +316,7 @@ mod tests {
         );
         assert_eq!(crate::pipe::write(&session, writer, &[5, 6]), Ok(2));
         assert_eq!(session.close_object_reference(writer), Ok(()));
-        assert_eq!(*broker.reserved_pipe_capacity.read(), 4);
+        assert_eq!(broker.reserved_pipe_capacity.load(Ordering::Relaxed), 4);
         assert_eq!(
             crate::pipe::check_readiness(&session, reader),
             Ok(ReadinessFlags::READ | ReadinessFlags::HANGUP)
@@ -328,10 +330,10 @@ mod tests {
             Ok(std::vec::Vec::new())
         );
         assert_eq!(session.close_object_reference(reader), Ok(()));
-        assert_eq!(*broker.reserved_pipe_capacity.read(), 0);
+        assert_eq!(broker.reserved_pipe_capacity.load(Ordering::Relaxed), 0);
 
         let (reader, writer) = crate::pipe::create(&session, 4, 2).unwrap();
-        assert_eq!(*broker.reserved_pipe_capacity.read(), 4);
+        assert_eq!(broker.reserved_pipe_capacity.load(Ordering::Relaxed), 4);
         assert_eq!(session.close_object_reference(reader), Ok(()));
         assert_eq!(crate::pipe::write(&session, writer, &[]), Ok(0));
         assert_eq!(
@@ -343,7 +345,7 @@ mod tests {
             Ok(ReadinessFlags::WRITE | ReadinessFlags::ERROR)
         );
         assert_eq!(session.close_object_reference(writer), Ok(()));
-        assert_eq!(*broker.reserved_pipe_capacity.read(), 0);
+        assert_eq!(broker.reserved_pipe_capacity.load(Ordering::Relaxed), 0);
 
         {
             let mut next_reference_handle = broker.next_reference_handle.write();

--- a/litebox_broker_core/src/session.rs
+++ b/litebox_broker_core/src/session.rs
@@ -212,6 +212,17 @@ mod tests {
             BrokerCoreLimits::new(2, 4),
         )
         .unwrap();
+
+        check_event_reference_lifecycle(&broker);
+        check_session_drop_releases_references(&broker);
+        check_pipe_lifecycle(&broker);
+        check_pipe_reader_closure(&broker);
+        check_pair_handle_exhaustion(&broker);
+
+        assert!(broker.references.read().is_empty());
+    }
+
+    fn check_event_reference_lifecycle(broker: &BrokerCore) {
         let session = broker
             .create_session(CallerCredential::Unauthenticated)
             .unwrap();
@@ -268,7 +279,9 @@ mod tests {
             session.close_object_reference(handle),
             Err(BrokerError::UnknownObject)
         );
+    }
 
+    fn check_session_drop_releases_references(broker: &BrokerCore) {
         let session = broker
             .create_session(CallerCredential::Unauthenticated)
             .unwrap();
@@ -284,7 +297,9 @@ mod tests {
             let references = broker.references.read();
             assert!(references.is_empty());
         }
+    }
 
+    fn check_pipe_lifecycle(broker: &BrokerCore) {
         let session = broker
             .create_session(CallerCredential::Unauthenticated)
             .unwrap();
@@ -330,7 +345,12 @@ mod tests {
         );
         assert_eq!(session.close_object_reference(reader), Ok(()));
         assert_eq!(broker.reserved_pipe_capacity.load(Ordering::Relaxed), 0);
+    }
 
+    fn check_pipe_reader_closure(broker: &BrokerCore) {
+        let session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
         let (reader, writer) = crate::pipe::create(&session, 4, 2).unwrap();
         assert_eq!(broker.reserved_pipe_capacity.load(Ordering::Relaxed), 4);
         assert_eq!(session.close_object_reference(reader), Ok(()));
@@ -345,7 +365,12 @@ mod tests {
         );
         assert_eq!(session.close_object_reference(writer), Ok(()));
         assert_eq!(broker.reserved_pipe_capacity.load(Ordering::Relaxed), 0);
+    }
 
+    fn check_pair_handle_exhaustion(broker: &BrokerCore) {
+        let session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
         {
             let mut next_reference_handle = broker.next_reference_handle.write();
             *next_reference_handle = u64::MAX - 1;
@@ -363,7 +388,5 @@ mod tests {
             crate::event::create(&session, 0),
             Err(BrokerError::ResourceExhausted)
         );
-        let references = broker.references.read();
-        assert!(references.is_empty());
     }
 }

--- a/litebox_broker_core/src/session.rs
+++ b/litebox_broker_core/src/session.rs
@@ -115,8 +115,7 @@ impl BrokerSession {
         {
             return Err(BrokerError::ResourceExhausted);
         }
-        let first_handle = self.core.allocate_reference_handle()?;
-        let second_handle = self.core.allocate_reference_handle()?;
+        let (first_handle, second_handle) = self.core.allocate_reference_handle_pair()?;
         for (handle, object) in [(first_handle, first), (second_handle, second)] {
             references.insert(
                 handle,
@@ -349,8 +348,17 @@ mod tests {
 
         {
             let mut next_reference_handle = broker.next_reference_handle.write();
-            *next_reference_handle = u64::MAX;
+            *next_reference_handle = u64::MAX - 1;
         }
+        assert_eq!(
+            crate::pipe::create(&session, 4, 2),
+            Err(BrokerError::ResourceExhausted)
+        );
+        assert_eq!(*broker.next_reference_handle.read(), u64::MAX - 1);
+        assert_eq!(broker.reserved_pipe_capacity.load(Ordering::Relaxed), 0);
+        let handle = crate::event::create(&session, 0).unwrap();
+        assert_eq!(handle, ObjectHandle(u64::MAX - 1));
+        assert_eq!(session.close_object_reference(handle), Ok(()));
         assert_eq!(
             crate::event::create(&session, 0),
             Err(BrokerError::ResourceExhausted)

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -21,6 +21,10 @@ use litebox_broker_protocol::error::ErrorCode;
 use litebox_broker_protocol::event::{AddEventResponse, CreateEventResponse, WaitEventResponse};
 use litebox_broker_protocol::message::{
     BrokerHandshakeResponse, BrokerRequest, BrokerResponse, EventRequest, EventResponse,
+    PipeRequest, PipeResponse,
+};
+use litebox_broker_protocol::pipe::{
+    CheckPipeReadinessResponse, CreatePipeResponse, ReadPipeResponse, WritePipeResponse,
 };
 
 mod error;
@@ -119,6 +123,46 @@ fn handle_request(session: &BrokerSession, request: BrokerRequest) -> BrokerResp
             Err(error) => BrokerResponse::Error(error.into()),
         },
         BrokerRequest::Event(request) => handle_event_request(session, request),
+        BrokerRequest::Pipe(request) => handle_pipe_request(session, request),
+    }
+}
+
+fn handle_pipe_request(session: &BrokerSession, request: PipeRequest) -> BrokerResponse {
+    let response = match request {
+        PipeRequest::Create(request) => {
+            litebox_broker_core::pipe::create(session, request.capacity, request.atomic_write_size)
+                .map(|(read_handle, write_handle)| {
+                    PipeResponse::Create(CreatePipeResponse {
+                        read_handle,
+                        write_handle,
+                    })
+                })
+        }
+        PipeRequest::Read(request) => {
+            litebox_broker_core::pipe::read(session, request.handle, request.length)
+                .map(|data| PipeResponse::Read(ReadPipeResponse { data }))
+        }
+        PipeRequest::Write(request) => {
+            litebox_broker_core::pipe::write(session, request.handle, &request.data).and_then(
+                |written| {
+                    Ok(PipeResponse::Write(WritePipeResponse {
+                        written: written
+                            .try_into()
+                            .map_err(|_| litebox_broker_core::BrokerError::ResourceExhausted)?,
+                    }))
+                },
+            )
+        }
+        PipeRequest::CheckReadiness(request) => {
+            litebox_broker_core::pipe::check_readiness(session, request.handle).map(|readiness| {
+                PipeResponse::CheckReadiness(CheckPipeReadinessResponse { readiness })
+            })
+        }
+    };
+
+    match response {
+        Ok(response) => BrokerResponse::Pipe(response),
+        Err(error) => BrokerResponse::Error(error.into()),
     }
 }
 

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -18,14 +18,12 @@ use litebox_broker_protocol::channel::{
     HostControlChannel, HostNotificationChannel, HostReceive, PeerCredential,
 };
 use litebox_broker_protocol::error::ErrorCode;
-use litebox_broker_protocol::event::{AddEventResponse, CreateEventResponse, WaitEventResponse};
+use litebox_broker_protocol::event::{AddEventResponse, CreateEventResponse};
 use litebox_broker_protocol::message::{
     BrokerHandshakeResponse, BrokerRequest, BrokerResponse, EventRequest, EventResponse,
     PipeRequest, PipeResponse,
 };
-use litebox_broker_protocol::pipe::{
-    CheckPipeReadinessResponse, CreatePipeResponse, ReadPipeResponse, WritePipeResponse,
-};
+use litebox_broker_protocol::pipe::{CreatePipeResponse, ReadPipeResponse, WritePipeResponse};
 
 mod error;
 
@@ -122,6 +120,10 @@ fn handle_request(session: &BrokerSession, request: BrokerRequest) -> BrokerResp
             Ok(()) => BrokerResponse::ObjectClosed,
             Err(error) => BrokerResponse::Error(error.into()),
         },
+        BrokerRequest::CheckReadiness(handle) => match session.check_readiness(handle) {
+            Ok(readiness) => BrokerResponse::Readiness(readiness),
+            Err(error) => BrokerResponse::Error(error.into()),
+        },
         BrokerRequest::Event(request) => handle_event_request(session, request),
         BrokerRequest::Pipe(request) => handle_pipe_request(session, request),
     }
@@ -153,11 +155,6 @@ fn handle_pipe_request(session: &BrokerSession, request: PipeRequest) -> BrokerR
                 },
             )
         }
-        PipeRequest::CheckReadiness(request) => {
-            litebox_broker_core::pipe::check_readiness(session, request.handle).map(|readiness| {
-                PipeResponse::CheckReadiness(CheckPipeReadinessResponse { readiness })
-            })
-        }
     };
 
     match response {
@@ -172,14 +169,6 @@ fn handle_event_request(session: &BrokerSession, request: EventRequest) -> Broke
             match litebox_broker_core::event::create(session, request.initial_count) {
                 Ok(handle) => {
                     BrokerResponse::Event(EventResponse::Create(CreateEventResponse { handle }))
-                }
-                Err(error) => BrokerResponse::Error(error.into()),
-            }
-        }
-        EventRequest::Wait(request) => {
-            match litebox_broker_core::event::wait(session, request.handle) {
-                Ok(readiness) => {
-                    BrokerResponse::Event(EventResponse::Wait(WaitEventResponse { readiness }))
                 }
                 Err(error) => BrokerResponse::Error(error.into()),
             }
@@ -217,7 +206,6 @@ mod tests {
     use litebox_broker_core::{ObjectRights, PolicyEngine};
     use litebox_broker_protocol::event::{
         AddEventRequest, ConsumeEventRequest, CreateEventRequest, EventConsumeMode,
-        WaitEventRequest,
     };
     use litebox_broker_protocol::message::{BrokerHandshakeRequest, BrokerNotification};
     use litebox_broker_protocol::{ObjectHandle, ProtocolVersion};
@@ -414,10 +402,7 @@ mod tests {
             BrokerResponse::ObjectClosed
         );
         assert_eq!(
-            handle_request(
-                &session,
-                BrokerRequest::Event(EventRequest::Wait(WaitEventRequest { handle }))
-            ),
+            handle_request(&session, BrokerRequest::CheckReadiness(handle)),
             BrokerResponse::Error(ErrorCode::UnknownObject)
         );
         assert_eq!(

--- a/litebox_broker_local/src/event.rs
+++ b/litebox_broker_local/src/event.rs
@@ -88,7 +88,7 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
         match self.request(BrokerRequest::Event(request))? {
             BrokerResponse::Event(response) => Ok(response),
             BrokerResponse::Error(error) => Err(BrokerLocalError::Broker(error)),
-            response @ BrokerResponse::ObjectClosed => {
+            response @ (BrokerResponse::ObjectClosed | BrokerResponse::Pipe(_)) => {
                 panic!("broker returned unexpected event response: {response:?}");
             }
         }

--- a/litebox_broker_local/src/event.rs
+++ b/litebox_broker_local/src/event.rs
@@ -5,7 +5,7 @@ use litebox_broker_protocol::ObjectHandle;
 use litebox_broker_protocol::channel::LocalControlChannel;
 use litebox_broker_protocol::event::{
     AddEventRequest, ConsumeEventRequest, ConsumeEventResponse, CreateEventRequest,
-    EventConsumeMode, WaitEventRequest,
+    EventConsumeMode,
 };
 use litebox_broker_protocol::message::{
     BrokerRequest, BrokerResponse, EventRequest, EventResponse,
@@ -29,20 +29,6 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
             self.request_event(EventRequest::Create(CreateEventRequest { initial_count }))?;
         match response {
             EventResponse::Create(response) => Ok(response.handle),
-            response => panic!("broker returned unexpected event response: {response:?}"),
-        }
-    }
-
-    /// Checks whether an event wait would complete now.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the broker reports an unrecoverable error or returns a protocol
-    /// response that does not match the issued event request.
-    pub fn wait_event(&mut self, handle: ObjectHandle) -> Result<ReadinessFlags, Channel::Error> {
-        let response = self.request_event(EventRequest::Wait(WaitEventRequest { handle }))?;
-        match response {
-            EventResponse::Wait(response) => Ok(response.readiness),
             response => panic!("broker returned unexpected event response: {response:?}"),
         }
     }
@@ -88,7 +74,9 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
         match self.request(BrokerRequest::Event(request))? {
             BrokerResponse::Event(response) => Ok(response),
             BrokerResponse::Error(error) => Err(BrokerLocalError::Broker(error)),
-            response @ (BrokerResponse::ObjectClosed | BrokerResponse::Pipe(_)) => {
+            response @ (BrokerResponse::ObjectClosed
+            | BrokerResponse::Readiness(_)
+            | BrokerResponse::Pipe(_)) => {
                 panic!("broker returned unexpected event response: {response:?}");
             }
         }

--- a/litebox_broker_local/src/lib.rs
+++ b/litebox_broker_local/src/lib.rs
@@ -26,6 +26,7 @@ use litebox_broker_protocol::message::{
     BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerNotification, BrokerRequest,
     BrokerResponse,
 };
+use litebox_broker_protocol::readiness::ReadinessFlags;
 use litebox_broker_protocol::{BROKER_PROTOCOL_VERSION, ObjectHandle};
 
 pub use error::{BrokerLocalError, Result};
@@ -118,7 +119,25 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
             },
             response @ (BrokerResponse::Event(_)
             | BrokerResponse::Pipe(_)
-            | BrokerResponse::ObjectClosed) => Ok(response),
+            | BrokerResponse::ObjectClosed
+            | BrokerResponse::Readiness(_)) => Ok(response),
+        }
+    }
+
+    /// Checks the current readiness of a broker-owned object.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the broker reports an unrecoverable error or returns a
+    /// response that does not match the issued readiness request.
+    pub fn check_readiness(
+        &mut self,
+        handle: ObjectHandle,
+    ) -> Result<ReadinessFlags, Channel::Error> {
+        match self.request(BrokerRequest::CheckReadiness(handle))? {
+            BrokerResponse::Readiness(readiness) => Ok(readiness),
+            BrokerResponse::Error(error) => Err(BrokerLocalError::Broker(error)),
+            response => panic!("broker returned unexpected readiness response: {response:?}"),
         }
     }
 
@@ -132,7 +151,9 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
         match self.request(BrokerRequest::CloseObject(handle))? {
             BrokerResponse::ObjectClosed => Ok(()),
             BrokerResponse::Error(error) => Err(BrokerLocalError::Broker(error)),
-            response @ (BrokerResponse::Event(_) | BrokerResponse::Pipe(_)) => {
+            response @ (BrokerResponse::Event(_)
+            | BrokerResponse::Pipe(_)
+            | BrokerResponse::Readiness(_)) => {
                 panic!("broker returned unexpected close response: {response:?}");
             }
         }

--- a/litebox_broker_local/src/lib.rs
+++ b/litebox_broker_local/src/lib.rs
@@ -11,11 +11,14 @@
 
 #![no_std]
 
+extern crate alloc;
+
 #[cfg(test)]
 extern crate std;
 
 mod error;
 mod event;
+mod pipe;
 
 use litebox_broker_protocol::channel::{LocalControlChannel, LocalNotificationChannel};
 use litebox_broker_protocol::error::ErrorCode;
@@ -103,7 +106,9 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
                 | ErrorCode::UnknownObject
                 | ErrorCode::InvalidRights
                 | ErrorCode::ResourceExhausted
-                | ErrorCode::WouldBlock => Err(BrokerLocalError::Broker(error)),
+                | ErrorCode::WouldBlock
+                | ErrorCode::PeerClosed
+                | ErrorCode::OutOfMemory => Err(BrokerLocalError::Broker(error)),
                 ErrorCode::UnsupportedVersion
                 | ErrorCode::MalformedRequest
                 | ErrorCode::ProtocolState
@@ -111,7 +116,9 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
                 | ErrorCode::Internal => panic!("broker returned unrecoverable error: {error}"),
                 _ => panic!("broker returned unsupported error: {error}"),
             },
-            response @ (BrokerResponse::Event(_) | BrokerResponse::ObjectClosed) => Ok(response),
+            response @ (BrokerResponse::Event(_)
+            | BrokerResponse::Pipe(_)
+            | BrokerResponse::ObjectClosed) => Ok(response),
         }
     }
 
@@ -125,7 +132,7 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
         match self.request(BrokerRequest::CloseObject(handle))? {
             BrokerResponse::ObjectClosed => Ok(()),
             BrokerResponse::Error(error) => Err(BrokerLocalError::Broker(error)),
-            response @ BrokerResponse::Event(_) => {
+            response @ (BrokerResponse::Event(_) | BrokerResponse::Pipe(_)) => {
                 panic!("broker returned unexpected close response: {response:?}");
             }
         }

--- a/litebox_broker_local/src/pipe.rs
+++ b/litebox_broker_local/src/pipe.rs
@@ -7,10 +7,8 @@ use litebox_broker_protocol::ObjectHandle;
 use litebox_broker_protocol::channel::LocalControlChannel;
 use litebox_broker_protocol::message::{BrokerRequest, BrokerResponse, PipeRequest, PipeResponse};
 use litebox_broker_protocol::pipe::{
-    CheckPipeReadinessRequest, CreatePipeRequest, CreatePipeResponse, ReadPipeRequest,
-    WritePipeRequest,
+    CreatePipeRequest, CreatePipeResponse, ReadPipeRequest, WritePipeRequest,
 };
-use litebox_broker_protocol::readiness::ReadinessFlags;
 
 use crate::{BrokerLocal, BrokerLocalError, Result};
 
@@ -72,29 +70,13 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
         }
     }
 
-    /// Checks one broker-owned pipe endpoint's readiness.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the broker reports an unrecoverable error or returns a
-    /// response that does not match the issued pipe request.
-    pub fn check_pipe_readiness(
-        &mut self,
-        handle: ObjectHandle,
-    ) -> Result<ReadinessFlags, Channel::Error> {
-        match self.request_pipe(PipeRequest::CheckReadiness(CheckPipeReadinessRequest {
-            handle,
-        }))? {
-            PipeResponse::CheckReadiness(response) => Ok(response.readiness),
-            response => panic!("broker returned unexpected pipe response: {response:?}"),
-        }
-    }
-
     fn request_pipe(&mut self, request: PipeRequest) -> Result<PipeResponse, Channel::Error> {
         match self.request(BrokerRequest::Pipe(request))? {
             BrokerResponse::Pipe(response) => Ok(response),
             BrokerResponse::Error(error) => Err(BrokerLocalError::Broker(error)),
-            response @ (BrokerResponse::ObjectClosed | BrokerResponse::Event(_)) => {
+            response @ (BrokerResponse::ObjectClosed
+            | BrokerResponse::Readiness(_)
+            | BrokerResponse::Event(_)) => {
                 panic!("broker returned unexpected pipe response: {response:?}");
             }
         }

--- a/litebox_broker_local/src/pipe.rs
+++ b/litebox_broker_local/src/pipe.rs
@@ -1,0 +1,102 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+use alloc::vec::Vec;
+
+use litebox_broker_protocol::ObjectHandle;
+use litebox_broker_protocol::channel::LocalControlChannel;
+use litebox_broker_protocol::message::{BrokerRequest, BrokerResponse, PipeRequest, PipeResponse};
+use litebox_broker_protocol::pipe::{
+    CheckPipeReadinessRequest, CreatePipeRequest, CreatePipeResponse, ReadPipeRequest,
+    WritePipeRequest,
+};
+use litebox_broker_protocol::readiness::ReadinessFlags;
+
+use crate::{BrokerLocal, BrokerLocalError, Result};
+
+impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
+    /// Creates a broker-owned byte pipe.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the broker reports an unrecoverable error or returns a
+    /// response that does not match the issued pipe request.
+    pub fn create_pipe(
+        &mut self,
+        capacity: u64,
+        atomic_write_size: u64,
+    ) -> Result<CreatePipeResponse, Channel::Error> {
+        match self.request_pipe(PipeRequest::Create(CreatePipeRequest {
+            capacity,
+            atomic_write_size,
+        }))? {
+            PipeResponse::Create(response) => Ok(response),
+            response => panic!("broker returned unexpected pipe response: {response:?}"),
+        }
+    }
+
+    /// Reads bytes from a broker-owned pipe.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the broker reports an unrecoverable error or returns a
+    /// response that does not match the issued pipe request.
+    pub fn read_pipe(
+        &mut self,
+        handle: ObjectHandle,
+        length: u32,
+    ) -> Result<Vec<u8>, Channel::Error> {
+        match self.request_pipe(PipeRequest::Read(ReadPipeRequest { handle, length }))? {
+            PipeResponse::Read(response) => Ok(response.data),
+            response => panic!("broker returned unexpected pipe response: {response:?}"),
+        }
+    }
+
+    /// Writes bytes to a broker-owned pipe.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the broker reports an unrecoverable error or returns a
+    /// response that does not match the issued pipe request.
+    pub fn write_pipe(
+        &mut self,
+        handle: ObjectHandle,
+        data: &[u8],
+    ) -> Result<usize, Channel::Error> {
+        match self.request_pipe(PipeRequest::Write(WritePipeRequest {
+            handle,
+            data: data.to_vec(),
+        }))? {
+            PipeResponse::Write(response) => Ok(response.written as usize),
+            response => panic!("broker returned unexpected pipe response: {response:?}"),
+        }
+    }
+
+    /// Checks one broker-owned pipe endpoint's readiness.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the broker reports an unrecoverable error or returns a
+    /// response that does not match the issued pipe request.
+    pub fn check_pipe_readiness(
+        &mut self,
+        handle: ObjectHandle,
+    ) -> Result<ReadinessFlags, Channel::Error> {
+        match self.request_pipe(PipeRequest::CheckReadiness(CheckPipeReadinessRequest {
+            handle,
+        }))? {
+            PipeResponse::CheckReadiness(response) => Ok(response.readiness),
+            response => panic!("broker returned unexpected pipe response: {response:?}"),
+        }
+    }
+
+    fn request_pipe(&mut self, request: PipeRequest) -> Result<PipeResponse, Channel::Error> {
+        match self.request(BrokerRequest::Pipe(request))? {
+            BrokerResponse::Pipe(response) => Ok(response),
+            BrokerResponse::Error(error) => Err(BrokerLocalError::Broker(error)),
+            response @ (BrokerResponse::ObjectClosed | BrokerResponse::Event(_)) => {
+                panic!("broker returned unexpected pipe response: {response:?}");
+            }
+        }
+    }
+}

--- a/litebox_broker_protocol/src/error.rs
+++ b/litebox_broker_protocol/src/error.rs
@@ -27,6 +27,10 @@ pub enum ErrorCode {
     ResourceExhausted,
     #[error("broker operation would block")]
     WouldBlock,
+    #[error("broker object peer is closed")]
+    PeerClosed,
+    #[error("broker memory allocation failed")]
+    OutOfMemory,
 }
 
 impl ErrorCode {
@@ -48,6 +52,8 @@ impl ErrorCode {
             8 => Some(Self::InvalidRights),
             9 => Some(Self::ResourceExhausted),
             10 => Some(Self::WouldBlock),
+            11 => Some(Self::PeerClosed),
+            12 => Some(Self::OutOfMemory),
             _ => None,
         }
     }
@@ -65,6 +71,8 @@ impl ErrorCode {
             Self::InvalidRights => 8,
             Self::ResourceExhausted => 9,
             Self::WouldBlock => 10,
+            Self::PeerClosed => 11,
+            Self::OutOfMemory => 12,
         }
     }
 }

--- a/litebox_broker_protocol/src/event.rs
+++ b/litebox_broker_protocol/src/event.rs
@@ -27,20 +27,6 @@ pub struct CreateEventResponse {
     pub handle: ObjectHandle,
 }
 
-/// Request to check whether an event wait would complete now.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct WaitEventRequest {
-    /// Event handle.
-    pub handle: ObjectHandle,
-}
-
-/// Response to an event wait request.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct WaitEventResponse {
-    /// Current readiness state.
-    pub readiness: ReadinessFlags,
-}
-
 /// Request to add readiness credits to an event.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct AddEventRequest {

--- a/litebox_broker_protocol/src/lib.rs
+++ b/litebox_broker_protocol/src/lib.rs
@@ -16,6 +16,7 @@ pub mod channel;
 pub mod error;
 pub mod event;
 pub mod message;
+pub mod pipe;
 pub mod readiness;
 pub mod wire;
 

--- a/litebox_broker_protocol/src/message.rs
+++ b/litebox_broker_protocol/src/message.rs
@@ -6,6 +6,10 @@ use crate::event::{
     AddEventRequest, AddEventResponse, ConsumeEventRequest, ConsumeEventResponse,
     CreateEventRequest, CreateEventResponse, WaitEventRequest, WaitEventResponse,
 };
+use crate::pipe::{
+    CheckPipeReadinessRequest, CheckPipeReadinessResponse, CreatePipeRequest, CreatePipeResponse,
+    ReadPipeRequest, ReadPipeResponse, WritePipeRequest, WritePipeResponse,
+};
 use crate::readiness::ReadinessFlags;
 use crate::{ObjectHandle, ProtocolVersion};
 
@@ -23,6 +27,8 @@ pub enum BrokerRequest {
     CloseObject(ObjectHandle),
     /// Event object request family.
     Event(EventRequest),
+    /// Pipe object request family.
+    Pipe(PipeRequest),
 }
 
 /// Broker handshake response sent before the control channel is active.
@@ -62,6 +68,19 @@ pub enum EventRequest {
     Consume(ConsumeEventRequest),
 }
 
+/// Broker-owned pipe object request.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PipeRequest {
+    /// Create a broker-owned byte pipe.
+    Create(CreatePipeRequest),
+    /// Read bytes from a pipe.
+    Read(ReadPipeRequest),
+    /// Write bytes to a pipe.
+    Write(WritePipeRequest),
+    /// Query one endpoint's readiness.
+    CheckReadiness(CheckPipeReadinessRequest),
+}
+
 /// Broker response sent over an active control channel.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum BrokerResponse {
@@ -69,6 +88,8 @@ pub enum BrokerResponse {
     ObjectClosed,
     /// Event object response family.
     Event(EventResponse),
+    /// Pipe object response family.
+    Pipe(PipeResponse),
     /// Operation failed with an ABI-neutral broker error.
     Error(ErrorCode),
 }
@@ -84,6 +105,19 @@ pub enum EventResponse {
     Add(AddEventResponse),
     /// Consume operation response.
     Consume(ConsumeEventResponse),
+}
+
+/// Broker-owned pipe object response.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PipeResponse {
+    /// Create operation response.
+    Create(CreatePipeResponse),
+    /// Read operation response.
+    Read(ReadPipeResponse),
+    /// Write operation response.
+    Write(WritePipeResponse),
+    /// Readiness query response.
+    CheckReadiness(CheckPipeReadinessResponse),
 }
 
 /// Broker-initiated asynchronous notification.

--- a/litebox_broker_protocol/src/message.rs
+++ b/litebox_broker_protocol/src/message.rs
@@ -4,11 +4,11 @@
 use crate::error::ErrorCode;
 use crate::event::{
     AddEventRequest, AddEventResponse, ConsumeEventRequest, ConsumeEventResponse,
-    CreateEventRequest, CreateEventResponse, WaitEventRequest, WaitEventResponse,
+    CreateEventRequest, CreateEventResponse,
 };
 use crate::pipe::{
-    CheckPipeReadinessRequest, CheckPipeReadinessResponse, CreatePipeRequest, CreatePipeResponse,
-    ReadPipeRequest, ReadPipeResponse, WritePipeRequest, WritePipeResponse,
+    CreatePipeRequest, CreatePipeResponse, ReadPipeRequest, ReadPipeResponse, WritePipeRequest,
+    WritePipeResponse,
 };
 use crate::readiness::ReadinessFlags;
 use crate::{ObjectHandle, ProtocolVersion};
@@ -25,6 +25,8 @@ pub struct BrokerHandshakeRequest {
 pub enum BrokerRequest {
     /// Close one broker object reference.
     CloseObject(ObjectHandle),
+    /// Check the current readiness of a broker-owned object.
+    CheckReadiness(ObjectHandle),
     /// Event object request family.
     Event(EventRequest),
     /// Pipe object request family.
@@ -60,8 +62,6 @@ pub enum BrokerHandshakeResponse {
 pub enum EventRequest {
     /// Create a broker-owned event object.
     Create(CreateEventRequest),
-    /// Check whether an event wait would complete now.
-    Wait(WaitEventRequest),
     /// Add readiness credits to an event.
     Add(AddEventRequest),
     /// Consume readiness credits from an event.
@@ -77,8 +77,6 @@ pub enum PipeRequest {
     Read(ReadPipeRequest),
     /// Write bytes to a pipe.
     Write(WritePipeRequest),
-    /// Query one endpoint's readiness.
-    CheckReadiness(CheckPipeReadinessRequest),
 }
 
 /// Broker response sent over an active control channel.
@@ -86,6 +84,8 @@ pub enum PipeRequest {
 pub enum BrokerResponse {
     /// Object close operation completed.
     ObjectClosed,
+    /// Current readiness of a broker-owned object.
+    Readiness(ReadinessFlags),
     /// Event object response family.
     Event(EventResponse),
     /// Pipe object response family.
@@ -99,8 +99,6 @@ pub enum BrokerResponse {
 pub enum EventResponse {
     /// Create operation response.
     Create(CreateEventResponse),
-    /// Wait operation response.
-    Wait(WaitEventResponse),
     /// Add operation response.
     Add(AddEventResponse),
     /// Consume operation response.
@@ -116,8 +114,6 @@ pub enum PipeResponse {
     Read(ReadPipeResponse),
     /// Write operation response.
     Write(WritePipeResponse),
-    /// Readiness query response.
-    CheckReadiness(CheckPipeReadinessResponse),
 }
 
 /// Broker-initiated asynchronous notification.

--- a/litebox_broker_protocol/src/pipe.rs
+++ b/litebox_broker_protocol/src/pipe.rs
@@ -4,7 +4,6 @@
 use alloc::vec::Vec;
 
 use crate::ObjectHandle;
-use crate::readiness::ReadinessFlags;
 
 /// Maximum pipe payload carried by one control-path request or response.
 ///
@@ -60,18 +59,4 @@ pub struct WritePipeRequest {
 pub struct WritePipeResponse {
     /// Number of bytes appended to the pipe.
     pub written: u32,
-}
-
-/// Request to query one pipe endpoint's readiness.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct CheckPipeReadinessRequest {
-    /// Pipe endpoint handle.
-    pub handle: ObjectHandle,
-}
-
-/// Response to a pipe readiness query.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct CheckPipeReadinessResponse {
-    /// Current endpoint readiness.
-    pub readiness: ReadinessFlags,
 }

--- a/litebox_broker_protocol/src/pipe.rs
+++ b/litebox_broker_protocol/src/pipe.rs
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+use alloc::vec::Vec;
+
+use crate::ObjectHandle;
+use crate::readiness::ReadinessFlags;
+
+/// Maximum pipe payload carried by one control-path request or response.
+///
+/// This leaves room for the broker envelope and operation metadata within the
+/// smallest currently supported transport frame.
+pub const MAX_PIPE_TRANSFER_SIZE: u32 = 32 * 1024;
+
+/// Request to create a broker-owned byte pipe.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CreatePipeRequest {
+    /// Maximum number of buffered bytes.
+    pub capacity: u64,
+    /// Maximum write size that must be accepted atomically.
+    pub atomic_write_size: u64,
+}
+
+/// Response to a pipe create request.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CreatePipeResponse {
+    /// Handle for the read endpoint.
+    pub read_handle: ObjectHandle,
+    /// Handle for the write endpoint.
+    pub write_handle: ObjectHandle,
+}
+
+/// Request to read bytes from a pipe endpoint.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ReadPipeRequest {
+    /// Read endpoint handle.
+    pub handle: ObjectHandle,
+    /// Maximum number of bytes to return.
+    pub length: u32,
+}
+
+/// Response containing bytes read from a pipe.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReadPipeResponse {
+    /// Bytes removed from the pipe.
+    pub data: Vec<u8>,
+}
+
+/// Request to write bytes to a pipe endpoint.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WritePipeRequest {
+    /// Write endpoint handle.
+    pub handle: ObjectHandle,
+    /// Bytes to append to the pipe.
+    pub data: Vec<u8>,
+}
+
+/// Response describing a completed pipe write.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct WritePipeResponse {
+    /// Number of bytes appended to the pipe.
+    pub written: u32,
+}
+
+/// Request to query one pipe endpoint's readiness.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CheckPipeReadinessRequest {
+    /// Pipe endpoint handle.
+    pub handle: ObjectHandle,
+}
+
+/// Response to a pipe readiness query.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CheckPipeReadinessResponse {
+    /// Current endpoint readiness.
+    pub readiness: ReadinessFlags,
+}

--- a/litebox_broker_protocol/src/wire.rs
+++ b/litebox_broker_protocol/src/wire.rs
@@ -28,17 +28,20 @@ use crate::readiness::ReadinessFlags;
 use primitive::{Decoder, Encoder};
 
 mod event;
+mod pipe;
 mod primitive;
 
 const REQUEST_TAG_NEGOTIATE: u8 = 0;
 const REQUEST_TAG_EVENT: u8 = 1;
 const REQUEST_TAG_CLOSE_OBJECT: u8 = 2;
+const REQUEST_TAG_PIPE: u8 = 3;
 
 const RESPONSE_TAG_NEGOTIATED: u8 = 0;
 const RESPONSE_TAG_EVENT: u8 = 1;
 const RESPONSE_TAG_ERROR: u8 = 2;
 const RESPONSE_TAG_VERSION_MISMATCH: u8 = 3;
 const RESPONSE_TAG_OBJECT_CLOSED: u8 = 4;
+const RESPONSE_TAG_PIPE: u8 = 5;
 
 const NOTIFICATION_TAG_READINESS: u8 = 0;
 
@@ -77,7 +80,9 @@ pub fn decode_handshake_request(frame: &[u8]) -> Result<BrokerHandshakeRequest, 
         REQUEST_TAG_NEGOTIATE => BrokerHandshakeRequest {
             protocol_version: decoder.protocol_version()?,
         },
-        REQUEST_TAG_EVENT | REQUEST_TAG_CLOSE_OBJECT => return Err(WireError::WrongMessagePhase),
+        REQUEST_TAG_EVENT | REQUEST_TAG_CLOSE_OBJECT | REQUEST_TAG_PIPE => {
+            return Err(WireError::WrongMessagePhase);
+        }
         _ => return Err(WireError::InvalidTag),
     };
     decoder.finish()?;
@@ -99,6 +104,10 @@ pub fn encode_request(request: BrokerRequest) -> Vec<u8> {
             encoder.u8(REQUEST_TAG_EVENT);
             event::encode_event_request(&mut encoder, request);
         }
+        BrokerRequest::Pipe(request) => {
+            encoder.u8(REQUEST_TAG_PIPE);
+            pipe::encode_pipe_request(&mut encoder, request);
+        }
     }
     encoder.finish()
 }
@@ -111,6 +120,7 @@ pub fn decode_request(frame: &[u8]) -> Result<BrokerRequest, WireError> {
         REQUEST_TAG_NEGOTIATE => return Err(WireError::WrongMessagePhase),
         REQUEST_TAG_CLOSE_OBJECT => BrokerRequest::CloseObject(decoder.handle()?),
         REQUEST_TAG_EVENT => BrokerRequest::Event(event::decode_event_request(&mut decoder)?),
+        REQUEST_TAG_PIPE => BrokerRequest::Pipe(pipe::decode_pipe_request(&mut decoder)?),
         _ => return Err(WireError::InvalidTag),
     };
     decoder.finish()?;
@@ -152,7 +162,7 @@ pub fn decode_handshake_response(frame: &[u8]) -> Result<BrokerHandshakeResponse
         RESPONSE_TAG_NEGOTIATED => BrokerHandshakeResponse::Negotiated {
             broker_protocol_version: decoder.protocol_version()?,
         },
-        RESPONSE_TAG_EVENT | RESPONSE_TAG_OBJECT_CLOSED => {
+        RESPONSE_TAG_EVENT | RESPONSE_TAG_OBJECT_CLOSED | RESPONSE_TAG_PIPE => {
             return Err(WireError::WrongMessagePhase);
         }
         RESPONSE_TAG_VERSION_MISMATCH => BrokerHandshakeResponse::VersionMismatch {
@@ -182,6 +192,10 @@ pub fn encode_response(response: BrokerResponse) -> Vec<u8> {
             encoder.u8(RESPONSE_TAG_EVENT);
             event::encode_event_response(&mut encoder, response);
         }
+        BrokerResponse::Pipe(response) => {
+            encoder.u8(RESPONSE_TAG_PIPE);
+            pipe::encode_pipe_response(&mut encoder, response);
+        }
         BrokerResponse::Error(error) => {
             encoder.u8(RESPONSE_TAG_ERROR);
             encoder.u16(error.as_raw());
@@ -199,6 +213,7 @@ pub fn decode_response(frame: &[u8]) -> Result<BrokerResponse, WireError> {
             return Err(WireError::WrongMessagePhase);
         }
         RESPONSE_TAG_EVENT => BrokerResponse::Event(event::decode_event_response(&mut decoder)?),
+        RESPONSE_TAG_PIPE => BrokerResponse::Pipe(pipe::decode_pipe_response(&mut decoder)?),
         RESPONSE_TAG_ERROR => {
             let error = ErrorCode::from_raw(decoder.u16()?).ok_or(WireError::InvalidTag)?;
             BrokerResponse::Error(error)
@@ -249,7 +264,11 @@ mod tests {
         CreateEventResponse, EventConsumeMode, EventConsumption, WaitEventRequest,
         WaitEventResponse,
     };
-    use crate::message::{EventRequest, EventResponse};
+    use crate::message::{EventRequest, EventResponse, PipeRequest, PipeResponse};
+    use crate::pipe::{
+        CheckPipeReadinessRequest, CheckPipeReadinessResponse, CreatePipeRequest,
+        CreatePipeResponse, ReadPipeRequest, ReadPipeResponse, WritePipeRequest, WritePipeResponse,
+    };
     use crate::{ObjectHandle, ProtocolVersion};
 
     #[test]
@@ -286,6 +305,18 @@ mod tests {
             BrokerRequest::Event(EventRequest::Consume(ConsumeEventRequest {
                 handle,
                 mode: EventConsumeMode::One,
+            })),
+            BrokerRequest::Pipe(PipeRequest::Create(CreatePipeRequest {
+                capacity: 4096,
+                atomic_write_size: 512,
+            })),
+            BrokerRequest::Pipe(PipeRequest::Read(ReadPipeRequest { handle, length: 32 })),
+            BrokerRequest::Pipe(PipeRequest::Write(WritePipeRequest {
+                handle,
+                data: Vec::from([1, 2, 3]),
+            })),
+            BrokerRequest::Pipe(PipeRequest::CheckReadiness(CheckPipeReadinessRequest {
+                handle,
             })),
         ];
 
@@ -337,8 +368,21 @@ mod tests {
                 value: 3,
                 readiness: ReadinessFlags::WRITE,
             })),
+            BrokerResponse::Pipe(PipeResponse::Create(CreatePipeResponse {
+                read_handle: handle,
+                write_handle: ObjectHandle(14),
+            })),
+            BrokerResponse::Pipe(PipeResponse::Read(ReadPipeResponse {
+                data: Vec::from([1, 2, 3]),
+            })),
+            BrokerResponse::Pipe(PipeResponse::Write(WritePipeResponse { written: 3 })),
+            BrokerResponse::Pipe(PipeResponse::CheckReadiness(CheckPipeReadinessResponse {
+                readiness: ReadinessFlags::READ | ReadinessFlags::HANGUP,
+            })),
             BrokerResponse::Error(ErrorCode::PolicyDenied),
             BrokerResponse::Error(ErrorCode::WouldBlock),
+            BrokerResponse::Error(ErrorCode::PeerClosed),
+            BrokerResponse::Error(ErrorCode::OutOfMemory),
             BrokerResponse::Error(ErrorCode::Internal),
         ];
 

--- a/litebox_broker_protocol/src/wire.rs
+++ b/litebox_broker_protocol/src/wire.rs
@@ -35,6 +35,7 @@ const REQUEST_TAG_NEGOTIATE: u8 = 0;
 const REQUEST_TAG_EVENT: u8 = 1;
 const REQUEST_TAG_CLOSE_OBJECT: u8 = 2;
 const REQUEST_TAG_PIPE: u8 = 3;
+const REQUEST_TAG_CHECK_READINESS: u8 = 4;
 
 const RESPONSE_TAG_NEGOTIATED: u8 = 0;
 const RESPONSE_TAG_EVENT: u8 = 1;
@@ -42,6 +43,7 @@ const RESPONSE_TAG_ERROR: u8 = 2;
 const RESPONSE_TAG_VERSION_MISMATCH: u8 = 3;
 const RESPONSE_TAG_OBJECT_CLOSED: u8 = 4;
 const RESPONSE_TAG_PIPE: u8 = 5;
+const RESPONSE_TAG_READINESS: u8 = 6;
 
 const NOTIFICATION_TAG_READINESS: u8 = 0;
 
@@ -80,7 +82,10 @@ pub fn decode_handshake_request(frame: &[u8]) -> Result<BrokerHandshakeRequest, 
         REQUEST_TAG_NEGOTIATE => BrokerHandshakeRequest {
             protocol_version: decoder.protocol_version()?,
         },
-        REQUEST_TAG_EVENT | REQUEST_TAG_CLOSE_OBJECT | REQUEST_TAG_PIPE => {
+        REQUEST_TAG_EVENT
+        | REQUEST_TAG_CLOSE_OBJECT
+        | REQUEST_TAG_PIPE
+        | REQUEST_TAG_CHECK_READINESS => {
             return Err(WireError::WrongMessagePhase);
         }
         _ => return Err(WireError::InvalidTag),
@@ -98,6 +103,10 @@ pub fn encode_request(request: BrokerRequest) -> Vec<u8> {
     match request {
         BrokerRequest::CloseObject(handle) => {
             encoder.u8(REQUEST_TAG_CLOSE_OBJECT);
+            encoder.handle(handle);
+        }
+        BrokerRequest::CheckReadiness(handle) => {
+            encoder.u8(REQUEST_TAG_CHECK_READINESS);
             encoder.handle(handle);
         }
         BrokerRequest::Event(request) => {
@@ -119,6 +128,7 @@ pub fn decode_request(frame: &[u8]) -> Result<BrokerRequest, WireError> {
     let request = match tag {
         REQUEST_TAG_NEGOTIATE => return Err(WireError::WrongMessagePhase),
         REQUEST_TAG_CLOSE_OBJECT => BrokerRequest::CloseObject(decoder.handle()?),
+        REQUEST_TAG_CHECK_READINESS => BrokerRequest::CheckReadiness(decoder.handle()?),
         REQUEST_TAG_EVENT => BrokerRequest::Event(event::decode_event_request(&mut decoder)?),
         REQUEST_TAG_PIPE => BrokerRequest::Pipe(pipe::decode_pipe_request(&mut decoder)?),
         _ => return Err(WireError::InvalidTag),
@@ -162,7 +172,10 @@ pub fn decode_handshake_response(frame: &[u8]) -> Result<BrokerHandshakeResponse
         RESPONSE_TAG_NEGOTIATED => BrokerHandshakeResponse::Negotiated {
             broker_protocol_version: decoder.protocol_version()?,
         },
-        RESPONSE_TAG_EVENT | RESPONSE_TAG_OBJECT_CLOSED | RESPONSE_TAG_PIPE => {
+        RESPONSE_TAG_EVENT
+        | RESPONSE_TAG_OBJECT_CLOSED
+        | RESPONSE_TAG_PIPE
+        | RESPONSE_TAG_READINESS => {
             return Err(WireError::WrongMessagePhase);
         }
         RESPONSE_TAG_VERSION_MISMATCH => BrokerHandshakeResponse::VersionMismatch {
@@ -187,6 +200,10 @@ pub fn encode_response(response: BrokerResponse) -> Vec<u8> {
     match response {
         BrokerResponse::ObjectClosed => {
             encoder.u8(RESPONSE_TAG_OBJECT_CLOSED);
+        }
+        BrokerResponse::Readiness(readiness) => {
+            encoder.u8(RESPONSE_TAG_READINESS);
+            encoder.u32(readiness.0);
         }
         BrokerResponse::Event(response) => {
             encoder.u8(RESPONSE_TAG_EVENT);
@@ -219,6 +236,7 @@ pub fn decode_response(frame: &[u8]) -> Result<BrokerResponse, WireError> {
             BrokerResponse::Error(error)
         }
         RESPONSE_TAG_OBJECT_CLOSED => BrokerResponse::ObjectClosed,
+        RESPONSE_TAG_READINESS => BrokerResponse::Readiness(ReadinessFlags(decoder.u32()?)),
         _ => return Err(WireError::InvalidTag),
     };
     decoder.finish()?;
@@ -261,13 +279,12 @@ mod tests {
     use super::*;
     use crate::event::{
         AddEventRequest, AddEventResponse, ConsumeEventRequest, CreateEventRequest,
-        CreateEventResponse, EventConsumeMode, EventConsumption, WaitEventRequest,
-        WaitEventResponse,
+        CreateEventResponse, EventConsumeMode, EventConsumption,
     };
     use crate::message::{EventRequest, EventResponse, PipeRequest, PipeResponse};
     use crate::pipe::{
-        CheckPipeReadinessRequest, CheckPipeReadinessResponse, CreatePipeRequest,
-        CreatePipeResponse, ReadPipeRequest, ReadPipeResponse, WritePipeRequest, WritePipeResponse,
+        CreatePipeRequest, CreatePipeResponse, ReadPipeRequest, ReadPipeResponse, WritePipeRequest,
+        WritePipeResponse,
     };
     use crate::{ObjectHandle, ProtocolVersion};
 
@@ -290,13 +307,13 @@ mod tests {
         let handle = ObjectHandle(13);
         let requests = [
             BrokerRequest::CloseObject(handle),
+            BrokerRequest::CheckReadiness(handle),
             BrokerRequest::Event(EventRequest::Create(CreateEventRequest {
                 initial_count: 0,
             })),
             BrokerRequest::Event(EventRequest::Create(CreateEventRequest {
                 initial_count: 7,
             })),
-            BrokerRequest::Event(EventRequest::Wait(WaitEventRequest { handle })),
             BrokerRequest::Event(EventRequest::Add(AddEventRequest { handle, value: 3 })),
             BrokerRequest::Event(EventRequest::Consume(ConsumeEventRequest {
                 handle,
@@ -314,9 +331,6 @@ mod tests {
             BrokerRequest::Pipe(PipeRequest::Write(WritePipeRequest {
                 handle,
                 data: Vec::from([1, 2, 3]),
-            })),
-            BrokerRequest::Pipe(PipeRequest::CheckReadiness(CheckPipeReadinessRequest {
-                handle,
             })),
         ];
 
@@ -354,13 +368,9 @@ mod tests {
         let handle = ObjectHandle(13);
         let responses = [
             BrokerResponse::ObjectClosed,
+            BrokerResponse::Readiness(ReadinessFlags::READ),
+            BrokerResponse::Readiness(ReadinessFlags::WRITE),
             BrokerResponse::Event(EventResponse::Create(CreateEventResponse { handle })),
-            BrokerResponse::Event(EventResponse::Wait(WaitEventResponse {
-                readiness: ReadinessFlags::READ,
-            })),
-            BrokerResponse::Event(EventResponse::Wait(WaitEventResponse {
-                readiness: ReadinessFlags::WRITE,
-            })),
             BrokerResponse::Event(EventResponse::Add(AddEventResponse {
                 readiness: ReadinessFlags::READ | ReadinessFlags::WRITE,
             })),
@@ -376,9 +386,6 @@ mod tests {
                 data: Vec::from([1, 2, 3]),
             })),
             BrokerResponse::Pipe(PipeResponse::Write(WritePipeResponse { written: 3 })),
-            BrokerResponse::Pipe(PipeResponse::CheckReadiness(CheckPipeReadinessResponse {
-                readiness: ReadinessFlags::READ | ReadinessFlags::HANGUP,
-            })),
             BrokerResponse::Error(ErrorCode::PolicyDenied),
             BrokerResponse::Error(ErrorCode::WouldBlock),
             BrokerResponse::Error(ErrorCode::PeerClosed),
@@ -521,7 +528,7 @@ mod tests {
             Err(WireError::WrongMessagePhase)
         );
         assert_eq!(
-            decode_response(&[1, 1, 0xff]),
+            decode_response(&[RESPONSE_TAG_READINESS, 0xff]),
             Err(WireError::TruncatedFrame)
         );
         assert_eq!(

--- a/litebox_broker_protocol/src/wire.rs
+++ b/litebox_broker_protocol/src/wire.rs
@@ -590,7 +590,7 @@ mod tests {
                     readiness: ReadinessFlags::READ,
                 }
             ))),
-            [1, 2, 1, 0, 0, 0]
+            [1, 1, 1, 0, 0, 0]
         );
     }
 

--- a/litebox_broker_protocol/src/wire/event.rs
+++ b/litebox_broker_protocol/src/wire/event.rs
@@ -14,12 +14,12 @@ use super::primitive::{Decoder, Encoder};
 // Event operation tags live with the event family. Future event operations
 // should add tags here; unrelated object families should get their own module.
 const EVENT_REQUEST_TAG_CREATE: u8 = 0;
-const EVENT_REQUEST_TAG_ADD: u8 = 2;
-const EVENT_REQUEST_TAG_CONSUME: u8 = 3;
+const EVENT_REQUEST_TAG_ADD: u8 = 1;
+const EVENT_REQUEST_TAG_CONSUME: u8 = 2;
 
 const EVENT_RESPONSE_TAG_CREATED: u8 = 0;
-const EVENT_RESPONSE_TAG_ADDED: u8 = 2;
-const EVENT_RESPONSE_TAG_CONSUMED: u8 = 3;
+const EVENT_RESPONSE_TAG_ADDED: u8 = 1;
+const EVENT_RESPONSE_TAG_CONSUMED: u8 = 2;
 
 const EVENT_CONSUME_MODE_TAG_ALL: u8 = 1;
 const EVENT_CONSUME_MODE_TAG_ONE: u8 = 2;

--- a/litebox_broker_protocol/src/wire/event.rs
+++ b/litebox_broker_protocol/src/wire/event.rs
@@ -3,7 +3,7 @@
 
 use crate::event::{
     AddEventRequest, AddEventResponse, ConsumeEventRequest, CreateEventRequest,
-    CreateEventResponse, EventConsumeMode, EventConsumption, WaitEventRequest, WaitEventResponse,
+    CreateEventResponse, EventConsumeMode, EventConsumption,
 };
 use crate::message::{EventRequest, EventResponse};
 use crate::readiness::ReadinessFlags;
@@ -14,12 +14,10 @@ use super::primitive::{Decoder, Encoder};
 // Event operation tags live with the event family. Future event operations
 // should add tags here; unrelated object families should get their own module.
 const EVENT_REQUEST_TAG_CREATE: u8 = 0;
-const EVENT_REQUEST_TAG_WAIT: u8 = 1;
 const EVENT_REQUEST_TAG_ADD: u8 = 2;
 const EVENT_REQUEST_TAG_CONSUME: u8 = 3;
 
 const EVENT_RESPONSE_TAG_CREATED: u8 = 0;
-const EVENT_RESPONSE_TAG_WAITED: u8 = 1;
 const EVENT_RESPONSE_TAG_ADDED: u8 = 2;
 const EVENT_RESPONSE_TAG_CONSUMED: u8 = 3;
 
@@ -31,10 +29,6 @@ pub(super) fn encode_event_request(encoder: &mut Encoder, request: EventRequest)
         EventRequest::Create(request) => {
             encoder.u8(EVENT_REQUEST_TAG_CREATE);
             encoder.u64(request.initial_count);
-        }
-        EventRequest::Wait(request) => {
-            encoder.u8(EVENT_REQUEST_TAG_WAIT);
-            encoder.handle(request.handle);
         }
         EventRequest::Add(request) => {
             encoder.u8(EVENT_REQUEST_TAG_ADD);
@@ -53,9 +47,6 @@ pub(super) fn decode_event_request(decoder: &mut Decoder<'_>) -> Result<EventReq
     let request = match decoder.u8()? {
         EVENT_REQUEST_TAG_CREATE => EventRequest::Create(CreateEventRequest {
             initial_count: decoder.u64()?,
-        }),
-        EVENT_REQUEST_TAG_WAIT => EventRequest::Wait(WaitEventRequest {
-            handle: decoder.handle()?,
         }),
         EVENT_REQUEST_TAG_ADD => EventRequest::Add(AddEventRequest {
             handle: decoder.handle()?,
@@ -77,10 +68,6 @@ pub(super) fn encode_event_response(encoder: &mut Encoder, response: EventRespon
             encoder.u8(EVENT_RESPONSE_TAG_CREATED);
             encoder.handle(response.handle);
         }
-        EventResponse::Wait(response) => {
-            encoder.u8(EVENT_RESPONSE_TAG_WAITED);
-            encoder.u32(response.readiness.0);
-        }
         EventResponse::Add(response) => {
             encoder.u8(EVENT_RESPONSE_TAG_ADDED);
             encoder.u32(response.readiness.0);
@@ -97,9 +84,6 @@ pub(super) fn decode_event_response(decoder: &mut Decoder<'_>) -> Result<EventRe
     let response = match decoder.u8()? {
         EVENT_RESPONSE_TAG_CREATED => EventResponse::Create(CreateEventResponse {
             handle: decoder.handle()?,
-        }),
-        EVENT_RESPONSE_TAG_WAITED => EventResponse::Wait(WaitEventResponse {
-            readiness: ReadinessFlags(decoder.u32()?),
         }),
         EVENT_RESPONSE_TAG_ADDED => EventResponse::Add(AddEventResponse {
             readiness: ReadinessFlags(decoder.u32()?),

--- a/litebox_broker_protocol/src/wire/pipe.rs
+++ b/litebox_broker_protocol/src/wire/pipe.rs
@@ -1,0 +1,112 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+use crate::message::{PipeRequest, PipeResponse};
+use crate::pipe::{
+    CheckPipeReadinessRequest, CheckPipeReadinessResponse, CreatePipeRequest, CreatePipeResponse,
+    ReadPipeRequest, ReadPipeResponse, WritePipeRequest, WritePipeResponse,
+};
+use crate::readiness::ReadinessFlags;
+
+use super::WireError;
+use super::primitive::{Decoder, Encoder};
+
+const PIPE_REQUEST_TAG_CREATE: u8 = 0;
+const PIPE_REQUEST_TAG_READ: u8 = 1;
+const PIPE_REQUEST_TAG_WRITE: u8 = 2;
+const PIPE_REQUEST_TAG_CHECK_READINESS: u8 = 3;
+
+const PIPE_RESPONSE_TAG_CREATED: u8 = 0;
+const PIPE_RESPONSE_TAG_READ: u8 = 1;
+const PIPE_RESPONSE_TAG_WRITTEN: u8 = 2;
+const PIPE_RESPONSE_TAG_READINESS: u8 = 3;
+
+pub(super) fn encode_pipe_request(encoder: &mut Encoder, request: PipeRequest) {
+    match request {
+        PipeRequest::Create(request) => {
+            encoder.u8(PIPE_REQUEST_TAG_CREATE);
+            encoder.u64(request.capacity);
+            encoder.u64(request.atomic_write_size);
+        }
+        PipeRequest::Read(request) => {
+            encoder.u8(PIPE_REQUEST_TAG_READ);
+            encoder.handle(request.handle);
+            encoder.u32(request.length);
+        }
+        PipeRequest::Write(request) => {
+            encoder.u8(PIPE_REQUEST_TAG_WRITE);
+            encoder.handle(request.handle);
+            encoder.bytes(&request.data);
+        }
+        PipeRequest::CheckReadiness(request) => {
+            encoder.u8(PIPE_REQUEST_TAG_CHECK_READINESS);
+            encoder.handle(request.handle);
+        }
+    }
+}
+
+pub(super) fn decode_pipe_request(decoder: &mut Decoder<'_>) -> Result<PipeRequest, WireError> {
+    match decoder.u8()? {
+        PIPE_REQUEST_TAG_CREATE => Ok(PipeRequest::Create(CreatePipeRequest {
+            capacity: decoder.u64()?,
+            atomic_write_size: decoder.u64()?,
+        })),
+        PIPE_REQUEST_TAG_READ => Ok(PipeRequest::Read(ReadPipeRequest {
+            handle: decoder.handle()?,
+            length: decoder.u32()?,
+        })),
+        PIPE_REQUEST_TAG_WRITE => Ok(PipeRequest::Write(WritePipeRequest {
+            handle: decoder.handle()?,
+            data: decoder.bytes()?,
+        })),
+        PIPE_REQUEST_TAG_CHECK_READINESS => {
+            Ok(PipeRequest::CheckReadiness(CheckPipeReadinessRequest {
+                handle: decoder.handle()?,
+            }))
+        }
+        _ => Err(WireError::InvalidTag),
+    }
+}
+
+pub(super) fn encode_pipe_response(encoder: &mut Encoder, response: PipeResponse) {
+    match response {
+        PipeResponse::Create(response) => {
+            encoder.u8(PIPE_RESPONSE_TAG_CREATED);
+            encoder.handle(response.read_handle);
+            encoder.handle(response.write_handle);
+        }
+        PipeResponse::Read(response) => {
+            encoder.u8(PIPE_RESPONSE_TAG_READ);
+            encoder.bytes(&response.data);
+        }
+        PipeResponse::Write(response) => {
+            encoder.u8(PIPE_RESPONSE_TAG_WRITTEN);
+            encoder.u32(response.written);
+        }
+        PipeResponse::CheckReadiness(response) => {
+            encoder.u8(PIPE_RESPONSE_TAG_READINESS);
+            encoder.u32(response.readiness.0);
+        }
+    }
+}
+
+pub(super) fn decode_pipe_response(decoder: &mut Decoder<'_>) -> Result<PipeResponse, WireError> {
+    match decoder.u8()? {
+        PIPE_RESPONSE_TAG_CREATED => Ok(PipeResponse::Create(CreatePipeResponse {
+            read_handle: decoder.handle()?,
+            write_handle: decoder.handle()?,
+        })),
+        PIPE_RESPONSE_TAG_READ => Ok(PipeResponse::Read(ReadPipeResponse {
+            data: decoder.bytes()?,
+        })),
+        PIPE_RESPONSE_TAG_WRITTEN => Ok(PipeResponse::Write(WritePipeResponse {
+            written: decoder.u32()?,
+        })),
+        PIPE_RESPONSE_TAG_READINESS => {
+            Ok(PipeResponse::CheckReadiness(CheckPipeReadinessResponse {
+                readiness: ReadinessFlags(decoder.u32()?),
+            }))
+        }
+        _ => Err(WireError::InvalidTag),
+    }
+}

--- a/litebox_broker_protocol/src/wire/pipe.rs
+++ b/litebox_broker_protocol/src/wire/pipe.rs
@@ -3,10 +3,9 @@
 
 use crate::message::{PipeRequest, PipeResponse};
 use crate::pipe::{
-    CheckPipeReadinessRequest, CheckPipeReadinessResponse, CreatePipeRequest, CreatePipeResponse,
-    ReadPipeRequest, ReadPipeResponse, WritePipeRequest, WritePipeResponse,
+    CreatePipeRequest, CreatePipeResponse, ReadPipeRequest, ReadPipeResponse, WritePipeRequest,
+    WritePipeResponse,
 };
-use crate::readiness::ReadinessFlags;
 
 use super::WireError;
 use super::primitive::{Decoder, Encoder};
@@ -14,12 +13,10 @@ use super::primitive::{Decoder, Encoder};
 const PIPE_REQUEST_TAG_CREATE: u8 = 0;
 const PIPE_REQUEST_TAG_READ: u8 = 1;
 const PIPE_REQUEST_TAG_WRITE: u8 = 2;
-const PIPE_REQUEST_TAG_CHECK_READINESS: u8 = 3;
 
 const PIPE_RESPONSE_TAG_CREATED: u8 = 0;
 const PIPE_RESPONSE_TAG_READ: u8 = 1;
 const PIPE_RESPONSE_TAG_WRITTEN: u8 = 2;
-const PIPE_RESPONSE_TAG_READINESS: u8 = 3;
 
 pub(super) fn encode_pipe_request(encoder: &mut Encoder, request: PipeRequest) {
     match request {
@@ -38,10 +35,6 @@ pub(super) fn encode_pipe_request(encoder: &mut Encoder, request: PipeRequest) {
             encoder.handle(request.handle);
             encoder.bytes(&request.data);
         }
-        PipeRequest::CheckReadiness(request) => {
-            encoder.u8(PIPE_REQUEST_TAG_CHECK_READINESS);
-            encoder.handle(request.handle);
-        }
     }
 }
 
@@ -59,11 +52,6 @@ pub(super) fn decode_pipe_request(decoder: &mut Decoder<'_>) -> Result<PipeReque
             handle: decoder.handle()?,
             data: decoder.bytes()?,
         })),
-        PIPE_REQUEST_TAG_CHECK_READINESS => {
-            Ok(PipeRequest::CheckReadiness(CheckPipeReadinessRequest {
-                handle: decoder.handle()?,
-            }))
-        }
         _ => Err(WireError::InvalidTag),
     }
 }
@@ -83,10 +71,6 @@ pub(super) fn encode_pipe_response(encoder: &mut Encoder, response: PipeResponse
             encoder.u8(PIPE_RESPONSE_TAG_WRITTEN);
             encoder.u32(response.written);
         }
-        PipeResponse::CheckReadiness(response) => {
-            encoder.u8(PIPE_RESPONSE_TAG_READINESS);
-            encoder.u32(response.readiness.0);
-        }
     }
 }
 
@@ -102,11 +86,6 @@ pub(super) fn decode_pipe_response(decoder: &mut Decoder<'_>) -> Result<PipeResp
         PIPE_RESPONSE_TAG_WRITTEN => Ok(PipeResponse::Write(WritePipeResponse {
             written: decoder.u32()?,
         })),
-        PIPE_RESPONSE_TAG_READINESS => {
-            Ok(PipeResponse::CheckReadiness(CheckPipeReadinessResponse {
-                readiness: ReadinessFlags(decoder.u32()?),
-            }))
-        }
         _ => Err(WireError::InvalidTag),
     }
 }

--- a/litebox_broker_protocol/src/wire/primitive.rs
+++ b/litebox_broker_protocol/src/wire/primitive.rs
@@ -33,6 +33,16 @@ impl Encoder {
         self.bytes.extend_from_slice(&value.to_le_bytes());
     }
 
+    pub(super) fn bytes(&mut self, value: &[u8]) {
+        self.u64(
+            value
+                .len()
+                .try_into()
+                .expect("broker byte payload length exceeds u64"),
+        );
+        self.bytes.extend_from_slice(value);
+    }
+
     pub(super) fn protocol_version(&mut self, version: ProtocolVersion) {
         self.u16(version.0);
     }
@@ -80,6 +90,11 @@ impl<'a> Decoder<'a> {
         Ok(u64::from_le_bytes([
             bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7],
         ]))
+    }
+
+    pub(super) fn bytes(&mut self) -> Result<Vec<u8>, WireError> {
+        let len = usize::try_from(self.u64()?).map_err(|_| WireError::OffsetOverflow)?;
+        Ok(self.take(len)?.to_vec())
     }
 
     pub(super) fn protocol_version(&mut self) -> Result<ProtocolVersion, WireError> {

--- a/litebox_broker_userland/tests/userland_broker.rs
+++ b/litebox_broker_userland/tests/userland_broker.rs
@@ -84,13 +84,16 @@ fn run_fake_runner(args: &[OsString]) {
     let mut local = BrokerLocal::negotiate(control_channel).unwrap();
 
     let handle = local.create_event_with_count(0).unwrap();
-    assert_eq!(local.wait_event(handle).unwrap(), ReadinessFlags::WRITE);
+    assert_eq!(
+        local.check_readiness(handle).unwrap(),
+        ReadinessFlags::WRITE
+    );
 
     let readiness = ReadinessFlags::READ | ReadinessFlags::WRITE;
     assert_eq!(local.add_event(handle, 1).unwrap(), readiness);
 
     assert_eq!(
-        local.wait_event(handle).unwrap(),
+        local.check_readiness(handle).unwrap(),
         ReadinessFlags::READ | ReadinessFlags::WRITE
     );
     drop(local);

--- a/litebox_common_linux/src/errno/mod.rs
+++ b/litebox_common_linux/src/errno/mod.rs
@@ -579,6 +579,11 @@ impl From<litebox::pipes::errors::ReadError> for Errno {
             litebox::pipes::errors::ReadError::ClosedFd
             | litebox::pipes::errors::ReadError::NotForReading => Errno::EBADF,
             litebox::pipes::errors::ReadError::WouldBlock => Errno::EWOULDBLOCK,
+            litebox::pipes::errors::ReadError::WaitError(e) => match e {
+                litebox::event::wait::WaitError::Interrupted => Errno::EINTR,
+                litebox::event::wait::WaitError::TimedOut => Errno::ETIMEDOUT,
+            },
+            litebox::pipes::errors::ReadError::Io => Errno::EIO,
             _ => todo!(),
         }
     }
@@ -591,6 +596,23 @@ impl From<litebox::pipes::errors::WriteError> for Errno {
             litebox::pipes::errors::WriteError::ReadEndClosed => Errno::EPIPE,
             litebox::pipes::errors::WriteError::NotForWriting => Errno::EBADF,
             litebox::pipes::errors::WriteError::WouldBlock => Errno::EWOULDBLOCK,
+            litebox::pipes::errors::WriteError::WaitError(e) => match e {
+                litebox::event::wait::WaitError::Interrupted => Errno::EINTR,
+                litebox::event::wait::WaitError::TimedOut => Errno::ETIMEDOUT,
+            },
+            litebox::pipes::errors::WriteError::Io => Errno::EIO,
+            _ => todo!(),
+        }
+    }
+}
+
+impl From<litebox::pipes::errors::CreateError> for Errno {
+    fn from(value: litebox::pipes::errors::CreateError) -> Self {
+        match value {
+            litebox::pipes::errors::CreateError::ResourceExhausted => Errno::ENFILE,
+            litebox::pipes::errors::CreateError::OutOfMemory => Errno::ENOMEM,
+            litebox::pipes::errors::CreateError::PermissionDenied => Errno::EACCES,
+            litebox::pipes::errors::CreateError::Io => Errno::EIO,
             _ => todo!(),
         }
     }

--- a/litebox_runner_linux_userland/tests/pipe_broker.c
+++ b/litebox_runner_linux_userland/tests/pipe_broker.c
@@ -1,0 +1,268 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <pthread.h>
+#include <sched.h>
+#include <signal.h>
+#include <stdatomic.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+#define BLOCKING_TEST_DELAY_US 50000
+#define OPERATION_TIMEOUT_SECONDS 2
+#define THREAD_JOIN_TIMEOUT_SECONDS 2
+
+struct io_thread_args {
+    int fd;
+    unsigned char value;
+    int write;
+    int result;
+    atomic_int started;
+    atomic_int completed;
+};
+
+static void *io_thread(void *arg) {
+    struct io_thread_args *args = arg;
+    unsigned char value = args->value;
+    atomic_store_explicit(&args->started, 1, memory_order_release);
+    ssize_t result = args->write ? write(args->fd, &value, 1)
+                                 : read(args->fd, &value, 1);
+    args->result = result == 1 && (args->write || value == args->value) ? 0 : 1;
+    atomic_store_explicit(&args->completed, 1, memory_order_release);
+    return NULL;
+}
+
+static int poll_events(int fd, short events, short expected) {
+    struct pollfd poll_fd = {
+        .fd = fd,
+        .events = events,
+    };
+    int ready = poll(&poll_fd, 1, 0);
+    return ready >= 0 && poll_fd.revents == expected ? 0 : 1;
+}
+
+static int join_thread(pthread_t thread, int wake_fd) {
+    struct timespec deadline;
+    if (clock_gettime(CLOCK_REALTIME, &deadline) == 0) {
+        deadline.tv_sec += THREAD_JOIN_TIMEOUT_SECONDS;
+        if (pthread_timedjoin_np(thread, NULL, &deadline) == 0) {
+            return 0;
+        }
+    }
+    close(wake_fd);
+    _exit(1);
+}
+
+static int test_nonblocking_and_lifecycle(void) {
+    int fds[2];
+    if (pipe2(fds, O_NONBLOCK | O_CLOEXEC) != 0) {
+        return 1;
+    }
+    int read_status = fcntl(fds[0], F_GETFL);
+    int write_status = fcntl(fds[1], F_GETFL);
+    int read_descriptor_flags = fcntl(fds[0], F_GETFD);
+    int write_descriptor_flags = fcntl(fds[1], F_GETFD);
+    if (read_status < 0 || write_status < 0 || read_descriptor_flags < 0 ||
+        write_descriptor_flags < 0 || (read_status & O_NONBLOCK) == 0 ||
+        (write_status & O_NONBLOCK) == 0 ||
+        (read_descriptor_flags & FD_CLOEXEC) == 0 ||
+        (write_descriptor_flags & FD_CLOEXEC) == 0) {
+        return 2;
+    }
+    if (poll_events(fds[0], POLLIN, 0) != 0 ||
+        poll_events(fds[1], POLLOUT, POLLOUT) != 0) {
+        return 3;
+    }
+
+    unsigned char data[3] = {1, 2, 3};
+    unsigned char output[3] = {0};
+    errno = 0;
+    if (read(fds[1], output, 0) != -1 || errno != EBADF) {
+        return 4;
+    }
+    errno = 0;
+    if (write(fds[0], data, 0) != -1 || errno != EBADF) {
+        return 4;
+    }
+    errno = 0;
+    if (read(fds[0], output, sizeof(output)) != -1 || errno != EAGAIN) {
+        return 5;
+    }
+    if (write(fds[1], data, sizeof(data)) != sizeof(data) ||
+        poll_events(fds[0], POLLIN, POLLIN) != 0 ||
+        read(fds[0], output, sizeof(output)) != sizeof(output) ||
+        memcmp(data, output, sizeof(data)) != 0) {
+        return 6;
+    }
+
+    int duplicate = dup(fds[1]);
+    if (duplicate < 0 || close(fds[1]) != 0 ||
+        write(duplicate, data, sizeof(data)) != sizeof(data) ||
+        read(fds[0], output, sizeof(output)) != sizeof(output)) {
+        return 7;
+    }
+    return close(duplicate) == 0 && close(fds[0]) == 0 ? 0 : 8;
+}
+
+static int test_blocking_read_wakeup(void) {
+    int fds[2];
+    if (pipe(fds) != 0) {
+        return 1;
+    }
+    struct io_thread_args args = {
+        .fd = fds[0],
+        .value = 42,
+        .write = 0,
+        .result = -1,
+    };
+    atomic_init(&args.started, 0);
+    atomic_init(&args.completed, 0);
+    pthread_t thread;
+    if (pthread_create(&thread, NULL, io_thread, &args) != 0) {
+        return 2;
+    }
+    alarm(OPERATION_TIMEOUT_SECONDS);
+    while (!atomic_load_explicit(&args.started, memory_order_acquire)) {
+        sched_yield();
+    }
+    alarm(0);
+    usleep(BLOCKING_TEST_DELAY_US);
+    if (atomic_load_explicit(&args.completed, memory_order_acquire)) {
+        pthread_join(thread, NULL);
+        return 3;
+    }
+    unsigned char value = 42;
+    alarm(OPERATION_TIMEOUT_SECONDS);
+    ssize_t wake_result = write(fds[1], &value, 1);
+    alarm(0);
+    int join_result = join_thread(thread, fds[1]);
+    if (wake_result != 1 || join_result != 0 || args.result != 0) {
+        return 3;
+    }
+
+    unsigned char input[65536];
+    unsigned char output[65536];
+    memset(input, 0x5a, sizeof(input));
+    alarm(OPERATION_TIMEOUT_SECONDS);
+    ssize_t large_write_result = write(fds[1], input, sizeof(input));
+    alarm(0);
+    if (large_write_result != sizeof(input)) {
+        return 4;
+    }
+    size_t read_size = 0;
+    alarm(OPERATION_TIMEOUT_SECONDS);
+    while (read_size < sizeof(output)) {
+        ssize_t size =
+            read(fds[0], output + read_size, sizeof(output) - read_size);
+        if (size <= 0) {
+            return 5;
+        }
+        read_size += (size_t)size;
+    }
+    alarm(0);
+    if (memcmp(input, output, sizeof(input)) != 0) {
+        return 6;
+    }
+    return close(fds[0]) == 0 && close(fds[1]) == 0 ? 0 : 7;
+}
+
+static int test_blocking_write_wakeup(void) {
+    int fds[2];
+    if (pipe2(fds, O_NONBLOCK) != 0) {
+        return 1;
+    }
+    unsigned char data[4096] = {0};
+    size_t total_written = 0;
+    ssize_t write_result;
+    alarm(OPERATION_TIMEOUT_SECONDS);
+    while ((write_result = write(fds[1], data, sizeof(data))) == sizeof(data)) {
+        total_written += sizeof(data);
+        if (total_written > 65536) {
+            return 2;
+        }
+    }
+    alarm(0);
+    if (total_written != 65536 || write_result != -1 || errno != EAGAIN ||
+        fcntl(fds[1], F_SETFL, 0) != 0) {
+        return 2;
+    }
+
+    struct io_thread_args args = {
+        .fd = fds[1],
+        .value = 7,
+        .write = 1,
+        .result = -1,
+    };
+    atomic_init(&args.started, 0);
+    atomic_init(&args.completed, 0);
+    pthread_t thread;
+    if (pthread_create(&thread, NULL, io_thread, &args) != 0) {
+        return 3;
+    }
+    alarm(OPERATION_TIMEOUT_SECONDS);
+    while (!atomic_load_explicit(&args.started, memory_order_acquire)) {
+        sched_yield();
+    }
+    alarm(0);
+    usleep(BLOCKING_TEST_DELAY_US);
+    if (atomic_load_explicit(&args.completed, memory_order_acquire)) {
+        pthread_join(thread, NULL);
+        return 4;
+    }
+    unsigned char value;
+    alarm(OPERATION_TIMEOUT_SECONDS);
+    ssize_t wake_result = read(fds[0], &value, 1);
+    alarm(0);
+    int join_result = join_thread(thread, fds[0]);
+    if (wake_result != 1 || join_result != 0 || args.result != 0) {
+        return 4;
+    }
+    return close(fds[0]) == 0 && close(fds[1]) == 0 ? 0 : 5;
+}
+
+static int test_closed_peers(void) {
+    int fds[2];
+    unsigned char value = 1;
+    if (pipe(fds) != 0 || close(fds[1]) != 0 ||
+        poll_events(fds[0], POLLIN, POLLHUP) != 0 ||
+        read(fds[0], &value, 1) != 0 || close(fds[0]) != 0) {
+        return 1;
+    }
+
+    if (signal(SIGPIPE, SIG_IGN) == SIG_ERR || pipe(fds) != 0 ||
+        close(fds[0]) != 0 ||
+        poll_events(fds[1], POLLOUT, POLLOUT | POLLERR) != 0) {
+        return 2;
+    }
+    if (write(fds[1], &value, 0) != 0) {
+        return 3;
+    }
+    errno = 0;
+    if (write(fds[1], &value, 1) != -1 || errno != EPIPE) {
+        return 4;
+    }
+    return close(fds[1]) == 0 ? 0 : 5;
+}
+
+int main(void) {
+    int result = test_nonblocking_and_lifecycle();
+    if (result != 0) {
+        return 10 + result;
+    }
+    result = test_blocking_read_wakeup();
+    if (result != 0) {
+        return 20 + result;
+    }
+    result = test_blocking_write_wakeup();
+    if (result != 0) {
+        return 30 + result;
+    }
+    result = test_closed_peers();
+    return result == 0 ? 0 : 40 + result;
+}

--- a/litebox_runner_linux_userland/tests/run.rs
+++ b/litebox_runner_linux_userland/tests/run.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 const BROKER_HELPER_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
-const BROKER_ONLY_C_TESTS: &[&str] = &["eventfd.c"];
+const BROKER_ONLY_C_TESTS: &[&str] = &["eventfd.c", "pipe_broker.c"];
 
 #[must_use]
 struct Runner {
@@ -473,6 +473,12 @@ console.log(content);
     let true_path = run_which("true");
     let node_path = run_which("node");
     let target = common::compile("./tests/eventfd.c", "broker_eventfd_rewriter", false, false);
+    let pipe_target = common::compile(
+        "./tests/pipe_broker.c",
+        "broker_pipe_rewriter",
+        false,
+        false,
+    );
     let control_socket_path = unique_test_socket_path("runner-broker-control");
     let notification_socket_path = unique_test_socket_path("runner-broker-notification");
     let broker_thread = spawn_test_broker(
@@ -481,7 +487,7 @@ console.log(content);
         litebox_broker_core::PolicyEngine::with_unauthenticated_rights(
             litebox_broker_core::ObjectRights::all(),
         ),
-        3,
+        4,
     );
 
     Runner::new(&true_path, "broker_true_rewriter")
@@ -494,6 +500,12 @@ console.log(content);
         .run();
     // eventfd.c creates thirteen eventfd objects; each should release one broker object.
     assert_eq!(broker_thread.next_close_object_count(), 13);
+
+    Runner::new(&pipe_target, "broker_pipe_rewriter")
+        .broker_sockets(&control_socket_path, &notification_socket_path)
+        .run();
+    // pipe_broker.c creates five pipes; each endpoint owns one broker object.
+    assert_eq!(broker_thread.next_close_object_count(), 10);
 
     Runner::new(&node_path, "hello_node_broker_rewriter")
         .broker_sockets(&control_socket_path, &notification_socket_path)

--- a/litebox_shim_linux/src/syscalls/epoll.rs
+++ b/litebox_shim_linux/src/syscalls/epoll.rs
@@ -635,10 +635,11 @@ mod test {
     #[test]
     fn test_epoll_with_pipe() {
         let (task, epoll) = setup_epoll();
-        let (producer, consumer) =
-            task.global
-                .pipes
-                .create_pipe(2, litebox::pipes::Flags::empty(), None);
+        let (producer, consumer) = task
+            .global
+            .pipes
+            .create_pipe(2, litebox::pipes::Flags::empty(), None)
+            .unwrap();
         let consumer = Arc::new(consumer);
         let reader = super::EpollDescriptor::Pipe(Arc::clone(&consumer));
         epoll

--- a/litebox_shim_linux/src/syscalls/pipe.rs
+++ b/litebox_shim_linux/src/syscalls/pipe.rs
@@ -19,7 +19,7 @@ use litebox_common_linux::{FileDescriptorFlags, InodeType, errno::Errno};
 
 use crate::{GlobalState, Platform, ShimFS};
 
-const DEFAULT_PIPE_BUF_SIZE: usize = 1024 * 1024;
+const DEFAULT_PIPE_BUF_SIZE: usize = 64 * 1024;
 
 /// Status flags for Linux pipe file descriptions.
 ///
@@ -58,7 +58,7 @@ impl<FS: ShimFS> GlobalState<FS> {
             pipe_flags,
             // See `man 7 pipe` for `PIPE_BUF`. On Linux, this is 4096.
             NonZero::new(4096),
-        );
+        )?;
 
         let initial_status = OFlags::from(pipe_flags);
         {


### PR DESCRIPTION
This PR adds broker-backed pipes, with the broker owning pipe state and endpoint lifetime. The existing in-process pipe remains available when no broker is configured.