### PR TITLE
Enable configured broker TCP egress

### DIFF
--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -4,9 +4,11 @@
 use std::error::Error;
 use std::ffi::OsString;
 use std::io::{Error as IoError, ErrorKind, Result as IoResult};
+use std::net::Ipv4Addr;
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::PathBuf;
 use std::process::{Child, Command};
+use std::str::FromStr;
 use std::sync::mpsc::{Receiver, SyncSender, sync_channel};
 use std::sync::{
     Arc, Mutex,
@@ -15,11 +17,15 @@ use std::sync::{
 use std::time::{Duration, Instant};
 
 use clap::Parser;
-use litebox_broker_core::{BrokerCore, BrokerCoreLimits, ObjectRights, PolicyEngine, SocketPolicy};
+use litebox_broker_core::{
+    BrokerCore, BrokerCoreLimits, CallerCredential, Ipv4Cidr, ObjectRights, PolicyEngine,
+    SocketPolicy, SocketPolicyError, TcpDestinationRule, TcpPortRange,
+};
 use litebox_broker_host::{BrokerHostAssociation, ConnectionTermination, setup_connection};
 use litebox_broker_platform_linux_userland::LinuxSocketProvider;
 use litebox_broker_protocol::message::BrokerRequest;
 use litebox_broker_protocol::shared_buffer::{SHARED_BUFFER_LAYOUT, SHARED_BUFFER_POOL_SIZE};
+use litebox_broker_protocol::socket::{Ipv4Address, Port};
 use litebox_broker_transport::channel::HostReceive;
 use litebox_broker_transport::control_ring::{CONTROL_RING_MEMORY_SIZE, ControlRing};
 use litebox_broker_transport::shared_memory::{SharedBufferPool, SharedMemory};
@@ -36,8 +42,57 @@ const ACCEPT_RETRY_DELAY: Duration = Duration::from_millis(10);
 const REQUEST_QUEUE_CAPACITY: usize = 64;
 const WORKER_COUNT: usize = 8;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct AllowedTcpDestination {
+    destination: Ipv4Cidr,
+    ports: TcpPortRange,
+}
+
+impl FromStr for AllowedTcpDestination {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let (cidr, ports) = value
+            .rsplit_once(':')
+            .ok_or_else(|| "expected CIDR:PORT or CIDR:START-END".to_owned())?;
+        let (network, prefix_length) = cidr
+            .split_once('/')
+            .ok_or_else(|| "destination must include an IPv4 CIDR prefix".to_owned())?;
+        let network = network
+            .parse::<Ipv4Addr>()
+            .map_err(|error| format!("invalid IPv4 network: {error}"))?;
+        let prefix_length = prefix_length
+            .parse::<u8>()
+            .map_err(|error| format!("invalid IPv4 prefix length: {error}"))?;
+        let destination =
+            Ipv4Cidr::new(Ipv4Address(network.octets()), prefix_length).ok_or_else(|| {
+                "IPv4 CIDR must have a valid prefix and canonical network address".to_owned()
+            })?;
+
+        let (start, end) = ports
+            .split_once('-')
+            .map_or((ports, ports), |(start, end)| (start, end));
+        let start = start
+            .parse::<u16>()
+            .map_err(|error| format!("invalid TCP port: {error}"))?;
+        let end = end
+            .parse::<u16>()
+            .map_err(|error| format!("invalid TCP port: {error}"))?;
+        let ports = TcpPortRange::new(Port(start), Port(end))
+            .ok_or_else(|| "TCP port range must be ordered and exclude port zero".to_owned())?;
+
+        Ok(Self { destination, ports })
+    }
+}
+
 #[derive(Parser, Debug)]
 struct CliArgs {
+    /// Permit outbound TCP connections to a destination CIDR and port range.
+    ///
+    /// May be repeated. Supplying any rule replaces the default loopback-only policy.
+    /// `0.0.0.0/0:1-65535` permits every nonzero IPv4 TCP destination.
+    #[arg(long, value_name = "CIDR:PORT[-PORT]")]
+    allow_tcp_destination: Vec<AllowedTcpDestination>,
     /// Local runner executable to launch.
     #[arg(long, value_name = "PATH", value_hint = clap::ValueHint::ExecutablePath)]
     runner: PathBuf,
@@ -57,7 +112,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let limits = BrokerCoreLimits::DEFAULT;
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_host_guaranteed_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4LoopbackTcp),
+            .with_socket_policy(configured_socket_policy(&args.allow_tcp_destination)?),
         limits,
         Arc::new(LinuxSocketProvider::new(limits.max_sockets)?),
     )?;
@@ -82,6 +137,25 @@ fn main() -> Result<(), Box<dyn Error>> {
         return Err(IoError::other(format!("runner exited with {runner_status}")).into());
     }
     Ok(())
+}
+
+fn configured_socket_policy(
+    allowed_destinations: &[AllowedTcpDestination],
+) -> Result<SocketPolicy, SocketPolicyError> {
+    if allowed_destinations.is_empty() {
+        return Ok(SocketPolicy::Ipv4LoopbackTcp);
+    }
+    let rules = allowed_destinations
+        .iter()
+        .map(|allowed| {
+            TcpDestinationRule::new(
+                CallerCredential::HostGuaranteed,
+                allowed.destination,
+                allowed.ports,
+            )
+        })
+        .collect::<Vec<_>>();
+    SocketPolicy::from_tcp_destination_rules(&rules)
 }
 
 fn serve_runner(
@@ -461,6 +535,48 @@ mod tests {
         UnixControlRingLocalShutdown, UnixStreamLocalSetupChannel,
     };
     use std::os::fd::AsFd;
+
+    #[test]
+    fn tcp_destination_argument_parses_canonical_cidr_and_ports() {
+        let allowed = "203.0.113.0/24:443-444"
+            .parse::<AllowedTcpDestination>()
+            .unwrap();
+
+        assert_eq!(
+            allowed,
+            AllowedTcpDestination {
+                destination: Ipv4Cidr::new(Ipv4Address([203, 0, 113, 0]), 24).unwrap(),
+                ports: TcpPortRange::new(Port(443), Port(444)).unwrap(),
+            }
+        );
+        assert!(
+            "203.0.113.1/24:443"
+                .parse::<AllowedTcpDestination>()
+                .is_err()
+        );
+        assert!("203.0.113.0/24:0".parse::<AllowedTcpDestination>().is_err());
+    }
+
+    #[test]
+    fn tcp_destination_arguments_replace_the_loopback_default() {
+        assert_eq!(
+            configured_socket_policy(&[]).unwrap(),
+            SocketPolicy::Ipv4LoopbackTcp
+        );
+
+        let allowed = "0.0.0.0/0:80".parse::<AllowedTcpDestination>().unwrap();
+        let policy = configured_socket_policy(&[allowed]).unwrap();
+        let rules = policy.tcp_destination_rules().unwrap();
+        assert_eq!(rules.len(), 1);
+        assert_eq!(
+            rules[0],
+            TcpDestinationRule::new(
+                CallerCredential::HostGuaranteed,
+                allowed.destination,
+                allowed.ports,
+            )
+        );
+    }
 
     /// One live host association: the endpoints teardown acts on, and the rest
     /// held open so the association stays up for the duration of a test.

--- a/litebox_broker_userland/tests/userland_broker.rs
+++ b/litebox_broker_userland/tests/userland_broker.rs
@@ -17,6 +17,7 @@ use litebox_broker_transport::control_ring::{CONTROL_RING_MEMORY_SIZE, ControlRi
 use litebox_broker_transport_linux_userland::unix_socket::UnixStreamLocalSetupChannel;
 
 const RUNNER_ARGUMENT: &str = "broker-userland-test-runner";
+const NETWORK_RUNNER_ARGUMENT: &str = "broker-userland-network-test-runner";
 
 fn main() {
     let args = std::env::args_os().skip(1).collect::<Vec<_>>();
@@ -39,13 +40,42 @@ fn run_parent_test() {
     // the fake runner finishes its broker requests, it terminates the broker
     // parent process; this lets the test exercise the long-running broker
     // without a test-only shutdown path.
+    let mut event_command = Command::new(env!("CARGO_BIN_EXE_litebox-broker-userland"));
+    event_command
+        .arg("--runner")
+        .arg(std::env::current_exe().unwrap())
+        .arg(RUNNER_ARGUMENT);
+    wait_for_broker(event_command);
+
+    let probe = std::net::UdpSocket::bind((std::net::Ipv4Addr::UNSPECIFIED, 0)).unwrap();
+    probe
+        .connect((std::net::Ipv4Addr::new(192, 0, 2, 1), 9))
+        .unwrap();
+    let std::net::IpAddr::V4(host_address) = probe.local_addr().unwrap().ip() else {
+        panic!("IPv4 route probe returned an IPv6 address");
+    };
+    assert!(!host_address.is_loopback() && !host_address.is_unspecified());
+
+    let listener = std::net::TcpListener::bind((host_address, 0)).unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let mut network_command = Command::new(env!("CARGO_BIN_EXE_litebox-broker-userland"));
+    network_command
+        .arg("--allow-tcp-destination")
+        .arg(format!("{host_address}/32:{port}"))
+        .arg("--runner")
+        .arg(std::env::current_exe().unwrap())
+        .arg(NETWORK_RUNNER_ARGUMENT)
+        .arg(host_address.to_string())
+        .arg(port.to_string());
+    wait_for_broker(network_command);
+
+    let (_stream, peer_address) = listener.accept().unwrap();
+    assert_eq!(peer_address.ip(), host_address);
+}
+
+fn wait_for_broker(mut command: Command) {
     let mut broker = ChildGuard {
-        child: Command::new(env!("CARGO_BIN_EXE_litebox-broker-userland"))
-            .arg("--runner")
-            .arg(std::env::current_exe().unwrap())
-            .arg(RUNNER_ARGUMENT)
-            .spawn()
-            .unwrap(),
+        child: command.spawn().unwrap(),
     };
 
     let deadline = Instant::now() + Duration::from_secs(5);
@@ -68,11 +98,6 @@ fn run_fake_runner(args: &[OsString]) {
         args.get(1).map(OsString::as_os_str),
         Some(OsStr::new("--broker-control-socket"))
     );
-    assert_eq!(
-        args.get(3).map(OsString::as_os_str),
-        Some(OsStr::new(RUNNER_ARGUMENT))
-    );
-    assert_eq!(args.len(), 4, "unexpected runner arguments: {args:?}");
 
     let control_socket_path = args.get(2).unwrap();
     let setup_channel = connect_control_with_retry(Path::new(control_socket_path)).unwrap();
@@ -96,6 +121,44 @@ fn run_fake_runner(args: &[OsString]) {
     })
     .unwrap();
     let local = Arc::new(local);
+
+    if args.get(3).and_then(|argument| argument.to_str()) == Some(NETWORK_RUNNER_ARGUMENT) {
+        use litebox_broker_protocol::socket::{
+            Ipv4Address, Port, SocketAddressV4, SocketConnectionStatus,
+        };
+
+        assert_eq!(args.len(), 6, "unexpected runner arguments: {args:?}");
+        let address = args[4]
+            .to_str()
+            .unwrap()
+            .parse::<std::net::Ipv4Addr>()
+            .unwrap();
+        let port = args[5].to_str().unwrap().parse::<u16>().unwrap();
+        let handle = local.create_tcp_socket().unwrap();
+        let mut status = local
+            .connect_socket(
+                handle,
+                SocketAddressV4 {
+                    address: Ipv4Address(address.octets()),
+                    port: Port(port),
+                },
+            )
+            .unwrap()
+            .unwrap();
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while status == SocketConnectionStatus::Connecting && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(10));
+            status = local.socket_status(handle).unwrap().status;
+        }
+        assert_eq!(status, SocketConnectionStatus::Connected);
+        local.close_object(handle).unwrap();
+        return;
+    }
+    assert_eq!(
+        args.get(3).map(OsString::as_os_str),
+        Some(OsStr::new(RUNNER_ARGUMENT))
+    );
+    assert_eq!(args.len(), 4, "unexpected runner arguments: {args:?}");
 
     let start = Arc::new(std::sync::Barrier::new(17));
     let callers = (0..16)

--- a/litebox_broker_userland/tests/userland_broker.rs
+++ b/litebox_broker_userland/tests/userland_broker.rs
@@ -47,16 +47,9 @@ fn run_parent_test() {
         .arg(RUNNER_ARGUMENT);
     wait_for_broker(event_command);
 
-    let probe = std::net::UdpSocket::bind((std::net::Ipv4Addr::UNSPECIFIED, 0)).unwrap();
-    probe
-        .connect((std::net::Ipv4Addr::new(192, 0, 2, 1), 9))
-        .unwrap();
-    let std::net::IpAddr::V4(host_address) = probe.local_addr().unwrap().ip() else {
-        panic!("IPv4 route probe returned an IPv6 address");
+    let Some((host_address, listener)) = non_loopback_listener() else {
+        return;
     };
-    assert!(!host_address.is_loopback() && !host_address.is_unspecified());
-
-    let listener = std::net::TcpListener::bind((host_address, 0)).unwrap();
     let port = listener.local_addr().unwrap().port();
     let mut network_command = Command::new(env!("CARGO_BIN_EXE_litebox-broker-userland"));
     network_command
@@ -71,6 +64,30 @@ fn run_parent_test() {
 
     let (_stream, peer_address) = listener.accept().unwrap();
     assert_eq!(peer_address.ip(), host_address);
+}
+
+fn non_loopback_listener() -> Option<(std::net::Ipv4Addr, std::net::TcpListener)> {
+    let probe = std::net::UdpSocket::bind((std::net::Ipv4Addr::UNSPECIFIED, 0)).unwrap();
+    if let Err(error) = probe.connect((std::net::Ipv4Addr::new(192, 0, 2, 1), 9)) {
+        eprintln!("skipping non-loopback broker TCP test: IPv4 route unavailable: {error}");
+        return None;
+    }
+    let std::net::IpAddr::V4(host_address) = probe.local_addr().unwrap().ip() else {
+        unreachable!("an IPv4 route probe must select an IPv4 source address");
+    };
+    if host_address.is_loopback() || host_address.is_unspecified() {
+        eprintln!(
+            "skipping non-loopback broker TCP test: route selected unusable address {host_address}"
+        );
+        return None;
+    }
+    match std::net::TcpListener::bind((host_address, 0)) {
+        Ok(listener) => Some((host_address, listener)),
+        Err(error) => {
+            eprintln!("skipping non-loopback broker TCP test: cannot bind {host_address}: {error}");
+            None
+        }
+    }
 }
 
 fn wait_for_broker(mut command: Command) {


### PR DESCRIPTION
This PR adds a repeatable `--allow-tcp-destination CIDR:PORT[-PORT]` option to enable explicitly authorized non-loopback IPv4 TCP egress while retaining the existing loopback-only behavior when no rules are supplied. It validates canonical CIDRs and nonzero port ranges, binds configured rules to the host-guaranteed caller, and adds an end-to-end production-broker test against a routed non-loopback endpoint without depending on an external internet service.