### PR TITLE
Define broker socket contracts

### DIFF
--- a/litebox/src/broker/mod.rs
+++ b/litebox/src/broker/mod.rs
@@ -291,10 +291,10 @@ where
 
 pub(crate) fn readiness_events(readiness: ReadinessFlags) -> Events {
     let mut events = Events::empty();
-    events.set(Events::IN, readiness.0 & ReadinessFlags::READ.0 != 0);
-    events.set(Events::OUT, readiness.0 & ReadinessFlags::WRITE.0 != 0);
-    events.set(Events::HUP, readiness.0 & ReadinessFlags::HANGUP.0 != 0);
-    events.set(Events::ERR, readiness.0 & ReadinessFlags::ERROR.0 != 0);
+    events.set(Events::IN, readiness.contains(ReadinessFlags::READ));
+    events.set(Events::OUT, readiness.contains(ReadinessFlags::WRITE));
+    events.set(Events::HUP, readiness.contains(ReadinessFlags::HANGUP));
+    events.set(Events::ERR, readiness.contains(ReadinessFlags::ERROR));
     events
 }
 

--- a/litebox/src/event/counter.rs
+++ b/litebox/src/event/counter.rs
@@ -88,7 +88,7 @@ where
     ) -> Result<u64, TryOpError<EventCounterError>> {
         self.pollee.wait(cx, nonblock, Events::IN, || {
             let response = self.consume(mode)?;
-            if response.readiness.0 & ReadinessFlags::WRITE.0 != 0 {
+            if response.readiness.contains(ReadinessFlags::WRITE) {
                 self.pollee.notify_observers(Events::OUT);
             }
             Ok(response.value)
@@ -107,7 +107,7 @@ where
         }
         self.pollee.wait(cx, nonblock, Events::OUT, || {
             let readiness = self.add(value)?;
-            if value != 0 && readiness.0 & ReadinessFlags::READ.0 != 0 {
+            if value != 0 && readiness.contains(ReadinessFlags::READ) {
                 self.pollee.notify_observers(Events::IN);
             }
             Ok(core::mem::size_of::<u64>())

--- a/litebox/src/event/counter.rs
+++ b/litebox/src/event/counter.rs
@@ -485,7 +485,9 @@ mod tests {
                 BrokerOperation::CheckReadiness(_) => {
                     BrokerResult::Readiness(ReadinessFlags::WRITE)
                 }
-                request @ (BrokerOperation::Event(_) | BrokerOperation::Pipe(_)) => {
+                request @ (BrokerOperation::Event(_)
+                | BrokerOperation::Pipe(_)
+                | BrokerOperation::Socket(_)) => {
                     panic!("unexpected broker request: {request:?}")
                 }
             };

--- a/litebox/src/pipes.rs
+++ b/litebox/src/pipes.rs
@@ -1195,7 +1195,9 @@ mod tests {
                 BrokerOperation::CheckReadiness(_) => {
                     BrokerResult::Readiness(ReadinessFlags::default())
                 }
-                request @ (BrokerOperation::Pipe(_) | BrokerOperation::Event(_)) => {
+                request @ (BrokerOperation::Pipe(_)
+                | BrokerOperation::Event(_)
+                | BrokerOperation::Socket(_)) => {
                     panic!("unexpected broker request: {request:?}")
                 }
             };

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -28,7 +28,7 @@ use litebox_broker_protocol::error::ErrorCode;
 use litebox_broker_protocol::event::{AddEventResponse, CreateEventResponse};
 use litebox_broker_protocol::message::{
     BrokerHandshakeResponse, BrokerOperation, BrokerRequest, BrokerResponse, BrokerResult,
-    EventRequest, EventResponse, PipeRequest, PipeResponse,
+    EventRequest, EventResponse, PipeRequest, PipeResponse, SocketRequest,
 };
 use litebox_broker_protocol::pipe::{
     CreatePipeResponse, MAX_PIPE_TRANSFER_SIZE, ReadPipeResponse, WritePipeResponse,
@@ -84,10 +84,13 @@ impl<Memory: SharedMemory> BrokerHostAssociation<'_, Memory> {
         let buffer_descriptor = match &operation {
             BrokerOperation::Pipe(PipeRequest::Read(request)) => Some(request.buffer),
             BrokerOperation::Pipe(PipeRequest::Write(request)) => Some(request.buffer),
+            BrokerOperation::Socket(SocketRequest::Send(request)) => Some(request.buffer),
+            BrokerOperation::Socket(SocketRequest::Receive(request)) => Some(request.buffer),
             BrokerOperation::CloseObject(_)
             | BrokerOperation::CheckReadiness(_)
             | BrokerOperation::Event(_)
-            | BrokerOperation::Pipe(PipeRequest::Create(_)) => None,
+            | BrokerOperation::Pipe(PipeRequest::Create(_))
+            | BrokerOperation::Socket(_) => None,
         };
 
         {
@@ -300,6 +303,19 @@ fn handle_request<Memory: SharedMemory>(
         BrokerOperation::Pipe(request) => {
             handle_pipe_request(session, request, shared_buffers).map(BrokerResult::Pipe)
         }
+        // The socket protocol is defined before the broker implements it, so
+        // the operations decode and their shared-buffer leases are validated,
+        // but no socket object exists to act on one yet.
+        //
+        // `UnsupportedOperation` is deliberately in the local endpoint's fatal
+        // group alongside `MalformedRequest` and `ProtocolState`: it means the
+        // local sent an operation this broker never serves, which cannot happen
+        // unless the two sides disagree about the protocol. No local code
+        // constructs a socket request today, so this is unreachable; reporting
+        // a recoverable code instead would let a future wiring mistake look
+        // like an ordinary runtime failure rather than the contract violation
+        // it is.
+        BrokerOperation::Socket(_) => Err(RequestFailure::Respond(ErrorCode::UnsupportedOperation)),
     }
 }
 

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -90,7 +90,12 @@ impl<Memory: SharedMemory> BrokerHostAssociation<'_, Memory> {
             | BrokerOperation::CheckReadiness(_)
             | BrokerOperation::Event(_)
             | BrokerOperation::Pipe(PipeRequest::Create(_))
-            | BrokerOperation::Socket(_) => None,
+            | BrokerOperation::Socket(
+                SocketRequest::Create(_)
+                | SocketRequest::Connect(_)
+                | SocketRequest::Shutdown(_)
+                | SocketRequest::Status(_),
+            ) => None,
         };
 
         {

--- a/litebox_broker_local/src/event.rs
+++ b/litebox_broker_local/src/event.rs
@@ -76,7 +76,8 @@ impl<Channel: LocalCallChannel> BrokerLocal<Channel> {
             BrokerResult::Error(error) => Err(BrokerLocalError::Broker(error)),
             response @ (BrokerResult::ObjectClosed
             | BrokerResult::Readiness(_)
-            | BrokerResult::Pipe(_)) => {
+            | BrokerResult::Pipe(_)
+            | BrokerResult::Socket(_)) => {
                 panic!("broker returned unexpected event response: {response:?}");
             }
         }

--- a/litebox_broker_local/src/lib.rs
+++ b/litebox_broker_local/src/lib.rs
@@ -180,6 +180,7 @@ impl<Channel: LocalCallChannel> BrokerLocal<Channel> {
             },
             result @ (BrokerResult::Event(_)
             | BrokerResult::Pipe(_)
+            | BrokerResult::Socket(_)
             | BrokerResult::ObjectClosed
             | BrokerResult::Readiness(_)) => Ok(result),
         }
@@ -211,6 +212,7 @@ impl<Channel: LocalCallChannel> BrokerLocal<Channel> {
             BrokerResult::Error(error) => Err(BrokerLocalError::Broker(error)),
             response @ (BrokerResult::Event(_)
             | BrokerResult::Pipe(_)
+            | BrokerResult::Socket(_)
             | BrokerResult::Readiness(_)) => {
                 panic!("broker returned unexpected close response: {response:?}");
             }

--- a/litebox_broker_local/src/pipe.rs
+++ b/litebox_broker_local/src/pipe.rs
@@ -129,7 +129,8 @@ impl<Channel: LocalCallChannel> BrokerLocal<Channel> {
             BrokerResult::Error(error) => Err(BrokerLocalError::Broker(error)),
             response @ (BrokerResult::ObjectClosed
             | BrokerResult::Readiness(_)
-            | BrokerResult::Event(_)) => {
+            | BrokerResult::Event(_)
+            | BrokerResult::Socket(_)) => {
                 panic!("broker returned unexpected pipe response: {response:?}");
             }
         }

--- a/litebox_broker_protocol/src/lib.rs
+++ b/litebox_broker_protocol/src/lib.rs
@@ -22,6 +22,7 @@ pub mod message;
 pub mod pipe;
 pub mod readiness;
 pub mod shared_buffer;
+pub mod socket;
 pub mod wire;
 
 /// Opaque broker object reference handle.

--- a/litebox_broker_protocol/src/message.rs
+++ b/litebox_broker_protocol/src/message.rs
@@ -14,7 +14,7 @@ use crate::readiness::ReadinessFlags;
 use crate::socket::{
     ConnectSocketRequest, ConnectSocketResponse, CreateSocketRequest, CreateSocketResponse,
     ReceiveSocketRequest, ReceiveSocketResponse, SendSocketRequest, SendSocketResponse,
-    ShutdownSocketRequest, SocketStatusRequest, SocketStatusResponse,
+    ShutdownSocketRequest, SocketError, SocketStatusRequest, SocketStatusResponse,
 };
 use crate::{ObjectHandle, ProtocolVersion, RequestId};
 
@@ -108,7 +108,7 @@ pub enum SocketRequest {
     Receive(ReceiveSocketRequest),
     /// Shut down one or both directions.
     Shutdown(ShutdownSocketRequest),
-    /// Read a socket's pending connection outcome.
+    /// Read a socket's connection state.
     Status(SocketStatusRequest),
 }
 
@@ -175,6 +175,15 @@ pub enum SocketResponse {
     Shutdown,
     /// Status operation response.
     Status(SocketStatusResponse),
+    /// A non-connect host network operation failed.
+    ///
+    /// Connect and status responses carry terminal failures in
+    /// [`SocketConnectionStatus`] so repeated status requests remain
+    /// idempotent. Broker and request-validation failures use
+    /// [`BrokerResult::Error`] instead.
+    ///
+    /// [`SocketConnectionStatus`]: crate::socket::SocketConnectionStatus
+    Failed(SocketError),
 }
 
 /// Broker-initiated asynchronous notification.

--- a/litebox_broker_protocol/src/message.rs
+++ b/litebox_broker_protocol/src/message.rs
@@ -11,6 +11,11 @@ use crate::pipe::{
     WritePipeResponse,
 };
 use crate::readiness::ReadinessFlags;
+use crate::socket::{
+    ConnectSocketRequest, ConnectSocketResponse, CreateSocketRequest, CreateSocketResponse,
+    ReceiveSocketRequest, ReceiveSocketResponse, SendSocketRequest, SendSocketResponse,
+    ShutdownSocketRequest, SocketStatusRequest, SocketStatusResponse,
+};
 use crate::{ObjectHandle, ProtocolVersion, RequestId};
 
 /// Broker handshake request sent before the control channel is active.
@@ -31,6 +36,8 @@ pub enum BrokerOperation {
     Event(EventRequest),
     /// Pipe object request family.
     Pipe(PipeRequest),
+    /// Socket object request family.
+    Socket(SocketRequest),
 }
 
 /// Request sent over an active broker control channel.
@@ -88,6 +95,23 @@ pub enum PipeRequest {
     Write(WritePipeRequest),
 }
 
+/// Broker-owned socket object request.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SocketRequest {
+    /// Create a broker-owned socket.
+    Create(CreateSocketRequest),
+    /// Connect a socket to a remote address.
+    Connect(ConnectSocketRequest),
+    /// Send bytes staged in shared memory.
+    Send(SendSocketRequest),
+    /// Receive bytes into shared memory.
+    Receive(ReceiveSocketRequest),
+    /// Shut down one or both directions.
+    Shutdown(ShutdownSocketRequest),
+    /// Read a socket's pending connection outcome.
+    Status(SocketStatusRequest),
+}
+
 /// Result returned for an active broker operation.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum BrokerResult {
@@ -99,6 +123,8 @@ pub enum BrokerResult {
     Event(EventResponse),
     /// Pipe object response family.
     Pipe(PipeResponse),
+    /// Socket object response family.
+    Socket(SocketResponse),
     /// Operation failed with an ABI-neutral broker error.
     Error(ErrorCode),
 }
@@ -132,6 +158,23 @@ pub enum PipeResponse {
     Read(ReadPipeResponse),
     /// Write operation response.
     Write(WritePipeResponse),
+}
+
+/// Broker-owned socket object response.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SocketResponse {
+    /// Create operation response.
+    Create(CreateSocketResponse),
+    /// Connect operation response.
+    Connect(ConnectSocketResponse),
+    /// Send operation response.
+    Send(SendSocketResponse),
+    /// Receive operation response.
+    Receive(ReceiveSocketResponse),
+    /// Shutdown operation completed.
+    Shutdown,
+    /// Status operation response.
+    Status(SocketStatusResponse),
 }
 
 /// Broker-initiated asynchronous notification.

--- a/litebox_broker_protocol/src/readiness.rs
+++ b/litebox_broker_protocol/src/readiness.rs
@@ -17,6 +17,12 @@ impl ReadinessFlags {
     pub const HANGUP: Self = Self(1 << 2);
     /// The object is in an error state.
     pub const ERROR: Self = Self(1 << 3);
+
+    /// Returns whether every flag in `other` is set.
+    #[must_use]
+    pub const fn contains(self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
 }
 
 impl core::ops::BitOr for ReadinessFlags {
@@ -24,5 +30,19 @@ impl core::ops::BitOr for ReadinessFlags {
 
     fn bitor(self, rhs: Self) -> Self::Output {
         Self(self.0 | rhs.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ReadinessFlags;
+
+    #[test]
+    fn contains_requires_every_requested_flag() {
+        let readiness = ReadinessFlags::READ | ReadinessFlags::WRITE;
+        assert!(readiness.contains(ReadinessFlags::READ));
+        assert!(readiness.contains(ReadinessFlags::WRITE));
+        assert!(readiness.contains(ReadinessFlags::READ | ReadinessFlags::WRITE));
+        assert!(!readiness.contains(ReadinessFlags::ERROR));
     }
 }

--- a/litebox_broker_protocol/src/socket.rs
+++ b/litebox_broker_protocol/src/socket.rs
@@ -1,0 +1,282 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//! Typed values for broker-mediated network sockets.
+//!
+//! These describe what a local endpoint may ask the broker to do with a socket,
+//! never how the broker does it: no descriptor, poll registration, or platform
+//! error appears here. Every value is a closed set rather than a passthrough
+//! integer, so a local endpoint cannot name an address family, type, protocol,
+//! or flag the broker has not agreed to support.
+
+use crate::ObjectHandle;
+use crate::shared_buffer::SharedBufferDescriptor;
+
+/// Address family of a broker socket.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum AddressFamily {
+    /// IPv4.
+    Ipv4,
+}
+
+/// Communication semantics of a broker socket.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SocketType {
+    /// Reliable ordered byte stream.
+    Stream,
+}
+
+/// IP protocol carried by a broker socket.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum IpProtocol {
+    /// TCP.
+    Tcp,
+}
+
+/// Which directions of a socket to shut down.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ShutdownMode {
+    /// Further receives return end of stream.
+    Read,
+    /// The peer sees end of stream.
+    Write,
+    /// Both directions.
+    Both,
+}
+
+/// IPv4 address in network byte order.
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Ipv4Address(pub [u8; 4]);
+
+/// Transport port in host byte order.
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Port(pub u16);
+
+/// IPv4 socket address.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SocketAddressV4 {
+    /// IPv4 address.
+    pub address: Ipv4Address,
+    /// Transport port.
+    pub port: Port,
+}
+
+/// Flags for a send operation.
+///
+/// Send and receive flags are separate types because their underlying flag sets
+/// are disjoint: a receive-only flag such as [`ReceiveFlags::PEEK`] is
+/// meaningless on a send, and one shared type would let a local endpoint name it
+/// there.
+///
+/// Like [`ReceiveFlags`] and unlike [`ReadinessFlags`], which preserves bits a
+/// peer may not understand, this is bounded: flags are forwarded to a host
+/// socket operation, so a bit the broker does not recognize must never reach
+/// one. [`Self::SUPPORTED`] defines the bound as part of the ABI, and the broker
+/// rejects anything outside it rather than masking it away, which would silently
+/// perform an operation the caller did not ask for.
+///
+/// No send flag is supported yet, so any nonzero value is rejected.
+///
+/// [`ReadinessFlags`]: crate::readiness::ReadinessFlags
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct SendFlags(pub u32);
+
+impl SendFlags {
+    /// No flags.
+    pub const NONE: Self = Self(0);
+
+    /// Every send flag this protocol version defines.
+    pub const SUPPORTED: Self = Self(0);
+
+    /// Returns whether any bit outside [`Self::SUPPORTED`] is set.
+    #[must_use]
+    pub const fn has_unsupported_bits(self) -> bool {
+        self.0 & !Self::SUPPORTED.0 != 0
+    }
+}
+
+/// Flags for a receive operation.
+///
+/// See [`SendFlags`] for why the two directions are separate types and why both
+/// are bounded rather than passthrough.
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ReceiveFlags(pub u32);
+
+impl ReceiveFlags {
+    /// No flags.
+    pub const NONE: Self = Self(0);
+    /// Return data without consuming it.
+    pub const PEEK: Self = Self(1 << 0);
+
+    /// Every receive flag this protocol version defines.
+    pub const SUPPORTED: Self = Self(Self::PEEK.0);
+
+    /// Returns whether any bit outside [`Self::SUPPORTED`] is set.
+    #[must_use]
+    pub const fn has_unsupported_bits(self) -> bool {
+        self.0 & !Self::SUPPORTED.0 != 0
+    }
+
+    /// Returns whether every flag in `other` is set.
+    #[must_use]
+    pub const fn contains(self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
+
+/// Reason a socket connection failed.
+///
+/// This is a bounded restatement of the connection-level failures a host stack
+/// reports, kept separate from [`ErrorCode`] because those describe how the
+/// broker handled a request, not what a remote peer or network did. Keeping
+/// them apart also means adding a network failure never widens the error type
+/// every broker operation can return.
+///
+/// [`ErrorCode`]: crate::error::ErrorCode
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SocketError {
+    /// The peer refused the connection.
+    ConnectionRefused,
+    /// The connection was reset by the peer.
+    ConnectionReset,
+    /// The connection was aborted before it completed.
+    ConnectionAborted,
+    /// No route to the network.
+    NetworkUnreachable,
+    /// No route to the host.
+    HostUnreachable,
+    /// The connection attempt timed out.
+    TimedOut,
+    /// The address is already in use.
+    AddressInUse,
+    /// The address is not available on this host.
+    AddressNotAvailable,
+    /// The policy engine refused the destination.
+    PolicyDenied,
+    /// The host stack failed in a way this protocol does not distinguish.
+    Other,
+}
+
+/// Request to create a broker-owned socket.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CreateSocketRequest {
+    /// Address family.
+    pub address_family: AddressFamily,
+    /// Communication semantics.
+    pub socket_type: SocketType,
+    /// Transport protocol.
+    pub protocol: IpProtocol,
+}
+
+/// Response to a socket create request.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CreateSocketResponse {
+    /// Handle naming the new socket.
+    pub handle: ObjectHandle,
+}
+
+/// Request to connect a socket to a remote address.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ConnectSocketRequest {
+    /// Socket handle.
+    pub handle: ObjectHandle,
+    /// Remote address to connect to.
+    pub address: SocketAddressV4,
+}
+
+/// Response to a socket connect request.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ConnectSocketResponse {
+    /// Whether the connection completed or is still in progress.
+    pub status: ConnectStatus,
+}
+
+/// Outcome of a connect attempt.
+///
+/// The broker only performs non-blocking operations, so a connect that cannot
+/// complete immediately reports [`Self::InProgress`] rather than waiting. The
+/// caller waits for write readiness and then reads the outcome with a status
+/// request, which is the only way a failed connect is reported.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ConnectStatus {
+    /// The connection is established.
+    Connected,
+    /// The connection is still being established.
+    InProgress,
+}
+
+/// Request to send bytes staged in shared memory.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SendSocketRequest {
+    /// Socket handle.
+    pub handle: ObjectHandle,
+    /// Leased shared-buffer region containing the staged bytes.
+    pub buffer: SharedBufferDescriptor,
+    /// Send flags.
+    pub flags: SendFlags,
+}
+
+/// Response describing a completed send.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SendSocketResponse {
+    /// Number of bytes accepted by the socket.
+    pub sent: u32,
+}
+
+/// Request to receive bytes into shared memory.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ReceiveSocketRequest {
+    /// Socket handle.
+    pub handle: ObjectHandle,
+    /// Leased shared-buffer region to receive the bytes.
+    pub buffer: SharedBufferDescriptor,
+    /// Receive flags.
+    pub flags: ReceiveFlags,
+}
+
+/// Response describing bytes received into shared memory.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ReceiveSocketResponse {
+    /// Number of bytes placed in the receive region.
+    ///
+    /// Zero means the peer closed its write side; a socket with nothing to read
+    /// yet reports [`ErrorCode::WouldBlock`] instead.
+    ///
+    /// [`ErrorCode::WouldBlock`]: crate::error::ErrorCode::WouldBlock
+    pub received: u32,
+}
+
+/// Request to shut down one or both directions of a socket.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ShutdownSocketRequest {
+    /// Socket handle.
+    pub handle: ObjectHandle,
+    /// Directions to shut down.
+    pub mode: ShutdownMode,
+}
+
+/// Request for a socket's pending connection outcome.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SocketStatusRequest {
+    /// Socket handle.
+    pub handle: ObjectHandle,
+}
+
+/// Response describing a socket's pending connection outcome.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SocketStatusResponse {
+    /// The failure the socket recorded, if any.
+    ///
+    /// Reading the status clears it, so each failure is reported once.
+    pub error: Option<SocketError>,
+}

--- a/litebox_broker_protocol/src/socket.rs
+++ b/litebox_broker_protocol/src/socket.rs
@@ -11,6 +11,7 @@
 
 use crate::ObjectHandle;
 use crate::shared_buffer::SharedBufferDescriptor;
+use thiserror::Error;
 
 /// Address family of a broker socket.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -141,29 +142,77 @@ impl ReceiveFlags {
 /// operation can return.
 ///
 /// [`ErrorCode`]: crate::error::ErrorCode
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum SocketError {
     /// The peer refused the connection.
+    #[error("connection refused")]
     ConnectionRefused,
     /// The connection was reset by the peer.
+    #[error("connection reset")]
     ConnectionReset,
     /// The connection was aborted before it completed.
+    #[error("connection aborted")]
     ConnectionAborted,
     /// No route to the network.
+    #[error("network unreachable")]
     NetworkUnreachable,
     /// No route to the host.
+    #[error("host unreachable")]
     HostUnreachable,
     /// The connection attempt timed out.
+    #[error("connection timed out")]
     TimedOut,
     /// The address is already in use.
+    #[error("address already in use")]
     AddressInUse,
     /// The address is not available on this host.
+    #[error("address not available")]
     AddressNotAvailable,
     /// The policy engine refused the destination.
+    #[error("socket policy denied the operation")]
     PolicyDenied,
     /// The host stack failed in a way this protocol does not distinguish.
+    #[error("other socket error")]
     Other,
+}
+
+impl SocketError {
+    /// Raw socket error values are part of the broker wire ABI.
+    ///
+    /// Value `0` is unassigned so a zero-filled value never represents a
+    /// concrete network failure.
+    pub const fn from_raw(raw: u8) -> Option<Self> {
+        match raw {
+            1 => Some(Self::ConnectionRefused),
+            2 => Some(Self::ConnectionReset),
+            3 => Some(Self::ConnectionAborted),
+            4 => Some(Self::NetworkUnreachable),
+            5 => Some(Self::HostUnreachable),
+            6 => Some(Self::TimedOut),
+            7 => Some(Self::AddressInUse),
+            8 => Some(Self::AddressNotAvailable),
+            9 => Some(Self::PolicyDenied),
+            10 => Some(Self::Other),
+            _ => None,
+        }
+    }
+
+    /// Returns the raw broker wire ABI value.
+    pub const fn as_raw(self) -> u8 {
+        match self {
+            Self::ConnectionRefused => 1,
+            Self::ConnectionReset => 2,
+            Self::ConnectionAborted => 3,
+            Self::NetworkUnreachable => 4,
+            Self::HostUnreachable => 5,
+            Self::TimedOut => 6,
+            Self::AddressInUse => 7,
+            Self::AddressNotAvailable => 8,
+            Self::PolicyDenied => 9,
+            Self::Other => 10,
+        }
+    }
 }
 
 /// Request to create a broker-owned socket.
@@ -212,6 +261,8 @@ pub struct ConnectSocketResponse {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum SocketConnectionStatus {
+    /// No connection attempt has started.
+    Unconnected,
     /// The connection is still being established.
     Connecting,
     /// The connection is established.
@@ -249,16 +300,19 @@ pub struct ReceiveSocketRequest {
     pub flags: ReceiveFlags,
 }
 
-/// Response describing bytes received into shared memory.
+/// Response to a socket receive request.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct ReceiveSocketResponse {
+#[non_exhaustive]
+pub enum ReceiveSocketResponse {
     /// Number of bytes placed in the receive region.
     ///
-    /// Zero means the peer closed its write side; a socket with nothing to read
-    /// yet reports [`ErrorCode::WouldBlock`] instead.
+    /// Zero is the successful result of a zero-length request. A socket with
+    /// nothing to read yet reports [`ErrorCode::WouldBlock`] instead.
     ///
     /// [`ErrorCode::WouldBlock`]: crate::error::ErrorCode::WouldBlock
-    pub received: u32,
+    Received(u32),
+    /// The socket's receive direction reached end of stream.
+    EndOfStream,
 }
 
 /// Request to shut down one or both directions of a socket.

--- a/litebox_broker_protocol/src/socket.rs
+++ b/litebox_broker_protocol/src/socket.rs
@@ -132,13 +132,13 @@ impl ReceiveFlags {
     }
 }
 
-/// Reason a socket connection failed.
+/// Reason a socket operation failed.
 ///
-/// This is a bounded restatement of the connection-level failures a host stack
-/// reports, kept separate from [`ErrorCode`] because those describe how the
-/// broker handled a request, not what a remote peer or network did. Keeping
-/// them apart also means adding a network failure never widens the error type
-/// every broker operation can return.
+/// This is a bounded restatement of the network failures a host stack reports,
+/// kept separate from [`ErrorCode`] because those describe how the broker
+/// handled a request, not what a remote peer or network did. Keeping them apart
+/// also means adding a network failure never widens the error type every broker
+/// operation can return.
 ///
 /// [`ErrorCode`]: crate::error::ErrorCode
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -196,23 +196,28 @@ pub struct ConnectSocketRequest {
 /// Response to a socket connect request.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ConnectSocketResponse {
-    /// Whether the connection completed or is still in progress.
-    pub status: ConnectStatus,
+    /// Connection state after the nonblocking attempt.
+    pub status: SocketConnectionStatus,
 }
 
-/// Outcome of a connect attempt.
+/// Broker-authoritative socket connection state.
 ///
 /// The broker only performs non-blocking operations, so a connect that cannot
-/// complete immediately reports [`Self::InProgress`] rather than waiting. The
-/// caller waits for write readiness and then reads the outcome with a status
-/// request, which is the only way a failed connect is reported.
+/// complete immediately reports [`Self::Connecting`] rather than waiting. The
+/// caller waits for write readiness and then reads the authoritative state with
+/// a status request.
+///
+/// Connected and failed states are terminal and idempotent: repeated status
+/// requests return the same state.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[non_exhaustive]
-pub enum ConnectStatus {
+pub enum SocketConnectionStatus {
+    /// The connection is still being established.
+    Connecting,
     /// The connection is established.
     Connected,
-    /// The connection is still being established.
-    InProgress,
+    /// The connection attempt failed.
+    Failed(SocketError),
 }
 
 /// Request to send bytes staged in shared memory.
@@ -265,18 +270,16 @@ pub struct ShutdownSocketRequest {
     pub mode: ShutdownMode,
 }
 
-/// Request for a socket's pending connection outcome.
+/// Request for a socket's connection state.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct SocketStatusRequest {
     /// Socket handle.
     pub handle: ObjectHandle,
 }
 
-/// Response describing a socket's pending connection outcome.
+/// Response describing a socket's broker-authoritative connection state.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct SocketStatusResponse {
-    /// The failure the socket recorded, if any.
-    ///
-    /// Reading the status clears it, so each failure is reported once.
-    pub error: Option<SocketError>,
+    /// Current connection state.
+    pub status: SocketConnectionStatus,
 }

--- a/litebox_broker_protocol/src/wire.rs
+++ b/litebox_broker_protocol/src/wire.rs
@@ -30,12 +30,14 @@ use primitive::{Decoder, Encoder};
 mod event;
 mod pipe;
 mod primitive;
+mod socket;
 
 const REQUEST_TAG_NEGOTIATE: u8 = 0;
 const REQUEST_TAG_EVENT: u8 = 1;
 const REQUEST_TAG_CLOSE_OBJECT: u8 = 2;
 const REQUEST_TAG_PIPE: u8 = 3;
 const REQUEST_TAG_CHECK_READINESS: u8 = 4;
+const REQUEST_TAG_SOCKET: u8 = 5;
 
 const RESPONSE_TAG_NEGOTIATED: u8 = 0;
 const RESPONSE_TAG_EVENT: u8 = 1;
@@ -45,11 +47,12 @@ const RESPONSE_TAG_OBJECT_CLOSED: u8 = 4;
 const RESPONSE_TAG_PIPE: u8 = 5;
 const RESPONSE_TAG_READINESS: u8 = 6;
 const RESPONSE_TAG_ERROR: u8 = 7;
+const RESPONSE_TAG_SOCKET: u8 = 8;
 
 const NOTIFICATION_TAG_READINESS: u8 = 0;
 
 /// Maximum byte length of any encoded active request or response.
-pub const MAX_ENCODED_ACTIVE_MESSAGE_SIZE: usize = 26;
+pub const MAX_ENCODED_ACTIVE_MESSAGE_SIZE: usize = 30;
 
 /// Maximum byte length of any encoded broker notification.
 pub const MAX_ENCODED_NOTIFICATION_SIZE: usize = 13;
@@ -92,7 +95,8 @@ pub fn decode_handshake_request(frame: &[u8]) -> Result<BrokerHandshakeRequest, 
         REQUEST_TAG_EVENT
         | REQUEST_TAG_CLOSE_OBJECT
         | REQUEST_TAG_PIPE
-        | REQUEST_TAG_CHECK_READINESS => {
+        | REQUEST_TAG_CHECK_READINESS
+        | REQUEST_TAG_SOCKET => {
             return Err(WireError::WrongMessagePhase);
         }
         _ => return Err(WireError::InvalidTag),
@@ -132,6 +136,11 @@ pub fn encode_request(request: BrokerRequest) -> Vec<u8> {
             encoder.request_id(request_id);
             pipe::encode_pipe_request(&mut encoder, request);
         }
+        BrokerOperation::Socket(request) => {
+            encoder.u8(REQUEST_TAG_SOCKET);
+            encoder.request_id(request_id);
+            socket::encode_socket_request(&mut encoder, request);
+        }
     }
     encoder.finish()
 }
@@ -145,7 +154,8 @@ pub fn decode_request(frame: &[u8]) -> Result<BrokerRequest, WireError> {
         REQUEST_TAG_CLOSE_OBJECT
         | REQUEST_TAG_CHECK_READINESS
         | REQUEST_TAG_EVENT
-        | REQUEST_TAG_PIPE => {}
+        | REQUEST_TAG_PIPE
+        | REQUEST_TAG_SOCKET => {}
         _ => return Err(WireError::InvalidTag),
     }
     let request_id = decoder.request_id()?;
@@ -154,6 +164,7 @@ pub fn decode_request(frame: &[u8]) -> Result<BrokerRequest, WireError> {
         REQUEST_TAG_CHECK_READINESS => BrokerOperation::CheckReadiness(decoder.handle()?),
         REQUEST_TAG_EVENT => BrokerOperation::Event(event::decode_event_request(&mut decoder)?),
         REQUEST_TAG_PIPE => BrokerOperation::Pipe(pipe::decode_pipe_request(&mut decoder)?),
+        REQUEST_TAG_SOCKET => BrokerOperation::Socket(socket::decode_socket_request(&mut decoder)?),
         _ => unreachable!("active request tag was validated"),
     };
     decoder.finish()?;
@@ -202,7 +213,8 @@ pub fn decode_handshake_response(frame: &[u8]) -> Result<BrokerHandshakeResponse
         | RESPONSE_TAG_OBJECT_CLOSED
         | RESPONSE_TAG_PIPE
         | RESPONSE_TAG_READINESS
-        | RESPONSE_TAG_ERROR => {
+        | RESPONSE_TAG_ERROR
+        | RESPONSE_TAG_SOCKET => {
             return Err(WireError::WrongMessagePhase);
         }
         RESPONSE_TAG_VERSION_MISMATCH => BrokerHandshakeResponse::VersionMismatch {
@@ -245,6 +257,11 @@ pub fn encode_response(response: BrokerResponse) -> Vec<u8> {
             encoder.request_id(request_id);
             pipe::encode_pipe_response(&mut encoder, response);
         }
+        BrokerResult::Socket(response) => {
+            encoder.u8(RESPONSE_TAG_SOCKET);
+            encoder.request_id(request_id);
+            socket::encode_socket_response(&mut encoder, response);
+        }
         BrokerResult::Error(error) => {
             encoder.u8(RESPONSE_TAG_ERROR);
             encoder.request_id(request_id);
@@ -266,13 +283,15 @@ pub fn decode_response(frame: &[u8]) -> Result<BrokerResponse, WireError> {
         | RESPONSE_TAG_OBJECT_CLOSED
         | RESPONSE_TAG_PIPE
         | RESPONSE_TAG_READINESS
-        | RESPONSE_TAG_ERROR => {}
+        | RESPONSE_TAG_ERROR
+        | RESPONSE_TAG_SOCKET => {}
         _ => return Err(WireError::InvalidTag),
     }
     let request_id = decoder.request_id()?;
     let result = match tag {
         RESPONSE_TAG_EVENT => BrokerResult::Event(event::decode_event_response(&mut decoder)?),
         RESPONSE_TAG_PIPE => BrokerResult::Pipe(pipe::decode_pipe_response(&mut decoder)?),
+        RESPONSE_TAG_SOCKET => BrokerResult::Socket(socket::decode_socket_response(&mut decoder)?),
         RESPONSE_TAG_ERROR => {
             let error = ErrorCode::from_raw(decoder.u16()?).ok_or(WireError::InvalidTag)?;
             BrokerResult::Error(error)
@@ -323,12 +342,21 @@ mod tests {
         AddEventRequest, AddEventResponse, ConsumeEventRequest, CreateEventRequest,
         CreateEventResponse, EventConsumeMode, EventConsumption,
     };
-    use crate::message::{EventRequest, EventResponse, PipeRequest, PipeResponse};
+    use crate::message::{
+        EventRequest, EventResponse, PipeRequest, PipeResponse, SocketRequest, SocketResponse,
+    };
     use crate::pipe::{
         CreatePipeRequest, CreatePipeResponse, ReadPipeRequest, ReadPipeResponse, WritePipeRequest,
         WritePipeResponse,
     };
     use crate::shared_buffer::{SharedBufferDescriptor, SharedBufferSlotIndex};
+    use crate::socket::{
+        AddressFamily, ConnectSocketRequest, ConnectSocketResponse, ConnectStatus,
+        CreateSocketRequest, CreateSocketResponse, IpProtocol, Ipv4Address, Port, ReceiveFlags,
+        ReceiveSocketRequest, ReceiveSocketResponse, SendFlags, SendSocketRequest,
+        SendSocketResponse, ShutdownMode, ShutdownSocketRequest, SocketAddressV4, SocketError,
+        SocketStatusRequest, SocketStatusResponse, SocketType,
+    };
     use crate::{ObjectHandle, ProtocolVersion, RequestId};
 
     const TEST_REQUEST_ID: RequestId = RequestId(0x0102_0304_0506_0708);
@@ -386,6 +414,47 @@ mod tests {
                     length: 3,
                 },
             })),
+            BrokerOperation::Socket(SocketRequest::Create(CreateSocketRequest {
+                address_family: AddressFamily::Ipv4,
+                socket_type: SocketType::Stream,
+                protocol: IpProtocol::Tcp,
+            })),
+            BrokerOperation::Socket(SocketRequest::Connect(ConnectSocketRequest {
+                handle,
+                address: SocketAddressV4 {
+                    address: Ipv4Address([203, 0, 113, 7]),
+                    port: Port(443),
+                },
+            })),
+            BrokerOperation::Socket(SocketRequest::Send(SendSocketRequest {
+                handle,
+                buffer: SharedBufferDescriptor {
+                    slot_index: SharedBufferSlotIndex(15),
+                    length: 3,
+                },
+                flags: SendFlags::NONE,
+            })),
+            BrokerOperation::Socket(SocketRequest::Receive(ReceiveSocketRequest {
+                handle,
+                buffer: SharedBufferDescriptor {
+                    slot_index: SharedBufferSlotIndex(15),
+                    length: 3,
+                },
+                flags: ReceiveFlags::PEEK,
+            })),
+            BrokerOperation::Socket(SocketRequest::Shutdown(ShutdownSocketRequest {
+                handle,
+                mode: ShutdownMode::Read,
+            })),
+            BrokerOperation::Socket(SocketRequest::Shutdown(ShutdownSocketRequest {
+                handle,
+                mode: ShutdownMode::Write,
+            })),
+            BrokerOperation::Socket(SocketRequest::Shutdown(ShutdownSocketRequest {
+                handle,
+                mode: ShutdownMode::Both,
+            })),
+            BrokerOperation::Socket(SocketRequest::Status(SocketStatusRequest { handle })),
         ];
         let mut maximum_encoded_size = 0;
 
@@ -398,8 +467,85 @@ mod tests {
             maximum_encoded_size = maximum_encoded_size.max(encoded.len());
             assert!(encoded.len() <= MAX_ENCODED_ACTIVE_MESSAGE_SIZE);
             assert_eq!(decode_request(&encoded).unwrap(), request);
+            // Every active tag must be reported as a phase violation during
+            // the handshake, not as an unknown tag: only the former is turned
+            // into a clean protocol-violation shutdown by the transport.
+            assert_eq!(
+                decode_handshake_request(&encoded),
+                Err(WireError::WrongMessagePhase)
+            );
         }
         assert_eq!(maximum_encoded_size, MAX_ENCODED_ACTIVE_MESSAGE_SIZE);
+    }
+
+    #[test]
+    fn flag_bits_round_trip_unmasked() {
+        // The codec carries flags verbatim so the core can reject unsupported
+        // bits; masking them here would hide them from that check, and a
+        // dropped field would make an unsupported flag look like none at all.
+        let handle = ObjectHandle(13);
+        let buffer = SharedBufferDescriptor {
+            slot_index: SharedBufferSlotIndex(15),
+            length: 3,
+        };
+        let unsupported = 0x8000_0001;
+        for operation in [
+            BrokerOperation::Socket(SocketRequest::Send(SendSocketRequest {
+                handle,
+                buffer,
+                flags: SendFlags(unsupported),
+            })),
+            BrokerOperation::Socket(SocketRequest::Receive(ReceiveSocketRequest {
+                handle,
+                buffer,
+                flags: ReceiveFlags(unsupported),
+            })),
+        ] {
+            let request = BrokerRequest {
+                request_id: TEST_REQUEST_ID,
+                operation,
+            };
+            assert_eq!(
+                decode_request(&encode_request(request.clone())).unwrap(),
+                request
+            );
+        }
+
+        assert!(SendFlags(unsupported).has_unsupported_bits());
+        assert!(ReceiveFlags(unsupported).has_unsupported_bits());
+        // No send flag exists yet, so every bit is unsupported there.
+        assert!(SendFlags(ReceiveFlags::PEEK.0).has_unsupported_bits());
+        assert!(!SendFlags::NONE.has_unsupported_bits());
+        assert!(!ReceiveFlags::PEEK.has_unsupported_bits());
+        assert!(ReceiveFlags::PEEK.contains(ReceiveFlags::PEEK));
+        assert!(!ReceiveFlags::NONE.contains(ReceiveFlags::PEEK));
+    }
+
+    #[test]
+    fn socket_error_codec_round_trips_all_variants() {
+        for error in [
+            SocketError::ConnectionRefused,
+            SocketError::ConnectionReset,
+            SocketError::ConnectionAborted,
+            SocketError::NetworkUnreachable,
+            SocketError::HostUnreachable,
+            SocketError::TimedOut,
+            SocketError::AddressInUse,
+            SocketError::AddressNotAvailable,
+            SocketError::PolicyDenied,
+            SocketError::Other,
+        ] {
+            let response = BrokerResponse {
+                request_id: TEST_REQUEST_ID,
+                result: BrokerResult::Socket(SocketResponse::Status(SocketStatusResponse {
+                    error: Some(error),
+                })),
+            };
+            assert_eq!(
+                decode_response(&encode_response(response.clone())).unwrap(),
+                response
+            );
+        }
     }
 
     #[test]
@@ -458,6 +604,22 @@ mod tests {
             })),
             BrokerResult::Pipe(PipeResponse::Read(ReadPipeResponse { read: 3 })),
             BrokerResult::Pipe(PipeResponse::Write(WritePipeResponse { written: 3 })),
+            BrokerResult::Socket(SocketResponse::Create(CreateSocketResponse { handle })),
+            BrokerResult::Socket(SocketResponse::Connect(ConnectSocketResponse {
+                status: ConnectStatus::Connected,
+            })),
+            BrokerResult::Socket(SocketResponse::Connect(ConnectSocketResponse {
+                status: ConnectStatus::InProgress,
+            })),
+            BrokerResult::Socket(SocketResponse::Send(SendSocketResponse { sent: 3 })),
+            BrokerResult::Socket(SocketResponse::Receive(ReceiveSocketResponse {
+                received: 3,
+            })),
+            BrokerResult::Socket(SocketResponse::Shutdown),
+            BrokerResult::Socket(SocketResponse::Status(SocketStatusResponse { error: None })),
+            BrokerResult::Socket(SocketResponse::Status(SocketStatusResponse {
+                error: Some(SocketError::ConnectionRefused),
+            })),
             BrokerResult::Error(ErrorCode::PolicyDenied),
             BrokerResult::Error(ErrorCode::WouldBlock),
             BrokerResult::Error(ErrorCode::PeerClosed),
@@ -475,8 +637,14 @@ mod tests {
             maximum_encoded_size = maximum_encoded_size.max(encoded.len());
             assert!(encoded.len() <= MAX_ENCODED_ACTIVE_MESSAGE_SIZE);
             assert_eq!(decode_response(&encoded).unwrap(), response);
+            assert_eq!(
+                decode_handshake_response(&encoded),
+                Err(WireError::WrongMessagePhase)
+            );
         }
-        assert_eq!(maximum_encoded_size, MAX_ENCODED_ACTIVE_MESSAGE_SIZE);
+        // Requests bind the shared limit, so responses only have to fit under
+        // it. The request test asserts the limit is reached and therefore tight.
+        assert!(maximum_encoded_size <= MAX_ENCODED_ACTIVE_MESSAGE_SIZE);
     }
 
     #[test]
@@ -580,6 +748,144 @@ mod tests {
         });
         frame.push(0xff);
         assert_eq!(decode_request(&frame), Err(WireError::TrailingBytes));
+    }
+
+    #[test]
+    fn decode_rejects_malformed_socket_request_frames() {
+        let mut unknown_operation = Vec::from([REQUEST_TAG_SOCKET]);
+        unknown_operation.extend_from_slice(&TEST_REQUEST_ID.0.to_le_bytes());
+        unknown_operation.push(0xff);
+        assert_eq!(
+            decode_request(&unknown_operation),
+            Err(WireError::InvalidTag)
+        );
+
+        // A socket envelope carrying no family tag at all.
+        assert_eq!(
+            decode_request(&unknown_operation[..unknown_operation.len() - 1]),
+            Err(WireError::TruncatedFrame)
+        );
+
+        // Address family, type, and protocol are the last three bytes of a
+        // create frame, so each unknown tag is rejected on its own.
+        let create = encode_request(BrokerRequest {
+            request_id: TEST_REQUEST_ID,
+            operation: BrokerOperation::Socket(SocketRequest::Create(CreateSocketRequest {
+                address_family: AddressFamily::Ipv4,
+                socket_type: SocketType::Stream,
+                protocol: IpProtocol::Tcp,
+            })),
+        });
+        for offset in 1..=3 {
+            let mut frame = create.clone();
+            let index = frame.len() - offset;
+            frame[index] = 0xff;
+            assert_eq!(decode_request(&frame), Err(WireError::InvalidTag));
+        }
+        assert_eq!(
+            decode_request(&create[..create.len() - 1]),
+            Err(WireError::TruncatedFrame)
+        );
+
+        let mut unknown_shutdown_mode = encode_request(BrokerRequest {
+            request_id: TEST_REQUEST_ID,
+            operation: BrokerOperation::Socket(SocketRequest::Shutdown(ShutdownSocketRequest {
+                handle: ObjectHandle(9),
+                mode: ShutdownMode::Both,
+            })),
+        });
+        *unknown_shutdown_mode.last_mut().unwrap() = 0xff;
+        assert_eq!(
+            decode_request(&unknown_shutdown_mode),
+            Err(WireError::InvalidTag)
+        );
+
+        let connect = encode_request(BrokerRequest {
+            request_id: TEST_REQUEST_ID,
+            operation: BrokerOperation::Socket(SocketRequest::Connect(ConnectSocketRequest {
+                handle: ObjectHandle(9),
+                address: SocketAddressV4 {
+                    address: Ipv4Address([203, 0, 113, 7]),
+                    port: Port(443),
+                },
+            })),
+        });
+        assert_eq!(
+            decode_request(&connect[..connect.len() - 1]),
+            Err(WireError::TruncatedFrame)
+        );
+
+        let mut trailing = connect;
+        trailing.push(0);
+        assert_eq!(decode_request(&trailing), Err(WireError::TrailingBytes));
+    }
+
+    #[test]
+    fn decode_rejects_malformed_socket_response_frames() {
+        let mut unknown_response = Vec::from([RESPONSE_TAG_SOCKET]);
+        unknown_response.extend_from_slice(&TEST_REQUEST_ID.0.to_le_bytes());
+        unknown_response.push(0xff);
+        assert_eq!(
+            decode_response(&unknown_response),
+            Err(WireError::InvalidTag)
+        );
+        assert_eq!(
+            decode_response(&unknown_response[..unknown_response.len() - 1]),
+            Err(WireError::TruncatedFrame)
+        );
+
+        let mut unknown_connect_status = encode_response(BrokerResponse {
+            request_id: TEST_REQUEST_ID,
+            result: BrokerResult::Socket(SocketResponse::Connect(ConnectSocketResponse {
+                status: ConnectStatus::InProgress,
+            })),
+        });
+        *unknown_connect_status.last_mut().unwrap() = 0xff;
+        assert_eq!(
+            decode_response(&unknown_connect_status),
+            Err(WireError::InvalidTag)
+        );
+
+        // The status response encodes presence and, when present, the error
+        // itself, so both tags reject unknown values.
+        let mut unknown_status_presence = encode_response(BrokerResponse {
+            request_id: TEST_REQUEST_ID,
+            result: BrokerResult::Socket(SocketResponse::Status(SocketStatusResponse {
+                error: None,
+            })),
+        });
+        *unknown_status_presence.last_mut().unwrap() = 0xff;
+        assert_eq!(
+            decode_response(&unknown_status_presence),
+            Err(WireError::InvalidTag)
+        );
+
+        let mut unknown_socket_error = encode_response(BrokerResponse {
+            request_id: TEST_REQUEST_ID,
+            result: BrokerResult::Socket(SocketResponse::Status(SocketStatusResponse {
+                error: Some(SocketError::TimedOut),
+            })),
+        });
+        *unknown_socket_error.last_mut().unwrap() = 0xff;
+        assert_eq!(
+            decode_response(&unknown_socket_error),
+            Err(WireError::InvalidTag)
+        );
+        assert_eq!(
+            decode_response(&unknown_socket_error[..unknown_socket_error.len() - 1]),
+            Err(WireError::TruncatedFrame)
+        );
+
+        let received = encode_response(BrokerResponse {
+            request_id: TEST_REQUEST_ID,
+            result: BrokerResult::Socket(SocketResponse::Receive(ReceiveSocketResponse {
+                received: 4096,
+            })),
+        });
+        assert_eq!(
+            decode_response(&received[..received.len() - 1]),
+            Err(WireError::TruncatedFrame)
+        );
     }
 
     #[test]
@@ -716,6 +1022,25 @@ mod tests {
                 })),
             }),
             [1, 13, 0, 0, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0]
+        );
+    }
+
+    #[test]
+    fn socket_connect_request_wire_shape_is_pinned() {
+        assert_eq!(
+            encode_request(BrokerRequest {
+                request_id: RequestId(13),
+                operation: BrokerOperation::Socket(SocketRequest::Connect(ConnectSocketRequest {
+                    handle: ObjectHandle(9),
+                    address: SocketAddressV4 {
+                        address: Ipv4Address([203, 0, 113, 7]),
+                        port: Port(443),
+                    },
+                })),
+            }),
+            [
+                5, 13, 0, 0, 0, 0, 0, 0, 0, 1, 9, 0, 0, 0, 0, 0, 0, 0, 203, 0, 113, 7, 187, 1
+            ]
         );
     }
 

--- a/litebox_broker_protocol/src/wire.rs
+++ b/litebox_broker_protocol/src/wire.rs
@@ -351,10 +351,10 @@ mod tests {
     };
     use crate::shared_buffer::{SharedBufferDescriptor, SharedBufferSlotIndex};
     use crate::socket::{
-        AddressFamily, ConnectSocketRequest, ConnectSocketResponse, ConnectStatus,
-        CreateSocketRequest, CreateSocketResponse, IpProtocol, Ipv4Address, Port, ReceiveFlags,
-        ReceiveSocketRequest, ReceiveSocketResponse, SendFlags, SendSocketRequest,
-        SendSocketResponse, ShutdownMode, ShutdownSocketRequest, SocketAddressV4, SocketError,
+        AddressFamily, ConnectSocketRequest, ConnectSocketResponse, CreateSocketRequest,
+        CreateSocketResponse, IpProtocol, Ipv4Address, Port, ReceiveFlags, ReceiveSocketRequest,
+        ReceiveSocketResponse, SendFlags, SendSocketRequest, SendSocketResponse, ShutdownMode,
+        ShutdownSocketRequest, SocketAddressV4, SocketConnectionStatus, SocketError,
         SocketStatusRequest, SocketStatusResponse, SocketType,
     };
     use crate::{ObjectHandle, ProtocolVersion, RequestId};
@@ -535,16 +535,24 @@ mod tests {
             SocketError::PolicyDenied,
             SocketError::Other,
         ] {
-            let response = BrokerResponse {
-                request_id: TEST_REQUEST_ID,
-                result: BrokerResult::Socket(SocketResponse::Status(SocketStatusResponse {
-                    error: Some(error),
-                })),
-            };
-            assert_eq!(
-                decode_response(&encode_response(response.clone())).unwrap(),
-                response
-            );
+            for socket_response in [
+                SocketResponse::Failed(error),
+                SocketResponse::Connect(ConnectSocketResponse {
+                    status: SocketConnectionStatus::Failed(error),
+                }),
+                SocketResponse::Status(SocketStatusResponse {
+                    status: SocketConnectionStatus::Failed(error),
+                }),
+            ] {
+                let response = BrokerResponse {
+                    request_id: TEST_REQUEST_ID,
+                    result: BrokerResult::Socket(socket_response),
+                };
+                assert_eq!(
+                    decode_response(&encode_response(response.clone())).unwrap(),
+                    response
+                );
+            }
         }
     }
 
@@ -606,20 +614,29 @@ mod tests {
             BrokerResult::Pipe(PipeResponse::Write(WritePipeResponse { written: 3 })),
             BrokerResult::Socket(SocketResponse::Create(CreateSocketResponse { handle })),
             BrokerResult::Socket(SocketResponse::Connect(ConnectSocketResponse {
-                status: ConnectStatus::Connected,
+                status: SocketConnectionStatus::Connecting,
             })),
             BrokerResult::Socket(SocketResponse::Connect(ConnectSocketResponse {
-                status: ConnectStatus::InProgress,
+                status: SocketConnectionStatus::Connected,
+            })),
+            BrokerResult::Socket(SocketResponse::Connect(ConnectSocketResponse {
+                status: SocketConnectionStatus::Failed(SocketError::ConnectionRefused),
             })),
             BrokerResult::Socket(SocketResponse::Send(SendSocketResponse { sent: 3 })),
             BrokerResult::Socket(SocketResponse::Receive(ReceiveSocketResponse {
                 received: 3,
             })),
             BrokerResult::Socket(SocketResponse::Shutdown),
-            BrokerResult::Socket(SocketResponse::Status(SocketStatusResponse { error: None })),
             BrokerResult::Socket(SocketResponse::Status(SocketStatusResponse {
-                error: Some(SocketError::ConnectionRefused),
+                status: SocketConnectionStatus::Connecting,
             })),
+            BrokerResult::Socket(SocketResponse::Status(SocketStatusResponse {
+                status: SocketConnectionStatus::Connected,
+            })),
+            BrokerResult::Socket(SocketResponse::Status(SocketStatusResponse {
+                status: SocketConnectionStatus::Failed(SocketError::TimedOut),
+            })),
+            BrokerResult::Socket(SocketResponse::Failed(SocketError::ConnectionReset)),
             BrokerResult::Error(ErrorCode::PolicyDenied),
             BrokerResult::Error(ErrorCode::WouldBlock),
             BrokerResult::Error(ErrorCode::PeerClosed),
@@ -837,7 +854,7 @@ mod tests {
         let mut unknown_connect_status = encode_response(BrokerResponse {
             request_id: TEST_REQUEST_ID,
             result: BrokerResult::Socket(SocketResponse::Connect(ConnectSocketResponse {
-                status: ConnectStatus::InProgress,
+                status: SocketConnectionStatus::Connecting,
             })),
         });
         *unknown_connect_status.last_mut().unwrap() = 0xff;
@@ -846,25 +863,18 @@ mod tests {
             Err(WireError::InvalidTag)
         );
 
-        // The status response encodes presence and, when present, the error
-        // itself, so both tags reject unknown values.
-        let mut unknown_status_presence = encode_response(BrokerResponse {
+        let mut unknown_status = encode_response(BrokerResponse {
             request_id: TEST_REQUEST_ID,
             result: BrokerResult::Socket(SocketResponse::Status(SocketStatusResponse {
-                error: None,
+                status: SocketConnectionStatus::Connected,
             })),
         });
-        *unknown_status_presence.last_mut().unwrap() = 0xff;
-        assert_eq!(
-            decode_response(&unknown_status_presence),
-            Err(WireError::InvalidTag)
-        );
+        *unknown_status.last_mut().unwrap() = 0xff;
+        assert_eq!(decode_response(&unknown_status), Err(WireError::InvalidTag));
 
         let mut unknown_socket_error = encode_response(BrokerResponse {
             request_id: TEST_REQUEST_ID,
-            result: BrokerResult::Socket(SocketResponse::Status(SocketStatusResponse {
-                error: Some(SocketError::TimedOut),
-            })),
+            result: BrokerResult::Socket(SocketResponse::Failed(SocketError::TimedOut)),
         });
         *unknown_socket_error.last_mut().unwrap() = 0xff;
         assert_eq!(
@@ -873,6 +883,17 @@ mod tests {
         );
         assert_eq!(
             decode_response(&unknown_socket_error[..unknown_socket_error.len() - 1]),
+            Err(WireError::TruncatedFrame)
+        );
+
+        let failed_connection = encode_response(BrokerResponse {
+            request_id: TEST_REQUEST_ID,
+            result: BrokerResult::Socket(SocketResponse::Connect(ConnectSocketResponse {
+                status: SocketConnectionStatus::Failed(SocketError::ConnectionRefused),
+            })),
+        });
+        assert_eq!(
+            decode_response(&failed_connection[..failed_connection.len() - 1]),
             Err(WireError::TruncatedFrame)
         );
 
@@ -1041,6 +1062,17 @@ mod tests {
             [
                 5, 13, 0, 0, 0, 0, 0, 0, 0, 1, 9, 0, 0, 0, 0, 0, 0, 0, 203, 0, 113, 7, 187, 1
             ]
+        );
+    }
+
+    #[test]
+    fn socket_failure_response_wire_shape_is_pinned() {
+        assert_eq!(
+            encode_response(BrokerResponse {
+                request_id: RequestId(13),
+                result: BrokerResult::Socket(SocketResponse::Failed(SocketError::ConnectionReset,)),
+            }),
+            [8, 13, 0, 0, 0, 0, 0, 0, 0, 6, 1]
         );
     }
 

--- a/litebox_broker_protocol/src/wire.rs
+++ b/litebox_broker_protocol/src/wire.rs
@@ -613,6 +613,9 @@ mod tests {
             BrokerResult::Pipe(PipeResponse::Read(ReadPipeResponse { read: 3 })),
             BrokerResult::Pipe(PipeResponse::Write(WritePipeResponse { written: 3 })),
             BrokerResult::Socket(SocketResponse::Create(CreateSocketResponse { handle })),
+            BrokerResult::Socket(SocketResponse::Status(SocketStatusResponse {
+                status: SocketConnectionStatus::Unconnected,
+            })),
             BrokerResult::Socket(SocketResponse::Connect(ConnectSocketResponse {
                 status: SocketConnectionStatus::Connecting,
             })),
@@ -623,9 +626,9 @@ mod tests {
                 status: SocketConnectionStatus::Failed(SocketError::ConnectionRefused),
             })),
             BrokerResult::Socket(SocketResponse::Send(SendSocketResponse { sent: 3 })),
-            BrokerResult::Socket(SocketResponse::Receive(ReceiveSocketResponse {
-                received: 3,
-            })),
+            BrokerResult::Socket(SocketResponse::Receive(ReceiveSocketResponse::Received(3))),
+            BrokerResult::Socket(SocketResponse::Receive(ReceiveSocketResponse::Received(0))),
+            BrokerResult::Socket(SocketResponse::Receive(ReceiveSocketResponse::EndOfStream)),
             BrokerResult::Socket(SocketResponse::Shutdown),
             BrokerResult::Socket(SocketResponse::Status(SocketStatusResponse {
                 status: SocketConnectionStatus::Connecting,
@@ -872,17 +875,20 @@ mod tests {
         *unknown_status.last_mut().unwrap() = 0xff;
         assert_eq!(decode_response(&unknown_status), Err(WireError::InvalidTag));
 
-        let mut unknown_socket_error = encode_response(BrokerResponse {
+        let socket_error = encode_response(BrokerResponse {
             request_id: TEST_REQUEST_ID,
             result: BrokerResult::Socket(SocketResponse::Failed(SocketError::TimedOut)),
         });
-        *unknown_socket_error.last_mut().unwrap() = 0xff;
+        for raw in [0, 11, u8::MAX] {
+            let mut unknown_socket_error = socket_error.clone();
+            *unknown_socket_error.last_mut().unwrap() = raw;
+            assert_eq!(
+                decode_response(&unknown_socket_error),
+                Err(WireError::InvalidTag)
+            );
+        }
         assert_eq!(
-            decode_response(&unknown_socket_error),
-            Err(WireError::InvalidTag)
-        );
-        assert_eq!(
-            decode_response(&unknown_socket_error[..unknown_socket_error.len() - 1]),
+            decode_response(&socket_error[..socket_error.len() - 1]),
             Err(WireError::TruncatedFrame)
         );
 
@@ -899,13 +905,25 @@ mod tests {
 
         let received = encode_response(BrokerResponse {
             request_id: TEST_REQUEST_ID,
-            result: BrokerResult::Socket(SocketResponse::Receive(ReceiveSocketResponse {
-                received: 4096,
-            })),
+            result: BrokerResult::Socket(SocketResponse::Receive(ReceiveSocketResponse::Received(
+                4096,
+            ))),
         });
         assert_eq!(
             decode_response(&received[..received.len() - 1]),
             Err(WireError::TruncatedFrame)
+        );
+
+        let mut unknown_receive_result = encode_response(BrokerResponse {
+            request_id: TEST_REQUEST_ID,
+            result: BrokerResult::Socket(SocketResponse::Receive(
+                ReceiveSocketResponse::EndOfStream,
+            )),
+        });
+        *unknown_receive_result.last_mut().unwrap() = 0xff;
+        assert_eq!(
+            decode_response(&unknown_receive_result),
+            Err(WireError::InvalidTag)
         );
     }
 
@@ -1072,7 +1090,7 @@ mod tests {
                 request_id: RequestId(13),
                 result: BrokerResult::Socket(SocketResponse::Failed(SocketError::ConnectionReset,)),
             }),
-            [8, 13, 0, 0, 0, 0, 0, 0, 0, 6, 1]
+            [8, 13, 0, 0, 0, 0, 0, 0, 0, 6, 2]
         );
     }
 

--- a/litebox_broker_protocol/src/wire/event.rs
+++ b/litebox_broker_protocol/src/wire/event.rs
@@ -17,9 +17,9 @@ const EVENT_REQUEST_TAG_CREATE: u8 = 0;
 const EVENT_REQUEST_TAG_ADD: u8 = 1;
 const EVENT_REQUEST_TAG_CONSUME: u8 = 2;
 
-const EVENT_RESPONSE_TAG_CREATED: u8 = 0;
-const EVENT_RESPONSE_TAG_ADDED: u8 = 1;
-const EVENT_RESPONSE_TAG_CONSUMED: u8 = 2;
+const EVENT_RESPONSE_TAG_CREATE: u8 = 0;
+const EVENT_RESPONSE_TAG_ADD: u8 = 1;
+const EVENT_RESPONSE_TAG_CONSUME: u8 = 2;
 
 const EVENT_CONSUME_MODE_TAG_ALL: u8 = 1;
 const EVENT_CONSUME_MODE_TAG_ONE: u8 = 2;
@@ -65,15 +65,15 @@ pub(super) fn decode_event_request(decoder: &mut Decoder<'_>) -> Result<EventReq
 pub(super) fn encode_event_response(encoder: &mut Encoder, response: EventResponse) {
     match response {
         EventResponse::Create(response) => {
-            encoder.u8(EVENT_RESPONSE_TAG_CREATED);
+            encoder.u8(EVENT_RESPONSE_TAG_CREATE);
             encoder.handle(response.handle);
         }
         EventResponse::Add(response) => {
-            encoder.u8(EVENT_RESPONSE_TAG_ADDED);
+            encoder.u8(EVENT_RESPONSE_TAG_ADD);
             encoder.u32(response.readiness.0);
         }
         EventResponse::Consume(response) => {
-            encoder.u8(EVENT_RESPONSE_TAG_CONSUMED);
+            encoder.u8(EVENT_RESPONSE_TAG_CONSUME);
             encoder.u64(response.value);
             encoder.u32(response.readiness.0);
         }
@@ -82,13 +82,13 @@ pub(super) fn encode_event_response(encoder: &mut Encoder, response: EventRespon
 
 pub(super) fn decode_event_response(decoder: &mut Decoder<'_>) -> Result<EventResponse, WireError> {
     let response = match decoder.u8()? {
-        EVENT_RESPONSE_TAG_CREATED => EventResponse::Create(CreateEventResponse {
+        EVENT_RESPONSE_TAG_CREATE => EventResponse::Create(CreateEventResponse {
             handle: decoder.handle()?,
         }),
-        EVENT_RESPONSE_TAG_ADDED => EventResponse::Add(AddEventResponse {
+        EVENT_RESPONSE_TAG_ADD => EventResponse::Add(AddEventResponse {
             readiness: ReadinessFlags(decoder.u32()?),
         }),
-        EVENT_RESPONSE_TAG_CONSUMED => EventResponse::Consume(EventConsumption {
+        EVENT_RESPONSE_TAG_CONSUME => EventResponse::Consume(EventConsumption {
             value: decoder.u64()?,
             readiness: ReadinessFlags(decoder.u32()?),
         }),

--- a/litebox_broker_protocol/src/wire/pipe.rs
+++ b/litebox_broker_protocol/src/wire/pipe.rs
@@ -15,9 +15,9 @@ const PIPE_REQUEST_TAG_CREATE: u8 = 0;
 const PIPE_REQUEST_TAG_READ: u8 = 1;
 const PIPE_REQUEST_TAG_WRITE: u8 = 2;
 
-const PIPE_RESPONSE_TAG_CREATED: u8 = 0;
+const PIPE_RESPONSE_TAG_CREATE: u8 = 0;
 const PIPE_RESPONSE_TAG_READ: u8 = 1;
-const PIPE_RESPONSE_TAG_WRITTEN: u8 = 2;
+const PIPE_RESPONSE_TAG_WRITE: u8 = 2;
 
 pub(super) fn encode_pipe_request(encoder: &mut Encoder, request: PipeRequest) {
     match request {
@@ -74,7 +74,7 @@ fn decode_shared_buffer_descriptor(
 pub(super) fn encode_pipe_response(encoder: &mut Encoder, response: PipeResponse) {
     match response {
         PipeResponse::Create(response) => {
-            encoder.u8(PIPE_RESPONSE_TAG_CREATED);
+            encoder.u8(PIPE_RESPONSE_TAG_CREATE);
             encoder.handle(response.read_handle);
             encoder.handle(response.write_handle);
         }
@@ -83,7 +83,7 @@ pub(super) fn encode_pipe_response(encoder: &mut Encoder, response: PipeResponse
             encoder.u32(response.read);
         }
         PipeResponse::Write(response) => {
-            encoder.u8(PIPE_RESPONSE_TAG_WRITTEN);
+            encoder.u8(PIPE_RESPONSE_TAG_WRITE);
             encoder.u32(response.written);
         }
     }
@@ -91,14 +91,14 @@ pub(super) fn encode_pipe_response(encoder: &mut Encoder, response: PipeResponse
 
 pub(super) fn decode_pipe_response(decoder: &mut Decoder<'_>) -> Result<PipeResponse, WireError> {
     match decoder.u8()? {
-        PIPE_RESPONSE_TAG_CREATED => Ok(PipeResponse::Create(CreatePipeResponse {
+        PIPE_RESPONSE_TAG_CREATE => Ok(PipeResponse::Create(CreatePipeResponse {
             read_handle: decoder.handle()?,
             write_handle: decoder.handle()?,
         })),
         PIPE_RESPONSE_TAG_READ => Ok(PipeResponse::Read(ReadPipeResponse {
             read: decoder.u32()?,
         })),
-        PIPE_RESPONSE_TAG_WRITTEN => Ok(PipeResponse::Write(WritePipeResponse {
+        PIPE_RESPONSE_TAG_WRITE => Ok(PipeResponse::Write(WritePipeResponse {
             written: decoder.u32()?,
         })),
         _ => Err(WireError::InvalidTag),

--- a/litebox_broker_protocol/src/wire/socket.rs
+++ b/litebox_broker_protocol/src/wire/socket.rs
@@ -21,10 +21,10 @@ const SOCKET_REQUEST_TAG_RECEIVE: u8 = 3;
 const SOCKET_REQUEST_TAG_SHUTDOWN: u8 = 4;
 const SOCKET_REQUEST_TAG_STATUS: u8 = 5;
 
-const SOCKET_RESPONSE_TAG_CREATED: u8 = 0;
+const SOCKET_RESPONSE_TAG_CREATE: u8 = 0;
 const SOCKET_RESPONSE_TAG_CONNECT: u8 = 1;
-const SOCKET_RESPONSE_TAG_SENT: u8 = 2;
-const SOCKET_RESPONSE_TAG_RECEIVED: u8 = 3;
+const SOCKET_RESPONSE_TAG_SEND: u8 = 2;
+const SOCKET_RESPONSE_TAG_RECEIVE: u8 = 3;
 const SOCKET_RESPONSE_TAG_SHUTDOWN: u8 = 4;
 const SOCKET_RESPONSE_TAG_STATUS: u8 = 5;
 const SOCKET_RESPONSE_TAG_FAILED: u8 = 6;
@@ -39,20 +39,13 @@ const SHUTDOWN_TAG_READ: u8 = 0;
 const SHUTDOWN_TAG_WRITE: u8 = 1;
 const SHUTDOWN_TAG_BOTH: u8 = 2;
 
-const CONNECTION_STATUS_TAG_CONNECTING: u8 = 0;
-const CONNECTION_STATUS_TAG_CONNECTED: u8 = 1;
-const CONNECTION_STATUS_TAG_FAILED: u8 = 2;
+const CONNECTION_STATUS_TAG_UNCONNECTED: u8 = 0;
+const CONNECTION_STATUS_TAG_CONNECTING: u8 = 1;
+const CONNECTION_STATUS_TAG_CONNECTED: u8 = 2;
+const CONNECTION_STATUS_TAG_FAILED: u8 = 3;
 
-const SOCKET_ERROR_TAG_CONNECTION_REFUSED: u8 = 0;
-const SOCKET_ERROR_TAG_CONNECTION_RESET: u8 = 1;
-const SOCKET_ERROR_TAG_CONNECTION_ABORTED: u8 = 2;
-const SOCKET_ERROR_TAG_NETWORK_UNREACHABLE: u8 = 3;
-const SOCKET_ERROR_TAG_HOST_UNREACHABLE: u8 = 4;
-const SOCKET_ERROR_TAG_TIMED_OUT: u8 = 5;
-const SOCKET_ERROR_TAG_ADDRESS_IN_USE: u8 = 6;
-const SOCKET_ERROR_TAG_ADDRESS_NOT_AVAILABLE: u8 = 7;
-const SOCKET_ERROR_TAG_POLICY_DENIED: u8 = 8;
-const SOCKET_ERROR_TAG_OTHER: u8 = 9;
+const RECEIVE_RESPONSE_TAG_RECEIVED: u8 = 0;
+const RECEIVE_RESPONSE_TAG_END_OF_STREAM: u8 = 1;
 
 pub(super) fn encode_socket_request(encoder: &mut Encoder, request: SocketRequest) {
     match request {
@@ -150,7 +143,7 @@ pub(super) fn decode_socket_request(decoder: &mut Decoder<'_>) -> Result<SocketR
 pub(super) fn encode_socket_response(encoder: &mut Encoder, response: SocketResponse) {
     match response {
         SocketResponse::Create(response) => {
-            encoder.u8(SOCKET_RESPONSE_TAG_CREATED);
+            encoder.u8(SOCKET_RESPONSE_TAG_CREATE);
             encoder.handle(response.handle);
         }
         SocketResponse::Connect(response) => {
@@ -158,12 +151,20 @@ pub(super) fn encode_socket_response(encoder: &mut Encoder, response: SocketResp
             encode_connection_status(encoder, response.status);
         }
         SocketResponse::Send(response) => {
-            encoder.u8(SOCKET_RESPONSE_TAG_SENT);
+            encoder.u8(SOCKET_RESPONSE_TAG_SEND);
             encoder.u32(response.sent);
         }
         SocketResponse::Receive(response) => {
-            encoder.u8(SOCKET_RESPONSE_TAG_RECEIVED);
-            encoder.u32(response.received);
+            encoder.u8(SOCKET_RESPONSE_TAG_RECEIVE);
+            match response {
+                ReceiveSocketResponse::Received(received) => {
+                    encoder.u8(RECEIVE_RESPONSE_TAG_RECEIVED);
+                    encoder.u32(received);
+                }
+                ReceiveSocketResponse::EndOfStream => {
+                    encoder.u8(RECEIVE_RESPONSE_TAG_END_OF_STREAM);
+                }
+            }
         }
         SocketResponse::Shutdown => encoder.u8(SOCKET_RESPONSE_TAG_SHUTDOWN),
         SocketResponse::Status(response) => {
@@ -181,17 +182,19 @@ pub(super) fn decode_socket_response(
     decoder: &mut Decoder<'_>,
 ) -> Result<SocketResponse, WireError> {
     match decoder.u8()? {
-        SOCKET_RESPONSE_TAG_CREATED => Ok(SocketResponse::Create(CreateSocketResponse {
+        SOCKET_RESPONSE_TAG_CREATE => Ok(SocketResponse::Create(CreateSocketResponse {
             handle: decoder.handle()?,
         })),
         SOCKET_RESPONSE_TAG_CONNECT => Ok(SocketResponse::Connect(ConnectSocketResponse {
             status: decode_connection_status(decoder)?,
         })),
-        SOCKET_RESPONSE_TAG_SENT => Ok(SocketResponse::Send(SendSocketResponse {
+        SOCKET_RESPONSE_TAG_SEND => Ok(SocketResponse::Send(SendSocketResponse {
             sent: decoder.u32()?,
         })),
-        SOCKET_RESPONSE_TAG_RECEIVED => Ok(SocketResponse::Receive(ReceiveSocketResponse {
-            received: decoder.u32()?,
+        SOCKET_RESPONSE_TAG_RECEIVE => Ok(SocketResponse::Receive(match decoder.u8()? {
+            RECEIVE_RESPONSE_TAG_RECEIVED => ReceiveSocketResponse::Received(decoder.u32()?),
+            RECEIVE_RESPONSE_TAG_END_OF_STREAM => ReceiveSocketResponse::EndOfStream,
+            _ => return Err(WireError::InvalidTag),
         })),
         SOCKET_RESPONSE_TAG_SHUTDOWN => Ok(SocketResponse::Shutdown),
         SOCKET_RESPONSE_TAG_STATUS => Ok(SocketResponse::Status(SocketStatusResponse {
@@ -204,6 +207,7 @@ pub(super) fn decode_socket_response(
 
 fn encode_connection_status(encoder: &mut Encoder, status: SocketConnectionStatus) {
     match status {
+        SocketConnectionStatus::Unconnected => encoder.u8(CONNECTION_STATUS_TAG_UNCONNECTED),
         SocketConnectionStatus::Connecting => encoder.u8(CONNECTION_STATUS_TAG_CONNECTING),
         SocketConnectionStatus::Connected => encoder.u8(CONNECTION_STATUS_TAG_CONNECTED),
         SocketConnectionStatus::Failed(error) => {
@@ -217,6 +221,7 @@ fn decode_connection_status(
     decoder: &mut Decoder<'_>,
 ) -> Result<SocketConnectionStatus, WireError> {
     match decoder.u8()? {
+        CONNECTION_STATUS_TAG_UNCONNECTED => Ok(SocketConnectionStatus::Unconnected),
         CONNECTION_STATUS_TAG_CONNECTING => Ok(SocketConnectionStatus::Connecting),
         CONNECTION_STATUS_TAG_CONNECTED => Ok(SocketConnectionStatus::Connected),
         CONNECTION_STATUS_TAG_FAILED => Ok(SocketConnectionStatus::Failed(decode_socket_error(
@@ -227,34 +232,11 @@ fn decode_connection_status(
 }
 
 fn encode_socket_error(encoder: &mut Encoder, error: SocketError) {
-    encoder.u8(match error {
-        SocketError::ConnectionRefused => SOCKET_ERROR_TAG_CONNECTION_REFUSED,
-        SocketError::ConnectionReset => SOCKET_ERROR_TAG_CONNECTION_RESET,
-        SocketError::ConnectionAborted => SOCKET_ERROR_TAG_CONNECTION_ABORTED,
-        SocketError::NetworkUnreachable => SOCKET_ERROR_TAG_NETWORK_UNREACHABLE,
-        SocketError::HostUnreachable => SOCKET_ERROR_TAG_HOST_UNREACHABLE,
-        SocketError::TimedOut => SOCKET_ERROR_TAG_TIMED_OUT,
-        SocketError::AddressInUse => SOCKET_ERROR_TAG_ADDRESS_IN_USE,
-        SocketError::AddressNotAvailable => SOCKET_ERROR_TAG_ADDRESS_NOT_AVAILABLE,
-        SocketError::PolicyDenied => SOCKET_ERROR_TAG_POLICY_DENIED,
-        SocketError::Other => SOCKET_ERROR_TAG_OTHER,
-    });
+    encoder.u8(error.as_raw());
 }
 
 fn decode_socket_error(decoder: &mut Decoder<'_>) -> Result<SocketError, WireError> {
-    match decoder.u8()? {
-        SOCKET_ERROR_TAG_CONNECTION_REFUSED => Ok(SocketError::ConnectionRefused),
-        SOCKET_ERROR_TAG_CONNECTION_RESET => Ok(SocketError::ConnectionReset),
-        SOCKET_ERROR_TAG_CONNECTION_ABORTED => Ok(SocketError::ConnectionAborted),
-        SOCKET_ERROR_TAG_NETWORK_UNREACHABLE => Ok(SocketError::NetworkUnreachable),
-        SOCKET_ERROR_TAG_HOST_UNREACHABLE => Ok(SocketError::HostUnreachable),
-        SOCKET_ERROR_TAG_TIMED_OUT => Ok(SocketError::TimedOut),
-        SOCKET_ERROR_TAG_ADDRESS_IN_USE => Ok(SocketError::AddressInUse),
-        SOCKET_ERROR_TAG_ADDRESS_NOT_AVAILABLE => Ok(SocketError::AddressNotAvailable),
-        SOCKET_ERROR_TAG_POLICY_DENIED => Ok(SocketError::PolicyDenied),
-        SOCKET_ERROR_TAG_OTHER => Ok(SocketError::Other),
-        _ => Err(WireError::InvalidTag),
-    }
+    SocketError::from_raw(decoder.u8()?).ok_or(WireError::InvalidTag)
 }
 
 fn encode_address(encoder: &mut Encoder, address: SocketAddressV4) {

--- a/litebox_broker_protocol/src/wire/socket.rs
+++ b/litebox_broker_protocol/src/wire/socket.rs
@@ -1,0 +1,271 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+use crate::message::{SocketRequest, SocketResponse};
+use crate::shared_buffer::{SharedBufferDescriptor, SharedBufferSlotIndex};
+use crate::socket::{
+    AddressFamily, ConnectSocketRequest, ConnectSocketResponse, ConnectStatus, CreateSocketRequest,
+    CreateSocketResponse, IpProtocol, Ipv4Address, Port, ReceiveFlags, ReceiveSocketRequest,
+    ReceiveSocketResponse, SendFlags, SendSocketRequest, SendSocketResponse, ShutdownMode,
+    ShutdownSocketRequest, SocketAddressV4, SocketError, SocketStatusRequest, SocketStatusResponse,
+    SocketType,
+};
+
+use super::WireError;
+use super::primitive::{Decoder, Encoder};
+
+const SOCKET_REQUEST_TAG_CREATE: u8 = 0;
+const SOCKET_REQUEST_TAG_CONNECT: u8 = 1;
+const SOCKET_REQUEST_TAG_SEND: u8 = 2;
+const SOCKET_REQUEST_TAG_RECEIVE: u8 = 3;
+const SOCKET_REQUEST_TAG_SHUTDOWN: u8 = 4;
+const SOCKET_REQUEST_TAG_STATUS: u8 = 5;
+
+const SOCKET_RESPONSE_TAG_CREATED: u8 = 0;
+const SOCKET_RESPONSE_TAG_CONNECT: u8 = 1;
+const SOCKET_RESPONSE_TAG_SENT: u8 = 2;
+const SOCKET_RESPONSE_TAG_RECEIVED: u8 = 3;
+const SOCKET_RESPONSE_TAG_SHUTDOWN: u8 = 4;
+const SOCKET_RESPONSE_TAG_STATUS: u8 = 5;
+
+const ADDRESS_FAMILY_TAG_IPV4: u8 = 0;
+
+const TYPE_TAG_STREAM: u8 = 0;
+
+const IP_PROTOCOL_TAG_TCP: u8 = 0;
+
+const SHUTDOWN_TAG_READ: u8 = 0;
+const SHUTDOWN_TAG_WRITE: u8 = 1;
+const SHUTDOWN_TAG_BOTH: u8 = 2;
+
+const CONNECT_TAG_CONNECTED: u8 = 0;
+const CONNECT_TAG_IN_PROGRESS: u8 = 1;
+
+const STATUS_TAG_OK: u8 = 0;
+const STATUS_TAG_ERROR: u8 = 1;
+
+const SOCKET_ERROR_TAG_CONNECTION_REFUSED: u8 = 0;
+const SOCKET_ERROR_TAG_CONNECTION_RESET: u8 = 1;
+const SOCKET_ERROR_TAG_CONNECTION_ABORTED: u8 = 2;
+const SOCKET_ERROR_TAG_NETWORK_UNREACHABLE: u8 = 3;
+const SOCKET_ERROR_TAG_HOST_UNREACHABLE: u8 = 4;
+const SOCKET_ERROR_TAG_TIMED_OUT: u8 = 5;
+const SOCKET_ERROR_TAG_ADDRESS_IN_USE: u8 = 6;
+const SOCKET_ERROR_TAG_ADDRESS_NOT_AVAILABLE: u8 = 7;
+const SOCKET_ERROR_TAG_POLICY_DENIED: u8 = 8;
+const SOCKET_ERROR_TAG_OTHER: u8 = 9;
+
+pub(super) fn encode_socket_request(encoder: &mut Encoder, request: SocketRequest) {
+    match request {
+        SocketRequest::Create(request) => {
+            encoder.u8(SOCKET_REQUEST_TAG_CREATE);
+            encoder.u8(match request.address_family {
+                AddressFamily::Ipv4 => ADDRESS_FAMILY_TAG_IPV4,
+            });
+            encoder.u8(match request.socket_type {
+                SocketType::Stream => TYPE_TAG_STREAM,
+            });
+            encoder.u8(match request.protocol {
+                IpProtocol::Tcp => IP_PROTOCOL_TAG_TCP,
+            });
+        }
+        SocketRequest::Connect(request) => {
+            encoder.u8(SOCKET_REQUEST_TAG_CONNECT);
+            encoder.handle(request.handle);
+            encode_address(encoder, request.address);
+        }
+        SocketRequest::Send(request) => {
+            encoder.u8(SOCKET_REQUEST_TAG_SEND);
+            encoder.handle(request.handle);
+            encode_shared_buffer_descriptor(encoder, request.buffer);
+            encoder.u32(request.flags.0);
+        }
+        SocketRequest::Receive(request) => {
+            encoder.u8(SOCKET_REQUEST_TAG_RECEIVE);
+            encoder.handle(request.handle);
+            encode_shared_buffer_descriptor(encoder, request.buffer);
+            encoder.u32(request.flags.0);
+        }
+        SocketRequest::Shutdown(request) => {
+            encoder.u8(SOCKET_REQUEST_TAG_SHUTDOWN);
+            encoder.handle(request.handle);
+            encoder.u8(match request.mode {
+                ShutdownMode::Read => SHUTDOWN_TAG_READ,
+                ShutdownMode::Write => SHUTDOWN_TAG_WRITE,
+                ShutdownMode::Both => SHUTDOWN_TAG_BOTH,
+            });
+        }
+        SocketRequest::Status(request) => {
+            encoder.u8(SOCKET_REQUEST_TAG_STATUS);
+            encoder.handle(request.handle);
+        }
+    }
+}
+
+pub(super) fn decode_socket_request(decoder: &mut Decoder<'_>) -> Result<SocketRequest, WireError> {
+    match decoder.u8()? {
+        SOCKET_REQUEST_TAG_CREATE => Ok(SocketRequest::Create(CreateSocketRequest {
+            address_family: match decoder.u8()? {
+                ADDRESS_FAMILY_TAG_IPV4 => AddressFamily::Ipv4,
+                _ => return Err(WireError::InvalidTag),
+            },
+            socket_type: match decoder.u8()? {
+                TYPE_TAG_STREAM => SocketType::Stream,
+                _ => return Err(WireError::InvalidTag),
+            },
+            protocol: match decoder.u8()? {
+                IP_PROTOCOL_TAG_TCP => IpProtocol::Tcp,
+                _ => return Err(WireError::InvalidTag),
+            },
+        })),
+        SOCKET_REQUEST_TAG_CONNECT => Ok(SocketRequest::Connect(ConnectSocketRequest {
+            handle: decoder.handle()?,
+            address: decode_address(decoder)?,
+        })),
+        SOCKET_REQUEST_TAG_SEND => Ok(SocketRequest::Send(SendSocketRequest {
+            handle: decoder.handle()?,
+            buffer: decode_shared_buffer_descriptor(decoder)?,
+            flags: SendFlags(decoder.u32()?),
+        })),
+        SOCKET_REQUEST_TAG_RECEIVE => Ok(SocketRequest::Receive(ReceiveSocketRequest {
+            handle: decoder.handle()?,
+            buffer: decode_shared_buffer_descriptor(decoder)?,
+            flags: ReceiveFlags(decoder.u32()?),
+        })),
+        SOCKET_REQUEST_TAG_SHUTDOWN => Ok(SocketRequest::Shutdown(ShutdownSocketRequest {
+            handle: decoder.handle()?,
+            mode: match decoder.u8()? {
+                SHUTDOWN_TAG_READ => ShutdownMode::Read,
+                SHUTDOWN_TAG_WRITE => ShutdownMode::Write,
+                SHUTDOWN_TAG_BOTH => ShutdownMode::Both,
+                _ => return Err(WireError::InvalidTag),
+            },
+        })),
+        SOCKET_REQUEST_TAG_STATUS => Ok(SocketRequest::Status(SocketStatusRequest {
+            handle: decoder.handle()?,
+        })),
+        _ => Err(WireError::InvalidTag),
+    }
+}
+
+pub(super) fn encode_socket_response(encoder: &mut Encoder, response: SocketResponse) {
+    match response {
+        SocketResponse::Create(response) => {
+            encoder.u8(SOCKET_RESPONSE_TAG_CREATED);
+            encoder.handle(response.handle);
+        }
+        SocketResponse::Connect(response) => {
+            encoder.u8(SOCKET_RESPONSE_TAG_CONNECT);
+            encoder.u8(match response.status {
+                ConnectStatus::Connected => CONNECT_TAG_CONNECTED,
+                ConnectStatus::InProgress => CONNECT_TAG_IN_PROGRESS,
+            });
+        }
+        SocketResponse::Send(response) => {
+            encoder.u8(SOCKET_RESPONSE_TAG_SENT);
+            encoder.u32(response.sent);
+        }
+        SocketResponse::Receive(response) => {
+            encoder.u8(SOCKET_RESPONSE_TAG_RECEIVED);
+            encoder.u32(response.received);
+        }
+        SocketResponse::Shutdown => encoder.u8(SOCKET_RESPONSE_TAG_SHUTDOWN),
+        SocketResponse::Status(response) => {
+            encoder.u8(SOCKET_RESPONSE_TAG_STATUS);
+            match response.error {
+                None => encoder.u8(STATUS_TAG_OK),
+                Some(error) => {
+                    encoder.u8(STATUS_TAG_ERROR);
+                    encoder.u8(match error {
+                        SocketError::ConnectionRefused => SOCKET_ERROR_TAG_CONNECTION_REFUSED,
+                        SocketError::ConnectionReset => SOCKET_ERROR_TAG_CONNECTION_RESET,
+                        SocketError::ConnectionAborted => SOCKET_ERROR_TAG_CONNECTION_ABORTED,
+                        SocketError::NetworkUnreachable => SOCKET_ERROR_TAG_NETWORK_UNREACHABLE,
+                        SocketError::HostUnreachable => SOCKET_ERROR_TAG_HOST_UNREACHABLE,
+                        SocketError::TimedOut => SOCKET_ERROR_TAG_TIMED_OUT,
+                        SocketError::AddressInUse => SOCKET_ERROR_TAG_ADDRESS_IN_USE,
+                        SocketError::AddressNotAvailable => SOCKET_ERROR_TAG_ADDRESS_NOT_AVAILABLE,
+                        SocketError::PolicyDenied => SOCKET_ERROR_TAG_POLICY_DENIED,
+                        SocketError::Other => SOCKET_ERROR_TAG_OTHER,
+                    });
+                }
+            }
+        }
+    }
+}
+
+pub(super) fn decode_socket_response(
+    decoder: &mut Decoder<'_>,
+) -> Result<SocketResponse, WireError> {
+    match decoder.u8()? {
+        SOCKET_RESPONSE_TAG_CREATED => Ok(SocketResponse::Create(CreateSocketResponse {
+            handle: decoder.handle()?,
+        })),
+        SOCKET_RESPONSE_TAG_CONNECT => Ok(SocketResponse::Connect(ConnectSocketResponse {
+            status: match decoder.u8()? {
+                CONNECT_TAG_CONNECTED => ConnectStatus::Connected,
+                CONNECT_TAG_IN_PROGRESS => ConnectStatus::InProgress,
+                _ => return Err(WireError::InvalidTag),
+            },
+        })),
+        SOCKET_RESPONSE_TAG_SENT => Ok(SocketResponse::Send(SendSocketResponse {
+            sent: decoder.u32()?,
+        })),
+        SOCKET_RESPONSE_TAG_RECEIVED => Ok(SocketResponse::Receive(ReceiveSocketResponse {
+            received: decoder.u32()?,
+        })),
+        SOCKET_RESPONSE_TAG_SHUTDOWN => Ok(SocketResponse::Shutdown),
+        SOCKET_RESPONSE_TAG_STATUS => Ok(SocketResponse::Status(SocketStatusResponse {
+            error: match decoder.u8()? {
+                STATUS_TAG_OK => None,
+                STATUS_TAG_ERROR => Some(match decoder.u8()? {
+                    SOCKET_ERROR_TAG_CONNECTION_REFUSED => SocketError::ConnectionRefused,
+                    SOCKET_ERROR_TAG_CONNECTION_RESET => SocketError::ConnectionReset,
+                    SOCKET_ERROR_TAG_CONNECTION_ABORTED => SocketError::ConnectionAborted,
+                    SOCKET_ERROR_TAG_NETWORK_UNREACHABLE => SocketError::NetworkUnreachable,
+                    SOCKET_ERROR_TAG_HOST_UNREACHABLE => SocketError::HostUnreachable,
+                    SOCKET_ERROR_TAG_TIMED_OUT => SocketError::TimedOut,
+                    SOCKET_ERROR_TAG_ADDRESS_IN_USE => SocketError::AddressInUse,
+                    SOCKET_ERROR_TAG_ADDRESS_NOT_AVAILABLE => SocketError::AddressNotAvailable,
+                    SOCKET_ERROR_TAG_POLICY_DENIED => SocketError::PolicyDenied,
+                    SOCKET_ERROR_TAG_OTHER => SocketError::Other,
+                    _ => return Err(WireError::InvalidTag),
+                }),
+                _ => return Err(WireError::InvalidTag),
+            },
+        })),
+        _ => Err(WireError::InvalidTag),
+    }
+}
+
+fn encode_address(encoder: &mut Encoder, address: SocketAddressV4) {
+    for octet in address.address.0 {
+        encoder.u8(octet);
+    }
+    encoder.u16(address.port.0);
+}
+
+fn decode_address(decoder: &mut Decoder<'_>) -> Result<SocketAddressV4, WireError> {
+    let mut octets = [0; 4];
+    for octet in &mut octets {
+        *octet = decoder.u8()?;
+    }
+    Ok(SocketAddressV4 {
+        address: Ipv4Address(octets),
+        port: Port(decoder.u16()?),
+    })
+}
+
+fn encode_shared_buffer_descriptor(encoder: &mut Encoder, descriptor: SharedBufferDescriptor) {
+    encoder.u32(descriptor.slot_index.0);
+    encoder.u32(descriptor.length);
+}
+
+fn decode_shared_buffer_descriptor(
+    decoder: &mut Decoder<'_>,
+) -> Result<SharedBufferDescriptor, WireError> {
+    Ok(SharedBufferDescriptor {
+        slot_index: SharedBufferSlotIndex(decoder.u32()?),
+        length: decoder.u32()?,
+    })
+}

--- a/litebox_broker_protocol/src/wire/socket.rs
+++ b/litebox_broker_protocol/src/wire/socket.rs
@@ -4,11 +4,11 @@
 use crate::message::{SocketRequest, SocketResponse};
 use crate::shared_buffer::{SharedBufferDescriptor, SharedBufferSlotIndex};
 use crate::socket::{
-    AddressFamily, ConnectSocketRequest, ConnectSocketResponse, ConnectStatus, CreateSocketRequest,
+    AddressFamily, ConnectSocketRequest, ConnectSocketResponse, CreateSocketRequest,
     CreateSocketResponse, IpProtocol, Ipv4Address, Port, ReceiveFlags, ReceiveSocketRequest,
     ReceiveSocketResponse, SendFlags, SendSocketRequest, SendSocketResponse, ShutdownMode,
-    ShutdownSocketRequest, SocketAddressV4, SocketError, SocketStatusRequest, SocketStatusResponse,
-    SocketType,
+    ShutdownSocketRequest, SocketAddressV4, SocketConnectionStatus, SocketError,
+    SocketStatusRequest, SocketStatusResponse, SocketType,
 };
 
 use super::WireError;
@@ -27,6 +27,7 @@ const SOCKET_RESPONSE_TAG_SENT: u8 = 2;
 const SOCKET_RESPONSE_TAG_RECEIVED: u8 = 3;
 const SOCKET_RESPONSE_TAG_SHUTDOWN: u8 = 4;
 const SOCKET_RESPONSE_TAG_STATUS: u8 = 5;
+const SOCKET_RESPONSE_TAG_FAILED: u8 = 6;
 
 const ADDRESS_FAMILY_TAG_IPV4: u8 = 0;
 
@@ -38,11 +39,9 @@ const SHUTDOWN_TAG_READ: u8 = 0;
 const SHUTDOWN_TAG_WRITE: u8 = 1;
 const SHUTDOWN_TAG_BOTH: u8 = 2;
 
-const CONNECT_TAG_CONNECTED: u8 = 0;
-const CONNECT_TAG_IN_PROGRESS: u8 = 1;
-
-const STATUS_TAG_OK: u8 = 0;
-const STATUS_TAG_ERROR: u8 = 1;
+const CONNECTION_STATUS_TAG_CONNECTING: u8 = 0;
+const CONNECTION_STATUS_TAG_CONNECTED: u8 = 1;
+const CONNECTION_STATUS_TAG_FAILED: u8 = 2;
 
 const SOCKET_ERROR_TAG_CONNECTION_REFUSED: u8 = 0;
 const SOCKET_ERROR_TAG_CONNECTION_RESET: u8 = 1;
@@ -156,10 +155,7 @@ pub(super) fn encode_socket_response(encoder: &mut Encoder, response: SocketResp
         }
         SocketResponse::Connect(response) => {
             encoder.u8(SOCKET_RESPONSE_TAG_CONNECT);
-            encoder.u8(match response.status {
-                ConnectStatus::Connected => CONNECT_TAG_CONNECTED,
-                ConnectStatus::InProgress => CONNECT_TAG_IN_PROGRESS,
-            });
+            encode_connection_status(encoder, response.status);
         }
         SocketResponse::Send(response) => {
             encoder.u8(SOCKET_RESPONSE_TAG_SENT);
@@ -172,24 +168,11 @@ pub(super) fn encode_socket_response(encoder: &mut Encoder, response: SocketResp
         SocketResponse::Shutdown => encoder.u8(SOCKET_RESPONSE_TAG_SHUTDOWN),
         SocketResponse::Status(response) => {
             encoder.u8(SOCKET_RESPONSE_TAG_STATUS);
-            match response.error {
-                None => encoder.u8(STATUS_TAG_OK),
-                Some(error) => {
-                    encoder.u8(STATUS_TAG_ERROR);
-                    encoder.u8(match error {
-                        SocketError::ConnectionRefused => SOCKET_ERROR_TAG_CONNECTION_REFUSED,
-                        SocketError::ConnectionReset => SOCKET_ERROR_TAG_CONNECTION_RESET,
-                        SocketError::ConnectionAborted => SOCKET_ERROR_TAG_CONNECTION_ABORTED,
-                        SocketError::NetworkUnreachable => SOCKET_ERROR_TAG_NETWORK_UNREACHABLE,
-                        SocketError::HostUnreachable => SOCKET_ERROR_TAG_HOST_UNREACHABLE,
-                        SocketError::TimedOut => SOCKET_ERROR_TAG_TIMED_OUT,
-                        SocketError::AddressInUse => SOCKET_ERROR_TAG_ADDRESS_IN_USE,
-                        SocketError::AddressNotAvailable => SOCKET_ERROR_TAG_ADDRESS_NOT_AVAILABLE,
-                        SocketError::PolicyDenied => SOCKET_ERROR_TAG_POLICY_DENIED,
-                        SocketError::Other => SOCKET_ERROR_TAG_OTHER,
-                    });
-                }
-            }
+            encode_connection_status(encoder, response.status);
+        }
+        SocketResponse::Failed(error) => {
+            encoder.u8(SOCKET_RESPONSE_TAG_FAILED);
+            encode_socket_error(encoder, error);
         }
     }
 }
@@ -202,11 +185,7 @@ pub(super) fn decode_socket_response(
             handle: decoder.handle()?,
         })),
         SOCKET_RESPONSE_TAG_CONNECT => Ok(SocketResponse::Connect(ConnectSocketResponse {
-            status: match decoder.u8()? {
-                CONNECT_TAG_CONNECTED => ConnectStatus::Connected,
-                CONNECT_TAG_IN_PROGRESS => ConnectStatus::InProgress,
-                _ => return Err(WireError::InvalidTag),
-            },
+            status: decode_connection_status(decoder)?,
         })),
         SOCKET_RESPONSE_TAG_SENT => Ok(SocketResponse::Send(SendSocketResponse {
             sent: decoder.u32()?,
@@ -216,24 +195,64 @@ pub(super) fn decode_socket_response(
         })),
         SOCKET_RESPONSE_TAG_SHUTDOWN => Ok(SocketResponse::Shutdown),
         SOCKET_RESPONSE_TAG_STATUS => Ok(SocketResponse::Status(SocketStatusResponse {
-            error: match decoder.u8()? {
-                STATUS_TAG_OK => None,
-                STATUS_TAG_ERROR => Some(match decoder.u8()? {
-                    SOCKET_ERROR_TAG_CONNECTION_REFUSED => SocketError::ConnectionRefused,
-                    SOCKET_ERROR_TAG_CONNECTION_RESET => SocketError::ConnectionReset,
-                    SOCKET_ERROR_TAG_CONNECTION_ABORTED => SocketError::ConnectionAborted,
-                    SOCKET_ERROR_TAG_NETWORK_UNREACHABLE => SocketError::NetworkUnreachable,
-                    SOCKET_ERROR_TAG_HOST_UNREACHABLE => SocketError::HostUnreachable,
-                    SOCKET_ERROR_TAG_TIMED_OUT => SocketError::TimedOut,
-                    SOCKET_ERROR_TAG_ADDRESS_IN_USE => SocketError::AddressInUse,
-                    SOCKET_ERROR_TAG_ADDRESS_NOT_AVAILABLE => SocketError::AddressNotAvailable,
-                    SOCKET_ERROR_TAG_POLICY_DENIED => SocketError::PolicyDenied,
-                    SOCKET_ERROR_TAG_OTHER => SocketError::Other,
-                    _ => return Err(WireError::InvalidTag),
-                }),
-                _ => return Err(WireError::InvalidTag),
-            },
+            status: decode_connection_status(decoder)?,
         })),
+        SOCKET_RESPONSE_TAG_FAILED => Ok(SocketResponse::Failed(decode_socket_error(decoder)?)),
+        _ => Err(WireError::InvalidTag),
+    }
+}
+
+fn encode_connection_status(encoder: &mut Encoder, status: SocketConnectionStatus) {
+    match status {
+        SocketConnectionStatus::Connecting => encoder.u8(CONNECTION_STATUS_TAG_CONNECTING),
+        SocketConnectionStatus::Connected => encoder.u8(CONNECTION_STATUS_TAG_CONNECTED),
+        SocketConnectionStatus::Failed(error) => {
+            encoder.u8(CONNECTION_STATUS_TAG_FAILED);
+            encode_socket_error(encoder, error);
+        }
+    }
+}
+
+fn decode_connection_status(
+    decoder: &mut Decoder<'_>,
+) -> Result<SocketConnectionStatus, WireError> {
+    match decoder.u8()? {
+        CONNECTION_STATUS_TAG_CONNECTING => Ok(SocketConnectionStatus::Connecting),
+        CONNECTION_STATUS_TAG_CONNECTED => Ok(SocketConnectionStatus::Connected),
+        CONNECTION_STATUS_TAG_FAILED => Ok(SocketConnectionStatus::Failed(decode_socket_error(
+            decoder,
+        )?)),
+        _ => Err(WireError::InvalidTag),
+    }
+}
+
+fn encode_socket_error(encoder: &mut Encoder, error: SocketError) {
+    encoder.u8(match error {
+        SocketError::ConnectionRefused => SOCKET_ERROR_TAG_CONNECTION_REFUSED,
+        SocketError::ConnectionReset => SOCKET_ERROR_TAG_CONNECTION_RESET,
+        SocketError::ConnectionAborted => SOCKET_ERROR_TAG_CONNECTION_ABORTED,
+        SocketError::NetworkUnreachable => SOCKET_ERROR_TAG_NETWORK_UNREACHABLE,
+        SocketError::HostUnreachable => SOCKET_ERROR_TAG_HOST_UNREACHABLE,
+        SocketError::TimedOut => SOCKET_ERROR_TAG_TIMED_OUT,
+        SocketError::AddressInUse => SOCKET_ERROR_TAG_ADDRESS_IN_USE,
+        SocketError::AddressNotAvailable => SOCKET_ERROR_TAG_ADDRESS_NOT_AVAILABLE,
+        SocketError::PolicyDenied => SOCKET_ERROR_TAG_POLICY_DENIED,
+        SocketError::Other => SOCKET_ERROR_TAG_OTHER,
+    });
+}
+
+fn decode_socket_error(decoder: &mut Decoder<'_>) -> Result<SocketError, WireError> {
+    match decoder.u8()? {
+        SOCKET_ERROR_TAG_CONNECTION_REFUSED => Ok(SocketError::ConnectionRefused),
+        SOCKET_ERROR_TAG_CONNECTION_RESET => Ok(SocketError::ConnectionReset),
+        SOCKET_ERROR_TAG_CONNECTION_ABORTED => Ok(SocketError::ConnectionAborted),
+        SOCKET_ERROR_TAG_NETWORK_UNREACHABLE => Ok(SocketError::NetworkUnreachable),
+        SOCKET_ERROR_TAG_HOST_UNREACHABLE => Ok(SocketError::HostUnreachable),
+        SOCKET_ERROR_TAG_TIMED_OUT => Ok(SocketError::TimedOut),
+        SOCKET_ERROR_TAG_ADDRESS_IN_USE => Ok(SocketError::AddressInUse),
+        SOCKET_ERROR_TAG_ADDRESS_NOT_AVAILABLE => Ok(SocketError::AddressNotAvailable),
+        SOCKET_ERROR_TAG_POLICY_DENIED => Ok(SocketError::PolicyDenied),
+        SOCKET_ERROR_TAG_OTHER => Ok(SocketError::Other),
         _ => Err(WireError::InvalidTag),
     }
 }


### PR DESCRIPTION
This PR defines portable, typed IPv4/TCP broker socket contracts and bounded wire codecs, including shared-buffer descriptors for send and receive. It separates ordinary network outcomes from broker failures and models connection and receive states without exposing platform ABI values or host descriptors. The broker host validates shared-buffer leases but continues to reject socket operations until socket authority is implemented.