### PR TITLE
Enable shared broker pipes over Unix sockets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1515,6 +1515,7 @@ dependencies = [
 name = "litebox_broker_transport"
 version = "0.1.0"
 dependencies = [
+ "libc",
  "litebox_broker_protocol",
 ]
 

--- a/dev_tests/src/ratchet.rs
+++ b/dev_tests/src/ratchet.rs
@@ -72,6 +72,7 @@ fn ratchet_maybe_uninit() -> Result<()> {
         &[
             ("dev_tests/", 1),
             ("litebox/", 1),
+            ("litebox_broker_transport/", 2),
             ("litebox_platform_linux_userland/", 2),
         ],
         |file| {

--- a/litebox_broker_transport/Cargo.toml
+++ b/litebox_broker_transport/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+libc = { version = "0.2.177", default-features = false }
 litebox_broker_protocol = { path = "../litebox_broker_protocol", version = "0.1.0" }
 
 [lints]

--- a/litebox_broker_transport/src/unix_socket.rs
+++ b/litebox_broker_transport/src/unix_socket.rs
@@ -9,8 +9,11 @@
 
 use std::io::{Error, ErrorKind, Read, Result as IoResult, Write};
 use std::net::Shutdown;
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
 use std::os::unix::net::UnixStream;
 use std::path::Path;
+use std::ptr::NonNull;
+use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
 use litebox_broker_protocol::channel::{
@@ -21,7 +24,7 @@ use litebox_broker_protocol::message::{
     BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerNotification, BrokerRequest,
     BrokerResponse,
 };
-use litebox_broker_protocol::shared_memory::NoSharedMemory;
+use litebox_broker_protocol::shared_memory::{SharedMemory, SharedMemoryError};
 use litebox_broker_protocol::wire::{
     WireError, decode_handshake_request, decode_handshake_response, decode_notification,
     decode_request, decode_response, encode_handshake_request, encode_handshake_response,
@@ -29,6 +32,9 @@ use litebox_broker_protocol::wire::{
 };
 
 const MAX_FRAME_LEN: usize = 64 * 1024;
+const SHARED_MEMORY_MARKER: u8 = 0xa5;
+const REQUIRED_MEMFD_SEALS: libc::c_int =
+    libc::F_SEAL_GROW | libc::F_SEAL_SHRINK | libc::F_SEAL_SEAL;
 
 /// Local-side Unix-domain-socket control channel for the hosted userland POC.
 pub struct UnixStreamLocalControlChannel {
@@ -39,6 +45,165 @@ pub struct UnixStreamLocalControlChannel {
 /// Independently owned handle for interrupting local control-channel I/O.
 pub struct UnixStreamLocalControlCancellation {
     stream: UnixStream,
+}
+
+/// Memfd-backed shared memory transferred over a Unix control channel.
+pub struct UnixSharedMemory {
+    fd: OwnedFd,
+    mapping: Mutex<MappedRegion>,
+}
+
+struct MappedRegion {
+    address: NonNull<u8>,
+    length: usize,
+}
+
+// SAFETY: `MappedRegion` exclusively owns its mapping, and all byte access is
+// serialized by the enclosing `Mutex`.
+unsafe impl Send for MappedRegion {}
+
+impl UnixSharedMemory {
+    fn create(length: usize) -> IoResult<Self> {
+        if length == 0 {
+            return Err(invalid_data("shared memory cannot be empty"));
+        }
+        let name = c"litebox-broker-pipe";
+        // SAFETY: `name` is a valid NUL-terminated C string and the flags are
+        // accepted by `memfd_create`.
+        let raw_fd = unsafe {
+            libc::memfd_create(name.as_ptr(), libc::MFD_CLOEXEC | libc::MFD_ALLOW_SEALING)
+        };
+        if raw_fd < 0 {
+            return Err(Error::last_os_error());
+        }
+        // SAFETY: `memfd_create` returned a new owned file descriptor.
+        let fd = unsafe { OwnedFd::from_raw_fd(raw_fd) };
+        let length_off_t = libc::off_t::try_from(length)
+            .map_err(|_| invalid_data("shared-memory length exceeds off_t"))?;
+        // SAFETY: `fd` is valid and `length_off_t` is nonnegative.
+        if unsafe { libc::ftruncate(fd.as_raw_fd(), length_off_t) } != 0 {
+            return Err(Error::last_os_error());
+        }
+        // SAFETY: `fd` is a sealable memfd and the seal mask is valid.
+        if unsafe { libc::fcntl(fd.as_raw_fd(), libc::F_ADD_SEALS, REQUIRED_MEMFD_SEALS) } != 0 {
+            return Err(Error::last_os_error());
+        }
+        Self::map(fd, length)
+    }
+
+    fn from_received_fd(fd: OwnedFd) -> IoResult<Self> {
+        let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
+        // SAFETY: `stat` points to writable storage and `fd` is valid.
+        if unsafe { libc::fstat(fd.as_raw_fd(), stat.as_mut_ptr()) } != 0 {
+            return Err(Error::last_os_error());
+        }
+        // SAFETY: `fstat` initialized `stat` after returning success.
+        let stat = unsafe { stat.assume_init() };
+        let length = usize::try_from(stat.st_size)
+            .map_err(|_| invalid_data("invalid shared-memory length"))?;
+        if length == 0 {
+            return Err(invalid_data("shared memory cannot be empty"));
+        }
+        // SAFETY: `fd` is valid and `F_GET_SEALS` does not modify memory.
+        let seals = unsafe { libc::fcntl(fd.as_raw_fd(), libc::F_GET_SEALS) };
+        if seals < 0 {
+            return Err(Error::last_os_error());
+        }
+        if seals & REQUIRED_MEMFD_SEALS != REQUIRED_MEMFD_SEALS {
+            return Err(invalid_data("shared-memory size is not sealed"));
+        }
+        Self::map(fd, length)
+    }
+
+    fn map(fd: OwnedFd, length: usize) -> IoResult<Self> {
+        // SAFETY: `fd` refers to a file at least `length` bytes long. The
+        // returned mapping is checked against `MAP_FAILED` and owned by
+        // `MappedRegion`.
+        let address = unsafe {
+            libc::mmap(
+                std::ptr::null_mut(),
+                length,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_SHARED,
+                fd.as_raw_fd(),
+                0,
+            )
+        };
+        if address == libc::MAP_FAILED {
+            return Err(Error::last_os_error());
+        }
+        let address =
+            NonNull::new(address.cast()).ok_or_else(|| invalid_data("mmap returned null"))?;
+        Ok(Self {
+            fd,
+            mapping: Mutex::new(MappedRegion { address, length }),
+        })
+    }
+}
+
+impl SharedMemory for UnixSharedMemory {
+    fn len(&self) -> usize {
+        self.mapping
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .length
+    }
+
+    fn read(&self, offset: usize, destination: &mut [u8]) -> Result<(), SharedMemoryError> {
+        let mapping = self
+            .mapping
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let end = offset
+            .checked_add(destination.len())
+            .filter(|end| *end <= mapping.length)
+            .ok_or(SharedMemoryError::InvalidRange)?;
+        let _ = end;
+        // SAFETY: The range was checked against the live mapping, and
+        // `destination` is valid for its full length. Control-channel
+        // serialization prevents the peer from reusing this staging range
+        // until the operation completes.
+        unsafe {
+            libc::memcpy(
+                destination.as_mut_ptr().cast(),
+                mapping.address.as_ptr().add(offset).cast(),
+                destination.len(),
+            );
+        }
+        Ok(())
+    }
+
+    fn write(&self, offset: usize, source: &[u8]) -> Result<(), SharedMemoryError> {
+        let mapping = self
+            .mapping
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let end = offset
+            .checked_add(source.len())
+            .filter(|end| *end <= mapping.length)
+            .ok_or(SharedMemoryError::InvalidRange)?;
+        let _ = end;
+        // SAFETY: The range was checked against the live mapping, and `source`
+        // is valid for its full length. The mapping is byte-addressed foreign
+        // memory and no Rust references into it are created.
+        unsafe {
+            libc::memcpy(
+                mapping.address.as_ptr().add(offset).cast(),
+                source.as_ptr().cast(),
+                source.len(),
+            );
+        }
+        Ok(())
+    }
+}
+
+impl Drop for MappedRegion {
+    fn drop(&mut self) {
+        // SAFETY: `address` and `length` describe the mapping exclusively owned
+        // by this value, and it is unmapped exactly once here.
+        let result = unsafe { libc::munmap(self.address.as_ptr().cast(), self.length) };
+        debug_assert_eq!(result, 0, "failed to unmap broker shared memory");
+    }
 }
 
 impl UnixStreamLocalControlChannel {
@@ -137,7 +302,7 @@ impl UnixStreamHostNotificationChannel {
 
 impl LocalControlChannel for UnixStreamLocalControlChannel {
     type Error = Error;
-    type SharedMemory = NoSharedMemory;
+    type SharedMemory = UnixSharedMemory;
 
     fn send_handshake_request(&mut self, request: &BrokerHandshakeRequest) -> IoResult<()> {
         let frame = encode_handshake_request(request.clone());
@@ -165,14 +330,20 @@ impl LocalControlChannel for UnixStreamLocalControlChannel {
 
     fn recv_response(&mut self) -> IoResult<Option<ControlResponse<Self::SharedMemory>>> {
         match read_frame_with_deadline(&mut self.stream, None)? {
-            Some(frame) => decode_response(&frame)
-                .map(|response| {
-                    Some(ControlResponse {
-                        response,
-                        shared_memory: None,
-                    })
-                })
-                .map_err(wire_error),
+            Some(frame) => {
+                let response = decode_response(&frame).map_err(wire_error)?;
+                let shared_memory = if response_has_shared_memory(&response) {
+                    Some(UnixSharedMemory::from_received_fd(receive_fd(
+                        &self.stream,
+                    )?)?)
+                } else {
+                    None
+                };
+                Ok(Some(ControlResponse {
+                    response,
+                    shared_memory,
+                }))
+            }
             None => Ok(None),
         }
     }
@@ -180,7 +351,7 @@ impl LocalControlChannel for UnixStreamLocalControlChannel {
 
 impl HostControlChannel for UnixStreamHostControlChannel {
     type Error = Error;
-    type SharedMemory = NoSharedMemory;
+    type SharedMemory = UnixSharedMemory;
 
     fn peer_credential(&self) -> IoResult<PeerCredential> {
         // TODO(broker): replace the PoC placeholder with Unix peer credential extraction
@@ -218,17 +389,25 @@ impl HostControlChannel for UnixStreamHostControlChannel {
         }
     }
 
+    fn create_shared_memory(&mut self, length: usize) -> IoResult<Option<Self::SharedMemory>> {
+        UnixSharedMemory::create(length).map(Some)
+    }
+
     fn send_response(
         &mut self,
         response: &BrokerResponse,
         shared_memory: Option<&Self::SharedMemory>,
     ) -> IoResult<()> {
-        if shared_memory.is_some() {
+        if response_has_shared_memory(response) != shared_memory.is_some() {
             return Err(invalid_data(
-                "Unix transport does not support shared memory yet",
+                "broker response shared-memory attachment mismatch",
             ));
         }
-        write_frame_with_deadline(&mut self.stream, &encode_response(response.clone()), None)
+        write_frame_with_deadline(&mut self.stream, &encode_response(response.clone()), None)?;
+        if let Some(shared_memory) = shared_memory {
+            send_fd(&self.stream, shared_memory.fd.as_raw_fd())?;
+        }
+        Ok(())
     }
 }
 
@@ -326,6 +505,138 @@ fn write_all_with_deadline(
     Ok(())
 }
 
+fn response_has_shared_memory(response: &BrokerResponse) -> bool {
+    matches!(
+        response,
+        BrokerResponse::Pipe(litebox_broker_protocol::message::PipeResponse::Create(response))
+            if response.shared_memory
+    )
+}
+
+#[repr(C)]
+struct FdControlMessage {
+    header: libc::cmsghdr,
+    fds: [RawFd; 4],
+}
+
+fn send_fd(stream: &UnixStream, fd: RawFd) -> IoResult<()> {
+    let fd_size: libc::c_uint = std::mem::size_of::<RawFd>()
+        .try_into()
+        .expect("file descriptor size must fit in c_uint");
+    let marker = [SHARED_MEMORY_MARKER];
+    let mut io = libc::iovec {
+        iov_base: marker.as_ptr().cast_mut().cast(),
+        iov_len: marker.len(),
+    };
+    // SAFETY: A zeroed cmsghdr/iovec message is a valid starting state.
+    let mut control: FdControlMessage = unsafe { std::mem::zeroed() };
+    control.header.cmsg_level = libc::SOL_SOCKET;
+    control.header.cmsg_type = libc::SCM_RIGHTS;
+    // SAFETY: The requested control-message size contains exactly one RawFd.
+    control.header.cmsg_len = unsafe { libc::CMSG_LEN(fd_size) } as usize;
+    control.fds[0] = fd;
+    // SAFETY: A zeroed msghdr is valid before assigning all used fields.
+    let mut message: libc::msghdr = unsafe { std::mem::zeroed() };
+    message.msg_iov = &raw mut io;
+    message.msg_iovlen = 1;
+    message.msg_control = std::ptr::addr_of_mut!(control).cast();
+    // SAFETY: The requested space is backed by `control`.
+    message.msg_controllen = unsafe { libc::CMSG_SPACE(fd_size) } as usize;
+
+    loop {
+        // SAFETY: `message` points to live marker and control buffers for the
+        // duration of the call.
+        let sent = unsafe { libc::sendmsg(stream.as_raw_fd(), &raw const message, 0) };
+        if sent == 1 {
+            return Ok(());
+        }
+        if sent == 0 {
+            return Err(Error::new(
+                ErrorKind::WriteZero,
+                "failed to send shared-memory descriptor",
+            ));
+        }
+        let error = Error::last_os_error();
+        if error.kind() != ErrorKind::Interrupted {
+            return Err(error);
+        }
+    }
+}
+
+fn receive_fd(stream: &UnixStream) -> IoResult<OwnedFd> {
+    let mut marker = [0];
+    let mut io = libc::iovec {
+        iov_base: marker.as_mut_ptr().cast(),
+        iov_len: marker.len(),
+    };
+    // SAFETY: A zeroed control buffer and msghdr are valid starting states.
+    let mut control: FdControlMessage = unsafe { std::mem::zeroed() };
+    // SAFETY: A zeroed msghdr is valid before assigning all used fields.
+    let mut message: libc::msghdr = unsafe { std::mem::zeroed() };
+    message.msg_iov = &raw mut io;
+    message.msg_iovlen = 1;
+    message.msg_control = std::ptr::addr_of_mut!(control).cast();
+    message.msg_controllen = std::mem::size_of::<FdControlMessage>();
+
+    let received = loop {
+        // SAFETY: `message` points to live marker and control buffers for the
+        // duration of the call.
+        let received =
+            unsafe { libc::recvmsg(stream.as_raw_fd(), &raw mut message, libc::MSG_CMSG_CLOEXEC) };
+        if received >= 0 {
+            break received;
+        }
+        let error = Error::last_os_error();
+        if error.kind() != ErrorKind::Interrupted {
+            return Err(error);
+        }
+    };
+    if received == 0 {
+        return Err(Error::new(
+            ErrorKind::UnexpectedEof,
+            "broker closed before shared-memory descriptor",
+        ));
+    }
+    let mut received_fds = Vec::new();
+    // SAFETY: `message` contains the kernel-initialized control buffer from
+    // `recvmsg`; CMSG iteration stays within `msg_controllen`.
+    unsafe {
+        let mut header = libc::CMSG_FIRSTHDR(&raw const message);
+        while !header.is_null() {
+            if (*header).cmsg_level == libc::SOL_SOCKET && (*header).cmsg_type == libc::SCM_RIGHTS {
+                let header_length = libc::CMSG_LEN(0) as usize;
+                let data_length = (*header).cmsg_len.saturating_sub(header_length);
+                if !data_length.is_multiple_of(std::mem::size_of::<RawFd>()) {
+                    return Err(invalid_data("invalid SCM_RIGHTS payload length"));
+                }
+                let count = data_length / std::mem::size_of::<RawFd>();
+                let data = libc::CMSG_DATA(header);
+                for index in 0..count {
+                    let mut fd = std::mem::MaybeUninit::<RawFd>::uninit();
+                    std::ptr::copy_nonoverlapping(
+                        data.add(index * std::mem::size_of::<RawFd>()),
+                        fd.as_mut_ptr().cast::<u8>(),
+                        std::mem::size_of::<RawFd>(),
+                    );
+                    received_fds.push(OwnedFd::from_raw_fd(fd.assume_init()));
+                }
+            }
+            header = libc::CMSG_NXTHDR(&raw const message, header);
+        }
+    }
+    if message.msg_flags & libc::MSG_CTRUNC != 0 || received_fds.len() != 1 {
+        return Err(invalid_data(
+            "shared-memory response must contain exactly one descriptor",
+        ));
+    }
+    if received != 1 || marker[0] != SHARED_MEMORY_MARKER {
+        return Err(invalid_data("invalid shared-memory descriptor marker"));
+    }
+    Ok(received_fds
+        .pop()
+        .expect("exactly one descriptor was checked"))
+}
+
 fn refresh_stream_io_deadline(stream: &UnixStream, deadline: Option<Instant>) -> IoResult<()> {
     if let Some(deadline) = deadline {
         let timeout = io_timeout_for_deadline(deadline)?;
@@ -357,6 +668,11 @@ fn wire_error(error: WireError) -> Error {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use litebox_broker_protocol::ObjectHandle;
+    use litebox_broker_protocol::message::PipeResponse;
+    use litebox_broker_protocol::pipe::{
+        CreatePipeResponse, PIPE_SHARED_MEMORY_REGION_SIZE, PIPE_SHARED_MEMORY_SIZE,
+    };
 
     #[test]
     fn frame_round_trip() {
@@ -369,6 +685,42 @@ mod tests {
                 .unwrap(),
             [1, 2, 3]
         );
+    }
+
+    #[test]
+    fn shared_memory_response_transfers_sealed_memfd() {
+        let (local_stream, host_stream) = UnixStream::pair().unwrap();
+        let mut local = UnixStreamLocalControlChannel::from_connected(local_stream);
+        let mut host = UnixStreamHostControlChannel::from_accepted(host_stream);
+        let host_memory = host
+            .create_shared_memory(PIPE_SHARED_MEMORY_SIZE)
+            .unwrap()
+            .unwrap();
+        host_memory.write(0, &[1, 2, 3]).unwrap();
+        let response = BrokerResponse::Pipe(PipeResponse::Create(CreatePipeResponse {
+            read_handle: ObjectHandle(1),
+            write_handle: ObjectHandle(2),
+            shared_memory: true,
+        }));
+
+        host.send_response(&response, Some(&host_memory)).unwrap();
+        let received = local.recv_response().unwrap().unwrap();
+
+        assert_eq!(received.response, response);
+        let local_memory = received.shared_memory.unwrap();
+        let mut data = [0; 3];
+        local_memory.read(0, &mut data).unwrap();
+        assert_eq!(data, [1, 2, 3]);
+        local_memory
+            .write(PIPE_SHARED_MEMORY_REGION_SIZE, &[4, 5, 6])
+            .unwrap();
+        host_memory
+            .read(PIPE_SHARED_MEMORY_REGION_SIZE, &mut data)
+            .unwrap();
+        assert_eq!(data, [4, 5, 6]);
+        // SAFETY: `F_GETFD` reads descriptor flags from a valid owned fd.
+        let descriptor_flags = unsafe { libc::fcntl(local_memory.fd.as_raw_fd(), libc::F_GETFD) };
+        assert_ne!(descriptor_flags & libc::FD_CLOEXEC, 0);
     }
 
     #[test]

--- a/litebox_platform_linux_userland/src/lib.rs
+++ b/litebox_platform_linux_userland/src/lib.rs
@@ -508,6 +508,39 @@ impl LinuxUserland {
                     .unwrap(),
                 ],
             ),
+            // Broker shared-memory responses receive one descriptor with
+            // close-on-exec and validate that its memfd size is sealed.
+            (
+                libc::SYS_recvmsg,
+                vec![
+                    SeccompRule::new(vec![
+                        SeccompCondition::new(
+                            2,
+                            SeccompCmpArgLen::Dword,
+                            SeccompCmpOp::Eq,
+                            libc::MSG_CMSG_CLOEXEC.cast_unsigned().into(),
+                        )
+                        .unwrap(),
+                    ])
+                    .unwrap(),
+                ],
+            ),
+            (libc::SYS_fstat, vec![]),
+            (
+                libc::SYS_fcntl,
+                vec![
+                    SeccompRule::new(vec![
+                        SeccompCondition::new(
+                            1,
+                            SeccompCmpArgLen::Dword,
+                            SeccompCmpOp::Eq,
+                            libc::F_GET_SEALS.cast_unsigned().into(),
+                        )
+                        .unwrap(),
+                    ])
+                    .unwrap(),
+                ],
+            ),
             (libc::SYS_close, vec![]),
         ];
         let rule_map: std::collections::BTreeMap<i64, Vec<SeccompRule>> =


### PR DESCRIPTION
## Summary
- create one sealed memfd per broker pipe and transfer it with SCM_RIGHTS
- map separate read and write staging regions on both control-channel peers
- allow only the Linux-userland syscalls needed to receive and validate attachments
- cover two-way mapping visibility and the runner broker integration path

## Stack
1. #1049 — protocol foundation
2. #1048 — broker-host staging
3. #1051 — broker-local data path
4. **#1050** — Unix transport enablement