### PR TITLE
Map initial-files tar read-only instead of reading it into a Vec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1810,6 +1810,7 @@ dependencies = [
  "litebox_shim_windows",
  "litebox_syscall_rewriter",
  "litebox_util_log",
+ "memmap2",
  "tar",
  "tracing-subscriber",
 ]

--- a/litebox_runner_windows_userland/Cargo.toml
+++ b/litebox_runner_windows_userland/Cargo.toml
@@ -11,6 +11,7 @@ litebox_common_linux = { version = "0.1.0", path = "../litebox_common_linux" }
 litebox_platform_windows_userland = { version = "0.1.0", path = "../litebox_platform_windows_userland" }
 litebox_shim_windows = { version = "0.1.0", path = "../litebox_shim_windows" }
 litebox_util_log = { version = "0.1.0", path = "../litebox_util_log", features = ["backend_tracing"] }
+memmap2 = "0.9.8"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
 
 [dev-dependencies]

--- a/litebox_runner_windows_userland/src/lib.rs
+++ b/litebox_runner_windows_userland/src/lib.rs
@@ -10,7 +10,25 @@ extern crate alloc;
 use anyhow::{Context as _, Result};
 use clap::Parser;
 use litebox_platform_windows_userland::WindowsUserland;
-use std::path::PathBuf;
+use memmap2::Mmap;
+use std::path::{Path, PathBuf};
+
+fn mmapped_file(path: impl AsRef<Path>) -> Result<&'static [u8]> {
+    let path = path.as_ref();
+    let file = std::fs::File::open(path)
+        .with_context(|| format!("Could not open tar file at {}", path.display()))?;
+    let data = {
+        // SAFETY: The runner maps the input read-only and does not modify it. The caller must ensure
+        // the tar file is not modified externally while the guest is running.
+        //
+        // Leak the mapping so the borrowed tar data remains valid for the process-lifetime file
+        // system.
+        Box::leak(Box::new(unsafe { Mmap::map(&file) }.with_context(
+            || format!("Could not map tar file at {}", path.display()),
+        )?))
+    };
+    Ok(data)
+}
 
 /// Run Windows PE programs with LiteBox on unmodified Windows.
 ///
@@ -64,8 +82,7 @@ pub fn run(cli_args: CliArgs) -> Result<()> {
     if tar_file.extension().and_then(|x| x.to_str()) != Some("tar") {
         anyhow::bail!("Expected a .tar file, found {}", tar_file.display());
     }
-    let tar_data = std::fs::read(tar_file)
-        .with_context(|| format!("Could not read tar file at {}", tar_file.display()))?;
+    let tar_data = mmapped_file(tar_file)?;
 
     let platform = WindowsUserland::new();
     let shim_builder = litebox_shim_windows::WindowsShimBuilder::new(platform);


### PR DESCRIPTION
Mirror the Linux runner by memory-mapping the tar read-only and passing a process-lifetime borrowed slice to the zero-copy tar filesystem.