### PR TITLE
Authenticate Unix broker channels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1525,7 +1525,6 @@ name = "litebox_broker_userland"
 version = "0.1.0"
 dependencies = [
  "clap",
- "libc",
  "litebox_broker_core",
  "litebox_broker_host",
  "litebox_broker_local",

--- a/litebox_broker_core/src/policy.rs
+++ b/litebox_broker_core/src/policy.rs
@@ -14,6 +14,11 @@ pub enum PolicyProfile {
         /// Rights for the unauthenticated principal used by the initial POC.
         unauthenticated: ObjectRights,
     },
+    /// Static rights for a principal authenticated by the broker entry layer.
+    HostGuaranteed {
+        /// Rights granted to the host-guaranteed principal.
+        rights: ObjectRights,
+    },
 }
 
 /// Broker policy decision and audit component.
@@ -42,6 +47,11 @@ impl PolicyEngine {
         Self::new(PolicyProfile::Static { unauthenticated })
     }
 
+    /// Creates a policy engine with rights for a host-guaranteed principal.
+    pub const fn with_host_guaranteed_rights(rights: ObjectRights) -> Self {
+        Self::new(PolicyProfile::HostGuaranteed { rights })
+    }
+
     pub(crate) fn principal_object_rights(
         &self,
         caller_credential: CallerCredential,
@@ -50,7 +60,8 @@ impl PolicyEngine {
             (PolicyProfile::Static { unauthenticated }, CallerCredential::Unauthenticated) => {
                 unauthenticated
             }
-            (PolicyProfile::DefaultDeny, _) => return Err(BrokerError::PolicyDenied),
+            (PolicyProfile::HostGuaranteed { rights }, CallerCredential::HostGuaranteed) => rights,
+            _ => return Err(BrokerError::PolicyDenied),
         };
         if rights.is_empty() {
             return Err(BrokerError::PolicyDenied);
@@ -86,6 +97,20 @@ mod tests {
         assert_eq!(
             policy.principal_object_rights(CallerCredential::Unauthenticated),
             Ok(ObjectRights::WAIT)
+        );
+    }
+
+    #[test]
+    fn host_guaranteed_policy_returns_configured_principal_rights() {
+        let policy = PolicyEngine::with_host_guaranteed_rights(ObjectRights::WAIT);
+
+        assert_eq!(
+            policy.principal_object_rights(CallerCredential::HostGuaranteed),
+            Ok(ObjectRights::WAIT)
+        );
+        assert_eq!(
+            policy.principal_object_rights(CallerCredential::Unauthenticated),
+            Err(BrokerError::PolicyDenied)
         );
     }
 

--- a/litebox_broker_core/src/session.rs
+++ b/litebox_broker_core/src/session.rs
@@ -19,6 +19,8 @@ use spin::rwlock::RwLock;
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 pub enum CallerCredential {
+    /// The trusted broker entry layer authenticated and bound the caller.
+    HostGuaranteed,
     /// Explicit deployment mode for the initial unauthenticated userland POC.
     Unauthenticated,
 }

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -66,6 +66,7 @@ where
         .peer_credential()
         .map_err(BrokerHostError::Channel)?;
     let caller_credential = match peer_credential {
+        PeerCredential::HostGuaranteed => CallerCredential::HostGuaranteed,
         PeerCredential::Unauthenticated => CallerCredential::Unauthenticated,
         _ => return Err(BrokerHostError::Broker(ErrorCode::PolicyDenied)),
     };

--- a/litebox_broker_protocol/src/channel.rs
+++ b/litebox_broker_protocol/src/channel.rs
@@ -14,6 +14,9 @@ use crate::message::{
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 pub enum PeerCredential {
+    /// The trusted host or deployment authenticated and bound the peer before
+    /// constructing the channel.
+    HostGuaranteed,
     /// Explicit deployment mode for the initial unauthenticated userland POC.
     ///
     /// Channels that are expected to authenticate peers must return an error

--- a/litebox_broker_transport/Cargo.toml
+++ b/litebox_broker_transport/Cargo.toml
@@ -5,9 +5,7 @@ edition = "2024"
 
 [features]
 std = []
-linux-peer-credentials = ["unix", "dep:rustix", "rustix/net"]
-linux-shared-memory = ["std", "dep:libc", "dep:rustix", "rustix/fs", "rustix/net"]
-unix = ["std"]
+linux-userland = ["std", "dep:libc", "dep:rustix", "rustix/fs", "rustix/net"]
 
 [dependencies]
 litebox_broker_protocol = { path = "../litebox_broker_protocol", version = "0.1.0" }

--- a/litebox_broker_transport/Cargo.toml
+++ b/litebox_broker_transport/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [features]
 std = []
+linux-peer-credentials = ["unix", "dep:rustix", "rustix/net"]
 linux-shared-memory = ["std", "dep:libc", "dep:rustix", "rustix/fs", "rustix/net"]
 unix = ["std"]
 

--- a/litebox_broker_transport/src/lib.rs
+++ b/litebox_broker_transport/src/lib.rs
@@ -9,14 +9,11 @@
 //! protocol messages, local-side adapters, host-side request handling, and core
 //! authority state live in separate crates.
 
-#[cfg(all(feature = "linux-shared-memory", target_os = "linux"))]
+#[cfg(all(feature = "linux-userland", target_os = "linux"))]
 pub mod shared_memory;
 
-#[cfg(all(feature = "unix", unix))]
+#[cfg(all(feature = "linux-userland", target_os = "linux"))]
 pub mod unix_socket;
 
-#[cfg(any(
-    all(feature = "linux-shared-memory", target_os = "linux"),
-    all(feature = "unix", unix)
-))]
+#[cfg(all(feature = "linux-userland", target_os = "linux"))]
 mod unix_io;

--- a/litebox_broker_transport/src/lib.rs
+++ b/litebox_broker_transport/src/lib.rs
@@ -14,3 +14,9 @@ pub mod shared_memory;
 
 #[cfg(all(feature = "unix", unix))]
 pub mod unix_socket;
+
+#[cfg(any(
+    all(feature = "linux-shared-memory", target_os = "linux"),
+    all(feature = "unix", unix)
+))]
+mod unix_io;

--- a/litebox_broker_transport/src/shared_memory.rs
+++ b/litebox_broker_transport/src/shared_memory.rs
@@ -9,7 +9,7 @@ use std::os::fd::{AsFd, AsRawFd, BorrowedFd, OwnedFd};
 use std::os::unix::net::UnixStream;
 use std::ptr::NonNull;
 use std::sync::Mutex;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use rustix::fs::{
     MemfdFlags, SealFlags, fcntl_add_seals, fcntl_get_seals, fstat, ftruncate, memfd_create,
@@ -21,6 +21,10 @@ use rustix::net::{
 };
 
 use litebox_broker_protocol::shared_memory::{SharedMemory, SharedMemoryError};
+
+use crate::unix_io::{
+    refresh_read_deadline, refresh_write_deadline, with_read_deadline, with_write_deadline,
+};
 
 const REQUIRED_MEMFD_SEALS: SealFlags = SealFlags::from_bits_retain(
     SealFlags::GROW.bits() | SealFlags::SHRINK.bits() | SealFlags::SEAL.bits(),
@@ -280,67 +284,6 @@ fn receive_fd(stream: &mut UnixStream, deadline: Option<Instant>) -> IoResult<Ow
         .expect("exactly one received descriptor was validated"))
 }
 
-fn with_read_deadline<Output>(
-    stream: &mut UnixStream,
-    deadline: Option<Instant>,
-    operation: impl FnOnce(&mut UnixStream, Option<Instant>) -> IoResult<Output>,
-) -> IoResult<Output> {
-    let Some(_) = deadline else {
-        return operation(stream, None);
-    };
-    let previous = stream.read_timeout()?;
-    let result = operation(stream, deadline);
-    combine_result_with_restore(result, stream.set_read_timeout(previous))
-}
-
-fn with_write_deadline<Output>(
-    stream: &mut UnixStream,
-    deadline: Option<Instant>,
-    operation: impl FnOnce(&mut UnixStream, Option<Instant>) -> IoResult<Output>,
-) -> IoResult<Output> {
-    let Some(_) = deadline else {
-        return operation(stream, None);
-    };
-    let previous = stream.write_timeout()?;
-    let result = operation(stream, deadline);
-    combine_result_with_restore(result, stream.set_write_timeout(previous))
-}
-
-fn refresh_read_deadline(stream: &UnixStream, deadline: Option<Instant>) -> IoResult<()> {
-    if let Some(deadline) = deadline {
-        stream.set_read_timeout(Some(io_timeout_for_deadline(deadline)?))?;
-    }
-    Ok(())
-}
-
-fn refresh_write_deadline(stream: &UnixStream, deadline: Option<Instant>) -> IoResult<()> {
-    if let Some(deadline) = deadline {
-        stream.set_write_timeout(Some(io_timeout_for_deadline(deadline)?))?;
-    }
-    Ok(())
-}
-
-fn combine_result_with_restore<Output>(
-    result: IoResult<Output>,
-    restore: IoResult<()>,
-) -> IoResult<Output> {
-    match (result, restore) {
-        (Ok(output), Ok(())) => Ok(output),
-        (Err(error), Ok(())) | (Ok(_), Err(error)) => Err(error),
-        (Err(operation), Err(restore)) => Err(Error::new(
-            operation.kind(),
-            format!("{operation}; additionally failed to restore socket timeout: {restore}"),
-        )),
-    }
-}
-
-fn io_timeout_for_deadline(deadline: Instant) -> IoResult<Duration> {
-    deadline
-        .checked_duration_since(Instant::now())
-        .filter(|timeout| !timeout.is_zero())
-        .ok_or_else(|| Error::new(ErrorKind::TimedOut, "shared-memory setup deadline expired"))
-}
-
 impl Drop for MappedRegion {
     fn drop(&mut self) {
         // SAFETY: `address` and `length` describe the mapping exclusively owned
@@ -359,6 +302,7 @@ mod tests {
     use super::*;
     use rustix::io::FdFlags;
     use std::io::Write;
+    use std::time::Duration;
 
     #[test]
     fn mappings_share_bytes_and_validate_ranges() {

--- a/litebox_broker_transport/src/unix_io.rs
+++ b/litebox_broker_transport/src/unix_io.rs
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+use std::io::{Error, ErrorKind, Result as IoResult};
+use std::os::unix::net::UnixStream;
+use std::time::{Duration, Instant};
+
+pub(crate) fn with_read_deadline<Output>(
+    stream: &mut UnixStream,
+    deadline: Option<Instant>,
+    operation: impl FnOnce(&mut UnixStream, Option<Instant>) -> IoResult<Output>,
+) -> IoResult<Output> {
+    let Some(_) = deadline else {
+        return operation(stream, None);
+    };
+    let previous = stream.read_timeout()?;
+    let result = operation(stream, deadline);
+    combine_result_with_restore(result, stream.set_read_timeout(previous))
+}
+
+pub(crate) fn with_write_deadline<Output>(
+    stream: &mut UnixStream,
+    deadline: Option<Instant>,
+    operation: impl FnOnce(&mut UnixStream, Option<Instant>) -> IoResult<Output>,
+) -> IoResult<Output> {
+    let Some(_) = deadline else {
+        return operation(stream, None);
+    };
+    let previous = stream.write_timeout()?;
+    let result = operation(stream, deadline);
+    combine_result_with_restore(result, stream.set_write_timeout(previous))
+}
+
+pub(crate) fn refresh_read_deadline(
+    stream: &UnixStream,
+    deadline: Option<Instant>,
+) -> IoResult<()> {
+    if let Some(deadline) = deadline {
+        stream.set_read_timeout(Some(io_timeout_for_deadline(deadline)?))?;
+    }
+    Ok(())
+}
+
+pub(crate) fn refresh_write_deadline(
+    stream: &UnixStream,
+    deadline: Option<Instant>,
+) -> IoResult<()> {
+    if let Some(deadline) = deadline {
+        stream.set_write_timeout(Some(io_timeout_for_deadline(deadline)?))?;
+    }
+    Ok(())
+}
+
+fn combine_result_with_restore<Output>(
+    result: IoResult<Output>,
+    restore: IoResult<()>,
+) -> IoResult<Output> {
+    match (result, restore) {
+        (Ok(output), Ok(())) => Ok(output),
+        (Err(error), Ok(())) | (Ok(_), Err(error)) => Err(error),
+        (Err(operation), Err(restore)) => Err(Error::new(
+            operation.kind(),
+            format!("{operation}; additionally failed to restore socket timeout: {restore}"),
+        )),
+    }
+}
+
+fn io_timeout_for_deadline(deadline: Instant) -> IoResult<Duration> {
+    deadline
+        .checked_duration_since(Instant::now())
+        .filter(|timeout| !timeout.is_zero())
+        .ok_or_else(|| Error::new(ErrorKind::TimedOut, "broker setup deadline expired"))
+}

--- a/litebox_broker_transport/src/unix_socket.rs
+++ b/litebox_broker_transport/src/unix_socket.rs
@@ -11,10 +11,13 @@ use std::io::{Error, ErrorKind, Read, Result as IoResult, Write};
 use std::net::Shutdown;
 use std::os::unix::net::UnixStream;
 use std::path::Path;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 #[cfg(all(feature = "linux-shared-memory", target_os = "linux"))]
 use crate::shared_memory::MemfdSharedMemory;
+use crate::unix_io::{
+    refresh_read_deadline, refresh_write_deadline, with_read_deadline, with_write_deadline,
+};
 use litebox_broker_protocol::channel::{
     HostControlChannel, HostNotificationChannel, HostReceive, LocalControlChannel,
     LocalNotificationChannel, PeerCredential,
@@ -308,40 +311,38 @@ fn read_frame_with_deadline(
     stream: &mut UnixStream,
     deadline: Option<Instant>,
 ) -> IoResult<Option<Vec<u8>>> {
-    with_read_deadline(stream, deadline, read_frame)
-}
-
-fn read_frame(stream: &mut UnixStream, deadline: Option<Instant>) -> IoResult<Option<Vec<u8>>> {
-    let mut len_buf = [0; 4];
-    let mut read = 0;
-    while read < len_buf.len() {
-        refresh_read_deadline(stream, deadline)?;
-        match stream.read(&mut len_buf[read..]) {
-            Ok(0) if read == 0 => return Ok(None),
-            Ok(0) => return Err(invalid_data("truncated broker frame length")),
-            Ok(len) => read += len,
-            Err(error) if error.kind() == ErrorKind::Interrupted => {}
-            Err(error) => return Err(error),
+    with_read_deadline(stream, deadline, |stream, deadline| {
+        let mut len_buf = [0; 4];
+        let mut read = 0;
+        while read < len_buf.len() {
+            refresh_read_deadline(stream, deadline)?;
+            match stream.read(&mut len_buf[read..]) {
+                Ok(0) if read == 0 => return Ok(None),
+                Ok(0) => return Err(invalid_data("truncated broker frame length")),
+                Ok(len) => read += len,
+                Err(error) if error.kind() == ErrorKind::Interrupted => {}
+                Err(error) => return Err(error),
+            }
         }
-    }
 
-    let len = u32::from_le_bytes(len_buf) as usize;
-    if len == 0 || len > MAX_FRAME_LEN {
-        return Err(invalid_data("invalid broker frame length"));
-    }
-
-    let mut frame = vec![0; len];
-    let mut read = 0;
-    while read < frame.len() {
-        refresh_read_deadline(stream, deadline)?;
-        match stream.read(&mut frame[read..]) {
-            Ok(0) => return Err(invalid_data("truncated broker frame")),
-            Ok(len) => read += len,
-            Err(error) if error.kind() == ErrorKind::Interrupted => {}
-            Err(error) => return Err(error),
+        let len = u32::from_le_bytes(len_buf) as usize;
+        if len == 0 || len > MAX_FRAME_LEN {
+            return Err(invalid_data("invalid broker frame length"));
         }
-    }
-    Ok(Some(frame))
+
+        let mut frame = vec![0; len];
+        let mut read = 0;
+        while read < frame.len() {
+            refresh_read_deadline(stream, deadline)?;
+            match stream.read(&mut frame[read..]) {
+                Ok(0) => return Err(invalid_data("truncated broker frame")),
+                Ok(len) => read += len,
+                Err(error) if error.kind() == ErrorKind::Interrupted => {}
+                Err(error) => return Err(error),
+            }
+        }
+        Ok(Some(frame))
+    })
 }
 
 fn write_frame_with_deadline(
@@ -350,17 +351,13 @@ fn write_frame_with_deadline(
     deadline: Option<Instant>,
 ) -> IoResult<()> {
     with_write_deadline(stream, deadline, |stream, deadline| {
-        write_frame(stream, frame, deadline)
+        if frame.is_empty() || frame.len() > MAX_FRAME_LEN {
+            return Err(invalid_data("invalid broker frame length"));
+        }
+        let len = u32::try_from(frame.len()).map_err(|_| invalid_data("broker frame too large"))?;
+        write_all_with_deadline(stream, &len.to_le_bytes(), deadline)?;
+        write_all_with_deadline(stream, frame, deadline)
     })
-}
-
-fn write_frame(stream: &mut UnixStream, frame: &[u8], deadline: Option<Instant>) -> IoResult<()> {
-    if frame.is_empty() || frame.len() > MAX_FRAME_LEN {
-        return Err(invalid_data("invalid broker frame length"));
-    }
-    let len = u32::try_from(frame.len()).map_err(|_| invalid_data("broker frame too large"))?;
-    write_all_with_deadline(stream, &len.to_le_bytes(), deadline)?;
-    write_all_with_deadline(stream, frame, deadline)
 }
 
 fn write_all_with_deadline(
@@ -385,69 +382,6 @@ fn write_all_with_deadline(
     Ok(())
 }
 
-fn with_read_deadline<Output>(
-    stream: &mut UnixStream,
-    deadline: Option<Instant>,
-    operation: impl FnOnce(&mut UnixStream, Option<Instant>) -> IoResult<Output>,
-) -> IoResult<Output> {
-    let Some(_) = deadline else {
-        return operation(stream, None);
-    };
-    let previous = stream.read_timeout()?;
-    let result = operation(stream, deadline);
-    combine_result_with_restore(result, stream.set_read_timeout(previous))
-}
-
-fn with_write_deadline<Output>(
-    stream: &mut UnixStream,
-    deadline: Option<Instant>,
-    operation: impl FnOnce(&mut UnixStream, Option<Instant>) -> IoResult<Output>,
-) -> IoResult<Output> {
-    let Some(_) = deadline else {
-        return operation(stream, None);
-    };
-    let previous = stream.write_timeout()?;
-    let result = operation(stream, deadline);
-    combine_result_with_restore(result, stream.set_write_timeout(previous))
-}
-
-fn refresh_read_deadline(stream: &UnixStream, deadline: Option<Instant>) -> IoResult<()> {
-    if let Some(deadline) = deadline {
-        stream.set_read_timeout(Some(io_timeout_for_deadline(deadline)?))?;
-    }
-    Ok(())
-}
-
-fn refresh_write_deadline(stream: &UnixStream, deadline: Option<Instant>) -> IoResult<()> {
-    if let Some(deadline) = deadline {
-        let timeout = io_timeout_for_deadline(deadline)?;
-        stream.set_write_timeout(Some(timeout))?;
-    }
-    Ok(())
-}
-
-fn combine_result_with_restore<Output>(
-    result: IoResult<Output>,
-    restore: IoResult<()>,
-) -> IoResult<Output> {
-    match (result, restore) {
-        (Ok(output), Ok(())) => Ok(output),
-        (Err(error), Ok(())) | (Ok(_), Err(error)) => Err(error),
-        (Err(operation), Err(restore)) => Err(Error::new(
-            operation.kind(),
-            format!("{operation}; additionally failed to restore socket timeout: {restore}"),
-        )),
-    }
-}
-
-fn io_timeout_for_deadline(deadline: Instant) -> IoResult<Duration> {
-    let timeout = deadline
-        .checked_duration_since(Instant::now())
-        .filter(|timeout| !timeout.is_zero())
-        .ok_or_else(|| Error::new(ErrorKind::TimedOut, "broker I/O deadline expired"))?;
-    Ok(timeout)
-}
-
 fn invalid_data(message: &'static str) -> Error {
     Error::new(ErrorKind::InvalidData, message)
 }
@@ -462,6 +396,7 @@ fn wire_error(error: WireError) -> Error {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::Duration;
 
     #[cfg(all(feature = "linux-peer-credentials", target_os = "linux"))]
     #[test]

--- a/litebox_broker_transport/src/unix_socket.rs
+++ b/litebox_broker_transport/src/unix_socket.rs
@@ -213,10 +213,7 @@ impl LocalControlChannel for UnixStreamLocalControlChannel {
 
     fn recv_handshake_response(&mut self) -> IoResult<Option<BrokerHandshakeResponse>> {
         let frame = read_frame_with_deadline(&mut self.stream, self.setup_deadline)?;
-        if self.setup_deadline.take().is_some() {
-            self.stream.set_read_timeout(None)?;
-            self.stream.set_write_timeout(None)?;
-        }
+        self.setup_deadline = None;
         match frame {
             Some(frame) => decode_handshake_response(&frame)
                 .map(Some)
@@ -262,11 +259,8 @@ impl HostControlChannel for UnixStreamHostControlChannel {
             &encode_handshake_response(response.clone()),
             self.setup_deadline,
         )?;
-        if matches!(response, BrokerHandshakeResponse::Negotiated { .. })
-            && self.setup_deadline.take().is_some()
-        {
-            self.stream.set_read_timeout(None)?;
-            self.stream.set_write_timeout(None)?;
+        if matches!(response, BrokerHandshakeResponse::Negotiated { .. }) {
+            self.setup_deadline = None;
         }
         Ok(())
     }
@@ -314,10 +308,14 @@ fn read_frame_with_deadline(
     stream: &mut UnixStream,
     deadline: Option<Instant>,
 ) -> IoResult<Option<Vec<u8>>> {
+    with_read_deadline(stream, deadline, read_frame)
+}
+
+fn read_frame(stream: &mut UnixStream, deadline: Option<Instant>) -> IoResult<Option<Vec<u8>>> {
     let mut len_buf = [0; 4];
     let mut read = 0;
     while read < len_buf.len() {
-        refresh_stream_io_deadline(stream, deadline)?;
+        refresh_read_deadline(stream, deadline)?;
         match stream.read(&mut len_buf[read..]) {
             Ok(0) if read == 0 => return Ok(None),
             Ok(0) => return Err(invalid_data("truncated broker frame length")),
@@ -335,7 +333,7 @@ fn read_frame_with_deadline(
     let mut frame = vec![0; len];
     let mut read = 0;
     while read < frame.len() {
-        refresh_stream_io_deadline(stream, deadline)?;
+        refresh_read_deadline(stream, deadline)?;
         match stream.read(&mut frame[read..]) {
             Ok(0) => return Err(invalid_data("truncated broker frame")),
             Ok(len) => read += len,
@@ -351,6 +349,12 @@ fn write_frame_with_deadline(
     frame: &[u8],
     deadline: Option<Instant>,
 ) -> IoResult<()> {
+    with_write_deadline(stream, deadline, |stream, deadline| {
+        write_frame(stream, frame, deadline)
+    })
+}
+
+fn write_frame(stream: &mut UnixStream, frame: &[u8], deadline: Option<Instant>) -> IoResult<()> {
     if frame.is_empty() || frame.len() > MAX_FRAME_LEN {
         return Err(invalid_data("invalid broker frame length"));
     }
@@ -365,7 +369,7 @@ fn write_all_with_deadline(
     deadline: Option<Instant>,
 ) -> IoResult<()> {
     while !buffer.is_empty() {
-        refresh_stream_io_deadline(stream, deadline)?;
+        refresh_write_deadline(stream, deadline)?;
         match stream.write(buffer) {
             Ok(0) => {
                 return Err(Error::new(
@@ -381,13 +385,59 @@ fn write_all_with_deadline(
     Ok(())
 }
 
-fn refresh_stream_io_deadline(stream: &UnixStream, deadline: Option<Instant>) -> IoResult<()> {
+fn with_read_deadline<Output>(
+    stream: &mut UnixStream,
+    deadline: Option<Instant>,
+    operation: impl FnOnce(&mut UnixStream, Option<Instant>) -> IoResult<Output>,
+) -> IoResult<Output> {
+    let Some(_) = deadline else {
+        return operation(stream, None);
+    };
+    let previous = stream.read_timeout()?;
+    let result = operation(stream, deadline);
+    combine_result_with_restore(result, stream.set_read_timeout(previous))
+}
+
+fn with_write_deadline<Output>(
+    stream: &mut UnixStream,
+    deadline: Option<Instant>,
+    operation: impl FnOnce(&mut UnixStream, Option<Instant>) -> IoResult<Output>,
+) -> IoResult<Output> {
+    let Some(_) = deadline else {
+        return operation(stream, None);
+    };
+    let previous = stream.write_timeout()?;
+    let result = operation(stream, deadline);
+    combine_result_with_restore(result, stream.set_write_timeout(previous))
+}
+
+fn refresh_read_deadline(stream: &UnixStream, deadline: Option<Instant>) -> IoResult<()> {
+    if let Some(deadline) = deadline {
+        stream.set_read_timeout(Some(io_timeout_for_deadline(deadline)?))?;
+    }
+    Ok(())
+}
+
+fn refresh_write_deadline(stream: &UnixStream, deadline: Option<Instant>) -> IoResult<()> {
     if let Some(deadline) = deadline {
         let timeout = io_timeout_for_deadline(deadline)?;
-        stream.set_read_timeout(Some(timeout))?;
         stream.set_write_timeout(Some(timeout))?;
     }
     Ok(())
+}
+
+fn combine_result_with_restore<Output>(
+    result: IoResult<Output>,
+    restore: IoResult<()>,
+) -> IoResult<Output> {
+    match (result, restore) {
+        (Ok(output), Ok(())) => Ok(output),
+        (Err(error), Ok(())) | (Ok(_), Err(error)) => Err(error),
+        (Err(operation), Err(restore)) => Err(Error::new(
+            operation.kind(),
+            format!("{operation}; additionally failed to restore socket timeout: {restore}"),
+        )),
+    }
 }
 
 fn io_timeout_for_deadline(deadline: Instant) -> IoResult<Duration> {
@@ -547,13 +597,30 @@ mod tests {
     }
 
     #[test]
-    fn negotiated_host_handshake_clears_setup_deadline() {
-        let (_local_stream, host_stream) = UnixStream::pair().unwrap();
+    fn negotiated_host_handshake_restores_active_timeouts() {
+        let (mut local_stream, host_stream) = UnixStream::pair().unwrap();
+        let active_read_timeout = Some(Duration::from_secs(2));
+        let active_write_timeout = Some(Duration::from_secs(3));
+        host_stream.set_read_timeout(active_read_timeout).unwrap();
+        host_stream.set_write_timeout(active_write_timeout).unwrap();
         let mut channel = UnixStreamHostControlChannel::from_host_guaranteed(
             host_stream,
             Instant::now() + Duration::from_secs(1),
         );
+        let request = BrokerHandshakeRequest {
+            protocol_version: litebox_broker_protocol::BROKER_PROTOCOL_VERSION,
+        };
 
+        write_frame_with_deadline(
+            &mut local_stream,
+            &encode_handshake_request(request.clone()),
+            None,
+        )
+        .unwrap();
+        assert_eq!(
+            channel.recv_handshake_request().unwrap(),
+            HostReceive::Message(request)
+        );
         channel
             .send_handshake_response(&BrokerHandshakeResponse::Negotiated {
                 broker_protocol_version: litebox_broker_protocol::BROKER_PROTOCOL_VERSION,
@@ -561,8 +628,11 @@ mod tests {
             .unwrap();
 
         assert_eq!(channel.setup_deadline, None);
-        assert_eq!(channel.stream.read_timeout().unwrap(), None);
-        assert_eq!(channel.stream.write_timeout().unwrap(), None);
+        assert_eq!(channel.stream.read_timeout().unwrap(), active_read_timeout);
+        assert_eq!(
+            channel.stream.write_timeout().unwrap(),
+            active_write_timeout
+        );
     }
 
     #[test]

--- a/litebox_broker_transport/src/unix_socket.rs
+++ b/litebox_broker_transport/src/unix_socket.rs
@@ -31,49 +31,35 @@ use litebox_broker_protocol::wire::{
 
 const MAX_FRAME_LEN: usize = 64 * 1024;
 
-/// Kernel-authenticated credentials for one Linux Unix-socket peer.
+/// Validates that a connected Unix socket belongs to `expected_process_id`.
 #[cfg(all(feature = "linux-peer-credentials", target_os = "linux"))]
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct UnixPeerCredentials {
-    pid: u32,
-    uid: u32,
-    gid: u32,
+pub fn validate_peer_process(stream: &UnixStream, expected_process_id: u32) -> IoResult<()> {
+    if peer_process_id(stream)? != expected_process_id {
+        return Err(Error::new(
+            ErrorKind::PermissionDenied,
+            "Unix socket peer is not the expected process",
+        ));
+    }
+    Ok(())
+}
+
+/// Validates that two connected Unix sockets belong to the same process.
+#[cfg(all(feature = "linux-peer-credentials", target_os = "linux"))]
+pub fn validate_same_peer_process(first: &UnixStream, second: &UnixStream) -> IoResult<()> {
+    if peer_process_id(first)? != peer_process_id(second)? {
+        return Err(Error::new(
+            ErrorKind::PermissionDenied,
+            "Unix sockets belong to different peer processes",
+        ));
+    }
+    Ok(())
 }
 
 #[cfg(all(feature = "linux-peer-credentials", target_os = "linux"))]
-impl UnixPeerCredentials {
-    /// Creates a credential value from raw Linux process, user, and group IDs.
-    pub const fn from_raw(pid: u32, uid: u32, gid: u32) -> Self {
-        Self { pid, uid, gid }
-    }
-
-    /// Returns the peer process ID.
-    pub const fn process_id(self) -> u32 {
-        self.pid
-    }
-
-    /// Returns the peer user ID.
-    pub const fn user_id(self) -> u32 {
-        self.uid
-    }
-
-    /// Returns the peer group ID.
-    pub const fn group_id(self) -> u32 {
-        self.gid
-    }
-}
-
-/// Returns Linux kernel-authenticated credentials for a connected Unix peer.
-#[cfg(all(feature = "linux-peer-credentials", target_os = "linux"))]
-pub fn peer_credentials(stream: &UnixStream) -> IoResult<UnixPeerCredentials> {
+fn peer_process_id(stream: &UnixStream) -> IoResult<u32> {
     let credentials = rustix::net::sockopt::socket_peercred(stream)?;
-    let process_id = u32::try_from(credentials.pid.as_raw_pid())
-        .map_err(|_| invalid_data("Unix peer process ID is invalid"))?;
-    Ok(UnixPeerCredentials::from_raw(
-        process_id,
-        credentials.uid.as_raw(),
-        credentials.gid.as_raw(),
-    ))
+    u32::try_from(credentials.pid.as_raw_pid())
+        .map_err(|_| invalid_data("Unix peer process ID is invalid"))
 }
 
 /// Local-side Unix-domain-socket control channel for the hosted userland POC.
@@ -429,13 +415,18 @@ mod tests {
 
     #[cfg(all(feature = "linux-peer-credentials", target_os = "linux"))]
     #[test]
-    fn linux_peer_credentials_identify_connected_process() {
+    fn linux_peer_validation_identifies_connected_process() {
         let (first, second) = UnixStream::pair().unwrap();
 
-        let first_peer = peer_credentials(&first).unwrap();
-        let second_peer = peer_credentials(&second).unwrap();
-        assert_eq!(first_peer, second_peer);
-        assert_eq!(first_peer.process_id(), std::process::id());
+        validate_peer_process(&first, std::process::id()).unwrap();
+        validate_same_peer_process(&first, &second).unwrap();
+        let unexpected_process_id = std::process::id().checked_add(1).unwrap();
+        assert_eq!(
+            validate_peer_process(&first, unexpected_process_id)
+                .unwrap_err()
+                .kind(),
+            ErrorKind::PermissionDenied
+        );
     }
 
     #[test]

--- a/litebox_broker_transport/src/unix_socket.rs
+++ b/litebox_broker_transport/src/unix_socket.rs
@@ -13,7 +13,6 @@ use std::os::unix::net::UnixStream;
 use std::path::Path;
 use std::time::Instant;
 
-#[cfg(all(feature = "linux-shared-memory", target_os = "linux"))]
 use crate::shared_memory::MemfdSharedMemory;
 use crate::unix_io::{
     refresh_read_deadline, refresh_write_deadline, with_read_deadline, with_write_deadline,
@@ -35,7 +34,6 @@ use litebox_broker_protocol::wire::{
 const MAX_FRAME_LEN: usize = 64 * 1024;
 
 /// Validates that a connected Unix socket belongs to `expected_process_id`.
-#[cfg(all(feature = "linux-peer-credentials", target_os = "linux"))]
 pub fn validate_peer_process(stream: &UnixStream, expected_process_id: u32) -> IoResult<()> {
     if peer_process_id(stream)? != expected_process_id {
         return Err(Error::new(
@@ -47,7 +45,6 @@ pub fn validate_peer_process(stream: &UnixStream, expected_process_id: u32) -> I
 }
 
 /// Validates that two connected Unix sockets belong to the same process.
-#[cfg(all(feature = "linux-peer-credentials", target_os = "linux"))]
 pub fn validate_same_peer_process(first: &UnixStream, second: &UnixStream) -> IoResult<()> {
     if peer_process_id(first)? != peer_process_id(second)? {
         return Err(Error::new(
@@ -58,7 +55,6 @@ pub fn validate_same_peer_process(first: &UnixStream, second: &UnixStream) -> Io
     Ok(())
 }
 
-#[cfg(all(feature = "linux-peer-credentials", target_os = "linux"))]
 fn peer_process_id(stream: &UnixStream) -> IoResult<u32> {
     let credentials = rustix::net::sockopt::socket_peercred(stream)?;
     u32::try_from(credentials.pid.as_raw_pid())
@@ -113,7 +109,6 @@ impl UnixStreamLocalControlChannel {
     }
 
     /// Receives the memfd associated with this control channel.
-    #[cfg(all(feature = "linux-shared-memory", target_os = "linux"))]
     pub fn receive_memfd(
         &mut self,
         expected_len: usize,
@@ -177,7 +172,6 @@ impl UnixStreamHostControlChannel {
     }
 
     /// Sends the memfd associated with this control channel.
-    #[cfg(all(feature = "linux-shared-memory", target_os = "linux"))]
     pub fn send_memfd(
         &mut self,
         shared_memory: &MemfdSharedMemory,
@@ -398,7 +392,6 @@ mod tests {
     use super::*;
     use std::time::Duration;
 
-    #[cfg(all(feature = "linux-peer-credentials", target_os = "linux"))]
     #[test]
     fn linux_peer_validation_identifies_connected_process() {
         let (first, second) = UnixStream::pair().unwrap();

--- a/litebox_broker_transport/src/unix_socket.rs
+++ b/litebox_broker_transport/src/unix_socket.rs
@@ -31,6 +31,51 @@ use litebox_broker_protocol::wire::{
 
 const MAX_FRAME_LEN: usize = 64 * 1024;
 
+/// Kernel-authenticated credentials for one Linux Unix-socket peer.
+#[cfg(all(feature = "linux-peer-credentials", target_os = "linux"))]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct UnixPeerCredentials {
+    pid: u32,
+    uid: u32,
+    gid: u32,
+}
+
+#[cfg(all(feature = "linux-peer-credentials", target_os = "linux"))]
+impl UnixPeerCredentials {
+    /// Creates a credential value from raw Linux process, user, and group IDs.
+    pub const fn from_raw(pid: u32, uid: u32, gid: u32) -> Self {
+        Self { pid, uid, gid }
+    }
+
+    /// Returns the peer process ID.
+    pub const fn process_id(self) -> u32 {
+        self.pid
+    }
+
+    /// Returns the peer user ID.
+    pub const fn user_id(self) -> u32 {
+        self.uid
+    }
+
+    /// Returns the peer group ID.
+    pub const fn group_id(self) -> u32 {
+        self.gid
+    }
+}
+
+/// Returns Linux kernel-authenticated credentials for a connected Unix peer.
+#[cfg(all(feature = "linux-peer-credentials", target_os = "linux"))]
+pub fn peer_credentials(stream: &UnixStream) -> IoResult<UnixPeerCredentials> {
+    let credentials = rustix::net::sockopt::socket_peercred(stream)?;
+    let process_id = u32::try_from(credentials.pid.as_raw_pid())
+        .map_err(|_| invalid_data("Unix peer process ID is invalid"))?;
+    Ok(UnixPeerCredentials::from_raw(
+        process_id,
+        credentials.uid.as_raw(),
+        credentials.gid.as_raw(),
+    ))
+}
+
 /// Local-side Unix-domain-socket control channel for the hosted userland POC.
 pub struct UnixStreamLocalControlChannel {
     stream: UnixStream,
@@ -108,6 +153,8 @@ impl Drop for UnixStreamLocalControlChannel {
 /// Host-side Unix-domain-socket control channel for the hosted userland POC.
 pub struct UnixStreamHostControlChannel {
     stream: UnixStream,
+    peer_credential: PeerCredential,
+    setup_deadline: Option<Instant>,
 }
 
 /// Local-side Unix-domain-socket notification channel for the hosted userland POC.
@@ -123,7 +170,21 @@ pub struct UnixStreamHostNotificationChannel {
 impl UnixStreamHostControlChannel {
     /// Creates a host control channel from an accepted Unix stream.
     pub const fn from_accepted(stream: UnixStream) -> Self {
-        Self { stream }
+        Self {
+            stream,
+            peer_credential: PeerCredential::Unauthenticated,
+            setup_deadline: None,
+        }
+    }
+
+    /// Creates a host control channel after the deployment has authenticated
+    /// and bound the accepted peer. `setup_deadline` bounds handshake I/O.
+    pub const fn from_host_guaranteed(stream: UnixStream, setup_deadline: Instant) -> Self {
+        Self {
+            stream,
+            peer_credential: PeerCredential::HostGuaranteed,
+            setup_deadline: Some(setup_deadline),
+        }
     }
 
     /// Sends the memfd associated with this control channel.
@@ -195,13 +256,11 @@ impl HostControlChannel for UnixStreamHostControlChannel {
     type Error = Error;
 
     fn peer_credential(&self) -> IoResult<PeerCredential> {
-        // TODO(broker): replace the PoC placeholder with Unix peer credential extraction
-        // before this channel is used as an authenticated deployment boundary.
-        Ok(PeerCredential::Unauthenticated)
+        Ok(self.peer_credential)
     }
 
     fn recv_handshake_request(&mut self) -> IoResult<HostReceive<BrokerHandshakeRequest>> {
-        let Some(frame) = read_frame_with_deadline(&mut self.stream, None)? else {
+        let Some(frame) = read_frame_with_deadline(&mut self.stream, self.setup_deadline)? else {
             return Ok(HostReceive::PeerClosed);
         };
         match decode_handshake_request(&frame) {
@@ -215,8 +274,15 @@ impl HostControlChannel for UnixStreamHostControlChannel {
         write_frame_with_deadline(
             &mut self.stream,
             &encode_handshake_response(response.clone()),
-            None,
-        )
+            self.setup_deadline,
+        )?;
+        if matches!(response, BrokerHandshakeResponse::Negotiated { .. })
+            && self.setup_deadline.take().is_some()
+        {
+            self.stream.set_read_timeout(None)?;
+            self.stream.set_write_timeout(None)?;
+        }
+        Ok(())
     }
 
     fn recv_request(&mut self) -> IoResult<HostReceive<BrokerRequest>> {
@@ -361,6 +427,17 @@ fn wire_error(error: WireError) -> Error {
 mod tests {
     use super::*;
 
+    #[cfg(all(feature = "linux-peer-credentials", target_os = "linux"))]
+    #[test]
+    fn linux_peer_credentials_identify_connected_process() {
+        let (first, second) = UnixStream::pair().unwrap();
+
+        let first_peer = peer_credentials(&first).unwrap();
+        let second_peer = peer_credentials(&second).unwrap();
+        assert_eq!(first_peer, second_peer);
+        assert_eq!(first_peer.process_id(), std::process::id());
+    }
+
     #[test]
     fn frame_round_trip() {
         let (mut writer, mut reader) = UnixStream::pair().unwrap();
@@ -452,6 +529,49 @@ mod tests {
             matches!(error.kind(), ErrorKind::WouldBlock | ErrorKind::TimedOut),
             "unexpected timeout error kind: {error:?}"
         );
+    }
+
+    #[test]
+    fn host_handshake_request_read_setup_deadline_is_wall_clock() {
+        let (mut local_stream, host_stream) = UnixStream::pair().unwrap();
+        let mut channel = UnixStreamHostControlChannel::from_host_guaranteed(
+            host_stream,
+            Instant::now() + Duration::from_millis(50),
+        );
+
+        let reader = std::thread::spawn(move || channel.recv_handshake_request().unwrap_err());
+        local_stream.write_all(&8u32.to_le_bytes()).unwrap();
+        for _ in 0..8 {
+            std::thread::sleep(Duration::from_millis(20));
+            if local_stream.write_all(&[0]).is_err() {
+                break;
+            }
+        }
+
+        let error = reader.join().expect("timeout reader panicked");
+        assert!(
+            matches!(error.kind(), ErrorKind::WouldBlock | ErrorKind::TimedOut),
+            "unexpected timeout error kind: {error:?}"
+        );
+    }
+
+    #[test]
+    fn negotiated_host_handshake_clears_setup_deadline() {
+        let (_local_stream, host_stream) = UnixStream::pair().unwrap();
+        let mut channel = UnixStreamHostControlChannel::from_host_guaranteed(
+            host_stream,
+            Instant::now() + Duration::from_secs(1),
+        );
+
+        channel
+            .send_handshake_response(&BrokerHandshakeResponse::Negotiated {
+                broker_protocol_version: litebox_broker_protocol::BROKER_PROTOCOL_VERSION,
+            })
+            .unwrap();
+
+        assert_eq!(channel.setup_deadline, None);
+        assert_eq!(channel.stream.read_timeout().unwrap(), None);
+        assert_eq!(channel.stream.write_timeout().unwrap(), None);
     }
 
     #[test]

--- a/litebox_broker_userland/Cargo.toml
+++ b/litebox_broker_userland/Cargo.toml
@@ -8,7 +8,7 @@ clap = { version = "4.5.33", features = ["derive"] }
 litebox_broker_core = { path = "../litebox_broker_core", version = "0.1.0" }
 litebox_broker_host = { path = "../litebox_broker_host", version = "0.1.0" }
 litebox_broker_protocol = { path = "../litebox_broker_protocol", version = "0.1.0" }
-litebox_broker_transport = { path = "../litebox_broker_transport", version = "0.1.0", features = ["linux-shared-memory", "unix"] }
+litebox_broker_transport = { path = "../litebox_broker_transport", version = "0.1.0", features = ["linux-peer-credentials", "linux-shared-memory", "unix"] }
 tempfile = { version = "3", default-features = false }
 
 [[bin]]
@@ -21,7 +21,6 @@ path = "tests/userland_broker.rs"
 harness = false
 
 [dev-dependencies]
-libc = { version = "0.2.169", default-features = false }
 litebox_broker_local = { path = "../litebox_broker_local", version = "0.1.0" }
 
 [lints]

--- a/litebox_broker_userland/Cargo.toml
+++ b/litebox_broker_userland/Cargo.toml
@@ -8,7 +8,7 @@ clap = { version = "4.5.33", features = ["derive"] }
 litebox_broker_core = { path = "../litebox_broker_core", version = "0.1.0" }
 litebox_broker_host = { path = "../litebox_broker_host", version = "0.1.0" }
 litebox_broker_protocol = { path = "../litebox_broker_protocol", version = "0.1.0" }
-litebox_broker_transport = { path = "../litebox_broker_transport", version = "0.1.0", features = ["linux-peer-credentials", "linux-shared-memory", "unix"] }
+litebox_broker_transport = { path = "../litebox_broker_transport", version = "0.1.0", features = ["linux-userland"] }
 tempfile = { version = "3", default-features = false }
 
 [[bin]]

--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -16,8 +16,7 @@ use litebox_broker_host::{ConnectionTermination, serve_connection};
 use litebox_broker_protocol::pipe::PIPE_TRANSFER_BUFFER_SIZE;
 use litebox_broker_transport::shared_memory::MemfdSharedMemory;
 use litebox_broker_transport::unix_socket::{
-    UnixPeerCredentials, UnixStreamHostControlChannel, UnixStreamHostNotificationChannel,
-    peer_credentials,
+    UnixStreamHostControlChannel, UnixStreamHostNotificationChannel, validate_peer_process,
 };
 
 const SETUP_TIMEOUT: Duration = Duration::from_secs(5);
@@ -85,22 +84,20 @@ fn serve_runner(
     runner_process_id: u32,
 ) -> Result<(), Box<dyn Error>> {
     let setup_deadline = Instant::now() + SETUP_TIMEOUT;
-    let (control_stream, control_credentials) = accept_runner_stream(
+    let control_stream = accept_runner_stream(
         control_listener,
         runner,
         runner_process_id,
         setup_deadline,
         "control",
     )?;
-    let (notification_stream, notification_credentials) = accept_runner_stream(
+    let notification_stream = accept_runner_stream(
         notification_listener,
         runner,
         runner_process_id,
         setup_deadline,
         "notification",
     )?;
-    validate_channel_pair(control_credentials, notification_credentials)?;
-
     let shared_memory = MemfdSharedMemory::create(PIPE_TRANSFER_BUFFER_SIZE)?;
     let mut control_channel =
         UnixStreamHostControlChannel::from_host_guaranteed(control_stream, setup_deadline);
@@ -141,7 +138,7 @@ fn accept_runner_stream(
     runner_process_id: u32,
     deadline: Instant,
     channel_name: &'static str,
-) -> IoResult<(UnixStream, UnixPeerCredentials)> {
+) -> IoResult<UnixStream> {
     loop {
         let remaining = deadline.saturating_duration_since(Instant::now());
         if remaining.is_zero() {
@@ -159,58 +156,12 @@ fn accept_runner_stream(
 
         match listener.accept() {
             Ok((stream, _)) => {
-                let credentials = peer_credentials(&stream)?;
-                validate_runner_peer(credentials, runner_process_id)?;
-                return Ok((stream, credentials));
+                validate_peer_process(&stream, runner_process_id)?;
+                return Ok(stream);
             }
             Err(error) if error.kind() == ErrorKind::WouldBlock => {}
             Err(error) => return Err(error),
         }
         std::thread::sleep(remaining.min(ACCEPT_RETRY_DELAY));
-    }
-}
-
-fn validate_runner_peer(credentials: UnixPeerCredentials, runner_process_id: u32) -> IoResult<()> {
-    if credentials.process_id() != runner_process_id {
-        return Err(IoError::new(
-            ErrorKind::PermissionDenied,
-            "broker channel peer is not the spawned runner",
-        ));
-    }
-    Ok(())
-}
-
-fn validate_channel_pair(
-    control: UnixPeerCredentials,
-    notification: UnixPeerCredentials,
-) -> IoResult<()> {
-    if control != notification {
-        return Err(IoError::new(
-            ErrorKind::PermissionDenied,
-            "broker control and notification channels have different peers",
-        ));
-    }
-    Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn runner_channel_validation_rejects_unexpected_or_mismatched_peers() {
-        let runner = UnixPeerCredentials::from_raw(7, 8, 9);
-        assert!(validate_runner_peer(runner, 7).is_ok());
-        assert_eq!(
-            validate_runner_peer(runner, 6).unwrap_err().kind(),
-            ErrorKind::PermissionDenied
-        );
-        assert!(validate_channel_pair(runner, runner).is_ok());
-        assert_eq!(
-            validate_channel_pair(runner, UnixPeerCredentials::from_raw(7, 10, 9))
-                .unwrap_err()
-                .kind(),
-            ErrorKind::PermissionDenied
-        );
     }
 }

--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -1,23 +1,27 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+use std::cell::Cell;
 use std::error::Error;
 use std::ffi::OsString;
-use std::os::unix::net::UnixListener;
+use std::io::{Error as IoError, ErrorKind, Result as IoResult};
+use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::PathBuf;
-use std::process::Command;
+use std::process::{Child, Command};
 use std::time::{Duration, Instant};
 
 use clap::Parser;
 use litebox_broker_core::{BrokerCore, ObjectRights, PolicyEngine};
-use litebox_broker_host::serve_connection;
+use litebox_broker_host::{ConnectionTermination, serve_connection};
 use litebox_broker_protocol::pipe::PIPE_TRANSFER_BUFFER_SIZE;
 use litebox_broker_transport::shared_memory::MemfdSharedMemory;
 use litebox_broker_transport::unix_socket::{
-    UnixStreamHostControlChannel, UnixStreamHostNotificationChannel,
+    UnixPeerCredentials, UnixStreamHostControlChannel, UnixStreamHostNotificationChannel,
+    peer_credentials,
 };
 
 const SETUP_TIMEOUT: Duration = Duration::from_secs(5);
+const ACCEPT_RETRY_DELAY: Duration = Duration::from_millis(10);
 
 #[derive(Parser, Debug)]
 struct CliArgs {
@@ -38,7 +42,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     let notification_socket_path = socket_dir.path().join("broker-notification.sock");
     let control_listener = UnixListener::bind(&control_socket_path)?;
     let notification_listener = UnixListener::bind(&notification_socket_path)?;
-    let broker = BrokerCore::new(PolicyEngine::with_unauthenticated_rights(
+    control_listener.set_nonblocking(true)?;
+    notification_listener.set_nonblocking(true)?;
+    let broker = BrokerCore::new(PolicyEngine::with_host_guaranteed_rights(
         ObjectRights::all(),
     ))?;
 
@@ -51,37 +57,160 @@ fn main() -> Result<(), Box<dyn Error>> {
         .arg(&notification_socket_path)
         .args(&args.runner_arguments);
     let mut runner = runner_command.spawn()?;
-    let _runner_waiter = std::thread::spawn(move || {
-        if let Err(error) = runner.wait() {
-            eprintln!("failed to wait for local runner: {error}");
-        }
-    });
+    let runner_process_id = runner.id();
 
+    let association_result = serve_runner(
+        &broker,
+        &control_listener,
+        &notification_listener,
+        &mut runner,
+        runner_process_id,
+    );
+    if association_result.is_err() {
+        let _ = runner.kill();
+    }
+    let runner_status = runner.wait()?;
+    association_result?;
+    if !runner_status.success() {
+        return Err(IoError::other(format!("runner exited with {runner_status}")).into());
+    }
+    Ok(())
+}
+
+fn serve_runner(
+    broker: &BrokerCore,
+    control_listener: &UnixListener,
+    notification_listener: &UnixListener,
+    runner: &mut Child,
+    runner_process_id: u32,
+) -> Result<(), Box<dyn Error>> {
+    let setup_deadline = Instant::now() + SETUP_TIMEOUT;
+    let (control_stream, control_credentials) = accept_runner_stream(
+        control_listener,
+        runner,
+        runner_process_id,
+        setup_deadline,
+        "control",
+    )?;
+    let (notification_stream, notification_credentials) = accept_runner_stream(
+        notification_listener,
+        runner,
+        runner_process_id,
+        setup_deadline,
+        "notification",
+    )?;
+    validate_channel_pair(control_credentials, notification_credentials)?;
+
+    let shared_memory = MemfdSharedMemory::create(PIPE_TRANSFER_BUFFER_SIZE)?;
+    let mut control_channel =
+        UnixStreamHostControlChannel::from_host_guaranteed(control_stream, setup_deadline);
+    let mut notification_channel =
+        UnixStreamHostNotificationChannel::from_accepted(notification_stream);
+    let setup_completed = Cell::new(false);
+    let termination = serve_connection(
+        broker,
+        &mut control_channel,
+        &mut notification_channel,
+        &shared_memory,
+        |channel| {
+            channel.send_memfd(&shared_memory, Some(setup_deadline))?;
+            setup_completed.set(true);
+            Ok(())
+        },
+    )?;
+    if termination != ConnectionTermination::PeerClosed {
+        return Err(IoError::new(
+            ErrorKind::InvalidData,
+            "runner violated the broker protocol",
+        )
+        .into());
+    }
+    if !setup_completed.get() {
+        return Err(IoError::new(
+            ErrorKind::UnexpectedEof,
+            "runner closed before completing broker setup",
+        )
+        .into());
+    }
+    Ok(())
+}
+
+fn accept_runner_stream(
+    listener: &UnixListener,
+    runner: &mut Child,
+    runner_process_id: u32,
+    deadline: Instant,
+    channel_name: &'static str,
+) -> IoResult<(UnixStream, UnixPeerCredentials)> {
     loop {
-        let (control_stream, _) = control_listener.accept()?;
-        let setup_deadline = Instant::now() + SETUP_TIMEOUT;
-        let shared_memory = MemfdSharedMemory::create(PIPE_TRANSFER_BUFFER_SIZE)?;
-        let (notification_stream, _) = notification_listener.accept()?;
-        let broker = broker.clone();
-        if let Err(error) = std::thread::Builder::new()
-            .name("litebox-broker-connection".to_owned())
-            .spawn(move || {
-                let mut control_channel =
-                    UnixStreamHostControlChannel::from_accepted(control_stream);
-                let mut notification_channel =
-                    UnixStreamHostNotificationChannel::from_accepted(notification_stream);
-                if let Err(error) = serve_connection(
-                    &broker,
-                    &mut control_channel,
-                    &mut notification_channel,
-                    &shared_memory,
-                    |channel| channel.send_memfd(&shared_memory, Some(setup_deadline)),
-                ) {
-                    eprintln!("failed to serve broker connection: {error}");
-                }
-            })
-        {
-            eprintln!("failed to spawn broker connection handler: {error}");
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return Err(IoError::new(
+                ErrorKind::TimedOut,
+                format!("timed out waiting for runner {channel_name} channel"),
+            ));
         }
+        if let Some(status) = runner.try_wait()? {
+            return Err(IoError::new(
+                ErrorKind::BrokenPipe,
+                format!("runner exited with {status} before connecting its {channel_name} channel"),
+            ));
+        }
+
+        match listener.accept() {
+            Ok((stream, _)) => {
+                let credentials = peer_credentials(&stream)?;
+                validate_runner_peer(credentials, runner_process_id)?;
+                return Ok((stream, credentials));
+            }
+            Err(error) if error.kind() == ErrorKind::WouldBlock => {}
+            Err(error) => return Err(error),
+        }
+        std::thread::sleep(remaining.min(ACCEPT_RETRY_DELAY));
+    }
+}
+
+fn validate_runner_peer(credentials: UnixPeerCredentials, runner_process_id: u32) -> IoResult<()> {
+    if credentials.process_id() != runner_process_id {
+        return Err(IoError::new(
+            ErrorKind::PermissionDenied,
+            "broker channel peer is not the spawned runner",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_channel_pair(
+    control: UnixPeerCredentials,
+    notification: UnixPeerCredentials,
+) -> IoResult<()> {
+    if control != notification {
+        return Err(IoError::new(
+            ErrorKind::PermissionDenied,
+            "broker control and notification channels have different peers",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn runner_channel_validation_rejects_unexpected_or_mismatched_peers() {
+        let runner = UnixPeerCredentials::from_raw(7, 8, 9);
+        assert!(validate_runner_peer(runner, 7).is_ok());
+        assert_eq!(
+            validate_runner_peer(runner, 6).unwrap_err().kind(),
+            ErrorKind::PermissionDenied
+        );
+        assert!(validate_channel_pair(runner, runner).is_ok());
+        assert_eq!(
+            validate_channel_pair(runner, UnixPeerCredentials::from_raw(7, 10, 9))
+                .unwrap_err()
+                .kind(),
+            ErrorKind::PermissionDenied
+        );
     }
 }

--- a/litebox_broker_userland/tests/userland_broker.rs
+++ b/litebox_broker_userland/tests/userland_broker.rs
@@ -2,8 +2,7 @@
 // Licensed under the MIT license.
 
 use std::ffi::{OsStr, OsString};
-use std::io::{Error, ErrorKind, Result};
-use std::os::unix::process::ExitStatusExt;
+use std::io::{ErrorKind, Result};
 use std::path::Path;
 use std::process::{Child, Command};
 use std::sync::Arc;
@@ -51,7 +50,7 @@ fn run_parent_test() {
     let deadline = Instant::now() + Duration::from_secs(5);
     while Instant::now() < deadline {
         if let Some(status) = broker.child.try_wait().unwrap() {
-            assert_eq!(status.signal(), Some(libc::SIGTERM));
+            assert!(status.success(), "broker failed with {status}");
             return;
         }
         std::thread::sleep(Duration::from_millis(10));
@@ -119,17 +118,6 @@ fn run_fake_runner(args: &[OsString]) {
         data
     );
     drop(local);
-
-    // SAFETY: `getppid` takes no pointer arguments and has no Rust-side aliasing requirements.
-    let broker_pid = unsafe { libc::getppid() };
-    // SAFETY: `broker_pid` is the runner's parent process and `SIGTERM` is a valid signal number.
-    let kill_result = unsafe { libc::kill(broker_pid, libc::SIGTERM) };
-    assert_eq!(
-        kill_result,
-        0,
-        "failed to stop broker: {}",
-        Error::last_os_error()
-    );
 }
 
 struct ChildGuard {

--- a/litebox_runner_linux_userland/Cargo.toml
+++ b/litebox_runner_linux_userland/Cargo.toml
@@ -10,7 +10,7 @@ libc = { version = "0.2.169", default-features = false }
 litebox = { version = "0.1.0", path = "../litebox" }
 litebox_broker_local = { version = "0.1.0", path = "../litebox_broker_local" }
 litebox_broker_protocol = { version = "0.1.0", path = "../litebox_broker_protocol" }
-litebox_broker_transport = { version = "0.1.0", path = "../litebox_broker_transport", features = ["linux-peer-credentials", "linux-shared-memory", "unix"] }
+litebox_broker_transport = { version = "0.1.0", path = "../litebox_broker_transport", features = ["linux-userland"] }
 litebox_common_linux = { version = "0.1.0", path = "../litebox_common_linux" }
 litebox_platform_linux_userland = { version = "0.1.0", path = "../litebox_platform_linux_userland" }
 litebox_platform_multiplex = { version = "0.1.0", path = "../litebox_platform_multiplex", default-features = false, features = ["platform_linux_userland"] }

--- a/litebox_runner_linux_userland/Cargo.toml
+++ b/litebox_runner_linux_userland/Cargo.toml
@@ -10,7 +10,7 @@ libc = { version = "0.2.169", default-features = false }
 litebox = { version = "0.1.0", path = "../litebox" }
 litebox_broker_local = { version = "0.1.0", path = "../litebox_broker_local" }
 litebox_broker_protocol = { version = "0.1.0", path = "../litebox_broker_protocol" }
-litebox_broker_transport = { version = "0.1.0", path = "../litebox_broker_transport", features = ["linux-shared-memory", "unix"] }
+litebox_broker_transport = { version = "0.1.0", path = "../litebox_broker_transport", features = ["linux-peer-credentials", "linux-shared-memory", "unix"] }
 litebox_common_linux = { version = "0.1.0", path = "../litebox_common_linux" }
 litebox_platform_linux_userland = { version = "0.1.0", path = "../litebox_platform_linux_userland" }
 litebox_platform_multiplex = { version = "0.1.0", path = "../litebox_platform_multiplex", default-features = false, features = ["platform_linux_userland"] }

--- a/litebox_runner_linux_userland/src/lib.rs
+++ b/litebox_runner_linux_userland/src/lib.rs
@@ -159,6 +159,23 @@ pub fn run(cli_args: CliArgs) -> Result<()> {
         );
     }
 
+    let broker_connection = match (
+        cli_args.broker_control_socket.as_deref(),
+        cli_args.broker_notification_socket.as_deref(),
+    ) {
+        (Some(control_socket_path), Some(notification_socket_path)) => Some(broker::connect(
+            control_socket_path,
+            notification_socket_path,
+        )?),
+        (None, None) => None,
+        (Some(_), None) => {
+            anyhow::bail!("broker notification socket is required with broker control socket")
+        }
+        (None, Some(_)) => {
+            anyhow::bail!("broker control socket is required with broker notification socket")
+        }
+    };
+
     let mut cow_eligible_regions: Vec<MmappedFile> = Vec::new();
 
     // When --program-from-tar is set, the program binary is already in the tar file,
@@ -223,22 +240,6 @@ pub fn run(cli_args: CliArgs) -> Result<()> {
     }
 
     litebox_platform_multiplex::set_platform(platform);
-    let broker_connection = match (
-        cli_args.broker_control_socket.as_deref(),
-        cli_args.broker_notification_socket.as_deref(),
-    ) {
-        (Some(control_socket_path), Some(notification_socket_path)) => Some(broker::connect(
-            control_socket_path,
-            notification_socket_path,
-        )?),
-        (None, None) => None,
-        (Some(_), None) => {
-            anyhow::bail!("broker notification socket is required with broker control socket")
-        }
-        (None, Some(_)) => {
-            anyhow::bail!("broker control socket is required with broker notification socket")
-        }
-    };
 
     let shim_builder = if let Some(broker_connection) = broker_connection {
         let (broker_local, broker_notifications, broker_control_cancellation) = broker_connection;

--- a/litebox_runner_linux_userland/tests/run.rs
+++ b/litebox_runner_linux_userland/tests/run.rs
@@ -348,16 +348,11 @@ fn spawn_test_broker(
                 let (notification_stream, _) = notification_listener
                     .accept()
                     .expect("failed to accept broker local notification connection");
-                let control_credentials =
-                    litebox_broker_transport::unix_socket::peer_credentials(&control_stream)
-                        .expect("failed to read broker control peer credentials");
-                let notification_credentials =
-                    litebox_broker_transport::unix_socket::peer_credentials(&notification_stream)
-                        .expect("failed to read broker notification peer credentials");
-                assert_eq!(
-                    control_credentials, notification_credentials,
-                    "broker channels must belong to the same runner process"
-                );
+                litebox_broker_transport::unix_socket::validate_same_peer_process(
+                    &control_stream,
+                    &notification_stream,
+                )
+                .expect("broker channels must belong to the same runner process");
                 control_stream
                     .set_read_timeout(Some(BROKER_HELPER_TIMEOUT))
                     .expect("failed to configure broker test read timeout");

--- a/litebox_runner_linux_userland/tests/run.rs
+++ b/litebox_runner_linux_userland/tests/run.rs
@@ -348,6 +348,16 @@ fn spawn_test_broker(
                 let (notification_stream, _) = notification_listener
                     .accept()
                     .expect("failed to accept broker local notification connection");
+                let control_credentials =
+                    litebox_broker_transport::unix_socket::peer_credentials(&control_stream)
+                        .expect("failed to read broker control peer credentials");
+                let notification_credentials =
+                    litebox_broker_transport::unix_socket::peer_credentials(&notification_stream)
+                        .expect("failed to read broker notification peer credentials");
+                assert_eq!(
+                    control_credentials, notification_credentials,
+                    "broker channels must belong to the same runner process"
+                );
                 control_stream
                     .set_read_timeout(Some(BROKER_HELPER_TIMEOUT))
                     .expect("failed to configure broker test read timeout");
@@ -361,7 +371,10 @@ fn spawn_test_broker(
                     .set_write_timeout(Some(BROKER_HELPER_TIMEOUT))
                     .expect("failed to configure broker notification test write timeout");
                 let mut channel = CountingHostControlChannel {
-                    inner: litebox_broker_transport::unix_socket::UnixStreamHostControlChannel::from_accepted(control_stream),
+                    inner: litebox_broker_transport::unix_socket::UnixStreamHostControlChannel::from_host_guaranteed(
+                        control_stream,
+                        std::time::Instant::now() + BROKER_HELPER_TIMEOUT,
+                    ),
                     close_object_count: 0,
                 };
                 let mut notification_channel =
@@ -491,7 +504,7 @@ console.log(content);
     let broker_thread = spawn_test_broker(
         &control_socket_path,
         &notification_socket_path,
-        litebox_broker_core::PolicyEngine::with_unauthenticated_rights(
+        litebox_broker_core::PolicyEngine::with_host_guaranteed_rights(
             litebox_broker_core::ObjectRights::all(),
         ),
         4,


### PR DESCRIPTION
Authenticate the broker control and notification sockets with Linux peer credentials before serving the spawned runner. Both channels must belong to the same live child process before the host grants broker rights through the transport-neutral host-guaranteed identity. Setup acceptance, handshake I/O, and shared-memory transfer share one deadline, and the broker serves and reaps one runner association.