### PR TITLE
Implement NtDuplicateObject for Windows Shim

### DIFF
--- a/litebox_common_windows/src/nt_status.rs
+++ b/litebox_common_windows/src/nt_status.rs
@@ -206,6 +206,7 @@ impl NtStatus {
             0xC0000202 => "STATUS_NO_USER_SESSION_KEY: No user session key",
             0xC0000225 => "STATUS_NOT_FOUND: Not found",
             0xC000022D => "STATUS_RETRY: The operation should be retried",
+            0xC0000235 => "STATUS_HANDLE_NOT_CLOSABLE: Handle not closable",
             0xC00002DF => "STATUS_SAM_NEED_BOOTKEY_PASSWORD: SAM needs boot key password",
             0xC00002E0 => "STATUS_SAM_NEED_BOOTKEY_FLOPPY: SAM needs boot key floppy",
             0xC0000282 => "STATUS_RANGE_LIST_CONFLICT: Range list conflict",
@@ -587,6 +588,9 @@ impl NtStatus {
 
     /// STATUS_RETRY
     pub const RETRY: Self = Self::from_raw(0xC000022D);
+
+    /// Handle not closable
+    pub const HANDLE_NOT_CLOSABLE: Self = Self::from_raw(0xC0000235);
 
     /// STATUS_SAM_NEED_BOOTKEY_PASSWORD
     pub const SAM_NEED_BOOTKEY_PASSWORD: Self = Self::from_raw(0xC00002DF);

--- a/litebox_shim_windows/src/lib.rs
+++ b/litebox_shim_windows/src/lib.rs
@@ -632,6 +632,23 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             .ok_or(NtStatus::INVALID_HANDLE)
     }
 
+    fn typed_handle_entry_with_access<Subsystem>(
+        &self,
+        handle: syscalls::Handle,
+        required_access: u32,
+    ) -> Result<litebox::fd::EntryHandle<Platform, Subsystem>, NtStatus>
+    where
+        Subsystem: WindowsHandleSubsystem,
+    {
+        let typed = self.typed_handle::<Subsystem>(handle)?;
+        self.require_typed_handle_access(&typed, required_access)?;
+        self.global
+            .litebox
+            .descriptor_table()
+            .entry_handle(&typed)
+            .ok_or(NtStatus::INVALID_HANDLE)
+    }
+
     fn typed_handle<Subsystem>(
         &self,
         handle: syscalls::Handle,
@@ -654,6 +671,23 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         }
     }
 
+    fn typed_handle_granted_access<Subsystem>(
+        &self,
+        typed: &litebox::fd::TypedFd<Subsystem>,
+    ) -> Result<u32, NtStatus>
+    where
+        Subsystem: WindowsHandleSubsystem,
+    {
+        self.global
+            .litebox
+            .descriptor_table()
+            .with_metadata::<Subsystem, WindowsHandleMetadata, _>(typed, |metadata| {
+                metadata.granted_access
+            })
+            .map_err(|_| NtStatus::INVALID_HANDLE)
+    }
+
+    #[cfg(test)]
     pub(crate) fn handle_granted_access<Subsystem>(
         &self,
         handle: syscalls::Handle,
@@ -662,13 +696,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         Subsystem: WindowsHandleSubsystem,
     {
         let typed = self.typed_handle::<Subsystem>(handle)?;
-        self.global
-            .litebox
-            .descriptor_table()
-            .with_metadata::<Subsystem, WindowsHandleMetadata, _>(&typed, |metadata| {
-                metadata.granted_access
-            })
-            .map_err(|_| NtStatus::INVALID_HANDLE)
+        self.typed_handle_granted_access(&typed)
     }
 
     pub(crate) fn require_handle_access<Subsystem>(
@@ -679,7 +707,19 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
     where
         Subsystem: WindowsHandleSubsystem,
     {
-        if self.handle_granted_access::<Subsystem>(handle)? & required_access == required_access {
+        let typed = self.typed_handle::<Subsystem>(handle)?;
+        self.require_typed_handle_access(&typed, required_access)
+    }
+
+    pub(crate) fn require_typed_handle_access<Subsystem>(
+        &self,
+        typed: &litebox::fd::TypedFd<Subsystem>,
+        required_access: u32,
+    ) -> Result<(), NtStatus>
+    where
+        Subsystem: WindowsHandleSubsystem,
+    {
+        if self.typed_handle_granted_access(typed)? & required_access == required_access {
             Ok(())
         } else {
             Err(NtStatus::ACCESS_DENIED)

--- a/litebox_shim_windows/src/lib.rs
+++ b/litebox_shim_windows/src/lib.rs
@@ -129,6 +129,8 @@ pub(crate) trait WindowsHandleSubsystem: litebox::fd::FdEnabledSubsystem {
         let explicit_access = desired_access & !nt_types::AccessMask::MAXIMUM_ALLOWED.bits();
         let normalized = Self::normalize_desired_access(explicit_access);
         Ok(if maximum_allowed {
+            // TODO(dacl-access-check): Derive this grant from the caller's token and the
+            // object's security descriptor instead of assuming a single trust context.
             normalized | Self::normalize_desired_access(nt_types::AccessMask::GENERIC_ALL.bits())
         } else {
             normalized

--- a/litebox_shim_windows/src/lib.rs
+++ b/litebox_shim_windows/src/lib.rs
@@ -121,18 +121,15 @@ struct WindowsHandleMetadata {
 pub(crate) trait WindowsHandleSubsystem: litebox::fd::FdEnabledSubsystem {
     fn normalize_desired_access(desired_access: u32) -> u32;
 
-    fn maximum_allowed_access() -> u32;
-
     fn resolve_duplicate_access(
         _entry: &Self::Entry,
-        _source_access: u32,
         desired_access: u32,
     ) -> Result<u32, NtStatus> {
         let maximum_allowed = desired_access & nt_types::AccessMask::MAXIMUM_ALLOWED.bits() != 0;
         let explicit_access = desired_access & !nt_types::AccessMask::MAXIMUM_ALLOWED.bits();
         let normalized = Self::normalize_desired_access(explicit_access);
         Ok(if maximum_allowed {
-            normalized | Self::maximum_allowed_access()
+            normalized | Self::normalize_desired_access(nt_types::AccessMask::GENERIC_ALL.bits())
         } else {
             normalized
         })
@@ -1843,7 +1840,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         } else {
             let descriptors = self.global.litebox.descriptor_table();
             match descriptors.with_entry(&typed, |entry| {
-                Subsystem::resolve_duplicate_access(entry, source_access, desired_access)
+                Subsystem::resolve_duplicate_access(entry, desired_access)
             }) {
                 Some(Ok(access)) => access,
                 Some(Err(status)) => return Some(Err(status)),

--- a/litebox_shim_windows/src/lib.rs
+++ b/litebox_shim_windows/src/lib.rs
@@ -89,6 +89,57 @@ pub(crate) type MutPtr<Platform, T> =
 pub(crate) type WindowsPageManager<Platform> = PageManager<Platform, PAGE_SIZE>;
 pub(crate) type WindowsHandleStore<Platform> =
     litebox::sync::RwLock<Platform, litebox::fd::RawDescriptorStorage>;
+
+bitflags::bitflags! {
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    struct DuplicateOptions: u32 {
+        const CLOSE_SOURCE = 0x0000_0001;
+        const SAME_ACCESS = 0x0000_0002;
+        const SAME_ATTRIBUTES = 0x0000_0004;
+
+        const _ = !0;
+    }
+}
+
+bitflags::bitflags! {
+    #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+    struct HandleAttributes: u32 {
+        const PROTECT_FROM_CLOSE = 0x0000_0001;
+        const INHERIT = 0x0000_0002;
+        const AUDIT_OBJECT_CLOSE = 0x0000_0004;
+
+        const _ = !0;
+    }
+}
+
+#[derive(Clone, Copy, Default)]
+struct WindowsHandleMetadata {
+    granted_access: u32,
+    attributes: HandleAttributes,
+}
+
+pub(crate) trait WindowsHandleSubsystem: litebox::fd::FdEnabledSubsystem {
+    fn granted_access(entry: &Self::Entry) -> u32;
+
+    fn normalize_desired_access(desired_access: u32) -> u32;
+
+    fn maximum_allowed_access() -> u32;
+
+    fn resolve_duplicate_access(
+        _entry: &Self::Entry,
+        _source_access: u32,
+        desired_access: u32,
+    ) -> Result<u32, NtStatus> {
+        let maximum_allowed = desired_access & nt_types::AccessMask::MAXIMUM_ALLOWED.bits() != 0;
+        let explicit_access = desired_access & !nt_types::AccessMask::MAXIMUM_ALLOWED.bits();
+        let normalized = Self::normalize_desired_access(explicit_access);
+        Ok(if maximum_allowed {
+            normalized | Self::maximum_allowed_access()
+        } else {
+            normalized
+        })
+    }
+}
 pub(crate) type WindowsNlsSectionMappings<Platform> =
     litebox::sync::RwLock<Platform, BTreeMap<(u32, u32), (usize, usize)>>;
 pub(crate) type WindowsVirtualAllocations<Platform> =
@@ -575,24 +626,66 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
     where
         Subsystem: litebox::fd::FdEnabledSubsystem,
     {
-        let Some(raw_fd) = handle.raw_fd() else {
-            return Err(NtStatus::INVALID_HANDLE);
-        };
-        let typed = {
-            let handles = self.process.handles.read();
-            match handles.fd_from_raw_integer::<Subsystem>(raw_fd) {
-                Ok(typed) => typed,
-                Err(litebox::fd::ErrRawIntFd::NotFound) => return Err(NtStatus::INVALID_HANDLE),
-                Err(litebox::fd::ErrRawIntFd::InvalidSubsystem) => {
-                    return Err(NtStatus::OBJECT_TYPE_MISMATCH);
-                }
-            }
-        };
+        let typed = self.typed_handle::<Subsystem>(handle)?;
         self.global
             .litebox
             .descriptor_table()
             .entry_handle(&typed)
             .ok_or(NtStatus::INVALID_HANDLE)
+    }
+
+    fn typed_handle<Subsystem>(
+        &self,
+        handle: syscalls::Handle,
+    ) -> Result<Arc<litebox::fd::TypedFd<Subsystem>>, NtStatus>
+    where
+        Subsystem: litebox::fd::FdEnabledSubsystem,
+    {
+        let Some(raw_fd) = handle.raw_fd() else {
+            return Err(NtStatus::INVALID_HANDLE);
+        };
+        {
+            let handles = self.process.handles.read();
+            match handles.fd_from_raw_integer::<Subsystem>(raw_fd) {
+                Ok(typed) => Ok(typed),
+                Err(litebox::fd::ErrRawIntFd::NotFound) => Err(NtStatus::INVALID_HANDLE),
+                Err(litebox::fd::ErrRawIntFd::InvalidSubsystem) => {
+                    Err(NtStatus::OBJECT_TYPE_MISMATCH)
+                }
+            }
+        }
+    }
+
+    pub(crate) fn handle_granted_access<Subsystem>(
+        &self,
+        handle: syscalls::Handle,
+    ) -> Result<u32, NtStatus>
+    where
+        Subsystem: WindowsHandleSubsystem,
+    {
+        let typed = self.typed_handle::<Subsystem>(handle)?;
+        self.global
+            .litebox
+            .descriptor_table()
+            .with_metadata::<Subsystem, WindowsHandleMetadata, _>(&typed, |metadata| {
+                metadata.granted_access
+            })
+            .map_err(|_| NtStatus::INVALID_HANDLE)
+    }
+
+    pub(crate) fn require_handle_access<Subsystem>(
+        &self,
+        handle: syscalls::Handle,
+        required_access: u32,
+    ) -> Result<(), NtStatus>
+    where
+        Subsystem: WindowsHandleSubsystem,
+    {
+        if self.handle_granted_access::<Subsystem>(handle)? & required_access == required_access {
+            Ok(())
+        } else {
+            Err(NtStatus::ACCESS_DENIED)
+        }
     }
 
     fn insert_typed_handle<Subsystem>(
@@ -601,13 +694,22 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         cleanup_entry: impl FnOnce(Subsystem::Entry),
     ) -> Result<syscalls::Handle, NtStatus>
     where
-        Subsystem: litebox::fd::FdEnabledSubsystem,
+        Subsystem: WindowsHandleSubsystem,
     {
-        let typed = self
-            .global
-            .litebox
-            .descriptor_table_mut()
-            .insert::<Subsystem>(entry);
+        let granted_access = Subsystem::granted_access(&entry);
+        let typed = {
+            let mut descriptors = self.global.litebox.descriptor_table_mut();
+            let typed = descriptors.insert::<Subsystem>(entry);
+            let old = descriptors.set_fd_metadata(
+                &typed,
+                WindowsHandleMetadata {
+                    granted_access,
+                    attributes: HandleAttributes::empty(),
+                },
+            );
+            debug_assert!(old.is_none());
+            typed
+        };
         insert_raw_handle::<Platform, Subsystem>(
             &self.global.litebox,
             &self.process.handles,
@@ -655,6 +757,26 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         let (result, op) = match req {
             SyscallRequest::NtClose { handle } => {
                 let status = self.sys_nt_close(handle);
+                (status, ContinueOperation::Resume)
+            }
+            SyscallRequest::NtDuplicateObject {
+                source_process_handle,
+                source_handle,
+                target_process_handle,
+                target_handle,
+                desired_access,
+                handle_attributes,
+                options,
+            } => {
+                let status = self.sys_nt_duplicate_object(
+                    source_process_handle,
+                    source_handle,
+                    target_process_handle,
+                    target_handle,
+                    desired_access,
+                    handle_attributes,
+                    options,
+                );
                 (status, ContinueOperation::Resume)
             }
             SyscallRequest::NtCreateEvent {
@@ -1560,7 +1682,255 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         let Some(raw_fd) = handle.raw_fd() else {
             return NtStatus::INVALID_HANDLE;
         };
+        match self.raw_fd_handle_attributes(raw_fd) {
+            Ok(attributes) if attributes.contains(HandleAttributes::PROTECT_FROM_CLOSE) => {
+                return NtStatus::HANDLE_NOT_CLOSABLE;
+            }
+            Ok(_) => {}
+            Err(status) => return status,
+        }
         self.close_raw_fd(raw_fd, CloseRawHandleVisitor { task: self })
+    }
+
+    fn raw_fd_handle_attributes(&self, raw_fd: usize) -> Result<HandleAttributes, NtStatus> {
+        macro_rules! try_attributes {
+            ($subsystem:ty) => {
+                if let Some(result) = self.try_raw_fd_handle_attributes::<$subsystem>(raw_fd) {
+                    return result;
+                }
+            };
+        }
+
+        try_attributes!(FileObjectSubsystem<FS>);
+        try_attributes!(RegistryKeySubsystem<Platform>);
+        try_attributes!(EventSubsystem<Platform>);
+        try_attributes!(DirectoryObjectSubsystem<Platform>);
+        try_attributes!(SymbolicLinkSubsystem<Platform>);
+        try_attributes!(IoCompletionSubsystem<Platform>);
+        try_attributes!(LpcPortSubsystem<Platform>);
+        try_attributes!(TimerSubsystem<Platform>);
+        try_attributes!(WaitCompletionPacketSubsystem<Platform>);
+        try_attributes!(WorkerFactorySubsystem<Platform>);
+        try_attributes!(SectionSubsystem<Platform>);
+
+        Err(NtStatus::INVALID_HANDLE)
+    }
+
+    fn try_raw_fd_handle_attributes<Subsystem>(
+        &self,
+        raw_fd: usize,
+    ) -> Option<Result<HandleAttributes, NtStatus>>
+    where
+        Subsystem: WindowsHandleSubsystem,
+    {
+        let typed = {
+            let handles = self.process.handles.read();
+            match handles.fd_from_raw_integer::<Subsystem>(raw_fd) {
+                Ok(typed) => typed,
+                Err(litebox::fd::ErrRawIntFd::InvalidSubsystem) => return None,
+                Err(litebox::fd::ErrRawIntFd::NotFound) => {
+                    return Some(Err(NtStatus::INVALID_HANDLE));
+                }
+            }
+        };
+        Some(
+            self.global
+                .litebox
+                .descriptor_table()
+                .with_metadata::<Subsystem, WindowsHandleMetadata, _>(&typed, |metadata| {
+                    metadata.attributes
+                })
+                .map_err(|_| NtStatus::INVALID_HANDLE),
+        )
+    }
+
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "matches the native NtDuplicateObject contract"
+    )]
+    pub(crate) fn sys_nt_duplicate_object(
+        &self,
+        source_process_handle: syscalls::ProcessHandle,
+        source_handle: syscalls::Handle,
+        target_process_handle: syscalls::ProcessHandle,
+        target_handle: Option<MutPtr<Platform, syscalls::Handle>>,
+        desired_access: u32,
+        handle_attributes: u32,
+        options: u32,
+    ) -> NtStatus {
+        let options = DuplicateOptions::from_bits_retain(options);
+        if let Some(target_handle) = target_handle
+            && target_handle
+                .write_at_offset(0, syscalls::Handle::default())
+                .is_none()
+        {
+            return NtStatus::ACCESS_VIOLATION;
+        }
+        if !source_process_handle.is_current() {
+            // TODO(duplicate-object-cross-process): resolve process handles once LiteBox supports
+            // multiple guest processes and per-process handle tables.
+            return NtStatus::INVALID_HANDLE;
+        }
+
+        let status = self.duplicate_object(
+            source_handle,
+            target_process_handle,
+            target_handle,
+            desired_access,
+            handle_attributes,
+            options,
+        );
+
+        if options.contains(DuplicateOptions::CLOSE_SOURCE) {
+            let _ = self.sys_nt_close(source_handle);
+        }
+        status
+    }
+
+    fn duplicate_object(
+        &self,
+        source_handle: syscalls::Handle,
+        target_process_handle: syscalls::ProcessHandle,
+        target_handle: Option<MutPtr<Platform, syscalls::Handle>>,
+        desired_access: u32,
+        handle_attributes: u32,
+        options: DuplicateOptions,
+    ) -> NtStatus {
+        if target_process_handle.is_null() {
+            return if options.contains(DuplicateOptions::CLOSE_SOURCE) {
+                NtStatus::SUCCESS
+            } else {
+                NtStatus::INVALID_PARAMETER
+            };
+        }
+        if !target_process_handle.is_current() {
+            // TODO(duplicate-object-cross-process): insert into the target process handle table.
+            return NtStatus::INVALID_HANDLE;
+        }
+        let Some(raw_fd) = source_handle.raw_fd() else {
+            return NtStatus::INVALID_HANDLE;
+        };
+        let duplicate =
+            match self.duplicate_raw_fd(raw_fd, desired_access, handle_attributes, options) {
+                Ok(handle) => handle,
+                Err(status) => return status,
+            };
+        if let Some(target_handle) = target_handle
+            && target_handle.write_at_offset(0, duplicate).is_none()
+        {
+            return NtStatus::ACCESS_VIOLATION;
+        }
+        NtStatus::SUCCESS
+    }
+
+    fn duplicate_raw_fd(
+        &self,
+        raw_fd: usize,
+        desired_access: u32,
+        handle_attributes: u32,
+        options: DuplicateOptions,
+    ) -> Result<syscalls::Handle, NtStatus> {
+        macro_rules! try_duplicate {
+            ($subsystem:ty) => {
+                if let Some(result) = self.try_duplicate_raw_fd::<$subsystem>(
+                    raw_fd,
+                    desired_access,
+                    handle_attributes,
+                    options,
+                ) {
+                    return result;
+                }
+            };
+        }
+
+        try_duplicate!(FileObjectSubsystem<FS>);
+        try_duplicate!(RegistryKeySubsystem<Platform>);
+        try_duplicate!(EventSubsystem<Platform>);
+        try_duplicate!(DirectoryObjectSubsystem<Platform>);
+        try_duplicate!(SymbolicLinkSubsystem<Platform>);
+        try_duplicate!(IoCompletionSubsystem<Platform>);
+        try_duplicate!(LpcPortSubsystem<Platform>);
+        try_duplicate!(TimerSubsystem<Platform>);
+        try_duplicate!(WaitCompletionPacketSubsystem<Platform>);
+        try_duplicate!(WorkerFactorySubsystem<Platform>);
+        try_duplicate!(SectionSubsystem<Platform>);
+
+        Err(NtStatus::INVALID_HANDLE)
+    }
+
+    fn try_duplicate_raw_fd<Subsystem>(
+        &self,
+        raw_fd: usize,
+        desired_access: u32,
+        handle_attributes: u32,
+        options: DuplicateOptions,
+    ) -> Option<Result<syscalls::Handle, NtStatus>>
+    where
+        Subsystem: WindowsHandleSubsystem,
+    {
+        let typed = {
+            let handles = self.process.handles.read();
+            match handles.fd_from_raw_integer::<Subsystem>(raw_fd) {
+                Ok(typed) => typed,
+                Err(litebox::fd::ErrRawIntFd::InvalidSubsystem) => return None,
+                Err(litebox::fd::ErrRawIntFd::NotFound) => {
+                    return Some(Err(NtStatus::INVALID_HANDLE));
+                }
+            }
+        };
+        let source_metadata = {
+            let descriptors = self.global.litebox.descriptor_table();
+            match descriptors
+                .with_metadata::<Subsystem, WindowsHandleMetadata, _>(&typed, |metadata| *metadata)
+            {
+                Ok(metadata) => metadata,
+                Err(_) => return Some(Err(NtStatus::INVALID_HANDLE)),
+            }
+        };
+
+        let duplicate_access = if options.contains(DuplicateOptions::SAME_ACCESS) {
+            source_metadata.granted_access
+        } else {
+            let descriptors = self.global.litebox.descriptor_table();
+            match descriptors.with_entry(&typed, |entry| {
+                Subsystem::resolve_duplicate_access(
+                    entry,
+                    source_metadata.granted_access,
+                    desired_access,
+                )
+            }) {
+                Some(Ok(access)) => access,
+                Some(Err(status)) => return Some(Err(status)),
+                None => return Some(Err(NtStatus::INVALID_HANDLE)),
+            }
+        };
+        let duplicate_attributes = if options.contains(DuplicateOptions::SAME_ATTRIBUTES) {
+            source_metadata.attributes
+        } else {
+            HandleAttributes::from_bits_retain(handle_attributes)
+        };
+
+        let duplicate = {
+            let mut descriptors = self.global.litebox.descriptor_table_mut();
+            let Some(duplicate) = descriptors.duplicate(&typed) else {
+                return Some(Err(NtStatus::INVALID_HANDLE));
+            };
+            let old = descriptors.set_fd_metadata(
+                &duplicate,
+                WindowsHandleMetadata {
+                    granted_access: duplicate_access,
+                    attributes: duplicate_attributes,
+                },
+            );
+            debug_assert!(old.is_none());
+            duplicate
+        };
+        Some(insert_raw_handle::<Platform, Subsystem>(
+            &self.global.litebox,
+            &self.process.handles,
+            duplicate,
+            drop,
+        ))
     }
 
     fn close_raw_fd(

--- a/litebox_shim_windows/src/lib.rs
+++ b/litebox_shim_windows/src/lib.rs
@@ -659,44 +659,26 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         let Some(raw_fd) = handle.raw_fd() else {
             return Err(NtStatus::INVALID_HANDLE);
         };
-        {
-            let handles = self.process.handles.read();
-            match handles.fd_from_raw_integer::<Subsystem>(raw_fd) {
-                Ok(typed) => Ok(typed),
-                Err(litebox::fd::ErrRawIntFd::NotFound) => Err(NtStatus::INVALID_HANDLE),
-                Err(litebox::fd::ErrRawIntFd::InvalidSubsystem) => {
-                    Err(NtStatus::OBJECT_TYPE_MISMATCH)
-                }
-            }
+        let handles = self.process.handles.read();
+        match handles.fd_from_raw_integer::<Subsystem>(raw_fd) {
+            Ok(typed) => Ok(typed),
+            Err(litebox::fd::ErrRawIntFd::NotFound) => Err(NtStatus::INVALID_HANDLE),
+            Err(litebox::fd::ErrRawIntFd::InvalidSubsystem) => Err(NtStatus::OBJECT_TYPE_MISMATCH),
         }
     }
 
-    fn typed_handle_granted_access<Subsystem>(
+    fn typed_handle_metadata<Subsystem>(
         &self,
         typed: &litebox::fd::TypedFd<Subsystem>,
-    ) -> Result<u32, NtStatus>
+    ) -> Result<WindowsHandleMetadata, NtStatus>
     where
         Subsystem: WindowsHandleSubsystem,
     {
         self.global
             .litebox
             .descriptor_table()
-            .with_metadata::<Subsystem, WindowsHandleMetadata, _>(typed, |metadata| {
-                metadata.granted_access
-            })
+            .with_metadata::<Subsystem, WindowsHandleMetadata, _>(typed, |metadata| *metadata)
             .map_err(|_| NtStatus::INVALID_HANDLE)
-    }
-
-    #[cfg(test)]
-    pub(crate) fn handle_granted_access<Subsystem>(
-        &self,
-        handle: syscalls::Handle,
-    ) -> Result<u32, NtStatus>
-    where
-        Subsystem: WindowsHandleSubsystem,
-    {
-        let typed = self.typed_handle::<Subsystem>(handle)?;
-        self.typed_handle_granted_access(&typed)
     }
 
     pub(crate) fn require_handle_access<Subsystem>(
@@ -719,7 +701,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
     where
         Subsystem: WindowsHandleSubsystem,
     {
-        if self.typed_handle_granted_access(typed)? & required_access == required_access {
+        if self.typed_handle_metadata(typed)?.granted_access & required_access == required_access {
             Ok(())
         } else {
             Err(NtStatus::ACCESS_DENIED)
@@ -1717,69 +1699,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
     }
 
     pub(crate) fn sys_nt_close(&self, handle: syscalls::Handle) -> NtStatus {
-        let Some(raw_fd) = handle.raw_fd() else {
-            return NtStatus::INVALID_HANDLE;
-        };
-        match self.raw_fd_handle_attributes(raw_fd) {
-            Ok(attributes) if attributes.contains(HandleAttributes::PROTECT_FROM_CLOSE) => {
-                return NtStatus::HANDLE_NOT_CLOSABLE;
-            }
-            Ok(_) => {}
-            Err(status) => return status,
-        }
-        self.close_raw_fd(raw_fd, CloseRawHandleVisitor { task: self })
-    }
-
-    fn raw_fd_handle_attributes(&self, raw_fd: usize) -> Result<HandleAttributes, NtStatus> {
-        macro_rules! try_attributes {
-            ($subsystem:ty) => {
-                if let Some(result) = self.try_raw_fd_handle_attributes::<$subsystem>(raw_fd) {
-                    return result;
-                }
-            };
-        }
-
-        try_attributes!(FileObjectSubsystem<FS>);
-        try_attributes!(RegistryKeySubsystem<Platform>);
-        try_attributes!(EventSubsystem<Platform>);
-        try_attributes!(DirectoryObjectSubsystem<Platform>);
-        try_attributes!(SymbolicLinkSubsystem<Platform>);
-        try_attributes!(IoCompletionSubsystem<Platform>);
-        try_attributes!(LpcPortSubsystem<Platform>);
-        try_attributes!(TimerSubsystem<Platform>);
-        try_attributes!(WaitCompletionPacketSubsystem<Platform>);
-        try_attributes!(WorkerFactorySubsystem<Platform>);
-        try_attributes!(SectionSubsystem<Platform>);
-
-        Err(NtStatus::INVALID_HANDLE)
-    }
-
-    fn try_raw_fd_handle_attributes<Subsystem>(
-        &self,
-        raw_fd: usize,
-    ) -> Option<Result<HandleAttributes, NtStatus>>
-    where
-        Subsystem: WindowsHandleSubsystem,
-    {
-        let typed = {
-            let handles = self.process.handles.read();
-            match handles.fd_from_raw_integer::<Subsystem>(raw_fd) {
-                Ok(typed) => typed,
-                Err(litebox::fd::ErrRawIntFd::InvalidSubsystem) => return None,
-                Err(litebox::fd::ErrRawIntFd::NotFound) => {
-                    return Some(Err(NtStatus::INVALID_HANDLE));
-                }
-            }
-        };
-        Some(
-            self.global
-                .litebox
-                .descriptor_table()
-                .with_metadata::<Subsystem, WindowsHandleMetadata, _>(&typed, |metadata| {
-                    metadata.attributes
-                })
-                .map_err(|_| NtStatus::INVALID_HANDLE),
-        )
+        self.close_handle(handle, CloseRawHandleVisitor { task: self })
     }
 
     #[expect(
@@ -1845,14 +1765,15 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             // TODO(duplicate-object-cross-process): insert into the target process handle table.
             return NtStatus::INVALID_HANDLE;
         }
-        let Some(raw_fd) = source_handle.raw_fd() else {
-            return NtStatus::INVALID_HANDLE;
+        let duplicate = match self.duplicate_handle(
+            source_handle,
+            desired_access,
+            handle_attributes,
+            options,
+        ) {
+            Ok(handle) => handle,
+            Err(status) => return status,
         };
-        let duplicate =
-            match self.duplicate_raw_fd(raw_fd, desired_access, handle_attributes, options) {
-                Ok(handle) => handle,
-                Err(status) => return status,
-            };
         if let Some(target_handle) = target_handle
             && target_handle.write_at_offset(0, duplicate).is_none()
         {
@@ -1861,17 +1782,17 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         NtStatus::SUCCESS
     }
 
-    fn duplicate_raw_fd(
+    fn duplicate_handle(
         &self,
-        raw_fd: usize,
+        source_handle: syscalls::Handle,
         desired_access: u32,
         handle_attributes: u32,
         options: DuplicateOptions,
     ) -> Result<syscalls::Handle, NtStatus> {
         macro_rules! try_duplicate {
             ($subsystem:ty) => {
-                if let Some(result) = self.try_duplicate_raw_fd::<$subsystem>(
-                    raw_fd,
+                if let Some(result) = self.try_duplicate_handle::<$subsystem>(
+                    source_handle,
                     desired_access,
                     handle_attributes,
                     options,
@@ -1896,9 +1817,9 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         Err(NtStatus::INVALID_HANDLE)
     }
 
-    fn try_duplicate_raw_fd<Subsystem>(
+    fn try_duplicate_handle<Subsystem>(
         &self,
-        raw_fd: usize,
+        source_handle: syscalls::Handle,
         desired_access: u32,
         handle_attributes: u32,
         options: DuplicateOptions,
@@ -1906,36 +1827,23 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
     where
         Subsystem: WindowsHandleSubsystem,
     {
-        let typed = {
-            let handles = self.process.handles.read();
-            match handles.fd_from_raw_integer::<Subsystem>(raw_fd) {
-                Ok(typed) => typed,
-                Err(litebox::fd::ErrRawIntFd::InvalidSubsystem) => return None,
-                Err(litebox::fd::ErrRawIntFd::NotFound) => {
-                    return Some(Err(NtStatus::INVALID_HANDLE));
-                }
-            }
+        let typed = match self.typed_handle::<Subsystem>(source_handle) {
+            Ok(typed) => typed,
+            Err(NtStatus::OBJECT_TYPE_MISMATCH) => return None,
+            Err(status) => return Some(Err(status)),
         };
-        let source_metadata = {
-            let descriptors = self.global.litebox.descriptor_table();
-            match descriptors
-                .with_metadata::<Subsystem, WindowsHandleMetadata, _>(&typed, |metadata| *metadata)
-            {
-                Ok(metadata) => metadata,
-                Err(_) => return Some(Err(NtStatus::INVALID_HANDLE)),
-            }
+        let source_metadata = match self.typed_handle_metadata(&typed) {
+            Ok(metadata) => metadata,
+            Err(status) => return Some(Err(status)),
         };
 
+        let source_access = source_metadata.granted_access;
         let duplicate_access = if options.contains(DuplicateOptions::SAME_ACCESS) {
-            source_metadata.granted_access
+            source_access
         } else {
             let descriptors = self.global.litebox.descriptor_table();
             match descriptors.with_entry(&typed, |entry| {
-                Subsystem::resolve_duplicate_access(
-                    entry,
-                    source_metadata.granted_access,
-                    desired_access,
-                )
+                Subsystem::resolve_duplicate_access(entry, source_access, desired_access)
             }) {
                 Some(Ok(access)) => access,
                 Some(Err(status)) => return Some(Err(status)),
@@ -1971,20 +1879,17 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         ))
     }
 
-    fn close_raw_fd(
+    fn close_handle(
         &self,
-        raw_fd: usize,
+        handle: syscalls::Handle,
         visitor: impl RawHandleVisitor<Platform, FS>,
     ) -> NtStatus {
         macro_rules! try_close {
             ($subsystem:ty, $visit:ident) => {
-                if remove_raw_handle_by_raw_fd::<Platform, $subsystem>(
-                    &self.global.litebox,
-                    &self.process.handles,
-                    raw_fd,
-                    |entry| visitor.$visit(entry),
-                ) {
-                    return NtStatus::SUCCESS;
+                if let Some(status) =
+                    self.try_close_handle::<$subsystem>(handle, |entry| visitor.$visit(entry))
+                {
+                    return status;
                 }
             };
         }
@@ -2005,6 +1910,39 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         try_close!(SectionSubsystem<Platform>, section);
 
         NtStatus::INVALID_HANDLE
+    }
+
+    fn try_close_handle<Subsystem>(
+        &self,
+        handle: syscalls::Handle,
+        cleanup_entry: impl FnOnce(Subsystem::Entry),
+    ) -> Option<NtStatus>
+    where
+        Subsystem: WindowsHandleSubsystem,
+    {
+        let typed = match self.typed_handle::<Subsystem>(handle) {
+            Ok(typed) => typed,
+            Err(NtStatus::OBJECT_TYPE_MISMATCH) => return None,
+            Err(status) => return Some(status),
+        };
+        let metadata = match self.typed_handle_metadata(&typed) {
+            Ok(metadata) => metadata,
+            Err(status) => return Some(status),
+        };
+        if metadata
+            .attributes
+            .contains(HandleAttributes::PROTECT_FROM_CLOSE)
+        {
+            return Some(NtStatus::HANDLE_NOT_CLOSABLE);
+        }
+
+        remove_raw_handle::<Platform, Subsystem>(
+            &self.global.litebox,
+            &self.process.handles,
+            handle,
+            cleanup_entry,
+        );
+        Some(NtStatus::SUCCESS)
     }
 
     fn handle_interrupt_request(

--- a/litebox_shim_windows/src/lib.rs
+++ b/litebox_shim_windows/src/lib.rs
@@ -119,8 +119,6 @@ struct WindowsHandleMetadata {
 }
 
 pub(crate) trait WindowsHandleSubsystem: litebox::fd::FdEnabledSubsystem {
-    fn granted_access(entry: &Self::Entry) -> u32;
-
     fn normalize_desired_access(desired_access: u32) -> u32;
 
     fn maximum_allowed_access() -> u32;
@@ -691,12 +689,12 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
     fn insert_typed_handle<Subsystem>(
         &self,
         entry: Subsystem::Entry,
+        granted_access: u32,
         cleanup_entry: impl FnOnce(Subsystem::Entry),
     ) -> Result<syscalls::Handle, NtStatus>
     where
         Subsystem: WindowsHandleSubsystem,
     {
-        let granted_access = Subsystem::granted_access(&entry);
         let typed = {
             let mut descriptors = self.global.litebox.descriptor_table_mut();
             let typed = descriptors.insert::<Subsystem>(entry);

--- a/litebox_shim_windows/src/nt_types.rs
+++ b/litebox_shim_windows/src/nt_types.rs
@@ -143,6 +143,7 @@ bitflags::bitflags! {
         const WRITE_DAC = 0x0004_0000;
         const WRITE_OWNER = 0x0008_0000;
         const SYNCHRONIZE = 0x0010_0000;
+        const MAXIMUM_ALLOWED = 0x0200_0000;
         const STANDARD_RIGHTS_READ = Self::READ_CONTROL.bits();
         const STANDARD_RIGHTS_WRITE = Self::READ_CONTROL.bits();
         const STANDARD_RIGHTS_EXECUTE = Self::READ_CONTROL.bits();

--- a/litebox_shim_windows/src/syscalls/event.rs
+++ b/litebox_shim_windows/src/syscalls/event.rs
@@ -81,10 +81,6 @@ impl<Platform: crate::ShimPlatform> FdEnabledSubsystem for EventSubsystem<Platfo
 impl<Platform: crate::ShimPlatform> FdEnabledSubsystemEntry for EventHandleObject<Platform> {}
 
 impl<Platform: crate::ShimPlatform> crate::WindowsHandleSubsystem for EventSubsystem<Platform> {
-    fn granted_access(entry: &Self::Entry) -> u32 {
-        entry.granted_access.bits()
-    }
-
     fn normalize_desired_access(desired_access: u32) -> u32 {
         EventAccess::from_desired_access(desired_access).bits()
     }
@@ -96,7 +92,6 @@ impl<Platform: crate::ShimPlatform> crate::WindowsHandleSubsystem for EventSubsy
 
 pub(crate) struct EventHandleObject<Platform: crate::ShimPlatform> {
     event: Arc<EventObject<Platform>>,
-    granted_access: EventAccess,
 }
 
 pub(crate) struct EventObject<Platform: crate::ShimPlatform> {
@@ -264,10 +259,8 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         granted_access: EventAccess,
     ) -> Result<Handle, NtStatus> {
         self.insert_typed_handle::<EventSubsystem<Platform>>(
-            EventHandleObject {
-                event,
-                granted_access,
-            },
+            EventHandleObject { event },
+            granted_access.bits(),
             drop,
         )
     }

--- a/litebox_shim_windows/src/syscalls/event.rs
+++ b/litebox_shim_windows/src/syscalls/event.rs
@@ -19,9 +19,7 @@ use crate::nt_types::{
     AccessMask, ObjectAttributes, ObjectAttributesFlags, UnicodeString, read_object_attributes,
 };
 use crate::syscalls::Handle;
-use crate::{
-    ConstPtr, MutPtr, ShimFS, Task, probe_guest_output_preserving_value, raw_handle_entry,
-};
+use crate::{ConstPtr, MutPtr, ShimFS, Task, probe_guest_output_preserving_value};
 
 #[repr(u32)]
 #[derive(Clone, Copy, Debug, Eq, IntEnum, PartialEq)]
@@ -241,18 +239,6 @@ fn read_event_object_attributes<Platform: RawPointerProvider>(
 }
 
 impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
-    fn event_entry(
-        &self,
-        handle: Handle,
-    ) -> Result<litebox::fd::EntryHandle<Platform, EventSubsystem<Platform>>, NtStatus> {
-        raw_handle_entry::<Platform, EventSubsystem<Platform>>(
-            &self.global.litebox,
-            &self.process.handles,
-            handle,
-        )
-        .ok_or(NtStatus::INVALID_HANDLE)
-    }
-
     fn insert_event_handle(
         &self,
         event: Arc<EventObject<Platform>>,
@@ -485,13 +471,10 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             return status;
         }
 
-        if let Err(status) = self.require_handle_access::<EventSubsystem<Platform>>(
+        let entry = match self.typed_handle_entry_with_access::<EventSubsystem<Platform>>(
             event_handle,
             EventAccess::QUERY_STATE.bits(),
         ) {
-            return status;
-        }
-        let entry = match self.event_entry(event_handle) {
             Ok(entry) => entry,
             Err(status) => return status,
         };
@@ -515,11 +498,10 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         previous_state: Option<MutPtr<Platform, i32>>,
         op: impl FnOnce(&EventObject<Platform>) -> Result<i32, NtStatus>,
     ) -> Result<(), NtStatus> {
-        self.require_handle_access::<EventSubsystem<Platform>>(
+        let entry = self.typed_handle_entry_with_access::<EventSubsystem<Platform>>(
             event_handle,
             EventAccess::MODIFY_STATE.bits(),
         )?;
-        let entry = self.event_entry(event_handle)?;
         let previous = entry.with_entry(|entry| op(&entry.event))?;
         if let Some(previous_state) = previous_state
             && previous_state.write_at_offset(0, previous).is_none()

--- a/litebox_shim_windows/src/syscalls/event.rs
+++ b/litebox_shim_windows/src/syscalls/event.rs
@@ -82,10 +82,6 @@ impl<Platform: crate::ShimPlatform> crate::WindowsHandleSubsystem for EventSubsy
     fn normalize_desired_access(desired_access: u32) -> u32 {
         EventAccess::from_desired_access(desired_access).bits()
     }
-
-    fn maximum_allowed_access() -> u32 {
-        EventAccess::ALL_ACCESS.bits()
-    }
 }
 
 pub(crate) struct EventHandleObject<Platform: crate::ShimPlatform> {

--- a/litebox_shim_windows/src/syscalls/event.rs
+++ b/litebox_shim_windows/src/syscalls/event.rs
@@ -70,14 +70,6 @@ impl EventAccess {
             Self::ALL_ACCESS.bits(),
         ))
     }
-
-    fn require(self, required: Self) -> Result<(), NtStatus> {
-        if self.contains(required) {
-            Ok(())
-        } else {
-            Err(NtStatus::ACCESS_DENIED)
-        }
-    }
 }
 
 pub(crate) struct EventSubsystem<Platform>(PhantomData<fn(Platform)>);
@@ -87,6 +79,20 @@ impl<Platform: crate::ShimPlatform> FdEnabledSubsystem for EventSubsystem<Platfo
 }
 
 impl<Platform: crate::ShimPlatform> FdEnabledSubsystemEntry for EventHandleObject<Platform> {}
+
+impl<Platform: crate::ShimPlatform> crate::WindowsHandleSubsystem for EventSubsystem<Platform> {
+    fn granted_access(entry: &Self::Entry) -> u32 {
+        entry.granted_access.bits()
+    }
+
+    fn normalize_desired_access(desired_access: u32) -> u32 {
+        EventAccess::from_desired_access(desired_access).bits()
+    }
+
+    fn maximum_allowed_access() -> u32 {
+        EventAccess::ALL_ACCESS.bits()
+    }
+}
 
 pub(crate) struct EventHandleObject<Platform: crate::ShimPlatform> {
     event: Arc<EventObject<Platform>>,
@@ -158,10 +164,6 @@ impl<Platform: crate::ShimPlatform> EventObject<Platform> {
 }
 
 impl<Platform: crate::ShimPlatform> EventHandleObject<Platform> {
-    pub(crate) fn require_access(&self, required: EventAccess) -> Result<(), NtStatus> {
-        self.granted_access.require(required)
-    }
-
     pub(crate) fn is_signaled(&self) -> bool {
         self.event.is_signaled()
     }
@@ -411,8 +413,10 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
     }
 
     pub(crate) fn check_event_modify_access(&self, event_handle: Handle) -> Result<(), NtStatus> {
-        let entry = self.event_entry(event_handle)?;
-        entry.with_entry(|entry| entry.granted_access.require(EventAccess::MODIFY_STATE))
+        self.require_handle_access::<EventSubsystem<Platform>>(
+            event_handle,
+            EventAccess::MODIFY_STATE.bits(),
+        )
     }
 
     pub(crate) fn sys_nt_reset_event(
@@ -488,19 +492,17 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             return status;
         }
 
-        let Ok(entry) = self.event_entry(event_handle) else {
-            return NtStatus::INVALID_HANDLE;
-        };
-        let query = entry.with_entry(|entry| {
-            entry
-                .granted_access
-                .require(EventAccess::QUERY_STATE)
-                .map(|()| entry.event.query())
-        });
-        let info = match query {
-            Ok(info) => info,
+        if let Err(status) = self.require_handle_access::<EventSubsystem<Platform>>(
+            event_handle,
+            EventAccess::QUERY_STATE.bits(),
+        ) {
+            return status;
+        }
+        let entry = match self.event_entry(event_handle) {
+            Ok(entry) => entry,
             Err(status) => return status,
         };
+        let info = entry.with_entry(|entry| entry.event.query());
         if event_information.write_at_offset(0, info).is_none() {
             return NtStatus::ACCESS_VIOLATION;
         }
@@ -520,11 +522,12 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         previous_state: Option<MutPtr<Platform, i32>>,
         op: impl FnOnce(&EventObject<Platform>) -> Result<i32, NtStatus>,
     ) -> Result<(), NtStatus> {
+        self.require_handle_access::<EventSubsystem<Platform>>(
+            event_handle,
+            EventAccess::MODIFY_STATE.bits(),
+        )?;
         let entry = self.event_entry(event_handle)?;
-        let previous = entry.with_entry(|entry| {
-            entry.granted_access.require(EventAccess::MODIFY_STATE)?;
-            op(&entry.event)
-        })?;
+        let previous = entry.with_entry(|entry| op(&entry.event))?;
         if let Some(previous_state) = previous_state
             && previous_state.write_at_offset(0, previous).is_none()
         {

--- a/litebox_shim_windows/src/syscalls/file.rs
+++ b/litebox_shim_windows/src/syscalls/file.rs
@@ -89,10 +89,6 @@ impl<FS: ShimFS> FdEnabledSubsystem for FileObjectSubsystem<FS> {
 impl<FS: ShimFS> FdEnabledSubsystemEntry for FileObject<FS> {}
 
 impl<FS: ShimFS> crate::WindowsHandleSubsystem for FileObjectSubsystem<FS> {
-    fn granted_access(entry: &Self::Entry) -> u32 {
-        entry.granted_access.bits()
-    }
-
     fn normalize_desired_access(desired_access: u32) -> u32 {
         FileAccess::from_desired_access(desired_access).bits()
     }
@@ -109,11 +105,11 @@ impl<FS: ShimFS> crate::WindowsHandleSubsystem for FileObjectSubsystem<FS> {
         let maximum_allowed = desired_access & AccessMask::MAXIMUM_ALLOWED.bits() != 0;
         let explicit_access =
             FileAccess::from_desired_access(desired_access & !AccessMask::MAXIMUM_ALLOWED.bits());
-        if !entry.granted_access.contains(explicit_access) {
+        if !entry.create_time_access.contains(explicit_access) {
             return Err(NtStatus::ACCESS_DENIED);
         }
         Ok(if maximum_allowed {
-            entry.granted_access.bits()
+            entry.create_time_access.bits()
         } else {
             explicit_access.bits()
         })
@@ -123,7 +119,7 @@ impl<FS: ShimFS> crate::WindowsHandleSubsystem for FileObjectSubsystem<FS> {
 pub(crate) struct FileObject<FS: ShimFS> {
     path: String,
     backing: FileObjectBacking<FS>,
-    granted_access: FileAccess,
+    create_time_access: FileAccess,
     share_access: FileShareAccess,
     create_options: FileCreateOptions,
 }
@@ -430,7 +426,10 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
     }
 
     fn insert_file_handle(&self, file: FileObject<FS>) -> Result<Handle, NtStatus> {
-        self.insert_typed_handle::<FileObjectSubsystem<FS>>(file, |file| self.close_file(file))
+        let granted_access = file.create_time_access.bits();
+        self.insert_typed_handle::<FileObjectSubsystem<FS>>(file, granted_access, |file| {
+            self.close_file(file);
+        })
     }
 
     pub(crate) fn close_file_handle(&self, handle: Handle) {
@@ -785,7 +784,7 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             FileObject {
                 path,
                 backing: FileObjectBacking::Filesystem { fd, is_directory },
-                granted_access: desired_access,
+                create_time_access: desired_access,
                 share_access,
                 create_options,
             },
@@ -858,7 +857,7 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             FileObject {
                 path,
                 backing,
-                granted_access: desired_access,
+                create_time_access: desired_access,
                 share_access,
                 create_options,
             },
@@ -964,7 +963,7 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                     fd,
                     is_directory: true,
                 },
-                granted_access: desired_access,
+                create_time_access: desired_access,
                 share_access,
                 create_options,
             },
@@ -1024,7 +1023,7 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             let conflicts = entry.with_entry(|file| {
                 identity.matches(file)
                     && (desired_access.conflicts_with_share(file.share_access)
-                        || file.granted_access.conflicts_with_share(share_access))
+                        || file.create_time_access.conflicts_with_share(share_access))
             });
             if conflicts {
                 return Err(NtStatus::SHARING_VIOLATION);

--- a/litebox_shim_windows/src/syscalls/file.rs
+++ b/litebox_shim_windows/src/syscalls/file.rs
@@ -93,15 +93,7 @@ impl<FS: ShimFS> crate::WindowsHandleSubsystem for FileObjectSubsystem<FS> {
         FileAccess::from_desired_access(desired_access).bits()
     }
 
-    fn maximum_allowed_access() -> u32 {
-        FileAccess::ALL_ACCESS.bits()
-    }
-
-    fn resolve_duplicate_access(
-        entry: &Self::Entry,
-        _source_access: u32,
-        desired_access: u32,
-    ) -> Result<u32, NtStatus> {
+    fn resolve_duplicate_access(entry: &Self::Entry, desired_access: u32) -> Result<u32, NtStatus> {
         let maximum_allowed = desired_access & AccessMask::MAXIMUM_ALLOWED.bits() != 0;
         let explicit_access =
             FileAccess::from_desired_access(desired_access & !AccessMask::MAXIMUM_ALLOWED.bits());

--- a/litebox_shim_windows/src/syscalls/file.rs
+++ b/litebox_shim_windows/src/syscalls/file.rs
@@ -88,6 +88,38 @@ impl<FS: ShimFS> FdEnabledSubsystem for FileObjectSubsystem<FS> {
 
 impl<FS: ShimFS> FdEnabledSubsystemEntry for FileObject<FS> {}
 
+impl<FS: ShimFS> crate::WindowsHandleSubsystem for FileObjectSubsystem<FS> {
+    fn granted_access(entry: &Self::Entry) -> u32 {
+        entry.granted_access.bits()
+    }
+
+    fn normalize_desired_access(desired_access: u32) -> u32 {
+        FileAccess::from_desired_access(desired_access).bits()
+    }
+
+    fn maximum_allowed_access() -> u32 {
+        FileAccess::ALL_ACCESS.bits()
+    }
+
+    fn resolve_duplicate_access(
+        entry: &Self::Entry,
+        _source_access: u32,
+        desired_access: u32,
+    ) -> Result<u32, NtStatus> {
+        let maximum_allowed = desired_access & AccessMask::MAXIMUM_ALLOWED.bits() != 0;
+        let explicit_access =
+            FileAccess::from_desired_access(desired_access & !AccessMask::MAXIMUM_ALLOWED.bits());
+        if !entry.granted_access.contains(explicit_access) {
+            return Err(NtStatus::ACCESS_DENIED);
+        }
+        Ok(if maximum_allowed {
+            entry.granted_access.bits()
+        } else {
+            explicit_access.bits()
+        })
+    }
+}
+
 pub(crate) struct FileObject<FS: ShimFS> {
     path: String,
     backing: FileObjectBacking<FS>,
@@ -1331,6 +1363,54 @@ mod tests {
     }
 
     #[test]
+    fn nt_duplicate_object_rejects_file_access_escalation() {
+        let task = crate::tests::test_task();
+        create_existing_file(&task, "/tmp/duplicate-read-only.txt", b"data");
+        let (status, source, _) = create_file(
+            &task,
+            "/tmp/duplicate-read-only.txt",
+            FILE_GENERIC_READ,
+            FILE_OPEN,
+        );
+        assert_eq!(status, NtStatus::SUCCESS);
+
+        let mut write_duplicate = Handle::default();
+        assert_eq!(
+            task.sys_nt_duplicate_object(
+                crate::syscalls::ProcessHandle::CURRENT,
+                source,
+                crate::syscalls::ProcessHandle::CURRENT,
+                Some(mut_ptr(&mut write_duplicate)),
+                FileAccess::WRITE_DATA.bits(),
+                0,
+                0,
+            ),
+            NtStatus::ACCESS_DENIED
+        );
+        assert!(write_duplicate.is_null());
+
+        let mut maximum_duplicate = Handle::default();
+        assert_eq!(
+            task.sys_nt_duplicate_object(
+                crate::syscalls::ProcessHandle::CURRENT,
+                source,
+                crate::syscalls::ProcessHandle::CURRENT,
+                Some(mut_ptr(&mut maximum_duplicate)),
+                AccessMask::MAXIMUM_ALLOWED.bits(),
+                0,
+                0,
+            ),
+            NtStatus::SUCCESS
+        );
+        assert_eq!(
+            task.handle_granted_access::<FileObjectSubsystem<TestFS>>(maximum_duplicate),
+            Ok(FileAccess::from_desired_access(FILE_GENERIC_READ).bits())
+        );
+        assert_eq!(task.sys_nt_close(source), NtStatus::SUCCESS);
+        assert_eq!(task.sys_nt_close(maximum_duplicate), NtStatus::SUCCESS);
+    }
+
+    #[test]
     fn nt_create_file_follows_condrv_connection_through_standard_streams() {
         let task = crate::tests::test_task();
         let server_handle = open_condrv_server(&task);
@@ -2315,6 +2395,15 @@ mod tests {
                 Length: u32,
                 FsInformationClass: u32,
             ) -> i32;
+            fn NtDuplicateObject(
+                SourceProcessHandle: *mut c_void,
+                SourceHandle: *mut c_void,
+                TargetProcessHandle: *mut c_void,
+                TargetHandle: *mut c_void,
+                DesiredAccess: u32,
+                HandleAttributes: u32,
+                Options: u32,
+            ) -> i32;
             fn NtClose(Handle: *mut c_void) -> i32;
         }
 
@@ -2704,6 +2793,70 @@ mod tests {
             assert_eq!(host_status, litebox_status.as_raw());
             assert_eq!(host_io_status.status, litebox_io_status.status);
             assert_eq!(host_io_status.information, litebox_io_status.information);
+        }
+
+        #[test]
+        fn nt_duplicate_object_file_access_matrix_matches_host() {
+            let test_dir = test_tmp_dir("nt_duplicate_object_file_access_matrix_matches_host");
+            let _ = std::fs::remove_dir_all(&test_dir);
+            std::fs::create_dir_all(&test_dir).unwrap();
+            let host_file = test_dir.join("read-only-source.txt");
+            std::fs::write(&host_file, b"host").unwrap();
+
+            let host_name_units = utf16(&host_nt_path(&host_file));
+            let host_name = unicode_string(&host_name_units);
+            let host_attributes = host_object_attributes(&host_name);
+            let mut host_source = core::ptr::null_mut();
+            let mut host_io_status = IoStatusBlock::default();
+            // SAFETY: All pointers reference live locals and ObjectName names the test file.
+            assert_eq!(
+                unsafe {
+                    NtOpenFile(
+                        &raw mut host_source,
+                        FILE_GENERIC_READ,
+                        &raw const host_attributes,
+                        &raw mut host_io_status,
+                        FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                        0,
+                    )
+                },
+                NtStatus::SUCCESS.as_raw()
+            );
+            let mut host_write_duplicate: *mut c_void = core::ptr::null_mut();
+            // SAFETY: The process pseudo-handles and source handle are valid; output is a local.
+            assert_eq!(
+                unsafe {
+                    NtDuplicateObject(
+                        usize::MAX as *mut c_void,
+                        host_source,
+                        usize::MAX as *mut c_void,
+                        (&raw mut host_write_duplicate).cast(),
+                        FileAccess::WRITE_DATA.bits(),
+                        0,
+                        0,
+                    )
+                },
+                NtStatus::ACCESS_DENIED.as_raw()
+            );
+            assert!(host_write_duplicate.is_null());
+            let mut host_maximum_duplicate: *mut c_void = core::ptr::null_mut();
+            // SAFETY: The process pseudo-handles and source handle are valid; output is a local.
+            assert_eq!(
+                unsafe {
+                    NtDuplicateObject(
+                        usize::MAX as *mut c_void,
+                        host_source,
+                        usize::MAX as *mut c_void,
+                        (&raw mut host_maximum_duplicate).cast(),
+                        AccessMask::MAXIMUM_ALLOWED.bits(),
+                        0,
+                        0,
+                    )
+                },
+                NtStatus::SUCCESS.as_raw()
+            );
+            close_host_handle(host_source);
+            close_host_handle(host_maximum_duplicate);
         }
 
         #[test]

--- a/litebox_shim_windows/src/syscalls/file.rs
+++ b/litebox_shim_windows/src/syscalls/file.rs
@@ -101,6 +101,8 @@ impl<FS: ShimFS> crate::WindowsHandleSubsystem for FileObjectSubsystem<FS> {
             return Err(NtStatus::ACCESS_DENIED);
         }
         Ok(if maximum_allowed {
+            // TODO(dacl-access-check): Replace this original-open ceiling with a token and
+            // security-descriptor access check when the shim models DACLs.
             entry.create_time_access.bits()
         } else {
             explicit_access.bits()

--- a/litebox_shim_windows/src/syscalls/file.rs
+++ b/litebox_shim_windows/src/syscalls/file.rs
@@ -1402,7 +1402,11 @@ mod tests {
             NtStatus::SUCCESS
         );
         assert_eq!(
-            task.handle_granted_access::<FileObjectSubsystem<TestFS>>(maximum_duplicate),
+            task.typed_handle::<FileObjectSubsystem<TestFS>>(maximum_duplicate)
+                .and_then(|typed| {
+                    task.typed_handle_metadata(&typed)
+                        .map(|metadata| metadata.granted_access)
+                }),
             Ok(FileAccess::from_desired_access(FILE_GENERIC_READ).bits())
         );
         assert_eq!(task.sys_nt_close(source), NtStatus::SUCCESS);

--- a/litebox_shim_windows/src/syscalls/iocp.rs
+++ b/litebox_shim_windows/src/syscalls/iocp.rs
@@ -54,10 +54,6 @@ impl<Platform: crate::ShimPlatform> FdEnabledSubsystemEntry for IoCompletionHand
 impl<Platform: crate::ShimPlatform> crate::WindowsHandleSubsystem
     for IoCompletionSubsystem<Platform>
 {
-    fn granted_access(entry: &Self::Entry) -> u32 {
-        entry.granted_access.bits()
-    }
-
     fn normalize_desired_access(desired_access: u32) -> u32 {
         IoCompletionAccess::from_desired_access(desired_access).bits()
     }
@@ -69,7 +65,6 @@ impl<Platform: crate::ShimPlatform> crate::WindowsHandleSubsystem
 
 pub(crate) struct IoCompletionHandleObject<Platform: crate::ShimPlatform> {
     port: Arc<IoCompletionObject<Platform>>,
-    granted_access: IoCompletionAccess,
 }
 
 pub(crate) struct IoCompletionObject<Platform: crate::ShimPlatform> {
@@ -112,10 +107,8 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         granted_access: IoCompletionAccess,
     ) -> Result<Handle, NtStatus> {
         self.insert_typed_handle::<IoCompletionSubsystem<Platform>>(
-            IoCompletionHandleObject {
-                port,
-                granted_access,
-            },
+            IoCompletionHandleObject { port },
+            granted_access.bits(),
             drop,
         )
     }

--- a/litebox_shim_windows/src/syscalls/iocp.rs
+++ b/litebox_shim_windows/src/syscalls/iocp.rs
@@ -57,10 +57,6 @@ impl<Platform: crate::ShimPlatform> crate::WindowsHandleSubsystem
     fn normalize_desired_access(desired_access: u32) -> u32 {
         IoCompletionAccess::from_desired_access(desired_access).bits()
     }
-
-    fn maximum_allowed_access() -> u32 {
-        IoCompletionAccess::ALL_ACCESS.bits()
-    }
 }
 
 pub(crate) struct IoCompletionHandleObject<Platform: crate::ShimPlatform> {

--- a/litebox_shim_windows/src/syscalls/iocp.rs
+++ b/litebox_shim_windows/src/syscalls/iocp.rs
@@ -41,14 +41,6 @@ impl IoCompletionAccess {
             Self::ALL_ACCESS.bits(),
         ))
     }
-
-    pub(crate) fn require(self, required: Self) -> Result<(), NtStatus> {
-        if self.contains(required) {
-            Ok(())
-        } else {
-            Err(NtStatus::ACCESS_DENIED)
-        }
-    }
 }
 
 pub(crate) struct IoCompletionSubsystem<Platform>(PhantomData<fn(Platform)>);
@@ -58,6 +50,22 @@ impl<Platform: crate::ShimPlatform> FdEnabledSubsystem for IoCompletionSubsystem
 }
 
 impl<Platform: crate::ShimPlatform> FdEnabledSubsystemEntry for IoCompletionHandleObject<Platform> {}
+
+impl<Platform: crate::ShimPlatform> crate::WindowsHandleSubsystem
+    for IoCompletionSubsystem<Platform>
+{
+    fn granted_access(entry: &Self::Entry) -> u32 {
+        entry.granted_access.bits()
+    }
+
+    fn normalize_desired_access(desired_access: u32) -> u32 {
+        IoCompletionAccess::from_desired_access(desired_access).bits()
+    }
+
+    fn maximum_allowed_access() -> u32 {
+        IoCompletionAccess::ALL_ACCESS.bits()
+    }
+}
 
 pub(crate) struct IoCompletionHandleObject<Platform: crate::ShimPlatform> {
     port: Arc<IoCompletionObject<Platform>>,
@@ -81,10 +89,6 @@ impl<Platform: crate::ShimPlatform> IoCompletionObject<Platform> {
 impl<Platform: crate::ShimPlatform> IoCompletionHandleObject<Platform> {
     pub(crate) fn port(&self) -> Arc<IoCompletionObject<Platform>> {
         self.port.clone()
-    }
-
-    pub(crate) fn require_access(&self, required: IoCompletionAccess) -> Result<(), NtStatus> {
-        self.granted_access.require(required)
     }
 }
 

--- a/litebox_shim_windows/src/syscalls/lpc.rs
+++ b/litebox_shim_windows/src/syscalls/lpc.rs
@@ -29,10 +29,6 @@ impl<Platform: ShimPlatform> FdEnabledSubsystem for LpcPortSubsystem<Platform> {
 impl FdEnabledSubsystemEntry for LpcPortHandleObject {}
 
 impl<Platform: ShimPlatform> crate::WindowsHandleSubsystem for LpcPortSubsystem<Platform> {
-    fn granted_access(_entry: &Self::Entry) -> u32 {
-        0
-    }
-
     fn normalize_desired_access(desired_access: u32) -> u32 {
         desired_access
     }
@@ -180,7 +176,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         let port = LpcPortHandleObject {
             _port_name: port_name.clone(),
         };
-        let handle = match self.insert_typed_handle::<LpcPortSubsystem<Platform>>(port, drop) {
+        let handle = match self.insert_typed_handle::<LpcPortSubsystem<Platform>>(port, 0, drop) {
             Ok(handle) => handle,
             Err(status) => {
                 self.rollback_pagefile_section_view(mapped_view.base);

--- a/litebox_shim_windows/src/syscalls/lpc.rs
+++ b/litebox_shim_windows/src/syscalls/lpc.rs
@@ -33,8 +33,11 @@ impl<Platform: ShimPlatform> crate::WindowsHandleSubsystem for LpcPortSubsystem<
         desired_access
     }
 
-    fn maximum_allowed_access() -> u32 {
-        0
+    fn resolve_duplicate_access(
+        _entry: &Self::Entry,
+        desired_access: u32,
+    ) -> Result<u32, NtStatus> {
+        Ok(desired_access & !crate::nt_types::AccessMask::MAXIMUM_ALLOWED.bits())
     }
 }
 

--- a/litebox_shim_windows/src/syscalls/lpc.rs
+++ b/litebox_shim_windows/src/syscalls/lpc.rs
@@ -28,6 +28,20 @@ impl<Platform: ShimPlatform> FdEnabledSubsystem for LpcPortSubsystem<Platform> {
 
 impl FdEnabledSubsystemEntry for LpcPortHandleObject {}
 
+impl<Platform: ShimPlatform> crate::WindowsHandleSubsystem for LpcPortSubsystem<Platform> {
+    fn granted_access(_entry: &Self::Entry) -> u32 {
+        0
+    }
+
+    fn normalize_desired_access(desired_access: u32) -> u32 {
+        desired_access
+    }
+
+    fn maximum_allowed_access() -> u32 {
+        0
+    }
+}
+
 pub(crate) struct LpcPortHandleObject {
     _port_name: String,
 }

--- a/litebox_shim_windows/src/syscalls/mod.rs
+++ b/litebox_shim_windows/src/syscalls/mod.rs
@@ -124,6 +124,15 @@ pub(crate) enum SyscallRequest<Platform: RawPointerProvider> {
     NtClose {
         handle: Handle,
     },
+    NtDuplicateObject {
+        source_process_handle: ProcessHandle,
+        source_handle: Handle,
+        target_process_handle: ProcessHandle,
+        target_handle: Option<Platform::RawMutPointer<Handle>>,
+        desired_access: u32,
+        handle_attributes: u32,
+        options: u32,
+    },
     NtCreateEvent {
         event_handle: Platform::RawMutPointer<Handle>,
         desired_access: u32,
@@ -554,6 +563,15 @@ impl<Platform: RawPointerProvider> SyscallRequest<Platform> {
         match NtSysno::from_raw(pt_regs.orig_rax)? {
             NtSysno::NtClose => Some(sys_req!(NtClose {
                 handle: { Handle::from_raw },
+            })),
+            NtSysno::NtDuplicateObject => Some(sys_req!(NtDuplicateObject {
+                source_process_handle: { ProcessHandle::from_raw },
+                source_handle: { Handle::from_raw },
+                target_process_handle: { ProcessHandle::from_raw },
+                target_handle:*,
+                desired_access,
+                handle_attributes,
+                options,
             })),
             NtSysno::NtCreateEvent => Some(sys_req!(NtCreateEvent {
                 event_handle:*,

--- a/litebox_shim_windows/src/syscalls/object_manager.rs
+++ b/litebox_shim_windows/src/syscalls/object_manager.rs
@@ -123,10 +123,6 @@ impl<Platform: crate::ShimPlatform> crate::WindowsHandleSubsystem
     fn normalize_desired_access(desired_access: u32) -> u32 {
         DirectoryAccess::from_desired_access(desired_access).bits()
     }
-
-    fn maximum_allowed_access() -> u32 {
-        DirectoryAccess::ALL_ACCESS.bits()
-    }
 }
 
 pub(crate) struct DirectoryHandleObject<Platform: crate::ShimPlatform> {

--- a/litebox_shim_windows/src/syscalls/object_manager.rs
+++ b/litebox_shim_windows/src/syscalls/object_manager.rs
@@ -1001,11 +1001,10 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         &self,
         handle: Handle,
     ) -> Result<Arc<ObjectNode<Platform>>, NtStatus> {
-        self.require_handle_access::<DirectoryObjectSubsystem<Platform>>(
+        let entry = self.typed_handle_entry_with_access::<DirectoryObjectSubsystem<Platform>>(
             handle,
             DirectoryAccess::TRAVERSE.bits(),
         )?;
-        let entry = self.directory_entry(handle)?;
         Ok(entry.with_entry(|entry| Arc::clone(&entry.directory)))
     }
 
@@ -1225,13 +1224,10 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         &self,
         params: DirectoryQueryParameters<Platform>,
     ) -> NtStatus {
-        if let Err(status) = self.require_handle_access::<DirectoryObjectSubsystem<Platform>>(
+        let entry = match self.typed_handle_entry_with_access::<DirectoryObjectSubsystem<Platform>>(
             params.directory_handle,
             DirectoryAccess::QUERY.bits(),
         ) {
-            return status;
-        }
-        let entry = match self.directory_entry(params.directory_handle) {
             Ok(entry) => entry,
             Err(status) => return status,
         };

--- a/litebox_shim_windows/src/syscalls/object_manager.rs
+++ b/litebox_shim_windows/src/syscalls/object_manager.rs
@@ -120,10 +120,6 @@ impl<Platform: crate::ShimPlatform> FdEnabledSubsystemEntry for DirectoryHandleO
 impl<Platform: crate::ShimPlatform> crate::WindowsHandleSubsystem
     for DirectoryObjectSubsystem<Platform>
 {
-    fn granted_access(entry: &Self::Entry) -> u32 {
-        entry.granted_access.bits()
-    }
-
     fn normalize_desired_access(desired_access: u32) -> u32 {
         DirectoryAccess::from_desired_access(desired_access).bits()
     }
@@ -135,7 +131,6 @@ impl<Platform: crate::ShimPlatform> crate::WindowsHandleSubsystem
 
 pub(crate) struct DirectoryHandleObject<Platform: crate::ShimPlatform> {
     directory: Arc<ObjectNode<Platform>>,
-    granted_access: DirectoryAccess,
 }
 
 pub(super) struct ObjectNode<Platform: crate::ShimPlatform> {
@@ -1081,10 +1076,8 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         granted_access: DirectoryAccess,
     ) -> Result<Handle, NtStatus> {
         self.insert_typed_handle::<DirectoryObjectSubsystem<Platform>>(
-            DirectoryHandleObject {
-                directory,
-                granted_access,
-            },
+            DirectoryHandleObject { directory },
+            granted_access.bits(),
             drop,
         )
     }

--- a/litebox_shim_windows/src/syscalls/object_manager.rs
+++ b/litebox_shim_windows/src/syscalls/object_manager.rs
@@ -107,14 +107,6 @@ impl DirectoryAccess {
             Self::ALL_ACCESS.bits(),
         ))
     }
-
-    fn require(self, required: Self) -> Result<(), NtStatus> {
-        if self.contains(required) {
-            Ok(())
-        } else {
-            Err(NtStatus::ACCESS_DENIED)
-        }
-    }
 }
 
 pub(crate) struct DirectoryObjectSubsystem<Platform>(PhantomData<fn(Platform)>);
@@ -124,6 +116,22 @@ impl<Platform: crate::ShimPlatform> FdEnabledSubsystem for DirectoryObjectSubsys
 }
 
 impl<Platform: crate::ShimPlatform> FdEnabledSubsystemEntry for DirectoryHandleObject<Platform> {}
+
+impl<Platform: crate::ShimPlatform> crate::WindowsHandleSubsystem
+    for DirectoryObjectSubsystem<Platform>
+{
+    fn granted_access(entry: &Self::Entry) -> u32 {
+        entry.granted_access.bits()
+    }
+
+    fn normalize_desired_access(desired_access: u32) -> u32 {
+        DirectoryAccess::from_desired_access(desired_access).bits()
+    }
+
+    fn maximum_allowed_access() -> u32 {
+        DirectoryAccess::ALL_ACCESS.bits()
+    }
+}
 
 pub(crate) struct DirectoryHandleObject<Platform: crate::ShimPlatform> {
     directory: Arc<ObjectNode<Platform>>,
@@ -998,11 +1006,12 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         &self,
         handle: Handle,
     ) -> Result<Arc<ObjectNode<Platform>>, NtStatus> {
+        self.require_handle_access::<DirectoryObjectSubsystem<Platform>>(
+            handle,
+            DirectoryAccess::TRAVERSE.bits(),
+        )?;
         let entry = self.directory_entry(handle)?;
-        entry.with_entry(|entry| {
-            entry.granted_access.require(DirectoryAccess::TRAVERSE)?;
-            Ok(Arc::clone(&entry.directory))
-        })
+        Ok(entry.with_entry(|entry| Arc::clone(&entry.directory)))
     }
 
     pub(super) fn read_directory_object_attributes(
@@ -1223,15 +1232,16 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         &self,
         params: DirectoryQueryParameters<Platform>,
     ) -> NtStatus {
+        if let Err(status) = self.require_handle_access::<DirectoryObjectSubsystem<Platform>>(
+            params.directory_handle,
+            DirectoryAccess::QUERY.bits(),
+        ) {
+            return status;
+        }
         let entry = match self.directory_entry(params.directory_handle) {
             Ok(entry) => entry,
             Err(status) => return status,
         };
-        if let Err(status) =
-            entry.with_entry(|entry| entry.granted_access.require(DirectoryAccess::QUERY))
-        {
-            return status;
-        }
         let directory = entry.with_entry(|entry| Arc::clone(&entry.directory));
         let entries = match directory.children_snapshot() {
             Ok(entries) => entries,

--- a/litebox_shim_windows/src/syscalls/registry.rs
+++ b/litebox_shim_windows/src/syscalls/registry.rs
@@ -65,10 +65,6 @@ impl<Platform: crate::ShimPlatform> FdEnabledSubsystemEntry for RegistryKeyObjec
 impl<Platform: crate::ShimPlatform> crate::WindowsHandleSubsystem
     for RegistryKeySubsystem<Platform>
 {
-    fn granted_access(entry: &Self::Entry) -> u32 {
-        entry.granted_access.bits()
-    }
-
     fn normalize_desired_access(desired_access: u32) -> u32 {
         RegistryKeyAccess::from_desired_access(desired_access).bits()
     }
@@ -81,7 +77,6 @@ impl<Platform: crate::ShimPlatform> crate::WindowsHandleSubsystem
 pub(crate) struct RegistryKeyObject<Platform: crate::ShimPlatform> {
     path: String,
     fd: TypedFd<RegistryFileSystem<Platform>>,
-    granted_access: RegistryKeyAccess,
 }
 
 pub(crate) struct RegistryStore<Platform: crate::ShimPlatform> {
@@ -379,10 +374,15 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
     fn insert_registry_key_handle(
         &self,
         key: RegistryKeyObject<Platform>,
+        granted_access: RegistryKeyAccess,
     ) -> Result<Handle, NtStatus> {
-        self.insert_typed_handle::<RegistryKeySubsystem<Platform>>(key, |key| {
-            self.close_registry_key(key);
-        })
+        self.insert_typed_handle::<RegistryKeySubsystem<Platform>>(
+            key,
+            granted_access.bits(),
+            |key| {
+                self.close_registry_key(key);
+            },
+        )
     }
 
     pub(crate) fn close_registry_key_handle(&self, handle: Handle) {
@@ -461,11 +461,7 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                     );
                 }
             })?;
-        self.insert_registry_key_handle(RegistryKeyObject {
-            path,
-            fd,
-            granted_access: desired_access,
-        })
+        self.insert_registry_key_handle(RegistryKeyObject { path, fd }, desired_access)
     }
 
     pub(crate) fn sys_nt_query_value_key(

--- a/litebox_shim_windows/src/syscalls/registry.rs
+++ b/litebox_shim_windows/src/syscalls/registry.rs
@@ -68,10 +68,6 @@ impl<Platform: crate::ShimPlatform> crate::WindowsHandleSubsystem
     fn normalize_desired_access(desired_access: u32) -> u32 {
         RegistryKeyAccess::from_desired_access(desired_access).bits()
     }
-
-    fn maximum_allowed_access() -> u32 {
-        RegistryKeyAccess::ALL_ACCESS.bits()
-    }
 }
 
 pub(crate) struct RegistryKeyObject<Platform: crate::ShimPlatform> {

--- a/litebox_shim_windows/src/syscalls/registry.rs
+++ b/litebox_shim_windows/src/syscalls/registry.rs
@@ -507,11 +507,10 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         length: u32,
         result_length: MutPtr<Platform, u32>,
     ) -> Result<(), NtStatus> {
-        self.require_handle_access::<RegistryKeySubsystem<Platform>>(
+        let key = self.typed_handle_entry_with_access::<RegistryKeySubsystem<Platform>>(
             key_handle,
             RegistryKeyAccess::QUERY_VALUE.bits(),
         )?;
-        let key = self.registry_key_entry(key_handle)?;
         let value_name = value_name.read_string::<Platform>()?;
         let value = key.with_entry(|key| {
             // TODO: Open the value relative to `key.fd` once the FS has an openat-style API.

--- a/litebox_shim_windows/src/syscalls/registry.rs
+++ b/litebox_shim_windows/src/syscalls/registry.rs
@@ -62,6 +62,22 @@ impl<Platform: crate::ShimPlatform> FdEnabledSubsystem for RegistryKeySubsystem<
 
 impl<Platform: crate::ShimPlatform> FdEnabledSubsystemEntry for RegistryKeyObject<Platform> {}
 
+impl<Platform: crate::ShimPlatform> crate::WindowsHandleSubsystem
+    for RegistryKeySubsystem<Platform>
+{
+    fn granted_access(entry: &Self::Entry) -> u32 {
+        entry.granted_access.bits()
+    }
+
+    fn normalize_desired_access(desired_access: u32) -> u32 {
+        RegistryKeyAccess::from_desired_access(desired_access).bits()
+    }
+
+    fn maximum_allowed_access() -> u32 {
+        RegistryKeyAccess::ALL_ACCESS.bits()
+    }
+}
+
 pub(crate) struct RegistryKeyObject<Platform: crate::ShimPlatform> {
     path: String,
     fd: TypedFd<RegistryFileSystem<Platform>>,
@@ -132,6 +148,18 @@ bitflags::bitflags! {
     }
 }
 
+impl RegistryKeyAccess {
+    fn from_desired_access(desired_access: u32) -> Self {
+        Self::from_bits_retain(AccessMask::expand_generic_access(
+            desired_access,
+            Self::READ.bits(),
+            Self::WRITE.bits(),
+            Self::EXECUTE.bits(),
+            Self::ALL_ACCESS.bits(),
+        ))
+    }
+}
+
 impl From<RegistryKeyAccess> for OFlags {
     fn from(desired_access: RegistryKeyAccess) -> Self {
         let wants_read = desired_access.intersects(RegistryKeyAccess::FS_READ_ACCESS);
@@ -143,16 +171,6 @@ impl From<RegistryKeyAccess> for OFlags {
             _ => OFlags::RDONLY,
         };
         access | OFlags::DIRECTORY
-    }
-}
-
-impl RegistryKeyAccess {
-    fn can_query_value(self) -> bool {
-        const QUERY_ACCESS_BITS: u32 = RegistryKeyAccess::QUERY_VALUE.bits()
-            | AccessMask::GENERIC_READ.bits()
-            | AccessMask::GENERIC_EXECUTE.bits()
-            | AccessMask::GENERIC_ALL.bits();
-        self.intersects(Self::from_bits_retain(QUERY_ACCESS_BITS))
     }
 }
 
@@ -426,7 +444,7 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                 .with_entry(|root_key| relative_nt_key_name_to_fs_path(&root_key.path, &key_name))?
         };
 
-        let desired_access = RegistryKeyAccess::from_bits_retain(desired_access);
+        let desired_access = RegistryKeyAccess::from_desired_access(desired_access);
         let fd = self
             .global
             .registry
@@ -493,12 +511,13 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         length: u32,
         result_length: MutPtr<Platform, u32>,
     ) -> Result<(), NtStatus> {
+        self.require_handle_access::<RegistryKeySubsystem<Platform>>(
+            key_handle,
+            RegistryKeyAccess::QUERY_VALUE.bits(),
+        )?;
         let key = self.registry_key_entry(key_handle)?;
         let value_name = value_name.read_string::<Platform>()?;
         let value = key.with_entry(|key| {
-            if !key.granted_access.can_query_value() {
-                return Err(NtStatus::ACCESS_DENIED);
-            }
             // TODO: Open the value relative to `key.fd` once the FS has an openat-style API.
             self.global
                 .registry

--- a/litebox_shim_windows/src/syscalls/section.rs
+++ b/litebox_shim_windows/src/syscalls/section.rs
@@ -61,6 +61,20 @@ impl<Platform: ShimPlatform> FdEnabledSubsystem for SectionSubsystem<Platform> {
 
 impl<Platform: ShimPlatform> FdEnabledSubsystemEntry for SectionHandleObject<Platform> {}
 
+impl<Platform: ShimPlatform> crate::WindowsHandleSubsystem for SectionSubsystem<Platform> {
+    fn granted_access(entry: &Self::Entry) -> u32 {
+        entry.granted_access.bits()
+    }
+
+    fn normalize_desired_access(desired_access: u32) -> u32 {
+        SectionAccess::from_desired_access(desired_access).bits()
+    }
+
+    fn maximum_allowed_access() -> u32 {
+        SectionAccess::ALL_ACCESS.bits()
+    }
+}
+
 pub(crate) struct SectionHandleObject<Platform: ShimPlatform> {
     section: Arc<SectionObject<Platform>>,
     granted_access: SectionAccess,
@@ -165,14 +179,6 @@ impl SectionAccess {
             access.insert(Self::ALL_ACCESS);
         }
         access
-    }
-
-    fn require(self, required: Self) -> Result<(), NtStatus> {
-        if self.contains(required) {
-            Ok(())
-        } else {
-            Err(NtStatus::ACCESS_DENIED)
-        }
     }
 }
 
@@ -451,20 +457,17 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         else {
             return NtStatus::INVALID_INFO_CLASS;
         };
+        if let Err(status) = self.require_handle_access::<SectionSubsystem<Platform>>(
+            section_handle,
+            SectionAccess::QUERY.bits(),
+        ) {
+            return status;
+        }
         let entry = match self.section_entry(section_handle) {
             Ok(entry) => entry,
             Err(status) => return status,
         };
-        let result = entry.with_entry(|entry| {
-            entry
-                .granted_access
-                .require(SectionAccess::QUERY)
-                .map(|()| Arc::clone(&entry.section))
-        });
-        let section = match result {
-            Ok(section) => section,
-            Err(status) => return status,
-        };
+        let section = entry.with_entry(|entry| Arc::clone(&entry.section));
         match information_class {
             SectionInformationClass::Basic => write_section_basic_information::<Platform>(
                 &section,
@@ -516,20 +519,17 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         else {
             return NtStatus::INVALID_PAGE_PROTECTION;
         };
+        if let Err(status) = self.require_handle_access::<SectionSubsystem<Platform>>(
+            request.section_handle,
+            required_map_access(page_protection).bits(),
+        ) {
+            return status;
+        }
         let entry = match self.section_entry(request.section_handle) {
             Ok(entry) => entry,
             Err(status) => return status,
         };
-        let result = entry.with_entry(|entry| {
-            entry
-                .granted_access
-                .require(required_map_access(page_protection))
-                .map(|()| Arc::clone(&entry.section))
-        });
-        let section = match result {
-            Ok(section) => section,
-            Err(status) => return status,
-        };
+        let section = entry.with_entry(|entry| Arc::clone(&entry.section));
         match section.backing {
             SectionBacking::Pagefile => self.map_pagefile_section(
                 request,
@@ -659,13 +659,12 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         section_handle: Handle,
         requested_view_size: usize,
     ) -> Result<MappedPagefileSectionView, NtStatus> {
+        self.require_handle_access::<SectionSubsystem<Platform>>(
+            section_handle,
+            (SectionAccess::MAP_READ | SectionAccess::MAP_WRITE).bits(),
+        )?;
         let entry = self.section_entry(section_handle)?;
-        let section = entry.with_entry(|entry| {
-            entry
-                .granted_access
-                .require(SectionAccess::MAP_READ | SectionAccess::MAP_WRITE)
-                .map(|()| Arc::clone(&entry.section))
-        })?;
+        let section = entry.with_entry(|entry| Arc::clone(&entry.section));
         let page_protection = PageProtection::PAGE_READWRITE;
         let Some((_, permissions)) = parse_page_protection(page_protection.bits()) else {
             return Err(NtStatus::INVALID_PAGE_PROTECTION);

--- a/litebox_shim_windows/src/syscalls/section.rs
+++ b/litebox_shim_windows/src/syscalls/section.rs
@@ -220,13 +220,6 @@ struct SectionImageInformation {
 const _: () = assert!(size_of::<SectionImageInformation>() == 64);
 
 impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
-    fn section_entry(
-        &self,
-        handle: Handle,
-    ) -> Result<litebox::fd::EntryHandle<Platform, SectionSubsystem<Platform>>, NtStatus> {
-        self.typed_handle_entry::<SectionSubsystem<Platform>>(handle)
-    }
-
     fn insert_section_handle(
         &self,
         section: Arc<SectionObject<Platform>>,
@@ -450,13 +443,10 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         else {
             return NtStatus::INVALID_INFO_CLASS;
         };
-        if let Err(status) = self.require_handle_access::<SectionSubsystem<Platform>>(
+        let entry = match self.typed_handle_entry_with_access::<SectionSubsystem<Platform>>(
             section_handle,
             SectionAccess::QUERY.bits(),
         ) {
-            return status;
-        }
-        let entry = match self.section_entry(section_handle) {
             Ok(entry) => entry,
             Err(status) => return status,
         };
@@ -512,13 +502,10 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         else {
             return NtStatus::INVALID_PAGE_PROTECTION;
         };
-        if let Err(status) = self.require_handle_access::<SectionSubsystem<Platform>>(
+        let entry = match self.typed_handle_entry_with_access::<SectionSubsystem<Platform>>(
             request.section_handle,
             required_map_access(page_protection).bits(),
         ) {
-            return status;
-        }
-        let entry = match self.section_entry(request.section_handle) {
             Ok(entry) => entry,
             Err(status) => return status,
         };
@@ -652,11 +639,10 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         section_handle: Handle,
         requested_view_size: usize,
     ) -> Result<MappedPagefileSectionView, NtStatus> {
-        self.require_handle_access::<SectionSubsystem<Platform>>(
+        let entry = self.typed_handle_entry_with_access::<SectionSubsystem<Platform>>(
             section_handle,
             (SectionAccess::MAP_READ | SectionAccess::MAP_WRITE).bits(),
         )?;
-        let entry = self.section_entry(section_handle)?;
         let section = entry.with_entry(|entry| Arc::clone(&entry.section));
         let page_protection = PageProtection::PAGE_READWRITE;
         let Some((_, permissions)) = parse_page_protection(page_protection.bits()) else {

--- a/litebox_shim_windows/src/syscalls/section.rs
+++ b/litebox_shim_windows/src/syscalls/section.rs
@@ -65,10 +65,6 @@ impl<Platform: ShimPlatform> crate::WindowsHandleSubsystem for SectionSubsystem<
     fn normalize_desired_access(desired_access: u32) -> u32 {
         SectionAccess::from_desired_access(desired_access).bits()
     }
-
-    fn maximum_allowed_access() -> u32 {
-        SectionAccess::ALL_ACCESS.bits()
-    }
 }
 
 pub(crate) struct SectionHandleObject<Platform: ShimPlatform> {

--- a/litebox_shim_windows/src/syscalls/section.rs
+++ b/litebox_shim_windows/src/syscalls/section.rs
@@ -62,10 +62,6 @@ impl<Platform: ShimPlatform> FdEnabledSubsystem for SectionSubsystem<Platform> {
 impl<Platform: ShimPlatform> FdEnabledSubsystemEntry for SectionHandleObject<Platform> {}
 
 impl<Platform: ShimPlatform> crate::WindowsHandleSubsystem for SectionSubsystem<Platform> {
-    fn granted_access(entry: &Self::Entry) -> u32 {
-        entry.granted_access.bits()
-    }
-
     fn normalize_desired_access(desired_access: u32) -> u32 {
         SectionAccess::from_desired_access(desired_access).bits()
     }
@@ -77,7 +73,6 @@ impl<Platform: ShimPlatform> crate::WindowsHandleSubsystem for SectionSubsystem<
 
 pub(crate) struct SectionHandleObject<Platform: ShimPlatform> {
     section: Arc<SectionObject<Platform>>,
-    granted_access: SectionAccess,
 }
 
 pub(crate) struct SectionObject<Platform: ShimPlatform> {
@@ -238,10 +233,8 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         granted_access: SectionAccess,
     ) -> Result<Handle, NtStatus> {
         self.insert_typed_handle::<SectionSubsystem<Platform>>(
-            SectionHandleObject {
-                section,
-                granted_access,
-            },
+            SectionHandleObject { section },
+            granted_access.bits(),
             drop,
         )
     }

--- a/litebox_shim_windows/src/syscalls/symlink.rs
+++ b/litebox_shim_windows/src/syscalls/symlink.rs
@@ -48,14 +48,6 @@ impl SymbolicLinkAccess {
             Self::ALL_ACCESS.bits(),
         ))
     }
-
-    fn require(self, required: Self) -> Result<(), NtStatus> {
-        if self.contains(required) {
-            Ok(())
-        } else {
-            Err(NtStatus::ACCESS_DENIED)
-        }
-    }
 }
 
 pub(crate) struct SymbolicLinkSubsystem<Platform>(PhantomData<fn(Platform)>);
@@ -65,6 +57,22 @@ impl<Platform: crate::ShimPlatform> FdEnabledSubsystem for SymbolicLinkSubsystem
 }
 
 impl<Platform: crate::ShimPlatform> FdEnabledSubsystemEntry for SymbolicLinkHandleObject<Platform> {}
+
+impl<Platform: crate::ShimPlatform> crate::WindowsHandleSubsystem
+    for SymbolicLinkSubsystem<Platform>
+{
+    fn granted_access(entry: &Self::Entry) -> u32 {
+        entry.granted_access.bits()
+    }
+
+    fn normalize_desired_access(desired_access: u32) -> u32 {
+        SymbolicLinkAccess::from_desired_access(desired_access).bits()
+    }
+
+    fn maximum_allowed_access() -> u32 {
+        SymbolicLinkAccess::ALL_ACCESS.bits()
+    }
+}
 
 pub(crate) struct SymbolicLinkHandleObject<Platform: crate::ShimPlatform> {
     link: Arc<ObjectNode<Platform>>,
@@ -234,15 +242,16 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         link_target: MutPtr<Platform, UnicodeString>,
         returned_length: Option<MutPtr<Platform, u32>>,
     ) -> NtStatus {
+        if let Err(status) = self.require_handle_access::<SymbolicLinkSubsystem<Platform>>(
+            link_handle,
+            SymbolicLinkAccess::QUERY.bits(),
+        ) {
+            return status;
+        }
         let entry = match self.symbolic_link_entry(link_handle) {
             Ok(entry) => entry,
             Err(status) => return status,
         };
-        if let Err(status) =
-            entry.with_entry(|entry| entry.granted_access.require(SymbolicLinkAccess::QUERY))
-        {
-            return status;
-        }
         if let Err(status) = probe_guest_output_preserving_value::<Platform, _>(link_target) {
             return status;
         }

--- a/litebox_shim_windows/src/syscalls/symlink.rs
+++ b/litebox_shim_windows/src/syscalls/symlink.rs
@@ -64,10 +64,6 @@ impl<Platform: crate::ShimPlatform> crate::WindowsHandleSubsystem
     fn normalize_desired_access(desired_access: u32) -> u32 {
         SymbolicLinkAccess::from_desired_access(desired_access).bits()
     }
-
-    fn maximum_allowed_access() -> u32 {
-        SymbolicLinkAccess::ALL_ACCESS.bits()
-    }
 }
 
 pub(crate) struct SymbolicLinkHandleObject<Platform: crate::ShimPlatform> {

--- a/litebox_shim_windows/src/syscalls/symlink.rs
+++ b/litebox_shim_windows/src/syscalls/symlink.rs
@@ -87,13 +87,6 @@ fn utf16_units(value: &str) -> Result<Vec<u16>, NtStatus> {
 }
 
 impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
-    fn symbolic_link_entry(
-        &self,
-        handle: Handle,
-    ) -> Result<litebox::fd::EntryHandle<Platform, SymbolicLinkSubsystem<Platform>>, NtStatus> {
-        self.typed_handle_entry::<SymbolicLinkSubsystem<Platform>>(handle)
-    }
-
     fn insert_symbolic_link_handle(
         &self,
         link: Arc<ObjectNode<Platform>>,
@@ -235,13 +228,10 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         link_target: MutPtr<Platform, UnicodeString>,
         returned_length: Option<MutPtr<Platform, u32>>,
     ) -> NtStatus {
-        if let Err(status) = self.require_handle_access::<SymbolicLinkSubsystem<Platform>>(
+        let entry = match self.typed_handle_entry_with_access::<SymbolicLinkSubsystem<Platform>>(
             link_handle,
             SymbolicLinkAccess::QUERY.bits(),
         ) {
-            return status;
-        }
-        let entry = match self.symbolic_link_entry(link_handle) {
             Ok(entry) => entry,
             Err(status) => return status,
         };

--- a/litebox_shim_windows/src/syscalls/symlink.rs
+++ b/litebox_shim_windows/src/syscalls/symlink.rs
@@ -61,10 +61,6 @@ impl<Platform: crate::ShimPlatform> FdEnabledSubsystemEntry for SymbolicLinkHand
 impl<Platform: crate::ShimPlatform> crate::WindowsHandleSubsystem
     for SymbolicLinkSubsystem<Platform>
 {
-    fn granted_access(entry: &Self::Entry) -> u32 {
-        entry.granted_access.bits()
-    }
-
     fn normalize_desired_access(desired_access: u32) -> u32 {
         SymbolicLinkAccess::from_desired_access(desired_access).bits()
     }
@@ -76,7 +72,6 @@ impl<Platform: crate::ShimPlatform> crate::WindowsHandleSubsystem
 
 pub(crate) struct SymbolicLinkHandleObject<Platform: crate::ShimPlatform> {
     link: Arc<ObjectNode<Platform>>,
-    granted_access: SymbolicLinkAccess,
 }
 
 fn utf16_units(value: &str) -> Result<Vec<u16>, NtStatus> {
@@ -105,10 +100,8 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         granted_access: SymbolicLinkAccess,
     ) -> Result<Handle, NtStatus> {
         self.insert_typed_handle::<SymbolicLinkSubsystem<Platform>>(
-            SymbolicLinkHandleObject {
-                link,
-                granted_access,
-            },
+            SymbolicLinkHandleObject { link },
+            granted_access.bits(),
             drop,
         )
     }

--- a/litebox_shim_windows/src/syscalls/timer.rs
+++ b/litebox_shim_windows/src/syscalls/timer.rs
@@ -73,10 +73,6 @@ impl<Platform: crate::ShimPlatform> FdEnabledSubsystem for TimerSubsystem<Platfo
 impl<Platform: crate::ShimPlatform> FdEnabledSubsystemEntry for TimerHandleObject<Platform> {}
 
 impl<Platform: crate::ShimPlatform> crate::WindowsHandleSubsystem for TimerSubsystem<Platform> {
-    fn granted_access(entry: &Self::Entry) -> u32 {
-        entry.granted_access.bits()
-    }
-
     fn normalize_desired_access(desired_access: u32) -> u32 {
         TimerAccess::from_desired_access(desired_access).bits()
     }
@@ -88,7 +84,6 @@ impl<Platform: crate::ShimPlatform> crate::WindowsHandleSubsystem for TimerSubsy
 
 pub(crate) struct TimerHandleObject<Platform: crate::ShimPlatform> {
     _timer: Arc<TimerObject<Platform>>,
-    granted_access: TimerAccess,
 }
 
 pub(crate) struct TimerObject<Platform: crate::ShimPlatform> {
@@ -139,10 +134,8 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         granted_access: TimerAccess,
     ) -> Result<Handle, NtStatus> {
         self.insert_typed_handle::<TimerSubsystem<Platform>>(
-            TimerHandleObject {
-                _timer: timer,
-                granted_access,
-            },
+            TimerHandleObject { _timer: timer },
+            granted_access.bits(),
             drop,
         )
     }

--- a/litebox_shim_windows/src/syscalls/timer.rs
+++ b/litebox_shim_windows/src/syscalls/timer.rs
@@ -12,9 +12,7 @@ use litebox_common_windows::nt_status::NtStatus;
 
 use crate::nt_types::{AccessMask, ObjectAttributes};
 use crate::syscalls::Handle;
-use crate::{
-    ConstPtr, MutPtr, ShimFS, Task, probe_guest_output_preserving_value, raw_handle_entry,
-};
+use crate::{ConstPtr, MutPtr, ShimFS, Task, probe_guest_output_preserving_value};
 
 const TIMER2_ATTRIBUTE_IR_TIMER: u32 = 0x0000_0002;
 const TIMER2_ATTRIBUTE_HIGH_RESOLUTION: u32 = 0x0000_0004;
@@ -74,19 +72,23 @@ impl<Platform: crate::ShimPlatform> FdEnabledSubsystem for TimerSubsystem<Platfo
 
 impl<Platform: crate::ShimPlatform> FdEnabledSubsystemEntry for TimerHandleObject<Platform> {}
 
+impl<Platform: crate::ShimPlatform> crate::WindowsHandleSubsystem for TimerSubsystem<Platform> {
+    fn granted_access(entry: &Self::Entry) -> u32 {
+        entry.granted_access.bits()
+    }
+
+    fn normalize_desired_access(desired_access: u32) -> u32 {
+        TimerAccess::from_desired_access(desired_access).bits()
+    }
+
+    fn maximum_allowed_access() -> u32 {
+        TimerAccess::ALL_ACCESS.bits()
+    }
+}
+
 pub(crate) struct TimerHandleObject<Platform: crate::ShimPlatform> {
     _timer: Arc<TimerObject<Platform>>,
     granted_access: TimerAccess,
-}
-
-impl<Platform: crate::ShimPlatform> TimerHandleObject<Platform> {
-    pub(crate) fn require_access(&self, required: TimerAccess) -> Result<(), NtStatus> {
-        if self.granted_access.contains(required) {
-            Ok(())
-        } else {
-            Err(NtStatus::ACCESS_DENIED)
-        }
-    }
 }
 
 pub(crate) struct TimerObject<Platform: crate::ShimPlatform> {
@@ -131,18 +133,6 @@ fn validate_timer2_after_output<Platform: RawPointerProvider>(
 }
 
 impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
-    fn timer_entry(
-        &self,
-        handle: Handle,
-    ) -> Result<litebox::fd::EntryHandle<Platform, TimerSubsystem<Platform>>, NtStatus> {
-        raw_handle_entry::<Platform, TimerSubsystem<Platform>>(
-            &self.global.litebox,
-            &self.process.handles,
-            handle,
-        )
-        .ok_or(NtStatus::INVALID_HANDLE)
-    }
-
     fn insert_timer_handle(
         &self,
         timer: Arc<TimerObject<Platform>>,
@@ -201,16 +191,12 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         period: Option<ConstPtr<Platform, i64>>,
         parameters: Option<ConstPtr<Platform, u8>>,
     ) -> NtStatus {
-        let timer = match self.timer_entry(timer_handle) {
-            Ok(timer) => timer,
-            Err(status) => return status,
-        };
-        if let Err(status) =
-            timer.with_entry(|timer| timer.require_access(TimerAccess::MODIFY_STATE))
-        {
+        if let Err(status) = self.require_handle_access::<TimerSubsystem<Platform>>(
+            timer_handle,
+            TimerAccess::MODIFY_STATE.bits(),
+        ) {
             return status;
         }
-
         let _due_time = match due_time {
             Some(due_time) => match due_time.read_at_offset(0) {
                 Some(due_time) => Some(due_time),

--- a/litebox_shim_windows/src/syscalls/timer.rs
+++ b/litebox_shim_windows/src/syscalls/timer.rs
@@ -76,10 +76,6 @@ impl<Platform: crate::ShimPlatform> crate::WindowsHandleSubsystem for TimerSubsy
     fn normalize_desired_access(desired_access: u32) -> u32 {
         TimerAccess::from_desired_access(desired_access).bits()
     }
-
-    fn maximum_allowed_access() -> u32 {
-        TimerAccess::ALL_ACCESS.bits()
-    }
 }
 
 pub(crate) struct TimerHandleObject<Platform: crate::ShimPlatform> {

--- a/litebox_shim_windows/src/syscalls/wait_completion_packet.rs
+++ b/litebox_shim_windows/src/syscalls/wait_completion_packet.rs
@@ -13,9 +13,9 @@ use litebox_common_windows::nt_status::NtStatus;
 
 use crate::nt_types::{AccessMask, ObjectAttributes, read_object_attributes};
 use crate::syscalls::Handle;
-use crate::syscalls::event::{EventAccess, EventSubsystem};
+use crate::syscalls::event::{EventHandleObject, EventSubsystem};
 use crate::syscalls::iocp::{IoCompletionAccess, IoCompletionSubsystem};
-use crate::syscalls::timer::{TimerAccess, TimerSubsystem};
+use crate::syscalls::timer::TimerSubsystem;
 use crate::{ConstPtr, MutPtr, ShimFS, Task, probe_guest_output_preserving_value};
 
 const STANDARD_RIGHTS_REQUIRED: u32 = AccessMask::DELETE.bits()
@@ -47,14 +47,6 @@ impl WaitCompletionPacketAccess {
             Self::ALL_ACCESS.bits(),
         ))
     }
-
-    fn require(self, required: Self) -> Result<(), NtStatus> {
-        if self.contains(required) {
-            Ok(())
-        } else {
-            Err(NtStatus::ACCESS_DENIED)
-        }
-    }
 }
 
 pub(crate) struct WaitCompletionPacketSubsystem<Platform>(PhantomData<fn(Platform)>);
@@ -66,6 +58,22 @@ impl<Platform: crate::ShimPlatform> FdEnabledSubsystem for WaitCompletionPacketS
 impl<Platform: crate::ShimPlatform> FdEnabledSubsystemEntry
     for WaitCompletionPacketHandleObject<Platform>
 {
+}
+
+impl<Platform: crate::ShimPlatform> crate::WindowsHandleSubsystem
+    for WaitCompletionPacketSubsystem<Platform>
+{
+    fn granted_access(entry: &Self::Entry) -> u32 {
+        entry.granted_access.bits()
+    }
+
+    fn normalize_desired_access(desired_access: u32) -> u32 {
+        WaitCompletionPacketAccess::from_desired_access(desired_access).bits()
+    }
+
+    fn maximum_allowed_access() -> u32 {
+        WaitCompletionPacketAccess::ALL_ACCESS.bits()
+    }
 }
 
 pub(crate) struct WaitCompletionPacketHandleObject<Platform: crate::ShimPlatform> {
@@ -163,22 +171,16 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         &self,
         handle: Handle,
     ) -> Result<(), NtStatus> {
-        let Some(raw_fd) = handle.raw_fd() else {
-            return Err(NtStatus::OBJECT_TYPE_MISMATCH);
-        };
-        let typed = {
-            let handles = self.process.handles.read();
-            match handles.fd_from_raw_integer::<IoCompletionSubsystem<Platform>>(raw_fd) {
-                Ok(typed) => typed,
-                Err(ErrRawIntFd::NotFound | ErrRawIntFd::InvalidSubsystem) => {
-                    return Err(NtStatus::OBJECT_TYPE_MISMATCH);
-                }
+        self.require_handle_access::<IoCompletionSubsystem<Platform>>(
+            handle,
+            IoCompletionAccess::MODIFY_STATE.bits(),
+        )
+        .map_err(|status| match status {
+            NtStatus::INVALID_HANDLE | NtStatus::OBJECT_TYPE_MISMATCH => {
+                NtStatus::OBJECT_TYPE_MISMATCH
             }
-        };
-        let Some(entry) = self.global.litebox.descriptor_table().entry_handle(&typed) else {
-            return Err(NtStatus::OBJECT_TYPE_MISMATCH);
-        };
-        entry.with_entry(|entry| entry.require_access(IoCompletionAccess::MODIFY_STATE))
+            status => status,
+        })
     }
 
     fn target_object_signaled_for_wait_completion_packet(
@@ -214,43 +216,34 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         let Some(entry) = self.global.litebox.descriptor_table().entry_handle(&typed) else {
             return Err(NtStatus::ACCESS_DENIED);
         };
-        entry
-            .with_entry(|entry| {
-                entry
-                    .require_access(EventAccess::from_bits_retain(
-                        AccessMask::SYNCHRONIZE.bits(),
-                    ))
-                    .map(|()| entry.is_signaled())
-            })
-            .map(Some)
+        let handle = Handle::from_raw_fd(raw_fd).ok_or(NtStatus::ACCESS_DENIED)?;
+        self.require_handle_access::<EventSubsystem<Platform>>(
+            handle,
+            AccessMask::SYNCHRONIZE.bits(),
+        )?;
+        Ok(Some(entry.with_entry(EventHandleObject::is_signaled)))
     }
 
     fn timer_signaled_for_wait_completion_packet(
         &self,
         raw_fd: usize,
     ) -> Result<Option<bool>, NtStatus> {
-        let typed = {
+        {
             let handles = self.process.handles.read();
             match handles.fd_from_raw_integer::<TimerSubsystem<Platform>>(raw_fd) {
-                Ok(typed) => typed,
+                Ok(_) => {}
                 Err(ErrRawIntFd::NotFound) => return Err(NtStatus::ACCESS_DENIED),
                 Err(ErrRawIntFd::InvalidSubsystem) => return Ok(None),
             }
-        };
-        let Some(entry) = self.global.litebox.descriptor_table().entry_handle(&typed) else {
-            return Err(NtStatus::ACCESS_DENIED);
-        };
+        }
+        let handle = Handle::from_raw_fd(raw_fd).ok_or(NtStatus::ACCESS_DENIED)?;
+        self.require_handle_access::<TimerSubsystem<Platform>>(
+            handle,
+            AccessMask::SYNCHRONIZE.bits(),
+        )?;
         // TODO: return the timer object's real signaled state after NtSetTimer2 models
         // due-time expiration and periodic re-signaling.
-        entry
-            .with_entry(|entry| {
-                entry
-                    .require_access(TimerAccess::from_bits_retain(
-                        AccessMask::SYNCHRONIZE.bits(),
-                    ))
-                    .map(|()| false)
-            })
-            .map(Some)
+        Ok(Some(false))
     }
 
     fn insert_wait_completion_packet_handle(
@@ -320,15 +313,13 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             Ok(entry) => entry,
             Err(status) => return status,
         };
-        let packet = match entry.with_entry(|entry| {
-            entry
-                .granted_access
-                .require(WaitCompletionPacketAccess::SET_STATE)
-                .map(|()| entry.packet.clone())
-        }) {
-            Ok(packet) => packet,
-            Err(status) => return status,
-        };
+        if let Err(status) = self.require_handle_access::<WaitCompletionPacketSubsystem<Platform>>(
+            params.wait_completion_packet_handle,
+            WaitCompletionPacketAccess::SET_STATE.bits(),
+        ) {
+            return status;
+        }
+        let packet = entry.with_entry(|entry| entry.packet.clone());
 
         if let Err(status) =
             self.validate_io_completion_for_wait_completion_packet(params.io_completion_handle)
@@ -381,15 +372,13 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                 Ok(entry) => entry,
                 Err(status) => return status,
             };
-        let packet = match entry.with_entry(|entry| {
-            entry
-                .granted_access
-                .require(WaitCompletionPacketAccess::SET_STATE)
-                .map(|()| Arc::clone(&entry.packet))
-        }) {
-            Ok(packet) => packet,
-            Err(status) => return status,
-        };
+        if let Err(status) = self.require_handle_access::<WaitCompletionPacketSubsystem<Platform>>(
+            wait_completion_packet_handle,
+            WaitCompletionPacketAccess::SET_STATE.bits(),
+        ) {
+            return status;
+        }
+        let packet = entry.with_entry(|entry| Arc::clone(&entry.packet));
 
         let mut association = packet.association.lock();
         let Some(current_association) = *association else {

--- a/litebox_shim_windows/src/syscalls/wait_completion_packet.rs
+++ b/litebox_shim_windows/src/syscalls/wait_completion_packet.rs
@@ -66,10 +66,6 @@ impl<Platform: crate::ShimPlatform> crate::WindowsHandleSubsystem
     fn normalize_desired_access(desired_access: u32) -> u32 {
         WaitCompletionPacketAccess::from_desired_access(desired_access).bits()
     }
-
-    fn maximum_allowed_access() -> u32 {
-        WaitCompletionPacketAccess::ALL_ACCESS.bits()
-    }
 }
 
 pub(crate) struct WaitCompletionPacketHandleObject<Platform: crate::ShimPlatform> {

--- a/litebox_shim_windows/src/syscalls/wait_completion_packet.rs
+++ b/litebox_shim_windows/src/syscalls/wait_completion_packet.rs
@@ -132,6 +132,7 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                 }
             }
         };
+        self.require_typed_handle_access(&typed, WaitCompletionPacketAccess::SET_STATE.bits())?;
         self.global
             .litebox
             .descriptor_table()
@@ -155,6 +156,7 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                 Err(ErrRawIntFd::InvalidSubsystem) => return Err(NtStatus::OBJECT_TYPE_MISMATCH),
             }
         };
+        self.require_typed_handle_access(&typed, WaitCompletionPacketAccess::SET_STATE.bits())?;
         self.global
             .litebox
             .descriptor_table()
@@ -211,9 +213,8 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         let Some(entry) = self.global.litebox.descriptor_table().entry_handle(&typed) else {
             return Err(NtStatus::ACCESS_DENIED);
         };
-        let handle = Handle::from_raw_fd(raw_fd).ok_or(NtStatus::ACCESS_DENIED)?;
-        self.require_handle_access::<EventSubsystem<Platform>>(
-            handle,
+        self.require_typed_handle_access::<EventSubsystem<Platform>>(
+            &typed,
             AccessMask::SYNCHRONIZE.bits(),
         )?;
         Ok(Some(entry.with_entry(EventHandleObject::is_signaled)))
@@ -223,19 +224,16 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         &self,
         raw_fd: usize,
     ) -> Result<Option<bool>, NtStatus> {
-        {
-            let handles = self.process.handles.read();
-            match handles.fd_from_raw_integer::<TimerSubsystem<Platform>>(raw_fd) {
-                Ok(_) => {}
-                Err(ErrRawIntFd::NotFound) => return Err(NtStatus::ACCESS_DENIED),
-                Err(ErrRawIntFd::InvalidSubsystem) => return Ok(None),
-            }
-        }
         let handle = Handle::from_raw_fd(raw_fd).ok_or(NtStatus::ACCESS_DENIED)?;
-        self.require_handle_access::<TimerSubsystem<Platform>>(
+        match self.require_handle_access::<TimerSubsystem<Platform>>(
             handle,
             AccessMask::SYNCHRONIZE.bits(),
-        )?;
+        ) {
+            Ok(()) => {}
+            Err(NtStatus::OBJECT_TYPE_MISMATCH) => return Ok(None),
+            Err(NtStatus::INVALID_HANDLE) => return Err(NtStatus::ACCESS_DENIED),
+            Err(status) => return Err(status),
+        }
         // TODO: return the timer object's real signaled state after NtSetTimer2 models
         // due-time expiration and periodic re-signaling.
         Ok(Some(false))
@@ -306,12 +304,6 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             Ok(entry) => entry,
             Err(status) => return status,
         };
-        if let Err(status) = self.require_handle_access::<WaitCompletionPacketSubsystem<Platform>>(
-            params.wait_completion_packet_handle,
-            WaitCompletionPacketAccess::SET_STATE.bits(),
-        ) {
-            return status;
-        }
         let packet = entry.with_entry(|entry| entry.packet.clone());
 
         if let Err(status) =
@@ -365,12 +357,6 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                 Ok(entry) => entry,
                 Err(status) => return status,
             };
-        if let Err(status) = self.require_handle_access::<WaitCompletionPacketSubsystem<Platform>>(
-            wait_completion_packet_handle,
-            WaitCompletionPacketAccess::SET_STATE.bits(),
-        ) {
-            return status;
-        }
         let packet = entry.with_entry(|entry| Arc::clone(&entry.packet));
 
         let mut association = packet.association.lock();

--- a/litebox_shim_windows/src/syscalls/wait_completion_packet.rs
+++ b/litebox_shim_windows/src/syscalls/wait_completion_packet.rs
@@ -63,10 +63,6 @@ impl<Platform: crate::ShimPlatform> FdEnabledSubsystemEntry
 impl<Platform: crate::ShimPlatform> crate::WindowsHandleSubsystem
     for WaitCompletionPacketSubsystem<Platform>
 {
-    fn granted_access(entry: &Self::Entry) -> u32 {
-        entry.granted_access.bits()
-    }
-
     fn normalize_desired_access(desired_access: u32) -> u32 {
         WaitCompletionPacketAccess::from_desired_access(desired_access).bits()
     }
@@ -78,7 +74,6 @@ impl<Platform: crate::ShimPlatform> crate::WindowsHandleSubsystem
 
 pub(crate) struct WaitCompletionPacketHandleObject<Platform: crate::ShimPlatform> {
     packet: Arc<WaitCompletionPacketObject<Platform>>,
-    granted_access: WaitCompletionPacketAccess,
 }
 
 pub(crate) struct WaitCompletionPacketObject<Platform: crate::ShimPlatform> {
@@ -252,10 +247,8 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         granted_access: WaitCompletionPacketAccess,
     ) -> Result<Handle, NtStatus> {
         self.insert_typed_handle::<WaitCompletionPacketSubsystem<Platform>>(
-            WaitCompletionPacketHandleObject {
-                packet,
-                granted_access,
-            },
+            WaitCompletionPacketHandleObject { packet },
+            granted_access.bits(),
             drop,
         )
     }

--- a/litebox_shim_windows/src/syscalls/worker_factory.rs
+++ b/litebox_shim_windows/src/syscalls/worker_factory.rs
@@ -13,7 +13,9 @@ use litebox::platform::{RawConstPointer as _, RawMutPointer as _, RawPointerProv
 use litebox_common_windows::nt_status::NtStatus;
 
 use crate::nt_types::{AccessMask, ObjectAttributes, read_object_attributes};
-use crate::syscalls::iocp::{IoCompletionAccess, IoCompletionObject, IoCompletionSubsystem};
+use crate::syscalls::iocp::{
+    IoCompletionAccess, IoCompletionHandleObject, IoCompletionObject, IoCompletionSubsystem,
+};
 use crate::syscalls::{Handle, ProcessHandle};
 use crate::{ConstPtr, MutPtr, ShimFS, Task, probe_guest_output_preserving_value};
 
@@ -54,14 +56,6 @@ impl WorkerFactoryAccess {
             Self::ALL_ACCESS.bits(),
         ))
     }
-
-    fn require(self, required: Self) -> Result<(), NtStatus> {
-        if self.contains(required) {
-            Ok(())
-        } else {
-            Err(NtStatus::ACCESS_DENIED)
-        }
-    }
 }
 
 #[repr(u32)]
@@ -94,6 +88,22 @@ impl<Platform: crate::ShimPlatform> FdEnabledSubsystem for WorkerFactorySubsyste
 impl<Platform: crate::ShimPlatform> FdEnabledSubsystemEntry
     for WorkerFactoryHandleObject<Platform>
 {
+}
+
+impl<Platform: crate::ShimPlatform> crate::WindowsHandleSubsystem
+    for WorkerFactorySubsystem<Platform>
+{
+    fn granted_access(entry: &Self::Entry) -> u32 {
+        entry.granted_access.bits()
+    }
+
+    fn normalize_desired_access(desired_access: u32) -> u32 {
+        WorkerFactoryAccess::from_desired_access(desired_access).bits()
+    }
+
+    fn maximum_allowed_access() -> u32 {
+        WorkerFactoryAccess::ALL_ACCESS.bits()
+    }
 }
 
 pub(crate) struct WorkerFactoryHandleObject<Platform: crate::ShimPlatform> {
@@ -181,26 +191,12 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         &self,
         handle: Handle,
     ) -> Result<Arc<IoCompletionObject<Platform>>, NtStatus> {
-        let Some(raw_fd) = handle.raw_fd() else {
-            return Err(NtStatus::INVALID_HANDLE);
-        };
-        let typed = {
-            let handles = self.process.handles.read();
-            match handles.fd_from_raw_integer::<IoCompletionSubsystem<Platform>>(raw_fd) {
-                Ok(typed) => typed,
-                Err(ErrRawIntFd::NotFound) => return Err(NtStatus::INVALID_HANDLE),
-                Err(ErrRawIntFd::InvalidSubsystem) => {
-                    return Err(NtStatus::OBJECT_TYPE_MISMATCH);
-                }
-            }
-        };
-        let Some(entry) = self.global.litebox.descriptor_table().entry_handle(&typed) else {
-            return Err(NtStatus::INVALID_HANDLE);
-        };
-        entry.with_entry(|entry| {
-            entry.require_access(IoCompletionAccess::MODIFY_STATE)?;
-            Ok(entry.port())
-        })
+        self.require_handle_access::<IoCompletionSubsystem<Platform>>(
+            handle,
+            IoCompletionAccess::MODIFY_STATE.bits(),
+        )?;
+        let entry = self.typed_handle_entry::<IoCompletionSubsystem<Platform>>(handle)?;
+        Ok(entry.with_entry(IoCompletionHandleObject::port))
     }
 
     fn validate_worker_process_handle(
@@ -327,11 +323,14 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             Ok(entry) => entry,
             Err(status) => return status,
         };
+        if let Err(status) = self.require_handle_access::<WorkerFactorySubsystem<Platform>>(
+            handle,
+            WorkerFactoryAccess::SET_INFORMATION.bits(),
+        ) {
+            return status;
+        }
         entry
             .with_entry(|entry| {
-                entry
-                    .granted_access
-                    .require(WorkerFactoryAccess::SET_INFORMATION)?;
                 // TODO: enforce these limits against real worker creation/drain behavior
                 // once worker threads are modeled; today they are only recorded.
                 match information_class {
@@ -384,15 +383,13 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             Ok(entry) => entry,
             Err(status) => return status,
         };
-        let factory = match entry.with_entry(|entry| {
-            entry
-                .granted_access
-                .require(WorkerFactoryAccess::SHUTDOWN)?;
-            Ok(Arc::clone(&entry.factory))
-        }) {
-            Ok(factory) => factory,
-            Err(status) => return status,
-        };
+        if let Err(status) = self.require_handle_access::<WorkerFactorySubsystem<Platform>>(
+            handle,
+            WorkerFactoryAccess::SHUTDOWN.bits(),
+        ) {
+            return status;
+        }
+        let factory = entry.with_entry(|entry| Arc::clone(&entry.factory));
         // TODO: report the actual pending worker count and wake/release workers once worker
         // threads are modeled; the current subset has no workers to drain.
         commit_worker_factory_shutdown(&factory, pending_worker_count)

--- a/litebox_shim_windows/src/syscalls/worker_factory.rs
+++ b/litebox_shim_windows/src/syscalls/worker_factory.rs
@@ -96,10 +96,6 @@ impl<Platform: crate::ShimPlatform> crate::WindowsHandleSubsystem
     fn normalize_desired_access(desired_access: u32) -> u32 {
         WorkerFactoryAccess::from_desired_access(desired_access).bits()
     }
-
-    fn maximum_allowed_access() -> u32 {
-        WorkerFactoryAccess::ALL_ACCESS.bits()
-    }
 }
 
 pub(crate) struct WorkerFactoryHandleObject<Platform: crate::ShimPlatform> {

--- a/litebox_shim_windows/src/syscalls/worker_factory.rs
+++ b/litebox_shim_windows/src/syscalls/worker_factory.rs
@@ -8,7 +8,7 @@ use core::marker::PhantomData;
 use core::mem::size_of;
 use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
-use litebox::fd::{ErrRawIntFd, FdEnabledSubsystem, FdEnabledSubsystemEntry};
+use litebox::fd::{FdEnabledSubsystem, FdEnabledSubsystemEntry};
 use litebox::platform::{RawConstPointer as _, RawMutPointer as _, RawPointerProvider};
 use litebox_common_windows::nt_status::NtStatus;
 
@@ -157,40 +157,14 @@ fn commit_worker_factory_shutdown<Platform: crate::ShimPlatform>(
 }
 
 impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
-    fn worker_factory_entry(
-        &self,
-        handle: Handle,
-    ) -> Result<litebox::fd::EntryHandle<Platform, WorkerFactorySubsystem<Platform>>, NtStatus>
-    {
-        let Some(raw_fd) = handle.raw_fd() else {
-            return Err(NtStatus::INVALID_HANDLE);
-        };
-        let typed = {
-            let handles = self.process.handles.read();
-            match handles.fd_from_raw_integer::<WorkerFactorySubsystem<Platform>>(raw_fd) {
-                Ok(typed) => typed,
-                Err(ErrRawIntFd::NotFound) => return Err(NtStatus::INVALID_HANDLE),
-                Err(ErrRawIntFd::InvalidSubsystem) => {
-                    return Err(NtStatus::OBJECT_TYPE_MISMATCH);
-                }
-            }
-        };
-        self.global
-            .litebox
-            .descriptor_table()
-            .entry_handle(&typed)
-            .ok_or(NtStatus::INVALID_HANDLE)
-    }
-
     fn io_completion_port(
         &self,
         handle: Handle,
     ) -> Result<Arc<IoCompletionObject<Platform>>, NtStatus> {
-        self.require_handle_access::<IoCompletionSubsystem<Platform>>(
+        let entry = self.typed_handle_entry_with_access::<IoCompletionSubsystem<Platform>>(
             handle,
             IoCompletionAccess::MODIFY_STATE.bits(),
         )?;
-        let entry = self.typed_handle_entry::<IoCompletionSubsystem<Platform>>(handle)?;
         Ok(entry.with_entry(IoCompletionHandleObject::port))
     }
 
@@ -312,16 +286,13 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                 .expect("ULONG input is four bytes"),
         );
 
-        let entry = match self.worker_factory_entry(handle) {
-            Ok(entry) => entry,
-            Err(status) => return status,
-        };
-        if let Err(status) = self.require_handle_access::<WorkerFactorySubsystem<Platform>>(
+        let entry = match self.typed_handle_entry_with_access::<WorkerFactorySubsystem<Platform>>(
             handle,
             WorkerFactoryAccess::SET_INFORMATION.bits(),
         ) {
-            return status;
-        }
+            Ok(entry) => entry,
+            Err(status) => return status,
+        };
         entry
             .with_entry(|entry| {
                 // TODO: enforce these limits against real worker creation/drain behavior
@@ -372,16 +343,13 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         {
             return status;
         }
-        let entry = match self.worker_factory_entry(handle) {
-            Ok(entry) => entry,
-            Err(status) => return status,
-        };
-        if let Err(status) = self.require_handle_access::<WorkerFactorySubsystem<Platform>>(
+        let entry = match self.typed_handle_entry_with_access::<WorkerFactorySubsystem<Platform>>(
             handle,
             WorkerFactoryAccess::SHUTDOWN.bits(),
         ) {
-            return status;
-        }
+            Ok(entry) => entry,
+            Err(status) => return status,
+        };
         let factory = entry.with_entry(|entry| Arc::clone(&entry.factory));
         // TODO: report the actual pending worker count and wake/release workers once worker
         // threads are modeled; the current subset has no workers to drain.
@@ -585,7 +553,7 @@ mod tests {
                 NtStatus::SUCCESS
             );
             let factory = task
-                .worker_factory_entry(worker_factory)
+                .typed_handle_entry::<WorkerFactorySubsystem<TestPlatform>>(worker_factory)
                 .expect("worker factory handle is valid")
                 .with_entry(|entry| Arc::clone(&entry.factory));
             assert!(!factory.shutdown.load(Ordering::Relaxed));

--- a/litebox_shim_windows/src/syscalls/worker_factory.rs
+++ b/litebox_shim_windows/src/syscalls/worker_factory.rs
@@ -93,10 +93,6 @@ impl<Platform: crate::ShimPlatform> FdEnabledSubsystemEntry
 impl<Platform: crate::ShimPlatform> crate::WindowsHandleSubsystem
     for WorkerFactorySubsystem<Platform>
 {
-    fn granted_access(entry: &Self::Entry) -> u32 {
-        entry.granted_access.bits()
-    }
-
     fn normalize_desired_access(desired_access: u32) -> u32 {
         WorkerFactoryAccess::from_desired_access(desired_access).bits()
     }
@@ -108,7 +104,6 @@ impl<Platform: crate::ShimPlatform> crate::WindowsHandleSubsystem
 
 pub(crate) struct WorkerFactoryHandleObject<Platform: crate::ShimPlatform> {
     factory: Arc<WorkerFactoryObject<Platform>>,
-    granted_access: WorkerFactoryAccess,
 }
 
 pub(crate) struct WorkerFactoryObject<Platform: crate::ShimPlatform> {
@@ -222,10 +217,8 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         granted_access: WorkerFactoryAccess,
     ) -> Result<Handle, NtStatus> {
         self.insert_typed_handle::<WorkerFactorySubsystem<Platform>>(
-            WorkerFactoryHandleObject {
-                factory,
-                granted_access,
-            },
+            WorkerFactoryHandleObject { factory },
+            granted_access.bits(),
             drop,
         )
     }

--- a/litebox_shim_windows/src/tests.rs
+++ b/litebox_shim_windows/src/tests.rs
@@ -169,3 +169,453 @@ pub(crate) fn test_task_with_nls_files(nls_files: &[(&str, &[u8])]) -> Task<Test
         teb_address: 0,
     }
 }
+
+const EVENT_MODIFY_STATE: u32 = 0x0002;
+const SYNCHRONIZE: u32 = 0x0010_0000;
+const DUPLICATE_CLOSE_SOURCE: u32 = 0x0000_0001;
+const DUPLICATE_SAME_ACCESS: u32 = 0x0000_0002;
+const DUPLICATE_SAME_ATTRIBUTES: u32 = 0x0000_0004;
+const MAXIMUM_ALLOWED: u32 = 0x0200_0000;
+
+fn create_event(task: &Task<TestPlatform, TestFS>, desired_access: u32) -> Handle {
+    let mut handle = Handle::default();
+    assert_eq!(
+        task.sys_nt_create_event(mut_ptr(&mut handle), desired_access, None, 0, 0,),
+        litebox_common_windows::nt_status::NtStatus::SUCCESS
+    );
+    handle
+}
+
+#[test]
+fn nt_duplicate_object_preserves_identity_with_independent_access() {
+    let task = test_task();
+    let source = create_event(&task, SYNCHRONIZE);
+    let mut duplicate = Handle::default();
+
+    assert_eq!(
+        task.sys_nt_duplicate_object(
+            crate::syscalls::ProcessHandle::CURRENT,
+            source,
+            crate::syscalls::ProcessHandle::CURRENT,
+            Some(mut_ptr(&mut duplicate)),
+            EVENT_MODIFY_STATE,
+            0,
+            0,
+        ),
+        litebox_common_windows::nt_status::NtStatus::SUCCESS
+    );
+    assert_ne!(source, duplicate);
+    assert_eq!(
+        task.sys_nt_set_event(source, None),
+        litebox_common_windows::nt_status::NtStatus::ACCESS_DENIED
+    );
+    assert_eq!(
+        task.sys_nt_set_event(duplicate, None),
+        litebox_common_windows::nt_status::NtStatus::SUCCESS
+    );
+    assert_eq!(
+        task.sys_nt_close(source),
+        litebox_common_windows::nt_status::NtStatus::SUCCESS
+    );
+    assert_eq!(
+        task.sys_nt_set_event(duplicate, None),
+        litebox_common_windows::nt_status::NtStatus::SUCCESS
+    );
+    assert_eq!(
+        task.sys_nt_close(duplicate),
+        litebox_common_windows::nt_status::NtStatus::SUCCESS
+    );
+}
+
+#[test]
+fn nt_duplicate_object_can_atomically_replace_the_source_handle() {
+    let task = test_task();
+    let source = create_event(&task, EVENT_MODIFY_STATE);
+    let mut duplicate = Handle::default();
+
+    assert_eq!(
+        task.sys_nt_duplicate_object(
+            crate::syscalls::ProcessHandle::CURRENT,
+            source,
+            crate::syscalls::ProcessHandle::CURRENT,
+            Some(mut_ptr(&mut duplicate)),
+            0,
+            0,
+            DUPLICATE_CLOSE_SOURCE | DUPLICATE_SAME_ACCESS,
+        ),
+        litebox_common_windows::nt_status::NtStatus::SUCCESS
+    );
+    assert_eq!(
+        task.sys_nt_close(source),
+        litebox_common_windows::nt_status::NtStatus::INVALID_HANDLE
+    );
+    assert_eq!(
+        task.sys_nt_set_event(duplicate, None),
+        litebox_common_windows::nt_status::NtStatus::SUCCESS
+    );
+    assert_eq!(
+        task.sys_nt_close(duplicate),
+        litebox_common_windows::nt_status::NtStatus::SUCCESS
+    );
+}
+
+#[test]
+fn nt_duplicate_object_closes_source_even_when_duplication_fails() {
+    let task = test_task();
+    let source = create_event(&task, EVENT_MODIFY_STATE);
+    let mut duplicate = Handle::from_raw(0x7777);
+
+    assert_eq!(
+        task.sys_nt_duplicate_object(
+            crate::syscalls::ProcessHandle::CURRENT,
+            source,
+            crate::syscalls::ProcessHandle::from_raw(0x1234),
+            Some(mut_ptr(&mut duplicate)),
+            0,
+            0,
+            DUPLICATE_CLOSE_SOURCE | DUPLICATE_SAME_ACCESS,
+        ),
+        litebox_common_windows::nt_status::NtStatus::INVALID_HANDLE
+    );
+    assert_eq!(
+        task.sys_nt_close(source),
+        litebox_common_windows::nt_status::NtStatus::INVALID_HANDLE
+    );
+    assert!(duplicate.is_null());
+}
+
+#[test]
+fn nt_duplicate_object_supports_close_only_calls() {
+    let task = test_task();
+    let source = create_event(&task, EVENT_MODIFY_STATE);
+
+    assert_eq!(
+        task.sys_nt_duplicate_object(
+            crate::syscalls::ProcessHandle::CURRENT,
+            source,
+            crate::syscalls::ProcessHandle::from_raw(0),
+            None,
+            0,
+            0,
+            0,
+        ),
+        litebox_common_windows::nt_status::NtStatus::INVALID_PARAMETER
+    );
+    assert_eq!(
+        task.sys_nt_set_event(source, None),
+        litebox_common_windows::nt_status::NtStatus::SUCCESS
+    );
+    assert_eq!(
+        task.sys_nt_duplicate_object(
+            crate::syscalls::ProcessHandle::CURRENT,
+            source,
+            crate::syscalls::ProcessHandle::from_raw(0),
+            None,
+            0,
+            0,
+            DUPLICATE_CLOSE_SOURCE,
+        ),
+        litebox_common_windows::nt_status::NtStatus::SUCCESS
+    );
+    assert_eq!(
+        task.sys_nt_close(source),
+        litebox_common_windows::nt_status::NtStatus::INVALID_HANDLE
+    );
+}
+
+#[test]
+fn nt_duplicate_object_null_output_retains_inaccessible_duplicate() {
+    let task = test_task();
+    let source = create_event(&task, EVENT_MODIFY_STATE);
+    let handles_before = task.process.handles.read().iter_alive().count();
+
+    assert_eq!(
+        task.sys_nt_duplicate_object(
+            crate::syscalls::ProcessHandle::CURRENT,
+            source,
+            crate::syscalls::ProcessHandle::CURRENT,
+            None,
+            0,
+            0,
+            DUPLICATE_SAME_ACCESS,
+        ),
+        litebox_common_windows::nt_status::NtStatus::SUCCESS
+    );
+    assert_eq!(
+        task.process.handles.read().iter_alive().count(),
+        handles_before + 1
+    );
+    assert_eq!(
+        task.sys_nt_close(source),
+        litebox_common_windows::nt_status::NtStatus::SUCCESS
+    );
+    assert_eq!(
+        task.process.handles.read().iter_alive().count(),
+        handles_before
+    );
+}
+
+#[test]
+fn nt_duplicate_object_ignores_unknown_flags_and_copies_attributes() {
+    let task = test_task();
+    let source = create_event(&task, EVENT_MODIFY_STATE);
+    let mut first_duplicate = Handle::default();
+    let mut second_duplicate = Handle::default();
+    let mut unprotected_duplicate = Handle::default();
+
+    assert_eq!(
+        task.sys_nt_duplicate_object(
+            crate::syscalls::ProcessHandle::CURRENT,
+            source,
+            crate::syscalls::ProcessHandle::CURRENT,
+            Some(mut_ptr(&mut first_duplicate)),
+            0,
+            0x8000_0001,
+            DUPLICATE_SAME_ACCESS | 0x8000_0000,
+        ),
+        litebox_common_windows::nt_status::NtStatus::SUCCESS
+    );
+    assert_eq!(
+        task.sys_nt_duplicate_object(
+            crate::syscalls::ProcessHandle::CURRENT,
+            first_duplicate,
+            crate::syscalls::ProcessHandle::CURRENT,
+            Some(mut_ptr(&mut second_duplicate)),
+            0,
+            0x4000_0000,
+            DUPLICATE_SAME_ACCESS | DUPLICATE_SAME_ATTRIBUTES,
+        ),
+        litebox_common_windows::nt_status::NtStatus::SUCCESS
+    );
+    assert_eq!(
+        task.sys_nt_duplicate_object(
+            crate::syscalls::ProcessHandle::CURRENT,
+            first_duplicate,
+            crate::syscalls::ProcessHandle::CURRENT,
+            Some(mut_ptr(&mut unprotected_duplicate)),
+            0,
+            0,
+            DUPLICATE_CLOSE_SOURCE | DUPLICATE_SAME_ACCESS,
+        ),
+        litebox_common_windows::nt_status::NtStatus::SUCCESS
+    );
+    assert_eq!(
+        task.sys_nt_close(source),
+        litebox_common_windows::nt_status::NtStatus::SUCCESS
+    );
+    assert_eq!(
+        task.sys_nt_close(first_duplicate),
+        litebox_common_windows::nt_status::NtStatus::HANDLE_NOT_CLOSABLE
+    );
+    assert_eq!(
+        task.sys_nt_close(second_duplicate),
+        litebox_common_windows::nt_status::NtStatus::HANDLE_NOT_CLOSABLE
+    );
+    assert_eq!(
+        task.sys_nt_close(unprotected_duplicate),
+        litebox_common_windows::nt_status::NtStatus::SUCCESS
+    );
+}
+
+#[test]
+fn nt_duplicate_object_grants_maximum_allowed_access() {
+    let task = test_task();
+    let source = create_event(&task, SYNCHRONIZE);
+    let mut duplicate = Handle::default();
+
+    assert_eq!(
+        task.sys_nt_duplicate_object(
+            crate::syscalls::ProcessHandle::CURRENT,
+            source,
+            crate::syscalls::ProcessHandle::CURRENT,
+            Some(mut_ptr(&mut duplicate)),
+            MAXIMUM_ALLOWED,
+            0,
+            0,
+        ),
+        litebox_common_windows::nt_status::NtStatus::SUCCESS
+    );
+    assert_eq!(
+        task.sys_nt_set_event(source, None),
+        litebox_common_windows::nt_status::NtStatus::ACCESS_DENIED
+    );
+    assert_eq!(
+        task.sys_nt_set_event(duplicate, None),
+        litebox_common_windows::nt_status::NtStatus::SUCCESS
+    );
+    assert_eq!(
+        task.sys_nt_close(source),
+        litebox_common_windows::nt_status::NtStatus::SUCCESS
+    );
+    assert_eq!(
+        task.sys_nt_close(duplicate),
+        litebox_common_windows::nt_status::NtStatus::SUCCESS
+    );
+}
+
+#[cfg(target_os = "windows")]
+#[test]
+fn host_nt_duplicate_object_failure_and_access_matrix() {
+    use core::ffi::c_void;
+
+    #[link(name = "kernel32")]
+    unsafe extern "system" {
+        fn CreateEventW(
+            event_attributes: *const c_void,
+            manual_reset: i32,
+            initial_state: i32,
+            name: *const u16,
+        ) -> *mut c_void;
+    }
+
+    #[link(name = "ntdll")]
+    unsafe extern "system" {
+        fn NtClose(handle: *mut c_void) -> i32;
+        fn NtSetEvent(handle: *mut c_void, previous_state: *mut i32) -> i32;
+        fn NtDuplicateObject(
+            source_process_handle: *mut c_void,
+            source_handle: *mut c_void,
+            target_process_handle: *mut c_void,
+            target_handle: *mut c_void,
+            desired_access: u32,
+            handle_attributes: u32,
+            options: u32,
+        ) -> i32;
+    }
+
+    // SAFETY: All pointers are either documented pseudo-handles, null, or valid local outputs.
+    unsafe {
+        let source = CreateEventW(core::ptr::null(), 0, 0, core::ptr::null());
+        assert!(!source.is_null());
+        let mut duplicate: *mut c_void = core::ptr::null_mut();
+        assert_eq!(
+            NtDuplicateObject(
+                usize::MAX as *mut c_void,
+                source,
+                0x1234usize as *mut c_void,
+                (&raw mut duplicate).cast(),
+                0,
+                0,
+                DUPLICATE_CLOSE_SOURCE | DUPLICATE_SAME_ACCESS,
+            ),
+            litebox_common_windows::nt_status::NtStatus::INVALID_HANDLE.as_raw()
+        );
+        assert_eq!(
+            NtClose(source),
+            litebox_common_windows::nt_status::NtStatus::INVALID_HANDLE.as_raw()
+        );
+        assert!(duplicate.is_null());
+
+        let source = CreateEventW(core::ptr::null(), 0, 0, core::ptr::null());
+        assert!(!source.is_null());
+        let mut duplicate = usize::MAX as *mut c_void;
+        assert_eq!(
+            NtDuplicateObject(
+                usize::MAX as *mut c_void,
+                source,
+                core::ptr::null_mut(),
+                (&raw mut duplicate).cast(),
+                0,
+                0,
+                DUPLICATE_SAME_ACCESS,
+            ),
+            litebox_common_windows::nt_status::NtStatus::INVALID_PARAMETER.as_raw()
+        );
+        assert!(duplicate.is_null());
+        assert_eq!(
+            NtClose(source),
+            litebox_common_windows::nt_status::NtStatus::SUCCESS.as_raw()
+        );
+
+        let source = CreateEventW(core::ptr::null(), 0, 0, core::ptr::null());
+        assert!(!source.is_null());
+        assert_eq!(
+            NtDuplicateObject(
+                usize::MAX as *mut c_void,
+                source,
+                usize::MAX as *mut c_void,
+                core::ptr::null_mut(),
+                0,
+                0,
+                DUPLICATE_SAME_ACCESS,
+            ),
+            litebox_common_windows::nt_status::NtStatus::SUCCESS.as_raw()
+        );
+        assert_eq!(
+            NtClose(source),
+            litebox_common_windows::nt_status::NtStatus::SUCCESS.as_raw()
+        );
+
+        let source = CreateEventW(core::ptr::null(), 0, 0, core::ptr::null());
+        assert!(!source.is_null());
+        assert_eq!(
+            NtDuplicateObject(
+                usize::MAX as *mut c_void,
+                source,
+                usize::MAX as *mut c_void,
+                core::ptr::dangling_mut::<c_void>(),
+                0,
+                0,
+                DUPLICATE_CLOSE_SOURCE | DUPLICATE_SAME_ACCESS,
+            ),
+            litebox_common_windows::nt_status::NtStatus::ACCESS_VIOLATION.as_raw()
+        );
+        assert_eq!(
+            NtSetEvent(source, core::ptr::null_mut()),
+            litebox_common_windows::nt_status::NtStatus::SUCCESS.as_raw()
+        );
+        assert_eq!(
+            NtClose(source),
+            litebox_common_windows::nt_status::NtStatus::SUCCESS.as_raw()
+        );
+
+        let source = CreateEventW(core::ptr::null(), 0, 0, core::ptr::null());
+        assert!(!source.is_null());
+        let mut reduced: *mut c_void = core::ptr::null_mut();
+        assert_eq!(
+            NtDuplicateObject(
+                usize::MAX as *mut c_void,
+                source,
+                usize::MAX as *mut c_void,
+                (&raw mut reduced).cast(),
+                SYNCHRONIZE,
+                0,
+                0,
+            ),
+            litebox_common_windows::nt_status::NtStatus::SUCCESS.as_raw()
+        );
+        let mut expanded: *mut c_void = core::ptr::null_mut();
+        assert_eq!(
+            NtDuplicateObject(
+                usize::MAX as *mut c_void,
+                reduced,
+                usize::MAX as *mut c_void,
+                (&raw mut expanded).cast(),
+                EVENT_MODIFY_STATE,
+                0,
+                0,
+            ),
+            litebox_common_windows::nt_status::NtStatus::SUCCESS.as_raw()
+        );
+        assert_eq!(
+            NtSetEvent(reduced, core::ptr::null_mut()),
+            litebox_common_windows::nt_status::NtStatus::ACCESS_DENIED.as_raw()
+        );
+        assert_eq!(
+            NtSetEvent(expanded, core::ptr::null_mut()),
+            litebox_common_windows::nt_status::NtStatus::SUCCESS.as_raw()
+        );
+        assert_eq!(
+            NtClose(source),
+            litebox_common_windows::nt_status::NtStatus::SUCCESS.as_raw()
+        );
+        assert_eq!(
+            NtClose(reduced),
+            litebox_common_windows::nt_status::NtStatus::SUCCESS.as_raw()
+        );
+        assert_eq!(
+            NtClose(expanded),
+            litebox_common_windows::nt_status::NtStatus::SUCCESS.as_raw()
+        );
+    }
+}


### PR DESCRIPTION
This PR implements current-process handle duplication across supported Windows object types.