### PR TITLE
Define the broker socket protocol

### DIFF
--- a/litebox/src/event/counter.rs
+++ b/litebox/src/event/counter.rs
@@ -485,7 +485,9 @@ mod tests {
                 BrokerOperation::CheckReadiness(_) => {
                     BrokerResult::Readiness(ReadinessFlags::WRITE)
                 }
-                request @ (BrokerOperation::Event(_) | BrokerOperation::Pipe(_)) => {
+                request @ (BrokerOperation::Event(_)
+                | BrokerOperation::Pipe(_)
+                | BrokerOperation::Socket(_)) => {
                     panic!("unexpected broker request: {request:?}")
                 }
             };

--- a/litebox/src/pipes.rs
+++ b/litebox/src/pipes.rs
@@ -1195,7 +1195,9 @@ mod tests {
                 BrokerOperation::CheckReadiness(_) => {
                     BrokerResult::Readiness(ReadinessFlags::default())
                 }
-                request @ (BrokerOperation::Pipe(_) | BrokerOperation::Event(_)) => {
+                request @ (BrokerOperation::Pipe(_)
+                | BrokerOperation::Event(_)
+                | BrokerOperation::Socket(_)) => {
                     panic!("unexpected broker request: {request:?}")
                 }
             };

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -22,7 +22,7 @@ use litebox_broker_protocol::error::ErrorCode;
 use litebox_broker_protocol::event::{AddEventResponse, CreateEventResponse};
 use litebox_broker_protocol::message::{
     BrokerHandshakeResponse, BrokerOperation, BrokerRequest, BrokerResponse, BrokerResult,
-    EventRequest, EventResponse, PipeRequest, PipeResponse,
+    EventRequest, EventResponse, PipeRequest, PipeResponse, SocketRequest,
 };
 use litebox_broker_protocol::pipe::{
     CreatePipeResponse, MAX_PIPE_TRANSFER_SIZE, ReadPipeResponse, WritePipeResponse,
@@ -77,10 +77,13 @@ impl<Memory: SharedMemory> BrokerHostAssociation<'_, Memory> {
         let buffer_descriptor = match &operation {
             BrokerOperation::Pipe(PipeRequest::Read(request)) => Some(request.buffer),
             BrokerOperation::Pipe(PipeRequest::Write(request)) => Some(request.buffer),
+            BrokerOperation::Socket(SocketRequest::Send(request)) => Some(request.buffer),
+            BrokerOperation::Socket(SocketRequest::Receive(request)) => Some(request.buffer),
             BrokerOperation::CloseObject(_)
             | BrokerOperation::CheckReadiness(_)
             | BrokerOperation::Event(_)
-            | BrokerOperation::Pipe(PipeRequest::Create(_)) => None,
+            | BrokerOperation::Pipe(PipeRequest::Create(_))
+            | BrokerOperation::Socket(_) => None,
         };
 
         {
@@ -293,6 +296,19 @@ fn handle_request<Memory: SharedMemory>(
         BrokerOperation::Pipe(request) => {
             handle_pipe_request(session, request, shared_buffers).map(BrokerResult::Pipe)
         }
+        // The socket protocol is defined before the broker implements it, so
+        // the operations decode and their shared-buffer leases are validated,
+        // but no socket object exists to act on one yet.
+        //
+        // `UnsupportedOperation` is deliberately in the local endpoint's fatal
+        // group alongside `MalformedRequest` and `ProtocolState`: it means the
+        // local sent an operation this broker never serves, which cannot happen
+        // unless the two sides disagree about the protocol. No local code
+        // constructs a socket request today, so this is unreachable; reporting
+        // a recoverable code instead would let a future wiring mistake look
+        // like an ordinary runtime failure rather than the contract violation
+        // it is.
+        BrokerOperation::Socket(_) => Err(RequestFailure::Respond(ErrorCode::UnsupportedOperation)),
     }
 }
 

--- a/litebox_broker_local/src/event.rs
+++ b/litebox_broker_local/src/event.rs
@@ -76,7 +76,8 @@ impl<Channel: LocalCallChannel> BrokerLocal<Channel> {
             BrokerResult::Error(error) => Err(BrokerLocalError::Broker(error)),
             response @ (BrokerResult::ObjectClosed
             | BrokerResult::Readiness(_)
-            | BrokerResult::Pipe(_)) => {
+            | BrokerResult::Pipe(_)
+            | BrokerResult::Socket(_)) => {
                 panic!("broker returned unexpected event response: {response:?}");
             }
         }

--- a/litebox_broker_local/src/lib.rs
+++ b/litebox_broker_local/src/lib.rs
@@ -179,6 +179,7 @@ impl<Channel: LocalCallChannel> BrokerLocal<Channel> {
             },
             result @ (BrokerResult::Event(_)
             | BrokerResult::Pipe(_)
+            | BrokerResult::Socket(_)
             | BrokerResult::ObjectClosed
             | BrokerResult::Readiness(_)) => Ok(result),
         }
@@ -210,6 +211,7 @@ impl<Channel: LocalCallChannel> BrokerLocal<Channel> {
             BrokerResult::Error(error) => Err(BrokerLocalError::Broker(error)),
             response @ (BrokerResult::Event(_)
             | BrokerResult::Pipe(_)
+            | BrokerResult::Socket(_)
             | BrokerResult::Readiness(_)) => {
                 panic!("broker returned unexpected close response: {response:?}");
             }

--- a/litebox_broker_local/src/pipe.rs
+++ b/litebox_broker_local/src/pipe.rs
@@ -129,7 +129,8 @@ impl<Channel: LocalCallChannel> BrokerLocal<Channel> {
             BrokerResult::Error(error) => Err(BrokerLocalError::Broker(error)),
             response @ (BrokerResult::ObjectClosed
             | BrokerResult::Readiness(_)
-            | BrokerResult::Event(_)) => {
+            | BrokerResult::Event(_)
+            | BrokerResult::Socket(_)) => {
                 panic!("broker returned unexpected pipe response: {response:?}");
             }
         }

--- a/litebox_broker_protocol/src/lib.rs
+++ b/litebox_broker_protocol/src/lib.rs
@@ -22,6 +22,7 @@ pub mod message;
 pub mod pipe;
 pub mod readiness;
 pub mod shared_memory;
+pub mod socket;
 pub mod wire;
 
 /// Opaque broker object reference handle.

--- a/litebox_broker_protocol/src/message.rs
+++ b/litebox_broker_protocol/src/message.rs
@@ -11,6 +11,11 @@ use crate::pipe::{
     WritePipeResponse,
 };
 use crate::readiness::ReadinessFlags;
+use crate::socket::{
+    ConnectSocketRequest, ConnectSocketResponse, CreateSocketRequest, CreateSocketResponse,
+    ReceiveSocketRequest, ReceiveSocketResponse, SendSocketRequest, SendSocketResponse,
+    ShutdownSocketRequest, SocketStatusRequest, SocketStatusResponse,
+};
 use crate::{ObjectHandle, ProtocolVersion, RequestId};
 
 /// Broker handshake request sent before the control channel is active.
@@ -31,6 +36,8 @@ pub enum BrokerOperation {
     Event(EventRequest),
     /// Pipe object request family.
     Pipe(PipeRequest),
+    /// Socket object request family.
+    Socket(SocketRequest),
 }
 
 /// Request sent over an active broker control channel.
@@ -88,6 +95,23 @@ pub enum PipeRequest {
     Write(WritePipeRequest),
 }
 
+/// Broker-owned socket object request.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SocketRequest {
+    /// Create a broker-owned socket.
+    Create(CreateSocketRequest),
+    /// Connect a socket to a remote address.
+    Connect(ConnectSocketRequest),
+    /// Send bytes staged in shared memory.
+    Send(SendSocketRequest),
+    /// Receive bytes into shared memory.
+    Receive(ReceiveSocketRequest),
+    /// Shut down one or both directions.
+    Shutdown(ShutdownSocketRequest),
+    /// Read a socket's pending connection outcome.
+    Status(SocketStatusRequest),
+}
+
 /// Result returned for an active broker operation.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum BrokerResult {
@@ -99,6 +123,8 @@ pub enum BrokerResult {
     Event(EventResponse),
     /// Pipe object response family.
     Pipe(PipeResponse),
+    /// Socket object response family.
+    Socket(SocketResponse),
     /// Operation failed with an ABI-neutral broker error.
     Error(ErrorCode),
 }
@@ -132,6 +158,23 @@ pub enum PipeResponse {
     Read(ReadPipeResponse),
     /// Write operation response.
     Write(WritePipeResponse),
+}
+
+/// Broker-owned socket object response.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SocketResponse {
+    /// Create operation response.
+    Create(CreateSocketResponse),
+    /// Connect operation response.
+    Connect(ConnectSocketResponse),
+    /// Send operation response.
+    Send(SendSocketResponse),
+    /// Receive operation response.
+    Receive(ReceiveSocketResponse),
+    /// Shutdown operation completed.
+    Shutdown,
+    /// Status operation response.
+    Status(SocketStatusResponse),
 }
 
 /// Broker-initiated asynchronous notification.

--- a/litebox_broker_protocol/src/socket.rs
+++ b/litebox_broker_protocol/src/socket.rs
@@ -1,0 +1,282 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//! Typed values for broker-mediated network sockets.
+//!
+//! These describe what a local endpoint may ask the broker to do with a socket,
+//! never how the broker does it: no descriptor, poll registration, or platform
+//! error appears here. Every value is a closed set rather than a passthrough
+//! integer, so a local endpoint cannot name an address family, type, protocol,
+//! or flag the broker has not agreed to support.
+
+use crate::ObjectHandle;
+use crate::shared_memory::SharedBufferDescriptor;
+
+/// Address family of a broker socket.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum AddressFamily {
+    /// IPv4.
+    Ipv4,
+}
+
+/// Communication semantics of a broker socket.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SocketType {
+    /// Reliable ordered byte stream.
+    Stream,
+}
+
+/// IP protocol carried by a broker socket.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum IpProtocol {
+    /// TCP.
+    Tcp,
+}
+
+/// Which directions of a socket to shut down.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ShutdownMode {
+    /// Further receives return end of stream.
+    Read,
+    /// The peer sees end of stream.
+    Write,
+    /// Both directions.
+    Both,
+}
+
+/// IPv4 address in network byte order.
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Ipv4Address(pub [u8; 4]);
+
+/// Transport port in host byte order.
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Port(pub u16);
+
+/// IPv4 socket address.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SocketAddressV4 {
+    /// IPv4 address.
+    pub address: Ipv4Address,
+    /// Transport port.
+    pub port: Port,
+}
+
+/// Flags for a send operation.
+///
+/// Send and receive flags are separate types because their underlying flag sets
+/// are disjoint: a receive-only flag such as [`ReceiveFlags::PEEK`] is
+/// meaningless on a send, and one shared type would let a local endpoint name it
+/// there.
+///
+/// Like [`ReceiveFlags`] and unlike [`ReadinessFlags`], which preserves bits a
+/// peer may not understand, this is bounded: flags are forwarded to a host
+/// socket operation, so a bit the broker does not recognize must never reach
+/// one. [`Self::SUPPORTED`] defines the bound as part of the ABI, and the broker
+/// rejects anything outside it rather than masking it away, which would silently
+/// perform an operation the caller did not ask for.
+///
+/// No send flag is supported yet, so any nonzero value is rejected.
+///
+/// [`ReadinessFlags`]: crate::readiness::ReadinessFlags
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct SendFlags(pub u32);
+
+impl SendFlags {
+    /// No flags.
+    pub const NONE: Self = Self(0);
+
+    /// Every send flag this protocol version defines.
+    pub const SUPPORTED: Self = Self(0);
+
+    /// Returns whether any bit outside [`Self::SUPPORTED`] is set.
+    #[must_use]
+    pub const fn has_unsupported_bits(self) -> bool {
+        self.0 & !Self::SUPPORTED.0 != 0
+    }
+}
+
+/// Flags for a receive operation.
+///
+/// See [`SendFlags`] for why the two directions are separate types and why both
+/// are bounded rather than passthrough.
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ReceiveFlags(pub u32);
+
+impl ReceiveFlags {
+    /// No flags.
+    pub const NONE: Self = Self(0);
+    /// Return data without consuming it.
+    pub const PEEK: Self = Self(1 << 0);
+
+    /// Every receive flag this protocol version defines.
+    pub const SUPPORTED: Self = Self(Self::PEEK.0);
+
+    /// Returns whether any bit outside [`Self::SUPPORTED`] is set.
+    #[must_use]
+    pub const fn has_unsupported_bits(self) -> bool {
+        self.0 & !Self::SUPPORTED.0 != 0
+    }
+
+    /// Returns whether every flag in `other` is set.
+    #[must_use]
+    pub const fn contains(self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
+
+/// Reason a socket connection failed.
+///
+/// This is a bounded restatement of the connection-level failures a host stack
+/// reports, kept separate from [`ErrorCode`] because those describe how the
+/// broker handled a request, not what a remote peer or network did. Keeping
+/// them apart also means adding a network failure never widens the error type
+/// every broker operation can return.
+///
+/// [`ErrorCode`]: crate::error::ErrorCode
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SocketError {
+    /// The peer refused the connection.
+    ConnectionRefused,
+    /// The connection was reset by the peer.
+    ConnectionReset,
+    /// The connection was aborted before it completed.
+    ConnectionAborted,
+    /// No route to the network.
+    NetworkUnreachable,
+    /// No route to the host.
+    HostUnreachable,
+    /// The connection attempt timed out.
+    TimedOut,
+    /// The address is already in use.
+    AddressInUse,
+    /// The address is not available on this host.
+    AddressNotAvailable,
+    /// The policy engine refused the destination.
+    PolicyDenied,
+    /// The host stack failed in a way this protocol does not distinguish.
+    Other,
+}
+
+/// Request to create a broker-owned socket.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CreateSocketRequest {
+    /// Address family.
+    pub address_family: AddressFamily,
+    /// Communication semantics.
+    pub socket_type: SocketType,
+    /// Transport protocol.
+    pub protocol: IpProtocol,
+}
+
+/// Response to a socket create request.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CreateSocketResponse {
+    /// Handle naming the new socket.
+    pub handle: ObjectHandle,
+}
+
+/// Request to connect a socket to a remote address.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ConnectSocketRequest {
+    /// Socket handle.
+    pub handle: ObjectHandle,
+    /// Remote address to connect to.
+    pub address: SocketAddressV4,
+}
+
+/// Response to a socket connect request.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ConnectSocketResponse {
+    /// Whether the connection completed or is still in progress.
+    pub status: ConnectStatus,
+}
+
+/// Outcome of a connect attempt.
+///
+/// The broker only performs non-blocking operations, so a connect that cannot
+/// complete immediately reports [`Self::InProgress`] rather than waiting. The
+/// caller waits for write readiness and then reads the outcome with a status
+/// request, which is the only way a failed connect is reported.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ConnectStatus {
+    /// The connection is established.
+    Connected,
+    /// The connection is still being established.
+    InProgress,
+}
+
+/// Request to send bytes staged in shared memory.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SendSocketRequest {
+    /// Socket handle.
+    pub handle: ObjectHandle,
+    /// Leased shared-buffer region containing the staged bytes.
+    pub buffer: SharedBufferDescriptor,
+    /// Send flags.
+    pub flags: SendFlags,
+}
+
+/// Response describing a completed send.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SendSocketResponse {
+    /// Number of bytes accepted by the socket.
+    pub sent: u32,
+}
+
+/// Request to receive bytes into shared memory.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ReceiveSocketRequest {
+    /// Socket handle.
+    pub handle: ObjectHandle,
+    /// Leased shared-buffer region to receive the bytes.
+    pub buffer: SharedBufferDescriptor,
+    /// Receive flags.
+    pub flags: ReceiveFlags,
+}
+
+/// Response describing bytes received into shared memory.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ReceiveSocketResponse {
+    /// Number of bytes placed in the receive region.
+    ///
+    /// Zero means the peer closed its write side; a socket with nothing to read
+    /// yet reports [`ErrorCode::WouldBlock`] instead.
+    ///
+    /// [`ErrorCode::WouldBlock`]: crate::error::ErrorCode::WouldBlock
+    pub received: u32,
+}
+
+/// Request to shut down one or both directions of a socket.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ShutdownSocketRequest {
+    /// Socket handle.
+    pub handle: ObjectHandle,
+    /// Directions to shut down.
+    pub mode: ShutdownMode,
+}
+
+/// Request for a socket's pending connection outcome.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SocketStatusRequest {
+    /// Socket handle.
+    pub handle: ObjectHandle,
+}
+
+/// Response describing a socket's pending connection outcome.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SocketStatusResponse {
+    /// The failure the socket recorded, if any.
+    ///
+    /// Reading the status clears it, so each failure is reported once.
+    pub error: Option<SocketError>,
+}

--- a/litebox_broker_protocol/src/wire.rs
+++ b/litebox_broker_protocol/src/wire.rs
@@ -30,12 +30,14 @@ use primitive::{Decoder, Encoder};
 mod event;
 mod pipe;
 mod primitive;
+mod socket;
 
 const REQUEST_TAG_NEGOTIATE: u8 = 0;
 const REQUEST_TAG_EVENT: u8 = 1;
 const REQUEST_TAG_CLOSE_OBJECT: u8 = 2;
 const REQUEST_TAG_PIPE: u8 = 3;
 const REQUEST_TAG_CHECK_READINESS: u8 = 4;
+const REQUEST_TAG_SOCKET: u8 = 5;
 
 const RESPONSE_TAG_NEGOTIATED: u8 = 0;
 const RESPONSE_TAG_EVENT: u8 = 1;
@@ -45,11 +47,12 @@ const RESPONSE_TAG_OBJECT_CLOSED: u8 = 4;
 const RESPONSE_TAG_PIPE: u8 = 5;
 const RESPONSE_TAG_READINESS: u8 = 6;
 const RESPONSE_TAG_ERROR: u8 = 7;
+const RESPONSE_TAG_SOCKET: u8 = 8;
 
 const NOTIFICATION_TAG_READINESS: u8 = 0;
 
 /// Maximum byte length of any encoded active request or response.
-pub const MAX_ENCODED_ACTIVE_MESSAGE_SIZE: usize = 26;
+pub const MAX_ENCODED_ACTIVE_MESSAGE_SIZE: usize = 30;
 
 /// Maximum byte length of any encoded broker notification.
 pub const MAX_ENCODED_NOTIFICATION_SIZE: usize = 13;
@@ -92,7 +95,8 @@ pub fn decode_handshake_request(frame: &[u8]) -> Result<BrokerHandshakeRequest, 
         REQUEST_TAG_EVENT
         | REQUEST_TAG_CLOSE_OBJECT
         | REQUEST_TAG_PIPE
-        | REQUEST_TAG_CHECK_READINESS => {
+        | REQUEST_TAG_CHECK_READINESS
+        | REQUEST_TAG_SOCKET => {
             return Err(WireError::WrongMessagePhase);
         }
         _ => return Err(WireError::InvalidTag),
@@ -132,6 +136,11 @@ pub fn encode_request(request: BrokerRequest) -> Vec<u8> {
             encoder.request_id(request_id);
             pipe::encode_pipe_request(&mut encoder, request);
         }
+        BrokerOperation::Socket(request) => {
+            encoder.u8(REQUEST_TAG_SOCKET);
+            encoder.request_id(request_id);
+            socket::encode_socket_request(&mut encoder, request);
+        }
     }
     encoder.finish()
 }
@@ -145,7 +154,8 @@ pub fn decode_request(frame: &[u8]) -> Result<BrokerRequest, WireError> {
         REQUEST_TAG_CLOSE_OBJECT
         | REQUEST_TAG_CHECK_READINESS
         | REQUEST_TAG_EVENT
-        | REQUEST_TAG_PIPE => {}
+        | REQUEST_TAG_PIPE
+        | REQUEST_TAG_SOCKET => {}
         _ => return Err(WireError::InvalidTag),
     }
     let request_id = decoder.request_id()?;
@@ -154,6 +164,7 @@ pub fn decode_request(frame: &[u8]) -> Result<BrokerRequest, WireError> {
         REQUEST_TAG_CHECK_READINESS => BrokerOperation::CheckReadiness(decoder.handle()?),
         REQUEST_TAG_EVENT => BrokerOperation::Event(event::decode_event_request(&mut decoder)?),
         REQUEST_TAG_PIPE => BrokerOperation::Pipe(pipe::decode_pipe_request(&mut decoder)?),
+        REQUEST_TAG_SOCKET => BrokerOperation::Socket(socket::decode_socket_request(&mut decoder)?),
         _ => unreachable!("active request tag was validated"),
     };
     decoder.finish()?;
@@ -202,7 +213,8 @@ pub fn decode_handshake_response(frame: &[u8]) -> Result<BrokerHandshakeResponse
         | RESPONSE_TAG_OBJECT_CLOSED
         | RESPONSE_TAG_PIPE
         | RESPONSE_TAG_READINESS
-        | RESPONSE_TAG_ERROR => {
+        | RESPONSE_TAG_ERROR
+        | RESPONSE_TAG_SOCKET => {
             return Err(WireError::WrongMessagePhase);
         }
         RESPONSE_TAG_VERSION_MISMATCH => BrokerHandshakeResponse::VersionMismatch {
@@ -245,6 +257,11 @@ pub fn encode_response(response: BrokerResponse) -> Vec<u8> {
             encoder.request_id(request_id);
             pipe::encode_pipe_response(&mut encoder, response);
         }
+        BrokerResult::Socket(response) => {
+            encoder.u8(RESPONSE_TAG_SOCKET);
+            encoder.request_id(request_id);
+            socket::encode_socket_response(&mut encoder, response);
+        }
         BrokerResult::Error(error) => {
             encoder.u8(RESPONSE_TAG_ERROR);
             encoder.request_id(request_id);
@@ -266,13 +283,15 @@ pub fn decode_response(frame: &[u8]) -> Result<BrokerResponse, WireError> {
         | RESPONSE_TAG_OBJECT_CLOSED
         | RESPONSE_TAG_PIPE
         | RESPONSE_TAG_READINESS
-        | RESPONSE_TAG_ERROR => {}
+        | RESPONSE_TAG_ERROR
+        | RESPONSE_TAG_SOCKET => {}
         _ => return Err(WireError::InvalidTag),
     }
     let request_id = decoder.request_id()?;
     let result = match tag {
         RESPONSE_TAG_EVENT => BrokerResult::Event(event::decode_event_response(&mut decoder)?),
         RESPONSE_TAG_PIPE => BrokerResult::Pipe(pipe::decode_pipe_response(&mut decoder)?),
+        RESPONSE_TAG_SOCKET => BrokerResult::Socket(socket::decode_socket_response(&mut decoder)?),
         RESPONSE_TAG_ERROR => {
             let error = ErrorCode::from_raw(decoder.u16()?).ok_or(WireError::InvalidTag)?;
             BrokerResult::Error(error)
@@ -323,12 +342,21 @@ mod tests {
         AddEventRequest, AddEventResponse, ConsumeEventRequest, CreateEventRequest,
         CreateEventResponse, EventConsumeMode, EventConsumption,
     };
-    use crate::message::{EventRequest, EventResponse, PipeRequest, PipeResponse};
+    use crate::message::{
+        EventRequest, EventResponse, PipeRequest, PipeResponse, SocketRequest, SocketResponse,
+    };
     use crate::pipe::{
         CreatePipeRequest, CreatePipeResponse, ReadPipeRequest, ReadPipeResponse, WritePipeRequest,
         WritePipeResponse,
     };
     use crate::shared_memory::{SharedBufferDescriptor, SharedBufferSlotIndex};
+    use crate::socket::{
+        AddressFamily, ConnectSocketRequest, ConnectSocketResponse, ConnectStatus,
+        CreateSocketRequest, CreateSocketResponse, IpProtocol, Ipv4Address, Port, ReceiveFlags,
+        ReceiveSocketRequest, ReceiveSocketResponse, SendFlags, SendSocketRequest,
+        SendSocketResponse, ShutdownMode, ShutdownSocketRequest, SocketAddressV4, SocketError,
+        SocketStatusRequest, SocketStatusResponse, SocketType,
+    };
     use crate::{ObjectHandle, ProtocolVersion, RequestId};
 
     const TEST_REQUEST_ID: RequestId = RequestId(0x0102_0304_0506_0708);
@@ -386,6 +414,47 @@ mod tests {
                     length: 3,
                 },
             })),
+            BrokerOperation::Socket(SocketRequest::Create(CreateSocketRequest {
+                address_family: AddressFamily::Ipv4,
+                socket_type: SocketType::Stream,
+                protocol: IpProtocol::Tcp,
+            })),
+            BrokerOperation::Socket(SocketRequest::Connect(ConnectSocketRequest {
+                handle,
+                address: SocketAddressV4 {
+                    address: Ipv4Address([203, 0, 113, 7]),
+                    port: Port(443),
+                },
+            })),
+            BrokerOperation::Socket(SocketRequest::Send(SendSocketRequest {
+                handle,
+                buffer: SharedBufferDescriptor {
+                    slot_index: SharedBufferSlotIndex(15),
+                    length: 3,
+                },
+                flags: SendFlags::NONE,
+            })),
+            BrokerOperation::Socket(SocketRequest::Receive(ReceiveSocketRequest {
+                handle,
+                buffer: SharedBufferDescriptor {
+                    slot_index: SharedBufferSlotIndex(15),
+                    length: 3,
+                },
+                flags: ReceiveFlags::PEEK,
+            })),
+            BrokerOperation::Socket(SocketRequest::Shutdown(ShutdownSocketRequest {
+                handle,
+                mode: ShutdownMode::Read,
+            })),
+            BrokerOperation::Socket(SocketRequest::Shutdown(ShutdownSocketRequest {
+                handle,
+                mode: ShutdownMode::Write,
+            })),
+            BrokerOperation::Socket(SocketRequest::Shutdown(ShutdownSocketRequest {
+                handle,
+                mode: ShutdownMode::Both,
+            })),
+            BrokerOperation::Socket(SocketRequest::Status(SocketStatusRequest { handle })),
         ];
         let mut maximum_encoded_size = 0;
 
@@ -398,8 +467,85 @@ mod tests {
             maximum_encoded_size = maximum_encoded_size.max(encoded.len());
             assert!(encoded.len() <= MAX_ENCODED_ACTIVE_MESSAGE_SIZE);
             assert_eq!(decode_request(&encoded).unwrap(), request);
+            // Every active tag must be reported as a phase violation during
+            // the handshake, not as an unknown tag: only the former is turned
+            // into a clean protocol-violation shutdown by the transport.
+            assert_eq!(
+                decode_handshake_request(&encoded),
+                Err(WireError::WrongMessagePhase)
+            );
         }
         assert_eq!(maximum_encoded_size, MAX_ENCODED_ACTIVE_MESSAGE_SIZE);
+    }
+
+    #[test]
+    fn flag_bits_round_trip_unmasked() {
+        // The codec carries flags verbatim so the core can reject unsupported
+        // bits; masking them here would hide them from that check, and a
+        // dropped field would make an unsupported flag look like none at all.
+        let handle = ObjectHandle(13);
+        let buffer = SharedBufferDescriptor {
+            slot_index: SharedBufferSlotIndex(15),
+            length: 3,
+        };
+        let unsupported = 0x8000_0001;
+        for operation in [
+            BrokerOperation::Socket(SocketRequest::Send(SendSocketRequest {
+                handle,
+                buffer,
+                flags: SendFlags(unsupported),
+            })),
+            BrokerOperation::Socket(SocketRequest::Receive(ReceiveSocketRequest {
+                handle,
+                buffer,
+                flags: ReceiveFlags(unsupported),
+            })),
+        ] {
+            let request = BrokerRequest {
+                request_id: TEST_REQUEST_ID,
+                operation,
+            };
+            assert_eq!(
+                decode_request(&encode_request(request.clone())).unwrap(),
+                request
+            );
+        }
+
+        assert!(SendFlags(unsupported).has_unsupported_bits());
+        assert!(ReceiveFlags(unsupported).has_unsupported_bits());
+        // No send flag exists yet, so every bit is unsupported there.
+        assert!(SendFlags(ReceiveFlags::PEEK.0).has_unsupported_bits());
+        assert!(!SendFlags::NONE.has_unsupported_bits());
+        assert!(!ReceiveFlags::PEEK.has_unsupported_bits());
+        assert!(ReceiveFlags::PEEK.contains(ReceiveFlags::PEEK));
+        assert!(!ReceiveFlags::NONE.contains(ReceiveFlags::PEEK));
+    }
+
+    #[test]
+    fn socket_error_codec_round_trips_all_variants() {
+        for error in [
+            SocketError::ConnectionRefused,
+            SocketError::ConnectionReset,
+            SocketError::ConnectionAborted,
+            SocketError::NetworkUnreachable,
+            SocketError::HostUnreachable,
+            SocketError::TimedOut,
+            SocketError::AddressInUse,
+            SocketError::AddressNotAvailable,
+            SocketError::PolicyDenied,
+            SocketError::Other,
+        ] {
+            let response = BrokerResponse {
+                request_id: TEST_REQUEST_ID,
+                result: BrokerResult::Socket(SocketResponse::Status(SocketStatusResponse {
+                    error: Some(error),
+                })),
+            };
+            assert_eq!(
+                decode_response(&encode_response(response.clone())).unwrap(),
+                response
+            );
+        }
     }
 
     #[test]
@@ -458,6 +604,22 @@ mod tests {
             })),
             BrokerResult::Pipe(PipeResponse::Read(ReadPipeResponse { read: 3 })),
             BrokerResult::Pipe(PipeResponse::Write(WritePipeResponse { written: 3 })),
+            BrokerResult::Socket(SocketResponse::Create(CreateSocketResponse { handle })),
+            BrokerResult::Socket(SocketResponse::Connect(ConnectSocketResponse {
+                status: ConnectStatus::Connected,
+            })),
+            BrokerResult::Socket(SocketResponse::Connect(ConnectSocketResponse {
+                status: ConnectStatus::InProgress,
+            })),
+            BrokerResult::Socket(SocketResponse::Send(SendSocketResponse { sent: 3 })),
+            BrokerResult::Socket(SocketResponse::Receive(ReceiveSocketResponse {
+                received: 3,
+            })),
+            BrokerResult::Socket(SocketResponse::Shutdown),
+            BrokerResult::Socket(SocketResponse::Status(SocketStatusResponse { error: None })),
+            BrokerResult::Socket(SocketResponse::Status(SocketStatusResponse {
+                error: Some(SocketError::ConnectionRefused),
+            })),
             BrokerResult::Error(ErrorCode::PolicyDenied),
             BrokerResult::Error(ErrorCode::WouldBlock),
             BrokerResult::Error(ErrorCode::PeerClosed),
@@ -475,8 +637,14 @@ mod tests {
             maximum_encoded_size = maximum_encoded_size.max(encoded.len());
             assert!(encoded.len() <= MAX_ENCODED_ACTIVE_MESSAGE_SIZE);
             assert_eq!(decode_response(&encoded).unwrap(), response);
+            assert_eq!(
+                decode_handshake_response(&encoded),
+                Err(WireError::WrongMessagePhase)
+            );
         }
-        assert_eq!(maximum_encoded_size, MAX_ENCODED_ACTIVE_MESSAGE_SIZE);
+        // Requests bind the shared limit, so responses only have to fit under
+        // it. The request test asserts the limit is reached and therefore tight.
+        assert!(maximum_encoded_size <= MAX_ENCODED_ACTIVE_MESSAGE_SIZE);
     }
 
     #[test]
@@ -580,6 +748,144 @@ mod tests {
         });
         frame.push(0xff);
         assert_eq!(decode_request(&frame), Err(WireError::TrailingBytes));
+    }
+
+    #[test]
+    fn decode_rejects_malformed_socket_request_frames() {
+        let mut unknown_operation = Vec::from([REQUEST_TAG_SOCKET]);
+        unknown_operation.extend_from_slice(&TEST_REQUEST_ID.0.to_le_bytes());
+        unknown_operation.push(0xff);
+        assert_eq!(
+            decode_request(&unknown_operation),
+            Err(WireError::InvalidTag)
+        );
+
+        // A socket envelope carrying no family tag at all.
+        assert_eq!(
+            decode_request(&unknown_operation[..unknown_operation.len() - 1]),
+            Err(WireError::TruncatedFrame)
+        );
+
+        // Address family, type, and protocol are the last three bytes of a
+        // create frame, so each unknown tag is rejected on its own.
+        let create = encode_request(BrokerRequest {
+            request_id: TEST_REQUEST_ID,
+            operation: BrokerOperation::Socket(SocketRequest::Create(CreateSocketRequest {
+                address_family: AddressFamily::Ipv4,
+                socket_type: SocketType::Stream,
+                protocol: IpProtocol::Tcp,
+            })),
+        });
+        for offset in 1..=3 {
+            let mut frame = create.clone();
+            let index = frame.len() - offset;
+            frame[index] = 0xff;
+            assert_eq!(decode_request(&frame), Err(WireError::InvalidTag));
+        }
+        assert_eq!(
+            decode_request(&create[..create.len() - 1]),
+            Err(WireError::TruncatedFrame)
+        );
+
+        let mut unknown_shutdown_mode = encode_request(BrokerRequest {
+            request_id: TEST_REQUEST_ID,
+            operation: BrokerOperation::Socket(SocketRequest::Shutdown(ShutdownSocketRequest {
+                handle: ObjectHandle(9),
+                mode: ShutdownMode::Both,
+            })),
+        });
+        *unknown_shutdown_mode.last_mut().unwrap() = 0xff;
+        assert_eq!(
+            decode_request(&unknown_shutdown_mode),
+            Err(WireError::InvalidTag)
+        );
+
+        let connect = encode_request(BrokerRequest {
+            request_id: TEST_REQUEST_ID,
+            operation: BrokerOperation::Socket(SocketRequest::Connect(ConnectSocketRequest {
+                handle: ObjectHandle(9),
+                address: SocketAddressV4 {
+                    address: Ipv4Address([203, 0, 113, 7]),
+                    port: Port(443),
+                },
+            })),
+        });
+        assert_eq!(
+            decode_request(&connect[..connect.len() - 1]),
+            Err(WireError::TruncatedFrame)
+        );
+
+        let mut trailing = connect;
+        trailing.push(0);
+        assert_eq!(decode_request(&trailing), Err(WireError::TrailingBytes));
+    }
+
+    #[test]
+    fn decode_rejects_malformed_socket_response_frames() {
+        let mut unknown_response = Vec::from([RESPONSE_TAG_SOCKET]);
+        unknown_response.extend_from_slice(&TEST_REQUEST_ID.0.to_le_bytes());
+        unknown_response.push(0xff);
+        assert_eq!(
+            decode_response(&unknown_response),
+            Err(WireError::InvalidTag)
+        );
+        assert_eq!(
+            decode_response(&unknown_response[..unknown_response.len() - 1]),
+            Err(WireError::TruncatedFrame)
+        );
+
+        let mut unknown_connect_status = encode_response(BrokerResponse {
+            request_id: TEST_REQUEST_ID,
+            result: BrokerResult::Socket(SocketResponse::Connect(ConnectSocketResponse {
+                status: ConnectStatus::InProgress,
+            })),
+        });
+        *unknown_connect_status.last_mut().unwrap() = 0xff;
+        assert_eq!(
+            decode_response(&unknown_connect_status),
+            Err(WireError::InvalidTag)
+        );
+
+        // The status response encodes presence and, when present, the error
+        // itself, so both tags reject unknown values.
+        let mut unknown_status_presence = encode_response(BrokerResponse {
+            request_id: TEST_REQUEST_ID,
+            result: BrokerResult::Socket(SocketResponse::Status(SocketStatusResponse {
+                error: None,
+            })),
+        });
+        *unknown_status_presence.last_mut().unwrap() = 0xff;
+        assert_eq!(
+            decode_response(&unknown_status_presence),
+            Err(WireError::InvalidTag)
+        );
+
+        let mut unknown_socket_error = encode_response(BrokerResponse {
+            request_id: TEST_REQUEST_ID,
+            result: BrokerResult::Socket(SocketResponse::Status(SocketStatusResponse {
+                error: Some(SocketError::TimedOut),
+            })),
+        });
+        *unknown_socket_error.last_mut().unwrap() = 0xff;
+        assert_eq!(
+            decode_response(&unknown_socket_error),
+            Err(WireError::InvalidTag)
+        );
+        assert_eq!(
+            decode_response(&unknown_socket_error[..unknown_socket_error.len() - 1]),
+            Err(WireError::TruncatedFrame)
+        );
+
+        let received = encode_response(BrokerResponse {
+            request_id: TEST_REQUEST_ID,
+            result: BrokerResult::Socket(SocketResponse::Receive(ReceiveSocketResponse {
+                received: 4096,
+            })),
+        });
+        assert_eq!(
+            decode_response(&received[..received.len() - 1]),
+            Err(WireError::TruncatedFrame)
+        );
     }
 
     #[test]
@@ -716,6 +1022,25 @@ mod tests {
                 })),
             }),
             [1, 13, 0, 0, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0]
+        );
+    }
+
+    #[test]
+    fn socket_connect_request_wire_shape_is_pinned() {
+        assert_eq!(
+            encode_request(BrokerRequest {
+                request_id: RequestId(13),
+                operation: BrokerOperation::Socket(SocketRequest::Connect(ConnectSocketRequest {
+                    handle: ObjectHandle(9),
+                    address: SocketAddressV4 {
+                        address: Ipv4Address([203, 0, 113, 7]),
+                        port: Port(443),
+                    },
+                })),
+            }),
+            [
+                5, 13, 0, 0, 0, 0, 0, 0, 0, 1, 9, 0, 0, 0, 0, 0, 0, 0, 203, 0, 113, 7, 187, 1
+            ]
         );
     }
 

--- a/litebox_broker_protocol/src/wire/socket.rs
+++ b/litebox_broker_protocol/src/wire/socket.rs
@@ -1,0 +1,271 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+use crate::message::{SocketRequest, SocketResponse};
+use crate::shared_memory::{SharedBufferDescriptor, SharedBufferSlotIndex};
+use crate::socket::{
+    AddressFamily, ConnectSocketRequest, ConnectSocketResponse, ConnectStatus, CreateSocketRequest,
+    CreateSocketResponse, IpProtocol, Ipv4Address, Port, ReceiveFlags, ReceiveSocketRequest,
+    ReceiveSocketResponse, SendFlags, SendSocketRequest, SendSocketResponse, ShutdownMode,
+    ShutdownSocketRequest, SocketAddressV4, SocketError, SocketStatusRequest, SocketStatusResponse,
+    SocketType,
+};
+
+use super::WireError;
+use super::primitive::{Decoder, Encoder};
+
+const SOCKET_REQUEST_TAG_CREATE: u8 = 0;
+const SOCKET_REQUEST_TAG_CONNECT: u8 = 1;
+const SOCKET_REQUEST_TAG_SEND: u8 = 2;
+const SOCKET_REQUEST_TAG_RECEIVE: u8 = 3;
+const SOCKET_REQUEST_TAG_SHUTDOWN: u8 = 4;
+const SOCKET_REQUEST_TAG_STATUS: u8 = 5;
+
+const SOCKET_RESPONSE_TAG_CREATED: u8 = 0;
+const SOCKET_RESPONSE_TAG_CONNECT: u8 = 1;
+const SOCKET_RESPONSE_TAG_SENT: u8 = 2;
+const SOCKET_RESPONSE_TAG_RECEIVED: u8 = 3;
+const SOCKET_RESPONSE_TAG_SHUTDOWN: u8 = 4;
+const SOCKET_RESPONSE_TAG_STATUS: u8 = 5;
+
+const ADDRESS_FAMILY_TAG_IPV4: u8 = 0;
+
+const TYPE_TAG_STREAM: u8 = 0;
+
+const IP_PROTOCOL_TAG_TCP: u8 = 0;
+
+const SHUTDOWN_TAG_READ: u8 = 0;
+const SHUTDOWN_TAG_WRITE: u8 = 1;
+const SHUTDOWN_TAG_BOTH: u8 = 2;
+
+const CONNECT_TAG_CONNECTED: u8 = 0;
+const CONNECT_TAG_IN_PROGRESS: u8 = 1;
+
+const STATUS_TAG_OK: u8 = 0;
+const STATUS_TAG_ERROR: u8 = 1;
+
+const SOCKET_ERROR_TAG_CONNECTION_REFUSED: u8 = 0;
+const SOCKET_ERROR_TAG_CONNECTION_RESET: u8 = 1;
+const SOCKET_ERROR_TAG_CONNECTION_ABORTED: u8 = 2;
+const SOCKET_ERROR_TAG_NETWORK_UNREACHABLE: u8 = 3;
+const SOCKET_ERROR_TAG_HOST_UNREACHABLE: u8 = 4;
+const SOCKET_ERROR_TAG_TIMED_OUT: u8 = 5;
+const SOCKET_ERROR_TAG_ADDRESS_IN_USE: u8 = 6;
+const SOCKET_ERROR_TAG_ADDRESS_NOT_AVAILABLE: u8 = 7;
+const SOCKET_ERROR_TAG_POLICY_DENIED: u8 = 8;
+const SOCKET_ERROR_TAG_OTHER: u8 = 9;
+
+pub(super) fn encode_socket_request(encoder: &mut Encoder, request: SocketRequest) {
+    match request {
+        SocketRequest::Create(request) => {
+            encoder.u8(SOCKET_REQUEST_TAG_CREATE);
+            encoder.u8(match request.address_family {
+                AddressFamily::Ipv4 => ADDRESS_FAMILY_TAG_IPV4,
+            });
+            encoder.u8(match request.socket_type {
+                SocketType::Stream => TYPE_TAG_STREAM,
+            });
+            encoder.u8(match request.protocol {
+                IpProtocol::Tcp => IP_PROTOCOL_TAG_TCP,
+            });
+        }
+        SocketRequest::Connect(request) => {
+            encoder.u8(SOCKET_REQUEST_TAG_CONNECT);
+            encoder.handle(request.handle);
+            encode_address(encoder, request.address);
+        }
+        SocketRequest::Send(request) => {
+            encoder.u8(SOCKET_REQUEST_TAG_SEND);
+            encoder.handle(request.handle);
+            encode_shared_buffer_descriptor(encoder, request.buffer);
+            encoder.u32(request.flags.0);
+        }
+        SocketRequest::Receive(request) => {
+            encoder.u8(SOCKET_REQUEST_TAG_RECEIVE);
+            encoder.handle(request.handle);
+            encode_shared_buffer_descriptor(encoder, request.buffer);
+            encoder.u32(request.flags.0);
+        }
+        SocketRequest::Shutdown(request) => {
+            encoder.u8(SOCKET_REQUEST_TAG_SHUTDOWN);
+            encoder.handle(request.handle);
+            encoder.u8(match request.mode {
+                ShutdownMode::Read => SHUTDOWN_TAG_READ,
+                ShutdownMode::Write => SHUTDOWN_TAG_WRITE,
+                ShutdownMode::Both => SHUTDOWN_TAG_BOTH,
+            });
+        }
+        SocketRequest::Status(request) => {
+            encoder.u8(SOCKET_REQUEST_TAG_STATUS);
+            encoder.handle(request.handle);
+        }
+    }
+}
+
+pub(super) fn decode_socket_request(decoder: &mut Decoder<'_>) -> Result<SocketRequest, WireError> {
+    match decoder.u8()? {
+        SOCKET_REQUEST_TAG_CREATE => Ok(SocketRequest::Create(CreateSocketRequest {
+            address_family: match decoder.u8()? {
+                ADDRESS_FAMILY_TAG_IPV4 => AddressFamily::Ipv4,
+                _ => return Err(WireError::InvalidTag),
+            },
+            socket_type: match decoder.u8()? {
+                TYPE_TAG_STREAM => SocketType::Stream,
+                _ => return Err(WireError::InvalidTag),
+            },
+            protocol: match decoder.u8()? {
+                IP_PROTOCOL_TAG_TCP => IpProtocol::Tcp,
+                _ => return Err(WireError::InvalidTag),
+            },
+        })),
+        SOCKET_REQUEST_TAG_CONNECT => Ok(SocketRequest::Connect(ConnectSocketRequest {
+            handle: decoder.handle()?,
+            address: decode_address(decoder)?,
+        })),
+        SOCKET_REQUEST_TAG_SEND => Ok(SocketRequest::Send(SendSocketRequest {
+            handle: decoder.handle()?,
+            buffer: decode_shared_buffer_descriptor(decoder)?,
+            flags: SendFlags(decoder.u32()?),
+        })),
+        SOCKET_REQUEST_TAG_RECEIVE => Ok(SocketRequest::Receive(ReceiveSocketRequest {
+            handle: decoder.handle()?,
+            buffer: decode_shared_buffer_descriptor(decoder)?,
+            flags: ReceiveFlags(decoder.u32()?),
+        })),
+        SOCKET_REQUEST_TAG_SHUTDOWN => Ok(SocketRequest::Shutdown(ShutdownSocketRequest {
+            handle: decoder.handle()?,
+            mode: match decoder.u8()? {
+                SHUTDOWN_TAG_READ => ShutdownMode::Read,
+                SHUTDOWN_TAG_WRITE => ShutdownMode::Write,
+                SHUTDOWN_TAG_BOTH => ShutdownMode::Both,
+                _ => return Err(WireError::InvalidTag),
+            },
+        })),
+        SOCKET_REQUEST_TAG_STATUS => Ok(SocketRequest::Status(SocketStatusRequest {
+            handle: decoder.handle()?,
+        })),
+        _ => Err(WireError::InvalidTag),
+    }
+}
+
+pub(super) fn encode_socket_response(encoder: &mut Encoder, response: SocketResponse) {
+    match response {
+        SocketResponse::Create(response) => {
+            encoder.u8(SOCKET_RESPONSE_TAG_CREATED);
+            encoder.handle(response.handle);
+        }
+        SocketResponse::Connect(response) => {
+            encoder.u8(SOCKET_RESPONSE_TAG_CONNECT);
+            encoder.u8(match response.status {
+                ConnectStatus::Connected => CONNECT_TAG_CONNECTED,
+                ConnectStatus::InProgress => CONNECT_TAG_IN_PROGRESS,
+            });
+        }
+        SocketResponse::Send(response) => {
+            encoder.u8(SOCKET_RESPONSE_TAG_SENT);
+            encoder.u32(response.sent);
+        }
+        SocketResponse::Receive(response) => {
+            encoder.u8(SOCKET_RESPONSE_TAG_RECEIVED);
+            encoder.u32(response.received);
+        }
+        SocketResponse::Shutdown => encoder.u8(SOCKET_RESPONSE_TAG_SHUTDOWN),
+        SocketResponse::Status(response) => {
+            encoder.u8(SOCKET_RESPONSE_TAG_STATUS);
+            match response.error {
+                None => encoder.u8(STATUS_TAG_OK),
+                Some(error) => {
+                    encoder.u8(STATUS_TAG_ERROR);
+                    encoder.u8(match error {
+                        SocketError::ConnectionRefused => SOCKET_ERROR_TAG_CONNECTION_REFUSED,
+                        SocketError::ConnectionReset => SOCKET_ERROR_TAG_CONNECTION_RESET,
+                        SocketError::ConnectionAborted => SOCKET_ERROR_TAG_CONNECTION_ABORTED,
+                        SocketError::NetworkUnreachable => SOCKET_ERROR_TAG_NETWORK_UNREACHABLE,
+                        SocketError::HostUnreachable => SOCKET_ERROR_TAG_HOST_UNREACHABLE,
+                        SocketError::TimedOut => SOCKET_ERROR_TAG_TIMED_OUT,
+                        SocketError::AddressInUse => SOCKET_ERROR_TAG_ADDRESS_IN_USE,
+                        SocketError::AddressNotAvailable => SOCKET_ERROR_TAG_ADDRESS_NOT_AVAILABLE,
+                        SocketError::PolicyDenied => SOCKET_ERROR_TAG_POLICY_DENIED,
+                        SocketError::Other => SOCKET_ERROR_TAG_OTHER,
+                    });
+                }
+            }
+        }
+    }
+}
+
+pub(super) fn decode_socket_response(
+    decoder: &mut Decoder<'_>,
+) -> Result<SocketResponse, WireError> {
+    match decoder.u8()? {
+        SOCKET_RESPONSE_TAG_CREATED => Ok(SocketResponse::Create(CreateSocketResponse {
+            handle: decoder.handle()?,
+        })),
+        SOCKET_RESPONSE_TAG_CONNECT => Ok(SocketResponse::Connect(ConnectSocketResponse {
+            status: match decoder.u8()? {
+                CONNECT_TAG_CONNECTED => ConnectStatus::Connected,
+                CONNECT_TAG_IN_PROGRESS => ConnectStatus::InProgress,
+                _ => return Err(WireError::InvalidTag),
+            },
+        })),
+        SOCKET_RESPONSE_TAG_SENT => Ok(SocketResponse::Send(SendSocketResponse {
+            sent: decoder.u32()?,
+        })),
+        SOCKET_RESPONSE_TAG_RECEIVED => Ok(SocketResponse::Receive(ReceiveSocketResponse {
+            received: decoder.u32()?,
+        })),
+        SOCKET_RESPONSE_TAG_SHUTDOWN => Ok(SocketResponse::Shutdown),
+        SOCKET_RESPONSE_TAG_STATUS => Ok(SocketResponse::Status(SocketStatusResponse {
+            error: match decoder.u8()? {
+                STATUS_TAG_OK => None,
+                STATUS_TAG_ERROR => Some(match decoder.u8()? {
+                    SOCKET_ERROR_TAG_CONNECTION_REFUSED => SocketError::ConnectionRefused,
+                    SOCKET_ERROR_TAG_CONNECTION_RESET => SocketError::ConnectionReset,
+                    SOCKET_ERROR_TAG_CONNECTION_ABORTED => SocketError::ConnectionAborted,
+                    SOCKET_ERROR_TAG_NETWORK_UNREACHABLE => SocketError::NetworkUnreachable,
+                    SOCKET_ERROR_TAG_HOST_UNREACHABLE => SocketError::HostUnreachable,
+                    SOCKET_ERROR_TAG_TIMED_OUT => SocketError::TimedOut,
+                    SOCKET_ERROR_TAG_ADDRESS_IN_USE => SocketError::AddressInUse,
+                    SOCKET_ERROR_TAG_ADDRESS_NOT_AVAILABLE => SocketError::AddressNotAvailable,
+                    SOCKET_ERROR_TAG_POLICY_DENIED => SocketError::PolicyDenied,
+                    SOCKET_ERROR_TAG_OTHER => SocketError::Other,
+                    _ => return Err(WireError::InvalidTag),
+                }),
+                _ => return Err(WireError::InvalidTag),
+            },
+        })),
+        _ => Err(WireError::InvalidTag),
+    }
+}
+
+fn encode_address(encoder: &mut Encoder, address: SocketAddressV4) {
+    for octet in address.address.0 {
+        encoder.u8(octet);
+    }
+    encoder.u16(address.port.0);
+}
+
+fn decode_address(decoder: &mut Decoder<'_>) -> Result<SocketAddressV4, WireError> {
+    let mut octets = [0; 4];
+    for octet in &mut octets {
+        *octet = decoder.u8()?;
+    }
+    Ok(SocketAddressV4 {
+        address: Ipv4Address(octets),
+        port: Port(decoder.u16()?),
+    })
+}
+
+fn encode_shared_buffer_descriptor(encoder: &mut Encoder, descriptor: SharedBufferDescriptor) {
+    encoder.u32(descriptor.slot_index.0);
+    encoder.u32(descriptor.length);
+}
+
+fn decode_shared_buffer_descriptor(
+    decoder: &mut Decoder<'_>,
+) -> Result<SharedBufferDescriptor, WireError> {
+    Ok(SharedBufferDescriptor {
+        slot_index: SharedBufferSlotIndex(decoder.u32()?),
+        length: decoder.u32()?,
+    })
+}


### PR DESCRIPTION
Adds the socket message family to the broker protocol crate: typed address family, socket type, IP protocol, address, shutdown, and message-flag values, the six request and response pairs for create, connect, send, receive, shutdown, and status, and their wire codec. Send and receive carry shared-buffer descriptors rather than inline bytes, matching pipes, and every value is a closed set instead of a passthrough integer, so a local endpoint cannot name an address family, protocol, or flag the broker has not agreed to support. Send and receive flags are separate types because their flag sets are disjoint, so a receive-only flag such as `PEEK` cannot be named on a send. Connection failures use a separate `SocketError` rather than widening `ErrorCode`, because `ErrorCode` maps to a guest panic for codes a local endpoint should never see, while network failures are ordinary outcomes. Nothing serves these operations yet: the broker host answers a socket request with `UnsupportedOperation` until the core gains a socket object, which follows in the next change together with host-resource retirement.