### PR TITLE
Store user pointers as address-only types instead of platform pointers

### DIFF
--- a/litebox_common_linux/src/lib.rs
+++ b/litebox_common_linux/src/lib.rs
@@ -11,7 +11,6 @@ use core::time::Duration;
 use int_enum::IntEnum;
 use litebox::{
     fs::OFlags,
-    platform::{RawConstPointer, RawMutPointer},
     utils::{ReinterpretSignedExt as _, ReinterpretUnsignedExt as _, TruncateExt as _},
 };
 use syscalls::Sysno;
@@ -24,9 +23,12 @@ pub mod loader;
 pub mod mm;
 pub mod physical_pointers;
 pub mod signal;
+pub mod user_pointers;
 pub mod vmap;
 
 extern crate alloc;
+
+pub use user_pointers::{UserPtr, UserPtrMut};
 
 /// Number of AArch64 general-purpose registers saved by the Linux user ABI
 /// (`x0` through `x30`).
@@ -344,39 +346,23 @@ pub struct FileStat {
 }
 
 /// Linux's `iovec` struct for `writev`
-#[derive(FromBytes, IntoBytes)]
+#[derive(Clone, Copy, FromBytes, IntoBytes)]
 #[repr(C, packed)]
-pub struct IoWriteVec<P: RawConstPointer<u8>> {
-    pub iov_base: P,
+pub struct IoWriteVec {
+    pub iov_base: UserPtr<u8>,
     pub iov_len: usize,
 }
 
 /// Linux's `iovec` struct for `readv`
-#[derive(FromBytes, IntoBytes)]
+#[derive(Clone, Copy, FromBytes, IntoBytes)]
 #[repr(C, packed)]
-pub struct IoReadVec<P: RawMutPointer<u8>> {
-    pub iov_base: P,
+pub struct IoReadVec {
+    pub iov_base: UserPtrMut<u8>,
     pub iov_len: usize,
 }
 
 /// `iovec` struct for both read and write
-pub type IoVec<P> = IoReadVec<P>;
-
-impl<P: RawConstPointer<u8>> Clone for IoWriteVec<P> {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-
-impl<P: RawConstPointer<u8>> Copy for IoWriteVec<P> {}
-
-impl<P: RawMutPointer<u8>> Clone for IoReadVec<P> {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-
-impl<P: RawMutPointer<u8>> Copy for IoReadVec<P> {}
+pub type IoVec = IoReadVec;
 
 impl From<litebox::fs::FileStatus> for FileStat {
     fn from(value: litebox::fs::FileStatus) -> Self {
@@ -592,7 +578,7 @@ impl From<FileStat> for Statx {
 /// Commands for use with `fcntl`.
 #[derive(Debug)]
 #[non_exhaustive]
-pub enum FcntlArg<Platform: litebox::platform::RawPointerProvider> {
+pub enum FcntlArg {
     /// Get the file descriptor flags
     GETFD,
     /// Set the file descriptor flags
@@ -602,11 +588,11 @@ pub enum FcntlArg<Platform: litebox::platform::RawPointerProvider> {
     /// Set descriptor status flags
     SETFL(OFlags),
     /// Get a file lock
-    GETLK(Platform::RawMutPointer<Flock>),
+    GETLK(UserPtrMut<Flock>),
     /// Set a file lock
-    SETLK(Platform::RawConstPointer<Flock>),
+    SETLK(UserPtr<Flock>),
     /// Set a file lock and wait if blocked
-    SETLKW(Platform::RawConstPointer<Flock>),
+    SETLKW(UserPtr<Flock>),
     /// Duplicate file descriptor
     DUPFD { cloexec: bool, min_fd: u32 },
 }
@@ -663,16 +649,16 @@ bitflags::bitflags! {
     }
 }
 
-impl<Platform: litebox::platform::RawPointerProvider> FcntlArg<Platform> {
+impl FcntlArg {
     pub fn try_from(cmd: i32, arg: usize) -> Option<Self> {
         Some(match cmd {
             F_GETFD => Self::GETFD,
             F_SETFD => Self::SETFD(FileDescriptorFlags::from_bits_truncate(arg.trunc())),
             F_GETFL => Self::GETFL,
             F_SETFL => Self::SETFL(OFlags::from_bits_truncate(arg.trunc())),
-            F_GETLK => Self::GETLK(Platform::RawMutPointer::from_usize(arg)),
-            F_SETLK => Self::SETLK(Platform::RawConstPointer::from_usize(arg)),
-            F_SETLKW => Self::SETLKW(Platform::RawConstPointer::from_usize(arg)),
+            F_GETLK => Self::GETLK(UserPtrMut::from_usize(arg)),
+            F_SETLK => Self::SETLK(UserPtr::from_usize(arg)),
+            F_SETLKW => Self::SETLKW(UserPtr::from_usize(arg)),
             F_DUPFD => Self::DUPFD {
                 cloexec: false,
                 min_fd: arg.trunc(),
@@ -729,23 +715,23 @@ pub const TIOCGPTN: u32 = 0x80045430;
 /// Commands for use with `ioctl`.
 #[non_exhaustive]
 #[derive(Debug)]
-pub enum IoctlArg<Platform: litebox::platform::RawPointerProvider> {
+pub enum IoctlArg {
     /// Get the current serial port settings.
-    TCGETS(Platform::RawMutPointer<Termios>),
+    TCGETS(UserPtrMut<Termios>),
     /// Set the current serial port settings.
-    TCSETS(Platform::RawConstPointer<Termios>),
+    TCSETS(UserPtr<Termios>),
     /// Get window size.
-    TIOCGWINSZ(Platform::RawMutPointer<Winsize>),
+    TIOCGWINSZ(UserPtrMut<Winsize>),
     /// Obtain device unit number, which can be used to generate
     /// the filename of the pseudo-terminal slave device.
-    TIOCGPTN(Platform::RawMutPointer<u32>),
+    TIOCGPTN(UserPtrMut<u32>),
     /// Enables or disables non-blocking mode
-    FIONBIO(Platform::RawConstPointer<i32>),
+    FIONBIO(UserPtr<i32>),
     /// Set close on exec
     FIOCLEX,
     Raw {
         cmd: u32,
-        arg: Platform::RawMutPointer<u8>,
+        arg: UserPtrMut<u8>,
     },
 }
 
@@ -1080,19 +1066,15 @@ pub enum ArchPrctlCode {
 /// Argument for the `arch_prctl` syscall, corresponding to the [`ArchPrctlCode`] enum.
 #[non_exhaustive]
 #[derive(Debug)]
-pub enum ArchPrctlArg<Platform: litebox::platform::RawPointerProvider> {
+pub enum ArchPrctlArg {
     #[cfg(target_arch = "x86_64")]
     SetFs(usize),
     #[cfg(target_arch = "x86_64")]
-    GetFs(Platform::RawMutPointer<usize>),
+    GetFs(UserPtrMut<usize>),
 
     CETStatus,
     CETDisable,
     CETLock,
-
-    #[doc(hidden)]
-    #[allow(non_camel_case_types)]
-    __Phantom(core::marker::PhantomData<Platform>),
 }
 
 /// Reads the FS segment base address
@@ -1698,25 +1680,25 @@ bitflags::bitflags! {
 
 #[non_exhaustive]
 #[derive(Debug)]
-pub enum FutexArgs<Platform: litebox::platform::RawPointerProvider> {
+pub enum FutexArgs {
     Wait {
-        addr: Platform::RawMutPointer<u32>,
+        addr: UserPtrMut<u32>,
         flags: FutexFlags,
         val: u32,
         /// Note: for FUTEX_WAIT, timeout is interpreted as a relative
         /// value. This differs from other futex operations, where
         /// timeout is interpreted as an absolute value.
-        timeout: TimeParam<Platform>,
+        timeout: TimeParam,
     },
     WaitBitset {
-        addr: Platform::RawMutPointer<u32>,
+        addr: UserPtrMut<u32>,
         flags: FutexFlags,
         val: u32,
-        timeout: TimeParam<Platform>,
+        timeout: TimeParam,
         bitmask: u32,
     },
     Wake {
-        addr: Platform::RawMutPointer<u32>,
+        addr: UserPtrMut<u32>,
         flags: FutexFlags,
         count: u32,
     },
@@ -1778,9 +1760,9 @@ pub enum PrctlOption {
 
 #[non_exhaustive]
 #[derive(Debug)]
-pub enum PrctlArg<Platform: litebox::platform::RawPointerProvider> {
-    SetName(Platform::RawConstPointer<u8>),
-    GetName(Platform::RawMutPointer<u8>),
+pub enum PrctlArg {
+    SetName(UserPtr<u8>),
+    GetName(UserPtrMut<u8>),
     CapBSetRead(usize),
 }
 
@@ -1855,16 +1837,16 @@ bitflags::bitflags! {
 /// Packaged sigset pointer with its size, used by `pselect6` syscall.
 #[derive(Clone, Copy, FromBytes)]
 #[repr(C)]
-pub struct SigSetPack<Platform: litebox::platform::RawPointerProvider> {
-    pub sigset: Platform::RawConstPointer<SigSet>,
+pub struct SigSetPack {
+    pub sigset: UserPtr<SigSet>,
     pub size: usize,
 }
 
-#[derive(Debug, FromBytes, IntoBytes)]
+#[derive(Debug, Clone, Copy, FromBytes, IntoBytes)]
 #[repr(C, packed)]
-pub struct UserMsgHdr<Platform: litebox::platform::RawPointerProvider> {
+pub struct UserMsgHdr {
     /// ptr to socket address structure
-    pub msg_name: Platform::RawMutPointer<u8>,
+    pub msg_name: UserPtrMut<u8>,
     /// size of socket address structure
     pub msg_namelen: u32,
     /// Explicit padding to match the 4-byte gap that Linux's naturally-aligned
@@ -1872,11 +1854,11 @@ pub struct UserMsgHdr<Platform: litebox::platform::RawPointerProvider> {
     #[cfg(target_pointer_width = "64")]
     _pad: u32,
     /// ptr to an array of `iovec` structures
-    pub msg_iov: Platform::RawConstPointer<IoVec<Platform::RawMutPointer<u8>>>,
+    pub msg_iov: UserPtr<IoVec>,
     /// number of elements in msg_iov
     pub msg_iovlen: usize,
     /// ptr to ancillary data
-    pub msg_control: Platform::RawConstPointer<u8>,
+    pub msg_control: UserPtr<u8>,
     /// number of bytes of ancillary data
     pub msg_controllen: usize,
     /// flags on received message
@@ -1887,34 +1869,18 @@ pub struct UserMsgHdr<Platform: litebox::platform::RawPointerProvider> {
     _pad2: u32,
 }
 
-impl<Platform: litebox::platform::RawPointerProvider> Clone for UserMsgHdr<Platform> {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-
-impl<Platform: litebox::platform::RawPointerProvider> Copy for UserMsgHdr<Platform> {}
-
 /// Linux's `struct mmsghdr`: a `msghdr` paired with the number of bytes
 /// transmitted, used by `sendmmsg`/`recvmmsg`.
-#[derive(Debug, FromBytes, IntoBytes)]
+#[derive(Debug, Clone, Copy, FromBytes, IntoBytes)]
 #[repr(C, packed)]
-pub struct UserMmsgHdr<Platform: litebox::platform::RawPointerProvider> {
+pub struct UserMmsgHdr {
     /// the per-message `msghdr`
-    pub msg_hdr: UserMsgHdr<Platform>,
+    pub msg_hdr: UserMsgHdr,
     /// bytes transmitted for this entry, written back by the kernel
     pub msg_len: u32,
     #[cfg(target_pointer_width = "64")]
     _pad: u32,
 }
-
-impl<Platform: litebox::platform::RawPointerProvider> Clone for UserMmsgHdr<Platform> {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-
-impl<Platform: litebox::platform::RawPointerProvider> Copy for UserMmsgHdr<Platform> {}
 
 #[repr(i32)]
 #[derive(Debug, IntEnum)]
@@ -1969,7 +1935,7 @@ impl ShutdownHow {
 /// Request to syscall handler
 #[non_exhaustive]
 #[derive(Debug)]
-pub enum SyscallRequest<Platform: litebox::platform::RawPointerProvider> {
+pub enum SyscallRequest {
     Exit {
         status: i32,
     },
@@ -1978,12 +1944,12 @@ pub enum SyscallRequest<Platform: litebox::platform::RawPointerProvider> {
     },
     Read {
         fd: i32,
-        buf: Platform::RawMutPointer<u8>,
+        buf: UserPtrMut<u8>,
         count: usize,
     },
     Write {
         fd: i32,
-        buf: Platform::RawConstPointer<u8>,
+        buf: UserPtr<u8>,
         count: usize,
     },
     Lseek {
@@ -1995,24 +1961,24 @@ pub enum SyscallRequest<Platform: litebox::platform::RawPointerProvider> {
         fd: i32,
     },
     Stat {
-        pathname: Platform::RawConstPointer<c_char>,
-        buf: Platform::RawMutPointer<FileStat>,
+        pathname: UserPtr<c_char>,
+        buf: UserPtrMut<FileStat>,
     },
     Fstat {
         fd: i32,
-        buf: Platform::RawMutPointer<FileStat>,
+        buf: UserPtrMut<FileStat>,
     },
     Lstat {
-        pathname: Platform::RawConstPointer<c_char>,
-        buf: Platform::RawMutPointer<FileStat>,
+        pathname: UserPtr<c_char>,
+        buf: UserPtrMut<FileStat>,
     },
     Mkdirat {
         dirfd: i32,
-        pathname: Platform::RawConstPointer<c_char>,
+        pathname: UserPtr<c_char>,
         mode: u32,
     },
     Chdir {
-        pathname: Platform::RawConstPointer<c_char>,
+        pathname: UserPtr<c_char>,
     },
     Mmap {
         addr: usize,
@@ -2023,34 +1989,34 @@ pub enum SyscallRequest<Platform: litebox::platform::RawPointerProvider> {
         offset: usize,
     },
     Mprotect {
-        addr: Platform::RawMutPointer<u8>,
+        addr: UserPtrMut<u8>,
         length: usize,
         prot: ProtFlags,
     },
     Munmap {
-        addr: Platform::RawMutPointer<u8>,
+        addr: UserPtrMut<u8>,
         length: usize,
     },
     Mremap {
-        old_addr: Platform::RawMutPointer<u8>,
+        old_addr: UserPtrMut<u8>,
         old_size: usize,
         new_size: usize,
         flags: MRemapFlags,
         new_addr: usize,
     },
     Brk {
-        addr: Platform::RawMutPointer<u8>,
+        addr: UserPtrMut<u8>,
     },
     RtSigprocmask {
         how: signal::SigmaskHow,
-        set: Option<Platform::RawConstPointer<SigSet>>,
-        oldset: Option<Platform::RawMutPointer<SigSet>>,
+        set: Option<UserPtr<SigSet>>,
+        oldset: Option<UserPtrMut<SigSet>>,
         sigsetsize: usize,
     },
     RtSigaction {
         signum: signal::Signal,
-        act: Option<Platform::RawConstPointer<signal::SigAction>>,
-        oldact: Option<Platform::RawMutPointer<signal::SigAction>>,
+        act: Option<UserPtr<signal::SigAction>>,
+        oldact: Option<UserPtrMut<signal::SigAction>>,
         sigsetsize: usize,
     },
     RtSigreturn,
@@ -2068,63 +2034,63 @@ pub enum SyscallRequest<Platform: litebox::platform::RawPointerProvider> {
         sig: i32,
     },
     Sigaltstack {
-        ss: Option<Platform::RawConstPointer<signal::SigAltStack>>,
-        old_ss: Option<Platform::RawMutPointer<signal::SigAltStack>>,
+        ss: Option<UserPtr<signal::SigAltStack>>,
+        old_ss: Option<UserPtrMut<signal::SigAltStack>>,
     },
     Ioctl {
         fd: i32,
-        arg: IoctlArg<Platform>,
+        arg: IoctlArg,
     },
     Pread64 {
         fd: i32,
-        buf: Platform::RawMutPointer<u8>,
+        buf: UserPtrMut<u8>,
         count: usize,
         offset: i64,
     },
     Pwrite64 {
         fd: i32,
-        buf: Platform::RawConstPointer<u8>,
+        buf: UserPtr<u8>,
         count: usize,
         offset: i64,
     },
     Sendfile {
         out_fd: i32,
         in_fd: i32,
-        offset: Option<Platform::RawMutPointer<i64>>,
+        offset: Option<UserPtrMut<i64>>,
         count: usize,
     },
     Readv {
         fd: i32,
-        iovec: Platform::RawConstPointer<IoReadVec<Platform::RawMutPointer<u8>>>,
+        iovec: UserPtr<IoReadVec>,
         iovcnt: usize,
     },
     Writev {
         fd: i32,
-        iovec: Platform::RawConstPointer<IoWriteVec<Platform::RawConstPointer<u8>>>,
+        iovec: UserPtr<IoWriteVec>,
         iovcnt: usize,
     },
     Preadv {
         fd: i32,
-        iovec: Platform::RawConstPointer<IoReadVec<Platform::RawMutPointer<u8>>>,
+        iovec: UserPtr<IoReadVec>,
         iovcnt: usize,
         pos_l: usize,
         pos_h: usize,
     },
     Pwritev {
         fd: i32,
-        iovec: Platform::RawConstPointer<IoWriteVec<Platform::RawConstPointer<u8>>>,
+        iovec: UserPtr<IoWriteVec>,
         iovcnt: usize,
         pos_l: usize,
         pos_h: usize,
     },
     Faccessat {
         dirfd: i32,
-        pathname: Platform::RawConstPointer<c_char>,
+        pathname: UserPtr<c_char>,
         mode: AccessFlags,
         flags: AtFlags,
     },
     Madvise {
-        addr: Platform::RawMutPointer<u8>,
+        addr: UserPtrMut<u8>,
         length: usize,
         behavior: MadviseBehavior,
     },
@@ -2142,57 +2108,57 @@ pub enum SyscallRequest<Platform: litebox::platform::RawPointerProvider> {
         domain: u32,
         type_and_flags: u32,
         protocol: u8,
-        sockvec: Platform::RawMutPointer<u32>,
+        sockvec: UserPtrMut<u32>,
     },
     Connect {
         sockfd: i32,
-        sockaddr: Platform::RawConstPointer<u8>,
+        sockaddr: UserPtr<u8>,
         addrlen: usize,
     },
     Accept {
         sockfd: i32,
-        addr: Option<Platform::RawMutPointer<u8>>,
-        addrlen: Option<Platform::RawMutPointer<u32>>,
+        addr: Option<UserPtrMut<u8>>,
+        addrlen: Option<UserPtrMut<u32>>,
         flags: SockFlags,
     },
     Sendto {
         sockfd: i32,
-        buf: Platform::RawConstPointer<u8>,
+        buf: UserPtr<u8>,
         len: usize,
         flags: SendFlags,
-        addr: Option<Platform::RawConstPointer<u8>>,
+        addr: Option<UserPtr<u8>>,
         addrlen: u32,
     },
     Sendmsg {
         sockfd: i32,
-        msg: Platform::RawConstPointer<UserMsgHdr<Platform>>,
+        msg: UserPtr<UserMsgHdr>,
         flags: SendFlags,
     },
     Sendmmsg {
         sockfd: i32,
-        msgvec: Platform::RawMutPointer<UserMmsgHdr<Platform>>,
+        msgvec: UserPtrMut<UserMmsgHdr>,
         vlen: u32,
         flags: SendFlags,
     },
     Recvfrom {
         sockfd: i32,
-        buf: Platform::RawMutPointer<u8>,
+        buf: UserPtrMut<u8>,
         len: usize,
         flags: ReceiveFlags,
-        addr: Option<Platform::RawMutPointer<u8>>,
-        addrlen: Platform::RawMutPointer<u32>,
+        addr: Option<UserPtrMut<u8>>,
+        addrlen: UserPtrMut<u32>,
     },
     Recvmsg {
         sockfd: i32,
-        msg: Platform::RawMutPointer<UserMsgHdr<Platform>>,
+        msg: UserPtrMut<UserMsgHdr>,
         flags: ReceiveFlags,
     },
     Recvmmsg {
         sockfd: i32,
-        msgvec: Platform::RawMutPointer<UserMmsgHdr<Platform>>,
+        msgvec: UserPtrMut<UserMmsgHdr>,
         vlen: u32,
         flags: ReceiveFlags,
-        timeout: TimeParam<Platform>,
+        timeout: TimeParam,
     },
     Shutdown {
         sockfd: i32,
@@ -2200,7 +2166,7 @@ pub enum SyscallRequest<Platform: litebox::platform::RawPointerProvider> {
     },
     Bind {
         sockfd: i32,
-        sockaddr: Platform::RawConstPointer<u8>,
+        sockaddr: UserPtr<u8>,
         addrlen: usize,
     },
     Listen {
@@ -2211,49 +2177,49 @@ pub enum SyscallRequest<Platform: litebox::platform::RawPointerProvider> {
         sockfd: i32,
         level: u32,
         optname: u32,
-        optval: Platform::RawConstPointer<u8>,
+        optval: UserPtr<u8>,
         optlen: usize,
     },
     Getsockopt {
         sockfd: i32,
         level: u32,
         optname: u32,
-        optval: Platform::RawMutPointer<u8>,
-        optlen: Platform::RawMutPointer<u32>,
+        optval: UserPtrMut<u8>,
+        optlen: UserPtrMut<u32>,
     },
     Getsockname {
         sockfd: i32,
-        addr: Platform::RawMutPointer<u8>,
-        addrlen: Platform::RawMutPointer<u32>,
+        addr: UserPtrMut<u8>,
+        addrlen: UserPtrMut<u32>,
     },
     Getpeername {
         sockfd: i32,
-        addr: Platform::RawMutPointer<u8>,
-        addrlen: Platform::RawMutPointer<u32>,
+        addr: UserPtrMut<u8>,
+        addrlen: UserPtrMut<u32>,
     },
     Uname {
-        buf: Platform::RawMutPointer<Utsname>,
+        buf: UserPtrMut<Utsname>,
     },
     Fcntl {
         fd: i32,
-        arg: FcntlArg<Platform>,
+        arg: FcntlArg,
     },
     Getcwd {
-        buf: Platform::RawMutPointer<u8>,
+        buf: UserPtrMut<u8>,
         size: usize,
     },
     EpollCtl {
         epfd: i32,
         op: EpollOp,
         fd: i32,
-        event: Platform::RawConstPointer<EpollEvent>,
+        event: UserPtr<EpollEvent>,
     },
     EpollPwait {
         epfd: i32,
-        events: Platform::RawMutPointer<EpollEvent>,
+        events: UserPtrMut<EpollEvent>,
         maxevents: u32,
         timeout: i32,
-        sigmask: Option<Platform::RawConstPointer<SigSet>>,
+        sigmask: Option<UserPtr<SigSet>>,
         sigsetsize: usize,
     },
     EpollCreate {
@@ -2261,37 +2227,37 @@ pub enum SyscallRequest<Platform: litebox::platform::RawPointerProvider> {
         flags: EpollCreateFlags,
     },
     Ppoll {
-        fds: Platform::RawMutPointer<Pollfd>,
+        fds: UserPtrMut<Pollfd>,
         nfds: usize,
-        timeout: TimeParam<Platform>,
-        sigmask: Option<Platform::RawConstPointer<SigSet>>,
+        timeout: TimeParam,
+        sigmask: Option<UserPtr<SigSet>>,
         sigsetsize: usize,
     },
     Pselect {
         nfds: u32,
-        readfds: Option<Platform::RawMutPointer<usize>>,
-        writefds: Option<Platform::RawMutPointer<usize>>,
-        exceptfds: Option<Platform::RawMutPointer<usize>>,
-        timeout: TimeParam<Platform>,
-        sigsetpack: Option<Platform::RawConstPointer<SigSetPack<Platform>>>,
+        readfds: Option<UserPtrMut<usize>>,
+        writefds: Option<UserPtrMut<usize>>,
+        exceptfds: Option<UserPtrMut<usize>>,
+        timeout: TimeParam,
+        sigsetpack: Option<UserPtr<SigSetPack>>,
     },
     ArchPrctl {
-        arg: ArchPrctlArg<Platform>,
+        arg: ArchPrctlArg,
     },
     Readlink {
-        pathname: Platform::RawConstPointer<c_char>,
-        buf: Platform::RawMutPointer<u8>,
+        pathname: UserPtr<c_char>,
+        buf: UserPtrMut<u8>,
         bufsiz: usize,
     },
     Readlinkat {
         dirfd: i32,
-        pathname: Platform::RawConstPointer<c_char>,
-        buf: Platform::RawMutPointer<u8>,
+        pathname: UserPtr<c_char>,
+        buf: UserPtrMut<u8>,
         bufsiz: usize,
     },
     Openat {
         dirfd: i32,
-        pathname: Platform::RawConstPointer<c_char>,
+        pathname: UserPtr<c_char>,
         flags: litebox::fs::OFlags,
         mode: litebox::fs::Mode,
     },
@@ -2301,19 +2267,19 @@ pub enum SyscallRequest<Platform: litebox::platform::RawPointerProvider> {
     },
     Mknodat {
         dirfd: i32,
-        pathname: Platform::RawConstPointer<c_char>,
+        pathname: UserPtr<c_char>,
         mode_and_type: u32,
         dev: u32,
     },
     Unlinkat {
         dirfd: i32,
-        pathname: Platform::RawConstPointer<c_char>,
+        pathname: UserPtr<c_char>,
         flags: AtFlags,
     },
     Newfstatat {
         dirfd: i32,
-        pathname: Platform::RawConstPointer<c_char>,
-        buf: Platform::RawMutPointer<FileStat>,
+        pathname: UserPtr<c_char>,
+        buf: UserPtrMut<FileStat>,
         flags: AtFlags,
     },
     Eventfd2 {
@@ -2321,48 +2287,48 @@ pub enum SyscallRequest<Platform: litebox::platform::RawPointerProvider> {
         flags: EfdFlags,
     },
     Pipe2 {
-        pipefd: Platform::RawMutPointer<u32>,
+        pipefd: UserPtrMut<u32>,
         flags: litebox::fs::OFlags,
     },
     Clone {
         args: CloneArgs,
     },
     Clone3 {
-        args: Platform::RawConstPointer<CloneArgs>,
+        args: UserPtr<CloneArgs>,
     },
     /// Manipulate thread-local storage information.
     /// Returns `ENOSYS` on x86_64.
     SetThreadArea {
-        user_desc: Platform::RawMutPointer<u8>,
+        user_desc: UserPtrMut<u8>,
     },
     ClockGettime {
         clockid: i32,
-        tp: TimeParam<Platform>,
+        tp: TimeParam,
     },
     ClockGetres {
         clockid: i32,
-        res: TimeParam<Platform>,
+        res: TimeParam,
     },
     ClockNanosleep {
         clockid: i32,
         flags: TimerFlags,
-        request: TimeParam<Platform>,
-        remain: TimeParam<Platform>,
+        request: TimeParam,
+        remain: TimeParam,
     },
     Gettimeofday {
-        tv: Option<Platform::RawMutPointer<TimeVal>>,
-        tz: Option<Platform::RawMutPointer<TimeZone>>,
+        tv: Option<UserPtrMut<TimeVal>>,
+        tz: Option<UserPtrMut<TimeZone>>,
     },
     Time {
-        tloc: Option<Platform::RawMutPointer<time_t>>,
+        tloc: Option<UserPtrMut<time_t>>,
     },
     Getrlimit {
         resource: RlimitResource,
-        rlim: Platform::RawMutPointer<Rlimit>,
+        rlim: UserPtrMut<Rlimit>,
     },
     Setrlimit {
         resource: RlimitResource,
-        rlim: Platform::RawConstPointer<Rlimit>,
+        rlim: UserPtr<Rlimit>,
     },
     Prlimit {
         pid: i32,
@@ -2370,13 +2336,13 @@ pub enum SyscallRequest<Platform: litebox::platform::RawPointerProvider> {
         resource: RlimitResource,
         /// If the new_limit argument is not a None, then the rlimit structure to which it points
         /// is used to set new values for the soft and hard limits for resource.
-        new_limit: Option<Platform::RawConstPointer<Rlimit64>>,
+        new_limit: Option<UserPtr<Rlimit64>>,
         /// If the old_limit argument is not a None, then a successful call to prlimit() places the
         /// previous soft and hard limits for resource in the rlimit structure pointed to by old_limit.
-        old_limit: Option<Platform::RawMutPointer<Rlimit64>>,
+        old_limit: Option<UserPtrMut<Rlimit64>>,
     },
     SetTidAddress {
-        tidptr: Platform::RawMutPointer<i32>,
+        tidptr: UserPtrMut<i32>,
     },
     Gettid,
     SetRobustList {
@@ -2384,11 +2350,11 @@ pub enum SyscallRequest<Platform: litebox::platform::RawPointerProvider> {
     },
     GetRobustList {
         pid: Option<i32>,
-        head: Platform::RawMutPointer<usize>,
-        len: Platform::RawMutPointer<usize>,
+        head: UserPtrMut<usize>,
+        len: UserPtrMut<usize>,
     },
     GetRandom {
-        buf: Platform::RawMutPointer<u8>,
+        buf: UserPtrMut<u8>,
         count: usize,
         flags: RngFlags,
     },
@@ -2399,36 +2365,36 @@ pub enum SyscallRequest<Platform: litebox::platform::RawPointerProvider> {
     Getgid,
     Getegid,
     Sysinfo {
-        buf: Platform::RawMutPointer<Sysinfo>,
+        buf: UserPtrMut<Sysinfo>,
     },
     CapGet {
-        header: Platform::RawMutPointer<CapHeader>,
-        data: Option<Platform::RawMutPointer<CapData>>,
+        header: UserPtrMut<CapHeader>,
+        data: Option<UserPtrMut<CapData>>,
     },
     GetDirent64 {
         fd: i32,
-        dirp: Platform::RawMutPointer<u8>,
+        dirp: UserPtrMut<u8>,
         count: usize,
     },
     SchedGetAffinity {
         pid: Option<i32>,
         len: usize,
-        mask: Platform::RawMutPointer<u8>,
+        mask: UserPtrMut<u8>,
     },
     SchedYield,
     Futex {
-        args: FutexArgs<Platform>,
+        args: FutexArgs,
     },
     Execve {
-        pathname: Platform::RawConstPointer<c_char>,
-        argv: Platform::RawConstPointer<Platform::RawConstPointer<c_char>>,
-        envp: Platform::RawConstPointer<Platform::RawConstPointer<c_char>>,
+        pathname: UserPtr<c_char>,
+        argv: UserPtr<UserPtr<c_char>>,
+        envp: UserPtr<UserPtr<c_char>>,
     },
     Umask {
         mask: u32,
     },
     Prctl {
-        args: PrctlArg<Platform>,
+        args: PrctlArg,
     },
     Alarm {
         seconds: u32,
@@ -2436,23 +2402,23 @@ pub enum SyscallRequest<Platform: litebox::platform::RawPointerProvider> {
     Pause,
     SetITimer {
         which: IntervalTimer,
-        new_value: Option<Platform::RawConstPointer<ItimerVal>>,
-        old_value: Option<Platform::RawMutPointer<ItimerVal>>,
+        new_value: Option<UserPtr<ItimerVal>>,
+        old_value: Option<UserPtrMut<ItimerVal>>,
     },
     GetITimer {
         which: IntervalTimer,
-        curr_value: Platform::RawMutPointer<ItimerVal>,
+        curr_value: UserPtrMut<ItimerVal>,
     },
     Statx {
         dirfd: i32,
-        pathname: Option<Platform::RawConstPointer<c_char>>,
+        pathname: Option<UserPtr<c_char>>,
         flags: AtFlags,
         mask: StatxMask,
-        statxbuf: Platform::RawMutPointer<Statx>,
+        statxbuf: UserPtrMut<Statx>,
     },
 }
 
-impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
+impl SyscallRequest {
     /// Take the raw syscall number and arguments, and provide a stronger-typed `SyscallRequest`.
     ///
     /// Returns `Ok` if a valid translation exists, if no such translation exists, returns the [`Errno`](errno::Errno) for it.
@@ -2990,9 +2956,9 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
 
     fn parse_futex<T: FromBytes + IntoBytes>(
         ctx: &PtRegs,
-        time_param: impl FnOnce(Option<Platform::RawMutPointer<T>>) -> TimeParam<Platform>,
+        time_param: impl FnOnce(Option<UserPtrMut<T>>) -> TimeParam,
         unsupported_einval: impl Fn(core::fmt::Arguments<'_>) -> errno::Errno,
-    ) -> Result<SyscallRequest<Platform>, errno::Errno> {
+    ) -> Result<SyscallRequest, errno::Errno> {
         let addr = ctx.sys_req_ptr(0);
         let op_and_flags: i32 = ctx.sys_req_arg(1);
         let op = op_and_flags & FutexFlags::FUTEX_CMD_MASK.bits();
@@ -3028,38 +2994,40 @@ impl<Platform: litebox::platform::RawPointerProvider> SyscallRequest<Platform> {
 }
 
 #[derive(Debug)]
-pub enum TimeParam<Platform: litebox::platform::RawPointerProvider> {
+pub enum TimeParam {
     None,
     Milliseconds(i32),
-    TimeVal(Platform::RawMutPointer<TimeVal>),
-    Timespec32(Platform::RawMutPointer<Timespec32>),
-    Timespec64(Platform::RawMutPointer<Timespec>),
+    TimeVal(UserPtrMut<TimeVal>),
+    Timespec32(UserPtrMut<Timespec32>),
+    Timespec64(UserPtrMut<Timespec>),
 }
 
-impl<Platform: litebox::platform::RawPointerProvider> TimeParam<Platform> {
+impl TimeParam {
     /// Return a `TimeParam` for a 64-bit timespec pointer.
-    pub fn timespec64(tp: Option<Platform::RawMutPointer<Timespec>>) -> Self {
+    pub fn timespec64(tp: Option<UserPtrMut<Timespec>>) -> Self {
         tp.map_or(TimeParam::None, TimeParam::Timespec64)
     }
 
     /// Return a `TimeParam` for a 32-bit timespec pointer.
-    pub fn timespec32(tp: Option<Platform::RawMutPointer<Timespec32>>) -> Self {
+    pub fn timespec32(tp: Option<UserPtrMut<Timespec32>>) -> Self {
         tp.map_or(TimeParam::None, TimeParam::Timespec32)
     }
 
     /// Return a `TimeParam` for the old timespec pointer type, which is
     /// architecture dependent.
-    pub fn timespec_old(tp: Option<Platform::RawMutPointer<Timespec>>) -> Self {
+    pub fn timespec_old(tp: Option<UserPtrMut<Timespec>>) -> Self {
         Self::timespec64(tp)
     }
 
     /// Return a `TimeParam` for a timeval pointer.
-    pub fn timeval(tp: Option<Platform::RawMutPointer<TimeVal>>) -> Self {
+    pub fn timeval(tp: Option<UserPtrMut<TimeVal>>) -> Self {
         tp.map_or(TimeParam::None, TimeParam::TimeVal)
     }
 
     /// Convert a generic timeout argument into a `Timeout` enum.
-    pub fn read(&self) -> Result<Option<Duration>, errno::Errno> {
+    pub fn read<P: litebox::platform::RawPointerProvider>(
+        &self,
+    ) -> Result<Option<Duration>, errno::Errno> {
         let v = match *self {
             TimeParam::None => return Ok(None),
             TimeParam::Milliseconds(s) => {
@@ -3070,15 +3038,15 @@ impl<Platform: litebox::platform::RawPointerProvider> TimeParam<Platform> {
                 Duration::from_millis(s)
             }
             TimeParam::TimeVal(tv) => {
-                let tv = tv.read_at_offset(0).ok_or(errno::Errno::EFAULT)?;
+                let tv = tv.read_at_offset::<P>(0).ok_or(errno::Errno::EFAULT)?;
                 Duration::try_from(tv).map_err(|_| errno::Errno::EINVAL)?
             }
             TimeParam::Timespec32(ts) => {
-                let ts = ts.read_at_offset(0).ok_or(errno::Errno::EFAULT)?;
+                let ts = ts.read_at_offset::<P>(0).ok_or(errno::Errno::EFAULT)?;
                 Duration::try_from(ts).map_err(|_| errno::Errno::EINVAL)?
             }
             TimeParam::Timespec64(ts) => {
-                let ts = ts.read_at_offset(0).ok_or(errno::Errno::EFAULT)?;
+                let ts = ts.read_at_offset::<P>(0).ok_or(errno::Errno::EFAULT)?;
                 Duration::try_from(ts).map_err(|_| errno::Errno::EINVAL)?
             }
         };
@@ -3086,24 +3054,27 @@ impl<Platform: litebox::platform::RawPointerProvider> TimeParam<Platform> {
     }
 
     /// Write a value to the time parameter.
-    pub fn write(&self, duration: Duration) -> Result<(), errno::Errno> {
+    pub fn write<P: litebox::platform::RawPointerProvider>(
+        &self,
+        duration: Duration,
+    ) -> Result<(), errno::Errno> {
         match *self {
             TimeParam::None | TimeParam::Milliseconds(_) => Ok(()),
             TimeParam::TimeVal(tv_ptr) => {
                 tv_ptr
-                    .write_at_offset(0, duration.into())
+                    .write_at_offset::<P>(0, duration.into())
                     .ok_or(errno::Errno::EFAULT)?;
                 Ok(())
             }
             TimeParam::Timespec32(ts_ptr) => {
                 ts_ptr
-                    .write_at_offset(0, duration.into())
+                    .write_at_offset::<P>(0, duration.into())
                     .ok_or(errno::Errno::EFAULT)?;
                 Ok(())
             }
             TimeParam::Timespec64(ts_ptr) => {
                 ts_ptr
-                    .write_at_offset(0, duration.into())
+                    .write_at_offset::<P>(0, duration.into())
                     .ok_or(errno::Errno::EFAULT)?;
                 Ok(())
             }
@@ -3441,17 +3412,31 @@ reinterpret_truncated_from_usize_for! {
 pub trait ReinterpretUsizeAsPtr<T>: Sized {
     fn reinterpret_usize_as_ptr(v: usize) -> Self;
 }
-impl<T: FromBytes, P: RawConstPointer<T>> ReinterpretUsizeAsPtr<core::marker::PhantomData<((), T)>>
-    for P
-{
+impl<T> ReinterpretUsizeAsPtr<core::marker::PhantomData<((), T)>> for UserPtr<T> {
     fn reinterpret_usize_as_ptr(v: usize) -> Self {
-        P::from_usize(v)
+        UserPtr::from_usize(v)
     }
 }
-impl<T: FromBytes, P: RawConstPointer<T>>
-    ReinterpretUsizeAsPtr<core::marker::PhantomData<(bool, T)>> for Option<P>
-{
+impl<T> ReinterpretUsizeAsPtr<core::marker::PhantomData<((), T)>> for UserPtrMut<T> {
     fn reinterpret_usize_as_ptr(v: usize) -> Self {
-        if v == 0 { None } else { Some(P::from_usize(v)) }
+        UserPtrMut::from_usize(v)
+    }
+}
+impl<T> ReinterpretUsizeAsPtr<core::marker::PhantomData<(bool, T)>> for Option<UserPtr<T>> {
+    fn reinterpret_usize_as_ptr(v: usize) -> Self {
+        if v == 0 {
+            None
+        } else {
+            Some(UserPtr::from_usize(v))
+        }
+    }
+}
+impl<T> ReinterpretUsizeAsPtr<core::marker::PhantomData<(bool, T)>> for Option<UserPtrMut<T>> {
+    fn reinterpret_usize_as_ptr(v: usize) -> Self {
+        if v == 0 {
+            None
+        } else {
+            Some(UserPtrMut::from_usize(v))
+        }
     }
 }

--- a/litebox_common_linux/src/lib.rs
+++ b/litebox_common_linux/src/lib.rs
@@ -28,7 +28,7 @@ pub mod vmap;
 
 extern crate alloc;
 
-pub use user_pointers::{UserPtr, UserPtrMut};
+use user_pointers::{UserPtr, UserPtrMut};
 
 /// Number of AArch64 general-purpose registers saved by the Linux user ABI
 /// (`x0` through `x30`).

--- a/litebox_common_linux/src/mm.rs
+++ b/litebox_common_linux/src/mm.rs
@@ -10,7 +10,7 @@ use litebox::{
     platform::{RawConstPointer, page_mgmt::DeallocationError},
 };
 
-use crate::{MRemapFlags, MapFlags, ProtFlags, errno::Errno};
+use crate::{MRemapFlags, MapFlags, ProtFlags, UserPtrMut, errno::Errno};
 
 const PAGE_MASK: usize = !(PAGE_SIZE - 1);
 
@@ -25,8 +25,9 @@ pub fn do_mmap<
     prot: ProtFlags,
     flags: MapFlags,
     ensure_space_after: bool,
-    op: impl FnOnce(Platform::RawMutPointer<u8>) -> Result<usize, litebox::mm::linux::MappingError>,
-) -> Result<Platform::RawMutPointer<u8>, litebox::mm::linux::MappingError> {
+    op: impl FnOnce(UserPtrMut<u8>) -> Result<usize, litebox::mm::linux::MappingError>,
+) -> Result<UserPtrMut<u8>, litebox::mm::linux::MappingError> {
+    let op = |p: Platform::RawMutPointer<u8>| op(UserPtrMut::from_usize(p.as_usize()));
     let flags = {
         let mut create_flags = CreatePagesFlags::empty();
         // MAP_FIXED_NOREPLACE implies MAP_FIXED behavior (exact address, not a hint)
@@ -82,6 +83,7 @@ pub fn do_mmap<
             }
         }
     }
+    .map(|p| UserPtrMut::from_usize(p.as_usize()))
 }
 
 /// Handle syscall `munmap`
@@ -91,7 +93,7 @@ pub fn sys_munmap<
         + litebox::platform::PageManagementProvider<{ litebox::mm::linux::PAGE_SIZE }>,
 >(
     pm: &litebox::mm::PageManager<Platform, { litebox::mm::linux::PAGE_SIZE }>,
-    addr: Platform::RawMutPointer<u8>,
+    addr: UserPtrMut<u8>,
     len: usize,
 ) -> Result<(), Errno> {
     if addr.as_usize() & !PAGE_MASK != 0 {
@@ -107,7 +109,7 @@ pub fn sys_munmap<
         return Err(Errno::EINVAL);
     }
 
-    match unsafe { pm.remove_pages(addr, aligned_len) } {
+    match unsafe { pm.remove_pages(addr.to_platform_ptr::<Platform>(), aligned_len) } {
         Err(VmemUnmapError::UnAligned) => Err(Errno::EINVAL),
         Err(VmemUnmapError::UnmapError(e)) => match e {
             DeallocationError::Unaligned => Err(Errno::EINVAL),
@@ -126,7 +128,7 @@ pub fn sys_mprotect<
         + litebox::platform::PageManagementProvider<{ litebox::mm::linux::PAGE_SIZE }>,
 >(
     pm: &litebox::mm::PageManager<Platform, { litebox::mm::linux::PAGE_SIZE }>,
-    addr: Platform::RawMutPointer<u8>,
+    addr: UserPtrMut<u8>,
     len: usize,
     prot: ProtFlags,
 ) -> Result<(), Errno> {
@@ -137,6 +139,7 @@ pub fn sys_mprotect<
         return Ok(());
     }
 
+    let addr = addr.to_platform_ptr::<Platform>();
     match prot {
         ProtFlags::PROT_READ_EXEC => unsafe { pm.make_pages_executable(addr, len) },
         ProtFlags::PROT_READ_WRITE => unsafe { pm.make_pages_writable(addr, len) },
@@ -160,12 +163,12 @@ pub fn sys_mremap<
         + litebox::platform::PageManagementProvider<{ litebox::mm::linux::PAGE_SIZE }>,
 >(
     pm: &litebox::mm::PageManager<Platform, { litebox::mm::linux::PAGE_SIZE }>,
-    old_addr: Platform::RawMutPointer<u8>,
+    old_addr: UserPtrMut<u8>,
     old_size: usize,
     new_size: usize,
     flags: MRemapFlags,
     _new_addr: usize,
-) -> Result<Platform::RawMutPointer<u8>, Errno> {
+) -> Result<UserPtrMut<u8>, Errno> {
     if flags.intersects(
         (MRemapFlags::MREMAP_FIXED | MRemapFlags::MREMAP_MAYMOVE | MRemapFlags::MREMAP_DONTUNMAP)
             .complement(),
@@ -207,12 +210,13 @@ pub fn sys_mremap<
 
     unsafe {
         pm.remap_pages(
-            old_addr,
+            old_addr.to_platform_ptr::<Platform>(),
             old_size,
             new_size,
             flags.contains(MRemapFlags::MREMAP_MAYMOVE),
         )
     }
+    .map(|p| UserPtrMut::from_usize(p.as_usize()))
     .map_err(Errno::from)
 }
 
@@ -222,7 +226,7 @@ pub fn sys_brk<
         + litebox::platform::PageManagementProvider<{ litebox::mm::linux::PAGE_SIZE }>,
 >(
     pm: &litebox::mm::PageManager<Platform, { litebox::mm::linux::PAGE_SIZE }>,
-    addr: Platform::RawMutPointer<u8>,
+    addr: UserPtrMut<u8>,
 ) -> Result<usize, Errno> {
     unsafe { pm.brk(addr.as_usize()) }.map_err(Errno::from)
 }
@@ -233,7 +237,7 @@ pub fn sys_madvise<
         + litebox::platform::PageManagementProvider<{ litebox::mm::linux::PAGE_SIZE }>,
 >(
     pm: &litebox::mm::PageManager<Platform, { litebox::mm::linux::PAGE_SIZE }>,
-    addr: Platform::RawMutPointer<u8>,
+    addr: UserPtrMut<u8>,
     len: usize,
     advice: crate::MadviseBehavior,
 ) -> Result<(), Errno> {
@@ -252,6 +256,7 @@ pub fn sys_madvise<
         return Err(Errno::EINVAL);
     };
 
+    let addr = addr.to_platform_ptr::<Platform>();
     match advice {
         crate::MadviseBehavior::Normal
         | crate::MadviseBehavior::DontFork

--- a/litebox_common_linux/src/mm.rs
+++ b/litebox_common_linux/src/mm.rs
@@ -7,7 +7,7 @@ use litebox::{
     mm::linux::{
         CreatePagesFlags, MappingError, NonZeroAddress, NonZeroPageSize, PAGE_SIZE, VmemUnmapError,
     },
-    platform::{RawConstPointer, page_mgmt::DeallocationError},
+    platform::page_mgmt::DeallocationError,
 };
 
 use crate::{MRemapFlags, MapFlags, ProtFlags, UserPtrMut, errno::Errno};
@@ -27,7 +27,7 @@ pub fn do_mmap<
     ensure_space_after: bool,
     op: impl FnOnce(UserPtrMut<u8>) -> Result<usize, litebox::mm::linux::MappingError>,
 ) -> Result<UserPtrMut<u8>, litebox::mm::linux::MappingError> {
-    let op = |p: Platform::RawMutPointer<u8>| op(UserPtrMut::from_usize(p.as_usize()));
+    let op = |p: Platform::RawMutPointer<u8>| op(UserPtrMut::from_platform_ptr::<Platform>(p));
     let flags = {
         let mut create_flags = CreatePagesFlags::empty();
         // MAP_FIXED_NOREPLACE implies MAP_FIXED behavior (exact address, not a hint)
@@ -83,7 +83,7 @@ pub fn do_mmap<
             }
         }
     }
-    .map(|p| UserPtrMut::from_usize(p.as_usize()))
+    .map(UserPtrMut::from_platform_ptr::<Platform>)
 }
 
 /// Handle syscall `munmap`
@@ -216,7 +216,7 @@ pub fn sys_mremap<
             flags.contains(MRemapFlags::MREMAP_MAYMOVE),
         )
     }
-    .map(|p| UserPtrMut::from_usize(p.as_usize()))
+    .map(UserPtrMut::from_platform_ptr::<Platform>)
     .map_err(Errno::from)
 }
 

--- a/litebox_common_linux/src/user_pointers.rs
+++ b/litebox_common_linux/src/user_pointers.rs
@@ -1,0 +1,216 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//! Address-only user pointer types.
+//!
+//! These wrap a bare `usize` address and, unlike
+//! [`litebox::platform::RawConstPointer`]/[`litebox::platform::RawMutPointer`],
+//! carry no [`RawPointerProvider`] (`Platform`) parameter. This keeps `Platform`
+//! from being viral across every type that merely *stores* a user pointer value.
+//! Memory is accessed by converting back to the platform pointer type via
+//! [`UserPtr::to_platform_ptr`]/[`UserPtrMut::to_platform_ptr`] (or the
+//! convenience access methods), which take the platform as an explicit witness
+//! `P`.
+
+use litebox::platform::{RawConstPointer, RawMutPointer, RawPointerProvider};
+use zerocopy::{FromBytes, IntoBytes};
+
+/// A user-space const pointer represented purely as an address (`usize`).
+///
+/// Unlike [`litebox::platform::RawConstPointer`], this type carries no
+/// [`RawPointerProvider`] (`Platform`) parameter: it only *stores* the address
+/// of a user pointer. Memory is accessed by converting back to the platform
+/// pointer type via the [`Self::read_at_offset`]/[`Self::to_owned_slice`]
+/// methods, which take the platform as an explicit witness `P`.
+///
+/// This keeps `Platform` from being viral across every type that merely holds a
+/// user pointer value.
+// NOTE: We explicitly write the `T: Sized` bound to document that these need to
+// be "thin" pointers; "fat" pointers (i.e., pointers to DSTs) are unsupported.
+#[derive(FromBytes, IntoBytes)]
+#[repr(transparent)]
+pub struct UserPtr<T: Sized> {
+    /// An exposed-provenance address of the pointer.
+    addr: usize,
+    _phantom: core::marker::PhantomData<*const T>,
+}
+
+impl<T> UserPtr<T> {
+    /// Create a pointer from a raw address.
+    pub fn from_usize(addr: usize) -> Self {
+        Self {
+            addr,
+            _phantom: core::marker::PhantomData,
+        }
+    }
+
+    /// Create a pointer from a native `*const T`, exposing its provenance.
+    pub fn from_ptr(ptr: *const T) -> Self {
+        Self::from_usize(ptr.expose_provenance())
+    }
+
+    /// Get the address of the pointer as a `usize`.
+    pub fn as_usize(&self) -> usize {
+        self.addr
+    }
+
+    /// Whether this pointer's address is null (zero).
+    pub fn is_null(&self) -> bool {
+        self.addr == 0
+    }
+
+    /// Reinterpret this pointer as pointing to a different type `U`.
+    pub fn cast<U>(self) -> UserPtr<U> {
+        UserPtr::from_usize(self.addr)
+    }
+}
+
+impl<T> Clone for UserPtr<T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl<T> Copy for UserPtr<T> {}
+impl<T> core::fmt::Debug for UserPtr<T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_tuple("UserPtr").field(&self.addr).finish()
+    }
+}
+
+impl<T: FromBytes> UserPtr<T> {
+    /// Convert this address-only pointer into platform `P`'s const pointer type,
+    /// through which memory can actually be accessed.
+    pub fn to_platform_ptr<P: RawPointerProvider>(self) -> P::RawConstPointer<T> {
+        <P::RawConstPointer<T> as RawConstPointer<T>>::from_usize(self.addr)
+    }
+
+    /// See [`RawConstPointer::read_at_offset`].
+    pub fn read_at_offset<P: RawPointerProvider>(self, count: isize) -> Option<T> {
+        self.to_platform_ptr::<P>().read_at_offset(count)
+    }
+
+    /// See [`RawConstPointer::to_owned_slice`].
+    pub fn to_owned_slice<P: RawPointerProvider>(
+        self,
+        len: usize,
+    ) -> Option<alloc::boxed::Box<[T]>> {
+        self.to_platform_ptr::<P>().to_owned_slice(len)
+    }
+}
+
+impl UserPtr<core::ffi::c_char> {
+    /// See [`RawConstPointer::to_cstring`].
+    pub fn to_cstring<P: RawPointerProvider>(self) -> Option<alloc::ffi::CString> {
+        self.to_platform_ptr::<P>().to_cstring()
+    }
+}
+
+/// A user-space mutable pointer represented purely as an address (`usize`).
+///
+/// The mutable counterpart of [`UserPtr`]. See [`UserPtr`] for the rationale.
+// NOTE: We explicitly write the `T: Sized` bound to document that these need to
+// be "thin" pointers; "fat" pointers (i.e., pointers to DSTs) are unsupported.
+#[derive(FromBytes, IntoBytes)]
+#[repr(transparent)]
+pub struct UserPtrMut<T: Sized> {
+    /// An exposed-provenance address of the pointer.
+    addr: usize,
+    _phantom: core::marker::PhantomData<*mut T>,
+}
+
+impl<T> UserPtrMut<T> {
+    /// Create a pointer from a raw address.
+    pub fn from_usize(addr: usize) -> Self {
+        Self {
+            addr,
+            _phantom: core::marker::PhantomData,
+        }
+    }
+
+    /// Create a pointer from a native `*mut T`, exposing its provenance.
+    pub fn from_ptr(ptr: *mut T) -> Self {
+        Self::from_usize(ptr.expose_provenance())
+    }
+
+    /// Get the address of the pointer as a `usize`.
+    pub fn as_usize(&self) -> usize {
+        self.addr
+    }
+
+    /// Whether this pointer's address is null (zero).
+    pub fn is_null(&self) -> bool {
+        self.addr == 0
+    }
+
+    /// Reinterpret this pointer as pointing to a different type `U`.
+    pub fn cast<U>(self) -> UserPtrMut<U> {
+        UserPtrMut::from_usize(self.addr)
+    }
+}
+
+impl<T> Clone for UserPtrMut<T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl<T> Copy for UserPtrMut<T> {}
+impl<T> core::fmt::Debug for UserPtrMut<T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_tuple("UserPtrMut").field(&self.addr).finish()
+    }
+}
+
+impl<T: FromBytes + IntoBytes> UserPtrMut<T> {
+    /// Convert this address-only pointer into platform `P`'s mutable pointer type,
+    /// through which memory can actually be accessed.
+    pub fn to_platform_ptr<P: RawPointerProvider>(self) -> P::RawMutPointer<T> {
+        <P::RawMutPointer<T> as RawConstPointer<T>>::from_usize(self.addr)
+    }
+
+    /// See [`RawConstPointer::read_at_offset`].
+    pub fn read_at_offset<P: RawPointerProvider>(self, count: isize) -> Option<T> {
+        self.to_platform_ptr::<P>().read_at_offset(count)
+    }
+
+    /// See [`RawConstPointer::to_owned_slice`].
+    pub fn to_owned_slice<P: RawPointerProvider>(
+        self,
+        len: usize,
+    ) -> Option<alloc::boxed::Box<[T]>> {
+        self.to_platform_ptr::<P>().to_owned_slice(len)
+    }
+
+    /// See [`RawMutPointer::write_at_offset`].
+    #[must_use]
+    pub fn write_at_offset<P: RawPointerProvider>(self, count: isize, value: T) -> Option<()> {
+        self.to_platform_ptr::<P>().write_at_offset(count, value)
+    }
+
+    /// See [`RawMutPointer::write_slice_at_offset`].
+    #[must_use]
+    pub fn write_slice_at_offset<P: RawPointerProvider>(
+        self,
+        count: isize,
+        values: &[T],
+    ) -> Option<()>
+    where
+        T: Clone,
+    {
+        self.to_platform_ptr::<P>()
+            .write_slice_at_offset(count, values)
+    }
+
+    /// See [`RawMutPointer::copy_from_slice`].
+    #[must_use]
+    pub fn copy_from_slice<P: RawPointerProvider>(
+        self,
+        start_offset: usize,
+        buf: &[T],
+    ) -> Option<()>
+    where
+        T: Copy,
+    {
+        self.to_platform_ptr::<P>()
+            .copy_from_slice(start_offset, buf)
+    }
+}

--- a/litebox_common_linux/src/user_pointers.rs
+++ b/litebox_common_linux/src/user_pointers.rs
@@ -32,6 +32,8 @@ use zerocopy::{FromBytes, IntoBytes};
 pub struct UserPtr<T: Sized> {
     /// An exposed-provenance address of the pointer.
     addr: usize,
+    /// Note: This keeps user pointers `!Send + !Sync`; see
+    /// <https://github.com/microsoft/litebox/issues/431>.
     _phantom: core::marker::PhantomData<*const T>,
 }
 
@@ -115,6 +117,8 @@ impl UserPtr<core::ffi::c_char> {
 pub struct UserPtrMut<T: Sized> {
     /// An exposed-provenance address of the pointer.
     addr: usize,
+    /// Note: This keeps user pointers `!Send + !Sync`; see
+    /// <https://github.com/microsoft/litebox/issues/431>.
     _phantom: core::marker::PhantomData<*mut T>,
 }
 

--- a/litebox_common_linux/src/user_pointers.rs
+++ b/litebox_common_linux/src/user_pointers.rs
@@ -80,6 +80,11 @@ impl<T> core::fmt::Debug for UserPtr<T> {
 }
 
 impl<T: FromBytes> UserPtr<T> {
+    /// Convert platform `P`'s const pointer type into an address-only pointer.
+    pub fn from_platform_ptr<P: RawPointerProvider>(ptr: P::RawConstPointer<T>) -> Self {
+        Self::from_usize(ptr.as_usize())
+    }
+
     /// Convert this address-only pointer into platform `P`'s const pointer type,
     /// through which memory can actually be accessed.
     pub fn to_platform_ptr<P: RawPointerProvider>(self) -> P::RawConstPointer<T> {
@@ -165,6 +170,11 @@ impl<T> core::fmt::Debug for UserPtrMut<T> {
 }
 
 impl<T: FromBytes + IntoBytes> UserPtrMut<T> {
+    /// Convert platform `P`'s mutable pointer type into an address-only pointer.
+    pub fn from_platform_ptr<P: RawPointerProvider>(ptr: P::RawMutPointer<T>) -> Self {
+        Self::from_usize(ptr.as_usize())
+    }
+
     /// Convert this address-only pointer into platform `P`'s mutable pointer type,
     /// through which memory can actually be accessed.
     pub fn to_platform_ptr<P: RawPointerProvider>(self) -> P::RawMutPointer<T> {

--- a/litebox_shim_linux/src/lib.rs
+++ b/litebox_shim_linux/src/lib.rs
@@ -30,7 +30,11 @@ use litebox::{
     sync::futex::FutexManager,
     utils::{ReinterpretSignedExt as _, ReinterpretUnsignedExt as _},
 };
-use litebox_common_linux::{SyscallRequest, UserPtr, UserPtrMut, errno::Errno};
+use litebox_common_linux::{
+    SyscallRequest,
+    errno::Errno,
+    user_pointers::{UserPtr, UserPtrMut},
+};
 use litebox_platform_multiplex::Platform;
 
 /// On debug builds, logs that the user attempted to use an unsupported feature.

--- a/litebox_shim_linux/src/lib.rs
+++ b/litebox_shim_linux/src/lib.rs
@@ -25,12 +25,12 @@ use litebox::{
     mm::{PageManager, linux::PAGE_SIZE},
     net::Network,
     pipes::Pipes,
-    platform::{RawConstPointer as _, RawMutPointer as _, TimeProvider},
+    platform::TimeProvider,
     shim::ContinueOperation,
     sync::futex::FutexManager,
     utils::{ReinterpretSignedExt as _, ReinterpretUnsignedExt as _},
 };
-use litebox_common_linux::{SyscallRequest, errno::Errno};
+use litebox_common_linux::{SyscallRequest, UserPtr, UserPtrMut, errno::Errno};
 use litebox_platform_multiplex::Platform;
 
 /// On debug builds, logs that the user attempted to use an unsupported feature.
@@ -394,10 +394,6 @@ impl<FS: ShimFS> syscalls::file::FilesState<FS> {
     }
 }
 
-// Convenience type aliases
-type ConstPtr<T> = <Platform as litebox::platform::RawPointerProvider>::RawConstPointer<T>;
-type MutPtr<T> = <Platform as litebox::platform::RawPointerProvider>::RawMutPointer<T>;
-
 impl<FS: ShimFS> Task<FS> {
     fn close_on_exec(&self) {
         let files = self.files.borrow();
@@ -484,7 +480,7 @@ impl<FS: ShimFS> Task<FS> {
     fn pread_with_user_buf(
         &self,
         fd: i32,
-        buf: MutPtr<u8>,
+        buf: UserPtrMut<u8>,
         count: usize,
         offset: i64,
     ) -> Result<usize, Errno> {
@@ -499,7 +495,7 @@ impl<FS: ShimFS> Task<FS> {
             ) {
                 Ok(0) => break, // EOF
                 Ok(size) => {
-                    buf.copy_from_slice(read_total, &kernel_buf[..size])
+                    buf.copy_from_slice::<Platform>(read_total, &kernel_buf[..size])
                         .ok_or(Errno::EFAULT)?;
                     read_total += size;
                 }
@@ -536,8 +532,7 @@ impl<FS: ShimFS> Task<FS> {
 
         #[cfg(target_arch = "x86_64")]
         let syscall_number = ctx.orig_rax;
-        let request =
-            SyscallRequest::<Platform>::try_from_raw(syscall_number, ctx, log_unsupported_fmt)?;
+        let request = SyscallRequest::try_from_raw(syscall_number, ctx, log_unsupported_fmt)?;
 
         match request {
             SyscallRequest::Exit { status } => {
@@ -559,7 +554,7 @@ impl<FS: ShimFS> Task<FS> {
                 if count <= MAX_KERNEL_BUF_SIZE {
                     let mut kernel_buf = vec![0u8; count.min(MAX_KERNEL_BUF_SIZE)];
                     self.sys_read(fd, &mut kernel_buf, None).and_then(|size| {
-                        buf.copy_from_slice(0, &kernel_buf[..size])
+                        buf.copy_from_slice::<Platform>(0, &kernel_buf[..size])
                             .map(|()| size)
                             .ok_or(Errno::EFAULT)
                     })
@@ -596,7 +591,8 @@ impl<FS: ShimFS> Task<FS> {
                     })
                 }
             }
-            SyscallRequest::Write { fd, buf, count } => match buf.to_owned_slice(count) {
+            SyscallRequest::Write { fd, buf, count } => match buf.to_owned_slice::<Platform>(count)
+            {
                 Some(buf) => self.sys_write(fd, &buf, None),
                 None => Err(Errno::EFAULT),
             },
@@ -611,11 +607,13 @@ impl<FS: ShimFS> Task<FS> {
                 dirfd,
                 pathname,
                 mode,
-            } => pathname.to_cstring().map_or(Err(Errno::EFAULT), |path| {
-                syscall!(sys_mkdirat(dirfd, path, mode))
-            }),
+            } => pathname
+                .to_cstring::<Platform>()
+                .map_or(Err(Errno::EFAULT), |path| {
+                    syscall!(sys_mkdirat(dirfd, path, mode))
+                }),
             SyscallRequest::Chdir { pathname } => pathname
-                .to_cstring()
+                .to_cstring::<Platform>()
                 .map_or(Err(Errno::EINVAL), |path| syscall!(sys_chdir(path))),
             SyscallRequest::RtSigprocmask {
                 how,
@@ -642,7 +640,7 @@ impl<FS: ShimFS> Task<FS> {
                 buf,
                 count,
                 offset,
-            } => match buf.to_owned_slice(count) {
+            } => match buf.to_owned_slice::<Platform>(count) {
                 Some(buf) => self.sys_pwrite64(fd, &buf, offset),
                 None => Err(Errno::EFAULT),
             },
@@ -697,9 +695,11 @@ impl<FS: ShimFS> Task<FS> {
                 pathname,
                 mode,
                 flags,
-            } => pathname.to_cstring().map_or(Err(Errno::EFAULT), |path| {
-                syscall!(sys_faccessat(dirfd, path, mode, flags))
-            }),
+            } => pathname
+                .to_cstring::<Platform>()
+                .map_or(Err(Errno::EFAULT), |path| {
+                    syscall!(sys_faccessat(dirfd, path, mode, flags))
+                }),
             SyscallRequest::Madvise {
                 addr,
                 length,
@@ -801,7 +801,7 @@ impl<FS: ShimFS> Task<FS> {
             SyscallRequest::Getcwd { buf, size: count } => {
                 let mut kernel_buf = vec![0u8; count.min(MAX_KERNEL_BUF_SIZE)];
                 self.sys_getcwd(&mut kernel_buf).and_then(|size| {
-                    buf.copy_from_slice(0, &kernel_buf[..size])
+                    buf.copy_from_slice::<Platform>(0, &kernel_buf[..size])
                         .map(|()| size)
                         .ok_or(Errno::EFAULT)
                 })
@@ -834,14 +834,16 @@ impl<FS: ShimFS> Task<FS> {
                 pathname,
                 buf,
                 bufsiz,
-            } => pathname.to_cstring().map_or(Err(Errno::EFAULT), |path| {
-                let mut kernel_buf = vec![0u8; bufsiz.min(MAX_KERNEL_BUF_SIZE)];
-                self.sys_readlink(path, &mut kernel_buf).and_then(|size| {
-                    buf.copy_from_slice(0, &kernel_buf[..size])
-                        .map(|()| size)
-                        .ok_or(Errno::EFAULT)
-                })
-            }),
+            } => pathname
+                .to_cstring::<Platform>()
+                .map_or(Err(Errno::EFAULT), |path| {
+                    let mut kernel_buf = vec![0u8; bufsiz.min(MAX_KERNEL_BUF_SIZE)];
+                    self.sys_readlink(path, &mut kernel_buf).and_then(|size| {
+                        buf.copy_from_slice::<Platform>(0, &kernel_buf[..size])
+                            .map(|()| size)
+                            .ok_or(Errno::EFAULT)
+                    })
+                }),
             SyscallRequest::Ppoll {
                 fds,
                 nfds,
@@ -862,15 +864,17 @@ impl<FS: ShimFS> Task<FS> {
                 pathname,
                 buf,
                 bufsiz,
-            } => pathname.to_cstring().map_or(Err(Errno::EFAULT), |path| {
-                let mut kernel_buf = vec![0u8; bufsiz.min(MAX_KERNEL_BUF_SIZE)];
-                self.sys_readlinkat(dirfd, path, &mut kernel_buf)
-                    .and_then(|size| {
-                        buf.copy_from_slice(0, &kernel_buf[..size])
-                            .map(|()| size)
-                            .ok_or(Errno::EFAULT)
-                    })
-            }),
+            } => pathname
+                .to_cstring::<Platform>()
+                .map_or(Err(Errno::EFAULT), |path| {
+                    let mut kernel_buf = vec![0u8; bufsiz.min(MAX_KERNEL_BUF_SIZE)];
+                    self.sys_readlinkat(dirfd, path, &mut kernel_buf)
+                        .and_then(|size| {
+                            buf.copy_from_slice::<Platform>(0, &kernel_buf[..size])
+                                .map(|()| size)
+                                .ok_or(Errno::EFAULT)
+                        })
+                }),
             SyscallRequest::Gettimeofday { tv, tz } => syscall!(sys_gettimeofday(tv, tz)),
             SyscallRequest::ClockGettime { clockid, tp } => {
                 litebox_common_linux::ClockId::try_from(clockid)
@@ -909,45 +913,55 @@ impl<FS: ShimFS> Task<FS> {
                 pathname,
                 flags,
                 mode,
-            } => pathname.to_cstring().map_or(Err(Errno::EFAULT), |path| {
-                syscall!(sys_openat(dirfd, path, flags, mode))
-            }),
+            } => pathname
+                .to_cstring::<Platform>()
+                .map_or(Err(Errno::EFAULT), |path| {
+                    syscall!(sys_openat(dirfd, path, flags, mode))
+                }),
             SyscallRequest::Ftruncate { fd, length } => syscall!(sys_ftruncate(fd, length)),
             SyscallRequest::Mknodat {
                 dirfd,
                 pathname,
                 mode_and_type,
                 dev,
-            } => pathname.to_cstring().map_or(Err(Errno::EFAULT), |path| {
-                syscall!(sys_mknodat(dirfd, path, mode_and_type, dev))
-            }),
+            } => pathname
+                .to_cstring::<Platform>()
+                .map_or(Err(Errno::EFAULT), |path| {
+                    syscall!(sys_mknodat(dirfd, path, mode_and_type, dev))
+                }),
             SyscallRequest::Unlinkat {
                 dirfd,
                 pathname,
                 flags,
-            } => pathname.to_cstring().map_or(Err(Errno::EFAULT), |path| {
-                syscall!(sys_unlinkat(dirfd, path, flags))
-            }),
+            } => pathname
+                .to_cstring::<Platform>()
+                .map_or(Err(Errno::EFAULT), |path| {
+                    syscall!(sys_unlinkat(dirfd, path, flags))
+                }),
             SyscallRequest::Stat { pathname, buf } => {
-                pathname.to_cstring().map_or(Err(Errno::EFAULT), |path| {
-                    self.sys_stat(path).and_then(|stat| {
-                        buf.write_at_offset(0, stat)
-                            .ok_or(Errno::EFAULT)
-                            .map(|()| 0)
+                pathname
+                    .to_cstring::<Platform>()
+                    .map_or(Err(Errno::EFAULT), |path| {
+                        self.sys_stat(path).and_then(|stat| {
+                            buf.write_at_offset::<Platform>(0, stat)
+                                .ok_or(Errno::EFAULT)
+                                .map(|()| 0)
+                        })
                     })
-                })
             }
             SyscallRequest::Lstat { pathname, buf } => {
-                pathname.to_cstring().map_or(Err(Errno::EFAULT), |path| {
-                    self.sys_lstat(path).and_then(|stat| {
-                        buf.write_at_offset(0, stat)
-                            .ok_or(Errno::EFAULT)
-                            .map(|()| 0)
+                pathname
+                    .to_cstring::<Platform>()
+                    .map_or(Err(Errno::EFAULT), |path| {
+                        self.sys_lstat(path).and_then(|stat| {
+                            buf.write_at_offset::<Platform>(0, stat)
+                                .ok_or(Errno::EFAULT)
+                                .map(|()| 0)
+                        })
                     })
-                })
             }
             SyscallRequest::Fstat { fd, buf } => self.sys_fstat(fd).and_then(|stat| {
-                buf.write_at_offset(0, stat)
+                buf.write_at_offset::<Platform>(0, stat)
                     .ok_or(Errno::EFAULT)
                     .map(|()| 0)
             }),
@@ -957,13 +971,15 @@ impl<FS: ShimFS> Task<FS> {
                 pathname,
                 buf,
                 flags,
-            } => pathname.to_cstring().map_or(Err(Errno::EFAULT), |path| {
-                self.sys_newfstatat(dirfd, path, flags).and_then(|stat| {
-                    buf.write_at_offset(0, stat)
-                        .ok_or(Errno::EFAULT)
-                        .map(|()| 0)
-                })
-            }),
+            } => pathname
+                .to_cstring::<Platform>()
+                .map_or(Err(Errno::EFAULT), |path| {
+                    self.sys_newfstatat(dirfd, path, flags).and_then(|stat| {
+                        buf.write_at_offset::<Platform>(0, stat)
+                            .ok_or(Errno::EFAULT)
+                            .map(|()| 0)
+                    })
+                }),
             SyscallRequest::Statx {
                 dirfd,
                 pathname,
@@ -977,12 +993,12 @@ impl<FS: ShimFS> Task<FS> {
                         Ok(c"".into()),
                         flags | litebox_common_linux::AtFlags::AT_EMPTY_PATH,
                     ),
-                    Some(p) => (p.to_cstring().ok_or(Errno::EFAULT), flags),
+                    Some(p) => (p.to_cstring::<Platform>().ok_or(Errno::EFAULT), flags),
                 };
                 path.and_then(|path| {
                     self.sys_statx(dirfd, path, flags, mask).and_then(|sx| {
                         statxbuf
-                            .write_at_offset(0, sx)
+                            .write_at_offset::<Platform>(0, sx)
                             .ok_or(Errno::EFAULT)
                             .map(|()| 0)
                     })
@@ -993,8 +1009,12 @@ impl<FS: ShimFS> Task<FS> {
             }
             SyscallRequest::Pipe2 { pipefd, flags } => {
                 self.sys_pipe2(flags).and_then(|(read_fd, write_fd)| {
-                    pipefd.write_at_offset(0, read_fd).ok_or(Errno::EFAULT)?;
-                    pipefd.write_at_offset(1, write_fd).ok_or(Errno::EFAULT)?;
+                    pipefd
+                        .write_at_offset::<Platform>(0, read_fd)
+                        .ok_or(Errno::EFAULT)?;
+                    pipefd
+                        .write_at_offset::<Platform>(1, write_fd)
+                        .ok_or(Errno::EFAULT)?;
                     Ok(0)
                 })
             }
@@ -1030,8 +1050,11 @@ impl<FS: ShimFS> Task<FS> {
             SyscallRequest::GetRobustList { pid, head, len } => self
                 .sys_get_robust_list(pid, head)
                 .and_then(|()| {
-                    len.write_at_offset(0, size_of::<litebox_common_linux::RobustListHead>())
-                        .ok_or(Errno::EFAULT)
+                    len.write_at_offset::<Platform>(
+                        0,
+                        size_of::<litebox_common_linux::RobustListHead>(),
+                    )
+                    .ok_or(Errno::EFAULT)
                 })
                 .map(|()| 0),
             SyscallRequest::GetRandom { buf, count, flags } => {
@@ -1045,7 +1068,7 @@ impl<FS: ShimFS> Task<FS> {
             SyscallRequest::Getegid => Ok(self.sys_getegid() as usize),
             SyscallRequest::Sysinfo { buf } => {
                 let sysinfo = self.sys_sysinfo();
-                buf.write_at_offset(0, sysinfo)
+                buf.write_at_offset::<Platform>(0, sysinfo)
                     .ok_or(Errno::EFAULT)
                     .map(|()| 0)
             }
@@ -1062,7 +1085,7 @@ impl<FS: ShimFS> Task<FS> {
                     Err(Errno::EINVAL)
                 } else {
                     let raw_bytes = cpuset.as_bytes();
-                    mask.copy_from_slice(0, raw_bytes)
+                    mask.copy_from_slice::<Platform>(0, raw_bytes)
                         .map(|()| raw_bytes.len())
                         .ok_or(Errno::EFAULT)
                 }

--- a/litebox_shim_linux/src/loader/elf.rs
+++ b/litebox_shim_linux/src/loader/elf.rs
@@ -14,7 +14,7 @@ use litebox_common_linux::{MapFlags, errno::Errno, loader::ElfParsedFile};
 use thiserror::Error;
 
 use crate::{
-    MutPtr,
+    UserPtrMut,
     loader::auxv::{AuxKey, AuxVec},
 };
 
@@ -116,10 +116,10 @@ impl<FS: ShimFS> litebox_common_linux::loader::MapMemory for ElfFile<'_, FS> {
             align,
         );
         if let Some((addr, size)) = regions.head_unmap {
-            self.task.sys_munmap(MutPtr::from_usize(addr), size)?;
+            self.task.sys_munmap(UserPtrMut::from_usize(addr), size)?;
         }
         if let Some((addr, size)) = regions.tail_unmap {
-            self.task.sys_munmap(MutPtr::from_usize(addr), size)?;
+            self.task.sys_munmap(UserPtrMut::from_usize(addr), size)?;
         }
         Ok(regions.aligned_ptr)
     }
@@ -165,7 +165,7 @@ impl<FS: ShimFS> litebox_common_linux::loader::MapMemory for ElfFile<'_, FS> {
         len: usize,
         prot: &litebox_common_linux::loader::Protection,
     ) -> Result<(), Self::Error> {
-        let addr = crate::MutPtr::<u8>::from_usize(address);
+        let addr = crate::UserPtrMut::<u8>::from_usize(address);
         self.task.sys_mprotect(addr, len, prot.flags())
     }
 }
@@ -294,8 +294,11 @@ impl<'a, FS: ShimFS> ElfLoader<'a, FS> {
                 .create_stack_pages(None, length, CreatePagesFlags::empty())
                 .map_err(ElfLoaderError::MappingError)?
         };
-        let mut stack = UserStack::new(sp, super::DEFAULT_STACK_SIZE)
-            .ok_or(ElfLoaderError::InvalidStackAddr)?;
+        let mut stack = UserStack::new(
+            UserPtrMut::from_usize(sp.as_usize()),
+            super::DEFAULT_STACK_SIZE,
+        )
+        .ok_or(ElfLoaderError::InvalidStackAddr)?;
         stack
             .init(argv, envp, aux)
             .ok_or(ElfLoaderError::InvalidStackAddr)?;

--- a/litebox_shim_linux/src/loader/elf.rs
+++ b/litebox_shim_linux/src/loader/elf.rs
@@ -7,10 +7,11 @@ use alloc::{ffi::CString, vec::Vec};
 use litebox::{
     fs::{Mode, OFlags},
     mm::linux::{CreatePagesFlags, MappingError, PAGE_SIZE},
-    platform::{RawConstPointer as _, SystemInfoProvider as _},
+    platform::SystemInfoProvider as _,
     utils::{ReinterpretSignedExt, TruncateExt},
 };
 use litebox_common_linux::{MapFlags, errno::Errno, loader::ElfParsedFile};
+use litebox_platform_multiplex::Platform;
 use thiserror::Error;
 
 use crate::{
@@ -295,7 +296,7 @@ impl<'a, FS: ShimFS> ElfLoader<'a, FS> {
                 .map_err(ElfLoaderError::MappingError)?
         };
         let mut stack = UserStack::new(
-            UserPtrMut::from_usize(sp.as_usize()),
+            UserPtrMut::from_platform_ptr::<Platform>(sp),
             super::DEFAULT_STACK_SIZE,
         )
         .ok_or(ElfLoaderError::InvalidStackAddr)?;

--- a/litebox_shim_linux/src/loader/elf.rs
+++ b/litebox_shim_linux/src/loader/elf.rs
@@ -165,7 +165,7 @@ impl<FS: ShimFS> litebox_common_linux::loader::MapMemory for ElfFile<'_, FS> {
         len: usize,
         prot: &litebox_common_linux::loader::Protection,
     ) -> Result<(), Self::Error> {
-        let addr = crate::UserPtrMut::<u8>::from_usize(address);
+        let addr = UserPtrMut::<u8>::from_usize(address);
         self.task.sys_mprotect(addr, len, prot.flags())
     }
 }

--- a/litebox_shim_linux/src/loader/stack.rs
+++ b/litebox_shim_linux/src/loader/stack.rs
@@ -4,13 +4,11 @@
 //! This module manages the stack layout for the user process.
 
 use alloc::{collections::btree_map::BTreeMap, ffi::CString, vec::Vec};
-use litebox::{
-    platform::{RawConstPointer, RawMutPointer},
-    utils::ReinterpretSignedExt as _,
-};
+use litebox::utils::ReinterpretSignedExt as _;
+use litebox_platform_multiplex::Platform;
 
 use crate::{
-    MutPtr,
+    UserPtrMut,
     loader::auxv::{AuxKey, AuxVec},
 };
 
@@ -54,7 +52,7 @@ use crate::{
 /// values, rather than 64-bit values) is used for 32-bit processes.
 pub(super) struct UserStack {
     /// The top of the stack (base address)
-    stack_top: MutPtr<u8>,
+    stack_top: UserPtrMut<u8>,
     /// The length of the stack
     #[expect(dead_code, reason = "should we remove this?")]
     len: usize,
@@ -69,8 +67,8 @@ impl UserStack {
     /// Create a new stack for the user process.
     ///
     /// `stack_top` and `len` must be aligned to [`Self::STACK_ALIGNMENT`]
-    pub(super) fn new(stack_top: MutPtr<u8>, len: usize) -> Option<Self> {
-        if stack_top.as_usize() % Self::STACK_ALIGNMENT != 0 {
+    pub(super) fn new(stack_top: UserPtrMut<u8>, len: usize) -> Option<Self> {
+        if !stack_top.as_usize().is_multiple_of(Self::STACK_ALIGNMENT) {
             return None;
         }
         if !len.is_multiple_of(Self::STACK_ALIGNMENT) {
@@ -94,7 +92,8 @@ impl UserStack {
     fn push_bytes(&mut self, bytes: &[u8]) -> Option<()> {
         let _end = isize::try_from(self.pos).ok()?;
         self.pos = self.pos.checked_sub(bytes.len())?;
-        self.stack_top.copy_from_slice(self.pos, bytes)?;
+        self.stack_top
+            .copy_from_slice::<Platform>(self.pos, bytes)?;
         Some(())
     }
 
@@ -136,10 +135,10 @@ impl UserStack {
         self.push_usize(0)?;
         let size = offsets.len().checked_mul(size_of::<usize>())?;
         self.pos = self.pos.checked_sub(size)?;
-        let ptr: MutPtr<usize> = MutPtr::from_usize(self.stack_top.as_usize() + self.pos);
+        let ptr: UserPtrMut<usize> = UserPtrMut::from_usize(self.stack_top.as_usize() + self.pos);
         for (i, p) in offsets.iter().enumerate() {
             let addr: usize = self.stack_top.as_usize() + *p;
-            ptr.write_at_offset(i.reinterpret_as_signed(), addr)?;
+            ptr.write_at_offset::<Platform>(i.reinterpret_as_signed(), addr)?;
         }
         Some(())
     }
@@ -168,7 +167,7 @@ impl UserStack {
         // end markers
         self.pos = self.pos.checked_sub(size_of::<usize>())?;
         self.stack_top
-            .write_at_offset(isize::try_from(self.pos).ok()?, 0)?;
+            .write_at_offset::<Platform>(isize::try_from(self.pos).ok()?, 0)?;
 
         let envp = self.push_cstrings(&env)?;
         let argvp = self.push_cstrings(&argv)?;

--- a/litebox_shim_linux/src/syscalls/file.rs
+++ b/litebox_shim_linux/src/syscalls/file.rs
@@ -2168,7 +2168,7 @@ impl<FS: ShimFS> Task<FS> {
             // TODO: This is not great from a provenance perspective. Consider
             // adding cast+add methods to UserPtr/UserPtrMut.
             let fd_addr = fds_base_addr + i * core::mem::size_of::<litebox_common_linux::Pollfd>();
-            let revents_ptr = crate::UserPtrMut::<i16>::from_usize(
+            let revents_ptr = UserPtrMut::<i16>::from_usize(
                 fd_addr + core::mem::offset_of!(litebox_common_linux::Pollfd, revents),
             );
             let revents: u16 = revents.bits().trunc();
@@ -2544,11 +2544,11 @@ impl<FS: ShimFS> Task<FS> {
                         typ: litebox_common_linux::DirentType::from(entry.file_type.clone()) as u8,
                         __name: [0; 0],
                     };
-                    let hdr_ptr = crate::UserPtrMut::from_usize(dirp.as_usize() + nbytes);
+                    let hdr_ptr = UserPtrMut::from_usize(dirp.as_usize() + nbytes);
                     hdr_ptr
                         .write_at_offset::<Platform>(0, dirent64)
                         .ok_or(Errno::EFAULT)?;
-                    let name_ptr = crate::UserPtrMut::from_usize(
+                    let name_ptr = UserPtrMut::from_usize(
                         hdr_ptr.as_usize() + DIRENT_STRUCT_BYTES_WITHOUT_NAME,
                     );
                     name_ptr

--- a/litebox_shim_linux/src/syscalls/file.rs
+++ b/litebox_shim_linux/src/syscalls/file.rs
@@ -14,7 +14,7 @@ use litebox::{
     fs::{Mode, OFlags, SeekWhence},
     mm::linux::PAGE_SIZE,
     path,
-    platform::{RawConstPointer, RawMutPointer, StdioProvider, StdioStream},
+    platform::{StdioProvider, StdioStream},
     utils::{ReinterpretSignedExt as _, ReinterpretUnsignedExt as _, TruncateExt as _},
 };
 use litebox_common_linux::{
@@ -25,7 +25,7 @@ use litebox_common_linux::{
 use litebox_platform_multiplex::Platform;
 use thiserror::Error;
 
-use crate::{ConstPtr, GlobalState, MutPtr, ShimFS, Task, syscalls::signal};
+use crate::{GlobalState, ShimFS, Task, UserPtr, UserPtrMut, syscalls::signal};
 use core::sync::atomic::{AtomicUsize, Ordering};
 
 #[derive(Clone, Copy)]
@@ -565,7 +565,7 @@ impl<FS: ShimFS> Task<FS> {
         &self,
         out_fd: i32,
         in_fd: i32,
-        offset_ptr: Option<MutPtr<i64>>,
+        offset_ptr: Option<UserPtrMut<i64>>,
         count: usize,
     ) -> Result<usize, Errno> {
         let Ok(in_raw_fd) = u32::try_from(in_fd).and_then(usize::try_from) else {
@@ -576,7 +576,7 @@ impl<FS: ShimFS> Task<FS> {
 
         let mut cur_off = offset_ptr
             .map(|p| {
-                let off = p.read_at_offset(0).ok_or(Errno::EFAULT)?;
+                let off = p.read_at_offset::<Platform>(0).ok_or(Errno::EFAULT)?;
                 if off < 0 {
                     return Err(Errno::EINVAL);
                 }
@@ -647,7 +647,7 @@ impl<FS: ShimFS> Task<FS> {
 
         if let (Some(p), Some(off)) = (offset_ptr, cur_off) {
             let off = i64::try_from(off).map_err(|_| Errno::EOVERFLOW)?;
-            p.write_at_offset(0, off).ok_or(Errno::EFAULT)?;
+            p.write_at_offset::<Platform>(0, off).ok_or(Errno::EFAULT)?;
         }
 
         Ok(total)
@@ -858,14 +858,16 @@ impl<FS: ShimFS> Task<FS> {
     pub(crate) fn sys_preadv(
         &self,
         fd: i32,
-        iovec: ConstPtr<IoReadVec<MutPtr<u8>>>,
+        iovec: UserPtr<IoReadVec>,
         iovcnt: usize,
         offset: i64,
     ) -> Result<usize, Errno> {
         let base_offset = usize::try_from(offset).map_err(|_| Errno::EINVAL)?;
         self.check_raw_fd_exists(fd)?;
         check_iovcnt(iovcnt)?;
-        let iovs: &[IoReadVec<MutPtr<u8>>] = &iovec.to_owned_slice(iovcnt).ok_or(Errno::EFAULT)?;
+        let iovs: &[IoReadVec] = &iovec
+            .to_owned_slice::<Platform>(iovcnt)
+            .ok_or(Errno::EFAULT)?;
         let mut kernel_buffer = vec![0u8; PAGE_SIZE];
         read_from_iovec(iovs, &mut kernel_buffer, |buf, total| {
             let cur_offset = base_offset.checked_add(total).ok_or(Errno::EOVERFLOW)?;
@@ -877,15 +879,16 @@ impl<FS: ShimFS> Task<FS> {
     pub(crate) fn sys_pwritev(
         &self,
         fd: i32,
-        iovec: ConstPtr<IoWriteVec<ConstPtr<u8>>>,
+        iovec: UserPtr<IoWriteVec>,
         iovcnt: usize,
         offset: i64,
     ) -> Result<usize, Errno> {
         let base_offset = usize::try_from(offset).map_err(|_| Errno::EINVAL)?;
         self.check_raw_fd_exists(fd)?;
         check_iovcnt(iovcnt)?;
-        let iovs: &[IoWriteVec<ConstPtr<u8>>] =
-            &iovec.to_owned_slice(iovcnt).ok_or(Errno::EFAULT)?;
+        let iovs: &[IoWriteVec] = &iovec
+            .to_owned_slice::<Platform>(iovcnt)
+            .ok_or(Errno::EFAULT)?;
         // TODO: Linux ignores pwritev's offset for O_APPEND files; see the O_APPEND bug documented in pwrite(2).
         write_to_iovec(iovs, |buf, total| {
             let cur_offset = base_offset.checked_add(total).ok_or(Errno::EOVERFLOW)?;
@@ -897,12 +900,14 @@ impl<FS: ShimFS> Task<FS> {
     pub(crate) fn sys_readv(
         &self,
         fd: i32,
-        iovec: ConstPtr<IoReadVec<MutPtr<u8>>>,
+        iovec: UserPtr<IoReadVec>,
         iovcnt: usize,
     ) -> Result<usize, Errno> {
         self.check_raw_fd_exists(fd)?;
         check_iovcnt(iovcnt)?;
-        let iovs: &[IoReadVec<MutPtr<u8>>] = &iovec.to_owned_slice(iovcnt).ok_or(Errno::EFAULT)?;
+        let iovs: &[IoReadVec] = &iovec
+            .to_owned_slice::<Platform>(iovcnt)
+            .ok_or(Errno::EFAULT)?;
         let mut kernel_buffer = vec![0u8; PAGE_SIZE];
         // TODO: The data transfers performed by readv() and writev() are atomic: the data
         // written by writev() is written as a single block that is not intermingled with
@@ -955,13 +960,12 @@ fn check_iov_lens(iov_lens: impl IntoIterator<Item = usize>) -> Result<(), Errno
 }
 
 /// Drain reads into a sequence of user iovecs.
-fn read_from_iovec<P, F>(
-    iovs: &[IoReadVec<P>],
+fn read_from_iovec<F>(
+    iovs: &[IoReadVec],
     kernel_buffer: &mut [u8],
     mut read_fn: F,
 ) -> Result<usize, Errno>
 where
-    P: RawMutPointer<u8>,
     F: FnMut(&mut [u8], usize) -> Result<usize, Errno>,
 {
     check_iov_lens(iovs.iter().map(|iov| iov.iov_len))?;
@@ -983,7 +987,7 @@ where
                 Err(e) => return bail(total_read, e),
             };
             if iov_base
-                .copy_from_slice(iov_filled, &kernel_buffer[..size])
+                .copy_from_slice::<Platform>(iov_filled, &kernel_buffer[..size])
                 .is_none()
             {
                 return bail(total_read, Errno::EFAULT);
@@ -1003,9 +1007,8 @@ where
 ///
 /// `write_fn` receives the contents of each iovec along with the total number of
 /// bytes already written from earlier iovecs.
-pub(super) fn write_to_iovec<P, F>(iovs: &[IoWriteVec<P>], mut write_fn: F) -> Result<usize, Errno>
+pub(super) fn write_to_iovec<F>(iovs: &[IoWriteVec], mut write_fn: F) -> Result<usize, Errno>
 where
-    P: RawConstPointer<u8>,
     F: FnMut(&[u8], usize) -> Result<usize, Errno>,
 {
     check_iov_lens(iovs.iter().map(|iov| iov.iov_len))?;
@@ -1029,7 +1032,8 @@ where
             let to_write = (iov_len - iov_written).min(kernel_buffer.len());
             let base_offset = isize::try_from(iov_written).unwrap();
             for (byte_offset, byte) in (0_isize..).zip(kernel_buffer[..to_write].iter_mut()) {
-                let Some(value) = iov_base.read_at_offset(base_offset + byte_offset) else {
+                let Some(value) = iov_base.read_at_offset::<Platform>(base_offset + byte_offset)
+                else {
                     return bail(total_written, Errno::EFAULT);
                 };
                 *byte = value;
@@ -1054,13 +1058,14 @@ impl<FS: ShimFS> Task<FS> {
     pub(crate) fn sys_writev(
         &self,
         fd: i32,
-        iovec: ConstPtr<IoWriteVec<ConstPtr<u8>>>,
+        iovec: UserPtr<IoWriteVec>,
         iovcnt: usize,
     ) -> Result<usize, Errno> {
         self.check_raw_fd_exists(fd)?;
         check_iovcnt(iovcnt)?;
-        let iovs: &[IoWriteVec<ConstPtr<u8>>] =
-            &iovec.to_owned_slice(iovcnt).ok_or(Errno::EFAULT)?;
+        let iovs: &[IoWriteVec] = &iovec
+            .to_owned_slice::<Platform>(iovcnt)
+            .ok_or(Errno::EFAULT)?;
         // TODO: The data transfers performed by readv() and writev() are atomic: the data
         // written by writev() is written as a single block that is not intermingled with
         // output from writes in other processes
@@ -1453,11 +1458,7 @@ impl<FS: ShimFS> Task<FS> {
         self.do_fstatat(dirfd, pathname, flags)
     }
 
-    pub(crate) fn sys_fcntl(
-        &self,
-        fd: i32,
-        arg: FcntlArg<litebox_platform_multiplex::Platform>,
-    ) -> Result<u32, Errno> {
+    pub(crate) fn sys_fcntl(&self, fd: i32, arg: FcntlArg) -> Result<u32, Errno> {
         let Ok(desc) = u32::try_from(fd).and_then(usize::try_from) else {
             return Err(Errno::EBADF);
         };
@@ -1593,7 +1594,8 @@ impl<FS: ShimFS> Task<FS> {
                     .run_on_raw_fd(
                         desc,
                         |_fd| {
-                            let mut flock = lock.read_at_offset(0).ok_or(Errno::EFAULT)?;
+                            let mut flock =
+                                lock.read_at_offset::<Platform>(0).ok_or(Errno::EFAULT)?;
                             let lock_type = litebox_common_linux::FlockType::try_from(flock.type_)
                                 .map_err(|_| Errno::EINVAL)?;
                             if let litebox_common_linux::FlockType::Unlock = lock_type {
@@ -1603,7 +1605,8 @@ impl<FS: ShimFS> Task<FS> {
                             // Note LiteBox does not support multiple processes yet, and one process
                             // can always acquire the lock it owns, so return `Unlock` unconditionally.
                             flock.type_ = litebox_common_linux::FlockType::Unlock as i16;
-                            lock.write_at_offset(0, flock).ok_or(Errno::EFAULT)?;
+                            lock.write_at_offset::<Platform>(0, flock)
+                                .ok_or(Errno::EFAULT)?;
                             Ok(0)
                         },
                         |_fd| todo!("net"),
@@ -1620,7 +1623,7 @@ impl<FS: ShimFS> Task<FS> {
                     .run_on_raw_fd(
                         desc,
                         |_fd| {
-                            let flock = lock.read_at_offset(0).ok_or(Errno::EFAULT)?;
+                            let flock = lock.read_at_offset::<Platform>(0).ok_or(Errno::EFAULT)?;
                             let _ = litebox_common_linux::FlockType::try_from(flock.type_)
                                 .map_err(|_| Errno::EINVAL)?;
 
@@ -1763,14 +1766,11 @@ impl<FS: ShimFS> Task<FS> {
         Ok(raw_fd.try_into().unwrap())
     }
 
-    fn stdio_ioctl(
-        &self,
-        arg: &IoctlArg<litebox_platform_multiplex::Platform>,
-    ) -> Result<u32, Errno> {
+    fn stdio_ioctl(&self, arg: &IoctlArg) -> Result<u32, Errno> {
         match arg {
             IoctlArg::TCGETS(termios) => {
                 termios
-                    .write_at_offset(
+                    .write_at_offset::<Platform>(
                         0,
                         litebox_common_linux::Termios {
                             c_iflag: 0,
@@ -1786,7 +1786,7 @@ impl<FS: ShimFS> Task<FS> {
             }
             IoctlArg::TCSETS(_) => Ok(0), // TODO: implement
             IoctlArg::TIOCGWINSZ(ws) => {
-                ws.write_at_offset(
+                ws.write_at_offset::<Platform>(
                     0,
                     litebox_common_linux::Winsize {
                         row: 20,
@@ -1817,11 +1817,7 @@ impl<FS: ShimFS> Task<FS> {
     }
 
     /// Handle syscall `ioctl`
-    pub fn sys_ioctl(
-        &self,
-        fd: i32,
-        arg: IoctlArg<litebox_platform_multiplex::Platform>,
-    ) -> Result<u32, Errno> {
+    pub fn sys_ioctl(&self, fd: i32, arg: IoctlArg) -> Result<u32, Errno> {
         let Ok(desc) = u32::try_from(fd).and_then(usize::try_from) else {
             return Err(Errno::EBADF);
         };
@@ -1829,7 +1825,7 @@ impl<FS: ShimFS> Task<FS> {
         let files = self.files.borrow();
         match arg {
             IoctlArg::FIONBIO(arg) => {
-                let val = arg.read_at_offset(0).ok_or(Errno::EFAULT)?;
+                let val = arg.read_at_offset::<Platform>(0).ok_or(Errno::EFAULT)?;
                 self.files
                     .borrow()
                     .run_on_raw_fd(
@@ -2018,7 +2014,7 @@ impl<FS: ShimFS> Task<FS> {
         epfd: i32,
         op: litebox_common_linux::EpollOp,
         fd: i32,
-        event: ConstPtr<litebox_common_linux::EpollEvent>,
+        event: UserPtr<litebox_common_linux::EpollEvent>,
     ) -> Result<(), Errno> {
         let Ok(epfd) = u32::try_from(epfd) else {
             return Err(Errno::EBADF);
@@ -2042,7 +2038,7 @@ impl<FS: ShimFS> Task<FS> {
         let event = if op == litebox_common_linux::EpollOp::EpollCtlDel {
             None
         } else {
-            Some(event.read_at_offset(0).ok_or(Errno::EFAULT)?)
+            Some(event.read_at_offset::<Platform>(0).ok_or(Errno::EFAULT)?)
         };
         let handle = self
             .global
@@ -2057,10 +2053,10 @@ impl<FS: ShimFS> Task<FS> {
     pub fn sys_epoll_pwait(
         &self,
         epfd: i32,
-        events: MutPtr<litebox_common_linux::EpollEvent>,
+        events: UserPtrMut<litebox_common_linux::EpollEvent>,
         maxevents: u32,
         timeout: i32,
-        sigmask: Option<ConstPtr<litebox_common_linux::signal::SigSet>>,
+        sigmask: Option<UserPtr<litebox_common_linux::signal::SigSet>>,
         _sigsetsize: usize,
     ) -> Result<usize, Errno> {
         if sigmask.is_some() {
@@ -2109,7 +2105,7 @@ impl<FS: ShimFS> Task<FS> {
                 Ok(epoll_events) => {
                     if !epoll_events.is_empty() {
                         events
-                            .copy_from_slice(0, &epoll_events)
+                            .copy_from_slice::<Platform>(0, &epoll_events)
                             .ok_or(Errno::EFAULT)?;
                     }
                     Ok(epoll_events.len())
@@ -2123,10 +2119,10 @@ impl<FS: ShimFS> Task<FS> {
     /// Handle syscall `ppoll`.
     pub fn sys_ppoll(
         &self,
-        fds: MutPtr<litebox_common_linux::Pollfd>,
+        fds: UserPtrMut<litebox_common_linux::Pollfd>,
         nfds: usize,
-        timeout: TimeParam<Platform>,
-        sigmask: Option<ConstPtr<litebox_common_linux::signal::SigSet>>,
+        timeout: TimeParam,
+        sigmask: Option<UserPtr<litebox_common_linux::signal::SigSet>>,
         sigsetsize: usize,
     ) -> Result<usize, Errno> {
         if sigmask.is_some() {
@@ -2136,12 +2132,12 @@ impl<FS: ShimFS> Task<FS> {
             }
             unimplemented!("no sigmask support yet");
         }
-        let timeout = timeout.read()?;
+        let timeout = timeout.read::<Platform>()?;
         let nfds_signed = isize::try_from(nfds).map_err(|_| Errno::EINVAL)?;
 
         let mut set = super::epoll::PollSet::with_capacity(nfds);
         for i in 0..nfds_signed {
-            let fd = fds.read_at_offset(i).ok_or(Errno::EFAULT)?;
+            let fd = fds.read_at_offset::<Platform>(i).ok_or(Errno::EFAULT)?;
 
             let events = litebox::event::Events::from_bits_truncate(
                 fd.events.reinterpret_as_unsigned().into(),
@@ -2170,14 +2166,14 @@ impl<FS: ShimFS> Task<FS> {
         let mut ready_count = 0;
         for (i, revents) in set.revents().enumerate() {
             // TODO: This is not great from a provenance perspective. Consider
-            // adding cast+add methods to ConstPtr/MutPtr.
+            // adding cast+add methods to UserPtr/UserPtrMut.
             let fd_addr = fds_base_addr + i * core::mem::size_of::<litebox_common_linux::Pollfd>();
-            let revents_ptr = crate::MutPtr::<i16>::from_usize(
+            let revents_ptr = crate::UserPtrMut::<i16>::from_usize(
                 fd_addr + core::mem::offset_of!(litebox_common_linux::Pollfd, revents),
             );
             let revents: u16 = revents.bits().trunc();
             revents_ptr
-                .write_at_offset(0, revents.reinterpret_as_signed())
+                .write_at_offset::<Platform>(0, revents.reinterpret_as_signed())
                 .ok_or(Errno::EFAULT)?;
             if revents != 0 {
                 ready_count += 1;
@@ -2263,22 +2259,29 @@ impl<FS: ShimFS> Task<FS> {
     pub(crate) fn sys_pselect(
         &self,
         nfds: u32,
-        readfds: Option<MutPtr<usize>>,
-        writefds: Option<MutPtr<usize>>,
-        exceptfds: Option<MutPtr<usize>>,
-        timeout: TimeParam<Platform>,
-        sigsetpack: Option<ConstPtr<litebox_common_linux::SigSetPack<Platform>>>,
+        readfds: Option<UserPtrMut<usize>>,
+        writefds: Option<UserPtrMut<usize>>,
+        exceptfds: Option<UserPtrMut<usize>>,
+        timeout: TimeParam,
+        sigsetpack: Option<UserPtr<litebox_common_linux::SigSetPack>>,
     ) -> Result<usize, Errno> {
         let sigmask = if let Some(sigsetpack) = sigsetpack {
-            let sigsetpack = sigsetpack.read_at_offset(0).ok_or(Errno::EFAULT)?;
+            let sigsetpack = sigsetpack
+                .read_at_offset::<Platform>(0)
+                .ok_or(Errno::EFAULT)?;
             if sigsetpack.size != core::mem::size_of::<litebox_common_linux::signal::SigSet>() {
                 return Err(Errno::EINVAL);
             }
-            Some(sigsetpack.sigset.read_at_offset(0).ok_or(Errno::EFAULT)?)
+            Some(
+                sigsetpack
+                    .sigset
+                    .read_at_offset::<Platform>(0)
+                    .ok_or(Errno::EFAULT)?,
+            )
         } else {
             None
         };
-        let timeout = timeout.read()?;
+        let timeout = timeout.read::<Platform>()?;
         if nfds >= i32::MAX as u32
             || nfds as usize
                 > self
@@ -2290,15 +2293,15 @@ impl<FS: ShimFS> Task<FS> {
         }
         let len = (nfds as usize).div_ceil(core::mem::size_of::<usize>() * 8);
         let mut kreadfds = readfds
-            .map(|fds| fds.to_owned_slice(len).ok_or(Errno::EFAULT))
+            .map(|fds| fds.to_owned_slice::<Platform>(len).ok_or(Errno::EFAULT))
             .transpose()?
             .map(|fds| bitvec::vec::BitVec::from_vec(fds.into_vec()));
         let mut kwritefds = writefds
-            .map(|fds| fds.to_owned_slice(len).ok_or(Errno::EFAULT))
+            .map(|fds| fds.to_owned_slice::<Platform>(len).ok_or(Errno::EFAULT))
             .transpose()?
             .map(|fds| bitvec::vec::BitVec::from_vec(fds.into_vec()));
         let mut kexceptfds = exceptfds
-            .map(|fds| fds.to_owned_slice(len).ok_or(Errno::EFAULT))
+            .map(|fds| fds.to_owned_slice::<Platform>(len).ok_or(Errno::EFAULT))
             .transpose()?
             .map(|fds| bitvec::vec::BitVec::from_vec(fds.into_vec()));
 
@@ -2320,19 +2323,19 @@ impl<FS: ShimFS> Task<FS> {
         if let Some(fds) = kreadfds {
             readfds
                 .unwrap()
-                .write_slice_at_offset(0, fds.as_raw_slice())
+                .write_slice_at_offset::<Platform>(0, fds.as_raw_slice())
                 .ok_or(Errno::EFAULT)?;
         }
         if let Some(fds) = kwritefds {
             writefds
                 .unwrap()
-                .write_slice_at_offset(0, fds.as_raw_slice())
+                .write_slice_at_offset::<Platform>(0, fds.as_raw_slice())
                 .ok_or(Errno::EFAULT)?;
         }
         if let Some(fds) = kexceptfds {
             exceptfds
                 .unwrap()
-                .write_slice_at_offset(0, fds.as_raw_slice())
+                .write_slice_at_offset::<Platform>(0, fds.as_raw_slice())
                 .ok_or(Errno::EFAULT)?;
         }
 
@@ -2500,7 +2503,7 @@ impl<FS: ShimFS> Task<FS> {
     pub(crate) fn sys_getdirent64(
         &self,
         fd: i32,
-        dirp: MutPtr<u8>,
+        dirp: UserPtrMut<u8>,
         count: usize,
     ) -> Result<usize, Errno> {
         let Ok(fd) = u32::try_from(fd).and_then(usize::try_from) else {
@@ -2541,18 +2544,20 @@ impl<FS: ShimFS> Task<FS> {
                         typ: litebox_common_linux::DirentType::from(entry.file_type.clone()) as u8,
                         __name: [0; 0],
                     };
-                    let hdr_ptr = crate::MutPtr::from_usize(dirp.as_usize() + nbytes);
-                    hdr_ptr.write_at_offset(0, dirent64).ok_or(Errno::EFAULT)?;
-                    let name_ptr = crate::MutPtr::from_usize(
+                    let hdr_ptr = crate::UserPtrMut::from_usize(dirp.as_usize() + nbytes);
+                    hdr_ptr
+                        .write_at_offset::<Platform>(0, dirent64)
+                        .ok_or(Errno::EFAULT)?;
+                    let name_ptr = crate::UserPtrMut::from_usize(
                         hdr_ptr.as_usize() + DIRENT_STRUCT_BYTES_WITHOUT_NAME,
                     );
                     name_ptr
-                        .write_slice_at_offset(0, entry.name.as_bytes())
+                        .write_slice_at_offset::<Platform>(0, entry.name.as_bytes())
                         .ok_or(Errno::EFAULT)?;
                     // set the null terminator and padding
                     let zeros_len = len - (DIRENT_STRUCT_BYTES_WITHOUT_NAME + entry.name.len());
                     name_ptr
-                        .write_slice_at_offset(
+                        .write_slice_at_offset::<Platform>(
                             isize::try_from(entry.name.len()).unwrap(),
                             &vec![0; zeros_len],
                         )
@@ -2591,11 +2596,11 @@ mod tests {
         let second = b"second";
         let iovs = [
             IoWriteVec {
-                iov_base: ConstPtr::from_usize(first.as_ptr().expose_provenance()),
+                iov_base: UserPtr::from_usize(first.as_ptr().expose_provenance()),
                 iov_len: first.len(),
             },
             IoWriteVec {
-                iov_base: ConstPtr::from_usize(second.as_ptr().expose_provenance()),
+                iov_base: UserPtr::from_usize(second.as_ptr().expose_provenance()),
                 iov_len: second.len(),
             },
         ];
@@ -2625,11 +2630,11 @@ mod tests {
         let mut second = [0u8; 4];
         let iovs = [
             IoReadVec {
-                iov_base: MutPtr::from_usize(first.as_mut_ptr().expose_provenance()),
+                iov_base: UserPtrMut::from_usize(first.as_mut_ptr().expose_provenance()),
                 iov_len: first.len(),
             },
             IoReadVec {
-                iov_base: MutPtr::from_usize(second.as_mut_ptr().expose_provenance()),
+                iov_base: UserPtrMut::from_usize(second.as_mut_ptr().expose_provenance()),
                 iov_len: second.len(),
             },
         ];
@@ -2659,7 +2664,7 @@ mod tests {
     fn read_from_iovec_chunks_iov_larger_than_kernel_buffer() {
         let mut dest = [0u8; 12];
         let iovs = [IoReadVec {
-            iov_base: MutPtr::from_usize(dest.as_mut_ptr().expose_provenance()),
+            iov_base: UserPtrMut::from_usize(dest.as_mut_ptr().expose_provenance()),
             iov_len: dest.len(),
         }];
         let mut kernel_buffer = [0u8; 4];
@@ -2685,11 +2690,11 @@ mod tests {
         let mut second = [0u8; 4];
         let iovs = [
             IoReadVec {
-                iov_base: MutPtr::from_usize(first.as_mut_ptr().expose_provenance()),
+                iov_base: UserPtrMut::from_usize(first.as_mut_ptr().expose_provenance()),
                 iov_len: first.len(),
             },
             IoReadVec {
-                iov_base: MutPtr::from_usize(second.as_mut_ptr().expose_provenance()),
+                iov_base: UserPtrMut::from_usize(second.as_mut_ptr().expose_provenance()),
                 iov_len: second.len(),
             },
         ];

--- a/litebox_shim_linux/src/syscalls/misc.rs
+++ b/litebox_shim_linux/src/syscalls/misc.rs
@@ -168,6 +168,7 @@ impl<FS: ShimFS> Task<FS> {
 #[cfg(test)]
 mod tests {
     use crate::syscalls::tests::init_platform;
+    use litebox_common_linux::user_pointers::UserPtrMut;
     use zerocopy::FromZeros as _;
 
     #[test]
@@ -177,7 +178,7 @@ mod tests {
         let task = init_platform(None);
 
         let mut buf = [0u8; 16];
-        let ptr = litebox_common_linux::user_pointers::UserPtrMut::from_ptr(buf.as_mut_ptr());
+        let ptr = UserPtrMut::from_ptr(buf.as_mut_ptr());
         let count = task
             .sys_getrandom(ptr, buf.len() - 1, RngFlags::empty())
             .expect("getrandom failed");
@@ -194,7 +195,7 @@ mod tests {
         let task = init_platform(None);
 
         let mut utsname = litebox_common_linux::Utsname::new_zeroed();
-        let ptr = litebox_common_linux::user_pointers::UserPtrMut::from_ptr(&raw mut utsname);
+        let ptr = UserPtrMut::from_ptr(&raw mut utsname);
         task.sys_uname(ptr).expect("uname failed");
 
         assert_eq!(utsname.sysname, super::SYS_INFO.sysname);

--- a/litebox_shim_linux/src/syscalls/misc.rs
+++ b/litebox_shim_linux/src/syscalls/misc.rs
@@ -7,16 +7,18 @@
 
 use crate::{ShimFS, Task};
 use litebox::{
-    platform::{Instant as _, RawConstPointer as _, RawMutPointer as _, TimeProvider as _},
+    platform::{Instant as _, TimeProvider as _},
     utils::TruncateExt as _,
 };
+use litebox_common_linux::UserPtrMut;
 use litebox_common_linux::errno::Errno;
+use litebox_platform_multiplex::Platform;
 
 impl<FS: ShimFS> Task<FS> {
     /// Handle syscall `getrandom`.
     pub(crate) fn sys_getrandom(
         &self,
-        buf: crate::MutPtr<u8>,
+        buf: UserPtrMut<u8>,
         count: usize,
         _flags: litebox_common_linux::RngFlags,
     ) -> Result<usize, Errno> {
@@ -29,7 +31,8 @@ impl<FS: ShimFS> Task<FS> {
             let len = (count - offset).min(kbuf.len());
             let kbuf = &mut kbuf[..len];
             <_ as litebox::platform::CrngProvider>::fill_bytes_crng(self.global.platform, kbuf);
-            buf.copy_from_slice(offset, kbuf).ok_or(Errno::EFAULT)?;
+            buf.copy_from_slice::<Platform>(offset, kbuf)
+                .ok_or(Errno::EFAULT)?;
             offset += len;
             // TODO: check for interrupt here and break out.
         }
@@ -69,9 +72,10 @@ impl<FS: ShimFS> Task<FS> {
     /// Handle syscall `uname`.
     pub(crate) fn sys_uname(
         &self,
-        buf: crate::MutPtr<litebox_common_linux::Utsname>,
+        buf: UserPtrMut<litebox_common_linux::Utsname>,
     ) -> Result<(), Errno> {
-        buf.write_at_offset(0, SYS_INFO).ok_or(Errno::EFAULT)
+        buf.write_at_offset::<Platform>(0, SYS_INFO)
+            .ok_or(Errno::EFAULT)
     }
 
     /// Handle syscall `sysinfo`.
@@ -107,10 +111,10 @@ impl<FS: ShimFS> Task<FS> {
     /// Note we don't support capabilities in LiteBox, so this returns empty capabilities.
     pub(crate) fn sys_capget(
         &self,
-        header: crate::MutPtr<litebox_common_linux::CapHeader>,
-        data: Option<crate::MutPtr<litebox_common_linux::CapData>>,
+        header: UserPtrMut<litebox_common_linux::CapHeader>,
+        data: Option<UserPtrMut<litebox_common_linux::CapData>>,
     ) -> Result<(), Errno> {
-        let hdr = header.read_at_offset(0).ok_or(Errno::EFAULT)?;
+        let hdr = header.read_at_offset::<Platform>(0).ok_or(Errno::EFAULT)?;
         match hdr.version {
             _LINUX_CAPABILITY_VERSION_1 => {
                 if let Some(data_ptr) = data {
@@ -119,7 +123,9 @@ impl<FS: ShimFS> Task<FS> {
                         permitted: 0,
                         inheritable: 0,
                     };
-                    data_ptr.write_at_offset(0, cap).ok_or(Errno::EFAULT)?;
+                    data_ptr
+                        .write_at_offset::<Platform>(0, cap)
+                        .ok_or(Errno::EFAULT)?;
                 }
                 Ok(())
             }
@@ -131,15 +137,17 @@ impl<FS: ShimFS> Task<FS> {
                         inheritable: 0,
                     };
                     data_ptr
-                        .write_at_offset(0, cap.clone())
+                        .write_at_offset::<Platform>(0, cap.clone())
                         .ok_or(Errno::EFAULT)?;
-                    data_ptr.write_at_offset(1, cap).ok_or(Errno::EFAULT)?;
+                    data_ptr
+                        .write_at_offset::<Platform>(1, cap)
+                        .ok_or(Errno::EFAULT)?;
                 }
                 Ok(())
             }
             _ => {
                 header
-                    .write_at_offset(
+                    .write_at_offset::<Platform>(
                         0,
                         litebox_common_linux::CapHeader {
                             version: _LINUX_CAPABILITY_VERSION_3,
@@ -169,7 +177,7 @@ mod tests {
         let task = init_platform(None);
 
         let mut buf = [0u8; 16];
-        let ptr = crate::MutPtr::from_ptr(buf.as_mut_ptr());
+        let ptr = litebox_common_linux::UserPtrMut::from_ptr(buf.as_mut_ptr());
         let count = task
             .sys_getrandom(ptr, buf.len() - 1, RngFlags::empty())
             .expect("getrandom failed");
@@ -186,7 +194,7 @@ mod tests {
         let task = init_platform(None);
 
         let mut utsname = litebox_common_linux::Utsname::new_zeroed();
-        let ptr = crate::MutPtr::from_ptr(&raw mut utsname);
+        let ptr = litebox_common_linux::UserPtrMut::from_ptr(&raw mut utsname);
         task.sys_uname(ptr).expect("uname failed");
 
         assert_eq!(utsname.sysname, super::SYS_INFO.sysname);

--- a/litebox_shim_linux/src/syscalls/misc.rs
+++ b/litebox_shim_linux/src/syscalls/misc.rs
@@ -10,8 +10,8 @@ use litebox::{
     platform::{Instant as _, TimeProvider as _},
     utils::TruncateExt as _,
 };
-use litebox_common_linux::UserPtrMut;
 use litebox_common_linux::errno::Errno;
+use litebox_common_linux::user_pointers::UserPtrMut;
 use litebox_platform_multiplex::Platform;
 
 impl<FS: ShimFS> Task<FS> {
@@ -177,7 +177,7 @@ mod tests {
         let task = init_platform(None);
 
         let mut buf = [0u8; 16];
-        let ptr = litebox_common_linux::UserPtrMut::from_ptr(buf.as_mut_ptr());
+        let ptr = litebox_common_linux::user_pointers::UserPtrMut::from_ptr(buf.as_mut_ptr());
         let count = task
             .sys_getrandom(ptr, buf.len() - 1, RngFlags::empty())
             .expect("getrandom failed");
@@ -194,7 +194,7 @@ mod tests {
         let task = init_platform(None);
 
         let mut utsname = litebox_common_linux::Utsname::new_zeroed();
-        let ptr = litebox_common_linux::UserPtrMut::from_ptr(&raw mut utsname);
+        let ptr = litebox_common_linux::user_pointers::UserPtrMut::from_ptr(&raw mut utsname);
         task.sys_uname(ptr).expect("uname failed");
 
         assert_eq!(utsname.sysname, super::SYS_INFO.sysname);

--- a/litebox_shim_linux/src/syscalls/mm.rs
+++ b/litebox_shim_linux/src/syscalls/mm.rs
@@ -260,7 +260,7 @@ impl<FS: ShimFS> Task<FS> {
                     )
                 }
                 .unwrap();
-                Some(Ok(UserPtrMut::from_usize(ptr.as_usize())))
+                Some(Ok(UserPtrMut::from_platform_ptr::<Platform>(ptr)))
             }
             Err(_cow_not_supported) => None,
         }

--- a/litebox_shim_linux/src/syscalls/mm.rs
+++ b/litebox_shim_linux/src/syscalls/mm.rs
@@ -379,7 +379,7 @@ impl<FS: ShimFS> Task<FS> {
 
     /// Handle syscall `munmap`
     #[inline]
-    pub(crate) fn sys_munmap(&self, addr: crate::UserPtrMut<u8>, len: usize) -> Result<(), Errno> {
+    pub(crate) fn sys_munmap(&self, addr: UserPtrMut<u8>, len: usize) -> Result<(), Errno> {
         let result = self.sys_munmap_raw(addr, len);
         if result.is_ok() {
             self.clear_file_mappings_for_range(addr.as_usize(), len);
@@ -390,7 +390,7 @@ impl<FS: ShimFS> Task<FS> {
     /// Raw munmap without clearing file_mappings — used internally by the
     /// patching logic to avoid deadlocks (the patch path holds elf_patch_cache).
     #[inline]
-    fn sys_munmap_raw(&self, addr: crate::UserPtrMut<u8>, len: usize) -> Result<(), Errno> {
+    fn sys_munmap_raw(&self, addr: UserPtrMut<u8>, len: usize) -> Result<(), Errno> {
         litebox_common_linux::mm::sys_munmap(&self.global.pm, addr, len)
     }
 
@@ -416,7 +416,7 @@ impl<FS: ShimFS> Task<FS> {
     #[inline]
     pub(crate) fn sys_mprotect(
         &self,
-        addr: crate::UserPtrMut<u8>,
+        addr: UserPtrMut<u8>,
         len: usize,
         prot: ProtFlags,
     ) -> Result<(), Errno> {
@@ -435,7 +435,7 @@ impl<FS: ShimFS> Task<FS> {
     #[inline]
     fn sys_mprotect_raw(
         &self,
-        addr: crate::UserPtrMut<u8>,
+        addr: UserPtrMut<u8>,
         len: usize,
         prot: ProtFlags,
     ) -> Result<(), Errno> {
@@ -445,12 +445,12 @@ impl<FS: ShimFS> Task<FS> {
     #[inline]
     pub(crate) fn sys_mremap(
         &self,
-        old_addr: crate::UserPtrMut<u8>,
+        old_addr: UserPtrMut<u8>,
         old_size: usize,
         new_size: usize,
         flags: MRemapFlags,
         new_addr: usize,
-    ) -> Result<crate::UserPtrMut<u8>, Errno> {
+    ) -> Result<UserPtrMut<u8>, Errno> {
         litebox_common_linux::mm::sys_mremap(
             &self.global.pm,
             old_addr,
@@ -483,12 +483,7 @@ impl<FS: ShimFS> Task<FS> {
     /// Check all tracked file mappings for unpatched regions that overlap the
     /// mprotect range. If found, run the runtime rewriter before the region
     /// becomes executable.
-    fn maybe_patch_on_mprotect_exec(
-        &self,
-        addr: crate::UserPtrMut<u8>,
-        len: usize,
-        syscall_entry: usize,
-    ) {
+    fn maybe_patch_on_mprotect_exec(&self, addr: UserPtrMut<u8>, len: usize, syscall_entry: usize) {
         let mprotect_start = addr.as_usize();
         let mprotect_end = mprotect_start.saturating_add(len);
 
@@ -718,12 +713,7 @@ impl<FS: ShimFS> Task<FS> {
     /// and the initial mprotect RW is skipped.
     ///
     /// Panics on infrastructure failures (mprotect/read/write/disassembly).
-    fn apply_trap_fallback(
-        &self,
-        mapped_addr: crate::UserPtrMut<u8>,
-        len: usize,
-        already_rw: bool,
-    ) {
+    fn apply_trap_fallback(&self, mapped_addr: UserPtrMut<u8>, len: usize, already_rw: bool) {
         if !already_rw {
             self.sys_mprotect_raw(
                 mapped_addr,
@@ -1142,7 +1132,7 @@ mod tests {
     use litebox_common_linux::{MRemapFlags, MapFlags, ProtFlags, errno::Errno};
     use litebox_platform_multiplex::Platform;
 
-    use crate::syscalls::tests::init_platform;
+    use crate::{UserPtrMut, syscalls::tests::init_platform};
 
     #[test]
     fn test_anonymous_mmap() {
@@ -1426,7 +1416,7 @@ mod tests {
         // grow the mapping without MREMAP_MAYMOVE should fail as the new region collides with the global allocator
         let err = task
             .sys_mremap(
-                crate::UserPtrMut::from_usize(addr - 0x1000),
+                UserPtrMut::from_usize(addr - 0x1000),
                 0x1000,
                 0x2000,
                 MRemapFlags::empty(),
@@ -1578,7 +1568,7 @@ mod tests {
     fn test_fallible_read() {
         let _ = init_platform(None);
 
-        let ptr = crate::UserPtrMut::<u8>::from_usize(0xdeadbeef);
+        let ptr = UserPtrMut::<u8>::from_usize(0xdeadbeef);
         let result = ptr.read_at_offset::<Platform>(0);
         assert!(result.is_none());
     }

--- a/litebox_shim_linux/src/syscalls/mm.rs
+++ b/litebox_shim_linux/src/syscalls/mm.rs
@@ -8,16 +8,17 @@ use alloc::collections::{BTreeMap, BTreeSet};
 use litebox::{
     mm::linux::{MappingError, PAGE_SIZE, PageRange},
     platform::{
-        PageManagementProvider, RawConstPointer, RawMutPointer, SystemInfoProvider,
+        PageManagementProvider, RawConstPointer, SystemInfoProvider,
         page_mgmt::{FixedAddressBehavior, MemoryRegionPermissions},
     },
 };
 use litebox_common_linux::{MRemapFlags, MapFlags, ProtFlags, errno::Errno};
 
-use crate::MutPtr;
 use crate::ShimFS;
 use crate::Task;
+use crate::UserPtrMut;
 use litebox::utils::TruncateExt as _;
+use litebox_platform_multiplex::Platform;
 use object::elf::{ET_DYN, FileHeader64, PT_LOAD, ProgramHeader64};
 use object::endian::LittleEndian;
 
@@ -82,8 +83,8 @@ impl<FS: ShimFS> Task<FS> {
         prot: ProtFlags,
         flags: MapFlags,
         ensure_space_after: bool,
-        op: impl FnOnce(MutPtr<u8>) -> Result<usize, MappingError>,
-    ) -> Result<MutPtr<u8>, MappingError> {
+        op: impl FnOnce(UserPtrMut<u8>) -> Result<usize, MappingError>,
+    ) -> Result<UserPtrMut<u8>, MappingError> {
         litebox_common_linux::mm::do_mmap(
             &self.global.pm,
             suggested_addr,
@@ -102,7 +103,7 @@ impl<FS: ShimFS> Task<FS> {
         len: usize,
         prot: ProtFlags,
         flags: MapFlags,
-    ) -> Result<MutPtr<u8>, MappingError> {
+    ) -> Result<UserPtrMut<u8>, MappingError> {
         let op = |_| Ok(0);
         self.do_mmap(suggested_addr, len, prot, flags, false, op)
     }
@@ -115,7 +116,7 @@ impl<FS: ShimFS> Task<FS> {
         flags: MapFlags,
         fd: i32,
         offset: usize,
-    ) -> Result<MutPtr<u8>, MappingError> {
+    ) -> Result<UserPtrMut<u8>, MappingError> {
         let is_exec = prot.contains(ProtFlags::PROT_EXEC);
 
         // Perform the normal mmap first (CoW or memcpy fallback).
@@ -172,7 +173,7 @@ impl<FS: ShimFS> Task<FS> {
         flags: &MapFlags,
         fd: i32,
         offset: usize,
-    ) -> Option<Result<MutPtr<u8>, MappingError>> {
+    ) -> Option<Result<UserPtrMut<u8>, MappingError>> {
         if !len.is_multiple_of(PAGE_SIZE) {
             return None;
         }
@@ -259,7 +260,7 @@ impl<FS: ShimFS> Task<FS> {
                     )
                 }
                 .unwrap();
-                Some(Ok(ptr))
+                Some(Ok(UserPtrMut::from_usize(ptr.as_usize())))
             }
             Err(_cow_not_supported) => None,
         }
@@ -275,8 +276,8 @@ impl<FS: ShimFS> Task<FS> {
         flags: MapFlags,
         fd: i32,
         offset: usize,
-    ) -> Result<MutPtr<u8>, MappingError> {
-        let op = |ptr: MutPtr<u8>| -> Result<usize, MappingError> {
+    ) -> Result<UserPtrMut<u8>, MappingError> {
+        let op = |ptr: UserPtrMut<u8>| -> Result<usize, MappingError> {
             // Note a malicious user may unmap ptr while we are reading.
             // `sys_read` does not handle page faults, so we need to use a
             // temporary buffer to read the data from fs (without worrying page
@@ -297,7 +298,8 @@ impl<FS: ShimFS> Task<FS> {
                     break;
                 }
                 // ptr is a valid pointer returned by do_mmap.
-                ptr.copy_from_slice(copied, &buffer[..size]).unwrap();
+                ptr.copy_from_slice::<Platform>(copied, &buffer[..size])
+                    .unwrap();
                 copied += size;
                 file_offset += size;
             }
@@ -325,7 +327,7 @@ impl<FS: ShimFS> Task<FS> {
         flags: MapFlags,
         fd: i32,
         offset: usize,
-    ) -> Result<MutPtr<u8>, Errno> {
+    ) -> Result<UserPtrMut<u8>, Errno> {
         // check alignment
         if !offset.is_multiple_of(PAGE_SIZE) || !addr.is_multiple_of(PAGE_SIZE) || len == 0 {
             return Err(Errno::EINVAL);
@@ -377,7 +379,7 @@ impl<FS: ShimFS> Task<FS> {
 
     /// Handle syscall `munmap`
     #[inline]
-    pub(crate) fn sys_munmap(&self, addr: crate::MutPtr<u8>, len: usize) -> Result<(), Errno> {
+    pub(crate) fn sys_munmap(&self, addr: crate::UserPtrMut<u8>, len: usize) -> Result<(), Errno> {
         let result = self.sys_munmap_raw(addr, len);
         if result.is_ok() {
             self.clear_file_mappings_for_range(addr.as_usize(), len);
@@ -388,7 +390,7 @@ impl<FS: ShimFS> Task<FS> {
     /// Raw munmap without clearing file_mappings — used internally by the
     /// patching logic to avoid deadlocks (the patch path holds elf_patch_cache).
     #[inline]
-    fn sys_munmap_raw(&self, addr: crate::MutPtr<u8>, len: usize) -> Result<(), Errno> {
+    fn sys_munmap_raw(&self, addr: crate::UserPtrMut<u8>, len: usize) -> Result<(), Errno> {
         litebox_common_linux::mm::sys_munmap(&self.global.pm, addr, len)
     }
 
@@ -414,7 +416,7 @@ impl<FS: ShimFS> Task<FS> {
     #[inline]
     pub(crate) fn sys_mprotect(
         &self,
-        addr: crate::MutPtr<u8>,
+        addr: crate::UserPtrMut<u8>,
         len: usize,
         prot: ProtFlags,
     ) -> Result<(), Errno> {
@@ -433,7 +435,7 @@ impl<FS: ShimFS> Task<FS> {
     #[inline]
     fn sys_mprotect_raw(
         &self,
-        addr: crate::MutPtr<u8>,
+        addr: crate::UserPtrMut<u8>,
         len: usize,
         prot: ProtFlags,
     ) -> Result<(), Errno> {
@@ -443,12 +445,12 @@ impl<FS: ShimFS> Task<FS> {
     #[inline]
     pub(crate) fn sys_mremap(
         &self,
-        old_addr: crate::MutPtr<u8>,
+        old_addr: crate::UserPtrMut<u8>,
         old_size: usize,
         new_size: usize,
         flags: MRemapFlags,
         new_addr: usize,
-    ) -> Result<crate::MutPtr<u8>, Errno> {
+    ) -> Result<crate::UserPtrMut<u8>, Errno> {
         litebox_common_linux::mm::sys_mremap(
             &self.global.pm,
             old_addr,
@@ -461,7 +463,7 @@ impl<FS: ShimFS> Task<FS> {
 
     /// Handle syscall `brk`
     #[inline]
-    pub(crate) fn sys_brk(&self, addr: MutPtr<u8>) -> Result<usize, Errno> {
+    pub(crate) fn sys_brk(&self, addr: UserPtrMut<u8>) -> Result<usize, Errno> {
         litebox_common_linux::mm::sys_brk(&self.global.pm, addr)
     }
 
@@ -469,7 +471,7 @@ impl<FS: ShimFS> Task<FS> {
     #[inline]
     pub(crate) fn sys_madvise(
         &self,
-        addr: MutPtr<u8>,
+        addr: UserPtrMut<u8>,
         len: usize,
         advice: litebox_common_linux::MadviseBehavior,
     ) -> Result<(), Errno> {
@@ -483,7 +485,7 @@ impl<FS: ShimFS> Task<FS> {
     /// becomes executable.
     fn maybe_patch_on_mprotect_exec(
         &self,
-        addr: crate::MutPtr<u8>,
+        addr: crate::UserPtrMut<u8>,
         len: usize,
         syscall_entry: usize,
     ) {
@@ -535,7 +537,7 @@ impl<FS: ShimFS> Task<FS> {
             if patch_len == 0 {
                 continue;
             }
-            let mapped_addr = MutPtr::<u8>::from_usize(patch_start);
+            let mapped_addr = UserPtrMut::<u8>::from_usize(patch_start);
             self.maybe_patch_exec_segment(mapped_addr, patch_len, fd, syscall_entry, None);
         }
     }
@@ -716,7 +718,12 @@ impl<FS: ShimFS> Task<FS> {
     /// and the initial mprotect RW is skipped.
     ///
     /// Panics on infrastructure failures (mprotect/read/write/disassembly).
-    fn apply_trap_fallback(&self, mapped_addr: crate::MutPtr<u8>, len: usize, already_rw: bool) {
+    fn apply_trap_fallback(
+        &self,
+        mapped_addr: crate::UserPtrMut<u8>,
+        len: usize,
+        already_rw: bool,
+    ) {
         if !already_rw {
             self.sys_mprotect_raw(
                 mapped_addr,
@@ -727,7 +734,7 @@ impl<FS: ShimFS> Task<FS> {
         }
 
         // Read, patch using the rewriter (proper disassembly), write back.
-        let Some(code_owned) = mapped_addr.to_owned_slice(len) else {
+        let Some(code_owned) = mapped_addr.to_owned_slice::<Platform>(len) else {
             panic!("fatal: failed to read code segment for trap fallback");
         };
         let mut code_buf = code_owned.into_vec();
@@ -743,7 +750,9 @@ impl<FS: ShimFS> Task<FS> {
             );
         }
         assert!(
-            mapped_addr.copy_from_slice(0, &code_buf).is_some(),
+            mapped_addr
+                .copy_from_slice::<Platform>(0, &code_buf)
+                .is_some(),
             "fatal: failed to write trap bytes back to code segment"
         );
 
@@ -769,7 +778,7 @@ impl<FS: ShimFS> Task<FS> {
     /// trampoline address.
     fn maybe_patch_exec_segment(
         &self,
-        mapped_addr: MutPtr<u8>,
+        mapped_addr: UserPtrMut<u8>,
         len: usize,
         fd: i32,
         syscall_entry: usize,
@@ -812,14 +821,15 @@ impl<FS: ShimFS> Task<FS> {
                 };
                 let actual_addr = alloc_ptr.as_usize();
                 if actual_addr != tramp_addr {
-                    let _ = self.sys_munmap_raw(MutPtr::<u8>::from_usize(actual_addr), tramp_len);
+                    let _ =
+                        self.sys_munmap_raw(UserPtrMut::<u8>::from_usize(actual_addr), tramp_len);
                     return false;
                 }
 
                 // Read trampoline data from the file.
                 let mut tramp_data = alloc::vec![0u8; state.trampoline_file_size];
                 let file_off = state.trampoline_file_offset.trunc();
-                let tramp_ptr = MutPtr::<u8>::from_usize(tramp_addr);
+                let tramp_ptr = UserPtrMut::<u8>::from_usize(tramp_addr);
                 match self.sys_read(fd, &mut tramp_data, Some(file_off)) {
                     Ok(n) if n == tramp_data.len() => {}
                     _ => {
@@ -834,7 +844,10 @@ impl<FS: ShimFS> Task<FS> {
                 }
 
                 // Write to the mapped region.
-                if tramp_ptr.copy_from_slice(0, &tramp_data).is_none() {
+                if tramp_ptr
+                    .copy_from_slice::<Platform>(0, &tramp_data)
+                    .is_none()
+                {
                     let _ = self.sys_munmap_raw(tramp_ptr, tramp_len);
                     return false;
                 }
@@ -902,7 +915,7 @@ impl<FS: ShimFS> Task<FS> {
                     distance:? = distance;
                     "trampoline too far from code segment, skipping patching"
                 );
-                let _ = self.sys_munmap_raw(MutPtr::<u8>::from_usize(actual_addr), PAGE_SIZE);
+                let _ = self.sys_munmap_raw(UserPtrMut::<u8>::from_usize(actual_addr), PAGE_SIZE);
                 self.apply_trap_fallback(mapped_addr, len, false);
                 return true;
             }
@@ -910,13 +923,13 @@ impl<FS: ShimFS> Task<FS> {
             state.trampoline_addr = actual_addr;
 
             // Write the 8-byte syscall entry point at the start.
-            let entry_ptr = MutPtr::<u8>::from_usize(actual_addr);
+            let entry_ptr = UserPtrMut::<u8>::from_usize(actual_addr);
             if entry_ptr
-                .copy_from_slice(0, &syscall_entry.to_le_bytes())
+                .copy_from_slice::<Platform>(0, &syscall_entry.to_le_bytes())
                 .is_none()
             {
                 litebox_util_log::warn!("failed to write syscall entry point to trampoline");
-                let _ = self.sys_munmap_raw(MutPtr::<u8>::from_usize(actual_addr), PAGE_SIZE);
+                let _ = self.sys_munmap_raw(UserPtrMut::<u8>::from_usize(actual_addr), PAGE_SIZE);
                 self.apply_trap_fallback(mapped_addr, len, false);
                 return true;
             }
@@ -935,7 +948,7 @@ impl<FS: ShimFS> Task<FS> {
         let restore_trampoline_rx = |task: &Self, state: &ElfPatchState| {
             if state.trampoline_mapped_len > 0 {
                 let _ = task.sys_mprotect_raw(
-                    MutPtr::<u8>::from_usize(state.trampoline_addr),
+                    UserPtrMut::<u8>::from_usize(state.trampoline_addr),
                     state.trampoline_mapped_len,
                     ProtFlags::PROT_READ | ProtFlags::PROT_EXEC,
                 );
@@ -946,7 +959,7 @@ impl<FS: ShimFS> Task<FS> {
         if state.trampoline_mapped_len > 0
             && self
                 .sys_mprotect_raw(
-                    MutPtr::<u8>::from_usize(state.trampoline_addr),
+                    UserPtrMut::<u8>::from_usize(state.trampoline_addr),
                     state.trampoline_mapped_len,
                     ProtFlags::PROT_READ | ProtFlags::PROT_WRITE,
                 )
@@ -967,7 +980,7 @@ impl<FS: ShimFS> Task<FS> {
         }
 
         // Read the mapped code into a buffer, patch it, write back.
-        let Some(code_owned) = mapped_addr.to_owned_slice(len) else {
+        let Some(code_owned) = mapped_addr.to_owned_slice::<Platform>(len) else {
             let _ = self.sys_mprotect_raw(
                 mapped_addr,
                 len,
@@ -1035,8 +1048,11 @@ impl<FS: ShimFS> Task<FS> {
                 // Write stubs before patching the code so rewritten jumps
                 // never target an uninitialized trampoline.
                 let tramp_write_ptr =
-                    MutPtr::<u8>::from_usize(state.trampoline_addr + state.trampoline_cursor);
-                if tramp_write_ptr.copy_from_slice(0, &stubs).is_none() {
+                    UserPtrMut::<u8>::from_usize(state.trampoline_addr + state.trampoline_cursor);
+                if tramp_write_ptr
+                    .copy_from_slice::<Platform>(0, &stubs)
+                    .is_none()
+                {
                     let _ = self.sys_mprotect_raw(
                         mapped_addr,
                         len,
@@ -1047,8 +1063,11 @@ impl<FS: ShimFS> Task<FS> {
                 }
 
                 // Write patched code back to the mapped region.
-                if mapped_addr.copy_from_slice(0, &code_buf).is_none() {
-                    let _ = mapped_addr.copy_from_slice(0, &original_code);
+                if mapped_addr
+                    .copy_from_slice::<Platform>(0, &code_buf)
+                    .is_none()
+                {
+                    let _ = mapped_addr.copy_from_slice::<Platform>(0, &original_code);
                     let _ = self.sys_mprotect_raw(
                         mapped_addr,
                         len,
@@ -1064,9 +1083,12 @@ impl<FS: ShimFS> Task<FS> {
                 // No trampoline stubs were generated, but the rewriter may
                 // have replaced unpatchable syscalls with trap instructions.
                 // Write back the modified code if it changed.
-                if code_buf != original_code && mapped_addr.copy_from_slice(0, &code_buf).is_none()
+                if code_buf != original_code
+                    && mapped_addr
+                        .copy_from_slice::<Platform>(0, &code_buf)
+                        .is_none()
                 {
-                    let _ = mapped_addr.copy_from_slice(0, &original_code);
+                    let _ = mapped_addr.copy_from_slice::<Platform>(0, &original_code);
                     panic!("fatal: failed to write trap bytes back to code segment");
                 }
                 // Fall through to restore RX protections below.
@@ -1102,7 +1124,10 @@ impl<FS: ShimFS> Task<FS> {
         {
             let tramp_len = state.trampoline_mapped_len;
             if tramp_len > 0 {
-                let _ = self.sys_munmap(MutPtr::<u8>::from_usize(state.trampoline_addr), tramp_len);
+                let _ = self.sys_munmap(
+                    UserPtrMut::<u8>::from_usize(state.trampoline_addr),
+                    tramp_len,
+                );
             }
         }
     }
@@ -1112,9 +1137,10 @@ impl<FS: ShimFS> Task<FS> {
 mod tests {
     use litebox::{
         fs::{Mode, OFlags},
-        platform::{PageManagementProvider, RawConstPointer, RawMutPointer},
+        platform::PageManagementProvider,
     };
     use litebox_common_linux::{MRemapFlags, MapFlags, ProtFlags, errno::Errno};
+    use litebox_platform_multiplex::Platform;
 
     use crate::syscalls::tests::init_platform;
 
@@ -1132,8 +1158,9 @@ mod tests {
                 0,
             )
             .unwrap();
-        addr.write_slice_at_offset(0, &[0xff; 0x2000]).unwrap();
-        assert_eq!(addr.read_at_offset(0x1000).unwrap(), 0xff,);
+        addr.write_slice_at_offset::<Platform>(0, &[0xff; 0x2000])
+            .unwrap();
+        assert_eq!(addr.read_at_offset::<Platform>(0x1000).unwrap(), 0xff,);
         task.sys_munmap(addr, 0x2000).unwrap();
     }
 
@@ -1158,7 +1185,9 @@ mod tests {
             )
             .unwrap();
         assert_eq!(
-            addr.to_owned_slice(content.len()).unwrap().as_ref(),
+            addr.to_owned_slice::<Platform>(content.len())
+                .unwrap()
+                .as_ref(),
             content.as_slice(),
         );
         task.sys_munmap(addr, 0x1000).unwrap();
@@ -1397,7 +1426,7 @@ mod tests {
         // grow the mapping without MREMAP_MAYMOVE should fail as the new region collides with the global allocator
         let err = task
             .sys_mremap(
-                crate::MutPtr::from_usize(addr - 0x1000),
+                crate::UserPtrMut::from_usize(addr - 0x1000),
                 0x1000,
                 0x2000,
                 MRemapFlags::empty(),
@@ -1424,13 +1453,14 @@ mod tests {
             .unwrap();
 
         // Reading should work
-        let _val: u8 = addr.read_at_offset(0).unwrap();
+        let _val: u8 = addr.read_at_offset::<Platform>(0).unwrap();
 
         // Anonymous shared mappings allow permission changes including write
         task.sys_mprotect(addr, 0x2000, ProtFlags::PROT_READ | ProtFlags::PROT_WRITE)
             .unwrap();
-        addr.write_slice_at_offset(0, &[0xab; 0x10]).unwrap();
-        assert_eq!(addr.read_at_offset(0).unwrap(), 0xab_u8);
+        addr.write_slice_at_offset::<Platform>(0, &[0xab; 0x10])
+            .unwrap();
+        assert_eq!(addr.read_at_offset::<Platform>(0).unwrap(), 0xab_u8);
 
         // mprotect to read-only or read-exec should also succeed
         task.sys_mprotect(addr, 0x2000, ProtFlags::PROT_READ)
@@ -1457,8 +1487,9 @@ mod tests {
             )
             .unwrap();
 
-        addr.write_slice_at_offset(0, &[0xcd; 0x10]).unwrap();
-        assert_eq!(addr.read_at_offset(0).unwrap(), 0xcd_u8);
+        addr.write_slice_at_offset::<Platform>(0, &[0xcd; 0x10])
+            .unwrap();
+        assert_eq!(addr.read_at_offset::<Platform>(0).unwrap(), 0xcd_u8);
 
         task.sys_munmap(addr, 0x1000).unwrap();
     }
@@ -1481,7 +1512,9 @@ mod tests {
 
         // Data should match
         assert_eq!(
-            addr.to_owned_slice(content.len()).unwrap().as_ref(),
+            addr.to_owned_slice::<Platform>(content.len())
+                .unwrap()
+                .as_ref(),
             content.as_slice(),
         );
 
@@ -1510,7 +1543,8 @@ mod tests {
             )
             .unwrap();
 
-        addr.write_slice_at_offset(0, &[0xff; 0x10]).unwrap();
+        addr.write_slice_at_offset::<Platform>(0, &[0xff; 0x10])
+            .unwrap();
 
         // Test MADV_NORMAL
         assert!(
@@ -1528,9 +1562,12 @@ mod tests {
             .is_ok()
         );
 
-        addr.to_owned_slice(0x10).unwrap().iter().for_each(|&x| {
-            assert_eq!(x, 0); // Should be zeroed after MADV_DONTNEED
-        });
+        addr.to_owned_slice::<Platform>(0x10)
+            .unwrap()
+            .iter()
+            .for_each(|&x| {
+                assert_eq!(x, 0); // Should be zeroed after MADV_DONTNEED
+            });
 
         task.sys_munmap(addr, 0x2000).unwrap();
     }
@@ -1541,8 +1578,8 @@ mod tests {
     fn test_fallible_read() {
         let _ = init_platform(None);
 
-        let ptr = crate::MutPtr::<u8>::from_usize(0xdeadbeef);
-        let result = ptr.read_at_offset(0);
+        let ptr = crate::UserPtrMut::<u8>::from_usize(0xdeadbeef);
+        let result = ptr.read_at_offset::<Platform>(0);
         assert!(result.is_none());
     }
 }

--- a/litebox_shim_linux/src/syscalls/mod.rs
+++ b/litebox_shim_linux/src/syscalls/mod.rs
@@ -46,29 +46,29 @@ use zerocopy::{FromBytes, Immutable, IntoBytes};
 /// If the buffer size (i.e., provided `len`) is smaller than `size_of::<T>()`, only write up to `len` bytes.
 fn write_to_user<T: FromBytes + IntoBytes + Immutable>(
     val: T,
-    optval: crate::MutPtr<u8>,
+    optval: crate::UserPtrMut<u8>,
     len: u32,
 ) -> Result<usize, litebox_common_linux::errno::Errno> {
-    use litebox::platform::RawMutPointer as _;
+    use litebox_platform_multiplex::Platform;
     let length = core::mem::size_of::<T>().min(len as usize);
     let data = &val.as_bytes()[..length];
     optval
-        .write_slice_at_offset(0, data)
+        .write_slice_at_offset::<Platform>(0, data)
         .ok_or(litebox_common_linux::errno::Errno::EFAULT)?;
     Ok(length)
 }
 /// Helper function to read a value of type T from user memory.
 /// If the buffer size (i.e., provided `optlen`) is smaller than `size_of::<T>()`, return EINVAL.
 fn read_from_user<T: FromBytes>(
-    optval: crate::ConstPtr<u8>,
+    optval: crate::UserPtr<u8>,
     optlen: usize,
 ) -> Result<T, litebox_common_linux::errno::Errno> {
-    use litebox::platform::RawConstPointer as _;
+    use litebox_platform_multiplex::Platform;
     if optlen < size_of::<T>() {
         return Err(litebox_common_linux::errno::Errno::EINVAL);
     }
-    let optval: crate::ConstPtr<T> = crate::ConstPtr::from_usize(optval.as_usize());
+    let optval: crate::UserPtr<T> = crate::UserPtr::from_usize(optval.as_usize());
     optval
-        .read_at_offset(0)
+        .read_at_offset::<Platform>(0)
         .ok_or(litebox_common_linux::errno::Errno::EFAULT)
 }

--- a/litebox_shim_linux/src/syscalls/mod.rs
+++ b/litebox_shim_linux/src/syscalls/mod.rs
@@ -39,6 +39,7 @@ macro_rules! common_functions_for_file_status {
     };
 }
 
+use crate::{UserPtr, UserPtrMut};
 pub(crate) use common_functions_for_file_status;
 use zerocopy::{FromBytes, Immutable, IntoBytes};
 
@@ -46,7 +47,7 @@ use zerocopy::{FromBytes, Immutable, IntoBytes};
 /// If the buffer size (i.e., provided `len`) is smaller than `size_of::<T>()`, only write up to `len` bytes.
 fn write_to_user<T: FromBytes + IntoBytes + Immutable>(
     val: T,
-    optval: crate::UserPtrMut<u8>,
+    optval: UserPtrMut<u8>,
     len: u32,
 ) -> Result<usize, litebox_common_linux::errno::Errno> {
     use litebox_platform_multiplex::Platform;
@@ -60,14 +61,14 @@ fn write_to_user<T: FromBytes + IntoBytes + Immutable>(
 /// Helper function to read a value of type T from user memory.
 /// If the buffer size (i.e., provided `optlen`) is smaller than `size_of::<T>()`, return EINVAL.
 fn read_from_user<T: FromBytes>(
-    optval: crate::UserPtr<u8>,
+    optval: UserPtr<u8>,
     optlen: usize,
 ) -> Result<T, litebox_common_linux::errno::Errno> {
     use litebox_platform_multiplex::Platform;
     if optlen < size_of::<T>() {
         return Err(litebox_common_linux::errno::Errno::EINVAL);
     }
-    let optval: crate::UserPtr<T> = crate::UserPtr::from_usize(optval.as_usize());
+    let optval: UserPtr<T> = UserPtr::from_usize(optval.as_usize());
     optval
         .read_at_offset::<Platform>(0)
         .ok_or(litebox_common_linux::errno::Errno::EFAULT)

--- a/litebox_shim_linux/src/syscalls/net.rs
+++ b/litebox_shim_linux/src/syscalls/net.rs
@@ -1114,8 +1114,8 @@ pub(crate) fn read_sockaddr_from_user(
 
 pub(crate) fn write_sockaddr_to_user(
     sock_addr: SocketAddress,
-    addr: crate::UserPtrMut<u8>,
-    addrlen: crate::UserPtrMut<u32>,
+    addr: UserPtrMut<u8>,
+    addrlen: UserPtrMut<u32>,
 ) -> Result<(), Errno> {
     let addrlen_val = addrlen.read_at_offset::<Platform>(0).ok_or(Errno::EFAULT)?;
     if addrlen_val >= i32::MAX as u32 {
@@ -2119,7 +2119,7 @@ mod tests {
             data: u64::from(target_fd),
         };
         let ev_ptr = (&raw const ev).cast::<litebox_common_linux::EpollEvent>();
-        let ev_const = crate::UserPtr::from_usize(ev_ptr as usize);
+        let ev_const = UserPtr::from_usize(ev_ptr as usize);
         task.sys_epoll_ctl(
             epfd,
             litebox_common_linux::EpollOp::EpollCtlAdd,
@@ -2134,7 +2134,7 @@ mod tests {
         epfd: i32,
         events: &mut [litebox_common_linux::EpollEvent],
     ) -> usize {
-        let events_ptr = crate::UserPtrMut::from_usize(events.as_mut_ptr() as usize);
+        let events_ptr = UserPtrMut::from_usize(events.as_mut_ptr() as usize);
         task.sys_epoll_pwait(epfd, events_ptr, events.len().trunc(), -1, None, 0)
             .expect("epoll_wait failed")
     }

--- a/litebox_shim_linux/src/syscalls/net.rs
+++ b/litebox_shim_linux/src/syscalls/net.rs
@@ -23,7 +23,7 @@ use litebox::{
         errors::AcceptError,
         socket_channel::{ChannelReadError, ChannelWriteError, NetworkProxy, SocketState},
     },
-    platform::{Instant as _, RawConstPointer as _, RawMutPointer as _, TimeProvider as _},
+    platform::{Instant as _, TimeProvider as _},
     utils::TruncateExt as _,
 };
 use litebox_common_linux::{
@@ -33,12 +33,12 @@ use litebox_common_linux::{
 };
 use zerocopy::{FromBytes, Immutable, IntoBytes};
 
-use crate::{ConstPtr, MutPtr, syscalls::signal};
 use crate::{GlobalState, ShimFS, Task};
 use crate::{
     Platform,
     syscalls::unix::{CSockUnixAddr, UnixSocket, UnixSocketAddr},
 };
+use crate::{UserPtr, UserPtrMut, syscalls::signal};
 
 /// Linux's hard cap on the number of iovecs per `*msg`-style call, and on the
 /// number of entries per `sendmmsg`. See `UIO_MAXIOV` in `<uapi/linux/uio.h>`.
@@ -275,7 +275,7 @@ impl<FS: ShimFS> GlobalState<FS> {
     pub(super) fn setsockopt_common<F>(
         &self,
         optname: SocketOptionName,
-        optval: ConstPtr<u8>,
+        optval: UserPtr<u8>,
         optlen: usize,
         set_option: F,
     ) -> Result<(), Errno>
@@ -318,7 +318,7 @@ impl<FS: ShimFS> GlobalState<FS> {
         &self,
         fd: &SocketFd,
         optname: SocketOptionName,
-        optval: ConstPtr<u8>,
+        optval: UserPtr<u8>,
         optlen: usize,
     ) -> Result<(), Errno> {
         match self.setsockopt_common(optname, optval, optlen, |so, value| {
@@ -406,7 +406,7 @@ impl<FS: ShimFS> GlobalState<FS> {
                 TcpOption::CONGESTION => {
                     const TCP_CONGESTION_NAME_MAX: usize = 16;
                     let data = optval
-                        .to_owned_slice(TCP_CONGESTION_NAME_MAX.min(optlen))
+                        .to_owned_slice::<Platform>(TCP_CONGESTION_NAME_MAX.min(optlen))
                         .ok_or(Errno::EFAULT)?;
                     let name = core::str::from_utf8(&data).map_err(|_| Errno::EINVAL)?;
                     self.net.lock().set_tcp_option(
@@ -484,7 +484,7 @@ impl<FS: ShimFS> GlobalState<FS> {
     pub(super) fn getsockopt_common<F>(
         &self,
         optname: SocketOptionName,
-        optval: MutPtr<u8>,
+        optval: UserPtrMut<u8>,
         len: u32,
         get_option: F,
     ) -> Result<usize, Errno>
@@ -518,7 +518,7 @@ impl<FS: ShimFS> GlobalState<FS> {
         &self,
         fd: &SocketFd,
         optname: SocketOptionName,
-        optval: MutPtr<u8>,
+        optval: UserPtrMut<u8>,
         len: u32,
     ) -> Result<usize, Errno> {
         match self.getsockopt_common(optname, optval, len, |sopt| {
@@ -585,7 +585,7 @@ impl<FS: ShimFS> GlobalState<FS> {
                         };
                         let len = name.len().min(len as usize);
                         optval
-                            .write_slice_at_offset(0, &name.as_bytes()[..len])
+                            .write_slice_at_offset::<Platform>(0, &name.as_bytes()[..len])
                             .ok_or(Errno::EFAULT)?;
                         return Ok(len);
                     }
@@ -1004,7 +1004,7 @@ impl<FS: ShimFS> Task<FS> {
         domain: u32,
         type_and_flags: u32,
         protocol: u8,
-        sockvec: MutPtr<u32>,
+        sockvec: UserPtrMut<u32>,
     ) -> Result<(), Errno> {
         let (ty, flags) = parse_type_and_flags(type_and_flags)?;
         let domain = AddressFamily::try_from(domain).map_err(|_| {
@@ -1012,8 +1012,12 @@ impl<FS: ShimFS> Task<FS> {
             Errno::EINVAL
         })?;
         let (sock1, sock2) = self.do_socketpair(domain, ty, flags, protocol)?;
-        sockvec.write_at_offset(0, sock1).ok_or(Errno::EFAULT)?;
-        sockvec.write_at_offset(1, sock2).ok_or(Errno::EFAULT)?;
+        sockvec
+            .write_at_offset::<Platform>(0, sock1)
+            .ok_or(Errno::EFAULT)?;
+        sockvec
+            .write_at_offset::<Platform>(1, sock2)
+            .ok_or(Errno::EFAULT)?;
         Ok(())
     }
     fn do_socketpair(
@@ -1062,31 +1066,33 @@ impl<FS: ShimFS> Task<FS> {
     }
 }
 pub(crate) fn read_sockaddr_from_user(
-    sockaddr: ConstPtr<u8>,
+    sockaddr: UserPtr<u8>,
     addrlen: usize,
 ) -> Result<SocketAddress, Errno> {
     if addrlen < 2 {
         return Err(Errno::EINVAL);
     }
 
-    let ptr: ConstPtr<u16> = ConstPtr::from_usize(sockaddr.as_usize());
-    let family = ptr.read_at_offset(0).ok_or(Errno::EFAULT)?;
+    let ptr: UserPtr<u16> = UserPtr::from_usize(sockaddr.as_usize());
+    let family = ptr.read_at_offset::<Platform>(0).ok_or(Errno::EFAULT)?;
     let family = AddressFamily::try_from(u32::from(family)).map_err(|_| Errno::EAFNOSUPPORT)?;
     match family {
         AddressFamily::INET => {
             if addrlen < size_of::<CSockInetAddr>() {
                 return Err(Errno::EINVAL);
             }
-            let ptr: ConstPtr<CSockInetAddr> = ConstPtr::from_usize(sockaddr.as_usize());
+            let ptr: UserPtr<CSockInetAddr> = UserPtr::from_usize(sockaddr.as_usize());
             // Note it reads the first 2 bytes (i.e., sa_family) again, but it is not used.
             // SocketAddrV4 only needs the port and addr.
-            let inet_addr = ptr.read_at_offset(0).ok_or(Errno::EFAULT)?;
+            let inet_addr = ptr.read_at_offset::<Platform>(0).ok_or(Errno::EFAULT)?;
             Ok(SocketAddress::Inet(SocketAddr::V4(SocketAddrV4::from(
                 inet_addr,
             ))))
         }
         AddressFamily::UNIX => {
-            let path = sockaddr.to_owned_slice(addrlen).ok_or(Errno::EFAULT)?;
+            let path = sockaddr
+                .to_owned_slice::<Platform>(addrlen)
+                .ok_or(Errno::EFAULT)?;
             // skip the first two bytes (sa_family)
             let path = &path[offset_of!(CSockUnixAddr, path)..];
             if path.is_empty() {
@@ -1108,10 +1114,10 @@ pub(crate) fn read_sockaddr_from_user(
 
 pub(crate) fn write_sockaddr_to_user(
     sock_addr: SocketAddress,
-    addr: crate::MutPtr<u8>,
-    addrlen: crate::MutPtr<u32>,
+    addr: crate::UserPtrMut<u8>,
+    addrlen: crate::UserPtrMut<u32>,
 ) -> Result<(), Errno> {
-    let addrlen_val = addrlen.read_at_offset(0).ok_or(Errno::EFAULT)?;
+    let addrlen_val = addrlen.read_at_offset::<Platform>(0).ok_or(Errno::EFAULT)?;
     if addrlen_val >= i32::MAX as u32 {
         return Err(Errno::EINVAL);
     }
@@ -1120,14 +1126,14 @@ pub(crate) fn write_sockaddr_to_user(
             let addrlen_val = size_of::<CSockInetAddr>().min(addrlen_val as usize);
             let c_addr: CSockInetAddr = v4_addr.into();
             let bytes: &[u8] = c_addr.as_bytes();
-            addr.write_slice_at_offset(0, &bytes[..addrlen_val])
+            addr.write_slice_at_offset::<Platform>(0, &bytes[..addrlen_val])
                 .ok_or(Errno::EFAULT)?;
             size_of::<CSockInetAddr>()
         }
         SocketAddress::Unix(v) => {
-            let family_ptr = MutPtr::<u16>::from_usize(addr.as_usize());
+            let family_ptr = UserPtrMut::<u16>::from_usize(addr.as_usize());
             family_ptr
-                .write_at_offset(0, AddressFamily::UNIX as u16)
+                .write_at_offset::<Platform>(0, AddressFamily::UNIX as u16)
                 .ok_or(Errno::EFAULT)?;
             match v {
                 UnixSocketAddr::Unnamed => {
@@ -1137,10 +1143,10 @@ pub(crate) fn write_sockaddr_to_user(
                 UnixSocketAddr::Abstract(name) => {
                     let offset = offset_of!(CSockUnixAddr, path);
                     if addrlen_val as usize > offset {
-                        addr.write_at_offset(isize::try_from(offset).unwrap(), 0)
+                        addr.write_at_offset::<Platform>(isize::try_from(offset).unwrap(), 0)
                             .ok_or(Errno::EFAULT)?;
                         let max_len = addrlen_val as usize - offset - 1;
-                        addr.write_slice_at_offset(
+                        addr.write_slice_at_offset::<Platform>(
                             isize::try_from(offset + 1).unwrap(),
                             &name[..name.len().min(max_len)],
                         )
@@ -1152,12 +1158,12 @@ pub(crate) fn write_sockaddr_to_user(
                     let offset = offset_of!(CSockUnixAddr, path);
                     let max_len = addrlen_val as usize - offset;
                     let name = &path.as_bytes()[..path.len().min(max_len)];
-                    addr.write_slice_at_offset(isize::try_from(offset).unwrap(), name)
+                    addr.write_slice_at_offset::<Platform>(isize::try_from(offset).unwrap(), name)
                         .ok_or(Errno::EFAULT)?;
                     let null_offset = offset + name.len();
                     // write null terminator if there is space
                     if addrlen_val as usize > null_offset {
-                        addr.write_at_offset(isize::try_from(null_offset).unwrap(), 0)
+                        addr.write_at_offset::<Platform>(isize::try_from(null_offset).unwrap(), 0)
                             .ok_or(Errno::EFAULT)?;
                     }
                     offset + path.len() + 1
@@ -1167,15 +1173,12 @@ pub(crate) fn write_sockaddr_to_user(
         SocketAddress::Inet(SocketAddr::V6(_)) => todo!("copy_sockaddr_to_user for IPv6"),
     }
     .trunc();
-    addrlen.write_at_offset(0, len).ok_or(Errno::EFAULT)
+    addrlen
+        .write_at_offset::<Platform>(0, len)
+        .ok_or(Errno::EFAULT)
 }
 
-fn copy_iovs_to_vec<P>(
-    iovs: &[litebox_common_linux::IoVec<P>],
-) -> Result<alloc::vec::Vec<u8>, Errno>
-where
-    P: litebox::platform::RawMutPointer<u8>,
-{
+fn copy_iovs_to_vec(iovs: &[litebox_common_linux::IoVec]) -> Result<alloc::vec::Vec<u8>, Errno> {
     let total_len = iovs.iter().try_fold(0usize, |total_len, iov| {
         total_len.checked_add(iov.iov_len).ok_or(Errno::EINVAL)
     })?;
@@ -1192,7 +1195,7 @@ where
         for (byte_offset, byte) in (0_isize..).zip(data[offset..end].iter_mut()) {
             *byte = iov
                 .iov_base
-                .read_at_offset(byte_offset)
+                .read_at_offset::<Platform>(byte_offset)
                 .ok_or(Errno::EFAULT)?;
         }
         offset = end;
@@ -1205,8 +1208,8 @@ impl<FS: ShimFS> Task<FS> {
     pub(crate) fn sys_accept(
         &self,
         sockfd: i32,
-        addr: Option<MutPtr<u8>>,
-        addrlen: Option<MutPtr<u32>>,
+        addr: Option<UserPtrMut<u8>>,
+        addrlen: Option<UserPtrMut<u32>>,
         flags: SockFlags,
     ) -> Result<u32, Errno> {
         let Ok(sockfd) = u32::try_from(sockfd) else {
@@ -1285,7 +1288,7 @@ impl<FS: ShimFS> Task<FS> {
     pub(crate) fn sys_connect(
         &self,
         fd: i32,
-        sockaddr: ConstPtr<u8>,
+        sockaddr: UserPtr<u8>,
         addrlen: usize,
     ) -> Result<(), Errno> {
         let Ok(fd) = u32::try_from(fd) else {
@@ -1313,7 +1316,7 @@ impl<FS: ShimFS> Task<FS> {
     pub(crate) fn sys_bind(
         &self,
         sockfd: i32,
-        sockaddr: ConstPtr<u8>,
+        sockaddr: UserPtr<u8>,
         addrlen: usize,
     ) -> Result<(), Errno> {
         let Ok(sockfd) = u32::try_from(sockfd) else {
@@ -1357,10 +1360,10 @@ impl<FS: ShimFS> Task<FS> {
     pub(crate) fn sys_sendto(
         &self,
         fd: i32,
-        buf: ConstPtr<u8>,
+        buf: UserPtr<u8>,
         len: usize,
         flags: SendFlags,
-        addr: Option<ConstPtr<u8>>,
+        addr: Option<UserPtr<u8>>,
         addrlen: u32,
     ) -> Result<usize, Errno> {
         let Ok(fd) = u32::try_from(fd) else {
@@ -1369,7 +1372,7 @@ impl<FS: ShimFS> Task<FS> {
         let sockaddr = addr
             .map(|addr| read_sockaddr_from_user(addr, addrlen as usize))
             .transpose()?;
-        let buf = buf.to_owned_slice(len).ok_or(Errno::EFAULT)?;
+        let buf = buf.to_owned_slice::<Platform>(len).ok_or(Errno::EFAULT)?;
         self.do_sendto(fd, &buf, flags, sockaddr)
     }
     fn do_sendto(
@@ -1410,25 +1413,25 @@ impl<FS: ShimFS> Task<FS> {
     pub(crate) fn sys_sendmsg(
         &self,
         fd: i32,
-        msg: ConstPtr<litebox_common_linux::UserMsgHdr<Platform>>,
+        msg: UserPtr<litebox_common_linux::UserMsgHdr>,
         flags: SendFlags,
     ) -> Result<usize, Errno> {
         let Ok(fd) = u32::try_from(fd) else {
             return Err(Errno::EBADF);
         };
-        let msg = msg.read_at_offset(0).ok_or(Errno::EFAULT)?;
+        let msg = msg.read_at_offset::<Platform>(0).ok_or(Errno::EFAULT)?;
         self.do_sendmsg(fd, &msg, flags)
     }
     fn do_sendmsg(
         &self,
         sockfd: u32,
-        msg: &litebox_common_linux::UserMsgHdr<Platform>,
+        msg: &litebox_common_linux::UserMsgHdr,
         flags: SendFlags,
     ) -> Result<usize, Errno> {
         let msg_name = msg.msg_name;
         let sock_addr = if msg_name.as_usize() != 0 {
             Some(read_sockaddr_from_user(
-                ConstPtr::from_usize(msg_name.as_usize()),
+                UserPtr::from_usize(msg_name.as_usize()),
                 msg.msg_namelen as usize,
             )?)
         } else {
@@ -1446,7 +1449,7 @@ impl<FS: ShimFS> Task<FS> {
         } else {
             Some(
                 msg.msg_iov
-                    .to_owned_slice(msg.msg_iovlen)
+                    .to_owned_slice::<Platform>(msg.msg_iovlen)
                     .ok_or(Errno::EFAULT)?,
             )
         };
@@ -1483,7 +1486,7 @@ impl<FS: ShimFS> Task<FS> {
     pub(crate) fn sys_sendmmsg(
         &self,
         fd: i32,
-        msgvec: MutPtr<litebox_common_linux::UserMmsgHdr<Platform>>,
+        msgvec: UserPtrMut<litebox_common_linux::UserMmsgHdr>,
         vlen: u32,
         flags: SendFlags,
     ) -> Result<usize, Errno> {
@@ -1506,14 +1509,13 @@ impl<FS: ShimFS> Task<FS> {
             return Ok(0);
         }
 
-        let stride = core::mem::size_of::<litebox_common_linux::UserMmsgHdr<Platform>>();
-        let msg_len_off =
-            core::mem::offset_of!(litebox_common_linux::UserMmsgHdr<Platform>, msg_len);
+        let stride = core::mem::size_of::<litebox_common_linux::UserMmsgHdr>();
+        let msg_len_off = core::mem::offset_of!(litebox_common_linux::UserMmsgHdr, msg_len);
 
         let mut sent: usize = 0;
         for i in 0..vlen {
             let bail = |e: Errno| if sent > 0 { Ok(sent) } else { Err(e) };
-            let Some(mmh) = msgvec.read_at_offset(isize::try_from(i).unwrap()) else {
+            let Some(mmh) = msgvec.read_at_offset::<Platform>(isize::try_from(i).unwrap()) else {
                 return bail(Errno::EFAULT);
             };
             let inner = mmh.msg_hdr;
@@ -1522,8 +1524,11 @@ impl<FS: ShimFS> Task<FS> {
                 Err(e) => return bail(e),
             };
             let msg_len_ptr =
-                MutPtr::<u32>::from_usize(msgvec.as_usize() + i * stride + msg_len_off);
-            if msg_len_ptr.write_at_offset(0, n.trunc()).is_none() {
+                UserPtrMut::<u32>::from_usize(msgvec.as_usize() + i * stride + msg_len_off);
+            if msg_len_ptr
+                .write_at_offset::<Platform>(0, n.trunc())
+                .is_none()
+            {
                 return bail(Errno::EFAULT);
             }
             sent += 1;
@@ -1535,11 +1540,11 @@ impl<FS: ShimFS> Task<FS> {
     pub(crate) fn sys_recvfrom(
         &self,
         fd: i32,
-        buf: MutPtr<u8>,
+        buf: UserPtrMut<u8>,
         len: usize,
         flags: ReceiveFlags,
-        addr: Option<MutPtr<u8>>,
-        addrlen: MutPtr<u32>,
+        addr: Option<UserPtrMut<u8>>,
+        addrlen: UserPtrMut<u32>,
     ) -> Result<usize, Errno> {
         const MAX_LEN: usize = 4096;
         let Ok(sockfd) = u32::try_from(fd) else {
@@ -1559,7 +1564,7 @@ impl<FS: ShimFS> Task<FS> {
             },
         )?;
         let capped_size = size.min(recv_buf.len());
-        buf.copy_from_slice(0, &recv_buf[..capped_size])
+        buf.copy_from_slice::<Platform>(0, &recv_buf[..capped_size])
             .ok_or(Errno::EFAULT)?;
         if let Some(src_addr) = source_addr
             && let Some(sock_ptr) = addr
@@ -1634,7 +1639,7 @@ impl<FS: ShimFS> Task<FS> {
     pub(crate) fn sys_recvmsg(
         &self,
         fd: i32,
-        msg_ptr: MutPtr<litebox_common_linux::UserMsgHdr<Platform>>,
+        msg_ptr: UserPtrMut<litebox_common_linux::UserMsgHdr>,
         flags: ReceiveFlags,
     ) -> Result<usize, Errno> {
         let Ok(sockfd) = u32::try_from(fd) else {
@@ -1652,10 +1657,10 @@ impl<FS: ShimFS> Task<FS> {
     fn do_recvmsg(
         &self,
         sockfd: u32,
-        msg_ptr: MutPtr<litebox_common_linux::UserMsgHdr<Platform>>,
+        msg_ptr: UserPtrMut<litebox_common_linux::UserMsgHdr>,
         flags: ReceiveFlags,
     ) -> Result<usize, Errno> {
-        let msg = msg_ptr.read_at_offset(0).ok_or(Errno::EFAULT)?;
+        let msg = msg_ptr.read_at_offset::<Platform>(0).ok_or(Errno::EFAULT)?;
 
         // Copy fields out of the packed struct to avoid unaligned references.
         let msg_name = msg.msg_name;
@@ -1670,7 +1675,9 @@ impl<FS: ShimFS> Task<FS> {
             return Err(Errno::EMSGSIZE);
         }
 
-        let iovs = msg_iov.to_owned_slice(msg_iovlen).ok_or(Errno::EFAULT)?;
+        let iovs = msg_iov
+            .to_owned_slice::<Platform>(msg_iovlen)
+            .ok_or(Errno::EFAULT)?;
 
         let total_iov_capacity = iovs.iter().try_fold(0usize, |capacity, iov| {
             capacity.checked_add(iov.iov_len).ok_or(Errno::EINVAL)
@@ -1715,7 +1722,7 @@ impl<FS: ShimFS> Task<FS> {
             }
             let chunk = (data_to_copy - offset).min(iov.iov_len);
             iov.iov_base
-                .copy_from_slice(0, &recv_buf[offset..offset + chunk])
+                .copy_from_slice::<Platform>(0, &recv_buf[offset..offset + chunk])
                 .ok_or(Errno::EFAULT)?;
             offset += chunk;
         }
@@ -1730,33 +1737,34 @@ impl<FS: ShimFS> Task<FS> {
 
         // Write back source address if requested.
         if want_source {
-            let addrlen_ptr = MutPtr::<u32>::from_usize(
+            let addrlen_ptr = UserPtrMut::<u32>::from_usize(
                 msg_ptr.as_usize()
-                    + core::mem::offset_of!(
-                        litebox_common_linux::UserMsgHdr<Platform>,
-                        msg_namelen
-                    ),
+                    + core::mem::offset_of!(litebox_common_linux::UserMsgHdr, msg_namelen),
             );
             if let Some(src_addr) = source_addr {
                 write_sockaddr_to_user(src_addr, msg_name, addrlen_ptr)?;
             } else {
                 // No source address (e.g. connected stream socket) — zero out msg_namelen.
-                addrlen_ptr.write_at_offset(0, 0u32).ok_or(Errno::EFAULT)?;
+                addrlen_ptr
+                    .write_at_offset::<Platform>(0, 0u32)
+                    .ok_or(Errno::EFAULT)?;
             }
         }
 
         // Ancillary data is not supported, so report that no control bytes were delivered.
         let controllen_offset =
-            core::mem::offset_of!(litebox_common_linux::UserMsgHdr<Platform>, msg_controllen);
-        let controllen_ptr = MutPtr::<usize>::from_usize(msg_ptr.as_usize() + controllen_offset);
-        controllen_ptr.write_at_offset(0, 0).ok_or(Errno::EFAULT)?;
+            core::mem::offset_of!(litebox_common_linux::UserMsgHdr, msg_controllen);
+        let controllen_ptr =
+            UserPtrMut::<usize>::from_usize(msg_ptr.as_usize() + controllen_offset);
+        controllen_ptr
+            .write_at_offset::<Platform>(0, 0)
+            .ok_or(Errno::EFAULT)?;
 
         // Write back msg_flags with any status flags (e.g. MSG_TRUNC).
-        let flags_offset =
-            core::mem::offset_of!(litebox_common_linux::UserMsgHdr<Platform>, msg_flags);
-        let flags_ptr = MutPtr::<ReceiveFlags>::from_usize(msg_ptr.as_usize() + flags_offset);
+        let flags_offset = core::mem::offset_of!(litebox_common_linux::UserMsgHdr, msg_flags);
+        let flags_ptr = UserPtrMut::<ReceiveFlags>::from_usize(msg_ptr.as_usize() + flags_offset);
         flags_ptr
-            .write_at_offset(0, ret_flags)
+            .write_at_offset::<Platform>(0, ret_flags)
             .ok_or(Errno::EFAULT)?;
 
         Ok(total_received)
@@ -1766,10 +1774,10 @@ impl<FS: ShimFS> Task<FS> {
     pub(crate) fn sys_recvmmsg(
         &self,
         fd: i32,
-        msgvec: MutPtr<litebox_common_linux::UserMmsgHdr<Platform>>,
+        msgvec: UserPtrMut<litebox_common_linux::UserMmsgHdr>,
         vlen: u32,
         flags: ReceiveFlags,
-        timeout: litebox_common_linux::TimeParam<Platform>,
+        timeout: litebox_common_linux::TimeParam,
     ) -> Result<usize, Errno> {
         let supported_flags =
             ReceiveFlags::DONTWAIT | ReceiveFlags::TRUNC | ReceiveFlags::WAITFORONE;
@@ -1780,7 +1788,7 @@ impl<FS: ShimFS> Task<FS> {
 
         // Linux's `do_recvmmsg` validates the timespec before looking up the fd,
         // so a bad timeout takes precedence over EBADF.
-        let timeout_duration = timeout.read()?;
+        let timeout_duration = timeout.read::<Platform>()?;
 
         let Ok(sockfd) = u32::try_from(fd) else {
             return Err(Errno::EBADF);
@@ -1805,8 +1813,8 @@ impl<FS: ShimFS> Task<FS> {
         // — both are treated as "no deadline".
         let deadline = timeout_duration.and_then(|d| self.global.platform.now().checked_add(d));
 
-        let stride = size_of::<UserMmsgHdr<Platform>>();
-        let msg_len_off = offset_of!(UserMmsgHdr<Platform>, msg_len);
+        let stride = size_of::<UserMmsgHdr>();
+        let msg_len_off = offset_of!(UserMmsgHdr, msg_len);
         let msgvec_base = msgvec.as_usize();
         let msgvec_len = vlen.checked_mul(stride).ok_or(Errno::EFAULT)?;
         if msgvec_base.checked_add(msgvec_len).is_none() {
@@ -1821,7 +1829,7 @@ impl<FS: ShimFS> Task<FS> {
         let mut async_error_to_restore = None;
         for i in 0..vlen {
             let base = msgvec_base + i * stride;
-            let inner_ptr = MutPtr::<UserMsgHdr<Platform>>::from_usize(base);
+            let inner_ptr = UserPtrMut::<UserMsgHdr>::from_usize(base);
             let n = match self.do_recvmsg(sockfd, inner_ptr, iter_flags) {
                 Ok(n) => n,
                 Err(e) => {
@@ -1832,8 +1840,11 @@ impl<FS: ShimFS> Task<FS> {
                     break;
                 }
             };
-            let msg_len_ptr = MutPtr::<u32>::from_usize(base + msg_len_off);
-            if msg_len_ptr.write_at_offset(0, n.trunc()).is_none() {
+            let msg_len_ptr = UserPtrMut::<u32>::from_usize(base + msg_len_off);
+            if msg_len_ptr
+                .write_at_offset::<Platform>(0, n.trunc())
+                .is_none()
+            {
                 last_err = Some(Errno::EFAULT);
                 break;
             }
@@ -1868,7 +1879,7 @@ impl<FS: ShimFS> Task<FS> {
         let remaining = deadline
             .and_then(|d| d.checked_duration_since(&self.global.platform.now()))
             .unwrap_or(core::time::Duration::ZERO);
-        timeout.write(remaining)?;
+        timeout.write::<Platform>(remaining)?;
 
         Ok(received)
     }
@@ -1878,7 +1889,7 @@ impl<FS: ShimFS> Task<FS> {
         sockfd: i32,
         level: u32,
         optname: u32,
-        optval: ConstPtr<u8>,
+        optval: UserPtr<u8>,
         optlen: usize,
     ) -> Result<(), Errno> {
         let Ok(sockfd) = u32::try_from(sockfd) else {
@@ -1894,7 +1905,7 @@ impl<FS: ShimFS> Task<FS> {
         &self,
         sockfd: u32,
         optname: SocketOptionName,
-        optval: ConstPtr<u8>,
+        optval: UserPtr<u8>,
         optlen: usize,
     ) -> Result<(), Errno> {
         self.files.borrow().with_socket(
@@ -1911,8 +1922,8 @@ impl<FS: ShimFS> Task<FS> {
         sockfd: i32,
         level: u32,
         optname: u32,
-        optval: MutPtr<u8>,
-        optlen: MutPtr<u32>,
+        optval: UserPtrMut<u8>,
+        optlen: UserPtrMut<u32>,
     ) -> Result<(), Errno> {
         let Ok(sockfd) = u32::try_from(sockfd) else {
             return Err(Errno::EBADF);
@@ -1921,13 +1932,13 @@ impl<FS: ShimFS> Task<FS> {
             log_unsupported!("setsockopt(level = {level}, optname = {optname})");
             Errno::EINVAL
         })?;
-        let len = optlen.read_at_offset(0).ok_or(Errno::EFAULT)?;
+        let len = optlen.read_at_offset::<Platform>(0).ok_or(Errno::EFAULT)?;
         if len > i32::MAX as u32 {
             return Err(Errno::EINVAL);
         }
         let new_len = self.do_getsockopt(sockfd, optname, optval, len)?;
         optlen
-            .write_at_offset(0, new_len.trunc())
+            .write_at_offset::<Platform>(0, new_len.trunc())
             .ok_or(Errno::EFAULT)?;
         Ok(())
     }
@@ -1938,7 +1949,7 @@ impl<FS: ShimFS> Task<FS> {
         &self,
         sockfd: u32,
         optname: SocketOptionName,
-        optval: MutPtr<u8>,
+        optval: UserPtrMut<u8>,
         len: u32,
     ) -> Result<usize, Errno> {
         self.files.borrow().with_socket(
@@ -1953,8 +1964,8 @@ impl<FS: ShimFS> Task<FS> {
     pub(crate) fn sys_getsockname(
         &self,
         sockfd: i32,
-        addr: MutPtr<u8>,
-        addrlen: MutPtr<u32>,
+        addr: UserPtrMut<u8>,
+        addrlen: UserPtrMut<u32>,
     ) -> Result<(), Errno> {
         let Ok(sockfd) = u32::try_from(sockfd) else {
             return Err(Errno::EBADF);
@@ -1982,8 +1993,8 @@ impl<FS: ShimFS> Task<FS> {
     pub(crate) fn sys_getpeername(
         &self,
         sockfd: i32,
-        addr: MutPtr<u8>,
-        addrlen: MutPtr<u32>,
+        addr: UserPtrMut<u8>,
+        addrlen: UserPtrMut<u32>,
     ) -> Result<(), Errno> {
         let Ok(sockfd) = u32::try_from(sockfd) else {
             return Err(Errno::EBADF);
@@ -2045,7 +2056,6 @@ mod tests {
     use core::net::SocketAddr;
 
     use alloc::string::ToString as _;
-    use litebox::platform::RawConstPointer as _;
     use litebox::utils::TruncateExt as _;
     use litebox_common_linux::{
         AddressFamily, ReceiveFlags, SendFlags, SockFlags, SockType, SocketOption,
@@ -2055,7 +2065,7 @@ mod tests {
 
     use super::SocketAddress;
     use crate::{
-        ConstPtr, MutPtr,
+        UserPtr, UserPtrMut,
         syscalls::{
             net::{CSockInetAddr, read_sockaddr_from_user},
             tests::init_platform,
@@ -2067,7 +2077,7 @@ mod tests {
 
     // Compile-time layout check: UserMsgHdr must match Linux's struct user_msghdr.
     const _USER_MSG_HDR_SIZE: () = assert!(
-        core::mem::size_of::<litebox_common_linux::UserMsgHdr<crate::Platform>>()
+        core::mem::size_of::<litebox_common_linux::UserMsgHdr>()
             == core::mem::size_of::<libc::msghdr>()
     );
 
@@ -2090,7 +2100,7 @@ mod tests {
             .do_getsockopt(
                 sockfd,
                 SocketOptionName::Socket(SocketOption::ERROR),
-                MutPtr::from_usize((&raw mut optval).cast::<u8>() as usize),
+                UserPtrMut::from_usize((&raw mut optval).cast::<u8>() as usize),
                 core::mem::size_of::<u32>().trunc(),
             )
             .expect("getsockopt SO_ERROR failed");
@@ -2109,7 +2119,7 @@ mod tests {
             data: u64::from(target_fd),
         };
         let ev_ptr = (&raw const ev).cast::<litebox_common_linux::EpollEvent>();
-        let ev_const = crate::ConstPtr::from_usize(ev_ptr as usize);
+        let ev_const = crate::UserPtr::from_usize(ev_ptr as usize);
         task.sys_epoll_ctl(
             epfd,
             litebox_common_linux::EpollOp::EpollCtlAdd,
@@ -2124,7 +2134,7 @@ mod tests {
         epfd: i32,
         events: &mut [litebox_common_linux::EpollEvent],
     ) -> usize {
-        let events_ptr = crate::MutPtr::from_usize(events.as_mut_ptr() as usize);
+        let events_ptr = crate::UserPtrMut::from_usize(events.as_mut_ptr() as usize);
         task.sys_epoll_pwait(epfd, events_ptr, events.len().trunc(), -1, None, 0)
             .expect("epoll_wait failed")
     }
@@ -2239,17 +2249,17 @@ mod tests {
                 let buf2 = " world!\n";
                 let iovec = [
                     litebox_common_linux::IoVec {
-                        iov_base: MutPtr::from_usize(buf1.as_ptr().expose_provenance()),
+                        iov_base: UserPtrMut::from_usize(buf1.as_ptr().expose_provenance()),
                         iov_len: buf1.len(),
                     },
                     litebox_common_linux::IoVec {
-                        iov_base: MutPtr::from_usize(buf2.as_ptr().expose_provenance()),
+                        iov_base: UserPtrMut::from_usize(buf2.as_ptr().expose_provenance()),
                         iov_len: buf2.len(),
                     },
                 ];
                 let hdr = {
-                    let mut h = litebox_common_linux::UserMsgHdr::<crate::Platform>::new_zeroed();
-                    h.msg_iov = ConstPtr::from_usize(iovec.as_ptr() as usize);
+                    let mut h = litebox_common_linux::UserMsgHdr::new_zeroed();
+                    h.msg_iov = UserPtr::from_usize(iovec.as_ptr() as usize);
                     h.msg_iovlen = iovec.len();
                     h
                 };
@@ -2288,14 +2298,15 @@ mod tests {
                         .expect("Failed to receive data"),
                     "recvmsg" => {
                         let iovec = [litebox_common_linux::IoVec {
-                            iov_base: MutPtr::from_usize(recv_buf.as_mut_ptr().expose_provenance()),
+                            iov_base: UserPtrMut::from_usize(
+                                recv_buf.as_mut_ptr().expose_provenance(),
+                            ),
                             iov_len: recv_buf.len(),
                         }];
-                        let mut msg_hdr =
-                            litebox_common_linux::UserMsgHdr::<crate::Platform>::new_zeroed();
-                        msg_hdr.msg_iov = ConstPtr::from_usize(iovec.as_ptr() as usize);
+                        let mut msg_hdr = litebox_common_linux::UserMsgHdr::new_zeroed();
+                        msg_hdr.msg_iov = UserPtr::from_usize(iovec.as_ptr() as usize);
                         msg_hdr.msg_iovlen = iovec.len();
-                        let msg_ptr = MutPtr::from_usize(&raw mut msg_hdr as usize);
+                        let msg_ptr = UserPtrMut::from_usize(&raw mut msg_hdr as usize);
                         task.sys_recvmsg(i32::try_from(client_fd).unwrap(), msg_ptr, flags)
                             .expect("failed to recvmsg")
                     }
@@ -2454,7 +2465,7 @@ mod tests {
             onoff: 1,   // enable linger
             linger: 60, // timeout in seconds
         };
-        let optval = ConstPtr::from_usize((&raw const linger).cast::<u8>() as usize);
+        let optval = UserPtr::from_usize((&raw const linger).cast::<u8>() as usize);
         task.do_setsockopt(
             client_fd,
             SocketOptionName::Socket(SocketOption::LINGER),
@@ -2563,25 +2574,25 @@ mod tests {
                 let mut addrlen = core::mem::size_of::<CSockInetAddr>();
                 task.sys_recvfrom(
                     i32::try_from(server_fd).unwrap(),
-                    MutPtr::from_usize(recv_buf.as_mut_ptr() as usize),
+                    UserPtrMut::from_usize(recv_buf.as_mut_ptr() as usize),
                     recv_len,
                     recv_flags,
-                    Some(MutPtr::from_usize(source_addr.as_ptr() as usize)),
-                    MutPtr::from_usize(&raw mut addrlen as usize),
+                    Some(UserPtrMut::from_usize(source_addr.as_ptr() as usize)),
+                    UserPtrMut::from_usize(&raw mut addrlen as usize),
                 )
                 .expect("recvfrom failed")
             }
             "recvmsg" => {
                 let iovec = [litebox_common_linux::IoVec {
-                    iov_base: MutPtr::from_usize(recv_buf.as_mut_ptr() as usize),
+                    iov_base: UserPtrMut::from_usize(recv_buf.as_mut_ptr() as usize),
                     iov_len: recv_len,
                 }];
-                let mut msg_hdr = litebox_common_linux::UserMsgHdr::<crate::Platform>::new_zeroed();
-                msg_hdr.msg_iov = ConstPtr::from_usize(iovec.as_ptr() as usize);
+                let mut msg_hdr = litebox_common_linux::UserMsgHdr::new_zeroed();
+                msg_hdr.msg_iov = UserPtr::from_usize(iovec.as_ptr() as usize);
                 msg_hdr.msg_iovlen = iovec.len();
-                msg_hdr.msg_name = MutPtr::from_usize(source_addr.as_ptr() as usize);
+                msg_hdr.msg_name = UserPtrMut::from_usize(source_addr.as_ptr() as usize);
                 msg_hdr.msg_namelen = source_addr.len().trunc();
-                let msg_ptr = MutPtr::from_usize(&raw mut msg_hdr as usize);
+                let msg_ptr = UserPtrMut::from_usize(&raw mut msg_hdr as usize);
                 let n = task
                     .sys_recvmsg(i32::try_from(server_fd).unwrap(), msg_ptr, recv_flags)
                     .expect("recvmsg failed");
@@ -2594,7 +2605,7 @@ mod tests {
             _ => panic!("Unknown operation"),
         };
         let sender_addr = read_sockaddr_from_user(
-            ConstPtr::from_usize(source_addr.as_ptr() as usize),
+            UserPtr::from_usize(source_addr.as_ptr() as usize),
             source_addr.len(),
         )
         .ok();
@@ -2705,7 +2716,7 @@ mod tests {
             .do_getsockopt(
                 sockfd,
                 SocketOptionName::TCP(TcpOption::CONGESTION),
-                MutPtr::from_usize(congestion_name.as_mut_ptr() as usize),
+                UserPtrMut::from_usize(congestion_name.as_mut_ptr() as usize),
                 congestion_name.len().trunc(),
             )
             .expect("Failed to get TCP_CONGESTION");
@@ -2718,7 +2729,7 @@ mod tests {
         task.do_setsockopt(
             sockfd,
             SocketOptionName::TCP(TcpOption::CONGESTION),
-            ConstPtr::from_usize(congestion_name.as_ptr() as usize),
+            UserPtr::from_usize(congestion_name.as_ptr() as usize),
             optlen,
         )
         .expect("Failed to set TCP_CONGESTION");
@@ -2728,14 +2739,14 @@ mod tests {
             .do_setsockopt(
                 sockfd,
                 SocketOptionName::TCP(TcpOption::CONGESTION),
-                ConstPtr::from_usize(congestion_name.as_ptr() as usize),
+                UserPtr::from_usize(congestion_name.as_ptr() as usize),
                 congestion_name.len(),
             )
             .unwrap_err();
         assert_eq!(err, Errno::EINVAL);
 
         let val: u32 = 1;
-        let optval = ConstPtr::from_usize((&raw const val).cast::<u8>() as usize);
+        let optval = UserPtr::from_usize((&raw const val).cast::<u8>() as usize);
         task.do_setsockopt(
             sockfd,
             SocketOptionName::Socket(SocketOption::KEEPALIVE),
@@ -2746,7 +2757,7 @@ mod tests {
 
         // Verify SO_KEEPALIVE is enabled
         let mut result: u32 = 0;
-        let optval_out = MutPtr::from_usize((&raw mut result).cast::<u8>() as usize);
+        let optval_out = UserPtrMut::from_usize((&raw mut result).cast::<u8>() as usize);
         let len = task
             .do_getsockopt(
                 sockfd,
@@ -2811,14 +2822,14 @@ mod unix_tests {
     use core::time::Duration;
 
     use alloc::{string::ToString, vec::Vec};
-    use litebox::{event::Events, platform::RawConstPointer};
+    use litebox::event::Events;
     use litebox_common_linux::{
         AddressFamily, AtFlags, ReceiveFlags, SendFlags, SockFlags, SockType, SocketOption,
         SocketOptionName, TimeParam, errno::Errno,
     };
 
     use crate::{
-        ConstPtr, MutPtr, Task,
+        Task, UserPtr, UserPtrMut,
         syscalls::{net::SocketAddress, tests::init_platform, unix::UnixSocketAddr},
     };
 
@@ -2857,7 +2868,7 @@ mod unix_tests {
 
         let n = task
             .sys_ppoll(
-                MutPtr::from_usize(pollfd.as_mut_ptr() as usize),
+                UserPtrMut::from_usize(pollfd.as_mut_ptr() as usize),
                 1,
                 TimeParam::None,
                 None,
@@ -3227,7 +3238,7 @@ mod unix_tests {
     fn unix_socketpair_bidirectional(ty: SockType, is_nonblocking: bool) {
         let task = init_platform(None);
         let mut sv_ptr = alloc::vec![0u32; 2];
-        let sv_mut_ptr = MutPtr::from_usize(sv_ptr.as_mut_ptr() as usize);
+        let sv_mut_ptr = UserPtrMut::from_usize(sv_ptr.as_mut_ptr() as usize);
 
         let ty_and_flags = if is_nonblocking {
             SockFlags::NONBLOCK.bits()
@@ -3297,7 +3308,7 @@ mod unix_tests {
             .expect("socketpair failed");
         let timeout = Duration::from_millis(200);
         let tv = litebox_common_linux::TimeVal::from(timeout);
-        let optval = ConstPtr::from_usize((&raw const tv).cast::<u8>() as usize);
+        let optval = UserPtr::from_usize((&raw const tv).cast::<u8>() as usize);
         task.do_setsockopt(
             sock1,
             SocketOptionName::Socket(SocketOption::RCVTIMEO),

--- a/litebox_shim_linux/src/syscalls/process.rs
+++ b/litebox_shim_linux/src/syscalls/process.rs
@@ -3,7 +3,7 @@
 
 //! Process/thread related syscalls.
 
-use crate::{ConstPtr, MutPtr, ShimFS, Task};
+use crate::{ShimFS, Task, UserPtr, UserPtrMut};
 use alloc::boxed::Box;
 use alloc::collections::btree_map::BTreeMap;
 use alloc::sync::Arc;
@@ -16,11 +16,9 @@ use core::time::Duration;
 use litebox::event::wait::WaitError;
 use litebox::mm::linux::VmFlags;
 use litebox::platform::ThreadProvider;
-use litebox::platform::{
-    ArchSpecificProvider as _, ArchSpecificRegister, RawConstPointer as _, RawMutex as _,
-};
+use litebox::platform::{ArchSpecificProvider as _, ArchSpecificRegister, RawMutex as _};
 use litebox::platform::{Instant as _, SystemTime as _, TimeProvider};
-use litebox::platform::{RawMutPointer as _, TimerHandle, TimerProvider};
+use litebox::platform::{TimerHandle, TimerProvider};
 use litebox::sync::Mutex;
 use litebox::utils::TruncateExt as _;
 use litebox_common_linux::{
@@ -43,12 +41,12 @@ pub(crate) struct ThreadState {
     ///
     /// This operation wakes a single thread waiting on the specified memory location via futex.
     /// Any errors from the futex wake operation are ignored.
-    clear_child_tid: Cell<Option<MutPtr<i32>>>,
+    clear_child_tid: Cell<Option<UserPtrMut<i32>>>,
     /// The purpose of the robust futex list is to ensure that if a thread accidentally fails to unlock a futex before
     /// terminating or calling execve(2), another thread that is waiting on that futex is notified that the former owner
     /// of the futex has died. This notification consists of two pieces: the FUTEX_OWNER_DIED bit is set in the futex word,
     /// and the kernel performs a futex(2) FUTEX_WAKE operation on one of the threads waiting on the futex.
-    robust_list: Cell<Option<ConstPtr<litebox_common_linux::RobustListHead>>>,
+    robust_list: Cell<Option<UserPtr<litebox_common_linux::RobustListHead>>>,
 }
 
 // TODO: remove once we figure out how to handle Send/Sync for raw pointers.
@@ -334,7 +332,7 @@ enum ThreadInitState {
     NewThread {
         stack: Option<usize>,
         tls: Option<ThreadLocalDescriptor>,
-        set_child_tid: Option<MutPtr<i32>>,
+        set_child_tid: Option<UserPtrMut<i32>>,
     },
 }
 
@@ -361,13 +359,10 @@ impl<FS: ShimFS> Task<FS> {
     }
 
     /// Handle syscall `prctl`.
-    pub(crate) fn sys_prctl(
-        &self,
-        arg: PrctlArg<litebox_platform_multiplex::Platform>,
-    ) -> Result<usize, Errno> {
+    pub(crate) fn sys_prctl(&self, arg: PrctlArg) -> Result<usize, Errno> {
         match arg {
             PrctlArg::GetName(name) => name
-                .write_slice_at_offset(0, &self.comm.get())
+                .write_slice_at_offset::<Platform>(0, &self.comm.get())
                 .ok_or(Errno::EFAULT)
                 .map(|()| 0),
             PrctlArg::SetName(name) => {
@@ -375,7 +370,7 @@ impl<FS: ShimFS> Task<FS> {
                 // strncpy
                 for (i, byte) in name_buf.iter_mut().enumerate() {
                     let b = name
-                        .read_at_offset(isize::try_from(i).unwrap())
+                        .read_at_offset::<Platform>(isize::try_from(i).unwrap())
                         .ok_or(Errno::EFAULT)?;
                     if b == 0 {
                         break;
@@ -403,10 +398,7 @@ impl<FS: ShimFS> Task<FS> {
     }
 
     /// Handle syscall `arch_prctl`.
-    pub(crate) fn sys_arch_prctl(
-        &self,
-        arg: ArchPrctlArg<litebox_platform_multiplex::Platform>,
-    ) -> Result<(), Errno> {
+    pub(crate) fn sys_arch_prctl(&self, arg: ArchPrctlArg) -> Result<(), Errno> {
         match arg {
             #[cfg(target_arch = "x86_64")]
             ArchPrctlArg::SetFs(addr) => self
@@ -420,7 +412,8 @@ impl<FS: ShimFS> Task<FS> {
                     .global
                     .platform
                     .get_arch_specific_register(&ArchSpecificRegister::FsBase)?;
-                addr.write_at_offset(0, fsbase).ok_or(Errno::EFAULT)?;
+                addr.write_at_offset::<Platform>(0, fsbase)
+                    .ok_or(Errno::EFAULT)?;
                 Ok(())
             }
             ArchPrctlArg::CETStatus | ArchPrctlArg::CETDisable | ArchPrctlArg::CETLock => {
@@ -438,11 +431,11 @@ const ROBUST_LIST_LIMIT: isize = 2048;
  * dying task, and do notification if so:
  */
 fn handle_futex_death(
-    futex_addr: crate::ConstPtr<u32>,
+    futex_addr: crate::UserPtr<u32>,
     _pi: bool,
     _pending_op: bool,
 ) -> Result<(), Errno> {
-    if futex_addr.as_usize() % 4 != 0 {
+    if !futex_addr.as_usize().is_multiple_of(4) {
         return Err(Errno::EINVAL);
     }
 
@@ -450,29 +443,29 @@ fn handle_futex_death(
 }
 
 fn fetch_robust_entry(
-    head: crate::ConstPtr<litebox_common_linux::RobustList>,
-) -> (crate::ConstPtr<litebox_common_linux::RobustList>, bool) {
+    head: crate::UserPtr<litebox_common_linux::RobustList>,
+) -> (crate::UserPtr<litebox_common_linux::RobustList>, bool) {
     let next = head.as_usize();
-    (crate::ConstPtr::from_usize(next & !1), next & 1 != 0)
+    (crate::UserPtr::from_usize(next & !1), next & 1 != 0)
 }
 
 fn wake_robust_list(
-    head: crate::ConstPtr<litebox_common_linux::RobustListHead>,
+    head: crate::UserPtr<litebox_common_linux::RobustListHead>,
 ) -> Result<(), Errno> {
     let mut limit = ROBUST_LIST_LIMIT;
     let head_ptr = head.as_usize();
-    let head = head.read_at_offset(0).ok_or(Errno::EFAULT)?;
-    let (mut entry, mut pi) = fetch_robust_entry(crate::ConstPtr::from_usize(head.list.next));
-    let (pending, ppi) = fetch_robust_entry(crate::ConstPtr::from_usize(head.list_op_pending));
+    let head = head.read_at_offset::<Platform>(0).ok_or(Errno::EFAULT)?;
+    let (mut entry, mut pi) = fetch_robust_entry(crate::UserPtr::from_usize(head.list.next));
+    let (pending, ppi) = fetch_robust_entry(crate::UserPtr::from_usize(head.list_op_pending));
     let futex_offset = head.futex_offset;
     let entry_head = head_ptr + offset_of!(litebox_common_linux::RobustListHead, list);
     while entry.as_usize() != entry_head && limit > 0 {
         let nxt = entry
-            .read_at_offset(0)
-            .map(|e| fetch_robust_entry(crate::ConstPtr::from_usize(e.next)));
+            .read_at_offset::<Platform>(0)
+            .map(|e| fetch_robust_entry(crate::UserPtr::from_usize(e.next)));
         if entry.as_usize() != pending.as_usize() {
             handle_futex_death(
-                crate::ConstPtr::from_usize(entry.as_usize() + futex_offset),
+                crate::UserPtr::from_usize(entry.as_usize() + futex_offset),
                 pi,
                 false,
             )?;
@@ -488,7 +481,7 @@ fn wake_robust_list(
 
     if pending.as_usize() != 0 {
         let _ = handle_futex_death(
-            crate::ConstPtr::from_usize(pending.as_usize() + futex_offset),
+            crate::UserPtr::from_usize(pending.as_usize() + futex_offset),
             ppi,
             true,
         );
@@ -504,9 +497,9 @@ impl<FS: ShimFS> Task<FS> {
         if let Some(clear_child_tid) = self.thread.clear_child_tid.take() {
             // Clear the child TID if requested
             // TODO: if we are the last thread, we don't need to clear it
-            let _ = clear_child_tid.write_at_offset(0, 0);
+            let _ = clear_child_tid.write_at_offset::<Platform>(0, 0);
             // Cast from *i32 to *u32
-            let clear_child_tid = crate::MutPtr::from_usize(clear_child_tid.as_usize());
+            let clear_child_tid = crate::UserPtrMut::from_usize(clear_child_tid.as_usize());
             let _ = self.sys_futex(litebox_common_linux::FutexArgs::Wake {
                 addr: clear_child_tid,
                 flags: litebox_common_linux::FutexFlags::PRIVATE,
@@ -535,7 +528,7 @@ impl<FS: ShimFS> Task<FS> {
 /// On `x86_64`, this is represented as a `*mut u8`. The TLS pointer can point to
 /// an arbitrary-sized memory region.
 #[cfg(target_arch = "x86_64")]
-type ThreadLocalDescriptor = MutPtr<u8>;
+type ThreadLocalDescriptor = UserPtrMut<u8>;
 
 struct NewThreadArgs<FS: ShimFS> {
     /// Task struct that maintains all per-thread data
@@ -570,9 +563,9 @@ impl<FS: ShimFS> Task<FS> {
     pub(crate) fn sys_clone3(
         &self,
         ctx: &litebox_common_linux::PtRegs,
-        args: ConstPtr<litebox_common_linux::CloneArgs>,
+        args: UserPtr<litebox_common_linux::CloneArgs>,
     ) -> Result<usize, Errno> {
-        let args = args.read_at_offset(0).ok_or(Errno::EFAULT)?;
+        let args = args.read_at_offset::<Platform>(0).ok_or(Errno::EFAULT)?;
         self.do_clone(ctx, &args, true)
     }
 
@@ -663,7 +656,7 @@ impl<FS: ShimFS> Task<FS> {
                 }
             }
             #[cfg(target_arch = "x86_64")]
-            let desc = MutPtr::from_usize(addr);
+            let desc = UserPtrMut::from_usize(addr);
             Some(desc)
         } else {
             None
@@ -672,7 +665,7 @@ impl<FS: ShimFS> Task<FS> {
         let child_tid = if child_tid == 0 {
             None
         } else {
-            Some(MutPtr::from_usize(child_tid.trunc()))
+            Some(UserPtrMut::from_usize(child_tid.trunc()))
         };
         let set_child_tid = if flags.contains(CloneFlags::CHILD_SETTID) {
             child_tid
@@ -685,7 +678,7 @@ impl<FS: ShimFS> Task<FS> {
             None
         };
         let set_parent_tid = if flags.contains(CloneFlags::PARENT_SETTID) && parent_tid != 0 {
-            Some(MutPtr::from_usize(parent_tid.trunc()))
+            Some(UserPtrMut::from_usize(parent_tid.trunc()))
         } else {
             None
         };
@@ -698,7 +691,7 @@ impl<FS: ShimFS> Task<FS> {
 
         let child_tid = self.global.next_thread_id.fetch_add(1, Ordering::Relaxed);
         if let Some(parent_tid_ptr) = set_parent_tid {
-            let _ = parent_tid_ptr.write_at_offset(0, child_tid);
+            let _ = parent_tid_ptr.write_at_offset::<Platform>(0, child_tid);
         }
 
         if (stack == 0 && stack_size != 0) || (stack != 0 && clone3 && stack_size == 0) {
@@ -751,7 +744,7 @@ impl<FS: ShimFS> Task<FS> {
     }
 
     /// Handle syscall `set_tid_address`.
-    pub(crate) fn sys_set_tid_address(&self, tidptr: crate::MutPtr<i32>) -> i32 {
+    pub(crate) fn sys_set_tid_address(&self, tidptr: crate::UserPtrMut<i32>) -> i32 {
         self.thread.clear_child_tid.set(Some(tidptr));
         self.tid
     }
@@ -882,15 +875,15 @@ impl<FS: ShimFS> Task<FS> {
         &self,
         pid: i32,
         resource: litebox_common_linux::RlimitResource,
-        new_rlim: Option<crate::ConstPtr<litebox_common_linux::Rlimit64>>,
-        old_rlim: Option<crate::MutPtr<litebox_common_linux::Rlimit64>>,
+        new_rlim: Option<crate::UserPtr<litebox_common_linux::Rlimit64>>,
+        old_rlim: Option<crate::UserPtrMut<litebox_common_linux::Rlimit64>>,
     ) -> Result<(), Errno> {
         if pid != 0 {
             unimplemented!("prlimit for a specific PID is not supported yet");
         }
         let new_limit = match new_rlim {
             Some(rlim) => {
-                let rlim = rlim.read_at_offset(0).ok_or(Errno::EINVAL)?;
+                let rlim = rlim.read_at_offset::<Platform>(0).ok_or(Errno::EINVAL)?;
                 Some(litebox_common_linux::rlimit64_to_rlimit(rlim))
             }
             None => None,
@@ -899,7 +892,7 @@ impl<FS: ShimFS> Task<FS> {
             litebox_common_linux::rlimit_to_rlimit64(self.do_prlimit(resource, new_limit)?);
         if let Some(old_rlim) = old_rlim {
             old_rlim
-                .write_at_offset(0, old_limit)
+                .write_at_offset::<Platform>(0, old_limit)
                 .ok_or(Errno::EINVAL)?;
         }
         Ok(())
@@ -909,26 +902,27 @@ impl<FS: ShimFS> Task<FS> {
     pub(crate) fn sys_getrlimit(
         &self,
         resource: litebox_common_linux::RlimitResource,
-        rlim: crate::MutPtr<litebox_common_linux::Rlimit>,
+        rlim: crate::UserPtrMut<litebox_common_linux::Rlimit>,
     ) -> Result<(), Errno> {
         let old_limit = self.do_prlimit(resource, None)?;
-        rlim.write_at_offset(0, old_limit).ok_or(Errno::EINVAL)
+        rlim.write_at_offset::<Platform>(0, old_limit)
+            .ok_or(Errno::EINVAL)
     }
 
     /// Handle syscall `setrlimit`.
     pub(crate) fn sys_setrlimit(
         &self,
         resource: litebox_common_linux::RlimitResource,
-        rlim: crate::ConstPtr<litebox_common_linux::Rlimit>,
+        rlim: crate::UserPtr<litebox_common_linux::Rlimit>,
     ) -> Result<(), Errno> {
-        let new_limit = rlim.read_at_offset(0).ok_or(Errno::EFAULT)?;
+        let new_limit = rlim.read_at_offset::<Platform>(0).ok_or(Errno::EFAULT)?;
         let _ = self.do_prlimit(resource, Some(new_limit))?;
         Ok(())
     }
 
     /// Handle syscall `set_robust_list`.
     pub(crate) fn sys_set_robust_list(&self, head: usize) {
-        let head = crate::ConstPtr::from_usize(head);
+        let head = crate::UserPtr::from_usize(head);
         self.thread.robust_list.set(Some(head));
     }
 
@@ -936,7 +930,7 @@ impl<FS: ShimFS> Task<FS> {
     pub(crate) fn sys_get_robust_list(
         &self,
         pid: Option<i32>,
-        head_ptr: crate::MutPtr<usize>,
+        head_ptr: crate::UserPtrMut<usize>,
     ) -> Result<(), Errno> {
         if pid.is_some() {
             unimplemented!("Getting robust list for a specific PID is not supported yet");
@@ -946,7 +940,9 @@ impl<FS: ShimFS> Task<FS> {
             .robust_list
             .get()
             .map_or(0, |ptr| ptr.as_usize());
-        head_ptr.write_at_offset(0, head).ok_or(Errno::EFAULT)
+        head_ptr
+            .write_at_offset::<Platform>(0, head)
+            .ok_or(Errno::EFAULT)
     }
 
     fn real_time_as_duration_since_epoch(&self) -> core::time::Duration {
@@ -961,10 +957,10 @@ impl<FS: ShimFS> Task<FS> {
     pub(crate) fn sys_clock_gettime(
         &self,
         clockid: litebox_common_linux::ClockId,
-        tp: TimeParam<Platform>,
+        tp: TimeParam,
     ) -> Result<(), Errno> {
         let duration = self.gettime_as_duration(clockid)?;
-        tp.write(duration)
+        tp.write::<Platform>(duration)
     }
 
     fn gettime_as_duration(
@@ -1035,7 +1031,7 @@ impl<FS: ShimFS> Task<FS> {
     pub(crate) fn sys_clock_getres(
         &self,
         clockid: litebox_common_linux::ClockId,
-        res: TimeParam<Platform>,
+        res: TimeParam,
     ) -> Result<(), Errno> {
         // Return the resolution of the clock
         let resolution = match clockid {
@@ -1051,7 +1047,7 @@ impl<FS: ShimFS> Task<FS> {
             _ => unimplemented!(),
         };
 
-        res.write(resolution)
+        res.write::<Platform>(resolution)
     }
 
     /// Handle syscall `clock_nanosleep`.
@@ -1059,10 +1055,10 @@ impl<FS: ShimFS> Task<FS> {
         &self,
         clockid: litebox_common_linux::ClockId,
         flags: litebox_common_linux::TimerFlags,
-        request: TimeParam<Platform>,
-        remain: TimeParam<Platform>,
+        request: TimeParam,
+        remain: TimeParam,
     ) -> Result<(), Errno> {
-        let request = request.read()?.ok_or(Errno::EFAULT)?;
+        let request = request.read::<Platform>()?.ok_or(Errno::EFAULT)?;
         if flags.intersects(litebox_common_linux::TimerFlags::ABSTIME.complement()) {
             return Err(Errno::EINVAL);
         }
@@ -1084,7 +1080,7 @@ impl<FS: ShimFS> Task<FS> {
                     return Err(Errno::EINTR);
                 }
                 if let Some(remaining_timeout) = wait_cx.remaining_timeout() {
-                    remain.write(remaining_timeout)?;
+                    remain.write::<Platform>(remaining_timeout)?;
                     return Err(Errno::EINTR);
                 }
                 // Whoops, time ran out after getting interrupted. Treat this as a timeout.
@@ -1097,18 +1093,19 @@ impl<FS: ShimFS> Task<FS> {
     /// Handle syscall `gettimeofday`.
     pub(crate) fn sys_gettimeofday(
         &self,
-        tv: Option<crate::MutPtr<litebox_common_linux::TimeVal>>,
-        tz: Option<crate::MutPtr<litebox_common_linux::TimeZone>>,
+        tv: Option<crate::UserPtrMut<litebox_common_linux::TimeVal>>,
+        tz: Option<crate::UserPtrMut<litebox_common_linux::TimeZone>>,
     ) -> Result<(), Errno> {
         if let Some(tz) = tz {
             // `man 2 gettimeofday`: The use of the timezone structure is obsolete; the tz argument
             // should normally be specified as NULL. Linux still accepts a non-NULL tz and fills it
             // in (typically with zeros for UTC systems) rather than returning an error.
             let utc_tz = litebox_common_linux::TimeZone::new(0, 0);
-            tz.write_at_offset(0, utc_tz).ok_or(Errno::EFAULT)?;
+            tz.write_at_offset::<Platform>(0, utc_tz)
+                .ok_or(Errno::EFAULT)?;
         }
         if let Some(tv) = tv {
-            tv.write_at_offset(0, self.real_time_as_duration_since_epoch().into())
+            tv.write_at_offset::<Platform>(0, self.real_time_as_duration_since_epoch().into())
                 .ok_or(Errno::EFAULT)?;
         }
         Ok(())
@@ -1117,13 +1114,14 @@ impl<FS: ShimFS> Task<FS> {
     /// Handle syscall `time`.
     pub(crate) fn sys_time(
         &self,
-        tloc: Option<crate::MutPtr<litebox_common_linux::time_t>>,
+        tloc: Option<crate::UserPtrMut<litebox_common_linux::time_t>>,
     ) -> Result<litebox_common_linux::time_t, Errno> {
         let time = self.real_time_as_duration_since_epoch();
         let seconds: u64 = time.as_secs();
         let seconds: litebox_common_linux::time_t = seconds.try_into().or(Err(Errno::EOVERFLOW))?;
         if let Some(tloc) = tloc {
-            tloc.write_at_offset(0, seconds).ok_or(Errno::EFAULT)?;
+            tloc.write_at_offset::<Platform>(0, seconds)
+                .ok_or(Errno::EFAULT)?;
         }
         Ok(seconds)
     }
@@ -1181,11 +1179,11 @@ impl<FS: ShimFS> Task<FS> {
     pub(crate) fn sys_setitimer(
         &self,
         which: IntervalTimer,
-        new_value: Option<ConstPtr<ItimerVal>>,
-        old_value: Option<MutPtr<ItimerVal>>,
+        new_value: Option<UserPtr<ItimerVal>>,
+        old_value: Option<UserPtrMut<ItimerVal>>,
     ) -> Result<(), Errno> {
         let new = match new_value {
-            Some(ptr) => ptr.read_at_offset(0).ok_or(Errno::EFAULT)?,
+            Some(ptr) => ptr.read_at_offset::<Platform>(0).ok_or(Errno::EFAULT)?,
             // Linux supports NULL `new_value` but says it would be removed in the future.
             None => ItimerVal::default(),
         };
@@ -1212,7 +1210,8 @@ impl<FS: ShimFS> Task<FS> {
         };
 
         if let Some(out) = old_value {
-            out.write_at_offset(0, prev).ok_or(Errno::EFAULT)?;
+            out.write_at_offset::<Platform>(0, prev)
+                .ok_or(Errno::EFAULT)?;
         }
         Ok(())
     }
@@ -1221,7 +1220,7 @@ impl<FS: ShimFS> Task<FS> {
     pub(crate) fn sys_getitimer(
         &self,
         which: IntervalTimer,
-        curr_value: MutPtr<ItimerVal>,
+        curr_value: UserPtrMut<ItimerVal>,
     ) -> Result<(), Errno> {
         let value = match which {
             IntervalTimer::Real => {
@@ -1235,7 +1234,7 @@ impl<FS: ShimFS> Task<FS> {
             }
         };
         curr_value
-            .write_at_offset(0, ItimerVal::single_shot(value))
+            .write_at_offset::<Platform>(0, ItimerVal::single_shot(value))
             .ok_or(Errno::EFAULT)
     }
 
@@ -1304,12 +1303,20 @@ impl<FS: ShimFS> Task<FS> {
     }
 }
 
+/// Bridge a local futex address pointer into the platform's mutable pointer type,
+/// which is what the platform-generic [`FutexManager`](litebox::sync::futex::FutexManager)
+/// expects.
+fn platform_futex_ptr(
+    addr: crate::UserPtrMut<u32>,
+) -> <litebox_platform_multiplex::Platform as litebox::platform::RawPointerProvider>::RawMutPointer<
+    u32,
+> {
+    litebox::platform::RawConstPointer::from_usize(addr.as_usize())
+}
+
 impl<FS: ShimFS> Task<FS> {
     /// Handle syscall `futex`
-    pub(crate) fn sys_futex(
-        &self,
-        arg: litebox_common_linux::FutexArgs<litebox_platform_multiplex::Platform>,
-    ) -> Result<usize, Errno> {
+    pub(crate) fn sys_futex(&self, arg: litebox_common_linux::FutexArgs) -> Result<usize, Errno> {
         /// Note our mutex implementation assumes futexes are private as we don't support shared memory yet.
         /// It should be fine to treat shared futexes as private for now.
         macro_rules! warn_shared_futex {
@@ -1326,7 +1333,9 @@ impl<FS: ShimFS> Task<FS> {
                 let Some(count) = core::num::NonZeroU32::new(count) else {
                     return Ok(0);
                 };
-                self.global.futex_manager.wake(addr, count, None)? as usize
+                self.global
+                    .futex_manager
+                    .wake(platform_futex_ptr(addr), count, None)? as usize
             }
             FutexArgs::Wait {
                 addr,
@@ -1335,10 +1344,10 @@ impl<FS: ShimFS> Task<FS> {
                 timeout,
             } => {
                 warn_shared_futex!(flags);
-                let timeout = timeout.read()?;
+                let timeout = timeout.read::<Platform>()?;
                 self.global.futex_manager.wait(
                     &self.wait_cx().with_timeout(timeout),
-                    addr,
+                    platform_futex_ptr(addr),
                     val,
                     None,
                 )?;
@@ -1352,7 +1361,7 @@ impl<FS: ShimFS> Task<FS> {
                 bitmask,
             } => {
                 warn_shared_futex!(flags);
-                let deadline = if let Some(timeout) = timeout.read()? {
+                let deadline = if let Some(timeout) = timeout.read::<Platform>()? {
                     let clock_id =
                         if flags.contains(litebox_common_linux::FutexFlags::CLOCK_REALTIME) {
                             litebox_common_linux::ClockId::RealTime
@@ -1365,7 +1374,7 @@ impl<FS: ShimFS> Task<FS> {
                 };
                 self.global.futex_manager.wait(
                     &self.wait_cx().with_deadline(deadline),
-                    addr,
+                    platform_futex_ptr(addr),
                     val,
                     core::num::NonZeroU32::new(bitmask),
                 )?;
@@ -1464,21 +1473,21 @@ impl<FS: ShimFS> Task<FS> {
     /// Handle syscall `execve`.
     pub(crate) fn sys_execve(
         &self,
-        pathname: crate::ConstPtr<i8>,
-        argv: crate::ConstPtr<crate::ConstPtr<i8>>,
-        envp: crate::ConstPtr<crate::ConstPtr<i8>>,
+        pathname: crate::UserPtr<i8>,
+        argv: crate::UserPtr<crate::UserPtr<i8>>,
+        envp: crate::UserPtr<crate::UserPtr<i8>>,
         ctx: &mut litebox_common_linux::PtRegs,
     ) -> Result<usize, Errno> {
         fn copy_vector(
-            mut base: crate::ConstPtr<crate::ConstPtr<i8>>,
+            mut base: crate::UserPtr<crate::UserPtr<i8>>,
             _which: &str,
         ) -> Result<alloc::vec::Vec<alloc::ffi::CString>, Errno> {
             let mut out = alloc::vec::Vec::new();
             let mut total = 0usize;
             for _ in 0..MAX_VEC {
-                let p: crate::ConstPtr<i8> = {
+                let p: crate::UserPtr<i8> = {
                     // read pointer-sized entries
-                    match base.read_at_offset(0) {
+                    match base.read_at_offset::<Platform>(0) {
                         Some(ptr) => ptr,
                         None => return Err(Errno::EFAULT),
                     }
@@ -1486,7 +1495,7 @@ impl<FS: ShimFS> Task<FS> {
                 if p.as_usize() == 0 {
                     break;
                 }
-                let Some(cs) = p.to_cstring() else {
+                let Some(cs) = p.to_cstring::<Platform>() else {
                     return Err(Errno::EFAULT);
                 };
                 total += cs.as_bytes().len() + 1;
@@ -1495,13 +1504,13 @@ impl<FS: ShimFS> Task<FS> {
                 }
                 out.push(cs);
                 // advance to next pointer
-                base = crate::ConstPtr::from_usize(base.as_usize() + core::mem::size_of::<usize>());
+                base = crate::UserPtr::from_usize(base.as_usize() + core::mem::size_of::<usize>());
             }
             Ok(out)
         }
 
         // Copy pathname
-        let Some(path_cstr) = pathname.to_cstring() else {
+        let Some(path_cstr) = pathname.to_cstring::<Platform>() else {
             return Err(Errno::EFAULT);
         };
         let path = path_cstr.to_str().map_err(|_| Errno::ENOENT)?;
@@ -1638,7 +1647,6 @@ impl<FS: ShimFS> Task<FS> {
                 if let Some(tls) = tls {
                     #[cfg(target_arch = "x86_64")]
                     {
-                        use litebox::platform::RawConstPointer as _;
                         self.sys_arch_prctl(ArchPrctlArg::SetFs(tls.as_usize()))
                             .unwrap();
                     }
@@ -1646,7 +1654,7 @@ impl<FS: ShimFS> Task<FS> {
 
                 if let Some(child_tid_ptr) = set_child_tid {
                     // Set the child TID if requested.
-                    let _ = child_tid_ptr.write_at_offset(0, self.tid);
+                    let _ = child_tid_ptr.write_at_offset::<Platform>(0, self.tid);
                 }
             }
         }
@@ -1660,33 +1668,32 @@ mod tests {
     #[cfg(target_arch = "x86_64")]
     #[test]
     fn test_arch_prctl() {
-        use crate::{MutPtr, syscalls::tests::init_platform};
-        use litebox::platform::RawConstPointer;
+        use crate::{UserPtrMut, syscalls::tests::init_platform};
         use litebox_common_linux::ArchPrctlArg;
 
         let task = init_platform(None);
 
         // Save old FS base
         let mut old_fs_base: usize = 0;
-        let ptr = MutPtr::from_ptr(&raw mut old_fs_base);
+        let ptr = UserPtrMut::from_ptr(&raw mut old_fs_base);
         task.sys_arch_prctl(ArchPrctlArg::GetFs(ptr))
             .expect("Failed to get FS base");
 
         // Set new FS base
         let mut new_fs_base: [u8; 16] = [0; 16];
-        let ptr = MutPtr::from_ptr(new_fs_base.as_mut_ptr());
+        let ptr = UserPtrMut::from_ptr(new_fs_base.as_mut_ptr());
         task.sys_arch_prctl(ArchPrctlArg::SetFs(ptr.as_usize()))
             .expect("Failed to set FS base");
 
         // Verify new FS base
         let mut current_fs_base: usize = 0;
-        let ptr = MutPtr::from_ptr(&raw mut current_fs_base);
+        let ptr = UserPtrMut::from_ptr(&raw mut current_fs_base);
         task.sys_arch_prctl(ArchPrctlArg::GetFs(ptr))
             .expect("Failed to get FS base");
         assert_eq!(current_fs_base, new_fs_base.as_ptr() as usize);
 
         // Restore old FS base
-        let ptr: crate::MutPtr<u8> = crate::MutPtr::from_usize(old_fs_base);
+        let ptr: crate::UserPtrMut<u8> = crate::UserPtrMut::from_usize(old_fs_base);
         task.sys_arch_prctl(ArchPrctlArg::SetFs(ptr.as_usize()))
             .expect("Failed to restore FS base");
     }
@@ -1714,13 +1721,13 @@ mod tests {
         let name: &[u8] = b"litebox-test\0";
 
         // Call prctl(PR_SET_NAME, set_buf)
-        let set_ptr = crate::ConstPtr::from_ptr(name.as_ptr());
+        let set_ptr = crate::UserPtr::from_ptr(name.as_ptr());
         task.sys_prctl(litebox_common_linux::PrctlArg::SetName(set_ptr))
             .expect("sys_prctl SetName failed");
 
         // Prepare buffer for prctl(PR_GET_NAME, get_buf)
         let mut get_buf = [0u8; litebox_common_linux::TASK_COMM_LEN];
-        let get_ptr = crate::MutPtr::from_ptr(get_buf.as_mut_ptr());
+        let get_ptr = crate::UserPtrMut::from_ptr(get_buf.as_mut_ptr());
 
         task.sys_prctl(litebox_common_linux::PrctlArg::GetName(get_ptr))
             .expect("sys_prctl GetName failed");
@@ -1732,13 +1739,13 @@ mod tests {
 
         // Test too long name
         let long_name = [b'a'; litebox_common_linux::TASK_COMM_LEN + 10];
-        let long_name_ptr = crate::ConstPtr::from_ptr(long_name.as_ptr());
+        let long_name_ptr = crate::UserPtr::from_ptr(long_name.as_ptr());
         task.sys_prctl(litebox_common_linux::PrctlArg::SetName(long_name_ptr))
             .expect("sys_prctl SetName failed");
 
         // Get the name again
         let mut get_buf = [0u8; litebox_common_linux::TASK_COMM_LEN];
-        let get_ptr = crate::MutPtr::from_ptr(get_buf.as_mut_ptr());
+        let get_ptr = crate::UserPtrMut::from_ptr(get_buf.as_mut_ptr());
         task.sys_prctl(litebox_common_linux::PrctlArg::GetName(get_ptr))
             .expect("sys_prctl GetName failed");
         assert_eq!(
@@ -1774,7 +1781,7 @@ mod tests {
                 restorer: 0,
                 mask: SigSet::empty(),
             };
-            let act_ptr = crate::ConstPtr::from_ptr(&raw const act);
+            let act_ptr = crate::UserPtr::from_ptr(&raw const act);
             task.sys_rt_sigaction(
                 Signal::SIGINT,
                 Some(act_ptr),
@@ -1801,7 +1808,7 @@ mod tests {
             let result = task.sys_clock_nanosleep(
                 ClockId::Monotonic,
                 TimerFlags::empty(),
-                litebox_common_linux::TimeParam::Timespec64(crate::MutPtr::from_ptr(
+                litebox_common_linux::TimeParam::Timespec64(crate::UserPtrMut::from_ptr(
                     &raw mut request,
                 )),
                 litebox_common_linux::TimeParam::None,
@@ -1854,8 +1861,8 @@ mod tests {
             let result = task.sys_clock_nanosleep(
                 ClockId::Monotonic,
                 TimerFlags::empty(),
-                litebox_common_linux::TimeParam::Timespec64(crate::MutPtr::from_ptr(&raw mut request)),
-                litebox_common_linux::TimeParam::Timespec64(crate::MutPtr::from_ptr(&raw mut remain)),
+                litebox_common_linux::TimeParam::Timespec64(crate::UserPtrMut::from_ptr(&raw mut request)),
+                litebox_common_linux::TimeParam::Timespec64(crate::UserPtrMut::from_ptr(&raw mut remain)),
             );
 
             let elapsed = platform.now().duration_since(&start);
@@ -1908,7 +1915,7 @@ mod tests {
             let result = task.sys_clock_nanosleep(
                 ClockId::Monotonic,
                 TimerFlags::empty(),
-                litebox_common_linux::TimeParam::Timespec64(crate::MutPtr::from_ptr(&raw mut request)),
+                litebox_common_linux::TimeParam::Timespec64(crate::UserPtrMut::from_ptr(&raw mut request)),
                 litebox_common_linux::TimeParam::None,
             );
             assert_eq!(result, Ok(()), "nanosleep should not have been interrupted");
@@ -1933,7 +1940,7 @@ mod tests {
             let block_set = SigSet::empty().with(Signal::SIGUSR1);
             task.sys_rt_sigprocmask(
                 SigmaskHow::SIG_BLOCK,
-                Some(crate::ConstPtr::from_ptr(&raw const block_set)),
+                Some(crate::UserPtr::from_ptr(&raw const block_set)),
                 None,
                 core::mem::size_of::<SigSet>(),
             )
@@ -1950,7 +1957,7 @@ mod tests {
 
             task.sys_rt_sigprocmask(
                 SigmaskHow::SIG_UNBLOCK,
-                Some(crate::ConstPtr::from_ptr(&raw const block_set)),
+                Some(crate::UserPtr::from_ptr(&raw const block_set)),
                 None,
                 core::mem::size_of::<SigSet>(),
             )
@@ -1986,7 +1993,7 @@ mod tests {
                 restorer: 0,
                 mask: SigSet::empty(),
             };
-            let act_ptr = crate::ConstPtr::from_ptr(&raw const act);
+            let act_ptr = crate::UserPtr::from_ptr(&raw const act);
             task.sys_rt_sigaction(
                 Signal::SIGALRM,
                 Some(act_ptr),
@@ -2004,7 +2011,7 @@ mod tests {
             let result = task.sys_clock_nanosleep(
                 ClockId::Monotonic,
                 TimerFlags::empty(),
-                litebox_common_linux::TimeParam::Timespec64(crate::MutPtr::from_ptr(&raw mut request)),
+                litebox_common_linux::TimeParam::Timespec64(crate::UserPtrMut::from_ptr(&raw mut request)),
                 litebox_common_linux::TimeParam::None,
             );
 
@@ -2049,7 +2056,7 @@ mod tests {
             let result = task.sys_clock_nanosleep(
                 ClockId::Monotonic,
                 TimerFlags::empty(),
-                litebox_common_linux::TimeParam::Timespec64(crate::MutPtr::from_ptr(
+                litebox_common_linux::TimeParam::Timespec64(crate::UserPtrMut::from_ptr(
                     &raw mut request,
                 )),
                 litebox_common_linux::TimeParam::None,

--- a/litebox_shim_linux/src/syscalls/process.rs
+++ b/litebox_shim_linux/src/syscalls/process.rs
@@ -430,11 +430,7 @@ const ROBUST_LIST_LIMIT: isize = 2048;
  * Process a futex-list entry, check whether it's owned by the
  * dying task, and do notification if so:
  */
-fn handle_futex_death(
-    futex_addr: crate::UserPtr<u32>,
-    _pi: bool,
-    _pending_op: bool,
-) -> Result<(), Errno> {
+fn handle_futex_death(futex_addr: UserPtr<u32>, _pi: bool, _pending_op: bool) -> Result<(), Errno> {
     if !futex_addr.as_usize().is_multiple_of(4) {
         return Err(Errno::EINVAL);
     }
@@ -443,29 +439,27 @@ fn handle_futex_death(
 }
 
 fn fetch_robust_entry(
-    head: crate::UserPtr<litebox_common_linux::RobustList>,
-) -> (crate::UserPtr<litebox_common_linux::RobustList>, bool) {
+    head: UserPtr<litebox_common_linux::RobustList>,
+) -> (UserPtr<litebox_common_linux::RobustList>, bool) {
     let next = head.as_usize();
-    (crate::UserPtr::from_usize(next & !1), next & 1 != 0)
+    (UserPtr::from_usize(next & !1), next & 1 != 0)
 }
 
-fn wake_robust_list(
-    head: crate::UserPtr<litebox_common_linux::RobustListHead>,
-) -> Result<(), Errno> {
+fn wake_robust_list(head: UserPtr<litebox_common_linux::RobustListHead>) -> Result<(), Errno> {
     let mut limit = ROBUST_LIST_LIMIT;
     let head_ptr = head.as_usize();
     let head = head.read_at_offset::<Platform>(0).ok_or(Errno::EFAULT)?;
-    let (mut entry, mut pi) = fetch_robust_entry(crate::UserPtr::from_usize(head.list.next));
-    let (pending, ppi) = fetch_robust_entry(crate::UserPtr::from_usize(head.list_op_pending));
+    let (mut entry, mut pi) = fetch_robust_entry(UserPtr::from_usize(head.list.next));
+    let (pending, ppi) = fetch_robust_entry(UserPtr::from_usize(head.list_op_pending));
     let futex_offset = head.futex_offset;
     let entry_head = head_ptr + offset_of!(litebox_common_linux::RobustListHead, list);
     while entry.as_usize() != entry_head && limit > 0 {
         let nxt = entry
             .read_at_offset::<Platform>(0)
-            .map(|e| fetch_robust_entry(crate::UserPtr::from_usize(e.next)));
+            .map(|e| fetch_robust_entry(UserPtr::from_usize(e.next)));
         if entry.as_usize() != pending.as_usize() {
             handle_futex_death(
-                crate::UserPtr::from_usize(entry.as_usize() + futex_offset),
+                UserPtr::from_usize(entry.as_usize() + futex_offset),
                 pi,
                 false,
             )?;
@@ -481,7 +475,7 @@ fn wake_robust_list(
 
     if pending.as_usize() != 0 {
         let _ = handle_futex_death(
-            crate::UserPtr::from_usize(pending.as_usize() + futex_offset),
+            UserPtr::from_usize(pending.as_usize() + futex_offset),
             ppi,
             true,
         );
@@ -499,7 +493,7 @@ impl<FS: ShimFS> Task<FS> {
             // TODO: if we are the last thread, we don't need to clear it
             let _ = clear_child_tid.write_at_offset::<Platform>(0, 0);
             // Cast from *i32 to *u32
-            let clear_child_tid = crate::UserPtrMut::from_usize(clear_child_tid.as_usize());
+            let clear_child_tid = UserPtrMut::from_usize(clear_child_tid.as_usize());
             let _ = self.sys_futex(litebox_common_linux::FutexArgs::Wake {
                 addr: clear_child_tid,
                 flags: litebox_common_linux::FutexFlags::PRIVATE,
@@ -744,7 +738,7 @@ impl<FS: ShimFS> Task<FS> {
     }
 
     /// Handle syscall `set_tid_address`.
-    pub(crate) fn sys_set_tid_address(&self, tidptr: crate::UserPtrMut<i32>) -> i32 {
+    pub(crate) fn sys_set_tid_address(&self, tidptr: UserPtrMut<i32>) -> i32 {
         self.thread.clear_child_tid.set(Some(tidptr));
         self.tid
     }
@@ -875,8 +869,8 @@ impl<FS: ShimFS> Task<FS> {
         &self,
         pid: i32,
         resource: litebox_common_linux::RlimitResource,
-        new_rlim: Option<crate::UserPtr<litebox_common_linux::Rlimit64>>,
-        old_rlim: Option<crate::UserPtrMut<litebox_common_linux::Rlimit64>>,
+        new_rlim: Option<UserPtr<litebox_common_linux::Rlimit64>>,
+        old_rlim: Option<UserPtrMut<litebox_common_linux::Rlimit64>>,
     ) -> Result<(), Errno> {
         if pid != 0 {
             unimplemented!("prlimit for a specific PID is not supported yet");
@@ -902,7 +896,7 @@ impl<FS: ShimFS> Task<FS> {
     pub(crate) fn sys_getrlimit(
         &self,
         resource: litebox_common_linux::RlimitResource,
-        rlim: crate::UserPtrMut<litebox_common_linux::Rlimit>,
+        rlim: UserPtrMut<litebox_common_linux::Rlimit>,
     ) -> Result<(), Errno> {
         let old_limit = self.do_prlimit(resource, None)?;
         rlim.write_at_offset::<Platform>(0, old_limit)
@@ -913,7 +907,7 @@ impl<FS: ShimFS> Task<FS> {
     pub(crate) fn sys_setrlimit(
         &self,
         resource: litebox_common_linux::RlimitResource,
-        rlim: crate::UserPtr<litebox_common_linux::Rlimit>,
+        rlim: UserPtr<litebox_common_linux::Rlimit>,
     ) -> Result<(), Errno> {
         let new_limit = rlim.read_at_offset::<Platform>(0).ok_or(Errno::EFAULT)?;
         let _ = self.do_prlimit(resource, Some(new_limit))?;
@@ -922,7 +916,7 @@ impl<FS: ShimFS> Task<FS> {
 
     /// Handle syscall `set_robust_list`.
     pub(crate) fn sys_set_robust_list(&self, head: usize) {
-        let head = crate::UserPtr::from_usize(head);
+        let head = UserPtr::from_usize(head);
         self.thread.robust_list.set(Some(head));
     }
 
@@ -930,7 +924,7 @@ impl<FS: ShimFS> Task<FS> {
     pub(crate) fn sys_get_robust_list(
         &self,
         pid: Option<i32>,
-        head_ptr: crate::UserPtrMut<usize>,
+        head_ptr: UserPtrMut<usize>,
     ) -> Result<(), Errno> {
         if pid.is_some() {
             unimplemented!("Getting robust list for a specific PID is not supported yet");
@@ -1093,8 +1087,8 @@ impl<FS: ShimFS> Task<FS> {
     /// Handle syscall `gettimeofday`.
     pub(crate) fn sys_gettimeofday(
         &self,
-        tv: Option<crate::UserPtrMut<litebox_common_linux::TimeVal>>,
-        tz: Option<crate::UserPtrMut<litebox_common_linux::TimeZone>>,
+        tv: Option<UserPtrMut<litebox_common_linux::TimeVal>>,
+        tz: Option<UserPtrMut<litebox_common_linux::TimeZone>>,
     ) -> Result<(), Errno> {
         if let Some(tz) = tz {
             // `man 2 gettimeofday`: The use of the timezone structure is obsolete; the tz argument
@@ -1114,7 +1108,7 @@ impl<FS: ShimFS> Task<FS> {
     /// Handle syscall `time`.
     pub(crate) fn sys_time(
         &self,
-        tloc: Option<crate::UserPtrMut<litebox_common_linux::time_t>>,
+        tloc: Option<UserPtrMut<litebox_common_linux::time_t>>,
     ) -> Result<litebox_common_linux::time_t, Errno> {
         let time = self.real_time_as_duration_since_epoch();
         let seconds: u64 = time.as_secs();
@@ -1464,19 +1458,19 @@ impl<FS: ShimFS> Task<FS> {
     /// Handle syscall `execve`.
     pub(crate) fn sys_execve(
         &self,
-        pathname: crate::UserPtr<i8>,
-        argv: crate::UserPtr<crate::UserPtr<i8>>,
-        envp: crate::UserPtr<crate::UserPtr<i8>>,
+        pathname: UserPtr<i8>,
+        argv: UserPtr<UserPtr<i8>>,
+        envp: UserPtr<UserPtr<i8>>,
         ctx: &mut litebox_common_linux::PtRegs,
     ) -> Result<usize, Errno> {
         fn copy_vector(
-            mut base: crate::UserPtr<crate::UserPtr<i8>>,
+            mut base: UserPtr<UserPtr<i8>>,
             _which: &str,
         ) -> Result<alloc::vec::Vec<alloc::ffi::CString>, Errno> {
             let mut out = alloc::vec::Vec::new();
             let mut total = 0usize;
             for _ in 0..MAX_VEC {
-                let p: crate::UserPtr<i8> = {
+                let p: UserPtr<i8> = {
                     // read pointer-sized entries
                     match base.read_at_offset::<Platform>(0) {
                         Some(ptr) => ptr,
@@ -1495,7 +1489,7 @@ impl<FS: ShimFS> Task<FS> {
                 }
                 out.push(cs);
                 // advance to next pointer
-                base = crate::UserPtr::from_usize(base.as_usize() + core::mem::size_of::<usize>());
+                base = UserPtr::from_usize(base.as_usize() + core::mem::size_of::<usize>());
             }
             Ok(out)
         }
@@ -1654,12 +1648,14 @@ impl<FS: ShimFS> Task<FS> {
 
 #[cfg(test)]
 mod tests {
+    use crate::{UserPtr, UserPtrMut};
+
     extern crate std;
 
     #[cfg(target_arch = "x86_64")]
     #[test]
     fn test_arch_prctl() {
-        use crate::{UserPtrMut, syscalls::tests::init_platform};
+        use crate::syscalls::tests::init_platform;
         use litebox_common_linux::ArchPrctlArg;
 
         let task = init_platform(None);
@@ -1684,7 +1680,7 @@ mod tests {
         assert_eq!(current_fs_base, new_fs_base.as_ptr() as usize);
 
         // Restore old FS base
-        let ptr: crate::UserPtrMut<u8> = crate::UserPtrMut::from_usize(old_fs_base);
+        let ptr: UserPtrMut<u8> = UserPtrMut::from_usize(old_fs_base);
         task.sys_arch_prctl(ArchPrctlArg::SetFs(ptr.as_usize()))
             .expect("Failed to restore FS base");
     }
@@ -1712,13 +1708,13 @@ mod tests {
         let name: &[u8] = b"litebox-test\0";
 
         // Call prctl(PR_SET_NAME, set_buf)
-        let set_ptr = crate::UserPtr::from_ptr(name.as_ptr());
+        let set_ptr = UserPtr::from_ptr(name.as_ptr());
         task.sys_prctl(litebox_common_linux::PrctlArg::SetName(set_ptr))
             .expect("sys_prctl SetName failed");
 
         // Prepare buffer for prctl(PR_GET_NAME, get_buf)
         let mut get_buf = [0u8; litebox_common_linux::TASK_COMM_LEN];
-        let get_ptr = crate::UserPtrMut::from_ptr(get_buf.as_mut_ptr());
+        let get_ptr = UserPtrMut::from_ptr(get_buf.as_mut_ptr());
 
         task.sys_prctl(litebox_common_linux::PrctlArg::GetName(get_ptr))
             .expect("sys_prctl GetName failed");
@@ -1730,13 +1726,13 @@ mod tests {
 
         // Test too long name
         let long_name = [b'a'; litebox_common_linux::TASK_COMM_LEN + 10];
-        let long_name_ptr = crate::UserPtr::from_ptr(long_name.as_ptr());
+        let long_name_ptr = UserPtr::from_ptr(long_name.as_ptr());
         task.sys_prctl(litebox_common_linux::PrctlArg::SetName(long_name_ptr))
             .expect("sys_prctl SetName failed");
 
         // Get the name again
         let mut get_buf = [0u8; litebox_common_linux::TASK_COMM_LEN];
-        let get_ptr = crate::UserPtrMut::from_ptr(get_buf.as_mut_ptr());
+        let get_ptr = UserPtrMut::from_ptr(get_buf.as_mut_ptr());
         task.sys_prctl(litebox_common_linux::PrctlArg::GetName(get_ptr))
             .expect("sys_prctl GetName failed");
         assert_eq!(
@@ -1772,7 +1768,7 @@ mod tests {
                 restorer: 0,
                 mask: SigSet::empty(),
             };
-            let act_ptr = crate::UserPtr::from_ptr(&raw const act);
+            let act_ptr = UserPtr::from_ptr(&raw const act);
             task.sys_rt_sigaction(
                 Signal::SIGINT,
                 Some(act_ptr),
@@ -1799,7 +1795,7 @@ mod tests {
             let result = task.sys_clock_nanosleep(
                 ClockId::Monotonic,
                 TimerFlags::empty(),
-                litebox_common_linux::TimeParam::Timespec64(crate::UserPtrMut::from_ptr(
+                litebox_common_linux::TimeParam::Timespec64(UserPtrMut::from_ptr(
                     &raw mut request,
                 )),
                 litebox_common_linux::TimeParam::None,
@@ -1852,8 +1848,8 @@ mod tests {
             let result = task.sys_clock_nanosleep(
                 ClockId::Monotonic,
                 TimerFlags::empty(),
-                litebox_common_linux::TimeParam::Timespec64(crate::UserPtrMut::from_ptr(&raw mut request)),
-                litebox_common_linux::TimeParam::Timespec64(crate::UserPtrMut::from_ptr(&raw mut remain)),
+                litebox_common_linux::TimeParam::Timespec64(UserPtrMut::from_ptr(&raw mut request)),
+                litebox_common_linux::TimeParam::Timespec64(UserPtrMut::from_ptr(&raw mut remain)),
             );
 
             let elapsed = platform.now().duration_since(&start);
@@ -1906,7 +1902,7 @@ mod tests {
             let result = task.sys_clock_nanosleep(
                 ClockId::Monotonic,
                 TimerFlags::empty(),
-                litebox_common_linux::TimeParam::Timespec64(crate::UserPtrMut::from_ptr(&raw mut request)),
+                litebox_common_linux::TimeParam::Timespec64(UserPtrMut::from_ptr(&raw mut request)),
                 litebox_common_linux::TimeParam::None,
             );
             assert_eq!(result, Ok(()), "nanosleep should not have been interrupted");
@@ -1931,7 +1927,7 @@ mod tests {
             let block_set = SigSet::empty().with(Signal::SIGUSR1);
             task.sys_rt_sigprocmask(
                 SigmaskHow::SIG_BLOCK,
-                Some(crate::UserPtr::from_ptr(&raw const block_set)),
+                Some(UserPtr::from_ptr(&raw const block_set)),
                 None,
                 core::mem::size_of::<SigSet>(),
             )
@@ -1948,7 +1944,7 @@ mod tests {
 
             task.sys_rt_sigprocmask(
                 SigmaskHow::SIG_UNBLOCK,
-                Some(crate::UserPtr::from_ptr(&raw const block_set)),
+                Some(UserPtr::from_ptr(&raw const block_set)),
                 None,
                 core::mem::size_of::<SigSet>(),
             )
@@ -1984,7 +1980,7 @@ mod tests {
                 restorer: 0,
                 mask: SigSet::empty(),
             };
-            let act_ptr = crate::UserPtr::from_ptr(&raw const act);
+            let act_ptr = UserPtr::from_ptr(&raw const act);
             task.sys_rt_sigaction(
                 Signal::SIGALRM,
                 Some(act_ptr),
@@ -2002,7 +1998,7 @@ mod tests {
             let result = task.sys_clock_nanosleep(
                 ClockId::Monotonic,
                 TimerFlags::empty(),
-                litebox_common_linux::TimeParam::Timespec64(crate::UserPtrMut::from_ptr(&raw mut request)),
+                litebox_common_linux::TimeParam::Timespec64(UserPtrMut::from_ptr(&raw mut request)),
                 litebox_common_linux::TimeParam::None,
             );
 
@@ -2047,7 +2043,7 @@ mod tests {
             let result = task.sys_clock_nanosleep(
                 ClockId::Monotonic,
                 TimerFlags::empty(),
-                litebox_common_linux::TimeParam::Timespec64(crate::UserPtrMut::from_ptr(
+                litebox_common_linux::TimeParam::Timespec64(UserPtrMut::from_ptr(
                     &raw mut request,
                 )),
                 litebox_common_linux::TimeParam::None,

--- a/litebox_shim_linux/src/syscalls/process.rs
+++ b/litebox_shim_linux/src/syscalls/process.rs
@@ -1303,17 +1303,6 @@ impl<FS: ShimFS> Task<FS> {
     }
 }
 
-/// Bridge a local futex address pointer into the platform's mutable pointer type,
-/// which is what the platform-generic [`FutexManager`](litebox::sync::futex::FutexManager)
-/// expects.
-fn platform_futex_ptr(
-    addr: crate::UserPtrMut<u32>,
-) -> <litebox_platform_multiplex::Platform as litebox::platform::RawPointerProvider>::RawMutPointer<
-    u32,
-> {
-    litebox::platform::RawConstPointer::from_usize(addr.as_usize())
-}
-
 impl<FS: ShimFS> Task<FS> {
     /// Handle syscall `futex`
     pub(crate) fn sys_futex(&self, arg: litebox_common_linux::FutexArgs) -> Result<usize, Errno> {
@@ -1333,9 +1322,11 @@ impl<FS: ShimFS> Task<FS> {
                 let Some(count) = core::num::NonZeroU32::new(count) else {
                     return Ok(0);
                 };
-                self.global
-                    .futex_manager
-                    .wake(platform_futex_ptr(addr), count, None)? as usize
+                self.global.futex_manager.wake(
+                    litebox::platform::RawConstPointer::from_usize(addr.as_usize()),
+                    count,
+                    None,
+                )? as usize
             }
             FutexArgs::Wait {
                 addr,
@@ -1347,7 +1338,7 @@ impl<FS: ShimFS> Task<FS> {
                 let timeout = timeout.read::<Platform>()?;
                 self.global.futex_manager.wait(
                     &self.wait_cx().with_timeout(timeout),
-                    platform_futex_ptr(addr),
+                    litebox::platform::RawConstPointer::from_usize(addr.as_usize()),
                     val,
                     None,
                 )?;
@@ -1374,7 +1365,7 @@ impl<FS: ShimFS> Task<FS> {
                 };
                 self.global.futex_manager.wait(
                     &self.wait_cx().with_deadline(deadline),
-                    platform_futex_ptr(addr),
+                    litebox::platform::RawConstPointer::from_usize(addr.as_usize()),
                     val,
                     core::num::NonZeroU32::new(bitmask),
                 )?;

--- a/litebox_shim_linux/src/syscalls/process.rs
+++ b/litebox_shim_linux/src/syscalls/process.rs
@@ -1316,11 +1316,9 @@ impl<FS: ShimFS> Task<FS> {
                 let Some(count) = core::num::NonZeroU32::new(count) else {
                     return Ok(0);
                 };
-                self.global.futex_manager.wake(
-                    litebox::platform::RawConstPointer::from_usize(addr.as_usize()),
-                    count,
-                    None,
-                )? as usize
+                self.global
+                    .futex_manager
+                    .wake(addr.to_platform_ptr::<Platform>(), count, None)? as usize
             }
             FutexArgs::Wait {
                 addr,
@@ -1332,7 +1330,7 @@ impl<FS: ShimFS> Task<FS> {
                 let timeout = timeout.read::<Platform>()?;
                 self.global.futex_manager.wait(
                     &self.wait_cx().with_timeout(timeout),
-                    litebox::platform::RawConstPointer::from_usize(addr.as_usize()),
+                    addr.to_platform_ptr::<Platform>(),
                     val,
                     None,
                 )?;
@@ -1359,7 +1357,7 @@ impl<FS: ShimFS> Task<FS> {
                 };
                 self.global.futex_manager.wait(
                     &self.wait_cx().with_deadline(deadline),
-                    litebox::platform::RawConstPointer::from_usize(addr.as_usize()),
+                    addr.to_platform_ptr::<Platform>(),
                     val,
                     core::num::NonZeroU32::new(bitmask),
                 )?;

--- a/litebox_shim_linux/src/syscalls/signal/mod.rs
+++ b/litebox_shim_linux/src/syscalls/signal/mod.rs
@@ -12,16 +12,11 @@ use x86_64 as arch;
 use zerocopy::FromZeros;
 
 use crate::syscalls::process::ExitStatus;
-use crate::{ConstPtr, MutPtr, ShimFS, Task};
+use crate::{ShimFS, Task, UserPtr, UserPtrMut};
 use alloc::collections::vec_deque::VecDeque;
 use alloc::sync::Arc;
 use core::cell::{Cell, RefCell};
-use litebox::{
-    platform::{RawConstPointer as _, RawMutPointer as _},
-    shim::Exception,
-    sync::Mutex,
-    utils::ReinterpretUnsignedExt as _,
-};
+use litebox::{shim::Exception, sync::Mutex, utils::ReinterpretUnsignedExt as _};
 use litebox_common_linux::signal::{
     MINSIGSTKSZ, NSIG, SI_KERNEL, SI_USER, SIG_DFL, SIG_IGN, SaFlags, SigAction, SigAltStack,
     SigSet, Siginfo, SiginfoData, SigmaskHow, Signal, SsFlags, Ucontext,
@@ -392,22 +387,24 @@ impl<FS: ShimFS> Task<FS> {
     pub(crate) fn sys_rt_sigprocmask(
         &self,
         how: SigmaskHow,
-        set_ptr: Option<crate::ConstPtr<SigSet>>,
-        oldset_ptr: Option<crate::MutPtr<SigSet>>,
+        set_ptr: Option<crate::UserPtr<SigSet>>,
+        oldset_ptr: Option<crate::UserPtrMut<SigSet>>,
         sigsetsize: usize,
     ) -> Result<usize, Errno> {
         if sigsetsize != core::mem::size_of::<SigSet>() {
             return Err(Errno::EINVAL);
         }
         let set = if let Some(set_ptr) = set_ptr {
-            Some(set_ptr.read_at_offset(0).ok_or(Errno::EFAULT)?)
+            Some(set_ptr.read_at_offset::<Platform>(0).ok_or(Errno::EFAULT)?)
         } else {
             None
         };
 
         if let Some(oldset_ptr) = oldset_ptr {
             let oldset = self.signals.blocked.get();
-            oldset_ptr.write_at_offset(0, oldset).ok_or(Errno::EFAULT)?;
+            oldset_ptr
+                .write_at_offset::<Platform>(0, oldset)
+                .ok_or(Errno::EFAULT)?;
         }
 
         if let Some(set) = set {
@@ -431,8 +428,8 @@ impl<FS: ShimFS> Task<FS> {
 
     pub(crate) fn sys_sigaltstack(
         &self,
-        ss_ptr: Option<ConstPtr<SigAltStack>>,
-        old_ss_ptr: Option<MutPtr<SigAltStack>>,
+        ss_ptr: Option<UserPtr<SigAltStack>>,
+        old_ss_ptr: Option<UserPtrMut<SigAltStack>>,
         ctx: &PtRegs,
     ) -> Result<usize, Errno> {
         let mut old_ss = self.signals.altstack.get();
@@ -441,13 +438,15 @@ impl<FS: ShimFS> Task<FS> {
             if is_on_stack {
                 old_ss.flags |= SsFlags::ONSTACK;
             }
-            old_ss_ptr.write_at_offset(0, old_ss).ok_or(Errno::EFAULT)?;
+            old_ss_ptr
+                .write_at_offset::<Platform>(0, old_ss)
+                .ok_or(Errno::EFAULT)?;
         }
         if let Some(ss_ptr) = ss_ptr {
             if is_on_stack {
                 return Err(Errno::EPERM);
             }
-            let ss = ss_ptr.read_at_offset(0).ok_or(Errno::EFAULT)?;
+            let ss = ss_ptr.read_at_offset::<Platform>(0).ok_or(Errno::EFAULT)?;
             self.signals.set_sigaltstack(ss)?;
         }
         Ok(0)
@@ -455,8 +454,8 @@ impl<FS: ShimFS> Task<FS> {
 
     pub(crate) fn sys_rt_sigreturn(&self, ctx: &mut PtRegs) -> Result<usize, Errno> {
         let uctx_addr = arch::uctx_addr(ctx);
-        let uctx_ptr = ConstPtr::<Ucontext>::from_usize(uctx_addr);
-        let Some(uctx) = uctx_ptr.read_at_offset(0) else {
+        let uctx_ptr = UserPtr::<Ucontext>::from_usize(uctx_addr);
+        let Some(uctx) = uctx_ptr.read_at_offset::<Platform>(0) else {
             self.force_signal(Signal::SIGSEGV, false);
             return Err(Errno::EFAULT);
         };
@@ -472,8 +471,8 @@ impl<FS: ShimFS> Task<FS> {
     pub(crate) fn sys_rt_sigaction(
         &self,
         signal: Signal,
-        act_ptr: Option<ConstPtr<SigAction>>,
-        oldact_ptr: Option<MutPtr<SigAction>>,
+        act_ptr: Option<UserPtr<SigAction>>,
+        oldact_ptr: Option<UserPtrMut<SigAction>>,
         sigsetsize: usize,
     ) -> Result<usize, Errno> {
         if signal == Signal::SIGKILL || signal == Signal::SIGSTOP {
@@ -483,7 +482,7 @@ impl<FS: ShimFS> Task<FS> {
             return Err(Errno::EINVAL);
         }
         let act = if let Some(act_ptr) = act_ptr {
-            Some(act_ptr.read_at_offset(0).ok_or(Errno::EFAULT)?)
+            Some(act_ptr.read_at_offset::<Platform>(0).ok_or(Errno::EFAULT)?)
         } else {
             None
         };
@@ -504,7 +503,7 @@ impl<FS: ShimFS> Task<FS> {
 
         if let Some(oldact_ptr) = oldact_ptr {
             oldact_ptr
-                .write_at_offset(0, old_act)
+                .write_at_offset::<Platform>(0, old_act)
                 .ok_or(Errno::EFAULT)?;
         }
 

--- a/litebox_shim_linux/src/syscalls/signal/mod.rs
+++ b/litebox_shim_linux/src/syscalls/signal/mod.rs
@@ -387,8 +387,8 @@ impl<FS: ShimFS> Task<FS> {
     pub(crate) fn sys_rt_sigprocmask(
         &self,
         how: SigmaskHow,
-        set_ptr: Option<crate::UserPtr<SigSet>>,
-        oldset_ptr: Option<crate::UserPtrMut<SigSet>>,
+        set_ptr: Option<UserPtr<SigSet>>,
+        oldset_ptr: Option<UserPtrMut<SigSet>>,
         sigsetsize: usize,
     ) -> Result<usize, Errno> {
         if sigsetsize != core::mem::size_of::<SigSet>() {

--- a/litebox_shim_linux/src/syscalls/signal/x86_64.rs
+++ b/litebox_shim_linux/src/syscalls/signal/x86_64.rs
@@ -1,15 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-use crate::MutPtr;
+use crate::UserPtrMut;
 use crate::syscalls::signal::{DeliverFault, SignalState};
 use core::mem::offset_of;
-use litebox::platform::{RawConstPointer as _, RawMutPointer as _};
 use litebox::utils::{ReinterpretUnsignedExt as _, TruncateExt as _};
 use litebox_common_linux::{
     PtRegs,
     signal::{SaFlags, SigAction, Siginfo, Ucontext, x86_64::Sigcontext},
 };
+use litebox_platform_multiplex::Platform;
 use zerocopy::{FromBytes, IntoBytes};
 
 #[repr(C)]
@@ -98,8 +98,10 @@ impl SignalState {
             siginfo: siginfo.clone(),
         };
 
-        let frame_ptr = MutPtr::from_usize(frame_addr);
-        frame_ptr.write_at_offset(0, frame).ok_or(DeliverFault)?;
+        let frame_ptr = UserPtrMut::from_usize(frame_addr);
+        frame_ptr
+            .write_at_offset::<Platform>(0, frame)
+            .ok_or(DeliverFault)?;
 
         ctx.rsp = frame_addr;
         ctx.rip = action.sigaction;

--- a/litebox_shim_linux/src/syscalls/tests.rs
+++ b/litebox_shim_linux/src/syscalls/tests.rs
@@ -2,12 +2,11 @@
 // Licensed under the MIT license.
 
 use litebox::fs::{FileSystem as _, Mode, OFlags};
-use litebox::platform::RawConstPointer as _;
 use litebox_common_linux::{AtFlags, EfdFlags, FcntlArg, FileDescriptorFlags, errno::Errno};
 use litebox_platform_multiplex::{Platform, set_platform};
 use zerocopy::FromBytes as _;
 
-use crate::MutPtr;
+use crate::UserPtrMut;
 
 extern crate std;
 
@@ -184,7 +183,7 @@ fn test_getdent64() {
     let bytes_read = task
         .sys_getdirent64(
             dir_fd,
-            MutPtr::from_usize(buffer.as_mut_ptr() as usize),
+            UserPtrMut::from_usize(buffer.as_mut_ptr() as usize),
             buffer.len(),
         )
         .expect("Failed to read directory entries");
@@ -266,7 +265,7 @@ fn test_getdent64() {
     assert_eq!(
         task.sys_getdirent64(
             dir_fd,
-            MutPtr::from_usize(buffer.as_mut_ptr() as usize),
+            UserPtrMut::from_usize(buffer.as_mut_ptr() as usize),
             buffer.len()
         )
         .expect("Failed to read directory entries"),
@@ -284,7 +283,7 @@ fn test_getdent64() {
     let bytes = task
         .sys_getdirent64(
             dir_fd,
-            MutPtr::from_usize(small_buffer.as_mut_ptr() as usize),
+            UserPtrMut::from_usize(small_buffer.as_mut_ptr() as usize),
             small_buffer.len(),
         )
         .expect("Failed to read directory entries");
@@ -305,7 +304,7 @@ fn test_getdent64() {
     // Test 3: Invalid file descriptor
     let result = task.sys_getdirent64(
         -1,
-        MutPtr::from_usize(buffer.as_mut_ptr() as usize),
+        UserPtrMut::from_usize(buffer.as_mut_ptr() as usize),
         buffer.len(),
     );
     assert_eq!(
@@ -322,7 +321,7 @@ fn test_getdent64() {
 
     let result = task.sys_getdirent64(
         file1_fd,
-        MutPtr::from_usize(buffer.as_mut_ptr() as usize),
+        UserPtrMut::from_usize(buffer.as_mut_ptr() as usize),
         buffer.len(),
     );
     assert_eq!(
@@ -333,7 +332,11 @@ fn test_getdent64() {
     task.sys_close(file1_fd).expect("Failed to close file");
 
     // Test 5: Zero-length buffer
-    let result = task.sys_getdirent64(dir_fd, MutPtr::from_usize(buffer.as_mut_ptr() as usize), 0);
+    let result = task.sys_getdirent64(
+        dir_fd,
+        UserPtrMut::from_usize(buffer.as_mut_ptr() as usize),
+        0,
+    );
     assert_eq!(
         result,
         Err(Errno::EINVAL),
@@ -357,7 +360,7 @@ fn test_getdent64() {
         let bytes_read = task
             .sys_getdirent64(
                 dir_fd2,
-                MutPtr::from_usize(chunk_buffer.as_mut_ptr() as usize),
+                UserPtrMut::from_usize(chunk_buffer.as_mut_ptr() as usize),
                 chunk_buffer.len(),
             )
             .expect("Failed to read directory chunk");

--- a/litebox_shim_linux/src/syscalls/unix.rs
+++ b/litebox_shim_linux/src/syscalls/unix.rs
@@ -31,7 +31,7 @@ use litebox_common_linux::{
 };
 
 use crate::{
-    ConstPtr, FileFd, GlobalState, MutPtr, ShimFS, Task,
+    FileFd, GlobalState, ShimFS, Task, UserPtr, UserPtrMut,
     channel::{Channel, ReadEnd, WriteEnd},
     syscalls::net::{SocketOptionValue, SocketOptions},
 };
@@ -1464,7 +1464,7 @@ impl<FS: ShimFS> UnixSocket<FS> {
         &self,
         global: &GlobalState<FS>,
         optname: SocketOptionName,
-        optval: ConstPtr<u8>,
+        optval: UserPtr<u8>,
         optlen: usize,
     ) -> Result<(), Errno> {
         match global.setsockopt_common(optname, optval, optlen, |so, value| {
@@ -1523,7 +1523,7 @@ impl<FS: ShimFS> UnixSocket<FS> {
         &self,
         global: &GlobalState<FS>,
         optname: SocketOptionName,
-        optval: MutPtr<u8>,
+        optval: UserPtrMut<u8>,
         len: u32,
     ) -> Result<usize, Errno> {
         match global.getsockopt_common(optname, optval, len, |sopt| match sopt {

--- a/litebox_shim_optee/src/syscalls/mm.rs
+++ b/litebox_shim_optee/src/syscalls/mm.rs
@@ -5,18 +5,18 @@
 
 use litebox::mm::linux::{MappingError, PAGE_SIZE};
 use litebox::platform::RawConstPointer;
-use litebox_common_linux::{MapFlags, ProtFlags, errno::Errno};
+use litebox_common_linux::{MapFlags, ProtFlags, errno::Errno, user_pointers::UserPtrMut};
 
 use crate::{Task, UserMutPtr};
 
 /// Bridge a platform mutable pointer to the address-only `UserPtrMut` used by
 /// the shared `litebox_common_linux::mm` helpers.
-fn to_local(ptr: UserMutPtr<u8>) -> litebox_common_linux::user_pointers::UserPtrMut<u8> {
-    litebox_common_linux::user_pointers::UserPtrMut::from_usize(ptr.as_usize())
+fn to_local(ptr: UserMutPtr<u8>) -> UserPtrMut<u8> {
+    UserPtrMut::from_usize(ptr.as_usize())
 }
 
 /// Bridge an address-only `UserPtrMut` back to a platform mutable pointer.
-fn from_local(ptr: litebox_common_linux::user_pointers::UserPtrMut<u8>) -> UserMutPtr<u8> {
+fn from_local(ptr: UserPtrMut<u8>) -> UserMutPtr<u8> {
     <UserMutPtr<u8> as RawConstPointer<u8>>::from_usize(ptr.as_usize())
 }
 

--- a/litebox_shim_optee/src/syscalls/mm.rs
+++ b/litebox_shim_optee/src/syscalls/mm.rs
@@ -4,7 +4,6 @@
 //! Implementation of memory management related syscalls, eg., `mmap`, `munmap`, etc.
 
 use litebox::mm::linux::{MappingError, PAGE_SIZE};
-use litebox::platform::RawConstPointer;
 use litebox_common_linux::{MapFlags, ProtFlags, errno::Errno, user_pointers::UserPtrMut};
 
 use crate::{Platform, Task, UserMutPtr};
@@ -94,7 +93,11 @@ impl Task {
     /// Handle syscall `munmap`
     pub(crate) fn sys_munmap(&self, addr: UserMutPtr<u8>, len: usize) -> Result<(), Errno> {
         let pm = &self.global.pm;
-        litebox_common_linux::mm::sys_munmap(pm, UserPtrMut::from_usize(addr.as_usize()), len)
+        litebox_common_linux::mm::sys_munmap(
+            pm,
+            UserPtrMut::from_platform_ptr::<Platform>(addr),
+            len,
+        )
     }
 
     /// Handle syscall `mprotect`
@@ -108,7 +111,7 @@ impl Task {
         let pm = &self.global.pm;
         litebox_common_linux::mm::sys_mprotect(
             pm,
-            UserPtrMut::from_usize(addr.as_usize()),
+            UserPtrMut::from_platform_ptr::<Platform>(addr),
             len,
             prot,
         )

--- a/litebox_shim_optee/src/syscalls/mm.rs
+++ b/litebox_shim_optee/src/syscalls/mm.rs
@@ -9,17 +9,6 @@ use litebox_common_linux::{MapFlags, ProtFlags, errno::Errno, user_pointers::Use
 
 use crate::{Task, UserMutPtr};
 
-/// Bridge a platform mutable pointer to the address-only `UserPtrMut` used by
-/// the shared `litebox_common_linux::mm` helpers.
-fn to_local(ptr: UserMutPtr<u8>) -> UserPtrMut<u8> {
-    UserPtrMut::from_usize(ptr.as_usize())
-}
-
-/// Bridge an address-only `UserPtrMut` back to a platform mutable pointer.
-fn from_local(ptr: UserPtrMut<u8>) -> UserMutPtr<u8> {
-    <UserMutPtr<u8> as RawConstPointer<u8>>::from_usize(ptr.as_usize())
-}
-
 #[inline]
 fn align_up(addr: usize, align: usize) -> Option<usize> {
     debug_assert!(align.is_power_of_two());
@@ -45,7 +34,7 @@ impl Task {
             false,
             op,
         )
-        .map(from_local)
+        .map(|ptr| <UserMutPtr<u8> as RawConstPointer<u8>>::from_usize(ptr.as_usize()))
     }
 
     /// Handle syscall `mmap`
@@ -105,7 +94,7 @@ impl Task {
     /// Handle syscall `munmap`
     pub(crate) fn sys_munmap(&self, addr: UserMutPtr<u8>, len: usize) -> Result<(), Errno> {
         let pm = &self.global.pm;
-        litebox_common_linux::mm::sys_munmap(pm, to_local(addr), len)
+        litebox_common_linux::mm::sys_munmap(pm, UserPtrMut::from_usize(addr.as_usize()), len)
     }
 
     /// Handle syscall `mprotect`
@@ -117,6 +106,11 @@ impl Task {
         prot: ProtFlags,
     ) -> Result<(), Errno> {
         let pm = &self.global.pm;
-        litebox_common_linux::mm::sys_mprotect(pm, to_local(addr), len, prot)
+        litebox_common_linux::mm::sys_mprotect(
+            pm,
+            UserPtrMut::from_usize(addr.as_usize()),
+            len,
+            prot,
+        )
     }
 }

--- a/litebox_shim_optee/src/syscalls/mm.rs
+++ b/litebox_shim_optee/src/syscalls/mm.rs
@@ -7,7 +7,7 @@ use litebox::mm::linux::{MappingError, PAGE_SIZE};
 use litebox::platform::RawConstPointer;
 use litebox_common_linux::{MapFlags, ProtFlags, errno::Errno, user_pointers::UserPtrMut};
 
-use crate::{Task, UserMutPtr};
+use crate::{Platform, Task, UserMutPtr};
 
 #[inline]
 fn align_up(addr: usize, align: usize) -> Option<usize> {
@@ -34,7 +34,7 @@ impl Task {
             false,
             op,
         )
-        .map(|ptr| <UserMutPtr<u8> as RawConstPointer<u8>>::from_usize(ptr.as_usize()))
+        .map(UserPtrMut::to_platform_ptr::<Platform>)
     }
 
     /// Handle syscall `mmap`

--- a/litebox_shim_optee/src/syscalls/mm.rs
+++ b/litebox_shim_optee/src/syscalls/mm.rs
@@ -11,12 +11,12 @@ use crate::{Task, UserMutPtr};
 
 /// Bridge a platform mutable pointer to the address-only `UserPtrMut` used by
 /// the shared `litebox_common_linux::mm` helpers.
-fn to_local(ptr: UserMutPtr<u8>) -> litebox_common_linux::UserPtrMut<u8> {
-    litebox_common_linux::UserPtrMut::from_usize(ptr.as_usize())
+fn to_local(ptr: UserMutPtr<u8>) -> litebox_common_linux::user_pointers::UserPtrMut<u8> {
+    litebox_common_linux::user_pointers::UserPtrMut::from_usize(ptr.as_usize())
 }
 
 /// Bridge an address-only `UserPtrMut` back to a platform mutable pointer.
-fn from_local(ptr: litebox_common_linux::UserPtrMut<u8>) -> UserMutPtr<u8> {
+fn from_local(ptr: litebox_common_linux::user_pointers::UserPtrMut<u8>) -> UserMutPtr<u8> {
     <UserMutPtr<u8> as RawConstPointer<u8>>::from_usize(ptr.as_usize())
 }
 

--- a/litebox_shim_optee/src/syscalls/mm.rs
+++ b/litebox_shim_optee/src/syscalls/mm.rs
@@ -4,9 +4,21 @@
 //! Implementation of memory management related syscalls, eg., `mmap`, `munmap`, etc.
 
 use litebox::mm::linux::{MappingError, PAGE_SIZE};
+use litebox::platform::RawConstPointer;
 use litebox_common_linux::{MapFlags, ProtFlags, errno::Errno};
 
 use crate::{Task, UserMutPtr};
+
+/// Bridge a platform mutable pointer to the address-only `UserPtrMut` used by
+/// the shared `litebox_common_linux::mm` helpers.
+fn to_local(ptr: UserMutPtr<u8>) -> litebox_common_linux::UserPtrMut<u8> {
+    litebox_common_linux::UserPtrMut::from_usize(ptr.as_usize())
+}
+
+/// Bridge an address-only `UserPtrMut` back to a platform mutable pointer.
+fn from_local(ptr: litebox_common_linux::UserPtrMut<u8>) -> UserMutPtr<u8> {
+    <UserMutPtr<u8> as RawConstPointer<u8>>::from_usize(ptr.as_usize())
+}
 
 #[inline]
 fn align_up(addr: usize, align: usize) -> Option<usize> {
@@ -33,6 +45,7 @@ impl Task {
             false,
             op,
         )
+        .map(from_local)
     }
 
     /// Handle syscall `mmap`
@@ -92,7 +105,7 @@ impl Task {
     /// Handle syscall `munmap`
     pub(crate) fn sys_munmap(&self, addr: UserMutPtr<u8>, len: usize) -> Result<(), Errno> {
         let pm = &self.global.pm;
-        litebox_common_linux::mm::sys_munmap(pm, addr, len)
+        litebox_common_linux::mm::sys_munmap(pm, to_local(addr), len)
     }
 
     /// Handle syscall `mprotect`
@@ -104,6 +117,6 @@ impl Task {
         prot: ProtFlags,
     ) -> Result<(), Errno> {
         let pm = &self.global.pm;
-        litebox_common_linux::mm::sys_mprotect(pm, addr, len, prot)
+        litebox_common_linux::mm::sys_mprotect(pm, to_local(addr), len, prot)
     }
 }


### PR DESCRIPTION
This PR changes how the Linux shim represents user pointers, so that `Platform` is no longer viral across types that merely hold a pointer value.

Previously, litebox_shim_linux and litebox_common_linux stored user pointers using the platform's associated pointer types (`Platform::RawConstPointer`/`RawMutPointer`). Because those types are parameterized by the platform, every struct, enum, and signature that carried a user pointer had to carry a `Platform` (or `RawPointerProvider`) parameter -- even when it never dereferenced anything. This is the main obstacle to eventually dropping litebox_platform_multiplex from the shim in favor of explicit `Platform` generic bounds.

This PR introduces address-only `UserPtr<T>`/`UserPtrMut<T>` (transparent `usize` wrappers) in litebox_common_linux and uses them everywhere a user pointer is stored. The platform only re-enters at the handful of sites that actually access memory: the access methods take the platform as an explicit witness (e.g. `ptr.read_at_offset::<Platform>(..)`), converting back to the real platform pointer via `to_platform_ptr`. As a result, `Platform` shows up only where memory is genuinely read or written, which is both clearer and the setup needed to make the shim generic over the platform.

Behavior is unchanged; this is purely a representation refactor.