### PR TITLE
Add broker-owned socket authority

### DIFF
--- a/litebox/src/broker/error.rs
+++ b/litebox/src/broker/error.rs
@@ -36,6 +36,8 @@ pub(crate) enum BrokerObjectError {
     PermissionDenied,
     #[error("broker memory allocation failed")]
     OutOfMemory,
+    #[error("broker object operation is unsupported")]
+    UnsupportedOperation,
 }
 
 impl From<BrokerControlError> for BrokerObjectError {
@@ -56,10 +58,10 @@ impl From<ErrorCode> for BrokerObjectError {
             ErrorCode::ResourceExhausted => Self::ResourceExhausted,
             ErrorCode::PolicyDenied => Self::PermissionDenied,
             ErrorCode::OutOfMemory => Self::OutOfMemory,
+            ErrorCode::UnsupportedOperation => Self::UnsupportedOperation,
             ErrorCode::UnsupportedVersion
             | ErrorCode::MalformedRequest
             | ErrorCode::ProtocolState
-            | ErrorCode::UnsupportedOperation
             | ErrorCode::Internal => panic!("broker returned unrecoverable error: {error}"),
             _ => panic!("broker returned unsupported error: {error}"),
         }
@@ -97,7 +99,8 @@ impl From<BrokerObjectError> for EventCounterError {
             BrokerObjectError::PermissionDenied => Self::PermissionDenied,
             BrokerObjectError::Control
             | BrokerObjectError::InvalidObject
-            | BrokerObjectError::PeerClosed => Self::Io,
+            | BrokerObjectError::PeerClosed
+            | BrokerObjectError::UnsupportedOperation => Self::Io,
         }
     }
 }

--- a/litebox/src/pipes.rs
+++ b/litebox/src/pipes.rs
@@ -542,7 +542,8 @@ impl From<BrokerObjectError> for TryOpError<PipeError> {
             | BrokerObjectError::InvalidObject
             | BrokerObjectError::ResourceExhausted
             | BrokerObjectError::PermissionDenied
-            | BrokerObjectError::OutOfMemory => TryOpError::Other(PipeError::Io),
+            | BrokerObjectError::OutOfMemory
+            | BrokerObjectError::UnsupportedOperation => TryOpError::Other(PipeError::Io),
         }
     }
 }
@@ -556,7 +557,8 @@ impl From<BrokerObjectError> for errors::CreateError {
             BrokerObjectError::Control
             | BrokerObjectError::InvalidObject
             | BrokerObjectError::WouldBlock
-            | BrokerObjectError::PeerClosed => Self::Io,
+            | BrokerObjectError::PeerClosed
+            | BrokerObjectError::UnsupportedOperation => Self::Io,
         }
     }
 }

--- a/litebox_broker_core/Cargo.toml
+++ b/litebox_broker_core/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 bitflags = { version = "2.9.0", default-features = false }
 hashbrown = "0.15.2"
 litebox_broker_protocol = { path = "../litebox_broker_protocol", version = "0.1.0" }
-spin = { version = "0.9.8", default-features = false, features = ["rwlock", "spin_mutex"] }
+spin = { version = "0.9.8", default-features = false, features = ["once", "rwlock", "spin_mutex"] }
 thiserror = { version = "2.0.6", default-features = false }
 
 [lints]

--- a/litebox_broker_core/src/event.rs
+++ b/litebox_broker_core/src/event.rs
@@ -22,11 +22,12 @@ pub fn create(session: &BrokerSession, initial_count: u64) -> Result<ObjectHandl
 
 /// Adds readiness credits to a broker-owned event object.
 pub fn add(session: &BrokerSession, handle: ObjectHandle, value: u64) -> Result<ReadinessFlags> {
-    let required_rights = ObjectRights::WRITE;
-    session.with_authorized_object_mut(handle, required_rights, |object| match object {
+    let object = session.authorized_object(handle, ObjectRights::WRITE)?;
+    let mut object = object.write();
+    match &mut *object {
         ObjectEntry::Event(event) => event.add(value),
         ObjectEntry::Pipe(_) | ObjectEntry::Socket(_) => Err(BrokerError::InvalidRights),
-    })
+    }
 }
 
 /// Consumes readiness credits from a broker-owned event object.
@@ -35,11 +36,12 @@ pub fn consume(
     handle: ObjectHandle,
     mode: EventConsumeMode,
 ) -> Result<EventConsumption> {
-    let required_rights = ObjectRights::WAIT;
-    session.with_authorized_object_mut(handle, required_rights, |object| match object {
+    let object = session.authorized_object(handle, ObjectRights::WAIT)?;
+    let mut object = object.write();
+    match &mut *object {
         ObjectEntry::Event(event) => event.consume(mode),
         ObjectEntry::Pipe(_) | ObjectEntry::Socket(_) => Err(BrokerError::InvalidRights),
-    })
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/litebox_broker_core/src/event.rs
+++ b/litebox_broker_core/src/event.rs
@@ -27,6 +27,7 @@ pub fn add(session: &BrokerSession, handle: ObjectHandle, value: u64) -> Result<
     match &mut *object {
         ObjectEntry::Event(event) => event.add(value),
         ObjectEntry::Pipe(_) | ObjectEntry::Socket(_) => Err(BrokerError::InvalidRights),
+        ObjectEntry::Reserved => Err(BrokerError::Internal),
     }
 }
 
@@ -41,6 +42,7 @@ pub fn consume(
     match &mut *object {
         ObjectEntry::Event(event) => event.consume(mode),
         ObjectEntry::Pipe(_) | ObjectEntry::Socket(_) => Err(BrokerError::InvalidRights),
+        ObjectEntry::Reserved => Err(BrokerError::Internal),
     }
 }
 

--- a/litebox_broker_core/src/event.rs
+++ b/litebox_broker_core/src/event.rs
@@ -25,7 +25,7 @@ pub fn add(session: &BrokerSession, handle: ObjectHandle, value: u64) -> Result<
     let required_rights = ObjectRights::WRITE;
     session.with_authorized_object_mut(handle, required_rights, |object| match object {
         ObjectEntry::Event(event) => event.add(value),
-        ObjectEntry::Pipe(_) => Err(BrokerError::InvalidRights),
+        ObjectEntry::Pipe(_) | ObjectEntry::Socket(_) => Err(BrokerError::InvalidRights),
     })
 }
 
@@ -38,7 +38,7 @@ pub fn consume(
     let required_rights = ObjectRights::WAIT;
     session.with_authorized_object_mut(handle, required_rights, |object| match object {
         ObjectEntry::Event(event) => event.consume(mode),
-        ObjectEntry::Pipe(_) => Err(BrokerError::InvalidRights),
+        ObjectEntry::Pipe(_) | ObjectEntry::Socket(_) => Err(BrokerError::InvalidRights),
     })
 }
 

--- a/litebox_broker_core/src/lib.rs
+++ b/litebox_broker_core/src/lib.rs
@@ -22,6 +22,7 @@ mod error;
 pub mod event;
 pub mod pipe;
 mod policy;
+pub mod readiness;
 mod session;
 pub mod socket;
 

--- a/litebox_broker_core/src/lib.rs
+++ b/litebox_broker_core/src/lib.rs
@@ -36,7 +36,7 @@ pub use error::BrokerError;
 pub use policy::{PolicyEngine, PolicyProfile, SocketPolicy};
 use session::ObjectReference;
 pub use session::{BrokerSession, CallerCredential, ObjectRights, SessionId};
-use socket::{SocketProvider, UnsupportedSocketProvider};
+use socket::SocketProvider;
 
 /// BrokerCore result type.
 pub type Result<T> = core::result::Result<T, BrokerError>;
@@ -118,37 +118,13 @@ pub struct BrokerCore {
 static BROKER_CORE_CREATED: AtomicBool = AtomicBool::new(false);
 
 impl BrokerCore {
-    /// Creates the broker core with the provided policy engine.
-    pub fn new(policy: PolicyEngine) -> Result<Self> {
-        Self::new_with_limits(policy, BrokerCoreLimits::DEFAULT)
-    }
-
-    /// Creates the broker core with explicit authority-state limits.
-    pub fn new_with_limits(policy: PolicyEngine, limits: BrokerCoreLimits) -> Result<Self> {
-        if !policy.denies_socket_creation() {
-            return Err(BrokerError::UnsupportedOperation);
-        }
-        Self::new_with_limits_and_socket_provider(
-            policy,
-            limits,
-            Arc::new(UnsupportedSocketProvider),
-        )
-    }
-
-    /// Creates the broker core with an injected platform socket provider.
-    pub fn new_with_socket_provider(
-        policy: PolicyEngine,
-        socket_provider: Arc<dyn SocketProvider>,
-    ) -> Result<Self> {
-        Self::new_with_limits_and_socket_provider(
-            policy,
-            BrokerCoreLimits::DEFAULT,
-            socket_provider,
-        )
+    /// Creates the broker core with a platform socket provider.
+    pub fn new(policy: PolicyEngine, socket_provider: Arc<dyn SocketProvider>) -> Result<Self> {
+        Self::new_with_limits(policy, BrokerCoreLimits::DEFAULT, socket_provider)
     }
 
     /// Creates the broker core with explicit limits and a platform socket provider.
-    pub fn new_with_limits_and_socket_provider(
+    pub fn new_with_limits(
         policy: PolicyEngine,
         limits: BrokerCoreLimits,
         socket_provider: Arc<dyn SocketProvider>,

--- a/litebox_broker_core/src/lib.rs
+++ b/litebox_broker_core/src/lib.rs
@@ -119,12 +119,12 @@ pub struct BrokerCore {
 static BROKER_CORE_CREATED: AtomicBool = AtomicBool::new(false);
 
 impl BrokerCore {
-    /// Creates the broker core with a platform socket provider.
+    /// Creates the broker core with a broker-wide platform socket provider.
     pub fn new(policy: PolicyEngine, socket_provider: Arc<dyn SocketProvider>) -> Result<Self> {
         Self::new_with_limits(policy, BrokerCoreLimits::DEFAULT, socket_provider)
     }
 
-    /// Creates the broker core with explicit limits and a platform socket provider.
+    /// Creates the broker core with explicit limits and a socket provider.
     pub fn new_with_limits(
         policy: PolicyEngine,
         limits: BrokerCoreLimits,

--- a/litebox_broker_core/src/lib.rs
+++ b/litebox_broker_core/src/lib.rs
@@ -187,7 +187,7 @@ impl BrokerCore {
             .ok_or(BrokerError::ResourceExhausted)?;
         Ok(BrokerSession::new(
             self.clone(),
-            SessionId::new(session_id),
+            SessionId(session_id),
             caller_credential,
         ))
     }

--- a/litebox_broker_core/src/lib.rs
+++ b/litebox_broker_core/src/lib.rs
@@ -75,8 +75,8 @@ impl BrokerCoreLimits {
         }
     }
 
-    /// Creates a broker core limit set with explicit socket limits.
-    pub const fn new_with_socket_limits(
+    /// Creates a broker core limit set with every limit specified explicitly.
+    pub const fn new_with_all_limits(
         max_references: usize,
         max_total_pipe_capacity: usize,
         max_sockets: usize,

--- a/litebox_broker_core/src/lib.rs
+++ b/litebox_broker_core/src/lib.rs
@@ -23,6 +23,7 @@ pub mod event;
 pub mod pipe;
 mod policy;
 mod session;
+pub mod socket;
 
 use alloc::sync::Arc;
 use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -32,16 +33,16 @@ use litebox_broker_protocol::ObjectHandle;
 use spin::rwlock::RwLock;
 
 pub use error::BrokerError;
-pub use policy::{PolicyEngine, PolicyProfile};
+pub use policy::{PolicyEngine, PolicyProfile, SocketPolicy};
 use session::ObjectReference;
-pub use session::{BrokerSession, CallerCredential, ObjectRights};
+pub use session::{BrokerSession, CallerCredential, ObjectRights, SessionId};
+use socket::{SocketProvider, UnsupportedSocketProvider};
 
 /// BrokerCore result type.
 pub type Result<T> = core::result::Result<T, BrokerError>;
 
 /// Resource limits for broker-owned authority state.
 ///
-/// These limits are global to the broker core, not per session.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct BrokerCoreLimits {
@@ -49,6 +50,10 @@ pub struct BrokerCoreLimits {
     pub max_references: usize,
     /// Maximum total capacity in bytes reserved by live pipes.
     pub max_total_pipe_capacity: usize,
+    /// Maximum live platform socket resources across all sessions.
+    pub max_sockets: usize,
+    /// Maximum live platform socket resources owned by one session.
+    pub max_sockets_per_session: usize,
 }
 
 impl BrokerCoreLimits {
@@ -56,6 +61,8 @@ impl BrokerCoreLimits {
     pub const DEFAULT: Self = Self {
         max_references: 4096,
         max_total_pipe_capacity: 64 * 1024 * 1024,
+        max_sockets: 1024,
+        max_sockets_per_session: 256,
     };
 
     /// Creates a broker core limit set.
@@ -63,6 +70,23 @@ impl BrokerCoreLimits {
         Self {
             max_references,
             max_total_pipe_capacity,
+            max_sockets: Self::DEFAULT.max_sockets,
+            max_sockets_per_session: Self::DEFAULT.max_sockets_per_session,
+        }
+    }
+
+    /// Creates a broker core limit set with explicit socket limits.
+    pub const fn new_with_socket_limits(
+        max_references: usize,
+        max_total_pipe_capacity: usize,
+        max_sockets: usize,
+        max_sockets_per_session: usize,
+    ) -> Self {
+        Self {
+            max_references,
+            max_total_pipe_capacity,
+            max_sockets,
+            max_sockets_per_session,
         }
     }
 }
@@ -85,7 +109,10 @@ pub struct BrokerCore {
     pub(crate) next_session_id: Arc<RwLock<u64>>,
     pub(crate) next_reference_handle: Arc<RwLock<u64>>,
     pub(crate) references: Arc<RwLock<HashMap<ObjectHandle, ObjectReference>>>,
+    pub(crate) pending_references: Arc<AtomicUsize>,
     pub(crate) reserved_pipe_capacity: Arc<AtomicUsize>,
+    pub(crate) reserved_sockets: Arc<AtomicUsize>,
+    pub(crate) socket_provider: Arc<dyn SocketProvider>,
 }
 
 static BROKER_CORE_CREATED: AtomicBool = AtomicBool::new(false);
@@ -98,6 +125,34 @@ impl BrokerCore {
 
     /// Creates the broker core with explicit authority-state limits.
     pub fn new_with_limits(policy: PolicyEngine, limits: BrokerCoreLimits) -> Result<Self> {
+        if !policy.denies_socket_creation() {
+            return Err(BrokerError::UnsupportedOperation);
+        }
+        Self::new_with_limits_and_socket_provider(
+            policy,
+            limits,
+            Arc::new(UnsupportedSocketProvider),
+        )
+    }
+
+    /// Creates the broker core with an injected platform socket provider.
+    pub fn new_with_socket_provider(
+        policy: PolicyEngine,
+        socket_provider: Arc<dyn SocketProvider>,
+    ) -> Result<Self> {
+        Self::new_with_limits_and_socket_provider(
+            policy,
+            BrokerCoreLimits::DEFAULT,
+            socket_provider,
+        )
+    }
+
+    /// Creates the broker core with explicit limits and a platform socket provider.
+    pub fn new_with_limits_and_socket_provider(
+        policy: PolicyEngine,
+        limits: BrokerCoreLimits,
+        socket_provider: Arc<dyn SocketProvider>,
+    ) -> Result<Self> {
         BROKER_CORE_CREATED
             .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
             .map_err(|_| BrokerError::BrokerCoreAlreadyExists)?;
@@ -108,8 +163,17 @@ impl BrokerCore {
             next_session_id: Arc::new(RwLock::new(1)),
             next_reference_handle: Arc::new(RwLock::new(1)),
             references: Arc::new(RwLock::new(HashMap::new())),
+            pending_references: Arc::new(AtomicUsize::new(0)),
             reserved_pipe_capacity: Arc::new(AtomicUsize::new(0)),
+            reserved_sockets: Arc::new(AtomicUsize::new(0)),
+            socket_provider,
         })
+    }
+
+    /// Returns the configured authority-state limits.
+    #[must_use]
+    pub const fn limits(&self) -> BrokerCoreLimits {
+        self.limits
     }
 
     pub(crate) fn allocate_reference_handle(&self) -> Result<ObjectHandle> {
@@ -147,7 +211,7 @@ impl BrokerCore {
             .ok_or(BrokerError::ResourceExhausted)?;
         Ok(BrokerSession::new(
             self.clone(),
-            session::SessionId(session_id),
+            SessionId::new(session_id),
             caller_credential,
         ))
     }

--- a/litebox_broker_core/src/pipe.rs
+++ b/litebox_broker_core/src/pipe.rs
@@ -58,10 +58,12 @@ pub fn read(session: &BrokerSession, handle: ObjectHandle, length: u32) -> Resul
     if length > MAX_PIPE_TRANSFER_SIZE {
         return Err(BrokerError::ResourceExhausted);
     }
-    session.with_authorized_object(handle, ObjectRights::WAIT, |object| match object {
+    let object = session.authorized_object(handle, ObjectRights::WAIT)?;
+    let object = object.read();
+    match &*object {
         ObjectEntry::Pipe(pipe) => pipe.read(length as usize),
         ObjectEntry::Event(_) | ObjectEntry::Socket(_) => Err(BrokerError::InvalidRights),
-    })
+    }
 }
 
 /// Writes bytes to a broker-owned pipe.
@@ -69,10 +71,12 @@ pub fn write(session: &BrokerSession, handle: ObjectHandle, data: &[u8]) -> Resu
     if data.len() > MAX_PIPE_TRANSFER_SIZE as usize {
         return Err(BrokerError::ResourceExhausted);
     }
-    session.with_authorized_object(handle, ObjectRights::WRITE, |object| match object {
+    let object = session.authorized_object(handle, ObjectRights::WRITE)?;
+    let object = object.read();
+    match &*object {
         ObjectEntry::Pipe(pipe) => pipe.write(data),
         ObjectEntry::Event(_) | ObjectEntry::Socket(_) => Err(BrokerError::InvalidRights),
-    })
+    }
 }
 
 pub(crate) struct PipeObject {

--- a/litebox_broker_core/src/pipe.rs
+++ b/litebox_broker_core/src/pipe.rs
@@ -63,6 +63,7 @@ pub fn read(session: &BrokerSession, handle: ObjectHandle, length: u32) -> Resul
     match &*object {
         ObjectEntry::Pipe(pipe) => pipe.read(length as usize),
         ObjectEntry::Event(_) | ObjectEntry::Socket(_) => Err(BrokerError::InvalidRights),
+        ObjectEntry::Reserved => Err(BrokerError::Internal),
     }
 }
 
@@ -76,6 +77,7 @@ pub fn write(session: &BrokerSession, handle: ObjectHandle, data: &[u8]) -> Resu
     match &*object {
         ObjectEntry::Pipe(pipe) => pipe.write(data),
         ObjectEntry::Event(_) | ObjectEntry::Socket(_) => Err(BrokerError::InvalidRights),
+        ObjectEntry::Reserved => Err(BrokerError::Internal),
     }
 }
 

--- a/litebox_broker_core/src/pipe.rs
+++ b/litebox_broker_core/src/pipe.rs
@@ -60,7 +60,7 @@ pub fn read(session: &BrokerSession, handle: ObjectHandle, length: u32) -> Resul
     }
     session.with_authorized_object(handle, ObjectRights::WAIT, |object| match object {
         ObjectEntry::Pipe(pipe) => pipe.read(length as usize),
-        ObjectEntry::Event(_) => Err(BrokerError::InvalidRights),
+        ObjectEntry::Event(_) | ObjectEntry::Socket(_) => Err(BrokerError::InvalidRights),
     })
 }
 
@@ -71,7 +71,7 @@ pub fn write(session: &BrokerSession, handle: ObjectHandle, data: &[u8]) -> Resu
     }
     session.with_authorized_object(handle, ObjectRights::WRITE, |object| match object {
         ObjectEntry::Pipe(pipe) => pipe.write(data),
-        ObjectEntry::Event(_) => Err(BrokerError::InvalidRights),
+        ObjectEntry::Event(_) | ObjectEntry::Socket(_) => Err(BrokerError::InvalidRights),
     })
 }
 

--- a/litebox_broker_core/src/policy.rs
+++ b/litebox_broker_core/src/policy.rs
@@ -7,6 +7,11 @@ use litebox_broker_protocol::socket::{
 };
 
 /// Network access available to broker-owned sockets.
+///
+/// This is separate from [`PolicyProfile`] because that profile grants generic
+/// object rights shared by events, pipes, and sockets. Granting those rights
+/// must not implicitly grant network access, so socket creation and destination
+/// restrictions are configured as an independent, default-deny policy axis.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum SocketPolicy {

--- a/litebox_broker_core/src/policy.rs
+++ b/litebox_broker_core/src/policy.rs
@@ -3,7 +3,7 @@
 
 use crate::{BrokerError, CallerCredential, ObjectRights};
 use litebox_broker_protocol::socket::{
-    AddressFamily, CreateSocketRequest, IpProtocol, SocketAddressV4, SocketError, SocketType,
+    AddressFamily, CreateSocketRequest, IpProtocol, SocketAddressV4, SocketType,
 };
 
 /// Network access available to broker-owned sockets.
@@ -121,14 +121,13 @@ impl PolicyEngine {
         &self,
         caller_credential: CallerCredential,
         address: SocketAddressV4,
-    ) -> Result<(), SocketError> {
-        self.principal_object_rights(caller_credential)
-            .map_err(|_| SocketError::PolicyDenied)?;
+    ) -> Result<(), BrokerError> {
+        self.principal_object_rights(caller_credential)?;
         match self.socket_policy {
             // The initial loopback profile intentionally permits every port.
             // Destination-port rules belong to the later Layer 3/4 policy.
             SocketPolicy::Ipv4LoopbackTcp if address.address.0[0] == 127 => Ok(()),
-            SocketPolicy::Deny | SocketPolicy::Ipv4LoopbackTcp => Err(SocketError::PolicyDenied),
+            SocketPolicy::Deny | SocketPolicy::Ipv4LoopbackTcp => Err(BrokerError::PolicyDenied),
         }
     }
 }
@@ -226,7 +225,7 @@ mod tests {
                     port: Port(80),
                 },
             ),
-            Err(SocketError::PolicyDenied)
+            Err(BrokerError::PolicyDenied)
         );
     }
 }

--- a/litebox_broker_core/src/policy.rs
+++ b/litebox_broker_core/src/policy.rs
@@ -2,6 +2,20 @@
 // Licensed under the MIT license.
 
 use crate::{BrokerError, CallerCredential, ObjectRights};
+use litebox_broker_protocol::socket::{
+    AddressFamily, CreateSocketRequest, IpProtocol, SocketAddressV4, SocketError, SocketType,
+};
+
+/// Network access available to broker-owned sockets.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SocketPolicy {
+    /// Deny all socket creation and connection attempts.
+    #[default]
+    Deny,
+    /// Allow IPv4 TCP sockets to connect only to the IPv4 loopback network.
+    Ipv4LoopbackTcp,
+}
 
 /// Configured broker policy.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -29,12 +43,16 @@ pub enum PolicyProfile {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PolicyEngine {
     profile: PolicyProfile,
+    socket_policy: SocketPolicy,
 }
 
 impl PolicyEngine {
     /// Creates a policy engine from a policy profile.
     pub const fn new(profile: PolicyProfile) -> Self {
-        Self { profile }
+        Self {
+            profile,
+            socket_policy: SocketPolicy::Deny,
+        }
     }
 
     /// Creates a policy engine that denies every operation.
@@ -50,6 +68,13 @@ impl PolicyEngine {
     /// Creates a policy engine with rights for a host-guaranteed principal.
     pub const fn with_host_guaranteed_rights(rights: ObjectRights) -> Self {
         Self::new(PolicyProfile::HostGuaranteed { rights })
+    }
+
+    /// Configures network access for broker-owned sockets.
+    #[must_use]
+    pub const fn with_socket_policy(mut self, socket_policy: SocketPolicy) -> Self {
+        self.socket_policy = socket_policy;
+        self
     }
 
     pub(crate) fn principal_object_rights(
@@ -68,6 +93,43 @@ impl PolicyEngine {
         }
         Ok(rights)
     }
+
+    pub(crate) fn authorize_socket_create(
+        &self,
+        caller_credential: CallerCredential,
+        request: CreateSocketRequest,
+    ) -> Result<ObjectRights, BrokerError> {
+        let rights = self.principal_object_rights(caller_credential)?;
+        match self.socket_policy {
+            SocketPolicy::Ipv4LoopbackTcp
+                if request.address_family == AddressFamily::Ipv4
+                    && request.socket_type == SocketType::Stream
+                    && request.protocol == IpProtocol::Tcp =>
+            {
+                Ok(rights)
+            }
+            SocketPolicy::Deny | SocketPolicy::Ipv4LoopbackTcp => Err(BrokerError::PolicyDenied),
+        }
+    }
+
+    pub(crate) const fn denies_socket_creation(&self) -> bool {
+        matches!(self.socket_policy, SocketPolicy::Deny)
+    }
+
+    pub(crate) fn authorize_socket_connect(
+        &self,
+        caller_credential: CallerCredential,
+        address: SocketAddressV4,
+    ) -> Result<(), SocketError> {
+        self.principal_object_rights(caller_credential)
+            .map_err(|_| SocketError::PolicyDenied)?;
+        match self.socket_policy {
+            // The initial loopback profile intentionally permits every port.
+            // Destination-port rules belong to the later Layer 3/4 policy.
+            SocketPolicy::Ipv4LoopbackTcp if address.address.0[0] == 127 => Ok(()),
+            SocketPolicy::Deny | SocketPolicy::Ipv4LoopbackTcp => Err(SocketError::PolicyDenied),
+        }
+    }
 }
 
 impl Default for PolicyEngine {
@@ -79,6 +141,7 @@ impl Default for PolicyEngine {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use litebox_broker_protocol::socket::{Ipv4Address, Port};
 
     #[test]
     fn static_policy_allows_configured_principal_rights() {
@@ -121,6 +184,48 @@ mod tests {
         assert_eq!(
             policy.principal_object_rights(CallerCredential::Unauthenticated),
             Err(BrokerError::PolicyDenied)
+        );
+    }
+
+    #[test]
+    fn socket_policy_defaults_to_deny() {
+        let policy = PolicyEngine::with_unauthenticated_rights(ObjectRights::all());
+        assert_eq!(
+            policy.authorize_socket_create(
+                CallerCredential::Unauthenticated,
+                CreateSocketRequest {
+                    address_family: AddressFamily::Ipv4,
+                    socket_type: SocketType::Stream,
+                    protocol: IpProtocol::Tcp,
+                },
+            ),
+            Err(BrokerError::PolicyDenied)
+        );
+    }
+
+    #[test]
+    fn loopback_socket_policy_rejects_non_loopback_destinations() {
+        let policy = PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
+            .with_socket_policy(SocketPolicy::Ipv4LoopbackTcp);
+        assert_eq!(
+            policy.authorize_socket_connect(
+                CallerCredential::Unauthenticated,
+                SocketAddressV4 {
+                    address: Ipv4Address([127, 0, 0, 1]),
+                    port: Port(80),
+                },
+            ),
+            Ok(())
+        );
+        assert_eq!(
+            policy.authorize_socket_connect(
+                CallerCredential::Unauthenticated,
+                SocketAddressV4 {
+                    address: Ipv4Address([10, 0, 0, 1]),
+                    port: Port(80),
+                },
+            ),
+            Err(SocketError::PolicyDenied)
         );
     }
 }

--- a/litebox_broker_core/src/policy.rs
+++ b/litebox_broker_core/src/policy.rs
@@ -112,10 +112,6 @@ impl PolicyEngine {
         }
     }
 
-    pub(crate) const fn denies_socket_creation(&self) -> bool {
-        matches!(self.socket_policy, SocketPolicy::Deny)
-    }
-
     pub(crate) fn authorize_socket_connect(
         &self,
         caller_credential: CallerCredential,

--- a/litebox_broker_core/src/readiness.rs
+++ b/litebox_broker_core/src/readiness.rs
@@ -119,3 +119,44 @@ impl Drop for ReadinessPublishGuard<'_> {
         }
     }
 }
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use super::*;
+
+    #[derive(Default)]
+    pub(crate) struct TestReadinessSink {
+        pub(crate) published: Mutex<std::vec::Vec<(ObjectHandle, ReadinessFlags)>>,
+        pub(crate) retired: Mutex<std::vec::Vec<ObjectHandle>>,
+    }
+
+    impl ReadinessSink for TestReadinessSink {
+        fn max_tracked_objects(&self) -> usize {
+            usize::MAX
+        }
+
+        fn publish(&self, handle: ObjectHandle, readiness: ReadinessFlags) -> Result<()> {
+            self.published.lock().unwrap().push((handle, readiness));
+            Ok(())
+        }
+
+        fn retire(&self, handle: ObjectHandle) {
+            self.retired.lock().unwrap().push(handle);
+        }
+    }
+
+    #[test]
+    fn retired_registration_discards_updates_from_retained_clones() {
+        let sink = Arc::new(TestReadinessSink::default());
+        let registration = ReadinessRegistration::new(ObjectHandle(99), sink.clone());
+        let retained = registration.clone();
+
+        registration.retire();
+        retained.publish(ReadinessFlags::READ).unwrap();
+
+        assert!(sink.published.lock().unwrap().is_empty());
+        assert_eq!(sink.retired.lock().unwrap().as_slice(), [ObjectHandle(99)]);
+    }
+}

--- a/litebox_broker_core/src/readiness.rs
+++ b/litebox_broker_core/src/readiness.rs
@@ -30,7 +30,16 @@ pub struct ReadinessRegistration {
 }
 
 impl ReadinessRegistration {
-    pub(crate) fn new(handle: ObjectHandle, sink: Arc<dyn ReadinessSink>) -> Self {
+    pub(crate) fn new_with_retirement_guard<Guard>(
+        handle: ObjectHandle,
+        sink: Arc<dyn ReadinessSink>,
+        retirement_guard: Arc<Guard>,
+    ) -> Self
+    where
+        Guard: Send + Sync + 'static,
+    {
+        // The guard keeps capacity charged until a deferred sink retirement
+        // has actually been delivered.
         Self {
             inner: Arc::new(ReadinessRegistrationInner {
                 handle,
@@ -39,6 +48,7 @@ impl ReadinessRegistration {
                     retired: false,
                     active_publishers: 0,
                     retirement_sent: false,
+                    retirement_guard: Some(retirement_guard),
                 }),
             }),
         }
@@ -77,19 +87,24 @@ struct ReadinessRegistrationState {
     retired: bool,
     active_publishers: usize,
     retirement_sent: bool,
+    retirement_guard: Option<Arc<dyn Send + Sync>>,
 }
 
 impl ReadinessRegistrationInner {
     fn retire(&self) {
-        let should_retire = {
+        let (should_retire, retirement_guard) = {
             let mut state = self.state.lock();
             state.retired = true;
             let should_retire = state.active_publishers == 0 && !state.retirement_sent;
             state.retirement_sent |= should_retire;
-            should_retire
+            let retirement_guard = should_retire
+                .then(|| state.retirement_guard.take())
+                .flatten();
+            (should_retire, retirement_guard)
         };
         if should_retire {
             self.sink.retire(self.handle);
+            drop(retirement_guard);
         }
     }
 }
@@ -106,16 +121,20 @@ struct ReadinessPublishGuard<'registration> {
 
 impl Drop for ReadinessPublishGuard<'_> {
     fn drop(&mut self) {
-        let should_retire = {
+        let (should_retire, retirement_guard) = {
             let mut state = self.inner.state.lock();
             state.active_publishers -= 1;
             let should_retire =
                 state.retired && state.active_publishers == 0 && !state.retirement_sent;
             state.retirement_sent |= should_retire;
-            should_retire
+            let retirement_guard = should_retire
+                .then(|| state.retirement_guard.take())
+                .flatten();
+            (should_retire, retirement_guard)
         };
         if should_retire {
             self.inner.sink.retire(self.inner.handle);
+            drop(retirement_guard);
         }
     }
 }
@@ -150,7 +169,11 @@ pub(crate) mod tests {
     #[test]
     fn retired_registration_discards_updates_from_retained_clones() {
         let sink = Arc::new(TestReadinessSink::default());
-        let registration = ReadinessRegistration::new(ObjectHandle(99), sink.clone());
+        let registration = ReadinessRegistration::new_with_retirement_guard(
+            ObjectHandle(99),
+            sink.clone(),
+            Arc::new(()),
+        );
         let retained = registration.clone();
 
         registration.retire();

--- a/litebox_broker_core/src/readiness.rs
+++ b/litebox_broker_core/src/readiness.rs
@@ -1,0 +1,121 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//! Provider-driven broker object readiness.
+
+use alloc::sync::Arc;
+
+use litebox_broker_protocol::ObjectHandle;
+use litebox_broker_protocol::readiness::ReadinessFlags;
+use spin::Mutex;
+
+use crate::{BrokerError, Result};
+
+/// Per-association destination for asynchronous broker object readiness.
+pub trait ReadinessSink: Send + Sync {
+    /// Maximum number of simultaneously live object registrations.
+    fn max_tracked_objects(&self) -> usize;
+
+    /// Records a new authoritative readiness snapshot.
+    fn publish(&self, handle: ObjectHandle, readiness: ReadinessFlags) -> Result<()>;
+
+    /// Retires all readiness state for an object that can no longer publish.
+    fn retire(&self, handle: ObjectHandle);
+}
+
+/// Capability for publishing readiness for one broker-assigned object handle.
+#[derive(Clone)]
+pub struct ReadinessRegistration {
+    inner: Arc<ReadinessRegistrationInner>,
+}
+
+impl ReadinessRegistration {
+    pub(crate) fn new(handle: ObjectHandle, sink: Arc<dyn ReadinessSink>) -> Self {
+        Self {
+            inner: Arc::new(ReadinessRegistrationInner {
+                handle,
+                sink,
+                state: Mutex::new(ReadinessRegistrationState {
+                    retired: false,
+                    active_publishers: 0,
+                    retirement_sent: false,
+                }),
+            }),
+        }
+    }
+
+    /// Publishes the object's current readiness.
+    ///
+    /// Updates after the broker retires the object are discarded.
+    pub fn publish(&self, readiness: ReadinessFlags) -> Result<()> {
+        {
+            let mut state = self.inner.state.lock();
+            if state.retired {
+                return Ok(());
+            }
+            state.active_publishers = state
+                .active_publishers
+                .checked_add(1)
+                .ok_or(BrokerError::ResourceExhausted)?;
+        }
+        let _publishing = ReadinessPublishGuard { inner: &self.inner };
+        self.inner.sink.publish(self.inner.handle, readiness)
+    }
+
+    pub(crate) fn retire(&self) {
+        self.inner.retire();
+    }
+}
+
+struct ReadinessRegistrationInner {
+    handle: ObjectHandle,
+    sink: Arc<dyn ReadinessSink>,
+    state: Mutex<ReadinessRegistrationState>,
+}
+
+struct ReadinessRegistrationState {
+    retired: bool,
+    active_publishers: usize,
+    retirement_sent: bool,
+}
+
+impl ReadinessRegistrationInner {
+    fn retire(&self) {
+        let should_retire = {
+            let mut state = self.state.lock();
+            state.retired = true;
+            let should_retire = state.active_publishers == 0 && !state.retirement_sent;
+            state.retirement_sent |= should_retire;
+            should_retire
+        };
+        if should_retire {
+            self.sink.retire(self.handle);
+        }
+    }
+}
+
+impl Drop for ReadinessRegistrationInner {
+    fn drop(&mut self) {
+        self.retire();
+    }
+}
+
+struct ReadinessPublishGuard<'registration> {
+    inner: &'registration ReadinessRegistrationInner,
+}
+
+impl Drop for ReadinessPublishGuard<'_> {
+    fn drop(&mut self) {
+        let should_retire = {
+            let mut state = self.inner.state.lock();
+            state.active_publishers -= 1;
+            let should_retire =
+                state.retired && state.active_publishers == 0 && !state.retirement_sent;
+            state.retirement_sent |= should_retire;
+            should_retire
+        };
+        if should_retire {
+            self.inner.sink.retire(self.inner.handle);
+        }
+    }
+}

--- a/litebox_broker_core/src/session.rs
+++ b/litebox_broker_core/src/session.rs
@@ -530,7 +530,7 @@ mod tests {
         let broker = BrokerCore::new_with_limits_and_socket_provider(
             PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
                 .with_socket_policy(SocketPolicy::Ipv4LoopbackTcp),
-            BrokerCoreLimits::new_with_socket_limits(2, 4, 2, 1),
+            BrokerCoreLimits::new_with_all_limits(2, 4, 2, 1),
             socket_provider.clone(),
         )
         .unwrap();

--- a/litebox_broker_core/src/session.rs
+++ b/litebox_broker_core/src/session.rs
@@ -302,7 +302,14 @@ impl BrokerSession {
         required_rights: ObjectRights,
     ) -> Result<Arc<RwLock<ObjectEntry>>> {
         let references = self.core.references.read();
-        self.authorize_use_object(&references, handle, required_rights)
+        let reference = references.get(&handle).ok_or(BrokerError::UnknownObject)?;
+        if reference.session_id != self.session_id {
+            return Err(BrokerError::UnknownObject);
+        }
+        if !reference.rights.contains(required_rights) {
+            return Err(BrokerError::InvalidRights);
+        }
+        Ok(Arc::clone(&reference.object))
     }
 
     /// Returns the current readiness of a broker-owned object.
@@ -317,23 +324,6 @@ impl BrokerSession {
             }
         };
         Ok(socket.readiness())
-    }
-
-    fn authorize_use_object(
-        &self,
-        references: &HashMap<ObjectHandle, ObjectReference>,
-        handle: ObjectHandle,
-        required_rights: ObjectRights,
-    ) -> Result<Arc<RwLock<ObjectEntry>>> {
-        let reference = references.get(&handle).ok_or(BrokerError::UnknownObject)?;
-        if reference.session_id != self.session_id {
-            return Err(BrokerError::UnknownObject);
-        }
-        if !reference.rights.contains(required_rights) {
-            return Err(BrokerError::InvalidRights);
-        }
-        let object = Arc::clone(&reference.object);
-        Ok(object)
     }
 
     /// Closes one object reference owned by this session.

--- a/litebox_broker_core/src/session.rs
+++ b/litebox_broker_core/src/session.rs
@@ -51,6 +51,7 @@ pub(crate) struct ObjectReference {
 }
 
 pub(crate) enum ObjectEntry {
+    Reserved,
     Event(EventObject),
     Pipe(PipeObject),
     Socket(SocketObject),
@@ -102,6 +103,7 @@ impl BrokerSession {
             .core
             .policy
             .principal_object_rights(self.caller_credential)?;
+        let object = Arc::new(RwLock::new(object));
         let mut session_references = self.references.lock();
         let additional = session_references
             .pending_handles
@@ -161,6 +163,8 @@ impl BrokerSession {
             .core
             .policy
             .principal_object_rights(self.caller_credential)?;
+        let first = Arc::new(RwLock::new(first));
+        let second = Arc::new(RwLock::new(second));
         let mut session_references = self.references.lock();
         let additional = session_references
             .pending_handles
@@ -220,6 +224,7 @@ impl BrokerSession {
         &self,
         rights: ObjectRights,
     ) -> Result<PendingObjectReference<'_>> {
+        let object = Arc::new(RwLock::new(ObjectEntry::Reserved));
         let mut session_references = self.references.lock();
         let next_session_pending = session_references
             .pending_handles
@@ -260,6 +265,7 @@ impl BrokerSession {
             session: self,
             handle,
             rights,
+            object,
             active: true,
         })
     }
@@ -269,14 +275,14 @@ impl BrokerSession {
         references: &mut HashMap<ObjectHandle, ObjectReference>,
         reference_handles: &mut Vec<ObjectHandle>,
         handle: ObjectHandle,
-        object: ObjectEntry,
+        object: Arc<RwLock<ObjectEntry>>,
         rights: ObjectRights,
     ) {
         let session_reference_index = reference_handles.len();
         references.insert(
             handle,
             ObjectReference {
-                object: Arc::new(RwLock::new(object)),
+                object,
                 session_id: self.session_id,
                 rights,
                 session_reference_index,
@@ -316,6 +322,7 @@ impl BrokerSession {
                 ObjectEntry::Event(event) => return Ok(event.readiness()),
                 ObjectEntry::Pipe(pipe) => return Ok(pipe.readiness()),
                 ObjectEntry::Socket(socket) => socket.resource(),
+                ObjectEntry::Reserved => return Err(BrokerError::Internal),
             }
         };
         Ok(socket.readiness())
@@ -389,6 +396,7 @@ pub(crate) struct PendingObjectReference<'session> {
     session: &'session BrokerSession,
     handle: ObjectHandle,
     rights: ObjectRights,
+    object: Arc<RwLock<ObjectEntry>>,
     active: bool,
 }
 
@@ -398,6 +406,9 @@ impl PendingObjectReference<'_> {
     }
 
     pub(crate) fn commit(mut self, object: ObjectEntry) -> Result<ObjectHandle> {
+        if !matches!(&*self.object.read(), ObjectEntry::Reserved) {
+            return Err(BrokerError::Internal);
+        }
         let mut session_references = self.session.references.lock();
         let mut references = self.session.core.references.write();
         if references.contains_key(&self.handle) {
@@ -415,11 +426,12 @@ impl PendingObjectReference<'_> {
             return Err(BrokerError::Internal);
         }
         self.active = false;
+        *self.object.write() = object;
         self.session.insert_object_reference(
             &mut references,
             &mut session_references.handles,
             self.handle,
-            object,
+            Arc::clone(&self.object),
             self.rights,
         );
         Ok(self.handle)

--- a/litebox_broker_core/src/session.rs
+++ b/litebox_broker_core/src/session.rs
@@ -5,6 +5,7 @@ use alloc::{sync::Arc, vec::Vec};
 
 use crate::event::EventObject;
 use crate::pipe::PipeObject;
+use crate::socket::SocketObject;
 use crate::{BrokerCore, BrokerError, Result};
 use hashbrown::HashMap;
 use litebox_broker_protocol::ObjectHandle;
@@ -28,7 +29,19 @@ pub enum CallerCredential {
 /// Broker-assigned session identity.
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub(crate) struct SessionId(pub u64);
+pub struct SessionId(u64);
+
+impl SessionId {
+    pub(crate) const fn new(value: u64) -> Self {
+        Self(value)
+    }
+
+    /// Returns the broker-assigned numeric identity.
+    #[must_use]
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+}
 
 bitflags::bitflags! {
     /// Broker rights attached to an object reference.
@@ -51,6 +64,12 @@ pub(crate) struct ObjectReference {
 pub(crate) enum ObjectEntry {
     Event(EventObject),
     Pipe(PipeObject),
+    Socket(SocketObject),
+}
+
+struct SessionReferences {
+    handles: Vec<ObjectHandle>,
+    pending: usize,
 }
 
 /// Broker-owned authority token for one authenticated caller session.
@@ -65,7 +84,8 @@ pub struct BrokerSession {
     /// Broker-entry-authenticated caller credential for this session.
     pub(crate) caller_credential: CallerCredential,
     /// Handles of the live object references owned by this session.
-    reference_handles: Mutex<Vec<ObjectHandle>>,
+    references: Mutex<SessionReferences>,
+    pub(crate) reserved_sockets: Arc<core::sync::atomic::AtomicUsize>,
 }
 
 impl BrokerSession {
@@ -79,7 +99,11 @@ impl BrokerSession {
             core,
             session_id,
             caller_credential,
-            reference_handles: Mutex::new(Vec::new()),
+            references: Mutex::new(SessionReferences {
+                handles: Vec::new(),
+                pending: 0,
+            }),
+            reserved_sockets: Arc::new(core::sync::atomic::AtomicUsize::new(0)),
         }
     }
 
@@ -88,21 +112,51 @@ impl BrokerSession {
             .core
             .policy
             .principal_object_rights(self.caller_credential)?;
-        let mut reference_handles = self.reference_handles.lock();
-        reference_handles
-            .try_reserve(1)
-            .map_err(|_| BrokerError::OutOfMemory)?;
+        let mut session_references = self.references.lock();
+        let additional = session_references
+            .pending
+            .checked_add(1)
+            .ok_or(BrokerError::ResourceExhausted)?;
+        if session_references.handles.try_reserve(additional).is_err() {
+            return Err(BrokerError::OutOfMemory);
+        }
         let mut references = self.core.references.write();
-        if references.len() >= self.core.limits.max_references {
-            return Err(BrokerError::ResourceExhausted);
-        }
-        let handle = self.core.allocate_reference_handle()?;
-        if references.contains_key(&handle) {
-            return Err(BrokerError::Internal);
-        }
+        let preparation = (|| {
+            let pending = self
+                .core
+                .pending_references
+                .load(core::sync::atomic::Ordering::Relaxed);
+            if references
+                .len()
+                .checked_add(pending)
+                .is_none_or(|count| count >= self.core.limits.max_references)
+            {
+                return Err(BrokerError::ResourceExhausted);
+            }
+            references
+                .try_reserve(
+                    pending
+                        .checked_add(1)
+                        .ok_or(BrokerError::ResourceExhausted)?,
+                )
+                .map_err(|_| BrokerError::OutOfMemory)?;
+            let handle = self.core.allocate_reference_handle()?;
+            if references.contains_key(&handle) {
+                return Err(BrokerError::Internal);
+            }
+            Ok(handle)
+        })();
+        let handle = match preparation {
+            Ok(handle) => handle,
+            Err(error) => {
+                drop(references);
+                drop(session_references);
+                return Err(error);
+            }
+        };
         self.insert_object_reference(
             &mut references,
-            &mut reference_handles,
+            &mut session_references.handles,
             handle,
             object,
             rights,
@@ -120,35 +174,110 @@ impl BrokerSession {
             .core
             .policy
             .principal_object_rights(self.caller_credential)?;
-        let mut reference_handles = self.reference_handles.lock();
-        reference_handles
-            .try_reserve(2)
-            .map_err(|_| BrokerError::OutOfMemory)?;
-        let mut references = self.core.references.write();
-        if references
-            .len()
+        let mut session_references = self.references.lock();
+        let additional = session_references
+            .pending
             .checked_add(2)
-            .is_none_or(|count| count > self.core.limits.max_references)
-        {
-            return Err(BrokerError::ResourceExhausted);
+            .ok_or(BrokerError::ResourceExhausted)?;
+        if session_references.handles.try_reserve(additional).is_err() {
+            return Err(BrokerError::OutOfMemory);
         }
-        let (first_handle, second_handle) = self.core.allocate_reference_handle_pair()?;
-        if first_handle == second_handle
-            || references.contains_key(&first_handle)
-            || references.contains_key(&second_handle)
-        {
-            return Err(BrokerError::Internal);
-        }
+        let mut references = self.core.references.write();
+        let preparation = (|| {
+            let pending = self
+                .core
+                .pending_references
+                .load(core::sync::atomic::Ordering::Relaxed);
+            if references
+                .len()
+                .checked_add(pending)
+                .and_then(|count| count.checked_add(2))
+                .is_none_or(|count| count > self.core.limits.max_references)
+            {
+                return Err(BrokerError::ResourceExhausted);
+            }
+            references
+                .try_reserve(
+                    pending
+                        .checked_add(2)
+                        .ok_or(BrokerError::ResourceExhausted)?,
+                )
+                .map_err(|_| BrokerError::OutOfMemory)?;
+            let (first_handle, second_handle) = self.core.allocate_reference_handle_pair()?;
+            if first_handle == second_handle
+                || references.contains_key(&first_handle)
+                || references.contains_key(&second_handle)
+            {
+                return Err(BrokerError::Internal);
+            }
+            Ok((first_handle, second_handle))
+        })();
+        let (first_handle, second_handle) = match preparation {
+            Ok(handles) => handles,
+            Err(error) => {
+                drop(references);
+                drop(session_references);
+                return Err(error);
+            }
+        };
         for (handle, object) in [(first_handle, first), (second_handle, second)] {
             self.insert_object_reference(
                 &mut references,
-                &mut reference_handles,
+                &mut session_references.handles,
                 handle,
                 object,
                 rights,
             );
         }
         Ok((first_handle, second_handle))
+    }
+
+    pub(crate) fn reserve_object_reference(
+        &self,
+        rights: ObjectRights,
+    ) -> Result<PendingObjectReference<'_>> {
+        let mut session_references = self.references.lock();
+        let next_session_pending = session_references
+            .pending
+            .checked_add(1)
+            .ok_or(BrokerError::ResourceExhausted)?;
+        session_references
+            .handles
+            .try_reserve(next_session_pending)
+            .map_err(|_| BrokerError::OutOfMemory)?;
+        let mut references = self.core.references.write();
+        let pending_references = self
+            .core
+            .pending_references
+            .load(core::sync::atomic::Ordering::Relaxed);
+        if references
+            .len()
+            .checked_add(pending_references)
+            .is_none_or(|count| count >= self.core.limits.max_references)
+        {
+            return Err(BrokerError::ResourceExhausted);
+        }
+        let handle = self.core.allocate_reference_handle()?;
+        if references.contains_key(&handle) {
+            return Err(BrokerError::Internal);
+        }
+        references
+            .try_reserve(
+                pending_references
+                    .checked_add(1)
+                    .ok_or(BrokerError::ResourceExhausted)?,
+            )
+            .map_err(|_| BrokerError::OutOfMemory)?;
+        self.core
+            .pending_references
+            .fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+        session_references.pending = next_session_pending;
+        Ok(PendingObjectReference {
+            session: self,
+            handle,
+            rights,
+            active: true,
+        })
     }
 
     fn insert_object_reference(
@@ -186,6 +315,15 @@ impl BrokerSession {
         f(&object)
     }
 
+    pub(crate) fn authorized_object(
+        &self,
+        handle: ObjectHandle,
+        required_rights: ObjectRights,
+    ) -> Result<Arc<RwLock<ObjectEntry>>> {
+        let references = self.core.references.read();
+        self.authorize_use_object(&references, handle, required_rights)
+    }
+
     pub(crate) fn with_authorized_object_mut<T>(
         &self,
         handle: ObjectHandle,
@@ -202,12 +340,16 @@ impl BrokerSession {
 
     /// Returns the current readiness of a broker-owned object.
     pub fn check_readiness(&self, handle: ObjectHandle) -> Result<ReadinessFlags> {
-        self.with_authorized_object(handle, ObjectRights::WAIT, |object| {
-            Ok(match object {
-                ObjectEntry::Event(event) => event.readiness(),
-                ObjectEntry::Pipe(pipe) => pipe.readiness(),
-            })
-        })
+        let object = self.authorized_object(handle, ObjectRights::WAIT)?;
+        let socket = {
+            let object = object.read();
+            match &*object {
+                ObjectEntry::Event(event) => return Ok(event.readiness()),
+                ObjectEntry::Pipe(pipe) => return Ok(pipe.readiness()),
+                ObjectEntry::Socket(socket) => socket.resource(),
+            }
+        };
+        Ok(socket.readiness())
     }
 
     fn authorize_use_object(
@@ -239,7 +381,8 @@ impl BrokerSession {
     }
 
     fn remove_object_reference(&self, handle: ObjectHandle) -> Result<ObjectReference> {
-        let mut reference_handles = self.reference_handles.lock();
+        let mut session_references = self.references.lock();
+        let reference_handles = &mut session_references.handles;
         let mut references = self.core.references.write();
         let reference = references
             .remove(&handle)
@@ -280,7 +423,7 @@ impl BrokerSession {
         if let Err(error) = removal_result {
             let replaced_reference = references.insert(handle, reference);
             drop(references);
-            drop(reference_handles);
+            drop(session_references);
             if replaced_reference.is_some() {
                 return Err(BrokerError::Internal);
             }
@@ -290,10 +433,59 @@ impl BrokerSession {
     }
 }
 
+pub(crate) struct PendingObjectReference<'session> {
+    session: &'session BrokerSession,
+    handle: ObjectHandle,
+    rights: ObjectRights,
+    active: bool,
+}
+
+impl PendingObjectReference<'_> {
+    pub(crate) const fn handle(&self) -> ObjectHandle {
+        self.handle
+    }
+
+    pub(crate) fn commit(mut self, object: ObjectEntry) -> Result<ObjectHandle> {
+        let mut session_references = self.session.references.lock();
+        let mut references = self.session.core.references.write();
+        if references.contains_key(&self.handle) {
+            drop(references);
+            drop(session_references);
+            return Err(BrokerError::Internal);
+        }
+        self.session.insert_object_reference(
+            &mut references,
+            &mut session_references.handles,
+            self.handle,
+            object,
+            self.rights,
+        );
+        session_references.pending -= 1;
+        self.session
+            .core
+            .pending_references
+            .fetch_sub(1, core::sync::atomic::Ordering::Relaxed);
+        self.active = false;
+        Ok(self.handle)
+    }
+}
+
+impl Drop for PendingObjectReference<'_> {
+    fn drop(&mut self) {
+        if self.active {
+            self.session.references.lock().pending -= 1;
+            self.session
+                .core
+                .pending_references
+                .fetch_sub(1, core::sync::atomic::Ordering::Relaxed);
+        }
+    }
+}
+
 impl Drop for BrokerSession {
     fn drop(&mut self) {
         loop {
-            let Some(handle) = self.reference_handles.lock().pop() else {
+            let Some(handle) = self.references.lock().handles.pop() else {
                 break;
             };
             // Do not restore an inconsistent handle: retrying it forever would
@@ -315,6 +507,7 @@ impl Drop for BrokerSession {
             // run while either reference index lock is held.
             drop(reference);
         }
+        self.core.socket_provider.close_session(self.session_id);
     }
 }
 
@@ -324,16 +517,21 @@ mod tests {
 
     use crate::{
         BrokerCore, BrokerCoreLimits, BrokerError, CallerCredential, ObjectRights, PolicyEngine,
+        SocketPolicy,
     };
     use litebox_broker_protocol::ObjectHandle;
     use litebox_broker_protocol::event::{EventConsumeMode, EventConsumption};
     use litebox_broker_protocol::readiness::ReadinessFlags;
+    use std::sync::Arc;
 
     #[test]
     fn object_reference_lifecycle_uses_public_core_constructor_once() {
-        let broker = BrokerCore::new_with_limits(
-            PolicyEngine::with_unauthenticated_rights(ObjectRights::all()),
-            BrokerCoreLimits::new(2, 4),
+        let socket_provider = Arc::new(crate::socket::tests::TestSocketProvider::default());
+        let broker = BrokerCore::new_with_limits_and_socket_provider(
+            PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
+                .with_socket_policy(SocketPolicy::Ipv4LoopbackTcp),
+            BrokerCoreLimits::new_with_socket_limits(2, 4, 2, 1),
+            socket_provider.clone(),
         )
         .unwrap();
 
@@ -343,6 +541,7 @@ mod tests {
         check_pipe_reader_closure(&broker);
         check_corrupt_index_fails_without_mutation(&broker);
         check_corrupt_index_does_not_break_teardown(&broker);
+        crate::socket::tests::check_socket_lifecycle(&broker, &socket_provider);
         check_pair_handle_exhaustion(&broker);
 
         assert!(broker.references.read().is_empty());

--- a/litebox_broker_core/src/session.rs
+++ b/litebox_broker_core/src/session.rs
@@ -290,25 +290,12 @@ impl BrokerSession {
         reference_handles.push(handle);
     }
 
-    pub(crate) fn with_authorized_object<T>(
-        &self,
-        handle: ObjectHandle,
-        required_rights: ObjectRights,
-        f: impl FnOnce(&ObjectEntry) -> Result<T>,
-    ) -> Result<T> {
-        let object = {
-            let references = self.core.references.read();
-            self.authorize_use_object(&references, handle, required_rights)?
-        };
-        let object = object.read();
-        f(&object)
-    }
-
     /// Returns an authorized object lease without holding the reference-table lock.
     ///
-    /// Socket operations use this to release all broker locks before calling an
-    /// external platform implementation, then reacquire only the object lock if
-    /// they need to update broker-owned state.
+    /// Callers explicitly choose the object-lock lifetime. Socket operations use
+    /// that control to release all broker locks before calling an external
+    /// platform implementation, then reacquire only the object lock if they need
+    /// to update broker-owned state.
     pub(crate) fn authorized_object(
         &self,
         handle: ObjectHandle,
@@ -316,20 +303,6 @@ impl BrokerSession {
     ) -> Result<Arc<RwLock<ObjectEntry>>> {
         let references = self.core.references.read();
         self.authorize_use_object(&references, handle, required_rights)
-    }
-
-    pub(crate) fn with_authorized_object_mut<T>(
-        &self,
-        handle: ObjectHandle,
-        required_rights: ObjectRights,
-        f: impl FnOnce(&mut ObjectEntry) -> Result<T>,
-    ) -> Result<T> {
-        let object = {
-            let references = self.core.references.read();
-            self.authorize_use_object(&references, handle, required_rights)?
-        };
-        let mut object = object.write();
-        f(&mut object)
     }
 
     /// Returns the current readiness of a broker-owned object.

--- a/litebox_broker_core/src/session.rs
+++ b/litebox_broker_core/src/session.rs
@@ -29,19 +29,7 @@ pub enum CallerCredential {
 /// Broker-assigned session identity.
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct SessionId(u64);
-
-impl SessionId {
-    pub(crate) const fn new(value: u64) -> Self {
-        Self(value)
-    }
-
-    /// Returns the broker-assigned numeric identity.
-    #[must_use]
-    pub const fn get(self) -> u64 {
-        self.0
-    }
-}
+pub struct SessionId(pub u64);
 
 bitflags::bitflags! {
     /// Broker rights attached to an object reference.

--- a/litebox_broker_core/src/session.rs
+++ b/litebox_broker_core/src/session.rs
@@ -57,7 +57,7 @@ pub(crate) enum ObjectEntry {
 
 struct SessionReferences {
     handles: Vec<ObjectHandle>,
-    pending_references: usize,
+    pending_handles: usize,
 }
 
 /// Broker-owned authority token for one authenticated caller session.
@@ -90,7 +90,7 @@ impl BrokerSession {
             caller_credential,
             references: Mutex::new(SessionReferences {
                 handles: Vec::new(),
-                pending_references: 0,
+                pending_handles: 0,
             }),
             reserved_sockets: Arc::new(core::sync::atomic::AtomicUsize::new(0)),
         }
@@ -103,7 +103,7 @@ impl BrokerSession {
             .principal_object_rights(self.caller_credential)?;
         let mut session_references = self.references.lock();
         let additional = session_references
-            .pending_references
+            .pending_handles
             .checked_add(1)
             .ok_or(BrokerError::ResourceExhausted)?;
         if session_references.handles.try_reserve(additional).is_err() {
@@ -165,7 +165,7 @@ impl BrokerSession {
             .principal_object_rights(self.caller_credential)?;
         let mut session_references = self.references.lock();
         let additional = session_references
-            .pending_references
+            .pending_handles
             .checked_add(2)
             .ok_or(BrokerError::ResourceExhausted)?;
         if session_references.handles.try_reserve(additional).is_err() {
@@ -227,7 +227,7 @@ impl BrokerSession {
     ) -> Result<PendingObjectReference<'_>> {
         let mut session_references = self.references.lock();
         let next_session_pending = session_references
-            .pending_references
+            .pending_handles
             .checked_add(1)
             .ok_or(BrokerError::ResourceExhausted)?;
         session_references
@@ -260,7 +260,7 @@ impl BrokerSession {
         self.core
             .pending_references
             .fetch_add(1, core::sync::atomic::Ordering::Relaxed);
-        session_references.pending_references = next_session_pending;
+        session_references.pending_handles = next_session_pending;
         Ok(PendingObjectReference {
             session: self,
             handle,
@@ -449,7 +449,7 @@ impl PendingObjectReference<'_> {
             object,
             self.rights,
         );
-        session_references.pending_references -= 1;
+        session_references.pending_handles -= 1;
         self.session
             .core
             .pending_references
@@ -462,7 +462,7 @@ impl PendingObjectReference<'_> {
 impl Drop for PendingObjectReference<'_> {
     fn drop(&mut self) {
         if self.active {
-            self.session.references.lock().pending_references -= 1;
+            self.session.references.lock().pending_handles -= 1;
             self.session
                 .core
                 .pending_references

--- a/litebox_broker_core/src/session.rs
+++ b/litebox_broker_core/src/session.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 use alloc::{sync::Arc, vec::Vec};
+use core::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::event::EventObject;
 use crate::pipe::PipeObject;
@@ -74,7 +75,7 @@ pub struct BrokerSession {
     /// Handles of the live object references owned by this session.
     references: Mutex<SessionReferences>,
     /// Socket quota held by pending, live, and closing in-flight resources.
-    pub(crate) reserved_sockets: Arc<core::sync::atomic::AtomicUsize>,
+    pub(crate) reserved_sockets: Arc<AtomicUsize>,
 }
 
 impl BrokerSession {
@@ -92,7 +93,7 @@ impl BrokerSession {
                 handles: Vec::new(),
                 pending_handles: 0,
             }),
-            reserved_sockets: Arc::new(core::sync::atomic::AtomicUsize::new(0)),
+            reserved_sockets: Arc::new(AtomicUsize::new(0)),
         }
     }
 
@@ -111,10 +112,7 @@ impl BrokerSession {
         }
         let mut references = self.core.references.write();
         let preparation = (|| {
-            let pending = self
-                .core
-                .pending_references
-                .load(core::sync::atomic::Ordering::Relaxed);
+            let pending = self.core.pending_references.load(Ordering::Relaxed);
             if references
                 .len()
                 .checked_add(pending)
@@ -173,10 +171,7 @@ impl BrokerSession {
         }
         let mut references = self.core.references.write();
         let preparation = (|| {
-            let pending = self
-                .core
-                .pending_references
-                .load(core::sync::atomic::Ordering::Relaxed);
+            let pending = self.core.pending_references.load(Ordering::Relaxed);
             if references
                 .len()
                 .checked_add(pending)
@@ -235,10 +230,7 @@ impl BrokerSession {
             .try_reserve(next_session_pending)
             .map_err(|_| BrokerError::OutOfMemory)?;
         let mut references = self.core.references.write();
-        let pending_references = self
-            .core
-            .pending_references
-            .load(core::sync::atomic::Ordering::Relaxed);
+        let pending_references = self.core.pending_references.load(Ordering::Relaxed);
         if references
             .len()
             .checked_add(pending_references)
@@ -259,7 +251,10 @@ impl BrokerSession {
             .map_err(|_| BrokerError::OutOfMemory)?;
         self.core
             .pending_references
-            .fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |pending| {
+                pending.checked_add(1)
+            })
+            .map_err(|_| BrokerError::ResourceExhausted)?;
         session_references.pending_handles = next_session_pending;
         Ok(PendingObjectReference {
             session: self,
@@ -410,6 +405,16 @@ impl PendingObjectReference<'_> {
             drop(session_references);
             return Err(BrokerError::Internal);
         }
+        if !release_pending_reference(
+            &self.session.core.pending_references,
+            &mut session_references,
+        ) {
+            self.active = false;
+            drop(references);
+            drop(session_references);
+            return Err(BrokerError::Internal);
+        }
+        self.active = false;
         self.session.insert_object_reference(
             &mut references,
             &mut session_references.handles,
@@ -417,12 +422,6 @@ impl PendingObjectReference<'_> {
             object,
             self.rights,
         );
-        session_references.pending_handles -= 1;
-        self.session
-            .core
-            .pending_references
-            .fetch_sub(1, core::sync::atomic::Ordering::Relaxed);
-        self.active = false;
         Ok(self.handle)
     }
 }
@@ -430,13 +429,34 @@ impl PendingObjectReference<'_> {
 impl Drop for PendingObjectReference<'_> {
     fn drop(&mut self) {
         if self.active {
-            self.session.references.lock().pending_handles -= 1;
-            self.session
-                .core
-                .pending_references
-                .fetch_sub(1, core::sync::atomic::Ordering::Relaxed);
+            let mut session_references = self.session.references.lock();
+            let released = release_pending_reference(
+                &self.session.core.pending_references,
+                &mut session_references,
+            );
+            self.active = false;
+            assert!(
+                released,
+                "pending object reference counters are inconsistent"
+            );
         }
     }
+}
+
+fn release_pending_reference(
+    core_pending_references: &AtomicUsize,
+    session_references: &mut SessionReferences,
+) -> bool {
+    let next_pending_handles = session_references.pending_handles.checked_sub(1);
+    let core_released = core_pending_references
+        .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |pending| {
+            pending.checked_sub(1)
+        })
+        .is_ok();
+    if let Some(next_pending_handles) = next_pending_handles {
+        session_references.pending_handles = next_pending_handles;
+    }
+    next_pending_handles.is_some() && core_released
 }
 
 impl Drop for BrokerSession {
@@ -470,8 +490,9 @@ impl Drop for BrokerSession {
 
 #[cfg(test)]
 mod tests {
-    use core::sync::atomic::Ordering;
+    use core::sync::atomic::{AtomicUsize, Ordering};
 
+    use super::{SessionReferences, release_pending_reference};
     use crate::{
         BrokerCore, BrokerCoreLimits, BrokerError, CallerCredential, ObjectRights, PolicyEngine,
         SocketPolicy,
@@ -479,7 +500,29 @@ mod tests {
     use litebox_broker_protocol::ObjectHandle;
     use litebox_broker_protocol::event::{EventConsumeMode, EventConsumption};
     use litebox_broker_protocol::readiness::ReadinessFlags;
-    use std::sync::Arc;
+    use std::{sync::Arc, vec::Vec};
+
+    #[test]
+    fn pending_reference_release_checks_both_counters() {
+        let core_pending_references = AtomicUsize::new(1);
+        let mut session_references = SessionReferences {
+            handles: Vec::new(),
+            pending_handles: 1,
+        };
+        assert!(release_pending_reference(
+            &core_pending_references,
+            &mut session_references
+        ));
+        assert_eq!(core_pending_references.load(Ordering::Relaxed), 0);
+        assert_eq!(session_references.pending_handles, 0);
+
+        assert!(!release_pending_reference(
+            &core_pending_references,
+            &mut session_references
+        ));
+        assert_eq!(core_pending_references.load(Ordering::Relaxed), 0);
+        assert_eq!(session_references.pending_handles, 0);
+    }
 
     #[test]
     fn object_reference_lifecycle_uses_public_core_constructor_once() {
@@ -512,7 +555,7 @@ mod tests {
             .create_session(CallerCredential::Unauthenticated)
             .unwrap();
         let handle = crate::event::create(&session, 0).unwrap();
-        let unknown_handle = ObjectHandle(handle.0 + 1);
+        let unknown_handle = ObjectHandle(handle.0.checked_add(1).unwrap());
 
         assert_ne!(unknown_handle, handle);
         assert_eq!(

--- a/litebox_broker_core/src/session.rs
+++ b/litebox_broker_core/src/session.rs
@@ -57,7 +57,7 @@ pub(crate) enum ObjectEntry {
 
 struct SessionReferences {
     handles: Vec<ObjectHandle>,
-    pending: usize,
+    pending_references: usize,
 }
 
 /// Broker-owned authority token for one authenticated caller session.
@@ -73,6 +73,7 @@ pub struct BrokerSession {
     pub(crate) caller_credential: CallerCredential,
     /// Handles of the live object references owned by this session.
     references: Mutex<SessionReferences>,
+    /// Socket quota held by pending, live, and closing in-flight resources.
     pub(crate) reserved_sockets: Arc<core::sync::atomic::AtomicUsize>,
 }
 
@@ -89,7 +90,7 @@ impl BrokerSession {
             caller_credential,
             references: Mutex::new(SessionReferences {
                 handles: Vec::new(),
-                pending: 0,
+                pending_references: 0,
             }),
             reserved_sockets: Arc::new(core::sync::atomic::AtomicUsize::new(0)),
         }
@@ -102,7 +103,7 @@ impl BrokerSession {
             .principal_object_rights(self.caller_credential)?;
         let mut session_references = self.references.lock();
         let additional = session_references
-            .pending
+            .pending_references
             .checked_add(1)
             .ok_or(BrokerError::ResourceExhausted)?;
         if session_references.handles.try_reserve(additional).is_err() {
@@ -164,7 +165,7 @@ impl BrokerSession {
             .principal_object_rights(self.caller_credential)?;
         let mut session_references = self.references.lock();
         let additional = session_references
-            .pending
+            .pending_references
             .checked_add(2)
             .ok_or(BrokerError::ResourceExhausted)?;
         if session_references.handles.try_reserve(additional).is_err() {
@@ -226,7 +227,7 @@ impl BrokerSession {
     ) -> Result<PendingObjectReference<'_>> {
         let mut session_references = self.references.lock();
         let next_session_pending = session_references
-            .pending
+            .pending_references
             .checked_add(1)
             .ok_or(BrokerError::ResourceExhausted)?;
         session_references
@@ -259,7 +260,7 @@ impl BrokerSession {
         self.core
             .pending_references
             .fetch_add(1, core::sync::atomic::Ordering::Relaxed);
-        session_references.pending = next_session_pending;
+        session_references.pending_references = next_session_pending;
         Ok(PendingObjectReference {
             session: self,
             handle,
@@ -448,7 +449,7 @@ impl PendingObjectReference<'_> {
             object,
             self.rights,
         );
-        session_references.pending -= 1;
+        session_references.pending_references -= 1;
         self.session
             .core
             .pending_references
@@ -461,7 +462,7 @@ impl PendingObjectReference<'_> {
 impl Drop for PendingObjectReference<'_> {
     fn drop(&mut self) {
         if self.active {
-            self.session.references.lock().pending -= 1;
+            self.session.references.lock().pending_references -= 1;
             self.session
                 .core
                 .pending_references

--- a/litebox_broker_core/src/session.rs
+++ b/litebox_broker_core/src/session.rs
@@ -304,6 +304,11 @@ impl BrokerSession {
         f(&object)
     }
 
+    /// Returns an authorized object lease without holding the reference-table lock.
+    ///
+    /// Socket operations use this to release all broker locks before calling an
+    /// external platform implementation, then reacquire only the object lock if
+    /// they need to update broker-owned state.
     pub(crate) fn authorized_object(
         &self,
         handle: ObjectHandle,

--- a/litebox_broker_core/src/session.rs
+++ b/litebox_broker_core/src/session.rs
@@ -527,7 +527,7 @@ mod tests {
     #[test]
     fn object_reference_lifecycle_uses_public_core_constructor_once() {
         let socket_provider = Arc::new(crate::socket::tests::TestSocketProvider::default());
-        let broker = BrokerCore::new_with_limits_and_socket_provider(
+        let broker = BrokerCore::new_with_limits(
             PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
                 .with_socket_policy(SocketPolicy::Ipv4LoopbackTcp),
             BrokerCoreLimits::new_with_all_limits(2, 4, 2, 1),

--- a/litebox_broker_core/src/socket.rs
+++ b/litebox_broker_core/src/socket.rs
@@ -145,23 +145,21 @@ pub fn create(
 }
 
 /// Starts a nonblocking connection attempt.
+///
+/// Policy denial is returned as a per-request [`SocketOutcome::Failed`] and
+/// leaves the socket unconnected, so a later authorized destination may still
+/// be attempted.
 pub fn connect(
     session: &BrokerSession,
     handle: ObjectHandle,
     address: SocketAddressV4,
-) -> Result<SocketConnectionStatus> {
+) -> Result<SocketOutcome<SocketConnectionStatus>> {
     let object = session.authorized_object(handle, ObjectRights::WRITE)?;
     {
         let object = object.read();
-        let ObjectEntry::Socket(socket) = &*object else {
+        let ObjectEntry::Socket(_) = &*object else {
             return Err(BrokerError::InvalidRights);
         };
-        if socket.connect_in_flight {
-            return Ok(SocketConnectionStatus::Connecting);
-        }
-        if socket.connection_status != SocketConnectionStatus::Unconnected {
-            return Ok(socket.connection_status);
-        }
     }
 
     if let Err(error) = session
@@ -169,23 +167,13 @@ pub fn connect(
         .policy
         .authorize_socket_connect(session.caller_credential, address)
     {
-        // Only a definitive authorization denial is a terminal socket outcome.
+        // Only a definitive authorization denial is a per-request socket outcome.
         // Any other error means the broker could not evaluate or serve policy
         // and must not be cached as if it were a network failure.
         if error != BrokerError::PolicyDenied {
             return Err(error);
         }
-        let mut object = object.write();
-        let ObjectEntry::Socket(socket) = &mut *object else {
-            return Err(BrokerError::InvalidRights);
-        };
-        if socket.connect_in_flight {
-            return Ok(SocketConnectionStatus::Connecting);
-        }
-        if socket.connection_status == SocketConnectionStatus::Unconnected {
-            socket.connection_status = SocketConnectionStatus::Failed(SocketError::PolicyDenied);
-        }
-        return Ok(socket.connection_status);
+        return Ok(SocketOutcome::Failed(SocketError::PolicyDenied));
     }
 
     let resource = {
@@ -194,10 +182,10 @@ pub fn connect(
             return Err(BrokerError::InvalidRights);
         };
         if socket.connect_in_flight {
-            return Ok(SocketConnectionStatus::Connecting);
+            return Ok(SocketOutcome::Completed(SocketConnectionStatus::Connecting));
         }
         if socket.connection_status != SocketConnectionStatus::Unconnected {
-            return Ok(socket.connection_status);
+            return Ok(SocketOutcome::Completed(socket.connection_status));
         }
         socket.connect_in_flight = true;
         Arc::clone(&socket.resource)
@@ -214,7 +202,7 @@ pub fn connect(
         }
     };
     finish_connect(&object, status);
-    Ok(status)
+    Ok(SocketOutcome::Completed(status))
 }
 
 /// Sends bytes without waiting for readiness.
@@ -634,37 +622,32 @@ pub(crate) mod tests {
             .create_session(CallerCredential::Unauthenticated)
             .unwrap();
         let readiness = Arc::new(TestReadinessSink::default());
-        let denied_handle = create(&session, create_request(), readiness.clone()).unwrap();
+        let handle = create(&session, create_request(), readiness.clone()).unwrap();
         assert_eq!(
             provider.state.creates.lock().unwrap().last(),
             Some(&(session.session_id, create_request()))
         );
         assert_eq!(broker.reserved_sockets.load(Ordering::Relaxed), 1);
         assert_eq!(session.reserved_sockets.load(Ordering::Relaxed), 1);
-        assert_eq!(
-            status(&other, denied_handle),
-            Err(BrokerError::UnknownObject)
-        );
+        assert_eq!(status(&other, handle), Err(BrokerError::UnknownObject));
         assert_eq!(
             connect(
                 &session,
-                denied_handle,
+                handle,
                 SocketAddressV4 {
                     address: Ipv4Address([10, 0, 0, 1]),
                     port: Port(80),
                 },
             ),
-            Ok(SocketConnectionStatus::Failed(SocketError::PolicyDenied))
+            Ok(SocketOutcome::Failed(SocketError::PolicyDenied))
         );
         assert_eq!(
-            status(&session, denied_handle),
-            Ok(SocketConnectionStatus::Failed(SocketError::PolicyDenied))
+            status(&session, handle),
+            Ok(SocketConnectionStatus::Unconnected)
         );
-        session.close_object_reference(denied_handle).unwrap();
-        let handle = create(&session, create_request(), readiness.clone()).unwrap();
         assert_eq!(
             connect(&session, handle, loopback_address()),
-            Ok(SocketConnectionStatus::Connecting)
+            Ok(SocketOutcome::Completed(SocketConnectionStatus::Connecting))
         );
         assert_eq!(
             readiness.published.lock().unwrap().as_slice(),
@@ -699,16 +682,10 @@ pub(crate) mod tests {
         let in_flight = socket_resource(&session, handle, ObjectRights::WAIT).unwrap();
         assert_eq!(session.close_object_reference(handle), Ok(()));
         assert_eq!(broker.reserved_sockets.load(Ordering::Relaxed), 1);
-        assert_eq!(
-            readiness.retired.lock().unwrap().as_slice(),
-            [denied_handle]
-        );
+        assert_eq!(readiness.retired.lock().unwrap().as_slice(), []);
         drop(in_flight);
-        assert_eq!(
-            readiness.retired.lock().unwrap().as_slice(),
-            [denied_handle, handle]
-        );
-        assert_eq!(provider.state.dropped_sockets.load(Ordering::Relaxed), 2);
+        assert_eq!(readiness.retired.lock().unwrap().as_slice(), [handle]);
+        assert_eq!(provider.state.dropped_sockets.load(Ordering::Relaxed), 1);
         assert_eq!(broker.reserved_sockets.load(Ordering::Relaxed), 0);
         assert_eq!(session.reserved_sockets.load(Ordering::Relaxed), 0);
         assert_eq!(provider.state.sent.lock().unwrap().as_slice(), [1, 2, 3]);
@@ -790,7 +767,9 @@ pub(crate) mod tests {
         );
         assert_eq!(
             connect(&session, handle, loopback_address()),
-            Ok(SocketConnectionStatus::Failed(SocketError::Other))
+            Ok(SocketOutcome::Completed(SocketConnectionStatus::Failed(
+                SocketError::Other
+            )))
         );
         assert_eq!(
             status(&session, handle),

--- a/litebox_broker_core/src/socket.rs
+++ b/litebox_broker_core/src/socket.rs
@@ -193,7 +193,8 @@ pub trait PlatformSocket: Send + Sync {
     fn readiness(&self) -> ReadinessFlags;
 }
 
-pub(crate) struct UnsupportedSocketProvider;
+/// Placeholder provider for deployments that deliberately disable sockets.
+pub struct UnsupportedSocketProvider;
 
 impl SocketProvider for UnsupportedSocketProvider {
     fn create(

--- a/litebox_broker_core/src/socket.rs
+++ b/litebox_broker_core/src/socket.rs
@@ -162,18 +162,18 @@ pub fn connect(
         };
     }
 
-    if let Err(error) = session
+    // Destination denial is an operation-level socket failure. Failures while
+    // evaluating policy remain broker errors.
+    match session
         .core
         .policy
         .authorize_socket_connect(session.caller_credential, address)
     {
-        // Only a definitive authorization denial is a per-request socket outcome.
-        // Any other error means the broker could not evaluate or serve policy
-        // and must not be cached as if it were a network failure.
-        if error != BrokerError::PolicyDenied {
-            return Err(error);
+        Ok(()) => {}
+        Err(BrokerError::PolicyDenied) => {
+            return Ok(SocketOutcome::Failed(SocketError::PolicyDenied));
         }
-        return Ok(SocketOutcome::Failed(SocketError::PolicyDenied));
+        Err(error) => return Err(error),
     }
 
     let resource = {

--- a/litebox_broker_core/src/socket.rs
+++ b/litebox_broker_core/src/socket.rs
@@ -12,6 +12,7 @@ use litebox_broker_protocol::socket::{
     CreateSocketRequest, ReceiveFlags, ReceiveSocketResponse, SendFlags, ShutdownMode,
     SocketAddressV4, SocketConnectionStatus, SocketError,
 };
+use spin::Once;
 
 use crate::readiness::{ReadinessRegistration, ReadinessSink};
 use crate::session::{ObjectEntry, ObjectRights};
@@ -118,29 +119,34 @@ pub fn create(
         .core
         .policy
         .authorize_socket_create(session.caller_credential, request)?;
-    let quota = SocketQuotaReservation::new(session)?;
+    let quota = Arc::new(SocketQuotaReservation::new(session)?);
     let reference = session.reserve_object_reference(rights)?;
-    let readiness = ReadinessRegistration::new(reference.handle(), readiness_sink);
-    let platform_socket =
-        match session
-            .core
-            .socket_provider
-            .create(session.session_id, request, readiness.clone())
-        {
-            Ok(socket) => socket,
-            Err(error) => {
-                // The provider may have retained its registration before
-                // failing, so retirement cannot rely on the local clone being
-                // the last one.
-                readiness.retire();
-                return Err(error);
-            }
-        };
-    let handle = reference.commit(ObjectEntry::Socket(SocketObject::new(
-        platform_socket,
+    let readiness = ReadinessRegistration::new_with_retirement_guard(
+        reference.handle(),
+        readiness_sink,
+        Arc::clone(&quota),
+    );
+    let resource = Arc::new(SocketResource {
+        platform_socket: Once::new(),
         readiness,
-        quota,
-    )))?;
+        _quota: quota,
+    });
+    let platform_socket = match session.core.socket_provider.create(
+        session.session_id,
+        request,
+        resource.readiness.clone(),
+    ) {
+        Ok(socket) => socket,
+        Err(error) => {
+            // The provider may have retained its registration before
+            // failing, so retirement cannot rely on the local clone being
+            // the last one.
+            resource.readiness.retire();
+            return Err(error);
+        }
+    };
+    resource.platform_socket.call_once(|| platform_socket);
+    let handle = reference.commit(ObjectEntry::Socket(SocketObject::new(resource)))?;
     Ok(handle)
 }
 
@@ -322,17 +328,9 @@ pub(crate) struct SocketObject {
 }
 
 impl SocketObject {
-    fn new(
-        platform_socket: Arc<dyn PlatformSocket>,
-        readiness: ReadinessRegistration,
-        quota: SocketQuotaReservation,
-    ) -> Self {
+    fn new(resource: Arc<SocketResource>) -> Self {
         Self {
-            resource: Arc::new(SocketResource {
-                platform_socket,
-                readiness,
-                _quota: quota,
-            }),
+            resource,
             connection_status: SocketConnectionStatus::Unconnected,
             connect_in_flight: false,
         }
@@ -344,18 +342,25 @@ impl SocketObject {
 }
 
 pub(crate) struct SocketResource {
-    platform_socket: Arc<dyn PlatformSocket>,
+    platform_socket: Once<Arc<dyn PlatformSocket>>,
     readiness: ReadinessRegistration,
-    _quota: SocketQuotaReservation,
+    _quota: Arc<SocketQuotaReservation>,
 }
 
 impl SocketResource {
+    fn platform_socket(&self) -> &dyn PlatformSocket {
+        self.platform_socket
+            .get()
+            .expect("committed socket resources are initialized")
+            .as_ref()
+    }
+
     fn connect(&self, address: SocketAddressV4) -> Result<SocketConnectionStatus> {
-        self.platform_socket.connect(address)
+        self.platform_socket().connect(address)
     }
 
     fn send(&self, data: &[u8], flags: SendFlags) -> Result<SocketOutcome<usize>> {
-        self.platform_socket.send(data, flags)
+        self.platform_socket().send(data, flags)
     }
 
     fn receive(
@@ -363,19 +368,19 @@ impl SocketResource {
         data: &mut [u8],
         flags: ReceiveFlags,
     ) -> Result<SocketOutcome<ReceiveSocketResponse>> {
-        self.platform_socket.receive(data, flags)
+        self.platform_socket().receive(data, flags)
     }
 
     fn shutdown(&self, mode: ShutdownMode) -> Result<SocketOutcome<()>> {
-        self.platform_socket.shutdown(mode)
+        self.platform_socket().shutdown(mode)
     }
 
     fn status(&self) -> Result<SocketConnectionStatus> {
-        self.platform_socket.status()
+        self.platform_socket().status()
     }
 
     pub(crate) fn readiness(&self) -> ReadinessFlags {
-        self.platform_socket.readiness()
+        self.platform_socket().readiness()
     }
 }
 
@@ -439,7 +444,8 @@ pub(crate) mod tests {
     use litebox_broker_protocol::socket::{
         AddressFamily, IpProtocol, Ipv4Address, Port, SocketType,
     };
-    use std::sync::Mutex as StdMutex;
+    use std::sync::{Mutex as StdMutex, mpsc};
+    use std::time::Duration;
 
     #[derive(Clone, Default)]
     pub(crate) struct TestSocketProvider {
@@ -458,6 +464,7 @@ pub(crate) mod tests {
         fail_create: core::sync::atomic::AtomicBool,
         fail_connect: core::sync::atomic::AtomicBool,
         failed_readiness: StdMutex<Option<ReadinessRegistration>>,
+        live_readiness: StdMutex<Option<ReadinessRegistration>>,
     }
 
     impl TestSocketProvider {
@@ -486,6 +493,7 @@ pub(crate) mod tests {
                 *self.state.failed_readiness.lock().unwrap() = Some(readiness);
                 return Err(BrokerError::OutOfMemory);
             }
+            *self.state.live_readiness.lock().unwrap() = Some(readiness.clone());
             Ok(Arc::new(TestPlatformSocket {
                 state: Arc::clone(&self.state),
                 readiness,
@@ -554,6 +562,7 @@ pub(crate) mod tests {
         check_failed_create_rolls_back(broker, provider);
         check_socket_operations_and_policy(broker, provider);
         check_connect_error_is_terminal(broker, provider);
+        check_quota_waits_for_deferred_retirement(broker, provider);
         check_socket_quotas(broker);
     }
 
@@ -716,6 +725,72 @@ pub(crate) mod tests {
         first.close_object_reference(first_handle).unwrap();
         second.close_object_reference(second_handle).unwrap();
         assert_eq!(broker.reserved_sockets.load(Ordering::Relaxed), 0);
+    }
+
+    struct BlockingReadinessSink {
+        started: StdMutex<Option<mpsc::Sender<()>>>,
+        release: StdMutex<mpsc::Receiver<()>>,
+        retired: AtomicUsize,
+    }
+
+    impl ReadinessSink for BlockingReadinessSink {
+        fn max_tracked_objects(&self) -> usize {
+            usize::MAX
+        }
+
+        fn publish(&self, _handle: ObjectHandle, _readiness: ReadinessFlags) -> Result<()> {
+            if let Some(started) = self.started.lock().unwrap().take() {
+                started.send(()).map_err(|_| BrokerError::Internal)?;
+            }
+            self.release
+                .lock()
+                .unwrap()
+                .recv_timeout(Duration::from_secs(5))
+                .map_err(|_| BrokerError::Internal)
+        }
+
+        fn retire(&self, _handle: ObjectHandle) {
+            self.retired.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    fn check_quota_waits_for_deferred_retirement(
+        broker: &BrokerCore,
+        provider: &TestSocketProvider,
+    ) {
+        let session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let (started_tx, started_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let readiness = Arc::new(BlockingReadinessSink {
+            started: StdMutex::new(Some(started_tx)),
+            release: StdMutex::new(release_rx),
+            retired: AtomicUsize::new(0),
+        });
+        let handle = create(&session, create_request(), readiness.clone()).unwrap();
+        let registration = provider
+            .state
+            .live_readiness
+            .lock()
+            .unwrap()
+            .as_ref()
+            .unwrap()
+            .clone();
+        let publisher = std::thread::spawn(move || registration.publish(ReadinessFlags::READ));
+        started_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+
+        session.close_object_reference(handle).unwrap();
+        assert_eq!(readiness.retired.load(Ordering::Relaxed), 0);
+        assert_eq!(broker.reserved_sockets.load(Ordering::Relaxed), 1);
+        assert_eq!(session.reserved_sockets.load(Ordering::Relaxed), 1);
+
+        release_tx.send(()).unwrap();
+        publisher.join().unwrap().unwrap();
+        assert_eq!(readiness.retired.load(Ordering::Relaxed), 1);
+        assert_eq!(broker.reserved_sockets.load(Ordering::Relaxed), 0);
+        assert_eq!(session.reserved_sockets.load(Ordering::Relaxed), 0);
+        *provider.state.live_readiness.lock().unwrap() = None;
     }
 
     fn check_connect_error_is_terminal(broker: &BrokerCore, provider: &TestSocketProvider) {

--- a/litebox_broker_core/src/socket.rs
+++ b/litebox_broker_core/src/socket.rs
@@ -434,6 +434,7 @@ fn reserve_socket(counter: &AtomicUsize, limit: usize) -> Result<()> {
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
+    use crate::readiness::tests::TestReadinessSink;
     use crate::{BrokerCore, CallerCredential};
     use litebox_broker_protocol::socket::{
         AddressFamily, IpProtocol, Ipv4Address, Port, SocketType,
@@ -549,43 +550,11 @@ pub(crate) mod tests {
         }
     }
 
-    #[derive(Default)]
-    struct TestReadinessSink {
-        published: StdMutex<std::vec::Vec<(ObjectHandle, ReadinessFlags)>>,
-        retired: StdMutex<std::vec::Vec<ObjectHandle>>,
-    }
-
-    impl ReadinessSink for TestReadinessSink {
-        fn max_tracked_objects(&self) -> usize {
-            usize::MAX
-        }
-
-        fn publish(&self, handle: ObjectHandle, readiness: ReadinessFlags) -> Result<()> {
-            self.published.lock().unwrap().push((handle, readiness));
-            Ok(())
-        }
-
-        fn retire(&self, handle: ObjectHandle) {
-            self.retired.lock().unwrap().push(handle);
-        }
-    }
-
     pub(crate) fn check_socket_lifecycle(broker: &BrokerCore, provider: &TestSocketProvider) {
         check_failed_create_rolls_back(broker, provider);
-        check_retired_registration_discards_updates();
         check_socket_operations_and_policy(broker, provider);
         check_connect_error_is_terminal(broker, provider);
         check_socket_quotas(broker);
-    }
-
-    fn check_retired_registration_discards_updates() {
-        let sink = Arc::new(TestReadinessSink::default());
-        let registration = ReadinessRegistration::new(ObjectHandle(99), sink.clone());
-        let delayed = registration.clone();
-        registration.retire();
-        delayed.publish(ReadinessFlags::READ).unwrap();
-        assert!(sink.published.lock().unwrap().is_empty());
-        assert_eq!(sink.retired.lock().unwrap().as_slice(), [ObjectHandle(99)]);
     }
 
     fn check_failed_create_rolls_back(broker: &BrokerCore, provider: &TestSocketProvider) {

--- a/litebox_broker_core/src/socket.rs
+++ b/litebox_broker_core/src/socket.rs
@@ -169,6 +169,9 @@ pub fn connect(
         .policy
         .authorize_socket_connect(session.caller_credential, address)
     {
+        if error != BrokerError::PolicyDenied {
+            return Err(error);
+        }
         let mut object = object.write();
         let ObjectEntry::Socket(socket) = &mut *object else {
             return Err(BrokerError::InvalidRights);
@@ -177,7 +180,7 @@ pub fn connect(
             return Ok(SocketConnectionStatus::Connecting);
         }
         if socket.connection_status == SocketConnectionStatus::Unconnected {
-            socket.connection_status = SocketConnectionStatus::Failed(error);
+            socket.connection_status = SocketConnectionStatus::Failed(SocketError::PolicyDenied);
         }
         return Ok(socket.connection_status);
     }

--- a/litebox_broker_core/src/socket.rs
+++ b/litebox_broker_core/src/socket.rs
@@ -27,9 +27,13 @@ pub enum SocketOutcome<T> {
     Failed(SocketError),
 }
 
-/// Deployment-provided factory for platform socket resources.
+/// Broker-wide socket provider supplied by the host platform.
+///
+/// The provider creates per-socket [`PlatformSocket`] resources and owns any
+/// bookkeeping shared across the sockets of a broker session. Operations on an
+/// individual socket belong to [`PlatformSocket`], not this shared provider.
 pub trait SocketProvider: Send + Sync {
-    /// Creates one nonblocking platform socket for an authenticated session.
+    /// Creates one nonblocking socket resource for an authenticated session.
     ///
     /// The returned socket must not retain authority beyond its `Arc` lifetime.
     fn create(
@@ -43,7 +47,11 @@ pub trait SocketProvider: Send + Sync {
     fn close_session(&self, session_id: SessionId);
 }
 
-/// One nonblocking platform socket resource.
+/// One nonblocking socket resource created by [`SocketProvider`].
+///
+/// The broker retains this resource in an `Arc`, allowing an operation already
+/// in flight to finish after its object handle closes. Dropping the final `Arc`
+/// releases the platform socket.
 pub trait PlatformSocket: Send + Sync {
     /// Starts a connection attempt.
     ///
@@ -84,7 +92,7 @@ pub trait PlatformSocket: Send + Sync {
     fn readiness(&self) -> ReadinessFlags;
 }
 
-/// Placeholder provider for deployments that deliberately disable sockets.
+/// Placeholder provider for broker configurations that deliberately disable sockets.
 pub struct UnsupportedSocketProvider;
 
 impl SocketProvider for UnsupportedSocketProvider {

--- a/litebox_broker_core/src/socket.rs
+++ b/litebox_broker_core/src/socket.rs
@@ -13,9 +13,9 @@ use litebox_broker_protocol::socket::{
     SocketAddressV4, SocketConnectionStatus, SocketError,
 };
 
+use crate::readiness::{ReadinessRegistration, ReadinessSink};
 use crate::session::{ObjectEntry, ObjectRights};
 use crate::{BrokerError, BrokerSession, Result, SessionId};
-use spin::Mutex;
 
 /// Result of a platform socket operation that can fail with a network outcome.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -27,115 +27,6 @@ pub enum SocketOutcome<T> {
     Failed(SocketError),
 }
 
-/// Per-association destination for asynchronous socket readiness changes.
-pub trait SocketReadinessSink: Send + Sync {
-    /// Maximum number of simultaneously live socket registrations.
-    fn max_tracked_sockets(&self) -> usize;
-
-    /// Records a new authoritative readiness snapshot.
-    fn publish(&self, handle: ObjectHandle, readiness: ReadinessFlags) -> Result<()>;
-
-    /// Retires all readiness state for a socket that can no longer publish.
-    fn retire(&self, handle: ObjectHandle);
-}
-
-/// Capability for publishing readiness for one broker-assigned socket handle.
-#[derive(Clone)]
-pub struct SocketReadinessRegistration {
-    inner: Arc<SocketReadinessRegistrationInner>,
-}
-
-impl SocketReadinessRegistration {
-    fn new(handle: ObjectHandle, sink: Arc<dyn SocketReadinessSink>) -> Self {
-        Self {
-            inner: Arc::new(SocketReadinessRegistrationInner {
-                handle,
-                sink,
-                state: Mutex::new(SocketReadinessRegistrationState {
-                    retired: false,
-                    active_publishers: 0,
-                    retirement_sent: false,
-                }),
-            }),
-        }
-    }
-
-    /// Publishes the socket's current readiness.
-    ///
-    /// Updates after the broker retires the socket are discarded.
-    pub fn publish(&self, readiness: ReadinessFlags) -> Result<()> {
-        {
-            let mut state = self.inner.state.lock();
-            if state.retired {
-                return Ok(());
-            }
-            state.active_publishers = state
-                .active_publishers
-                .checked_add(1)
-                .ok_or(BrokerError::ResourceExhausted)?;
-        }
-        let _publishing = SocketReadinessPublishGuard { inner: &self.inner };
-        self.inner.sink.publish(self.inner.handle, readiness)
-    }
-
-    fn retire(&self) {
-        self.inner.retire();
-    }
-}
-
-struct SocketReadinessRegistrationInner {
-    handle: ObjectHandle,
-    sink: Arc<dyn SocketReadinessSink>,
-    state: Mutex<SocketReadinessRegistrationState>,
-}
-
-struct SocketReadinessRegistrationState {
-    retired: bool,
-    active_publishers: usize,
-    retirement_sent: bool,
-}
-
-impl SocketReadinessRegistrationInner {
-    fn retire(&self) {
-        let should_retire = {
-            let mut state = self.state.lock();
-            state.retired = true;
-            let should_retire = state.active_publishers == 0 && !state.retirement_sent;
-            state.retirement_sent |= should_retire;
-            should_retire
-        };
-        if should_retire {
-            self.sink.retire(self.handle);
-        }
-    }
-}
-
-impl Drop for SocketReadinessRegistrationInner {
-    fn drop(&mut self) {
-        self.retire();
-    }
-}
-
-struct SocketReadinessPublishGuard<'registration> {
-    inner: &'registration SocketReadinessRegistrationInner,
-}
-
-impl Drop for SocketReadinessPublishGuard<'_> {
-    fn drop(&mut self) {
-        let should_retire = {
-            let mut state = self.inner.state.lock();
-            state.active_publishers -= 1;
-            let should_retire =
-                state.retired && state.active_publishers == 0 && !state.retirement_sent;
-            state.retirement_sent |= should_retire;
-            should_retire
-        };
-        if should_retire {
-            self.inner.sink.retire(self.inner.handle);
-        }
-    }
-}
-
 /// Deployment-provided factory for platform socket resources.
 pub trait SocketProvider: Send + Sync {
     /// Creates one nonblocking platform socket for an authenticated session.
@@ -145,7 +36,7 @@ pub trait SocketProvider: Send + Sync {
         &self,
         session_id: SessionId,
         request: CreateSocketRequest,
-        readiness: SocketReadinessRegistration,
+        readiness: ReadinessRegistration,
     ) -> Result<Arc<dyn PlatformSocket>>;
 
     /// Releases provider state associated with a session after its references close.
@@ -201,7 +92,7 @@ impl SocketProvider for UnsupportedSocketProvider {
         &self,
         _session_id: SessionId,
         _request: CreateSocketRequest,
-        _readiness: SocketReadinessRegistration,
+        _readiness: ReadinessRegistration,
     ) -> Result<Arc<dyn PlatformSocket>> {
         Err(BrokerError::UnsupportedOperation)
     }
@@ -213,7 +104,7 @@ impl SocketProvider for UnsupportedSocketProvider {
 pub fn create(
     session: &BrokerSession,
     request: CreateSocketRequest,
-    readiness_sink: Arc<dyn SocketReadinessSink>,
+    readiness_sink: Arc<dyn ReadinessSink>,
 ) -> Result<ObjectHandle> {
     let rights = session
         .core
@@ -221,7 +112,7 @@ pub fn create(
         .authorize_socket_create(session.caller_credential, request)?;
     let quota = SocketQuotaReservation::new(session)?;
     let reference = session.reserve_object_reference(rights)?;
-    let readiness = SocketReadinessRegistration::new(reference.handle(), readiness_sink);
+    let readiness = ReadinessRegistration::new(reference.handle(), readiness_sink);
     let platform_socket =
         match session
             .core
@@ -431,7 +322,7 @@ pub(crate) struct SocketObject {
 impl SocketObject {
     fn new(
         platform_socket: Arc<dyn PlatformSocket>,
-        readiness: SocketReadinessRegistration,
+        readiness: ReadinessRegistration,
         quota: SocketQuotaReservation,
     ) -> Self {
         Self {
@@ -452,7 +343,7 @@ impl SocketObject {
 
 pub(crate) struct SocketResource {
     platform_socket: Arc<dyn PlatformSocket>,
-    readiness: SocketReadinessRegistration,
+    readiness: ReadinessRegistration,
     _quota: SocketQuotaReservation,
 }
 
@@ -563,7 +454,7 @@ pub(crate) mod tests {
         dropped_sockets: AtomicUsize,
         fail_create: core::sync::atomic::AtomicBool,
         fail_connect: core::sync::atomic::AtomicBool,
-        failed_readiness: StdMutex<Option<SocketReadinessRegistration>>,
+        failed_readiness: StdMutex<Option<ReadinessRegistration>>,
     }
 
     impl TestSocketProvider {
@@ -581,7 +472,7 @@ pub(crate) mod tests {
             &self,
             session_id: SessionId,
             request: CreateSocketRequest,
-            readiness: SocketReadinessRegistration,
+            readiness: ReadinessRegistration,
         ) -> Result<Arc<dyn PlatformSocket>> {
             self.state
                 .creates
@@ -605,7 +496,7 @@ pub(crate) mod tests {
 
     struct TestPlatformSocket {
         state: Arc<TestSocketState>,
-        readiness: SocketReadinessRegistration,
+        readiness: ReadinessRegistration,
     }
 
     impl PlatformSocket for TestPlatformSocket {
@@ -662,8 +553,8 @@ pub(crate) mod tests {
         retired: StdMutex<std::vec::Vec<ObjectHandle>>,
     }
 
-    impl SocketReadinessSink for TestReadinessSink {
-        fn max_tracked_sockets(&self) -> usize {
+    impl ReadinessSink for TestReadinessSink {
+        fn max_tracked_objects(&self) -> usize {
             usize::MAX
         }
 
@@ -687,7 +578,7 @@ pub(crate) mod tests {
 
     fn check_retired_registration_discards_updates() {
         let sink = Arc::new(TestReadinessSink::default());
-        let registration = SocketReadinessRegistration::new(ObjectHandle(99), sink.clone());
+        let registration = ReadinessRegistration::new(ObjectHandle(99), sink.clone());
         let delayed = registration.clone();
         registration.retire();
         delayed.publish(ReadinessFlags::READ).unwrap();

--- a/litebox_broker_core/src/socket.rs
+++ b/litebox_broker_core/src/socket.rs
@@ -169,6 +169,9 @@ pub fn connect(
         .policy
         .authorize_socket_connect(session.caller_credential, address)
     {
+        // Only a definitive authorization denial is a terminal socket outcome.
+        // Any other error means the broker could not evaluate or serve policy
+        // and must not be cached as if it were a network failure.
         if error != BrokerError::PolicyDenied {
             return Err(error);
         }

--- a/litebox_broker_core/src/socket.rs
+++ b/litebox_broker_core/src/socket.rs
@@ -1,0 +1,913 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//! Broker-owned platform socket authority.
+
+use alloc::sync::Arc;
+use core::sync::atomic::{AtomicUsize, Ordering};
+
+use litebox_broker_protocol::ObjectHandle;
+use litebox_broker_protocol::readiness::ReadinessFlags;
+use litebox_broker_protocol::socket::{
+    CreateSocketRequest, ReceiveFlags, ReceiveSocketResponse, SendFlags, ShutdownMode,
+    SocketAddressV4, SocketConnectionStatus, SocketError,
+};
+
+use crate::session::{ObjectEntry, ObjectRights};
+use crate::{BrokerError, BrokerSession, Result, SessionId};
+use spin::Mutex;
+
+/// Result of a platform socket operation that can fail with a network outcome.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[must_use]
+pub enum SocketOutcome<T> {
+    /// The operation completed successfully.
+    Completed(T),
+    /// The platform reported an ordinary network failure.
+    Failed(SocketError),
+}
+
+/// Per-association destination for asynchronous socket readiness changes.
+pub trait SocketReadinessSink: Send + Sync {
+    /// Maximum number of simultaneously live socket registrations.
+    fn max_tracked_sockets(&self) -> usize;
+
+    /// Records a new authoritative readiness snapshot.
+    fn publish(&self, handle: ObjectHandle, readiness: ReadinessFlags) -> Result<()>;
+
+    /// Retires all readiness state for a socket that can no longer publish.
+    fn retire(&self, handle: ObjectHandle);
+}
+
+/// Capability for publishing readiness for one broker-assigned socket handle.
+#[derive(Clone)]
+pub struct SocketReadinessRegistration {
+    inner: Arc<SocketReadinessRegistrationInner>,
+}
+
+impl SocketReadinessRegistration {
+    fn new(handle: ObjectHandle, sink: Arc<dyn SocketReadinessSink>) -> Self {
+        Self {
+            inner: Arc::new(SocketReadinessRegistrationInner {
+                handle,
+                sink,
+                state: Mutex::new(SocketReadinessRegistrationState {
+                    retired: false,
+                    active_publishers: 0,
+                    retirement_sent: false,
+                }),
+            }),
+        }
+    }
+
+    /// Publishes the socket's current readiness.
+    ///
+    /// Updates after the broker retires the socket are discarded.
+    pub fn publish(&self, readiness: ReadinessFlags) -> Result<()> {
+        {
+            let mut state = self.inner.state.lock();
+            if state.retired {
+                return Ok(());
+            }
+            state.active_publishers = state
+                .active_publishers
+                .checked_add(1)
+                .ok_or(BrokerError::ResourceExhausted)?;
+        }
+        let _publishing = SocketReadinessPublishGuard { inner: &self.inner };
+        self.inner.sink.publish(self.inner.handle, readiness)
+    }
+
+    fn retire(&self) {
+        self.inner.retire();
+    }
+}
+
+struct SocketReadinessRegistrationInner {
+    handle: ObjectHandle,
+    sink: Arc<dyn SocketReadinessSink>,
+    state: Mutex<SocketReadinessRegistrationState>,
+}
+
+struct SocketReadinessRegistrationState {
+    retired: bool,
+    active_publishers: usize,
+    retirement_sent: bool,
+}
+
+impl SocketReadinessRegistrationInner {
+    fn retire(&self) {
+        let should_retire = {
+            let mut state = self.state.lock();
+            state.retired = true;
+            let should_retire = state.active_publishers == 0 && !state.retirement_sent;
+            state.retirement_sent |= should_retire;
+            should_retire
+        };
+        if should_retire {
+            self.sink.retire(self.handle);
+        }
+    }
+}
+
+impl Drop for SocketReadinessRegistrationInner {
+    fn drop(&mut self) {
+        self.retire();
+    }
+}
+
+struct SocketReadinessPublishGuard<'registration> {
+    inner: &'registration SocketReadinessRegistrationInner,
+}
+
+impl Drop for SocketReadinessPublishGuard<'_> {
+    fn drop(&mut self) {
+        let should_retire = {
+            let mut state = self.inner.state.lock();
+            state.active_publishers -= 1;
+            let should_retire =
+                state.retired && state.active_publishers == 0 && !state.retirement_sent;
+            state.retirement_sent |= should_retire;
+            should_retire
+        };
+        if should_retire {
+            self.inner.sink.retire(self.inner.handle);
+        }
+    }
+}
+
+/// Deployment-provided factory for platform socket resources.
+pub trait SocketProvider: Send + Sync {
+    /// Creates one nonblocking platform socket for an authenticated session.
+    ///
+    /// The returned socket must not retain authority beyond its `Arc` lifetime.
+    fn create(
+        &self,
+        session_id: SessionId,
+        request: CreateSocketRequest,
+        readiness: SocketReadinessRegistration,
+    ) -> Result<Arc<dyn PlatformSocket>>;
+
+    /// Releases provider state associated with a session after its references close.
+    fn close_session(&self, session_id: SessionId);
+}
+
+/// One nonblocking platform socket resource.
+pub trait PlatformSocket: Send + Sync {
+    /// Starts a connection attempt.
+    ///
+    /// `Unconnected` is not a valid result once the attempt reaches the
+    /// platform. A pending attempt returns `Connecting`, and ordinary network
+    /// failures return `Failed`. A broker error is surfaced for that call and
+    /// leaves the socket terminally failed, because retrying a platform call
+    /// that may already have side effects is unsafe.
+    fn connect(&self, address: SocketAddressV4) -> Result<SocketConnectionStatus>;
+
+    /// Sends bytes without waiting for platform readiness.
+    ///
+    /// A temporarily full socket returns [`BrokerError::WouldBlock`]. Ordinary
+    /// network failures return [`SocketOutcome::Failed`].
+    fn send(&self, data: &[u8], flags: SendFlags) -> Result<SocketOutcome<usize>>;
+
+    /// Receives bytes without waiting for platform readiness.
+    ///
+    /// A temporarily empty socket returns [`BrokerError::WouldBlock`]. End of
+    /// stream returns [`ReceiveSocketResponse::EndOfStream`]; `Received(0)` is
+    /// reserved for a zero-length input buffer handled by the core.
+    fn receive(
+        &self,
+        data: &mut [u8],
+        flags: ReceiveFlags,
+    ) -> Result<SocketOutcome<ReceiveSocketResponse>>;
+
+    /// Shuts down one or both socket directions.
+    fn shutdown(&self, mode: ShutdownMode) -> Result<SocketOutcome<()>>;
+
+    /// Returns the authoritative connection status.
+    ///
+    /// Once a connection attempt starts this returns `Connecting`, `Connected`,
+    /// or `Failed`, never `Unconnected`.
+    fn status(&self) -> Result<SocketConnectionStatus>;
+
+    /// Returns the current readiness snapshot.
+    fn readiness(&self) -> ReadinessFlags;
+}
+
+pub(crate) struct UnsupportedSocketProvider;
+
+impl SocketProvider for UnsupportedSocketProvider {
+    fn create(
+        &self,
+        _session_id: SessionId,
+        _request: CreateSocketRequest,
+        _readiness: SocketReadinessRegistration,
+    ) -> Result<Arc<dyn PlatformSocket>> {
+        Err(BrokerError::UnsupportedOperation)
+    }
+
+    fn close_session(&self, _session_id: SessionId) {}
+}
+
+/// Creates a broker-owned socket.
+pub fn create(
+    session: &BrokerSession,
+    request: CreateSocketRequest,
+    readiness_sink: Arc<dyn SocketReadinessSink>,
+) -> Result<ObjectHandle> {
+    let rights = session
+        .core
+        .policy
+        .authorize_socket_create(session.caller_credential, request)?;
+    let quota = SocketQuotaReservation::new(session)?;
+    let reference = session.reserve_object_reference(rights)?;
+    let readiness = SocketReadinessRegistration::new(reference.handle(), readiness_sink);
+    let platform_socket =
+        match session
+            .core
+            .socket_provider
+            .create(session.session_id, request, readiness.clone())
+        {
+            Ok(socket) => socket,
+            Err(error) => {
+                // The provider may have retained its registration before
+                // failing, so retirement cannot rely on the local clone being
+                // the last one.
+                readiness.retire();
+                return Err(error);
+            }
+        };
+    let handle = reference.commit(ObjectEntry::Socket(SocketObject::new(
+        platform_socket,
+        readiness,
+        quota,
+    )))?;
+    Ok(handle)
+}
+
+/// Starts a nonblocking connection attempt.
+pub fn connect(
+    session: &BrokerSession,
+    handle: ObjectHandle,
+    address: SocketAddressV4,
+) -> Result<SocketConnectionStatus> {
+    let object = session.authorized_object(handle, ObjectRights::WRITE)?;
+    {
+        let object = object.read();
+        let ObjectEntry::Socket(socket) = &*object else {
+            return Err(BrokerError::InvalidRights);
+        };
+        if socket.connect_in_flight {
+            return Ok(SocketConnectionStatus::Connecting);
+        }
+        if socket.connection_status != SocketConnectionStatus::Unconnected {
+            return Ok(socket.connection_status);
+        }
+    }
+
+    if let Err(error) = session
+        .core
+        .policy
+        .authorize_socket_connect(session.caller_credential, address)
+    {
+        let mut object = object.write();
+        let ObjectEntry::Socket(socket) = &mut *object else {
+            return Err(BrokerError::InvalidRights);
+        };
+        if socket.connect_in_flight {
+            return Ok(SocketConnectionStatus::Connecting);
+        }
+        if socket.connection_status == SocketConnectionStatus::Unconnected {
+            socket.connection_status = SocketConnectionStatus::Failed(error);
+        }
+        return Ok(socket.connection_status);
+    }
+
+    let resource = {
+        let mut object = object.write();
+        let ObjectEntry::Socket(socket) = &mut *object else {
+            return Err(BrokerError::InvalidRights);
+        };
+        if socket.connect_in_flight {
+            return Ok(SocketConnectionStatus::Connecting);
+        }
+        if socket.connection_status != SocketConnectionStatus::Unconnected {
+            return Ok(socket.connection_status);
+        }
+        socket.connect_in_flight = true;
+        Arc::clone(&socket.resource)
+    };
+    let status = match resource.connect(address) {
+        Ok(SocketConnectionStatus::Unconnected) => {
+            finish_connect(&object, SocketConnectionStatus::Failed(SocketError::Other));
+            return Err(BrokerError::Internal);
+        }
+        Ok(status) => status,
+        Err(error) => {
+            finish_connect(&object, SocketConnectionStatus::Failed(SocketError::Other));
+            return Err(error);
+        }
+    };
+    finish_connect(&object, status);
+    Ok(status)
+}
+
+/// Sends bytes without waiting for readiness.
+pub fn send(
+    session: &BrokerSession,
+    handle: ObjectHandle,
+    data: &[u8],
+    flags: SendFlags,
+) -> Result<SocketOutcome<usize>> {
+    if flags.has_unsupported_bits() {
+        return Err(BrokerError::UnsupportedOperation);
+    }
+    let resource = socket_resource(session, handle, ObjectRights::WRITE)?;
+    let outcome = resource.send(data, flags)?;
+    if let SocketOutcome::Completed(sent) = outcome
+        && sent > data.len()
+    {
+        return Err(BrokerError::Internal);
+    }
+    Ok(outcome)
+}
+
+/// Receives bytes without waiting for readiness.
+pub fn receive(
+    session: &BrokerSession,
+    handle: ObjectHandle,
+    data: &mut [u8],
+    flags: ReceiveFlags,
+) -> Result<SocketOutcome<ReceiveSocketResponse>> {
+    if flags.has_unsupported_bits() {
+        return Err(BrokerError::UnsupportedOperation);
+    }
+    let resource = socket_resource(session, handle, ObjectRights::WAIT)?;
+    if data.is_empty() {
+        return Ok(SocketOutcome::Completed(ReceiveSocketResponse::Received(0)));
+    }
+    let outcome = resource.receive(data, flags)?;
+    if let SocketOutcome::Completed(ReceiveSocketResponse::Received(received)) = outcome
+        && (received as usize > data.len() || received == 0)
+    {
+        return Err(BrokerError::Internal);
+    }
+    Ok(outcome)
+}
+
+/// Shuts down one or both socket directions.
+pub fn shutdown(
+    session: &BrokerSession,
+    handle: ObjectHandle,
+    mode: ShutdownMode,
+) -> Result<SocketOutcome<()>> {
+    socket_resource(session, handle, ObjectRights::WRITE)?.shutdown(mode)
+}
+
+/// Returns the broker-authoritative connection status.
+pub fn status(session: &BrokerSession, handle: ObjectHandle) -> Result<SocketConnectionStatus> {
+    let object = session.authorized_object(handle, ObjectRights::WAIT)?;
+    let (resource, status, connect_in_flight) = {
+        let object = object.read();
+        let ObjectEntry::Socket(socket) = &*object else {
+            return Err(BrokerError::InvalidRights);
+        };
+        (
+            Arc::clone(&socket.resource),
+            socket.connection_status,
+            socket.connect_in_flight,
+        )
+    };
+    if connect_in_flight {
+        return Ok(SocketConnectionStatus::Connecting);
+    }
+    if status != SocketConnectionStatus::Connecting {
+        return Ok(status);
+    }
+    let status = resource.status()?;
+    if status == SocketConnectionStatus::Unconnected {
+        return Err(BrokerError::Internal);
+    }
+    let mut object = object.write();
+    let ObjectEntry::Socket(socket) = &mut *object else {
+        return Err(BrokerError::InvalidRights);
+    };
+    let status = if socket.connection_status == SocketConnectionStatus::Connecting {
+        socket.connection_status = status;
+        status
+    } else {
+        socket.connection_status
+    };
+    Ok(status)
+}
+
+fn socket_resource(
+    session: &BrokerSession,
+    handle: ObjectHandle,
+    required_rights: ObjectRights,
+) -> Result<Arc<SocketResource>> {
+    let object = session.authorized_object(handle, required_rights)?;
+    let object = object.read();
+    let ObjectEntry::Socket(socket) = &*object else {
+        return Err(BrokerError::InvalidRights);
+    };
+    Ok(Arc::clone(&socket.resource))
+}
+
+fn finish_connect(object: &spin::RwLock<ObjectEntry>, status: SocketConnectionStatus) {
+    let mut object = object.write();
+    if let ObjectEntry::Socket(socket) = &mut *object {
+        socket.connect_in_flight = false;
+        socket.connection_status = status;
+    }
+}
+
+pub(crate) struct SocketObject {
+    resource: Arc<SocketResource>,
+    connection_status: SocketConnectionStatus,
+    connect_in_flight: bool,
+}
+
+impl SocketObject {
+    fn new(
+        platform_socket: Arc<dyn PlatformSocket>,
+        readiness: SocketReadinessRegistration,
+        quota: SocketQuotaReservation,
+    ) -> Self {
+        Self {
+            resource: Arc::new(SocketResource {
+                platform_socket,
+                readiness,
+                _quota: quota,
+            }),
+            connection_status: SocketConnectionStatus::Unconnected,
+            connect_in_flight: false,
+        }
+    }
+
+    pub(crate) fn resource(&self) -> Arc<SocketResource> {
+        Arc::clone(&self.resource)
+    }
+}
+
+pub(crate) struct SocketResource {
+    platform_socket: Arc<dyn PlatformSocket>,
+    readiness: SocketReadinessRegistration,
+    _quota: SocketQuotaReservation,
+}
+
+impl SocketResource {
+    fn connect(&self, address: SocketAddressV4) -> Result<SocketConnectionStatus> {
+        self.platform_socket.connect(address)
+    }
+
+    fn send(&self, data: &[u8], flags: SendFlags) -> Result<SocketOutcome<usize>> {
+        self.platform_socket.send(data, flags)
+    }
+
+    fn receive(
+        &self,
+        data: &mut [u8],
+        flags: ReceiveFlags,
+    ) -> Result<SocketOutcome<ReceiveSocketResponse>> {
+        self.platform_socket.receive(data, flags)
+    }
+
+    fn shutdown(&self, mode: ShutdownMode) -> Result<SocketOutcome<()>> {
+        self.platform_socket.shutdown(mode)
+    }
+
+    fn status(&self) -> Result<SocketConnectionStatus> {
+        self.platform_socket.status()
+    }
+
+    pub(crate) fn readiness(&self) -> ReadinessFlags {
+        self.platform_socket.readiness()
+    }
+}
+
+impl Drop for SocketResource {
+    fn drop(&mut self) {
+        self.readiness.retire();
+    }
+}
+
+struct SocketQuotaReservation {
+    global: Arc<AtomicUsize>,
+    session: Arc<AtomicUsize>,
+}
+
+impl SocketQuotaReservation {
+    fn new(session: &BrokerSession) -> Result<Self> {
+        reserve_socket(
+            &session.core.reserved_sockets,
+            session.core.limits.max_sockets,
+        )?;
+        if reserve_socket(
+            &session.reserved_sockets,
+            session.core.limits.max_sockets_per_session,
+        )
+        .is_err()
+        {
+            session
+                .core
+                .reserved_sockets
+                .fetch_sub(1, Ordering::Relaxed);
+            return Err(BrokerError::ResourceExhausted);
+        }
+        Ok(Self {
+            global: Arc::clone(&session.core.reserved_sockets),
+            session: Arc::clone(&session.reserved_sockets),
+        })
+    }
+}
+
+impl Drop for SocketQuotaReservation {
+    fn drop(&mut self) {
+        self.session.fetch_sub(1, Ordering::Relaxed);
+        self.global.fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
+fn reserve_socket(counter: &AtomicUsize, limit: usize) -> Result<()> {
+    counter
+        .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |reserved| {
+            reserved.checked_add(1).filter(|next| *next <= limit)
+        })
+        .map(|_| ())
+        .map_err(|_| BrokerError::ResourceExhausted)
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+    use crate::{BrokerCore, CallerCredential};
+    use litebox_broker_protocol::socket::{
+        AddressFamily, IpProtocol, Ipv4Address, Port, SocketType,
+    };
+    use std::sync::Mutex as StdMutex;
+
+    #[derive(Clone, Default)]
+    pub(crate) struct TestSocketProvider {
+        state: Arc<TestSocketState>,
+    }
+
+    #[derive(Default)]
+    struct TestSocketState {
+        creates: StdMutex<std::vec::Vec<(SessionId, CreateSocketRequest)>>,
+        closed_sessions: StdMutex<std::vec::Vec<SessionId>>,
+        sent: StdMutex<std::vec::Vec<u8>>,
+        connect_calls: AtomicUsize,
+        status_calls: AtomicUsize,
+        shutdown_calls: AtomicUsize,
+        dropped_sockets: AtomicUsize,
+        fail_create: core::sync::atomic::AtomicBool,
+        fail_connect: core::sync::atomic::AtomicBool,
+        failed_readiness: StdMutex<Option<SocketReadinessRegistration>>,
+    }
+
+    impl TestSocketProvider {
+        pub(crate) fn fail_next_create(&self) {
+            self.state.fail_create.store(true, Ordering::Relaxed);
+        }
+
+        fn fail_next_connect(&self) {
+            self.state.fail_connect.store(true, Ordering::Relaxed);
+        }
+    }
+
+    impl SocketProvider for TestSocketProvider {
+        fn create(
+            &self,
+            session_id: SessionId,
+            request: CreateSocketRequest,
+            readiness: SocketReadinessRegistration,
+        ) -> Result<Arc<dyn PlatformSocket>> {
+            self.state
+                .creates
+                .lock()
+                .unwrap()
+                .push((session_id, request));
+            if self.state.fail_create.swap(false, Ordering::Relaxed) {
+                *self.state.failed_readiness.lock().unwrap() = Some(readiness);
+                return Err(BrokerError::OutOfMemory);
+            }
+            Ok(Arc::new(TestPlatformSocket {
+                state: Arc::clone(&self.state),
+                readiness,
+            }))
+        }
+
+        fn close_session(&self, session_id: SessionId) {
+            self.state.closed_sessions.lock().unwrap().push(session_id);
+        }
+    }
+
+    struct TestPlatformSocket {
+        state: Arc<TestSocketState>,
+        readiness: SocketReadinessRegistration,
+    }
+
+    impl PlatformSocket for TestPlatformSocket {
+        fn connect(&self, _address: SocketAddressV4) -> Result<SocketConnectionStatus> {
+            self.state.connect_calls.fetch_add(1, Ordering::Relaxed);
+            if self.state.fail_connect.swap(false, Ordering::Relaxed) {
+                return Err(BrokerError::Internal);
+            }
+            self.readiness.publish(ReadinessFlags::WRITE)?;
+            Ok(SocketConnectionStatus::Connecting)
+        }
+
+        fn send(&self, data: &[u8], _flags: SendFlags) -> Result<SocketOutcome<usize>> {
+            self.state.sent.lock().unwrap().extend_from_slice(data);
+            Ok(SocketOutcome::Completed(data.len()))
+        }
+
+        fn receive(
+            &self,
+            data: &mut [u8],
+            _flags: ReceiveFlags,
+        ) -> Result<SocketOutcome<ReceiveSocketResponse>> {
+            let received = data.len().min(2);
+            data[..received].copy_from_slice(&[7, 9][..received]);
+            Ok(SocketOutcome::Completed(ReceiveSocketResponse::Received(
+                u32::try_from(received).unwrap(),
+            )))
+        }
+
+        fn shutdown(&self, _mode: ShutdownMode) -> Result<SocketOutcome<()>> {
+            self.state.shutdown_calls.fetch_add(1, Ordering::Relaxed);
+            Ok(SocketOutcome::Completed(()))
+        }
+
+        fn status(&self) -> Result<SocketConnectionStatus> {
+            self.state.status_calls.fetch_add(1, Ordering::Relaxed);
+            Ok(SocketConnectionStatus::Connected)
+        }
+
+        fn readiness(&self) -> ReadinessFlags {
+            ReadinessFlags::READ | ReadinessFlags::WRITE
+        }
+    }
+
+    impl Drop for TestPlatformSocket {
+        fn drop(&mut self) {
+            self.state.dropped_sockets.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    #[derive(Default)]
+    struct TestReadinessSink {
+        published: StdMutex<std::vec::Vec<(ObjectHandle, ReadinessFlags)>>,
+        retired: StdMutex<std::vec::Vec<ObjectHandle>>,
+    }
+
+    impl SocketReadinessSink for TestReadinessSink {
+        fn max_tracked_sockets(&self) -> usize {
+            usize::MAX
+        }
+
+        fn publish(&self, handle: ObjectHandle, readiness: ReadinessFlags) -> Result<()> {
+            self.published.lock().unwrap().push((handle, readiness));
+            Ok(())
+        }
+
+        fn retire(&self, handle: ObjectHandle) {
+            self.retired.lock().unwrap().push(handle);
+        }
+    }
+
+    pub(crate) fn check_socket_lifecycle(broker: &BrokerCore, provider: &TestSocketProvider) {
+        check_failed_create_rolls_back(broker, provider);
+        check_retired_registration_discards_updates();
+        check_socket_operations_and_policy(broker, provider);
+        check_connect_error_is_terminal(broker, provider);
+        check_socket_quotas(broker);
+    }
+
+    fn check_retired_registration_discards_updates() {
+        let sink = Arc::new(TestReadinessSink::default());
+        let registration = SocketReadinessRegistration::new(ObjectHandle(99), sink.clone());
+        let delayed = registration.clone();
+        registration.retire();
+        delayed.publish(ReadinessFlags::READ).unwrap();
+        assert!(sink.published.lock().unwrap().is_empty());
+        assert_eq!(sink.retired.lock().unwrap().as_slice(), [ObjectHandle(99)]);
+    }
+
+    fn check_failed_create_rolls_back(broker: &BrokerCore, provider: &TestSocketProvider) {
+        let session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        provider.fail_next_create();
+        let readiness = Arc::new(TestReadinessSink::default());
+        assert_eq!(
+            create(&session, create_request(), readiness.clone()),
+            Err(BrokerError::OutOfMemory)
+        );
+        provider
+            .state
+            .failed_readiness
+            .lock()
+            .unwrap()
+            .as_ref()
+            .unwrap()
+            .publish(ReadinessFlags::READ)
+            .unwrap();
+        assert!(readiness.published.lock().unwrap().is_empty());
+        assert_eq!(readiness.retired.lock().unwrap().len(), 1);
+        assert_eq!(broker.pending_references.load(Ordering::Relaxed), 0);
+        assert_eq!(broker.reserved_sockets.load(Ordering::Relaxed), 0);
+        assert_eq!(session.reserved_sockets.load(Ordering::Relaxed), 0);
+    }
+
+    fn check_socket_operations_and_policy(broker: &BrokerCore, provider: &TestSocketProvider) {
+        let session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let other = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let readiness = Arc::new(TestReadinessSink::default());
+        let denied_handle = create(&session, create_request(), readiness.clone()).unwrap();
+        assert_eq!(
+            provider.state.creates.lock().unwrap().last(),
+            Some(&(session.session_id, create_request()))
+        );
+        assert_eq!(broker.reserved_sockets.load(Ordering::Relaxed), 1);
+        assert_eq!(session.reserved_sockets.load(Ordering::Relaxed), 1);
+        assert_eq!(
+            status(&other, denied_handle),
+            Err(BrokerError::UnknownObject)
+        );
+        assert_eq!(
+            connect(
+                &session,
+                denied_handle,
+                SocketAddressV4 {
+                    address: Ipv4Address([10, 0, 0, 1]),
+                    port: Port(80),
+                },
+            ),
+            Ok(SocketConnectionStatus::Failed(SocketError::PolicyDenied))
+        );
+        assert_eq!(
+            status(&session, denied_handle),
+            Ok(SocketConnectionStatus::Failed(SocketError::PolicyDenied))
+        );
+        session.close_object_reference(denied_handle).unwrap();
+        let handle = create(&session, create_request(), readiness.clone()).unwrap();
+        assert_eq!(
+            connect(&session, handle, loopback_address()),
+            Ok(SocketConnectionStatus::Connecting)
+        );
+        assert_eq!(
+            readiness.published.lock().unwrap().as_slice(),
+            [(handle, ReadinessFlags::WRITE)]
+        );
+        assert_eq!(
+            status(&session, handle),
+            Ok(SocketConnectionStatus::Connected)
+        );
+        assert_eq!(
+            session.check_readiness(handle),
+            Ok(ReadinessFlags::READ | ReadinessFlags::WRITE)
+        );
+        assert_eq!(
+            send(&session, handle, &[1, 2, 3], SendFlags::NONE),
+            Ok(SocketOutcome::Completed(3))
+        );
+        let mut data = [0; 4];
+        assert_eq!(
+            receive(&session, handle, &mut data, ReceiveFlags::PEEK),
+            Ok(SocketOutcome::Completed(ReceiveSocketResponse::Received(2)))
+        );
+        assert_eq!(data, [7, 9, 0, 0]);
+        assert_eq!(
+            shutdown(&session, handle, ShutdownMode::Both),
+            Ok(SocketOutcome::Completed(()))
+        );
+        assert_eq!(
+            send(&session, handle, &[], SendFlags(1)),
+            Err(BrokerError::UnsupportedOperation)
+        );
+        let in_flight = socket_resource(&session, handle, ObjectRights::WAIT).unwrap();
+        assert_eq!(session.close_object_reference(handle), Ok(()));
+        assert_eq!(broker.reserved_sockets.load(Ordering::Relaxed), 1);
+        assert_eq!(
+            readiness.retired.lock().unwrap().as_slice(),
+            [denied_handle]
+        );
+        drop(in_flight);
+        assert_eq!(
+            readiness.retired.lock().unwrap().as_slice(),
+            [denied_handle, handle]
+        );
+        assert_eq!(provider.state.dropped_sockets.load(Ordering::Relaxed), 2);
+        assert_eq!(broker.reserved_sockets.load(Ordering::Relaxed), 0);
+        assert_eq!(session.reserved_sockets.load(Ordering::Relaxed), 0);
+        assert_eq!(provider.state.sent.lock().unwrap().as_slice(), [1, 2, 3]);
+        assert_eq!(provider.state.connect_calls.load(Ordering::Relaxed), 1);
+        assert_eq!(provider.state.status_calls.load(Ordering::Relaxed), 1);
+        assert_eq!(provider.state.shutdown_calls.load(Ordering::Relaxed), 1);
+        let session_id = session.session_id;
+        drop(other);
+        drop(session);
+        assert!(
+            provider
+                .state
+                .closed_sessions
+                .lock()
+                .unwrap()
+                .contains(&session_id)
+        );
+    }
+
+    fn check_socket_quotas(broker: &BrokerCore) {
+        let first = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let second = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let third = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let first_handle = create(
+            &first,
+            create_request(),
+            Arc::new(TestReadinessSink::default()),
+        )
+        .unwrap();
+        assert_eq!(
+            create(
+                &first,
+                create_request(),
+                Arc::new(TestReadinessSink::default())
+            ),
+            Err(BrokerError::ResourceExhausted)
+        );
+        let second_handle = create(
+            &second,
+            create_request(),
+            Arc::new(TestReadinessSink::default()),
+        )
+        .unwrap();
+        assert_eq!(
+            create(
+                &third,
+                create_request(),
+                Arc::new(TestReadinessSink::default())
+            ),
+            Err(BrokerError::ResourceExhausted)
+        );
+        assert_eq!(broker.reserved_sockets.load(Ordering::Relaxed), 2);
+        first.close_object_reference(first_handle).unwrap();
+        second.close_object_reference(second_handle).unwrap();
+        assert_eq!(broker.reserved_sockets.load(Ordering::Relaxed), 0);
+    }
+
+    fn check_connect_error_is_terminal(broker: &BrokerCore, provider: &TestSocketProvider) {
+        let session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let handle = create(
+            &session,
+            create_request(),
+            Arc::new(TestReadinessSink::default()),
+        )
+        .unwrap();
+        let calls_before = provider.state.connect_calls.load(Ordering::Relaxed);
+        provider.fail_next_connect();
+        assert_eq!(
+            connect(&session, handle, loopback_address()),
+            Err(BrokerError::Internal)
+        );
+        assert_eq!(
+            connect(&session, handle, loopback_address()),
+            Ok(SocketConnectionStatus::Failed(SocketError::Other))
+        );
+        assert_eq!(
+            status(&session, handle),
+            Ok(SocketConnectionStatus::Failed(SocketError::Other))
+        );
+        assert_eq!(
+            provider.state.connect_calls.load(Ordering::Relaxed),
+            calls_before + 1
+        );
+    }
+
+    const fn create_request() -> CreateSocketRequest {
+        CreateSocketRequest {
+            address_family: AddressFamily::Ipv4,
+            socket_type: SocketType::Stream,
+            protocol: IpProtocol::Tcp,
+        }
+    }
+
+    const fn loopback_address() -> SocketAddressV4 {
+        SocketAddressV4 {
+            address: Ipv4Address([127, 0, 0, 1]),
+            port: Port(8080),
+        }
+    }
+}

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -244,6 +244,18 @@ enum RequestFailure {
     Abort(ErrorCode),
 }
 
+impl From<litebox_broker_core::BrokerError> for RequestFailure {
+    fn from(error: litebox_broker_core::BrokerError) -> Self {
+        match error {
+            litebox_broker_core::BrokerError::Internal
+            | litebox_broker_core::BrokerError::BrokerCoreAlreadyExists => {
+                Self::Abort(ErrorCode::Internal)
+            }
+            error => Self::Respond(error.into()),
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum SharedBufferSlotState {
     Unused,
@@ -319,11 +331,11 @@ fn handle_request<Memory: SharedMemory>(
         BrokerOperation::CloseObject(handle) => session
             .close_object_reference(handle)
             .map(|()| BrokerResult::ObjectClosed)
-            .map_err(|error| RequestFailure::Respond(error.into())),
+            .map_err(RequestFailure::from),
         BrokerOperation::CheckReadiness(handle) => session
             .check_readiness(handle)
             .map(BrokerResult::Readiness)
-            .map_err(|error| RequestFailure::Respond(error.into())),
+            .map_err(RequestFailure::from),
         BrokerOperation::Event(request) => {
             handle_event_request(session, request).map(BrokerResult::Event)
         }
@@ -347,12 +359,12 @@ fn handle_socket_request<Memory: SharedMemory>(
         SocketRequest::Create(request) => {
             let handle =
                 litebox_broker_core::socket::create(session, request, Arc::clone(readiness_sink))
-                    .map_err(socket_request_failure)?;
+                    .map_err(RequestFailure::from)?;
             Ok(SocketResponse::Create(CreateSocketResponse { handle }))
         }
         SocketRequest::Connect(request) => {
             match litebox_broker_core::socket::connect(session, request.handle, request.address)
-                .map_err(socket_request_failure)?
+                .map_err(RequestFailure::from)?
             {
                 SocketOutcome::Completed(status) => {
                     Ok(SocketResponse::Connect(ConnectSocketResponse { status }))
@@ -361,7 +373,9 @@ fn handle_socket_request<Memory: SharedMemory>(
             }
         }
         SocketRequest::Send(request) => {
-            if request.buffer.length > MAX_SOCKET_TRANSFER_SIZE {
+            if request.flags.has_unsupported_bits()
+                || request.buffer.length > MAX_SOCKET_TRANSFER_SIZE
+            {
                 return Err(RequestFailure::Abort(ErrorCode::MalformedRequest));
             }
             let length = request.buffer.length as usize;
@@ -374,7 +388,7 @@ fn handle_socket_request<Memory: SharedMemory>(
                 .read(request.buffer.slot_index, &mut data)
                 .map_err(|_| RequestFailure::Abort(ErrorCode::Internal))?;
             match litebox_broker_core::socket::send(session, request.handle, &data, request.flags)
-                .map_err(socket_request_failure)?
+                .map_err(RequestFailure::from)?
             {
                 SocketOutcome::Completed(sent) => {
                     let sent = sent
@@ -386,7 +400,9 @@ fn handle_socket_request<Memory: SharedMemory>(
             }
         }
         SocketRequest::Receive(request) => {
-            if request.buffer.length > MAX_SOCKET_TRANSFER_SIZE {
+            if request.flags.has_unsupported_bits()
+                || request.buffer.length > MAX_SOCKET_TRANSFER_SIZE
+            {
                 return Err(RequestFailure::Abort(ErrorCode::MalformedRequest));
             }
             let length = request.buffer.length as usize;
@@ -401,7 +417,7 @@ fn handle_socket_request<Memory: SharedMemory>(
                 &mut data,
                 request.flags,
             )
-            .map_err(socket_request_failure)?
+            .map_err(RequestFailure::from)?
             {
                 SocketOutcome::Completed(response) => {
                     if let ReceiveSocketResponse::Received(received) = response {
@@ -416,7 +432,7 @@ fn handle_socket_request<Memory: SharedMemory>(
         }
         SocketRequest::Shutdown(request) => {
             match litebox_broker_core::socket::shutdown(session, request.handle, request.mode)
-                .map_err(socket_request_failure)?
+                .map_err(RequestFailure::from)?
             {
                 SocketOutcome::Completed(()) => Ok(SocketResponse::Shutdown),
                 SocketOutcome::Failed(error) => Ok(SocketResponse::Failed(error)),
@@ -425,16 +441,8 @@ fn handle_socket_request<Memory: SharedMemory>(
         SocketRequest::Status(request) => {
             litebox_broker_core::socket::status(session, request.handle)
                 .map(|status| SocketResponse::Status(SocketStatusResponse { status }))
-                .map_err(socket_request_failure)
+                .map_err(RequestFailure::from)
         }
-    }
-}
-
-fn socket_request_failure(error: litebox_broker_core::BrokerError) -> RequestFailure {
-    if error == litebox_broker_core::BrokerError::UnsupportedOperation {
-        RequestFailure::Abort(ErrorCode::MalformedRequest)
-    } else {
-        RequestFailure::Respond(error.into())
     }
 }
 
@@ -452,7 +460,7 @@ fn handle_pipe_request<Memory: SharedMemory>(
                         write_handle,
                     })
                 })
-                .map_err(|error| RequestFailure::Respond(error.into()))
+                .map_err(RequestFailure::from)
         }
         PipeRequest::Read(request) => {
             if request.buffer.length > MAX_PIPE_TRANSFER_SIZE {
@@ -460,7 +468,7 @@ fn handle_pipe_request<Memory: SharedMemory>(
             }
             let data =
                 litebox_broker_core::pipe::read(session, request.handle, request.buffer.length)
-                    .map_err(|error| RequestFailure::Respond(error.into()))?;
+                    .map_err(RequestFailure::from)?;
             shared_buffers
                 .write(request.buffer.slot_index, &data)
                 .map_err(|_| RequestFailure::Abort(ErrorCode::Internal))?;
@@ -485,7 +493,7 @@ fn handle_pipe_request<Memory: SharedMemory>(
                 .read(request.buffer.slot_index, &mut data)
                 .map_err(|_| RequestFailure::Abort(ErrorCode::Internal))?;
             litebox_broker_core::pipe::write(session, request.handle, &data)
-                .map_err(|error| RequestFailure::Respond(error.into()))
+                .map_err(RequestFailure::from)
                 .and_then(|written| {
                     Ok(PipeResponse::Write(WritePipeResponse {
                         written: written
@@ -505,17 +513,17 @@ fn handle_event_request(
         EventRequest::Create(request) => {
             litebox_broker_core::event::create(session, request.initial_count)
                 .map(|handle| EventResponse::Create(CreateEventResponse { handle }))
-                .map_err(|error| RequestFailure::Respond(error.into()))
+                .map_err(RequestFailure::from)
         }
         EventRequest::Add(request) => {
             litebox_broker_core::event::add(session, request.handle, request.value)
                 .map(|readiness| EventResponse::Add(AddEventResponse { readiness }))
-                .map_err(|error| RequestFailure::Respond(error.into()))
+                .map_err(RequestFailure::from)
         }
         EventRequest::Consume(request) => {
             litebox_broker_core::event::consume(session, request.handle, request.mode)
                 .map(EventResponse::Consume)
-                .map_err(|error| RequestFailure::Respond(error.into()))
+                .map_err(RequestFailure::from)
         }
     }
 }
@@ -1174,6 +1182,27 @@ mod tests {
                 &test_readiness_sink(),
             )),
             Err(ErrorCode::MalformedRequest)
+        );
+        assert_eq!(
+            complete_request(handle_request(
+                &session,
+                BrokerOperation::Socket(SocketRequest::Receive(ReceiveSocketRequest {
+                    handle: response.handle,
+                    buffer: descriptor(2, 0),
+                    flags: ReceiveFlags(ReceiveFlags::SUPPORTED.0 | 2),
+                })),
+                &shared_buffers,
+                &test_readiness_sink(),
+            )),
+            Err(ErrorCode::MalformedRequest)
+        );
+        assert_eq!(
+            RequestFailure::from(litebox_broker_core::BrokerError::UnsupportedOperation),
+            RequestFailure::Respond(ErrorCode::UnsupportedOperation)
+        );
+        assert_eq!(
+            RequestFailure::from(litebox_broker_core::BrokerError::Internal),
+            RequestFailure::Abort(ErrorCode::Internal)
         );
         session.close_object_reference(response.handle).unwrap();
     }

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -167,8 +167,8 @@ where
         return Err(BrokerHostError::SharedBufferLayoutMismatch);
     }
     let limits = core.limits();
-    // Sockets are currently the only provider-backed objects. Add future
-    // provider-object limits here so every live registration fits in the
+    // Sockets are currently the only externally backed objects. Add future
+    // resource limits here so every live registration fits in the
     // association's shared readiness sink.
     let max_live_readiness_registrations = limits
         .max_references

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -21,20 +21,25 @@ extern crate alloc;
 #[cfg(test)]
 extern crate std;
 
-use alloc::vec::Vec;
+use alloc::{sync::Arc, vec::Vec};
 
+use litebox_broker_core::socket::{SocketOutcome, SocketReadinessSink};
 use litebox_broker_core::{BrokerCore, BrokerSession, CallerCredential};
 use litebox_broker_protocol::error::ErrorCode;
 use litebox_broker_protocol::event::{AddEventResponse, CreateEventResponse};
 use litebox_broker_protocol::message::{
     BrokerHandshakeResponse, BrokerOperation, BrokerRequest, BrokerResponse, BrokerResult,
-    EventRequest, EventResponse, PipeRequest, PipeResponse, SocketRequest,
+    EventRequest, EventResponse, PipeRequest, PipeResponse, SocketRequest, SocketResponse,
 };
 use litebox_broker_protocol::pipe::{
     CreatePipeResponse, MAX_PIPE_TRANSFER_SIZE, ReadPipeResponse, WritePipeResponse,
 };
 use litebox_broker_protocol::shared_buffer::{
     SHARED_BUFFER_LAYOUT, SHARED_BUFFER_SLOT_COUNT, SharedBufferDescriptor, SharedBufferSlotIndex,
+};
+use litebox_broker_protocol::socket::{
+    ConnectSocketResponse, CreateSocketResponse, MAX_SOCKET_TRANSFER_SIZE, ReceiveSocketResponse,
+    SendSocketResponse, SocketStatusResponse,
 };
 use litebox_broker_protocol::{BROKER_PROTOCOL_VERSION, RequestId};
 use litebox_broker_transport::channel::{HostReceive, HostSetupChannel, PeerCredential};
@@ -58,6 +63,7 @@ pub type ConnectionSetup<'a, Memory> =
 pub struct BrokerHostAssociation<'a, Memory: SharedMemory> {
     session: BrokerSession,
     shared_buffers: &'a SharedBufferPool<Memory>,
+    socket_readiness: Arc<dyn SocketReadinessSink>,
     state: SpinMutex<AssociationState>,
 }
 
@@ -119,6 +125,7 @@ impl<Memory: SharedMemory> BrokerHostAssociation<'_, Memory> {
             &self.session,
             operation,
             self.shared_buffers,
+            &self.socket_readiness,
         )) {
             Ok(result) => result,
             Err(error) => {
@@ -148,6 +155,7 @@ pub fn setup_connection<'a, SetupChannel, Memory, ChannelError>(
     core: &BrokerCore,
     setup_channel: &mut SetupChannel,
     shared_buffers: &'a SharedBufferPool<Memory>,
+    socket_readiness: Arc<dyn SocketReadinessSink>,
     send_shared_memory: impl FnOnce(&mut SetupChannel) -> core::result::Result<(), ChannelError>,
 ) -> Result<ConnectionSetup<'a, Memory>, ChannelError>
 where
@@ -156,6 +164,14 @@ where
 {
     if shared_buffers.layout() != SHARED_BUFFER_LAYOUT {
         return Err(BrokerHostError::SharedBufferLayoutMismatch);
+    }
+    let limits = core.limits();
+    let max_live_session_sockets = limits
+        .max_references
+        .min(limits.max_sockets)
+        .min(limits.max_sockets_per_session);
+    if max_live_session_sockets > socket_readiness.max_tracked_sockets() {
+        return Err(BrokerHostError::Broker(ErrorCode::ResourceExhausted));
     }
 
     let peer_credential = setup_channel
@@ -204,6 +220,7 @@ where
             return Ok(Ok(BrokerHostAssociation {
                 session,
                 shared_buffers,
+                socket_readiness,
                 state: SpinMutex::new(AssociationState {
                     failed: false,
                     shared_buffer_usage: SharedBufferUsage::new(),
@@ -292,6 +309,7 @@ fn handle_request<Memory: SharedMemory>(
     session: &BrokerSession,
     operation: BrokerOperation,
     shared_buffers: &SharedBufferPool<Memory>,
+    socket_readiness: &Arc<dyn SocketReadinessSink>,
 ) -> RequestResult<BrokerResult> {
     match operation {
         BrokerOperation::CloseObject(handle) => session
@@ -308,19 +326,106 @@ fn handle_request<Memory: SharedMemory>(
         BrokerOperation::Pipe(request) => {
             handle_pipe_request(session, request, shared_buffers).map(BrokerResult::Pipe)
         }
-        // The socket protocol is defined before the broker implements it, so
-        // the operations decode and their shared-buffer leases are validated,
-        // but no socket object exists to act on one yet.
-        //
-        // `UnsupportedOperation` is deliberately in the local endpoint's fatal
-        // group alongside `MalformedRequest` and `ProtocolState`: it means the
-        // local sent an operation this broker never serves, which cannot happen
-        // unless the two sides disagree about the protocol. No local code
-        // constructs a socket request today, so this is unreachable; reporting
-        // a recoverable code instead would let a future wiring mistake look
-        // like an ordinary runtime failure rather than the contract violation
-        // it is.
-        BrokerOperation::Socket(_) => Err(RequestFailure::Respond(ErrorCode::UnsupportedOperation)),
+        BrokerOperation::Socket(request) => {
+            handle_socket_request(session, request, shared_buffers, socket_readiness)
+                .map(BrokerResult::Socket)
+        }
+    }
+}
+
+fn handle_socket_request<Memory: SharedMemory>(
+    session: &BrokerSession,
+    request: SocketRequest,
+    shared_buffers: &SharedBufferPool<Memory>,
+    socket_readiness: &Arc<dyn SocketReadinessSink>,
+) -> RequestResult<SocketResponse> {
+    match request {
+        SocketRequest::Create(request) => {
+            let handle =
+                litebox_broker_core::socket::create(session, request, Arc::clone(socket_readiness))
+                    .map_err(socket_request_failure)?;
+            Ok(SocketResponse::Create(CreateSocketResponse { handle }))
+        }
+        SocketRequest::Connect(request) => {
+            litebox_broker_core::socket::connect(session, request.handle, request.address)
+                .map(|status| SocketResponse::Connect(ConnectSocketResponse { status }))
+                .map_err(socket_request_failure)
+        }
+        SocketRequest::Send(request) => {
+            if request.buffer.length > MAX_SOCKET_TRANSFER_SIZE {
+                return Err(RequestFailure::Abort(ErrorCode::MalformedRequest));
+            }
+            let length = request.buffer.length as usize;
+            let mut data = Vec::new();
+            if data.try_reserve_exact(length).is_err() {
+                return Err(RequestFailure::Respond(ErrorCode::OutOfMemory));
+            }
+            data.resize(length, 0);
+            shared_buffers
+                .read(request.buffer.slot_index, &mut data)
+                .map_err(|_| RequestFailure::Abort(ErrorCode::Internal))?;
+            match litebox_broker_core::socket::send(session, request.handle, &data, request.flags)
+                .map_err(socket_request_failure)?
+            {
+                SocketOutcome::Completed(sent) => {
+                    let sent = sent
+                        .try_into()
+                        .map_err(|_| RequestFailure::Abort(ErrorCode::Internal))?;
+                    Ok(SocketResponse::Send(SendSocketResponse { sent }))
+                }
+                SocketOutcome::Failed(error) => Ok(SocketResponse::Failed(error)),
+            }
+        }
+        SocketRequest::Receive(request) => {
+            if request.buffer.length > MAX_SOCKET_TRANSFER_SIZE {
+                return Err(RequestFailure::Abort(ErrorCode::MalformedRequest));
+            }
+            let length = request.buffer.length as usize;
+            let mut data = Vec::new();
+            if data.try_reserve_exact(length).is_err() {
+                return Err(RequestFailure::Respond(ErrorCode::OutOfMemory));
+            }
+            data.resize(length, 0);
+            match litebox_broker_core::socket::receive(
+                session,
+                request.handle,
+                &mut data,
+                request.flags,
+            )
+            .map_err(socket_request_failure)?
+            {
+                SocketOutcome::Completed(response) => {
+                    if let ReceiveSocketResponse::Received(received) = response {
+                        shared_buffers
+                            .write(request.buffer.slot_index, &data[..received as usize])
+                            .map_err(|_| RequestFailure::Abort(ErrorCode::Internal))?;
+                    }
+                    Ok(SocketResponse::Receive(response))
+                }
+                SocketOutcome::Failed(error) => Ok(SocketResponse::Failed(error)),
+            }
+        }
+        SocketRequest::Shutdown(request) => {
+            match litebox_broker_core::socket::shutdown(session, request.handle, request.mode)
+                .map_err(socket_request_failure)?
+            {
+                SocketOutcome::Completed(()) => Ok(SocketResponse::Shutdown),
+                SocketOutcome::Failed(error) => Ok(SocketResponse::Failed(error)),
+            }
+        }
+        SocketRequest::Status(request) => {
+            litebox_broker_core::socket::status(session, request.handle)
+                .map(|status| SocketResponse::Status(SocketStatusResponse { status }))
+                .map_err(socket_request_failure)
+        }
+    }
+}
+
+fn socket_request_failure(error: litebox_broker_core::BrokerError) -> RequestFailure {
+    if error == litebox_broker_core::BrokerError::UnsupportedOperation {
+        RequestFailure::Abort(ErrorCode::MalformedRequest)
+    } else {
+        RequestFailure::Respond(error.into())
     }
 }
 
@@ -420,7 +525,10 @@ pub enum ConnectionTermination {
 mod tests {
     use super::*;
     use core::cell::Cell;
-    use litebox_broker_core::{ObjectRights, PolicyEngine};
+    use litebox_broker_core::socket::{
+        PlatformSocket, SocketOutcome, SocketProvider, SocketReadinessRegistration,
+    };
+    use litebox_broker_core::{ObjectRights, PolicyEngine, SessionId, SocketPolicy};
     use litebox_broker_protocol::event::{
         AddEventRequest, ConsumeEventRequest, CreateEventRequest, EventConsumeMode,
     };
@@ -430,16 +538,110 @@ mod tests {
         SHARED_BUFFER_LAYOUT, SHARED_BUFFER_POOL_SIZE, SHARED_BUFFER_SLOT_SIZE,
         SharedBufferDescriptor,
     };
+    use litebox_broker_protocol::socket::{
+        AddressFamily, ConnectSocketRequest, CreateSocketRequest, IpProtocol, Ipv4Address, Port,
+        ReceiveFlags, ReceiveSocketRequest, SendFlags, SendSocketRequest, ShutdownMode,
+        ShutdownSocketRequest, SocketAddressV4, SocketConnectionStatus, SocketStatusRequest,
+        SocketType,
+    };
     use litebox_broker_protocol::{ObjectHandle, ProtocolVersion, RequestId};
     use litebox_broker_transport::shared_memory::{SharedBufferPool, SharedMemoryError};
     use std::sync::{Arc, Condvar, Mutex, mpsc};
     use std::time::Duration;
 
+    struct TestSocketReadiness;
+
+    impl SocketReadinessSink for TestSocketReadiness {
+        fn max_tracked_sockets(&self) -> usize {
+            usize::MAX
+        }
+
+        fn publish(
+            &self,
+            _handle: ObjectHandle,
+            _readiness: litebox_broker_protocol::readiness::ReadinessFlags,
+        ) -> litebox_broker_core::Result<()> {
+            Ok(())
+        }
+
+        fn retire(&self, _handle: ObjectHandle) {}
+    }
+
+    fn test_socket_readiness() -> Arc<dyn SocketReadinessSink> {
+        Arc::new(TestSocketReadiness)
+    }
+
+    #[derive(Default)]
+    struct TestSocketProvider;
+
+    impl SocketProvider for TestSocketProvider {
+        fn create(
+            &self,
+            _session_id: SessionId,
+            _request: CreateSocketRequest,
+            readiness: SocketReadinessRegistration,
+        ) -> litebox_broker_core::Result<Arc<dyn PlatformSocket>> {
+            Ok(Arc::new(TestPlatformSocket { readiness }))
+        }
+
+        fn close_session(&self, _session_id: SessionId) {}
+    }
+
+    struct TestPlatformSocket {
+        readiness: SocketReadinessRegistration,
+    }
+
+    impl PlatformSocket for TestPlatformSocket {
+        fn connect(
+            &self,
+            _address: SocketAddressV4,
+        ) -> litebox_broker_core::Result<SocketConnectionStatus> {
+            self.readiness
+                .publish(litebox_broker_protocol::readiness::ReadinessFlags::WRITE)?;
+            Ok(SocketConnectionStatus::Connecting)
+        }
+
+        fn send(
+            &self,
+            data: &[u8],
+            _flags: SendFlags,
+        ) -> litebox_broker_core::Result<SocketOutcome<usize>> {
+            Ok(SocketOutcome::Completed(data.len()))
+        }
+
+        fn receive(
+            &self,
+            data: &mut [u8],
+            _flags: ReceiveFlags,
+        ) -> litebox_broker_core::Result<SocketOutcome<ReceiveSocketResponse>> {
+            let received = data.len().min(3);
+            data[..received].copy_from_slice(&[4, 5, 6][..received]);
+            Ok(SocketOutcome::Completed(ReceiveSocketResponse::Received(
+                u32::try_from(received).unwrap(),
+            )))
+        }
+
+        fn shutdown(&self, _mode: ShutdownMode) -> litebox_broker_core::Result<SocketOutcome<()>> {
+            Ok(SocketOutcome::Completed(()))
+        }
+
+        fn status(&self) -> litebox_broker_core::Result<SocketConnectionStatus> {
+            Ok(SocketConnectionStatus::Connected)
+        }
+
+        fn readiness(&self) -> litebox_broker_protocol::readiness::ReadinessFlags {
+            litebox_broker_protocol::readiness::ReadinessFlags::READ
+                | litebox_broker_protocol::readiness::ReadinessFlags::WRITE
+        }
+    }
+
     #[test]
     fn host_request_handling_uses_one_broker_core() {
-        let broker = BrokerCore::new(PolicyEngine::with_unauthenticated_rights(
-            ObjectRights::all(),
-        ))
+        let broker = BrokerCore::new_with_socket_provider(
+            PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
+                .with_socket_policy(SocketPolicy::Ipv4LoopbackTcp),
+            Arc::new(TestSocketProvider),
+        )
         .unwrap();
 
         test_channel_negotiates_routes_one_request_and_returns_peer_closed(&broker);
@@ -455,6 +657,7 @@ mod tests {
         test_channel_rejects_incompatible_shared_buffer_layout(&broker);
         active_request_closes_object_reference(&broker);
         association_shared_buffer_descriptors_stage_pipe_data(&broker);
+        association_shared_buffer_descriptors_stage_socket_data(&broker);
         shared_buffer_usage_rejects_invalid_descriptors();
         association_executes_distinct_slots_concurrently(&broker);
         association_allows_slot_reuse_during_response_emission(&broker);
@@ -846,6 +1049,113 @@ mod tests {
         assert_eq!(second_slot, [9]);
     }
 
+    fn association_shared_buffer_descriptors_stage_socket_data(broker: &BrokerCore) {
+        let session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let shared_buffers = test_shared_buffers();
+        let created = handle_test_request_with_buffers(
+            &session,
+            BrokerOperation::Socket(SocketRequest::Create(CreateSocketRequest {
+                address_family: AddressFamily::Ipv4,
+                socket_type: SocketType::Stream,
+                protocol: IpProtocol::Tcp,
+            })),
+            &shared_buffers,
+        );
+        let BrokerResult::Socket(SocketResponse::Create(response)) = created else {
+            panic!("expected successful socket creation");
+        };
+
+        assert_eq!(
+            handle_test_request_with_buffers(
+                &session,
+                BrokerOperation::Socket(SocketRequest::Connect(ConnectSocketRequest {
+                    handle: response.handle,
+                    address: SocketAddressV4 {
+                        address: Ipv4Address([127, 0, 0, 1]),
+                        port: Port(8080),
+                    },
+                })),
+                &shared_buffers,
+            ),
+            BrokerResult::Socket(SocketResponse::Connect(ConnectSocketResponse {
+                status: SocketConnectionStatus::Connecting,
+            }))
+        );
+        assert_eq!(
+            handle_test_request_with_buffers(
+                &session,
+                BrokerOperation::Socket(SocketRequest::Status(SocketStatusRequest {
+                    handle: response.handle,
+                })),
+                &shared_buffers,
+            ),
+            BrokerResult::Socket(SocketResponse::Status(SocketStatusResponse {
+                status: SocketConnectionStatus::Connected,
+            }))
+        );
+
+        shared_buffers
+            .write(SharedBufferSlotIndex(2), &[1, 2, 3])
+            .unwrap();
+        assert_eq!(
+            handle_test_request_with_buffers(
+                &session,
+                BrokerOperation::Socket(SocketRequest::Send(SendSocketRequest {
+                    handle: response.handle,
+                    buffer: descriptor(2, 3),
+                    flags: SendFlags::NONE,
+                })),
+                &shared_buffers,
+            ),
+            BrokerResult::Socket(SocketResponse::Send(SendSocketResponse { sent: 3 }))
+        );
+        assert_eq!(
+            handle_test_request_with_buffers(
+                &session,
+                BrokerOperation::Socket(SocketRequest::Receive(ReceiveSocketRequest {
+                    handle: response.handle,
+                    buffer: descriptor(4, 4),
+                    flags: ReceiveFlags::PEEK,
+                })),
+                &shared_buffers,
+            ),
+            BrokerResult::Socket(SocketResponse::Receive(ReceiveSocketResponse::Received(3)))
+        );
+        let mut received = [0; 3];
+        shared_buffers
+            .read(SharedBufferSlotIndex(4), &mut received)
+            .unwrap();
+        assert_eq!(received, [4, 5, 6]);
+        assert_eq!(
+            handle_test_request_with_buffers(
+                &session,
+                BrokerOperation::Socket(SocketRequest::Shutdown(ShutdownSocketRequest {
+                    handle: response.handle,
+                    mode: ShutdownMode::Both,
+                })),
+                &shared_buffers,
+            ),
+            BrokerResult::Socket(SocketResponse::Shutdown)
+        );
+
+        assert_eq!(
+            complete_request(handle_request(
+                &session,
+                BrokerOperation::Socket(SocketRequest::Send(SendSocketRequest {
+                    handle: response.handle,
+                    buffer: descriptor(2, 0),
+                    flags: SendFlags(1),
+                })),
+                &shared_buffers,
+                &test_socket_readiness(),
+            )),
+            Err(ErrorCode::MalformedRequest)
+        );
+        session.close_object_reference(response.handle).unwrap();
+    }
+
     fn shared_buffer_usage_rejects_invalid_descriptors() {
         let mut usage = SharedBufferUsage::new();
         usage
@@ -1014,6 +1324,7 @@ mod tests {
                 .create_session(CallerCredential::Unauthenticated)
                 .unwrap(),
             shared_buffers,
+            socket_readiness: test_socket_readiness(),
             state: SpinMutex::new(AssociationState {
                 failed: false,
                 shared_buffer_usage: SharedBufferUsage::new(),
@@ -1074,7 +1385,13 @@ mod tests {
         operation: BrokerOperation,
         shared_buffers: &SharedBufferPool<Memory>,
     ) -> BrokerResult {
-        complete_request(handle_request(session, operation, shared_buffers)).unwrap()
+        complete_request(handle_request(
+            session,
+            operation,
+            shared_buffers,
+            &test_socket_readiness(),
+        ))
+        .unwrap()
     }
 
     fn test_shared_buffers() -> SharedBufferPool<TestSharedMemory> {
@@ -1091,11 +1408,16 @@ mod tests {
         shared_buffers: &SharedBufferPool<Memory>,
         send_shared_memory: impl FnOnce(&mut FakeHostControlChannel) -> core::result::Result<(), ()>,
     ) -> Result<ConnectionTermination, ()> {
-        let association =
-            match setup_connection(broker, control_channel, shared_buffers, send_shared_memory)? {
-                Ok(association) => association,
-                Err(termination) => return Ok(termination),
-            };
+        let association = match setup_connection(
+            broker,
+            control_channel,
+            shared_buffers,
+            test_socket_readiness(),
+            send_shared_memory,
+        )? {
+            Ok(association) => association,
+            Err(termination) => return Ok(termination),
+        };
         loop {
             let request = match control_channel
                 .recv_request()

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -351,9 +351,14 @@ fn handle_socket_request<Memory: SharedMemory>(
             Ok(SocketResponse::Create(CreateSocketResponse { handle }))
         }
         SocketRequest::Connect(request) => {
-            litebox_broker_core::socket::connect(session, request.handle, request.address)
-                .map(|status| SocketResponse::Connect(ConnectSocketResponse { status }))
-                .map_err(socket_request_failure)
+            match litebox_broker_core::socket::connect(session, request.handle, request.address)
+                .map_err(socket_request_failure)?
+            {
+                SocketOutcome::Completed(status) => {
+                    Ok(SocketResponse::Connect(ConnectSocketResponse { status }))
+                }
+                SocketOutcome::Failed(error) => Ok(SocketResponse::Failed(error)),
+            }
         }
         SocketRequest::Send(request) => {
             if request.buffer.length > MAX_SOCKET_TRANSFER_SIZE {
@@ -544,8 +549,8 @@ mod tests {
     use litebox_broker_protocol::socket::{
         AddressFamily, ConnectSocketRequest, CreateSocketRequest, IpProtocol, Ipv4Address, Port,
         ReceiveFlags, ReceiveSocketRequest, SendFlags, SendSocketRequest, ShutdownMode,
-        ShutdownSocketRequest, SocketAddressV4, SocketConnectionStatus, SocketStatusRequest,
-        SocketType,
+        ShutdownSocketRequest, SocketAddressV4, SocketConnectionStatus, SocketError,
+        SocketStatusRequest, SocketType,
     };
     use litebox_broker_protocol::{ObjectHandle, ProtocolVersion, RequestId};
     use litebox_broker_transport::shared_memory::{SharedBufferPool, SharedMemoryError};
@@ -1070,6 +1075,20 @@ mod tests {
             panic!("expected successful socket creation");
         };
 
+        assert_eq!(
+            handle_test_request_with_buffers(
+                &session,
+                BrokerOperation::Socket(SocketRequest::Connect(ConnectSocketRequest {
+                    handle: response.handle,
+                    address: SocketAddressV4 {
+                        address: Ipv4Address([10, 0, 0, 1]),
+                        port: Port(8080),
+                    },
+                })),
+                &shared_buffers,
+            ),
+            BrokerResult::Socket(SocketResponse::Failed(SocketError::PolicyDenied))
+        );
         assert_eq!(
             handle_test_request_with_buffers(
                 &session,

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -637,7 +637,7 @@ mod tests {
 
     #[test]
     fn host_request_handling_uses_one_broker_core() {
-        let broker = BrokerCore::new_with_socket_provider(
+        let broker = BrokerCore::new(
             PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
                 .with_socket_policy(SocketPolicy::Ipv4LoopbackTcp),
             Arc::new(TestSocketProvider),

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -23,7 +23,8 @@ extern crate std;
 
 use alloc::{sync::Arc, vec::Vec};
 
-use litebox_broker_core::socket::{SocketOutcome, SocketReadinessSink};
+use litebox_broker_core::readiness::ReadinessSink;
+use litebox_broker_core::socket::SocketOutcome;
 use litebox_broker_core::{BrokerCore, BrokerSession, CallerCredential};
 use litebox_broker_protocol::error::ErrorCode;
 use litebox_broker_protocol::event::{AddEventResponse, CreateEventResponse};
@@ -63,7 +64,7 @@ pub type ConnectionSetup<'a, Memory> =
 pub struct BrokerHostAssociation<'a, Memory: SharedMemory> {
     session: BrokerSession,
     shared_buffers: &'a SharedBufferPool<Memory>,
-    socket_readiness: Arc<dyn SocketReadinessSink>,
+    readiness_sink: Arc<dyn ReadinessSink>,
     state: SpinMutex<AssociationState>,
 }
 
@@ -125,7 +126,7 @@ impl<Memory: SharedMemory> BrokerHostAssociation<'_, Memory> {
             &self.session,
             operation,
             self.shared_buffers,
-            &self.socket_readiness,
+            &self.readiness_sink,
         )) {
             Ok(result) => result,
             Err(error) => {
@@ -155,7 +156,7 @@ pub fn setup_connection<'a, SetupChannel, Memory, ChannelError>(
     core: &BrokerCore,
     setup_channel: &mut SetupChannel,
     shared_buffers: &'a SharedBufferPool<Memory>,
-    socket_readiness: Arc<dyn SocketReadinessSink>,
+    readiness_sink: Arc<dyn ReadinessSink>,
     send_shared_memory: impl FnOnce(&mut SetupChannel) -> core::result::Result<(), ChannelError>,
 ) -> Result<ConnectionSetup<'a, Memory>, ChannelError>
 where
@@ -166,11 +167,14 @@ where
         return Err(BrokerHostError::SharedBufferLayoutMismatch);
     }
     let limits = core.limits();
-    let max_live_session_sockets = limits
+    // Sockets are currently the only provider-backed objects. Add future
+    // provider-object limits here so every live registration fits in the
+    // association's shared readiness sink.
+    let max_live_readiness_registrations = limits
         .max_references
         .min(limits.max_sockets)
         .min(limits.max_sockets_per_session);
-    if max_live_session_sockets > socket_readiness.max_tracked_sockets() {
+    if max_live_readiness_registrations > readiness_sink.max_tracked_objects() {
         return Err(BrokerHostError::Broker(ErrorCode::ResourceExhausted));
     }
 
@@ -220,7 +224,7 @@ where
             return Ok(Ok(BrokerHostAssociation {
                 session,
                 shared_buffers,
-                socket_readiness,
+                readiness_sink,
                 state: SpinMutex::new(AssociationState {
                     failed: false,
                     shared_buffer_usage: SharedBufferUsage::new(),
@@ -309,7 +313,7 @@ fn handle_request<Memory: SharedMemory>(
     session: &BrokerSession,
     operation: BrokerOperation,
     shared_buffers: &SharedBufferPool<Memory>,
-    socket_readiness: &Arc<dyn SocketReadinessSink>,
+    readiness_sink: &Arc<dyn ReadinessSink>,
 ) -> RequestResult<BrokerResult> {
     match operation {
         BrokerOperation::CloseObject(handle) => session
@@ -327,7 +331,7 @@ fn handle_request<Memory: SharedMemory>(
             handle_pipe_request(session, request, shared_buffers).map(BrokerResult::Pipe)
         }
         BrokerOperation::Socket(request) => {
-            handle_socket_request(session, request, shared_buffers, socket_readiness)
+            handle_socket_request(session, request, shared_buffers, readiness_sink)
                 .map(BrokerResult::Socket)
         }
     }
@@ -337,12 +341,12 @@ fn handle_socket_request<Memory: SharedMemory>(
     session: &BrokerSession,
     request: SocketRequest,
     shared_buffers: &SharedBufferPool<Memory>,
-    socket_readiness: &Arc<dyn SocketReadinessSink>,
+    readiness_sink: &Arc<dyn ReadinessSink>,
 ) -> RequestResult<SocketResponse> {
     match request {
         SocketRequest::Create(request) => {
             let handle =
-                litebox_broker_core::socket::create(session, request, Arc::clone(socket_readiness))
+                litebox_broker_core::socket::create(session, request, Arc::clone(readiness_sink))
                     .map_err(socket_request_failure)?;
             Ok(SocketResponse::Create(CreateSocketResponse { handle }))
         }
@@ -525,9 +529,8 @@ pub enum ConnectionTermination {
 mod tests {
     use super::*;
     use core::cell::Cell;
-    use litebox_broker_core::socket::{
-        PlatformSocket, SocketOutcome, SocketProvider, SocketReadinessRegistration,
-    };
+    use litebox_broker_core::readiness::ReadinessRegistration;
+    use litebox_broker_core::socket::{PlatformSocket, SocketOutcome, SocketProvider};
     use litebox_broker_core::{ObjectRights, PolicyEngine, SessionId, SocketPolicy};
     use litebox_broker_protocol::event::{
         AddEventRequest, ConsumeEventRequest, CreateEventRequest, EventConsumeMode,
@@ -549,10 +552,10 @@ mod tests {
     use std::sync::{Arc, Condvar, Mutex, mpsc};
     use std::time::Duration;
 
-    struct TestSocketReadiness;
+    struct TestReadinessSink;
 
-    impl SocketReadinessSink for TestSocketReadiness {
-        fn max_tracked_sockets(&self) -> usize {
+    impl ReadinessSink for TestReadinessSink {
+        fn max_tracked_objects(&self) -> usize {
             usize::MAX
         }
 
@@ -567,8 +570,8 @@ mod tests {
         fn retire(&self, _handle: ObjectHandle) {}
     }
 
-    fn test_socket_readiness() -> Arc<dyn SocketReadinessSink> {
-        Arc::new(TestSocketReadiness)
+    fn test_readiness_sink() -> Arc<dyn ReadinessSink> {
+        Arc::new(TestReadinessSink)
     }
 
     #[derive(Default)]
@@ -579,7 +582,7 @@ mod tests {
             &self,
             _session_id: SessionId,
             _request: CreateSocketRequest,
-            readiness: SocketReadinessRegistration,
+            readiness: ReadinessRegistration,
         ) -> litebox_broker_core::Result<Arc<dyn PlatformSocket>> {
             Ok(Arc::new(TestPlatformSocket { readiness }))
         }
@@ -588,7 +591,7 @@ mod tests {
     }
 
     struct TestPlatformSocket {
-        readiness: SocketReadinessRegistration,
+        readiness: ReadinessRegistration,
     }
 
     impl PlatformSocket for TestPlatformSocket {
@@ -1149,7 +1152,7 @@ mod tests {
                     flags: SendFlags(1),
                 })),
                 &shared_buffers,
-                &test_socket_readiness(),
+                &test_readiness_sink(),
             )),
             Err(ErrorCode::MalformedRequest)
         );
@@ -1324,7 +1327,7 @@ mod tests {
                 .create_session(CallerCredential::Unauthenticated)
                 .unwrap(),
             shared_buffers,
-            socket_readiness: test_socket_readiness(),
+            readiness_sink: test_readiness_sink(),
             state: SpinMutex::new(AssociationState {
                 failed: false,
                 shared_buffer_usage: SharedBufferUsage::new(),
@@ -1389,7 +1392,7 @@ mod tests {
             session,
             operation,
             shared_buffers,
-            &test_socket_readiness(),
+            &test_readiness_sink(),
         ))
         .unwrap()
     }
@@ -1412,7 +1415,7 @@ mod tests {
             broker,
             control_channel,
             shared_buffers,
-            test_socket_readiness(),
+            test_readiness_sink(),
             send_shared_memory,
         )? {
             Ok(association) => association,

--- a/litebox_broker_local/src/lib.rs
+++ b/litebox_broker_local/src/lib.rs
@@ -170,11 +170,11 @@ impl<Channel: LocalCallChannel> BrokerLocal<Channel> {
                 | ErrorCode::ResourceExhausted
                 | ErrorCode::WouldBlock
                 | ErrorCode::PeerClosed
-                | ErrorCode::OutOfMemory => Err(BrokerLocalError::Broker(error)),
+                | ErrorCode::OutOfMemory
+                | ErrorCode::UnsupportedOperation => Err(BrokerLocalError::Broker(error)),
                 ErrorCode::UnsupportedVersion
                 | ErrorCode::MalformedRequest
                 | ErrorCode::ProtocolState
-                | ErrorCode::UnsupportedOperation
                 | ErrorCode::Internal => panic!("broker returned unrecoverable error: {error}"),
                 _ => panic!("broker returned unsupported error: {error}"),
             },
@@ -396,19 +396,20 @@ mod tests {
     }
 
     #[test]
-    fn active_request_returns_recoverable_broker_error() {
-        let channel =
-            FakeControlChannel::new(None, Some(BrokerResult::Error(ErrorCode::WouldBlock)));
-        let local = BrokerLocal {
-            channel,
-            shared_buffers: noop_shared_buffers(),
-            next_request_id: AtomicU64::new(0),
-        };
+    fn active_request_returns_recoverable_broker_errors() {
+        for error in [ErrorCode::WouldBlock, ErrorCode::UnsupportedOperation] {
+            let channel = FakeControlChannel::new(None, Some(BrokerResult::Error(error)));
+            let local = BrokerLocal {
+                channel,
+                shared_buffers: noop_shared_buffers(),
+                next_request_id: AtomicU64::new(0),
+            };
 
-        assert!(matches!(
-            local.create_event_with_count(0),
-            Err(BrokerLocalError::Broker(ErrorCode::WouldBlock))
-        ));
+            assert!(matches!(
+                local.create_event_with_count(0),
+                Err(BrokerLocalError::Broker(actual)) if actual == error
+            ));
+        }
     }
 
     #[test]

--- a/litebox_broker_protocol/src/socket.rs
+++ b/litebox_broker_protocol/src/socket.rs
@@ -10,8 +10,11 @@
 //! or flag the broker has not agreed to support.
 
 use crate::ObjectHandle;
-use crate::shared_buffer::SharedBufferDescriptor;
+use crate::shared_buffer::{SHARED_BUFFER_SLOT_SIZE, SharedBufferDescriptor};
 use thiserror::Error;
+
+/// Maximum socket bytes transferred by one broker request.
+pub const MAX_SOCKET_TRANSFER_SIZE: u32 = SHARED_BUFFER_SLOT_SIZE;
 
 /// Address family of a broker socket.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -169,6 +172,9 @@ pub enum SocketError {
     /// The address is not available on this host.
     #[error("address not available")]
     AddressNotAvailable,
+    /// The operation requires a connected socket.
+    #[error("socket is not connected")]
+    NotConnected,
     /// The policy engine refused the destination.
     #[error("socket policy denied the operation")]
     PolicyDenied,
@@ -194,6 +200,7 @@ impl SocketError {
             8 => Some(Self::AddressNotAvailable),
             9 => Some(Self::PolicyDenied),
             10 => Some(Self::Other),
+            11 => Some(Self::NotConnected),
             _ => None,
         }
     }
@@ -211,6 +218,7 @@ impl SocketError {
             Self::AddressNotAvailable => 8,
             Self::PolicyDenied => 9,
             Self::Other => 10,
+            Self::NotConnected => 11,
         }
     }
 }

--- a/litebox_broker_protocol/src/wire.rs
+++ b/litebox_broker_protocol/src/wire.rs
@@ -534,6 +534,7 @@ mod tests {
             SocketError::AddressNotAvailable,
             SocketError::PolicyDenied,
             SocketError::Other,
+            SocketError::NotConnected,
         ] {
             for socket_response in [
                 SocketResponse::Failed(error),
@@ -879,7 +880,7 @@ mod tests {
             request_id: TEST_REQUEST_ID,
             result: BrokerResult::Socket(SocketResponse::Failed(SocketError::TimedOut)),
         });
-        for raw in [0, 11, u8::MAX] {
+        for raw in [0, 12, u8::MAX] {
             let mut unknown_socket_error = socket_error.clone();
             *unknown_socket_error.last_mut().unwrap() = raw;
             assert_eq!(

--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -15,6 +15,7 @@ use std::sync::{
 use std::time::{Duration, Instant};
 
 use clap::Parser;
+use litebox_broker_core::socket::UnsupportedSocketProvider;
 use litebox_broker_core::{BrokerCore, ObjectRights, PolicyEngine};
 use litebox_broker_host::{BrokerHostAssociation, ConnectionTermination, setup_connection};
 use litebox_broker_protocol::message::BrokerRequest;
@@ -53,9 +54,10 @@ fn main() -> Result<(), Box<dyn Error>> {
     let control_socket_path = socket_dir.path().join("broker.sock");
     let control_listener = UnixListener::bind(&control_socket_path)?;
     control_listener.set_nonblocking(true)?;
-    let broker = BrokerCore::new(PolicyEngine::with_host_guaranteed_rights(
-        ObjectRights::all(),
-    ))?;
+    let broker = BrokerCore::new(
+        PolicyEngine::with_host_guaranteed_rights(ObjectRights::all()),
+        Arc::new(UnsupportedSocketProvider),
+    )?;
 
     let mut runner_command = Command::new(&args.runner);
     runner_command
@@ -561,9 +563,10 @@ mod tests {
         let (outcome_sender, outcome) = sync_channel(1);
         let (start, started) = sync_channel(1);
         let host = std::thread::spawn(move || {
-            let broker = BrokerCore::new(PolicyEngine::with_host_guaranteed_rights(
-                ObjectRights::all(),
-            ))
+            let broker = BrokerCore::new(
+                PolicyEngine::with_host_guaranteed_rights(ObjectRights::all()),
+                Arc::new(UnsupportedSocketProvider),
+            )
             .unwrap();
             let shared_memory = MemfdSharedMemory::create(SHARED_BUFFER_POOL_SIZE).unwrap();
             let shared_buffers =

--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -100,40 +100,46 @@ fn serve_runner(
         .map_err(|error| IoError::other(format!("failed to create control ring: {error:?}")))?;
     let mut control_channel =
         UnixStreamHostSetupChannel::from_host_guaranteed(control_stream, setup_deadline);
-    let association =
-        match setup_connection(broker, &mut control_channel, &shared_buffers, |channel| {
+    let readiness = Arc::new(ReadinessPublisherRuntime::new());
+    let association = match setup_connection(
+        broker,
+        &mut control_channel,
+        &shared_buffers,
+        readiness.clone(),
+        |channel| {
             channel.send_memfd(shared_buffers.memory(), Some(setup_deadline))?;
             channel.send_memfd(control_ring.memory(), Some(setup_deadline))?;
             Ok(())
-        })? {
-            Ok(association) => association,
-            Err(ConnectionTermination::PeerClosed) => {
-                return Err(IoError::new(
-                    ErrorKind::UnexpectedEof,
-                    "runner closed before completing broker setup",
-                )
-                .into());
-            }
-            Err(ConnectionTermination::ProtocolViolation) => {
-                return Err(IoError::new(
-                    ErrorKind::InvalidData,
-                    "runner violated the broker protocol during setup",
-                )
-                .into());
-            }
-            Err(_) => {
-                return Err(IoError::new(
-                    ErrorKind::InvalidData,
-                    "runner ended broker setup unexpectedly",
-                )
-                .into());
-            }
-        };
+        },
+    )? {
+        Ok(association) => association,
+        Err(ConnectionTermination::PeerClosed) => {
+            return Err(IoError::new(
+                ErrorKind::UnexpectedEof,
+                "runner closed before completing broker setup",
+            )
+            .into());
+        }
+        Err(ConnectionTermination::ProtocolViolation) => {
+            return Err(IoError::new(
+                ErrorKind::InvalidData,
+                "runner violated the broker protocol during setup",
+            )
+            .into());
+        }
+        Err(_) => {
+            return Err(IoError::new(
+                ErrorKind::InvalidData,
+                "runner ended broker setup unexpectedly",
+            )
+            .into());
+        }
+    };
     let (request_source, response_sink, notification_channel, shutdown) =
         control_channel.into_active(control_ring)?;
     dispatch_requests(
         association,
-        Arc::new(ReadinessPublisherRuntime::new()),
+        readiness,
         request_source,
         response_sink,
         notification_channel,
@@ -568,10 +574,16 @@ mod tests {
                 host_stream,
                 Instant::now() + SETUP_TIMEOUT,
             );
-            let association = setup_connection(&broker, &mut control, &shared_buffers, |channel| {
-                channel.send_memfd(shared_buffers.memory(), None)?;
-                channel.send_memfd(control_ring.memory(), None)
-            })
+            let association = setup_connection(
+                &broker,
+                &mut control,
+                &shared_buffers,
+                readiness.clone(),
+                |channel| {
+                    channel.send_memfd(shared_buffers.memory(), None)?;
+                    channel.send_memfd(control_ring.memory(), None)
+                },
+            )
             .unwrap()
             .unwrap();
             let (request_source, response_sink, notifications, shutdown) =

--- a/litebox_broker_userland/src/readiness.rs
+++ b/litebox_broker_userland/src/readiness.rs
@@ -11,6 +11,8 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Condvar, Mutex};
 
+use litebox_broker_core::socket::SocketReadinessSink;
+use litebox_broker_core::{BrokerError, Result as BrokerResult};
 use litebox_broker_host::readiness::{
     PublishOutcome, ReadinessPublishError, ReadinessPublisher, publish_readiness,
 };
@@ -145,6 +147,20 @@ impl ReadinessPublisherRuntime {
                 .expect("broker readiness publisher mutex poisoned");
         }
         *signaled = false;
+    }
+}
+
+impl SocketReadinessSink for ReadinessPublisherRuntime {
+    fn max_tracked_sockets(&self) -> usize {
+        litebox_broker_host::readiness::MAX_TRACKED_READINESS_OBJECTS
+    }
+
+    fn publish(&self, handle: ObjectHandle, readiness: ReadinessFlags) -> BrokerResult<()> {
+        Self::publish(self, handle, readiness).map_err(|_| BrokerError::ResourceExhausted)
+    }
+
+    fn retire(&self, handle: ObjectHandle) {
+        Self::retire(self, handle);
     }
 }
 

--- a/litebox_broker_userland/src/readiness.rs
+++ b/litebox_broker_userland/src/readiness.rs
@@ -11,7 +11,7 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Condvar, Mutex};
 
-use litebox_broker_core::socket::SocketReadinessSink;
+use litebox_broker_core::readiness::ReadinessSink;
 use litebox_broker_core::{BrokerError, Result as BrokerResult};
 use litebox_broker_host::readiness::{
     PublishOutcome, ReadinessPublishError, ReadinessPublisher, publish_readiness,
@@ -150,8 +150,8 @@ impl ReadinessPublisherRuntime {
     }
 }
 
-impl SocketReadinessSink for ReadinessPublisherRuntime {
-    fn max_tracked_sockets(&self) -> usize {
+impl ReadinessSink for ReadinessPublisherRuntime {
+    fn max_tracked_objects(&self) -> usize {
         litebox_broker_host::readiness::MAX_TRACKED_READINESS_OBJECTS
     }
 

--- a/litebox_broker_userland/tests/notification_runtime.rs
+++ b/litebox_broker_userland/tests/notification_runtime.rs
@@ -7,6 +7,7 @@ use std::sync::mpsc::{Receiver, channel};
 use std::thread::JoinHandle;
 use std::time::Duration;
 
+use litebox_broker_core::socket::UnsupportedSocketProvider;
 use litebox_broker_core::{BrokerCore, ObjectRights, PolicyEngine};
 use litebox_broker_host::{ConnectionTermination, setup_connection};
 use litebox_broker_local::{BrokerLocal, BrokerNotifications};
@@ -47,9 +48,10 @@ fn spawn_host(
     + 'static,
 ) -> JoinHandle<()> {
     std::thread::spawn(move || {
-        let broker = BrokerCore::new(PolicyEngine::with_unauthenticated_rights(
-            ObjectRights::all(),
-        ))
+        let broker = BrokerCore::new(
+            PolicyEngine::with_unauthenticated_rights(ObjectRights::all()),
+            Arc::new(UnsupportedSocketProvider),
+        )
         .unwrap();
         let shared_memory = MemfdSharedMemory::create(SHARED_BUFFER_POOL_SIZE).unwrap();
         let shared_buffers = SharedBufferPool::new(shared_memory, SHARED_BUFFER_LAYOUT).unwrap();
@@ -128,9 +130,10 @@ fn readiness_of(notification: Option<BrokerNotification>) -> ReadinessNotificati
 
 #[test]
 fn host_serves_control_requests_and_notifications_over_shared_rings() {
-    let broker = BrokerCore::new(PolicyEngine::with_unauthenticated_rights(
-        ObjectRights::all(),
-    ))
+    let broker = BrokerCore::new(
+        PolicyEngine::with_unauthenticated_rights(ObjectRights::all()),
+        Arc::new(UnsupportedSocketProvider),
+    )
     .unwrap();
     let (local_control, host_control) = UnixStream::pair().unwrap();
     let host_shared_memory = MemfdSharedMemory::create(SHARED_BUFFER_POOL_SIZE).unwrap();

--- a/litebox_broker_userland/tests/notification_runtime.rs
+++ b/litebox_broker_userland/tests/notification_runtime.rs
@@ -56,10 +56,16 @@ fn spawn_host(
         let control_memory = MemfdSharedMemory::create(CONTROL_RING_MEMORY_SIZE).unwrap();
         let control_ring = ControlRing::new(control_memory).unwrap();
         let mut control = UnixStreamHostSetupChannel::from_accepted(stream);
-        let association = setup_connection(&broker, &mut control, &shared_buffers, |channel| {
-            channel.send_memfd(shared_buffers.memory(), None)?;
-            channel.send_memfd(control_ring.memory(), None)
-        })
+        let association = setup_connection(
+            &broker,
+            &mut control,
+            &shared_buffers,
+            Arc::new(ReadinessPublisherRuntime::new()),
+            |channel| {
+                channel.send_memfd(shared_buffers.memory(), None)?;
+                channel.send_memfd(control_ring.memory(), None)
+            },
+        )
         .unwrap()
         .unwrap();
         let (mut request_source, response_sink, notifications, shutdown) =
@@ -140,13 +146,18 @@ fn host_serves_control_requests_and_notifications_over_shared_rings() {
 
     let host_thread = std::thread::spawn(move || {
         let mut control = UnixStreamHostSetupChannel::from_accepted(host_control);
-        let association =
-            setup_connection(&broker, &mut control, &host_shared_buffers, |channel| {
+        let association = setup_connection(
+            &broker,
+            &mut control,
+            &host_shared_buffers,
+            Arc::new(ReadinessPublisherRuntime::new()),
+            |channel| {
                 channel.send_memfd(host_shared_buffers.memory(), None)?;
                 channel.send_memfd(host_control_ring.memory(), None)
-            })
-            .unwrap()
-            .unwrap();
+            },
+        )
+        .unwrap()
+        .unwrap();
         let (mut request_source, response_sink, mut notifications, _shutdown) =
             control.into_active(host_control_ring).unwrap();
         notifications.send_notification(&host_notification).unwrap();

--- a/litebox_runner_linux_userland/tests/run.rs
+++ b/litebox_runner_linux_userland/tests/run.rs
@@ -12,6 +12,24 @@ use std::{
 const BROKER_HELPER_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 const BROKER_ONLY_C_TESTS: &[&str] = &["eventfd.c", "pipe_broker.c"];
 
+struct TestSocketReadiness;
+
+impl litebox_broker_core::socket::SocketReadinessSink for TestSocketReadiness {
+    fn max_tracked_sockets(&self) -> usize {
+        usize::MAX
+    }
+
+    fn publish(
+        &self,
+        _handle: litebox_broker_protocol::ObjectHandle,
+        _readiness: litebox_broker_protocol::readiness::ReadinessFlags,
+    ) -> litebox_broker_core::Result<()> {
+        Ok(())
+    }
+
+    fn retire(&self, _handle: litebox_broker_protocol::ObjectHandle) {}
+}
+
 #[must_use]
 struct Runner {
     command: std::process::Command,
@@ -395,6 +413,7 @@ fn spawn_test_broker(
                     &broker,
                     &mut channel,
                     &shared_buffers,
+                    std::sync::Arc::new(TestSocketReadiness),
                     |channel| {
                         channel.send_memfd(shared_buffers.memory(), None)?;
                         channel.send_memfd(control_ring.memory(), None)

--- a/litebox_runner_linux_userland/tests/run.rs
+++ b/litebox_runner_linux_userland/tests/run.rs
@@ -12,10 +12,10 @@ use std::{
 const BROKER_HELPER_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 const BROKER_ONLY_C_TESTS: &[&str] = &["eventfd.c", "pipe_broker.c"];
 
-struct TestSocketReadiness;
+struct TestReadinessSink;
 
-impl litebox_broker_core::socket::SocketReadinessSink for TestSocketReadiness {
-    fn max_tracked_sockets(&self) -> usize {
+impl litebox_broker_core::readiness::ReadinessSink for TestReadinessSink {
+    fn max_tracked_objects(&self) -> usize {
         usize::MAX
     }
 
@@ -416,7 +416,7 @@ fn spawn_test_broker(
                     &broker,
                     &mut channel,
                     &shared_buffers,
-                    std::sync::Arc::new(TestSocketReadiness),
+                    std::sync::Arc::new(TestReadinessSink),
                     |channel| {
                         channel.send_memfd(shared_buffers.memory(), None)?;
                         channel.send_memfd(control_ring.memory(), None)

--- a/litebox_runner_linux_userland/tests/run.rs
+++ b/litebox_runner_linux_userland/tests/run.rs
@@ -371,8 +371,11 @@ fn spawn_test_broker(
             let control_listener =
                 std::os::unix::net::UnixListener::bind(&server_control_socket_path)
                     .expect("failed to bind broker test control socket");
-            let broker =
-                litebox_broker_core::BrokerCore::new(policy).expect("failed to create broker core");
+            let broker = litebox_broker_core::BrokerCore::new(
+                policy,
+                std::sync::Arc::new(litebox_broker_core::socket::UnsupportedSocketProvider),
+            )
+            .expect("failed to create broker core");
             ready_tx.send(()).expect("failed to report broker ready");
 
             for _ in 0..connection_count {


### PR DESCRIPTION
This PR adds the portable broker authority for IPv4 TCP sockets, including provider and resource contracts, loopback-only policy, global and per-session quotas, readiness lifecycle, and complete host dispatch.