### PR TITLE
Increase broker shared-buffer slots to 64 KiB

### DIFF
--- a/litebox_broker_protocol/src/pipe.rs
+++ b/litebox_broker_protocol/src/pipe.rs
@@ -8,8 +8,11 @@ use crate::shared_buffer::{SHARED_BUFFER_SLOT_SIZE, SharedBufferDescriptor};
 ///
 /// One transfer occupies at most one association shared-buffer slot. Larger
 /// blocking writes are split across requests, while reads may return at most
-/// this amount.
-pub const MAX_PIPE_TRANSFER_SIZE: u32 = SHARED_BUFFER_SLOT_SIZE;
+/// this amount. This remains independent of slot capacity so increasing the
+/// shared-buffer layout does not change pipe behavior.
+pub const MAX_PIPE_TRANSFER_SIZE: u32 = 32 * 1024;
+
+const _: () = assert!(MAX_PIPE_TRANSFER_SIZE <= SHARED_BUFFER_SLOT_SIZE);
 
 /// Request to create a broker-owned byte pipe.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/litebox_broker_protocol/src/shared_buffer.rs
+++ b/litebox_broker_protocol/src/shared_buffer.rs
@@ -14,7 +14,7 @@ use core::ops::Range;
 use thiserror::Error;
 
 /// Size of each association shared-buffer slot.
-pub const SHARED_BUFFER_SLOT_SIZE: u32 = 32 * 1024;
+pub const SHARED_BUFFER_SLOT_SIZE: u32 = 64 * 1024;
 
 /// Number of slots in one association shared-buffer pool.
 pub const SHARED_BUFFER_SLOT_COUNT: u32 = 16;
@@ -131,9 +131,15 @@ mod tests {
 
     #[test]
     fn association_layout_has_expected_size() {
-        assert_eq!(SHARED_BUFFER_LAYOUT.slot_size(), 32 * 1024);
+        assert_eq!(SHARED_BUFFER_LAYOUT.slot_size(), 64 * 1024);
         assert_eq!(SHARED_BUFFER_LAYOUT.slot_count(), 16);
-        assert_eq!(SHARED_BUFFER_POOL_SIZE, 512 * 1024);
+        assert_eq!(SHARED_BUFFER_POOL_SIZE, 1024 * 1024);
+    }
+
+    #[test]
+    fn larger_slots_do_not_change_existing_transfer_limits() {
+        assert_eq!(crate::pipe::MAX_PIPE_TRANSFER_SIZE, 32 * 1024);
+        assert_eq!(crate::socket::MAX_SOCKET_TRANSFER_SIZE, 32 * 1024);
     }
 
     #[test]

--- a/litebox_broker_protocol/src/socket.rs
+++ b/litebox_broker_protocol/src/socket.rs
@@ -16,7 +16,13 @@ use crate::shared_buffer::{SHARED_BUFFER_SLOT_SIZE, SharedBufferDescriptor};
 use thiserror::Error;
 
 /// Maximum socket bytes transferred by one broker request.
-pub const MAX_SOCKET_TRANSFER_SIZE: u32 = SHARED_BUFFER_SLOT_SIZE;
+///
+/// This remains independent of slot capacity so increasing the shared-buffer
+/// layout does not change existing TCP behavior.
+pub const MAX_SOCKET_TRANSFER_SIZE: u32 = 32 * 1024;
+
+const _: () = assert!(MAX_SOCKET_TRANSFER_SIZE <= SHARED_BUFFER_SLOT_SIZE);
+
 /// Maximum stream prefix addressable by offset-based peek requests.
 pub const MAX_SOCKET_PEEK_SIZE: u32 = 0x80_000;
 /// Maximum TCP listen backlog accepted by the broker protocol.


### PR DESCRIPTION
This PR prepares brokered UDP by increasing each of the 16 association shared-buffer slots from 32 KiB to 64 KiB, expanding the payload pool from 512 KiB to 1 MiB, while decoupling and pinning the existing pipe and TCP per-request transfer limits at 32 KiB; compile-time guards and protocol tests ensure current behavior remains unchanged and every transfer still fits within one slot.