### PR TITLE
Retire host-backed broker objects exactly once

### DIFF
--- a/litebox_broker_core/src/event.rs
+++ b/litebox_broker_core/src/event.rs
@@ -25,7 +25,7 @@ pub fn add(session: &BrokerSession, handle: ObjectHandle, value: u64) -> Result<
     let required_rights = ObjectRights::WRITE;
     session.with_authorized_object_mut(handle, required_rights, |object| match object {
         ObjectEntry::Event(event) => event.add(value),
-        ObjectEntry::Pipe(_) => Err(BrokerError::InvalidRights),
+        ObjectEntry::Pipe(_) | ObjectEntry::HostBacked(_) => Err(BrokerError::InvalidRights),
     })
 }
 
@@ -38,7 +38,7 @@ pub fn consume(
     let required_rights = ObjectRights::WAIT;
     session.with_authorized_object_mut(handle, required_rights, |object| match object {
         ObjectEntry::Event(event) => event.consume(mode),
-        ObjectEntry::Pipe(_) => Err(BrokerError::InvalidRights),
+        ObjectEntry::Pipe(_) | ObjectEntry::HostBacked(_) => Err(BrokerError::InvalidRights),
     })
 }
 

--- a/litebox_broker_core/src/host_resource.rs
+++ b/litebox_broker_core/src/host_resource.rs
@@ -1,0 +1,168 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//! Naming and retirement for broker objects backed by host resources.
+//!
+//! Events and pipes keep every byte of their state inside this crate, so
+//! dropping the last reference to one releases everything it owned. A socket
+//! will not: its concrete state is a host descriptor and a poll registration
+//! owned by the broker host, neither of which this crate can name or touch.
+//! This module gives it an opaque name for such a resource and a way to hand
+//! that name back once the last reference to it is gone, so the host can
+//! release what this crate cannot.
+
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+
+use spin::rwlock::RwLock;
+
+use crate::{BrokerError, Result};
+
+/// Opaque identity of one resource owned by the broker host.
+///
+/// The host allocates these and maps them to whatever it actually owns.
+/// This type is deliberately absent from `litebox_broker_protocol`, so it
+/// cannot be placed in a protocol message and cannot reach a local endpoint:
+/// the local side names broker objects by [`ObjectHandle`] and never learns
+/// what backs one.
+///
+/// [`ObjectHandle`]: litebox_broker_protocol::ObjectHandle
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct HostResourceId(pub u64);
+
+#[derive(Debug)]
+struct RetirementState {
+    /// Retired identities the host has not taken back yet.
+    retired: Vec<HostResourceId>,
+    /// Resources this session named that the host has not released.
+    ///
+    /// This counts a resource from the moment the core names it until the
+    /// host takes it back, which spans three states a resource passes
+    /// through: reachable through the reference table, unreachable but still
+    /// alive behind an in-flight operation that cloned the reference, and
+    /// retired but not yet taken. Counting the whole span is what makes the
+    /// bound below hold; counting reference-table membership would not, since
+    /// a reference can be closed while an operation still holds the object.
+    charged: usize,
+}
+
+/// Resources a session named on the host's behalf, and those whose last
+/// reference is gone and that the host has not released yet.
+///
+/// One of these belongs to each session, and the host serving that session
+/// drains it. Retirement is deferred rather than immediate because a
+/// reference is dropped while the core holds the process-wide reference lock:
+/// releasing a host resource closes descriptors and deregisters pollers, and
+/// running that under a spin lock every request worker contends for would burn
+/// host CPU for the length of a syscall. Recording the identity there is O(1),
+/// and the host releases it after the lock is gone.
+#[derive(Debug)]
+pub struct HostResourceRetirement {
+    state: RwLock<RetirementState>,
+    /// The most resources this session may have outstanding at once.
+    ///
+    /// Naming a resource is refused past this, which is what keeps `retired`
+    /// within the capacity reserved for it: a retired resource is still
+    /// charged, so the queue can never grow beyond the number of resources
+    /// admitted at once.
+    capacity: usize,
+}
+
+impl HostResourceRetirement {
+    /// Creates retirement state for a session allowed `capacity` resources.
+    pub(crate) fn with_capacity(capacity: usize) -> Result<Arc<Self>> {
+        let mut retired = Vec::new();
+        retired
+            .try_reserve_exact(capacity)
+            .map_err(|_| BrokerError::OutOfMemory)?;
+        Ok(Arc::new(Self {
+            state: RwLock::new(RetirementState {
+                retired,
+                charged: 0,
+            }),
+            capacity,
+        }))
+    }
+
+    /// Admits one more resource, or refuses if the session is already at its
+    /// limit.
+    ///
+    /// Charging before the resource exists is what makes [`Self::retire`]
+    /// infallible: the charge reserves the queue slot the resource will
+    /// eventually occupy, and holds it for as long as the host owns the
+    /// resource.
+    pub(crate) fn try_charge(&self) -> Result<()> {
+        let mut state = self.state.write();
+        if state.charged >= self.capacity {
+            return Err(BrokerError::ResourceExhausted);
+        }
+        state.charged += 1;
+        Ok(())
+    }
+
+    /// Records that the last reference to `resource` is gone.
+    ///
+    /// This never allocates and never fails, which it must not, because it runs
+    /// in `Drop`: a failure could not be reported and a lost identity would
+    /// leak a host resource for the lifetime of the broker. The reservation
+    /// made when the resource was charged is still held, so the push below
+    /// always fits.
+    fn retire(&self, resource: HostResourceId) {
+        let mut state = self.state.write();
+        debug_assert!(
+            state.retired.len() < state.charged,
+            "a retiring resource must still hold the charge it was admitted under"
+        );
+        state.retired.push(resource);
+    }
+
+    /// Takes back one resource waiting to be released, if any.
+    ///
+    /// The caller assumes sole responsibility for releasing what this returns:
+    /// nothing tracks the identity afterwards, so a caller that discards a
+    /// `Some` leaks the underlying host resource for the lifetime of the
+    /// broker. Call this only where the resource is released unconditionally,
+    /// never on a path that can drop the value.
+    ///
+    /// Callers release each resource after this returns rather than under a
+    /// callback, so releasing one never runs while this lock is held. Order is
+    /// unspecified; resources are independent and each is released once.
+    #[must_use]
+    pub fn take_retired(&self) -> Option<HostResourceId> {
+        let mut state = self.state.write();
+        let resource = state.retired.pop()?;
+        state.charged -= 1;
+        Some(resource)
+    }
+}
+
+/// A broker object whose concrete state belongs to the host.
+///
+/// The core knows only the identity and returns it for retirement when the
+/// last reference is dropped, which covers an explicit close, session teardown,
+/// and a reference still held by an in-flight request alike.
+pub(crate) struct HostBackedObject {
+    resource: HostResourceId,
+    retirement: Arc<HostResourceRetirement>,
+}
+
+impl HostBackedObject {
+    /// Names `resource`, which must already be charged to `retirement`.
+    pub(crate) fn new(resource: HostResourceId, retirement: Arc<HostResourceRetirement>) -> Self {
+        Self {
+            resource,
+            retirement,
+        }
+    }
+
+    pub(crate) fn resource(&self) -> HostResourceId {
+        self.resource
+    }
+}
+
+impl Drop for HostBackedObject {
+    fn drop(&mut self) {
+        self.retirement.retire(self.resource);
+    }
+}

--- a/litebox_broker_core/src/lib.rs
+++ b/litebox_broker_core/src/lib.rs
@@ -20,6 +20,7 @@ extern crate std;
 
 mod error;
 pub mod event;
+pub mod host_resource;
 pub mod pipe;
 mod policy;
 mod session;
@@ -32,6 +33,7 @@ use litebox_broker_protocol::ObjectHandle;
 use spin::rwlock::RwLock;
 
 pub use error::BrokerError;
+use host_resource::HostResourceRetirement;
 pub use policy::{PolicyEngine, PolicyProfile};
 use session::ObjectReference;
 pub use session::{BrokerSession, CallerCredential, ObjectRights};
@@ -140,15 +142,23 @@ impl BrokerCore {
 
     /// Allocates broker authority state for one authenticated caller session.
     pub fn create_session(&self, caller_credential: CallerCredential) -> Result<BrokerSession> {
-        let mut next_session_id = self.next_session_id.write();
-        let session_id = *next_session_id;
-        *next_session_id = session_id
-            .checked_add(1)
-            .ok_or(BrokerError::ResourceExhausted)?;
+        // Reserving retirement state allocates, so it happens before the
+        // session-id lock rather than under it: this is a spin lock every
+        // caller entering the broker contends for.
+        let retirement = HostResourceRetirement::with_capacity(self.limits.max_references)?;
+        let session_id = {
+            let mut next_session_id = self.next_session_id.write();
+            let session_id = *next_session_id;
+            *next_session_id = session_id
+                .checked_add(1)
+                .ok_or(BrokerError::ResourceExhausted)?;
+            session_id
+        };
         Ok(BrokerSession::new(
             self.clone(),
             session::SessionId(session_id),
             caller_credential,
+            retirement,
         ))
     }
 

--- a/litebox_broker_core/src/pipe.rs
+++ b/litebox_broker_core/src/pipe.rs
@@ -60,7 +60,7 @@ pub fn read(session: &BrokerSession, handle: ObjectHandle, length: u32) -> Resul
     }
     session.with_authorized_object(handle, ObjectRights::WAIT, |object| match object {
         ObjectEntry::Pipe(pipe) => pipe.read(length as usize),
-        ObjectEntry::Event(_) => Err(BrokerError::InvalidRights),
+        ObjectEntry::Event(_) | ObjectEntry::HostBacked(_) => Err(BrokerError::InvalidRights),
     })
 }
 
@@ -71,7 +71,7 @@ pub fn write(session: &BrokerSession, handle: ObjectHandle, data: &[u8]) -> Resu
     }
     session.with_authorized_object(handle, ObjectRights::WRITE, |object| match object {
         ObjectEntry::Pipe(pipe) => pipe.write(data),
-        ObjectEntry::Event(_) => Err(BrokerError::InvalidRights),
+        ObjectEntry::Event(_) | ObjectEntry::HostBacked(_) => Err(BrokerError::InvalidRights),
     })
 }
 

--- a/litebox_broker_core/src/session.rs
+++ b/litebox_broker_core/src/session.rs
@@ -4,6 +4,7 @@
 use alloc::sync::Arc;
 
 use crate::event::EventObject;
+use crate::host_resource::{HostBackedObject, HostResourceId, HostResourceRetirement};
 use crate::pipe::PipeObject;
 use crate::{BrokerCore, BrokerError, Result};
 use hashbrown::HashMap;
@@ -50,6 +51,7 @@ pub(crate) struct ObjectReference {
 pub(crate) enum ObjectEntry {
     Event(EventObject),
     Pipe(PipeObject),
+    HostBacked(HostBackedObject),
 }
 
 /// Broker-owned authority token for one authenticated caller session.
@@ -63,6 +65,12 @@ pub struct BrokerSession {
     pub(crate) session_id: SessionId,
     /// Broker-entry-authenticated caller credential for this session.
     pub(crate) caller_credential: CallerCredential,
+    /// Host resources this session named and no longer references.
+    ///
+    /// Held behind an [`Arc`] so the host serving the session can keep
+    /// draining it after the session is dropped, which is when teardown
+    /// retires everything the session still referenced.
+    retirement: Arc<HostResourceRetirement>,
 }
 
 impl BrokerSession {
@@ -71,24 +79,130 @@ impl BrokerSession {
         core: BrokerCore,
         session_id: SessionId,
         caller_credential: CallerCredential,
+        retirement: Arc<HostResourceRetirement>,
     ) -> Self {
         Self {
             core,
             session_id,
             caller_credential,
+            retirement,
         }
     }
 
+    /// Returns the host resources this session has finished with.
+    ///
+    /// A host that names resources clones this before serving the
+    /// session, drains it as it serves, and drains it once more after dropping
+    /// the session, which retires everything the session still referenced.
+    #[must_use]
+    pub fn host_resource_retirement(&self) -> &Arc<HostResourceRetirement> {
+        &self.retirement
+    }
+
+    /// Names a host-owned resource as a broker object.
+    ///
+    /// The session takes ownership only if this succeeds. A failure leaves the
+    /// resource with the caller, which must release it, because admitting it
+    /// far enough to retire it is exactly what the limit refused.
+    ///
+    /// An identity must be unique across the whole broker host, not merely
+    /// within this session, until the host takes it back through
+    /// [`HostResourceRetirement::take_retired`]: each session retires into its
+    /// own queue, so naming one identity in two sessions passes every check
+    /// here and retires it twice. The core treats identities as opaque and
+    /// cannot tell two names apart, and a host that releases a
+    /// descriptor twice may close an unrelated one that reused the number.
+    pub fn adopt_host_resource(&self, resource: HostResourceId) -> Result<ObjectHandle> {
+        self.create_object_reference_with(|| {
+            self.retirement.try_charge()?;
+            Ok(ObjectEntry::HostBacked(HostBackedObject::new(
+                resource,
+                Arc::clone(&self.retirement),
+            )))
+        })
+    }
+
+    /// Runs `f` on the host resource an authorized handle names.
+    ///
+    /// This is the only way out of the core for a host resource identity, and
+    /// it is a lease rather than a getter because the identity is only
+    /// meaningful while the object naming it is alive. The object is held for
+    /// the duration of `f`, so within `f` the resource cannot be retired or
+    /// released. Acting on the resource is therefore only safe inside `f`: an
+    /// identity that escapes carries no such protection, and a concurrent
+    /// close can retire it and let the host release the descriptor
+    /// before the escaped copy is used, leaving that caller operating on
+    /// whatever reused the number next. `f` must not let the identity outlive
+    /// it, except to report which resource was named.
+    ///
+    /// The session that owns the handle is enforced here, so one session can
+    /// never resolve another's resource; `required_rights` is the rights the
+    /// caller intends to exercise, and the caller is responsible for asking for
+    /// the rights the operation it is about to perform actually needs. A handle
+    /// naming an object the core owns outright is not a host resource and is
+    /// refused.
+    ///
+    /// `f` runs while the leased object is locked for reading, so it must not
+    /// perform an operation that mutates a broker object, on this handle or any
+    /// other: those take an object write lock, which self-deadlocks on this
+    /// handle and risks a lock-order inversion between two threads holding
+    /// leases on different objects. Closing references, naming resources, and
+    /// draining retirement are all safe here. `f` should also confine itself to
+    /// non-blocking work, since it holds a spin lock.
+    pub fn with_host_resource<T>(
+        &self,
+        handle: ObjectHandle,
+        required_rights: ObjectRights,
+        f: impl FnOnce(HostResourceId) -> Result<T>,
+    ) -> Result<T> {
+        self.with_authorized_object(handle, required_rights, |object| match object {
+            ObjectEntry::HostBacked(host_backed) => f(host_backed.resource()),
+            ObjectEntry::Event(_) | ObjectEntry::Pipe(_) => Err(BrokerError::InvalidRights),
+        })
+    }
+
+    /// Checks that `additional` more references fit under the core limit.
+    ///
+    /// This bounds the reference table only. Host resources are bounded
+    /// separately, by the charge [`HostResourceRetirement`] keeps, because a
+    /// reference can be closed while an in-flight operation still holds the
+    /// object it named: during that window the resource is absent from this
+    /// table and not yet retired, so no count taken here could bound it.
+    fn check_reference_capacity(
+        &self,
+        references: &HashMap<ObjectHandle, ObjectReference>,
+        additional: usize,
+    ) -> Result<()> {
+        let admitted = references.len().checked_add(additional);
+        if admitted.is_none_or(|admitted| admitted > self.core.limits.max_references) {
+            return Err(BrokerError::ResourceExhausted);
+        }
+        Ok(())
+    }
+
     pub(crate) fn create_object_reference(&self, object: ObjectEntry) -> Result<ObjectHandle> {
+        self.create_object_reference_with(|| Ok(object))
+    }
+
+    /// Admits one reference and only then builds the object it names.
+    ///
+    /// The object is built inside the admitted path rather than by the caller
+    /// because building a host-backed object is what makes it retirable: a
+    /// refused adoption that had already built one would drop it, queue its
+    /// resource for retirement, and push retirement past the capacity the
+    /// refusal was protecting.
+    fn create_object_reference_with(
+        &self,
+        object: impl FnOnce() -> Result<ObjectEntry>,
+    ) -> Result<ObjectHandle> {
         let rights = self
             .core
             .policy
             .principal_object_rights(self.caller_credential)?;
         let mut references = self.core.references.write();
-        if references.len() >= self.core.limits.max_references {
-            return Err(BrokerError::ResourceExhausted);
-        }
+        self.check_reference_capacity(&references, 1)?;
         let handle = self.core.allocate_reference_handle()?;
+        let object = object()?;
         references.insert(
             handle,
             ObjectReference {
@@ -111,13 +225,7 @@ impl BrokerSession {
             .policy
             .principal_object_rights(self.caller_credential)?;
         let mut references = self.core.references.write();
-        if references
-            .len()
-            .checked_add(2)
-            .is_none_or(|count| count > self.core.limits.max_references)
-        {
-            return Err(BrokerError::ResourceExhausted);
-        }
+        self.check_reference_capacity(&references, 2)?;
         let (first_handle, second_handle) = self.core.allocate_reference_handle_pair()?;
         for (handle, object) in [(first_handle, first), (second_handle, second)] {
             references.insert(
@@ -163,10 +271,16 @@ impl BrokerSession {
     /// Returns the current readiness of a broker-owned object.
     pub fn check_readiness(&self, handle: ObjectHandle) -> Result<ReadinessFlags> {
         self.with_authorized_object(handle, ObjectRights::WAIT, |object| {
-            Ok(match object {
-                ObjectEntry::Event(event) => event.readiness(),
-                ObjectEntry::Pipe(pipe) => pipe.readiness(),
-            })
+            match object {
+                ObjectEntry::Event(event) => Ok(event.readiness()),
+                ObjectEntry::Pipe(pipe) => Ok(pipe.readiness()),
+                // Readiness of a host-backed object lives in the host that
+                // owns it, so the core cannot answer. This reports the
+                // same mismatch every other operation reports for the wrong
+                // kind of object, because `UnsupportedOperation` reaches the
+                // guest as an unrecoverable error and aborts it.
+                ObjectEntry::HostBacked(_) => Err(BrokerError::InvalidRights),
+            }
         })
     }
 
@@ -211,9 +325,11 @@ impl Drop for BrokerSession {
 mod tests {
     use core::sync::atomic::Ordering;
 
+    use crate::host_resource::HostResourceId;
     use crate::{
         BrokerCore, BrokerCoreLimits, BrokerError, CallerCredential, ObjectRights, PolicyEngine,
     };
+    use alloc::sync::Arc;
     use litebox_broker_protocol::ObjectHandle;
     use litebox_broker_protocol::event::{EventConsumeMode, EventConsumption};
     use litebox_broker_protocol::readiness::ReadinessFlags;
@@ -230,6 +346,11 @@ mod tests {
         check_session_drop_releases_references(&broker);
         check_pipe_lifecycle(&broker);
         check_pipe_reader_closure(&broker);
+        check_host_resource_retirement(&broker);
+        check_session_teardown_retires_host_resources(&broker);
+        check_unreleased_resources_hold_their_capacity(&broker);
+        check_in_flight_resources_hold_their_capacity(&broker);
+        check_host_resource_naming_is_authorized(&broker);
         check_pair_handle_exhaustion(&broker);
 
         assert!(broker.references.read().is_empty());
@@ -375,6 +496,161 @@ mod tests {
         );
         assert_eq!(session.close_object_reference(writer), Ok(()));
         assert_eq!(broker.reserved_pipe_capacity.load(Ordering::Relaxed), 0);
+    }
+
+    fn check_host_resource_retirement(broker: &BrokerCore) {
+        let session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let retirement = Arc::clone(session.host_resource_retirement());
+        let resource = HostResourceId(41);
+        let handle = session.adopt_host_resource(resource).unwrap();
+
+        assert_eq!(
+            session.with_host_resource(handle, ObjectRights::WAIT, Ok),
+            Ok(resource)
+        );
+        // The lease holds the object, so a resource cannot be retired while a
+        // caller is acting on it.
+        assert_eq!(
+            session.with_host_resource(handle, ObjectRights::WAIT, |named| {
+                session.close_object_reference(handle)?;
+                assert_eq!(retirement.take_retired(), None);
+                Ok(named)
+            }),
+            Ok(resource)
+        );
+        assert_eq!(retirement.take_retired(), Some(resource));
+        let handle = session.adopt_host_resource(resource).unwrap();
+        // Readiness belongs to the host that owns the resource, so the
+        // core refuses rather than inventing an answer, and it refuses the way
+        // a guest can recover from.
+        assert_eq!(
+            session.check_readiness(handle),
+            Err(BrokerError::InvalidRights)
+        );
+        assert_eq!(retirement.take_retired(), None);
+
+        assert_eq!(session.close_object_reference(handle), Ok(()));
+        assert_eq!(retirement.take_retired(), Some(resource));
+        assert_eq!(retirement.take_retired(), None);
+    }
+
+    fn check_session_teardown_retires_host_resources(broker: &BrokerCore) {
+        let session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let retirement = Arc::clone(session.host_resource_retirement());
+        let first = session.adopt_host_resource(HostResourceId(51)).unwrap();
+        let second = session.adopt_host_resource(HostResourceId(52)).unwrap();
+        assert_ne!(first, second);
+
+        // Retirement state outlives the session, which is what lets a
+        // host release resources the session never closed explicitly.
+        drop(session);
+
+        let mut retired = [
+            retirement.take_retired().unwrap(),
+            retirement.take_retired().unwrap(),
+        ];
+        retired.sort_unstable();
+        assert_eq!(retired, [HostResourceId(51), HostResourceId(52)]);
+        assert_eq!(retirement.take_retired(), None);
+    }
+
+    fn check_unreleased_resources_hold_their_capacity(broker: &BrokerCore) {
+        let session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let retirement = Arc::clone(session.host_resource_retirement());
+        let first = session.adopt_host_resource(HostResourceId(61)).unwrap();
+        let second = session.adopt_host_resource(HostResourceId(62)).unwrap();
+
+        // A refused naming leaves the resource with the caller instead of
+        // queueing it, because queueing what the limit just refused is what
+        // would let retirement state outgrow the capacity reserved for it.
+        assert_eq!(
+            session.adopt_host_resource(HostResourceId(63)),
+            Err(BrokerError::ResourceExhausted)
+        );
+        assert_eq!(retirement.take_retired(), None);
+
+        assert_eq!(session.close_object_reference(first), Ok(()));
+        assert_eq!(session.close_object_reference(second), Ok(()));
+
+        // Both references are gone, but nothing has released the resources they
+        // named, so they still hold the capacity that bounds retirement state.
+        assert_eq!(
+            session.adopt_host_resource(HostResourceId(63)),
+            Err(BrokerError::ResourceExhausted)
+        );
+
+        assert!(retirement.take_retired().is_some());
+        assert!(retirement.take_retired().is_some());
+        let handle = session.adopt_host_resource(HostResourceId(63)).unwrap();
+        assert_eq!(session.close_object_reference(handle), Ok(()));
+        assert_eq!(retirement.take_retired(), Some(HostResourceId(63)));
+    }
+
+    fn check_in_flight_resources_hold_their_capacity(broker: &BrokerCore) {
+        let session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let retirement = Arc::clone(session.host_resource_retirement());
+        let in_flight = HostResourceId(71);
+        let handle = session.adopt_host_resource(in_flight).unwrap();
+
+        // What an in-flight operation holds: every request clones the object
+        // out of the reference table and then works without the table lock.
+        let operand = {
+            let references = broker.references.read();
+            session
+                .authorize_use_object(&references, handle, ObjectRights::WAIT)
+                .unwrap()
+        };
+        assert_eq!(session.close_object_reference(handle), Ok(()));
+
+        // The resource is now in neither the reference table nor the retirement
+        // queue, so only the charge it still holds keeps the session from
+        // naming more resources than the queue reserved room for.
+        assert_eq!(retirement.take_retired(), None);
+        let other = session.adopt_host_resource(HostResourceId(72)).unwrap();
+        assert_eq!(
+            session.adopt_host_resource(HostResourceId(73)),
+            Err(BrokerError::ResourceExhausted)
+        );
+
+        drop(operand);
+        assert_eq!(retirement.take_retired(), Some(in_flight));
+        assert_eq!(session.close_object_reference(other), Ok(()));
+        assert_eq!(retirement.take_retired(), Some(HostResourceId(72)));
+    }
+
+    fn check_host_resource_naming_is_authorized(broker: &BrokerCore) {
+        let session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let other = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let handle = session.adopt_host_resource(HostResourceId(71)).unwrap();
+        let event = crate::event::create(&session, 0).unwrap();
+
+        // Naming runs the same session check every operation runs, so one
+        // session cannot reach another session's host resource.
+        assert_eq!(
+            other.with_host_resource(handle, ObjectRights::WAIT, Ok),
+            Err(BrokerError::UnknownObject)
+        );
+        // An object the core owns outright has no host resource to name.
+        assert_eq!(
+            session.with_host_resource(event, ObjectRights::WAIT, Ok),
+            Err(BrokerError::InvalidRights)
+        );
+
+        let retirement = Arc::clone(session.host_resource_retirement());
+        drop(session);
+        assert_eq!(retirement.take_retired(), Some(HostResourceId(71)));
     }
 
     fn check_pair_handle_exhaustion(broker: &BrokerCore) {

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -14,8 +14,10 @@ extern crate alloc;
 #[cfg(test)]
 extern crate std;
 
+use alloc::sync::Arc;
 use alloc::vec::Vec;
 
+use litebox_broker_core::host_resource::HostResourceRetirement;
 use litebox_broker_core::{BrokerCore, BrokerSession, CallerCredential};
 use litebox_broker_protocol::channel::{HostReceive, HostSetupChannel, PeerCredential};
 use litebox_broker_protocol::error::ErrorCode;
@@ -60,6 +62,19 @@ struct AssociationState {
 }
 
 impl<Memory: SharedMemory> BrokerHostAssociation<'_, Memory> {
+    /// Returns the host resources this association has finished with.
+    ///
+    /// A host that names resources clones this before serving the
+    /// association and drains it as it serves. Dropping the association drops
+    /// its session, which retires every resource the session still referenced,
+    /// so it must drain once more afterwards to release those. The
+    /// clone is what makes that possible: retirement state outlives the
+    /// association that produced it.
+    #[must_use]
+    pub fn host_resource_retirement(&self) -> &Arc<HostResourceRetirement> {
+        self.session.host_resource_retirement()
+    }
+
     /// Executes one active request and emits its response.
     ///
     /// Any fatal broker or response-channel error permanently fails this
@@ -430,6 +445,35 @@ mod tests {
         association_executes_distinct_slots_concurrently(&broker);
         association_allows_slot_reuse_during_response_emission(&broker);
         association_allows_out_of_order_responses(&broker);
+        association_teardown_retires_host_resources(&broker);
+    }
+
+    fn association_teardown_retires_host_resources(broker: &BrokerCore) {
+        use litebox_broker_core::host_resource::HostResourceId;
+
+        let shared_buffers = test_shared_buffers();
+        let association = test_association(broker, &shared_buffers);
+        let retirement = Arc::clone(association.host_resource_retirement());
+        let resource = HostResourceId(97);
+        let handle = association.session.adopt_host_resource(resource).unwrap();
+
+        assert_eq!(
+            handle_test_request(&association.session, BrokerOperation::CloseObject(handle)),
+            BrokerResult::ObjectClosed
+        );
+        assert_eq!(retirement.take_retired(), Some(resource));
+
+        // Naming the same identity again is only legitimate because the
+        // host took the first one back and released it above.
+        // Teardown then retires what the association still referenced, which
+        // the host only observes because retirement outlives the
+        // association that produced it.
+        let survivor = association.session.adopt_host_resource(resource).unwrap();
+        assert_ne!(survivor, handle);
+        assert_eq!(retirement.take_retired(), None);
+        drop(association);
+        assert_eq!(retirement.take_retired(), Some(resource));
+        assert_eq!(retirement.take_retired(), None);
     }
 
     fn test_channel_negotiates_routes_one_request_and_returns_peer_closed(broker: &BrokerCore) {


### PR DESCRIPTION
Events and pipes keep all of their state inside `litebox_broker_core`, so dropping the last reference to one releases everything it owned; a socket will not, since its state is a host descriptor and a poll registration that only the broker host can release. This adds the seam a socket will need: an opaque `HostResourceId`, a per-session retirement queue, and a host-backed object entry whose drop records its identity for the host to release. Retirement is deferred because references drop under the process-wide reference lock, where releasing a host resource would hold a spin lock across a syscall, and the queue reserves capacity once so recording never allocates inside `Drop`. What bounds the queue is a charge taken when a resource is named and released when the host takes it back, since a close during an in-flight operation leaves a resource in neither the reference table nor the queue. Nothing names a host resource yet.