### PR TITLE
Use shared memory for broker pipes

### DIFF
--- a/litebox/src/event/counter.rs
+++ b/litebox/src/event/counter.rs
@@ -201,14 +201,17 @@ mod tests {
         let consume_attempts = Arc::new(AtomicUsize::new(0));
         let read_ready = Arc::new(AtomicBool::new(false));
         let request_count = Arc::new(AtomicUsize::new(0));
-        let local = BrokerLocal::negotiate(FakeLocalControlChannel {
-            next_handle: handle.0,
-            consume_attempts: consume_attempts.clone(),
-            read_ready: read_ready.clone(),
-            request_count,
-            fail_requests: Arc::new(AtomicBool::new(false)),
-            last_request: None,
-        })
+        let local = BrokerLocal::negotiate(
+            FakeLocalControlChannel {
+                next_handle: handle.0,
+                consume_attempts: consume_attempts.clone(),
+                read_ready: read_ready.clone(),
+                request_count,
+                fail_requests: Arc::new(AtomicBool::new(false)),
+                last_request: None,
+            },
+            Arc::new(TestSharedMemory),
+        )
         .unwrap();
         let litebox = LiteBox::new_with_broker_local(platform, local);
         let counter = Arc::new(EventCounter::new(&litebox, 0).unwrap());
@@ -257,14 +260,17 @@ mod tests {
         let handle = ObjectHandle(7);
         let consume_attempts = Arc::new(AtomicUsize::new(0));
         let request_count = Arc::new(AtomicUsize::new(0));
-        let local = BrokerLocal::negotiate(FakeLocalControlChannel {
-            next_handle: handle.0,
-            consume_attempts: Arc::clone(&consume_attempts),
-            read_ready: Arc::new(AtomicBool::new(false)),
-            request_count: Arc::clone(&request_count),
-            fail_requests: Arc::new(AtomicBool::new(false)),
-            last_request: None,
-        })
+        let local = BrokerLocal::negotiate(
+            FakeLocalControlChannel {
+                next_handle: handle.0,
+                consume_attempts: Arc::clone(&consume_attempts),
+                read_ready: Arc::new(AtomicBool::new(false)),
+                request_count: Arc::clone(&request_count),
+                fail_requests: Arc::new(AtomicBool::new(false)),
+                last_request: None,
+            },
+            Arc::new(TestSharedMemory),
+        )
         .unwrap();
         let litebox = Arc::new(LiteBox::new_with_broker_local(platform, local));
         let counter = Arc::new(EventCounter::new(&litebox, 0).unwrap());
@@ -306,14 +312,17 @@ mod tests {
         let handle = ObjectHandle(7);
         let request_count = Arc::new(AtomicUsize::new(0));
         let fail_requests = Arc::new(AtomicBool::new(false));
-        let local = BrokerLocal::negotiate(FakeLocalControlChannel {
-            next_handle: handle.0,
-            consume_attempts: Arc::new(AtomicUsize::new(0)),
-            read_ready: Arc::new(AtomicBool::new(false)),
-            request_count: Arc::clone(&request_count),
-            fail_requests: Arc::clone(&fail_requests),
-            last_request: None,
-        })
+        let local = BrokerLocal::negotiate(
+            FakeLocalControlChannel {
+                next_handle: handle.0,
+                consume_attempts: Arc::new(AtomicUsize::new(0)),
+                read_ready: Arc::new(AtomicBool::new(false)),
+                request_count: Arc::clone(&request_count),
+                fail_requests: Arc::clone(&fail_requests),
+                last_request: None,
+            },
+            Arc::new(TestSharedMemory),
+        )
         .unwrap();
         let litebox = LiteBox::new_with_broker_local(platform, local);
         let first = EventCounter::new(&litebox, 0).unwrap();
@@ -340,14 +349,17 @@ mod tests {
         let platform = MockPlatform::new();
         let handle = ObjectHandle(7);
         let request_count = Arc::new(AtomicUsize::new(0));
-        let local = BrokerLocal::negotiate(FakeLocalControlChannel {
-            next_handle: handle.0,
-            consume_attempts: Arc::new(AtomicUsize::new(0)),
-            read_ready: Arc::new(AtomicBool::new(false)),
-            request_count: Arc::clone(&request_count),
-            fail_requests: Arc::new(AtomicBool::new(false)),
-            last_request: None,
-        })
+        let local = BrokerLocal::negotiate(
+            FakeLocalControlChannel {
+                next_handle: handle.0,
+                consume_attempts: Arc::new(AtomicUsize::new(0)),
+                read_ready: Arc::new(AtomicBool::new(false)),
+                request_count: Arc::clone(&request_count),
+                fail_requests: Arc::new(AtomicBool::new(false)),
+                last_request: None,
+            },
+            Arc::new(TestSharedMemory),
+        )
         .unwrap();
         let litebox = LiteBox::new_with_broker_local(platform, local);
         let counter = EventCounter::new(&litebox, 0).unwrap();
@@ -398,6 +410,32 @@ mod tests {
         request_count: Arc<AtomicUsize>,
         fail_requests: Arc<AtomicBool>,
         last_request: Option<BrokerRequest>,
+    }
+
+    struct TestSharedMemory;
+
+    impl litebox_broker_protocol::shared_memory::SharedMemory for TestSharedMemory {
+        fn len(&self) -> usize {
+            litebox_broker_protocol::pipe::PIPE_TRANSFER_BUFFER_SIZE
+        }
+
+        fn read(
+            &self,
+            _offset: usize,
+            _destination: &mut [u8],
+        ) -> core::result::Result<(), litebox_broker_protocol::shared_memory::SharedMemoryError>
+        {
+            unreachable!("event tests do not access shared memory")
+        }
+
+        fn write(
+            &self,
+            _offset: usize,
+            _source: &[u8],
+        ) -> core::result::Result<(), litebox_broker_protocol::shared_memory::SharedMemoryError>
+        {
+            unreachable!("event tests do not access shared memory")
+        }
     }
 
     impl LocalControlChannel for FakeLocalControlChannel {

--- a/litebox/src/event/counter.rs
+++ b/litebox/src/event/counter.rs
@@ -210,7 +210,7 @@ mod tests {
                 fail_requests: Arc::new(AtomicBool::new(false)),
                 last_request: None,
             },
-            Arc::new(TestSharedMemory),
+            |_| Ok(Arc::new(TestSharedMemory)),
         )
         .unwrap();
         let litebox = LiteBox::new_with_broker_local(platform, local);
@@ -269,7 +269,7 @@ mod tests {
                 fail_requests: Arc::new(AtomicBool::new(false)),
                 last_request: None,
             },
-            Arc::new(TestSharedMemory),
+            |_| Ok(Arc::new(TestSharedMemory)),
         )
         .unwrap();
         let litebox = Arc::new(LiteBox::new_with_broker_local(platform, local));
@@ -321,7 +321,7 @@ mod tests {
                 fail_requests: Arc::clone(&fail_requests),
                 last_request: None,
             },
-            Arc::new(TestSharedMemory),
+            |_| Ok(Arc::new(TestSharedMemory)),
         )
         .unwrap();
         let litebox = LiteBox::new_with_broker_local(platform, local);
@@ -358,7 +358,7 @@ mod tests {
                 fail_requests: Arc::new(AtomicBool::new(false)),
                 last_request: None,
             },
-            Arc::new(TestSharedMemory),
+            |_| Ok(Arc::new(TestSharedMemory)),
         )
         .unwrap();
         let litebox = LiteBox::new_with_broker_local(platform, local);

--- a/litebox/src/event/counter.rs
+++ b/litebox/src/event/counter.rs
@@ -210,7 +210,7 @@ mod tests {
                 fail_requests: Arc::new(AtomicBool::new(false)),
                 last_request: None,
             },
-            |_| Ok(Arc::new(TestSharedMemory)),
+            |_| Ok(Arc::new(NoopSharedMemory)),
         )
         .unwrap();
         let litebox = LiteBox::new_with_broker_local(platform, local);
@@ -269,7 +269,7 @@ mod tests {
                 fail_requests: Arc::new(AtomicBool::new(false)),
                 last_request: None,
             },
-            |_| Ok(Arc::new(TestSharedMemory)),
+            |_| Ok(Arc::new(NoopSharedMemory)),
         )
         .unwrap();
         let litebox = Arc::new(LiteBox::new_with_broker_local(platform, local));
@@ -321,7 +321,7 @@ mod tests {
                 fail_requests: Arc::clone(&fail_requests),
                 last_request: None,
             },
-            |_| Ok(Arc::new(TestSharedMemory)),
+            |_| Ok(Arc::new(NoopSharedMemory)),
         )
         .unwrap();
         let litebox = LiteBox::new_with_broker_local(platform, local);
@@ -358,7 +358,7 @@ mod tests {
                 fail_requests: Arc::new(AtomicBool::new(false)),
                 last_request: None,
             },
-            |_| Ok(Arc::new(TestSharedMemory)),
+            |_| Ok(Arc::new(NoopSharedMemory)),
         )
         .unwrap();
         let litebox = LiteBox::new_with_broker_local(platform, local);
@@ -412,9 +412,9 @@ mod tests {
         last_request: Option<BrokerRequest>,
     }
 
-    struct TestSharedMemory;
+    struct NoopSharedMemory;
 
-    impl litebox_broker_protocol::shared_memory::SharedMemory for TestSharedMemory {
+    impl litebox_broker_protocol::shared_memory::SharedMemory for NoopSharedMemory {
         fn len(&self) -> usize {
             litebox_broker_protocol::pipe::PIPE_TRANSFER_BUFFER_SIZE
         }
@@ -422,10 +422,11 @@ mod tests {
         fn read(
             &self,
             _offset: usize,
-            _destination: &mut [u8],
+            destination: &mut [u8],
         ) -> core::result::Result<(), litebox_broker_protocol::shared_memory::SharedMemoryError>
         {
-            unreachable!("event tests do not access shared memory")
+            destination.fill(0);
+            Ok(())
         }
 
         fn write(
@@ -434,7 +435,7 @@ mod tests {
             _source: &[u8],
         ) -> core::result::Result<(), litebox_broker_protocol::shared_memory::SharedMemoryError>
         {
-            unreachable!("event tests do not access shared memory")
+            Ok(())
         }
     }
 

--- a/litebox/src/pipes.rs
+++ b/litebox/src/pipes.rs
@@ -957,7 +957,7 @@ mod tests {
                 read_failure: ReadFailure::Transport,
                 force_transport,
             },
-            Arc::new(FakePipeSharedMemory),
+            |_| Ok(Arc::new(FakePipeSharedMemory)),
         )
         .unwrap();
         let litebox = crate::LiteBox::new_with_broker_local(platform, local);
@@ -1004,7 +1004,7 @@ mod tests {
                 read_failure: ReadFailure::WouldBlock,
                 force_transport: Arc::clone(&force_transport),
             },
-            Arc::new(FakePipeSharedMemory),
+            |_| Ok(Arc::new(FakePipeSharedMemory)),
         )
         .unwrap();
         let litebox = Arc::new(crate::LiteBox::new_with_broker_local(platform, local));

--- a/litebox/src/pipes.rs
+++ b/litebox/src/pipes.rs
@@ -957,7 +957,7 @@ mod tests {
                 read_failure: ReadFailure::Transport,
                 force_transport,
             },
-            |_| Ok(Arc::new(FakePipeSharedMemory)),
+            |_| Ok(Arc::new(NoopSharedMemory)),
         )
         .unwrap();
         let litebox = crate::LiteBox::new_with_broker_local(platform, local);
@@ -1004,7 +1004,7 @@ mod tests {
                 read_failure: ReadFailure::WouldBlock,
                 force_transport: Arc::clone(&force_transport),
             },
-            |_| Ok(Arc::new(FakePipeSharedMemory)),
+            |_| Ok(Arc::new(NoopSharedMemory)),
         )
         .unwrap();
         let litebox = Arc::new(crate::LiteBox::new_with_broker_local(platform, local));
@@ -1118,9 +1118,9 @@ mod tests {
     }
 
     #[derive(Clone, Copy)]
-    struct FakePipeSharedMemory;
+    struct NoopSharedMemory;
 
-    impl litebox_broker_protocol::shared_memory::SharedMemory for FakePipeSharedMemory {
+    impl litebox_broker_protocol::shared_memory::SharedMemory for NoopSharedMemory {
         fn len(&self) -> usize {
             litebox_broker_protocol::pipe::PIPE_TRANSFER_BUFFER_SIZE
         }

--- a/litebox/src/pipes.rs
+++ b/litebox/src/pipes.rs
@@ -932,7 +932,7 @@ mod tests {
     use litebox_broker_protocol::error::ErrorCode;
     use litebox_broker_protocol::message::{
         BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerNotification, BrokerRequest,
-        BrokerResponse, PipeRequest, PipeResponse, ReadinessNotification,
+        BrokerResponse, PipeRequest, ReadinessNotification,
     };
     use litebox_broker_protocol::pipe::CreatePipeResponse;
     use litebox_broker_protocol::readiness::ReadinessFlags;
@@ -950,12 +950,15 @@ mod tests {
         let platform = crate::platform::mock::MockPlatform::new();
         let request_count = Arc::new(AtomicUsize::new(0));
         let force_transport = Arc::new(AtomicBool::new(false));
-        let local = BrokerLocal::negotiate(FailingPipeChannel {
-            last_request: None,
-            request_count: Arc::clone(&request_count),
-            read_failure: ReadFailure::Transport,
-            force_transport,
-        })
+        let local = BrokerLocal::negotiate(
+            FailingPipeChannel {
+                last_request: None,
+                request_count: Arc::clone(&request_count),
+                read_failure: ReadFailure::Transport,
+                force_transport,
+            },
+            Arc::new(FakePipeSharedMemory),
+        )
         .unwrap();
         let litebox = crate::LiteBox::new_with_broker_local(platform, local);
         let pipes = super::Pipes::new(&litebox);
@@ -994,12 +997,15 @@ mod tests {
         let platform = crate::platform::mock::MockPlatform::new();
         let request_count = Arc::new(AtomicUsize::new(0));
         let force_transport = Arc::new(AtomicBool::new(false));
-        let local = BrokerLocal::negotiate(FailingPipeChannel {
-            last_request: None,
-            request_count: Arc::clone(&request_count),
-            read_failure: ReadFailure::WouldBlock,
-            force_transport: Arc::clone(&force_transport),
-        })
+        let local = BrokerLocal::negotiate(
+            FailingPipeChannel {
+                last_request: None,
+                request_count: Arc::clone(&request_count),
+                read_failure: ReadFailure::WouldBlock,
+                force_transport: Arc::clone(&force_transport),
+            },
+            Arc::new(FakePipeSharedMemory),
+        )
         .unwrap();
         let litebox = Arc::new(crate::LiteBox::new_with_broker_local(platform, local));
         let pipes = super::Pipes::new(&litebox);
@@ -1111,6 +1117,34 @@ mod tests {
         force_transport: Arc<AtomicBool>,
     }
 
+    #[derive(Clone, Copy)]
+    struct FakePipeSharedMemory;
+
+    impl litebox_broker_protocol::shared_memory::SharedMemory for FakePipeSharedMemory {
+        fn len(&self) -> usize {
+            litebox_broker_protocol::pipe::PIPE_TRANSFER_BUFFER_SIZE
+        }
+
+        fn read(
+            &self,
+            _offset: usize,
+            destination: &mut [u8],
+        ) -> core::result::Result<(), litebox_broker_protocol::shared_memory::SharedMemoryError>
+        {
+            destination.fill(0);
+            Ok(())
+        }
+
+        fn write(
+            &self,
+            _offset: usize,
+            _source: &[u8],
+        ) -> core::result::Result<(), litebox_broker_protocol::shared_memory::SharedMemoryError>
+        {
+            Ok(())
+        }
+    }
+
     #[derive(Clone, Copy, Debug)]
     enum ReadFailure {
         Transport,
@@ -1147,7 +1181,7 @@ mod tests {
         fn recv_response(&mut self) -> core::result::Result<Option<BrokerResponse>, Self::Error> {
             match self.last_request.take().unwrap() {
                 BrokerRequest::Pipe(PipeRequest::Create(_)) => Ok(Some(BrokerResponse::Pipe(
-                    PipeResponse::Create(CreatePipeResponse {
+                    litebox_broker_protocol::message::PipeResponse::Create(CreatePipeResponse {
                         read_handle: ObjectHandle(1),
                         write_handle: ObjectHandle(2),
                     }),

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -294,10 +294,10 @@ mod tests {
         serve_connection_rejects_handshake_request_after_negotiation(&broker);
         serve_connection_returns_channel_error_when_response_send_fails(&broker);
         serve_connection_returns_event_readiness_in_control_responses(&broker);
+        serve_connection_continues_after_recoverable_request_failure(&broker);
+        serve_connection_aborts_without_response_on_shared_memory_failure(&broker);
         active_request_closes_object_reference(&broker);
         association_shared_memory_stages_pipe_data(&broker);
-        shared_pipe_copy_failure_is_terminal(&broker);
-        pipe_requests_preserve_handle_errors(&broker);
     }
 
     fn serve_connection_negotiates_routes_one_request_and_returns_peer_closed(broker: &BrokerCore) {
@@ -533,6 +533,79 @@ mod tests {
         );
     }
 
+    fn serve_connection_continues_after_recoverable_request_failure(broker: &BrokerCore) {
+        let mut channel = FakeHostControlChannel::new(
+            std::vec::Vec::from([Ok(HostReceive::Message(BrokerHandshakeRequest {
+                protocol_version: BROKER_PROTOCOL_VERSION,
+            }))]),
+            std::vec::Vec::from([
+                Ok(HostReceive::Message(BrokerRequest::Pipe(
+                    PipeRequest::Read(ReadPipeRequest {
+                        handle: ObjectHandle(u64::MAX),
+                        length: 1,
+                    }),
+                ))),
+                Ok(HostReceive::Message(BrokerRequest::Event(
+                    EventRequest::Create(CreateEventRequest { initial_count: 0 }),
+                ))),
+                Ok(HostReceive::PeerClosed),
+            ]),
+        );
+        let mut notifications = FakeHostNotificationChannel::default();
+
+        assert_eq!(
+            serve_connection(
+                broker,
+                &mut channel,
+                &mut notifications,
+                &TestSharedMemory::new(PIPE_TRANSFER_BUFFER_SIZE),
+                |_| Ok(()),
+            )
+            .unwrap(),
+            ConnectionTermination::PeerClosed
+        );
+        assert_eq!(
+            channel.responses[0],
+            BrokerResponse::Error(ErrorCode::UnknownObject)
+        );
+        assert!(matches!(
+            channel.responses[1],
+            BrokerResponse::Event(EventResponse::Create(_))
+        ));
+    }
+
+    fn serve_connection_aborts_without_response_on_shared_memory_failure(broker: &BrokerCore) {
+        let mut channel = FakeHostControlChannel::new(
+            std::vec::Vec::from([Ok(HostReceive::Message(BrokerHandshakeRequest {
+                protocol_version: BROKER_PROTOCOL_VERSION,
+            }))]),
+            std::vec::Vec::from([Ok(HostReceive::Message(BrokerRequest::Pipe(
+                PipeRequest::Create(CreatePipeRequest {
+                    capacity: 64,
+                    atomic_write_size: 16,
+                }),
+            )))]),
+        );
+        channel.enqueue_write_request_after_pipe_create = true;
+        let mut notifications = FakeHostNotificationChannel::default();
+
+        assert!(matches!(
+            serve_connection(
+                broker,
+                &mut channel,
+                &mut notifications,
+                &FailingSharedMemory,
+                |_| Ok(()),
+            ),
+            Err(BrokerHostError::Broker(ErrorCode::Internal))
+        ));
+        assert_eq!(channel.responses.len(), 1);
+        assert!(matches!(
+            channel.responses[0],
+            BrokerResponse::Pipe(PipeResponse::Create(_))
+        ));
+    }
+
     fn active_request_closes_object_reference(broker: &BrokerCore) {
         let session = broker
             .create_session(CallerCredential::Unauthenticated)
@@ -612,18 +685,6 @@ mod tests {
         memory.read(0, &mut data).unwrap();
         assert_eq!(data, [1, 2, 3]);
 
-        let wrong_endpoint = handle_test_request_with_memory(
-            &session,
-            BrokerRequest::Pipe(PipeRequest::Read(ReadPipeRequest {
-                handle: response.write_handle,
-                length: 1,
-            })),
-            &memory,
-        );
-        assert_eq!(
-            wrong_endpoint,
-            BrokerResponse::Error(ErrorCode::InvalidRights)
-        );
         let invalid_range = handle_test_request_with_memory(
             &session,
             BrokerRequest::Pipe(PipeRequest::Write(WritePipeRequest {
@@ -635,63 +696,6 @@ mod tests {
         assert_eq!(
             invalid_range,
             BrokerResponse::Error(ErrorCode::MalformedRequest)
-        );
-    }
-
-    fn shared_pipe_copy_failure_is_terminal(broker: &BrokerCore) {
-        let session = broker
-            .create_session(CallerCredential::Unauthenticated)
-            .unwrap();
-        let (read_handle, write_handle) =
-            litebox_broker_core::pipe::create(&session, 64, 16).unwrap();
-        litebox_broker_core::pipe::write(&session, write_handle, &[1]).unwrap();
-        assert_eq!(
-            handle_pipe_request(
-                &session,
-                PipeRequest::Read(ReadPipeRequest {
-                    handle: read_handle,
-                    length: 1,
-                }),
-                &FailingSharedMemory,
-            ),
-            Err(RequestFailure::Abort(ErrorCode::Internal))
-        );
-    }
-
-    fn pipe_requests_preserve_handle_errors(broker: &BrokerCore) {
-        let session = broker
-            .create_session(CallerCredential::Unauthenticated)
-            .unwrap();
-        let event_handle = litebox_broker_core::event::create(&session, 0).unwrap();
-        let memory = TestSharedMemory::new(PIPE_TRANSFER_BUFFER_SIZE);
-
-        assert_eq!(
-            complete_request(
-                handle_pipe_request(
-                    &session,
-                    PipeRequest::Read(ReadPipeRequest {
-                        handle: event_handle,
-                        length: 1,
-                    }),
-                    &memory,
-                )
-                .map(BrokerResponse::Pipe)
-            ),
-            Ok(BrokerResponse::Error(ErrorCode::InvalidRights))
-        );
-        assert_eq!(
-            complete_request(
-                handle_pipe_request(
-                    &session,
-                    PipeRequest::Read(ReadPipeRequest {
-                        handle: ObjectHandle(u64::MAX),
-                        length: 1,
-                    }),
-                    &memory,
-                )
-                .map(BrokerResponse::Pipe)
-            ),
-            Ok(BrokerResponse::Error(ErrorCode::UnknownObject))
         );
     }
 
@@ -718,6 +722,7 @@ mod tests {
         handshake_responses: std::vec::Vec<BrokerHandshakeResponse>,
         responses: std::vec::Vec<BrokerResponse>,
         enqueue_readiness_requests_after_create: bool,
+        enqueue_write_request_after_pipe_create: bool,
         send_error: bool,
     }
 
@@ -734,6 +739,7 @@ mod tests {
                 handshake_responses: std::vec::Vec::new(),
                 responses: std::vec::Vec::new(),
                 enqueue_readiness_requests_after_create: false,
+                enqueue_write_request_after_pipe_create: false,
                 send_error: false,
             }
         }
@@ -799,6 +805,18 @@ mod tests {
                         EventRequest::Consume(ConsumeEventRequest {
                             handle: response.handle,
                             mode: EventConsumeMode::One,
+                        }),
+                    ))));
+                self.requests.push(Ok(HostReceive::PeerClosed));
+            }
+            if self.enqueue_write_request_after_pipe_create
+                && let BrokerResponse::Pipe(PipeResponse::Create(response)) = response
+            {
+                self.requests
+                    .push(Ok(HostReceive::Message(BrokerRequest::Pipe(
+                        PipeRequest::Write(WritePipeRequest {
+                            handle: response.write_handle,
+                            length: 1,
                         }),
                     ))));
                 self.requests.push(Ok(HostReceive::PeerClosed));

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -9,8 +9,12 @@
 
 #![no_std]
 
+extern crate alloc;
+
 #[cfg(test)]
 extern crate std;
+
+use alloc::vec::Vec;
 
 use litebox_broker_core::{BrokerCore, BrokerSession, CallerCredential};
 use litebox_broker_protocol::BROKER_PROTOCOL_VERSION;
@@ -23,7 +27,10 @@ use litebox_broker_protocol::message::{
     BrokerHandshakeResponse, BrokerRequest, BrokerResponse, EventRequest, EventResponse,
     PipeRequest, PipeResponse,
 };
-use litebox_broker_protocol::pipe::{CreatePipeResponse, ReadPipeResponse, WritePipeResponse};
+use litebox_broker_protocol::pipe::{
+    CreatePipeResponse, PIPE_TRANSFER_BUFFER_SIZE, ReadPipeResponse, WritePipeResponse,
+};
+use litebox_broker_protocol::shared_memory::SharedMemory;
 
 mod error;
 
@@ -37,15 +44,44 @@ pub use error::{BrokerHostError, Result};
 /// broker-initiated readiness wakeups are sent on the notification channel.
 /// Event mutations caused by control requests return readiness in their control
 /// response and do not also emit a duplicate notification.
+///
+/// `shared_memory` belongs to this association and is reused at offset zero for
+/// serialized pipe transfers.
 pub fn serve_connection<ControlChannel, NotificationChannel, ChannelError>(
     core: &BrokerCore,
     control_channel: &mut ControlChannel,
-    _notification_channel: &mut NotificationChannel,
+    notification_channel: &mut NotificationChannel,
+    shared_memory: &dyn SharedMemory,
 ) -> Result<ConnectionTermination, ChannelError>
 where
     ControlChannel: HostControlChannel<Error = ChannelError>,
     NotificationChannel: HostNotificationChannel<Error = ChannelError>,
 {
+    serve_connection_with_setup(
+        core,
+        control_channel,
+        notification_channel,
+        shared_memory,
+        |_| Ok(()),
+    )
+}
+
+/// Negotiates and serves one broker association, establishing deployment
+/// resources after version negotiation and before active requests.
+pub fn serve_connection_with_setup<ControlChannel, NotificationChannel, ChannelError>(
+    core: &BrokerCore,
+    control_channel: &mut ControlChannel,
+    _notification_channel: &mut NotificationChannel,
+    shared_memory: &dyn SharedMemory,
+    establish_association: impl FnOnce(&mut ControlChannel) -> core::result::Result<(), ChannelError>,
+) -> Result<ConnectionTermination, ChannelError>
+where
+    ControlChannel: HostControlChannel<Error = ChannelError>,
+    NotificationChannel: HostNotificationChannel<Error = ChannelError>,
+{
+    if shared_memory.len() != PIPE_TRANSFER_BUFFER_SIZE {
+        return Err(BrokerHostError::Broker(ErrorCode::Internal));
+    }
     let peer_credential = control_channel
         .peer_credential()
         .map_err(BrokerHostError::Channel)?;
@@ -54,7 +90,6 @@ where
         _ => return Err(BrokerHostError::Broker(ErrorCode::PolicyDenied)),
     };
     let session = core.create_session(caller_credential)?;
-
     loop {
         let request = match control_channel
             .recv_handshake_request()
@@ -86,6 +121,7 @@ where
             .send_handshake_response(&response)
             .map_err(BrokerHostError::Channel)?;
         if negotiated {
+            establish_association(control_channel).map_err(BrokerHostError::Channel)?;
             break;
         }
     }
@@ -105,7 +141,8 @@ where
             HostReceive::PeerClosed => break,
         };
 
-        let response = handle_request(&session, request);
+        let response =
+            handle_request(&session, request, shared_memory).map_err(BrokerHostError::Broker)?;
         control_channel
             .send_response(&response)
             .map_err(BrokerHostError::Channel)?;
@@ -114,53 +151,95 @@ where
     Ok(ConnectionTermination::PeerClosed)
 }
 
-fn handle_request(session: &BrokerSession, request: BrokerRequest) -> BrokerResponse {
+fn handle_request(
+    session: &BrokerSession,
+    request: BrokerRequest,
+    shared_memory: &dyn SharedMemory,
+) -> core::result::Result<BrokerResponse, ErrorCode> {
     match request {
         BrokerRequest::CloseObject(handle) => match session.close_object_reference(handle) {
-            Ok(()) => BrokerResponse::ObjectClosed,
-            Err(error) => BrokerResponse::Error(error.into()),
+            Ok(()) => Ok(BrokerResponse::ObjectClosed),
+            Err(error) => Ok(BrokerResponse::Error(error.into())),
         },
-        BrokerRequest::CheckReadiness(handle) => match session.check_readiness(handle) {
+        BrokerRequest::CheckReadiness(handle) => Ok(match session.check_readiness(handle) {
             Ok(readiness) => BrokerResponse::Readiness(readiness),
             Err(error) => BrokerResponse::Error(error.into()),
-        },
-        BrokerRequest::Event(request) => handle_event_request(session, request),
-        BrokerRequest::Pipe(request) => handle_pipe_request(session, request),
+        }),
+        BrokerRequest::Event(request) => Ok(handle_event_request(session, request)),
+        BrokerRequest::Pipe(PipeRequest::Create(request)) => Ok(
+            match litebox_broker_core::pipe::create(
+                session,
+                request.capacity,
+                request.atomic_write_size,
+            ) {
+                Ok((read_handle, write_handle)) => {
+                    BrokerResponse::Pipe(PipeResponse::Create(CreatePipeResponse {
+                        read_handle,
+                        write_handle,
+                    }))
+                }
+                Err(error) => BrokerResponse::Error(error.into()),
+            },
+        ),
+        BrokerRequest::Pipe(request) => handle_pipe_request(session, request, shared_memory),
     }
 }
 
-fn handle_pipe_request(session: &BrokerSession, request: PipeRequest) -> BrokerResponse {
-    let response = match request {
-        PipeRequest::Create(request) => {
-            litebox_broker_core::pipe::create(session, request.capacity, request.atomic_write_size)
-                .map(|(read_handle, write_handle)| {
-                    PipeResponse::Create(CreatePipeResponse {
-                        read_handle,
-                        write_handle,
-                    })
-                })
-        }
+fn handle_pipe_request(
+    session: &BrokerSession,
+    request: PipeRequest,
+    shared_memory: &dyn SharedMemory,
+) -> core::result::Result<BrokerResponse, ErrorCode> {
+    let response: core::result::Result<PipeResponse, ErrorCode> = match request {
+        PipeRequest::Create(_) => unreachable!("pipe creation is handled separately"),
         PipeRequest::Read(request) => {
-            litebox_broker_core::pipe::read(session, request.handle, request.length)
-                .map(|data| PipeResponse::Read(ReadPipeResponse { data }))
+            if request.length as usize > PIPE_TRANSFER_BUFFER_SIZE {
+                return Ok(BrokerResponse::Error(ErrorCode::MalformedRequest));
+            }
+            let data =
+                match litebox_broker_core::pipe::read(session, request.handle, request.length) {
+                    Ok(data) => data,
+                    Err(error) => return Ok(BrokerResponse::Error(error.into())),
+                };
+            shared_memory
+                .write(0, &data)
+                .map_err(|_| ErrorCode::Internal)?;
+            Ok(PipeResponse::Read(ReadPipeResponse {
+                read: data
+                    .len()
+                    .try_into()
+                    .map_err(|_| ErrorCode::ResourceExhausted)?,
+            }))
         }
         PipeRequest::Write(request) => {
-            litebox_broker_core::pipe::write(session, request.handle, &request.data).and_then(
-                |written| {
+            if request.length as usize > PIPE_TRANSFER_BUFFER_SIZE {
+                return Ok(BrokerResponse::Error(ErrorCode::MalformedRequest));
+            }
+            let length = request.length as usize;
+            let mut data = Vec::new();
+            if data.try_reserve_exact(length).is_err() {
+                return Ok(BrokerResponse::Error(ErrorCode::OutOfMemory));
+            }
+            data.resize(length, 0);
+            shared_memory
+                .read(0, &mut data)
+                .map_err(|_| ErrorCode::Internal)?;
+            litebox_broker_core::pipe::write(session, request.handle, &data)
+                .map_err(ErrorCode::from)
+                .and_then(|written| {
                     Ok(PipeResponse::Write(WritePipeResponse {
                         written: written
                             .try_into()
-                            .map_err(|_| litebox_broker_core::BrokerError::ResourceExhausted)?,
+                            .map_err(|_| ErrorCode::ResourceExhausted)?,
                     }))
-                },
-            )
+                })
         }
     };
 
-    match response {
+    Ok(match response {
         Ok(response) => BrokerResponse::Pipe(response),
-        Err(error) => BrokerResponse::Error(error.into()),
-    }
+        Err(error) => BrokerResponse::Error(error),
+    })
 }
 
 fn handle_event_request(session: &BrokerSession, request: EventRequest) -> BrokerResponse {
@@ -203,12 +282,17 @@ pub enum ConnectionTermination {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use core::cell::Cell;
     use litebox_broker_core::{ObjectRights, PolicyEngine};
+    use litebox_broker_protocol::channel::HostControlChannel;
     use litebox_broker_protocol::event::{
         AddEventRequest, ConsumeEventRequest, CreateEventRequest, EventConsumeMode,
     };
     use litebox_broker_protocol::message::{BrokerHandshakeRequest, BrokerNotification};
+    use litebox_broker_protocol::pipe::{CreatePipeRequest, ReadPipeRequest, WritePipeRequest};
+    use litebox_broker_protocol::shared_memory::SharedMemoryError;
     use litebox_broker_protocol::{ObjectHandle, ProtocolVersion};
+    use std::sync::{Arc, Mutex};
 
     #[test]
     fn host_request_handling_uses_one_broker_core() {
@@ -219,11 +303,15 @@ mod tests {
 
         serve_connection_negotiates_routes_one_request_and_returns_peer_closed(&broker);
         serve_connection_retries_after_version_mismatch(&broker);
+        serve_connection_skips_setup_after_version_mismatch(&broker);
         serve_connection_rejects_active_request_before_negotiation(&broker);
         serve_connection_rejects_handshake_request_after_negotiation(&broker);
         serve_connection_returns_channel_error_when_response_send_fails(&broker);
         serve_connection_returns_event_readiness_in_control_responses(&broker);
         active_request_closes_object_reference(&broker);
+        association_shared_memory_stages_pipe_data(&broker);
+        shared_pipe_copy_failure_is_terminal(&broker);
+        pipe_requests_preserve_handle_errors(&broker);
     }
 
     fn serve_connection_negotiates_routes_one_request_and_returns_peer_closed(broker: &BrokerCore) {
@@ -241,7 +329,13 @@ mod tests {
         let mut notifications = FakeHostNotificationChannel::default();
 
         assert_eq!(
-            serve_connection(broker, &mut channel, &mut notifications).unwrap(),
+            serve_connection(
+                broker,
+                &mut channel,
+                &mut notifications,
+                &TestSharedMemory::new(PIPE_TRANSFER_BUFFER_SIZE),
+            )
+            .unwrap(),
             ConnectionTermination::PeerClosed
         );
         assert_eq!(
@@ -272,7 +366,13 @@ mod tests {
         let mut notifications = FakeHostNotificationChannel::default();
 
         assert_eq!(
-            serve_connection(broker, &mut channel, &mut notifications).unwrap(),
+            serve_connection(
+                broker,
+                &mut channel,
+                &mut notifications,
+                &TestSharedMemory::new(PIPE_TRANSFER_BUFFER_SIZE),
+            )
+            .unwrap(),
             ConnectionTermination::PeerClosed
         );
         assert_eq!(
@@ -288,6 +388,42 @@ mod tests {
         );
     }
 
+    fn serve_connection_skips_setup_after_version_mismatch(broker: &BrokerCore) {
+        let mut channel = FakeHostControlChannel::new(
+            std::vec::Vec::from([
+                Ok(HostReceive::Message(BrokerHandshakeRequest {
+                    protocol_version: ProtocolVersion(BROKER_PROTOCOL_VERSION.0 - 1),
+                })),
+                Ok(HostReceive::PeerClosed),
+            ]),
+            std::vec::Vec::new(),
+        );
+        let mut notifications = FakeHostNotificationChannel::default();
+        let setup_called = Cell::new(false);
+
+        assert_eq!(
+            serve_connection_with_setup(
+                broker,
+                &mut channel,
+                &mut notifications,
+                &TestSharedMemory::new(PIPE_TRANSFER_BUFFER_SIZE),
+                |_| {
+                    setup_called.set(true);
+                    Ok(())
+                },
+            )
+            .unwrap(),
+            ConnectionTermination::PeerClosed
+        );
+        assert_eq!(
+            channel.handshake_responses,
+            [BrokerHandshakeResponse::VersionMismatch {
+                broker_protocol_version: BROKER_PROTOCOL_VERSION
+            }]
+        );
+        assert!(!setup_called.get());
+    }
+
     fn serve_connection_rejects_active_request_before_negotiation(broker: &BrokerCore) {
         let mut channel = FakeHostControlChannel::new(
             std::vec::Vec::from([Ok(HostReceive::ProtocolViolation)]),
@@ -296,7 +432,13 @@ mod tests {
         let mut notifications = FakeHostNotificationChannel::default();
 
         assert_eq!(
-            serve_connection(broker, &mut channel, &mut notifications).unwrap(),
+            serve_connection(
+                broker,
+                &mut channel,
+                &mut notifications,
+                &TestSharedMemory::new(PIPE_TRANSFER_BUFFER_SIZE),
+            )
+            .unwrap(),
             ConnectionTermination::ProtocolViolation
         );
         assert_eq!(
@@ -316,7 +458,13 @@ mod tests {
         let mut notifications = FakeHostNotificationChannel::default();
 
         assert_eq!(
-            serve_connection(broker, &mut channel, &mut notifications).unwrap(),
+            serve_connection(
+                broker,
+                &mut channel,
+                &mut notifications,
+                &TestSharedMemory::new(PIPE_TRANSFER_BUFFER_SIZE),
+            )
+            .unwrap(),
             ConnectionTermination::ProtocolViolation
         );
         assert_eq!(
@@ -341,7 +489,12 @@ mod tests {
         channel.send_error = true;
         let mut notifications = FakeHostNotificationChannel::default();
 
-        match serve_connection(broker, &mut channel, &mut notifications) {
+        match serve_connection(
+            broker,
+            &mut channel,
+            &mut notifications,
+            &TestSharedMemory::new(PIPE_TRANSFER_BUFFER_SIZE),
+        ) {
             Err(BrokerHostError::Channel(())) => {}
             result => panic!("unexpected serve result: {result:?}"),
         }
@@ -361,7 +514,13 @@ mod tests {
         let mut notifications = FakeHostNotificationChannel::default();
 
         assert_eq!(
-            serve_connection(broker, &mut channel, &mut notifications).unwrap(),
+            serve_connection(
+                broker,
+                &mut channel,
+                &mut notifications,
+                &TestSharedMemory::new(PIPE_TRANSFER_BUFFER_SIZE),
+            )
+            .unwrap(),
             ConnectionTermination::PeerClosed
         );
         assert!(notifications.notifications.is_empty());
@@ -386,7 +545,7 @@ mod tests {
         let session = broker
             .create_session(CallerCredential::Unauthenticated)
             .unwrap();
-        let response = handle_request(
+        let response = handle_test_request(
             &session,
             BrokerRequest::Event(EventRequest::Create(CreateEventRequest {
                 initial_count: 0,
@@ -398,20 +557,158 @@ mod tests {
         let handle = response.handle;
 
         assert_eq!(
-            handle_request(&session, BrokerRequest::CloseObject(handle)),
+            handle_test_request(&session, BrokerRequest::CloseObject(handle)),
             BrokerResponse::ObjectClosed
         );
         assert_eq!(
-            handle_request(&session, BrokerRequest::CheckReadiness(handle)),
+            handle_test_request(&session, BrokerRequest::CheckReadiness(handle)),
             BrokerResponse::Error(ErrorCode::UnknownObject)
         );
         assert_eq!(
-            handle_request(
+            handle_test_request(
                 &session,
                 BrokerRequest::CloseObject(ObjectHandle(handle.0 + 1))
             ),
             BrokerResponse::Error(ErrorCode::UnknownObject)
         );
+    }
+
+    fn association_shared_memory_stages_pipe_data(broker: &BrokerCore) {
+        let session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let memory = TestSharedMemory::new(PIPE_TRANSFER_BUFFER_SIZE);
+        let created = handle_request(
+            &session,
+            BrokerRequest::Pipe(PipeRequest::Create(CreatePipeRequest {
+                capacity: 64,
+                atomic_write_size: 16,
+            })),
+            &memory,
+        )
+        .unwrap();
+        let BrokerResponse::Pipe(PipeResponse::Create(response)) = created else {
+            panic!("expected successful pipe creation");
+        };
+
+        memory.write(0, &[1, 2, 3]).unwrap();
+        let write = handle_request(
+            &session,
+            BrokerRequest::Pipe(PipeRequest::Write(WritePipeRequest {
+                handle: response.write_handle,
+                length: 3,
+            })),
+            &memory,
+        )
+        .unwrap();
+        assert_eq!(
+            write,
+            BrokerResponse::Pipe(PipeResponse::Write(WritePipeResponse { written: 3 }))
+        );
+
+        let read = handle_request(
+            &session,
+            BrokerRequest::Pipe(PipeRequest::Read(ReadPipeRequest {
+                handle: response.read_handle,
+                length: 3,
+            })),
+            &memory,
+        )
+        .unwrap();
+        assert_eq!(
+            read,
+            BrokerResponse::Pipe(PipeResponse::Read(ReadPipeResponse { read: 3 }))
+        );
+        let mut data = [0; 3];
+        memory.read(0, &mut data).unwrap();
+        assert_eq!(data, [1, 2, 3]);
+
+        let wrong_endpoint = handle_request(
+            &session,
+            BrokerRequest::Pipe(PipeRequest::Read(ReadPipeRequest {
+                handle: response.write_handle,
+                length: 1,
+            })),
+            &memory,
+        )
+        .unwrap();
+        assert_eq!(
+            wrong_endpoint,
+            BrokerResponse::Error(ErrorCode::InvalidRights)
+        );
+        let invalid_range = handle_request(
+            &session,
+            BrokerRequest::Pipe(PipeRequest::Write(WritePipeRequest {
+                handle: response.write_handle,
+                length: u32::try_from(PIPE_TRANSFER_BUFFER_SIZE).unwrap() + 1,
+            })),
+            &memory,
+        )
+        .unwrap();
+        assert_eq!(
+            invalid_range,
+            BrokerResponse::Error(ErrorCode::MalformedRequest)
+        );
+    }
+
+    fn shared_pipe_copy_failure_is_terminal(broker: &BrokerCore) {
+        let session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let (read_handle, write_handle) =
+            litebox_broker_core::pipe::create(&session, 64, 16).unwrap();
+        litebox_broker_core::pipe::write(&session, write_handle, &[1]).unwrap();
+        assert_eq!(
+            handle_pipe_request(
+                &session,
+                PipeRequest::Read(ReadPipeRequest {
+                    handle: read_handle,
+                    length: 1,
+                }),
+                &FailingSharedMemory,
+            ),
+            Err(ErrorCode::Internal)
+        );
+    }
+
+    fn pipe_requests_preserve_handle_errors(broker: &BrokerCore) {
+        let session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let event_handle = litebox_broker_core::event::create(&session, 0).unwrap();
+        let memory = TestSharedMemory::new(PIPE_TRANSFER_BUFFER_SIZE);
+
+        assert_eq!(
+            handle_pipe_request(
+                &session,
+                PipeRequest::Read(ReadPipeRequest {
+                    handle: event_handle,
+                    length: 1,
+                }),
+                &memory,
+            ),
+            Ok(BrokerResponse::Error(ErrorCode::InvalidRights))
+        );
+        assert_eq!(
+            handle_pipe_request(
+                &session,
+                PipeRequest::Read(ReadPipeRequest {
+                    handle: ObjectHandle(u64::MAX),
+                    length: 1,
+                }),
+                &memory,
+            ),
+            Ok(BrokerResponse::Error(ErrorCode::UnknownObject))
+        );
+    }
+
+    fn handle_test_request(session: &BrokerSession, request: BrokerRequest) -> BrokerResponse {
+        handle_request(
+            session,
+            request,
+            &TestSharedMemory::new(PIPE_TRANSFER_BUFFER_SIZE),
+        )
+        .unwrap()
     }
 
     struct FakeHostControlChannel {
@@ -508,6 +805,77 @@ mod tests {
             }
             self.responses.push(response.clone());
             Ok(())
+        }
+    }
+
+    #[derive(Clone)]
+    struct TestSharedMemory(Arc<Mutex<Vec<u8>>>);
+
+    impl TestSharedMemory {
+        fn new(length: usize) -> Self {
+            Self(Arc::new(Mutex::new(std::vec![0; length])))
+        }
+    }
+
+    impl SharedMemory for TestSharedMemory {
+        fn len(&self) -> usize {
+            self.0.lock().unwrap().len()
+        }
+
+        fn read(
+            &self,
+            offset: usize,
+            destination: &mut [u8],
+        ) -> core::result::Result<(), SharedMemoryError> {
+            let memory = self.0.lock().unwrap();
+            let end = offset
+                .checked_add(destination.len())
+                .ok_or(SharedMemoryError::InvalidRange)?;
+            let source = memory
+                .get(offset..end)
+                .ok_or(SharedMemoryError::InvalidRange)?;
+            destination.copy_from_slice(source);
+            Ok(())
+        }
+
+        fn write(
+            &self,
+            offset: usize,
+            source: &[u8],
+        ) -> core::result::Result<(), SharedMemoryError> {
+            let mut memory = self.0.lock().unwrap();
+            let end = offset
+                .checked_add(source.len())
+                .ok_or(SharedMemoryError::InvalidRange)?;
+            let destination = memory
+                .get_mut(offset..end)
+                .ok_or(SharedMemoryError::InvalidRange)?;
+            destination.copy_from_slice(source);
+            Ok(())
+        }
+    }
+
+    struct FailingSharedMemory;
+
+    impl SharedMemory for FailingSharedMemory {
+        fn len(&self) -> usize {
+            PIPE_TRANSFER_BUFFER_SIZE
+        }
+
+        fn read(
+            &self,
+            _offset: usize,
+            _destination: &mut [u8],
+        ) -> core::result::Result<(), SharedMemoryError> {
+            Err(SharedMemoryError::InvalidRange)
+        }
+
+        fn write(
+            &self,
+            _offset: usize,
+            _source: &[u8],
+        ) -> core::result::Result<(), SharedMemoryError> {
+            Err(SharedMemoryError::InvalidRange)
         }
     }
 

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -46,29 +46,9 @@ pub use error::{BrokerHostError, Result};
 /// response and do not also emit a duplicate notification.
 ///
 /// `shared_memory` belongs to this association and is reused at offset zero for
-/// serialized pipe transfers.
+/// serialized pipe transfers. `establish_association` runs after version
+/// negotiation and before active requests begin.
 pub fn serve_connection<ControlChannel, NotificationChannel, ChannelError>(
-    core: &BrokerCore,
-    control_channel: &mut ControlChannel,
-    notification_channel: &mut NotificationChannel,
-    shared_memory: &dyn SharedMemory,
-) -> Result<ConnectionTermination, ChannelError>
-where
-    ControlChannel: HostControlChannel<Error = ChannelError>,
-    NotificationChannel: HostNotificationChannel<Error = ChannelError>,
-{
-    serve_connection_with_setup(
-        core,
-        control_channel,
-        notification_channel,
-        shared_memory,
-        |_| Ok(()),
-    )
-}
-
-/// Negotiates and serves one broker association, establishing deployment
-/// resources after version negotiation and before active requests.
-pub fn serve_connection_with_setup<ControlChannel, NotificationChannel, ChannelError>(
     core: &BrokerCore,
     control_channel: &mut ControlChannel,
     _notification_channel: &mut NotificationChannel,
@@ -334,6 +314,7 @@ mod tests {
                 &mut channel,
                 &mut notifications,
                 &TestSharedMemory::new(PIPE_TRANSFER_BUFFER_SIZE),
+                |_| Ok(()),
             )
             .unwrap(),
             ConnectionTermination::PeerClosed
@@ -371,6 +352,7 @@ mod tests {
                 &mut channel,
                 &mut notifications,
                 &TestSharedMemory::new(PIPE_TRANSFER_BUFFER_SIZE),
+                |_| Ok(()),
             )
             .unwrap(),
             ConnectionTermination::PeerClosed
@@ -402,7 +384,7 @@ mod tests {
         let setup_called = Cell::new(false);
 
         assert_eq!(
-            serve_connection_with_setup(
+            serve_connection(
                 broker,
                 &mut channel,
                 &mut notifications,
@@ -437,6 +419,7 @@ mod tests {
                 &mut channel,
                 &mut notifications,
                 &TestSharedMemory::new(PIPE_TRANSFER_BUFFER_SIZE),
+                |_| Ok(()),
             )
             .unwrap(),
             ConnectionTermination::ProtocolViolation
@@ -463,6 +446,7 @@ mod tests {
                 &mut channel,
                 &mut notifications,
                 &TestSharedMemory::new(PIPE_TRANSFER_BUFFER_SIZE),
+                |_| Ok(()),
             )
             .unwrap(),
             ConnectionTermination::ProtocolViolation
@@ -494,6 +478,7 @@ mod tests {
             &mut channel,
             &mut notifications,
             &TestSharedMemory::new(PIPE_TRANSFER_BUFFER_SIZE),
+            |_| Ok(()),
         ) {
             Err(BrokerHostError::Channel(())) => {}
             result => panic!("unexpected serve result: {result:?}"),
@@ -519,6 +504,7 @@ mod tests {
                 &mut channel,
                 &mut notifications,
                 &TestSharedMemory::new(PIPE_TRANSFER_BUFFER_SIZE),
+                |_| Ok(()),
             )
             .unwrap(),
             ConnectionTermination::PeerClosed

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -121,8 +121,8 @@ where
             HostReceive::PeerClosed => break,
         };
 
-        let response =
-            handle_request(&session, request, shared_memory).map_err(BrokerHostError::Broker)?;
+        let response = complete_request(handle_request(&session, request, shared_memory))
+            .map_err(BrokerHostError::Broker)?;
         control_channel
             .send_response(&response)
             .map_err(BrokerHostError::Channel)?;
@@ -131,37 +131,46 @@ where
     Ok(ConnectionTermination::PeerClosed)
 }
 
+type RequestResult<T> = core::result::Result<T, RequestFailure>;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RequestFailure {
+    /// Send an error response and continue serving the association.
+    Respond(ErrorCode),
+    /// Terminate the association without sending a response.
+    Abort(ErrorCode),
+}
+
+fn complete_request(
+    result: RequestResult<BrokerResponse>,
+) -> core::result::Result<BrokerResponse, ErrorCode> {
+    match result {
+        Ok(response) => Ok(response),
+        Err(RequestFailure::Respond(error)) => Ok(BrokerResponse::Error(error)),
+        Err(RequestFailure::Abort(error)) => Err(error),
+    }
+}
+
 fn handle_request(
     session: &BrokerSession,
     request: BrokerRequest,
     shared_memory: &dyn SharedMemory,
-) -> core::result::Result<BrokerResponse, ErrorCode> {
+) -> RequestResult<BrokerResponse> {
     match request {
-        BrokerRequest::CloseObject(handle) => match session.close_object_reference(handle) {
-            Ok(()) => Ok(BrokerResponse::ObjectClosed),
-            Err(error) => Ok(BrokerResponse::Error(error.into())),
-        },
-        BrokerRequest::CheckReadiness(handle) => Ok(match session.check_readiness(handle) {
-            Ok(readiness) => BrokerResponse::Readiness(readiness),
-            Err(error) => BrokerResponse::Error(error.into()),
-        }),
-        BrokerRequest::Event(request) => Ok(handle_event_request(session, request)),
-        BrokerRequest::Pipe(PipeRequest::Create(request)) => Ok(
-            match litebox_broker_core::pipe::create(
-                session,
-                request.capacity,
-                request.atomic_write_size,
-            ) {
-                Ok((read_handle, write_handle)) => {
-                    BrokerResponse::Pipe(PipeResponse::Create(CreatePipeResponse {
-                        read_handle,
-                        write_handle,
-                    }))
-                }
-                Err(error) => BrokerResponse::Error(error.into()),
-            },
-        ),
-        BrokerRequest::Pipe(request) => handle_pipe_request(session, request, shared_memory),
+        BrokerRequest::CloseObject(handle) => session
+            .close_object_reference(handle)
+            .map(|()| BrokerResponse::ObjectClosed)
+            .map_err(|error| RequestFailure::Respond(error.into())),
+        BrokerRequest::CheckReadiness(handle) => session
+            .check_readiness(handle)
+            .map(BrokerResponse::Readiness)
+            .map_err(|error| RequestFailure::Respond(error.into())),
+        BrokerRequest::Event(request) => {
+            handle_event_request(session, request).map(BrokerResponse::Event)
+        }
+        BrokerRequest::Pipe(request) => {
+            handle_pipe_request(session, request, shared_memory).map(BrokerResponse::Pipe)
+        }
     }
 }
 
@@ -169,82 +178,79 @@ fn handle_pipe_request(
     session: &BrokerSession,
     request: PipeRequest,
     shared_memory: &dyn SharedMemory,
-) -> core::result::Result<BrokerResponse, ErrorCode> {
-    let response: core::result::Result<PipeResponse, ErrorCode> = match request {
-        PipeRequest::Create(_) => unreachable!("pipe creation is handled separately"),
+) -> RequestResult<PipeResponse> {
+    match request {
+        PipeRequest::Create(request) => {
+            litebox_broker_core::pipe::create(session, request.capacity, request.atomic_write_size)
+                .map(|(read_handle, write_handle)| {
+                    PipeResponse::Create(CreatePipeResponse {
+                        read_handle,
+                        write_handle,
+                    })
+                })
+                .map_err(|error| RequestFailure::Respond(error.into()))
+        }
         PipeRequest::Read(request) => {
             if request.length as usize > PIPE_TRANSFER_BUFFER_SIZE {
-                return Ok(BrokerResponse::Error(ErrorCode::MalformedRequest));
+                return Err(RequestFailure::Respond(ErrorCode::MalformedRequest));
             }
-            let data =
-                match litebox_broker_core::pipe::read(session, request.handle, request.length) {
-                    Ok(data) => data,
-                    Err(error) => return Ok(BrokerResponse::Error(error.into())),
-                };
+            let data = litebox_broker_core::pipe::read(session, request.handle, request.length)
+                .map_err(|error| RequestFailure::Respond(error.into()))?;
             shared_memory
                 .write(0, &data)
-                .map_err(|_| ErrorCode::Internal)?;
+                .map_err(|_| RequestFailure::Abort(ErrorCode::Internal))?;
             Ok(PipeResponse::Read(ReadPipeResponse {
                 read: data
                     .len()
                     .try_into()
-                    .map_err(|_| ErrorCode::ResourceExhausted)?,
+                    .map_err(|_| RequestFailure::Abort(ErrorCode::ResourceExhausted))?,
             }))
         }
         PipeRequest::Write(request) => {
             if request.length as usize > PIPE_TRANSFER_BUFFER_SIZE {
-                return Ok(BrokerResponse::Error(ErrorCode::MalformedRequest));
+                return Err(RequestFailure::Respond(ErrorCode::MalformedRequest));
             }
             let length = request.length as usize;
             let mut data = Vec::new();
             if data.try_reserve_exact(length).is_err() {
-                return Ok(BrokerResponse::Error(ErrorCode::OutOfMemory));
+                return Err(RequestFailure::Respond(ErrorCode::OutOfMemory));
             }
             data.resize(length, 0);
             shared_memory
                 .read(0, &mut data)
-                .map_err(|_| ErrorCode::Internal)?;
+                .map_err(|_| RequestFailure::Abort(ErrorCode::Internal))?;
             litebox_broker_core::pipe::write(session, request.handle, &data)
-                .map_err(ErrorCode::from)
+                .map_err(|error| RequestFailure::Respond(error.into()))
                 .and_then(|written| {
                     Ok(PipeResponse::Write(WritePipeResponse {
                         written: written
                             .try_into()
-                            .map_err(|_| ErrorCode::ResourceExhausted)?,
+                            .map_err(|_| RequestFailure::Abort(ErrorCode::ResourceExhausted))?,
                     }))
                 })
         }
-    };
-
-    Ok(match response {
-        Ok(response) => BrokerResponse::Pipe(response),
-        Err(error) => BrokerResponse::Error(error),
-    })
+    }
 }
 
-fn handle_event_request(session: &BrokerSession, request: EventRequest) -> BrokerResponse {
+fn handle_event_request(
+    session: &BrokerSession,
+    request: EventRequest,
+) -> RequestResult<EventResponse> {
     match request {
         EventRequest::Create(request) => {
-            match litebox_broker_core::event::create(session, request.initial_count) {
-                Ok(handle) => {
-                    BrokerResponse::Event(EventResponse::Create(CreateEventResponse { handle }))
-                }
-                Err(error) => BrokerResponse::Error(error.into()),
-            }
+            litebox_broker_core::event::create(session, request.initial_count)
+                .map(|handle| EventResponse::Create(CreateEventResponse { handle }))
+                .map_err(|error| RequestFailure::Respond(error.into()))
         }
         EventRequest::Add(request) => {
-            match litebox_broker_core::event::add(session, request.handle, request.value) {
-                Ok(readiness) => {
-                    BrokerResponse::Event(EventResponse::Add(AddEventResponse { readiness }))
-                }
-                Err(error) => BrokerResponse::Error(error.into()),
-            }
+            litebox_broker_core::event::add(session, request.handle, request.value)
+                .map(|readiness| EventResponse::Add(AddEventResponse { readiness }))
+                .map_err(|error| RequestFailure::Respond(error.into()))
         }
         EventRequest::Consume(request) => {
-            match litebox_broker_core::event::consume(session, request.handle, request.mode) {
-                Ok(consumption) => BrokerResponse::Event(EventResponse::Consume(consumption)),
-                Err(error) => BrokerResponse::Error(error.into()),
-            }
+            litebox_broker_core::event::consume(session, request.handle, request.mode)
+                .map(EventResponse::Consume)
+                .map_err(|error| RequestFailure::Respond(error.into()))
         }
     }
 }
@@ -564,43 +570,40 @@ mod tests {
             .create_session(CallerCredential::Unauthenticated)
             .unwrap();
         let memory = TestSharedMemory::new(PIPE_TRANSFER_BUFFER_SIZE);
-        let created = handle_request(
+        let created = handle_test_request_with_memory(
             &session,
             BrokerRequest::Pipe(PipeRequest::Create(CreatePipeRequest {
                 capacity: 64,
                 atomic_write_size: 16,
             })),
             &memory,
-        )
-        .unwrap();
+        );
         let BrokerResponse::Pipe(PipeResponse::Create(response)) = created else {
             panic!("expected successful pipe creation");
         };
 
         memory.write(0, &[1, 2, 3]).unwrap();
-        let write = handle_request(
+        let write = handle_test_request_with_memory(
             &session,
             BrokerRequest::Pipe(PipeRequest::Write(WritePipeRequest {
                 handle: response.write_handle,
                 length: 3,
             })),
             &memory,
-        )
-        .unwrap();
+        );
         assert_eq!(
             write,
             BrokerResponse::Pipe(PipeResponse::Write(WritePipeResponse { written: 3 }))
         );
 
-        let read = handle_request(
+        let read = handle_test_request_with_memory(
             &session,
             BrokerRequest::Pipe(PipeRequest::Read(ReadPipeRequest {
                 handle: response.read_handle,
                 length: 3,
             })),
             &memory,
-        )
-        .unwrap();
+        );
         assert_eq!(
             read,
             BrokerResponse::Pipe(PipeResponse::Read(ReadPipeResponse { read: 3 }))
@@ -609,28 +612,26 @@ mod tests {
         memory.read(0, &mut data).unwrap();
         assert_eq!(data, [1, 2, 3]);
 
-        let wrong_endpoint = handle_request(
+        let wrong_endpoint = handle_test_request_with_memory(
             &session,
             BrokerRequest::Pipe(PipeRequest::Read(ReadPipeRequest {
                 handle: response.write_handle,
                 length: 1,
             })),
             &memory,
-        )
-        .unwrap();
+        );
         assert_eq!(
             wrong_endpoint,
             BrokerResponse::Error(ErrorCode::InvalidRights)
         );
-        let invalid_range = handle_request(
+        let invalid_range = handle_test_request_with_memory(
             &session,
             BrokerRequest::Pipe(PipeRequest::Write(WritePipeRequest {
                 handle: response.write_handle,
                 length: u32::try_from(PIPE_TRANSFER_BUFFER_SIZE).unwrap() + 1,
             })),
             &memory,
-        )
-        .unwrap();
+        );
         assert_eq!(
             invalid_range,
             BrokerResponse::Error(ErrorCode::MalformedRequest)
@@ -653,7 +654,7 @@ mod tests {
                 }),
                 &FailingSharedMemory,
             ),
-            Err(ErrorCode::Internal)
+            Err(RequestFailure::Abort(ErrorCode::Internal))
         );
     }
 
@@ -665,36 +666,49 @@ mod tests {
         let memory = TestSharedMemory::new(PIPE_TRANSFER_BUFFER_SIZE);
 
         assert_eq!(
-            handle_pipe_request(
-                &session,
-                PipeRequest::Read(ReadPipeRequest {
-                    handle: event_handle,
-                    length: 1,
-                }),
-                &memory,
+            complete_request(
+                handle_pipe_request(
+                    &session,
+                    PipeRequest::Read(ReadPipeRequest {
+                        handle: event_handle,
+                        length: 1,
+                    }),
+                    &memory,
+                )
+                .map(BrokerResponse::Pipe)
             ),
             Ok(BrokerResponse::Error(ErrorCode::InvalidRights))
         );
         assert_eq!(
-            handle_pipe_request(
-                &session,
-                PipeRequest::Read(ReadPipeRequest {
-                    handle: ObjectHandle(u64::MAX),
-                    length: 1,
-                }),
-                &memory,
+            complete_request(
+                handle_pipe_request(
+                    &session,
+                    PipeRequest::Read(ReadPipeRequest {
+                        handle: ObjectHandle(u64::MAX),
+                        length: 1,
+                    }),
+                    &memory,
+                )
+                .map(BrokerResponse::Pipe)
             ),
             Ok(BrokerResponse::Error(ErrorCode::UnknownObject))
         );
     }
 
     fn handle_test_request(session: &BrokerSession, request: BrokerRequest) -> BrokerResponse {
-        handle_request(
+        handle_test_request_with_memory(
             session,
             request,
             &TestSharedMemory::new(PIPE_TRANSFER_BUFFER_SIZE),
         )
-        .unwrap()
+    }
+
+    fn handle_test_request_with_memory(
+        session: &BrokerSession,
+        request: BrokerRequest,
+        shared_memory: &dyn SharedMemory,
+    ) -> BrokerResponse {
+        complete_request(handle_request(session, request, shared_memory)).unwrap()
     }
 
     struct FakeHostControlChannel {

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -46,14 +46,14 @@ pub use error::{BrokerHostError, Result};
 /// response and do not also emit a duplicate notification.
 ///
 /// `shared_memory` belongs to this association and is reused at offset zero for
-/// serialized pipe transfers. `establish_association` runs after version
+/// serialized pipe transfers. `send_shared_memory` runs after version
 /// negotiation and before active requests begin.
 pub fn serve_connection<ControlChannel, NotificationChannel, ChannelError>(
     core: &BrokerCore,
     control_channel: &mut ControlChannel,
     _notification_channel: &mut NotificationChannel,
     shared_memory: &dyn SharedMemory,
-    establish_association: impl FnOnce(&mut ControlChannel) -> core::result::Result<(), ChannelError>,
+    send_shared_memory: impl FnOnce(&mut ControlChannel) -> core::result::Result<(), ChannelError>,
 ) -> Result<ConnectionTermination, ChannelError>
 where
     ControlChannel: HostControlChannel<Error = ChannelError>,
@@ -101,7 +101,7 @@ where
             .send_handshake_response(&response)
             .map_err(BrokerHostError::Channel)?;
         if negotiated {
-            establish_association(control_channel).map_err(BrokerHostError::Channel)?;
+            send_shared_memory(control_channel).map_err(BrokerHostError::Channel)?;
             break;
         }
     }

--- a/litebox_broker_local/src/lib.rs
+++ b/litebox_broker_local/src/lib.rs
@@ -60,7 +60,7 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
     /// shared memory with an invalid size.
     pub fn negotiate(
         mut channel: Channel,
-        establish_shared_memory: impl FnOnce(
+        receive_shared_memory: impl FnOnce(
             &mut Channel,
         ) -> core::result::Result<
             Arc<dyn SharedMemory>,
@@ -87,7 +87,7 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
                     "broker returned unexpected negotiation response: {response:?}"
                 );
                 let shared_memory =
-                    establish_shared_memory(&mut channel).map_err(BrokerLocalError::Channel)?;
+                    receive_shared_memory(&mut channel).map_err(BrokerLocalError::Channel)?;
                 assert_eq!(
                     shared_memory.len(),
                     PIPE_TRANSFER_BUFFER_SIZE,

--- a/litebox_broker_local/src/lib.rs
+++ b/litebox_broker_local/src/lib.rs
@@ -50,20 +50,6 @@ pub struct BrokerNotifications<Channel: LocalNotificationChannel> {
 }
 
 impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
-    /// Negotiates the broker protocol over an already-connected control channel
-    /// with its associated shared memory.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the broker reports an unrecoverable error or returns a protocol
-    /// response that does not match the negotiation request.
-    pub fn negotiate(
-        channel: Channel,
-        shared_memory: Arc<dyn SharedMemory>,
-    ) -> Result<Self, Channel::Error> {
-        Self::negotiate_with_setup(channel, |_| Ok(shared_memory))
-    }
-
     /// Negotiates the broker protocol, then establishes the association shared
     /// memory before active requests begin.
     ///
@@ -72,7 +58,7 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
     /// Panics if the broker reports an unrecoverable error, returns a protocol
     /// response that does not match the negotiation request, or setup returns
     /// shared memory with an invalid size.
-    pub fn negotiate_with_setup(
+    pub fn negotiate(
         mut channel: Channel,
         establish_shared_memory: impl FnOnce(
             &mut Channel,
@@ -241,7 +227,7 @@ mod tests {
             }),
             None,
         );
-        let local = BrokerLocal::negotiate(channel, test_shared_memory()).unwrap();
+        let local = BrokerLocal::negotiate(channel, |_| Ok(test_shared_memory())).unwrap();
 
         assert_eq!(
             local.channel.sent_handshake_request,
@@ -346,7 +332,7 @@ mod tests {
             None,
         );
 
-        let _ = BrokerLocal::negotiate(channel, test_shared_memory());
+        let _ = BrokerLocal::negotiate(channel, |_| Ok(test_shared_memory()));
     }
 
     #[test]
@@ -375,7 +361,7 @@ mod tests {
 
         let setup_called = Cell::new(false);
         assert!(matches!(
-            BrokerLocal::negotiate_with_setup(channel, |_| {
+            BrokerLocal::negotiate(channel, |_| {
                 setup_called.set(true);
                 Ok(test_shared_memory())
             }),
@@ -392,7 +378,7 @@ mod tests {
             None,
         );
 
-        let _ = BrokerLocal::negotiate(channel, test_shared_memory());
+        let _ = BrokerLocal::negotiate(channel, |_| Ok(test_shared_memory()));
     }
 
     struct FakeControlChannel {

--- a/litebox_broker_local/src/lib.rs
+++ b/litebox_broker_local/src/lib.rs
@@ -227,7 +227,7 @@ mod tests {
             }),
             None,
         );
-        let local = BrokerLocal::negotiate(channel, |_| Ok(test_shared_memory())).unwrap();
+        let local = BrokerLocal::negotiate(channel, |_| Ok(noop_shared_memory())).unwrap();
 
         assert_eq!(
             local.channel.sent_handshake_request,
@@ -247,7 +247,7 @@ mod tests {
         let channel = FakeControlChannel::new(None, Some(response.clone()));
         let mut local = BrokerLocal {
             channel,
-            shared_memory: test_shared_memory(),
+            shared_memory: noop_shared_memory(),
         };
 
         assert_eq!(local.request(request.clone()).unwrap(), response);
@@ -262,7 +262,7 @@ mod tests {
         let channel = FakeControlChannel::new(None, Some(response.clone()));
         let mut local = BrokerLocal {
             channel,
-            shared_memory: test_shared_memory(),
+            shared_memory: noop_shared_memory(),
         };
 
         assert!(local.close_object(handle).is_ok());
@@ -278,7 +278,7 @@ mod tests {
             FakeControlChannel::new(None, Some(BrokerResponse::Error(ErrorCode::WouldBlock)));
         let mut local = BrokerLocal {
             channel,
-            shared_memory: test_shared_memory(),
+            shared_memory: noop_shared_memory(),
         };
 
         assert!(matches!(
@@ -297,7 +297,7 @@ mod tests {
             FakeControlChannel::new(None, Some(BrokerResponse::Error(ErrorCode::Internal)));
         let mut local = BrokerLocal {
             channel,
-            shared_memory: test_shared_memory(),
+            shared_memory: noop_shared_memory(),
         };
 
         let _ = local.request(request);
@@ -315,7 +315,7 @@ mod tests {
         );
         let mut local = BrokerLocal {
             channel,
-            shared_memory: test_shared_memory(),
+            shared_memory: noop_shared_memory(),
         };
 
         let _ = local.request(request);
@@ -332,7 +332,7 @@ mod tests {
             None,
         );
 
-        let _ = BrokerLocal::negotiate(channel, |_| Ok(test_shared_memory()));
+        let _ = BrokerLocal::negotiate(channel, |_| Ok(noop_shared_memory()));
     }
 
     #[test]
@@ -363,7 +363,7 @@ mod tests {
         assert!(matches!(
             BrokerLocal::negotiate(channel, |_| {
                 setup_called.set(true);
-                Ok(test_shared_memory())
+                Ok(noop_shared_memory())
             }),
             Err(BrokerLocalError::Broker(ErrorCode::UnsupportedVersion))
         ));
@@ -378,7 +378,7 @@ mod tests {
             None,
         );
 
-        let _ = BrokerLocal::negotiate(channel, |_| Ok(test_shared_memory()));
+        let _ = BrokerLocal::negotiate(channel, |_| Ok(noop_shared_memory()));
     }
 
     struct FakeControlChannel {
@@ -388,9 +388,9 @@ mod tests {
         response: Option<BrokerResponse>,
     }
 
-    struct TestSharedMemory;
+    struct NoopSharedMemory;
 
-    impl SharedMemory for TestSharedMemory {
+    impl SharedMemory for NoopSharedMemory {
         fn len(&self) -> usize {
             PIPE_TRANSFER_BUFFER_SIZE
         }
@@ -398,10 +398,11 @@ mod tests {
         fn read(
             &self,
             _offset: usize,
-            _destination: &mut [u8],
+            destination: &mut [u8],
         ) -> core::result::Result<(), litebox_broker_protocol::shared_memory::SharedMemoryError>
         {
-            unreachable!("shared memory is not used by these tests")
+            destination.fill(0);
+            Ok(())
         }
 
         fn write(
@@ -410,12 +411,12 @@ mod tests {
             _source: &[u8],
         ) -> core::result::Result<(), litebox_broker_protocol::shared_memory::SharedMemoryError>
         {
-            unreachable!("shared memory is not used by these tests")
+            Ok(())
         }
     }
 
-    fn test_shared_memory() -> Arc<dyn SharedMemory> {
-        Arc::new(TestSharedMemory)
+    fn noop_shared_memory() -> Arc<dyn SharedMemory> {
+        Arc::new(NoopSharedMemory)
     }
 
     impl FakeControlChannel {

--- a/litebox_broker_local/src/lib.rs
+++ b/litebox_broker_local/src/lib.rs
@@ -215,19 +215,26 @@ mod tests {
     use litebox_broker_protocol::ObjectHandle;
     use litebox_broker_protocol::ProtocolVersion;
     use litebox_broker_protocol::channel::LocalNotificationChannel;
-    use litebox_broker_protocol::event::{CreateEventRequest, CreateEventResponse};
-    use litebox_broker_protocol::message::{EventRequest, EventResponse, ReadinessNotification};
+    use litebox_broker_protocol::message::ReadinessNotification;
     use litebox_broker_protocol::readiness::ReadinessFlags;
 
     #[test]
-    fn negotiate_returns_active_local_connection() {
+    fn negotiate_runs_setup_after_response_before_active_requests() {
         let channel = FakeControlChannel::new(
             Some(BrokerHandshakeResponse::Negotiated {
                 broker_protocol_version: BROKER_PROTOCOL_VERSION,
             }),
             None,
         );
-        let local = BrokerLocal::negotiate(channel, |_| Ok(noop_shared_memory())).unwrap();
+        let setup_calls = Cell::new(0);
+        let local = BrokerLocal::negotiate(channel, |channel| {
+            assert!(channel.sent_handshake_request.is_some());
+            assert!(channel.handshake_response.is_none());
+            assert!(channel.sent_request.is_none());
+            setup_calls.set(setup_calls.get() + 1);
+            Ok(noop_shared_memory())
+        })
+        .unwrap();
 
         assert_eq!(
             local.channel.sent_handshake_request,
@@ -235,23 +242,7 @@ mod tests {
                 protocol_version: BROKER_PROTOCOL_VERSION
             })
         );
-    }
-
-    #[test]
-    fn active_request_sends_event_request() {
-        let handle = ObjectHandle(7);
-        let request = BrokerRequest::Event(EventRequest::Create(CreateEventRequest {
-            initial_count: 0,
-        }));
-        let response = BrokerResponse::Event(EventResponse::Create(CreateEventResponse { handle }));
-        let channel = FakeControlChannel::new(None, Some(response.clone()));
-        let mut local = BrokerLocal {
-            channel,
-            shared_memory: noop_shared_memory(),
-        };
-
-        assert_eq!(local.request(request.clone()).unwrap(), response);
-        assert_eq!(local.channel.sent_request, Some(request));
+        assert_eq!(setup_calls.get(), 1);
     }
 
     #[test]
@@ -271,9 +262,6 @@ mod tests {
 
     #[test]
     fn active_request_returns_recoverable_broker_error() {
-        let request = BrokerRequest::Event(EventRequest::Create(CreateEventRequest {
-            initial_count: 0,
-        }));
         let channel =
             FakeControlChannel::new(None, Some(BrokerResponse::Error(ErrorCode::WouldBlock)));
         let mut local = BrokerLocal {
@@ -282,7 +270,7 @@ mod tests {
         };
 
         assert!(matches!(
-            local.request(request),
+            local.create_event_with_count(0),
             Err(BrokerLocalError::Broker(ErrorCode::WouldBlock))
         ));
     }
@@ -290,9 +278,6 @@ mod tests {
     #[test]
     #[should_panic(expected = "broker returned unrecoverable error")]
     fn active_request_panics_on_unrecoverable_broker_error() {
-        let request = BrokerRequest::Event(EventRequest::Create(CreateEventRequest {
-            initial_count: 0,
-        }));
         let channel =
             FakeControlChannel::new(None, Some(BrokerResponse::Error(ErrorCode::Internal)));
         let mut local = BrokerLocal {
@@ -300,30 +285,11 @@ mod tests {
             shared_memory: noop_shared_memory(),
         };
 
-        let _ = local.request(request);
+        let _ = local.create_event_with_count(0);
     }
 
     #[test]
-    #[should_panic(expected = "broker returned unrecoverable error")]
-    fn active_request_panics_on_unsupported_operation() {
-        let request = BrokerRequest::Event(EventRequest::Create(CreateEventRequest {
-            initial_count: 0,
-        }));
-        let channel = FakeControlChannel::new(
-            None,
-            Some(BrokerResponse::Error(ErrorCode::UnsupportedOperation)),
-        );
-        let mut local = BrokerLocal {
-            channel,
-            shared_memory: noop_shared_memory(),
-        };
-
-        let _ = local.request(request);
-    }
-
-    #[test]
-    #[should_panic(expected = "broker returned unexpected negotiation response")]
-    fn negotiate_rejects_broker_different_version_response() {
+    fn negotiate_rejects_broker_different_version_without_setup() {
         let broker_protocol_version = ProtocolVersion(BROKER_PROTOCOL_VERSION.0 + 1);
         let channel = FakeControlChannel::new(
             Some(BrokerHandshakeResponse::Negotiated {
@@ -331,8 +297,16 @@ mod tests {
             }),
             None,
         );
+        let setup_called = Cell::new(false);
 
-        let _ = BrokerLocal::negotiate(channel, |_| Ok(noop_shared_memory()));
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _ = BrokerLocal::negotiate(channel, |_| {
+                setup_called.set(true);
+                Ok(noop_shared_memory())
+            });
+        }));
+        assert_panic_contains(result, "broker returned unexpected negotiation response");
+        assert!(!setup_called.get());
     }
 
     #[test]
@@ -371,14 +345,70 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "broker returned unrecoverable error")]
-    fn negotiate_panics_on_unrecoverable_broker_error() {
+    fn negotiate_skips_setup_before_panicking_on_unrecoverable_broker_error() {
         let channel = FakeControlChannel::new(
             Some(BrokerHandshakeResponse::Error(ErrorCode::Internal)),
             None,
         );
+        let setup_called = Cell::new(false);
 
-        let _ = BrokerLocal::negotiate(channel, |_| Ok(noop_shared_memory()));
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _ = BrokerLocal::negotiate(channel, |_| {
+                setup_called.set(true);
+                Ok(noop_shared_memory())
+            });
+        }));
+        assert_panic_contains(result, "broker returned unrecoverable error");
+        assert!(!setup_called.get());
+    }
+
+    #[test]
+    fn negotiate_propagates_shared_memory_receive_error() {
+        let channel = FakeControlChannel::new(
+            Some(BrokerHandshakeResponse::Negotiated {
+                broker_protocol_version: BROKER_PROTOCOL_VERSION,
+            }),
+            None,
+        );
+
+        assert!(matches!(
+            BrokerLocal::negotiate(channel, |_| Err(FakeChannelError::SharedMemoryReceive)),
+            Err(BrokerLocalError::Channel(
+                FakeChannelError::SharedMemoryReceive
+            ))
+        ));
+    }
+
+    #[test]
+    #[should_panic(expected = "broker association shared memory has an invalid size")]
+    fn negotiate_rejects_invalid_shared_memory_size() {
+        let channel = FakeControlChannel::new(
+            Some(BrokerHandshakeResponse::Negotiated {
+                broker_protocol_version: BROKER_PROTOCOL_VERSION,
+            }),
+            None,
+        );
+
+        let _ = BrokerLocal::negotiate(channel, |_| {
+            Ok(Arc::new(NoopSharedMemory {
+                length: PIPE_TRANSFER_BUFFER_SIZE - 1,
+            }) as Arc<dyn SharedMemory>)
+        });
+    }
+
+    fn assert_panic_contains(result: std::thread::Result<()>, expected: &str) {
+        let panic = result.expect_err("operation did not panic");
+        let message = if let Some(message) = panic.downcast_ref::<&str>() {
+            *message
+        } else if let Some(message) = panic.downcast_ref::<std::string::String>() {
+            message.as_str()
+        } else {
+            panic!("unexpected panic payload");
+        };
+        assert!(
+            message.contains(expected),
+            "panic message did not contain {expected:?}: {message}"
+        );
     }
 
     struct FakeControlChannel {
@@ -388,11 +418,18 @@ mod tests {
         response: Option<BrokerResponse>,
     }
 
-    struct NoopSharedMemory;
+    #[derive(Debug, PartialEq, Eq)]
+    enum FakeChannelError {
+        SharedMemoryReceive,
+    }
+
+    struct NoopSharedMemory {
+        length: usize,
+    }
 
     impl SharedMemory for NoopSharedMemory {
         fn len(&self) -> usize {
-            PIPE_TRANSFER_BUFFER_SIZE
+            self.length
         }
 
         fn read(
@@ -416,7 +453,9 @@ mod tests {
     }
 
     fn noop_shared_memory() -> Arc<dyn SharedMemory> {
-        Arc::new(NoopSharedMemory)
+        Arc::new(NoopSharedMemory {
+            length: PIPE_TRANSFER_BUFFER_SIZE,
+        })
     }
 
     impl FakeControlChannel {
@@ -434,7 +473,7 @@ mod tests {
     }
 
     impl LocalControlChannel for FakeControlChannel {
-        type Error = Infallible;
+        type Error = FakeChannelError;
 
         fn send_handshake_request(
             &mut self,

--- a/litebox_broker_local/src/lib.rs
+++ b/litebox_broker_local/src/lib.rs
@@ -20,20 +20,28 @@ mod error;
 mod event;
 mod pipe;
 
+use alloc::sync::Arc;
+
 use litebox_broker_protocol::channel::{LocalControlChannel, LocalNotificationChannel};
 use litebox_broker_protocol::error::ErrorCode;
 use litebox_broker_protocol::message::{
     BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerNotification, BrokerRequest,
     BrokerResponse,
 };
+use litebox_broker_protocol::pipe::PIPE_TRANSFER_BUFFER_SIZE;
 use litebox_broker_protocol::readiness::ReadinessFlags;
+use litebox_broker_protocol::shared_memory::SharedMemory;
 use litebox_broker_protocol::{BROKER_PROTOCOL_VERSION, ObjectHandle};
 
 pub use error::{BrokerLocalError, Result};
 
 /// Typed broker-local control adapter for broker operations.
+///
+/// The shared memory belongs to the broker association and is reused for each
+/// serialized pipe transfer.
 pub struct BrokerLocal<Channel: LocalControlChannel> {
     channel: Channel,
+    shared_memory: Arc<dyn SharedMemory>,
 }
 
 /// Broker-local receive adapter for broker-initiated asynchronous notifications.
@@ -42,13 +50,37 @@ pub struct BrokerNotifications<Channel: LocalNotificationChannel> {
 }
 
 impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
-    /// Negotiates the broker protocol over an already-connected control channel.
+    /// Negotiates the broker protocol over an already-connected control channel
+    /// with its associated shared memory.
     ///
     /// # Panics
     ///
     /// Panics if the broker reports an unrecoverable error or returns a protocol
     /// response that does not match the negotiation request.
-    pub fn negotiate(mut channel: Channel) -> Result<Self, Channel::Error> {
+    pub fn negotiate(
+        channel: Channel,
+        shared_memory: Arc<dyn SharedMemory>,
+    ) -> Result<Self, Channel::Error> {
+        Self::negotiate_with_setup(channel, |_| Ok(shared_memory))
+    }
+
+    /// Negotiates the broker protocol, then establishes the association shared
+    /// memory before active requests begin.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the broker reports an unrecoverable error, returns a protocol
+    /// response that does not match the negotiation request, or setup returns
+    /// shared memory with an invalid size.
+    pub fn negotiate_with_setup(
+        mut channel: Channel,
+        establish_shared_memory: impl FnOnce(
+            &mut Channel,
+        ) -> core::result::Result<
+            Arc<dyn SharedMemory>,
+            Channel::Error,
+        >,
+    ) -> Result<Self, Channel::Error> {
         let requested = BROKER_PROTOCOL_VERSION;
         let request = BrokerHandshakeRequest {
             protocol_version: requested,
@@ -68,7 +100,17 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
                     requested, broker_protocol_version,
                     "broker returned unexpected negotiation response: {response:?}"
                 );
-                Ok(Self { channel })
+                let shared_memory =
+                    establish_shared_memory(&mut channel).map_err(BrokerLocalError::Channel)?;
+                assert_eq!(
+                    shared_memory.len(),
+                    PIPE_TRANSFER_BUFFER_SIZE,
+                    "broker association shared memory has an invalid size"
+                );
+                Ok(Self {
+                    channel,
+                    shared_memory,
+                })
             }
             BrokerHandshakeResponse::VersionMismatch { .. } => {
                 Err(BrokerLocalError::Broker(ErrorCode::UnsupportedVersion))
@@ -92,7 +134,10 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
     ///
     /// Panics if the broker reports an unrecoverable error or returns a protocol
     /// response that does not match an active request.
-    pub fn request(&mut self, request: BrokerRequest) -> Result<BrokerResponse, Channel::Error> {
+    pub(crate) fn request(
+        &mut self,
+        request: BrokerRequest,
+    ) -> Result<BrokerResponse, Channel::Error> {
         self.channel
             .send_request(&request)
             .map_err(BrokerLocalError::Channel)?;
@@ -179,6 +224,7 @@ impl<Channel: LocalNotificationChannel> BrokerNotifications<Channel> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use core::cell::Cell;
     use core::convert::Infallible;
     use litebox_broker_protocol::ObjectHandle;
     use litebox_broker_protocol::ProtocolVersion;
@@ -195,7 +241,7 @@ mod tests {
             }),
             None,
         );
-        let local = BrokerLocal::negotiate(channel).unwrap();
+        let local = BrokerLocal::negotiate(channel, test_shared_memory()).unwrap();
 
         assert_eq!(
             local.channel.sent_handshake_request,
@@ -213,7 +259,10 @@ mod tests {
         }));
         let response = BrokerResponse::Event(EventResponse::Create(CreateEventResponse { handle }));
         let channel = FakeControlChannel::new(None, Some(response.clone()));
-        let mut local = BrokerLocal { channel };
+        let mut local = BrokerLocal {
+            channel,
+            shared_memory: test_shared_memory(),
+        };
 
         assert_eq!(local.request(request.clone()).unwrap(), response);
         assert_eq!(local.channel.sent_request, Some(request));
@@ -225,7 +274,10 @@ mod tests {
         let request = BrokerRequest::CloseObject(handle);
         let response = BrokerResponse::ObjectClosed;
         let channel = FakeControlChannel::new(None, Some(response.clone()));
-        let mut local = BrokerLocal { channel };
+        let mut local = BrokerLocal {
+            channel,
+            shared_memory: test_shared_memory(),
+        };
 
         assert!(local.close_object(handle).is_ok());
         assert_eq!(local.channel.sent_request, Some(request));
@@ -238,7 +290,10 @@ mod tests {
         }));
         let channel =
             FakeControlChannel::new(None, Some(BrokerResponse::Error(ErrorCode::WouldBlock)));
-        let mut local = BrokerLocal { channel };
+        let mut local = BrokerLocal {
+            channel,
+            shared_memory: test_shared_memory(),
+        };
 
         assert!(matches!(
             local.request(request),
@@ -254,7 +309,28 @@ mod tests {
         }));
         let channel =
             FakeControlChannel::new(None, Some(BrokerResponse::Error(ErrorCode::Internal)));
-        let mut local = BrokerLocal { channel };
+        let mut local = BrokerLocal {
+            channel,
+            shared_memory: test_shared_memory(),
+        };
+
+        let _ = local.request(request);
+    }
+
+    #[test]
+    #[should_panic(expected = "broker returned unrecoverable error")]
+    fn active_request_panics_on_unsupported_operation() {
+        let request = BrokerRequest::Event(EventRequest::Create(CreateEventRequest {
+            initial_count: 0,
+        }));
+        let channel = FakeControlChannel::new(
+            None,
+            Some(BrokerResponse::Error(ErrorCode::UnsupportedOperation)),
+        );
+        let mut local = BrokerLocal {
+            channel,
+            shared_memory: test_shared_memory(),
+        };
 
         let _ = local.request(request);
     }
@@ -270,7 +346,7 @@ mod tests {
             None,
         );
 
-        let _ = BrokerLocal::negotiate(channel);
+        let _ = BrokerLocal::negotiate(channel, test_shared_memory());
     }
 
     #[test]
@@ -297,10 +373,15 @@ mod tests {
             None,
         );
 
+        let setup_called = Cell::new(false);
         assert!(matches!(
-            BrokerLocal::negotiate(channel),
+            BrokerLocal::negotiate_with_setup(channel, |_| {
+                setup_called.set(true);
+                Ok(test_shared_memory())
+            }),
             Err(BrokerLocalError::Broker(ErrorCode::UnsupportedVersion))
         ));
+        assert!(!setup_called.get());
     }
 
     #[test]
@@ -311,7 +392,7 @@ mod tests {
             None,
         );
 
-        let _ = BrokerLocal::negotiate(channel);
+        let _ = BrokerLocal::negotiate(channel, test_shared_memory());
     }
 
     struct FakeControlChannel {
@@ -319,6 +400,36 @@ mod tests {
         sent_request: Option<BrokerRequest>,
         handshake_response: Option<BrokerHandshakeResponse>,
         response: Option<BrokerResponse>,
+    }
+
+    struct TestSharedMemory;
+
+    impl SharedMemory for TestSharedMemory {
+        fn len(&self) -> usize {
+            PIPE_TRANSFER_BUFFER_SIZE
+        }
+
+        fn read(
+            &self,
+            _offset: usize,
+            _destination: &mut [u8],
+        ) -> core::result::Result<(), litebox_broker_protocol::shared_memory::SharedMemoryError>
+        {
+            unreachable!("shared memory is not used by these tests")
+        }
+
+        fn write(
+            &self,
+            _offset: usize,
+            _source: &[u8],
+        ) -> core::result::Result<(), litebox_broker_protocol::shared_memory::SharedMemoryError>
+        {
+            unreachable!("shared memory is not used by these tests")
+        }
+    }
+
+    fn test_shared_memory() -> Arc<dyn SharedMemory> {
+        Arc::new(TestSharedMemory)
     }
 
     impl FakeControlChannel {

--- a/litebox_broker_local/src/pipe.rs
+++ b/litebox_broker_local/src/pipe.rs
@@ -166,7 +166,7 @@ mod tests {
             BrokerResponse::Pipe(PipeResponse::Read(ReadPipeResponse { read: 2 })),
             BrokerResponse::ObjectClosed,
         ]);
-        let mut local = BrokerLocal::negotiate(channel, memory.clone()).unwrap();
+        let mut local = BrokerLocal::negotiate(channel, |_| Ok(memory.clone())).unwrap();
 
         local.create_pipe(64, 16).unwrap();
         assert_eq!(local.write_pipe(write_handle, &[1, 2, 3]).unwrap(), 3);
@@ -204,7 +204,7 @@ mod tests {
             litebox_broker_protocol::error::ErrorCode::UnknownObject,
         )]);
         let memory = Arc::new(TestSharedMemory::new(PIPE_TRANSFER_BUFFER_SIZE));
-        let mut local = BrokerLocal::negotiate(channel, memory).unwrap();
+        let mut local = BrokerLocal::negotiate(channel, |_| Ok(memory)).unwrap();
 
         assert!(matches!(
             local.read_pipe(unknown_handle, 1),
@@ -225,7 +225,7 @@ mod tests {
             litebox_broker_protocol::error::ErrorCode::InvalidRights,
         )]);
         let memory = Arc::new(TestSharedMemory::new(PIPE_TRANSFER_BUFFER_SIZE));
-        let mut local = BrokerLocal::negotiate(channel, memory).unwrap();
+        let mut local = BrokerLocal::negotiate(channel, |_| Ok(memory)).unwrap();
 
         assert!(matches!(
             local.write_pipe(event_handle, &[1]),

--- a/litebox_broker_local/src/pipe.rs
+++ b/litebox_broker_local/src/pipe.rs
@@ -51,33 +51,6 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
                 litebox_broker_protocol::error::ErrorCode::ResourceExhausted,
             ));
         }
-        self.read_pipe_shared(handle, length)
-    }
-
-    /// Writes bytes to a broker-owned pipe.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the broker reports an unrecoverable error or returns a
-    /// response that does not match the issued pipe request.
-    pub fn write_pipe(
-        &mut self,
-        handle: ObjectHandle,
-        data: &[u8],
-    ) -> Result<usize, Channel::Error> {
-        if data.len() > PIPE_TRANSFER_BUFFER_SIZE {
-            return Err(BrokerLocalError::Broker(
-                litebox_broker_protocol::error::ErrorCode::ResourceExhausted,
-            ));
-        }
-        self.write_pipe_shared(handle, data)
-    }
-
-    fn read_pipe_shared(
-        &mut self,
-        handle: ObjectHandle,
-        length: u32,
-    ) -> Result<Vec<u8>, Channel::Error> {
         let mut data = Vec::new();
         data.try_reserve_exact(length as usize).map_err(|_| {
             BrokerLocalError::Broker(litebox_broker_protocol::error::ErrorCode::OutOfMemory)
@@ -99,11 +72,22 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
         Ok(data)
     }
 
-    fn write_pipe_shared(
+    /// Writes bytes to a broker-owned pipe.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the broker reports an unrecoverable error or returns a
+    /// response that does not match the issued pipe request.
+    pub fn write_pipe(
         &mut self,
         handle: ObjectHandle,
         data: &[u8],
     ) -> Result<usize, Channel::Error> {
+        if data.len() > PIPE_TRANSFER_BUFFER_SIZE {
+            return Err(BrokerLocalError::Broker(
+                litebox_broker_protocol::error::ErrorCode::ResourceExhausted,
+            ));
+        }
         self.shared_memory
             .write(0, data)
             .expect("validated shared pipe write range must be accessible");

--- a/litebox_broker_local/src/pipe.rs
+++ b/litebox_broker_local/src/pipe.rs
@@ -7,7 +7,8 @@ use litebox_broker_protocol::ObjectHandle;
 use litebox_broker_protocol::channel::LocalControlChannel;
 use litebox_broker_protocol::message::{BrokerRequest, BrokerResponse, PipeRequest, PipeResponse};
 use litebox_broker_protocol::pipe::{
-    CreatePipeRequest, CreatePipeResponse, ReadPipeRequest, WritePipeRequest,
+    CreatePipeRequest, CreatePipeResponse, PIPE_TRANSFER_BUFFER_SIZE, ReadPipeRequest,
+    WritePipeRequest,
 };
 
 use crate::{BrokerLocal, BrokerLocalError, Result};
@@ -24,13 +25,14 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
         capacity: u64,
         atomic_write_size: u64,
     ) -> Result<CreatePipeResponse, Channel::Error> {
-        match self.request_pipe(PipeRequest::Create(CreatePipeRequest {
+        let response = self.request_pipe(PipeRequest::Create(CreatePipeRequest {
             capacity,
             atomic_write_size,
-        }))? {
-            PipeResponse::Create(response) => Ok(response),
-            response => panic!("broker returned unexpected pipe response: {response:?}"),
-        }
+        }))?;
+        let PipeResponse::Create(response) = response else {
+            panic!("broker returned unexpected pipe create response: {response:?}");
+        };
+        Ok(response)
     }
 
     /// Reads bytes from a broker-owned pipe.
@@ -44,10 +46,12 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
         handle: ObjectHandle,
         length: u32,
     ) -> Result<Vec<u8>, Channel::Error> {
-        match self.request_pipe(PipeRequest::Read(ReadPipeRequest { handle, length }))? {
-            PipeResponse::Read(response) => Ok(response.data),
-            response => panic!("broker returned unexpected pipe response: {response:?}"),
+        if length as usize > PIPE_TRANSFER_BUFFER_SIZE {
+            return Err(BrokerLocalError::Broker(
+                litebox_broker_protocol::error::ErrorCode::ResourceExhausted,
+            ));
         }
+        self.read_pipe_shared(handle, length)
     }
 
     /// Writes bytes to a broker-owned pipe.
@@ -61,13 +65,64 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
         handle: ObjectHandle,
         data: &[u8],
     ) -> Result<usize, Channel::Error> {
-        match self.request_pipe(PipeRequest::Write(WritePipeRequest {
-            handle,
-            data: data.to_vec(),
-        }))? {
-            PipeResponse::Write(response) => Ok(response.written as usize),
-            response => panic!("broker returned unexpected pipe response: {response:?}"),
+        if data.len() > PIPE_TRANSFER_BUFFER_SIZE {
+            return Err(BrokerLocalError::Broker(
+                litebox_broker_protocol::error::ErrorCode::ResourceExhausted,
+            ));
         }
+        self.write_pipe_shared(handle, data)
+    }
+
+    fn read_pipe_shared(
+        &mut self,
+        handle: ObjectHandle,
+        length: u32,
+    ) -> Result<Vec<u8>, Channel::Error> {
+        let mut data = Vec::new();
+        data.try_reserve_exact(length as usize).map_err(|_| {
+            BrokerLocalError::Broker(litebox_broker_protocol::error::ErrorCode::OutOfMemory)
+        })?;
+        data.resize(length as usize, 0);
+        let response = self.request_pipe(PipeRequest::Read(ReadPipeRequest { handle, length }))?;
+        let PipeResponse::Read(response) = response else {
+            panic!("broker returned unexpected pipe read response: {response:?}");
+        };
+        assert!(
+            response.read <= length,
+            "broker returned oversized pipe read"
+        );
+        let read = response.read as usize;
+        data.truncate(read);
+        self.shared_memory
+            .read(0, &mut data)
+            .expect("validated shared pipe read range must be accessible");
+        Ok(data)
+    }
+
+    fn write_pipe_shared(
+        &mut self,
+        handle: ObjectHandle,
+        data: &[u8],
+    ) -> Result<usize, Channel::Error> {
+        self.shared_memory
+            .write(0, data)
+            .expect("validated shared pipe write range must be accessible");
+        let response = self.request_pipe(PipeRequest::Write(WritePipeRequest {
+            handle,
+            length: data
+                .len()
+                .try_into()
+                .expect("shared pipe transfer length must fit in u32"),
+        }))?;
+        let PipeResponse::Write(response) = response else {
+            panic!("broker returned unexpected pipe write response: {response:?}");
+        };
+        let written = response.written as usize;
+        assert!(
+            written <= data.len(),
+            "broker returned oversized shared pipe write"
+        );
+        Ok(written)
     }
 
     fn request_pipe(&mut self, request: PipeRequest) -> Result<PipeResponse, Channel::Error> {
@@ -79,6 +134,204 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
             | BrokerResponse::Event(_)) => {
                 panic!("broker returned unexpected pipe response: {response:?}");
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::sync::Arc;
+    use core::convert::Infallible;
+    use std::collections::VecDeque;
+    use std::sync::Mutex;
+
+    use litebox_broker_protocol::BROKER_PROTOCOL_VERSION;
+    use litebox_broker_protocol::channel::LocalControlChannel;
+    use litebox_broker_protocol::message::{BrokerHandshakeRequest, BrokerHandshakeResponse};
+    use litebox_broker_protocol::pipe::{ReadPipeResponse, WritePipeResponse};
+    use litebox_broker_protocol::shared_memory::{SharedMemory, SharedMemoryError};
+
+    #[test]
+    fn pipe_uses_attached_shared_memory_for_data_operations() {
+        let read_handle = ObjectHandle(1);
+        let write_handle = ObjectHandle(2);
+        let memory = Arc::new(TestSharedMemory::new(PIPE_TRANSFER_BUFFER_SIZE));
+        let channel = ScriptedChannel::new([
+            BrokerResponse::Pipe(PipeResponse::Create(CreatePipeResponse {
+                read_handle,
+                write_handle,
+            })),
+            BrokerResponse::Pipe(PipeResponse::Write(WritePipeResponse { written: 3 })),
+            BrokerResponse::Pipe(PipeResponse::Read(ReadPipeResponse { read: 2 })),
+            BrokerResponse::ObjectClosed,
+        ]);
+        let mut local = BrokerLocal::negotiate(channel, memory.clone()).unwrap();
+
+        local.create_pipe(64, 16).unwrap();
+        assert_eq!(local.write_pipe(write_handle, &[1, 2, 3]).unwrap(), 3);
+        let mut staged = [0; 3];
+        memory.read(0, &mut staged).unwrap();
+        assert_eq!(staged, [1, 2, 3]);
+
+        memory.write(0, &[4, 5]).unwrap();
+        assert_eq!(local.read_pipe(read_handle, 2).unwrap(), [4, 5]);
+        local.close_object(read_handle).unwrap();
+        assert_eq!(
+            local.channel.sent_requests,
+            [
+                BrokerRequest::Pipe(PipeRequest::Create(CreatePipeRequest {
+                    capacity: 64,
+                    atomic_write_size: 16,
+                })),
+                BrokerRequest::Pipe(PipeRequest::Write(WritePipeRequest {
+                    handle: write_handle,
+                    length: 3,
+                })),
+                BrokerRequest::Pipe(PipeRequest::Read(ReadPipeRequest {
+                    handle: read_handle,
+                    length: 2,
+                })),
+                BrokerRequest::CloseObject(read_handle),
+            ]
+        );
+    }
+
+    #[test]
+    fn pipe_operations_preserve_invalid_handle_errors() {
+        let unknown_handle = ObjectHandle(9);
+        let channel = ScriptedChannel::new([BrokerResponse::Error(
+            litebox_broker_protocol::error::ErrorCode::UnknownObject,
+        )]);
+        let memory = Arc::new(TestSharedMemory::new(PIPE_TRANSFER_BUFFER_SIZE));
+        let mut local = BrokerLocal::negotiate(channel, memory).unwrap();
+
+        assert!(matches!(
+            local.read_pipe(unknown_handle, 1),
+            Err(BrokerLocalError::Broker(
+                litebox_broker_protocol::error::ErrorCode::UnknownObject
+            ))
+        ));
+        assert_eq!(
+            local.channel.sent_requests,
+            [BrokerRequest::Pipe(PipeRequest::Read(ReadPipeRequest {
+                handle: unknown_handle,
+                length: 1,
+            }))]
+        );
+
+        let event_handle = ObjectHandle(10);
+        let channel = ScriptedChannel::new([BrokerResponse::Error(
+            litebox_broker_protocol::error::ErrorCode::InvalidRights,
+        )]);
+        let memory = Arc::new(TestSharedMemory::new(PIPE_TRANSFER_BUFFER_SIZE));
+        let mut local = BrokerLocal::negotiate(channel, memory).unwrap();
+
+        assert!(matches!(
+            local.write_pipe(event_handle, &[1]),
+            Err(BrokerLocalError::Broker(
+                litebox_broker_protocol::error::ErrorCode::InvalidRights
+            ))
+        ));
+        assert_eq!(
+            local.channel.sent_requests,
+            [BrokerRequest::Pipe(PipeRequest::Write(WritePipeRequest {
+                handle: event_handle,
+                length: 1,
+            }))]
+        );
+    }
+
+    #[derive(Clone)]
+    struct TestSharedMemory(Arc<Mutex<Vec<u8>>>);
+
+    impl TestSharedMemory {
+        fn new(length: usize) -> Self {
+            Self(Arc::new(Mutex::new(std::vec![0; length])))
+        }
+    }
+
+    impl SharedMemory for TestSharedMemory {
+        fn len(&self) -> usize {
+            self.0.lock().unwrap().len()
+        }
+
+        fn read(
+            &self,
+            offset: usize,
+            destination: &mut [u8],
+        ) -> core::result::Result<(), SharedMemoryError> {
+            let memory = self.0.lock().unwrap();
+            let end = offset
+                .checked_add(destination.len())
+                .ok_or(SharedMemoryError::InvalidRange)?;
+            let source = memory
+                .get(offset..end)
+                .ok_or(SharedMemoryError::InvalidRange)?;
+            destination.copy_from_slice(source);
+            Ok(())
+        }
+
+        fn write(
+            &self,
+            offset: usize,
+            source: &[u8],
+        ) -> core::result::Result<(), SharedMemoryError> {
+            let mut memory = self.0.lock().unwrap();
+            let end = offset
+                .checked_add(source.len())
+                .ok_or(SharedMemoryError::InvalidRange)?;
+            let destination = memory
+                .get_mut(offset..end)
+                .ok_or(SharedMemoryError::InvalidRange)?;
+            destination.copy_from_slice(source);
+            Ok(())
+        }
+    }
+
+    struct ScriptedChannel {
+        responses: VecDeque<BrokerResponse>,
+        sent_requests: Vec<BrokerRequest>,
+    }
+
+    impl ScriptedChannel {
+        fn new(responses: impl IntoIterator<Item = BrokerResponse>) -> Self {
+            Self {
+                responses: responses.into_iter().collect(),
+                sent_requests: Vec::new(),
+            }
+        }
+    }
+
+    impl LocalControlChannel for ScriptedChannel {
+        type Error = Infallible;
+
+        fn send_handshake_request(
+            &mut self,
+            request: &BrokerHandshakeRequest,
+        ) -> core::result::Result<(), Self::Error> {
+            assert_eq!(request.protocol_version, BROKER_PROTOCOL_VERSION);
+            Ok(())
+        }
+
+        fn recv_handshake_response(
+            &mut self,
+        ) -> core::result::Result<Option<BrokerHandshakeResponse>, Self::Error> {
+            Ok(Some(BrokerHandshakeResponse::Negotiated {
+                broker_protocol_version: BROKER_PROTOCOL_VERSION,
+            }))
+        }
+
+        fn send_request(
+            &mut self,
+            request: &BrokerRequest,
+        ) -> core::result::Result<(), Self::Error> {
+            self.sent_requests.push(request.clone());
+            Ok(())
+        }
+
+        fn recv_response(&mut self) -> core::result::Result<Option<BrokerResponse>, Self::Error> {
+            Ok(self.responses.pop_front())
         }
     }
 }

--- a/litebox_broker_local/src/pipe.rs
+++ b/litebox_broker_local/src/pipe.rs
@@ -146,21 +146,19 @@ mod tests {
                 read_handle,
                 write_handle,
             })),
-            BrokerResponse::Pipe(PipeResponse::Write(WritePipeResponse { written: 3 })),
+            BrokerResponse::Pipe(PipeResponse::Write(WritePipeResponse { written: 2 })),
             BrokerResponse::Pipe(PipeResponse::Read(ReadPipeResponse { read: 2 })),
-            BrokerResponse::ObjectClosed,
         ]);
         let mut local = BrokerLocal::negotiate(channel, |_| Ok(memory.clone())).unwrap();
 
         local.create_pipe(64, 16).unwrap();
-        assert_eq!(local.write_pipe(write_handle, &[1, 2, 3]).unwrap(), 3);
+        assert_eq!(local.write_pipe(write_handle, &[1, 2, 3]).unwrap(), 2);
         let mut staged = [0; 3];
         memory.read(0, &mut staged).unwrap();
         assert_eq!(staged, [1, 2, 3]);
 
-        memory.write(0, &[4, 5]).unwrap();
-        assert_eq!(local.read_pipe(read_handle, 2).unwrap(), [4, 5]);
-        local.close_object(read_handle).unwrap();
+        memory.write(0, &[4, 5, 6]).unwrap();
+        assert_eq!(local.read_pipe(read_handle, 3).unwrap(), [4, 5]);
         assert_eq!(
             local.channel.sent_requests,
             [
@@ -174,56 +172,57 @@ mod tests {
                 })),
                 BrokerRequest::Pipe(PipeRequest::Read(ReadPipeRequest {
                     handle: read_handle,
-                    length: 2,
+                    length: 3,
                 })),
-                BrokerRequest::CloseObject(read_handle),
             ]
         );
     }
 
     #[test]
-    fn pipe_operations_preserve_invalid_handle_errors() {
-        let unknown_handle = ObjectHandle(9);
-        let channel = ScriptedChannel::new([BrokerResponse::Error(
-            litebox_broker_protocol::error::ErrorCode::UnknownObject,
-        )]);
+    fn pipe_rejects_oversized_transfers_before_request() {
+        let memory = Arc::new(TestSharedMemory::new(PIPE_TRANSFER_BUFFER_SIZE));
+        let channel = ScriptedChannel::new([]);
+        let mut local = BrokerLocal::negotiate(channel, |_| Ok(memory)).unwrap();
+        let oversized_length = PIPE_TRANSFER_BUFFER_SIZE + 1;
+
+        assert!(matches!(
+            local.read_pipe(ObjectHandle(1), u32::try_from(oversized_length).unwrap()),
+            Err(BrokerLocalError::Broker(
+                litebox_broker_protocol::error::ErrorCode::ResourceExhausted
+            ))
+        ));
+        assert!(matches!(
+            local.write_pipe(ObjectHandle(2), &std::vec![0; oversized_length]),
+            Err(BrokerLocalError::Broker(
+                litebox_broker_protocol::error::ErrorCode::ResourceExhausted
+            ))
+        ));
+        assert!(local.channel.sent_requests.is_empty());
+    }
+
+    #[test]
+    #[should_panic(expected = "broker returned oversized pipe read")]
+    fn read_pipe_rejects_oversized_response() {
+        let channel =
+            ScriptedChannel::new([BrokerResponse::Pipe(PipeResponse::Read(ReadPipeResponse {
+                read: 2,
+            }))]);
         let memory = Arc::new(TestSharedMemory::new(PIPE_TRANSFER_BUFFER_SIZE));
         let mut local = BrokerLocal::negotiate(channel, |_| Ok(memory)).unwrap();
 
-        assert!(matches!(
-            local.read_pipe(unknown_handle, 1),
-            Err(BrokerLocalError::Broker(
-                litebox_broker_protocol::error::ErrorCode::UnknownObject
-            ))
-        ));
-        assert_eq!(
-            local.channel.sent_requests,
-            [BrokerRequest::Pipe(PipeRequest::Read(ReadPipeRequest {
-                handle: unknown_handle,
-                length: 1,
-            }))]
-        );
+        let _ = local.read_pipe(ObjectHandle(1), 1);
+    }
 
-        let event_handle = ObjectHandle(10);
-        let channel = ScriptedChannel::new([BrokerResponse::Error(
-            litebox_broker_protocol::error::ErrorCode::InvalidRights,
-        )]);
+    #[test]
+    #[should_panic(expected = "broker returned oversized shared pipe write")]
+    fn write_pipe_rejects_oversized_response() {
+        let channel = ScriptedChannel::new([BrokerResponse::Pipe(PipeResponse::Write(
+            WritePipeResponse { written: 2 },
+        ))]);
         let memory = Arc::new(TestSharedMemory::new(PIPE_TRANSFER_BUFFER_SIZE));
         let mut local = BrokerLocal::negotiate(channel, |_| Ok(memory)).unwrap();
 
-        assert!(matches!(
-            local.write_pipe(event_handle, &[1]),
-            Err(BrokerLocalError::Broker(
-                litebox_broker_protocol::error::ErrorCode::InvalidRights
-            ))
-        ));
-        assert_eq!(
-            local.channel.sent_requests,
-            [BrokerRequest::Pipe(PipeRequest::Write(WritePipeRequest {
-                handle: event_handle,
-                length: 1,
-            }))]
-        );
+        let _ = local.write_pipe(ObjectHandle(1), &[0]);
     }
 
     #[derive(Clone)]

--- a/litebox_broker_protocol/src/lib.rs
+++ b/litebox_broker_protocol/src/lib.rs
@@ -32,4 +32,4 @@ pub struct ObjectHandle(pub u64);
 pub struct ProtocolVersion(pub u16);
 
 /// Current broker protocol version.
-pub const BROKER_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion(2);
+pub const BROKER_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion(1);

--- a/litebox_broker_protocol/src/lib.rs
+++ b/litebox_broker_protocol/src/lib.rs
@@ -32,4 +32,4 @@ pub struct ObjectHandle(pub u64);
 pub struct ProtocolVersion(pub u16);
 
 /// Current broker protocol version.
-pub const BROKER_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion(1);
+pub const BROKER_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion(2);

--- a/litebox_broker_protocol/src/pipe.rs
+++ b/litebox_broker_protocol/src/pipe.rs
@@ -1,15 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-use alloc::vec::Vec;
-
 use crate::ObjectHandle;
 
-/// Maximum pipe payload carried by one control-path request or response.
+/// Maximum pipe transfer described by one control-path request or response.
 ///
 /// This leaves room for the broker envelope and operation metadata within the
 /// smallest currently supported transport frame.
 pub const MAX_PIPE_TRANSFER_SIZE: u32 = 32 * 1024;
+
+/// Association shared-memory size required for broker pipe transfers.
+pub const PIPE_TRANSFER_BUFFER_SIZE: usize = MAX_PIPE_TRANSFER_SIZE as usize;
 
 /// Request to create a broker-owned byte pipe.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -38,20 +39,20 @@ pub struct ReadPipeRequest {
     pub length: u32,
 }
 
-/// Response containing bytes read from a pipe.
-#[derive(Clone, Debug, PartialEq, Eq)]
+/// Response describing bytes read into shared memory.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ReadPipeResponse {
-    /// Bytes removed from the pipe.
-    pub data: Vec<u8>,
+    /// Number of bytes placed in the read region.
+    pub read: u32,
 }
 
-/// Request to write bytes to a pipe endpoint.
-#[derive(Clone, Debug, PartialEq, Eq)]
+/// Request to write bytes staged in shared memory.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct WritePipeRequest {
     /// Write endpoint handle.
     pub handle: ObjectHandle,
-    /// Bytes to append to the pipe.
-    pub data: Vec<u8>,
+    /// Number of staged bytes to write.
+    pub length: u32,
 }
 
 /// Response describing a completed pipe write.

--- a/litebox_broker_protocol/src/wire.rs
+++ b/litebox_broker_protocol/src/wire.rs
@@ -328,10 +328,7 @@ mod tests {
                 atomic_write_size: 512,
             })),
             BrokerRequest::Pipe(PipeRequest::Read(ReadPipeRequest { handle, length: 32 })),
-            BrokerRequest::Pipe(PipeRequest::Write(WritePipeRequest {
-                handle,
-                data: Vec::from([1, 2, 3]),
-            })),
+            BrokerRequest::Pipe(PipeRequest::Write(WritePipeRequest { handle, length: 3 })),
         ];
 
         for request in requests {
@@ -382,9 +379,7 @@ mod tests {
                 read_handle: handle,
                 write_handle: ObjectHandle(14),
             })),
-            BrokerResponse::Pipe(PipeResponse::Read(ReadPipeResponse {
-                data: Vec::from([1, 2, 3]),
-            })),
+            BrokerResponse::Pipe(PipeResponse::Read(ReadPipeResponse { read: 3 })),
             BrokerResponse::Pipe(PipeResponse::Write(WritePipeResponse { written: 3 })),
             BrokerResponse::Error(ErrorCode::PolicyDenied),
             BrokerResponse::Error(ErrorCode::WouldBlock),

--- a/litebox_broker_protocol/src/wire/pipe.rs
+++ b/litebox_broker_protocol/src/wire/pipe.rs
@@ -33,7 +33,7 @@ pub(super) fn encode_pipe_request(encoder: &mut Encoder, request: PipeRequest) {
         PipeRequest::Write(request) => {
             encoder.u8(PIPE_REQUEST_TAG_WRITE);
             encoder.handle(request.handle);
-            encoder.bytes(&request.data);
+            encoder.u32(request.length);
         }
     }
 }
@@ -50,7 +50,7 @@ pub(super) fn decode_pipe_request(decoder: &mut Decoder<'_>) -> Result<PipeReque
         })),
         PIPE_REQUEST_TAG_WRITE => Ok(PipeRequest::Write(WritePipeRequest {
             handle: decoder.handle()?,
-            data: decoder.bytes()?,
+            length: decoder.u32()?,
         })),
         _ => Err(WireError::InvalidTag),
     }
@@ -65,7 +65,7 @@ pub(super) fn encode_pipe_response(encoder: &mut Encoder, response: PipeResponse
         }
         PipeResponse::Read(response) => {
             encoder.u8(PIPE_RESPONSE_TAG_READ);
-            encoder.bytes(&response.data);
+            encoder.u32(response.read);
         }
         PipeResponse::Write(response) => {
             encoder.u8(PIPE_RESPONSE_TAG_WRITTEN);
@@ -81,7 +81,7 @@ pub(super) fn decode_pipe_response(decoder: &mut Decoder<'_>) -> Result<PipeResp
             write_handle: decoder.handle()?,
         })),
         PIPE_RESPONSE_TAG_READ => Ok(PipeResponse::Read(ReadPipeResponse {
-            data: decoder.bytes()?,
+            read: decoder.u32()?,
         })),
         PIPE_RESPONSE_TAG_WRITTEN => Ok(PipeResponse::Write(WritePipeResponse {
             written: decoder.u32()?,

--- a/litebox_broker_protocol/src/wire/primitive.rs
+++ b/litebox_broker_protocol/src/wire/primitive.rs
@@ -33,16 +33,6 @@ impl Encoder {
         self.bytes.extend_from_slice(&value.to_le_bytes());
     }
 
-    pub(super) fn bytes(&mut self, value: &[u8]) {
-        self.u64(
-            value
-                .len()
-                .try_into()
-                .expect("broker byte payload length exceeds u64"),
-        );
-        self.bytes.extend_from_slice(value);
-    }
-
     pub(super) fn protocol_version(&mut self, version: ProtocolVersion) {
         self.u16(version.0);
     }
@@ -90,11 +80,6 @@ impl<'a> Decoder<'a> {
         Ok(u64::from_le_bytes([
             bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7],
         ]))
-    }
-
-    pub(super) fn bytes(&mut self) -> Result<Vec<u8>, WireError> {
-        let len = usize::try_from(self.u64()?).map_err(|_| WireError::OffsetOverflow)?;
-        Ok(self.take(len)?.to_vec())
     }
 
     pub(super) fn protocol_version(&mut self) -> Result<ProtocolVersion, WireError> {

--- a/litebox_broker_transport/src/unix_socket.rs
+++ b/litebox_broker_transport/src/unix_socket.rs
@@ -51,18 +51,6 @@ impl UnixStreamLocalControlChannel {
         }
     }
 
-    /// Creates a local control channel from an already-connected Unix stream
-    /// with a deadline for handshake I/O.
-    pub const fn from_connected_with_setup_deadline(
-        stream: UnixStream,
-        setup_deadline: Instant,
-    ) -> Self {
-        Self {
-            stream,
-            setup_deadline: Some(setup_deadline),
-        }
-    }
-
     /// Connects to a userland broker Unix socket.
     pub fn connect(path: impl AsRef<Path>) -> IoResult<Self> {
         UnixStream::connect(path).map(Self::from_connected)

--- a/litebox_broker_transport/src/unix_socket.rs
+++ b/litebox_broker_transport/src/unix_socket.rs
@@ -13,6 +13,8 @@ use std::os::unix::net::UnixStream;
 use std::path::Path;
 use std::time::{Duration, Instant};
 
+#[cfg(all(feature = "linux-shared-memory", target_os = "linux"))]
+use crate::shared_memory::MemfdSharedMemory;
 use litebox_broker_protocol::channel::{
     HostControlChannel, HostNotificationChannel, HostReceive, LocalControlChannel,
     LocalNotificationChannel, PeerCredential,
@@ -49,6 +51,18 @@ impl UnixStreamLocalControlChannel {
         }
     }
 
+    /// Creates a local control channel from an already-connected Unix stream
+    /// with a deadline for handshake I/O.
+    pub const fn from_connected_with_setup_deadline(
+        stream: UnixStream,
+        setup_deadline: Instant,
+    ) -> Self {
+        Self {
+            stream,
+            setup_deadline: Some(setup_deadline),
+        }
+    }
+
     /// Connects to a userland broker Unix socket.
     pub fn connect(path: impl AsRef<Path>) -> IoResult<Self> {
         UnixStream::connect(path).map(Self::from_connected)
@@ -74,6 +88,16 @@ impl UnixStreamLocalControlChannel {
         self.stream
             .try_clone()
             .map(|stream| UnixStreamLocalControlCancellation { stream })
+    }
+
+    /// Receives the memfd associated with this control channel.
+    #[cfg(all(feature = "linux-shared-memory", target_os = "linux"))]
+    pub fn receive_memfd(
+        &mut self,
+        expected_len: usize,
+        deadline: Option<Instant>,
+    ) -> IoResult<MemfdSharedMemory> {
+        crate::shared_memory::receive_memfd(&mut self.stream, expected_len, deadline)
     }
 }
 
@@ -112,6 +136,16 @@ impl UnixStreamHostControlChannel {
     /// Creates a host control channel from an accepted Unix stream.
     pub const fn from_accepted(stream: UnixStream) -> Self {
         Self { stream }
+    }
+
+    /// Sends the memfd associated with this control channel.
+    #[cfg(all(feature = "linux-shared-memory", target_os = "linux"))]
+    pub fn send_memfd(
+        &mut self,
+        shared_memory: &MemfdSharedMemory,
+        deadline: Option<Instant>,
+    ) -> IoResult<()> {
+        crate::shared_memory::send_memfd(&mut self.stream, shared_memory, deadline)
     }
 }
 

--- a/litebox_broker_userland/Cargo.toml
+++ b/litebox_broker_userland/Cargo.toml
@@ -7,7 +7,8 @@ edition = "2024"
 clap = { version = "4.5.33", features = ["derive"] }
 litebox_broker_core = { path = "../litebox_broker_core", version = "0.1.0" }
 litebox_broker_host = { path = "../litebox_broker_host", version = "0.1.0" }
-litebox_broker_transport = { path = "../litebox_broker_transport", version = "0.1.0", features = ["unix"] }
+litebox_broker_protocol = { path = "../litebox_broker_protocol", version = "0.1.0" }
+litebox_broker_transport = { path = "../litebox_broker_transport", version = "0.1.0", features = ["linux-shared-memory", "unix"] }
 tempfile = { version = "3", default-features = false }
 
 [[bin]]
@@ -22,7 +23,6 @@ harness = false
 [dev-dependencies]
 libc = { version = "0.2.169", default-features = false }
 litebox_broker_local = { path = "../litebox_broker_local", version = "0.1.0" }
-litebox_broker_protocol = { path = "../litebox_broker_protocol", version = "0.1.0" }
 
 [lints]
 workspace = true

--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -10,7 +10,7 @@ use std::time::{Duration, Instant};
 
 use clap::Parser;
 use litebox_broker_core::{BrokerCore, ObjectRights, PolicyEngine};
-use litebox_broker_host::serve_connection_with_setup;
+use litebox_broker_host::serve_connection;
 use litebox_broker_protocol::pipe::PIPE_TRANSFER_BUFFER_SIZE;
 use litebox_broker_transport::shared_memory::MemfdSharedMemory;
 use litebox_broker_transport::unix_socket::{
@@ -70,7 +70,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                     UnixStreamHostControlChannel::from_accepted(control_stream);
                 let mut notification_channel =
                     UnixStreamHostNotificationChannel::from_accepted(notification_stream);
-                if let Err(error) = serve_connection_with_setup(
+                if let Err(error) = serve_connection(
                     &broker,
                     &mut control_channel,
                     &mut notification_channel,

--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -6,13 +6,18 @@ use std::ffi::OsString;
 use std::os::unix::net::UnixListener;
 use std::path::PathBuf;
 use std::process::Command;
+use std::time::{Duration, Instant};
 
 use clap::Parser;
 use litebox_broker_core::{BrokerCore, ObjectRights, PolicyEngine};
-use litebox_broker_host::serve_connection;
+use litebox_broker_host::serve_connection_with_setup;
+use litebox_broker_protocol::pipe::PIPE_TRANSFER_BUFFER_SIZE;
+use litebox_broker_transport::shared_memory::MemfdSharedMemory;
 use litebox_broker_transport::unix_socket::{
     UnixStreamHostControlChannel, UnixStreamHostNotificationChannel,
 };
+
+const SETUP_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[derive(Parser, Debug)]
 struct CliArgs {
@@ -54,6 +59,8 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     loop {
         let (control_stream, _) = control_listener.accept()?;
+        let setup_deadline = Instant::now() + SETUP_TIMEOUT;
+        let shared_memory = MemfdSharedMemory::create(PIPE_TRANSFER_BUFFER_SIZE)?;
         let (notification_stream, _) = notification_listener.accept()?;
         let broker = broker.clone();
         if let Err(error) = std::thread::Builder::new()
@@ -63,9 +70,13 @@ fn main() -> Result<(), Box<dyn Error>> {
                     UnixStreamHostControlChannel::from_accepted(control_stream);
                 let mut notification_channel =
                     UnixStreamHostNotificationChannel::from_accepted(notification_stream);
-                if let Err(error) =
-                    serve_connection(&broker, &mut control_channel, &mut notification_channel)
-                {
+                if let Err(error) = serve_connection_with_setup(
+                    &broker,
+                    &mut control_channel,
+                    &mut notification_channel,
+                    &shared_memory,
+                    |channel| channel.send_memfd(&shared_memory, Some(setup_deadline)),
+                ) {
                     eprintln!("failed to serve broker connection: {error}");
                 }
             })

--- a/litebox_broker_userland/tests/notification_runtime.rs
+++ b/litebox_broker_userland/tests/notification_runtime.rs
@@ -2,11 +2,14 @@
 // Licensed under the MIT license.
 
 use std::os::unix::net::UnixStream;
+use std::sync::Arc;
 
 use litebox_broker_core::{BrokerCore, ObjectRights, PolicyEngine};
-use litebox_broker_host::{ConnectionTermination, serve_connection};
+use litebox_broker_host::{ConnectionTermination, serve_connection_with_setup};
 use litebox_broker_local::BrokerLocal;
+use litebox_broker_protocol::pipe::PIPE_TRANSFER_BUFFER_SIZE;
 use litebox_broker_protocol::readiness::ReadinessFlags;
+use litebox_broker_transport::shared_memory::MemfdSharedMemory;
 use litebox_broker_transport::unix_socket::{
     UnixStreamHostControlChannel, UnixStreamHostNotificationChannel, UnixStreamLocalControlChannel,
 };
@@ -19,16 +22,28 @@ fn host_serves_control_requests_over_paired_userland_channels() {
     .unwrap();
     let (local_control, host_control) = UnixStream::pair().unwrap();
     let (_local_notification, host_notification) = UnixStream::pair().unwrap();
+    let host_shared_memory = MemfdSharedMemory::create(PIPE_TRANSFER_BUFFER_SIZE).unwrap();
 
     let host_thread = std::thread::spawn(move || {
         let mut control = UnixStreamHostControlChannel::from_accepted(host_control);
         let mut notification = UnixStreamHostNotificationChannel::from_accepted(host_notification);
-        serve_connection(&broker, &mut control, &mut notification)
+        serve_connection_with_setup(
+            &broker,
+            &mut control,
+            &mut notification,
+            &host_shared_memory,
+            |channel| channel.send_memfd(&host_shared_memory, None),
+        )
     });
 
-    let mut local =
-        BrokerLocal::negotiate(UnixStreamLocalControlChannel::from_connected(local_control))
-            .unwrap();
+    let mut local = BrokerLocal::negotiate_with_setup(
+        UnixStreamLocalControlChannel::from_connected(local_control),
+        |channel| {
+            let shared_memory = channel.receive_memfd(PIPE_TRANSFER_BUFFER_SIZE, None)?;
+            Ok(Arc::new(shared_memory))
+        },
+    )
+    .unwrap();
 
     let handle = local.create_event_with_count(0).unwrap();
     let readiness = ReadinessFlags::READ | ReadinessFlags::WRITE;

--- a/litebox_broker_userland/tests/notification_runtime.rs
+++ b/litebox_broker_userland/tests/notification_runtime.rs
@@ -5,7 +5,7 @@ use std::os::unix::net::UnixStream;
 use std::sync::Arc;
 
 use litebox_broker_core::{BrokerCore, ObjectRights, PolicyEngine};
-use litebox_broker_host::{ConnectionTermination, serve_connection_with_setup};
+use litebox_broker_host::{ConnectionTermination, serve_connection};
 use litebox_broker_local::BrokerLocal;
 use litebox_broker_protocol::pipe::PIPE_TRANSFER_BUFFER_SIZE;
 use litebox_broker_protocol::readiness::ReadinessFlags;
@@ -27,7 +27,7 @@ fn host_serves_control_requests_over_paired_userland_channels() {
     let host_thread = std::thread::spawn(move || {
         let mut control = UnixStreamHostControlChannel::from_accepted(host_control);
         let mut notification = UnixStreamHostNotificationChannel::from_accepted(host_notification);
-        serve_connection_with_setup(
+        serve_connection(
             &broker,
             &mut control,
             &mut notification,

--- a/litebox_broker_userland/tests/notification_runtime.rs
+++ b/litebox_broker_userland/tests/notification_runtime.rs
@@ -36,7 +36,7 @@ fn host_serves_control_requests_over_paired_userland_channels() {
         )
     });
 
-    let mut local = BrokerLocal::negotiate_with_setup(
+    let mut local = BrokerLocal::negotiate(
         UnixStreamLocalControlChannel::from_connected(local_control),
         |channel| {
             let shared_memory = channel.receive_memfd(PIPE_TRANSFER_BUFFER_SIZE, None)?;

--- a/litebox_broker_userland/tests/userland_broker.rs
+++ b/litebox_broker_userland/tests/userland_broker.rs
@@ -3,12 +3,15 @@
 
 use std::ffi::{OsStr, OsString};
 use std::io::{Error, ErrorKind, Result};
+use std::os::unix::net::UnixStream;
 use std::os::unix::process::ExitStatusExt;
 use std::path::Path;
 use std::process::{Child, Command};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use litebox_broker_local::BrokerLocal;
+use litebox_broker_protocol::pipe::PIPE_TRANSFER_BUFFER_SIZE;
 use litebox_broker_protocol::readiness::ReadinessFlags;
 use litebox_broker_transport::unix_socket::{
     UnixStreamLocalControlChannel, UnixStreamLocalNotificationChannel,
@@ -81,7 +84,14 @@ fn run_fake_runner(args: &[OsString]) {
     let control_channel = connect_control_with_retry(Path::new(control_socket_path)).unwrap();
     let _notification_channel =
         connect_notification_with_retry(Path::new(notification_socket_path)).unwrap();
-    let mut local = BrokerLocal::negotiate(control_channel).unwrap();
+    let mut local = BrokerLocal::negotiate_with_setup(control_channel, |channel| {
+        let shared_memory = channel.receive_memfd(
+            PIPE_TRANSFER_BUFFER_SIZE,
+            Some(Instant::now() + Duration::from_secs(5)),
+        )?;
+        Ok(Arc::new(shared_memory))
+    })
+    .unwrap();
 
     let handle = local.create_event_with_count(0).unwrap();
     assert_eq!(
@@ -126,7 +136,9 @@ impl Drop for ChildGuard {
 fn connect_control_with_retry(socket_path: &Path) -> Result<UnixStreamLocalControlChannel> {
     let deadline = Instant::now() + Duration::from_secs(5);
     loop {
-        match UnixStreamLocalControlChannel::connect_with_setup_deadline(socket_path, deadline) {
+        match UnixStream::connect(socket_path).map(|stream| {
+            UnixStreamLocalControlChannel::from_connected_with_setup_deadline(stream, deadline)
+        }) {
             Ok(channel) => return Ok(channel),
             Err(error) if Instant::now() < deadline => {
                 if error.kind() != ErrorKind::NotFound

--- a/litebox_broker_userland/tests/userland_broker.rs
+++ b/litebox_broker_userland/tests/userland_broker.rs
@@ -84,7 +84,7 @@ fn run_fake_runner(args: &[OsString]) {
     let control_channel = connect_control_with_retry(Path::new(control_socket_path)).unwrap();
     let _notification_channel =
         connect_notification_with_retry(Path::new(notification_socket_path)).unwrap();
-    let mut local = BrokerLocal::negotiate_with_setup(control_channel, |channel| {
+    let mut local = BrokerLocal::negotiate(control_channel, |channel| {
         let shared_memory = channel.receive_memfd(
             PIPE_TRANSFER_BUFFER_SIZE,
             Some(Instant::now() + Duration::from_secs(5)),

--- a/litebox_broker_userland/tests/userland_broker.rs
+++ b/litebox_broker_userland/tests/userland_broker.rs
@@ -3,7 +3,6 @@
 
 use std::ffi::{OsStr, OsString};
 use std::io::{Error, ErrorKind, Result};
-use std::os::unix::net::UnixStream;
 use std::os::unix::process::ExitStatusExt;
 use std::path::Path;
 use std::process::{Child, Command};
@@ -136,9 +135,7 @@ impl Drop for ChildGuard {
 fn connect_control_with_retry(socket_path: &Path) -> Result<UnixStreamLocalControlChannel> {
     let deadline = Instant::now() + Duration::from_secs(5);
     loop {
-        match UnixStream::connect(socket_path).map(|stream| {
-            UnixStreamLocalControlChannel::from_connected_with_setup_deadline(stream, deadline)
-        }) {
+        match UnixStreamLocalControlChannel::connect_with_setup_deadline(socket_path, deadline) {
             Ok(channel) => return Ok(channel),
             Err(error) if Instant::now() < deadline => {
                 if error.kind() != ErrorKind::NotFound

--- a/litebox_broker_userland/tests/userland_broker.rs
+++ b/litebox_broker_userland/tests/userland_broker.rs
@@ -105,6 +105,19 @@ fn run_fake_runner(args: &[OsString]) {
         local.check_readiness(handle).unwrap(),
         ReadinessFlags::READ | ReadinessFlags::WRITE
     );
+
+    let pipe = local.create_pipe(64, 16).unwrap();
+    let data = b"shared pipe data";
+    assert_eq!(
+        local.write_pipe(pipe.write_handle, data).unwrap(),
+        data.len()
+    );
+    assert_eq!(
+        local
+            .read_pipe(pipe.read_handle, data.len().try_into().unwrap())
+            .unwrap(),
+        data
+    );
     drop(local);
 
     // SAFETY: `getppid` takes no pointer arguments and has no Rust-side aliasing requirements.

--- a/litebox_runner_linux_userland/Cargo.toml
+++ b/litebox_runner_linux_userland/Cargo.toml
@@ -10,7 +10,7 @@ libc = { version = "0.2.169", default-features = false }
 litebox = { version = "0.1.0", path = "../litebox" }
 litebox_broker_local = { version = "0.1.0", path = "../litebox_broker_local" }
 litebox_broker_protocol = { version = "0.1.0", path = "../litebox_broker_protocol" }
-litebox_broker_transport = { version = "0.1.0", path = "../litebox_broker_transport", features = ["unix"] }
+litebox_broker_transport = { version = "0.1.0", path = "../litebox_broker_transport", features = ["linux-shared-memory", "unix"] }
 litebox_common_linux = { version = "0.1.0", path = "../litebox_common_linux" }
 litebox_platform_linux_userland = { version = "0.1.0", path = "../litebox_platform_linux_userland" }
 litebox_platform_multiplex = { version = "0.1.0", path = "../litebox_platform_multiplex", default-features = false, features = ["platform_linux_userland"] }

--- a/litebox_runner_linux_userland/src/broker.rs
+++ b/litebox_runner_linux_userland/src/broker.rs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 
 use std::{
-    os::unix::net::UnixStream,
     path::Path,
     sync::Arc,
     time::{Duration, Instant},
@@ -29,11 +28,11 @@ pub(crate) fn connect(
     UnixStreamLocalControlCancellation,
 )> {
     let setup_deadline = Instant::now() + SETUP_TIMEOUT;
-    let control_stream = connect_with_retry(
+    let control_channel = connect_with_retry(
         control_socket_path,
         setup_deadline,
         "timed out connecting to broker",
-        |path, _deadline| UnixStream::connect(path),
+        |path, deadline| UnixStreamLocalControlChannel::connect_with_setup_deadline(path, deadline),
     )
     .with_context(|| {
         format!(
@@ -41,10 +40,6 @@ pub(crate) fn connect(
             control_socket_path.display()
         )
     })?;
-    let control_channel = UnixStreamLocalControlChannel::from_connected_with_setup_deadline(
-        control_stream,
-        setup_deadline,
-    );
     let notification_channel = connect_with_retry(
         notification_socket_path,
         setup_deadline,

--- a/litebox_runner_linux_userland/src/broker.rs
+++ b/litebox_runner_linux_userland/src/broker.rs
@@ -2,13 +2,16 @@
 // Licensed under the MIT license.
 
 use std::{
+    os::unix::net::UnixStream,
     path::Path,
+    sync::Arc,
     time::{Duration, Instant},
 };
 
 use anyhow::{Context as _, Result};
 use litebox_broker_local::{BrokerLocal, BrokerNotifications};
 use litebox_broker_protocol::message::BrokerNotification;
+use litebox_broker_protocol::pipe::PIPE_TRANSFER_BUFFER_SIZE;
 use litebox_broker_transport::unix_socket::{
     UnixStreamLocalControlCancellation, UnixStreamLocalControlChannel,
     UnixStreamLocalNotificationChannel,
@@ -26,11 +29,11 @@ pub(crate) fn connect(
     UnixStreamLocalControlCancellation,
 )> {
     let setup_deadline = Instant::now() + SETUP_TIMEOUT;
-    let control_channel = connect_with_retry(
+    let control_stream = connect_with_retry(
         control_socket_path,
         setup_deadline,
         "timed out connecting to broker",
-        |path, deadline| UnixStreamLocalControlChannel::connect_with_setup_deadline(path, deadline),
+        |path, _deadline| UnixStream::connect(path),
     )
     .with_context(|| {
         format!(
@@ -38,6 +41,10 @@ pub(crate) fn connect(
             control_socket_path.display()
         )
     })?;
+    let control_channel = UnixStreamLocalControlChannel::from_connected_with_setup_deadline(
+        control_stream,
+        setup_deadline,
+    );
     let notification_channel = connect_with_retry(
         notification_socket_path,
         setup_deadline,
@@ -53,7 +60,12 @@ pub(crate) fn connect(
     let control_cancellation = control_channel
         .cancellation_handle()
         .context("failed to create broker control cancellation handle")?;
-    let local = BrokerLocal::negotiate(control_channel).context("broker negotiation failed")?;
+    let local = BrokerLocal::negotiate_with_setup(control_channel, |channel| {
+        let shared_memory =
+            channel.receive_memfd(PIPE_TRANSFER_BUFFER_SIZE, Some(setup_deadline))?;
+        Ok(Arc::new(shared_memory))
+    })
+    .context("broker negotiation failed")?;
     Ok((
         local,
         BrokerNotifications::new(notification_channel),

--- a/litebox_runner_linux_userland/src/broker.rs
+++ b/litebox_runner_linux_userland/src/broker.rs
@@ -60,7 +60,7 @@ pub(crate) fn connect(
     let control_cancellation = control_channel
         .cancellation_handle()
         .context("failed to create broker control cancellation handle")?;
-    let local = BrokerLocal::negotiate_with_setup(control_channel, |channel| {
+    let local = BrokerLocal::negotiate(control_channel, |channel| {
         let shared_memory =
             channel.receive_memfd(PIPE_TRANSFER_BUFFER_SIZE, Some(setup_deadline))?;
         Ok(Arc::new(shared_memory))

--- a/litebox_runner_linux_userland/tests/run.rs
+++ b/litebox_runner_linux_userland/tests/run.rs
@@ -340,6 +340,11 @@ fn spawn_test_broker(
                 let (control_stream, _) = control_listener
                     .accept()
                     .expect("failed to accept broker local control connection");
+                let shared_memory =
+                    litebox_broker_transport::shared_memory::MemfdSharedMemory::create(
+                        litebox_broker_protocol::pipe::PIPE_TRANSFER_BUFFER_SIZE,
+                    )
+                    .expect("failed to create broker test shared memory");
                 let (notification_stream, _) = notification_listener
                     .accept()
                     .expect("failed to accept broker local notification connection");
@@ -361,10 +366,12 @@ fn spawn_test_broker(
                 };
                 let mut notification_channel =
                     litebox_broker_transport::unix_socket::UnixStreamHostNotificationChannel::from_accepted(notification_stream);
-                let termination = litebox_broker_host::serve_connection(
+                let termination = litebox_broker_host::serve_connection_with_setup(
                     &broker,
                     &mut channel,
                     &mut notification_channel,
+                    &shared_memory,
+                    |channel| channel.inner.send_memfd(&shared_memory, None),
                 )
                 .expect("broker host failed");
                 assert_eq!(

--- a/litebox_runner_linux_userland/tests/run.rs
+++ b/litebox_runner_linux_userland/tests/run.rs
@@ -366,7 +366,7 @@ fn spawn_test_broker(
                 };
                 let mut notification_channel =
                     litebox_broker_transport::unix_socket::UnixStreamHostNotificationChannel::from_accepted(notification_stream);
-                let termination = litebox_broker_host::serve_connection_with_setup(
+                let termination = litebox_broker_host::serve_connection(
                     &broker,
                     &mut channel,
                     &mut notification_channel,


### PR DESCRIPTION
Each broker connection establishes one sealed memfd after protocol negotiation and reuses it at offset zero for serialized pipe transfers. Pipe requests carry transfer lengths and responses carry byte counts; the host and local adapters stage data through shared memory while BrokerCore remains authoritative for pipe state.