### PR TITLE
Improve handle management

### DIFF
--- a/litebox/src/fs/backend.rs
+++ b/litebox/src/fs/backend.rs
@@ -147,9 +147,6 @@ pub trait Backend: private::Sealed + Send + Sync + Any {
     // XXX(jayb): I don't like that unlink and rmdir exist separately, we should probably merge them.
     fn rmdir_at(&self, dir: DirHandle, name: &str) -> Result<(), RmdirError>;
 
-    /// Update the permissions for the file/dir `name` at `parent`.
-    fn chmod_at(&self, dir: DirHandle, name: &str, mode: Mode) -> Result<(), ChmodError>;
-
     /// Update the permissions for the file/dir `h` refers to.
     fn chmod(&self, h: HandleRef<'_>, mode: Mode) -> Result<(), ChmodError>;
 
@@ -157,15 +154,6 @@ pub trait Backend: private::Sealed + Send + Sync + Any {
     fn chown(
         &self,
         h: HandleRef<'_>,
-        user: Option<u16>,
-        group: Option<u16>,
-    ) -> Result<(), ChownError>;
-
-    /// Update the owner/group for the file/dir `name` at `parent`.
-    fn chown_at(
-        &self,
-        dir: DirHandle,
-        name: &str,
         user: Option<u16>,
         group: Option<u16>,
     ) -> Result<(), ChownError>;

--- a/litebox/src/fs/backend.rs
+++ b/litebox/src/fs/backend.rs
@@ -127,7 +127,7 @@ pub trait Backend: private::Sealed + Send + Sync + Any {
     fn seek_behavior(&self, h: &FileHandle) -> SeekBehavior;
 
     /// Status of an open file or directory handle.
-    fn status(&self, h: &Handle) -> Result<FileStatus, FileStatusError>;
+    fn status(&self, h: HandleRef<'_>) -> Result<FileStatus, FileStatusError>;
 
     /// Create a new file at `parent` with the given `name` and `mode`.
     fn create_file_at(
@@ -200,6 +200,26 @@ pub enum Handle {
     File(FileHandle),
     /// A handle to an open directory
     Dir(DirHandle),
+}
+
+impl Handle {
+    /// Borrow this handle, for passing to the object-addressed [`Backend`] operations.
+    #[must_use]
+    pub fn as_ref(&self) -> HandleRef<'_> {
+        match self {
+            Handle::File(handle) => HandleRef::File(handle),
+            Handle::Dir(handle) => HandleRef::Dir(handle),
+        }
+    }
+}
+
+/// A borrowed handle to an open file or directory.
+#[derive(Clone, Copy)]
+pub enum HandleRef<'a> {
+    /// A handle to an open file
+    File(&'a FileHandle),
+    /// A handle to an open directory
+    Dir(&'a DirHandle),
 }
 
 trait ErasedWalkingDirHandle {

--- a/litebox/src/fs/backend.rs
+++ b/litebox/src/fs/backend.rs
@@ -126,11 +126,8 @@ pub trait Backend: private::Sealed + Send + Sync + Any {
     /// Describe seek behavior for an open file handle.
     fn seek_behavior(&self, h: &FileHandle) -> SeekBehavior;
 
-    /// Status of an open file handle.
-    fn file_status(&self, h: &FileHandle) -> Result<FileStatus, FileStatusError>;
-
-    /// Status of an open directory handle.
-    fn dir_status(&self, h: &DirHandle) -> Result<FileStatus, FileStatusError>;
+    /// Status of an open file or directory handle.
+    fn status(&self, h: &Handle) -> Result<FileStatus, FileStatusError>;
 
     /// Create a new file at `parent` with the given `name` and `mode`.
     fn create_file_at(
@@ -194,6 +191,15 @@ pub struct FileHandle {
 #[derive(Clone)]
 pub struct DirHandle {
     raw: Box<dyn AnyCloneSendSync>,
+}
+
+/// An owned handle to an open file or directory.
+#[derive(Clone)]
+pub enum Handle {
+    /// A handle to an open file
+    File(FileHandle),
+    /// A handle to an open directory
+    Dir(DirHandle),
 }
 
 trait ErasedWalkingDirHandle {

--- a/litebox/src/fs/backend.rs
+++ b/litebox/src/fs/backend.rs
@@ -150,6 +150,17 @@ pub trait Backend: private::Sealed + Send + Sync + Any {
     /// Update the permissions for the file/dir `name` at `parent`.
     fn chmod_at(&self, dir: DirHandle, name: &str, mode: Mode) -> Result<(), ChmodError>;
 
+    /// Update the permissions for the file/dir `h` refers to.
+    fn chmod(&self, h: HandleRef<'_>, mode: Mode) -> Result<(), ChmodError>;
+
+    /// Update the owner/group for the file/dir `h` refers to.
+    fn chown(
+        &self,
+        h: HandleRef<'_>,
+        user: Option<u16>,
+        group: Option<u16>,
+    ) -> Result<(), ChownError>;
+
     /// Update the owner/group for the file/dir `name` at `parent`.
     fn chown_at(
         &self,

--- a/litebox/src/fs/composer.rs
+++ b/litebox/src/fs/composer.rs
@@ -774,6 +774,53 @@ impl Backend for Composer {
         }
     }
 
+    fn chmod(&self, h: HandleRef<'_>, mode: Mode) -> Result<(), ChmodError> {
+        match h {
+            HandleRef::File(h) => {
+                let h = h.get_typed::<Self>();
+                self.mounts[h.mount_index]
+                    .backend
+                    .chmod(HandleRef::File(&h.handle), mode)
+            }
+            HandleRef::Dir(h) => match &h.get_typed::<Self>().inner {
+                ComposerDirHandleInner::Virtual { .. } => Err(ChmodError::ReadOnlyFileSystem),
+                ComposerDirHandleInner::Mounted {
+                    mount_index,
+                    handle,
+                    ..
+                } => self.mounts[*mount_index]
+                    .backend
+                    .chmod(HandleRef::Dir(handle), mode),
+            },
+        }
+    }
+
+    fn chown(
+        &self,
+        h: HandleRef<'_>,
+        user: Option<u16>,
+        group: Option<u16>,
+    ) -> Result<(), ChownError> {
+        match h {
+            HandleRef::File(h) => {
+                let h = h.get_typed::<Self>();
+                self.mounts[h.mount_index]
+                    .backend
+                    .chown(HandleRef::File(&h.handle), user, group)
+            }
+            HandleRef::Dir(h) => match &h.get_typed::<Self>().inner {
+                ComposerDirHandleInner::Virtual { .. } => Err(ChownError::ReadOnlyFileSystem),
+                ComposerDirHandleInner::Mounted {
+                    mount_index,
+                    handle,
+                    ..
+                } => self.mounts[*mount_index]
+                    .backend
+                    .chown(HandleRef::Dir(handle), user, group),
+            },
+        }
+    }
+
     fn chmod_at(&self, dir: DirHandle, name: &str, mode: Mode) -> Result<(), ChmodError> {
         let dir = dir.into_typed::<Self>();
         match dir.inner {

--- a/litebox/src/fs/composer.rs
+++ b/litebox/src/fs/composer.rs
@@ -820,44 +820,4 @@ impl Backend for Composer {
             },
         }
     }
-
-    fn chmod_at(&self, dir: DirHandle, name: &str, mode: Mode) -> Result<(), ChmodError> {
-        let dir = dir.into_typed::<Self>();
-        match dir.inner {
-            ComposerDirHandleInner::Virtual { .. } => Err(ChmodError::ReadOnlyFileSystem),
-            ComposerDirHandleInner::Mounted {
-                path,
-                mount_index,
-                handle,
-            } => {
-                self.checked_child_path(path, name, ChmodError::ReadOnlyFileSystem)?;
-                self.mounts[mount_index]
-                    .backend
-                    .chmod_at(handle, name, mode)
-            }
-        }
-    }
-
-    fn chown_at(
-        &self,
-        dir: DirHandle,
-        name: &str,
-        user: Option<u16>,
-        group: Option<u16>,
-    ) -> Result<(), ChownError> {
-        let dir = dir.into_typed::<Self>();
-        match dir.inner {
-            ComposerDirHandleInner::Virtual { .. } => Err(ChownError::ReadOnlyFileSystem),
-            ComposerDirHandleInner::Mounted {
-                path,
-                mount_index,
-                handle,
-            } => {
-                self.checked_child_path(path, name, ChownError::ReadOnlyFileSystem)?;
-                self.mounts[mount_index]
-                    .backend
-                    .chown_at(handle, name, user, group)
-            }
-        }
-    }
 }

--- a/litebox/src/fs/composer.rs
+++ b/litebox/src/fs/composer.rs
@@ -10,7 +10,7 @@ use alloc::vec;
 use alloc::vec::Vec;
 
 use super::backend::{
-    Backend, BackendHandles, DirHandle, FileHandle, Handle, PermissionCheck, Permissioned,
+    Backend, BackendHandles, DirHandle, FileHandle, HandleRef, PermissionCheck, Permissioned,
     SeekBehavior, WalkOutcome, WalkStopReason, WalkedComponent, WalkingDirHandle,
 };
 use super::errors::{
@@ -668,15 +668,15 @@ impl Backend for Composer {
         self.mounts[h.mount_index].backend.seek_behavior(&h.handle)
     }
 
-    fn status(&self, h: &Handle) -> Result<FileStatus, FileStatusError> {
+    fn status(&self, h: HandleRef<'_>) -> Result<FileStatus, FileStatusError> {
         match h {
-            Handle::File(h) => {
+            HandleRef::File(h) => {
                 let h = h.get_typed::<Self>();
                 self.mounts[h.mount_index]
                     .backend
-                    .status(&Handle::File(h.handle.clone()))
+                    .status(HandleRef::File(&h.handle))
             }
-            Handle::Dir(h) => match &h.get_typed::<Self>().inner {
+            HandleRef::Dir(h) => match &h.get_typed::<Self>().inner {
                 ComposerDirHandleInner::Virtual { path } => Ok(self.virtual_dir_status(path)),
                 ComposerDirHandleInner::Mounted {
                     mount_index,
@@ -684,7 +684,7 @@ impl Backend for Composer {
                     ..
                 } => self.mounts[*mount_index]
                     .backend
-                    .status(&Handle::Dir(handle.clone())),
+                    .status(HandleRef::Dir(handle)),
             },
         }
     }

--- a/litebox/src/fs/composer.rs
+++ b/litebox/src/fs/composer.rs
@@ -10,8 +10,8 @@ use alloc::vec;
 use alloc::vec::Vec;
 
 use super::backend::{
-    Backend, BackendHandles, DirHandle, FileHandle, PermissionCheck, Permissioned, SeekBehavior,
-    WalkOutcome, WalkStopReason, WalkedComponent, WalkingDirHandle,
+    Backend, BackendHandles, DirHandle, FileHandle, Handle, PermissionCheck, Permissioned,
+    SeekBehavior, WalkOutcome, WalkStopReason, WalkedComponent, WalkingDirHandle,
 };
 use super::errors::{
     ChmodError, ChownError, FileStatusError, MkdirError, OpenError, PathError, ReadDirError,
@@ -668,20 +668,24 @@ impl Backend for Composer {
         self.mounts[h.mount_index].backend.seek_behavior(&h.handle)
     }
 
-    fn file_status(&self, h: &FileHandle) -> Result<FileStatus, FileStatusError> {
-        let h = h.get_typed::<Self>();
-        self.mounts[h.mount_index].backend.file_status(&h.handle)
-    }
-
-    fn dir_status(&self, h: &DirHandle) -> Result<FileStatus, FileStatusError> {
-        let h = h.get_typed::<Self>();
-        match &h.inner {
-            ComposerDirHandleInner::Virtual { path } => Ok(self.virtual_dir_status(path)),
-            ComposerDirHandleInner::Mounted {
-                mount_index,
-                handle,
-                ..
-            } => self.mounts[*mount_index].backend.dir_status(handle),
+    fn status(&self, h: &Handle) -> Result<FileStatus, FileStatusError> {
+        match h {
+            Handle::File(h) => {
+                let h = h.get_typed::<Self>();
+                self.mounts[h.mount_index]
+                    .backend
+                    .status(&Handle::File(h.handle.clone()))
+            }
+            Handle::Dir(h) => match &h.get_typed::<Self>().inner {
+                ComposerDirHandleInner::Virtual { path } => Ok(self.virtual_dir_status(path)),
+                ComposerDirHandleInner::Mounted {
+                    mount_index,
+                    handle,
+                    ..
+                } => self.mounts[*mount_index]
+                    .backend
+                    .status(&Handle::Dir(handle.clone())),
+            },
         }
     }
 

--- a/litebox/src/fs/devices.rs
+++ b/litebox/src/fs/devices.rs
@@ -13,8 +13,8 @@ use crate::LiteBox;
 use crate::sync::RawSyncPrimitivesProvider;
 
 use super::backend::{
-    Backend, BackendHandles, DirHandle, FileHandle, PermissionCheck, Permissioned, SeekBehavior,
-    WalkOutcome, WalkStopReason, WalkingDirHandle,
+    Backend, BackendHandles, DirHandle, FileHandle, Handle, PermissionCheck, Permissioned,
+    SeekBehavior, WalkOutcome, WalkStopReason, WalkingDirHandle,
 };
 use super::errors::{
     ChmodError, ChownError, FileStatusError, MkdirError, OpenError, PathError, ReadDirError,
@@ -338,20 +338,21 @@ where
         }
     }
 
-    fn file_status(&self, h: &FileHandle) -> Result<FileStatus, FileStatusError> {
-        Ok(h.get_typed::<Self>().device.file_status())
-    }
-
-    fn dir_status(&self, h: &DirHandle) -> Result<FileStatus, FileStatusError> {
-        let _h = h.get_typed::<Self>();
-        Ok(FileStatus {
-            file_type: FileType::Directory,
-            mode: Mode::RWXU | Mode::RGRP | Mode::XGRP | Mode::ROTH | Mode::XOTH,
-            size: super::DEFAULT_DIRECTORY_SIZE,
-            owner: UserInfo::ROOT,
-            node_info: self.root_inode.clone(),
-            blksize: super::DEFAULT_DIRECTORY_SIZE,
-        })
+    fn status(&self, h: &Handle) -> Result<FileStatus, FileStatusError> {
+        match h {
+            Handle::File(h) => Ok(h.get_typed::<Self>().device.file_status()),
+            Handle::Dir(h) => {
+                let _h = h.get_typed::<Self>();
+                Ok(FileStatus {
+                    file_type: FileType::Directory,
+                    mode: Mode::RWXU | Mode::RGRP | Mode::XGRP | Mode::ROTH | Mode::XOTH,
+                    size: super::DEFAULT_DIRECTORY_SIZE,
+                    owner: UserInfo::ROOT,
+                    node_info: self.root_inode.clone(),
+                    blksize: super::DEFAULT_DIRECTORY_SIZE,
+                })
+            }
+        }
     }
 
     fn create_file_at(

--- a/litebox/src/fs/devices.rs
+++ b/litebox/src/fs/devices.rs
@@ -376,10 +376,6 @@ where
         Err(RmdirError::ReadOnlyFileSystem)
     }
 
-    fn chmod_at(&self, _dir: DirHandle, _name: &str, _mode: Mode) -> Result<(), ChmodError> {
-        Err(ChmodError::ReadOnlyFileSystem)
-    }
-
     fn chmod(&self, _h: HandleRef<'_>, _mode: Mode) -> Result<(), ChmodError> {
         Err(ChmodError::ReadOnlyFileSystem)
     }
@@ -387,16 +383,6 @@ where
     fn chown(
         &self,
         _h: HandleRef<'_>,
-        _user: Option<u16>,
-        _group: Option<u16>,
-    ) -> Result<(), ChownError> {
-        Err(ChownError::ReadOnlyFileSystem)
-    }
-
-    fn chown_at(
-        &self,
-        _dir: DirHandle,
-        _name: &str,
         _user: Option<u16>,
         _group: Option<u16>,
     ) -> Result<(), ChownError> {

--- a/litebox/src/fs/devices.rs
+++ b/litebox/src/fs/devices.rs
@@ -13,7 +13,7 @@ use crate::LiteBox;
 use crate::sync::RawSyncPrimitivesProvider;
 
 use super::backend::{
-    Backend, BackendHandles, DirHandle, FileHandle, Handle, PermissionCheck, Permissioned,
+    Backend, BackendHandles, DirHandle, FileHandle, HandleRef, PermissionCheck, Permissioned,
     SeekBehavior, WalkOutcome, WalkStopReason, WalkingDirHandle,
 };
 use super::errors::{
@@ -338,10 +338,10 @@ where
         }
     }
 
-    fn status(&self, h: &Handle) -> Result<FileStatus, FileStatusError> {
+    fn status(&self, h: HandleRef<'_>) -> Result<FileStatus, FileStatusError> {
         match h {
-            Handle::File(h) => Ok(h.get_typed::<Self>().device.file_status()),
-            Handle::Dir(h) => {
+            HandleRef::File(h) => Ok(h.get_typed::<Self>().device.file_status()),
+            HandleRef::Dir(h) => {
                 let _h = h.get_typed::<Self>();
                 Ok(FileStatus {
                     file_type: FileType::Directory,

--- a/litebox/src/fs/devices.rs
+++ b/litebox/src/fs/devices.rs
@@ -380,6 +380,19 @@ where
         Err(ChmodError::ReadOnlyFileSystem)
     }
 
+    fn chmod(&self, _h: HandleRef<'_>, _mode: Mode) -> Result<(), ChmodError> {
+        Err(ChmodError::ReadOnlyFileSystem)
+    }
+
+    fn chown(
+        &self,
+        _h: HandleRef<'_>,
+        _user: Option<u16>,
+        _group: Option<u16>,
+    ) -> Result<(), ChownError> {
+        Err(ChownError::ReadOnlyFileSystem)
+    }
+
     fn chown_at(
         &self,
         _dir: DirHandle,

--- a/litebox/src/fs/resolver.rs
+++ b/litebox/src/fs/resolver.rs
@@ -19,8 +19,8 @@ use super::errors::{
 use super::{
     FileType, Mode, OFlags,
     backend::{
-        DirHandle, FileHandle, HandleRef, PermissionCheck, PermissionInfo, SeekBehavior,
-        WalkOutcome, WalkStopReason, WalkingDirHandle,
+        DirHandle, Handle, HandleRef, PermissionCheck, PermissionInfo, SeekBehavior, WalkOutcome,
+        WalkStopReason, WalkingDirHandle,
     },
 };
 
@@ -355,7 +355,7 @@ impl<Platform: sync::RawSyncPrimitivesProvider, Backend: super::backend::Backend
                 return Err(OpenError::AlreadyExists);
             }
             return Ok(insert(
-                OwnedHandle::Dir(self.backend.owned_dir_at(self.backend.root(), flags)?),
+                Handle::Dir(self.backend.owned_dir_at(self.backend.root(), flags)?),
                 SeekBehavior::NonSeekable,
             ));
         }
@@ -374,7 +374,7 @@ impl<Platform: sync::RawSyncPrimitivesProvider, Backend: super::backend::Backend
                     return Err(OpenError::AlreadyExists);
                 }
                 Ok(insert(
-                    OwnedHandle::Dir(self.backend.owned_dir_at(outcome.last, flags)?),
+                    Handle::Dir(self.backend.owned_dir_at(outcome.last, flags)?),
                     SeekBehavior::NonSeekable,
                 ))
             }
@@ -396,7 +396,7 @@ impl<Platform: sync::RawSyncPrimitivesProvider, Backend: super::backend::Backend
                     return Err(OpenError::AccessNotAllowed);
                 }
                 let seek_behavior = self.backend.seek_behavior(&file.item);
-                Ok(insert(OwnedHandle::File(file.item), seek_behavior))
+                Ok(insert(Handle::File(file.item), seek_behavior))
             }
             Ok(_) => {
                 // `walk_path` validates stop reasons before returning.
@@ -426,7 +426,7 @@ impl<Platform: sync::RawSyncPrimitivesProvider, Backend: super::backend::Backend
                 })?;
                 let file = self.backend.create_file_at(parent, name, mode)?;
                 let seek_behavior = self.backend.seek_behavior(&file);
-                Ok(insert(OwnedHandle::File(file), seek_behavior))
+                Ok(insert(Handle::File(file), seek_behavior))
             }
             Err(error) => match error {
                 WalkError::Io => Err(OpenError::Io),
@@ -456,8 +456,8 @@ impl<Platform: sync::RawSyncPrimitivesProvider, Backend: super::backend::Backend
         // smaller per-open-file-description primitive for position/append serialization, so the
         // descriptor entry can be unlocked before potentially blocking backend calls.
         let file = match &entry.entry.handle {
-            OwnedHandle::File(file) => file,
-            OwnedHandle::Dir(_) => return Err(ReadError::NotAFile),
+            Handle::File(file) => file,
+            Handle::Dir(_) => return Err(ReadError::NotAFile),
         };
         let seek_behavior = entry.entry.seek_behavior;
         if !entry.entry.read_allowed {
@@ -495,8 +495,8 @@ impl<Platform: sync::RawSyncPrimitivesProvider, Backend: super::backend::Backend
         // smaller per-open-file-description primitive for position/append serialization, so the
         // descriptor entry can be unlocked before potentially blocking backend calls.
         let file = match &entry.entry.handle {
-            OwnedHandle::File(file) => file,
-            OwnedHandle::Dir(_) => return Err(WriteError::NotAFile),
+            Handle::File(file) => file,
+            Handle::Dir(_) => return Err(WriteError::NotAFile),
         };
         let seek_behavior = entry.entry.seek_behavior;
         if !entry.entry.write_allowed {
@@ -537,8 +537,8 @@ impl<Platform: sync::RawSyncPrimitivesProvider, Backend: super::backend::Backend
             .ok_or(SeekError::ClosedFd)?;
         let mut entry = entry.get_entry_mut();
         let file = match &entry.entry.handle {
-            OwnedHandle::File(file) => file,
-            OwnedHandle::Dir(_) => return Err(SeekError::NotAFile),
+            Handle::File(file) => file,
+            Handle::Dir(_) => return Err(SeekError::NotAFile),
         };
         if entry.entry.path_only {
             // TODO(jayb): Add an error variant for operations not permitted on O_PATH fds.
@@ -586,8 +586,8 @@ impl<Platform: sync::RawSyncPrimitivesProvider, Backend: super::backend::Backend
             .ok_or(TruncateError::ClosedFd)?;
         let mut entry = entry.get_entry_mut();
         let file = match &entry.entry.handle {
-            OwnedHandle::File(file) => file,
-            OwnedHandle::Dir(_) => return Err(TruncateError::IsDirectory),
+            Handle::File(file) => file,
+            Handle::Dir(_) => return Err(TruncateError::IsDirectory),
         };
         if !entry.entry.write_allowed {
             return Err(TruncateError::NotForWriting);
@@ -718,8 +718,8 @@ impl<Platform: sync::RawSyncPrimitivesProvider, Backend: super::backend::Backend
             unimplemented!("read_dir on O_PATH fd")
         }
         let dir = match &entry.entry.handle {
-            OwnedHandle::File(_) => return Err(ReadDirError::NotADirectory),
-            OwnedHandle::Dir(dir) => dir,
+            Handle::File(_) => return Err(ReadDirError::NotADirectory),
+            Handle::Dir(dir) => dir,
         };
 
         let mut entries = Vec::new();
@@ -762,26 +762,17 @@ impl<Platform: sync::RawSyncPrimitivesProvider, Backend: super::backend::Backend
             .entry_handle(fd)
             .ok_or(FileStatusError::ClosedFd)?;
         let entry = entry.get_entry();
-        match &entry.entry.handle {
-            OwnedHandle::File(file) => self.backend.status(HandleRef::File(file)),
-            OwnedHandle::Dir(dir) => self.backend.status(HandleRef::Dir(dir)),
-        }
+        self.backend.status(entry.entry.handle.as_ref())
     }
 
     fn get_static_backing_data(&self, fd: &TypedFd<Self>) -> Option<&'static [u8]> {
         let entry = self.litebox.descriptor_table().entry_handle(fd)?;
         let entry = entry.get_entry();
         match &entry.entry.handle {
-            OwnedHandle::File(file) => self.backend.get_static_backing_data(file),
-            OwnedHandle::Dir(_) => None,
+            Handle::File(file) => self.backend.get_static_backing_data(file),
+            Handle::Dir(_) => None,
         }
     }
-}
-
-/// A file or a directory handle
-enum OwnedHandle {
-    File(FileHandle),
-    Dir(DirHandle),
 }
 
 #[expect(
@@ -789,7 +780,7 @@ enum OwnedHandle {
     reason = "resolver fd entries carry independent descriptor flags"
 )]
 struct ResolverEntry<Backend: super::backend::Backend> {
-    handle: OwnedHandle,
+    handle: Handle,
     _backend: core::marker::PhantomData<Backend>,
     read_allowed: bool,
     write_allowed: bool,

--- a/litebox/src/fs/resolver.rs
+++ b/litebox/src/fs/resolver.rs
@@ -19,7 +19,7 @@ use super::errors::{
 use super::{
     FileType, Mode, OFlags,
     backend::{
-        DirHandle, FileHandle, PermissionCheck, PermissionInfo, SeekBehavior, WalkOutcome,
+        DirHandle, FileHandle, Handle, PermissionCheck, PermissionInfo, SeekBehavior, WalkOutcome,
         WalkStopReason, WalkingDirHandle,
     },
 };
@@ -511,7 +511,7 @@ impl<Platform: sync::RawSyncPrimitivesProvider, Backend: super::backend::Backend
             SeekBehavior::NonSeekable | SeekBehavior::ZeroPosition => 0,
             SeekBehavior::PositionBased if entry.entry.append_mode && offset.is_none() => {
                 self.backend
-                    .file_status(file)
+                    .status(&Handle::File(file.clone()))
                     .map_err(|_| WriteError::Io)?
                     .size
             }
@@ -551,7 +551,7 @@ impl<Platform: sync::RawSyncPrimitivesProvider, Backend: super::backend::Backend
             SeekBehavior::PositionBased => {
                 let file_len = self
                     .backend
-                    .file_status(file)
+                    .status(&Handle::File(file.clone()))
                     .map_err(|_| SeekError::Io)?
                     .size;
                 let base = match whence {
@@ -763,8 +763,8 @@ impl<Platform: sync::RawSyncPrimitivesProvider, Backend: super::backend::Backend
             .ok_or(FileStatusError::ClosedFd)?;
         let entry = entry.get_entry();
         match &entry.entry.handle {
-            OwnedHandle::File(file) => self.backend.file_status(file),
-            OwnedHandle::Dir(dir) => self.backend.dir_status(dir),
+            OwnedHandle::File(file) => self.backend.status(&Handle::File(file.clone())),
+            OwnedHandle::Dir(dir) => self.backend.status(&Handle::Dir(dir.clone())),
         }
     }
 

--- a/litebox/src/fs/resolver.rs
+++ b/litebox/src/fs/resolver.rs
@@ -191,6 +191,49 @@ impl<Platform: sync::RawSyncPrimitivesProvider, Backend: super::backend::Backend
             })
     }
 
+    /// Resolve `path` to an owned handle on the file or directory it names.
+    ///
+    /// The handle is taken with [`OFlags::PATH`], as it addresses the object for operations that
+    /// do not read or write its contents, and thus needs no access permissions on it.
+    fn path_handle(&self, context: &Context, path: &ResolvedPath) -> Result<Handle, WalkError> {
+        let map_open_error = |error| match error {
+            OpenError::PathError(error) => WalkError::PathError(error),
+            _ => WalkError::Io,
+        };
+        let components: Vec<_> = path.components.iter().map(String::as_str).collect();
+        if components.is_empty() {
+            let root = self
+                .backend
+                .owned_dir_at(self.backend.root(), OFlags::PATH)
+                .map_err(map_open_error)?;
+            return Ok(Handle::Dir(root));
+        }
+        let (outcome, walked) = self.walk_path(
+            context,
+            self.backend.root(),
+            &components,
+            #[cfg(debug_assertions)]
+            &components,
+        )?;
+        match outcome.stop_reason {
+            WalkStopReason::CompleteDirectory => Ok(Handle::Dir(
+                self.backend
+                    .owned_dir_at(outcome.last, OFlags::PATH)
+                    .map_err(map_open_error)?,
+            )),
+            WalkStopReason::StoppedAtNonDirectory => Ok(Handle::File(
+                self.backend
+                    .open_file_at(outcome.last, components[walked], OFlags::PATH)
+                    .map_err(map_open_error)?
+                    .item,
+            )),
+            WalkStopReason::Continue => {
+                // `walk_path` validates stop reasons before returning.
+                unreachable!()
+            }
+        }
+    }
+
     fn walk_to_directory<'a>(
         &'a self,
         context: &Context,
@@ -607,21 +650,13 @@ impl<Platform: sync::RawSyncPrimitivesProvider, Backend: super::backend::Backend
     fn chmod(&self, path: impl Arg, mode: Mode) -> Result<(), ChmodError> {
         let context = default_context_pre_context_management_changes();
         let path = context.resolve(path)?;
-        let Some((parent, name)) =
-            self.parent_dir_and_name(&context, &path)
-                .map_err(|error| match error {
-                    WalkError::Io => ChmodError::Io,
-                    WalkError::PathError(error) => error.into(),
-                })?
-        else {
-            // TODO(jayb): Add backend support for mutating the root directory itself.
-            unimplemented!("chmod root directory")
-        };
-        let parent = self.owned_parent_dir(parent).map_err(|error| match error {
-            WalkError::Io => ChmodError::Io,
-            WalkError::PathError(error) => error.into(),
-        })?;
-        self.backend.chmod_at(parent, name, mode)
+        let handle = self
+            .path_handle(&context, &path)
+            .map_err(|error| match error {
+                WalkError::Io => ChmodError::Io,
+                WalkError::PathError(error) => error.into(),
+            })?;
+        self.backend.chmod(handle.as_ref(), mode)
     }
 
     fn chown(
@@ -632,21 +667,13 @@ impl<Platform: sync::RawSyncPrimitivesProvider, Backend: super::backend::Backend
     ) -> Result<(), ChownError> {
         let context = default_context_pre_context_management_changes();
         let path = context.resolve(path)?;
-        let Some((parent, name)) =
-            self.parent_dir_and_name(&context, &path)
-                .map_err(|error| match error {
-                    WalkError::Io => ChownError::Io,
-                    WalkError::PathError(error) => error.into(),
-                })?
-        else {
-            // TODO(jayb): Add backend support for mutating the root directory itself.
-            unimplemented!("chown root directory")
-        };
-        let parent = self.owned_parent_dir(parent).map_err(|error| match error {
-            WalkError::Io => ChownError::Io,
-            WalkError::PathError(error) => error.into(),
-        })?;
-        self.backend.chown_at(parent, name, user, group)
+        let handle = self
+            .path_handle(&context, &path)
+            .map_err(|error| match error {
+                WalkError::Io => ChownError::Io,
+                WalkError::PathError(error) => error.into(),
+            })?;
+        self.backend.chown(handle.as_ref(), user, group)
     }
 
     fn unlink(&self, path: impl Arg) -> Result<(), UnlinkError> {

--- a/litebox/src/fs/resolver.rs
+++ b/litebox/src/fs/resolver.rs
@@ -19,8 +19,8 @@ use super::errors::{
 use super::{
     FileType, Mode, OFlags,
     backend::{
-        DirHandle, FileHandle, Handle, PermissionCheck, PermissionInfo, SeekBehavior, WalkOutcome,
-        WalkStopReason, WalkingDirHandle,
+        DirHandle, FileHandle, HandleRef, PermissionCheck, PermissionInfo, SeekBehavior,
+        WalkOutcome, WalkStopReason, WalkingDirHandle,
     },
 };
 
@@ -511,7 +511,7 @@ impl<Platform: sync::RawSyncPrimitivesProvider, Backend: super::backend::Backend
             SeekBehavior::NonSeekable | SeekBehavior::ZeroPosition => 0,
             SeekBehavior::PositionBased if entry.entry.append_mode && offset.is_none() => {
                 self.backend
-                    .status(&Handle::File(file.clone()))
+                    .status(HandleRef::File(file))
                     .map_err(|_| WriteError::Io)?
                     .size
             }
@@ -551,7 +551,7 @@ impl<Platform: sync::RawSyncPrimitivesProvider, Backend: super::backend::Backend
             SeekBehavior::PositionBased => {
                 let file_len = self
                     .backend
-                    .status(&Handle::File(file.clone()))
+                    .status(HandleRef::File(file))
                     .map_err(|_| SeekError::Io)?
                     .size;
                 let base = match whence {
@@ -763,8 +763,8 @@ impl<Platform: sync::RawSyncPrimitivesProvider, Backend: super::backend::Backend
             .ok_or(FileStatusError::ClosedFd)?;
         let entry = entry.get_entry();
         match &entry.entry.handle {
-            OwnedHandle::File(file) => self.backend.status(&Handle::File(file.clone())),
-            OwnedHandle::Dir(dir) => self.backend.status(&Handle::Dir(dir.clone())),
+            OwnedHandle::File(file) => self.backend.status(HandleRef::File(file)),
+            OwnedHandle::Dir(dir) => self.backend.status(HandleRef::Dir(dir)),
         }
     }
 

--- a/litebox/src/fs/tar_ro.rs
+++ b/litebox/src/fs/tar_ro.rs
@@ -33,7 +33,7 @@ use crate::fs::{DirEntry, FileType};
 
 use super::{
     Mode, NodeInfo, OFlags, UserInfo,
-    backend::{DirHandle, FileHandle, WalkingDirHandle},
+    backend::{DirHandle, FileHandle, Handle, WalkingDirHandle},
     errors::{
         ChmodError, ChownError, MkdirError, OpenError, PathError, ReadDirError, ReadError,
         RmdirError, TruncateError, UnlinkError, WalkError, WriteError,
@@ -225,34 +225,31 @@ impl super::backend::Backend for TarRo {
         super::backend::SeekBehavior::PositionBased
     }
 
-    fn file_status(
-        &self,
-        h: &FileHandle,
-    ) -> Result<super::FileStatus, super::errors::FileStatusError> {
-        let file = &self.tar_index.files[h.get_typed::<Self>().idx];
-        Ok(super::FileStatus {
-            file_type: FileType::RegularFile,
-            mode: file.mode,
-            size: file.data_range.len(),
-            owner: file.owner,
-            node_info: file.node_info.clone(),
-            blksize: BLOCK_SIZE,
-        })
-    }
-
-    fn dir_status(
-        &self,
-        h: &DirHandle,
-    ) -> Result<super::FileStatus, super::errors::FileStatusError> {
-        let dir = &self.tar_index.dirs[h.get_typed::<Self>().idx];
-        Ok(super::FileStatus {
-            file_type: FileType::Directory,
-            mode: DEFAULT_DIR_MODE,
-            size: super::DEFAULT_DIRECTORY_SIZE,
-            owner: dir.owner.unwrap_or(DEFAULT_DIRECTORY_OWNER),
-            node_info: dir.node_info.clone(),
-            blksize: BLOCK_SIZE,
-        })
+    fn status(&self, h: &Handle) -> Result<super::FileStatus, super::errors::FileStatusError> {
+        match h {
+            Handle::File(h) => {
+                let file = &self.tar_index.files[h.get_typed::<Self>().idx];
+                Ok(super::FileStatus {
+                    file_type: FileType::RegularFile,
+                    mode: file.mode,
+                    size: file.data_range.len(),
+                    owner: file.owner,
+                    node_info: file.node_info.clone(),
+                    blksize: BLOCK_SIZE,
+                })
+            }
+            Handle::Dir(h) => {
+                let dir = &self.tar_index.dirs[h.get_typed::<Self>().idx];
+                Ok(super::FileStatus {
+                    file_type: FileType::Directory,
+                    mode: DEFAULT_DIR_MODE,
+                    size: super::DEFAULT_DIRECTORY_SIZE,
+                    owner: dir.owner.unwrap_or(DEFAULT_DIRECTORY_OWNER),
+                    node_info: dir.node_info.clone(),
+                    blksize: BLOCK_SIZE,
+                })
+            }
+        }
     }
 
     fn create_file_at(

--- a/litebox/src/fs/tar_ro.rs
+++ b/litebox/src/fs/tar_ro.rs
@@ -295,6 +295,19 @@ impl super::backend::Backend for TarRo {
         }
     }
 
+    fn chmod(&self, _h: HandleRef<'_>, _mode: Mode) -> Result<(), ChmodError> {
+        Err(ChmodError::ReadOnlyFileSystem)
+    }
+
+    fn chown(
+        &self,
+        _h: HandleRef<'_>,
+        _user: Option<u16>,
+        _group: Option<u16>,
+    ) -> Result<(), ChownError> {
+        Err(ChownError::ReadOnlyFileSystem)
+    }
+
     fn chown_at(
         &self,
         dir: DirHandle,

--- a/litebox/src/fs/tar_ro.rs
+++ b/litebox/src/fs/tar_ro.rs
@@ -286,15 +286,6 @@ impl super::backend::Backend for TarRo {
         }
     }
 
-    fn chmod_at(&self, dir: DirHandle, name: &str, _mode: Mode) -> Result<(), ChmodError> {
-        let dir = dir.into_typed::<Self>();
-        if self.tar_index.dirs[dir.idx].children.contains_key(name) {
-            Err(ChmodError::ReadOnlyFileSystem)
-        } else {
-            Err(PathError::NoSuchFileOrDirectory.into())
-        }
-    }
-
     fn chmod(&self, _h: HandleRef<'_>, _mode: Mode) -> Result<(), ChmodError> {
         Err(ChmodError::ReadOnlyFileSystem)
     }
@@ -306,21 +297,6 @@ impl super::backend::Backend for TarRo {
         _group: Option<u16>,
     ) -> Result<(), ChownError> {
         Err(ChownError::ReadOnlyFileSystem)
-    }
-
-    fn chown_at(
-        &self,
-        dir: DirHandle,
-        name: &str,
-        _user: Option<u16>,
-        _group: Option<u16>,
-    ) -> Result<(), ChownError> {
-        let dir = dir.into_typed::<Self>();
-        if self.tar_index.dirs[dir.idx].children.contains_key(name) {
-            Err(ChownError::ReadOnlyFileSystem)
-        } else {
-            Err(PathError::NoSuchFileOrDirectory.into())
-        }
     }
 }
 

--- a/litebox/src/fs/tar_ro.rs
+++ b/litebox/src/fs/tar_ro.rs
@@ -33,7 +33,7 @@ use crate::fs::{DirEntry, FileType};
 
 use super::{
     Mode, NodeInfo, OFlags, UserInfo,
-    backend::{DirHandle, FileHandle, Handle, WalkingDirHandle},
+    backend::{DirHandle, FileHandle, HandleRef, WalkingDirHandle},
     errors::{
         ChmodError, ChownError, MkdirError, OpenError, PathError, ReadDirError, ReadError,
         RmdirError, TruncateError, UnlinkError, WalkError, WriteError,
@@ -225,9 +225,12 @@ impl super::backend::Backend for TarRo {
         super::backend::SeekBehavior::PositionBased
     }
 
-    fn status(&self, h: &Handle) -> Result<super::FileStatus, super::errors::FileStatusError> {
+    fn status(
+        &self,
+        h: HandleRef<'_>,
+    ) -> Result<super::FileStatus, super::errors::FileStatusError> {
         match h {
-            Handle::File(h) => {
+            HandleRef::File(h) => {
                 let file = &self.tar_index.files[h.get_typed::<Self>().idx];
                 Ok(super::FileStatus {
                     file_type: FileType::RegularFile,
@@ -238,7 +241,7 @@ impl super::backend::Backend for TarRo {
                     blksize: BLOCK_SIZE,
                 })
             }
-            Handle::Dir(h) => {
+            HandleRef::Dir(h) => {
                 let dir = &self.tar_index.dirs[h.get_typed::<Self>().idx];
                 Ok(super::FileStatus {
                     file_type: FileType::Directory,


### PR DESCRIPTION
This PR merges some operations to use a single `Handle` enum, rather than do them individually.  This simplifies the `Backend` interface and also allows for supporting `chmod` of `/` (for example), which is needed as more backends move to the new design.