### PR TITLE
Make the VTL1 kernel gsbase-less (#514)

### DIFF
--- a/dev_tests/src/ratchet.rs
+++ b/dev_tests/src/ratchet.rs
@@ -37,7 +37,7 @@ fn ratchet_globals() -> Result<()> {
             ("litebox/", 9),
             ("litebox_platform_linux_kernel/", 6),
             ("litebox_platform_linux_userland/", 5),
-            ("litebox_platform_lvbs/", 24),
+            ("litebox_platform_lvbs/", 26),
             ("litebox_platform_multiplex/", 1),
             ("litebox_platform_windows_userland/", 8),
             ("litebox_runner_lvbs/", 5),

--- a/litebox_platform_linux_kernel/src/arch/x86/mm/paging.rs
+++ b/litebox_platform_linux_kernel/src/arch/x86/mm/paging.rs
@@ -324,9 +324,14 @@ impl<M: MemoryProvider, const ALIGN: usize> PageTableImpl<ALIGN> for X64PageTabl
                 let mut allocator = PageTableAllocator::<M>::new();
                 // TODO: if it is file-backed, we need to read the page from file
                 let frame = PageTableAllocator::<M>::allocate_frame(true).unwrap();
+                // ACCESSED and DIRTY are pre-set here (mirroring the Linux kernel's
+                // `_KERNPG_TABLE`) so the CPU's page-table walker doesn't need an
+                // atomic read-modify-write on this entry the first time it's traversed.
                 let table_flags = PageTableFlags::PRESENT
                     | PageTableFlags::WRITABLE
-                    | PageTableFlags::USER_ACCESSIBLE;
+                    | PageTableFlags::USER_ACCESSIBLE
+                    | PageTableFlags::ACCESSED
+                    | PageTableFlags::DIRTY;
                 match unsafe {
                     inner.map_to_with_table_flags(
                         page,

--- a/litebox_platform_linux_kernel/src/arch/x86/mm/paging.rs
+++ b/litebox_platform_linux_kernel/src/arch/x86/mm/paging.rs
@@ -65,12 +65,19 @@ impl<M: MemoryProvider> FrameDeallocator<Size4KiB> for PageTableAllocator<M> {
 }
 
 pub(crate) fn vmflags_to_pteflags(values: VmFlags) -> PageTableFlags {
-    let mut flags = PageTableFlags::empty();
+    // ACCESSED is pre-set on every newly-constructed leaf PTE, and DIRTY only
+    // on writable ones, so the CPU's page-table walker doesn't need an atomic
+    // read-modify-write to set them on first access (mirroring the Linux
+    // kernel's pre-set A/D on populated PTEs). DIRTY must never be pre-set on
+    // a read-only PTE: WRITABLE=0 + DIRTY=1 is the CET shadow-stack PTE shape.
+    // mprotect masks with `MPROTECT_PTE_MASK`, so the A/D added here are
+    // stripped on that path and the live PTE's A/D bits are preserved instead.
+    let mut flags = PageTableFlags::ACCESSED;
     if values.intersects(VmFlags::VM_READ | VmFlags::VM_WRITE) {
         flags |= PageTableFlags::USER_ACCESSIBLE;
     }
     if values.contains(VmFlags::VM_WRITE) {
-        flags |= PageTableFlags::WRITABLE;
+        flags |= PageTableFlags::WRITABLE | PageTableFlags::DIRTY;
     }
     if !values.contains(VmFlags::VM_EXEC) {
         flags |= PageTableFlags::NO_EXECUTE;
@@ -172,7 +179,30 @@ impl<M: MemoryProvider, const ALIGN: usize> X64PageTable<'_, M, ALIGN> {
                     flags,
                 } => match inner.unmap(start) {
                     Ok((frame, fl)) => {
-                        match unsafe { inner.map_to(new_start, frame, flags, &mut allocator) } {
+                        // `map_to` internally derives parent-table flags as
+                        // `flags & (PRESENT | WRITABLE | USER_ACCESSIBLE)`. Do the
+                        // same masking here (stripping leaf-only bits such as
+                        // NO_EXECUTE and any ACCESSED/DIRTY carried over from the
+                        // old leaf), then pre-set ACCESSED and DIRTY (mirroring the
+                        // Linux kernel's `_KERNPG_TABLE`) so the CPU's page-table
+                        // walker doesn't need an atomic read-modify-write on newly
+                        // created parent entries. Both bits are ignored by hardware
+                        // on non-leaf entries.
+                        let table_flags = (flags
+                            & (PageTableFlags::PRESENT
+                                | PageTableFlags::WRITABLE
+                                | PageTableFlags::USER_ACCESSIBLE))
+                            | PageTableFlags::ACCESSED
+                            | PageTableFlags::DIRTY;
+                        match unsafe {
+                            inner.map_to_with_table_flags(
+                                new_start,
+                                frame,
+                                flags,
+                                table_flags,
+                                &mut allocator,
+                            )
+                        } {
                             Ok(_) => {}
                             Err(e) => match e {
                                 MapToError::PageAlreadyMapped(_) => {

--- a/litebox_platform_linux_kernel/src/mm/tests.rs
+++ b/litebox_platform_linux_kernel/src/mm/tests.rs
@@ -158,7 +158,16 @@ fn test_page_table() {
 
     // update flags
     let new_vmflags = VmFlags::empty();
-    let new_pteflags = vmflags_to_pteflags(new_vmflags) | PageTableFlags::PRESENT;
+    // Explicit expectation: mprotect preserves the PTE's pre-existing
+    // ACCESSED/DIRTY via `(flags & !MPROTECT_PTE_MASK) | new`, while
+    // `vmflags_to_pteflags` derives them fresh (ACCESSED always; DIRTY only
+    // with VM_WRITE). The initial mapping above is read-only (VM_READ), so its
+    // PTE carries ACCESSED but no DIRTY, and after mprotect(VmFlags::empty())
+    // the PTE is exactly PRESENT | ACCESSED | NO_EXECUTE. If the initial
+    // mapping ever becomes writable, its preserved DIRTY must be added here —
+    // the derived form of this expression would then be wrong.
+    let new_pteflags =
+        PageTableFlags::PRESENT | PageTableFlags::ACCESSED | PageTableFlags::NO_EXECUTE;
     unsafe {
         assert!(
             pgtable

--- a/litebox_platform_lvbs/src/arch/x86/gdt.rs
+++ b/litebox_platform_lvbs/src/arch/x86/gdt.rs
@@ -80,15 +80,22 @@ impl Default for GdtWrapper {
 }
 
 fn setup_gdt_tss() {
-    let double_fault_stack_top = with_per_cpu_variables(|pcv| pcv.asm.get_double_fault_stack_ptr());
-    let exception_stack_top = with_per_cpu_variables(|pcv| pcv.asm.get_exception_stack_ptr());
+    // Stack tops come straight from the per-CPU struct fields (16-byte
+    // aligned down, as hardware stack switching requires).
+    const STACK_ALIGNMENT: u64 = 16;
+    let (double_fault_stack_top, exception_stack_top) = with_per_cpu_variables(|pcv| {
+        (
+            pcv.double_fault_stack_top() & !(STACK_ALIGNMENT - 1),
+            pcv.exception_stack_top() & !(STACK_ALIGNMENT - 1),
+        )
+    });
 
     let mut tss = Box::new(AlignedTss(TaskStateSegment::new()));
     // TSS.IST1: dedicated stack for double faults
-    tss.0.interrupt_stack_table[0] = VirtAddr::new(double_fault_stack_top as u64);
+    tss.0.interrupt_stack_table[0] = VirtAddr::new(double_fault_stack_top);
     // TSS.RSP0: stack loaded by the CPU on Ring 3 -> Ring 0 transition when the IDT
     // entry's IST index is 0. In our setup, all exceptions except for double faults.
-    tss.0.privilege_stack_table[0] = VirtAddr::new(exception_stack_top as u64);
+    tss.0.privilege_stack_table[0] = VirtAddr::new(exception_stack_top);
     // `tss_segment()` requires `&'static TaskStateSegment`. Leaking `tss` is fine because
     // it will be used until the LVBS kernel resets.
     let tss = Box::leak(tss);

--- a/litebox_platform_lvbs/src/arch/x86/mm/paging.rs
+++ b/litebox_platform_lvbs/src/arch/x86/mm/paging.rs
@@ -609,7 +609,14 @@ impl<M: MemoryProvider, const ALIGN: usize> X64PageTable<'_, M, ALIGN> {
                 flags
             };
             // Parent entries use a stable permissive constant, not leaf-derived flags.
-            let table_flags = PageTableFlags::PRESENT | PageTableFlags::WRITABLE;
+            //
+            // ACCESSED and DIRTY are pre-set here (mirroring the Linux kernel's
+            // `_KERNPG_TABLE`) so the CPU's page-table walker doesn't need an
+            // atomic read-modify-write on this entry the first time it's traversed.
+            let table_flags = PageTableFlags::PRESENT
+                | PageTableFlags::WRITABLE
+                | PageTableFlags::ACCESSED
+                | PageTableFlags::DIRTY;
 
             match unsafe {
                 inner.map_to_with_table_flags(
@@ -668,7 +675,13 @@ impl<M: MemoryProvider, const ALIGN: usize> X64PageTable<'_, M, ALIGN> {
             .map_err(|_| MapToError::FrameAllocationFailed)?;
         let end_page = start_page + frames.len() as u64;
 
-        let table_flags = PageTableFlags::PRESENT | PageTableFlags::WRITABLE;
+        // ACCESSED and DIRTY are pre-set here (mirroring the Linux kernel's
+        // `_KERNPG_TABLE`) so the CPU's page-table walker doesn't need an
+        // atomic read-modify-write on this entry the first time it's traversed.
+        let table_flags = PageTableFlags::PRESENT
+            | PageTableFlags::WRITABLE
+            | PageTableFlags::ACCESSED
+            | PageTableFlags::DIRTY;
         for (page, &target_frame) in Page::range(start_page, end_page).zip(frames.iter()) {
             // Note: Since we lock the entire page table for the duration of this function (`self.inner.lock()`),
             // there should be no concurrent modifications to the page table. If we allow concurrent mappings
@@ -890,9 +903,14 @@ impl<M: MemoryProvider, const ALIGN: usize> PageTableImpl<ALIGN> for X64PageTabl
                 let mut allocator = PageTableAllocator::<M>::new();
                 // TODO: if it is file-backed, we need to read the page from file
                 let frame = PageTableAllocator::<M>::allocate_frame(true).unwrap();
+                // ACCESSED and DIRTY are pre-set here (mirroring the Linux kernel's
+                // `_KERNPG_TABLE`) so the CPU's page-table walker doesn't need an
+                // atomic read-modify-write on this entry the first time it's traversed.
                 let table_flags = PageTableFlags::PRESENT
                     | PageTableFlags::WRITABLE
-                    | PageTableFlags::USER_ACCESSIBLE;
+                    | PageTableFlags::USER_ACCESSIBLE
+                    | PageTableFlags::ACCESSED
+                    | PageTableFlags::DIRTY;
                 match unsafe {
                     inner.map_to_with_table_flags(
                         page,

--- a/litebox_platform_lvbs/src/arch/x86/mm/paging.rs
+++ b/litebox_platform_lvbs/src/arch/x86/mm/paging.rs
@@ -131,12 +131,19 @@ impl<M: MemoryProvider> FrameDeallocator<Size4KiB> for PageTableAllocator<M> {
 }
 
 pub(crate) fn vmflags_to_pteflags(values: VmFlags) -> PageTableFlags {
-    let mut flags = PageTableFlags::empty();
+    // ACCESSED is pre-set on every newly-constructed leaf PTE, and DIRTY only
+    // on writable ones, so the CPU's page-table walker doesn't need an atomic
+    // read-modify-write to set them on first access (mirroring the Linux
+    // kernel's pre-set A/D on populated PTEs). DIRTY must never be pre-set on
+    // a read-only PTE: WRITABLE=0 + DIRTY=1 is the CET shadow-stack PTE shape.
+    // mprotect masks with `MPROTECT_PTE_MASK`, so the A/D added here are
+    // stripped on that path and the live PTE's A/D bits are preserved instead.
+    let mut flags = PageTableFlags::ACCESSED;
     if values.intersects(VmFlags::VM_READ | VmFlags::VM_WRITE) {
         flags |= PageTableFlags::USER_ACCESSIBLE;
     }
     if values.contains(VmFlags::VM_WRITE) {
-        flags |= PageTableFlags::WRITABLE;
+        flags |= PageTableFlags::WRITABLE | PageTableFlags::DIRTY;
     }
     if !values.contains(VmFlags::VM_EXEC) {
         flags |= PageTableFlags::NO_EXECUTE;
@@ -366,9 +373,31 @@ impl<M: MemoryProvider, const ALIGN: usize> X64PageTable<'_, M, ALIGN> {
                         }
                         TranslateResult::NotMapped => {}
                     }
+                    // `map_to` internally derives parent-table flags as
+                    // `flags & (PRESENT | WRITABLE | USER_ACCESSIBLE)`. Do the same
+                    // masking here (stripping leaf-only bits such as NO_EXECUTE and
+                    // any ACCESSED/DIRTY carried over from the old leaf), then
+                    // pre-set ACCESSED and DIRTY (mirroring the Linux kernel's
+                    // `_KERNPG_TABLE`) so the CPU's page-table walker doesn't need
+                    // an atomic read-modify-write on newly created parent entries.
+                    // Both bits are ignored by hardware on non-leaf entries.
+                    let table_flags = (flags
+                        & (PageTableFlags::PRESENT
+                            | PageTableFlags::WRITABLE
+                            | PageTableFlags::USER_ACCESSIBLE))
+                        | PageTableFlags::ACCESSED
+                        | PageTableFlags::DIRTY;
                     match inner.unmap(start) {
                         Ok((frame, _)) => {
-                            match unsafe { inner.map_to(new_start, frame, flags, &mut allocator) } {
+                            match unsafe {
+                                inner.map_to_with_table_flags(
+                                    new_start,
+                                    frame,
+                                    flags,
+                                    table_flags,
+                                    &mut allocator,
+                                )
+                            } {
                                 Ok(_) => {}
                                 Err(MapToError::FrameAllocationFailed) => {
                                     // Best-effort: restore the page we just unmapped before
@@ -377,9 +406,15 @@ impl<M: MemoryProvider, const ALIGN: usize> X64PageTable<'_, M, ALIGN> {
                                     // caller may still observe a partial move on this error.
                                     // `unmap` leaves the parent tables for `start` in place, so
                                     // restoring the old mapping does not require allocation.
-                                    if let Err(rollback_err) =
-                                        unsafe { inner.map_to(start, frame, flags, &mut allocator) }
-                                    {
+                                    if let Err(rollback_err) = unsafe {
+                                        inner.map_to_with_table_flags(
+                                            start,
+                                            frame,
+                                            flags,
+                                            table_flags,
+                                            &mut allocator,
+                                        )
+                                    } {
                                         crate::serial_println!(
                                             "BUG: remap rollback failed: {:?}",
                                             rollback_err
@@ -601,7 +636,12 @@ impl<M: MemoryProvider, const ALIGN: usize> X64PageTable<'_, M, ALIGN> {
                 let is_exec = ranges.iter().any(|r| r.contains(&frame_addr));
                 if is_exec {
                     // W^X: if the page is executable, it should not be writable.
-                    (flags & !PageTableFlags::NO_EXECUTE) & !PageTableFlags::WRITABLE
+                    // Strip DIRTY together with WRITABLE: a read-only PTE with
+                    // DIRTY set (WRITABLE=0, DIRTY=1) is the CET shadow-stack
+                    // PTE shape (SDM Vol. 3, Sec. 4.6) and must not be created
+                    // for executable pages.
+                    (flags & !PageTableFlags::NO_EXECUTE)
+                        & !(PageTableFlags::WRITABLE | PageTableFlags::DIRTY)
                 } else {
                     flags | PageTableFlags::NO_EXECUTE
                 }

--- a/litebox_platform_lvbs/src/arch/x86/mod.rs
+++ b/litebox_platform_lvbs/src/arch/x86/mod.rs
@@ -85,11 +85,6 @@ pub fn enable_extended_states() {
     );
 }
 
-#[inline]
-pub fn write_kernel_gsbase_msr(addr: VirtAddr) {
-    x86_64::registers::model_specific::KernelGsBase::write(addr);
-}
-
 /// Enable Data Execution Prevention (DEP).
 ///
 /// This enables support for the `NO_EXECUTE` page table flag, allowing

--- a/litebox_platform_lvbs/src/host/per_cpu_variables.rs
+++ b/litebox_platform_lvbs/src/host/per_cpu_variables.rs
@@ -108,7 +108,9 @@ const _: () = assert!(size_of::<PerCpuVariables>() == PER_CPU_ALIGN);
 // masking any RSP within it (including a full stack) recovers the base.
 const _: () = {
     assert!(offset_of!(PerCpuVariables, double_fault_stack) > 0);
-    assert!(offset_of!(PerCpuVariables, double_fault_stack) + DOUBLE_FAULT_STACK_SIZE < PER_CPU_ALIGN);
+    assert!(
+        offset_of!(PerCpuVariables, double_fault_stack) + DOUBLE_FAULT_STACK_SIZE < PER_CPU_ALIGN
+    );
     assert!(offset_of!(PerCpuVariables, exception_stack) > 0);
     assert!(offset_of!(PerCpuVariables, exception_stack) + EXCEPTION_STACK_SIZE < PER_CPU_ALIGN);
     assert!(offset_of!(PerCpuVariables, kernel_stack) > 0);

--- a/litebox_platform_lvbs/src/host/per_cpu_variables.rs
+++ b/litebox_platform_lvbs/src/host/per_cpu_variables.rs
@@ -15,17 +15,34 @@ use alloc::boxed::Box;
 use core::cell::{Cell, UnsafeCell};
 use core::mem::offset_of;
 use litebox::utils::TruncateExt;
-use litebox_common_linux::{rdgsbase, wrgsbase};
 use x86_64::VirtAddr;
 
 pub const DOUBLE_FAULT_STACK_SIZE: usize = 2 * PAGE_SIZE;
 pub const EXCEPTION_STACK_SIZE: usize = PAGE_SIZE;
 pub const KERNEL_STACK_SIZE: usize = 32 * PAGE_SIZE;
 
+/// Size and alignment of [`PerCpuVariables`]. Must be a power of two so the
+/// per-CPU base can be derived by masking any in-struct stack pointer.
+pub const PER_CPU_ALIGN: usize = 262144;
+
 /// Per-CPU VTL1 kernel variables
-#[repr(C, align(4096))]
+///
+/// This kernel is *gsbase-less* (Coconut-SVSM-style, see issue #514): kernel
+/// mode never executes `swapgs`/`rdgsbase`/`wrgsbase` and never addresses
+/// through `gs:`. Instead, the per-CPU base is derived positionally from RSP:
+/// the struct is aligned to **and** exactly [`PER_CPU_ALIGN`] bytes in size,
+/// and every stack the kernel ever runs on after boot (kernel stack,
+/// TSS.RSP0 exception stack, TSS.IST1 double-fault stack) is a field *inside*
+/// this struct. Therefore `rsp & !(PER_CPU_ALIGN - 1)` recovers the struct
+/// base from any kernel context. The invariant "every kernel-mode stack lives
+/// inside the 256 KiB-aligned `PerCpuVariables`" is load-bearing: code must
+/// never run on a foreign stack (the `self_ptr` canary converts violations
+/// into panics on Rust paths). The one path with an untrusted RSP (syscall
+/// entry) is anchored by per-core LSTAR stubs instead (see `syscall_entry`).
+#[repr(C, align(262144))]
 pub struct PerCpuVariables {
-    /// Assembly-accessible fields at GS offset 0 (`gs:[offset]` in inline asm).
+    /// Assembly-accessible fields at offset 0 (addressed as `[base + offset]`
+    /// in inline asm, where `base` is the masked per-CPU pointer).
     ///
     /// All fields use `Cell<T>` for interior mutability, so they can be accessed
     /// through `&PerCpuVariables` without requiring `&mut`.
@@ -42,9 +59,8 @@ pub struct PerCpuVariables {
     hv_simp_page: UnsafeCell<[u8; PAGE_SIZE]>,
     hvcall_input: UnsafeCell<[u8; PAGE_SIZE]>,
     hvcall_output: UnsafeCell<[u8; PAGE_SIZE]>,
-    /// VTL0 general-purpose register state, saved/restored by assembly
-    /// (`SAVE_VTL_STATE_ASM`/`LOAD_VTL_STATE_ASM`) via raw pushes/pops to
-    /// the address cached in `PerCpuVariablesAsm::vtl0_state_top_addr`.
+    /// VTL0 general-purpose register state, saved/restored by the
+    /// `vtl_switch` assembly via direct `[base + offset]` stores/loads.
     /// Rust code accesses it only between save and load (i.e., while VTL1
     /// is executing), so there is no data race with the assembly.
     pub(crate) vtl0_state: Cell<VtlState>,
@@ -63,6 +79,11 @@ pub struct PerCpuVariables {
     pub(crate) preemption_armed: Cell<bool>,
     /// Set when a preemption timer killed user-mode code.
     pub(crate) preemption_timeout_killed_user: Cell<bool>,
+    /// Canary holding this struct's own address, set once by
+    /// [`allocate_per_cpu_variables`]. [`get_per_cpu_variables_ptr`] asserts
+    /// it against the RSP-derived base, converting any "kernel code running
+    /// on a foreign stack" bug from silent corruption into a panic.
+    self_ptr: Cell<usize>,
 }
 
 // These Hyper-V pages must be page-aligned.
@@ -72,13 +93,35 @@ const _: () = assert!(offset_of!(PerCpuVariables, hv_simp_page) % PAGE_SIZE == 0
 const _: () = assert!(offset_of!(PerCpuVariables, hvcall_input) % PAGE_SIZE == 0);
 const _: () = assert!(offset_of!(PerCpuVariables, hvcall_output) % PAGE_SIZE == 0);
 
+// RSP-mask derivation requires size == align (a power of two): masking any
+// address inside the struct with `!(PER_CPU_ALIGN - 1)` must yield the struct
+// base. `repr(C, align(N))` rounds the size up to the alignment, so equality
+// also proves the fields fit in one 256 KiB block. If a future field/stack
+// growth trips this, size/align/mask must all move to 512 KiB together
+// (doubling per-core memory) — a deliberate policy decision, not a tweak.
+// The size == align invariant also guarantees the allocation is served by the
+// buddy allocator (256 KiB > slab MAX_ALLOC_SIZE), which returns naturally
+// size-aligned power-of-two blocks.
+const _: () = assert!(align_of::<PerCpuVariables>() == PER_CPU_ALIGN);
+const _: () = assert!(size_of::<PerCpuVariables>() == PER_CPU_ALIGN);
+// Every kernel-mode stack must be strictly interior to the struct so that
+// masking any RSP within it (including a full stack) recovers the base.
+const _: () = {
+    assert!(offset_of!(PerCpuVariables, double_fault_stack) > 0);
+    assert!(offset_of!(PerCpuVariables, double_fault_stack) + DOUBLE_FAULT_STACK_SIZE < PER_CPU_ALIGN);
+    assert!(offset_of!(PerCpuVariables, exception_stack) > 0);
+    assert!(offset_of!(PerCpuVariables, exception_stack) + EXCEPTION_STACK_SIZE < PER_CPU_ALIGN);
+    assert!(offset_of!(PerCpuVariables, kernel_stack) > 0);
+    assert!(offset_of!(PerCpuVariables, kernel_stack) + KERNEL_STACK_SIZE < PER_CPU_ALIGN);
+};
+
 impl PerCpuVariables {
     const XSAVE_ALIGNMENT: usize = 64; // XSAVE and XRSTORE require a 64-byte aligned buffer
     pub const VTL1_XSAVE_MASK: u64 = 0b11; // let XSAVE and XRSTORE deal with x87 and SSE states
     // XSAVE area size for VTL1: 512 bytes (legacy x87+SSE area) + 64 bytes (XSAVE header)
     const VTL1_XSAVE_AREA_SIZE: usize = 512 + 64;
 
-    pub(crate) fn kernel_stack_top(&self) -> u64 {
+    pub fn kernel_stack_top(&self) -> u64 {
         &raw const self.kernel_stack as u64 + (self.kernel_stack.len() - 1) as u64
     }
 
@@ -259,20 +302,14 @@ impl PerCpuVariables {
 #[repr(C, align(4096))]
 #[derive(Clone)]
 pub struct PerCpuVariablesAsm {
-    /// Initial kernel stack pointer to reset the kernel stack on VTL switch
-    kernel_stack_ptr: Cell<usize>,
-    /// Double fault stack pointer (TSS.IST1)
-    double_fault_stack_ptr: Cell<usize>,
-    /// Exception stack pointer (TSS.RSP0)
-    exception_stack_ptr: Cell<usize>,
-    /// Return address for call-based VTL switching
-    vtl_return_addr: Cell<usize>,
+    /// Address of this core's `SyscallSlot` (see `syscall_entry`), cached so
+    /// the syscall entry path can fetch the stub-spilled user `rax` with one
+    /// indirection from the per-CPU base.
+    syscall_slot_ptr: Cell<usize>,
     /// Scratch pad
     scratch: Cell<usize>,
     /// User-mode RFLAGS captured at `syscall` entry
     user_rflags: Cell<usize>,
-    /// Top address of VTL0 VtlState
-    vtl0_state_top_addr: Cell<usize>,
     /// Current kernel stack pointer
     cur_kernel_stack_ptr: Cell<usize>,
     /// Current kernel base pointer
@@ -310,29 +347,8 @@ pub struct PerCpuVariablesAsm {
 }
 
 impl PerCpuVariablesAsm {
-    pub fn set_kernel_stack_ptr(&self, sp: usize) {
-        self.kernel_stack_ptr.set(sp);
-    }
-    pub fn set_double_fault_stack_ptr(&self, sp: usize) {
-        self.double_fault_stack_ptr.set(sp);
-    }
-    pub fn get_double_fault_stack_ptr(&self) -> usize {
-        self.double_fault_stack_ptr.get()
-    }
-    pub fn set_exception_stack_ptr(&self, sp: usize) {
-        self.exception_stack_ptr.set(sp);
-    }
-    pub fn get_exception_stack_ptr(&self) -> usize {
-        self.exception_stack_ptr.get()
-    }
-    pub fn set_vtl_return_addr(&self, addr: usize) {
-        self.vtl_return_addr.set(addr);
-    }
-    pub fn get_vtl_return_addr(&self) -> usize {
-        self.vtl_return_addr.get()
-    }
-    pub fn set_vtl0_state_top_addr(&self, addr: usize) {
-        self.vtl0_state_top_addr.set(addr);
+    pub fn set_syscall_slot_ptr(&self, addr: usize) {
+        self.syscall_slot_ptr.set(addr);
     }
     pub fn set_vtl0_xsave_area_addr(&self, addr: usize) {
         self.vtl0_xsave_area_addr.set(addr);
@@ -353,26 +369,14 @@ impl PerCpuVariablesAsm {
         self.vtl1_xsave_mask_hi
             .set(((mask >> 32) & 0xffff_ffff) as u32);
     }
-    pub const fn kernel_stack_ptr_offset() -> usize {
-        offset_of!(PerCpuVariablesAsm, kernel_stack_ptr)
-    }
-    pub const fn double_fault_stack_ptr_offset() -> usize {
-        offset_of!(PerCpuVariablesAsm, double_fault_stack_ptr)
-    }
-    pub const fn exception_stack_ptr_offset() -> usize {
-        offset_of!(PerCpuVariablesAsm, exception_stack_ptr)
-    }
-    pub const fn vtl_return_addr_offset() -> usize {
-        offset_of!(PerCpuVariablesAsm, vtl_return_addr)
+    pub const fn syscall_slot_ptr_offset() -> usize {
+        offset_of!(PerCpuVariablesAsm, syscall_slot_ptr)
     }
     pub const fn scratch_offset() -> usize {
         offset_of!(PerCpuVariablesAsm, scratch)
     }
     pub const fn user_rflags_offset() -> usize {
         offset_of!(PerCpuVariablesAsm, user_rflags)
-    }
-    pub const fn vtl0_state_top_addr_offset() -> usize {
-        offset_of!(PerCpuVariablesAsm, vtl0_state_top_addr)
     }
     pub const fn cur_kernel_stack_ptr_offset() -> usize {
         offset_of!(PerCpuVariablesAsm, cur_kernel_stack_ptr)
@@ -435,12 +439,15 @@ impl PerCpuVariablesAsm {
 /// Execute a closure with a shared reference to the current core's per-CPU variables.
 ///
 /// # Safety
-/// The GSBASE register must point to a valid, heap-allocated `PerCpuVariables`
-/// (set by [`allocate_per_cpu_variables`]). Each core must have a distinct
-/// GSBASE value.
+/// The caller must be executing on a stack inside this core's
+/// `PerCpuVariables` (kernel/exception/double-fault stack) — true for every
+/// kernel context after the boot stack switch. Boot code running on the
+/// shared boot stack must not call this; it receives the pointer returned by
+/// [`allocate_per_cpu_variables`] explicitly instead.
 ///
 /// # Panics
-/// Panics if GSBASE is not set or contains a non-canonical address.
+/// Panics if the RSP-derived base fails the `self_ptr` canary check
+/// (i.e., the current stack is not inside a `PerCpuVariables`).
 pub fn with_per_cpu_variables<F, R>(f: F) -> R
 where
     F: FnOnce(&PerCpuVariables) -> R,
@@ -453,36 +460,55 @@ where
     f(pcv)
 }
 
-/// Get a raw pointer to the current core's `PerCpuVariables` from GSBASE.
+/// Get a raw pointer to the current core's `PerCpuVariables` by masking RSP.
+///
+/// Every post-boot kernel stack lives inside the 256 KiB-aligned
+/// `PerCpuVariables` (see the struct doc), so `rsp & !(PER_CPU_ALIGN - 1)`
+/// is the struct base regardless of which in-struct stack is active.
 ///
 /// # Panics
-/// Panics if GSBASE is zero or non-canonical.
+/// Panics if the derived base fails the `self_ptr` canary check. This is a
+/// release-mode assert on purpose: it replaces the two release asserts the
+/// old GSBASE-based accessor performed (gsbase != 0 + canonical check) at
+/// cost parity (one dependent load + compare), and it turns execution on a
+/// foreign stack from silent corruption into a panic.
 fn get_per_cpu_variables_ptr() -> *mut PerCpuVariables {
-    let gsbase = unsafe { rdgsbase() };
+    let rsp: usize;
+    // Safety: reading RSP has no side effects.
+    unsafe {
+        core::arch::asm!(
+            "mov {}, rsp",
+            out(reg) rsp,
+            options(nomem, nostack, preserves_flags)
+        );
+    }
+    let ptr = (rsp & !(PER_CPU_ALIGN - 1)) as *mut PerCpuVariables;
+    // Safety: if the invariant holds, `ptr` is this core's PerCpuVariables;
+    // if it does not, this read is the canary check that catches it (the
+    // masked address is at worst a wild kernel read that faults loudly).
     assert!(
-        gsbase != 0,
-        "GSBASE not set. Call allocate_per_cpu_variables() first"
+        unsafe { (*ptr).self_ptr.get() } == ptr as usize,
+        "per-CPU derivation on a stack outside PerCpuVariables"
     );
-    let _ = VirtAddr::try_new(gsbase as u64).expect("GS contains a non-canonical address");
-    gsbase as *mut PerCpuVariables
+    ptr
 }
 
-/// Heap-allocate this core's per-CPU variables and set GSBASE to point at them.
+/// Heap-allocate this core's per-CPU variables and return them.
 ///
 /// Every core (BSP and AP) calls this exactly once during its boot path,
-/// **before** [`init_per_cpu_variables`].
-///
-/// GSBASE will point directly at the `PerCpuVariables` struct, so assembly
-/// code can access the `asm` field at GS offset 0 (guaranteed by `#[repr(C)]`).
+/// while still on the boot stack. The returned reference must be passed
+/// explicitly to boot code that needs it (e.g., to compute the kernel stack
+/// pointer); [`with_per_cpu_variables`] only works after the caller has
+/// switched RSP onto the in-struct kernel stack.
 ///
 /// The caller must have already:
-///   1. Enabled FSGSBASE (`enable_fsgsbase()`).
-///   2. Enabled extended CPU states (`enable_extended_states()`).
-///   3. (BSP only) Seeded the global heap (`seed_initial_heap()`).
+///   1. Enabled extended CPU states (`enable_extended_states()`).
+///   2. (BSP only) Seeded the global heap (`seed_initial_heap()`).
 ///
 /// # Panics
-/// Panics if the heap allocation fails.
-pub fn allocate_per_cpu_variables() {
+/// Panics if the heap allocation fails or returns a block that is not
+/// `PER_CPU_ALIGN`-aligned (the RSP-mask derivation depends on it).
+pub fn allocate_per_cpu_variables() -> &'static PerCpuVariables {
     let mut per_cpu_variables = Box::<PerCpuVariables>::new_uninit();
     // Safety: `PerCpuVariables` is too large for the stack, so we zero-init
     // via `write_bytes` then fix up the `vp_index` sentinel. Zero is valid
@@ -499,58 +525,28 @@ pub fn allocate_per_cpu_variables() {
 
     // Leak the box so it lives for the core's lifetime.
     let pcv = Box::leak(per_cpu_variables);
-    let addr = &raw const *pcv as u64;
-    unsafe {
-        wrgsbase(addr.trunc());
-    }
+    let addr = &raw const *pcv as usize;
+    // The 256 KiB layout is served by the buddy allocator, whose power-of-two
+    // blocks are naturally size-aligned. Assert so any future allocator
+    // change that breaks the RSP-mask invariant fails loudly here rather
+    // than corrupting per-CPU state at the first masked access.
+    assert!(
+        addr.is_multiple_of(PER_CPU_ALIGN),
+        "PerCpuVariables allocation is not PER_CPU_ALIGN-aligned"
+    );
+    pcv.self_ptr.set(addr);
+    pcv
 }
 
 /// Allocate XSAVE areas for the current core.
 ///
-/// Must be called **after** [`allocate_per_cpu_variables`] (so GSBASE is
-/// set) and **after** switching to the kernel stack. The CPUID queries and
-/// `avec!` allocations inside `PerCpuVariables::allocate_xsave_area` use
-/// significant stack space that exceeds the 4 KiB boot stack.
+/// Must be called **after** switching to the in-struct kernel stack (so the
+/// RSP-mask accessor works). The CPUID queries and `avec!` allocations
+/// inside `PerCpuVariables::allocate_xsave_area` also use significant stack
+/// space that exceeds the 4 KiB boot stack.
 pub fn allocate_xsave_area() {
     with_per_cpu_variables(|pcv| {
         PerCpuVariables::allocate_xsave_area(&pcv.asm);
-    });
-}
-
-/// Initialize PerCpuVariable and PerCpuVariableAsm for the current core.
-///
-/// Currently, it initializes the kernel and interrupt stack pointers and the top address of VTL0 VtlState
-/// in the PerCpuVariablesAsm area.
-///
-/// # Panics
-/// Panics if the per-CPU variables are not properly initialized.
-pub fn init_per_cpu_variables() {
-    const STACK_ALIGNMENT: usize = 16;
-    with_per_cpu_variables(|per_cpu_variables| {
-        let kernel_sp = TruncateExt::<usize>::trunc(per_cpu_variables.kernel_stack_top())
-            & !(STACK_ALIGNMENT - 1);
-        let double_fault_sp =
-            TruncateExt::<usize>::trunc(per_cpu_variables.double_fault_stack_top())
-                & !(STACK_ALIGNMENT - 1);
-        let exception_sp = TruncateExt::<usize>::trunc(per_cpu_variables.exception_stack_top())
-            & !(STACK_ALIGNMENT - 1);
-        // `Cell<VtlState>` is `#[repr(transparent)]`, so its address equals
-        // the inner `VtlState`'s address. Assembly code (`SAVE_VTL_STATE_ASM`
-        // / `LOAD_VTL_STATE_ASM`) pushes/pops registers directly to/from this
-        // address. This is sound because the assembly executes outside any
-        // Rust reference scope and the Cell is only accessed in Rust between
-        // the save and load points (i.e., while VTL1 is executing).
-        let vtl0_state_top_addr =
-            TruncateExt::<usize>::trunc(&raw const per_cpu_variables.vtl0_state as u64)
-                + core::mem::size_of::<VtlState>();
-        per_cpu_variables.asm.set_kernel_stack_ptr(kernel_sp);
-        per_cpu_variables
-            .asm
-            .set_double_fault_stack_ptr(double_fault_sp);
-        per_cpu_variables.asm.set_exception_stack_ptr(exception_sp);
-        per_cpu_variables
-            .asm
-            .set_vtl0_state_top_addr(vtl0_state_top_addr);
     });
 }
 

--- a/litebox_platform_lvbs/src/lib.rs
+++ b/litebox_platform_lvbs/src/lib.rs
@@ -6,7 +6,16 @@
 #![cfg(target_arch = "x86_64")]
 #![no_std]
 
-use crate::{host::per_cpu_variables::PerCpuVariablesAsm, mshv::vsm::Vtl0KernelInfo};
+use crate::{
+    host::per_cpu_variables::{PER_CPU_ALIGN, PerCpuVariablesAsm},
+    mshv::vsm::Vtl0KernelInfo,
+};
+
+/// Negated [`PER_CPU_ALIGN`] for `and reg, imm32` per-CPU base derivation in
+/// inline asm (sign-extended imm32).
+#[cfg(target_arch = "x86_64")]
+#[allow(clippy::cast_possible_wrap)]
+const PER_CPU_ALIGN_NEG: i64 = -(PER_CPU_ALIGN as i64);
 use core::sync::atomic::AtomicU32;
 use hashbrown::HashMap;
 use litebox::platform::{
@@ -26,12 +35,9 @@ use litebox_common_linux::vmap::{
     GlobalVmapManager, PhysPageAddrArray, PhysPageMapInfo, PhysPageMapPermissions,
     PhysPointerError, VmapManager,
 };
-use x86_64::{
-    VirtAddr,
-    structures::paging::{
-        PageOffset, PageSize, PageTableFlags, PhysFrame, Size4KiB, frame::PhysFrameRange,
-        mapper::MapToError,
-    },
+use x86_64::structures::paging::{
+    PageOffset, PageSize, PageTableFlags, PhysFrame, Size4KiB, frame::PhysFrameRange,
+    mapper::MapToError,
 };
 use zerocopy::{FromBytes, IntoBytes};
 
@@ -1316,11 +1322,11 @@ pub unsafe fn run_thread<T>(shim: T, ctx: &mut litebox_common_linux::PtRegs)
 where
     T: litebox::shim::EnterShim<ExecutionContext = litebox_common_linux::PtRegs>,
 {
-    // Currently, `litebox_platform_lvbs` uses `swapgs` to efficiently switch between
-    // kernel and user GS base values during kernel-user mode transitions.
-    // This `swapgs` usage can pontetially leak a kernel address to the user, so
-    // we clear the `KernelGsBase` MSR before running the user thread.
-    crate::arch::write_kernel_gsbase_msr(VirtAddr::zero());
+    // The kernel never touches GS, so a TA's GSBASE survives kernel entries
+    // within one dispatch by construction. Reset it to 0 for each fresh
+    // dispatch from VTL0 so one TA's GSBASE cannot leak to the next TA
+    // scheduled on this core (same TA-visible semantics as before).
+    unsafe { litebox_common_linux::wrgsbase(0) };
     run_thread_inner(&shim, ctx, false);
 }
 
@@ -1335,7 +1341,8 @@ pub unsafe fn run_thread_ref<T>(shim: &T, ctx: &mut litebox_common_linux::PtRegs
 where
     T: litebox::shim::EnterShim<ExecutionContext = litebox_common_linux::PtRegs>,
 {
-    crate::arch::write_kernel_gsbase_msr(VirtAddr::zero());
+    // Reset user GSBASE for a fresh dispatch (see `run_thread`).
+    unsafe { litebox_common_linux::wrgsbase(0) };
     run_thread_inner(shim, ctx, false);
 }
 
@@ -1350,7 +1357,8 @@ pub unsafe fn reenter_thread_ref<T>(shim: &T, ctx: &mut litebox_common_linux::Pt
 where
     T: litebox::shim::EnterShim<ExecutionContext = litebox_common_linux::PtRegs>,
 {
-    crate::arch::write_kernel_gsbase_msr(VirtAddr::zero());
+    // Reset user GSBASE for a fresh dispatch (see `run_thread`).
+    unsafe { litebox_common_linux::wrgsbase(0) };
     run_thread_inner(shim, ctx, true);
 }
 
@@ -1433,21 +1441,31 @@ macro_rules! RESTORE_CALLEE_SAVED_REGISTERS_ASM {
 
 /// Assembly macro to save VTL1 extended states (XSAVE/XSAVEOPT).
 /// Uses xsaveopt only after XRSTOR has established tracking (xsaved == 2).
+/// `$base` is a register holding the `PerCpuVariables` pointer; it must not
+/// be rax/rcx/rdx (clobbered by this macro).
 /// Clobbers: rax, rcx, rdx
 #[cfg(target_arch = "x86_64")]
 macro_rules! XSAVE_VTL1_ASM {
-    ($xsave_area_off:tt, $mask_lo_off:tt, $mask_hi_off:tt, $xsaved_off:tt) => {
+    ($base:tt, $xsave_area_off:tt, $mask_lo_off:tt, $mask_hi_off:tt, $xsaved_off:tt) => {
         concat!(
-            "mov rcx, gs:[",
+            "mov rcx, [",
+            stringify!($base),
+            " + ",
             stringify!($xsave_area_off),
             "]\n",
-            "mov eax, gs:[",
+            "mov eax, [",
+            stringify!($base),
+            " + ",
             stringify!($mask_lo_off),
             "]\n",
-            "mov edx, gs:[",
+            "mov edx, [",
+            stringify!($base),
+            " + ",
             stringify!($mask_hi_off),
             "]\n",
-            "cmp byte ptr gs:[",
+            "cmp byte ptr [",
+            stringify!($base),
+            " + ",
             stringify!($xsaved_off),
             "], 2\n",
             "jne 2f\n",
@@ -1456,11 +1474,15 @@ macro_rules! XSAVE_VTL1_ASM {
             "2:\n",
             "xsave [rcx]\n",
             // Set to 1 if it was 0 (first save). If already 1, keep it as 1.
-            "cmp byte ptr gs:[",
+            "cmp byte ptr [",
+            stringify!($base),
+            " + ",
             stringify!($xsaved_off),
             "], 0\n",
             "jne 3f\n",
-            "mov byte ptr gs:[",
+            "mov byte ptr [",
+            stringify!($base),
+            " + ",
             stringify!($xsaved_off),
             "], 1\n",
             "3:\n",
@@ -1471,27 +1493,39 @@ macro_rules! XSAVE_VTL1_ASM {
 /// Assembly macro to restore VTL1 extended states (XRSTOR).
 /// Skips restore if state was never saved (xsaved == 0).
 /// Sets xsaved to 2 after restore to enable XSAVEOPT optimization.
+/// `$base` is a register holding the `PerCpuVariables` pointer; it must not
+/// be rax/rcx/rdx (clobbered by this macro).
 /// Clobbers: rax, rcx, rdx
 #[cfg(target_arch = "x86_64")]
 macro_rules! XRSTOR_VTL1_ASM {
-    ($xsave_area_off:tt, $mask_lo_off:tt, $mask_hi_off:tt, $xsaved_off:tt) => {
+    ($base:tt, $xsave_area_off:tt, $mask_lo_off:tt, $mask_hi_off:tt, $xsaved_off:tt) => {
         concat!(
-            "cmp byte ptr gs:[",
+            "cmp byte ptr [",
+            stringify!($base),
+            " + ",
             stringify!($xsaved_off),
             "], 0\n",
             "je 4f\n",
-            "mov rcx, gs:[",
+            "mov rcx, [",
+            stringify!($base),
+            " + ",
             stringify!($xsave_area_off),
             "]\n",
-            "mov eax, gs:[",
+            "mov eax, [",
+            stringify!($base),
+            " + ",
             stringify!($mask_lo_off),
             "]\n",
-            "mov edx, gs:[",
+            "mov edx, [",
+            stringify!($base),
+            " + ",
             stringify!($mask_hi_off),
             "]\n",
             "xrstor [rcx]\n",
             // After XRSTOR, tracking is established - XSAVEOPT is now safe
-            "mov byte ptr gs:[",
+            "mov byte ptr [",
+            stringify!($base),
+            " + ",
             stringify!($xsaved_off),
             "], 2\n",
             "4:\n",
@@ -1507,8 +1541,11 @@ macro_rules! XRSTOR_VTL1_ASM {
 /// (i.e., from high addresses down to low ones).
 ///
 /// Prerequisite:
+/// - `rax` holds the `PerCpuVariables` pointer (loaded by this core's
+///   syscall entry stub).
 /// - Store user `rsp` in `r11` before calling this macro.
-/// - Store user `rflags` in `gs:[user_rflags]` before calling this macro.
+/// - Store user `rflags` in `[rax + user_rflags]` before calling this macro.
+/// - Store user `rax` in `[rax + scratch]` before calling this macro.
 /// - Store the userspace return address in `rcx` (`syscall` does this automatically).
 #[cfg(target_arch = "x86_64")]
 macro_rules! SAVE_SYSCALL_USER_CONTEXT_ASM {
@@ -1516,10 +1553,10 @@ macro_rules! SAVE_SYSCALL_USER_CONTEXT_ASM {
         "
         push 0x2b       // pt_regs->ss = __USER_DS
         push r11        // pt_regs->rsp
-        push qword ptr gs:[{user_rflags_off}] // pt_regs->eflags
+        push qword ptr [rax + {user_rflags_off}] // pt_regs->eflags
         push 0x33       // pt_regs->cs = __USER_CS
         push rcx        // pt_regs->rip
-        push rax        // pt_regs->orig_rax
+        push qword ptr [rax + {scratch_off}] // pt_regs->orig_rax (user rax)
         push rdi        // pt_regs->rdi
         push rsi        // pt_regs->rsi
         push rdx        // pt_regs->rdx
@@ -1547,35 +1584,34 @@ macro_rules! SAVE_SYSCALL_USER_CONTEXT_ASM {
 ///
 /// Prerequisites:
 /// - `rsp` points to the top of the user context area (push target)
-/// - `rax` points to the ISR stack: `[rax]`=vector, `[rax+8]`=error_code,
-///   `[rax+16]`=RIP, `[rax+24]`=CS, `[rax+32]`=RFLAGS, `[rax+40]`=RSP,
-///   `[rax+48]`=SS
-/// - All GPRs except `rax` contain user-mode values
-/// - User `rax` has been saved to per-CPU scratch
-/// - `swapgs` has already been executed (GS = kernel)
+/// - `rbx` points to the ISR stack: `[rbx]`=vector, `[rbx+8]`=error_code,
+///   `[rbx+16]`=RIP, `[rbx+24]`=CS, `[rbx+32]`=RFLAGS, `[rbx+40]`=RSP,
+///   `[rbx+48]`=SS
+/// - User `rax` was pushed at `[rbx-8]`, user `rbx` at `[rbx-16]` by
+///   `exception_callback` before it derived the per-CPU base
+/// - All other GPRs contain user-mode values
 ///
-/// Clobbers: rax
+/// Clobbers: none
 #[cfg(target_arch = "x86_64")]
 macro_rules! SAVE_PF_USER_CONTEXT_ASM {
     () => {
         "
-        push [rax + 48]   // pt_regs->ss
-        push [rax + 40]   // pt_regs->rsp
-        push [rax + 32]   // pt_regs->eflags
-        push [rax + 24]   // pt_regs->cs
-        push [rax + 16]   // pt_regs->rip
-        push [rax + 8]    // pt_regs->orig_rax (error code)
+        push [rbx + 48]   // pt_regs->ss
+        push [rbx + 40]   // pt_regs->rsp
+        push [rbx + 32]   // pt_regs->eflags
+        push [rbx + 24]   // pt_regs->cs
+        push [rbx + 16]   // pt_regs->rip
+        push [rbx + 8]    // pt_regs->orig_rax (error code)
         push rdi          // pt_regs->rdi
         push rsi          // pt_regs->rsi
         push rdx          // pt_regs->rdx
         push rcx          // pt_regs->rcx
-        mov rax, gs:[{scratch_off}]
-        push rax          // pt_regs->rax
+        push [rbx - 8]    // pt_regs->rax (user rax)
         push r8           // pt_regs->r8
         push r9           // pt_regs->r9
         push r10          // pt_regs->r10
         push r11          // pt_regs->r11
-        push rbx          // pt_regs->rbx
+        push [rbx - 16]   // pt_regs->rbx (user rbx)
         push rbp          // pt_regs->rbp
         push r12          // pt_regs->r12
         push r13          // pt_regs->r13
@@ -1647,18 +1683,22 @@ unsafe extern "C" fn run_thread_arch(
         SAVE_CALLEE_SAVED_REGISTERS_ASM!(),
         // Save reenter flag (in dl) before XSAVE clobbers edx
         "mov r9b, dl",
+        // Derive the per-CPU base from RSP (the kernel stack lives inside the
+        // 256 KiB-aligned PerCpuVariables; see its doc comment).
+        "mov r10, rsp",
+        "and r10, {neg_pcv_align}",
         // Extended states are callee-saved. Save all extended states for now because
         // we don't know whether the caller touched any of them.
-        XSAVE_VTL1_ASM!({vtl1_kernel_xsave_area_off}, {vtl1_xsave_mask_lo_off}, {vtl1_xsave_mask_hi_off}, {vtl1_kernel_xsaved_off}),
+        XSAVE_VTL1_ASM!(r10, {vtl1_kernel_xsave_area_off}, {vtl1_xsave_mask_lo_off}, {vtl1_xsave_mask_hi_off}, {vtl1_kernel_xsaved_off}),
         "push rdi", // save `thread_ctx`
         // Save kernel rsp and rbp and user context top in PerCpuVariablesAsm.
-        "mov gs:[{cur_kernel_sp_off}], rsp",
-        "mov gs:[{cur_kernel_bp_off}], rbp",
+        "mov [r10 + {cur_kernel_sp_off}], rsp",
+        "mov [r10 + {cur_kernel_bp_off}], rbp",
         "lea r8, [rsi + {USER_CONTEXT_SIZE}]",
-        "mov gs:[{user_context_top_off}], r8",
+        "mov [r10 + {user_context_top_off}], r8",
         // Mark that we are inside a user/TA context so that
         // kernel_exception_callback knows a valid ThreadContext exists.
-        "mov byte ptr gs:[{is_in_user_off}], 1",
+        "mov byte ptr [r10 + {is_in_user_off}], 1",
         // Call init_handler or reenter_handler based on reenter flag (in dl)
         "test r9b, r9b",
         "jnz 1f",
@@ -1667,16 +1707,26 @@ unsafe extern "C" fn run_thread_arch(
         "1:",
         "call {reenter_handler}",
         "jmp done",
+        // Syscall callback: entered from this core's per-core LSTAR stub
+        // (see `syscall_entry`). At this point:
+        // - rax = this core's PerCpuVariables pointer (loaded by the stub)
+        // - user rax is parked in this core's SyscallSlot rax_spill
+        // - rsp = UNTRUSTED user rsp (unchanged by the stub)
+        // - rcx = user return RIP, r11 = user RFLAGS (hardware)
+        // - Interrupts are masked (SFMASK clears IF)
         ".globl syscall_callback",
         "syscall_callback:",
-        "swapgs",
-        "mov gs:[{user_rflags_off}], r11", // store user `rflags`.
+        "mov [rax + {user_rflags_off}], r11", // store user `rflags`.
+        "mov r11, [rax + {syscall_slot_ptr_off}]",
+        "mov r11, [r11]", // user `rax` from the stub's spill slot
+        "mov [rax + {scratch_off}], r11", // park user `rax` in pcv scratch
         "mov r11, rsp", // store user `rsp` in `r11`
-        "mov rsp, gs:[{user_context_top_off}]", // `rsp` points to the top address of user context area
+        "mov rsp, [rax + {user_context_top_off}]", // `rsp` points to the top address of user context area
         SAVE_SYSCALL_USER_CONTEXT_ASM!(),
-        XSAVE_VTL1_ASM!({vtl1_user_xsave_area_off}, {vtl1_xsave_mask_lo_off}, {vtl1_xsave_mask_hi_off}, {vtl1_user_xsaved_off}),
-        "mov rbp, gs:[{cur_kernel_bp_off}]",
-        "mov rsp, gs:[{cur_kernel_sp_off}]",
+        "mov rbx, rax", // XSAVE clobbers rax/rcx/rdx; keep pcv in rbx
+        XSAVE_VTL1_ASM!(rbx, {vtl1_user_xsave_area_off}, {vtl1_xsave_mask_lo_off}, {vtl1_xsave_mask_hi_off}, {vtl1_user_xsaved_off}),
+        "mov rbp, [rbx + {cur_kernel_bp_off}]",
+        "mov rsp, [rbx + {cur_kernel_sp_off}]",
         // Handle the syscall. This will jump back to the user but
         // will return if the thread is exiting.
         "mov rdi, [rsp]", // pass `thread_ctx`
@@ -1684,24 +1734,29 @@ unsafe extern "C" fn run_thread_arch(
         "jmp done",
         // Exception callback: entered from ISR stubs for user-mode exceptions.
         // At this point:
-        // - rsp = ISR stack: [vector, error_code, rip, cs, rflags, rsp, ss]
+        // - rsp = ISR stack: [vector, error_code, rip, cs, rflags, rsp, ss],
+        //   hardware-loaded from TSS.RSP0 (or TSS.IST1 for a double fault) —
+        //   both stacks live inside PerCpuVariables, so masking RSP recovers
+        //   the per-CPU base
         // - All GPRs contain user-mode values
         // - Interrupts are disabled (IDT gate clears IF)
-        // - GS = user (swapgs has NOT happened yet)
         ".globl exception_callback",
         "exception_callback:",
         "cld",
         "clac",
-        "swapgs",
-        "mov gs:[{scratch_off}], rax", // Save `rax` to per-CPU scratch
-        "mov al, [rsp]",
-        "mov gs:[{exception_trapno_off}], al", // vector number from ISR stack
-        "mov rax, rsp", // store ISR `rsp` in `rax`
-        "mov rsp, gs:[{user_context_top_off}]", // `rsp` points to the top address of user context area
+        "push rax", // free rax (user value preserved at [rbx - 8] below)
+        "push rbx", // free rbx (user value preserved at [rbx - 16] below)
+        "lea rbx, [rsp + 16]", // rbx = ISR frame pointer ([rbx] = vector)
+        "mov rax, rsp",
+        "and rax, {neg_pcv_align}", // rax = per-CPU base
+        "mov rsp, [rax + {user_context_top_off}]", // `rsp` points to the top address of user context area
         SAVE_PF_USER_CONTEXT_ASM!(),
-        XSAVE_VTL1_ASM!({vtl1_user_xsave_area_off}, {vtl1_xsave_mask_lo_off}, {vtl1_xsave_mask_hi_off}, {vtl1_user_xsaved_off}),
-        "mov rbp, gs:[{cur_kernel_bp_off}]",
-        "mov rsp, gs:[{cur_kernel_sp_off}]",
+        "mov cl, [rbx]", // vector number from ISR stack (user rcx already saved)
+        "mov [rax + {exception_trapno_off}], cl",
+        "mov rbx, rax", // XSAVE clobbers rax/rcx/rdx; keep pcv in rbx
+        XSAVE_VTL1_ASM!(rbx, {vtl1_user_xsave_area_off}, {vtl1_xsave_mask_lo_off}, {vtl1_xsave_mask_hi_off}, {vtl1_user_xsaved_off}),
+        "mov rbp, [rbx + {cur_kernel_bp_off}]",
+        "mov rsp, [rbx + {cur_kernel_sp_off}]",
         "mov rdi, [rsp]", // pass `thread_ctx`
         "xor esi, esi",   // kernel_mode = false
         "mov rdx, cr2",   // cr2 (still valid — nothing overwrites it)
@@ -1711,9 +1766,9 @@ unsafe extern "C" fn run_thread_arch(
         // and exception-table fixup).
         // At entry:
         // - rsp = ISR stack: [vector, error_code, rip, cs, rflags, rsp, ss]
+        //   (the interrupted kernel stack, inside PerCpuVariables)
         // - All GPRs = kernel values at time of fault
         // - Interrupts are disabled (IDT gate clears IF)
-        // - GS = kernel (no swapgs needed)
         //
         // Saves GPRs, then passes exception info (CR2, error code, faulting
         // RIP) to exception_handler via registers. exception_handler will try
@@ -1725,15 +1780,19 @@ unsafe extern "C" fn run_thread_arch(
         SAVE_CPU_CONTEXT_ASM!(),
         "mov rbp, rsp",
         "and rsp, -16",
+        // Derive the per-CPU base from RSP (rax is dead: SAVE_CPU_CONTEXT
+        // already saved it).
+        "mov rax, rsp",
+        "and rax, {neg_pcv_align}",
         // Check if we are inside a user/TA context (is_in_user flag).
         // When is_in_user is set, a valid ThreadContext exists on the
-        // kernel stack at [gs:cur_kernel_sp] and we can attempt demand
+        // kernel stack at [pcv cur_kernel_sp] and we can attempt demand
         // paging through the shim.  When clear, the page fault occurred
         // outside run_thread_arch and only exception-table fixup is available.
-        "cmp byte ptr gs:[{is_in_user_off}], 0",
+        "cmp byte ptr [rax + {is_in_user_off}], 0",
         "je 6f",
         // In-user path: load ThreadContext and call full exception_handler.
-        "mov rdi, gs:[{cur_kernel_sp_off}]",
+        "mov rdi, [rax + {cur_kernel_sp_off}]",
         // Pass exception info via registers (SysV ABI args 1-5)
         "mov rdi, [rdi]",                   // arg1: thread_ctx
         "mov esi, 1",                       // arg2: kernel_mode = true
@@ -1763,15 +1822,18 @@ unsafe extern "C" fn run_thread_arch(
         "interrupt_callback:",
         "jmp done",
         "done:",
+        // Derive the per-CPU base from RSP (rdi is dead here).
+        "mov rdi, rsp",
+        "and rdi, {neg_pcv_align}",
         // We are leaving the user/TA context. Clear is_in_user first
         // so that any kernel-mode page fault from this point on takes the
         // exception-table-only path in kernel_exception_callback.
-        "mov byte ptr gs:[{is_in_user_off}], 0",
-        "mov rbp, gs:[{cur_kernel_bp_off}]",
-        "mov rsp, gs:[{cur_kernel_sp_off}]",
+        "mov byte ptr [rdi + {is_in_user_off}], 0",
+        "mov rbp, [rdi + {cur_kernel_bp_off}]",
+        "mov rsp, [rdi + {cur_kernel_sp_off}]",
         // Zero cur_kernel_sp as defence in depth
-        "mov qword ptr gs:[{cur_kernel_sp_off}], 0",
-        XRSTOR_VTL1_ASM!({vtl1_kernel_xsave_area_off}, {vtl1_xsave_mask_lo_off}, {vtl1_xsave_mask_hi_off}, {vtl1_kernel_xsaved_off}),
+        "mov qword ptr [rdi + {cur_kernel_sp_off}], 0",
+        XRSTOR_VTL1_ASM!(rdi, {vtl1_kernel_xsave_area_off}, {vtl1_xsave_mask_lo_off}, {vtl1_xsave_mask_hi_off}, {vtl1_kernel_xsaved_off}),
         RESTORE_CALLEE_SAVED_REGISTERS_ASM!(),
         "ret",
         cur_kernel_sp_off = const { PerCpuVariablesAsm::cur_kernel_stack_ptr_offset() },
@@ -1786,8 +1848,10 @@ unsafe extern "C" fn run_thread_arch(
         USER_CONTEXT_SIZE = const core::mem::size_of::<litebox_common_linux::PtRegs>(),
         scratch_off = const { PerCpuVariablesAsm::scratch_offset() },
         user_rflags_off = const { PerCpuVariablesAsm::user_rflags_offset() },
+        syscall_slot_ptr_off = const { PerCpuVariablesAsm::syscall_slot_ptr_offset() },
         exception_trapno_off = const { PerCpuVariablesAsm::exception_trapno_offset() },
         is_in_user_off = const { PerCpuVariablesAsm::is_in_user_offset() },
+        neg_pcv_align = const { PER_CPU_ALIGN_NEG },
         init_handler = sym init_handler,
         reenter_handler = sym reenter_handler,
         syscall_handler = sym syscall_handler,
@@ -1970,19 +2034,24 @@ unsafe extern "C" fn switch_to_user(_ctx: &litebox_common_linux::PtRegs) -> ! {
         "mov cr3, rax",
         // Clear rax to not leak CR3 value to user
         "xor eax, eax",
-        XRSTOR_VTL1_ASM!({vtl1_user_xsave_area_off}, {vtl1_xsave_mask_lo_off}, {vtl1_xsave_mask_hi_off}, {vtl1_user_xsaved_off}),
+        // Derive the per-CPU base from RSP (the caller's kernel stack, inside
+        // PerCpuVariables). r8 is overwritten by the context pops below, so
+        // no kernel address leaks to user.
+        "mov r8, rsp",
+        "and r8, {neg_pcv_align}",
+        XRSTOR_VTL1_ASM!(r8, {vtl1_user_xsave_area_off}, {vtl1_xsave_mask_lo_off}, {vtl1_xsave_mask_hi_off}, {vtl1_user_xsaved_off}),
         // Restore user context from ctx.
         "mov rsp, rdi",
         RESTORE_CPU_CONTEXT_ASM!(),
-        // clear the GS base register (as the `KernelGsBase` MSR contains 0)
-        // while writing the current GS base value to `KernelGsBase`.
-        "swapgs",
+        // The kernel never touches GS: the TA's GSBASE is still live and
+        // needs no restore (no swapgs; KernelGsBase stays 0 forever).
         "iretq",
         "switch_to_user_end:",
         vtl1_user_xsave_area_off = const { PerCpuVariablesAsm::vtl1_user_xsave_area_addr_offset() },
         vtl1_xsave_mask_lo_off = const { PerCpuVariablesAsm::vtl1_xsave_mask_lo_offset() },
         vtl1_xsave_mask_hi_off = const { PerCpuVariablesAsm::vtl1_xsave_mask_hi_offset() },
         vtl1_user_xsaved_off = const { PerCpuVariablesAsm::vtl1_user_xsaved_offset() },
+        neg_pcv_align = const { PER_CPU_ALIGN_NEG },
     );
 }
 

--- a/litebox_platform_lvbs/src/lib.rs
+++ b/litebox_platform_lvbs/src/lib.rs
@@ -595,7 +595,15 @@ impl<Host: HostInterface> LinuxKernel<Host> {
         if base_pt
             .map_phys_frame_range(
                 vtl1_range,
-                PageTableFlags::PRESENT | PageTableFlags::WRITABLE,
+                // ACCESSED/DIRTY are pre-set on these kernel leaf mappings
+                // (mirroring the Linux kernel's `_PAGE_KERNEL`) so the CPU
+                // walker never takes an atomic RMW to set them; the W^X logic
+                // in `map_phys_frame_range` strips WRITABLE and DIRTY for
+                // exec ranges.
+                PageTableFlags::PRESENT
+                    | PageTableFlags::WRITABLE
+                    | PageTableFlags::ACCESSED
+                    | PageTableFlags::DIRTY,
                 Some(&exec_ranges),
             )
             .is_err()
@@ -1158,9 +1166,13 @@ unsafe impl<Host: HostInterface, const ALIGN: usize> VmapManager<ALIGN> for Linu
         }
 
         // VTL0 memory must never be executable from VTL1 (DEP).
-        let mut flags = PageTableFlags::PRESENT | PageTableFlags::NO_EXECUTE;
+        // ACCESSED is pre-set on every vmap leaf (avoids the walker's atomic
+        // RMW on first access); DIRTY only together with WRITABLE below,
+        // because WRITABLE=0 + DIRTY=1 is the CET shadow-stack PTE shape.
+        let mut flags =
+            PageTableFlags::PRESENT | PageTableFlags::NO_EXECUTE | PageTableFlags::ACCESSED;
         if perms.contains(PhysPageMapPermissions::WRITE) {
-            flags |= PageTableFlags::WRITABLE;
+            flags |= PageTableFlags::WRITABLE | PageTableFlags::DIRTY;
         }
 
         // Always allocate a fresh, private virtual address window for the mapping. This lets

--- a/litebox_platform_lvbs/src/lib.rs
+++ b/litebox_platform_lvbs/src/lib.rs
@@ -6,7 +6,16 @@
 #![cfg(target_arch = "x86_64")]
 #![no_std]
 
-use crate::{host::per_cpu_variables::PerCpuVariablesAsm, mshv::vsm::Vtl0KernelInfo};
+use crate::{
+    host::per_cpu_variables::{PER_CPU_ALIGN, PerCpuVariablesAsm},
+    mshv::vsm::Vtl0KernelInfo,
+};
+
+/// Negated [`PER_CPU_ALIGN`] for `and reg, imm32` per-CPU base derivation in
+/// inline asm (sign-extended imm32).
+#[cfg(target_arch = "x86_64")]
+#[allow(clippy::cast_possible_wrap)]
+const PER_CPU_ALIGN_NEG: i64 = -(PER_CPU_ALIGN as i64);
 use core::sync::atomic::AtomicU32;
 use hashbrown::HashMap;
 use litebox::platform::{
@@ -26,12 +35,9 @@ use litebox_common_linux::vmap::{
     GlobalVmapManager, PhysPageAddrArray, PhysPageMapInfo, PhysPageMapPermissions,
     PhysPointerError, VmapManager,
 };
-use x86_64::{
-    VirtAddr,
-    structures::paging::{
-        PageOffset, PageSize, PageTableFlags, PhysFrame, Size4KiB, frame::PhysFrameRange,
-        mapper::MapToError,
-    },
+use x86_64::structures::paging::{
+    PageOffset, PageSize, PageTableFlags, PhysFrame, Size4KiB, frame::PhysFrameRange,
+    mapper::MapToError,
 };
 use zerocopy::{FromBytes, IntoBytes};
 
@@ -1328,11 +1334,11 @@ pub unsafe fn run_thread<T>(shim: T, ctx: &mut litebox_common_linux::PtRegs)
 where
     T: litebox::shim::EnterShim<ExecutionContext = litebox_common_linux::PtRegs>,
 {
-    // Currently, `litebox_platform_lvbs` uses `swapgs` to efficiently switch between
-    // kernel and user GS base values during kernel-user mode transitions.
-    // This `swapgs` usage can pontetially leak a kernel address to the user, so
-    // we clear the `KernelGsBase` MSR before running the user thread.
-    crate::arch::write_kernel_gsbase_msr(VirtAddr::zero());
+    // The kernel never touches GS, so a TA's GSBASE survives kernel entries
+    // within one dispatch by construction. Reset it to 0 for each fresh
+    // dispatch from VTL0 so one TA's GSBASE cannot leak to the next TA
+    // scheduled on this core (same TA-visible semantics as before).
+    unsafe { litebox_common_linux::wrgsbase(0) };
     run_thread_inner(&shim, ctx, false);
 }
 
@@ -1347,7 +1353,8 @@ pub unsafe fn run_thread_ref<T>(shim: &T, ctx: &mut litebox_common_linux::PtRegs
 where
     T: litebox::shim::EnterShim<ExecutionContext = litebox_common_linux::PtRegs>,
 {
-    crate::arch::write_kernel_gsbase_msr(VirtAddr::zero());
+    // Reset user GSBASE for a fresh dispatch (see `run_thread`).
+    unsafe { litebox_common_linux::wrgsbase(0) };
     run_thread_inner(shim, ctx, false);
 }
 
@@ -1362,7 +1369,8 @@ pub unsafe fn reenter_thread_ref<T>(shim: &T, ctx: &mut litebox_common_linux::Pt
 where
     T: litebox::shim::EnterShim<ExecutionContext = litebox_common_linux::PtRegs>,
 {
-    crate::arch::write_kernel_gsbase_msr(VirtAddr::zero());
+    // Reset user GSBASE for a fresh dispatch (see `run_thread`).
+    unsafe { litebox_common_linux::wrgsbase(0) };
     run_thread_inner(shim, ctx, true);
 }
 
@@ -1445,21 +1453,31 @@ macro_rules! RESTORE_CALLEE_SAVED_REGISTERS_ASM {
 
 /// Assembly macro to save VTL1 extended states (XSAVE/XSAVEOPT).
 /// Uses xsaveopt only after XRSTOR has established tracking (xsaved == 2).
+/// `$base` is a register holding the `PerCpuVariables` pointer; it must not
+/// be rax/rcx/rdx (clobbered by this macro).
 /// Clobbers: rax, rcx, rdx
 #[cfg(target_arch = "x86_64")]
 macro_rules! XSAVE_VTL1_ASM {
-    ($xsave_area_off:tt, $mask_lo_off:tt, $mask_hi_off:tt, $xsaved_off:tt) => {
+    ($base:tt, $xsave_area_off:tt, $mask_lo_off:tt, $mask_hi_off:tt, $xsaved_off:tt) => {
         concat!(
-            "mov rcx, gs:[",
+            "mov rcx, [",
+            stringify!($base),
+            " + ",
             stringify!($xsave_area_off),
             "]\n",
-            "mov eax, gs:[",
+            "mov eax, [",
+            stringify!($base),
+            " + ",
             stringify!($mask_lo_off),
             "]\n",
-            "mov edx, gs:[",
+            "mov edx, [",
+            stringify!($base),
+            " + ",
             stringify!($mask_hi_off),
             "]\n",
-            "cmp byte ptr gs:[",
+            "cmp byte ptr [",
+            stringify!($base),
+            " + ",
             stringify!($xsaved_off),
             "], 2\n",
             "jne 2f\n",
@@ -1468,11 +1486,15 @@ macro_rules! XSAVE_VTL1_ASM {
             "2:\n",
             "xsave [rcx]\n",
             // Set to 1 if it was 0 (first save). If already 1, keep it as 1.
-            "cmp byte ptr gs:[",
+            "cmp byte ptr [",
+            stringify!($base),
+            " + ",
             stringify!($xsaved_off),
             "], 0\n",
             "jne 3f\n",
-            "mov byte ptr gs:[",
+            "mov byte ptr [",
+            stringify!($base),
+            " + ",
             stringify!($xsaved_off),
             "], 1\n",
             "3:\n",
@@ -1483,27 +1505,39 @@ macro_rules! XSAVE_VTL1_ASM {
 /// Assembly macro to restore VTL1 extended states (XRSTOR).
 /// Skips restore if state was never saved (xsaved == 0).
 /// Sets xsaved to 2 after restore to enable XSAVEOPT optimization.
+/// `$base` is a register holding the `PerCpuVariables` pointer; it must not
+/// be rax/rcx/rdx (clobbered by this macro).
 /// Clobbers: rax, rcx, rdx
 #[cfg(target_arch = "x86_64")]
 macro_rules! XRSTOR_VTL1_ASM {
-    ($xsave_area_off:tt, $mask_lo_off:tt, $mask_hi_off:tt, $xsaved_off:tt) => {
+    ($base:tt, $xsave_area_off:tt, $mask_lo_off:tt, $mask_hi_off:tt, $xsaved_off:tt) => {
         concat!(
-            "cmp byte ptr gs:[",
+            "cmp byte ptr [",
+            stringify!($base),
+            " + ",
             stringify!($xsaved_off),
             "], 0\n",
             "je 4f\n",
-            "mov rcx, gs:[",
+            "mov rcx, [",
+            stringify!($base),
+            " + ",
             stringify!($xsave_area_off),
             "]\n",
-            "mov eax, gs:[",
+            "mov eax, [",
+            stringify!($base),
+            " + ",
             stringify!($mask_lo_off),
             "]\n",
-            "mov edx, gs:[",
+            "mov edx, [",
+            stringify!($base),
+            " + ",
             stringify!($mask_hi_off),
             "]\n",
             "xrstor [rcx]\n",
             // After XRSTOR, tracking is established - XSAVEOPT is now safe
-            "mov byte ptr gs:[",
+            "mov byte ptr [",
+            stringify!($base),
+            " + ",
             stringify!($xsaved_off),
             "], 2\n",
             "4:\n",
@@ -1519,8 +1553,11 @@ macro_rules! XRSTOR_VTL1_ASM {
 /// (i.e., from high addresses down to low ones).
 ///
 /// Prerequisite:
+/// - `rax` holds the `PerCpuVariables` pointer (loaded by this core's
+///   syscall entry stub).
 /// - Store user `rsp` in `r11` before calling this macro.
-/// - Store user `rflags` in `gs:[user_rflags]` before calling this macro.
+/// - Store user `rflags` in `[rax + user_rflags]` before calling this macro.
+/// - Store user `rax` in `[rax + scratch]` before calling this macro.
 /// - Store the userspace return address in `rcx` (`syscall` does this automatically).
 #[cfg(target_arch = "x86_64")]
 macro_rules! SAVE_SYSCALL_USER_CONTEXT_ASM {
@@ -1528,10 +1565,10 @@ macro_rules! SAVE_SYSCALL_USER_CONTEXT_ASM {
         "
         push 0x2b       // pt_regs->ss = __USER_DS
         push r11        // pt_regs->rsp
-        push qword ptr gs:[{user_rflags_off}] // pt_regs->eflags
+        push qword ptr [rax + {user_rflags_off}] // pt_regs->eflags
         push 0x33       // pt_regs->cs = __USER_CS
         push rcx        // pt_regs->rip
-        push rax        // pt_regs->orig_rax
+        push qword ptr [rax + {scratch_off}] // pt_regs->orig_rax (user rax)
         push rdi        // pt_regs->rdi
         push rsi        // pt_regs->rsi
         push rdx        // pt_regs->rdx
@@ -1559,35 +1596,34 @@ macro_rules! SAVE_SYSCALL_USER_CONTEXT_ASM {
 ///
 /// Prerequisites:
 /// - `rsp` points to the top of the user context area (push target)
-/// - `rax` points to the ISR stack: `[rax]`=vector, `[rax+8]`=error_code,
-///   `[rax+16]`=RIP, `[rax+24]`=CS, `[rax+32]`=RFLAGS, `[rax+40]`=RSP,
-///   `[rax+48]`=SS
-/// - All GPRs except `rax` contain user-mode values
-/// - User `rax` has been saved to per-CPU scratch
-/// - `swapgs` has already been executed (GS = kernel)
+/// - `rbx` points to the ISR stack: `[rbx]`=vector, `[rbx+8]`=error_code,
+///   `[rbx+16]`=RIP, `[rbx+24]`=CS, `[rbx+32]`=RFLAGS, `[rbx+40]`=RSP,
+///   `[rbx+48]`=SS
+/// - User `rax` was pushed at `[rbx-8]`, user `rbx` at `[rbx-16]` by
+///   `exception_callback` before it derived the per-CPU base
+/// - All other GPRs contain user-mode values
 ///
-/// Clobbers: rax
+/// Clobbers: none
 #[cfg(target_arch = "x86_64")]
 macro_rules! SAVE_PF_USER_CONTEXT_ASM {
     () => {
         "
-        push [rax + 48]   // pt_regs->ss
-        push [rax + 40]   // pt_regs->rsp
-        push [rax + 32]   // pt_regs->eflags
-        push [rax + 24]   // pt_regs->cs
-        push [rax + 16]   // pt_regs->rip
-        push [rax + 8]    // pt_regs->orig_rax (error code)
+        push [rbx + 48]   // pt_regs->ss
+        push [rbx + 40]   // pt_regs->rsp
+        push [rbx + 32]   // pt_regs->eflags
+        push [rbx + 24]   // pt_regs->cs
+        push [rbx + 16]   // pt_regs->rip
+        push [rbx + 8]    // pt_regs->orig_rax (error code)
         push rdi          // pt_regs->rdi
         push rsi          // pt_regs->rsi
         push rdx          // pt_regs->rdx
         push rcx          // pt_regs->rcx
-        mov rax, gs:[{scratch_off}]
-        push rax          // pt_regs->rax
+        push [rbx - 8]    // pt_regs->rax (user rax)
         push r8           // pt_regs->r8
         push r9           // pt_regs->r9
         push r10          // pt_regs->r10
         push r11          // pt_regs->r11
-        push rbx          // pt_regs->rbx
+        push [rbx - 16]   // pt_regs->rbx (user rbx)
         push rbp          // pt_regs->rbp
         push r12          // pt_regs->r12
         push r13          // pt_regs->r13
@@ -1659,18 +1695,22 @@ unsafe extern "C" fn run_thread_arch(
         SAVE_CALLEE_SAVED_REGISTERS_ASM!(),
         // Save reenter flag (in dl) before XSAVE clobbers edx
         "mov r9b, dl",
+        // Derive the per-CPU base from RSP (the kernel stack lives inside the
+        // 256 KiB-aligned PerCpuVariables; see its doc comment).
+        "mov r10, rsp",
+        "and r10, {neg_pcv_align}",
         // Extended states are callee-saved. Save all extended states for now because
         // we don't know whether the caller touched any of them.
-        XSAVE_VTL1_ASM!({vtl1_kernel_xsave_area_off}, {vtl1_xsave_mask_lo_off}, {vtl1_xsave_mask_hi_off}, {vtl1_kernel_xsaved_off}),
+        XSAVE_VTL1_ASM!(r10, {vtl1_kernel_xsave_area_off}, {vtl1_xsave_mask_lo_off}, {vtl1_xsave_mask_hi_off}, {vtl1_kernel_xsaved_off}),
         "push rdi", // save `thread_ctx`
         // Save kernel rsp and rbp and user context top in PerCpuVariablesAsm.
-        "mov gs:[{cur_kernel_sp_off}], rsp",
-        "mov gs:[{cur_kernel_bp_off}], rbp",
+        "mov [r10 + {cur_kernel_sp_off}], rsp",
+        "mov [r10 + {cur_kernel_bp_off}], rbp",
         "lea r8, [rsi + {USER_CONTEXT_SIZE}]",
-        "mov gs:[{user_context_top_off}], r8",
+        "mov [r10 + {user_context_top_off}], r8",
         // Mark that we are inside a user/TA context so that
         // kernel_exception_callback knows a valid ThreadContext exists.
-        "mov byte ptr gs:[{is_in_user_off}], 1",
+        "mov byte ptr [r10 + {is_in_user_off}], 1",
         // Call init_handler or reenter_handler based on reenter flag (in dl)
         "test r9b, r9b",
         "jnz 1f",
@@ -1679,16 +1719,26 @@ unsafe extern "C" fn run_thread_arch(
         "1:",
         "call {reenter_handler}",
         "jmp done",
+        // Syscall callback: entered from this core's per-core LSTAR stub
+        // (see `syscall_entry`). At this point:
+        // - rax = this core's PerCpuVariables pointer (loaded by the stub)
+        // - user rax is parked in this core's SyscallSlot rax_spill
+        // - rsp = UNTRUSTED user rsp (unchanged by the stub)
+        // - rcx = user return RIP, r11 = user RFLAGS (hardware)
+        // - Interrupts are masked (SFMASK clears IF)
         ".globl syscall_callback",
         "syscall_callback:",
-        "swapgs",
-        "mov gs:[{user_rflags_off}], r11", // store user `rflags`.
+        "mov [rax + {user_rflags_off}], r11", // store user `rflags`.
+        "mov r11, [rax + {syscall_slot_ptr_off}]",
+        "mov r11, [r11]", // user `rax` from the stub's spill slot
+        "mov [rax + {scratch_off}], r11", // park user `rax` in pcv scratch
         "mov r11, rsp", // store user `rsp` in `r11`
-        "mov rsp, gs:[{user_context_top_off}]", // `rsp` points to the top address of user context area
+        "mov rsp, [rax + {user_context_top_off}]", // `rsp` points to the top address of user context area
         SAVE_SYSCALL_USER_CONTEXT_ASM!(),
-        XSAVE_VTL1_ASM!({vtl1_user_xsave_area_off}, {vtl1_xsave_mask_lo_off}, {vtl1_xsave_mask_hi_off}, {vtl1_user_xsaved_off}),
-        "mov rbp, gs:[{cur_kernel_bp_off}]",
-        "mov rsp, gs:[{cur_kernel_sp_off}]",
+        "mov rbx, rax", // XSAVE clobbers rax/rcx/rdx; keep pcv in rbx
+        XSAVE_VTL1_ASM!(rbx, {vtl1_user_xsave_area_off}, {vtl1_xsave_mask_lo_off}, {vtl1_xsave_mask_hi_off}, {vtl1_user_xsaved_off}),
+        "mov rbp, [rbx + {cur_kernel_bp_off}]",
+        "mov rsp, [rbx + {cur_kernel_sp_off}]",
         // Handle the syscall. This will jump back to the user but
         // will return if the thread is exiting.
         "mov rdi, [rsp]", // pass `thread_ctx`
@@ -1696,24 +1746,29 @@ unsafe extern "C" fn run_thread_arch(
         "jmp done",
         // Exception callback: entered from ISR stubs for user-mode exceptions.
         // At this point:
-        // - rsp = ISR stack: [vector, error_code, rip, cs, rflags, rsp, ss]
+        // - rsp = ISR stack: [vector, error_code, rip, cs, rflags, rsp, ss],
+        //   hardware-loaded from TSS.RSP0 (or TSS.IST1 for a double fault) —
+        //   both stacks live inside PerCpuVariables, so masking RSP recovers
+        //   the per-CPU base
         // - All GPRs contain user-mode values
         // - Interrupts are disabled (IDT gate clears IF)
-        // - GS = user (swapgs has NOT happened yet)
         ".globl exception_callback",
         "exception_callback:",
         "cld",
         "clac",
-        "swapgs",
-        "mov gs:[{scratch_off}], rax", // Save `rax` to per-CPU scratch
-        "mov al, [rsp]",
-        "mov gs:[{exception_trapno_off}], al", // vector number from ISR stack
-        "mov rax, rsp", // store ISR `rsp` in `rax`
-        "mov rsp, gs:[{user_context_top_off}]", // `rsp` points to the top address of user context area
+        "push rax", // free rax (user value preserved at [rbx - 8] below)
+        "push rbx", // free rbx (user value preserved at [rbx - 16] below)
+        "lea rbx, [rsp + 16]", // rbx = ISR frame pointer ([rbx] = vector)
+        "mov rax, rsp",
+        "and rax, {neg_pcv_align}", // rax = per-CPU base
+        "mov rsp, [rax + {user_context_top_off}]", // `rsp` points to the top address of user context area
         SAVE_PF_USER_CONTEXT_ASM!(),
-        XSAVE_VTL1_ASM!({vtl1_user_xsave_area_off}, {vtl1_xsave_mask_lo_off}, {vtl1_xsave_mask_hi_off}, {vtl1_user_xsaved_off}),
-        "mov rbp, gs:[{cur_kernel_bp_off}]",
-        "mov rsp, gs:[{cur_kernel_sp_off}]",
+        "mov cl, [rbx]", // vector number from ISR stack (user rcx already saved)
+        "mov [rax + {exception_trapno_off}], cl",
+        "mov rbx, rax", // XSAVE clobbers rax/rcx/rdx; keep pcv in rbx
+        XSAVE_VTL1_ASM!(rbx, {vtl1_user_xsave_area_off}, {vtl1_xsave_mask_lo_off}, {vtl1_xsave_mask_hi_off}, {vtl1_user_xsaved_off}),
+        "mov rbp, [rbx + {cur_kernel_bp_off}]",
+        "mov rsp, [rbx + {cur_kernel_sp_off}]",
         "mov rdi, [rsp]", // pass `thread_ctx`
         "xor esi, esi",   // kernel_mode = false
         "mov rdx, cr2",   // cr2 (still valid — nothing overwrites it)
@@ -1723,9 +1778,9 @@ unsafe extern "C" fn run_thread_arch(
         // and exception-table fixup).
         // At entry:
         // - rsp = ISR stack: [vector, error_code, rip, cs, rflags, rsp, ss]
+        //   (the interrupted kernel stack, inside PerCpuVariables)
         // - All GPRs = kernel values at time of fault
         // - Interrupts are disabled (IDT gate clears IF)
-        // - GS = kernel (no swapgs needed)
         //
         // Saves GPRs, then passes exception info (CR2, error code, faulting
         // RIP) to exception_handler via registers. exception_handler will try
@@ -1737,15 +1792,19 @@ unsafe extern "C" fn run_thread_arch(
         SAVE_CPU_CONTEXT_ASM!(),
         "mov rbp, rsp",
         "and rsp, -16",
+        // Derive the per-CPU base from RSP (rax is dead: SAVE_CPU_CONTEXT
+        // already saved it).
+        "mov rax, rsp",
+        "and rax, {neg_pcv_align}",
         // Check if we are inside a user/TA context (is_in_user flag).
         // When is_in_user is set, a valid ThreadContext exists on the
-        // kernel stack at [gs:cur_kernel_sp] and we can attempt demand
+        // kernel stack at [pcv cur_kernel_sp] and we can attempt demand
         // paging through the shim.  When clear, the page fault occurred
         // outside run_thread_arch and only exception-table fixup is available.
-        "cmp byte ptr gs:[{is_in_user_off}], 0",
+        "cmp byte ptr [rax + {is_in_user_off}], 0",
         "je 6f",
         // In-user path: load ThreadContext and call full exception_handler.
-        "mov rdi, gs:[{cur_kernel_sp_off}]",
+        "mov rdi, [rax + {cur_kernel_sp_off}]",
         // Pass exception info via registers (SysV ABI args 1-5)
         "mov rdi, [rdi]",                   // arg1: thread_ctx
         "mov esi, 1",                       // arg2: kernel_mode = true
@@ -1775,15 +1834,18 @@ unsafe extern "C" fn run_thread_arch(
         "interrupt_callback:",
         "jmp done",
         "done:",
+        // Derive the per-CPU base from RSP (rdi is dead here).
+        "mov rdi, rsp",
+        "and rdi, {neg_pcv_align}",
         // We are leaving the user/TA context. Clear is_in_user first
         // so that any kernel-mode page fault from this point on takes the
         // exception-table-only path in kernel_exception_callback.
-        "mov byte ptr gs:[{is_in_user_off}], 0",
-        "mov rbp, gs:[{cur_kernel_bp_off}]",
-        "mov rsp, gs:[{cur_kernel_sp_off}]",
+        "mov byte ptr [rdi + {is_in_user_off}], 0",
+        "mov rbp, [rdi + {cur_kernel_bp_off}]",
+        "mov rsp, [rdi + {cur_kernel_sp_off}]",
         // Zero cur_kernel_sp as defence in depth
-        "mov qword ptr gs:[{cur_kernel_sp_off}], 0",
-        XRSTOR_VTL1_ASM!({vtl1_kernel_xsave_area_off}, {vtl1_xsave_mask_lo_off}, {vtl1_xsave_mask_hi_off}, {vtl1_kernel_xsaved_off}),
+        "mov qword ptr [rdi + {cur_kernel_sp_off}], 0",
+        XRSTOR_VTL1_ASM!(rdi, {vtl1_kernel_xsave_area_off}, {vtl1_xsave_mask_lo_off}, {vtl1_xsave_mask_hi_off}, {vtl1_kernel_xsaved_off}),
         RESTORE_CALLEE_SAVED_REGISTERS_ASM!(),
         "ret",
         cur_kernel_sp_off = const { PerCpuVariablesAsm::cur_kernel_stack_ptr_offset() },
@@ -1798,8 +1860,10 @@ unsafe extern "C" fn run_thread_arch(
         USER_CONTEXT_SIZE = const core::mem::size_of::<litebox_common_linux::PtRegs>(),
         scratch_off = const { PerCpuVariablesAsm::scratch_offset() },
         user_rflags_off = const { PerCpuVariablesAsm::user_rflags_offset() },
+        syscall_slot_ptr_off = const { PerCpuVariablesAsm::syscall_slot_ptr_offset() },
         exception_trapno_off = const { PerCpuVariablesAsm::exception_trapno_offset() },
         is_in_user_off = const { PerCpuVariablesAsm::is_in_user_offset() },
+        neg_pcv_align = const { PER_CPU_ALIGN_NEG },
         init_handler = sym init_handler,
         reenter_handler = sym reenter_handler,
         syscall_handler = sym syscall_handler,
@@ -1982,19 +2046,24 @@ unsafe extern "C" fn switch_to_user(_ctx: &litebox_common_linux::PtRegs) -> ! {
         "mov cr3, rax",
         // Clear rax to not leak CR3 value to user
         "xor eax, eax",
-        XRSTOR_VTL1_ASM!({vtl1_user_xsave_area_off}, {vtl1_xsave_mask_lo_off}, {vtl1_xsave_mask_hi_off}, {vtl1_user_xsaved_off}),
+        // Derive the per-CPU base from RSP (the caller's kernel stack, inside
+        // PerCpuVariables). r8 is overwritten by the context pops below, so
+        // no kernel address leaks to user.
+        "mov r8, rsp",
+        "and r8, {neg_pcv_align}",
+        XRSTOR_VTL1_ASM!(r8, {vtl1_user_xsave_area_off}, {vtl1_xsave_mask_lo_off}, {vtl1_xsave_mask_hi_off}, {vtl1_user_xsaved_off}),
         // Restore user context from ctx.
         "mov rsp, rdi",
         RESTORE_CPU_CONTEXT_ASM!(),
-        // clear the GS base register (as the `KernelGsBase` MSR contains 0)
-        // while writing the current GS base value to `KernelGsBase`.
-        "swapgs",
+        // The kernel never touches GS: the TA's GSBASE is still live and
+        // needs no restore (no swapgs; KernelGsBase stays 0 forever).
         "iretq",
         "switch_to_user_end:",
         vtl1_user_xsave_area_off = const { PerCpuVariablesAsm::vtl1_user_xsave_area_addr_offset() },
         vtl1_xsave_mask_lo_off = const { PerCpuVariablesAsm::vtl1_xsave_mask_lo_offset() },
         vtl1_xsave_mask_hi_off = const { PerCpuVariablesAsm::vtl1_xsave_mask_hi_offset() },
         vtl1_user_xsaved_off = const { PerCpuVariablesAsm::vtl1_user_xsaved_offset() },
+        neg_pcv_align = const { PER_CPU_ALIGN_NEG },
     );
 }
 

--- a/litebox_platform_lvbs/src/mm/tests.rs
+++ b/litebox_platform_lvbs/src/mm/tests.rs
@@ -173,7 +173,16 @@ fn test_page_table() {
 
     // update flags
     let new_vmflags = VmFlags::empty();
-    let new_pteflags = vmflags_to_pteflags(new_vmflags) | PageTableFlags::PRESENT;
+    // Explicit expectation: mprotect preserves the PTE's pre-existing
+    // ACCESSED/DIRTY via `(flags & !MPROTECT_PTE_MASK) | new`, while
+    // `vmflags_to_pteflags` derives them fresh (ACCESSED always; DIRTY only
+    // with VM_WRITE). The initial mapping above is read-only (VM_READ), so its
+    // PTE carries ACCESSED but no DIRTY, and after mprotect(VmFlags::empty())
+    // the PTE is exactly PRESENT | ACCESSED | NO_EXECUTE. If the initial
+    // mapping ever becomes writable, its preserved DIRTY must be added here —
+    // the derived form of this expression would then be wrong.
+    let new_pteflags =
+        PageTableFlags::PRESENT | PageTableFlags::ACCESSED | PageTableFlags::NO_EXECUTE;
     unsafe {
         assert!(
             pgtable

--- a/litebox_platform_lvbs/src/mshv/mod.rs
+++ b/litebox_platform_lvbs/src/mshv/mod.rs
@@ -1022,11 +1022,10 @@ impl HvPendingExceptionEvent {
 #[cfg(not(test))]
 #[inline]
 pub(crate) fn is_hvcall_ready() -> bool {
-    use crate::host::per_cpu_variables::with_per_cpu_variables;
-    // The VTL return address is configured only after the hypercall page
+    // The VTL return target is configured only after the hypercall page
     // has been set up, so a non-zero value indicates that hypercalls are
     // available.
-    with_per_cpu_variables(|pcv| pcv.asm.get_vtl_return_addr() != 0)
+    vtl_switch::is_vtl_return_target_set()
 }
 
 #[cfg(test)]

--- a/litebox_platform_lvbs/src/mshv/vtl_switch.rs
+++ b/litebox_platform_lvbs/src/mshv/vtl_switch.rs
@@ -5,7 +5,9 @@
 
 use crate::host::{
     hv_hypercall_page_address,
-    per_cpu_variables::{PER_CPU_ALIGN, PerCpuVariables, PerCpuVariablesAsm, with_per_cpu_variables},
+    per_cpu_variables::{
+        PER_CPU_ALIGN, PerCpuVariables, PerCpuVariablesAsm, with_per_cpu_variables,
+    },
 };
 use crate::mshv::{
     HV_FLUSH_EX_VP_SET_BANKS, HV_REGISTER_VSM_CODEPAGE_OFFSETS, HvRegisterVsmCodePageOffsets,

--- a/litebox_platform_lvbs/src/mshv/vtl_switch.rs
+++ b/litebox_platform_lvbs/src/mshv/vtl_switch.rs
@@ -5,7 +5,7 @@
 
 use crate::host::{
     hv_hypercall_page_address,
-    per_cpu_variables::{PerCpuVariables, PerCpuVariablesAsm, with_per_cpu_variables},
+    per_cpu_variables::{PER_CPU_ALIGN, PerCpuVariables, PerCpuVariablesAsm, with_per_cpu_variables},
 };
 use crate::mshv::{
     HV_FLUSH_EX_VP_SET_BANKS, HV_REGISTER_VSM_CODEPAGE_OFFSETS, HvRegisterVsmCodePageOffsets,
@@ -13,7 +13,7 @@ use crate::mshv::{
     VTL_ENTRY_REASON_RESERVED, error::VsmError, hvcall_vp::hvcall_get_vp_registers,
     vsm_intercept::vsm_handle_intercept,
 };
-use core::sync::atomic::{AtomicU64, Ordering};
+use core::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use litebox::utils::{ReinterpretUnsignedExt, TruncateExt};
 use num_enum::TryFromPrimitive;
 
@@ -135,17 +135,25 @@ pub(crate) fn is_only_vp_in_vtl1() -> bool {
 // context switches), so we cannot rely on XSAVEOPT's tracking. Always use plain XSAVE.
 
 /// Assembly macro to save VTL0 extended states using plain XSAVE.
+/// `$base` is a register holding the `PerCpuVariables` pointer; it must not
+/// be rax/rcx/rdx (clobbered by this macro).
 /// Clobbers: rax, rcx, rdx
 macro_rules! XSAVE_VTL0_ASM {
-    ($xsave_area_off:tt, $mask_lo_off:tt, $mask_hi_off:tt) => {
+    ($base:tt, $xsave_area_off:tt, $mask_lo_off:tt, $mask_hi_off:tt) => {
         concat!(
-            "mov rcx, gs:[",
+            "mov rcx, [",
+            stringify!($base),
+            " + ",
             stringify!($xsave_area_off),
             "]\n",
-            "mov eax, gs:[",
+            "mov eax, [",
+            stringify!($base),
+            " + ",
             stringify!($mask_lo_off),
             "]\n",
-            "mov edx, gs:[",
+            "mov edx, [",
+            stringify!($base),
+            " + ",
             stringify!($mask_hi_off),
             "]\n",
             "xsave [rcx]\n",
@@ -154,17 +162,25 @@ macro_rules! XSAVE_VTL0_ASM {
 }
 
 /// Assembly macro to restore VTL0 extended states using plain XRSTOR.
+/// `$base` is a register holding the `PerCpuVariables` pointer; it must not
+/// be rax/rcx/rdx (clobbered by this macro).
 /// Clobbers: rax, rcx, rdx
 macro_rules! XRSTOR_VTL0_ASM {
-    ($xsave_area_off:tt, $mask_lo_off:tt, $mask_hi_off:tt) => {
+    ($base:tt, $xsave_area_off:tt, $mask_lo_off:tt, $mask_hi_off:tt) => {
         concat!(
-            "mov rcx, gs:[",
+            "mov rcx, [",
+            stringify!($base),
+            " + ",
             stringify!($xsave_area_off),
             "]\n",
-            "mov eax, gs:[",
+            "mov eax, [",
+            stringify!($base),
+            " + ",
             stringify!($mask_lo_off),
             "]\n",
-            "mov edx, gs:[",
+            "mov edx, [",
+            stringify!($base),
+            " + ",
             stringify!($mask_hi_off),
             "]\n",
             "xrstor [rcx]\n",
@@ -172,20 +188,19 @@ macro_rules! XRSTOR_VTL0_ASM {
     };
 }
 
-/// Assembly macro to return to VTL0 using the Hyper-V hypercall stub.
-/// Although Hyper-V lets each core use the same VTL return address, this implementation
-/// uses per-CPU return address to avoid using a mutable global variable.
-/// `ret_off` is the offset of the PerCpuVariablesAsm which holds the VTL return address.
-macro_rules! VTL_RETURN_ASM {
-    ($ret_off:tt) => {
-        concat!(
-            "xor ecx, ecx\n",
-            "mov rax, gs:[",
-            stringify!($ret_off),
-            "]\n",
-            "call rax\n",
-        )
-    };
+/// VTL return address inside the Hyper-V hypercall page (hypercall page
+/// address + the hypervisor-reported VTL-return code offset). The value is
+/// identical on every core; it is written by
+/// [`mshv_vsm_get_code_page_offsets`] during each core's boot (BSP first,
+/// before any AP exists) and read by the `vtl_switch` asm via RIP-relative
+/// addressing.
+static VTL_RETURN_TARGET: AtomicUsize = AtomicUsize::new(0);
+
+/// Whether the VTL return target (and hence the hypercall page) has been
+/// configured. Used by `is_hvcall_ready`.
+#[cfg(not(test))]
+pub(crate) fn is_vtl_return_target_set() -> bool {
+    VTL_RETURN_TARGET.load(Ordering::Relaxed) != 0
 }
 
 // The following registers are shared between different VTLs.
@@ -218,6 +233,17 @@ pub struct VtlState {
     // X87, XMM, AVX, XCR
 }
 
+/// Byte offset of `PerCpuVariables::vtl0_state` (a `#[repr(transparent)]`
+/// `Cell<VtlState>`, so this is also the offset of the inner `VtlState`).
+/// Used by the `vtl_switch` asm to address VTL0 GPR slots directly.
+#[cfg(target_arch = "x86_64")]
+const VTL0_STATE_OFF: usize = core::mem::offset_of!(PerCpuVariables, vtl0_state);
+
+/// Negated `PER_CPU_ALIGN` for `and reg, imm32` per-CPU base derivation.
+#[cfg(target_arch = "x86_64")]
+#[allow(clippy::cast_possible_wrap)]
+const PER_CPU_ALIGN_NEG: i64 = -(PER_CPU_ALIGN as i64);
+
 impl VtlState {
     pub fn new() -> Self {
         VtlState {
@@ -247,84 +273,6 @@ pub fn vtl_switch_init(platform: Option<&'static crate::Platform>) {
     // in the mask so TLB flushes during the first VTL call dispatch
     // target this VP.
     vtl1_vp_enter();
-}
-
-/// Assembly macro to save VTL state to the VtlState memory area.
-///
-/// This macro saves the current `rsp` to scratch, sets `rsp` to point to the top of
-/// the VtlState area, pushes all general-purpose registers, then restores `rsp` from scratch.
-///
-/// Clobbers: none (rsp is saved and restored)
-macro_rules! SAVE_VTL_STATE_ASM {
-    ($scratch_off:tt, $vtl_state_top_addr_off:tt) => {
-        concat!(
-            "mov gs:[",
-            stringify!($scratch_off),
-            "], rsp\n",
-            "mov rsp, gs:[",
-            stringify!($vtl_state_top_addr_off),
-            "]\n",
-            "push r15\n",
-            "push r14\n",
-            "push r13\n",
-            "push r12\n",
-            "push r11\n",
-            "push r10\n",
-            "push r9\n",
-            "push r8\n",
-            "push rdi\n",
-            "push rsi\n",
-            "push rdx\n",
-            "push rcx\n",
-            "push rbx\n",
-            "push rax\n",
-            "push rbp\n",
-            "mov rsp, gs:[",
-            stringify!($scratch_off),
-            "]\n",
-        )
-    };
-}
-
-/// Assembly macro to restore VTL state from the VtlState memory area.
-///
-/// This macro saves the current `rsp` to scratch, sets `rsp` to point to the start of
-/// the VtlState area (top - size), pops all general-purpose registers, then restores
-/// `rsp` from scratch.
-///
-/// Clobbers: none (rsp is saved and restored)
-macro_rules! LOAD_VTL_STATE_ASM {
-    ($scratch_off:tt, $vtl_state_top_addr_off:tt, $vtl_state_size:tt) => {
-        concat!(
-            "mov gs:[",
-            stringify!($scratch_off),
-            "], rsp\n",
-            "mov rsp, gs:[",
-            stringify!($vtl_state_top_addr_off),
-            "]\n",
-            "sub rsp, ",
-            stringify!($vtl_state_size),
-            "\n",
-            "pop rbp\n",
-            "pop rax\n",
-            "pop rbx\n",
-            "pop rcx\n",
-            "pop rdx\n",
-            "pop rsi\n",
-            "pop rdi\n",
-            "pop r8\n",
-            "pop r9\n",
-            "pop r10\n",
-            "pop r11\n",
-            "pop r12\n",
-            "pop r13\n",
-            "pop r14\n",
-            "pop r15\n",
-            "mov rsp, gs:[",
-            stringify!($scratch_off),
-            "]\n",
-        )
-    };
 }
 
 /// Handle a VTL entry event.
@@ -401,9 +349,13 @@ pub(crate) fn mshv_vsm_get_code_page_offsets() -> Result<(), VsmError> {
     let vtl_return_address = hvcall_page
         .checked_add(usize::from(code_page_offsets.vtl_return_offset()))
         .ok_or(VsmError::CodePageOffsetOverflow)?;
-    with_per_cpu_variables(|pcv| {
-        pcv.asm.set_vtl_return_addr(vtl_return_address);
-    });
+    // Every core computes the same value (the hypercall page is shared and
+    // the offset is partition-wide); the redundant stores from APs are
+    // benign. The BSP's store happens during its boot, strictly before any
+    // AP is started (APs boot via a BootAps VTL call, which requires the BSP
+    // to have completed init and entered its vtl_switch loop), so the target
+    // is always non-zero by the time any core executes a VTL return.
+    VTL_RETURN_TARGET.store(vtl_return_address, Ordering::Relaxed);
     Ok(())
 }
 
@@ -437,9 +389,17 @@ pub fn vtl_switch(return_value: Option<i64>) -> [u64; NUM_VTLCALL_PARAMS] {
         // the VTL1 mask before the asm block.
 
         // Inline asm performs the VTL switch:
-        // 1. Restore VTL0 state (XRSTOR + load GP registers)
+        // 1. Restore VTL0 state (XRSTOR + load GP registers from vtl0_state)
         // 2. Return to VTL0 (cli + hypercall)
-        // 3. Save VTL0 state when VTL1 resumes (save GP registers + XSAVE)
+        // 3. Save VTL0 state when VTL1 resumes (store GP registers + XSAVE)
+        //
+        // The per-CPU base is derived by masking RSP (the kernel stack lives
+        // inside the 256 KiB-aligned PerCpuVariables) and parked on the
+        // hypervisor-preserved kernel stack across the VTL round trip.
+        // VTL0 GPRs are moved directly between registers and the vtl0_state
+        // cell — RSP never leaves the kernel stack (the old push/pop scheme
+        // pointed RSP into vtl0_state while IF was still set, so an
+        // interrupt there could clobber adjacent per-CPU data).
         //
         // All GP registers are clobbered by loading VTL0's state.
         // - rbx and rbp cannot be in clobber list (LLVM restriction), so we manually save/restore
@@ -451,26 +411,81 @@ pub fn vtl_switch(return_value: Option<i64>) -> [u64; NUM_VTLCALL_PARAMS] {
             core::arch::asm!(
                 "push rbx",
                 "push rbp",
-                XRSTOR_VTL0_ASM!({vtl0_xsave_area_off}, {vtl0_xsave_mask_lo_off}, {vtl0_xsave_mask_hi_off}),
-                LOAD_VTL_STATE_ASM!({scratch_off}, {vtl0_state_top_addr_off}, {VTL_STATE_SIZE}),
+                // rsi := per-CPU base; park it for the resume side.
+                "mov rsi, rsp",
+                "and rsi, {neg_pcv_align}",
+                "push rsi",
+                XRSTOR_VTL0_ASM!(rsi, {vtl0_xsave_area_off}, {vtl0_xsave_mask_lo_off}, {vtl0_xsave_mask_hi_off}),
+                // Load VTL0 GPRs from vtl0_state (base register rsi last).
+                // rax and rcx are skipped: they are immediately clobbered by
+                // the VTL return sequence below (the old code popped them and
+                // then clobbered them the same way).
+                "mov rbp, [rsi + {o_rbp}]",
+                "mov rbx, [rsi + {o_rbx}]",
+                "mov rdx, [rsi + {o_rdx}]",
+                "mov rdi, [rsi + {o_rdi}]",
+                "mov r8, [rsi + {o_r8}]",
+                "mov r9, [rsi + {o_r9}]",
+                "mov r10, [rsi + {o_r10}]",
+                "mov r11, [rsi + {o_r11}]",
+                "mov r12, [rsi + {o_r12}]",
+                "mov r13, [rsi + {o_r13}]",
+                "mov r14, [rsi + {o_r14}]",
+                "mov r15, [rsi + {o_r15}]",
+                "mov rsi, [rsi + {o_rsi}]",
                 // *** VTL0 state is restored. Return to VTL0 immediately ***
                 "cli", // disable VTL1 interrupts before returning to VTL0
-                VTL_RETURN_ASM!({vtl_ret_addr_off}),
+                "xor ecx, ecx",
+                "mov rax, [rip + {vtl_return_target}]",
+                "call rax",
                 // *** VTL1 resumes here regardless of the entry reason (VTL switch or intercept) ***
-                // Hyper-V restored VTL1's rip and rsp, so we're back on the original stack.
-                SAVE_VTL_STATE_ASM!({scratch_off}, {vtl0_state_top_addr_off}),
-                XSAVE_VTL0_ASM!({vtl0_xsave_area_off}, {vtl0_xsave_mask_lo_off}, {vtl0_xsave_mask_hi_off}),
+                // Hyper-V restored VTL1's rip and rsp, so we're back on the
+                // original stack with the parked per-CPU base at [rsp].
+                // All 15 GPRs hold live VTL0 values; free rdi by pushing it.
+                "push rdi",
+                "mov rdi, [rsp + 8]", // rdi := parked per-CPU base
+                "mov [rdi + {o_rbp}], rbp",
+                "mov [rdi + {o_rax}], rax",
+                "mov [rdi + {o_rbx}], rbx",
+                "mov [rdi + {o_rcx}], rcx",
+                "mov [rdi + {o_rdx}], rdx",
+                "mov [rdi + {o_rsi}], rsi",
+                "mov [rdi + {o_r8}], r8",
+                "mov [rdi + {o_r9}], r9",
+                "mov [rdi + {o_r10}], r10",
+                "mov [rdi + {o_r11}], r11",
+                "mov [rdi + {o_r12}], r12",
+                "mov [rdi + {o_r13}], r13",
+                "mov [rdi + {o_r14}], r14",
+                "mov [rdi + {o_r15}], r15",
+                "pop rax", // VTL0's rdi
+                "mov [rdi + {o_rdi}], rax",
+                XSAVE_VTL0_ASM!(rdi, {vtl0_xsave_area_off}, {vtl0_xsave_mask_lo_off}, {vtl0_xsave_mask_hi_off}),
                 "sti", // enable VTL1 interrupts after saving VTL0 state
                 // A pending SINT can be fired here. Our SINT handler only executes `iretq` so returns to here immediately.
+                "add rsp, 8", // drop the parked per-CPU base
                 "pop rbp",
                 "pop rbx",
-                vtl_ret_addr_off = const { PerCpuVariablesAsm::vtl_return_addr_offset() },
-                scratch_off = const { PerCpuVariablesAsm::scratch_offset() },
-                vtl0_state_top_addr_off = const { PerCpuVariablesAsm::vtl0_state_top_addr_offset() },
                 vtl0_xsave_area_off = const { PerCpuVariablesAsm::vtl0_xsave_area_addr_offset() },
                 vtl0_xsave_mask_lo_off = const { PerCpuVariablesAsm::vtl0_xsave_mask_lo_offset() },
                 vtl0_xsave_mask_hi_off = const { PerCpuVariablesAsm::vtl0_xsave_mask_hi_offset() },
-                VTL_STATE_SIZE = const core::mem::size_of::<VtlState>(),
+                neg_pcv_align = const { PER_CPU_ALIGN_NEG },
+                vtl_return_target = sym VTL_RETURN_TARGET,
+                o_rbp = const { VTL0_STATE_OFF + core::mem::offset_of!(VtlState, rbp) },
+                o_rax = const { VTL0_STATE_OFF + core::mem::offset_of!(VtlState, rax) },
+                o_rbx = const { VTL0_STATE_OFF + core::mem::offset_of!(VtlState, rbx) },
+                o_rcx = const { VTL0_STATE_OFF + core::mem::offset_of!(VtlState, rcx) },
+                o_rdx = const { VTL0_STATE_OFF + core::mem::offset_of!(VtlState, rdx) },
+                o_rsi = const { VTL0_STATE_OFF + core::mem::offset_of!(VtlState, rsi) },
+                o_rdi = const { VTL0_STATE_OFF + core::mem::offset_of!(VtlState, rdi) },
+                o_r8 = const { VTL0_STATE_OFF + core::mem::offset_of!(VtlState, r8) },
+                o_r9 = const { VTL0_STATE_OFF + core::mem::offset_of!(VtlState, r9) },
+                o_r10 = const { VTL0_STATE_OFF + core::mem::offset_of!(VtlState, r10) },
+                o_r11 = const { VTL0_STATE_OFF + core::mem::offset_of!(VtlState, r11) },
+                o_r12 = const { VTL0_STATE_OFF + core::mem::offset_of!(VtlState, r12) },
+                o_r13 = const { VTL0_STATE_OFF + core::mem::offset_of!(VtlState, r13) },
+                o_r14 = const { VTL0_STATE_OFF + core::mem::offset_of!(VtlState, r14) },
+                o_r15 = const { VTL0_STATE_OFF + core::mem::offset_of!(VtlState, r15) },
                 clobber_abi("C"),
                 out("r12") _,
                 out("r13") _,

--- a/litebox_platform_lvbs/src/syscall_entry.rs
+++ b/litebox_platform_lvbs/src/syscall_entry.rs
@@ -1,8 +1,26 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+//! Per-core `syscall` entry stubs.
+//!
+//! `syscall` is the one kernel entry with an untrusted RSP and no free
+//! register, so it needs an anchor that does not rely on GS (this kernel is
+//! gsbase-less, see `PerCpuVariables`). The anchor is the LSTAR MSR itself:
+//! it is per-core, so each core points it at its own 32-byte stub in a
+//! compile-time `.rept` table. Stub `i` spills user `rax` into
+//! `SYSCALL_SLOTS[i]`, loads that core's `PerCpuVariables` pointer into
+//! `rax`, and jumps to the shared `syscall_callback`, which then runs fully
+//! base-register-relative.
+//!
+//! The stubs use only RIP-relative addressing (static PC32 relocations), so
+//! the table is ordinary shared .text — no runtime codegen, no per-core
+//! executable pages, and nothing new for the runner's self-relocation pass
+//! (which only handles `R_X86_64_RELATIVE`).
+
+use crate::arch::MAX_CORES;
 use crate::host::per_cpu_variables::with_per_cpu_variables;
-use core::arch::naked_asm;
+use core::arch::global_asm;
+use core::cell::{Cell, UnsafeCell};
 use x86_64::{
     VirtAddr,
     registers::{
@@ -11,9 +29,77 @@ use x86_64::{
     },
 };
 
-#[unsafe(naked)]
-unsafe extern "C" fn syscall_entry_wrapper() {
-    naked_asm!("jmp syscall_callback");
+/// Byte stride of one stub in the `syscall_entry_stubs` table.
+const SYSCALL_STUB_STRIDE: usize = 32;
+
+/// Per-core syscall entry slot: the stub's `rax` spill cell plus the cached
+/// `PerCpuVariables` pointer the stub loads. 64-byte stride (one cache line
+/// per core) prevents false sharing on the hot spill store.
+#[repr(C, align(64))]
+struct SyscallSlot {
+    /// User `rax` spilled by this core's stub on every syscall entry.
+    rax_spill: UnsafeCell<u64>,
+    /// This core's `PerCpuVariables` address, written once at [`init`].
+    pcv: Cell<usize>,
+    _pad: [u8; 48],
+}
+
+const _: () = assert!(size_of::<SyscallSlot>() == 64);
+// `syscall_callback` reads the spilled user rax via a single deref of
+// `PerCpuVariablesAsm::syscall_slot_ptr`, which relies on `rax_spill` being
+// the first field.
+const _: () = assert!(core::mem::offset_of!(SyscallSlot, rax_spill) == 0);
+const _: () = assert!(core::mem::offset_of!(SyscallSlot, pcv) == 8);
+
+// SAFETY: each slot is written and read only by its owning core (the core
+// whose LSTAR points at stub `i` and whose `vp_index()` is `i`).
+unsafe impl Sync for SyscallSlot {}
+
+#[allow(clippy::declare_interior_mutable_const)]
+const EMPTY_SLOT: SyscallSlot = SyscallSlot {
+    rax_spill: UnsafeCell::new(0),
+    pcv: Cell::new(0),
+    _pad: [0; 48],
+};
+
+/// One slot per core, indexed by Hyper-V VP index (8 KiB of .bss).
+static SYSCALL_SLOTS: [SyscallSlot; MAX_CORES] = [EMPTY_SLOT; MAX_CORES];
+
+// The stub table: MAX_CORES stubs, 32 bytes apart (19 bytes used). Stub `i`:
+//   mov [rip + SYSCALL_SLOTS + i*64], rax     ; spill user rax
+//   mov rax, [rip + SYSCALL_SLOTS + i*64 + 8] ; rax := this core's pcv
+//   jmp syscall_callback
+// The two-instruction window still runs on the (untrusted) user RSP; it is
+// interrupt-free for the same reasons today's entry sequence is: SFMASK
+// masks IF, and NMI/MCE are never delivered to VTL1.
+// `init()` asserts at boot that the emitted table's label-difference size
+// matches the SYSCALL_STUB_STRIDE the Rust side uses to program LSTAR
+// (the assembler cannot fold the label difference at parse time because of
+// the `.balign` fragments, so the check cannot be a `.if`).
+global_asm!(
+    ".balign 32",
+    ".globl syscall_entry_stubs",
+    "syscall_entry_stubs:",
+    ".set stub_index, 0",
+    ".rept {max_cores}",
+    ".balign 32",
+    "mov qword ptr [rip + {slots} + stub_index * 64], rax",
+    "mov rax, qword ptr [rip + {slots} + stub_index * 64 + 8]",
+    "jmp syscall_callback",
+    ".set stub_index, stub_index + 1",
+    ".endr",
+    ".balign 32",
+    ".globl syscall_entry_stubs_end",
+    "syscall_entry_stubs_end:",
+    max_cores = const MAX_CORES,
+    slots = sym SYSCALL_SLOTS,
+);
+
+unsafe extern "C" {
+    /// First stub of the table defined in `global_asm!` above.
+    fn syscall_entry_stubs();
+    /// One-past-the-end label of the stub table.
+    fn syscall_entry_stubs_end();
 }
 
 /// This function enables 64-bit syscall extensions and sets up the necessary MSRs.
@@ -29,9 +115,6 @@ pub(crate) fn init() {
     let mut efer = Efer::read();
     efer.insert(EferFlags::SYSTEM_CALL_EXTENSIONS);
     unsafe { Efer::write(efer) };
-
-    let syscall_entry_addr = syscall_entry_wrapper as *const () as u64;
-    LStar::write(VirtAddr::new(syscall_entry_addr));
 
     // Mask some important bits of the FLAGS register.
     //
@@ -49,11 +132,33 @@ pub(crate) fn init() {
         | RFlags::IOPL_HIGH;
     SFMask::write(rflags);
 
-    // configure STAR MSR for CS/SS selectors
-    let (kernel_cs, user_cs, _) = with_per_cpu_variables(|per_cpu_variables| {
+    // Label-difference check: the emitted stub table must match the stride
+    // used below to compute each core's LSTAR value.
+    assert_eq!(
+        syscall_entry_stubs_end as *const () as usize - syscall_entry_stubs as *const () as usize,
+        MAX_CORES * SYSCALL_STUB_STRIDE,
+        "syscall stub table stride drift"
+    );
+
+    // Register this core's slot and point its LSTAR at its own stub.
+    let (kernel_cs, user_cs) = with_per_cpu_variables(|per_cpu_variables| {
+        let vp_index = per_cpu_variables.vp_index() as usize;
+        let slot = &SYSCALL_SLOTS[vp_index];
+        slot.pcv
+            .set(core::ptr::from_ref(per_cpu_variables) as usize);
         per_cpu_variables
+            .asm
+            .set_syscall_slot_ptr(core::ptr::from_ref(slot) as usize);
+        LStar::write(VirtAddr::new(
+            (syscall_entry_stubs as *const () as usize + vp_index * SYSCALL_STUB_STRIDE) as u64,
+        ));
+
+        let (kernel_cs, user_cs, _) = per_cpu_variables
             .get_segment_selectors()
-            .expect("GDT not initialized for the current core")
+            .expect("GDT not initialized for the current core");
+        (kernel_cs, user_cs)
     });
+
+    // configure STAR MSR for CS/SS selectors
     unsafe { Star::write_raw(user_cs, kernel_cs) };
 }

--- a/litebox_runner_lvbs/src/main.rs
+++ b/litebox_runner_lvbs/src/main.rs
@@ -9,12 +9,7 @@ use core::arch::{asm, naked_asm};
 use core::sync::atomic::{AtomicBool, Ordering};
 use litebox_platform_lvbs::{
     arch::{enable_extended_states, enable_fsgsbase, enable_smep_smap, instrs::hlt_loop},
-    host::{
-        bootparam::save_boot_info,
-        per_cpu_variables::{
-            PerCpuVariablesAsm, allocate_per_cpu_variables, init_per_cpu_variables,
-        },
-    },
+    host::{bootparam::save_boot_info, per_cpu_variables::allocate_per_cpu_variables},
     mshv::vtl1_mem_layout::{self, VTL1_REMAP_PDE_PAGE, VTL1_REMAP_PDPT_PAGE},
     serial_println,
 };
@@ -252,7 +247,7 @@ unsafe fn apply_relocations() {
 /// # Safety
 /// - Must be called exactly once on BSP in `_start()`, after `apply_relocations()`
 /// - Must be called before any heap/allocator initialization
-/// - Must be called before `enable_fsgsbase()` and `init_per_cpu_variables()`
+/// - Must be called before `enable_fsgsbase()` and `allocate_per_cpu_variables()`
 /// - The VTL0-provided page table must be at the expected layout (pages 2-12)
 #[inline(never)]
 #[allow(clippy::similar_names)]
@@ -387,6 +382,9 @@ pub unsafe extern "C" fn _ap_start() -> ! {
 ///
 /// When `is_bsp` is `true`, seeds the initial heap.
 unsafe extern "C" fn common_start(is_bsp: bool) -> ! {
+    // FSGSBASE now serves user mode only (kernel `wrfsbase` for FsBase
+    // support and TA-side rd/wr fs/gs base); the kernel itself is
+    // gsbase-less and never reads or swaps GS.
     enable_fsgsbase();
     enable_extended_states();
 
@@ -394,18 +392,27 @@ unsafe extern "C" fn common_start(is_bsp: bool) -> ! {
         litebox_runner_lvbs::seed_initial_heap();
     }
 
-    // Each core heap-allocates its own PerCpuVariables and sets GSBASE
-    // to point at it (assembly fields are at GS offset 0).
-    allocate_per_cpu_variables();
+    // Each core heap-allocates its own PerCpuVariables. The kernel never
+    // touches GS after this point: per-CPU state is found by masking RSP
+    // (all kernel stacks live inside the 256 KiB-aligned struct).
+    let pcv = allocate_per_cpu_variables();
 
-    init_per_cpu_variables();
+    // One-time GS MSR hygiene: clear any VTL0-inherited value from both GS
+    // base MSRs. The kernel never writes them again (no swapgs exists), so
+    // no kernel address can ever reside in either.
+    unsafe { litebox_common_linux::wrgsbase(0) };
+    x86_64::registers::model_specific::KernelGsBase::write(VirtAddr::zero());
+
+    // Compute this core's kernel stack pointer while still on the boot stack.
+    let kernel_sp = pcv.kernel_stack_top() & !15;
 
     // Switch to the kernel stack and tail-call kernel_main with is_bsp
     let is_bsp_u32 = u32::from(is_bsp);
     unsafe {
         asm!(
-            // Now use this core's heap-allocated kernel stack.
-            "mov rsp, gs:[{kernel_sp_off}]",
+            // Now use this core's heap-allocated kernel stack. From here on,
+            // RSP-mask per-CPU derivation (with_per_cpu_variables) is valid.
+            "mov rsp, {kernel_sp}",
             // The boot stack is no longer in use. Release the AP boot stack
             // spinlock so the next AP can proceed. For the BSP this is a
             // harmless no-op (the lock was never held).
@@ -413,7 +420,7 @@ unsafe extern "C" fn common_start(is_bsp: bool) -> ! {
             "call {release_lock}",
             "pop rdi",
             "call {kernel_main}",
-            kernel_sp_off = const { PerCpuVariablesAsm::kernel_stack_ptr_offset() },
+            kernel_sp = in(reg) kernel_sp,
             in("edi") is_bsp_u32,
             release_lock = sym release_boot_stack_lock,
             kernel_main = sym kernel_main,

--- a/litebox_runner_lvbs/src/main.rs
+++ b/litebox_runner_lvbs/src/main.rs
@@ -9,12 +9,7 @@ use core::arch::{asm, naked_asm};
 use core::sync::atomic::{AtomicBool, Ordering};
 use litebox_platform_lvbs::{
     arch::{enable_extended_states, enable_fsgsbase, enable_smep_smap, instrs::hlt_loop},
-    host::{
-        bootparam::save_boot_info,
-        per_cpu_variables::{
-            PerCpuVariablesAsm, allocate_per_cpu_variables, init_per_cpu_variables,
-        },
-    },
+    host::{bootparam::save_boot_info, per_cpu_variables::allocate_per_cpu_variables},
     mshv::vtl1_mem_layout::{self, VTL1_REMAP_PDE_PAGE, VTL1_REMAP_PDPT_PAGE},
     serial_println,
 };
@@ -259,7 +254,7 @@ unsafe fn apply_relocations() {
 /// # Safety
 /// - Must be called exactly once on BSP in `_start()`, after `apply_relocations()`
 /// - Must be called before any heap/allocator initialization
-/// - Must be called before `enable_fsgsbase()` and `init_per_cpu_variables()`
+/// - Must be called before `enable_fsgsbase()` and `allocate_per_cpu_variables()`
 /// - The VTL0-provided page table must be at the expected layout (pages 2-12)
 #[inline(never)]
 #[allow(clippy::similar_names)]
@@ -394,6 +389,9 @@ pub unsafe extern "C" fn _ap_start() -> ! {
 ///
 /// When `is_bsp` is `true`, seeds the initial heap.
 unsafe extern "C" fn common_start(is_bsp: bool) -> ! {
+    // FSGSBASE now serves user mode only (kernel `wrfsbase` for FsBase
+    // support and TA-side rd/wr fs/gs base); the kernel itself is
+    // gsbase-less and never reads or swaps GS.
     enable_fsgsbase();
     enable_extended_states();
 
@@ -401,18 +399,27 @@ unsafe extern "C" fn common_start(is_bsp: bool) -> ! {
         litebox_runner_lvbs::seed_initial_heap();
     }
 
-    // Each core heap-allocates its own PerCpuVariables and sets GSBASE
-    // to point at it (assembly fields are at GS offset 0).
-    allocate_per_cpu_variables();
+    // Each core heap-allocates its own PerCpuVariables. The kernel never
+    // touches GS after this point: per-CPU state is found by masking RSP
+    // (all kernel stacks live inside the 256 KiB-aligned struct).
+    let pcv = allocate_per_cpu_variables();
 
-    init_per_cpu_variables();
+    // One-time GS MSR hygiene: clear any VTL0-inherited value from both GS
+    // base MSRs. The kernel never writes them again (no swapgs exists), so
+    // no kernel address can ever reside in either.
+    unsafe { litebox_common_linux::wrgsbase(0) };
+    x86_64::registers::model_specific::KernelGsBase::write(VirtAddr::zero());
+
+    // Compute this core's kernel stack pointer while still on the boot stack.
+    let kernel_sp = pcv.kernel_stack_top() & !15;
 
     // Switch to the kernel stack and tail-call kernel_main with is_bsp
     let is_bsp_u32 = u32::from(is_bsp);
     unsafe {
         asm!(
-            // Now use this core's heap-allocated kernel stack.
-            "mov rsp, gs:[{kernel_sp_off}]",
+            // Now use this core's heap-allocated kernel stack. From here on,
+            // RSP-mask per-CPU derivation (with_per_cpu_variables) is valid.
+            "mov rsp, {kernel_sp}",
             // The boot stack is no longer in use. Release the AP boot stack
             // spinlock so the next AP can proceed. For the BSP this is a
             // harmless no-op (the lock was never held).
@@ -420,7 +427,7 @@ unsafe extern "C" fn common_start(is_bsp: bool) -> ! {
             "call {release_lock}",
             "pop rdi",
             "call {kernel_main}",
-            kernel_sp_off = const { PerCpuVariablesAsm::kernel_stack_ptr_offset() },
+            kernel_sp = in(reg) kernel_sp,
             in("edi") is_bsp_u32,
             release_lock = sym release_boot_stack_lock,
             kernel_main = sym kernel_main,

--- a/litebox_runner_lvbs/src/main.rs
+++ b/litebox_runner_lvbs/src/main.rs
@@ -69,7 +69,14 @@ const R_X86_64_RELATIVE: u64 = 8;
 const KERNEL_OFFSET: u64 = litebox_platform_lvbs::KERNEL_OFFSET;
 
 /// Page table entry flags for Phase 1 mappings (present + writable).
-const PTE_TABLE_FLAGS: u64 = PageTableFlags::PRESENT.bits() | PageTableFlags::WRITABLE.bits();
+///
+/// ACCESSED and DIRTY are pre-set here too (mirroring the Linux kernel's
+/// `_KERNPG_TABLE`) so the CPU's page-table walker doesn't need an atomic
+/// read-modify-write on these entries the first time they're traversed.
+const PTE_TABLE_FLAGS: u64 = PageTableFlags::PRESENT.bits()
+    | PageTableFlags::WRITABLE.bits()
+    | PageTableFlags::ACCESSED.bits()
+    | PageTableFlags::DIRTY.bits();
 
 /// x86-64 page table structure constants
 const ENTRIES_PER_PT_PAGE: usize = 512;


### PR DESCRIPTION
Closes issue #514.

Remove all kernel-mode GSBASE/swapgs usage from VTL1, replacing it with RSP-based per-CPU lookup and per-core LSTAR syscall stubs. Also removes obsolete GSBASE infrastructure and fixes a vtl_switch RSP bug. ABI unchanged..