### PR TITLE
Tag broker control requests

### DIFF
--- a/litebox/src/broker/error.rs
+++ b/litebox/src/broker/error.rs
@@ -10,8 +10,8 @@ use crate::event::{counter::EventCounterError, polling::TryOpError};
 /// Error returned by the deployment-provided broker control path.
 #[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
 pub(crate) enum BrokerControlError {
-    #[error("broker control transport failed")]
-    Transport,
+    #[error("broker control association failed")]
+    AssociationFailed,
     #[error("broker returned operation error: {0}")]
     Broker(#[source] ErrorCode),
 }
@@ -41,7 +41,7 @@ pub(crate) enum BrokerObjectError {
 impl From<BrokerControlError> for BrokerObjectError {
     fn from(error: BrokerControlError) -> Self {
         match error {
-            BrokerControlError::Transport => Self::Control,
+            BrokerControlError::AssociationFailed => Self::Control,
             BrokerControlError::Broker(error) => error.into(),
         }
     }
@@ -72,7 +72,7 @@ impl<E> From<BrokerLocalError<E>> for BrokerControlError {
             BrokerLocalError::Channel(_)
             | BrokerLocalError::ChannelClosed
             | BrokerLocalError::RequestIdExhausted
-            | BrokerLocalError::UnexpectedResponseId { .. } => Self::Transport,
+            | BrokerLocalError::UnexpectedResponseId { .. } => Self::AssociationFailed,
             BrokerLocalError::Broker(error) => Self::Broker(error),
         }
     }

--- a/litebox/src/broker/error.rs
+++ b/litebox/src/broker/error.rs
@@ -69,7 +69,10 @@ impl From<ErrorCode> for BrokerObjectError {
 impl<E> From<BrokerLocalError<E>> for BrokerControlError {
     fn from(error: BrokerLocalError<E>) -> Self {
         match error {
-            BrokerLocalError::Channel(_) | BrokerLocalError::ChannelClosed => Self::Transport,
+            BrokerLocalError::Channel(_)
+            | BrokerLocalError::ChannelClosed
+            | BrokerLocalError::RequestIdExhausted
+            | BrokerLocalError::UnexpectedResponseId { .. } => Self::Transport,
             BrokerLocalError::Broker(error) => Self::Broker(error),
         }
     }

--- a/litebox/src/broker/mod.rs
+++ b/litebox/src/broker/mod.rs
@@ -173,15 +173,15 @@ where
         let (result, failed_connection) = {
             let mut local = self.local.lock();
             let Some(connection) = local.as_mut() else {
-                return Err(BrokerControlError::Transport);
+                return Err(BrokerControlError::AssociationFailed);
             };
             let result = request(connection).map_err(BrokerControlError::from);
-            let failed_connection = if matches!(result.as_ref(), Err(BrokerControlError::Transport))
-            {
-                local.take()
-            } else {
-                None
-            };
+            let failed_connection =
+                if matches!(result.as_ref(), Err(BrokerControlError::AssociationFailed)) {
+                    local.take()
+                } else {
+                    None
+                };
             (result, failed_connection)
         };
         if let Some(connection) = failed_connection {

--- a/litebox/src/event/counter.rs
+++ b/litebox/src/event/counter.rs
@@ -182,8 +182,8 @@ mod tests {
     use litebox_broker_protocol::error::ErrorCode;
     use litebox_broker_protocol::event::{CreateEventResponse, EventConsumption};
     use litebox_broker_protocol::message::{
-        BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerNotification, BrokerRequest,
-        BrokerRequestEnvelope, BrokerResponse, BrokerResponseEnvelope, EventRequest, EventResponse,
+        BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerNotification, BrokerOperation,
+        BrokerRequest, BrokerResponse, BrokerResult, EventRequest, EventResponse,
         ReadinessNotification,
     };
     use litebox_broker_protocol::readiness::ReadinessFlags;
@@ -410,7 +410,7 @@ mod tests {
         read_ready: Arc<AtomicBool>,
         request_count: Arc<AtomicUsize>,
         fail_requests: Arc<AtomicBool>,
-        last_request: Option<BrokerRequestEnvelope>,
+        last_request: Option<BrokerRequest>,
     }
 
     struct NoopSharedMemory;
@@ -460,49 +460,47 @@ mod tests {
 
         fn send_request(
             &mut self,
-            request: &BrokerRequestEnvelope,
+            request: &BrokerRequest,
         ) -> core::result::Result<(), Self::Error> {
             self.last_request = Some(request.clone());
             self.request_count.fetch_add(1, Ordering::SeqCst);
             Ok(())
         }
 
-        fn recv_response(
-            &mut self,
-        ) -> core::result::Result<Option<BrokerResponseEnvelope>, Self::Error> {
+        fn recv_response(&mut self) -> core::result::Result<Option<BrokerResponse>, Self::Error> {
             if self.fail_requests.load(Ordering::SeqCst) {
                 self.last_request.take();
                 return Err(());
             }
             let request = self.last_request.take().unwrap();
-            let response = match request.request {
-                BrokerRequest::Event(EventRequest::Create(_)) => {
+            let result = match request.operation {
+                BrokerOperation::Event(EventRequest::Create(_)) => {
                     let handle = ObjectHandle(self.next_handle);
                     self.next_handle += 1;
-                    BrokerResponse::Event(EventResponse::Create(CreateEventResponse { handle }))
+                    BrokerResult::Event(EventResponse::Create(CreateEventResponse { handle }))
                 }
-                BrokerRequest::Event(EventRequest::Consume(_)) => {
+                BrokerOperation::Event(EventRequest::Consume(_)) => {
                     self.consume_attempts.fetch_add(1, Ordering::SeqCst);
                     if self.read_ready.swap(false, Ordering::SeqCst) {
-                        BrokerResponse::Event(EventResponse::Consume(EventConsumption {
+                        BrokerResult::Event(EventResponse::Consume(EventConsumption {
                             value: 1,
                             readiness: ReadinessFlags::WRITE,
                         }))
                     } else {
-                        BrokerResponse::Error(ErrorCode::WouldBlock)
+                        BrokerResult::Error(ErrorCode::WouldBlock)
                     }
                 }
-                BrokerRequest::CloseObject(_) => BrokerResponse::ObjectClosed,
-                BrokerRequest::CheckReadiness(_) => {
-                    BrokerResponse::Readiness(ReadinessFlags::WRITE)
+                BrokerOperation::CloseObject(_) => BrokerResult::ObjectClosed,
+                BrokerOperation::CheckReadiness(_) => {
+                    BrokerResult::Readiness(ReadinessFlags::WRITE)
                 }
-                request @ (BrokerRequest::Event(_) | BrokerRequest::Pipe(_)) => {
+                request @ (BrokerOperation::Event(_) | BrokerOperation::Pipe(_)) => {
                     panic!("unexpected broker request: {request:?}")
                 }
             };
-            Ok(Some(BrokerResponseEnvelope {
+            Ok(Some(BrokerResponse {
                 request_id: request.request_id,
-                response,
+                result,
             }))
         }
     }

--- a/litebox/src/event/counter.rs
+++ b/litebox/src/event/counter.rs
@@ -183,7 +183,8 @@ mod tests {
     use litebox_broker_protocol::event::{CreateEventResponse, EventConsumption};
     use litebox_broker_protocol::message::{
         BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerNotification, BrokerRequest,
-        BrokerResponse, EventRequest, EventResponse, ReadinessNotification,
+        BrokerRequestEnvelope, BrokerResponse, BrokerResponseEnvelope, EventRequest, EventResponse,
+        ReadinessNotification,
     };
     use litebox_broker_protocol::readiness::ReadinessFlags;
 
@@ -409,7 +410,7 @@ mod tests {
         read_ready: Arc<AtomicBool>,
         request_count: Arc<AtomicUsize>,
         fail_requests: Arc<AtomicBool>,
-        last_request: Option<BrokerRequest>,
+        last_request: Option<BrokerRequestEnvelope>,
     }
 
     struct NoopSharedMemory;
@@ -459,19 +460,22 @@ mod tests {
 
         fn send_request(
             &mut self,
-            request: &BrokerRequest,
+            request: &BrokerRequestEnvelope,
         ) -> core::result::Result<(), Self::Error> {
             self.last_request = Some(request.clone());
             self.request_count.fetch_add(1, Ordering::SeqCst);
             Ok(())
         }
 
-        fn recv_response(&mut self) -> core::result::Result<Option<BrokerResponse>, Self::Error> {
+        fn recv_response(
+            &mut self,
+        ) -> core::result::Result<Option<BrokerResponseEnvelope>, Self::Error> {
             if self.fail_requests.load(Ordering::SeqCst) {
                 self.last_request.take();
                 return Err(());
             }
-            let response = match self.last_request.take().unwrap() {
+            let request = self.last_request.take().unwrap();
+            let response = match request.request {
                 BrokerRequest::Event(EventRequest::Create(_)) => {
                     let handle = ObjectHandle(self.next_handle);
                     self.next_handle += 1;
@@ -496,7 +500,10 @@ mod tests {
                     panic!("unexpected broker request: {request:?}")
                 }
             };
-            Ok(Some(response))
+            Ok(Some(BrokerResponseEnvelope {
+                request_id: request.request_id,
+                response,
+            }))
         }
     }
 }

--- a/litebox/src/pipes.rs
+++ b/litebox/src/pipes.rs
@@ -931,9 +931,8 @@ mod tests {
     use litebox_broker_protocol::channel::LocalControlChannel;
     use litebox_broker_protocol::error::ErrorCode;
     use litebox_broker_protocol::message::{
-        BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerNotification, BrokerRequest,
-        BrokerRequestEnvelope, BrokerResponse, BrokerResponseEnvelope, PipeRequest,
-        ReadinessNotification,
+        BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerNotification, BrokerOperation,
+        BrokerRequest, BrokerResponse, BrokerResult, PipeRequest, ReadinessNotification,
     };
     use litebox_broker_protocol::pipe::CreatePipeResponse;
     use litebox_broker_protocol::readiness::ReadinessFlags;
@@ -1112,7 +1111,7 @@ mod tests {
 
     #[derive(Debug)]
     struct FailingPipeChannel {
-        last_request: Option<BrokerRequestEnvelope>,
+        last_request: Option<BrokerRequest>,
         request_count: Arc<AtomicUsize>,
         read_failure: ReadFailure,
         force_transport: Arc<AtomicBool>,
@@ -1172,44 +1171,42 @@ mod tests {
 
         fn send_request(
             &mut self,
-            request: &BrokerRequestEnvelope,
+            request: &BrokerRequest,
         ) -> core::result::Result<(), Self::Error> {
             self.last_request = Some(request.clone());
             self.request_count.fetch_add(1, Ordering::SeqCst);
             Ok(())
         }
 
-        fn recv_response(
-            &mut self,
-        ) -> core::result::Result<Option<BrokerResponseEnvelope>, Self::Error> {
+        fn recv_response(&mut self) -> core::result::Result<Option<BrokerResponse>, Self::Error> {
             let request = self.last_request.take().unwrap();
-            let response = match request.request {
-                BrokerRequest::Pipe(PipeRequest::Create(_)) => BrokerResponse::Pipe(
+            let result = match request.operation {
+                BrokerOperation::Pipe(PipeRequest::Create(_)) => BrokerResult::Pipe(
                     litebox_broker_protocol::message::PipeResponse::Create(CreatePipeResponse {
                         read_handle: ObjectHandle(1),
                         write_handle: ObjectHandle(2),
                     }),
                 ),
-                BrokerRequest::Pipe(PipeRequest::Read(_))
+                BrokerOperation::Pipe(PipeRequest::Read(_))
                     if self.force_transport.load(Ordering::SeqCst) =>
                 {
                     return Err(());
                 }
-                BrokerRequest::Pipe(PipeRequest::Read(_)) => match self.read_failure {
+                BrokerOperation::Pipe(PipeRequest::Read(_)) => match self.read_failure {
                     ReadFailure::Transport => return Err(()),
-                    ReadFailure::WouldBlock => BrokerResponse::Error(ErrorCode::WouldBlock),
+                    ReadFailure::WouldBlock => BrokerResult::Error(ErrorCode::WouldBlock),
                 },
-                BrokerRequest::CloseObject(_) => BrokerResponse::ObjectClosed,
-                BrokerRequest::CheckReadiness(_) => {
-                    BrokerResponse::Readiness(ReadinessFlags::default())
+                BrokerOperation::CloseObject(_) => BrokerResult::ObjectClosed,
+                BrokerOperation::CheckReadiness(_) => {
+                    BrokerResult::Readiness(ReadinessFlags::default())
                 }
-                request @ (BrokerRequest::Pipe(_) | BrokerRequest::Event(_)) => {
+                request @ (BrokerOperation::Pipe(_) | BrokerOperation::Event(_)) => {
                     panic!("unexpected broker request: {request:?}")
                 }
             };
-            Ok(Some(BrokerResponseEnvelope {
+            Ok(Some(BrokerResponse {
                 request_id: request.request_id,
-                response,
+                result,
             }))
         }
     }

--- a/litebox/src/pipes.rs
+++ b/litebox/src/pipes.rs
@@ -932,7 +932,8 @@ mod tests {
     use litebox_broker_protocol::error::ErrorCode;
     use litebox_broker_protocol::message::{
         BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerNotification, BrokerRequest,
-        BrokerResponse, PipeRequest, ReadinessNotification,
+        BrokerRequestEnvelope, BrokerResponse, BrokerResponseEnvelope, PipeRequest,
+        ReadinessNotification,
     };
     use litebox_broker_protocol::pipe::CreatePipeResponse;
     use litebox_broker_protocol::readiness::ReadinessFlags;
@@ -1111,7 +1112,7 @@ mod tests {
 
     #[derive(Debug)]
     struct FailingPipeChannel {
-        last_request: Option<BrokerRequest>,
+        last_request: Option<BrokerRequestEnvelope>,
         request_count: Arc<AtomicUsize>,
         read_failure: ReadFailure,
         force_transport: Arc<AtomicBool>,
@@ -1171,40 +1172,45 @@ mod tests {
 
         fn send_request(
             &mut self,
-            request: &BrokerRequest,
+            request: &BrokerRequestEnvelope,
         ) -> core::result::Result<(), Self::Error> {
             self.last_request = Some(request.clone());
             self.request_count.fetch_add(1, Ordering::SeqCst);
             Ok(())
         }
 
-        fn recv_response(&mut self) -> core::result::Result<Option<BrokerResponse>, Self::Error> {
-            match self.last_request.take().unwrap() {
-                BrokerRequest::Pipe(PipeRequest::Create(_)) => Ok(Some(BrokerResponse::Pipe(
+        fn recv_response(
+            &mut self,
+        ) -> core::result::Result<Option<BrokerResponseEnvelope>, Self::Error> {
+            let request = self.last_request.take().unwrap();
+            let response = match request.request {
+                BrokerRequest::Pipe(PipeRequest::Create(_)) => BrokerResponse::Pipe(
                     litebox_broker_protocol::message::PipeResponse::Create(CreatePipeResponse {
                         read_handle: ObjectHandle(1),
                         write_handle: ObjectHandle(2),
                     }),
-                ))),
+                ),
                 BrokerRequest::Pipe(PipeRequest::Read(_))
                     if self.force_transport.load(Ordering::SeqCst) =>
                 {
-                    Err(())
+                    return Err(());
                 }
                 BrokerRequest::Pipe(PipeRequest::Read(_)) => match self.read_failure {
-                    ReadFailure::Transport => Err(()),
-                    ReadFailure::WouldBlock => {
-                        Ok(Some(BrokerResponse::Error(ErrorCode::WouldBlock)))
-                    }
+                    ReadFailure::Transport => return Err(()),
+                    ReadFailure::WouldBlock => BrokerResponse::Error(ErrorCode::WouldBlock),
                 },
-                BrokerRequest::CloseObject(_) => Ok(Some(BrokerResponse::ObjectClosed)),
+                BrokerRequest::CloseObject(_) => BrokerResponse::ObjectClosed,
                 BrokerRequest::CheckReadiness(_) => {
-                    Ok(Some(BrokerResponse::Readiness(ReadinessFlags::default())))
+                    BrokerResponse::Readiness(ReadinessFlags::default())
                 }
                 request @ (BrokerRequest::Pipe(_) | BrokerRequest::Event(_)) => {
                     panic!("unexpected broker request: {request:?}")
                 }
-            }
+            };
+            Ok(Some(BrokerResponseEnvelope {
+                request_id: request.request_id,
+                response,
+            }))
         }
     }
 

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -24,8 +24,8 @@ use litebox_broker_protocol::channel::{
 use litebox_broker_protocol::error::ErrorCode;
 use litebox_broker_protocol::event::{AddEventResponse, CreateEventResponse};
 use litebox_broker_protocol::message::{
-    BrokerHandshakeResponse, BrokerRequest, BrokerRequestEnvelope, BrokerResponse,
-    BrokerResponseEnvelope, EventRequest, EventResponse, PipeRequest, PipeResponse,
+    BrokerHandshakeResponse, BrokerOperation, BrokerRequest, BrokerResponse, BrokerResult,
+    EventRequest, EventResponse, PipeRequest, PipeResponse,
 };
 use litebox_broker_protocol::pipe::{
     CreatePipeResponse, PIPE_TRANSFER_BUFFER_SIZE, ReadPipeResponse, WritePipeResponse,
@@ -119,17 +119,14 @@ where
             HostReceive::PeerClosed => break,
         };
 
-        let BrokerRequestEnvelope {
+        let BrokerRequest {
             request_id,
-            request,
+            operation,
         } = request;
-        let response = complete_request(handle_request(&session, request, shared_memory))
+        let result = complete_request(handle_request(&session, operation, shared_memory))
             .map_err(BrokerHostError::Broker)?;
         control_channel
-            .send_response(&BrokerResponseEnvelope {
-                request_id,
-                response,
-            })
+            .send_response(&BrokerResponse { request_id, result })
             .map_err(BrokerHostError::Channel)?;
     }
 
@@ -147,34 +144,34 @@ enum RequestFailure {
 }
 
 fn complete_request(
-    result: RequestResult<BrokerResponse>,
-) -> core::result::Result<BrokerResponse, ErrorCode> {
+    result: RequestResult<BrokerResult>,
+) -> core::result::Result<BrokerResult, ErrorCode> {
     match result {
         Ok(response) => Ok(response),
-        Err(RequestFailure::Respond(error)) => Ok(BrokerResponse::Error(error)),
+        Err(RequestFailure::Respond(error)) => Ok(BrokerResult::Error(error)),
         Err(RequestFailure::Abort(error)) => Err(error),
     }
 }
 
 fn handle_request(
     session: &BrokerSession,
-    request: BrokerRequest,
+    operation: BrokerOperation,
     shared_memory: &dyn SharedMemory,
-) -> RequestResult<BrokerResponse> {
-    match request {
-        BrokerRequest::CloseObject(handle) => session
+) -> RequestResult<BrokerResult> {
+    match operation {
+        BrokerOperation::CloseObject(handle) => session
             .close_object_reference(handle)
-            .map(|()| BrokerResponse::ObjectClosed)
+            .map(|()| BrokerResult::ObjectClosed)
             .map_err(|error| RequestFailure::Respond(error.into())),
-        BrokerRequest::CheckReadiness(handle) => session
+        BrokerOperation::CheckReadiness(handle) => session
             .check_readiness(handle)
-            .map(BrokerResponse::Readiness)
+            .map(BrokerResult::Readiness)
             .map_err(|error| RequestFailure::Respond(error.into())),
-        BrokerRequest::Event(request) => {
-            handle_event_request(session, request).map(BrokerResponse::Event)
+        BrokerOperation::Event(request) => {
+            handle_event_request(session, request).map(BrokerResult::Event)
         }
-        BrokerRequest::Pipe(request) => {
-            handle_pipe_request(session, request, shared_memory).map(BrokerResponse::Pipe)
+        BrokerOperation::Pipe(request) => {
+            handle_pipe_request(session, request, shared_memory).map(BrokerResult::Pipe)
         }
     }
 }
@@ -311,7 +308,7 @@ mod tests {
                 protocol_version: BROKER_PROTOCOL_VERSION,
             }))]),
             std::vec::Vec::from([
-                Ok(HostReceive::Message(BrokerRequest::Event(
+                Ok(HostReceive::Message(BrokerOperation::Event(
                     EventRequest::Create(CreateEventRequest { initial_count: 0 }),
                 ))),
                 Ok(HostReceive::PeerClosed),
@@ -337,8 +334,8 @@ mod tests {
                 broker_protocol_version: BROKER_PROTOCOL_VERSION
             }
         );
-        let handle = match &channel.responses[0] {
-            BrokerResponse::Event(EventResponse::Create(response)) => response.handle,
+        let handle = match &channel.results[0] {
+            BrokerResult::Event(EventResponse::Create(response)) => response.handle,
             response => panic!("unexpected response: {response:?}"),
         };
         assert_ne!(handle.0, 0);
@@ -441,7 +438,7 @@ mod tests {
             channel.handshake_responses,
             [BrokerHandshakeResponse::Error(ErrorCode::ProtocolState)]
         );
-        assert!(channel.responses.is_empty());
+        assert!(channel.results.is_empty());
     }
 
     fn serve_connection_rejects_handshake_request_after_negotiation(broker: &BrokerCore) {
@@ -470,7 +467,7 @@ mod tests {
                 broker_protocol_version: BROKER_PROTOCOL_VERSION
             }]
         );
-        assert!(channel.responses.is_empty());
+        assert!(channel.results.is_empty());
     }
 
     fn serve_connection_returns_channel_error_when_response_send_fails(broker: &BrokerCore) {
@@ -501,7 +498,7 @@ mod tests {
             std::vec::Vec::from([Ok(HostReceive::Message(BrokerHandshakeRequest {
                 protocol_version: BROKER_PROTOCOL_VERSION,
             }))]),
-            std::vec::Vec::from([Ok(HostReceive::Message(BrokerRequest::Event(
+            std::vec::Vec::from([Ok(HostReceive::Message(BrokerOperation::Event(
                 EventRequest::Create(CreateEventRequest { initial_count: 0 }),
             )))]),
         );
@@ -521,13 +518,13 @@ mod tests {
         );
         assert!(notifications.notifications.is_empty());
         assert_eq!(
-            &channel.responses[1..],
+            &channel.results[1..],
             [
-                BrokerResponse::Event(EventResponse::Add(AddEventResponse {
+                BrokerResult::Event(EventResponse::Add(AddEventResponse {
                     readiness: litebox_broker_protocol::readiness::ReadinessFlags::READ
                         | litebox_broker_protocol::readiness::ReadinessFlags::WRITE,
                 })),
-                BrokerResponse::Event(EventResponse::Consume(
+                BrokerResult::Event(EventResponse::Consume(
                     litebox_broker_protocol::event::ConsumeEventResponse {
                         value: 1,
                         readiness: litebox_broker_protocol::readiness::ReadinessFlags::WRITE,
@@ -543,13 +540,13 @@ mod tests {
                 protocol_version: BROKER_PROTOCOL_VERSION,
             }))]),
             std::vec::Vec::from([
-                Ok(HostReceive::Message(BrokerRequest::Pipe(
+                Ok(HostReceive::Message(BrokerOperation::Pipe(
                     PipeRequest::Read(ReadPipeRequest {
                         handle: ObjectHandle(u64::MAX),
                         length: 1,
                     }),
                 ))),
-                Ok(HostReceive::Message(BrokerRequest::Event(
+                Ok(HostReceive::Message(BrokerOperation::Event(
                     EventRequest::Create(CreateEventRequest { initial_count: 0 }),
                 ))),
                 Ok(HostReceive::PeerClosed),
@@ -569,12 +566,12 @@ mod tests {
             ConnectionTermination::PeerClosed
         );
         assert_eq!(
-            channel.responses[0],
-            BrokerResponse::Error(ErrorCode::UnknownObject)
+            channel.results[0],
+            BrokerResult::Error(ErrorCode::UnknownObject)
         );
         assert!(matches!(
-            channel.responses[1],
-            BrokerResponse::Event(EventResponse::Create(_))
+            channel.results[1],
+            BrokerResult::Event(EventResponse::Create(_))
         ));
         assert_eq!(channel.response_ids, [RequestId(0), RequestId(1)]);
     }
@@ -584,7 +581,7 @@ mod tests {
             std::vec::Vec::from([Ok(HostReceive::Message(BrokerHandshakeRequest {
                 protocol_version: BROKER_PROTOCOL_VERSION,
             }))]),
-            std::vec::Vec::from([Ok(HostReceive::Message(BrokerRequest::Pipe(
+            std::vec::Vec::from([Ok(HostReceive::Message(BrokerOperation::Pipe(
                 PipeRequest::Create(CreatePipeRequest {
                     capacity: 64,
                     atomic_write_size: 16,
@@ -604,10 +601,10 @@ mod tests {
             ),
             Err(BrokerHostError::Broker(ErrorCode::Internal))
         ));
-        assert_eq!(channel.responses.len(), 1);
+        assert_eq!(channel.results.len(), 1);
         assert!(matches!(
-            channel.responses[0],
-            BrokerResponse::Pipe(PipeResponse::Create(_))
+            channel.results[0],
+            BrokerResult::Pipe(PipeResponse::Create(_))
         ));
     }
 
@@ -617,29 +614,29 @@ mod tests {
             .unwrap();
         let response = handle_test_request(
             &session,
-            BrokerRequest::Event(EventRequest::Create(CreateEventRequest {
+            BrokerOperation::Event(EventRequest::Create(CreateEventRequest {
                 initial_count: 0,
             })),
         );
-        let BrokerResponse::Event(EventResponse::Create(response)) = response else {
+        let BrokerResult::Event(EventResponse::Create(response)) = response else {
             panic!("unexpected create response: {response:?}");
         };
         let handle = response.handle;
 
         assert_eq!(
-            handle_test_request(&session, BrokerRequest::CloseObject(handle)),
-            BrokerResponse::ObjectClosed
+            handle_test_request(&session, BrokerOperation::CloseObject(handle)),
+            BrokerResult::ObjectClosed
         );
         assert_eq!(
-            handle_test_request(&session, BrokerRequest::CheckReadiness(handle)),
-            BrokerResponse::Error(ErrorCode::UnknownObject)
+            handle_test_request(&session, BrokerOperation::CheckReadiness(handle)),
+            BrokerResult::Error(ErrorCode::UnknownObject)
         );
         assert_eq!(
             handle_test_request(
                 &session,
-                BrokerRequest::CloseObject(ObjectHandle(handle.0 + 1))
+                BrokerOperation::CloseObject(ObjectHandle(handle.0 + 1))
             ),
-            BrokerResponse::Error(ErrorCode::UnknownObject)
+            BrokerResult::Error(ErrorCode::UnknownObject)
         );
     }
 
@@ -650,20 +647,20 @@ mod tests {
         let memory = TestSharedMemory::new(PIPE_TRANSFER_BUFFER_SIZE);
         let created = handle_test_request_with_memory(
             &session,
-            BrokerRequest::Pipe(PipeRequest::Create(CreatePipeRequest {
+            BrokerOperation::Pipe(PipeRequest::Create(CreatePipeRequest {
                 capacity: 64,
                 atomic_write_size: 16,
             })),
             &memory,
         );
-        let BrokerResponse::Pipe(PipeResponse::Create(response)) = created else {
+        let BrokerResult::Pipe(PipeResponse::Create(response)) = created else {
             panic!("expected successful pipe creation");
         };
 
         memory.write(0, &[1, 2, 3]).unwrap();
         let write = handle_test_request_with_memory(
             &session,
-            BrokerRequest::Pipe(PipeRequest::Write(WritePipeRequest {
+            BrokerOperation::Pipe(PipeRequest::Write(WritePipeRequest {
                 handle: response.write_handle,
                 length: 3,
             })),
@@ -671,12 +668,12 @@ mod tests {
         );
         assert_eq!(
             write,
-            BrokerResponse::Pipe(PipeResponse::Write(WritePipeResponse { written: 3 }))
+            BrokerResult::Pipe(PipeResponse::Write(WritePipeResponse { written: 3 }))
         );
 
         let read = handle_test_request_with_memory(
             &session,
-            BrokerRequest::Pipe(PipeRequest::Read(ReadPipeRequest {
+            BrokerOperation::Pipe(PipeRequest::Read(ReadPipeRequest {
                 handle: response.read_handle,
                 length: 3,
             })),
@@ -684,7 +681,7 @@ mod tests {
         );
         assert_eq!(
             read,
-            BrokerResponse::Pipe(PipeResponse::Read(ReadPipeResponse { read: 3 }))
+            BrokerResult::Pipe(PipeResponse::Read(ReadPipeResponse { read: 3 }))
         );
         let mut data = [0; 3];
         memory.read(0, &mut data).unwrap();
@@ -692,7 +689,7 @@ mod tests {
 
         let invalid_range = handle_test_request_with_memory(
             &session,
-            BrokerRequest::Pipe(PipeRequest::Write(WritePipeRequest {
+            BrokerOperation::Pipe(PipeRequest::Write(WritePipeRequest {
                 handle: response.write_handle,
                 length: u32::try_from(PIPE_TRANSFER_BUFFER_SIZE).unwrap() + 1,
             })),
@@ -700,32 +697,32 @@ mod tests {
         );
         assert_eq!(
             invalid_range,
-            BrokerResponse::Error(ErrorCode::MalformedRequest)
+            BrokerResult::Error(ErrorCode::MalformedRequest)
         );
     }
 
-    fn handle_test_request(session: &BrokerSession, request: BrokerRequest) -> BrokerResponse {
+    fn handle_test_request(session: &BrokerSession, operation: BrokerOperation) -> BrokerResult {
         handle_test_request_with_memory(
             session,
-            request,
+            operation,
             &TestSharedMemory::new(PIPE_TRANSFER_BUFFER_SIZE),
         )
     }
 
     fn handle_test_request_with_memory(
         session: &BrokerSession,
-        request: BrokerRequest,
+        operation: BrokerOperation,
         shared_memory: &dyn SharedMemory,
-    ) -> BrokerResponse {
-        complete_request(handle_request(session, request, shared_memory)).unwrap()
+    ) -> BrokerResult {
+        complete_request(handle_request(session, operation, shared_memory)).unwrap()
     }
 
     struct FakeHostControlChannel {
         handshake_requests:
             std::vec::Vec<core::result::Result<HostReceive<BrokerHandshakeRequest>, ()>>,
-        requests: std::vec::Vec<core::result::Result<HostReceive<BrokerRequest>, ()>>,
+        operations: std::vec::Vec<core::result::Result<HostReceive<BrokerOperation>, ()>>,
         handshake_responses: std::vec::Vec<BrokerHandshakeResponse>,
-        responses: std::vec::Vec<BrokerResponse>,
+        results: std::vec::Vec<BrokerResult>,
         response_ids: std::vec::Vec<RequestId>,
         next_request_id: u64,
         enqueue_readiness_requests_after_create: bool,
@@ -738,13 +735,13 @@ mod tests {
             handshake_requests: std::vec::Vec<
                 core::result::Result<HostReceive<BrokerHandshakeRequest>, ()>,
             >,
-            requests: std::vec::Vec<core::result::Result<HostReceive<BrokerRequest>, ()>>,
+            operations: std::vec::Vec<core::result::Result<HostReceive<BrokerOperation>, ()>>,
         ) -> Self {
             Self {
                 handshake_requests,
-                requests,
+                operations,
                 handshake_responses: std::vec::Vec::new(),
-                responses: std::vec::Vec::new(),
+                results: std::vec::Vec::new(),
                 response_ids: std::vec::Vec::new(),
                 next_request_id: 0,
                 enqueue_readiness_requests_after_create: false,
@@ -784,19 +781,19 @@ mod tests {
 
         fn recv_request(
             &mut self,
-        ) -> core::result::Result<HostReceive<BrokerRequestEnvelope>, Self::Error> {
-            let received = if self.requests.is_empty() {
+        ) -> core::result::Result<HostReceive<BrokerRequest>, Self::Error> {
+            let received = if self.operations.is_empty() {
                 HostReceive::PeerClosed
             } else {
-                self.requests.remove(0)?
+                self.operations.remove(0)?
             };
             Ok(match received {
                 HostReceive::Message(request) => {
                     let request_id = RequestId(self.next_request_id);
                     self.next_request_id += 1;
-                    HostReceive::Message(BrokerRequestEnvelope {
+                    HostReceive::Message(BrokerRequest {
                         request_id,
-                        request,
+                        operation: request,
                     })
                 }
                 HostReceive::ProtocolViolation => HostReceive::ProtocolViolation,
@@ -806,45 +803,45 @@ mod tests {
 
         fn send_response(
             &mut self,
-            envelope: &BrokerResponseEnvelope,
+            response: &BrokerResponse,
         ) -> core::result::Result<(), Self::Error> {
             if self.send_error {
                 return Err(());
             }
-            let response = &envelope.response;
+            let result = &response.result;
             if self.enqueue_readiness_requests_after_create
-                && let BrokerResponse::Event(EventResponse::Create(response)) = response
+                && let BrokerResult::Event(EventResponse::Create(response)) = result
             {
-                self.requests
-                    .push(Ok(HostReceive::Message(BrokerRequest::Event(
+                self.operations
+                    .push(Ok(HostReceive::Message(BrokerOperation::Event(
                         EventRequest::Add(AddEventRequest {
                             handle: response.handle,
                             value: 1,
                         }),
                     ))));
-                self.requests
-                    .push(Ok(HostReceive::Message(BrokerRequest::Event(
+                self.operations
+                    .push(Ok(HostReceive::Message(BrokerOperation::Event(
                         EventRequest::Consume(ConsumeEventRequest {
                             handle: response.handle,
                             mode: EventConsumeMode::One,
                         }),
                     ))));
-                self.requests.push(Ok(HostReceive::PeerClosed));
+                self.operations.push(Ok(HostReceive::PeerClosed));
             }
             if self.enqueue_write_request_after_pipe_create
-                && let BrokerResponse::Pipe(PipeResponse::Create(response)) = response
+                && let BrokerResult::Pipe(PipeResponse::Create(response)) = result
             {
-                self.requests
-                    .push(Ok(HostReceive::Message(BrokerRequest::Pipe(
+                self.operations
+                    .push(Ok(HostReceive::Message(BrokerOperation::Pipe(
                         PipeRequest::Write(WritePipeRequest {
                             handle: response.write_handle,
                             length: 1,
                         }),
                     ))));
-                self.requests.push(Ok(HostReceive::PeerClosed));
+                self.operations.push(Ok(HostReceive::PeerClosed));
             }
-            self.responses.push(response.clone());
-            self.response_ids.push(envelope.request_id);
+            self.results.push(result.clone());
+            self.response_ids.push(response.request_id);
             Ok(())
         }
     }

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -24,8 +24,8 @@ use litebox_broker_protocol::channel::{
 use litebox_broker_protocol::error::ErrorCode;
 use litebox_broker_protocol::event::{AddEventResponse, CreateEventResponse};
 use litebox_broker_protocol::message::{
-    BrokerHandshakeResponse, BrokerRequest, BrokerResponse, EventRequest, EventResponse,
-    PipeRequest, PipeResponse,
+    BrokerHandshakeResponse, BrokerRequest, BrokerRequestEnvelope, BrokerResponse,
+    BrokerResponseEnvelope, EventRequest, EventResponse, PipeRequest, PipeResponse,
 };
 use litebox_broker_protocol::pipe::{
     CreatePipeResponse, PIPE_TRANSFER_BUFFER_SIZE, ReadPipeResponse, WritePipeResponse,
@@ -114,18 +114,22 @@ where
         {
             HostReceive::Message(request) => request,
             HostReceive::ProtocolViolation => {
-                control_channel
-                    .send_response(&BrokerResponse::Error(ErrorCode::ProtocolState))
-                    .map_err(BrokerHostError::Channel)?;
                 return Ok(ConnectionTermination::ProtocolViolation);
             }
             HostReceive::PeerClosed => break,
         };
 
+        let BrokerRequestEnvelope {
+            request_id,
+            request,
+        } = request;
         let response = complete_request(handle_request(&session, request, shared_memory))
             .map_err(BrokerHostError::Broker)?;
         control_channel
-            .send_response(&response)
+            .send_response(&BrokerResponseEnvelope {
+                request_id,
+                response,
+            })
             .map_err(BrokerHostError::Channel)?;
     }
 
@@ -262,7 +266,7 @@ fn handle_event_request(
 pub enum ConnectionTermination {
     /// The peer cleanly closed the channel.
     PeerClosed,
-    /// The broker sent a protocol-state error before closing the channel.
+    /// The peer violated the protocol.
     ProtocolViolation,
 }
 
@@ -278,7 +282,7 @@ mod tests {
     use litebox_broker_protocol::message::{BrokerHandshakeRequest, BrokerNotification};
     use litebox_broker_protocol::pipe::{CreatePipeRequest, ReadPipeRequest, WritePipeRequest};
     use litebox_broker_protocol::shared_memory::SharedMemoryError;
-    use litebox_broker_protocol::{ObjectHandle, ProtocolVersion};
+    use litebox_broker_protocol::{ObjectHandle, ProtocolVersion, RequestId};
     use std::sync::{Arc, Mutex};
 
     #[test]
@@ -313,6 +317,7 @@ mod tests {
                 Ok(HostReceive::PeerClosed),
             ]),
         );
+        channel.next_request_id = 41;
         let mut notifications = FakeHostNotificationChannel::default();
 
         assert_eq!(
@@ -337,6 +342,7 @@ mod tests {
             response => panic!("unexpected response: {response:?}"),
         };
         assert_ne!(handle.0, 0);
+        assert_eq!(channel.response_ids, [RequestId(41)]);
     }
 
     fn serve_connection_retries_after_version_mismatch(broker: &BrokerCore) {
@@ -464,10 +470,7 @@ mod tests {
                 broker_protocol_version: BROKER_PROTOCOL_VERSION
             }]
         );
-        assert_eq!(
-            channel.responses,
-            [BrokerResponse::Error(ErrorCode::ProtocolState)]
-        );
+        assert!(channel.responses.is_empty());
     }
 
     fn serve_connection_returns_channel_error_when_response_send_fails(broker: &BrokerCore) {
@@ -573,6 +576,7 @@ mod tests {
             channel.responses[1],
             BrokerResponse::Event(EventResponse::Create(_))
         ));
+        assert_eq!(channel.response_ids, [RequestId(0), RequestId(1)]);
     }
 
     fn serve_connection_aborts_without_response_on_shared_memory_failure(broker: &BrokerCore) {
@@ -722,6 +726,8 @@ mod tests {
         requests: std::vec::Vec<core::result::Result<HostReceive<BrokerRequest>, ()>>,
         handshake_responses: std::vec::Vec<BrokerHandshakeResponse>,
         responses: std::vec::Vec<BrokerResponse>,
+        response_ids: std::vec::Vec<RequestId>,
+        next_request_id: u64,
         enqueue_readiness_requests_after_create: bool,
         enqueue_write_request_after_pipe_create: bool,
         send_error: bool,
@@ -739,6 +745,8 @@ mod tests {
                 requests,
                 handshake_responses: std::vec::Vec::new(),
                 responses: std::vec::Vec::new(),
+                response_ids: std::vec::Vec::new(),
+                next_request_id: 0,
                 enqueue_readiness_requests_after_create: false,
                 enqueue_write_request_after_pipe_create: false,
                 send_error: false,
@@ -776,21 +784,34 @@ mod tests {
 
         fn recv_request(
             &mut self,
-        ) -> core::result::Result<HostReceive<BrokerRequest>, Self::Error> {
-            if self.requests.is_empty() {
-                Ok(HostReceive::PeerClosed)
+        ) -> core::result::Result<HostReceive<BrokerRequestEnvelope>, Self::Error> {
+            let received = if self.requests.is_empty() {
+                HostReceive::PeerClosed
             } else {
-                self.requests.remove(0)
-            }
+                self.requests.remove(0)?
+            };
+            Ok(match received {
+                HostReceive::Message(request) => {
+                    let request_id = RequestId(self.next_request_id);
+                    self.next_request_id += 1;
+                    HostReceive::Message(BrokerRequestEnvelope {
+                        request_id,
+                        request,
+                    })
+                }
+                HostReceive::ProtocolViolation => HostReceive::ProtocolViolation,
+                HostReceive::PeerClosed => HostReceive::PeerClosed,
+            })
         }
 
         fn send_response(
             &mut self,
-            response: &BrokerResponse,
+            envelope: &BrokerResponseEnvelope,
         ) -> core::result::Result<(), Self::Error> {
             if self.send_error {
                 return Err(());
             }
+            let response = &envelope.response;
             if self.enqueue_readiness_requests_after_create
                 && let BrokerResponse::Event(EventResponse::Create(response)) = response
             {
@@ -823,6 +844,7 @@ mod tests {
                 self.requests.push(Ok(HostReceive::PeerClosed));
             }
             self.responses.push(response.clone());
+            self.response_ids.push(envelope.request_id);
             Ok(())
         }
     }

--- a/litebox_broker_local/src/error.rs
+++ b/litebox_broker_local/src/error.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+use litebox_broker_protocol::RequestId;
 use litebox_broker_protocol::error::ErrorCode;
 use thiserror::Error;
 
@@ -11,6 +12,15 @@ pub enum BrokerLocalError<E> {
     Channel(#[source] E),
     #[error("broker closed the channel")]
     ChannelClosed,
+    #[error("broker request identifiers are exhausted")]
+    RequestIdExhausted,
+    #[error("broker returned response ID {actual:?} for request {expected:?}")]
+    UnexpectedResponseId {
+        /// Request identifier sent by the local endpoint.
+        expected: RequestId,
+        /// Request identifier returned by the broker.
+        actual: RequestId,
+    },
     #[error("broker rejected request: {0}")]
     Broker(#[source] ErrorCode),
 }

--- a/litebox_broker_local/src/event.rs
+++ b/litebox_broker_local/src/event.rs
@@ -8,7 +8,7 @@ use litebox_broker_protocol::event::{
     EventConsumeMode,
 };
 use litebox_broker_protocol::message::{
-    BrokerRequest, BrokerResponse, EventRequest, EventResponse,
+    BrokerOperation, BrokerResult, EventRequest, EventResponse,
 };
 use litebox_broker_protocol::readiness::ReadinessFlags;
 
@@ -71,12 +71,12 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
     }
 
     fn request_event(&mut self, request: EventRequest) -> Result<EventResponse, Channel::Error> {
-        match self.request(BrokerRequest::Event(request))? {
-            BrokerResponse::Event(response) => Ok(response),
-            BrokerResponse::Error(error) => Err(BrokerLocalError::Broker(error)),
-            response @ (BrokerResponse::ObjectClosed
-            | BrokerResponse::Readiness(_)
-            | BrokerResponse::Pipe(_)) => {
+        match self.request(BrokerOperation::Event(request))? {
+            BrokerResult::Event(response) => Ok(response),
+            BrokerResult::Error(error) => Err(BrokerLocalError::Broker(error)),
+            response @ (BrokerResult::ObjectClosed
+            | BrokerResult::Readiness(_)
+            | BrokerResult::Pipe(_)) => {
                 panic!("broker returned unexpected event response: {response:?}");
             }
         }

--- a/litebox_broker_local/src/lib.rs
+++ b/litebox_broker_local/src/lib.rs
@@ -26,12 +26,12 @@ use litebox_broker_protocol::channel::{LocalControlChannel, LocalNotificationCha
 use litebox_broker_protocol::error::ErrorCode;
 use litebox_broker_protocol::message::{
     BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerNotification, BrokerRequest,
-    BrokerResponse,
+    BrokerRequestEnvelope, BrokerResponse, BrokerResponseEnvelope,
 };
 use litebox_broker_protocol::pipe::PIPE_TRANSFER_BUFFER_SIZE;
 use litebox_broker_protocol::readiness::ReadinessFlags;
 use litebox_broker_protocol::shared_memory::SharedMemory;
-use litebox_broker_protocol::{BROKER_PROTOCOL_VERSION, ObjectHandle};
+use litebox_broker_protocol::{BROKER_PROTOCOL_VERSION, ObjectHandle, RequestId};
 
 pub use error::{BrokerLocalError, Result};
 
@@ -42,6 +42,7 @@ pub use error::{BrokerLocalError, Result};
 pub struct BrokerLocal<Channel: LocalControlChannel> {
     channel: Channel,
     shared_memory: Arc<dyn SharedMemory>,
+    next_request_id: u64,
 }
 
 /// Broker-local receive adapter for broker-initiated asynchronous notifications.
@@ -96,6 +97,7 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
                 Ok(Self {
                     channel,
                     shared_memory,
+                    next_request_id: 0,
                 })
             }
             BrokerHandshakeResponse::VersionMismatch { .. } => {
@@ -124,15 +126,32 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
         &mut self,
         request: BrokerRequest,
     ) -> Result<BrokerResponse, Channel::Error> {
+        let request_id = RequestId(self.next_request_id);
+        self.next_request_id = self
+            .next_request_id
+            .checked_add(1)
+            .ok_or(BrokerLocalError::RequestIdExhausted)?;
         self.channel
-            .send_request(&request)
+            .send_request(&BrokerRequestEnvelope {
+                request_id,
+                request,
+            })
             .map_err(BrokerLocalError::Channel)?;
-        match self
+        let BrokerResponseEnvelope {
+            request_id: response_id,
+            response,
+        } = self
             .channel
             .recv_response()
             .map_err(BrokerLocalError::Channel)?
-            .ok_or(BrokerLocalError::ChannelClosed)?
-        {
+            .ok_or(BrokerLocalError::ChannelClosed)?;
+        if response_id != request_id {
+            return Err(BrokerLocalError::UnexpectedResponseId {
+                expected: request_id,
+                actual: response_id,
+            });
+        }
+        match response {
             BrokerResponse::Error(error) => match error {
                 ErrorCode::PolicyDenied
                 | ErrorCode::UnknownObject
@@ -254,10 +273,76 @@ mod tests {
         let mut local = BrokerLocal {
             channel,
             shared_memory: noop_shared_memory(),
+            next_request_id: 0,
         };
 
         assert!(local.close_object(handle).is_ok());
-        assert_eq!(local.channel.sent_request, Some(request));
+        assert_eq!(
+            local.channel.sent_request,
+            Some(BrokerRequestEnvelope {
+                request_id: RequestId(0),
+                request,
+            })
+        );
+    }
+
+    #[test]
+    fn active_requests_use_monotonic_identifiers() {
+        let handle = ObjectHandle(7);
+        let channel = FakeControlChannel::new(None, Some(BrokerResponse::ObjectClosed));
+        let mut local = BrokerLocal {
+            channel,
+            shared_memory: noop_shared_memory(),
+            next_request_id: 0,
+        };
+
+        local.close_object(handle).unwrap();
+        assert_eq!(
+            local.channel.sent_request.as_ref().unwrap().request_id,
+            RequestId(0)
+        );
+
+        local.channel.response = Some(BrokerResponse::ObjectClosed);
+        local.close_object(handle).unwrap();
+        assert_eq!(
+            local.channel.sent_request.as_ref().unwrap().request_id,
+            RequestId(1)
+        );
+    }
+
+    #[test]
+    fn active_request_rejects_mismatched_response_identifier() {
+        let channel = FakeControlChannel::new(None, Some(BrokerResponse::ObjectClosed));
+        let mut local = BrokerLocal {
+            channel,
+            shared_memory: noop_shared_memory(),
+            next_request_id: 0,
+        };
+        local.channel.response_id = Some(RequestId(9));
+
+        assert!(matches!(
+            local.close_object(ObjectHandle(7)),
+            Err(BrokerLocalError::UnexpectedResponseId {
+                expected: RequestId(0),
+                actual: RequestId(9),
+            })
+        ));
+    }
+
+    #[test]
+    fn active_request_identifier_exhaustion_does_not_wrap() {
+        let channel = FakeControlChannel::new(None, Some(BrokerResponse::ObjectClosed));
+        let mut local = BrokerLocal {
+            channel,
+            shared_memory: noop_shared_memory(),
+            next_request_id: u64::MAX,
+        };
+
+        assert!(matches!(
+            local.close_object(ObjectHandle(7)),
+            Err(BrokerLocalError::RequestIdExhausted)
+        ));
+        assert!(local.channel.sent_request.is_none());
     }
 
     #[test]
@@ -267,6 +352,7 @@ mod tests {
         let mut local = BrokerLocal {
             channel,
             shared_memory: noop_shared_memory(),
+            next_request_id: 0,
         };
 
         assert!(matches!(
@@ -283,6 +369,7 @@ mod tests {
         let mut local = BrokerLocal {
             channel,
             shared_memory: noop_shared_memory(),
+            next_request_id: 0,
         };
 
         let _ = local.create_event_with_count(0);
@@ -413,9 +500,10 @@ mod tests {
 
     struct FakeControlChannel {
         sent_handshake_request: Option<BrokerHandshakeRequest>,
-        sent_request: Option<BrokerRequest>,
+        sent_request: Option<BrokerRequestEnvelope>,
         handshake_response: Option<BrokerHandshakeResponse>,
         response: Option<BrokerResponse>,
+        response_id: Option<RequestId>,
     }
 
     #[derive(Debug, PartialEq, Eq)]
@@ -468,6 +556,7 @@ mod tests {
                 sent_request: None,
                 handshake_response,
                 response,
+                response_id: None,
             }
         }
     }
@@ -491,14 +580,24 @@ mod tests {
 
         fn send_request(
             &mut self,
-            request: &BrokerRequest,
+            request: &BrokerRequestEnvelope,
         ) -> core::result::Result<(), Self::Error> {
             self.sent_request = Some(request.clone());
             Ok(())
         }
 
-        fn recv_response(&mut self) -> core::result::Result<Option<BrokerResponse>, Self::Error> {
-            Ok(self.response.take())
+        fn recv_response(
+            &mut self,
+        ) -> core::result::Result<Option<BrokerResponseEnvelope>, Self::Error> {
+            Ok(self.response.take().map(|response| BrokerResponseEnvelope {
+                request_id: self.response_id.unwrap_or_else(|| {
+                    self.sent_request
+                        .as_ref()
+                        .expect("response requires a sent request")
+                        .request_id
+                }),
+                response,
+            }))
         }
     }
 

--- a/litebox_broker_local/src/lib.rs
+++ b/litebox_broker_local/src/lib.rs
@@ -42,7 +42,7 @@ pub use error::{BrokerLocalError, Result};
 pub struct BrokerLocal<Channel: LocalControlChannel> {
     channel: Channel,
     shared_memory: Arc<dyn SharedMemory>,
-    next_request_id: Option<RequestId>,
+    next_request_id: u64,
 }
 
 /// Broker-local receive adapter for broker-initiated asynchronous notifications.
@@ -97,7 +97,7 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
                 Ok(Self {
                     channel,
                     shared_memory,
-                    next_request_id: Some(RequestId(0)),
+                    next_request_id: 0,
                 })
             }
             BrokerHandshakeResponse::VersionMismatch { .. } => {
@@ -126,11 +126,11 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
         &mut self,
         operation: BrokerOperation,
     ) -> Result<BrokerResult, Channel::Error> {
-        let request_id = self
+        let request_id = RequestId(self.next_request_id);
+        self.next_request_id = self
             .next_request_id
-            .take()
+            .checked_add(1)
             .ok_or(BrokerLocalError::RequestIdExhausted)?;
-        self.next_request_id = request_id.0.checked_add(1).map(RequestId);
         self.channel
             .send_request(&BrokerRequest {
                 request_id,
@@ -273,7 +273,7 @@ mod tests {
         let mut local = BrokerLocal {
             channel,
             shared_memory: noop_shared_memory(),
-            next_request_id: Some(RequestId(0)),
+            next_request_id: 0,
         };
 
         assert!(local.close_object(handle).is_ok());
@@ -293,7 +293,7 @@ mod tests {
         let mut local = BrokerLocal {
             channel,
             shared_memory: noop_shared_memory(),
-            next_request_id: Some(RequestId(0)),
+            next_request_id: 0,
         };
 
         local.close_object(handle).unwrap();
@@ -312,11 +312,11 @@ mod tests {
 
     #[test]
     fn active_request_rejects_mismatched_response_identifier() {
-        let channel = FakeControlChannel::new(None, Some(BrokerResult::Error(ErrorCode::Internal)));
+        let channel = FakeControlChannel::new(None, Some(BrokerResult::ObjectClosed));
         let mut local = BrokerLocal {
             channel,
             shared_memory: noop_shared_memory(),
-            next_request_id: Some(RequestId(0)),
+            next_request_id: 0,
         };
         local.channel.response_id = Some(RequestId(9));
 
@@ -330,20 +330,14 @@ mod tests {
     }
 
     #[test]
-    fn active_request_identifier_exhaustion_allows_maximum_identifier_once() {
+    fn active_request_identifier_exhaustion_does_not_wrap() {
         let channel = FakeControlChannel::new(None, Some(BrokerResult::ObjectClosed));
         let mut local = BrokerLocal {
             channel,
             shared_memory: noop_shared_memory(),
-            next_request_id: Some(RequestId(u64::MAX)),
+            next_request_id: u64::MAX,
         };
 
-        local.close_object(ObjectHandle(7)).unwrap();
-        assert_eq!(
-            local.channel.sent_request.as_ref().unwrap().request_id,
-            RequestId(u64::MAX)
-        );
-        local.channel.sent_request = None;
         assert!(matches!(
             local.close_object(ObjectHandle(7)),
             Err(BrokerLocalError::RequestIdExhausted)
@@ -358,7 +352,7 @@ mod tests {
         let mut local = BrokerLocal {
             channel,
             shared_memory: noop_shared_memory(),
-            next_request_id: Some(RequestId(0)),
+            next_request_id: 0,
         };
 
         assert!(matches!(
@@ -374,7 +368,7 @@ mod tests {
         let mut local = BrokerLocal {
             channel,
             shared_memory: noop_shared_memory(),
-            next_request_id: Some(RequestId(0)),
+            next_request_id: 0,
         };
 
         let _ = local.create_event_with_count(0);

--- a/litebox_broker_local/src/lib.rs
+++ b/litebox_broker_local/src/lib.rs
@@ -42,7 +42,7 @@ pub use error::{BrokerLocalError, Result};
 pub struct BrokerLocal<Channel: LocalControlChannel> {
     channel: Channel,
     shared_memory: Arc<dyn SharedMemory>,
-    next_request_id: u64,
+    next_request_id: Option<RequestId>,
 }
 
 /// Broker-local receive adapter for broker-initiated asynchronous notifications.
@@ -97,7 +97,7 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
                 Ok(Self {
                     channel,
                     shared_memory,
-                    next_request_id: 0,
+                    next_request_id: Some(RequestId(0)),
                 })
             }
             BrokerHandshakeResponse::VersionMismatch { .. } => {
@@ -126,11 +126,11 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
         &mut self,
         operation: BrokerOperation,
     ) -> Result<BrokerResult, Channel::Error> {
-        let request_id = RequestId(self.next_request_id);
-        self.next_request_id = self
+        let request_id = self
             .next_request_id
-            .checked_add(1)
+            .take()
             .ok_or(BrokerLocalError::RequestIdExhausted)?;
+        self.next_request_id = request_id.0.checked_add(1).map(RequestId);
         self.channel
             .send_request(&BrokerRequest {
                 request_id,
@@ -273,7 +273,7 @@ mod tests {
         let mut local = BrokerLocal {
             channel,
             shared_memory: noop_shared_memory(),
-            next_request_id: 0,
+            next_request_id: Some(RequestId(0)),
         };
 
         assert!(local.close_object(handle).is_ok());
@@ -293,7 +293,7 @@ mod tests {
         let mut local = BrokerLocal {
             channel,
             shared_memory: noop_shared_memory(),
-            next_request_id: 0,
+            next_request_id: Some(RequestId(0)),
         };
 
         local.close_object(handle).unwrap();
@@ -312,11 +312,11 @@ mod tests {
 
     #[test]
     fn active_request_rejects_mismatched_response_identifier() {
-        let channel = FakeControlChannel::new(None, Some(BrokerResult::ObjectClosed));
+        let channel = FakeControlChannel::new(None, Some(BrokerResult::Error(ErrorCode::Internal)));
         let mut local = BrokerLocal {
             channel,
             shared_memory: noop_shared_memory(),
-            next_request_id: 0,
+            next_request_id: Some(RequestId(0)),
         };
         local.channel.response_id = Some(RequestId(9));
 
@@ -330,14 +330,20 @@ mod tests {
     }
 
     #[test]
-    fn active_request_identifier_exhaustion_does_not_wrap() {
+    fn active_request_identifier_exhaustion_allows_maximum_identifier_once() {
         let channel = FakeControlChannel::new(None, Some(BrokerResult::ObjectClosed));
         let mut local = BrokerLocal {
             channel,
             shared_memory: noop_shared_memory(),
-            next_request_id: u64::MAX,
+            next_request_id: Some(RequestId(u64::MAX)),
         };
 
+        local.close_object(ObjectHandle(7)).unwrap();
+        assert_eq!(
+            local.channel.sent_request.as_ref().unwrap().request_id,
+            RequestId(u64::MAX)
+        );
+        local.channel.sent_request = None;
         assert!(matches!(
             local.close_object(ObjectHandle(7)),
             Err(BrokerLocalError::RequestIdExhausted)
@@ -352,7 +358,7 @@ mod tests {
         let mut local = BrokerLocal {
             channel,
             shared_memory: noop_shared_memory(),
-            next_request_id: 0,
+            next_request_id: Some(RequestId(0)),
         };
 
         assert!(matches!(
@@ -368,7 +374,7 @@ mod tests {
         let mut local = BrokerLocal {
             channel,
             shared_memory: noop_shared_memory(),
-            next_request_id: 0,
+            next_request_id: Some(RequestId(0)),
         };
 
         let _ = local.create_event_with_count(0);

--- a/litebox_broker_local/src/lib.rs
+++ b/litebox_broker_local/src/lib.rs
@@ -25,8 +25,8 @@ use alloc::sync::Arc;
 use litebox_broker_protocol::channel::{LocalControlChannel, LocalNotificationChannel};
 use litebox_broker_protocol::error::ErrorCode;
 use litebox_broker_protocol::message::{
-    BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerNotification, BrokerRequest,
-    BrokerRequestEnvelope, BrokerResponse, BrokerResponseEnvelope,
+    BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerNotification, BrokerOperation,
+    BrokerRequest, BrokerResponse, BrokerResult,
 };
 use litebox_broker_protocol::pipe::PIPE_TRANSFER_BUFFER_SIZE;
 use litebox_broker_protocol::readiness::ReadinessFlags;
@@ -124,22 +124,22 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
     /// response that does not match an active request.
     pub(crate) fn request(
         &mut self,
-        request: BrokerRequest,
-    ) -> Result<BrokerResponse, Channel::Error> {
+        operation: BrokerOperation,
+    ) -> Result<BrokerResult, Channel::Error> {
         let request_id = RequestId(self.next_request_id);
         self.next_request_id = self
             .next_request_id
             .checked_add(1)
             .ok_or(BrokerLocalError::RequestIdExhausted)?;
         self.channel
-            .send_request(&BrokerRequestEnvelope {
+            .send_request(&BrokerRequest {
                 request_id,
-                request,
+                operation,
             })
             .map_err(BrokerLocalError::Channel)?;
-        let BrokerResponseEnvelope {
+        let BrokerResponse {
             request_id: response_id,
-            response,
+            result,
         } = self
             .channel
             .recv_response()
@@ -151,8 +151,8 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
                 actual: response_id,
             });
         }
-        match response {
-            BrokerResponse::Error(error) => match error {
+        match result {
+            BrokerResult::Error(error) => match error {
                 ErrorCode::PolicyDenied
                 | ErrorCode::UnknownObject
                 | ErrorCode::InvalidRights
@@ -167,10 +167,10 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
                 | ErrorCode::Internal => panic!("broker returned unrecoverable error: {error}"),
                 _ => panic!("broker returned unsupported error: {error}"),
             },
-            response @ (BrokerResponse::Event(_)
-            | BrokerResponse::Pipe(_)
-            | BrokerResponse::ObjectClosed
-            | BrokerResponse::Readiness(_)) => Ok(response),
+            result @ (BrokerResult::Event(_)
+            | BrokerResult::Pipe(_)
+            | BrokerResult::ObjectClosed
+            | BrokerResult::Readiness(_)) => Ok(result),
         }
     }
 
@@ -184,9 +184,9 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
         &mut self,
         handle: ObjectHandle,
     ) -> Result<ReadinessFlags, Channel::Error> {
-        match self.request(BrokerRequest::CheckReadiness(handle))? {
-            BrokerResponse::Readiness(readiness) => Ok(readiness),
-            BrokerResponse::Error(error) => Err(BrokerLocalError::Broker(error)),
+        match self.request(BrokerOperation::CheckReadiness(handle))? {
+            BrokerResult::Readiness(readiness) => Ok(readiness),
+            BrokerResult::Error(error) => Err(BrokerLocalError::Broker(error)),
             response => panic!("broker returned unexpected readiness response: {response:?}"),
         }
     }
@@ -198,12 +198,12 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
     /// Panics if the broker reports an unrecoverable error or returns a protocol
     /// response that does not match an object close request.
     pub fn close_object(&mut self, handle: ObjectHandle) -> Result<(), Channel::Error> {
-        match self.request(BrokerRequest::CloseObject(handle))? {
-            BrokerResponse::ObjectClosed => Ok(()),
-            BrokerResponse::Error(error) => Err(BrokerLocalError::Broker(error)),
-            response @ (BrokerResponse::Event(_)
-            | BrokerResponse::Pipe(_)
-            | BrokerResponse::Readiness(_)) => {
+        match self.request(BrokerOperation::CloseObject(handle))? {
+            BrokerResult::ObjectClosed => Ok(()),
+            BrokerResult::Error(error) => Err(BrokerLocalError::Broker(error)),
+            response @ (BrokerResult::Event(_)
+            | BrokerResult::Pipe(_)
+            | BrokerResult::Readiness(_)) => {
                 panic!("broker returned unexpected close response: {response:?}");
             }
         }
@@ -267,8 +267,8 @@ mod tests {
     #[test]
     fn close_object_sends_close_object_request() {
         let handle = ObjectHandle(7);
-        let request = BrokerRequest::CloseObject(handle);
-        let response = BrokerResponse::ObjectClosed;
+        let request = BrokerOperation::CloseObject(handle);
+        let response = BrokerResult::ObjectClosed;
         let channel = FakeControlChannel::new(None, Some(response.clone()));
         let mut local = BrokerLocal {
             channel,
@@ -279,9 +279,9 @@ mod tests {
         assert!(local.close_object(handle).is_ok());
         assert_eq!(
             local.channel.sent_request,
-            Some(BrokerRequestEnvelope {
+            Some(BrokerRequest {
                 request_id: RequestId(0),
-                request,
+                operation: request,
             })
         );
     }
@@ -289,7 +289,7 @@ mod tests {
     #[test]
     fn active_requests_use_monotonic_identifiers() {
         let handle = ObjectHandle(7);
-        let channel = FakeControlChannel::new(None, Some(BrokerResponse::ObjectClosed));
+        let channel = FakeControlChannel::new(None, Some(BrokerResult::ObjectClosed));
         let mut local = BrokerLocal {
             channel,
             shared_memory: noop_shared_memory(),
@@ -302,7 +302,7 @@ mod tests {
             RequestId(0)
         );
 
-        local.channel.response = Some(BrokerResponse::ObjectClosed);
+        local.channel.response = Some(BrokerResult::ObjectClosed);
         local.close_object(handle).unwrap();
         assert_eq!(
             local.channel.sent_request.as_ref().unwrap().request_id,
@@ -312,7 +312,7 @@ mod tests {
 
     #[test]
     fn active_request_rejects_mismatched_response_identifier() {
-        let channel = FakeControlChannel::new(None, Some(BrokerResponse::ObjectClosed));
+        let channel = FakeControlChannel::new(None, Some(BrokerResult::ObjectClosed));
         let mut local = BrokerLocal {
             channel,
             shared_memory: noop_shared_memory(),
@@ -331,7 +331,7 @@ mod tests {
 
     #[test]
     fn active_request_identifier_exhaustion_does_not_wrap() {
-        let channel = FakeControlChannel::new(None, Some(BrokerResponse::ObjectClosed));
+        let channel = FakeControlChannel::new(None, Some(BrokerResult::ObjectClosed));
         let mut local = BrokerLocal {
             channel,
             shared_memory: noop_shared_memory(),
@@ -348,7 +348,7 @@ mod tests {
     #[test]
     fn active_request_returns_recoverable_broker_error() {
         let channel =
-            FakeControlChannel::new(None, Some(BrokerResponse::Error(ErrorCode::WouldBlock)));
+            FakeControlChannel::new(None, Some(BrokerResult::Error(ErrorCode::WouldBlock)));
         let mut local = BrokerLocal {
             channel,
             shared_memory: noop_shared_memory(),
@@ -364,8 +364,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "broker returned unrecoverable error")]
     fn active_request_panics_on_unrecoverable_broker_error() {
-        let channel =
-            FakeControlChannel::new(None, Some(BrokerResponse::Error(ErrorCode::Internal)));
+        let channel = FakeControlChannel::new(None, Some(BrokerResult::Error(ErrorCode::Internal)));
         let mut local = BrokerLocal {
             channel,
             shared_memory: noop_shared_memory(),
@@ -500,9 +499,9 @@ mod tests {
 
     struct FakeControlChannel {
         sent_handshake_request: Option<BrokerHandshakeRequest>,
-        sent_request: Option<BrokerRequestEnvelope>,
+        sent_request: Option<BrokerRequest>,
         handshake_response: Option<BrokerHandshakeResponse>,
-        response: Option<BrokerResponse>,
+        response: Option<BrokerResult>,
         response_id: Option<RequestId>,
     }
 
@@ -549,7 +548,7 @@ mod tests {
     impl FakeControlChannel {
         const fn new(
             handshake_response: Option<BrokerHandshakeResponse>,
-            response: Option<BrokerResponse>,
+            response: Option<BrokerResult>,
         ) -> Self {
             Self {
                 sent_handshake_request: None,
@@ -580,23 +579,21 @@ mod tests {
 
         fn send_request(
             &mut self,
-            request: &BrokerRequestEnvelope,
+            request: &BrokerRequest,
         ) -> core::result::Result<(), Self::Error> {
             self.sent_request = Some(request.clone());
             Ok(())
         }
 
-        fn recv_response(
-            &mut self,
-        ) -> core::result::Result<Option<BrokerResponseEnvelope>, Self::Error> {
-            Ok(self.response.take().map(|response| BrokerResponseEnvelope {
+        fn recv_response(&mut self) -> core::result::Result<Option<BrokerResponse>, Self::Error> {
+            Ok(self.response.take().map(|result| BrokerResponse {
                 request_id: self.response_id.unwrap_or_else(|| {
                     self.sent_request
                         .as_ref()
                         .expect("response requires a sent request")
                         .request_id
                 }),
-                response,
+                result,
             }))
         }
     }

--- a/litebox_broker_local/src/pipe.rs
+++ b/litebox_broker_local/src/pipe.rs
@@ -130,11 +130,14 @@ mod tests {
     use std::collections::VecDeque;
     use std::sync::Mutex;
 
-    use litebox_broker_protocol::BROKER_PROTOCOL_VERSION;
     use litebox_broker_protocol::channel::LocalControlChannel;
-    use litebox_broker_protocol::message::{BrokerHandshakeRequest, BrokerHandshakeResponse};
+    use litebox_broker_protocol::message::{
+        BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerRequestEnvelope,
+        BrokerResponseEnvelope,
+    };
     use litebox_broker_protocol::pipe::{ReadPipeResponse, WritePipeResponse};
     use litebox_broker_protocol::shared_memory::{SharedMemory, SharedMemoryError};
+    use litebox_broker_protocol::{BROKER_PROTOCOL_VERSION, RequestId};
 
     #[test]
     fn pipe_uses_attached_shared_memory_for_data_operations() {
@@ -275,6 +278,7 @@ mod tests {
     struct ScriptedChannel {
         responses: VecDeque<BrokerResponse>,
         sent_requests: Vec<BrokerRequest>,
+        last_request_id: Option<RequestId>,
     }
 
     impl ScriptedChannel {
@@ -282,6 +286,7 @@ mod tests {
             Self {
                 responses: responses.into_iter().collect(),
                 sent_requests: Vec::new(),
+                last_request_id: None,
             }
         }
     }
@@ -307,14 +312,25 @@ mod tests {
 
         fn send_request(
             &mut self,
-            request: &BrokerRequest,
+            request: &BrokerRequestEnvelope,
         ) -> core::result::Result<(), Self::Error> {
-            self.sent_requests.push(request.clone());
+            self.sent_requests.push(request.request.clone());
+            self.last_request_id = Some(request.request_id);
             Ok(())
         }
 
-        fn recv_response(&mut self) -> core::result::Result<Option<BrokerResponse>, Self::Error> {
-            Ok(self.responses.pop_front())
+        fn recv_response(
+            &mut self,
+        ) -> core::result::Result<Option<BrokerResponseEnvelope>, Self::Error> {
+            Ok(self
+                .responses
+                .pop_front()
+                .map(|response| BrokerResponseEnvelope {
+                    request_id: self
+                        .last_request_id
+                        .expect("response requires a sent request"),
+                    response,
+                }))
         }
     }
 }

--- a/litebox_broker_local/src/pipe.rs
+++ b/litebox_broker_local/src/pipe.rs
@@ -5,7 +5,7 @@ use alloc::vec::Vec;
 
 use litebox_broker_protocol::ObjectHandle;
 use litebox_broker_protocol::channel::LocalControlChannel;
-use litebox_broker_protocol::message::{BrokerRequest, BrokerResponse, PipeRequest, PipeResponse};
+use litebox_broker_protocol::message::{BrokerOperation, BrokerResult, PipeRequest, PipeResponse};
 use litebox_broker_protocol::pipe::{
     CreatePipeRequest, CreatePipeResponse, PIPE_TRANSFER_BUFFER_SIZE, ReadPipeRequest,
     WritePipeRequest,
@@ -110,12 +110,12 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
     }
 
     fn request_pipe(&mut self, request: PipeRequest) -> Result<PipeResponse, Channel::Error> {
-        match self.request(BrokerRequest::Pipe(request))? {
-            BrokerResponse::Pipe(response) => Ok(response),
-            BrokerResponse::Error(error) => Err(BrokerLocalError::Broker(error)),
-            response @ (BrokerResponse::ObjectClosed
-            | BrokerResponse::Readiness(_)
-            | BrokerResponse::Event(_)) => {
+        match self.request(BrokerOperation::Pipe(request))? {
+            BrokerResult::Pipe(response) => Ok(response),
+            BrokerResult::Error(error) => Err(BrokerLocalError::Broker(error)),
+            response @ (BrokerResult::ObjectClosed
+            | BrokerResult::Readiness(_)
+            | BrokerResult::Event(_)) => {
                 panic!("broker returned unexpected pipe response: {response:?}");
             }
         }
@@ -132,8 +132,8 @@ mod tests {
 
     use litebox_broker_protocol::channel::LocalControlChannel;
     use litebox_broker_protocol::message::{
-        BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerRequestEnvelope,
-        BrokerResponseEnvelope,
+        BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerOperation, BrokerRequest,
+        BrokerResponse, BrokerResult,
     };
     use litebox_broker_protocol::pipe::{ReadPipeResponse, WritePipeResponse};
     use litebox_broker_protocol::shared_memory::{SharedMemory, SharedMemoryError};
@@ -145,12 +145,12 @@ mod tests {
         let write_handle = ObjectHandle(2);
         let memory = Arc::new(TestSharedMemory::new(PIPE_TRANSFER_BUFFER_SIZE));
         let channel = ScriptedChannel::new([
-            BrokerResponse::Pipe(PipeResponse::Create(CreatePipeResponse {
+            BrokerResult::Pipe(PipeResponse::Create(CreatePipeResponse {
                 read_handle,
                 write_handle,
             })),
-            BrokerResponse::Pipe(PipeResponse::Write(WritePipeResponse { written: 2 })),
-            BrokerResponse::Pipe(PipeResponse::Read(ReadPipeResponse { read: 2 })),
+            BrokerResult::Pipe(PipeResponse::Write(WritePipeResponse { written: 2 })),
+            BrokerResult::Pipe(PipeResponse::Read(ReadPipeResponse { read: 2 })),
         ]);
         let mut local = BrokerLocal::negotiate(channel, |_| Ok(memory.clone())).unwrap();
 
@@ -163,17 +163,17 @@ mod tests {
         memory.write(0, &[4, 5, 6]).unwrap();
         assert_eq!(local.read_pipe(read_handle, 3).unwrap(), [4, 5]);
         assert_eq!(
-            local.channel.sent_requests,
+            local.channel.sent_operations,
             [
-                BrokerRequest::Pipe(PipeRequest::Create(CreatePipeRequest {
+                BrokerOperation::Pipe(PipeRequest::Create(CreatePipeRequest {
                     capacity: 64,
                     atomic_write_size: 16,
                 })),
-                BrokerRequest::Pipe(PipeRequest::Write(WritePipeRequest {
+                BrokerOperation::Pipe(PipeRequest::Write(WritePipeRequest {
                     handle: write_handle,
                     length: 3,
                 })),
-                BrokerRequest::Pipe(PipeRequest::Read(ReadPipeRequest {
+                BrokerOperation::Pipe(PipeRequest::Read(ReadPipeRequest {
                     handle: read_handle,
                     length: 3,
                 })),
@@ -200,14 +200,14 @@ mod tests {
                 litebox_broker_protocol::error::ErrorCode::ResourceExhausted
             ))
         ));
-        assert!(local.channel.sent_requests.is_empty());
+        assert!(local.channel.sent_operations.is_empty());
     }
 
     #[test]
     #[should_panic(expected = "broker returned oversized pipe read")]
     fn read_pipe_rejects_oversized_response() {
         let channel =
-            ScriptedChannel::new([BrokerResponse::Pipe(PipeResponse::Read(ReadPipeResponse {
+            ScriptedChannel::new([BrokerResult::Pipe(PipeResponse::Read(ReadPipeResponse {
                 read: 2,
             }))]);
         let memory = Arc::new(TestSharedMemory::new(PIPE_TRANSFER_BUFFER_SIZE));
@@ -219,9 +219,10 @@ mod tests {
     #[test]
     #[should_panic(expected = "broker returned oversized shared pipe write")]
     fn write_pipe_rejects_oversized_response() {
-        let channel = ScriptedChannel::new([BrokerResponse::Pipe(PipeResponse::Write(
-            WritePipeResponse { written: 2 },
-        ))]);
+        let channel =
+            ScriptedChannel::new([BrokerResult::Pipe(PipeResponse::Write(WritePipeResponse {
+                written: 2,
+            }))]);
         let memory = Arc::new(TestSharedMemory::new(PIPE_TRANSFER_BUFFER_SIZE));
         let mut local = BrokerLocal::negotiate(channel, |_| Ok(memory)).unwrap();
 
@@ -276,16 +277,16 @@ mod tests {
     }
 
     struct ScriptedChannel {
-        responses: VecDeque<BrokerResponse>,
-        sent_requests: Vec<BrokerRequest>,
+        results: VecDeque<BrokerResult>,
+        sent_operations: Vec<BrokerOperation>,
         last_request_id: Option<RequestId>,
     }
 
     impl ScriptedChannel {
-        fn new(responses: impl IntoIterator<Item = BrokerResponse>) -> Self {
+        fn new(results: impl IntoIterator<Item = BrokerResult>) -> Self {
             Self {
-                responses: responses.into_iter().collect(),
-                sent_requests: Vec::new(),
+                results: results.into_iter().collect(),
+                sent_operations: Vec::new(),
                 last_request_id: None,
             }
         }
@@ -312,25 +313,20 @@ mod tests {
 
         fn send_request(
             &mut self,
-            request: &BrokerRequestEnvelope,
+            request: &BrokerRequest,
         ) -> core::result::Result<(), Self::Error> {
-            self.sent_requests.push(request.request.clone());
+            self.sent_operations.push(request.operation.clone());
             self.last_request_id = Some(request.request_id);
             Ok(())
         }
 
-        fn recv_response(
-            &mut self,
-        ) -> core::result::Result<Option<BrokerResponseEnvelope>, Self::Error> {
-            Ok(self
-                .responses
-                .pop_front()
-                .map(|response| BrokerResponseEnvelope {
-                    request_id: self
-                        .last_request_id
-                        .expect("response requires a sent request"),
-                    response,
-                }))
+        fn recv_response(&mut self) -> core::result::Result<Option<BrokerResponse>, Self::Error> {
+            Ok(self.results.pop_front().map(|result| BrokerResponse {
+                request_id: self
+                    .last_request_id
+                    .expect("response requires a sent request"),
+                result,
+            }))
         }
     }
 }

--- a/litebox_broker_protocol/src/channel.rs
+++ b/litebox_broker_protocol/src/channel.rs
@@ -2,8 +2,8 @@
 // Licensed under the MIT license.
 
 use crate::message::{
-    BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerNotification, BrokerRequest,
-    BrokerResponse,
+    BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerNotification, BrokerRequestEnvelope,
+    BrokerResponseEnvelope,
 };
 
 /// Peer identity information supplied by the channel or host layer.
@@ -55,13 +55,13 @@ pub trait LocalControlChannel {
     fn recv_handshake_response(&mut self) -> Result<Option<BrokerHandshakeResponse>, Self::Error>;
 
     /// Sends one active broker request.
-    fn send_request(&mut self, request: &BrokerRequest) -> Result<(), Self::Error>;
+    fn send_request(&mut self, request: &BrokerRequestEnvelope) -> Result<(), Self::Error>;
 
     /// Receives one active broker response.
     ///
     /// Returns `Ok(None)` when the broker closed the channel cleanly before
     /// starting another response frame.
-    fn recv_response(&mut self) -> Result<Option<BrokerResponse>, Self::Error>;
+    fn recv_response(&mut self) -> Result<Option<BrokerResponseEnvelope>, Self::Error>;
 }
 
 /// Host-side control channel for broker authority calls.
@@ -84,10 +84,10 @@ pub trait HostControlChannel {
     ) -> Result<(), Self::Error>;
 
     /// Receives one active broker request.
-    fn recv_request(&mut self) -> Result<HostReceive<BrokerRequest>, Self::Error>;
+    fn recv_request(&mut self) -> Result<HostReceive<BrokerRequestEnvelope>, Self::Error>;
 
     /// Sends one active broker response.
-    fn send_response(&mut self, response: &BrokerResponse) -> Result<(), Self::Error>;
+    fn send_response(&mut self, response: &BrokerResponseEnvelope) -> Result<(), Self::Error>;
 }
 
 /// Local-side receive channel for broker-initiated asynchronous notifications.

--- a/litebox_broker_protocol/src/channel.rs
+++ b/litebox_broker_protocol/src/channel.rs
@@ -2,8 +2,8 @@
 // Licensed under the MIT license.
 
 use crate::message::{
-    BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerNotification, BrokerRequestEnvelope,
-    BrokerResponseEnvelope,
+    BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerNotification, BrokerRequest,
+    BrokerResponse,
 };
 
 /// Peer identity information supplied by the channel or host layer.
@@ -55,13 +55,13 @@ pub trait LocalControlChannel {
     fn recv_handshake_response(&mut self) -> Result<Option<BrokerHandshakeResponse>, Self::Error>;
 
     /// Sends one active broker request.
-    fn send_request(&mut self, request: &BrokerRequestEnvelope) -> Result<(), Self::Error>;
+    fn send_request(&mut self, request: &BrokerRequest) -> Result<(), Self::Error>;
 
     /// Receives one active broker response.
     ///
     /// Returns `Ok(None)` when the broker closed the channel cleanly before
     /// starting another response frame.
-    fn recv_response(&mut self) -> Result<Option<BrokerResponseEnvelope>, Self::Error>;
+    fn recv_response(&mut self) -> Result<Option<BrokerResponse>, Self::Error>;
 }
 
 /// Host-side control channel for broker authority calls.
@@ -84,10 +84,10 @@ pub trait HostControlChannel {
     ) -> Result<(), Self::Error>;
 
     /// Receives one active broker request.
-    fn recv_request(&mut self) -> Result<HostReceive<BrokerRequestEnvelope>, Self::Error>;
+    fn recv_request(&mut self) -> Result<HostReceive<BrokerRequest>, Self::Error>;
 
     /// Sends one active broker response.
-    fn send_response(&mut self, response: &BrokerResponseEnvelope) -> Result<(), Self::Error>;
+    fn send_response(&mut self, response: &BrokerResponse) -> Result<(), Self::Error>;
 }
 
 /// Local-side receive channel for broker-initiated asynchronous notifications.

--- a/litebox_broker_protocol/src/lib.rs
+++ b/litebox_broker_protocol/src/lib.rs
@@ -26,6 +26,11 @@ pub mod wire;
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ObjectHandle(pub u64);
 
+/// Association-scoped broker request identifier.
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct RequestId(pub u64);
+
 /// Broker protocol version.
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/litebox_broker_protocol/src/message.rs
+++ b/litebox_broker_protocol/src/message.rs
@@ -11,7 +11,7 @@ use crate::pipe::{
     WritePipeResponse,
 };
 use crate::readiness::ReadinessFlags;
-use crate::{ObjectHandle, ProtocolVersion};
+use crate::{ObjectHandle, ProtocolVersion, RequestId};
 
 /// Broker handshake request sent before the control channel is active.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -31,6 +31,15 @@ pub enum BrokerRequest {
     Event(EventRequest),
     /// Pipe object request family.
     Pipe(PipeRequest),
+}
+
+/// Broker request and its association-scoped correlation identifier.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BrokerRequestEnvelope {
+    /// Correlation identifier allocated by the local endpoint.
+    pub request_id: RequestId,
+    /// Requested broker operation.
+    pub request: BrokerRequest,
 }
 
 /// Broker handshake response sent before the control channel is active.
@@ -92,6 +101,15 @@ pub enum BrokerResponse {
     Pipe(PipeResponse),
     /// Operation failed with an ABI-neutral broker error.
     Error(ErrorCode),
+}
+
+/// Broker response and the identifier of its corresponding request.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BrokerResponseEnvelope {
+    /// Correlation identifier copied from the request.
+    pub request_id: RequestId,
+    /// Broker operation result.
+    pub response: BrokerResponse,
 }
 
 /// Broker-owned event object response.

--- a/litebox_broker_protocol/src/message.rs
+++ b/litebox_broker_protocol/src/message.rs
@@ -20,9 +20,9 @@ pub struct BrokerHandshakeRequest {
     pub protocol_version: ProtocolVersion,
 }
 
-/// Broker request sent over an active control channel.
+/// Operation requested over an active broker control channel.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum BrokerRequest {
+pub enum BrokerOperation {
     /// Close one broker object reference.
     CloseObject(ObjectHandle),
     /// Check the current readiness of a broker-owned object.
@@ -33,13 +33,13 @@ pub enum BrokerRequest {
     Pipe(PipeRequest),
 }
 
-/// Broker request and its association-scoped correlation identifier.
+/// Request sent over an active broker control channel.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct BrokerRequestEnvelope {
+pub struct BrokerRequest {
     /// Correlation identifier allocated by the local endpoint.
     pub request_id: RequestId,
     /// Requested broker operation.
-    pub request: BrokerRequest,
+    pub operation: BrokerOperation,
 }
 
 /// Broker handshake response sent before the control channel is active.
@@ -88,9 +88,9 @@ pub enum PipeRequest {
     Write(WritePipeRequest),
 }
 
-/// Broker response sent over an active control channel.
+/// Result returned for an active broker operation.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum BrokerResponse {
+pub enum BrokerResult {
     /// Object close operation completed.
     ObjectClosed,
     /// Current readiness of a broker-owned object.
@@ -103,13 +103,13 @@ pub enum BrokerResponse {
     Error(ErrorCode),
 }
 
-/// Broker response and the identifier of its corresponding request.
+/// Response sent over an active broker control channel.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct BrokerResponseEnvelope {
+pub struct BrokerResponse {
     /// Correlation identifier copied from the request.
     pub request_id: RequestId,
-    /// Broker operation result.
-    pub response: BrokerResponse,
+    /// Result of the requested broker operation.
+    pub result: BrokerResult,
 }
 
 /// Broker-owned event object response.

--- a/litebox_broker_protocol/src/wire.rs
+++ b/litebox_broker_protocol/src/wire.rs
@@ -39,7 +39,7 @@ const REQUEST_TAG_CHECK_READINESS: u8 = 4;
 
 const RESPONSE_TAG_NEGOTIATED: u8 = 0;
 const RESPONSE_TAG_EVENT: u8 = 1;
-const HANDSHAKE_RESPONSE_TAG_ERROR: u8 = 2;
+const RESPONSE_TAG_HANDSHAKE_ERROR: u8 = 2;
 const RESPONSE_TAG_VERSION_MISMATCH: u8 = 3;
 const RESPONSE_TAG_OBJECT_CLOSED: u8 = 4;
 const RESPONSE_TAG_PIPE: u8 = 5;
@@ -177,7 +177,7 @@ pub fn encode_handshake_response(response: BrokerHandshakeResponse) -> Vec<u8> {
             encoder.protocol_version(broker_protocol_version);
         }
         BrokerHandshakeResponse::Error(error) => {
-            encoder.u8(HANDSHAKE_RESPONSE_TAG_ERROR);
+            encoder.u8(RESPONSE_TAG_HANDSHAKE_ERROR);
             encoder.u16(error.as_raw());
         }
     }
@@ -202,7 +202,7 @@ pub fn decode_handshake_response(frame: &[u8]) -> Result<BrokerHandshakeResponse
         RESPONSE_TAG_VERSION_MISMATCH => BrokerHandshakeResponse::VersionMismatch {
             broker_protocol_version: decoder.protocol_version()?,
         },
-        HANDSHAKE_RESPONSE_TAG_ERROR => {
+        RESPONSE_TAG_HANDSHAKE_ERROR => {
             let error = ErrorCode::from_raw(decoder.u16()?).ok_or(WireError::InvalidTag)?;
             BrokerHandshakeResponse::Error(error)
         }
@@ -253,7 +253,7 @@ pub fn decode_response(frame: &[u8]) -> Result<BrokerResponse, WireError> {
     let mut decoder = Decoder::new(frame);
     let tag = decoder.u8()?;
     match tag {
-        RESPONSE_TAG_NEGOTIATED | HANDSHAKE_RESPONSE_TAG_ERROR | RESPONSE_TAG_VERSION_MISMATCH => {
+        RESPONSE_TAG_NEGOTIATED | RESPONSE_TAG_HANDSHAKE_ERROR | RESPONSE_TAG_VERSION_MISMATCH => {
             return Err(WireError::WrongMessagePhase);
         }
         RESPONSE_TAG_EVENT

--- a/litebox_broker_protocol/src/wire.rs
+++ b/litebox_broker_protocol/src/wire.rs
@@ -20,8 +20,8 @@ use thiserror::Error;
 
 use crate::error::ErrorCode;
 use crate::message::{
-    BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerNotification, BrokerRequest,
-    BrokerRequestEnvelope, BrokerResponse, BrokerResponseEnvelope, ReadinessNotification,
+    BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerNotification, BrokerOperation,
+    BrokerRequest, BrokerResponse, BrokerResult, ReadinessNotification,
 };
 use crate::readiness::ReadinessFlags;
 
@@ -99,29 +99,29 @@ pub fn decode_handshake_request(frame: &[u8]) -> Result<BrokerHandshakeRequest, 
 ///
 /// Successful encodings are always non-empty because the first byte is the
 /// message tag.
-pub fn encode_request(envelope: BrokerRequestEnvelope) -> Vec<u8> {
+pub fn encode_request(request: BrokerRequest) -> Vec<u8> {
     let mut encoder = Encoder::default();
-    let BrokerRequestEnvelope {
+    let BrokerRequest {
         request_id,
-        request,
-    } = envelope;
-    match request {
-        BrokerRequest::CloseObject(handle) => {
+        operation,
+    } = request;
+    match operation {
+        BrokerOperation::CloseObject(handle) => {
             encoder.u8(REQUEST_TAG_CLOSE_OBJECT);
             encoder.request_id(request_id);
             encoder.handle(handle);
         }
-        BrokerRequest::CheckReadiness(handle) => {
+        BrokerOperation::CheckReadiness(handle) => {
             encoder.u8(REQUEST_TAG_CHECK_READINESS);
             encoder.request_id(request_id);
             encoder.handle(handle);
         }
-        BrokerRequest::Event(request) => {
+        BrokerOperation::Event(request) => {
             encoder.u8(REQUEST_TAG_EVENT);
             encoder.request_id(request_id);
             event::encode_event_request(&mut encoder, request);
         }
-        BrokerRequest::Pipe(request) => {
+        BrokerOperation::Pipe(request) => {
             encoder.u8(REQUEST_TAG_PIPE);
             encoder.request_id(request_id);
             pipe::encode_pipe_request(&mut encoder, request);
@@ -131,7 +131,7 @@ pub fn encode_request(envelope: BrokerRequestEnvelope) -> Vec<u8> {
 }
 
 /// Decodes a broker request body.
-pub fn decode_request(frame: &[u8]) -> Result<BrokerRequestEnvelope, WireError> {
+pub fn decode_request(frame: &[u8]) -> Result<BrokerRequest, WireError> {
     let mut decoder = Decoder::new(frame);
     let tag = decoder.u8()?;
     match tag {
@@ -143,17 +143,17 @@ pub fn decode_request(frame: &[u8]) -> Result<BrokerRequestEnvelope, WireError> 
         _ => return Err(WireError::InvalidTag),
     }
     let request_id = decoder.request_id()?;
-    let request = match tag {
-        REQUEST_TAG_CLOSE_OBJECT => BrokerRequest::CloseObject(decoder.handle()?),
-        REQUEST_TAG_CHECK_READINESS => BrokerRequest::CheckReadiness(decoder.handle()?),
-        REQUEST_TAG_EVENT => BrokerRequest::Event(event::decode_event_request(&mut decoder)?),
-        REQUEST_TAG_PIPE => BrokerRequest::Pipe(pipe::decode_pipe_request(&mut decoder)?),
+    let operation = match tag {
+        REQUEST_TAG_CLOSE_OBJECT => BrokerOperation::CloseObject(decoder.handle()?),
+        REQUEST_TAG_CHECK_READINESS => BrokerOperation::CheckReadiness(decoder.handle()?),
+        REQUEST_TAG_EVENT => BrokerOperation::Event(event::decode_event_request(&mut decoder)?),
+        REQUEST_TAG_PIPE => BrokerOperation::Pipe(pipe::decode_pipe_request(&mut decoder)?),
         _ => unreachable!("active request tag was validated"),
     };
     decoder.finish()?;
-    Ok(BrokerRequestEnvelope {
+    Ok(BrokerRequest {
         request_id,
-        request,
+        operation,
     })
 }
 
@@ -216,33 +216,30 @@ pub fn decode_handshake_response(frame: &[u8]) -> Result<BrokerHandshakeResponse
 ///
 /// Successful encodings are always non-empty because the first byte is the
 /// message tag.
-pub fn encode_response(envelope: BrokerResponseEnvelope) -> Vec<u8> {
+pub fn encode_response(response: BrokerResponse) -> Vec<u8> {
     let mut encoder = Encoder::default();
-    let BrokerResponseEnvelope {
-        request_id,
-        response,
-    } = envelope;
-    match response {
-        BrokerResponse::ObjectClosed => {
+    let BrokerResponse { request_id, result } = response;
+    match result {
+        BrokerResult::ObjectClosed => {
             encoder.u8(RESPONSE_TAG_OBJECT_CLOSED);
             encoder.request_id(request_id);
         }
-        BrokerResponse::Readiness(readiness) => {
+        BrokerResult::Readiness(readiness) => {
             encoder.u8(RESPONSE_TAG_READINESS);
             encoder.request_id(request_id);
             encoder.u32(readiness.0);
         }
-        BrokerResponse::Event(response) => {
+        BrokerResult::Event(response) => {
             encoder.u8(RESPONSE_TAG_EVENT);
             encoder.request_id(request_id);
             event::encode_event_response(&mut encoder, response);
         }
-        BrokerResponse::Pipe(response) => {
+        BrokerResult::Pipe(response) => {
             encoder.u8(RESPONSE_TAG_PIPE);
             encoder.request_id(request_id);
             pipe::encode_pipe_response(&mut encoder, response);
         }
-        BrokerResponse::Error(error) => {
+        BrokerResult::Error(error) => {
             encoder.u8(RESPONSE_TAG_ERROR);
             encoder.request_id(request_id);
             encoder.u16(error.as_raw());
@@ -252,7 +249,7 @@ pub fn encode_response(envelope: BrokerResponseEnvelope) -> Vec<u8> {
 }
 
 /// Decodes a broker response body.
-pub fn decode_response(frame: &[u8]) -> Result<BrokerResponseEnvelope, WireError> {
+pub fn decode_response(frame: &[u8]) -> Result<BrokerResponse, WireError> {
     let mut decoder = Decoder::new(frame);
     let tag = decoder.u8()?;
     match tag {
@@ -267,22 +264,19 @@ pub fn decode_response(frame: &[u8]) -> Result<BrokerResponseEnvelope, WireError
         _ => return Err(WireError::InvalidTag),
     }
     let request_id = decoder.request_id()?;
-    let response = match tag {
-        RESPONSE_TAG_EVENT => BrokerResponse::Event(event::decode_event_response(&mut decoder)?),
-        RESPONSE_TAG_PIPE => BrokerResponse::Pipe(pipe::decode_pipe_response(&mut decoder)?),
+    let result = match tag {
+        RESPONSE_TAG_EVENT => BrokerResult::Event(event::decode_event_response(&mut decoder)?),
+        RESPONSE_TAG_PIPE => BrokerResult::Pipe(pipe::decode_pipe_response(&mut decoder)?),
         RESPONSE_TAG_ERROR => {
             let error = ErrorCode::from_raw(decoder.u16()?).ok_or(WireError::InvalidTag)?;
-            BrokerResponse::Error(error)
+            BrokerResult::Error(error)
         }
-        RESPONSE_TAG_OBJECT_CLOSED => BrokerResponse::ObjectClosed,
-        RESPONSE_TAG_READINESS => BrokerResponse::Readiness(ReadinessFlags(decoder.u32()?)),
+        RESPONSE_TAG_OBJECT_CLOSED => BrokerResult::ObjectClosed,
+        RESPONSE_TAG_READINESS => BrokerResult::Readiness(ReadinessFlags(decoder.u32()?)),
         _ => unreachable!("active response tag was validated"),
     };
     decoder.finish()?;
-    Ok(BrokerResponseEnvelope {
-        request_id,
-        response,
-    })
+    Ok(BrokerResponse { request_id, result })
 }
 
 /// Encodes a broker notification body.
@@ -332,17 +326,17 @@ mod tests {
 
     const TEST_REQUEST_ID: RequestId = RequestId(0x0102_0304_0506_0708);
 
-    fn request_envelope(request: BrokerRequest) -> BrokerRequestEnvelope {
-        BrokerRequestEnvelope {
+    fn active_request(operation: BrokerOperation) -> BrokerRequest {
+        BrokerRequest {
             request_id: TEST_REQUEST_ID,
-            request,
+            operation,
         }
     }
 
-    fn response_envelope(response: BrokerResponse) -> BrokerResponseEnvelope {
-        BrokerResponseEnvelope {
+    fn active_response(result: BrokerResult) -> BrokerResponse {
+        BrokerResponse {
             request_id: TEST_REQUEST_ID,
-            response,
+            result,
         }
     }
 
@@ -364,36 +358,36 @@ mod tests {
     fn request_codec_round_trips_all_variants() {
         let handle = ObjectHandle(13);
         let requests = [
-            BrokerRequest::CloseObject(handle),
-            BrokerRequest::CheckReadiness(handle),
-            BrokerRequest::Event(EventRequest::Create(CreateEventRequest {
+            BrokerOperation::CloseObject(handle),
+            BrokerOperation::CheckReadiness(handle),
+            BrokerOperation::Event(EventRequest::Create(CreateEventRequest {
                 initial_count: 0,
             })),
-            BrokerRequest::Event(EventRequest::Create(CreateEventRequest {
+            BrokerOperation::Event(EventRequest::Create(CreateEventRequest {
                 initial_count: 7,
             })),
-            BrokerRequest::Event(EventRequest::Add(AddEventRequest { handle, value: 3 })),
-            BrokerRequest::Event(EventRequest::Consume(ConsumeEventRequest {
+            BrokerOperation::Event(EventRequest::Add(AddEventRequest { handle, value: 3 })),
+            BrokerOperation::Event(EventRequest::Consume(ConsumeEventRequest {
                 handle,
                 mode: EventConsumeMode::All,
             })),
-            BrokerRequest::Event(EventRequest::Consume(ConsumeEventRequest {
+            BrokerOperation::Event(EventRequest::Consume(ConsumeEventRequest {
                 handle,
                 mode: EventConsumeMode::One,
             })),
-            BrokerRequest::Pipe(PipeRequest::Create(CreatePipeRequest {
+            BrokerOperation::Pipe(PipeRequest::Create(CreatePipeRequest {
                 capacity: 4096,
                 atomic_write_size: 512,
             })),
-            BrokerRequest::Pipe(PipeRequest::Read(ReadPipeRequest { handle, length: 32 })),
-            BrokerRequest::Pipe(PipeRequest::Write(WritePipeRequest { handle, length: 3 })),
+            BrokerOperation::Pipe(PipeRequest::Read(ReadPipeRequest { handle, length: 32 })),
+            BrokerOperation::Pipe(PipeRequest::Write(WritePipeRequest { handle, length: 3 })),
         ];
 
         for request in requests {
-            let envelope = request_envelope(request);
+            let request = active_request(request);
             assert_eq!(
-                decode_request(&encode_request(envelope.clone())).unwrap(),
-                envelope
+                decode_request(&encode_request(request.clone())).unwrap(),
+                request
             );
         }
     }
@@ -401,13 +395,13 @@ mod tests {
     #[test]
     fn request_codec_round_trips_identifier_bounds() {
         for request_id in [RequestId(0), RequestId(u64::MAX)] {
-            let envelope = BrokerRequestEnvelope {
+            let request = BrokerRequest {
                 request_id,
-                request: BrokerRequest::CloseObject(ObjectHandle(13)),
+                operation: BrokerOperation::CloseObject(ObjectHandle(13)),
             };
             assert_eq!(
-                decode_request(&encode_request(envelope.clone())).unwrap(),
-                envelope
+                decode_request(&encode_request(request.clone())).unwrap(),
+                request
             );
         }
     }
@@ -437,35 +431,35 @@ mod tests {
     fn response_codec_round_trips_all_variants() {
         let handle = ObjectHandle(13);
         let responses = [
-            BrokerResponse::ObjectClosed,
-            BrokerResponse::Readiness(ReadinessFlags::READ),
-            BrokerResponse::Readiness(ReadinessFlags::WRITE),
-            BrokerResponse::Event(EventResponse::Create(CreateEventResponse { handle })),
-            BrokerResponse::Event(EventResponse::Add(AddEventResponse {
+            BrokerResult::ObjectClosed,
+            BrokerResult::Readiness(ReadinessFlags::READ),
+            BrokerResult::Readiness(ReadinessFlags::WRITE),
+            BrokerResult::Event(EventResponse::Create(CreateEventResponse { handle })),
+            BrokerResult::Event(EventResponse::Add(AddEventResponse {
                 readiness: ReadinessFlags::READ | ReadinessFlags::WRITE,
             })),
-            BrokerResponse::Event(EventResponse::Consume(EventConsumption {
+            BrokerResult::Event(EventResponse::Consume(EventConsumption {
                 value: 3,
                 readiness: ReadinessFlags::WRITE,
             })),
-            BrokerResponse::Pipe(PipeResponse::Create(CreatePipeResponse {
+            BrokerResult::Pipe(PipeResponse::Create(CreatePipeResponse {
                 read_handle: handle,
                 write_handle: ObjectHandle(14),
             })),
-            BrokerResponse::Pipe(PipeResponse::Read(ReadPipeResponse { read: 3 })),
-            BrokerResponse::Pipe(PipeResponse::Write(WritePipeResponse { written: 3 })),
-            BrokerResponse::Error(ErrorCode::PolicyDenied),
-            BrokerResponse::Error(ErrorCode::WouldBlock),
-            BrokerResponse::Error(ErrorCode::PeerClosed),
-            BrokerResponse::Error(ErrorCode::OutOfMemory),
-            BrokerResponse::Error(ErrorCode::Internal),
+            BrokerResult::Pipe(PipeResponse::Read(ReadPipeResponse { read: 3 })),
+            BrokerResult::Pipe(PipeResponse::Write(WritePipeResponse { written: 3 })),
+            BrokerResult::Error(ErrorCode::PolicyDenied),
+            BrokerResult::Error(ErrorCode::WouldBlock),
+            BrokerResult::Error(ErrorCode::PeerClosed),
+            BrokerResult::Error(ErrorCode::OutOfMemory),
+            BrokerResult::Error(ErrorCode::Internal),
         ];
 
         for response in responses {
-            let envelope = response_envelope(response);
+            let response = active_response(response);
             assert_eq!(
-                decode_response(&encode_response(envelope.clone())).unwrap(),
-                envelope
+                decode_response(&encode_response(response.clone())).unwrap(),
+                response
             );
         }
     }
@@ -473,13 +467,13 @@ mod tests {
     #[test]
     fn response_codec_round_trips_identifier_bounds() {
         for request_id in [RequestId(0), RequestId(u64::MAX)] {
-            let envelope = BrokerResponseEnvelope {
+            let response = BrokerResponse {
                 request_id,
-                response: BrokerResponse::ObjectClosed,
+                result: BrokerResult::ObjectClosed,
             };
             assert_eq!(
-                decode_response(&encode_response(envelope.clone())).unwrap(),
-                envelope
+                decode_response(&encode_response(response.clone())).unwrap(),
+                response
             );
         }
     }
@@ -511,14 +505,14 @@ mod tests {
             Err(WireError::TruncatedFrame)
         );
         assert_eq!(
-            decode_handshake_request(&encode_request(request_envelope(BrokerRequest::Event(
+            decode_handshake_request(&encode_request(active_request(BrokerOperation::Event(
                 EventRequest::Create(CreateEventRequest { initial_count: 0 }),
             )))),
             Err(WireError::WrongMessagePhase)
         );
         assert_eq!(
-            decode_handshake_request(&encode_request(request_envelope(
-                BrokerRequest::CloseObject(ObjectHandle(13))
+            decode_handshake_request(&encode_request(active_request(
+                BrokerOperation::CloseObject(ObjectHandle(13))
             ))),
             Err(WireError::WrongMessagePhase)
         );
@@ -545,7 +539,7 @@ mod tests {
             decode_request(&[REQUEST_TAG_EVENT, 0, 0, 0, 0, 0, 0, 0]),
             Err(WireError::TruncatedFrame)
         );
-        let mut unknown_consume_mode = encode_request(request_envelope(BrokerRequest::Event(
+        let mut unknown_consume_mode = encode_request(active_request(BrokerOperation::Event(
             EventRequest::Consume(ConsumeEventRequest {
                 handle: ObjectHandle(13),
                 mode: EventConsumeMode::All,
@@ -556,7 +550,7 @@ mod tests {
             decode_request(&unknown_consume_mode),
             Err(WireError::InvalidTag)
         );
-        let mut frame = encode_request(request_envelope(BrokerRequest::Event(
+        let mut frame = encode_request(active_request(BrokerOperation::Event(
             EventRequest::Create(CreateEventRequest { initial_count: 0 }),
         )));
         frame.push(0xff);
@@ -578,7 +572,7 @@ mod tests {
             Err(WireError::InvalidTag)
         );
         assert_eq!(
-            decode_handshake_response(&encode_response(response_envelope(BrokerResponse::Event(
+            decode_handshake_response(&encode_response(active_response(BrokerResult::Event(
                 EventResponse::Create(CreateEventResponse {
                     handle: ObjectHandle(13),
                 })
@@ -586,13 +580,13 @@ mod tests {
             Err(WireError::WrongMessagePhase)
         );
         assert_eq!(
-            decode_handshake_response(&encode_response(response_envelope(
-                BrokerResponse::ObjectClosed
+            decode_handshake_response(&encode_response(active_response(
+                BrokerResult::ObjectClosed
             ))),
             Err(WireError::WrongMessagePhase)
         );
         assert_eq!(
-            decode_handshake_response(&encode_response(response_envelope(BrokerResponse::Error(
+            decode_handshake_response(&encode_response(active_response(BrokerResult::Error(
                 ErrorCode::WouldBlock
             )))),
             Err(WireError::WrongMessagePhase)
@@ -640,11 +634,11 @@ mod tests {
         let truncated = [RESPONSE_TAG_EVENT, 2, 2, 0];
         assert_eq!(decode_response(&truncated), Err(WireError::TruncatedFrame));
 
-        let mut frame = encode_response(response_envelope(BrokerResponse::Event(
-            EventResponse::Add(AddEventResponse {
+        let mut frame = encode_response(active_response(BrokerResult::Event(EventResponse::Add(
+            AddEventResponse {
                 readiness: ReadinessFlags::READ | ReadinessFlags::WRITE,
-            }),
-        )));
+            },
+        ))));
         frame.push(0xff);
         assert_eq!(decode_response(&frame), Err(WireError::TrailingBytes));
     }
@@ -686,9 +680,9 @@ mod tests {
     #[test]
     fn event_create_request_wire_shape_is_pinned() {
         assert_eq!(
-            encode_request(BrokerRequestEnvelope {
+            encode_request(BrokerRequest {
                 request_id: RequestId(13),
-                request: BrokerRequest::Event(EventRequest::Create(CreateEventRequest {
+                operation: BrokerOperation::Event(EventRequest::Create(CreateEventRequest {
                     initial_count: 7,
                 })),
             }),
@@ -699,9 +693,9 @@ mod tests {
     #[test]
     fn event_add_response_wire_shape_is_pinned() {
         assert_eq!(
-            encode_response(BrokerResponseEnvelope {
+            encode_response(BrokerResponse {
                 request_id: RequestId(13),
-                response: BrokerResponse::Event(EventResponse::Add(AddEventResponse {
+                result: BrokerResult::Event(EventResponse::Add(AddEventResponse {
                     readiness: ReadinessFlags::READ,
                 })),
             }),

--- a/litebox_broker_protocol/src/wire.rs
+++ b/litebox_broker_protocol/src/wire.rs
@@ -326,20 +326,6 @@ mod tests {
 
     const TEST_REQUEST_ID: RequestId = RequestId(0x0102_0304_0506_0708);
 
-    fn active_request(operation: BrokerOperation) -> BrokerRequest {
-        BrokerRequest {
-            request_id: TEST_REQUEST_ID,
-            operation,
-        }
-    }
-
-    fn active_response(result: BrokerResult) -> BrokerResponse {
-        BrokerResponse {
-            request_id: TEST_REQUEST_ID,
-            result,
-        }
-    }
-
     #[test]
     fn handshake_request_codec_round_trips_all_variants() {
         let requests = [BrokerHandshakeRequest {
@@ -357,7 +343,7 @@ mod tests {
     #[test]
     fn request_codec_round_trips_all_variants() {
         let handle = ObjectHandle(13);
-        let requests = [
+        let operations = [
             BrokerOperation::CloseObject(handle),
             BrokerOperation::CheckReadiness(handle),
             BrokerOperation::Event(EventRequest::Create(CreateEventRequest {
@@ -383,8 +369,11 @@ mod tests {
             BrokerOperation::Pipe(PipeRequest::Write(WritePipeRequest { handle, length: 3 })),
         ];
 
-        for request in requests {
-            let request = active_request(request);
+        for operation in operations {
+            let request = BrokerRequest {
+                request_id: TEST_REQUEST_ID,
+                operation,
+            };
             assert_eq!(
                 decode_request(&encode_request(request.clone())).unwrap(),
                 request
@@ -430,7 +419,7 @@ mod tests {
     #[test]
     fn response_codec_round_trips_all_variants() {
         let handle = ObjectHandle(13);
-        let responses = [
+        let results = [
             BrokerResult::ObjectClosed,
             BrokerResult::Readiness(ReadinessFlags::READ),
             BrokerResult::Readiness(ReadinessFlags::WRITE),
@@ -455,8 +444,11 @@ mod tests {
             BrokerResult::Error(ErrorCode::Internal),
         ];
 
-        for response in responses {
-            let response = active_response(response);
+        for result in results {
+            let response = BrokerResponse {
+                request_id: TEST_REQUEST_ID,
+                result,
+            };
             assert_eq!(
                 decode_response(&encode_response(response.clone())).unwrap(),
                 response
@@ -505,15 +497,19 @@ mod tests {
             Err(WireError::TruncatedFrame)
         );
         assert_eq!(
-            decode_handshake_request(&encode_request(active_request(BrokerOperation::Event(
-                EventRequest::Create(CreateEventRequest { initial_count: 0 }),
-            )))),
+            decode_handshake_request(&encode_request(BrokerRequest {
+                request_id: TEST_REQUEST_ID,
+                operation: BrokerOperation::Event(EventRequest::Create(CreateEventRequest {
+                    initial_count: 0,
+                })),
+            })),
             Err(WireError::WrongMessagePhase)
         );
         assert_eq!(
-            decode_handshake_request(&encode_request(active_request(
-                BrokerOperation::CloseObject(ObjectHandle(13))
-            ))),
+            decode_handshake_request(&encode_request(BrokerRequest {
+                request_id: TEST_REQUEST_ID,
+                operation: BrokerOperation::CloseObject(ObjectHandle(13)),
+            })),
             Err(WireError::WrongMessagePhase)
         );
         let mut frame = encode_handshake_request(BrokerHandshakeRequest {
@@ -539,20 +535,24 @@ mod tests {
             decode_request(&[REQUEST_TAG_EVENT, 0, 0, 0, 0, 0, 0, 0]),
             Err(WireError::TruncatedFrame)
         );
-        let mut unknown_consume_mode = encode_request(active_request(BrokerOperation::Event(
-            EventRequest::Consume(ConsumeEventRequest {
+        let mut unknown_consume_mode = encode_request(BrokerRequest {
+            request_id: TEST_REQUEST_ID,
+            operation: BrokerOperation::Event(EventRequest::Consume(ConsumeEventRequest {
                 handle: ObjectHandle(13),
                 mode: EventConsumeMode::All,
-            }),
-        )));
+            })),
+        });
         *unknown_consume_mode.last_mut().unwrap() = 0xff;
         assert_eq!(
             decode_request(&unknown_consume_mode),
             Err(WireError::InvalidTag)
         );
-        let mut frame = encode_request(active_request(BrokerOperation::Event(
-            EventRequest::Create(CreateEventRequest { initial_count: 0 }),
-        )));
+        let mut frame = encode_request(BrokerRequest {
+            request_id: TEST_REQUEST_ID,
+            operation: BrokerOperation::Event(EventRequest::Create(CreateEventRequest {
+                initial_count: 0,
+            })),
+        });
         frame.push(0xff);
         assert_eq!(decode_request(&frame), Err(WireError::TrailingBytes));
     }
@@ -572,23 +572,26 @@ mod tests {
             Err(WireError::InvalidTag)
         );
         assert_eq!(
-            decode_handshake_response(&encode_response(active_response(BrokerResult::Event(
-                EventResponse::Create(CreateEventResponse {
+            decode_handshake_response(&encode_response(BrokerResponse {
+                request_id: TEST_REQUEST_ID,
+                result: BrokerResult::Event(EventResponse::Create(CreateEventResponse {
                     handle: ObjectHandle(13),
-                })
-            ),))),
+                })),
+            })),
             Err(WireError::WrongMessagePhase)
         );
         assert_eq!(
-            decode_handshake_response(&encode_response(active_response(
-                BrokerResult::ObjectClosed
-            ))),
+            decode_handshake_response(&encode_response(BrokerResponse {
+                request_id: TEST_REQUEST_ID,
+                result: BrokerResult::ObjectClosed,
+            })),
             Err(WireError::WrongMessagePhase)
         );
         assert_eq!(
-            decode_handshake_response(&encode_response(active_response(BrokerResult::Error(
-                ErrorCode::WouldBlock
-            )))),
+            decode_handshake_response(&encode_response(BrokerResponse {
+                request_id: TEST_REQUEST_ID,
+                result: BrokerResult::Error(ErrorCode::WouldBlock),
+            })),
             Err(WireError::WrongMessagePhase)
         );
 
@@ -634,11 +637,12 @@ mod tests {
         let truncated = [RESPONSE_TAG_EVENT, 2, 2, 0];
         assert_eq!(decode_response(&truncated), Err(WireError::TruncatedFrame));
 
-        let mut frame = encode_response(active_response(BrokerResult::Event(EventResponse::Add(
-            AddEventResponse {
+        let mut frame = encode_response(BrokerResponse {
+            request_id: TEST_REQUEST_ID,
+            result: BrokerResult::Event(EventResponse::Add(AddEventResponse {
                 readiness: ReadinessFlags::READ | ReadinessFlags::WRITE,
-            },
-        ))));
+            })),
+        });
         frame.push(0xff);
         assert_eq!(decode_response(&frame), Err(WireError::TrailingBytes));
     }

--- a/litebox_broker_protocol/src/wire.rs
+++ b/litebox_broker_protocol/src/wire.rs
@@ -21,7 +21,7 @@ use thiserror::Error;
 use crate::error::ErrorCode;
 use crate::message::{
     BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerNotification, BrokerRequest,
-    BrokerResponse, ReadinessNotification,
+    BrokerRequestEnvelope, BrokerResponse, BrokerResponseEnvelope, ReadinessNotification,
 };
 use crate::readiness::ReadinessFlags;
 
@@ -39,11 +39,12 @@ const REQUEST_TAG_CHECK_READINESS: u8 = 4;
 
 const RESPONSE_TAG_NEGOTIATED: u8 = 0;
 const RESPONSE_TAG_EVENT: u8 = 1;
-const RESPONSE_TAG_ERROR: u8 = 2;
+const HANDSHAKE_RESPONSE_TAG_ERROR: u8 = 2;
 const RESPONSE_TAG_VERSION_MISMATCH: u8 = 3;
 const RESPONSE_TAG_OBJECT_CLOSED: u8 = 4;
 const RESPONSE_TAG_PIPE: u8 = 5;
 const RESPONSE_TAG_READINESS: u8 = 6;
+const RESPONSE_TAG_ERROR: u8 = 7;
 
 const NOTIFICATION_TAG_READINESS: u8 = 0;
 
@@ -98,23 +99,31 @@ pub fn decode_handshake_request(frame: &[u8]) -> Result<BrokerHandshakeRequest, 
 ///
 /// Successful encodings are always non-empty because the first byte is the
 /// message tag.
-pub fn encode_request(request: BrokerRequest) -> Vec<u8> {
+pub fn encode_request(envelope: BrokerRequestEnvelope) -> Vec<u8> {
     let mut encoder = Encoder::default();
+    let BrokerRequestEnvelope {
+        request_id,
+        request,
+    } = envelope;
     match request {
         BrokerRequest::CloseObject(handle) => {
             encoder.u8(REQUEST_TAG_CLOSE_OBJECT);
+            encoder.request_id(request_id);
             encoder.handle(handle);
         }
         BrokerRequest::CheckReadiness(handle) => {
             encoder.u8(REQUEST_TAG_CHECK_READINESS);
+            encoder.request_id(request_id);
             encoder.handle(handle);
         }
         BrokerRequest::Event(request) => {
             encoder.u8(REQUEST_TAG_EVENT);
+            encoder.request_id(request_id);
             event::encode_event_request(&mut encoder, request);
         }
         BrokerRequest::Pipe(request) => {
             encoder.u8(REQUEST_TAG_PIPE);
+            encoder.request_id(request_id);
             pipe::encode_pipe_request(&mut encoder, request);
         }
     }
@@ -122,19 +131,30 @@ pub fn encode_request(request: BrokerRequest) -> Vec<u8> {
 }
 
 /// Decodes a broker request body.
-pub fn decode_request(frame: &[u8]) -> Result<BrokerRequest, WireError> {
+pub fn decode_request(frame: &[u8]) -> Result<BrokerRequestEnvelope, WireError> {
     let mut decoder = Decoder::new(frame);
     let tag = decoder.u8()?;
-    let request = match tag {
+    match tag {
         REQUEST_TAG_NEGOTIATE => return Err(WireError::WrongMessagePhase),
+        REQUEST_TAG_CLOSE_OBJECT
+        | REQUEST_TAG_CHECK_READINESS
+        | REQUEST_TAG_EVENT
+        | REQUEST_TAG_PIPE => {}
+        _ => return Err(WireError::InvalidTag),
+    }
+    let request_id = decoder.request_id()?;
+    let request = match tag {
         REQUEST_TAG_CLOSE_OBJECT => BrokerRequest::CloseObject(decoder.handle()?),
         REQUEST_TAG_CHECK_READINESS => BrokerRequest::CheckReadiness(decoder.handle()?),
         REQUEST_TAG_EVENT => BrokerRequest::Event(event::decode_event_request(&mut decoder)?),
         REQUEST_TAG_PIPE => BrokerRequest::Pipe(pipe::decode_pipe_request(&mut decoder)?),
-        _ => return Err(WireError::InvalidTag),
+        _ => unreachable!("active request tag was validated"),
     };
     decoder.finish()?;
-    Ok(request)
+    Ok(BrokerRequestEnvelope {
+        request_id,
+        request,
+    })
 }
 
 /// Encodes a broker handshake response body.
@@ -157,7 +177,7 @@ pub fn encode_handshake_response(response: BrokerHandshakeResponse) -> Vec<u8> {
             encoder.protocol_version(broker_protocol_version);
         }
         BrokerHandshakeResponse::Error(error) => {
-            encoder.u8(RESPONSE_TAG_ERROR);
+            encoder.u8(HANDSHAKE_RESPONSE_TAG_ERROR);
             encoder.u16(error.as_raw());
         }
     }
@@ -175,13 +195,14 @@ pub fn decode_handshake_response(frame: &[u8]) -> Result<BrokerHandshakeResponse
         RESPONSE_TAG_EVENT
         | RESPONSE_TAG_OBJECT_CLOSED
         | RESPONSE_TAG_PIPE
-        | RESPONSE_TAG_READINESS => {
+        | RESPONSE_TAG_READINESS
+        | RESPONSE_TAG_ERROR => {
             return Err(WireError::WrongMessagePhase);
         }
         RESPONSE_TAG_VERSION_MISMATCH => BrokerHandshakeResponse::VersionMismatch {
             broker_protocol_version: decoder.protocol_version()?,
         },
-        RESPONSE_TAG_ERROR => {
+        HANDSHAKE_RESPONSE_TAG_ERROR => {
             let error = ErrorCode::from_raw(decoder.u16()?).ok_or(WireError::InvalidTag)?;
             BrokerHandshakeResponse::Error(error)
         }
@@ -195,26 +216,35 @@ pub fn decode_handshake_response(frame: &[u8]) -> Result<BrokerHandshakeResponse
 ///
 /// Successful encodings are always non-empty because the first byte is the
 /// message tag.
-pub fn encode_response(response: BrokerResponse) -> Vec<u8> {
+pub fn encode_response(envelope: BrokerResponseEnvelope) -> Vec<u8> {
     let mut encoder = Encoder::default();
+    let BrokerResponseEnvelope {
+        request_id,
+        response,
+    } = envelope;
     match response {
         BrokerResponse::ObjectClosed => {
             encoder.u8(RESPONSE_TAG_OBJECT_CLOSED);
+            encoder.request_id(request_id);
         }
         BrokerResponse::Readiness(readiness) => {
             encoder.u8(RESPONSE_TAG_READINESS);
+            encoder.request_id(request_id);
             encoder.u32(readiness.0);
         }
         BrokerResponse::Event(response) => {
             encoder.u8(RESPONSE_TAG_EVENT);
+            encoder.request_id(request_id);
             event::encode_event_response(&mut encoder, response);
         }
         BrokerResponse::Pipe(response) => {
             encoder.u8(RESPONSE_TAG_PIPE);
+            encoder.request_id(request_id);
             pipe::encode_pipe_response(&mut encoder, response);
         }
         BrokerResponse::Error(error) => {
             encoder.u8(RESPONSE_TAG_ERROR);
+            encoder.request_id(request_id);
             encoder.u16(error.as_raw());
         }
     }
@@ -222,13 +252,22 @@ pub fn encode_response(response: BrokerResponse) -> Vec<u8> {
 }
 
 /// Decodes a broker response body.
-pub fn decode_response(frame: &[u8]) -> Result<BrokerResponse, WireError> {
+pub fn decode_response(frame: &[u8]) -> Result<BrokerResponseEnvelope, WireError> {
     let mut decoder = Decoder::new(frame);
     let tag = decoder.u8()?;
-    let response = match tag {
-        RESPONSE_TAG_NEGOTIATED | RESPONSE_TAG_VERSION_MISMATCH => {
+    match tag {
+        RESPONSE_TAG_NEGOTIATED | HANDSHAKE_RESPONSE_TAG_ERROR | RESPONSE_TAG_VERSION_MISMATCH => {
             return Err(WireError::WrongMessagePhase);
         }
+        RESPONSE_TAG_EVENT
+        | RESPONSE_TAG_OBJECT_CLOSED
+        | RESPONSE_TAG_PIPE
+        | RESPONSE_TAG_READINESS
+        | RESPONSE_TAG_ERROR => {}
+        _ => return Err(WireError::InvalidTag),
+    }
+    let request_id = decoder.request_id()?;
+    let response = match tag {
         RESPONSE_TAG_EVENT => BrokerResponse::Event(event::decode_event_response(&mut decoder)?),
         RESPONSE_TAG_PIPE => BrokerResponse::Pipe(pipe::decode_pipe_response(&mut decoder)?),
         RESPONSE_TAG_ERROR => {
@@ -237,10 +276,13 @@ pub fn decode_response(frame: &[u8]) -> Result<BrokerResponse, WireError> {
         }
         RESPONSE_TAG_OBJECT_CLOSED => BrokerResponse::ObjectClosed,
         RESPONSE_TAG_READINESS => BrokerResponse::Readiness(ReadinessFlags(decoder.u32()?)),
-        _ => return Err(WireError::InvalidTag),
+        _ => unreachable!("active response tag was validated"),
     };
     decoder.finish()?;
-    Ok(response)
+    Ok(BrokerResponseEnvelope {
+        request_id,
+        response,
+    })
 }
 
 /// Encodes a broker notification body.
@@ -286,7 +328,23 @@ mod tests {
         CreatePipeRequest, CreatePipeResponse, ReadPipeRequest, ReadPipeResponse, WritePipeRequest,
         WritePipeResponse,
     };
-    use crate::{ObjectHandle, ProtocolVersion};
+    use crate::{ObjectHandle, ProtocolVersion, RequestId};
+
+    const TEST_REQUEST_ID: RequestId = RequestId(0x0102_0304_0506_0708);
+
+    fn request_envelope(request: BrokerRequest) -> BrokerRequestEnvelope {
+        BrokerRequestEnvelope {
+            request_id: TEST_REQUEST_ID,
+            request,
+        }
+    }
+
+    fn response_envelope(response: BrokerResponse) -> BrokerResponseEnvelope {
+        BrokerResponseEnvelope {
+            request_id: TEST_REQUEST_ID,
+            response,
+        }
+    }
 
     #[test]
     fn handshake_request_codec_round_trips_all_variants() {
@@ -332,9 +390,24 @@ mod tests {
         ];
 
         for request in requests {
+            let envelope = request_envelope(request);
             assert_eq!(
-                decode_request(&encode_request(request.clone())).unwrap(),
-                request
+                decode_request(&encode_request(envelope.clone())).unwrap(),
+                envelope
+            );
+        }
+    }
+
+    #[test]
+    fn request_codec_round_trips_identifier_bounds() {
+        for request_id in [RequestId(0), RequestId(u64::MAX)] {
+            let envelope = BrokerRequestEnvelope {
+                request_id,
+                request: BrokerRequest::CloseObject(ObjectHandle(13)),
+            };
+            assert_eq!(
+                decode_request(&encode_request(envelope.clone())).unwrap(),
+                envelope
             );
         }
     }
@@ -389,9 +462,24 @@ mod tests {
         ];
 
         for response in responses {
+            let envelope = response_envelope(response);
             assert_eq!(
-                decode_response(&encode_response(response.clone())).unwrap(),
-                response
+                decode_response(&encode_response(envelope.clone())).unwrap(),
+                envelope
+            );
+        }
+    }
+
+    #[test]
+    fn response_codec_round_trips_identifier_bounds() {
+        for request_id in [RequestId(0), RequestId(u64::MAX)] {
+            let envelope = BrokerResponseEnvelope {
+                request_id,
+                response: BrokerResponse::ObjectClosed,
+            };
+            assert_eq!(
+                decode_response(&encode_response(envelope.clone())).unwrap(),
+                envelope
             );
         }
     }
@@ -423,15 +511,15 @@ mod tests {
             Err(WireError::TruncatedFrame)
         );
         assert_eq!(
-            decode_handshake_request(&encode_request(BrokerRequest::Event(EventRequest::Create(
-                CreateEventRequest { initial_count: 0 },
+            decode_handshake_request(&encode_request(request_envelope(BrokerRequest::Event(
+                EventRequest::Create(CreateEventRequest { initial_count: 0 }),
             )))),
             Err(WireError::WrongMessagePhase)
         );
         assert_eq!(
-            decode_handshake_request(&encode_request(BrokerRequest::CloseObject(ObjectHandle(
-                13
-            )))),
+            decode_handshake_request(&encode_request(request_envelope(
+                BrokerRequest::CloseObject(ObjectHandle(13))
+            ))),
             Err(WireError::WrongMessagePhase)
         );
         let mut frame = encode_handshake_request(BrokerHandshakeRequest {
@@ -453,19 +541,23 @@ mod tests {
             })),
             Err(WireError::WrongMessagePhase)
         );
-        let mut unknown_consume_mode = encode_request(BrokerRequest::Event(EventRequest::Consume(
-            ConsumeEventRequest {
+        assert_eq!(
+            decode_request(&[REQUEST_TAG_EVENT, 0, 0, 0, 0, 0, 0, 0]),
+            Err(WireError::TruncatedFrame)
+        );
+        let mut unknown_consume_mode = encode_request(request_envelope(BrokerRequest::Event(
+            EventRequest::Consume(ConsumeEventRequest {
                 handle: ObjectHandle(13),
                 mode: EventConsumeMode::All,
-            },
+            }),
         )));
         *unknown_consume_mode.last_mut().unwrap() = 0xff;
         assert_eq!(
             decode_request(&unknown_consume_mode),
             Err(WireError::InvalidTag)
         );
-        let mut frame = encode_request(BrokerRequest::Event(EventRequest::Create(
-            CreateEventRequest { initial_count: 0 },
+        let mut frame = encode_request(request_envelope(BrokerRequest::Event(
+            EventRequest::Create(CreateEventRequest { initial_count: 0 }),
         )));
         frame.push(0xff);
         assert_eq!(decode_request(&frame), Err(WireError::TrailingBytes));
@@ -486,15 +578,23 @@ mod tests {
             Err(WireError::InvalidTag)
         );
         assert_eq!(
-            decode_handshake_response(&encode_response(BrokerResponse::Event(
+            decode_handshake_response(&encode_response(response_envelope(BrokerResponse::Event(
                 EventResponse::Create(CreateEventResponse {
                     handle: ObjectHandle(13),
-                }),
+                })
+            ),))),
+            Err(WireError::WrongMessagePhase)
+        );
+        assert_eq!(
+            decode_handshake_response(&encode_response(response_envelope(
+                BrokerResponse::ObjectClosed
             ))),
             Err(WireError::WrongMessagePhase)
         );
         assert_eq!(
-            decode_handshake_response(&encode_response(BrokerResponse::ObjectClosed)),
+            decode_handshake_response(&encode_response(response_envelope(BrokerResponse::Error(
+                ErrorCode::WouldBlock
+            )))),
             Err(WireError::WrongMessagePhase)
         );
 
@@ -514,30 +614,36 @@ mod tests {
             decode_response(&[0xff, 1, 2, 3]),
             Err(WireError::InvalidTag)
         );
-        assert_eq!(
-            decode_response(&encode_handshake_response(
-                BrokerHandshakeResponse::Negotiated {
-                    broker_protocol_version: ProtocolVersion(1),
-                },
-            )),
-            Err(WireError::WrongMessagePhase)
-        );
+        for response in [
+            BrokerHandshakeResponse::Negotiated {
+                broker_protocol_version: ProtocolVersion(1),
+            },
+            BrokerHandshakeResponse::VersionMismatch {
+                broker_protocol_version: ProtocolVersion(1),
+            },
+            BrokerHandshakeResponse::Error(ErrorCode::PolicyDenied),
+        ] {
+            assert_eq!(
+                decode_response(&encode_handshake_response(response)),
+                Err(WireError::WrongMessagePhase)
+            );
+        }
         assert_eq!(
             decode_response(&[RESPONSE_TAG_READINESS, 0xff]),
             Err(WireError::TruncatedFrame)
         );
-        assert_eq!(
-            decode_response(&[2, 0xff, 0xff]),
-            Err(WireError::InvalidTag)
-        );
+        let mut invalid_error = Vec::from([RESPONSE_TAG_ERROR]);
+        invalid_error.extend_from_slice(&TEST_REQUEST_ID.0.to_le_bytes());
+        invalid_error.extend_from_slice(&u16::MAX.to_le_bytes());
+        assert_eq!(decode_response(&invalid_error), Err(WireError::InvalidTag));
 
-        let truncated = [1, 2, 2, 0];
+        let truncated = [RESPONSE_TAG_EVENT, 2, 2, 0];
         assert_eq!(decode_response(&truncated), Err(WireError::TruncatedFrame));
 
-        let mut frame = encode_response(BrokerResponse::Event(EventResponse::Add(
-            AddEventResponse {
+        let mut frame = encode_response(response_envelope(BrokerResponse::Event(
+            EventResponse::Add(AddEventResponse {
                 readiness: ReadinessFlags::READ | ReadinessFlags::WRITE,
-            },
+            }),
         )));
         frame.push(0xff);
         assert_eq!(decode_response(&frame), Err(WireError::TrailingBytes));
@@ -578,14 +684,28 @@ mod tests {
     }
 
     #[test]
+    fn event_create_request_wire_shape_is_pinned() {
+        assert_eq!(
+            encode_request(BrokerRequestEnvelope {
+                request_id: RequestId(13),
+                request: BrokerRequest::Event(EventRequest::Create(CreateEventRequest {
+                    initial_count: 7,
+                })),
+            }),
+            [1, 13, 0, 0, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0]
+        );
+    }
+
+    #[test]
     fn event_add_response_wire_shape_is_pinned() {
         assert_eq!(
-            encode_response(BrokerResponse::Event(EventResponse::Add(
-                AddEventResponse {
+            encode_response(BrokerResponseEnvelope {
+                request_id: RequestId(13),
+                response: BrokerResponse::Event(EventResponse::Add(AddEventResponse {
                     readiness: ReadinessFlags::READ,
-                }
-            ))),
-            [1, 1, 1, 0, 0, 0]
+                })),
+            }),
+            [1, 13, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0]
         );
     }
 

--- a/litebox_broker_protocol/src/wire/primitive.rs
+++ b/litebox_broker_protocol/src/wire/primitive.rs
@@ -3,7 +3,7 @@
 
 use alloc::vec::Vec;
 
-use crate::{ObjectHandle, ProtocolVersion};
+use crate::{ObjectHandle, ProtocolVersion, RequestId};
 
 use super::WireError;
 
@@ -39,6 +39,10 @@ impl Encoder {
 
     pub(super) fn handle(&mut self, handle: ObjectHandle) {
         self.u64(handle.0);
+    }
+
+    pub(super) fn request_id(&mut self, request_id: RequestId) {
+        self.u64(request_id.0);
     }
 }
 
@@ -88,6 +92,10 @@ impl<'a> Decoder<'a> {
 
     pub(super) fn handle(&mut self) -> Result<ObjectHandle, WireError> {
         Ok(ObjectHandle(self.u64()?))
+    }
+
+    pub(super) fn request_id(&mut self) -> Result<RequestId, WireError> {
+        Ok(RequestId(self.u64()?))
     }
 
     fn take(&mut self, len: usize) -> Result<&'a [u8], WireError> {

--- a/litebox_broker_transport/src/unix_socket.rs
+++ b/litebox_broker_transport/src/unix_socket.rs
@@ -22,8 +22,8 @@ use litebox_broker_protocol::channel::{
     LocalNotificationChannel, PeerCredential,
 };
 use litebox_broker_protocol::message::{
-    BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerNotification, BrokerRequest,
-    BrokerResponse,
+    BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerNotification, BrokerRequestEnvelope,
+    BrokerResponseEnvelope,
 };
 use litebox_broker_protocol::wire::{
     WireError, decode_handshake_request, decode_handshake_response, decode_notification,
@@ -219,12 +219,12 @@ impl LocalControlChannel for UnixStreamLocalControlChannel {
         }
     }
 
-    fn send_request(&mut self, request: &BrokerRequest) -> IoResult<()> {
+    fn send_request(&mut self, request: &BrokerRequestEnvelope) -> IoResult<()> {
         let frame = encode_request(request.clone());
         write_frame_with_deadline(&mut self.stream, &frame, None)
     }
 
-    fn recv_response(&mut self) -> IoResult<Option<BrokerResponse>> {
+    fn recv_response(&mut self) -> IoResult<Option<BrokerResponseEnvelope>> {
         match read_frame_with_deadline(&mut self.stream, None)? {
             Some(frame) => decode_response(&frame).map(Some).map_err(wire_error),
             None => Ok(None),
@@ -262,7 +262,7 @@ impl HostControlChannel for UnixStreamHostControlChannel {
         Ok(())
     }
 
-    fn recv_request(&mut self) -> IoResult<HostReceive<BrokerRequest>> {
+    fn recv_request(&mut self) -> IoResult<HostReceive<BrokerRequestEnvelope>> {
         let Some(frame) = read_frame_with_deadline(&mut self.stream, None)? else {
             return Ok(HostReceive::PeerClosed);
         };
@@ -273,7 +273,7 @@ impl HostControlChannel for UnixStreamHostControlChannel {
         }
     }
 
-    fn send_response(&mut self, response: &BrokerResponse) -> IoResult<()> {
+    fn send_response(&mut self, response: &BrokerResponseEnvelope) -> IoResult<()> {
         write_frame_with_deadline(&mut self.stream, &encode_response(response.clone()), None)
     }
 }
@@ -390,6 +390,8 @@ fn wire_error(error: WireError) -> Error {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use litebox_broker_protocol::RequestId;
+    use litebox_broker_protocol::message::BrokerRequest;
     use std::time::Duration;
 
     #[test]
@@ -610,11 +612,14 @@ mod tests {
         let mut channel = UnixStreamHostControlChannel::from_accepted(host_stream);
         write_frame_with_deadline(
             &mut peer_stream,
-            &encode_request(BrokerRequest::Event(
-                litebox_broker_protocol::message::EventRequest::Create(
-                    litebox_broker_protocol::event::CreateEventRequest { initial_count: 0 },
+            &encode_request(BrokerRequestEnvelope {
+                request_id: RequestId(0),
+                request: BrokerRequest::Event(
+                    litebox_broker_protocol::message::EventRequest::Create(
+                        litebox_broker_protocol::event::CreateEventRequest { initial_count: 0 },
+                    ),
                 ),
-            )),
+            }),
             None,
         )
         .unwrap();

--- a/litebox_broker_transport/src/unix_socket.rs
+++ b/litebox_broker_transport/src/unix_socket.rs
@@ -22,8 +22,8 @@ use litebox_broker_protocol::channel::{
     LocalNotificationChannel, PeerCredential,
 };
 use litebox_broker_protocol::message::{
-    BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerNotification, BrokerRequestEnvelope,
-    BrokerResponseEnvelope,
+    BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerNotification, BrokerRequest,
+    BrokerResponse,
 };
 use litebox_broker_protocol::wire::{
     WireError, decode_handshake_request, decode_handshake_response, decode_notification,
@@ -219,12 +219,12 @@ impl LocalControlChannel for UnixStreamLocalControlChannel {
         }
     }
 
-    fn send_request(&mut self, request: &BrokerRequestEnvelope) -> IoResult<()> {
+    fn send_request(&mut self, request: &BrokerRequest) -> IoResult<()> {
         let frame = encode_request(request.clone());
         write_frame_with_deadline(&mut self.stream, &frame, None)
     }
 
-    fn recv_response(&mut self) -> IoResult<Option<BrokerResponseEnvelope>> {
+    fn recv_response(&mut self) -> IoResult<Option<BrokerResponse>> {
         match read_frame_with_deadline(&mut self.stream, None)? {
             Some(frame) => decode_response(&frame).map(Some).map_err(wire_error),
             None => Ok(None),
@@ -262,7 +262,7 @@ impl HostControlChannel for UnixStreamHostControlChannel {
         Ok(())
     }
 
-    fn recv_request(&mut self) -> IoResult<HostReceive<BrokerRequestEnvelope>> {
+    fn recv_request(&mut self) -> IoResult<HostReceive<BrokerRequest>> {
         let Some(frame) = read_frame_with_deadline(&mut self.stream, None)? else {
             return Ok(HostReceive::PeerClosed);
         };
@@ -273,7 +273,7 @@ impl HostControlChannel for UnixStreamHostControlChannel {
         }
     }
 
-    fn send_response(&mut self, response: &BrokerResponseEnvelope) -> IoResult<()> {
+    fn send_response(&mut self, response: &BrokerResponse) -> IoResult<()> {
         write_frame_with_deadline(&mut self.stream, &encode_response(response.clone()), None)
     }
 }
@@ -391,7 +391,7 @@ fn wire_error(error: WireError) -> Error {
 mod tests {
     use super::*;
     use litebox_broker_protocol::RequestId;
-    use litebox_broker_protocol::message::BrokerRequest;
+    use litebox_broker_protocol::message::{BrokerOperation, BrokerRequest};
     use std::time::Duration;
 
     #[test]
@@ -612,9 +612,9 @@ mod tests {
         let mut channel = UnixStreamHostControlChannel::from_accepted(host_stream);
         write_frame_with_deadline(
             &mut peer_stream,
-            &encode_request(BrokerRequestEnvelope {
+            &encode_request(BrokerRequest {
                 request_id: RequestId(0),
-                request: BrokerRequest::Event(
+                operation: BrokerOperation::Event(
                     litebox_broker_protocol::message::EventRequest::Create(
                         litebox_broker_protocol::event::CreateEventRequest { initial_count: 0 },
                     ),

--- a/litebox_runner_linux_userland/tests/run.rs
+++ b/litebox_runner_linux_userland/tests/run.rs
@@ -451,7 +451,7 @@ impl<Channel: litebox_broker_protocol::channel::HostControlChannel>
         &mut self,
     ) -> Result<
         litebox_broker_protocol::channel::HostReceive<
-            litebox_broker_protocol::message::BrokerRequest,
+            litebox_broker_protocol::message::BrokerRequestEnvelope,
         >,
         Self::Error,
     > {
@@ -459,7 +459,10 @@ impl<Channel: litebox_broker_protocol::channel::HostControlChannel>
         if matches!(
             &request,
             litebox_broker_protocol::channel::HostReceive::Message(
-                litebox_broker_protocol::message::BrokerRequest::CloseObject(_)
+                litebox_broker_protocol::message::BrokerRequestEnvelope {
+                    request: litebox_broker_protocol::message::BrokerRequest::CloseObject(_),
+                    ..
+                }
             )
         ) {
             self.close_object_count += 1;
@@ -469,7 +472,7 @@ impl<Channel: litebox_broker_protocol::channel::HostControlChannel>
 
     fn send_response(
         &mut self,
-        response: &litebox_broker_protocol::message::BrokerResponse,
+        response: &litebox_broker_protocol::message::BrokerResponseEnvelope,
     ) -> Result<(), Self::Error> {
         self.inner.send_response(response)
     }

--- a/litebox_runner_linux_userland/tests/run.rs
+++ b/litebox_runner_linux_userland/tests/run.rs
@@ -451,7 +451,7 @@ impl<Channel: litebox_broker_protocol::channel::HostControlChannel>
         &mut self,
     ) -> Result<
         litebox_broker_protocol::channel::HostReceive<
-            litebox_broker_protocol::message::BrokerRequestEnvelope,
+            litebox_broker_protocol::message::BrokerRequest,
         >,
         Self::Error,
     > {
@@ -459,8 +459,8 @@ impl<Channel: litebox_broker_protocol::channel::HostControlChannel>
         if matches!(
             &request,
             litebox_broker_protocol::channel::HostReceive::Message(
-                litebox_broker_protocol::message::BrokerRequestEnvelope {
-                    request: litebox_broker_protocol::message::BrokerRequest::CloseObject(_),
+                litebox_broker_protocol::message::BrokerRequest {
+                    operation: litebox_broker_protocol::message::BrokerOperation::CloseObject(_),
                     ..
                 }
             )
@@ -472,7 +472,7 @@ impl<Channel: litebox_broker_protocol::channel::HostControlChannel>
 
     fn send_response(
         &mut self,
-        response: &litebox_broker_protocol::message::BrokerResponseEnvelope,
+        response: &litebox_broker_protocol::message::BrokerResponse,
     ) -> Result<(), Self::Error> {
         self.inner.send_response(response)
     }


### PR DESCRIPTION
Adds association-scoped `RequestId`s to active broker requests and responses while leaving handshake and notification messages unchanged. The local endpoint allocates non-wrapping IDs and rejects mismatched responses, while the serial host loop echoes each request ID. Uncorrelated protocol violations terminate the association instead of fabricating a response.