### PR TITLE
Move broker notifications to shared memory

### DIFF
--- a/litebox/src/broker/mod.rs
+++ b/litebox/src/broker/mod.rs
@@ -331,8 +331,8 @@ mod tests {
             observed_sender,
             release: StdArc::clone(&release),
         };
-        let local = BrokerLocal::negotiate(channel, |channel| {
-            Ok((channel, Arc::new(memory) as Arc<dyn SharedMemory>))
+        let (local, ()) = BrokerLocal::negotiate(channel, |channel| {
+            Ok((channel, Arc::new(memory) as Arc<dyn SharedMemory>, ()))
         })
         .unwrap();
         let control = Arc::new(BrokerLocalControl::<MockPlatform, _>::new(
@@ -376,8 +376,8 @@ mod tests {
             observed_sender,
             release: StdArc::clone(&release),
         };
-        let local = BrokerLocal::negotiate(channel, |channel| {
-            Ok((channel, Arc::new(memory) as Arc<dyn SharedMemory>))
+        let (local, ()) = BrokerLocal::negotiate(channel, |channel| {
+            Ok((channel, Arc::new(memory) as Arc<dyn SharedMemory>, ()))
         })
         .unwrap();
         let control = Arc::new(BrokerLocalControl::<MockPlatform, _>::new(

--- a/litebox/src/broker/mod.rs
+++ b/litebox/src/broker/mod.rs
@@ -9,7 +9,7 @@ use alloc::{
 use hashbrown::HashMap;
 use litebox_broker_local::BrokerLocal;
 use litebox_broker_protocol::ObjectHandle;
-use litebox_broker_protocol::channel::LocalControlChannel;
+use litebox_broker_protocol::channel::LocalCallChannel;
 use litebox_broker_protocol::error::ErrorCode;
 use litebox_broker_protocol::event::{ConsumeEventResponse, EventConsumeMode};
 use litebox_broker_protocol::pipe::{CreatePipeResponse, MAX_PIPE_TRANSFER_SIZE};
@@ -146,7 +146,7 @@ impl<Platform: RawSyncPrimitivesProvider> BrokerPollableRegistry<Platform> {
 
 pub(crate) struct BrokerLocalControl<
     Platform: RawSyncPrimitivesProvider,
-    Channel: LocalControlChannel + Send + Sync,
+    Channel: LocalCallChannel + Send + Sync,
 > {
     local: Mutex<Platform, Option<Arc<BrokerLocal<Channel>>>>,
     pollable_registry: Arc<BrokerPollableRegistry<Platform>>,
@@ -156,7 +156,7 @@ pub(crate) struct BrokerLocalControl<
 impl<Platform, Channel> BrokerLocalControl<Platform, Channel>
 where
     Platform: RawSyncPrimitivesProvider + TimeProvider,
-    Channel: LocalControlChannel + Send + Sync,
+    Channel: LocalCallChannel + Send + Sync,
 {
     pub(crate) fn new(
         local: BrokerLocal<Channel>,
@@ -208,7 +208,7 @@ where
 impl<Platform, Channel> BrokerControl for BrokerLocalControl<Platform, Channel>
 where
     Platform: RawSyncPrimitivesProvider + TimeProvider,
-    Channel: LocalControlChannel + Send + Sync,
+    Channel: LocalCallChannel + Send + Sync,
 {
     fn create_event_with_count(
         &self,
@@ -308,7 +308,7 @@ mod tests {
     use std::time::Duration;
 
     use litebox_broker_protocol::BROKER_PROTOCOL_VERSION;
-    use litebox_broker_protocol::channel::LocalControlChannel;
+    use litebox_broker_protocol::channel::{LocalCallChannel, LocalSetupChannel};
     use litebox_broker_protocol::message::{
         BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerOperation, BrokerRequest,
         BrokerResponse, BrokerResult, PipeRequest, PipeResponse,
@@ -331,9 +331,10 @@ mod tests {
             observed_sender,
             release: StdArc::clone(&release),
         };
-        let local =
-            BrokerLocal::negotiate(channel, |_| Ok(Arc::new(memory) as Arc<dyn SharedMemory>))
-                .unwrap();
+        let local = BrokerLocal::negotiate(channel, |channel| {
+            Ok((channel, Arc::new(memory) as Arc<dyn SharedMemory>))
+        })
+        .unwrap();
         let control = Arc::new(BrokerLocalControl::<MockPlatform, _>::new(
             local,
             Arc::new(BrokerPollableRegistry::new()),
@@ -375,9 +376,10 @@ mod tests {
             observed_sender,
             release: StdArc::clone(&release),
         };
-        let local =
-            BrokerLocal::negotiate(channel, |_| Ok(Arc::new(memory) as Arc<dyn SharedMemory>))
-                .unwrap();
+        let local = BrokerLocal::negotiate(channel, |channel| {
+            Ok((channel, Arc::new(memory) as Arc<dyn SharedMemory>))
+        })
+        .unwrap();
         let control = Arc::new(BrokerLocalControl::<MockPlatform, _>::new(
             local,
             Arc::new(BrokerPollableRegistry::new()),
@@ -468,7 +470,7 @@ mod tests {
         release: StdArc<(StdMutex<bool>, StdCondvar)>,
     }
 
-    impl LocalControlChannel for ConcurrentPipeChannel {
+    impl LocalSetupChannel for ConcurrentPipeChannel {
         type Error = Infallible;
 
         fn send_handshake_request(
@@ -486,6 +488,10 @@ mod tests {
                 broker_protocol_version: BROKER_PROTOCOL_VERSION,
             }))
         }
+    }
+
+    impl LocalCallChannel for ConcurrentPipeChannel {
+        type Error = Infallible;
 
         fn call(
             &self,
@@ -516,7 +522,7 @@ mod tests {
         }
     }
 
-    impl LocalControlChannel for ConcurrentPipeReadChannel {
+    impl LocalSetupChannel for ConcurrentPipeReadChannel {
         type Error = Infallible;
 
         fn send_handshake_request(
@@ -534,6 +540,10 @@ mod tests {
                 broker_protocol_version: BROKER_PROTOCOL_VERSION,
             }))
         }
+    }
+
+    impl LocalCallChannel for ConcurrentPipeReadChannel {
+        type Error = Infallible;
 
         fn call(
             &self,

--- a/litebox/src/event/counter.rs
+++ b/litebox/src/event/counter.rs
@@ -178,7 +178,7 @@ mod tests {
 
     use alloc::sync::Arc;
     use litebox_broker_local::BrokerLocal;
-    use litebox_broker_protocol::channel::LocalControlChannel;
+    use litebox_broker_protocol::channel::{LocalCallChannel, LocalSetupChannel};
     use litebox_broker_protocol::error::ErrorCode;
     use litebox_broker_protocol::event::{CreateEventResponse, EventConsumption};
     use litebox_broker_protocol::message::{
@@ -203,14 +203,14 @@ mod tests {
         let read_ready = Arc::new(AtomicBool::new(false));
         let request_count = Arc::new(AtomicUsize::new(0));
         let local = BrokerLocal::negotiate(
-            FakeLocalControlChannel {
+            FakeLocalChannel {
                 next_handle: AtomicU64::new(handle.0),
                 consume_attempts: consume_attempts.clone(),
                 read_ready: read_ready.clone(),
                 request_count,
                 fail_requests: Arc::new(AtomicBool::new(false)),
             },
-            |_| Ok(Arc::new(NoopSharedMemory)),
+            |channel| Ok((channel, Arc::new(NoopSharedMemory))),
         )
         .unwrap();
         let litebox = LiteBox::new_with_broker_local(platform, local);
@@ -261,14 +261,14 @@ mod tests {
         let consume_attempts = Arc::new(AtomicUsize::new(0));
         let request_count = Arc::new(AtomicUsize::new(0));
         let local = BrokerLocal::negotiate(
-            FakeLocalControlChannel {
+            FakeLocalChannel {
                 next_handle: AtomicU64::new(handle.0),
                 consume_attempts: Arc::clone(&consume_attempts),
                 read_ready: Arc::new(AtomicBool::new(false)),
                 request_count: Arc::clone(&request_count),
                 fail_requests: Arc::new(AtomicBool::new(false)),
             },
-            |_| Ok(Arc::new(NoopSharedMemory)),
+            |channel| Ok((channel, Arc::new(NoopSharedMemory))),
         )
         .unwrap();
         let litebox = Arc::new(LiteBox::new_with_broker_local(platform, local));
@@ -312,14 +312,14 @@ mod tests {
         let request_count = Arc::new(AtomicUsize::new(0));
         let fail_requests = Arc::new(AtomicBool::new(false));
         let local = BrokerLocal::negotiate(
-            FakeLocalControlChannel {
+            FakeLocalChannel {
                 next_handle: AtomicU64::new(handle.0),
                 consume_attempts: Arc::new(AtomicUsize::new(0)),
                 read_ready: Arc::new(AtomicBool::new(false)),
                 request_count: Arc::clone(&request_count),
                 fail_requests: Arc::clone(&fail_requests),
             },
-            |_| Ok(Arc::new(NoopSharedMemory)),
+            |channel| Ok((channel, Arc::new(NoopSharedMemory))),
         )
         .unwrap();
         let litebox = LiteBox::new_with_broker_local(platform, local);
@@ -348,14 +348,14 @@ mod tests {
         let handle = ObjectHandle(7);
         let request_count = Arc::new(AtomicUsize::new(0));
         let local = BrokerLocal::negotiate(
-            FakeLocalControlChannel {
+            FakeLocalChannel {
                 next_handle: AtomicU64::new(handle.0),
                 consume_attempts: Arc::new(AtomicUsize::new(0)),
                 read_ready: Arc::new(AtomicBool::new(false)),
                 request_count: Arc::clone(&request_count),
                 fail_requests: Arc::new(AtomicBool::new(false)),
             },
-            |_| Ok(Arc::new(NoopSharedMemory)),
+            |channel| Ok((channel, Arc::new(NoopSharedMemory))),
         )
         .unwrap();
         let litebox = LiteBox::new_with_broker_local(platform, local);
@@ -400,7 +400,7 @@ mod tests {
         }
     }
 
-    struct FakeLocalControlChannel {
+    struct FakeLocalChannel {
         next_handle: AtomicU64,
         consume_attempts: Arc<AtomicUsize>,
         read_ready: Arc<AtomicBool>,
@@ -435,7 +435,7 @@ mod tests {
         }
     }
 
-    impl LocalControlChannel for FakeLocalControlChannel {
+    impl LocalSetupChannel for FakeLocalChannel {
         type Error = ();
 
         fn send_handshake_request(
@@ -452,6 +452,11 @@ mod tests {
                 broker_protocol_version: litebox_broker_protocol::BROKER_PROTOCOL_VERSION,
             }))
         }
+    }
+
+    impl LocalCallChannel for FakeLocalChannel {
+        type Error = ();
+
         fn call(
             &self,
             request: BrokerRequest,

--- a/litebox/src/event/counter.rs
+++ b/litebox/src/event/counter.rs
@@ -202,7 +202,7 @@ mod tests {
         let consume_attempts = Arc::new(AtomicUsize::new(0));
         let read_ready = Arc::new(AtomicBool::new(false));
         let request_count = Arc::new(AtomicUsize::new(0));
-        let local = BrokerLocal::negotiate(
+        let (local, ()) = BrokerLocal::negotiate(
             FakeLocalChannel {
                 next_handle: AtomicU64::new(handle.0),
                 consume_attempts: consume_attempts.clone(),
@@ -210,7 +210,7 @@ mod tests {
                 request_count,
                 fail_requests: Arc::new(AtomicBool::new(false)),
             },
-            |channel| Ok((channel, Arc::new(NoopSharedMemory))),
+            |channel| Ok((channel, Arc::new(NoopSharedMemory), ())),
         )
         .unwrap();
         let litebox = LiteBox::new_with_broker_local(platform, local);
@@ -260,7 +260,7 @@ mod tests {
         let handle = ObjectHandle(7);
         let consume_attempts = Arc::new(AtomicUsize::new(0));
         let request_count = Arc::new(AtomicUsize::new(0));
-        let local = BrokerLocal::negotiate(
+        let (local, ()) = BrokerLocal::negotiate(
             FakeLocalChannel {
                 next_handle: AtomicU64::new(handle.0),
                 consume_attempts: Arc::clone(&consume_attempts),
@@ -268,7 +268,7 @@ mod tests {
                 request_count: Arc::clone(&request_count),
                 fail_requests: Arc::new(AtomicBool::new(false)),
             },
-            |channel| Ok((channel, Arc::new(NoopSharedMemory))),
+            |channel| Ok((channel, Arc::new(NoopSharedMemory), ())),
         )
         .unwrap();
         let litebox = Arc::new(LiteBox::new_with_broker_local(platform, local));
@@ -311,7 +311,7 @@ mod tests {
         let handle = ObjectHandle(7);
         let request_count = Arc::new(AtomicUsize::new(0));
         let fail_requests = Arc::new(AtomicBool::new(false));
-        let local = BrokerLocal::negotiate(
+        let (local, ()) = BrokerLocal::negotiate(
             FakeLocalChannel {
                 next_handle: AtomicU64::new(handle.0),
                 consume_attempts: Arc::new(AtomicUsize::new(0)),
@@ -319,7 +319,7 @@ mod tests {
                 request_count: Arc::clone(&request_count),
                 fail_requests: Arc::clone(&fail_requests),
             },
-            |channel| Ok((channel, Arc::new(NoopSharedMemory))),
+            |channel| Ok((channel, Arc::new(NoopSharedMemory), ())),
         )
         .unwrap();
         let litebox = LiteBox::new_with_broker_local(platform, local);
@@ -347,7 +347,7 @@ mod tests {
         let platform = MockPlatform::new();
         let handle = ObjectHandle(7);
         let request_count = Arc::new(AtomicUsize::new(0));
-        let local = BrokerLocal::negotiate(
+        let (local, ()) = BrokerLocal::negotiate(
             FakeLocalChannel {
                 next_handle: AtomicU64::new(handle.0),
                 consume_attempts: Arc::new(AtomicUsize::new(0)),
@@ -355,7 +355,7 @@ mod tests {
                 request_count: Arc::clone(&request_count),
                 fail_requests: Arc::new(AtomicBool::new(false)),
             },
-            |channel| Ok((channel, Arc::new(NoopSharedMemory))),
+            |channel| Ok((channel, Arc::new(NoopSharedMemory), ())),
         )
         .unwrap();
         let litebox = LiteBox::new_with_broker_local(platform, local);

--- a/litebox/src/litebox.rs
+++ b/litebox/src/litebox.rs
@@ -6,7 +6,7 @@
 use alloc::sync::Arc;
 
 use litebox_broker_local::BrokerLocal;
-use litebox_broker_protocol::channel::LocalControlChannel;
+use litebox_broker_protocol::channel::LocalCallChannel;
 use litebox_broker_protocol::message::BrokerNotification;
 
 use crate::{
@@ -50,7 +50,7 @@ impl<Platform: RawSyncPrimitivesProvider> LiteBox<Platform> {
     ) -> Self
     where
         Platform: TimeProvider,
-        Channel: LocalControlChannel + Send + Sync + 'static,
+        Channel: LocalCallChannel + Send + Sync + 'static,
     {
         let broker_pollables = Arc::new(broker::BrokerPollableRegistry::new());
         let broker_control = Arc::new(broker::BrokerLocalControl::<Platform, Channel>::new(

--- a/litebox/src/pipes.rs
+++ b/litebox/src/pipes.rs
@@ -928,7 +928,7 @@ mod tests {
 
     use alloc::sync::Arc;
     use litebox_broker_local::BrokerLocal;
-    use litebox_broker_protocol::channel::LocalControlChannel;
+    use litebox_broker_protocol::channel::{LocalCallChannel, LocalSetupChannel};
     use litebox_broker_protocol::error::ErrorCode;
     use litebox_broker_protocol::message::{
         BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerNotification, BrokerOperation,
@@ -956,7 +956,7 @@ mod tests {
                 read_failure: ReadFailure::Transport,
                 force_transport,
             },
-            |_| Ok(Arc::new(NoopSharedMemory)),
+            |channel| Ok((channel, Arc::new(NoopSharedMemory))),
         )
         .unwrap();
         let litebox = crate::LiteBox::new_with_broker_local(platform, local);
@@ -1002,7 +1002,7 @@ mod tests {
                 read_failure: ReadFailure::WouldBlock,
                 force_transport: Arc::clone(&force_transport),
             },
-            |_| Ok(Arc::new(NoopSharedMemory)),
+            |channel| Ok((channel, Arc::new(NoopSharedMemory))),
         )
         .unwrap();
         let litebox = Arc::new(crate::LiteBox::new_with_broker_local(platform, local));
@@ -1148,7 +1148,7 @@ mod tests {
         WouldBlock,
     }
 
-    impl LocalControlChannel for FailingPipeChannel {
+    impl LocalSetupChannel for FailingPipeChannel {
         type Error = ();
 
         fn send_handshake_request(
@@ -1165,6 +1165,11 @@ mod tests {
                 broker_protocol_version: BROKER_PROTOCOL_VERSION,
             }))
         }
+    }
+
+    impl LocalCallChannel for FailingPipeChannel {
+        type Error = ();
+
         fn call(
             &self,
             request: BrokerRequest,

--- a/litebox/src/pipes.rs
+++ b/litebox/src/pipes.rs
@@ -950,13 +950,13 @@ mod tests {
         let platform = crate::platform::mock::MockPlatform::new();
         let request_count = Arc::new(AtomicUsize::new(0));
         let force_transport = Arc::new(AtomicBool::new(false));
-        let local = BrokerLocal::negotiate(
+        let (local, ()) = BrokerLocal::negotiate(
             FailingPipeChannel {
                 request_count: Arc::clone(&request_count),
                 read_failure: ReadFailure::Transport,
                 force_transport,
             },
-            |channel| Ok((channel, Arc::new(NoopSharedMemory))),
+            |channel| Ok((channel, Arc::new(NoopSharedMemory), ())),
         )
         .unwrap();
         let litebox = crate::LiteBox::new_with_broker_local(platform, local);
@@ -996,13 +996,13 @@ mod tests {
         let platform = crate::platform::mock::MockPlatform::new();
         let request_count = Arc::new(AtomicUsize::new(0));
         let force_transport = Arc::new(AtomicBool::new(false));
-        let local = BrokerLocal::negotiate(
+        let (local, ()) = BrokerLocal::negotiate(
             FailingPipeChannel {
                 request_count: Arc::clone(&request_count),
                 read_failure: ReadFailure::WouldBlock,
                 force_transport: Arc::clone(&force_transport),
             },
-            |channel| Ok((channel, Arc::new(NoopSharedMemory))),
+            |channel| Ok((channel, Arc::new(NoopSharedMemory), ())),
         )
         .unwrap();
         let litebox = Arc::new(crate::LiteBox::new_with_broker_local(platform, local));

--- a/litebox_broker_local/src/event.rs
+++ b/litebox_broker_local/src/event.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 use litebox_broker_protocol::ObjectHandle;
-use litebox_broker_protocol::channel::LocalControlChannel;
+use litebox_broker_protocol::channel::LocalCallChannel;
 use litebox_broker_protocol::event::{
     AddEventRequest, ConsumeEventRequest, ConsumeEventResponse, CreateEventRequest,
     EventConsumeMode,
@@ -14,7 +14,7 @@ use litebox_broker_protocol::readiness::ReadinessFlags;
 
 use crate::{BrokerLocal, BrokerLocalError, Result};
 
-impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
+impl<Channel: LocalCallChannel> BrokerLocal<Channel> {
     /// Creates a broker-owned event object with initial readiness credits.
     ///
     /// # Panics

--- a/litebox_broker_local/src/lib.rs
+++ b/litebox_broker_local/src/lib.rs
@@ -4,8 +4,10 @@
 //! Typed broker-local adapters for broker requests and notifications.
 //!
 //! The local control adapter owns request identifiers but does not own transport
-//! sequencing. Userland, kernel, or ring-buffer deployments provide control
-//! channels by implementing [`litebox_broker_protocol::channel::LocalControlChannel`].
+//! sequencing. Userland, kernel, or ring-buffer deployments provide channels by
+//! implementing [`litebox_broker_protocol::channel::LocalSetupChannel`] for
+//! association setup and
+//! [`litebox_broker_protocol::channel::LocalCallChannel`] for active calls.
 //! Notification receive adapters are intentionally separate so active control
 //! requests remain strictly paired with their responses.
 
@@ -23,7 +25,9 @@ mod pipe;
 use alloc::sync::Arc;
 use core::sync::atomic::{AtomicU64, Ordering};
 
-use litebox_broker_protocol::channel::{LocalControlChannel, LocalNotificationChannel};
+use litebox_broker_protocol::channel::{
+    LocalCallChannel, LocalNotificationChannel, LocalSetupChannel,
+};
 use litebox_broker_protocol::error::ErrorCode;
 use litebox_broker_protocol::message::{
     BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerNotification, BrokerOperation,
@@ -41,7 +45,7 @@ pub use error::{BrokerLocalError, Result};
 ///
 /// The shared-buffer pool belongs to the broker association. Payload request
 /// descriptors identify operation-scoped slots managed by the caller.
-pub struct BrokerLocal<Channel: LocalControlChannel> {
+pub struct BrokerLocal<Channel: LocalCallChannel> {
     channel: Channel,
     shared_buffers: SharedBufferPool<Arc<dyn SharedMemory>>,
     next_request_id: AtomicU64,
@@ -52,29 +56,35 @@ pub struct BrokerNotifications<Channel: LocalNotificationChannel> {
     channel: Channel,
 }
 
-impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
-    /// Negotiates the broker protocol, then establishes the association shared
-    /// memory before active requests begin.
+impl<Channel: LocalCallChannel> BrokerLocal<Channel> {
+    /// Negotiates the broker protocol on `setup`, then consumes it into the
+    /// active call channel and association shared memory before active requests
+    /// begin.
+    ///
+    /// `activate` owns every deployment-specific setup step that must complete
+    /// after negotiation, such as receiving shared memory and starting the
+    /// active transport.
     ///
     /// # Panics
     ///
     /// Panics if the broker reports an unrecoverable error, returns a protocol
     /// response that does not match the negotiation request, or setup returns
     /// shared memory with an invalid size.
-    pub fn negotiate(
-        mut channel: Channel,
+    pub fn negotiate<Setup: LocalSetupChannel<Error = Channel::Error>>(
+        mut setup: Setup,
         activate: impl FnOnce(
-            &mut Channel,
-        ) -> core::result::Result<Arc<dyn SharedMemory>, Channel::Error>,
+            Setup,
+        )
+            -> core::result::Result<(Channel, Arc<dyn SharedMemory>), Channel::Error>,
     ) -> Result<Self, Channel::Error> {
         let requested = BROKER_PROTOCOL_VERSION;
         let request = BrokerHandshakeRequest {
             protocol_version: requested,
         };
-        channel
+        setup
             .send_handshake_request(&request)
             .map_err(BrokerLocalError::Channel)?;
-        match channel
+        match setup
             .recv_handshake_response()
             .map_err(BrokerLocalError::Channel)?
             .ok_or(BrokerLocalError::ChannelClosed)?
@@ -86,7 +96,8 @@ impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
                     requested, broker_protocol_version,
                     "broker returned unexpected negotiation response: {response:?}"
                 );
-                let shared_memory = activate(&mut channel).map_err(BrokerLocalError::Channel)?;
+                let (channel, shared_memory) =
+                    activate(setup).map_err(BrokerLocalError::Channel)?;
                 let shared_buffers = SharedBufferPool::new(shared_memory, SHARED_BUFFER_LAYOUT)
                     .expect("broker association shared memory has an invalid size");
                 Ok(Self {
@@ -242,7 +253,7 @@ mod tests {
             assert!(channel.handshake_response.is_none());
             assert!(channel.sent_request.borrow().is_none());
             setup_calls.set(setup_calls.get() + 1);
-            Ok(noop_shared_memory())
+            Ok((channel, noop_shared_memory()))
         })
         .unwrap();
 
@@ -416,9 +427,9 @@ mod tests {
         let setup_called = Cell::new(false);
 
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            let _ = BrokerLocal::negotiate(channel, |_| {
+            let _ = BrokerLocal::negotiate(channel, |channel| {
                 setup_called.set(true);
-                Ok(noop_shared_memory())
+                Ok((channel, noop_shared_memory()))
             });
         }));
         assert_panic_contains(result, "broker returned unexpected negotiation response");
@@ -451,9 +462,9 @@ mod tests {
 
         let setup_called = Cell::new(false);
         assert!(matches!(
-            BrokerLocal::negotiate(channel, |_| {
+            BrokerLocal::negotiate(channel, |channel| {
                 setup_called.set(true);
-                Ok(noop_shared_memory())
+                Ok((channel, noop_shared_memory()))
             }),
             Err(BrokerLocalError::Broker(ErrorCode::UnsupportedVersion))
         ));
@@ -469,9 +480,9 @@ mod tests {
         let setup_called = Cell::new(false);
 
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            let _ = BrokerLocal::negotiate(channel, |_| {
+            let _ = BrokerLocal::negotiate(channel, |channel| {
                 setup_called.set(true);
-                Ok(noop_shared_memory())
+                Ok((channel, noop_shared_memory()))
             });
         }));
         assert_panic_contains(result, "broker returned unrecoverable error");
@@ -507,10 +518,13 @@ mod tests {
             None,
         );
 
-        let _ = BrokerLocal::negotiate(channel, |_| {
-            Ok(Arc::new(NoopSharedMemory {
-                length: litebox_broker_protocol::shared_memory::SHARED_BUFFER_POOL_SIZE - 1,
-            }) as Arc<dyn SharedMemory>)
+        let _ = BrokerLocal::negotiate(channel, |channel| {
+            Ok((
+                channel,
+                Arc::new(NoopSharedMemory {
+                    length: litebox_broker_protocol::shared_memory::SHARED_BUFFER_POOL_SIZE - 1,
+                }) as Arc<dyn SharedMemory>,
+            ))
         });
     }
 
@@ -596,7 +610,7 @@ mod tests {
         }
     }
 
-    impl LocalControlChannel for FakeControlChannel {
+    impl LocalSetupChannel for FakeControlChannel {
         type Error = FakeChannelError;
 
         fn send_handshake_request(
@@ -612,6 +626,11 @@ mod tests {
         ) -> core::result::Result<Option<BrokerHandshakeResponse>, Self::Error> {
             Ok(self.handshake_response.take())
         }
+    }
+
+    impl LocalCallChannel for FakeControlChannel {
+        type Error = FakeChannelError;
+
         fn call(
             &self,
             request: BrokerRequest,
@@ -643,7 +662,7 @@ mod tests {
         request_ids: Mutex<std::vec::Vec<RequestId>>,
     }
 
-    impl LocalControlChannel for ConcurrentCallChannel {
+    impl LocalSetupChannel for ConcurrentCallChannel {
         type Error = Infallible;
 
         fn send_handshake_request(
@@ -660,6 +679,10 @@ mod tests {
                 broker_protocol_version: BROKER_PROTOCOL_VERSION,
             }))
         }
+    }
+
+    impl LocalCallChannel for ConcurrentCallChannel {
+        type Error = Infallible;
 
         fn call(
             &self,

--- a/litebox_broker_local/src/lib.rs
+++ b/litebox_broker_local/src/lib.rs
@@ -63,20 +63,23 @@ impl<Channel: LocalCallChannel> BrokerLocal<Channel> {
     ///
     /// `activate` owns every deployment-specific setup step that must complete
     /// after negotiation, such as receiving shared memory and starting the
-    /// active transport.
+    /// active transport. Any additional endpoints activation produces, such as
+    /// a notification receiver, are returned to the caller as `Activated`.
     ///
     /// # Panics
     ///
     /// Panics if the broker reports an unrecoverable error, returns a protocol
     /// response that does not match the negotiation request, or setup returns
     /// shared memory with an invalid size.
-    pub fn negotiate<Setup: LocalSetupChannel<Error = Channel::Error>>(
+    pub fn negotiate<Setup: LocalSetupChannel<Error = Channel::Error>, Activated>(
         mut setup: Setup,
         activate: impl FnOnce(
             Setup,
-        )
-            -> core::result::Result<(Channel, Arc<dyn SharedMemory>), Channel::Error>,
-    ) -> Result<Self, Channel::Error> {
+        ) -> core::result::Result<
+            (Channel, Arc<dyn SharedMemory>, Activated),
+            Channel::Error,
+        >,
+    ) -> Result<(Self, Activated), Channel::Error> {
         let requested = BROKER_PROTOCOL_VERSION;
         let request = BrokerHandshakeRequest {
             protocol_version: requested,
@@ -96,15 +99,18 @@ impl<Channel: LocalCallChannel> BrokerLocal<Channel> {
                     requested, broker_protocol_version,
                     "broker returned unexpected negotiation response: {response:?}"
                 );
-                let (channel, shared_memory) =
+                let (channel, shared_memory, activated) =
                     activate(setup).map_err(BrokerLocalError::Channel)?;
                 let shared_buffers = SharedBufferPool::new(shared_memory, SHARED_BUFFER_LAYOUT)
                     .expect("broker association shared memory has an invalid size");
-                Ok(Self {
-                    channel,
-                    shared_buffers,
-                    next_request_id: AtomicU64::new(0),
-                })
+                Ok((
+                    Self {
+                        channel,
+                        shared_buffers,
+                        next_request_id: AtomicU64::new(0),
+                    },
+                    activated,
+                ))
             }
             BrokerHandshakeResponse::VersionMismatch { .. } => {
                 Err(BrokerLocalError::Broker(ErrorCode::UnsupportedVersion))
@@ -248,12 +254,12 @@ mod tests {
             None,
         );
         let setup_calls = Cell::new(0);
-        let local = BrokerLocal::negotiate(channel, |channel| {
+        let (local, ()) = BrokerLocal::negotiate(channel, |channel| {
             assert!(channel.sent_handshake_request.is_some());
             assert!(channel.handshake_response.is_none());
             assert!(channel.sent_request.borrow().is_none());
             setup_calls.set(setup_calls.get() + 1);
-            Ok((channel, noop_shared_memory()))
+            Ok((channel, noop_shared_memory(), ()))
         })
         .unwrap();
 
@@ -429,7 +435,7 @@ mod tests {
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let _ = BrokerLocal::negotiate(channel, |channel| {
                 setup_called.set(true);
-                Ok((channel, noop_shared_memory()))
+                Ok((channel, noop_shared_memory(), ()))
             });
         }));
         assert_panic_contains(result, "broker returned unexpected negotiation response");
@@ -464,7 +470,7 @@ mod tests {
         assert!(matches!(
             BrokerLocal::negotiate(channel, |channel| {
                 setup_called.set(true);
-                Ok((channel, noop_shared_memory()))
+                Ok((channel, noop_shared_memory(), ()))
             }),
             Err(BrokerLocalError::Broker(ErrorCode::UnsupportedVersion))
         ));
@@ -482,7 +488,7 @@ mod tests {
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let _ = BrokerLocal::negotiate(channel, |channel| {
                 setup_called.set(true);
-                Ok((channel, noop_shared_memory()))
+                Ok((channel, noop_shared_memory(), ()))
             });
         }));
         assert_panic_contains(result, "broker returned unrecoverable error");
@@ -500,7 +506,9 @@ mod tests {
 
         assert!(matches!(
             BrokerLocal::<FakeControlChannel>::negotiate(channel, |_| {
-                Err(FakeChannelError::SharedMemoryReceive)
+                Err::<(FakeControlChannel, Arc<dyn SharedMemory>, ()), _>(
+                    FakeChannelError::SharedMemoryReceive,
+                )
             }),
             Err(BrokerLocalError::Channel(
                 FakeChannelError::SharedMemoryReceive
@@ -524,6 +532,7 @@ mod tests {
                 Arc::new(NoopSharedMemory {
                     length: litebox_broker_protocol::shared_memory::SHARED_BUFFER_POOL_SIZE - 1,
                 }) as Arc<dyn SharedMemory>,
+                (),
             ))
         });
     }

--- a/litebox_broker_local/src/pipe.rs
+++ b/litebox_broker_local/src/pipe.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 use litebox_broker_protocol::ObjectHandle;
-use litebox_broker_protocol::channel::LocalControlChannel;
+use litebox_broker_protocol::channel::LocalCallChannel;
 use litebox_broker_protocol::message::{BrokerOperation, BrokerResult, PipeRequest, PipeResponse};
 use litebox_broker_protocol::pipe::{
     CreatePipeRequest, CreatePipeResponse, MAX_PIPE_TRANSFER_SIZE, ReadPipeRequest,
@@ -12,7 +12,7 @@ use litebox_broker_protocol::shared_memory::SharedBufferDescriptor;
 
 use crate::{BrokerLocal, BrokerLocalError, Result};
 
-impl<Channel: LocalControlChannel> BrokerLocal<Channel> {
+impl<Channel: LocalCallChannel> BrokerLocal<Channel> {
     /// Creates a broker-owned byte pipe.
     ///
     /// # Panics
@@ -146,7 +146,7 @@ mod tests {
     use std::sync::Mutex;
 
     use litebox_broker_protocol::BROKER_PROTOCOL_VERSION;
-    use litebox_broker_protocol::channel::LocalControlChannel;
+    use litebox_broker_protocol::channel::{LocalCallChannel, LocalSetupChannel};
     use litebox_broker_protocol::message::{
         BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerOperation, BrokerRequest,
         BrokerResponse, BrokerResult,
@@ -170,7 +170,8 @@ mod tests {
             BrokerResult::Pipe(PipeResponse::Write(WritePipeResponse { written: 2 })),
             BrokerResult::Pipe(PipeResponse::Read(ReadPipeResponse { read: 2 })),
         ]);
-        let local = BrokerLocal::negotiate(channel, |_| Ok(memory.clone())).unwrap();
+        let local =
+            BrokerLocal::negotiate(channel, |channel| Ok((channel, memory.clone()))).unwrap();
         let write_buffer = descriptor(2, 3);
         let read_buffer = descriptor(4, 3);
 
@@ -219,7 +220,7 @@ mod tests {
     fn pipe_rejects_oversized_transfers_before_request() {
         let memory = Arc::new(TestSharedMemory::new(SHARED_BUFFER_POOL_SIZE));
         let channel = ScriptedChannel::new([]);
-        let local = BrokerLocal::negotiate(channel, |_| Ok(memory)).unwrap();
+        let local = BrokerLocal::negotiate(channel, |channel| Ok((channel, memory))).unwrap();
         let oversized = descriptor(0, MAX_PIPE_TRANSFER_SIZE + 1);
 
         assert!(matches!(
@@ -245,7 +246,7 @@ mod tests {
                 read: 2,
             }))]);
         let memory = Arc::new(TestSharedMemory::new(SHARED_BUFFER_POOL_SIZE));
-        let local = BrokerLocal::negotiate(channel, |_| Ok(memory)).unwrap();
+        let local = BrokerLocal::negotiate(channel, |channel| Ok((channel, memory))).unwrap();
         let mut destination = [0];
 
         let _ = local.read_pipe(ObjectHandle(1), descriptor(0, 1), &mut destination);
@@ -259,7 +260,7 @@ mod tests {
                 written: 2,
             }))]);
         let memory = Arc::new(TestSharedMemory::new(SHARED_BUFFER_POOL_SIZE));
-        let local = BrokerLocal::negotiate(channel, |_| Ok(memory)).unwrap();
+        let local = BrokerLocal::negotiate(channel, |channel| Ok((channel, memory))).unwrap();
 
         let _ = local.write_pipe(ObjectHandle(1), descriptor(0, 1), &[0]);
     }
@@ -332,7 +333,7 @@ mod tests {
         }
     }
 
-    impl LocalControlChannel for ScriptedChannel {
+    impl LocalSetupChannel for ScriptedChannel {
         type Error = Infallible;
 
         fn send_handshake_request(
@@ -350,6 +351,11 @@ mod tests {
                 broker_protocol_version: BROKER_PROTOCOL_VERSION,
             }))
         }
+    }
+
+    impl LocalCallChannel for ScriptedChannel {
+        type Error = Infallible;
+
         fn call(
             &self,
             request: BrokerRequest,

--- a/litebox_broker_local/src/pipe.rs
+++ b/litebox_broker_local/src/pipe.rs
@@ -170,8 +170,8 @@ mod tests {
             BrokerResult::Pipe(PipeResponse::Write(WritePipeResponse { written: 2 })),
             BrokerResult::Pipe(PipeResponse::Read(ReadPipeResponse { read: 2 })),
         ]);
-        let local =
-            BrokerLocal::negotiate(channel, |channel| Ok((channel, memory.clone()))).unwrap();
+        let (local, ()) =
+            BrokerLocal::negotiate(channel, |channel| Ok((channel, memory.clone(), ()))).unwrap();
         let write_buffer = descriptor(2, 3);
         let read_buffer = descriptor(4, 3);
 
@@ -220,7 +220,8 @@ mod tests {
     fn pipe_rejects_oversized_transfers_before_request() {
         let memory = Arc::new(TestSharedMemory::new(SHARED_BUFFER_POOL_SIZE));
         let channel = ScriptedChannel::new([]);
-        let local = BrokerLocal::negotiate(channel, |channel| Ok((channel, memory))).unwrap();
+        let (local, ()) =
+            BrokerLocal::negotiate(channel, |channel| Ok((channel, memory, ()))).unwrap();
         let oversized = descriptor(0, MAX_PIPE_TRANSFER_SIZE + 1);
 
         assert!(matches!(
@@ -246,7 +247,8 @@ mod tests {
                 read: 2,
             }))]);
         let memory = Arc::new(TestSharedMemory::new(SHARED_BUFFER_POOL_SIZE));
-        let local = BrokerLocal::negotiate(channel, |channel| Ok((channel, memory))).unwrap();
+        let (local, ()) =
+            BrokerLocal::negotiate(channel, |channel| Ok((channel, memory, ()))).unwrap();
         let mut destination = [0];
 
         let _ = local.read_pipe(ObjectHandle(1), descriptor(0, 1), &mut destination);
@@ -260,7 +262,8 @@ mod tests {
                 written: 2,
             }))]);
         let memory = Arc::new(TestSharedMemory::new(SHARED_BUFFER_POOL_SIZE));
-        let local = BrokerLocal::negotiate(channel, |channel| Ok((channel, memory))).unwrap();
+        let (local, ()) =
+            BrokerLocal::negotiate(channel, |channel| Ok((channel, memory, ()))).unwrap();
 
         let _ = local.write_pipe(ObjectHandle(1), descriptor(0, 1), &[0]);
     }

--- a/litebox_broker_protocol/src/channel.rs
+++ b/litebox_broker_protocol/src/channel.rs
@@ -37,8 +37,11 @@ pub enum HostReceive<T> {
     PeerClosed,
 }
 
-/// Local-side control channel for broker association setup and active calls.
-pub trait LocalControlChannel {
+/// Local-side channel for broker association setup.
+///
+/// Setup ends when the deployment consumes this channel into an active
+/// [`LocalCallChannel`], so handshake and active call state cannot overlap.
+pub trait LocalSetupChannel {
     /// Channel-specific error type.
     type Error;
 
@@ -53,6 +56,12 @@ pub trait LocalControlChannel {
     /// Returns `Ok(None)` when the broker closed the channel cleanly before
     /// starting another response frame.
     fn recv_handshake_response(&mut self) -> Result<Option<BrokerHandshakeResponse>, Self::Error>;
+}
+
+/// Local-side channel for active broker calls.
+pub trait LocalCallChannel {
+    /// Channel-specific error type.
+    type Error;
 
     /// Publishes one request and waits for its correlated response.
     ///

--- a/litebox_broker_protocol/src/channel.rs
+++ b/litebox_broker_protocol/src/channel.rs
@@ -85,10 +85,10 @@ pub trait HostSetupChannel {
 
 /// Local-side receive channel for broker-initiated asynchronous notifications.
 ///
-/// A notification channel is separate from the control channel so active broker
-/// requests remain strictly paired with their responses. The deployment is
-/// responsible for binding this channel to the same authenticated broker
-/// association as the matching control channel.
+/// The notification path is logically separate from request and response
+/// traffic so active broker requests remain strictly paired with their
+/// responses. A deployment may carry notifications in the same authenticated
+/// association as its control path.
 pub trait LocalNotificationChannel {
     /// Channel-specific error type.
     type Error;

--- a/litebox_broker_transport/src/unix_socket.rs
+++ b/litebox_broker_transport/src/unix_socket.rs
@@ -81,8 +81,8 @@ struct UnixStreamLocalSetup {
     negotiated: bool,
 }
 
-/// Independently owned handle for interrupting local control-channel I/O.
-pub struct UnixStreamLocalControlCancellation {
+/// Independently owned handle for interrupting all local active-ring I/O.
+pub struct UnixControlRingLocalCancellation {
     active: Arc<LocalActiveState>,
 }
 
@@ -159,7 +159,7 @@ impl UnixStreamLocalControlChannel {
         ring: ControlRing<MemfdSharedMemory>,
         association_failure: impl Fn() + Send + Sync + 'static,
     ) -> IoResult<(
-        UnixStreamLocalControlCancellation,
+        UnixControlRingLocalCancellation,
         UnixControlRingLocalNotificationChannel,
     )> {
         let UnixStreamLocalControlState::Setup(setup) = &self.state else {
@@ -235,7 +235,7 @@ impl UnixStreamLocalControlChannel {
 
         self.state = UnixStreamLocalControlState::Active(Arc::clone(&active));
         Ok((
-            UnixStreamLocalControlCancellation {
+            UnixControlRingLocalCancellation {
                 active: Arc::clone(&active),
             },
             UnixControlRingLocalNotificationChannel {
@@ -246,7 +246,7 @@ impl UnixStreamLocalControlChannel {
     }
 }
 
-impl UnixStreamLocalControlCancellation {
+impl UnixControlRingLocalCancellation {
     /// Shuts down the control stream, unblocking pending reads or writes.
     pub fn cancel(&self) -> IoResult<()> {
         self.active.fail(Error::new(
@@ -296,8 +296,8 @@ pub struct UnixControlRingHostResponseSink {
     active: Arc<HostActiveState>,
 }
 
-/// RAII guard that interrupts all active host control-channel I/O when dropped.
-pub struct UnixStreamHostControlShutdown {
+/// RAII guard that interrupts all active host ring I/O when dropped.
+pub struct UnixControlRingHostShutdown {
     active: Arc<HostActiveState>,
 }
 
@@ -361,7 +361,7 @@ impl UnixStreamHostControlChannel {
         UnixControlRingHostRequestSource,
         UnixControlRingHostResponseSink,
         UnixControlRingHostNotificationChannel,
-        UnixStreamHostControlShutdown,
+        UnixControlRingHostShutdown,
     )> {
         if !self.negotiated {
             return Err(invalid_data(
@@ -411,27 +411,26 @@ impl UnixStreamHostControlChannel {
                 producer: notification_producer,
                 active: Arc::clone(&active),
             },
-            UnixStreamHostControlShutdown { active },
+            UnixControlRingHostShutdown { active },
         ))
     }
 }
 
-impl UnixStreamHostControlShutdown {
-    /// Shuts down the active control socket without waiting for the response
-    /// writer mutex.
+impl UnixControlRingHostShutdown {
+    /// Shuts down the active association without waiting for a ring lock.
     pub fn shutdown(&self) -> IoResult<()> {
         self.active.fail(Error::new(
             ErrorKind::ConnectionAborted,
-            "broker host control channel shut down",
+            "broker host association shut down",
         ))
     }
 }
 
-impl Drop for UnixStreamHostControlShutdown {
+impl Drop for UnixControlRingHostShutdown {
     fn drop(&mut self) {
         let _ = self.active.fail(Error::new(
             ErrorKind::ConnectionAborted,
-            "broker host control shutdown guard dropped",
+            "broker host association shutdown guard dropped",
         ));
     }
 }
@@ -1198,7 +1197,7 @@ mod control_ring_tests {
         association_failure: impl Fn() + Send + Sync + 'static,
     ) -> (
         UnixStreamLocalControlChannel,
-        UnixStreamLocalControlCancellation,
+        UnixControlRingLocalCancellation,
         Producer,
         Consumer,
         UnixStream,
@@ -1236,7 +1235,7 @@ mod control_ring_tests {
     fn split_host() -> (
         UnixControlRingHostRequestSource,
         UnixControlRingHostResponseSink,
-        UnixStreamHostControlShutdown,
+        UnixControlRingHostShutdown,
         Producer,
         Consumer,
         UnixStream,
@@ -1280,7 +1279,7 @@ mod control_ring_tests {
         UnixStreamLocalControlChannel,
         UnixControlRingLocalNotificationChannel,
         UnixControlRingHostNotificationChannel,
-        UnixStreamHostControlShutdown,
+        UnixControlRingHostShutdown,
     ) {
         let (local_stream, host_stream) = UnixStream::pair().unwrap();
         let (local_ring, host_ring) = ring_pair();
@@ -1904,7 +1903,7 @@ mod control_ring_tests {
     }
 
     #[test]
-    fn control_shutdown_interrupts_notification_wait() {
+    fn association_shutdown_interrupts_notification_wait() {
         let (_control, mut local, _host, shutdown) = active_notification_channels();
         let receiver = thread::spawn(move || local.recv_notification());
 

--- a/litebox_broker_transport/src/unix_socket.rs
+++ b/litebox_broker_transport/src/unix_socket.rs
@@ -64,18 +64,18 @@ fn peer_process_id(stream: &UnixStream) -> IoResult<u32> {
         .map_err(|_| invalid_data("Unix peer process ID is invalid"))
 }
 
-/// Local-side Unix-domain-socket control channel for the hosted userland POC.
-pub struct UnixStreamLocalControlChannel {
-    state: UnixStreamLocalControlState,
+/// Local control channel using a Unix stream for setup and control rings for active calls.
+pub struct UnixControlRingLocalControlChannel {
+    state: LocalControlState,
 }
 
-enum UnixStreamLocalControlState {
-    Setup(UnixStreamLocalSetup),
+enum LocalControlState {
+    Setup(LocalSetupState),
     Active(Arc<LocalActiveState>),
     Failed,
 }
 
-struct UnixStreamLocalSetup {
+struct LocalSetupState {
     stream: UnixStream,
     setup_deadline: Option<Instant>,
     negotiated: bool,
@@ -88,12 +88,12 @@ pub struct UnixControlRingLocalCancellation {
 
 struct LocalActiveState {
     request_producer: Mutex<crate::control_ring::ControlRingProducer<MemfdSharedMemory>>,
-    stream: UnixStream,
+    control_stream: UnixStream,
     pending_calls: Arc<PendingCalls>,
     association_failure: Arc<dyn Fn() + Send + Sync>,
-    request_wait: ControlRingWakeHandle<MemfdSharedMemory>,
-    response_wait: ControlRingWakeHandle<MemfdSharedMemory>,
-    notification_wait: ControlRingWakeHandle<MemfdSharedMemory>,
+    request_wake: ControlRingWakeHandle<MemfdSharedMemory>,
+    response_wake: ControlRingWakeHandle<MemfdSharedMemory>,
+    notification_wake: ControlRingWakeHandle<MemfdSharedMemory>,
 }
 
 /// Local notification receiver for a shared-ring Unix broker association.
@@ -102,11 +102,11 @@ pub struct UnixControlRingLocalNotificationChannel {
     active: Arc<LocalActiveState>,
 }
 
-impl UnixStreamLocalControlChannel {
+impl UnixControlRingLocalControlChannel {
     /// Creates a local control channel from an already-connected Unix stream.
     pub const fn from_connected(stream: UnixStream) -> Self {
         Self {
-            state: UnixStreamLocalControlState::Setup(UnixStreamLocalSetup {
+            state: LocalControlState::Setup(LocalSetupState {
                 stream,
                 setup_deadline: None,
                 negotiated: false,
@@ -129,7 +129,7 @@ impl UnixStreamLocalControlChannel {
         deadline: Instant,
     ) -> IoResult<Self> {
         UnixStream::connect(path).map(|stream| Self {
-            state: UnixStreamLocalControlState::Setup(UnixStreamLocalSetup {
+            state: LocalControlState::Setup(LocalSetupState {
                 stream,
                 setup_deadline: Some(deadline),
                 negotiated: false,
@@ -143,7 +143,7 @@ impl UnixStreamLocalControlChannel {
         expected_len: usize,
         deadline: Option<Instant>,
     ) -> IoResult<MemfdSharedMemory> {
-        let UnixStreamLocalControlState::Setup(setup) = &mut self.state else {
+        let LocalControlState::Setup(setup) = &mut self.state else {
             return Err(invalid_data("broker control setup already completed"));
         };
         crate::shared_memory::receive_memfd(&mut setup.stream, expected_len, deadline)
@@ -162,7 +162,7 @@ impl UnixStreamLocalControlChannel {
         UnixControlRingLocalCancellation,
         UnixControlRingLocalNotificationChannel,
     )> {
-        let UnixStreamLocalControlState::Setup(setup) = &self.state else {
+        let LocalControlState::Setup(setup) = &self.state else {
             return Err(invalid_data("broker control channel already active"));
         };
         if !setup.negotiated {
@@ -170,8 +170,8 @@ impl UnixStreamLocalControlChannel {
                 "broker control channel activated before negotiation completed",
             ));
         }
-        let UnixStreamLocalControlState::Setup(setup) =
-            core::mem::replace(&mut self.state, UnixStreamLocalControlState::Failed)
+        let LocalControlState::Setup(setup) =
+            core::mem::replace(&mut self.state, LocalControlState::Failed)
         else {
             unreachable!("broker control setup state disappeared");
         };
@@ -204,13 +204,13 @@ impl UnixStreamLocalControlChannel {
         let pending_calls = Arc::new(PendingCalls::new());
         let association_failure: Arc<dyn Fn() + Send + Sync> = Arc::new(association_failure);
         let active = Arc::new(LocalActiveState {
-            request_wait: request_producer.wake_handle(),
+            request_wake: request_producer.wake_handle(),
             request_producer: Mutex::new(request_producer),
-            stream: shutdown_stream,
+            control_stream: shutdown_stream,
             pending_calls: Arc::clone(&pending_calls),
             association_failure,
-            response_wait: response_consumer.wake_handle(),
-            notification_wait: notification_consumer.wake_handle(),
+            response_wake: response_consumer.wake_handle(),
+            notification_wake: notification_consumer.wake_handle(),
         });
         let response_active = Arc::clone(&active);
         if let Err(error) = thread::Builder::new()
@@ -233,7 +233,7 @@ impl UnixStreamLocalControlChannel {
             return Err(Error::other("failed to start broker liveness monitor"));
         }
 
-        self.state = UnixStreamLocalControlState::Active(Arc::clone(&active));
+        self.state = LocalControlState::Active(Arc::clone(&active));
         Ok((
             UnixControlRingLocalCancellation {
                 active: Arc::clone(&active),
@@ -247,7 +247,7 @@ impl UnixStreamLocalControlChannel {
 }
 
 impl UnixControlRingLocalCancellation {
-    /// Shuts down the control stream, unblocking pending reads or writes.
+    /// Cancels the active association, unblocking ring and socket waits.
     pub fn cancel(&self) -> IoResult<()> {
         self.active.fail(Error::new(
             ErrorKind::ConnectionAborted,
@@ -256,40 +256,40 @@ impl UnixControlRingLocalCancellation {
     }
 }
 
-impl Drop for UnixStreamLocalControlChannel {
+impl Drop for UnixControlRingLocalControlChannel {
     fn drop(&mut self) {
-        let UnixStreamLocalControlState::Active(active) = &self.state else {
+        let LocalControlState::Active(active) = &self.state else {
             return;
         };
         let _ = active.fail(Error::new(
             ErrorKind::ConnectionAborted,
-            "broker active channel dropped",
+            "broker local control channel dropped",
         ));
     }
 }
 
-fn shutdown(stream: &UnixStream) -> IoResult<()> {
+fn shutdown_socket(stream: &UnixStream) -> IoResult<()> {
     match stream.shutdown(Shutdown::Both) {
         Err(error) if error.kind() == ErrorKind::NotConnected => Ok(()),
         result => result,
     }
 }
 
-/// Host-side Unix-domain-socket control channel for the hosted userland POC.
-pub struct UnixStreamHostControlChannel {
+/// Host-side broker association setup channel over a Unix stream.
+pub struct UnixStreamHostSetupChannel {
     stream: UnixStream,
     peer_credential: PeerCredential,
     setup_deadline: Option<Instant>,
     negotiated: bool,
 }
 
-/// Request-reading half of an active host control channel.
+/// Request-reading endpoint of an active host control-ring association.
 pub struct UnixControlRingHostRequestSource {
     consumer: ControlRingConsumer<MemfdSharedMemory>,
     active: Arc<HostActiveState>,
 }
 
-/// Shared response-writing half of an active host control channel.
+/// Shared response-writing endpoint of an active host control-ring association.
 #[derive(Clone)]
 pub struct UnixControlRingHostResponseSink {
     producer: Arc<Mutex<crate::control_ring::ControlRingProducer<MemfdSharedMemory>>>,
@@ -302,11 +302,11 @@ pub struct UnixControlRingHostShutdown {
 }
 
 struct HostActiveState {
-    stream: UnixStream,
+    control_stream: UnixStream,
     status: Mutex<HostActiveStatus>,
-    request_wait: ControlRingWakeHandle<MemfdSharedMemory>,
-    response_wait: ControlRingWakeHandle<MemfdSharedMemory>,
-    notification_wait: ControlRingWakeHandle<MemfdSharedMemory>,
+    request_wake: ControlRingWakeHandle<MemfdSharedMemory>,
+    response_wake: ControlRingWakeHandle<MemfdSharedMemory>,
+    notification_wake: ControlRingWakeHandle<MemfdSharedMemory>,
 }
 
 enum HostActiveStatus {
@@ -321,8 +321,8 @@ pub struct UnixControlRingHostNotificationChannel {
     active: Arc<HostActiveState>,
 }
 
-impl UnixStreamHostControlChannel {
-    /// Creates a host control channel from an accepted Unix stream.
+impl UnixStreamHostSetupChannel {
+    /// Creates a host setup channel from an accepted Unix stream.
     pub const fn from_accepted(stream: UnixStream) -> Self {
         Self {
             stream,
@@ -332,7 +332,7 @@ impl UnixStreamHostControlChannel {
         }
     }
 
-    /// Creates a host control channel after the deployment has authenticated
+    /// Creates a host setup channel after the deployment has authenticated
     /// and bound the accepted peer. `setup_deadline` bounds handshake I/O.
     pub const fn from_host_guaranteed(stream: UnixStream, setup_deadline: Instant) -> Self {
         Self {
@@ -343,7 +343,7 @@ impl UnixStreamHostControlChannel {
         }
     }
 
-    /// Sends the memfd associated with this control channel.
+    /// Sends a memfd during association setup.
     pub fn send_memfd(
         &mut self,
         shared_memory: &MemfdSharedMemory,
@@ -365,7 +365,7 @@ impl UnixStreamHostControlChannel {
     )> {
         if !self.negotiated {
             return Err(invalid_data(
-                "broker host control channel activated before negotiation completed",
+                "broker host setup channel activated before negotiation completed",
             ));
         }
         let Some(ready) = read_frame_with_deadline(&mut self.stream, self.setup_deadline)? else {
@@ -388,11 +388,11 @@ impl UnixStreamHostControlChannel {
             notification_producer,
         } = ring.into_broker();
         let active = Arc::new(HostActiveState {
-            stream: shutdown_stream,
+            control_stream: shutdown_stream,
             status: Mutex::new(HostActiveStatus::Live),
-            request_wait: request_consumer.wake_handle(),
-            response_wait: response_producer.wake_handle(),
-            notification_wait: notification_producer.wake_handle(),
+            request_wake: request_consumer.wake_handle(),
+            response_wake: response_producer.wake_handle(),
+            notification_wake: notification_producer.wake_handle(),
         });
         let monitor_active = Arc::clone(&active);
         thread::Builder::new()
@@ -435,11 +435,11 @@ impl Drop for UnixControlRingHostShutdown {
     }
 }
 
-impl LocalControlChannel for UnixStreamLocalControlChannel {
+impl LocalControlChannel for UnixControlRingLocalControlChannel {
     type Error = Error;
 
     fn send_handshake_request(&mut self, request: &BrokerHandshakeRequest) -> IoResult<()> {
-        let UnixStreamLocalControlState::Setup(setup) = &mut self.state else {
+        let LocalControlState::Setup(setup) = &mut self.state else {
             return Err(invalid_data("broker control channel is already active"));
         };
         let frame = encode_handshake_request(request.clone());
@@ -447,7 +447,7 @@ impl LocalControlChannel for UnixStreamLocalControlChannel {
     }
 
     fn recv_handshake_response(&mut self) -> IoResult<Option<BrokerHandshakeResponse>> {
-        let UnixStreamLocalControlState::Setup(setup) = &mut self.state else {
+        let LocalControlState::Setup(setup) = &mut self.state else {
             return Err(invalid_data("broker control channel is already active"));
         };
         let frame = read_frame_with_deadline(&mut setup.stream, setup.setup_deadline)?;
@@ -462,7 +462,7 @@ impl LocalControlChannel for UnixStreamLocalControlChannel {
     }
 
     fn call(&self, request: BrokerRequest) -> IoResult<BrokerResponse> {
-        let UnixStreamLocalControlState::Active(active) = &self.state else {
+        let LocalControlState::Active(active) = &self.state else {
             return Err(invalid_data("broker control channel is not active"));
         };
         let request_id = request.request_id;
@@ -502,7 +502,7 @@ impl LocalControlChannel for UnixStreamLocalControlChannel {
     }
 }
 
-impl HostSetupChannel for UnixStreamHostControlChannel {
+impl HostSetupChannel for UnixStreamHostSetupChannel {
     type Error = Error;
 
     fn peer_credential(&self) -> IoResult<PeerCredential> {
@@ -657,11 +657,11 @@ impl HostNotificationChannel for UnixControlRingHostNotificationChannel {
 }
 
 struct PendingCalls {
-    state: Mutex<PendingCallState>,
+    state: Mutex<PendingCallsState>,
     capacity_available: Condvar,
 }
 
-struct PendingCallState {
+struct PendingCallsState {
     calls: HashMap<RequestId, Arc<PendingCall>>,
     failure: Option<Arc<Error>>,
 }
@@ -717,7 +717,7 @@ impl PendingCall {
 impl PendingCalls {
     fn new() -> Self {
         Self {
-            state: Mutex::new(PendingCallState {
+            state: Mutex::new(PendingCallsState {
                 calls: HashMap::new(),
                 failure: None,
             }),
@@ -821,10 +821,10 @@ impl LocalActiveState {
 
     fn fail(&self, error: Error) -> IoResult<()> {
         let first_failure = self.pending_calls.record_failure(Arc::new(error));
-        let request_wake = self.request_wait.interrupt_wait();
-        let response_wake = self.response_wait.interrupt_wait();
-        let notification_wake = self.notification_wait.interrupt_wait();
-        let shutdown_result = shutdown(&self.stream);
+        let request_wake = self.request_wake.interrupt_wait();
+        let response_wake = self.response_wake.interrupt_wait();
+        let notification_wake = self.notification_wake.interrupt_wait();
+        let shutdown_result = shutdown_socket(&self.control_stream);
         if first_failure {
             (self.association_failure)();
         }
@@ -871,13 +871,13 @@ impl HostActiveState {
                 *status = HostActiveStatus::Failed(Arc::new(error));
             }
         }
-        let request_wake = self.request_wait.interrupt_wait();
-        let response_wake = self.response_wait.interrupt_wait();
-        let notification_wake = self.notification_wait.interrupt_wait();
+        let request_wake = self.request_wake.interrupt_wait();
+        let response_wake = self.response_wake.interrupt_wait();
+        let notification_wake = self.notification_wake.interrupt_wait();
         request_wake
             .and(response_wake)
             .and(notification_wake)
-            .and(shutdown(&self.stream))
+            .and(shutdown_socket(&self.control_stream))
     }
 
     fn peer_closed(&self) {
@@ -890,9 +890,9 @@ impl HostActiveState {
                 *status = HostActiveStatus::PeerClosed;
             }
         }
-        let _ = self.request_wait.interrupt_wait();
-        let _ = self.response_wait.interrupt_wait();
-        let _ = self.notification_wait.interrupt_wait();
+        let _ = self.request_wake.interrupt_wait();
+        let _ = self.response_wake.interrupt_wait();
+        let _ = self.notification_wake.interrupt_wait();
     }
 
     fn request_terminal_result(&self) -> Option<IoResult<HostReceive<BrokerRequest>>> {
@@ -933,7 +933,7 @@ impl HostActiveState {
                 HostActiveStatus::PeerClosed => {
                     return Err(Error::new(
                         ErrorKind::BrokenPipe,
-                        "runner closed the active control channel",
+                        "runner closed the active broker association",
                     ));
                 }
                 HostActiveStatus::Failed(error) => return Err(copy_io_error(error)),
@@ -992,7 +992,7 @@ fn monitor_socket(stream: &mut UnixStream, peer: &'static str) -> Error {
             Ok(0) => {
                 return Error::new(
                     ErrorKind::UnexpectedEof,
-                    format!("{peer} closed the active control channel"),
+                    format!("{peer} closed the active broker association"),
                 );
             }
             Ok(_) => {
@@ -1183,9 +1183,9 @@ mod control_ring_tests {
         )
     }
 
-    fn negotiated_local(stream: UnixStream) -> UnixStreamLocalControlChannel {
-        UnixStreamLocalControlChannel {
-            state: UnixStreamLocalControlState::Setup(UnixStreamLocalSetup {
+    fn negotiated_local(stream: UnixStream) -> UnixControlRingLocalControlChannel {
+        UnixControlRingLocalControlChannel {
+            state: LocalControlState::Setup(LocalSetupState {
                 stream,
                 setup_deadline: Some(Instant::now() + Duration::from_secs(2)),
                 negotiated: true,
@@ -1196,7 +1196,7 @@ mod control_ring_tests {
     fn activate_local(
         association_failure: impl Fn() + Send + Sync + 'static,
     ) -> (
-        UnixStreamLocalControlChannel,
+        UnixControlRingLocalControlChannel,
         UnixControlRingLocalCancellation,
         Producer,
         Consumer,
@@ -1232,7 +1232,7 @@ mod control_ring_tests {
         )
     }
 
-    fn split_host() -> (
+    fn activate_host() -> (
         UnixControlRingHostRequestSource,
         UnixControlRingHostResponseSink,
         UnixControlRingHostShutdown,
@@ -1252,7 +1252,7 @@ mod control_ring_tests {
             );
         });
         let (local_ring, host_ring) = ring_pair();
-        let channel = UnixStreamHostControlChannel {
+        let channel = UnixStreamHostSetupChannel {
             stream: host_stream,
             peer_credential: PeerCredential::HostGuaranteed,
             setup_deadline: Some(Instant::now() + Duration::from_secs(2)),
@@ -1276,7 +1276,7 @@ mod control_ring_tests {
     }
 
     fn active_notification_channels() -> (
-        UnixStreamLocalControlChannel,
+        UnixControlRingLocalControlChannel,
         UnixControlRingLocalNotificationChannel,
         UnixControlRingHostNotificationChannel,
         UnixControlRingHostShutdown,
@@ -1284,7 +1284,7 @@ mod control_ring_tests {
         let (local_stream, host_stream) = UnixStream::pair().unwrap();
         let (local_ring, host_ring) = ring_pair();
         let mut local_control = negotiated_local(local_stream);
-        let host_control = UnixStreamHostControlChannel {
+        let host_control = UnixStreamHostSetupChannel {
             stream: host_stream,
             peer_credential: PeerCredential::HostGuaranteed,
             setup_deadline: Some(Instant::now() + Duration::from_secs(2)),
@@ -1427,7 +1427,7 @@ mod control_ring_tests {
     #[test]
     fn local_control_channel_enforces_setup_and_active_phases() {
         let (local_stream, mut host_stream) = UnixStream::pair().unwrap();
-        let mut channel = UnixStreamLocalControlChannel::from_connected(local_stream);
+        let mut channel = UnixControlRingLocalControlChannel::from_connected(local_stream);
         assert_eq!(
             channel.call(request(0)).unwrap_err().kind(),
             ErrorKind::InvalidData
@@ -1504,7 +1504,7 @@ mod control_ring_tests {
         let (local_stream, host_stream) = UnixStream::pair().unwrap();
         let (local_ring, host_ring) = ring_pair();
         let mut local = negotiated_local(local_stream);
-        let host = UnixStreamHostControlChannel {
+        let host = UnixStreamHostSetupChannel {
             stream: host_stream,
             peer_credential: PeerCredential::HostGuaranteed,
             setup_deadline: Some(Instant::now() + Duration::from_secs(2)),
@@ -1633,8 +1633,8 @@ mod control_ring_tests {
     }
 
     #[test]
-    fn host_split_decodes_requests_and_cloned_sinks_publish_complete_responses() {
-        let (mut source, sink, _shutdown, mut requests, mut responses, _peer) = split_host();
+    fn host_activation_decodes_requests_and_cloned_sinks_publish_complete_responses() {
+        let (mut source, sink, _shutdown, mut requests, mut responses, _peer) = activate_host();
         write_payload(&mut requests, &encode_request(request(1)));
         assert!(matches!(
             source.recv_request().unwrap(),
@@ -1658,7 +1658,7 @@ mod control_ring_tests {
 
     #[test]
     fn host_clean_close_wakes_request_wait_as_peer_closed() {
-        let (mut source, _sink, _shutdown, _requests, _responses, peer) = split_host();
+        let (mut source, _sink, _shutdown, _requests, _responses, peer) = activate_host();
         let receiver = thread::spawn(move || source.recv_request());
         drop(peer);
         assert_eq!(receiver.join().unwrap().unwrap(), HostReceive::PeerClosed);
@@ -1666,7 +1666,7 @@ mod control_ring_tests {
 
     #[test]
     fn host_failure_preempts_queued_and_decoded_requests_but_peer_close_drains() {
-        let (mut source, _sink, _shutdown, mut requests, _responses, _peer) = split_host();
+        let (mut source, _sink, _shutdown, mut requests, _responses, _peer) = activate_host();
         write_payload(&mut requests, &encode_request(request(1)));
         source
             .active
@@ -1677,7 +1677,7 @@ mod control_ring_tests {
             ErrorKind::TimedOut
         );
 
-        let (mut source, _sink, _shutdown, mut requests, _responses, _peer) = split_host();
+        let (mut source, _sink, _shutdown, mut requests, _responses, _peer) = activate_host();
         write_payload(&mut requests, &encode_request(request(2)));
         assert!(matches!(
             source.consumer.try_read(decode_request).unwrap(),
@@ -1696,7 +1696,7 @@ mod control_ring_tests {
             ErrorKind::TimedOut
         );
 
-        let (mut source, _sink, _shutdown, mut requests, _responses, _peer) = split_host();
+        let (mut source, _sink, _shutdown, mut requests, _responses, _peer) = activate_host();
         write_payload(&mut requests, &encode_request(request(3)));
         source.active.peer_closed();
         assert!(matches!(
@@ -1711,7 +1711,7 @@ mod control_ring_tests {
 
     #[test]
     fn dropping_host_shutdown_guard_wakes_request_wait_and_closes_socket() {
-        let (mut source, sink, shutdown, _requests, _responses, mut peer) = split_host();
+        let (mut source, sink, shutdown, _requests, _responses, mut peer) = activate_host();
         peer.set_read_timeout(Some(Duration::from_secs(1))).unwrap();
         let receiver = thread::spawn(move || source.recv_request());
 
@@ -1728,7 +1728,7 @@ mod control_ring_tests {
 
     #[test]
     fn host_close_wakes_response_producer_blocked_on_full_ring() {
-        let (_source, sink, _shutdown, _requests, _responses, peer) = split_host();
+        let (_source, sink, _shutdown, _requests, _responses, peer) = activate_host();
         for id in 0..CONTROL_RING_SLOT_COUNT {
             sink.send_response(&response(RequestId(id))).unwrap();
         }
@@ -1744,7 +1744,7 @@ mod control_ring_tests {
 
     #[test]
     fn host_reports_wrong_phase_ring_message_as_protocol_violation() {
-        let (mut source, _sink, _shutdown, mut requests, _responses, _peer) = split_host();
+        let (mut source, _sink, _shutdown, mut requests, _responses, _peer) = activate_host();
         write_payload(
             &mut requests,
             &encode_handshake_request(BrokerHandshakeRequest {
@@ -1759,7 +1759,7 @@ mod control_ring_tests {
 
     #[test]
     fn malformed_host_ring_request_is_fatal_invalid_data() {
-        let (mut source, _sink, _shutdown, mut requests, _responses, _peer) = split_host();
+        let (mut source, _sink, _shutdown, mut requests, _responses, _peer) = activate_host();
         write_payload(&mut requests, &[u8::MAX]);
         assert_eq!(
             source.recv_request().unwrap_err().kind(),
@@ -1770,7 +1770,7 @@ mod control_ring_tests {
     #[test]
     fn host_setup_rejects_active_frames_and_requires_negotiation() {
         let (mut peer_stream, host_stream) = UnixStream::pair().unwrap();
-        let mut channel = UnixStreamHostControlChannel::from_accepted(host_stream);
+        let mut channel = UnixStreamHostSetupChannel::from_accepted(host_stream);
         write_frame_with_deadline(&mut peer_stream, &encode_request(request(0)), None).unwrap();
         assert_eq!(
             channel.recv_handshake_request().unwrap(),
@@ -1778,7 +1778,7 @@ mod control_ring_tests {
         );
 
         let (_peer_stream, host_stream) = UnixStream::pair().unwrap();
-        let channel = UnixStreamHostControlChannel::from_accepted(host_stream);
+        let channel = UnixStreamHostSetupChannel::from_accepted(host_stream);
         let (ring, _) = ring_pair();
         let Err(error) = channel.into_active(ring) else {
             panic!("host control channel activated before negotiation");
@@ -1790,8 +1790,8 @@ mod control_ring_tests {
     fn ready_ack_uses_absolute_setup_deadline() {
         let (local_stream, _peer) = UnixStream::pair().unwrap();
         let (ring, _) = ring_pair();
-        let mut local = UnixStreamLocalControlChannel {
-            state: UnixStreamLocalControlState::Setup(UnixStreamLocalSetup {
+        let mut local = UnixControlRingLocalControlChannel {
+            state: LocalControlState::Setup(LocalSetupState {
                 stream: local_stream,
                 setup_deadline: Some(Instant::now() + Duration::from_millis(30)),
                 negotiated: true,
@@ -1809,8 +1809,8 @@ mod control_ring_tests {
     #[test]
     fn handshake_reads_use_absolute_setup_deadlines() {
         let (mut host_stream, local_stream) = UnixStream::pair().unwrap();
-        let mut local = UnixStreamLocalControlChannel {
-            state: UnixStreamLocalControlState::Setup(UnixStreamLocalSetup {
+        let mut local = UnixControlRingLocalControlChannel {
+            state: LocalControlState::Setup(LocalSetupState {
                 stream: local_stream,
                 setup_deadline: Some(Instant::now() + Duration::from_millis(50)),
                 negotiated: false,
@@ -1831,7 +1831,7 @@ mod control_ring_tests {
         );
 
         let (mut local_stream, host_stream) = UnixStream::pair().unwrap();
-        let mut host = UnixStreamHostControlChannel::from_host_guaranteed(
+        let mut host = UnixStreamHostSetupChannel::from_host_guaranteed(
             host_stream,
             Instant::now() + Duration::from_millis(50),
         );
@@ -1928,7 +1928,7 @@ mod control_ring_tests {
             local.recv_notification().unwrap_err().kind(),
             ErrorKind::InvalidData
         );
-        let UnixStreamLocalControlState::Active(active) = &control.state else {
+        let LocalControlState::Active(active) = &control.state else {
             panic!("control channel is not active");
         };
         assert!(active.pending_calls.current_failure().is_some());

--- a/litebox_broker_transport/src/unix_socket.rs
+++ b/litebox_broker_transport/src/unix_socket.rs
@@ -8,7 +8,8 @@
 //! no_std protocol, local, core, and host crates.
 //!
 //! After setup, the authenticated socket is retained only for liveness and
-//! cancellation. Active requests and responses use a shared control ring.
+//! cancellation. Active requests, responses, and notifications use shared
+//! control rings.
 
 use std::io::{Error, ErrorKind, Read, Result as IoResult, Write};
 use std::net::Shutdown;
@@ -57,17 +58,6 @@ pub fn validate_peer_process(stream: &UnixStream, expected_process_id: u32) -> I
     Ok(())
 }
 
-/// Validates that two connected Unix sockets belong to the same process.
-pub fn validate_same_peer_process(first: &UnixStream, second: &UnixStream) -> IoResult<()> {
-    if peer_process_id(first)? != peer_process_id(second)? {
-        return Err(Error::new(
-            ErrorKind::PermissionDenied,
-            "Unix sockets belong to different peer processes",
-        ));
-    }
-    Ok(())
-}
-
 fn peer_process_id(stream: &UnixStream) -> IoResult<u32> {
     let credentials = rustix::net::sockopt::socket_peercred(stream)?;
     u32::try_from(credentials.pid.as_raw_pid())
@@ -107,6 +97,13 @@ struct LocalActiveFailureCoordinator {
     association_failure: Arc<dyn Fn() + Send + Sync>,
     request_wait: ControlRingWakeHandle<MemfdSharedMemory>,
     response_wait: ControlRingWakeHandle<MemfdSharedMemory>,
+    notification_wait: ControlRingWakeHandle<MemfdSharedMemory>,
+}
+
+/// Local notification receiver for a shared-ring Unix broker association.
+pub struct UnixControlRingLocalNotificationChannel {
+    consumer: ControlRingConsumer<MemfdSharedMemory>,
+    failure_coordinator: Arc<LocalActiveFailureCoordinator>,
 }
 
 impl UnixStreamLocalControlChannel {
@@ -156,7 +153,8 @@ impl UnixStreamLocalControlChannel {
         crate::shared_memory::receive_memfd(&mut setup.stream, expected_len, deadline)
     }
 
-    /// Completes setup and starts the active control-ring response pump.
+    /// Completes setup, starts the response pump, and returns the notification
+    /// receiver for the active shared-ring association.
     ///
     /// The ring must be the validated control-ring memfd received during this
     /// setup exchange.
@@ -164,7 +162,10 @@ impl UnixStreamLocalControlChannel {
         &mut self,
         ring: ControlRing<MemfdSharedMemory>,
         association_failure: impl Fn() + Send + Sync + 'static,
-    ) -> IoResult<UnixStreamLocalControlCancellation> {
+    ) -> IoResult<(
+        UnixStreamLocalControlCancellation,
+        UnixControlRingLocalNotificationChannel,
+    )> {
         let UnixStreamLocalControlState::Setup(setup) = &self.state else {
             return Err(invalid_data("broker control channel already active"));
         };
@@ -202,7 +203,7 @@ impl UnixStreamLocalControlChannel {
         let crate::control_ring::LocalControlRingEndpoints {
             request_producer,
             response_consumer,
-            notification_consumer: _,
+            notification_consumer,
         } = ring.into_local();
         let pending_calls = Arc::new(PendingCalls::new());
         let association_failure: Arc<dyn Fn() + Send + Sync> = Arc::new(association_failure);
@@ -212,6 +213,7 @@ impl UnixStreamLocalControlChannel {
             association_failure,
             request_wait: request_producer.wake_handle(),
             response_wait: response_consumer.wake_handle(),
+            notification_wait: notification_consumer.wake_handle(),
         });
         let response_failure_coordinator = Arc::clone(&failure_coordinator);
         if let Err(error) = thread::Builder::new()
@@ -238,9 +240,15 @@ impl UnixStreamLocalControlChannel {
             request_producer: Mutex::new(request_producer),
             failure_coordinator: Arc::clone(&failure_coordinator),
         });
-        Ok(UnixStreamLocalControlCancellation {
-            failure_coordinator,
-        })
+        Ok((
+            UnixStreamLocalControlCancellation {
+                failure_coordinator: Arc::clone(&failure_coordinator),
+            },
+            UnixControlRingLocalNotificationChannel {
+                consumer: notification_consumer,
+                failure_coordinator,
+            },
+        ))
     }
 }
 
@@ -304,6 +312,7 @@ struct HostActiveState {
     status: Mutex<HostActiveStatus>,
     request_wait: ControlRingWakeHandle<MemfdSharedMemory>,
     response_wait: ControlRingWakeHandle<MemfdSharedMemory>,
+    notification_wait: ControlRingWakeHandle<MemfdSharedMemory>,
 }
 
 enum HostActiveStatus {
@@ -312,19 +321,10 @@ enum HostActiveStatus {
     Failed(Arc<Error>),
 }
 
-/// Local-side Unix-domain-socket notification channel for the hosted userland POC.
-pub struct UnixStreamLocalNotificationChannel {
-    stream: UnixStream,
-}
-
-/// Independently owned handle for interrupting local notification-channel I/O.
-pub struct UnixStreamLocalNotificationCancellation {
-    stream: UnixStream,
-}
-
-/// Host-side Unix-domain-socket notification channel for the hosted userland POC.
-pub struct UnixStreamHostNotificationChannel {
-    stream: UnixStream,
+/// Host notification sender for a shared-ring Unix broker association.
+pub struct UnixControlRingHostNotificationChannel {
+    producer: ControlRingProducer<MemfdSharedMemory>,
+    active: Arc<HostActiveState>,
 }
 
 impl UnixStreamHostControlChannel {
@@ -359,13 +359,14 @@ impl UnixStreamHostControlChannel {
     }
 
     /// Consumes a negotiated setup channel into independently usable active
-    /// request, response, and shutdown handles.
+    /// request, response, notification, and shutdown handles.
     pub fn into_active(
         mut self,
         ring: ControlRing<MemfdSharedMemory>,
     ) -> IoResult<(
         UnixStreamHostRequestSource,
         UnixStreamHostResponseSink,
+        UnixControlRingHostNotificationChannel,
         UnixStreamHostControlShutdown,
     )> {
         if !self.negotiated {
@@ -390,13 +391,14 @@ impl UnixStreamHostControlChannel {
         let crate::control_ring::BrokerControlRingEndpoints {
             request_consumer,
             response_producer,
-            notification_producer: _,
+            notification_producer,
         } = ring.into_broker();
         let active = Arc::new(HostActiveState {
             stream: shutdown_stream,
             status: Mutex::new(HostActiveStatus::Live),
             request_wait: request_consumer.wake_handle(),
             response_wait: response_producer.wake_handle(),
+            notification_wait: notification_producer.wake_handle(),
         });
         let monitor_active = Arc::clone(&active);
         thread::Builder::new()
@@ -409,6 +411,10 @@ impl UnixStreamHostControlChannel {
             },
             UnixStreamHostResponseSink {
                 producer: Arc::new(Mutex::new(response_producer)),
+                active: Arc::clone(&active),
+            },
+            UnixControlRingHostNotificationChannel {
+                producer: notification_producer,
                 active: Arc::clone(&active),
             },
             UnixStreamHostControlShutdown { active },
@@ -433,45 +439,6 @@ impl Drop for UnixStreamHostControlShutdown {
             ErrorKind::ConnectionAborted,
             "broker host control shutdown guard dropped",
         ));
-    }
-}
-
-impl UnixStreamLocalNotificationChannel {
-    /// Creates a local notification channel from an already-connected Unix stream.
-    pub const fn from_connected(stream: UnixStream) -> Self {
-        Self { stream }
-    }
-
-    /// Connects to a userland broker Unix notification socket.
-    pub fn connect(path: impl AsRef<Path>) -> IoResult<Self> {
-        UnixStream::connect(path).map(Self::from_connected)
-    }
-
-    /// Creates a handle that can interrupt pending notification-channel I/O.
-    pub fn cancellation_handle(&self) -> IoResult<UnixStreamLocalNotificationCancellation> {
-        self.stream
-            .try_clone()
-            .map(|stream| UnixStreamLocalNotificationCancellation { stream })
-    }
-}
-
-impl UnixStreamLocalNotificationCancellation {
-    /// Shuts down the notification stream, unblocking pending reads.
-    pub fn cancel(&self) -> IoResult<()> {
-        shutdown(&self.stream)
-    }
-}
-
-impl Drop for UnixStreamLocalNotificationChannel {
-    fn drop(&mut self) {
-        let _ = shutdown(&self.stream);
-    }
-}
-
-impl UnixStreamHostNotificationChannel {
-    /// Creates a host notification channel from an accepted Unix stream.
-    pub const fn from_accepted(stream: UnixStream) -> Self {
-        Self { stream }
     }
 }
 
@@ -626,7 +593,7 @@ impl UnixStreamHostResponseSink {
             .lock()
             .map_err(|_| Error::other("broker response writer mutex poisoned"))?;
         loop {
-            match self.active.try_publish_response(&mut producer, &frame)? {
+            match self.active.try_publish(&mut producer, &frame)? {
                 ControlRingWriteStatus::Written => return Ok(()),
                 ControlRingWriteStatus::Full { wait_epoch } => {
                     if let Err(error) = producer.wait_for_capacity(wait_epoch) {
@@ -640,26 +607,64 @@ impl UnixStreamHostResponseSink {
     }
 }
 
-impl LocalNotificationChannel for UnixStreamLocalNotificationChannel {
+impl LocalNotificationChannel for UnixControlRingLocalNotificationChannel {
     type Error = Error;
 
     fn recv_notification(&mut self) -> IoResult<Option<BrokerNotification>> {
-        match read_frame_with_deadline(&mut self.stream, None)? {
-            Some(frame) => decode_notification(&frame).map(Some).map_err(wire_error),
-            None => Ok(None),
+        loop {
+            if let Some(error) = self.failure_coordinator.pending_calls.current_failure() {
+                return Err(copy_io_error(&error));
+            }
+            match self.consumer.try_read(decode_notification) {
+                Ok(ControlRingReadStatus::Message(notification)) => {
+                    self.failure_coordinator
+                        .acknowledge_notification(&mut self.consumer)?;
+                    return Ok(Some(notification));
+                }
+                Ok(ControlRingReadStatus::Empty { wait_epoch }) => {
+                    if let Some(error) = self.failure_coordinator.pending_calls.current_failure() {
+                        return Err(copy_io_error(&error));
+                    }
+                    if let Err(error) = self.consumer.wait_for_message(wait_epoch) {
+                        let result = Err(copy_io_error(&error));
+                        let _ = self.failure_coordinator.fail(error);
+                        return result;
+                    }
+                }
+                Err(ControlRingReadError::Ring(error)) => {
+                    let error = Error::from(error);
+                    let result = Err(copy_io_error(&error));
+                    let _ = self.failure_coordinator.fail(error);
+                    return result;
+                }
+                Err(ControlRingReadError::Decode(error)) => {
+                    let error = wire_error(error);
+                    let result = Err(copy_io_error(&error));
+                    let _ = self.failure_coordinator.fail(error);
+                    return result;
+                }
+            }
         }
     }
 }
 
-impl HostNotificationChannel for UnixStreamHostNotificationChannel {
+impl HostNotificationChannel for UnixControlRingHostNotificationChannel {
     type Error = Error;
 
     fn send_notification(&mut self, notification: &BrokerNotification) -> IoResult<()> {
-        write_frame_with_deadline(
-            &mut self.stream,
-            &encode_notification(notification.clone()),
-            None,
-        )
+        let frame = encode_notification(notification.clone());
+        loop {
+            match self.active.try_publish(&mut self.producer, &frame)? {
+                ControlRingWriteStatus::Written => return Ok(()),
+                ControlRingWriteStatus::Full { wait_epoch } => {
+                    if let Err(error) = self.producer.wait_for_capacity(wait_epoch) {
+                        let result = Err(copy_io_error(&error));
+                        let _ = self.active.fail(error);
+                        return result;
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -808,15 +813,37 @@ impl PendingCalls {
 }
 
 impl LocalActiveFailureCoordinator {
+    fn acknowledge_notification(
+        &self,
+        consumer: &mut ControlRingConsumer<MemfdSharedMemory>,
+    ) -> IoResult<()> {
+        let result = self.pending_calls.run_if_live(|| {
+            consumer
+                .publish_head()
+                .map_err(Error::from)
+                .and_then(|()| consumer.wake_producer())
+        });
+        if let Err(error) = result {
+            let result = Err(copy_io_error(&error));
+            let _ = self.fail(error);
+            return result;
+        }
+        Ok(())
+    }
+
     fn fail(&self, error: Error) -> IoResult<()> {
         let first_failure = self.pending_calls.record_failure(Arc::new(error));
         let request_wake = self.request_wait.interrupt_wait();
         let response_wake = self.response_wait.interrupt_wait();
+        let notification_wake = self.notification_wait.interrupt_wait();
         let shutdown_result = shutdown(&self.stream);
         if first_failure {
             (self.association_failure)();
         }
-        request_wake.and(response_wake).and(shutdown_result)
+        request_wake
+            .and(response_wake)
+            .and(notification_wake)
+            .and(shutdown_result)
     }
 }
 
@@ -858,7 +885,11 @@ impl HostActiveState {
         }
         let request_wake = self.request_wait.interrupt_wait();
         let response_wake = self.response_wait.interrupt_wait();
-        request_wake.and(response_wake).and(shutdown(&self.stream))
+        let notification_wake = self.notification_wait.interrupt_wait();
+        request_wake
+            .and(response_wake)
+            .and(notification_wake)
+            .and(shutdown(&self.stream))
     }
 
     fn peer_closed(&self) {
@@ -873,6 +904,7 @@ impl HostActiveState {
         }
         let _ = self.request_wait.interrupt_wait();
         let _ = self.response_wait.interrupt_wait();
+        let _ = self.notification_wait.interrupt_wait();
     }
 
     fn request_terminal_result(&self) -> Option<IoResult<HostReceive<BrokerRequest>>> {
@@ -898,7 +930,7 @@ impl HostActiveState {
         }
     }
 
-    fn try_publish_response(
+    fn try_publish(
         &self,
         producer: &mut ControlRingProducer<MemfdSharedMemory>,
         frame: &[u8],
@@ -1202,7 +1234,8 @@ mod control_ring_tests {
         });
         let (local_ring, broker_ring) = ring_pair();
         let mut channel = negotiated_local(local_stream);
-        let cancellation = channel.activate(local_ring, association_failure).unwrap();
+        let (cancellation, _notifications) =
+            channel.activate(local_ring, association_failure).unwrap();
         acknowledgement.join().unwrap();
         let crate::control_ring::BrokerControlRingEndpoints {
             request_consumer,
@@ -1244,7 +1277,7 @@ mod control_ring_tests {
             setup_deadline: Some(Instant::now() + Duration::from_secs(2)),
             negotiated: true,
         };
-        let (source, sink, shutdown) = channel.into_active(host_ring).unwrap();
+        let (source, sink, _notifications, shutdown) = channel.into_active(host_ring).unwrap();
         acknowledgement.join().unwrap();
         let crate::control_ring::LocalControlRingEndpoints {
             request_producer,
@@ -1258,6 +1291,33 @@ mod control_ring_tests {
             request_producer,
             response_consumer,
             peer_stream,
+        )
+    }
+
+    fn active_notification_channels() -> (
+        UnixStreamLocalControlChannel,
+        UnixControlRingLocalNotificationChannel,
+        UnixControlRingHostNotificationChannel,
+        UnixStreamHostControlShutdown,
+    ) {
+        let (local_stream, host_stream) = UnixStream::pair().unwrap();
+        let (local_ring, host_ring) = ring_pair();
+        let mut local_control = negotiated_local(local_stream);
+        let host_control = UnixStreamHostControlChannel {
+            stream: host_stream,
+            peer_credential: PeerCredential::HostGuaranteed,
+            setup_deadline: Some(Instant::now() + Duration::from_secs(2)),
+            negotiated: true,
+        };
+        let host_active = thread::spawn(move || host_control.into_active(host_ring).unwrap());
+        let (_cancellation, local_notifications) =
+            local_control.activate(local_ring, || {}).unwrap();
+        let (_source, _sink, host_notifications, shutdown) = host_active.join().unwrap();
+        (
+            local_control,
+            local_notifications,
+            host_notifications,
+            shutdown,
         )
     }
 
@@ -1321,10 +1381,9 @@ mod control_ring_tests {
 
     #[test]
     fn linux_peer_validation_identifies_connected_process() {
-        let (first, second) = UnixStream::pair().unwrap();
+        let (first, _second) = UnixStream::pair().unwrap();
 
         validate_peer_process(&first, std::process::id()).unwrap();
-        validate_same_peer_process(&first, &second).unwrap();
         let unexpected_process_id = std::process::id().checked_add(1).unwrap();
         assert_eq!(
             validate_peer_process(&first, unexpected_process_id)
@@ -1471,8 +1530,8 @@ mod control_ring_tests {
             negotiated: true,
         };
         let host_active = thread::spawn(move || host.into_active(host_ring).unwrap());
-        let _cancellation = local.activate(local_ring, || {}).unwrap();
-        let (mut source, sink, _shutdown) = host_active.join().unwrap();
+        let (_cancellation, _local_notifications) = local.activate(local_ring, || {}).unwrap();
+        let (mut source, sink, _host_notifications, _shutdown) = host_active.join().unwrap();
 
         let caller = thread::spawn(move || local.call(request(7)));
         let HostReceive::Message(received) = source.recv_request().unwrap() else {
@@ -1811,10 +1870,8 @@ mod control_ring_tests {
     }
 
     #[test]
-    fn notification_frame_round_trips() {
-        let (local_stream, host_stream) = UnixStream::pair().unwrap();
-        let mut local = UnixStreamLocalNotificationChannel::from_connected(local_stream);
-        let mut host = UnixStreamHostNotificationChannel::from_accepted(host_stream);
+    fn notification_ring_round_trips() {
+        let (_control, mut local, mut host, _shutdown) = active_notification_channels();
         let notification = BrokerNotification::Readiness(
             litebox_broker_protocol::message::ReadinessNotification {
                 handle: ObjectHandle(7),
@@ -1822,9 +1879,84 @@ mod control_ring_tests {
             },
         );
 
+        let receiver = thread::spawn(move || local.recv_notification());
+        thread::sleep(Duration::from_millis(20));
         host.send_notification(&notification).unwrap();
 
-        assert_eq!(local.recv_notification().unwrap(), Some(notification));
+        assert_eq!(receiver.join().unwrap().unwrap(), Some(notification));
+    }
+
+    #[test]
+    fn full_notification_ring_wakes_after_consumer_progress() {
+        let (_control, mut local, mut host, _shutdown) = active_notification_channels();
+        let notification = BrokerNotification::Readiness(
+            litebox_broker_protocol::message::ReadinessNotification {
+                handle: ObjectHandle(7),
+                readiness: litebox_broker_protocol::readiness::ReadinessFlags::READ,
+            },
+        );
+        for _ in 0..crate::control_ring::CONTROL_RING_NOTIFICATION_SLOT_COUNT {
+            host.send_notification(&notification).unwrap();
+        }
+
+        let (started_sender, started_receiver) = std::sync::mpsc::sync_channel(1);
+        let (done_sender, done_receiver) = std::sync::mpsc::sync_channel(1);
+        let writer = thread::spawn(move || {
+            started_sender.send(()).unwrap();
+            host.send_notification(&notification).unwrap();
+            done_sender.send(()).unwrap();
+        });
+        started_receiver.recv().unwrap();
+        assert!(
+            done_receiver
+                .recv_timeout(Duration::from_millis(20))
+                .is_err()
+        );
+
+        assert!(matches!(
+            local.recv_notification().unwrap(),
+            Some(BrokerNotification::Readiness(_))
+        ));
+        done_receiver.recv_timeout(Duration::from_secs(1)).unwrap();
+        writer.join().unwrap();
+    }
+
+    #[test]
+    fn control_shutdown_interrupts_notification_wait() {
+        let (_control, mut local, _host, shutdown) = active_notification_channels();
+        let receiver = thread::spawn(move || local.recv_notification());
+
+        shutdown.shutdown().unwrap();
+
+        assert_eq!(
+            receiver.join().unwrap().unwrap_err().kind(),
+            ErrorKind::UnexpectedEof
+        );
+    }
+
+    #[test]
+    fn malformed_notification_fails_the_association() {
+        let (control, mut local, mut host, _shutdown) = active_notification_channels();
+        assert_eq!(
+            host.producer.try_write(&[0xff]).unwrap(),
+            ControlRingWriteStatus::Written
+        );
+        host.producer.wake_consumer().unwrap();
+
+        assert_eq!(
+            local.recv_notification().unwrap_err().kind(),
+            ErrorKind::InvalidData
+        );
+        let UnixStreamLocalControlState::Active(active) = &control.state else {
+            panic!("control channel is not active");
+        };
+        assert!(
+            active
+                .failure_coordinator
+                .pending_calls
+                .current_failure()
+                .is_some()
+        );
     }
 
     #[test]

--- a/litebox_broker_transport/src/unix_socket.rs
+++ b/litebox_broker_transport/src/unix_socket.rs
@@ -71,7 +71,7 @@ pub struct UnixStreamLocalControlChannel {
 
 enum UnixStreamLocalControlState {
     Setup(UnixStreamLocalSetup),
-    Active(UnixStreamLocalActive),
+    Active(Arc<LocalActiveState>),
     Failed,
 }
 
@@ -83,15 +83,11 @@ struct UnixStreamLocalSetup {
 
 /// Independently owned handle for interrupting local control-channel I/O.
 pub struct UnixStreamLocalControlCancellation {
-    failure_coordinator: Arc<LocalActiveFailureCoordinator>,
+    active: Arc<LocalActiveState>,
 }
 
-struct UnixStreamLocalActive {
+struct LocalActiveState {
     request_producer: Mutex<crate::control_ring::ControlRingProducer<MemfdSharedMemory>>,
-    failure_coordinator: Arc<LocalActiveFailureCoordinator>,
-}
-
-struct LocalActiveFailureCoordinator {
     stream: UnixStream,
     pending_calls: Arc<PendingCalls>,
     association_failure: Arc<dyn Fn() + Send + Sync>,
@@ -103,7 +99,7 @@ struct LocalActiveFailureCoordinator {
 /// Local notification receiver for a shared-ring Unix broker association.
 pub struct UnixControlRingLocalNotificationChannel {
     consumer: ControlRingConsumer<MemfdSharedMemory>,
-    failure_coordinator: Arc<LocalActiveFailureCoordinator>,
+    active: Arc<LocalActiveState>,
 }
 
 impl UnixStreamLocalControlChannel {
@@ -207,46 +203,44 @@ impl UnixStreamLocalControlChannel {
         } = ring.into_local();
         let pending_calls = Arc::new(PendingCalls::new());
         let association_failure: Arc<dyn Fn() + Send + Sync> = Arc::new(association_failure);
-        let failure_coordinator = Arc::new(LocalActiveFailureCoordinator {
+        let active = Arc::new(LocalActiveState {
+            request_wait: request_producer.wake_handle(),
+            request_producer: Mutex::new(request_producer),
             stream: shutdown_stream,
             pending_calls: Arc::clone(&pending_calls),
             association_failure,
-            request_wait: request_producer.wake_handle(),
             response_wait: response_consumer.wake_handle(),
             notification_wait: notification_consumer.wake_handle(),
         });
-        let response_failure_coordinator = Arc::clone(&failure_coordinator);
+        let response_active = Arc::clone(&active);
         if let Err(error) = thread::Builder::new()
             .name("litebox-broker-responses".to_owned())
             .spawn(move || {
-                dispatch_responses(response_consumer, response_failure_coordinator);
+                dispatch_responses(response_consumer, response_active);
             })
         {
-            let _ = failure_coordinator.fail(error);
+            let _ = active.fail(error);
             return Err(Error::other("failed to start broker response pump"));
         }
-        let monitor_failure_coordinator = Arc::clone(&failure_coordinator);
+        let monitor_active = Arc::clone(&active);
         if let Err(error) = thread::Builder::new()
             .name("litebox-broker-liveness".to_owned())
             .spawn(move || {
-                monitor_local_socket(&mut monitor_stream, &monitor_failure_coordinator);
+                monitor_local_socket(&mut monitor_stream, &monitor_active);
             })
         {
-            let _ = failure_coordinator.fail(error);
+            let _ = active.fail(error);
             return Err(Error::other("failed to start broker liveness monitor"));
         }
 
-        self.state = UnixStreamLocalControlState::Active(UnixStreamLocalActive {
-            request_producer: Mutex::new(request_producer),
-            failure_coordinator: Arc::clone(&failure_coordinator),
-        });
+        self.state = UnixStreamLocalControlState::Active(Arc::clone(&active));
         Ok((
             UnixStreamLocalControlCancellation {
-                failure_coordinator: Arc::clone(&failure_coordinator),
+                active: Arc::clone(&active),
             },
             UnixControlRingLocalNotificationChannel {
                 consumer: notification_consumer,
-                failure_coordinator,
+                active,
             },
         ))
     }
@@ -255,7 +249,7 @@ impl UnixStreamLocalControlChannel {
 impl UnixStreamLocalControlCancellation {
     /// Shuts down the control stream, unblocking pending reads or writes.
     pub fn cancel(&self) -> IoResult<()> {
-        self.failure_coordinator.fail(Error::new(
+        self.active.fail(Error::new(
             ErrorKind::ConnectionAborted,
             "broker association cancelled",
         ))
@@ -267,7 +261,7 @@ impl Drop for UnixStreamLocalControlChannel {
         let UnixStreamLocalControlState::Active(active) = &self.state else {
             return;
         };
-        let _ = active.failure_coordinator.fail(Error::new(
+        let _ = active.fail(Error::new(
             ErrorKind::ConnectionAborted,
             "broker active channel dropped",
         ));
@@ -290,14 +284,14 @@ pub struct UnixStreamHostControlChannel {
 }
 
 /// Request-reading half of an active host control channel.
-pub struct UnixStreamHostRequestSource {
+pub struct UnixControlRingHostRequestSource {
     consumer: ControlRingConsumer<MemfdSharedMemory>,
     active: Arc<HostActiveState>,
 }
 
 /// Shared response-writing half of an active host control channel.
 #[derive(Clone)]
-pub struct UnixStreamHostResponseSink {
+pub struct UnixControlRingHostResponseSink {
     producer: Arc<Mutex<crate::control_ring::ControlRingProducer<MemfdSharedMemory>>>,
     active: Arc<HostActiveState>,
 }
@@ -364,8 +358,8 @@ impl UnixStreamHostControlChannel {
         mut self,
         ring: ControlRing<MemfdSharedMemory>,
     ) -> IoResult<(
-        UnixStreamHostRequestSource,
-        UnixStreamHostResponseSink,
+        UnixControlRingHostRequestSource,
+        UnixControlRingHostResponseSink,
         UnixControlRingHostNotificationChannel,
         UnixStreamHostControlShutdown,
     )> {
@@ -405,11 +399,11 @@ impl UnixStreamHostControlChannel {
             .name("litebox-runner-liveness".to_owned())
             .spawn(move || monitor_host_socket(&mut self.stream, &monitor_active))?;
         Ok((
-            UnixStreamHostRequestSource {
+            UnixControlRingHostRequestSource {
                 consumer: request_consumer,
                 active: Arc::clone(&active),
             },
-            UnixStreamHostResponseSink {
+            UnixControlRingHostResponseSink {
                 producer: Arc::new(Mutex::new(response_producer)),
                 active: Arc::clone(&active),
             },
@@ -473,10 +467,7 @@ impl LocalControlChannel for UnixStreamLocalControlChannel {
             return Err(invalid_data("broker control channel is not active"));
         };
         let request_id = request.request_id;
-        let pending_call = active
-            .failure_coordinator
-            .pending_calls
-            .register(request_id)?;
+        let pending_call = active.pending_calls.register(request_id)?;
         let request_frame = encode_request(request);
 
         let write_result = {
@@ -486,7 +477,6 @@ impl LocalControlChannel for UnixStreamLocalControlChannel {
                 .expect("broker request writer mutex poisoned");
             loop {
                 let write_status = active
-                    .failure_coordinator
                     .pending_calls
                     .run_if_live(|| producer.try_write(&request_frame).map_err(Error::from));
                 match write_status {
@@ -506,7 +496,7 @@ impl LocalControlChannel for UnixStreamLocalControlChannel {
             }
         };
         if let Err(error) = write_result {
-            let _ = active.failure_coordinator.fail(error);
+            let _ = active.fail(error);
         }
 
         pending_call.wait()
@@ -542,7 +532,7 @@ impl HostSetupChannel for UnixStreamHostControlChannel {
     }
 }
 
-impl UnixStreamHostRequestSource {
+impl UnixControlRingHostRequestSource {
     /// Receives one active broker request.
     pub fn recv_request(&mut self) -> IoResult<HostReceive<BrokerRequest>> {
         loop {
@@ -584,7 +574,7 @@ impl UnixStreamHostRequestSource {
     }
 }
 
-impl UnixStreamHostResponseSink {
+impl UnixControlRingHostResponseSink {
     /// Serializes and sends one complete active broker response.
     pub fn send_response(&self, response: &BrokerResponse) -> IoResult<()> {
         let frame = encode_response(response.clone());
@@ -612,35 +602,34 @@ impl LocalNotificationChannel for UnixControlRingLocalNotificationChannel {
 
     fn recv_notification(&mut self) -> IoResult<Option<BrokerNotification>> {
         loop {
-            if let Some(error) = self.failure_coordinator.pending_calls.current_failure() {
+            if let Some(error) = self.active.pending_calls.current_failure() {
                 return Err(copy_io_error(&error));
             }
             match self.consumer.try_read(decode_notification) {
                 Ok(ControlRingReadStatus::Message(notification)) => {
-                    self.failure_coordinator
-                        .acknowledge_notification(&mut self.consumer)?;
+                    self.active.acknowledge_notification(&mut self.consumer)?;
                     return Ok(Some(notification));
                 }
                 Ok(ControlRingReadStatus::Empty { wait_epoch }) => {
-                    if let Some(error) = self.failure_coordinator.pending_calls.current_failure() {
+                    if let Some(error) = self.active.pending_calls.current_failure() {
                         return Err(copy_io_error(&error));
                     }
                     if let Err(error) = self.consumer.wait_for_message(wait_epoch) {
                         let result = Err(copy_io_error(&error));
-                        let _ = self.failure_coordinator.fail(error);
+                        let _ = self.active.fail(error);
                         return result;
                     }
                 }
                 Err(ControlRingReadError::Ring(error)) => {
                     let error = Error::from(error);
                     let result = Err(copy_io_error(&error));
-                    let _ = self.failure_coordinator.fail(error);
+                    let _ = self.active.fail(error);
                     return result;
                 }
                 Err(ControlRingReadError::Decode(error)) => {
                     let error = wire_error(error);
                     let result = Err(copy_io_error(&error));
-                    let _ = self.failure_coordinator.fail(error);
+                    let _ = self.active.fail(error);
                     return result;
                 }
             }
@@ -812,7 +801,7 @@ impl PendingCalls {
     }
 }
 
-impl LocalActiveFailureCoordinator {
+impl LocalActiveState {
     fn acknowledge_notification(
         &self,
         consumer: &mut ControlRingConsumer<MemfdSharedMemory>,
@@ -969,12 +958,9 @@ impl HostActiveState {
     }
 }
 
-fn monitor_local_socket(
-    stream: &mut UnixStream,
-    failure_coordinator: &LocalActiveFailureCoordinator,
-) {
+fn monitor_local_socket(stream: &mut UnixStream, active: &LocalActiveState) {
     let error = monitor_socket(stream, "broker");
-    let _ = failure_coordinator.fail(error);
+    let _ = active.fail(error);
 }
 
 fn monitor_host_socket(stream: &mut UnixStream, active: &HostActiveState) {
@@ -1021,7 +1007,7 @@ fn monitor_socket(stream: &mut UnixStream, peer: &'static str) -> Error {
 
 fn dispatch_responses(
     mut consumer: ControlRingConsumer<MemfdSharedMemory>,
-    failure_coordinator: Arc<LocalActiveFailureCoordinator>,
+    active: Arc<LocalActiveState>,
 ) {
     loop {
         match consumer.try_read(decode_response) {
@@ -1030,31 +1016,27 @@ fn dispatch_responses(
                     .publish_head()
                     .map_err(Error::from)
                     .and_then(|()| consumer.wake_producer())
-                    .and_then(|()| failure_coordinator.pending_calls.complete(response))
+                    .and_then(|()| active.pending_calls.complete(response))
                 {
-                    let _ = failure_coordinator.fail(error);
+                    let _ = active.fail(error);
                     return;
                 }
             }
             Ok(ControlRingReadStatus::Empty { wait_epoch }) => {
-                if failure_coordinator
-                    .pending_calls
-                    .current_failure()
-                    .is_some()
-                {
+                if active.pending_calls.current_failure().is_some() {
                     return;
                 }
                 if let Err(error) = consumer.wait_for_message(wait_epoch) {
-                    let _ = failure_coordinator.fail(error);
+                    let _ = active.fail(error);
                     return;
                 }
             }
             Err(ControlRingReadError::Ring(error)) => {
-                let _ = failure_coordinator.fail(Error::from(error));
+                let _ = active.fail(Error::from(error));
                 return;
             }
             Err(ControlRingReadError::Decode(error)) => {
-                let _ = failure_coordinator.fail(wire_error(error));
+                let _ = active.fail(wire_error(error));
                 return;
             }
         }
@@ -1252,8 +1234,8 @@ mod control_ring_tests {
     }
 
     fn split_host() -> (
-        UnixStreamHostRequestSource,
-        UnixStreamHostResponseSink,
+        UnixControlRingHostRequestSource,
+        UnixControlRingHostResponseSink,
         UnixStreamHostControlShutdown,
         Producer,
         Consumer,
@@ -1950,13 +1932,7 @@ mod control_ring_tests {
         let UnixStreamLocalControlState::Active(active) = &control.state else {
             panic!("control channel is not active");
         };
-        assert!(
-            active
-                .failure_coordinator
-                .pending_calls
-                .current_failure()
-                .is_some()
-        );
+        assert!(active.pending_calls.current_failure().is_some());
     }
 
     #[test]

--- a/litebox_broker_transport/src/unix_socket.rs
+++ b/litebox_broker_transport/src/unix_socket.rs
@@ -29,8 +29,8 @@ use crate::unix_io::{
 };
 use litebox_broker_protocol::RequestId;
 use litebox_broker_protocol::channel::{
-    HostNotificationChannel, HostReceive, HostSetupChannel, LocalControlChannel,
-    LocalNotificationChannel, PeerCredential,
+    HostNotificationChannel, HostReceive, HostSetupChannel, LocalCallChannel,
+    LocalNotificationChannel, LocalSetupChannel, PeerCredential,
 };
 use litebox_broker_protocol::message::{
     BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerNotification, BrokerRequest,
@@ -64,21 +64,16 @@ fn peer_process_id(stream: &UnixStream) -> IoResult<u32> {
         .map_err(|_| invalid_data("Unix peer process ID is invalid"))
 }
 
-/// Local control channel using a Unix stream for setup and control rings for active calls.
-pub struct UnixControlRingLocalControlChannel {
-    state: LocalControlState,
-}
-
-enum LocalControlState {
-    Setup(LocalSetupState),
-    Active(Arc<LocalRingAssociation>),
-    Failed,
-}
-
-struct LocalSetupState {
+/// Local-side broker association setup channel over a Unix stream.
+pub struct UnixStreamLocalSetupChannel {
     stream: UnixStream,
     setup_deadline: Option<Instant>,
     negotiated: bool,
+}
+
+/// Call-issuing endpoint of an active local control-ring association.
+pub struct UnixControlRingLocalCallChannel {
+    association: Arc<LocalRingAssociation>,
 }
 
 /// Independently owned handle for interrupting all local active-ring I/O.
@@ -105,15 +100,13 @@ pub struct UnixControlRingLocalNotificationChannel {
     association: Arc<LocalRingAssociation>,
 }
 
-impl UnixControlRingLocalControlChannel {
-    /// Creates a local control channel from an already-connected Unix stream.
+impl UnixStreamLocalSetupChannel {
+    /// Creates a local setup channel from an already-connected Unix stream.
     pub const fn from_connected(stream: UnixStream) -> Self {
         Self {
-            state: LocalControlState::Setup(LocalSetupState {
-                stream,
-                setup_deadline: None,
-                negotiated: false,
-            }),
+            stream,
+            setup_deadline: None,
+            negotiated: false,
         }
     }
 
@@ -132,56 +125,45 @@ impl UnixControlRingLocalControlChannel {
         deadline: Instant,
     ) -> IoResult<Self> {
         UnixStream::connect(path).map(|stream| Self {
-            state: LocalControlState::Setup(LocalSetupState {
-                stream,
-                setup_deadline: Some(deadline),
-                negotiated: false,
-            }),
+            stream,
+            setup_deadline: Some(deadline),
+            negotiated: false,
         })
     }
 
-    /// Receives the memfd associated with this control channel.
+    /// Receives one memfd offered by the broker during setup.
     pub fn receive_memfd(
         &mut self,
         expected_len: usize,
         deadline: Option<Instant>,
     ) -> IoResult<MemfdSharedMemory> {
-        let LocalControlState::Setup(setup) = &mut self.state else {
-            return Err(invalid_data("broker control setup already completed"));
-        };
-        crate::shared_memory::receive_memfd(&mut setup.stream, expected_len, deadline)
+        crate::shared_memory::receive_memfd(&mut self.stream, expected_len, deadline)
     }
 
-    /// Completes setup, starts the response dispatcher, and returns the
-    /// notification receiver for the active shared-ring association.
+    /// Consumes a negotiated setup channel into independently usable active
+    /// call, notification, and shutdown handles, starting the response
+    /// dispatcher and liveness monitor.
     ///
     /// The ring must be the validated control-ring memfd received during this
     /// setup exchange.
-    pub fn activate(
-        &mut self,
+    pub fn into_active(
+        self,
         ring: ControlRing<MemfdSharedMemory>,
         on_failure: impl Fn() + Send + Sync + 'static,
     ) -> IoResult<(
-        UnixControlRingLocalShutdown,
+        UnixControlRingLocalCallChannel,
         UnixControlRingLocalNotificationChannel,
+        UnixControlRingLocalShutdown,
     )> {
-        let LocalControlState::Setup(setup) = &self.state else {
-            return Err(invalid_data("broker control channel already active"));
-        };
-        if !setup.negotiated {
+        if !self.negotiated {
             return Err(invalid_data(
-                "broker control channel activated before negotiation completed",
+                "broker local setup channel activated before negotiation completed",
             ));
         }
-        let LocalControlState::Setup(setup) =
-            core::mem::replace(&mut self.state, LocalControlState::Failed)
-        else {
-            unreachable!("broker control setup state disappeared");
-        };
 
-        let mut setup_stream = setup.stream;
-        write_setup_frame(&mut setup_stream, CONTROL_RING_READY, setup.setup_deadline)?;
-        let Some(ready) = read_setup_frame(&mut setup_stream, setup.setup_deadline)? else {
+        let mut setup_stream = self.stream;
+        write_setup_frame(&mut setup_stream, CONTROL_RING_READY, self.setup_deadline)?;
+        let Some(ready) = read_setup_frame(&mut setup_stream, self.setup_deadline)? else {
             return Err(Error::new(
                 ErrorKind::UnexpectedEof,
                 "broker closed before control-ring setup acknowledgement",
@@ -231,15 +213,15 @@ impl UnixControlRingLocalControlChannel {
             return Err(Error::other("failed to start broker liveness monitor"));
         }
 
-        self.state = LocalControlState::Active(Arc::clone(&association));
         Ok((
-            UnixControlRingLocalShutdown {
+            UnixControlRingLocalCallChannel {
                 association: Arc::clone(&association),
             },
             UnixControlRingLocalNotificationChannel {
                 consumer: notification_consumer,
-                association,
+                association: Arc::clone(&association),
             },
+            UnixControlRingLocalShutdown { association },
         ))
     }
 }
@@ -254,14 +236,11 @@ impl UnixControlRingLocalShutdown {
     }
 }
 
-impl Drop for UnixControlRingLocalControlChannel {
+impl Drop for UnixControlRingLocalCallChannel {
     fn drop(&mut self) {
-        let LocalControlState::Active(association) = &self.state else {
-            return;
-        };
-        let _ = association.fail(Error::new(
+        let _ = self.association.fail(Error::new(
             ErrorKind::ConnectionAborted,
-            "broker local control channel dropped",
+            "broker local call channel dropped",
         ));
     }
 }
@@ -436,36 +415,32 @@ impl Drop for UnixControlRingHostShutdown {
     }
 }
 
-impl LocalControlChannel for UnixControlRingLocalControlChannel {
+impl LocalSetupChannel for UnixStreamLocalSetupChannel {
     type Error = Error;
 
     fn send_handshake_request(&mut self, request: &BrokerHandshakeRequest) -> IoResult<()> {
-        let LocalControlState::Setup(setup) = &mut self.state else {
-            return Err(invalid_data("broker control channel is already active"));
-        };
         let frame = encode_handshake_request(request.clone());
-        write_setup_frame(&mut setup.stream, &frame, setup.setup_deadline)
+        write_setup_frame(&mut self.stream, &frame, self.setup_deadline)
     }
 
     fn recv_handshake_response(&mut self) -> IoResult<Option<BrokerHandshakeResponse>> {
-        let LocalControlState::Setup(setup) = &mut self.state else {
-            return Err(invalid_data("broker control channel is already active"));
-        };
-        let frame = read_setup_frame(&mut setup.stream, setup.setup_deadline)?;
+        let frame = read_setup_frame(&mut self.stream, self.setup_deadline)?;
         match frame {
             Some(frame) => {
                 let response = decode_handshake_response(&frame).map_err(wire_error)?;
-                setup.negotiated = matches!(&response, BrokerHandshakeResponse::Negotiated { .. });
+                self.negotiated = matches!(&response, BrokerHandshakeResponse::Negotiated { .. });
                 Ok(Some(response))
             }
             None => Ok(None),
         }
     }
+}
+
+impl LocalCallChannel for UnixControlRingLocalCallChannel {
+    type Error = Error;
 
     fn call(&self, request: BrokerRequest) -> IoResult<BrokerResponse> {
-        let LocalControlState::Active(association) = &self.state else {
-            return Err(invalid_data("broker control channel is not active"));
-        };
+        let association = &self.association;
         let request_id = request.request_id;
         let pending_call = association.pending_calls.register(request_id)?;
         let request_frame = encode_request(request);
@@ -1153,7 +1128,7 @@ mod control_ring_tests {
     use crate::control_ring::{
         CONTROL_RING_MEMORY_SIZE, CONTROL_RING_SLOT_COUNT, ControlRingProducer,
     };
-    use litebox_broker_protocol::channel::LocalControlChannel;
+    use litebox_broker_protocol::channel::{LocalCallChannel, LocalSetupChannel};
     use litebox_broker_protocol::message::{
         BrokerOperation, BrokerRequest, BrokerResponse, BrokerResult,
     };
@@ -1186,20 +1161,18 @@ mod control_ring_tests {
         )
     }
 
-    fn negotiated_local(stream: UnixStream) -> UnixControlRingLocalControlChannel {
-        UnixControlRingLocalControlChannel {
-            state: LocalControlState::Setup(LocalSetupState {
-                stream,
-                setup_deadline: Some(Instant::now() + Duration::from_secs(2)),
-                negotiated: true,
-            }),
+    fn negotiated_local(stream: UnixStream) -> UnixStreamLocalSetupChannel {
+        UnixStreamLocalSetupChannel {
+            stream,
+            setup_deadline: Some(Instant::now() + Duration::from_secs(2)),
+            negotiated: true,
         }
     }
 
     fn activate_local(
         on_failure: impl Fn() + Send + Sync + 'static,
     ) -> (
-        UnixControlRingLocalControlChannel,
+        UnixControlRingLocalCallChannel,
         UnixControlRingLocalShutdown,
         Producer,
         Consumer,
@@ -1215,8 +1188,9 @@ mod control_ring_tests {
             write_setup_frame(&mut ack_stream, CONTROL_RING_READY, None).unwrap();
         });
         let (local_ring, broker_ring) = ring_pair();
-        let mut channel = negotiated_local(local_stream);
-        let (shutdown, _notifications) = channel.activate(local_ring, on_failure).unwrap();
+        let setup = negotiated_local(local_stream);
+        let (channel, _notifications, shutdown) =
+            setup.into_active(local_ring, on_failure).unwrap();
         acknowledgement.join().unwrap();
         let crate::control_ring::BrokerControlRingEndpoints {
             request_consumer,
@@ -1274,14 +1248,14 @@ mod control_ring_tests {
     }
 
     fn notification_channel_pair() -> (
-        UnixControlRingLocalControlChannel,
+        UnixControlRingLocalCallChannel,
         UnixControlRingLocalNotificationChannel,
         UnixControlRingHostNotificationChannel,
         UnixControlRingHostShutdown,
     ) {
         let (local_stream, host_stream) = UnixStream::pair().unwrap();
         let (local_ring, host_ring) = ring_pair();
-        let mut local_control = negotiated_local(local_stream);
+        let local_setup = negotiated_local(local_stream);
         let host_control = UnixStreamHostSetupChannel {
             stream: host_stream,
             peer_credential: PeerCredential::HostGuaranteed,
@@ -1289,10 +1263,11 @@ mod control_ring_tests {
             negotiated: true,
         };
         let host_active = thread::spawn(move || host_control.into_active(host_ring).unwrap());
-        let (_shutdown, local_notifications) = local_control.activate(local_ring, || {}).unwrap();
+        let (local_call, local_notifications, _local_shutdown) =
+            local_setup.into_active(local_ring, || {}).unwrap();
         let (_source, _sink, host_notifications, shutdown) = host_active.join().unwrap();
         (
-            local_control,
+            local_call,
             local_notifications,
             host_notifications,
             shutdown,
@@ -1412,23 +1387,25 @@ mod control_ring_tests {
     }
 
     #[test]
-    fn local_control_channel_enforces_setup_and_active_phases() {
-        let (local_stream, mut host_stream) = UnixStream::pair().unwrap();
-        let mut channel = UnixControlRingLocalControlChannel::from_connected(local_stream);
-        assert_eq!(
-            channel.call(request(0)).unwrap_err().kind(),
-            ErrorKind::InvalidData
-        );
+    fn local_setup_rejects_activation_before_negotiation() {
+        let (local_stream, _host_stream) = UnixStream::pair().unwrap();
+        let setup = UnixStreamLocalSetupChannel::from_connected(local_stream);
         let (ring, _) = ring_pair();
-        assert_eq!(
-            channel.activate(ring, || {}).err().unwrap().kind(),
-            ErrorKind::InvalidData
-        );
+        let Err(error) = setup.into_active(ring, || {}) else {
+            panic!("local setup channel activated before negotiation");
+        };
+        assert_eq!(error.kind(), ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn local_setup_negotiates_then_activates_and_closes_on_drop() {
+        let (local_stream, mut host_stream) = UnixStream::pair().unwrap();
+        let mut setup = UnixStreamLocalSetupChannel::from_connected(local_stream);
 
         let handshake_request = BrokerHandshakeRequest {
             protocol_version: litebox_broker_protocol::BROKER_PROTOCOL_VERSION,
         };
-        channel.send_handshake_request(&handshake_request).unwrap();
+        setup.send_handshake_request(&handshake_request).unwrap();
         assert_eq!(
             decode_handshake_request(&read_setup_frame(&mut host_stream, None).unwrap().unwrap())
                 .unwrap(),
@@ -1443,7 +1420,7 @@ mod control_ring_tests {
         )
         .unwrap();
         assert!(matches!(
-            channel.recv_handshake_response().unwrap(),
+            setup.recv_handshake_response().unwrap(),
             Some(BrokerHandshakeResponse::Negotiated { .. })
         ));
 
@@ -1456,26 +1433,13 @@ mod control_ring_tests {
             host_stream
         });
         let (ring, _) = ring_pair();
-        let _shutdown = channel.activate(ring, || {}).unwrap();
+        let (call_channel, _notifications, _shutdown) = setup.into_active(ring, || {}).unwrap();
         let mut host_stream = acknowledgement.join().unwrap();
-
-        let (ring, _) = ring_pair();
-        assert_eq!(
-            channel.activate(ring, || {}).err().unwrap().kind(),
-            ErrorKind::InvalidData
-        );
-        assert_eq!(
-            channel
-                .send_handshake_request(&handshake_request)
-                .unwrap_err()
-                .kind(),
-            ErrorKind::InvalidData
-        );
 
         host_stream
             .set_read_timeout(Some(Duration::from_secs(1)))
             .unwrap();
-        drop(channel);
+        drop(call_channel);
         let mut byte = [0];
         assert_eq!(host_stream.read(&mut byte).unwrap(), 0);
     }
@@ -1484,7 +1448,7 @@ mod control_ring_tests {
     fn two_way_ready_ack_activates_ring_transport() {
         let (local_stream, host_stream) = UnixStream::pair().unwrap();
         let (local_ring, host_ring) = ring_pair();
-        let mut local = negotiated_local(local_stream);
+        let local_setup = negotiated_local(local_stream);
         let host = UnixStreamHostSetupChannel {
             stream: host_stream,
             peer_credential: PeerCredential::HostGuaranteed,
@@ -1492,7 +1456,8 @@ mod control_ring_tests {
             negotiated: true,
         };
         let host_active = thread::spawn(move || host.into_active(host_ring).unwrap());
-        let (_shutdown, _local_notifications) = local.activate(local_ring, || {}).unwrap();
+        let (local, _local_notifications, _local_shutdown) =
+            local_setup.into_active(local_ring, || {}).unwrap();
         let (mut source, sink, _host_notifications, _shutdown) = host_active.join().unwrap();
 
         let caller = thread::spawn(move || local.call(request(7)));
@@ -1771,14 +1736,12 @@ mod control_ring_tests {
     fn ready_ack_uses_absolute_setup_deadline() {
         let (local_stream, _peer) = UnixStream::pair().unwrap();
         let (ring, _) = ring_pair();
-        let mut local = UnixControlRingLocalControlChannel {
-            state: LocalControlState::Setup(LocalSetupState {
-                stream: local_stream,
-                setup_deadline: Some(Instant::now() + Duration::from_millis(30)),
-                negotiated: true,
-            }),
+        let local = UnixStreamLocalSetupChannel {
+            stream: local_stream,
+            setup_deadline: Some(Instant::now() + Duration::from_millis(30)),
+            negotiated: true,
         };
-        let Err(error) = local.activate(ring, || {}) else {
+        let Err(error) = local.into_active(ring, || {}) else {
             panic!("activation unexpectedly succeeded");
         };
         assert!(matches!(
@@ -1790,12 +1753,10 @@ mod control_ring_tests {
     #[test]
     fn handshake_reads_use_absolute_setup_deadlines() {
         let (mut host_stream, local_stream) = UnixStream::pair().unwrap();
-        let mut local = UnixControlRingLocalControlChannel {
-            state: LocalControlState::Setup(LocalSetupState {
-                stream: local_stream,
-                setup_deadline: Some(Instant::now() + Duration::from_millis(50)),
-                negotiated: false,
-            }),
+        let mut local = UnixStreamLocalSetupChannel {
+            stream: local_stream,
+            setup_deadline: Some(Instant::now() + Duration::from_millis(50)),
+            negotiated: false,
         };
         let local_reader = thread::spawn(move || local.recv_handshake_response().unwrap_err());
         host_stream.write_all(&8u32.to_le_bytes()).unwrap();
@@ -1909,10 +1870,13 @@ mod control_ring_tests {
             local.recv_notification().unwrap_err().kind(),
             ErrorKind::InvalidData
         );
-        let LocalControlState::Active(association) = &control.state else {
-            panic!("control channel is not active");
-        };
-        assert!(association.pending_calls.current_failure().is_some());
+        assert!(
+            control
+                .association
+                .pending_calls
+                .current_failure()
+                .is_some()
+        );
     }
 
     #[test]

--- a/litebox_broker_transport/src/unix_socket.rs
+++ b/litebox_broker_transport/src/unix_socket.rs
@@ -71,7 +71,7 @@ pub struct UnixControlRingLocalControlChannel {
 
 enum LocalControlState {
     Setup(LocalSetupState),
-    Active(Arc<LocalActiveState>),
+    Active(Arc<LocalRingAssociation>),
     Failed,
 }
 
@@ -83,14 +83,17 @@ struct LocalSetupState {
 
 /// Independently owned handle for interrupting all local active-ring I/O.
 pub struct UnixControlRingLocalCancellation {
-    active: Arc<LocalActiveState>,
+    association: Arc<LocalRingAssociation>,
 }
 
-struct LocalActiveState {
+/// State shared by every activated local endpoint of one association: the
+/// request producer, the setup socket used for liveness and teardown, pending
+/// call tracking, and the wake handles of all three ring directions.
+struct LocalRingAssociation {
     request_producer: Mutex<crate::control_ring::ControlRingProducer<MemfdSharedMemory>>,
     control_stream: UnixStream,
     pending_calls: Arc<PendingCalls>,
-    association_failure: Arc<dyn Fn() + Send + Sync>,
+    on_failure: Arc<dyn Fn() + Send + Sync>,
     request_wake: ControlRingWakeHandle<MemfdSharedMemory>,
     response_wake: ControlRingWakeHandle<MemfdSharedMemory>,
     notification_wake: ControlRingWakeHandle<MemfdSharedMemory>,
@@ -99,7 +102,7 @@ struct LocalActiveState {
 /// Local notification receiver for a shared-ring Unix broker association.
 pub struct UnixControlRingLocalNotificationChannel {
     consumer: ControlRingConsumer<MemfdSharedMemory>,
-    active: Arc<LocalActiveState>,
+    association: Arc<LocalRingAssociation>,
 }
 
 impl UnixControlRingLocalControlChannel {
@@ -157,7 +160,7 @@ impl UnixControlRingLocalControlChannel {
     pub fn activate(
         &mut self,
         ring: ControlRing<MemfdSharedMemory>,
-        association_failure: impl Fn() + Send + Sync + 'static,
+        on_failure: impl Fn() + Send + Sync + 'static,
     ) -> IoResult<(
         UnixControlRingLocalCancellation,
         UnixControlRingLocalNotificationChannel,
@@ -202,45 +205,45 @@ impl UnixControlRingLocalControlChannel {
             notification_consumer,
         } = ring.into_local();
         let pending_calls = Arc::new(PendingCalls::new());
-        let association_failure: Arc<dyn Fn() + Send + Sync> = Arc::new(association_failure);
-        let active = Arc::new(LocalActiveState {
+        let on_failure: Arc<dyn Fn() + Send + Sync> = Arc::new(on_failure);
+        let association = Arc::new(LocalRingAssociation {
             request_wake: request_producer.wake_handle(),
             request_producer: Mutex::new(request_producer),
             control_stream: shutdown_stream,
             pending_calls: Arc::clone(&pending_calls),
-            association_failure,
+            on_failure,
             response_wake: response_consumer.wake_handle(),
             notification_wake: notification_consumer.wake_handle(),
         });
-        let response_active = Arc::clone(&active);
+        let response_association = Arc::clone(&association);
         if let Err(error) = thread::Builder::new()
             .name("litebox-broker-responses".to_owned())
             .spawn(move || {
-                dispatch_responses(response_consumer, response_active);
+                dispatch_responses(response_consumer, response_association);
             })
         {
-            let _ = active.fail(error);
+            let _ = association.fail(error);
             return Err(Error::other("failed to start broker response pump"));
         }
-        let monitor_active = Arc::clone(&active);
+        let monitor_association = Arc::clone(&association);
         if let Err(error) = thread::Builder::new()
             .name("litebox-broker-liveness".to_owned())
             .spawn(move || {
-                monitor_local_socket(&mut monitor_stream, &monitor_active);
+                monitor_local_socket(&mut monitor_stream, &monitor_association);
             })
         {
-            let _ = active.fail(error);
+            let _ = association.fail(error);
             return Err(Error::other("failed to start broker liveness monitor"));
         }
 
-        self.state = LocalControlState::Active(Arc::clone(&active));
+        self.state = LocalControlState::Active(Arc::clone(&association));
         Ok((
             UnixControlRingLocalCancellation {
-                active: Arc::clone(&active),
+                association: Arc::clone(&association),
             },
             UnixControlRingLocalNotificationChannel {
                 consumer: notification_consumer,
-                active,
+                association,
             },
         ))
     }
@@ -249,7 +252,7 @@ impl UnixControlRingLocalControlChannel {
 impl UnixControlRingLocalCancellation {
     /// Cancels the active association, unblocking ring and socket waits.
     pub fn cancel(&self) -> IoResult<()> {
-        self.active.fail(Error::new(
+        self.association.fail(Error::new(
             ErrorKind::ConnectionAborted,
             "broker association cancelled",
         ))
@@ -258,10 +261,10 @@ impl UnixControlRingLocalCancellation {
 
 impl Drop for UnixControlRingLocalControlChannel {
     fn drop(&mut self) {
-        let LocalControlState::Active(active) = &self.state else {
+        let LocalControlState::Active(association) = &self.state else {
             return;
         };
-        let _ = active.fail(Error::new(
+        let _ = association.fail(Error::new(
             ErrorKind::ConnectionAborted,
             "broker local control channel dropped",
         ));
@@ -286,30 +289,33 @@ pub struct UnixStreamHostSetupChannel {
 /// Request-reading endpoint of an active host control-ring association.
 pub struct UnixControlRingHostRequestSource {
     consumer: ControlRingConsumer<MemfdSharedMemory>,
-    active: Arc<HostActiveState>,
+    association: Arc<HostRingAssociation>,
 }
 
 /// Shared response-writing endpoint of an active host control-ring association.
 #[derive(Clone)]
 pub struct UnixControlRingHostResponseSink {
     producer: Arc<Mutex<crate::control_ring::ControlRingProducer<MemfdSharedMemory>>>,
-    active: Arc<HostActiveState>,
+    association: Arc<HostRingAssociation>,
 }
 
 /// RAII guard that interrupts all active host ring I/O when dropped.
 pub struct UnixControlRingHostShutdown {
-    active: Arc<HostActiveState>,
+    association: Arc<HostRingAssociation>,
 }
 
-struct HostActiveState {
+/// State shared by every activated host endpoint of one association: the setup
+/// socket used for liveness and teardown, terminal status, and the wake handles
+/// of all three ring directions.
+struct HostRingAssociation {
     control_stream: UnixStream,
-    status: Mutex<HostActiveStatus>,
+    status: Mutex<HostAssociationStatus>,
     request_wake: ControlRingWakeHandle<MemfdSharedMemory>,
     response_wake: ControlRingWakeHandle<MemfdSharedMemory>,
     notification_wake: ControlRingWakeHandle<MemfdSharedMemory>,
 }
 
-enum HostActiveStatus {
+enum HostAssociationStatus {
     Live,
     PeerClosed,
     Failed(Arc<Error>),
@@ -318,7 +324,7 @@ enum HostActiveStatus {
 /// Host notification sender for a shared-ring Unix broker association.
 pub struct UnixControlRingHostNotificationChannel {
     producer: ControlRingProducer<MemfdSharedMemory>,
-    active: Arc<HostActiveState>,
+    association: Arc<HostRingAssociation>,
 }
 
 impl UnixStreamHostSetupChannel {
@@ -387,31 +393,31 @@ impl UnixStreamHostSetupChannel {
             response_producer,
             notification_producer,
         } = ring.into_broker();
-        let active = Arc::new(HostActiveState {
+        let association = Arc::new(HostRingAssociation {
             control_stream: shutdown_stream,
-            status: Mutex::new(HostActiveStatus::Live),
+            status: Mutex::new(HostAssociationStatus::Live),
             request_wake: request_consumer.wake_handle(),
             response_wake: response_producer.wake_handle(),
             notification_wake: notification_producer.wake_handle(),
         });
-        let monitor_active = Arc::clone(&active);
+        let monitor_association = Arc::clone(&association);
         thread::Builder::new()
             .name("litebox-runner-liveness".to_owned())
-            .spawn(move || monitor_host_socket(&mut self.stream, &monitor_active))?;
+            .spawn(move || monitor_host_socket(&mut self.stream, &monitor_association))?;
         Ok((
             UnixControlRingHostRequestSource {
                 consumer: request_consumer,
-                active: Arc::clone(&active),
+                association: Arc::clone(&association),
             },
             UnixControlRingHostResponseSink {
                 producer: Arc::new(Mutex::new(response_producer)),
-                active: Arc::clone(&active),
+                association: Arc::clone(&association),
             },
             UnixControlRingHostNotificationChannel {
                 producer: notification_producer,
-                active: Arc::clone(&active),
+                association: Arc::clone(&association),
             },
-            UnixControlRingHostShutdown { active },
+            UnixControlRingHostShutdown { association },
         ))
     }
 }
@@ -419,7 +425,7 @@ impl UnixStreamHostSetupChannel {
 impl UnixControlRingHostShutdown {
     /// Shuts down the active association without waiting for a ring lock.
     pub fn shutdown(&self) -> IoResult<()> {
-        self.active.fail(Error::new(
+        self.association.fail(Error::new(
             ErrorKind::ConnectionAborted,
             "broker host association shut down",
         ))
@@ -428,7 +434,7 @@ impl UnixControlRingHostShutdown {
 
 impl Drop for UnixControlRingHostShutdown {
     fn drop(&mut self) {
-        let _ = self.active.fail(Error::new(
+        let _ = self.association.fail(Error::new(
             ErrorKind::ConnectionAborted,
             "broker host association shutdown guard dropped",
         ));
@@ -462,20 +468,20 @@ impl LocalControlChannel for UnixControlRingLocalControlChannel {
     }
 
     fn call(&self, request: BrokerRequest) -> IoResult<BrokerResponse> {
-        let LocalControlState::Active(active) = &self.state else {
+        let LocalControlState::Active(association) = &self.state else {
             return Err(invalid_data("broker control channel is not active"));
         };
         let request_id = request.request_id;
-        let pending_call = active.pending_calls.register(request_id)?;
+        let pending_call = association.pending_calls.register(request_id)?;
         let request_frame = encode_request(request);
 
         let write_result = {
-            let mut producer = active
+            let mut producer = association
                 .request_producer
                 .lock()
                 .expect("broker request writer mutex poisoned");
             loop {
-                let write_status = active
+                let write_status = association
                     .pending_calls
                     .run_if_live(|| producer.try_write(&request_frame).map_err(Error::from));
                 match write_status {
@@ -495,7 +501,7 @@ impl LocalControlChannel for UnixControlRingLocalControlChannel {
             }
         };
         if let Err(error) = write_result {
-            let _ = active.fail(error);
+            let _ = association.fail(error);
         }
 
         pending_call.wait()
@@ -535,21 +541,21 @@ impl UnixControlRingHostRequestSource {
     /// Receives one active broker request.
     pub fn recv_request(&mut self) -> IoResult<HostReceive<BrokerRequest>> {
         loop {
-            if let Some(error) = self.active.request_failure() {
+            if let Some(error) = self.association.request_failure() {
                 return Err(error);
             }
             match self.consumer.try_read(decode_request) {
                 Ok(ControlRingReadStatus::Message(request)) => {
-                    self.active.acknowledge_request(&mut self.consumer)?;
+                    self.association.acknowledge_request(&mut self.consumer)?;
                     return Ok(HostReceive::Message(request));
                 }
                 Ok(ControlRingReadStatus::Empty { wait_epoch }) => {
-                    if let Some(terminal) = self.active.request_terminal_result() {
+                    if let Some(terminal) = self.association.request_terminal_result() {
                         return terminal;
                     }
                     if let Err(error) = self.consumer.wait_for_message(wait_epoch) {
                         let result = Err(copy_io_error(&error));
-                        let _ = self.active.fail(error);
+                        let _ = self.association.fail(error);
                         return result;
                     }
                 }
@@ -559,13 +565,13 @@ impl UnixControlRingHostRequestSource {
                 Err(ControlRingReadError::Decode(error)) => {
                     let error = wire_error(error);
                     let result = Err(copy_io_error(&error));
-                    let _ = self.active.fail(error);
+                    let _ = self.association.fail(error);
                     return result;
                 }
                 Err(ControlRingReadError::Ring(error)) => {
                     let error = Error::from(error);
                     let result = Err(copy_io_error(&error));
-                    let _ = self.active.fail(error);
+                    let _ = self.association.fail(error);
                     return result;
                 }
             }
@@ -582,12 +588,12 @@ impl UnixControlRingHostResponseSink {
             .lock()
             .map_err(|_| Error::other("broker response writer mutex poisoned"))?;
         loop {
-            match self.active.try_publish(&mut producer, &frame)? {
+            match self.association.try_publish(&mut producer, &frame)? {
                 ControlRingWriteStatus::Written => return Ok(()),
                 ControlRingWriteStatus::Full { wait_epoch } => {
                     if let Err(error) = producer.wait_for_capacity(wait_epoch) {
                         let result = Err(copy_io_error(&error));
-                        let _ = self.active.fail(error);
+                        let _ = self.association.fail(error);
                         return result;
                     }
                 }
@@ -601,34 +607,35 @@ impl LocalNotificationChannel for UnixControlRingLocalNotificationChannel {
 
     fn recv_notification(&mut self) -> IoResult<Option<BrokerNotification>> {
         loop {
-            if let Some(error) = self.active.pending_calls.current_failure() {
+            if let Some(error) = self.association.pending_calls.current_failure() {
                 return Err(copy_io_error(&error));
             }
             match self.consumer.try_read(decode_notification) {
                 Ok(ControlRingReadStatus::Message(notification)) => {
-                    self.active.acknowledge_notification(&mut self.consumer)?;
+                    self.association
+                        .acknowledge_notification(&mut self.consumer)?;
                     return Ok(Some(notification));
                 }
                 Ok(ControlRingReadStatus::Empty { wait_epoch }) => {
-                    if let Some(error) = self.active.pending_calls.current_failure() {
+                    if let Some(error) = self.association.pending_calls.current_failure() {
                         return Err(copy_io_error(&error));
                     }
                     if let Err(error) = self.consumer.wait_for_message(wait_epoch) {
                         let result = Err(copy_io_error(&error));
-                        let _ = self.active.fail(error);
+                        let _ = self.association.fail(error);
                         return result;
                     }
                 }
                 Err(ControlRingReadError::Ring(error)) => {
                     let error = Error::from(error);
                     let result = Err(copy_io_error(&error));
-                    let _ = self.active.fail(error);
+                    let _ = self.association.fail(error);
                     return result;
                 }
                 Err(ControlRingReadError::Decode(error)) => {
                     let error = wire_error(error);
                     let result = Err(copy_io_error(&error));
-                    let _ = self.active.fail(error);
+                    let _ = self.association.fail(error);
                     return result;
                 }
             }
@@ -642,12 +649,12 @@ impl HostNotificationChannel for UnixControlRingHostNotificationChannel {
     fn send_notification(&mut self, notification: &BrokerNotification) -> IoResult<()> {
         let frame = encode_notification(notification.clone());
         loop {
-            match self.active.try_publish(&mut self.producer, &frame)? {
+            match self.association.try_publish(&mut self.producer, &frame)? {
                 ControlRingWriteStatus::Written => return Ok(()),
                 ControlRingWriteStatus::Full { wait_epoch } => {
                     if let Err(error) = self.producer.wait_for_capacity(wait_epoch) {
                         let result = Err(copy_io_error(&error));
-                        let _ = self.active.fail(error);
+                        let _ = self.association.fail(error);
                         return result;
                     }
                 }
@@ -800,7 +807,7 @@ impl PendingCalls {
     }
 }
 
-impl LocalActiveState {
+impl LocalRingAssociation {
     fn acknowledge_notification(
         &self,
         consumer: &mut ControlRingConsumer<MemfdSharedMemory>,
@@ -826,7 +833,7 @@ impl LocalActiveState {
         let notification_wake = self.notification_wake.interrupt_wait();
         let shutdown_result = shutdown_socket(&self.control_stream);
         if first_failure {
-            (self.association_failure)();
+            (self.on_failure)();
         }
         request_wake
             .and(response_wake)
@@ -835,7 +842,7 @@ impl LocalActiveState {
     }
 }
 
-impl HostActiveState {
+impl HostRingAssociation {
     fn acknowledge_request(
         &self,
         consumer: &mut ControlRingConsumer<MemfdSharedMemory>,
@@ -844,8 +851,8 @@ impl HostActiveState {
             let status = self
                 .status
                 .lock()
-                .expect("broker host active-state mutex poisoned");
-            if let HostActiveStatus::Failed(error) = &*status {
+                .expect("broker host association mutex poisoned");
+            if let HostAssociationStatus::Failed(error) = &*status {
                 return Err(copy_io_error(error));
             }
             consumer
@@ -866,9 +873,9 @@ impl HostActiveState {
             let mut status = self
                 .status
                 .lock()
-                .expect("broker host active-state mutex poisoned");
-            if matches!(*status, HostActiveStatus::Live) {
-                *status = HostActiveStatus::Failed(Arc::new(error));
+                .expect("broker host association mutex poisoned");
+            if matches!(*status, HostAssociationStatus::Live) {
+                *status = HostAssociationStatus::Failed(Arc::new(error));
             }
         }
         let request_wake = self.request_wake.interrupt_wait();
@@ -885,9 +892,9 @@ impl HostActiveState {
             let mut status = self
                 .status
                 .lock()
-                .expect("broker host active-state mutex poisoned");
-            if matches!(*status, HostActiveStatus::Live) {
-                *status = HostActiveStatus::PeerClosed;
+                .expect("broker host association mutex poisoned");
+            if matches!(*status, HostAssociationStatus::Live) {
+                *status = HostAssociationStatus::PeerClosed;
             }
         }
         let _ = self.request_wake.interrupt_wait();
@@ -899,11 +906,11 @@ impl HostActiveState {
         match &*self
             .status
             .lock()
-            .expect("broker host active-state mutex poisoned")
+            .expect("broker host association mutex poisoned")
         {
-            HostActiveStatus::Live => None,
-            HostActiveStatus::PeerClosed => Some(Ok(HostReceive::PeerClosed)),
-            HostActiveStatus::Failed(error) => Some(Err(copy_io_error(error))),
+            HostAssociationStatus::Live => None,
+            HostAssociationStatus::PeerClosed => Some(Ok(HostReceive::PeerClosed)),
+            HostAssociationStatus::Failed(error) => Some(Err(copy_io_error(error))),
         }
     }
 
@@ -911,10 +918,10 @@ impl HostActiveState {
         match &*self
             .status
             .lock()
-            .expect("broker host active-state mutex poisoned")
+            .expect("broker host association mutex poisoned")
         {
-            HostActiveStatus::Failed(error) => Some(copy_io_error(error)),
-            HostActiveStatus::Live | HostActiveStatus::PeerClosed => None,
+            HostAssociationStatus::Failed(error) => Some(copy_io_error(error)),
+            HostAssociationStatus::Live | HostAssociationStatus::PeerClosed => None,
         }
     }
 
@@ -927,16 +934,16 @@ impl HostActiveState {
             let status = self
                 .status
                 .lock()
-                .expect("broker host active-state mutex poisoned");
+                .expect("broker host association mutex poisoned");
             match &*status {
-                HostActiveStatus::Live => {}
-                HostActiveStatus::PeerClosed => {
+                HostAssociationStatus::Live => {}
+                HostAssociationStatus::PeerClosed => {
                     return Err(Error::new(
                         ErrorKind::BrokenPipe,
                         "runner closed the active broker association",
                     ));
                 }
-                HostActiveStatus::Failed(error) => return Err(copy_io_error(error)),
+                HostAssociationStatus::Failed(error) => return Err(copy_io_error(error)),
             }
             producer
                 .try_write(frame)
@@ -957,28 +964,28 @@ impl HostActiveState {
     }
 }
 
-fn monitor_local_socket(stream: &mut UnixStream, active: &LocalActiveState) {
+fn monitor_local_socket(stream: &mut UnixStream, association: &LocalRingAssociation) {
     let error = monitor_socket(stream, "broker");
-    let _ = active.fail(error);
+    let _ = association.fail(error);
 }
 
-fn monitor_host_socket(stream: &mut UnixStream, active: &HostActiveState) {
+fn monitor_host_socket(stream: &mut UnixStream, association: &HostRingAssociation) {
     let mut byte = [0];
     loop {
         match stream.read(&mut byte) {
             Ok(0) => {
-                active.peer_closed();
+                association.peer_closed();
                 return;
             }
             Ok(_) => {
-                let _ = active.fail(invalid_data(
+                let _ = association.fail(invalid_data(
                     "runner sent unexpected active control-socket data",
                 ));
                 return;
             }
             Err(error) if error.kind() == ErrorKind::Interrupted => {}
             Err(error) => {
-                let _ = active.fail(error);
+                let _ = association.fail(error);
                 return;
             }
         }
@@ -1006,7 +1013,7 @@ fn monitor_socket(stream: &mut UnixStream, peer: &'static str) -> Error {
 
 fn dispatch_responses(
     mut consumer: ControlRingConsumer<MemfdSharedMemory>,
-    active: Arc<LocalActiveState>,
+    association: Arc<LocalRingAssociation>,
 ) {
     loop {
         match consumer.try_read(decode_response) {
@@ -1015,27 +1022,27 @@ fn dispatch_responses(
                     .publish_head()
                     .map_err(Error::from)
                     .and_then(|()| consumer.wake_producer())
-                    .and_then(|()| active.pending_calls.complete(response))
+                    .and_then(|()| association.pending_calls.complete(response))
                 {
-                    let _ = active.fail(error);
+                    let _ = association.fail(error);
                     return;
                 }
             }
             Ok(ControlRingReadStatus::Empty { wait_epoch }) => {
-                if active.pending_calls.current_failure().is_some() {
+                if association.pending_calls.current_failure().is_some() {
                     return;
                 }
                 if let Err(error) = consumer.wait_for_message(wait_epoch) {
-                    let _ = active.fail(error);
+                    let _ = association.fail(error);
                     return;
                 }
             }
             Err(ControlRingReadError::Ring(error)) => {
-                let _ = active.fail(Error::from(error));
+                let _ = association.fail(Error::from(error));
                 return;
             }
             Err(ControlRingReadError::Decode(error)) => {
-                let _ = active.fail(wire_error(error));
+                let _ = association.fail(wire_error(error));
                 return;
             }
         }
@@ -1194,7 +1201,7 @@ mod control_ring_tests {
     }
 
     fn activate_local(
-        association_failure: impl Fn() + Send + Sync + 'static,
+        on_failure: impl Fn() + Send + Sync + 'static,
     ) -> (
         UnixControlRingLocalControlChannel,
         UnixControlRingLocalCancellation,
@@ -1215,8 +1222,7 @@ mod control_ring_tests {
         });
         let (local_ring, broker_ring) = ring_pair();
         let mut channel = negotiated_local(local_stream);
-        let (cancellation, _notifications) =
-            channel.activate(local_ring, association_failure).unwrap();
+        let (cancellation, _notifications) = channel.activate(local_ring, on_failure).unwrap();
         acknowledgement.join().unwrap();
         let crate::control_ring::BrokerControlRingEndpoints {
             request_consumer,
@@ -1669,7 +1675,7 @@ mod control_ring_tests {
         let (mut source, _sink, _shutdown, mut requests, _responses, _peer) = activate_host();
         write_payload(&mut requests, &encode_request(request(1)));
         source
-            .active
+            .association
             .fail(Error::new(ErrorKind::TimedOut, "test failure"))
             .unwrap();
         assert_eq!(
@@ -1684,12 +1690,12 @@ mod control_ring_tests {
             ControlRingReadStatus::Message(_)
         ));
         source
-            .active
+            .association
             .fail(Error::new(ErrorKind::TimedOut, "test failure"))
             .unwrap();
         assert_eq!(
             source
-                .active
+                .association
                 .acknowledge_request(&mut source.consumer)
                 .unwrap_err()
                 .kind(),
@@ -1698,7 +1704,7 @@ mod control_ring_tests {
 
         let (mut source, _sink, _shutdown, mut requests, _responses, _peer) = activate_host();
         write_payload(&mut requests, &encode_request(request(3)));
-        source.active.peer_closed();
+        source.association.peer_closed();
         assert!(matches!(
             source.recv_request().unwrap(),
             HostReceive::Message(BrokerRequest {
@@ -1928,10 +1934,10 @@ mod control_ring_tests {
             local.recv_notification().unwrap_err().kind(),
             ErrorKind::InvalidData
         );
-        let LocalControlState::Active(active) = &control.state else {
+        let LocalControlState::Active(association) = &control.state else {
             panic!("control channel is not active");
         };
-        assert!(active.pending_calls.current_failure().is_some());
+        assert!(association.pending_calls.current_failure().is_some());
     }
 
     #[test]

--- a/litebox_broker_transport/src/unix_socket.rs
+++ b/litebox_broker_transport/src/unix_socket.rs
@@ -8,8 +8,8 @@
 //! no_std protocol, local, core, and host crates.
 //!
 //! After setup, the authenticated socket is retained only for liveness and
-//! cancellation. Active requests, responses, and notifications use shared
-//! control rings.
+//! fail-closed shutdown. Active requests, responses, and notifications use
+//! shared control rings.
 
 use std::io::{Error, ErrorKind, Read, Result as IoResult, Write};
 use std::net::Shutdown;
@@ -42,7 +42,7 @@ use litebox_broker_protocol::wire::{
     encode_notification, encode_request, encode_response,
 };
 
-const MAX_FRAME_LEN: usize = 64 * 1024;
+const MAX_SETUP_FRAME_LEN: usize = 64 * 1024;
 const CONTROL_RING_READY: &[u8] = b"litebox-control-ring-ready-v1";
 /// Maximum number of active calls waiting for broker responses.
 pub const MAX_PENDING_CALLS: usize = 64;
@@ -82,7 +82,7 @@ struct LocalSetupState {
 }
 
 /// Independently owned handle for interrupting all local active-ring I/O.
-pub struct UnixControlRingLocalCancellation {
+pub struct UnixControlRingLocalShutdown {
     association: Arc<LocalRingAssociation>,
 }
 
@@ -152,8 +152,8 @@ impl UnixControlRingLocalControlChannel {
         crate::shared_memory::receive_memfd(&mut setup.stream, expected_len, deadline)
     }
 
-    /// Completes setup, starts the response pump, and returns the notification
-    /// receiver for the active shared-ring association.
+    /// Completes setup, starts the response dispatcher, and returns the
+    /// notification receiver for the active shared-ring association.
     ///
     /// The ring must be the validated control-ring memfd received during this
     /// setup exchange.
@@ -162,7 +162,7 @@ impl UnixControlRingLocalControlChannel {
         ring: ControlRing<MemfdSharedMemory>,
         on_failure: impl Fn() + Send + Sync + 'static,
     ) -> IoResult<(
-        UnixControlRingLocalCancellation,
+        UnixControlRingLocalShutdown,
         UnixControlRingLocalNotificationChannel,
     )> {
         let LocalControlState::Setup(setup) = &self.state else {
@@ -179,14 +179,9 @@ impl UnixControlRingLocalControlChannel {
             unreachable!("broker control setup state disappeared");
         };
 
-        let mut monitor_stream = setup.stream;
-        write_frame_with_deadline(
-            &mut monitor_stream,
-            CONTROL_RING_READY,
-            setup.setup_deadline,
-        )?;
-        let Some(ready) = read_frame_with_deadline(&mut monitor_stream, setup.setup_deadline)?
-        else {
+        let mut setup_stream = setup.stream;
+        write_setup_frame(&mut setup_stream, CONTROL_RING_READY, setup.setup_deadline)?;
+        let Some(ready) = read_setup_frame(&mut setup_stream, setup.setup_deadline)? else {
             return Err(Error::new(
                 ErrorKind::UnexpectedEof,
                 "broker closed before control-ring setup acknowledgement",
@@ -198,7 +193,7 @@ impl UnixControlRingLocalControlChannel {
             ));
         }
 
-        let shutdown_stream = monitor_stream.try_clone()?;
+        let shutdown_stream = setup_stream.try_clone()?;
         let crate::control_ring::LocalControlRingEndpoints {
             request_producer,
             response_consumer,
@@ -223,13 +218,13 @@ impl UnixControlRingLocalControlChannel {
             })
         {
             let _ = association.fail(error);
-            return Err(Error::other("failed to start broker response pump"));
+            return Err(Error::other("failed to start broker response dispatcher"));
         }
         let monitor_association = Arc::clone(&association);
         if let Err(error) = thread::Builder::new()
             .name("litebox-broker-liveness".to_owned())
             .spawn(move || {
-                monitor_local_socket(&mut monitor_stream, &monitor_association);
+                monitor_local_socket(&mut setup_stream, &monitor_association);
             })
         {
             let _ = association.fail(error);
@@ -238,7 +233,7 @@ impl UnixControlRingLocalControlChannel {
 
         self.state = LocalControlState::Active(Arc::clone(&association));
         Ok((
-            UnixControlRingLocalCancellation {
+            UnixControlRingLocalShutdown {
                 association: Arc::clone(&association),
             },
             UnixControlRingLocalNotificationChannel {
@@ -249,12 +244,12 @@ impl UnixControlRingLocalControlChannel {
     }
 }
 
-impl UnixControlRingLocalCancellation {
-    /// Cancels the active association, unblocking ring and socket waits.
-    pub fn cancel(&self) -> IoResult<()> {
+impl UnixControlRingLocalShutdown {
+    /// Shuts down the active association, unblocking ring and socket waits.
+    pub fn shutdown(&self) -> IoResult<()> {
         self.association.fail(Error::new(
             ErrorKind::ConnectionAborted,
-            "broker association cancelled",
+            "broker local association shut down",
         ))
     }
 }
@@ -374,7 +369,7 @@ impl UnixStreamHostSetupChannel {
                 "broker host setup channel activated before negotiation completed",
             ));
         }
-        let Some(ready) = read_frame_with_deadline(&mut self.stream, self.setup_deadline)? else {
+        let Some(ready) = read_setup_frame(&mut self.stream, self.setup_deadline)? else {
             return Err(Error::new(
                 ErrorKind::UnexpectedEof,
                 "runner closed before control-ring setup acknowledgement",
@@ -385,7 +380,7 @@ impl UnixStreamHostSetupChannel {
                 "runner sent an invalid control-ring setup acknowledgement",
             ));
         }
-        write_frame_with_deadline(&mut self.stream, CONTROL_RING_READY, self.setup_deadline)?;
+        write_setup_frame(&mut self.stream, CONTROL_RING_READY, self.setup_deadline)?;
 
         let shutdown_stream = self.stream.try_clone()?;
         let crate::control_ring::BrokerControlRingEndpoints {
@@ -449,14 +444,14 @@ impl LocalControlChannel for UnixControlRingLocalControlChannel {
             return Err(invalid_data("broker control channel is already active"));
         };
         let frame = encode_handshake_request(request.clone());
-        write_frame_with_deadline(&mut setup.stream, &frame, setup.setup_deadline)
+        write_setup_frame(&mut setup.stream, &frame, setup.setup_deadline)
     }
 
     fn recv_handshake_response(&mut self) -> IoResult<Option<BrokerHandshakeResponse>> {
         let LocalControlState::Setup(setup) = &mut self.state else {
             return Err(invalid_data("broker control channel is already active"));
         };
-        let frame = read_frame_with_deadline(&mut setup.stream, setup.setup_deadline)?;
+        let frame = read_setup_frame(&mut setup.stream, setup.setup_deadline)?;
         match frame {
             Some(frame) => {
                 let response = decode_handshake_response(&frame).map_err(wire_error)?;
@@ -516,7 +511,7 @@ impl HostSetupChannel for UnixStreamHostSetupChannel {
     }
 
     fn recv_handshake_request(&mut self) -> IoResult<HostReceive<BrokerHandshakeRequest>> {
-        let Some(frame) = read_frame_with_deadline(&mut self.stream, self.setup_deadline)? else {
+        let Some(frame) = read_setup_frame(&mut self.stream, self.setup_deadline)? else {
             return Ok(HostReceive::PeerClosed);
         };
         match decode_handshake_request(&frame) {
@@ -527,7 +522,7 @@ impl HostSetupChannel for UnixStreamHostSetupChannel {
     }
 
     fn send_handshake_response(&mut self, response: &BrokerHandshakeResponse) -> IoResult<()> {
-        write_frame_with_deadline(
+        write_setup_frame(
             &mut self.stream,
             &encode_handshake_response(response.clone()),
             self.setup_deadline,
@@ -541,7 +536,7 @@ impl UnixControlRingHostRequestSource {
     /// Receives one active broker request.
     pub fn recv_request(&mut self) -> IoResult<HostReceive<BrokerRequest>> {
         loop {
-            if let Some(error) = self.association.request_failure() {
+            if let Some(error) = self.association.current_failure() {
                 return Err(error);
             }
             match self.consumer.try_read(decode_request) {
@@ -914,7 +909,7 @@ impl HostRingAssociation {
         }
     }
 
-    fn request_failure(&self) -> Option<Error> {
+    fn current_failure(&self) -> Option<Error> {
         match &*self
             .status
             .lock()
@@ -965,7 +960,7 @@ impl HostRingAssociation {
 }
 
 fn monitor_local_socket(stream: &mut UnixStream, association: &LocalRingAssociation) {
-    let error = monitor_socket(stream, "broker");
+    let error = wait_for_socket_termination(stream, "broker");
     let _ = association.fail(error);
 }
 
@@ -992,7 +987,7 @@ fn monitor_host_socket(stream: &mut UnixStream, association: &HostRingAssociatio
     }
 }
 
-fn monitor_socket(stream: &mut UnixStream, peer: &'static str) -> Error {
+fn wait_for_socket_termination(stream: &mut UnixStream, peer: &'static str) -> Error {
     let mut byte = [0];
     loop {
         match stream.read(&mut byte) {
@@ -1056,7 +1051,7 @@ fn copy_io_error(error: &Error) -> Error {
     }
 }
 
-fn read_frame_with_deadline(
+fn read_setup_frame(
     stream: &mut UnixStream,
     deadline: Option<Instant>,
 ) -> IoResult<Option<Vec<u8>>> {
@@ -1067,7 +1062,7 @@ fn read_frame_with_deadline(
             refresh_read_deadline(stream, deadline)?;
             match stream.read(&mut len_buf[read..]) {
                 Ok(0) if read == 0 => return Ok(None),
-                Ok(0) => return Err(invalid_data("truncated broker frame length")),
+                Ok(0) => return Err(invalid_data("truncated broker setup frame length")),
                 Ok(len) => read += len,
                 Err(error) if error.kind() == ErrorKind::Interrupted => {}
                 Err(error) => return Err(error),
@@ -1075,8 +1070,8 @@ fn read_frame_with_deadline(
         }
 
         let len = u32::from_le_bytes(len_buf) as usize;
-        if len == 0 || len > MAX_FRAME_LEN {
-            return Err(invalid_data("invalid broker frame length"));
+        if len == 0 || len > MAX_SETUP_FRAME_LEN {
+            return Err(invalid_data("invalid broker setup frame length"));
         }
 
         let mut frame = vec![0; len];
@@ -1084,7 +1079,7 @@ fn read_frame_with_deadline(
         while read < frame.len() {
             refresh_read_deadline(stream, deadline)?;
             match stream.read(&mut frame[read..]) {
-                Ok(0) => return Err(invalid_data("truncated broker frame")),
+                Ok(0) => return Err(invalid_data("truncated broker setup frame")),
                 Ok(len) => read += len,
                 Err(error) if error.kind() == ErrorKind::Interrupted => {}
                 Err(error) => return Err(error),
@@ -1094,16 +1089,17 @@ fn read_frame_with_deadline(
     })
 }
 
-fn write_frame_with_deadline(
+fn write_setup_frame(
     stream: &mut UnixStream,
     frame: &[u8],
     deadline: Option<Instant>,
 ) -> IoResult<()> {
     with_write_deadline(stream, deadline, |stream, deadline| {
-        if frame.is_empty() || frame.len() > MAX_FRAME_LEN {
-            return Err(invalid_data("invalid broker frame length"));
+        if frame.is_empty() || frame.len() > MAX_SETUP_FRAME_LEN {
+            return Err(invalid_data("invalid broker setup frame length"));
         }
-        let len = u32::try_from(frame.len()).map_err(|_| invalid_data("broker frame too large"))?;
+        let len =
+            u32::try_from(frame.len()).map_err(|_| invalid_data("broker setup frame too large"))?;
         write_all_with_deadline(stream, &len.to_le_bytes(), deadline)?;
         write_all_with_deadline(stream, frame, deadline)
     })
@@ -1120,7 +1116,7 @@ fn write_all_with_deadline(
             Ok(0) => {
                 return Err(Error::new(
                     ErrorKind::WriteZero,
-                    "failed to write broker frame",
+                    "failed to write broker setup frame",
                 ));
             }
             Ok(written) => buffer = &buffer[written..],
@@ -1204,7 +1200,7 @@ mod control_ring_tests {
         on_failure: impl Fn() + Send + Sync + 'static,
     ) -> (
         UnixControlRingLocalControlChannel,
-        UnixControlRingLocalCancellation,
+        UnixControlRingLocalShutdown,
         Producer,
         Consumer,
         UnixStream,
@@ -1213,16 +1209,14 @@ mod control_ring_tests {
         let mut ack_stream = peer_stream.try_clone().unwrap();
         let acknowledgement = thread::spawn(move || {
             assert_eq!(
-                read_frame_with_deadline(&mut ack_stream, None)
-                    .unwrap()
-                    .unwrap(),
+                read_setup_frame(&mut ack_stream, None).unwrap().unwrap(),
                 CONTROL_RING_READY
             );
-            write_frame_with_deadline(&mut ack_stream, CONTROL_RING_READY, None).unwrap();
+            write_setup_frame(&mut ack_stream, CONTROL_RING_READY, None).unwrap();
         });
         let (local_ring, broker_ring) = ring_pair();
         let mut channel = negotiated_local(local_stream);
-        let (cancellation, _notifications) = channel.activate(local_ring, on_failure).unwrap();
+        let (shutdown, _notifications) = channel.activate(local_ring, on_failure).unwrap();
         acknowledgement.join().unwrap();
         let crate::control_ring::BrokerControlRingEndpoints {
             request_consumer,
@@ -1231,7 +1225,7 @@ mod control_ring_tests {
         } = broker_ring.into_broker();
         (
             channel,
-            cancellation,
+            shutdown,
             response_producer,
             request_consumer,
             peer_stream,
@@ -1249,11 +1243,9 @@ mod control_ring_tests {
         let (peer_stream, host_stream) = UnixStream::pair().unwrap();
         let mut ack_stream = peer_stream.try_clone().unwrap();
         let acknowledgement = thread::spawn(move || {
-            write_frame_with_deadline(&mut ack_stream, CONTROL_RING_READY, None).unwrap();
+            write_setup_frame(&mut ack_stream, CONTROL_RING_READY, None).unwrap();
             assert_eq!(
-                read_frame_with_deadline(&mut ack_stream, None)
-                    .unwrap()
-                    .unwrap(),
+                read_setup_frame(&mut ack_stream, None).unwrap().unwrap(),
                 CONTROL_RING_READY
             );
         });
@@ -1281,7 +1273,7 @@ mod control_ring_tests {
         )
     }
 
-    fn active_notification_channels() -> (
+    fn notification_channel_pair() -> (
         UnixControlRingLocalControlChannel,
         UnixControlRingLocalNotificationChannel,
         UnixControlRingHostNotificationChannel,
@@ -1297,8 +1289,7 @@ mod control_ring_tests {
             negotiated: true,
         };
         let host_active = thread::spawn(move || host_control.into_active(host_ring).unwrap());
-        let (_cancellation, local_notifications) =
-            local_control.activate(local_ring, || {}).unwrap();
+        let (_shutdown, local_notifications) = local_control.activate(local_ring, || {}).unwrap();
         let (_source, _sink, host_notifications, shutdown) = host_active.join().unwrap();
         (
             local_control,
@@ -1383,26 +1374,20 @@ mod control_ring_tests {
     #[test]
     fn setup_frames_round_trip_and_reject_invalid_boundaries() {
         let (mut writer, mut reader) = UnixStream::pair().unwrap();
-        write_frame_with_deadline(&mut writer, &[1, 2, 3], None).unwrap();
+        write_setup_frame(&mut writer, &[1, 2, 3], None).unwrap();
         assert_eq!(
-            read_frame_with_deadline(&mut reader, None)
-                .unwrap()
-                .unwrap(),
+            read_setup_frame(&mut reader, None).unwrap().unwrap(),
             [1, 2, 3]
         );
 
         let (writer, mut reader) = UnixStream::pair().unwrap();
         drop(writer);
-        assert!(
-            read_frame_with_deadline(&mut reader, None)
-                .unwrap()
-                .is_none()
-        );
+        assert!(read_setup_frame(&mut reader, None).unwrap().is_none());
 
         for frame_prefix in [
             vec![1, 0],
             0u32.to_le_bytes().to_vec(),
-            u32::try_from(MAX_FRAME_LEN + 1)
+            u32::try_from(MAX_SETUP_FRAME_LEN + 1)
                 .unwrap()
                 .to_le_bytes()
                 .to_vec(),
@@ -1411,9 +1396,7 @@ mod control_ring_tests {
             writer.write_all(&frame_prefix).unwrap();
             drop(writer);
             assert_eq!(
-                read_frame_with_deadline(&mut reader, None)
-                    .unwrap_err()
-                    .kind(),
+                read_setup_frame(&mut reader, None).unwrap_err().kind(),
                 ErrorKind::InvalidData
             );
         }
@@ -1423,9 +1406,7 @@ mod control_ring_tests {
         writer.write_all(&[1, 2]).unwrap();
         drop(writer);
         assert_eq!(
-            read_frame_with_deadline(&mut reader, None)
-                .unwrap_err()
-                .kind(),
+            read_setup_frame(&mut reader, None).unwrap_err().kind(),
             ErrorKind::InvalidData
         );
     }
@@ -1449,15 +1430,11 @@ mod control_ring_tests {
         };
         channel.send_handshake_request(&handshake_request).unwrap();
         assert_eq!(
-            decode_handshake_request(
-                &read_frame_with_deadline(&mut host_stream, None)
-                    .unwrap()
-                    .unwrap()
-            )
-            .unwrap(),
+            decode_handshake_request(&read_setup_frame(&mut host_stream, None).unwrap().unwrap())
+                .unwrap(),
             handshake_request
         );
-        write_frame_with_deadline(
+        write_setup_frame(
             &mut host_stream,
             &encode_handshake_response(BrokerHandshakeResponse::Negotiated {
                 broker_protocol_version: litebox_broker_protocol::BROKER_PROTOCOL_VERSION,
@@ -1472,16 +1449,14 @@ mod control_ring_tests {
 
         let acknowledgement = thread::spawn(move || {
             assert_eq!(
-                read_frame_with_deadline(&mut host_stream, None)
-                    .unwrap()
-                    .unwrap(),
+                read_setup_frame(&mut host_stream, None).unwrap().unwrap(),
                 CONTROL_RING_READY
             );
-            write_frame_with_deadline(&mut host_stream, CONTROL_RING_READY, None).unwrap();
+            write_setup_frame(&mut host_stream, CONTROL_RING_READY, None).unwrap();
             host_stream
         });
         let (ring, _) = ring_pair();
-        let _cancellation = channel.activate(ring, || {}).unwrap();
+        let _shutdown = channel.activate(ring, || {}).unwrap();
         let mut host_stream = acknowledgement.join().unwrap();
 
         let (ring, _) = ring_pair();
@@ -1517,7 +1492,7 @@ mod control_ring_tests {
             negotiated: true,
         };
         let host_active = thread::spawn(move || host.into_active(host_ring).unwrap());
-        let (_cancellation, _local_notifications) = local.activate(local_ring, || {}).unwrap();
+        let (_shutdown, _local_notifications) = local.activate(local_ring, || {}).unwrap();
         let (mut source, sink, _host_notifications, _shutdown) = host_active.join().unwrap();
 
         let caller = thread::spawn(move || local.call(request(7)));
@@ -1530,7 +1505,7 @@ mod control_ring_tests {
 
     #[test]
     fn local_matches_out_of_order_ring_responses_without_socket_frames() {
-        let (channel, _cancellation, mut responses, mut requests, mut peer) = activate_local(|| {});
+        let (channel, _shutdown, mut responses, mut requests, mut peer) = activate_local(|| {});
         peer.set_read_timeout(Some(Duration::from_millis(100)))
             .unwrap();
         let channel = Arc::new(channel);
@@ -1558,7 +1533,7 @@ mod control_ring_tests {
 
     #[test]
     fn pending_capacity_blocks_before_sixty_fifth_publication() {
-        let (channel, cancellation, mut responses, mut requests, _peer) = activate_local(|| {});
+        let (channel, shutdown, mut responses, mut requests, _peer) = activate_local(|| {});
         let channel = Arc::new(channel);
         let start = Arc::new(Barrier::new(MAX_PENDING_CALLS + 2));
         let callers = (0..=MAX_PENDING_CALLS)
@@ -1581,7 +1556,7 @@ mod control_ring_tests {
         let released = read_request(&mut requests).request_id;
         assert!(!published.contains(&released));
 
-        cancellation.cancel().unwrap();
+        shutdown.shutdown().unwrap();
         let completed = callers
             .into_iter()
             .map(|caller| usize::from(caller.join().unwrap().is_ok()))
@@ -1594,7 +1569,7 @@ mod control_ring_tests {
         for payload_kind in 0..3 {
             let failures = Arc::new(AtomicUsize::new(0));
             let callback_failures = Arc::clone(&failures);
-            let (channel, _cancellation, mut responses, mut requests, _peer) =
+            let (channel, _shutdown, mut responses, mut requests, _peer) =
                 activate_local(move || {
                     callback_failures.fetch_add(1, Ordering::SeqCst);
                 });
@@ -1624,15 +1599,15 @@ mod control_ring_tests {
     }
 
     #[test]
-    fn local_socket_eof_and_cancellation_wake_pending_calls() {
+    fn local_socket_eof_and_shutdown_wake_pending_calls() {
         for close_peer in [false, true] {
-            let (channel, cancellation, _responses, mut requests, peer) = activate_local(|| {});
+            let (channel, shutdown, _responses, mut requests, peer) = activate_local(|| {});
             let caller = thread::spawn(move || channel.call(request(1)));
             read_request(&mut requests);
             if close_peer {
                 drop(peer);
             } else {
-                cancellation.cancel().unwrap();
+                shutdown.shutdown().unwrap();
             }
             assert!(caller.join().unwrap().is_err());
         }
@@ -1777,7 +1752,7 @@ mod control_ring_tests {
     fn host_setup_rejects_active_frames_and_requires_negotiation() {
         let (mut peer_stream, host_stream) = UnixStream::pair().unwrap();
         let mut channel = UnixStreamHostSetupChannel::from_accepted(host_stream);
-        write_frame_with_deadline(&mut peer_stream, &encode_request(request(0)), None).unwrap();
+        write_setup_frame(&mut peer_stream, &encode_request(request(0)), None).unwrap();
         assert_eq!(
             channel.recv_handshake_request().unwrap(),
             HostReceive::ProtocolViolation
@@ -1858,7 +1833,7 @@ mod control_ring_tests {
 
     #[test]
     fn notification_ring_round_trips() {
-        let (_control, mut local, mut host, _shutdown) = active_notification_channels();
+        let (_control, mut local, mut host, _shutdown) = notification_channel_pair();
         let notification = BrokerNotification::Readiness(
             litebox_broker_protocol::message::ReadinessNotification {
                 handle: ObjectHandle(7),
@@ -1875,7 +1850,7 @@ mod control_ring_tests {
 
     #[test]
     fn full_notification_ring_wakes_after_consumer_progress() {
-        let (_control, mut local, mut host, _shutdown) = active_notification_channels();
+        let (_control, mut local, mut host, _shutdown) = notification_channel_pair();
         let notification = BrokerNotification::Readiness(
             litebox_broker_protocol::message::ReadinessNotification {
                 handle: ObjectHandle(7),
@@ -1910,7 +1885,7 @@ mod control_ring_tests {
 
     #[test]
     fn association_shutdown_interrupts_notification_wait() {
-        let (_control, mut local, _host, shutdown) = active_notification_channels();
+        let (_control, mut local, _host, shutdown) = notification_channel_pair();
         let receiver = thread::spawn(move || local.recv_notification());
 
         shutdown.shutdown().unwrap();
@@ -1923,7 +1898,7 @@ mod control_ring_tests {
 
     #[test]
     fn malformed_notification_fails_the_association() {
-        let (control, mut local, mut host, _shutdown) = active_notification_channels();
+        let (control, mut local, mut host, _shutdown) = notification_channel_pair();
         assert_eq!(
             host.producer.try_write(&[0xff]).unwrap(),
             ControlRingWriteStatus::Written

--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -25,8 +25,8 @@ use litebox_broker_protocol::shared_memory::{
 use litebox_broker_transport::control_ring::{CONTROL_RING_MEMORY_SIZE, ControlRing};
 use litebox_broker_transport::shared_memory::MemfdSharedMemory;
 use litebox_broker_transport::unix_socket::{
-    UnixStreamHostControlChannel, UnixStreamHostControlShutdown, UnixStreamHostNotificationChannel,
-    UnixStreamHostRequestSource, UnixStreamHostResponseSink, validate_peer_process,
+    UnixStreamHostControlChannel, UnixStreamHostControlShutdown, UnixStreamHostRequestSource,
+    UnixStreamHostResponseSink, validate_peer_process,
 };
 
 const SETUP_TIMEOUT: Duration = Duration::from_secs(5);
@@ -50,11 +50,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         .prefix("litebox-broker-userland-")
         .tempdir()?;
     let control_socket_path = socket_dir.path().join("broker.sock");
-    let notification_socket_path = socket_dir.path().join("broker-notification.sock");
     let control_listener = UnixListener::bind(&control_socket_path)?;
-    let notification_listener = UnixListener::bind(&notification_socket_path)?;
     control_listener.set_nonblocking(true)?;
-    notification_listener.set_nonblocking(true)?;
     let broker = BrokerCore::new(PolicyEngine::with_host_guaranteed_rights(
         ObjectRights::all(),
     ))?;
@@ -64,19 +61,12 @@ fn main() -> Result<(), Box<dyn Error>> {
         .arg("--unstable")
         .arg("--broker-control-socket")
         .arg(&control_socket_path)
-        .arg("--broker-notification-socket")
-        .arg(&notification_socket_path)
         .args(&args.runner_arguments);
     let mut runner = runner_command.spawn()?;
     let runner_process_id = runner.id();
 
-    let association_result = serve_runner(
-        &broker,
-        &control_listener,
-        &notification_listener,
-        &mut runner,
-        runner_process_id,
-    );
+    let association_result =
+        serve_runner(&broker, &control_listener, &mut runner, runner_process_id);
     if association_result.is_err() {
         let _ = runner.kill();
     }
@@ -91,7 +81,6 @@ fn main() -> Result<(), Box<dyn Error>> {
 fn serve_runner(
     broker: &BrokerCore,
     control_listener: &UnixListener,
-    notification_listener: &UnixListener,
     runner: &mut Child,
     runner_process_id: u32,
 ) -> Result<(), Box<dyn Error>> {
@@ -103,13 +92,6 @@ fn serve_runner(
         setup_deadline,
         "control",
     )?;
-    let notification_stream = accept_runner_stream(
-        notification_listener,
-        runner,
-        runner_process_id,
-        setup_deadline,
-        "notification",
-    )?;
     let shared_memory = MemfdSharedMemory::create(SHARED_BUFFER_POOL_SIZE)?;
     let shared_buffers = SharedBufferPool::new(shared_memory, SHARED_BUFFER_LAYOUT)?;
     let control_memory = MemfdSharedMemory::create(CONTROL_RING_MEMORY_SIZE)?;
@@ -117,8 +99,6 @@ fn serve_runner(
         .map_err(|error| IoError::other(format!("failed to create control ring: {error:?}")))?;
     let mut control_channel =
         UnixStreamHostControlChannel::from_host_guaranteed(control_stream, setup_deadline);
-    let _notification_channel =
-        UnixStreamHostNotificationChannel::from_accepted(notification_stream);
     let association =
         match setup_connection(broker, &mut control_channel, &shared_buffers, |channel| {
             channel.send_memfd(shared_buffers.memory(), Some(setup_deadline))?;
@@ -148,7 +128,8 @@ fn serve_runner(
                 .into());
             }
         };
-    let (request_source, response_sink, shutdown) = control_channel.into_active(control_ring)?;
+    let (request_source, response_sink, _notification_channel, shutdown) =
+        control_channel.into_active(control_ring)?;
     dispatch_requests(association, request_source, response_sink, shutdown)?;
     Ok(())
 }
@@ -371,7 +352,7 @@ mod tests {
             let cancellation = local_channel.activate(local_ring, || {}).unwrap();
             (local_channel, cancellation)
         });
-        let (mut request_source, _response_sink, shutdown) =
+        let (mut request_source, _response_sink, _notifications, shutdown) =
             control_channel.into_active(host_ring).unwrap();
         let (_local_channel, _cancellation) = local_activation.join().unwrap();
         let failure_coordinator = HostAssociationFailureCoordinator::new(shutdown);

--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -349,12 +349,12 @@ mod tests {
         let local_ring = ControlRing::new(local_memory).unwrap();
         let host_ring = ControlRing::new(host_memory).unwrap();
         let local_activation = std::thread::spawn(move || {
-            let cancellation = local_channel.activate(local_ring, || {}).unwrap();
-            (local_channel, cancellation)
+            let local_shutdown = local_channel.activate(local_ring, || {}).unwrap();
+            (local_channel, local_shutdown)
         });
         let (mut request_source, _response_sink, _notifications, shutdown) =
             control_channel.into_active(host_ring).unwrap();
-        let (_local_channel, _cancellation) = local_activation.join().unwrap();
+        let (_local_channel, _local_shutdown) = local_activation.join().unwrap();
         let failure_coordinator = HostAssociationFailureCoordinator::new(shutdown);
         let (result_sender, result_receiver) = std::sync::mpsc::sync_channel(1);
         let reader = std::thread::spawn(move || {

--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -324,22 +324,22 @@ fn accept_runner_stream(
 mod tests {
     use super::*;
     use litebox_broker_protocol::BROKER_PROTOCOL_VERSION;
-    use litebox_broker_protocol::channel::{HostSetupChannel, LocalControlChannel};
+    use litebox_broker_protocol::channel::{HostSetupChannel, LocalSetupChannel};
     use litebox_broker_protocol::message::BrokerHandshakeResponse;
-    use litebox_broker_transport::unix_socket::UnixControlRingLocalControlChannel;
+    use litebox_broker_transport::unix_socket::UnixStreamLocalSetupChannel;
     use std::os::fd::AsFd;
 
     #[test]
     fn first_failure_is_preserved_and_unblocks_request_reading() {
         let (peer_stream, host_stream) = UnixStream::pair().unwrap();
-        let mut local_channel = UnixControlRingLocalControlChannel::from_connected(peer_stream);
+        let mut local_setup = UnixStreamLocalSetupChannel::from_connected(peer_stream);
         let mut control_channel = UnixStreamHostSetupChannel::from_accepted(host_stream);
         control_channel
             .send_handshake_response(&BrokerHandshakeResponse::Negotiated {
                 broker_protocol_version: BROKER_PROTOCOL_VERSION,
             })
             .unwrap();
-        local_channel.recv_handshake_response().unwrap().unwrap();
+        local_setup.recv_handshake_response().unwrap().unwrap();
         let local_memory = MemfdSharedMemory::create(CONTROL_RING_MEMORY_SIZE).unwrap();
         let host_memory = MemfdSharedMemory::from_received_fd(
             local_memory.as_fd().try_clone_to_owned().unwrap(),
@@ -348,13 +348,11 @@ mod tests {
         .unwrap();
         let local_ring = ControlRing::new(local_memory).unwrap();
         let host_ring = ControlRing::new(host_memory).unwrap();
-        let local_activation = std::thread::spawn(move || {
-            let local_shutdown = local_channel.activate(local_ring, || {}).unwrap();
-            (local_channel, local_shutdown)
-        });
+        let local_activation =
+            std::thread::spawn(move || local_setup.into_active(local_ring, || {}).unwrap());
         let (mut request_source, _response_sink, _notifications, shutdown) =
             control_channel.into_active(host_ring).unwrap();
-        let (_local_channel, _local_shutdown) = local_activation.join().unwrap();
+        let (_local_call, _local_notifications, _local_shutdown) = local_activation.join().unwrap();
         let failure_coordinator = HostAssociationFailureCoordinator::new(shutdown);
         let (result_sender, result_receiver) = std::sync::mpsc::sync_channel(1);
         let reader = std::thread::spawn(move || {

--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -25,8 +25,8 @@ use litebox_broker_protocol::shared_memory::{
 use litebox_broker_transport::control_ring::{CONTROL_RING_MEMORY_SIZE, ControlRing};
 use litebox_broker_transport::shared_memory::MemfdSharedMemory;
 use litebox_broker_transport::unix_socket::{
-    UnixStreamHostControlChannel, UnixStreamHostControlShutdown, UnixStreamHostRequestSource,
-    UnixStreamHostResponseSink, validate_peer_process,
+    UnixControlRingHostRequestSource, UnixControlRingHostResponseSink,
+    UnixStreamHostControlChannel, UnixStreamHostControlShutdown, validate_peer_process,
 };
 
 const SETUP_TIMEOUT: Duration = Duration::from_secs(5);
@@ -136,8 +136,8 @@ fn serve_runner(
 
 fn dispatch_requests<Memory: SharedMemory>(
     association: BrokerHostAssociation<'_, Memory>,
-    mut request_source: UnixStreamHostRequestSource,
-    response_sink: UnixStreamHostResponseSink,
+    mut request_source: UnixControlRingHostRequestSource,
+    response_sink: UnixControlRingHostResponseSink,
     shutdown: UnixStreamHostControlShutdown,
 ) -> IoResult<()> {
     let association = Arc::new(association);
@@ -185,7 +185,7 @@ fn dispatch_requests<Memory: SharedMemory>(
 }
 
 fn read_requests(
-    request_source: &mut UnixStreamHostRequestSource,
+    request_source: &mut UnixControlRingHostRequestSource,
     request_sender: SyncSender<BrokerRequest>,
     failure_coordinator: &HostAssociationFailureCoordinator,
 ) {
@@ -222,7 +222,7 @@ fn read_requests(
 fn run_worker<Memory: SharedMemory>(
     association: &BrokerHostAssociation<'_, Memory>,
     request_receiver: &Mutex<Receiver<BrokerRequest>>,
-    response_sink: &UnixStreamHostResponseSink,
+    response_sink: &UnixControlRingHostResponseSink,
     failure_coordinator: &HostAssociationFailureCoordinator,
 ) {
     loop {

--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -26,7 +26,7 @@ use litebox_broker_transport::control_ring::{CONTROL_RING_MEMORY_SIZE, ControlRi
 use litebox_broker_transport::shared_memory::MemfdSharedMemory;
 use litebox_broker_transport::unix_socket::{
     UnixControlRingHostRequestSource, UnixControlRingHostResponseSink, UnixControlRingHostShutdown,
-    UnixStreamHostControlChannel, validate_peer_process,
+    UnixStreamHostSetupChannel, validate_peer_process,
 };
 
 const SETUP_TIMEOUT: Duration = Duration::from_secs(5);
@@ -98,7 +98,7 @@ fn serve_runner(
     let control_ring = ControlRing::new(control_memory)
         .map_err(|error| IoError::other(format!("failed to create control ring: {error:?}")))?;
     let mut control_channel =
-        UnixStreamHostControlChannel::from_host_guaranteed(control_stream, setup_deadline);
+        UnixStreamHostSetupChannel::from_host_guaranteed(control_stream, setup_deadline);
     let association =
         match setup_connection(broker, &mut control_channel, &shared_buffers, |channel| {
             channel.send_memfd(shared_buffers.memory(), Some(setup_deadline))?;
@@ -326,14 +326,14 @@ mod tests {
     use litebox_broker_protocol::BROKER_PROTOCOL_VERSION;
     use litebox_broker_protocol::channel::{HostSetupChannel, LocalControlChannel};
     use litebox_broker_protocol::message::BrokerHandshakeResponse;
-    use litebox_broker_transport::unix_socket::UnixStreamLocalControlChannel;
+    use litebox_broker_transport::unix_socket::UnixControlRingLocalControlChannel;
     use std::os::fd::AsFd;
 
     #[test]
     fn first_failure_is_preserved_and_unblocks_request_reading() {
         let (peer_stream, host_stream) = UnixStream::pair().unwrap();
-        let mut local_channel = UnixStreamLocalControlChannel::from_connected(peer_stream);
-        let mut control_channel = UnixStreamHostControlChannel::from_accepted(host_stream);
+        let mut local_channel = UnixControlRingLocalControlChannel::from_connected(peer_stream);
+        let mut control_channel = UnixStreamHostSetupChannel::from_accepted(host_stream);
         control_channel
             .send_handshake_response(&BrokerHandshakeResponse::Negotiated {
                 broker_protocol_version: BROKER_PROTOCOL_VERSION,

--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -25,8 +25,8 @@ use litebox_broker_protocol::shared_memory::{
 use litebox_broker_transport::control_ring::{CONTROL_RING_MEMORY_SIZE, ControlRing};
 use litebox_broker_transport::shared_memory::MemfdSharedMemory;
 use litebox_broker_transport::unix_socket::{
-    UnixControlRingHostRequestSource, UnixControlRingHostResponseSink,
-    UnixStreamHostControlChannel, UnixStreamHostControlShutdown, validate_peer_process,
+    UnixControlRingHostRequestSource, UnixControlRingHostResponseSink, UnixControlRingHostShutdown,
+    UnixStreamHostControlChannel, validate_peer_process,
 };
 
 const SETUP_TIMEOUT: Duration = Duration::from_secs(5);
@@ -138,7 +138,7 @@ fn dispatch_requests<Memory: SharedMemory>(
     association: BrokerHostAssociation<'_, Memory>,
     mut request_source: UnixControlRingHostRequestSource,
     response_sink: UnixControlRingHostResponseSink,
-    shutdown: UnixStreamHostControlShutdown,
+    shutdown: UnixControlRingHostShutdown,
 ) -> IoResult<()> {
     let association = Arc::new(association);
     let failure_coordinator = Arc::new(HostAssociationFailureCoordinator::new(shutdown));
@@ -251,11 +251,11 @@ fn run_worker<Memory: SharedMemory>(
 struct HostAssociationFailureCoordinator {
     failed: AtomicBool,
     error: Mutex<Option<IoError>>,
-    shutdown: UnixStreamHostControlShutdown,
+    shutdown: UnixControlRingHostShutdown,
 }
 
 impl HostAssociationFailureCoordinator {
-    const fn new(shutdown: UnixStreamHostControlShutdown) -> Self {
+    const fn new(shutdown: UnixControlRingHostShutdown) -> Self {
         Self {
             failed: AtomicBool::new(false),
             error: Mutex::new(None),

--- a/litebox_broker_userland/tests/notification_runtime.rs
+++ b/litebox_broker_userland/tests/notification_runtime.rs
@@ -17,7 +17,7 @@ use litebox_broker_protocol::shared_memory::{
 use litebox_broker_transport::control_ring::{CONTROL_RING_MEMORY_SIZE, ControlRing};
 use litebox_broker_transport::shared_memory::MemfdSharedMemory;
 use litebox_broker_transport::unix_socket::{
-    UnixControlRingLocalControlChannel, UnixStreamHostSetupChannel,
+    UnixStreamHostSetupChannel, UnixStreamLocalSetupChannel,
 };
 
 #[test]
@@ -65,19 +65,20 @@ fn host_serves_control_requests_and_notifications_over_shared_rings() {
 
     let mut notification_channel = None;
     let local = BrokerLocal::negotiate(
-        UnixControlRingLocalControlChannel::from_connected(local_control),
-        |channel| {
-            let shared_memory = channel.receive_memfd(SHARED_BUFFER_POOL_SIZE, None)?;
-            let control_memory = channel.receive_memfd(CONTROL_RING_MEMORY_SIZE, None)?;
+        UnixStreamLocalSetupChannel::from_connected(local_control),
+        |mut setup| {
+            let shared_memory = setup.receive_memfd(SHARED_BUFFER_POOL_SIZE, None)?;
+            let control_memory = setup.receive_memfd(CONTROL_RING_MEMORY_SIZE, None)?;
             let control_ring = ControlRing::new(control_memory).map_err(|error| {
                 std::io::Error::new(
                     std::io::ErrorKind::InvalidData,
                     format!("invalid test control ring: {error:?}"),
                 )
             })?;
-            let (_cancellation, notifications) = channel.activate(control_ring, || {})?;
+            let (call_channel, notifications, _shutdown) =
+                setup.into_active(control_ring, || {})?;
             notification_channel = Some(notifications);
-            Ok(Arc::new(shared_memory))
+            Ok((call_channel, Arc::new(shared_memory)))
         },
     )
     .unwrap();

--- a/litebox_broker_userland/tests/notification_runtime.rs
+++ b/litebox_broker_userland/tests/notification_runtime.rs
@@ -17,7 +17,7 @@ use litebox_broker_protocol::shared_memory::{
 use litebox_broker_transport::control_ring::{CONTROL_RING_MEMORY_SIZE, ControlRing};
 use litebox_broker_transport::shared_memory::MemfdSharedMemory;
 use litebox_broker_transport::unix_socket::{
-    UnixStreamHostControlChannel, UnixStreamLocalControlChannel,
+    UnixControlRingLocalControlChannel, UnixStreamHostSetupChannel,
 };
 
 #[test]
@@ -39,7 +39,7 @@ fn host_serves_control_requests_and_notifications_over_shared_rings() {
     let host_notification = notification.clone();
 
     let host_thread = std::thread::spawn(move || {
-        let mut control = UnixStreamHostControlChannel::from_accepted(host_control);
+        let mut control = UnixStreamHostSetupChannel::from_accepted(host_control);
         let association =
             setup_connection(&broker, &mut control, &host_shared_buffers, |channel| {
                 channel.send_memfd(host_shared_buffers.memory(), None)?;
@@ -65,7 +65,7 @@ fn host_serves_control_requests_and_notifications_over_shared_rings() {
 
     let mut notification_channel = None;
     let local = BrokerLocal::negotiate(
-        UnixStreamLocalControlChannel::from_connected(local_control),
+        UnixControlRingLocalControlChannel::from_connected(local_control),
         |channel| {
             let shared_memory = channel.receive_memfd(SHARED_BUFFER_POOL_SIZE, None)?;
             let control_memory = channel.receive_memfd(CONTROL_RING_MEMORY_SIZE, None)?;

--- a/litebox_broker_userland/tests/notification_runtime.rs
+++ b/litebox_broker_userland/tests/notification_runtime.rs
@@ -6,8 +6,10 @@ use std::sync::Arc;
 
 use litebox_broker_core::{BrokerCore, ObjectRights, PolicyEngine};
 use litebox_broker_host::{ConnectionTermination, setup_connection};
-use litebox_broker_local::BrokerLocal;
-use litebox_broker_protocol::channel::HostReceive;
+use litebox_broker_local::{BrokerLocal, BrokerNotifications};
+use litebox_broker_protocol::ObjectHandle;
+use litebox_broker_protocol::channel::{HostNotificationChannel, HostReceive};
+use litebox_broker_protocol::message::{BrokerNotification, ReadinessNotification};
 use litebox_broker_protocol::readiness::ReadinessFlags;
 use litebox_broker_protocol::shared_memory::{
     SHARED_BUFFER_LAYOUT, SHARED_BUFFER_POOL_SIZE, SharedBufferPool,
@@ -15,26 +17,29 @@ use litebox_broker_protocol::shared_memory::{
 use litebox_broker_transport::control_ring::{CONTROL_RING_MEMORY_SIZE, ControlRing};
 use litebox_broker_transport::shared_memory::MemfdSharedMemory;
 use litebox_broker_transport::unix_socket::{
-    UnixStreamHostControlChannel, UnixStreamHostNotificationChannel, UnixStreamLocalControlChannel,
+    UnixStreamHostControlChannel, UnixStreamLocalControlChannel,
 };
 
 #[test]
-fn host_serves_control_requests_over_paired_userland_channels() {
+fn host_serves_control_requests_and_notifications_over_shared_rings() {
     let broker = BrokerCore::new(PolicyEngine::with_unauthenticated_rights(
         ObjectRights::all(),
     ))
     .unwrap();
     let (local_control, host_control) = UnixStream::pair().unwrap();
-    let (_local_notification, host_notification) = UnixStream::pair().unwrap();
     let host_shared_memory = MemfdSharedMemory::create(SHARED_BUFFER_POOL_SIZE).unwrap();
     let host_shared_buffers =
         SharedBufferPool::new(host_shared_memory, SHARED_BUFFER_LAYOUT).unwrap();
     let host_control_memory = MemfdSharedMemory::create(CONTROL_RING_MEMORY_SIZE).unwrap();
     let host_control_ring = ControlRing::new(host_control_memory).unwrap();
+    let notification = BrokerNotification::Readiness(ReadinessNotification {
+        handle: ObjectHandle(7),
+        readiness: ReadinessFlags::READ,
+    });
+    let host_notification = notification.clone();
 
     let host_thread = std::thread::spawn(move || {
         let mut control = UnixStreamHostControlChannel::from_accepted(host_control);
-        let _notification = UnixStreamHostNotificationChannel::from_accepted(host_notification);
         let association =
             setup_connection(&broker, &mut control, &host_shared_buffers, |channel| {
                 channel.send_memfd(host_shared_buffers.memory(), None)?;
@@ -42,8 +47,9 @@ fn host_serves_control_requests_over_paired_userland_channels() {
             })
             .unwrap()
             .unwrap();
-        let (mut request_source, response_sink, _shutdown) =
+        let (mut request_source, response_sink, mut notifications, _shutdown) =
             control.into_active(host_control_ring).unwrap();
+        notifications.send_notification(&host_notification).unwrap();
         loop {
             match request_source.recv_request().unwrap() {
                 HostReceive::Message(request) => association
@@ -57,6 +63,7 @@ fn host_serves_control_requests_over_paired_userland_channels() {
         }
     });
 
+    let mut notification_channel = None;
     let local = BrokerLocal::negotiate(
         UnixStreamLocalControlChannel::from_connected(local_control),
         |channel| {
@@ -68,11 +75,19 @@ fn host_serves_control_requests_over_paired_userland_channels() {
                     format!("invalid test control ring: {error:?}"),
                 )
             })?;
-            let _cancellation = channel.activate(control_ring, || {})?;
+            let (_cancellation, notifications) = channel.activate(control_ring, || {})?;
+            notification_channel = Some(notifications);
             Ok(Arc::new(shared_memory))
         },
     )
     .unwrap();
+    let mut notifications = BrokerNotifications::new(
+        notification_channel.expect("activation must return a notification receiver"),
+    );
+    assert_eq!(
+        notifications.recv_notification().unwrap(),
+        Some(notification)
+    );
 
     let handle = local.create_event_with_count(0).unwrap();
     let readiness = ReadinessFlags::READ | ReadinessFlags::WRITE;

--- a/litebox_broker_userland/tests/notification_runtime.rs
+++ b/litebox_broker_userland/tests/notification_runtime.rs
@@ -63,8 +63,7 @@ fn host_serves_control_requests_and_notifications_over_shared_rings() {
         }
     });
 
-    let mut notification_channel = None;
-    let local = BrokerLocal::negotiate(
+    let (local, notification_channel) = BrokerLocal::negotiate(
         UnixStreamLocalSetupChannel::from_connected(local_control),
         |mut setup| {
             let shared_memory = setup.receive_memfd(SHARED_BUFFER_POOL_SIZE, None)?;
@@ -77,14 +76,11 @@ fn host_serves_control_requests_and_notifications_over_shared_rings() {
             })?;
             let (call_channel, notifications, _shutdown) =
                 setup.into_active(control_ring, || {})?;
-            notification_channel = Some(notifications);
-            Ok((call_channel, Arc::new(shared_memory)))
+            Ok((call_channel, Arc::new(shared_memory), notifications))
         },
     )
     .unwrap();
-    let mut notifications = BrokerNotifications::new(
-        notification_channel.expect("activation must return a notification receiver"),
-    );
+    let mut notifications = BrokerNotifications::new(notification_channel);
     assert_eq!(
         notifications.recv_notification().unwrap(),
         Some(notification)

--- a/litebox_broker_userland/tests/userland_broker.rs
+++ b/litebox_broker_userland/tests/userland_broker.rs
@@ -76,28 +76,26 @@ fn run_fake_runner(args: &[OsString]) {
 
     let control_socket_path = args.get(2).unwrap();
     let setup_channel = connect_control_with_retry(Path::new(control_socket_path)).unwrap();
-    let local = Arc::new(
-        BrokerLocal::negotiate(setup_channel, |mut setup| {
-            let shared_memory = setup.receive_memfd(
-                SHARED_BUFFER_POOL_SIZE,
-                Some(Instant::now() + Duration::from_secs(5)),
-            )?;
-            let control_memory = setup.receive_memfd(
-                CONTROL_RING_MEMORY_SIZE,
-                Some(Instant::now() + Duration::from_secs(5)),
-            )?;
-            let control_ring = ControlRing::new(control_memory).map_err(|error| {
-                std::io::Error::new(
-                    ErrorKind::InvalidData,
-                    format!("invalid test control ring: {error:?}"),
-                )
-            })?;
-            let (call_channel, _notifications, _shutdown) =
-                setup.into_active(control_ring, || {})?;
-            Ok((call_channel, Arc::new(shared_memory)))
-        })
-        .unwrap(),
-    );
+    let (local, ()) = BrokerLocal::negotiate(setup_channel, |mut setup| {
+        let shared_memory = setup.receive_memfd(
+            SHARED_BUFFER_POOL_SIZE,
+            Some(Instant::now() + Duration::from_secs(5)),
+        )?;
+        let control_memory = setup.receive_memfd(
+            CONTROL_RING_MEMORY_SIZE,
+            Some(Instant::now() + Duration::from_secs(5)),
+        )?;
+        let control_ring = ControlRing::new(control_memory).map_err(|error| {
+            std::io::Error::new(
+                ErrorKind::InvalidData,
+                format!("invalid test control ring: {error:?}"),
+            )
+        })?;
+        let (call_channel, _notifications, _shutdown) = setup.into_active(control_ring, || {})?;
+        Ok((call_channel, Arc::new(shared_memory), ()))
+    })
+    .unwrap();
+    let local = Arc::new(local);
 
     let start = Arc::new(std::sync::Barrier::new(17));
     let callers = (0..16)

--- a/litebox_broker_userland/tests/userland_broker.rs
+++ b/litebox_broker_userland/tests/userland_broker.rs
@@ -14,9 +14,7 @@ use litebox_broker_protocol::shared_memory::{
     SHARED_BUFFER_POOL_SIZE, SharedBufferDescriptor, SharedBufferSlotIndex,
 };
 use litebox_broker_transport::control_ring::{CONTROL_RING_MEMORY_SIZE, ControlRing};
-use litebox_broker_transport::unix_socket::{
-    UnixStreamLocalControlChannel, UnixStreamLocalNotificationChannel,
-};
+use litebox_broker_transport::unix_socket::UnixStreamLocalControlChannel;
 
 const RUNNER_ARGUMENT: &str = "broker-userland-test-runner";
 
@@ -36,8 +34,8 @@ fn run_parent_test() {
     // This custom-harness integration test uses its own executable as the broker's
     // runner. Cargo starts this executable without broker args, so it runs the
     // parent path here. The broker then starts the same executable with the real
-    // runner argv (`--unstable --broker-control-socket <path>
-    // --broker-notification-socket <path>`), which runs `run_fake_runner`. After
+    // runner argv (`--unstable --broker-control-socket <path>`), which runs
+    // `run_fake_runner`. After
     // the fake runner finishes its broker requests, it terminates the broker
     // parent process; this lets the test exercise the long-running broker
     // without a test-only shutdown path.
@@ -72,19 +70,12 @@ fn run_fake_runner(args: &[OsString]) {
     );
     assert_eq!(
         args.get(3).map(OsString::as_os_str),
-        Some(OsStr::new("--broker-notification-socket"))
-    );
-    assert_eq!(
-        args.get(5).map(OsString::as_os_str),
         Some(OsStr::new(RUNNER_ARGUMENT))
     );
-    assert_eq!(args.len(), 6, "unexpected runner arguments: {args:?}");
+    assert_eq!(args.len(), 4, "unexpected runner arguments: {args:?}");
 
     let control_socket_path = args.get(2).unwrap();
-    let notification_socket_path = args.get(4).unwrap();
     let control_channel = connect_control_with_retry(Path::new(control_socket_path)).unwrap();
-    let _notification_channel =
-        connect_notification_with_retry(Path::new(notification_socket_path)).unwrap();
     let local = Arc::new(
         BrokerLocal::negotiate(control_channel, |channel| {
             let shared_memory = channel.receive_memfd(
@@ -101,7 +92,7 @@ fn run_fake_runner(args: &[OsString]) {
                     format!("invalid test control ring: {error:?}"),
                 )
             })?;
-            let _cancellation = channel.activate(control_ring, || {})?;
+            let (_cancellation, _notifications) = channel.activate(control_ring, || {})?;
             Ok(Arc::new(shared_memory))
         })
         .unwrap(),
@@ -185,26 +176,6 @@ fn connect_control_with_retry(socket_path: &Path) -> Result<UnixStreamLocalContr
     let deadline = Instant::now() + Duration::from_secs(5);
     loop {
         match UnixStreamLocalControlChannel::connect_with_setup_deadline(socket_path, deadline) {
-            Ok(channel) => return Ok(channel),
-            Err(error) if Instant::now() < deadline => {
-                if error.kind() != ErrorKind::NotFound
-                    && error.kind() != ErrorKind::ConnectionRefused
-                {
-                    return Err(error);
-                }
-                std::thread::sleep(Duration::from_millis(10));
-            }
-            Err(error) => return Err(error),
-        }
-    }
-}
-
-fn connect_notification_with_retry(
-    socket_path: &Path,
-) -> Result<UnixStreamLocalNotificationChannel> {
-    let deadline = Instant::now() + Duration::from_secs(5);
-    loop {
-        match UnixStreamLocalNotificationChannel::connect(socket_path) {
             Ok(channel) => return Ok(channel),
             Err(error) if Instant::now() < deadline => {
                 if error.kind() != ErrorKind::NotFound

--- a/litebox_broker_userland/tests/userland_broker.rs
+++ b/litebox_broker_userland/tests/userland_broker.rs
@@ -14,7 +14,7 @@ use litebox_broker_protocol::shared_memory::{
     SHARED_BUFFER_POOL_SIZE, SharedBufferDescriptor, SharedBufferSlotIndex,
 };
 use litebox_broker_transport::control_ring::{CONTROL_RING_MEMORY_SIZE, ControlRing};
-use litebox_broker_transport::unix_socket::UnixControlRingLocalControlChannel;
+use litebox_broker_transport::unix_socket::UnixStreamLocalSetupChannel;
 
 const RUNNER_ARGUMENT: &str = "broker-userland-test-runner";
 
@@ -75,14 +75,14 @@ fn run_fake_runner(args: &[OsString]) {
     assert_eq!(args.len(), 4, "unexpected runner arguments: {args:?}");
 
     let control_socket_path = args.get(2).unwrap();
-    let control_channel = connect_control_with_retry(Path::new(control_socket_path)).unwrap();
+    let setup_channel = connect_control_with_retry(Path::new(control_socket_path)).unwrap();
     let local = Arc::new(
-        BrokerLocal::negotiate(control_channel, |channel| {
-            let shared_memory = channel.receive_memfd(
+        BrokerLocal::negotiate(setup_channel, |mut setup| {
+            let shared_memory = setup.receive_memfd(
                 SHARED_BUFFER_POOL_SIZE,
                 Some(Instant::now() + Duration::from_secs(5)),
             )?;
-            let control_memory = channel.receive_memfd(
+            let control_memory = setup.receive_memfd(
                 CONTROL_RING_MEMORY_SIZE,
                 Some(Instant::now() + Duration::from_secs(5)),
             )?;
@@ -92,8 +92,9 @@ fn run_fake_runner(args: &[OsString]) {
                     format!("invalid test control ring: {error:?}"),
                 )
             })?;
-            let (_cancellation, _notifications) = channel.activate(control_ring, || {})?;
-            Ok(Arc::new(shared_memory))
+            let (call_channel, _notifications, _shutdown) =
+                setup.into_active(control_ring, || {})?;
+            Ok((call_channel, Arc::new(shared_memory)))
         })
         .unwrap(),
     );
@@ -172,11 +173,10 @@ impl Drop for ChildGuard {
     }
 }
 
-fn connect_control_with_retry(socket_path: &Path) -> Result<UnixControlRingLocalControlChannel> {
+fn connect_control_with_retry(socket_path: &Path) -> Result<UnixStreamLocalSetupChannel> {
     let deadline = Instant::now() + Duration::from_secs(5);
     loop {
-        match UnixControlRingLocalControlChannel::connect_with_setup_deadline(socket_path, deadline)
-        {
+        match UnixStreamLocalSetupChannel::connect_with_setup_deadline(socket_path, deadline) {
             Ok(channel) => return Ok(channel),
             Err(error) if Instant::now() < deadline => {
                 if error.kind() != ErrorKind::NotFound

--- a/litebox_broker_userland/tests/userland_broker.rs
+++ b/litebox_broker_userland/tests/userland_broker.rs
@@ -14,7 +14,7 @@ use litebox_broker_protocol::shared_memory::{
     SHARED_BUFFER_POOL_SIZE, SharedBufferDescriptor, SharedBufferSlotIndex,
 };
 use litebox_broker_transport::control_ring::{CONTROL_RING_MEMORY_SIZE, ControlRing};
-use litebox_broker_transport::unix_socket::UnixStreamLocalControlChannel;
+use litebox_broker_transport::unix_socket::UnixControlRingLocalControlChannel;
 
 const RUNNER_ARGUMENT: &str = "broker-userland-test-runner";
 
@@ -172,10 +172,11 @@ impl Drop for ChildGuard {
     }
 }
 
-fn connect_control_with_retry(socket_path: &Path) -> Result<UnixStreamLocalControlChannel> {
+fn connect_control_with_retry(socket_path: &Path) -> Result<UnixControlRingLocalControlChannel> {
     let deadline = Instant::now() + Duration::from_secs(5);
     loop {
-        match UnixStreamLocalControlChannel::connect_with_setup_deadline(socket_path, deadline) {
+        match UnixControlRingLocalControlChannel::connect_with_setup_deadline(socket_path, deadline)
+        {
             Ok(channel) => return Ok(channel),
             Err(error) if Instant::now() < deadline => {
                 if error.kind() != ErrorKind::NotFound

--- a/litebox_runner_linux_userland/src/broker.rs
+++ b/litebox_runner_linux_userland/src/broker.rs
@@ -210,9 +210,9 @@ mod tests {
     use litebox_broker_protocol::readiness::ReadinessFlags;
     use litebox_broker_transport::shared_memory::MemfdSharedMemory;
     use litebox_broker_transport::unix_socket::{
-        UnixControlRingHostNotificationChannel, UnixControlRingLocalNotificationChannel,
-        UnixStreamHostControlChannel, UnixStreamHostControlShutdown, UnixStreamHostRequestSource,
-        UnixStreamHostResponseSink,
+        UnixControlRingHostNotificationChannel, UnixControlRingHostRequestSource,
+        UnixControlRingHostResponseSink, UnixControlRingLocalNotificationChannel,
+        UnixStreamHostControlChannel, UnixStreamHostControlShutdown,
     };
     use std::io::ErrorKind;
     use std::os::fd::AsFd;
@@ -253,8 +253,8 @@ mod tests {
     ) -> (
         UnixStreamLocalControlCancellation,
         UnixControlRingLocalNotificationChannel,
-        UnixStreamHostRequestSource,
-        UnixStreamHostResponseSink,
+        UnixControlRingHostRequestSource,
+        UnixControlRingHostResponseSink,
         UnixControlRingHostNotificationChannel,
         UnixStreamHostControlShutdown,
     ) {

--- a/litebox_runner_linux_userland/src/broker.rs
+++ b/litebox_runner_linux_userland/src/broker.rs
@@ -16,7 +16,7 @@ use litebox_broker_protocol::message::BrokerNotification;
 use litebox_broker_protocol::shared_memory::SHARED_BUFFER_POOL_SIZE;
 use litebox_broker_transport::control_ring::{CONTROL_RING_MEMORY_SIZE, ControlRing};
 use litebox_broker_transport::unix_socket::{
-    UnixControlRingLocalNotificationChannel, UnixStreamLocalControlCancellation,
+    UnixControlRingLocalCancellation, UnixControlRingLocalNotificationChannel,
     UnixStreamLocalControlChannel,
 };
 
@@ -56,13 +56,13 @@ pub(crate) fn connect(
             )
         })?;
         let weak_association_coordinator = Arc::downgrade(&association_coordinator);
-        let (control_cancellation_handle, active_notification_channel) =
+        let (association_cancellation, active_notification_channel) =
             channel.activate(control_ring, move || {
                 if let Some(association_coordinator) = weak_association_coordinator.upgrade() {
                     association_coordinator.report_failure();
                 }
             })?;
-        association_coordinator.install_control_cancellation_handle(control_cancellation_handle)?;
+        association_coordinator.install_cancellation(association_cancellation)?;
         notification_channel = Some(active_notification_channel);
         Ok(Arc::new(shared_memory))
     })
@@ -102,7 +102,7 @@ pub(crate) fn start_notification_receiver(
 
 pub(crate) struct BrokerAssociationFailureCoordinator {
     failed: AtomicBool,
-    control_cancellation_handle: Mutex<Option<UnixStreamLocalControlCancellation>>,
+    cancellation: Mutex<Option<UnixControlRingLocalCancellation>>,
     dispatch_failure: Mutex<Option<Box<dyn FnOnce() + Send>>>,
 }
 
@@ -110,31 +110,31 @@ impl BrokerAssociationFailureCoordinator {
     fn new() -> Self {
         Self {
             failed: AtomicBool::new(false),
-            control_cancellation_handle: Mutex::new(None),
+            cancellation: Mutex::new(None),
             dispatch_failure: Mutex::new(None),
         }
     }
 
-    fn install_control_cancellation_handle(
+    fn install_cancellation(
         &self,
-        control_cancellation_handle: UnixStreamLocalControlCancellation,
+        cancellation: UnixControlRingLocalCancellation,
     ) -> std::io::Result<()> {
         let mut installed = self
-            .control_cancellation_handle
+            .cancellation
             .lock()
-            .expect("broker control cancellation mutex poisoned");
+            .expect("broker association cancellation mutex poisoned");
         assert!(
             installed.is_none(),
-            "broker control cancellation already installed"
+            "broker association cancellation already installed"
         );
         if self.failed.load(Ordering::Acquire) {
-            control_cancellation_handle.cancel()?;
+            cancellation.cancel()?;
             return Err(std::io::Error::new(
                 std::io::ErrorKind::ConnectionAborted,
                 "broker association failed during activation",
             ));
         }
-        *installed = Some(control_cancellation_handle);
+        *installed = Some(cancellation);
         Ok(())
     }
 
@@ -160,13 +160,13 @@ impl BrokerAssociationFailureCoordinator {
             return;
         }
         if let Some(cancellation_handle) = self
-            .control_cancellation_handle
+            .cancellation
             .lock()
-            .expect("broker control cancellation mutex poisoned")
+            .expect("broker association cancellation mutex poisoned")
             .as_ref()
             && let Err(error) = cancellation_handle.cancel()
         {
-            eprintln!("failed to cancel broker control channel: {error}");
+            eprintln!("failed to cancel broker association: {error}");
         }
         let dispatch_failure = self
             .dispatch_failure
@@ -211,8 +211,9 @@ mod tests {
     use litebox_broker_transport::shared_memory::MemfdSharedMemory;
     use litebox_broker_transport::unix_socket::{
         UnixControlRingHostNotificationChannel, UnixControlRingHostRequestSource,
-        UnixControlRingHostResponseSink, UnixControlRingLocalNotificationChannel,
-        UnixStreamHostControlChannel, UnixStreamHostControlShutdown,
+        UnixControlRingHostResponseSink, UnixControlRingHostShutdown,
+        UnixControlRingLocalCancellation, UnixControlRingLocalNotificationChannel,
+        UnixStreamHostControlChannel,
     };
     use std::io::ErrorKind;
     use std::os::fd::AsFd;
@@ -251,12 +252,12 @@ mod tests {
         host_channel: UnixStreamHostControlChannel,
         association_coordinator: &Arc<BrokerAssociationFailureCoordinator>,
     ) -> (
-        UnixStreamLocalControlCancellation,
+        UnixControlRingLocalCancellation,
         UnixControlRingLocalNotificationChannel,
         UnixControlRingHostRequestSource,
         UnixControlRingHostResponseSink,
         UnixControlRingHostNotificationChannel,
-        UnixStreamHostControlShutdown,
+        UnixControlRingHostShutdown,
     ) {
         let local_memory = MemfdSharedMemory::create(CONTROL_RING_MEMORY_SIZE).unwrap();
         let host_memory = MemfdSharedMemory::from_received_fd(
@@ -295,7 +296,7 @@ mod tests {
             negotiate_control_pair(local_control, host_control);
         let association_coordinator = Arc::new(BrokerAssociationFailureCoordinator::new());
         let (
-            control_cancellation_handle,
+            association_cancellation,
             notification_channel,
             host_request_source,
             host_response_sink,
@@ -303,7 +304,7 @@ mod tests {
             host_shutdown,
         ) = activate_control_channel(&mut active_channel, host_control, &association_coordinator);
         association_coordinator
-            .install_control_cancellation_handle(control_cancellation_handle)
+            .install_cancellation(association_cancellation)
             .unwrap();
         let (failure_sender, failure_receiver) = mpsc::sync_channel(1);
         association_coordinator.install_dispatch(move || failure_sender.send(()).unwrap());
@@ -325,7 +326,7 @@ mod tests {
     }
 
     #[test]
-    fn failure_before_installation_cancels_control_and_dispatches_failure() {
+    fn failure_before_installation_cancels_association_and_dispatches_failure() {
         let (local_control, host_control) = UnixStream::pair().unwrap();
         host_control
             .set_read_timeout(Some(Duration::from_secs(1)))
@@ -334,7 +335,7 @@ mod tests {
             negotiate_control_pair(local_control, host_control);
         let association_coordinator = Arc::new(BrokerAssociationFailureCoordinator::new());
         let (
-            control_cancellation_handle,
+            association_cancellation,
             _notification_channel,
             mut host_request_source,
             _host_response_sink,
@@ -346,7 +347,7 @@ mod tests {
 
         assert_eq!(
             association_coordinator
-                .install_control_cancellation_handle(control_cancellation_handle)
+                .install_cancellation(association_cancellation)
                 .unwrap_err()
                 .kind(),
             ErrorKind::ConnectionAborted
@@ -368,7 +369,7 @@ mod tests {
             negotiate_control_pair(local_control, host_control);
         let association_coordinator = Arc::new(BrokerAssociationFailureCoordinator::new());
         let (
-            control_cancellation_handle,
+            association_cancellation,
             notification_channel,
             _host_request_source,
             _host_response_sink,
@@ -376,7 +377,7 @@ mod tests {
             host_shutdown,
         ) = activate_control_channel(&mut active_channel, host_control, &association_coordinator);
         association_coordinator
-            .install_control_cancellation_handle(control_cancellation_handle)
+            .install_cancellation(association_cancellation)
             .unwrap();
         association_coordinator.install_dispatch(|| {});
         let (notification_sender, notification_receiver) = mpsc::sync_channel(1);

--- a/litebox_runner_linux_userland/src/broker.rs
+++ b/litebox_runner_linux_userland/src/broker.rs
@@ -16,8 +16,8 @@ use litebox_broker_protocol::message::BrokerNotification;
 use litebox_broker_protocol::shared_memory::SHARED_BUFFER_POOL_SIZE;
 use litebox_broker_transport::control_ring::{CONTROL_RING_MEMORY_SIZE, ControlRing};
 use litebox_broker_transport::unix_socket::{
-    UnixControlRingLocalCancellation, UnixControlRingLocalControlChannel,
-    UnixControlRingLocalNotificationChannel,
+    UnixControlRingLocalControlChannel, UnixControlRingLocalNotificationChannel,
+    UnixControlRingLocalShutdown,
 };
 
 const SETUP_TIMEOUT: Duration = Duration::from_secs(5);
@@ -58,13 +58,13 @@ pub(crate) fn connect(
             )
         })?;
         let weak_association_coordinator = Arc::downgrade(&association_coordinator);
-        let (association_cancellation, active_notification_channel) =
+        let (association_shutdown, active_notification_channel) =
             channel.activate(control_ring, move || {
                 if let Some(association_coordinator) = weak_association_coordinator.upgrade() {
                     association_coordinator.report_failure();
                 }
             })?;
-        association_coordinator.install_cancellation(association_cancellation)?;
+        association_coordinator.install_shutdown(association_shutdown)?;
         notification_channel = Some(active_notification_channel);
         Ok(Arc::new(shared_memory))
     })
@@ -104,7 +104,7 @@ pub(crate) fn start_notification_receiver(
 
 pub(crate) struct BrokerAssociationFailureCoordinator {
     failed: AtomicBool,
-    cancellation: Mutex<Option<UnixControlRingLocalCancellation>>,
+    shutdown: Mutex<Option<UnixControlRingLocalShutdown>>,
     dispatch_failure: Mutex<Option<Box<dyn FnOnce() + Send>>>,
 }
 
@@ -112,31 +112,28 @@ impl BrokerAssociationFailureCoordinator {
     fn new() -> Self {
         Self {
             failed: AtomicBool::new(false),
-            cancellation: Mutex::new(None),
+            shutdown: Mutex::new(None),
             dispatch_failure: Mutex::new(None),
         }
     }
 
-    fn install_cancellation(
-        &self,
-        cancellation: UnixControlRingLocalCancellation,
-    ) -> std::io::Result<()> {
+    fn install_shutdown(&self, shutdown: UnixControlRingLocalShutdown) -> std::io::Result<()> {
         let mut installed = self
-            .cancellation
+            .shutdown
             .lock()
-            .expect("broker association cancellation mutex poisoned");
+            .expect("broker association shutdown mutex poisoned");
         assert!(
             installed.is_none(),
-            "broker association cancellation already installed"
+            "broker association shutdown already installed"
         );
         if self.failed.load(Ordering::Acquire) {
-            cancellation.cancel()?;
+            shutdown.shutdown()?;
             return Err(std::io::Error::new(
                 std::io::ErrorKind::ConnectionAborted,
                 "broker association failed during activation",
             ));
         }
-        *installed = Some(cancellation);
+        *installed = Some(shutdown);
         Ok(())
     }
 
@@ -161,14 +158,14 @@ impl BrokerAssociationFailureCoordinator {
         if self.failed.swap(true, Ordering::AcqRel) {
             return;
         }
-        if let Some(cancellation_handle) = self
-            .cancellation
+        if let Some(shutdown_handle) = self
+            .shutdown
             .lock()
-            .expect("broker association cancellation mutex poisoned")
+            .expect("broker association shutdown mutex poisoned")
             .as_ref()
-            && let Err(error) = cancellation_handle.cancel()
+            && let Err(error) = shutdown_handle.shutdown()
         {
-            eprintln!("failed to cancel broker association: {error}");
+            eprintln!("failed to shut down broker association: {error}");
         }
         let dispatch_failure = self
             .dispatch_failure
@@ -214,7 +211,7 @@ mod tests {
     use litebox_broker_transport::unix_socket::{
         UnixControlRingHostNotificationChannel, UnixControlRingHostRequestSource,
         UnixControlRingHostResponseSink, UnixControlRingHostShutdown,
-        UnixControlRingLocalCancellation, UnixControlRingLocalNotificationChannel,
+        UnixControlRingLocalNotificationChannel, UnixControlRingLocalShutdown,
         UnixStreamHostSetupChannel,
     };
     use std::io::ErrorKind;
@@ -257,7 +254,7 @@ mod tests {
         host_channel: UnixStreamHostSetupChannel,
         association_coordinator: &Arc<BrokerAssociationFailureCoordinator>,
     ) -> (
-        UnixControlRingLocalCancellation,
+        UnixControlRingLocalShutdown,
         UnixControlRingLocalNotificationChannel,
         UnixControlRingHostRequestSource,
         UnixControlRingHostResponseSink,
@@ -275,22 +272,22 @@ mod tests {
         let host_activation =
             std::thread::spawn(move || host_channel.into_active(host_ring).unwrap());
         let weak_association_coordinator = Arc::downgrade(association_coordinator);
-        let (cancellation, local_notifications) = channel
+        let (local_shutdown, local_notifications) = channel
             .activate(local_ring, move || {
                 if let Some(association_coordinator) = weak_association_coordinator.upgrade() {
                     association_coordinator.report_failure();
                 }
             })
             .unwrap();
-        let (request_source, response_sink, host_notifications, shutdown) =
+        let (request_source, response_sink, host_notifications, host_shutdown) =
             host_activation.join().unwrap();
         (
-            cancellation,
+            local_shutdown,
             local_notifications,
             request_source,
             response_sink,
             host_notifications,
-            shutdown,
+            host_shutdown,
         )
     }
 
@@ -301,7 +298,7 @@ mod tests {
             negotiate_control_pair(local_control, host_control);
         let association_coordinator = Arc::new(BrokerAssociationFailureCoordinator::new());
         let (
-            association_cancellation,
+            association_shutdown,
             notification_channel,
             host_request_source,
             host_response_sink,
@@ -309,7 +306,7 @@ mod tests {
             host_shutdown,
         ) = activate_control_channel(&mut active_channel, host_control, &association_coordinator);
         association_coordinator
-            .install_cancellation(association_cancellation)
+            .install_shutdown(association_shutdown)
             .unwrap();
         let (failure_sender, failure_receiver) = mpsc::sync_channel(1);
         association_coordinator.install_dispatch(move || failure_sender.send(()).unwrap());
@@ -340,7 +337,7 @@ mod tests {
             negotiate_control_pair(local_control, host_control);
         let association_coordinator = Arc::new(BrokerAssociationFailureCoordinator::new());
         let (
-            association_cancellation,
+            association_shutdown,
             _notification_channel,
             mut host_request_source,
             _host_response_sink,
@@ -352,7 +349,7 @@ mod tests {
 
         assert_eq!(
             association_coordinator
-                .install_cancellation(association_cancellation)
+                .install_shutdown(association_shutdown)
                 .unwrap_err()
                 .kind(),
             ErrorKind::ConnectionAborted
@@ -374,7 +371,7 @@ mod tests {
             negotiate_control_pair(local_control, host_control);
         let association_coordinator = Arc::new(BrokerAssociationFailureCoordinator::new());
         let (
-            association_cancellation,
+            association_shutdown,
             notification_channel,
             _host_request_source,
             _host_response_sink,
@@ -382,7 +379,7 @@ mod tests {
             host_shutdown,
         ) = activate_control_channel(&mut active_channel, host_control, &association_coordinator);
         association_coordinator
-            .install_cancellation(association_cancellation)
+            .install_shutdown(association_shutdown)
             .unwrap();
         association_coordinator.install_dispatch(|| {});
         let (notification_sender, notification_receiver) = mpsc::sync_channel(1);

--- a/litebox_runner_linux_userland/src/broker.rs
+++ b/litebox_runner_linux_userland/src/broker.rs
@@ -44,8 +44,7 @@ pub(crate) fn connect(
         )
     })?;
     let association_coordinator = Arc::new(BrokerAssociationFailureCoordinator::new());
-    let mut notification_channel = None;
-    let local = BrokerLocal::negotiate(setup_channel, |mut setup| {
+    let (local, notification_channel) = BrokerLocal::negotiate(setup_channel, |mut setup| {
         let shared_memory = setup.receive_memfd(SHARED_BUFFER_POOL_SIZE, Some(setup_deadline))?;
         let control_memory = setup.receive_memfd(CONTROL_RING_MEMORY_SIZE, Some(setup_deadline))?;
         let control_ring = ControlRing::new(control_memory).map_err(|error| {
@@ -55,19 +54,16 @@ pub(crate) fn connect(
             )
         })?;
         let weak_association_coordinator = Arc::downgrade(&association_coordinator);
-        let (call_channel, active_notification_channel, association_shutdown) =
+        let (call_channel, notification_channel, association_shutdown) =
             setup.into_active(control_ring, move || {
                 if let Some(association_coordinator) = weak_association_coordinator.upgrade() {
                     association_coordinator.report_failure();
                 }
             })?;
         association_coordinator.install_shutdown(association_shutdown)?;
-        notification_channel = Some(active_notification_channel);
-        Ok((call_channel, Arc::new(shared_memory)))
+        Ok((call_channel, Arc::new(shared_memory), notification_channel))
     })
     .context("broker negotiation failed")?;
-    let notification_channel =
-        notification_channel.expect("successful broker activation must return notifications");
     Ok((
         local,
         BrokerNotifications::new(notification_channel),

--- a/litebox_runner_linux_userland/src/broker.rs
+++ b/litebox_runner_linux_userland/src/broker.rs
@@ -16,8 +16,8 @@ use litebox_broker_protocol::message::BrokerNotification;
 use litebox_broker_protocol::shared_memory::SHARED_BUFFER_POOL_SIZE;
 use litebox_broker_transport::control_ring::{CONTROL_RING_MEMORY_SIZE, ControlRing};
 use litebox_broker_transport::unix_socket::{
-    UnixControlRingLocalControlChannel, UnixControlRingLocalNotificationChannel,
-    UnixControlRingLocalShutdown,
+    UnixControlRingLocalCallChannel, UnixControlRingLocalNotificationChannel,
+    UnixControlRingLocalShutdown, UnixStreamLocalSetupChannel,
 };
 
 const SETUP_TIMEOUT: Duration = Duration::from_secs(5);
@@ -26,18 +26,16 @@ const RETRY_DELAY: Duration = Duration::from_millis(20);
 pub(crate) fn connect(
     control_socket_path: &Path,
 ) -> Result<(
-    BrokerLocal<UnixControlRingLocalControlChannel>,
+    BrokerLocal<UnixControlRingLocalCallChannel>,
     BrokerNotifications<UnixControlRingLocalNotificationChannel>,
     Arc<BrokerAssociationFailureCoordinator>,
 )> {
     let setup_deadline = Instant::now() + SETUP_TIMEOUT;
-    let control_channel = connect_with_retry(
+    let setup_channel = connect_with_retry(
         control_socket_path,
         setup_deadline,
         "timed out connecting to broker",
-        |path, deadline| {
-            UnixControlRingLocalControlChannel::connect_with_setup_deadline(path, deadline)
-        },
+        |path, deadline| UnixStreamLocalSetupChannel::connect_with_setup_deadline(path, deadline),
     )
     .with_context(|| {
         format!(
@@ -47,10 +45,9 @@ pub(crate) fn connect(
     })?;
     let association_coordinator = Arc::new(BrokerAssociationFailureCoordinator::new());
     let mut notification_channel = None;
-    let local = BrokerLocal::negotiate(control_channel, |channel| {
-        let shared_memory = channel.receive_memfd(SHARED_BUFFER_POOL_SIZE, Some(setup_deadline))?;
-        let control_memory =
-            channel.receive_memfd(CONTROL_RING_MEMORY_SIZE, Some(setup_deadline))?;
+    let local = BrokerLocal::negotiate(setup_channel, |mut setup| {
+        let shared_memory = setup.receive_memfd(SHARED_BUFFER_POOL_SIZE, Some(setup_deadline))?;
+        let control_memory = setup.receive_memfd(CONTROL_RING_MEMORY_SIZE, Some(setup_deadline))?;
         let control_ring = ControlRing::new(control_memory).map_err(|error| {
             std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
@@ -58,15 +55,15 @@ pub(crate) fn connect(
             )
         })?;
         let weak_association_coordinator = Arc::downgrade(&association_coordinator);
-        let (association_shutdown, active_notification_channel) =
-            channel.activate(control_ring, move || {
+        let (call_channel, active_notification_channel, association_shutdown) =
+            setup.into_active(control_ring, move || {
                 if let Some(association_coordinator) = weak_association_coordinator.upgrade() {
                     association_coordinator.report_failure();
                 }
             })?;
         association_coordinator.install_shutdown(association_shutdown)?;
         notification_channel = Some(active_notification_channel);
-        Ok(Arc::new(shared_memory))
+        Ok((call_channel, Arc::new(shared_memory)))
     })
     .context("broker negotiation failed")?;
     let notification_channel =
@@ -203,7 +200,7 @@ mod tests {
     use super::*;
     use litebox_broker_protocol::ObjectHandle;
     use litebox_broker_protocol::channel::{
-        HostNotificationChannel, HostReceive, HostSetupChannel, LocalControlChannel,
+        HostNotificationChannel, HostReceive, HostSetupChannel, LocalSetupChannel,
     };
     use litebox_broker_protocol::message::{BrokerNotification, ReadinessNotification};
     use litebox_broker_protocol::readiness::ReadinessFlags;
@@ -211,8 +208,8 @@ mod tests {
     use litebox_broker_transport::unix_socket::{
         UnixControlRingHostNotificationChannel, UnixControlRingHostRequestSource,
         UnixControlRingHostResponseSink, UnixControlRingHostShutdown,
-        UnixControlRingLocalNotificationChannel, UnixControlRingLocalShutdown,
-        UnixStreamHostSetupChannel,
+        UnixControlRingLocalCallChannel, UnixControlRingLocalNotificationChannel,
+        UnixControlRingLocalShutdown, UnixStreamHostSetupChannel, UnixStreamLocalSetupChannel,
     };
     use std::io::ErrorKind;
     use std::os::fd::AsFd;
@@ -222,11 +219,8 @@ mod tests {
     fn negotiate_control_pair(
         local_stream: UnixStream,
         host_stream: UnixStream,
-    ) -> (
-        UnixControlRingLocalControlChannel,
-        UnixStreamHostSetupChannel,
-    ) {
-        let mut local = UnixControlRingLocalControlChannel::from_connected(local_stream);
+    ) -> (UnixStreamLocalSetupChannel, UnixStreamHostSetupChannel) {
+        let mut local = UnixStreamLocalSetupChannel::from_connected(local_stream);
         let mut host = UnixStreamHostSetupChannel::from_accepted(host_stream);
         let request = litebox_broker_protocol::message::BrokerHandshakeRequest {
             protocol_version: litebox_broker_protocol::BROKER_PROTOCOL_VERSION,
@@ -250,10 +244,11 @@ mod tests {
     }
 
     fn activate_control_channel(
-        channel: &mut UnixControlRingLocalControlChannel,
+        setup: UnixStreamLocalSetupChannel,
         host_channel: UnixStreamHostSetupChannel,
         association_coordinator: &Arc<BrokerAssociationFailureCoordinator>,
     ) -> (
+        UnixControlRingLocalCallChannel,
         UnixControlRingLocalShutdown,
         UnixControlRingLocalNotificationChannel,
         UnixControlRingHostRequestSource,
@@ -272,8 +267,8 @@ mod tests {
         let host_activation =
             std::thread::spawn(move || host_channel.into_active(host_ring).unwrap());
         let weak_association_coordinator = Arc::downgrade(association_coordinator);
-        let (local_shutdown, local_notifications) = channel
-            .activate(local_ring, move || {
+        let (local_call, local_notifications, local_shutdown) = setup
+            .into_active(local_ring, move || {
                 if let Some(association_coordinator) = weak_association_coordinator.upgrade() {
                     association_coordinator.report_failure();
                 }
@@ -282,6 +277,7 @@ mod tests {
         let (request_source, response_sink, host_notifications, host_shutdown) =
             host_activation.join().unwrap();
         (
+            local_call,
             local_shutdown,
             local_notifications,
             request_source,
@@ -294,17 +290,17 @@ mod tests {
     #[test]
     fn control_failure_cancels_notifications() {
         let (local_control, host_control) = UnixStream::pair().unwrap();
-        let (mut active_channel, host_control) =
-            negotiate_control_pair(local_control, host_control);
+        let (local_setup, host_control) = negotiate_control_pair(local_control, host_control);
         let association_coordinator = Arc::new(BrokerAssociationFailureCoordinator::new());
         let (
+            active_channel,
             association_shutdown,
             notification_channel,
             host_request_source,
             host_response_sink,
             _host_notifications,
             host_shutdown,
-        ) = activate_control_channel(&mut active_channel, host_control, &association_coordinator);
+        ) = activate_control_channel(local_setup, host_control, &association_coordinator);
         association_coordinator
             .install_shutdown(association_shutdown)
             .unwrap();
@@ -333,17 +329,17 @@ mod tests {
         host_control
             .set_read_timeout(Some(Duration::from_secs(1)))
             .unwrap();
-        let (mut active_channel, host_control) =
-            negotiate_control_pair(local_control, host_control);
+        let (local_setup, host_control) = negotiate_control_pair(local_control, host_control);
         let association_coordinator = Arc::new(BrokerAssociationFailureCoordinator::new());
         let (
+            active_channel,
             association_shutdown,
             _notification_channel,
             mut host_request_source,
             _host_response_sink,
             _host_notifications,
             _host_shutdown,
-        ) = activate_control_channel(&mut active_channel, host_control, &association_coordinator);
+        ) = activate_control_channel(local_setup, host_control, &association_coordinator);
 
         association_coordinator.report_failure();
 
@@ -367,17 +363,17 @@ mod tests {
     #[test]
     fn notification_receiver_dispatches_ring_message() {
         let (local_control, host_control) = UnixStream::pair().unwrap();
-        let (mut active_channel, host_control) =
-            negotiate_control_pair(local_control, host_control);
+        let (local_setup, host_control) = negotiate_control_pair(local_control, host_control);
         let association_coordinator = Arc::new(BrokerAssociationFailureCoordinator::new());
         let (
+            active_channel,
             association_shutdown,
             notification_channel,
             _host_request_source,
             _host_response_sink,
             mut host_notifications,
             host_shutdown,
-        ) = activate_control_channel(&mut active_channel, host_control, &association_coordinator);
+        ) = activate_control_channel(local_setup, host_control, &association_coordinator);
         association_coordinator
             .install_shutdown(association_shutdown)
             .unwrap();

--- a/litebox_runner_linux_userland/src/broker.rs
+++ b/litebox_runner_linux_userland/src/broker.rs
@@ -16,8 +16,8 @@ use litebox_broker_protocol::message::BrokerNotification;
 use litebox_broker_protocol::shared_memory::SHARED_BUFFER_POOL_SIZE;
 use litebox_broker_transport::control_ring::{CONTROL_RING_MEMORY_SIZE, ControlRing};
 use litebox_broker_transport::unix_socket::{
-    UnixStreamLocalControlCancellation, UnixStreamLocalControlChannel,
-    UnixStreamLocalNotificationCancellation, UnixStreamLocalNotificationChannel,
+    UnixControlRingLocalNotificationChannel, UnixStreamLocalControlCancellation,
+    UnixStreamLocalControlChannel,
 };
 
 const SETUP_TIMEOUT: Duration = Duration::from_secs(5);
@@ -25,10 +25,9 @@ const RETRY_DELAY: Duration = Duration::from_millis(20);
 
 pub(crate) fn connect(
     control_socket_path: &Path,
-    notification_socket_path: &Path,
 ) -> Result<(
     BrokerLocal<UnixStreamLocalControlChannel>,
-    BrokerNotifications<UnixStreamLocalNotificationChannel>,
+    BrokerNotifications<UnixControlRingLocalNotificationChannel>,
     Arc<BrokerAssociationFailureCoordinator>,
 )> {
     let setup_deadline = Instant::now() + SETUP_TIMEOUT;
@@ -44,49 +43,32 @@ pub(crate) fn connect(
             control_socket_path.display()
         )
     })?;
-    let notification_channel = connect_with_retry(
-        notification_socket_path,
-        setup_deadline,
-        "timed out connecting to broker notifications",
-        |path, _deadline| UnixStreamLocalNotificationChannel::connect(path),
-    )
-    .with_context(|| {
-        format!(
-            "failed to connect to broker notifications at {}",
-            notification_socket_path.display()
-        )
-    })?;
-    let notification_cancellation_handle = notification_channel
-        .cancellation_handle()
-        .context("failed to create broker notification cancellation handle")?;
-    let association_coordinator = Arc::new(BrokerAssociationFailureCoordinator::new(
-        notification_cancellation_handle,
-    ));
-    let local = BrokerLocal::negotiate(control_channel, {
-        let association_coordinator = Arc::clone(&association_coordinator);
-        move |channel| {
-            let shared_memory =
-                channel.receive_memfd(SHARED_BUFFER_POOL_SIZE, Some(setup_deadline))?;
-            let control_memory =
-                channel.receive_memfd(CONTROL_RING_MEMORY_SIZE, Some(setup_deadline))?;
-            let control_ring = ControlRing::new(control_memory).map_err(|error| {
-                std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    format!("invalid broker control ring: {error:?}"),
-                )
-            })?;
-            let weak_association_coordinator = Arc::downgrade(&association_coordinator);
-            let control_cancellation_handle = channel.activate(control_ring, move || {
+    let association_coordinator = Arc::new(BrokerAssociationFailureCoordinator::new());
+    let mut notification_channel = None;
+    let local = BrokerLocal::negotiate(control_channel, |channel| {
+        let shared_memory = channel.receive_memfd(SHARED_BUFFER_POOL_SIZE, Some(setup_deadline))?;
+        let control_memory =
+            channel.receive_memfd(CONTROL_RING_MEMORY_SIZE, Some(setup_deadline))?;
+        let control_ring = ControlRing::new(control_memory).map_err(|error| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("invalid broker control ring: {error:?}"),
+            )
+        })?;
+        let weak_association_coordinator = Arc::downgrade(&association_coordinator);
+        let (control_cancellation_handle, active_notification_channel) =
+            channel.activate(control_ring, move || {
                 if let Some(association_coordinator) = weak_association_coordinator.upgrade() {
                     association_coordinator.report_failure();
                 }
             })?;
-            association_coordinator
-                .install_control_cancellation_handle(control_cancellation_handle)?;
-            Ok(Arc::new(shared_memory))
-        }
+        association_coordinator.install_control_cancellation_handle(control_cancellation_handle)?;
+        notification_channel = Some(active_notification_channel);
+        Ok(Arc::new(shared_memory))
     })
     .context("broker negotiation failed")?;
+    let notification_channel =
+        notification_channel.expect("successful broker activation must return notifications");
     Ok((
         local,
         BrokerNotifications::new(notification_channel),
@@ -95,7 +77,7 @@ pub(crate) fn connect(
 }
 
 pub(crate) fn start_notification_receiver(
-    mut notifications: BrokerNotifications<UnixStreamLocalNotificationChannel>,
+    mut notifications: BrokerNotifications<UnixControlRingLocalNotificationChannel>,
     association_coordinator: Arc<BrokerAssociationFailureCoordinator>,
     dispatch_notification: impl Fn(BrokerNotification) + Send + 'static,
 ) -> Result<()> {
@@ -121,16 +103,14 @@ pub(crate) fn start_notification_receiver(
 pub(crate) struct BrokerAssociationFailureCoordinator {
     failed: AtomicBool,
     control_cancellation_handle: Mutex<Option<UnixStreamLocalControlCancellation>>,
-    notification_cancellation_handle: UnixStreamLocalNotificationCancellation,
     dispatch_failure: Mutex<Option<Box<dyn FnOnce() + Send>>>,
 }
 
 impl BrokerAssociationFailureCoordinator {
-    fn new(notification_cancellation_handle: UnixStreamLocalNotificationCancellation) -> Self {
+    fn new() -> Self {
         Self {
             failed: AtomicBool::new(false),
             control_cancellation_handle: Mutex::new(None),
-            notification_cancellation_handle,
             dispatch_failure: Mutex::new(None),
         }
     }
@@ -188,9 +168,6 @@ impl BrokerAssociationFailureCoordinator {
         {
             eprintln!("failed to cancel broker control channel: {error}");
         }
-        if let Err(error) = self.notification_cancellation_handle.cancel() {
-            eprintln!("failed to cancel broker notification channel: {error}");
-        }
         let dispatch_failure = self
             .dispatch_failure
             .lock()
@@ -225,15 +202,19 @@ fn connect_with_retry<Channel>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use litebox_broker_protocol::channel::{HostReceive, HostSetupChannel, LocalControlChannel};
-    use litebox_broker_protocol::message::{BrokerOperation, BrokerRequest};
-    use litebox_broker_protocol::{ObjectHandle, RequestId};
+    use litebox_broker_protocol::ObjectHandle;
+    use litebox_broker_protocol::channel::{
+        HostNotificationChannel, HostReceive, HostSetupChannel, LocalControlChannel,
+    };
+    use litebox_broker_protocol::message::{BrokerNotification, ReadinessNotification};
+    use litebox_broker_protocol::readiness::ReadinessFlags;
     use litebox_broker_transport::shared_memory::MemfdSharedMemory;
     use litebox_broker_transport::unix_socket::{
+        UnixControlRingHostNotificationChannel, UnixControlRingLocalNotificationChannel,
         UnixStreamHostControlChannel, UnixStreamHostControlShutdown, UnixStreamHostRequestSource,
         UnixStreamHostResponseSink,
     };
-    use std::io::{ErrorKind, Read};
+    use std::io::ErrorKind;
     use std::os::fd::AsFd;
     use std::os::unix::net::UnixStream;
     use std::sync::mpsc;
@@ -271,8 +252,10 @@ mod tests {
         association_coordinator: &Arc<BrokerAssociationFailureCoordinator>,
     ) -> (
         UnixStreamLocalControlCancellation,
+        UnixControlRingLocalNotificationChannel,
         UnixStreamHostRequestSource,
         UnixStreamHostResponseSink,
+        UnixControlRingHostNotificationChannel,
         UnixStreamHostControlShutdown,
     ) {
         let local_memory = MemfdSharedMemory::create(CONTROL_RING_MEMORY_SIZE).unwrap();
@@ -286,15 +269,23 @@ mod tests {
         let host_activation =
             std::thread::spawn(move || host_channel.into_active(host_ring).unwrap());
         let weak_association_coordinator = Arc::downgrade(association_coordinator);
-        let cancellation = channel
+        let (cancellation, local_notifications) = channel
             .activate(local_ring, move || {
                 if let Some(association_coordinator) = weak_association_coordinator.upgrade() {
                     association_coordinator.report_failure();
                 }
             })
             .unwrap();
-        let (request_source, response_sink, shutdown) = host_activation.join().unwrap();
-        (cancellation, request_source, response_sink, shutdown)
+        let (request_source, response_sink, host_notifications, shutdown) =
+            host_activation.join().unwrap();
+        (
+            cancellation,
+            local_notifications,
+            request_source,
+            response_sink,
+            host_notifications,
+            shutdown,
+        )
     }
 
     #[test]
@@ -302,22 +293,26 @@ mod tests {
         let (local_control, host_control) = UnixStream::pair().unwrap();
         let (mut active_channel, host_control) =
             negotiate_control_pair(local_control, host_control);
-        let (local_notification, mut host_notification) = UnixStream::pair().unwrap();
-        host_notification
-            .set_read_timeout(Some(Duration::from_secs(1)))
-            .unwrap();
-        let notification_channel =
-            UnixStreamLocalNotificationChannel::from_connected(local_notification);
-        let association_coordinator = Arc::new(BrokerAssociationFailureCoordinator::new(
-            notification_channel.cancellation_handle().unwrap(),
-        ));
-        let (control_cancellation_handle, host_request_source, host_response_sink, host_shutdown) =
-            activate_control_channel(&mut active_channel, host_control, &association_coordinator);
+        let association_coordinator = Arc::new(BrokerAssociationFailureCoordinator::new());
+        let (
+            control_cancellation_handle,
+            notification_channel,
+            host_request_source,
+            host_response_sink,
+            _host_notifications,
+            host_shutdown,
+        ) = activate_control_channel(&mut active_channel, host_control, &association_coordinator);
         association_coordinator
             .install_control_cancellation_handle(control_cancellation_handle)
             .unwrap();
         let (failure_sender, failure_receiver) = mpsc::sync_channel(1);
         association_coordinator.install_dispatch(move || failure_sender.send(()).unwrap());
+        start_notification_receiver(
+            BrokerNotifications::new(notification_channel),
+            Arc::clone(&association_coordinator),
+            |_| {},
+        )
+        .unwrap();
 
         host_shutdown.shutdown().unwrap();
         drop(host_request_source);
@@ -326,10 +321,7 @@ mod tests {
         failure_receiver
             .recv_timeout(Duration::from_secs(1))
             .unwrap();
-        let mut byte = [0];
-        assert_eq!(host_notification.read(&mut byte).unwrap(), 0);
         drop(active_channel);
-        drop(notification_channel);
     }
 
     #[test]
@@ -340,19 +332,13 @@ mod tests {
             .unwrap();
         let (mut active_channel, host_control) =
             negotiate_control_pair(local_control, host_control);
-        let (local_notification, mut host_notification) = UnixStream::pair().unwrap();
-        host_notification
-            .set_read_timeout(Some(Duration::from_secs(1)))
-            .unwrap();
-        let notification_channel =
-            UnixStreamLocalNotificationChannel::from_connected(local_notification);
-        let association_coordinator = Arc::new(BrokerAssociationFailureCoordinator::new(
-            notification_channel.cancellation_handle().unwrap(),
-        ));
+        let association_coordinator = Arc::new(BrokerAssociationFailureCoordinator::new());
         let (
             control_cancellation_handle,
+            _notification_channel,
             mut host_request_source,
             _host_response_sink,
+            _host_notifications,
             _host_shutdown,
         ) = activate_control_channel(&mut active_channel, host_control, &association_coordinator);
 
@@ -372,62 +358,48 @@ mod tests {
             host_request_source.recv_request().unwrap(),
             HostReceive::PeerClosed
         );
-        let mut byte = [0];
-        assert_eq!(host_notification.read(&mut byte).unwrap(), 0);
         drop(active_channel);
-        drop(notification_channel);
     }
 
     #[test]
-    fn notification_failure_cancels_control() {
+    fn notification_receiver_dispatches_ring_message() {
         let (local_control, host_control) = UnixStream::pair().unwrap();
         let (mut active_channel, host_control) =
             negotiate_control_pair(local_control, host_control);
-        let (local_notification, host_notification) = UnixStream::pair().unwrap();
-        let notification_channel =
-            UnixStreamLocalNotificationChannel::from_connected(local_notification);
-        let association_coordinator = Arc::new(BrokerAssociationFailureCoordinator::new(
-            notification_channel.cancellation_handle().unwrap(),
-        ));
+        let association_coordinator = Arc::new(BrokerAssociationFailureCoordinator::new());
         let (
             control_cancellation_handle,
-            mut host_request_source,
+            notification_channel,
+            _host_request_source,
             _host_response_sink,
-            _host_shutdown,
+            mut host_notifications,
+            host_shutdown,
         ) = activate_control_channel(&mut active_channel, host_control, &association_coordinator);
         association_coordinator
             .install_control_cancellation_handle(control_cancellation_handle)
             .unwrap();
-        let (failure_sender, failure_receiver) = mpsc::sync_channel(1);
-        association_coordinator.install_dispatch(move || failure_sender.send(()).unwrap());
+        association_coordinator.install_dispatch(|| {});
+        let (notification_sender, notification_receiver) = mpsc::sync_channel(1);
         start_notification_receiver(
             BrokerNotifications::new(notification_channel),
             Arc::clone(&association_coordinator),
-            |_| {},
+            move |notification| notification_sender.send(notification).unwrap(),
         )
         .unwrap();
-        let active_channel = Arc::new(active_channel);
-        let pending_channel = Arc::clone(&active_channel);
-        let pending_call = std::thread::spawn(move || {
-            pending_channel.call(BrokerRequest {
-                request_id: RequestId(1),
-                operation: BrokerOperation::CloseObject(ObjectHandle(1)),
-            })
+        let notification = BrokerNotification::Readiness(ReadinessNotification {
+            handle: ObjectHandle(7),
+            readiness: ReadinessFlags::READ,
         });
-        assert!(matches!(
-            host_request_source.recv_request().unwrap(),
-            HostReceive::Message(_)
-        ));
 
-        drop(host_notification);
+        host_notifications.send_notification(&notification).unwrap();
 
-        failure_receiver
-            .recv_timeout(Duration::from_secs(1))
-            .unwrap();
-        assert!(pending_call.join().unwrap().is_err());
         assert_eq!(
-            host_request_source.recv_request().unwrap(),
-            HostReceive::PeerClosed
+            notification_receiver
+                .recv_timeout(Duration::from_secs(1))
+                .unwrap(),
+            notification
         );
+        host_shutdown.shutdown().unwrap();
+        drop(active_channel);
     }
 }

--- a/litebox_runner_linux_userland/src/broker.rs
+++ b/litebox_runner_linux_userland/src/broker.rs
@@ -16,8 +16,8 @@ use litebox_broker_protocol::message::BrokerNotification;
 use litebox_broker_protocol::shared_memory::SHARED_BUFFER_POOL_SIZE;
 use litebox_broker_transport::control_ring::{CONTROL_RING_MEMORY_SIZE, ControlRing};
 use litebox_broker_transport::unix_socket::{
-    UnixControlRingLocalCancellation, UnixControlRingLocalNotificationChannel,
-    UnixStreamLocalControlChannel,
+    UnixControlRingLocalCancellation, UnixControlRingLocalControlChannel,
+    UnixControlRingLocalNotificationChannel,
 };
 
 const SETUP_TIMEOUT: Duration = Duration::from_secs(5);
@@ -26,7 +26,7 @@ const RETRY_DELAY: Duration = Duration::from_millis(20);
 pub(crate) fn connect(
     control_socket_path: &Path,
 ) -> Result<(
-    BrokerLocal<UnixStreamLocalControlChannel>,
+    BrokerLocal<UnixControlRingLocalControlChannel>,
     BrokerNotifications<UnixControlRingLocalNotificationChannel>,
     Arc<BrokerAssociationFailureCoordinator>,
 )> {
@@ -35,7 +35,9 @@ pub(crate) fn connect(
         control_socket_path,
         setup_deadline,
         "timed out connecting to broker",
-        |path, deadline| UnixStreamLocalControlChannel::connect_with_setup_deadline(path, deadline),
+        |path, deadline| {
+            UnixControlRingLocalControlChannel::connect_with_setup_deadline(path, deadline)
+        },
     )
     .with_context(|| {
         format!(
@@ -213,7 +215,7 @@ mod tests {
         UnixControlRingHostNotificationChannel, UnixControlRingHostRequestSource,
         UnixControlRingHostResponseSink, UnixControlRingHostShutdown,
         UnixControlRingLocalCancellation, UnixControlRingLocalNotificationChannel,
-        UnixStreamHostControlChannel,
+        UnixStreamHostSetupChannel,
     };
     use std::io::ErrorKind;
     use std::os::fd::AsFd;
@@ -223,9 +225,12 @@ mod tests {
     fn negotiate_control_pair(
         local_stream: UnixStream,
         host_stream: UnixStream,
-    ) -> (UnixStreamLocalControlChannel, UnixStreamHostControlChannel) {
-        let mut local = UnixStreamLocalControlChannel::from_connected(local_stream);
-        let mut host = UnixStreamHostControlChannel::from_accepted(host_stream);
+    ) -> (
+        UnixControlRingLocalControlChannel,
+        UnixStreamHostSetupChannel,
+    ) {
+        let mut local = UnixControlRingLocalControlChannel::from_connected(local_stream);
+        let mut host = UnixStreamHostSetupChannel::from_accepted(host_stream);
         let request = litebox_broker_protocol::message::BrokerHandshakeRequest {
             protocol_version: litebox_broker_protocol::BROKER_PROTOCOL_VERSION,
         };
@@ -248,8 +253,8 @@ mod tests {
     }
 
     fn activate_control_channel(
-        channel: &mut UnixStreamLocalControlChannel,
-        host_channel: UnixStreamHostControlChannel,
+        channel: &mut UnixControlRingLocalControlChannel,
+        host_channel: UnixStreamHostSetupChannel,
         association_coordinator: &Arc<BrokerAssociationFailureCoordinator>,
     ) -> (
         UnixControlRingLocalCancellation,

--- a/litebox_runner_linux_userland/src/lib.rs
+++ b/litebox_runner_linux_userland/src/lib.rs
@@ -85,20 +85,10 @@ pub struct CliArgs {
         value_name = "PATH",
         value_hint = clap::ValueHint::FilePath,
         hide = true,
-        requires_all = ["unstable", "broker_notification_socket"],
+        requires = "unstable",
         help_heading = "Unstable Options"
     )]
     pub broker_control_socket: Option<PathBuf>,
-    /// Broker-supplied Unix socket path for the local notification channel.
-    #[arg(
-        long = "broker-notification-socket",
-        value_name = "PATH",
-        value_hint = clap::ValueHint::FilePath,
-        hide = true,
-        requires_all = ["unstable", "broker_control_socket"],
-        help_heading = "Unstable Options"
-    )]
-    pub broker_notification_socket: Option<PathBuf>,
 }
 
 struct MmappedFile {
@@ -159,21 +149,9 @@ pub fn run(cli_args: CliArgs) -> Result<()> {
         );
     }
 
-    let broker_connection = match (
-        cli_args.broker_control_socket.as_deref(),
-        cli_args.broker_notification_socket.as_deref(),
-    ) {
-        (Some(control_socket_path), Some(notification_socket_path)) => Some(broker::connect(
-            control_socket_path,
-            notification_socket_path,
-        )?),
-        (None, None) => None,
-        (Some(_), None) => {
-            anyhow::bail!("broker notification socket is required with broker control socket")
-        }
-        (None, Some(_)) => {
-            anyhow::bail!("broker control socket is required with broker notification socket")
-        }
+    let broker_connection = match cli_args.broker_control_socket.as_deref() {
+        Some(control_socket_path) => Some(broker::connect(control_socket_path)?),
+        None => None,
     };
 
     let mut cow_eligible_regions: Vec<MmappedFile> = Vec::new();

--- a/litebox_runner_linux_userland/tests/run.rs
+++ b/litebox_runner_linux_userland/tests/run.rs
@@ -119,17 +119,10 @@ impl Runner {
     }
 
     #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
-    fn broker_sockets(
-        &mut self,
-        control_socket_path: &Path,
-        notification_socket_path: &Path,
-    ) -> &mut Self {
+    fn broker_socket(&mut self, control_socket_path: &Path) -> &mut Self {
         self.command
             .arg("--broker-control-socket")
             .arg(control_socket_path);
-        self.command
-            .arg("--broker-notification-socket")
-            .arg(notification_socket_path);
         self
     }
 
@@ -312,7 +305,6 @@ struct TestBroker {
     done_rx: std::sync::mpsc::Receiver<()>,
     close_object_count_rx: std::sync::mpsc::Receiver<usize>,
     control_socket_path: PathBuf,
-    notification_socket_path: PathBuf,
 }
 
 #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
@@ -333,7 +325,6 @@ impl TestBroker {
             .join()
             .expect("broker test host panicked");
         let _ = std::fs::remove_file(&self.control_socket_path);
-        let _ = std::fs::remove_file(&self.notification_socket_path);
     }
 }
 
@@ -341,35 +332,27 @@ impl TestBroker {
 impl Drop for TestBroker {
     fn drop(&mut self) {
         let _ = std::fs::remove_file(&self.control_socket_path);
-        let _ = std::fs::remove_file(&self.notification_socket_path);
     }
 }
 
 #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
 fn spawn_test_broker(
     control_socket_path: &Path,
-    notification_socket_path: &Path,
     policy: litebox_broker_core::PolicyEngine,
     connection_count: usize,
 ) -> TestBroker {
     let _ = std::fs::remove_file(control_socket_path);
-    let _ = std::fs::remove_file(notification_socket_path);
 
     let (ready_tx, ready_rx) = std::sync::mpsc::channel();
     let (done_tx, done_rx) = std::sync::mpsc::channel();
     let (close_object_count_tx, close_object_count_rx) = std::sync::mpsc::channel();
     let server_control_socket_path = control_socket_path.to_path_buf();
-    let server_notification_socket_path = notification_socket_path.to_path_buf();
     let cleanup_control_socket_path = control_socket_path.to_path_buf();
-    let cleanup_notification_socket_path = notification_socket_path.to_path_buf();
     let broker_thread = std::thread::spawn(move || {
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let control_listener =
                 std::os::unix::net::UnixListener::bind(&server_control_socket_path)
                     .expect("failed to bind broker test control socket");
-            let notification_listener =
-                std::os::unix::net::UnixListener::bind(&server_notification_socket_path)
-                    .expect("failed to bind broker test notification socket");
             let broker =
                 litebox_broker_core::BrokerCore::new(policy).expect("failed to create broker core");
             ready_tx.send(()).expect("failed to report broker ready");
@@ -396,33 +379,17 @@ fn spawn_test_broker(
                 let control_ring =
                     litebox_broker_transport::control_ring::ControlRing::new(control_memory)
                         .expect("failed to attach broker test control ring");
-                let (notification_stream, _) = notification_listener
-                    .accept()
-                    .expect("failed to accept broker local notification connection");
-                litebox_broker_transport::unix_socket::validate_same_peer_process(
-                    &control_stream,
-                    &notification_stream,
-                )
-                .expect("broker channels must belong to the same runner process");
                 control_stream
                     .set_read_timeout(Some(BROKER_HELPER_TIMEOUT))
                     .expect("failed to configure broker test read timeout");
                 control_stream
                     .set_write_timeout(Some(BROKER_HELPER_TIMEOUT))
                     .expect("failed to configure broker test write timeout");
-                notification_stream
-                    .set_read_timeout(Some(BROKER_HELPER_TIMEOUT))
-                    .expect("failed to configure broker notification test read timeout");
-                notification_stream
-                    .set_write_timeout(Some(BROKER_HELPER_TIMEOUT))
-                    .expect("failed to configure broker notification test write timeout");
                 let mut channel =
                     litebox_broker_transport::unix_socket::UnixStreamHostControlChannel::from_host_guaranteed(
                         control_stream,
                         std::time::Instant::now() + BROKER_HELPER_TIMEOUT,
                     );
-                let _notification_channel =
-                    litebox_broker_transport::unix_socket::UnixStreamHostNotificationChannel::from_accepted(notification_stream);
                 let association = litebox_broker_host::setup_connection(
                     &broker,
                     &mut channel,
@@ -434,7 +401,7 @@ fn spawn_test_broker(
                 )
                 .expect("broker host setup failed")
                 .expect("broker setup terminated before activation");
-                let (mut request_source, response_sink, _shutdown) = channel
+                let (mut request_source, response_sink, _notifications, _shutdown) = channel
                     .into_active(control_ring)
                     .expect("failed to activate broker test control ring");
                 let mut close_object_count = 0;
@@ -474,7 +441,6 @@ fn spawn_test_broker(
             }
         }));
         let _ = std::fs::remove_file(&server_control_socket_path);
-        let _ = std::fs::remove_file(&server_notification_socket_path);
         let _ = done_tx.send(());
         if let Err(panic) = result {
             std::panic::resume_unwind(panic);
@@ -489,7 +455,6 @@ fn spawn_test_broker(
         done_rx,
         close_object_count_rx,
         control_socket_path: cleanup_control_socket_path,
-        notification_socket_path: cleanup_notification_socket_path,
     }
 }
 
@@ -513,10 +478,8 @@ console.log(content);
         false,
     );
     let control_socket_path = unique_test_socket_path("runner-broker-control");
-    let notification_socket_path = unique_test_socket_path("runner-broker-notification");
     let broker_thread = spawn_test_broker(
         &control_socket_path,
-        &notification_socket_path,
         litebox_broker_core::PolicyEngine::with_host_guaranteed_rights(
             litebox_broker_core::ObjectRights::all(),
         ),
@@ -524,24 +487,24 @@ console.log(content);
     );
 
     Runner::new(&true_path, "broker_true_rewriter")
-        .broker_sockets(&control_socket_path, &notification_socket_path)
+        .broker_socket(&control_socket_path)
         .run();
     assert_eq!(broker_thread.next_close_object_count(), 0);
 
     Runner::new(&target, "broker_eventfd_rewriter")
-        .broker_sockets(&control_socket_path, &notification_socket_path)
+        .broker_socket(&control_socket_path)
         .run();
     // eventfd.c creates thirteen eventfd objects; each should release one broker object.
     assert_eq!(broker_thread.next_close_object_count(), 13);
 
     Runner::new(&pipe_target, "broker_pipe_rewriter")
-        .broker_sockets(&control_socket_path, &notification_socket_path)
+        .broker_socket(&control_socket_path)
         .run();
     // pipe_broker.c creates five pipes; each endpoint owns one broker object.
     assert_eq!(broker_thread.next_close_object_count(), 10);
 
     Runner::new(&node_path, "hello_node_broker_rewriter")
-        .broker_sockets(&control_socket_path, &notification_socket_path)
+        .broker_socket(&control_socket_path)
         .arg("/out/hello_world.js")
         .with_fs_path(|out_dir| {
             std::fs::write(out_dir.join("out/hello_world.js"), HELLO_WORLD_JS).unwrap();

--- a/litebox_runner_linux_userland/tests/run.rs
+++ b/litebox_runner_linux_userland/tests/run.rs
@@ -386,7 +386,7 @@ fn spawn_test_broker(
                     .set_write_timeout(Some(BROKER_HELPER_TIMEOUT))
                     .expect("failed to configure broker test write timeout");
                 let mut channel =
-                    litebox_broker_transport::unix_socket::UnixStreamHostControlChannel::from_host_guaranteed(
+                    litebox_broker_transport::unix_socket::UnixStreamHostSetupChannel::from_host_guaranteed(
                         control_stream,
                         std::time::Instant::now() + BROKER_HELPER_TIMEOUT,
                     );


### PR DESCRIPTION
Route broker-to-local notifications through the association shared-memory notification ring and share the existing control socket's liveness and shutdown across all ring directions. Remove the dedicated notification socket listener, runner argument, connection retry, credential pairing, and shutdown path while keeping the portable notification channel contracts.

Split the portable local channel into `LocalSetupChannel` for association setup and `LocalCallChannel` for active calls, mirroring the host side. `UnixStreamLocalSetupChannel::into_active` consumes a negotiated setup channel into the call, notification, and shutdown handles, retiring the failed placeholder state and the runtime phase errors it guarded. `BrokerLocal::negotiate` returns the endpoints activation produced alongside the association, so deployments no longer route the notification receiver out through a captured option. Setup-phase types are named `UnixStream*` and active ring-backed endpoints `UnixControlRing*`.