### PR TITLE
Normalize objdump snapshot output

### DIFF
--- a/litebox_syscall_rewriter/tests/snapshot_tests.rs
+++ b/litebox_syscall_rewriter/tests/snapshot_tests.rs
@@ -17,12 +17,17 @@ fn objdump(objdump_cmd: &str, binary: &[u8]) -> String {
         .output()
         .unwrap();
 
-    String::from_utf8_lossy(&output.stdout)
+    let mut lines = String::from_utf8_lossy(&output.stdout)
         .lines()
         .filter(|l| !l.contains("/tmp/"))
         .map(|line| normalize_objdump_line(line, trampoline_range.as_ref()))
-        .collect::<Vec<_>>()
-        .join("\n")
+        .collect::<Vec<_>>();
+    let first_content = lines
+        .iter()
+        .position(|line| !line.is_empty())
+        .unwrap_or(lines.len());
+    lines.drain(..first_content);
+    lines.join("\n")
 }
 
 /// Return the first objdump-like command that exists on the host from
@@ -57,9 +62,6 @@ fn trampoline_range(binary: &[u8]) -> Option<std::ops::Range<u64>> {
 }
 
 fn normalize_objdump_line(line: &str, trampoline_range: Option<&std::ops::Range<u64>>) -> String {
-    let Some(trampoline_range) = trampoline_range else {
-        return line.trim_end().to_owned();
-    };
     let Some((address, rest)) = line.split_once(':') else {
         return line.trim_end().to_owned();
     };
@@ -71,19 +73,54 @@ fn normalize_objdump_line(line: &str, trampoline_range: Option<&std::ops::Range<
     // trampoline base so the snapshot is independent of the trampoline's exact
     // address. Other branches (and same-mnemonic branches that stay in the
     // original code) are left untouched.
-    for (i, token) in tokens.iter().enumerate() {
-        if !matches!(*token, "jmp" | "b" | "bl") {
-            continue;
-        }
-        if let Some(target) = tokens
-            .get(i + 1)
-            .and_then(|t| u64::from_str_radix(t.trim_start_matches("0x"), 16).ok())
-            && trampoline_range.contains(&target)
-        {
-            let offset = target - trampoline_range.start;
-            return format!("{address}:\t<trampoline-{token}+0x{offset:x}>");
+    if let Some(trampoline_range) = trampoline_range {
+        for (i, token) in tokens.iter().enumerate() {
+            if !matches!(*token, "jmp" | "b" | "bl") {
+                continue;
+            }
+            if let Some(target) = tokens
+                .get(i + 1)
+                .and_then(|t| u64::from_str_radix(t.trim_start_matches("0x"), 16).ok())
+                && trampoline_range.contains(&target)
+            {
+                let offset = target - trampoline_range.start;
+                return format!("{address}:\t<trampoline-{token}+0x{offset:x}>");
+            }
         }
     }
+
+    // GNU and LLVM objdump differ in whitespace, capitalization, comments,
+    // and some numeric formatting. Keep snapshots focused on instructions
+    // rather than the disassembler that happened to be available.
+    let code_len = tokens
+        .iter()
+        .take_while(|token| {
+            matches!(token.len(), 2 | 8) && token.bytes().all(|byte| byte.is_ascii_hexdigit())
+        })
+        .count();
+    if code_len != 0 && code_len < tokens.len() {
+        let machine_code = tokens[..code_len].join(" ").to_ascii_lowercase();
+        let instruction = tokens[code_len..]
+            .iter()
+            .take_while(|token| !matches!(**token, "//" | "#"))
+            .map(|token| {
+                let token = token.to_ascii_lowercase();
+                if token == "#0" {
+                    "#0x0".to_owned()
+                } else if let Some(value) = token.strip_prefix("0x")
+                    && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+                {
+                    value.to_owned()
+                } else {
+                    token
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(" ")
+            .replace(", ", ",");
+        return format!("{address}:\t{machine_code}\t{instruction}");
+    }
+
     line.trim_end().to_owned()
 }
 

--- a/litebox_syscall_rewriter/tests/snapshots/snapshot_tests__hello-aarch64-diff.snap
+++ b/litebox_syscall_rewriter/tests/snapshots/snapshot_tests__hello-aarch64-diff.snap
@@ -4,26 +4,26 @@ expression: diff
 ---
 --- original
 +++ rewritten
-@@ -4,15 +4,15 @@
+@@ -1,15 +1,15 @@
  Disassembly of section .text:
  
  0000000000400110 <_start>:
--  400110:	d51bd045 	msr	tpidr_el0, x5
--  400114:	d53bd049 	mrs	x9, tpidr_el0
+-  400110:	d51bd045	msr tpidr_el0,x5
+-  400114:	d53bd049	mrs x9,tpidr_el0
 +  400110:	<trampoline-b+0x10>
 +  400114:	<trampoline-b+0x34>
-   400118:	d2800808 	mov	x8, #0x40                  	// #64
-   40011c:	d2800020 	mov	x0, #0x1                   	// #1
-   400120:	910003e1 	mov	x1, sp
-   400124:	d28001c2 	mov	x2, #0xe                   	// #14
--  400128:	d4000001 	svc	#0x0
+   400118:	d2800808	mov x8,#0x40
+   40011c:	d2800020	mov x0,#0x1
+   400120:	910003e1	mov x1,sp
+   400124:	d28001c2	mov x2,#0xe
+-  400128:	d4000001	svc #0x0
 +  400128:	<trampoline-b+0x40>
-   40012c:	d2801588 	mov	x8, #0xac                  	// #172
--  400130:	d4000001 	svc	#0x0
+   40012c:	d2801588	mov x8,#0xac
+-  400130:	d4000001	svc #0x0
 +  400130:	<trampoline-b+0x58>
-   400134:	d2800ba8 	mov	x8, #0x5d                  	// #93
-   400138:	d2800000 	mov	x0, #0x0                   	// #0
--  40013c:	d4000001 	svc	#0x0
+   400134:	d2800ba8	mov x8,#0x5d
+   400138:	d2800000	mov x0,#0x0
+-  40013c:	d4000001	svc #0x0
 \ No newline at end of file
 +  40013c:	<trampoline-b+0x70>
 \ No newline at end of file

--- a/litebox_syscall_rewriter/tests/snapshots/snapshot_tests__hello-diff.snap
+++ b/litebox_syscall_rewriter/tests/snapshots/snapshot_tests__hello-diff.snap
@@ -4,1288 +4,1288 @@ expression: diff
 ---
 --- original
 +++ rewritten
-@@ -131,8 +131,9 @@
-   401217:	48 c7 85 50 ff ff ff 	movq   $0x20,-0xb0(%rbp)
+@@ -128,8 +128,9 @@
+   401217:	48 c7 85 50 ff ff ff	movq $0x20,-0xb0(%rbp)
    40121e:	20 00 00 00
-   401222:	bf 01 00 00 00       	mov    $0x1,%edi
--  401227:	b8 0e 00 00 00       	mov    $0xe,%eax
--  40122c:	0f 05                	syscall
+   401222:	bf 01 00 00 00	mov $0x1,%edi
+-  401227:	b8 0e 00 00 00	mov $0xe,%eax
+-  40122c:	0f 05	syscall
 +  401227:	<trampoline-jmp+0x8>
-+  40122c:	90                   	nop
-+  40122d:	90                   	nop
-   40122e:	8b 05 0c fc 0a 00    	mov    0xafc0c(%rip),%eax        # 4b0e40 <stage>
-   401234:	83 f8 01             	cmp    $0x1,%eax
-   401237:	75 77                	jne    4012b0 <abort+0x119>
-@@ -1133,9 +1134,8 @@
-   401e6c:	74 12                	je     401e80 <__libc_start_call_main+0x90>
-   401e6e:	ba 3c 00 00 00       	mov    $0x3c,%edx
-   401e73:	0f 1f 44 00 00       	nopl   0x0(%rax,%rax,1)
--  401e78:	31 ff                	xor    %edi,%edi
--  401e7a:	89 d0                	mov    %edx,%eax
--  401e7c:	0f 05                	syscall
++  40122c:	90	nop
++  40122d:	90	nop
+   40122e:	8b 05 0c fc 0a 00	mov 0xafc0c(%rip),%eax
+   401234:	83 f8 01	cmp $0x1,%eax
+   401237:	75 77	jne 4012b0 <abort+0x119>
+@@ -1130,9 +1131,8 @@
+   401e6c:	74 12	je 401e80 <__libc_start_call_main+0x90>
+   401e6e:	ba 3c 00 00 00	mov $0x3c,%edx
+   401e73:	0f 1f 44 00 00	nopl 0x0(%rax,%rax,1)
+-  401e78:	31 ff	xor %edi,%edi
+-  401e7a:	89 d0	mov %edx,%eax
+-  401e7c:	0f 05	syscall
 +  401e78:	<trampoline-jmp+0x1f>
-+  401e7d:	90                   	nop
-   401e7e:	eb f8                	jmp    401e78 <__libc_start_call_main+0x88>
-   401e80:	31 c0                	xor    %eax,%eax
-   401e82:	eb d4                	jmp    401e58 <__libc_start_call_main+0x68>
-@@ -3117,8 +3117,9 @@
-   403ed9:	74 11                	je     403eec <__libc_start_main+0x13c>
-   403edb:	be 01 00 00 00       	mov    $0x1,%esi
-   403ee0:	bf 01 50 00 00       	mov    $0x5001,%edi
--  403ee5:	b8 9e 00 00 00       	mov    $0x9e,%eax
--  403eea:	0f 05                	syscall
++  401e7d:	90	nop
+   401e7e:	eb f8	jmp 401e78 <__libc_start_call_main+0x88>
+   401e80:	31 c0	xor %eax,%eax
+   401e82:	eb d4	jmp 401e58 <__libc_start_call_main+0x68>
+@@ -3114,8 +3114,9 @@
+   403ed9:	74 11	je 403eec <__libc_start_main+0x13c>
+   403edb:	be 01 00 00 00	mov $0x1,%esi
+   403ee0:	bf 01 50 00 00	mov $0x5001,%edi
+-  403ee5:	b8 9e 00 00 00	mov $0x9e,%eax
+-  403eea:	0f 05	syscall
 +  403ee5:	<trampoline-jmp+0x35>
-+  403eea:	90                   	nop
-+  403eeb:	90                   	nop
-   403eec:	44 89 ef             	mov    %r13d,%edi
-   403eef:	e8 9c d4 01 00       	call   421390 <_dl_cet_setup_features>
-   403ef4:	48 8b 15 0d 52 0a 00 	mov    0xa520d(%rip),%rdx        # 4a9108 <_dl_random>
-@@ -3441,18 +3442,22 @@
-   4043c5:	48 89 46 08          	mov    %rax,0x8(%rsi)
-   4043c9:	b8 9e 00 00 00       	mov    $0x9e,%eax
-   4043ce:	48 89 36             	mov    %rsi,(%rsi)
--  4043d1:	48 89 76 10          	mov    %rsi,0x10(%rsi)
--  4043d5:	0f 05                	syscall
++  403eea:	90	nop
++  403eeb:	90	nop
+   403eec:	44 89 ef	mov %r13d,%edi
+   403eef:	e8 9c d4 01 00	call 421390 <_dl_cet_setup_features>
+   403ef4:	48 8b 15 0d 52 0a 00	mov 0xa520d(%rip),%rdx
+@@ -3438,18 +3439,22 @@
+   4043c5:	48 89 46 08	mov %rax,0x8(%rsi)
+   4043c9:	b8 9e 00 00 00	mov $0x9e,%eax
+   4043ce:	48 89 36	mov %rsi,(%rsi)
+-  4043d1:	48 89 76 10	mov %rsi,0x10(%rsi)
+-  4043d5:	0f 05	syscall
 +  4043d1:	<trampoline-jmp+0x4c>
-+  4043d6:	90                   	nop
-   4043d7:	85 c0                	test   %eax,%eax
-   4043d9:	74 24                	je     4043ff <__libc_setup_tls+0x1df>
-   4043db:	ba 2d 00 00 00       	mov    $0x2d,%edx
-   4043e0:	bf 02 00 00 00       	mov    $0x2,%edi
-   4043e5:	b8 01 00 00 00       	mov    $0x1,%eax
--  4043ea:	48 8d 35 c7 d1 07 00 	lea    0x7d1c7(%rip),%rsi        # 4815b8 <slashdot.0+0x76b>
--  4043f1:	0f 05                	syscall
++  4043d6:	90	nop
+   4043d7:	85 c0	test %eax,%eax
+   4043d9:	74 24	je 4043ff <__libc_setup_tls+0x1df>
+   4043db:	ba 2d 00 00 00	mov $0x2d,%edx
+   4043e0:	bf 02 00 00 00	mov $0x2,%edi
+   4043e5:	b8 01 00 00 00	mov $0x1,%eax
+-  4043ea:	48 8d 35 c7 d1 07 00	lea 0x7d1c7(%rip),%rsi
+-  4043f1:	0f 05	syscall
 +  4043ea:	<trampoline-jmp+0x62>
-+  4043ef:	90                   	nop
-+  4043f0:	90                   	nop
-+  4043f1:	90                   	nop
-+  4043f2:	90                   	nop
-   4043f3:	bf 7f 00 00 00       	mov    $0x7f,%edi
--  4043f8:	b8 e7 00 00 00       	mov    $0xe7,%eax
--  4043fd:	0f 05                	syscall
++  4043ef:	90	nop
++  4043f0:	90	nop
++  4043f1:	90	nop
++  4043f2:	90	nop
+   4043f3:	bf 7f 00 00 00	mov $0x7f,%edi
+-  4043f8:	b8 e7 00 00 00	mov $0xe7,%eax
+-  4043fd:	0f 05	syscall
 +  4043f8:	<trampoline-jmp+0x7b>
-+  4043fd:	90                   	nop
-+  4043fe:	90                   	nop
-   4043ff:	e8 dc ba 01 00       	call   41fee0 <__tls_init_tp>
-   404404:	48 8b 45 c8          	mov    -0x38(%rbp),%rax
-   404408:	4d 89 ae 78 04 00 00 	mov    %r13,0x478(%r14)
-@@ -3492,11 +3497,15 @@
-   4044b0:	ba 2d 00 00 00       	mov    $0x2d,%edx
-   4044b5:	bf 02 00 00 00       	mov    $0x2,%edi
-   4044ba:	b8 01 00 00 00       	mov    $0x1,%eax
--  4044bf:	48 8d 35 f2 d0 07 00 	lea    0x7d0f2(%rip),%rsi        # 4815b8 <slashdot.0+0x76b>
--  4044c6:	0f 05                	syscall
++  4043fd:	90	nop
++  4043fe:	90	nop
+   4043ff:	e8 dc ba 01 00	call 41fee0 <__tls_init_tp>
+   404404:	48 8b 45 c8	mov -0x38(%rbp),%rax
+   404408:	4d 89 ae 78 04 00 00	mov %r13,0x478(%r14)
+@@ -3489,11 +3494,15 @@
+   4044b0:	ba 2d 00 00 00	mov $0x2d,%edx
+   4044b5:	bf 02 00 00 00	mov $0x2,%edi
+   4044ba:	b8 01 00 00 00	mov $0x1,%eax
+-  4044bf:	48 8d 35 f2 d0 07 00	lea 0x7d0f2(%rip),%rsi
+-  4044c6:	0f 05	syscall
 +  4044bf:	<trampoline-jmp+0x92>
-+  4044c4:	90                   	nop
-+  4044c5:	90                   	nop
-+  4044c6:	90                   	nop
-+  4044c7:	90                   	nop
-   4044c8:	bf 7f 00 00 00       	mov    $0x7f,%edi
--  4044cd:	b8 e7 00 00 00       	mov    $0xe7,%eax
--  4044d2:	0f 05                	syscall
++  4044c4:	90	nop
++  4044c5:	90	nop
++  4044c6:	90	nop
++  4044c7:	90	nop
+   4044c8:	bf 7f 00 00 00	mov $0x7f,%edi
+-  4044cd:	b8 e7 00 00 00	mov $0xe7,%eax
+-  4044d2:	0f 05	syscall
 +  4044cd:	<trampoline-jmp+0xab>
-+  4044d2:	90                   	nop
-+  4044d3:	90                   	nop
-   4044d4:	e9 70 fe ff ff       	jmp    404349 <__libc_setup_tls+0x129>
-   4044d9:	0f 1f 80 00 00 00 00 	nopl   0x0(%rax)
++  4044d2:	90	nop
++  4044d3:	90	nop
+   4044d4:	e9 70 fe ff ff	jmp 404349 <__libc_setup_tls+0x129>
+   4044d9:	0f 1f 80 00 00 00 00	nopl 0x0(%rax)
  
-@@ -9234,8 +9243,7 @@
-   40a3dc:	0f 1f 40 00          	nopl   0x0(%rax)
-   40a3e0:	48 8b b5 f0 fe ff ff 	mov    -0x110(%rbp),%rsi
-   40a3e7:	bf 02 00 00 00       	mov    $0x2,%edi
--  40a3ec:	44 89 c8             	mov    %r9d,%eax
--  40a3ef:	0f 05                	syscall
+@@ -9231,8 +9240,7 @@
+   40a3dc:	0f 1f 40 00	nopl 0x0(%rax)
+   40a3e0:	48 8b b5 f0 fe ff ff	mov -0x110(%rbp),%rsi
+   40a3e7:	bf 02 00 00 00	mov $0x2,%edi
+-  40a3ec:	44 89 c8	mov %r9d,%eax
+-  40a3ef:	0f 05	syscall
 +  40a3ec:	<trampoline-jmp+0xc2>
-   40a3f1:	48 83 f8 fc          	cmp    $0xfffffffffffffffc,%rax
-   40a3f5:	74 e9                	je     40a3e0 <__libc_message_impl+0x150>
-   40a3f7:	45 31 c9             	xor    %r9d,%r9d
-@@ -9372,8 +9380,9 @@
-   40a5c7:	45 31 d2             	xor    %r10d,%r10d
-   40a5ca:	ba 02 00 00 00       	mov    $0x2,%edx
-   40a5cf:	be 80 00 00 00       	mov    $0x80,%esi
--  40a5d4:	b8 ca 00 00 00       	mov    $0xca,%eax
--  40a5d9:	0f 05                	syscall
+   40a3f1:	48 83 f8 fc	cmp $0xfffffffffffffffc,%rax
+   40a3f5:	74 e9	je 40a3e0 <__libc_message_impl+0x150>
+   40a3f7:	45 31 c9	xor %r9d,%r9d
+@@ -9369,8 +9377,9 @@
+   40a5c7:	45 31 d2	xor %r10d,%r10d
+   40a5ca:	ba 02 00 00 00	mov $0x2,%edx
+   40a5cf:	be 80 00 00 00	mov $0x80,%esi
+-  40a5d4:	b8 ca 00 00 00	mov $0xca,%eax
+-  40a5d9:	0f 05	syscall
 +  40a5d4:	<trampoline-jmp+0xd7>
-+  40a5d9:	90                   	nop
-+  40a5da:	90                   	nop
-   40a5db:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
-   40a5e1:	76 d8                	jbe    40a5bb <__lll_lock_wait_private+0xb>
-   40a5e3:	83 f8 f5             	cmp    $0xfffffff5,%eax
-@@ -9405,8 +9414,8 @@
-   40a62d:	45 31 d2             	xor    %r10d,%r10d
-   40a630:	ba 02 00 00 00       	mov    $0x2,%edx
-   40a635:	b8 ca 00 00 00       	mov    $0xca,%eax
--  40a63a:	40 80 f6 80          	xor    $0x80,%sil
--  40a63e:	0f 05                	syscall
++  40a5d9:	90	nop
++  40a5da:	90	nop
+   40a5db:	48 3d 00 f0 ff ff	cmp $0xfffffffffffff000,%rax
+   40a5e1:	76 d8	jbe 40a5bb <__lll_lock_wait_private+0xb>
+   40a5e3:	83 f8 f5	cmp $0xfffffff5,%eax
+@@ -9402,8 +9411,8 @@
+   40a62d:	45 31 d2	xor %r10d,%r10d
+   40a630:	ba 02 00 00 00	mov $0x2,%edx
+   40a635:	b8 ca 00 00 00	mov $0xca,%eax
+-  40a63a:	40 80 f6 80	xor $0x80,%sil
+-  40a63e:	0f 05	syscall
 +  40a63a:	<trampoline-jmp+0xee>
-+  40a63f:	90                   	nop
-   40a640:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
-   40a646:	76 d6                	jbe    40a61e <__lll_lock_wait+0xe>
-   40a648:	83 f8 f5             	cmp    $0xfffffff5,%eax
-@@ -9426,8 +9435,9 @@
-   40a674:	45 31 d2             	xor    %r10d,%r10d
-   40a677:	ba 01 00 00 00       	mov    $0x1,%edx
-   40a67c:	be 81 00 00 00       	mov    $0x81,%esi
--  40a681:	b8 ca 00 00 00       	mov    $0xca,%eax
--  40a686:	0f 05                	syscall
++  40a63f:	90	nop
+   40a640:	48 3d 00 f0 ff ff	cmp $0xfffffffffffff000,%rax
+   40a646:	76 d6	jbe 40a61e <__lll_lock_wait+0xe>
+   40a648:	83 f8 f5	cmp $0xfffffff5,%eax
+@@ -9423,8 +9432,9 @@
+   40a674:	45 31 d2	xor %r10d,%r10d
+   40a677:	ba 01 00 00 00	mov $0x1,%edx
+   40a67c:	be 81 00 00 00	mov $0x81,%esi
+-  40a681:	b8 ca 00 00 00	mov $0xca,%eax
+-  40a686:	0f 05	syscall
 +  40a681:	<trampoline-jmp+0x104>
-+  40a686:	90                   	nop
-+  40a687:	90                   	nop
-   40a688:	c3                   	ret
-   40a689:	0f 1f 80 00 00 00 00 	nopl   0x0(%rax)
++  40a686:	90	nop
++  40a687:	90	nop
+   40a688:	c3	ret
+   40a689:	0f 1f 80 00 00 00 00	nopl 0x0(%rax)
  
-@@ -9436,8 +9446,9 @@
-   40a694:	40 80 f6 81          	xor    $0x81,%sil
-   40a698:	45 31 d2             	xor    %r10d,%r10d
-   40a69b:	ba 01 00 00 00       	mov    $0x1,%edx
--  40a6a0:	b8 ca 00 00 00       	mov    $0xca,%eax
--  40a6a5:	0f 05                	syscall
+@@ -9433,8 +9443,9 @@
+   40a694:	40 80 f6 81	xor $0x81,%sil
+   40a698:	45 31 d2	xor %r10d,%r10d
+   40a69b:	ba 01 00 00 00	mov $0x1,%edx
+-  40a6a0:	b8 ca 00 00 00	mov $0xca,%eax
+-  40a6a5:	0f 05	syscall
 +  40a6a0:	<trampoline-jmp+0x11b>
-+  40a6a5:	90                   	nop
-+  40a6a6:	90                   	nop
-   40a6a7:	c3                   	ret
-   40a6a8:	0f 1f 84 00 00 00 00 	nopl   0x0(%rax,%rax,1)
++  40a6a5:	90	nop
++  40a6a6:	90	nop
+   40a6a7:	c3	ret
+   40a6a8:	0f 1f 84 00 00 00 00	nopl 0x0(%rax,%rax,1)
    40a6af:	00
-@@ -10840,8 +10851,9 @@
-   40bbd5:	48 89 45 e8          	mov    %rax,-0x18(%rbp)
-   40bbd9:	31 c0                	xor    %eax,%eax
-   40bbdb:	c6 05 3e 4c 0a 00 01 	movb   $0x1,0xa4c3e(%rip)        # 4b0820 <__malloc_initialized>
--  40bbe2:	b8 3e 01 00 00       	mov    $0x13e,%eax
--  40bbe7:	0f 05                	syscall
+@@ -10837,8 +10848,9 @@
+   40bbd5:	48 89 45 e8	mov %rax,-0x18(%rbp)
+   40bbd9:	31 c0	xor %eax,%eax
+   40bbdb:	c6 05 3e 4c 0a 00 01	movb $0x1,0xa4c3e(%rip)
+-  40bbe2:	b8 3e 01 00 00	mov $0x13e,%eax
+-  40bbe7:	0f 05	syscall
 +  40bbe2:	<trampoline-jmp+0x132>
-+  40bbe7:	90                   	nop
-+  40bbe8:	90                   	nop
-   40bbe9:	48 8d 5d d0          	lea    -0x30(%rbp),%rbx
-   40bbed:	48 83 f8 08          	cmp    $0x8,%rax
-   40bbf1:	74 4e                	je     40bc41 <ptmalloc_init.part.0+0x91>
-@@ -23532,8 +23544,9 @@
-   4181dc:	5d                   	pop    %rbp
-   4181dd:	c3                   	ret
-   4181de:	66 90                	xchg   %ax,%ax
--  4181e0:	b8 e4 00 00 00       	mov    $0xe4,%eax
--  4181e5:	0f 05                	syscall
++  40bbe7:	90	nop
++  40bbe8:	90	nop
+   40bbe9:	48 8d 5d d0	lea -0x30(%rbp),%rbx
+   40bbed:	48 83 f8 08	cmp $0x8,%rax
+   40bbf1:	74 4e	je 40bc41 <ptmalloc_init.part.0+0x91>
+@@ -23529,8 +23541,9 @@
+   4181dc:	5d	pop %rbp
+   4181dd:	c3	ret
+   4181de:	66 90	xchg %ax,%ax
+-  4181e0:	b8 e4 00 00 00	mov $0xe4,%eax
+-  4181e5:	0f 05	syscall
 +  4181e0:	<trampoline-jmp+0x149>
-+  4181e5:	90                   	nop
-+  4181e6:	90                   	nop
-   4181e7:	85 c0                	test   %eax,%eax
-   4181e9:	75 1d                	jne    418208 <__clock_gettime+0x48>
-   4181eb:	31 c0                	xor    %eax,%eax
-@@ -23566,8 +23579,10 @@
-   418242:	66 0f 1f 44 00 00    	nopw   0x0(%rax,%rax,1)
-   418248:	f4                   	hlt
-   418249:	89 d0                	mov    %edx,%eax
--  41824b:	0f 05                	syscall
--  41824d:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
++  4181e5:	90	nop
++  4181e6:	90	nop
+   4181e7:	85 c0	test %eax,%eax
+   4181e9:	75 1d	jne 418208 <__clock_gettime+0x48>
+   4181eb:	31 c0	xor %eax,%eax
+@@ -23563,8 +23576,10 @@
+   418242:	66 0f 1f 44 00 00	nopw 0x0(%rax,%rax,1)
+   418248:	f4	hlt
+   418249:	89 d0	mov %edx,%eax
+-  41824b:	0f 05	syscall
+-  41824d:	48 3d 00 f0 ff ff	cmp $0xfffffffffffff000,%rax
 +  41824b:	<trampoline-jmp+0x160>
-+  418250:	90                   	nop
-+  418251:	90                   	nop
-+  418252:	90                   	nop
-   418253:	76 f3                	jbe    418248 <_exit+0x18>
-   418255:	f7 d8                	neg    %eax
-   418257:	64 89 06             	mov    %eax,%fs:(%rsi)
-@@ -23576,8 +23591,9 @@
++  418250:	90	nop
++  418251:	90	nop
++  418252:	90	nop
+   418253:	76 f3	jbe 418248 <_exit+0x18>
+   418255:	f7 d8	neg %eax
+   418257:	64 89 06	mov %eax,%fs:(%rsi)
+@@ -23573,8 +23588,9 @@
  
  0000000000418260 <__fstat>:
-   418260:	f3 0f 1e fa          	endbr64
--  418264:	b8 05 00 00 00       	mov    $0x5,%eax
--  418269:	0f 05                	syscall
+   418260:	f3 0f 1e fa	endbr64
+-  418264:	b8 05 00 00 00	mov $0x5,%eax
+-  418269:	0f 05	syscall
 +  418264:	<trampoline-jmp+0x178>
-+  418269:	90                   	nop
-+  41826a:	90                   	nop
-   41826b:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
-   418271:	77 05                	ja     418278 <__fstat+0x18>
-   418273:	c3                   	ret
-@@ -23591,8 +23607,9 @@
++  418269:	90	nop
++  41826a:	90	nop
+   41826b:	48 3d 00 f0 ff ff	cmp $0xfffffffffffff000,%rax
+   418271:	77 05	ja 418278 <__fstat+0x18>
+   418273:	c3	ret
+@@ -23588,8 +23604,9 @@
  
  0000000000418290 <__close_nocancel>:
-   418290:	f3 0f 1e fa          	endbr64
--  418294:	b8 03 00 00 00       	mov    $0x3,%eax
--  418299:	0f 05                	syscall
+   418290:	f3 0f 1e fa	endbr64
+-  418294:	b8 03 00 00 00	mov $0x3,%eax
+-  418299:	0f 05	syscall
 +  418294:	<trampoline-jmp+0x18f>
-+  418299:	90                   	nop
-+  41829a:	90                   	nop
-   41829b:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
-   4182a1:	77 05                	ja     4182a8 <__close_nocancel+0x18>
-   4182a3:	c3                   	ret
-@@ -23621,8 +23638,9 @@
-   4182f2:	48 89 45 c0          	mov    %rax,-0x40(%rbp)
-   4182f6:	83 fe 09             	cmp    $0x9,%esi
-   4182f9:	74 25                	je     418320 <__fcntl64_nocancel+0x60>
--  4182fb:	b8 48 00 00 00       	mov    $0x48,%eax
--  418300:	0f 05                	syscall
++  418299:	90	nop
++  41829a:	90	nop
+   41829b:	48 3d 00 f0 ff ff	cmp $0xfffffffffffff000,%rax
+   4182a1:	77 05	ja 4182a8 <__close_nocancel+0x18>
+   4182a3:	c3	ret
+@@ -23618,8 +23635,9 @@
+   4182f2:	48 89 45 c0	mov %rax,-0x40(%rbp)
+   4182f6:	83 fe 09	cmp $0x9,%esi
+   4182f9:	74 25	je 418320 <__fcntl64_nocancel+0x60>
+-  4182fb:	b8 48 00 00 00	mov $0x48,%eax
+-  418300:	0f 05	syscall
 +  4182fb:	<trampoline-jmp+0x1a6>
-+  418300:	90                   	nop
-+  418301:	90                   	nop
-   418302:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
-   418308:	77 3e                	ja     418348 <__fcntl64_nocancel+0x88>
-   41830a:	48 8b 55 c8          	mov    -0x38(%rbp),%rdx
-@@ -23634,8 +23652,9 @@
-   41831b:	0f 1f 44 00 00       	nopl   0x0(%rax,%rax,1)
-   418320:	48 8d 55 a8          	lea    -0x58(%rbp),%rdx
-   418324:	be 10 00 00 00       	mov    $0x10,%esi
--  418329:	b8 48 00 00 00       	mov    $0x48,%eax
--  41832e:	0f 05                	syscall
++  418300:	90	nop
++  418301:	90	nop
+   418302:	48 3d 00 f0 ff ff	cmp $0xfffffffffffff000,%rax
+   418308:	77 3e	ja 418348 <__fcntl64_nocancel+0x88>
+   41830a:	48 8b 55 c8	mov -0x38(%rbp),%rdx
+@@ -23631,8 +23649,9 @@
+   41831b:	0f 1f 44 00 00	nopl 0x0(%rax,%rax,1)
+   418320:	48 8d 55 a8	lea -0x58(%rbp),%rdx
+   418324:	be 10 00 00 00	mov $0x10,%esi
+-  418329:	b8 48 00 00 00	mov $0x48,%eax
+-  41832e:	0f 05	syscall
 +  418329:	<trampoline-jmp+0x1bd>
-+  41832e:	90                   	nop
-+  41832f:	90                   	nop
-   418330:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
-   418335:	77 11                	ja     418348 <__fcntl64_nocancel+0x88>
-   418337:	83 7d a8 02          	cmpl   $0x2,-0x58(%rbp)
-@@ -23662,8 +23681,9 @@
-   418379:	31 c0                	xor    %eax,%eax
-   41837b:	83 fe 09             	cmp    $0x9,%esi
-   41837e:	74 20                	je     4183a0 <__fcntl64_nocancel_adjusted+0x40>
--  418380:	b8 48 00 00 00       	mov    $0x48,%eax
--  418385:	0f 05                	syscall
++  41832e:	90	nop
++  41832f:	90	nop
+   418330:	3d 00 f0 ff ff	cmp $0xfffff000,%eax
+   418335:	77 11	ja 418348 <__fcntl64_nocancel+0x88>
+   418337:	83 7d a8 02	cmpl $0x2,-0x58(%rbp)
+@@ -23659,8 +23678,9 @@
+   418379:	31 c0	xor %eax,%eax
+   41837b:	83 fe 09	cmp $0x9,%esi
+   41837e:	74 20	je 4183a0 <__fcntl64_nocancel_adjusted+0x40>
+-  418380:	b8 48 00 00 00	mov $0x48,%eax
+-  418385:	0f 05	syscall
 +  418380:	<trampoline-jmp+0x1d4>
-+  418385:	90                   	nop
-+  418386:	90                   	nop
-   418387:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
-   41838d:	77 39                	ja     4183c8 <__fcntl64_nocancel_adjusted+0x68>
-   41838f:	48 8b 55 f8          	mov    -0x8(%rbp),%rdx
-@@ -23674,8 +23694,9 @@
-   41839f:	c3                   	ret
-   4183a0:	48 8d 55 f0          	lea    -0x10(%rbp),%rdx
-   4183a4:	be 10 00 00 00       	mov    $0x10,%esi
--  4183a9:	b8 48 00 00 00       	mov    $0x48,%eax
--  4183ae:	0f 05                	syscall
++  418385:	90	nop
++  418386:	90	nop
+   418387:	48 3d 00 f0 ff ff	cmp $0xfffffffffffff000,%rax
+   41838d:	77 39	ja 4183c8 <__fcntl64_nocancel_adjusted+0x68>
+   41838f:	48 8b 55 f8	mov -0x8(%rbp),%rdx
+@@ -23671,8 +23691,9 @@
+   41839f:	c3	ret
+   4183a0:	48 8d 55 f0	lea -0x10(%rbp),%rdx
+   4183a4:	be 10 00 00 00	mov $0x10,%esi
+-  4183a9:	b8 48 00 00 00	mov $0x48,%eax
+-  4183ae:	0f 05	syscall
 +  4183a9:	<trampoline-jmp+0x1eb>
-+  4183ae:	90                   	nop
-+  4183af:	90                   	nop
-   4183b0:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
-   4183b5:	77 11                	ja     4183c8 <__fcntl64_nocancel_adjusted+0x68>
-   4183b7:	83 7d f0 02          	cmpl   $0x2,-0x10(%rbp)
-@@ -23711,8 +23732,9 @@
-   418413:	89 f2                	mov    %esi,%edx
-   418415:	b8 01 01 00 00       	mov    $0x101,%eax
-   41841a:	48 89 fe             	mov    %rdi,%rsi
--  41841d:	bf 9c ff ff ff       	mov    $0xffffff9c,%edi
--  418422:	0f 05                	syscall
++  4183ae:	90	nop
++  4183af:	90	nop
+   4183b0:	3d 00 f0 ff ff	cmp $0xfffff000,%eax
+   4183b5:	77 11	ja 4183c8 <__fcntl64_nocancel_adjusted+0x68>
+   4183b7:	83 7d f0 02	cmpl $0x2,-0x10(%rbp)
+@@ -23708,8 +23729,9 @@
+   418413:	89 f2	mov %esi,%edx
+   418415:	b8 01 01 00 00	mov $0x101,%eax
+   41841a:	48 89 fe	mov %rdi,%rsi
+-  41841d:	bf 9c ff ff ff	mov $0xffffff9c,%edi
+-  418422:	0f 05	syscall
 +  41841d:	<trampoline-jmp+0x202>
-+  418422:	90                   	nop
-+  418423:	90                   	nop
-   418424:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
-   41842a:	77 34                	ja     418460 <__open64_nocancel+0x80>
-   41842c:	48 8b 55 c8          	mov    -0x38(%rbp),%rdx
-@@ -23740,9 +23762,10 @@
++  418422:	90	nop
++  418423:	90	nop
+   418424:	48 3d 00 f0 ff ff	cmp $0xfffffffffffff000,%rax
+   41842a:	77 34	ja 418460 <__open64_nocancel+0x80>
+   41842c:	48 8b 55 c8	mov -0x38(%rbp),%rdx
+@@ -23737,9 +23759,10 @@
    41847f:	00
  
  0000000000418480 <__read_nocancel>:
--  418480:	f3 0f 1e fa          	endbr64
--  418484:	31 c0                	xor    %eax,%eax
--  418486:	0f 05                	syscall
+-  418480:	f3 0f 1e fa	endbr64
+-  418484:	31 c0	xor %eax,%eax
+-  418486:	0f 05	syscall
 +  418480:	<trampoline-jmp+0x219>
-+  418485:	90                   	nop
-+  418486:	90                   	nop
-+  418487:	90                   	nop
-   418488:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
-   41848e:	77 08                	ja     418498 <__read_nocancel+0x18>
-   418490:	c3                   	ret
-@@ -23756,8 +23779,9 @@
++  418485:	90	nop
++  418486:	90	nop
++  418487:	90	nop
+   418488:	48 3d 00 f0 ff ff	cmp $0xfffffffffffff000,%rax
+   41848e:	77 08	ja 418498 <__read_nocancel+0x18>
+   418490:	c3	ret
+@@ -23753,8 +23776,9 @@
  
  00000000004184b0 <__brk>:
-   4184b0:	f3 0f 1e fa          	endbr64
--  4184b4:	b8 0c 00 00 00       	mov    $0xc,%eax
--  4184b9:	0f 05                	syscall
+   4184b0:	f3 0f 1e fa	endbr64
+-  4184b4:	b8 0c 00 00 00	mov $0xc,%eax
+-  4184b9:	0f 05	syscall
 +  4184b4:	<trampoline-jmp+0x231>
-+  4184b9:	90                   	nop
-+  4184ba:	90                   	nop
-   4184bb:	48 89 05 96 83 09 00 	mov    %rax,0x98396(%rip)        # 4b0858 <__curbrk>
-   4184c2:	48 39 f8             	cmp    %rdi,%rax
-   4184c5:	72 09                	jb     4184d0 <__brk+0x20>
-@@ -23922,8 +23946,9 @@
-   418714:	48 89 45 f8          	mov    %rax,-0x8(%rbp)
-   418718:	31 c0                	xor    %eax,%eax
-   41871a:	48 8d 95 f0 ef ff ff 	lea    -0x1010(%rbp),%rdx
--  418721:	b8 cc 00 00 00       	mov    $0xcc,%eax
--  418726:	0f 05                	syscall
++  4184b9:	90	nop
++  4184ba:	90	nop
+   4184bb:	48 89 05 96 83 09 00	mov %rax,0x98396(%rip)
+   4184c2:	48 39 f8	cmp %rdi,%rax
+   4184c5:	72 09	jb 4184d0 <__brk+0x20>
+@@ -23919,8 +23943,9 @@
+   418714:	48 89 45 f8	mov %rax,-0x8(%rbp)
+   418718:	31 c0	xor %eax,%eax
+   41871a:	48 8d 95 f0 ef ff ff	lea -0x1010(%rbp),%rdx
+-  418721:	b8 cc 00 00 00	mov $0xcc,%eax
+-  418726:	0f 05	syscall
 +  418721:	<trampoline-jmp+0x248>
-+  418726:	90                   	nop
-+  418727:	90                   	nop
-   418728:	85 c0                	test   %eax,%eax
-   41872a:	7f 24                	jg     418750 <__get_nprocs_sched+0x60>
-   41872c:	83 f8 ea             	cmp    $0xffffffea,%eax
-@@ -24231,8 +24256,9 @@
++  418726:	90	nop
++  418727:	90	nop
+   418728:	85 c0	test %eax,%eax
+   41872a:	7f 24	jg 418750 <__get_nprocs_sched+0x60>
+   41872c:	83 f8 ea	cmp $0xffffffea,%eax
+@@ -24228,8 +24253,9 @@
  
  0000000000418b40 <__madvise>:
-   418b40:	f3 0f 1e fa          	endbr64
--  418b44:	b8 1c 00 00 00       	mov    $0x1c,%eax
--  418b49:	0f 05                	syscall
+   418b40:	f3 0f 1e fa	endbr64
+-  418b44:	b8 1c 00 00 00	mov $0x1c,%eax
+-  418b49:	0f 05	syscall
 +  418b44:	<trampoline-jmp+0x25f>
-+  418b49:	90                   	nop
-+  418b4a:	90                   	nop
-   418b4b:	48 3d 01 f0 ff ff    	cmp    $0xfffffffffffff001,%rax
-   418b51:	73 01                	jae    418b54 <__madvise+0x14>
-   418b53:	c3                   	ret
-@@ -24259,8 +24285,9 @@
-   418b8d:	74 41                	je     418bd0 <__mmap64+0x60>
-   418b8f:	45 89 e2             	mov    %r12d,%r10d
-   418b92:	48 89 df             	mov    %rbx,%rdi
--  418b95:	b8 09 00 00 00       	mov    $0x9,%eax
--  418b9a:	0f 05                	syscall
++  418b49:	90	nop
++  418b4a:	90	nop
+   418b4b:	48 3d 01 f0 ff ff	cmp $0xfffffffffffff001,%rax
+   418b51:	73 01	jae 418b54 <__madvise+0x14>
+   418b53:	c3	ret
+@@ -24256,8 +24282,9 @@
+   418b8d:	74 41	je 418bd0 <__mmap64+0x60>
+   418b8f:	45 89 e2	mov %r12d,%r10d
+   418b92:	48 89 df	mov %rbx,%rdi
+-  418b95:	b8 09 00 00 00	mov $0x9,%eax
+-  418b9a:	0f 05	syscall
 +  418b95:	<trampoline-jmp+0x276>
-+  418b9a:	90                   	nop
-+  418b9b:	90                   	nop
-   418b9c:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
-   418ba2:	77 6c                	ja     418c10 <__mmap64+0xa0>
-   418ba4:	5b                   	pop    %rbx
-@@ -24284,8 +24311,8 @@
-   418be8:	45 89 e2             	mov    %r12d,%r10d
-   418beb:	31 ff                	xor    %edi,%edi
-   418bed:	b8 09 00 00 00       	mov    $0x9,%eax
--  418bf2:	41 83 ca 40          	or     $0x40,%r10d
--  418bf6:	0f 05                	syscall
++  418b9a:	90	nop
++  418b9b:	90	nop
+   418b9c:	48 3d 00 f0 ff ff	cmp $0xfffffffffffff000,%rax
+   418ba2:	77 6c	ja 418c10 <__mmap64+0xa0>
+   418ba4:	5b	pop %rbx
+@@ -24281,8 +24308,8 @@
+   418be8:	45 89 e2	mov %r12d,%r10d
+   418beb:	31 ff	xor %edi,%edi
+   418bed:	b8 09 00 00 00	mov $0x9,%eax
+-  418bf2:	41 83 ca 40	or $0x40,%r10d
+-  418bf6:	0f 05	syscall
 +  418bf2:	<trampoline-jmp+0x28d>
-+  418bf7:	90                   	nop
-   418bf8:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
-   418bfe:	76 a4                	jbe    418ba4 <__mmap64+0x34>
-   418c00:	48 c7 c1 c0 ff ff ff 	mov    $0xffffffffffffffc0,%rcx
-@@ -24303,8 +24330,9 @@
++  418bf7:	90	nop
+   418bf8:	48 3d 00 f0 ff ff	cmp $0xfffffffffffff000,%rax
+   418bfe:	76 a4	jbe 418ba4 <__mmap64+0x34>
+   418c00:	48 c7 c1 c0 ff ff ff	mov $0xffffffffffffffc0,%rcx
+@@ -24300,8 +24327,9 @@
  
  0000000000418c30 <__mprotect>:
-   418c30:	f3 0f 1e fa          	endbr64
--  418c34:	b8 0a 00 00 00       	mov    $0xa,%eax
--  418c39:	0f 05                	syscall
+   418c30:	f3 0f 1e fa	endbr64
+-  418c34:	b8 0a 00 00 00	mov $0xa,%eax
+-  418c39:	0f 05	syscall
 +  418c34:	<trampoline-jmp+0x2a3>
-+  418c39:	90                   	nop
-+  418c3a:	90                   	nop
-   418c3b:	48 3d 01 f0 ff ff    	cmp    $0xfffffffffffff001,%rax
-   418c41:	73 01                	jae    418c44 <__mprotect+0x14>
-   418c43:	c3                   	ret
-@@ -24319,8 +24347,9 @@
++  418c39:	90	nop
++  418c3a:	90	nop
+   418c3b:	48 3d 01 f0 ff ff	cmp $0xfffffffffffff001,%rax
+   418c41:	73 01	jae 418c44 <__mprotect+0x14>
+   418c43:	c3	ret
+@@ -24316,8 +24344,9 @@
  
  0000000000418c60 <__munmap>:
-   418c60:	f3 0f 1e fa          	endbr64
--  418c64:	b8 0b 00 00 00       	mov    $0xb,%eax
--  418c69:	0f 05                	syscall
+   418c60:	f3 0f 1e fa	endbr64
+-  418c64:	b8 0b 00 00 00	mov $0xb,%eax
+-  418c69:	0f 05	syscall
 +  418c64:	<trampoline-jmp+0x2ba>
-+  418c69:	90                   	nop
-+  418c6a:	90                   	nop
-   418c6b:	48 3d 01 f0 ff ff    	cmp    $0xfffffffffffff001,%rax
-   418c71:	73 01                	jae    418c74 <__munmap+0x14>
-   418c73:	c3                   	ret
-@@ -24396,8 +24425,9 @@
-   418d42:	83 e1 02             	and    $0x2,%ecx
-   418d45:	75 29                	jne    418d70 <__mremap+0x50>
-   418d47:	45 31 c0             	xor    %r8d,%r8d
--  418d4a:	b8 19 00 00 00       	mov    $0x19,%eax
--  418d4f:	0f 05                	syscall
++  418c69:	90	nop
++  418c6a:	90	nop
+   418c6b:	48 3d 01 f0 ff ff	cmp $0xfffffffffffff001,%rax
+   418c71:	73 01	jae 418c74 <__munmap+0x14>
+   418c73:	c3	ret
+@@ -24393,8 +24422,9 @@
+   418d42:	83 e1 02	and $0x2,%ecx
+   418d45:	75 29	jne 418d70 <__mremap+0x50>
+   418d47:	45 31 c0	xor %r8d,%r8d
+-  418d4a:	b8 19 00 00 00	mov $0x19,%eax
+-  418d4f:	0f 05	syscall
 +  418d4a:	<trampoline-jmp+0x2d1>
-+  418d4f:	90                   	nop
-+  418d50:	90                   	nop
-   418d51:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
-   418d57:	77 37                	ja     418d90 <__mremap+0x70>
-   418d59:	48 8b 55 c8          	mov    -0x38(%rbp),%rdx
-@@ -24463,8 +24493,9 @@
-   418e1e:	48 89 da             	mov    %rbx,%rdx
-   418e21:	31 f6                	xor    %esi,%esi
-   418e23:	bf 41 4d 56 53       	mov    $0x53564d41,%edi
--  418e28:	b8 9d 00 00 00       	mov    $0x9d,%eax
--  418e2d:	0f 05                	syscall
++  418d4f:	90	nop
++  418d50:	90	nop
+   418d51:	48 3d 00 f0 ff ff	cmp $0xfffffffffffff000,%rax
+   418d57:	77 37	ja 418d90 <__mremap+0x70>
+   418d59:	48 8b 55 c8	mov -0x38(%rbp),%rdx
+@@ -24460,8 +24490,9 @@
+   418e1e:	48 89 da	mov %rbx,%rdx
+   418e21:	31 f6	xor %esi,%esi
+   418e23:	bf 41 4d 56 53	mov $0x53564d41,%edi
+-  418e28:	b8 9d 00 00 00	mov $0x9d,%eax
+-  418e2d:	0f 05	syscall
 +  418e28:	<trampoline-jmp+0x2e8>
-+  418e2d:	90                   	nop
-+  418e2e:	90                   	nop
-   418e2f:	83 f8 ea             	cmp    $0xffffffea,%eax
-   418e32:	75 a4                	jne    418dd8 <__set_vma_name+0x28>
-   418e34:	c7 05 5e 1c 09 00 00 	movl   $0x0,0x91c5e(%rip)        # 4aaa9c <prctl_supported.0>
-@@ -24477,8 +24508,9 @@
++  418e2d:	90	nop
++  418e2e:	90	nop
+   418e2f:	83 f8 ea	cmp $0xffffffea,%eax
+   418e32:	75 a4	jne 418dd8 <__set_vma_name+0x28>
+   418e34:	c7 05 5e 1c 09 00 00	movl $0x0,0x91c5e(%rip)
+@@ -24474,8 +24505,9 @@
  
  0000000000418e50 <__sysinfo>:
-   418e50:	f3 0f 1e fa          	endbr64
--  418e54:	b8 63 00 00 00       	mov    $0x63,%eax
--  418e59:	0f 05                	syscall
+   418e50:	f3 0f 1e fa	endbr64
+-  418e54:	b8 63 00 00 00	mov $0x63,%eax
+-  418e59:	0f 05	syscall
 +  418e54:	<trampoline-jmp+0x2ff>
-+  418e59:	90                   	nop
-+  418e5a:	90                   	nop
-   418e5b:	48 3d 01 f0 ff ff    	cmp    $0xfffffffffffff001,%rax
-   418e61:	73 01                	jae    418e64 <__sysinfo+0x14>
-   418e63:	c3                   	ret
-@@ -29948,8 +29980,7 @@
-   41e488:	b8 0b 01 00 00       	mov    $0x10b,%eax
-   41e48d:	48 8d 35 0d 17 06 00 	lea    0x6170d(%rip),%rsi        # 47fba1 <__PRETTY_FUNCTION__.20+0x37e>
-   41e494:	48 8d 9d e0 ef ff ff 	lea    -0x1020(%rbp),%rbx
--  41e49b:	48 89 da             	mov    %rbx,%rdx
--  41e49e:	0f 05                	syscall
++  418e59:	90	nop
++  418e5a:	90	nop
+   418e5b:	48 3d 01 f0 ff ff	cmp $0xfffffffffffff001,%rax
+   418e61:	73 01	jae 418e64 <__sysinfo+0x14>
+   418e63:	c3	ret
+@@ -29945,8 +29977,7 @@
+   41e488:	b8 0b 01 00 00	mov $0x10b,%eax
+   41e48d:	48 8d 35 0d 17 06 00	lea 0x6170d(%rip),%rsi
+   41e494:	48 8d 9d e0 ef ff ff	lea -0x1020(%rbp),%rbx
+-  41e49b:	48 89 da	mov %rbx,%rdx
+-  41e49e:	0f 05	syscall
 +  41e49b:	<trampoline-jmp+0x316>
-   41e4a0:	85 c0                	test   %eax,%eax
-   41e4a2:	7e 5c                	jle    41e500 <_dl_get_origin+0xa0>
-   41e4a4:	0f b6 95 e0 ef ff ff 	movzbl -0x1020(%rbp),%edx
-@@ -30115,8 +30146,9 @@
-   41e6d2:	8b bd a8 f6 ff ff    	mov    -0x958(%rbp),%edi
-   41e6d8:	48 63 d3             	movslq %ebx,%rdx
-   41e6db:	48 8d b5 d0 f6 ff ff 	lea    -0x930(%rbp),%rsi
--  41e6e2:	b8 14 00 00 00       	mov    $0x14,%eax
--  41e6e7:	0f 05                	syscall
+   41e4a0:	85 c0	test %eax,%eax
+   41e4a2:	7e 5c	jle 41e500 <_dl_get_origin+0xa0>
+   41e4a4:	0f b6 95 e0 ef ff ff	movzbl -0x1020(%rbp),%edx
+@@ -30112,8 +30143,9 @@
+   41e6d2:	8b bd a8 f6 ff ff	mov -0x958(%rbp),%edi
+   41e6d8:	48 63 d3	movslq %ebx,%rdx
+   41e6db:	48 8d b5 d0 f6 ff ff	lea -0x930(%rbp),%rsi
+-  41e6e2:	b8 14 00 00 00	mov $0x14,%eax
+-  41e6e7:	0f 05	syscall
 +  41e6e2:	<trampoline-jmp+0x32b>
-+  41e6e7:	90                   	nop
-+  41e6e8:	90                   	nop
-   41e6e9:	48 81 c4 38 09 00 00 	add    $0x938,%rsp
-   41e6f0:	5b                   	pop    %rbx
-   41e6f1:	41 5c                	pop    %r12
-@@ -31674,8 +31706,9 @@
-   41ff19:	48 89 42 08          	mov    %rax,0x8(%rdx)
-   41ff1d:	48 89 05 ec 09 09 00 	mov    %rax,0x909ec(%rip)        # 4b0910 <_dl_stack_user>
-   41ff24:	48 8d bb d0 02 00 00 	lea    0x2d0(%rbx),%rdi
--  41ff2b:	b8 da 00 00 00       	mov    $0xda,%eax
--  41ff30:	0f 05                	syscall
++  41e6e7:	90	nop
++  41e6e8:	90	nop
+   41e6e9:	48 81 c4 38 09 00 00	add $0x938,%rsp
+   41e6f0:	5b	pop %rbx
+   41e6f1:	41 5c	pop %r12
+@@ -31671,8 +31703,9 @@
+   41ff19:	48 89 42 08	mov %rax,0x8(%rdx)
+   41ff1d:	48 89 05 ec 09 09 00	mov %rax,0x909ec(%rip)
+   41ff24:	48 8d bb d0 02 00 00	lea 0x2d0(%rbx),%rdi
+-  41ff2b:	b8 da 00 00 00	mov $0xda,%eax
+-  41ff30:	0f 05	syscall
 +  41ff2b:	<trampoline-jmp+0x342>
-+  41ff30:	90                   	nop
-+  41ff31:	90                   	nop
-   41ff32:	89 83 d0 02 00 00    	mov    %eax,0x2d0(%rbx)
-   41ff38:	48 8d 83 10 03 00 00 	lea    0x310(%rbx),%rax
-   41ff3f:	64 48 89 04 25 10 05 	mov    %rax,%fs:0x510
-@@ -31692,8 +31725,11 @@
-   41ff77:	b8 11 01 00 00       	mov    $0x111,%eax
-   41ff7c:	66 48 0f 6e c7       	movq   %rdi,%xmm0
-   41ff81:	66 0f 6c c0          	punpcklqdq %xmm0,%xmm0
--  41ff85:	0f 11 83 d8 02 00 00 	movups %xmm0,0x2d8(%rbx)
--  41ff8c:	0f 05                	syscall
++  41ff30:	90	nop
++  41ff31:	90	nop
+   41ff32:	89 83 d0 02 00 00	mov %eax,0x2d0(%rbx)
+   41ff38:	48 8d 83 10 03 00 00	lea 0x310(%rbx),%rax
+   41ff3f:	64 48 89 04 25 10 05	mov %rax,%fs:0x510
+@@ -31689,8 +31722,11 @@
+   41ff77:	b8 11 01 00 00	mov $0x111,%eax
+   41ff7c:	66 48 0f 6e c7	movq %rdi,%xmm0
+   41ff81:	66 0f 6c c0	punpcklqdq %xmm0,%xmm0
+-  41ff85:	0f 11 83 d8 02 00 00	movups %xmm0,0x2d8(%rbx)
+-  41ff8c:	0f 05	syscall
 +  41ff85:	<trampoline-jmp+0x359>
-+  41ff8a:	90                   	nop
-+  41ff8b:	90                   	nop
-+  41ff8c:	90                   	nop
-+  41ff8d:	90                   	nop
-   41ff8e:	31 d2                	xor    %edx,%edx
-   41ff90:	48 8d 75 ec          	lea    -0x14(%rbp),%rsi
-   41ff94:	bf 28 00 00 00       	mov    $0x28,%edi
-@@ -31719,8 +31755,9 @@
-   41ffed:	31 d2                	xor    %edx,%edx
-   41ffef:	be 20 00 00 00       	mov    $0x20,%esi
-   41fff4:	48 89 df             	mov    %rbx,%rdi
--  41fff7:	b8 4e 01 00 00       	mov    $0x14e,%eax
--  41fffc:	0f 05                	syscall
++  41ff8a:	90	nop
++  41ff8b:	90	nop
++  41ff8c:	90	nop
++  41ff8d:	90	nop
+   41ff8e:	31 d2	xor %edx,%edx
+   41ff90:	48 8d 75 ec	lea -0x14(%rbp),%rsi
+   41ff94:	bf 28 00 00 00	mov $0x28,%edi
+@@ -31716,8 +31752,9 @@
+   41ffed:	31 d2	xor %edx,%edx
+   41ffef:	be 20 00 00 00	mov $0x20,%esi
+   41fff4:	48 89 df	mov %rbx,%rdi
+-  41fff7:	b8 4e 01 00 00	mov $0x14e,%eax
+-  41fffc:	0f 05	syscall
 +  41fff7:	<trampoline-jmp+0x372>
-+  41fffc:	90                   	nop
-+  41fffd:	90                   	nop
-   41fffe:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
-   420003:	77 a7                	ja     41ffac <__tls_init_tp+0xcc>
-   420005:	c7 05 11 7b 08 00 20 	movl   $0x20,0x87b11(%rip)        # 4a7b20 <__rseq_size>
-@@ -33086,8 +33123,9 @@
-   421339:	0f 84 d9 fe ff ff    	je     421218 <_dl_cet_open_check+0x158>
-   42133f:	be 01 00 00 00       	mov    $0x1,%esi
-   421344:	bf 02 50 00 00       	mov    $0x5002,%edi
--  421349:	b8 9e 00 00 00       	mov    $0x9e,%eax
--  42134e:	0f 05                	syscall
++  41fffc:	90	nop
++  41fffd:	90	nop
+   41fffe:	3d 00 f0 ff ff	cmp $0xfffff000,%eax
+   420003:	77 a7	ja 41ffac <__tls_init_tp+0xcc>
+   420005:	c7 05 11 7b 08 00 20	movl $0x20,0x87b11(%rip)
+@@ -33083,8 +33120,9 @@
+   421339:	0f 84 d9 fe ff ff	je 421218 <_dl_cet_open_check+0x158>
+   42133f:	be 01 00 00 00	mov $0x1,%esi
+   421344:	bf 02 50 00 00	mov $0x5002,%edi
+-  421349:	b8 9e 00 00 00	mov $0x9e,%eax
+-  42134e:	0f 05	syscall
 +  421349:	<trampoline-jmp+0x389>
-+  42134e:	90                   	nop
-+  42134f:	90                   	nop
-   421350:	89 c7                	mov    %eax,%edi
-   421352:	85 c0                	test   %eax,%eax
-   421354:	75 24                	jne    42137a <_dl_cet_open_check+0x2ba>
-@@ -33117,8 +33155,8 @@
-   42139e:	bf 05 50 00 00       	mov    $0x5005,%edi
-   4213a3:	89 d0                	mov    %edx,%eax
-   4213a5:	48 89 e5             	mov    %rsp,%rbp
--  4213a8:	48 8d 75 f8          	lea    -0x8(%rbp),%rsi
--  4213ac:	0f 05                	syscall
++  42134e:	90	nop
++  42134f:	90	nop
+   421350:	89 c7	mov %eax,%edi
+   421352:	85 c0	test %eax,%eax
+   421354:	75 24	jne 42137a <_dl_cet_open_check+0x2ba>
+@@ -33114,8 +33152,8 @@
+   42139e:	bf 05 50 00 00	mov $0x5005,%edi
+   4213a3:	89 d0	mov %edx,%eax
+   4213a5:	48 89 e5	mov %rsp,%rbp
+-  4213a8:	48 8d 75 f8	lea -0x8(%rbp),%rsi
+-  4213ac:	0f 05	syscall
 +  4213a8:	<trampoline-jmp+0x3a0>
-+  4213ad:	90                   	nop
-   4213ae:	48 85 c0             	test   %rax,%rax
-   4213b1:	74 15                	je     4213c8 <_dl_cet_setup_features+0x38>
-   4213b3:	31 c0                	xor    %eax,%eax
-@@ -33141,9 +33179,11 @@
-   4213ec:	a8 0c                	test   $0xc,%al
-   4213ee:	74 10                	je     421400 <_dl_cet_setup_features+0x70>
-   4213f0:	48 c7 c6 ff ff ff ff 	mov    $0xffffffffffffffff,%rsi
--  4213f7:	bf 03 50 00 00       	mov    $0x5003,%edi
--  4213fc:	89 d0                	mov    %edx,%eax
--  4213fe:	0f 05                	syscall
++  4213ad:	90	nop
+   4213ae:	48 85 c0	test %rax,%rax
+   4213b1:	74 15	je 4213c8 <_dl_cet_setup_features+0x38>
+   4213b3:	31 c0	xor %eax,%eax
+@@ -33138,9 +33176,11 @@
+   4213ec:	a8 0c	test $0xc,%al
+   4213ee:	74 10	je 421400 <_dl_cet_setup_features+0x70>
+   4213f0:	48 c7 c6 ff ff ff ff	mov $0xffffffffffffffff,%rsi
+-  4213f7:	bf 03 50 00 00	mov $0x5003,%edi
+-  4213fc:	89 d0	mov %edx,%eax
+-  4213fe:	0f 05	syscall
 +  4213f7:	<trampoline-jmp+0x3b6>
-+  4213fc:	90                   	nop
-+  4213fd:	90                   	nop
-+  4213fe:	90                   	nop
-+  4213ff:	90                   	nop
-   421400:	b8 02 00 00 00       	mov    $0x2,%eax
-   421405:	eb ae                	jmp    4213b5 <_dl_cet_setup_features+0x25>
-   421407:	66 0f 1f 84 00 00 00 	nopw   0x0(%rax,%rax,1)
-@@ -33172,13 +33212,13 @@
-   421446:	66 2e 0f 1f 84 00 00 	cs nopw 0x0(%rax,%rax,1)
++  4213fc:	90	nop
++  4213fd:	90	nop
++  4213fe:	90	nop
++  4213ff:	90	nop
+   421400:	b8 02 00 00 00	mov $0x2,%eax
+   421405:	eb ae	jmp 4213b5 <_dl_cet_setup_features+0x25>
+   421407:	66 0f 1f 84 00 00 00	nopw 0x0(%rax,%rax,1)
+@@ -33169,13 +33209,13 @@
+   421446:	66 2e 0f 1f 84 00 00	cs nopw 0x0(%rax,%rax,1)
    42144d:	00 00 00
-   421450:	be 0c 00 00 00       	mov    $0xc,%esi
--  421455:	31 ff                	xor    %edi,%edi
--  421457:	89 f0                	mov    %esi,%eax
--  421459:	0f 05                	syscall
+   421450:	be 0c 00 00 00	mov $0xc,%esi
+-  421455:	31 ff	xor %edi,%edi
+-  421457:	89 f0	mov %esi,%eax
+-  421459:	0f 05	syscall
 +  421455:	<trampoline-jmp+0x3cf>
-+  42145a:	90                   	nop
-   42145b:	48 89 c2             	mov    %rax,%rdx
--  42145e:	48 8d 3c 18          	lea    (%rax,%rbx,1),%rdi
--  421462:	89 f0                	mov    %esi,%eax
--  421464:	0f 05                	syscall
++  42145a:	90	nop
+   42145b:	48 89 c2	mov %rax,%rdx
+-  42145e:	48 8d 3c 18	lea (%rax,%rbx,1),%rdi
+-  421462:	89 f0	mov %esi,%eax
+-  421464:	0f 05	syscall
 +  42145e:	<trampoline-jmp+0x3e5>
-+  421463:	90                   	nop
-+  421464:	90                   	nop
-+  421465:	90                   	nop
-   421466:	48 39 c2             	cmp    %rax,%rdx
-   421469:	75 cd                	jne    421438 <_dl_early_allocate+0x28>
-   42146b:	45 31 c9             	xor    %r9d,%r9d
-@@ -33187,8 +33227,9 @@
-   421479:	31 ff                	xor    %edi,%edi
-   42147b:	41 ba 22 00 00 00    	mov    $0x22,%r10d
-   421481:	48 89 de             	mov    %rbx,%rsi
--  421484:	b8 09 00 00 00       	mov    $0x9,%eax
--  421489:	0f 05                	syscall
++  421463:	90	nop
++  421464:	90	nop
++  421465:	90	nop
+   421466:	48 39 c2	cmp %rax,%rdx
+   421469:	75 cd	jne 421438 <_dl_early_allocate+0x28>
+   42146b:	45 31 c9	xor %r9d,%r9d
+@@ -33184,8 +33224,9 @@
+   421479:	31 ff	xor %edi,%edi
+   42147b:	41 ba 22 00 00 00	mov $0x22,%r10d
+   421481:	48 89 de	mov %rbx,%rsi
+-  421484:	b8 09 00 00 00	mov $0x9,%eax
+-  421489:	0f 05	syscall
 +  421484:	<trampoline-jmp+0x3fd>
-+  421489:	90                   	nop
-+  42148a:	90                   	nop
-   42148b:	31 d2                	xor    %edx,%edx
-   42148d:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
-   421493:	48 8b 5d f8          	mov    -0x8(%rbp),%rbx
-@@ -69741,8 +69782,9 @@
-   444c0d:	41 ba 08 00 00 00    	mov    $0x8,%r10d
-   444c13:	4c 89 f2             	mov    %r14,%rdx
-   444c16:	48 8d 35 b3 0a 04 00 	lea    0x40ab3(%rip),%rsi        # 4856d0 <sigall_set>
--  444c1d:	b8 0e 00 00 00       	mov    $0xe,%eax
--  444c22:	0f 05                	syscall
++  421489:	90	nop
++  42148a:	90	nop
+   42148b:	31 d2	xor %edx,%edx
+   42148d:	48 3d 00 f0 ff ff	cmp $0xfffffffffffff000,%rax
+   421493:	48 8b 5d f8	mov -0x8(%rbp),%rbx
+@@ -69738,8 +69779,9 @@
+   444c0d:	41 ba 08 00 00 00	mov $0x8,%r10d
+   444c13:	4c 89 f2	mov %r14,%rdx
+   444c16:	48 8d 35 b3 0a 04 00	lea 0x40ab3(%rip),%rsi
+-  444c1d:	b8 0e 00 00 00	mov $0xe,%eax
+-  444c22:	0f 05	syscall
 +  444c1d:	<trampoline-jmp+0x414>
-+  444c22:	90                   	nop
-+  444c23:	90                   	nop
-   444c24:	31 c0                	xor    %eax,%eax
-   444c26:	4c 8d a3 04 09 00 00 	lea    0x904(%rbx),%r12
-   444c2d:	ba 01 00 00 00       	mov    $0x1,%edx
-@@ -69759,8 +69801,9 @@
-   444c5e:	31 d2                	xor    %edx,%edx
-   444c60:	4c 89 f6             	mov    %r14,%rsi
-   444c63:	bf 02 00 00 00       	mov    $0x2,%edi
--  444c68:	b8 0e 00 00 00       	mov    $0xe,%eax
--  444c6d:	0f 05                	syscall
++  444c22:	90	nop
++  444c23:	90	nop
+   444c24:	31 c0	xor %eax,%eax
+   444c26:	4c 8d a3 04 09 00 00	lea 0x904(%rbx),%r12
+   444c2d:	ba 01 00 00 00	mov $0x1,%edx
+@@ -69756,8 +69798,9 @@
+   444c5e:	31 d2	xor %edx,%edx
+   444c60:	4c 89 f6	mov %r14,%rsi
+   444c63:	bf 02 00 00 00	mov $0x2,%edi
+-  444c68:	b8 0e 00 00 00	mov $0xe,%eax
+-  444c6d:	0f 05	syscall
 +  444c68:	<trampoline-jmp+0x42b>
-+  444c6d:	90                   	nop
-+  444c6e:	90                   	nop
-   444c6f:	48 8b 45 d8          	mov    -0x28(%rbp),%rax
-   444c73:	64 48 2b 04 25 28 00 	sub    %fs:0x28,%rax
++  444c6d:	90	nop
++  444c6e:	90	nop
+   444c6f:	48 8b 45 d8	mov -0x28(%rbp),%rax
+   444c73:	64 48 2b 04 25 28 00	sub %fs:0x28,%rax
    444c7a:	00 00
-@@ -69779,23 +69822,26 @@
-   444ca3:	44 89 ea             	mov    %r13d,%edx
-   444ca6:	89 c7                	mov    %eax,%edi
-   444ca8:	89 de                	mov    %ebx,%esi
--  444caa:	b8 ea 00 00 00       	mov    $0xea,%eax
--  444caf:	0f 05                	syscall
+@@ -69776,23 +69819,26 @@
+   444ca3:	44 89 ea	mov %r13d,%edx
+   444ca6:	89 c7	mov %eax,%edi
+   444ca8:	89 de	mov %ebx,%esi
+-  444caa:	b8 ea 00 00 00	mov $0xea,%eax
+-  444caf:	0f 05	syscall
 +  444caa:	<trampoline-jmp+0x442>
-+  444caf:	90                   	nop
-+  444cb0:	90                   	nop
-   444cb1:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
-   444cb6:	76 8f                	jbe    444c47 <__pthread_kill_internal+0x77>
-   444cb8:	89 c3                	mov    %eax,%ebx
-   444cba:	f7 db                	neg    %ebx
-   444cbc:	eb 8b                	jmp    444c49 <__pthread_kill_internal+0x79>
-   444cbe:	66 90                	xchg   %ax,%ax
--  444cc0:	b8 ba 00 00 00       	mov    $0xba,%eax
--  444cc5:	0f 05                	syscall
++  444caf:	90	nop
++  444cb0:	90	nop
+   444cb1:	3d 00 f0 ff ff	cmp $0xfffff000,%eax
+   444cb6:	76 8f	jbe 444c47 <__pthread_kill_internal+0x77>
+   444cb8:	89 c3	mov %eax,%ebx
+   444cba:	f7 db	neg %ebx
+   444cbc:	eb 8b	jmp 444c49 <__pthread_kill_internal+0x79>
+   444cbe:	66 90	xchg %ax,%ax
+-  444cc0:	b8 ba 00 00 00	mov $0xba,%eax
+-  444cc5:	0f 05	syscall
 +  444cc0:	<trampoline-jmp+0x459>
-+  444cc5:	90                   	nop
-+  444cc6:	90                   	nop
-   444cc7:	89 c3                	mov    %eax,%ebx
-   444cc9:	e8 82 6e 01 00       	call   45bb50 <__getpid>
-   444cce:	44 89 ea             	mov    %r13d,%edx
-   444cd1:	89 de                	mov    %ebx,%esi
-   444cd3:	89 c7                	mov    %eax,%edi
--  444cd5:	b8 ea 00 00 00       	mov    $0xea,%eax
--  444cda:	0f 05                	syscall
++  444cc5:	90	nop
++  444cc6:	90	nop
+   444cc7:	89 c3	mov %eax,%ebx
+   444cc9:	e8 82 6e 01 00	call 45bb50 <__getpid>
+   444cce:	44 89 ea	mov %r13d,%edx
+   444cd1:	89 de	mov %ebx,%esi
+   444cd3:	89 c7	mov %eax,%edi
+-  444cd5:	b8 ea 00 00 00	mov $0xea,%eax
+-  444cda:	0f 05	syscall
 +  444cd5:	<trampoline-jmp+0x470>
-+  444cda:	90                   	nop
-+  444cdb:	90                   	nop
-   444cdc:	89 c3                	mov    %eax,%ebx
-   444cde:	f7 db                	neg    %ebx
-   444ce0:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
-@@ -69843,8 +69889,11 @@
-   444d71:	31 ff                	xor    %edi,%edi
-   444d73:	b8 0e 00 00 00       	mov    $0xe,%eax
-   444d78:	4c 89 fa             	mov    %r15,%rdx
--  444d7b:	48 8d 35 4e 09 04 00 	lea    0x4094e(%rip),%rsi        # 4856d0 <sigall_set>
--  444d82:	0f 05                	syscall
++  444cda:	90	nop
++  444cdb:	90	nop
+   444cdc:	89 c3	mov %eax,%ebx
+   444cde:	f7 db	neg %ebx
+   444ce0:	3d 00 f0 ff ff	cmp $0xfffff000,%eax
+@@ -69840,8 +69886,11 @@
+   444d71:	31 ff	xor %edi,%edi
+   444d73:	b8 0e 00 00 00	mov $0xe,%eax
+   444d78:	4c 89 fa	mov %r15,%rdx
+-  444d7b:	48 8d 35 4e 09 04 00	lea 0x4094e(%rip),%rsi
+-  444d82:	0f 05	syscall
 +  444d7b:	<trampoline-jmp+0x487>
-+  444d80:	90                   	nop
-+  444d81:	90                   	nop
-+  444d82:	90                   	nop
-+  444d83:	90                   	nop
-   444d84:	31 c0                	xor    %eax,%eax
-   444d86:	4c 8d ab 04 09 00 00 	lea    0x904(%rbx),%r13
-   444d8d:	ba 01 00 00 00       	mov    $0x1,%edx
-@@ -69861,8 +69910,9 @@
-   444dbf:	31 d2                	xor    %edx,%edx
-   444dc1:	4c 89 fe             	mov    %r15,%rsi
-   444dc4:	bf 02 00 00 00       	mov    $0x2,%edi
--  444dc9:	b8 0e 00 00 00       	mov    $0xe,%eax
--  444dce:	0f 05                	syscall
++  444d80:	90	nop
++  444d81:	90	nop
++  444d82:	90	nop
++  444d83:	90	nop
+   444d84:	31 c0	xor %eax,%eax
+   444d86:	4c 8d ab 04 09 00 00	lea 0x904(%rbx),%r13
+   444d8d:	ba 01 00 00 00	mov $0x1,%edx
+@@ -69858,8 +69907,9 @@
+   444dbf:	31 d2	xor %edx,%edx
+   444dc1:	4c 89 fe	mov %r15,%rsi
+   444dc4:	bf 02 00 00 00	mov $0x2,%edi
+-  444dc9:	b8 0e 00 00 00	mov $0xe,%eax
+-  444dce:	0f 05	syscall
 +  444dc9:	<trampoline-jmp+0x4a0>
-+  444dce:	90                   	nop
-+  444dcf:	90                   	nop
-   444dd0:	48 8b 45 c8          	mov    -0x38(%rbp),%rax
-   444dd4:	64 48 2b 04 25 28 00 	sub    %fs:0x28,%rax
++  444dce:	90	nop
++  444dcf:	90	nop
+   444dd0:	48 8b 45 c8	mov -0x38(%rbp),%rax
+   444dd4:	64 48 2b 04 25 28 00	sub %fs:0x28,%rax
    444ddb:	00 00
-@@ -69882,22 +69932,25 @@
-   444e03:	44 89 e2             	mov    %r12d,%edx
-   444e06:	89 c7                	mov    %eax,%edi
-   444e08:	89 de                	mov    %ebx,%esi
--  444e0a:	b8 ea 00 00 00       	mov    $0xea,%eax
--  444e0f:	0f 05                	syscall
+@@ -69879,22 +69929,25 @@
+   444e03:	44 89 e2	mov %r12d,%edx
+   444e06:	89 c7	mov %eax,%edi
+   444e08:	89 de	mov %ebx,%esi
+-  444e0a:	b8 ea 00 00 00	mov $0xea,%eax
+-  444e0f:	0f 05	syscall
 +  444e0a:	<trampoline-jmp+0x4b7>
-+  444e0f:	90                   	nop
-+  444e10:	90                   	nop
-   444e11:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
-   444e16:	76 8f                	jbe    444da7 <__pthread_kill+0x87>
-   444e18:	41 89 c6             	mov    %eax,%r14d
-   444e1b:	41 f7 de             	neg    %r14d
-   444e1e:	eb 8a                	jmp    444daa <__pthread_kill+0x8a>
--  444e20:	b8 ba 00 00 00       	mov    $0xba,%eax
--  444e25:	0f 05                	syscall
++  444e0f:	90	nop
++  444e10:	90	nop
+   444e11:	3d 00 f0 ff ff	cmp $0xfffff000,%eax
+   444e16:	76 8f	jbe 444da7 <__pthread_kill+0x87>
+   444e18:	41 89 c6	mov %eax,%r14d
+   444e1b:	41 f7 de	neg %r14d
+   444e1e:	eb 8a	jmp 444daa <__pthread_kill+0x8a>
+-  444e20:	b8 ba 00 00 00	mov $0xba,%eax
+-  444e25:	0f 05	syscall
 +  444e20:	<trampoline-jmp+0x4ce>
-+  444e25:	90                   	nop
-+  444e26:	90                   	nop
-   444e27:	89 c3                	mov    %eax,%ebx
-   444e29:	e8 22 6d 01 00       	call   45bb50 <__getpid>
-   444e2e:	44 89 e2             	mov    %r12d,%edx
-   444e31:	89 de                	mov    %ebx,%esi
-   444e33:	89 c7                	mov    %eax,%edi
--  444e35:	b8 ea 00 00 00       	mov    $0xea,%eax
--  444e3a:	0f 05                	syscall
++  444e25:	90	nop
++  444e26:	90	nop
+   444e27:	89 c3	mov %eax,%ebx
+   444e29:	e8 22 6d 01 00	call 45bb50 <__getpid>
+   444e2e:	44 89 e2	mov %r12d,%edx
+   444e31:	89 de	mov %ebx,%esi
+   444e33:	89 c7	mov %eax,%edi
+-  444e35:	b8 ea 00 00 00	mov $0xea,%eax
+-  444e3a:	0f 05	syscall
 +  444e35:	<trampoline-jmp+0x4e5>
-+  444e3a:	90                   	nop
-+  444e3b:	90                   	nop
-   444e3c:	41 89 c6             	mov    %eax,%r14d
-   444e3f:	41 f7 de             	neg    %r14d
-   444e42:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
-@@ -70102,8 +70155,10 @@
-   445101:	48 89 df             	mov    %rbx,%rdi
-   445104:	44 89 f0             	mov    %r14d,%eax
-   445107:	f7 d6                	not    %esi
--  445109:	81 e6 80 00 00 00    	and    $0x80,%esi
--  44510f:	0f 05                	syscall
++  444e3a:	90	nop
++  444e3b:	90	nop
+   444e3c:	41 89 c6	mov %eax,%r14d
+   444e3f:	41 f7 de	neg %r14d
+   444e42:	3d 00 f0 ff ff	cmp $0xfffff000,%eax
+@@ -70099,8 +70152,10 @@
+   445101:	48 89 df	mov %rbx,%rdi
+   445104:	44 89 f0	mov %r14d,%eax
+   445107:	f7 d6	not %esi
+-  445109:	81 e6 80 00 00 00	and $0x80,%esi
+-  44510f:	0f 05	syscall
 +  445109:	<trampoline-jmp+0x4fc>
-+  44510e:	90                   	nop
-+  44510f:	90                   	nop
-+  445110:	90                   	nop
-   445111:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
-   445117:	76 b7                	jbe    4450d0 <__pthread_mutex_lock_full+0x1a0>
-   445119:	83 f8 f5             	cmp    $0xfffffff5,%eax
-@@ -70220,8 +70275,9 @@
-   4452df:	45 31 d2             	xor    %r10d,%r10d
-   4452e2:	31 f6                	xor    %esi,%esi
-   4452e4:	48 89 df             	mov    %rbx,%rdi
--  4452e7:	b8 ca 00 00 00       	mov    $0xca,%eax
--  4452ec:	0f 05                	syscall
++  44510e:	90	nop
++  44510f:	90	nop
++  445110:	90	nop
+   445111:	48 3d 00 f0 ff ff	cmp $0xfffffffffffff000,%rax
+   445117:	76 b7	jbe 4450d0 <__pthread_mutex_lock_full+0x1a0>
+   445119:	83 f8 f5	cmp $0xfffffff5,%eax
+@@ -70217,8 +70272,9 @@
+   4452df:	45 31 d2	xor %r10d,%r10d
+   4452e2:	31 f6	xor %esi,%esi
+   4452e4:	48 89 df	mov %rbx,%rdi
+-  4452e7:	b8 ca 00 00 00	mov $0xca,%eax
+-  4452ec:	0f 05	syscall
 +  4452e7:	<trampoline-jmp+0x514>
-+  4452ec:	90                   	nop
-+  4452ed:	90                   	nop
-   4452ee:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
-   4452f4:	0f 87 4e 02 00 00    	ja     445548 <__pthread_mutex_lock_full+0x618>
-   4452fa:	8b 13                	mov    (%rbx),%edx
-@@ -70339,8 +70395,9 @@
-   4454fa:	31 d2                	xor    %edx,%edx
-   4454fc:	48 89 df             	mov    %rbx,%rdi
-   4454ff:	be 07 00 00 00       	mov    $0x7,%esi
--  445504:	b8 ca 00 00 00       	mov    $0xca,%eax
--  445509:	0f 05                	syscall
++  4452ec:	90	nop
++  4452ed:	90	nop
+   4452ee:	48 3d 00 f0 ff ff	cmp $0xfffffffffffff000,%rax
+   4452f4:	0f 87 4e 02 00 00	ja 445548 <__pthread_mutex_lock_full+0x618>
+   4452fa:	8b 13	mov (%rbx),%edx
+@@ -70336,8 +70392,9 @@
+   4454fa:	31 d2	xor %edx,%edx
+   4454fc:	48 89 df	mov %rbx,%rdi
+   4454ff:	be 07 00 00 00	mov $0x7,%esi
+-  445504:	b8 ca 00 00 00	mov $0xca,%eax
+-  445509:	0f 05	syscall
 +  445504:	<trampoline-jmp+0x52b>
-+  445509:	90                   	nop
-+  44550a:	90                   	nop
-   44550b:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
-   445511:	0f 86 71 ff ff ff    	jbe    445488 <__pthread_mutex_lock_full+0x558>
-   445517:	83 f8 92             	cmp    $0xffffff92,%eax
-@@ -70720,8 +70777,8 @@
-   445aa1:	4c 89 c7             	mov    %r8,%rdi
-   445aa4:	b8 ca 00 00 00       	mov    $0xca,%eax
-   445aa9:	81 e6 80 00 00 00    	and    $0x80,%esi
--  445aaf:	40 80 f6 81          	xor    $0x81,%sil
--  445ab3:	0f 05                	syscall
++  445509:	90	nop
++  44550a:	90	nop
+   44550b:	48 3d 00 f0 ff ff	cmp $0xfffffffffffff000,%rax
+   445511:	0f 86 71 ff ff ff	jbe 445488 <__pthread_mutex_lock_full+0x558>
+   445517:	83 f8 92	cmp $0xffffff92,%eax
+@@ -70717,8 +70774,8 @@
+   445aa1:	4c 89 c7	mov %r8,%rdi
+   445aa4:	b8 ca 00 00 00	mov $0xca,%eax
+   445aa9:	81 e6 80 00 00 00	and $0x80,%esi
+-  445aaf:	40 80 f6 81	xor $0x81,%sil
+-  445ab3:	0f 05	syscall
 +  445aaf:	<trampoline-jmp+0x542>
-+  445ab4:	90                   	nop
-   445ab5:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
-   445abb:	0f 87 0e 02 00 00    	ja     445ccf <__pthread_mutex_unlock_full+0x3bf>
-   445ac1:	90                   	nop
-@@ -70863,8 +70920,9 @@
-   445cf3:	ba 01 00 00 00       	mov    $0x1,%edx
-   445cf8:	be 01 00 00 00       	mov    $0x1,%esi
-   445cfd:	4c 89 c7             	mov    %r8,%rdi
--  445d00:	b8 ca 00 00 00       	mov    $0xca,%eax
--  445d05:	0f 05                	syscall
++  445ab4:	90	nop
+   445ab5:	48 3d 00 f0 ff ff	cmp $0xfffffffffffff000,%rax
+   445abb:	0f 87 0e 02 00 00	ja 445ccf <__pthread_mutex_unlock_full+0x3bf>
+   445ac1:	90	nop
+@@ -70860,8 +70917,9 @@
+   445cf3:	ba 01 00 00 00	mov $0x1,%edx
+   445cf8:	be 01 00 00 00	mov $0x1,%esi
+   445cfd:	4c 89 c7	mov %r8,%rdi
+-  445d00:	b8 ca 00 00 00	mov $0xca,%eax
+-  445d05:	0f 05	syscall
 +  445d00:	<trampoline-jmp+0x558>
-+  445d05:	90                   	nop
-+  445d06:	90                   	nop
-   445d07:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
-   445d0d:	0f 86 36 fd ff ff    	jbe    445a49 <__pthread_mutex_unlock_full+0x139>
-   445d13:	83 c0 16             	add    $0x16,%eax
-@@ -70875,8 +70933,9 @@
-   445d24:	45 31 d2             	xor    %r10d,%r10d
-   445d27:	31 d2                	xor    %edx,%edx
-   445d29:	4c 89 c7             	mov    %r8,%rdi
--  445d2c:	b8 ca 00 00 00       	mov    $0xca,%eax
--  445d31:	0f 05                	syscall
++  445d05:	90	nop
++  445d06:	90	nop
+   445d07:	48 3d 00 f0 ff ff	cmp $0xfffffffffffff000,%rax
+   445d0d:	0f 86 36 fd ff ff	jbe 445a49 <__pthread_mutex_unlock_full+0x139>
+   445d13:	83 c0 16	add $0x16,%eax
+@@ -70872,8 +70930,9 @@
+   445d24:	45 31 d2	xor %r10d,%r10d
+   445d27:	31 d2	xor %edx,%edx
+   445d29:	4c 89 c7	mov %r8,%rdi
+-  445d2c:	b8 ca 00 00 00	mov $0xca,%eax
+-  445d31:	0f 05	syscall
 +  445d2c:	<trampoline-jmp+0x56f>
-+  445d31:	90                   	nop
-+  445d32:	90                   	nop
-   445d33:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
-   445d39:	0f 86 f8 fd ff ff    	jbe    445b37 <__pthread_mutex_unlock_full+0x227>
-   445d3f:	83 f8 92             	cmp    $0xffffff92,%eax
-@@ -71093,8 +71152,9 @@
-   446007:	45 31 d2             	xor    %r10d,%r10d
-   44600a:	be 80 00 00 00       	mov    $0x80,%esi
-   44600f:	48 89 df             	mov    %rbx,%rdi
--  446012:	b8 ca 00 00 00       	mov    $0xca,%eax
--  446017:	0f 05                	syscall
++  445d31:	90	nop
++  445d32:	90	nop
+   445d33:	48 3d 00 f0 ff ff	cmp $0xfffffffffffff000,%rax
+   445d39:	0f 86 f8 fd ff ff	jbe 445b37 <__pthread_mutex_unlock_full+0x227>
+   445d3f:	83 f8 92	cmp $0xffffff92,%eax
+@@ -71090,8 +71149,9 @@
+   446007:	45 31 d2	xor %r10d,%r10d
+   44600a:	be 80 00 00 00	mov $0x80,%esi
+   44600f:	48 89 df	mov %rbx,%rdi
+-  446012:	b8 ca 00 00 00	mov $0xca,%eax
+-  446017:	0f 05	syscall
 +  446012:	<trampoline-jmp+0x586>
-+  446017:	90                   	nop
-+  446018:	90                   	nop
-   446019:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
-   44601f:	76 a1                	jbe    445fc2 <__pthread_once_slow+0x22>
-   446021:	83 f8 f5             	cmp    $0xfffffff5,%eax
-@@ -71130,8 +71190,9 @@
-   4460a5:	be 81 00 00 00       	mov    $0x81,%esi
-   4460aa:	c7 03 02 00 00 00    	movl   $0x2,(%rbx)
-   4460b0:	48 89 df             	mov    %rbx,%rdi
--  4460b3:	b8 ca 00 00 00       	mov    $0xca,%eax
--  4460b8:	0f 05                	syscall
++  446017:	90	nop
++  446018:	90	nop
+   446019:	48 3d 00 f0 ff ff	cmp $0xfffffffffffff000,%rax
+   44601f:	76 a1	jbe 445fc2 <__pthread_once_slow+0x22>
+   446021:	83 f8 f5	cmp $0xfffffff5,%eax
+@@ -71127,8 +71187,9 @@
+   4460a5:	be 81 00 00 00	mov $0x81,%esi
+   4460aa:	c7 03 02 00 00 00	movl $0x2,(%rbx)
+   4460b0:	48 89 df	mov %rbx,%rdi
+-  4460b3:	b8 ca 00 00 00	mov $0xca,%eax
+-  4460b8:	0f 05	syscall
 +  4460b3:	<trampoline-jmp+0x59d>
-+  4460b8:	90                   	nop
-+  4460b9:	90                   	nop
-   4460ba:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
-   4460c0:	0f 86 02 ff ff ff    	jbe    445fc8 <__pthread_once_slow+0x28>
-   4460c6:	83 c0 16             	add    $0x16,%eax
-@@ -71173,8 +71234,9 @@
-   44613a:	45 31 d2             	xor    %r10d,%r10d
-   44613d:	ba ff ff ff 7f       	mov    $0x7fffffff,%edx
-   446142:	be 81 00 00 00       	mov    $0x81,%esi
--  446147:	b8 ca 00 00 00       	mov    $0xca,%eax
--  44614c:	0f 05                	syscall
++  4460b8:	90	nop
++  4460b9:	90	nop
+   4460ba:	48 3d 00 f0 ff ff	cmp $0xfffffffffffff000,%rax
+   4460c0:	0f 86 02 ff ff ff	jbe 445fc8 <__pthread_once_slow+0x28>
+   4460c6:	83 c0 16	add $0x16,%eax
+@@ -71170,8 +71231,9 @@
+   44613a:	45 31 d2	xor %r10d,%r10d
+   44613d:	ba ff ff ff 7f	mov $0x7fffffff,%edx
+   446142:	be 81 00 00 00	mov $0x81,%esi
+-  446147:	b8 ca 00 00 00	mov $0xca,%eax
+-  44614c:	0f 05	syscall
 +  446147:	<trampoline-jmp+0x5b4>
-+  44614c:	90                   	nop
-+  44614d:	90                   	nop
-   44614e:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
-   446154:	77 0a                	ja     446160 <clear_once_control+0x30>
-   446156:	c3                   	ret
-@@ -71316,8 +71378,8 @@
-   4462dc:	40 0f 95 c6          	setne  %sil
-   4462e0:	45 31 d2             	xor    %r10d,%r10d
-   4462e3:	c1 e6 07             	shl    $0x7,%esi
--  4462e6:	40 80 f6 81          	xor    $0x81,%sil
--  4462ea:	0f 05                	syscall
++  44614c:	90	nop
++  44614d:	90	nop
+   44614e:	48 3d 00 f0 ff ff	cmp $0xfffffffffffff000,%rax
+   446154:	77 0a	ja 446160 <clear_once_control+0x30>
+   446156:	c3	ret
+@@ -71313,8 +71375,8 @@
+   4462dc:	40 0f 95 c6	setne %sil
+   4462e0:	45 31 d2	xor %r10d,%r10d
+   4462e3:	c1 e6 07	shl $0x7,%esi
+-  4462e6:	40 80 f6 81	xor $0x81,%sil
+-  4462ea:	0f 05	syscall
 +  4462e6:	<trampoline-jmp+0x5cb>
-+  4462eb:	90                   	nop
-   4462ec:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
-   4462f2:	0f 86 2e ff ff ff    	jbe    446226 <___pthread_rwlock_rdlock+0x46>
-   4462f8:	83 c0 16             	add    $0x16,%eax
-@@ -71420,8 +71482,9 @@
-   44642f:	ba ff ff ff 7f       	mov    $0x7fffffff,%edx
-   446434:	4c 89 c7             	mov    %r8,%rdi
-   446437:	40 80 f6 81          	xor    $0x81,%sil
--  44643b:	b8 ca 00 00 00       	mov    $0xca,%eax
--  446440:	0f 05                	syscall
++  4462eb:	90	nop
+   4462ec:	48 3d 00 f0 ff ff	cmp $0xfffffffffffff000,%rax
+   4462f2:	0f 86 2e ff ff ff	jbe 446226 <___pthread_rwlock_rdlock+0x46>
+   4462f8:	83 c0 16	add $0x16,%eax
+@@ -71417,8 +71479,9 @@
+   44642f:	ba ff ff ff 7f	mov $0x7fffffff,%edx
+   446434:	4c 89 c7	mov %r8,%rdi
+   446437:	40 80 f6 81	xor $0x81,%sil
+-  44643b:	b8 ca 00 00 00	mov $0xca,%eax
+-  446440:	0f 05	syscall
 +  44643b:	<trampoline-jmp+0x5e1>
-+  446440:	90                   	nop
-+  446441:	90                   	nop
-   446442:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
-   446448:	0f 87 da 00 00 00    	ja     446528 <___pthread_rwlock_unlock+0x158>
-   44644e:	5b                   	pop    %rbx
-@@ -71446,8 +71509,8 @@
-   446482:	45 31 d2             	xor    %r10d,%r10d
-   446485:	ba ff ff ff 7f       	mov    $0x7fffffff,%edx
-   44648a:	b8 ca 00 00 00       	mov    $0xca,%eax
--  44648f:	40 80 f6 81          	xor    $0x81,%sil
--  446493:	0f 05                	syscall
++  446440:	90	nop
++  446441:	90	nop
+   446442:	48 3d 00 f0 ff ff	cmp $0xfffffffffffff000,%rax
+   446448:	0f 87 da 00 00 00	ja 446528 <___pthread_rwlock_unlock+0x158>
+   44644e:	5b	pop %rbx
+@@ -71443,8 +71506,8 @@
+   446482:	45 31 d2	xor %r10d,%r10d
+   446485:	ba ff ff ff 7f	mov $0x7fffffff,%edx
+   44648a:	b8 ca 00 00 00	mov $0xca,%eax
+-  44648f:	40 80 f6 81	xor $0x81,%sil
+-  446493:	0f 05	syscall
 +  44648f:	<trampoline-jmp+0x5f8>
-+  446494:	90                   	nop
-   446495:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
-   44649b:	76 83                	jbe    446420 <___pthread_rwlock_unlock+0x50>
-   44649d:	83 c0 16             	add    $0x16,%eax
-@@ -71487,8 +71550,9 @@
-   446509:	ba 01 00 00 00       	mov    $0x1,%edx
-   44650e:	48 89 df             	mov    %rbx,%rdi
-   446511:	40 80 f6 81          	xor    $0x81,%sil
--  446515:	b8 ca 00 00 00       	mov    $0xca,%eax
--  44651a:	0f 05                	syscall
++  446494:	90	nop
+   446495:	48 3d 00 f0 ff ff	cmp $0xfffffffffffff000,%rax
+   44649b:	76 83	jbe 446420 <___pthread_rwlock_unlock+0x50>
+   44649d:	83 c0 16	add $0x16,%eax
+@@ -71484,8 +71547,9 @@
+   446509:	ba 01 00 00 00	mov $0x1,%edx
+   44650e:	48 89 df	mov %rbx,%rdi
+   446511:	40 80 f6 81	xor $0x81,%sil
+-  446515:	b8 ca 00 00 00	mov $0xca,%eax
+-  44651a:	0f 05	syscall
 +  446515:	<trampoline-jmp+0x60e>
-+  44651a:	90                   	nop
-+  44651b:	90                   	nop
-   44651c:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
-   446522:	0f 86 26 ff ff ff    	jbe    44644e <___pthread_rwlock_unlock+0x7e>
-   446528:	83 c0 16             	add    $0x16,%eax
-@@ -71515,8 +71579,8 @@
-   44656f:	45 31 d2             	xor    %r10d,%r10d
-   446572:	ba ff ff ff 7f       	mov    $0x7fffffff,%edx
-   446577:	b8 ca 00 00 00       	mov    $0xca,%eax
--  44657c:	40 80 f6 81          	xor    $0x81,%sil
--  446580:	0f 05                	syscall
++  44651a:	90	nop
++  44651b:	90	nop
+   44651c:	48 3d 00 f0 ff ff	cmp $0xfffffffffffff000,%rax
+   446522:	0f 86 26 ff ff ff	jbe 44644e <___pthread_rwlock_unlock+0x7e>
+   446528:	83 c0 16	add $0x16,%eax
+@@ -71512,8 +71576,8 @@
+   44656f:	45 31 d2	xor %r10d,%r10d
+   446572:	ba ff ff ff 7f	mov $0x7fffffff,%edx
+   446577:	b8 ca 00 00 00	mov $0xca,%eax
+-  44657c:	40 80 f6 81	xor $0x81,%sil
+-  446580:	0f 05	syscall
 +  44657c:	<trampoline-jmp+0x625>
-+  446581:	90                   	nop
-   446582:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
-   446588:	0f 86 6c ff ff ff    	jbe    4464fa <___pthread_rwlock_unlock+0x12a>
-   44658e:	83 c0 16             	add    $0x16,%eax
-@@ -71736,8 +71800,9 @@
-   44684d:	ba 01 00 00 00       	mov    $0x1,%edx
-   446852:	4c 89 e7             	mov    %r12,%rdi
-   446855:	40 80 f6 81          	xor    $0x81,%sil
--  446859:	b8 ca 00 00 00       	mov    $0xca,%eax
--  44685e:	0f 05                	syscall
++  446581:	90	nop
+   446582:	48 3d 00 f0 ff ff	cmp $0xfffffffffffff000,%rax
+   446588:	0f 86 6c ff ff ff	jbe 4464fa <___pthread_rwlock_unlock+0x12a>
+   44658e:	83 c0 16	add $0x16,%eax
+@@ -71733,8 +71797,9 @@
+   44684d:	ba 01 00 00 00	mov $0x1,%edx
+   446852:	4c 89 e7	mov %r12,%rdi
+   446855:	40 80 f6 81	xor $0x81,%sil
+-  446859:	b8 ca 00 00 00	mov $0xca,%eax
+-  44685e:	0f 05	syscall
 +  446859:	<trampoline-jmp+0x63b>
-+  44685e:	90                   	nop
-+  44685f:	90                   	nop
-   446860:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
-   446866:	0f 87 f9 00 00 00    	ja     446965 <___pthread_rwlock_wrlock+0x3c5>
-   44686c:	41 83 e0 04          	and    $0x4,%r8d
-@@ -71747,8 +71812,9 @@
-   446878:	ba ff ff ff 7f       	mov    $0x7fffffff,%edx
-   44687d:	48 89 df             	mov    %rbx,%rdi
-   446880:	40 80 f6 81          	xor    $0x81,%sil
--  446884:	b8 ca 00 00 00       	mov    $0xca,%eax
--  446889:	0f 05                	syscall
++  44685e:	90	nop
++  44685f:	90	nop
+   446860:	48 3d 00 f0 ff ff	cmp $0xfffffffffffff000,%rax
+   446866:	0f 87 f9 00 00 00	ja 446965 <___pthread_rwlock_wrlock+0x3c5>
+   44686c:	41 83 e0 04	and $0x4,%r8d
+@@ -71744,8 +71809,9 @@
+   446878:	ba ff ff ff 7f	mov $0x7fffffff,%edx
+   44687d:	48 89 df	mov %rbx,%rdi
+   446880:	40 80 f6 81	xor $0x81,%sil
+-  446884:	b8 ca 00 00 00	mov $0xca,%eax
+-  446889:	0f 05	syscall
 +  446884:	<trampoline-jmp+0x652>
-+  446889:	90                   	nop
-+  44688a:	90                   	nop
-   44688b:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
-   446891:	0f 87 c1 00 00 00    	ja     446958 <___pthread_rwlock_wrlock+0x3b8>
-   446897:	41 b8 6e 00 00 00    	mov    $0x6e,%r8d
-@@ -71786,8 +71852,9 @@
-   44691c:	ba 01 00 00 00       	mov    $0x1,%edx
-   446921:	4c 89 e7             	mov    %r12,%rdi
-   446924:	40 80 f6 81          	xor    $0x81,%sil
--  446928:	b8 ca 00 00 00       	mov    $0xca,%eax
--  44692d:	0f 05                	syscall
++  446889:	90	nop
++  44688a:	90	nop
+   44688b:	48 3d 00 f0 ff ff	cmp $0xfffffffffffff000,%rax
+   446891:	0f 87 c1 00 00 00	ja 446958 <___pthread_rwlock_wrlock+0x3b8>
+   446897:	41 b8 6e 00 00 00	mov $0x6e,%r8d
+@@ -71783,8 +71849,9 @@
+   44691c:	ba 01 00 00 00	mov $0x1,%edx
+   446921:	4c 89 e7	mov %r12,%rdi
+   446924:	40 80 f6 81	xor $0x81,%sil
+-  446928:	b8 ca 00 00 00	mov $0xca,%eax
+-  44692d:	0f 05	syscall
 +  446928:	<trampoline-jmp+0x669>
-+  44692d:	90                   	nop
-+  44692e:	90                   	nop
-   44692f:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
-   446935:	0f 86 e8 fc ff ff    	jbe    446623 <___pthread_rwlock_wrlock+0x83>
-   44693b:	83 c0 16             	add    $0x16,%eax
-@@ -71852,8 +71919,9 @@
-   446a05:	48 89 f0             	mov    %rsi,%rax
-   446a08:	48 89 c6             	mov    %rax,%rsi
-   446a0b:	41 ba 08 00 00 00    	mov    $0x8,%r10d
--  446a11:	b8 0e 00 00 00       	mov    $0xe,%eax
--  446a16:	0f 05                	syscall
++  44692d:	90	nop
++  44692e:	90	nop
+   44692f:	48 3d 00 f0 ff ff	cmp $0xfffffffffffff000,%rax
+   446935:	0f 86 e8 fc ff ff	jbe 446623 <___pthread_rwlock_wrlock+0x83>
+   44693b:	83 c0 16	add $0x16,%eax
+@@ -71849,8 +71916,9 @@
+   446a05:	48 89 f0	mov %rsi,%rax
+   446a08:	48 89 c6	mov %rax,%rsi
+   446a0b:	41 ba 08 00 00 00	mov $0x8,%r10d
+-  446a11:	b8 0e 00 00 00	mov $0xe,%eax
+-  446a16:	0f 05	syscall
 +  446a11:	<trampoline-jmp+0x680>
-+  446a16:	90                   	nop
-+  446a17:	90                   	nop
-   446a18:	89 c2                	mov    %eax,%edx
-   446a1a:	f7 da                	neg    %edx
-   446a1c:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
-@@ -93239,8 +93307,9 @@
-   45ba24:	b8 ff ff ff 7f       	mov    $0x7fffffff,%eax
-   45ba29:	48 39 c2             	cmp    %rax,%rdx
-   45ba2c:	48 0f 47 d0          	cmova  %rax,%rdx
--  45ba30:	b8 d9 00 00 00       	mov    $0xd9,%eax
--  45ba35:	0f 05                	syscall
++  446a16:	90	nop
++  446a17:	90	nop
+   446a18:	89 c2	mov %eax,%edx
+   446a1a:	f7 da	neg %edx
+   446a1c:	3d 00 f0 ff ff	cmp $0xfffff000,%eax
+@@ -93236,8 +93304,9 @@
+   45ba24:	b8 ff ff ff 7f	mov $0x7fffffff,%eax
+   45ba29:	48 39 c2	cmp %rax,%rdx
+   45ba2c:	48 0f 47 d0	cmova %rax,%rdx
+-  45ba30:	b8 d9 00 00 00	mov $0xd9,%eax
+-  45ba35:	0f 05	syscall
 +  45ba30:	<trampoline-jmp+0x697>
-+  45ba35:	90                   	nop
-+  45ba36:	90                   	nop
-   45ba37:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
-   45ba3d:	77 01                	ja     45ba40 <__getdents+0x20>
-   45ba3f:	c3                   	ret
-@@ -93332,8 +93401,9 @@
++  45ba35:	90	nop
++  45ba36:	90	nop
+   45ba37:	48 3d 00 f0 ff ff	cmp $0xfffffffffffff000,%rax
+   45ba3d:	77 01	ja 45ba40 <__getdents+0x20>
+   45ba3f:	c3	ret
+@@ -93329,8 +93398,9 @@
  
  000000000045bb50 <__getpid>:
-   45bb50:	f3 0f 1e fa          	endbr64
--  45bb54:	b8 27 00 00 00       	mov    $0x27,%eax
--  45bb59:	0f 05                	syscall
+   45bb50:	f3 0f 1e fa	endbr64
+-  45bb54:	b8 27 00 00 00	mov $0x27,%eax
+-  45bb59:	0f 05	syscall
 +  45bb54:	<trampoline-jmp+0x6ae>
-+  45bb59:	90                   	nop
-+  45bb5a:	90                   	nop
-   45bb5b:	c3                   	ret
-   45bb5c:	0f 1f 40 00          	nopl   0x0(%rax)
++  45bb59:	90	nop
++  45bb5a:	90	nop
+   45bb5b:	c3	ret
+   45bb5c:	0f 1f 40 00	nopl 0x0(%rax)
  
-@@ -93365,8 +93435,9 @@
+@@ -93362,8 +93432,9 @@
  
  000000000045bba0 <__sched_getparam>:
-   45bba0:	f3 0f 1e fa          	endbr64
--  45bba4:	b8 8f 00 00 00       	mov    $0x8f,%eax
--  45bba9:	0f 05                	syscall
+   45bba0:	f3 0f 1e fa	endbr64
+-  45bba4:	b8 8f 00 00 00	mov $0x8f,%eax
+-  45bba9:	0f 05	syscall
 +  45bba4:	<trampoline-jmp+0x6c5>
-+  45bba9:	90                   	nop
-+  45bbaa:	90                   	nop
-   45bbab:	48 3d 01 f0 ff ff    	cmp    $0xfffffffffffff001,%rax
-   45bbb1:	73 01                	jae    45bbb4 <__sched_getparam+0x14>
-   45bbb3:	c3                   	ret
-@@ -93381,8 +93452,9 @@
++  45bba9:	90	nop
++  45bbaa:	90	nop
+   45bbab:	48 3d 01 f0 ff ff	cmp $0xfffffffffffff001,%rax
+   45bbb1:	73 01	jae 45bbb4 <__sched_getparam+0x14>
+   45bbb3:	c3	ret
+@@ -93378,8 +93449,9 @@
  
  000000000045bbd0 <__sched_getscheduler>:
-   45bbd0:	f3 0f 1e fa          	endbr64
--  45bbd4:	b8 91 00 00 00       	mov    $0x91,%eax
--  45bbd9:	0f 05                	syscall
+   45bbd0:	f3 0f 1e fa	endbr64
+-  45bbd4:	b8 91 00 00 00	mov $0x91,%eax
+-  45bbd9:	0f 05	syscall
 +  45bbd4:	<trampoline-jmp+0x6dc>
-+  45bbd9:	90                   	nop
-+  45bbda:	90                   	nop
-   45bbdb:	48 3d 01 f0 ff ff    	cmp    $0xfffffffffffff001,%rax
-   45bbe1:	73 01                	jae    45bbe4 <__sched_getscheduler+0x14>
-   45bbe3:	c3                   	ret
-@@ -93397,8 +93469,9 @@
++  45bbd9:	90	nop
++  45bbda:	90	nop
+   45bbdb:	48 3d 01 f0 ff ff	cmp $0xfffffffffffff001,%rax
+   45bbe1:	73 01	jae 45bbe4 <__sched_getscheduler+0x14>
+   45bbe3:	c3	ret
+@@ -93394,8 +93466,9 @@
  
  000000000045bc00 <__sched_get_priority_max>:
-   45bc00:	f3 0f 1e fa          	endbr64
--  45bc04:	b8 92 00 00 00       	mov    $0x92,%eax
--  45bc09:	0f 05                	syscall
+   45bc00:	f3 0f 1e fa	endbr64
+-  45bc04:	b8 92 00 00 00	mov $0x92,%eax
+-  45bc09:	0f 05	syscall
 +  45bc04:	<trampoline-jmp+0x6f3>
-+  45bc09:	90                   	nop
-+  45bc0a:	90                   	nop
-   45bc0b:	48 3d 01 f0 ff ff    	cmp    $0xfffffffffffff001,%rax
-   45bc11:	73 01                	jae    45bc14 <__sched_get_priority_max+0x14>
-   45bc13:	c3                   	ret
-@@ -93413,8 +93486,9 @@
++  45bc09:	90	nop
++  45bc0a:	90	nop
+   45bc0b:	48 3d 01 f0 ff ff	cmp $0xfffffffffffff001,%rax
+   45bc11:	73 01	jae 45bc14 <__sched_get_priority_max+0x14>
+   45bc13:	c3	ret
+@@ -93410,8 +93483,9 @@
  
  000000000045bc30 <__sched_get_priority_min>:
-   45bc30:	f3 0f 1e fa          	endbr64
--  45bc34:	b8 93 00 00 00       	mov    $0x93,%eax
--  45bc39:	0f 05                	syscall
+   45bc30:	f3 0f 1e fa	endbr64
+-  45bc34:	b8 93 00 00 00	mov $0x93,%eax
+-  45bc39:	0f 05	syscall
 +  45bc34:	<trampoline-jmp+0x70a>
-+  45bc39:	90                   	nop
-+  45bc3a:	90                   	nop
-   45bc3b:	48 3d 01 f0 ff ff    	cmp    $0xfffffffffffff001,%rax
-   45bc41:	73 01                	jae    45bc44 <__sched_get_priority_min+0x14>
-   45bc43:	c3                   	ret
-@@ -93429,8 +93503,9 @@
++  45bc39:	90	nop
++  45bc3a:	90	nop
+   45bc3b:	48 3d 01 f0 ff ff	cmp $0xfffffffffffff001,%rax
+   45bc41:	73 01	jae 45bc44 <__sched_get_priority_min+0x14>
+   45bc43:	c3	ret
+@@ -93426,8 +93500,9 @@
  
  000000000045bc60 <__sched_setscheduler>:
-   45bc60:	f3 0f 1e fa          	endbr64
--  45bc64:	b8 90 00 00 00       	mov    $0x90,%eax
--  45bc69:	0f 05                	syscall
+   45bc60:	f3 0f 1e fa	endbr64
+-  45bc64:	b8 90 00 00 00	mov $0x90,%eax
+-  45bc69:	0f 05	syscall
 +  45bc64:	<trampoline-jmp+0x721>
-+  45bc69:	90                   	nop
-+  45bc6a:	90                   	nop
-   45bc6b:	48 3d 01 f0 ff ff    	cmp    $0xfffffffffffff001,%rax
-   45bc71:	73 01                	jae    45bc74 <__sched_setscheduler+0x14>
-   45bc73:	c3                   	ret
-@@ -93477,8 +93552,9 @@
-   45bd00:	48 89 85 08 ff ff ff 	mov    %rax,-0xf8(%rbp)
-   45bd07:	0f 84 21 04 00 00    	je     45c12e <__getcwd+0x49e>
-   45bd0d:	48 8b bd 08 ff ff ff 	mov    -0xf8(%rbp),%rdi
--  45bd14:	b8 4f 00 00 00       	mov    $0x4f,%eax
--  45bd19:	0f 05                	syscall
++  45bc69:	90	nop
++  45bc6a:	90	nop
+   45bc6b:	48 3d 01 f0 ff ff	cmp $0xfffffffffffff001,%rax
+   45bc71:	73 01	jae 45bc74 <__sched_setscheduler+0x14>
+   45bc73:	c3	ret
+@@ -93474,8 +93549,9 @@
+   45bd00:	48 89 85 08 ff ff ff	mov %rax,-0xf8(%rbp)
+   45bd07:	0f 84 21 04 00 00	je 45c12e <__getcwd+0x49e>
+   45bd0d:	48 8b bd 08 ff ff ff	mov -0xf8(%rbp),%rdi
+-  45bd14:	b8 4f 00 00 00	mov $0x4f,%eax
+-  45bd19:	0f 05	syscall
 +  45bd14:	<trampoline-jmp+0x738>
-+  45bd19:	90                   	nop
-+  45bd1a:	90                   	nop
-   45bd1b:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
-   45bd21:	0f 87 85 05 00 00    	ja     45c2ac <__getcwd+0x61c>
-   45bd27:	85 c0                	test   %eax,%eax
-@@ -93914,8 +93990,9 @@
++  45bd19:	90	nop
++  45bd1a:	90	nop
+   45bd1b:	48 3d 00 f0 ff ff	cmp $0xfffffffffffff000,%rax
+   45bd21:	0f 87 85 05 00 00	ja 45c2ac <__getcwd+0x61c>
+   45bd27:	85 c0	test %eax,%eax
+@@ -93911,8 +93987,9 @@
  
  000000000045c510 <__libc_lseek>:
-   45c510:	f3 0f 1e fa          	endbr64
--  45c514:	b8 08 00 00 00       	mov    $0x8,%eax
--  45c519:	0f 05                	syscall
+   45c510:	f3 0f 1e fa	endbr64
+-  45c514:	b8 08 00 00 00	mov $0x8,%eax
+-  45c519:	0f 05	syscall
 +  45c514:	<trampoline-jmp+0x74f>
-+  45c519:	90                   	nop
-+  45c51a:	90                   	nop
-   45c51b:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
-   45c521:	77 05                	ja     45c528 <__libc_lseek+0x18>
-   45c523:	c3                   	ret
-@@ -93962,8 +94039,9 @@
-   45c5a4:	89 da                	mov    %ebx,%edx
-   45c5a6:	4c 89 e6             	mov    %r12,%rsi
-   45c5a9:	bf 9c ff ff ff       	mov    $0xffffff9c,%edi
--  45c5ae:	b8 01 01 00 00       	mov    $0x101,%eax
--  45c5b3:	0f 05                	syscall
++  45c519:	90	nop
++  45c51a:	90	nop
+   45c51b:	48 3d 00 f0 ff ff	cmp $0xfffffffffffff000,%rax
+   45c521:	77 05	ja 45c528 <__libc_lseek+0x18>
+   45c523:	c3	ret
+@@ -93959,8 +94036,9 @@
+   45c5a4:	89 da	mov %ebx,%edx
+   45c5a6:	4c 89 e6	mov %r12,%rsi
+   45c5a9:	bf 9c ff ff ff	mov $0xffffff9c,%edi
+-  45c5ae:	b8 01 01 00 00	mov $0x101,%eax
+-  45c5b3:	0f 05	syscall
 +  45c5ae:	<trampoline-jmp+0x766>
-+  45c5b3:	90                   	nop
-+  45c5b4:	90                   	nop
-   45c5b5:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
-   45c5bb:	0f 87 7f 00 00 00    	ja     45c640 <__libc_open+0xe0>
-   45c5c1:	48 8b 55 b8          	mov    -0x48(%rbp),%rdx
-@@ -93991,8 +94069,9 @@
-   45c613:	4c 89 e6             	mov    %r12,%rsi
-   45c616:	41 89 c0             	mov    %eax,%r8d
-   45c619:	bf 9c ff ff ff       	mov    $0xffffff9c,%edi
--  45c61e:	b8 01 01 00 00       	mov    $0x101,%eax
--  45c623:	0f 05                	syscall
++  45c5b3:	90	nop
++  45c5b4:	90	nop
+   45c5b5:	48 3d 00 f0 ff ff	cmp $0xfffffffffffff000,%rax
+   45c5bb:	0f 87 7f 00 00 00	ja 45c640 <__libc_open+0xe0>
+   45c5c1:	48 8b 55 b8	mov -0x48(%rbp),%rdx
+@@ -93988,8 +94066,9 @@
+   45c613:	4c 89 e6	mov %r12,%rsi
+   45c616:	41 89 c0	mov %eax,%r8d
+   45c619:	bf 9c ff ff ff	mov $0xffffff9c,%edi
+-  45c61e:	b8 01 01 00 00	mov $0x101,%eax
+-  45c623:	0f 05	syscall
 +  45c61e:	<trampoline-jmp+0x77d>
-+  45c623:	90                   	nop
-+  45c624:	90                   	nop
-   45c625:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
-   45c62b:	77 33                	ja     45c660 <__libc_open+0x100>
-   45c62d:	44 89 c7             	mov    %r8d,%edi
-@@ -94036,8 +94115,9 @@
-   45c6b0:	74 36                	je     45c6e8 <__libc_openat64+0x68>
-   45c6b2:	80 3d df e3 04 00 00 	cmpb   $0x0,0x4e3df(%rip)        # 4aaa98 <__libc_single_threaded>
-   45c6b9:	74 51                	je     45c70c <__libc_openat64+0x8c>
--  45c6bb:	b8 01 01 00 00       	mov    $0x101,%eax
--  45c6c0:	0f 05                	syscall
++  45c623:	90	nop
++  45c624:	90	nop
+   45c625:	48 3d 00 f0 ff ff	cmp $0xfffffffffffff000,%rax
+   45c62b:	77 33	ja 45c660 <__libc_open+0x100>
+   45c62d:	44 89 c7	mov %r8d,%edi
+@@ -94033,8 +94112,9 @@
+   45c6b0:	74 36	je 45c6e8 <__libc_openat64+0x68>
+   45c6b2:	80 3d df e3 04 00 00	cmpb $0x0,0x4e3df(%rip)
+   45c6b9:	74 51	je 45c70c <__libc_openat64+0x8c>
+-  45c6bb:	b8 01 01 00 00	mov $0x101,%eax
+-  45c6c0:	0f 05	syscall
 +  45c6bb:	<trampoline-jmp+0x794>
-+  45c6c0:	90                   	nop
-+  45c6c1:	90                   	nop
-   45c6c2:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
-   45c6c8:	0f 87 8a 00 00 00    	ja     45c758 <__libc_openat64+0xd8>
-   45c6ce:	48 8b 55 c8          	mov    -0x38(%rbp),%rdx
-@@ -94065,8 +94145,9 @@
-   45c726:	41 89 c0             	mov    %eax,%r8d
-   45c729:	48 8b 75 a0          	mov    -0x60(%rbp),%rsi
-   45c72d:	8b 7d a8             	mov    -0x58(%rbp),%edi
--  45c730:	b8 01 01 00 00       	mov    $0x101,%eax
--  45c735:	0f 05                	syscall
++  45c6c0:	90	nop
++  45c6c1:	90	nop
+   45c6c2:	48 3d 00 f0 ff ff	cmp $0xfffffffffffff000,%rax
+   45c6c8:	0f 87 8a 00 00 00	ja 45c758 <__libc_openat64+0xd8>
+   45c6ce:	48 8b 55 c8	mov -0x38(%rbp),%rdx
+@@ -94062,8 +94142,9 @@
+   45c726:	41 89 c0	mov %eax,%r8d
+   45c729:	48 8b 75 a0	mov -0x60(%rbp),%rsi
+   45c72d:	8b 7d a8	mov -0x58(%rbp),%edi
+-  45c730:	b8 01 01 00 00	mov $0x101,%eax
+-  45c735:	0f 05	syscall
 +  45c730:	<trampoline-jmp+0x7ab>
-+  45c735:	90                   	nop
-+  45c736:	90                   	nop
-   45c737:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
-   45c73d:	77 31                	ja     45c770 <__libc_openat64+0xf0>
-   45c73f:	44 89 c7             	mov    %r8d,%edi
-@@ -94095,8 +94176,10 @@
-   45c794:	80 3d fd e2 04 00 00 	cmpb   $0x0,0x4e2fd(%rip)        # 4aaa98 <__libc_single_threaded>
-   45c79b:	74 13                	je     45c7b0 <__libc_read+0x20>
-   45c79d:	31 c0                	xor    %eax,%eax
--  45c79f:	0f 05                	syscall
--  45c7a1:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
++  45c735:	90	nop
++  45c736:	90	nop
+   45c737:	48 3d 00 f0 ff ff	cmp $0xfffffffffffff000,%rax
+   45c73d:	77 31	ja 45c770 <__libc_openat64+0xf0>
+   45c73f:	44 89 c7	mov %r8d,%edi
+@@ -94092,8 +94173,10 @@
+   45c794:	80 3d fd e2 04 00 00	cmpb $0x0,0x4e2fd(%rip)
+   45c79b:	74 13	je 45c7b0 <__libc_read+0x20>
+   45c79d:	31 c0	xor %eax,%eax
+-  45c79f:	0f 05	syscall
+-  45c7a1:	48 3d 00 f0 ff ff	cmp $0xfffffffffffff000,%rax
 +  45c79f:	<trampoline-jmp+0x7c2>
-+  45c7a4:	90                   	nop
-+  45c7a5:	90                   	nop
-+  45c7a6:	90                   	nop
-   45c7a7:	77 4f                	ja     45c7f8 <__libc_read+0x68>
-   45c7a9:	c3                   	ret
-   45c7aa:	66 0f 1f 44 00 00    	nopw   0x0(%rax,%rax,1)
-@@ -94110,9 +94193,9 @@
-   45c7c8:	48 8b 55 e8          	mov    -0x18(%rbp),%rdx
-   45c7cc:	48 8b 75 f0          	mov    -0x10(%rbp),%rsi
-   45c7d0:	41 89 c0             	mov    %eax,%r8d
--  45c7d3:	8b 7d f8             	mov    -0x8(%rbp),%edi
--  45c7d6:	31 c0                	xor    %eax,%eax
--  45c7d8:	0f 05                	syscall
++  45c7a4:	90	nop
++  45c7a5:	90	nop
++  45c7a6:	90	nop
+   45c7a7:	77 4f	ja 45c7f8 <__libc_read+0x68>
+   45c7a9:	c3	ret
+   45c7aa:	66 0f 1f 44 00 00	nopw 0x0(%rax,%rax,1)
+@@ -94107,9 +94190,9 @@
+   45c7c8:	48 8b 55 e8	mov -0x18(%rbp),%rdx
+   45c7cc:	48 8b 75 f0	mov -0x10(%rbp),%rsi
+   45c7d0:	41 89 c0	mov %eax,%r8d
+-  45c7d3:	8b 7d f8	mov -0x8(%rbp),%edi
+-  45c7d6:	31 c0	xor %eax,%eax
+-  45c7d8:	0f 05	syscall
 +  45c7d3:	<trampoline-jmp+0x7da>
-+  45c7d8:	90                   	nop
-+  45c7d9:	90                   	nop
-   45c7da:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
-   45c7e0:	77 2e                	ja     45c810 <__libc_read+0x80>
-   45c7e2:	44 89 c7             	mov    %r8d,%edi
-@@ -94151,8 +94234,9 @@
-   45c850:	f3 0f 1e fa          	endbr64
-   45c854:	80 3d 3d e2 04 00 00 	cmpb   $0x0,0x4e23d(%rip)        # 4aaa98 <__libc_single_threaded>
-   45c85b:	74 13                	je     45c870 <__libc_write+0x20>
--  45c85d:	b8 01 00 00 00       	mov    $0x1,%eax
--  45c862:	0f 05                	syscall
++  45c7d8:	90	nop
++  45c7d9:	90	nop
+   45c7da:	48 3d 00 f0 ff ff	cmp $0xfffffffffffff000,%rax
+   45c7e0:	77 2e	ja 45c810 <__libc_read+0x80>
+   45c7e2:	44 89 c7	mov %r8d,%edi
+@@ -94148,8 +94231,9 @@
+   45c850:	f3 0f 1e fa	endbr64
+   45c854:	80 3d 3d e2 04 00 00	cmpb $0x0,0x4e23d(%rip)
+   45c85b:	74 13	je 45c870 <__libc_write+0x20>
+-  45c85d:	b8 01 00 00 00	mov $0x1,%eax
+-  45c862:	0f 05	syscall
 +  45c85d:	<trampoline-jmp+0x7f1>
-+  45c862:	90                   	nop
-+  45c863:	90                   	nop
-   45c864:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
-   45c86a:	77 54                	ja     45c8c0 <__libc_write+0x70>
-   45c86c:	c3                   	ret
-@@ -94168,8 +94252,9 @@
-   45c88c:	48 8b 75 f0          	mov    -0x10(%rbp),%rsi
-   45c890:	41 89 c0             	mov    %eax,%r8d
-   45c893:	8b 7d f8             	mov    -0x8(%rbp),%edi
--  45c896:	b8 01 00 00 00       	mov    $0x1,%eax
--  45c89b:	0f 05                	syscall
++  45c862:	90	nop
++  45c863:	90	nop
+   45c864:	48 3d 00 f0 ff ff	cmp $0xfffffffffffff000,%rax
+   45c86a:	77 54	ja 45c8c0 <__libc_write+0x70>
+   45c86c:	c3	ret
+@@ -94165,8 +94249,9 @@
+   45c88c:	48 8b 75 f0	mov -0x10(%rbp),%rsi
+   45c890:	41 89 c0	mov %eax,%r8d
+   45c893:	8b 7d f8	mov -0x8(%rbp),%edi
+-  45c896:	b8 01 00 00 00	mov $0x1,%eax
+-  45c89b:	0f 05	syscall
 +  45c896:	<trampoline-jmp+0x808>
-+  45c89b:	90                   	nop
-+  45c89c:	90                   	nop
-   45c89d:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
-   45c8a3:	77 33                	ja     45c8d8 <__libc_write+0x88>
-   45c8a5:	44 89 c7             	mov    %r8d,%edi
-@@ -94210,8 +94295,9 @@
-   45c919:	f7 d0                	not    %eax
-   45c91b:	a9 00 00 41 00       	test   $0x410000,%eax
-   45c920:	74 26                	je     45c948 <__openat64_nocancel+0x58>
--  45c922:	b8 01 01 00 00       	mov    $0x101,%eax
--  45c927:	0f 05                	syscall
++  45c89b:	90	nop
++  45c89c:	90	nop
+   45c89d:	48 3d 00 f0 ff ff	cmp $0xfffffffffffff000,%rax
+   45c8a3:	77 33	ja 45c8d8 <__libc_write+0x88>
+   45c8a5:	44 89 c7	mov %r8d,%edi
+@@ -94207,8 +94292,9 @@
+   45c919:	f7 d0	not %eax
+   45c91b:	a9 00 00 41 00	test $0x410000,%eax
+   45c920:	74 26	je 45c948 <__openat64_nocancel+0x58>
+-  45c922:	b8 01 01 00 00	mov $0x101,%eax
+-  45c927:	0f 05	syscall
 +  45c922:	<trampoline-jmp+0x81f>
-+  45c927:	90                   	nop
-+  45c928:	90                   	nop
-   45c929:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
-   45c92f:	77 37                	ja     45c968 <__openat64_nocancel+0x78>
-   45c931:	48 8b 55 c8          	mov    -0x38(%rbp),%rdx
-@@ -94239,8 +94325,9 @@
++  45c927:	90	nop
++  45c928:	90	nop
+   45c929:	48 3d 00 f0 ff ff	cmp $0xfffffffffffff000,%rax
+   45c92f:	77 37	ja 45c968 <__openat64_nocancel+0x78>
+   45c931:	48 8b 55 c8	mov -0x38(%rbp),%rdx
+@@ -94236,8 +94322,9 @@
  000000000045c980 <__pread64_nocancel>:
-   45c980:	f3 0f 1e fa          	endbr64
-   45c984:	49 89 ca             	mov    %rcx,%r10
--  45c987:	b8 11 00 00 00       	mov    $0x11,%eax
--  45c98c:	0f 05                	syscall
+   45c980:	f3 0f 1e fa	endbr64
+   45c984:	49 89 ca	mov %rcx,%r10
+-  45c987:	b8 11 00 00 00	mov $0x11,%eax
+-  45c98c:	0f 05	syscall
 +  45c987:	<trampoline-jmp+0x836>
-+  45c98c:	90                   	nop
-+  45c98d:	90                   	nop
-   45c98e:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
-   45c994:	77 0a                	ja     45c9a0 <__pread64_nocancel+0x20>
-   45c996:	c3                   	ret
-@@ -94257,8 +94344,9 @@
++  45c98c:	90	nop
++  45c98d:	90	nop
+   45c98e:	48 3d 00 f0 ff ff	cmp $0xfffffffffffff000,%rax
+   45c994:	77 0a	ja 45c9a0 <__pread64_nocancel+0x20>
+   45c996:	c3	ret
+@@ -94254,8 +94341,9 @@
  
  000000000045c9c0 <__write_nocancel>:
-   45c9c0:	f3 0f 1e fa          	endbr64
--  45c9c4:	b8 01 00 00 00       	mov    $0x1,%eax
--  45c9c9:	0f 05                	syscall
+   45c9c0:	f3 0f 1e fa	endbr64
+-  45c9c4:	b8 01 00 00 00	mov $0x1,%eax
+-  45c9c9:	0f 05	syscall
 +  45c9c4:	<trampoline-jmp+0x84d>
-+  45c9c9:	90                   	nop
-+  45c9ca:	90                   	nop
-   45c9cb:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
-   45c9d1:	77 05                	ja     45c9d8 <__write_nocancel+0x18>
-   45c9d3:	c3                   	ret
-@@ -94282,8 +94370,9 @@
-   45ca0d:	48 89 45 f8          	mov    %rax,-0x8(%rbp)
-   45ca11:	31 c0                	xor    %eax,%eax
-   45ca13:	48 8d 55 d0          	lea    -0x30(%rbp),%rdx
--  45ca17:	b8 10 00 00 00       	mov    $0x10,%eax
--  45ca1c:	0f 05                	syscall
++  45c9c9:	90	nop
++  45c9ca:	90	nop
+   45c9cb:	48 3d 00 f0 ff ff	cmp $0xfffffffffffff000,%rax
+   45c9d1:	77 05	ja 45c9d8 <__write_nocancel+0x18>
+   45c9d3:	c3	ret
+@@ -94279,8 +94367,9 @@
+   45ca0d:	48 89 45 f8	mov %rax,-0x8(%rbp)
+   45ca11:	31 c0	xor %eax,%eax
+   45ca13:	48 8d 55 d0	lea -0x30(%rbp),%rdx
+-  45ca17:	b8 10 00 00 00	mov $0x10,%eax
+-  45ca1c:	0f 05	syscall
 +  45ca17:	<trampoline-jmp+0x864>
-+  45ca1c:	90                   	nop
-+  45ca1d:	90                   	nop
-   45ca1e:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
-   45ca24:	77 6a                	ja     45ca90 <__tcgetattr+0xa0>
-   45ca26:	89 c2                	mov    %eax,%edx
-@@ -94329,9 +94418,11 @@
-   45cab4:	49 89 f2             	mov    %rsi,%r10
-   45cab7:	31 d2                	xor    %edx,%edx
-   45cab9:	89 fe                	mov    %edi,%esi
--  45cabb:	b8 2e 01 00 00       	mov    $0x12e,%eax
--  45cac0:	31 ff                	xor    %edi,%edi
--  45cac2:	0f 05                	syscall
++  45ca1c:	90	nop
++  45ca1d:	90	nop
+   45ca1e:	48 3d 00 f0 ff ff	cmp $0xfffffffffffff000,%rax
+   45ca24:	77 6a	ja 45ca90 <__tcgetattr+0xa0>
+   45ca26:	89 c2	mov %eax,%edx
+@@ -94326,9 +94415,11 @@
+   45cab4:	49 89 f2	mov %rsi,%r10
+   45cab7:	31 d2	xor %edx,%edx
+   45cab9:	89 fe	mov %edi,%esi
+-  45cabb:	b8 2e 01 00 00	mov $0x12e,%eax
+-  45cac0:	31 ff	xor %edi,%edi
+-  45cac2:	0f 05	syscall
 +  45cabb:	<trampoline-jmp+0x87b>
-+  45cac0:	90                   	nop
-+  45cac1:	90                   	nop
-+  45cac2:	90                   	nop
-+  45cac3:	90                   	nop
-   45cac4:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
-   45caca:	77 04                	ja     45cad0 <__GI___getrlimit+0x20>
-   45cacc:	c3                   	ret
-@@ -97928,8 +98019,9 @@
-   45ff97:	64 48 8b 04 25 10 00 	mov    %fs:0x10,%rax
++  45cac0:	90	nop
++  45cac1:	90	nop
++  45cac2:	90	nop
++  45cac3:	90	nop
+   45cac4:	48 3d 00 f0 ff ff	cmp $0xfffffffffffff000,%rax
+   45caca:	77 04	ja 45cad0 <__gi___getrlimit+0x20>
+   45cacc:	c3	ret
+@@ -97925,8 +98016,9 @@
+   45ff97:	64 48 8b 04 25 10 00	mov %fs:0x10,%rax
    45ff9e:	00 00
-   45ffa0:	48 8d 78 1c          	lea    0x1c(%rax),%rdi
--  45ffa4:	b8 ca 00 00 00       	mov    $0xca,%eax
--  45ffa9:	0f 05                	syscall
+   45ffa0:	48 8d 78 1c	lea 0x1c(%rax),%rdi
+-  45ffa4:	b8 ca 00 00 00	mov $0xca,%eax
+-  45ffa9:	0f 05	syscall
 +  45ffa4:	<trampoline-jmp+0x894>
-+  45ffa9:	90                   	nop
-+  45ffaa:	90                   	nop
-   45ffab:	48 8d 3d 6e ab 04 00 	lea    0x4ab6e(%rip),%rdi        # 4aab20 <_dl_load_lock>
-   45ffb2:	44 89 8d 44 ff ff ff 	mov    %r9d,-0xbc(%rbp)
-   45ffb9:	4c 89 85 48 ff ff ff 	mov    %r8,-0xb8(%rbp)
-@@ -100864,8 +100956,7 @@
-   463062:	45 31 d2             	xor    %r10d,%r10d
-   463065:	ba 02 00 00 00       	mov    $0x2,%edx
-   46306a:	be 80 00 00 00       	mov    $0x80,%esi
--  46306f:	44 89 c8             	mov    %r9d,%eax
--  463072:	0f 05                	syscall
++  45ffa9:	90	nop
++  45ffaa:	90	nop
+   45ffab:	48 8d 3d 6e ab 04 00	lea 0x4ab6e(%rip),%rdi
+   45ffb2:	44 89 8d 44 ff ff ff	mov %r9d,-0xbc(%rbp)
+   45ffb9:	4c 89 85 48 ff ff ff	mov %r8,-0xb8(%rbp)
+@@ -100861,8 +100953,7 @@
+   463062:	45 31 d2	xor %r10d,%r10d
+   463065:	ba 02 00 00 00	mov $0x2,%edx
+   46306a:	be 80 00 00 00	mov $0x80,%esi
+-  46306f:	44 89 c8	mov %r9d,%eax
+-  463072:	0f 05	syscall
 +  46306f:	<trampoline-jmp+0x8ab>
-   463074:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
-   46307a:	76 dc                	jbe    463058 <__thread_gscope_wait+0x88>
-   46307c:	83 f8 f5             	cmp    $0xfffffff5,%eax
-@@ -100904,8 +100995,7 @@
-   463102:	45 31 d2             	xor    %r10d,%r10d
-   463105:	ba 02 00 00 00       	mov    $0x2,%edx
-   46310a:	be 80 00 00 00       	mov    $0x80,%esi
--  46310f:	44 89 c8             	mov    %r9d,%eax
--  463112:	0f 05                	syscall
+   463074:	48 3d 00 f0 ff ff	cmp $0xfffffffffffff000,%rax
+   46307a:	76 dc	jbe 463058 <__thread_gscope_wait+0x88>
+   46307c:	83 f8 f5	cmp $0xfffffff5,%eax
+@@ -100901,8 +100992,7 @@
+   463102:	45 31 d2	xor %r10d,%r10d
+   463105:	ba 02 00 00 00	mov $0x2,%edx
+   46310a:	be 80 00 00 00	mov $0x80,%esi
+-  46310f:	44 89 c8	mov %r9d,%eax
+-  463112:	0f 05	syscall
 +  46310f:	<trampoline-jmp+0x8c0>
-   463114:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
-   46311a:	76 dc                	jbe    4630f8 <__thread_gscope_wait+0x128>
-   46311c:	83 f8 f5             	cmp    $0xfffffff5,%eax
-@@ -104731,8 +104821,11 @@
-   4669cc:	0f 1f 40 00          	nopl   0x0(%rax)
+   463114:	48 3d 00 f0 ff ff	cmp $0xfffffffffffff000,%rax
+   46311a:	76 dc	jbe 4630f8 <__thread_gscope_wait+0x128>
+   46311c:	83 f8 f5	cmp $0xfffffff5,%eax
+@@ -104728,8 +104818,11 @@
+   4669cc:	0f 1f 40 00	nopl 0x0(%rax)
  
  00000000004669d0 <__restore_rt>:
--  4669d0:	48 c7 c0 0f 00 00 00 	mov    $0xf,%rax
--  4669d7:	0f 05                	syscall
+-  4669d0:	48 c7 c0 0f 00 00 00	mov $0xf,%rax
+-  4669d7:	0f 05	syscall
 +  4669d0:	<trampoline-jmp+0x8d5>
-+  4669d5:	90                   	nop
-+  4669d6:	90                   	nop
-+  4669d7:	90                   	nop
-+  4669d8:	90                   	nop
-   4669d9:	0f 1f 80 00 00 00 00 	nopl   0x0(%rax)
++  4669d5:	90	nop
++  4669d6:	90	nop
++  4669d7:	90	nop
++  4669d8:	90	nop
+   4669d9:	0f 1f 80 00 00 00 00	nopl 0x0(%rax)
  
  00000000004669e0 <__libc_sigaction>:
-@@ -104776,8 +104869,9 @@
-   466a9f:	0f 11 b5 38 ff ff ff 	movups %xmm6,-0xc8(%rbp)
-   466aa6:	0f 11 bd 48 ff ff ff 	movups %xmm7,-0xb8(%rbp)
-   466aad:	41 ba 08 00 00 00    	mov    $0x8,%r10d
--  466ab3:	b8 0d 00 00 00       	mov    $0xd,%eax
--  466ab8:	0f 05                	syscall
+@@ -104773,8 +104866,9 @@
+   466a9f:	0f 11 b5 38 ff ff ff	movups %xmm6,-0xc8(%rbp)
+   466aa6:	0f 11 bd 48 ff ff ff	movups %xmm7,-0xb8(%rbp)
+   466aad:	41 ba 08 00 00 00	mov $0x8,%r10d
+-  466ab3:	b8 0d 00 00 00	mov $0xd,%eax
+-  466ab8:	0f 05	syscall
 +  466ab3:	<trampoline-jmp+0x8ee>
-+  466ab8:	90                   	nop
-+  466ab9:	90                   	nop
-   466aba:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
-   466ac0:	0f 87 ba 00 00 00    	ja     466b80 <__libc_sigaction+0x1a0>
-   466ac6:	89 c2                	mov    %eax,%edx
-@@ -111544,8 +111638,7 @@
-   46cb11:	45 31 d2             	xor    %r10d,%r10d
-   46cb14:	89 ca                	mov    %ecx,%edx
-   46cb16:	be 80 00 00 00       	mov    $0x80,%esi
--  46cb1b:	44 89 c0             	mov    %r8d,%eax
--  46cb1e:	0f 05                	syscall
++  466ab8:	90	nop
++  466ab9:	90	nop
+   466aba:	48 3d 00 f0 ff ff	cmp $0xfffffffffffff000,%rax
+   466ac0:	0f 87 ba 00 00 00	ja 466b80 <__libc_sigaction+0x1a0>
+   466ac6:	89 c2	mov %eax,%edx
+@@ -111541,8 +111635,7 @@
+   46cb11:	45 31 d2	xor %r10d,%r10d
+   46cb14:	89 ca	mov %ecx,%edx
+   46cb16:	be 80 00 00 00	mov $0x80,%esi
+-  46cb1b:	44 89 c0	mov %r8d,%eax
+-  46cb1e:	0f 05	syscall
 +  46cb1b:	<trampoline-jmp+0x905>
-   46cb20:	48 3d 00 f0 ff ff    	cmp    $0xfffffffffffff000,%rax
-   46cb26:	77 0d                	ja     46cb35 <__pthread_disable_asynccancel+0x65>
-   46cb28:	8b 0f                	mov    (%rdi),%ecx
-@@ -111701,8 +111794,7 @@
-   46ccd5:	81 f6 00 01 00 00    	xor    $0x100,%esi
-   46ccdb:	40 80 ce 89          	or     $0x89,%sil
-   46ccdf:	44 31 c6             	xor    %r8d,%esi
--  46cce2:	45 31 c0             	xor    %r8d,%r8d
--  46cce5:	0f 05                	syscall
+   46cb20:	48 3d 00 f0 ff ff	cmp $0xfffffffffffff000,%rax
+   46cb26:	77 0d	ja 46cb35 <__pthread_disable_asynccancel+0x65>
+   46cb28:	8b 0f	mov (%rdi),%ecx
+@@ -111698,8 +111791,7 @@
+   46ccd5:	81 f6 00 01 00 00	xor $0x100,%esi
+   46ccdb:	40 80 ce 89	or $0x89,%sil
+   46ccdf:	44 31 c6	xor %r8d,%esi
+-  46cce2:	45 31 c0	xor %r8d,%r8d
+-  46cce5:	0f 05	syscall
 +  46cce2:	<trampoline-jmp+0x91a>
-   46cce7:	85 c0                	test   %eax,%eax
-   46cce9:	7f 27                	jg     46cd12 <__futex_abstimed_wait64+0x62>
-   46cceb:	83 f8 ea             	cmp    $0xffffffea,%eax
-@@ -111756,8 +111848,9 @@
-   46cd83:	45 31 c0             	xor    %r8d,%r8d
-   46cd86:	49 89 ca             	mov    %rcx,%r10
-   46cd89:	44 89 e2             	mov    %r12d,%edx
--  46cd8c:	b8 ca 00 00 00       	mov    $0xca,%eax
--  46cd91:	0f 05                	syscall
+   46cce7:	85 c0	test %eax,%eax
+   46cce9:	7f 27	jg 46cd12 <__futex_abstimed_wait64+0x62>
+   46cceb:	83 f8 ea	cmp $0xffffffea,%eax
+@@ -111753,8 +111845,9 @@
+   46cd83:	45 31 c0	xor %r8d,%r8d
+   46cd86:	49 89 ca	mov %rcx,%r10
+   46cd89:	44 89 e2	mov %r12d,%edx
+-  46cd8c:	b8 ca 00 00 00	mov $0xca,%eax
+-  46cd91:	0f 05	syscall
 +  46cd8c:	<trampoline-jmp+0x92f>
-+  46cd91:	90                   	nop
-+  46cd92:	90                   	nop
-   46cd93:	48 89 c3             	mov    %rax,%rbx
-   46cd96:	89 d8                	mov    %ebx,%eax
-   46cd98:	85 db                	test   %ebx,%ebx
-@@ -111802,8 +111895,9 @@
-   46ce0d:	48 8b 7d d0          	mov    -0x30(%rbp),%rdi
-   46ce11:	41 b9 ff ff ff ff    	mov    $0xffffffff,%r9d
-   46ce17:	44 89 e2             	mov    %r12d,%edx
--  46ce1a:	b8 ca 00 00 00       	mov    $0xca,%eax
--  46ce1f:	0f 05                	syscall
++  46cd91:	90	nop
++  46cd92:	90	nop
+   46cd93:	48 89 c3	mov %rax,%rbx
+   46cd96:	89 d8	mov %ebx,%eax
+   46cd98:	85 db	test %ebx,%ebx
+@@ -111799,8 +111892,9 @@
+   46ce0d:	48 8b 7d d0	mov -0x30(%rbp),%rdi
+   46ce11:	41 b9 ff ff ff ff	mov $0xffffffff,%r9d
+   46ce17:	44 89 e2	mov %r12d,%edx
+-  46ce1a:	b8 ca 00 00 00	mov $0xca,%eax
+-  46ce1f:	0f 05	syscall
 +  46ce1a:	<trampoline-jmp+0x946>
-+  46ce1f:	90                   	nop
-+  46ce20:	90                   	nop
-   46ce21:	44 89 ef             	mov    %r13d,%edi
-   46ce24:	48 89 c3             	mov    %rax,%rbx
-   46ce27:	e8 a4 fc ff ff       	call   46cad0 <__pthread_disable_asynccancel>
-@@ -111827,8 +111921,9 @@
-   46ce66:	48 85 d2             	test   %rdx,%rdx
-   46ce69:	0f 45 f1             	cmovne %ecx,%esi
-   46ce6c:	31 d2                	xor    %edx,%edx
--  46ce6e:	b8 ca 00 00 00       	mov    $0xca,%eax
--  46ce73:	0f 05                	syscall
++  46ce1f:	90	nop
++  46ce20:	90	nop
+   46ce21:	44 89 ef	mov %r13d,%edi
+   46ce24:	48 89 c3	mov %rax,%rbx
+   46ce27:	e8 a4 fc ff ff	call 46cad0 <__pthread_disable_asynccancel>
+@@ -111824,8 +111918,9 @@
+   46ce66:	48 85 d2	test %rdx,%rdx
+   46ce69:	0f 45 f1	cmovne %ecx,%esi
+   46ce6c:	31 d2	xor %edx,%edx
+-  46ce6e:	b8 ca 00 00 00	mov $0xca,%eax
+-  46ce73:	0f 05	syscall
 +  46ce6e:	<trampoline-jmp+0x95d>
-+  46ce73:	90                   	nop
-+  46ce74:	90                   	nop
-   46ce75:	83 f8 da             	cmp    $0xffffffda,%eax
-   46ce78:	74 26                	je     46cea0 <__futex_lock_pi64+0x50>
-   46ce7a:	83 f8 92             	cmp    $0xffffff92,%eax
-@@ -114436,8 +114531,9 @@
++  46ce73:	90	nop
++  46ce74:	90	nop
+   46ce75:	83 f8 da	cmp $0xffffffda,%eax
+   46ce78:	74 26	je 46cea0 <__futex_lock_pi64+0x50>
+   46ce7a:	83 f8 92	cmp $0xffffff92,%eax
+@@ -114433,8 +114528,9 @@
  000000000046f340 <__GI___fstatat>:
-   46f340:	f3 0f 1e fa          	endbr64
-   46f344:	41 89 ca             	mov    %ecx,%r10d
--  46f347:	b8 06 01 00 00       	mov    $0x106,%eax
--  46f34c:	0f 05                	syscall
+   46f340:	f3 0f 1e fa	endbr64
+   46f344:	41 89 ca	mov %ecx,%r10d
+-  46f347:	b8 06 01 00 00	mov $0x106,%eax
+-  46f34c:	0f 05	syscall
 +  46f347:	<trampoline-jmp+0x974>
-+  46f34c:	90                   	nop
-+  46f34d:	90                   	nop
-   46f34e:	3d 00 f0 ff ff       	cmp    $0xfffff000,%eax
-   46f353:	77 0b                	ja     46f360 <__GI___fstatat+0x20>
-   46f355:	31 c0                	xor    %eax,%eax
-@@ -117945,8 +118041,9 @@
-   47296c:	64 48 8b 04 25 10 00 	mov    %fs:0x10,%rax
++  46f34c:	90	nop
++  46f34d:	90	nop
+   46f34e:	3d 00 f0 ff ff	cmp $0xfffff000,%eax
+   46f353:	77 0b	ja 46f360 <__gi___fstatat+0x20>
+   46f355:	31 c0	xor %eax,%eax
+@@ -117942,8 +118038,9 @@
+   47296c:	64 48 8b 04 25 10 00	mov %fs:0x10,%rax
    472973:	00 00
-   472975:	48 8d 78 1c          	lea    0x1c(%rax),%rdi
--  472979:	b8 ca 00 00 00       	mov    $0xca,%eax
--  47297e:	0f 05                	syscall
+   472975:	48 8d 78 1c	lea 0x1c(%rax),%rdi
+-  472979:	b8 ca 00 00 00	mov $0xca,%eax
+-  47297e:	0f 05	syscall
 +  472979:	<trampoline-jmp+0x98b>
-+  47297e:	90                   	nop
-+  47297f:	90                   	nop
-   472980:	eb 8c                	jmp    47290e <_dl_fixup+0x10e>
-   472982:	66 0f 1f 44 00 00    	nopw   0x0(%rax,%rax,1)
-   472988:	31 c0                	xor    %eax,%eax
-@@ -122353,8 +122450,9 @@
-   476c07:	64 48 8b 04 25 10 00 	mov    %fs:0x10,%rax
++  47297e:	90	nop
++  47297f:	90	nop
+   472980:	eb 8c	jmp 47290e <_dl_fixup+0x10e>
+   472982:	66 0f 1f 44 00 00	nopw 0x0(%rax,%rax,1)
+   472988:	31 c0	xor %eax,%eax
+@@ -122350,8 +122447,9 @@
+   476c07:	64 48 8b 04 25 10 00	mov %fs:0x10,%rax
    476c0e:	00 00
-   476c10:	48 8d 78 1c          	lea    0x1c(%rax),%rdi
--  476c14:	b8 ca 00 00 00       	mov    $0xca,%eax
--  476c19:	0f 05                	syscall
+   476c10:	48 8d 78 1c	lea 0x1c(%rax),%rdi
+-  476c14:	b8 ca 00 00 00	mov $0xca,%eax
+-  476c19:	0f 05	syscall
 +  476c14:	<trampoline-jmp+0x9a2>
-+  476c19:	90                   	nop
-+  476c1a:	90                   	nop
-   476c1b:	48 83 7d 98 00       	cmpq   $0x0,-0x68(%rbp)
-   476c20:	48 8b 4d b0          	mov    -0x50(%rbp),%rcx
-   476c24:	0f 84 ae fd ff ff    	je     4769d8 <_dl_vsym+0xb8>
-@@ -122513,8 +122611,9 @@
-   476e41:	64 48 8b 04 25 10 00 	mov    %fs:0x10,%rax
++  476c19:	90	nop
++  476c1a:	90	nop
+   476c1b:	48 83 7d 98 00	cmpq $0x0,-0x68(%rbp)
+   476c20:	48 8b 4d b0	mov -0x50(%rbp),%rcx
+   476c24:	0f 84 ae fd ff ff	je 4769d8 <_dl_vsym+0xb8>
+@@ -122510,8 +122608,9 @@
+   476e41:	64 48 8b 04 25 10 00	mov %fs:0x10,%rax
    476e48:	00 00
-   476e4a:	48 8d 78 1c          	lea    0x1c(%rax),%rdi
--  476e4e:	b8 ca 00 00 00       	mov    $0xca,%eax
--  476e53:	0f 05                	syscall
+   476e4a:	48 8d 78 1c	lea 0x1c(%rax),%rdi
+-  476e4e:	b8 ca 00 00 00	mov $0xca,%eax
+-  476e53:	0f 05	syscall
 +  476e4e:	<trampoline-jmp+0x9b9>
-+  476e53:	90                   	nop
-+  476e54:	90                   	nop
-   476e55:	48 83 7d 98 00       	cmpq   $0x0,-0x68(%rbp)
-   476e5a:	48 8b 4d b0          	mov    -0x50(%rbp),%rcx
-   476e5e:	0f 84 3c fe ff ff    	je     476ca0 <_dl_sym+0x60>
++  476e53:	90	nop
++  476e54:	90	nop
+   476e55:	48 83 7d 98 00	cmpq $0x0,-0x68(%rbp)
+   476e5a:	48 8b 4d b0	mov -0x50(%rbp),%rcx
+   476e5e:	0f 84 3c fe ff ff	je 476ca0 <_dl_sym+0x60>


### PR DESCRIPTION
This allows more consistent results across different machines with differing toolchains of objdump, which could otherwise have spurious failures.  Primarily only impacts whitespace changes, but also normalizes out the comments