### PR TITLE
Set ACCESSED and DIRTY on page-table (non-leaf) entries

### DIFF
--- a/litebox_platform_linux_kernel/src/arch/x86/mm/paging.rs
+++ b/litebox_platform_linux_kernel/src/arch/x86/mm/paging.rs
@@ -324,9 +324,14 @@ impl<M: MemoryProvider, const ALIGN: usize> PageTableImpl<ALIGN> for X64PageTabl
                 let mut allocator = PageTableAllocator::<M>::new();
                 // TODO: if it is file-backed, we need to read the page from file
                 let frame = PageTableAllocator::<M>::allocate_frame(true).unwrap();
+                // ACCESSED and DIRTY are pre-set here (mirroring the Linux kernel's
+                // `_KERNPG_TABLE`) so the CPU's page-table walker doesn't need an
+                // atomic read-modify-write on this entry the first time it's traversed.
                 let table_flags = PageTableFlags::PRESENT
                     | PageTableFlags::WRITABLE
-                    | PageTableFlags::USER_ACCESSIBLE;
+                    | PageTableFlags::USER_ACCESSIBLE
+                    | PageTableFlags::ACCESSED
+                    | PageTableFlags::DIRTY;
                 match unsafe {
                     inner.map_to_with_table_flags(
                         page,

--- a/litebox_platform_lvbs/src/arch/x86/mm/paging.rs
+++ b/litebox_platform_lvbs/src/arch/x86/mm/paging.rs
@@ -609,7 +609,14 @@ impl<M: MemoryProvider, const ALIGN: usize> X64PageTable<'_, M, ALIGN> {
                 flags
             };
             // Parent entries use a stable permissive constant, not leaf-derived flags.
-            let table_flags = PageTableFlags::PRESENT | PageTableFlags::WRITABLE;
+            //
+            // ACCESSED and DIRTY are pre-set here (mirroring the Linux kernel's
+            // `_KERNPG_TABLE`) so the CPU's page-table walker doesn't need an
+            // atomic read-modify-write on this entry the first time it's traversed.
+            let table_flags = PageTableFlags::PRESENT
+                | PageTableFlags::WRITABLE
+                | PageTableFlags::ACCESSED
+                | PageTableFlags::DIRTY;
 
             match unsafe {
                 inner.map_to_with_table_flags(
@@ -668,7 +675,13 @@ impl<M: MemoryProvider, const ALIGN: usize> X64PageTable<'_, M, ALIGN> {
             .map_err(|_| MapToError::FrameAllocationFailed)?;
         let end_page = start_page + frames.len() as u64;
 
-        let table_flags = PageTableFlags::PRESENT | PageTableFlags::WRITABLE;
+        // ACCESSED and DIRTY are pre-set here (mirroring the Linux kernel's
+        // `_KERNPG_TABLE`) so the CPU's page-table walker doesn't need an
+        // atomic read-modify-write on this entry the first time it's traversed.
+        let table_flags = PageTableFlags::PRESENT
+            | PageTableFlags::WRITABLE
+            | PageTableFlags::ACCESSED
+            | PageTableFlags::DIRTY;
         for (page, &target_frame) in Page::range(start_page, end_page).zip(frames.iter()) {
             // Note: Since we lock the entire page table for the duration of this function (`self.inner.lock()`),
             // there should be no concurrent modifications to the page table. If we allow concurrent mappings
@@ -890,9 +903,14 @@ impl<M: MemoryProvider, const ALIGN: usize> PageTableImpl<ALIGN> for X64PageTabl
                 let mut allocator = PageTableAllocator::<M>::new();
                 // TODO: if it is file-backed, we need to read the page from file
                 let frame = PageTableAllocator::<M>::allocate_frame(true).unwrap();
+                // ACCESSED and DIRTY are pre-set here (mirroring the Linux kernel's
+                // `_KERNPG_TABLE`) so the CPU's page-table walker doesn't need an
+                // atomic read-modify-write on this entry the first time it's traversed.
                 let table_flags = PageTableFlags::PRESENT
                     | PageTableFlags::WRITABLE
-                    | PageTableFlags::USER_ACCESSIBLE;
+                    | PageTableFlags::USER_ACCESSIBLE
+                    | PageTableFlags::ACCESSED
+                    | PageTableFlags::DIRTY;
                 match unsafe {
                     inner.map_to_with_table_flags(
                         page,

--- a/litebox_runner_lvbs/src/main.rs
+++ b/litebox_runner_lvbs/src/main.rs
@@ -69,7 +69,14 @@ const R_X86_64_RELATIVE: u64 = 8;
 const KERNEL_OFFSET: u64 = litebox_platform_lvbs::KERNEL_OFFSET;
 
 /// Page table entry flags for Phase 1 mappings (present + writable).
-const PTE_TABLE_FLAGS: u64 = PageTableFlags::PRESENT.bits() | PageTableFlags::WRITABLE.bits();
+///
+/// ACCESSED and DIRTY are pre-set here too (mirroring the Linux kernel's
+/// `_KERNPG_TABLE`) so the CPU's page-table walker doesn't need an atomic
+/// read-modify-write on these entries the first time they're traversed.
+const PTE_TABLE_FLAGS: u64 = PageTableFlags::PRESENT.bits()
+    | PageTableFlags::WRITABLE.bits()
+    | PageTableFlags::ACCESSED.bits()
+    | PageTableFlags::DIRTY.bits();
 
 /// x86-64 page table structure constants
 const ENTRIES_PER_PT_PAGE: usize = 512;


### PR DESCRIPTION
Mirrors the Linux kernel's _KERNPG_TABLE convention (_PAGE_PRESENT | _PAGE_RW | _PAGE_ACCESSED | _PAGE_DIRTY) for entries that point at another page table (PML4E, non-huge PDPTE, non-huge PDE). Pre-setting Accessed/Dirty avoids the CPU needing an atomic read-modify-write on the entry the first time it's walked, reducing cache-coherency traffic on the page-table walk path.

Addresses microsoft/litebox#980, following up on a review comment from ziqiaozhou on PR #972 that suggested this optimization.

Fixes 5 call sites that construct parent/intermediate table-pointer flags: three in litebox_platform_lvbs's map_phys_frame_range, map_non_contiguous_phys_frames, and page-fault handler; one in litebox_platform_linux_kernel's page-fault handler; and the raw PTE_TABLE_FLAGS constant used for manual PML4/PDPT/PDE writes during litebox_runner_lvbs's early boot trampoline mapping.


