### PR TITLE
Add broker-host shared pipe staging

### DIFF
--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -9,11 +9,16 @@
 
 #![no_std]
 
+extern crate alloc;
+
 #[cfg(test)]
 extern crate std;
 
+use alloc::{collections::BTreeMap, sync::Arc, vec::Vec};
+
 use litebox_broker_core::{BrokerCore, BrokerSession, CallerCredential};
 use litebox_broker_protocol::BROKER_PROTOCOL_VERSION;
+use litebox_broker_protocol::ObjectHandle;
 use litebox_broker_protocol::channel::{
     HostControlChannel, HostNotificationChannel, HostReceive, PeerCredential,
 };
@@ -24,6 +29,10 @@ use litebox_broker_protocol::message::{
     PipeRequest, PipeResponse,
 };
 use litebox_broker_protocol::pipe::{CreatePipeResponse, ReadPipeResponse, WritePipeResponse};
+use litebox_broker_protocol::pipe::{
+    PIPE_SHARED_MEMORY_REGION_SIZE, PIPE_SHARED_MEMORY_SIZE, ReadPipeSharedResponse,
+};
+use litebox_broker_protocol::shared_memory::SharedMemory;
 
 mod error;
 
@@ -54,6 +63,7 @@ where
         _ => return Err(BrokerHostError::Broker(ErrorCode::PolicyDenied)),
     };
     let session = core.create_session(caller_credential)?;
+    let mut pipe_shared_memories = BTreeMap::new();
 
     loop {
         let request = match control_channel
@@ -105,66 +115,245 @@ where
             HostReceive::PeerClosed => break,
         };
 
-        let response = handle_request(&session, request);
+        let response = handle_request(
+            &session,
+            request,
+            control_channel,
+            &mut pipe_shared_memories,
+        )
+        .map_err(BrokerHostError::Channel)?;
         control_channel
-            .send_response(&response, None)
+            .send_response(&response.response, response.shared_memory.as_deref())
             .map_err(BrokerHostError::Channel)?;
     }
 
     Ok(ConnectionTermination::PeerClosed)
 }
 
-fn handle_request(session: &BrokerSession, request: BrokerRequest) -> BrokerResponse {
+struct HandledResponse<Memory> {
+    response: BrokerResponse,
+    shared_memory: Option<Arc<Memory>>,
+}
+
+struct PipeSharedMemory<Memory> {
+    memory: Arc<Memory>,
+    endpoint: SharedPipeEndpoint,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SharedPipeEndpoint {
+    Read,
+    Write,
+}
+
+fn handle_request<Channel: HostControlChannel>(
+    session: &BrokerSession,
+    request: BrokerRequest,
+    channel: &mut Channel,
+    pipe_shared_memories: &mut BTreeMap<ObjectHandle, PipeSharedMemory<Channel::SharedMemory>>,
+) -> core::result::Result<HandledResponse<Channel::SharedMemory>, Channel::Error> {
+    let mut shared_memory = None;
     match request {
         BrokerRequest::CloseObject(handle) => match session.close_object_reference(handle) {
-            Ok(()) => BrokerResponse::ObjectClosed,
-            Err(error) => BrokerResponse::Error(error.into()),
+            Ok(()) => {
+                pipe_shared_memories.remove(&handle);
+                Ok(HandledResponse {
+                    response: BrokerResponse::ObjectClosed,
+                    shared_memory,
+                })
+            }
+            Err(error) => Ok(HandledResponse {
+                response: BrokerResponse::Error(error.into()),
+                shared_memory,
+            }),
         },
-        BrokerRequest::CheckReadiness(handle) => match session.check_readiness(handle) {
-            Ok(readiness) => BrokerResponse::Readiness(readiness),
-            Err(error) => BrokerResponse::Error(error.into()),
-        },
-        BrokerRequest::Event(request) => handle_event_request(session, request),
-        BrokerRequest::Pipe(request) => handle_pipe_request(session, request),
+        BrokerRequest::CheckReadiness(handle) => Ok(HandledResponse {
+            response: match session.check_readiness(handle) {
+                Ok(readiness) => BrokerResponse::Readiness(readiness),
+                Err(error) => BrokerResponse::Error(error.into()),
+            },
+            shared_memory,
+        }),
+        BrokerRequest::Event(request) => Ok(HandledResponse {
+            response: handle_event_request(session, request),
+            shared_memory,
+        }),
+        BrokerRequest::Pipe(PipeRequest::Create(request)) => {
+            let response = match litebox_broker_core::pipe::create(
+                session,
+                request.capacity,
+                request.atomic_write_size,
+            ) {
+                Ok((read_handle, write_handle)) => {
+                    let memory = match channel.create_shared_memory(PIPE_SHARED_MEMORY_SIZE) {
+                        Ok(memory) => memory,
+                        Err(error) => {
+                            session
+                                .close_object_reference(read_handle)
+                                .expect("new pipe read handle must be valid");
+                            session
+                                .close_object_reference(write_handle)
+                                .expect("new pipe write handle must be valid");
+                            return Err(error);
+                        }
+                    };
+                    let has_shared_memory = memory.is_some();
+                    if let Some(memory) = memory {
+                        if memory.len() != PIPE_SHARED_MEMORY_SIZE {
+                            session
+                                .close_object_reference(read_handle)
+                                .expect("new pipe read handle must be valid");
+                            session
+                                .close_object_reference(write_handle)
+                                .expect("new pipe write handle must be valid");
+                            return Ok(HandledResponse {
+                                response: BrokerResponse::Error(ErrorCode::Internal),
+                                shared_memory: None,
+                            });
+                        }
+                        let memory = Arc::new(memory);
+                        pipe_shared_memories.insert(
+                            read_handle,
+                            PipeSharedMemory {
+                                memory: Arc::clone(&memory),
+                                endpoint: SharedPipeEndpoint::Read,
+                            },
+                        );
+                        pipe_shared_memories.insert(
+                            write_handle,
+                            PipeSharedMemory {
+                                memory: Arc::clone(&memory),
+                                endpoint: SharedPipeEndpoint::Write,
+                            },
+                        );
+                        shared_memory = Some(memory);
+                    }
+                    BrokerResponse::Pipe(PipeResponse::Create(CreatePipeResponse {
+                        read_handle,
+                        write_handle,
+                        shared_memory: has_shared_memory,
+                    }))
+                }
+                Err(error) => BrokerResponse::Error(error.into()),
+            };
+            Ok(HandledResponse {
+                response,
+                shared_memory,
+            })
+        }
+        BrokerRequest::Pipe(request) => Ok(HandledResponse {
+            response: handle_pipe_request(session, request, pipe_shared_memories),
+            shared_memory,
+        }),
     }
 }
 
-fn handle_pipe_request(session: &BrokerSession, request: PipeRequest) -> BrokerResponse {
-    let response = match request {
-        PipeRequest::Create(request) => {
-            litebox_broker_core::pipe::create(session, request.capacity, request.atomic_write_size)
-                .map(|(read_handle, write_handle)| {
-                    PipeResponse::Create(CreatePipeResponse {
-                        read_handle,
-                        write_handle,
-                        shared_memory: false,
-                    })
-                })
-        }
+fn handle_pipe_request<Memory: SharedMemory>(
+    session: &BrokerSession,
+    request: PipeRequest,
+    pipe_shared_memories: &BTreeMap<ObjectHandle, PipeSharedMemory<Memory>>,
+) -> BrokerResponse {
+    let response: core::result::Result<PipeResponse, ErrorCode> = match request {
+        PipeRequest::Create(_) => unreachable!("pipe creation is handled with the control channel"),
         PipeRequest::Read(request) => {
             litebox_broker_core::pipe::read(session, request.handle, request.length)
                 .map(|data| PipeResponse::Read(ReadPipeResponse { data }))
+                .map_err(Into::into)
+        }
+        PipeRequest::ReadShared(request) => {
+            let Some(shared) = pipe_shared_memories.get(&request.handle) else {
+                return BrokerResponse::Error(ErrorCode::InvalidRights);
+            };
+            if shared.endpoint != SharedPipeEndpoint::Read {
+                return BrokerResponse::Error(ErrorCode::InvalidRights);
+            }
+            let Some(offset) = shared_memory_offset(shared, 0, request.offset, request.length)
+            else {
+                return BrokerResponse::Error(ErrorCode::MalformedRequest);
+            };
+            litebox_broker_core::pipe::read(session, request.handle, request.length)
+                .map_err(ErrorCode::from)
+                .and_then(|data| {
+                    shared
+                        .memory
+                        .write(offset, &data)
+                        .map_err(|_| ErrorCode::Internal)?;
+                    Ok(PipeResponse::ReadShared(ReadPipeSharedResponse {
+                        read: data
+                            .len()
+                            .try_into()
+                            .map_err(|_| ErrorCode::ResourceExhausted)?,
+                    }))
+                })
         }
         PipeRequest::Write(request) => {
-            litebox_broker_core::pipe::write(session, request.handle, &request.data).and_then(
-                |written| {
+            litebox_broker_core::pipe::write(session, request.handle, &request.data)
+                .map_err(ErrorCode::from)
+                .and_then(|written| {
                     Ok(PipeResponse::Write(WritePipeResponse {
                         written: written
                             .try_into()
-                            .map_err(|_| litebox_broker_core::BrokerError::ResourceExhausted)?,
+                            .map_err(|_| ErrorCode::ResourceExhausted)?,
                     }))
-                },
-            )
+                })
         }
-        PipeRequest::ReadShared(_) | PipeRequest::WriteShared(_) => {
-            Err(litebox_broker_core::BrokerError::UnsupportedOperation)
+        PipeRequest::WriteShared(request) => {
+            let Some(shared) = pipe_shared_memories.get(&request.handle) else {
+                return BrokerResponse::Error(ErrorCode::InvalidRights);
+            };
+            if shared.endpoint != SharedPipeEndpoint::Write {
+                return BrokerResponse::Error(ErrorCode::InvalidRights);
+            }
+            let Some(offset) = shared_memory_offset(
+                shared,
+                PIPE_SHARED_MEMORY_REGION_SIZE,
+                request.offset,
+                request.length,
+            ) else {
+                return BrokerResponse::Error(ErrorCode::MalformedRequest);
+            };
+            let length = request.length as usize;
+            let mut data = Vec::new();
+            if data.try_reserve_exact(length).is_err() {
+                return BrokerResponse::Error(ErrorCode::OutOfMemory);
+            }
+            data.resize(length, 0);
+            if shared.memory.read(offset, &mut data).is_err() {
+                return BrokerResponse::Error(ErrorCode::Internal);
+            }
+            litebox_broker_core::pipe::write(session, request.handle, &data)
+                .map_err(ErrorCode::from)
+                .and_then(|written| {
+                    Ok(PipeResponse::WriteShared(WritePipeResponse {
+                        written: written
+                            .try_into()
+                            .map_err(|_| ErrorCode::ResourceExhausted)?,
+                    }))
+                })
         }
     };
 
     match response {
         Ok(response) => BrokerResponse::Pipe(response),
-        Err(error) => BrokerResponse::Error(error.into()),
+        Err(error) => BrokerResponse::Error(error),
     }
+}
+
+fn shared_memory_offset<Memory: SharedMemory>(
+    shared: &PipeSharedMemory<Memory>,
+    base: usize,
+    offset: u32,
+    length: u32,
+) -> Option<usize> {
+    let offset = offset as usize;
+    let length = length as usize;
+    let end = offset.checked_add(length)?;
+    if end > PIPE_SHARED_MEMORY_REGION_SIZE {
+        return None;
+    }
+    let absolute = base.checked_add(offset)?;
+    let absolute_end = absolute.checked_add(length)?;
+    (absolute_end <= shared.memory.len()).then_some(absolute)
 }
 
 fn handle_event_request(session: &BrokerSession, request: EventRequest) -> BrokerResponse {
@@ -212,7 +401,13 @@ mod tests {
         AddEventRequest, ConsumeEventRequest, CreateEventRequest, EventConsumeMode,
     };
     use litebox_broker_protocol::message::{BrokerHandshakeRequest, BrokerNotification};
+    use litebox_broker_protocol::pipe::{
+        CreatePipeRequest, ReadPipeRequest, ReadPipeSharedRequest, WritePipeRequest,
+        WritePipeSharedRequest,
+    };
+    use litebox_broker_protocol::shared_memory::{NoSharedMemory, SharedMemoryError};
     use litebox_broker_protocol::{ObjectHandle, ProtocolVersion};
+    use std::sync::Mutex;
 
     #[test]
     fn host_request_handling_uses_one_broker_core() {
@@ -228,6 +423,8 @@ mod tests {
         serve_connection_returns_channel_error_when_response_send_fails(&broker);
         serve_connection_returns_event_readiness_in_control_responses(&broker);
         active_request_closes_object_reference(&broker);
+        shared_pipe_data_path_stages_bytes_and_validates_ranges(&broker);
+        pipe_data_path_falls_back_to_inline_operations(&broker);
     }
 
     fn serve_connection_negotiates_routes_one_request_and_returns_peer_closed(broker: &BrokerCore) {
@@ -390,7 +587,7 @@ mod tests {
         let session = broker
             .create_session(CallerCredential::Unauthenticated)
             .unwrap();
-        let response = handle_request(
+        let response = handle_test_request(
             &session,
             BrokerRequest::Event(EventRequest::Create(CreateEventRequest {
                 initial_count: 0,
@@ -402,20 +599,177 @@ mod tests {
         let handle = response.handle;
 
         assert_eq!(
-            handle_request(&session, BrokerRequest::CloseObject(handle)),
+            handle_test_request(&session, BrokerRequest::CloseObject(handle)),
             BrokerResponse::ObjectClosed
         );
         assert_eq!(
-            handle_request(&session, BrokerRequest::CheckReadiness(handle)),
+            handle_test_request(&session, BrokerRequest::CheckReadiness(handle)),
             BrokerResponse::Error(ErrorCode::UnknownObject)
         );
         assert_eq!(
-            handle_request(
+            handle_test_request(
                 &session,
                 BrokerRequest::CloseObject(ObjectHandle(handle.0 + 1))
             ),
             BrokerResponse::Error(ErrorCode::UnknownObject)
         );
+    }
+
+    fn shared_pipe_data_path_stages_bytes_and_validates_ranges(broker: &BrokerCore) {
+        let session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let mut channel = SharedMemoryHostControlChannel;
+        let mut shared_memories = BTreeMap::new();
+        let HandledResponse {
+            response,
+            shared_memory,
+        } = handle_request(
+            &session,
+            BrokerRequest::Pipe(PipeRequest::Create(CreatePipeRequest {
+                capacity: 64,
+                atomic_write_size: 16,
+            })),
+            &mut channel,
+            &mut shared_memories,
+        )
+        .unwrap();
+        let BrokerResponse::Pipe(PipeResponse::Create(response)) = response else {
+            panic!("unexpected create response: {response:?}");
+        };
+        assert!(response.shared_memory);
+        assert_eq!(shared_memories.len(), 2);
+        let memory = shared_memory.unwrap();
+
+        memory
+            .write(PIPE_SHARED_MEMORY_REGION_SIZE + 7, &[1, 2, 3])
+            .unwrap();
+        let write = handle_request(
+            &session,
+            BrokerRequest::Pipe(PipeRequest::WriteShared(WritePipeSharedRequest {
+                handle: response.write_handle,
+                offset: 7,
+                length: 3,
+            })),
+            &mut channel,
+            &mut shared_memories,
+        )
+        .unwrap();
+        assert_eq!(
+            write.response,
+            BrokerResponse::Pipe(PipeResponse::WriteShared(WritePipeResponse { written: 3 }))
+        );
+
+        let read = handle_request(
+            &session,
+            BrokerRequest::Pipe(PipeRequest::ReadShared(ReadPipeSharedRequest {
+                handle: response.read_handle,
+                offset: 11,
+                length: 3,
+            })),
+            &mut channel,
+            &mut shared_memories,
+        )
+        .unwrap();
+        assert_eq!(
+            read.response,
+            BrokerResponse::Pipe(PipeResponse::ReadShared(ReadPipeSharedResponse { read: 3 }))
+        );
+        let mut data = [0; 3];
+        memory.read(11, &mut data).unwrap();
+        assert_eq!(data, [1, 2, 3]);
+
+        let wrong_endpoint = handle_request(
+            &session,
+            BrokerRequest::Pipe(PipeRequest::ReadShared(ReadPipeSharedRequest {
+                handle: response.write_handle,
+                offset: 0,
+                length: 1,
+            })),
+            &mut channel,
+            &mut shared_memories,
+        )
+        .unwrap();
+        assert_eq!(
+            wrong_endpoint.response,
+            BrokerResponse::Error(ErrorCode::InvalidRights)
+        );
+        let invalid_range = handle_request(
+            &session,
+            BrokerRequest::Pipe(PipeRequest::WriteShared(WritePipeSharedRequest {
+                handle: response.write_handle,
+                offset: (PIPE_SHARED_MEMORY_REGION_SIZE - 1).try_into().unwrap(),
+                length: 2,
+            })),
+            &mut channel,
+            &mut shared_memories,
+        )
+        .unwrap();
+        assert_eq!(
+            invalid_range.response,
+            BrokerResponse::Error(ErrorCode::MalformedRequest)
+        );
+    }
+
+    fn pipe_data_path_falls_back_to_inline_operations(broker: &BrokerCore) {
+        let session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let mut channel = FakeHostControlChannel::new(std::vec::Vec::new(), std::vec::Vec::new());
+        let mut shared_memories = BTreeMap::new();
+        let created = handle_request(
+            &session,
+            BrokerRequest::Pipe(PipeRequest::Create(CreatePipeRequest {
+                capacity: 64,
+                atomic_write_size: 16,
+            })),
+            &mut channel,
+            &mut shared_memories,
+        )
+        .unwrap();
+        let BrokerResponse::Pipe(PipeResponse::Create(response)) = created.response else {
+            panic!("unexpected create response: {:?}", created.response);
+        };
+        assert!(!response.shared_memory);
+        assert!(created.shared_memory.is_none());
+
+        let written = handle_request(
+            &session,
+            BrokerRequest::Pipe(PipeRequest::Write(WritePipeRequest {
+                handle: response.write_handle,
+                data: Vec::from([1, 2, 3]),
+            })),
+            &mut channel,
+            &mut shared_memories,
+        )
+        .unwrap();
+        assert_eq!(
+            written.response,
+            BrokerResponse::Pipe(PipeResponse::Write(WritePipeResponse { written: 3 }))
+        );
+        let read = handle_request(
+            &session,
+            BrokerRequest::Pipe(PipeRequest::Read(ReadPipeRequest {
+                handle: response.read_handle,
+                length: 3,
+            })),
+            &mut channel,
+            &mut shared_memories,
+        )
+        .unwrap();
+        assert_eq!(
+            read.response,
+            BrokerResponse::Pipe(PipeResponse::Read(ReadPipeResponse {
+                data: Vec::from([1, 2, 3])
+            }))
+        );
+    }
+
+    fn handle_test_request(session: &BrokerSession, request: BrokerRequest) -> BrokerResponse {
+        let mut channel = FakeHostControlChannel::new(std::vec::Vec::new(), std::vec::Vec::new());
+        handle_request(session, request, &mut channel, &mut BTreeMap::new())
+            .unwrap()
+            .response
     }
 
     struct FakeHostControlChannel {
@@ -448,7 +802,7 @@ mod tests {
 
     impl HostControlChannel for FakeHostControlChannel {
         type Error = ();
-        type SharedMemory = litebox_broker_protocol::shared_memory::NoSharedMemory;
+        type SharedMemory = NoSharedMemory;
 
         fn peer_credential(&self) -> core::result::Result<PeerCredential, Self::Error> {
             Ok(PeerCredential::Unauthenticated)
@@ -515,6 +869,98 @@ mod tests {
             }
             self.responses.push(response.clone());
             Ok(())
+        }
+    }
+
+    #[derive(Clone)]
+    struct TestSharedMemory(Arc<Mutex<Vec<u8>>>);
+
+    impl TestSharedMemory {
+        fn new(length: usize) -> Self {
+            Self(Arc::new(Mutex::new(std::vec![0; length])))
+        }
+    }
+
+    impl SharedMemory for TestSharedMemory {
+        fn len(&self) -> usize {
+            self.0.lock().unwrap().len()
+        }
+
+        fn read(
+            &self,
+            offset: usize,
+            destination: &mut [u8],
+        ) -> core::result::Result<(), SharedMemoryError> {
+            let memory = self.0.lock().unwrap();
+            let end = offset
+                .checked_add(destination.len())
+                .ok_or(SharedMemoryError::InvalidRange)?;
+            let source = memory
+                .get(offset..end)
+                .ok_or(SharedMemoryError::InvalidRange)?;
+            destination.copy_from_slice(source);
+            Ok(())
+        }
+
+        fn write(
+            &self,
+            offset: usize,
+            source: &[u8],
+        ) -> core::result::Result<(), SharedMemoryError> {
+            let mut memory = self.0.lock().unwrap();
+            let end = offset
+                .checked_add(source.len())
+                .ok_or(SharedMemoryError::InvalidRange)?;
+            let destination = memory
+                .get_mut(offset..end)
+                .ok_or(SharedMemoryError::InvalidRange)?;
+            destination.copy_from_slice(source);
+            Ok(())
+        }
+    }
+
+    struct SharedMemoryHostControlChannel;
+
+    impl HostControlChannel for SharedMemoryHostControlChannel {
+        type Error = ();
+        type SharedMemory = TestSharedMemory;
+
+        fn peer_credential(&self) -> core::result::Result<PeerCredential, Self::Error> {
+            Ok(PeerCredential::Unauthenticated)
+        }
+
+        fn recv_handshake_request(
+            &mut self,
+        ) -> core::result::Result<HostReceive<BrokerHandshakeRequest>, Self::Error> {
+            panic!("unexpected handshake receive")
+        }
+
+        fn send_handshake_response(
+            &mut self,
+            _response: &BrokerHandshakeResponse,
+        ) -> core::result::Result<(), Self::Error> {
+            panic!("unexpected handshake response")
+        }
+
+        fn recv_request(
+            &mut self,
+        ) -> core::result::Result<HostReceive<BrokerRequest>, Self::Error> {
+            panic!("unexpected request receive")
+        }
+
+        fn create_shared_memory(
+            &mut self,
+            length: usize,
+        ) -> core::result::Result<Option<Self::SharedMemory>, Self::Error> {
+            Ok(Some(TestSharedMemory::new(length)))
+        }
+
+        fn send_response(
+            &mut self,
+            _response: &BrokerResponse,
+            _shared_memory: Option<&Self::SharedMemory>,
+        ) -> core::result::Result<(), Self::Error> {
+            panic!("unexpected response send")
         }
     }
 


### PR DESCRIPTION
## Summary
- create one channel-provided staging resource per broker pipe
- validate endpoint direction, region offsets, lengths, and mapping size
- keep BrokerCore authoritative for bytes, capacity, rights, readiness, and closure

## Stack
1. #1049 — protocol foundation
2. **#1048** — broker-host staging
3. #1051 — broker-local data path
4. #1050 — Unix transport enablement