### PR TITLE
Implement Windows process token

### DIFF
--- a/litebox_shim_windows/src/lib.rs
+++ b/litebox_shim_windows/src/lib.rs
@@ -43,6 +43,7 @@ use crate::syscalls::section::{
 };
 use crate::syscalls::symlink::{SymbolicLinkHandleObject, SymbolicLinkSubsystem};
 use crate::syscalls::timer::{TimerCreateParameters, TimerHandleObject, TimerSubsystem};
+use crate::syscalls::token::{TokenHandleObject, TokenObject, TokenSubsystem};
 use crate::syscalls::wait_completion_packet::{
     WaitCompletionPacketAssociateParameters, WaitCompletionPacketHandleObject,
     WaitCompletionPacketSubsystem,
@@ -107,8 +108,40 @@ bitflags::bitflags! {
         const PROTECT_FROM_CLOSE = 0x0000_0001;
         const INHERIT = 0x0000_0002;
         const AUDIT_OBJECT_CLOSE = 0x0000_0004;
+        const HANDLE_BEHAVIOR_ATTRIBUTES = Self::PROTECT_FROM_CLOSE.bits()
+            | Self::INHERIT.bits()
+            | Self::AUDIT_OBJECT_CLOSE.bits();
 
         const _ = !0;
+    }
+}
+
+impl HandleAttributes {
+    fn from_token_open_attributes(attributes: u32) -> Option<Self> {
+        const OBJ_EXCLUSIVE: u32 = 0x20;
+        const OBJ_OPENLINK: u32 = 0x100;
+
+        // NtOpenProcessTokenEx accepts and ignores unrelated object attributes, but native
+        // Windows rejects the two attributes that cannot apply to opening an existing token.
+        if attributes & (OBJ_EXCLUSIVE | OBJ_OPENLINK) != 0 {
+            return None;
+        }
+        Some(Self::from_bits_retain(
+            attributes & Self::HANDLE_BEHAVIOR_ATTRIBUTES.bits(),
+        ))
+    }
+
+    fn from_duplicate_attributes(attributes: u32) -> Option<Self> {
+        const OBJ_EXCLUSIVE: u32 = 0x20;
+
+        // Native NtDuplicateObject accepts and ignores unrelated object attributes, but an
+        // exclusive duplicate is invalid because the object already has an open handle.
+        if attributes & OBJ_EXCLUSIVE != 0 {
+            return None;
+        }
+        Some(Self::from_bits_retain(
+            attributes & Self::HANDLE_BEHAVIOR_ATTRIBUTES.bits(),
+        ))
     }
 }
 
@@ -536,6 +569,7 @@ pub struct Process<Platform: ShimPlatform> {
     ntdll_mapping: Option<MappingInfo>,
     peb_address: usize,
     handles: WindowsHandleStore<Platform>,
+    token: Arc<TokenObject>,
     condrv_console: syscalls::condrv::CondrvConsole<Platform>,
     object_manager: WindowsObjectManager<Platform>,
     section_views: WindowsSectionViews<Platform>,
@@ -583,6 +617,7 @@ impl<Platform: ShimPlatform> Process<Platform> {
             ntdll_mapping: None,
             peb_address: 0,
             handles: WindowsHandleStore::<Platform>::new(litebox::fd::RawDescriptorStorage::new()),
+            token: Arc::new(TokenObject::primary()),
             // TODO(condrv-shared-console): move console ownership to shared state or a broker when
             // LiteBox supports AttachConsole/IOCTL_CONDRV_BIND_PID across guest processes.
             condrv_console: syscalls::condrv::CondrvConsole::new(),
@@ -743,6 +778,24 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
     where
         Subsystem: WindowsHandleSubsystem,
     {
+        self.insert_typed_handle_with_attributes::<Subsystem>(
+            entry,
+            granted_access,
+            HandleAttributes::empty(),
+            cleanup_entry,
+        )
+    }
+
+    fn insert_typed_handle_with_attributes<Subsystem>(
+        &self,
+        entry: Subsystem::Entry,
+        granted_access: u32,
+        attributes: HandleAttributes,
+        cleanup_entry: impl FnOnce(Subsystem::Entry),
+    ) -> Result<syscalls::Handle, NtStatus>
+    where
+        Subsystem: WindowsHandleSubsystem,
+    {
         let typed = {
             let mut descriptors = self.global.litebox.descriptor_table_mut();
             let typed = descriptors.insert::<Subsystem>(entry);
@@ -750,7 +803,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                 &typed,
                 WindowsHandleMetadata {
                     granted_access,
-                    attributes: HandleAttributes::empty(),
+                    attributes,
                 },
             );
             debug_assert!(old.is_none());
@@ -1614,6 +1667,45 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                 );
                 (status, ContinueOperation::Resume)
             }
+            SyscallRequest::NtOpenProcessToken {
+                process_handle,
+                desired_access,
+                token_handle,
+            } => {
+                let status =
+                    self.sys_nt_open_process_token(process_handle, desired_access, token_handle);
+                (status, ContinueOperation::Resume)
+            }
+            SyscallRequest::NtOpenProcessTokenEx {
+                process_handle,
+                desired_access,
+                handle_attributes,
+                token_handle,
+            } => {
+                let status = self.sys_nt_open_process_token_ex(
+                    process_handle,
+                    desired_access,
+                    handle_attributes,
+                    token_handle,
+                );
+                (status, ContinueOperation::Resume)
+            }
+            SyscallRequest::NtQueryInformationToken {
+                token_handle,
+                token_information_class,
+                token_information,
+                token_information_length,
+                return_length,
+            } => {
+                let status = self.sys_nt_query_information_token(
+                    token_handle,
+                    token_information_class,
+                    token_information,
+                    token_information_length,
+                    return_length,
+                );
+                (status, ContinueOperation::Resume)
+            }
             SyscallRequest::NtConvertBetweenAuxiliaryCounterAndPerformanceCounter {
                 flag,
                 source,
@@ -1892,6 +1984,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         if let Some(target_handle) = target_handle
             && target_handle.write_at_offset(0, duplicate).is_none()
         {
+            let _ = self.remove_handle(duplicate, CloseRawHandleVisitor { task: self }, false);
             return NtStatus::ACCESS_VIOLATION;
         }
         NtStatus::SUCCESS
@@ -1928,6 +2021,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         try_duplicate!(WaitCompletionPacketSubsystem<Platform>);
         try_duplicate!(WorkerFactorySubsystem<Platform>);
         try_duplicate!(SectionSubsystem<Platform>);
+        try_duplicate!(TokenSubsystem);
 
         Err(NtStatus::INVALID_HANDLE)
     }
@@ -1968,7 +2062,11 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         let duplicate_attributes = if options.contains(DuplicateOptions::SAME_ATTRIBUTES) {
             source_metadata.attributes
         } else {
-            HandleAttributes::from_bits_retain(handle_attributes)
+            let Some(attributes) = HandleAttributes::from_duplicate_attributes(handle_attributes)
+            else {
+                return Some(Err(NtStatus::INVALID_PARAMETER));
+            };
+            attributes
         };
 
         let duplicate = {
@@ -1999,11 +2097,22 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         handle: syscalls::Handle,
         visitor: impl RawHandleVisitor<Platform, FS>,
     ) -> NtStatus {
+        self.remove_handle(handle, visitor, true)
+    }
+
+    fn remove_handle(
+        &self,
+        handle: syscalls::Handle,
+        visitor: impl RawHandleVisitor<Platform, FS>,
+        enforce_protect_from_close: bool,
+    ) -> NtStatus {
         macro_rules! try_close {
             ($subsystem:ty, $visit:ident) => {
-                if let Some(status) =
-                    self.try_close_handle::<$subsystem>(handle, |entry| visitor.$visit(entry))
-                {
+                if let Some(status) = self.try_remove_handle::<$subsystem>(
+                    handle,
+                    enforce_protect_from_close,
+                    |entry| visitor.$visit(entry),
+                ) {
                     return status;
                 }
             };
@@ -2023,13 +2132,15 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         );
         try_close!(WorkerFactorySubsystem<Platform>, worker_factory);
         try_close!(SectionSubsystem<Platform>, section);
+        try_close!(TokenSubsystem, token);
 
         NtStatus::INVALID_HANDLE
     }
 
-    fn try_close_handle<Subsystem>(
+    fn try_remove_handle<Subsystem>(
         &self,
         handle: syscalls::Handle,
+        enforce_protect_from_close: bool,
         cleanup_entry: impl FnOnce(Subsystem::Entry),
     ) -> Option<NtStatus>
     where
@@ -2044,9 +2155,10 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             Ok(metadata) => metadata,
             Err(status) => return Some(status),
         };
-        if metadata
-            .attributes
-            .contains(HandleAttributes::PROTECT_FROM_CLOSE)
+        if enforce_protect_from_close
+            && metadata
+                .attributes
+                .contains(HandleAttributes::PROTECT_FROM_CLOSE)
         {
             return Some(NtStatus::HANDLE_NOT_CLOSABLE);
         }
@@ -2097,6 +2209,8 @@ trait RawHandleVisitor<Platform: ShimPlatform, FS: ShimFS> {
     fn worker_factory(&self, worker_factory: WorkerFactoryHandleObject<Platform>);
 
     fn section(&self, section: SectionHandleObject<Platform>);
+
+    fn token(&self, token: TokenHandleObject);
 }
 
 struct CloseRawHandleVisitor<'task, Platform: ShimPlatform, FS: ShimFS> {
@@ -2151,6 +2265,10 @@ impl<Platform: ShimPlatform, FS: ShimFS> RawHandleVisitor<Platform, FS>
 
     fn section(&self, section: SectionHandleObject<Platform>) {
         Task::<Platform, FS>::close_section(section);
+    }
+
+    fn token(&self, token: TokenHandleObject) {
+        Task::<Platform, FS>::close_token(token);
     }
 }
 

--- a/litebox_shim_windows/src/loader/pe.rs
+++ b/litebox_shim_windows/src/loader/pe.rs
@@ -27,8 +27,8 @@ use thiserror::Error;
 use zerocopy::{FromBytes, FromZeros, Immutable, IntoBytes, KnownLayout};
 
 use crate::nt_types::{
-    ClientId, PebBitField, ProcessEnvironmentBlock, RtlUserProcFlags, RtlUserProcessParameters,
-    ThreadEnvironmentBlock, UnicodeString, X64Context,
+    ClientId, Luid, PebBitField, ProcessEnvironmentBlock, RtlUserProcFlags,
+    RtlUserProcessParameters, ThreadEnvironmentBlock, UnicodeString, X64Context,
 };
 use crate::syscalls::mm::{MemoryType, PageProtection};
 use crate::syscalls::process::{INITIAL_PROCESS_ID, INITIAL_THREAD_ID};
@@ -753,13 +753,6 @@ struct NlsUserInfo {
     user_locale_id: u32,
     interactive_user_luid: Luid,
     ul_cache_update_count: u32,
-}
-
-#[repr(C)]
-#[derive(FromBytes, IntoBytes)]
-struct Luid {
-    low_part: u32,
-    high_part: i32,
 }
 
 #[repr(C)]

--- a/litebox_shim_windows/src/nt_types.rs
+++ b/litebox_shim_windows/src/nt_types.rs
@@ -20,6 +20,13 @@ const USER_MODE_STACK_SELECTOR: u16 = 0x2b;
 const INITIAL_CONTEXT_EFLAGS: u32 = 0x200;
 
 #[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, FromBytes, Immutable, IntoBytes, PartialEq)]
+pub(crate) struct Luid {
+    pub(crate) low_part: u32,
+    pub(crate) high_part: i32,
+}
+
+#[repr(C)]
 #[derive(Clone, Copy, Debug, FromBytes, IntoBytes, Immutable)]
 pub struct X64Context {
     pub p1_home: u64,

--- a/litebox_shim_windows/src/syscalls/mod.rs
+++ b/litebox_shim_windows/src/syscalls/mod.rs
@@ -18,6 +18,7 @@ pub(crate) mod symlink;
 pub(crate) mod sysinfo;
 pub(crate) mod thread;
 pub(crate) mod timer;
+pub(crate) mod token;
 pub(crate) mod wait_completion_packet;
 pub(crate) mod wnf;
 pub(crate) mod worker_factory;
@@ -493,6 +494,24 @@ pub(crate) enum SyscallRequest<Platform: RawPointerProvider> {
         open_as_self: u32,
         handle_attributes: u32,
         token_handle: Platform::RawMutPointer<Handle>,
+    },
+    NtOpenProcessToken {
+        process_handle: ProcessHandle,
+        desired_access: u32,
+        token_handle: Platform::RawMutPointer<Handle>,
+    },
+    NtOpenProcessTokenEx {
+        process_handle: ProcessHandle,
+        desired_access: u32,
+        handle_attributes: u32,
+        token_handle: Platform::RawMutPointer<Handle>,
+    },
+    NtQueryInformationToken {
+        token_handle: Handle,
+        token_information_class: u32,
+        token_information: Platform::RawMutPointer<u8>,
+        token_information_length: u32,
+        return_length: Platform::RawMutPointer<u32>,
     },
     NtConvertBetweenAuxiliaryCounterAndPerformanceCounter {
         flag: u32,
@@ -979,6 +998,24 @@ impl<Platform: RawPointerProvider> SyscallRequest<Platform> {
                 open_as_self,
                 handle_attributes,
                 token_handle:*,
+            })),
+            NtSysno::NtOpenProcessToken => Some(sys_req!(NtOpenProcessToken {
+                process_handle: { ProcessHandle::from_raw },
+                desired_access,
+                token_handle:*,
+            })),
+            NtSysno::NtOpenProcessTokenEx => Some(sys_req!(NtOpenProcessTokenEx {
+                process_handle: { ProcessHandle::from_raw },
+                desired_access,
+                handle_attributes,
+                token_handle:*,
+            })),
+            NtSysno::NtQueryInformationToken => Some(sys_req!(NtQueryInformationToken {
+                token_handle: { Handle::from_raw },
+                token_information_class,
+                token_information:*,
+                token_information_length,
+                return_length:*,
             })),
             NtSysno::NtConvertBetweenAuxiliaryCounterAndPerformanceCounter => Some(
                 sys_req!(NtConvertBetweenAuxiliaryCounterAndPerformanceCounter {

--- a/litebox_shim_windows/src/syscalls/token.rs
+++ b/litebox_shim_windows/src/syscalls/token.rs
@@ -1,0 +1,787 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//! Windows NT access-token syscalls.
+
+use alloc::sync::Arc;
+use core::mem::size_of;
+
+use int_enum::IntEnum;
+use litebox::fd::{FdEnabledSubsystem, FdEnabledSubsystemEntry};
+use litebox::platform::{RawConstPointer as _, RawMutPointer as _};
+use litebox::utils::TruncateExt as _;
+use litebox_common_windows::nt_status::NtStatus;
+use zerocopy::{FromBytes, Immutable, IntoBytes};
+
+use crate::nt_types::AccessMask;
+use crate::syscalls::{Handle, ProcessHandle};
+use crate::{
+    HandleAttributes, MutPtr, ShimFS, Task, WindowsHandleSubsystem, probe_guest_output_buffer,
+    probe_guest_output_preserving_value,
+};
+
+bitflags::bitflags! {
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    pub(crate) struct TokenAccess: u32 {
+        const ASSIGN_PRIMARY = 0x0001;
+        const DUPLICATE = 0x0002;
+        const IMPERSONATE = 0x0004;
+        const QUERY = 0x0008;
+        const QUERY_SOURCE = 0x0010;
+        const ADJUST_PRIVILEGES = 0x0020;
+        const ADJUST_GROUPS = 0x0040;
+        const ADJUST_DEFAULT = 0x0080;
+        const ADJUST_SESSION_ID = 0x0100;
+
+        const READ = AccessMask::STANDARD_RIGHTS_READ.bits() | Self::QUERY.bits();
+        const WRITE = AccessMask::STANDARD_RIGHTS_WRITE.bits()
+            | Self::ADJUST_PRIVILEGES.bits()
+            | Self::ADJUST_GROUPS.bits()
+            | Self::ADJUST_DEFAULT.bits();
+        const EXECUTE = AccessMask::STANDARD_RIGHTS_EXECUTE.bits();
+        const ALL_ACCESS = AccessMask::DELETE.bits()
+            | AccessMask::READ_CONTROL.bits()
+            | AccessMask::WRITE_DAC.bits()
+            | AccessMask::WRITE_OWNER.bits()
+            | Self::ASSIGN_PRIMARY.bits()
+            | Self::DUPLICATE.bits()
+            | Self::IMPERSONATE.bits()
+            | Self::QUERY.bits()
+            | Self::QUERY_SOURCE.bits()
+            | Self::ADJUST_PRIVILEGES.bits()
+            | Self::ADJUST_GROUPS.bits()
+            | Self::ADJUST_DEFAULT.bits()
+            | Self::ADJUST_SESSION_ID.bits();
+
+        const _ = !0;
+    }
+}
+
+impl TokenAccess {
+    fn from_desired_access(desired_access: u32) -> Self {
+        let maximum_allowed = desired_access & AccessMask::MAXIMUM_ALLOWED.bits() != 0;
+        let explicit_access = desired_access & !AccessMask::MAXIMUM_ALLOWED.bits();
+        let normalized = AccessMask::expand_generic_access(
+            explicit_access,
+            Self::READ.bits(),
+            Self::WRITE.bits(),
+            Self::EXECUTE.bits(),
+            Self::ALL_ACCESS.bits(),
+        );
+        Self::from_bits_retain(if maximum_allowed {
+            normalized | Self::ALL_ACCESS.bits()
+        } else {
+            normalized
+        })
+    }
+}
+
+#[repr(u32)]
+#[derive(Clone, Copy, Debug, Eq, IntEnum, PartialEq)]
+pub(crate) enum TokenInformationClass {
+    User = 1,
+    Groups = 2,
+    Privileges = 3,
+    Owner = 4,
+    PrimaryGroup = 5,
+    DefaultDacl = 6,
+    Source = 7,
+    Type = 8,
+    ImpersonationLevel = 9,
+    Statistics = 10,
+    RestrictedSids = 11,
+    SessionId = 12,
+    GroupsAndPrivileges = 13,
+    SessionReference = 14,
+    SandBoxInert = 15,
+    AuditPolicy = 16,
+    Origin = 17,
+    ElevationType = 18,
+    LinkedToken = 19,
+    Elevation = 20,
+    HasRestrictions = 21,
+    AccessInformation = 22,
+    VirtualizationAllowed = 23,
+    VirtualizationEnabled = 24,
+    IntegrityLevel = 25,
+    UiAccess = 26,
+    MandatoryPolicy = 27,
+    LogonSid = 28,
+    IsAppContainer = 29,
+    Capabilities = 30,
+    AppContainerSid = 31,
+    AppContainerNumber = 32,
+    UserClaimAttributes = 33,
+    DeviceClaimAttributes = 34,
+    RestrictedUserClaimAttributes = 35,
+    RestrictedDeviceClaimAttributes = 36,
+    DeviceGroups = 37,
+    RestrictedDeviceGroups = 38,
+    SecurityAttributes = 39,
+    IsRestricted = 40,
+    ProcessTrustLevel = 41,
+    PrivateNameSpace = 42,
+    SingletonAttributes = 43,
+    BnoIsolation = 44,
+    ChildProcessFlags = 45,
+    IsLessPrivilegedAppContainer = 46,
+    IsSandboxed = 47,
+    IsAppSilo = 48,
+    LoggingInformation = 49,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, FromBytes, Immutable, IntoBytes, PartialEq)]
+pub(crate) struct Luid {
+    low_part: u32,
+    high_part: i32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, FromBytes, Immutable, IntoBytes, PartialEq)]
+pub(crate) struct SidAndAttributes {
+    sid: usize,
+    attributes: u32,
+    padding: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, FromBytes, Immutable, IntoBytes, PartialEq)]
+pub(crate) struct TokenUser {
+    user: SidAndAttributes,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, FromBytes, Immutable, IntoBytes, PartialEq)]
+pub(crate) struct Sid {
+    revision: u8,
+    sub_authority_count: u8,
+    identifier_authority: [u8; 6],
+    sub_authority: [u32; 1],
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, FromBytes, Immutable, IntoBytes, PartialEq)]
+pub(crate) struct TokenPrivileges {
+    privilege_count: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, FromBytes, Immutable, IntoBytes, PartialEq)]
+pub(crate) struct TokenStatistics {
+    token_id: Luid,
+    authentication_id: Luid,
+    expiration_time: i64,
+    token_type: u32,
+    impersonation_level: u32,
+    dynamic_charged: u32,
+    dynamic_available: u32,
+    group_count: u32,
+    privilege_count: u32,
+    modified_id: Luid,
+}
+
+const TOKEN_TYPE_PRIMARY: u32 = 1;
+const SECURITY_ANONYMOUS: u32 = 0;
+
+const LOCAL_SYSTEM_SID: Sid = Sid {
+    revision: 1,
+    sub_authority_count: 1,
+    identifier_authority: [0, 0, 0, 0, 0, 5],
+    sub_authority: [18],
+};
+
+const TOKEN_USER_SIZE: usize = size_of::<TokenUser>() + size_of::<Sid>();
+const TOKEN_USER_SID_OFFSET: isize = 16;
+const TOKEN_PRIVILEGES_SIZE: usize = size_of::<TokenPrivileges>();
+const TOKEN_STATISTICS_SIZE: usize = size_of::<TokenStatistics>();
+
+const _: () = assert!(size_of::<TokenUser>() == 16);
+const _: () = assert!(size_of::<Sid>() == 12);
+const _: () = assert!(TOKEN_USER_SIZE == 28);
+const _: () = assert!(TOKEN_PRIVILEGES_SIZE == 4);
+const _: () = assert!(TOKEN_STATISTICS_SIZE == 56);
+
+pub(crate) struct TokenObject {
+    user: Sid,
+    statistics: TokenStatistics,
+}
+
+impl TokenObject {
+    pub(crate) const fn primary() -> Self {
+        Self {
+            user: LOCAL_SYSTEM_SID,
+            statistics: TokenStatistics {
+                token_id: Luid {
+                    low_part: 1,
+                    high_part: 0,
+                },
+                authentication_id: Luid {
+                    low_part: 0x3e7,
+                    high_part: 0,
+                },
+                expiration_time: i64::MAX,
+                token_type: TOKEN_TYPE_PRIMARY,
+                impersonation_level: SECURITY_ANONYMOUS,
+                dynamic_charged: 0,
+                dynamic_available: 0,
+                group_count: 0,
+                privilege_count: 0,
+                modified_id: Luid {
+                    low_part: 2,
+                    high_part: 0,
+                },
+            },
+        }
+    }
+}
+
+pub(crate) struct TokenHandleObject {
+    token: Arc<TokenObject>,
+}
+
+pub(crate) struct TokenSubsystem;
+
+impl FdEnabledSubsystem for TokenSubsystem {
+    type Entry = TokenHandleObject;
+}
+
+impl FdEnabledSubsystemEntry for TokenHandleObject {}
+
+impl WindowsHandleSubsystem for TokenSubsystem {
+    fn normalize_desired_access(desired_access: u32) -> u32 {
+        TokenAccess::from_desired_access(desired_access).bits()
+    }
+}
+
+impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
+    pub(crate) fn sys_nt_open_process_token(
+        &self,
+        process_handle: ProcessHandle,
+        desired_access: u32,
+        token_handle: MutPtr<Platform, Handle>,
+    ) -> NtStatus {
+        self.open_process_token(process_handle, desired_access, 0, token_handle)
+    }
+
+    pub(crate) fn sys_nt_open_process_token_ex(
+        &self,
+        process_handle: ProcessHandle,
+        desired_access: u32,
+        handle_attributes: u32,
+        token_handle: MutPtr<Platform, Handle>,
+    ) -> NtStatus {
+        self.open_process_token(
+            process_handle,
+            desired_access,
+            handle_attributes,
+            token_handle,
+        )
+    }
+
+    fn open_process_token(
+        &self,
+        process_handle: ProcessHandle,
+        desired_access: u32,
+        handle_attributes: u32,
+        token_handle: MutPtr<Platform, Handle>,
+    ) -> NtStatus {
+        if let Err(status) = probe_guest_output_preserving_value::<Platform, _>(token_handle) {
+            return status;
+        }
+        let Some(attributes) = HandleAttributes::from_token_open_attributes(handle_attributes)
+        else {
+            return NtStatus::INVALID_PARAMETER;
+        };
+        if !process_handle.is_current() {
+            // TODO(token-cross-process): Resolve real process handles once the sandbox supports
+            // multiple guest processes and per-process primary tokens.
+            return NtStatus::INVALID_HANDLE;
+        }
+
+        let handle = match self.insert_typed_handle_with_attributes::<TokenSubsystem>(
+            TokenHandleObject {
+                token: self.process.token.clone(),
+            },
+            TokenAccess::from_desired_access(desired_access).bits(),
+            attributes,
+            drop,
+        ) {
+            Ok(handle) => handle,
+            Err(status) => return status,
+        };
+        if token_handle.write_at_offset(0, handle).is_none() {
+            self.close_token_handle(handle);
+            return NtStatus::ACCESS_VIOLATION;
+        }
+        NtStatus::SUCCESS
+    }
+
+    pub(crate) fn sys_nt_query_information_token(
+        &self,
+        token_handle: Handle,
+        token_information_class: u32,
+        token_information: MutPtr<Platform, u8>,
+        token_information_length: u32,
+        return_length: MutPtr<Platform, u32>,
+    ) -> NtStatus {
+        if let Err(status) = probe_guest_output_preserving_value::<Platform, _>(return_length) {
+            return status;
+        }
+        let Ok(class) = TokenInformationClass::try_from(token_information_class) else {
+            return NtStatus::INVALID_INFO_CLASS;
+        };
+        if let Err(status) = probe_guest_output_buffer::<Platform>(
+            token_information,
+            token_information_length as usize,
+        ) {
+            return status;
+        }
+
+        let entry = match self.typed_handle_entry_with_access::<TokenSubsystem>(
+            token_handle,
+            TokenAccess::QUERY.bits(),
+        ) {
+            Ok(entry) => entry,
+            Err(status) => return status,
+        };
+
+        match class {
+            TokenInformationClass::User => entry.with_entry(|entry| {
+                Self::write_token_user(
+                    &entry.token,
+                    token_information,
+                    token_information_length,
+                    return_length,
+                )
+            }),
+            TokenInformationClass::Privileges => entry.with_entry(|entry| {
+                Self::write_token_privileges(
+                    &entry.token,
+                    token_information,
+                    token_information_length,
+                    return_length,
+                )
+            }),
+            TokenInformationClass::Statistics => entry.with_entry(|entry| {
+                Self::write_token_statistics(
+                    &entry.token,
+                    token_information,
+                    token_information_length,
+                    return_length,
+                )
+            }),
+            _ => {
+                // TODO(token-model): Add each information class when its backing token state is
+                // modeled; do not synthesize security-sensitive token data.
+                NtStatus::NOT_IMPLEMENTED
+            }
+        }
+    }
+
+    fn write_token_user(
+        token: &TokenObject,
+        token_information: MutPtr<Platform, u8>,
+        token_information_length: u32,
+        return_length: MutPtr<Platform, u32>,
+    ) -> NtStatus {
+        let required_length = TOKEN_USER_SIZE.trunc();
+        if return_length.write_at_offset(0, required_length).is_none() {
+            return NtStatus::ACCESS_VIOLATION;
+        }
+        if token_information_length < required_length {
+            return NtStatus::BUFFER_TOO_SMALL;
+        }
+
+        let Some(sid_address) = token_information
+            .as_usize()
+            .checked_add(size_of::<TokenUser>())
+        else {
+            return NtStatus::ACCESS_VIOLATION;
+        };
+        let user = TokenUser {
+            user: SidAndAttributes {
+                sid: sid_address,
+                attributes: 0,
+                padding: 0,
+            },
+        };
+        if token_information
+            .write_slice_at_offset(0, user.as_bytes())
+            .is_none()
+            || token_information
+                .write_slice_at_offset(TOKEN_USER_SID_OFFSET, token.user.as_bytes())
+                .is_none()
+        {
+            return NtStatus::ACCESS_VIOLATION;
+        }
+        NtStatus::SUCCESS
+    }
+
+    fn write_token_privileges(
+        _token: &TokenObject,
+        token_information: MutPtr<Platform, u8>,
+        token_information_length: u32,
+        return_length: MutPtr<Platform, u32>,
+    ) -> NtStatus {
+        let required_length = TOKEN_PRIVILEGES_SIZE.trunc();
+        if return_length.write_at_offset(0, required_length).is_none() {
+            return NtStatus::ACCESS_VIOLATION;
+        }
+        if token_information_length < required_length {
+            return NtStatus::BUFFER_TOO_SMALL;
+        }
+        let privileges = TokenPrivileges { privilege_count: 0 };
+        if token_information
+            .write_slice_at_offset(0, privileges.as_bytes())
+            .is_none()
+        {
+            return NtStatus::ACCESS_VIOLATION;
+        }
+        NtStatus::SUCCESS
+    }
+
+    fn write_token_statistics(
+        token: &TokenObject,
+        token_information: MutPtr<Platform, u8>,
+        token_information_length: u32,
+        return_length: MutPtr<Platform, u32>,
+    ) -> NtStatus {
+        let required_length = TOKEN_STATISTICS_SIZE.trunc();
+        if return_length.write_at_offset(0, required_length).is_none() {
+            return NtStatus::ACCESS_VIOLATION;
+        }
+        if token_information_length < required_length {
+            return NtStatus::BUFFER_TOO_SMALL;
+        }
+        if token_information
+            .write_slice_at_offset(0, token.statistics.as_bytes())
+            .is_none()
+        {
+            return NtStatus::ACCESS_VIOLATION;
+        }
+        NtStatus::SUCCESS
+    }
+
+    pub(crate) fn close_token_handle(&self, handle: Handle) {
+        self.close_typed_handle::<TokenSubsystem>(handle, drop);
+    }
+
+    pub(crate) fn close_token(token: TokenHandleObject) {
+        drop(token);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tests::{mut_byte_ptr, mut_ptr, null_mut_ptr, test_task};
+    use crate::{DuplicateOptions, tests::TestPlatform};
+    use litebox::platform::ThreadProvider;
+
+    #[repr(C)]
+    #[derive(Clone, Copy, Debug, Eq, FromBytes, Immutable, IntoBytes, PartialEq)]
+    struct TokenUserBuffer {
+        user: TokenUser,
+        sid: Sid,
+        padding: u32,
+    }
+
+    #[test]
+    fn open_and_query_process_token_identity() {
+        let task = test_task();
+        let mut handle = Handle::default();
+        assert_eq!(
+            task.sys_nt_open_process_token(
+                ProcessHandle::CURRENT,
+                TokenAccess::QUERY.bits(),
+                mut_ptr(&mut handle),
+            ),
+            NtStatus::SUCCESS
+        );
+
+        let mut required_length = 0;
+        assert_eq!(
+            task.sys_nt_query_information_token(
+                handle,
+                TokenInformationClass::User as u32,
+                null_mut_ptr(),
+                0,
+                mut_ptr(&mut required_length),
+            ),
+            NtStatus::BUFFER_TOO_SMALL
+        );
+        assert_eq!(required_length as usize, TOKEN_USER_SIZE);
+
+        let mut output = TokenUserBuffer {
+            user: TokenUser {
+                user: SidAndAttributes {
+                    sid: 0,
+                    attributes: u32::MAX,
+                    padding: 0,
+                },
+            },
+            sid: Sid {
+                revision: 0,
+                sub_authority_count: 0,
+                identifier_authority: [0; 6],
+                sub_authority: [0],
+            },
+            padding: 0,
+        };
+        assert_eq!(
+            task.sys_nt_query_information_token(
+                handle,
+                TokenInformationClass::User as u32,
+                mut_byte_ptr(&mut output),
+                required_length,
+                mut_ptr(&mut required_length),
+            ),
+            NtStatus::SUCCESS
+        );
+        assert_eq!(
+            output.user.user.sid,
+            core::ptr::from_ref(&output.sid) as usize
+        );
+        assert_eq!(output.user.user.attributes, 0);
+        assert_eq!(output.sid, LOCAL_SYSTEM_SID);
+    }
+
+    #[test]
+    fn query_process_token_reports_privileges_and_statistics() {
+        let task = test_task();
+        let mut handle = Handle::default();
+        assert_eq!(
+            task.sys_nt_open_process_token_ex(
+                ProcessHandle::CURRENT,
+                TokenAccess::QUERY.bits(),
+                HandleAttributes::INHERIT.bits(),
+                mut_ptr(&mut handle),
+            ),
+            NtStatus::SUCCESS
+        );
+
+        let mut privileges = TokenPrivileges {
+            privilege_count: u32::MAX,
+        };
+        let mut return_length = 0;
+        assert_eq!(
+            task.sys_nt_query_information_token(
+                handle,
+                TokenInformationClass::Privileges as u32,
+                mut_byte_ptr(&mut privileges),
+                size_of::<TokenPrivileges>().trunc(),
+                mut_ptr(&mut return_length),
+            ),
+            NtStatus::SUCCESS
+        );
+        assert_eq!(return_length as usize, TOKEN_PRIVILEGES_SIZE);
+        assert_eq!(privileges.privilege_count, 0);
+
+        let mut statistics = TokenStatistics {
+            token_id: Luid {
+                low_part: 0,
+                high_part: 0,
+            },
+            authentication_id: Luid {
+                low_part: 0,
+                high_part: 0,
+            },
+            expiration_time: 0,
+            token_type: 0,
+            impersonation_level: 0,
+            dynamic_charged: 0,
+            dynamic_available: 0,
+            group_count: u32::MAX,
+            privilege_count: u32::MAX,
+            modified_id: Luid {
+                low_part: 0,
+                high_part: 0,
+            },
+        };
+        assert_eq!(
+            task.sys_nt_query_information_token(
+                handle,
+                TokenInformationClass::Statistics as u32,
+                mut_byte_ptr(&mut statistics),
+                size_of::<TokenStatistics>().trunc(),
+                mut_ptr(&mut return_length),
+            ),
+            NtStatus::SUCCESS
+        );
+        assert_eq!(return_length as usize, TOKEN_STATISTICS_SIZE);
+        assert_eq!(statistics.authentication_id.low_part, 0x3e7);
+        assert_eq!(statistics.token_type, TOKEN_TYPE_PRIMARY);
+        assert_eq!(statistics.group_count, 0);
+        assert_eq!(statistics.privilege_count, 0);
+    }
+
+    #[test]
+    fn query_process_token_enforces_buffer_and_access() {
+        let task = test_task();
+        let mut query_handle = Handle::default();
+        assert_eq!(
+            task.sys_nt_open_process_token(
+                ProcessHandle::CURRENT,
+                TokenAccess::QUERY.bits(),
+                mut_ptr(&mut query_handle),
+            ),
+            NtStatus::SUCCESS
+        );
+
+        let mut output = [0xa5_u8; TOKEN_STATISTICS_SIZE];
+        let mut return_length = 0;
+        assert_eq!(
+            task.sys_nt_query_information_token(
+                query_handle,
+                TokenInformationClass::Statistics as u32,
+                mut_byte_ptr(&mut output),
+                (TOKEN_STATISTICS_SIZE - 1).trunc(),
+                mut_ptr(&mut return_length),
+            ),
+            NtStatus::BUFFER_TOO_SMALL
+        );
+        assert_eq!(return_length as usize, TOKEN_STATISTICS_SIZE);
+        assert_eq!(output, [0xa5; TOKEN_STATISTICS_SIZE]);
+
+        let mut duplicate_only_handle = Handle::default();
+        assert_eq!(
+            task.sys_nt_open_process_token(
+                ProcessHandle::CURRENT,
+                TokenAccess::DUPLICATE.bits(),
+                mut_ptr(&mut duplicate_only_handle),
+            ),
+            NtStatus::SUCCESS
+        );
+        assert_eq!(
+            task.sys_nt_query_information_token(
+                duplicate_only_handle,
+                TokenInformationClass::Statistics as u32,
+                mut_byte_ptr(&mut output),
+                TOKEN_STATISTICS_SIZE.trunc(),
+                mut_ptr(&mut return_length),
+            ),
+            NtStatus::ACCESS_DENIED
+        );
+    }
+
+    #[test]
+    fn open_process_token_validates_process_and_attributes() {
+        let task = test_task();
+        let sentinel = Handle::from_raw(0x1122_3344);
+        let mut handle = sentinel;
+        assert_eq!(
+            task.sys_nt_open_process_token(
+                ProcessHandle::from_raw(0x1234),
+                TokenAccess::QUERY.bits(),
+                mut_ptr(&mut handle),
+            ),
+            NtStatus::INVALID_HANDLE
+        );
+        assert_eq!(handle, sentinel);
+
+        assert_eq!(
+            task.sys_nt_open_process_token_ex(
+                ProcessHandle::CURRENT,
+                TokenAccess::QUERY.bits(),
+                0x20,
+                mut_ptr(&mut handle),
+            ),
+            NtStatus::INVALID_PARAMETER
+        );
+        assert_eq!(handle, sentinel);
+
+        assert_eq!(
+            task.sys_nt_open_process_token_ex(
+                ProcessHandle::CURRENT,
+                TokenAccess::QUERY.bits(),
+                0x40,
+                mut_ptr(&mut handle),
+            ),
+            NtStatus::SUCCESS
+        );
+        assert_eq!(task.sys_nt_close(handle), NtStatus::SUCCESS);
+    }
+
+    #[test]
+    fn duplicated_token_handle_remains_queryable_after_source_close() {
+        let task = test_task();
+        let mut source = Handle::default();
+        assert_eq!(
+            task.sys_nt_open_process_token(
+                ProcessHandle::CURRENT,
+                TokenAccess::QUERY.bits(),
+                mut_ptr(&mut source),
+            ),
+            NtStatus::SUCCESS
+        );
+        let mut duplicate = Handle::default();
+        assert_eq!(
+            task.sys_nt_duplicate_object(
+                ProcessHandle::CURRENT,
+                source,
+                ProcessHandle::CURRENT,
+                Some(mut_ptr(&mut duplicate)),
+                0,
+                0,
+                DuplicateOptions::SAME_ACCESS.bits(),
+            ),
+            NtStatus::SUCCESS
+        );
+        assert_eq!(task.sys_nt_close(source), NtStatus::SUCCESS);
+
+        let mut privileges = TokenPrivileges {
+            privilege_count: u32::MAX,
+        };
+        let mut return_length = 0;
+        assert_eq!(
+            task.sys_nt_query_information_token(
+                duplicate,
+                TokenInformationClass::Privileges as u32,
+                mut_byte_ptr(&mut privileges),
+                TOKEN_PRIVILEGES_SIZE.trunc(),
+                mut_ptr(&mut return_length),
+            ),
+            NtStatus::SUCCESS
+        );
+        assert_eq!(privileges.privilege_count, 0);
+        assert_eq!(task.sys_nt_close(duplicate), NtStatus::SUCCESS);
+        assert_eq!(
+            task.sys_nt_query_information_token(
+                duplicate,
+                TokenInformationClass::Privileges as u32,
+                mut_byte_ptr(&mut privileges),
+                TOKEN_PRIVILEGES_SIZE.trunc(),
+                mut_ptr(&mut return_length),
+            ),
+            NtStatus::INVALID_HANDLE
+        );
+    }
+
+    #[test]
+    fn query_process_token_requires_return_length() {
+        let _ = crate::tests::test_platform();
+        <TestPlatform as ThreadProvider>::run_test_thread(|| {
+            let task = test_task();
+            let mut handle = Handle::default();
+            assert_eq!(
+                task.sys_nt_open_process_token(
+                    ProcessHandle::CURRENT,
+                    TokenAccess::QUERY.bits(),
+                    mut_ptr(&mut handle),
+                ),
+                NtStatus::SUCCESS
+            );
+            assert_eq!(
+                task.sys_nt_query_information_token(
+                    handle,
+                    TokenInformationClass::User as u32,
+                    null_mut_ptr(),
+                    0,
+                    MutPtr::<TestPlatform, u32>::from_usize(0),
+                ),
+                NtStatus::ACCESS_VIOLATION
+            );
+        });
+    }
+}

--- a/litebox_shim_windows/src/syscalls/token.rs
+++ b/litebox_shim_windows/src/syscalls/token.rs
@@ -13,7 +13,7 @@ use litebox::utils::TruncateExt as _;
 use litebox_common_windows::nt_status::NtStatus;
 use zerocopy::{FromBytes, Immutable, IntoBytes};
 
-use crate::nt_types::AccessMask;
+use crate::nt_types::{AccessMask, Luid};
 use crate::syscalls::{Handle, ProcessHandle};
 use crate::{
     HandleAttributes, MutPtr, ShimFS, Task, WindowsHandleSubsystem, probe_guest_output_buffer,
@@ -132,13 +132,6 @@ pub(crate) enum TokenInformationClass {
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, FromBytes, Immutable, IntoBytes, PartialEq)]
-pub(crate) struct Luid {
-    low_part: u32,
-    high_part: i32,
-}
-
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, FromBytes, Immutable, IntoBytes, PartialEq)]
 pub(crate) struct SidAndAttributes {
     sid: usize,
     attributes: u32,
@@ -158,6 +151,13 @@ pub(crate) struct Sid {
     sub_authority_count: u8,
     identifier_authority: [u8; 6],
     sub_authority: [u32; 1],
+}
+
+#[repr(C, packed(4))]
+#[derive(Immutable, IntoBytes)]
+struct TokenUserInformation {
+    user: TokenUser,
+    sid: Sid,
 }
 
 #[repr(C)]
@@ -184,23 +184,29 @@ pub(crate) struct TokenStatistics {
 const TOKEN_TYPE_PRIMARY: u32 = 1;
 const SECURITY_ANONYMOUS: u32 = 0;
 
+// TODO(token-luid-allocation): Allocate these from sandbox-wide state once multiple token objects
+// or token mutation are supported.
+const PRIMARY_TOKEN_ID: Luid = Luid {
+    low_part: 1,
+    high_part: 0,
+};
+
+const PRIMARY_TOKEN_MODIFIED_ID: Luid = Luid {
+    low_part: 2,
+    high_part: 0,
+};
+
+const SYSTEM_LUID: Luid = Luid {
+    low_part: 0x3e7,
+    high_part: 0,
+};
+
 const LOCAL_SYSTEM_SID: Sid = Sid {
     revision: 1,
     sub_authority_count: 1,
     identifier_authority: [0, 0, 0, 0, 0, 5],
     sub_authority: [18],
 };
-
-const TOKEN_USER_SIZE: usize = size_of::<TokenUser>() + size_of::<Sid>();
-const TOKEN_USER_SID_OFFSET: isize = 16;
-const TOKEN_PRIVILEGES_SIZE: usize = size_of::<TokenPrivileges>();
-const TOKEN_STATISTICS_SIZE: usize = size_of::<TokenStatistics>();
-
-const _: () = assert!(size_of::<TokenUser>() == 16);
-const _: () = assert!(size_of::<Sid>() == 12);
-const _: () = assert!(TOKEN_USER_SIZE == 28);
-const _: () = assert!(TOKEN_PRIVILEGES_SIZE == 4);
-const _: () = assert!(TOKEN_STATISTICS_SIZE == 56);
 
 pub(crate) struct TokenObject {
     user: Sid,
@@ -212,14 +218,8 @@ impl TokenObject {
         Self {
             user: LOCAL_SYSTEM_SID,
             statistics: TokenStatistics {
-                token_id: Luid {
-                    low_part: 1,
-                    high_part: 0,
-                },
-                authentication_id: Luid {
-                    low_part: 0x3e7,
-                    high_part: 0,
-                },
+                token_id: PRIMARY_TOKEN_ID,
+                authentication_id: SYSTEM_LUID,
                 expiration_time: i64::MAX,
                 token_type: TOKEN_TYPE_PRIMARY,
                 impersonation_level: SECURITY_ANONYMOUS,
@@ -227,10 +227,7 @@ impl TokenObject {
                 dynamic_available: 0,
                 group_count: 0,
                 privilege_count: 0,
-                modified_id: Luid {
-                    low_part: 2,
-                    high_part: 0,
-                },
+                modified_id: PRIMARY_TOKEN_MODIFIED_ID,
             },
         }
     }
@@ -348,27 +345,40 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
 
         match class {
             TokenInformationClass::User => entry.with_entry(|entry| {
-                Self::write_token_user(
-                    &entry.token,
+                Self::write_token_information_value(
                     token_information,
                     token_information_length,
                     return_length,
+                    || {
+                        let sid_address = token_information
+                            .as_usize()
+                            .checked_add(size_of::<TokenUser>())
+                            .ok_or(NtStatus::ACCESS_VIOLATION)?;
+                        Ok(TokenUserInformation {
+                            user: TokenUser {
+                                user: SidAndAttributes {
+                                    sid: sid_address,
+                                    attributes: 0,
+                                    padding: 0,
+                                },
+                            },
+                            sid: entry.token.user,
+                        })
+                    },
                 )
             }),
-            TokenInformationClass::Privileges => entry.with_entry(|entry| {
-                Self::write_token_privileges(
-                    &entry.token,
-                    token_information,
-                    token_information_length,
-                    return_length,
-                )
-            }),
+            TokenInformationClass::Privileges => Self::write_token_information_value(
+                token_information,
+                token_information_length,
+                return_length,
+                || Ok(TokenPrivileges { privilege_count: 0 }),
+            ),
             TokenInformationClass::Statistics => entry.with_entry(|entry| {
-                Self::write_token_statistics(
-                    &entry.token,
+                Self::write_token_information_value(
                     token_information,
                     token_information_length,
                     return_length,
+                    || Ok(entry.token.statistics),
                 )
             }),
             _ => {
@@ -379,83 +389,25 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         }
     }
 
-    fn write_token_user(
-        token: &TokenObject,
+    fn write_token_information_value<T: Immutable + IntoBytes>(
         token_information: MutPtr<Platform, u8>,
         token_information_length: u32,
         return_length: MutPtr<Platform, u32>,
+        build_information: impl FnOnce() -> Result<T, NtStatus>,
     ) -> NtStatus {
-        let required_length = TOKEN_USER_SIZE.trunc();
+        let required_length = size_of::<T>().trunc();
         if return_length.write_at_offset(0, required_length).is_none() {
             return NtStatus::ACCESS_VIOLATION;
         }
         if token_information_length < required_length {
             return NtStatus::BUFFER_TOO_SMALL;
         }
-
-        let Some(sid_address) = token_information
-            .as_usize()
-            .checked_add(size_of::<TokenUser>())
-        else {
-            return NtStatus::ACCESS_VIOLATION;
-        };
-        let user = TokenUser {
-            user: SidAndAttributes {
-                sid: sid_address,
-                attributes: 0,
-                padding: 0,
-            },
+        let information = match build_information() {
+            Ok(information) => information,
+            Err(status) => return status,
         };
         if token_information
-            .write_slice_at_offset(0, user.as_bytes())
-            .is_none()
-            || token_information
-                .write_slice_at_offset(TOKEN_USER_SID_OFFSET, token.user.as_bytes())
-                .is_none()
-        {
-            return NtStatus::ACCESS_VIOLATION;
-        }
-        NtStatus::SUCCESS
-    }
-
-    fn write_token_privileges(
-        _token: &TokenObject,
-        token_information: MutPtr<Platform, u8>,
-        token_information_length: u32,
-        return_length: MutPtr<Platform, u32>,
-    ) -> NtStatus {
-        let required_length = TOKEN_PRIVILEGES_SIZE.trunc();
-        if return_length.write_at_offset(0, required_length).is_none() {
-            return NtStatus::ACCESS_VIOLATION;
-        }
-        if token_information_length < required_length {
-            return NtStatus::BUFFER_TOO_SMALL;
-        }
-        let privileges = TokenPrivileges { privilege_count: 0 };
-        if token_information
-            .write_slice_at_offset(0, privileges.as_bytes())
-            .is_none()
-        {
-            return NtStatus::ACCESS_VIOLATION;
-        }
-        NtStatus::SUCCESS
-    }
-
-    fn write_token_statistics(
-        token: &TokenObject,
-        token_information: MutPtr<Platform, u8>,
-        token_information_length: u32,
-        return_length: MutPtr<Platform, u32>,
-    ) -> NtStatus {
-        let required_length = TOKEN_STATISTICS_SIZE.trunc();
-        if return_length.write_at_offset(0, required_length).is_none() {
-            return NtStatus::ACCESS_VIOLATION;
-        }
-        if token_information_length < required_length {
-            return NtStatus::BUFFER_TOO_SMALL;
-        }
-        if token_information
-            .write_slice_at_offset(0, token.statistics.as_bytes())
+            .write_slice_at_offset(0, information.as_bytes())
             .is_none()
         {
             return NtStatus::ACCESS_VIOLATION;
@@ -476,8 +428,6 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
 mod tests {
     use super::*;
     use crate::tests::{mut_byte_ptr, mut_ptr, null_mut_ptr, test_task};
-    use crate::{DuplicateOptions, tests::TestPlatform};
-    use litebox::platform::ThreadProvider;
 
     #[repr(C)]
     #[derive(Clone, Copy, Debug, Eq, FromBytes, Immutable, IntoBytes, PartialEq)]
@@ -511,7 +461,10 @@ mod tests {
             ),
             NtStatus::BUFFER_TOO_SMALL
         );
-        assert_eq!(required_length as usize, TOKEN_USER_SIZE);
+        assert_eq!(
+            required_length as usize,
+            size_of::<TokenUser>() + size_of::<Sid>()
+        );
 
         let mut output = TokenUserBuffer {
             user: TokenUser {
@@ -545,243 +498,5 @@ mod tests {
         );
         assert_eq!(output.user.user.attributes, 0);
         assert_eq!(output.sid, LOCAL_SYSTEM_SID);
-    }
-
-    #[test]
-    fn query_process_token_reports_privileges_and_statistics() {
-        let task = test_task();
-        let mut handle = Handle::default();
-        assert_eq!(
-            task.sys_nt_open_process_token_ex(
-                ProcessHandle::CURRENT,
-                TokenAccess::QUERY.bits(),
-                HandleAttributes::INHERIT.bits(),
-                mut_ptr(&mut handle),
-            ),
-            NtStatus::SUCCESS
-        );
-
-        let mut privileges = TokenPrivileges {
-            privilege_count: u32::MAX,
-        };
-        let mut return_length = 0;
-        assert_eq!(
-            task.sys_nt_query_information_token(
-                handle,
-                TokenInformationClass::Privileges as u32,
-                mut_byte_ptr(&mut privileges),
-                size_of::<TokenPrivileges>().trunc(),
-                mut_ptr(&mut return_length),
-            ),
-            NtStatus::SUCCESS
-        );
-        assert_eq!(return_length as usize, TOKEN_PRIVILEGES_SIZE);
-        assert_eq!(privileges.privilege_count, 0);
-
-        let mut statistics = TokenStatistics {
-            token_id: Luid {
-                low_part: 0,
-                high_part: 0,
-            },
-            authentication_id: Luid {
-                low_part: 0,
-                high_part: 0,
-            },
-            expiration_time: 0,
-            token_type: 0,
-            impersonation_level: 0,
-            dynamic_charged: 0,
-            dynamic_available: 0,
-            group_count: u32::MAX,
-            privilege_count: u32::MAX,
-            modified_id: Luid {
-                low_part: 0,
-                high_part: 0,
-            },
-        };
-        assert_eq!(
-            task.sys_nt_query_information_token(
-                handle,
-                TokenInformationClass::Statistics as u32,
-                mut_byte_ptr(&mut statistics),
-                size_of::<TokenStatistics>().trunc(),
-                mut_ptr(&mut return_length),
-            ),
-            NtStatus::SUCCESS
-        );
-        assert_eq!(return_length as usize, TOKEN_STATISTICS_SIZE);
-        assert_eq!(statistics.authentication_id.low_part, 0x3e7);
-        assert_eq!(statistics.token_type, TOKEN_TYPE_PRIMARY);
-        assert_eq!(statistics.group_count, 0);
-        assert_eq!(statistics.privilege_count, 0);
-    }
-
-    #[test]
-    fn query_process_token_enforces_buffer_and_access() {
-        let task = test_task();
-        let mut query_handle = Handle::default();
-        assert_eq!(
-            task.sys_nt_open_process_token(
-                ProcessHandle::CURRENT,
-                TokenAccess::QUERY.bits(),
-                mut_ptr(&mut query_handle),
-            ),
-            NtStatus::SUCCESS
-        );
-
-        let mut output = [0xa5_u8; TOKEN_STATISTICS_SIZE];
-        let mut return_length = 0;
-        assert_eq!(
-            task.sys_nt_query_information_token(
-                query_handle,
-                TokenInformationClass::Statistics as u32,
-                mut_byte_ptr(&mut output),
-                (TOKEN_STATISTICS_SIZE - 1).trunc(),
-                mut_ptr(&mut return_length),
-            ),
-            NtStatus::BUFFER_TOO_SMALL
-        );
-        assert_eq!(return_length as usize, TOKEN_STATISTICS_SIZE);
-        assert_eq!(output, [0xa5; TOKEN_STATISTICS_SIZE]);
-
-        let mut duplicate_only_handle = Handle::default();
-        assert_eq!(
-            task.sys_nt_open_process_token(
-                ProcessHandle::CURRENT,
-                TokenAccess::DUPLICATE.bits(),
-                mut_ptr(&mut duplicate_only_handle),
-            ),
-            NtStatus::SUCCESS
-        );
-        assert_eq!(
-            task.sys_nt_query_information_token(
-                duplicate_only_handle,
-                TokenInformationClass::Statistics as u32,
-                mut_byte_ptr(&mut output),
-                TOKEN_STATISTICS_SIZE.trunc(),
-                mut_ptr(&mut return_length),
-            ),
-            NtStatus::ACCESS_DENIED
-        );
-    }
-
-    #[test]
-    fn open_process_token_validates_process_and_attributes() {
-        let task = test_task();
-        let sentinel = Handle::from_raw(0x1122_3344);
-        let mut handle = sentinel;
-        assert_eq!(
-            task.sys_nt_open_process_token(
-                ProcessHandle::from_raw(0x1234),
-                TokenAccess::QUERY.bits(),
-                mut_ptr(&mut handle),
-            ),
-            NtStatus::INVALID_HANDLE
-        );
-        assert_eq!(handle, sentinel);
-
-        assert_eq!(
-            task.sys_nt_open_process_token_ex(
-                ProcessHandle::CURRENT,
-                TokenAccess::QUERY.bits(),
-                0x20,
-                mut_ptr(&mut handle),
-            ),
-            NtStatus::INVALID_PARAMETER
-        );
-        assert_eq!(handle, sentinel);
-
-        assert_eq!(
-            task.sys_nt_open_process_token_ex(
-                ProcessHandle::CURRENT,
-                TokenAccess::QUERY.bits(),
-                0x40,
-                mut_ptr(&mut handle),
-            ),
-            NtStatus::SUCCESS
-        );
-        assert_eq!(task.sys_nt_close(handle), NtStatus::SUCCESS);
-    }
-
-    #[test]
-    fn duplicated_token_handle_remains_queryable_after_source_close() {
-        let task = test_task();
-        let mut source = Handle::default();
-        assert_eq!(
-            task.sys_nt_open_process_token(
-                ProcessHandle::CURRENT,
-                TokenAccess::QUERY.bits(),
-                mut_ptr(&mut source),
-            ),
-            NtStatus::SUCCESS
-        );
-        let mut duplicate = Handle::default();
-        assert_eq!(
-            task.sys_nt_duplicate_object(
-                ProcessHandle::CURRENT,
-                source,
-                ProcessHandle::CURRENT,
-                Some(mut_ptr(&mut duplicate)),
-                0,
-                0,
-                DuplicateOptions::SAME_ACCESS.bits(),
-            ),
-            NtStatus::SUCCESS
-        );
-        assert_eq!(task.sys_nt_close(source), NtStatus::SUCCESS);
-
-        let mut privileges = TokenPrivileges {
-            privilege_count: u32::MAX,
-        };
-        let mut return_length = 0;
-        assert_eq!(
-            task.sys_nt_query_information_token(
-                duplicate,
-                TokenInformationClass::Privileges as u32,
-                mut_byte_ptr(&mut privileges),
-                TOKEN_PRIVILEGES_SIZE.trunc(),
-                mut_ptr(&mut return_length),
-            ),
-            NtStatus::SUCCESS
-        );
-        assert_eq!(privileges.privilege_count, 0);
-        assert_eq!(task.sys_nt_close(duplicate), NtStatus::SUCCESS);
-        assert_eq!(
-            task.sys_nt_query_information_token(
-                duplicate,
-                TokenInformationClass::Privileges as u32,
-                mut_byte_ptr(&mut privileges),
-                TOKEN_PRIVILEGES_SIZE.trunc(),
-                mut_ptr(&mut return_length),
-            ),
-            NtStatus::INVALID_HANDLE
-        );
-    }
-
-    #[test]
-    fn query_process_token_requires_return_length() {
-        let _ = crate::tests::test_platform();
-        <TestPlatform as ThreadProvider>::run_test_thread(|| {
-            let task = test_task();
-            let mut handle = Handle::default();
-            assert_eq!(
-                task.sys_nt_open_process_token(
-                    ProcessHandle::CURRENT,
-                    TokenAccess::QUERY.bits(),
-                    mut_ptr(&mut handle),
-                ),
-                NtStatus::SUCCESS
-            );
-            assert_eq!(
-                task.sys_nt_query_information_token(
-                    handle,
-                    TokenInformationClass::User as u32,
-                    null_mut_ptr(),
-                    0,
-                    MutPtr::<TestPlatform, u32>::from_usize(0),
-                ),
-                NtStatus::ACCESS_VIOLATION
-            );
-        });
     }
 }

--- a/litebox_shim_windows/src/tests.rs
+++ b/litebox_shim_windows/src/tests.rs
@@ -282,6 +282,53 @@ fn nt_duplicate_object_closes_source_even_when_duplication_fails() {
     assert!(duplicate.is_null());
 }
 
+#[test]
+fn nt_duplicate_object_validates_and_filters_handle_attributes() {
+    let task = test_task();
+    let source = create_event(&task, EVENT_MODIFY_STATE);
+    let sentinel = Handle::from_raw(0x7777);
+    let mut duplicate = sentinel;
+
+    assert_eq!(
+        task.sys_nt_duplicate_object(
+            crate::syscalls::ProcessHandle::CURRENT,
+            source,
+            crate::syscalls::ProcessHandle::CURRENT,
+            Some(mut_ptr(&mut duplicate)),
+            0,
+            0x20,
+            DUPLICATE_SAME_ACCESS,
+        ),
+        litebox_common_windows::nt_status::NtStatus::INVALID_PARAMETER
+    );
+    assert!(duplicate.is_null());
+
+    assert_eq!(
+        task.sys_nt_duplicate_object(
+            crate::syscalls::ProcessHandle::CURRENT,
+            source,
+            crate::syscalls::ProcessHandle::CURRENT,
+            Some(mut_ptr(&mut duplicate)),
+            0,
+            0x100,
+            DUPLICATE_SAME_ACCESS,
+        ),
+        litebox_common_windows::nt_status::NtStatus::SUCCESS
+    );
+    assert_eq!(
+        task.sys_nt_set_event(duplicate, None),
+        litebox_common_windows::nt_status::NtStatus::SUCCESS
+    );
+    assert_eq!(
+        task.sys_nt_close(duplicate),
+        litebox_common_windows::nt_status::NtStatus::SUCCESS
+    );
+    assert_eq!(
+        task.sys_nt_close(source),
+        litebox_common_windows::nt_status::NtStatus::SUCCESS
+    );
+}
+
 #[cfg(target_os = "windows")]
 #[test]
 fn host_nt_duplicate_object_failure_and_access_matrix() {

--- a/litebox_shim_windows/src/tests.rs
+++ b/litebox_shim_windows/src/tests.rs
@@ -282,53 +282,6 @@ fn nt_duplicate_object_closes_source_even_when_duplication_fails() {
     assert!(duplicate.is_null());
 }
 
-#[test]
-fn nt_duplicate_object_validates_and_filters_handle_attributes() {
-    let task = test_task();
-    let source = create_event(&task, EVENT_MODIFY_STATE);
-    let sentinel = Handle::from_raw(0x7777);
-    let mut duplicate = sentinel;
-
-    assert_eq!(
-        task.sys_nt_duplicate_object(
-            crate::syscalls::ProcessHandle::CURRENT,
-            source,
-            crate::syscalls::ProcessHandle::CURRENT,
-            Some(mut_ptr(&mut duplicate)),
-            0,
-            0x20,
-            DUPLICATE_SAME_ACCESS,
-        ),
-        litebox_common_windows::nt_status::NtStatus::INVALID_PARAMETER
-    );
-    assert!(duplicate.is_null());
-
-    assert_eq!(
-        task.sys_nt_duplicate_object(
-            crate::syscalls::ProcessHandle::CURRENT,
-            source,
-            crate::syscalls::ProcessHandle::CURRENT,
-            Some(mut_ptr(&mut duplicate)),
-            0,
-            0x100,
-            DUPLICATE_SAME_ACCESS,
-        ),
-        litebox_common_windows::nt_status::NtStatus::SUCCESS
-    );
-    assert_eq!(
-        task.sys_nt_set_event(duplicate, None),
-        litebox_common_windows::nt_status::NtStatus::SUCCESS
-    );
-    assert_eq!(
-        task.sys_nt_close(duplicate),
-        litebox_common_windows::nt_status::NtStatus::SUCCESS
-    );
-    assert_eq!(
-        task.sys_nt_close(source),
-        litebox_common_windows::nt_status::NtStatus::SUCCESS
-    );
-}
-
 #[cfg(target_os = "windows")]
 #[test]
 fn host_nt_duplicate_object_failure_and_access_matrix() {


### PR DESCRIPTION
This PR adds typed current-process token handles for `NtOpenProcessToken`, `NtOpenProcessTokenEx` and `NtQueryInformationToken`, including close and duplicate support. Cross-process tokens and remaining token information classes are deferred.