### PR TITLE
Stabilize broker TCP reset test

### DIFF
--- a/litebox_runner_linux_userland/tests/run.rs
+++ b/litebox_runner_linux_userland/tests/run.rs
@@ -599,6 +599,9 @@ fn test_runner_broker_tcp_client_with_rewriter() {
             drop(reset_stream);
         }
         let (mut partial_reset_stream, _) = listener.accept().unwrap();
+        let mut connected = [0; 1];
+        partial_reset_stream.read_exact(&mut connected).unwrap();
+        assert_eq!(connected, [0x4c]);
         partial_reset_stream.write_all(&[0x7e]).unwrap();
         // SAFETY: `partial_reset_stream` owns a live socket and `linger` is valid for the supplied length.
         assert_eq!(

--- a/litebox_runner_linux_userland/tests/tcp_broker.c
+++ b/litebox_runner_linux_userland/tests/tcp_broker.c
@@ -244,6 +244,9 @@ int main(int argc, char **argv) {
     fd = socket(AF_INET, SOCK_STREAM | SOCK_CLOEXEC, 0);
     assert(fd >= 0);
     assert(connect(fd, (const struct sockaddr *)&address, sizeof(address)) == 0);
+    unsigned char partial_ready = 0x4c;
+    assert(send(fd, &partial_ready, sizeof(partial_ready), MSG_NOSIGNAL) ==
+           sizeof(partial_ready));
     unsigned char partial_reset[2];
     assert(recv(fd, partial_reset, sizeof(partial_reset), MSG_WAITALL) == 1);
     assert(partial_reset[0] == 0x7e);


### PR DESCRIPTION
This PR removes a timing race from the broker TCP partial-read/reset test by adding a one-byte client/server barrier after the guest connect completes and before the server sends data and performs an abortive close. Without the barrier, the reset could reach the broker reactor before it recorded connect completion, causing the blocking connect to return `ECONNRESET`.