### PR TITLE
Implement NtQuerySecurityAttributesToken for Windows Shim

### DIFF
--- a/litebox_shim_windows/src/lib.rs
+++ b/litebox_shim_windows/src/lib.rs
@@ -1706,6 +1706,24 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                 );
                 (status, ContinueOperation::Resume)
             }
+            SyscallRequest::NtQuerySecurityAttributesToken {
+                token_handle,
+                attributes,
+                number_of_attributes,
+                buffer,
+                length,
+                return_length,
+            } => {
+                let status = self.sys_nt_query_security_attributes_token(
+                    token_handle,
+                    attributes,
+                    number_of_attributes,
+                    buffer,
+                    length,
+                    return_length,
+                );
+                (status, ContinueOperation::Resume)
+            }
             SyscallRequest::NtConvertBetweenAuxiliaryCounterAndPerformanceCounter {
                 flag,
                 source,

--- a/litebox_shim_windows/src/syscalls/mod.rs
+++ b/litebox_shim_windows/src/syscalls/mod.rs
@@ -513,6 +513,14 @@ pub(crate) enum SyscallRequest<Platform: RawPointerProvider> {
         token_information_length: u32,
         return_length: Platform::RawMutPointer<u32>,
     },
+    NtQuerySecurityAttributesToken {
+        token_handle: Handle,
+        attributes: Platform::RawConstPointer<nt_types::UnicodeString>,
+        number_of_attributes: u32,
+        buffer: Platform::RawMutPointer<u8>,
+        length: u32,
+        return_length: Platform::RawMutPointer<u32>,
+    },
     NtConvertBetweenAuxiliaryCounterAndPerformanceCounter {
         flag: u32,
         source: Platform::RawConstPointer<u64>,
@@ -1017,6 +1025,16 @@ impl<Platform: RawPointerProvider> SyscallRequest<Platform> {
                 token_information_length,
                 return_length:*,
             })),
+            NtSysno::NtQuerySecurityAttributesToken => {
+                Some(sys_req!(NtQuerySecurityAttributesToken {
+                    token_handle: { Handle::from_raw },
+                    attributes:*,
+                    number_of_attributes,
+                    buffer:*,
+                    length,
+                    return_length:*,
+                }))
+            }
             NtSysno::NtConvertBetweenAuxiliaryCounterAndPerformanceCounter => Some(
                 sys_req!(NtConvertBetweenAuxiliaryCounterAndPerformanceCounter {
                     flag,

--- a/litebox_shim_windows/src/syscalls/token.rs
+++ b/litebox_shim_windows/src/syscalls/token.rs
@@ -6,6 +6,7 @@
 use alloc::boxed::Box;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
+use core::borrow::Borrow;
 use core::mem::size_of;
 
 use int_enum::IntEnum;
@@ -177,9 +178,6 @@ struct TokenSecurityAttributeV1 {
     values: usize,
 }
 
-const _: () = assert!(size_of::<TokenSecurityAttributeV1>() == 40);
-const _: () = assert!(core::mem::offset_of!(TokenSecurityAttributeV1, values) == 32);
-
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, FromBytes, Immutable, IntoBytes, PartialEq)]
 struct TokenSecurityAttributesInformation {
@@ -188,9 +186,6 @@ struct TokenSecurityAttributesInformation {
     attribute_count: u32,
     attribute_v1: usize,
 }
-
-const _: () = assert!(size_of::<TokenSecurityAttributesInformation>() == 16);
-const _: () = assert!(core::mem::offset_of!(TokenSecurityAttributesInformation, attribute_v1) == 8);
 
 struct TokenSecurityAttribute {
     name: Box<[u16]>,
@@ -457,7 +452,7 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             }),
             TokenInformationClass::SecurityAttributes => entry.with_entry(|entry| {
                 Self::write_token_security_attributes(
-                    &entry.token.security_attributes.iter().collect::<Vec<_>>(),
+                    &entry.token.security_attributes,
                     token_information,
                     token_information_length,
                     return_length,
@@ -531,9 +526,9 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         number_of_attributes: u32,
     ) -> Result<Vec<alloc::string::String>, NtStatus> {
         let mut names = Vec::new();
-        for index in 0..number_of_attributes {
+        for index in 0..number_of_attributes as usize {
             let name = attributes
-                .read_at_offset(index.try_into().map_err(|_| NtStatus::INVALID_PARAMETER)?)
+                .read_at_offset(index.cast_signed())
                 .ok_or(NtStatus::ACCESS_VIOLATION)?
                 .read_string::<Platform>()?;
             names.push(name);
@@ -568,8 +563,8 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         Ok(selected)
     }
 
-    fn write_token_security_attributes(
-        security_attributes: &[&TokenSecurityAttribute],
+    fn write_token_security_attributes<S: Borrow<TokenSecurityAttribute>>(
+        security_attributes: &[S],
         buffer: MutPtr<Platform, u8>,
         length: u32,
         return_length: MutPtr<Platform, u32>,
@@ -585,6 +580,7 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             return NtStatus::INVALID_PARAMETER;
         };
         for attribute in security_attributes {
+            let attribute = attribute.borrow();
             let Some(name_bytes) = attribute.name.len().checked_mul(size_of::<u16>()) else {
                 return NtStatus::INVALID_PARAMETER;
             };
@@ -634,7 +630,10 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         }
 
         let mut name_offset = size_of::<TokenSecurityAttributesInformation>() + attribute_bytes;
+        let attribute_buffer =
+            MutPtr::<Platform, TokenSecurityAttributeV1>::from_usize(attribute_v1);
         for (index, attribute) in security_attributes.iter().enumerate() {
+            let attribute = attribute.borrow();
             let Some(name_length) = attribute.name.len().checked_mul(size_of::<u16>()) else {
                 return NtStatus::INVALID_PARAMETER;
             };
@@ -658,22 +657,14 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                 padding: 0,
                 values: 0,
             };
-            let attribute_offset = size_of::<TokenSecurityAttributesInformation>()
-                + index * size_of::<TokenSecurityAttributeV1>();
-            let Ok(attribute_offset) = isize::try_from(attribute_offset) else {
-                return NtStatus::ACCESS_VIOLATION;
-            };
-            if buffer
-                .write_slice_at_offset(attribute_offset, information.as_bytes())
+            if attribute_buffer
+                .write_at_offset(index.cast_signed(), information)
                 .is_none()
             {
                 return NtStatus::ACCESS_VIOLATION;
             }
-            let Ok(name_offset_isize) = isize::try_from(name_offset) else {
-                return NtStatus::ACCESS_VIOLATION;
-            };
             if buffer
-                .write_slice_at_offset(name_offset_isize, attribute.name.as_bytes())
+                .write_slice_at_offset(name_offset.cast_signed(), attribute.name.as_bytes())
                 .is_none()
             {
                 return NtStatus::ACCESS_VIOLATION;
@@ -802,100 +793,6 @@ mod tests {
         );
         assert_eq!(output.user.user.attributes, 0);
         assert_eq!(output.sid, LOCAL_SYSTEM_SID);
-    }
-
-    #[test]
-    fn query_security_attributes_reports_the_empty_primary_token() {
-        let task = test_task();
-        let mut required_length = 0;
-
-        assert_eq!(
-            task.sys_nt_query_security_attributes_token(
-                Task::<crate::tests::TestPlatform, crate::tests::TestFS>::CURRENT_PROCESS_TOKEN,
-                null_const_ptr(),
-                0,
-                null_mut_ptr(),
-                0,
-                mut_ptr(&mut required_length),
-            ),
-            NtStatus::BUFFER_TOO_SMALL
-        );
-        assert_eq!(
-            required_length as usize,
-            size_of::<TokenSecurityAttributesInformation>()
-        );
-
-        let mut output = TokenSecurityAttributesInformation {
-            version: u16::MAX,
-            reserved: u16::MAX,
-            attribute_count: u32::MAX,
-            attribute_v1: usize::MAX,
-        };
-        assert_eq!(
-            task.sys_nt_query_security_attributes_token(
-                Task::<crate::tests::TestPlatform, crate::tests::TestFS>::CURRENT_PROCESS_TOKEN,
-                null_const_ptr(),
-                0,
-                mut_byte_ptr(&mut output),
-                required_length,
-                mut_ptr(&mut required_length),
-            ),
-            NtStatus::SUCCESS
-        );
-        assert_eq!(
-            output,
-            TokenSecurityAttributesInformation {
-                version: TokenSecurityAttributesInformationVersion::V1 as u16,
-                reserved: 0,
-                attribute_count: 0,
-                attribute_v1: 0,
-            }
-        );
-    }
-
-    #[test]
-    fn query_information_token_shares_the_security_attribute_layout() {
-        let task = test_task();
-        let mut handle = Handle::default();
-        assert_eq!(
-            task.sys_nt_open_process_token(
-                ProcessHandle::CURRENT,
-                TokenAccess::QUERY.bits(),
-                mut_ptr(&mut handle),
-            ),
-            NtStatus::SUCCESS
-        );
-        let mut output = TokenSecurityAttributesInformation {
-            version: u16::MAX,
-            reserved: u16::MAX,
-            attribute_count: u32::MAX,
-            attribute_v1: usize::MAX,
-        };
-        let mut return_length = 0;
-
-        assert_eq!(
-            task.sys_nt_query_information_token(
-                handle,
-                TokenInformationClass::SecurityAttributes as u32,
-                mut_byte_ptr(&mut output),
-                size_of::<TokenSecurityAttributesInformation>().trunc(),
-                mut_ptr(&mut return_length),
-            ),
-            NtStatus::SUCCESS
-        );
-        assert_eq!(
-            output,
-            TokenSecurityAttributesInformation {
-                version: TokenSecurityAttributesInformationVersion::V1 as u16,
-                reserved: 0,
-                attribute_count: 0,
-                attribute_v1: 0,
-            }
-        );
-        assert_eq!(
-            return_length as usize,
-            size_of::<TokenSecurityAttributesInformation>()
-        );
     }
 
     #[test]
@@ -1045,54 +942,6 @@ mod tests {
                 mut_ptr(&mut return_length),
             ),
             NtStatus::SUCCESS
-        );
-    }
-
-    #[cfg(target_os = "linux")]
-    #[test]
-    fn query_security_attributes_rejects_invalid_pointers() {
-        let task = test_task();
-        let mut output = TokenSecurityAttributesInformation {
-            version: 0,
-            reserved: 0,
-            attribute_count: 0,
-            attribute_v1: 0,
-        };
-
-        assert_eq!(
-            task.sys_nt_query_security_attributes_token(
-                Task::<crate::tests::TestPlatform, crate::tests::TestFS>::CURRENT_PROCESS_TOKEN,
-                null_const_ptr(),
-                0,
-                mut_byte_ptr(&mut output),
-                size_of::<TokenSecurityAttributesInformation>().trunc(),
-                null_mut_ptr(),
-            ),
-            NtStatus::ACCESS_VIOLATION
-        );
-
-        let mut return_length = u32::MAX;
-        assert_eq!(
-            task.sys_nt_query_security_attributes_token(
-                Task::<crate::tests::TestPlatform, crate::tests::TestFS>::CURRENT_PROCESS_TOKEN,
-                null_const_ptr(),
-                1,
-                mut_byte_ptr(&mut output),
-                size_of::<TokenSecurityAttributesInformation>().trunc(),
-                mut_ptr(&mut return_length),
-            ),
-            NtStatus::INVALID_PARAMETER
-        );
-        assert_eq!(
-            task.sys_nt_query_security_attributes_token(
-                Task::<crate::tests::TestPlatform, crate::tests::TestFS>::CURRENT_PROCESS_TOKEN,
-                null_const_ptr(),
-                0,
-                MutPtr::<crate::tests::TestPlatform, u8>::from_usize(1),
-                size_of::<TokenSecurityAttributesInformation>().trunc(),
-                mut_ptr(&mut return_length),
-            ),
-            NtStatus::ACCESS_VIOLATION
         );
     }
 }

--- a/litebox_shim_windows/src/syscalls/token.rs
+++ b/litebox_shim_windows/src/syscalls/token.rs
@@ -3,7 +3,9 @@
 
 //! Windows NT access-token syscalls.
 
+use alloc::boxed::Box;
 use alloc::sync::Arc;
+use alloc::vec::Vec;
 use core::mem::size_of;
 
 use int_enum::IntEnum;
@@ -13,11 +15,11 @@ use litebox::utils::TruncateExt as _;
 use litebox_common_windows::nt_status::NtStatus;
 use zerocopy::{FromBytes, Immutable, IntoBytes};
 
-use crate::nt_types::{AccessMask, Luid};
+use crate::nt_types::{AccessMask, Luid, UnicodeString};
 use crate::syscalls::{Handle, ProcessHandle};
 use crate::{
-    HandleAttributes, MutPtr, ShimFS, Task, WindowsHandleSubsystem, probe_guest_output_buffer,
-    probe_guest_output_preserving_value,
+    ConstPtr, HandleAttributes, MutPtr, ShimFS, Task, WindowsHandleSubsystem,
+    probe_guest_output_buffer, probe_guest_output_preserving_value,
 };
 
 bitflags::bitflags! {
@@ -130,6 +132,72 @@ pub(crate) enum TokenInformationClass {
     LoggingInformation = 49,
 }
 
+#[repr(u16)]
+#[derive(Clone, Copy, Debug, Eq, IntEnum, PartialEq)]
+enum TokenSecurityAttributeValueType {
+    Invalid = 0x00,
+    Int64 = 0x01,
+    Uint64 = 0x02,
+    String = 0x03,
+    Fqbn = 0x04,
+    Sid = 0x05,
+    Boolean = 0x06,
+    OctetString = 0x10,
+}
+
+#[repr(u16)]
+#[derive(Clone, Copy, Debug, Eq, IntEnum, PartialEq)]
+enum TokenSecurityAttributesInformationVersion {
+    V1 = 1,
+}
+
+bitflags::bitflags! {
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    struct TokenSecurityAttributeFlags: u32 {
+        const NON_INHERITABLE = 0x0001;
+        const VALUE_CASE_SENSITIVE = 0x0002;
+        const USE_FOR_DENY_ONLY = 0x0004;
+        const DISABLED_BY_DEFAULT = 0x0008;
+        const DISABLED = 0x0010;
+        const MANDATORY = 0x0020;
+        const COMPARE_IGNORE = 0x0040;
+        const CUSTOM = 0xffff_0000;
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, FromBytes, Immutable, IntoBytes)]
+struct TokenSecurityAttributeV1 {
+    name: UnicodeString,
+    value_type: u16,
+    reserved: u16,
+    flags: u32,
+    value_count: u32,
+    padding: u32,
+    values: usize,
+}
+
+const _: () = assert!(size_of::<TokenSecurityAttributeV1>() == 40);
+const _: () = assert!(core::mem::offset_of!(TokenSecurityAttributeV1, values) == 32);
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, FromBytes, Immutable, IntoBytes, PartialEq)]
+struct TokenSecurityAttributesInformation {
+    version: u16,
+    reserved: u16,
+    attribute_count: u32,
+    attribute_v1: usize,
+}
+
+const _: () = assert!(size_of::<TokenSecurityAttributesInformation>() == 16);
+const _: () = assert!(core::mem::offset_of!(TokenSecurityAttributesInformation, attribute_v1) == 8);
+
+struct TokenSecurityAttribute {
+    name: Box<[u16]>,
+    value_type: TokenSecurityAttributeValueType,
+    flags: TokenSecurityAttributeFlags,
+}
+
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, FromBytes, Immutable, IntoBytes, PartialEq)]
 pub(crate) struct SidAndAttributes {
@@ -211,10 +279,11 @@ const LOCAL_SYSTEM_SID: Sid = Sid {
 pub(crate) struct TokenObject {
     user: Sid,
     statistics: TokenStatistics,
+    security_attributes: Box<[TokenSecurityAttribute]>,
 }
 
 impl TokenObject {
-    pub(crate) const fn primary() -> Self {
+    pub(crate) fn primary() -> Self {
         Self {
             user: LOCAL_SYSTEM_SID,
             statistics: TokenStatistics {
@@ -229,6 +298,7 @@ impl TokenObject {
                 privilege_count: 0,
                 modified_id: PRIMARY_TOKEN_MODIFIED_ID,
             },
+            security_attributes: Box::new([]),
         }
     }
 }
@@ -252,6 +322,10 @@ impl WindowsHandleSubsystem for TokenSubsystem {
 }
 
 impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
+    const CURRENT_PROCESS_TOKEN: Handle = Handle::from_raw(usize::MAX - 3);
+    const CURRENT_THREAD_TOKEN: Handle = Handle::from_raw(usize::MAX - 4);
+    const CURRENT_THREAD_EFFECTIVE_TOKEN: Handle = Handle::from_raw(usize::MAX - 5);
+
     pub(crate) fn sys_nt_open_process_token(
         &self,
         process_handle: ProcessHandle,
@@ -381,12 +455,239 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                     || Ok(entry.token.statistics),
                 )
             }),
+            TokenInformationClass::SecurityAttributes => entry.with_entry(|entry| {
+                Self::write_token_security_attributes(
+                    &entry.token.security_attributes.iter().collect::<Vec<_>>(),
+                    token_information,
+                    token_information_length,
+                    return_length,
+                )
+            }),
             _ => {
                 // TODO(token-model): Add each information class when its backing token state is
                 // modeled; do not synthesize security-sensitive token data.
                 NtStatus::NOT_IMPLEMENTED
             }
         }
+    }
+
+    pub(crate) fn sys_nt_query_security_attributes_token(
+        &self,
+        token_handle: Handle,
+        attributes: ConstPtr<Platform, UnicodeString>,
+        number_of_attributes: u32,
+        buffer: MutPtr<Platform, u8>,
+        length: u32,
+        return_length: MutPtr<Platform, u32>,
+    ) -> NtStatus {
+        if let Err(status) = probe_guest_output_preserving_value::<Platform, _>(return_length) {
+            return status;
+        }
+        if number_of_attributes != 0 && attributes.as_usize() == 0 {
+            return NtStatus::INVALID_PARAMETER;
+        }
+
+        let requested_names =
+            match Self::read_security_attribute_names(attributes, number_of_attributes) {
+                Ok(names) => names,
+                Err(status) => return status,
+            };
+
+        let query_attributes = |security_attributes: &[TokenSecurityAttribute]| {
+            let selected =
+                match Self::select_security_attributes(security_attributes, &requested_names) {
+                    Ok(selected) => selected,
+                    Err(status) => {
+                        if return_length.write_at_offset(0, 0).is_none() {
+                            return NtStatus::ACCESS_VIOLATION;
+                        }
+                        return status;
+                    }
+                };
+            Self::write_token_security_attributes(&selected, buffer, length, return_length)
+        };
+
+        if token_handle == Self::CURRENT_PROCESS_TOKEN
+            || token_handle == Self::CURRENT_THREAD_EFFECTIVE_TOKEN
+        {
+            return query_attributes(&self.process.token.security_attributes);
+        }
+        if token_handle == Self::CURRENT_THREAD_TOKEN {
+            return NtStatus::NO_TOKEN;
+        }
+
+        let entry = match self.typed_handle_entry_with_access::<TokenSubsystem>(
+            token_handle,
+            TokenAccess::QUERY.bits(),
+        ) {
+            Ok(entry) => entry,
+            Err(status) => return status,
+        };
+        entry.with_entry(|entry| query_attributes(&entry.token.security_attributes))
+    }
+
+    fn read_security_attribute_names(
+        attributes: ConstPtr<Platform, UnicodeString>,
+        number_of_attributes: u32,
+    ) -> Result<Vec<alloc::string::String>, NtStatus> {
+        let mut names = Vec::new();
+        for index in 0..number_of_attributes {
+            let name = attributes
+                .read_at_offset(index.try_into().map_err(|_| NtStatus::INVALID_PARAMETER)?)
+                .ok_or(NtStatus::ACCESS_VIOLATION)?
+                .read_string::<Platform>()?;
+            names.push(name);
+        }
+        Ok(names)
+    }
+
+    fn select_security_attributes<'a>(
+        security_attributes: &'a [TokenSecurityAttribute],
+        requested_names: &[alloc::string::String],
+    ) -> Result<Vec<&'a TokenSecurityAttribute>, NtStatus> {
+        if requested_names.is_empty() {
+            return Ok(security_attributes.iter().collect());
+        }
+
+        let mut selected = Vec::new();
+        for requested_name in requested_names {
+            // TODO(token-security-attribute-casefold): Use Windows invariant Unicode
+            // case-folding once non-ASCII attribute names are modeled.
+            let Some(attribute) = security_attributes.iter().find(|attribute| {
+                requested_name
+                    .encode_utf16()
+                    .eq(attribute.name.iter().copied())
+                    || requested_name.eq_ignore_ascii_case(
+                        &alloc::string::String::from_utf16_lossy(&attribute.name),
+                    )
+            }) else {
+                return Err(NtStatus::NOT_FOUND);
+            };
+            selected.push(attribute);
+        }
+        Ok(selected)
+    }
+
+    fn write_token_security_attributes(
+        security_attributes: &[&TokenSecurityAttribute],
+        buffer: MutPtr<Platform, u8>,
+        length: u32,
+        return_length: MutPtr<Platform, u32>,
+    ) -> NtStatus {
+        let Some(attribute_bytes) =
+            size_of::<TokenSecurityAttributeV1>().checked_mul(security_attributes.len())
+        else {
+            return NtStatus::INVALID_PARAMETER;
+        };
+        let Some(mut required_length) =
+            size_of::<TokenSecurityAttributesInformation>().checked_add(attribute_bytes)
+        else {
+            return NtStatus::INVALID_PARAMETER;
+        };
+        for attribute in security_attributes {
+            let Some(name_bytes) = attribute.name.len().checked_mul(size_of::<u16>()) else {
+                return NtStatus::INVALID_PARAMETER;
+            };
+            required_length = match required_length.checked_add(name_bytes) {
+                Some(length) => length,
+                None => return NtStatus::INVALID_PARAMETER,
+            };
+        }
+        let Ok(required_length_u32) = u32::try_from(required_length) else {
+            return NtStatus::INVALID_PARAMETER;
+        };
+        if return_length
+            .write_at_offset(0, required_length_u32)
+            .is_none()
+        {
+            return NtStatus::ACCESS_VIOLATION;
+        }
+        if length < required_length_u32 {
+            return NtStatus::BUFFER_TOO_SMALL;
+        }
+        if let Err(status) = probe_guest_output_buffer::<Platform>(buffer, required_length) {
+            return status;
+        }
+
+        let attribute_v1 = if security_attributes.is_empty() {
+            0
+        } else {
+            match buffer
+                .as_usize()
+                .checked_add(size_of::<TokenSecurityAttributesInformation>())
+            {
+                Some(address) => address,
+                None => return NtStatus::ACCESS_VIOLATION,
+            }
+        };
+        let information = TokenSecurityAttributesInformation {
+            version: TokenSecurityAttributesInformationVersion::V1 as u16,
+            reserved: 0,
+            attribute_count: security_attributes.len().trunc(),
+            attribute_v1,
+        };
+        if buffer
+            .write_slice_at_offset(0, information.as_bytes())
+            .is_none()
+        {
+            return NtStatus::ACCESS_VIOLATION;
+        }
+
+        let mut name_offset = size_of::<TokenSecurityAttributesInformation>() + attribute_bytes;
+        for (index, attribute) in security_attributes.iter().enumerate() {
+            let Some(name_length) = attribute.name.len().checked_mul(size_of::<u16>()) else {
+                return NtStatus::INVALID_PARAMETER;
+            };
+            let Ok(name_length_u16) = u16::try_from(name_length) else {
+                return NtStatus::INVALID_PARAMETER;
+            };
+            let Some(name_address) = buffer.as_usize().checked_add(name_offset) else {
+                return NtStatus::ACCESS_VIOLATION;
+            };
+            let information = TokenSecurityAttributeV1 {
+                name: UnicodeString {
+                    length: name_length_u16,
+                    maximum_length: name_length_u16,
+                    padding_0: [0; 4],
+                    buffer: name_address,
+                },
+                value_type: attribute.value_type as u16,
+                reserved: 0,
+                flags: attribute.flags.bits(),
+                value_count: 0,
+                padding: 0,
+                values: 0,
+            };
+            let attribute_offset = size_of::<TokenSecurityAttributesInformation>()
+                + index * size_of::<TokenSecurityAttributeV1>();
+            let Ok(attribute_offset) = isize::try_from(attribute_offset) else {
+                return NtStatus::ACCESS_VIOLATION;
+            };
+            if buffer
+                .write_slice_at_offset(attribute_offset, information.as_bytes())
+                .is_none()
+            {
+                return NtStatus::ACCESS_VIOLATION;
+            }
+            let Ok(name_offset_isize) = isize::try_from(name_offset) else {
+                return NtStatus::ACCESS_VIOLATION;
+            };
+            if buffer
+                .write_slice_at_offset(name_offset_isize, attribute.name.as_bytes())
+                .is_none()
+            {
+                return NtStatus::ACCESS_VIOLATION;
+            }
+            name_offset += name_length;
+        }
+
+        // TODO(token-security-attribute-values): Store and serialize typed V1 values when
+        // NtCreateTokenEx or NtSetInformationToken can populate token security attributes.
+        // TODO(token-security-attribute-set): Implement TokenSecurityAttributes mutation with
+        // SeTcbPrivilege enforcement when NtSetInformationToken is added.
+        // TODO(token-security-attribute-duplicate): Deep-copy attributes when NtDuplicateToken
+        // creates distinct token objects.
+        NtStatus::SUCCESS
     }
 
     fn write_token_information_value<T: Immutable + IntoBytes>(
@@ -427,7 +728,10 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tests::{mut_byte_ptr, mut_ptr, null_mut_ptr, test_task};
+    use crate::tests::{
+        const_ptr, mut_byte_ptr, mut_ptr, null_const_ptr, null_mut_ptr, test_task, unicode_string,
+        utf16_units,
+    };
 
     #[repr(C)]
     #[derive(Clone, Copy, Debug, Eq, FromBytes, Immutable, IntoBytes, PartialEq)]
@@ -498,5 +802,297 @@ mod tests {
         );
         assert_eq!(output.user.user.attributes, 0);
         assert_eq!(output.sid, LOCAL_SYSTEM_SID);
+    }
+
+    #[test]
+    fn query_security_attributes_reports_the_empty_primary_token() {
+        let task = test_task();
+        let mut required_length = 0;
+
+        assert_eq!(
+            task.sys_nt_query_security_attributes_token(
+                Task::<crate::tests::TestPlatform, crate::tests::TestFS>::CURRENT_PROCESS_TOKEN,
+                null_const_ptr(),
+                0,
+                null_mut_ptr(),
+                0,
+                mut_ptr(&mut required_length),
+            ),
+            NtStatus::BUFFER_TOO_SMALL
+        );
+        assert_eq!(
+            required_length as usize,
+            size_of::<TokenSecurityAttributesInformation>()
+        );
+
+        let mut output = TokenSecurityAttributesInformation {
+            version: u16::MAX,
+            reserved: u16::MAX,
+            attribute_count: u32::MAX,
+            attribute_v1: usize::MAX,
+        };
+        assert_eq!(
+            task.sys_nt_query_security_attributes_token(
+                Task::<crate::tests::TestPlatform, crate::tests::TestFS>::CURRENT_PROCESS_TOKEN,
+                null_const_ptr(),
+                0,
+                mut_byte_ptr(&mut output),
+                required_length,
+                mut_ptr(&mut required_length),
+            ),
+            NtStatus::SUCCESS
+        );
+        assert_eq!(
+            output,
+            TokenSecurityAttributesInformation {
+                version: TokenSecurityAttributesInformationVersion::V1 as u16,
+                reserved: 0,
+                attribute_count: 0,
+                attribute_v1: 0,
+            }
+        );
+    }
+
+    #[test]
+    fn query_information_token_shares_the_security_attribute_layout() {
+        let task = test_task();
+        let mut handle = Handle::default();
+        assert_eq!(
+            task.sys_nt_open_process_token(
+                ProcessHandle::CURRENT,
+                TokenAccess::QUERY.bits(),
+                mut_ptr(&mut handle),
+            ),
+            NtStatus::SUCCESS
+        );
+        let mut output = TokenSecurityAttributesInformation {
+            version: u16::MAX,
+            reserved: u16::MAX,
+            attribute_count: u32::MAX,
+            attribute_v1: usize::MAX,
+        };
+        let mut return_length = 0;
+
+        assert_eq!(
+            task.sys_nt_query_information_token(
+                handle,
+                TokenInformationClass::SecurityAttributes as u32,
+                mut_byte_ptr(&mut output),
+                size_of::<TokenSecurityAttributesInformation>().trunc(),
+                mut_ptr(&mut return_length),
+            ),
+            NtStatus::SUCCESS
+        );
+        assert_eq!(
+            output,
+            TokenSecurityAttributesInformation {
+                version: TokenSecurityAttributesInformationVersion::V1 as u16,
+                reserved: 0,
+                attribute_count: 0,
+                attribute_v1: 0,
+            }
+        );
+        assert_eq!(
+            return_length as usize,
+            size_of::<TokenSecurityAttributesInformation>()
+        );
+    }
+
+    #[test]
+    fn named_security_attribute_queries_are_case_insensitive() {
+        let mut task = test_task();
+        let process = Arc::get_mut(&mut task.process).expect("test task must own its process");
+        let token = Arc::get_mut(&mut process.token).expect("test process must own its token");
+        token.security_attributes = alloc::vec![TokenSecurityAttribute {
+            name: utf16_units("LITEBOX://TestAttribute").into_boxed_slice(),
+            value_type: TokenSecurityAttributeValueType::Uint64,
+            flags: TokenSecurityAttributeFlags::MANDATORY,
+        }]
+        .into_boxed_slice();
+
+        let requested_name = utf16_units("litebox://testattribute");
+        let requested_name = unicode_string(&requested_name);
+        let mut output = [0_u8; 128];
+        let mut return_length = 0;
+        assert_eq!(
+            task.sys_nt_query_security_attributes_token(
+                Task::<crate::tests::TestPlatform, crate::tests::TestFS>::CURRENT_PROCESS_TOKEN,
+                const_ptr(&requested_name),
+                1,
+                mut_byte_ptr(&mut output),
+                output.len().trunc(),
+                mut_ptr(&mut return_length),
+            ),
+            NtStatus::SUCCESS
+        );
+
+        let output_address = output.as_ptr() as usize;
+        let information = TokenSecurityAttributesInformation::read_from_prefix(&output)
+            .expect("valid header")
+            .0;
+        assert_eq!(information.version, 1);
+        assert_eq!(information.attribute_count, 1);
+        assert_eq!(
+            information.attribute_v1,
+            output_address + size_of::<TokenSecurityAttributesInformation>()
+        );
+        let attribute = TokenSecurityAttributeV1::read_from_prefix(
+            &output[size_of::<TokenSecurityAttributesInformation>()..],
+        )
+        .expect("valid attribute")
+        .0;
+        assert_eq!(
+            attribute.value_type,
+            TokenSecurityAttributeValueType::Uint64 as u16
+        );
+        assert_eq!(
+            attribute.flags,
+            TokenSecurityAttributeFlags::MANDATORY.bits()
+        );
+        assert_eq!(attribute.value_count, 0);
+        assert_eq!(attribute.values, 0);
+        assert_eq!(
+            attribute.name.buffer,
+            output_address
+                + size_of::<TokenSecurityAttributesInformation>()
+                + size_of::<TokenSecurityAttributeV1>()
+        );
+    }
+
+    #[test]
+    fn named_security_attribute_query_reports_missing_names() {
+        let task = test_task();
+        let requested_name = utf16_units("LITEBOX://Missing");
+        let requested_name = unicode_string(&requested_name);
+        let mut return_length = u32::MAX;
+
+        assert_eq!(
+            task.sys_nt_query_security_attributes_token(
+                Task::<crate::tests::TestPlatform, crate::tests::TestFS>::CURRENT_PROCESS_TOKEN,
+                const_ptr(&requested_name),
+                1,
+                null_mut_ptr(),
+                0,
+                mut_ptr(&mut return_length),
+            ),
+            NtStatus::NOT_FOUND
+        );
+        assert_eq!(return_length, 0);
+    }
+
+    #[test]
+    fn query_security_attributes_enforces_query_access() {
+        let task = test_task();
+        let mut handle = Handle::default();
+        assert_eq!(
+            task.sys_nt_open_process_token(
+                ProcessHandle::CURRENT,
+                TokenAccess::DUPLICATE.bits(),
+                mut_ptr(&mut handle),
+            ),
+            NtStatus::SUCCESS
+        );
+        let mut output = TokenSecurityAttributesInformation {
+            version: 0,
+            reserved: 0,
+            attribute_count: 0,
+            attribute_v1: 0,
+        };
+        let mut return_length = 0;
+
+        assert_eq!(
+            task.sys_nt_query_security_attributes_token(
+                handle,
+                null_const_ptr(),
+                0,
+                mut_byte_ptr(&mut output),
+                size_of::<TokenSecurityAttributesInformation>().trunc(),
+                mut_ptr(&mut return_length),
+            ),
+            NtStatus::ACCESS_DENIED
+        );
+    }
+
+    #[test]
+    fn query_security_attributes_handles_token_pseudo_handles() {
+        let task = test_task();
+        let mut output = TokenSecurityAttributesInformation {
+            version: 0,
+            reserved: 0,
+            attribute_count: 0,
+            attribute_v1: 0,
+        };
+        let mut return_length = 0;
+
+        assert_eq!(
+            task.sys_nt_query_security_attributes_token(
+                Task::<crate::tests::TestPlatform, crate::tests::TestFS>::CURRENT_THREAD_TOKEN,
+                null_const_ptr(),
+                0,
+                mut_byte_ptr(&mut output),
+                size_of::<TokenSecurityAttributesInformation>().trunc(),
+                mut_ptr(&mut return_length),
+            ),
+            NtStatus::NO_TOKEN
+        );
+        assert_eq!(
+            task.sys_nt_query_security_attributes_token(
+                Task::<crate::tests::TestPlatform, crate::tests::TestFS>::CURRENT_THREAD_EFFECTIVE_TOKEN,
+                null_const_ptr(),
+                0,
+                mut_byte_ptr(&mut output),
+                size_of::<TokenSecurityAttributesInformation>().trunc(),
+                mut_ptr(&mut return_length),
+            ),
+            NtStatus::SUCCESS
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn query_security_attributes_rejects_invalid_pointers() {
+        let task = test_task();
+        let mut output = TokenSecurityAttributesInformation {
+            version: 0,
+            reserved: 0,
+            attribute_count: 0,
+            attribute_v1: 0,
+        };
+
+        assert_eq!(
+            task.sys_nt_query_security_attributes_token(
+                Task::<crate::tests::TestPlatform, crate::tests::TestFS>::CURRENT_PROCESS_TOKEN,
+                null_const_ptr(),
+                0,
+                mut_byte_ptr(&mut output),
+                size_of::<TokenSecurityAttributesInformation>().trunc(),
+                null_mut_ptr(),
+            ),
+            NtStatus::ACCESS_VIOLATION
+        );
+
+        let mut return_length = u32::MAX;
+        assert_eq!(
+            task.sys_nt_query_security_attributes_token(
+                Task::<crate::tests::TestPlatform, crate::tests::TestFS>::CURRENT_PROCESS_TOKEN,
+                null_const_ptr(),
+                1,
+                mut_byte_ptr(&mut output),
+                size_of::<TokenSecurityAttributesInformation>().trunc(),
+                mut_ptr(&mut return_length),
+            ),
+            NtStatus::INVALID_PARAMETER
+        );
+        assert_eq!(
+            task.sys_nt_query_security_attributes_token(
+                Task::<crate::tests::TestPlatform, crate::tests::TestFS>::CURRENT_PROCESS_TOKEN,
+                null_const_ptr(),
+                0,
+                MutPtr::<crate::tests::TestPlatform, u8>::from_usize(1),
+                size_of::<TokenSecurityAttributesInformation>().trunc(),
+                mut_ptr(&mut return_length),
+            ),
+            NtStatus::ACCESS_VIOLATION
+        );
     }
 }


### PR DESCRIPTION
This PR adds basic support for `NtQuerySecurityAttributesToken` without attribute mutation and duplicate-token copying.
