### PR TITLE
Add bounded TCP destination policy

### DIFF
--- a/litebox_broker_core/src/lib.rs
+++ b/litebox_broker_core/src/lib.rs
@@ -34,7 +34,10 @@ use litebox_broker_protocol::ObjectHandle;
 use spin::rwlock::RwLock;
 
 pub use error::BrokerError;
-pub use policy::{PolicyEngine, PolicyProfile, SocketPolicy};
+pub use policy::{
+    Ipv4Cidr, MAX_TCP_DESTINATION_RULES, PolicyEngine, PolicyProfile, SocketPolicy,
+    SocketPolicyError, TcpDestinationPolicy, TcpDestinationRule, TcpPortRange,
+};
 use session::ObjectReference;
 pub use session::{BrokerSession, CallerCredential, ObjectRights, SessionId};
 use socket::SocketProvider;
@@ -105,7 +108,7 @@ impl Default for BrokerCoreLimits {
 /// core has already been constructed.
 #[derive(Clone)]
 pub struct BrokerCore {
-    pub(crate) policy: PolicyEngine,
+    pub(crate) policy: Arc<PolicyEngine>,
     pub(crate) limits: BrokerCoreLimits,
     pub(crate) next_session_id: Arc<RwLock<u64>>,
     pub(crate) next_reference_handle: Arc<RwLock<u64>>,
@@ -135,7 +138,7 @@ impl BrokerCore {
             .map_err(|_| BrokerError::BrokerCoreAlreadyExists)?;
 
         Ok(Self {
-            policy,
+            policy: Arc::new(policy),
             limits,
             next_session_id: Arc::new(RwLock::new(1)),
             next_reference_handle: Arc::new(RwLock::new(1)),

--- a/litebox_broker_core/src/policy.rs
+++ b/litebox_broker_core/src/policy.rs
@@ -3,23 +3,261 @@
 
 use crate::{BrokerError, CallerCredential, ObjectRights};
 use litebox_broker_protocol::socket::{
-    AddressFamily, CreateSocketRequest, IpProtocol, SocketAddressV4, SocketType,
+    AddressFamily, CreateSocketRequest, IpProtocol, Ipv4Address, Port, SocketAddressV4, SocketType,
+};
+use thiserror::Error;
+
+/// Maximum number of TCP destination rules in one socket policy.
+pub const MAX_TCP_DESTINATION_RULES: usize = 64;
+
+/// An IPv4 network in canonical CIDR form.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Ipv4Cidr {
+    network: Ipv4Address,
+    prefix_length: u8,
+}
+
+impl Ipv4Cidr {
+    /// Creates a CIDR if the prefix is valid and the address has no host bits set.
+    #[must_use]
+    pub const fn new(network: Ipv4Address, prefix_length: u8) -> Option<Self> {
+        if prefix_length > 32 {
+            return None;
+        }
+        let mask = ipv4_prefix_mask(prefix_length);
+        if u32::from_be_bytes(network.0) & !mask != 0 {
+            return None;
+        }
+        Some(Self {
+            network,
+            prefix_length,
+        })
+    }
+
+    /// Returns the canonical network address.
+    #[must_use]
+    pub const fn network(self) -> Ipv4Address {
+        self.network
+    }
+
+    /// Returns the CIDR prefix length.
+    #[must_use]
+    pub const fn prefix_length(self) -> u8 {
+        self.prefix_length
+    }
+
+    const fn contains(self, address: Ipv4Address) -> bool {
+        let mask = ipv4_prefix_mask(self.prefix_length);
+        u32::from_be_bytes(address.0) & mask == u32::from_be_bytes(self.network.0)
+    }
+}
+
+const fn ipv4_prefix_mask(prefix_length: u8) -> u32 {
+    if prefix_length == 0 {
+        0
+    } else {
+        u32::MAX << (32 - prefix_length)
+    }
+}
+
+/// Inclusive nonzero TCP destination-port range.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TcpPortRange {
+    start: Port,
+    end: Port,
+}
+
+impl TcpPortRange {
+    /// Creates a nonempty range of valid TCP destination ports.
+    #[must_use]
+    pub const fn new(start: Port, end: Port) -> Option<Self> {
+        if start.0 == 0 || start.0 > end.0 {
+            return None;
+        }
+        Some(Self { start, end })
+    }
+
+    /// Returns the first allowed port.
+    #[must_use]
+    pub const fn start(self) -> Port {
+        self.start
+    }
+
+    /// Returns the last allowed port.
+    #[must_use]
+    pub const fn end(self) -> Port {
+        self.end
+    }
+
+    const fn contains(self, port: Port) -> bool {
+        self.start.0 <= port.0 && port.0 <= self.end.0
+    }
+}
+
+/// One static IPv4 TCP destination authorization rule.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TcpDestinationRule {
+    caller_credential: CallerCredential,
+    destination: Ipv4Cidr,
+    ports: TcpPortRange,
+}
+
+impl TcpDestinationRule {
+    /// Creates a rule for one caller, destination network, and port range.
+    #[must_use]
+    pub const fn new(
+        caller_credential: CallerCredential,
+        destination: Ipv4Cidr,
+        ports: TcpPortRange,
+    ) -> Self {
+        Self {
+            caller_credential,
+            destination,
+            ports,
+        }
+    }
+
+    /// Returns the caller authorized by this rule.
+    #[must_use]
+    pub const fn caller_credential(self) -> CallerCredential {
+        self.caller_credential
+    }
+
+    /// Returns the authorized destination network.
+    #[must_use]
+    pub const fn destination(self) -> Ipv4Cidr {
+        self.destination
+    }
+
+    /// Returns the authorized destination-port range.
+    #[must_use]
+    pub const fn ports(self) -> TcpPortRange {
+        self.ports
+    }
+
+    fn permits(self, caller_credential: CallerCredential, address: SocketAddressV4) -> bool {
+        self.caller_credential == caller_credential
+            && self.destination.contains(address.address)
+            && self.ports.contains(address.port)
+    }
+}
+
+const EMPTY_TCP_DESTINATION_RULE: TcpDestinationRule = TcpDestinationRule {
+    caller_credential: CallerCredential::Unauthenticated,
+    destination: Ipv4Cidr {
+        network: Ipv4Address([0, 0, 0, 0]),
+        prefix_length: 0,
+    },
+    ports: TcpPortRange {
+        start: Port(1),
+        end: Port(1),
+    },
 };
 
+/// Invalid socket-policy configuration.
+#[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SocketPolicyError {
+    /// The configured rule count exceeds [`MAX_TCP_DESTINATION_RULES`].
+    #[error("TCP destination policy has {actual} rules; maximum is {maximum}")]
+    TooManyRules {
+        /// Maximum supported rule count.
+        maximum: usize,
+        /// Requested rule count.
+        actual: usize,
+    },
+}
+
+/// Bounded static IPv4 TCP destination rules.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TcpDestinationPolicy {
+    tcp_destination_rules: [TcpDestinationRule; MAX_TCP_DESTINATION_RULES],
+    tcp_destination_rule_count: usize,
+}
+
+impl TcpDestinationPolicy {
+    const fn empty() -> Self {
+        Self {
+            tcp_destination_rules: [EMPTY_TCP_DESTINATION_RULE; MAX_TCP_DESTINATION_RULES],
+            tcp_destination_rule_count: 0,
+        }
+    }
+
+    /// Returns the configured TCP destination rules.
+    #[must_use]
+    pub fn rules(&self) -> &[TcpDestinationRule] {
+        &self.tcp_destination_rules[..self.tcp_destination_rule_count]
+    }
+}
+
 /// Network access available to broker-owned sockets.
-///
-/// This is separate from [`PolicyProfile`] because that profile grants generic
-/// object rights shared by events, pipes, and sockets. Granting those rights
-/// must not implicitly grant network access, so socket creation and destination
-/// restrictions are configured as an independent, default-deny policy axis.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[non_exhaustive]
+#[expect(
+    clippy::large_enum_variant,
+    reason = "fixed-capacity policy storage avoids infallible allocation in no_std configuration"
+)]
 pub enum SocketPolicy {
     /// Deny all socket creation and connection attempts.
     #[default]
     Deny,
     /// Allow IPv4 TCP sockets to connect only to the IPv4 loopback network.
     Ipv4LoopbackTcp,
+    /// Apply bounded caller, IPv4 CIDR, and destination-port rules.
+    TcpDestinationRules(TcpDestinationPolicy),
+}
+
+impl SocketPolicy {
+    /// Creates a bounded policy from static IPv4 TCP destination rules.
+    pub fn from_tcp_destination_rules(
+        rules: &[TcpDestinationRule],
+    ) -> Result<Self, SocketPolicyError> {
+        if rules.len() > MAX_TCP_DESTINATION_RULES {
+            return Err(SocketPolicyError::TooManyRules {
+                maximum: MAX_TCP_DESTINATION_RULES,
+                actual: rules.len(),
+            });
+        }
+        let mut policy = TcpDestinationPolicy::empty();
+        policy.tcp_destination_rules[..rules.len()].copy_from_slice(rules);
+        policy.tcp_destination_rule_count = rules.len();
+        Ok(Self::TcpDestinationRules(policy))
+    }
+
+    /// Returns the configured rules for a bounded destination policy.
+    #[must_use]
+    pub fn tcp_destination_rules(&self) -> Option<&[TcpDestinationRule]> {
+        match self {
+            Self::TcpDestinationRules(policy) => Some(policy.rules()),
+            Self::Deny | Self::Ipv4LoopbackTcp => None,
+        }
+    }
+
+    fn permits_tcp_socket(self, caller_credential: CallerCredential) -> bool {
+        match self {
+            Self::Deny => false,
+            Self::Ipv4LoopbackTcp => true,
+            Self::TcpDestinationRules(policy) => policy
+                .rules()
+                .iter()
+                .any(|rule| rule.caller_credential == caller_credential),
+        }
+    }
+
+    fn permits_tcp_destination(
+        self,
+        caller_credential: CallerCredential,
+        address: SocketAddressV4,
+    ) -> bool {
+        match self {
+            Self::Deny => false,
+            Self::Ipv4LoopbackTcp => address.address.0[0] == 127,
+            Self::TcpDestinationRules(policy) => policy
+                .rules()
+                .iter()
+                .any(|rule| rule.permits(caller_credential, address)),
+        }
+    }
 }
 
 /// Configured broker policy.
@@ -41,10 +279,6 @@ pub enum PolicyProfile {
 }
 
 /// Broker policy decision and audit component.
-///
-/// This initial engine is a placeholder static policy surface for the broker
-/// POC. A fuller policy model is intentionally deferred until the broker needs
-/// authenticated principals, richer rules, and audit integration.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PolicyEngine {
     profile: PolicyProfile,
@@ -105,29 +339,34 @@ impl PolicyEngine {
         request: CreateSocketRequest,
     ) -> Result<ObjectRights, BrokerError> {
         let rights = self.principal_object_rights(caller_credential)?;
-        match self.socket_policy {
-            SocketPolicy::Ipv4LoopbackTcp
-                if request.address_family == AddressFamily::Ipv4
-                    && request.socket_type == SocketType::Stream
-                    && request.protocol == IpProtocol::Tcp =>
-            {
-                Ok(rights)
-            }
-            SocketPolicy::Deny | SocketPolicy::Ipv4LoopbackTcp => Err(BrokerError::PolicyDenied),
+        if request.address_family == AddressFamily::Ipv4
+            && request.socket_type == SocketType::Stream
+            && request.protocol == IpProtocol::Tcp
+            && self.socket_policy.permits_tcp_socket(caller_credential)
+        {
+            Ok(rights)
+        } else {
+            Err(BrokerError::PolicyDenied)
         }
     }
 
     pub(crate) fn authorize_socket_connect(
         &self,
         caller_credential: CallerCredential,
+        request: CreateSocketRequest,
         address: SocketAddressV4,
     ) -> Result<(), BrokerError> {
         self.principal_object_rights(caller_credential)?;
-        match self.socket_policy {
-            // The initial loopback profile intentionally permits every port.
-            // Destination-port rules belong to the later Layer 3/4 policy.
-            SocketPolicy::Ipv4LoopbackTcp if address.address.0[0] == 127 => Ok(()),
-            SocketPolicy::Deny | SocketPolicy::Ipv4LoopbackTcp => Err(BrokerError::PolicyDenied),
+        if request.address_family == AddressFamily::Ipv4
+            && request.socket_type == SocketType::Stream
+            && request.protocol == IpProtocol::Tcp
+            && self
+                .socket_policy
+                .permits_tcp_destination(caller_credential, address)
+        {
+            Ok(())
+        } else {
+            Err(BrokerError::PolicyDenied)
         }
     }
 }
@@ -141,7 +380,27 @@ impl Default for PolicyEngine {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use litebox_broker_protocol::socket::{Ipv4Address, Port};
+
+    const IPV4_TCP: CreateSocketRequest = CreateSocketRequest {
+        address_family: AddressFamily::Ipv4,
+        socket_type: SocketType::Stream,
+        protocol: IpProtocol::Tcp,
+    };
+
+    fn cidr(address: [u8; 4], prefix_length: u8) -> Ipv4Cidr {
+        Ipv4Cidr::new(Ipv4Address(address), prefix_length).unwrap()
+    }
+
+    fn ports(start: u16, end: u16) -> TcpPortRange {
+        TcpPortRange::new(Port(start), Port(end)).unwrap()
+    }
+
+    fn address(address: [u8; 4], port: u16) -> SocketAddressV4 {
+        SocketAddressV4 {
+            address: Ipv4Address(address),
+            port: Port(port),
+        }
+    }
 
     #[test]
     fn static_policy_allows_configured_principal_rights() {
@@ -154,17 +413,7 @@ mod tests {
     }
 
     #[test]
-    fn static_policy_returns_configured_principal_rights() {
-        let policy = PolicyEngine::with_unauthenticated_rights(ObjectRights::WAIT);
-
-        assert_eq!(
-            policy.principal_object_rights(CallerCredential::Unauthenticated),
-            Ok(ObjectRights::WAIT)
-        );
-    }
-
-    #[test]
-    fn host_guaranteed_policy_returns_configured_principal_rights() {
+    fn host_guaranteed_policy_rejects_other_principals() {
         let policy = PolicyEngine::with_host_guaranteed_rights(ObjectRights::WAIT);
 
         assert_eq!(
@@ -191,41 +440,140 @@ mod tests {
     fn socket_policy_defaults_to_deny() {
         let policy = PolicyEngine::with_unauthenticated_rights(ObjectRights::all());
         assert_eq!(
-            policy.authorize_socket_create(
-                CallerCredential::Unauthenticated,
-                CreateSocketRequest {
-                    address_family: AddressFamily::Ipv4,
-                    socket_type: SocketType::Stream,
-                    protocol: IpProtocol::Tcp,
-                },
-            ),
+            policy.authorize_socket_create(CallerCredential::Unauthenticated, IPV4_TCP),
             Err(BrokerError::PolicyDenied)
         );
     }
 
     #[test]
-    fn loopback_socket_policy_rejects_non_loopback_destinations() {
+    fn cidr_requires_canonical_networks_and_matches_partial_bytes() {
+        assert_eq!(Ipv4Cidr::new(Ipv4Address([10, 0, 0, 0]), 33), None);
+        assert_eq!(Ipv4Cidr::new(Ipv4Address([10, 1, 0, 1]), 24), None);
+        assert_eq!(Ipv4Cidr::new(Ipv4Address([10, 8, 0, 1]), 13), None);
+
+        let all = cidr([0, 0, 0, 0], 0);
+        assert!(all.contains(Ipv4Address([203, 0, 113, 9])));
+
+        let network = cidr([10, 8, 0, 0], 13);
+        assert!(network.contains(Ipv4Address([10, 15, 255, 255])));
+        assert!(!network.contains(Ipv4Address([10, 16, 0, 0])));
+
+        let host = cidr([192, 0, 2, 7], 32);
+        assert!(host.contains(Ipv4Address([192, 0, 2, 7])));
+        assert!(!host.contains(Ipv4Address([192, 0, 2, 8])));
+    }
+
+    #[test]
+    fn port_ranges_are_nonzero_ordered_and_inclusive() {
+        assert_eq!(TcpPortRange::new(Port(0), Port(80)), None);
+        assert_eq!(TcpPortRange::new(Port(81), Port(80)), None);
+
+        let range = ports(443, 444);
+        assert!(!range.contains(Port(442)));
+        assert!(range.contains(Port(443)));
+        assert!(range.contains(Port(444)));
+        assert!(!range.contains(Port(445)));
+    }
+
+    #[test]
+    fn destination_policy_is_bounded() {
+        let rule = TcpDestinationRule::new(
+            CallerCredential::Unauthenticated,
+            cidr([127, 0, 0, 0], 8),
+            ports(1, u16::MAX),
+        );
+        let maximum = [rule; MAX_TCP_DESTINATION_RULES];
+        assert_eq!(
+            SocketPolicy::from_tcp_destination_rules(&maximum)
+                .unwrap()
+                .tcp_destination_rules()
+                .unwrap(),
+            &maximum
+        );
+
+        let excessive = [rule; MAX_TCP_DESTINATION_RULES + 1];
+        assert_eq!(
+            SocketPolicy::from_tcp_destination_rules(&excessive),
+            Err(SocketPolicyError::TooManyRules {
+                maximum: MAX_TCP_DESTINATION_RULES,
+                actual: MAX_TCP_DESTINATION_RULES + 1,
+            })
+        );
+    }
+
+    #[test]
+    fn destination_rules_enforce_principal_cidr_and_port() {
+        let socket_policy = SocketPolicy::from_tcp_destination_rules(&[
+            TcpDestinationRule::new(
+                CallerCredential::Unauthenticated,
+                cidr([10, 8, 0, 0], 13),
+                ports(443, 444),
+            ),
+            TcpDestinationRule::new(
+                CallerCredential::HostGuaranteed,
+                cidr([192, 0, 2, 7], 32),
+                ports(8443, 8443),
+            ),
+        ])
+        .unwrap();
+        let unauthenticated = PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
+            .with_socket_policy(socket_policy);
+        assert_eq!(
+            unauthenticated.authorize_socket_create(CallerCredential::Unauthenticated, IPV4_TCP),
+            Ok(ObjectRights::all())
+        );
+        assert_eq!(
+            unauthenticated.authorize_socket_connect(
+                CallerCredential::Unauthenticated,
+                IPV4_TCP,
+                address([10, 15, 0, 1], 443),
+            ),
+            Ok(())
+        );
+        for denied in [
+            address([10, 16, 0, 1], 443),
+            address([10, 15, 0, 1], 445),
+            address([192, 0, 2, 7], 8443),
+            address([10, 15, 0, 1], 0),
+        ] {
+            assert_eq!(
+                unauthenticated.authorize_socket_connect(
+                    CallerCredential::Unauthenticated,
+                    IPV4_TCP,
+                    denied,
+                ),
+                Err(BrokerError::PolicyDenied)
+            );
+        }
+    }
+
+    #[test]
+    fn loopback_policy_preserves_initial_production_scope() {
         let policy = PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
             .with_socket_policy(SocketPolicy::Ipv4LoopbackTcp);
         assert_eq!(
             policy.authorize_socket_connect(
                 CallerCredential::Unauthenticated,
-                SocketAddressV4 {
-                    address: Ipv4Address([127, 0, 0, 1]),
-                    port: Port(80),
-                },
+                IPV4_TCP,
+                address([127, 255, 0, 1], 80),
             ),
             Ok(())
         );
         assert_eq!(
             policy.authorize_socket_connect(
                 CallerCredential::Unauthenticated,
-                SocketAddressV4 {
-                    address: Ipv4Address([10, 0, 0, 1]),
-                    port: Port(80),
-                },
+                IPV4_TCP,
+                address([10, 0, 0, 1], 80),
             ),
             Err(BrokerError::PolicyDenied)
+        );
+        assert_eq!(
+            policy.authorize_socket_connect(
+                CallerCredential::Unauthenticated,
+                IPV4_TCP,
+                address([127, 0, 0, 1], 0),
+            ),
+            Ok(())
         );
     }
 }

--- a/litebox_broker_core/src/socket.rs
+++ b/litebox_broker_core/src/socket.rs
@@ -139,7 +139,7 @@ pub fn create(
         }
     };
     resource.platform_socket.call_once(|| platform_socket);
-    let handle = reference.commit(ObjectEntry::Socket(SocketObject::new(resource)))?;
+    let handle = reference.commit(ObjectEntry::Socket(SocketObject::new(resource, request)))?;
     Ok(handle)
 }
 
@@ -154,20 +154,21 @@ pub fn connect(
     address: SocketAddressV4,
 ) -> Result<SocketOutcome<SocketConnectionStatus>> {
     let object = session.authorized_object(handle, ObjectRights::WRITE)?;
-    {
+    let create_request = {
         let object = object.read();
-        let ObjectEntry::Socket(_) = &*object else {
+        let ObjectEntry::Socket(socket) = &*object else {
             return Err(BrokerError::InvalidRights);
         };
-    }
+        socket.create_request
+    };
 
     // Destination denial is an operation-level socket failure. Failures while
     // evaluating policy remain broker errors.
-    match session
-        .core
-        .policy
-        .authorize_socket_connect(session.caller_credential, address)
-    {
+    match session.core.policy.authorize_socket_connect(
+        session.caller_credential,
+        create_request,
+        address,
+    ) {
         Ok(()) => {}
         Err(BrokerError::PolicyDenied) => {
             return Ok(SocketOutcome::Failed(SocketError::PolicyDenied));
@@ -354,15 +355,17 @@ fn finish_connect(object: &spin::RwLock<ObjectEntry>, status: SocketConnectionSt
 
 pub(crate) struct SocketObject {
     resource: Arc<SocketResource>,
+    create_request: CreateSocketRequest,
     connection_status: SocketConnectionStatus,
     local_address: Option<SocketAddressV4>,
     connect_in_flight: bool,
 }
 
 impl SocketObject {
-    fn new(resource: Arc<SocketResource>) -> Self {
+    fn new(resource: Arc<SocketResource>, create_request: CreateSocketRequest) -> Self {
         Self {
             resource,
+            create_request,
             connection_status: SocketConnectionStatus::Unconnected,
             local_address: None,
             connect_in_flight: false,


### PR DESCRIPTION
This PR adds an allocation-free, default-deny TCP destination policy with a fixed maximum of 64 caller, IPv4 CIDR, and destination-port rules while preserving the existing deny and loopback policy variants. It also shares immutable policy state across broker sessions and binds connect authorization to each socket's trusted IPv4 stream TCP creation tuple; production remains loopback-only.