### PR TITLE
Move broker control traffic to shared-memory rings

### DIFF
--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -18,7 +18,7 @@ use alloc::vec::Vec;
 
 use litebox_broker_core::{BrokerCore, BrokerSession, CallerCredential};
 use litebox_broker_protocol::channel::{
-    HostControlChannel, HostNotificationChannel, HostReceive, PeerCredential,
+    HostControlChannel, HostNotificationChannel, HostReceive, HostSetupChannel, PeerCredential,
 };
 use litebox_broker_protocol::error::ErrorCode;
 use litebox_broker_protocol::event::{AddEventResponse, CreateEventResponse};
@@ -137,7 +137,7 @@ pub fn setup_connection<'a, ControlChannel, Memory, ChannelError>(
     send_shared_memory: impl FnOnce(&mut ControlChannel) -> core::result::Result<(), ChannelError>,
 ) -> Result<ConnectionSetup<'a, Memory>, ChannelError>
 where
-    ControlChannel: HostControlChannel<Error = ChannelError>,
+    ControlChannel: HostSetupChannel<Error = ChannelError>,
     Memory: SharedMemory,
 {
     if shared_buffers.layout() != SHARED_BUFFER_LAYOUT {
@@ -1228,7 +1228,7 @@ mod tests {
         }
     }
 
-    impl HostControlChannel for FakeHostControlChannel {
+    impl HostSetupChannel for FakeHostControlChannel {
         type Error = ();
 
         fn peer_credential(&self) -> core::result::Result<PeerCredential, Self::Error> {
@@ -1252,7 +1252,9 @@ mod tests {
             self.handshake_responses.push(response.clone());
             Ok(())
         }
+    }
 
+    impl HostControlChannel for FakeHostControlChannel {
         fn recv_request(
             &mut self,
         ) -> core::result::Result<HostReceive<BrokerRequest>, Self::Error> {

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -17,9 +17,7 @@ extern crate std;
 use alloc::vec::Vec;
 
 use litebox_broker_core::{BrokerCore, BrokerSession, CallerCredential};
-use litebox_broker_protocol::channel::{
-    HostControlChannel, HostNotificationChannel, HostReceive, HostSetupChannel, PeerCredential,
-};
+use litebox_broker_protocol::channel::{HostReceive, HostSetupChannel, PeerCredential};
 use litebox_broker_protocol::error::ErrorCode;
 use litebox_broker_protocol::event::{AddEventResponse, CreateEventResponse};
 use litebox_broker_protocol::message::{
@@ -197,52 +195,6 @@ where
             }));
         }
     }
-}
-
-/// Authenticates, negotiates, and serves one broker association over paired
-/// control and notification channels.
-///
-/// The deployment must bind both channels to the same authenticated peer
-/// association. Active requests and responses remain on the control channel;
-/// broker-initiated readiness wakeups are sent on the notification channel.
-/// Event mutations caused by control requests return readiness in their control
-/// response and do not also emit a duplicate notification.
-///
-/// `shared_buffers` belongs to this association. Payload descriptors are
-/// validated against trusted per-slot claim state. `send_shared_memory` runs
-/// after version negotiation and before active requests begin.
-pub fn serve_connection<ControlChannel, NotificationChannel, Memory, ChannelError>(
-    core: &BrokerCore,
-    control_channel: &mut ControlChannel,
-    _notification_channel: &mut NotificationChannel,
-    shared_buffers: &SharedBufferPool<Memory>,
-    send_shared_memory: impl FnOnce(&mut ControlChannel) -> core::result::Result<(), ChannelError>,
-) -> Result<ConnectionTermination, ChannelError>
-where
-    ControlChannel: HostControlChannel<Error = ChannelError>,
-    NotificationChannel: HostNotificationChannel<Error = ChannelError>,
-    Memory: SharedMemory,
-{
-    let association =
-        match setup_connection(core, control_channel, shared_buffers, send_shared_memory)? {
-            Ok(association) => association,
-            Err(termination) => return Ok(termination),
-        };
-    loop {
-        let request = match control_channel
-            .recv_request()
-            .map_err(BrokerHostError::Channel)?
-        {
-            HostReceive::Message(request) => request,
-            HostReceive::ProtocolViolation => {
-                return Ok(ConnectionTermination::ProtocolViolation);
-            }
-            HostReceive::PeerClosed => break,
-        };
-        association.execute_request(request, |response| control_channel.send_response(response))?;
-    }
-
-    Ok(ConnectionTermination::PeerClosed)
 }
 
 type RequestResult<T> = core::result::Result<T, RequestFailure>;
@@ -440,11 +392,10 @@ mod tests {
     use super::*;
     use core::cell::Cell;
     use litebox_broker_core::{ObjectRights, PolicyEngine};
-    use litebox_broker_protocol::channel::HostControlChannel;
     use litebox_broker_protocol::event::{
         AddEventRequest, ConsumeEventRequest, CreateEventRequest, EventConsumeMode,
     };
-    use litebox_broker_protocol::message::{BrokerHandshakeRequest, BrokerNotification};
+    use litebox_broker_protocol::message::BrokerHandshakeRequest;
     use litebox_broker_protocol::pipe::{CreatePipeRequest, ReadPipeRequest, WritePipeRequest};
     use litebox_broker_protocol::shared_memory::{
         SHARED_BUFFER_LAYOUT, SHARED_BUFFER_POOL_SIZE, SHARED_BUFFER_SLOT_SIZE,
@@ -461,17 +412,17 @@ mod tests {
         ))
         .unwrap();
 
-        serve_connection_negotiates_routes_one_request_and_returns_peer_closed(&broker);
-        serve_connection_retries_after_version_mismatch(&broker);
-        serve_connection_skips_setup_after_version_mismatch(&broker);
-        serve_connection_rejects_active_request_before_negotiation(&broker);
-        serve_connection_rejects_handshake_request_after_negotiation(&broker);
-        serve_connection_returns_channel_error_when_response_send_fails(&broker);
-        serve_connection_returns_event_readiness_in_control_responses(&broker);
-        serve_connection_continues_after_recoverable_request_failure(&broker);
-        serve_connection_aborts_on_stale_shared_buffer_request(&broker);
-        serve_connection_aborts_without_response_on_shared_memory_failure(&broker);
-        serve_connection_rejects_incompatible_shared_buffer_layout(&broker);
+        test_channel_negotiates_routes_one_request_and_returns_peer_closed(&broker);
+        test_channel_retries_after_version_mismatch(&broker);
+        test_channel_skips_setup_after_version_mismatch(&broker);
+        test_channel_rejects_active_request_before_negotiation(&broker);
+        test_channel_rejects_handshake_request_after_negotiation(&broker);
+        test_channel_returns_channel_error_when_response_send_fails(&broker);
+        test_channel_returns_event_readiness_in_control_responses(&broker);
+        test_channel_continues_after_recoverable_request_failure(&broker);
+        test_channel_aborts_on_stale_shared_buffer_request(&broker);
+        test_channel_aborts_without_response_on_shared_memory_failure(&broker);
+        test_channel_rejects_incompatible_shared_buffer_layout(&broker);
         active_request_closes_object_reference(&broker);
         association_shared_buffer_descriptors_stage_pipe_data(&broker);
         shared_buffer_usage_rejects_invalid_descriptors();
@@ -480,7 +431,7 @@ mod tests {
         association_allows_out_of_order_responses(&broker);
     }
 
-    fn serve_connection_negotiates_routes_one_request_and_returns_peer_closed(broker: &BrokerCore) {
+    fn test_channel_negotiates_routes_one_request_and_returns_peer_closed(broker: &BrokerCore) {
         let mut channel = FakeHostControlChannel::new(
             std::vec::Vec::from([Ok(HostReceive::Message(BrokerHandshakeRequest {
                 protocol_version: BROKER_PROTOCOL_VERSION,
@@ -493,17 +444,8 @@ mod tests {
             ]),
         );
         channel.next_request_id = 41;
-        let mut notifications = FakeHostNotificationChannel::default();
-
         assert_eq!(
-            serve_connection(
-                broker,
-                &mut channel,
-                &mut notifications,
-                &test_shared_buffers(),
-                |_| Ok(()),
-            )
-            .unwrap(),
+            serve_test_channel(broker, &mut channel, &test_shared_buffers(), |_| Ok(())).unwrap(),
             ConnectionTermination::PeerClosed
         );
         assert_eq!(
@@ -520,7 +462,7 @@ mod tests {
         assert_eq!(channel.response_ids, [RequestId(41)]);
     }
 
-    fn serve_connection_retries_after_version_mismatch(broker: &BrokerCore) {
+    fn test_channel_retries_after_version_mismatch(broker: &BrokerCore) {
         let mut channel = FakeHostControlChannel::new(
             std::vec::Vec::from([
                 Ok(HostReceive::Message(BrokerHandshakeRequest {
@@ -532,17 +474,8 @@ mod tests {
             ]),
             std::vec::Vec::from([Ok(HostReceive::PeerClosed)]),
         );
-        let mut notifications = FakeHostNotificationChannel::default();
-
         assert_eq!(
-            serve_connection(
-                broker,
-                &mut channel,
-                &mut notifications,
-                &test_shared_buffers(),
-                |_| Ok(()),
-            )
-            .unwrap(),
+            serve_test_channel(broker, &mut channel, &test_shared_buffers(), |_| Ok(())).unwrap(),
             ConnectionTermination::PeerClosed
         );
         assert_eq!(
@@ -558,7 +491,7 @@ mod tests {
         );
     }
 
-    fn serve_connection_skips_setup_after_version_mismatch(broker: &BrokerCore) {
+    fn test_channel_skips_setup_after_version_mismatch(broker: &BrokerCore) {
         let mut channel = FakeHostControlChannel::new(
             std::vec::Vec::from([
                 Ok(HostReceive::Message(BrokerHandshakeRequest {
@@ -568,20 +501,13 @@ mod tests {
             ]),
             std::vec::Vec::new(),
         );
-        let mut notifications = FakeHostNotificationChannel::default();
         let setup_called = Cell::new(false);
 
         assert_eq!(
-            serve_connection(
-                broker,
-                &mut channel,
-                &mut notifications,
-                &test_shared_buffers(),
-                |_| {
-                    setup_called.set(true);
-                    Ok(())
-                },
-            )
+            serve_test_channel(broker, &mut channel, &test_shared_buffers(), |_| {
+                setup_called.set(true);
+                Ok(())
+            })
             .unwrap(),
             ConnectionTermination::PeerClosed
         );
@@ -594,22 +520,13 @@ mod tests {
         assert!(!setup_called.get());
     }
 
-    fn serve_connection_rejects_active_request_before_negotiation(broker: &BrokerCore) {
+    fn test_channel_rejects_active_request_before_negotiation(broker: &BrokerCore) {
         let mut channel = FakeHostControlChannel::new(
             std::vec::Vec::from([Ok(HostReceive::ProtocolViolation)]),
             std::vec::Vec::new(),
         );
-        let mut notifications = FakeHostNotificationChannel::default();
-
         assert_eq!(
-            serve_connection(
-                broker,
-                &mut channel,
-                &mut notifications,
-                &test_shared_buffers(),
-                |_| Ok(()),
-            )
-            .unwrap(),
+            serve_test_channel(broker, &mut channel, &test_shared_buffers(), |_| Ok(())).unwrap(),
             ConnectionTermination::ProtocolViolation
         );
         assert_eq!(
@@ -619,24 +536,15 @@ mod tests {
         assert!(channel.results.is_empty());
     }
 
-    fn serve_connection_rejects_handshake_request_after_negotiation(broker: &BrokerCore) {
+    fn test_channel_rejects_handshake_request_after_negotiation(broker: &BrokerCore) {
         let mut channel = FakeHostControlChannel::new(
             std::vec::Vec::from([Ok(HostReceive::Message(BrokerHandshakeRequest {
                 protocol_version: BROKER_PROTOCOL_VERSION,
             }))]),
             std::vec::Vec::from([Ok(HostReceive::ProtocolViolation)]),
         );
-        let mut notifications = FakeHostNotificationChannel::default();
-
         assert_eq!(
-            serve_connection(
-                broker,
-                &mut channel,
-                &mut notifications,
-                &test_shared_buffers(),
-                |_| Ok(()),
-            )
-            .unwrap(),
+            serve_test_channel(broker, &mut channel, &test_shared_buffers(), |_| Ok(())).unwrap(),
             ConnectionTermination::ProtocolViolation
         );
         assert_eq!(
@@ -648,7 +556,7 @@ mod tests {
         assert!(channel.results.is_empty());
     }
 
-    fn serve_connection_returns_channel_error_when_response_send_fails(broker: &BrokerCore) {
+    fn test_channel_returns_channel_error_when_response_send_fails(broker: &BrokerCore) {
         let mut channel = FakeHostControlChannel::new(
             std::vec::Vec::from([Ok(HostReceive::Message(BrokerHandshakeRequest {
                 protocol_version: BROKER_PROTOCOL_VERSION,
@@ -658,15 +566,7 @@ mod tests {
             )))]),
         );
         channel.response_send_error = true;
-        let mut notifications = FakeHostNotificationChannel::default();
-
-        match serve_connection(
-            broker,
-            &mut channel,
-            &mut notifications,
-            &test_shared_buffers(),
-            |_| Ok(()),
-        ) {
+        match serve_test_channel(broker, &mut channel, &test_shared_buffers(), |_| Ok(())) {
             Err(BrokerHostError::Channel(())) => {}
             result => panic!("unexpected serve result: {result:?}"),
         }
@@ -674,7 +574,7 @@ mod tests {
         assert!(channel.results.is_empty());
     }
 
-    fn serve_connection_returns_event_readiness_in_control_responses(broker: &BrokerCore) {
+    fn test_channel_returns_event_readiness_in_control_responses(broker: &BrokerCore) {
         let mut channel = FakeHostControlChannel::new(
             std::vec::Vec::from([Ok(HostReceive::Message(BrokerHandshakeRequest {
                 protocol_version: BROKER_PROTOCOL_VERSION,
@@ -684,20 +584,10 @@ mod tests {
             )))]),
         );
         channel.enqueue_readiness_requests_after_create = true;
-        let mut notifications = FakeHostNotificationChannel::default();
-
         assert_eq!(
-            serve_connection(
-                broker,
-                &mut channel,
-                &mut notifications,
-                &test_shared_buffers(),
-                |_| Ok(()),
-            )
-            .unwrap(),
+            serve_test_channel(broker, &mut channel, &test_shared_buffers(), |_| Ok(())).unwrap(),
             ConnectionTermination::PeerClosed
         );
-        assert!(notifications.notifications.is_empty());
         assert_eq!(
             &channel.results[1..],
             [
@@ -715,7 +605,7 @@ mod tests {
         );
     }
 
-    fn serve_connection_continues_after_recoverable_request_failure(broker: &BrokerCore) {
+    fn test_channel_continues_after_recoverable_request_failure(broker: &BrokerCore) {
         let mut channel = FakeHostControlChannel::new(
             std::vec::Vec::from([Ok(HostReceive::Message(BrokerHandshakeRequest {
                 protocol_version: BROKER_PROTOCOL_VERSION,
@@ -733,17 +623,8 @@ mod tests {
                 Ok(HostReceive::PeerClosed),
             ]),
         );
-        let mut notifications = FakeHostNotificationChannel::default();
-
         assert_eq!(
-            serve_connection(
-                broker,
-                &mut channel,
-                &mut notifications,
-                &test_shared_buffers(),
-                |_| Ok(()),
-            )
-            .unwrap(),
+            serve_test_channel(broker, &mut channel, &test_shared_buffers(), |_| Ok(())).unwrap(),
             ConnectionTermination::PeerClosed
         );
         assert_eq!(
@@ -757,7 +638,7 @@ mod tests {
         assert_eq!(channel.response_ids, [RequestId(0), RequestId(1)]);
     }
 
-    fn serve_connection_aborts_on_stale_shared_buffer_request(broker: &BrokerCore) {
+    fn test_channel_aborts_on_stale_shared_buffer_request(broker: &BrokerCore) {
         let stale_request = BrokerOperation::Pipe(PipeRequest::Read(ReadPipeRequest {
             handle: ObjectHandle(u64::MAX),
             buffer: descriptor(0, 1),
@@ -772,16 +653,8 @@ mod tests {
             ]),
         );
         channel.request_id_step = 0;
-        let mut notifications = FakeHostNotificationChannel::default();
-
         assert!(matches!(
-            serve_connection(
-                broker,
-                &mut channel,
-                &mut notifications,
-                &test_shared_buffers(),
-                |_| Ok(()),
-            ),
+            serve_test_channel(broker, &mut channel, &test_shared_buffers(), |_| Ok(())),
             Err(BrokerHostError::Broker(ErrorCode::MalformedRequest))
         ));
         assert_eq!(
@@ -791,7 +664,7 @@ mod tests {
         assert_eq!(channel.response_ids, [RequestId(0)]);
     }
 
-    fn serve_connection_aborts_without_response_on_shared_memory_failure(broker: &BrokerCore) {
+    fn test_channel_aborts_without_response_on_shared_memory_failure(broker: &BrokerCore) {
         let mut channel = FakeHostControlChannel::new(
             std::vec::Vec::from([Ok(HostReceive::Message(BrokerHandshakeRequest {
                 protocol_version: BROKER_PROTOCOL_VERSION,
@@ -804,13 +677,10 @@ mod tests {
             )))]),
         );
         channel.enqueue_write_request_after_pipe_create = true;
-        let mut notifications = FakeHostNotificationChannel::default();
-
         assert!(matches!(
-            serve_connection(
+            serve_test_channel(
                 broker,
                 &mut channel,
-                &mut notifications,
                 &SharedBufferPool::new(FailingSharedMemory, SHARED_BUFFER_LAYOUT).unwrap(),
                 |_| Ok(()),
             ),
@@ -823,14 +693,13 @@ mod tests {
         ));
     }
 
-    fn serve_connection_rejects_incompatible_shared_buffer_layout(broker: &BrokerCore) {
+    fn test_channel_rejects_incompatible_shared_buffer_layout(broker: &BrokerCore) {
         let mut channel = FakeHostControlChannel::new(
             std::vec::Vec::from([Ok(HostReceive::Message(BrokerHandshakeRequest {
                 protocol_version: BROKER_PROTOCOL_VERSION,
             }))]),
             std::vec::Vec::new(),
         );
-        let mut notifications = FakeHostNotificationChannel::default();
         let incompatible_layout = litebox_broker_protocol::shared_memory::SharedBufferLayout::new(
             u32::try_from(SHARED_BUFFER_POOL_SIZE).unwrap(),
             1,
@@ -844,16 +713,10 @@ mod tests {
         let setup_called = Cell::new(false);
 
         assert!(matches!(
-            serve_connection(
-                broker,
-                &mut channel,
-                &mut notifications,
-                &shared_buffers,
-                |_| {
-                    setup_called.set(true);
-                    Ok(())
-                },
-            ),
+            serve_test_channel(broker, &mut channel, &shared_buffers, |_| {
+                setup_called.set(true);
+                Ok(())
+            }),
             Err(BrokerHostError::SharedBufferLayoutMismatch)
         ));
         assert!(!setup_called.get());
@@ -1192,6 +1055,34 @@ mod tests {
         .unwrap()
     }
 
+    fn serve_test_channel<Memory: SharedMemory>(
+        broker: &BrokerCore,
+        control_channel: &mut FakeHostControlChannel,
+        shared_buffers: &SharedBufferPool<Memory>,
+        send_shared_memory: impl FnOnce(&mut FakeHostControlChannel) -> core::result::Result<(), ()>,
+    ) -> Result<ConnectionTermination, ()> {
+        let association =
+            match setup_connection(broker, control_channel, shared_buffers, send_shared_memory)? {
+                Ok(association) => association,
+                Err(termination) => return Ok(termination),
+            };
+        loop {
+            let request = match control_channel
+                .recv_request()
+                .map_err(BrokerHostError::Channel)?
+            {
+                HostReceive::Message(request) => request,
+                HostReceive::ProtocolViolation => {
+                    return Ok(ConnectionTermination::ProtocolViolation);
+                }
+                HostReceive::PeerClosed => break,
+            };
+            association
+                .execute_request(request, |response| control_channel.send_response(response))?;
+        }
+        Ok(ConnectionTermination::PeerClosed)
+    }
+
     struct FakeHostControlChannel {
         handshake_requests:
             std::vec::Vec<core::result::Result<HostReceive<BrokerHandshakeRequest>, ()>>,
@@ -1254,10 +1145,8 @@ mod tests {
         }
     }
 
-    impl HostControlChannel for FakeHostControlChannel {
-        fn recv_request(
-            &mut self,
-        ) -> core::result::Result<HostReceive<BrokerRequest>, Self::Error> {
+    impl FakeHostControlChannel {
+        fn recv_request(&mut self) -> core::result::Result<HostReceive<BrokerRequest>, ()> {
             let received = if self.operations.is_empty() {
                 HostReceive::PeerClosed
             } else {
@@ -1277,10 +1166,7 @@ mod tests {
             })
         }
 
-        fn send_response(
-            &mut self,
-            response: &BrokerResponse,
-        ) -> core::result::Result<(), Self::Error> {
+        fn send_response(&mut self, response: &BrokerResponse) -> core::result::Result<(), ()> {
             if self.response_send_error {
                 return Err(());
             }
@@ -1420,23 +1306,6 @@ mod tests {
             _source: &[u8],
         ) -> core::result::Result<(), SharedMemoryError> {
             Err(SharedMemoryError::InvalidRange)
-        }
-    }
-
-    #[derive(Default)]
-    struct FakeHostNotificationChannel {
-        notifications: std::vec::Vec<BrokerNotification>,
-    }
-
-    impl HostNotificationChannel for FakeHostNotificationChannel {
-        type Error = ();
-
-        fn send_notification(
-            &mut self,
-            notification: &BrokerNotification,
-        ) -> core::result::Result<(), Self::Error> {
-            self.notifications.push(notification.clone());
-            Ok(())
         }
     }
 }

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -128,21 +128,21 @@ impl<Memory: SharedMemory> BrokerHostAssociation<'_, Memory> {
 ///
 /// `send_shared_memory` runs after version negotiation and before the active
 /// association is returned.
-pub fn setup_connection<'a, ControlChannel, Memory, ChannelError>(
+pub fn setup_connection<'a, SetupChannel, Memory, ChannelError>(
     core: &BrokerCore,
-    control_channel: &mut ControlChannel,
+    setup_channel: &mut SetupChannel,
     shared_buffers: &'a SharedBufferPool<Memory>,
-    send_shared_memory: impl FnOnce(&mut ControlChannel) -> core::result::Result<(), ChannelError>,
+    send_shared_memory: impl FnOnce(&mut SetupChannel) -> core::result::Result<(), ChannelError>,
 ) -> Result<ConnectionSetup<'a, Memory>, ChannelError>
 where
-    ControlChannel: HostSetupChannel<Error = ChannelError>,
+    SetupChannel: HostSetupChannel<Error = ChannelError>,
     Memory: SharedMemory,
 {
     if shared_buffers.layout() != SHARED_BUFFER_LAYOUT {
         return Err(BrokerHostError::SharedBufferLayoutMismatch);
     }
 
-    let peer_credential = control_channel
+    let peer_credential = setup_channel
         .peer_credential()
         .map_err(BrokerHostError::Channel)?;
     let caller_credential = match peer_credential {
@@ -152,13 +152,13 @@ where
     };
     let session = core.create_session(caller_credential)?;
     loop {
-        let request = match control_channel
+        let request = match setup_channel
             .recv_handshake_request()
             .map_err(BrokerHostError::Channel)?
         {
             HostReceive::Message(request) => request,
             HostReceive::ProtocolViolation => {
-                control_channel
+                setup_channel
                     .send_handshake_response(&BrokerHandshakeResponse::Error(
                         ErrorCode::ProtocolState,
                     ))
@@ -180,11 +180,11 @@ where
                 broker_protocol_version: BROKER_PROTOCOL_VERSION,
             }
         };
-        control_channel
+        setup_channel
             .send_handshake_response(&response)
             .map_err(BrokerHostError::Channel)?;
         if negotiated {
-            send_shared_memory(control_channel).map_err(BrokerHostError::Channel)?;
+            send_shared_memory(setup_channel).map_err(BrokerHostError::Channel)?;
             return Ok(Ok(BrokerHostAssociation {
                 session,
                 shared_buffers,

--- a/litebox_broker_protocol/src/channel.rs
+++ b/litebox_broker_protocol/src/channel.rs
@@ -83,15 +83,6 @@ pub trait HostSetupChannel {
     ) -> Result<(), Self::Error>;
 }
 
-/// Host-side control channel that carries both setup and active broker calls.
-pub trait HostControlChannel: HostSetupChannel {
-    /// Receives one active broker request.
-    fn recv_request(&mut self) -> Result<HostReceive<BrokerRequest>, Self::Error>;
-
-    /// Sends one active broker response.
-    fn send_response(&mut self, response: &BrokerResponse) -> Result<(), Self::Error>;
-}
-
 /// Local-side receive channel for broker-initiated asynchronous notifications.
 ///
 /// A notification channel is separate from the control channel so active broker
@@ -112,7 +103,7 @@ pub trait LocalNotificationChannel {
 /// Host-side send channel for broker-initiated asynchronous notifications.
 ///
 /// Implementations carry notification frames only; object operation responses
-/// continue to use [`HostControlChannel::send_response`].
+/// remain on the active control transport.
 pub trait HostNotificationChannel {
     /// Channel-specific error type.
     type Error;

--- a/litebox_broker_protocol/src/channel.rs
+++ b/litebox_broker_protocol/src/channel.rs
@@ -20,7 +20,7 @@ pub enum PeerCredential {
     /// Explicit deployment mode for the initial unauthenticated userland POC.
     ///
     /// Channels that are expected to authenticate peers must return an error
-    /// from [`HostControlChannel::peer_credential`] when authentication is
+    /// from [`HostSetupChannel::peer_credential`] when authentication is
     /// unavailable or fails; this variant is only for deployments that
     /// deliberately choose unauthenticated operation.
     Unauthenticated,
@@ -63,8 +63,8 @@ pub trait LocalControlChannel {
     fn call(&self, request: BrokerRequest) -> Result<BrokerResponse, Self::Error>;
 }
 
-/// Host-side control channel for broker authority calls.
-pub trait HostControlChannel {
+/// Host-side channel for broker association setup.
+pub trait HostSetupChannel {
     /// Channel-specific error type.
     type Error;
 
@@ -81,7 +81,10 @@ pub trait HostControlChannel {
         &mut self,
         response: &BrokerHandshakeResponse,
     ) -> Result<(), Self::Error>;
+}
 
+/// Host-side control channel that carries both setup and active broker calls.
+pub trait HostControlChannel: HostSetupChannel {
     /// Receives one active broker request.
     fn recv_request(&mut self) -> Result<HostReceive<BrokerRequest>, Self::Error>;
 

--- a/litebox_broker_protocol/src/pipe.rs
+++ b/litebox_broker_protocol/src/pipe.rs
@@ -4,10 +4,10 @@
 use crate::ObjectHandle;
 use crate::shared_memory::SharedBufferDescriptor;
 
-/// Maximum pipe transfer described by one control-path request or response.
+/// Maximum pipe bytes transferred by one broker request.
 ///
-/// This leaves room for the broker envelope and operation metadata within the
-/// smallest currently supported transport frame.
+/// Each association shared-buffer slot has this size. Larger blocking writes
+/// are split across requests, while reads may return at most this amount.
 pub const MAX_PIPE_TRANSFER_SIZE: u32 = 32 * 1024;
 
 /// Request to create a broker-owned byte pipe.

--- a/litebox_broker_protocol/src/wire.rs
+++ b/litebox_broker_protocol/src/wire.rs
@@ -48,6 +48,9 @@ const RESPONSE_TAG_ERROR: u8 = 7;
 
 const NOTIFICATION_TAG_READINESS: u8 = 0;
 
+/// Maximum byte length of any encoded active request or response.
+pub const MAX_ENCODED_ACTIVE_MESSAGE_SIZE: usize = 26;
+
 /// Error produced while encoding or decoding a broker wire message.
 #[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
 #[non_exhaustive]
@@ -381,17 +384,19 @@ mod tests {
                 },
             })),
         ];
+        let mut maximum_encoded_size = 0;
 
         for operation in operations {
             let request = BrokerRequest {
                 request_id: TEST_REQUEST_ID,
                 operation,
             };
-            assert_eq!(
-                decode_request(&encode_request(request.clone())).unwrap(),
-                request
-            );
+            let encoded = encode_request(request.clone());
+            maximum_encoded_size = maximum_encoded_size.max(encoded.len());
+            assert!(encoded.len() <= MAX_ENCODED_ACTIVE_MESSAGE_SIZE);
+            assert_eq!(decode_request(&encoded).unwrap(), request);
         }
+        assert_eq!(maximum_encoded_size, MAX_ENCODED_ACTIVE_MESSAGE_SIZE);
     }
 
     #[test]
@@ -456,17 +461,19 @@ mod tests {
             BrokerResult::Error(ErrorCode::OutOfMemory),
             BrokerResult::Error(ErrorCode::Internal),
         ];
+        let mut maximum_encoded_size = 0;
 
         for result in results {
             let response = BrokerResponse {
                 request_id: TEST_REQUEST_ID,
                 result,
             };
-            assert_eq!(
-                decode_response(&encode_response(response.clone())).unwrap(),
-                response
-            );
+            let encoded = encode_response(response.clone());
+            maximum_encoded_size = maximum_encoded_size.max(encoded.len());
+            assert!(encoded.len() <= MAX_ENCODED_ACTIVE_MESSAGE_SIZE);
+            assert_eq!(decode_response(&encoded).unwrap(), response);
         }
+        assert_eq!(maximum_encoded_size, MAX_ENCODED_ACTIVE_MESSAGE_SIZE);
     }
 
     #[test]

--- a/litebox_broker_transport/src/control_ring.rs
+++ b/litebox_broker_transport/src/control_ring.rs
@@ -313,6 +313,38 @@ pub struct ControlRingProducer<Memory: AtomicSharedMemory> {
     acknowledged_head: u64,
 }
 
+/// Cloneable, narrow handle for interrupting a wait on one ring endpoint.
+///
+/// This handle intentionally exposes neither the backing memory nor endpoint
+/// state. Hosted transports use it to make liveness and cancellation events
+/// visible to a thread blocked in an OS-specific wait.
+#[cfg(any(test, all(feature = "linux-userland", target_os = "linux")))]
+pub(crate) struct ControlRingWakeHandle<Memory: AtomicSharedMemory> {
+    ring: Arc<ControlRing<Memory>>,
+    wait_epoch_offset: usize,
+}
+
+#[cfg(any(test, all(feature = "linux-userland", target_os = "linux")))]
+impl<Memory: AtomicSharedMemory> Clone for ControlRingWakeHandle<Memory> {
+    fn clone(&self) -> Self {
+        Self {
+            ring: Arc::clone(&self.ring),
+            wait_epoch_offset: self.wait_epoch_offset,
+        }
+    }
+}
+
+#[cfg(any(test, all(feature = "linux-userland", target_os = "linux")))]
+impl<Memory: AtomicSharedMemory> ControlRingWakeHandle<Memory> {
+    pub(crate) const fn wait_epoch_offset(&self) -> usize {
+        self.wait_epoch_offset
+    }
+
+    pub(crate) fn memory(&self) -> &Memory {
+        self.ring.memory()
+    }
+}
+
 impl<Memory: AtomicSharedMemory> ControlRingProducer<Memory> {
     fn new(ring: Arc<ControlRing<Memory>>, direction: ControlRingDirection) -> Self {
         Self {
@@ -326,6 +358,14 @@ impl<Memory: AtomicSharedMemory> ControlRingProducer<Memory> {
     /// Returns the ring direction written by this producer.
     pub const fn direction(&self) -> ControlRingDirection {
         self.direction
+    }
+
+    #[cfg(any(test, all(feature = "linux-userland", target_os = "linux")))]
+    pub(crate) fn wake_handle(&self) -> ControlRingWakeHandle<Memory> {
+        ControlRingWakeHandle {
+            ring: Arc::clone(&self.ring),
+            wait_epoch_offset: self.direction.consumer_epoch_offset(),
+        }
     }
 
     #[cfg(any(test, all(feature = "linux-userland", target_os = "linux")))]
@@ -410,6 +450,14 @@ impl<Memory: AtomicSharedMemory> ControlRingConsumer<Memory> {
     /// Returns the ring direction read by this consumer.
     pub const fn direction(&self) -> ControlRingDirection {
         self.direction
+    }
+
+    #[cfg(any(test, all(feature = "linux-userland", target_os = "linux")))]
+    pub(crate) fn wake_handle(&self) -> ControlRingWakeHandle<Memory> {
+        ControlRingWakeHandle {
+            ring: Arc::clone(&self.ring),
+            wait_epoch_offset: self.direction.producer_epoch_offset(),
+        }
     }
 
     #[cfg(any(test, all(feature = "linux-userland", target_os = "linux")))]

--- a/litebox_broker_transport/src/control_ring.rs
+++ b/litebox_broker_transport/src/control_ring.rs
@@ -14,7 +14,7 @@ use litebox_broker_protocol::shared_memory::SharedMemory;
 use litebox_broker_protocol::shared_memory::{AtomicSharedMemory, SharedMemoryError};
 
 /// Size of one shared control-ring slot.
-pub const CONTROL_RING_SLOT_SIZE: usize = 4096;
+pub const CONTROL_RING_SLOT_SIZE: usize = 128;
 
 /// Size of the fixed metadata at the start of a control-ring slot.
 pub const CONTROL_RING_SLOT_HEADER_SIZE: usize = 16;
@@ -22,6 +22,11 @@ pub const CONTROL_RING_SLOT_HEADER_SIZE: usize = 16;
 /// Maximum encoded request or response size in one control-ring slot.
 pub const CONTROL_RING_PAYLOAD_CAPACITY: usize =
     CONTROL_RING_SLOT_SIZE - CONTROL_RING_SLOT_HEADER_SIZE;
+
+const _: () = assert!(
+    CONTROL_RING_PAYLOAD_CAPACITY >= litebox_broker_protocol::wire::MAX_ENCODED_ACTIVE_MESSAGE_SIZE
+);
+const _: () = assert!(CONTROL_RING_SLOT_SIZE.is_multiple_of(size_of::<u64>()));
 
 /// Number of slots in each direction of the shared control ring.
 pub const CONTROL_RING_SLOT_COUNT: u64 = 64;

--- a/litebox_broker_transport/src/control_ring.rs
+++ b/litebox_broker_transport/src/control_ring.rs
@@ -321,7 +321,24 @@ pub struct ControlRingProducer<Memory: AtomicSharedMemory> {
 #[cfg(any(test, all(feature = "linux-userland", target_os = "linux")))]
 pub(crate) struct ControlRingWakeHandle<Memory: AtomicSharedMemory> {
     ring: Arc<ControlRing<Memory>>,
-    wait_epoch_offset: usize,
+    wait_epoch: ControlRingWaitEpoch,
+}
+
+#[cfg(any(test, all(feature = "linux-userland", target_os = "linux")))]
+#[derive(Clone, Copy)]
+enum ControlRingWaitEpoch {
+    Producer(ControlRingDirection),
+    Consumer(ControlRingDirection),
+}
+
+#[cfg(any(test, all(feature = "linux-userland", target_os = "linux")))]
+impl ControlRingWaitEpoch {
+    const fn offset(self) -> usize {
+        match self {
+            Self::Producer(direction) => direction.producer_epoch_offset(),
+            Self::Consumer(direction) => direction.consumer_epoch_offset(),
+        }
+    }
 }
 
 #[cfg(any(test, all(feature = "linux-userland", target_os = "linux")))]
@@ -329,7 +346,7 @@ impl<Memory: AtomicSharedMemory> Clone for ControlRingWakeHandle<Memory> {
     fn clone(&self) -> Self {
         Self {
             ring: Arc::clone(&self.ring),
-            wait_epoch_offset: self.wait_epoch_offset,
+            wait_epoch: self.wait_epoch,
         }
     }
 }
@@ -337,7 +354,7 @@ impl<Memory: AtomicSharedMemory> Clone for ControlRingWakeHandle<Memory> {
 #[cfg(any(test, all(feature = "linux-userland", target_os = "linux")))]
 impl<Memory: AtomicSharedMemory> ControlRingWakeHandle<Memory> {
     pub(crate) const fn wait_epoch_offset(&self) -> usize {
-        self.wait_epoch_offset
+        self.wait_epoch.offset()
     }
 
     pub(crate) fn memory(&self) -> &Memory {
@@ -364,7 +381,7 @@ impl<Memory: AtomicSharedMemory> ControlRingProducer<Memory> {
     pub(crate) fn wake_handle(&self) -> ControlRingWakeHandle<Memory> {
         ControlRingWakeHandle {
             ring: Arc::clone(&self.ring),
-            wait_epoch_offset: self.direction.consumer_epoch_offset(),
+            wait_epoch: ControlRingWaitEpoch::Consumer(self.direction),
         }
     }
 
@@ -456,7 +473,7 @@ impl<Memory: AtomicSharedMemory> ControlRingConsumer<Memory> {
     pub(crate) fn wake_handle(&self) -> ControlRingWakeHandle<Memory> {
         ControlRingWakeHandle {
             ring: Arc::clone(&self.ring),
-            wait_epoch_offset: self.direction.producer_epoch_offset(),
+            wait_epoch: ControlRingWaitEpoch::Producer(self.direction),
         }
     }
 

--- a/litebox_broker_transport/src/shared_memory.rs
+++ b/litebox_broker_transport/src/shared_memory.rs
@@ -26,7 +26,7 @@ use litebox_broker_protocol::shared_memory::{AtomicSharedMemory, SharedMemory, S
 
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 
-use crate::control_ring::{ControlRingConsumer, ControlRingProducer};
+use crate::control_ring::{ControlRingConsumer, ControlRingProducer, ControlRingWakeHandle};
 use crate::unix_io::{
     refresh_read_deadline, refresh_write_deadline, with_read_deadline, with_write_deadline,
 };
@@ -256,6 +256,19 @@ impl ControlRingConsumer<MemfdSharedMemory> {
     pub fn wake_producer(&self) -> IoResult<()> {
         self.memory()
             .futex_wake_u32(self.direction().consumer_epoch_offset())
+    }
+}
+
+impl ControlRingWakeHandle<MemfdSharedMemory> {
+    /// Changes and wakes the epoch observed by this endpoint's wait operation.
+    ///
+    /// Incrementing before waking closes the race where cancellation happens
+    /// after a ring operation samples its epoch but before it enters futex wait.
+    pub(crate) fn interrupt_wait(&self) -> IoResult<()> {
+        self.memory()
+            .fetch_add_u32_release(self.wait_epoch_offset(), 1)
+            .map_err(|error| Error::new(ErrorKind::InvalidInput, error))?;
+        self.memory().futex_wake_u32(self.wait_epoch_offset())
     }
 }
 

--- a/litebox_broker_transport/src/unix_socket.rs
+++ b/litebox_broker_transport/src/unix_socket.rs
@@ -19,7 +19,7 @@ use std::time::Instant;
 use std::{collections::HashMap, thread};
 
 use crate::control_ring::{
-    ControlRing, ControlRingConsumer, ControlRingError, ControlRingReadError,
+    ControlRing, ControlRingConsumer, ControlRingError, ControlRingProducer, ControlRingReadError,
     ControlRingReadStatus, ControlRingWakeHandle, ControlRingWriteStatus,
 };
 use crate::shared_memory::MemfdSharedMemory;
@@ -618,27 +618,14 @@ impl UnixStreamHostResponseSink {
             .lock()
             .map_err(|_| Error::other("broker response writer mutex poisoned"))?;
         loop {
-            self.active.ensure_response_path_live()?;
-            match producer.try_write(&frame).map_err(Error::from) {
-                Ok(ControlRingWriteStatus::Written) => {
-                    if let Err(error) = producer.wake_consumer() {
-                        let result = Err(copy_io_error(&error));
-                        let _ = self.active.fail(error);
-                        return result;
-                    }
-                    return Ok(());
-                }
-                Ok(ControlRingWriteStatus::Full { wait_epoch }) => {
+            match self.active.try_publish_response(&mut producer, &frame)? {
+                ControlRingWriteStatus::Written => return Ok(()),
+                ControlRingWriteStatus::Full { wait_epoch } => {
                     if let Err(error) = producer.wait_for_capacity(wait_epoch) {
                         let result = Err(copy_io_error(&error));
                         let _ = self.active.fail(error);
                         return result;
                     }
-                }
-                Err(error) => {
-                    let result = Err(copy_io_error(&error));
-                    let _ = self.active.fail(error);
-                    return result;
                 }
             }
         }
@@ -903,19 +890,42 @@ impl HostActiveState {
         }
     }
 
-    fn ensure_response_path_live(&self) -> IoResult<()> {
-        match &*self
-            .status
-            .lock()
-            .expect("broker host active-state mutex poisoned")
-        {
-            HostActiveStatus::Live => Ok(()),
-            HostActiveStatus::PeerClosed => Err(Error::new(
-                ErrorKind::BrokenPipe,
-                "runner closed the active control channel",
-            )),
-            HostActiveStatus::Failed(error) => Err(copy_io_error(error)),
+    fn try_publish_response(
+        &self,
+        producer: &mut ControlRingProducer<MemfdSharedMemory>,
+        frame: &[u8],
+    ) -> IoResult<ControlRingWriteStatus> {
+        let result = {
+            let status = self
+                .status
+                .lock()
+                .expect("broker host active-state mutex poisoned");
+            match &*status {
+                HostActiveStatus::Live => {}
+                HostActiveStatus::PeerClosed => {
+                    return Err(Error::new(
+                        ErrorKind::BrokenPipe,
+                        "runner closed the active control channel",
+                    ));
+                }
+                HostActiveStatus::Failed(error) => return Err(copy_io_error(error)),
+            }
+            producer
+                .try_write(frame)
+                .map_err(Error::from)
+                .and_then(|write_status| {
+                    if matches!(write_status, ControlRingWriteStatus::Written) {
+                        producer.wake_consumer()?;
+                    }
+                    Ok(write_status)
+                })
+        };
+        if let Err(error) = result {
+            let result = Err(copy_io_error(&error));
+            let _ = self.fail(error);
+            return result;
         }
+        result
     }
 }
 

--- a/litebox_broker_transport/src/unix_socket.rs
+++ b/litebox_broker_transport/src/unix_socket.rs
@@ -588,7 +588,7 @@ impl UnixStreamHostRequestSource {
                     return Ok(HostReceive::Message(request));
                 }
                 Ok(ControlRingReadStatus::Empty { wait_epoch }) => {
-                    if let Some(terminal) = self.active.request_terminal() {
+                    if let Some(terminal) = self.active.request_terminal_result() {
                         return terminal;
                     }
                     if let Err(error) = self.consumer.wait_for_message(wait_epoch) {
@@ -854,7 +854,7 @@ impl HostActiveState {
         let _ = self.response_wait.interrupt_wait();
     }
 
-    fn request_terminal(&self) -> Option<IoResult<HostReceive<BrokerRequest>>> {
+    fn request_terminal_result(&self) -> Option<IoResult<HostReceive<BrokerRequest>>> {
         match &*self
             .status
             .lock()

--- a/litebox_broker_transport/src/unix_socket.rs
+++ b/litebox_broker_transport/src/unix_socket.rs
@@ -93,15 +93,15 @@ struct UnixStreamLocalSetup {
 
 /// Independently owned handle for interrupting local control-channel I/O.
 pub struct UnixStreamLocalControlCancellation {
-    failure: Arc<LocalActiveFailure>,
+    failure_coordinator: Arc<LocalActiveFailureCoordinator>,
 }
 
 struct UnixStreamLocalActive {
     request_producer: Mutex<crate::control_ring::ControlRingProducer<MemfdSharedMemory>>,
-    failure: Arc<LocalActiveFailure>,
+    failure_coordinator: Arc<LocalActiveFailureCoordinator>,
 }
 
-struct LocalActiveFailure {
+struct LocalActiveFailureCoordinator {
     stream: UnixStream,
     pending_calls: Arc<PendingCalls>,
     association_failure: Arc<dyn Fn() + Send + Sync>,
@@ -202,44 +202,48 @@ impl UnixStreamLocalControlChannel {
         let (request_producer, response_consumer) = ring.into_local();
         let pending_calls = Arc::new(PendingCalls::new());
         let association_failure: Arc<dyn Fn() + Send + Sync> = Arc::new(association_failure);
-        let failure = Arc::new(LocalActiveFailure {
+        let failure_coordinator = Arc::new(LocalActiveFailureCoordinator {
             stream: shutdown_stream,
             pending_calls: Arc::clone(&pending_calls),
             association_failure,
             request_wait: request_producer.wake_handle(),
             response_wait: response_consumer.wake_handle(),
         });
-        let response_failure = Arc::clone(&failure);
+        let response_failure_coordinator = Arc::clone(&failure_coordinator);
         if let Err(error) = thread::Builder::new()
             .name("litebox-broker-responses".to_owned())
             .spawn(move || {
-                dispatch_responses(response_consumer, response_failure);
+                dispatch_responses(response_consumer, response_failure_coordinator);
             })
         {
-            let _ = failure.fail(error);
+            let _ = failure_coordinator.fail(error);
             return Err(Error::other("failed to start broker response pump"));
         }
-        let monitor_failure = Arc::clone(&failure);
+        let monitor_failure_coordinator = Arc::clone(&failure_coordinator);
         if let Err(error) = thread::Builder::new()
             .name("litebox-broker-liveness".to_owned())
-            .spawn(move || monitor_local_socket(&mut monitor_stream, &monitor_failure))
+            .spawn(move || {
+                monitor_local_socket(&mut monitor_stream, &monitor_failure_coordinator);
+            })
         {
-            let _ = failure.fail(error);
+            let _ = failure_coordinator.fail(error);
             return Err(Error::other("failed to start broker liveness monitor"));
         }
 
         self.state = UnixStreamLocalControlState::Active(UnixStreamLocalActive {
             request_producer: Mutex::new(request_producer),
-            failure: Arc::clone(&failure),
+            failure_coordinator: Arc::clone(&failure_coordinator),
         });
-        Ok(UnixStreamLocalControlCancellation { failure })
+        Ok(UnixStreamLocalControlCancellation {
+            failure_coordinator,
+        })
     }
 }
 
 impl UnixStreamLocalControlCancellation {
     /// Shuts down the control stream, unblocking pending reads or writes.
     pub fn cancel(&self) -> IoResult<()> {
-        self.failure.fail(Error::new(
+        self.failure_coordinator.fail(Error::new(
             ErrorKind::ConnectionAborted,
             "broker association cancelled",
         ))
@@ -251,7 +255,7 @@ impl Drop for UnixStreamLocalControlChannel {
         let UnixStreamLocalControlState::Active(active) = &self.state else {
             return;
         };
-        let _ = active.failure.fail(Error::new(
+        let _ = active.failure_coordinator.fail(Error::new(
             ErrorKind::ConnectionAborted,
             "broker active channel dropped",
         ));
@@ -494,7 +498,10 @@ impl LocalControlChannel for UnixStreamLocalControlChannel {
             return Err(invalid_data("broker control channel is not active"));
         };
         let request_id = request.request_id;
-        let pending_call = active.failure.pending_calls.register(request_id)?;
+        let pending_call = active
+            .failure_coordinator
+            .pending_calls
+            .register(request_id)?;
         let request_frame = encode_request(request);
 
         let write_result = {
@@ -503,7 +510,7 @@ impl LocalControlChannel for UnixStreamLocalControlChannel {
                 .lock()
                 .expect("broker request writer mutex poisoned");
             loop {
-                if let Some(error) = active.failure.pending_calls.current_failure() {
+                if let Some(error) = active.failure_coordinator.pending_calls.current_failure() {
                     break Err(copy_io_error(&error));
                 }
                 match producer
@@ -526,7 +533,7 @@ impl LocalControlChannel for UnixStreamLocalControlChannel {
             }
         };
         if let Err(error) = write_result {
-            let _ = active.failure.fail(error);
+            let _ = active.failure_coordinator.fail(error);
         }
 
         pending_call.wait()
@@ -804,7 +811,7 @@ impl PendingCalls {
     }
 }
 
-impl LocalActiveFailure {
+impl LocalActiveFailureCoordinator {
     fn fail(&self, error: Error) -> IoResult<()> {
         let first_failure = self.pending_calls.record_failure(Arc::new(error));
         let request_wake = self.request_wait.interrupt_wait();
@@ -875,9 +882,12 @@ impl HostActiveState {
     }
 }
 
-fn monitor_local_socket(stream: &mut UnixStream, failure: &LocalActiveFailure) {
+fn monitor_local_socket(
+    stream: &mut UnixStream,
+    failure_coordinator: &LocalActiveFailureCoordinator,
+) {
     let error = monitor_socket(stream, "broker");
-    let _ = failure.fail(error);
+    let _ = failure_coordinator.fail(error);
 }
 
 fn monitor_host_socket(stream: &mut UnixStream, active: &HostActiveState) {
@@ -924,7 +934,7 @@ fn monitor_socket(stream: &mut UnixStream, peer: &'static str) -> Error {
 
 fn dispatch_responses(
     mut consumer: ControlRingConsumer<MemfdSharedMemory>,
-    failure: Arc<LocalActiveFailure>,
+    failure_coordinator: Arc<LocalActiveFailureCoordinator>,
 ) {
     loop {
         match consumer.try_read(decode_response) {
@@ -933,27 +943,31 @@ fn dispatch_responses(
                     .publish_head()
                     .map_err(control_ring_error)
                     .and_then(|()| consumer.wake_producer())
-                    .and_then(|()| failure.pending_calls.complete(response))
+                    .and_then(|()| failure_coordinator.pending_calls.complete(response))
                 {
-                    let _ = failure.fail(error);
+                    let _ = failure_coordinator.fail(error);
                     return;
                 }
             }
             Ok(ControlRingReadStatus::Empty { wait_epoch }) => {
-                if failure.pending_calls.current_failure().is_some() {
+                if failure_coordinator
+                    .pending_calls
+                    .current_failure()
+                    .is_some()
+                {
                     return;
                 }
                 if let Err(error) = consumer.wait_for_message(wait_epoch) {
-                    let _ = failure.fail(error);
+                    let _ = failure_coordinator.fail(error);
                     return;
                 }
             }
             Err(ControlRingReadError::Ring(error)) => {
-                let _ = failure.fail(control_ring_error(error));
+                let _ = failure_coordinator.fail(control_ring_error(error));
                 return;
             }
             Err(ControlRingReadError::Decode(error)) => {
-                let _ = failure.fail(wire_error(error));
+                let _ = failure_coordinator.fail(wire_error(error));
                 return;
             }
         }

--- a/litebox_broker_transport/src/unix_socket.rs
+++ b/litebox_broker_transport/src/unix_socket.rs
@@ -7,10 +7,8 @@
 //! framing are hosted userland concerns. Portable broker interfaces live in the
 //! no_std protocol, local, core, and host crates.
 //!
-//! After setup, each caller thread registers its request and writes its complete
-//! frame while holding the shared writer mutex; there is no local request worker.
-//! One response-dispatcher thread exclusively reads responses, correlates them by
-//! request ID, and wakes the matching callers.
+//! After setup, the authenticated socket is retained only for liveness and
+//! cancellation. Active requests and responses use a shared control ring.
 
 use std::io::{Error, ErrorKind, Read, Result as IoResult, Write};
 use std::net::Shutdown;
@@ -20,13 +18,17 @@ use std::sync::{Arc, Condvar, Mutex};
 use std::time::Instant;
 use std::{collections::HashMap, thread};
 
+use crate::control_ring::{
+    ControlRing, ControlRingConsumer, ControlRingReadError, ControlRingReadStatus,
+    ControlRingWakeHandle, ControlRingWriteStatus,
+};
 use crate::shared_memory::MemfdSharedMemory;
 use crate::unix_io::{
     refresh_read_deadline, refresh_write_deadline, with_read_deadline, with_write_deadline,
 };
 use litebox_broker_protocol::RequestId;
 use litebox_broker_protocol::channel::{
-    HostControlChannel, HostNotificationChannel, HostReceive, LocalControlChannel,
+    HostNotificationChannel, HostReceive, HostSetupChannel, LocalControlChannel,
     LocalNotificationChannel, PeerCredential,
 };
 use litebox_broker_protocol::message::{
@@ -40,6 +42,7 @@ use litebox_broker_protocol::wire::{
 };
 
 const MAX_FRAME_LEN: usize = 64 * 1024;
+const CONTROL_RING_READY: &[u8] = b"litebox-control-ring-ready-v1";
 /// Maximum number of active calls waiting for broker responses.
 pub const MAX_PENDING_CALLS: usize = 64;
 
@@ -90,16 +93,20 @@ struct UnixStreamLocalSetup {
 
 /// Independently owned handle for interrupting local control-channel I/O.
 pub struct UnixStreamLocalControlCancellation {
-    stream: UnixStream,
-    pending_calls: Arc<PendingCalls>,
-    association_failure: Arc<dyn Fn() + Send + Sync>,
+    failure: Arc<LocalActiveFailure>,
 }
 
 struct UnixStreamLocalActive {
-    request_stream: Mutex<UnixStream>,
-    shutdown_stream: UnixStream,
+    request_producer: Mutex<crate::control_ring::ControlRingProducer<MemfdSharedMemory>>,
+    failure: Arc<LocalActiveFailure>,
+}
+
+struct LocalActiveFailure {
+    stream: UnixStream,
     pending_calls: Arc<PendingCalls>,
     association_failure: Arc<dyn Fn() + Send + Sync>,
+    request_wait: ControlRingWakeHandle<MemfdSharedMemory>,
+    response_wait: ControlRingWakeHandle<MemfdSharedMemory>,
 }
 
 impl UnixStreamLocalControlChannel {
@@ -149,9 +156,13 @@ impl UnixStreamLocalControlChannel {
         crate::shared_memory::receive_memfd(&mut setup.stream, expected_len, deadline)
     }
 
-    /// Completes setup and starts the active response pump.
+    /// Completes setup and starts the active control-ring response pump.
+    ///
+    /// The ring must be the validated control-ring memfd received during this
+    /// setup exchange.
     pub fn activate(
         &mut self,
+        ring: ControlRing<MemfdSharedMemory>,
         association_failure: impl Fn() + Send + Sync + 'static,
     ) -> IoResult<UnixStreamLocalControlCancellation> {
         let UnixStreamLocalControlState::Setup(setup) = &self.state else {
@@ -168,49 +179,70 @@ impl UnixStreamLocalControlChannel {
             unreachable!("broker control setup state disappeared");
         };
 
-        let response_stream = setup.stream;
-        let request_stream = response_stream.try_clone()?;
-        let shutdown_stream = response_stream.try_clone()?;
-        let cancellation_stream = response_stream.try_clone()?;
-        let response_cancellation = response_stream.try_clone()?;
+        let mut monitor_stream = setup.stream;
+        write_frame_with_deadline(
+            &mut monitor_stream,
+            CONTROL_RING_READY,
+            setup.setup_deadline,
+        )?;
+        let Some(ready) = read_frame_with_deadline(&mut monitor_stream, setup.setup_deadline)?
+        else {
+            return Err(Error::new(
+                ErrorKind::UnexpectedEof,
+                "broker closed before control-ring setup acknowledgement",
+            ));
+        };
+        if ready != CONTROL_RING_READY {
+            return Err(invalid_data(
+                "broker sent an invalid control-ring setup acknowledgement",
+            ));
+        }
+
+        let shutdown_stream = monitor_stream.try_clone()?;
+        let (request_producer, response_consumer) = ring.into_local();
         let pending_calls = Arc::new(PendingCalls::new());
         let association_failure: Arc<dyn Fn() + Send + Sync> = Arc::new(association_failure);
-        let response_pending_calls = Arc::clone(&pending_calls);
-        let response_failure = Arc::clone(&association_failure);
-        thread::Builder::new()
+        let failure = Arc::new(LocalActiveFailure {
+            stream: shutdown_stream,
+            pending_calls: Arc::clone(&pending_calls),
+            association_failure,
+            request_wait: request_producer.wake_handle(),
+            response_wait: response_consumer.wake_handle(),
+        });
+        let response_failure = Arc::clone(&failure);
+        if let Err(error) = thread::Builder::new()
             .name("litebox-broker-responses".to_owned())
             .spawn(move || {
-                dispatch_responses(
-                    response_stream,
-                    response_cancellation,
-                    response_pending_calls,
-                    response_failure,
-                );
-            })?;
+                dispatch_responses(response_consumer, response_failure);
+            })
+        {
+            let _ = failure.fail(error);
+            return Err(Error::other("failed to start broker response pump"));
+        }
+        let monitor_failure = Arc::clone(&failure);
+        if let Err(error) = thread::Builder::new()
+            .name("litebox-broker-liveness".to_owned())
+            .spawn(move || monitor_local_socket(&mut monitor_stream, &monitor_failure))
+        {
+            let _ = failure.fail(error);
+            return Err(Error::other("failed to start broker liveness monitor"));
+        }
 
         self.state = UnixStreamLocalControlState::Active(UnixStreamLocalActive {
-            request_stream: Mutex::new(request_stream),
-            shutdown_stream,
-            pending_calls: Arc::clone(&pending_calls),
-            association_failure: Arc::clone(&association_failure),
+            request_producer: Mutex::new(request_producer),
+            failure: Arc::clone(&failure),
         });
-        Ok(UnixStreamLocalControlCancellation {
-            stream: cancellation_stream,
-            pending_calls,
-            association_failure,
-        })
+        Ok(UnixStreamLocalControlCancellation { failure })
     }
 }
 
 impl UnixStreamLocalControlCancellation {
     /// Shuts down the control stream, unblocking pending reads or writes.
     pub fn cancel(&self) -> IoResult<()> {
-        fail_active_channel(
-            &self.pending_calls,
-            &self.stream,
-            self.association_failure.as_ref(),
-            Error::new(ErrorKind::ConnectionAborted, "broker association cancelled"),
-        )
+        self.failure.fail(Error::new(
+            ErrorKind::ConnectionAborted,
+            "broker association cancelled",
+        ))
     }
 }
 
@@ -219,15 +251,10 @@ impl Drop for UnixStreamLocalControlChannel {
         let UnixStreamLocalControlState::Active(active) = &self.state else {
             return;
         };
-        let _ = fail_active_channel(
-            &active.pending_calls,
-            &active.shutdown_stream,
-            active.association_failure.as_ref(),
-            Error::new(
-                ErrorKind::ConnectionAborted,
-                "broker active channel dropped",
-            ),
-        );
+        let _ = active.failure.fail(Error::new(
+            ErrorKind::ConnectionAborted,
+            "broker active channel dropped",
+        ));
     }
 }
 
@@ -248,18 +275,33 @@ pub struct UnixStreamHostControlChannel {
 
 /// Request-reading half of an active host control channel.
 pub struct UnixStreamHostRequestSource {
-    stream: UnixStream,
+    consumer: ControlRingConsumer<MemfdSharedMemory>,
+    active: Arc<HostActiveState>,
 }
 
 /// Shared response-writing half of an active host control channel.
 #[derive(Clone)]
 pub struct UnixStreamHostResponseSink {
-    stream: Arc<Mutex<UnixStream>>,
+    producer: Arc<Mutex<crate::control_ring::ControlRingProducer<MemfdSharedMemory>>>,
+    active: Arc<HostActiveState>,
 }
 
-/// Handle that interrupts all active host control-channel I/O.
+/// RAII guard that interrupts all active host control-channel I/O when dropped.
 pub struct UnixStreamHostControlShutdown {
+    active: Arc<HostActiveState>,
+}
+
+struct HostActiveState {
     stream: UnixStream,
+    status: Mutex<HostActiveStatus>,
+    request_wait: ControlRingWakeHandle<MemfdSharedMemory>,
+    response_wait: ControlRingWakeHandle<MemfdSharedMemory>,
+}
+
+enum HostActiveStatus {
+    Live,
+    PeerClosed,
+    Failed(Arc<Error>),
 }
 
 /// Local-side Unix-domain-socket notification channel for the hosted userland POC.
@@ -311,7 +353,8 @@ impl UnixStreamHostControlChannel {
     /// Consumes a negotiated setup channel into independently usable active
     /// request, response, and shutdown handles.
     pub fn into_active(
-        self,
+        mut self,
+        ring: ControlRing<MemfdSharedMemory>,
     ) -> IoResult<(
         UnixStreamHostRequestSource,
         UnixStreamHostResponseSink,
@@ -322,18 +365,41 @@ impl UnixStreamHostControlChannel {
                 "broker host control channel activated before negotiation completed",
             ));
         }
-        let response_stream = self.stream.try_clone()?;
+        let Some(ready) = read_frame_with_deadline(&mut self.stream, self.setup_deadline)? else {
+            return Err(Error::new(
+                ErrorKind::UnexpectedEof,
+                "runner closed before control-ring setup acknowledgement",
+            ));
+        };
+        if ready != CONTROL_RING_READY {
+            return Err(invalid_data(
+                "runner sent an invalid control-ring setup acknowledgement",
+            ));
+        }
+        write_frame_with_deadline(&mut self.stream, CONTROL_RING_READY, self.setup_deadline)?;
+
         let shutdown_stream = self.stream.try_clone()?;
+        let (response_producer, request_consumer) = ring.into_broker();
+        let active = Arc::new(HostActiveState {
+            stream: shutdown_stream,
+            status: Mutex::new(HostActiveStatus::Live),
+            request_wait: request_consumer.wake_handle(),
+            response_wait: response_producer.wake_handle(),
+        });
+        let monitor_active = Arc::clone(&active);
+        thread::Builder::new()
+            .name("litebox-runner-liveness".to_owned())
+            .spawn(move || monitor_host_socket(&mut self.stream, &monitor_active))?;
         Ok((
             UnixStreamHostRequestSource {
-                stream: self.stream,
+                consumer: request_consumer,
+                active: Arc::clone(&active),
             },
             UnixStreamHostResponseSink {
-                stream: Arc::new(Mutex::new(response_stream)),
+                producer: Arc::new(Mutex::new(response_producer)),
+                active: Arc::clone(&active),
             },
-            UnixStreamHostControlShutdown {
-                stream: shutdown_stream,
-            },
+            UnixStreamHostControlShutdown { active },
         ))
     }
 }
@@ -342,7 +408,19 @@ impl UnixStreamHostControlShutdown {
     /// Shuts down the active control socket without waiting for the response
     /// writer mutex.
     pub fn shutdown(&self) -> IoResult<()> {
-        shutdown(&self.stream)
+        self.active.fail(Error::new(
+            ErrorKind::ConnectionAborted,
+            "broker host control channel shut down",
+        ))
+    }
+}
+
+impl Drop for UnixStreamHostControlShutdown {
+    fn drop(&mut self) {
+        let _ = self.active.fail(Error::new(
+            ErrorKind::ConnectionAborted,
+            "broker host control shutdown guard dropped",
+        ));
     }
 }
 
@@ -401,7 +479,6 @@ impl LocalControlChannel for UnixStreamLocalControlChannel {
             return Err(invalid_data("broker control channel is already active"));
         };
         let frame = read_frame_with_deadline(&mut setup.stream, setup.setup_deadline)?;
-        setup.setup_deadline = None;
         match frame {
             Some(frame) => {
                 let response = decode_handshake_response(&frame).map_err(wire_error)?;
@@ -417,33 +494,46 @@ impl LocalControlChannel for UnixStreamLocalControlChannel {
             return Err(invalid_data("broker control channel is not active"));
         };
         let request_id = request.request_id;
-        let pending_call = active.pending_calls.register(request_id)?;
+        let pending_call = active.failure.pending_calls.register(request_id)?;
         let request_frame = encode_request(request);
 
         let write_result = {
-            let mut request_stream = active
-                .request_stream
+            let mut producer = active
+                .request_producer
                 .lock()
                 .expect("broker request writer mutex poisoned");
-            match active.pending_calls.current_failure() {
-                Some(error) => Err(copy_io_error(&error)),
-                None => write_frame_with_deadline(&mut request_stream, &request_frame, None),
+            loop {
+                if let Some(error) = active.failure.pending_calls.current_failure() {
+                    break Err(copy_io_error(&error));
+                }
+                match producer
+                    .try_write(&request_frame)
+                    .map_err(control_ring_error)
+                {
+                    Ok(ControlRingWriteStatus::Written) => {
+                        if let Err(error) = producer.wake_consumer() {
+                            break Err(error);
+                        }
+                        break Ok(());
+                    }
+                    Ok(ControlRingWriteStatus::Full { wait_epoch }) => {
+                        if let Err(error) = producer.wait_for_capacity(wait_epoch) {
+                            break Err(error);
+                        }
+                    }
+                    Err(error) => break Err(error),
+                }
             }
         };
         if let Err(error) = write_result {
-            let _ = fail_active_channel(
-                &active.pending_calls,
-                &active.shutdown_stream,
-                active.association_failure.as_ref(),
-                error,
-            );
+            let _ = active.failure.fail(error);
         }
 
         pending_call.wait()
     }
 }
 
-impl HostControlChannel for UnixStreamHostControlChannel {
+impl HostSetupChannel for UnixStreamHostControlChannel {
     type Error = Error;
 
     fn peer_credential(&self) -> IoResult<PeerCredential> {
@@ -468,38 +558,54 @@ impl HostControlChannel for UnixStreamHostControlChannel {
             self.setup_deadline,
         )?;
         self.negotiated = matches!(response, BrokerHandshakeResponse::Negotiated { .. });
-        if self.negotiated {
-            self.setup_deadline = None;
-        }
         Ok(())
-    }
-
-    fn recv_request(&mut self) -> IoResult<HostReceive<BrokerRequest>> {
-        let Some(frame) = read_frame_with_deadline(&mut self.stream, None)? else {
-            return Ok(HostReceive::PeerClosed);
-        };
-        match decode_request(&frame) {
-            Ok(request) => Ok(HostReceive::Message(request)),
-            Err(WireError::WrongMessagePhase) => Ok(HostReceive::ProtocolViolation),
-            Err(error) => Err(wire_error(error)),
-        }
-    }
-
-    fn send_response(&mut self, response: &BrokerResponse) -> IoResult<()> {
-        write_frame_with_deadline(&mut self.stream, &encode_response(response.clone()), None)
     }
 }
 
 impl UnixStreamHostRequestSource {
     /// Receives one active broker request.
     pub fn recv_request(&mut self) -> IoResult<HostReceive<BrokerRequest>> {
-        let Some(frame) = read_frame_with_deadline(&mut self.stream, None)? else {
-            return Ok(HostReceive::PeerClosed);
-        };
-        match decode_request(&frame) {
-            Ok(request) => Ok(HostReceive::Message(request)),
-            Err(WireError::WrongMessagePhase) => Ok(HostReceive::ProtocolViolation),
-            Err(error) => Err(wire_error(error)),
+        loop {
+            match self.consumer.try_read(decode_request) {
+                Ok(ControlRingReadStatus::Message(request)) => {
+                    if let Err(error) = self
+                        .consumer
+                        .publish_head()
+                        .map_err(control_ring_error)
+                        .and_then(|()| self.consumer.wake_producer())
+                    {
+                        let result = Err(copy_io_error(&error));
+                        let _ = self.active.fail(error);
+                        return result;
+                    }
+                    return Ok(HostReceive::Message(request));
+                }
+                Ok(ControlRingReadStatus::Empty { wait_epoch }) => {
+                    if let Some(terminal) = self.active.request_terminal() {
+                        return terminal;
+                    }
+                    if let Err(error) = self.consumer.wait_for_message(wait_epoch) {
+                        let result = Err(copy_io_error(&error));
+                        let _ = self.active.fail(error);
+                        return result;
+                    }
+                }
+                Err(ControlRingReadError::Decode(WireError::WrongMessagePhase)) => {
+                    return Ok(HostReceive::ProtocolViolation);
+                }
+                Err(ControlRingReadError::Decode(error)) => {
+                    let error = wire_error(error);
+                    let result = Err(copy_io_error(&error));
+                    let _ = self.active.fail(error);
+                    return result;
+                }
+                Err(ControlRingReadError::Ring(error)) => {
+                    let error = control_ring_error(error);
+                    let result = Err(copy_io_error(&error));
+                    let _ = self.active.fail(error);
+                    return result;
+                }
+            }
         }
     }
 }
@@ -507,11 +613,36 @@ impl UnixStreamHostRequestSource {
 impl UnixStreamHostResponseSink {
     /// Serializes and sends one complete active broker response.
     pub fn send_response(&self, response: &BrokerResponse) -> IoResult<()> {
-        let mut stream = self
-            .stream
+        let frame = encode_response(response.clone());
+        let mut producer = self
+            .producer
             .lock()
             .map_err(|_| Error::other("broker response writer mutex poisoned"))?;
-        write_frame_with_deadline(&mut stream, &encode_response(response.clone()), None)
+        loop {
+            self.active.response_live()?;
+            match producer.try_write(&frame).map_err(control_ring_error) {
+                Ok(ControlRingWriteStatus::Written) => {
+                    if let Err(error) = producer.wake_consumer() {
+                        let result = Err(copy_io_error(&error));
+                        let _ = self.active.fail(error);
+                        return result;
+                    }
+                    return Ok(());
+                }
+                Ok(ControlRingWriteStatus::Full { wait_epoch }) => {
+                    if let Err(error) = producer.wait_for_capacity(wait_epoch) {
+                        let result = Err(copy_io_error(&error));
+                        let _ = self.active.fail(error);
+                        return result;
+                    }
+                }
+                Err(error) => {
+                    let result = Err(copy_io_error(&error));
+                    let _ = self.active.fail(error);
+                    return result;
+                }
+            }
+        }
     }
 }
 
@@ -673,73 +804,160 @@ impl PendingCalls {
     }
 }
 
-fn dispatch_responses(
-    mut response_stream: UnixStream,
-    response_cancellation: UnixStream,
-    pending_calls: Arc<PendingCalls>,
-    association_failure: Arc<dyn Fn() + Send + Sync>,
-) {
-    loop {
-        let response = match read_frame_with_deadline(&mut response_stream, None) {
-            Ok(Some(frame)) => match decode_response(&frame).map_err(wire_error) {
-                Ok(response) => response,
-                Err(error) => {
-                    let _ = fail_active_channel(
-                        &pending_calls,
-                        &response_cancellation,
-                        association_failure.as_ref(),
-                        error,
-                    );
-                    return;
-                }
-            },
-            Ok(None) => {
-                let _ = fail_active_channel(
-                    &pending_calls,
-                    &response_cancellation,
-                    association_failure.as_ref(),
-                    Error::new(
-                        ErrorKind::UnexpectedEof,
-                        "broker closed the active control channel",
-                    ),
-                );
-                return;
-            }
-            Err(error) => {
-                let _ = fail_active_channel(
-                    &pending_calls,
-                    &response_cancellation,
-                    association_failure.as_ref(),
-                    error,
-                );
-                return;
-            }
-        };
+impl LocalActiveFailure {
+    fn fail(&self, error: Error) -> IoResult<()> {
+        let first_failure = self.pending_calls.record_failure(Arc::new(error));
+        let request_wake = self.request_wait.interrupt_wait();
+        let response_wake = self.response_wait.interrupt_wait();
+        let shutdown_result = shutdown(&self.stream);
+        if first_failure {
+            (self.association_failure)();
+        }
+        request_wake.and(response_wake).and(shutdown_result)
+    }
+}
 
-        if let Err(error) = pending_calls.complete(response) {
-            let _ = fail_active_channel(
-                &pending_calls,
-                &response_cancellation,
-                association_failure.as_ref(),
-                error,
-            );
-            return;
+impl HostActiveState {
+    fn fail(&self, error: Error) -> IoResult<()> {
+        {
+            let mut status = self
+                .status
+                .lock()
+                .expect("broker host active-state mutex poisoned");
+            if matches!(*status, HostActiveStatus::Live) {
+                *status = HostActiveStatus::Failed(Arc::new(error));
+            }
+        }
+        let request_wake = self.request_wait.interrupt_wait();
+        let response_wake = self.response_wait.interrupt_wait();
+        request_wake.and(response_wake).and(shutdown(&self.stream))
+    }
+
+    fn peer_closed(&self) {
+        {
+            let mut status = self
+                .status
+                .lock()
+                .expect("broker host active-state mutex poisoned");
+            if matches!(*status, HostActiveStatus::Live) {
+                *status = HostActiveStatus::PeerClosed;
+            }
+        }
+        let _ = self.request_wait.interrupt_wait();
+        let _ = self.response_wait.interrupt_wait();
+    }
+
+    fn request_terminal(&self) -> Option<IoResult<HostReceive<BrokerRequest>>> {
+        match &*self
+            .status
+            .lock()
+            .expect("broker host active-state mutex poisoned")
+        {
+            HostActiveStatus::Live => None,
+            HostActiveStatus::PeerClosed => Some(Ok(HostReceive::PeerClosed)),
+            HostActiveStatus::Failed(error) => Some(Err(copy_io_error(error))),
+        }
+    }
+
+    fn response_live(&self) -> IoResult<()> {
+        match &*self
+            .status
+            .lock()
+            .expect("broker host active-state mutex poisoned")
+        {
+            HostActiveStatus::Live => Ok(()),
+            HostActiveStatus::PeerClosed => Err(Error::new(
+                ErrorKind::BrokenPipe,
+                "runner closed the active control channel",
+            )),
+            HostActiveStatus::Failed(error) => Err(copy_io_error(error)),
         }
     }
 }
 
-fn fail_active_channel(
-    pending_calls: &PendingCalls,
-    shutdown_stream: &UnixStream,
-    association_failure: &(dyn Fn() + Send + Sync),
-    error: Error,
-) -> IoResult<()> {
-    let first_failure = pending_calls.record_failure(Arc::new(error));
-    let shutdown_result = shutdown(shutdown_stream);
-    if first_failure {
-        association_failure();
+fn monitor_local_socket(stream: &mut UnixStream, failure: &LocalActiveFailure) {
+    let error = monitor_socket(stream, "broker");
+    let _ = failure.fail(error);
+}
+
+fn monitor_host_socket(stream: &mut UnixStream, active: &HostActiveState) {
+    let mut byte = [0];
+    loop {
+        match stream.read(&mut byte) {
+            Ok(0) => {
+                active.peer_closed();
+                return;
+            }
+            Ok(_) => {
+                let _ = active.fail(invalid_data(
+                    "runner sent unexpected active control-socket data",
+                ));
+                return;
+            }
+            Err(error) if error.kind() == ErrorKind::Interrupted => {}
+            Err(error) => {
+                let _ = active.fail(error);
+                return;
+            }
+        }
     }
-    shutdown_result
+}
+
+fn monitor_socket(stream: &mut UnixStream, peer: &'static str) -> Error {
+    let mut byte = [0];
+    loop {
+        match stream.read(&mut byte) {
+            Ok(0) => {
+                return Error::new(
+                    ErrorKind::UnexpectedEof,
+                    format!("{peer} closed the active control channel"),
+                );
+            }
+            Ok(_) => {
+                return invalid_data("peer sent unexpected active control-socket data");
+            }
+            Err(error) if error.kind() == ErrorKind::Interrupted => {}
+            Err(error) => return error,
+        }
+    }
+}
+
+fn dispatch_responses(
+    mut consumer: ControlRingConsumer<MemfdSharedMemory>,
+    failure: Arc<LocalActiveFailure>,
+) {
+    loop {
+        match consumer.try_read(decode_response) {
+            Ok(ControlRingReadStatus::Message(response)) => {
+                if let Err(error) = consumer
+                    .publish_head()
+                    .map_err(control_ring_error)
+                    .and_then(|()| consumer.wake_producer())
+                    .and_then(|()| failure.pending_calls.complete(response))
+                {
+                    let _ = failure.fail(error);
+                    return;
+                }
+            }
+            Ok(ControlRingReadStatus::Empty { wait_epoch }) => {
+                if failure.pending_calls.current_failure().is_some() {
+                    return;
+                }
+                if let Err(error) = consumer.wait_for_message(wait_epoch) {
+                    let _ = failure.fail(error);
+                    return;
+                }
+            }
+            Err(ControlRingReadError::Ring(error)) => {
+                let _ = failure.fail(control_ring_error(error));
+                return;
+            }
+            Err(ControlRingReadError::Decode(error)) => {
+                let _ = failure.fail(wire_error(error));
+                return;
+            }
+        }
+    }
 }
 
 fn copy_io_error(error: &Error) -> Error {
@@ -835,51 +1053,191 @@ fn wire_error(error: WireError) -> Error {
     )
 }
 
+fn control_ring_error(error: crate::control_ring::ControlRingError) -> Error {
+    Error::new(
+        ErrorKind::InvalidData,
+        format!("invalid broker control ring: {error:?}"),
+    )
+}
+
 #[cfg(test)]
-mod tests {
+mod control_ring_tests {
     use super::*;
+    use crate::control_ring::{
+        CONTROL_RING_MEMORY_SIZE, CONTROL_RING_SLOT_COUNT, ControlRingProducer,
+    };
+    use litebox_broker_protocol::channel::LocalControlChannel;
     use litebox_broker_protocol::message::{
         BrokerOperation, BrokerRequest, BrokerResponse, BrokerResult,
     };
+    use litebox_broker_protocol::wire::{
+        decode_request, decode_response, encode_handshake_request, encode_response,
+    };
     use litebox_broker_protocol::{ObjectHandle, RequestId};
+    use std::io::{Read, Write};
+    use std::os::fd::AsFd;
+    use std::sync::Barrier;
     use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::sync::{Barrier, mpsc};
     use std::time::Duration;
 
-    fn activate_test_channel(
-        stream: UnixStream,
+    type Producer = ControlRingProducer<MemfdSharedMemory>;
+    type Consumer = ControlRingConsumer<MemfdSharedMemory>;
+
+    fn ring_pair() -> (
+        ControlRing<MemfdSharedMemory>,
+        ControlRing<MemfdSharedMemory>,
+    ) {
+        let first = MemfdSharedMemory::create(CONTROL_RING_MEMORY_SIZE).unwrap();
+        let second = MemfdSharedMemory::from_received_fd(
+            first.as_fd().try_clone_to_owned().unwrap(),
+            CONTROL_RING_MEMORY_SIZE,
+        )
+        .unwrap();
+        (
+            ControlRing::new(first).unwrap(),
+            ControlRing::new(second).unwrap(),
+        )
+    }
+
+    fn negotiated_local(stream: UnixStream) -> UnixStreamLocalControlChannel {
+        UnixStreamLocalControlChannel {
+            state: UnixStreamLocalControlState::Setup(UnixStreamLocalSetup {
+                stream,
+                setup_deadline: Some(Instant::now() + Duration::from_secs(2)),
+                negotiated: true,
+            }),
+        }
+    }
+
+    fn activate_local(
         association_failure: impl Fn() + Send + Sync + 'static,
     ) -> (
         UnixStreamLocalControlChannel,
         UnixStreamLocalControlCancellation,
+        Producer,
+        Consumer,
+        UnixStream,
     ) {
-        let mut channel = UnixStreamLocalControlChannel {
-            state: UnixStreamLocalControlState::Setup(UnixStreamLocalSetup {
-                stream,
-                setup_deadline: None,
-                negotiated: true,
-            }),
-        };
-        let cancellation = channel.activate(association_failure).unwrap();
-        (channel, cancellation)
+        let (local_stream, peer_stream) = UnixStream::pair().unwrap();
+        let mut ack_stream = peer_stream.try_clone().unwrap();
+        let acknowledgement = thread::spawn(move || {
+            assert_eq!(
+                read_frame_with_deadline(&mut ack_stream, None)
+                    .unwrap()
+                    .unwrap(),
+                CONTROL_RING_READY
+            );
+            write_frame_with_deadline(&mut ack_stream, CONTROL_RING_READY, None).unwrap();
+        });
+        let (local_ring, broker_ring) = ring_pair();
+        let mut channel = negotiated_local(local_stream);
+        let cancellation = channel.activate(local_ring, association_failure).unwrap();
+        acknowledgement.join().unwrap();
+        let (response_producer, request_consumer) = broker_ring.into_broker();
+        (
+            channel,
+            cancellation,
+            response_producer,
+            request_consumer,
+            peer_stream,
+        )
     }
 
-    fn activate_counting_failure_channel(
-        stream: UnixStream,
-    ) -> (
-        UnixStreamLocalControlChannel,
-        UnixStreamLocalControlCancellation,
-        Arc<AtomicUsize>,
-        mpsc::Receiver<()>,
+    fn split_host() -> (
+        UnixStreamHostRequestSource,
+        UnixStreamHostResponseSink,
+        UnixStreamHostControlShutdown,
+        Producer,
+        Consumer,
+        UnixStream,
     ) {
-        let failure_count = Arc::new(AtomicUsize::new(0));
-        let response_failure_count = Arc::clone(&failure_count);
-        let (failure_sender, failure_receiver) = mpsc::channel();
-        let (channel, cancellation) = activate_test_channel(stream, move || {
-            response_failure_count.fetch_add(1, Ordering::SeqCst);
-            failure_sender.send(()).unwrap();
+        let (peer_stream, host_stream) = UnixStream::pair().unwrap();
+        let mut ack_stream = peer_stream.try_clone().unwrap();
+        let acknowledgement = thread::spawn(move || {
+            write_frame_with_deadline(&mut ack_stream, CONTROL_RING_READY, None).unwrap();
+            assert_eq!(
+                read_frame_with_deadline(&mut ack_stream, None)
+                    .unwrap()
+                    .unwrap(),
+                CONTROL_RING_READY
+            );
         });
-        (channel, cancellation, failure_count, failure_receiver)
+        let (local_ring, host_ring) = ring_pair();
+        let channel = UnixStreamHostControlChannel {
+            stream: host_stream,
+            peer_credential: PeerCredential::HostGuaranteed,
+            setup_deadline: Some(Instant::now() + Duration::from_secs(2)),
+            negotiated: true,
+        };
+        let (source, sink, shutdown) = channel.into_active(host_ring).unwrap();
+        acknowledgement.join().unwrap();
+        let (request_producer, response_consumer) = local_ring.into_local();
+        (
+            source,
+            sink,
+            shutdown,
+            request_producer,
+            response_consumer,
+            peer_stream,
+        )
+    }
+
+    fn read_request(consumer: &mut Consumer) -> BrokerRequest {
+        loop {
+            match consumer.try_read(decode_request).unwrap() {
+                ControlRingReadStatus::Message(request) => {
+                    consumer.publish_head().unwrap();
+                    consumer.wake_producer().unwrap();
+                    return request;
+                }
+                ControlRingReadStatus::Empty { wait_epoch } => {
+                    consumer.wait_for_message(wait_epoch).unwrap();
+                }
+            }
+        }
+    }
+
+    fn read_response(consumer: &mut Consumer) -> BrokerResponse {
+        loop {
+            match consumer.try_read(decode_response).unwrap() {
+                ControlRingReadStatus::Message(response) => {
+                    consumer.publish_head().unwrap();
+                    consumer.wake_producer().unwrap();
+                    return response;
+                }
+                ControlRingReadStatus::Empty { wait_epoch } => {
+                    consumer.wait_for_message(wait_epoch).unwrap();
+                }
+            }
+        }
+    }
+
+    fn write_payload(producer: &mut Producer, payload: &[u8]) {
+        loop {
+            match producer.try_write(payload).unwrap() {
+                ControlRingWriteStatus::Written => {
+                    producer.wake_consumer().unwrap();
+                    return;
+                }
+                ControlRingWriteStatus::Full { wait_epoch } => {
+                    producer.wait_for_capacity(wait_epoch).unwrap();
+                }
+            }
+        }
+    }
+
+    fn request(id: u64) -> BrokerRequest {
+        BrokerRequest {
+            request_id: RequestId(id),
+            operation: BrokerOperation::CloseObject(ObjectHandle(id)),
+        }
+    }
+
+    fn response(id: RequestId) -> BrokerResponse {
+        BrokerResponse {
+            request_id: id,
+            result: BrokerResult::ObjectClosed,
+        }
     }
 
     #[test]
@@ -898,27 +1256,52 @@ mod tests {
     }
 
     #[test]
-    fn frame_round_trip() {
+    fn setup_frames_round_trip_and_reject_invalid_boundaries() {
         let (mut writer, mut reader) = UnixStream::pair().unwrap();
         write_frame_with_deadline(&mut writer, &[1, 2, 3], None).unwrap();
-
         assert_eq!(
             read_frame_with_deadline(&mut reader, None)
                 .unwrap()
                 .unwrap(),
             [1, 2, 3]
         );
-    }
 
-    #[test]
-    fn clean_eof_before_frame_is_close() {
         let (writer, mut reader) = UnixStream::pair().unwrap();
         drop(writer);
-
         assert!(
             read_frame_with_deadline(&mut reader, None)
                 .unwrap()
                 .is_none()
+        );
+
+        for frame_prefix in [
+            vec![1, 0],
+            0u32.to_le_bytes().to_vec(),
+            u32::try_from(MAX_FRAME_LEN + 1)
+                .unwrap()
+                .to_le_bytes()
+                .to_vec(),
+        ] {
+            let (mut writer, mut reader) = UnixStream::pair().unwrap();
+            writer.write_all(&frame_prefix).unwrap();
+            drop(writer);
+            assert_eq!(
+                read_frame_with_deadline(&mut reader, None)
+                    .unwrap_err()
+                    .kind(),
+                ErrorKind::InvalidData
+            );
+        }
+
+        let (mut writer, mut reader) = UnixStream::pair().unwrap();
+        writer.write_all(&4u32.to_le_bytes()).unwrap();
+        writer.write_all(&[1, 2]).unwrap();
+        drop(writer);
+        assert_eq!(
+            read_frame_with_deadline(&mut reader, None)
+                .unwrap_err()
+                .kind(),
+            ErrorKind::InvalidData
         );
     }
 
@@ -927,20 +1310,15 @@ mod tests {
         let (local_stream, mut host_stream) = UnixStream::pair().unwrap();
         let mut channel = UnixStreamLocalControlChannel::from_connected(local_stream);
         assert_eq!(
-            channel
-                .call(BrokerRequest {
-                    request_id: RequestId(0),
-                    operation: BrokerOperation::CloseObject(ObjectHandle(1)),
-                })
-                .unwrap_err()
-                .kind(),
+            channel.call(request(0)).unwrap_err().kind(),
+            ErrorKind::InvalidData
+        );
+        let (ring, _) = ring_pair();
+        assert_eq!(
+            channel.activate(ring, || {}).err().unwrap().kind(),
             ErrorKind::InvalidData
         );
 
-        assert_eq!(
-            channel.activate(|| {}).err().unwrap().kind(),
-            ErrorKind::InvalidData
-        );
         let handshake_request = BrokerHandshakeRequest {
             protocol_version: litebox_broker_protocol::BROKER_PROTOCOL_VERSION,
         };
@@ -967,735 +1345,355 @@ mod tests {
             Some(BrokerHandshakeResponse::Negotiated { .. })
         ));
 
-        let _cancellation = channel.activate(|| {}).unwrap();
+        let acknowledgement = thread::spawn(move || {
+            assert_eq!(
+                read_frame_with_deadline(&mut host_stream, None)
+                    .unwrap()
+                    .unwrap(),
+                CONTROL_RING_READY
+            );
+            write_frame_with_deadline(&mut host_stream, CONTROL_RING_READY, None).unwrap();
+            host_stream
+        });
+        let (ring, _) = ring_pair();
+        let _cancellation = channel.activate(ring, || {}).unwrap();
+        let mut host_stream = acknowledgement.join().unwrap();
 
+        let (ring, _) = ring_pair();
         assert_eq!(
-            channel.activate(|| {}).err().unwrap().kind(),
+            channel.activate(ring, || {}).err().unwrap().kind(),
             ErrorKind::InvalidData
         );
         assert_eq!(
             channel
-                .send_handshake_request(&BrokerHandshakeRequest {
-                    protocol_version: litebox_broker_protocol::BROKER_PROTOCOL_VERSION,
-                })
+                .send_handshake_request(&handshake_request)
                 .unwrap_err()
                 .kind(),
             ErrorKind::InvalidData
         );
 
-        let channel = Arc::new(channel);
-        let call_channel = Arc::clone(&channel);
-        let call = thread::spawn(move || {
-            call_channel.call(BrokerRequest {
-                request_id: RequestId(1),
-                operation: BrokerOperation::CloseObject(ObjectHandle(1)),
-            })
-        });
-        let request = decode_request(
-            &read_frame_with_deadline(&mut host_stream, None)
-                .unwrap()
-                .unwrap(),
-        )
-        .unwrap();
-        write_frame_with_deadline(
-            &mut host_stream,
-            &encode_response(BrokerResponse {
-                request_id: request.request_id,
-                result: BrokerResult::ObjectClosed,
-            }),
-            None,
-        )
-        .unwrap();
-        assert_eq!(call.join().unwrap().unwrap().request_id, RequestId(1));
-    }
-
-    #[test]
-    fn active_channel_matches_out_of_order_responses() {
-        let (local_stream, mut host_stream) = UnixStream::pair().unwrap();
-        let (channel, _cancellation) = activate_test_channel(local_stream, || {});
-        let channel = Arc::new(channel);
-
-        let first_channel = Arc::clone(&channel);
-        let first = thread::spawn(move || {
-            first_channel.call(BrokerRequest {
-                request_id: RequestId(3),
-                operation: BrokerOperation::CloseObject(ObjectHandle(3)),
-            })
-        });
-        let second_channel = Arc::clone(&channel);
-        let second = thread::spawn(move || {
-            second_channel.call(BrokerRequest {
-                request_id: RequestId(7),
-                operation: BrokerOperation::CloseObject(ObjectHandle(7)),
-            })
-        });
-
-        let first_request = decode_request(
-            &read_frame_with_deadline(&mut host_stream, None)
-                .unwrap()
-                .unwrap(),
-        )
-        .unwrap();
-        let second_request = decode_request(
-            &read_frame_with_deadline(&mut host_stream, None)
-                .unwrap()
-                .unwrap(),
-        )
-        .unwrap();
-        let mut request_ids = [first_request.request_id, second_request.request_id];
-        request_ids.sort();
-        assert_eq!(request_ids, [RequestId(3), RequestId(7)]);
-
-        write_frame_with_deadline(
-            &mut host_stream,
-            &encode_response(BrokerResponse {
-                request_id: second_request.request_id,
-                result: BrokerResult::ObjectClosed,
-            }),
-            None,
-        )
-        .unwrap();
-        write_frame_with_deadline(
-            &mut host_stream,
-            &encode_response(BrokerResponse {
-                request_id: first_request.request_id,
-                result: BrokerResult::ObjectClosed,
-            }),
-            None,
-        )
-        .unwrap();
-
-        assert_eq!(first.join().unwrap().unwrap().request_id, RequestId(3));
-        assert_eq!(second.join().unwrap().unwrap().request_id, RequestId(7));
-    }
-
-    #[test]
-    fn active_channel_bounds_pending_calls_before_publication() {
-        let (local_stream, mut host_stream) = UnixStream::pair().unwrap();
         host_stream
-            .set_read_timeout(Some(Duration::from_secs(2)))
+            .set_read_timeout(Some(Duration::from_secs(1)))
             .unwrap();
-        let (channel, cancellation) = activate_test_channel(local_stream, || {});
+        drop(channel);
+        let mut byte = [0];
+        assert_eq!(host_stream.read(&mut byte).unwrap(), 0);
+    }
+
+    #[test]
+    fn two_way_ready_ack_activates_ring_transport() {
+        let (local_stream, host_stream) = UnixStream::pair().unwrap();
+        let (local_ring, host_ring) = ring_pair();
+        let mut local = negotiated_local(local_stream);
+        let host = UnixStreamHostControlChannel {
+            stream: host_stream,
+            peer_credential: PeerCredential::HostGuaranteed,
+            setup_deadline: Some(Instant::now() + Duration::from_secs(2)),
+            negotiated: true,
+        };
+        let host_active = thread::spawn(move || host.into_active(host_ring).unwrap());
+        let _cancellation = local.activate(local_ring, || {}).unwrap();
+        let (mut source, sink, _shutdown) = host_active.join().unwrap();
+
+        let caller = thread::spawn(move || local.call(request(7)));
+        let HostReceive::Message(received) = source.recv_request().unwrap() else {
+            panic!("expected ring request");
+        };
+        sink.send_response(&response(received.request_id)).unwrap();
+        assert_eq!(caller.join().unwrap().unwrap().request_id, RequestId(7));
+    }
+
+    #[test]
+    fn local_matches_out_of_order_ring_responses_without_socket_frames() {
+        let (channel, _cancellation, mut responses, mut requests, mut peer) = activate_local(|| {});
+        peer.set_read_timeout(Some(Duration::from_millis(100)))
+            .unwrap();
         let channel = Arc::new(channel);
-        let call_start = Arc::new(Barrier::new(MAX_PENDING_CALLS + 2));
+        let calls = [3, 7].map(|id| {
+            let channel = Arc::clone(&channel);
+            thread::spawn(move || channel.call(request(id)))
+        });
+        let first = read_request(&mut requests);
+        let second = read_request(&mut requests);
+
+        write_payload(
+            &mut responses,
+            &encode_response(response(second.request_id)),
+        );
+        write_payload(&mut responses, &encode_response(response(first.request_id)));
+        for call in calls {
+            assert!(call.join().unwrap().is_ok());
+        }
+        let mut byte = [0];
+        assert!(matches!(
+            peer.read(&mut byte).unwrap_err().kind(),
+            ErrorKind::WouldBlock | ErrorKind::TimedOut
+        ));
+    }
+
+    #[test]
+    fn pending_capacity_blocks_before_sixty_fifth_publication() {
+        let (channel, cancellation, mut responses, mut requests, _peer) = activate_local(|| {});
+        let channel = Arc::new(channel);
+        let start = Arc::new(Barrier::new(MAX_PENDING_CALLS + 2));
         let callers = (0..=MAX_PENDING_CALLS)
-            .map(|request_id| {
+            .map(|id| {
                 let channel = Arc::clone(&channel);
-                let call_start = Arc::clone(&call_start);
+                let start = Arc::clone(&start);
                 thread::spawn(move || {
-                    call_start.wait();
-                    channel.call(BrokerRequest {
-                        request_id: RequestId(request_id as u64),
-                        operation: BrokerOperation::CloseObject(ObjectHandle(request_id as u64)),
-                    })
+                    start.wait();
+                    channel.call(request(id as u64))
                 })
             })
             .collect::<Vec<_>>();
+        start.wait();
 
-        call_start.wait();
-        let mut published_request_ids = Vec::with_capacity(MAX_PENDING_CALLS);
+        let mut published = Vec::new();
         for _ in 0..MAX_PENDING_CALLS {
-            let frame = read_frame_with_deadline(&mut host_stream, None)
-                .unwrap()
-                .unwrap();
-            published_request_ids.push(decode_request(&frame).unwrap().request_id);
+            published.push(read_request(&mut requests).request_id);
         }
-        host_stream
-            .set_read_timeout(Some(Duration::from_millis(100)))
-            .unwrap();
-        let error = read_frame_with_deadline(&mut host_stream, None).unwrap_err();
+        write_payload(&mut responses, &encode_response(response(published[0])));
+        let released = read_request(&mut requests).request_id;
+        assert!(!published.contains(&released));
+
+        cancellation.cancel().unwrap();
+        let completed = callers
+            .into_iter()
+            .map(|caller| usize::from(caller.join().unwrap().is_ok()))
+            .sum::<usize>();
+        assert_eq!(completed, 1);
+    }
+
+    #[test]
+    fn unknown_duplicate_and_malformed_responses_fail_closed() {
+        for payload_kind in 0..3 {
+            let failures = Arc::new(AtomicUsize::new(0));
+            let callback_failures = Arc::clone(&failures);
+            let (channel, _cancellation, mut responses, mut requests, _peer) =
+                activate_local(move || {
+                    callback_failures.fetch_add(1, Ordering::SeqCst);
+                });
+            let channel = Arc::new(channel);
+            let calls = [1, 2].map(|id| {
+                let channel = Arc::clone(&channel);
+                thread::spawn(move || channel.call(request(id)))
+            });
+            read_request(&mut requests);
+            read_request(&mut requests);
+
+            match payload_kind {
+                0 => write_payload(&mut responses, &encode_response(response(RequestId(99)))),
+                1 => {
+                    let duplicate = encode_response(response(RequestId(1)));
+                    write_payload(&mut responses, &duplicate);
+                    write_payload(&mut responses, &duplicate);
+                }
+                _ => write_payload(&mut responses, &[u8::MAX]),
+            }
+
+            let results = calls.map(|call| call.join().unwrap());
+            let error_count = results.iter().filter(|result| result.is_err()).count();
+            assert_eq!(error_count, if payload_kind == 1 { 1 } else { 2 });
+            assert_eq!(failures.load(Ordering::SeqCst), 1);
+        }
+    }
+
+    #[test]
+    fn local_socket_eof_and_cancellation_wake_pending_calls() {
+        for close_peer in [false, true] {
+            let (channel, cancellation, _responses, mut requests, peer) = activate_local(|| {});
+            let caller = thread::spawn(move || channel.call(request(1)));
+            read_request(&mut requests);
+            if close_peer {
+                drop(peer);
+            } else {
+                cancellation.cancel().unwrap();
+            }
+            assert!(caller.join().unwrap().is_err());
+        }
+    }
+
+    #[test]
+    fn host_split_decodes_requests_and_cloned_sinks_publish_complete_responses() {
+        let (mut source, sink, _shutdown, mut requests, mut responses, _peer) = split_host();
+        write_payload(&mut requests, &encode_request(request(1)));
+        assert!(matches!(
+            source.recv_request().unwrap(),
+            HostReceive::Message(BrokerRequest {
+                request_id: RequestId(1),
+                ..
+            })
+        ));
+
+        let first = sink.clone();
+        let writer = thread::spawn(move || first.send_response(&response(RequestId(3))));
+        sink.send_response(&response(RequestId(7))).unwrap();
+        writer.join().unwrap().unwrap();
+        let mut ids = [
+            read_response(&mut responses).request_id,
+            read_response(&mut responses).request_id,
+        ];
+        ids.sort();
+        assert_eq!(ids, [RequestId(3), RequestId(7)]);
+    }
+
+    #[test]
+    fn host_clean_close_wakes_request_wait_as_peer_closed() {
+        let (mut source, _sink, _shutdown, _requests, _responses, peer) = split_host();
+        let receiver = thread::spawn(move || source.recv_request());
+        drop(peer);
+        assert_eq!(receiver.join().unwrap().unwrap(), HostReceive::PeerClosed);
+    }
+
+    #[test]
+    fn dropping_host_shutdown_guard_wakes_request_wait_and_closes_socket() {
+        let (mut source, sink, shutdown, _requests, _responses, mut peer) = split_host();
+        peer.set_read_timeout(Some(Duration::from_secs(1))).unwrap();
+        let receiver = thread::spawn(move || source.recv_request());
+
+        drop(sink);
+        drop(shutdown);
+
+        assert_eq!(
+            receiver.join().unwrap().unwrap_err().kind(),
+            ErrorKind::ConnectionAborted
+        );
+        let mut byte = [0];
+        assert_eq!(peer.read(&mut byte).unwrap(), 0);
+    }
+
+    #[test]
+    fn host_close_wakes_response_producer_blocked_on_full_ring() {
+        let (_source, sink, _shutdown, _requests, _responses, peer) = split_host();
+        for id in 0..CONTROL_RING_SLOT_COUNT {
+            sink.send_response(&response(RequestId(id))).unwrap();
+        }
+        let blocked_sink = sink.clone();
+        let blocked = thread::spawn(move || blocked_sink.send_response(&response(RequestId(99))));
+        thread::sleep(Duration::from_millis(20));
+        drop(peer);
+        assert_eq!(
+            blocked.join().unwrap().unwrap_err().kind(),
+            ErrorKind::BrokenPipe
+        );
+    }
+
+    #[test]
+    fn host_reports_wrong_phase_ring_message_as_protocol_violation() {
+        let (mut source, _sink, _shutdown, mut requests, _responses, _peer) = split_host();
+        write_payload(
+            &mut requests,
+            &encode_handshake_request(BrokerHandshakeRequest {
+                protocol_version: litebox_broker_protocol::BROKER_PROTOCOL_VERSION,
+            }),
+        );
+        assert_eq!(
+            source.recv_request().unwrap(),
+            HostReceive::ProtocolViolation
+        );
+    }
+
+    #[test]
+    fn malformed_host_ring_request_is_fatal_invalid_data() {
+        let (mut source, _sink, _shutdown, mut requests, _responses, _peer) = split_host();
+        write_payload(&mut requests, &[u8::MAX]);
+        assert_eq!(
+            source.recv_request().unwrap_err().kind(),
+            ErrorKind::InvalidData
+        );
+    }
+
+    #[test]
+    fn host_setup_rejects_active_frames_and_requires_negotiation() {
+        let (mut peer_stream, host_stream) = UnixStream::pair().unwrap();
+        let mut channel = UnixStreamHostControlChannel::from_accepted(host_stream);
+        write_frame_with_deadline(&mut peer_stream, &encode_request(request(0)), None).unwrap();
+        assert_eq!(
+            channel.recv_handshake_request().unwrap(),
+            HostReceive::ProtocolViolation
+        );
+
+        let (_peer_stream, host_stream) = UnixStream::pair().unwrap();
+        let channel = UnixStreamHostControlChannel::from_accepted(host_stream);
+        let (ring, _) = ring_pair();
+        let Err(error) = channel.into_active(ring) else {
+            panic!("host control channel activated before negotiation");
+        };
+        assert_eq!(error.kind(), ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn ready_ack_uses_absolute_setup_deadline() {
+        let (local_stream, _peer) = UnixStream::pair().unwrap();
+        let (ring, _) = ring_pair();
+        let mut local = UnixStreamLocalControlChannel {
+            state: UnixStreamLocalControlState::Setup(UnixStreamLocalSetup {
+                stream: local_stream,
+                setup_deadline: Some(Instant::now() + Duration::from_millis(30)),
+                negotiated: true,
+            }),
+        };
+        let Err(error) = local.activate(ring, || {}) else {
+            panic!("activation unexpectedly succeeded");
+        };
         assert!(matches!(
             error.kind(),
             ErrorKind::WouldBlock | ErrorKind::TimedOut
         ));
-
-        write_frame_with_deadline(
-            &mut host_stream,
-            &encode_response(BrokerResponse {
-                request_id: published_request_ids[0],
-                result: BrokerResult::ObjectClosed,
-            }),
-            None,
-        )
-        .unwrap();
-        host_stream
-            .set_read_timeout(Some(Duration::from_secs(2)))
-            .unwrap();
-        let released_request = decode_request(
-            &read_frame_with_deadline(&mut host_stream, None)
-                .unwrap()
-                .unwrap(),
-        )
-        .unwrap();
-        assert!(!published_request_ids.contains(&released_request.request_id));
-
-        cancellation.cancel().unwrap();
-        let mut completed = 0;
-        let mut failed = 0;
-        for caller in callers {
-            match caller.join().unwrap() {
-                Ok(_) => completed += 1,
-                Err(_) => failed += 1,
-            }
-        }
-        assert_eq!(completed, 1);
-        assert_eq!(failed, MAX_PENDING_CALLS);
     }
 
     #[test]
-    fn unknown_response_identifier_fails_all_pending_calls() {
-        let (local_stream, mut host_stream) = UnixStream::pair().unwrap();
-        let (channel, _cancellation, failure_count, failure_receiver) =
-            activate_counting_failure_channel(local_stream);
-        let channel = Arc::new(channel);
-        let callers = [1, 2].map(|request_id| {
-            let channel = Arc::clone(&channel);
-            thread::spawn(move || {
-                channel.call(BrokerRequest {
-                    request_id: RequestId(request_id),
-                    operation: BrokerOperation::CloseObject(ObjectHandle(request_id)),
-                })
-            })
-        });
-
-        for _ in 0..callers.len() {
-            let frame = read_frame_with_deadline(&mut host_stream, None)
-                .unwrap()
-                .unwrap();
-            decode_request(&frame).unwrap();
-        }
-        write_frame_with_deadline(
-            &mut host_stream,
-            &encode_response(BrokerResponse {
-                request_id: RequestId(99),
-                result: BrokerResult::ObjectClosed,
-            }),
-            None,
-        )
-        .unwrap();
-
-        for caller in callers {
-            assert_eq!(
-                caller.join().unwrap().unwrap_err().kind(),
-                ErrorKind::InvalidData
-            );
-        }
-        failure_receiver
-            .recv_timeout(Duration::from_secs(1))
-            .unwrap();
-        assert_eq!(failure_count.load(Ordering::SeqCst), 1);
-    }
-
-    #[test]
-    fn malformed_response_fails_all_pending_calls() {
-        let (local_stream, mut host_stream) = UnixStream::pair().unwrap();
-        let (channel, _cancellation, failure_count, failure_receiver) =
-            activate_counting_failure_channel(local_stream);
-        let channel = Arc::new(channel);
-        let callers = [1, 2].map(|request_id| {
-            let channel = Arc::clone(&channel);
-            thread::spawn(move || {
-                channel.call(BrokerRequest {
-                    request_id: RequestId(request_id),
-                    operation: BrokerOperation::CloseObject(ObjectHandle(request_id)),
-                })
-            })
-        });
-
-        for _ in 0..callers.len() {
-            let frame = read_frame_with_deadline(&mut host_stream, None)
-                .unwrap()
-                .unwrap();
-            decode_request(&frame).unwrap();
-        }
-        write_frame_with_deadline(&mut host_stream, &[u8::MAX], None).unwrap();
-
-        for caller in callers {
-            assert_eq!(
-                caller.join().unwrap().unwrap_err().kind(),
-                ErrorKind::InvalidData
-            );
-        }
-        failure_receiver
-            .recv_timeout(Duration::from_secs(1))
-            .unwrap();
-        assert_eq!(failure_count.load(Ordering::SeqCst), 1);
-    }
-
-    #[test]
-    fn response_eof_fails_all_pending_calls() {
-        let (local_stream, mut host_stream) = UnixStream::pair().unwrap();
-        let (channel, _cancellation, failure_count, failure_receiver) =
-            activate_counting_failure_channel(local_stream);
-        let channel = Arc::new(channel);
-        let callers = [1, 2].map(|request_id| {
-            let channel = Arc::clone(&channel);
-            thread::spawn(move || {
-                channel.call(BrokerRequest {
-                    request_id: RequestId(request_id),
-                    operation: BrokerOperation::CloseObject(ObjectHandle(request_id)),
-                })
-            })
-        });
-
-        for _ in 0..callers.len() {
-            let frame = read_frame_with_deadline(&mut host_stream, None)
-                .unwrap()
-                .unwrap();
-            decode_request(&frame).unwrap();
-        }
-        drop(host_stream);
-
-        for caller in callers {
-            assert_eq!(
-                caller.join().unwrap().unwrap_err().kind(),
-                ErrorKind::UnexpectedEof
-            );
-        }
-        failure_receiver
-            .recv_timeout(Duration::from_secs(1))
-            .unwrap();
-        assert_eq!(failure_count.load(Ordering::SeqCst), 1);
-    }
-
-    #[test]
-    fn request_write_failure_fails_existing_pending_calls() {
-        let (local_stream, mut host_stream) = UnixStream::pair().unwrap();
-        let (channel, _cancellation, failure_count, failure_receiver) =
-            activate_counting_failure_channel(local_stream);
-        let channel = Arc::new(channel);
-        let pending_callers = [1, 2].map(|request_id| {
-            let channel = Arc::clone(&channel);
-            thread::spawn(move || {
-                channel.call(BrokerRequest {
-                    request_id: RequestId(request_id),
-                    operation: BrokerOperation::CloseObject(ObjectHandle(request_id)),
-                })
-            })
-        });
-        for _ in 0..pending_callers.len() {
-            let frame = read_frame_with_deadline(&mut host_stream, None)
-                .unwrap()
-                .unwrap();
-            decode_request(&frame).unwrap();
-        }
-
-        host_stream.shutdown(Shutdown::Read).unwrap();
-        let failing_channel = Arc::clone(&channel);
-        let failing_caller = thread::spawn(move || {
-            failing_channel.call(BrokerRequest {
-                request_id: RequestId(3),
-                operation: BrokerOperation::CloseObject(ObjectHandle(3)),
-            })
-        });
-
-        assert!(failing_caller.join().unwrap().is_err());
-        for caller in pending_callers {
-            assert!(caller.join().unwrap().is_err());
-        }
-        failure_receiver
-            .recv_timeout(Duration::from_secs(1))
-            .unwrap();
-        assert_eq!(failure_count.load(Ordering::SeqCst), 1);
-    }
-
-    #[test]
-    fn duplicate_response_identifier_fails_other_pending_calls() {
-        let (local_stream, mut host_stream) = UnixStream::pair().unwrap();
-        let (channel, _cancellation, failure_count, failure_receiver) =
-            activate_counting_failure_channel(local_stream);
-        let channel = Arc::new(channel);
-        let first_channel = Arc::clone(&channel);
-        let first = thread::spawn(move || {
-            first_channel.call(BrokerRequest {
-                request_id: RequestId(1),
-                operation: BrokerOperation::CloseObject(ObjectHandle(1)),
-            })
-        });
-        let second_channel = Arc::clone(&channel);
-        let second = thread::spawn(move || {
-            second_channel.call(BrokerRequest {
-                request_id: RequestId(2),
-                operation: BrokerOperation::CloseObject(ObjectHandle(2)),
-            })
-        });
-
-        for _ in 0..2 {
-            let frame = read_frame_with_deadline(&mut host_stream, None)
-                .unwrap()
-                .unwrap();
-            decode_request(&frame).unwrap();
-        }
-        let response = encode_response(BrokerResponse {
-            request_id: RequestId(1),
-            result: BrokerResult::ObjectClosed,
-        });
-        write_frame_with_deadline(&mut host_stream, &response, None).unwrap();
-        write_frame_with_deadline(&mut host_stream, &response, None).unwrap();
-
-        assert_eq!(first.join().unwrap().unwrap().request_id, RequestId(1));
-        assert_eq!(
-            second.join().unwrap().unwrap_err().kind(),
-            ErrorKind::InvalidData
-        );
-        failure_receiver
-            .recv_timeout(Duration::from_secs(1))
-            .unwrap();
-        assert_eq!(failure_count.load(Ordering::SeqCst), 1);
-    }
-
-    #[test]
-    fn completed_call_wins_over_later_association_failure() {
-        let pending = PendingCalls::new();
-        let request_id = RequestId(1);
-        let pending_call = pending.register(request_id).unwrap();
-        pending
-            .complete(BrokerResponse {
-                request_id,
-                result: BrokerResult::ObjectClosed,
-            })
-            .unwrap();
-        pending.record_failure(Arc::new(Error::new(
-            ErrorKind::ConnectionAborted,
-            "test failure",
-        )));
-
-        assert_eq!(pending_call.wait().unwrap().request_id, request_id);
-    }
-
-    #[test]
-    fn duplicate_pending_registration_preserves_the_original_call() {
-        let pending = PendingCalls::new();
-        let request_id = RequestId(1);
-        let pending_call = pending.register(request_id).unwrap();
-        assert_eq!(
-            pending.register(request_id).err().unwrap().kind(),
-            ErrorKind::InvalidData
-        );
-        pending
-            .complete(BrokerResponse {
-                request_id,
-                result: BrokerResult::ObjectClosed,
-            })
-            .unwrap();
-
-        assert_eq!(pending_call.wait().unwrap().request_id, request_id);
-    }
-
-    #[test]
-    fn association_failure_wins_before_completion() {
-        let pending = PendingCalls::new();
-        let request_id = RequestId(1);
-        let pending_call = pending.register(request_id).unwrap();
-        pending.record_failure(Arc::new(Error::new(
-            ErrorKind::ConnectionAborted,
-            "test failure",
-        )));
-
-        assert!(
-            pending
-                .complete(BrokerResponse {
-                    request_id,
-                    result: BrokerResult::ObjectClosed,
-                })
-                .is_err()
-        );
-        assert_eq!(
-            pending_call.wait().unwrap_err().kind(),
-            ErrorKind::ConnectionAborted
-        );
-    }
-
-    #[test]
-    fn malformed_frames_are_invalid() {
-        let (mut writer, mut reader) = UnixStream::pair().unwrap();
-        writer.write_all(&[1, 0]).unwrap();
-        drop(writer);
-        assert_eq!(
-            read_frame_with_deadline(&mut reader, None)
-                .unwrap_err()
-                .kind(),
-            ErrorKind::InvalidData
-        );
-
-        let (mut writer, mut reader) = UnixStream::pair().unwrap();
-        writer.write_all(&0u32.to_le_bytes()).unwrap();
-        assert_eq!(
-            read_frame_with_deadline(&mut reader, None)
-                .unwrap_err()
-                .kind(),
-            ErrorKind::InvalidData
-        );
-
-        let (mut writer, mut reader) = UnixStream::pair().unwrap();
-        writer
-            .write_all(&u32::try_from(MAX_FRAME_LEN + 1).unwrap().to_le_bytes())
-            .unwrap();
-        assert_eq!(
-            read_frame_with_deadline(&mut reader, None)
-                .unwrap_err()
-                .kind(),
-            ErrorKind::InvalidData
-        );
-
-        let (mut writer, mut reader) = UnixStream::pair().unwrap();
-        writer.write_all(&4u32.to_le_bytes()).unwrap();
-        writer.write_all(&[1, 2]).unwrap();
-        drop(writer);
-        assert_eq!(
-            read_frame_with_deadline(&mut reader, None)
-                .unwrap_err()
-                .kind(),
-            ErrorKind::InvalidData
-        );
-    }
-
-    #[test]
-    fn local_handshake_response_read_setup_deadline_is_wall_clock() {
+    fn handshake_reads_use_absolute_setup_deadlines() {
         let (mut host_stream, local_stream) = UnixStream::pair().unwrap();
-        let mut channel = UnixStreamLocalControlChannel {
+        let mut local = UnixStreamLocalControlChannel {
             state: UnixStreamLocalControlState::Setup(UnixStreamLocalSetup {
                 stream: local_stream,
                 setup_deadline: Some(Instant::now() + Duration::from_millis(50)),
                 negotiated: false,
             }),
         };
-
-        let reader = std::thread::spawn(move || channel.recv_handshake_response().unwrap_err());
+        let local_reader = thread::spawn(move || local.recv_handshake_response().unwrap_err());
         host_stream.write_all(&8u32.to_le_bytes()).unwrap();
         for _ in 0..8 {
-            std::thread::sleep(Duration::from_millis(20));
+            thread::sleep(Duration::from_millis(20));
             if host_stream.write_all(&[0]).is_err() {
                 break;
             }
         }
-
-        let error = reader.join().expect("timeout reader panicked");
+        let error = local_reader.join().unwrap();
         assert!(
             matches!(error.kind(), ErrorKind::WouldBlock | ErrorKind::TimedOut),
-            "unexpected timeout error kind: {error:?}"
+            "unexpected local timeout error: {error:?}"
         );
-    }
 
-    #[test]
-    fn host_handshake_request_read_setup_deadline_is_wall_clock() {
         let (mut local_stream, host_stream) = UnixStream::pair().unwrap();
-        let mut channel = UnixStreamHostControlChannel::from_host_guaranteed(
+        let mut host = UnixStreamHostControlChannel::from_host_guaranteed(
             host_stream,
             Instant::now() + Duration::from_millis(50),
         );
-
-        let reader = std::thread::spawn(move || channel.recv_handshake_request().unwrap_err());
+        let host_reader = thread::spawn(move || host.recv_handshake_request().unwrap_err());
         local_stream.write_all(&8u32.to_le_bytes()).unwrap();
         for _ in 0..8 {
-            std::thread::sleep(Duration::from_millis(20));
+            thread::sleep(Duration::from_millis(20));
             if local_stream.write_all(&[0]).is_err() {
                 break;
             }
         }
-
-        let error = reader.join().expect("timeout reader panicked");
+        let error = host_reader.join().unwrap();
         assert!(
             matches!(error.kind(), ErrorKind::WouldBlock | ErrorKind::TimedOut),
-            "unexpected timeout error kind: {error:?}"
+            "unexpected host timeout error: {error:?}"
         );
     }
 
     #[test]
-    fn negotiated_host_handshake_restores_active_timeouts() {
-        let (mut local_stream, host_stream) = UnixStream::pair().unwrap();
-        let active_read_timeout = Some(Duration::from_secs(2));
-        let active_write_timeout = Some(Duration::from_secs(3));
-        host_stream.set_read_timeout(active_read_timeout).unwrap();
-        host_stream.set_write_timeout(active_write_timeout).unwrap();
-        let mut channel = UnixStreamHostControlChannel::from_host_guaranteed(
-            host_stream,
-            Instant::now() + Duration::from_secs(1),
-        );
-        let request = BrokerHandshakeRequest {
-            protocol_version: litebox_broker_protocol::BROKER_PROTOCOL_VERSION,
-        };
-
-        write_frame_with_deadline(
-            &mut local_stream,
-            &encode_handshake_request(request.clone()),
-            None,
-        )
-        .unwrap();
-        assert_eq!(
-            channel.recv_handshake_request().unwrap(),
-            HostReceive::Message(request)
-        );
-        channel
-            .send_handshake_response(&BrokerHandshakeResponse::Negotiated {
-                broker_protocol_version: litebox_broker_protocol::BROKER_PROTOCOL_VERSION,
-            })
-            .unwrap();
-
-        assert_eq!(channel.setup_deadline, None);
-        assert_eq!(channel.stream.read_timeout().unwrap(), active_read_timeout);
-        assert_eq!(
-            channel.stream.write_timeout().unwrap(),
-            active_write_timeout
-        );
-    }
-
-    #[test]
-    fn host_control_requires_negotiation_before_active_split() {
-        let (_peer_stream, host_stream) = UnixStream::pair().unwrap();
-        let channel = UnixStreamHostControlChannel::from_accepted(host_stream);
-
-        assert!(channel.into_active().is_err());
-    }
-
-    #[test]
-    fn concurrent_host_response_sinks_write_complete_frames() {
-        let (mut peer_stream, host_stream) = UnixStream::pair().unwrap();
-        let mut channel = UnixStreamHostControlChannel::from_accepted(host_stream);
-        channel
-            .send_handshake_response(&BrokerHandshakeResponse::Negotiated {
-                broker_protocol_version: litebox_broker_protocol::BROKER_PROTOCOL_VERSION,
-            })
-            .unwrap();
-        let handshake = read_frame_with_deadline(&mut peer_stream, None)
-            .unwrap()
-            .unwrap();
-        assert!(matches!(
-            decode_handshake_response(&handshake).unwrap(),
-            BrokerHandshakeResponse::Negotiated { .. }
-        ));
-        let (_request_source, response_sink, _shutdown) = channel.into_active().unwrap();
-        let first_sink = response_sink.clone();
-        let first = std::thread::spawn(move || {
-            first_sink
-                .send_response(&BrokerResponse {
-                    request_id: RequestId(1),
-                    result: BrokerResult::ObjectClosed,
-                })
-                .unwrap();
-        });
-        let second = std::thread::spawn(move || {
-            response_sink
-                .send_response(&BrokerResponse {
-                    request_id: RequestId(2),
-                    result: BrokerResult::ObjectClosed,
-                })
-                .unwrap();
-        });
-
-        let mut response_ids = [RequestId(0); 2];
-        for response_id in &mut response_ids {
-            let frame = read_frame_with_deadline(&mut peer_stream, None)
-                .unwrap()
-                .unwrap();
-            *response_id = decode_response(&frame).unwrap().request_id;
-        }
-        response_ids.sort();
-        assert_eq!(response_ids, [RequestId(1), RequestId(2)]);
-        first.join().unwrap();
-        second.join().unwrap();
-    }
-
-    #[test]
-    fn local_control_cancellation_unblocks_pending_call() {
-        let (local_stream, mut host_stream) = UnixStream::pair().unwrap();
-        host_stream
-            .set_read_timeout(Some(Duration::from_secs(1)))
-            .unwrap();
-        let (channel, cancellation) = activate_test_channel(local_stream, || {});
-        let (result_sender, result_receiver) = mpsc::sync_channel(1);
-        let caller = std::thread::spawn(move || {
-            result_sender
-                .send(channel.call(BrokerRequest {
-                    request_id: RequestId(0),
-                    operation: BrokerOperation::CloseObject(litebox_broker_protocol::ObjectHandle(
-                        1,
-                    )),
-                }))
-                .unwrap();
-        });
-
-        let frame = read_frame_with_deadline(&mut host_stream, None)
-            .unwrap()
-            .unwrap();
-        decode_request(&frame).unwrap();
-        assert!(matches!(
-            result_receiver.try_recv(),
-            Err(mpsc::TryRecvError::Empty)
-        ));
-        cancellation.cancel().unwrap();
-
-        assert_eq!(
-            result_receiver
-                .recv_timeout(Duration::from_secs(1))
-                .unwrap()
-                .unwrap_err()
-                .kind(),
-            ErrorKind::ConnectionAborted
-        );
-        caller.join().unwrap();
-    }
-
-    #[test]
-    fn dropping_local_control_closes_connection_with_cancellation_clone() {
-        let (local_stream, mut host_stream) = UnixStream::pair().unwrap();
-        let (channel, _cancellation) = activate_test_channel(local_stream, || {});
-        host_stream
-            .set_read_timeout(Some(Duration::from_secs(1)))
-            .unwrap();
-
-        drop(channel);
-
-        let mut byte = [0];
-        assert_eq!(host_stream.read(&mut byte).unwrap(), 0);
-    }
-
-    #[test]
-    fn host_reports_wrong_phase_request_frames_as_protocol_violations() {
-        let (mut peer_stream, host_stream) = UnixStream::pair().unwrap();
-        let mut channel = UnixStreamHostControlChannel::from_accepted(host_stream);
-        write_frame_with_deadline(
-            &mut peer_stream,
-            &encode_request(BrokerRequest {
-                request_id: RequestId(0),
-                operation: BrokerOperation::Event(
-                    litebox_broker_protocol::message::EventRequest::Create(
-                        litebox_broker_protocol::event::CreateEventRequest { initial_count: 0 },
-                    ),
-                ),
-            }),
-            None,
-        )
-        .unwrap();
-        assert_eq!(
-            channel.recv_handshake_request().unwrap(),
-            HostReceive::ProtocolViolation
-        );
-
-        let (mut peer_stream, host_stream) = UnixStream::pair().unwrap();
-        let mut channel = UnixStreamHostControlChannel::from_accepted(host_stream);
-        write_frame_with_deadline(
-            &mut peer_stream,
-            &encode_handshake_request(BrokerHandshakeRequest {
-                protocol_version: litebox_broker_protocol::BROKER_PROTOCOL_VERSION,
-            }),
-            None,
-        )
-        .unwrap();
-        assert_eq!(
-            channel.recv_request().unwrap(),
-            HostReceive::ProtocolViolation
-        );
-    }
-
-    #[test]
-    fn notification_frame_round_trip() {
+    fn notification_frame_round_trips() {
         let (local_stream, host_stream) = UnixStream::pair().unwrap();
         let mut local = UnixStreamLocalNotificationChannel::from_connected(local_stream);
         let mut host = UnixStreamHostNotificationChannel::from_accepted(host_stream);
         let notification = BrokerNotification::Readiness(
             litebox_broker_protocol::message::ReadinessNotification {
-                handle: litebox_broker_protocol::ObjectHandle(7),
+                handle: ObjectHandle(7),
                 readiness: litebox_broker_protocol::readiness::ReadinessFlags::READ,
             },
         );
@@ -1703,5 +1701,41 @@ mod tests {
         host.send_notification(&notification).unwrap();
 
         assert_eq!(local.recv_notification().unwrap(), Some(notification));
+    }
+
+    #[test]
+    fn completed_call_wins_over_later_failure_and_failure_wins_before_completion() {
+        let pending = PendingCalls::new();
+        let completed = pending.register(RequestId(1)).unwrap();
+        pending.complete(response(RequestId(1))).unwrap();
+        pending.record_failure(Arc::new(Error::new(
+            ErrorKind::ConnectionAborted,
+            "test failure",
+        )));
+        assert_eq!(completed.wait().unwrap().request_id, RequestId(1));
+
+        let pending = PendingCalls::new();
+        let failed = pending.register(RequestId(2)).unwrap();
+        pending.record_failure(Arc::new(Error::new(
+            ErrorKind::ConnectionAborted,
+            "test failure",
+        )));
+        assert!(pending.complete(response(RequestId(2))).is_err());
+        assert_eq!(
+            failed.wait().unwrap_err().kind(),
+            ErrorKind::ConnectionAborted
+        );
+    }
+
+    #[test]
+    fn duplicate_pending_registration_preserves_original() {
+        let pending = PendingCalls::new();
+        let original = pending.register(RequestId(1)).unwrap();
+        let Err(error) = pending.register(RequestId(1)) else {
+            panic!("duplicate registration unexpectedly succeeded");
+        };
+        assert_eq!(error.kind(), ErrorKind::InvalidData);
+        pending.complete(response(RequestId(1))).unwrap();
+        assert_eq!(original.wait().unwrap().request_id, RequestId(1));
     }
 }

--- a/litebox_broker_transport/src/unix_socket.rs
+++ b/litebox_broker_transport/src/unix_socket.rs
@@ -570,8 +570,14 @@ impl UnixStreamHostRequestSource {
     /// Receives one active broker request.
     pub fn recv_request(&mut self) -> IoResult<HostReceive<BrokerRequest>> {
         loop {
+            if let Some(error) = self.active.request_failure() {
+                return Err(error);
+            }
             match self.consumer.try_read(decode_request) {
                 Ok(ControlRingReadStatus::Message(request)) => {
+                    if let Some(error) = self.active.request_failure() {
+                        return Err(error);
+                    }
                     if let Err(error) = self
                         .consumer
                         .publish_head()
@@ -860,6 +866,17 @@ impl HostActiveState {
             HostActiveStatus::Live => None,
             HostActiveStatus::PeerClosed => Some(Ok(HostReceive::PeerClosed)),
             HostActiveStatus::Failed(error) => Some(Err(copy_io_error(error))),
+        }
+    }
+
+    fn request_failure(&self) -> Option<Error> {
+        match &*self
+            .status
+            .lock()
+            .expect("broker host active-state mutex poisoned")
+        {
+            HostActiveStatus::Failed(error) => Some(copy_io_error(error)),
+            HostActiveStatus::Live | HostActiveStatus::PeerClosed => None,
         }
     }
 
@@ -1556,6 +1573,32 @@ mod control_ring_tests {
         let receiver = thread::spawn(move || source.recv_request());
         drop(peer);
         assert_eq!(receiver.join().unwrap().unwrap(), HostReceive::PeerClosed);
+    }
+
+    #[test]
+    fn host_failure_preempts_queued_request_but_peer_close_drains_it() {
+        let (mut source, _sink, _shutdown, mut requests, _responses, _peer) = split_host();
+        write_payload(&mut requests, &encode_request(request(1)));
+        source
+            .active
+            .fail(Error::new(ErrorKind::TimedOut, "test failure"))
+            .unwrap();
+        assert_eq!(
+            source.recv_request().unwrap_err().kind(),
+            ErrorKind::TimedOut
+        );
+
+        let (mut source, _sink, _shutdown, mut requests, _responses, _peer) = split_host();
+        write_payload(&mut requests, &encode_request(request(2)));
+        source.active.peer_closed();
+        assert!(matches!(
+            source.recv_request().unwrap(),
+            HostReceive::Message(BrokerRequest {
+                request_id: RequestId(2),
+                ..
+            })
+        ));
+        assert_eq!(source.recv_request().unwrap(), HostReceive::PeerClosed);
     }
 
     #[test]

--- a/litebox_broker_transport/src/unix_socket.rs
+++ b/litebox_broker_transport/src/unix_socket.rs
@@ -19,8 +19,8 @@ use std::time::Instant;
 use std::{collections::HashMap, thread};
 
 use crate::control_ring::{
-    ControlRing, ControlRingConsumer, ControlRingReadError, ControlRingReadStatus,
-    ControlRingWakeHandle, ControlRingWriteStatus,
+    ControlRing, ControlRingConsumer, ControlRingError, ControlRingReadError,
+    ControlRingReadStatus, ControlRingWakeHandle, ControlRingWriteStatus,
 };
 use crate::shared_memory::MemfdSharedMemory;
 use crate::unix_io::{
@@ -513,10 +513,7 @@ impl LocalControlChannel for UnixStreamLocalControlChannel {
                 if let Some(error) = active.failure_coordinator.pending_calls.current_failure() {
                     break Err(copy_io_error(&error));
                 }
-                match producer
-                    .try_write(&request_frame)
-                    .map_err(control_ring_error)
-                {
+                match producer.try_write(&request_frame).map_err(Error::from) {
                     Ok(ControlRingWriteStatus::Written) => {
                         if let Err(error) = producer.wake_consumer() {
                             break Err(error);
@@ -578,7 +575,7 @@ impl UnixStreamHostRequestSource {
                     if let Err(error) = self
                         .consumer
                         .publish_head()
-                        .map_err(control_ring_error)
+                        .map_err(Error::from)
                         .and_then(|()| self.consumer.wake_producer())
                     {
                         let result = Err(copy_io_error(&error));
@@ -607,7 +604,7 @@ impl UnixStreamHostRequestSource {
                     return result;
                 }
                 Err(ControlRingReadError::Ring(error)) => {
-                    let error = control_ring_error(error);
+                    let error = Error::from(error);
                     let result = Err(copy_io_error(&error));
                     let _ = self.active.fail(error);
                     return result;
@@ -627,7 +624,7 @@ impl UnixStreamHostResponseSink {
             .map_err(|_| Error::other("broker response writer mutex poisoned"))?;
         loop {
             self.active.ensure_response_path_live()?;
-            match producer.try_write(&frame).map_err(control_ring_error) {
+            match producer.try_write(&frame).map_err(Error::from) {
                 Ok(ControlRingWriteStatus::Written) => {
                     if let Err(error) = producer.wake_consumer() {
                         let result = Err(copy_io_error(&error));
@@ -941,7 +938,7 @@ fn dispatch_responses(
             Ok(ControlRingReadStatus::Message(response)) => {
                 if let Err(error) = consumer
                     .publish_head()
-                    .map_err(control_ring_error)
+                    .map_err(Error::from)
                     .and_then(|()| consumer.wake_producer())
                     .and_then(|()| failure_coordinator.pending_calls.complete(response))
                 {
@@ -963,7 +960,7 @@ fn dispatch_responses(
                 }
             }
             Err(ControlRingReadError::Ring(error)) => {
-                let _ = failure_coordinator.fail(control_ring_error(error));
+                let _ = failure_coordinator.fail(Error::from(error));
                 return;
             }
             Err(ControlRingReadError::Decode(error)) => {
@@ -1067,11 +1064,13 @@ fn wire_error(error: WireError) -> Error {
     )
 }
 
-fn control_ring_error(error: crate::control_ring::ControlRingError) -> Error {
-    Error::new(
-        ErrorKind::InvalidData,
-        format!("invalid broker control ring: {error:?}"),
-    )
+impl From<ControlRingError> for Error {
+    fn from(error: ControlRingError) -> Self {
+        Self::new(
+            ErrorKind::InvalidData,
+            format!("invalid broker control ring: {error:?}"),
+        )
+    }
 }
 
 #[cfg(test)]

--- a/litebox_broker_transport/src/unix_socket.rs
+++ b/litebox_broker_transport/src/unix_socket.rs
@@ -626,7 +626,7 @@ impl UnixStreamHostResponseSink {
             .lock()
             .map_err(|_| Error::other("broker response writer mutex poisoned"))?;
         loop {
-            self.active.response_live()?;
+            self.active.ensure_response_path_live()?;
             match producer.try_write(&frame).map_err(control_ring_error) {
                 Ok(ControlRingWriteStatus::Written) => {
                     if let Err(error) = producer.wake_consumer() {
@@ -866,7 +866,7 @@ impl HostActiveState {
         }
     }
 
-    fn response_live(&self) -> IoResult<()> {
+    fn ensure_response_path_live(&self) -> IoResult<()> {
         match &*self
             .status
             .lock()

--- a/litebox_broker_transport/src/unix_socket.rs
+++ b/litebox_broker_transport/src/unix_socket.rs
@@ -510,10 +510,11 @@ impl LocalControlChannel for UnixStreamLocalControlChannel {
                 .lock()
                 .expect("broker request writer mutex poisoned");
             loop {
-                if let Some(error) = active.failure_coordinator.pending_calls.current_failure() {
-                    break Err(copy_io_error(&error));
-                }
-                match producer.try_write(&request_frame).map_err(Error::from) {
+                let write_status = active
+                    .failure_coordinator
+                    .pending_calls
+                    .run_if_live(|| producer.try_write(&request_frame).map_err(Error::from));
+                match write_status {
                     Ok(ControlRingWriteStatus::Written) => {
                         if let Err(error) = producer.wake_consumer() {
                             break Err(error);
@@ -575,19 +576,7 @@ impl UnixStreamHostRequestSource {
             }
             match self.consumer.try_read(decode_request) {
                 Ok(ControlRingReadStatus::Message(request)) => {
-                    if let Some(error) = self.active.request_failure() {
-                        return Err(error);
-                    }
-                    if let Err(error) = self
-                        .consumer
-                        .publish_head()
-                        .map_err(Error::from)
-                        .and_then(|()| self.consumer.wake_producer())
-                    {
-                        let result = Err(copy_io_error(&error));
-                        let _ = self.active.fail(error);
-                        return result;
-                    }
+                    self.active.acknowledge_request(&mut self.consumer)?;
                     return Ok(HostReceive::Message(request));
                 }
                 Ok(ControlRingReadStatus::Empty { wait_epoch }) => {
@@ -812,6 +801,15 @@ impl PendingCalls {
             .as_ref()
             .map(Arc::clone)
     }
+
+    /// Runs a nonblocking publication while excluding failure recording.
+    fn run_if_live<T>(&self, operation: impl FnOnce() -> IoResult<T>) -> IoResult<T> {
+        let state = self.state.lock().expect("broker pending mutex poisoned");
+        if let Some(error) = state.failure.as_ref() {
+            return Err(copy_io_error(error));
+        }
+        operation()
+    }
 }
 
 impl LocalActiveFailureCoordinator {
@@ -828,6 +826,31 @@ impl LocalActiveFailureCoordinator {
 }
 
 impl HostActiveState {
+    fn acknowledge_request(
+        &self,
+        consumer: &mut ControlRingConsumer<MemfdSharedMemory>,
+    ) -> IoResult<()> {
+        let result = {
+            let status = self
+                .status
+                .lock()
+                .expect("broker host active-state mutex poisoned");
+            if let HostActiveStatus::Failed(error) = &*status {
+                return Err(copy_io_error(error));
+            }
+            consumer
+                .publish_head()
+                .map_err(Error::from)
+                .and_then(|()| consumer.wake_producer())
+        };
+        if let Err(error) = result {
+            let result = Err(copy_io_error(&error));
+            let _ = self.fail(error);
+            return result;
+        }
+        Ok(())
+    }
+
     fn fail(&self, error: Error) -> IoResult<()> {
         {
             let mut status = self
@@ -1576,7 +1599,7 @@ mod control_ring_tests {
     }
 
     #[test]
-    fn host_failure_preempts_queued_request_but_peer_close_drains_it() {
+    fn host_failure_preempts_queued_and_decoded_requests_but_peer_close_drains() {
         let (mut source, _sink, _shutdown, mut requests, _responses, _peer) = split_host();
         write_payload(&mut requests, &encode_request(request(1)));
         source
@@ -1590,11 +1613,30 @@ mod control_ring_tests {
 
         let (mut source, _sink, _shutdown, mut requests, _responses, _peer) = split_host();
         write_payload(&mut requests, &encode_request(request(2)));
+        assert!(matches!(
+            source.consumer.try_read(decode_request).unwrap(),
+            ControlRingReadStatus::Message(_)
+        ));
+        source
+            .active
+            .fail(Error::new(ErrorKind::TimedOut, "test failure"))
+            .unwrap();
+        assert_eq!(
+            source
+                .active
+                .acknowledge_request(&mut source.consumer)
+                .unwrap_err()
+                .kind(),
+            ErrorKind::TimedOut
+        );
+
+        let (mut source, _sink, _shutdown, mut requests, _responses, _peer) = split_host();
+        write_payload(&mut requests, &encode_request(request(3)));
         source.active.peer_closed();
         assert!(matches!(
             source.recv_request().unwrap(),
             HostReceive::Message(BrokerRequest {
-                request_id: RequestId(2),
+                request_id: RequestId(3),
                 ..
             })
         ));
@@ -1779,6 +1821,59 @@ mod control_ring_tests {
         assert!(pending.complete(response(RequestId(2))).is_err());
         assert_eq!(
             failed.wait().unwrap_err().kind(),
+            ErrorKind::ConnectionAborted
+        );
+    }
+
+    #[test]
+    fn failure_recording_waits_for_in_progress_publication() {
+        let pending = Arc::new(PendingCalls::new());
+        let pending_call = pending.register(RequestId(1)).unwrap();
+        let publication_state = Arc::new(AtomicUsize::new(0));
+        let (publication_started, wait_for_publication) = std::sync::mpsc::sync_channel(0);
+        let (release_publication, publication_released) = std::sync::mpsc::sync_channel(0);
+        let publisher_pending = Arc::clone(&pending);
+        let publisher_state = Arc::clone(&publication_state);
+        let publisher = thread::spawn(move || {
+            publisher_pending
+                .run_if_live(|| {
+                    publisher_state.store(1, Ordering::Release);
+                    publication_started.send(()).unwrap();
+                    publication_released.recv().unwrap();
+                    publisher_state.store(2, Ordering::Release);
+                    Ok(())
+                })
+                .unwrap();
+        });
+        wait_for_publication.recv().unwrap();
+
+        let (failure_started, wait_for_failure) = std::sync::mpsc::sync_channel(0);
+        let (failure_recorded, wait_for_recording) = std::sync::mpsc::sync_channel(0);
+        let failure_pending = Arc::clone(&pending);
+        let failure_state = Arc::clone(&publication_state);
+        let failure = thread::spawn(move || {
+            failure_started.send(()).unwrap();
+            failure_pending.record_failure(Arc::new(Error::new(
+                ErrorKind::ConnectionAborted,
+                "test failure",
+            )));
+            assert_eq!(failure_state.load(Ordering::Acquire), 2);
+            failure_recorded.send(()).unwrap();
+        });
+        wait_for_failure.recv().unwrap();
+        assert!(matches!(
+            wait_for_recording.recv_timeout(Duration::from_millis(20)),
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout)
+        ));
+
+        release_publication.send(()).unwrap();
+        publisher.join().unwrap();
+        wait_for_recording
+            .recv_timeout(Duration::from_secs(1))
+            .unwrap();
+        failure.join().unwrap();
+        assert_eq!(
+            pending_call.wait().unwrap_err().kind(),
             ErrorKind::ConnectionAborted
         );
     }

--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -160,7 +160,7 @@ fn dispatch_requests<Memory: SharedMemory>(
     shutdown: UnixStreamHostControlShutdown,
 ) -> IoResult<()> {
     let association = Arc::new(association);
-    let failure = Arc::new(HostAssociationFailure::new(shutdown));
+    let failure_coordinator = Arc::new(HostAssociationFailureCoordinator::new(shutdown));
     let (request_sender, request_receiver) = sync_channel(REQUEST_QUEUE_CAPACITY);
     let request_receiver = Arc::new(Mutex::new(request_receiver));
 
@@ -170,7 +170,7 @@ fn dispatch_requests<Memory: SharedMemory>(
             let association = Arc::clone(&association);
             let request_receiver = Arc::clone(&request_receiver);
             let response_sink = response_sink.clone();
-            let worker_failure = Arc::clone(&failure);
+            let worker_failure_coordinator = Arc::clone(&failure_coordinator);
             match std::thread::Builder::new()
                 .name(format!("litebox-broker-worker-{worker_id}"))
                 .spawn_scoped(scope, move || {
@@ -178,26 +178,26 @@ fn dispatch_requests<Memory: SharedMemory>(
                         &association,
                         &request_receiver,
                         &response_sink,
-                        &worker_failure,
+                        &worker_failure_coordinator,
                     );
                 }) {
                 Ok(worker) => workers.push(worker),
                 Err(error) => {
-                    failure.report(error);
+                    failure_coordinator.report(error);
                     break;
                 }
             }
         }
 
-        read_requests(&mut request_source, request_sender, &failure);
+        read_requests(&mut request_source, request_sender, &failure_coordinator);
         for worker in workers {
             if worker.join().is_err() {
-                failure.report(IoError::other("broker request worker panicked"));
+                failure_coordinator.report(IoError::other("broker request worker panicked"));
             }
         }
     });
 
-    match failure.take_error() {
+    match failure_coordinator.take_error() {
         Some(error) => Err(error),
         None => Ok(()),
     }
@@ -206,16 +206,16 @@ fn dispatch_requests<Memory: SharedMemory>(
 fn read_requests(
     request_source: &mut UnixStreamHostRequestSource,
     request_sender: SyncSender<BrokerRequest>,
-    failure: &HostAssociationFailure,
+    failure_coordinator: &HostAssociationFailureCoordinator,
 ) {
     loop {
-        if failure.failed() {
+        if failure_coordinator.failed() {
             break;
         }
         match request_source.recv_request() {
             Ok(HostReceive::Message(request)) => {
                 if request_sender.send(request).is_err() {
-                    failure.report(IoError::new(
+                    failure_coordinator.report(IoError::new(
                         ErrorKind::BrokenPipe,
                         "broker request workers stopped",
                     ));
@@ -223,7 +223,7 @@ fn read_requests(
                 }
             }
             Ok(HostReceive::ProtocolViolation) => {
-                failure.report(IoError::new(
+                failure_coordinator.report(IoError::new(
                     ErrorKind::InvalidData,
                     "runner sent a request for the wrong protocol phase",
                 ));
@@ -231,7 +231,7 @@ fn read_requests(
             }
             Ok(HostReceive::PeerClosed) => break,
             Err(error) => {
-                failure.report(error);
+                failure_coordinator.report(error);
                 break;
             }
         }
@@ -242,7 +242,7 @@ fn run_worker<Memory: SharedMemory>(
     association: &BrokerHostAssociation<'_, Memory>,
     request_receiver: &Mutex<Receiver<BrokerRequest>>,
     response_sink: &UnixStreamHostResponseSink,
-    failure: &HostAssociationFailure,
+    failure_coordinator: &HostAssociationFailureCoordinator,
 ) {
     loop {
         let request = request_receiver
@@ -252,26 +252,28 @@ fn run_worker<Memory: SharedMemory>(
         let Ok(request) = request else {
             break;
         };
-        if failure.failed() {
+        if failure_coordinator.failed() {
             continue;
         }
         match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             association.execute_request(request, |response| response_sink.send_response(response))
         })) {
             Ok(Ok(())) => {}
-            Ok(Err(error)) => failure.report(IoError::other(error)),
-            Err(_) => failure.report(IoError::other("broker request worker panicked")),
+            Ok(Err(error)) => failure_coordinator.report(IoError::other(error)),
+            Err(_) => {
+                failure_coordinator.report(IoError::other("broker request worker panicked"));
+            }
         }
     }
 }
 
-struct HostAssociationFailure {
+struct HostAssociationFailureCoordinator {
     failed: AtomicBool,
     error: Mutex<Option<IoError>>,
     shutdown: UnixStreamHostControlShutdown,
 }
 
-impl HostAssociationFailure {
+impl HostAssociationFailureCoordinator {
     const fn new(shutdown: UnixStreamHostControlShutdown) -> Self {
         Self {
             failed: AtomicBool::new(false),
@@ -372,14 +374,14 @@ mod tests {
         let (mut request_source, _response_sink, shutdown) =
             control_channel.into_active(host_ring).unwrap();
         let (_local_channel, _cancellation) = local_activation.join().unwrap();
-        let failure = HostAssociationFailure::new(shutdown);
+        let failure_coordinator = HostAssociationFailureCoordinator::new(shutdown);
         let (result_sender, result_receiver) = std::sync::mpsc::sync_channel(1);
         let reader = std::thread::spawn(move || {
             result_sender.send(request_source.recv_request()).unwrap();
         });
 
-        failure.report(IoError::new(ErrorKind::TimedOut, "first failure"));
-        failure.report(IoError::other("second failure"));
+        failure_coordinator.report(IoError::new(ErrorKind::TimedOut, "first failure"));
+        failure_coordinator.report(IoError::other("second failure"));
         let receive_result = result_receiver.recv_timeout(Duration::from_secs(1));
         reader.join().unwrap();
 
@@ -387,7 +389,7 @@ mod tests {
             receive_result.unwrap(),
             Ok(HostReceive::PeerClosed) | Err(_)
         ));
-        let error = failure.take_error().unwrap();
+        let error = failure_coordinator.take_error().unwrap();
         assert_eq!(error.kind(), ErrorKind::TimedOut);
         assert_eq!(error.to_string(), "first failure");
     }

--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -22,6 +22,7 @@ use litebox_broker_protocol::message::BrokerRequest;
 use litebox_broker_protocol::shared_memory::{
     SHARED_BUFFER_LAYOUT, SHARED_BUFFER_POOL_SIZE, SharedBufferPool, SharedMemory,
 };
+use litebox_broker_transport::control_ring::{CONTROL_RING_MEMORY_SIZE, ControlRing};
 use litebox_broker_transport::shared_memory::MemfdSharedMemory;
 use litebox_broker_transport::unix_socket::{
     UnixStreamHostControlChannel, UnixStreamHostControlShutdown, UnixStreamHostNotificationChannel,
@@ -111,6 +112,9 @@ fn serve_runner(
     )?;
     let shared_memory = MemfdSharedMemory::create(SHARED_BUFFER_POOL_SIZE)?;
     let shared_buffers = SharedBufferPool::new(shared_memory, SHARED_BUFFER_LAYOUT)?;
+    let control_memory = MemfdSharedMemory::create(CONTROL_RING_MEMORY_SIZE)?;
+    let control_ring = ControlRing::new(control_memory)
+        .map_err(|error| IoError::other(format!("failed to create control ring: {error:?}")))?;
     let mut control_channel =
         UnixStreamHostControlChannel::from_host_guaranteed(control_stream, setup_deadline);
     let _notification_channel =
@@ -118,6 +122,7 @@ fn serve_runner(
     let association =
         match setup_connection(broker, &mut control_channel, &shared_buffers, |channel| {
             channel.send_memfd(shared_buffers.memory(), Some(setup_deadline))?;
+            channel.send_memfd(control_ring.memory(), Some(setup_deadline))?;
             Ok(())
         })? {
             Ok(association) => association,
@@ -143,7 +148,7 @@ fn serve_runner(
                 .into());
             }
         };
-    let (request_source, response_sink, shutdown) = control_channel.into_active()?;
+    let (request_source, response_sink, shutdown) = control_channel.into_active(control_ring)?;
     dispatch_requests(association, request_source, response_sink, shutdown)?;
     Ok(())
 }
@@ -336,19 +341,37 @@ fn accept_runner_stream(
 mod tests {
     use super::*;
     use litebox_broker_protocol::BROKER_PROTOCOL_VERSION;
-    use litebox_broker_protocol::channel::HostControlChannel;
+    use litebox_broker_protocol::channel::{HostSetupChannel, LocalControlChannel};
     use litebox_broker_protocol::message::BrokerHandshakeResponse;
+    use litebox_broker_transport::unix_socket::UnixStreamLocalControlChannel;
+    use std::os::fd::AsFd;
 
     #[test]
     fn first_failure_is_preserved_and_unblocks_request_reading() {
         let (peer_stream, host_stream) = UnixStream::pair().unwrap();
+        let mut local_channel = UnixStreamLocalControlChannel::from_connected(peer_stream);
         let mut control_channel = UnixStreamHostControlChannel::from_accepted(host_stream);
         control_channel
             .send_handshake_response(&BrokerHandshakeResponse::Negotiated {
                 broker_protocol_version: BROKER_PROTOCOL_VERSION,
             })
             .unwrap();
-        let (mut request_source, _response_sink, shutdown) = control_channel.into_active().unwrap();
+        local_channel.recv_handshake_response().unwrap().unwrap();
+        let local_memory = MemfdSharedMemory::create(CONTROL_RING_MEMORY_SIZE).unwrap();
+        let host_memory = MemfdSharedMemory::from_received_fd(
+            local_memory.as_fd().try_clone_to_owned().unwrap(),
+            CONTROL_RING_MEMORY_SIZE,
+        )
+        .unwrap();
+        let local_ring = ControlRing::new(local_memory).unwrap();
+        let host_ring = ControlRing::new(host_memory).unwrap();
+        let local_activation = std::thread::spawn(move || {
+            let cancellation = local_channel.activate(local_ring, || {}).unwrap();
+            (local_channel, cancellation)
+        });
+        let (mut request_source, _response_sink, shutdown) =
+            control_channel.into_active(host_ring).unwrap();
+        let (_local_channel, _cancellation) = local_activation.join().unwrap();
         let failure = HostAssociationFailure::new(shutdown);
         let (result_sender, result_receiver) = std::sync::mpsc::sync_channel(1);
         let reader = std::thread::spawn(move || {
@@ -358,7 +381,6 @@ mod tests {
         failure.report(IoError::new(ErrorKind::TimedOut, "first failure"));
         failure.report(IoError::other("second failure"));
         let receive_result = result_receiver.recv_timeout(Duration::from_secs(1));
-        drop(peer_stream);
         reader.join().unwrap();
 
         assert!(matches!(

--- a/litebox_broker_userland/tests/notification_runtime.rs
+++ b/litebox_broker_userland/tests/notification_runtime.rs
@@ -5,12 +5,14 @@ use std::os::unix::net::UnixStream;
 use std::sync::Arc;
 
 use litebox_broker_core::{BrokerCore, ObjectRights, PolicyEngine};
-use litebox_broker_host::{ConnectionTermination, serve_connection};
+use litebox_broker_host::{ConnectionTermination, setup_connection};
 use litebox_broker_local::BrokerLocal;
+use litebox_broker_protocol::channel::HostReceive;
 use litebox_broker_protocol::readiness::ReadinessFlags;
 use litebox_broker_protocol::shared_memory::{
     SHARED_BUFFER_LAYOUT, SHARED_BUFFER_POOL_SIZE, SharedBufferPool,
 };
+use litebox_broker_transport::control_ring::{CONTROL_RING_MEMORY_SIZE, ControlRing};
 use litebox_broker_transport::shared_memory::MemfdSharedMemory;
 use litebox_broker_transport::unix_socket::{
     UnixStreamHostControlChannel, UnixStreamHostNotificationChannel, UnixStreamLocalControlChannel,
@@ -27,24 +29,46 @@ fn host_serves_control_requests_over_paired_userland_channels() {
     let host_shared_memory = MemfdSharedMemory::create(SHARED_BUFFER_POOL_SIZE).unwrap();
     let host_shared_buffers =
         SharedBufferPool::new(host_shared_memory, SHARED_BUFFER_LAYOUT).unwrap();
+    let host_control_memory = MemfdSharedMemory::create(CONTROL_RING_MEMORY_SIZE).unwrap();
+    let host_control_ring = ControlRing::new(host_control_memory).unwrap();
 
     let host_thread = std::thread::spawn(move || {
         let mut control = UnixStreamHostControlChannel::from_accepted(host_control);
-        let mut notification = UnixStreamHostNotificationChannel::from_accepted(host_notification);
-        serve_connection(
-            &broker,
-            &mut control,
-            &mut notification,
-            &host_shared_buffers,
-            |channel| channel.send_memfd(host_shared_buffers.memory(), None),
-        )
+        let _notification = UnixStreamHostNotificationChannel::from_accepted(host_notification);
+        let association =
+            setup_connection(&broker, &mut control, &host_shared_buffers, |channel| {
+                channel.send_memfd(host_shared_buffers.memory(), None)?;
+                channel.send_memfd(host_control_ring.memory(), None)
+            })
+            .unwrap()
+            .unwrap();
+        let (mut request_source, response_sink, _shutdown) =
+            control.into_active(host_control_ring).unwrap();
+        loop {
+            match request_source.recv_request().unwrap() {
+                HostReceive::Message(request) => association
+                    .execute_request(request, |response| response_sink.send_response(response))
+                    .unwrap(),
+                HostReceive::PeerClosed => return ConnectionTermination::PeerClosed,
+                HostReceive::ProtocolViolation => {
+                    return ConnectionTermination::ProtocolViolation;
+                }
+            }
+        }
     });
 
     let local = BrokerLocal::negotiate(
         UnixStreamLocalControlChannel::from_connected(local_control),
         |channel| {
             let shared_memory = channel.receive_memfd(SHARED_BUFFER_POOL_SIZE, None)?;
-            let _cancellation = channel.activate(|| {})?;
+            let control_memory = channel.receive_memfd(CONTROL_RING_MEMORY_SIZE, None)?;
+            let control_ring = ControlRing::new(control_memory).map_err(|error| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("invalid test control ring: {error:?}"),
+                )
+            })?;
+            let _cancellation = channel.activate(control_ring, || {})?;
             Ok(Arc::new(shared_memory))
         },
     )
@@ -56,7 +80,7 @@ fn host_serves_control_requests_over_paired_userland_channels() {
 
     drop(local);
     assert_eq!(
-        host_thread.join().unwrap().unwrap(),
+        host_thread.join().unwrap(),
         ConnectionTermination::PeerClosed
     );
 }

--- a/litebox_broker_userland/tests/userland_broker.rs
+++ b/litebox_broker_userland/tests/userland_broker.rs
@@ -13,6 +13,7 @@ use litebox_broker_protocol::readiness::ReadinessFlags;
 use litebox_broker_protocol::shared_memory::{
     SHARED_BUFFER_POOL_SIZE, SharedBufferDescriptor, SharedBufferSlotIndex,
 };
+use litebox_broker_transport::control_ring::{CONTROL_RING_MEMORY_SIZE, ControlRing};
 use litebox_broker_transport::unix_socket::{
     UnixStreamLocalControlChannel, UnixStreamLocalNotificationChannel,
 };
@@ -90,7 +91,17 @@ fn run_fake_runner(args: &[OsString]) {
                 SHARED_BUFFER_POOL_SIZE,
                 Some(Instant::now() + Duration::from_secs(5)),
             )?;
-            let _cancellation = channel.activate(|| {})?;
+            let control_memory = channel.receive_memfd(
+                CONTROL_RING_MEMORY_SIZE,
+                Some(Instant::now() + Duration::from_secs(5)),
+            )?;
+            let control_ring = ControlRing::new(control_memory).map_err(|error| {
+                std::io::Error::new(
+                    ErrorKind::InvalidData,
+                    format!("invalid test control ring: {error:?}"),
+                )
+            })?;
+            let _cancellation = channel.activate(control_ring, || {})?;
             Ok(Arc::new(shared_memory))
         })
         .unwrap(),

--- a/litebox_runner_linux_userland/src/broker.rs
+++ b/litebox_runner_linux_userland/src/broker.rs
@@ -14,6 +14,7 @@ use anyhow::{Context as _, Result};
 use litebox_broker_local::{BrokerLocal, BrokerNotifications};
 use litebox_broker_protocol::message::BrokerNotification;
 use litebox_broker_protocol::shared_memory::SHARED_BUFFER_POOL_SIZE;
+use litebox_broker_transport::control_ring::{CONTROL_RING_MEMORY_SIZE, ControlRing};
 use litebox_broker_transport::unix_socket::{
     UnixStreamLocalControlCancellation, UnixStreamLocalControlChannel,
     UnixStreamLocalNotificationCancellation, UnixStreamLocalNotificationChannel,
@@ -66,8 +67,16 @@ pub(crate) fn connect(
         move |channel| {
             let shared_memory =
                 channel.receive_memfd(SHARED_BUFFER_POOL_SIZE, Some(setup_deadline))?;
+            let control_memory =
+                channel.receive_memfd(CONTROL_RING_MEMORY_SIZE, Some(setup_deadline))?;
+            let control_ring = ControlRing::new(control_memory).map_err(|error| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("invalid broker control ring: {error:?}"),
+                )
+            })?;
             let weak_association_coordinator = Arc::downgrade(&association_coordinator);
-            let control_cancellation_handle = channel.activate(move || {
+            let control_cancellation_handle = channel.activate(control_ring, move || {
                 if let Some(association_coordinator) = weak_association_coordinator.upgrade() {
                     association_coordinator.report_failure();
                 }
@@ -216,11 +225,16 @@ fn connect_with_retry<Channel>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use litebox_broker_protocol::channel::{HostControlChannel, HostReceive, LocalControlChannel};
+    use litebox_broker_protocol::channel::{HostReceive, HostSetupChannel, LocalControlChannel};
     use litebox_broker_protocol::message::{BrokerOperation, BrokerRequest};
     use litebox_broker_protocol::{ObjectHandle, RequestId};
-    use litebox_broker_transport::unix_socket::UnixStreamHostControlChannel;
+    use litebox_broker_transport::shared_memory::MemfdSharedMemory;
+    use litebox_broker_transport::unix_socket::{
+        UnixStreamHostControlChannel, UnixStreamHostControlShutdown, UnixStreamHostRequestSource,
+        UnixStreamHostResponseSink,
+    };
     use std::io::{ErrorKind, Read};
+    use std::os::fd::AsFd;
     use std::os::unix::net::UnixStream;
     use std::sync::mpsc;
 
@@ -253,16 +267,34 @@ mod tests {
 
     fn activate_control_channel(
         channel: &mut UnixStreamLocalControlChannel,
+        host_channel: UnixStreamHostControlChannel,
         association_coordinator: &Arc<BrokerAssociationFailureCoordinator>,
-    ) -> UnixStreamLocalControlCancellation {
+    ) -> (
+        UnixStreamLocalControlCancellation,
+        UnixStreamHostRequestSource,
+        UnixStreamHostResponseSink,
+        UnixStreamHostControlShutdown,
+    ) {
+        let local_memory = MemfdSharedMemory::create(CONTROL_RING_MEMORY_SIZE).unwrap();
+        let host_memory = MemfdSharedMemory::from_received_fd(
+            local_memory.as_fd().try_clone_to_owned().unwrap(),
+            CONTROL_RING_MEMORY_SIZE,
+        )
+        .unwrap();
+        let local_ring = ControlRing::new(local_memory).unwrap();
+        let host_ring = ControlRing::new(host_memory).unwrap();
+        let host_activation =
+            std::thread::spawn(move || host_channel.into_active(host_ring).unwrap());
         let weak_association_coordinator = Arc::downgrade(association_coordinator);
-        channel
-            .activate(move || {
+        let cancellation = channel
+            .activate(local_ring, move || {
                 if let Some(association_coordinator) = weak_association_coordinator.upgrade() {
                     association_coordinator.report_failure();
                 }
             })
-            .unwrap()
+            .unwrap();
+        let (request_source, response_sink, shutdown) = host_activation.join().unwrap();
+        (cancellation, request_source, response_sink, shutdown)
     }
 
     #[test]
@@ -279,15 +311,17 @@ mod tests {
         let association_coordinator = Arc::new(BrokerAssociationFailureCoordinator::new(
             notification_channel.cancellation_handle().unwrap(),
         ));
-        let control_cancellation_handle =
-            activate_control_channel(&mut active_channel, &association_coordinator);
+        let (control_cancellation_handle, host_request_source, host_response_sink, host_shutdown) =
+            activate_control_channel(&mut active_channel, host_control, &association_coordinator);
         association_coordinator
             .install_control_cancellation_handle(control_cancellation_handle)
             .unwrap();
         let (failure_sender, failure_receiver) = mpsc::sync_channel(1);
         association_coordinator.install_dispatch(move || failure_sender.send(()).unwrap());
 
-        drop(host_control);
+        host_shutdown.shutdown().unwrap();
+        drop(host_request_source);
+        drop(host_response_sink);
 
         failure_receiver
             .recv_timeout(Duration::from_secs(1))
@@ -304,7 +338,7 @@ mod tests {
         host_control
             .set_read_timeout(Some(Duration::from_secs(1)))
             .unwrap();
-        let (mut active_channel, mut host_control) =
+        let (mut active_channel, host_control) =
             negotiate_control_pair(local_control, host_control);
         let (local_notification, mut host_notification) = UnixStream::pair().unwrap();
         host_notification
@@ -315,8 +349,12 @@ mod tests {
         let association_coordinator = Arc::new(BrokerAssociationFailureCoordinator::new(
             notification_channel.cancellation_handle().unwrap(),
         ));
-        let control_cancellation_handle =
-            activate_control_channel(&mut active_channel, &association_coordinator);
+        let (
+            control_cancellation_handle,
+            mut host_request_source,
+            _host_response_sink,
+            _host_shutdown,
+        ) = activate_control_channel(&mut active_channel, host_control, &association_coordinator);
 
         association_coordinator.report_failure();
 
@@ -331,7 +369,7 @@ mod tests {
         association_coordinator.install_dispatch(move || failure_sender.send(()).unwrap());
         failure_receiver.try_recv().unwrap();
         assert_eq!(
-            host_control.recv_request().unwrap(),
+            host_request_source.recv_request().unwrap(),
             HostReceive::PeerClosed
         );
         let mut byte = [0];
@@ -343,7 +381,7 @@ mod tests {
     #[test]
     fn notification_failure_cancels_control() {
         let (local_control, host_control) = UnixStream::pair().unwrap();
-        let (mut active_channel, mut host_control) =
+        let (mut active_channel, host_control) =
             negotiate_control_pair(local_control, host_control);
         let (local_notification, host_notification) = UnixStream::pair().unwrap();
         let notification_channel =
@@ -351,8 +389,12 @@ mod tests {
         let association_coordinator = Arc::new(BrokerAssociationFailureCoordinator::new(
             notification_channel.cancellation_handle().unwrap(),
         ));
-        let control_cancellation_handle =
-            activate_control_channel(&mut active_channel, &association_coordinator);
+        let (
+            control_cancellation_handle,
+            mut host_request_source,
+            _host_response_sink,
+            _host_shutdown,
+        ) = activate_control_channel(&mut active_channel, host_control, &association_coordinator);
         association_coordinator
             .install_control_cancellation_handle(control_cancellation_handle)
             .unwrap();
@@ -373,7 +415,7 @@ mod tests {
             })
         });
         assert!(matches!(
-            host_control.recv_request().unwrap(),
+            host_request_source.recv_request().unwrap(),
             HostReceive::Message(_)
         ));
 
@@ -384,7 +426,7 @@ mod tests {
             .unwrap();
         assert!(pending_call.join().unwrap().is_err());
         assert_eq!(
-            host_control.recv_request().unwrap(),
+            host_request_source.recv_request().unwrap(),
             HostReceive::PeerClosed
         );
     }

--- a/litebox_runner_linux_userland/tests/run.rs
+++ b/litebox_runner_linux_userland/tests/run.rs
@@ -388,6 +388,14 @@ fn spawn_test_broker(
                     litebox_broker_protocol::shared_memory::SHARED_BUFFER_LAYOUT,
                 )
                 .expect("failed to attach broker test shared-buffer layout");
+                let control_memory =
+                    litebox_broker_transport::shared_memory::MemfdSharedMemory::create(
+                        litebox_broker_transport::control_ring::CONTROL_RING_MEMORY_SIZE,
+                    )
+                    .expect("failed to create broker test control ring");
+                let control_ring =
+                    litebox_broker_transport::control_ring::ControlRing::new(control_memory)
+                        .expect("failed to attach broker test control ring");
                 let (notification_stream, _) = notification_listener
                     .accept()
                     .expect("failed to accept broker local notification connection");
@@ -408,29 +416,60 @@ fn spawn_test_broker(
                 notification_stream
                     .set_write_timeout(Some(BROKER_HELPER_TIMEOUT))
                     .expect("failed to configure broker notification test write timeout");
-                let mut channel = CountingHostControlChannel {
-                    inner: litebox_broker_transport::unix_socket::UnixStreamHostControlChannel::from_host_guaranteed(
+                let mut channel =
+                    litebox_broker_transport::unix_socket::UnixStreamHostControlChannel::from_host_guaranteed(
                         control_stream,
                         std::time::Instant::now() + BROKER_HELPER_TIMEOUT,
-                    ),
-                    close_object_count: 0,
-                };
-                let mut notification_channel =
+                    );
+                let _notification_channel =
                     litebox_broker_transport::unix_socket::UnixStreamHostNotificationChannel::from_accepted(notification_stream);
-                let termination = litebox_broker_host::serve_connection(
+                let association = litebox_broker_host::setup_connection(
                     &broker,
                     &mut channel,
-                    &mut notification_channel,
                     &shared_buffers,
-                    |channel| channel.inner.send_memfd(shared_buffers.memory(), None),
+                    |channel| {
+                        channel.send_memfd(shared_buffers.memory(), None)?;
+                        channel.send_memfd(control_ring.memory(), None)
+                    },
                 )
-                .expect("broker host failed");
+                .expect("broker host setup failed")
+                .expect("broker setup terminated before activation");
+                let (mut request_source, response_sink, _shutdown) = channel
+                    .into_active(control_ring)
+                    .expect("failed to activate broker test control ring");
+                let mut close_object_count = 0;
+                let termination = loop {
+                    match request_source
+                        .recv_request()
+                        .expect("failed to receive broker test request")
+                    {
+                        litebox_broker_protocol::channel::HostReceive::Message(request) => {
+                            if matches!(
+                                &request.operation,
+                                litebox_broker_protocol::message::BrokerOperation::CloseObject(_)
+                            ) {
+                                close_object_count += 1;
+                            }
+                            association
+                                .execute_request(request, |response| {
+                                    response_sink.send_response(response)
+                                })
+                                .expect("failed to execute broker test request");
+                        }
+                        litebox_broker_protocol::channel::HostReceive::PeerClosed => {
+                            break litebox_broker_host::ConnectionTermination::PeerClosed;
+                        }
+                        litebox_broker_protocol::channel::HostReceive::ProtocolViolation => {
+                            break litebox_broker_host::ConnectionTermination::ProtocolViolation;
+                        }
+                    }
+                };
                 assert_eq!(
                     termination,
                     litebox_broker_host::ConnectionTermination::PeerClosed
                 );
                 close_object_count_tx
-                    .send(channel.close_object_count)
+                    .send(close_object_count)
                     .expect("failed to report broker close-object count");
             }
         }));
@@ -451,73 +490,6 @@ fn spawn_test_broker(
         close_object_count_rx,
         control_socket_path: cleanup_control_socket_path,
         notification_socket_path: cleanup_notification_socket_path,
-    }
-}
-
-#[cfg(all(target_arch = "x86_64", target_os = "linux"))]
-struct CountingHostControlChannel<Channel: litebox_broker_protocol::channel::HostControlChannel> {
-    inner: Channel,
-    close_object_count: usize,
-}
-
-#[cfg(all(target_arch = "x86_64", target_os = "linux"))]
-impl<Channel: litebox_broker_protocol::channel::HostControlChannel>
-    litebox_broker_protocol::channel::HostControlChannel for CountingHostControlChannel<Channel>
-{
-    type Error = Channel::Error;
-
-    fn peer_credential(
-        &self,
-    ) -> Result<litebox_broker_protocol::channel::PeerCredential, Self::Error> {
-        self.inner.peer_credential()
-    }
-
-    fn recv_handshake_request(
-        &mut self,
-    ) -> Result<
-        litebox_broker_protocol::channel::HostReceive<
-            litebox_broker_protocol::message::BrokerHandshakeRequest,
-        >,
-        Self::Error,
-    > {
-        self.inner.recv_handshake_request()
-    }
-
-    fn send_handshake_response(
-        &mut self,
-        response: &litebox_broker_protocol::message::BrokerHandshakeResponse,
-    ) -> Result<(), Self::Error> {
-        self.inner.send_handshake_response(response)
-    }
-
-    fn recv_request(
-        &mut self,
-    ) -> Result<
-        litebox_broker_protocol::channel::HostReceive<
-            litebox_broker_protocol::message::BrokerRequest,
-        >,
-        Self::Error,
-    > {
-        let request = self.inner.recv_request()?;
-        if matches!(
-            &request,
-            litebox_broker_protocol::channel::HostReceive::Message(
-                litebox_broker_protocol::message::BrokerRequest {
-                    operation: litebox_broker_protocol::message::BrokerOperation::CloseObject(_),
-                    ..
-                }
-            )
-        ) {
-            self.close_object_count += 1;
-        }
-        Ok(request)
-    }
-
-    fn send_response(
-        &mut self,
-        response: &litebox_broker_protocol::message::BrokerResponse,
-    ) -> Result<(), Self::Error> {
-        self.inner.send_response(response)
     }
 }
 


### PR DESCRIPTION
Active broker requests and responses now use paired shared-memory control rings, preserving request-ID multiplexing and bounded host dispatch. Setup transfers and validates an exact-size ring memfd, while the authenticated Unix socket remains for setup, liveness, cancellation, and teardown. Futex-backed waits and 128-byte slots keep the ring efficient and bounded by the protocol's maximum encoded message size.