### PR TITLE
Add broker shared-buffer slots

### DIFF
--- a/litebox/src/event/counter.rs
+++ b/litebox/src/event/counter.rs
@@ -412,7 +412,7 @@ mod tests {
 
     impl litebox_broker_protocol::shared_memory::SharedMemory for NoopSharedMemory {
         fn len(&self) -> usize {
-            litebox_broker_protocol::pipe::PIPE_TRANSFER_BUFFER_SIZE
+            litebox_broker_protocol::shared_memory::SHARED_BUFFER_POOL_SIZE
         }
 
         fn read(

--- a/litebox/src/pipes.rs
+++ b/litebox/src/pipes.rs
@@ -1119,7 +1119,7 @@ mod tests {
 
     impl litebox_broker_protocol::shared_memory::SharedMemory for NoopSharedMemory {
         fn len(&self) -> usize {
-            litebox_broker_protocol::pipe::PIPE_TRANSFER_BUFFER_SIZE
+            litebox_broker_protocol::shared_memory::SHARED_BUFFER_POOL_SIZE
         }
 
         fn read(

--- a/litebox_broker_host/src/error.rs
+++ b/litebox_broker_host/src/error.rs
@@ -13,6 +13,8 @@ pub enum BrokerHostError<E> {
     Channel(#[source] E),
     #[error("broker setup failed: {0}")]
     Broker(#[source] ErrorCode),
+    #[error("broker association shared-buffer layout does not match the protocol layout")]
+    SharedBufferLayoutMismatch,
 }
 
 impl<E> From<BrokerError> for BrokerHostError<E> {

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -28,7 +28,7 @@ use litebox_broker_protocol::message::{
     EventRequest, EventResponse, PipeRequest, PipeResponse,
 };
 use litebox_broker_protocol::pipe::{
-    CreatePipeResponse, PIPE_TRANSFER_BUFFER_SIZE, ReadPipeResponse, WritePipeResponse,
+    CreatePipeResponse, MAX_PIPE_TRANSFER_SIZE, ReadPipeResponse, WritePipeResponse,
 };
 use litebox_broker_protocol::shared_memory::{
     SHARED_BUFFER_LAYOUT, SharedBufferPool, SharedBufferSlotIndex, SharedMemory,
@@ -199,7 +199,7 @@ fn handle_pipe_request<Memory: SharedMemory>(
                 .map_err(|error| RequestFailure::Respond(error.into()))
         }
         PipeRequest::Read(request) => {
-            if request.length as usize > PIPE_TRANSFER_BUFFER_SIZE {
+            if request.length > MAX_PIPE_TRANSFER_SIZE {
                 return Err(RequestFailure::Respond(ErrorCode::MalformedRequest));
             }
             let data = litebox_broker_core::pipe::read(session, request.handle, request.length)
@@ -215,7 +215,7 @@ fn handle_pipe_request<Memory: SharedMemory>(
             }))
         }
         PipeRequest::Write(request) => {
-            if request.length as usize > PIPE_TRANSFER_BUFFER_SIZE {
+            if request.length > MAX_PIPE_TRANSFER_SIZE {
                 return Err(RequestFailure::Respond(ErrorCode::MalformedRequest));
             }
             let length = request.length as usize;
@@ -750,7 +750,7 @@ mod tests {
             &session,
             BrokerOperation::Pipe(PipeRequest::Write(WritePipeRequest {
                 handle: response.write_handle,
-                length: u32::try_from(PIPE_TRANSFER_BUFFER_SIZE).unwrap() + 1,
+                length: MAX_PIPE_TRANSFER_SIZE + 1,
             })),
             &shared_buffers,
         );

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -30,7 +30,9 @@ use litebox_broker_protocol::message::{
 use litebox_broker_protocol::pipe::{
     CreatePipeResponse, PIPE_TRANSFER_BUFFER_SIZE, ReadPipeResponse, WritePipeResponse,
 };
-use litebox_broker_protocol::shared_memory::SharedMemory;
+use litebox_broker_protocol::shared_memory::{
+    SHARED_BUFFER_LAYOUT, SharedBufferPool, SharedBufferSlotIndex, SharedMemory,
+};
 
 mod error;
 
@@ -45,23 +47,25 @@ pub use error::{BrokerHostError, Result};
 /// Event mutations caused by control requests return readiness in their control
 /// response and do not also emit a duplicate notification.
 ///
-/// `shared_memory` belongs to this association and is reused at offset zero for
-/// serialized pipe transfers. `send_shared_memory` runs after version
+/// `shared_buffers` belongs to this association. Pipe transfers currently reuse
+/// slot zero serially. `send_shared_memory` runs after version
 /// negotiation and before active requests begin.
-pub fn serve_connection<ControlChannel, NotificationChannel, ChannelError>(
+pub fn serve_connection<ControlChannel, NotificationChannel, Memory, ChannelError>(
     core: &BrokerCore,
     control_channel: &mut ControlChannel,
     _notification_channel: &mut NotificationChannel,
-    shared_memory: &dyn SharedMemory,
+    shared_buffers: &SharedBufferPool<Memory>,
     send_shared_memory: impl FnOnce(&mut ControlChannel) -> core::result::Result<(), ChannelError>,
 ) -> Result<ConnectionTermination, ChannelError>
 where
     ControlChannel: HostControlChannel<Error = ChannelError>,
     NotificationChannel: HostNotificationChannel<Error = ChannelError>,
+    Memory: SharedMemory,
 {
-    if shared_memory.len() != PIPE_TRANSFER_BUFFER_SIZE {
-        return Err(BrokerHostError::Broker(ErrorCode::Internal));
+    if shared_buffers.layout() != SHARED_BUFFER_LAYOUT {
+        return Err(BrokerHostError::SharedBufferLayoutMismatch);
     }
+
     let peer_credential = control_channel
         .peer_credential()
         .map_err(BrokerHostError::Channel)?;
@@ -123,7 +127,7 @@ where
             request_id,
             operation,
         } = request;
-        let result = complete_request(handle_request(&session, operation, shared_memory))
+        let result = complete_request(handle_request(&session, operation, shared_buffers))
             .map_err(BrokerHostError::Broker)?;
         control_channel
             .send_response(&BrokerResponse { request_id, result })
@@ -153,10 +157,10 @@ fn complete_request(
     }
 }
 
-fn handle_request(
+fn handle_request<Memory: SharedMemory>(
     session: &BrokerSession,
     operation: BrokerOperation,
-    shared_memory: &dyn SharedMemory,
+    shared_buffers: &SharedBufferPool<Memory>,
 ) -> RequestResult<BrokerResult> {
     match operation {
         BrokerOperation::CloseObject(handle) => session
@@ -171,16 +175,18 @@ fn handle_request(
             handle_event_request(session, request).map(BrokerResult::Event)
         }
         BrokerOperation::Pipe(request) => {
-            handle_pipe_request(session, request, shared_memory).map(BrokerResult::Pipe)
+            handle_pipe_request(session, request, shared_buffers).map(BrokerResult::Pipe)
         }
     }
 }
 
-fn handle_pipe_request(
+fn handle_pipe_request<Memory: SharedMemory>(
     session: &BrokerSession,
     request: PipeRequest,
-    shared_memory: &dyn SharedMemory,
+    shared_buffers: &SharedBufferPool<Memory>,
 ) -> RequestResult<PipeResponse> {
+    const SERIALIZED_PIPE_SLOT: SharedBufferSlotIndex = SharedBufferSlotIndex::new(0);
+
     match request {
         PipeRequest::Create(request) => {
             litebox_broker_core::pipe::create(session, request.capacity, request.atomic_write_size)
@@ -198,8 +204,8 @@ fn handle_pipe_request(
             }
             let data = litebox_broker_core::pipe::read(session, request.handle, request.length)
                 .map_err(|error| RequestFailure::Respond(error.into()))?;
-            shared_memory
-                .write(0, &data)
+            shared_buffers
+                .write(SERIALIZED_PIPE_SLOT, &data)
                 .map_err(|_| RequestFailure::Abort(ErrorCode::Internal))?;
             Ok(PipeResponse::Read(ReadPipeResponse {
                 read: data
@@ -218,8 +224,8 @@ fn handle_pipe_request(
                 return Err(RequestFailure::Respond(ErrorCode::OutOfMemory));
             }
             data.resize(length, 0);
-            shared_memory
-                .read(0, &mut data)
+            shared_buffers
+                .read(SERIALIZED_PIPE_SLOT, &mut data)
                 .map_err(|_| RequestFailure::Abort(ErrorCode::Internal))?;
             litebox_broker_core::pipe::write(session, request.handle, &data)
                 .map_err(|error| RequestFailure::Respond(error.into()))
@@ -278,7 +284,9 @@ mod tests {
     };
     use litebox_broker_protocol::message::{BrokerHandshakeRequest, BrokerNotification};
     use litebox_broker_protocol::pipe::{CreatePipeRequest, ReadPipeRequest, WritePipeRequest};
-    use litebox_broker_protocol::shared_memory::SharedMemoryError;
+    use litebox_broker_protocol::shared_memory::{
+        SHARED_BUFFER_LAYOUT, SHARED_BUFFER_POOL_SIZE, SharedBufferPool, SharedMemoryError,
+    };
     use litebox_broker_protocol::{ObjectHandle, ProtocolVersion, RequestId};
     use std::sync::{Arc, Mutex};
 
@@ -298,8 +306,9 @@ mod tests {
         serve_connection_returns_event_readiness_in_control_responses(&broker);
         serve_connection_continues_after_recoverable_request_failure(&broker);
         serve_connection_aborts_without_response_on_shared_memory_failure(&broker);
+        serve_connection_rejects_incompatible_shared_buffer_layout(&broker);
         active_request_closes_object_reference(&broker);
-        association_shared_memory_stages_pipe_data(&broker);
+        association_shared_buffer_slot_zero_stages_pipe_data(&broker);
     }
 
     fn serve_connection_negotiates_routes_one_request_and_returns_peer_closed(broker: &BrokerCore) {
@@ -322,7 +331,7 @@ mod tests {
                 broker,
                 &mut channel,
                 &mut notifications,
-                &TestSharedMemory::new(PIPE_TRANSFER_BUFFER_SIZE),
+                &test_shared_buffers(),
                 |_| Ok(()),
             )
             .unwrap(),
@@ -361,7 +370,7 @@ mod tests {
                 broker,
                 &mut channel,
                 &mut notifications,
-                &TestSharedMemory::new(PIPE_TRANSFER_BUFFER_SIZE),
+                &test_shared_buffers(),
                 |_| Ok(()),
             )
             .unwrap(),
@@ -398,7 +407,7 @@ mod tests {
                 broker,
                 &mut channel,
                 &mut notifications,
-                &TestSharedMemory::new(PIPE_TRANSFER_BUFFER_SIZE),
+                &test_shared_buffers(),
                 |_| {
                     setup_called.set(true);
                     Ok(())
@@ -428,7 +437,7 @@ mod tests {
                 broker,
                 &mut channel,
                 &mut notifications,
-                &TestSharedMemory::new(PIPE_TRANSFER_BUFFER_SIZE),
+                &test_shared_buffers(),
                 |_| Ok(()),
             )
             .unwrap(),
@@ -455,7 +464,7 @@ mod tests {
                 broker,
                 &mut channel,
                 &mut notifications,
-                &TestSharedMemory::new(PIPE_TRANSFER_BUFFER_SIZE),
+                &test_shared_buffers(),
                 |_| Ok(()),
             )
             .unwrap(),
@@ -484,7 +493,7 @@ mod tests {
             broker,
             &mut channel,
             &mut notifications,
-            &TestSharedMemory::new(PIPE_TRANSFER_BUFFER_SIZE),
+            &test_shared_buffers(),
             |_| Ok(()),
         ) {
             Err(BrokerHostError::Channel(())) => {}
@@ -510,7 +519,7 @@ mod tests {
                 broker,
                 &mut channel,
                 &mut notifications,
-                &TestSharedMemory::new(PIPE_TRANSFER_BUFFER_SIZE),
+                &test_shared_buffers(),
                 |_| Ok(()),
             )
             .unwrap(),
@@ -559,7 +568,7 @@ mod tests {
                 broker,
                 &mut channel,
                 &mut notifications,
-                &TestSharedMemory::new(PIPE_TRANSFER_BUFFER_SIZE),
+                &test_shared_buffers(),
                 |_| Ok(()),
             )
             .unwrap(),
@@ -596,7 +605,7 @@ mod tests {
                 broker,
                 &mut channel,
                 &mut notifications,
-                &FailingSharedMemory,
+                &SharedBufferPool::new(FailingSharedMemory, SHARED_BUFFER_LAYOUT).unwrap(),
                 |_| Ok(()),
             ),
             Err(BrokerHostError::Broker(ErrorCode::Internal))
@@ -606,6 +615,43 @@ mod tests {
             channel.results[0],
             BrokerResult::Pipe(PipeResponse::Create(_))
         ));
+    }
+
+    fn serve_connection_rejects_incompatible_shared_buffer_layout(broker: &BrokerCore) {
+        let mut channel = FakeHostControlChannel::new(
+            std::vec::Vec::from([Ok(HostReceive::Message(BrokerHandshakeRequest {
+                protocol_version: BROKER_PROTOCOL_VERSION,
+            }))]),
+            std::vec::Vec::new(),
+        );
+        let mut notifications = FakeHostNotificationChannel::default();
+        let incompatible_layout = litebox_broker_protocol::shared_memory::SharedBufferLayout::new(
+            u32::try_from(SHARED_BUFFER_POOL_SIZE).unwrap(),
+            1,
+        )
+        .unwrap();
+        let shared_buffers = SharedBufferPool::new(
+            TestSharedMemory::new(SHARED_BUFFER_POOL_SIZE),
+            incompatible_layout,
+        )
+        .unwrap();
+        let setup_called = Cell::new(false);
+
+        assert!(matches!(
+            serve_connection(
+                broker,
+                &mut channel,
+                &mut notifications,
+                &shared_buffers,
+                |_| {
+                    setup_called.set(true);
+                    Ok(())
+                },
+            ),
+            Err(BrokerHostError::SharedBufferLayoutMismatch)
+        ));
+        assert!(!setup_called.get());
+        assert!(channel.handshake_responses.is_empty());
     }
 
     fn active_request_closes_object_reference(broker: &BrokerCore) {
@@ -640,60 +686,73 @@ mod tests {
         );
     }
 
-    fn association_shared_memory_stages_pipe_data(broker: &BrokerCore) {
+    fn association_shared_buffer_slot_zero_stages_pipe_data(broker: &BrokerCore) {
         let session = broker
             .create_session(CallerCredential::Unauthenticated)
             .unwrap();
-        let memory = TestSharedMemory::new(PIPE_TRANSFER_BUFFER_SIZE);
-        let created = handle_test_request_with_memory(
+        let memory = TestSharedMemory::new(SHARED_BUFFER_POOL_SIZE);
+        let shared_buffers = SharedBufferPool::new(memory.clone(), SHARED_BUFFER_LAYOUT).unwrap();
+        shared_buffers
+            .write(SharedBufferSlotIndex::new(1), &[9])
+            .unwrap();
+        let created = handle_test_request_with_buffers(
             &session,
             BrokerOperation::Pipe(PipeRequest::Create(CreatePipeRequest {
                 capacity: 64,
                 atomic_write_size: 16,
             })),
-            &memory,
+            &shared_buffers,
         );
         let BrokerResult::Pipe(PipeResponse::Create(response)) = created else {
             panic!("expected successful pipe creation");
         };
 
-        memory.write(0, &[1, 2, 3]).unwrap();
-        let write = handle_test_request_with_memory(
+        shared_buffers
+            .write(SharedBufferSlotIndex::new(0), &[1, 2, 3])
+            .unwrap();
+        let write = handle_test_request_with_buffers(
             &session,
             BrokerOperation::Pipe(PipeRequest::Write(WritePipeRequest {
                 handle: response.write_handle,
                 length: 3,
             })),
-            &memory,
+            &shared_buffers,
         );
         assert_eq!(
             write,
             BrokerResult::Pipe(PipeResponse::Write(WritePipeResponse { written: 3 }))
         );
 
-        let read = handle_test_request_with_memory(
+        let read = handle_test_request_with_buffers(
             &session,
             BrokerOperation::Pipe(PipeRequest::Read(ReadPipeRequest {
                 handle: response.read_handle,
                 length: 3,
             })),
-            &memory,
+            &shared_buffers,
         );
         assert_eq!(
             read,
             BrokerResult::Pipe(PipeResponse::Read(ReadPipeResponse { read: 3 }))
         );
         let mut data = [0; 3];
-        memory.read(0, &mut data).unwrap();
+        shared_buffers
+            .read(SharedBufferSlotIndex::new(0), &mut data)
+            .unwrap();
         assert_eq!(data, [1, 2, 3]);
+        let mut second_slot = [0];
+        shared_buffers
+            .read(SharedBufferSlotIndex::new(1), &mut second_slot)
+            .unwrap();
+        assert_eq!(second_slot, [9]);
 
-        let invalid_range = handle_test_request_with_memory(
+        let invalid_range = handle_test_request_with_buffers(
             &session,
             BrokerOperation::Pipe(PipeRequest::Write(WritePipeRequest {
                 handle: response.write_handle,
                 length: u32::try_from(PIPE_TRANSFER_BUFFER_SIZE).unwrap() + 1,
             })),
-            &memory,
+            &shared_buffers,
         );
         assert_eq!(
             invalid_range,
@@ -702,19 +761,23 @@ mod tests {
     }
 
     fn handle_test_request(session: &BrokerSession, operation: BrokerOperation) -> BrokerResult {
-        handle_test_request_with_memory(
-            session,
-            operation,
-            &TestSharedMemory::new(PIPE_TRANSFER_BUFFER_SIZE),
-        )
+        handle_test_request_with_buffers(session, operation, &test_shared_buffers())
     }
 
-    fn handle_test_request_with_memory(
+    fn handle_test_request_with_buffers<Memory: SharedMemory>(
         session: &BrokerSession,
         operation: BrokerOperation,
-        shared_memory: &dyn SharedMemory,
+        shared_buffers: &SharedBufferPool<Memory>,
     ) -> BrokerResult {
-        complete_request(handle_request(session, operation, shared_memory)).unwrap()
+        complete_request(handle_request(session, operation, shared_buffers)).unwrap()
+    }
+
+    fn test_shared_buffers() -> SharedBufferPool<TestSharedMemory> {
+        SharedBufferPool::new(
+            TestSharedMemory::new(SHARED_BUFFER_POOL_SIZE),
+            SHARED_BUFFER_LAYOUT,
+        )
+        .unwrap()
     }
 
     struct FakeHostControlChannel {
@@ -897,7 +960,7 @@ mod tests {
 
     impl SharedMemory for FailingSharedMemory {
         fn len(&self) -> usize {
-            PIPE_TRANSFER_BUFFER_SIZE
+            SHARED_BUFFER_POOL_SIZE
         }
 
         fn read(

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -185,7 +185,7 @@ fn handle_pipe_request<Memory: SharedMemory>(
     request: PipeRequest,
     shared_buffers: &SharedBufferPool<Memory>,
 ) -> RequestResult<PipeResponse> {
-    const SERIALIZED_PIPE_SLOT: SharedBufferSlotIndex = SharedBufferSlotIndex::new(0);
+    const SERIALIZED_PIPE_SLOT: SharedBufferSlotIndex = SharedBufferSlotIndex(0);
 
     match request {
         PipeRequest::Create(request) => {
@@ -693,7 +693,7 @@ mod tests {
         let memory = TestSharedMemory::new(SHARED_BUFFER_POOL_SIZE);
         let shared_buffers = SharedBufferPool::new(memory.clone(), SHARED_BUFFER_LAYOUT).unwrap();
         shared_buffers
-            .write(SharedBufferSlotIndex::new(1), &[9])
+            .write(SharedBufferSlotIndex(1), &[9])
             .unwrap();
         let created = handle_test_request_with_buffers(
             &session,
@@ -708,7 +708,7 @@ mod tests {
         };
 
         shared_buffers
-            .write(SharedBufferSlotIndex::new(0), &[1, 2, 3])
+            .write(SharedBufferSlotIndex(0), &[1, 2, 3])
             .unwrap();
         let write = handle_test_request_with_buffers(
             &session,
@@ -737,12 +737,12 @@ mod tests {
         );
         let mut data = [0; 3];
         shared_buffers
-            .read(SharedBufferSlotIndex::new(0), &mut data)
+            .read(SharedBufferSlotIndex(0), &mut data)
             .unwrap();
         assert_eq!(data, [1, 2, 3]);
         let mut second_slot = [0];
         shared_buffers
-            .read(SharedBufferSlotIndex::new(1), &mut second_slot)
+            .read(SharedBufferSlotIndex(1), &mut second_slot)
             .unwrap();
         assert_eq!(second_slot, [9]);
 

--- a/litebox_broker_local/src/lib.rs
+++ b/litebox_broker_local/src/lib.rs
@@ -29,20 +29,21 @@ use litebox_broker_protocol::message::{
     BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerNotification, BrokerOperation,
     BrokerRequest, BrokerResponse, BrokerResult,
 };
-use litebox_broker_protocol::pipe::PIPE_TRANSFER_BUFFER_SIZE;
 use litebox_broker_protocol::readiness::ReadinessFlags;
-use litebox_broker_protocol::shared_memory::SharedMemory;
+use litebox_broker_protocol::shared_memory::{
+    SHARED_BUFFER_LAYOUT, SharedBufferPool, SharedMemory,
+};
 use litebox_broker_protocol::{BROKER_PROTOCOL_VERSION, ObjectHandle, RequestId};
 
 pub use error::{BrokerLocalError, Result};
 
 /// Typed broker-local control adapter for broker operations.
 ///
-/// The shared memory belongs to the broker association and is reused for each
-/// serialized pipe transfer.
+/// The shared-buffer pool belongs to the broker association. Pipe transfers
+/// currently reuse slot zero under the channel's serialization scope.
 pub struct BrokerLocal<Channel: LocalControlChannel> {
     channel: Channel,
-    shared_memory: Arc<dyn SharedMemory>,
+    shared_buffers: SharedBufferPool<Arc<dyn SharedMemory>>,
     next_request_id: AtomicU64,
 }
 
@@ -86,14 +87,11 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
                     "broker returned unexpected negotiation response: {response:?}"
                 );
                 let shared_memory = activate(&mut channel).map_err(BrokerLocalError::Channel)?;
-                assert_eq!(
-                    shared_memory.len(),
-                    PIPE_TRANSFER_BUFFER_SIZE,
-                    "broker association shared memory has an invalid size"
-                );
+                let shared_buffers = SharedBufferPool::new(shared_memory, SHARED_BUFFER_LAYOUT)
+                    .expect("broker association shared memory has an invalid size");
                 Ok(Self {
                     channel,
-                    shared_memory,
+                    shared_buffers,
                     next_request_id: AtomicU64::new(0),
                 })
             }
@@ -265,7 +263,7 @@ mod tests {
         let channel = FakeControlChannel::new(None, Some(response.clone()));
         let local = BrokerLocal {
             channel,
-            shared_memory: noop_shared_memory(),
+            shared_buffers: noop_shared_buffers(),
             next_request_id: AtomicU64::new(0),
         };
 
@@ -285,7 +283,7 @@ mod tests {
         let channel = FakeControlChannel::new(None, Some(BrokerResult::ObjectClosed));
         let local = BrokerLocal {
             channel,
-            shared_memory: noop_shared_memory(),
+            shared_buffers: noop_shared_buffers(),
             next_request_id: AtomicU64::new(0),
         };
 
@@ -321,7 +319,7 @@ mod tests {
             channel: ConcurrentCallChannel {
                 request_ids: Mutex::new(std::vec::Vec::new()),
             },
-            shared_memory: noop_shared_memory(),
+            shared_buffers: noop_shared_buffers(),
             next_request_id: AtomicU64::new(0),
         });
         let callers = (0..16)
@@ -347,7 +345,7 @@ mod tests {
         let channel = FakeControlChannel::new(None, Some(BrokerResult::ObjectClosed));
         let local = BrokerLocal {
             channel,
-            shared_memory: noop_shared_memory(),
+            shared_buffers: noop_shared_buffers(),
             next_request_id: AtomicU64::new(0),
         };
         local.channel.response_id.set(Some(RequestId(9)));
@@ -366,7 +364,7 @@ mod tests {
         let channel = FakeControlChannel::new(None, Some(BrokerResult::ObjectClosed));
         let local = BrokerLocal {
             channel,
-            shared_memory: noop_shared_memory(),
+            shared_buffers: noop_shared_buffers(),
             next_request_id: AtomicU64::new(u64::MAX),
         };
 
@@ -383,7 +381,7 @@ mod tests {
             FakeControlChannel::new(None, Some(BrokerResult::Error(ErrorCode::WouldBlock)));
         let local = BrokerLocal {
             channel,
-            shared_memory: noop_shared_memory(),
+            shared_buffers: noop_shared_buffers(),
             next_request_id: AtomicU64::new(0),
         };
 
@@ -399,7 +397,7 @@ mod tests {
         let channel = FakeControlChannel::new(None, Some(BrokerResult::Error(ErrorCode::Internal)));
         let local = BrokerLocal {
             channel,
-            shared_memory: noop_shared_memory(),
+            shared_buffers: noop_shared_buffers(),
             next_request_id: AtomicU64::new(0),
         };
 
@@ -511,7 +509,7 @@ mod tests {
 
         let _ = BrokerLocal::negotiate(channel, |_| {
             Ok(Arc::new(NoopSharedMemory {
-                length: PIPE_TRANSFER_BUFFER_SIZE - 1,
+                length: litebox_broker_protocol::shared_memory::SHARED_BUFFER_POOL_SIZE - 1,
             }) as Arc<dyn SharedMemory>)
         });
     }
@@ -575,8 +573,12 @@ mod tests {
 
     fn noop_shared_memory() -> Arc<dyn SharedMemory> {
         Arc::new(NoopSharedMemory {
-            length: PIPE_TRANSFER_BUFFER_SIZE,
+            length: litebox_broker_protocol::shared_memory::SHARED_BUFFER_POOL_SIZE,
         })
+    }
+
+    fn noop_shared_buffers() -> SharedBufferPool<Arc<dyn SharedMemory>> {
+        SharedBufferPool::new(noop_shared_memory(), SHARED_BUFFER_LAYOUT).unwrap()
     }
 
     impl FakeControlChannel {

--- a/litebox_broker_local/src/pipe.rs
+++ b/litebox_broker_local/src/pipe.rs
@@ -10,8 +10,11 @@ use litebox_broker_protocol::pipe::{
     CreatePipeRequest, CreatePipeResponse, PIPE_TRANSFER_BUFFER_SIZE, ReadPipeRequest,
     WritePipeRequest,
 };
+use litebox_broker_protocol::shared_memory::SharedBufferSlotIndex;
 
 use crate::{BrokerLocal, BrokerLocalError, Result};
+
+const SERIALIZED_PIPE_SLOT: SharedBufferSlotIndex = SharedBufferSlotIndex::new(0);
 
 impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
     /// Creates a broker-owned byte pipe.
@@ -72,8 +75,8 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
         );
         let read = response.read as usize;
         data.truncate(read);
-        self.shared_memory
-            .read(0, &mut data)
+        self.shared_buffers
+            .read(SERIALIZED_PIPE_SLOT, &mut data)
             .expect("validated shared pipe read range must be accessible");
         Ok(data)
     }
@@ -100,8 +103,8 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
                 litebox_broker_protocol::error::ErrorCode::ResourceExhausted,
             ));
         }
-        self.shared_memory
-            .write(0, data)
+        self.shared_buffers
+            .write(SERIALIZED_PIPE_SLOT, data)
             .expect("validated shared pipe write range must be accessible");
         let response = self.request_pipe(PipeRequest::Write(WritePipeRequest {
             handle,
@@ -149,13 +152,15 @@ mod tests {
         BrokerResponse, BrokerResult,
     };
     use litebox_broker_protocol::pipe::{ReadPipeResponse, WritePipeResponse};
-    use litebox_broker_protocol::shared_memory::{SharedMemory, SharedMemoryError};
+    use litebox_broker_protocol::shared_memory::{
+        SHARED_BUFFER_POOL_SIZE, SHARED_BUFFER_SLOT_SIZE, SharedMemory, SharedMemoryError,
+    };
 
     #[test]
-    fn pipe_uses_attached_shared_memory_for_data_operations() {
+    fn pipe_uses_slot_zero_for_serialized_data_operations() {
         let read_handle = ObjectHandle(1);
         let write_handle = ObjectHandle(2);
-        let memory = Arc::new(TestSharedMemory::new(PIPE_TRANSFER_BUFFER_SIZE));
+        let memory = Arc::new(TestSharedMemory::new(SHARED_BUFFER_POOL_SIZE));
         let channel = ScriptedChannel::new([
             BrokerResult::Pipe(PipeResponse::Create(CreatePipeResponse {
                 read_handle,
@@ -165,6 +170,9 @@ mod tests {
             BrokerResult::Pipe(PipeResponse::Read(ReadPipeResponse { read: 2 })),
         ]);
         let local = BrokerLocal::negotiate(channel, |_| Ok(memory.clone())).unwrap();
+        memory
+            .write(SHARED_BUFFER_SLOT_SIZE as usize, &[9])
+            .unwrap();
 
         local.create_pipe(64, 16).unwrap();
         assert_eq!(local.write_pipe(write_handle, &[1, 2, 3]).unwrap(), 2);
@@ -174,6 +182,11 @@ mod tests {
 
         memory.write(0, &[4, 5, 6]).unwrap();
         assert_eq!(local.read_pipe(read_handle, 3).unwrap(), [4, 5]);
+        let mut second_slot = [0];
+        memory
+            .read(SHARED_BUFFER_SLOT_SIZE as usize, &mut second_slot)
+            .unwrap();
+        assert_eq!(second_slot, [9]);
         assert_eq!(
             local.channel.sent_operations.borrow().as_slice(),
             &[
@@ -195,7 +208,7 @@ mod tests {
 
     #[test]
     fn pipe_rejects_oversized_transfers_before_request() {
-        let memory = Arc::new(TestSharedMemory::new(PIPE_TRANSFER_BUFFER_SIZE));
+        let memory = Arc::new(TestSharedMemory::new(SHARED_BUFFER_POOL_SIZE));
         let channel = ScriptedChannel::new([]);
         let local = BrokerLocal::negotiate(channel, |_| Ok(memory)).unwrap();
         let oversized_length = PIPE_TRANSFER_BUFFER_SIZE + 1;
@@ -222,7 +235,7 @@ mod tests {
             ScriptedChannel::new([BrokerResult::Pipe(PipeResponse::Read(ReadPipeResponse {
                 read: 2,
             }))]);
-        let memory = Arc::new(TestSharedMemory::new(PIPE_TRANSFER_BUFFER_SIZE));
+        let memory = Arc::new(TestSharedMemory::new(SHARED_BUFFER_POOL_SIZE));
         let local = BrokerLocal::negotiate(channel, |_| Ok(memory)).unwrap();
 
         let _ = local.read_pipe(ObjectHandle(1), 1);
@@ -235,7 +248,7 @@ mod tests {
             ScriptedChannel::new([BrokerResult::Pipe(PipeResponse::Write(WritePipeResponse {
                 written: 2,
             }))]);
-        let memory = Arc::new(TestSharedMemory::new(PIPE_TRANSFER_BUFFER_SIZE));
+        let memory = Arc::new(TestSharedMemory::new(SHARED_BUFFER_POOL_SIZE));
         let local = BrokerLocal::negotiate(channel, |_| Ok(memory)).unwrap();
 
         let _ = local.write_pipe(ObjectHandle(1), &[0]);

--- a/litebox_broker_local/src/pipe.rs
+++ b/litebox_broker_local/src/pipe.rs
@@ -7,7 +7,7 @@ use litebox_broker_protocol::ObjectHandle;
 use litebox_broker_protocol::channel::LocalControlChannel;
 use litebox_broker_protocol::message::{BrokerOperation, BrokerResult, PipeRequest, PipeResponse};
 use litebox_broker_protocol::pipe::{
-    CreatePipeRequest, CreatePipeResponse, PIPE_TRANSFER_BUFFER_SIZE, ReadPipeRequest,
+    CreatePipeRequest, CreatePipeResponse, MAX_PIPE_TRANSFER_SIZE, ReadPipeRequest,
     WritePipeRequest,
 };
 use litebox_broker_protocol::shared_memory::SharedBufferSlotIndex;
@@ -55,7 +55,7 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
         handle: ObjectHandle,
         length: u32,
     ) -> Result<Vec<u8>, Channel::Error> {
-        if length as usize > PIPE_TRANSFER_BUFFER_SIZE {
+        if length > MAX_PIPE_TRANSFER_SIZE {
             return Err(BrokerLocalError::Broker(
                 litebox_broker_protocol::error::ErrorCode::ResourceExhausted,
             ));
@@ -98,7 +98,7 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
         handle: ObjectHandle,
         data: &[u8],
     ) -> Result<usize, Channel::Error> {
-        if data.len() > PIPE_TRANSFER_BUFFER_SIZE {
+        if data.len() > MAX_PIPE_TRANSFER_SIZE as usize {
             return Err(BrokerLocalError::Broker(
                 litebox_broker_protocol::error::ErrorCode::ResourceExhausted,
             ));
@@ -211,7 +211,7 @@ mod tests {
         let memory = Arc::new(TestSharedMemory::new(SHARED_BUFFER_POOL_SIZE));
         let channel = ScriptedChannel::new([]);
         let local = BrokerLocal::negotiate(channel, |_| Ok(memory)).unwrap();
-        let oversized_length = PIPE_TRANSFER_BUFFER_SIZE + 1;
+        let oversized_length = MAX_PIPE_TRANSFER_SIZE as usize + 1;
 
         assert!(matches!(
             local.read_pipe(ObjectHandle(1), u32::try_from(oversized_length).unwrap()),

--- a/litebox_broker_local/src/pipe.rs
+++ b/litebox_broker_local/src/pipe.rs
@@ -14,7 +14,7 @@ use litebox_broker_protocol::shared_memory::SharedBufferSlotIndex;
 
 use crate::{BrokerLocal, BrokerLocalError, Result};
 
-const SERIALIZED_PIPE_SLOT: SharedBufferSlotIndex = SharedBufferSlotIndex::new(0);
+const SERIALIZED_PIPE_SLOT: SharedBufferSlotIndex = SharedBufferSlotIndex(0);
 
 impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
     /// Creates a broker-owned byte pipe.

--- a/litebox_broker_protocol/src/lib.rs
+++ b/litebox_broker_protocol/src/lib.rs
@@ -12,6 +12,9 @@
 
 extern crate alloc;
 
+#[cfg(test)]
+extern crate std;
+
 pub mod channel;
 pub mod error;
 pub mod event;

--- a/litebox_broker_protocol/src/pipe.rs
+++ b/litebox_broker_protocol/src/pipe.rs
@@ -9,7 +9,7 @@ use crate::ObjectHandle;
 /// smallest currently supported transport frame.
 pub const MAX_PIPE_TRANSFER_SIZE: u32 = 32 * 1024;
 
-/// Association shared-memory size required for broker pipe transfers.
+/// Size of one association shared-buffer slot used for broker pipe transfers.
 pub const PIPE_TRANSFER_BUFFER_SIZE: usize = MAX_PIPE_TRANSFER_SIZE as usize;
 
 /// Request to create a broker-owned byte pipe.

--- a/litebox_broker_protocol/src/pipe.rs
+++ b/litebox_broker_protocol/src/pipe.rs
@@ -9,9 +9,6 @@ use crate::ObjectHandle;
 /// smallest currently supported transport frame.
 pub const MAX_PIPE_TRANSFER_SIZE: u32 = 32 * 1024;
 
-/// Size of one association shared-buffer slot used for broker pipe transfers.
-pub const PIPE_TRANSFER_BUFFER_SIZE: usize = MAX_PIPE_TRANSFER_SIZE as usize;
-
 /// Request to create a broker-owned byte pipe.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct CreatePipeRequest {

--- a/litebox_broker_protocol/src/shared_memory.rs
+++ b/litebox_broker_protocol/src/shared_memory.rs
@@ -148,13 +148,13 @@ impl SharedBufferLayout {
         slot: SharedBufferSlotIndex,
         length: usize,
     ) -> Result<Range<usize>, SharedBufferError> {
-        if slot.index() >= self.slot_count {
+        if slot.0 >= self.slot_count {
             return Err(SharedBufferError::InvalidSlot);
         }
         if length > self.slot_size as usize {
             return Err(SharedBufferError::RangeExceedsSlot);
         }
-        let offset = (slot.index() as usize)
+        let offset = (slot.0 as usize)
             .checked_mul(self.slot_size as usize)
             .ok_or(SharedBufferError::InvalidLayout)?;
         let end = offset
@@ -167,19 +167,7 @@ impl SharedBufferLayout {
 /// Index of one fixed shared-buffer slot.
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct SharedBufferSlotIndex(u32);
-
-impl SharedBufferSlotIndex {
-    /// Creates a slot index.
-    pub const fn new(index: u32) -> Self {
-        Self(index)
-    }
-
-    /// Returns the numeric slot index.
-    pub const fn index(self) -> u32 {
-        self.0
-    }
-}
+pub struct SharedBufferSlotIndex(pub u32);
 
 /// A shared-memory resource viewed as a checked fixed-slot buffer pool.
 ///
@@ -267,15 +255,15 @@ mod tests {
     fn layout_derives_disjoint_slot_ranges() {
         let layout = SharedBufferLayout::new(8, 3).unwrap();
 
-        assert_eq!(layout.range(SharedBufferSlotIndex::new(0), 8), Ok(0..8));
-        assert_eq!(layout.range(SharedBufferSlotIndex::new(1), 8), Ok(8..16));
-        assert_eq!(layout.range(SharedBufferSlotIndex::new(2), 8), Ok(16..24));
+        assert_eq!(layout.range(SharedBufferSlotIndex(0), 8), Ok(0..8));
+        assert_eq!(layout.range(SharedBufferSlotIndex(1), 8), Ok(8..16));
+        assert_eq!(layout.range(SharedBufferSlotIndex(2), 8), Ok(16..24));
         assert_eq!(
-            layout.range(SharedBufferSlotIndex::new(3), 0),
+            layout.range(SharedBufferSlotIndex(3), 0),
             Err(SharedBufferError::InvalidSlot)
         );
         assert_eq!(
-            layout.range(SharedBufferSlotIndex::new(0), 9),
+            layout.range(SharedBufferSlotIndex(0), 9),
             Err(SharedBufferError::RangeExceedsSlot)
         );
     }
@@ -290,16 +278,14 @@ mod tests {
         let memory = Arc::new(TestSharedMemory::new(layout.total_len()));
         let pool = SharedBufferPool::new(Arc::clone(&memory), layout).unwrap();
 
-        pool.write(SharedBufferSlotIndex::new(0), &[1, 2, 3])
-            .unwrap();
-        pool.write(SharedBufferSlotIndex::new(2), &[4, 5]).unwrap();
+        pool.write(SharedBufferSlotIndex(0), &[1, 2, 3]).unwrap();
+        pool.write(SharedBufferSlotIndex(2), &[4, 5]).unwrap();
         let mut first = [0; 3];
-        pool.read(SharedBufferSlotIndex::new(0), &mut first)
-            .unwrap();
+        pool.read(SharedBufferSlotIndex(0), &mut first).unwrap();
         assert_eq!(first, [1, 2, 3]);
         assert_eq!(&memory.bytes()[8..16], &[0; 8]);
         assert_eq!(
-            pool.write(SharedBufferSlotIndex::new(2), &[0; 9]),
+            pool.write(SharedBufferSlotIndex(2), &[0; 9]),
             Err(SharedBufferError::RangeExceedsSlot)
         );
     }

--- a/litebox_broker_protocol/src/shared_memory.rs
+++ b/litebox_broker_protocol/src/shared_memory.rs
@@ -3,7 +3,28 @@
 
 //! Transport-neutral shared-memory resources.
 
+use alloc::sync::Arc;
+use core::ops::Range;
+
 use thiserror::Error;
+
+use crate::pipe::MAX_PIPE_TRANSFER_SIZE;
+
+/// Size of each association shared-buffer slot.
+pub const SHARED_BUFFER_SLOT_SIZE: u32 = MAX_PIPE_TRANSFER_SIZE;
+
+/// Number of slots in one association shared-buffer pool.
+pub const SHARED_BUFFER_SLOT_COUNT: u32 = 16;
+
+/// Fixed layout of one association shared-buffer pool.
+pub const SHARED_BUFFER_LAYOUT: SharedBufferLayout =
+    match SharedBufferLayout::new(SHARED_BUFFER_SLOT_SIZE, SHARED_BUFFER_SLOT_COUNT) {
+        Ok(layout) => layout,
+        Err(_) => panic!("broker shared-buffer constants must form a valid layout"),
+    };
+
+/// Exact shared-memory size required for one association shared-buffer pool.
+pub const SHARED_BUFFER_POOL_SIZE: usize = SHARED_BUFFER_LAYOUT.total_len();
 
 /// Error accessing a shared-memory resource.
 #[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
@@ -42,4 +63,286 @@ pub trait SharedMemory: Send + Sync + 'static {
 
     /// Copies bytes from `source` into shared memory.
     fn write(&self, offset: usize, source: &[u8]) -> Result<(), SharedMemoryError>;
+}
+
+impl<Memory: SharedMemory + ?Sized> SharedMemory for Arc<Memory> {
+    fn len(&self) -> usize {
+        (**self).len()
+    }
+
+    fn read(&self, offset: usize, destination: &mut [u8]) -> Result<(), SharedMemoryError> {
+        (**self).read(offset, destination)
+    }
+
+    fn write(&self, offset: usize, source: &[u8]) -> Result<(), SharedMemoryError> {
+        (**self).write(offset, source)
+    }
+}
+
+/// Error validating or accessing a fixed-slot shared-buffer pool.
+#[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SharedBufferError {
+    /// The layout has no slots, has empty slots, or exceeds the addressable range.
+    #[error("invalid shared-buffer layout")]
+    InvalidLayout,
+    /// The backing shared-memory length does not exactly match the layout.
+    #[error("shared-memory length does not match the shared-buffer layout")]
+    MemoryLengthMismatch,
+    /// The requested slot does not exist in the layout.
+    #[error("shared-buffer slot is out of bounds")]
+    InvalidSlot,
+    /// The requested byte range does not fit in one slot.
+    #[error("shared-buffer range exceeds the slot size")]
+    RangeExceedsSlot,
+    /// The backing shared-memory access failed.
+    #[error("shared-memory access failed: {0}")]
+    SharedMemory(#[from] SharedMemoryError),
+}
+
+/// Immutable fixed-slot layout for an association shared-buffer pool.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SharedBufferLayout {
+    slot_size: u32,
+    slot_count: u32,
+    total_len: usize,
+}
+
+impl SharedBufferLayout {
+    /// Creates a checked fixed-slot layout.
+    pub const fn new(slot_size: u32, slot_count: u32) -> Result<Self, SharedBufferError> {
+        if slot_size == 0 || slot_count == 0 {
+            return Err(SharedBufferError::InvalidLayout);
+        }
+        let Some(total_len) = (slot_size as usize).checked_mul(slot_count as usize) else {
+            return Err(SharedBufferError::InvalidLayout);
+        };
+        if total_len > isize::MAX as usize {
+            return Err(SharedBufferError::InvalidLayout);
+        }
+        Ok(Self {
+            slot_size,
+            slot_count,
+            total_len,
+        })
+    }
+
+    /// Returns the size of each slot in bytes.
+    pub const fn slot_size(self) -> u32 {
+        self.slot_size
+    }
+
+    /// Returns the number of slots.
+    pub const fn slot_count(self) -> u32 {
+        self.slot_count
+    }
+
+    /// Returns the exact backing-memory length required by this layout.
+    pub const fn total_len(self) -> usize {
+        self.total_len
+    }
+
+    /// Returns the shared-memory range for a prefix of one slot.
+    pub fn range(
+        self,
+        slot: SharedBufferSlotIndex,
+        length: usize,
+    ) -> Result<Range<usize>, SharedBufferError> {
+        if slot.index() >= self.slot_count {
+            return Err(SharedBufferError::InvalidSlot);
+        }
+        if length > self.slot_size as usize {
+            return Err(SharedBufferError::RangeExceedsSlot);
+        }
+        let offset = (slot.index() as usize)
+            .checked_mul(self.slot_size as usize)
+            .ok_or(SharedBufferError::InvalidLayout)?;
+        let end = offset
+            .checked_add(length)
+            .ok_or(SharedBufferError::RangeExceedsSlot)?;
+        Ok(offset..end)
+    }
+}
+
+/// Index of one fixed shared-buffer slot.
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SharedBufferSlotIndex(u32);
+
+impl SharedBufferSlotIndex {
+    /// Creates a slot index.
+    pub const fn new(index: u32) -> Self {
+        Self(index)
+    }
+
+    /// Returns the numeric slot index.
+    pub const fn index(self) -> u32 {
+        self.0
+    }
+}
+
+/// A shared-memory resource viewed as a checked fixed-slot buffer pool.
+///
+/// Slot ownership and reuse remain responsibilities of the protocol using the
+/// pool. Accessors copy bytes and never expose references into peer-writable
+/// memory.
+pub struct SharedBufferPool<Memory: SharedMemory> {
+    memory: Memory,
+    layout: SharedBufferLayout,
+}
+
+impl<Memory: SharedMemory> SharedBufferPool<Memory> {
+    /// Attaches a layout to an exact-size shared-memory resource.
+    pub fn new(memory: Memory, layout: SharedBufferLayout) -> Result<Self, SharedBufferError> {
+        if memory.len() != layout.total_len() {
+            return Err(SharedBufferError::MemoryLengthMismatch);
+        }
+        Ok(Self { memory, layout })
+    }
+
+    /// Returns the fixed-slot layout.
+    pub const fn layout(&self) -> SharedBufferLayout {
+        self.layout
+    }
+
+    /// Returns the backing shared-memory resource.
+    pub const fn memory(&self) -> &Memory {
+        &self.memory
+    }
+
+    /// Copies bytes from the start of `slot` into `destination`.
+    pub fn read(
+        &self,
+        slot: SharedBufferSlotIndex,
+        destination: &mut [u8],
+    ) -> Result<(), SharedBufferError> {
+        let range = self.layout.range(slot, destination.len())?;
+        self.memory.read(range.start, destination)?;
+        Ok(())
+    }
+
+    /// Copies `source` into the start of `slot`.
+    pub fn write(
+        &self,
+        slot: SharedBufferSlotIndex,
+        source: &[u8],
+    ) -> Result<(), SharedBufferError> {
+        let range = self.layout.range(slot, source.len())?;
+        self.memory.write(range.start, source)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec;
+    use alloc::vec::Vec;
+    use std::sync::Mutex;
+
+    #[test]
+    fn association_layout_has_expected_size() {
+        assert_eq!(SHARED_BUFFER_LAYOUT.slot_size(), 32 * 1024);
+        assert_eq!(SHARED_BUFFER_LAYOUT.slot_count(), 16);
+        assert_eq!(SHARED_BUFFER_POOL_SIZE, 512 * 1024);
+    }
+
+    #[test]
+    fn layout_rejects_empty_and_overflowing_configurations() {
+        assert_eq!(
+            SharedBufferLayout::new(0, 1),
+            Err(SharedBufferError::InvalidLayout)
+        );
+        assert_eq!(
+            SharedBufferLayout::new(1, 0),
+            Err(SharedBufferError::InvalidLayout)
+        );
+        assert_eq!(
+            SharedBufferLayout::new(u32::MAX, u32::MAX),
+            Err(SharedBufferError::InvalidLayout)
+        );
+    }
+
+    #[test]
+    fn layout_derives_disjoint_slot_ranges() {
+        let layout = SharedBufferLayout::new(8, 3).unwrap();
+
+        assert_eq!(layout.range(SharedBufferSlotIndex::new(0), 8), Ok(0..8));
+        assert_eq!(layout.range(SharedBufferSlotIndex::new(1), 8), Ok(8..16));
+        assert_eq!(layout.range(SharedBufferSlotIndex::new(2), 8), Ok(16..24));
+        assert_eq!(
+            layout.range(SharedBufferSlotIndex::new(3), 0),
+            Err(SharedBufferError::InvalidSlot)
+        );
+        assert_eq!(
+            layout.range(SharedBufferSlotIndex::new(0), 9),
+            Err(SharedBufferError::RangeExceedsSlot)
+        );
+    }
+
+    #[test]
+    fn pool_checks_backing_length_and_slot_boundaries() {
+        let layout = SharedBufferLayout::new(8, 3).unwrap();
+        assert!(matches!(
+            SharedBufferPool::new(TestSharedMemory::new(23), layout),
+            Err(SharedBufferError::MemoryLengthMismatch)
+        ));
+        let memory = Arc::new(TestSharedMemory::new(layout.total_len()));
+        let pool = SharedBufferPool::new(Arc::clone(&memory), layout).unwrap();
+
+        pool.write(SharedBufferSlotIndex::new(0), &[1, 2, 3])
+            .unwrap();
+        pool.write(SharedBufferSlotIndex::new(2), &[4, 5]).unwrap();
+        let mut first = [0; 3];
+        pool.read(SharedBufferSlotIndex::new(0), &mut first)
+            .unwrap();
+        assert_eq!(first, [1, 2, 3]);
+        assert_eq!(&memory.bytes()[8..16], &[0; 8]);
+        assert_eq!(
+            pool.write(SharedBufferSlotIndex::new(2), &[0; 9]),
+            Err(SharedBufferError::RangeExceedsSlot)
+        );
+    }
+
+    struct TestSharedMemory(Mutex<Vec<u8>>);
+
+    impl TestSharedMemory {
+        fn new(length: usize) -> Self {
+            Self(Mutex::new(vec![0; length]))
+        }
+
+        fn bytes(&self) -> Vec<u8> {
+            self.0.lock().unwrap().clone()
+        }
+    }
+
+    impl SharedMemory for TestSharedMemory {
+        fn len(&self) -> usize {
+            self.0.lock().unwrap().len()
+        }
+
+        fn read(&self, offset: usize, destination: &mut [u8]) -> Result<(), SharedMemoryError> {
+            let memory = self.0.lock().unwrap();
+            let end = offset
+                .checked_add(destination.len())
+                .ok_or(SharedMemoryError::InvalidRange)?;
+            let source = memory
+                .get(offset..end)
+                .ok_or(SharedMemoryError::InvalidRange)?;
+            destination.copy_from_slice(source);
+            Ok(())
+        }
+
+        fn write(&self, offset: usize, source: &[u8]) -> Result<(), SharedMemoryError> {
+            let mut memory = self.0.lock().unwrap();
+            let end = offset
+                .checked_add(source.len())
+                .ok_or(SharedMemoryError::InvalidRange)?;
+            let destination = memory
+                .get_mut(offset..end)
+                .ok_or(SharedMemoryError::InvalidRange)?;
+            destination.copy_from_slice(source);
+            Ok(())
+        }
+    }
 }

--- a/litebox_broker_transport/src/shared_memory.rs
+++ b/litebox_broker_transport/src/shared_memory.rs
@@ -366,7 +366,7 @@ mod tests {
         let pool = SharedBufferPool::new(memory, SHARED_BUFFER_LAYOUT).unwrap();
         for index in 0..SHARED_BUFFER_LAYOUT.slot_count() {
             pool.write(
-                SharedBufferSlotIndex::new(index),
+                SharedBufferSlotIndex(index),
                 &[u8::try_from(index).unwrap()],
             )
             .unwrap();
@@ -380,7 +380,7 @@ mod tests {
         for index in 0..SHARED_BUFFER_LAYOUT.slot_count() {
             let mut byte = [0];
             mapped_pool
-                .read(SharedBufferSlotIndex::new(index), &mut byte)
+                .read(SharedBufferSlotIndex(index), &mut byte)
                 .unwrap();
             assert_eq!(byte, [u8::try_from(index).unwrap()]);
         }

--- a/litebox_broker_transport/src/shared_memory.rs
+++ b/litebox_broker_transport/src/shared_memory.rs
@@ -300,6 +300,9 @@ fn invalid_data(message: &'static str) -> Error {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use litebox_broker_protocol::shared_memory::{
+        SHARED_BUFFER_LAYOUT, SHARED_BUFFER_POOL_SIZE, SharedBufferPool, SharedBufferSlotIndex,
+    };
     use rustix::io::FdFlags;
     use std::io::Write;
     use std::time::Duration;
@@ -358,18 +361,30 @@ mod tests {
     }
 
     #[test]
-    fn transfers_exact_size_memory_with_close_on_exec() {
-        let length = 24;
-        let memory = MemfdSharedMemory::create(length).unwrap();
-        memory.write(16, &[1, 2, 3]).unwrap();
+    fn transfers_exact_pool_with_shared_visibility_and_close_on_exec() {
+        let memory = MemfdSharedMemory::create(SHARED_BUFFER_POOL_SIZE).unwrap();
+        let pool = SharedBufferPool::new(memory, SHARED_BUFFER_LAYOUT).unwrap();
+        for index in 0..SHARED_BUFFER_LAYOUT.slot_count() {
+            pool.write(
+                SharedBufferSlotIndex::new(index),
+                &[u8::try_from(index).unwrap()],
+            )
+            .unwrap();
+        }
         let (mut local_stream, mut host_stream) = UnixStream::pair().unwrap();
 
-        send_memfd(&mut host_stream, &memory, None).unwrap();
-        let mapped_memory = receive_memfd(&mut local_stream, length, None).unwrap();
-        let mut bytes = [0; 3];
-        mapped_memory.read(16, &mut bytes).unwrap();
-        assert_eq!(bytes, [1, 2, 3]);
-        let flags = rustix::io::fcntl_getfd(mapped_memory.as_fd()).unwrap();
+        send_memfd(&mut host_stream, pool.memory(), None).unwrap();
+        let mapped_memory =
+            receive_memfd(&mut local_stream, SHARED_BUFFER_POOL_SIZE, None).unwrap();
+        let mapped_pool = SharedBufferPool::new(mapped_memory, SHARED_BUFFER_LAYOUT).unwrap();
+        for index in 0..SHARED_BUFFER_LAYOUT.slot_count() {
+            let mut byte = [0];
+            mapped_pool
+                .read(SharedBufferSlotIndex::new(index), &mut byte)
+                .unwrap();
+            assert_eq!(byte, [u8::try_from(index).unwrap()]);
+        }
+        let flags = rustix::io::fcntl_getfd(mapped_pool.memory().as_fd()).unwrap();
         assert!(flags.contains(FdFlags::CLOEXEC));
     }
 
@@ -412,9 +427,9 @@ mod tests {
 
     #[test]
     fn rejects_wrong_size_and_unsealed_memory() {
-        let length = 8;
+        let length = SHARED_BUFFER_POOL_SIZE;
 
-        let wrong_size = MemfdSharedMemory::create(7).unwrap();
+        let wrong_size = MemfdSharedMemory::create(length - 1).unwrap();
         let (mut receiver, mut sender) = UnixStream::pair().unwrap();
         send_memfd(&mut sender, &wrong_size, None).unwrap();
         assert_eq!(

--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -13,7 +13,9 @@ use std::time::{Duration, Instant};
 use clap::Parser;
 use litebox_broker_core::{BrokerCore, ObjectRights, PolicyEngine};
 use litebox_broker_host::{ConnectionTermination, serve_connection};
-use litebox_broker_protocol::pipe::PIPE_TRANSFER_BUFFER_SIZE;
+use litebox_broker_protocol::shared_memory::{
+    SHARED_BUFFER_LAYOUT, SHARED_BUFFER_POOL_SIZE, SharedBufferPool,
+};
 use litebox_broker_transport::shared_memory::MemfdSharedMemory;
 use litebox_broker_transport::unix_socket::{
     UnixStreamHostControlChannel, UnixStreamHostNotificationChannel, validate_peer_process,
@@ -98,7 +100,8 @@ fn serve_runner(
         setup_deadline,
         "notification",
     )?;
-    let shared_memory = MemfdSharedMemory::create(PIPE_TRANSFER_BUFFER_SIZE)?;
+    let shared_memory = MemfdSharedMemory::create(SHARED_BUFFER_POOL_SIZE)?;
+    let shared_buffers = SharedBufferPool::new(shared_memory, SHARED_BUFFER_LAYOUT)?;
     let mut control_channel =
         UnixStreamHostControlChannel::from_host_guaranteed(control_stream, setup_deadline);
     let mut notification_channel =
@@ -108,9 +111,9 @@ fn serve_runner(
         broker,
         &mut control_channel,
         &mut notification_channel,
-        &shared_memory,
+        &shared_buffers,
         |channel| {
-            channel.send_memfd(&shared_memory, Some(setup_deadline))?;
+            channel.send_memfd(shared_buffers.memory(), Some(setup_deadline))?;
             setup_completed.set(true);
             Ok(())
         },

--- a/litebox_broker_userland/tests/notification_runtime.rs
+++ b/litebox_broker_userland/tests/notification_runtime.rs
@@ -7,8 +7,10 @@ use std::sync::Arc;
 use litebox_broker_core::{BrokerCore, ObjectRights, PolicyEngine};
 use litebox_broker_host::{ConnectionTermination, serve_connection};
 use litebox_broker_local::BrokerLocal;
-use litebox_broker_protocol::pipe::PIPE_TRANSFER_BUFFER_SIZE;
 use litebox_broker_protocol::readiness::ReadinessFlags;
+use litebox_broker_protocol::shared_memory::{
+    SHARED_BUFFER_LAYOUT, SHARED_BUFFER_POOL_SIZE, SharedBufferPool,
+};
 use litebox_broker_transport::shared_memory::MemfdSharedMemory;
 use litebox_broker_transport::unix_socket::{
     UnixStreamHostControlChannel, UnixStreamHostNotificationChannel, UnixStreamLocalControlChannel,
@@ -22,7 +24,9 @@ fn host_serves_control_requests_over_paired_userland_channels() {
     .unwrap();
     let (local_control, host_control) = UnixStream::pair().unwrap();
     let (_local_notification, host_notification) = UnixStream::pair().unwrap();
-    let host_shared_memory = MemfdSharedMemory::create(PIPE_TRANSFER_BUFFER_SIZE).unwrap();
+    let host_shared_memory = MemfdSharedMemory::create(SHARED_BUFFER_POOL_SIZE).unwrap();
+    let host_shared_buffers =
+        SharedBufferPool::new(host_shared_memory, SHARED_BUFFER_LAYOUT).unwrap();
 
     let host_thread = std::thread::spawn(move || {
         let mut control = UnixStreamHostControlChannel::from_accepted(host_control);
@@ -31,15 +35,15 @@ fn host_serves_control_requests_over_paired_userland_channels() {
             &broker,
             &mut control,
             &mut notification,
-            &host_shared_memory,
-            |channel| channel.send_memfd(&host_shared_memory, None),
+            &host_shared_buffers,
+            |channel| channel.send_memfd(host_shared_buffers.memory(), None),
         )
     });
 
     let local = BrokerLocal::negotiate(
         UnixStreamLocalControlChannel::from_connected(local_control),
         |channel| {
-            let shared_memory = channel.receive_memfd(PIPE_TRANSFER_BUFFER_SIZE, None)?;
+            let shared_memory = channel.receive_memfd(SHARED_BUFFER_POOL_SIZE, None)?;
             let _cancellation = channel.activate(|| {})?;
             Ok(Arc::new(shared_memory))
         },

--- a/litebox_broker_userland/tests/userland_broker.rs
+++ b/litebox_broker_userland/tests/userland_broker.rs
@@ -9,8 +9,8 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use litebox_broker_local::BrokerLocal;
-use litebox_broker_protocol::pipe::PIPE_TRANSFER_BUFFER_SIZE;
 use litebox_broker_protocol::readiness::ReadinessFlags;
+use litebox_broker_protocol::shared_memory::SHARED_BUFFER_POOL_SIZE;
 use litebox_broker_transport::unix_socket::{
     UnixStreamLocalControlChannel, UnixStreamLocalNotificationChannel,
 };
@@ -84,7 +84,7 @@ fn run_fake_runner(args: &[OsString]) {
         connect_notification_with_retry(Path::new(notification_socket_path)).unwrap();
     let local = BrokerLocal::negotiate(control_channel, |channel| {
         let shared_memory = channel.receive_memfd(
-            PIPE_TRANSFER_BUFFER_SIZE,
+            SHARED_BUFFER_POOL_SIZE,
             Some(Instant::now() + Duration::from_secs(5)),
         )?;
         let _cancellation = channel.activate(|| {})?;

--- a/litebox_runner_linux_userland/src/broker.rs
+++ b/litebox_runner_linux_userland/src/broker.rs
@@ -13,7 +13,7 @@ use std::{
 use anyhow::{Context as _, Result};
 use litebox_broker_local::{BrokerLocal, BrokerNotifications};
 use litebox_broker_protocol::message::BrokerNotification;
-use litebox_broker_protocol::pipe::PIPE_TRANSFER_BUFFER_SIZE;
+use litebox_broker_protocol::shared_memory::SHARED_BUFFER_POOL_SIZE;
 use litebox_broker_transport::unix_socket::{
     UnixStreamLocalControlCancellation, UnixStreamLocalControlChannel,
     UnixStreamLocalNotificationCancellation, UnixStreamLocalNotificationChannel,
@@ -65,7 +65,7 @@ pub(crate) fn connect(
         let association_coordinator = Arc::clone(&association_coordinator);
         move |channel| {
             let shared_memory =
-                channel.receive_memfd(PIPE_TRANSFER_BUFFER_SIZE, Some(setup_deadline))?;
+                channel.receive_memfd(SHARED_BUFFER_POOL_SIZE, Some(setup_deadline))?;
             let weak_association_coordinator = Arc::downgrade(&association_coordinator);
             let control_cancellation_handle = channel.activate(move || {
                 if let Some(association_coordinator) = weak_association_coordinator.upgrade() {

--- a/litebox_runner_linux_userland/tests/run.rs
+++ b/litebox_runner_linux_userland/tests/run.rs
@@ -342,9 +342,14 @@ fn spawn_test_broker(
                     .expect("failed to accept broker local control connection");
                 let shared_memory =
                     litebox_broker_transport::shared_memory::MemfdSharedMemory::create(
-                        litebox_broker_protocol::pipe::PIPE_TRANSFER_BUFFER_SIZE,
+                        litebox_broker_protocol::shared_memory::SHARED_BUFFER_POOL_SIZE,
                     )
                     .expect("failed to create broker test shared memory");
+                let shared_buffers = litebox_broker_protocol::shared_memory::SharedBufferPool::new(
+                    shared_memory,
+                    litebox_broker_protocol::shared_memory::SHARED_BUFFER_LAYOUT,
+                )
+                .expect("failed to attach broker test shared-buffer layout");
                 let (notification_stream, _) = notification_listener
                     .accept()
                     .expect("failed to accept broker local notification connection");
@@ -378,8 +383,8 @@ fn spawn_test_broker(
                     &broker,
                     &mut channel,
                     &mut notification_channel,
-                    &shared_memory,
-                    |channel| channel.inner.send_memfd(&shared_memory, None),
+                    &shared_buffers,
+                    |channel| channel.inner.send_memfd(shared_buffers.memory(), None),
                 )
                 .expect("broker host failed");
                 assert_eq!(


### PR DESCRIPTION
Adds a checked 16-slot association shared-buffer pool with 32 KiB per slot and wires the full 512 KiB mapping through Linux-userland broker setup. Pipe payloads remain serialized through slot zero. Slot leasing and wire protocol changes are intentionally deferred.