### PR TITLE
Add shared-memory broker pipe data path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1515,6 +1515,7 @@ dependencies = [
 name = "litebox_broker_transport"
 version = "0.1.0"
 dependencies = [
+ "libc",
  "litebox_broker_protocol",
 ]
 

--- a/dev_tests/src/ratchet.rs
+++ b/dev_tests/src/ratchet.rs
@@ -72,6 +72,7 @@ fn ratchet_maybe_uninit() -> Result<()> {
         &[
             ("dev_tests/", 1),
             ("litebox/", 1),
+            ("litebox_broker_transport/", 2),
             ("litebox_platform_linux_userland/", 2),
         ],
         |file| {

--- a/litebox/src/event/counter.rs
+++ b/litebox/src/event/counter.rs
@@ -402,6 +402,7 @@ mod tests {
 
     impl LocalControlChannel for FakeLocalControlChannel {
         type Error = ();
+        type SharedMemory = litebox_broker_protocol::shared_memory::NoSharedMemory;
 
         fn send_handshake_request(
             &mut self,
@@ -427,7 +428,12 @@ mod tests {
             Ok(())
         }
 
-        fn recv_response(&mut self) -> core::result::Result<Option<BrokerResponse>, Self::Error> {
+        fn recv_response(
+            &mut self,
+        ) -> core::result::Result<
+            Option<litebox_broker_protocol::channel::ControlResponse<Self::SharedMemory>>,
+            Self::Error,
+        > {
             if self.fail_requests.load(Ordering::SeqCst) {
                 self.last_request.take();
                 return Err(());
@@ -457,7 +463,10 @@ mod tests {
                     panic!("unexpected broker request: {request:?}")
                 }
             };
-            Ok(Some(response))
+            Ok(Some(litebox_broker_protocol::channel::ControlResponse {
+                response,
+                shared_memory: None,
+            }))
         }
     }
 }

--- a/litebox/src/pipes.rs
+++ b/litebox/src/pipes.rs
@@ -1119,6 +1119,7 @@ mod tests {
 
     impl LocalControlChannel for FailingPipeChannel {
         type Error = ();
+        type SharedMemory = litebox_broker_protocol::shared_memory::NoSharedMemory;
 
         fn send_handshake_request(
             &mut self,
@@ -1144,12 +1145,18 @@ mod tests {
             Ok(())
         }
 
-        fn recv_response(&mut self) -> core::result::Result<Option<BrokerResponse>, Self::Error> {
-            match self.last_request.take().unwrap() {
+        fn recv_response(
+            &mut self,
+        ) -> core::result::Result<
+            Option<litebox_broker_protocol::channel::ControlResponse<Self::SharedMemory>>,
+            Self::Error,
+        > {
+            let response = match self.last_request.take().unwrap() {
                 BrokerRequest::Pipe(PipeRequest::Create(_)) => Ok(Some(BrokerResponse::Pipe(
                     PipeResponse::Create(CreatePipeResponse {
                         read_handle: ObjectHandle(1),
                         write_handle: ObjectHandle(2),
+                        shared_memory: false,
                     }),
                 ))),
                 BrokerRequest::Pipe(PipeRequest::Read(_))
@@ -1170,7 +1177,13 @@ mod tests {
                 request @ (BrokerRequest::Pipe(_) | BrokerRequest::Event(_)) => {
                     panic!("unexpected broker request: {request:?}")
                 }
-            }
+            }?;
+            Ok(response.map(
+                |response| litebox_broker_protocol::channel::ControlResponse {
+                    response,
+                    shared_memory: None,
+                },
+            ))
         }
     }
 

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -9,11 +9,16 @@
 
 #![no_std]
 
+extern crate alloc;
+
 #[cfg(test)]
 extern crate std;
 
+use alloc::{collections::BTreeMap, sync::Arc, vec::Vec};
+
 use litebox_broker_core::{BrokerCore, BrokerSession, CallerCredential};
 use litebox_broker_protocol::BROKER_PROTOCOL_VERSION;
+use litebox_broker_protocol::ObjectHandle;
 use litebox_broker_protocol::channel::{
     HostControlChannel, HostNotificationChannel, HostReceive, PeerCredential,
 };
@@ -24,6 +29,10 @@ use litebox_broker_protocol::message::{
     PipeRequest, PipeResponse,
 };
 use litebox_broker_protocol::pipe::{CreatePipeResponse, ReadPipeResponse, WritePipeResponse};
+use litebox_broker_protocol::pipe::{
+    PIPE_SHARED_MEMORY_REGION_SIZE, PIPE_SHARED_MEMORY_SIZE, ReadPipeSharedResponse,
+};
+use litebox_broker_protocol::shared_memory::SharedMemory;
 
 mod error;
 
@@ -54,6 +63,7 @@ where
         _ => return Err(BrokerHostError::Broker(ErrorCode::PolicyDenied)),
     };
     let session = core.create_session(caller_credential)?;
+    let mut pipe_shared_memories = BTreeMap::new();
 
     loop {
         let request = match control_channel
@@ -98,69 +108,252 @@ where
             HostReceive::Message(request) => request,
             HostReceive::ProtocolViolation => {
                 control_channel
-                    .send_response(&BrokerResponse::Error(ErrorCode::ProtocolState))
+                    .send_response(&BrokerResponse::Error(ErrorCode::ProtocolState), None)
                     .map_err(BrokerHostError::Channel)?;
                 return Ok(ConnectionTermination::ProtocolViolation);
             }
             HostReceive::PeerClosed => break,
         };
 
-        let response = handle_request(&session, request);
+        let response = handle_request(
+            &session,
+            request,
+            control_channel,
+            &mut pipe_shared_memories,
+        )
+        .map_err(BrokerHostError::Channel)?;
         control_channel
-            .send_response(&response)
+            .send_response(&response.response, response.shared_memory.as_deref())
             .map_err(BrokerHostError::Channel)?;
     }
 
     Ok(ConnectionTermination::PeerClosed)
 }
 
-fn handle_request(session: &BrokerSession, request: BrokerRequest) -> BrokerResponse {
+struct HandledResponse<Memory> {
+    response: BrokerResponse,
+    shared_memory: Option<Arc<Memory>>,
+}
+
+struct PipeSharedMemory<Memory> {
+    memory: Arc<Memory>,
+    endpoint: SharedPipeEndpoint,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SharedPipeEndpoint {
+    Read,
+    Write,
+}
+
+fn handle_request<Channel: HostControlChannel>(
+    session: &BrokerSession,
+    request: BrokerRequest,
+    channel: &mut Channel,
+    pipe_shared_memories: &mut BTreeMap<ObjectHandle, PipeSharedMemory<Channel::SharedMemory>>,
+) -> core::result::Result<HandledResponse<Channel::SharedMemory>, Channel::Error> {
+    let mut shared_memory = None;
     match request {
         BrokerRequest::CloseObject(handle) => match session.close_object_reference(handle) {
-            Ok(()) => BrokerResponse::ObjectClosed,
-            Err(error) => BrokerResponse::Error(error.into()),
+            Ok(()) => {
+                pipe_shared_memories.remove(&handle);
+                Ok(HandledResponse {
+                    response: BrokerResponse::ObjectClosed,
+                    shared_memory,
+                })
+            }
+            Err(error) => Ok(HandledResponse {
+                response: BrokerResponse::Error(error.into()),
+                shared_memory,
+            }),
         },
-        BrokerRequest::CheckReadiness(handle) => match session.check_readiness(handle) {
-            Ok(readiness) => BrokerResponse::Readiness(readiness),
-            Err(error) => BrokerResponse::Error(error.into()),
-        },
-        BrokerRequest::Event(request) => handle_event_request(session, request),
-        BrokerRequest::Pipe(request) => handle_pipe_request(session, request),
+        BrokerRequest::CheckReadiness(handle) => Ok(HandledResponse {
+            response: match session.check_readiness(handle) {
+                Ok(readiness) => BrokerResponse::Readiness(readiness),
+                Err(error) => BrokerResponse::Error(error.into()),
+            },
+            shared_memory,
+        }),
+        BrokerRequest::Event(request) => Ok(HandledResponse {
+            response: handle_event_request(session, request),
+            shared_memory,
+        }),
+        BrokerRequest::Pipe(PipeRequest::Create(request)) => {
+            let response = match litebox_broker_core::pipe::create(
+                session,
+                request.capacity,
+                request.atomic_write_size,
+            ) {
+                Ok((read_handle, write_handle)) => {
+                    let memory = match channel.create_shared_memory(PIPE_SHARED_MEMORY_SIZE) {
+                        Ok(memory) => memory,
+                        Err(error) => {
+                            session
+                                .close_object_reference(read_handle)
+                                .expect("new pipe read handle must be valid");
+                            session
+                                .close_object_reference(write_handle)
+                                .expect("new pipe write handle must be valid");
+                            return Err(error);
+                        }
+                    };
+                    let has_shared_memory = memory.is_some();
+                    if let Some(memory) = memory {
+                        if memory.len() != PIPE_SHARED_MEMORY_SIZE {
+                            session
+                                .close_object_reference(read_handle)
+                                .expect("new pipe read handle must be valid");
+                            session
+                                .close_object_reference(write_handle)
+                                .expect("new pipe write handle must be valid");
+                            return Ok(HandledResponse {
+                                response: BrokerResponse::Error(ErrorCode::Internal),
+                                shared_memory: None,
+                            });
+                        }
+                        let memory = Arc::new(memory);
+                        pipe_shared_memories.insert(
+                            read_handle,
+                            PipeSharedMemory {
+                                memory: Arc::clone(&memory),
+                                endpoint: SharedPipeEndpoint::Read,
+                            },
+                        );
+                        pipe_shared_memories.insert(
+                            write_handle,
+                            PipeSharedMemory {
+                                memory: Arc::clone(&memory),
+                                endpoint: SharedPipeEndpoint::Write,
+                            },
+                        );
+                        shared_memory = Some(memory);
+                    }
+                    BrokerResponse::Pipe(PipeResponse::Create(CreatePipeResponse {
+                        read_handle,
+                        write_handle,
+                        shared_memory: has_shared_memory,
+                    }))
+                }
+                Err(error) => BrokerResponse::Error(error.into()),
+            };
+            Ok(HandledResponse {
+                response,
+                shared_memory,
+            })
+        }
+        BrokerRequest::Pipe(request) => Ok(HandledResponse {
+            response: handle_pipe_request(session, request, pipe_shared_memories),
+            shared_memory,
+        }),
     }
 }
 
-fn handle_pipe_request(session: &BrokerSession, request: PipeRequest) -> BrokerResponse {
-    let response = match request {
-        PipeRequest::Create(request) => {
-            litebox_broker_core::pipe::create(session, request.capacity, request.atomic_write_size)
-                .map(|(read_handle, write_handle)| {
-                    PipeResponse::Create(CreatePipeResponse {
-                        read_handle,
-                        write_handle,
-                    })
-                })
-        }
+fn handle_pipe_request<Memory: SharedMemory>(
+    session: &BrokerSession,
+    request: PipeRequest,
+    pipe_shared_memories: &BTreeMap<ObjectHandle, PipeSharedMemory<Memory>>,
+) -> BrokerResponse {
+    let response: core::result::Result<PipeResponse, ErrorCode> = match request {
+        PipeRequest::Create(_) => unreachable!("pipe creation is handled with the control channel"),
         PipeRequest::Read(request) => {
             litebox_broker_core::pipe::read(session, request.handle, request.length)
                 .map(|data| PipeResponse::Read(ReadPipeResponse { data }))
+                .map_err(Into::into)
+        }
+        PipeRequest::ReadShared(request) => {
+            let Some(shared) = pipe_shared_memories.get(&request.handle) else {
+                return BrokerResponse::Error(ErrorCode::InvalidRights);
+            };
+            if shared.endpoint != SharedPipeEndpoint::Read {
+                return BrokerResponse::Error(ErrorCode::InvalidRights);
+            }
+            let Some(offset) = shared_memory_offset(shared, 0, request.offset, request.length)
+            else {
+                return BrokerResponse::Error(ErrorCode::MalformedRequest);
+            };
+            litebox_broker_core::pipe::read(session, request.handle, request.length)
+                .map_err(ErrorCode::from)
+                .and_then(|data| {
+                    shared
+                        .memory
+                        .write(offset, &data)
+                        .map_err(|_| ErrorCode::Internal)?;
+                    Ok(PipeResponse::ReadShared(ReadPipeSharedResponse {
+                        read: data
+                            .len()
+                            .try_into()
+                            .map_err(|_| ErrorCode::ResourceExhausted)?,
+                    }))
+                })
         }
         PipeRequest::Write(request) => {
-            litebox_broker_core::pipe::write(session, request.handle, &request.data).and_then(
-                |written| {
+            litebox_broker_core::pipe::write(session, request.handle, &request.data)
+                .map_err(ErrorCode::from)
+                .and_then(|written| {
                     Ok(PipeResponse::Write(WritePipeResponse {
                         written: written
                             .try_into()
-                            .map_err(|_| litebox_broker_core::BrokerError::ResourceExhausted)?,
+                            .map_err(|_| ErrorCode::ResourceExhausted)?,
                     }))
-                },
-            )
+                })
+        }
+        PipeRequest::WriteShared(request) => {
+            let Some(shared) = pipe_shared_memories.get(&request.handle) else {
+                return BrokerResponse::Error(ErrorCode::InvalidRights);
+            };
+            if shared.endpoint != SharedPipeEndpoint::Write {
+                return BrokerResponse::Error(ErrorCode::InvalidRights);
+            }
+            let Some(offset) = shared_memory_offset(
+                shared,
+                PIPE_SHARED_MEMORY_REGION_SIZE,
+                request.offset,
+                request.length,
+            ) else {
+                return BrokerResponse::Error(ErrorCode::MalformedRequest);
+            };
+            let length = request.length as usize;
+            let mut data = Vec::new();
+            if data.try_reserve_exact(length).is_err() {
+                return BrokerResponse::Error(ErrorCode::OutOfMemory);
+            }
+            data.resize(length, 0);
+            if shared.memory.read(offset, &mut data).is_err() {
+                return BrokerResponse::Error(ErrorCode::Internal);
+            }
+            litebox_broker_core::pipe::write(session, request.handle, &data)
+                .map_err(ErrorCode::from)
+                .and_then(|written| {
+                    Ok(PipeResponse::WriteShared(WritePipeResponse {
+                        written: written
+                            .try_into()
+                            .map_err(|_| ErrorCode::ResourceExhausted)?,
+                    }))
+                })
         }
     };
 
     match response {
         Ok(response) => BrokerResponse::Pipe(response),
-        Err(error) => BrokerResponse::Error(error.into()),
+        Err(error) => BrokerResponse::Error(error),
     }
+}
+
+fn shared_memory_offset<Memory: SharedMemory>(
+    shared: &PipeSharedMemory<Memory>,
+    base: usize,
+    offset: u32,
+    length: u32,
+) -> Option<usize> {
+    let offset = offset as usize;
+    let length = length as usize;
+    let end = offset.checked_add(length)?;
+    if end > PIPE_SHARED_MEMORY_REGION_SIZE {
+        return None;
+    }
+    let absolute = base.checked_add(offset)?;
+    let absolute_end = absolute.checked_add(length)?;
+    (absolute_end <= shared.memory.len()).then_some(absolute)
 }
 
 fn handle_event_request(session: &BrokerSession, request: EventRequest) -> BrokerResponse {
@@ -208,7 +401,13 @@ mod tests {
         AddEventRequest, ConsumeEventRequest, CreateEventRequest, EventConsumeMode,
     };
     use litebox_broker_protocol::message::{BrokerHandshakeRequest, BrokerNotification};
+    use litebox_broker_protocol::pipe::{
+        CreatePipeRequest, ReadPipeRequest, ReadPipeSharedRequest, WritePipeRequest,
+        WritePipeSharedRequest,
+    };
+    use litebox_broker_protocol::shared_memory::{NoSharedMemory, SharedMemoryError};
     use litebox_broker_protocol::{ObjectHandle, ProtocolVersion};
+    use std::sync::Mutex;
 
     #[test]
     fn host_request_handling_uses_one_broker_core() {
@@ -224,6 +423,8 @@ mod tests {
         serve_connection_returns_channel_error_when_response_send_fails(&broker);
         serve_connection_returns_event_readiness_in_control_responses(&broker);
         active_request_closes_object_reference(&broker);
+        shared_pipe_data_path_stages_bytes_and_validates_ranges(&broker);
+        pipe_data_path_falls_back_to_inline_operations(&broker);
     }
 
     fn serve_connection_negotiates_routes_one_request_and_returns_peer_closed(broker: &BrokerCore) {
@@ -386,7 +587,7 @@ mod tests {
         let session = broker
             .create_session(CallerCredential::Unauthenticated)
             .unwrap();
-        let response = handle_request(
+        let response = handle_test_request(
             &session,
             BrokerRequest::Event(EventRequest::Create(CreateEventRequest {
                 initial_count: 0,
@@ -398,20 +599,177 @@ mod tests {
         let handle = response.handle;
 
         assert_eq!(
-            handle_request(&session, BrokerRequest::CloseObject(handle)),
+            handle_test_request(&session, BrokerRequest::CloseObject(handle)),
             BrokerResponse::ObjectClosed
         );
         assert_eq!(
-            handle_request(&session, BrokerRequest::CheckReadiness(handle)),
+            handle_test_request(&session, BrokerRequest::CheckReadiness(handle)),
             BrokerResponse::Error(ErrorCode::UnknownObject)
         );
         assert_eq!(
-            handle_request(
+            handle_test_request(
                 &session,
                 BrokerRequest::CloseObject(ObjectHandle(handle.0 + 1))
             ),
             BrokerResponse::Error(ErrorCode::UnknownObject)
         );
+    }
+
+    fn shared_pipe_data_path_stages_bytes_and_validates_ranges(broker: &BrokerCore) {
+        let session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let mut channel = SharedMemoryHostControlChannel;
+        let mut shared_memories = BTreeMap::new();
+        let HandledResponse {
+            response,
+            shared_memory,
+        } = handle_request(
+            &session,
+            BrokerRequest::Pipe(PipeRequest::Create(CreatePipeRequest {
+                capacity: 64,
+                atomic_write_size: 16,
+            })),
+            &mut channel,
+            &mut shared_memories,
+        )
+        .unwrap();
+        let BrokerResponse::Pipe(PipeResponse::Create(response)) = response else {
+            panic!("unexpected create response: {response:?}");
+        };
+        assert!(response.shared_memory);
+        assert_eq!(shared_memories.len(), 2);
+        let memory = shared_memory.unwrap();
+
+        memory
+            .write(PIPE_SHARED_MEMORY_REGION_SIZE + 7, &[1, 2, 3])
+            .unwrap();
+        let write = handle_request(
+            &session,
+            BrokerRequest::Pipe(PipeRequest::WriteShared(WritePipeSharedRequest {
+                handle: response.write_handle,
+                offset: 7,
+                length: 3,
+            })),
+            &mut channel,
+            &mut shared_memories,
+        )
+        .unwrap();
+        assert_eq!(
+            write.response,
+            BrokerResponse::Pipe(PipeResponse::WriteShared(WritePipeResponse { written: 3 }))
+        );
+
+        let read = handle_request(
+            &session,
+            BrokerRequest::Pipe(PipeRequest::ReadShared(ReadPipeSharedRequest {
+                handle: response.read_handle,
+                offset: 11,
+                length: 3,
+            })),
+            &mut channel,
+            &mut shared_memories,
+        )
+        .unwrap();
+        assert_eq!(
+            read.response,
+            BrokerResponse::Pipe(PipeResponse::ReadShared(ReadPipeSharedResponse { read: 3 }))
+        );
+        let mut data = [0; 3];
+        memory.read(11, &mut data).unwrap();
+        assert_eq!(data, [1, 2, 3]);
+
+        let wrong_endpoint = handle_request(
+            &session,
+            BrokerRequest::Pipe(PipeRequest::ReadShared(ReadPipeSharedRequest {
+                handle: response.write_handle,
+                offset: 0,
+                length: 1,
+            })),
+            &mut channel,
+            &mut shared_memories,
+        )
+        .unwrap();
+        assert_eq!(
+            wrong_endpoint.response,
+            BrokerResponse::Error(ErrorCode::InvalidRights)
+        );
+        let invalid_range = handle_request(
+            &session,
+            BrokerRequest::Pipe(PipeRequest::WriteShared(WritePipeSharedRequest {
+                handle: response.write_handle,
+                offset: (PIPE_SHARED_MEMORY_REGION_SIZE - 1).try_into().unwrap(),
+                length: 2,
+            })),
+            &mut channel,
+            &mut shared_memories,
+        )
+        .unwrap();
+        assert_eq!(
+            invalid_range.response,
+            BrokerResponse::Error(ErrorCode::MalformedRequest)
+        );
+    }
+
+    fn pipe_data_path_falls_back_to_inline_operations(broker: &BrokerCore) {
+        let session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let mut channel = FakeHostControlChannel::new(std::vec::Vec::new(), std::vec::Vec::new());
+        let mut shared_memories = BTreeMap::new();
+        let created = handle_request(
+            &session,
+            BrokerRequest::Pipe(PipeRequest::Create(CreatePipeRequest {
+                capacity: 64,
+                atomic_write_size: 16,
+            })),
+            &mut channel,
+            &mut shared_memories,
+        )
+        .unwrap();
+        let BrokerResponse::Pipe(PipeResponse::Create(response)) = created.response else {
+            panic!("unexpected create response: {:?}", created.response);
+        };
+        assert!(!response.shared_memory);
+        assert!(created.shared_memory.is_none());
+
+        let written = handle_request(
+            &session,
+            BrokerRequest::Pipe(PipeRequest::Write(WritePipeRequest {
+                handle: response.write_handle,
+                data: Vec::from([1, 2, 3]),
+            })),
+            &mut channel,
+            &mut shared_memories,
+        )
+        .unwrap();
+        assert_eq!(
+            written.response,
+            BrokerResponse::Pipe(PipeResponse::Write(WritePipeResponse { written: 3 }))
+        );
+        let read = handle_request(
+            &session,
+            BrokerRequest::Pipe(PipeRequest::Read(ReadPipeRequest {
+                handle: response.read_handle,
+                length: 3,
+            })),
+            &mut channel,
+            &mut shared_memories,
+        )
+        .unwrap();
+        assert_eq!(
+            read.response,
+            BrokerResponse::Pipe(PipeResponse::Read(ReadPipeResponse {
+                data: Vec::from([1, 2, 3])
+            }))
+        );
+    }
+
+    fn handle_test_request(session: &BrokerSession, request: BrokerRequest) -> BrokerResponse {
+        let mut channel = FakeHostControlChannel::new(std::vec::Vec::new(), std::vec::Vec::new());
+        handle_request(session, request, &mut channel, &mut BTreeMap::new())
+            .unwrap()
+            .response
     }
 
     struct FakeHostControlChannel {
@@ -444,6 +802,7 @@ mod tests {
 
     impl HostControlChannel for FakeHostControlChannel {
         type Error = ();
+        type SharedMemory = NoSharedMemory;
 
         fn peer_credential(&self) -> core::result::Result<PeerCredential, Self::Error> {
             Ok(PeerCredential::Unauthenticated)
@@ -483,7 +842,9 @@ mod tests {
         fn send_response(
             &mut self,
             response: &BrokerResponse,
+            shared_memory: Option<&Self::SharedMemory>,
         ) -> core::result::Result<(), Self::Error> {
+            assert!(shared_memory.is_none());
             if self.send_error {
                 return Err(());
             }
@@ -508,6 +869,98 @@ mod tests {
             }
             self.responses.push(response.clone());
             Ok(())
+        }
+    }
+
+    #[derive(Clone)]
+    struct TestSharedMemory(Arc<Mutex<Vec<u8>>>);
+
+    impl TestSharedMemory {
+        fn new(length: usize) -> Self {
+            Self(Arc::new(Mutex::new(std::vec![0; length])))
+        }
+    }
+
+    impl SharedMemory for TestSharedMemory {
+        fn len(&self) -> usize {
+            self.0.lock().unwrap().len()
+        }
+
+        fn read(
+            &self,
+            offset: usize,
+            destination: &mut [u8],
+        ) -> core::result::Result<(), SharedMemoryError> {
+            let memory = self.0.lock().unwrap();
+            let end = offset
+                .checked_add(destination.len())
+                .ok_or(SharedMemoryError::InvalidRange)?;
+            let source = memory
+                .get(offset..end)
+                .ok_or(SharedMemoryError::InvalidRange)?;
+            destination.copy_from_slice(source);
+            Ok(())
+        }
+
+        fn write(
+            &self,
+            offset: usize,
+            source: &[u8],
+        ) -> core::result::Result<(), SharedMemoryError> {
+            let mut memory = self.0.lock().unwrap();
+            let end = offset
+                .checked_add(source.len())
+                .ok_or(SharedMemoryError::InvalidRange)?;
+            let destination = memory
+                .get_mut(offset..end)
+                .ok_or(SharedMemoryError::InvalidRange)?;
+            destination.copy_from_slice(source);
+            Ok(())
+        }
+    }
+
+    struct SharedMemoryHostControlChannel;
+
+    impl HostControlChannel for SharedMemoryHostControlChannel {
+        type Error = ();
+        type SharedMemory = TestSharedMemory;
+
+        fn peer_credential(&self) -> core::result::Result<PeerCredential, Self::Error> {
+            Ok(PeerCredential::Unauthenticated)
+        }
+
+        fn recv_handshake_request(
+            &mut self,
+        ) -> core::result::Result<HostReceive<BrokerHandshakeRequest>, Self::Error> {
+            panic!("unexpected handshake receive")
+        }
+
+        fn send_handshake_response(
+            &mut self,
+            _response: &BrokerHandshakeResponse,
+        ) -> core::result::Result<(), Self::Error> {
+            panic!("unexpected handshake response")
+        }
+
+        fn recv_request(
+            &mut self,
+        ) -> core::result::Result<HostReceive<BrokerRequest>, Self::Error> {
+            panic!("unexpected request receive")
+        }
+
+        fn create_shared_memory(
+            &mut self,
+            length: usize,
+        ) -> core::result::Result<Option<Self::SharedMemory>, Self::Error> {
+            Ok(Some(TestSharedMemory::new(length)))
+        }
+
+        fn send_response(
+            &mut self,
+            _response: &BrokerResponse,
+            _shared_memory: Option<&Self::SharedMemory>,
+        ) -> core::result::Result<(), Self::Error> {
+            panic!("unexpected response send")
         }
     }
 

--- a/litebox_broker_local/src/lib.rs
+++ b/litebox_broker_local/src/lib.rs
@@ -20,7 +20,12 @@ mod error;
 mod event;
 mod pipe;
 
-use litebox_broker_protocol::channel::{LocalControlChannel, LocalNotificationChannel};
+use alloc::collections::BTreeMap;
+use alloc::sync::Arc;
+
+use litebox_broker_protocol::channel::{
+    ControlResponse, LocalControlChannel, LocalNotificationChannel,
+};
 use litebox_broker_protocol::error::ErrorCode;
 use litebox_broker_protocol::message::{
     BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerNotification, BrokerRequest,
@@ -34,6 +39,13 @@ pub use error::{BrokerLocalError, Result};
 /// Typed broker-local control adapter for broker operations.
 pub struct BrokerLocal<Channel: LocalControlChannel> {
     channel: Channel,
+    pipe_shared_memories: BTreeMap<ObjectHandle, PipeSharedMemory<Channel::SharedMemory>>,
+}
+
+struct PipeSharedMemory<Memory> {
+    memory: Arc<Memory>,
+    base: usize,
+    cursor: usize,
 }
 
 /// Broker-local receive adapter for broker-initiated asynchronous notifications.
@@ -68,7 +80,10 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
                     requested, broker_protocol_version,
                     "broker returned unexpected negotiation response: {response:?}"
                 );
-                Ok(Self { channel })
+                Ok(Self {
+                    channel,
+                    pipe_shared_memories: BTreeMap::new(),
+                })
             }
             BrokerHandshakeResponse::VersionMismatch { .. } => {
                 Err(BrokerLocalError::Broker(ErrorCode::UnsupportedVersion))
@@ -93,23 +108,35 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
     /// Panics if the broker reports an unrecoverable error or returns a protocol
     /// response that does not match an active request.
     pub fn request(&mut self, request: BrokerRequest) -> Result<BrokerResponse, Channel::Error> {
+        let response = self.request_with_shared_memory(request)?;
+        assert!(
+            response.shared_memory.is_none(),
+            "broker attached unexpected shared memory to response"
+        );
+        Ok(response.response)
+    }
+
+    fn request_with_shared_memory(
+        &mut self,
+        request: BrokerRequest,
+    ) -> Result<ControlResponse<Channel::SharedMemory>, Channel::Error> {
         self.channel
             .send_request(&request)
             .map_err(BrokerLocalError::Channel)?;
-        match self
+        let response = self
             .channel
             .recv_response()
             .map_err(BrokerLocalError::Channel)?
-            .ok_or(BrokerLocalError::ChannelClosed)?
-        {
-            BrokerResponse::Error(error) => match error {
+            .ok_or(BrokerLocalError::ChannelClosed)?;
+        match &response.response {
+            BrokerResponse::Error(error) => match *error {
                 ErrorCode::PolicyDenied
                 | ErrorCode::UnknownObject
                 | ErrorCode::InvalidRights
                 | ErrorCode::ResourceExhausted
                 | ErrorCode::WouldBlock
                 | ErrorCode::PeerClosed
-                | ErrorCode::OutOfMemory => Err(BrokerLocalError::Broker(error)),
+                | ErrorCode::OutOfMemory => Err(BrokerLocalError::Broker(*error)),
                 ErrorCode::UnsupportedVersion
                 | ErrorCode::MalformedRequest
                 | ErrorCode::ProtocolState
@@ -117,10 +144,10 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
                 | ErrorCode::Internal => panic!("broker returned unrecoverable error: {error}"),
                 _ => panic!("broker returned unsupported error: {error}"),
             },
-            response @ (BrokerResponse::Event(_)
+            BrokerResponse::Event(_)
             | BrokerResponse::Pipe(_)
             | BrokerResponse::ObjectClosed
-            | BrokerResponse::Readiness(_)) => Ok(response),
+            | BrokerResponse::Readiness(_) => Ok(response),
         }
     }
 
@@ -149,7 +176,10 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
     /// response that does not match an object close request.
     pub fn close_object(&mut self, handle: ObjectHandle) -> Result<(), Channel::Error> {
         match self.request(BrokerRequest::CloseObject(handle))? {
-            BrokerResponse::ObjectClosed => Ok(()),
+            BrokerResponse::ObjectClosed => {
+                self.pipe_shared_memories.remove(&handle);
+                Ok(())
+            }
             BrokerResponse::Error(error) => Err(BrokerLocalError::Broker(error)),
             response @ (BrokerResponse::Event(_)
             | BrokerResponse::Pipe(_)
@@ -186,6 +216,7 @@ mod tests {
     use litebox_broker_protocol::event::{CreateEventRequest, CreateEventResponse};
     use litebox_broker_protocol::message::{EventRequest, EventResponse, ReadinessNotification};
     use litebox_broker_protocol::readiness::ReadinessFlags;
+    use litebox_broker_protocol::shared_memory::NoSharedMemory;
 
     #[test]
     fn negotiate_returns_active_local_connection() {
@@ -213,7 +244,10 @@ mod tests {
         }));
         let response = BrokerResponse::Event(EventResponse::Create(CreateEventResponse { handle }));
         let channel = FakeControlChannel::new(None, Some(response.clone()));
-        let mut local = BrokerLocal { channel };
+        let mut local = BrokerLocal {
+            channel,
+            pipe_shared_memories: BTreeMap::new(),
+        };
 
         assert_eq!(local.request(request.clone()).unwrap(), response);
         assert_eq!(local.channel.sent_request, Some(request));
@@ -225,7 +259,10 @@ mod tests {
         let request = BrokerRequest::CloseObject(handle);
         let response = BrokerResponse::ObjectClosed;
         let channel = FakeControlChannel::new(None, Some(response.clone()));
-        let mut local = BrokerLocal { channel };
+        let mut local = BrokerLocal {
+            channel,
+            pipe_shared_memories: BTreeMap::new(),
+        };
 
         assert!(local.close_object(handle).is_ok());
         assert_eq!(local.channel.sent_request, Some(request));
@@ -238,7 +275,10 @@ mod tests {
         }));
         let channel =
             FakeControlChannel::new(None, Some(BrokerResponse::Error(ErrorCode::WouldBlock)));
-        let mut local = BrokerLocal { channel };
+        let mut local = BrokerLocal {
+            channel,
+            pipe_shared_memories: BTreeMap::new(),
+        };
 
         assert!(matches!(
             local.request(request),
@@ -254,7 +294,10 @@ mod tests {
         }));
         let channel =
             FakeControlChannel::new(None, Some(BrokerResponse::Error(ErrorCode::Internal)));
-        let mut local = BrokerLocal { channel };
+        let mut local = BrokerLocal {
+            channel,
+            pipe_shared_memories: BTreeMap::new(),
+        };
 
         let _ = local.request(request);
     }
@@ -337,6 +380,7 @@ mod tests {
 
     impl LocalControlChannel for FakeControlChannel {
         type Error = Infallible;
+        type SharedMemory = NoSharedMemory;
 
         fn send_handshake_request(
             &mut self,
@@ -360,8 +404,14 @@ mod tests {
             Ok(())
         }
 
-        fn recv_response(&mut self) -> core::result::Result<Option<BrokerResponse>, Self::Error> {
-            Ok(self.response.take())
+        fn recv_response(
+            &mut self,
+        ) -> core::result::Result<Option<ControlResponse<Self::SharedMemory>>, Self::Error>
+        {
+            Ok(self.response.take().map(|response| ControlResponse {
+                response,
+                shared_memory: None,
+            }))
         }
     }
 

--- a/litebox_broker_local/src/pipe.rs
+++ b/litebox_broker_local/src/pipe.rs
@@ -1,16 +1,18 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-use alloc::vec::Vec;
+use alloc::{sync::Arc, vec::Vec};
 
 use litebox_broker_protocol::ObjectHandle;
-use litebox_broker_protocol::channel::LocalControlChannel;
+use litebox_broker_protocol::channel::{ControlResponse, LocalControlChannel};
 use litebox_broker_protocol::message::{BrokerRequest, BrokerResponse, PipeRequest, PipeResponse};
 use litebox_broker_protocol::pipe::{
-    CreatePipeRequest, CreatePipeResponse, ReadPipeRequest, WritePipeRequest,
+    CreatePipeRequest, CreatePipeResponse, PIPE_SHARED_MEMORY_REGION_SIZE, PIPE_SHARED_MEMORY_SIZE,
+    ReadPipeRequest, ReadPipeSharedRequest, WritePipeRequest, WritePipeSharedRequest,
 };
+use litebox_broker_protocol::shared_memory::SharedMemory;
 
-use crate::{BrokerLocal, BrokerLocalError, Result};
+use crate::{BrokerLocal, BrokerLocalError, PipeSharedMemory, Result};
 
 impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
     /// Creates a broker-owned byte pipe.
@@ -24,11 +26,48 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
         capacity: u64,
         atomic_write_size: u64,
     ) -> Result<CreatePipeResponse, Channel::Error> {
-        match self.request_pipe(PipeRequest::Create(CreatePipeRequest {
-            capacity,
-            atomic_write_size,
-        }))? {
-            PipeResponse::Create(response) => Ok(response),
+        let ControlResponse {
+            response,
+            shared_memory,
+        } = self.request_with_shared_memory(BrokerRequest::Pipe(PipeRequest::Create(
+            CreatePipeRequest {
+                capacity,
+                atomic_write_size,
+            },
+        )))?;
+        match response {
+            BrokerResponse::Pipe(PipeResponse::Create(response)) => {
+                match (response.shared_memory, shared_memory) {
+                    (false, None) => {}
+                    (true, Some(memory)) => {
+                        assert_eq!(
+                            memory.len(),
+                            PIPE_SHARED_MEMORY_SIZE,
+                            "broker returned shared memory with an invalid size"
+                        );
+                        let memory = Arc::new(memory);
+                        self.pipe_shared_memories.insert(
+                            response.read_handle,
+                            PipeSharedMemory {
+                                memory: Arc::clone(&memory),
+                                base: 0,
+                                cursor: 0,
+                            },
+                        );
+                        self.pipe_shared_memories.insert(
+                            response.write_handle,
+                            PipeSharedMemory {
+                                memory,
+                                base: PIPE_SHARED_MEMORY_REGION_SIZE,
+                                cursor: 0,
+                            },
+                        );
+                    }
+                    _ => panic!("broker pipe response shared-memory attachment mismatch"),
+                }
+                Ok(response)
+            }
+            BrokerResponse::Error(error) => Err(BrokerLocalError::Broker(error)),
             response => panic!("broker returned unexpected pipe response: {response:?}"),
         }
     }
@@ -44,6 +83,11 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
         handle: ObjectHandle,
         length: u32,
     ) -> Result<Vec<u8>, Channel::Error> {
+        if length as usize <= PIPE_SHARED_MEMORY_REGION_SIZE
+            && self.pipe_shared_memories.contains_key(&handle)
+        {
+            return self.read_pipe_shared(handle, length);
+        }
         match self.request_pipe(PipeRequest::Read(ReadPipeRequest { handle, length }))? {
             PipeResponse::Read(response) => Ok(response.data),
             response => panic!("broker returned unexpected pipe response: {response:?}"),
@@ -61,6 +105,11 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
         handle: ObjectHandle,
         data: &[u8],
     ) -> Result<usize, Channel::Error> {
+        if data.len() <= PIPE_SHARED_MEMORY_REGION_SIZE
+            && self.pipe_shared_memories.contains_key(&handle)
+        {
+            return self.write_pipe_shared(handle, data);
+        }
         match self.request_pipe(PipeRequest::Write(WritePipeRequest {
             handle,
             data: data.to_vec(),
@@ -68,6 +117,101 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
             PipeResponse::Write(response) => Ok(response.written as usize),
             response => panic!("broker returned unexpected pipe response: {response:?}"),
         }
+    }
+
+    fn read_pipe_shared(
+        &mut self,
+        handle: ObjectHandle,
+        length: u32,
+    ) -> Result<Vec<u8>, Channel::Error> {
+        let (memory, base, offset) = {
+            let shared = self
+                .pipe_shared_memories
+                .get(&handle)
+                .expect("shared pipe handle disappeared");
+            let length = length as usize;
+            let offset = if shared.cursor + length > PIPE_SHARED_MEMORY_REGION_SIZE {
+                0
+            } else {
+                shared.cursor
+            };
+            (Arc::clone(&shared.memory), shared.base, offset)
+        };
+        let offset_u32 = offset
+            .try_into()
+            .expect("shared pipe ring offset must fit in u32");
+        let mut data = Vec::new();
+        data.try_reserve_exact(length as usize).map_err(|_| {
+            BrokerLocalError::Broker(litebox_broker_protocol::error::ErrorCode::OutOfMemory)
+        })?;
+        data.resize(length as usize, 0);
+        let response = self.request_pipe(PipeRequest::ReadShared(ReadPipeSharedRequest {
+            handle,
+            offset: offset_u32,
+            length,
+        }))?;
+        let PipeResponse::ReadShared(response) = response else {
+            panic!("broker returned unexpected shared pipe read response: {response:?}");
+        };
+        assert!(
+            response.read <= length,
+            "broker returned oversized pipe read"
+        );
+        let read = response.read as usize;
+        data.truncate(read);
+        memory
+            .read(base + offset, &mut data)
+            .expect("validated shared pipe read range must be accessible");
+        self.pipe_shared_memories
+            .get_mut(&handle)
+            .expect("shared pipe handle disappeared")
+            .cursor = (offset + read) % PIPE_SHARED_MEMORY_REGION_SIZE;
+        Ok(data)
+    }
+
+    fn write_pipe_shared(
+        &mut self,
+        handle: ObjectHandle,
+        data: &[u8],
+    ) -> Result<usize, Channel::Error> {
+        let (memory, base, offset) = {
+            let shared = self
+                .pipe_shared_memories
+                .get(&handle)
+                .expect("shared pipe handle disappeared");
+            let offset = if shared.cursor + data.len() > PIPE_SHARED_MEMORY_REGION_SIZE {
+                0
+            } else {
+                shared.cursor
+            };
+            (Arc::clone(&shared.memory), shared.base, offset)
+        };
+        memory
+            .write(base + offset, data)
+            .expect("validated shared pipe write range must be accessible");
+        let response = self.request_pipe(PipeRequest::WriteShared(WritePipeSharedRequest {
+            handle,
+            offset: offset
+                .try_into()
+                .expect("shared pipe ring offset must fit in u32"),
+            length: data
+                .len()
+                .try_into()
+                .expect("shared pipe transfer length must fit in u32"),
+        }))?;
+        let PipeResponse::WriteShared(response) = response else {
+            panic!("broker returned unexpected shared pipe write response: {response:?}");
+        };
+        let written = response.written as usize;
+        assert!(
+            written <= data.len(),
+            "broker returned oversized shared pipe write"
+        );
+        self.pipe_shared_memories
+            .get_mut(&handle)
+            .expect("shared pipe handle disappeared")
+            .cursor = (offset + written) % PIPE_SHARED_MEMORY_REGION_SIZE;
+        Ok(written)
     }
 
     fn request_pipe(&mut self, request: PipeRequest) -> Result<PipeResponse, Channel::Error> {
@@ -79,6 +223,223 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
             | BrokerResponse::Event(_)) => {
                 panic!("broker returned unexpected pipe response: {response:?}");
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::convert::Infallible;
+    use std::collections::VecDeque;
+    use std::sync::Mutex;
+
+    use litebox_broker_protocol::BROKER_PROTOCOL_VERSION;
+    use litebox_broker_protocol::message::{BrokerHandshakeRequest, BrokerHandshakeResponse};
+    use litebox_broker_protocol::pipe::{
+        ReadPipeResponse, ReadPipeSharedResponse, WritePipeResponse,
+    };
+    use litebox_broker_protocol::shared_memory::SharedMemoryError;
+
+    #[test]
+    fn pipe_uses_attached_shared_memory_for_data_operations() {
+        let read_handle = ObjectHandle(1);
+        let write_handle = ObjectHandle(2);
+        let memory = TestSharedMemory::new(PIPE_SHARED_MEMORY_SIZE);
+        let channel = ScriptedChannel::new([
+            ControlResponse {
+                response: BrokerResponse::Pipe(PipeResponse::Create(CreatePipeResponse {
+                    read_handle,
+                    write_handle,
+                    shared_memory: true,
+                })),
+                shared_memory: Some(memory.clone()),
+            },
+            ControlResponse {
+                response: BrokerResponse::Pipe(PipeResponse::WriteShared(WritePipeResponse {
+                    written: 3,
+                })),
+                shared_memory: None,
+            },
+            ControlResponse {
+                response: BrokerResponse::Pipe(PipeResponse::ReadShared(ReadPipeSharedResponse {
+                    read: 2,
+                })),
+                shared_memory: None,
+            },
+        ]);
+        let mut local = BrokerLocal::negotiate(channel).unwrap();
+
+        local.create_pipe(64, 16).unwrap();
+        assert_eq!(local.write_pipe(write_handle, &[1, 2, 3]).unwrap(), 3);
+        let mut staged = [0; 3];
+        memory
+            .read(PIPE_SHARED_MEMORY_REGION_SIZE, &mut staged)
+            .unwrap();
+        assert_eq!(staged, [1, 2, 3]);
+
+        memory.write(0, &[4, 5]).unwrap();
+        assert_eq!(local.read_pipe(read_handle, 2).unwrap(), [4, 5]);
+        assert_eq!(
+            local.channel.sent_requests,
+            [
+                BrokerRequest::Pipe(PipeRequest::Create(CreatePipeRequest {
+                    capacity: 64,
+                    atomic_write_size: 16,
+                })),
+                BrokerRequest::Pipe(PipeRequest::WriteShared(WritePipeSharedRequest {
+                    handle: write_handle,
+                    offset: 0,
+                    length: 3,
+                })),
+                BrokerRequest::Pipe(PipeRequest::ReadShared(ReadPipeSharedRequest {
+                    handle: read_handle,
+                    offset: 0,
+                    length: 2,
+                })),
+            ]
+        );
+    }
+
+    #[test]
+    fn pipe_uses_inline_operations_without_shared_memory() {
+        let read_handle = ObjectHandle(1);
+        let write_handle = ObjectHandle(2);
+        let channel = ScriptedChannel::new([
+            ControlResponse {
+                response: BrokerResponse::Pipe(PipeResponse::Create(CreatePipeResponse {
+                    read_handle,
+                    write_handle,
+                    shared_memory: false,
+                })),
+                shared_memory: None,
+            },
+            ControlResponse {
+                response: BrokerResponse::Pipe(PipeResponse::Write(WritePipeResponse {
+                    written: 3,
+                })),
+                shared_memory: None,
+            },
+            ControlResponse {
+                response: BrokerResponse::Pipe(PipeResponse::Read(ReadPipeResponse {
+                    data: Vec::from([4, 5]),
+                })),
+                shared_memory: None,
+            },
+        ]);
+        let mut local = BrokerLocal::negotiate(channel).unwrap();
+
+        local.create_pipe(64, 16).unwrap();
+        assert_eq!(local.write_pipe(write_handle, &[1, 2, 3]).unwrap(), 3);
+        assert_eq!(local.read_pipe(read_handle, 2).unwrap(), [4, 5]);
+        assert!(matches!(
+            &local.channel.sent_requests[1],
+            BrokerRequest::Pipe(PipeRequest::Write(WritePipeRequest { handle, data }))
+                if *handle == write_handle && data == &[1, 2, 3]
+        ));
+        assert_eq!(
+            local.channel.sent_requests[2],
+            BrokerRequest::Pipe(PipeRequest::Read(ReadPipeRequest {
+                handle: read_handle,
+                length: 2,
+            }))
+        );
+    }
+
+    #[derive(Clone)]
+    struct TestSharedMemory(Arc<Mutex<Vec<u8>>>);
+
+    impl TestSharedMemory {
+        fn new(length: usize) -> Self {
+            Self(Arc::new(Mutex::new(std::vec![0; length])))
+        }
+    }
+
+    impl SharedMemory for TestSharedMemory {
+        fn len(&self) -> usize {
+            self.0.lock().unwrap().len()
+        }
+
+        fn read(
+            &self,
+            offset: usize,
+            destination: &mut [u8],
+        ) -> core::result::Result<(), SharedMemoryError> {
+            let memory = self.0.lock().unwrap();
+            let end = offset
+                .checked_add(destination.len())
+                .ok_or(SharedMemoryError::InvalidRange)?;
+            let source = memory
+                .get(offset..end)
+                .ok_or(SharedMemoryError::InvalidRange)?;
+            destination.copy_from_slice(source);
+            Ok(())
+        }
+
+        fn write(
+            &self,
+            offset: usize,
+            source: &[u8],
+        ) -> core::result::Result<(), SharedMemoryError> {
+            let mut memory = self.0.lock().unwrap();
+            let end = offset
+                .checked_add(source.len())
+                .ok_or(SharedMemoryError::InvalidRange)?;
+            let destination = memory
+                .get_mut(offset..end)
+                .ok_or(SharedMemoryError::InvalidRange)?;
+            destination.copy_from_slice(source);
+            Ok(())
+        }
+    }
+
+    struct ScriptedChannel {
+        responses: VecDeque<ControlResponse<TestSharedMemory>>,
+        sent_requests: Vec<BrokerRequest>,
+    }
+
+    impl ScriptedChannel {
+        fn new(responses: impl IntoIterator<Item = ControlResponse<TestSharedMemory>>) -> Self {
+            Self {
+                responses: responses.into_iter().collect(),
+                sent_requests: Vec::new(),
+            }
+        }
+    }
+
+    impl LocalControlChannel for ScriptedChannel {
+        type Error = Infallible;
+        type SharedMemory = TestSharedMemory;
+
+        fn send_handshake_request(
+            &mut self,
+            request: &BrokerHandshakeRequest,
+        ) -> core::result::Result<(), Self::Error> {
+            assert_eq!(request.protocol_version, BROKER_PROTOCOL_VERSION);
+            Ok(())
+        }
+
+        fn recv_handshake_response(
+            &mut self,
+        ) -> core::result::Result<Option<BrokerHandshakeResponse>, Self::Error> {
+            Ok(Some(BrokerHandshakeResponse::Negotiated {
+                broker_protocol_version: BROKER_PROTOCOL_VERSION,
+            }))
+        }
+
+        fn send_request(
+            &mut self,
+            request: &BrokerRequest,
+        ) -> core::result::Result<(), Self::Error> {
+            self.sent_requests.push(request.clone());
+            Ok(())
+        }
+
+        fn recv_response(
+            &mut self,
+        ) -> core::result::Result<Option<ControlResponse<Self::SharedMemory>>, Self::Error>
+        {
+            Ok(self.responses.pop_front())
         }
     }
 }

--- a/litebox_broker_protocol/src/channel.rs
+++ b/litebox_broker_protocol/src/channel.rs
@@ -5,6 +5,15 @@ use crate::message::{
     BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerNotification, BrokerRequest,
     BrokerResponse,
 };
+use crate::shared_memory::SharedMemory;
+
+/// Active control response and its optional transport-provided shared memory.
+pub struct ControlResponse<Memory> {
+    /// Broker protocol response.
+    pub response: BrokerResponse,
+    /// Shared-memory resource attached to this response.
+    pub shared_memory: Option<Memory>,
+}
 
 /// Peer identity information supplied by the channel or host layer.
 ///
@@ -38,6 +47,8 @@ pub enum HostReceive<T> {
 pub trait LocalControlChannel {
     /// Channel-specific error type.
     type Error;
+    /// Shared-memory resource received from this channel.
+    type SharedMemory: SharedMemory;
 
     /// Sends one broker handshake request.
     fn send_handshake_request(
@@ -58,13 +69,16 @@ pub trait LocalControlChannel {
     ///
     /// Returns `Ok(None)` when the broker closed the channel cleanly before
     /// starting another response frame.
-    fn recv_response(&mut self) -> Result<Option<BrokerResponse>, Self::Error>;
+    fn recv_response(&mut self)
+    -> Result<Option<ControlResponse<Self::SharedMemory>>, Self::Error>;
 }
 
 /// Host-side control channel for broker authority calls.
 pub trait HostControlChannel {
     /// Channel-specific error type.
     type Error;
+    /// Shared-memory resource created and transferred by this channel.
+    type SharedMemory: SharedMemory;
 
     /// Returns the peer credential authenticated for this channel endpoint.
     fn peer_credential(&self) -> Result<PeerCredential, Self::Error>;
@@ -83,8 +97,23 @@ pub trait HostControlChannel {
     /// Receives one active broker request.
     fn recv_request(&mut self) -> Result<HostReceive<BrokerRequest>, Self::Error>;
 
+    /// Creates a shared-memory resource for an active response.
+    ///
+    /// Returns `Ok(None)` when this channel does not support shared-memory
+    /// attachments.
+    fn create_shared_memory(
+        &mut self,
+        _length: usize,
+    ) -> Result<Option<Self::SharedMemory>, Self::Error> {
+        Ok(None)
+    }
+
     /// Sends one active broker response.
-    fn send_response(&mut self, response: &BrokerResponse) -> Result<(), Self::Error>;
+    fn send_response(
+        &mut self,
+        response: &BrokerResponse,
+        shared_memory: Option<&Self::SharedMemory>,
+    ) -> Result<(), Self::Error>;
 }
 
 /// Local-side receive channel for broker-initiated asynchronous notifications.

--- a/litebox_broker_protocol/src/lib.rs
+++ b/litebox_broker_protocol/src/lib.rs
@@ -18,6 +18,7 @@ pub mod event;
 pub mod message;
 pub mod pipe;
 pub mod readiness;
+pub mod shared_memory;
 pub mod wire;
 
 /// Opaque broker object reference handle.

--- a/litebox_broker_protocol/src/message.rs
+++ b/litebox_broker_protocol/src/message.rs
@@ -7,8 +7,9 @@ use crate::event::{
     CreateEventRequest, CreateEventResponse,
 };
 use crate::pipe::{
-    CreatePipeRequest, CreatePipeResponse, ReadPipeRequest, ReadPipeResponse, WritePipeRequest,
-    WritePipeResponse,
+    CreatePipeRequest, CreatePipeResponse, ReadPipeRequest, ReadPipeResponse,
+    ReadPipeSharedRequest, ReadPipeSharedResponse, WritePipeRequest, WritePipeResponse,
+    WritePipeSharedRequest,
 };
 use crate::readiness::ReadinessFlags;
 use crate::{ObjectHandle, ProtocolVersion};
@@ -75,8 +76,12 @@ pub enum PipeRequest {
     Create(CreatePipeRequest),
     /// Read bytes from a pipe.
     Read(ReadPipeRequest),
+    /// Read bytes from a pipe into shared memory.
+    ReadShared(ReadPipeSharedRequest),
     /// Write bytes to a pipe.
     Write(WritePipeRequest),
+    /// Write bytes staged in shared memory to a pipe.
+    WriteShared(WritePipeSharedRequest),
 }
 
 /// Broker response sent over an active control channel.
@@ -112,8 +117,12 @@ pub enum PipeResponse {
     Create(CreatePipeResponse),
     /// Read operation response.
     Read(ReadPipeResponse),
+    /// Shared-memory read operation response.
+    ReadShared(ReadPipeSharedResponse),
     /// Write operation response.
     Write(WritePipeResponse),
+    /// Shared-memory write operation response.
+    WriteShared(WritePipeResponse),
 }
 
 /// Broker-initiated asynchronous notification.

--- a/litebox_broker_protocol/src/pipe.rs
+++ b/litebox_broker_protocol/src/pipe.rs
@@ -11,6 +11,12 @@ use crate::ObjectHandle;
 /// smallest currently supported transport frame.
 pub const MAX_PIPE_TRANSFER_SIZE: u32 = 32 * 1024;
 
+/// Size of each directional shared-memory staging ring.
+pub const PIPE_SHARED_MEMORY_REGION_SIZE: usize = MAX_PIPE_TRANSFER_SIZE as usize;
+
+/// Total size of one pipe's read and write staging rings.
+pub const PIPE_SHARED_MEMORY_SIZE: usize = PIPE_SHARED_MEMORY_REGION_SIZE * 2;
+
 /// Request to create a broker-owned byte pipe.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct CreatePipeRequest {
@@ -27,6 +33,8 @@ pub struct CreatePipeResponse {
     pub read_handle: ObjectHandle,
     /// Handle for the write endpoint.
     pub write_handle: ObjectHandle,
+    /// Whether the control response includes the pipe's shared-memory resource.
+    pub shared_memory: bool,
 }
 
 /// Request to read bytes from a pipe endpoint.
@@ -45,6 +53,24 @@ pub struct ReadPipeResponse {
     pub data: Vec<u8>,
 }
 
+/// Request to read pipe bytes into the shared-memory read ring.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ReadPipeSharedRequest {
+    /// Read endpoint handle.
+    pub handle: ObjectHandle,
+    /// Byte offset within the read ring.
+    pub offset: u32,
+    /// Maximum number of bytes to read.
+    pub length: u32,
+}
+
+/// Response describing bytes placed in the shared-memory read ring.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ReadPipeSharedResponse {
+    /// Number of bytes placed in the ring.
+    pub read: u32,
+}
+
 /// Request to write bytes to a pipe endpoint.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct WritePipeRequest {
@@ -52,6 +78,17 @@ pub struct WritePipeRequest {
     pub handle: ObjectHandle,
     /// Bytes to append to the pipe.
     pub data: Vec<u8>,
+}
+
+/// Request to write bytes staged in the shared-memory write ring.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct WritePipeSharedRequest {
+    /// Write endpoint handle.
+    pub handle: ObjectHandle,
+    /// Byte offset within the write ring.
+    pub offset: u32,
+    /// Number of staged bytes to write.
+    pub length: u32,
 }
 
 /// Response describing a completed pipe write.

--- a/litebox_broker_protocol/src/shared_memory.rs
+++ b/litebox_broker_protocol/src/shared_memory.rs
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//! Transport-neutral shared-memory resources attached to control responses.
+
+use thiserror::Error;
+
+/// Error accessing a shared-memory resource.
+#[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SharedMemoryError {
+    /// The requested byte range is outside the shared-memory resource.
+    #[error("shared-memory range is out of bounds")]
+    InvalidRange,
+    /// The channel does not support shared-memory resources.
+    #[error("shared memory is unsupported")]
+    Unsupported,
+}
+
+/// Byte-copy access to a shared-memory resource supplied by a control channel.
+///
+/// Implementations must keep the backing resource alive for the lifetime of
+/// the value and synchronize concurrent accesses without exposing typed
+/// references into memory writable by another process.
+pub trait SharedMemory: Send + Sync + 'static {
+    /// Returns the mapped resource length in bytes.
+    fn len(&self) -> usize;
+
+    /// Returns whether the resource is empty.
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Copies bytes from shared memory into `destination`.
+    fn read(&self, offset: usize, destination: &mut [u8]) -> Result<(), SharedMemoryError>;
+
+    /// Copies bytes from `source` into shared memory.
+    fn write(&self, offset: usize, source: &[u8]) -> Result<(), SharedMemoryError>;
+}
+
+/// Shared-memory type for control channels that do not support attachments.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct NoSharedMemory;
+
+impl SharedMemory for NoSharedMemory {
+    fn len(&self) -> usize {
+        0
+    }
+
+    fn read(&self, _offset: usize, _destination: &mut [u8]) -> Result<(), SharedMemoryError> {
+        Err(SharedMemoryError::Unsupported)
+    }
+
+    fn write(&self, _offset: usize, _source: &[u8]) -> Result<(), SharedMemoryError> {
+        Err(SharedMemoryError::Unsupported)
+    }
+}

--- a/litebox_broker_protocol/src/wire.rs
+++ b/litebox_broker_protocol/src/wire.rs
@@ -283,8 +283,9 @@ mod tests {
     };
     use crate::message::{EventRequest, EventResponse, PipeRequest, PipeResponse};
     use crate::pipe::{
-        CreatePipeRequest, CreatePipeResponse, ReadPipeRequest, ReadPipeResponse, WritePipeRequest,
-        WritePipeResponse,
+        CreatePipeRequest, CreatePipeResponse, ReadPipeRequest, ReadPipeResponse,
+        ReadPipeSharedRequest, ReadPipeSharedResponse, WritePipeRequest, WritePipeResponse,
+        WritePipeSharedRequest,
     };
     use crate::{ObjectHandle, ProtocolVersion};
 
@@ -328,9 +329,19 @@ mod tests {
                 atomic_write_size: 512,
             })),
             BrokerRequest::Pipe(PipeRequest::Read(ReadPipeRequest { handle, length: 32 })),
+            BrokerRequest::Pipe(PipeRequest::ReadShared(ReadPipeSharedRequest {
+                handle,
+                offset: 7,
+                length: 32,
+            })),
             BrokerRequest::Pipe(PipeRequest::Write(WritePipeRequest {
                 handle,
                 data: Vec::from([1, 2, 3]),
+            })),
+            BrokerRequest::Pipe(PipeRequest::WriteShared(WritePipeSharedRequest {
+                handle,
+                offset: 9,
+                length: 3,
             })),
         ];
 
@@ -381,11 +392,14 @@ mod tests {
             BrokerResponse::Pipe(PipeResponse::Create(CreatePipeResponse {
                 read_handle: handle,
                 write_handle: ObjectHandle(14),
+                shared_memory: true,
             })),
             BrokerResponse::Pipe(PipeResponse::Read(ReadPipeResponse {
                 data: Vec::from([1, 2, 3]),
             })),
+            BrokerResponse::Pipe(PipeResponse::ReadShared(ReadPipeSharedResponse { read: 3 })),
             BrokerResponse::Pipe(PipeResponse::Write(WritePipeResponse { written: 3 })),
+            BrokerResponse::Pipe(PipeResponse::WriteShared(WritePipeResponse { written: 3 })),
             BrokerResponse::Error(ErrorCode::PolicyDenied),
             BrokerResponse::Error(ErrorCode::WouldBlock),
             BrokerResponse::Error(ErrorCode::PeerClosed),

--- a/litebox_broker_protocol/src/wire/pipe.rs
+++ b/litebox_broker_protocol/src/wire/pipe.rs
@@ -3,8 +3,9 @@
 
 use crate::message::{PipeRequest, PipeResponse};
 use crate::pipe::{
-    CreatePipeRequest, CreatePipeResponse, ReadPipeRequest, ReadPipeResponse, WritePipeRequest,
-    WritePipeResponse,
+    CreatePipeRequest, CreatePipeResponse, ReadPipeRequest, ReadPipeResponse,
+    ReadPipeSharedRequest, ReadPipeSharedResponse, WritePipeRequest, WritePipeResponse,
+    WritePipeSharedRequest,
 };
 
 use super::WireError;
@@ -13,10 +14,14 @@ use super::primitive::{Decoder, Encoder};
 const PIPE_REQUEST_TAG_CREATE: u8 = 0;
 const PIPE_REQUEST_TAG_READ: u8 = 1;
 const PIPE_REQUEST_TAG_WRITE: u8 = 2;
+const PIPE_REQUEST_TAG_READ_SHARED: u8 = 3;
+const PIPE_REQUEST_TAG_WRITE_SHARED: u8 = 4;
 
 const PIPE_RESPONSE_TAG_CREATED: u8 = 0;
 const PIPE_RESPONSE_TAG_READ: u8 = 1;
 const PIPE_RESPONSE_TAG_WRITTEN: u8 = 2;
+const PIPE_RESPONSE_TAG_READ_SHARED: u8 = 3;
+const PIPE_RESPONSE_TAG_WRITE_SHARED: u8 = 4;
 
 pub(super) fn encode_pipe_request(encoder: &mut Encoder, request: PipeRequest) {
     match request {
@@ -30,10 +35,22 @@ pub(super) fn encode_pipe_request(encoder: &mut Encoder, request: PipeRequest) {
             encoder.handle(request.handle);
             encoder.u32(request.length);
         }
+        PipeRequest::ReadShared(request) => {
+            encoder.u8(PIPE_REQUEST_TAG_READ_SHARED);
+            encoder.handle(request.handle);
+            encoder.u32(request.offset);
+            encoder.u32(request.length);
+        }
         PipeRequest::Write(request) => {
             encoder.u8(PIPE_REQUEST_TAG_WRITE);
             encoder.handle(request.handle);
             encoder.bytes(&request.data);
+        }
+        PipeRequest::WriteShared(request) => {
+            encoder.u8(PIPE_REQUEST_TAG_WRITE_SHARED);
+            encoder.handle(request.handle);
+            encoder.u32(request.offset);
+            encoder.u32(request.length);
         }
     }
 }
@@ -48,9 +65,19 @@ pub(super) fn decode_pipe_request(decoder: &mut Decoder<'_>) -> Result<PipeReque
             handle: decoder.handle()?,
             length: decoder.u32()?,
         })),
+        PIPE_REQUEST_TAG_READ_SHARED => Ok(PipeRequest::ReadShared(ReadPipeSharedRequest {
+            handle: decoder.handle()?,
+            offset: decoder.u32()?,
+            length: decoder.u32()?,
+        })),
         PIPE_REQUEST_TAG_WRITE => Ok(PipeRequest::Write(WritePipeRequest {
             handle: decoder.handle()?,
             data: decoder.bytes()?,
+        })),
+        PIPE_REQUEST_TAG_WRITE_SHARED => Ok(PipeRequest::WriteShared(WritePipeSharedRequest {
+            handle: decoder.handle()?,
+            offset: decoder.u32()?,
+            length: decoder.u32()?,
         })),
         _ => Err(WireError::InvalidTag),
     }
@@ -62,13 +89,22 @@ pub(super) fn encode_pipe_response(encoder: &mut Encoder, response: PipeResponse
             encoder.u8(PIPE_RESPONSE_TAG_CREATED);
             encoder.handle(response.read_handle);
             encoder.handle(response.write_handle);
+            encoder.bool(response.shared_memory);
         }
         PipeResponse::Read(response) => {
             encoder.u8(PIPE_RESPONSE_TAG_READ);
             encoder.bytes(&response.data);
         }
+        PipeResponse::ReadShared(response) => {
+            encoder.u8(PIPE_RESPONSE_TAG_READ_SHARED);
+            encoder.u32(response.read);
+        }
         PipeResponse::Write(response) => {
             encoder.u8(PIPE_RESPONSE_TAG_WRITTEN);
+            encoder.u32(response.written);
+        }
+        PipeResponse::WriteShared(response) => {
+            encoder.u8(PIPE_RESPONSE_TAG_WRITE_SHARED);
             encoder.u32(response.written);
         }
     }
@@ -79,11 +115,18 @@ pub(super) fn decode_pipe_response(decoder: &mut Decoder<'_>) -> Result<PipeResp
         PIPE_RESPONSE_TAG_CREATED => Ok(PipeResponse::Create(CreatePipeResponse {
             read_handle: decoder.handle()?,
             write_handle: decoder.handle()?,
+            shared_memory: decoder.bool()?,
         })),
         PIPE_RESPONSE_TAG_READ => Ok(PipeResponse::Read(ReadPipeResponse {
             data: decoder.bytes()?,
         })),
+        PIPE_RESPONSE_TAG_READ_SHARED => Ok(PipeResponse::ReadShared(ReadPipeSharedResponse {
+            read: decoder.u32()?,
+        })),
         PIPE_RESPONSE_TAG_WRITTEN => Ok(PipeResponse::Write(WritePipeResponse {
+            written: decoder.u32()?,
+        })),
+        PIPE_RESPONSE_TAG_WRITE_SHARED => Ok(PipeResponse::WriteShared(WritePipeResponse {
             written: decoder.u32()?,
         })),
         _ => Err(WireError::InvalidTag),

--- a/litebox_broker_protocol/src/wire/primitive.rs
+++ b/litebox_broker_protocol/src/wire/primitive.rs
@@ -21,6 +21,10 @@ impl Encoder {
         self.bytes.push(value);
     }
 
+    pub(super) fn bool(&mut self, value: bool) {
+        self.u8(u8::from(value));
+    }
+
     pub(super) fn u16(&mut self, value: u16) {
         self.bytes.extend_from_slice(&value.to_le_bytes());
     }
@@ -73,6 +77,14 @@ impl<'a> Decoder<'a> {
     pub(super) fn u8(&mut self) -> Result<u8, WireError> {
         let bytes = self.take(1)?;
         Ok(bytes[0])
+    }
+
+    pub(super) fn bool(&mut self) -> Result<bool, WireError> {
+        match self.u8()? {
+            0 => Ok(false),
+            1 => Ok(true),
+            _ => Err(WireError::InvalidTag),
+        }
     }
 
     pub(super) fn u16(&mut self) -> Result<u16, WireError> {

--- a/litebox_broker_transport/Cargo.toml
+++ b/litebox_broker_transport/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+libc = { version = "0.2.177", default-features = false }
 litebox_broker_protocol = { path = "../litebox_broker_protocol", version = "0.1.0" }
 
 [lints]

--- a/litebox_broker_transport/src/unix_socket.rs
+++ b/litebox_broker_transport/src/unix_socket.rs
@@ -9,18 +9,22 @@
 
 use std::io::{Error, ErrorKind, Read, Result as IoResult, Write};
 use std::net::Shutdown;
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
 use std::os::unix::net::UnixStream;
 use std::path::Path;
+use std::ptr::NonNull;
+use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
 use litebox_broker_protocol::channel::{
-    HostControlChannel, HostNotificationChannel, HostReceive, LocalControlChannel,
+    ControlResponse, HostControlChannel, HostNotificationChannel, HostReceive, LocalControlChannel,
     LocalNotificationChannel, PeerCredential,
 };
 use litebox_broker_protocol::message::{
     BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerNotification, BrokerRequest,
     BrokerResponse,
 };
+use litebox_broker_protocol::shared_memory::{SharedMemory, SharedMemoryError};
 use litebox_broker_protocol::wire::{
     WireError, decode_handshake_request, decode_handshake_response, decode_notification,
     decode_request, decode_response, encode_handshake_request, encode_handshake_response,
@@ -28,6 +32,9 @@ use litebox_broker_protocol::wire::{
 };
 
 const MAX_FRAME_LEN: usize = 64 * 1024;
+const SHARED_MEMORY_MARKER: u8 = 0xa5;
+const REQUIRED_MEMFD_SEALS: libc::c_int =
+    libc::F_SEAL_GROW | libc::F_SEAL_SHRINK | libc::F_SEAL_SEAL;
 
 /// Local-side Unix-domain-socket control channel for the hosted userland POC.
 pub struct UnixStreamLocalControlChannel {
@@ -38,6 +45,165 @@ pub struct UnixStreamLocalControlChannel {
 /// Independently owned handle for interrupting local control-channel I/O.
 pub struct UnixStreamLocalControlCancellation {
     stream: UnixStream,
+}
+
+/// Memfd-backed shared memory transferred over a Unix control channel.
+pub struct UnixSharedMemory {
+    fd: OwnedFd,
+    mapping: Mutex<MappedRegion>,
+}
+
+struct MappedRegion {
+    address: NonNull<u8>,
+    length: usize,
+}
+
+// SAFETY: `MappedRegion` exclusively owns its mapping, and all byte access is
+// serialized by the enclosing `Mutex`.
+unsafe impl Send for MappedRegion {}
+
+impl UnixSharedMemory {
+    fn create(length: usize) -> IoResult<Self> {
+        if length == 0 {
+            return Err(invalid_data("shared memory cannot be empty"));
+        }
+        let name = c"litebox-broker-pipe";
+        // SAFETY: `name` is a valid NUL-terminated C string and the flags are
+        // accepted by `memfd_create`.
+        let raw_fd = unsafe {
+            libc::memfd_create(name.as_ptr(), libc::MFD_CLOEXEC | libc::MFD_ALLOW_SEALING)
+        };
+        if raw_fd < 0 {
+            return Err(Error::last_os_error());
+        }
+        // SAFETY: `memfd_create` returned a new owned file descriptor.
+        let fd = unsafe { OwnedFd::from_raw_fd(raw_fd) };
+        let length_off_t = libc::off_t::try_from(length)
+            .map_err(|_| invalid_data("shared-memory length exceeds off_t"))?;
+        // SAFETY: `fd` is valid and `length_off_t` is nonnegative.
+        if unsafe { libc::ftruncate(fd.as_raw_fd(), length_off_t) } != 0 {
+            return Err(Error::last_os_error());
+        }
+        // SAFETY: `fd` is a sealable memfd and the seal mask is valid.
+        if unsafe { libc::fcntl(fd.as_raw_fd(), libc::F_ADD_SEALS, REQUIRED_MEMFD_SEALS) } != 0 {
+            return Err(Error::last_os_error());
+        }
+        Self::map(fd, length)
+    }
+
+    fn from_received_fd(fd: OwnedFd) -> IoResult<Self> {
+        let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
+        // SAFETY: `stat` points to writable storage and `fd` is valid.
+        if unsafe { libc::fstat(fd.as_raw_fd(), stat.as_mut_ptr()) } != 0 {
+            return Err(Error::last_os_error());
+        }
+        // SAFETY: `fstat` initialized `stat` after returning success.
+        let stat = unsafe { stat.assume_init() };
+        let length = usize::try_from(stat.st_size)
+            .map_err(|_| invalid_data("invalid shared-memory length"))?;
+        if length == 0 {
+            return Err(invalid_data("shared memory cannot be empty"));
+        }
+        // SAFETY: `fd` is valid and `F_GET_SEALS` does not modify memory.
+        let seals = unsafe { libc::fcntl(fd.as_raw_fd(), libc::F_GET_SEALS) };
+        if seals < 0 {
+            return Err(Error::last_os_error());
+        }
+        if seals & REQUIRED_MEMFD_SEALS != REQUIRED_MEMFD_SEALS {
+            return Err(invalid_data("shared-memory size is not sealed"));
+        }
+        Self::map(fd, length)
+    }
+
+    fn map(fd: OwnedFd, length: usize) -> IoResult<Self> {
+        // SAFETY: `fd` refers to a file at least `length` bytes long. The
+        // returned mapping is checked against `MAP_FAILED` and owned by
+        // `MappedRegion`.
+        let address = unsafe {
+            libc::mmap(
+                std::ptr::null_mut(),
+                length,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_SHARED,
+                fd.as_raw_fd(),
+                0,
+            )
+        };
+        if address == libc::MAP_FAILED {
+            return Err(Error::last_os_error());
+        }
+        let address =
+            NonNull::new(address.cast()).ok_or_else(|| invalid_data("mmap returned null"))?;
+        Ok(Self {
+            fd,
+            mapping: Mutex::new(MappedRegion { address, length }),
+        })
+    }
+}
+
+impl SharedMemory for UnixSharedMemory {
+    fn len(&self) -> usize {
+        self.mapping
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .length
+    }
+
+    fn read(&self, offset: usize, destination: &mut [u8]) -> Result<(), SharedMemoryError> {
+        let mapping = self
+            .mapping
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let end = offset
+            .checked_add(destination.len())
+            .filter(|end| *end <= mapping.length)
+            .ok_or(SharedMemoryError::InvalidRange)?;
+        let _ = end;
+        // SAFETY: The range was checked against the live mapping, and
+        // `destination` is valid for its full length. Control-channel
+        // serialization prevents the peer from reusing this staging range
+        // until the operation completes.
+        unsafe {
+            libc::memcpy(
+                destination.as_mut_ptr().cast(),
+                mapping.address.as_ptr().add(offset).cast(),
+                destination.len(),
+            );
+        }
+        Ok(())
+    }
+
+    fn write(&self, offset: usize, source: &[u8]) -> Result<(), SharedMemoryError> {
+        let mapping = self
+            .mapping
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let end = offset
+            .checked_add(source.len())
+            .filter(|end| *end <= mapping.length)
+            .ok_or(SharedMemoryError::InvalidRange)?;
+        let _ = end;
+        // SAFETY: The range was checked against the live mapping, and `source`
+        // is valid for its full length. The mapping is byte-addressed foreign
+        // memory and no Rust references into it are created.
+        unsafe {
+            libc::memcpy(
+                mapping.address.as_ptr().add(offset).cast(),
+                source.as_ptr().cast(),
+                source.len(),
+            );
+        }
+        Ok(())
+    }
+}
+
+impl Drop for MappedRegion {
+    fn drop(&mut self) {
+        // SAFETY: `address` and `length` describe the mapping exclusively owned
+        // by this value, and it is unmapped exactly once here.
+        let result = unsafe { libc::munmap(self.address.as_ptr().cast(), self.length) };
+        debug_assert_eq!(result, 0, "failed to unmap broker shared memory");
+    }
 }
 
 impl UnixStreamLocalControlChannel {
@@ -136,6 +302,7 @@ impl UnixStreamHostNotificationChannel {
 
 impl LocalControlChannel for UnixStreamLocalControlChannel {
     type Error = Error;
+    type SharedMemory = UnixSharedMemory;
 
     fn send_handshake_request(&mut self, request: &BrokerHandshakeRequest) -> IoResult<()> {
         let frame = encode_handshake_request(request.clone());
@@ -161,9 +328,22 @@ impl LocalControlChannel for UnixStreamLocalControlChannel {
         write_frame_with_deadline(&mut self.stream, &frame, None)
     }
 
-    fn recv_response(&mut self) -> IoResult<Option<BrokerResponse>> {
+    fn recv_response(&mut self) -> IoResult<Option<ControlResponse<Self::SharedMemory>>> {
         match read_frame_with_deadline(&mut self.stream, None)? {
-            Some(frame) => decode_response(&frame).map(Some).map_err(wire_error),
+            Some(frame) => {
+                let response = decode_response(&frame).map_err(wire_error)?;
+                let shared_memory = if response_has_shared_memory(&response) {
+                    Some(UnixSharedMemory::from_received_fd(receive_fd(
+                        &self.stream,
+                    )?)?)
+                } else {
+                    None
+                };
+                Ok(Some(ControlResponse {
+                    response,
+                    shared_memory,
+                }))
+            }
             None => Ok(None),
         }
     }
@@ -171,6 +351,7 @@ impl LocalControlChannel for UnixStreamLocalControlChannel {
 
 impl HostControlChannel for UnixStreamHostControlChannel {
     type Error = Error;
+    type SharedMemory = UnixSharedMemory;
 
     fn peer_credential(&self) -> IoResult<PeerCredential> {
         // TODO(broker): replace the PoC placeholder with Unix peer credential extraction
@@ -208,8 +389,25 @@ impl HostControlChannel for UnixStreamHostControlChannel {
         }
     }
 
-    fn send_response(&mut self, response: &BrokerResponse) -> IoResult<()> {
-        write_frame_with_deadline(&mut self.stream, &encode_response(response.clone()), None)
+    fn create_shared_memory(&mut self, length: usize) -> IoResult<Option<Self::SharedMemory>> {
+        UnixSharedMemory::create(length).map(Some)
+    }
+
+    fn send_response(
+        &mut self,
+        response: &BrokerResponse,
+        shared_memory: Option<&Self::SharedMemory>,
+    ) -> IoResult<()> {
+        if response_has_shared_memory(response) != shared_memory.is_some() {
+            return Err(invalid_data(
+                "broker response shared-memory attachment mismatch",
+            ));
+        }
+        write_frame_with_deadline(&mut self.stream, &encode_response(response.clone()), None)?;
+        if let Some(shared_memory) = shared_memory {
+            send_fd(&self.stream, shared_memory.fd.as_raw_fd())?;
+        }
+        Ok(())
     }
 }
 
@@ -307,6 +505,138 @@ fn write_all_with_deadline(
     Ok(())
 }
 
+fn response_has_shared_memory(response: &BrokerResponse) -> bool {
+    matches!(
+        response,
+        BrokerResponse::Pipe(litebox_broker_protocol::message::PipeResponse::Create(response))
+            if response.shared_memory
+    )
+}
+
+#[repr(C)]
+struct FdControlMessage {
+    header: libc::cmsghdr,
+    fds: [RawFd; 4],
+}
+
+fn send_fd(stream: &UnixStream, fd: RawFd) -> IoResult<()> {
+    let fd_size: libc::c_uint = std::mem::size_of::<RawFd>()
+        .try_into()
+        .expect("file descriptor size must fit in c_uint");
+    let marker = [SHARED_MEMORY_MARKER];
+    let mut io = libc::iovec {
+        iov_base: marker.as_ptr().cast_mut().cast(),
+        iov_len: marker.len(),
+    };
+    // SAFETY: A zeroed cmsghdr/iovec message is a valid starting state.
+    let mut control: FdControlMessage = unsafe { std::mem::zeroed() };
+    control.header.cmsg_level = libc::SOL_SOCKET;
+    control.header.cmsg_type = libc::SCM_RIGHTS;
+    // SAFETY: The requested control-message size contains exactly one RawFd.
+    control.header.cmsg_len = unsafe { libc::CMSG_LEN(fd_size) } as usize;
+    control.fds[0] = fd;
+    // SAFETY: A zeroed msghdr is valid before assigning all used fields.
+    let mut message: libc::msghdr = unsafe { std::mem::zeroed() };
+    message.msg_iov = &raw mut io;
+    message.msg_iovlen = 1;
+    message.msg_control = std::ptr::addr_of_mut!(control).cast();
+    // SAFETY: The requested space is backed by `control`.
+    message.msg_controllen = unsafe { libc::CMSG_SPACE(fd_size) } as usize;
+
+    loop {
+        // SAFETY: `message` points to live marker and control buffers for the
+        // duration of the call.
+        let sent = unsafe { libc::sendmsg(stream.as_raw_fd(), &raw const message, 0) };
+        if sent == 1 {
+            return Ok(());
+        }
+        if sent == 0 {
+            return Err(Error::new(
+                ErrorKind::WriteZero,
+                "failed to send shared-memory descriptor",
+            ));
+        }
+        let error = Error::last_os_error();
+        if error.kind() != ErrorKind::Interrupted {
+            return Err(error);
+        }
+    }
+}
+
+fn receive_fd(stream: &UnixStream) -> IoResult<OwnedFd> {
+    let mut marker = [0];
+    let mut io = libc::iovec {
+        iov_base: marker.as_mut_ptr().cast(),
+        iov_len: marker.len(),
+    };
+    // SAFETY: A zeroed control buffer and msghdr are valid starting states.
+    let mut control: FdControlMessage = unsafe { std::mem::zeroed() };
+    // SAFETY: A zeroed msghdr is valid before assigning all used fields.
+    let mut message: libc::msghdr = unsafe { std::mem::zeroed() };
+    message.msg_iov = &raw mut io;
+    message.msg_iovlen = 1;
+    message.msg_control = std::ptr::addr_of_mut!(control).cast();
+    message.msg_controllen = std::mem::size_of::<FdControlMessage>();
+
+    let received = loop {
+        // SAFETY: `message` points to live marker and control buffers for the
+        // duration of the call.
+        let received =
+            unsafe { libc::recvmsg(stream.as_raw_fd(), &raw mut message, libc::MSG_CMSG_CLOEXEC) };
+        if received >= 0 {
+            break received;
+        }
+        let error = Error::last_os_error();
+        if error.kind() != ErrorKind::Interrupted {
+            return Err(error);
+        }
+    };
+    if received == 0 {
+        return Err(Error::new(
+            ErrorKind::UnexpectedEof,
+            "broker closed before shared-memory descriptor",
+        ));
+    }
+    let mut received_fds = Vec::new();
+    // SAFETY: `message` contains the kernel-initialized control buffer from
+    // `recvmsg`; CMSG iteration stays within `msg_controllen`.
+    unsafe {
+        let mut header = libc::CMSG_FIRSTHDR(&raw const message);
+        while !header.is_null() {
+            if (*header).cmsg_level == libc::SOL_SOCKET && (*header).cmsg_type == libc::SCM_RIGHTS {
+                let header_length = libc::CMSG_LEN(0) as usize;
+                let data_length = (*header).cmsg_len.saturating_sub(header_length);
+                if !data_length.is_multiple_of(std::mem::size_of::<RawFd>()) {
+                    return Err(invalid_data("invalid SCM_RIGHTS payload length"));
+                }
+                let count = data_length / std::mem::size_of::<RawFd>();
+                let data = libc::CMSG_DATA(header);
+                for index in 0..count {
+                    let mut fd = std::mem::MaybeUninit::<RawFd>::uninit();
+                    std::ptr::copy_nonoverlapping(
+                        data.add(index * std::mem::size_of::<RawFd>()),
+                        fd.as_mut_ptr().cast::<u8>(),
+                        std::mem::size_of::<RawFd>(),
+                    );
+                    received_fds.push(OwnedFd::from_raw_fd(fd.assume_init()));
+                }
+            }
+            header = libc::CMSG_NXTHDR(&raw const message, header);
+        }
+    }
+    if message.msg_flags & libc::MSG_CTRUNC != 0 || received_fds.len() != 1 {
+        return Err(invalid_data(
+            "shared-memory response must contain exactly one descriptor",
+        ));
+    }
+    if received != 1 || marker[0] != SHARED_MEMORY_MARKER {
+        return Err(invalid_data("invalid shared-memory descriptor marker"));
+    }
+    Ok(received_fds
+        .pop()
+        .expect("exactly one descriptor was checked"))
+}
+
 fn refresh_stream_io_deadline(stream: &UnixStream, deadline: Option<Instant>) -> IoResult<()> {
     if let Some(deadline) = deadline {
         let timeout = io_timeout_for_deadline(deadline)?;
@@ -338,6 +668,11 @@ fn wire_error(error: WireError) -> Error {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use litebox_broker_protocol::ObjectHandle;
+    use litebox_broker_protocol::message::PipeResponse;
+    use litebox_broker_protocol::pipe::{
+        CreatePipeResponse, PIPE_SHARED_MEMORY_REGION_SIZE, PIPE_SHARED_MEMORY_SIZE,
+    };
 
     #[test]
     fn frame_round_trip() {
@@ -350,6 +685,42 @@ mod tests {
                 .unwrap(),
             [1, 2, 3]
         );
+    }
+
+    #[test]
+    fn shared_memory_response_transfers_sealed_memfd() {
+        let (local_stream, host_stream) = UnixStream::pair().unwrap();
+        let mut local = UnixStreamLocalControlChannel::from_connected(local_stream);
+        let mut host = UnixStreamHostControlChannel::from_accepted(host_stream);
+        let host_memory = host
+            .create_shared_memory(PIPE_SHARED_MEMORY_SIZE)
+            .unwrap()
+            .unwrap();
+        host_memory.write(0, &[1, 2, 3]).unwrap();
+        let response = BrokerResponse::Pipe(PipeResponse::Create(CreatePipeResponse {
+            read_handle: ObjectHandle(1),
+            write_handle: ObjectHandle(2),
+            shared_memory: true,
+        }));
+
+        host.send_response(&response, Some(&host_memory)).unwrap();
+        let received = local.recv_response().unwrap().unwrap();
+
+        assert_eq!(received.response, response);
+        let local_memory = received.shared_memory.unwrap();
+        let mut data = [0; 3];
+        local_memory.read(0, &mut data).unwrap();
+        assert_eq!(data, [1, 2, 3]);
+        local_memory
+            .write(PIPE_SHARED_MEMORY_REGION_SIZE, &[4, 5, 6])
+            .unwrap();
+        host_memory
+            .read(PIPE_SHARED_MEMORY_REGION_SIZE, &mut data)
+            .unwrap();
+        assert_eq!(data, [4, 5, 6]);
+        // SAFETY: `F_GETFD` reads descriptor flags from a valid owned fd.
+        let descriptor_flags = unsafe { libc::fcntl(local_memory.fd.as_raw_fd(), libc::F_GETFD) };
+        assert_ne!(descriptor_flags & libc::FD_CLOEXEC, 0);
     }
 
     #[test]

--- a/litebox_platform_linux_userland/src/lib.rs
+++ b/litebox_platform_linux_userland/src/lib.rs
@@ -508,6 +508,39 @@ impl LinuxUserland {
                     .unwrap(),
                 ],
             ),
+            // Broker shared-memory responses receive one descriptor with
+            // close-on-exec and validate that its memfd size is sealed.
+            (
+                libc::SYS_recvmsg,
+                vec![
+                    SeccompRule::new(vec![
+                        SeccompCondition::new(
+                            2,
+                            SeccompCmpArgLen::Dword,
+                            SeccompCmpOp::Eq,
+                            libc::MSG_CMSG_CLOEXEC.cast_unsigned().into(),
+                        )
+                        .unwrap(),
+                    ])
+                    .unwrap(),
+                ],
+            ),
+            (libc::SYS_fstat, vec![]),
+            (
+                libc::SYS_fcntl,
+                vec![
+                    SeccompRule::new(vec![
+                        SeccompCondition::new(
+                            1,
+                            SeccompCmpArgLen::Dword,
+                            SeccompCmpOp::Eq,
+                            libc::F_GET_SEALS.cast_unsigned().into(),
+                        )
+                        .unwrap(),
+                    ])
+                    .unwrap(),
+                ],
+            ),
             (libc::SYS_close, vec![]),
         ];
         let rule_map: std::collections::BTreeMap<i64, Vec<SeccompRule>> =

--- a/litebox_runner_linux_userland/tests/run.rs
+++ b/litebox_runner_linux_userland/tests/run.rs
@@ -407,6 +407,7 @@ impl<Channel: litebox_broker_protocol::channel::HostControlChannel>
     litebox_broker_protocol::channel::HostControlChannel for CountingHostControlChannel<Channel>
 {
     type Error = Channel::Error;
+    type SharedMemory = Channel::SharedMemory;
 
     fn peer_credential(
         &self,
@@ -452,11 +453,19 @@ impl<Channel: litebox_broker_protocol::channel::HostControlChannel>
         Ok(request)
     }
 
+    fn create_shared_memory(
+        &mut self,
+        length: usize,
+    ) -> Result<Option<Self::SharedMemory>, Self::Error> {
+        self.inner.create_shared_memory(length)
+    }
+
     fn send_response(
         &mut self,
         response: &litebox_broker_protocol::message::BrokerResponse,
+        shared_memory: Option<&Self::SharedMemory>,
     ) -> Result<(), Self::Error> {
-        self.inner.send_response(response)
+        self.inner.send_response(response, shared_memory)
     }
 }
 


### PR DESCRIPTION
## Summary
- add transport-neutral shared-memory attachments and offset/length pipe operations
- transfer one sealed memfd per pipe over Unix sockets with separate read/write staging regions
- keep BrokerCore authoritative through synchronous control requests and preserve inline fallback
- allow only the Linux-userland syscalls needed to receive and validate shared-memory descriptors

## Testing
- `cargo fmt --check`
- `cargo test -p litebox_broker_protocol -p litebox_broker_local -p litebox_broker_host -p litebox_broker_transport`
- `cargo test -p litebox pipes`
- `cargo clippy -p litebox_broker_protocol -p litebox_broker_local -p litebox_broker_host -p litebox_broker_transport -p litebox_platform_linux_userland -p litebox_runner_linux_userland -p litebox --all-targets --all-features -- -D warnings`
- `cargo test -p litebox_runner_linux_userland --test run test_runner_broker_integration_with_rewriter -- --exact`