### PR TITLE
Multiplex broker control calls

### DIFF
--- a/litebox/src/broker/mod.rs
+++ b/litebox/src/broker/mod.rs
@@ -9,7 +9,7 @@ use alloc::{
 use hashbrown::HashMap;
 use litebox_broker_local::BrokerLocal;
 use litebox_broker_protocol::ObjectHandle;
-use litebox_broker_protocol::channel::LocalCallChannel;
+use litebox_broker_protocol::channel::LocalControlChannel;
 use litebox_broker_protocol::event::{ConsumeEventResponse, EventConsumeMode};
 use litebox_broker_protocol::pipe::CreatePipeResponse;
 use litebox_broker_protocol::readiness::ReadinessFlags;
@@ -143,7 +143,7 @@ impl<Platform: RawSyncPrimitivesProvider> BrokerPollableRegistry<Platform> {
 
 pub(crate) struct BrokerLocalControl<
     Platform: RawSyncPrimitivesProvider,
-    Channel: LocalCallChannel + Send + Sync,
+    Channel: LocalControlChannel + Send + Sync,
 > {
     local: Mutex<Platform, Option<Arc<BrokerLocal<Channel>>>>,
     pollable_registry: Arc<BrokerPollableRegistry<Platform>>,
@@ -152,7 +152,7 @@ pub(crate) struct BrokerLocalControl<
 impl<Platform, Channel> BrokerLocalControl<Platform, Channel>
 where
     Platform: RawSyncPrimitivesProvider + TimeProvider,
-    Channel: LocalCallChannel + Send + Sync,
+    Channel: LocalControlChannel + Send + Sync,
 {
     pub(crate) fn new(
         local: BrokerLocal<Channel>,
@@ -188,7 +188,7 @@ where
 impl<Platform, Channel> BrokerControl for BrokerLocalControl<Platform, Channel>
 where
     Platform: RawSyncPrimitivesProvider + TimeProvider,
-    Channel: LocalCallChannel + Send + Sync,
+    Channel: LocalControlChannel + Send + Sync,
 {
     fn create_event_with_count(
         &self,

--- a/litebox/src/broker/mod.rs
+++ b/litebox/src/broker/mod.rs
@@ -9,7 +9,7 @@ use alloc::{
 use hashbrown::HashMap;
 use litebox_broker_local::BrokerLocal;
 use litebox_broker_protocol::ObjectHandle;
-use litebox_broker_protocol::channel::LocalControlChannel;
+use litebox_broker_protocol::channel::LocalCallChannel;
 use litebox_broker_protocol::event::{ConsumeEventResponse, EventConsumeMode};
 use litebox_broker_protocol::pipe::CreatePipeResponse;
 use litebox_broker_protocol::readiness::ReadinessFlags;
@@ -143,49 +143,42 @@ impl<Platform: RawSyncPrimitivesProvider> BrokerPollableRegistry<Platform> {
 
 pub(crate) struct BrokerLocalControl<
     Platform: RawSyncPrimitivesProvider,
-    Channel: LocalControlChannel + Send,
+    Channel: LocalCallChannel + Send + Sync,
 > {
-    local: Mutex<Platform, Option<BrokerLocal<Channel>>>,
+    local: Mutex<Platform, Option<Arc<BrokerLocal<Channel>>>>,
     pollable_registry: Arc<BrokerPollableRegistry<Platform>>,
 }
 
 impl<Platform, Channel> BrokerLocalControl<Platform, Channel>
 where
     Platform: RawSyncPrimitivesProvider + TimeProvider,
-    Channel: LocalControlChannel + Send,
+    Channel: LocalCallChannel + Send + Sync,
 {
     pub(crate) fn new(
         local: BrokerLocal<Channel>,
         pollable_registry: Arc<BrokerPollableRegistry<Platform>>,
     ) -> Self {
         Self {
-            local: Mutex::new(Some(local)),
+            local: Mutex::new(Some(Arc::new(local))),
             pollable_registry,
         }
     }
 
     fn request<T>(
         &self,
-        request: impl FnOnce(
-            &mut BrokerLocal<Channel>,
-        ) -> litebox_broker_local::Result<T, Channel::Error>,
+        request: impl FnOnce(&BrokerLocal<Channel>) -> litebox_broker_local::Result<T, Channel::Error>,
     ) -> core::result::Result<T, BrokerControlError> {
-        let (result, failed_connection) = {
-            let mut local = self.local.lock();
-            let Some(connection) = local.as_mut() else {
+        let connection = {
+            let local = self.local.lock();
+            let Some(connection) = local.as_ref() else {
                 return Err(BrokerControlError::AssociationFailed);
             };
-            let result = request(connection).map_err(BrokerControlError::from);
-            let failed_connection =
-                if matches!(result.as_ref(), Err(BrokerControlError::AssociationFailed)) {
-                    local.take()
-                } else {
-                    None
-                };
-            (result, failed_connection)
+            Arc::clone(connection)
         };
-        if let Some(connection) = failed_connection {
-            drop(connection);
+        let result = request(&connection).map_err(BrokerControlError::from);
+        if matches!(result.as_ref(), Err(BrokerControlError::AssociationFailed))
+            && self.local.lock().take().is_some()
+        {
             self.pollable_registry.notify_all(Events::ERR);
         }
         result
@@ -195,7 +188,7 @@ where
 impl<Platform, Channel> BrokerControl for BrokerLocalControl<Platform, Channel>
 where
     Platform: RawSyncPrimitivesProvider + TimeProvider,
-    Channel: LocalControlChannel + Send,
+    Channel: LocalCallChannel + Send + Sync,
 {
     fn create_event_with_count(
         &self,
@@ -257,8 +250,7 @@ where
 
     fn fail_connection(&self) {
         let connection = self.local.lock().take();
-        if let Some(connection) = connection {
-            drop(connection);
+        if connection.is_some() {
             self.pollable_registry.notify_all(Events::ERR);
         }
     }

--- a/litebox/src/event/counter.rs
+++ b/litebox/src/event/counter.rs
@@ -178,7 +178,7 @@ mod tests {
 
     use alloc::sync::Arc;
     use litebox_broker_local::BrokerLocal;
-    use litebox_broker_protocol::channel::{LocalCallChannel, LocalSetupChannel};
+    use litebox_broker_protocol::channel::LocalControlChannel;
     use litebox_broker_protocol::error::ErrorCode;
     use litebox_broker_protocol::event::{CreateEventResponse, EventConsumption};
     use litebox_broker_protocol::message::{
@@ -210,7 +210,7 @@ mod tests {
                 request_count,
                 fail_requests: Arc::new(AtomicBool::new(false)),
             },
-            |channel| Ok((Arc::new(NoopSharedMemory), channel)),
+            |_| Ok(Arc::new(NoopSharedMemory)),
         )
         .unwrap();
         let litebox = LiteBox::new_with_broker_local(platform, local);
@@ -268,7 +268,7 @@ mod tests {
                 request_count: Arc::clone(&request_count),
                 fail_requests: Arc::new(AtomicBool::new(false)),
             },
-            |channel| Ok((Arc::new(NoopSharedMemory), channel)),
+            |_| Ok(Arc::new(NoopSharedMemory)),
         )
         .unwrap();
         let litebox = Arc::new(LiteBox::new_with_broker_local(platform, local));
@@ -319,7 +319,7 @@ mod tests {
                 request_count: Arc::clone(&request_count),
                 fail_requests: Arc::clone(&fail_requests),
             },
-            |channel| Ok((Arc::new(NoopSharedMemory), channel)),
+            |_| Ok(Arc::new(NoopSharedMemory)),
         )
         .unwrap();
         let litebox = LiteBox::new_with_broker_local(platform, local);
@@ -355,7 +355,7 @@ mod tests {
                 request_count: Arc::clone(&request_count),
                 fail_requests: Arc::new(AtomicBool::new(false)),
             },
-            |channel| Ok((Arc::new(NoopSharedMemory), channel)),
+            |_| Ok(Arc::new(NoopSharedMemory)),
         )
         .unwrap();
         let litebox = LiteBox::new_with_broker_local(platform, local);
@@ -435,7 +435,7 @@ mod tests {
         }
     }
 
-    impl LocalSetupChannel for FakeLocalControlChannel {
+    impl LocalControlChannel for FakeLocalControlChannel {
         type Error = ();
 
         fn send_handshake_request(
@@ -452,11 +452,6 @@ mod tests {
                 broker_protocol_version: litebox_broker_protocol::BROKER_PROTOCOL_VERSION,
             }))
         }
-    }
-
-    impl LocalCallChannel for FakeLocalControlChannel {
-        type Error = ();
-
         fn call(
             &self,
             request: BrokerRequest,
@@ -495,8 +490,11 @@ mod tests {
             })
         }
 
-        fn with_serialized_payload<T>(&self, transfer: impl FnOnce() -> T) -> T {
-            transfer()
+        fn with_serialized_payload<T>(
+            &self,
+            transfer: impl FnOnce() -> T,
+        ) -> core::result::Result<T, Self::Error> {
+            Ok(transfer())
         }
     }
 }

--- a/litebox/src/event/counter.rs
+++ b/litebox/src/event/counter.rs
@@ -174,11 +174,11 @@ where
 mod tests {
     extern crate std;
 
-    use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use core::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 
     use alloc::sync::Arc;
     use litebox_broker_local::BrokerLocal;
-    use litebox_broker_protocol::channel::LocalControlChannel;
+    use litebox_broker_protocol::channel::{LocalCallChannel, LocalSetupChannel};
     use litebox_broker_protocol::error::ErrorCode;
     use litebox_broker_protocol::event::{CreateEventResponse, EventConsumption};
     use litebox_broker_protocol::message::{
@@ -204,14 +204,13 @@ mod tests {
         let request_count = Arc::new(AtomicUsize::new(0));
         let local = BrokerLocal::negotiate(
             FakeLocalControlChannel {
-                next_handle: handle.0,
+                next_handle: AtomicU64::new(handle.0),
                 consume_attempts: consume_attempts.clone(),
                 read_ready: read_ready.clone(),
                 request_count,
                 fail_requests: Arc::new(AtomicBool::new(false)),
-                last_request: None,
             },
-            |_| Ok(Arc::new(NoopSharedMemory)),
+            |channel| Ok((Arc::new(NoopSharedMemory), channel)),
         )
         .unwrap();
         let litebox = LiteBox::new_with_broker_local(platform, local);
@@ -263,14 +262,13 @@ mod tests {
         let request_count = Arc::new(AtomicUsize::new(0));
         let local = BrokerLocal::negotiate(
             FakeLocalControlChannel {
-                next_handle: handle.0,
+                next_handle: AtomicU64::new(handle.0),
                 consume_attempts: Arc::clone(&consume_attempts),
                 read_ready: Arc::new(AtomicBool::new(false)),
                 request_count: Arc::clone(&request_count),
                 fail_requests: Arc::new(AtomicBool::new(false)),
-                last_request: None,
             },
-            |_| Ok(Arc::new(NoopSharedMemory)),
+            |channel| Ok((Arc::new(NoopSharedMemory), channel)),
         )
         .unwrap();
         let litebox = Arc::new(LiteBox::new_with_broker_local(platform, local));
@@ -315,14 +313,13 @@ mod tests {
         let fail_requests = Arc::new(AtomicBool::new(false));
         let local = BrokerLocal::negotiate(
             FakeLocalControlChannel {
-                next_handle: handle.0,
+                next_handle: AtomicU64::new(handle.0),
                 consume_attempts: Arc::new(AtomicUsize::new(0)),
                 read_ready: Arc::new(AtomicBool::new(false)),
                 request_count: Arc::clone(&request_count),
                 fail_requests: Arc::clone(&fail_requests),
-                last_request: None,
             },
-            |_| Ok(Arc::new(NoopSharedMemory)),
+            |channel| Ok((Arc::new(NoopSharedMemory), channel)),
         )
         .unwrap();
         let litebox = LiteBox::new_with_broker_local(platform, local);
@@ -352,14 +349,13 @@ mod tests {
         let request_count = Arc::new(AtomicUsize::new(0));
         let local = BrokerLocal::negotiate(
             FakeLocalControlChannel {
-                next_handle: handle.0,
+                next_handle: AtomicU64::new(handle.0),
                 consume_attempts: Arc::new(AtomicUsize::new(0)),
                 read_ready: Arc::new(AtomicBool::new(false)),
                 request_count: Arc::clone(&request_count),
                 fail_requests: Arc::new(AtomicBool::new(false)),
-                last_request: None,
             },
-            |_| Ok(Arc::new(NoopSharedMemory)),
+            |channel| Ok((Arc::new(NoopSharedMemory), channel)),
         )
         .unwrap();
         let litebox = LiteBox::new_with_broker_local(platform, local);
@@ -405,12 +401,11 @@ mod tests {
     }
 
     struct FakeLocalControlChannel {
-        next_handle: u64,
+        next_handle: AtomicU64,
         consume_attempts: Arc<AtomicUsize>,
         read_ready: Arc<AtomicBool>,
         request_count: Arc<AtomicUsize>,
         fail_requests: Arc<AtomicBool>,
-        last_request: Option<BrokerRequest>,
     }
 
     struct NoopSharedMemory;
@@ -440,7 +435,7 @@ mod tests {
         }
     }
 
-    impl LocalControlChannel for FakeLocalControlChannel {
+    impl LocalSetupChannel for FakeLocalControlChannel {
         type Error = ();
 
         fn send_handshake_request(
@@ -457,26 +452,22 @@ mod tests {
                 broker_protocol_version: litebox_broker_protocol::BROKER_PROTOCOL_VERSION,
             }))
         }
+    }
 
-        fn send_request(
-            &mut self,
-            request: &BrokerRequest,
-        ) -> core::result::Result<(), Self::Error> {
-            self.last_request = Some(request.clone());
+    impl LocalCallChannel for FakeLocalControlChannel {
+        type Error = ();
+
+        fn call(
+            &self,
+            request: BrokerRequest,
+        ) -> core::result::Result<BrokerResponse, Self::Error> {
             self.request_count.fetch_add(1, Ordering::SeqCst);
-            Ok(())
-        }
-
-        fn recv_response(&mut self) -> core::result::Result<Option<BrokerResponse>, Self::Error> {
             if self.fail_requests.load(Ordering::SeqCst) {
-                self.last_request.take();
                 return Err(());
             }
-            let request = self.last_request.take().unwrap();
             let result = match request.operation {
                 BrokerOperation::Event(EventRequest::Create(_)) => {
-                    let handle = ObjectHandle(self.next_handle);
-                    self.next_handle += 1;
+                    let handle = ObjectHandle(self.next_handle.fetch_add(1, Ordering::SeqCst));
                     BrokerResult::Event(EventResponse::Create(CreateEventResponse { handle }))
                 }
                 BrokerOperation::Event(EventRequest::Consume(_)) => {
@@ -498,10 +489,14 @@ mod tests {
                     panic!("unexpected broker request: {request:?}")
                 }
             };
-            Ok(Some(BrokerResponse {
+            Ok(BrokerResponse {
                 request_id: request.request_id,
                 result,
-            }))
+            })
+        }
+
+        fn with_serialized_payload<T>(&self, transfer: impl FnOnce() -> T) -> T {
+            transfer()
         }
     }
 }

--- a/litebox/src/litebox.rs
+++ b/litebox/src/litebox.rs
@@ -6,7 +6,7 @@
 use alloc::sync::Arc;
 
 use litebox_broker_local::BrokerLocal;
-use litebox_broker_protocol::channel::LocalCallChannel;
+use litebox_broker_protocol::channel::LocalControlChannel;
 use litebox_broker_protocol::message::BrokerNotification;
 
 use crate::{
@@ -50,7 +50,7 @@ impl<Platform: RawSyncPrimitivesProvider> LiteBox<Platform> {
     ) -> Self
     where
         Platform: TimeProvider,
-        Channel: LocalCallChannel + Send + Sync + 'static,
+        Channel: LocalControlChannel + Send + Sync + 'static,
     {
         let broker_pollables = Arc::new(broker::BrokerPollableRegistry::new());
         let broker_control = Arc::new(broker::BrokerLocalControl::<Platform, Channel>::new(

--- a/litebox/src/litebox.rs
+++ b/litebox/src/litebox.rs
@@ -6,7 +6,7 @@
 use alloc::sync::Arc;
 
 use litebox_broker_local::BrokerLocal;
-use litebox_broker_protocol::channel::LocalControlChannel;
+use litebox_broker_protocol::channel::LocalCallChannel;
 use litebox_broker_protocol::message::BrokerNotification;
 
 use crate::{
@@ -50,7 +50,7 @@ impl<Platform: RawSyncPrimitivesProvider> LiteBox<Platform> {
     ) -> Self
     where
         Platform: TimeProvider,
-        Channel: LocalControlChannel + Send + 'static,
+        Channel: LocalCallChannel + Send + Sync + 'static,
     {
         let broker_pollables = Arc::new(broker::BrokerPollableRegistry::new());
         let broker_control = Arc::new(broker::BrokerLocalControl::<Platform, Channel>::new(

--- a/litebox/src/pipes.rs
+++ b/litebox/src/pipes.rs
@@ -928,7 +928,7 @@ mod tests {
 
     use alloc::sync::Arc;
     use litebox_broker_local::BrokerLocal;
-    use litebox_broker_protocol::channel::LocalControlChannel;
+    use litebox_broker_protocol::channel::{LocalCallChannel, LocalSetupChannel};
     use litebox_broker_protocol::error::ErrorCode;
     use litebox_broker_protocol::message::{
         BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerNotification, BrokerOperation,
@@ -952,12 +952,11 @@ mod tests {
         let force_transport = Arc::new(AtomicBool::new(false));
         let local = BrokerLocal::negotiate(
             FailingPipeChannel {
-                last_request: None,
                 request_count: Arc::clone(&request_count),
                 read_failure: ReadFailure::Transport,
                 force_transport,
             },
-            |_| Ok(Arc::new(NoopSharedMemory)),
+            |channel| Ok((Arc::new(NoopSharedMemory), channel)),
         )
         .unwrap();
         let litebox = crate::LiteBox::new_with_broker_local(platform, local);
@@ -999,12 +998,11 @@ mod tests {
         let force_transport = Arc::new(AtomicBool::new(false));
         let local = BrokerLocal::negotiate(
             FailingPipeChannel {
-                last_request: None,
                 request_count: Arc::clone(&request_count),
                 read_failure: ReadFailure::WouldBlock,
                 force_transport: Arc::clone(&force_transport),
             },
-            |_| Ok(Arc::new(NoopSharedMemory)),
+            |channel| Ok((Arc::new(NoopSharedMemory), channel)),
         )
         .unwrap();
         let litebox = Arc::new(crate::LiteBox::new_with_broker_local(platform, local));
@@ -1111,7 +1109,6 @@ mod tests {
 
     #[derive(Debug)]
     struct FailingPipeChannel {
-        last_request: Option<BrokerRequest>,
         request_count: Arc<AtomicUsize>,
         read_failure: ReadFailure,
         force_transport: Arc<AtomicBool>,
@@ -1151,7 +1148,7 @@ mod tests {
         WouldBlock,
     }
 
-    impl LocalControlChannel for FailingPipeChannel {
+    impl LocalSetupChannel for FailingPipeChannel {
         type Error = ();
 
         fn send_handshake_request(
@@ -1168,18 +1165,16 @@ mod tests {
                 broker_protocol_version: BROKER_PROTOCOL_VERSION,
             }))
         }
+    }
 
-        fn send_request(
-            &mut self,
-            request: &BrokerRequest,
-        ) -> core::result::Result<(), Self::Error> {
-            self.last_request = Some(request.clone());
+    impl LocalCallChannel for FailingPipeChannel {
+        type Error = ();
+
+        fn call(
+            &self,
+            request: BrokerRequest,
+        ) -> core::result::Result<BrokerResponse, Self::Error> {
             self.request_count.fetch_add(1, Ordering::SeqCst);
-            Ok(())
-        }
-
-        fn recv_response(&mut self) -> core::result::Result<Option<BrokerResponse>, Self::Error> {
-            let request = self.last_request.take().unwrap();
             let result = match request.operation {
                 BrokerOperation::Pipe(PipeRequest::Create(_)) => BrokerResult::Pipe(
                     litebox_broker_protocol::message::PipeResponse::Create(CreatePipeResponse {
@@ -1204,10 +1199,14 @@ mod tests {
                     panic!("unexpected broker request: {request:?}")
                 }
             };
-            Ok(Some(BrokerResponse {
+            Ok(BrokerResponse {
                 request_id: request.request_id,
                 result,
-            }))
+            })
+        }
+
+        fn with_serialized_payload<T>(&self, transfer: impl FnOnce() -> T) -> T {
+            transfer()
         }
     }
 

--- a/litebox/src/pipes.rs
+++ b/litebox/src/pipes.rs
@@ -928,7 +928,7 @@ mod tests {
 
     use alloc::sync::Arc;
     use litebox_broker_local::BrokerLocal;
-    use litebox_broker_protocol::channel::{LocalCallChannel, LocalSetupChannel};
+    use litebox_broker_protocol::channel::LocalControlChannel;
     use litebox_broker_protocol::error::ErrorCode;
     use litebox_broker_protocol::message::{
         BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerNotification, BrokerOperation,
@@ -956,7 +956,7 @@ mod tests {
                 read_failure: ReadFailure::Transport,
                 force_transport,
             },
-            |channel| Ok((Arc::new(NoopSharedMemory), channel)),
+            |_| Ok(Arc::new(NoopSharedMemory)),
         )
         .unwrap();
         let litebox = crate::LiteBox::new_with_broker_local(platform, local);
@@ -1002,7 +1002,7 @@ mod tests {
                 read_failure: ReadFailure::WouldBlock,
                 force_transport: Arc::clone(&force_transport),
             },
-            |channel| Ok((Arc::new(NoopSharedMemory), channel)),
+            |_| Ok(Arc::new(NoopSharedMemory)),
         )
         .unwrap();
         let litebox = Arc::new(crate::LiteBox::new_with_broker_local(platform, local));
@@ -1148,7 +1148,7 @@ mod tests {
         WouldBlock,
     }
 
-    impl LocalSetupChannel for FailingPipeChannel {
+    impl LocalControlChannel for FailingPipeChannel {
         type Error = ();
 
         fn send_handshake_request(
@@ -1165,11 +1165,6 @@ mod tests {
                 broker_protocol_version: BROKER_PROTOCOL_VERSION,
             }))
         }
-    }
-
-    impl LocalCallChannel for FailingPipeChannel {
-        type Error = ();
-
         fn call(
             &self,
             request: BrokerRequest,
@@ -1205,8 +1200,11 @@ mod tests {
             })
         }
 
-        fn with_serialized_payload<T>(&self, transfer: impl FnOnce() -> T) -> T {
-            transfer()
+        fn with_serialized_payload<T>(
+            &self,
+            transfer: impl FnOnce() -> T,
+        ) -> core::result::Result<T, Self::Error> {
+            Ok(transfer())
         }
     }
 

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -48,6 +48,10 @@ pub use error::{BrokerHostError, Result};
 /// `shared_memory` belongs to this association and is reused at offset zero for
 /// serialized pipe transfers. `send_shared_memory` runs after version
 /// negotiation and before active requests begin.
+///
+/// Active requests are intentionally executed serially: this function receives,
+/// executes, and responds to one request before reading the next. It does not
+/// create a request queue or dispatch work to worker threads.
 pub fn serve_connection<ControlChannel, NotificationChannel, ChannelError>(
     core: &BrokerCore,
     control_channel: &mut ControlChannel,

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -48,10 +48,6 @@ pub use error::{BrokerHostError, Result};
 /// `shared_memory` belongs to this association and is reused at offset zero for
 /// serialized pipe transfers. `send_shared_memory` runs after version
 /// negotiation and before active requests begin.
-///
-/// Active requests are intentionally executed serially: this function receives,
-/// executes, and responds to one request before reading the next. It does not
-/// create a request queue or dispatch work to worker threads.
 pub fn serve_connection<ControlChannel, NotificationChannel, ChannelError>(
     core: &BrokerCore,
     control_channel: &mut ControlChannel,

--- a/litebox_broker_local/src/event.rs
+++ b/litebox_broker_local/src/event.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 use litebox_broker_protocol::ObjectHandle;
-use litebox_broker_protocol::channel::LocalControlChannel;
+use litebox_broker_protocol::channel::LocalCallChannel;
 use litebox_broker_protocol::event::{
     AddEventRequest, ConsumeEventRequest, ConsumeEventResponse, CreateEventRequest,
     EventConsumeMode,
@@ -14,7 +14,7 @@ use litebox_broker_protocol::readiness::ReadinessFlags;
 
 use crate::{BrokerLocal, BrokerLocalError, Result};
 
-impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
+impl<Channel: LocalCallChannel> BrokerLocal<Channel> {
     /// Creates a broker-owned event object with initial readiness credits.
     ///
     /// # Panics
@@ -22,7 +22,7 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
     /// Panics if the broker reports an unrecoverable error or returns a protocol
     /// response that does not match the issued event request.
     pub fn create_event_with_count(
-        &mut self,
+        &self,
         initial_count: u64,
     ) -> Result<ObjectHandle, Channel::Error> {
         let response =
@@ -40,7 +40,7 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
     /// Panics if the broker reports an unrecoverable error or returns a protocol
     /// response that does not match the issued event request.
     pub fn add_event(
-        &mut self,
+        &self,
         handle: ObjectHandle,
         value: u64,
     ) -> Result<ReadinessFlags, Channel::Error> {
@@ -58,7 +58,7 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
     /// Panics if the broker reports an unrecoverable error or returns a protocol
     /// response that does not match the issued event request.
     pub fn consume_event(
-        &mut self,
+        &self,
         handle: ObjectHandle,
         mode: EventConsumeMode,
     ) -> Result<ConsumeEventResponse, Channel::Error> {
@@ -70,7 +70,7 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
         }
     }
 
-    fn request_event(&mut self, request: EventRequest) -> Result<EventResponse, Channel::Error> {
+    fn request_event(&self, request: EventRequest) -> Result<EventResponse, Channel::Error> {
         match self.request(BrokerOperation::Event(request))? {
             BrokerResult::Event(response) => Ok(response),
             BrokerResult::Error(error) => Err(BrokerLocalError::Broker(error)),

--- a/litebox_broker_local/src/event.rs
+++ b/litebox_broker_local/src/event.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 use litebox_broker_protocol::ObjectHandle;
-use litebox_broker_protocol::channel::LocalCallChannel;
+use litebox_broker_protocol::channel::LocalControlChannel;
 use litebox_broker_protocol::event::{
     AddEventRequest, ConsumeEventRequest, ConsumeEventResponse, CreateEventRequest,
     EventConsumeMode,
@@ -14,7 +14,7 @@ use litebox_broker_protocol::readiness::ReadinessFlags;
 
 use crate::{BrokerLocal, BrokerLocalError, Result};
 
-impl<Channel: LocalCallChannel> BrokerLocal<Channel> {
+impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
     /// Creates a broker-owned event object with initial readiness credits.
     ///
     /// # Panics

--- a/litebox_broker_local/src/lib.rs
+++ b/litebox_broker_local/src/lib.rs
@@ -4,8 +4,8 @@
 //! Typed broker-local adapters for broker requests and notifications.
 //!
 //! The local control adapter owns request identifiers but does not own transport
-//! sequencing. Userland, kernel, or ring-buffer deployments provide active call
-//! channels by implementing [`litebox_broker_protocol::channel::LocalCallChannel`].
+//! sequencing. Userland, kernel, or ring-buffer deployments provide control
+//! channels by implementing [`litebox_broker_protocol::channel::LocalControlChannel`].
 //! Notification receive adapters are intentionally separate so active control
 //! requests remain strictly paired with their responses.
 
@@ -23,9 +23,7 @@ mod pipe;
 use alloc::sync::Arc;
 use core::sync::atomic::{AtomicU64, Ordering};
 
-use litebox_broker_protocol::channel::{
-    LocalCallChannel, LocalNotificationChannel, LocalSetupChannel,
-};
+use litebox_broker_protocol::channel::{LocalControlChannel, LocalNotificationChannel};
 use litebox_broker_protocol::error::ErrorCode;
 use litebox_broker_protocol::message::{
     BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerNotification, BrokerOperation,
@@ -42,7 +40,7 @@ pub use error::{BrokerLocalError, Result};
 ///
 /// The shared memory belongs to the broker association and is reused for each
 /// serialized pipe transfer.
-pub struct BrokerLocal<Channel: LocalCallChannel> {
+pub struct BrokerLocal<Channel: LocalControlChannel> {
     channel: Channel,
     shared_memory: Arc<dyn SharedMemory>,
     next_request_id: AtomicU64,
@@ -53,7 +51,7 @@ pub struct BrokerNotifications<Channel: LocalNotificationChannel> {
     channel: Channel,
 }
 
-impl<Channel: LocalCallChannel> BrokerLocal<Channel> {
+impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
     /// Negotiates the broker protocol, then establishes the association shared
     /// memory before active requests begin.
     ///
@@ -62,26 +60,20 @@ impl<Channel: LocalCallChannel> BrokerLocal<Channel> {
     /// Panics if the broker reports an unrecoverable error, returns a protocol
     /// response that does not match the negotiation request, or setup returns
     /// shared memory with an invalid size.
-    pub fn negotiate<SetupChannel>(
-        mut setup_channel: SetupChannel,
+    pub fn negotiate(
+        mut channel: Channel,
         activate: impl FnOnce(
-            SetupChannel,
-        ) -> core::result::Result<
-            (Arc<dyn SharedMemory>, Channel),
-            SetupChannel::Error,
-        >,
-    ) -> Result<Self, SetupChannel::Error>
-    where
-        SetupChannel: LocalSetupChannel,
-    {
+            &mut Channel,
+        ) -> core::result::Result<Arc<dyn SharedMemory>, Channel::Error>,
+    ) -> Result<Self, Channel::Error> {
         let requested = BROKER_PROTOCOL_VERSION;
         let request = BrokerHandshakeRequest {
             protocol_version: requested,
         };
-        setup_channel
+        channel
             .send_handshake_request(&request)
             .map_err(BrokerLocalError::Channel)?;
-        match setup_channel
+        match channel
             .recv_handshake_response()
             .map_err(BrokerLocalError::Channel)?
             .ok_or(BrokerLocalError::ChannelClosed)?
@@ -93,8 +85,7 @@ impl<Channel: LocalCallChannel> BrokerLocal<Channel> {
                     requested, broker_protocol_version,
                     "broker returned unexpected negotiation response: {response:?}"
                 );
-                let (shared_memory, channel) =
-                    activate(setup_channel).map_err(BrokerLocalError::Channel)?;
+                let shared_memory = activate(&mut channel).map_err(BrokerLocalError::Channel)?;
                 assert_eq!(
                     shared_memory.len(),
                     PIPE_TRANSFER_BUFFER_SIZE,
@@ -253,7 +244,7 @@ mod tests {
             assert!(channel.handshake_response.is_none());
             assert!(channel.sent_request.borrow().is_none());
             setup_calls.set(setup_calls.get() + 1);
-            Ok((noop_shared_memory(), channel))
+            Ok(noop_shared_memory())
         })
         .unwrap();
 
@@ -427,9 +418,9 @@ mod tests {
         let setup_called = Cell::new(false);
 
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            let _ = BrokerLocal::negotiate(channel, |channel| {
+            let _ = BrokerLocal::negotiate(channel, |_| {
                 setup_called.set(true);
-                Ok((noop_shared_memory(), channel))
+                Ok(noop_shared_memory())
             });
         }));
         assert_panic_contains(result, "broker returned unexpected negotiation response");
@@ -462,9 +453,9 @@ mod tests {
 
         let setup_called = Cell::new(false);
         assert!(matches!(
-            BrokerLocal::negotiate(channel, |channel| {
+            BrokerLocal::negotiate(channel, |_| {
                 setup_called.set(true);
-                Ok((noop_shared_memory(), channel))
+                Ok(noop_shared_memory())
             }),
             Err(BrokerLocalError::Broker(ErrorCode::UnsupportedVersion))
         ));
@@ -480,9 +471,9 @@ mod tests {
         let setup_called = Cell::new(false);
 
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            let _ = BrokerLocal::negotiate(channel, |channel| {
+            let _ = BrokerLocal::negotiate(channel, |_| {
                 setup_called.set(true);
-                Ok((noop_shared_memory(), channel))
+                Ok(noop_shared_memory())
             });
         }));
         assert_panic_contains(result, "broker returned unrecoverable error");
@@ -518,13 +509,10 @@ mod tests {
             None,
         );
 
-        let _ = BrokerLocal::negotiate(channel, |channel| {
-            Ok((
-                Arc::new(NoopSharedMemory {
-                    length: PIPE_TRANSFER_BUFFER_SIZE - 1,
-                }) as Arc<dyn SharedMemory>,
-                channel,
-            ))
+        let _ = BrokerLocal::negotiate(channel, |_| {
+            Ok(Arc::new(NoopSharedMemory {
+                length: PIPE_TRANSFER_BUFFER_SIZE - 1,
+            }) as Arc<dyn SharedMemory>)
         });
     }
 
@@ -606,7 +594,7 @@ mod tests {
         }
     }
 
-    impl LocalSetupChannel for FakeControlChannel {
+    impl LocalControlChannel for FakeControlChannel {
         type Error = FakeChannelError;
 
         fn send_handshake_request(
@@ -622,11 +610,6 @@ mod tests {
         ) -> core::result::Result<Option<BrokerHandshakeResponse>, Self::Error> {
             Ok(self.handshake_response.take())
         }
-    }
-
-    impl LocalCallChannel for FakeControlChannel {
-        type Error = FakeChannelError;
-
         fn call(
             &self,
             request: BrokerRequest,
@@ -649,8 +632,11 @@ mod tests {
             })
         }
 
-        fn with_serialized_payload<T>(&self, transfer: impl FnOnce() -> T) -> T {
-            transfer()
+        fn with_serialized_payload<T>(
+            &self,
+            transfer: impl FnOnce() -> T,
+        ) -> core::result::Result<T, Self::Error> {
+            Ok(transfer())
         }
     }
 
@@ -662,8 +648,23 @@ mod tests {
         request_ids: Mutex<std::vec::Vec<RequestId>>,
     }
 
-    impl LocalCallChannel for ConcurrentCallChannel {
+    impl LocalControlChannel for ConcurrentCallChannel {
         type Error = Infallible;
+
+        fn send_handshake_request(
+            &mut self,
+            _request: &BrokerHandshakeRequest,
+        ) -> core::result::Result<(), Self::Error> {
+            Ok(())
+        }
+
+        fn recv_handshake_response(
+            &mut self,
+        ) -> core::result::Result<Option<BrokerHandshakeResponse>, Self::Error> {
+            Ok(Some(BrokerHandshakeResponse::Negotiated {
+                broker_protocol_version: BROKER_PROTOCOL_VERSION,
+            }))
+        }
 
         fn call(
             &self,
@@ -676,8 +677,11 @@ mod tests {
             })
         }
 
-        fn with_serialized_payload<T>(&self, transfer: impl FnOnce() -> T) -> T {
-            transfer()
+        fn with_serialized_payload<T>(
+            &self,
+            transfer: impl FnOnce() -> T,
+        ) -> core::result::Result<T, Self::Error> {
+            Ok(transfer())
         }
     }
 

--- a/litebox_broker_local/src/lib.rs
+++ b/litebox_broker_local/src/lib.rs
@@ -3,9 +3,9 @@
 
 //! Typed broker-local adapters for broker requests and notifications.
 //!
-//! The local control adapter owns request/response sequencing but does not own a channel.
-//! Userland, kernel, or ring-buffer deployments can provide channels by
-//! implementing [`litebox_broker_protocol::channel::LocalControlChannel`].
+//! The local control adapter owns request identifiers but does not own transport
+//! sequencing. Userland, kernel, or ring-buffer deployments provide active call
+//! channels by implementing [`litebox_broker_protocol::channel::LocalCallChannel`].
 //! Notification receive adapters are intentionally separate so active control
 //! requests remain strictly paired with their responses.
 
@@ -21,8 +21,11 @@ mod event;
 mod pipe;
 
 use alloc::sync::Arc;
+use core::sync::atomic::{AtomicU64, Ordering};
 
-use litebox_broker_protocol::channel::{LocalControlChannel, LocalNotificationChannel};
+use litebox_broker_protocol::channel::{
+    LocalCallChannel, LocalNotificationChannel, LocalSetupChannel,
+};
 use litebox_broker_protocol::error::ErrorCode;
 use litebox_broker_protocol::message::{
     BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerNotification, BrokerOperation,
@@ -39,10 +42,10 @@ pub use error::{BrokerLocalError, Result};
 ///
 /// The shared memory belongs to the broker association and is reused for each
 /// serialized pipe transfer.
-pub struct BrokerLocal<Channel: LocalControlChannel> {
+pub struct BrokerLocal<Channel: LocalCallChannel> {
     channel: Channel,
     shared_memory: Arc<dyn SharedMemory>,
-    next_request_id: u64,
+    next_request_id: AtomicU64,
 }
 
 /// Broker-local receive adapter for broker-initiated asynchronous notifications.
@@ -50,7 +53,7 @@ pub struct BrokerNotifications<Channel: LocalNotificationChannel> {
     channel: Channel,
 }
 
-impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
+impl<Channel: LocalCallChannel> BrokerLocal<Channel> {
     /// Negotiates the broker protocol, then establishes the association shared
     /// memory before active requests begin.
     ///
@@ -59,23 +62,26 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
     /// Panics if the broker reports an unrecoverable error, returns a protocol
     /// response that does not match the negotiation request, or setup returns
     /// shared memory with an invalid size.
-    pub fn negotiate(
-        mut channel: Channel,
-        receive_shared_memory: impl FnOnce(
-            &mut Channel,
+    pub fn negotiate<SetupChannel>(
+        mut setup_channel: SetupChannel,
+        activate: impl FnOnce(
+            SetupChannel,
         ) -> core::result::Result<
-            Arc<dyn SharedMemory>,
-            Channel::Error,
+            (Arc<dyn SharedMemory>, Channel),
+            SetupChannel::Error,
         >,
-    ) -> Result<Self, Channel::Error> {
+    ) -> Result<Self, SetupChannel::Error>
+    where
+        SetupChannel: LocalSetupChannel,
+    {
         let requested = BROKER_PROTOCOL_VERSION;
         let request = BrokerHandshakeRequest {
             protocol_version: requested,
         };
-        channel
+        setup_channel
             .send_handshake_request(&request)
             .map_err(BrokerLocalError::Channel)?;
-        match channel
+        match setup_channel
             .recv_handshake_response()
             .map_err(BrokerLocalError::Channel)?
             .ok_or(BrokerLocalError::ChannelClosed)?
@@ -87,8 +93,8 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
                     requested, broker_protocol_version,
                     "broker returned unexpected negotiation response: {response:?}"
                 );
-                let shared_memory =
-                    receive_shared_memory(&mut channel).map_err(BrokerLocalError::Channel)?;
+                let (shared_memory, channel) =
+                    activate(setup_channel).map_err(BrokerLocalError::Channel)?;
                 assert_eq!(
                     shared_memory.len(),
                     PIPE_TRANSFER_BUFFER_SIZE,
@@ -97,7 +103,7 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
                 Ok(Self {
                     channel,
                     shared_memory,
-                    next_request_id: 0,
+                    next_request_id: AtomicU64::new(0),
                 })
             }
             BrokerHandshakeResponse::VersionMismatch { .. } => {
@@ -123,28 +129,26 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
     /// Panics if the broker reports an unrecoverable error or returns a protocol
     /// response that does not match an active request.
     pub(crate) fn request(
-        &mut self,
+        &self,
         operation: BrokerOperation,
     ) -> Result<BrokerResult, Channel::Error> {
-        let request_id = RequestId(self.next_request_id);
-        self.next_request_id = self
+        let request_id = self
             .next_request_id
-            .checked_add(1)
-            .ok_or(BrokerLocalError::RequestIdExhausted)?;
-        self.channel
-            .send_request(&BrokerRequest {
-                request_id,
-                operation,
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |request_id| {
+                request_id.checked_add(1)
             })
-            .map_err(BrokerLocalError::Channel)?;
+            .map(RequestId)
+            .map_err(|_| BrokerLocalError::RequestIdExhausted)?;
         let BrokerResponse {
             request_id: response_id,
             result,
         } = self
             .channel
-            .recv_response()
-            .map_err(BrokerLocalError::Channel)?
-            .ok_or(BrokerLocalError::ChannelClosed)?;
+            .call(BrokerRequest {
+                request_id,
+                operation,
+            })
+            .map_err(BrokerLocalError::Channel)?;
         if response_id != request_id {
             return Err(BrokerLocalError::UnexpectedResponseId {
                 expected: request_id,
@@ -180,10 +184,7 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
     ///
     /// Panics if the broker reports an unrecoverable error or returns a
     /// response that does not match the issued readiness request.
-    pub fn check_readiness(
-        &mut self,
-        handle: ObjectHandle,
-    ) -> Result<ReadinessFlags, Channel::Error> {
+    pub fn check_readiness(&self, handle: ObjectHandle) -> Result<ReadinessFlags, Channel::Error> {
         match self.request(BrokerOperation::CheckReadiness(handle))? {
             BrokerResult::Readiness(readiness) => Ok(readiness),
             BrokerResult::Error(error) => Err(BrokerLocalError::Broker(error)),
@@ -197,7 +198,7 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
     ///
     /// Panics if the broker reports an unrecoverable error or returns a protocol
     /// response that does not match an object close request.
-    pub fn close_object(&mut self, handle: ObjectHandle) -> Result<(), Channel::Error> {
+    pub fn close_object(&self, handle: ObjectHandle) -> Result<(), Channel::Error> {
         match self.request(BrokerOperation::CloseObject(handle))? {
             BrokerResult::ObjectClosed => Ok(()),
             BrokerResult::Error(error) => Err(BrokerLocalError::Broker(error)),
@@ -229,13 +230,14 @@ impl<Channel: LocalNotificationChannel> BrokerNotifications<Channel> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use core::cell::Cell;
+    use core::cell::{Cell, RefCell};
     use core::convert::Infallible;
     use litebox_broker_protocol::ObjectHandle;
     use litebox_broker_protocol::ProtocolVersion;
     use litebox_broker_protocol::channel::LocalNotificationChannel;
     use litebox_broker_protocol::message::ReadinessNotification;
     use litebox_broker_protocol::readiness::ReadinessFlags;
+    use std::sync::Mutex;
 
     #[test]
     fn negotiate_runs_setup_after_response_before_active_requests() {
@@ -249,9 +251,9 @@ mod tests {
         let local = BrokerLocal::negotiate(channel, |channel| {
             assert!(channel.sent_handshake_request.is_some());
             assert!(channel.handshake_response.is_none());
-            assert!(channel.sent_request.is_none());
+            assert!(channel.sent_request.borrow().is_none());
             setup_calls.set(setup_calls.get() + 1);
-            Ok(noop_shared_memory())
+            Ok((noop_shared_memory(), channel))
         })
         .unwrap();
 
@@ -270,15 +272,15 @@ mod tests {
         let request = BrokerOperation::CloseObject(handle);
         let response = BrokerResult::ObjectClosed;
         let channel = FakeControlChannel::new(None, Some(response.clone()));
-        let mut local = BrokerLocal {
+        let local = BrokerLocal {
             channel,
             shared_memory: noop_shared_memory(),
-            next_request_id: 0,
+            next_request_id: AtomicU64::new(0),
         };
 
         assert!(local.close_object(handle).is_ok());
         assert_eq!(
-            local.channel.sent_request,
+            local.channel.sent_request.borrow().clone(),
             Some(BrokerRequest {
                 request_id: RequestId(0),
                 operation: request,
@@ -290,35 +292,74 @@ mod tests {
     fn active_requests_use_monotonic_identifiers() {
         let handle = ObjectHandle(7);
         let channel = FakeControlChannel::new(None, Some(BrokerResult::ObjectClosed));
-        let mut local = BrokerLocal {
+        let local = BrokerLocal {
             channel,
             shared_memory: noop_shared_memory(),
-            next_request_id: 0,
+            next_request_id: AtomicU64::new(0),
         };
 
         local.close_object(handle).unwrap();
         assert_eq!(
-            local.channel.sent_request.as_ref().unwrap().request_id,
+            local
+                .channel
+                .sent_request
+                .borrow()
+                .as_ref()
+                .unwrap()
+                .request_id,
             RequestId(0)
         );
 
-        local.channel.response = Some(BrokerResult::ObjectClosed);
+        *local.channel.response.borrow_mut() = Some(BrokerResult::ObjectClosed);
         local.close_object(handle).unwrap();
         assert_eq!(
-            local.channel.sent_request.as_ref().unwrap().request_id,
+            local
+                .channel
+                .sent_request
+                .borrow()
+                .as_ref()
+                .unwrap()
+                .request_id,
             RequestId(1)
+        );
+    }
+
+    #[test]
+    fn concurrent_active_requests_use_distinct_identifiers() {
+        let local = Arc::new(BrokerLocal {
+            channel: ConcurrentCallChannel {
+                request_ids: Mutex::new(std::vec::Vec::new()),
+            },
+            shared_memory: noop_shared_memory(),
+            next_request_id: AtomicU64::new(0),
+        });
+        let callers = (0..16)
+            .map(|handle| {
+                let local = Arc::clone(&local);
+                std::thread::spawn(move || local.close_object(ObjectHandle(handle)))
+            })
+            .collect::<std::vec::Vec<_>>();
+
+        for caller in callers {
+            caller.join().unwrap().unwrap();
+        }
+        let mut request_ids = local.channel.request_ids.lock().unwrap().clone();
+        request_ids.sort();
+        assert_eq!(
+            request_ids,
+            (0..16).map(RequestId).collect::<std::vec::Vec<_>>()
         );
     }
 
     #[test]
     fn active_request_rejects_mismatched_response_identifier() {
         let channel = FakeControlChannel::new(None, Some(BrokerResult::ObjectClosed));
-        let mut local = BrokerLocal {
+        let local = BrokerLocal {
             channel,
             shared_memory: noop_shared_memory(),
-            next_request_id: 0,
+            next_request_id: AtomicU64::new(0),
         };
-        local.channel.response_id = Some(RequestId(9));
+        local.channel.response_id.set(Some(RequestId(9)));
 
         assert!(matches!(
             local.close_object(ObjectHandle(7)),
@@ -332,27 +373,27 @@ mod tests {
     #[test]
     fn active_request_identifier_exhaustion_does_not_wrap() {
         let channel = FakeControlChannel::new(None, Some(BrokerResult::ObjectClosed));
-        let mut local = BrokerLocal {
+        let local = BrokerLocal {
             channel,
             shared_memory: noop_shared_memory(),
-            next_request_id: u64::MAX,
+            next_request_id: AtomicU64::new(u64::MAX),
         };
 
         assert!(matches!(
             local.close_object(ObjectHandle(7)),
             Err(BrokerLocalError::RequestIdExhausted)
         ));
-        assert!(local.channel.sent_request.is_none());
+        assert!(local.channel.sent_request.borrow().is_none());
     }
 
     #[test]
     fn active_request_returns_recoverable_broker_error() {
         let channel =
             FakeControlChannel::new(None, Some(BrokerResult::Error(ErrorCode::WouldBlock)));
-        let mut local = BrokerLocal {
+        let local = BrokerLocal {
             channel,
             shared_memory: noop_shared_memory(),
-            next_request_id: 0,
+            next_request_id: AtomicU64::new(0),
         };
 
         assert!(matches!(
@@ -365,10 +406,10 @@ mod tests {
     #[should_panic(expected = "broker returned unrecoverable error")]
     fn active_request_panics_on_unrecoverable_broker_error() {
         let channel = FakeControlChannel::new(None, Some(BrokerResult::Error(ErrorCode::Internal)));
-        let mut local = BrokerLocal {
+        let local = BrokerLocal {
             channel,
             shared_memory: noop_shared_memory(),
-            next_request_id: 0,
+            next_request_id: AtomicU64::new(0),
         };
 
         let _ = local.create_event_with_count(0);
@@ -386,9 +427,9 @@ mod tests {
         let setup_called = Cell::new(false);
 
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            let _ = BrokerLocal::negotiate(channel, |_| {
+            let _ = BrokerLocal::negotiate(channel, |channel| {
                 setup_called.set(true);
-                Ok(noop_shared_memory())
+                Ok((noop_shared_memory(), channel))
             });
         }));
         assert_panic_contains(result, "broker returned unexpected negotiation response");
@@ -421,9 +462,9 @@ mod tests {
 
         let setup_called = Cell::new(false);
         assert!(matches!(
-            BrokerLocal::negotiate(channel, |_| {
+            BrokerLocal::negotiate(channel, |channel| {
                 setup_called.set(true);
-                Ok(noop_shared_memory())
+                Ok((noop_shared_memory(), channel))
             }),
             Err(BrokerLocalError::Broker(ErrorCode::UnsupportedVersion))
         ));
@@ -439,9 +480,9 @@ mod tests {
         let setup_called = Cell::new(false);
 
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            let _ = BrokerLocal::negotiate(channel, |_| {
+            let _ = BrokerLocal::negotiate(channel, |channel| {
                 setup_called.set(true);
-                Ok(noop_shared_memory())
+                Ok((noop_shared_memory(), channel))
             });
         }));
         assert_panic_contains(result, "broker returned unrecoverable error");
@@ -458,7 +499,9 @@ mod tests {
         );
 
         assert!(matches!(
-            BrokerLocal::negotiate(channel, |_| Err(FakeChannelError::SharedMemoryReceive)),
+            BrokerLocal::<FakeControlChannel>::negotiate(channel, |_| {
+                Err(FakeChannelError::SharedMemoryReceive)
+            }),
             Err(BrokerLocalError::Channel(
                 FakeChannelError::SharedMemoryReceive
             ))
@@ -475,10 +518,13 @@ mod tests {
             None,
         );
 
-        let _ = BrokerLocal::negotiate(channel, |_| {
-            Ok(Arc::new(NoopSharedMemory {
-                length: PIPE_TRANSFER_BUFFER_SIZE - 1,
-            }) as Arc<dyn SharedMemory>)
+        let _ = BrokerLocal::negotiate(channel, |channel| {
+            Ok((
+                Arc::new(NoopSharedMemory {
+                    length: PIPE_TRANSFER_BUFFER_SIZE - 1,
+                }) as Arc<dyn SharedMemory>,
+                channel,
+            ))
         });
     }
 
@@ -499,10 +545,10 @@ mod tests {
 
     struct FakeControlChannel {
         sent_handshake_request: Option<BrokerHandshakeRequest>,
-        sent_request: Option<BrokerRequest>,
+        sent_request: RefCell<Option<BrokerRequest>>,
         handshake_response: Option<BrokerHandshakeResponse>,
-        response: Option<BrokerResult>,
-        response_id: Option<RequestId>,
+        response: RefCell<Option<BrokerResult>>,
+        response_id: Cell<Option<RequestId>>,
     }
 
     #[derive(Debug, PartialEq, Eq)]
@@ -552,15 +598,15 @@ mod tests {
         ) -> Self {
             Self {
                 sent_handshake_request: None,
-                sent_request: None,
+                sent_request: RefCell::new(None),
                 handshake_response,
-                response,
-                response_id: None,
+                response: RefCell::new(response),
+                response_id: Cell::new(None),
             }
         }
     }
 
-    impl LocalControlChannel for FakeControlChannel {
+    impl LocalSetupChannel for FakeControlChannel {
         type Error = FakeChannelError;
 
         fn send_handshake_request(
@@ -576,30 +622,63 @@ mod tests {
         ) -> core::result::Result<Option<BrokerHandshakeResponse>, Self::Error> {
             Ok(self.handshake_response.take())
         }
+    }
 
-        fn send_request(
-            &mut self,
-            request: &BrokerRequest,
-        ) -> core::result::Result<(), Self::Error> {
-            self.sent_request = Some(request.clone());
-            Ok(())
-        }
+    impl LocalCallChannel for FakeControlChannel {
+        type Error = FakeChannelError;
 
-        fn recv_response(&mut self) -> core::result::Result<Option<BrokerResponse>, Self::Error> {
-            Ok(self.response.take().map(|result| BrokerResponse {
-                request_id: self.response_id.unwrap_or_else(|| {
+        fn call(
+            &self,
+            request: BrokerRequest,
+        ) -> core::result::Result<BrokerResponse, Self::Error> {
+            *self.sent_request.borrow_mut() = Some(request);
+            let result = self
+                .response
+                .borrow_mut()
+                .take()
+                .expect("response requires a scripted result");
+            Ok(BrokerResponse {
+                request_id: self.response_id.get().unwrap_or_else(|| {
                     self.sent_request
+                        .borrow()
                         .as_ref()
                         .expect("response requires a sent request")
                         .request_id
                 }),
                 result,
-            }))
+            })
+        }
+
+        fn with_serialized_payload<T>(&self, transfer: impl FnOnce() -> T) -> T {
+            transfer()
         }
     }
 
     struct FakeNotificationChannel {
         notification: Option<BrokerNotification>,
+    }
+
+    struct ConcurrentCallChannel {
+        request_ids: Mutex<std::vec::Vec<RequestId>>,
+    }
+
+    impl LocalCallChannel for ConcurrentCallChannel {
+        type Error = Infallible;
+
+        fn call(
+            &self,
+            request: BrokerRequest,
+        ) -> core::result::Result<BrokerResponse, Self::Error> {
+            self.request_ids.lock().unwrap().push(request.request_id);
+            Ok(BrokerResponse {
+                request_id: request.request_id,
+                result: BrokerResult::ObjectClosed,
+            })
+        }
+
+        fn with_serialized_payload<T>(&self, transfer: impl FnOnce() -> T) -> T {
+            transfer()
+        }
     }
 
     impl LocalNotificationChannel for FakeNotificationChannel {

--- a/litebox_broker_local/src/pipe.rs
+++ b/litebox_broker_local/src/pipe.rs
@@ -4,7 +4,7 @@
 use alloc::vec::Vec;
 
 use litebox_broker_protocol::ObjectHandle;
-use litebox_broker_protocol::channel::LocalCallChannel;
+use litebox_broker_protocol::channel::LocalControlChannel;
 use litebox_broker_protocol::message::{BrokerOperation, BrokerResult, PipeRequest, PipeResponse};
 use litebox_broker_protocol::pipe::{
     CreatePipeRequest, CreatePipeResponse, PIPE_TRANSFER_BUFFER_SIZE, ReadPipeRequest,
@@ -13,7 +13,7 @@ use litebox_broker_protocol::pipe::{
 
 use crate::{BrokerLocal, BrokerLocalError, Result};
 
-impl<Channel: LocalCallChannel> BrokerLocal<Channel> {
+impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
     /// Creates a broker-owned byte pipe.
     ///
     /// # Panics
@@ -44,6 +44,7 @@ impl<Channel: LocalCallChannel> BrokerLocal<Channel> {
     pub fn read_pipe(&self, handle: ObjectHandle, length: u32) -> Result<Vec<u8>, Channel::Error> {
         self.channel
             .with_serialized_payload(|| self.read_pipe_serialized(handle, length))
+            .map_err(BrokerLocalError::Channel)?
     }
 
     fn read_pipe_serialized(
@@ -86,6 +87,7 @@ impl<Channel: LocalCallChannel> BrokerLocal<Channel> {
     pub fn write_pipe(&self, handle: ObjectHandle, data: &[u8]) -> Result<usize, Channel::Error> {
         self.channel
             .with_serialized_payload(|| self.write_pipe_serialized(handle, data))
+            .map_err(BrokerLocalError::Channel)?
     }
 
     fn write_pipe_serialized(
@@ -141,7 +143,7 @@ mod tests {
     use std::sync::Mutex;
 
     use litebox_broker_protocol::BROKER_PROTOCOL_VERSION;
-    use litebox_broker_protocol::channel::{LocalCallChannel, LocalSetupChannel};
+    use litebox_broker_protocol::channel::LocalControlChannel;
     use litebox_broker_protocol::message::{
         BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerOperation, BrokerRequest,
         BrokerResponse, BrokerResult,
@@ -162,8 +164,7 @@ mod tests {
             BrokerResult::Pipe(PipeResponse::Write(WritePipeResponse { written: 2 })),
             BrokerResult::Pipe(PipeResponse::Read(ReadPipeResponse { read: 2 })),
         ]);
-        let local =
-            BrokerLocal::negotiate(channel, |channel| Ok((memory.clone(), channel))).unwrap();
+        let local = BrokerLocal::negotiate(channel, |_| Ok(memory.clone())).unwrap();
 
         local.create_pipe(64, 16).unwrap();
         assert_eq!(local.write_pipe(write_handle, &[1, 2, 3]).unwrap(), 2);
@@ -196,7 +197,7 @@ mod tests {
     fn pipe_rejects_oversized_transfers_before_request() {
         let memory = Arc::new(TestSharedMemory::new(PIPE_TRANSFER_BUFFER_SIZE));
         let channel = ScriptedChannel::new([]);
-        let local = BrokerLocal::negotiate(channel, |channel| Ok((memory, channel))).unwrap();
+        let local = BrokerLocal::negotiate(channel, |_| Ok(memory)).unwrap();
         let oversized_length = PIPE_TRANSFER_BUFFER_SIZE + 1;
 
         assert!(matches!(
@@ -222,7 +223,7 @@ mod tests {
                 read: 2,
             }))]);
         let memory = Arc::new(TestSharedMemory::new(PIPE_TRANSFER_BUFFER_SIZE));
-        let local = BrokerLocal::negotiate(channel, |channel| Ok((memory, channel))).unwrap();
+        let local = BrokerLocal::negotiate(channel, |_| Ok(memory)).unwrap();
 
         let _ = local.read_pipe(ObjectHandle(1), 1);
     }
@@ -235,7 +236,7 @@ mod tests {
                 written: 2,
             }))]);
         let memory = Arc::new(TestSharedMemory::new(PIPE_TRANSFER_BUFFER_SIZE));
-        let local = BrokerLocal::negotiate(channel, |channel| Ok((memory, channel))).unwrap();
+        let local = BrokerLocal::negotiate(channel, |_| Ok(memory)).unwrap();
 
         let _ = local.write_pipe(ObjectHandle(1), &[0]);
     }
@@ -301,7 +302,7 @@ mod tests {
         }
     }
 
-    impl LocalSetupChannel for ScriptedChannel {
+    impl LocalControlChannel for ScriptedChannel {
         type Error = Infallible;
 
         fn send_handshake_request(
@@ -319,11 +320,6 @@ mod tests {
                 broker_protocol_version: BROKER_PROTOCOL_VERSION,
             }))
         }
-    }
-
-    impl LocalCallChannel for ScriptedChannel {
-        type Error = Infallible;
-
         fn call(
             &self,
             request: BrokerRequest,
@@ -339,8 +335,11 @@ mod tests {
             })
         }
 
-        fn with_serialized_payload<T>(&self, transfer: impl FnOnce() -> T) -> T {
-            transfer()
+        fn with_serialized_payload<T>(
+            &self,
+            transfer: impl FnOnce() -> T,
+        ) -> core::result::Result<T, Self::Error> {
+            Ok(transfer())
         }
     }
 }

--- a/litebox_broker_local/src/pipe.rs
+++ b/litebox_broker_local/src/pipe.rs
@@ -4,7 +4,7 @@
 use alloc::vec::Vec;
 
 use litebox_broker_protocol::ObjectHandle;
-use litebox_broker_protocol::channel::LocalControlChannel;
+use litebox_broker_protocol::channel::LocalCallChannel;
 use litebox_broker_protocol::message::{BrokerOperation, BrokerResult, PipeRequest, PipeResponse};
 use litebox_broker_protocol::pipe::{
     CreatePipeRequest, CreatePipeResponse, PIPE_TRANSFER_BUFFER_SIZE, ReadPipeRequest,
@@ -13,7 +13,7 @@ use litebox_broker_protocol::pipe::{
 
 use crate::{BrokerLocal, BrokerLocalError, Result};
 
-impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
+impl<Channel: LocalCallChannel> BrokerLocal<Channel> {
     /// Creates a broker-owned byte pipe.
     ///
     /// # Panics
@@ -21,7 +21,7 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
     /// Panics if the broker reports an unrecoverable error or returns a
     /// response that does not match the issued pipe request.
     pub fn create_pipe(
-        &mut self,
+        &self,
         capacity: u64,
         atomic_write_size: u64,
     ) -> Result<CreatePipeResponse, Channel::Error> {
@@ -41,8 +41,13 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
     ///
     /// Panics if the broker reports an unrecoverable error or returns a
     /// response that does not match the issued pipe request.
-    pub fn read_pipe(
-        &mut self,
+    pub fn read_pipe(&self, handle: ObjectHandle, length: u32) -> Result<Vec<u8>, Channel::Error> {
+        self.channel
+            .with_serialized_payload(|| self.read_pipe_serialized(handle, length))
+    }
+
+    fn read_pipe_serialized(
+        &self,
         handle: ObjectHandle,
         length: u32,
     ) -> Result<Vec<u8>, Channel::Error> {
@@ -78,8 +83,13 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
     ///
     /// Panics if the broker reports an unrecoverable error or returns a
     /// response that does not match the issued pipe request.
-    pub fn write_pipe(
-        &mut self,
+    pub fn write_pipe(&self, handle: ObjectHandle, data: &[u8]) -> Result<usize, Channel::Error> {
+        self.channel
+            .with_serialized_payload(|| self.write_pipe_serialized(handle, data))
+    }
+
+    fn write_pipe_serialized(
+        &self,
         handle: ObjectHandle,
         data: &[u8],
     ) -> Result<usize, Channel::Error> {
@@ -109,7 +119,7 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
         Ok(written)
     }
 
-    fn request_pipe(&mut self, request: PipeRequest) -> Result<PipeResponse, Channel::Error> {
+    fn request_pipe(&self, request: PipeRequest) -> Result<PipeResponse, Channel::Error> {
         match self.request(BrokerOperation::Pipe(request))? {
             BrokerResult::Pipe(response) => Ok(response),
             BrokerResult::Error(error) => Err(BrokerLocalError::Broker(error)),
@@ -126,18 +136,18 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
 mod tests {
     use super::*;
     use alloc::sync::Arc;
-    use core::convert::Infallible;
+    use core::{cell::RefCell, convert::Infallible};
     use std::collections::VecDeque;
     use std::sync::Mutex;
 
-    use litebox_broker_protocol::channel::LocalControlChannel;
+    use litebox_broker_protocol::BROKER_PROTOCOL_VERSION;
+    use litebox_broker_protocol::channel::{LocalCallChannel, LocalSetupChannel};
     use litebox_broker_protocol::message::{
         BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerOperation, BrokerRequest,
         BrokerResponse, BrokerResult,
     };
     use litebox_broker_protocol::pipe::{ReadPipeResponse, WritePipeResponse};
     use litebox_broker_protocol::shared_memory::{SharedMemory, SharedMemoryError};
-    use litebox_broker_protocol::{BROKER_PROTOCOL_VERSION, RequestId};
 
     #[test]
     fn pipe_uses_attached_shared_memory_for_data_operations() {
@@ -152,7 +162,8 @@ mod tests {
             BrokerResult::Pipe(PipeResponse::Write(WritePipeResponse { written: 2 })),
             BrokerResult::Pipe(PipeResponse::Read(ReadPipeResponse { read: 2 })),
         ]);
-        let mut local = BrokerLocal::negotiate(channel, |_| Ok(memory.clone())).unwrap();
+        let local =
+            BrokerLocal::negotiate(channel, |channel| Ok((memory.clone(), channel))).unwrap();
 
         local.create_pipe(64, 16).unwrap();
         assert_eq!(local.write_pipe(write_handle, &[1, 2, 3]).unwrap(), 2);
@@ -163,8 +174,8 @@ mod tests {
         memory.write(0, &[4, 5, 6]).unwrap();
         assert_eq!(local.read_pipe(read_handle, 3).unwrap(), [4, 5]);
         assert_eq!(
-            local.channel.sent_operations,
-            [
+            local.channel.sent_operations.borrow().as_slice(),
+            &[
                 BrokerOperation::Pipe(PipeRequest::Create(CreatePipeRequest {
                     capacity: 64,
                     atomic_write_size: 16,
@@ -185,7 +196,7 @@ mod tests {
     fn pipe_rejects_oversized_transfers_before_request() {
         let memory = Arc::new(TestSharedMemory::new(PIPE_TRANSFER_BUFFER_SIZE));
         let channel = ScriptedChannel::new([]);
-        let mut local = BrokerLocal::negotiate(channel, |_| Ok(memory)).unwrap();
+        let local = BrokerLocal::negotiate(channel, |channel| Ok((memory, channel))).unwrap();
         let oversized_length = PIPE_TRANSFER_BUFFER_SIZE + 1;
 
         assert!(matches!(
@@ -200,7 +211,7 @@ mod tests {
                 litebox_broker_protocol::error::ErrorCode::ResourceExhausted
             ))
         ));
-        assert!(local.channel.sent_operations.is_empty());
+        assert!(local.channel.sent_operations.borrow().is_empty());
     }
 
     #[test]
@@ -211,7 +222,7 @@ mod tests {
                 read: 2,
             }))]);
         let memory = Arc::new(TestSharedMemory::new(PIPE_TRANSFER_BUFFER_SIZE));
-        let mut local = BrokerLocal::negotiate(channel, |_| Ok(memory)).unwrap();
+        let local = BrokerLocal::negotiate(channel, |channel| Ok((memory, channel))).unwrap();
 
         let _ = local.read_pipe(ObjectHandle(1), 1);
     }
@@ -224,7 +235,7 @@ mod tests {
                 written: 2,
             }))]);
         let memory = Arc::new(TestSharedMemory::new(PIPE_TRANSFER_BUFFER_SIZE));
-        let mut local = BrokerLocal::negotiate(channel, |_| Ok(memory)).unwrap();
+        let local = BrokerLocal::negotiate(channel, |channel| Ok((memory, channel))).unwrap();
 
         let _ = local.write_pipe(ObjectHandle(1), &[0]);
     }
@@ -277,22 +288,20 @@ mod tests {
     }
 
     struct ScriptedChannel {
-        results: VecDeque<BrokerResult>,
-        sent_operations: Vec<BrokerOperation>,
-        last_request_id: Option<RequestId>,
+        results: RefCell<VecDeque<BrokerResult>>,
+        sent_operations: RefCell<Vec<BrokerOperation>>,
     }
 
     impl ScriptedChannel {
         fn new(results: impl IntoIterator<Item = BrokerResult>) -> Self {
             Self {
-                results: results.into_iter().collect(),
-                sent_operations: Vec::new(),
-                last_request_id: None,
+                results: RefCell::new(results.into_iter().collect()),
+                sent_operations: RefCell::new(Vec::new()),
             }
         }
     }
 
-    impl LocalControlChannel for ScriptedChannel {
+    impl LocalSetupChannel for ScriptedChannel {
         type Error = Infallible;
 
         fn send_handshake_request(
@@ -310,23 +319,28 @@ mod tests {
                 broker_protocol_version: BROKER_PROTOCOL_VERSION,
             }))
         }
+    }
 
-        fn send_request(
-            &mut self,
-            request: &BrokerRequest,
-        ) -> core::result::Result<(), Self::Error> {
-            self.sent_operations.push(request.operation.clone());
-            self.last_request_id = Some(request.request_id);
-            Ok(())
+    impl LocalCallChannel for ScriptedChannel {
+        type Error = Infallible;
+
+        fn call(
+            &self,
+            request: BrokerRequest,
+        ) -> core::result::Result<BrokerResponse, Self::Error> {
+            self.sent_operations.borrow_mut().push(request.operation);
+            Ok(BrokerResponse {
+                request_id: request.request_id,
+                result: self
+                    .results
+                    .borrow_mut()
+                    .pop_front()
+                    .expect("response requires a scripted result"),
+            })
         }
 
-        fn recv_response(&mut self) -> core::result::Result<Option<BrokerResponse>, Self::Error> {
-            Ok(self.results.pop_front().map(|result| BrokerResponse {
-                request_id: self
-                    .last_request_id
-                    .expect("response requires a sent request"),
-                result,
-            }))
+        fn with_serialized_payload<T>(&self, transfer: impl FnOnce() -> T) -> T {
+            transfer()
         }
     }
 }

--- a/litebox_broker_protocol/src/channel.rs
+++ b/litebox_broker_protocol/src/channel.rs
@@ -37,8 +37,8 @@ pub enum HostReceive<T> {
     PeerClosed,
 }
 
-/// Local-side sequential channel for broker association setup.
-pub trait LocalSetupChannel {
+/// Local-side control channel for broker association setup and active calls.
+pub trait LocalControlChannel {
     /// Channel-specific error type.
     type Error;
 
@@ -53,12 +53,6 @@ pub trait LocalSetupChannel {
     /// Returns `Ok(None)` when the broker closed the channel cleanly before
     /// starting another response frame.
     fn recv_handshake_response(&mut self) -> Result<Option<BrokerHandshakeResponse>, Self::Error>;
-}
-
-/// Local-side shared channel for active broker calls.
-pub trait LocalCallChannel {
-    /// Channel-specific error type.
-    type Error;
 
     /// Publishes one request and waits for its correlated response.
     fn call(&self, request: BrokerRequest) -> Result<BrokerResponse, Self::Error>;
@@ -67,7 +61,7 @@ pub trait LocalCallChannel {
     ///
     /// The closure must run exactly once while no other payload transfer using
     /// the same association shared memory is active.
-    fn with_serialized_payload<T>(&self, transfer: impl FnOnce() -> T) -> T;
+    fn with_serialized_payload<T>(&self, transfer: impl FnOnce() -> T) -> Result<T, Self::Error>;
 }
 
 /// Host-side control channel for broker authority calls.

--- a/litebox_broker_protocol/src/channel.rs
+++ b/litebox_broker_protocol/src/channel.rs
@@ -55,6 +55,11 @@ pub trait LocalControlChannel {
     fn recv_handshake_response(&mut self) -> Result<Option<BrokerHandshakeResponse>, Self::Error>;
 
     /// Publishes one request and waits for its correlated response.
+    ///
+    /// Calls may execute concurrently, and each pending request must have a
+    /// distinct identifier. If a valid active call returns a channel error, the
+    /// association is considered failed: every concurrent or future call must
+    /// return an error rather than remain blocked.
     fn call(&self, request: BrokerRequest) -> Result<BrokerResponse, Self::Error>;
 
     /// Serializes one complete shared-memory payload transfer.

--- a/litebox_broker_protocol/src/channel.rs
+++ b/litebox_broker_protocol/src/channel.rs
@@ -37,8 +37,8 @@ pub enum HostReceive<T> {
     PeerClosed,
 }
 
-/// Local-side control channel for broker authority calls.
-pub trait LocalControlChannel {
+/// Local-side sequential channel for broker association setup.
+pub trait LocalSetupChannel {
     /// Channel-specific error type.
     type Error;
 
@@ -53,15 +53,21 @@ pub trait LocalControlChannel {
     /// Returns `Ok(None)` when the broker closed the channel cleanly before
     /// starting another response frame.
     fn recv_handshake_response(&mut self) -> Result<Option<BrokerHandshakeResponse>, Self::Error>;
+}
 
-    /// Sends one active broker request.
-    fn send_request(&mut self, request: &BrokerRequest) -> Result<(), Self::Error>;
+/// Local-side shared channel for active broker calls.
+pub trait LocalCallChannel {
+    /// Channel-specific error type.
+    type Error;
 
-    /// Receives one active broker response.
+    /// Publishes one request and waits for its correlated response.
+    fn call(&self, request: BrokerRequest) -> Result<BrokerResponse, Self::Error>;
+
+    /// Serializes one complete shared-memory payload transfer.
     ///
-    /// Returns `Ok(None)` when the broker closed the channel cleanly before
-    /// starting another response frame.
-    fn recv_response(&mut self) -> Result<Option<BrokerResponse>, Self::Error>;
+    /// The closure must run exactly once while no other payload transfer using
+    /// the same association shared memory is active.
+    fn with_serialized_payload<T>(&self, transfer: impl FnOnce() -> T) -> T;
 }
 
 /// Host-side control channel for broker authority calls.

--- a/litebox_broker_transport/src/unix_socket.rs
+++ b/litebox_broker_transport/src/unix_socket.rs
@@ -386,7 +386,7 @@ impl LocalControlChannel for UnixStreamLocalControlChannel {
             );
         }
 
-        active.pending_calls.wait(pending_call)
+        pending_call.wait()
     }
 
     fn with_serialized_payload<T>(&self, transfer: impl FnOnce() -> T) -> IoResult<T> {
@@ -476,19 +476,56 @@ struct PendingCalls {
 }
 
 struct PendingCallState {
-    calls: HashMap<RequestId, PendingCall>,
+    calls: HashMap<RequestId, Arc<PendingCall>>,
     failure: Option<Arc<Error>>,
 }
 
 struct PendingCall {
-    response: Option<BrokerResponse>,
-    response_ready: Arc<Condvar>,
+    result: Mutex<Option<PendingCallResult>>,
+    result_ready: Condvar,
 }
 
-#[derive(Debug)]
-struct PendingCallWaiter {
-    request_id: RequestId,
-    response_ready: Arc<Condvar>,
+enum PendingCallResult {
+    Response(BrokerResponse),
+    Failure(Arc<Error>),
+}
+
+impl PendingCall {
+    fn new() -> Self {
+        Self {
+            result: Mutex::new(None),
+            result_ready: Condvar::new(),
+        }
+    }
+
+    fn resolve(&self, result: PendingCallResult) {
+        let mut stored = self
+            .result
+            .lock()
+            .expect("broker pending-call result mutex poisoned");
+        assert!(stored.is_none(), "broker pending call already resolved");
+        *stored = Some(result);
+        self.result_ready.notify_one();
+    }
+
+    fn wait(&self) -> IoResult<BrokerResponse> {
+        let mut result = self
+            .result
+            .lock()
+            .expect("broker pending-call result mutex poisoned");
+        loop {
+            if let Some(result) = result.take() {
+                return match result {
+                    PendingCallResult::Response(response) => Ok(response),
+                    PendingCallResult::Failure(error) => Err(copy_io_error(&error)),
+                };
+            }
+            result = self
+                .result_ready
+                .wait(result)
+                .expect("broker pending-call result mutex poisoned");
+        }
+    }
 }
 
 impl PendingCalls {
@@ -502,7 +539,7 @@ impl PendingCalls {
         }
     }
 
-    fn register(&self, request_id: RequestId) -> IoResult<PendingCallWaiter> {
+    fn register(&self, request_id: RequestId) -> IoResult<Arc<PendingCall>> {
         let mut state = self.state.lock().expect("broker pending mutex poisoned");
         while state.calls.len() == MAX_PENDING_CALLS && state.failure.is_none() {
             state = self
@@ -513,73 +550,52 @@ impl PendingCalls {
         if let Some(error) = state.failure.as_ref() {
             return Err(copy_io_error(error));
         }
-        let response_ready = Arc::new(Condvar::new());
+        let pending_call = Arc::new(PendingCall::new());
         match state.calls.entry(request_id) {
             std::collections::hash_map::Entry::Vacant(entry) => {
-                entry.insert(PendingCall {
-                    response: None,
-                    response_ready: Arc::clone(&response_ready),
-                });
+                entry.insert(Arc::clone(&pending_call));
             }
             std::collections::hash_map::Entry::Occupied(_) => {
                 return Err(invalid_data("duplicate broker request ID"));
             }
         }
-        Ok(PendingCallWaiter {
-            request_id,
-            response_ready,
-        })
+        Ok(pending_call)
     }
 
     fn complete(&self, response: BrokerResponse) -> IoResult<()> {
-        let mut state = self.state.lock().expect("broker pending mutex poisoned");
-        if let Some(error) = state.failure.as_ref() {
-            return Err(copy_io_error(error));
-        }
-        let Some(call) = state.calls.get_mut(&response.request_id) else {
-            return Err(invalid_data("broker returned an unknown response ID"));
+        let pending_call = {
+            let mut state = self.state.lock().expect("broker pending mutex poisoned");
+            if let Some(error) = state.failure.as_ref() {
+                return Err(copy_io_error(error));
+            }
+            let Some(pending_call) = state.calls.remove(&response.request_id) else {
+                return Err(invalid_data("broker returned an unknown response ID"));
+            };
+            self.capacity_available.notify_one();
+            pending_call
         };
-        if call.response.is_some() {
-            return Err(invalid_data("broker returned a duplicate response ID"));
-        }
-        call.response = Some(response);
-        call.response_ready.notify_one();
+        pending_call.resolve(PendingCallResult::Response(response));
         Ok(())
     }
 
-    fn wait(&self, pending_call: PendingCallWaiter) -> IoResult<BrokerResponse> {
-        let mut state = self.state.lock().expect("broker pending mutex poisoned");
-        loop {
-            let Some(call) = state.calls.get_mut(&pending_call.request_id) else {
-                unreachable!("pending broker call disappeared");
-            };
-            if let Some(response) = call.response.take() {
-                state.calls.remove(&pending_call.request_id);
-                self.capacity_available.notify_one();
-                return Ok(response);
-            }
-            if let Some(error) = state.failure.as_ref().map(Arc::clone) {
-                state.calls.remove(&pending_call.request_id);
-                self.capacity_available.notify_one();
-                return Err(copy_io_error(&error));
-            }
-            state = pending_call
-                .response_ready
-                .wait(state)
-                .expect("broker pending mutex poisoned");
-        }
-    }
-
     fn record_failure(&self, error: Arc<Error>) -> bool {
-        let mut state = self.state.lock().expect("broker pending mutex poisoned");
-        if state.failure.is_some() {
-            return false;
+        let pending_calls = {
+            let mut state = self.state.lock().expect("broker pending mutex poisoned");
+            if state.failure.is_some() {
+                return false;
+            }
+            state.failure = Some(Arc::clone(&error));
+            let pending_calls = state
+                .calls
+                .drain()
+                .map(|(_, call)| call)
+                .collect::<Vec<_>>();
+            self.capacity_available.notify_all();
+            pending_calls
+        };
+        for pending_call in pending_calls {
+            pending_call.resolve(PendingCallResult::Failure(Arc::clone(&error)));
         }
-        state.failure = Some(error);
-        for call in state.calls.values() {
-            call.response_ready.notify_one();
-        }
-        self.capacity_available.notify_all();
         true
     }
 
@@ -1303,14 +1319,18 @@ mod tests {
             "test failure",
         )));
 
-        assert_eq!(pending.wait(pending_call).unwrap().request_id, request_id);
+        assert_eq!(pending_call.wait().unwrap().request_id, request_id);
     }
 
     #[test]
-    fn duplicate_registration_preserves_the_original_call() {
+    fn duplicate_pending_registration_preserves_the_original_call() {
         let pending = PendingCalls::new();
         let request_id = RequestId(1);
         let pending_call = pending.register(request_id).unwrap();
+        assert_eq!(
+            pending.register(request_id).err().unwrap().kind(),
+            ErrorKind::InvalidData
+        );
         pending
             .complete(BrokerResponse {
                 request_id,
@@ -1318,11 +1338,7 @@ mod tests {
             })
             .unwrap();
 
-        assert_eq!(
-            pending.register(request_id).unwrap_err().kind(),
-            ErrorKind::InvalidData
-        );
-        assert_eq!(pending.wait(pending_call).unwrap().request_id, request_id);
+        assert_eq!(pending_call.wait().unwrap().request_id, request_id);
     }
 
     #[test]
@@ -1344,7 +1360,7 @@ mod tests {
                 .is_err()
         );
         assert_eq!(
-            pending.wait(pending_call).unwrap_err().kind(),
+            pending_call.wait().unwrap_err().kind(),
             ErrorKind::ConnectionAborted
         );
     }

--- a/litebox_broker_transport/src/unix_socket.rs
+++ b/litebox_broker_transport/src/unix_socket.rs
@@ -6,6 +6,11 @@
 //! This module deliberately uses `std` because Unix-domain sockets and `std::io`
 //! framing are hosted userland concerns. Portable broker interfaces live in the
 //! no_std protocol, local, core, and host crates.
+//!
+//! After setup, each caller thread registers its request and writes its complete
+//! frame while holding the shared writer mutex; there is no local request worker.
+//! One response-dispatcher thread exclusively reads responses, correlates them by
+//! request ID, and wakes the matching callers.
 
 use std::io::{Error, ErrorKind, Read, Result as IoResult, Write};
 use std::net::Shutdown;

--- a/litebox_broker_transport/src/unix_socket.rs
+++ b/litebox_broker_transport/src/unix_socket.rs
@@ -11,15 +11,18 @@ use std::io::{Error, ErrorKind, Read, Result as IoResult, Write};
 use std::net::Shutdown;
 use std::os::unix::net::UnixStream;
 use std::path::Path;
+use std::sync::{Arc, Condvar, Mutex};
 use std::time::Instant;
+use std::{collections::HashMap, thread};
 
 use crate::shared_memory::MemfdSharedMemory;
 use crate::unix_io::{
     refresh_read_deadline, refresh_write_deadline, with_read_deadline, with_write_deadline,
 };
+use litebox_broker_protocol::RequestId;
 use litebox_broker_protocol::channel::{
-    HostControlChannel, HostNotificationChannel, HostReceive, LocalControlChannel,
-    LocalNotificationChannel, PeerCredential,
+    HostControlChannel, HostNotificationChannel, HostReceive, LocalCallChannel,
+    LocalNotificationChannel, LocalSetupChannel, PeerCredential,
 };
 use litebox_broker_protocol::message::{
     BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerNotification, BrokerRequest,
@@ -32,6 +35,8 @@ use litebox_broker_protocol::wire::{
 };
 
 const MAX_FRAME_LEN: usize = 64 * 1024;
+/// Maximum number of active calls waiting for broker responses.
+pub const MAX_PENDING_CALLS: usize = 64;
 
 /// Validates that a connected Unix socket belongs to `expected_process_id`.
 pub fn validate_peer_process(stream: &UnixStream, expected_process_id: u32) -> IoResult<()> {
@@ -70,6 +75,17 @@ pub struct UnixStreamLocalControlChannel {
 /// Independently owned handle for interrupting local control-channel I/O.
 pub struct UnixStreamLocalControlCancellation {
     stream: UnixStream,
+    pending_calls: Arc<PendingCalls>,
+    association_failure: Arc<dyn Fn() + Send + Sync>,
+}
+
+/// Shared active-call channel backed by one Unix stream.
+pub struct UnixStreamLocalCallChannel {
+    request_stream: Mutex<UnixStream>,
+    shutdown_stream: UnixStream,
+    pending_calls: Arc<PendingCalls>,
+    payload_transfer: Mutex<()>,
+    association_failure: Arc<dyn Fn() + Send + Sync>,
 }
 
 impl UnixStreamLocalControlChannel {
@@ -101,13 +117,6 @@ impl UnixStreamLocalControlChannel {
         })
     }
 
-    /// Creates a handle that can interrupt pending control-channel I/O.
-    pub fn cancellation_handle(&self) -> IoResult<UnixStreamLocalControlCancellation> {
-        self.stream
-            .try_clone()
-            .map(|stream| UnixStreamLocalControlCancellation { stream })
-    }
-
     /// Receives the memfd associated with this control channel.
     pub fn receive_memfd(
         &mut self,
@@ -116,21 +125,88 @@ impl UnixStreamLocalControlChannel {
     ) -> IoResult<MemfdSharedMemory> {
         crate::shared_memory::receive_memfd(&mut self.stream, expected_len, deadline)
     }
+
+    /// Consumes the setup channel and starts the active response pump.
+    pub fn activate(
+        self,
+        association_failure: impl Fn() + Send + Sync + 'static,
+    ) -> IoResult<(
+        UnixStreamLocalCallChannel,
+        UnixStreamLocalControlCancellation,
+    )> {
+        if self.setup_deadline.is_some() {
+            return Err(invalid_data(
+                "broker control channel activated before setup completed",
+            ));
+        }
+
+        let response_stream = self.stream;
+        let request_stream = response_stream.try_clone()?;
+        let shutdown_stream = response_stream.try_clone()?;
+        let cancellation_stream = response_stream.try_clone()?;
+        let response_cancellation = response_stream.try_clone()?;
+        let pending_calls = Arc::new(PendingCalls::new());
+        let association_failure: Arc<dyn Fn() + Send + Sync> = Arc::new(association_failure);
+        let response_pending_calls = Arc::clone(&pending_calls);
+        let response_failure = Arc::clone(&association_failure);
+        thread::Builder::new()
+            .name("litebox-broker-responses".to_owned())
+            .spawn(move || {
+                response_pump(
+                    response_stream,
+                    response_cancellation,
+                    response_pending_calls,
+                    response_failure,
+                );
+            })?;
+
+        Ok((
+            UnixStreamLocalCallChannel {
+                request_stream: Mutex::new(request_stream),
+                shutdown_stream,
+                pending_calls: Arc::clone(&pending_calls),
+                payload_transfer: Mutex::new(()),
+                association_failure: Arc::clone(&association_failure),
+            },
+            UnixStreamLocalControlCancellation {
+                stream: cancellation_stream,
+                pending_calls,
+                association_failure: Arc::clone(&association_failure),
+            },
+        ))
+    }
 }
 
 impl UnixStreamLocalControlCancellation {
     /// Shuts down the control stream, unblocking pending reads or writes.
     pub fn cancel(&self) -> IoResult<()> {
-        match self.stream.shutdown(Shutdown::Both) {
-            Err(error) if error.kind() == ErrorKind::NotConnected => Ok(()),
-            result => result,
-        }
+        fail_active_channel(
+            &self.pending_calls,
+            &self.stream,
+            self.association_failure.as_ref(),
+            Error::new(ErrorKind::ConnectionAborted, "broker association cancelled"),
+        )
     }
 }
 
-impl Drop for UnixStreamLocalControlChannel {
+impl Drop for UnixStreamLocalCallChannel {
     fn drop(&mut self) {
-        let _ = self.stream.shutdown(Shutdown::Both);
+        let _ = fail_active_channel(
+            &self.pending_calls,
+            &self.shutdown_stream,
+            self.association_failure.as_ref(),
+            Error::new(
+                ErrorKind::ConnectionAborted,
+                "broker active channel dropped",
+            ),
+        );
+    }
+}
+
+fn shutdown(stream: &UnixStream) -> IoResult<()> {
+    match stream.shutdown(Shutdown::Both) {
+        Err(error) if error.kind() == ErrorKind::NotConnected => Ok(()),
+        result => result,
     }
 }
 
@@ -143,6 +219,11 @@ pub struct UnixStreamHostControlChannel {
 
 /// Local-side Unix-domain-socket notification channel for the hosted userland POC.
 pub struct UnixStreamLocalNotificationChannel {
+    stream: UnixStream,
+}
+
+/// Independently owned handle for interrupting local notification-channel I/O.
+pub struct UnixStreamLocalNotificationCancellation {
     stream: UnixStream,
 }
 
@@ -191,6 +272,26 @@ impl UnixStreamLocalNotificationChannel {
     pub fn connect(path: impl AsRef<Path>) -> IoResult<Self> {
         UnixStream::connect(path).map(Self::from_connected)
     }
+
+    /// Creates a handle that can interrupt pending notification-channel I/O.
+    pub fn cancellation_handle(&self) -> IoResult<UnixStreamLocalNotificationCancellation> {
+        self.stream
+            .try_clone()
+            .map(|stream| UnixStreamLocalNotificationCancellation { stream })
+    }
+}
+
+impl UnixStreamLocalNotificationCancellation {
+    /// Shuts down the notification stream, unblocking pending reads.
+    pub fn cancel(&self) -> IoResult<()> {
+        shutdown(&self.stream)
+    }
+}
+
+impl Drop for UnixStreamLocalNotificationChannel {
+    fn drop(&mut self) {
+        let _ = shutdown(&self.stream);
+    }
 }
 
 impl UnixStreamHostNotificationChannel {
@@ -200,7 +301,7 @@ impl UnixStreamHostNotificationChannel {
     }
 }
 
-impl LocalControlChannel for UnixStreamLocalControlChannel {
+impl LocalSetupChannel for UnixStreamLocalControlChannel {
     type Error = Error;
 
     fn send_handshake_request(&mut self, request: &BrokerHandshakeRequest) -> IoResult<()> {
@@ -218,17 +319,45 @@ impl LocalControlChannel for UnixStreamLocalControlChannel {
             None => Ok(None),
         }
     }
+}
 
-    fn send_request(&mut self, request: &BrokerRequest) -> IoResult<()> {
-        let frame = encode_request(request.clone());
-        write_frame_with_deadline(&mut self.stream, &frame, None)
+impl LocalCallChannel for UnixStreamLocalCallChannel {
+    type Error = Error;
+
+    fn call(&self, request: BrokerRequest) -> IoResult<BrokerResponse> {
+        let request_id = request.request_id;
+        self.pending_calls.register(request_id)?;
+
+        let write_result = {
+            let mut request_stream = self
+                .request_stream
+                .lock()
+                .expect("broker request writer mutex poisoned");
+            match self.pending_calls.failure() {
+                Some(error) => Err(copy_io_error(&error)),
+                None => {
+                    write_frame_with_deadline(&mut request_stream, &encode_request(request), None)
+                }
+            }
+        };
+        if let Err(error) = write_result {
+            let _ = fail_active_channel(
+                &self.pending_calls,
+                &self.shutdown_stream,
+                self.association_failure.as_ref(),
+                error,
+            );
+        }
+
+        self.pending_calls.wait(request_id)
     }
 
-    fn recv_response(&mut self) -> IoResult<Option<BrokerResponse>> {
-        match read_frame_with_deadline(&mut self.stream, None)? {
-            Some(frame) => decode_response(&frame).map(Some).map_err(wire_error),
-            None => Ok(None),
-        }
+    fn with_serialized_payload<T>(&self, transfer: impl FnOnce() -> T) -> T {
+        let _transfer = self
+            .payload_transfer
+            .lock()
+            .expect("broker payload-transfer mutex poisoned");
+        transfer()
     }
 }
 
@@ -298,6 +427,193 @@ impl HostNotificationChannel for UnixStreamHostNotificationChannel {
             &encode_notification(notification.clone()),
             None,
         )
+    }
+}
+
+struct PendingCalls {
+    state: Mutex<PendingCallState>,
+    changed: Condvar,
+}
+
+struct PendingCallState {
+    calls: HashMap<RequestId, PendingCall>,
+    failure: Option<Arc<Error>>,
+}
+
+enum PendingCall {
+    Submitted,
+    Completed(BrokerResponse),
+}
+
+impl PendingCalls {
+    fn new() -> Self {
+        Self {
+            state: Mutex::new(PendingCallState {
+                calls: HashMap::new(),
+                failure: None,
+            }),
+            changed: Condvar::new(),
+        }
+    }
+
+    fn register(&self, request_id: RequestId) -> IoResult<()> {
+        let mut state = self.state.lock().expect("broker pending mutex poisoned");
+        while state.calls.len() == MAX_PENDING_CALLS && state.failure.is_none() {
+            state = self
+                .changed
+                .wait(state)
+                .expect("broker pending mutex poisoned");
+        }
+        if let Some(error) = state.failure.as_ref() {
+            return Err(copy_io_error(error));
+        }
+        match state.calls.entry(request_id) {
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                entry.insert(PendingCall::Submitted);
+            }
+            std::collections::hash_map::Entry::Occupied(_) => {
+                return Err(invalid_data("duplicate broker request ID"));
+            }
+        }
+        Ok(())
+    }
+
+    fn complete(&self, response: BrokerResponse) -> IoResult<()> {
+        let mut state = self.state.lock().expect("broker pending mutex poisoned");
+        if let Some(error) = state.failure.as_ref() {
+            return Err(copy_io_error(error));
+        }
+        let Some(call) = state.calls.get_mut(&response.request_id) else {
+            return Err(invalid_data("broker returned an unknown response ID"));
+        };
+        match call {
+            PendingCall::Submitted => *call = PendingCall::Completed(response),
+            PendingCall::Completed(_) => {
+                return Err(invalid_data("broker returned a duplicate response ID"));
+            }
+        }
+        self.changed.notify_all();
+        Ok(())
+    }
+
+    fn wait(&self, request_id: RequestId) -> IoResult<BrokerResponse> {
+        let mut state = self.state.lock().expect("broker pending mutex poisoned");
+        loop {
+            if matches!(
+                state.calls.get(&request_id),
+                Some(PendingCall::Completed(_))
+            ) {
+                let Some(PendingCall::Completed(response)) = state.calls.remove(&request_id) else {
+                    unreachable!("completed broker call disappeared");
+                };
+                self.changed.notify_all();
+                return Ok(response);
+            }
+            if let Some(error) = state.failure.as_ref().map(Arc::clone) {
+                state.calls.remove(&request_id);
+                self.changed.notify_all();
+                return Err(copy_io_error(&error));
+            }
+            state = self
+                .changed
+                .wait(state)
+                .expect("broker pending mutex poisoned");
+        }
+    }
+
+    fn fail(&self, error: Arc<Error>) -> bool {
+        let mut state = self.state.lock().expect("broker pending mutex poisoned");
+        if state.failure.is_some() {
+            return false;
+        }
+        state.failure = Some(error);
+        self.changed.notify_all();
+        true
+    }
+
+    fn failure(&self) -> Option<Arc<Error>> {
+        self.state
+            .lock()
+            .expect("broker pending mutex poisoned")
+            .failure
+            .as_ref()
+            .map(Arc::clone)
+    }
+}
+
+fn response_pump(
+    mut response_stream: UnixStream,
+    response_cancellation: UnixStream,
+    pending_calls: Arc<PendingCalls>,
+    association_failure: Arc<dyn Fn() + Send + Sync>,
+) {
+    loop {
+        let response = match read_frame_with_deadline(&mut response_stream, None) {
+            Ok(Some(frame)) => match decode_response(&frame).map_err(wire_error) {
+                Ok(response) => response,
+                Err(error) => {
+                    let _ = fail_active_channel(
+                        &pending_calls,
+                        &response_cancellation,
+                        association_failure.as_ref(),
+                        error,
+                    );
+                    return;
+                }
+            },
+            Ok(None) => {
+                let _ = fail_active_channel(
+                    &pending_calls,
+                    &response_cancellation,
+                    association_failure.as_ref(),
+                    Error::new(
+                        ErrorKind::UnexpectedEof,
+                        "broker closed the active control channel",
+                    ),
+                );
+                return;
+            }
+            Err(error) => {
+                let _ = fail_active_channel(
+                    &pending_calls,
+                    &response_cancellation,
+                    association_failure.as_ref(),
+                    error,
+                );
+                return;
+            }
+        };
+
+        if let Err(error) = pending_calls.complete(response) {
+            let _ = fail_active_channel(
+                &pending_calls,
+                &response_cancellation,
+                association_failure.as_ref(),
+                error,
+            );
+            return;
+        }
+    }
+}
+
+fn fail_active_channel(
+    pending_calls: &PendingCalls,
+    shutdown_stream: &UnixStream,
+    association_failure: &(dyn Fn() + Send + Sync),
+    error: Error,
+) -> IoResult<()> {
+    let first_failure = pending_calls.fail(Arc::new(error));
+    let shutdown_result = shutdown(shutdown_stream);
+    if first_failure {
+        association_failure();
+    }
+    shutdown_result
+}
+
+fn copy_io_error(error: &Error) -> Error {
+    match error.raw_os_error() {
+        Some(code) => Error::from_raw_os_error(code),
+        None => Error::new(error.kind(), error.to_string()),
     }
 }
 
@@ -390,8 +706,11 @@ fn wire_error(error: WireError) -> Error {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use litebox_broker_protocol::RequestId;
-    use litebox_broker_protocol::message::{BrokerOperation, BrokerRequest};
+    use litebox_broker_protocol::message::{
+        BrokerOperation, BrokerRequest, BrokerResponse, BrokerResult,
+    };
+    use litebox_broker_protocol::{ObjectHandle, RequestId};
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Duration;
 
     #[test]
@@ -431,6 +750,293 @@ mod tests {
             read_frame_with_deadline(&mut reader, None)
                 .unwrap()
                 .is_none()
+        );
+    }
+
+    #[test]
+    fn active_channel_matches_out_of_order_responses() {
+        let (local_stream, mut host_stream) = UnixStream::pair().unwrap();
+        let (channel, _cancellation) = UnixStreamLocalControlChannel::from_connected(local_stream)
+            .activate(|| {})
+            .unwrap();
+        let channel = Arc::new(channel);
+
+        let first_channel = Arc::clone(&channel);
+        let first = thread::spawn(move || {
+            first_channel.call(BrokerRequest {
+                request_id: RequestId(3),
+                operation: BrokerOperation::CloseObject(ObjectHandle(3)),
+            })
+        });
+        let second_channel = Arc::clone(&channel);
+        let second = thread::spawn(move || {
+            second_channel.call(BrokerRequest {
+                request_id: RequestId(7),
+                operation: BrokerOperation::CloseObject(ObjectHandle(7)),
+            })
+        });
+
+        let first_request = decode_request(
+            &read_frame_with_deadline(&mut host_stream, None)
+                .unwrap()
+                .unwrap(),
+        )
+        .unwrap();
+        let second_request = decode_request(
+            &read_frame_with_deadline(&mut host_stream, None)
+                .unwrap()
+                .unwrap(),
+        )
+        .unwrap();
+        let mut request_ids = [first_request.request_id, second_request.request_id];
+        request_ids.sort();
+        assert_eq!(request_ids, [RequestId(3), RequestId(7)]);
+
+        write_frame_with_deadline(
+            &mut host_stream,
+            &encode_response(BrokerResponse {
+                request_id: second_request.request_id,
+                result: BrokerResult::ObjectClosed,
+            }),
+            None,
+        )
+        .unwrap();
+        write_frame_with_deadline(
+            &mut host_stream,
+            &encode_response(BrokerResponse {
+                request_id: first_request.request_id,
+                result: BrokerResult::ObjectClosed,
+            }),
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(first.join().unwrap().unwrap().request_id, RequestId(3));
+        assert_eq!(second.join().unwrap().unwrap().request_id, RequestId(7));
+    }
+
+    #[test]
+    fn active_channel_serializes_shared_payload_transfers() {
+        let (local_stream, _host_stream) = UnixStream::pair().unwrap();
+        let (channel, _cancellation) = UnixStreamLocalControlChannel::from_connected(local_stream)
+            .activate(|| {})
+            .unwrap();
+        let channel = Arc::new(channel);
+        let active_transfers = Arc::new(AtomicUsize::new(0));
+        let callers = (0..2)
+            .map(|_| {
+                let channel = Arc::clone(&channel);
+                let active_transfers = Arc::clone(&active_transfers);
+                thread::spawn(move || {
+                    channel.with_serialized_payload(|| {
+                        assert_eq!(active_transfers.fetch_add(1, Ordering::SeqCst), 0);
+                        thread::sleep(Duration::from_millis(20));
+                        assert_eq!(active_transfers.fetch_sub(1, Ordering::SeqCst), 1);
+                    });
+                })
+            })
+            .collect::<Vec<_>>();
+
+        for caller in callers {
+            caller.join().unwrap();
+        }
+    }
+
+    #[test]
+    fn active_channel_bounds_pending_calls_before_publication() {
+        let (local_stream, mut host_stream) = UnixStream::pair().unwrap();
+        host_stream
+            .set_read_timeout(Some(Duration::from_secs(2)))
+            .unwrap();
+        let (channel, cancellation) = UnixStreamLocalControlChannel::from_connected(local_stream)
+            .activate(|| {})
+            .unwrap();
+        let channel = Arc::new(channel);
+        let callers = (0..=MAX_PENDING_CALLS)
+            .map(|request_id| {
+                let channel = Arc::clone(&channel);
+                thread::spawn(move || {
+                    channel.call(BrokerRequest {
+                        request_id: RequestId(request_id as u64),
+                        operation: BrokerOperation::CloseObject(ObjectHandle(request_id as u64)),
+                    })
+                })
+            })
+            .collect::<Vec<_>>();
+
+        for _ in 0..MAX_PENDING_CALLS {
+            let frame = read_frame_with_deadline(&mut host_stream, None)
+                .unwrap()
+                .unwrap();
+            decode_request(&frame).unwrap();
+        }
+        host_stream
+            .set_read_timeout(Some(Duration::from_millis(50)))
+            .unwrap();
+        let error = read_frame_with_deadline(&mut host_stream, None).unwrap_err();
+        assert!(matches!(
+            error.kind(),
+            ErrorKind::WouldBlock | ErrorKind::TimedOut
+        ));
+
+        cancellation.cancel().unwrap();
+        for caller in callers {
+            assert!(caller.join().unwrap().is_err());
+        }
+    }
+
+    #[test]
+    fn unknown_response_identifier_fails_all_pending_calls() {
+        let (local_stream, mut host_stream) = UnixStream::pair().unwrap();
+        let failure_count = Arc::new(AtomicUsize::new(0));
+        let response_failure_count = Arc::clone(&failure_count);
+        let (channel, _cancellation) = UnixStreamLocalControlChannel::from_connected(local_stream)
+            .activate(move || {
+                response_failure_count.fetch_add(1, Ordering::SeqCst);
+            })
+            .unwrap();
+        let channel = Arc::new(channel);
+        let callers = [1, 2].map(|request_id| {
+            let channel = Arc::clone(&channel);
+            thread::spawn(move || {
+                channel.call(BrokerRequest {
+                    request_id: RequestId(request_id),
+                    operation: BrokerOperation::CloseObject(ObjectHandle(request_id)),
+                })
+            })
+        });
+
+        for _ in 0..callers.len() {
+            let frame = read_frame_with_deadline(&mut host_stream, None)
+                .unwrap()
+                .unwrap();
+            decode_request(&frame).unwrap();
+        }
+        write_frame_with_deadline(
+            &mut host_stream,
+            &encode_response(BrokerResponse {
+                request_id: RequestId(99),
+                result: BrokerResult::ObjectClosed,
+            }),
+            None,
+        )
+        .unwrap();
+
+        for caller in callers {
+            assert_eq!(
+                caller.join().unwrap().unwrap_err().kind(),
+                ErrorKind::InvalidData
+            );
+        }
+        assert_eq!(failure_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn duplicate_response_identifier_fails_other_pending_calls() {
+        let (local_stream, mut host_stream) = UnixStream::pair().unwrap();
+        let failure_count = Arc::new(AtomicUsize::new(0));
+        let response_failure_count = Arc::clone(&failure_count);
+        let (channel, _cancellation) = UnixStreamLocalControlChannel::from_connected(local_stream)
+            .activate(move || {
+                response_failure_count.fetch_add(1, Ordering::SeqCst);
+            })
+            .unwrap();
+        let channel = Arc::new(channel);
+        let first_channel = Arc::clone(&channel);
+        let first = thread::spawn(move || {
+            first_channel.call(BrokerRequest {
+                request_id: RequestId(1),
+                operation: BrokerOperation::CloseObject(ObjectHandle(1)),
+            })
+        });
+        let second_channel = Arc::clone(&channel);
+        let second = thread::spawn(move || {
+            second_channel.call(BrokerRequest {
+                request_id: RequestId(2),
+                operation: BrokerOperation::CloseObject(ObjectHandle(2)),
+            })
+        });
+
+        for _ in 0..2 {
+            let frame = read_frame_with_deadline(&mut host_stream, None)
+                .unwrap()
+                .unwrap();
+            decode_request(&frame).unwrap();
+        }
+        let response = encode_response(BrokerResponse {
+            request_id: RequestId(1),
+            result: BrokerResult::ObjectClosed,
+        });
+        write_frame_with_deadline(&mut host_stream, &response, None).unwrap();
+        write_frame_with_deadline(&mut host_stream, &response, None).unwrap();
+
+        assert_eq!(first.join().unwrap().unwrap().request_id, RequestId(1));
+        assert_eq!(
+            second.join().unwrap().unwrap_err().kind(),
+            ErrorKind::InvalidData
+        );
+        assert_eq!(failure_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn completed_call_wins_over_later_association_failure() {
+        let pending = PendingCalls::new();
+        let request_id = RequestId(1);
+        pending.register(request_id).unwrap();
+        pending
+            .complete(BrokerResponse {
+                request_id,
+                result: BrokerResult::ObjectClosed,
+            })
+            .unwrap();
+        pending.fail(Arc::new(Error::new(
+            ErrorKind::ConnectionAborted,
+            "test failure",
+        )));
+
+        assert_eq!(pending.wait(request_id).unwrap().request_id, request_id);
+    }
+
+    #[test]
+    fn duplicate_registration_preserves_the_original_call() {
+        let pending = PendingCalls::new();
+        let request_id = RequestId(1);
+        pending.register(request_id).unwrap();
+        pending
+            .complete(BrokerResponse {
+                request_id,
+                result: BrokerResult::ObjectClosed,
+            })
+            .unwrap();
+
+        assert_eq!(
+            pending.register(request_id).unwrap_err().kind(),
+            ErrorKind::InvalidData
+        );
+        assert_eq!(pending.wait(request_id).unwrap().request_id, request_id);
+    }
+
+    #[test]
+    fn association_failure_wins_before_completion() {
+        let pending = PendingCalls::new();
+        let request_id = RequestId(1);
+        pending.register(request_id).unwrap();
+        pending.fail(Arc::new(Error::new(
+            ErrorKind::ConnectionAborted,
+            "test failure",
+        )));
+
+        assert!(
+            pending
+                .complete(BrokerResponse {
+                    request_id,
+                    result: BrokerResult::ObjectClosed,
+                })
+                .is_err()
+        );
+        assert_eq!(
+            pending.wait(request_id).unwrap_err().kind(),
+            ErrorKind::ConnectionAborted
         );
     }
 
@@ -568,15 +1174,23 @@ mod tests {
     #[test]
     fn local_control_cancellation_unblocks_response_read() {
         let (local_stream, _host_stream) = UnixStream::pair().unwrap();
-        let mut channel = UnixStreamLocalControlChannel::from_connected(local_stream);
-        let cancellation = channel.cancellation_handle().unwrap();
+        let (channel, cancellation) = UnixStreamLocalControlChannel::from_connected(local_stream)
+            .activate(|| {})
+            .unwrap();
         let completed = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
         let (started_sender, started_receiver) = std::sync::mpsc::sync_channel(1);
         let (result_sender, result_receiver) = std::sync::mpsc::sync_channel(1);
         let reader_completed = completed.clone();
         let reader = std::thread::spawn(move || {
             started_sender.send(()).unwrap();
-            result_sender.send(channel.recv_response()).unwrap();
+            result_sender
+                .send(channel.call(BrokerRequest {
+                    request_id: RequestId(0),
+                    operation: BrokerOperation::CloseObject(litebox_broker_protocol::ObjectHandle(
+                        1,
+                    )),
+                }))
+                .unwrap();
             reader_completed.store(true, std::sync::atomic::Ordering::Release);
         });
 
@@ -594,8 +1208,9 @@ mod tests {
     #[test]
     fn dropping_local_control_closes_connection_with_cancellation_clone() {
         let (local_stream, mut host_stream) = UnixStream::pair().unwrap();
-        let channel = UnixStreamLocalControlChannel::from_connected(local_stream);
-        let _cancellation = channel.cancellation_handle().unwrap();
+        let (channel, _cancellation) = UnixStreamLocalControlChannel::from_connected(local_stream)
+            .activate(|| {})
+            .unwrap();
         host_stream
             .set_read_timeout(Some(Duration::from_secs(1)))
             .unwrap();

--- a/litebox_broker_transport/src/unix_socket.rs
+++ b/litebox_broker_transport/src/unix_socket.rs
@@ -751,6 +751,7 @@ mod tests {
     };
     use litebox_broker_protocol::{ObjectHandle, RequestId};
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::mpsc;
     use std::time::Duration;
 
     fn activate_test_channel(
@@ -769,6 +770,24 @@ mod tests {
         };
         let cancellation = channel.activate(association_failure).unwrap();
         (channel, cancellation)
+    }
+
+    fn activate_counting_failure_channel(
+        stream: UnixStream,
+    ) -> (
+        UnixStreamLocalControlChannel,
+        UnixStreamLocalControlCancellation,
+        Arc<AtomicUsize>,
+        mpsc::Receiver<()>,
+    ) {
+        let failure_count = Arc::new(AtomicUsize::new(0));
+        let response_failure_count = Arc::clone(&failure_count);
+        let (failure_sender, failure_receiver) = mpsc::channel();
+        let (channel, cancellation) = activate_test_channel(stream, move || {
+            response_failure_count.fetch_add(1, Ordering::SeqCst);
+            failure_sender.send(()).unwrap();
+        });
+        (channel, cancellation, failure_count, failure_receiver)
     }
 
     #[test]
@@ -1005,11 +1024,12 @@ mod tests {
             })
             .collect::<Vec<_>>();
 
+        let mut published_request_ids = Vec::with_capacity(MAX_PENDING_CALLS);
         for _ in 0..MAX_PENDING_CALLS {
             let frame = read_frame_with_deadline(&mut host_stream, None)
                 .unwrap()
                 .unwrap();
-            decode_request(&frame).unwrap();
+            published_request_ids.push(decode_request(&frame).unwrap().request_id);
         }
         host_stream
             .set_read_timeout(Some(Duration::from_millis(50)))
@@ -1020,20 +1040,44 @@ mod tests {
             ErrorKind::WouldBlock | ErrorKind::TimedOut
         ));
 
+        write_frame_with_deadline(
+            &mut host_stream,
+            &encode_response(BrokerResponse {
+                request_id: published_request_ids[0],
+                result: BrokerResult::ObjectClosed,
+            }),
+            None,
+        )
+        .unwrap();
+        host_stream
+            .set_read_timeout(Some(Duration::from_secs(2)))
+            .unwrap();
+        let released_request = decode_request(
+            &read_frame_with_deadline(&mut host_stream, None)
+                .unwrap()
+                .unwrap(),
+        )
+        .unwrap();
+        assert!(!published_request_ids.contains(&released_request.request_id));
+
         cancellation.cancel().unwrap();
+        let mut completed = 0;
+        let mut failed = 0;
         for caller in callers {
-            assert!(caller.join().unwrap().is_err());
+            match caller.join().unwrap() {
+                Ok(_) => completed += 1,
+                Err(_) => failed += 1,
+            }
         }
+        assert_eq!(completed, 1);
+        assert_eq!(failed, MAX_PENDING_CALLS);
     }
 
     #[test]
     fn unknown_response_identifier_fails_all_pending_calls() {
         let (local_stream, mut host_stream) = UnixStream::pair().unwrap();
-        let failure_count = Arc::new(AtomicUsize::new(0));
-        let response_failure_count = Arc::clone(&failure_count);
-        let (channel, _cancellation) = activate_test_channel(local_stream, move || {
-            response_failure_count.fetch_add(1, Ordering::SeqCst);
-        });
+        let (channel, _cancellation, failure_count, failure_receiver) =
+            activate_counting_failure_channel(local_stream);
         let channel = Arc::new(channel);
         let callers = [1, 2].map(|request_id| {
             let channel = Arc::clone(&channel);
@@ -1067,17 +1111,17 @@ mod tests {
                 ErrorKind::InvalidData
             );
         }
+        failure_receiver
+            .recv_timeout(Duration::from_secs(1))
+            .unwrap();
         assert_eq!(failure_count.load(Ordering::SeqCst), 1);
     }
 
     #[test]
     fn malformed_response_fails_all_pending_calls() {
         let (local_stream, mut host_stream) = UnixStream::pair().unwrap();
-        let failure_count = Arc::new(AtomicUsize::new(0));
-        let response_failure_count = Arc::clone(&failure_count);
-        let (channel, _cancellation) = activate_test_channel(local_stream, move || {
-            response_failure_count.fetch_add(1, Ordering::SeqCst);
-        });
+        let (channel, _cancellation, failure_count, failure_receiver) =
+            activate_counting_failure_channel(local_stream);
         let channel = Arc::new(channel);
         let callers = [1, 2].map(|request_id| {
             let channel = Arc::clone(&channel);
@@ -1103,17 +1147,17 @@ mod tests {
                 ErrorKind::InvalidData
             );
         }
+        failure_receiver
+            .recv_timeout(Duration::from_secs(1))
+            .unwrap();
         assert_eq!(failure_count.load(Ordering::SeqCst), 1);
     }
 
     #[test]
     fn response_eof_fails_all_pending_calls() {
         let (local_stream, mut host_stream) = UnixStream::pair().unwrap();
-        let failure_count = Arc::new(AtomicUsize::new(0));
-        let response_failure_count = Arc::clone(&failure_count);
-        let (channel, _cancellation) = activate_test_channel(local_stream, move || {
-            response_failure_count.fetch_add(1, Ordering::SeqCst);
-        });
+        let (channel, _cancellation, failure_count, failure_receiver) =
+            activate_counting_failure_channel(local_stream);
         let channel = Arc::new(channel);
         let callers = [1, 2].map(|request_id| {
             let channel = Arc::clone(&channel);
@@ -1139,17 +1183,17 @@ mod tests {
                 ErrorKind::UnexpectedEof
             );
         }
+        failure_receiver
+            .recv_timeout(Duration::from_secs(1))
+            .unwrap();
         assert_eq!(failure_count.load(Ordering::SeqCst), 1);
     }
 
     #[test]
     fn request_write_failure_fails_existing_pending_calls() {
         let (local_stream, mut host_stream) = UnixStream::pair().unwrap();
-        let failure_count = Arc::new(AtomicUsize::new(0));
-        let response_failure_count = Arc::clone(&failure_count);
-        let (channel, _cancellation) = activate_test_channel(local_stream, move || {
-            response_failure_count.fetch_add(1, Ordering::SeqCst);
-        });
+        let (channel, _cancellation, failure_count, failure_receiver) =
+            activate_counting_failure_channel(local_stream);
         let channel = Arc::new(channel);
         let pending_callers = [1, 2].map(|request_id| {
             let channel = Arc::clone(&channel);
@@ -1180,17 +1224,17 @@ mod tests {
         for caller in pending_callers {
             assert!(caller.join().unwrap().is_err());
         }
+        failure_receiver
+            .recv_timeout(Duration::from_secs(1))
+            .unwrap();
         assert_eq!(failure_count.load(Ordering::SeqCst), 1);
     }
 
     #[test]
     fn duplicate_response_identifier_fails_other_pending_calls() {
         let (local_stream, mut host_stream) = UnixStream::pair().unwrap();
-        let failure_count = Arc::new(AtomicUsize::new(0));
-        let response_failure_count = Arc::clone(&failure_count);
-        let (channel, _cancellation) = activate_test_channel(local_stream, move || {
-            response_failure_count.fetch_add(1, Ordering::SeqCst);
-        });
+        let (channel, _cancellation, failure_count, failure_receiver) =
+            activate_counting_failure_channel(local_stream);
         let channel = Arc::new(channel);
         let first_channel = Arc::clone(&channel);
         let first = thread::spawn(move || {
@@ -1225,6 +1269,9 @@ mod tests {
             second.join().unwrap().unwrap_err().kind(),
             ErrorKind::InvalidData
         );
+        failure_receiver
+            .recv_timeout(Duration::from_secs(1))
+            .unwrap();
         assert_eq!(failure_count.load(Ordering::SeqCst), 1);
     }
 

--- a/litebox_broker_transport/src/unix_socket.rs
+++ b/litebox_broker_transport/src/unix_socket.rs
@@ -360,7 +360,7 @@ impl LocalControlChannel for UnixStreamLocalControlChannel {
                 .request_stream
                 .lock()
                 .expect("broker request writer mutex poisoned");
-            match active.pending_calls.failure() {
+            match active.pending_calls.current_failure() {
                 Some(error) => Err(copy_io_error(&error)),
                 None => {
                     write_frame_with_deadline(&mut request_stream, &encode_request(request), None)
@@ -551,7 +551,7 @@ impl PendingCalls {
         }
     }
 
-    fn fail(&self, error: Arc<Error>) -> bool {
+    fn record_failure(&self, error: Arc<Error>) -> bool {
         let mut state = self.state.lock().expect("broker pending mutex poisoned");
         if state.failure.is_some() {
             return false;
@@ -561,7 +561,7 @@ impl PendingCalls {
         true
     }
 
-    fn failure(&self) -> Option<Arc<Error>> {
+    fn current_failure(&self) -> Option<Arc<Error>> {
         self.state
             .lock()
             .expect("broker pending mutex poisoned")
@@ -632,7 +632,7 @@ fn fail_active_channel(
     association_failure: &(dyn Fn() + Send + Sync),
     error: Error,
 ) -> IoResult<()> {
-    let first_failure = pending_calls.fail(Arc::new(error));
+    let first_failure = pending_calls.record_failure(Arc::new(error));
     let shutdown_result = shutdown(shutdown_stream);
     if first_failure {
         association_failure();
@@ -1077,7 +1077,7 @@ mod tests {
                 result: BrokerResult::ObjectClosed,
             })
             .unwrap();
-        pending.fail(Arc::new(Error::new(
+        pending.record_failure(Arc::new(Error::new(
             ErrorKind::ConnectionAborted,
             "test failure",
         )));
@@ -1109,7 +1109,7 @@ mod tests {
         let pending = PendingCalls::new();
         let request_id = RequestId(1);
         pending.register(request_id).unwrap();
-        pending.fail(Arc::new(Error::new(
+        pending.record_failure(Arc::new(Error::new(
             ErrorKind::ConnectionAborted,
             "test failure",
         )));

--- a/litebox_broker_transport/src/unix_socket.rs
+++ b/litebox_broker_transport/src/unix_socket.rs
@@ -21,8 +21,8 @@ use crate::unix_io::{
 };
 use litebox_broker_protocol::RequestId;
 use litebox_broker_protocol::channel::{
-    HostControlChannel, HostNotificationChannel, HostReceive, LocalCallChannel,
-    LocalNotificationChannel, LocalSetupChannel, PeerCredential,
+    HostControlChannel, HostNotificationChannel, HostReceive, LocalControlChannel,
+    LocalNotificationChannel, PeerCredential,
 };
 use litebox_broker_protocol::message::{
     BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerNotification, BrokerRequest,
@@ -68,6 +68,16 @@ fn peer_process_id(stream: &UnixStream) -> IoResult<u32> {
 
 /// Local-side Unix-domain-socket control channel for the hosted userland POC.
 pub struct UnixStreamLocalControlChannel {
+    state: UnixStreamLocalControlState,
+}
+
+enum UnixStreamLocalControlState {
+    Setup(UnixStreamLocalSetup),
+    Active(UnixStreamLocalActive),
+    Failed,
+}
+
+struct UnixStreamLocalSetup {
     stream: UnixStream,
     setup_deadline: Option<Instant>,
 }
@@ -79,8 +89,7 @@ pub struct UnixStreamLocalControlCancellation {
     association_failure: Arc<dyn Fn() + Send + Sync>,
 }
 
-/// Shared active-call channel backed by one Unix stream.
-pub struct UnixStreamLocalCallChannel {
+struct UnixStreamLocalActive {
     request_stream: Mutex<UnixStream>,
     shutdown_stream: UnixStream,
     pending_calls: Arc<PendingCalls>,
@@ -92,8 +101,10 @@ impl UnixStreamLocalControlChannel {
     /// Creates a local control channel from an already-connected Unix stream.
     pub const fn from_connected(stream: UnixStream) -> Self {
         Self {
-            stream,
-            setup_deadline: None,
+            state: UnixStreamLocalControlState::Setup(UnixStreamLocalSetup {
+                stream,
+                setup_deadline: None,
+            }),
         }
     }
 
@@ -112,8 +123,10 @@ impl UnixStreamLocalControlChannel {
         deadline: Instant,
     ) -> IoResult<Self> {
         UnixStream::connect(path).map(|stream| Self {
-            stream,
-            setup_deadline: Some(deadline),
+            state: UnixStreamLocalControlState::Setup(UnixStreamLocalSetup {
+                stream,
+                setup_deadline: Some(deadline),
+            }),
         })
     }
 
@@ -123,24 +136,32 @@ impl UnixStreamLocalControlChannel {
         expected_len: usize,
         deadline: Option<Instant>,
     ) -> IoResult<MemfdSharedMemory> {
-        crate::shared_memory::receive_memfd(&mut self.stream, expected_len, deadline)
+        let UnixStreamLocalControlState::Setup(setup) = &mut self.state else {
+            return Err(invalid_data("broker control setup already completed"));
+        };
+        crate::shared_memory::receive_memfd(&mut setup.stream, expected_len, deadline)
     }
 
-    /// Consumes the setup channel and starts the active response pump.
+    /// Completes setup and starts the active response pump.
     pub fn activate(
-        self,
+        &mut self,
         association_failure: impl Fn() + Send + Sync + 'static,
-    ) -> IoResult<(
-        UnixStreamLocalCallChannel,
-        UnixStreamLocalControlCancellation,
-    )> {
-        if self.setup_deadline.is_some() {
+    ) -> IoResult<UnixStreamLocalControlCancellation> {
+        if !matches!(&self.state, UnixStreamLocalControlState::Setup(_)) {
+            return Err(invalid_data("broker control channel already active"));
+        }
+        let UnixStreamLocalControlState::Setup(setup) =
+            core::mem::replace(&mut self.state, UnixStreamLocalControlState::Failed)
+        else {
+            unreachable!("broker control setup state disappeared");
+        };
+        if setup.setup_deadline.is_some() {
             return Err(invalid_data(
                 "broker control channel activated before setup completed",
             ));
         }
 
-        let response_stream = self.stream;
+        let response_stream = setup.stream;
         let request_stream = response_stream.try_clone()?;
         let shutdown_stream = response_stream.try_clone()?;
         let cancellation_stream = response_stream.try_clone()?;
@@ -160,20 +181,18 @@ impl UnixStreamLocalControlChannel {
                 );
             })?;
 
-        Ok((
-            UnixStreamLocalCallChannel {
-                request_stream: Mutex::new(request_stream),
-                shutdown_stream,
-                pending_calls: Arc::clone(&pending_calls),
-                payload_transfer: Mutex::new(()),
-                association_failure: Arc::clone(&association_failure),
-            },
-            UnixStreamLocalControlCancellation {
-                stream: cancellation_stream,
-                pending_calls,
-                association_failure: Arc::clone(&association_failure),
-            },
-        ))
+        self.state = UnixStreamLocalControlState::Active(UnixStreamLocalActive {
+            request_stream: Mutex::new(request_stream),
+            shutdown_stream,
+            pending_calls: Arc::clone(&pending_calls),
+            payload_transfer: Mutex::new(()),
+            association_failure: Arc::clone(&association_failure),
+        });
+        Ok(UnixStreamLocalControlCancellation {
+            stream: cancellation_stream,
+            pending_calls,
+            association_failure,
+        })
     }
 }
 
@@ -189,12 +208,15 @@ impl UnixStreamLocalControlCancellation {
     }
 }
 
-impl Drop for UnixStreamLocalCallChannel {
+impl Drop for UnixStreamLocalControlChannel {
     fn drop(&mut self) {
+        let UnixStreamLocalControlState::Active(active) = &self.state else {
+            return;
+        };
         let _ = fail_active_channel(
-            &self.pending_calls,
-            &self.shutdown_stream,
-            self.association_failure.as_ref(),
+            &active.pending_calls,
+            &active.shutdown_stream,
+            active.association_failure.as_ref(),
             Error::new(
                 ErrorKind::ConnectionAborted,
                 "broker active channel dropped",
@@ -301,17 +323,23 @@ impl UnixStreamHostNotificationChannel {
     }
 }
 
-impl LocalSetupChannel for UnixStreamLocalControlChannel {
+impl LocalControlChannel for UnixStreamLocalControlChannel {
     type Error = Error;
 
     fn send_handshake_request(&mut self, request: &BrokerHandshakeRequest) -> IoResult<()> {
+        let UnixStreamLocalControlState::Setup(setup) = &mut self.state else {
+            return Err(invalid_data("broker control channel is already active"));
+        };
         let frame = encode_handshake_request(request.clone());
-        write_frame_with_deadline(&mut self.stream, &frame, self.setup_deadline)
+        write_frame_with_deadline(&mut setup.stream, &frame, setup.setup_deadline)
     }
 
     fn recv_handshake_response(&mut self) -> IoResult<Option<BrokerHandshakeResponse>> {
-        let frame = read_frame_with_deadline(&mut self.stream, self.setup_deadline)?;
-        self.setup_deadline = None;
+        let UnixStreamLocalControlState::Setup(setup) = &mut self.state else {
+            return Err(invalid_data("broker control channel is already active"));
+        };
+        let frame = read_frame_with_deadline(&mut setup.stream, setup.setup_deadline)?;
+        setup.setup_deadline = None;
         match frame {
             Some(frame) => decode_handshake_response(&frame)
                 .map(Some)
@@ -319,21 +347,20 @@ impl LocalSetupChannel for UnixStreamLocalControlChannel {
             None => Ok(None),
         }
     }
-}
-
-impl LocalCallChannel for UnixStreamLocalCallChannel {
-    type Error = Error;
 
     fn call(&self, request: BrokerRequest) -> IoResult<BrokerResponse> {
+        let UnixStreamLocalControlState::Active(active) = &self.state else {
+            return Err(invalid_data("broker control channel is not active"));
+        };
         let request_id = request.request_id;
-        self.pending_calls.register(request_id)?;
+        active.pending_calls.register(request_id)?;
 
         let write_result = {
-            let mut request_stream = self
+            let mut request_stream = active
                 .request_stream
                 .lock()
                 .expect("broker request writer mutex poisoned");
-            match self.pending_calls.failure() {
+            match active.pending_calls.failure() {
                 Some(error) => Err(copy_io_error(&error)),
                 None => {
                     write_frame_with_deadline(&mut request_stream, &encode_request(request), None)
@@ -342,22 +369,25 @@ impl LocalCallChannel for UnixStreamLocalCallChannel {
         };
         if let Err(error) = write_result {
             let _ = fail_active_channel(
-                &self.pending_calls,
-                &self.shutdown_stream,
-                self.association_failure.as_ref(),
+                &active.pending_calls,
+                &active.shutdown_stream,
+                active.association_failure.as_ref(),
                 error,
             );
         }
 
-        self.pending_calls.wait(request_id)
+        active.pending_calls.wait(request_id)
     }
 
-    fn with_serialized_payload<T>(&self, transfer: impl FnOnce() -> T) -> T {
-        let _transfer = self
+    fn with_serialized_payload<T>(&self, transfer: impl FnOnce() -> T) -> IoResult<T> {
+        let UnixStreamLocalControlState::Active(active) = &self.state else {
+            return Err(invalid_data("broker control channel is not active"));
+        };
+        let _transfer = active
             .payload_transfer
             .lock()
             .expect("broker payload-transfer mutex poisoned");
-        transfer()
+        Ok(transfer())
     }
 }
 
@@ -754,11 +784,67 @@ mod tests {
     }
 
     #[test]
+    fn local_control_channel_enforces_setup_and_active_phases() {
+        let (local_stream, mut host_stream) = UnixStream::pair().unwrap();
+        let mut channel = UnixStreamLocalControlChannel::from_connected(local_stream);
+        assert_eq!(
+            channel
+                .call(BrokerRequest {
+                    request_id: RequestId(0),
+                    operation: BrokerOperation::CloseObject(ObjectHandle(1)),
+                })
+                .unwrap_err()
+                .kind(),
+            ErrorKind::InvalidData
+        );
+
+        let _cancellation = channel.activate(|| {}).unwrap();
+
+        assert_eq!(
+            channel.activate(|| {}).err().unwrap().kind(),
+            ErrorKind::InvalidData
+        );
+        assert_eq!(
+            channel
+                .send_handshake_request(&BrokerHandshakeRequest {
+                    protocol_version: litebox_broker_protocol::BROKER_PROTOCOL_VERSION,
+                })
+                .unwrap_err()
+                .kind(),
+            ErrorKind::InvalidData
+        );
+
+        let channel = Arc::new(channel);
+        let call_channel = Arc::clone(&channel);
+        let call = thread::spawn(move || {
+            call_channel.call(BrokerRequest {
+                request_id: RequestId(1),
+                operation: BrokerOperation::CloseObject(ObjectHandle(1)),
+            })
+        });
+        let request = decode_request(
+            &read_frame_with_deadline(&mut host_stream, None)
+                .unwrap()
+                .unwrap(),
+        )
+        .unwrap();
+        write_frame_with_deadline(
+            &mut host_stream,
+            &encode_response(BrokerResponse {
+                request_id: request.request_id,
+                result: BrokerResult::ObjectClosed,
+            }),
+            None,
+        )
+        .unwrap();
+        assert_eq!(call.join().unwrap().unwrap().request_id, RequestId(1));
+    }
+
+    #[test]
     fn active_channel_matches_out_of_order_responses() {
         let (local_stream, mut host_stream) = UnixStream::pair().unwrap();
-        let (channel, _cancellation) = UnixStreamLocalControlChannel::from_connected(local_stream)
-            .activate(|| {})
-            .unwrap();
+        let mut channel = UnixStreamLocalControlChannel::from_connected(local_stream);
+        let _cancellation = channel.activate(|| {}).unwrap();
         let channel = Arc::new(channel);
 
         let first_channel = Arc::clone(&channel);
@@ -818,9 +904,8 @@ mod tests {
     #[test]
     fn active_channel_serializes_shared_payload_transfers() {
         let (local_stream, _host_stream) = UnixStream::pair().unwrap();
-        let (channel, _cancellation) = UnixStreamLocalControlChannel::from_connected(local_stream)
-            .activate(|| {})
-            .unwrap();
+        let mut channel = UnixStreamLocalControlChannel::from_connected(local_stream);
+        let _cancellation = channel.activate(|| {}).unwrap();
         let channel = Arc::new(channel);
         let active_transfers = Arc::new(AtomicUsize::new(0));
         let callers = (0..2)
@@ -828,11 +913,13 @@ mod tests {
                 let channel = Arc::clone(&channel);
                 let active_transfers = Arc::clone(&active_transfers);
                 thread::spawn(move || {
-                    channel.with_serialized_payload(|| {
-                        assert_eq!(active_transfers.fetch_add(1, Ordering::SeqCst), 0);
-                        thread::sleep(Duration::from_millis(20));
-                        assert_eq!(active_transfers.fetch_sub(1, Ordering::SeqCst), 1);
-                    });
+                    channel
+                        .with_serialized_payload(|| {
+                            assert_eq!(active_transfers.fetch_add(1, Ordering::SeqCst), 0);
+                            thread::sleep(Duration::from_millis(20));
+                            assert_eq!(active_transfers.fetch_sub(1, Ordering::SeqCst), 1);
+                        })
+                        .unwrap();
                 })
             })
             .collect::<Vec<_>>();
@@ -848,9 +935,8 @@ mod tests {
         host_stream
             .set_read_timeout(Some(Duration::from_secs(2)))
             .unwrap();
-        let (channel, cancellation) = UnixStreamLocalControlChannel::from_connected(local_stream)
-            .activate(|| {})
-            .unwrap();
+        let mut channel = UnixStreamLocalControlChannel::from_connected(local_stream);
+        let cancellation = channel.activate(|| {}).unwrap();
         let channel = Arc::new(channel);
         let callers = (0..=MAX_PENDING_CALLS)
             .map(|request_id| {
@@ -890,7 +976,8 @@ mod tests {
         let (local_stream, mut host_stream) = UnixStream::pair().unwrap();
         let failure_count = Arc::new(AtomicUsize::new(0));
         let response_failure_count = Arc::clone(&failure_count);
-        let (channel, _cancellation) = UnixStreamLocalControlChannel::from_connected(local_stream)
+        let mut channel = UnixStreamLocalControlChannel::from_connected(local_stream);
+        let _cancellation = channel
             .activate(move || {
                 response_failure_count.fetch_add(1, Ordering::SeqCst);
             })
@@ -936,7 +1023,8 @@ mod tests {
         let (local_stream, mut host_stream) = UnixStream::pair().unwrap();
         let failure_count = Arc::new(AtomicUsize::new(0));
         let response_failure_count = Arc::clone(&failure_count);
-        let (channel, _cancellation) = UnixStreamLocalControlChannel::from_connected(local_stream)
+        let mut channel = UnixStreamLocalControlChannel::from_connected(local_stream);
+        let _cancellation = channel
             .activate(move || {
                 response_failure_count.fetch_add(1, Ordering::SeqCst);
             })
@@ -1088,8 +1176,10 @@ mod tests {
     fn local_handshake_response_read_setup_deadline_is_wall_clock() {
         let (mut host_stream, local_stream) = UnixStream::pair().unwrap();
         let mut channel = UnixStreamLocalControlChannel {
-            stream: local_stream,
-            setup_deadline: Some(Instant::now() + Duration::from_millis(50)),
+            state: UnixStreamLocalControlState::Setup(UnixStreamLocalSetup {
+                stream: local_stream,
+                setup_deadline: Some(Instant::now() + Duration::from_millis(50)),
+            }),
         };
 
         let reader = std::thread::spawn(move || channel.recv_handshake_response().unwrap_err());
@@ -1174,9 +1264,8 @@ mod tests {
     #[test]
     fn local_control_cancellation_unblocks_response_read() {
         let (local_stream, _host_stream) = UnixStream::pair().unwrap();
-        let (channel, cancellation) = UnixStreamLocalControlChannel::from_connected(local_stream)
-            .activate(|| {})
-            .unwrap();
+        let mut channel = UnixStreamLocalControlChannel::from_connected(local_stream);
+        let cancellation = channel.activate(|| {}).unwrap();
         let completed = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
         let (started_sender, started_receiver) = std::sync::mpsc::sync_channel(1);
         let (result_sender, result_receiver) = std::sync::mpsc::sync_channel(1);
@@ -1208,9 +1297,8 @@ mod tests {
     #[test]
     fn dropping_local_control_closes_connection_with_cancellation_clone() {
         let (local_stream, mut host_stream) = UnixStream::pair().unwrap();
-        let (channel, _cancellation) = UnixStreamLocalControlChannel::from_connected(local_stream)
-            .activate(|| {})
-            .unwrap();
+        let mut channel = UnixStreamLocalControlChannel::from_connected(local_stream);
+        let _cancellation = channel.activate(|| {}).unwrap();
         host_stream
             .set_read_timeout(Some(Duration::from_secs(1)))
             .unwrap();

--- a/litebox_broker_transport/src/unix_socket.rs
+++ b/litebox_broker_transport/src/unix_socket.rs
@@ -1005,26 +1005,45 @@ mod tests {
         let (local_stream, _host_stream) = UnixStream::pair().unwrap();
         let (channel, _cancellation) = activate_test_channel(local_stream, || {});
         let channel = Arc::new(channel);
-        let active_transfers = Arc::new(AtomicUsize::new(0));
-        let callers = (0..2)
-            .map(|_| {
-                let channel = Arc::clone(&channel);
-                let active_transfers = Arc::clone(&active_transfers);
-                thread::spawn(move || {
-                    channel
-                        .with_serialized_payload(|| {
-                            assert_eq!(active_transfers.fetch_add(1, Ordering::SeqCst), 0);
-                            thread::sleep(Duration::from_millis(20));
-                            assert_eq!(active_transfers.fetch_sub(1, Ordering::SeqCst), 1);
-                        })
-                        .unwrap();
+        let (first_entered_sender, first_entered_receiver) = mpsc::sync_channel(1);
+        let (release_first_sender, release_first_receiver) = mpsc::sync_channel(1);
+        let first_channel = Arc::clone(&channel);
+        let first = thread::spawn(move || {
+            first_channel
+                .with_serialized_payload(|| {
+                    first_entered_sender.send(()).unwrap();
+                    release_first_receiver.recv().unwrap();
                 })
-            })
-            .collect::<Vec<_>>();
+                .unwrap();
+        });
+        first_entered_receiver
+            .recv_timeout(Duration::from_secs(1))
+            .unwrap();
 
-        for caller in callers {
-            caller.join().unwrap();
+        let (second_started_sender, second_started_receiver) = mpsc::sync_channel(1);
+        let (second_entered_sender, second_entered_receiver) = mpsc::sync_channel(1);
+        let second = thread::spawn(move || {
+            second_started_sender.send(()).unwrap();
+            channel
+                .with_serialized_payload(|| second_entered_sender.send(()).unwrap())
+                .unwrap();
+        });
+        second_started_receiver
+            .recv_timeout(Duration::from_secs(1))
+            .unwrap();
+        let entered_before_release = second_entered_receiver
+            .recv_timeout(Duration::from_millis(100))
+            .is_ok();
+
+        release_first_sender.send(()).unwrap();
+        if !entered_before_release {
+            second_entered_receiver
+                .recv_timeout(Duration::from_secs(1))
+                .unwrap();
         }
+        first.join().unwrap();
+        second.join().unwrap();
+        assert!(!entered_before_release);
     }
 
     #[test]

--- a/litebox_broker_transport/src/unix_socket.rs
+++ b/litebox_broker_transport/src/unix_socket.rs
@@ -779,7 +779,7 @@ mod tests {
     };
     use litebox_broker_protocol::{ObjectHandle, RequestId};
     use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::sync::mpsc;
+    use std::sync::{Barrier, mpsc};
     use std::time::Duration;
 
     fn activate_test_channel(
@@ -1040,10 +1040,13 @@ mod tests {
             .unwrap();
         let (channel, cancellation) = activate_test_channel(local_stream, || {});
         let channel = Arc::new(channel);
+        let call_start = Arc::new(Barrier::new(MAX_PENDING_CALLS + 2));
         let callers = (0..=MAX_PENDING_CALLS)
             .map(|request_id| {
                 let channel = Arc::clone(&channel);
+                let call_start = Arc::clone(&call_start);
                 thread::spawn(move || {
+                    call_start.wait();
                     channel.call(BrokerRequest {
                         request_id: RequestId(request_id as u64),
                         operation: BrokerOperation::CloseObject(ObjectHandle(request_id as u64)),
@@ -1052,6 +1055,7 @@ mod tests {
             })
             .collect::<Vec<_>>();
 
+        call_start.wait();
         let mut published_request_ids = Vec::with_capacity(MAX_PENDING_CALLS);
         for _ in 0..MAX_PENDING_CALLS {
             let frame = read_frame_with_deadline(&mut host_stream, None)
@@ -1060,7 +1064,7 @@ mod tests {
             published_request_ids.push(decode_request(&frame).unwrap().request_id);
         }
         host_stream
-            .set_read_timeout(Some(Duration::from_millis(50)))
+            .set_read_timeout(Some(Duration::from_millis(100)))
             .unwrap();
         let error = read_frame_with_deadline(&mut host_stream, None).unwrap_err();
         assert!(matches!(
@@ -1500,15 +1504,14 @@ mod tests {
     }
 
     #[test]
-    fn local_control_cancellation_unblocks_response_read() {
-        let (local_stream, _host_stream) = UnixStream::pair().unwrap();
+    fn local_control_cancellation_unblocks_pending_call() {
+        let (local_stream, mut host_stream) = UnixStream::pair().unwrap();
+        host_stream
+            .set_read_timeout(Some(Duration::from_secs(1)))
+            .unwrap();
         let (channel, cancellation) = activate_test_channel(local_stream, || {});
-        let completed = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
-        let (started_sender, started_receiver) = std::sync::mpsc::sync_channel(1);
-        let (result_sender, result_receiver) = std::sync::mpsc::sync_channel(1);
-        let reader_completed = completed.clone();
-        let reader = std::thread::spawn(move || {
-            started_sender.send(()).unwrap();
+        let (result_sender, result_receiver) = mpsc::sync_channel(1);
+        let caller = std::thread::spawn(move || {
             result_sender
                 .send(channel.call(BrokerRequest {
                     request_id: RequestId(0),
@@ -1517,18 +1520,27 @@ mod tests {
                     )),
                 }))
                 .unwrap();
-            reader_completed.store(true, std::sync::atomic::Ordering::Release);
         });
 
-        started_receiver
-            .recv_timeout(Duration::from_secs(1))
+        let frame = read_frame_with_deadline(&mut host_stream, None)
+            .unwrap()
             .unwrap();
-        std::thread::sleep(Duration::from_millis(50));
-        assert!(!completed.load(std::sync::atomic::Ordering::Acquire));
+        decode_request(&frame).unwrap();
+        assert!(matches!(
+            result_receiver.try_recv(),
+            Err(mpsc::TryRecvError::Empty)
+        ));
         cancellation.cancel().unwrap();
 
-        assert!(result_receiver.recv_timeout(Duration::from_secs(1)).is_ok());
-        reader.join().unwrap();
+        assert_eq!(
+            result_receiver
+                .recv_timeout(Duration::from_secs(1))
+                .unwrap()
+                .unwrap_err()
+                .kind(),
+            ErrorKind::ConnectionAborted
+        );
+        caller.join().unwrap();
     }
 
     #[test]

--- a/litebox_broker_transport/src/unix_socket.rs
+++ b/litebox_broker_transport/src/unix_socket.rs
@@ -364,6 +364,7 @@ impl LocalControlChannel for UnixStreamLocalControlChannel {
         };
         let request_id = request.request_id;
         let pending_call = active.pending_calls.register(request_id)?;
+        let request_frame = encode_request(request);
 
         let write_result = {
             let mut request_stream = active
@@ -372,9 +373,7 @@ impl LocalControlChannel for UnixStreamLocalControlChannel {
                 .expect("broker request writer mutex poisoned");
             match active.pending_calls.current_failure() {
                 Some(error) => Err(copy_io_error(&error)),
-                None => {
-                    write_frame_with_deadline(&mut request_stream, &encode_request(request), None)
-                }
+                None => write_frame_with_deadline(&mut request_stream, &request_frame, None),
             }
         };
         if let Err(error) = write_result {
@@ -540,6 +539,7 @@ impl PendingCalls {
     }
 
     fn register(&self, request_id: RequestId) -> IoResult<Arc<PendingCall>> {
+        let pending_call = Arc::new(PendingCall::new());
         let mut state = self.state.lock().expect("broker pending mutex poisoned");
         while state.calls.len() == MAX_PENDING_CALLS && state.failure.is_none() {
             state = self
@@ -550,7 +550,6 @@ impl PendingCalls {
         if let Some(error) = state.failure.as_ref() {
             return Err(copy_io_error(error));
         }
-        let pending_call = Arc::new(PendingCall::new());
         match state.calls.entry(request_id) {
             std::collections::hash_map::Entry::Vacant(entry) => {
                 entry.insert(Arc::clone(&pending_call));
@@ -585,15 +584,11 @@ impl PendingCalls {
                 return false;
             }
             state.failure = Some(Arc::clone(&error));
-            let pending_calls = state
-                .calls
-                .drain()
-                .map(|(_, call)| call)
-                .collect::<Vec<_>>();
+            let pending_calls = core::mem::take(&mut state.calls);
             self.capacity_available.notify_all();
             pending_calls
         };
-        for pending_call in pending_calls {
+        for pending_call in pending_calls.into_values() {
             pending_call.resolve(PendingCallResult::Failure(Arc::clone(&error)));
         }
         true

--- a/litebox_broker_transport/src/unix_socket.rs
+++ b/litebox_broker_transport/src/unix_socket.rs
@@ -363,7 +363,7 @@ impl LocalControlChannel for UnixStreamLocalControlChannel {
             return Err(invalid_data("broker control channel is not active"));
         };
         let request_id = request.request_id;
-        active.pending_calls.register(request_id)?;
+        let pending_call = active.pending_calls.register(request_id)?;
 
         let write_result = {
             let mut request_stream = active
@@ -386,7 +386,7 @@ impl LocalControlChannel for UnixStreamLocalControlChannel {
             );
         }
 
-        active.pending_calls.wait(request_id)
+        active.pending_calls.wait(pending_call)
     }
 
     fn with_serialized_payload<T>(&self, transfer: impl FnOnce() -> T) -> IoResult<T> {
@@ -472,7 +472,7 @@ impl HostNotificationChannel for UnixStreamHostNotificationChannel {
 
 struct PendingCalls {
     state: Mutex<PendingCallState>,
-    changed: Condvar,
+    capacity_available: Condvar,
 }
 
 struct PendingCallState {
@@ -480,9 +480,15 @@ struct PendingCallState {
     failure: Option<Arc<Error>>,
 }
 
-enum PendingCall {
-    Submitted,
-    Completed(BrokerResponse),
+struct PendingCall {
+    response: Option<BrokerResponse>,
+    response_ready: Arc<Condvar>,
+}
+
+#[derive(Debug)]
+struct PendingCallWaiter {
+    request_id: RequestId,
+    response_ready: Arc<Condvar>,
 }
 
 impl PendingCalls {
@@ -492,30 +498,37 @@ impl PendingCalls {
                 calls: HashMap::new(),
                 failure: None,
             }),
-            changed: Condvar::new(),
+            capacity_available: Condvar::new(),
         }
     }
 
-    fn register(&self, request_id: RequestId) -> IoResult<()> {
+    fn register(&self, request_id: RequestId) -> IoResult<PendingCallWaiter> {
         let mut state = self.state.lock().expect("broker pending mutex poisoned");
         while state.calls.len() == MAX_PENDING_CALLS && state.failure.is_none() {
             state = self
-                .changed
+                .capacity_available
                 .wait(state)
                 .expect("broker pending mutex poisoned");
         }
         if let Some(error) = state.failure.as_ref() {
             return Err(copy_io_error(error));
         }
+        let response_ready = Arc::new(Condvar::new());
         match state.calls.entry(request_id) {
             std::collections::hash_map::Entry::Vacant(entry) => {
-                entry.insert(PendingCall::Submitted);
+                entry.insert(PendingCall {
+                    response: None,
+                    response_ready: Arc::clone(&response_ready),
+                });
             }
             std::collections::hash_map::Entry::Occupied(_) => {
                 return Err(invalid_data("duplicate broker request ID"));
             }
         }
-        Ok(())
+        Ok(PendingCallWaiter {
+            request_id,
+            response_ready,
+        })
     }
 
     fn complete(&self, response: BrokerResponse) -> IoResult<()> {
@@ -526,36 +539,32 @@ impl PendingCalls {
         let Some(call) = state.calls.get_mut(&response.request_id) else {
             return Err(invalid_data("broker returned an unknown response ID"));
         };
-        match call {
-            PendingCall::Submitted => *call = PendingCall::Completed(response),
-            PendingCall::Completed(_) => {
-                return Err(invalid_data("broker returned a duplicate response ID"));
-            }
+        if call.response.is_some() {
+            return Err(invalid_data("broker returned a duplicate response ID"));
         }
-        self.changed.notify_all();
+        call.response = Some(response);
+        call.response_ready.notify_one();
         Ok(())
     }
 
-    fn wait(&self, request_id: RequestId) -> IoResult<BrokerResponse> {
+    fn wait(&self, pending_call: PendingCallWaiter) -> IoResult<BrokerResponse> {
         let mut state = self.state.lock().expect("broker pending mutex poisoned");
         loop {
-            if matches!(
-                state.calls.get(&request_id),
-                Some(PendingCall::Completed(_))
-            ) {
-                let Some(PendingCall::Completed(response)) = state.calls.remove(&request_id) else {
-                    unreachable!("completed broker call disappeared");
-                };
-                self.changed.notify_all();
+            let Some(call) = state.calls.get_mut(&pending_call.request_id) else {
+                unreachable!("pending broker call disappeared");
+            };
+            if let Some(response) = call.response.take() {
+                state.calls.remove(&pending_call.request_id);
+                self.capacity_available.notify_one();
                 return Ok(response);
             }
             if let Some(error) = state.failure.as_ref().map(Arc::clone) {
-                state.calls.remove(&request_id);
-                self.changed.notify_all();
+                state.calls.remove(&pending_call.request_id);
+                self.capacity_available.notify_one();
                 return Err(copy_io_error(&error));
             }
-            state = self
-                .changed
+            state = pending_call
+                .response_ready
                 .wait(state)
                 .expect("broker pending mutex poisoned");
         }
@@ -567,7 +576,10 @@ impl PendingCalls {
             return false;
         }
         state.failure = Some(error);
-        self.changed.notify_all();
+        for call in state.calls.values() {
+            call.response_ready.notify_one();
+        }
+        self.capacity_available.notify_all();
         true
     }
 
@@ -1279,7 +1291,7 @@ mod tests {
     fn completed_call_wins_over_later_association_failure() {
         let pending = PendingCalls::new();
         let request_id = RequestId(1);
-        pending.register(request_id).unwrap();
+        let pending_call = pending.register(request_id).unwrap();
         pending
             .complete(BrokerResponse {
                 request_id,
@@ -1291,14 +1303,14 @@ mod tests {
             "test failure",
         )));
 
-        assert_eq!(pending.wait(request_id).unwrap().request_id, request_id);
+        assert_eq!(pending.wait(pending_call).unwrap().request_id, request_id);
     }
 
     #[test]
     fn duplicate_registration_preserves_the_original_call() {
         let pending = PendingCalls::new();
         let request_id = RequestId(1);
-        pending.register(request_id).unwrap();
+        let pending_call = pending.register(request_id).unwrap();
         pending
             .complete(BrokerResponse {
                 request_id,
@@ -1310,14 +1322,14 @@ mod tests {
             pending.register(request_id).unwrap_err().kind(),
             ErrorKind::InvalidData
         );
-        assert_eq!(pending.wait(request_id).unwrap().request_id, request_id);
+        assert_eq!(pending.wait(pending_call).unwrap().request_id, request_id);
     }
 
     #[test]
     fn association_failure_wins_before_completion() {
         let pending = PendingCalls::new();
         let request_id = RequestId(1);
-        pending.register(request_id).unwrap();
+        let pending_call = pending.register(request_id).unwrap();
         pending.record_failure(Arc::new(Error::new(
             ErrorKind::ConnectionAborted,
             "test failure",
@@ -1332,7 +1344,7 @@ mod tests {
                 .is_err()
         );
         assert_eq!(
-            pending.wait(request_id).unwrap_err().kind(),
+            pending.wait(pending_call).unwrap_err().kind(),
             ErrorKind::ConnectionAborted
         );
     }

--- a/litebox_broker_transport/src/unix_socket.rs
+++ b/litebox_broker_transport/src/unix_socket.rs
@@ -85,6 +85,7 @@ enum UnixStreamLocalControlState {
 struct UnixStreamLocalSetup {
     stream: UnixStream,
     setup_deadline: Option<Instant>,
+    negotiated: bool,
 }
 
 /// Independently owned handle for interrupting local control-channel I/O.
@@ -109,6 +110,7 @@ impl UnixStreamLocalControlChannel {
             state: UnixStreamLocalControlState::Setup(UnixStreamLocalSetup {
                 stream,
                 setup_deadline: None,
+                negotiated: false,
             }),
         }
     }
@@ -131,6 +133,7 @@ impl UnixStreamLocalControlChannel {
             state: UnixStreamLocalControlState::Setup(UnixStreamLocalSetup {
                 stream,
                 setup_deadline: Some(deadline),
+                negotiated: false,
             }),
         })
     }
@@ -152,19 +155,19 @@ impl UnixStreamLocalControlChannel {
         &mut self,
         association_failure: impl Fn() + Send + Sync + 'static,
     ) -> IoResult<UnixStreamLocalControlCancellation> {
-        if !matches!(&self.state, UnixStreamLocalControlState::Setup(_)) {
+        let UnixStreamLocalControlState::Setup(setup) = &self.state else {
             return Err(invalid_data("broker control channel already active"));
+        };
+        if !setup.negotiated {
+            return Err(invalid_data(
+                "broker control channel activated before negotiation completed",
+            ));
         }
         let UnixStreamLocalControlState::Setup(setup) =
             core::mem::replace(&mut self.state, UnixStreamLocalControlState::Failed)
         else {
             unreachable!("broker control setup state disappeared");
         };
-        if setup.setup_deadline.is_some() {
-            return Err(invalid_data(
-                "broker control channel activated before setup completed",
-            ));
-        }
 
         let response_stream = setup.stream;
         let request_stream = response_stream.try_clone()?;
@@ -346,9 +349,11 @@ impl LocalControlChannel for UnixStreamLocalControlChannel {
         let frame = read_frame_with_deadline(&mut setup.stream, setup.setup_deadline)?;
         setup.setup_deadline = None;
         match frame {
-            Some(frame) => decode_handshake_response(&frame)
-                .map(Some)
-                .map_err(wire_error),
+            Some(frame) => {
+                let response = decode_handshake_response(&frame).map_err(wire_error)?;
+                setup.negotiated = matches!(&response, BrokerHandshakeResponse::Negotiated { .. });
+                Ok(Some(response))
+            }
             None => Ok(None),
         }
     }
@@ -748,6 +753,24 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Duration;
 
+    fn activate_test_channel(
+        stream: UnixStream,
+        association_failure: impl Fn() + Send + Sync + 'static,
+    ) -> (
+        UnixStreamLocalControlChannel,
+        UnixStreamLocalControlCancellation,
+    ) {
+        let mut channel = UnixStreamLocalControlChannel {
+            state: UnixStreamLocalControlState::Setup(UnixStreamLocalSetup {
+                stream,
+                setup_deadline: None,
+                negotiated: true,
+            }),
+        };
+        let cancellation = channel.activate(association_failure).unwrap();
+        (channel, cancellation)
+    }
+
     #[test]
     fn linux_peer_validation_identifies_connected_process() {
         let (first, second) = UnixStream::pair().unwrap();
@@ -803,6 +826,36 @@ mod tests {
             ErrorKind::InvalidData
         );
 
+        assert_eq!(
+            channel.activate(|| {}).err().unwrap().kind(),
+            ErrorKind::InvalidData
+        );
+        let handshake_request = BrokerHandshakeRequest {
+            protocol_version: litebox_broker_protocol::BROKER_PROTOCOL_VERSION,
+        };
+        channel.send_handshake_request(&handshake_request).unwrap();
+        assert_eq!(
+            decode_handshake_request(
+                &read_frame_with_deadline(&mut host_stream, None)
+                    .unwrap()
+                    .unwrap()
+            )
+            .unwrap(),
+            handshake_request
+        );
+        write_frame_with_deadline(
+            &mut host_stream,
+            &encode_handshake_response(BrokerHandshakeResponse::Negotiated {
+                broker_protocol_version: litebox_broker_protocol::BROKER_PROTOCOL_VERSION,
+            }),
+            None,
+        )
+        .unwrap();
+        assert!(matches!(
+            channel.recv_handshake_response().unwrap(),
+            Some(BrokerHandshakeResponse::Negotiated { .. })
+        ));
+
         let _cancellation = channel.activate(|| {}).unwrap();
 
         assert_eq!(
@@ -848,8 +901,7 @@ mod tests {
     #[test]
     fn active_channel_matches_out_of_order_responses() {
         let (local_stream, mut host_stream) = UnixStream::pair().unwrap();
-        let mut channel = UnixStreamLocalControlChannel::from_connected(local_stream);
-        let _cancellation = channel.activate(|| {}).unwrap();
+        let (channel, _cancellation) = activate_test_channel(local_stream, || {});
         let channel = Arc::new(channel);
 
         let first_channel = Arc::clone(&channel);
@@ -909,8 +961,7 @@ mod tests {
     #[test]
     fn active_channel_serializes_shared_payload_transfers() {
         let (local_stream, _host_stream) = UnixStream::pair().unwrap();
-        let mut channel = UnixStreamLocalControlChannel::from_connected(local_stream);
-        let _cancellation = channel.activate(|| {}).unwrap();
+        let (channel, _cancellation) = activate_test_channel(local_stream, || {});
         let channel = Arc::new(channel);
         let active_transfers = Arc::new(AtomicUsize::new(0));
         let callers = (0..2)
@@ -940,8 +991,7 @@ mod tests {
         host_stream
             .set_read_timeout(Some(Duration::from_secs(2)))
             .unwrap();
-        let mut channel = UnixStreamLocalControlChannel::from_connected(local_stream);
-        let cancellation = channel.activate(|| {}).unwrap();
+        let (channel, cancellation) = activate_test_channel(local_stream, || {});
         let channel = Arc::new(channel);
         let callers = (0..=MAX_PENDING_CALLS)
             .map(|request_id| {
@@ -981,12 +1031,9 @@ mod tests {
         let (local_stream, mut host_stream) = UnixStream::pair().unwrap();
         let failure_count = Arc::new(AtomicUsize::new(0));
         let response_failure_count = Arc::clone(&failure_count);
-        let mut channel = UnixStreamLocalControlChannel::from_connected(local_stream);
-        let _cancellation = channel
-            .activate(move || {
-                response_failure_count.fetch_add(1, Ordering::SeqCst);
-            })
-            .unwrap();
+        let (channel, _cancellation) = activate_test_channel(local_stream, move || {
+            response_failure_count.fetch_add(1, Ordering::SeqCst);
+        });
         let channel = Arc::new(channel);
         let callers = [1, 2].map(|request_id| {
             let channel = Arc::clone(&channel);
@@ -1024,16 +1071,126 @@ mod tests {
     }
 
     #[test]
+    fn malformed_response_fails_all_pending_calls() {
+        let (local_stream, mut host_stream) = UnixStream::pair().unwrap();
+        let failure_count = Arc::new(AtomicUsize::new(0));
+        let response_failure_count = Arc::clone(&failure_count);
+        let (channel, _cancellation) = activate_test_channel(local_stream, move || {
+            response_failure_count.fetch_add(1, Ordering::SeqCst);
+        });
+        let channel = Arc::new(channel);
+        let callers = [1, 2].map(|request_id| {
+            let channel = Arc::clone(&channel);
+            thread::spawn(move || {
+                channel.call(BrokerRequest {
+                    request_id: RequestId(request_id),
+                    operation: BrokerOperation::CloseObject(ObjectHandle(request_id)),
+                })
+            })
+        });
+
+        for _ in 0..callers.len() {
+            let frame = read_frame_with_deadline(&mut host_stream, None)
+                .unwrap()
+                .unwrap();
+            decode_request(&frame).unwrap();
+        }
+        write_frame_with_deadline(&mut host_stream, &[u8::MAX], None).unwrap();
+
+        for caller in callers {
+            assert_eq!(
+                caller.join().unwrap().unwrap_err().kind(),
+                ErrorKind::InvalidData
+            );
+        }
+        assert_eq!(failure_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn response_eof_fails_all_pending_calls() {
+        let (local_stream, mut host_stream) = UnixStream::pair().unwrap();
+        let failure_count = Arc::new(AtomicUsize::new(0));
+        let response_failure_count = Arc::clone(&failure_count);
+        let (channel, _cancellation) = activate_test_channel(local_stream, move || {
+            response_failure_count.fetch_add(1, Ordering::SeqCst);
+        });
+        let channel = Arc::new(channel);
+        let callers = [1, 2].map(|request_id| {
+            let channel = Arc::clone(&channel);
+            thread::spawn(move || {
+                channel.call(BrokerRequest {
+                    request_id: RequestId(request_id),
+                    operation: BrokerOperation::CloseObject(ObjectHandle(request_id)),
+                })
+            })
+        });
+
+        for _ in 0..callers.len() {
+            let frame = read_frame_with_deadline(&mut host_stream, None)
+                .unwrap()
+                .unwrap();
+            decode_request(&frame).unwrap();
+        }
+        drop(host_stream);
+
+        for caller in callers {
+            assert_eq!(
+                caller.join().unwrap().unwrap_err().kind(),
+                ErrorKind::UnexpectedEof
+            );
+        }
+        assert_eq!(failure_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn request_write_failure_fails_existing_pending_calls() {
+        let (local_stream, mut host_stream) = UnixStream::pair().unwrap();
+        let failure_count = Arc::new(AtomicUsize::new(0));
+        let response_failure_count = Arc::clone(&failure_count);
+        let (channel, _cancellation) = activate_test_channel(local_stream, move || {
+            response_failure_count.fetch_add(1, Ordering::SeqCst);
+        });
+        let channel = Arc::new(channel);
+        let pending_callers = [1, 2].map(|request_id| {
+            let channel = Arc::clone(&channel);
+            thread::spawn(move || {
+                channel.call(BrokerRequest {
+                    request_id: RequestId(request_id),
+                    operation: BrokerOperation::CloseObject(ObjectHandle(request_id)),
+                })
+            })
+        });
+        for _ in 0..pending_callers.len() {
+            let frame = read_frame_with_deadline(&mut host_stream, None)
+                .unwrap()
+                .unwrap();
+            decode_request(&frame).unwrap();
+        }
+
+        host_stream.shutdown(Shutdown::Read).unwrap();
+        let failing_channel = Arc::clone(&channel);
+        let failing_caller = thread::spawn(move || {
+            failing_channel.call(BrokerRequest {
+                request_id: RequestId(3),
+                operation: BrokerOperation::CloseObject(ObjectHandle(3)),
+            })
+        });
+
+        assert!(failing_caller.join().unwrap().is_err());
+        for caller in pending_callers {
+            assert!(caller.join().unwrap().is_err());
+        }
+        assert_eq!(failure_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
     fn duplicate_response_identifier_fails_other_pending_calls() {
         let (local_stream, mut host_stream) = UnixStream::pair().unwrap();
         let failure_count = Arc::new(AtomicUsize::new(0));
         let response_failure_count = Arc::clone(&failure_count);
-        let mut channel = UnixStreamLocalControlChannel::from_connected(local_stream);
-        let _cancellation = channel
-            .activate(move || {
-                response_failure_count.fetch_add(1, Ordering::SeqCst);
-            })
-            .unwrap();
+        let (channel, _cancellation) = activate_test_channel(local_stream, move || {
+            response_failure_count.fetch_add(1, Ordering::SeqCst);
+        });
         let channel = Arc::new(channel);
         let first_channel = Arc::clone(&channel);
         let first = thread::spawn(move || {
@@ -1184,6 +1341,7 @@ mod tests {
             state: UnixStreamLocalControlState::Setup(UnixStreamLocalSetup {
                 stream: local_stream,
                 setup_deadline: Some(Instant::now() + Duration::from_millis(50)),
+                negotiated: false,
             }),
         };
 
@@ -1269,8 +1427,7 @@ mod tests {
     #[test]
     fn local_control_cancellation_unblocks_response_read() {
         let (local_stream, _host_stream) = UnixStream::pair().unwrap();
-        let mut channel = UnixStreamLocalControlChannel::from_connected(local_stream);
-        let cancellation = channel.activate(|| {}).unwrap();
+        let (channel, cancellation) = activate_test_channel(local_stream, || {});
         let completed = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
         let (started_sender, started_receiver) = std::sync::mpsc::sync_channel(1);
         let (result_sender, result_receiver) = std::sync::mpsc::sync_channel(1);
@@ -1302,8 +1459,7 @@ mod tests {
     #[test]
     fn dropping_local_control_closes_connection_with_cancellation_clone() {
         let (local_stream, mut host_stream) = UnixStream::pair().unwrap();
-        let mut channel = UnixStreamLocalControlChannel::from_connected(local_stream);
-        let _cancellation = channel.activate(|| {}).unwrap();
+        let (channel, _cancellation) = activate_test_channel(local_stream, || {});
         host_stream
             .set_read_timeout(Some(Duration::from_secs(1)))
             .unwrap();

--- a/litebox_broker_transport/src/unix_socket.rs
+++ b/litebox_broker_transport/src/unix_socket.rs
@@ -173,7 +173,7 @@ impl UnixStreamLocalControlChannel {
         thread::Builder::new()
             .name("litebox-broker-responses".to_owned())
             .spawn(move || {
-                response_pump(
+                dispatch_responses(
                     response_stream,
                     response_cancellation,
                     response_pending_calls,
@@ -571,7 +571,7 @@ impl PendingCalls {
     }
 }
 
-fn response_pump(
+fn dispatch_responses(
     mut response_stream: UnixStream,
     response_cancellation: UnixStream,
     pending_calls: Arc<PendingCalls>,

--- a/litebox_broker_userland/tests/notification_runtime.rs
+++ b/litebox_broker_userland/tests/notification_runtime.rs
@@ -36,11 +36,12 @@ fn host_serves_control_requests_over_paired_userland_channels() {
         )
     });
 
-    let mut local = BrokerLocal::negotiate(
+    let local = BrokerLocal::negotiate(
         UnixStreamLocalControlChannel::from_connected(local_control),
-        |channel| {
+        |mut channel| {
             let shared_memory = channel.receive_memfd(PIPE_TRANSFER_BUFFER_SIZE, None)?;
-            Ok(Arc::new(shared_memory))
+            let (channel, _cancellation) = channel.activate(|| {})?;
+            Ok((Arc::new(shared_memory), channel))
         },
     )
     .unwrap();

--- a/litebox_broker_userland/tests/notification_runtime.rs
+++ b/litebox_broker_userland/tests/notification_runtime.rs
@@ -38,10 +38,10 @@ fn host_serves_control_requests_over_paired_userland_channels() {
 
     let local = BrokerLocal::negotiate(
         UnixStreamLocalControlChannel::from_connected(local_control),
-        |mut channel| {
+        |channel| {
             let shared_memory = channel.receive_memfd(PIPE_TRANSFER_BUFFER_SIZE, None)?;
-            let (channel, _cancellation) = channel.activate(|| {})?;
-            Ok((Arc::new(shared_memory), channel))
+            let _cancellation = channel.activate(|| {})?;
+            Ok(Arc::new(shared_memory))
         },
     )
     .unwrap();

--- a/litebox_broker_userland/tests/userland_broker.rs
+++ b/litebox_broker_userland/tests/userland_broker.rs
@@ -82,12 +82,13 @@ fn run_fake_runner(args: &[OsString]) {
     let control_channel = connect_control_with_retry(Path::new(control_socket_path)).unwrap();
     let _notification_channel =
         connect_notification_with_retry(Path::new(notification_socket_path)).unwrap();
-    let mut local = BrokerLocal::negotiate(control_channel, |channel| {
+    let local = BrokerLocal::negotiate(control_channel, |mut channel| {
         let shared_memory = channel.receive_memfd(
             PIPE_TRANSFER_BUFFER_SIZE,
             Some(Instant::now() + Duration::from_secs(5)),
         )?;
-        Ok(Arc::new(shared_memory))
+        let (channel, _cancellation) = channel.activate(|| {})?;
+        Ok((Arc::new(shared_memory), channel))
     })
     .unwrap();
 

--- a/litebox_broker_userland/tests/userland_broker.rs
+++ b/litebox_broker_userland/tests/userland_broker.rs
@@ -82,13 +82,13 @@ fn run_fake_runner(args: &[OsString]) {
     let control_channel = connect_control_with_retry(Path::new(control_socket_path)).unwrap();
     let _notification_channel =
         connect_notification_with_retry(Path::new(notification_socket_path)).unwrap();
-    let local = BrokerLocal::negotiate(control_channel, |mut channel| {
+    let local = BrokerLocal::negotiate(control_channel, |channel| {
         let shared_memory = channel.receive_memfd(
             PIPE_TRANSFER_BUFFER_SIZE,
             Some(Instant::now() + Duration::from_secs(5)),
         )?;
-        let (channel, _cancellation) = channel.activate(|| {})?;
-        Ok((Arc::new(shared_memory), channel))
+        let _cancellation = channel.activate(|| {})?;
+        Ok(Arc::new(shared_memory))
     })
     .unwrap();
 

--- a/litebox_runner_linux_userland/src/broker.rs
+++ b/litebox_runner_linux_userland/src/broker.rs
@@ -219,9 +219,38 @@ mod tests {
     use std::os::unix::net::UnixStream;
     use std::sync::mpsc;
 
+    fn negotiate_control_pair(
+        local_stream: UnixStream,
+        host_stream: UnixStream,
+    ) -> (UnixStreamLocalControlChannel, UnixStreamHostControlChannel) {
+        let mut local = UnixStreamLocalControlChannel::from_connected(local_stream);
+        let mut host = UnixStreamHostControlChannel::from_accepted(host_stream);
+        let request = litebox_broker_protocol::message::BrokerHandshakeRequest {
+            protocol_version: litebox_broker_protocol::BROKER_PROTOCOL_VERSION,
+        };
+        local.send_handshake_request(&request).unwrap();
+        assert_eq!(
+            host.recv_handshake_request().unwrap(),
+            HostReceive::Message(request)
+        );
+        host.send_handshake_response(
+            &litebox_broker_protocol::message::BrokerHandshakeResponse::Negotiated {
+                broker_protocol_version: litebox_broker_protocol::BROKER_PROTOCOL_VERSION,
+            },
+        )
+        .unwrap();
+        assert!(matches!(
+            local.recv_handshake_response().unwrap(),
+            Some(litebox_broker_protocol::message::BrokerHandshakeResponse::Negotiated { .. })
+        ));
+        (local, host)
+    }
+
     #[test]
     fn control_failure_cancels_notifications() {
         let (local_control, host_control) = UnixStream::pair().unwrap();
+        let (mut active_channel, host_control) =
+            negotiate_control_pair(local_control, host_control);
         let (local_notification, mut host_notification) = UnixStream::pair().unwrap();
         host_notification
             .set_read_timeout(Some(Duration::from_secs(1)))
@@ -232,7 +261,6 @@ mod tests {
             notification_channel.cancellation_handle().unwrap(),
         ));
         let response_failure = Arc::downgrade(&association_failure);
-        let mut active_channel = UnixStreamLocalControlChannel::from_connected(local_control);
         let control_cancellation = active_channel
             .activate(move || {
                 if let Some(response_failure) = response_failure.upgrade() {
@@ -260,15 +288,15 @@ mod tests {
     #[test]
     fn notification_failure_cancels_control() {
         let (local_control, host_control) = UnixStream::pair().unwrap();
+        let (mut active_channel, mut host_control) =
+            negotiate_control_pair(local_control, host_control);
         let (local_notification, host_notification) = UnixStream::pair().unwrap();
-        let mut host_control = UnixStreamHostControlChannel::from_accepted(host_control);
         let notification_channel =
             UnixStreamLocalNotificationChannel::from_connected(local_notification);
         let association_failure = Arc::new(BrokerAssociationFailure::new(
             notification_channel.cancellation_handle().unwrap(),
         ));
         let response_failure = Arc::downgrade(&association_failure);
-        let mut active_channel = UnixStreamLocalControlChannel::from_connected(local_control);
         let control_cancellation = active_channel
             .activate(move || {
                 if let Some(response_failure) = response_failure.upgrade() {

--- a/litebox_runner_linux_userland/src/broker.rs
+++ b/litebox_runner_linux_userland/src/broker.rs
@@ -28,7 +28,7 @@ pub(crate) fn connect(
 ) -> Result<(
     BrokerLocal<UnixStreamLocalControlChannel>,
     BrokerNotifications<UnixStreamLocalNotificationChannel>,
-    Arc<BrokerAssociationState>,
+    Arc<BrokerAssociationFailureCoordinator>,
 )> {
     let setup_deadline = Instant::now() + SETUP_TIMEOUT;
     let control_channel = connect_with_retry(
@@ -58,21 +58,22 @@ pub(crate) fn connect(
     let notification_cancellation_handle = notification_channel
         .cancellation_handle()
         .context("failed to create broker notification cancellation handle")?;
-    let association_state = Arc::new(BrokerAssociationState::new(
+    let association_coordinator = Arc::new(BrokerAssociationFailureCoordinator::new(
         notification_cancellation_handle,
     ));
     let local = BrokerLocal::negotiate(control_channel, {
-        let association_state = Arc::clone(&association_state);
+        let association_coordinator = Arc::clone(&association_coordinator);
         move |channel| {
             let shared_memory =
                 channel.receive_memfd(PIPE_TRANSFER_BUFFER_SIZE, Some(setup_deadline))?;
-            let weak_association_state = Arc::downgrade(&association_state);
+            let weak_association_coordinator = Arc::downgrade(&association_coordinator);
             let control_cancellation_handle = channel.activate(move || {
-                if let Some(association_state) = weak_association_state.upgrade() {
-                    association_state.fail();
+                if let Some(association_coordinator) = weak_association_coordinator.upgrade() {
+                    association_coordinator.fail();
                 }
             })?;
-            association_state.install_control_cancellation_handle(control_cancellation_handle)?;
+            association_coordinator
+                .install_control_cancellation_handle(control_cancellation_handle)?;
             Ok(Arc::new(shared_memory))
         }
     })
@@ -80,13 +81,13 @@ pub(crate) fn connect(
     Ok((
         local,
         BrokerNotifications::new(notification_channel),
-        association_state,
+        association_coordinator,
     ))
 }
 
 pub(crate) fn start_notification_receiver(
     mut notifications: BrokerNotifications<UnixStreamLocalNotificationChannel>,
-    association_state: Arc<BrokerAssociationState>,
+    association_coordinator: Arc<BrokerAssociationFailureCoordinator>,
     dispatch_notification: impl Fn(BrokerNotification) + Send + 'static,
 ) -> Result<()> {
     std::thread::Builder::new()
@@ -99,7 +100,7 @@ pub(crate) fn start_notification_receiver(
                     Err(error) => break Some(error),
                 }
             };
-            association_state.fail();
+            association_coordinator.fail();
             if let Some(error) = receive_error {
                 eprintln!("failed to receive broker notification: {error}");
             }
@@ -108,14 +109,14 @@ pub(crate) fn start_notification_receiver(
     Ok(())
 }
 
-pub(crate) struct BrokerAssociationState {
+pub(crate) struct BrokerAssociationFailureCoordinator {
     failed: AtomicBool,
     control_cancellation_handle: Mutex<Option<UnixStreamLocalControlCancellation>>,
     notification_cancellation_handle: UnixStreamLocalNotificationCancellation,
     dispatch_failure: Mutex<Option<Box<dyn FnOnce() + Send>>>,
 }
 
-impl BrokerAssociationState {
+impl BrokerAssociationFailureCoordinator {
     fn new(notification_cancellation_handle: UnixStreamLocalNotificationCancellation) -> Self {
         Self {
             failed: AtomicBool::new(false),
@@ -261,22 +262,22 @@ mod tests {
             .unwrap();
         let notification_channel =
             UnixStreamLocalNotificationChannel::from_connected(local_notification);
-        let association_state = Arc::new(BrokerAssociationState::new(
+        let association_coordinator = Arc::new(BrokerAssociationFailureCoordinator::new(
             notification_channel.cancellation_handle().unwrap(),
         ));
-        let weak_association_state = Arc::downgrade(&association_state);
+        let weak_association_coordinator = Arc::downgrade(&association_coordinator);
         let control_cancellation_handle = active_channel
             .activate(move || {
-                if let Some(association_state) = weak_association_state.upgrade() {
-                    association_state.fail();
+                if let Some(association_coordinator) = weak_association_coordinator.upgrade() {
+                    association_coordinator.fail();
                 }
             })
             .unwrap();
-        association_state
+        association_coordinator
             .install_control_cancellation_handle(control_cancellation_handle)
             .unwrap();
         let (failure_sender, failure_receiver) = mpsc::sync_channel(1);
-        association_state.install_dispatch(move || failure_sender.send(()).unwrap());
+        association_coordinator.install_dispatch(move || failure_sender.send(()).unwrap());
 
         drop(host_control);
 
@@ -297,25 +298,25 @@ mod tests {
         let (local_notification, host_notification) = UnixStream::pair().unwrap();
         let notification_channel =
             UnixStreamLocalNotificationChannel::from_connected(local_notification);
-        let association_state = Arc::new(BrokerAssociationState::new(
+        let association_coordinator = Arc::new(BrokerAssociationFailureCoordinator::new(
             notification_channel.cancellation_handle().unwrap(),
         ));
-        let weak_association_state = Arc::downgrade(&association_state);
+        let weak_association_coordinator = Arc::downgrade(&association_coordinator);
         let control_cancellation_handle = active_channel
             .activate(move || {
-                if let Some(association_state) = weak_association_state.upgrade() {
-                    association_state.fail();
+                if let Some(association_coordinator) = weak_association_coordinator.upgrade() {
+                    association_coordinator.fail();
                 }
             })
             .unwrap();
-        association_state
+        association_coordinator
             .install_control_cancellation_handle(control_cancellation_handle)
             .unwrap();
         let (failure_sender, failure_receiver) = mpsc::sync_channel(1);
-        association_state.install_dispatch(move || failure_sender.send(()).unwrap());
+        association_coordinator.install_dispatch(move || failure_sender.send(()).unwrap());
         start_notification_receiver(
             BrokerNotifications::new(notification_channel),
-            Arc::clone(&association_state),
+            Arc::clone(&association_coordinator),
             |_| {},
         )
         .unwrap();

--- a/litebox_runner_linux_userland/src/broker.rs
+++ b/litebox_runner_linux_userland/src/broker.rs
@@ -69,7 +69,7 @@ pub(crate) fn connect(
             let weak_association_coordinator = Arc::downgrade(&association_coordinator);
             let control_cancellation_handle = channel.activate(move || {
                 if let Some(association_coordinator) = weak_association_coordinator.upgrade() {
-                    association_coordinator.fail();
+                    association_coordinator.report_failure();
                 }
             })?;
             association_coordinator
@@ -100,7 +100,7 @@ pub(crate) fn start_notification_receiver(
                     Err(error) => break Some(error),
                 }
             };
-            association_coordinator.fail();
+            association_coordinator.report_failure();
             if let Some(error) = receive_error {
                 eprintln!("failed to receive broker notification: {error}");
             }
@@ -166,7 +166,7 @@ impl BrokerAssociationFailureCoordinator {
         }
     }
 
-    fn fail(&self) {
+    fn report_failure(&self) {
         if self.failed.swap(true, Ordering::AcqRel) {
             return;
         }
@@ -269,7 +269,7 @@ mod tests {
         let control_cancellation_handle = active_channel
             .activate(move || {
                 if let Some(association_coordinator) = weak_association_coordinator.upgrade() {
-                    association_coordinator.fail();
+                    association_coordinator.report_failure();
                 }
             })
             .unwrap();
@@ -305,7 +305,7 @@ mod tests {
         let control_cancellation_handle = active_channel
             .activate(move || {
                 if let Some(association_coordinator) = weak_association_coordinator.upgrade() {
-                    association_coordinator.fail();
+                    association_coordinator.report_failure();
                 }
             })
             .unwrap();

--- a/litebox_runner_linux_userland/src/broker.rs
+++ b/litebox_runner_linux_userland/src/broker.rs
@@ -55,22 +55,24 @@ pub(crate) fn connect(
             notification_socket_path.display()
         )
     })?;
-    let notification_cancellation = notification_channel
+    let notification_cancellation_handle = notification_channel
         .cancellation_handle()
         .context("failed to create broker notification cancellation handle")?;
-    let association_state = Arc::new(BrokerAssociationState::new(notification_cancellation));
+    let association_state = Arc::new(BrokerAssociationState::new(
+        notification_cancellation_handle,
+    ));
     let local = BrokerLocal::negotiate(control_channel, {
         let association_state = Arc::clone(&association_state);
         move |channel| {
             let shared_memory =
                 channel.receive_memfd(PIPE_TRANSFER_BUFFER_SIZE, Some(setup_deadline))?;
             let weak_association_state = Arc::downgrade(&association_state);
-            let control_cancellation = channel.activate(move || {
+            let control_cancellation_handle = channel.activate(move || {
                 if let Some(association_state) = weak_association_state.upgrade() {
                     association_state.fail();
                 }
             })?;
-            association_state.install_control(control_cancellation)?;
+            association_state.install_control_cancellation_handle(control_cancellation_handle)?;
             Ok(Arc::new(shared_memory))
         }
     })
@@ -108,27 +110,27 @@ pub(crate) fn start_notification_receiver(
 
 pub(crate) struct BrokerAssociationState {
     failed: AtomicBool,
-    control_cancellation: Mutex<Option<UnixStreamLocalControlCancellation>>,
-    notification_cancellation: UnixStreamLocalNotificationCancellation,
+    control_cancellation_handle: Mutex<Option<UnixStreamLocalControlCancellation>>,
+    notification_cancellation_handle: UnixStreamLocalNotificationCancellation,
     dispatch_failure: Mutex<Option<Box<dyn FnOnce() + Send>>>,
 }
 
 impl BrokerAssociationState {
-    fn new(notification_cancellation: UnixStreamLocalNotificationCancellation) -> Self {
+    fn new(notification_cancellation_handle: UnixStreamLocalNotificationCancellation) -> Self {
         Self {
             failed: AtomicBool::new(false),
-            control_cancellation: Mutex::new(None),
-            notification_cancellation,
+            control_cancellation_handle: Mutex::new(None),
+            notification_cancellation_handle,
             dispatch_failure: Mutex::new(None),
         }
     }
 
-    fn install_control(
+    fn install_control_cancellation_handle(
         &self,
-        control_cancellation: UnixStreamLocalControlCancellation,
+        control_cancellation_handle: UnixStreamLocalControlCancellation,
     ) -> std::io::Result<()> {
         let mut installed = self
-            .control_cancellation
+            .control_cancellation_handle
             .lock()
             .expect("broker control cancellation mutex poisoned");
         assert!(
@@ -136,13 +138,13 @@ impl BrokerAssociationState {
             "broker control cancellation already installed"
         );
         if self.failed.load(Ordering::Acquire) {
-            control_cancellation.cancel()?;
+            control_cancellation_handle.cancel()?;
             return Err(std::io::Error::new(
                 std::io::ErrorKind::ConnectionAborted,
                 "broker association failed during activation",
             ));
         }
-        *installed = Some(control_cancellation);
+        *installed = Some(control_cancellation_handle);
         Ok(())
     }
 
@@ -167,16 +169,16 @@ impl BrokerAssociationState {
         if self.failed.swap(true, Ordering::AcqRel) {
             return;
         }
-        if let Some(cancellation) = self
-            .control_cancellation
+        if let Some(cancellation_handle) = self
+            .control_cancellation_handle
             .lock()
             .expect("broker control cancellation mutex poisoned")
             .as_ref()
-            && let Err(error) = cancellation.cancel()
+            && let Err(error) = cancellation_handle.cancel()
         {
             eprintln!("failed to cancel broker control channel: {error}");
         }
-        if let Err(error) = self.notification_cancellation.cancel() {
+        if let Err(error) = self.notification_cancellation_handle.cancel() {
             eprintln!("failed to cancel broker notification channel: {error}");
         }
         let dispatch_failure = self
@@ -263,7 +265,7 @@ mod tests {
             notification_channel.cancellation_handle().unwrap(),
         ));
         let weak_association_state = Arc::downgrade(&association_state);
-        let control_cancellation = active_channel
+        let control_cancellation_handle = active_channel
             .activate(move || {
                 if let Some(association_state) = weak_association_state.upgrade() {
                     association_state.fail();
@@ -271,7 +273,7 @@ mod tests {
             })
             .unwrap();
         association_state
-            .install_control(control_cancellation)
+            .install_control_cancellation_handle(control_cancellation_handle)
             .unwrap();
         let (failure_sender, failure_receiver) = mpsc::sync_channel(1);
         association_state.install_dispatch(move || failure_sender.send(()).unwrap());
@@ -299,7 +301,7 @@ mod tests {
             notification_channel.cancellation_handle().unwrap(),
         ));
         let weak_association_state = Arc::downgrade(&association_state);
-        let control_cancellation = active_channel
+        let control_cancellation_handle = active_channel
             .activate(move || {
                 if let Some(association_state) = weak_association_state.upgrade() {
                     association_state.fail();
@@ -307,7 +309,7 @@ mod tests {
             })
             .unwrap();
         association_state
-            .install_control(control_cancellation)
+            .install_control_cancellation_handle(control_cancellation_handle)
             .unwrap();
         let (failure_sender, failure_receiver) = mpsc::sync_channel(1);
         association_state.install_dispatch(move || failure_sender.send(()).unwrap());

--- a/litebox_runner_linux_userland/src/broker.rs
+++ b/litebox_runner_linux_userland/src/broker.rs
@@ -220,7 +220,7 @@ mod tests {
     use litebox_broker_protocol::message::{BrokerOperation, BrokerRequest};
     use litebox_broker_protocol::{ObjectHandle, RequestId};
     use litebox_broker_transport::unix_socket::UnixStreamHostControlChannel;
-    use std::io::Read;
+    use std::io::{ErrorKind, Read};
     use std::os::unix::net::UnixStream;
     use std::sync::mpsc;
 
@@ -251,6 +251,20 @@ mod tests {
         (local, host)
     }
 
+    fn activate_control_channel(
+        channel: &mut UnixStreamLocalControlChannel,
+        association_coordinator: &Arc<BrokerAssociationFailureCoordinator>,
+    ) -> UnixStreamLocalControlCancellation {
+        let weak_association_coordinator = Arc::downgrade(association_coordinator);
+        channel
+            .activate(move || {
+                if let Some(association_coordinator) = weak_association_coordinator.upgrade() {
+                    association_coordinator.report_failure();
+                }
+            })
+            .unwrap()
+    }
+
     #[test]
     fn control_failure_cancels_notifications() {
         let (local_control, host_control) = UnixStream::pair().unwrap();
@@ -265,14 +279,8 @@ mod tests {
         let association_coordinator = Arc::new(BrokerAssociationFailureCoordinator::new(
             notification_channel.cancellation_handle().unwrap(),
         ));
-        let weak_association_coordinator = Arc::downgrade(&association_coordinator);
-        let control_cancellation_handle = active_channel
-            .activate(move || {
-                if let Some(association_coordinator) = weak_association_coordinator.upgrade() {
-                    association_coordinator.report_failure();
-                }
-            })
-            .unwrap();
+        let control_cancellation_handle =
+            activate_control_channel(&mut active_channel, &association_coordinator);
         association_coordinator
             .install_control_cancellation_handle(control_cancellation_handle)
             .unwrap();
@@ -291,6 +299,48 @@ mod tests {
     }
 
     #[test]
+    fn failure_before_installation_cancels_control_and_dispatches_failure() {
+        let (local_control, host_control) = UnixStream::pair().unwrap();
+        host_control
+            .set_read_timeout(Some(Duration::from_secs(1)))
+            .unwrap();
+        let (mut active_channel, mut host_control) =
+            negotiate_control_pair(local_control, host_control);
+        let (local_notification, mut host_notification) = UnixStream::pair().unwrap();
+        host_notification
+            .set_read_timeout(Some(Duration::from_secs(1)))
+            .unwrap();
+        let notification_channel =
+            UnixStreamLocalNotificationChannel::from_connected(local_notification);
+        let association_coordinator = Arc::new(BrokerAssociationFailureCoordinator::new(
+            notification_channel.cancellation_handle().unwrap(),
+        ));
+        let control_cancellation_handle =
+            activate_control_channel(&mut active_channel, &association_coordinator);
+
+        association_coordinator.report_failure();
+
+        assert_eq!(
+            association_coordinator
+                .install_control_cancellation_handle(control_cancellation_handle)
+                .unwrap_err()
+                .kind(),
+            ErrorKind::ConnectionAborted
+        );
+        let (failure_sender, failure_receiver) = mpsc::sync_channel(1);
+        association_coordinator.install_dispatch(move || failure_sender.send(()).unwrap());
+        failure_receiver.try_recv().unwrap();
+        assert_eq!(
+            host_control.recv_request().unwrap(),
+            HostReceive::PeerClosed
+        );
+        let mut byte = [0];
+        assert_eq!(host_notification.read(&mut byte).unwrap(), 0);
+        drop(active_channel);
+        drop(notification_channel);
+    }
+
+    #[test]
     fn notification_failure_cancels_control() {
         let (local_control, host_control) = UnixStream::pair().unwrap();
         let (mut active_channel, mut host_control) =
@@ -301,14 +351,8 @@ mod tests {
         let association_coordinator = Arc::new(BrokerAssociationFailureCoordinator::new(
             notification_channel.cancellation_handle().unwrap(),
         ));
-        let weak_association_coordinator = Arc::downgrade(&association_coordinator);
-        let control_cancellation_handle = active_channel
-            .activate(move || {
-                if let Some(association_coordinator) = weak_association_coordinator.upgrade() {
-                    association_coordinator.report_failure();
-                }
-            })
-            .unwrap();
+        let control_cancellation_handle =
+            activate_control_channel(&mut active_channel, &association_coordinator);
         association_coordinator
             .install_control_cancellation_handle(control_cancellation_handle)
             .unwrap();

--- a/litebox_runner_linux_userland/src/broker.rs
+++ b/litebox_runner_linux_userland/src/broker.rs
@@ -15,7 +15,7 @@ use litebox_broker_local::{BrokerLocal, BrokerNotifications};
 use litebox_broker_protocol::message::BrokerNotification;
 use litebox_broker_protocol::pipe::PIPE_TRANSFER_BUFFER_SIZE;
 use litebox_broker_transport::unix_socket::{
-    UnixStreamLocalCallChannel, UnixStreamLocalControlCancellation, UnixStreamLocalControlChannel,
+    UnixStreamLocalControlCancellation, UnixStreamLocalControlChannel,
     UnixStreamLocalNotificationCancellation, UnixStreamLocalNotificationChannel,
 };
 
@@ -26,7 +26,7 @@ pub(crate) fn connect(
     control_socket_path: &Path,
     notification_socket_path: &Path,
 ) -> Result<(
-    BrokerLocal<UnixStreamLocalCallChannel>,
+    BrokerLocal<UnixStreamLocalControlChannel>,
     BrokerNotifications<UnixStreamLocalNotificationChannel>,
     Arc<BrokerAssociationFailure>,
 )> {
@@ -60,17 +60,17 @@ pub(crate) fn connect(
         .context("failed to create broker notification cancellation handle")?;
     let association_failure = Arc::new(BrokerAssociationFailure::new(notification_cancellation));
     let activation_failure = Arc::clone(&association_failure);
-    let local = BrokerLocal::negotiate(control_channel, move |mut channel| {
+    let local = BrokerLocal::negotiate(control_channel, move |channel| {
         let shared_memory =
             channel.receive_memfd(PIPE_TRANSFER_BUFFER_SIZE, Some(setup_deadline))?;
         let response_failure = Arc::downgrade(&activation_failure);
-        let (channel, control_cancellation) = channel.activate(move || {
+        let control_cancellation = channel.activate(move || {
             if let Some(response_failure) = response_failure.upgrade() {
                 response_failure.fail();
             }
         })?;
         activation_failure.install_control(control_cancellation)?;
-        Ok((Arc::new(shared_memory), channel))
+        Ok(Arc::new(shared_memory))
     })
     .context("broker negotiation failed")?;
     Ok((
@@ -211,7 +211,7 @@ fn connect_with_retry<Channel>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use litebox_broker_protocol::channel::{HostControlChannel, HostReceive, LocalCallChannel};
+    use litebox_broker_protocol::channel::{HostControlChannel, HostReceive, LocalControlChannel};
     use litebox_broker_protocol::message::{BrokerOperation, BrokerRequest};
     use litebox_broker_protocol::{ObjectHandle, RequestId};
     use litebox_broker_transport::unix_socket::UnixStreamHostControlChannel;
@@ -232,14 +232,14 @@ mod tests {
             notification_channel.cancellation_handle().unwrap(),
         ));
         let response_failure = Arc::downgrade(&association_failure);
-        let (active_channel, control_cancellation) =
-            UnixStreamLocalControlChannel::from_connected(local_control)
-                .activate(move || {
-                    if let Some(response_failure) = response_failure.upgrade() {
-                        response_failure.fail();
-                    }
-                })
-                .unwrap();
+        let mut active_channel = UnixStreamLocalControlChannel::from_connected(local_control);
+        let control_cancellation = active_channel
+            .activate(move || {
+                if let Some(response_failure) = response_failure.upgrade() {
+                    response_failure.fail();
+                }
+            })
+            .unwrap();
         association_failure
             .install_control(control_cancellation)
             .unwrap();
@@ -268,14 +268,14 @@ mod tests {
             notification_channel.cancellation_handle().unwrap(),
         ));
         let response_failure = Arc::downgrade(&association_failure);
-        let (active_channel, control_cancellation) =
-            UnixStreamLocalControlChannel::from_connected(local_control)
-                .activate(move || {
-                    if let Some(response_failure) = response_failure.upgrade() {
-                        response_failure.fail();
-                    }
-                })
-                .unwrap();
+        let mut active_channel = UnixStreamLocalControlChannel::from_connected(local_control);
+        let control_cancellation = active_channel
+            .activate(move || {
+                if let Some(response_failure) = response_failure.upgrade() {
+                    response_failure.fail();
+                }
+            })
+            .unwrap();
         association_failure
             .install_control(control_cancellation)
             .unwrap();

--- a/litebox_runner_linux_userland/src/broker.rs
+++ b/litebox_runner_linux_userland/src/broker.rs
@@ -3,7 +3,10 @@
 
 use std::{
     path::Path,
-    sync::Arc,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, Ordering},
+    },
     time::{Duration, Instant},
 };
 
@@ -12,8 +15,8 @@ use litebox_broker_local::{BrokerLocal, BrokerNotifications};
 use litebox_broker_protocol::message::BrokerNotification;
 use litebox_broker_protocol::pipe::PIPE_TRANSFER_BUFFER_SIZE;
 use litebox_broker_transport::unix_socket::{
-    UnixStreamLocalControlCancellation, UnixStreamLocalControlChannel,
-    UnixStreamLocalNotificationChannel,
+    UnixStreamLocalCallChannel, UnixStreamLocalControlCancellation, UnixStreamLocalControlChannel,
+    UnixStreamLocalNotificationCancellation, UnixStreamLocalNotificationChannel,
 };
 
 const SETUP_TIMEOUT: Duration = Duration::from_secs(5);
@@ -23,9 +26,9 @@ pub(crate) fn connect(
     control_socket_path: &Path,
     notification_socket_path: &Path,
 ) -> Result<(
-    BrokerLocal<UnixStreamLocalControlChannel>,
+    BrokerLocal<UnixStreamLocalCallChannel>,
     BrokerNotifications<UnixStreamLocalNotificationChannel>,
-    UnixStreamLocalControlCancellation,
+    Arc<BrokerAssociationFailure>,
 )> {
     let setup_deadline = Instant::now() + SETUP_TIMEOUT;
     let control_channel = connect_with_retry(
@@ -52,27 +55,35 @@ pub(crate) fn connect(
             notification_socket_path.display()
         )
     })?;
-    let control_cancellation = control_channel
+    let notification_cancellation = notification_channel
         .cancellation_handle()
-        .context("failed to create broker control cancellation handle")?;
-    let local = BrokerLocal::negotiate(control_channel, |channel| {
+        .context("failed to create broker notification cancellation handle")?;
+    let association_failure = Arc::new(BrokerAssociationFailure::new(notification_cancellation));
+    let activation_failure = Arc::clone(&association_failure);
+    let local = BrokerLocal::negotiate(control_channel, move |mut channel| {
         let shared_memory =
             channel.receive_memfd(PIPE_TRANSFER_BUFFER_SIZE, Some(setup_deadline))?;
-        Ok(Arc::new(shared_memory))
+        let response_failure = Arc::downgrade(&activation_failure);
+        let (channel, control_cancellation) = channel.activate(move || {
+            if let Some(response_failure) = response_failure.upgrade() {
+                response_failure.fail();
+            }
+        })?;
+        activation_failure.install_control(control_cancellation)?;
+        Ok((Arc::new(shared_memory), channel))
     })
     .context("broker negotiation failed")?;
     Ok((
         local,
         BrokerNotifications::new(notification_channel),
-        control_cancellation,
+        association_failure,
     ))
 }
 
 pub(crate) fn start_notification_receiver(
     mut notifications: BrokerNotifications<UnixStreamLocalNotificationChannel>,
-    control_cancellation: UnixStreamLocalControlCancellation,
+    association_failure: Arc<BrokerAssociationFailure>,
     dispatch_notification: impl Fn(BrokerNotification) + Send + 'static,
-    dispatch_failure: impl Fn() + Send + 'static,
 ) -> Result<()> {
     std::thread::Builder::new()
         .name("litebox-broker-notifications".to_owned())
@@ -84,17 +95,97 @@ pub(crate) fn start_notification_receiver(
                     Err(error) => break Some(error),
                 }
             };
-            let cancellation_error = control_cancellation.cancel().err();
-            dispatch_failure();
+            association_failure.fail();
             if let Some(error) = receive_error {
                 eprintln!("failed to receive broker notification: {error}");
-            }
-            if let Some(error) = cancellation_error {
-                eprintln!("failed to cancel broker control channel: {error}");
             }
         })
         .context("failed to start broker notification receiver")?;
     Ok(())
+}
+
+pub(crate) struct BrokerAssociationFailure {
+    failed: AtomicBool,
+    control_cancellation: Mutex<Option<UnixStreamLocalControlCancellation>>,
+    notification_cancellation: UnixStreamLocalNotificationCancellation,
+    dispatch_failure: Mutex<Option<Box<dyn FnOnce() + Send>>>,
+}
+
+impl BrokerAssociationFailure {
+    fn new(notification_cancellation: UnixStreamLocalNotificationCancellation) -> Self {
+        Self {
+            failed: AtomicBool::new(false),
+            control_cancellation: Mutex::new(None),
+            notification_cancellation,
+            dispatch_failure: Mutex::new(None),
+        }
+    }
+
+    fn install_control(
+        &self,
+        control_cancellation: UnixStreamLocalControlCancellation,
+    ) -> std::io::Result<()> {
+        let mut installed = self
+            .control_cancellation
+            .lock()
+            .expect("broker control cancellation mutex poisoned");
+        assert!(
+            installed.is_none(),
+            "broker control cancellation already installed"
+        );
+        if self.failed.load(Ordering::Acquire) {
+            control_cancellation.cancel()?;
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::ConnectionAborted,
+                "broker association failed during activation",
+            ));
+        }
+        *installed = Some(control_cancellation);
+        Ok(())
+    }
+
+    pub(crate) fn install_dispatch(&self, dispatch_failure: impl FnOnce() + Send + 'static) {
+        let mut installed = self
+            .dispatch_failure
+            .lock()
+            .expect("broker failure dispatch mutex poisoned");
+        assert!(
+            installed.is_none(),
+            "broker failure dispatch already installed"
+        );
+        if self.failed.load(Ordering::Acquire) {
+            drop(installed);
+            dispatch_failure();
+        } else {
+            *installed = Some(Box::new(dispatch_failure));
+        }
+    }
+
+    fn fail(&self) {
+        if self.failed.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        if let Some(cancellation) = self
+            .control_cancellation
+            .lock()
+            .expect("broker control cancellation mutex poisoned")
+            .as_ref()
+            && let Err(error) = cancellation.cancel()
+        {
+            eprintln!("failed to cancel broker control channel: {error}");
+        }
+        if let Err(error) = self.notification_cancellation.cancel() {
+            eprintln!("failed to cancel broker notification channel: {error}");
+        }
+        let dispatch_failure = self
+            .dispatch_failure
+            .lock()
+            .expect("broker failure dispatch mutex poisoned")
+            .take();
+        if let Some(dispatch_failure) = dispatch_failure {
+            dispatch_failure();
+        }
+    }
 }
 
 fn connect_with_retry<Channel>(
@@ -114,5 +205,110 @@ fn connect_with_retry<Channel>(
         }
         let remaining = setup_deadline.saturating_duration_since(Instant::now());
         std::thread::sleep(RETRY_DELAY.min(remaining));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use litebox_broker_protocol::channel::{HostControlChannel, HostReceive, LocalCallChannel};
+    use litebox_broker_protocol::message::{BrokerOperation, BrokerRequest};
+    use litebox_broker_protocol::{ObjectHandle, RequestId};
+    use litebox_broker_transport::unix_socket::UnixStreamHostControlChannel;
+    use std::io::Read;
+    use std::os::unix::net::UnixStream;
+    use std::sync::mpsc;
+
+    #[test]
+    fn control_failure_cancels_notifications() {
+        let (local_control, host_control) = UnixStream::pair().unwrap();
+        let (local_notification, mut host_notification) = UnixStream::pair().unwrap();
+        host_notification
+            .set_read_timeout(Some(Duration::from_secs(1)))
+            .unwrap();
+        let notification_channel =
+            UnixStreamLocalNotificationChannel::from_connected(local_notification);
+        let association_failure = Arc::new(BrokerAssociationFailure::new(
+            notification_channel.cancellation_handle().unwrap(),
+        ));
+        let response_failure = Arc::downgrade(&association_failure);
+        let (active_channel, control_cancellation) =
+            UnixStreamLocalControlChannel::from_connected(local_control)
+                .activate(move || {
+                    if let Some(response_failure) = response_failure.upgrade() {
+                        response_failure.fail();
+                    }
+                })
+                .unwrap();
+        association_failure
+            .install_control(control_cancellation)
+            .unwrap();
+        let (failure_sender, failure_receiver) = mpsc::sync_channel(1);
+        association_failure.install_dispatch(move || failure_sender.send(()).unwrap());
+
+        drop(host_control);
+
+        failure_receiver
+            .recv_timeout(Duration::from_secs(1))
+            .unwrap();
+        let mut byte = [0];
+        assert_eq!(host_notification.read(&mut byte).unwrap(), 0);
+        drop(active_channel);
+        drop(notification_channel);
+    }
+
+    #[test]
+    fn notification_failure_cancels_control() {
+        let (local_control, host_control) = UnixStream::pair().unwrap();
+        let (local_notification, host_notification) = UnixStream::pair().unwrap();
+        let mut host_control = UnixStreamHostControlChannel::from_accepted(host_control);
+        let notification_channel =
+            UnixStreamLocalNotificationChannel::from_connected(local_notification);
+        let association_failure = Arc::new(BrokerAssociationFailure::new(
+            notification_channel.cancellation_handle().unwrap(),
+        ));
+        let response_failure = Arc::downgrade(&association_failure);
+        let (active_channel, control_cancellation) =
+            UnixStreamLocalControlChannel::from_connected(local_control)
+                .activate(move || {
+                    if let Some(response_failure) = response_failure.upgrade() {
+                        response_failure.fail();
+                    }
+                })
+                .unwrap();
+        association_failure
+            .install_control(control_cancellation)
+            .unwrap();
+        let (failure_sender, failure_receiver) = mpsc::sync_channel(1);
+        association_failure.install_dispatch(move || failure_sender.send(()).unwrap());
+        start_notification_receiver(
+            BrokerNotifications::new(notification_channel),
+            Arc::clone(&association_failure),
+            |_| {},
+        )
+        .unwrap();
+        let active_channel = Arc::new(active_channel);
+        let pending_channel = Arc::clone(&active_channel);
+        let pending_call = std::thread::spawn(move || {
+            pending_channel.call(BrokerRequest {
+                request_id: RequestId(1),
+                operation: BrokerOperation::CloseObject(ObjectHandle(1)),
+            })
+        });
+        assert!(matches!(
+            host_control.recv_request().unwrap(),
+            HostReceive::Message(_)
+        ));
+
+        drop(host_notification);
+
+        failure_receiver
+            .recv_timeout(Duration::from_secs(1))
+            .unwrap();
+        assert!(pending_call.join().unwrap().is_err());
+        assert_eq!(
+            host_control.recv_request().unwrap(),
+            HostReceive::PeerClosed
+        );
     }
 }

--- a/litebox_runner_linux_userland/src/broker.rs
+++ b/litebox_runner_linux_userland/src/broker.rs
@@ -28,7 +28,7 @@ pub(crate) fn connect(
 ) -> Result<(
     BrokerLocal<UnixStreamLocalControlChannel>,
     BrokerNotifications<UnixStreamLocalNotificationChannel>,
-    Arc<BrokerAssociationFailure>,
+    Arc<BrokerAssociationState>,
 )> {
     let setup_deadline = Instant::now() + SETUP_TIMEOUT;
     let control_channel = connect_with_retry(
@@ -58,31 +58,33 @@ pub(crate) fn connect(
     let notification_cancellation = notification_channel
         .cancellation_handle()
         .context("failed to create broker notification cancellation handle")?;
-    let association_failure = Arc::new(BrokerAssociationFailure::new(notification_cancellation));
-    let activation_failure = Arc::clone(&association_failure);
-    let local = BrokerLocal::negotiate(control_channel, move |channel| {
-        let shared_memory =
-            channel.receive_memfd(PIPE_TRANSFER_BUFFER_SIZE, Some(setup_deadline))?;
-        let response_failure = Arc::downgrade(&activation_failure);
-        let control_cancellation = channel.activate(move || {
-            if let Some(response_failure) = response_failure.upgrade() {
-                response_failure.fail();
-            }
-        })?;
-        activation_failure.install_control(control_cancellation)?;
-        Ok(Arc::new(shared_memory))
+    let association_state = Arc::new(BrokerAssociationState::new(notification_cancellation));
+    let local = BrokerLocal::negotiate(control_channel, {
+        let association_state = Arc::clone(&association_state);
+        move |channel| {
+            let shared_memory =
+                channel.receive_memfd(PIPE_TRANSFER_BUFFER_SIZE, Some(setup_deadline))?;
+            let weak_association_state = Arc::downgrade(&association_state);
+            let control_cancellation = channel.activate(move || {
+                if let Some(association_state) = weak_association_state.upgrade() {
+                    association_state.fail();
+                }
+            })?;
+            association_state.install_control(control_cancellation)?;
+            Ok(Arc::new(shared_memory))
+        }
     })
     .context("broker negotiation failed")?;
     Ok((
         local,
         BrokerNotifications::new(notification_channel),
-        association_failure,
+        association_state,
     ))
 }
 
 pub(crate) fn start_notification_receiver(
     mut notifications: BrokerNotifications<UnixStreamLocalNotificationChannel>,
-    association_failure: Arc<BrokerAssociationFailure>,
+    association_state: Arc<BrokerAssociationState>,
     dispatch_notification: impl Fn(BrokerNotification) + Send + 'static,
 ) -> Result<()> {
     std::thread::Builder::new()
@@ -95,7 +97,7 @@ pub(crate) fn start_notification_receiver(
                     Err(error) => break Some(error),
                 }
             };
-            association_failure.fail();
+            association_state.fail();
             if let Some(error) = receive_error {
                 eprintln!("failed to receive broker notification: {error}");
             }
@@ -104,14 +106,14 @@ pub(crate) fn start_notification_receiver(
     Ok(())
 }
 
-pub(crate) struct BrokerAssociationFailure {
+pub(crate) struct BrokerAssociationState {
     failed: AtomicBool,
     control_cancellation: Mutex<Option<UnixStreamLocalControlCancellation>>,
     notification_cancellation: UnixStreamLocalNotificationCancellation,
     dispatch_failure: Mutex<Option<Box<dyn FnOnce() + Send>>>,
 }
 
-impl BrokerAssociationFailure {
+impl BrokerAssociationState {
     fn new(notification_cancellation: UnixStreamLocalNotificationCancellation) -> Self {
         Self {
             failed: AtomicBool::new(false),
@@ -257,22 +259,22 @@ mod tests {
             .unwrap();
         let notification_channel =
             UnixStreamLocalNotificationChannel::from_connected(local_notification);
-        let association_failure = Arc::new(BrokerAssociationFailure::new(
+        let association_state = Arc::new(BrokerAssociationState::new(
             notification_channel.cancellation_handle().unwrap(),
         ));
-        let response_failure = Arc::downgrade(&association_failure);
+        let weak_association_state = Arc::downgrade(&association_state);
         let control_cancellation = active_channel
             .activate(move || {
-                if let Some(response_failure) = response_failure.upgrade() {
-                    response_failure.fail();
+                if let Some(association_state) = weak_association_state.upgrade() {
+                    association_state.fail();
                 }
             })
             .unwrap();
-        association_failure
+        association_state
             .install_control(control_cancellation)
             .unwrap();
         let (failure_sender, failure_receiver) = mpsc::sync_channel(1);
-        association_failure.install_dispatch(move || failure_sender.send(()).unwrap());
+        association_state.install_dispatch(move || failure_sender.send(()).unwrap());
 
         drop(host_control);
 
@@ -293,25 +295,25 @@ mod tests {
         let (local_notification, host_notification) = UnixStream::pair().unwrap();
         let notification_channel =
             UnixStreamLocalNotificationChannel::from_connected(local_notification);
-        let association_failure = Arc::new(BrokerAssociationFailure::new(
+        let association_state = Arc::new(BrokerAssociationState::new(
             notification_channel.cancellation_handle().unwrap(),
         ));
-        let response_failure = Arc::downgrade(&association_failure);
+        let weak_association_state = Arc::downgrade(&association_state);
         let control_cancellation = active_channel
             .activate(move || {
-                if let Some(response_failure) = response_failure.upgrade() {
-                    response_failure.fail();
+                if let Some(association_state) = weak_association_state.upgrade() {
+                    association_state.fail();
                 }
             })
             .unwrap();
-        association_failure
+        association_state
             .install_control(control_cancellation)
             .unwrap();
         let (failure_sender, failure_receiver) = mpsc::sync_channel(1);
-        association_failure.install_dispatch(move || failure_sender.send(()).unwrap());
+        association_state.install_dispatch(move || failure_sender.send(()).unwrap());
         start_notification_receiver(
             BrokerNotifications::new(notification_channel),
-            Arc::clone(&association_failure),
+            Arc::clone(&association_state),
             |_| {},
         )
         .unwrap();

--- a/litebox_runner_linux_userland/src/lib.rs
+++ b/litebox_runner_linux_userland/src/lib.rs
@@ -242,15 +242,15 @@ pub fn run(cli_args: CliArgs) -> Result<()> {
     litebox_platform_multiplex::set_platform(platform);
 
     let shim_builder = if let Some(broker_connection) = broker_connection {
-        let (broker_local, broker_notifications, broker_association_failure) = broker_connection;
+        let (broker_local, broker_notifications, broker_association_state) = broker_connection;
         let litebox = litebox::LiteBox::new_with_broker_local(
             litebox_platform_multiplex::platform(),
             broker_local,
         );
-        broker_association_failure.install_dispatch(litebox.broker_failure_dispatcher());
+        broker_association_state.install_dispatch(litebox.broker_failure_dispatcher());
         broker::start_notification_receiver(
             broker_notifications,
-            broker_association_failure,
+            broker_association_state,
             litebox.broker_notification_dispatcher(),
         )?;
         litebox_shim_linux::LinuxShimBuilder::new_with_litebox(litebox)

--- a/litebox_runner_linux_userland/src/lib.rs
+++ b/litebox_runner_linux_userland/src/lib.rs
@@ -242,15 +242,16 @@ pub fn run(cli_args: CliArgs) -> Result<()> {
     litebox_platform_multiplex::set_platform(platform);
 
     let shim_builder = if let Some(broker_connection) = broker_connection {
-        let (broker_local, broker_notifications, broker_association_state) = broker_connection;
+        let (broker_local, broker_notifications, broker_association_coordinator) =
+            broker_connection;
         let litebox = litebox::LiteBox::new_with_broker_local(
             litebox_platform_multiplex::platform(),
             broker_local,
         );
-        broker_association_state.install_dispatch(litebox.broker_failure_dispatcher());
+        broker_association_coordinator.install_dispatch(litebox.broker_failure_dispatcher());
         broker::start_notification_receiver(
             broker_notifications,
-            broker_association_state,
+            broker_association_coordinator,
             litebox.broker_notification_dispatcher(),
         )?;
         litebox_shim_linux::LinuxShimBuilder::new_with_litebox(litebox)

--- a/litebox_runner_linux_userland/src/lib.rs
+++ b/litebox_runner_linux_userland/src/lib.rs
@@ -242,16 +242,16 @@ pub fn run(cli_args: CliArgs) -> Result<()> {
     litebox_platform_multiplex::set_platform(platform);
 
     let shim_builder = if let Some(broker_connection) = broker_connection {
-        let (broker_local, broker_notifications, broker_control_cancellation) = broker_connection;
+        let (broker_local, broker_notifications, broker_association_failure) = broker_connection;
         let litebox = litebox::LiteBox::new_with_broker_local(
             litebox_platform_multiplex::platform(),
             broker_local,
         );
+        broker_association_failure.install_dispatch(litebox.broker_failure_dispatcher());
         broker::start_notification_receiver(
             broker_notifications,
-            broker_control_cancellation,
+            broker_association_failure,
             litebox.broker_notification_dispatcher(),
-            litebox.broker_failure_dispatcher(),
         )?;
         litebox_shim_linux::LinuxShimBuilder::new_with_litebox(litebox)
     } else {


### PR DESCRIPTION
Allows multiple local threads to issue broker calls concurrently while preserving serial host execution. It unifies local setup and active operations under a phase-aware `LocalControlChannel`, bounds each Unix association to 64 published calls, serializes complete request frames, and uses one response dispatcher to correlate out-of-order replies by request ID and wake only the matching caller. Offset-zero shared-memory payload transfers remain serialized, while fatal control or notification failures cross-cancel the association, wake all pending callers, and fail broker-backed pollables closed. It also prevents Unix control activation before successful negotiation.