### PR TITLE
Model connected ConDrv stream objects

### DIFF
--- a/litebox_shim_windows/src/lib.rs
+++ b/litebox_shim_windows/src/lib.rs
@@ -464,6 +464,7 @@ pub struct Process<Platform: ShimPlatform> {
     ntdll_mapping: Option<MappingInfo>,
     peb_address: usize,
     handles: WindowsHandleStore<Platform>,
+    condrv_console: syscalls::condrv::CondrvConsole<Platform>,
     object_manager: WindowsObjectManager<Platform>,
     section_views: WindowsSectionViews<Platform>,
     // TODO: move this into `GlobalState` once we have a proper shared mapping implementation.
@@ -507,6 +508,9 @@ impl<Platform: ShimPlatform> Process<Platform> {
             ntdll_mapping: None,
             peb_address: 0,
             handles: WindowsHandleStore::<Platform>::new(litebox::fd::RawDescriptorStorage::new()),
+            // TODO(condrv-shared-console): move console ownership to shared state or a broker when
+            // LiteBox supports AttachConsole/IOCTL_CONDRV_BIND_PID across guest processes.
+            condrv_console: syscalls::condrv::CondrvConsole::new(),
             object_manager,
             windows_shared_section,
             section_views: WindowsSectionViews::<Platform>::new(BTreeMap::new()),

--- a/litebox_shim_windows/src/syscalls/condrv.rs
+++ b/litebox_shim_windows/src/syscalls/condrv.rs
@@ -21,15 +21,25 @@ const CD_SERVER_EA_NAME: &[u8] = b"server";
 pub(crate) enum CondrvObject {
     Input = 0,
     Output = 1,
-    Server = 2,
-    Reference = 3,
-    Connect = 4,
+    CurrentInput = 2,
+    CurrentOutput = 3,
+    ScreenBuffer = 4,
+    Server = 5,
+    Reference = 6,
+    Connect = 7,
 }
 
 impl CondrvObject {
     pub(crate) fn from_device_name(name: &str) -> Result<Self, NtStatus> {
         match Self::from_component(name) {
-            Some(object @ (Self::Input | Self::Output | Self::Server)) => Ok(object),
+            Some(
+                object @ (Self::Input
+                | Self::Output
+                | Self::CurrentInput
+                | Self::CurrentOutput
+                | Self::ScreenBuffer
+                | Self::Server),
+            ) => Ok(object),
             Some(Self::Reference) => Err(NtStatus::INVALID_HANDLE),
             Some(Self::Connect) => Err(NtStatus::OBJECT_TYPE_MISMATCH),
             None => Err(NtStatus::OBJECT_NAME_NOT_FOUND),
@@ -41,6 +51,12 @@ impl CondrvObject {
             Some(Self::Input)
         } else if name.eq_ignore_ascii_case("Output") {
             Some(Self::Output)
+        } else if name.eq_ignore_ascii_case("CurrentIn") {
+            Some(Self::CurrentInput)
+        } else if name.eq_ignore_ascii_case("CurrentOut") {
+            Some(Self::CurrentOutput)
+        } else if name.eq_ignore_ascii_case("ScreenBuffer") {
+            Some(Self::ScreenBuffer)
         } else if name.eq_ignore_ascii_case("Server") {
             Some(Self::Server)
         } else if name.eq_ignore_ascii_case("Reference") {
@@ -54,41 +70,39 @@ impl CondrvObject {
 
     pub(crate) fn relative_child(self, name: &str) -> Result<Self, NtStatus> {
         let name = name.strip_prefix('\\').ok_or(NtStatus::NOT_FOUND)?;
-        let child = if self == Self::Connect {
-            if name.eq_ignore_ascii_case("CurrentIn") {
-                Self::Input
-            } else if name.eq_ignore_ascii_case("CurrentOut")
-                || name.eq_ignore_ascii_case("ScreenBuffer")
-            {
-                Self::Output
-            } else {
-                Self::from_component(name).ok_or(NtStatus::NOT_FOUND)?
-            }
-        } else {
-            Self::from_component(name).ok_or(NtStatus::NOT_FOUND)?
-        };
+        let child = Self::from_component(name).ok_or(NtStatus::NOT_FOUND)?;
 
-        match (self, child) {
-            (Self::Server, Self::Server | Self::Reference)
-            | (Self::Reference, Self::Server | Self::Connect | Self::Input | Self::Output)
-            | (Self::Input | Self::Output, Self::Server | Self::Input | Self::Output)
-            | (Self::Connect, Self::Server | Self::Reference | Self::Input | Self::Output) => {
-                Ok(child)
+        match child {
+            Self::Server => Ok(child),
+            Self::Reference => match self {
+                Self::Server | Self::Connect => Ok(child),
+                _ => Err(NtStatus::OBJECT_TYPE_MISMATCH),
+            },
+            Self::Connect => {
+                if self == Self::Reference {
+                    Ok(child)
+                } else {
+                    Err(NtStatus::INVALID_HANDLE)
+                }
             }
-            (Self::Server, Self::Input | Self::Output) => Err(NtStatus::INVALID_DEVICE_STATE),
-            (Self::Reference | Self::Input | Self::Output, Self::Reference) => {
-                Err(NtStatus::OBJECT_TYPE_MISMATCH)
-            }
-            (Self::Server | Self::Input | Self::Output | Self::Connect, Self::Connect) => {
-                Err(NtStatus::INVALID_HANDLE)
+            Self::Input
+            | Self::Output
+            | Self::CurrentInput
+            | Self::CurrentOutput
+            | Self::ScreenBuffer => {
+                if self == Self::Server {
+                    Err(NtStatus::INVALID_DEVICE_STATE)
+                } else {
+                    Ok(child)
+                }
             }
         }
     }
 
     pub(crate) fn handle_path(self) -> &'static str {
         match self {
-            Self::Input => "/dev/stdin",
-            Self::Output => "/dev/stdout",
+            Self::Input | Self::CurrentInput => "/dev/stdin",
+            Self::Output | Self::CurrentOutput | Self::ScreenBuffer => "/dev/stdout",
             Self::Server => r"\Device\ConDrv\Server",
             Self::Reference => r"\Device\ConDrv\Reference",
             Self::Connect => r"\Device\ConDrv\Connect",
@@ -288,7 +302,9 @@ mod tests {
 
     #[test]
     fn relative_children_match_host_parse_contexts() {
-        use CondrvObject::{Connect, Input, Output, Reference, Server};
+        use CondrvObject::{
+            Connect, CurrentInput, CurrentOutput, Input, Output, Reference, ScreenBuffer, Server,
+        };
 
         for (parent, name, expected) in [
             (Server, r"\Server", Ok(Server)),
@@ -317,9 +333,9 @@ mod tests {
             (Output, r"\Connect", Err(NtStatus::INVALID_HANDLE)),
             (Connect, r"\Input", Ok(Input)),
             (Connect, r"\Output", Ok(Output)),
-            (Connect, r"\CurrentIn", Ok(Input)),
-            (Connect, r"\CurrentOut", Ok(Output)),
-            (Connect, r"\ScreenBuffer", Ok(Output)),
+            (Connect, r"\CurrentIn", Ok(CurrentInput)),
+            (Connect, r"\CurrentOut", Ok(CurrentOutput)),
+            (Connect, r"\ScreenBuffer", Ok(ScreenBuffer)),
             (Connect, r"\Server", Ok(Server)),
             (Connect, r"\Reference", Ok(Reference)),
             (Connect, r"\Connect", Err(NtStatus::INVALID_HANDLE)),

--- a/litebox_shim_windows/src/syscalls/condrv.rs
+++ b/litebox_shim_windows/src/syscalls/condrv.rs
@@ -3,8 +3,7 @@
 
 //! Windows console driver support.
 
-use alloc::collections::BTreeMap;
-use alloc::sync::{Arc, Weak};
+use alloc::sync::Arc;
 use core::mem::size_of;
 
 use int_enum::IntEnum;
@@ -41,15 +40,8 @@ pub(crate) struct CondrvStreamObject {
     id: u64,
 }
 
-pub(crate) struct CondrvStreamOpen {
-    pub(crate) object: Arc<CondrvStreamObject>,
-}
-
 struct CondrvConsoleState {
     next_object_id: u64,
-    // Weak entries keep handle lifetime authoritative while retaining an object-id registry for
-    // future activation and cross-process lookup.
-    objects: BTreeMap<u64, Weak<CondrvStreamObject>>,
     bound_input: Arc<CondrvStreamObject>,
     active_output: Arc<CondrvStreamObject>,
 }
@@ -68,34 +60,32 @@ impl<Platform: crate::ShimPlatform> CondrvConsole<Platform> {
     pub(crate) fn new() -> Self {
         let bound_input = Arc::new(CondrvStreamObject { id: 1 });
         let active_output = Arc::new(CondrvStreamObject { id: 2 });
-        let mut objects = BTreeMap::new();
-        objects.insert(bound_input.id, Arc::downgrade(&bound_input));
-        objects.insert(active_output.id, Arc::downgrade(&active_output));
         Self {
             state: litebox::sync::Mutex::new(CondrvConsoleState {
                 next_object_id: 3,
-                objects,
                 bound_input,
                 active_output,
             }),
         }
     }
 
-    pub(crate) fn open_stream(&self, endpoint: CondrvObject) -> Result<CondrvStreamOpen, NtStatus> {
+    pub(crate) fn open_stream(
+        &self,
+        endpoint: CondrvObject,
+    ) -> Result<Arc<CondrvStreamObject>, NtStatus> {
         let mut state = self.state.lock();
-        let object = match endpoint {
-            CondrvObject::CurrentInput => Arc::clone(&state.bound_input),
+        match endpoint {
+            CondrvObject::CurrentInput => Ok(Arc::clone(&state.bound_input)),
             // TODO(condrv-activate-buffer): update this pointer when LiteBox implements and
             // host-validates the ConDrv activate-buffer IOCTL.
-            CondrvObject::CurrentOutput => Arc::clone(&state.active_output),
+            CondrvObject::CurrentOutput => Ok(Arc::clone(&state.active_output)),
             CondrvObject::Input | CondrvObject::Output | CondrvObject::ScreenBuffer => {
-                state.allocate_object()?
+                state.allocate_object()
             }
             CondrvObject::Server | CondrvObject::Reference | CondrvObject::Connect => {
-                return Err(NtStatus::OBJECT_TYPE_MISMATCH);
+                Err(NtStatus::OBJECT_TYPE_MISMATCH)
             }
-        };
-        Ok(CondrvStreamOpen { object })
+        }
     }
 }
 
@@ -103,10 +93,7 @@ impl CondrvConsoleState {
     fn allocate_object(&mut self) -> Result<Arc<CondrvStreamObject>, NtStatus> {
         let id = self.next_object_id;
         self.next_object_id = id.checked_add(1).ok_or(NtStatus::QUOTA_EXCEEDED)?;
-        let object = Arc::new(CondrvStreamObject { id });
-        self.objects.retain(|_, object| object.strong_count() != 0);
-        self.objects.insert(id, Arc::downgrade(&object));
-        Ok(object)
+        Ok(Arc::new(CondrvStreamObject { id }))
     }
 }
 

--- a/litebox_shim_windows/src/syscalls/condrv.rs
+++ b/litebox_shim_windows/src/syscalls/condrv.rs
@@ -16,6 +16,9 @@ use crate::{ConstPtr, MutPtr};
 const FILE_DEVICE_CONSOLE: u32 = 0x50;
 const CD_SERVER_EA_NAME: &[u8] = b"server";
 
+// TODO(condrv-backing-fidelity): LiteBox exposes only stdin/stdout/stderr backing streams, so
+// these endpoint kinds cannot yet carry the distinct console-object state modeled by Wine's
+// server/console.c and ReactOS ConDrv. Faithful behavior needs per-object console infrastructure.
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, Eq, IntEnum, PartialEq)]
 pub(crate) enum CondrvObject {
@@ -100,6 +103,9 @@ impl CondrvObject {
     }
 
     pub(crate) fn handle_path(self) -> &'static str {
+        // TODO(condrv-bound-endpoint): CurrentIn and CurrentOut are bound to the attached
+        // console's input and active screen buffer in Wine server/console.c and ReactOS ConDrv.
+        // Mapping them to the same host streams as Input and Output makes that distinction nominal.
         match self {
             Self::Input | Self::CurrentInput => "/dev/stdin",
             Self::Output | Self::CurrentOutput | Self::ScreenBuffer => "/dev/stdout",

--- a/litebox_shim_windows/src/syscalls/condrv.rs
+++ b/litebox_shim_windows/src/syscalls/condrv.rs
@@ -3,6 +3,8 @@
 
 //! Windows console driver support.
 
+use alloc::collections::BTreeMap;
+use alloc::sync::{Arc, Weak};
 use core::mem::size_of;
 
 use int_enum::IntEnum;
@@ -16,9 +18,6 @@ use crate::{ConstPtr, MutPtr};
 const FILE_DEVICE_CONSOLE: u32 = 0x50;
 const CD_SERVER_EA_NAME: &[u8] = b"server";
 
-// TODO(condrv-backing-fidelity): LiteBox exposes only stdin/stdout/stderr backing streams, so
-// these endpoint kinds cannot yet carry the distinct console-object state modeled by Wine's
-// server/console.c and ReactOS ConDrv. Faithful behavior needs per-object console infrastructure.
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, Eq, IntEnum, PartialEq)]
 pub(crate) enum CondrvObject {
@@ -30,6 +29,85 @@ pub(crate) enum CondrvObject {
     Server = 5,
     Reference = 6,
     Connect = 7,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum CondrvStreamDirection {
+    Input,
+    Output,
+}
+
+pub(crate) struct CondrvStreamObject {
+    id: u64,
+}
+
+pub(crate) struct CondrvStreamOpen {
+    pub(crate) object: Arc<CondrvStreamObject>,
+}
+
+struct CondrvConsoleState {
+    next_object_id: u64,
+    // Weak entries keep handle lifetime authoritative while retaining an object-id registry for
+    // future activation and cross-process lookup.
+    objects: BTreeMap<u64, Weak<CondrvStreamObject>>,
+    bound_input: Arc<CondrvStreamObject>,
+    active_output: Arc<CondrvStreamObject>,
+}
+
+pub(crate) struct CondrvConsole<Platform: crate::ShimPlatform> {
+    state: litebox::sync::Mutex<Platform, CondrvConsoleState>,
+}
+
+impl CondrvStreamObject {
+    pub(crate) fn id(&self) -> u64 {
+        self.id
+    }
+}
+
+impl<Platform: crate::ShimPlatform> CondrvConsole<Platform> {
+    pub(crate) fn new() -> Self {
+        let bound_input = Arc::new(CondrvStreamObject { id: 1 });
+        let active_output = Arc::new(CondrvStreamObject { id: 2 });
+        let mut objects = BTreeMap::new();
+        objects.insert(bound_input.id, Arc::downgrade(&bound_input));
+        objects.insert(active_output.id, Arc::downgrade(&active_output));
+        Self {
+            state: litebox::sync::Mutex::new(CondrvConsoleState {
+                next_object_id: 3,
+                objects,
+                bound_input,
+                active_output,
+            }),
+        }
+    }
+
+    pub(crate) fn open_stream(&self, endpoint: CondrvObject) -> Result<CondrvStreamOpen, NtStatus> {
+        let mut state = self.state.lock();
+        let object = match endpoint {
+            CondrvObject::CurrentInput => Arc::clone(&state.bound_input),
+            // TODO(condrv-activate-buffer): update this pointer when LiteBox implements and
+            // host-validates the ConDrv activate-buffer IOCTL.
+            CondrvObject::CurrentOutput => Arc::clone(&state.active_output),
+            CondrvObject::Input | CondrvObject::Output | CondrvObject::ScreenBuffer => {
+                state.allocate_object()?
+            }
+            CondrvObject::Server | CondrvObject::Reference | CondrvObject::Connect => {
+                return Err(NtStatus::OBJECT_TYPE_MISMATCH);
+            }
+        };
+        Ok(CondrvStreamOpen { object })
+    }
+}
+
+impl CondrvConsoleState {
+    fn allocate_object(&mut self) -> Result<Arc<CondrvStreamObject>, NtStatus> {
+        let id = self.next_object_id;
+        self.next_object_id = id.checked_add(1).ok_or(NtStatus::QUOTA_EXCEEDED)?;
+        let object = Arc::new(CondrvStreamObject { id });
+        self.objects.retain(|_, object| object.strong_count() != 0);
+        self.objects.insert(id, Arc::downgrade(&object));
+        Ok(object)
+    }
 }
 
 impl CondrvObject {
@@ -103,15 +181,22 @@ impl CondrvObject {
     }
 
     pub(crate) fn handle_path(self) -> &'static str {
-        // TODO(condrv-bound-endpoint): CurrentIn and CurrentOut are bound to the attached
-        // console's input and active screen buffer in Wine server/console.c and ReactOS ConDrv.
-        // Mapping them to the same host streams as Input and Output makes that distinction nominal.
         match self {
             Self::Input | Self::CurrentInput => "/dev/stdin",
             Self::Output | Self::CurrentOutput | Self::ScreenBuffer => "/dev/stdout",
             Self::Server => r"\Device\ConDrv\Server",
             Self::Reference => r"\Device\ConDrv\Reference",
             Self::Connect => r"\Device\ConDrv\Connect",
+        }
+    }
+
+    pub(crate) fn stream_direction(self) -> Option<CondrvStreamDirection> {
+        match self {
+            Self::Input | Self::CurrentInput => Some(CondrvStreamDirection::Input),
+            Self::Output | Self::CurrentOutput | Self::ScreenBuffer => {
+                Some(CondrvStreamDirection::Output)
+            }
+            Self::Server | Self::Reference | Self::Connect => None,
         }
     }
 }

--- a/litebox_shim_windows/src/syscalls/condrv.rs
+++ b/litebox_shim_windows/src/syscalls/condrv.rs
@@ -24,6 +24,7 @@ pub(crate) enum CondrvObject {
     Server = 2,
     Reference = 3,
     Connect = 4,
+    Connected = 5,
 }
 
 impl CondrvObject {
@@ -32,6 +33,7 @@ impl CondrvObject {
             Some(object @ (Self::Input | Self::Output | Self::Server)) => Ok(object),
             Some(Self::Reference) => Err(NtStatus::INVALID_HANDLE),
             Some(Self::Connect) => Err(NtStatus::OBJECT_TYPE_MISMATCH),
+            Some(Self::Connected) => unreachable!("Connected is not a named ConDrv endpoint"),
             None => Err(NtStatus::OBJECT_NAME_NOT_FOUND),
         }
     }
@@ -59,14 +61,17 @@ impl CondrvObject {
         match (self, child) {
             (Self::Server, Self::Server | Self::Reference)
             | (Self::Reference, Self::Server | Self::Connect | Self::Input | Self::Output)
-            | (Self::Input | Self::Output, Self::Server | Self::Input | Self::Output) => Ok(child),
+            | (Self::Input | Self::Output, Self::Server | Self::Input | Self::Output)
+            | (Self::Connected, Self::Server | Self::Reference | Self::Input | Self::Output) => {
+                Ok(child)
+            }
             (Self::Server, Self::Input | Self::Output) => Err(NtStatus::INVALID_DEVICE_STATE),
             (Self::Reference | Self::Input | Self::Output, Self::Reference) => {
                 Err(NtStatus::OBJECT_TYPE_MISMATCH)
             }
-            (Self::Server | Self::Input | Self::Output, Self::Connect) | (Self::Connect, _) => {
-                Err(NtStatus::INVALID_HANDLE)
-            }
+            (Self::Server | Self::Input | Self::Output | Self::Connected, Self::Connect)
+            | (Self::Connect, _) => Err(NtStatus::INVALID_HANDLE),
+            (_, Self::Connected) => Err(NtStatus::NOT_FOUND),
         }
     }
 
@@ -76,7 +81,7 @@ impl CondrvObject {
             Self::Output => "/dev/stdout",
             Self::Server => r"\Device\ConDrv\Server",
             Self::Reference => r"\Device\ConDrv\Reference",
-            Self::Connect => r"\Device\ConDrv\Connect",
+            Self::Connect | Self::Connected => r"\Device\ConDrv\Connect",
         }
     }
 }
@@ -177,13 +182,16 @@ pub(crate) fn validate_connect_server_ea<Platform: crate::ShimPlatform>(
     let Some(value_address) = ea_buffer.as_usize().checked_add(value_offset) else {
         return Err(NtStatus::EAS_NOT_SUPPORTED);
     };
-    // The ConDrv "server" EA value format is undocumented; probe the declared payload without
-    // interpreting it until its semantics are understood.
-    if ConstPtr::<Platform, u8>::from_usize(value_address)
-        .to_owned_slice(value_length)
-        .is_none()
-    {
+    // Windows rejects a structurally valid but zeroed server handshake with
+    // STATUS_PIPE_DISCONNECTED.
+    // TODO(condrv-handshake): decode the undocumented server payload once its layout is known.
+    let Some(value) =
+        ConstPtr::<Platform, u8>::from_usize(value_address).to_owned_slice(value_length)
+    else {
         return Err(NtStatus::ACCESS_VIOLATION);
+    };
+    if value.iter().all(|byte| *byte == 0) {
+        return Err(NtStatus::PIPE_DISCONNECTED);
     }
 
     Ok(())
@@ -269,7 +277,7 @@ mod tests {
 
     #[test]
     fn relative_children_match_host_parse_contexts() {
-        use CondrvObject::{Connect, Input, Output, Reference, Server};
+        use CondrvObject::{Connect, Connected, Input, Output, Reference, Server};
 
         for (parent, name, expected) in [
             (Server, r"\Server", Ok(Server)),
@@ -296,6 +304,13 @@ mod tests {
             (Output, r"\Output", Ok(Output)),
             (Output, r"\Reference", Err(NtStatus::OBJECT_TYPE_MISMATCH)),
             (Output, r"\Connect", Err(NtStatus::INVALID_HANDLE)),
+            (Connect, r"\Input", Err(NtStatus::INVALID_HANDLE)),
+            (Connect, r"\Output", Err(NtStatus::INVALID_HANDLE)),
+            (Connected, r"\Input", Ok(Input)),
+            (Connected, r"\Output", Ok(Output)),
+            (Connected, r"\Server", Ok(Server)),
+            (Connected, r"\Reference", Ok(Reference)),
+            (Connected, r"\Connect", Err(NtStatus::INVALID_HANDLE)),
         ] {
             assert_eq!(parent.relative_child(name), expected, "{parent:?} + {name}");
         }

--- a/litebox_shim_windows/src/syscalls/condrv.rs
+++ b/litebox_shim_windows/src/syscalls/condrv.rs
@@ -24,7 +24,6 @@ pub(crate) enum CondrvObject {
     Server = 2,
     Reference = 3,
     Connect = 4,
-    Connected = 5,
 }
 
 impl CondrvObject {
@@ -33,7 +32,6 @@ impl CondrvObject {
             Some(object @ (Self::Input | Self::Output | Self::Server)) => Ok(object),
             Some(Self::Reference) => Err(NtStatus::INVALID_HANDLE),
             Some(Self::Connect) => Err(NtStatus::OBJECT_TYPE_MISMATCH),
-            Some(Self::Connected) => unreachable!("Connected is not a named ConDrv endpoint"),
             None => Err(NtStatus::OBJECT_NAME_NOT_FOUND),
         }
     }
@@ -56,22 +54,34 @@ impl CondrvObject {
 
     pub(crate) fn relative_child(self, name: &str) -> Result<Self, NtStatus> {
         let name = name.strip_prefix('\\').ok_or(NtStatus::NOT_FOUND)?;
-        let child = Self::from_component(name).ok_or(NtStatus::NOT_FOUND)?;
+        let child = if self == Self::Connect {
+            if name.eq_ignore_ascii_case("CurrentIn") {
+                Self::Input
+            } else if name.eq_ignore_ascii_case("CurrentOut")
+                || name.eq_ignore_ascii_case("ScreenBuffer")
+            {
+                Self::Output
+            } else {
+                Self::from_component(name).ok_or(NtStatus::NOT_FOUND)?
+            }
+        } else {
+            Self::from_component(name).ok_or(NtStatus::NOT_FOUND)?
+        };
 
         match (self, child) {
             (Self::Server, Self::Server | Self::Reference)
             | (Self::Reference, Self::Server | Self::Connect | Self::Input | Self::Output)
             | (Self::Input | Self::Output, Self::Server | Self::Input | Self::Output)
-            | (Self::Connected, Self::Server | Self::Reference | Self::Input | Self::Output) => {
+            | (Self::Connect, Self::Server | Self::Reference | Self::Input | Self::Output) => {
                 Ok(child)
             }
             (Self::Server, Self::Input | Self::Output) => Err(NtStatus::INVALID_DEVICE_STATE),
             (Self::Reference | Self::Input | Self::Output, Self::Reference) => {
                 Err(NtStatus::OBJECT_TYPE_MISMATCH)
             }
-            (Self::Server | Self::Input | Self::Output | Self::Connected, Self::Connect)
-            | (Self::Connect, _) => Err(NtStatus::INVALID_HANDLE),
-            (_, Self::Connected) => Err(NtStatus::NOT_FOUND),
+            (Self::Server | Self::Input | Self::Output | Self::Connect, Self::Connect) => {
+                Err(NtStatus::INVALID_HANDLE)
+            }
         }
     }
 
@@ -81,7 +91,7 @@ impl CondrvObject {
             Self::Output => "/dev/stdout",
             Self::Server => r"\Device\ConDrv\Server",
             Self::Reference => r"\Device\ConDrv\Reference",
-            Self::Connect | Self::Connected => r"\Device\ConDrv\Connect",
+            Self::Connect => r"\Device\ConDrv\Connect",
         }
     }
 }
@@ -184,7 +194,8 @@ pub(crate) fn validate_connect_server_ea<Platform: crate::ShimPlatform>(
     };
     // Windows rejects a structurally valid but zeroed server handshake with
     // STATUS_PIPE_DISCONNECTED.
-    // TODO(condrv-handshake): decode the undocumented server payload once its layout is known.
+    // TODO(condrv-handshake): fully decode the undocumented server payload; the current subset
+    // only pins the native all-zero rejection and validates its readable extent.
     let Some(value) =
         ConstPtr::<Platform, u8>::from_usize(value_address).to_owned_slice(value_length)
     else {
@@ -277,7 +288,7 @@ mod tests {
 
     #[test]
     fn relative_children_match_host_parse_contexts() {
-        use CondrvObject::{Connect, Connected, Input, Output, Reference, Server};
+        use CondrvObject::{Connect, Input, Output, Reference, Server};
 
         for (parent, name, expected) in [
             (Server, r"\Server", Ok(Server)),
@@ -304,13 +315,14 @@ mod tests {
             (Output, r"\Output", Ok(Output)),
             (Output, r"\Reference", Err(NtStatus::OBJECT_TYPE_MISMATCH)),
             (Output, r"\Connect", Err(NtStatus::INVALID_HANDLE)),
-            (Connect, r"\Input", Err(NtStatus::INVALID_HANDLE)),
-            (Connect, r"\Output", Err(NtStatus::INVALID_HANDLE)),
-            (Connected, r"\Input", Ok(Input)),
-            (Connected, r"\Output", Ok(Output)),
-            (Connected, r"\Server", Ok(Server)),
-            (Connected, r"\Reference", Ok(Reference)),
-            (Connected, r"\Connect", Err(NtStatus::INVALID_HANDLE)),
+            (Connect, r"\Input", Ok(Input)),
+            (Connect, r"\Output", Ok(Output)),
+            (Connect, r"\CurrentIn", Ok(Input)),
+            (Connect, r"\CurrentOut", Ok(Output)),
+            (Connect, r"\ScreenBuffer", Ok(Output)),
+            (Connect, r"\Server", Ok(Server)),
+            (Connect, r"\Reference", Ok(Reference)),
+            (Connect, r"\Connect", Err(NtStatus::INVALID_HANDLE)),
         ] {
             assert_eq!(parent.relative_child(name), expected, "{parent:?} + {name}");
         }

--- a/litebox_shim_windows/src/syscalls/condrv.rs
+++ b/litebox_shim_windows/src/syscalls/condrv.rs
@@ -323,6 +323,7 @@ mod tests {
             (Connect, r"\Server", Ok(Server)),
             (Connect, r"\Reference", Ok(Reference)),
             (Connect, r"\Connect", Err(NtStatus::INVALID_HANDLE)),
+            (Connect, r"\Bogus", Err(NtStatus::NOT_FOUND)),
         ] {
             assert_eq!(parent.relative_child(name), expected, "{parent:?} + {name}");
         }

--- a/litebox_shim_windows/src/syscalls/file.rs
+++ b/litebox_shim_windows/src/syscalls/file.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 use alloc::string::String;
+use alloc::sync::Arc;
 use core::marker::PhantomData;
 use core::mem::size_of;
 
@@ -17,7 +18,7 @@ use crate::nt_types::{
     AccessMask, IoStatusBlock, ObjectAttributes, UnicodeString, read_object_attributes,
 };
 use crate::syscalls::Handle;
-use crate::syscalls::condrv::{self, CondrvObject};
+use crate::syscalls::condrv::{self, CondrvObject, CondrvStreamDirection, CondrvStreamObject};
 use crate::syscalls::file_path::{FilePathResolver, FilePathRoot, FileTarget};
 use crate::{
     ConstPtr, MutPtr, ShimFS, Task, probe_guest_output_preserving_value, raw_handle_entry,
@@ -102,9 +103,27 @@ enum FileObjectBacking<FS: ShimFS> {
     },
     CondrvStream {
         object: CondrvObject,
+        stream_object: Arc<CondrvStreamObject>,
         fd: TypedFd<FS>,
     },
     CondrvControl(CondrvObject),
+}
+
+#[derive(Clone, Copy)]
+enum FileSharingIdentity<'a> {
+    Path(&'a str),
+    // TODO(condrv-share-access): native CONIN$/CONOUT$ permits multiple share-access-zero opens
+    // of the same bound object; determine which ConDrv opens ignore sharing before enforcing it.
+    CondrvObject(u64),
+}
+
+impl FileSharingIdentity<'_> {
+    fn matches<FS: ShimFS>(self, file: &FileObject<FS>) -> bool {
+        match self {
+            Self::Path(path) => file.condrv_stream_object_id().is_none() && file.path == path,
+            Self::CondrvObject(object_id) => file.condrv_stream_object_id() == Some(object_id),
+        }
+    }
 }
 
 impl<FS: ShimFS> FileObject<FS> {
@@ -113,6 +132,13 @@ impl<FS: ShimFS> FileObject<FS> {
             FileObjectBacking::CondrvStream { object, .. }
             | FileObjectBacking::CondrvControl(object) => Some(object),
             FileObjectBacking::Filesystem { .. } => None,
+        }
+    }
+
+    fn condrv_stream_object_id(&self) -> Option<u64> {
+        match &self.backing {
+            FileObjectBacking::CondrvStream { stream_object, .. } => Some(stream_object.id()),
+            FileObjectBacking::Filesystem { .. } | FileObjectBacking::CondrvControl(_) => None,
         }
     }
 
@@ -700,7 +726,11 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         create_options: FileCreateOptions,
         file_attributes: u32,
     ) -> Result<(FileObject<FS>, FileCreateInformation), NtStatus> {
-        self.check_file_sharing(&path, desired_access, share_access)?;
+        self.check_file_sharing(
+            FileSharingIdentity::Path(&path),
+            desired_access,
+            share_access,
+        )?;
         if create_options.contains(FileCreateOptions::DIRECTORY_FILE) {
             return self.open_or_create_directory(
                 &path,
@@ -755,39 +785,42 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         }
 
         let path = String::from(object.handle_path());
-        // TODO(condrv-screenbuffer-identity): CreateConsoleScreenBuffer creates a new,
-        // independently shared object in Wine server/console.c and ReactOS ConDrv; a native probe
-        // likewise opened two exclusive buffers concurrently. LiteBox collapses every instance
-        // onto /dev/stdout, so sharing is bypassed until the backing layer has per-object identity.
-        if object != CondrvObject::ScreenBuffer {
-            self.check_file_sharing(&path, desired_access, share_access)?;
-        }
-        let (backing, information) = match object {
-            CondrvObject::Input
-            | CondrvObject::Output
-            | CondrvObject::CurrentInput
-            | CondrvObject::CurrentOutput
-            | CondrvObject::ScreenBuffer => {
-                let backing_access = match object {
-                    CondrvObject::Input | CondrvObject::CurrentInput => FileAccess::READ_DATA,
-                    CondrvObject::Output
-                    | CondrvObject::CurrentOutput
-                    | CondrvObject::ScreenBuffer => FileAccess::WRITE_DATA,
-                    _ => unreachable!(),
-                };
-                let (fd, _, information) = self.open_backing_fd(
-                    &path,
-                    backing_access,
-                    create_disposition,
-                    create_options,
-                    Mode::empty(),
-                )?;
-                (FileObjectBacking::CondrvStream { object, fd }, information)
-            }
-            CondrvObject::Server | CondrvObject::Reference | CondrvObject::Connect => (
+        let (backing, information) = if let Some(direction) = object.stream_direction() {
+            let stream_open = self.process.condrv_console.open_stream(object)?;
+            self.check_file_sharing(
+                FileSharingIdentity::CondrvObject(stream_open.object.id()),
+                desired_access,
+                share_access,
+            )?;
+            let backing_access = match direction {
+                CondrvStreamDirection::Input => FileAccess::READ_DATA,
+                CondrvStreamDirection::Output => FileAccess::WRITE_DATA,
+            };
+            let (fd, _, information) = self.open_backing_fd(
+                &path,
+                backing_access,
+                create_disposition,
+                create_options,
+                Mode::empty(),
+            )?;
+            (
+                FileObjectBacking::CondrvStream {
+                    object,
+                    stream_object: stream_open.object,
+                    fd,
+                },
+                information,
+            )
+        } else {
+            self.check_file_sharing(
+                FileSharingIdentity::Path(&path),
+                desired_access,
+                share_access,
+            )?;
+            (
                 FileObjectBacking::CondrvControl(object),
                 FileCreateInformation::Opened,
-            ),
+            )
         };
         Ok((
             FileObject {
@@ -939,7 +972,7 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
 
     fn check_file_sharing(
         &self,
-        path: &str,
+        identity: FileSharingIdentity<'_>,
         desired_access: FileAccess,
         share_access: FileShareAccess,
     ) -> Result<(), NtStatus> {
@@ -957,8 +990,7 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                 continue;
             };
             let conflicts = entry.with_entry(|file| {
-                file.condrv_object() != Some(CondrvObject::ScreenBuffer)
-                    && file.path == path
+                identity.matches(file)
                     && (desired_access.conflicts_with_share(file.share_access)
                         || file.granted_access.conflicts_with_share(share_access))
             });
@@ -1401,63 +1433,82 @@ mod tests {
         assert_eq!(current_input_status, NtStatus::SUCCESS);
         assert_eq!(current_output_status, NtStatus::SUCCESS);
         assert_eq!(screen_buffer_status, NtStatus::SUCCESS);
-        assert_eq!(
-            task.file_entry(current_input_handle)
-                .unwrap()
-                .with_entry(FileObject::condrv_object),
-            Some(CondrvObject::CurrentInput)
-        );
-        assert_eq!(
-            task.file_entry(current_output_handle)
-                .unwrap()
-                .with_entry(FileObject::condrv_object),
-            Some(CondrvObject::CurrentOutput)
-        );
-        assert_eq!(
-            task.file_entry(screen_buffer_handle)
-                .unwrap()
-                .with_entry(FileObject::condrv_object),
-            Some(CondrvObject::ScreenBuffer)
-        );
+        let stream_identity = |handle| {
+            task.file_entry(handle).unwrap().with_entry(|file| {
+                (
+                    file.condrv_object().unwrap(),
+                    file.condrv_stream_object_id().unwrap(),
+                )
+            })
+        };
+        let input_identity = stream_identity(input_handle);
+        let output_identity = stream_identity(output_handle);
+        let current_input_identity = stream_identity(current_input_handle);
+        let current_output_identity = stream_identity(current_output_handle);
+        let screen_buffer_identity = stream_identity(screen_buffer_handle);
+        assert_eq!(current_input_identity.0, CondrvObject::CurrentInput);
+        assert_eq!(current_output_identity.0, CondrvObject::CurrentOutput);
+        assert_eq!(screen_buffer_identity.0, CondrvObject::ScreenBuffer);
+        assert_ne!(input_identity.1, current_input_identity.1);
+        assert_ne!(output_identity.1, current_output_identity.1);
+        assert_ne!(output_identity.1, screen_buffer_identity.1);
+        assert_ne!(current_output_identity.1, screen_buffer_identity.1);
+        for handle in [output_handle, current_output_handle, screen_buffer_handle] {
+            assert_eq!(
+                task.file_entry(handle)
+                    .unwrap()
+                    .with_entry(|file| file.path.clone()),
+                "/dev/stdout"
+            );
+        }
 
-        for (path, desired_access, expected_object) in [
+        for (path, desired_access, expected_object, expected_bound_id) in [
             (
                 r"\Device\ConDrv\CurrentIn",
                 FILE_GENERIC_READ,
                 CondrvObject::CurrentInput,
+                Some(current_input_identity.1),
             ),
             (
                 r"\Device\ConDrv\CurrentOut",
                 FILE_GENERIC_WRITE,
                 CondrvObject::CurrentOutput,
+                Some(current_output_identity.1),
             ),
             (
                 r"\Device\ConDrv\ScreenBuffer",
                 FILE_GENERIC_WRITE,
                 CondrvObject::ScreenBuffer,
+                None,
             ),
         ] {
             let (status, handle, _) = create_file(&task, path, desired_access, FILE_OPEN);
             assert_eq!(status, NtStatus::SUCCESS, "{path}");
-            assert_eq!(
-                task.file_entry(handle)
-                    .unwrap()
-                    .with_entry(FileObject::condrv_object),
-                Some(expected_object),
-                "{path}"
-            );
+            let identity = stream_identity(handle);
+            assert_eq!(identity.0, expected_object, "{path}");
+            if let Some(expected_bound_id) = expected_bound_id {
+                assert_eq!(identity.1, expected_bound_id, "{path}");
+            } else {
+                assert_ne!(identity.1, screen_buffer_identity.1, "{path}");
+            }
             assert_eq!(task.sys_nt_close(handle), NtStatus::SUCCESS);
         }
 
-        let (_path, _name, screen_buffer_attributes) =
-            open_object_attributes(r"\Device\ConDrv\ScreenBuffer");
-        let mut exclusive_screen_buffers = [Handle::default(); 2];
-        for handle in &mut exclusive_screen_buffers {
+        assert_eq!(task.sys_nt_close(current_output_handle), NtStatus::SUCCESS);
+        let mut exclusive_handles = alloc::vec::Vec::new();
+        for path in [
+            r"\Device\ConDrv\Output",
+            r"\Device\ConDrv\CurrentOut",
+            r"\Device\ConDrv\ScreenBuffer",
+            r"\Device\ConDrv\ScreenBuffer",
+        ] {
+            let (_path, _name, attributes) = open_object_attributes(path);
+            let mut handle = Handle::default();
             assert_eq!(
                 task.sys_nt_create_file(
-                    mut_ptr(handle),
+                    mut_ptr(&mut handle),
                     FILE_GENERIC_READ | FILE_GENERIC_WRITE,
-                    Some(const_ptr(&screen_buffer_attributes)),
+                    Some(const_ptr(&attributes)),
                     mut_ptr(&mut io_status),
                     None,
                     0,
@@ -1467,15 +1518,41 @@ mod tests {
                     None,
                     0,
                 ),
-                NtStatus::SUCCESS
+                NtStatus::SUCCESS,
+                "{path}"
             );
+            exclusive_handles.push(handle);
         }
-        for handle in exclusive_screen_buffers {
+        let exclusive_identities: alloc::vec::Vec<_> = exclusive_handles
+            .iter()
+            .map(|handle| stream_identity(*handle))
+            .collect();
+        assert_eq!(exclusive_identities[0].0, CondrvObject::Output);
+        assert_eq!(exclusive_identities[1].0, CondrvObject::CurrentOutput);
+        assert_eq!(
+            exclusive_identities[1].1, current_output_identity.1,
+            "CurrentOut must reference the active output object"
+        );
+        assert_ne!(exclusive_identities[0].1, exclusive_identities[1].1);
+        assert_ne!(exclusive_identities[2].1, exclusive_identities[3].1);
+        let closed_screen_buffer_id = exclusive_identities[2].1;
+        for handle in exclusive_handles {
             assert_eq!(task.sys_nt_close(handle), NtStatus::SUCCESS);
         }
+        let (status, reopened_screen_buffer, _) = create_file(
+            &task,
+            r"\Device\ConDrv\ScreenBuffer",
+            FILE_GENERIC_WRITE,
+            FILE_OPEN,
+        );
+        assert_eq!(status, NtStatus::SUCCESS);
+        assert_ne!(
+            stream_identity(reopened_screen_buffer).1,
+            closed_screen_buffer_id
+        );
+        assert_eq!(task.sys_nt_close(reopened_screen_buffer), NtStatus::SUCCESS);
 
         assert_eq!(task.sys_nt_close(screen_buffer_handle), NtStatus::SUCCESS);
-        assert_eq!(task.sys_nt_close(current_output_handle), NtStatus::SUCCESS);
         assert_eq!(task.sys_nt_close(current_input_handle), NtStatus::SUCCESS);
         assert_eq!(task.sys_nt_close(output_handle), NtStatus::SUCCESS);
         assert_eq!(task.sys_nt_close(input_handle), NtStatus::SUCCESS);

--- a/litebox_shim_windows/src/syscalls/file.rs
+++ b/litebox_shim_windows/src/syscalls/file.rs
@@ -755,6 +755,10 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         }
 
         let path = String::from(object.handle_path());
+        // TODO(condrv-screenbuffer-identity): CreateConsoleScreenBuffer creates a new,
+        // independently shared object in Wine server/console.c and ReactOS ConDrv; a native probe
+        // likewise opened two exclusive buffers concurrently. LiteBox collapses every instance
+        // onto /dev/stdout, so sharing is bypassed until the backing layer has per-object identity.
         if object != CondrvObject::ScreenBuffer {
             self.check_file_sharing(&path, desired_access, share_access)?;
         }

--- a/litebox_shim_windows/src/syscalls/file.rs
+++ b/litebox_shim_windows/src/syscalls/file.rs
@@ -755,12 +755,20 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         }
 
         let path = String::from(object.handle_path());
-        self.check_file_sharing(&path, desired_access, share_access)?;
+        if object != CondrvObject::ScreenBuffer {
+            self.check_file_sharing(&path, desired_access, share_access)?;
+        }
         let (backing, information) = match object {
-            CondrvObject::Input | CondrvObject::Output => {
+            CondrvObject::Input
+            | CondrvObject::Output
+            | CondrvObject::CurrentInput
+            | CondrvObject::CurrentOutput
+            | CondrvObject::ScreenBuffer => {
                 let backing_access = match object {
-                    CondrvObject::Input => FileAccess::READ_DATA,
-                    CondrvObject::Output => FileAccess::WRITE_DATA,
+                    CondrvObject::Input | CondrvObject::CurrentInput => FileAccess::READ_DATA,
+                    CondrvObject::Output
+                    | CondrvObject::CurrentOutput
+                    | CondrvObject::ScreenBuffer => FileAccess::WRITE_DATA,
                     _ => unreachable!(),
                 };
                 let (fd, _, information) = self.open_backing_fd(
@@ -945,7 +953,8 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                 continue;
             };
             let conflicts = entry.with_entry(|file| {
-                file.path == path
+                file.condrv_object() != Some(CondrvObject::ScreenBuffer)
+                    && file.path == path
                     && (desired_access.conflicts_with_share(file.share_access)
                         || file.granted_access.conflicts_with_share(share_access))
             });
@@ -1388,6 +1397,78 @@ mod tests {
         assert_eq!(current_input_status, NtStatus::SUCCESS);
         assert_eq!(current_output_status, NtStatus::SUCCESS);
         assert_eq!(screen_buffer_status, NtStatus::SUCCESS);
+        assert_eq!(
+            task.file_entry(current_input_handle)
+                .unwrap()
+                .with_entry(FileObject::condrv_object),
+            Some(CondrvObject::CurrentInput)
+        );
+        assert_eq!(
+            task.file_entry(current_output_handle)
+                .unwrap()
+                .with_entry(FileObject::condrv_object),
+            Some(CondrvObject::CurrentOutput)
+        );
+        assert_eq!(
+            task.file_entry(screen_buffer_handle)
+                .unwrap()
+                .with_entry(FileObject::condrv_object),
+            Some(CondrvObject::ScreenBuffer)
+        );
+
+        for (path, desired_access, expected_object) in [
+            (
+                r"\Device\ConDrv\CurrentIn",
+                FILE_GENERIC_READ,
+                CondrvObject::CurrentInput,
+            ),
+            (
+                r"\Device\ConDrv\CurrentOut",
+                FILE_GENERIC_WRITE,
+                CondrvObject::CurrentOutput,
+            ),
+            (
+                r"\Device\ConDrv\ScreenBuffer",
+                FILE_GENERIC_WRITE,
+                CondrvObject::ScreenBuffer,
+            ),
+        ] {
+            let (status, handle, _) = create_file(&task, path, desired_access, FILE_OPEN);
+            assert_eq!(status, NtStatus::SUCCESS, "{path}");
+            assert_eq!(
+                task.file_entry(handle)
+                    .unwrap()
+                    .with_entry(FileObject::condrv_object),
+                Some(expected_object),
+                "{path}"
+            );
+            assert_eq!(task.sys_nt_close(handle), NtStatus::SUCCESS);
+        }
+
+        let (_path, _name, screen_buffer_attributes) =
+            open_object_attributes(r"\Device\ConDrv\ScreenBuffer");
+        let mut exclusive_screen_buffers = [Handle::default(); 2];
+        for handle in &mut exclusive_screen_buffers {
+            assert_eq!(
+                task.sys_nt_create_file(
+                    mut_ptr(handle),
+                    FILE_GENERIC_READ | FILE_GENERIC_WRITE,
+                    Some(const_ptr(&screen_buffer_attributes)),
+                    mut_ptr(&mut io_status),
+                    None,
+                    0,
+                    0,
+                    FILE_OPEN,
+                    FileCreateOptions::NON_DIRECTORY_FILE.bits(),
+                    None,
+                    0,
+                ),
+                NtStatus::SUCCESS
+            );
+        }
+        for handle in exclusive_screen_buffers {
+            assert_eq!(task.sys_nt_close(handle), NtStatus::SUCCESS);
+        }
 
         assert_eq!(task.sys_nt_close(screen_buffer_handle), NtStatus::SUCCESS);
         assert_eq!(task.sys_nt_close(current_output_handle), NtStatus::SUCCESS);
@@ -2247,23 +2328,28 @@ mod tests {
             );
             let console_handle = Handle::from_raw(process_parameters.console_handle);
 
+            let success = [NtStatus::SUCCESS];
+            let screen_buffer = [NtStatus::SUCCESS, NtStatus::INVALID_PARAMETER];
+            let invalid_handle = [NtStatus::INVALID_HANDLE];
+            let not_found = [NtStatus::NOT_FOUND];
             for (name, expected) in [
-                (r"\Input", NtStatus::SUCCESS),
-                (r"\Output", NtStatus::SUCCESS),
-                (r"\CurrentIn", NtStatus::SUCCESS),
-                (r"\CurrentOut", NtStatus::SUCCESS),
-                (r"\ScreenBuffer", NtStatus::SUCCESS),
-                (r"\Server", NtStatus::SUCCESS),
-                (r"\Reference", NtStatus::SUCCESS),
-                (r"\Connect", NtStatus::INVALID_HANDLE),
-                (r"\Bogus", NtStatus::NOT_FOUND),
+                (r"\Input", success.as_slice()),
+                (r"\Output", success.as_slice()),
+                (r"\CurrentIn", success.as_slice()),
+                (r"\CurrentOut", success.as_slice()),
+                // Headless and pseudoconsole hosts may not support creating a bound legacy
+                // screen buffer even though their connected root supports CurrentOut.
+                (r"\ScreenBuffer", screen_buffer.as_slice()),
+                (r"\Server", success.as_slice()),
+                (r"\Reference", success.as_slice()),
+                (r"\Connect", invalid_handle.as_slice()),
+                (r"\Bogus", not_found.as_slice()),
             ] {
                 let (status, handle) = host_create_file(console_handle, name);
-                assert_eq!(
-                    status,
-                    expected,
-                    "{name:?} under console handle {:#x}",
-                    console_handle.as_raw()
+                assert!(
+                    expected.contains(&status),
+                    "{name:?} under console handle {:#x}: expected one of {expected:?}, got {status:?}",
+                    console_handle.as_raw(),
                 );
                 if status == NtStatus::SUCCESS {
                     assert!(!handle.is_null());

--- a/litebox_shim_windows/src/syscalls/file.rs
+++ b/litebox_shim_windows/src/syscalls/file.rs
@@ -786,9 +786,9 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
 
         let path = String::from(object.handle_path());
         let (backing, information) = if let Some(direction) = object.stream_direction() {
-            let stream_open = self.process.condrv_console.open_stream(object)?;
+            let stream_object = self.process.condrv_console.open_stream(object)?;
             self.check_file_sharing(
-                FileSharingIdentity::CondrvObject(stream_open.object.id()),
+                FileSharingIdentity::CondrvObject(stream_object.id()),
                 desired_access,
                 share_access,
             )?;
@@ -806,7 +806,7 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             (
                 FileObjectBacking::CondrvStream {
                     object,
-                    stream_object: stream_open.object,
+                    stream_object,
                     fd,
                 },
                 information,

--- a/litebox_shim_windows/src/syscalls/file.rs
+++ b/litebox_shim_windows/src/syscalls/file.rs
@@ -745,14 +745,11 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         ea_buffer: Option<ConstPtr<Platform, u8>>,
         ea_length: u32,
     ) -> Result<(FileObject<FS>, FileCreateInformation), NtStatus> {
-        let object = if object == CondrvObject::Connect {
+        if object == CondrvObject::Connect {
             condrv::validate_connect_server_ea::<Platform>(ea_buffer, ea_length)?;
-            CondrvObject::Connected
         } else if ea_buffer.is_some() || ea_length != 0 {
             return Err(NtStatus::EAS_NOT_SUPPORTED);
-        } else {
-            object
-        };
+        }
         if create_options.contains(FileCreateOptions::DIRECTORY_FILE) {
             return Err(NtStatus::NOT_A_DIRECTORY);
         }
@@ -775,10 +772,7 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                 )?;
                 (FileObjectBacking::CondrvStream { object, fd }, information)
             }
-            CondrvObject::Server
-            | CondrvObject::Reference
-            | CondrvObject::Connect
-            | CondrvObject::Connected => (
+            CondrvObject::Server | CondrvObject::Reference | CondrvObject::Connect => (
                 FileObjectBacking::CondrvControl(object),
                 FileCreateInformation::Opened,
             ),
@@ -1327,6 +1321,24 @@ mod tests {
                 FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
                 FILE_OPEN,
                 FileCreateOptions::SYNCHRONOUS_IO_NONALERT.bits(),
+                None,
+                0,
+            ),
+            NtStatus::EAS_NOT_SUPPORTED
+        );
+        assert!(connect_handle.is_null());
+
+        assert_eq!(
+            task.sys_nt_create_file(
+                mut_ptr(&mut connect_handle),
+                FILE_GENERIC_READ | FILE_GENERIC_WRITE,
+                Some(const_ptr(&connect_attributes)),
+                mut_ptr(&mut io_status),
+                None,
+                0,
+                FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                FILE_OPEN,
+                FileCreateOptions::SYNCHRONOUS_IO_NONALERT.bits(),
                 Some(const_ptr(&ea[0])),
                 u32::try_from(ea.len()).unwrap(),
             ),
@@ -1357,7 +1369,7 @@ mod tests {
             task.file_entry(connect_handle)
                 .unwrap()
                 .with_entry(FileObject::condrv_object),
-            Some(CondrvObject::Connected)
+            Some(CondrvObject::Connect)
         );
 
         assert_eq!(connect_handle, server_handle);
@@ -1365,9 +1377,21 @@ mod tests {
             open_condrv_child(&task, connect_handle, r"\Input", FILE_GENERIC_READ);
         let (output_status, output_handle) =
             open_condrv_child(&task, connect_handle, r"\Output", FILE_GENERIC_WRITE);
+        let (current_input_status, current_input_handle) =
+            open_condrv_child(&task, connect_handle, r"\CurrentIn", FILE_GENERIC_READ);
+        let (current_output_status, current_output_handle) =
+            open_condrv_child(&task, connect_handle, r"\CurrentOut", FILE_GENERIC_WRITE);
+        let (screen_buffer_status, screen_buffer_handle) =
+            open_condrv_child(&task, connect_handle, r"\ScreenBuffer", FILE_GENERIC_WRITE);
         assert_eq!(input_status, NtStatus::SUCCESS);
         assert_eq!(output_status, NtStatus::SUCCESS);
+        assert_eq!(current_input_status, NtStatus::SUCCESS);
+        assert_eq!(current_output_status, NtStatus::SUCCESS);
+        assert_eq!(screen_buffer_status, NtStatus::SUCCESS);
 
+        assert_eq!(task.sys_nt_close(screen_buffer_handle), NtStatus::SUCCESS);
+        assert_eq!(task.sys_nt_close(current_output_handle), NtStatus::SUCCESS);
+        assert_eq!(task.sys_nt_close(current_input_handle), NtStatus::SUCCESS);
         assert_eq!(task.sys_nt_close(output_handle), NtStatus::SUCCESS);
         assert_eq!(task.sys_nt_close(input_handle), NtStatus::SUCCESS);
         assert_eq!(task.sys_nt_close(connect_handle), NtStatus::SUCCESS);
@@ -2197,6 +2221,9 @@ mod tests {
             for (name, expected) in [
                 (r"\Input", NtStatus::SUCCESS),
                 (r"\Output", NtStatus::SUCCESS),
+                (r"\CurrentIn", NtStatus::SUCCESS),
+                (r"\CurrentOut", NtStatus::SUCCESS),
+                (r"\ScreenBuffer", NtStatus::SUCCESS),
                 (r"\Server", NtStatus::SUCCESS),
                 (r"\Reference", NtStatus::SUCCESS),
                 (r"\Connect", NtStatus::INVALID_HANDLE),

--- a/litebox_shim_windows/src/syscalls/file.rs
+++ b/litebox_shim_windows/src/syscalls/file.rs
@@ -683,7 +683,6 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                 share_access,
                 create_disposition,
                 create_options,
-                file_attributes,
                 ea_buffer,
                 ea_length,
             ),
@@ -718,7 +717,7 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             desired_access,
             create_disposition,
             create_options,
-            file_attributes,
+            create_mode(file_attributes),
         )?;
         Ok((
             FileObject {
@@ -743,15 +742,17 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         share_access: FileShareAccess,
         create_disposition: CreateDisposition,
         create_options: FileCreateOptions,
-        file_attributes: u32,
         ea_buffer: Option<ConstPtr<Platform, u8>>,
         ea_length: u32,
     ) -> Result<(FileObject<FS>, FileCreateInformation), NtStatus> {
-        if object == CondrvObject::Connect {
+        let object = if object == CondrvObject::Connect {
             condrv::validate_connect_server_ea::<Platform>(ea_buffer, ea_length)?;
+            CondrvObject::Connected
         } else if ea_buffer.is_some() || ea_length != 0 {
             return Err(NtStatus::EAS_NOT_SUPPORTED);
-        }
+        } else {
+            object
+        };
         if create_options.contains(FileCreateOptions::DIRECTORY_FILE) {
             return Err(NtStatus::NOT_A_DIRECTORY);
         }
@@ -760,16 +761,24 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         self.check_file_sharing(&path, desired_access, share_access)?;
         let (backing, information) = match object {
             CondrvObject::Input | CondrvObject::Output => {
+                let backing_access = match object {
+                    CondrvObject::Input => FileAccess::READ_DATA,
+                    CondrvObject::Output => FileAccess::WRITE_DATA,
+                    _ => unreachable!(),
+                };
                 let (fd, _, information) = self.open_backing_fd(
                     &path,
-                    desired_access,
+                    backing_access,
                     create_disposition,
                     create_options,
-                    file_attributes,
+                    Mode::empty(),
                 )?;
                 (FileObjectBacking::CondrvStream { object, fd }, information)
             }
-            CondrvObject::Server | CondrvObject::Reference | CondrvObject::Connect => (
+            CondrvObject::Server
+            | CondrvObject::Reference
+            | CondrvObject::Connect
+            | CondrvObject::Connected => (
                 FileObjectBacking::CondrvControl(object),
                 FileCreateInformation::Opened,
             ),
@@ -792,7 +801,7 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         desired_access: FileAccess,
         create_disposition: CreateDisposition,
         create_options: FileCreateOptions,
-        file_attributes: u32,
+        mode: Mode,
     ) -> Result<(TypedFd<FS>, bool, FileCreateInformation), NtStatus> {
         let existed_before_open = self.fs.file_status(path).is_ok();
         if create_disposition == CreateDisposition::Supersede
@@ -804,7 +813,7 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         let flags = desired_access.open_flags(create_disposition, create_options);
         let fd = self
             .fs
-            .open(path, flags, create_mode(file_attributes))
+            .open(path, flags, mode)
             .map_err(|error| map_open_error(error, create_disposition))?;
         let file_status = match self.fs.fd_file_status(&fd) {
             Ok(file_status) => file_status,
@@ -1256,8 +1265,34 @@ mod tests {
         .0
     }
 
+    fn open_condrv_child(
+        task: &Task<TestPlatform, TestFS>,
+        root: Handle,
+        name: &str,
+        desired_access: u32,
+    ) -> (NtStatus, Handle) {
+        let (_path, _name, mut attributes) = open_object_attributes(name);
+        attributes.root_directory = root;
+        let mut handle = Handle::default();
+        let mut io_status = IoStatusBlock::default();
+        let status = task.sys_nt_create_file(
+            mut_ptr(&mut handle),
+            desired_access,
+            Some(const_ptr(&attributes)),
+            mut_ptr(&mut io_status),
+            None,
+            0,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            FILE_OPEN,
+            FileCreateOptions::SYNCHRONOUS_IO_NONALERT.bits(),
+            None,
+            0,
+        );
+        (status, handle)
+    }
+
     #[test]
-    fn nt_create_file_follows_condrv_server_reference_connect_sequence() {
+    fn nt_create_file_follows_condrv_connection_through_standard_streams() {
         let task = crate::tests::test_task();
         let server_handle = open_condrv_server(&task);
         let reference_handle = open_condrv_reference(&task, server_handle);
@@ -1280,6 +1315,28 @@ mod tests {
                 .with_entry(FileObject::condrv_object),
             Some(CondrvObject::Reference)
         );
+
+        assert_eq!(
+            task.sys_nt_create_file(
+                mut_ptr(&mut connect_handle),
+                FILE_GENERIC_READ | FILE_GENERIC_WRITE,
+                Some(const_ptr(&connect_attributes)),
+                mut_ptr(&mut io_status),
+                None,
+                0,
+                FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                FILE_OPEN,
+                FileCreateOptions::SYNCHRONOUS_IO_NONALERT.bits(),
+                Some(const_ptr(&ea[0])),
+                u32::try_from(ea.len()).unwrap(),
+            ),
+            NtStatus::PIPE_DISCONNECTED
+        );
+        assert!(connect_handle.is_null());
+
+        assert_eq!(task.sys_nt_close(server_handle), NtStatus::SUCCESS);
+        let mut ea = ea;
+        *ea.last_mut().unwrap() = 1;
         assert_eq!(
             task.sys_nt_create_file(
                 mut_ptr(&mut connect_handle),
@@ -1300,12 +1357,21 @@ mod tests {
             task.file_entry(connect_handle)
                 .unwrap()
                 .with_entry(FileObject::condrv_object),
-            Some(CondrvObject::Connect)
+            Some(CondrvObject::Connected)
         );
 
+        assert_eq!(connect_handle, server_handle);
+        let (input_status, input_handle) =
+            open_condrv_child(&task, connect_handle, r"\Input", FILE_GENERIC_READ);
+        let (output_status, output_handle) =
+            open_condrv_child(&task, connect_handle, r"\Output", FILE_GENERIC_WRITE);
+        assert_eq!(input_status, NtStatus::SUCCESS);
+        assert_eq!(output_status, NtStatus::SUCCESS);
+
+        assert_eq!(task.sys_nt_close(output_handle), NtStatus::SUCCESS);
+        assert_eq!(task.sys_nt_close(input_handle), NtStatus::SUCCESS);
         assert_eq!(task.sys_nt_close(connect_handle), NtStatus::SUCCESS);
         assert_eq!(task.sys_nt_close(reference_handle), NtStatus::SUCCESS);
-        assert_eq!(task.sys_nt_close(server_handle), NtStatus::SUCCESS);
     }
 
     #[test]
@@ -2029,10 +2095,12 @@ mod tests {
     #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
     mod host_fidelity {
         use super::*;
+        use crate::nt_types::{ProcessEnvironmentBlock, RtlUserProcessParameters};
         use core::ffi::c_void;
 
         #[link(name = "ntdll")]
         unsafe extern "system" {
+            fn RtlGetCurrentPeb() -> *const ProcessEnvironmentBlock;
             fn NtCreateFile(
                 FileHandle: *mut *mut c_void,
                 DesiredAccess: u32,
@@ -2088,6 +2156,60 @@ mod tests {
 
         fn host_status(status: i32) -> NtStatus {
             NtStatus::from_raw(u32::from_ne_bytes(status.to_ne_bytes()))
+        }
+
+        fn host_create_file(root: Handle, name: &str) -> (NtStatus, *mut c_void) {
+            let path = utf16(name);
+            let name = unicode_string(&path);
+            let mut attributes = host_object_attributes(&name);
+            attributes.root_directory = root;
+            let mut handle = core::ptr::null_mut();
+            let mut io_status = IoStatusBlock::default();
+            // SAFETY: All pointers reference live local typed values for the call.
+            let status = unsafe {
+                NtCreateFile(
+                    &raw mut handle,
+                    FILE_GENERIC_READ | FILE_GENERIC_WRITE,
+                    &raw const attributes,
+                    &raw mut io_status,
+                    core::ptr::null(),
+                    0,
+                    FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                    FILE_OPEN,
+                    FileCreateOptions::SYNCHRONOUS_IO_NONALERT.bits(),
+                    core::ptr::null(),
+                    0,
+                )
+            };
+            (host_status(status), handle)
+        }
+
+        #[test]
+        fn connected_console_child_matrix_matches_host() {
+            // SAFETY: RtlGetCurrentPeb returns the live typed PEB for this process.
+            let peb = unsafe { &*RtlGetCurrentPeb() };
+            // SAFETY: The current process owns a live RTL_USER_PROCESS_PARAMETERS block.
+            let process_parameters =
+                unsafe { &*(peb.process_parameters as *const RtlUserProcessParameters) };
+            assert_ne!(process_parameters.console_handle, 0);
+            let console_handle = Handle::from_raw(process_parameters.console_handle);
+
+            for (name, expected) in [
+                (r"\Input", NtStatus::SUCCESS),
+                (r"\Output", NtStatus::SUCCESS),
+                (r"\Server", NtStatus::SUCCESS),
+                (r"\Reference", NtStatus::SUCCESS),
+                (r"\Connect", NtStatus::INVALID_HANDLE),
+            ] {
+                let (status, handle) = host_create_file(console_handle, name);
+                assert_eq!(status, expected, "{name:?}");
+                if status == NtStatus::SUCCESS {
+                    assert!(!handle.is_null());
+                    close_host_handle(handle);
+                } else {
+                    assert!(handle.is_null());
+                }
+            }
         }
 
         #[test]

--- a/litebox_shim_windows/src/syscalls/file.rs
+++ b/litebox_shim_windows/src/syscalls/file.rs
@@ -2227,6 +2227,7 @@ mod tests {
                 (r"\Server", NtStatus::SUCCESS),
                 (r"\Reference", NtStatus::SUCCESS),
                 (r"\Connect", NtStatus::INVALID_HANDLE),
+                (r"\Bogus", NtStatus::NOT_FOUND),
             ] {
                 let (status, handle) = host_create_file(console_handle, name);
                 assert_eq!(status, expected, "{name:?}");

--- a/litebox_shim_windows/src/syscalls/file.rs
+++ b/litebox_shim_windows/src/syscalls/file.rs
@@ -2156,6 +2156,12 @@ mod tests {
             fn NtClose(Handle: *mut c_void) -> i32;
         }
 
+        #[link(name = "kernel32")]
+        unsafe extern "system" {
+            fn AllocConsole() -> i32;
+            fn GetLastError() -> u32;
+        }
+
         fn host_nt_path(path: &std::path::Path) -> std::string::String {
             std::format!(r"\??\{}", path.display())
         }
@@ -2211,11 +2217,34 @@ mod tests {
         #[test]
         fn connected_console_child_matrix_matches_host() {
             // SAFETY: RtlGetCurrentPeb returns the live typed PEB for this process.
-            let peb = unsafe { &*RtlGetCurrentPeb() };
+            let mut peb = unsafe { &*RtlGetCurrentPeb() };
             // SAFETY: The current process owns a live RTL_USER_PROCESS_PARAMETERS block.
-            let process_parameters =
+            let mut process_parameters =
                 unsafe { &*(peb.process_parameters as *const RtlUserProcessParameters) };
-            assert_ne!(process_parameters.console_handle, 0);
+            let console_handle = process_parameters.console_handle;
+            // ReactOS and Wine model detached/new/no-window console states as null or
+            // the reserved pseudo-handles -1 through -4.
+            if console_handle == 0 || console_handle >= usize::MAX - 3 {
+                // SAFETY: The test process has no connected console, so AllocConsole may attach one.
+                let allocated = unsafe { AllocConsole() };
+                assert_ne!(
+                    allocated,
+                    0,
+                    "AllocConsole failed with Win32 error {}",
+                    // SAFETY: GetLastError has no preconditions.
+                    unsafe { GetLastError() }
+                );
+                // AllocConsole updates the live process parameters.
+                // SAFETY: RtlGetCurrentPeb returns the live typed PEB for this process.
+                peb = unsafe { &*RtlGetCurrentPeb() };
+                // SAFETY: The PEB owns a live RTL_USER_PROCESS_PARAMETERS block.
+                process_parameters =
+                    unsafe { &*(peb.process_parameters as *const RtlUserProcessParameters) };
+            }
+            assert_ne!(
+                process_parameters.console_handle, 0,
+                "console handle remained null after ensuring a console"
+            );
             let console_handle = Handle::from_raw(process_parameters.console_handle);
 
             for (name, expected) in [
@@ -2230,7 +2259,12 @@ mod tests {
                 (r"\Bogus", NtStatus::NOT_FOUND),
             ] {
                 let (status, handle) = host_create_file(console_handle, name);
-                assert_eq!(status, expected, "{name:?}");
+                assert_eq!(
+                    status,
+                    expected,
+                    "{name:?} under console handle {:#x}",
+                    console_handle.as_raw()
+                );
                 if status == NtStatus::SUCCESS {
                     assert!(!handle.is_null());
                     close_host_handle(handle);


### PR DESCRIPTION
Model the ConDrv `Server` → `Reference` → `Connect` flow and resolve connected console children with native-observed status behavior.

Remaining work:
- Decode the full undocumented ConDrv handshake payload.
- Implement active screen-buffer switching and native ConDrv share-access exceptions.
- Defer shared-console ownership until LiteBox supports multiple guest processes.