### PR TITLE
Publish broker readiness notifications

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1470,6 +1470,7 @@ dependencies = [
 name = "litebox_broker_host"
 version = "0.1.0"
 dependencies = [
+ "hashbrown",
  "litebox_broker_core",
  "litebox_broker_protocol",
  "spin 0.9.8",

--- a/litebox_broker_host/Cargo.toml
+++ b/litebox_broker_host/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+hashbrown = "0.15.2"
 litebox_broker_core = { path = "../litebox_broker_core", version = "0.1.0" }
 litebox_broker_protocol = { path = "../litebox_broker_protocol", version = "0.1.0" }
 spin = { version = "0.9.8", default-features = false, features = ["spin_mutex"] }

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -35,6 +35,7 @@ use litebox_broker_protocol::{BROKER_PROTOCOL_VERSION, RequestId};
 use spin::mutex::SpinMutex;
 
 mod error;
+pub mod readiness;
 
 pub use error::{BrokerHostError, Result};
 

--- a/litebox_broker_host/src/readiness.rs
+++ b/litebox_broker_host/src/readiness.rs
@@ -74,9 +74,10 @@ pub enum PublishOutcome {
 ///
 /// The claim borrows the publisher it came from, so it cannot be confirmed
 /// against a different one, and it is not `Copy`, so it cannot be replayed.
-/// Dropping it without calling [`confirm`] requeues the update rather than
-/// stranding it, which is what returns the object to a publishable state when
-/// a send fails or unwinds.
+/// Dropping it without calling [`confirm`] requeues the update it carried, so
+/// a send that fails or unwinds leaves the object publishable again. The
+/// requeue is skipped when the update is no longer the current one to send:
+/// retirement, closure, and a newer recorded change all supersede it.
 ///
 /// [`confirm`]: Self::confirm
 #[derive(Debug)]
@@ -656,6 +657,19 @@ mod tests {
         }
     }
 
+    struct PanickingChannel;
+
+    impl HostNotificationChannel for PanickingChannel {
+        type Error = &'static str;
+
+        fn send_notification(
+            &mut self,
+            _notification: &BrokerNotification,
+        ) -> Result<(), Self::Error> {
+            panic!("notification channel panicked")
+        }
+    }
+
     fn readiness_of(notification: &BrokerNotification) -> ReadinessNotification {
         let BrokerNotification::Readiness(readiness) = notification;
         *readiness
@@ -792,6 +806,33 @@ mod tests {
             [ReadinessNotification {
                 handle: HANDLE,
                 readiness: ReadinessFlags::WRITE,
+            }]
+        );
+    }
+
+    #[test]
+    fn a_panicking_send_returns_its_update_to_the_queue() {
+        let publisher = ReadinessPublisher::new();
+        publish(&publisher, HANDLE, ReadinessFlags::READ);
+
+        let previous_hook = std::panic::take_hook();
+        std::panic::set_hook(alloc::boxed::Box::new(|_| {}));
+        let unwound = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _ = publish_readiness(&publisher, &mut PanickingChannel, || {
+                unreachable!("a panicking send must not park the publisher")
+            });
+        }));
+        std::panic::set_hook(previous_hook);
+
+        assert!(unwound.is_err());
+
+        // Unwinding past the claim runs its drop, which must leave the update
+        // publishable rather than stranded.
+        assert_eq!(
+            drain(&publisher),
+            [ReadinessNotification {
+                handle: HANDLE,
+                readiness: ReadinessFlags::READ,
             }]
         );
     }

--- a/litebox_broker_host/src/readiness.rs
+++ b/litebox_broker_host/src/readiness.rs
@@ -545,7 +545,7 @@ mod tests {
     }
 
     #[test]
-    fn confirming_a_claim_taken_before_reuse_does_not_clear_the_new_update() {
+    fn confirming_a_stale_claim_keeps_the_new_update() {
         let publisher = ReadinessPublisher::new();
         publish(&publisher, HANDLE, ReadinessFlags::READ);
         let stale = publisher.take_pending().unwrap();
@@ -822,7 +822,7 @@ mod tests {
     }
 
     #[test]
-    fn abandoning_a_stale_claim_does_not_requeue_a_newer_update_twice() {
+    fn abandoning_a_stale_claim_requeues_nothing() {
         let publisher = ReadinessPublisher::new();
         publish(&publisher, HANDLE, ReadinessFlags::READ);
         let stale = publisher.take_pending().unwrap();

--- a/litebox_broker_host/src/readiness.rs
+++ b/litebox_broker_host/src/readiness.rs
@@ -1,0 +1,653 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//! Bounded, coalescing readiness publication state for one broker association.
+//!
+//! Backend readiness sources and the notification transport have very different
+//! blocking behavior. A source discovers a readiness change while holding
+//! backend state and must never wait for notification-ring capacity; the
+//! notification ring is a bounded shared region whose producer blocks when the
+//! local endpoint stops draining it.
+//!
+//! [`ReadinessPublisher`] separates the two. Sources call [`publish`] to record
+//! the authoritative flags for an object, which only updates in-memory state.
+//! One dedicated publisher owns the notification channel and repeatedly claims
+//! pending updates with [`take_pending`], sends them, and reports completion
+//! with [`confirm`].
+//!
+//! Because [`BrokerNotification::Readiness`] is a hint to re-check state rather
+//! than an ordered transition, repeated updates for one handle collapse into a
+//! single notification carrying the newest flags. Updates that arrive while a
+//! notification is in flight are not lost: each entry carries a generation that
+//! advances on every observable change, and [`confirm`] clears the pending mark
+//! only when the published generation is still current.
+//!
+//! This type is transport-neutral and never blocks, so it holds no thread,
+//! timer, or wake primitive. Deployments own those and wake their publisher
+//! whenever [`publish`] reports [`PublishOutcome::Queued`].
+//!
+//! [`publish`]: ReadinessPublisher::publish
+//! [`take_pending`]: ReadinessPublisher::take_pending
+//! [`confirm`]: ReadinessPublisher::confirm
+//! [`BrokerNotification::Readiness`]: litebox_broker_protocol::message::BrokerNotification::Readiness
+
+use alloc::collections::{BTreeMap, VecDeque};
+
+use litebox_broker_protocol::ObjectHandle;
+use litebox_broker_protocol::channel::HostNotificationChannel;
+use litebox_broker_protocol::message::{BrokerNotification, ReadinessNotification};
+use litebox_broker_protocol::readiness::ReadinessFlags;
+use spin::mutex::SpinMutex;
+use thiserror::Error;
+
+/// Maximum number of objects one association tracks readiness for.
+///
+/// An association cannot hold more object references than the broker core
+/// grants in total, so this bound is not reachable before the core reference
+/// limit is. It exists so that a defective readiness source cannot grow
+/// publication state without limit.
+pub const MAX_TRACKED_READINESS_OBJECTS: usize = 4096;
+
+/// Error returned when readiness state cannot record an update.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Error)]
+#[non_exhaustive]
+pub enum ReadinessPublishError {
+    /// The association already tracks [`MAX_TRACKED_READINESS_OBJECTS`] objects.
+    #[error("broker association already tracks the maximum number of readiness objects")]
+    TooManyObjects,
+}
+
+/// Outcome of recording one readiness update.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PublishOutcome {
+    /// The update queued work the publisher may not know about yet, so the
+    /// deployment must wake its publisher.
+    Queued,
+    /// The update matched state already known to the local endpoint, or work
+    /// for this object was already queued. No wake is required.
+    Coalesced,
+    /// The publisher is closed and the update was discarded.
+    Closed,
+}
+
+/// One readiness notification claimed for publication.
+///
+/// The claim is returned to the publisher by [`ReadinessPublisher::confirm`]
+/// after the notification is durably handed to the transport.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PendingReadiness {
+    notification: ReadinessNotification,
+    generation: u64,
+}
+
+impl PendingReadiness {
+    /// Notification to send on the association notification channel.
+    #[must_use]
+    pub const fn notification(&self) -> ReadinessNotification {
+        self.notification
+    }
+}
+
+/// Coalescing readiness publication state shared by backend sources and one
+/// notification publisher.
+#[derive(Debug)]
+pub struct ReadinessPublisher {
+    state: SpinMutex<PublisherState>,
+}
+
+#[derive(Debug)]
+struct PublisherState {
+    entries: BTreeMap<ObjectHandle, ReadinessEntry>,
+    queue: VecDeque<ObjectHandle>,
+    closed: bool,
+}
+
+#[derive(Debug)]
+struct ReadinessEntry {
+    /// Newest authoritative flags recorded by a backend source.
+    readiness: ReadinessFlags,
+    /// Advances whenever `readiness` changes, identifying the exact value a
+    /// claim was taken from.
+    generation: u64,
+    /// A change has not yet been confirmed as published.
+    dirty: bool,
+    /// The handle currently sits in `queue`.
+    queued: bool,
+}
+
+impl Default for ReadinessPublisher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ReadinessPublisher {
+    /// Creates empty readiness publication state.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            state: SpinMutex::new(PublisherState {
+                entries: BTreeMap::new(),
+                queue: VecDeque::new(),
+                closed: false,
+            }),
+        }
+    }
+
+    /// Records the authoritative readiness of one object.
+    ///
+    /// This never waits for notification-ring capacity, so backend sources may
+    /// call it while holding their own state. The caller must wake the
+    /// publisher when the outcome is [`PublishOutcome::Queued`].
+    pub fn publish(
+        &self,
+        handle: ObjectHandle,
+        readiness: ReadinessFlags,
+    ) -> Result<PublishOutcome, ReadinessPublishError> {
+        let mut state = self.state.lock();
+        if state.closed {
+            return Ok(PublishOutcome::Closed);
+        }
+        if let Some(entry) = state.entries.get_mut(&handle) {
+            if entry.readiness == readiness {
+                // Either the local endpoint already knows this value or a
+                // claim carrying it is queued or in flight.
+                return Ok(PublishOutcome::Coalesced);
+            }
+            entry.readiness = readiness;
+            entry.generation = entry.generation.wrapping_add(1);
+            entry.dirty = true;
+            if entry.queued {
+                return Ok(PublishOutcome::Coalesced);
+            }
+            entry.queued = true;
+        } else {
+            if state.entries.len() >= MAX_TRACKED_READINESS_OBJECTS {
+                return Err(ReadinessPublishError::TooManyObjects);
+            }
+            state.entries.insert(
+                handle,
+                ReadinessEntry {
+                    readiness,
+                    generation: 0,
+                    dirty: true,
+                    queued: true,
+                },
+            );
+        }
+        state.queue.push_back(handle);
+        Ok(PublishOutcome::Queued)
+    }
+
+    /// Claims the next pending readiness notification, if any.
+    ///
+    /// The claim stays pending until [`confirm`] reports it as published, so a
+    /// publisher that fails or is interrupted does not silently drop it.
+    ///
+    /// [`confirm`]: Self::confirm
+    #[must_use]
+    pub fn take_pending(&self) -> Option<PendingReadiness> {
+        let mut state = self.state.lock();
+        while let Some(handle) = state.queue.pop_front() {
+            let Some(entry) = state.entries.get_mut(&handle) else {
+                continue;
+            };
+            entry.queued = false;
+            if !entry.dirty {
+                continue;
+            }
+            return Some(PendingReadiness {
+                notification: ReadinessNotification {
+                    handle,
+                    readiness: entry.readiness,
+                },
+                generation: entry.generation,
+            });
+        }
+        None
+    }
+
+    /// Reports that a claimed notification reached the notification channel.
+    ///
+    /// The pending mark is cleared only when the object still holds the
+    /// generation the claim was taken from. A change recorded while the
+    /// notification was in flight leaves the object pending and already queued
+    /// it for another claim.
+    pub fn confirm(&self, pending: &PendingReadiness) {
+        let mut state = self.state.lock();
+        if let Some(entry) = state.entries.get_mut(&pending.notification.handle)
+            && entry.generation == pending.generation
+        {
+            entry.dirty = false;
+        }
+    }
+
+    /// Drops readiness state for an object whose backend resource is retired.
+    ///
+    /// Notifications already claimed for the object stay valid to send. The
+    /// local endpoint ignores notifications for objects it no longer holds.
+    pub fn retire(&self, handle: ObjectHandle) {
+        let mut state = self.state.lock();
+        if state.entries.remove(&handle).is_some() {
+            state.queue.retain(|queued| *queued != handle);
+        }
+    }
+
+    /// Closes publication permanently and discards pending state.
+    ///
+    /// Later updates are discarded and [`take_pending`] yields nothing, so a
+    /// publisher woken during association teardown observes [`is_closed`] and
+    /// stops.
+    ///
+    /// [`take_pending`]: Self::take_pending
+    /// [`is_closed`]: Self::is_closed
+    pub fn close(&self) {
+        let mut state = self.state.lock();
+        state.closed = true;
+        state.entries.clear();
+        state.queue.clear();
+    }
+
+    /// Reports whether publication is closed.
+    #[must_use]
+    pub fn is_closed(&self) -> bool {
+        self.state.lock().closed
+    }
+
+    /// Number of objects with recorded readiness state.
+    #[must_use]
+    pub fn tracked_objects(&self) -> usize {
+        self.state.lock().entries.len()
+    }
+}
+
+/// Publishes coalesced readiness updates until publication closes.
+///
+/// This is the single owner of `channel`. Sending may block when the local
+/// endpoint stops draining the notification transport; backend sources calling
+/// [`ReadinessPublisher::publish`] are unaffected because they never touch the
+/// channel.
+///
+/// `wait_for_work` parks the caller while nothing is pending. It must return
+/// once [`ReadinessPublisher::publish`] reports [`PublishOutcome::Queued`] or
+/// [`ReadinessPublisher::close`] runs, so association teardown always ends the
+/// loop. Deployments that must also interrupt an in-progress send do so through
+/// their transport, which fails the blocked send.
+///
+/// Returns `Ok(())` once publication is closed and no claim is outstanding.
+pub fn publish_readiness<Channel: HostNotificationChannel>(
+    publisher: &ReadinessPublisher,
+    channel: &mut Channel,
+    mut wait_for_work: impl FnMut(),
+) -> Result<(), Channel::Error> {
+    loop {
+        if let Some(pending) = publisher.take_pending() {
+            channel.send_notification(&BrokerNotification::Readiness(pending.notification()))?;
+            publisher.confirm(&pending);
+            continue;
+        }
+        if publisher.is_closed() {
+            return Ok(());
+        }
+        wait_for_work();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const HANDLE: ObjectHandle = ObjectHandle(7);
+    const OTHER_HANDLE: ObjectHandle = ObjectHandle(9);
+
+    fn publish(publisher: &ReadinessPublisher, handle: ObjectHandle, readiness: ReadinessFlags) {
+        publisher.publish(handle, readiness).unwrap();
+    }
+
+    fn drain(publisher: &ReadinessPublisher) -> alloc::vec::Vec<ReadinessNotification> {
+        let mut drained = alloc::vec::Vec::new();
+        while let Some(pending) = publisher.take_pending() {
+            publisher.confirm(&pending);
+            drained.push(pending.notification());
+        }
+        drained
+    }
+
+    #[test]
+    fn first_update_for_an_object_queues_a_notification() {
+        let publisher = ReadinessPublisher::new();
+
+        assert_eq!(
+            publisher.publish(HANDLE, ReadinessFlags::READ).unwrap(),
+            PublishOutcome::Queued
+        );
+
+        assert_eq!(
+            drain(&publisher),
+            [ReadinessNotification {
+                handle: HANDLE,
+                readiness: ReadinessFlags::READ,
+            }]
+        );
+    }
+
+    #[test]
+    fn repeating_known_readiness_publishes_nothing() {
+        let publisher = ReadinessPublisher::new();
+        publish(&publisher, HANDLE, ReadinessFlags::READ);
+        drain(&publisher);
+
+        assert_eq!(
+            publisher.publish(HANDLE, ReadinessFlags::READ).unwrap(),
+            PublishOutcome::Coalesced
+        );
+
+        assert!(publisher.take_pending().is_none());
+    }
+
+    #[test]
+    fn queued_updates_collapse_to_the_newest_flags() {
+        let publisher = ReadinessPublisher::new();
+
+        publish(&publisher, HANDLE, ReadinessFlags::READ);
+        assert_eq!(
+            publisher
+                .publish(HANDLE, ReadinessFlags::READ | ReadinessFlags::WRITE)
+                .unwrap(),
+            PublishOutcome::Coalesced
+        );
+        publish(&publisher, HANDLE, ReadinessFlags::HANGUP);
+
+        assert_eq!(
+            drain(&publisher),
+            [ReadinessNotification {
+                handle: HANDLE,
+                readiness: ReadinessFlags::HANGUP,
+            }]
+        );
+    }
+
+    #[test]
+    fn updates_during_publication_are_republished() {
+        let publisher = ReadinessPublisher::new();
+        publish(&publisher, HANDLE, ReadinessFlags::READ);
+
+        let pending = publisher.take_pending().unwrap();
+        assert_eq!(
+            publisher.publish(HANDLE, ReadinessFlags::WRITE).unwrap(),
+            PublishOutcome::Queued
+        );
+        publisher.confirm(&pending);
+
+        assert_eq!(
+            drain(&publisher),
+            [ReadinessNotification {
+                handle: HANDLE,
+                readiness: ReadinessFlags::WRITE,
+            }]
+        );
+    }
+
+    #[test]
+    fn a_claim_stays_pending_until_it_is_confirmed() {
+        let publisher = ReadinessPublisher::new();
+        publish(&publisher, HANDLE, ReadinessFlags::READ);
+        let pending = publisher.take_pending().unwrap();
+
+        // An interrupted publisher never confirms, so re-queueing the handle
+        // must reoffer the update rather than treat it as delivered.
+        publish(&publisher, HANDLE, ReadinessFlags::WRITE);
+        publish(&publisher, HANDLE, ReadinessFlags::READ);
+
+        assert_eq!(
+            publisher.take_pending().unwrap().notification(),
+            pending.notification()
+        );
+    }
+
+    #[test]
+    fn independent_objects_publish_independently() {
+        let publisher = ReadinessPublisher::new();
+
+        publish(&publisher, HANDLE, ReadinessFlags::READ);
+        publish(&publisher, OTHER_HANDLE, ReadinessFlags::WRITE);
+
+        assert_eq!(
+            drain(&publisher),
+            [
+                ReadinessNotification {
+                    handle: HANDLE,
+                    readiness: ReadinessFlags::READ,
+                },
+                ReadinessNotification {
+                    handle: OTHER_HANDLE,
+                    readiness: ReadinessFlags::WRITE,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn retiring_an_object_drops_its_queued_update() {
+        let publisher = ReadinessPublisher::new();
+        publish(&publisher, HANDLE, ReadinessFlags::READ);
+        publish(&publisher, OTHER_HANDLE, ReadinessFlags::WRITE);
+
+        publisher.retire(HANDLE);
+
+        assert_eq!(publisher.tracked_objects(), 1);
+        assert_eq!(
+            drain(&publisher),
+            [ReadinessNotification {
+                handle: OTHER_HANDLE,
+                readiness: ReadinessFlags::WRITE,
+            }]
+        );
+    }
+
+    #[test]
+    fn confirming_a_retired_object_does_not_resurrect_it() {
+        let publisher = ReadinessPublisher::new();
+        publish(&publisher, HANDLE, ReadinessFlags::READ);
+        let pending = publisher.take_pending().unwrap();
+
+        publisher.retire(HANDLE);
+        publisher.confirm(&pending);
+
+        assert_eq!(publisher.tracked_objects(), 0);
+        assert!(publisher.take_pending().is_none());
+    }
+
+    #[test]
+    fn a_reused_handle_starts_from_unknown_readiness() {
+        let publisher = ReadinessPublisher::new();
+        publish(&publisher, HANDLE, ReadinessFlags::READ);
+        drain(&publisher);
+
+        publisher.retire(HANDLE);
+
+        assert_eq!(
+            publisher.publish(HANDLE, ReadinessFlags::READ).unwrap(),
+            PublishOutcome::Queued
+        );
+    }
+
+    #[test]
+    fn closing_discards_state_and_later_updates() {
+        let publisher = ReadinessPublisher::new();
+        publish(&publisher, HANDLE, ReadinessFlags::READ);
+
+        publisher.close();
+
+        assert!(publisher.is_closed());
+        assert!(publisher.take_pending().is_none());
+        assert_eq!(
+            publisher.publish(HANDLE, ReadinessFlags::WRITE).unwrap(),
+            PublishOutcome::Closed
+        );
+        assert_eq!(publisher.tracked_objects(), 0);
+    }
+
+    #[test]
+    fn tracking_is_bounded() {
+        let publisher = ReadinessPublisher::new();
+        for index in 0..MAX_TRACKED_READINESS_OBJECTS {
+            publish(&publisher, ObjectHandle(index as u64), ReadinessFlags::READ);
+        }
+
+        assert_eq!(
+            publisher.publish(ObjectHandle(u64::MAX), ReadinessFlags::READ),
+            Err(ReadinessPublishError::TooManyObjects)
+        );
+
+        // Retiring an object makes room again.
+        publisher.retire(ObjectHandle(0));
+        assert_eq!(
+            publisher.publish(ObjectHandle(u64::MAX), ReadinessFlags::READ),
+            Ok(PublishOutcome::Queued)
+        );
+    }
+
+    #[test]
+    fn repeated_updates_queue_one_claim_per_object() {
+        let publisher = ReadinessPublisher::new();
+        for round in 1..=8u32 {
+            for handle in 0..4u64 {
+                publish(&publisher, ObjectHandle(handle), ReadinessFlags(round));
+            }
+        }
+
+        let drained = drain(&publisher);
+
+        assert_eq!(drained.len(), 4);
+        assert!(
+            drained
+                .iter()
+                .all(|notification| notification.readiness == ReadinessFlags(8))
+        );
+    }
+
+    /// Notification channel that hands each notification to the test thread and
+    /// then blocks until the test releases it, modelling a full ring.
+    struct GatedChannel {
+        sent: std::sync::mpsc::SyncSender<BrokerNotification>,
+        release: std::sync::mpsc::Receiver<()>,
+    }
+
+    impl HostNotificationChannel for GatedChannel {
+        type Error = &'static str;
+
+        fn send_notification(
+            &mut self,
+            notification: &BrokerNotification,
+        ) -> Result<(), Self::Error> {
+            self.sent
+                .send(notification.clone())
+                .map_err(|_| "test receiver dropped")?;
+            self.release.recv().map_err(|_| "test releaser dropped")
+        }
+    }
+
+    struct FailingChannel;
+
+    impl HostNotificationChannel for FailingChannel {
+        type Error = &'static str;
+
+        fn send_notification(
+            &mut self,
+            _notification: &BrokerNotification,
+        ) -> Result<(), Self::Error> {
+            Err("notification channel failed")
+        }
+    }
+
+    fn readiness_of(notification: &BrokerNotification) -> ReadinessNotification {
+        let BrokerNotification::Readiness(readiness) = notification;
+        *readiness
+    }
+
+    #[test]
+    fn publishing_drains_pending_work_before_observing_closure() {
+        let publisher = ReadinessPublisher::new();
+        publish(&publisher, HANDLE, ReadinessFlags::READ);
+        publish(&publisher, OTHER_HANDLE, ReadinessFlags::WRITE);
+        let (sent, received) = std::sync::mpsc::sync_channel(4);
+        let (releaser, release) = std::sync::mpsc::channel();
+        for _ in 0..2 {
+            releaser.send(()).unwrap();
+        }
+        let mut channel = GatedChannel { sent, release };
+
+        publish_readiness(&publisher, &mut channel, || publisher.close()).unwrap();
+
+        let drained: alloc::vec::Vec<_> = received.try_iter().map(|n| readiness_of(&n)).collect();
+        assert_eq!(drained.len(), 2);
+        assert_eq!(drained[0].handle, HANDLE);
+        assert_eq!(drained[1].handle, OTHER_HANDLE);
+    }
+
+    #[test]
+    fn closing_ends_a_parked_publisher() {
+        let publisher = std::sync::Arc::new(ReadinessPublisher::new());
+        let (sent, _received) = std::sync::mpsc::sync_channel(1);
+        let (_releaser, release) = std::sync::mpsc::channel();
+        let mut channel = GatedChannel { sent, release };
+        let parked = std::sync::Arc::clone(&publisher);
+
+        let publisher_thread = std::thread::spawn(move || {
+            publish_readiness(&parked, &mut channel, || {
+                std::thread::sleep(core::time::Duration::from_millis(1));
+            })
+        });
+        publisher.close();
+
+        publisher_thread.join().unwrap().unwrap();
+    }
+
+    #[test]
+    fn updates_recorded_while_a_send_blocks_are_published_afterwards() {
+        let publisher = std::sync::Arc::new(ReadinessPublisher::new());
+        publish(&publisher, HANDLE, ReadinessFlags::READ);
+        let (sent, received) = std::sync::mpsc::sync_channel(0);
+        let (releaser, release) = std::sync::mpsc::channel();
+        let mut channel = GatedChannel { sent, release };
+        let publishing = std::sync::Arc::clone(&publisher);
+        let publisher_thread = std::thread::spawn(move || {
+            publish_readiness(&publishing, &mut channel, || {
+                std::thread::sleep(core::time::Duration::from_millis(1));
+            })
+        });
+
+        // The first notification is now in flight and cannot be confirmed yet.
+        assert_eq!(
+            readiness_of(&received.recv().unwrap()).readiness,
+            ReadinessFlags::READ
+        );
+        assert_eq!(
+            publisher.publish(HANDLE, ReadinessFlags::HANGUP).unwrap(),
+            PublishOutcome::Queued
+        );
+        releaser.send(()).unwrap();
+
+        assert_eq!(
+            readiness_of(&received.recv().unwrap()).readiness,
+            ReadinessFlags::HANGUP
+        );
+        releaser.send(()).unwrap();
+        publisher.close();
+        publisher_thread.join().unwrap().unwrap();
+    }
+
+    #[test]
+    fn a_failed_send_stops_publication_and_reports_the_channel_error() {
+        let publisher = ReadinessPublisher::new();
+        publish(&publisher, HANDLE, ReadinessFlags::READ);
+
+        let error = publish_readiness(&publisher, &mut FailingChannel, || {
+            unreachable!("a failed send must not park the publisher")
+        })
+        .unwrap_err();
+
+        assert_eq!(error, "notification channel failed");
+    }
+}

--- a/litebox_broker_host/src/readiness.rs
+++ b/litebox_broker_host/src/readiness.rs
@@ -41,10 +41,10 @@ use thiserror::Error;
 
 /// Maximum number of objects one association tracks readiness for.
 ///
-/// An association cannot hold more object references than the broker core
-/// grants in total, so this bound is not reachable before the core reference
-/// limit is. It exists so that a defective readiness source cannot grow
-/// publication state without limit.
+/// This matches the default broker-core reference limit, so a source that
+/// retires an object as its backend resource is released stays well inside it.
+/// It exists so that a source which does not, or a deployment that raises the
+/// core limit, cannot grow publication state without limit.
 pub const MAX_TRACKED_READINESS_OBJECTS: usize = 4096;
 
 /// Error returned when readiness state cannot record an update.

--- a/litebox_broker_host/src/readiness.rs
+++ b/litebox_broker_host/src/readiness.rs
@@ -21,9 +21,10 @@
 //! identifies its newest change, and a claim is confirmed only while the
 //! generation it was taken from is still current.
 //!
-//! This type is transport-neutral and never blocks, so it holds no thread,
-//! timer, or wake primitive. Deployments own those and wake their publisher
-//! whenever [`publish`] reports [`PublishOutcome::Queued`].
+//! This type is transport-neutral and performs no transport I/O, so it holds no
+//! thread, timer, or wake primitive and never waits for notification-ring
+//! capacity. Deployments own those and wake their publisher whenever
+//! [`publish`] reports [`PublishOutcome::Queued`].
 //!
 //! [`publish`]: ReadinessPublisher::publish
 //! [`BrokerNotification::Readiness`]: litebox_broker_protocol::message::BrokerNotification::Readiness
@@ -61,8 +62,9 @@ pub enum PublishOutcome {
     /// The update queued work the publisher may not know about yet, so the
     /// deployment must wake its publisher.
     Queued,
-    /// The update matched state already known to the local endpoint, or work
-    /// for this object was already queued. No wake is required.
+    /// The update matched the newest recorded state, so delivery for it is
+    /// already known to the local endpoint, queued, or in flight. No wake is
+    /// required.
     Coalesced,
     /// The publisher is closed and the update was discarded.
     Closed,
@@ -70,22 +72,58 @@ pub enum PublishOutcome {
 
 /// One readiness notification claimed for publication.
 ///
-/// The claim is returned to the publisher by [`ReadinessPublisher::confirm`]
-/// after the notification is durably handed to the transport. It is crate
-/// private because a claim is only meaningful to the publisher it was taken
-/// from: confirming it against another publisher, or never confirming it at
-/// all, strands the update it describes. [`publish_readiness`] is the only
-/// consumer and does neither.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) struct PendingReadiness {
+/// The claim borrows the publisher it came from, so it cannot be confirmed
+/// against a different one, and it is not `Copy`, so it cannot be replayed.
+/// Dropping it without calling [`confirm`] requeues the update rather than
+/// stranding it, which is what returns the object to a publishable state when
+/// a send fails or unwinds.
+///
+/// [`confirm`]: Self::confirm
+#[derive(Debug)]
+pub(crate) struct PendingReadiness<'publisher> {
+    publisher: &'publisher ReadinessPublisher,
     notification: ReadinessNotification,
     generation: u64,
 }
 
-impl PendingReadiness {
+impl PendingReadiness<'_> {
     /// Notification to send on the association notification channel.
     pub(crate) const fn notification(&self) -> ReadinessNotification {
         self.notification
+    }
+
+    /// Reports that the notification reached the notification channel.
+    ///
+    /// The pending mark is cleared only when the object still holds the
+    /// generation the claim was taken from. Any change recorded while the
+    /// notification was in flight leaves the object pending, including a change
+    /// that returned to the published flags, because the local endpoint samples
+    /// authoritative state independently and may have observed the intermediate
+    /// value.
+    pub(crate) fn confirm(self) {
+        let mut state = self.publisher.state.lock();
+        if let Some(entry) = state.entries.get_mut(&self.notification.handle)
+            && entry.generation == self.generation
+        {
+            entry.dirty = false;
+        }
+        drop(state);
+        core::mem::forget(self);
+    }
+}
+
+impl Drop for PendingReadiness<'_> {
+    fn drop(&mut self) {
+        let mut state = self.publisher.state.lock();
+        // A newer change has already requeued the object, and a retired or
+        // closed publisher has nothing left to publish.
+        if let Some(entry) = state.entries.get_mut(&self.notification.handle)
+            && entry.generation == self.generation
+            && !entry.queued
+        {
+            entry.queued = true;
+            state.queue.push_back(self.notification.handle);
+        }
     }
 }
 
@@ -105,9 +143,10 @@ struct PublisherState {
     /// Generations are allocated publisher-wide rather than per object so that
     /// an object re-registered under a recycled handle cannot reuse a value a
     /// still-unconfirmed claim was taken from. Values are skipped freely; only
-    /// their distinctness matters, which holds for as long as the counter does
-    /// not wrap. Wrapping would need `u64::MAX` recorded changes to elapse
-    /// while one claim stayed in flight, so it is treated as unreachable.
+    /// their distinctness matters, which holds unless the counter wraps all the
+    /// way back to a value a claim is still holding. That needs `2^64` recorded
+    /// changes to elapse while one send is in flight, so it is treated as
+    /// unreachable.
     next_generation: u64,
     closed: bool,
 }
@@ -201,17 +240,12 @@ impl ReadinessPublisher {
 
     /// Claims the next pending readiness notification, if any.
     ///
-    /// The claim leaves the object marked pending until [`confirm`] reports it
-    /// as published, so a change recorded while it is in flight is republished
-    /// rather than lost. Every claim must be confirmed against the publisher it
-    /// came from: a claim that is dropped leaves the object pending but
-    /// unqueued, and only a later *changed* publication requeues it.
-    /// [`publish_readiness`] drops a claim only when the send that carried it
-    /// failed, which ends publication for good.
-    ///
-    /// [`confirm`]: Self::confirm
+    /// The claim leaves the object marked pending until it is confirmed, so a
+    /// change recorded while it is in flight is republished rather than lost.
+    /// A claim that is dropped unconfirmed requeues the object, so a failed or
+    /// unwinding send leaves the update publishable by a later publisher.
     #[must_use]
-    pub(crate) fn take_pending(&self) -> Option<PendingReadiness> {
+    pub(crate) fn take_pending(&self) -> Option<PendingReadiness<'_>> {
         let mut state = self.state.lock();
         while let Some(handle) = state.queue.pop_front() {
             let Some(entry) = state.entries.get_mut(&handle) else {
@@ -221,32 +255,19 @@ impl ReadinessPublisher {
             if !entry.dirty {
                 continue;
             }
+            let notification = ReadinessNotification {
+                handle,
+                readiness: entry.readiness,
+            };
+            let generation = entry.generation;
+            drop(state);
             return Some(PendingReadiness {
-                notification: ReadinessNotification {
-                    handle,
-                    readiness: entry.readiness,
-                },
-                generation: entry.generation,
+                publisher: self,
+                notification,
+                generation,
             });
         }
         None
-    }
-
-    /// Reports that a claimed notification reached the notification channel.
-    ///
-    /// The pending mark is cleared only when the object still holds the
-    /// generation the claim was taken from. Any change recorded while the
-    /// notification was in flight leaves the object pending, including a change
-    /// that returned to the published flags, because the local endpoint samples
-    /// authoritative state independently and may have observed the intermediate
-    /// value.
-    pub(crate) fn confirm(&self, pending: &PendingReadiness) {
-        let mut state = self.state.lock();
-        if let Some(entry) = state.entries.get_mut(&pending.notification.handle)
-            && entry.generation == pending.generation
-        {
-            entry.dirty = false;
-        }
     }
 
     /// Drops readiness state for an object whose backend resource is retired.
@@ -302,7 +323,9 @@ impl ReadinessPublisher {
 /// loop. Deployments that must also interrupt an in-progress send do so through
 /// their transport, which fails the blocked send.
 ///
-/// Returns `Ok(())` once publication is closed and no claim is outstanding.
+/// Returns `Ok(())` once publication is closed and no claim is outstanding. A
+/// failed send returns its error with the claimed update left publishable, so
+/// resuming on a replacement channel does not lose the notification.
 pub fn publish_readiness<Channel: HostNotificationChannel>(
     publisher: &ReadinessPublisher,
     channel: &mut Channel,
@@ -311,7 +334,7 @@ pub fn publish_readiness<Channel: HostNotificationChannel>(
     loop {
         if let Some(pending) = publisher.take_pending() {
             channel.send_notification(&BrokerNotification::Readiness(pending.notification()))?;
-            publisher.confirm(&pending);
+            pending.confirm();
             continue;
         }
         if publisher.is_closed() {
@@ -335,8 +358,8 @@ mod tests {
     fn drain(publisher: &ReadinessPublisher) -> alloc::vec::Vec<ReadinessNotification> {
         let mut drained = alloc::vec::Vec::new();
         while let Some(pending) = publisher.take_pending() {
-            publisher.confirm(&pending);
             drained.push(pending.notification());
+            pending.confirm();
         }
         drained
     }
@@ -405,7 +428,7 @@ mod tests {
             publisher.publish(HANDLE, ReadinessFlags::WRITE).unwrap(),
             PublishOutcome::Queued
         );
-        publisher.confirm(&pending);
+        pending.confirm();
 
         assert_eq!(
             drain(&publisher),
@@ -428,7 +451,7 @@ mod tests {
         // which is why confirmation compares generations and not flags.
         publish(&publisher, HANDLE, ReadinessFlags::WRITE);
         publish(&publisher, HANDLE, ReadinessFlags::READ);
-        publisher.confirm(&pending);
+        pending.confirm();
 
         assert_eq!(
             drain(&publisher),
@@ -503,7 +526,7 @@ mod tests {
         let pending = publisher.take_pending().unwrap();
 
         publisher.retire(HANDLE);
-        publisher.confirm(&pending);
+        pending.confirm();
 
         assert_eq!(publisher.tracked_objects(), 0);
         assert!(publisher.take_pending().is_none());
@@ -533,7 +556,7 @@ mod tests {
         // while the first claim is still in flight.
         publisher.retire(HANDLE);
         publish(&publisher, HANDLE, ReadinessFlags::WRITE);
-        publisher.confirm(&stale);
+        stale.confirm();
 
         assert_eq!(
             drain(&publisher),
@@ -721,5 +744,55 @@ mod tests {
         .unwrap_err();
 
         assert_eq!(error, "notification channel failed");
+
+        // The claim was dropped by the failed send rather than confirmed, so
+        // the update it carried is still publishable on a replacement channel.
+        assert_eq!(
+            drain(&publisher),
+            [ReadinessNotification {
+                handle: HANDLE,
+                readiness: ReadinessFlags::READ,
+            }]
+        );
+    }
+
+    #[test]
+    fn an_abandoned_claim_returns_its_update_to_the_queue() {
+        let publisher = ReadinessPublisher::new();
+        publish(&publisher, HANDLE, ReadinessFlags::READ);
+
+        drop(publisher.take_pending().unwrap());
+
+        // Republishing the same flags coalesces, so nothing else can rescue the
+        // update if abandoning the claim strands it.
+        assert_eq!(
+            publisher.publish(HANDLE, ReadinessFlags::READ).unwrap(),
+            PublishOutcome::Coalesced
+        );
+        assert_eq!(
+            drain(&publisher),
+            [ReadinessNotification {
+                handle: HANDLE,
+                readiness: ReadinessFlags::READ,
+            }]
+        );
+    }
+
+    #[test]
+    fn abandoning_a_stale_claim_does_not_requeue_a_newer_update_twice() {
+        let publisher = ReadinessPublisher::new();
+        publish(&publisher, HANDLE, ReadinessFlags::READ);
+        let stale = publisher.take_pending().unwrap();
+
+        publish(&publisher, HANDLE, ReadinessFlags::WRITE);
+        drop(stale);
+
+        assert_eq!(
+            drain(&publisher),
+            [ReadinessNotification {
+                handle: HANDLE,
+                readiness: ReadinessFlags::WRITE,
+            }]
+        );
     }
 }

--- a/litebox_broker_host/src/readiness.rs
+++ b/litebox_broker_host/src/readiness.rs
@@ -11,24 +11,21 @@
 //!
 //! [`ReadinessPublisher`] separates the two. Sources call [`publish`] to record
 //! the authoritative flags for an object, which only updates in-memory state.
-//! One dedicated publisher owns the notification channel and repeatedly claims
-//! pending updates with [`take_pending`], sends them, and reports completion
-//! with [`confirm`].
+//! [`publish_readiness`] owns the notification channel and repeatedly claims
+//! pending updates, sends them, and reports completion.
 //!
 //! Because [`BrokerNotification::Readiness`] is a hint to re-check state rather
 //! than an ordered transition, repeated updates for one handle collapse into a
 //! single notification carrying the newest flags. Updates that arrive while a
 //! notification is in flight are not lost: each entry carries a generation that
-//! advances on every observable change, and [`confirm`] clears the pending mark
-//! only when the published generation is still current.
+//! identifies its newest change, and a claim is confirmed only while the
+//! generation it was taken from is still current.
 //!
 //! This type is transport-neutral and never blocks, so it holds no thread,
 //! timer, or wake primitive. Deployments own those and wake their publisher
 //! whenever [`publish`] reports [`PublishOutcome::Queued`].
 //!
 //! [`publish`]: ReadinessPublisher::publish
-//! [`take_pending`]: ReadinessPublisher::take_pending
-//! [`confirm`]: ReadinessPublisher::confirm
 //! [`BrokerNotification::Readiness`]: litebox_broker_protocol::message::BrokerNotification::Readiness
 
 use alloc::collections::VecDeque;
@@ -74,17 +71,20 @@ pub enum PublishOutcome {
 /// One readiness notification claimed for publication.
 ///
 /// The claim is returned to the publisher by [`ReadinessPublisher::confirm`]
-/// after the notification is durably handed to the transport.
+/// after the notification is durably handed to the transport. It is crate
+/// private because a claim is only meaningful to the publisher it was taken
+/// from: confirming it against another publisher, or never confirming it at
+/// all, strands the update it describes. [`publish_readiness`] is the only
+/// consumer and does neither.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct PendingReadiness {
+pub(crate) struct PendingReadiness {
     notification: ReadinessNotification,
     generation: u64,
 }
 
 impl PendingReadiness {
     /// Notification to send on the association notification channel.
-    #[must_use]
-    pub const fn notification(&self) -> ReadinessNotification {
+    pub(crate) const fn notification(&self) -> ReadinessNotification {
         self.notification
     }
 }
@@ -104,8 +104,10 @@ struct PublisherState {
     ///
     /// Generations are allocated publisher-wide rather than per object so that
     /// an object re-registered under a recycled handle cannot reuse a value a
-    /// still-unconfirmed claim was taken from. Values may be skipped; only
-    /// their uniqueness matters.
+    /// still-unconfirmed claim was taken from. Values are skipped freely; only
+    /// their distinctness matters, which holds for as long as the counter does
+    /// not wrap. Wrapping would need `u64::MAX` recorded changes to elapse
+    /// while one claim stayed in flight, so it is treated as unreachable.
     next_generation: u64,
     closed: bool,
 }
@@ -201,15 +203,15 @@ impl ReadinessPublisher {
     ///
     /// The claim leaves the object marked pending until [`confirm`] reports it
     /// as published, so a change recorded while it is in flight is republished
-    /// rather than lost. The caller must confirm every claim it takes: a claim
-    /// that is dropped leaves the object pending but unqueued, and only a
-    /// later *changed* publication requeues it. Callers that cannot confirm
-    /// must treat publication as finished, which is what a failed send means
-    /// because it has already broken the association's notification channel.
+    /// rather than lost. Every claim must be confirmed against the publisher it
+    /// came from: a claim that is dropped leaves the object pending but
+    /// unqueued, and only a later *changed* publication requeues it.
+    /// [`publish_readiness`] drops a claim only when the send that carried it
+    /// failed, which ends publication for good.
     ///
     /// [`confirm`]: Self::confirm
     #[must_use]
-    pub fn take_pending(&self) -> Option<PendingReadiness> {
+    pub(crate) fn take_pending(&self) -> Option<PendingReadiness> {
         let mut state = self.state.lock();
         while let Some(handle) = state.queue.pop_front() {
             let Some(entry) = state.entries.get_mut(&handle) else {
@@ -238,7 +240,7 @@ impl ReadinessPublisher {
     /// that returned to the published flags, because the local endpoint samples
     /// authoritative state independently and may have observed the intermediate
     /// value.
-    pub fn confirm(&self, pending: &PendingReadiness) {
+    pub(crate) fn confirm(&self, pending: &PendingReadiness) {
         let mut state = self.state.lock();
         if let Some(entry) = state.entries.get_mut(&pending.notification.handle)
             && entry.generation == pending.generation
@@ -249,8 +251,10 @@ impl ReadinessPublisher {
 
     /// Drops readiness state for an object whose backend resource is retired.
     ///
-    /// Notifications already claimed for the object stay valid to send. The
-    /// local endpoint ignores notifications for objects it no longer holds.
+    /// Notifications already claimed for the object stay valid to send. A
+    /// notification that arrives after retirement is ignored by the local
+    /// endpoint, or, if the handle has since been recycled, is treated as a
+    /// spurious hint to re-check the new object.
     pub fn retire(&self, handle: ObjectHandle) {
         let mut state = self.state.lock();
         if state.entries.remove(&handle).is_some() {
@@ -260,11 +264,10 @@ impl ReadinessPublisher {
 
     /// Closes publication permanently and discards pending state.
     ///
-    /// Later updates are discarded and [`take_pending`] yields nothing, so a
+    /// Later updates are discarded and no further claim is produced, so a
     /// publisher woken during association teardown observes [`is_closed`] and
     /// stops.
     ///
-    /// [`take_pending`]: Self::take_pending
     /// [`is_closed`]: Self::is_closed
     pub fn close(&self) {
         let mut state = self.state.lock();

--- a/litebox_broker_host/src/readiness.rs
+++ b/litebox_broker_host/src/readiness.rs
@@ -117,7 +117,11 @@ impl Drop for PendingReadiness<'_> {
     fn drop(&mut self) {
         let mut state = self.publisher.state.lock();
         // A newer change has already requeued the object, and a retired or
-        // closed publisher has nothing left to publish.
+        // closed publisher has nothing left to publish. The queued check is
+        // defensive rather than load bearing, so no test can distinguish it: a
+        // matching generation means no publication since this claim was taken,
+        // and only publication or a requeue can queue the object, so a matching
+        // generation already implies the object is unqueued.
         if let Some(entry) = state.entries.get_mut(&self.notification.handle)
             && entry.generation == self.generation
             && !entry.queued
@@ -377,27 +381,12 @@ mod tests {
     }
 
     #[test]
-    fn first_update_for_an_object_queues_a_notification() {
+    fn repeating_known_readiness_publishes_nothing() {
         let publisher = ReadinessPublisher::new();
-
         assert_eq!(
             publisher.publish(HANDLE, ReadinessFlags::READ).unwrap(),
             PublishOutcome::Queued
         );
-
-        assert_eq!(
-            drain(&publisher),
-            [ReadinessNotification {
-                handle: HANDLE,
-                readiness: ReadinessFlags::READ,
-            }]
-        );
-    }
-
-    #[test]
-    fn repeating_known_readiness_publishes_nothing() {
-        let publisher = ReadinessPublisher::new();
-        publish(&publisher, HANDLE, ReadinessFlags::READ);
         drain(&publisher);
 
         assert_eq!(
@@ -471,28 +460,6 @@ mod tests {
                 handle: HANDLE,
                 readiness: ReadinessFlags::READ,
             }]
-        );
-    }
-
-    #[test]
-    fn independent_objects_publish_independently() {
-        let publisher = ReadinessPublisher::new();
-
-        publish(&publisher, HANDLE, ReadinessFlags::READ);
-        publish(&publisher, OTHER_HANDLE, ReadinessFlags::WRITE);
-
-        assert_eq!(
-            drain(&publisher),
-            [
-                ReadinessNotification {
-                    handle: HANDLE,
-                    readiness: ReadinessFlags::READ,
-                },
-                ReadinessNotification {
-                    handle: OTHER_HANDLE,
-                    readiness: ReadinessFlags::WRITE,
-                },
-            ]
         );
     }
 
@@ -828,16 +795,29 @@ mod tests {
         let stale = publisher.take_pending().unwrap();
 
         publish(&publisher, HANDLE, ReadinessFlags::WRITE);
-        drop(stale);
+        let newer = publisher.take_pending().unwrap();
 
-        // The newer change already queued the object, so the abandoned claim
-        // must not queue it a second time.
+        // Taking the newer update leaves the object unqueued, so its generation
+        // is all that marks the older claim as superseded. Without that
+        // comparison the older claim requeues an object whose current update is
+        // already in flight, publishing the same readiness twice.
+        assert_eq!(publisher.queued_updates(), 0);
+        drop(stale);
+        assert_eq!(publisher.queued_updates(), 0);
+
+        // A change recorded while that newer claim is still out queues the
+        // object again, and abandoning the claim must not queue it a second
+        // time.
+        publish(&publisher, HANDLE, ReadinessFlags::READ);
         assert_eq!(publisher.queued_updates(), 1);
+        drop(newer);
+        assert_eq!(publisher.queued_updates(), 1);
+
         assert_eq!(
             drain(&publisher),
             [ReadinessNotification {
                 handle: HANDLE,
-                readiness: ReadinessFlags::WRITE,
+                readiness: ReadinessFlags::READ,
             }]
         );
     }

--- a/litebox_broker_host/src/readiness.rs
+++ b/litebox_broker_host/src/readiness.rs
@@ -473,23 +473,6 @@ mod tests {
     }
 
     #[test]
-    fn a_claim_stays_pending_until_it_is_confirmed() {
-        let publisher = ReadinessPublisher::new();
-        publish(&publisher, HANDLE, ReadinessFlags::READ);
-        let pending = publisher.take_pending().unwrap();
-
-        // An interrupted publisher never confirms, so re-queueing the handle
-        // must reoffer the update rather than treat it as delivered.
-        publish(&publisher, HANDLE, ReadinessFlags::WRITE);
-        publish(&publisher, HANDLE, ReadinessFlags::READ);
-
-        assert_eq!(
-            publisher.take_pending().unwrap().notification(),
-            pending.notification()
-        );
-    }
-
-    #[test]
     fn independent_objects_publish_independently() {
         let publisher = ReadinessPublisher::new();
 
@@ -714,12 +697,20 @@ mod tests {
         let (_releaser, release) = std::sync::mpsc::channel();
         let mut channel = GatedChannel { sent, release };
         let parked = std::sync::Arc::clone(&publisher);
+        let (parked_sender, parked_receiver) = std::sync::mpsc::channel();
 
         let publisher_thread = std::thread::spawn(move || {
             publish_readiness(&parked, &mut channel, || {
+                // Reporting from inside the wait is what proves the publisher
+                // reached it, so closing is what ends it rather than a queue it
+                // already found closed.
+                let _ = parked_sender.send(());
                 std::thread::sleep(core::time::Duration::from_millis(1));
             })
         });
+        parked_receiver
+            .recv()
+            .expect("publication must park before it is closed");
         publisher.close();
 
         publisher_thread.join().unwrap().unwrap();

--- a/litebox_broker_host/src/readiness.rs
+++ b/litebox_broker_host/src/readiness.rs
@@ -62,9 +62,9 @@ pub enum PublishOutcome {
     /// The update queued work the publisher may not know about yet, so the
     /// deployment must wake its publisher.
     Queued,
-    /// The update matched the newest recorded state, so delivery for it is
-    /// already known to the local endpoint, queued, or in flight. No wake is
-    /// required.
+    /// The update needs no wake: it either matched the newest recorded state or
+    /// joined a notification that is already queued or in flight, which carries
+    /// the newest flags when it is published.
     Coalesced,
     /// The publisher is closed and the update was discarded.
     Closed,
@@ -333,7 +333,9 @@ impl ReadinessPublisher {
 ///
 /// Returns `Ok(())` once publication is closed and no claim is outstanding. A
 /// failed send returns its error with the claimed update left publishable, so
-/// resuming on a replacement channel does not lose the notification.
+/// resuming on a replacement channel does not lose the notification; the
+/// requeue raises no wake of its own, so a deployment that resumes must call
+/// this again rather than wait for one.
 pub fn publish_readiness<Channel: HostNotificationChannel>(
     publisher: &ReadinessPublisher,
     channel: &mut Channel,

--- a/litebox_broker_host/src/readiness.rs
+++ b/litebox_broker_host/src/readiness.rs
@@ -358,6 +358,8 @@ pub fn publish_readiness<Channel: HostNotificationChannel>(
 mod tests {
     use super::*;
 
+    /// Deadline for every test wait, so a regression fails instead of hanging.
+    const TEST_TIMEOUT: core::time::Duration = core::time::Duration::from_secs(10);
     const HANDLE: ObjectHandle = ObjectHandle(7);
     const OTHER_HANDLE: ObjectHandle = ObjectHandle(9);
 
@@ -670,9 +672,35 @@ mod tests {
         *readiness
     }
 
+    /// Runs publication on its own thread and reports its result through a
+    /// channel, so a loop that never ends fails a test on the deadline instead
+    /// of blocking it forever.
+    fn spawn_publication(
+        publisher: std::sync::Arc<ReadinessPublisher>,
+        mut channel: GatedChannel,
+        mut wait_for_work: impl FnMut() + Send + 'static,
+    ) -> std::sync::mpsc::Receiver<Result<(), &'static str>> {
+        let (finished, finish) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let _ = finished.send(publish_readiness(
+                &publisher,
+                &mut channel,
+                &mut wait_for_work,
+            ));
+        });
+        finish
+    }
+
+    fn expect_publication_ended(finish: &std::sync::mpsc::Receiver<Result<(), &'static str>>) {
+        finish
+            .recv_timeout(TEST_TIMEOUT)
+            .expect("publication must end")
+            .expect("publication must end without a channel error");
+    }
+
     #[test]
     fn queued_updates_publish_in_order_until_the_waiter_closes() {
-        let publisher = ReadinessPublisher::new();
+        let publisher = std::sync::Arc::new(ReadinessPublisher::new());
         publish(&publisher, HANDLE, ReadinessFlags::READ);
         publish(&publisher, OTHER_HANDLE, ReadinessFlags::WRITE);
         let (sent, received) = std::sync::mpsc::sync_channel(4);
@@ -680,9 +708,11 @@ mod tests {
         for _ in 0..2 {
             releaser.send(()).unwrap();
         }
-        let mut channel = GatedChannel { sent, release };
+        let channel = GatedChannel { sent, release };
+        let closing = std::sync::Arc::clone(&publisher);
 
-        publish_readiness(&publisher, &mut channel, || publisher.close()).unwrap();
+        let finish = spawn_publication(publisher, channel, move || closing.close());
+        expect_publication_ended(&finish);
 
         let drained: alloc::vec::Vec<_> = received.try_iter().map(|n| readiness_of(&n)).collect();
         assert_eq!(drained.len(), 2);
@@ -695,25 +725,23 @@ mod tests {
         let publisher = std::sync::Arc::new(ReadinessPublisher::new());
         let (sent, _received) = std::sync::mpsc::sync_channel(1);
         let (_releaser, release) = std::sync::mpsc::channel();
-        let mut channel = GatedChannel { sent, release };
+        let channel = GatedChannel { sent, release };
         let parked = std::sync::Arc::clone(&publisher);
         let (parked_sender, parked_receiver) = std::sync::mpsc::channel();
 
-        let publisher_thread = std::thread::spawn(move || {
-            publish_readiness(&parked, &mut channel, || {
-                // Reporting from inside the wait is what proves the publisher
-                // reached it, so closing is what ends it rather than a queue it
-                // already found closed.
-                let _ = parked_sender.send(());
-                std::thread::sleep(core::time::Duration::from_millis(1));
-            })
+        let finish = spawn_publication(parked, channel, move || {
+            // Reporting from inside the wait is what proves the publisher
+            // reached it, so closing is what ends it rather than a queue it
+            // already found closed.
+            let _ = parked_sender.send(());
+            std::thread::sleep(core::time::Duration::from_millis(1));
         });
         parked_receiver
-            .recv()
+            .recv_timeout(TEST_TIMEOUT)
             .expect("publication must park before it is closed");
         publisher.close();
 
-        publisher_thread.join().unwrap().unwrap();
+        expect_publication_ended(&finish);
     }
 
     #[test]
@@ -722,17 +750,15 @@ mod tests {
         publish(&publisher, HANDLE, ReadinessFlags::READ);
         let (sent, received) = std::sync::mpsc::sync_channel(0);
         let (releaser, release) = std::sync::mpsc::channel();
-        let mut channel = GatedChannel { sent, release };
+        let channel = GatedChannel { sent, release };
         let publishing = std::sync::Arc::clone(&publisher);
-        let publisher_thread = std::thread::spawn(move || {
-            publish_readiness(&publishing, &mut channel, || {
-                std::thread::sleep(core::time::Duration::from_millis(1));
-            })
+        let finish = spawn_publication(publishing, channel, || {
+            std::thread::sleep(core::time::Duration::from_millis(1));
         });
 
         // The first notification is now in flight and cannot be confirmed yet.
         assert_eq!(
-            readiness_of(&received.recv().unwrap()).readiness,
+            readiness_of(&received.recv_timeout(TEST_TIMEOUT).unwrap()).readiness,
             ReadinessFlags::READ
         );
         assert_eq!(
@@ -742,12 +768,12 @@ mod tests {
         releaser.send(()).unwrap();
 
         assert_eq!(
-            readiness_of(&received.recv().unwrap()).readiness,
+            readiness_of(&received.recv_timeout(TEST_TIMEOUT).unwrap()).readiness,
             ReadinessFlags::HANGUP
         );
         releaser.send(()).unwrap();
         publisher.close();
-        publisher_thread.join().unwrap().unwrap();
+        expect_publication_ended(&finish);
     }
 
     #[test]

--- a/litebox_broker_host/src/readiness.rs
+++ b/litebox_broker_host/src/readiness.rs
@@ -106,8 +106,13 @@ struct PublisherState {
 struct ReadinessEntry {
     /// Newest authoritative flags recorded by a backend source.
     readiness: ReadinessFlags,
-    /// Advances whenever `readiness` changes, identifying the exact value a
-    /// claim was taken from.
+    /// Advances whenever `readiness` changes.
+    ///
+    /// Confirmation compares this rather than the published flags because a
+    /// notification only tells the local endpoint to re-check; the endpoint
+    /// then samples authoritative state itself and may observe a value the
+    /// publisher never sent. Flags that change and return to the published
+    /// value are therefore still a change the endpoint must be told about.
     generation: u64,
     /// A change has not yet been confirmed as published.
     dirty: bool,
@@ -210,9 +215,11 @@ impl ReadinessPublisher {
     /// Reports that a claimed notification reached the notification channel.
     ///
     /// The pending mark is cleared only when the object still holds the
-    /// generation the claim was taken from. A change recorded while the
-    /// notification was in flight leaves the object pending and already queued
-    /// it for another claim.
+    /// generation the claim was taken from. Any change recorded while the
+    /// notification was in flight leaves the object pending, including a change
+    /// that returned to the published flags, because the local endpoint samples
+    /// authoritative state independently and may have observed the intermediate
+    /// value.
     pub fn confirm(&self, pending: &PendingReadiness) {
         let mut state = self.state.lock();
         if let Some(entry) = state.entries.get_mut(&pending.notification.handle)
@@ -384,6 +391,29 @@ mod tests {
             [ReadinessNotification {
                 handle: HANDLE,
                 readiness: ReadinessFlags::WRITE,
+            }]
+        );
+    }
+
+    #[test]
+    fn readiness_that_returns_to_the_claimed_value_is_still_republished() {
+        let publisher = ReadinessPublisher::new();
+        publish(&publisher, HANDLE, ReadinessFlags::READ);
+        let pending = publisher.take_pending().unwrap();
+
+        // The local endpoint re-checks authoritative state on its own after a
+        // notification, so it may sample the intermediate value. Returning to
+        // the claimed value is therefore still a change it must be told about,
+        // which is why confirmation compares generations and not flags.
+        publish(&publisher, HANDLE, ReadinessFlags::WRITE);
+        publish(&publisher, HANDLE, ReadinessFlags::READ);
+        publisher.confirm(&pending);
+
+        assert_eq!(
+            drain(&publisher),
+            [ReadinessNotification {
+                handle: HANDLE,
+                readiness: ReadinessFlags::READ,
             }]
         );
     }

--- a/litebox_broker_host/src/readiness.rs
+++ b/litebox_broker_host/src/readiness.rs
@@ -100,6 +100,13 @@ pub struct ReadinessPublisher {
 struct PublisherState {
     entries: HashMap<ObjectHandle, ReadinessEntry>,
     queue: VecDeque<ObjectHandle>,
+    /// Generation to hand to the next recorded change.
+    ///
+    /// Generations are allocated publisher-wide rather than per object so that
+    /// an object re-registered under a recycled handle cannot reuse a value a
+    /// still-unconfirmed claim was taken from. Values may be skipped; only
+    /// their uniqueness matters.
+    next_generation: u64,
     closed: bool,
 }
 
@@ -107,7 +114,7 @@ struct PublisherState {
 struct ReadinessEntry {
     /// Newest authoritative flags recorded by a backend source.
     readiness: ReadinessFlags,
-    /// Advances whenever `readiness` changes.
+    /// Identifies the recorded change, and is replaced whenever one arrives.
     ///
     /// Confirmation compares this rather than the published flags because a
     /// notification only tells the local endpoint to re-check; the endpoint
@@ -135,6 +142,7 @@ impl ReadinessPublisher {
             state: SpinMutex::new(PublisherState {
                 entries: HashMap::new(),
                 queue: VecDeque::new(),
+                next_generation: 0,
                 closed: false,
             }),
         }
@@ -154,6 +162,7 @@ impl ReadinessPublisher {
         if state.closed {
             return Ok(PublishOutcome::Closed);
         }
+        let generation = state.next_generation;
         if let Some(entry) = state.entries.get_mut(&handle) {
             if entry.readiness == readiness {
                 // Either the local endpoint already knows this value or a
@@ -161,12 +170,14 @@ impl ReadinessPublisher {
                 return Ok(PublishOutcome::Coalesced);
             }
             entry.readiness = readiness;
-            entry.generation = entry.generation.wrapping_add(1);
+            entry.generation = generation;
             entry.dirty = true;
-            if entry.queued {
+            let already_queued = entry.queued;
+            entry.queued = true;
+            state.next_generation = generation.wrapping_add(1);
+            if already_queued {
                 return Ok(PublishOutcome::Coalesced);
             }
-            entry.queued = true;
         } else {
             if state.entries.len() >= MAX_TRACKED_READINESS_OBJECTS {
                 return Err(ReadinessPublishError::TooManyObjects);
@@ -175,11 +186,12 @@ impl ReadinessPublisher {
                 handle,
                 ReadinessEntry {
                     readiness,
-                    generation: 0,
+                    generation,
                     dirty: true,
                     queued: true,
                 },
             );
+            state.next_generation = generation.wrapping_add(1);
         }
         state.queue.push_back(handle);
         Ok(PublishOutcome::Queued)
@@ -187,8 +199,13 @@ impl ReadinessPublisher {
 
     /// Claims the next pending readiness notification, if any.
     ///
-    /// The claim stays pending until [`confirm`] reports it as published, so a
-    /// publisher that fails or is interrupted does not silently drop it.
+    /// The claim leaves the object marked pending until [`confirm`] reports it
+    /// as published, so a change recorded while it is in flight is republished
+    /// rather than lost. The caller must confirm every claim it takes: a claim
+    /// that is dropped leaves the object pending but unqueued, and only a
+    /// later *changed* publication requeues it. Callers that cannot confirm
+    /// must treat publication as finished, which is what a failed send means
+    /// because it has already broken the association's notification channel.
     ///
     /// [`confirm`]: Self::confirm
     #[must_use]
@@ -500,6 +517,27 @@ mod tests {
         assert_eq!(
             publisher.publish(HANDLE, ReadinessFlags::READ).unwrap(),
             PublishOutcome::Queued
+        );
+    }
+
+    #[test]
+    fn confirming_a_claim_taken_before_reuse_does_not_clear_the_new_update() {
+        let publisher = ReadinessPublisher::new();
+        publish(&publisher, HANDLE, ReadinessFlags::READ);
+        let stale = publisher.take_pending().unwrap();
+
+        // The object is retired and the handle is recycled for a new object
+        // while the first claim is still in flight.
+        publisher.retire(HANDLE);
+        publish(&publisher, HANDLE, ReadinessFlags::WRITE);
+        publisher.confirm(&stale);
+
+        assert_eq!(
+            drain(&publisher),
+            [ReadinessNotification {
+                handle: HANDLE,
+                readiness: ReadinessFlags::WRITE,
+            }]
         );
     }
 

--- a/litebox_broker_host/src/readiness.rs
+++ b/litebox_broker_host/src/readiness.rs
@@ -31,8 +31,9 @@
 //! [`confirm`]: ReadinessPublisher::confirm
 //! [`BrokerNotification::Readiness`]: litebox_broker_protocol::message::BrokerNotification::Readiness
 
-use alloc::collections::{BTreeMap, VecDeque};
+use alloc::collections::VecDeque;
 
+use hashbrown::HashMap;
 use litebox_broker_protocol::ObjectHandle;
 use litebox_broker_protocol::channel::HostNotificationChannel;
 use litebox_broker_protocol::message::{BrokerNotification, ReadinessNotification};
@@ -97,7 +98,7 @@ pub struct ReadinessPublisher {
 
 #[derive(Debug)]
 struct PublisherState {
-    entries: BTreeMap<ObjectHandle, ReadinessEntry>,
+    entries: HashMap<ObjectHandle, ReadinessEntry>,
     queue: VecDeque<ObjectHandle>,
     closed: bool,
 }
@@ -129,10 +130,10 @@ impl Default for ReadinessPublisher {
 impl ReadinessPublisher {
     /// Creates empty readiness publication state.
     #[must_use]
-    pub const fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             state: SpinMutex::new(PublisherState {
-                entries: BTreeMap::new(),
+                entries: HashMap::new(),
                 queue: VecDeque::new(),
                 closed: false,
             }),

--- a/litebox_broker_host/src/readiness.rs
+++ b/litebox_broker_host/src/readiness.rs
@@ -309,6 +309,13 @@ impl ReadinessPublisher {
     pub fn tracked_objects(&self) -> usize {
         self.state.lock().entries.len()
     }
+
+    /// Number of queue slots holding work, which must never exceed the number
+    /// of tracked objects.
+    #[cfg(test)]
+    fn queued_updates(&self) -> usize {
+        self.state.lock().queue.len()
+    }
 }
 
 /// Publishes coalesced readiness updates until publication closes.
@@ -511,6 +518,9 @@ mod tests {
         publisher.retire(HANDLE);
 
         assert_eq!(publisher.tracked_objects(), 1);
+        // The queued slot goes with the object; leaving it behind would let a
+        // local grow the queue without bound by cycling objects.
+        assert_eq!(publisher.queued_updates(), 1);
         assert_eq!(
             drain(&publisher),
             [ReadinessNotification {
@@ -676,7 +686,7 @@ mod tests {
     }
 
     #[test]
-    fn publishing_drains_pending_work_before_observing_closure() {
+    fn queued_updates_publish_in_order_until_the_waiter_closes() {
         let publisher = ReadinessPublisher::new();
         publish(&publisher, HANDLE, ReadinessFlags::READ);
         publish(&publisher, OTHER_HANDLE, ReadinessFlags::WRITE);
@@ -801,6 +811,9 @@ mod tests {
         publish(&publisher, HANDLE, ReadinessFlags::WRITE);
         drop(stale);
 
+        // The newer change already queued the object, so the abandoned claim
+        // must not queue it a second time.
+        assert_eq!(publisher.queued_updates(), 1);
         assert_eq!(
             drain(&publisher),
             [ReadinessNotification {

--- a/litebox_broker_userland/src/lib.rs
+++ b/litebox_broker_userland/src/lib.rs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//! Linux-userland broker host deployment support.
+//!
+//! The broker host binary in this crate owns process, socket, and thread
+//! policy. This library holds the deployment pieces that are useful outside
+//! `main`, so integration tests can drive the same code the binary runs.
+
+pub mod readiness;

--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -417,9 +417,9 @@ mod tests {
     /// held open so the association stays up for the duration of a test.
     struct LiveAssociation {
         request_source: UnixControlRingHostRequestSource,
+        notifications: UnixControlRingHostNotificationChannel,
         shutdown: UnixControlRingHostShutdown,
         _response_sink: UnixControlRingHostResponseSink,
-        _notifications: UnixControlRingHostNotificationChannel,
         _local: (
             UnixControlRingLocalCallChannel,
             UnixControlRingLocalNotificationChannel,
@@ -451,9 +451,9 @@ mod tests {
             control_channel.into_active(host_ring).unwrap();
         LiveAssociation {
             request_source,
+            notifications,
             shutdown,
             _response_sink: response_sink,
-            _notifications: notifications,
             _local: local_activation.join().unwrap(),
         }
     }
@@ -502,29 +502,47 @@ mod tests {
     }
 
     #[test]
-    fn dropping_the_publication_guard_ends_the_notification_transport() {
-        let association = live_association();
-        let mut request_source = association.request_source;
-        let failure_coordinator = HostAssociationFailureCoordinator::new(association.shutdown);
-        let readiness = ReadinessPublisherRuntime::new();
-        let (received, receive) = sync_channel(1);
-        let reader = std::thread::spawn(move || {
-            received.send(request_source.recv_request()).unwrap();
-        });
+    fn dropping_the_publication_guard_ends_a_publisher_blocked_on_ring_capacity() {
+        use litebox_broker_protocol::ObjectHandle;
+        use litebox_broker_protocol::readiness::ReadinessFlags;
+        use litebox_broker_transport::control_ring::CONTROL_RING_NOTIFICATION_SLOT_COUNT;
 
-        // Closing publication cannot reach a publisher blocked on notification
-        // capacity, and an unwind reaches the scope join before anything else
-        // ends the transport, so the guard has to end it too.
+        let association = live_association();
+        let mut notifications = association.notifications;
+        let failure_coordinator = HostAssociationFailureCoordinator::new(association.shutdown);
+        let readiness = Arc::new(ReadinessPublisherRuntime::new());
+
+        // The local endpoint never drains, so the ring fills and the publisher
+        // ends up blocked on capacity rather than parked for work. Closing
+        // publication cannot reach it there, and an unwind reaches the scope
+        // join before anything else ends the transport.
+        for handle in 0..CONTROL_RING_NOTIFICATION_SLOT_COUNT * 3 {
+            readiness
+                .publish(ObjectHandle(handle), ReadinessFlags::READ)
+                .unwrap();
+        }
+        let publishing = Arc::clone(&readiness);
+        let (finished, finish) = sync_channel(1);
+        let publisher = std::thread::spawn(move || {
+            finished.send(publishing.run(&mut notifications)).unwrap();
+        });
+        std::thread::sleep(Duration::from_millis(20));
+
         drop(ReadinessPublicationGuard {
             readiness: &readiness,
             failure_coordinator: &failure_coordinator,
         });
 
-        let result = receive
+        let outcome = finish
             .recv_timeout(SETUP_TIMEOUT)
-            .expect("dropping the guard must end the association transport");
-        reader.join().unwrap();
-        assert!(matches!(result, Ok(HostReceive::PeerClosed) | Err(_)));
+            .expect("dropping the guard must end a publisher blocked on capacity");
+        publisher.join().unwrap();
+        assert_eq!(
+            outcome
+                .expect_err("ending the transport must fail the blocked send")
+                .kind(),
+            ErrorKind::ConnectionAborted
+        );
         assert!(
             failure_coordinator.take_error().is_none(),
             "ending the transport during teardown must not report a failure"

--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -25,9 +25,11 @@ use litebox_broker_protocol::shared_memory::{
 use litebox_broker_transport::control_ring::{CONTROL_RING_MEMORY_SIZE, ControlRing};
 use litebox_broker_transport::shared_memory::MemfdSharedMemory;
 use litebox_broker_transport::unix_socket::{
-    UnixControlRingHostRequestSource, UnixControlRingHostResponseSink, UnixControlRingHostShutdown,
-    UnixStreamHostSetupChannel, validate_peer_process,
+    UnixControlRingHostNotificationChannel, UnixControlRingHostRequestSource,
+    UnixControlRingHostResponseSink, UnixControlRingHostShutdown, UnixStreamHostSetupChannel,
+    validate_peer_process,
 };
+use litebox_broker_userland::readiness::ReadinessPublisherRuntime;
 
 const SETUP_TIMEOUT: Duration = Duration::from_secs(5);
 const ACCEPT_RETRY_DELAY: Duration = Duration::from_millis(10);
@@ -128,9 +130,15 @@ fn serve_runner(
                 .into());
             }
         };
-    let (request_source, response_sink, _notification_channel, shutdown) =
+    let (request_source, response_sink, notification_channel, shutdown) =
         control_channel.into_active(control_ring)?;
-    dispatch_requests(association, request_source, response_sink, shutdown)?;
+    dispatch_requests(
+        association,
+        request_source,
+        response_sink,
+        notification_channel,
+        shutdown,
+    )?;
     Ok(())
 }
 
@@ -138,14 +146,35 @@ fn dispatch_requests<Memory: SharedMemory>(
     association: BrokerHostAssociation<'_, Memory>,
     mut request_source: UnixControlRingHostRequestSource,
     response_sink: UnixControlRingHostResponseSink,
+    mut notification_channel: UnixControlRingHostNotificationChannel,
     shutdown: UnixControlRingHostShutdown,
 ) -> IoResult<()> {
     let association = Arc::new(association);
     let failure_coordinator = Arc::new(HostAssociationFailureCoordinator::new(shutdown));
+    let readiness = Arc::new(ReadinessPublisherRuntime::new());
     let (request_sender, request_receiver) = sync_channel(REQUEST_QUEUE_CAPACITY);
     let request_receiver = Arc::new(Mutex::new(request_receiver));
 
     std::thread::scope(|scope| {
+        let publisher_readiness = Arc::clone(&readiness);
+        let publisher = std::thread::Builder::new()
+            .name("litebox-broker-notifier".to_owned())
+            .spawn_scoped(scope, move || {
+                // The request reader owns association termination. A failing
+                // notification transport fails the association, so the reader
+                // observes and reports the same error, and a peer that closed
+                // cleanly is not a failure at all. Reporting here would turn a
+                // clean shutdown into a reported error.
+                let _ = publisher_readiness.run(&mut notification_channel);
+            });
+        let publisher = match publisher {
+            Ok(publisher) => Some(publisher),
+            Err(error) => {
+                failure_coordinator.report(error);
+                None
+            }
+        };
+
         let mut workers = Vec::with_capacity(WORKER_COUNT);
         for worker_id in 0..WORKER_COUNT {
             let association = Arc::clone(&association);
@@ -171,10 +200,18 @@ fn dispatch_requests<Memory: SharedMemory>(
         }
 
         read_requests(&mut request_source, request_sender, &failure_coordinator);
+        // Request reading ends on peer closure or on any reported failure, both
+        // of which end the association, so readiness publication stops here.
+        readiness.close();
         for worker in workers {
             if worker.join().is_err() {
                 failure_coordinator.report(IoError::other("broker request worker panicked"));
             }
+        }
+        if let Some(publisher) = publisher
+            && publisher.join().is_err()
+        {
+            failure_coordinator.report(IoError::other("broker readiness publisher panicked"));
         }
     });
 

--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -142,6 +142,57 @@ fn serve_runner(
     Ok(())
 }
 
+/// Records the first failure of an association and ends its transport.
+///
+/// Every thread serving an association reports through this, and the endpoints
+/// they block on are released by ending the transport, so it is what the
+/// teardown guards below reach for.
+struct HostAssociationFailureCoordinator {
+    failed: AtomicBool,
+    error: Mutex<Option<IoError>>,
+    shutdown: UnixControlRingHostShutdown,
+}
+
+impl HostAssociationFailureCoordinator {
+    const fn new(shutdown: UnixControlRingHostShutdown) -> Self {
+        Self {
+            failed: AtomicBool::new(false),
+            error: Mutex::new(None),
+            shutdown,
+        }
+    }
+
+    fn failed(&self) -> bool {
+        self.failed.load(Ordering::Acquire)
+    }
+
+    fn report(&self, error: IoError) {
+        if self.failed.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        *self
+            .error
+            .lock()
+            .expect("broker association failure mutex poisoned") = Some(error);
+        let _ = self.shutdown.shutdown();
+    }
+
+    /// Ends the association transport without recording a failure.
+    ///
+    /// Teardown uses this to release endpoints blocked on the control ring
+    /// without turning a shutdown that reported nothing into a reported error.
+    fn shutdown(&self) {
+        let _ = self.shutdown.shutdown();
+    }
+
+    fn take_error(&self) -> Option<IoError> {
+        self.error
+            .lock()
+            .expect("broker association failure mutex poisoned")
+            .take()
+    }
+}
+
 /// Fails the association if readiness publication unwinds.
 ///
 /// The request reader owns association termination but does not depend on the
@@ -345,52 +396,6 @@ fn run_worker<Memory: SharedMemory>(
                 failure_coordinator.report(IoError::other("broker request worker panicked"));
             }
         }
-    }
-}
-
-struct HostAssociationFailureCoordinator {
-    failed: AtomicBool,
-    error: Mutex<Option<IoError>>,
-    shutdown: UnixControlRingHostShutdown,
-}
-
-impl HostAssociationFailureCoordinator {
-    const fn new(shutdown: UnixControlRingHostShutdown) -> Self {
-        Self {
-            failed: AtomicBool::new(false),
-            error: Mutex::new(None),
-            shutdown,
-        }
-    }
-
-    fn failed(&self) -> bool {
-        self.failed.load(Ordering::Acquire)
-    }
-
-    fn report(&self, error: IoError) {
-        if self.failed.swap(true, Ordering::AcqRel) {
-            return;
-        }
-        *self
-            .error
-            .lock()
-            .expect("broker association failure mutex poisoned") = Some(error);
-        let _ = self.shutdown.shutdown();
-    }
-
-    /// Ends the association transport without recording a failure.
-    ///
-    /// Teardown uses this to release endpoints blocked on the control ring
-    /// without turning a shutdown that reported nothing into a reported error.
-    fn shutdown(&self) {
-        let _ = self.shutdown.shutdown();
-    }
-
-    fn take_error(&self) -> Option<IoError> {
-        self.error
-            .lock()
-            .expect("broker association failure mutex poisoned")
-            .take()
     }
 }
 

--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -142,17 +142,24 @@ fn serve_runner(
     Ok(())
 }
 
-/// Closes readiness publication when an association scope ends for any reason.
+/// Ends readiness publication when an association scope ends for any reason.
 ///
 /// The publisher is a scoped thread, so the scope joins it before propagating a
-/// panic out of the association. A publisher parked for work only returns once
-/// publication closes, so an unwind that skipped closing would hang teardown
-/// forever instead of reporting the panic.
-struct ReadinessPublicationGuard<'runtime>(&'runtime ReadinessPublisherRuntime);
+/// panic out of the association, and both states it can rest in have to end for
+/// that join to complete. Closing publication returns a publisher parked for
+/// work, and ending the transport returns one blocked on notification capacity
+/// that a local endpoint stopped draining. The failure coordinator owns the
+/// association until `dispatch_requests` returns, which is after that join, so
+/// an unwind cannot leave ending the transport to dropping it.
+struct ReadinessPublicationGuard<'association> {
+    readiness: &'association ReadinessPublisherRuntime,
+    failure_coordinator: &'association HostAssociationFailureCoordinator,
+}
 
 impl Drop for ReadinessPublicationGuard<'_> {
     fn drop(&mut self) {
-        self.0.close();
+        self.readiness.close();
+        self.failure_coordinator.shutdown();
     }
 }
 
@@ -191,10 +198,14 @@ fn dispatch_requests<Memory: SharedMemory>(
             }
         };
 
-        // Publication must close on every exit, including an unwind: the scope
+        // Publication must end on every exit, including an unwind: the scope
         // joins the publisher before it propagates a panic, and a publisher
-        // parked for work would never return, hanging teardown instead.
-        let _publication = ReadinessPublicationGuard(&readiness);
+        // still parked or still blocked on ring capacity would never return,
+        // hanging teardown instead.
+        let _publication = ReadinessPublicationGuard {
+            readiness: &readiness,
+            failure_coordinator: &failure_coordinator,
+        };
 
         let mut workers = Vec::with_capacity(WORKER_COUNT);
         for worker_id in 0..WORKER_COUNT {
@@ -340,6 +351,14 @@ impl HostAssociationFailureCoordinator {
         let _ = self.shutdown.shutdown();
     }
 
+    /// Ends the association transport without recording a failure.
+    ///
+    /// Teardown uses this to release endpoints blocked on the control ring
+    /// without turning a shutdown that reported nothing into a reported error.
+    fn shutdown(&self) {
+        let _ = self.shutdown.shutdown();
+    }
+
     fn take_error(&self) -> Option<IoError> {
         self.error
             .lock()
@@ -388,49 +407,27 @@ mod tests {
     use litebox_broker_protocol::BROKER_PROTOCOL_VERSION;
     use litebox_broker_protocol::channel::{HostSetupChannel, LocalSetupChannel};
     use litebox_broker_protocol::message::BrokerHandshakeResponse;
-    use litebox_broker_transport::unix_socket::UnixStreamLocalSetupChannel;
+    use litebox_broker_transport::unix_socket::{
+        UnixControlRingLocalCallChannel, UnixControlRingLocalNotificationChannel,
+        UnixControlRingLocalShutdown, UnixStreamLocalSetupChannel,
+    };
     use std::os::fd::AsFd;
 
-    #[test]
-    fn dropping_the_publication_guard_ends_a_parked_publisher() {
-        use litebox_broker_protocol::channel::HostNotificationChannel;
-        use litebox_broker_protocol::message::BrokerNotification;
-
-        struct DiscardingChannel;
-
-        impl HostNotificationChannel for DiscardingChannel {
-            type Error = IoError;
-
-            fn send_notification(&mut self, _notification: &BrokerNotification) -> IoResult<()> {
-                Ok(())
-            }
-        }
-
-        let readiness = Arc::new(ReadinessPublisherRuntime::new());
-        let publishing = Arc::clone(&readiness);
-        let (finished, finish) = sync_channel(1);
-        let publisher = std::thread::spawn(move || {
-            finished
-                .send(publishing.run(&mut DiscardingChannel))
-                .unwrap();
-        });
-
-        // The publisher parks on an empty queue, so only closing publication
-        // ends it. An unwind past the explicit close leaves the guard as the
-        // only thing that can, and the scope joins the publisher before it
-        // propagates the panic.
-        std::thread::sleep(Duration::from_millis(20));
-        drop(ReadinessPublicationGuard(&readiness));
-
-        finish
-            .recv_timeout(SETUP_TIMEOUT)
-            .expect("dropping the guard must end the parked publisher")
-            .unwrap();
-        publisher.join().unwrap();
+    /// One live host association: the endpoints teardown acts on, and the rest
+    /// held open so the association stays up for the duration of a test.
+    struct LiveAssociation {
+        request_source: UnixControlRingHostRequestSource,
+        shutdown: UnixControlRingHostShutdown,
+        _response_sink: UnixControlRingHostResponseSink,
+        _notifications: UnixControlRingHostNotificationChannel,
+        _local: (
+            UnixControlRingLocalCallChannel,
+            UnixControlRingLocalNotificationChannel,
+            UnixControlRingLocalShutdown,
+        ),
     }
 
-    #[test]
-    fn first_failure_is_preserved_and_unblocks_request_reading() {
+    fn live_association() -> LiveAssociation {
         let (peer_stream, host_stream) = UnixStream::pair().unwrap();
         let mut local_setup = UnixStreamLocalSetupChannel::from_connected(peer_stream);
         let mut control_channel = UnixStreamHostSetupChannel::from_accepted(host_stream);
@@ -450,10 +447,95 @@ mod tests {
         let host_ring = ControlRing::new(host_memory).unwrap();
         let local_activation =
             std::thread::spawn(move || local_setup.into_active(local_ring, || {}).unwrap());
-        let (mut request_source, _response_sink, _notifications, shutdown) =
+        let (request_source, response_sink, notifications, shutdown) =
             control_channel.into_active(host_ring).unwrap();
-        let (_local_call, _local_notifications, _local_shutdown) = local_activation.join().unwrap();
-        let failure_coordinator = HostAssociationFailureCoordinator::new(shutdown);
+        LiveAssociation {
+            request_source,
+            shutdown,
+            _response_sink: response_sink,
+            _notifications: notifications,
+            _local: local_activation.join().unwrap(),
+        }
+    }
+
+    #[test]
+    fn dropping_the_publication_guard_ends_a_parked_publisher() {
+        use litebox_broker_protocol::channel::HostNotificationChannel;
+        use litebox_broker_protocol::message::BrokerNotification;
+
+        struct DiscardingChannel;
+
+        impl HostNotificationChannel for DiscardingChannel {
+            type Error = IoError;
+
+            fn send_notification(&mut self, _notification: &BrokerNotification) -> IoResult<()> {
+                Ok(())
+            }
+        }
+
+        let association = live_association();
+        let failure_coordinator = HostAssociationFailureCoordinator::new(association.shutdown);
+        let readiness = Arc::new(ReadinessPublisherRuntime::new());
+        let publishing = Arc::clone(&readiness);
+        let (finished, finish) = sync_channel(1);
+        let publisher = std::thread::spawn(move || {
+            finished
+                .send(publishing.run(&mut DiscardingChannel))
+                .unwrap();
+        });
+
+        // The publisher parks on an empty queue, so only closing publication
+        // ends it. An unwind past the explicit close leaves the guard as the
+        // only thing that can, and the scope joins the publisher before it
+        // propagates the panic.
+        std::thread::sleep(Duration::from_millis(20));
+        drop(ReadinessPublicationGuard {
+            readiness: &readiness,
+            failure_coordinator: &failure_coordinator,
+        });
+
+        finish
+            .recv_timeout(SETUP_TIMEOUT)
+            .expect("dropping the guard must end the parked publisher")
+            .unwrap();
+        publisher.join().unwrap();
+    }
+
+    #[test]
+    fn dropping_the_publication_guard_ends_the_notification_transport() {
+        let association = live_association();
+        let mut request_source = association.request_source;
+        let failure_coordinator = HostAssociationFailureCoordinator::new(association.shutdown);
+        let readiness = ReadinessPublisherRuntime::new();
+        let (received, receive) = sync_channel(1);
+        let reader = std::thread::spawn(move || {
+            received.send(request_source.recv_request()).unwrap();
+        });
+
+        // Closing publication cannot reach a publisher blocked on notification
+        // capacity, and an unwind reaches the scope join before anything else
+        // ends the transport, so the guard has to end it too.
+        drop(ReadinessPublicationGuard {
+            readiness: &readiness,
+            failure_coordinator: &failure_coordinator,
+        });
+
+        let result = receive
+            .recv_timeout(SETUP_TIMEOUT)
+            .expect("dropping the guard must end the association transport");
+        reader.join().unwrap();
+        assert!(matches!(result, Ok(HostReceive::PeerClosed) | Err(_)));
+        assert!(
+            failure_coordinator.take_error().is_none(),
+            "ending the transport during teardown must not report a failure"
+        );
+    }
+
+    #[test]
+    fn first_failure_is_preserved_and_unblocks_request_reading() {
+        let association = live_association();
+        let mut request_source = association.request_source;
+        let failure_coordinator = HostAssociationFailureCoordinator::new(association.shutdown);
         let (result_sender, result_receiver) = std::sync::mpsc::sync_channel(1);
         let reader = std::thread::spawn(move || {
             result_sender.send(request_source.recv_request()).unwrap();

--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -200,14 +200,16 @@ fn dispatch_requests<Memory: SharedMemory>(
         }
 
         read_requests(&mut request_source, request_sender, &failure_coordinator);
-        // Request reading ends on peer closure or on any reported failure, both
-        // of which end the association, so readiness publication stops here.
-        readiness.close();
         for worker in workers {
             if worker.join().is_err() {
                 failure_coordinator.report(IoError::other("broker request worker panicked"));
             }
         }
+        // Readiness publication lives exactly as long as the association. The
+        // request reader returns only once the association is over, but workers
+        // keep draining already-queued requests after that, so publication must
+        // outlive them or a late readiness change would be discarded.
+        readiness.close();
         if let Some(publisher) = publisher
             && publisher.join().is_err()
         {

--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -491,7 +491,7 @@ mod tests {
     }
 
     #[test]
-    fn dropping_the_publication_guard_ends_a_parked_publisher() {
+    fn publication_guard_ends_a_parked_publisher() {
         use litebox_broker_protocol::channel::HostNotificationChannel;
         use litebox_broker_protocol::message::BrokerNotification;
 
@@ -534,7 +534,7 @@ mod tests {
     }
 
     #[test]
-    fn dropping_the_publication_guard_ends_a_publisher_blocked_on_ring_capacity() {
+    fn publication_guard_ends_a_capacity_blocked_publisher() {
         use litebox_broker_protocol::ObjectHandle;
         use litebox_broker_protocol::readiness::ReadinessFlags;
         use litebox_broker_transport::control_ring::CONTROL_RING_NOTIFICATION_SLOT_COUNT;

--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -202,7 +202,7 @@ fn dispatch_requests<Memory: SharedMemory>(
         // joins the publisher before it propagates a panic, and a publisher
         // still parked or still blocked on ring capacity would never return,
         // hanging teardown instead.
-        let _publication = ReadinessPublicationGuard {
+        let publication = ReadinessPublicationGuard {
             readiness: &readiness,
             failure_coordinator: &failure_coordinator,
         };
@@ -240,10 +240,12 @@ fn dispatch_requests<Memory: SharedMemory>(
         // Readiness publication lives exactly as long as the association. The
         // request reader returns only once the association is over, but workers
         // keep draining already-queued requests after that, so publication must
-        // outlive them or a late readiness change would be discarded. Closing
-        // here rather than leaving it to the guard orders it before the join
-        // that observes a panicking publisher.
-        readiness.close();
+        // outlive them or a late readiness change would be discarded. Ending it
+        // here rather than leaving it to the scope orders it before the join
+        // that observes a panicking publisher, and dropping the guard is what
+        // ends both states the publisher can rest in without depending on the
+        // reader having failed the association already.
+        drop(publication);
         if let Some(publisher) = publisher
             && publisher.join().is_err()
         {

--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -142,6 +142,27 @@ fn serve_runner(
     Ok(())
 }
 
+/// Fails the association if readiness publication unwinds.
+///
+/// The request reader owns association termination but does not depend on the
+/// publisher, so an unwinding publisher would otherwise leave a live
+/// association with no notification source. The join that turns that panic into
+/// a reported failure is reached only once the reader has returned, and a peer
+/// that is waiting for a readiness change it will never be told about does not
+/// return it. Failing the association here ends that wait instead.
+struct PublisherPanicGuard<'association> {
+    failure_coordinator: &'association HostAssociationFailureCoordinator,
+}
+
+impl Drop for PublisherPanicGuard<'_> {
+    fn drop(&mut self) {
+        if std::thread::panicking() {
+            self.failure_coordinator
+                .report(IoError::other("broker readiness publisher panicked"));
+        }
+    }
+}
+
 /// Ends readiness publication when an association scope ends for any reason.
 ///
 /// The publisher is a scoped thread, so the scope joins it before propagating a
@@ -178,9 +199,13 @@ fn dispatch_requests<Memory: SharedMemory>(
 
     std::thread::scope(|scope| {
         let publisher_readiness = Arc::clone(&readiness);
+        let publisher_failure_coordinator = Arc::clone(&failure_coordinator);
         let publisher = std::thread::Builder::new()
             .name("litebox-broker-notifier".to_owned())
             .spawn_scoped(scope, move || {
+                let _panicking = PublisherPanicGuard {
+                    failure_coordinator: &publisher_failure_coordinator,
+                };
                 // The request reader owns association termination. A failing
                 // notification transport fails the association, so a reader
                 // still running observes and reports the same error, and a peer
@@ -549,6 +574,39 @@ mod tests {
             failure_coordinator.take_error().is_none(),
             "ending the transport during teardown must not report a failure"
         );
+    }
+
+    #[test]
+    fn a_panicking_publisher_ends_a_blocked_request_reader() {
+        let association = live_association();
+        let mut request_source = association.request_source;
+        let failure_coordinator =
+            Arc::new(HostAssociationFailureCoordinator::new(association.shutdown));
+        let (result_sender, result_receiver) = std::sync::mpsc::sync_channel(1);
+        let reader = std::thread::spawn(move || {
+            result_sender.send(request_source.recv_request()).unwrap();
+        });
+
+        // The peer sends nothing and never closes, so the reader returns only
+        // if the publisher's unwind fails the association.
+        let publisher_failure_coordinator = Arc::clone(&failure_coordinator);
+        let publisher = std::thread::spawn(move || {
+            let _panicking = PublisherPanicGuard {
+                failure_coordinator: &publisher_failure_coordinator,
+            };
+            panic!("readiness publication panicked");
+        });
+
+        let receive_result = result_receiver
+            .recv_timeout(SETUP_TIMEOUT)
+            .expect("a panicking publisher must end a blocked request reader");
+        assert!(matches!(
+            receive_result,
+            Ok(HostReceive::PeerClosed) | Err(_)
+        ));
+        reader.join().unwrap();
+        assert!(publisher.join().is_err());
+        assert!(failure_coordinator.take_error().is_some());
     }
 
     #[test]

--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -175,10 +175,12 @@ fn dispatch_requests<Memory: SharedMemory>(
             .name("litebox-broker-notifier".to_owned())
             .spawn_scoped(scope, move || {
                 // The request reader owns association termination. A failing
-                // notification transport fails the association, so the reader
-                // observes and reports the same error, and a peer that closed
-                // cleanly is not a failure at all. Reporting here would turn a
-                // clean shutdown into a reported error.
+                // notification transport fails the association, so a reader
+                // still running observes and reports the same error, and a peer
+                // that closed cleanly is not a failure at all. Reporting here
+                // would turn a clean shutdown into a reported error. A failure
+                // that first appears once the reader has returned is dropped
+                // deliberately, because the association is already over.
                 let _ = publisher_readiness.run(&mut notification_channel);
             });
         let publisher = match publisher {

--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -134,6 +134,7 @@ fn serve_runner(
         control_channel.into_active(control_ring)?;
     dispatch_requests(
         association,
+        Arc::new(ReadinessPublisherRuntime::new()),
         request_source,
         response_sink,
         notification_channel,
@@ -235,8 +236,14 @@ impl Drop for ReadinessPublicationGuard<'_> {
     }
 }
 
+/// Serves one association until it ends, then reports its first failure.
+///
+/// `readiness` is created by the caller rather than here so readiness sources
+/// can record into the same runtime this publishes from. Nothing publishes into
+/// it in production yet; the Linux network reactor is its first source.
 fn dispatch_requests<Memory: SharedMemory>(
     association: BrokerHostAssociation<'_, Memory>,
+    readiness: Arc<ReadinessPublisherRuntime>,
     mut request_source: UnixControlRingHostRequestSource,
     response_sink: UnixControlRingHostResponseSink,
     mut notification_channel: UnixControlRingHostNotificationChannel,
@@ -244,7 +251,6 @@ fn dispatch_requests<Memory: SharedMemory>(
 ) -> IoResult<()> {
     let association = Arc::new(association);
     let failure_coordinator = Arc::new(HostAssociationFailureCoordinator::new(shutdown));
-    let readiness = Arc::new(ReadinessPublisherRuntime::new());
     let (request_sender, request_receiver) = sync_channel(REQUEST_QUEUE_CAPACITY);
     let request_receiver = Arc::new(Mutex::new(request_receiver));
 
@@ -490,21 +496,106 @@ mod tests {
         }
     }
 
+    /// A notification channel that accepts every send and keeps nothing.
+    struct DiscardingChannel;
+
+    impl litebox_broker_protocol::channel::HostNotificationChannel for DiscardingChannel {
+        type Error = IoError;
+
+        fn send_notification(
+            &mut self,
+            _notification: &litebox_broker_protocol::message::BrokerNotification,
+        ) -> IoResult<()> {
+            Ok(())
+        }
+    }
+
+    /// Negotiates the local half of an association served by [`spawn_dispatch`].
+    fn negotiate_local(
+        stream: UnixStream,
+    ) -> (
+        litebox_broker_local::BrokerLocal<UnixControlRingLocalCallChannel>,
+        UnixControlRingLocalNotificationChannel,
+    ) {
+        litebox_broker_local::BrokerLocal::negotiate(
+            UnixStreamLocalSetupChannel::from_connected(stream),
+            |mut setup| {
+                let shared_memory = setup.receive_memfd(SHARED_BUFFER_POOL_SIZE, None)?;
+                let control_memory = setup.receive_memfd(CONTROL_RING_MEMORY_SIZE, None)?;
+                let control_ring = ControlRing::new(control_memory).map_err(|error| {
+                    IoError::new(
+                        ErrorKind::InvalidData,
+                        format!("invalid test control ring: {error:?}"),
+                    )
+                })?;
+                let (call_channel, notifications, _shutdown) =
+                    setup.into_active(control_ring, || {})?;
+                Ok((call_channel, Arc::new(shared_memory), notifications))
+            },
+        )
+        .unwrap()
+    }
+
+    /// One association served by `dispatch_requests` exactly as production
+    /// serves it.
+    ///
+    /// The guard tests above cover what the teardown guards do; only this
+    /// covers that `dispatch_requests` installs them and starts a publisher at
+    /// all, because its single production caller is unreachable from a test.
+    /// Dispatch starts only once the local half has finished negotiating, so a
+    /// publisher that fails immediately cannot race activation.
+    fn spawn_dispatch(
+        readiness: Arc<ReadinessPublisherRuntime>,
+    ) -> (
+        litebox_broker_local::BrokerLocal<UnixControlRingLocalCallChannel>,
+        UnixControlRingLocalNotificationChannel,
+        Receiver<IoResult<()>>,
+        std::thread::JoinHandle<()>,
+    ) {
+        let (local_stream, host_stream) = UnixStream::pair().unwrap();
+        let (outcome_sender, outcome) = sync_channel(1);
+        let (start, started) = sync_channel(1);
+        let host = std::thread::spawn(move || {
+            let broker = BrokerCore::new(PolicyEngine::with_host_guaranteed_rights(
+                ObjectRights::all(),
+            ))
+            .unwrap();
+            let shared_memory = MemfdSharedMemory::create(SHARED_BUFFER_POOL_SIZE).unwrap();
+            let shared_buffers =
+                SharedBufferPool::new(shared_memory, SHARED_BUFFER_LAYOUT).unwrap();
+            let control_memory = MemfdSharedMemory::create(CONTROL_RING_MEMORY_SIZE).unwrap();
+            let control_ring = ControlRing::new(control_memory).unwrap();
+            let mut control = UnixStreamHostSetupChannel::from_host_guaranteed(
+                host_stream,
+                Instant::now() + SETUP_TIMEOUT,
+            );
+            let association = setup_connection(&broker, &mut control, &shared_buffers, |channel| {
+                channel.send_memfd(shared_buffers.memory(), None)?;
+                channel.send_memfd(control_ring.memory(), None)
+            })
+            .unwrap()
+            .unwrap();
+            let (request_source, response_sink, notifications, shutdown) =
+                control.into_active(control_ring).unwrap();
+            started.recv().unwrap();
+            outcome_sender
+                .send(dispatch_requests(
+                    association,
+                    readiness,
+                    request_source,
+                    response_sink,
+                    notifications,
+                    shutdown,
+                ))
+                .unwrap();
+        });
+        let (local, notifications) = negotiate_local(local_stream);
+        start.send(()).unwrap();
+        (local, notifications, outcome, host)
+    }
+
     #[test]
     fn publication_guard_ends_a_parked_publisher() {
-        use litebox_broker_protocol::channel::HostNotificationChannel;
-        use litebox_broker_protocol::message::BrokerNotification;
-
-        struct DiscardingChannel;
-
-        impl HostNotificationChannel for DiscardingChannel {
-            type Error = IoError;
-
-            fn send_notification(&mut self, _notification: &BrokerNotification) -> IoResult<()> {
-                Ok(())
-            }
-        }
-
         let association = live_association();
         let failure_coordinator = HostAssociationFailureCoordinator::new(association.shutdown);
         let readiness = Arc::new(ReadinessPublisherRuntime::new());
@@ -636,5 +727,72 @@ mod tests {
         let error = failure_coordinator.take_error().unwrap();
         assert_eq!(error.kind(), ErrorKind::TimedOut);
         assert_eq!(error.to_string(), "first failure");
+    }
+
+    #[test]
+    fn dispatching_requests_publishes_readiness_until_the_association_ends() {
+        use litebox_broker_protocol::ObjectHandle;
+        use litebox_broker_protocol::message::{BrokerNotification, ReadinessNotification};
+        use litebox_broker_protocol::readiness::ReadinessFlags;
+
+        const HANDLE: ObjectHandle = ObjectHandle(11);
+        let expected = ReadinessFlags::READ | ReadinessFlags::WRITE;
+        let readiness = Arc::new(ReadinessPublisherRuntime::new());
+        let (local, mut notifications, outcome, host) = spawn_dispatch(Arc::clone(&readiness));
+
+        readiness.publish(HANDLE, expected).unwrap();
+
+        // The receive has no deadline of its own, so a publisher that dispatch
+        // never started has to fail the test rather than hang it.
+        let (notified, notifications_seen) = sync_channel(1);
+        let receiver = std::thread::spawn(move || {
+            use litebox_broker_protocol::channel::LocalNotificationChannel;
+
+            let notification = notifications.recv_notification().unwrap();
+            notified.send(notification).unwrap();
+            notifications
+        });
+        let notification = notifications_seen
+            .recv_timeout(SETUP_TIMEOUT)
+            .expect("dispatch must publish readiness recorded in its runtime");
+        assert_eq!(
+            notification,
+            Some(BrokerNotification::Readiness(ReadinessNotification {
+                handle: HANDLE,
+                readiness: expected,
+            }))
+        );
+        let notifications = receiver.join().unwrap();
+
+        // A publisher parked for work outlives a clean local close unless
+        // dispatch ends publication, so this deadline covers that too.
+        drop(local);
+        drop(notifications);
+        outcome
+            .recv_timeout(SETUP_TIMEOUT)
+            .expect("a clean local close must end dispatch")
+            .unwrap();
+        host.join().unwrap();
+    }
+
+    #[test]
+    fn dispatching_requests_fails_when_its_readiness_publisher_panics() {
+        // Publication is one-shot, so a runtime that has already run makes the
+        // publisher thread panic as soon as dispatch starts it.
+        let readiness = Arc::new(ReadinessPublisherRuntime::new());
+        readiness.close();
+        readiness.run(&mut DiscardingChannel).unwrap();
+
+        // The local half stays connected and idle, so nothing but the panic can
+        // release the request reader that owns association termination.
+        let (local, _notifications, outcome, host) = spawn_dispatch(Arc::clone(&readiness));
+
+        let error = outcome
+            .recv_timeout(SETUP_TIMEOUT)
+            .expect("a panicking publisher must end dispatch")
+            .expect_err("a panicking publisher must fail the association");
+        assert_eq!(error.to_string(), "broker readiness publisher panicked");
+        drop(local);
+        host.join().unwrap();
     }
 }

--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -142,6 +142,20 @@ fn serve_runner(
     Ok(())
 }
 
+/// Closes readiness publication when an association scope ends for any reason.
+///
+/// The publisher is a scoped thread, so the scope joins it before propagating a
+/// panic out of the association. A publisher parked for work only returns once
+/// publication closes, so an unwind that skipped closing would hang teardown
+/// forever instead of reporting the panic.
+struct ReadinessPublicationGuard<'runtime>(&'runtime ReadinessPublisherRuntime);
+
+impl Drop for ReadinessPublicationGuard<'_> {
+    fn drop(&mut self) {
+        self.0.close();
+    }
+}
+
 fn dispatch_requests<Memory: SharedMemory>(
     association: BrokerHostAssociation<'_, Memory>,
     mut request_source: UnixControlRingHostRequestSource,
@@ -174,6 +188,11 @@ fn dispatch_requests<Memory: SharedMemory>(
                 None
             }
         };
+
+        // Publication must close on every exit, including an unwind: the scope
+        // joins the publisher before it propagates a panic, and a publisher
+        // parked for work would never return, hanging teardown instead.
+        let _publication = ReadinessPublicationGuard(&readiness);
 
         let mut workers = Vec::with_capacity(WORKER_COUNT);
         for worker_id in 0..WORKER_COUNT {
@@ -208,7 +227,9 @@ fn dispatch_requests<Memory: SharedMemory>(
         // Readiness publication lives exactly as long as the association. The
         // request reader returns only once the association is over, but workers
         // keep draining already-queued requests after that, so publication must
-        // outlive them or a late readiness change would be discarded.
+        // outlive them or a late readiness change would be discarded. Closing
+        // here rather than leaving it to the guard orders it before the join
+        // that observes a panicking publisher.
         readiness.close();
         if let Some(publisher) = publisher
             && publisher.join().is_err()
@@ -367,6 +388,44 @@ mod tests {
     use litebox_broker_protocol::message::BrokerHandshakeResponse;
     use litebox_broker_transport::unix_socket::UnixStreamLocalSetupChannel;
     use std::os::fd::AsFd;
+
+    #[test]
+    fn dropping_the_publication_guard_ends_a_parked_publisher() {
+        use litebox_broker_protocol::channel::HostNotificationChannel;
+        use litebox_broker_protocol::message::BrokerNotification;
+
+        struct DiscardingChannel;
+
+        impl HostNotificationChannel for DiscardingChannel {
+            type Error = IoError;
+
+            fn send_notification(&mut self, _notification: &BrokerNotification) -> IoResult<()> {
+                Ok(())
+            }
+        }
+
+        let readiness = Arc::new(ReadinessPublisherRuntime::new());
+        let publishing = Arc::clone(&readiness);
+        let (finished, finish) = sync_channel(1);
+        let publisher = std::thread::spawn(move || {
+            finished
+                .send(publishing.run(&mut DiscardingChannel))
+                .unwrap();
+        });
+
+        // The publisher parks on an empty queue, so only closing publication
+        // ends it. An unwind past the explicit close leaves the guard as the
+        // only thing that can, and the scope joins the publisher before it
+        // propagates the panic.
+        std::thread::sleep(Duration::from_millis(20));
+        drop(ReadinessPublicationGuard(&readiness));
+
+        finish
+            .recv_timeout(SETUP_TIMEOUT)
+            .expect("dropping the guard must end the parked publisher")
+            .unwrap();
+        publisher.join().unwrap();
+    }
 
     #[test]
     fn first_failure_is_preserved_and_unblocks_request_reading() {

--- a/litebox_broker_userland/src/readiness.rs
+++ b/litebox_broker_userland/src/readiness.rs
@@ -128,7 +128,7 @@ impl ReadinessPublisherRuntime {
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
-    use std::sync::mpsc::{Sender, channel};
+    use std::sync::mpsc::{Receiver, Sender, channel};
     use std::time::Duration;
 
     use litebox_broker_protocol::message::{BrokerNotification, ReadinessNotification};
@@ -155,15 +155,34 @@ mod tests {
         }
     }
 
+    /// Runs a publisher on its own thread and reports its result through a
+    /// channel, so a publisher that never ends fails a test on the deadline
+    /// instead of hanging its join.
+    fn spawn_publisher(
+        runtime: &Arc<ReadinessPublisherRuntime>,
+        sent: Sender<ReadinessNotification>,
+    ) -> Receiver<Result<(), &'static str>> {
+        let publishing = Arc::clone(runtime);
+        let (finished, finish) = channel();
+        std::thread::spawn(move || {
+            let mut channel = RecordingChannel { sent };
+            let _ = finished.send(publishing.run(&mut channel));
+        });
+        finish
+    }
+
+    fn expect_publication_ended(finish: &Receiver<Result<(), &'static str>>) {
+        finish
+            .recv_timeout(TEST_TIMEOUT)
+            .expect("publication must end")
+            .expect("publication must end without a channel error");
+    }
+
     #[test]
     fn a_parked_publisher_wakes_for_a_later_readiness_update() {
         let runtime = Arc::new(ReadinessPublisherRuntime::new());
         let (sent, received) = channel();
-        let publishing = Arc::clone(&runtime);
-        let publisher = std::thread::spawn(move || {
-            let mut channel = RecordingChannel { sent };
-            publishing.run(&mut channel)
-        });
+        let finish = spawn_publisher(&runtime, sent);
 
         // The publisher parks first, so this update must wake it.
         std::thread::sleep(Duration::from_millis(20));
@@ -177,25 +196,27 @@ mod tests {
             }
         );
         runtime.close();
-        publisher.join().unwrap().unwrap();
+        expect_publication_ended(&finish);
     }
 
     #[test]
-    fn closing_ends_a_parked_publisher() {
+    fn closing_wakes_a_publisher_waiting_for_work() {
         let runtime = Arc::new(ReadinessPublisherRuntime::new());
-        let (sent, _received) = channel();
-        let publishing = Arc::clone(&runtime);
-        let publisher = std::thread::spawn(move || {
-            let mut channel = RecordingChannel { sent };
-            publishing.run(&mut channel)
+        let waiting = Arc::clone(&runtime);
+        let (wake_sender, wakes) = channel();
+        std::thread::spawn(move || {
+            waiting.wait_for_work();
+            let _ = wake_sender.send(());
         });
 
-        // The publisher parks on an empty queue first, so closing is what must
-        // end it rather than a queue it already found closed.
-        std::thread::sleep(Duration::from_millis(20));
+        // The latch is sticky, so this must end the wait whether it lands
+        // before the waiter parks or after it, which is why the test needs no
+        // rendezvous with a park it cannot observe.
         runtime.close();
 
-        publisher.join().unwrap().unwrap();
+        wakes
+            .recv_timeout(TEST_TIMEOUT)
+            .expect("closing must end a wait for work");
     }
 
     #[test]
@@ -211,11 +232,7 @@ mod tests {
         runtime.retire(HANDLE);
         runtime.publish(OTHER_HANDLE, ReadinessFlags::READ).unwrap();
 
-        let publishing = Arc::clone(&runtime);
-        let publisher = std::thread::spawn(move || {
-            let mut channel = RecordingChannel { sent };
-            publishing.run(&mut channel)
-        });
+        let finish = spawn_publisher(&runtime, sent);
 
         assert_eq!(
             received.recv_timeout(TEST_TIMEOUT).unwrap(),
@@ -226,7 +243,7 @@ mod tests {
             "a retired object must not be published"
         );
         runtime.close();
-        publisher.join().unwrap().unwrap();
+        expect_publication_ended(&finish);
         assert!(received.try_iter().next().is_none());
     }
 }

--- a/litebox_broker_userland/src/readiness.rs
+++ b/litebox_broker_userland/src/readiness.rs
@@ -85,7 +85,12 @@ impl ReadinessPublisherRuntime {
         publish_readiness(&self.publisher, channel, || self.wait_for_work())
     }
 
-    /// Closes publication and wakes the publisher so [`run`] returns.
+    /// Closes publication and wakes a publisher parked for work so [`run`]
+    /// returns.
+    ///
+    /// A publisher already inside a blocking send is not woken by this; the
+    /// notification transport ends that send when the association fails or its
+    /// peer closes.
     ///
     /// [`run`]: Self::run
     pub fn close(&self) {
@@ -181,6 +186,9 @@ mod tests {
             publishing.run(&mut channel)
         });
 
+        // The publisher parks on an empty queue first, so closing is what must
+        // end it rather than a queue it already found closed.
+        std::thread::sleep(Duration::from_millis(20));
         runtime.close();
 
         publisher.join().unwrap().unwrap();

--- a/litebox_broker_userland/src/readiness.rs
+++ b/litebox_broker_userland/src/readiness.rs
@@ -54,8 +54,12 @@ impl ReadinessPublisherRuntime {
     /// Records the authoritative readiness of one broker object.
     ///
     /// Updates are coalesced per object, so a source may call this as often as
-    /// its backend state changes. Returns an error only when the association
-    /// already tracks the maximum number of objects.
+    /// its backend state changes. An update recorded after [`close`] is
+    /// discarded rather than reported, because the association it would reach
+    /// is already over. Returns an error only when the association already
+    /// tracks the maximum number of objects.
+    ///
+    /// [`close`]: Self::close
     pub fn publish(
         &self,
         handle: ObjectHandle,

--- a/litebox_broker_userland/src/readiness.rs
+++ b/litebox_broker_userland/src/readiness.rs
@@ -8,6 +8,7 @@
 //! deployment supplies one. This module pairs that state with a condition
 //! variable and the thread-facing API the broker host binary needs.
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Condvar, Mutex};
 
 use litebox_broker_host::readiness::{
@@ -32,6 +33,7 @@ pub struct ReadinessPublisherRuntime {
     publisher: ReadinessPublisher,
     signaled: Mutex<bool>,
     work_available: Condvar,
+    running: AtomicBool,
 }
 
 impl Default for ReadinessPublisherRuntime {
@@ -48,6 +50,7 @@ impl ReadinessPublisherRuntime {
             publisher: ReadinessPublisher::new(),
             signaled: Mutex::new(false),
             work_available: Condvar::new(),
+            running: AtomicBool::new(false),
         }
     }
 
@@ -82,10 +85,21 @@ impl ReadinessPublisherRuntime {
     /// local endpoint leaves the notification transport full; that is confined
     /// to this thread by design, and association teardown fails the blocked
     /// send through the transport.
+    ///
+    /// # Panics
+    ///
+    /// Panics if publication has already run. Closure is terminal, so a runtime
+    /// serves exactly one publisher, and a second one would park on a wake that
+    /// only ever releases one waiter. That is a silent hang, so the second
+    /// caller is rejected loudly instead.
     pub fn run<Channel: HostNotificationChannel>(
         &self,
         channel: &mut Channel,
     ) -> Result<(), Channel::Error> {
+        assert!(
+            !self.running.swap(true, Ordering::Relaxed),
+            "readiness publication must run exactly once per runtime"
+        );
         publish_readiness(&self.publisher, channel, || self.wait_for_work())
     }
 
@@ -197,6 +211,21 @@ mod tests {
         );
         runtime.close();
         expect_publication_ended(&finish);
+    }
+
+    #[test]
+    #[should_panic(expected = "exactly once")]
+    fn publication_runs_at_most_once() {
+        let runtime = ReadinessPublisherRuntime::new();
+        let (sent, _received) = channel();
+        let mut channel = RecordingChannel { sent };
+
+        // Closure is terminal, so the first run returns at once and the second
+        // would otherwise park on a wake that can never come.
+        runtime.close();
+        runtime.run(&mut channel).unwrap();
+
+        let _ = runtime.run(&mut channel);
     }
 
     #[test]

--- a/litebox_broker_userland/src/readiness.rs
+++ b/litebox_broker_userland/src/readiness.rs
@@ -127,6 +127,7 @@ mod tests {
     use super::*;
 
     const HANDLE: ObjectHandle = ObjectHandle(3);
+    const OTHER_HANDLE: ObjectHandle = ObjectHandle(5);
     const TEST_TIMEOUT: Duration = Duration::from_secs(5);
 
     struct RecordingChannel {
@@ -187,15 +188,33 @@ mod tests {
 
     #[test]
     fn retired_objects_stop_being_published() {
-        let runtime = ReadinessPublisherRuntime::new();
+        let runtime = Arc::new(ReadinessPublisherRuntime::new());
         let (sent, received) = channel();
-        let mut channel = RecordingChannel { sent };
+
+        // The retired handle is queued ahead of the surviving one, so it would
+        // arrive first if retirement had not dropped its queued update. The
+        // publisher starts only once both calls have run, which keeps it from
+        // draining the queue before retirement.
         runtime.publish(HANDLE, ReadinessFlags::READ).unwrap();
-
         runtime.retire(HANDLE);
-        runtime.close();
-        runtime.run(&mut channel).unwrap();
+        runtime.publish(OTHER_HANDLE, ReadinessFlags::READ).unwrap();
 
+        let publishing = Arc::clone(&runtime);
+        let publisher = std::thread::spawn(move || {
+            let mut channel = RecordingChannel { sent };
+            publishing.run(&mut channel)
+        });
+
+        assert_eq!(
+            received.recv_timeout(TEST_TIMEOUT).unwrap(),
+            ReadinessNotification {
+                handle: OTHER_HANDLE,
+                readiness: ReadinessFlags::READ,
+            },
+            "a retired object must not be published"
+        );
+        runtime.close();
+        publisher.join().unwrap().unwrap();
         assert!(received.try_iter().next().is_none());
     }
 }

--- a/litebox_broker_userland/src/readiness.rs
+++ b/litebox_broker_userland/src/readiness.rs
@@ -91,10 +91,12 @@ impl ReadinessPublisherRuntime {
     /// Panics if publication has already run. Closure is terminal, so a runtime
     /// serves exactly one publisher, and a second one would park on a wake that
     /// only ever releases one waiter. That is a silent hang, so the second
-    /// caller is rejected loudly instead. A returned error is therefore
-    /// terminal for this runtime as well: the portable loop leaves the failed
-    /// update publishable, but resuming it on a replacement channel needs a new
-    /// runtime rather than a second call.
+    /// caller is rejected loudly instead. A returned error is terminal for the
+    /// same reason: the portable loop leaves the failed update publishable, but
+    /// no later publisher can send it, so this closes publication rather than
+    /// leave sources recording into state nothing will drain. Resuming on a
+    /// replacement channel means a new runtime, which starts empty, so the
+    /// failed update is lost at this layer.
     pub fn run<Channel: HostNotificationChannel>(
         &self,
         channel: &mut Channel,
@@ -103,7 +105,11 @@ impl ReadinessPublisherRuntime {
             !self.running.swap(true, Ordering::Relaxed),
             "readiness publication must run exactly once per runtime"
         );
-        publish_readiness(&self.publisher, channel, || self.wait_for_work())
+        let outcome = publish_readiness(&self.publisher, channel, || self.wait_for_work());
+        if outcome.is_err() {
+            self.publisher.close();
+        }
+        outcome
     }
 
     /// Closes publication and wakes a publisher parked for work so [`run`]
@@ -214,6 +220,37 @@ mod tests {
         );
         runtime.close();
         expect_publication_ended(&finish);
+    }
+
+    use litebox_broker_host::readiness::MAX_TRACKED_READINESS_OBJECTS;
+
+    struct FailingChannel;
+
+    impl HostNotificationChannel for FailingChannel {
+        type Error = &'static str;
+
+        fn send_notification(
+            &mut self,
+            _notification: &BrokerNotification,
+        ) -> Result<(), Self::Error> {
+            Err("notification channel failed")
+        }
+    }
+
+    #[test]
+    fn a_failed_publication_closes_the_runtime() {
+        let runtime = ReadinessPublisherRuntime::new();
+        runtime.publish(HANDLE, ReadinessFlags::READ).unwrap();
+
+        runtime.run(&mut FailingChannel).unwrap_err();
+
+        // Publication cannot run again, so a closed runtime must discard later
+        // updates rather than let sources fill tracking state to its limit.
+        for handle in 0..=MAX_TRACKED_READINESS_OBJECTS as u64 {
+            runtime
+                .publish(ObjectHandle(handle), ReadinessFlags::READ)
+                .unwrap();
+        }
     }
 
     #[test]

--- a/litebox_broker_userland/src/readiness.rs
+++ b/litebox_broker_userland/src/readiness.rs
@@ -43,7 +43,7 @@ impl Default for ReadinessPublisherRuntime {
 impl ReadinessPublisherRuntime {
     /// Creates idle readiness publication state.
     #[must_use]
-    pub const fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             publisher: ReadinessPublisher::new(),
             signaled: Mutex::new(false),

--- a/litebox_broker_userland/src/readiness.rs
+++ b/litebox_broker_userland/src/readiness.rs
@@ -1,0 +1,201 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//! Threaded readiness publication for the Linux-userland broker host.
+//!
+//! [`litebox_broker_host::readiness`] owns the portable coalescing state and
+//! the publication loop but deliberately holds no wake primitive, so a
+//! deployment supplies one. This module pairs that state with a condition
+//! variable and the thread-facing API the broker host binary needs.
+
+use std::sync::{Condvar, Mutex};
+
+use litebox_broker_host::readiness::{
+    PublishOutcome, ReadinessPublishError, ReadinessPublisher, publish_readiness,
+};
+use litebox_broker_protocol::ObjectHandle;
+use litebox_broker_protocol::channel::HostNotificationChannel;
+use litebox_broker_protocol::readiness::ReadinessFlags;
+
+/// Readiness publication state plus the wake primitive its publisher parks on.
+///
+/// Backend readiness sources share this value and call [`publish`] and
+/// [`retire`]; neither waits for notification transport capacity. Exactly one
+/// thread calls [`run`], which owns the association notification channel for
+/// the lifetime of the association.
+///
+/// [`publish`]: Self::publish
+/// [`retire`]: Self::retire
+/// [`run`]: Self::run
+#[derive(Debug)]
+pub struct ReadinessPublisherRuntime {
+    publisher: ReadinessPublisher,
+    signaled: Mutex<bool>,
+    work_available: Condvar,
+}
+
+impl Default for ReadinessPublisherRuntime {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ReadinessPublisherRuntime {
+    /// Creates idle readiness publication state.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            publisher: ReadinessPublisher::new(),
+            signaled: Mutex::new(false),
+            work_available: Condvar::new(),
+        }
+    }
+
+    /// Records the authoritative readiness of one broker object.
+    ///
+    /// Updates are coalesced per object, so a source may call this as often as
+    /// its backend state changes. Returns an error only when the association
+    /// already tracks the maximum number of objects.
+    pub fn publish(
+        &self,
+        handle: ObjectHandle,
+        readiness: ReadinessFlags,
+    ) -> Result<(), ReadinessPublishError> {
+        if self.publisher.publish(handle, readiness)? == PublishOutcome::Queued {
+            self.signal();
+        }
+        Ok(())
+    }
+
+    /// Drops readiness state for an object whose backend resource is retired.
+    pub fn retire(&self, handle: ObjectHandle) {
+        self.publisher.retire(handle);
+    }
+
+    /// Publishes readiness notifications until the runtime is closed.
+    ///
+    /// The caller must be the only owner of `channel`. Sending blocks while the
+    /// local endpoint leaves the notification transport full; that is confined
+    /// to this thread by design, and association teardown fails the blocked
+    /// send through the transport.
+    pub fn run<Channel: HostNotificationChannel>(
+        &self,
+        channel: &mut Channel,
+    ) -> Result<(), Channel::Error> {
+        publish_readiness(&self.publisher, channel, || self.wait_for_work())
+    }
+
+    /// Closes publication and wakes the publisher so [`run`] returns.
+    ///
+    /// [`run`]: Self::run
+    pub fn close(&self) {
+        self.publisher.close();
+        self.signal();
+    }
+
+    fn signal(&self) {
+        *self
+            .signaled
+            .lock()
+            .expect("broker readiness publisher mutex poisoned") = true;
+        self.work_available.notify_one();
+    }
+
+    fn wait_for_work(&self) {
+        let mut signaled = self
+            .signaled
+            .lock()
+            .expect("broker readiness publisher mutex poisoned");
+        while !*signaled {
+            signaled = self
+                .work_available
+                .wait(signaled)
+                .expect("broker readiness publisher mutex poisoned");
+        }
+        *signaled = false;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::mpsc::{Sender, channel};
+    use std::time::Duration;
+
+    use litebox_broker_protocol::message::{BrokerNotification, ReadinessNotification};
+
+    use super::*;
+
+    const HANDLE: ObjectHandle = ObjectHandle(3);
+    const TEST_TIMEOUT: Duration = Duration::from_secs(5);
+
+    struct RecordingChannel {
+        sent: Sender<ReadinessNotification>,
+    }
+
+    impl HostNotificationChannel for RecordingChannel {
+        type Error = &'static str;
+
+        fn send_notification(
+            &mut self,
+            notification: &BrokerNotification,
+        ) -> Result<(), Self::Error> {
+            let BrokerNotification::Readiness(readiness) = notification;
+            self.sent.send(*readiness).map_err(|_| "receiver dropped")
+        }
+    }
+
+    #[test]
+    fn a_parked_publisher_wakes_for_a_later_readiness_update() {
+        let runtime = Arc::new(ReadinessPublisherRuntime::new());
+        let (sent, received) = channel();
+        let publishing = Arc::clone(&runtime);
+        let publisher = std::thread::spawn(move || {
+            let mut channel = RecordingChannel { sent };
+            publishing.run(&mut channel)
+        });
+
+        // The publisher parks first, so this update must wake it.
+        std::thread::sleep(Duration::from_millis(20));
+        runtime.publish(HANDLE, ReadinessFlags::READ).unwrap();
+
+        assert_eq!(
+            received.recv_timeout(TEST_TIMEOUT).unwrap(),
+            ReadinessNotification {
+                handle: HANDLE,
+                readiness: ReadinessFlags::READ,
+            }
+        );
+        runtime.close();
+        publisher.join().unwrap().unwrap();
+    }
+
+    #[test]
+    fn closing_ends_a_parked_publisher() {
+        let runtime = Arc::new(ReadinessPublisherRuntime::new());
+        let (sent, _received) = channel();
+        let publishing = Arc::clone(&runtime);
+        let publisher = std::thread::spawn(move || {
+            let mut channel = RecordingChannel { sent };
+            publishing.run(&mut channel)
+        });
+
+        runtime.close();
+
+        publisher.join().unwrap().unwrap();
+    }
+
+    #[test]
+    fn retired_objects_stop_being_published() {
+        let runtime = ReadinessPublisherRuntime::new();
+        let (sent, received) = channel();
+        let mut channel = RecordingChannel { sent };
+        runtime.publish(HANDLE, ReadinessFlags::READ).unwrap();
+
+        runtime.retire(HANDLE);
+        runtime.close();
+        runtime.run(&mut channel).unwrap();
+
+        assert!(received.try_iter().next().is_none());
+    }
+}

--- a/litebox_broker_userland/src/readiness.rs
+++ b/litebox_broker_userland/src/readiness.rs
@@ -91,7 +91,10 @@ impl ReadinessPublisherRuntime {
     /// Panics if publication has already run. Closure is terminal, so a runtime
     /// serves exactly one publisher, and a second one would park on a wake that
     /// only ever releases one waiter. That is a silent hang, so the second
-    /// caller is rejected loudly instead.
+    /// caller is rejected loudly instead. A returned error is therefore
+    /// terminal for this runtime as well: the portable loop leaves the failed
+    /// update publishable, but resuming it on a replacement channel needs a new
+    /// runtime rather than a second call.
     pub fn run<Channel: HostNotificationChannel>(
         &self,
         channel: &mut Channel,

--- a/litebox_broker_userland/tests/notification_runtime.rs
+++ b/litebox_broker_userland/tests/notification_runtime.rs
@@ -209,16 +209,28 @@ fn a_host_readiness_source_wakes_a_blocked_local_receiver() {
         publisher.join().unwrap().unwrap();
     });
 
-    let (local, mut notifications) = negotiate_local(local_control);
-    let received = readiness_of(notifications.recv_notification().unwrap());
+    let (local, notifications) = negotiate_local(local_control);
+    let (notification_sender, notification_receiver) = channel();
+    let receiver_thread = std::thread::spawn(move || {
+        let mut notifications = notifications;
+        // Receiving on a helper thread keeps a wake that never arrives a test
+        // failure rather than a hang: the notification wait has no deadline of
+        // its own.
+        let notification = readiness_of(notifications.recv_notification().unwrap());
+        notification_sender.send(notification).unwrap();
+        notifications
+    });
 
     assert_eq!(
-        received,
+        notification_receiver
+            .recv_timeout(TEST_TIMEOUT)
+            .expect("a host readiness source must wake the blocked local receiver"),
         ReadinessNotification {
             handle: HANDLE,
             readiness,
         }
     );
+    let _notifications = receiver_thread.join().unwrap();
     drop(finish_sender);
     drop(local);
     host.join().unwrap();

--- a/litebox_broker_userland/tests/notification_runtime.rs
+++ b/litebox_broker_userland/tests/notification_runtime.rs
@@ -3,6 +3,9 @@
 
 use std::os::unix::net::UnixStream;
 use std::sync::Arc;
+use std::sync::mpsc::channel;
+use std::thread::JoinHandle;
+use std::time::Duration;
 
 use litebox_broker_core::{BrokerCore, ObjectRights, PolicyEngine};
 use litebox_broker_host::{ConnectionTermination, setup_connection};
@@ -14,11 +17,98 @@ use litebox_broker_protocol::readiness::ReadinessFlags;
 use litebox_broker_protocol::shared_memory::{
     SHARED_BUFFER_LAYOUT, SHARED_BUFFER_POOL_SIZE, SharedBufferPool,
 };
-use litebox_broker_transport::control_ring::{CONTROL_RING_MEMORY_SIZE, ControlRing};
+use litebox_broker_transport::control_ring::{
+    CONTROL_RING_MEMORY_SIZE, CONTROL_RING_NOTIFICATION_SLOT_COUNT, ControlRing,
+};
 use litebox_broker_transport::shared_memory::MemfdSharedMemory;
 use litebox_broker_transport::unix_socket::{
+    UnixControlRingHostNotificationChannel, UnixControlRingHostShutdown,
+    UnixControlRingLocalCallChannel, UnixControlRingLocalNotificationChannel,
     UnixStreamHostSetupChannel, UnixStreamLocalSetupChannel,
 };
+use litebox_broker_userland::readiness::ReadinessPublisherRuntime;
+
+/// Long enough that a hung wakeup fails the test instead of hanging CI.
+const TEST_TIMEOUT: Duration = Duration::from_secs(10);
+/// Long enough for the local endpoint to reach its blocking receive.
+const BLOCK_DELAY: Duration = Duration::from_millis(50);
+/// More objects than the notification ring holds, so publication must block.
+const OVERSUBSCRIBED_OBJECT_COUNT: u64 = CONTROL_RING_NOTIFICATION_SLOT_COUNT * 3;
+
+/// Runs one host association whose only traffic is readiness notifications.
+///
+/// The reader thread mirrors production: it is the endpoint that observes local
+/// termination and interrupts every ring wait of the association.
+fn spawn_host(
+    stream: UnixStream,
+    host: impl FnOnce(UnixControlRingHostNotificationChannel, UnixControlRingHostShutdown)
+    + Send
+    + 'static,
+) -> JoinHandle<()> {
+    std::thread::spawn(move || {
+        let broker = BrokerCore::new(PolicyEngine::with_unauthenticated_rights(
+            ObjectRights::all(),
+        ))
+        .unwrap();
+        let shared_memory = MemfdSharedMemory::create(SHARED_BUFFER_POOL_SIZE).unwrap();
+        let shared_buffers = SharedBufferPool::new(shared_memory, SHARED_BUFFER_LAYOUT).unwrap();
+        let control_memory = MemfdSharedMemory::create(CONTROL_RING_MEMORY_SIZE).unwrap();
+        let control_ring = ControlRing::new(control_memory).unwrap();
+        let mut control = UnixStreamHostSetupChannel::from_accepted(stream);
+        let association = setup_connection(&broker, &mut control, &shared_buffers, |channel| {
+            channel.send_memfd(shared_buffers.memory(), None)?;
+            channel.send_memfd(control_ring.memory(), None)
+        })
+        .unwrap()
+        .unwrap();
+        let (mut request_source, response_sink, notifications, shutdown) =
+            control.into_active(control_ring).unwrap();
+        std::thread::scope(|scope| {
+            scope.spawn(|| {
+                while let Ok(HostReceive::Message(request)) = request_source.recv_request() {
+                    association
+                        .execute_request(request, |response| response_sink.send_response(response))
+                        .unwrap();
+                }
+            });
+            host(notifications, shutdown);
+        });
+    })
+}
+
+/// Negotiates the local half of an association created by [`spawn_host`].
+fn negotiate_local(
+    stream: UnixStream,
+) -> (
+    BrokerLocal<UnixControlRingLocalCallChannel>,
+    BrokerNotifications<UnixControlRingLocalNotificationChannel>,
+) {
+    let (local, notifications) = BrokerLocal::negotiate(
+        UnixStreamLocalSetupChannel::from_connected(stream),
+        |mut setup| {
+            let shared_memory = setup.receive_memfd(SHARED_BUFFER_POOL_SIZE, None)?;
+            let control_memory = setup.receive_memfd(CONTROL_RING_MEMORY_SIZE, None)?;
+            let control_ring = ControlRing::new(control_memory).map_err(|error| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("invalid test control ring: {error:?}"),
+                )
+            })?;
+            let (call_channel, notifications, _shutdown) =
+                setup.into_active(control_ring, || {})?;
+            Ok((call_channel, Arc::new(shared_memory), notifications))
+        },
+    )
+    .unwrap();
+    (local, BrokerNotifications::new(notifications))
+}
+
+fn readiness_of(notification: Option<BrokerNotification>) -> ReadinessNotification {
+    let Some(BrokerNotification::Readiness(readiness)) = notification else {
+        panic!("expected a readiness notification, got {notification:?}");
+    };
+    readiness
+}
 
 #[test]
 fn host_serves_control_requests_and_notifications_over_shared_rings() {
@@ -95,4 +185,122 @@ fn host_serves_control_requests_and_notifications_over_shared_rings() {
         host_thread.join().unwrap(),
         ConnectionTermination::PeerClosed
     );
+}
+
+#[test]
+fn a_host_readiness_source_wakes_a_blocked_local_receiver() {
+    const HANDLE: ObjectHandle = ObjectHandle(11);
+    let readiness = ReadinessFlags::READ | ReadinessFlags::WRITE;
+    let (local_control, host_control) = UnixStream::pair().unwrap();
+    let (finish_sender, finish_receiver) = channel::<()>();
+
+    let host = spawn_host(host_control, move |mut notifications, _shutdown| {
+        let runtime = Arc::new(ReadinessPublisherRuntime::new());
+        let publishing = Arc::clone(&runtime);
+        let publisher = std::thread::spawn(move || publishing.run(&mut notifications));
+
+        // The local endpoint is blocked in its notification receive by now, so
+        // this update is the only thing that can wake it.
+        std::thread::sleep(BLOCK_DELAY);
+        runtime.publish(HANDLE, readiness).unwrap();
+
+        let _ = finish_receiver.recv();
+        runtime.close();
+        publisher.join().unwrap().unwrap();
+    });
+
+    let (local, mut notifications) = negotiate_local(local_control);
+    let received = readiness_of(notifications.recv_notification().unwrap());
+
+    assert_eq!(
+        received,
+        ReadinessNotification {
+            handle: HANDLE,
+            readiness,
+        }
+    );
+    drop(finish_sender);
+    drop(local);
+    host.join().unwrap();
+}
+
+#[test]
+fn a_full_notification_ring_does_not_block_readiness_sources() {
+    let (local_control, host_control) = UnixStream::pair().unwrap();
+    let (published_sender, published_receiver) = channel::<()>();
+    let (finish_sender, finish_receiver) = channel::<()>();
+
+    let host = spawn_host(host_control, move |mut notifications, _shutdown| {
+        let runtime = Arc::new(ReadinessPublisherRuntime::new());
+        let publishing = Arc::clone(&runtime);
+        let publisher = std::thread::spawn(move || publishing.run(&mut notifications));
+
+        // The local endpoint drains nothing until it sees this signal, so the
+        // ring fills and the publisher blocks while the source runs to
+        // completion.
+        for handle in 0..OVERSUBSCRIBED_OBJECT_COUNT {
+            runtime
+                .publish(ObjectHandle(handle), ReadinessFlags::READ)
+                .unwrap();
+        }
+        published_sender.send(()).unwrap();
+
+        let _ = finish_receiver.recv();
+        runtime.close();
+        publisher.join().unwrap().unwrap();
+    });
+
+    let (local, mut notifications) = negotiate_local(local_control);
+    published_receiver.recv_timeout(TEST_TIMEOUT).unwrap();
+    for handle in 0..OVERSUBSCRIBED_OBJECT_COUNT {
+        assert_eq!(
+            readiness_of(notifications.recv_notification().unwrap()),
+            ReadinessNotification {
+                handle: ObjectHandle(handle),
+                readiness: ReadinessFlags::READ,
+            }
+        );
+    }
+
+    drop(finish_sender);
+    drop(local);
+    host.join().unwrap();
+}
+
+#[test]
+fn a_clean_local_close_ends_a_publisher_blocked_on_a_full_ring() {
+    let (local_control, host_control) = UnixStream::pair().unwrap();
+    let (published_sender, published_receiver) = channel::<()>();
+    let (outcome_sender, outcome_receiver) = channel();
+
+    let host = spawn_host(host_control, move |mut notifications, _shutdown| {
+        let runtime = Arc::new(ReadinessPublisherRuntime::new());
+        let publishing = Arc::clone(&runtime);
+        let publisher = std::thread::spawn(move || publishing.run(&mut notifications));
+
+        for handle in 0..OVERSUBSCRIBED_OBJECT_COUNT {
+            runtime
+                .publish(ObjectHandle(handle), ReadinessFlags::READ)
+                .unwrap();
+        }
+        published_sender.send(()).unwrap();
+
+        // The publisher is blocked on notification-ring capacity that the local
+        // endpoint will never make available. Only teardown can end it.
+        outcome_sender.send(publisher.join().unwrap()).unwrap();
+    });
+
+    let (local, notifications) = negotiate_local(local_control);
+    published_receiver.recv_timeout(TEST_TIMEOUT).unwrap();
+    drop(notifications);
+    drop(local);
+
+    let outcome = outcome_receiver.recv_timeout(TEST_TIMEOUT).unwrap();
+    let error = outcome.expect_err("a closed association must end the blocked publisher");
+    assert_eq!(
+        error.kind(),
+        std::io::ErrorKind::BrokenPipe,
+        "a closed peer must end publication as a closure rather than a transport failure, got {error:?}"
+    );
+    host.join().unwrap();
 }

--- a/litebox_broker_userland/tests/notification_runtime.rs
+++ b/litebox_broker_userland/tests/notification_runtime.rs
@@ -3,7 +3,7 @@
 
 use std::os::unix::net::UnixStream;
 use std::sync::Arc;
-use std::sync::mpsc::channel;
+use std::sync::mpsc::{Receiver, channel};
 use std::thread::JoinHandle;
 use std::time::Duration;
 
@@ -103,6 +103,15 @@ fn negotiate_local(
     (local, BrokerNotifications::new(notifications))
 }
 
+/// Receives a publisher's outcome under the test deadline, so publication that
+/// never ends fails the test instead of hanging its join.
+fn expect_publication_ended(outcomes: &Receiver<std::io::Result<()>>) {
+    outcomes
+        .recv_timeout(TEST_TIMEOUT)
+        .expect("publication must end")
+        .expect("publication must end without a transport error");
+}
+
 fn readiness_of(notification: Option<BrokerNotification>) -> ReadinessNotification {
     let Some(BrokerNotification::Readiness(readiness)) = notification else {
         panic!("expected a readiness notification, got {notification:?}");
@@ -193,6 +202,7 @@ fn a_host_readiness_source_wakes_a_blocked_local_receiver() {
     let readiness = ReadinessFlags::READ | ReadinessFlags::WRITE;
     let (local_control, host_control) = UnixStream::pair().unwrap();
     let (finish_sender, finish_receiver) = channel::<()>();
+    let (outcome_sender, outcome_receiver) = channel();
 
     let host = spawn_host(host_control, move |mut notifications, _shutdown| {
         let runtime = Arc::new(ReadinessPublisherRuntime::new());
@@ -206,7 +216,9 @@ fn a_host_readiness_source_wakes_a_blocked_local_receiver() {
 
         let _ = finish_receiver.recv();
         runtime.close();
-        publisher.join().unwrap().unwrap();
+        // Reporting the publisher's outcome rather than joining here keeps a
+        // close that stops waking it a test failure instead of a hang.
+        outcome_sender.send(publisher.join().unwrap()).unwrap();
     });
 
     let (local, notifications) = negotiate_local(local_control);
@@ -233,6 +245,7 @@ fn a_host_readiness_source_wakes_a_blocked_local_receiver() {
     let _notifications = receiver_thread.join().unwrap();
     drop(finish_sender);
     drop(local);
+    expect_publication_ended(&outcome_receiver);
     host.join().unwrap();
 }
 
@@ -241,6 +254,7 @@ fn a_full_notification_ring_does_not_block_readiness_sources() {
     let (local_control, host_control) = UnixStream::pair().unwrap();
     let (published_sender, published_receiver) = channel::<()>();
     let (finish_sender, finish_receiver) = channel::<()>();
+    let (outcome_sender, outcome_receiver) = channel();
 
     let host = spawn_host(host_control, move |mut notifications, _shutdown| {
         let runtime = Arc::new(ReadinessPublisherRuntime::new());
@@ -259,7 +273,7 @@ fn a_full_notification_ring_does_not_block_readiness_sources() {
 
         let _ = finish_receiver.recv();
         runtime.close();
-        publisher.join().unwrap().unwrap();
+        outcome_sender.send(publisher.join().unwrap()).unwrap();
     });
 
     let (local, mut notifications) = negotiate_local(local_control);
@@ -276,6 +290,7 @@ fn a_full_notification_ring_does_not_block_readiness_sources() {
 
     drop(finish_sender);
     drop(local);
+    expect_publication_ended(&outcome_receiver);
     host.join().unwrap();
 }
 

--- a/litebox_broker_userland/tests/notification_runtime.rs
+++ b/litebox_broker_userland/tests/notification_runtime.rs
@@ -276,13 +276,31 @@ fn a_full_notification_ring_does_not_block_readiness_sources() {
         outcome_sender.send(publisher.join().unwrap()).unwrap();
     });
 
-    let (local, mut notifications) = negotiate_local(local_control);
+    let (local, notifications) = negotiate_local(local_control);
     published_receiver.recv_timeout(TEST_TIMEOUT).unwrap();
-    for handle in 0..OVERSUBSCRIBED_OBJECT_COUNT {
+
+    // Draining on a helper thread keeps an update that is wrongly coalesced
+    // away a test failure rather than a hang, because only this thread can
+    // release the host closure.
+    let (drained_sender, drained_receiver) = channel();
+    let drain = std::thread::spawn(move || {
+        let mut notifications = notifications;
+        let drained: Vec<_> = (0..OVERSUBSCRIBED_OBJECT_COUNT)
+            .map(|_| readiness_of(notifications.recv_notification().unwrap()))
+            .collect();
+        drained_sender.send(drained).unwrap();
+        notifications
+    });
+    let drained = drained_receiver
+        .recv_timeout(TEST_TIMEOUT)
+        .expect("a full ring must still deliver every published update");
+    let _notifications = drain.join().unwrap();
+
+    for (handle, notification) in drained.into_iter().enumerate() {
         assert_eq!(
-            readiness_of(notifications.recv_notification().unwrap()),
+            notification,
             ReadinessNotification {
-                handle: ObjectHandle(handle),
+                handle: ObjectHandle(handle as u64),
                 readiness: ReadinessFlags::READ,
             }
         );


### PR DESCRIPTION
The association notification ring has been wired end to end since broker notifications moved to shared memory, but nothing published on it, so readiness that no local request causes had no way to reach a local waiter. This adds bounded coalescing readiness publication to the portable host adapter: sources record the authoritative flags of an object without ever waiting for notification-ring capacity, and one dedicated publisher owns the ring producer, so only that publisher can block when a local endpoint stops draining. The userland broker host supplies the wake primitive and runs that publisher on its own thread per association. No production source publishes yet.