### PR TITLE
fix(net): accept advisory socket options (IP_TOS, SO_RCVBUF, SO_SNDBUF) (cherry-pick of #1054)

### DIFF
--- a/litebox_shim_linux/src/syscalls/net.rs
+++ b/litebox_shim_linux/src/syscalls/net.rs
@@ -385,7 +385,15 @@ impl<FS: ShimFS> GlobalState<FS> {
 
         match optname {
             SocketOptionName::IP(ip) => match ip {
-                litebox_common_linux::IpOption::TOS => return Err(Errno::EOPNOTSUPP),
+                // IP_TOS is an advisory traffic-class hint. Accept it (we don't
+                // propagate the bit anywhere) instead of returning EOPNOTSUPP,
+                // which Node's Socket.setTypeOfService treats as fatal and
+                // cascades into tearing down the connection. Log at debug so the
+                // accepted-but-ignored option stays visible.
+                litebox_common_linux::IpOption::TOS => {
+                    litebox_util_log::debug!("accepting and ignoring setsockopt(IP_TOS)");
+                    return Ok(());
+                }
             },
             SocketOptionName::Socket(so) => match so {
                 // handled by `setsockopt_common`
@@ -395,8 +403,17 @@ impl<FS: ShimFS> GlobalState<FS> {
                 | SocketOption::REUSEADDR
                 | SocketOption::BROADCAST
                 | SocketOption::KEEPALIVE => unreachable!(),
-                // We use fixed buffer size for now
-                SocketOption::RCVBUF | SocketOption::SNDBUF => return Err(Errno::EOPNOTSUPP),
+                // SO_RCVBUF / SO_SNDBUF are advisory hints. Accept them and keep
+                // the fixed internal buffer size that getsockopt reports, instead
+                // of returning EOPNOTSUPP (which Node's TLS socket path treats as
+                // fatal). Log at debug so the accepted-but-ignored option stays
+                // visible.
+                SocketOption::RCVBUF | SocketOption::SNDBUF => {
+                    litebox_util_log::debug!(
+                        "accepting and ignoring setsockopt(SO_RCVBUF/SO_SNDBUF); using fixed buffer size"
+                    );
+                    return Ok(());
+                }
                 // Socket does not support these options
                 SocketOption::TYPE | SocketOption::PEERCRED | SocketOption::ERROR => {
                     return Err(Errno::ENOPROTOOPT);

--- a/litebox_shim_linux/src/syscalls/unix.rs
+++ b/litebox_shim_linux/src/syscalls/unix.rs
@@ -1513,8 +1513,15 @@ impl<FS: ShimFS> UnixSocket<FS> {
                 SocketOption::TYPE | SocketOption::PEERCRED | SocketOption::ERROR => {
                     Err(Errno::ENOPROTOOPT)
                 }
-                // We use fixed buffer size for now
-                SocketOption::RCVBUF | SocketOption::SNDBUF => Err(Errno::EOPNOTSUPP),
+                // SO_RCVBUF / SO_SNDBUF are advisory hints. Accept them and keep
+                // the fixed internal buffer size, instead of returning EOPNOTSUPP.
+                // Log at debug so the accepted-but-ignored option stays visible.
+                SocketOption::RCVBUF | SocketOption::SNDBUF => {
+                    litebox_util_log::debug!(
+                        "accepting and ignoring setsockopt(SO_RCVBUF/SO_SNDBUF) on unix socket; using fixed buffer size"
+                    );
+                    Ok(())
+                }
             },
             SocketOptionName::TCP(_) => Err(Errno::EOPNOTSUPP),
         }


### PR DESCRIPTION
Cherry-pick of #1054 (commit `886f8278`) onto `ulitebox`.

---

setsockopt returned EOPNOTSUPP for IP_TOS, SO_RCVBUF and SO_SNDBUF, which Node/libuv treat as fatal — Socket.setTypeOfService and TLS buffer sizing raise uncaught exceptions that tear down the connection. These options are advisory hints, so accept them silently and keep the fixed internal buffer size that getsockopt already reports, for both INET and UNIX sockets. This matches how unprivileged sockets behave on native Linux.
