### PR TITLE
Pre-set ACCESSED and DIRTY flags in page table entries

### DIFF
--- a/litebox_platform_linux_kernel/src/arch/x86/mm/paging.rs
+++ b/litebox_platform_linux_kernel/src/arch/x86/mm/paging.rs
@@ -324,9 +324,14 @@ impl<M: MemoryProvider, const ALIGN: usize> PageTableImpl<ALIGN> for X64PageTabl
                 let mut allocator = PageTableAllocator::<M>::new();
                 // TODO: if it is file-backed, we need to read the page from file
                 let frame = PageTableAllocator::<M>::allocate_frame(true).unwrap();
+                // ACCESSED and DIRTY are pre-set here (mirroring the Linux kernel's
+                // `_KERNPG_TABLE`) so the CPU's page-table walker doesn't need an
+                // atomic read-modify-write on this entry the first time it's traversed.
                 let table_flags = PageTableFlags::PRESENT
                     | PageTableFlags::WRITABLE
-                    | PageTableFlags::USER_ACCESSIBLE;
+                    | PageTableFlags::USER_ACCESSIBLE
+                    | PageTableFlags::ACCESSED
+                    | PageTableFlags::DIRTY;
                 match unsafe {
                     inner.map_to_with_table_flags(
                         page,

--- a/litebox_platform_lvbs/src/arch/x86/mm/paging.rs
+++ b/litebox_platform_lvbs/src/arch/x86/mm/paging.rs
@@ -609,7 +609,14 @@ impl<M: MemoryProvider, const ALIGN: usize> X64PageTable<'_, M, ALIGN> {
                 flags
             };
             // Parent entries use a stable permissive constant, not leaf-derived flags.
-            let table_flags = PageTableFlags::PRESENT | PageTableFlags::WRITABLE;
+            //
+            // ACCESSED and DIRTY are pre-set here (mirroring the Linux kernel's
+            // `_KERNPG_TABLE`) so the CPU's page-table walker doesn't need an
+            // atomic read-modify-write on this entry the first time it's traversed.
+            let table_flags = PageTableFlags::PRESENT
+                | PageTableFlags::WRITABLE
+                | PageTableFlags::ACCESSED
+                | PageTableFlags::DIRTY;
 
             match unsafe {
                 inner.map_to_with_table_flags(
@@ -668,7 +675,13 @@ impl<M: MemoryProvider, const ALIGN: usize> X64PageTable<'_, M, ALIGN> {
             .map_err(|_| MapToError::FrameAllocationFailed)?;
         let end_page = start_page + frames.len() as u64;
 
-        let table_flags = PageTableFlags::PRESENT | PageTableFlags::WRITABLE;
+        // ACCESSED and DIRTY are pre-set here (mirroring the Linux kernel's
+        // `_KERNPG_TABLE`) so the CPU's page-table walker doesn't need an
+        // atomic read-modify-write on this entry the first time it's traversed.
+        let table_flags = PageTableFlags::PRESENT
+            | PageTableFlags::WRITABLE
+            | PageTableFlags::ACCESSED
+            | PageTableFlags::DIRTY;
         for (page, &target_frame) in Page::range(start_page, end_page).zip(frames.iter()) {
             // Note: Since we lock the entire page table for the duration of this function (`self.inner.lock()`),
             // there should be no concurrent modifications to the page table. If we allow concurrent mappings
@@ -890,9 +903,14 @@ impl<M: MemoryProvider, const ALIGN: usize> PageTableImpl<ALIGN> for X64PageTabl
                 let mut allocator = PageTableAllocator::<M>::new();
                 // TODO: if it is file-backed, we need to read the page from file
                 let frame = PageTableAllocator::<M>::allocate_frame(true).unwrap();
+                // ACCESSED and DIRTY are pre-set here (mirroring the Linux kernel's
+                // `_KERNPG_TABLE`) so the CPU's page-table walker doesn't need an
+                // atomic read-modify-write on this entry the first time it's traversed.
                 let table_flags = PageTableFlags::PRESENT
                     | PageTableFlags::WRITABLE
-                    | PageTableFlags::USER_ACCESSIBLE;
+                    | PageTableFlags::USER_ACCESSIBLE
+                    | PageTableFlags::ACCESSED
+                    | PageTableFlags::DIRTY;
                 match unsafe {
                     inner.map_to_with_table_flags(
                         page,

--- a/litebox_runner_lvbs/src/main.rs
+++ b/litebox_runner_lvbs/src/main.rs
@@ -69,7 +69,14 @@ const R_X86_64_RELATIVE: u64 = 8;
 const KERNEL_OFFSET: u64 = litebox_platform_lvbs::KERNEL_OFFSET;
 
 /// Page table entry flags for Phase 1 mappings (present + writable).
-const PTE_TABLE_FLAGS: u64 = PageTableFlags::PRESENT.bits() | PageTableFlags::WRITABLE.bits();
+///
+/// ACCESSED and DIRTY are pre-set here too (mirroring the Linux kernel's
+/// `_KERNPG_TABLE`) so the CPU's page-table walker doesn't need an atomic
+/// read-modify-write on these entries the first time they're traversed.
+const PTE_TABLE_FLAGS: u64 = PageTableFlags::PRESENT.bits()
+    | PageTableFlags::WRITABLE.bits()
+    | PageTableFlags::ACCESSED.bits()
+    | PageTableFlags::DIRTY.bits();
 
 /// x86-64 page table structure constants
 const ENTRIES_PER_PT_PAGE: usize = 512;


### PR DESCRIPTION
Pre-set the ACCESSED and DIRTY flags when creating page table entries, matching Linux’s `_KERNPG_TABLE` behavior. This avoids atomic read-modify-write operations by the CPU page-table walker on first access.