### PR TITLE
Bound broker resource budgets per session

### DIFF
--- a/litebox_broker_core/src/lib.rs
+++ b/litebox_broker_core/src/lib.rs
@@ -39,30 +39,74 @@ pub use session::{BrokerSession, CallerCredential, ObjectRights};
 /// BrokerCore result type.
 pub type Result<T> = core::result::Result<T, BrokerError>;
 
+/// Number of equal shares a global ceiling is split into when a limit set does
+/// not state its per-session quota explicitly.
+///
+/// A session may hold one share, so several sessions must each spend their
+/// whole quota before a global ceiling is reached, and no single session can
+/// reach one on its own.
+const DEFAULT_SESSION_QUOTA_SHARES: usize = 4;
+
 /// Resource limits for broker-owned authority state.
 ///
-/// These limits are global to the broker core, not per session.
+/// Every budget has two limits. The global ceiling bounds what all sessions
+/// hold together and keeps the broker process bounded. The per-session quota
+/// bounds what any one session holds, so a malicious or malfunctioning session
+/// cannot spend the whole ceiling and deny object and pipe creation to every
+/// other session served by the same broker core. Both are enforced on every
+/// allocation, with the global ceiling acting as the backstop.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct BrokerCoreLimits {
-    /// Maximum live object references.
+    /// Maximum live object references across all sessions.
     pub max_references: usize,
-    /// Maximum total capacity in bytes reserved by live pipes.
+    /// Maximum total capacity in bytes reserved by live pipes across all
+    /// sessions.
     pub max_total_pipe_capacity: usize,
+    /// Maximum live object references held by any one session.
+    pub max_session_references: usize,
+    /// Maximum capacity in bytes reserved by the live pipes of any one session.
+    pub max_session_pipe_capacity: usize,
 }
 
 impl BrokerCoreLimits {
     /// Conservative default limits for initial broker deployments.
-    pub const DEFAULT: Self = Self {
-        max_references: 4096,
-        max_total_pipe_capacity: 64 * 1024 * 1024,
-    };
+    pub const DEFAULT: Self = Self::new(4096, 64 * 1024 * 1024);
 
-    /// Creates a broker core limit set.
+    /// Creates a broker core limit set that gives each session an equal share
+    /// of the global ceilings.
+    ///
+    /// Each session may hold up to a quarter of each ceiling, rounded up, so a
+    /// caller that has not thought about per-session quotas still gets a core
+    /// no single session can exhaust. Use
+    /// [`BrokerCoreLimits::with_session_quotas`] to state the quotas
+    /// explicitly.
     pub const fn new(max_references: usize, max_total_pipe_capacity: usize) -> Self {
         Self {
             max_references,
             max_total_pipe_capacity,
+            max_session_references: max_references.div_ceil(DEFAULT_SESSION_QUOTA_SHARES),
+            max_session_pipe_capacity: max_total_pipe_capacity
+                .div_ceil(DEFAULT_SESSION_QUOTA_SHARES),
+        }
+    }
+
+    /// Returns these limits with explicit per-session quotas.
+    ///
+    /// A quota above its global ceiling is accepted rather than rejected: the
+    /// ceiling is still enforced, so the effective quota is whichever of the
+    /// two is smaller.
+    #[must_use]
+    pub const fn with_session_quotas(
+        self,
+        max_session_references: usize,
+        max_session_pipe_capacity: usize,
+    ) -> Self {
+        Self {
+            max_references: self.max_references,
+            max_total_pipe_capacity: self.max_total_pipe_capacity,
+            max_session_references,
+            max_session_pipe_capacity,
         }
     }
 }
@@ -150,5 +194,55 @@ impl BrokerCore {
             session::SessionId(session_id),
             caller_credential,
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BrokerCoreLimits, DEFAULT_SESSION_QUOTA_SHARES};
+
+    #[test]
+    fn default_limits_bound_what_one_session_can_hold() {
+        let limits = BrokerCoreLimits::DEFAULT;
+
+        assert_eq!(limits.max_references, 4096);
+        assert_eq!(limits.max_total_pipe_capacity, 64 * 1024 * 1024);
+        assert_eq!(
+            limits.max_session_references,
+            limits.max_references / DEFAULT_SESSION_QUOTA_SHARES
+        );
+        assert_eq!(
+            limits.max_session_pipe_capacity,
+            limits.max_total_pipe_capacity / DEFAULT_SESSION_QUOTA_SHARES
+        );
+        // No single session can reach a global ceiling on its own.
+        assert!(limits.max_session_references < limits.max_references);
+        assert!(limits.max_session_pipe_capacity < limits.max_total_pipe_capacity);
+    }
+
+    #[test]
+    fn derived_quotas_never_round_a_usable_ceiling_down_to_nothing() {
+        let limits = BrokerCoreLimits::new(1, 1);
+
+        assert_eq!(limits.max_session_references, 1);
+        assert_eq!(limits.max_session_pipe_capacity, 1);
+    }
+
+    #[test]
+    fn derived_quotas_stay_zero_for_a_ceiling_of_zero() {
+        let limits = BrokerCoreLimits::new(0, 0);
+
+        assert_eq!(limits.max_session_references, 0);
+        assert_eq!(limits.max_session_pipe_capacity, 0);
+    }
+
+    #[test]
+    fn explicit_quotas_replace_the_derived_ones_and_keep_the_ceilings() {
+        let limits = BrokerCoreLimits::new(4096, 64 * 1024 * 1024).with_session_quotas(7, 9);
+
+        assert_eq!(limits.max_references, 4096);
+        assert_eq!(limits.max_total_pipe_capacity, 64 * 1024 * 1024);
+        assert_eq!(limits.max_session_references, 7);
+        assert_eq!(limits.max_session_pipe_capacity, 9);
     }
 }

--- a/litebox_broker_core/src/lib.rs
+++ b/litebox_broker_core/src/lib.rs
@@ -95,7 +95,19 @@ impl BrokerCoreLimits {
     ///
     /// A quota above its global ceiling is accepted rather than rejected: the
     /// ceiling is still enforced, so the effective quota is whichever of the
-    /// two is smaller.
+    /// two is smaller. A deployment that knowingly serves one session can
+    /// therefore hand it the whole core by raising each quota to its ceiling.
+    ///
+    /// ```
+    /// use litebox_broker_core::BrokerCoreLimits;
+    ///
+    /// let shared = BrokerCoreLimits::DEFAULT;
+    /// assert_eq!(shared.max_session_references, 1024);
+    ///
+    /// let single_tenant =
+    ///     shared.with_session_quotas(shared.max_references, shared.max_total_pipe_capacity);
+    /// assert_eq!(single_tenant.max_session_references, shared.max_references);
+    /// ```
     #[must_use]
     pub const fn with_session_quotas(
         self,
@@ -184,11 +196,17 @@ impl BrokerCore {
 
     /// Allocates broker authority state for one authenticated caller session.
     pub fn create_session(&self, caller_credential: CallerCredential) -> Result<BrokerSession> {
-        let mut next_session_id = self.next_session_id.write();
-        let session_id = *next_session_id;
-        *next_session_id = session_id
-            .checked_add(1)
-            .ok_or(BrokerError::ResourceExhausted)?;
+        // Release the identity lock before building the session: session
+        // construction allocates the per-session capacity counter, and every
+        // session creation contends for this lock.
+        let session_id = {
+            let mut next_session_id = self.next_session_id.write();
+            let session_id = *next_session_id;
+            *next_session_id = session_id
+                .checked_add(1)
+                .ok_or(BrokerError::ResourceExhausted)?;
+            session_id
+        };
         Ok(BrokerSession::new(
             self.clone(),
             session::SessionId(session_id),

--- a/litebox_broker_core/src/pipe.rs
+++ b/litebox_broker_core/src/pipe.rs
@@ -184,19 +184,19 @@ enum PipeEndpoint {
     Write,
 }
 
-struct PipeCapacityReservation {
+/// Capacity charged to one counter for as long as this value is alive.
+struct CapacityCharge {
     reserved_capacity: Arc<AtomicUsize>,
     capacity: usize,
 }
 
-impl PipeCapacityReservation {
-    fn new(session: &BrokerSession, capacity: usize) -> Result<Self> {
-        let reserved_capacity = Arc::clone(&session.core.reserved_pipe_capacity);
+impl CapacityCharge {
+    fn new(reserved_capacity: Arc<AtomicUsize>, capacity: usize, limit: usize) -> Result<Self> {
         reserved_capacity
             .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |reserved| {
                 reserved
                     .checked_add(capacity)
-                    .filter(|total| *total <= session.core.limits.max_total_pipe_capacity)
+                    .filter(|total| *total <= limit)
             })
             .map_err(|_| BrokerError::ResourceExhausted)?;
         Ok(Self {
@@ -206,13 +206,47 @@ impl PipeCapacityReservation {
     }
 }
 
-impl Drop for PipeCapacityReservation {
+impl Drop for CapacityCharge {
     fn drop(&mut self) {
         self.reserved_capacity
             .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |reserved| {
                 reserved.checked_sub(self.capacity)
             })
             .expect("reserved pipe capacity must include every live pipe");
+    }
+}
+
+/// Both capacity budgets one live pipe holds.
+///
+/// The per-session quota keeps one session from reserving the whole core-wide
+/// ceiling; the core-wide ceiling remains the backstop across all sessions.
+/// Both charges are released together when the pipe's shared state is dropped,
+/// which happens once the last reference to either endpoint is closed or its
+/// owning session is torn down.
+struct PipeCapacityReservation {
+    _session_charge: CapacityCharge,
+    _core_charge: CapacityCharge,
+}
+
+impl PipeCapacityReservation {
+    fn new(session: &BrokerSession, capacity: usize) -> Result<Self> {
+        // Charge the session first: a session already at its quota is rejected
+        // without touching the shared counter, and the `?` below releases this
+        // charge if the core-wide ceiling then rejects the pipe.
+        let session_charge = CapacityCharge::new(
+            Arc::clone(&session.reserved_pipe_capacity),
+            capacity,
+            session.core.limits.max_session_pipe_capacity,
+        )?;
+        let core_charge = CapacityCharge::new(
+            Arc::clone(&session.core.reserved_pipe_capacity),
+            capacity,
+            session.core.limits.max_total_pipe_capacity,
+        )?;
+        Ok(Self {
+            _session_charge: session_charge,
+            _core_charge: core_charge,
+        })
     }
 }
 

--- a/litebox_broker_core/src/pipe.rs
+++ b/litebox_broker_core/src/pipe.rs
@@ -223,6 +223,13 @@ impl Drop for CapacityCharge {
 /// Both charges are released together when the pipe's shared state is dropped,
 /// which happens once the last reference to either endpoint is closed or its
 /// owning session is torn down.
+///
+/// Each counter is at every instant at least the total capacity of the live
+/// pipes it covers, because a charge is taken before the pipe state that owns
+/// it exists and released after that state is destroyed. The two charges are
+/// therefore not jointly atomic, and do not need to be: the only transient a
+/// concurrent creator can observe is over-counting, which can refuse it
+/// slightly too early but can never admit it too late.
 struct PipeCapacityReservation {
     _session_charge: CapacityCharge,
     _core_charge: CapacityCharge,

--- a/litebox_broker_core/src/session.rs
+++ b/litebox_broker_core/src/session.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 use alloc::{sync::Arc, vec::Vec};
+use core::sync::atomic::AtomicUsize;
 
 use crate::event::EventObject;
 use crate::pipe::PipeObject;
@@ -57,7 +58,8 @@ pub(crate) enum ObjectEntry {
 ///
 /// User mode does not choose this value. The broker entry layer authenticates
 /// the caller, then BrokerCore assigns this identity for all operations received
-/// on that session. Dropping the session releases all object references it owns.
+/// on that session. Dropping the session releases all object references it owns,
+/// and with them the share of the core-wide budgets they held.
 pub struct BrokerSession {
     pub(crate) core: BrokerCore,
     /// Broker-assigned session identity.
@@ -65,7 +67,18 @@ pub struct BrokerSession {
     /// Broker-entry-authenticated caller credential for this session.
     pub(crate) caller_credential: CallerCredential,
     /// Handles of the live object references owned by this session.
+    ///
+    /// The length of this vector is the session's live reference count, so the
+    /// per-session reference quota is enforced against the very state that
+    /// releases it and the two cannot drift apart.
     reference_handles: Mutex<Vec<ObjectHandle>>,
+    /// Capacity in bytes reserved by this session's live pipes.
+    ///
+    /// Reservations share ownership of this counter because a pipe object may
+    /// outlive the session that created it: another worker can hold the
+    /// object's `Arc` across session teardown, and the release must still find
+    /// a live counter to credit.
+    pub(crate) reserved_pipe_capacity: Arc<AtomicUsize>,
 }
 
 impl BrokerSession {
@@ -80,6 +93,7 @@ impl BrokerSession {
             session_id,
             caller_credential,
             reference_handles: Mutex::new(Vec::new()),
+            reserved_pipe_capacity: Arc::new(AtomicUsize::new(0)),
         }
     }
 
@@ -89,6 +103,12 @@ impl BrokerSession {
             .policy
             .principal_object_rights(self.caller_credential)?;
         let mut reference_handles = self.reference_handles.lock();
+        // Charge the session before the core-wide table is locked, so a session
+        // that is already at its quota cannot make every other session contend
+        // for the shared lock to be told the core is full.
+        if reference_handles.len() >= self.core.limits.max_session_references {
+            return Err(BrokerError::ResourceExhausted);
+        }
         reference_handles
             .try_reserve(1)
             .map_err(|_| BrokerError::OutOfMemory)?;
@@ -121,6 +141,13 @@ impl BrokerSession {
             .policy
             .principal_object_rights(self.caller_credential)?;
         let mut reference_handles = self.reference_handles.lock();
+        if reference_handles
+            .len()
+            .checked_add(2)
+            .is_none_or(|count| count > self.core.limits.max_session_references)
+        {
+            return Err(BrokerError::ResourceExhausted);
+        }
         reference_handles
             .try_reserve(2)
             .map_err(|_| BrokerError::OutOfMemory)?;
@@ -320,6 +347,7 @@ impl Drop for BrokerSession {
 
 #[cfg(test)]
 mod tests {
+    use alloc::sync::Arc;
     use core::sync::atomic::Ordering;
 
     use crate::{
@@ -329,11 +357,28 @@ mod tests {
     use litebox_broker_protocol::event::{EventConsumeMode, EventConsumption};
     use litebox_broker_protocol::readiness::ReadinessFlags;
 
+    /// Core-wide ceilings used by every check below.
+    ///
+    /// They are exactly twice the per-session quotas, so two sessions spending
+    /// their full quota reach the ceilings and a third session is refused by
+    /// the backstop rather than by its own quota.
+    const TEST_MAX_REFERENCES: usize = 4;
+    const TEST_MAX_TOTAL_PIPE_CAPACITY: usize = 8;
+    /// Per-session quotas used by every check below.
+    ///
+    /// Two references is the smallest quota that still admits a pipe, whose two
+    /// endpoints are created together.
+    const TEST_MAX_SESSION_REFERENCES: usize = 2;
+    const TEST_MAX_SESSION_PIPE_CAPACITY: usize = 4;
+    /// `TEST_MAX_SESSION_PIPE_CAPACITY` in the width `pipe::create` accepts.
+    const TEST_SESSION_PIPE_CAPACITY_REQUEST: u64 = 4;
+
     #[test]
     fn object_reference_lifecycle_uses_public_core_constructor_once() {
         let broker = BrokerCore::new_with_limits(
             PolicyEngine::with_unauthenticated_rights(ObjectRights::all()),
-            BrokerCoreLimits::new(2, 4),
+            BrokerCoreLimits::new(TEST_MAX_REFERENCES, TEST_MAX_TOTAL_PIPE_CAPACITY)
+                .with_session_quotas(TEST_MAX_SESSION_REFERENCES, TEST_MAX_SESSION_PIPE_CAPACITY),
         )
         .unwrap();
 
@@ -343,9 +388,16 @@ mod tests {
         check_pipe_reader_closure(&broker);
         check_corrupt_index_fails_without_mutation(&broker);
         check_corrupt_index_does_not_break_teardown(&broker);
+        check_reference_quota_is_per_session(&broker);
+        check_pipe_capacity_quota_is_per_session(&broker);
+        check_session_drop_releases_quotas(&broker);
+        check_pipe_capacity_is_released_when_endpoints_are_refused(&broker);
+        // Handle allocation is exhausted for the rest of the process once this
+        // check runs, so it must stay last.
         check_pair_handle_exhaustion(&broker);
 
         assert!(broker.references.read().is_empty());
+        assert_eq!(broker.reserved_pipe_capacity.load(Ordering::Relaxed), 0);
     }
 
     fn check_event_reference_lifecycle(broker: &BrokerCore) {
@@ -527,6 +579,180 @@ mod tests {
 
         drop(session);
 
+        assert!(broker.references.read().is_empty());
+    }
+
+    /// One session spending its whole reference quota must not stop another
+    /// session from creating objects. This is the regression test for the
+    /// core-wide budgets being reachable by a single session.
+    fn check_reference_quota_is_per_session(broker: &BrokerCore) {
+        let greedy = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let neighbor = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+
+        let greedy_first = crate::event::create(&greedy, 0).unwrap();
+        let greedy_second = crate::event::create(&greedy, 0).unwrap();
+        // The greedy session stops at its own quota while the core-wide
+        // ceiling still has room for every other session's share.
+        assert_eq!(
+            crate::event::create(&greedy, 0),
+            Err(BrokerError::ResourceExhausted)
+        );
+        assert_eq!(broker.references.read().len(), TEST_MAX_SESSION_REFERENCES);
+
+        let neighbor_first = crate::event::create(&neighbor, 0).unwrap();
+        let neighbor_second = crate::event::create(&neighbor, 0).unwrap();
+        assert_eq!(broker.references.read().len(), TEST_MAX_REFERENCES);
+
+        // With every quota spent, the core-wide ceiling is the backstop.
+        let latecomer = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        assert_eq!(
+            crate::event::create(&latecomer, 0),
+            Err(BrokerError::ResourceExhausted)
+        );
+
+        // Closing a reference returns quota to the session that held it.
+        assert_eq!(greedy.close_object_reference(greedy_first), Ok(()));
+        let greedy_third = crate::event::create(&greedy, 0).unwrap();
+
+        assert_eq!(greedy.close_object_reference(greedy_second), Ok(()));
+        assert_eq!(greedy.close_object_reference(greedy_third), Ok(()));
+        assert_eq!(neighbor.close_object_reference(neighbor_first), Ok(()));
+        assert_eq!(neighbor.close_object_reference(neighbor_second), Ok(()));
+        assert!(broker.references.read().is_empty());
+    }
+
+    /// The same isolation must hold for reserved pipe capacity, which is
+    /// tracked in a counter rather than in the reference table.
+    fn check_pipe_capacity_quota_is_per_session(broker: &BrokerCore) {
+        let greedy = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let neighbor = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+
+        let (greedy_reader, greedy_writer) =
+            crate::pipe::create(&greedy, TEST_SESSION_PIPE_CAPACITY_REQUEST, 2).unwrap();
+        assert_eq!(
+            greedy.reserved_pipe_capacity.load(Ordering::Relaxed),
+            TEST_MAX_SESSION_PIPE_CAPACITY
+        );
+        assert_eq!(
+            broker.reserved_pipe_capacity.load(Ordering::Relaxed),
+            TEST_MAX_SESSION_PIPE_CAPACITY
+        );
+        // The greedy session is refused by its own quota, without charging the
+        // core-wide counter it would otherwise have consumed.
+        assert_eq!(
+            crate::pipe::create(&greedy, 1, 1),
+            Err(BrokerError::ResourceExhausted)
+        );
+        assert_eq!(
+            broker.reserved_pipe_capacity.load(Ordering::Relaxed),
+            TEST_MAX_SESSION_PIPE_CAPACITY
+        );
+
+        let (neighbor_reader, neighbor_writer) =
+            crate::pipe::create(&neighbor, TEST_SESSION_PIPE_CAPACITY_REQUEST, 2).unwrap();
+        assert_eq!(
+            broker.reserved_pipe_capacity.load(Ordering::Relaxed),
+            TEST_MAX_TOTAL_PIPE_CAPACITY
+        );
+
+        // The core-wide ceiling backstops a session that is within its quota,
+        // and the refused reservation leaves no charge behind on either counter.
+        let latecomer = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        assert_eq!(
+            crate::pipe::create(&latecomer, 1, 1),
+            Err(BrokerError::ResourceExhausted)
+        );
+        assert_eq!(latecomer.reserved_pipe_capacity.load(Ordering::Relaxed), 0);
+        assert_eq!(
+            broker.reserved_pipe_capacity.load(Ordering::Relaxed),
+            TEST_MAX_TOTAL_PIPE_CAPACITY
+        );
+
+        // Capacity is held until both endpoints are gone, then credited back to
+        // the session and to the core together.
+        assert_eq!(greedy.close_object_reference(greedy_reader), Ok(()));
+        assert_eq!(
+            greedy.reserved_pipe_capacity.load(Ordering::Relaxed),
+            TEST_MAX_SESSION_PIPE_CAPACITY
+        );
+        assert_eq!(greedy.close_object_reference(greedy_writer), Ok(()));
+        assert_eq!(greedy.reserved_pipe_capacity.load(Ordering::Relaxed), 0);
+        assert_eq!(
+            broker.reserved_pipe_capacity.load(Ordering::Relaxed),
+            TEST_MAX_SESSION_PIPE_CAPACITY
+        );
+
+        assert_eq!(neighbor.close_object_reference(neighbor_reader), Ok(()));
+        assert_eq!(neighbor.close_object_reference(neighbor_writer), Ok(()));
+        assert_eq!(neighbor.reserved_pipe_capacity.load(Ordering::Relaxed), 0);
+        assert_eq!(broker.reserved_pipe_capacity.load(Ordering::Relaxed), 0);
+        assert!(broker.references.read().is_empty());
+    }
+
+    /// Tearing a session down must return everything it held, so a session that
+    /// stops making progress cannot pin a share of the core-wide budgets past
+    /// its own lifetime.
+    fn check_session_drop_releases_quotas(broker: &BrokerCore) {
+        // Twice, so the second session proves the first really gave the
+        // core-wide budgets back rather than merely stopping using them.
+        for _ in 0..2 {
+            let session = broker
+                .create_session(CallerCredential::Unauthenticated)
+                .unwrap();
+            let (reader, writer) =
+                crate::pipe::create(&session, TEST_SESSION_PIPE_CAPACITY_REQUEST, 2).unwrap();
+            assert_ne!(reader, writer);
+            assert_eq!(broker.references.read().len(), 2);
+            assert_eq!(
+                broker.reserved_pipe_capacity.load(Ordering::Relaxed),
+                TEST_MAX_SESSION_PIPE_CAPACITY
+            );
+            // Outlives the session, so the per-session charge stays observable
+            // across teardown.
+            let session_capacity = Arc::clone(&session.reserved_pipe_capacity);
+            assert_eq!(
+                session_capacity.load(Ordering::Relaxed),
+                TEST_MAX_SESSION_PIPE_CAPACITY
+            );
+
+            drop(session);
+
+            assert!(broker.references.read().is_empty());
+            assert_eq!(broker.reserved_pipe_capacity.load(Ordering::Relaxed), 0);
+            assert_eq!(session_capacity.load(Ordering::Relaxed), 0);
+        }
+    }
+
+    /// Pipe capacity is reserved before the endpoint references exist, so a
+    /// session that is at its reference quota must get the reservation back.
+    fn check_pipe_capacity_is_released_when_endpoints_are_refused(broker: &BrokerCore) {
+        let session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let first = crate::event::create(&session, 0).unwrap();
+        let second = crate::event::create(&session, 0).unwrap();
+
+        assert_eq!(
+            crate::pipe::create(&session, TEST_SESSION_PIPE_CAPACITY_REQUEST, 2),
+            Err(BrokerError::ResourceExhausted)
+        );
+        assert_eq!(session.reserved_pipe_capacity.load(Ordering::Relaxed), 0);
+        assert_eq!(broker.reserved_pipe_capacity.load(Ordering::Relaxed), 0);
+
+        assert_eq!(session.close_object_reference(first), Ok(()));
+        assert_eq!(session.close_object_reference(second), Ok(()));
         assert!(broker.references.read().is_empty());
     }
 

--- a/litebox_broker_core/src/session.rs
+++ b/litebox_broker_core/src/session.rs
@@ -136,6 +136,11 @@ impl BrokerSession {
         first: ObjectEntry,
         second: ObjectEntry,
     ) -> Result<(ObjectHandle, ObjectHandle)> {
+        // `first` and `second` are parameters, so they are dropped after every
+        // lock guard declared in this body. That is what makes each failure
+        // return below destroy the pipe endpoints, which take the pipe-state
+        // lock, only once both reference-index locks are released. Do not
+        // rebind them to locals declared after either guard.
         let rights = self
             .core
             .policy
@@ -187,6 +192,12 @@ impl BrokerSession {
         rights: ObjectRights,
     ) {
         let session_reference_index = reference_handles.len();
+        // Both callers check `contains_key` first, so this always replaces
+        // nothing. Anything dropped here would be destroyed while both the
+        // session's reference-handle lock and the core-wide reference lock are
+        // held, so `ObjectReference` must never gain a destructor that takes
+        // either. Keeping this insert infallible is also what lets the caller's
+        // pair loop run without a rollback path.
         references.insert(
             handle,
             ObjectReference {
@@ -615,6 +626,15 @@ mod tests {
             crate::event::create(&latecomer, 0),
             Err(BrokerError::ResourceExhausted)
         );
+        // Same backstop on the pair path, which admits two references at once.
+        // No pipe is alive here, so the capacity ceiling cannot short-circuit
+        // it, and the latecomer is well inside its own quota.
+        assert_eq!(
+            crate::pipe::create(&latecomer, 1, 1),
+            Err(BrokerError::ResourceExhausted)
+        );
+        assert_eq!(latecomer.reserved_pipe_capacity.load(Ordering::Relaxed), 0);
+        assert_eq!(broker.reserved_pipe_capacity.load(Ordering::Relaxed), 0);
 
         // Closing a reference returns quota to the session that held it.
         assert_eq!(greedy.close_object_reference(greedy_first), Ok(()));

--- a/litebox_broker_host/src/readiness.rs
+++ b/litebox_broker_host/src/readiness.rs
@@ -41,10 +41,11 @@ use thiserror::Error;
 
 /// Maximum number of objects one association tracks readiness for.
 ///
-/// This matches the default broker-core reference limit, so a source that
-/// retires an object as its backend resource is released stays well inside it.
-/// It exists so that a source which does not, or a deployment that raises the
-/// core limit, cannot grow publication state without limit.
+/// One association is one broker-core session, so this sits above the default
+/// per-session reference quota rather than matching it exactly, and a source
+/// that retires an object as its backend resource is released stays well
+/// inside it. It exists so that a source which does not, or a deployment that
+/// raises the core limits, cannot grow publication state without limit.
 pub const MAX_TRACKED_READINESS_OBJECTS: usize = 4096;
 
 /// Error returned when readiness state cannot record an update.


### PR DESCRIPTION
BrokerCoreLimits is global to the broker core, but one broker process serves every client association.