### PR TITLE
Execute broker requests concurrently

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1493,6 +1493,7 @@ version = "0.1.0"
 dependencies = [
  "litebox_broker_core",
  "litebox_broker_protocol",
+ "spin 0.9.8",
  "thiserror",
 ]
 

--- a/litebox_broker_host/Cargo.toml
+++ b/litebox_broker_host/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 litebox_broker_core = { path = "../litebox_broker_core", version = "0.1.0" }
 litebox_broker_protocol = { path = "../litebox_broker_protocol", version = "0.1.0" }
+spin = { version = "0.9.8", default-features = false, features = ["spin_mutex"] }
 thiserror = { version = "2.0.6", default-features = false }
 
 [lints]

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -34,33 +34,110 @@ use litebox_broker_protocol::shared_memory::{
     SharedBufferSlotIndex, SharedMemory,
 };
 use litebox_broker_protocol::{BROKER_PROTOCOL_VERSION, RequestId};
+use spin::mutex::SpinMutex;
 
 mod error;
 
 pub use error::{BrokerHostError, Result};
 
-/// Authenticates, negotiates, and serves one broker association over paired
-/// control and notification channels.
+/// Negotiated active association, or a terminal outcome reached during setup.
+pub type ConnectionSetup<'a, Memory> =
+    core::result::Result<BrokerHostAssociation<'a, Memory>, ConnectionTermination>;
+
+/// Active portable broker association.
 ///
-/// The deployment must bind both channels to the same authenticated peer
-/// association. Active requests and responses remain on the control channel;
-/// broker-initiated readiness wakeups are sent on the notification channel.
-/// Event mutations caused by control requests return readiness in their control
-/// response and do not also emit a duplicate notification.
+/// Deployments may share this value across bounded workers. Each request is
+/// executed independently, while shared-buffer usage is synchronized and
+/// released immediately before publishing the response.
+pub struct BrokerHostAssociation<'a, Memory: SharedMemory> {
+    session: BrokerSession,
+    shared_buffers: &'a SharedBufferPool<Memory>,
+    state: SpinMutex<AssociationState>,
+}
+
+struct AssociationState {
+    failed: bool,
+    shared_buffer_usage: SharedBufferUsage,
+}
+
+impl<Memory: SharedMemory> BrokerHostAssociation<'_, Memory> {
+    /// Executes one active request and emits its response.
+    ///
+    /// Any fatal broker or response-channel error permanently fails this
+    /// association. Recoverable broker operation errors are emitted normally in
+    /// the correlated response.
+    pub fn execute_request<ChannelError>(
+        &self,
+        request: BrokerRequest,
+        send_response: impl FnOnce(&BrokerResponse) -> core::result::Result<(), ChannelError>,
+    ) -> Result<(), ChannelError> {
+        let BrokerRequest {
+            request_id,
+            operation,
+        } = request;
+        let buffer_descriptor = match &operation {
+            BrokerOperation::Pipe(PipeRequest::Read(request)) => Some(request.buffer),
+            BrokerOperation::Pipe(PipeRequest::Write(request)) => Some(request.buffer),
+            BrokerOperation::CloseObject(_)
+            | BrokerOperation::CheckReadiness(_)
+            | BrokerOperation::Event(_)
+            | BrokerOperation::Pipe(PipeRequest::Create(_)) => None,
+        };
+
+        {
+            let mut state = self.state.lock();
+            if state.failed {
+                return Err(BrokerHostError::Broker(ErrorCode::Internal));
+            }
+            if let Some(descriptor) = buffer_descriptor
+                && let Err(error) = state.shared_buffer_usage.begin(
+                    request_id,
+                    descriptor,
+                    self.shared_buffers.layout(),
+                )
+            {
+                state.failed = true;
+                return Err(BrokerHostError::Broker(error));
+            }
+        }
+
+        let result = match complete_request(handle_request(
+            &self.session,
+            operation,
+            self.shared_buffers,
+        )) {
+            Ok(result) => result,
+            Err(error) => {
+                self.state.lock().failed = true;
+                return Err(BrokerHostError::Broker(error));
+            }
+        };
+        if let Some(descriptor) = buffer_descriptor {
+            self.state
+                .lock()
+                .shared_buffer_usage
+                .end(request_id, descriptor.slot_index);
+        }
+        if let Err(error) = send_response(&BrokerResponse { request_id, result }) {
+            self.state.lock().failed = true;
+            return Err(BrokerHostError::Channel(error));
+        }
+        Ok(())
+    }
+}
+
+/// Authenticates and negotiates one broker control connection.
 ///
-/// `shared_buffers` belongs to this association. Payload descriptors are
-/// validated against trusted per-slot claim state. `send_shared_memory` runs
-/// after version negotiation and before active requests begin.
-pub fn serve_connection<ControlChannel, NotificationChannel, Memory, ChannelError>(
+/// `send_shared_memory` runs after version negotiation and before the active
+/// association is returned.
+pub fn setup_connection<'a, ControlChannel, Memory, ChannelError>(
     core: &BrokerCore,
     control_channel: &mut ControlChannel,
-    _notification_channel: &mut NotificationChannel,
-    shared_buffers: &SharedBufferPool<Memory>,
+    shared_buffers: &'a SharedBufferPool<Memory>,
     send_shared_memory: impl FnOnce(&mut ControlChannel) -> core::result::Result<(), ChannelError>,
-) -> Result<ConnectionTermination, ChannelError>
+) -> Result<ConnectionSetup<'a, Memory>, ChannelError>
 where
     ControlChannel: HostControlChannel<Error = ChannelError>,
-    NotificationChannel: HostNotificationChannel<Error = ChannelError>,
     Memory: SharedMemory,
 {
     if shared_buffers.layout() != SHARED_BUFFER_LAYOUT {
@@ -88,9 +165,11 @@ where
                         ErrorCode::ProtocolState,
                     ))
                     .map_err(BrokerHostError::Channel)?;
-                return Ok(ConnectionTermination::ProtocolViolation);
+                return Ok(Err(ConnectionTermination::ProtocolViolation));
             }
-            HostReceive::PeerClosed => return Ok(ConnectionTermination::PeerClosed),
+            HostReceive::PeerClosed => {
+                return Ok(Err(ConnectionTermination::PeerClosed));
+            }
         };
 
         let negotiated = request.protocol_version == BROKER_PROTOCOL_VERSION;
@@ -108,11 +187,47 @@ where
             .map_err(BrokerHostError::Channel)?;
         if negotiated {
             send_shared_memory(control_channel).map_err(BrokerHostError::Channel)?;
-            break;
+            return Ok(Ok(BrokerHostAssociation {
+                session,
+                shared_buffers,
+                state: SpinMutex::new(AssociationState {
+                    failed: false,
+                    shared_buffer_usage: SharedBufferUsage::new(),
+                }),
+            }));
         }
     }
+}
 
-    let mut shared_buffer_usage = SharedBufferUsage::new();
+/// Authenticates, negotiates, and serves one broker association over paired
+/// control and notification channels.
+///
+/// The deployment must bind both channels to the same authenticated peer
+/// association. Active requests and responses remain on the control channel;
+/// broker-initiated readiness wakeups are sent on the notification channel.
+/// Event mutations caused by control requests return readiness in their control
+/// response and do not also emit a duplicate notification.
+///
+/// `shared_buffers` belongs to this association. Payload descriptors are
+/// validated against trusted per-slot claim state. `send_shared_memory` runs
+/// after version negotiation and before active requests begin.
+pub fn serve_connection<ControlChannel, NotificationChannel, Memory, ChannelError>(
+    core: &BrokerCore,
+    control_channel: &mut ControlChannel,
+    _notification_channel: &mut NotificationChannel,
+    shared_buffers: &SharedBufferPool<Memory>,
+    send_shared_memory: impl FnOnce(&mut ControlChannel) -> core::result::Result<(), ChannelError>,
+) -> Result<ConnectionTermination, ChannelError>
+where
+    ControlChannel: HostControlChannel<Error = ChannelError>,
+    NotificationChannel: HostNotificationChannel<Error = ChannelError>,
+    Memory: SharedMemory,
+{
+    let association =
+        match setup_connection(core, control_channel, shared_buffers, send_shared_memory)? {
+            Ok(association) => association,
+            Err(termination) => return Ok(termination),
+        };
     loop {
         let request = match control_channel
             .recv_request()
@@ -124,32 +239,7 @@ where
             }
             HostReceive::PeerClosed => break,
         };
-
-        let BrokerRequest {
-            request_id,
-            operation,
-        } = request;
-        let buffer_descriptor = match &operation {
-            BrokerOperation::Pipe(PipeRequest::Read(request)) => Some(request.buffer),
-            BrokerOperation::Pipe(PipeRequest::Write(request)) => Some(request.buffer),
-            BrokerOperation::CloseObject(_)
-            | BrokerOperation::CheckReadiness(_)
-            | BrokerOperation::Event(_)
-            | BrokerOperation::Pipe(PipeRequest::Create(_)) => None,
-        };
-        if let Some(descriptor) = buffer_descriptor {
-            shared_buffer_usage
-                .begin(request_id, descriptor, shared_buffers.layout())
-                .map_err(BrokerHostError::Broker)?;
-        }
-        let result = complete_request(handle_request(&session, operation, shared_buffers))
-            .map_err(BrokerHostError::Broker)?;
-        control_channel
-            .send_response(&BrokerResponse { request_id, result })
-            .map_err(BrokerHostError::Channel)?;
-        if let Some(descriptor) = buffer_descriptor {
-            shared_buffer_usage.end(request_id, descriptor.slot_index);
-        }
+        association.execute_request(request, |response| control_channel.send_response(response))?;
     }
 
     Ok(ConnectionTermination::PeerClosed)
@@ -361,7 +451,8 @@ mod tests {
         SharedBufferDescriptor, SharedBufferPool, SharedMemoryError,
     };
     use litebox_broker_protocol::{ObjectHandle, ProtocolVersion, RequestId};
-    use std::sync::{Arc, Mutex};
+    use std::sync::{Arc, Condvar, Mutex, mpsc};
+    use std::time::Duration;
 
     #[test]
     fn host_request_handling_uses_one_broker_core() {
@@ -384,6 +475,9 @@ mod tests {
         active_request_closes_object_reference(&broker);
         association_shared_buffer_descriptors_stage_pipe_data(&broker);
         shared_buffer_usage_rejects_invalid_descriptors();
+        association_executes_distinct_slots_concurrently(&broker);
+        association_allows_slot_reuse_during_response_emission(&broker);
+        association_allows_out_of_order_responses(&broker);
     }
 
     fn serve_connection_negotiates_routes_one_request_and_returns_peer_closed(broker: &BrokerCore) {
@@ -559,9 +653,11 @@ mod tests {
             std::vec::Vec::from([Ok(HostReceive::Message(BrokerHandshakeRequest {
                 protocol_version: BROKER_PROTOCOL_VERSION,
             }))]),
-            std::vec::Vec::new(),
+            std::vec::Vec::from([Ok(HostReceive::Message(BrokerOperation::Event(
+                EventRequest::Create(CreateEventRequest { initial_count: 0 }),
+            )))]),
         );
-        channel.send_error = true;
+        channel.response_send_error = true;
         let mut notifications = FakeHostNotificationChannel::default();
 
         match serve_connection(
@@ -574,7 +670,8 @@ mod tests {
             Err(BrokerHostError::Channel(())) => {}
             result => panic!("unexpected serve result: {result:?}"),
         }
-        assert!(channel.handshake_responses.is_empty());
+        assert_eq!(channel.handshake_responses.len(), 1);
+        assert!(channel.results.is_empty());
     }
 
     fn serve_connection_returns_event_readiness_in_control_responses(broker: &BrokerCore) {
@@ -893,6 +990,174 @@ mod tests {
         );
     }
 
+    fn association_executes_distinct_slots_concurrently(broker: &BrokerCore) {
+        let shared_buffers = test_shared_buffers();
+        let association = test_association(broker, &shared_buffers);
+        let release = Arc::new((Mutex::new(false), Condvar::new()));
+        let (started_sender, started_receiver) = mpsc::sync_channel(2);
+
+        std::thread::scope(|scope| {
+            let first_release = Arc::clone(&release);
+            let first_sender = started_sender.clone();
+            let first_association = &association;
+            let first = scope.spawn(move || {
+                first_association.execute_request(read_request(1, 0), |response| {
+                    first_sender.send(response.request_id).unwrap();
+                    wait_for_release(&first_release);
+                    Ok::<_, ()>(())
+                })
+            });
+            let second_release = Arc::clone(&release);
+            let second_association = &association;
+            let second = scope.spawn(move || {
+                second_association.execute_request(read_request(2, 1), |response| {
+                    started_sender.send(response.request_id).unwrap();
+                    wait_for_release(&second_release);
+                    Ok::<_, ()>(())
+                })
+            });
+
+            let mut started = [
+                started_receiver
+                    .recv_timeout(Duration::from_secs(1))
+                    .unwrap(),
+                started_receiver
+                    .recv_timeout(Duration::from_secs(1))
+                    .unwrap(),
+            ];
+            started.sort();
+            assert_eq!(started, [RequestId(1), RequestId(2)]);
+            let (released, available) = &*release;
+            *released.lock().unwrap() = true;
+            available.notify_all();
+            first.join().unwrap().unwrap();
+            second.join().unwrap().unwrap();
+        });
+    }
+
+    fn association_allows_slot_reuse_during_response_emission(broker: &BrokerCore) {
+        let shared_buffers = test_shared_buffers();
+        let association = test_association(broker, &shared_buffers);
+        let release = Arc::new((Mutex::new(false), Condvar::new()));
+        let (started_sender, started_receiver) = mpsc::sync_channel(1);
+
+        std::thread::scope(|scope| {
+            let worker_release = Arc::clone(&release);
+            let first_association = &association;
+            let first = scope.spawn(move || {
+                first_association.execute_request(read_request(1, 0), |_| {
+                    started_sender.send(()).unwrap();
+                    wait_for_release(&worker_release);
+                    Ok::<_, ()>(())
+                })
+            });
+            started_receiver
+                .recv_timeout(Duration::from_secs(1))
+                .unwrap();
+
+            association
+                .execute_request(read_request(2, 0), |_| Ok::<_, ()>(()))
+                .unwrap();
+            let (released, available) = &*release;
+            *released.lock().unwrap() = true;
+            available.notify_all();
+            first.join().unwrap().unwrap();
+        });
+    }
+
+    fn association_allows_out_of_order_responses(broker: &BrokerCore) {
+        let shared_buffers = test_shared_buffers();
+        let association = test_association(broker, &shared_buffers);
+        let release = Arc::new((Mutex::new(false), Condvar::new()));
+        let (first_started_sender, first_started_receiver) = mpsc::sync_channel(1);
+        let (response_sender, response_receiver) = mpsc::sync_channel(2);
+
+        std::thread::scope(|scope| {
+            let first_association = &association;
+            let first_release = Arc::clone(&release);
+            let first_response_sender = response_sender.clone();
+            let first = scope.spawn(move || {
+                first_association.execute_request(event_create_request(1), |response| {
+                    first_started_sender.send(()).unwrap();
+                    wait_for_release(&first_release);
+                    first_response_sender.send(response.request_id).unwrap();
+                    Ok::<_, ()>(())
+                })
+            });
+            first_started_receiver
+                .recv_timeout(Duration::from_secs(1))
+                .unwrap();
+
+            let second_association = &association;
+            let second = scope.spawn(move || {
+                second_association.execute_request(event_create_request(2), |response| {
+                    response_sender.send(response.request_id).unwrap();
+                    Ok::<_, ()>(())
+                })
+            });
+            assert_eq!(
+                response_receiver
+                    .recv_timeout(Duration::from_secs(1))
+                    .unwrap(),
+                RequestId(2)
+            );
+            let (released, available) = &*release;
+            *released.lock().unwrap() = true;
+            available.notify_all();
+            assert_eq!(
+                response_receiver
+                    .recv_timeout(Duration::from_secs(1))
+                    .unwrap(),
+                RequestId(1)
+            );
+            first.join().unwrap().unwrap();
+            second.join().unwrap().unwrap();
+        });
+    }
+
+    fn test_association<'a>(
+        broker: &BrokerCore,
+        shared_buffers: &'a SharedBufferPool<TestSharedMemory>,
+    ) -> BrokerHostAssociation<'a, TestSharedMemory> {
+        BrokerHostAssociation {
+            session: broker
+                .create_session(CallerCredential::Unauthenticated)
+                .unwrap(),
+            shared_buffers,
+            state: SpinMutex::new(AssociationState {
+                failed: false,
+                shared_buffer_usage: SharedBufferUsage::new(),
+            }),
+        }
+    }
+
+    fn read_request(request_id: u64, slot_index: u32) -> BrokerRequest {
+        BrokerRequest {
+            request_id: RequestId(request_id),
+            operation: BrokerOperation::Pipe(PipeRequest::Read(ReadPipeRequest {
+                handle: ObjectHandle(u64::MAX),
+                buffer: descriptor(slot_index, 1),
+            })),
+        }
+    }
+
+    fn event_create_request(request_id: u64) -> BrokerRequest {
+        BrokerRequest {
+            request_id: RequestId(request_id),
+            operation: BrokerOperation::Event(EventRequest::Create(CreateEventRequest {
+                initial_count: 0,
+            })),
+        }
+    }
+
+    fn wait_for_release(release: &(Mutex<bool>, Condvar)) {
+        let (released, available) = release;
+        let mut released = released.lock().unwrap();
+        while !*released {
+            released = available.wait(released).unwrap();
+        }
+    }
+
     const fn descriptor(slot: u32, length: u32) -> SharedBufferDescriptor {
         SharedBufferDescriptor {
             slot_index: SharedBufferSlotIndex(slot),
@@ -931,7 +1196,7 @@ mod tests {
         request_id_step: u64,
         enqueue_readiness_requests_after_create: bool,
         enqueue_write_request_after_pipe_create: bool,
-        send_error: bool,
+        response_send_error: bool,
     }
 
     impl FakeHostControlChannel {
@@ -951,7 +1216,7 @@ mod tests {
                 request_id_step: 1,
                 enqueue_readiness_requests_after_create: false,
                 enqueue_write_request_after_pipe_create: false,
-                send_error: false,
+                response_send_error: false,
             }
         }
     }
@@ -977,9 +1242,6 @@ mod tests {
             &mut self,
             response: &BrokerHandshakeResponse,
         ) -> core::result::Result<(), Self::Error> {
-            if self.send_error {
-                return Err(());
-            }
             self.handshake_responses.push(response.clone());
             Ok(())
         }
@@ -1010,7 +1272,7 @@ mod tests {
             &mut self,
             response: &BrokerResponse,
         ) -> core::result::Result<(), Self::Error> {
-            if self.send_error {
+            if self.response_send_error {
                 return Err(());
             }
             let result = &response.result;

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -991,47 +991,44 @@ mod tests {
     }
 
     fn association_executes_distinct_slots_concurrently(broker: &BrokerCore) {
-        let shared_buffers = test_shared_buffers();
-        let association = test_association(broker, &shared_buffers);
         let release = Arc::new((Mutex::new(false), Condvar::new()));
-        let (started_sender, started_receiver) = mpsc::sync_channel(2);
+        let (entered_sender, entered_receiver) = mpsc::sync_channel(2);
+        let memory = BlockingReadSharedMemory {
+            memory: TestSharedMemory::new(SHARED_BUFFER_POOL_SIZE),
+            entered_sender,
+            release: Arc::clone(&release),
+        };
+        let shared_buffers = SharedBufferPool::new(memory, SHARED_BUFFER_LAYOUT).unwrap();
+        let association = test_association(broker, &shared_buffers);
+        let (_, first_write_handle) =
+            litebox_broker_core::pipe::create(&association.session, 64, 16).unwrap();
+        let (_, second_write_handle) =
+            litebox_broker_core::pipe::create(&association.session, 64, 16).unwrap();
 
         std::thread::scope(|scope| {
-            let first_release = Arc::clone(&release);
-            let first_sender = started_sender.clone();
             let first_association = &association;
             let first = scope.spawn(move || {
-                first_association.execute_request(read_request(1, 0), |response| {
-                    first_sender.send(response.request_id).unwrap();
-                    wait_for_release(&first_release);
-                    Ok::<_, ()>(())
-                })
+                first_association
+                    .execute_request(write_request(1, 0, first_write_handle), |_| Ok::<_, ()>(()))
             });
-            let second_release = Arc::clone(&release);
             let second_association = &association;
             let second = scope.spawn(move || {
-                second_association.execute_request(read_request(2, 1), |response| {
-                    started_sender.send(response.request_id).unwrap();
-                    wait_for_release(&second_release);
+                second_association.execute_request(write_request(2, 1, second_write_handle), |_| {
                     Ok::<_, ()>(())
                 })
             });
 
-            let mut started = [
-                started_receiver
-                    .recv_timeout(Duration::from_secs(1))
-                    .unwrap(),
-                started_receiver
-                    .recv_timeout(Duration::from_secs(1))
-                    .unwrap(),
+            let entered = [
+                entered_receiver.recv_timeout(Duration::from_secs(1)),
+                entered_receiver.recv_timeout(Duration::from_secs(1)),
             ];
-            started.sort();
-            assert_eq!(started, [RequestId(1), RequestId(2)]);
             let (released, available) = &*release;
             *released.lock().unwrap() = true;
             available.notify_all();
             first.join().unwrap().unwrap();
             second.join().unwrap().unwrap();
+            let [first_offset, second_offset] = entered.map(|result| result.unwrap());
+            assert_ne!(first_offset, second_offset);
         });
     }
 
@@ -1115,10 +1112,10 @@ mod tests {
         });
     }
 
-    fn test_association<'a>(
+    fn test_association<'a, Memory: SharedMemory>(
         broker: &BrokerCore,
-        shared_buffers: &'a SharedBufferPool<TestSharedMemory>,
-    ) -> BrokerHostAssociation<'a, TestSharedMemory> {
+        shared_buffers: &'a SharedBufferPool<Memory>,
+    ) -> BrokerHostAssociation<'a, Memory> {
         BrokerHostAssociation {
             session: broker
                 .create_session(CallerCredential::Unauthenticated)
@@ -1136,6 +1133,16 @@ mod tests {
             request_id: RequestId(request_id),
             operation: BrokerOperation::Pipe(PipeRequest::Read(ReadPipeRequest {
                 handle: ObjectHandle(u64::MAX),
+                buffer: descriptor(slot_index, 1),
+            })),
+        }
+    }
+
+    fn write_request(request_id: u64, slot_index: u32, handle: ObjectHandle) -> BrokerRequest {
+        BrokerRequest {
+            request_id: RequestId(request_id),
+            operation: BrokerOperation::Pipe(PipeRequest::Write(WritePipeRequest {
+                handle,
                 buffer: descriptor(slot_index, 1),
             })),
         }
@@ -1357,6 +1364,36 @@ mod tests {
                 .ok_or(SharedMemoryError::InvalidRange)?;
             destination.copy_from_slice(source);
             Ok(())
+        }
+    }
+
+    struct BlockingReadSharedMemory {
+        memory: TestSharedMemory,
+        entered_sender: mpsc::SyncSender<usize>,
+        release: Arc<(Mutex<bool>, Condvar)>,
+    }
+
+    impl SharedMemory for BlockingReadSharedMemory {
+        fn len(&self) -> usize {
+            self.memory.len()
+        }
+
+        fn read(
+            &self,
+            offset: usize,
+            destination: &mut [u8],
+        ) -> core::result::Result<(), SharedMemoryError> {
+            self.entered_sender.send(offset).unwrap();
+            wait_for_release(&self.release);
+            self.memory.read(offset, destination)
+        }
+
+        fn write(
+            &self,
+            offset: usize,
+            source: &[u8],
+        ) -> core::result::Result<(), SharedMemoryError> {
+            self.memory.write(offset, source)
         }
     }
 

--- a/litebox_broker_protocol/src/channel.rs
+++ b/litebox_broker_protocol/src/channel.rs
@@ -89,6 +89,27 @@ pub trait HostControlChannel {
     fn send_response(&mut self, response: &BrokerResponse) -> Result<(), Self::Error>;
 }
 
+/// Host-side source of active broker requests.
+pub trait HostRequestSource {
+    /// Channel-specific error type.
+    type Error;
+
+    /// Receives one active broker request.
+    fn recv_request(&mut self) -> Result<HostReceive<BrokerRequest>, Self::Error>;
+}
+
+/// Host-side sink for complete active broker responses.
+pub trait HostResponseSink {
+    /// Channel-specific error type.
+    type Error;
+
+    /// Sends one complete broker response.
+    ///
+    /// Implementations must serialize concurrent calls so response frames never
+    /// interleave.
+    fn send_response(&self, response: &BrokerResponse) -> Result<(), Self::Error>;
+}
+
 /// Local-side receive channel for broker-initiated asynchronous notifications.
 ///
 /// A notification channel is separate from the control channel so active broker

--- a/litebox_broker_protocol/src/channel.rs
+++ b/litebox_broker_protocol/src/channel.rs
@@ -89,27 +89,6 @@ pub trait HostControlChannel {
     fn send_response(&mut self, response: &BrokerResponse) -> Result<(), Self::Error>;
 }
 
-/// Host-side source of active broker requests.
-pub trait HostRequestSource {
-    /// Channel-specific error type.
-    type Error;
-
-    /// Receives one active broker request.
-    fn recv_request(&mut self) -> Result<HostReceive<BrokerRequest>, Self::Error>;
-}
-
-/// Host-side sink for complete active broker responses.
-pub trait HostResponseSink {
-    /// Channel-specific error type.
-    type Error;
-
-    /// Sends one complete broker response.
-    ///
-    /// Implementations must serialize concurrent calls so response frames never
-    /// interleave.
-    fn send_response(&self, response: &BrokerResponse) -> Result<(), Self::Error>;
-}
-
 /// Local-side receive channel for broker-initiated asynchronous notifications.
 ///
 /// A notification channel is separate from the control channel so active broker

--- a/litebox_broker_transport/src/unix_socket.rs
+++ b/litebox_broker_transport/src/unix_socket.rs
@@ -26,8 +26,8 @@ use crate::unix_io::{
 };
 use litebox_broker_protocol::RequestId;
 use litebox_broker_protocol::channel::{
-    HostControlChannel, HostNotificationChannel, HostReceive, LocalControlChannel,
-    LocalNotificationChannel, PeerCredential,
+    HostControlChannel, HostNotificationChannel, HostReceive, HostRequestSource, HostResponseSink,
+    LocalControlChannel, LocalNotificationChannel, PeerCredential,
 };
 use litebox_broker_protocol::message::{
     BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerNotification, BrokerRequest,
@@ -243,6 +243,23 @@ pub struct UnixStreamHostControlChannel {
     stream: UnixStream,
     peer_credential: PeerCredential,
     setup_deadline: Option<Instant>,
+    negotiated: bool,
+}
+
+/// Request-reading half of an active host control channel.
+pub struct UnixStreamHostRequestSource {
+    stream: UnixStream,
+}
+
+/// Shared response-writing half of an active host control channel.
+#[derive(Clone)]
+pub struct UnixStreamHostResponseSink {
+    stream: Arc<Mutex<UnixStream>>,
+}
+
+/// Handle that interrupts all active host control-channel I/O.
+pub struct UnixStreamHostControlShutdown {
+    stream: UnixStream,
 }
 
 /// Local-side Unix-domain-socket notification channel for the hosted userland POC.
@@ -267,6 +284,7 @@ impl UnixStreamHostControlChannel {
             stream,
             peer_credential: PeerCredential::Unauthenticated,
             setup_deadline: None,
+            negotiated: false,
         }
     }
 
@@ -277,6 +295,7 @@ impl UnixStreamHostControlChannel {
             stream,
             peer_credential: PeerCredential::HostGuaranteed,
             setup_deadline: Some(setup_deadline),
+            negotiated: false,
         }
     }
 
@@ -287,6 +306,43 @@ impl UnixStreamHostControlChannel {
         deadline: Option<Instant>,
     ) -> IoResult<()> {
         crate::shared_memory::send_memfd(&mut self.stream, shared_memory, deadline)
+    }
+
+    /// Consumes a negotiated setup channel into independently usable active
+    /// request, response, and shutdown handles.
+    pub fn into_active(
+        self,
+    ) -> IoResult<(
+        UnixStreamHostRequestSource,
+        UnixStreamHostResponseSink,
+        UnixStreamHostControlShutdown,
+    )> {
+        if !self.negotiated {
+            return Err(invalid_data(
+                "broker host control channel activated before negotiation completed",
+            ));
+        }
+        let response_stream = self.stream.try_clone()?;
+        let shutdown_stream = self.stream.try_clone()?;
+        Ok((
+            UnixStreamHostRequestSource {
+                stream: self.stream,
+            },
+            UnixStreamHostResponseSink {
+                stream: Arc::new(Mutex::new(response_stream)),
+            },
+            UnixStreamHostControlShutdown {
+                stream: shutdown_stream,
+            },
+        ))
+    }
+}
+
+impl UnixStreamHostControlShutdown {
+    /// Shuts down the active control socket without waiting for the response
+    /// writer mutex.
+    pub fn shutdown(&self) -> IoResult<()> {
+        shutdown(&self.stream)
     }
 }
 
@@ -411,7 +467,8 @@ impl HostControlChannel for UnixStreamHostControlChannel {
             &encode_handshake_response(response.clone()),
             self.setup_deadline,
         )?;
-        if matches!(response, BrokerHandshakeResponse::Negotiated { .. }) {
+        self.negotiated = matches!(response, BrokerHandshakeResponse::Negotiated { .. });
+        if self.negotiated {
             self.setup_deadline = None;
         }
         Ok(())
@@ -430,6 +487,33 @@ impl HostControlChannel for UnixStreamHostControlChannel {
 
     fn send_response(&mut self, response: &BrokerResponse) -> IoResult<()> {
         write_frame_with_deadline(&mut self.stream, &encode_response(response.clone()), None)
+    }
+}
+
+impl HostRequestSource for UnixStreamHostRequestSource {
+    type Error = Error;
+
+    fn recv_request(&mut self) -> IoResult<HostReceive<BrokerRequest>> {
+        let Some(frame) = read_frame_with_deadline(&mut self.stream, None)? else {
+            return Ok(HostReceive::PeerClosed);
+        };
+        match decode_request(&frame) {
+            Ok(request) => Ok(HostReceive::Message(request)),
+            Err(WireError::WrongMessagePhase) => Ok(HostReceive::ProtocolViolation),
+            Err(error) => Err(wire_error(error)),
+        }
+    }
+}
+
+impl HostResponseSink for UnixStreamHostResponseSink {
+    type Error = Error;
+
+    fn send_response(&self, response: &BrokerResponse) -> IoResult<()> {
+        let mut stream = self
+            .stream
+            .lock()
+            .expect("broker response writer mutex poisoned");
+        write_frame_with_deadline(&mut stream, &encode_response(response.clone()), None)
     }
 }
 
@@ -1456,6 +1540,62 @@ mod tests {
             channel.stream.write_timeout().unwrap(),
             active_write_timeout
         );
+    }
+
+    #[test]
+    fn host_control_requires_negotiation_before_active_split() {
+        let (_peer_stream, host_stream) = UnixStream::pair().unwrap();
+        let channel = UnixStreamHostControlChannel::from_accepted(host_stream);
+
+        assert!(channel.into_active().is_err());
+    }
+
+    #[test]
+    fn concurrent_host_response_sinks_write_complete_frames() {
+        let (mut peer_stream, host_stream) = UnixStream::pair().unwrap();
+        let mut channel = UnixStreamHostControlChannel::from_accepted(host_stream);
+        channel
+            .send_handshake_response(&BrokerHandshakeResponse::Negotiated {
+                broker_protocol_version: litebox_broker_protocol::BROKER_PROTOCOL_VERSION,
+            })
+            .unwrap();
+        let handshake = read_frame_with_deadline(&mut peer_stream, None)
+            .unwrap()
+            .unwrap();
+        assert!(matches!(
+            decode_handshake_response(&handshake).unwrap(),
+            BrokerHandshakeResponse::Negotiated { .. }
+        ));
+        let (_request_source, response_sink, _shutdown) = channel.into_active().unwrap();
+        let first_sink = response_sink.clone();
+        let first = std::thread::spawn(move || {
+            first_sink
+                .send_response(&BrokerResponse {
+                    request_id: RequestId(1),
+                    result: BrokerResult::ObjectClosed,
+                })
+                .unwrap();
+        });
+        let second = std::thread::spawn(move || {
+            response_sink
+                .send_response(&BrokerResponse {
+                    request_id: RequestId(2),
+                    result: BrokerResult::ObjectClosed,
+                })
+                .unwrap();
+        });
+
+        let mut response_ids = [RequestId(0); 2];
+        for response_id in &mut response_ids {
+            let frame = read_frame_with_deadline(&mut peer_stream, None)
+                .unwrap()
+                .unwrap();
+            *response_id = decode_response(&frame).unwrap().request_id;
+        }
+        response_ids.sort();
+        assert_eq!(response_ids, [RequestId(1), RequestId(2)]);
+        first.join().unwrap();
+        second.join().unwrap();
     }
 
     #[test]

--- a/litebox_broker_transport/src/unix_socket.rs
+++ b/litebox_broker_transport/src/unix_socket.rs
@@ -26,8 +26,8 @@ use crate::unix_io::{
 };
 use litebox_broker_protocol::RequestId;
 use litebox_broker_protocol::channel::{
-    HostControlChannel, HostNotificationChannel, HostReceive, HostRequestSource, HostResponseSink,
-    LocalControlChannel, LocalNotificationChannel, PeerCredential,
+    HostControlChannel, HostNotificationChannel, HostReceive, LocalControlChannel,
+    LocalNotificationChannel, PeerCredential,
 };
 use litebox_broker_protocol::message::{
     BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerNotification, BrokerRequest,
@@ -490,10 +490,9 @@ impl HostControlChannel for UnixStreamHostControlChannel {
     }
 }
 
-impl HostRequestSource for UnixStreamHostRequestSource {
-    type Error = Error;
-
-    fn recv_request(&mut self) -> IoResult<HostReceive<BrokerRequest>> {
+impl UnixStreamHostRequestSource {
+    /// Receives one active broker request.
+    pub fn recv_request(&mut self) -> IoResult<HostReceive<BrokerRequest>> {
         let Some(frame) = read_frame_with_deadline(&mut self.stream, None)? else {
             return Ok(HostReceive::PeerClosed);
         };
@@ -505,14 +504,13 @@ impl HostRequestSource for UnixStreamHostRequestSource {
     }
 }
 
-impl HostResponseSink for UnixStreamHostResponseSink {
-    type Error = Error;
-
-    fn send_response(&self, response: &BrokerResponse) -> IoResult<()> {
+impl UnixStreamHostResponseSink {
+    /// Serializes and sends one complete active broker response.
+    pub fn send_response(&self, response: &BrokerResponse) -> IoResult<()> {
         let mut stream = self
             .stream
             .lock()
-            .expect("broker response writer mutex poisoned");
+            .map_err(|_| Error::other("broker response writer mutex poisoned"))?;
         write_frame_with_deadline(&mut stream, &encode_response(response.clone()), None)
     }
 }

--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -17,7 +17,7 @@ use std::time::{Duration, Instant};
 use clap::Parser;
 use litebox_broker_core::{BrokerCore, ObjectRights, PolicyEngine};
 use litebox_broker_host::{BrokerHostAssociation, ConnectionTermination, setup_connection};
-use litebox_broker_protocol::channel::{HostReceive, HostRequestSource, HostResponseSink};
+use litebox_broker_protocol::channel::HostReceive;
 use litebox_broker_protocol::message::BrokerRequest;
 use litebox_broker_protocol::shared_memory::{
     SHARED_BUFFER_LAYOUT, SHARED_BUFFER_POOL_SIZE, SharedBufferPool, SharedMemory,

--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -161,14 +161,27 @@ fn dispatch_requests<Memory: SharedMemory>(
 
     std::thread::scope(|scope| {
         let mut workers = Vec::with_capacity(WORKER_COUNT);
-        for _ in 0..WORKER_COUNT {
+        for worker_id in 0..WORKER_COUNT {
             let association = Arc::clone(&association);
             let request_receiver = Arc::clone(&request_receiver);
             let response_sink = response_sink.clone();
-            let failure = Arc::clone(&failure);
-            workers.push(scope.spawn(move || {
-                run_worker(&association, &request_receiver, &response_sink, &failure);
-            }));
+            let worker_failure = Arc::clone(&failure);
+            match std::thread::Builder::new()
+                .name(format!("litebox-broker-worker-{worker_id}"))
+                .spawn_scoped(scope, move || {
+                    run_worker(
+                        &association,
+                        &request_receiver,
+                        &response_sink,
+                        &worker_failure,
+                    );
+                }) {
+                Ok(worker) => workers.push(worker),
+                Err(error) => {
+                    failure.report(error);
+                    break;
+                }
+            }
         }
 
         read_requests(&mut request_source, request_sender, &failure);

--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -1,28 +1,37 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-use std::cell::Cell;
 use std::error::Error;
 use std::ffi::OsString;
 use std::io::{Error as IoError, ErrorKind, Result as IoResult};
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::PathBuf;
 use std::process::{Child, Command};
+use std::sync::mpsc::{Receiver, SyncSender, sync_channel};
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicBool, Ordering},
+};
 use std::time::{Duration, Instant};
 
 use clap::Parser;
 use litebox_broker_core::{BrokerCore, ObjectRights, PolicyEngine};
-use litebox_broker_host::{ConnectionTermination, serve_connection};
+use litebox_broker_host::{BrokerHostAssociation, ConnectionTermination, setup_connection};
+use litebox_broker_protocol::channel::{HostReceive, HostRequestSource, HostResponseSink};
+use litebox_broker_protocol::message::BrokerRequest;
 use litebox_broker_protocol::shared_memory::{
-    SHARED_BUFFER_LAYOUT, SHARED_BUFFER_POOL_SIZE, SharedBufferPool,
+    SHARED_BUFFER_LAYOUT, SHARED_BUFFER_POOL_SIZE, SharedBufferPool, SharedMemory,
 };
 use litebox_broker_transport::shared_memory::MemfdSharedMemory;
 use litebox_broker_transport::unix_socket::{
-    UnixStreamHostControlChannel, UnixStreamHostNotificationChannel, validate_peer_process,
+    UnixStreamHostControlChannel, UnixStreamHostControlShutdown, UnixStreamHostNotificationChannel,
+    UnixStreamHostRequestSource, UnixStreamHostResponseSink, validate_peer_process,
 };
 
 const SETUP_TIMEOUT: Duration = Duration::from_secs(5);
 const ACCEPT_RETRY_DELAY: Duration = Duration::from_millis(10);
+const REQUEST_QUEUE_CAPACITY: usize = 64;
+const WORKER_COUNT: usize = 8;
 
 #[derive(Parser, Debug)]
 struct CliArgs {
@@ -104,35 +113,176 @@ fn serve_runner(
     let shared_buffers = SharedBufferPool::new(shared_memory, SHARED_BUFFER_LAYOUT)?;
     let mut control_channel =
         UnixStreamHostControlChannel::from_host_guaranteed(control_stream, setup_deadline);
-    let mut notification_channel =
+    let _notification_channel =
         UnixStreamHostNotificationChannel::from_accepted(notification_stream);
-    let setup_completed = Cell::new(false);
-    let termination = serve_connection(
-        broker,
-        &mut control_channel,
-        &mut notification_channel,
-        &shared_buffers,
-        |channel| {
+    let association =
+        match setup_connection(broker, &mut control_channel, &shared_buffers, |channel| {
             channel.send_memfd(shared_buffers.memory(), Some(setup_deadline))?;
-            setup_completed.set(true);
             Ok(())
-        },
-    )?;
-    if termination != ConnectionTermination::PeerClosed {
-        return Err(IoError::new(
-            ErrorKind::InvalidData,
-            "runner violated the broker protocol",
-        )
-        .into());
-    }
-    if !setup_completed.get() {
-        return Err(IoError::new(
-            ErrorKind::UnexpectedEof,
-            "runner closed before completing broker setup",
-        )
-        .into());
-    }
+        })? {
+            Ok(association) => association,
+            Err(ConnectionTermination::PeerClosed) => {
+                return Err(IoError::new(
+                    ErrorKind::UnexpectedEof,
+                    "runner closed before completing broker setup",
+                )
+                .into());
+            }
+            Err(ConnectionTermination::ProtocolViolation) => {
+                return Err(IoError::new(
+                    ErrorKind::InvalidData,
+                    "runner violated the broker protocol during setup",
+                )
+                .into());
+            }
+            Err(_) => {
+                return Err(IoError::new(
+                    ErrorKind::InvalidData,
+                    "runner ended broker setup unexpectedly",
+                )
+                .into());
+            }
+        };
+    let (request_source, response_sink, shutdown) = control_channel.into_active()?;
+    dispatch_requests(association, request_source, response_sink, shutdown)?;
     Ok(())
+}
+
+fn dispatch_requests<Memory: SharedMemory>(
+    association: BrokerHostAssociation<'_, Memory>,
+    mut request_source: UnixStreamHostRequestSource,
+    response_sink: UnixStreamHostResponseSink,
+    shutdown: UnixStreamHostControlShutdown,
+) -> IoResult<()> {
+    let association = Arc::new(association);
+    let failure = Arc::new(HostAssociationFailure::new(shutdown));
+    let (request_sender, request_receiver) = sync_channel(REQUEST_QUEUE_CAPACITY);
+    let request_receiver = Arc::new(Mutex::new(request_receiver));
+
+    std::thread::scope(|scope| {
+        let mut workers = Vec::with_capacity(WORKER_COUNT);
+        for _ in 0..WORKER_COUNT {
+            let association = Arc::clone(&association);
+            let request_receiver = Arc::clone(&request_receiver);
+            let response_sink = response_sink.clone();
+            let failure = Arc::clone(&failure);
+            workers.push(scope.spawn(move || {
+                run_worker(&association, &request_receiver, &response_sink, &failure);
+            }));
+        }
+
+        read_requests(&mut request_source, request_sender, &failure);
+        for worker in workers {
+            if worker.join().is_err() {
+                failure.report(IoError::other("broker request worker panicked"));
+            }
+        }
+    });
+
+    match failure.take_error() {
+        Some(error) => Err(error),
+        None => Ok(()),
+    }
+}
+
+fn read_requests(
+    request_source: &mut UnixStreamHostRequestSource,
+    request_sender: SyncSender<BrokerRequest>,
+    failure: &HostAssociationFailure,
+) {
+    loop {
+        if failure.failed() {
+            break;
+        }
+        match request_source.recv_request() {
+            Ok(HostReceive::Message(request)) => {
+                if request_sender.send(request).is_err() {
+                    failure.report(IoError::new(
+                        ErrorKind::BrokenPipe,
+                        "broker request workers stopped",
+                    ));
+                    break;
+                }
+            }
+            Ok(HostReceive::ProtocolViolation) => {
+                failure.report(IoError::new(
+                    ErrorKind::InvalidData,
+                    "runner sent a request for the wrong protocol phase",
+                ));
+                break;
+            }
+            Ok(HostReceive::PeerClosed) => break,
+            Err(error) => {
+                failure.report(error);
+                break;
+            }
+        }
+    }
+}
+
+fn run_worker<Memory: SharedMemory>(
+    association: &BrokerHostAssociation<'_, Memory>,
+    request_receiver: &Mutex<Receiver<BrokerRequest>>,
+    response_sink: &UnixStreamHostResponseSink,
+    failure: &HostAssociationFailure,
+) {
+    loop {
+        let request = request_receiver
+            .lock()
+            .expect("broker request receiver mutex poisoned")
+            .recv();
+        let Ok(request) = request else {
+            break;
+        };
+        if failure.failed() {
+            continue;
+        }
+        match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            association.execute_request(request, |response| response_sink.send_response(response))
+        })) {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => failure.report(IoError::other(error)),
+            Err(_) => failure.report(IoError::other("broker request worker panicked")),
+        }
+    }
+}
+
+struct HostAssociationFailure {
+    failed: AtomicBool,
+    error: Mutex<Option<IoError>>,
+    shutdown: UnixStreamHostControlShutdown,
+}
+
+impl HostAssociationFailure {
+    const fn new(shutdown: UnixStreamHostControlShutdown) -> Self {
+        Self {
+            failed: AtomicBool::new(false),
+            error: Mutex::new(None),
+            shutdown,
+        }
+    }
+
+    fn failed(&self) -> bool {
+        self.failed.load(Ordering::Acquire)
+    }
+
+    fn report(&self, error: IoError) {
+        if self.failed.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        *self
+            .error
+            .lock()
+            .expect("broker association failure mutex poisoned") = Some(error);
+        let _ = self.shutdown.shutdown();
+    }
+
+    fn take_error(&self) -> Option<IoError> {
+        self.error
+            .lock()
+            .expect("broker association failure mutex poisoned")
+            .take()
+    }
 }
 
 fn accept_runner_stream(

--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -331,3 +331,42 @@ fn accept_runner_stream(
         std::thread::sleep(remaining.min(ACCEPT_RETRY_DELAY));
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use litebox_broker_protocol::BROKER_PROTOCOL_VERSION;
+    use litebox_broker_protocol::channel::HostControlChannel;
+    use litebox_broker_protocol::message::BrokerHandshakeResponse;
+
+    #[test]
+    fn first_failure_is_preserved_and_unblocks_request_reading() {
+        let (peer_stream, host_stream) = UnixStream::pair().unwrap();
+        let mut control_channel = UnixStreamHostControlChannel::from_accepted(host_stream);
+        control_channel
+            .send_handshake_response(&BrokerHandshakeResponse::Negotiated {
+                broker_protocol_version: BROKER_PROTOCOL_VERSION,
+            })
+            .unwrap();
+        let (mut request_source, _response_sink, shutdown) = control_channel.into_active().unwrap();
+        let failure = HostAssociationFailure::new(shutdown);
+        let (result_sender, result_receiver) = std::sync::mpsc::sync_channel(1);
+        let reader = std::thread::spawn(move || {
+            result_sender.send(request_source.recv_request()).unwrap();
+        });
+
+        failure.report(IoError::new(ErrorKind::TimedOut, "first failure"));
+        failure.report(IoError::other("second failure"));
+        let receive_result = result_receiver.recv_timeout(Duration::from_secs(1));
+        drop(peer_stream);
+        reader.join().unwrap();
+
+        assert!(matches!(
+            receive_result.unwrap(),
+            Ok(HostReceive::PeerClosed) | Err(_)
+        ));
+        let error = failure.take_error().unwrap();
+        assert_eq!(error.kind(), ErrorKind::TimedOut);
+        assert_eq!(error.to_string(), "first failure");
+    }
+}

--- a/litebox_broker_userland/tests/userland_broker.rs
+++ b/litebox_broker_userland/tests/userland_broker.rs
@@ -84,15 +84,37 @@ fn run_fake_runner(args: &[OsString]) {
     let control_channel = connect_control_with_retry(Path::new(control_socket_path)).unwrap();
     let _notification_channel =
         connect_notification_with_retry(Path::new(notification_socket_path)).unwrap();
-    let local = BrokerLocal::negotiate(control_channel, |channel| {
-        let shared_memory = channel.receive_memfd(
-            SHARED_BUFFER_POOL_SIZE,
-            Some(Instant::now() + Duration::from_secs(5)),
-        )?;
-        let _cancellation = channel.activate(|| {})?;
-        Ok(Arc::new(shared_memory))
-    })
-    .unwrap();
+    let local = Arc::new(
+        BrokerLocal::negotiate(control_channel, |channel| {
+            let shared_memory = channel.receive_memfd(
+                SHARED_BUFFER_POOL_SIZE,
+                Some(Instant::now() + Duration::from_secs(5)),
+            )?;
+            let _cancellation = channel.activate(|| {})?;
+            Ok(Arc::new(shared_memory))
+        })
+        .unwrap(),
+    );
+
+    let start = Arc::new(std::sync::Barrier::new(17));
+    let callers = (0..16)
+        .map(|initial_count| {
+            let local = Arc::clone(&local);
+            let start = Arc::clone(&start);
+            std::thread::spawn(move || {
+                start.wait();
+                local.create_event_with_count(initial_count).unwrap()
+            })
+        })
+        .collect::<Vec<_>>();
+    start.wait();
+    let mut concurrent_handles = callers
+        .into_iter()
+        .map(|caller| caller.join().unwrap())
+        .collect::<Vec<_>>();
+    concurrent_handles.sort();
+    concurrent_handles.dedup();
+    assert_eq!(concurrent_handles.len(), 16);
 
     let handle = local.create_event_with_count(0).unwrap();
     assert_eq!(


### PR DESCRIPTION
Adds a portable host association for concurrent request execution and splits active Unix control into request, response, and shutdown handles. The userland broker dispatches a bounded 64-request queue across eight workers, serializes complete response frames in completion order, and preserves shared-buffer slot validation. Reader, worker, and writer failures converge on fail-closed socket shutdown and bounded cleanup.