### PR TITLE
Add broker IPv4 UDP support

### DIFF
--- a/litebox_broker_core/src/lib.rs
+++ b/litebox_broker_core/src/lib.rs
@@ -35,9 +35,9 @@ use spin::rwlock::RwLock;
 
 pub use error::BrokerError;
 pub use policy::{
-    Ipv4Cidr, MAX_TCP_DESTINATION_RULES, MAX_UDP_DESTINATION_RULES, PolicyEngine, PolicyProfile,
-    SocketPolicy, SocketPolicyError, TcpDestinationPolicy, TcpDestinationRule, TcpPortRange,
-    UdpDestinationPolicy, UdpDestinationRule, UdpPortRange,
+    DestinationPortRange, Ipv4Cidr, MAX_TCP_DESTINATION_RULES, MAX_UDP_DESTINATION_RULES,
+    PolicyEngine, PolicyProfile, SocketPolicy, SocketPolicyError, TcpDestinationPolicy,
+    TcpDestinationRule, UdpDestinationPolicy, UdpDestinationRule,
 };
 use session::ObjectReference;
 pub use session::{BrokerSession, CallerCredential, ObjectRights, SessionId};

--- a/litebox_broker_core/src/lib.rs
+++ b/litebox_broker_core/src/lib.rs
@@ -35,9 +35,8 @@ use spin::rwlock::RwLock;
 
 pub use error::BrokerError;
 pub use policy::{
-    DestinationPortRange, DestinationRule, Ipv4Cidr, MAX_TCP_DESTINATION_RULES,
-    MAX_UDP_DESTINATION_RULES, PolicyEngine, PolicyProfile, SocketPolicy, SocketPolicyError,
-    TcpDestinationPolicy, UdpDestinationPolicy,
+    DestinationPolicy, DestinationPortRange, DestinationRule, Ipv4Cidr, MAX_DESTINATION_RULES,
+    PolicyEngine, PolicyProfile, SocketPolicy, SocketPolicyError,
 };
 use session::ObjectReference;
 pub use session::{BrokerSession, CallerCredential, ObjectRights, SessionId};

--- a/litebox_broker_core/src/lib.rs
+++ b/litebox_broker_core/src/lib.rs
@@ -35,9 +35,9 @@ use spin::rwlock::RwLock;
 
 pub use error::BrokerError;
 pub use policy::{
-    DestinationPortRange, Ipv4Cidr, MAX_TCP_DESTINATION_RULES, MAX_UDP_DESTINATION_RULES,
-    PolicyEngine, PolicyProfile, SocketPolicy, SocketPolicyError, TcpDestinationPolicy,
-    TcpDestinationRule, UdpDestinationPolicy, UdpDestinationRule,
+    DestinationPortRange, DestinationRule, Ipv4Cidr, MAX_TCP_DESTINATION_RULES,
+    MAX_UDP_DESTINATION_RULES, PolicyEngine, PolicyProfile, SocketPolicy, SocketPolicyError,
+    TcpDestinationPolicy, UdpDestinationPolicy,
 };
 use session::ObjectReference;
 pub use session::{BrokerSession, CallerCredential, ObjectRights, SessionId};

--- a/litebox_broker_core/src/lib.rs
+++ b/litebox_broker_core/src/lib.rs
@@ -35,8 +35,9 @@ use spin::rwlock::RwLock;
 
 pub use error::BrokerError;
 pub use policy::{
-    Ipv4Cidr, MAX_TCP_DESTINATION_RULES, PolicyEngine, PolicyProfile, SocketPolicy,
-    SocketPolicyError, TcpDestinationPolicy, TcpDestinationRule, TcpPortRange,
+    Ipv4Cidr, MAX_TCP_DESTINATION_RULES, MAX_UDP_DESTINATION_RULES, PolicyEngine, PolicyProfile,
+    SocketPolicy, SocketPolicyError, TcpDestinationPolicy, TcpDestinationRule, TcpPortRange,
+    UdpDestinationPolicy, UdpDestinationRule, UdpPortRange,
 };
 use session::ObjectReference;
 pub use session::{BrokerSession, CallerCredential, ObjectRights, SessionId};

--- a/litebox_broker_core/src/policy.rs
+++ b/litebox_broker_core/src/policy.rs
@@ -11,6 +11,8 @@ use thiserror::Error;
 
 /// Maximum number of TCP destination rules in one socket policy.
 pub const MAX_TCP_DESTINATION_RULES: usize = 64;
+/// Maximum number of UDP destination rules in one socket policy.
+pub const MAX_UDP_DESTINATION_RULES: usize = 64;
 
 /// An IPv4 network in canonical CIDR form.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -62,15 +64,18 @@ const fn ipv4_prefix_mask(prefix_length: u8) -> u32 {
     }
 }
 
-/// Inclusive nonzero TCP destination-port range.
+/// Inclusive nonzero transport destination-port range.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct TcpPortRange {
     start: Port,
     end: Port,
 }
 
+/// Inclusive nonzero UDP destination-port range.
+pub type UdpPortRange = TcpPortRange;
+
 impl TcpPortRange {
-    /// Creates a nonempty range of valid TCP destination ports.
+    /// Creates a nonempty range of valid transport destination ports.
     #[must_use]
     pub const fn new(start: Port, end: Port) -> Option<Self> {
         if start.0 == 0 || start.0 > end.0 {
@@ -146,6 +151,56 @@ impl TcpDestinationRule {
     }
 }
 
+/// One static IPv4 UDP destination authorization rule.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct UdpDestinationRule {
+    caller_credential: CallerCredential,
+    destination: Ipv4Cidr,
+    ports: UdpPortRange,
+}
+
+impl UdpDestinationRule {
+    /// Creates a rule for one caller, destination network, and port range.
+    #[must_use]
+    pub const fn new(
+        caller_credential: CallerCredential,
+        destination: Ipv4Cidr,
+        ports: UdpPortRange,
+    ) -> Self {
+        Self {
+            caller_credential,
+            destination,
+            ports,
+        }
+    }
+
+    /// Returns the caller authorized by this rule.
+    #[must_use]
+    pub const fn caller_credential(self) -> CallerCredential {
+        self.caller_credential
+    }
+
+    /// Returns the authorized destination network.
+    #[must_use]
+    pub const fn destination(self) -> Ipv4Cidr {
+        self.destination
+    }
+
+    /// Returns the authorized destination-port range.
+    #[must_use]
+    pub const fn ports(self) -> UdpPortRange {
+        self.ports
+    }
+
+    fn permits(self, caller_credential: CallerCredential, address: SocketAddrV4) -> bool {
+        self.caller_credential == caller_credential
+            && self
+                .destination
+                .contains(Ipv4Address(address.ip().octets()))
+            && self.ports.contains(Port(address.port()))
+    }
+}
+
 const EMPTY_TCP_DESTINATION_RULE: TcpDestinationRule = TcpDestinationRule {
     caller_credential: CallerCredential::Unauthenticated,
     destination: Ipv4Cidr {
@@ -158,6 +213,18 @@ const EMPTY_TCP_DESTINATION_RULE: TcpDestinationRule = TcpDestinationRule {
     },
 };
 
+const EMPTY_UDP_DESTINATION_RULE: UdpDestinationRule = UdpDestinationRule {
+    caller_credential: CallerCredential::Unauthenticated,
+    destination: Ipv4Cidr {
+        network: Ipv4Address([0, 0, 0, 0]),
+        prefix_length: 0,
+    },
+    ports: UdpPortRange {
+        start: Port(1),
+        end: Port(1),
+    },
+};
+
 /// Invalid socket-policy configuration.
 #[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
 #[non_exhaustive]
@@ -165,6 +232,14 @@ pub enum SocketPolicyError {
     /// The configured rule count exceeds [`MAX_TCP_DESTINATION_RULES`].
     #[error("TCP destination policy has {actual} rules; maximum is {maximum}")]
     TooManyRules {
+        /// Maximum supported rule count.
+        maximum: usize,
+        /// Requested rule count.
+        actual: usize,
+    },
+    /// The configured rule count exceeds [`MAX_UDP_DESTINATION_RULES`].
+    #[error("UDP destination policy has {actual} rules; maximum is {maximum}")]
+    TooManyUdpRules {
         /// Maximum supported rule count.
         maximum: usize,
         /// Requested rule count.
@@ -194,11 +269,32 @@ impl TcpDestinationPolicy {
     }
 }
 
+/// Bounded static IPv4 UDP destination rules.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct UdpDestinationPolicy {
+    udp_destination_rules: [UdpDestinationRule; MAX_UDP_DESTINATION_RULES],
+    udp_destination_rule_count: usize,
+}
+
+impl UdpDestinationPolicy {
+    const fn empty() -> Self {
+        Self {
+            udp_destination_rules: [EMPTY_UDP_DESTINATION_RULE; MAX_UDP_DESTINATION_RULES],
+            udp_destination_rule_count: 0,
+        }
+    }
+
+    /// Returns the configured UDP destination rules.
+    #[must_use]
+    pub fn rules(&self) -> &[UdpDestinationRule] {
+        &self.udp_destination_rules[..self.udp_destination_rule_count]
+    }
+}
+
 /// Socket creation and outbound destination access available to broker-owned sockets.
 ///
-/// Listener authority is separate from egress destination rules: any principal
-/// permitted to create an IPv4 TCP socket may bind it only within the IPv4
-/// loopback network.
+/// Local bind authority is separate from egress destination rules: an admitted
+/// IPv4 TCP or UDP socket may bind only within the IPv4 loopback network.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[non_exhaustive]
 #[expect(
@@ -211,8 +307,19 @@ pub enum SocketPolicy {
     Deny,
     /// Allow IPv4 TCP sockets to connect only to the IPv4 loopback network.
     Ipv4LoopbackTcp,
+    /// Allow IPv4 TCP and UDP sockets to use only the IPv4 loopback network.
+    Ipv4LoopbackTcpUdp,
     /// Apply bounded caller, IPv4 CIDR, and destination-port rules.
     TcpDestinationRules(TcpDestinationPolicy),
+    /// Apply bounded UDP caller, IPv4 CIDR, and destination-port rules.
+    UdpDestinationRules(UdpDestinationPolicy),
+    /// Apply independent bounded TCP and UDP destination rules.
+    TcpUdpDestinationRules {
+        /// TCP destination policy.
+        tcp: TcpDestinationPolicy,
+        /// UDP destination policy.
+        udp: UdpDestinationPolicy,
+    },
 }
 
 impl SocketPolicy {
@@ -220,32 +327,73 @@ impl SocketPolicy {
     pub fn from_tcp_destination_rules(
         rules: &[TcpDestinationRule],
     ) -> Result<Self, SocketPolicyError> {
-        if rules.len() > MAX_TCP_DESTINATION_RULES {
-            return Err(SocketPolicyError::TooManyRules {
-                maximum: MAX_TCP_DESTINATION_RULES,
-                actual: rules.len(),
-            });
-        }
-        let mut policy = TcpDestinationPolicy::empty();
-        policy.tcp_destination_rules[..rules.len()].copy_from_slice(rules);
-        policy.tcp_destination_rule_count = rules.len();
-        Ok(Self::TcpDestinationRules(policy))
+        Ok(Self::TcpDestinationRules(copy_tcp_destination_rules(
+            rules,
+        )?))
+    }
+
+    /// Creates a bounded policy from static IPv4 UDP destination rules.
+    pub fn from_udp_destination_rules(
+        rules: &[UdpDestinationRule],
+    ) -> Result<Self, SocketPolicyError> {
+        let policy = copy_udp_destination_rules(rules)?;
+        Ok(Self::UdpDestinationRules(policy))
+    }
+
+    /// Creates a policy with independent static IPv4 TCP and UDP rules.
+    pub fn from_tcp_udp_destination_rules(
+        tcp_rules: &[TcpDestinationRule],
+        udp_rules: &[UdpDestinationRule],
+    ) -> Result<Self, SocketPolicyError> {
+        let tcp = copy_tcp_destination_rules(tcp_rules)?;
+        let udp = copy_udp_destination_rules(udp_rules)?;
+        Ok(Self::TcpUdpDestinationRules { tcp, udp })
     }
 
     /// Returns the configured rules for a bounded destination policy.
     #[must_use]
     pub fn tcp_destination_rules(&self) -> Option<&[TcpDestinationRule]> {
         match self {
-            Self::TcpDestinationRules(policy) => Some(policy.rules()),
-            Self::Deny | Self::Ipv4LoopbackTcp => None,
+            Self::TcpDestinationRules(policy)
+            | Self::TcpUdpDestinationRules { tcp: policy, .. } => Some(policy.rules()),
+            Self::Deny
+            | Self::Ipv4LoopbackTcp
+            | Self::Ipv4LoopbackTcpUdp
+            | Self::UdpDestinationRules(_) => None,
+        }
+    }
+
+    /// Returns the configured UDP rules for a bounded destination policy.
+    #[must_use]
+    pub fn udp_destination_rules(&self) -> Option<&[UdpDestinationRule]> {
+        match self {
+            Self::UdpDestinationRules(policy)
+            | Self::TcpUdpDestinationRules { udp: policy, .. } => Some(policy.rules()),
+            Self::Deny
+            | Self::Ipv4LoopbackTcp
+            | Self::Ipv4LoopbackTcpUdp
+            | Self::TcpDestinationRules(_) => None,
         }
     }
 
     fn permits_tcp_socket(self, caller_credential: CallerCredential) -> bool {
         match self {
-            Self::Deny => false,
-            Self::Ipv4LoopbackTcp => true,
-            Self::TcpDestinationRules(policy) => policy
+            Self::Deny | Self::UdpDestinationRules(_) => false,
+            Self::Ipv4LoopbackTcp | Self::Ipv4LoopbackTcpUdp => true,
+            Self::TcpDestinationRules(policy)
+            | Self::TcpUdpDestinationRules { tcp: policy, .. } => policy
+                .rules()
+                .iter()
+                .any(|rule| rule.caller_credential == caller_credential),
+        }
+    }
+
+    fn permits_udp_socket(self, caller_credential: CallerCredential) -> bool {
+        match self {
+            Self::Deny | Self::Ipv4LoopbackTcp | Self::TcpDestinationRules(_) => false,
+            Self::Ipv4LoopbackTcpUdp => true,
+            Self::UdpDestinationRules(policy)
+            | Self::TcpUdpDestinationRules { udp: policy, .. } => policy
                 .rules()
                 .iter()
                 .any(|rule| rule.caller_credential == caller_credential),
@@ -258,14 +406,61 @@ impl SocketPolicy {
         address: SocketAddrV4,
     ) -> bool {
         match self {
-            Self::Deny => false,
-            Self::Ipv4LoopbackTcp => address.ip().is_loopback(),
-            Self::TcpDestinationRules(policy) => policy
+            Self::Deny | Self::UdpDestinationRules(_) => false,
+            Self::Ipv4LoopbackTcp | Self::Ipv4LoopbackTcpUdp => address.ip().is_loopback(),
+            Self::TcpDestinationRules(policy)
+            | Self::TcpUdpDestinationRules { tcp: policy, .. } => policy
                 .rules()
                 .iter()
                 .any(|rule| rule.permits(caller_credential, address)),
         }
     }
+
+    fn permits_udp_destination(
+        self,
+        caller_credential: CallerCredential,
+        address: SocketAddrV4,
+    ) -> bool {
+        match self {
+            Self::Deny | Self::Ipv4LoopbackTcp | Self::TcpDestinationRules(_) => false,
+            Self::Ipv4LoopbackTcpUdp => address.ip().is_loopback(),
+            Self::UdpDestinationRules(policy)
+            | Self::TcpUdpDestinationRules { udp: policy, .. } => policy
+                .rules()
+                .iter()
+                .any(|rule| rule.permits(caller_credential, address)),
+        }
+    }
+}
+
+fn copy_tcp_destination_rules(
+    rules: &[TcpDestinationRule],
+) -> Result<TcpDestinationPolicy, SocketPolicyError> {
+    if rules.len() > MAX_TCP_DESTINATION_RULES {
+        return Err(SocketPolicyError::TooManyRules {
+            maximum: MAX_TCP_DESTINATION_RULES,
+            actual: rules.len(),
+        });
+    }
+    let mut policy = TcpDestinationPolicy::empty();
+    policy.tcp_destination_rules[..rules.len()].copy_from_slice(rules);
+    policy.tcp_destination_rule_count = rules.len();
+    Ok(policy)
+}
+
+fn copy_udp_destination_rules(
+    rules: &[UdpDestinationRule],
+) -> Result<UdpDestinationPolicy, SocketPolicyError> {
+    if rules.len() > MAX_UDP_DESTINATION_RULES {
+        return Err(SocketPolicyError::TooManyUdpRules {
+            maximum: MAX_UDP_DESTINATION_RULES,
+            actual: rules.len(),
+        });
+    }
+    let mut policy = UdpDestinationPolicy::empty();
+    policy.udp_destination_rules[..rules.len()].copy_from_slice(rules);
+    policy.udp_destination_rule_count = rules.len();
+    Ok(policy)
 }
 
 /// Configured broker policy.
@@ -347,11 +542,16 @@ impl PolicyEngine {
         request: CreateSocketRequest,
     ) -> Result<ObjectRights, BrokerError> {
         let rights = self.principal_object_rights(caller_credential)?;
-        if request.address_family == AddressFamily::Ipv4
-            && request.socket_type == SocketType::Stream
-            && request.protocol == IpProtocol::Tcp
-            && self.socket_policy.permits_tcp_socket(caller_credential)
-        {
+        let permitted = match (request.socket_type, request.protocol) {
+            (SocketType::Stream, IpProtocol::Tcp) => {
+                self.socket_policy.permits_tcp_socket(caller_credential)
+            }
+            (SocketType::Datagram, IpProtocol::Udp) => {
+                self.socket_policy.permits_udp_socket(caller_credential)
+            }
+            _ => false,
+        };
+        if request.address_family == AddressFamily::Ipv4 && permitted {
             Ok(rights)
         } else {
             Err(BrokerError::PolicyDenied)
@@ -365,13 +565,16 @@ impl PolicyEngine {
         address: SocketAddrV4,
     ) -> Result<(), BrokerError> {
         self.principal_object_rights(caller_credential)?;
-        if request.address_family == AddressFamily::Ipv4
-            && request.socket_type == SocketType::Stream
-            && request.protocol == IpProtocol::Tcp
-            && self
+        let permitted = match (request.socket_type, request.protocol) {
+            (SocketType::Stream, IpProtocol::Tcp) => self
                 .socket_policy
-                .permits_tcp_destination(caller_credential, address)
-        {
+                .permits_tcp_destination(caller_credential, address),
+            (SocketType::Datagram, IpProtocol::Udp) => self
+                .socket_policy
+                .permits_udp_destination(caller_credential, address),
+            _ => false,
+        };
+        if request.address_family == AddressFamily::Ipv4 && permitted {
             Ok(())
         } else {
             Err(BrokerError::PolicyDenied)
@@ -387,9 +590,12 @@ impl PolicyEngine {
         self.principal_object_rights(caller_credential)?;
         // Egress rules do not describe local listener authority. Socket
         // creation admission plus this fixed loopback boundary governs binds.
+        let supported_socket = matches!(
+            (request.socket_type, request.protocol),
+            (SocketType::Stream, IpProtocol::Tcp) | (SocketType::Datagram, IpProtocol::Udp)
+        );
         if request.address_family == AddressFamily::Ipv4
-            && request.socket_type == SocketType::Stream
-            && request.protocol == IpProtocol::Tcp
+            && supported_socket
             && address.ip().is_loopback()
         {
             Ok(())
@@ -414,6 +620,11 @@ mod tests {
         address_family: AddressFamily::Ipv4,
         socket_type: SocketType::Stream,
         protocol: IpProtocol::Tcp,
+    };
+    const IPV4_UDP: CreateSocketRequest = CreateSocketRequest {
+        address_family: AddressFamily::Ipv4,
+        socket_type: SocketType::Datagram,
+        protocol: IpProtocol::Udp,
     };
 
     fn cidr(address: [u8; 4], prefix_length: u8) -> Ipv4Cidr {
@@ -528,6 +739,32 @@ mod tests {
     }
 
     #[test]
+    fn udp_destination_policy_is_bounded() {
+        let rule = UdpDestinationRule::new(
+            CallerCredential::Unauthenticated,
+            cidr([127, 0, 0, 0], 8),
+            ports(1, u16::MAX),
+        );
+        let maximum = [rule; MAX_UDP_DESTINATION_RULES];
+        assert_eq!(
+            SocketPolicy::from_udp_destination_rules(&maximum)
+                .unwrap()
+                .udp_destination_rules()
+                .unwrap(),
+            &maximum
+        );
+
+        let excessive = [rule; MAX_UDP_DESTINATION_RULES + 1];
+        assert_eq!(
+            SocketPolicy::from_udp_destination_rules(&excessive),
+            Err(SocketPolicyError::TooManyUdpRules {
+                maximum: MAX_UDP_DESTINATION_RULES,
+                actual: MAX_UDP_DESTINATION_RULES + 1,
+            })
+        );
+    }
+
+    #[test]
     fn destination_rules_enforce_principal_cidr_and_port() {
         let socket_policy = SocketPolicy::from_tcp_destination_rules(&[
             TcpDestinationRule::new(
@@ -600,6 +837,61 @@ mod tests {
                 address([127, 0, 0, 1], 0),
             ),
             Ok(())
+        );
+    }
+
+    #[test]
+    fn mixed_policy_authorizes_udp_independently_from_tcp() {
+        let tcp_rule = TcpDestinationRule::new(
+            CallerCredential::Unauthenticated,
+            cidr([192, 0, 2, 0], 24),
+            ports(443, 443),
+        );
+        let udp_rule = UdpDestinationRule::new(
+            CallerCredential::Unauthenticated,
+            cidr([127, 0, 0, 0], 8),
+            ports(53, 53),
+        );
+        let policy = PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
+            .with_socket_policy(
+                SocketPolicy::from_tcp_udp_destination_rules(&[tcp_rule], &[udp_rule]).unwrap(),
+            );
+
+        assert_eq!(
+            policy.authorize_socket_create(CallerCredential::Unauthenticated, IPV4_UDP),
+            Ok(ObjectRights::all())
+        );
+        assert_eq!(
+            policy.authorize_socket_connect(
+                CallerCredential::Unauthenticated,
+                IPV4_UDP,
+                address([127, 0, 0, 1], 53),
+            ),
+            Ok(())
+        );
+        assert_eq!(
+            policy.authorize_socket_connect(
+                CallerCredential::Unauthenticated,
+                IPV4_UDP,
+                address([192, 0, 2, 1], 443),
+            ),
+            Err(BrokerError::PolicyDenied)
+        );
+        assert_eq!(
+            policy.authorize_socket_bind(
+                CallerCredential::Unauthenticated,
+                IPV4_UDP,
+                address([127, 0, 0, 1], 0),
+            ),
+            Ok(())
+        );
+        assert_eq!(
+            policy.authorize_socket_bind(
+                CallerCredential::Unauthenticated,
+                IPV4_UDP,
+                address([0, 0, 0, 0], 0),
+            ),
+            Err(BrokerError::PolicyDenied)
         );
     }
 }

--- a/litebox_broker_core/src/policy.rs
+++ b/litebox_broker_core/src/policy.rs
@@ -9,10 +9,8 @@ use litebox_broker_protocol::socket::{
 };
 use thiserror::Error;
 
-/// Maximum number of TCP destination rules in one socket policy.
-pub const MAX_TCP_DESTINATION_RULES: usize = 64;
-/// Maximum number of UDP destination rules in one socket policy.
-pub const MAX_UDP_DESTINATION_RULES: usize = 64;
+/// Maximum number of destination rules in one transport policy.
+pub const MAX_DESTINATION_RULES: usize = 64;
 
 /// An IPv4 network in canonical CIDR form.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -164,65 +162,35 @@ const EMPTY_DESTINATION_RULE: DestinationRule = DestinationRule {
 #[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum SocketPolicyError {
-    /// The configured rule count exceeds [`MAX_TCP_DESTINATION_RULES`].
-    #[error("TCP destination policy has {actual} rules; maximum is {maximum}")]
+    /// The configured rule count exceeds [`MAX_DESTINATION_RULES`].
+    #[error("destination policy has {actual} rules; maximum is {maximum}")]
     TooManyRules {
         /// Maximum supported rule count.
         maximum: usize,
         /// Requested rule count.
         actual: usize,
     },
-    /// The configured rule count exceeds [`MAX_UDP_DESTINATION_RULES`].
-    #[error("UDP destination policy has {actual} rules; maximum is {maximum}")]
-    TooManyUdpRules {
-        /// Maximum supported rule count.
-        maximum: usize,
-        /// Requested rule count.
-        actual: usize,
-    },
 }
 
-/// Bounded static IPv4 TCP destination rules.
+/// Bounded static IPv4 destination rules for one transport protocol.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct TcpDestinationPolicy {
-    tcp_destination_rules: [DestinationRule; MAX_TCP_DESTINATION_RULES],
-    tcp_destination_rule_count: usize,
+pub struct DestinationPolicy {
+    destination_rules: [DestinationRule; MAX_DESTINATION_RULES],
+    destination_rule_count: usize,
 }
 
-impl TcpDestinationPolicy {
+impl DestinationPolicy {
     const fn empty() -> Self {
         Self {
-            tcp_destination_rules: [EMPTY_DESTINATION_RULE; MAX_TCP_DESTINATION_RULES],
-            tcp_destination_rule_count: 0,
+            destination_rules: [EMPTY_DESTINATION_RULE; MAX_DESTINATION_RULES],
+            destination_rule_count: 0,
         }
     }
 
-    /// Returns the configured TCP destination rules.
+    /// Returns the configured destination rules.
     #[must_use]
     pub fn rules(&self) -> &[DestinationRule] {
-        &self.tcp_destination_rules[..self.tcp_destination_rule_count]
-    }
-}
-
-/// Bounded static IPv4 UDP destination rules.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct UdpDestinationPolicy {
-    udp_destination_rules: [DestinationRule; MAX_UDP_DESTINATION_RULES],
-    udp_destination_rule_count: usize,
-}
-
-impl UdpDestinationPolicy {
-    const fn empty() -> Self {
-        Self {
-            udp_destination_rules: [EMPTY_DESTINATION_RULE; MAX_UDP_DESTINATION_RULES],
-            udp_destination_rule_count: 0,
-        }
-    }
-
-    /// Returns the configured UDP destination rules.
-    #[must_use]
-    pub fn rules(&self) -> &[DestinationRule] {
-        &self.udp_destination_rules[..self.udp_destination_rule_count]
+        &self.destination_rules[..self.destination_rule_count]
     }
 }
 
@@ -245,15 +213,15 @@ pub enum SocketPolicy {
     /// Allow IPv4 TCP and UDP sockets to use only the IPv4 loopback network.
     Ipv4LoopbackTcpUdp,
     /// Apply bounded caller, IPv4 CIDR, and destination-port rules.
-    TcpDestinationRules(TcpDestinationPolicy),
+    TcpDestinationRules(DestinationPolicy),
     /// Apply bounded UDP caller, IPv4 CIDR, and destination-port rules.
-    UdpDestinationRules(UdpDestinationPolicy),
+    UdpDestinationRules(DestinationPolicy),
     /// Apply independent bounded TCP and UDP destination rules.
     TcpUdpDestinationRules {
         /// TCP destination policy.
-        tcp: TcpDestinationPolicy,
+        tcp: DestinationPolicy,
         /// UDP destination policy.
-        udp: UdpDestinationPolicy,
+        udp: DestinationPolicy,
     },
 }
 
@@ -262,16 +230,14 @@ impl SocketPolicy {
     pub fn from_tcp_destination_rules(
         rules: &[DestinationRule],
     ) -> Result<Self, SocketPolicyError> {
-        Ok(Self::TcpDestinationRules(copy_tcp_destination_rules(
-            rules,
-        )?))
+        Ok(Self::TcpDestinationRules(copy_destination_rules(rules)?))
     }
 
     /// Creates a bounded policy from static IPv4 UDP destination rules.
     pub fn from_udp_destination_rules(
         rules: &[DestinationRule],
     ) -> Result<Self, SocketPolicyError> {
-        let policy = copy_udp_destination_rules(rules)?;
+        let policy = copy_destination_rules(rules)?;
         Ok(Self::UdpDestinationRules(policy))
     }
 
@@ -280,8 +246,8 @@ impl SocketPolicy {
         tcp_rules: &[DestinationRule],
         udp_rules: &[DestinationRule],
     ) -> Result<Self, SocketPolicyError> {
-        let tcp = copy_tcp_destination_rules(tcp_rules)?;
-        let udp = copy_udp_destination_rules(udp_rules)?;
+        let tcp = copy_destination_rules(tcp_rules)?;
+        let udp = copy_destination_rules(udp_rules)?;
         Ok(Self::TcpUdpDestinationRules { tcp, udp })
     }
 
@@ -368,33 +334,18 @@ impl SocketPolicy {
     }
 }
 
-fn copy_tcp_destination_rules(
+fn copy_destination_rules(
     rules: &[DestinationRule],
-) -> Result<TcpDestinationPolicy, SocketPolicyError> {
-    if rules.len() > MAX_TCP_DESTINATION_RULES {
+) -> Result<DestinationPolicy, SocketPolicyError> {
+    if rules.len() > MAX_DESTINATION_RULES {
         return Err(SocketPolicyError::TooManyRules {
-            maximum: MAX_TCP_DESTINATION_RULES,
+            maximum: MAX_DESTINATION_RULES,
             actual: rules.len(),
         });
     }
-    let mut policy = TcpDestinationPolicy::empty();
-    policy.tcp_destination_rules[..rules.len()].copy_from_slice(rules);
-    policy.tcp_destination_rule_count = rules.len();
-    Ok(policy)
-}
-
-fn copy_udp_destination_rules(
-    rules: &[DestinationRule],
-) -> Result<UdpDestinationPolicy, SocketPolicyError> {
-    if rules.len() > MAX_UDP_DESTINATION_RULES {
-        return Err(SocketPolicyError::TooManyUdpRules {
-            maximum: MAX_UDP_DESTINATION_RULES,
-            actual: rules.len(),
-        });
-    }
-    let mut policy = UdpDestinationPolicy::empty();
-    policy.udp_destination_rules[..rules.len()].copy_from_slice(rules);
-    policy.udp_destination_rule_count = rules.len();
+    let mut policy = DestinationPolicy::empty();
+    policy.destination_rules[..rules.len()].copy_from_slice(rules);
+    policy.destination_rule_count = rules.len();
     Ok(policy)
 }
 
@@ -654,7 +605,7 @@ mod tests {
             cidr([127, 0, 0, 0], 8),
             ports(1, u16::MAX),
         );
-        let maximum = [rule; MAX_TCP_DESTINATION_RULES];
+        let maximum = [rule; MAX_DESTINATION_RULES];
         assert_eq!(
             SocketPolicy::from_tcp_destination_rules(&maximum)
                 .unwrap()
@@ -663,12 +614,12 @@ mod tests {
             &maximum
         );
 
-        let excessive = [rule; MAX_TCP_DESTINATION_RULES + 1];
+        let excessive = [rule; MAX_DESTINATION_RULES + 1];
         assert_eq!(
             SocketPolicy::from_tcp_destination_rules(&excessive),
             Err(SocketPolicyError::TooManyRules {
-                maximum: MAX_TCP_DESTINATION_RULES,
-                actual: MAX_TCP_DESTINATION_RULES + 1,
+                maximum: MAX_DESTINATION_RULES,
+                actual: MAX_DESTINATION_RULES + 1,
             })
         );
     }
@@ -680,7 +631,7 @@ mod tests {
             cidr([127, 0, 0, 0], 8),
             ports(1, u16::MAX),
         );
-        let maximum = [rule; MAX_UDP_DESTINATION_RULES];
+        let maximum = [rule; MAX_DESTINATION_RULES];
         assert_eq!(
             SocketPolicy::from_udp_destination_rules(&maximum)
                 .unwrap()
@@ -689,12 +640,12 @@ mod tests {
             &maximum
         );
 
-        let excessive = [rule; MAX_UDP_DESTINATION_RULES + 1];
+        let excessive = [rule; MAX_DESTINATION_RULES + 1];
         assert_eq!(
             SocketPolicy::from_udp_destination_rules(&excessive),
-            Err(SocketPolicyError::TooManyUdpRules {
-                maximum: MAX_UDP_DESTINATION_RULES,
-                actual: MAX_UDP_DESTINATION_RULES + 1,
+            Err(SocketPolicyError::TooManyRules {
+                maximum: MAX_DESTINATION_RULES,
+                actual: MAX_DESTINATION_RULES + 1,
             })
         );
     }

--- a/litebox_broker_core/src/policy.rs
+++ b/litebox_broker_core/src/policy.rs
@@ -210,9 +210,9 @@ pub enum SocketPolicy {
     Deny,
     /// Allow IPv4 TCP and UDP sockets to use only the IPv4 loopback network.
     Ipv4Loopback,
-    /// Apply bounded caller, IPv4 CIDR, and destination-port rules.
+    /// Apply bounded TCP destination rules.
     TcpDestinationRules(DestinationPolicy),
-    /// Apply bounded UDP caller, IPv4 CIDR, and destination-port rules.
+    /// Apply bounded UDP destination rules.
     UdpDestinationRules(DestinationPolicy),
     /// Apply independent bounded TCP and UDP destination rules.
     TcpUdpDestinationRules {

--- a/litebox_broker_core/src/policy.rs
+++ b/litebox_broker_core/src/policy.rs
@@ -208,10 +208,8 @@ pub enum SocketPolicy {
     /// Deny all socket creation and connection attempts.
     #[default]
     Deny,
-    /// Allow IPv4 TCP sockets to connect only to the IPv4 loopback network.
-    Ipv4LoopbackTcp,
     /// Allow IPv4 TCP and UDP sockets to use only the IPv4 loopback network.
-    Ipv4LoopbackTcpUdp,
+    Ipv4Loopback,
     /// Apply bounded caller, IPv4 CIDR, and destination-port rules.
     TcpDestinationRules(DestinationPolicy),
     /// Apply bounded UDP caller, IPv4 CIDR, and destination-port rules.
@@ -257,10 +255,7 @@ impl SocketPolicy {
         match self {
             Self::TcpDestinationRules(policy)
             | Self::TcpUdpDestinationRules { tcp: policy, .. } => Some(policy.rules()),
-            Self::Deny
-            | Self::Ipv4LoopbackTcp
-            | Self::Ipv4LoopbackTcpUdp
-            | Self::UdpDestinationRules(_) => None,
+            Self::Deny | Self::Ipv4Loopback | Self::UdpDestinationRules(_) => None,
         }
     }
 
@@ -270,17 +265,14 @@ impl SocketPolicy {
         match self {
             Self::UdpDestinationRules(policy)
             | Self::TcpUdpDestinationRules { udp: policy, .. } => Some(policy.rules()),
-            Self::Deny
-            | Self::Ipv4LoopbackTcp
-            | Self::Ipv4LoopbackTcpUdp
-            | Self::TcpDestinationRules(_) => None,
+            Self::Deny | Self::Ipv4Loopback | Self::TcpDestinationRules(_) => None,
         }
     }
 
     fn permits_tcp_socket(self, caller_credential: CallerCredential) -> bool {
         match self {
             Self::Deny | Self::UdpDestinationRules(_) => false,
-            Self::Ipv4LoopbackTcp | Self::Ipv4LoopbackTcpUdp => true,
+            Self::Ipv4Loopback => true,
             Self::TcpDestinationRules(policy)
             | Self::TcpUdpDestinationRules { tcp: policy, .. } => policy
                 .rules()
@@ -291,8 +283,8 @@ impl SocketPolicy {
 
     fn permits_udp_socket(self, caller_credential: CallerCredential) -> bool {
         match self {
-            Self::Deny | Self::Ipv4LoopbackTcp | Self::TcpDestinationRules(_) => false,
-            Self::Ipv4LoopbackTcpUdp => true,
+            Self::Deny | Self::TcpDestinationRules(_) => false,
+            Self::Ipv4Loopback => true,
             Self::UdpDestinationRules(policy)
             | Self::TcpUdpDestinationRules { udp: policy, .. } => policy
                 .rules()
@@ -308,7 +300,7 @@ impl SocketPolicy {
     ) -> bool {
         match self {
             Self::Deny | Self::UdpDestinationRules(_) => false,
-            Self::Ipv4LoopbackTcp | Self::Ipv4LoopbackTcpUdp => address.ip().is_loopback(),
+            Self::Ipv4Loopback => address.ip().is_loopback(),
             Self::TcpDestinationRules(policy)
             | Self::TcpUdpDestinationRules { tcp: policy, .. } => policy
                 .rules()
@@ -323,8 +315,8 @@ impl SocketPolicy {
         address: SocketAddrV4,
     ) -> bool {
         match self {
-            Self::Deny | Self::Ipv4LoopbackTcp | Self::TcpDestinationRules(_) => false,
-            Self::Ipv4LoopbackTcpUdp => address.ip().is_loopback(),
+            Self::Deny | Self::TcpDestinationRules(_) => false,
+            Self::Ipv4Loopback => address.ip().is_loopback(),
             Self::UdpDestinationRules(policy)
             | Self::TcpUdpDestinationRules { udp: policy, .. } => policy
                 .rules()
@@ -697,9 +689,9 @@ mod tests {
     }
 
     #[test]
-    fn loopback_policy_preserves_initial_production_scope() {
+    fn loopback_policy_allows_tcp_and_udp_only_within_loopback() {
         let policy = PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4LoopbackTcp);
+            .with_socket_policy(SocketPolicy::Ipv4Loopback);
         assert_eq!(
             policy.authorize_socket_connect(
                 CallerCredential::Unauthenticated,
@@ -723,6 +715,22 @@ mod tests {
                 address([127, 0, 0, 1], 0),
             ),
             Ok(())
+        );
+        assert_eq!(
+            policy.authorize_socket_connect(
+                CallerCredential::Unauthenticated,
+                IPV4_UDP,
+                address([127, 0, 0, 1], 53),
+            ),
+            Ok(())
+        );
+        assert_eq!(
+            policy.authorize_socket_connect(
+                CallerCredential::Unauthenticated,
+                IPV4_UDP,
+                address([10, 0, 0, 1], 53),
+            ),
+            Err(BrokerError::PolicyDenied)
         );
     }
 

--- a/litebox_broker_core/src/policy.rs
+++ b/litebox_broker_core/src/policy.rs
@@ -66,15 +66,12 @@ const fn ipv4_prefix_mask(prefix_length: u8) -> u32 {
 
 /// Inclusive nonzero transport destination-port range.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct TcpPortRange {
+pub struct DestinationPortRange {
     start: Port,
     end: Port,
 }
 
-/// Inclusive nonzero UDP destination-port range.
-pub type UdpPortRange = TcpPortRange;
-
-impl TcpPortRange {
+impl DestinationPortRange {
     /// Creates a nonempty range of valid transport destination ports.
     #[must_use]
     pub const fn new(start: Port, end: Port) -> Option<Self> {
@@ -106,7 +103,7 @@ impl TcpPortRange {
 pub struct TcpDestinationRule {
     caller_credential: CallerCredential,
     destination: Ipv4Cidr,
-    ports: TcpPortRange,
+    ports: DestinationPortRange,
 }
 
 impl TcpDestinationRule {
@@ -115,7 +112,7 @@ impl TcpDestinationRule {
     pub const fn new(
         caller_credential: CallerCredential,
         destination: Ipv4Cidr,
-        ports: TcpPortRange,
+        ports: DestinationPortRange,
     ) -> Self {
         Self {
             caller_credential,
@@ -138,7 +135,7 @@ impl TcpDestinationRule {
 
     /// Returns the authorized destination-port range.
     #[must_use]
-    pub const fn ports(self) -> TcpPortRange {
+    pub const fn ports(self) -> DestinationPortRange {
         self.ports
     }
 
@@ -156,7 +153,7 @@ impl TcpDestinationRule {
 pub struct UdpDestinationRule {
     caller_credential: CallerCredential,
     destination: Ipv4Cidr,
-    ports: UdpPortRange,
+    ports: DestinationPortRange,
 }
 
 impl UdpDestinationRule {
@@ -165,7 +162,7 @@ impl UdpDestinationRule {
     pub const fn new(
         caller_credential: CallerCredential,
         destination: Ipv4Cidr,
-        ports: UdpPortRange,
+        ports: DestinationPortRange,
     ) -> Self {
         Self {
             caller_credential,
@@ -188,7 +185,7 @@ impl UdpDestinationRule {
 
     /// Returns the authorized destination-port range.
     #[must_use]
-    pub const fn ports(self) -> UdpPortRange {
+    pub const fn ports(self) -> DestinationPortRange {
         self.ports
     }
 
@@ -207,7 +204,7 @@ const EMPTY_TCP_DESTINATION_RULE: TcpDestinationRule = TcpDestinationRule {
         network: Ipv4Address([0, 0, 0, 0]),
         prefix_length: 0,
     },
-    ports: TcpPortRange {
+    ports: DestinationPortRange {
         start: Port(1),
         end: Port(1),
     },
@@ -219,7 +216,7 @@ const EMPTY_UDP_DESTINATION_RULE: UdpDestinationRule = UdpDestinationRule {
         network: Ipv4Address([0, 0, 0, 0]),
         prefix_length: 0,
     },
-    ports: UdpPortRange {
+    ports: DestinationPortRange {
         start: Port(1),
         end: Port(1),
     },
@@ -631,8 +628,8 @@ mod tests {
         Ipv4Cidr::new(Ipv4Address(address), prefix_length).unwrap()
     }
 
-    fn ports(start: u16, end: u16) -> TcpPortRange {
-        TcpPortRange::new(Port(start), Port(end)).unwrap()
+    fn ports(start: u16, end: u16) -> DestinationPortRange {
+        DestinationPortRange::new(Port(start), Port(end)).unwrap()
     }
 
     fn address(address: [u8; 4], port: u16) -> SocketAddrV4 {
@@ -702,8 +699,8 @@ mod tests {
 
     #[test]
     fn port_ranges_are_nonzero_ordered_and_inclusive() {
-        assert_eq!(TcpPortRange::new(Port(0), Port(80)), None);
-        assert_eq!(TcpPortRange::new(Port(81), Port(80)), None);
+        assert_eq!(DestinationPortRange::new(Port(0), Port(80)), None);
+        assert_eq!(DestinationPortRange::new(Port(81), Port(80)), None);
 
         let range = ports(443, 444);
         assert!(!range.contains(Port(442)));

--- a/litebox_broker_core/src/policy.rs
+++ b/litebox_broker_core/src/policy.rs
@@ -98,15 +98,15 @@ impl DestinationPortRange {
     }
 }
 
-/// One static IPv4 TCP destination authorization rule.
+/// One static IPv4 destination authorization rule.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct TcpDestinationRule {
+pub struct DestinationRule {
     caller_credential: CallerCredential,
     destination: Ipv4Cidr,
     ports: DestinationPortRange,
 }
 
-impl TcpDestinationRule {
+impl DestinationRule {
     /// Creates a rule for one caller, destination network, and port range.
     #[must_use]
     pub const fn new(
@@ -148,69 +148,7 @@ impl TcpDestinationRule {
     }
 }
 
-/// One static IPv4 UDP destination authorization rule.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct UdpDestinationRule {
-    caller_credential: CallerCredential,
-    destination: Ipv4Cidr,
-    ports: DestinationPortRange,
-}
-
-impl UdpDestinationRule {
-    /// Creates a rule for one caller, destination network, and port range.
-    #[must_use]
-    pub const fn new(
-        caller_credential: CallerCredential,
-        destination: Ipv4Cidr,
-        ports: DestinationPortRange,
-    ) -> Self {
-        Self {
-            caller_credential,
-            destination,
-            ports,
-        }
-    }
-
-    /// Returns the caller authorized by this rule.
-    #[must_use]
-    pub const fn caller_credential(self) -> CallerCredential {
-        self.caller_credential
-    }
-
-    /// Returns the authorized destination network.
-    #[must_use]
-    pub const fn destination(self) -> Ipv4Cidr {
-        self.destination
-    }
-
-    /// Returns the authorized destination-port range.
-    #[must_use]
-    pub const fn ports(self) -> DestinationPortRange {
-        self.ports
-    }
-
-    fn permits(self, caller_credential: CallerCredential, address: SocketAddrV4) -> bool {
-        self.caller_credential == caller_credential
-            && self
-                .destination
-                .contains(Ipv4Address(address.ip().octets()))
-            && self.ports.contains(Port(address.port()))
-    }
-}
-
-const EMPTY_TCP_DESTINATION_RULE: TcpDestinationRule = TcpDestinationRule {
-    caller_credential: CallerCredential::Unauthenticated,
-    destination: Ipv4Cidr {
-        network: Ipv4Address([0, 0, 0, 0]),
-        prefix_length: 0,
-    },
-    ports: DestinationPortRange {
-        start: Port(1),
-        end: Port(1),
-    },
-};
-
-const EMPTY_UDP_DESTINATION_RULE: UdpDestinationRule = UdpDestinationRule {
+const EMPTY_DESTINATION_RULE: DestinationRule = DestinationRule {
     caller_credential: CallerCredential::Unauthenticated,
     destination: Ipv4Cidr {
         network: Ipv4Address([0, 0, 0, 0]),
@@ -247,21 +185,21 @@ pub enum SocketPolicyError {
 /// Bounded static IPv4 TCP destination rules.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct TcpDestinationPolicy {
-    tcp_destination_rules: [TcpDestinationRule; MAX_TCP_DESTINATION_RULES],
+    tcp_destination_rules: [DestinationRule; MAX_TCP_DESTINATION_RULES],
     tcp_destination_rule_count: usize,
 }
 
 impl TcpDestinationPolicy {
     const fn empty() -> Self {
         Self {
-            tcp_destination_rules: [EMPTY_TCP_DESTINATION_RULE; MAX_TCP_DESTINATION_RULES],
+            tcp_destination_rules: [EMPTY_DESTINATION_RULE; MAX_TCP_DESTINATION_RULES],
             tcp_destination_rule_count: 0,
         }
     }
 
     /// Returns the configured TCP destination rules.
     #[must_use]
-    pub fn rules(&self) -> &[TcpDestinationRule] {
+    pub fn rules(&self) -> &[DestinationRule] {
         &self.tcp_destination_rules[..self.tcp_destination_rule_count]
     }
 }
@@ -269,21 +207,21 @@ impl TcpDestinationPolicy {
 /// Bounded static IPv4 UDP destination rules.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct UdpDestinationPolicy {
-    udp_destination_rules: [UdpDestinationRule; MAX_UDP_DESTINATION_RULES],
+    udp_destination_rules: [DestinationRule; MAX_UDP_DESTINATION_RULES],
     udp_destination_rule_count: usize,
 }
 
 impl UdpDestinationPolicy {
     const fn empty() -> Self {
         Self {
-            udp_destination_rules: [EMPTY_UDP_DESTINATION_RULE; MAX_UDP_DESTINATION_RULES],
+            udp_destination_rules: [EMPTY_DESTINATION_RULE; MAX_UDP_DESTINATION_RULES],
             udp_destination_rule_count: 0,
         }
     }
 
     /// Returns the configured UDP destination rules.
     #[must_use]
-    pub fn rules(&self) -> &[UdpDestinationRule] {
+    pub fn rules(&self) -> &[DestinationRule] {
         &self.udp_destination_rules[..self.udp_destination_rule_count]
     }
 }
@@ -322,7 +260,7 @@ pub enum SocketPolicy {
 impl SocketPolicy {
     /// Creates a bounded policy from static IPv4 TCP destination rules.
     pub fn from_tcp_destination_rules(
-        rules: &[TcpDestinationRule],
+        rules: &[DestinationRule],
     ) -> Result<Self, SocketPolicyError> {
         Ok(Self::TcpDestinationRules(copy_tcp_destination_rules(
             rules,
@@ -331,7 +269,7 @@ impl SocketPolicy {
 
     /// Creates a bounded policy from static IPv4 UDP destination rules.
     pub fn from_udp_destination_rules(
-        rules: &[UdpDestinationRule],
+        rules: &[DestinationRule],
     ) -> Result<Self, SocketPolicyError> {
         let policy = copy_udp_destination_rules(rules)?;
         Ok(Self::UdpDestinationRules(policy))
@@ -339,8 +277,8 @@ impl SocketPolicy {
 
     /// Creates a policy with independent static IPv4 TCP and UDP rules.
     pub fn from_tcp_udp_destination_rules(
-        tcp_rules: &[TcpDestinationRule],
-        udp_rules: &[UdpDestinationRule],
+        tcp_rules: &[DestinationRule],
+        udp_rules: &[DestinationRule],
     ) -> Result<Self, SocketPolicyError> {
         let tcp = copy_tcp_destination_rules(tcp_rules)?;
         let udp = copy_udp_destination_rules(udp_rules)?;
@@ -349,7 +287,7 @@ impl SocketPolicy {
 
     /// Returns the configured rules for a bounded destination policy.
     #[must_use]
-    pub fn tcp_destination_rules(&self) -> Option<&[TcpDestinationRule]> {
+    pub fn tcp_destination_rules(&self) -> Option<&[DestinationRule]> {
         match self {
             Self::TcpDestinationRules(policy)
             | Self::TcpUdpDestinationRules { tcp: policy, .. } => Some(policy.rules()),
@@ -362,7 +300,7 @@ impl SocketPolicy {
 
     /// Returns the configured UDP rules for a bounded destination policy.
     #[must_use]
-    pub fn udp_destination_rules(&self) -> Option<&[UdpDestinationRule]> {
+    pub fn udp_destination_rules(&self) -> Option<&[DestinationRule]> {
         match self {
             Self::UdpDestinationRules(policy)
             | Self::TcpUdpDestinationRules { udp: policy, .. } => Some(policy.rules()),
@@ -431,7 +369,7 @@ impl SocketPolicy {
 }
 
 fn copy_tcp_destination_rules(
-    rules: &[TcpDestinationRule],
+    rules: &[DestinationRule],
 ) -> Result<TcpDestinationPolicy, SocketPolicyError> {
     if rules.len() > MAX_TCP_DESTINATION_RULES {
         return Err(SocketPolicyError::TooManyRules {
@@ -446,7 +384,7 @@ fn copy_tcp_destination_rules(
 }
 
 fn copy_udp_destination_rules(
-    rules: &[UdpDestinationRule],
+    rules: &[DestinationRule],
 ) -> Result<UdpDestinationPolicy, SocketPolicyError> {
     if rules.len() > MAX_UDP_DESTINATION_RULES {
         return Err(SocketPolicyError::TooManyUdpRules {
@@ -711,7 +649,7 @@ mod tests {
 
     #[test]
     fn destination_policy_is_bounded() {
-        let rule = TcpDestinationRule::new(
+        let rule = DestinationRule::new(
             CallerCredential::Unauthenticated,
             cidr([127, 0, 0, 0], 8),
             ports(1, u16::MAX),
@@ -737,7 +675,7 @@ mod tests {
 
     #[test]
     fn udp_destination_policy_is_bounded() {
-        let rule = UdpDestinationRule::new(
+        let rule = DestinationRule::new(
             CallerCredential::Unauthenticated,
             cidr([127, 0, 0, 0], 8),
             ports(1, u16::MAX),
@@ -764,12 +702,12 @@ mod tests {
     #[test]
     fn destination_rules_enforce_principal_cidr_and_port() {
         let socket_policy = SocketPolicy::from_tcp_destination_rules(&[
-            TcpDestinationRule::new(
+            DestinationRule::new(
                 CallerCredential::Unauthenticated,
                 cidr([10, 8, 0, 0], 13),
                 ports(443, 444),
             ),
-            TcpDestinationRule::new(
+            DestinationRule::new(
                 CallerCredential::HostGuaranteed,
                 cidr([192, 0, 2, 7], 32),
                 ports(8443, 8443),
@@ -839,12 +777,12 @@ mod tests {
 
     #[test]
     fn mixed_policy_authorizes_udp_independently_from_tcp() {
-        let tcp_rule = TcpDestinationRule::new(
+        let tcp_rule = DestinationRule::new(
             CallerCredential::Unauthenticated,
             cidr([192, 0, 2, 0], 24),
             ports(443, 443),
         );
-        let udp_rule = UdpDestinationRule::new(
+        let udp_rule = DestinationRule::new(
             CallerCredential::Unauthenticated,
             cidr([127, 0, 0, 0], 8),
             ports(53, 53),

--- a/litebox_broker_core/src/session.rs
+++ b/litebox_broker_core/src/session.rs
@@ -541,7 +541,7 @@ mod tests {
         let socket_provider = Arc::new(crate::socket::tests::TestSocketProvider::default());
         let broker = BrokerCore::new_with_limits(
             PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-                .with_socket_policy(SocketPolicy::Ipv4LoopbackTcpUdp),
+                .with_socket_policy(SocketPolicy::Ipv4Loopback),
             BrokerCoreLimits::new_with_all_limits(2, 4, 2, 1),
             socket_provider.clone(),
         )

--- a/litebox_broker_core/src/session.rs
+++ b/litebox_broker_core/src/session.rs
@@ -541,7 +541,7 @@ mod tests {
         let socket_provider = Arc::new(crate::socket::tests::TestSocketProvider::default());
         let broker = BrokerCore::new_with_limits(
             PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-                .with_socket_policy(SocketPolicy::Ipv4LoopbackTcp),
+                .with_socket_policy(SocketPolicy::Ipv4LoopbackTcpUdp),
             BrokerCoreLimits::new_with_all_limits(2, 4, 2, 1),
             socket_provider.clone(),
         )

--- a/litebox_broker_core/src/socket.rs
+++ b/litebox_broker_core/src/socket.rs
@@ -721,44 +721,61 @@ pub fn status(session: &BrokerSession, handle: ObjectHandle) -> Result<SocketSta
             pending_error: None,
         });
     }
-    let mut response = resource.status()?;
-    let mut object = object.write();
-    let ObjectEntry::Socket(socket) = &mut *object else {
-        return Err(BrokerError::InvalidRights);
-    };
-    if is_udp(socket.create_request) {
-        if matches!(
-            response.status,
-            SocketConnectionStatus::Connecting | SocketConnectionStatus::Failed(_)
-        ) {
+    let mut expected_datagram_generation = datagram_connect_generation;
+    let mut retried_datagram_status = false;
+    let mut pending_error = None;
+    loop {
+        let mut response = resource.status()?;
+        pending_error = pending_error.or(response.pending_error);
+        let mut object = object.write();
+        let ObjectEntry::Socket(socket) = &mut *object else {
+            return Err(BrokerError::InvalidRights);
+        };
+        if is_udp(socket.create_request) {
+            if matches!(
+                response.status,
+                SocketConnectionStatus::Connecting | SocketConnectionStatus::Failed(_)
+            ) {
+                return Err(BrokerError::Internal);
+            }
+            if socket.datagram_connect_generation != expected_datagram_generation {
+                if !retried_datagram_status && pending_error.is_none() {
+                    expected_datagram_generation = socket.datagram_connect_generation;
+                    retried_datagram_status = true;
+                    drop(object);
+                    continue;
+                }
+                // Continuous peer replacement can race both bounded queries.
+                // Do not let an unordered platform snapshot overwrite newer
+                // broker observations.
+                response.status = socket.connection_status;
+                socket.local_address = socket.local_address.or(response.local_address);
+                response.local_address = socket.local_address;
+                response.pending_error = pending_error;
+                return Ok(response);
+            }
+        } else if socket.connection_status == SocketConnectionStatus::Connecting
+            && response.status == SocketConnectionStatus::Unconnected
+        {
             return Err(BrokerError::Internal);
         }
-        if socket.datagram_connect_generation != datagram_connect_generation {
-            // The platform response is a valid snapshot from before or after a
-            // concurrent peer replacement, but must not overwrite the newer
-            // broker state.
-            return Ok(response);
+        socket.local_address = if is_udp(socket.create_request) {
+            response.local_address.or(socket.local_address)
+        } else {
+            socket.local_address.or(response.local_address)
+        };
+        response.local_address = socket.local_address;
+        response.pending_error = pending_error;
+        if is_udp(socket.create_request) {
+            response.status = socket.connection_status;
+        } else if socket.connection_status == SocketConnectionStatus::Connecting {
+            socket.connection_status = response.status;
+        } else {
+            // Another status call reached a terminal state while this platform query was in flight.
+            response.status = socket.connection_status;
         }
-    } else if socket.connection_status == SocketConnectionStatus::Connecting
-        && response.status == SocketConnectionStatus::Unconnected
-    {
-        return Err(BrokerError::Internal);
+        return Ok(response);
     }
-    socket.local_address = if is_udp(socket.create_request) {
-        response.local_address.or(socket.local_address)
-    } else {
-        socket.local_address.or(response.local_address)
-    };
-    response.local_address = socket.local_address;
-    if is_udp(socket.create_request) {
-        response.status = socket.connection_status;
-    } else if socket.connection_status == SocketConnectionStatus::Connecting {
-        socket.connection_status = response.status;
-    } else {
-        // Another status call reached a terminal state while this platform query was in flight.
-        response.status = socket.connection_status;
-    }
-    Ok(response)
 }
 
 #[cfg(test)]
@@ -1675,16 +1692,19 @@ pub(crate) mod tests {
             Arc::new(TestReadinessSink::default()),
         )
         .unwrap();
-        provider
-            .state
-            .status_responses
-            .lock()
-            .unwrap()
-            .push_back(SocketStatusResponse {
+        let local_address = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 49152);
+        *provider.state.status_responses.lock().unwrap() = std::collections::VecDeque::from([
+            SocketStatusResponse {
                 status: SocketConnectionStatus::Unconnected,
-                local_address: Some(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 49152)),
+                local_address: None,
                 pending_error: None,
-            });
+            },
+            SocketStatusResponse {
+                status: SocketConnectionStatus::Connected,
+                local_address: Some(local_address),
+                pending_error: None,
+            },
+        ]);
         let (started_tx, started_rx) = mpsc::channel();
         let (release_tx, release_rx) = mpsc::channel();
         *provider.state.status_block.lock().unwrap() = Some((started_tx, release_rx));
@@ -1698,11 +1718,52 @@ pub(crate) mod tests {
         );
         release_tx.send(()).unwrap();
         let stale = in_flight.join().unwrap();
-        assert_eq!(stale.status, SocketConnectionStatus::Unconnected);
+        assert_eq!(stale.status, SocketConnectionStatus::Connected);
+        assert_eq!(stale.local_address, Some(local_address));
+        assert_eq!(stale.pending_error, None);
+
+        let next_local_address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 49153);
+        let stale_local_address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 49154);
+        *provider.state.status_responses.lock().unwrap() = std::collections::VecDeque::from([
+            SocketStatusResponse {
+                status: SocketConnectionStatus::Unconnected,
+                local_address: Some(stale_local_address),
+                pending_error: Some(SocketError::ConnectionRefused),
+            },
+            SocketStatusResponse {
+                status: SocketConnectionStatus::Connected,
+                local_address: Some(next_local_address),
+                pending_error: Some(SocketError::NetworkUnreachable),
+            },
+        ]);
+        let status_calls = provider.state.status_calls.load(Ordering::Relaxed);
+        let (started_tx, started_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        *provider.state.status_block.lock().unwrap() = Some((started_tx, release_rx));
+        let status_session = Arc::clone(&session);
+        let in_flight = std::thread::spawn(move || status(&status_session, handle).unwrap());
+        started_rx.recv_timeout(Duration::from_secs(5)).unwrap();
         assert_eq!(
-            stale.local_address,
-            Some(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 49152))
+            connect(&session, handle, SocketAddrV4::new(Ipv4Addr::LOCALHOST, 54),),
+            Ok(SocketOutcome::Completed(SocketConnectionStatus::Connected))
         );
+        release_tx.send(()).unwrap();
+        let status_with_error = in_flight.join().unwrap();
+        assert_eq!(
+            status_with_error.pending_error,
+            Some(SocketError::ConnectionRefused)
+        );
+        assert_eq!(status_with_error.local_address, Some(local_address));
+        assert_eq!(
+            provider.state.status_calls.load(Ordering::Relaxed),
+            status_calls + 1
+        );
+        let next_status = status(&session, handle).unwrap();
+        assert_eq!(
+            next_status.pending_error,
+            Some(SocketError::NetworkUnreachable)
+        );
+        assert_eq!(next_status.local_address, Some(next_local_address));
         assert_eq!(
             status(&session, handle).unwrap().status,
             SocketConnectionStatus::Connected

--- a/litebox_broker_core/src/socket.rs
+++ b/litebox_broker_core/src/socket.rs
@@ -33,6 +33,15 @@ pub struct AcceptedPlatformSocket {
     pub remote_address: SocketAddrV4,
 }
 
+/// Broker failure from a platform connect operation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PlatformConnectError {
+    /// The operation did not change the socket's peer.
+    PeerUnchanged(BrokerError),
+    /// The operation may have changed the socket's peer.
+    PeerIndeterminate(BrokerError),
+}
+
 /// Broker socket and endpoint metadata returned by an accept operation.
 pub struct AcceptedBrokerSocket {
     /// Broker handle naming the accepted socket.
@@ -97,8 +106,13 @@ pub trait PlatformSocket: Send + Sync {
     /// A stream attempt may return `Connecting` and stores ordinary failures as
     /// terminal state. A datagram connect completes immediately; the core
     /// permits replacing its peer and treats synchronous failures as retryable
-    /// operation outcomes.
-    fn connect(&self, address: SocketAddrV4) -> Result<SocketConnectionStatus>;
+    /// operation outcomes. A datagram `Failed` status must leave the previous
+    /// peer unchanged. Platform failures must distinguish a peer known to be
+    /// unchanged from one whose state is indeterminate.
+    fn connect(
+        &self,
+        address: SocketAddrV4,
+    ) -> core::result::Result<SocketConnectionStatus, PlatformConnectError>;
 
     /// Sends bytes without waiting for platform readiness.
     ///
@@ -271,7 +285,11 @@ pub fn connect(
             return Err(BrokerError::Internal);
         }
         Ok(status) => status,
-        Err(error) => {
+        Err(PlatformConnectError::PeerUnchanged(error)) => {
+            finish_connect(&object, SocketConnectionStatus::Unconnected);
+            return Err(error);
+        }
+        Err(PlatformConnectError::PeerIndeterminate(error)) => {
             finish_connect(&object, SocketConnectionStatus::Failed(SocketError::Other));
             return Err(error);
         }
@@ -696,7 +714,7 @@ pub fn status(session: &BrokerSession, handle: ObjectHandle) -> Result<SocketSta
             pending_error: None,
         });
     }
-    if matches!(status, SocketConnectionStatus::Failed(_)) {
+    if matches!(status, SocketConnectionStatus::Failed(_)) && !is_udp(create_request) {
         return Ok(SocketStatusResponse {
             status,
             local_address,
@@ -803,11 +821,23 @@ fn connect_datagram(
             Ok(SocketOutcome::Failed(error))
         }
         Ok(_) => {
-            finish_datagram_connect(object, previous_status, false);
+            finish_datagram_connect(
+                object,
+                SocketConnectionStatus::Failed(SocketError::Other),
+                true,
+            );
             Err(BrokerError::Internal)
         }
-        Err(error) => {
+        Err(PlatformConnectError::PeerUnchanged(error)) => {
             finish_datagram_connect(object, previous_status, false);
+            Err(error)
+        }
+        Err(PlatformConnectError::PeerIndeterminate(error)) => {
+            finish_datagram_connect(
+                object,
+                SocketConnectionStatus::Failed(SocketError::Other),
+                true,
+            );
             Err(error)
         }
     }
@@ -816,16 +846,17 @@ fn connect_datagram(
 fn finish_datagram_connect(
     object: &spin::RwLock<ObjectEntry>,
     status: SocketConnectionStatus,
-    connected: bool,
+    peer_state_changed: bool,
 ) {
     let mut object = object.write();
     if let ObjectEntry::Socket(socket) = &mut *object {
         socket.configuration_in_flight = false;
         socket.connection_status = status;
-        if connected {
-            // This only distinguishes operations concurrently in flight. A
-            // status call cannot overlap enough connects for wrapping to make
-            // a stale snapshot appear current.
+        if peer_state_changed {
+            // This distinguishes status snapshots from before a successful
+            // peer replacement or an indeterminate platform failure. A status
+            // call cannot overlap enough connects for wrapping to make a stale
+            // snapshot appear current.
             socket.datagram_connect_generation = socket.datagram_connect_generation.wrapping_add(1);
         }
     }
@@ -913,7 +944,10 @@ impl SocketResource {
             .as_ref()
     }
 
-    fn connect(&self, address: SocketAddrV4) -> Result<SocketConnectionStatus> {
+    fn connect(
+        &self,
+        address: SocketAddrV4,
+    ) -> core::result::Result<SocketConnectionStatus, PlatformConnectError> {
         self.platform_socket().connect(address)
     }
 
@@ -1073,6 +1107,7 @@ pub(crate) mod tests {
         dropped_sockets: AtomicUsize,
         fail_create: core::sync::atomic::AtomicBool,
         fail_connect: core::sync::atomic::AtomicBool,
+        fail_connect_indeterminate: core::sync::atomic::AtomicBool,
         fail_shutdown: core::sync::atomic::AtomicBool,
         failed_readiness: StdMutex<Option<ReadinessRegistration>>,
         live_readiness: StdMutex<Option<ReadinessRegistration>>,
@@ -1085,6 +1120,12 @@ pub(crate) mod tests {
 
         fn fail_next_connect(&self) {
             self.state.fail_connect.store(true, Ordering::Relaxed);
+        }
+
+        fn fail_next_connect_indeterminate(&self) {
+            self.state
+                .fail_connect_indeterminate
+                .store(true, Ordering::Relaxed);
         }
 
         fn fail_next_shutdown(&self) {
@@ -1158,12 +1199,26 @@ pub(crate) mod tests {
             Err(BrokerError::WouldBlock)
         }
 
-        fn connect(&self, _address: SocketAddrV4) -> Result<SocketConnectionStatus> {
+        fn connect(
+            &self,
+            _address: SocketAddrV4,
+        ) -> core::result::Result<SocketConnectionStatus, PlatformConnectError> {
             self.state.connect_calls.fetch_add(1, Ordering::Relaxed);
             if self.state.fail_connect.swap(false, Ordering::Relaxed) {
-                return Err(BrokerError::Internal);
+                return Err(PlatformConnectError::PeerUnchanged(BrokerError::Internal));
             }
-            self.readiness.publish(ReadinessFlags::WRITE)?;
+            if self
+                .state
+                .fail_connect_indeterminate
+                .swap(false, Ordering::Relaxed)
+            {
+                return Err(PlatformConnectError::PeerIndeterminate(
+                    BrokerError::Internal,
+                ));
+            }
+            self.readiness
+                .publish(ReadinessFlags::WRITE)
+                .map_err(PlatformConnectError::PeerIndeterminate)?;
             if is_udp(self.create_request) {
                 Ok(SocketConnectionStatus::Connected)
             } else {
@@ -1262,7 +1317,7 @@ pub(crate) mod tests {
         check_server_socket_operations(broker, provider);
         check_failed_listener_shutdown_preserves_state(broker, provider);
         check_listener_shutdown_does_not_race_listen(broker, provider);
-        check_connect_error_is_terminal(broker, provider);
+        check_connect_errors_classify_peer_state(broker, provider);
         check_concurrent_status_preserves_terminal_state(broker, provider);
         check_failed_status_preserves_local_address(broker, provider);
         check_quota_waits_for_deferred_retirement(broker, provider);
@@ -1396,6 +1451,7 @@ pub(crate) mod tests {
     }
 
     fn check_udp_socket_operations(broker: &BrokerCore, provider: &TestSocketProvider) {
+        let connect_calls_before = provider.state.connect_calls.load(Ordering::Relaxed);
         let session = broker
             .create_session(CallerCredential::Unauthenticated)
             .unwrap();
@@ -1445,6 +1501,46 @@ pub(crate) mod tests {
             connect(&session, handle, SocketAddrV4::new(Ipv4Addr::LOCALHOST, 53),),
             Ok(SocketOutcome::Completed(SocketConnectionStatus::Connected))
         );
+        provider.fail_next_connect();
+        assert_eq!(
+            connect(&session, handle, SocketAddrV4::new(Ipv4Addr::LOCALHOST, 54),),
+            Err(BrokerError::Internal)
+        );
+        assert_eq!(
+            status(&session, handle).unwrap().status,
+            SocketConnectionStatus::Connected
+        );
+        assert_eq!(
+            send_to(&session, handle, b"peer", SendFlags::NONE, None),
+            Ok(SocketOutcome::Completed(4))
+        );
+        provider.fail_next_connect_indeterminate();
+        assert_eq!(
+            connect(&session, handle, SocketAddrV4::new(Ipv4Addr::LOCALHOST, 54),),
+            Err(BrokerError::Internal)
+        );
+        provider
+            .state
+            .status_responses
+            .lock()
+            .unwrap()
+            .push_back(SocketStatusResponse {
+                status: SocketConnectionStatus::Connected,
+                local_address: None,
+                pending_error: Some(SocketError::ConnectionRefused),
+            });
+        assert_eq!(
+            status(&session, handle),
+            Ok(SocketStatusResponse {
+                status: SocketConnectionStatus::Failed(SocketError::Other),
+                local_address: None,
+                pending_error: Some(SocketError::ConnectionRefused),
+            })
+        );
+        assert_eq!(
+            send_to(&session, handle, b"peer", SendFlags::NONE, None),
+            Ok(SocketOutcome::Failed(SocketError::NotConnected))
+        );
         assert_eq!(
             connect(&session, handle, SocketAddrV4::new(Ipv4Addr::LOCALHOST, 54),),
             Ok(SocketOutcome::Completed(SocketConnectionStatus::Connected))
@@ -1470,7 +1566,10 @@ pub(crate) mod tests {
             Ok(SocketOutcome::Completed(()))
         );
         session.close_object_reference(handle).unwrap();
-        assert_eq!(provider.state.connect_calls.load(Ordering::Relaxed), 3);
+        assert_eq!(
+            provider.state.connect_calls.load(Ordering::Relaxed),
+            connect_calls_before + 4
+        );
     }
 
     fn check_server_socket_operations(broker: &BrokerCore, provider: &TestSocketProvider) {
@@ -1796,11 +1895,14 @@ pub(crate) mod tests {
         *provider.state.live_readiness.lock().unwrap() = None;
     }
 
-    fn check_connect_error_is_terminal(broker: &BrokerCore, provider: &TestSocketProvider) {
+    fn check_connect_errors_classify_peer_state(
+        broker: &BrokerCore,
+        provider: &TestSocketProvider,
+    ) {
         let session = broker
             .create_session(CallerCredential::Unauthenticated)
             .unwrap();
-        let handle = create(
+        let retryable = create(
             &session,
             create_request(),
             Arc::new(TestReadinessSink::default()),
@@ -1809,17 +1911,38 @@ pub(crate) mod tests {
         let calls_before = provider.state.connect_calls.load(Ordering::Relaxed);
         provider.fail_next_connect();
         assert_eq!(
-            connect(&session, handle, loopback_address()),
+            connect(&session, retryable, loopback_address()),
             Err(BrokerError::Internal)
         );
         assert_eq!(
-            connect(&session, handle, loopback_address()),
+            status(&session, retryable).unwrap().status,
+            SocketConnectionStatus::Unconnected
+        );
+        assert_eq!(
+            connect(&session, retryable, loopback_address()),
+            Ok(SocketOutcome::Completed(SocketConnectionStatus::Connecting))
+        );
+        session.close_object_reference(retryable).unwrap();
+
+        let poisoned = create(
+            &session,
+            create_request(),
+            Arc::new(TestReadinessSink::default()),
+        )
+        .unwrap();
+        provider.fail_next_connect_indeterminate();
+        assert_eq!(
+            connect(&session, poisoned, loopback_address()),
+            Err(BrokerError::Internal)
+        );
+        assert_eq!(
+            connect(&session, poisoned, loopback_address()),
             Ok(SocketOutcome::Completed(SocketConnectionStatus::Failed(
                 SocketError::Other
             )))
         );
         assert_eq!(
-            status(&session, handle),
+            status(&session, poisoned),
             Ok(SocketStatusResponse {
                 status: SocketConnectionStatus::Failed(SocketError::Other),
                 local_address: None,
@@ -1828,7 +1951,7 @@ pub(crate) mod tests {
         );
         assert_eq!(
             provider.state.connect_calls.load(Ordering::Relaxed),
-            calls_before + 1
+            calls_before + 3
         );
     }
 

--- a/litebox_broker_core/src/socket.rs
+++ b/litebox_broker_core/src/socket.rs
@@ -10,9 +10,10 @@ use core::sync::atomic::{AtomicUsize, Ordering};
 use litebox_broker_protocol::ObjectHandle;
 use litebox_broker_protocol::readiness::ReadinessFlags;
 use litebox_broker_protocol::socket::{
-    CreateSocketRequest, MAX_SOCKET_TRANSFER_SIZE, MAX_TCP_LISTEN_BACKLOG, ReceiveFlags,
-    ReceiveSocketResponse, SendFlags, ShutdownMode, SocketConnectionStatus, SocketError,
-    SocketOutcome, SocketStatusResponse,
+    CreateSocketRequest, IpProtocol, MAX_SOCKET_TRANSFER_SIZE, MAX_TCP_LISTEN_BACKLOG,
+    MAX_UDP_DATAGRAM_SIZE, ReceiveFlags, ReceiveFromFlags, ReceiveSocketResponse, SendFlags,
+    ShutdownMode, SocketConnectionStatus, SocketError, SocketOutcome, SocketStatusResponse,
+    SocketType,
 };
 use spin::Once;
 
@@ -40,6 +41,17 @@ pub struct AcceptedBrokerSocket {
     pub local_address: SocketAddrV4,
     /// Remote endpoint of the accepted connection.
     pub remote_address: SocketAddrV4,
+}
+
+/// Platform result for one datagram receive.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ReceivedPlatformDatagram {
+    /// Number of bytes copied into the caller's buffer.
+    pub received: usize,
+    /// Original datagram length before truncation.
+    pub datagram_length: usize,
+    /// Source address of the datagram.
+    pub source_address: SocketAddrV4,
 }
 
 /// Broker-wide socket provider supplied by the host platform.
@@ -82,11 +94,10 @@ pub trait PlatformSocket: Send + Sync {
 
     /// Starts a connection attempt.
     ///
-    /// `Unconnected` is not a valid result once the attempt reaches the
-    /// platform. A pending attempt returns `Connecting`, and ordinary network
-    /// failures return `Failed`. A broker error is surfaced for that call and
-    /// leaves the socket terminally failed, because retrying a platform call
-    /// that may already have side effects is unsafe.
+    /// A stream attempt may return `Connecting` and stores ordinary failures as
+    /// terminal state. A datagram connect completes immediately; the core
+    /// permits replacing its peer and treats synchronous failures as retryable
+    /// operation outcomes.
     fn connect(&self, address: SocketAddrV4) -> Result<SocketConnectionStatus>;
 
     /// Sends bytes without waiting for platform readiness.
@@ -94,6 +105,17 @@ pub trait PlatformSocket: Send + Sync {
     /// A temporarily full socket returns [`BrokerError::WouldBlock`]. Ordinary
     /// network failures return [`SocketOutcome::Failed`].
     fn send(&self, data: &[u8], flags: SendFlags) -> Result<SocketOutcome<usize>>;
+
+    /// Sends one complete datagram without waiting for platform readiness.
+    ///
+    /// A destination is required for an unconnected socket and omitted to use
+    /// the socket's connected peer. Partial successful sends are invalid.
+    fn send_to(
+        &self,
+        data: &[u8],
+        flags: SendFlags,
+        destination: Option<SocketAddrV4>,
+    ) -> Result<SocketOutcome<usize>>;
 
     /// Receives bytes without waiting for platform readiness.
     ///
@@ -108,13 +130,24 @@ pub trait PlatformSocket: Send + Sync {
         peek_length: u32,
     ) -> Result<SocketOutcome<ReceiveSocketResponse>>;
 
+    /// Receives one datagram without waiting for platform readiness.
+    ///
+    /// The original datagram length is returned even when the caller's buffer
+    /// is smaller, and zero-length datagrams are successful receives.
+    fn receive_from(
+        &self,
+        data: &mut [u8],
+        flags: ReceiveFromFlags,
+    ) -> Result<SocketOutcome<ReceivedPlatformDatagram>>;
+
     /// Shuts down one or both socket directions.
     fn shutdown(&self, mode: ShutdownMode) -> Result<SocketOutcome<()>>;
 
     /// Returns the authoritative connection status.
     ///
-    /// Once a connection attempt starts this returns `Connecting`, `Connected`,
-    /// or `Failed`, never `Unconnected`.
+    /// Stream sockets with an attempted connection return `Connecting`,
+    /// `Connected`, or `Failed`. Datagram sockets return `Unconnected` or
+    /// `Connected` and may change between those states through peer updates.
     fn status(&self) -> Result<SocketStatusResponse>;
 
     /// Returns the current readiness snapshot.
@@ -209,6 +242,10 @@ pub fn connect(
             return Ok(SocketOutcome::Failed(SocketError::PolicyDenied));
         }
         Err(error) => return Err(error),
+    }
+
+    if is_udp(create_request) {
+        return connect_datagram(&object, address);
     }
 
     let resource = {
@@ -313,6 +350,9 @@ pub fn listen(
         let ObjectEntry::Socket(socket) = &mut *object else {
             return Err(BrokerError::InvalidRights);
         };
+        if !is_tcp(socket.create_request) {
+            return Ok(SocketOutcome::Failed(SocketError::InvalidArgument));
+        }
         if socket.configuration_in_flight
             || socket.connect_in_flight
             || socket.connection_status != SocketConnectionStatus::Unconnected
@@ -386,6 +426,9 @@ pub fn accept(
         let ObjectEntry::Socket(socket) = &*listener else {
             return Err(BrokerError::InvalidRights);
         };
+        if !is_tcp(socket.create_request) {
+            return Ok(SocketOutcome::Failed(SocketError::InvalidArgument));
+        }
         if !socket.listening {
             return Ok(SocketOutcome::Failed(SocketError::NotConnected));
         }
@@ -439,10 +482,53 @@ pub fn send(
     if flags.has_unsupported_bits() {
         return Err(BrokerError::UnsupportedOperation);
     }
-    let resource = socket_resource(session, handle, ObjectRights::WRITE)?;
+    let (resource, create_request, _) = socket_state(session, handle, ObjectRights::WRITE)?;
+    if !is_tcp(create_request) {
+        return Ok(SocketOutcome::Failed(SocketError::InvalidArgument));
+    }
     let outcome = resource.send(data, flags)?;
     if let SocketOutcome::Completed(sent) = outcome
         && sent > data.len()
+    {
+        return Err(BrokerError::Internal);
+    }
+    Ok(outcome)
+}
+
+/// Sends one complete datagram without waiting for readiness.
+pub fn send_to(
+    session: &BrokerSession,
+    handle: ObjectHandle,
+    data: &[u8],
+    flags: SendFlags,
+    destination: Option<SocketAddrV4>,
+) -> Result<SocketOutcome<usize>> {
+    if flags.has_unsupported_bits() || data.len() > MAX_UDP_DATAGRAM_SIZE as usize {
+        return Err(BrokerError::UnsupportedOperation);
+    }
+    let (resource, create_request, connection_status) =
+        socket_state(session, handle, ObjectRights::WRITE)?;
+    if !is_udp(create_request) {
+        return Ok(SocketOutcome::Failed(SocketError::InvalidArgument));
+    }
+    if let Some(destination) = destination {
+        match session.core.policy.authorize_socket_connect(
+            session.caller_credential,
+            create_request,
+            destination,
+        ) {
+            Ok(()) => {}
+            Err(BrokerError::PolicyDenied) => {
+                return Ok(SocketOutcome::Failed(SocketError::PolicyDenied));
+            }
+            Err(error) => return Err(error),
+        }
+    } else if connection_status != SocketConnectionStatus::Connected {
+        return Ok(SocketOutcome::Failed(SocketError::NotConnected));
+    }
+    let outcome = resource.send_to(data, flags, destination)?;
+    if let SocketOutcome::Completed(sent) = outcome
+        && sent != data.len()
     {
         return Err(BrokerError::Internal);
     }
@@ -477,13 +563,41 @@ pub fn receive(
     {
         return Err(BrokerError::UnsupportedOperation);
     }
-    let resource = socket_resource(session, handle, ObjectRights::WAIT)?;
+    let (resource, create_request, _) = socket_state(session, handle, ObjectRights::WAIT)?;
+    if !is_tcp(create_request) {
+        return Ok(SocketOutcome::Failed(SocketError::InvalidArgument));
+    }
     if data.is_empty() {
         return Ok(SocketOutcome::Completed(ReceiveSocketResponse::Received(0)));
     }
     let outcome = resource.receive(data, flags, peek_offset, peek_length)?;
     if let SocketOutcome::Completed(ReceiveSocketResponse::Received(received)) = outcome
         && (received as usize > data.len() || received == 0)
+    {
+        return Err(BrokerError::Internal);
+    }
+    Ok(outcome)
+}
+
+/// Receives one datagram without waiting for readiness.
+pub fn receive_from(
+    session: &BrokerSession,
+    handle: ObjectHandle,
+    data: &mut [u8],
+    flags: ReceiveFromFlags,
+) -> Result<SocketOutcome<ReceivedPlatformDatagram>> {
+    if flags.has_unsupported_bits() || data.len() > MAX_UDP_DATAGRAM_SIZE as usize {
+        return Err(BrokerError::UnsupportedOperation);
+    }
+    let (resource, create_request, _) = socket_state(session, handle, ObjectRights::WAIT)?;
+    if !is_udp(create_request) {
+        return Ok(SocketOutcome::Failed(SocketError::InvalidArgument));
+    }
+    let outcome = resource.receive_from(data, flags)?;
+    if let SocketOutcome::Completed(received) = outcome
+        && (received.received > data.len()
+            || received.datagram_length < received.received
+            || received.datagram_length > MAX_UDP_DATAGRAM_SIZE as usize)
     {
         return Err(BrokerError::Internal);
     }
@@ -502,6 +616,11 @@ pub fn shutdown(
         let ObjectEntry::Socket(socket) = &mut *object else {
             return Err(BrokerError::InvalidRights);
         };
+        if is_udp(socket.create_request)
+            && matches!(mode, ShutdownMode::Abort | ShutdownMode::StopListening)
+        {
+            return Ok(SocketOutcome::Failed(SocketError::InvalidArgument));
+        }
         if socket.listening && !matches!(mode, ShutdownMode::Abort | ShutdownMode::StopListening) {
             return Ok(SocketOutcome::Failed(SocketError::NotConnected));
         }
@@ -542,16 +661,25 @@ pub fn shutdown(
 /// Returns broker-authoritative socket status and consumes its pending asynchronous error.
 pub fn status(session: &BrokerSession, handle: ObjectHandle) -> Result<SocketStatusResponse> {
     let object = session.authorized_object(handle, ObjectRights::WAIT)?;
-    let (resource, status, local_address, connect_in_flight) = {
+    let (
+        resource,
+        create_request,
+        status,
+        local_address,
+        connect_in_flight,
+        datagram_connect_generation,
+    ) = {
         let object = object.read();
         let ObjectEntry::Socket(socket) = &*object else {
             return Err(BrokerError::InvalidRights);
         };
         (
             Arc::clone(&socket.resource),
+            socket.create_request,
             socket.connection_status,
             socket.local_address,
             socket.connect_in_flight,
+            socket.datagram_connect_generation,
         )
     };
     if connect_in_flight {
@@ -561,7 +689,7 @@ pub fn status(session: &BrokerSession, handle: ObjectHandle) -> Result<SocketSta
             pending_error: None,
         });
     }
-    if matches!(status, SocketConnectionStatus::Unconnected) {
+    if matches!(status, SocketConnectionStatus::Unconnected) && !is_udp(create_request) {
         return Ok(SocketStatusResponse {
             status,
             local_address,
@@ -580,14 +708,33 @@ pub fn status(session: &BrokerSession, handle: ObjectHandle) -> Result<SocketSta
     let ObjectEntry::Socket(socket) = &mut *object else {
         return Err(BrokerError::InvalidRights);
     };
-    if socket.connection_status == SocketConnectionStatus::Connecting
+    if is_udp(socket.create_request) {
+        if matches!(
+            response.status,
+            SocketConnectionStatus::Connecting | SocketConnectionStatus::Failed(_)
+        ) {
+            return Err(BrokerError::Internal);
+        }
+        if socket.datagram_connect_generation != datagram_connect_generation {
+            // The platform response is a valid snapshot from before or after a
+            // concurrent peer replacement, but must not overwrite the newer
+            // broker state.
+            return Ok(response);
+        }
+    } else if socket.connection_status == SocketConnectionStatus::Connecting
         && response.status == SocketConnectionStatus::Unconnected
     {
         return Err(BrokerError::Internal);
     }
-    socket.local_address = socket.local_address.or(response.local_address);
+    socket.local_address = if is_udp(socket.create_request) {
+        response.local_address.or(socket.local_address)
+    } else {
+        socket.local_address.or(response.local_address)
+    };
     response.local_address = socket.local_address;
-    if socket.connection_status == SocketConnectionStatus::Connecting {
+    if is_udp(socket.create_request) {
+        response.status = socket.connection_status;
+    } else if socket.connection_status == SocketConnectionStatus::Connecting {
         socket.connection_status = response.status;
     } else {
         // Another status call reached a terminal state while this platform query was in flight.
@@ -596,6 +743,7 @@ pub fn status(session: &BrokerSession, handle: ObjectHandle) -> Result<SocketSta
     Ok(response)
 }
 
+#[cfg(test)]
 fn socket_resource(
     session: &BrokerSession,
     handle: ObjectHandle,
@@ -607,6 +755,80 @@ fn socket_resource(
         return Err(BrokerError::InvalidRights);
     };
     Ok(Arc::clone(&socket.resource))
+}
+
+fn socket_state(
+    session: &BrokerSession,
+    handle: ObjectHandle,
+    required_rights: ObjectRights,
+) -> Result<(
+    Arc<SocketResource>,
+    CreateSocketRequest,
+    SocketConnectionStatus,
+)> {
+    let object = session.authorized_object(handle, required_rights)?;
+    let object = object.read();
+    let ObjectEntry::Socket(socket) = &*object else {
+        return Err(BrokerError::InvalidRights);
+    };
+    Ok((
+        Arc::clone(&socket.resource),
+        socket.create_request,
+        socket.connection_status,
+    ))
+}
+
+fn connect_datagram(
+    object: &spin::RwLock<ObjectEntry>,
+    address: SocketAddrV4,
+) -> Result<SocketOutcome<SocketConnectionStatus>> {
+    let (resource, previous_status) = {
+        let mut object = object.write();
+        let ObjectEntry::Socket(socket) = &mut *object else {
+            return Err(BrokerError::InvalidRights);
+        };
+        if socket.configuration_in_flight || socket.connect_in_flight || socket.listening {
+            return Ok(SocketOutcome::Failed(SocketError::InvalidArgument));
+        }
+        socket.configuration_in_flight = true;
+        (Arc::clone(&socket.resource), socket.connection_status)
+    };
+    match resource.connect(address) {
+        Ok(SocketConnectionStatus::Connected) => {
+            finish_datagram_connect(object, SocketConnectionStatus::Connected, true);
+            Ok(SocketOutcome::Completed(SocketConnectionStatus::Connected))
+        }
+        Ok(SocketConnectionStatus::Failed(error)) => {
+            finish_datagram_connect(object, previous_status, false);
+            Ok(SocketOutcome::Failed(error))
+        }
+        Ok(_) => {
+            finish_datagram_connect(object, previous_status, false);
+            Err(BrokerError::Internal)
+        }
+        Err(error) => {
+            finish_datagram_connect(object, previous_status, false);
+            Err(error)
+        }
+    }
+}
+
+fn finish_datagram_connect(
+    object: &spin::RwLock<ObjectEntry>,
+    status: SocketConnectionStatus,
+    connected: bool,
+) {
+    let mut object = object.write();
+    if let ObjectEntry::Socket(socket) = &mut *object {
+        socket.configuration_in_flight = false;
+        socket.connection_status = status;
+        if connected {
+            // This only distinguishes operations concurrently in flight. A
+            // status call cannot overlap enough connects for wrapping to make
+            // a stale snapshot appear current.
+            socket.datagram_connect_generation = socket.datagram_connect_generation.wrapping_add(1);
+        }
+    }
 }
 
 fn finish_connect(object: &spin::RwLock<ObjectEntry>, status: SocketConnectionStatus) {
@@ -638,6 +860,7 @@ pub(crate) struct SocketObject {
     connect_in_flight: bool,
     configuration_in_flight: bool,
     listening: bool,
+    datagram_connect_generation: u64,
 }
 
 impl SocketObject {
@@ -650,6 +873,7 @@ impl SocketObject {
             connect_in_flight: false,
             configuration_in_flight: false,
             listening: false,
+            datagram_connect_generation: 0,
         }
     }
 
@@ -666,6 +890,7 @@ impl SocketObject {
             connect_in_flight: false,
             configuration_in_flight: false,
             listening: false,
+            datagram_connect_generation: 0,
         }
     }
 
@@ -711,6 +936,15 @@ impl SocketResource {
         self.platform_socket().send(data, flags)
     }
 
+    fn send_to(
+        &self,
+        data: &[u8],
+        flags: SendFlags,
+        destination: Option<SocketAddrV4>,
+    ) -> Result<SocketOutcome<usize>> {
+        self.platform_socket().send_to(data, flags, destination)
+    }
+
     fn receive(
         &self,
         data: &mut [u8],
@@ -720,6 +954,14 @@ impl SocketResource {
     ) -> Result<SocketOutcome<ReceiveSocketResponse>> {
         self.platform_socket()
             .receive(data, flags, peek_offset, peek_length)
+    }
+
+    fn receive_from(
+        &self,
+        data: &mut [u8],
+        flags: ReceiveFromFlags,
+    ) -> Result<SocketOutcome<ReceivedPlatformDatagram>> {
+        self.platform_socket().receive_from(data, flags)
     }
 
     fn shutdown(&self, mode: ShutdownMode) -> Result<SocketOutcome<()>> {
@@ -733,6 +975,20 @@ impl SocketResource {
     pub(crate) fn readiness(&self) -> ReadinessFlags {
         self.platform_socket().readiness()
     }
+}
+
+const fn is_tcp(request: CreateSocketRequest) -> bool {
+    matches!(
+        (request.socket_type, request.protocol),
+        (SocketType::Stream, IpProtocol::Tcp)
+    )
+}
+
+const fn is_udp(request: CreateSocketRequest) -> bool {
+    matches!(
+        (request.socket_type, request.protocol),
+        (SocketType::Datagram, IpProtocol::Udp)
+    )
 }
 
 impl Drop for SocketResource {
@@ -856,6 +1112,7 @@ pub(crate) mod tests {
             Ok(Arc::new(TestPlatformSocket {
                 state: Arc::clone(&self.state),
                 readiness,
+                create_request: request,
             }))
         }
 
@@ -867,6 +1124,7 @@ pub(crate) mod tests {
     struct TestPlatformSocket {
         state: Arc<TestSocketState>,
         readiness: ReadinessRegistration,
+        create_request: CreateSocketRequest,
     }
 
     impl PlatformSocket for TestPlatformSocket {
@@ -906,10 +1164,24 @@ pub(crate) mod tests {
                 return Err(BrokerError::Internal);
             }
             self.readiness.publish(ReadinessFlags::WRITE)?;
-            Ok(SocketConnectionStatus::Connecting)
+            if is_udp(self.create_request) {
+                Ok(SocketConnectionStatus::Connected)
+            } else {
+                Ok(SocketConnectionStatus::Connecting)
+            }
         }
 
         fn send(&self, data: &[u8], _flags: SendFlags) -> Result<SocketOutcome<usize>> {
+            self.state.sent.lock().unwrap().extend_from_slice(data);
+            Ok(SocketOutcome::Completed(data.len()))
+        }
+
+        fn send_to(
+            &self,
+            data: &[u8],
+            _flags: SendFlags,
+            _destination: Option<SocketAddrV4>,
+        ) -> Result<SocketOutcome<usize>> {
             self.state.sent.lock().unwrap().extend_from_slice(data);
             Ok(SocketOutcome::Completed(data.len()))
         }
@@ -926,6 +1198,20 @@ pub(crate) mod tests {
             Ok(SocketOutcome::Completed(ReceiveSocketResponse::Received(
                 u32::try_from(received).unwrap(),
             )))
+        }
+
+        fn receive_from(
+            &self,
+            data: &mut [u8],
+            _flags: ReceiveFromFlags,
+        ) -> Result<SocketOutcome<ReceivedPlatformDatagram>> {
+            let received = data.len().min(2);
+            data[..received].copy_from_slice(&[7, 9][..received]);
+            Ok(SocketOutcome::Completed(ReceivedPlatformDatagram {
+                received,
+                datagram_length: 4,
+                source_address: SocketAddrV4::new(Ipv4Addr::LOCALHOST, 49153),
+            }))
         }
 
         fn shutdown(&self, _mode: ShutdownMode) -> Result<SocketOutcome<()>> {
@@ -971,6 +1257,8 @@ pub(crate) mod tests {
     pub(crate) fn check_socket_lifecycle(broker: &BrokerCore, provider: &TestSocketProvider) {
         check_failed_create_rolls_back(broker, provider);
         check_socket_operations_and_policy(broker, provider);
+        check_udp_socket_operations(broker, provider);
+        check_concurrent_udp_status_does_not_regress_connection(broker, provider);
         check_server_socket_operations(broker, provider);
         check_failed_listener_shutdown_preserves_state(broker, provider);
         check_listener_shutdown_does_not_race_listen(broker, provider);
@@ -1107,6 +1395,84 @@ pub(crate) mod tests {
         );
     }
 
+    fn check_udp_socket_operations(broker: &BrokerCore, provider: &TestSocketProvider) {
+        let session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let readiness = Arc::new(TestReadinessSink::default());
+        let request = CreateSocketRequest {
+            address_family: AddressFamily::Ipv4,
+            socket_type: SocketType::Datagram,
+            protocol: IpProtocol::Udp,
+        };
+        let handle = create(&session, request, readiness).unwrap();
+
+        assert_eq!(
+            send_to(&session, handle, b"x", SendFlags::NONE, None),
+            Ok(SocketOutcome::Failed(SocketError::NotConnected))
+        );
+        assert_eq!(
+            send_to(
+                &session,
+                handle,
+                b"x",
+                SendFlags::NONE,
+                Some(SocketAddrV4::new(Ipv4Addr::new(10, 0, 0, 1), 53)),
+            ),
+            Ok(SocketOutcome::Failed(SocketError::PolicyDenied))
+        );
+        assert_eq!(
+            send_to(
+                &session,
+                handle,
+                b"udp",
+                SendFlags::NONE,
+                Some(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 53)),
+            ),
+            Ok(SocketOutcome::Completed(3))
+        );
+        let mut data = [0; 2];
+        assert_eq!(
+            receive_from(&session, handle, &mut data, ReceiveFromFlags::PEEK),
+            Ok(SocketOutcome::Completed(ReceivedPlatformDatagram {
+                received: 2,
+                datagram_length: 4,
+                source_address: SocketAddrV4::new(Ipv4Addr::LOCALHOST, 49153),
+            }))
+        );
+        assert_eq!(data, [7, 9]);
+        assert_eq!(
+            connect(&session, handle, SocketAddrV4::new(Ipv4Addr::LOCALHOST, 53),),
+            Ok(SocketOutcome::Completed(SocketConnectionStatus::Connected))
+        );
+        assert_eq!(
+            connect(&session, handle, SocketAddrV4::new(Ipv4Addr::LOCALHOST, 54),),
+            Ok(SocketOutcome::Completed(SocketConnectionStatus::Connected))
+        );
+        assert_eq!(
+            send_to(&session, handle, b"peer", SendFlags::NONE, None),
+            Ok(SocketOutcome::Completed(4))
+        );
+        assert_eq!(
+            send(&session, handle, b"x", SendFlags::NONE),
+            Ok(SocketOutcome::Failed(SocketError::InvalidArgument))
+        );
+        assert_eq!(
+            listen(&session, handle, 1),
+            Ok(SocketOutcome::Failed(SocketError::InvalidArgument))
+        );
+        assert_eq!(
+            shutdown(&session, handle, ShutdownMode::Abort),
+            Ok(SocketOutcome::Failed(SocketError::InvalidArgument))
+        );
+        assert_eq!(
+            shutdown(&session, handle, ShutdownMode::Both),
+            Ok(SocketOutcome::Completed(()))
+        );
+        session.close_object_reference(handle).unwrap();
+        assert_eq!(provider.state.connect_calls.load(Ordering::Relaxed), 3);
+    }
+
     fn check_server_socket_operations(broker: &BrokerCore, provider: &TestSocketProvider) {
         let session = broker
             .create_session(CallerCredential::Unauthenticated)
@@ -1193,6 +1559,55 @@ pub(crate) mod tests {
             Some(&DEFAULT_TCP_LISTEN_ADDRESS)
         );
         session.close_object_reference(auto_bound).unwrap();
+    }
+
+    fn check_concurrent_udp_status_does_not_regress_connection(
+        broker: &BrokerCore,
+        provider: &TestSocketProvider,
+    ) {
+        let session = Arc::new(
+            broker
+                .create_session(CallerCredential::Unauthenticated)
+                .unwrap(),
+        );
+        let handle = create(
+            &session,
+            create_udp_request(),
+            Arc::new(TestReadinessSink::default()),
+        )
+        .unwrap();
+        provider
+            .state
+            .status_responses
+            .lock()
+            .unwrap()
+            .push_back(SocketStatusResponse {
+                status: SocketConnectionStatus::Unconnected,
+                local_address: Some(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 49152)),
+                pending_error: None,
+            });
+        let (started_tx, started_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        *provider.state.status_block.lock().unwrap() = Some((started_tx, release_rx));
+
+        let status_session = Arc::clone(&session);
+        let in_flight = std::thread::spawn(move || status(&status_session, handle).unwrap());
+        started_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+        assert_eq!(
+            connect(&session, handle, loopback_address()),
+            Ok(SocketOutcome::Completed(SocketConnectionStatus::Connected))
+        );
+        release_tx.send(()).unwrap();
+        let stale = in_flight.join().unwrap();
+        assert_eq!(stale.status, SocketConnectionStatus::Unconnected);
+        assert_eq!(
+            stale.local_address,
+            Some(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 49152))
+        );
+        assert_eq!(
+            status(&session, handle).unwrap().status,
+            SocketConnectionStatus::Connected
+        );
     }
 
     fn check_failed_listener_shutdown_preserves_state(
@@ -1521,6 +1936,14 @@ pub(crate) mod tests {
             address_family: AddressFamily::Ipv4,
             socket_type: SocketType::Stream,
             protocol: IpProtocol::Tcp,
+        }
+    }
+
+    const fn create_udp_request() -> CreateSocketRequest {
+        CreateSocketRequest {
+            address_family: AddressFamily::Ipv4,
+            socket_type: SocketType::Datagram,
+            protocol: IpProtocol::Udp,
         }
     }
 

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -679,7 +679,8 @@ mod tests {
     use core::net::{Ipv4Addr, SocketAddrV4};
     use litebox_broker_core::readiness::ReadinessRegistration;
     use litebox_broker_core::socket::{
-        AcceptedPlatformSocket, PlatformSocket, ReceivedPlatformDatagram, SocketProvider,
+        AcceptedPlatformSocket, PlatformConnectError, PlatformSocket, ReceivedPlatformDatagram,
+        SocketProvider,
     };
     use litebox_broker_core::{ObjectRights, PolicyEngine, SessionId, SocketPolicy};
     use litebox_broker_protocol::event::{
@@ -790,9 +791,10 @@ mod tests {
         fn connect(
             &self,
             _address: SocketAddrV4,
-        ) -> litebox_broker_core::Result<SocketConnectionStatus> {
+        ) -> core::result::Result<SocketConnectionStatus, PlatformConnectError> {
             self.readiness
-                .publish(litebox_broker_protocol::readiness::ReadinessFlags::WRITE)?;
+                .publish(litebox_broker_protocol::readiness::ReadinessFlags::WRITE)
+                .map_err(PlatformConnectError::PeerUnchanged)?;
             if self.create_request.socket_type == SocketType::Datagram {
                 Ok(SocketConnectionStatus::Connected)
             } else {

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -867,7 +867,7 @@ mod tests {
     fn host_request_handling_uses_one_broker_core() {
         let broker = BrokerCore::new(
             PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-                .with_socket_policy(SocketPolicy::Ipv4LoopbackTcpUdp),
+                .with_socket_policy(SocketPolicy::Ipv4Loopback),
             Arc::new(TestSocketProvider),
         )
         .unwrap();

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -40,7 +40,8 @@ use litebox_broker_protocol::shared_buffer::{
 use litebox_broker_protocol::socket::{
     AcceptSocketResponse, BindSocketResponse, ConnectSocketResponse, CreateSocketResponse,
     ListenSocketResponse, MAX_SOCKET_PEEK_SIZE, MAX_SOCKET_TRANSFER_SIZE, MAX_TCP_LISTEN_BACKLOG,
-    ReceiveFlags, ReceiveSocketResponse, SendSocketResponse, SocketOutcome,
+    MAX_UDP_DATAGRAM_SIZE, ReceiveFlags, ReceiveFromSocketResponse, ReceiveSocketResponse,
+    SendSocketResponse, SendToSocketResponse, SocketOutcome,
 };
 use litebox_broker_protocol::{BROKER_PROTOCOL_VERSION, RequestId};
 use litebox_broker_transport::channel::{HostReceive, HostSetupChannel, PeerCredential};
@@ -92,7 +93,9 @@ impl<Memory: SharedMemory> BrokerHostAssociation<'_, Memory> {
             BrokerOperation::Pipe(PipeRequest::Read(request)) => Some(request.buffer),
             BrokerOperation::Pipe(PipeRequest::Write(request)) => Some(request.buffer),
             BrokerOperation::Socket(SocketRequest::Send(request)) => Some(request.buffer),
+            BrokerOperation::Socket(SocketRequest::SendTo(request)) => Some(request.buffer),
             BrokerOperation::Socket(SocketRequest::Receive(request)) => Some(request.buffer),
+            BrokerOperation::Socket(SocketRequest::ReceiveFrom(request)) => Some(request.buffer),
             BrokerOperation::CloseObject(_)
             | BrokerOperation::CheckReadiness(_)
             | BrokerOperation::Event(_)
@@ -445,6 +448,39 @@ fn handle_socket_request<Memory: SharedMemory>(
                 SocketOutcome::Failed(error) => Ok(SocketResponse::Failed(error)),
             }
         }
+        SocketRequest::SendTo(request) => {
+            if request.flags.has_unsupported_bits() || request.buffer.length > MAX_UDP_DATAGRAM_SIZE
+            {
+                return Err(RequestFailure::Abort(ErrorCode::MalformedRequest));
+            }
+            let length = request.buffer.length as usize;
+            let mut data = Vec::new();
+            if data.try_reserve_exact(length).is_err() {
+                return Err(RequestFailure::Respond(ErrorCode::OutOfMemory));
+            }
+            data.resize(length, 0);
+            shared_buffers
+                .read(request.buffer.slot_index, &mut data)
+                .map_err(|_| RequestFailure::Abort(ErrorCode::Internal))?;
+            match litebox_broker_core::socket::send_to(
+                session,
+                request.handle,
+                &data,
+                request.flags,
+                request.destination,
+            )
+            .map_err(RequestFailure::from)?
+            {
+                SocketOutcome::Completed(sent) => {
+                    Ok(SocketResponse::SendTo(SendToSocketResponse {
+                        sent: sent
+                            .try_into()
+                            .map_err(|_| RequestFailure::Abort(ErrorCode::Internal))?,
+                    }))
+                }
+                SocketOutcome::Failed(error) => Ok(SocketResponse::Failed(error)),
+            }
+        }
         SocketRequest::Receive(request) => {
             let peek = request.flags.contains(ReceiveFlags::PEEK);
             let peek_end = request.peek_offset.checked_add(request.buffer.length);
@@ -486,6 +522,44 @@ fn handle_socket_request<Memory: SharedMemory>(
                             .map_err(|_| RequestFailure::Abort(ErrorCode::Internal))?;
                     }
                     Ok(SocketResponse::Receive(response))
+                }
+                SocketOutcome::Failed(error) => Ok(SocketResponse::Failed(error)),
+            }
+        }
+        SocketRequest::ReceiveFrom(request) => {
+            if request.flags.has_unsupported_bits() || request.buffer.length > MAX_UDP_DATAGRAM_SIZE
+            {
+                return Err(RequestFailure::Abort(ErrorCode::MalformedRequest));
+            }
+            let length = request.buffer.length as usize;
+            let mut data = Vec::new();
+            if data.try_reserve_exact(length).is_err() {
+                return Err(RequestFailure::Respond(ErrorCode::OutOfMemory));
+            }
+            data.resize(length, 0);
+            match litebox_broker_core::socket::receive_from(
+                session,
+                request.handle,
+                &mut data,
+                request.flags,
+            )
+            .map_err(RequestFailure::from)?
+            {
+                SocketOutcome::Completed(received) => {
+                    shared_buffers
+                        .write(request.buffer.slot_index, &data[..received.received])
+                        .map_err(|_| RequestFailure::Abort(ErrorCode::Internal))?;
+                    Ok(SocketResponse::ReceiveFrom(ReceiveFromSocketResponse {
+                        received: received
+                            .received
+                            .try_into()
+                            .map_err(|_| RequestFailure::Abort(ErrorCode::Internal))?,
+                        datagram_length: received
+                            .datagram_length
+                            .try_into()
+                            .map_err(|_| RequestFailure::Abort(ErrorCode::Internal))?,
+                        source_address: received.source_address,
+                    }))
                 }
                 SocketOutcome::Failed(error) => Ok(SocketResponse::Failed(error)),
             }
@@ -604,7 +678,9 @@ mod tests {
     use core::cell::Cell;
     use core::net::{Ipv4Addr, SocketAddrV4};
     use litebox_broker_core::readiness::ReadinessRegistration;
-    use litebox_broker_core::socket::{AcceptedPlatformSocket, PlatformSocket, SocketProvider};
+    use litebox_broker_core::socket::{
+        AcceptedPlatformSocket, PlatformSocket, ReceivedPlatformDatagram, SocketProvider,
+    };
     use litebox_broker_core::{ObjectRights, PolicyEngine, SessionId, SocketPolicy};
     use litebox_broker_protocol::event::{
         AddEventRequest, ConsumeEventRequest, CreateEventRequest, EventConsumeMode,
@@ -617,8 +693,10 @@ mod tests {
     };
     use litebox_broker_protocol::socket::{
         AddressFamily, ConnectSocketRequest, CreateSocketRequest, IpProtocol, ReceiveFlags,
-        ReceiveSocketRequest, SendFlags, SendSocketRequest, ShutdownMode, ShutdownSocketRequest,
-        SocketConnectionStatus, SocketError, SocketStatusRequest, SocketStatusResponse, SocketType,
+        ReceiveFromFlags, ReceiveFromSocketRequest, ReceiveFromSocketResponse,
+        ReceiveSocketRequest, SendFlags, SendSocketRequest, SendToSocketRequest,
+        SendToSocketResponse, ShutdownMode, ShutdownSocketRequest, SocketConnectionStatus,
+        SocketError, SocketStatusRequest, SocketStatusResponse, SocketType,
     };
     use litebox_broker_protocol::{ObjectHandle, ProtocolVersion, RequestId};
     use litebox_broker_transport::shared_memory::{SharedBufferPool, SharedMemoryError};
@@ -662,10 +740,13 @@ mod tests {
         fn create(
             &self,
             _session_id: SessionId,
-            _request: CreateSocketRequest,
+            request: CreateSocketRequest,
             readiness: ReadinessRegistration,
         ) -> litebox_broker_core::Result<Arc<dyn PlatformSocket>> {
-            Ok(Arc::new(TestPlatformSocket { readiness }))
+            Ok(Arc::new(TestPlatformSocket {
+                readiness,
+                create_request: request,
+            }))
         }
 
         fn close_session(&self, _session_id: SessionId) {}
@@ -673,6 +754,7 @@ mod tests {
 
     struct TestPlatformSocket {
         readiness: ReadinessRegistration,
+        create_request: CreateSocketRequest,
     }
 
     impl PlatformSocket for TestPlatformSocket {
@@ -711,13 +793,26 @@ mod tests {
         ) -> litebox_broker_core::Result<SocketConnectionStatus> {
             self.readiness
                 .publish(litebox_broker_protocol::readiness::ReadinessFlags::WRITE)?;
-            Ok(SocketConnectionStatus::Connecting)
+            if self.create_request.socket_type == SocketType::Datagram {
+                Ok(SocketConnectionStatus::Connected)
+            } else {
+                Ok(SocketConnectionStatus::Connecting)
+            }
         }
 
         fn send(
             &self,
             data: &[u8],
             _flags: SendFlags,
+        ) -> litebox_broker_core::Result<SocketOutcome<usize>> {
+            Ok(SocketOutcome::Completed(data.len()))
+        }
+
+        fn send_to(
+            &self,
+            data: &[u8],
+            _flags: SendFlags,
+            _destination: Option<SocketAddrV4>,
         ) -> litebox_broker_core::Result<SocketOutcome<usize>> {
             Ok(SocketOutcome::Completed(data.len()))
         }
@@ -734,6 +829,20 @@ mod tests {
             Ok(SocketOutcome::Completed(ReceiveSocketResponse::Received(
                 u32::try_from(received).unwrap(),
             )))
+        }
+
+        fn receive_from(
+            &self,
+            data: &mut [u8],
+            _flags: ReceiveFromFlags,
+        ) -> litebox_broker_core::Result<SocketOutcome<ReceivedPlatformDatagram>> {
+            let received = data.len().min(3);
+            data[..received].copy_from_slice(&[4, 5, 6][..received]);
+            Ok(SocketOutcome::Completed(ReceivedPlatformDatagram {
+                received,
+                datagram_length: 4,
+                source_address: SocketAddrV4::new(Ipv4Addr::LOCALHOST, 49153),
+            }))
         }
 
         fn shutdown(&self, _mode: ShutdownMode) -> litebox_broker_core::Result<SocketOutcome<()>> {
@@ -758,7 +867,7 @@ mod tests {
     fn host_request_handling_uses_one_broker_core() {
         let broker = BrokerCore::new(
             PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-                .with_socket_policy(SocketPolicy::Ipv4LoopbackTcp),
+                .with_socket_policy(SocketPolicy::Ipv4LoopbackTcpUdp),
             Arc::new(TestSocketProvider),
         )
         .unwrap();
@@ -1323,6 +1432,70 @@ mod tests {
             RequestFailure::Abort(ErrorCode::Internal)
         );
         session.close_object_reference(response.handle).unwrap();
+
+        let created = handle_test_request_with_buffers(
+            &session,
+            BrokerOperation::Socket(SocketRequest::Create(CreateSocketRequest {
+                address_family: AddressFamily::Ipv4,
+                socket_type: SocketType::Datagram,
+                protocol: IpProtocol::Udp,
+            })),
+            &shared_buffers,
+        );
+        let BrokerResult::Socket(SocketResponse::Create(udp)) = created else {
+            panic!("expected successful UDP socket creation");
+        };
+        shared_buffers
+            .write(SharedBufferSlotIndex(3), &[8, 9])
+            .unwrap();
+        assert_eq!(
+            handle_test_request_with_buffers(
+                &session,
+                BrokerOperation::Socket(SocketRequest::SendTo(SendToSocketRequest {
+                    handle: udp.handle,
+                    buffer: descriptor(3, 2),
+                    flags: SendFlags::NONE,
+                    destination: Some(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 53)),
+                })),
+                &shared_buffers,
+            ),
+            BrokerResult::Socket(SocketResponse::SendTo(SendToSocketResponse { sent: 2 }))
+        );
+        assert_eq!(
+            handle_test_request_with_buffers(
+                &session,
+                BrokerOperation::Socket(SocketRequest::ReceiveFrom(ReceiveFromSocketRequest {
+                    handle: udp.handle,
+                    buffer: descriptor(5, 2),
+                    flags: ReceiveFromFlags::PEEK,
+                })),
+                &shared_buffers,
+            ),
+            BrokerResult::Socket(SocketResponse::ReceiveFrom(ReceiveFromSocketResponse {
+                received: 2,
+                datagram_length: 4,
+                source_address: SocketAddrV4::new(Ipv4Addr::LOCALHOST, 49153),
+            }))
+        );
+        let mut received = [0; 2];
+        shared_buffers
+            .read(SharedBufferSlotIndex(5), &mut received)
+            .unwrap();
+        assert_eq!(received, [4, 5]);
+        assert_eq!(
+            complete_request(handle_request(
+                &session,
+                BrokerOperation::Socket(SocketRequest::ReceiveFrom(ReceiveFromSocketRequest {
+                    handle: udp.handle,
+                    buffer: descriptor(5, 0),
+                    flags: ReceiveFromFlags(1 << 31),
+                })),
+                &shared_buffers,
+                &test_readiness_sink(),
+            )),
+            Err(ErrorCode::MalformedRequest)
+        );
+        session.close_object_reference(udp.handle).unwrap();
     }
 
     fn shared_buffer_usage_rejects_invalid_descriptors() {

--- a/litebox_broker_local/src/socket.rs
+++ b/litebox_broker_local/src/socket.rs
@@ -11,9 +11,10 @@ use litebox_broker_protocol::shared_buffer::SharedBufferDescriptor;
 use litebox_broker_protocol::socket::{
     AcceptSocketRequest, AcceptSocketResponse, AddressFamily, BindSocketRequest,
     ConnectSocketRequest, CreateSocketRequest, IpProtocol, ListenSocketRequest,
-    MAX_SOCKET_TRANSFER_SIZE, ReceiveSocketRequest, ReceiveSocketResponse, SendFlags,
-    SendSocketRequest, ShutdownMode, ShutdownSocketRequest, SocketConnectionStatus, SocketError,
-    SocketStatusRequest, SocketStatusResponse, SocketType,
+    MAX_SOCKET_TRANSFER_SIZE, MAX_UDP_DATAGRAM_SIZE, ReceiveFromFlags, ReceiveFromSocketRequest,
+    ReceiveFromSocketResponse, ReceiveSocketRequest, ReceiveSocketResponse, SendFlags,
+    SendSocketRequest, SendToSocketRequest, ShutdownMode, ShutdownSocketRequest,
+    SocketConnectionStatus, SocketError, SocketStatusRequest, SocketStatusResponse, SocketType,
 };
 use litebox_broker_transport::channel::LocalCallChannel;
 
@@ -30,6 +31,23 @@ impl<Channel: LocalCallChannel> BrokerLocal<Channel> {
             address_family: AddressFamily::Ipv4,
             socket_type: SocketType::Stream,
             protocol: IpProtocol::Tcp,
+        }))?;
+        let SocketResponse::Create(response) = response else {
+            panic!("broker returned unexpected socket create response: {response:?}");
+        };
+        Ok(response.handle)
+    }
+
+    /// Creates a broker-owned IPv4 UDP datagram socket.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the broker returns a response for a different operation.
+    pub fn create_udp_socket(&self) -> Result<ObjectHandle, Channel::Error> {
+        let response = self.request_socket(SocketRequest::Create(CreateSocketRequest {
+            address_family: AddressFamily::Ipv4,
+            socket_type: SocketType::Datagram,
+            protocol: IpProtocol::Udp,
         }))?;
         let SocketResponse::Create(response) = response else {
             panic!("broker returned unexpected socket create response: {response:?}");
@@ -57,8 +75,214 @@ impl<Channel: LocalCallChannel> BrokerLocal<Channel> {
             response => panic!("broker returned unexpected socket connect response: {response:?}"),
         }
     }
+}
 
-    /// Binds a broker-owned TCP socket to a local IPv4 address.
+#[cfg(test)]
+#[expect(
+    clippy::items_after_test_module,
+    reason = "the test module must access private adapter state while the production methods stay grouped"
+)]
+mod tests {
+    use super::*;
+    use alloc::sync::Arc;
+    use core::cell::RefCell;
+    use core::convert::Infallible;
+    use litebox_broker_protocol::message::{
+        BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerRequest, BrokerResponse,
+    };
+    use litebox_broker_protocol::shared_buffer::{
+        SHARED_BUFFER_POOL_SIZE, SHARED_BUFFER_SLOT_SIZE, SharedBufferSlotIndex,
+    };
+    use litebox_broker_transport::channel::LocalSetupChannel;
+    use litebox_broker_transport::shared_memory::{SharedMemory, SharedMemoryError};
+    use std::collections::VecDeque;
+    use std::sync::Mutex;
+
+    #[test]
+    fn udp_operations_stage_complete_datagrams() {
+        let handle = ObjectHandle(7);
+        let channel = ScriptedChannel::new([
+            BrokerResult::Socket(SocketResponse::Create(
+                litebox_broker_protocol::socket::CreateSocketResponse { handle },
+            )),
+            BrokerResult::Socket(SocketResponse::SendTo(
+                litebox_broker_protocol::socket::SendToSocketResponse { sent: 3 },
+            )),
+            BrokerResult::Socket(SocketResponse::ReceiveFrom(ReceiveFromSocketResponse {
+                received: 2,
+                datagram_length: 4,
+                source_address: SocketAddrV4::new(core::net::Ipv4Addr::LOCALHOST, 49153),
+            })),
+        ]);
+        let memory = Arc::new(TestSharedMemory::new(SHARED_BUFFER_POOL_SIZE));
+        let (local, ()) =
+            BrokerLocal::negotiate(channel, |channel| Ok((channel, memory.clone(), ()))).unwrap();
+
+        assert_eq!(local.create_udp_socket().unwrap(), handle);
+        assert_eq!(
+            local
+                .send_to_socket(
+                    handle,
+                    descriptor(0, 3),
+                    &[1, 2, 3],
+                    SendFlags::NONE,
+                    Some(SocketAddrV4::new(core::net::Ipv4Addr::LOCALHOST, 53)),
+                )
+                .unwrap(),
+            Ok(3)
+        );
+        let mut staged = [0; 3];
+        memory.read(0, &mut staged).unwrap();
+        assert_eq!(staged, [1, 2, 3]);
+
+        memory
+            .write(SHARED_BUFFER_SLOT_SIZE as usize, &[4, 5])
+            .unwrap();
+        let mut received = [0; 2];
+        assert_eq!(
+            local
+                .receive_from_socket(
+                    handle,
+                    descriptor(1, 2),
+                    &mut received,
+                    ReceiveFromFlags::PEEK,
+                )
+                .unwrap(),
+            Ok(ReceiveFromSocketResponse {
+                received: 2,
+                datagram_length: 4,
+                source_address: SocketAddrV4::new(core::net::Ipv4Addr::LOCALHOST, 49153),
+            })
+        );
+        assert_eq!(received, [4, 5]);
+        assert!(matches!(
+            local.channel.sent_operations.borrow().as_slice(),
+            [
+                BrokerOperation::Socket(SocketRequest::Create(CreateSocketRequest {
+                    socket_type: SocketType::Datagram,
+                    protocol: IpProtocol::Udp,
+                    ..
+                })),
+                BrokerOperation::Socket(SocketRequest::SendTo(_)),
+                BrokerOperation::Socket(SocketRequest::ReceiveFrom(_)),
+            ]
+        ));
+    }
+
+    const fn descriptor(slot: u32, length: u32) -> SharedBufferDescriptor {
+        SharedBufferDescriptor {
+            slot_index: SharedBufferSlotIndex(slot),
+            length,
+        }
+    }
+
+    #[derive(Clone)]
+    struct TestSharedMemory(Arc<Mutex<std::vec::Vec<u8>>>);
+
+    impl TestSharedMemory {
+        fn new(length: usize) -> Self {
+            Self(Arc::new(Mutex::new(std::vec![0; length])))
+        }
+    }
+
+    impl SharedMemory for TestSharedMemory {
+        fn len(&self) -> usize {
+            self.0.lock().unwrap().len()
+        }
+
+        fn read(
+            &self,
+            offset: usize,
+            destination: &mut [u8],
+        ) -> core::result::Result<(), SharedMemoryError> {
+            let memory = self.0.lock().unwrap();
+            let end = offset
+                .checked_add(destination.len())
+                .ok_or(SharedMemoryError::InvalidRange)?;
+            destination.copy_from_slice(
+                memory
+                    .get(offset..end)
+                    .ok_or(SharedMemoryError::InvalidRange)?,
+            );
+            Ok(())
+        }
+
+        fn write(
+            &self,
+            offset: usize,
+            source: &[u8],
+        ) -> core::result::Result<(), SharedMemoryError> {
+            let mut memory = self.0.lock().unwrap();
+            let end = offset
+                .checked_add(source.len())
+                .ok_or(SharedMemoryError::InvalidRange)?;
+            memory
+                .get_mut(offset..end)
+                .ok_or(SharedMemoryError::InvalidRange)?
+                .copy_from_slice(source);
+            Ok(())
+        }
+    }
+
+    struct ScriptedChannel {
+        results: RefCell<VecDeque<BrokerResult>>,
+        sent_operations: RefCell<std::vec::Vec<BrokerOperation>>,
+    }
+
+    impl ScriptedChannel {
+        fn new(results: impl IntoIterator<Item = BrokerResult>) -> Self {
+            Self {
+                results: RefCell::new(results.into_iter().collect()),
+                sent_operations: RefCell::new(std::vec::Vec::new()),
+            }
+        }
+    }
+
+    impl LocalSetupChannel for ScriptedChannel {
+        type Error = Infallible;
+
+        fn send_handshake_request(
+            &mut self,
+            request: &BrokerHandshakeRequest,
+        ) -> core::result::Result<(), Self::Error> {
+            assert_eq!(
+                request.protocol_version,
+                litebox_broker_protocol::BROKER_PROTOCOL_VERSION
+            );
+            Ok(())
+        }
+
+        fn recv_handshake_response(
+            &mut self,
+        ) -> core::result::Result<Option<BrokerHandshakeResponse>, Self::Error> {
+            Ok(Some(BrokerHandshakeResponse::Negotiated {
+                broker_protocol_version: litebox_broker_protocol::BROKER_PROTOCOL_VERSION,
+            }))
+        }
+    }
+
+    impl LocalCallChannel for ScriptedChannel {
+        type Error = Infallible;
+
+        fn call(
+            &self,
+            request: BrokerRequest,
+        ) -> core::result::Result<BrokerResponse, Self::Error> {
+            self.sent_operations.borrow_mut().push(request.operation);
+            Ok(BrokerResponse {
+                request_id: request.request_id,
+                result: self
+                    .results
+                    .borrow_mut()
+                    .pop_front()
+                    .expect("response requires a scripted result"),
+            })
+        }
+    }
+}
+
+impl<Channel: LocalCallChannel> BrokerLocal<Channel> {
+    /// Binds a broker-owned socket to a local IPv4 address.
     ///
     /// # Panics
     ///
@@ -163,6 +387,42 @@ impl<Channel: LocalCallChannel> BrokerLocal<Channel> {
         }
     }
 
+    /// Sends one datagram from an operation-scoped shared-buffer lease.
+    ///
+    /// The destination is omitted only for a connected UDP socket.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the descriptor does not match `data`, or if the broker
+    /// returns a mismatched or non-atomic response.
+    pub fn send_to_socket(
+        &self,
+        handle: ObjectHandle,
+        buffer: SharedBufferDescriptor,
+        data: &[u8],
+        flags: SendFlags,
+        destination: Option<SocketAddrV4>,
+    ) -> Result<core::result::Result<usize, SocketError>, Channel::Error> {
+        self.validate_udp_buffer(buffer, data.len());
+        self.shared_buffers
+            .write(buffer.slot_index, data)
+            .expect("validated shared UDP send range must be accessible");
+        match self.request_socket(SocketRequest::SendTo(SendToSocketRequest {
+            handle,
+            buffer,
+            flags,
+            destination,
+        }))? {
+            SocketResponse::SendTo(response) => {
+                let sent = response.sent as usize;
+                assert_eq!(sent, data.len(), "broker returned partial UDP send");
+                Ok(Ok(sent))
+            }
+            SocketResponse::Failed(error) => Ok(Err(error)),
+            response => panic!("broker returned unexpected UDP send response: {response:?}"),
+        }
+    }
+
     /// Receives bytes into an operation-scoped shared-buffer lease.
     ///
     /// The caller must retain exclusive ownership of the descriptor's slot
@@ -200,6 +460,49 @@ impl<Channel: LocalCallChannel> BrokerLocal<Channel> {
         }
     }
 
+    /// Receives one datagram into an operation-scoped shared-buffer lease.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the descriptor does not match `destination`, or if the broker
+    /// returns inconsistent datagram lengths.
+    pub fn receive_from_socket(
+        &self,
+        handle: ObjectHandle,
+        buffer: SharedBufferDescriptor,
+        destination: &mut [u8],
+        flags: ReceiveFromFlags,
+    ) -> Result<core::result::Result<ReceiveFromSocketResponse, SocketError>, Channel::Error> {
+        self.validate_udp_buffer(buffer, destination.len());
+        match self.request_socket(SocketRequest::ReceiveFrom(ReceiveFromSocketRequest {
+            handle,
+            buffer,
+            flags,
+        }))? {
+            SocketResponse::ReceiveFrom(response) => {
+                assert!(
+                    response.received <= buffer.length,
+                    "broker returned oversized UDP receive"
+                );
+                assert!(
+                    response.received <= response.datagram_length,
+                    "broker returned inconsistent UDP receive lengths"
+                );
+                assert!(
+                    response.datagram_length <= MAX_UDP_DATAGRAM_SIZE,
+                    "broker returned oversized UDP datagram length"
+                );
+                let received = response.received as usize;
+                self.shared_buffers
+                    .read(buffer.slot_index, &mut destination[..received])
+                    .expect("validated shared UDP receive range must be accessible");
+                Ok(Ok(response))
+            }
+            SocketResponse::Failed(error) => Ok(Err(error)),
+            response => panic!("broker returned unexpected UDP receive response: {response:?}"),
+        }
+    }
+
     /// Shuts down one or both directions of a broker socket.
     ///
     /// # Panics
@@ -233,6 +536,21 @@ impl<Channel: LocalCallChannel> BrokerLocal<Channel> {
             .layout()
             .range(buffer.slot_index, data_len)
             .expect("shared socket descriptor must identify a valid slot range");
+    }
+
+    fn validate_udp_buffer(&self, buffer: SharedBufferDescriptor, data_len: usize) {
+        assert!(
+            buffer.length <= MAX_UDP_DATAGRAM_SIZE,
+            "shared UDP descriptor exceeds the datagram limit"
+        );
+        assert_eq!(
+            data_len, buffer.length as usize,
+            "shared UDP data must match its descriptor"
+        );
+        self.shared_buffers
+            .layout()
+            .range(buffer.slot_index, data_len)
+            .expect("shared UDP descriptor must identify a valid slot range");
     }
 
     fn request_socket(&self, request: SocketRequest) -> Result<SocketResponse, Channel::Error> {

--- a/litebox_broker_platform_linux_userland/src/socket.rs
+++ b/litebox_broker_platform_linux_userland/src/socket.rs
@@ -16,7 +16,8 @@ use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
 use litebox_broker_core::socket::{
-    AcceptedPlatformSocket, PlatformSocket, ReceivedPlatformDatagram, SocketProvider,
+    AcceptedPlatformSocket, PlatformConnectError, PlatformSocket, ReceivedPlatformDatagram,
+    SocketProvider,
 };
 use litebox_broker_core::{BrokerError, Result as BrokerResult, SessionId};
 use litebox_broker_protocol::readiness::ReadinessFlags;
@@ -157,12 +158,11 @@ impl PlatformSocket for LinuxSocket {
         }
     }
 
-    fn connect(&self, address: SocketAddrV4) -> BrokerResult<SocketConnectionStatus> {
-        self.reactor.request(|response| ReactorCommand::Connect {
-            id: self.id,
-            address,
-            response,
-        })
+    fn connect(
+        &self,
+        address: SocketAddrV4,
+    ) -> core::result::Result<SocketConnectionStatus, PlatformConnectError> {
+        self.reactor.connect(self.id, address)
     }
 
     fn send(&self, data: &[u8], _flags: SendFlags) -> BrokerResult<SocketOutcome<usize>> {
@@ -385,6 +385,38 @@ impl ReactorClient {
         }
         self.signal().map_err(|_| BrokerError::Internal)?;
         receive.recv().map_err(|_| BrokerError::Internal)?
+    }
+
+    fn connect(
+        &self,
+        id: u64,
+        address: SocketAddrV4,
+    ) -> core::result::Result<SocketConnectionStatus, PlatformConnectError> {
+        let (response, receive) = sync_channel(1);
+        let command = ReactorCommand::Connect {
+            id,
+            address,
+            response,
+        };
+        match self.commands.try_send(command) {
+            Ok(()) => {}
+            Err(TrySendError::Full(_)) => {
+                return Err(PlatformConnectError::PeerUnchanged(
+                    BrokerError::ResourceExhausted,
+                ));
+            }
+            Err(TrySendError::Disconnected(_)) => {
+                return Err(PlatformConnectError::PeerIndeterminate(
+                    BrokerError::Internal,
+                ));
+            }
+        }
+        self.signal()
+            .map_err(|_| PlatformConnectError::PeerIndeterminate(BrokerError::Internal))?;
+        receive
+            .recv()
+            .map_err(|_| PlatformConnectError::PeerIndeterminate(BrokerError::Internal))?
+            .map_err(PlatformConnectError::PeerIndeterminate)
     }
 
     fn close_socket(&self, id: u64) {

--- a/litebox_broker_platform_linux_userland/src/socket.rs
+++ b/litebox_broker_platform_linux_userland/src/socket.rs
@@ -1942,7 +1942,7 @@ mod tests {
         let provider = Arc::new(LinuxSocketProvider::new(8).unwrap());
         let broker = BrokerCore::new_with_limits(
             PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-                .with_socket_policy(SocketPolicy::Ipv4LoopbackTcp),
+                .with_socket_policy(SocketPolicy::Ipv4Loopback),
             BrokerCoreLimits::new_with_all_limits(16, 0, 8, 8),
             provider,
         )
@@ -2254,7 +2254,7 @@ mod tests {
         let provider = Arc::new(LinuxSocketProvider::new(4).unwrap());
         let broker = BrokerCore::new_with_limits(
             PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-                .with_socket_policy(SocketPolicy::Ipv4LoopbackTcp),
+                .with_socket_policy(SocketPolicy::Ipv4Loopback),
             BrokerCoreLimits::new_with_all_limits(8, 0, 4, 4),
             provider,
         )
@@ -2410,7 +2410,7 @@ mod tests {
         let provider = Arc::new(LinuxSocketProvider::new(2).unwrap());
         let broker = BrokerCore::new_with_limits(
             PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-                .with_socket_policy(SocketPolicy::Ipv4LoopbackTcpUdp),
+                .with_socket_policy(SocketPolicy::Ipv4Loopback),
             BrokerCoreLimits::new_with_all_limits(4, 0, 2, 2),
             provider,
         )

--- a/litebox_broker_platform_linux_userland/src/socket.rs
+++ b/litebox_broker_platform_linux_userland/src/socket.rs
@@ -416,7 +416,6 @@ impl ReactorClient {
         receive
             .recv()
             .map_err(|_| PlatformConnectError::PeerIndeterminate(BrokerError::Internal))?
-            .map_err(PlatformConnectError::PeerIndeterminate)
     }
 
     fn close_socket(&self, id: u64) {
@@ -490,7 +489,7 @@ enum ReactorCommand {
     Connect {
         id: u64,
         address: SocketAddrV4,
-        response: SyncSender<BrokerResult<SocketConnectionStatus>>,
+        response: SyncSender<core::result::Result<SocketConnectionStatus, PlatformConnectError>>,
     },
     Bind {
         id: u64,
@@ -729,11 +728,12 @@ impl Reactor {
                     address,
                     response,
                 } => {
-                    let outcome = self
-                        .sockets
-                        .get_mut(&id)
-                        .ok_or(BrokerError::Internal)
-                        .and_then(|socket| connect_socket(&self.epoll, id, socket, address));
+                    let outcome = match self.sockets.get_mut(&id) {
+                        Some(socket) => connect_socket(&self.epoll, id, socket, address),
+                        None => Err(PlatformConnectError::PeerIndeterminate(
+                            BrokerError::Internal,
+                        )),
+                    };
                     let _ = response.send(outcome);
                 }
                 ReactorCommand::Bind {
@@ -1044,7 +1044,7 @@ fn connect_socket(
     id: u64,
     socket: &mut SocketEntry,
     address: SocketAddrV4,
-) -> BrokerResult<SocketConnectionStatus> {
+) -> core::result::Result<SocketConnectionStatus, PlatformConnectError> {
     if socket.kind == SocketKind::Udp {
         return connect_datagram_socket(socket, address);
     }
@@ -1054,12 +1054,9 @@ fn connect_socket(
         epoll::EventData::new_u64(id),
         active_epoll_events(),
     ) {
-        update_snapshot(
-            socket,
-            Some(SocketConnectionStatus::Failed(SocketError::Other)),
-            ReadinessFlags::ERROR,
-        )?;
-        return Err(broker_error_from_errno(error));
+        return Err(PlatformConnectError::PeerUnchanged(
+            broker_error_from_errno(error),
+        ));
     }
     let status = loop {
         match connect(&socket.socket, &address) {
@@ -1076,8 +1073,9 @@ fn connect_socket(
                             socket,
                             Some(SocketConnectionStatus::Failed(SocketError::Other)),
                             ReadinessFlags::ERROR,
-                        )?;
-                        return Err(error);
+                        )
+                        .map_err(PlatformConnectError::PeerIndeterminate)?;
+                        return Err(PlatformConnectError::PeerIndeterminate(error));
                     }
                 };
                 break SocketConnectionStatus::Failed(error);
@@ -1086,7 +1084,8 @@ fn connect_socket(
     };
     let readiness = match status {
         SocketConnectionStatus::Connected | SocketConnectionStatus::Connecting => {
-            let local_address = local_socket_address(&socket.socket)?;
+            let local_address = local_socket_address(&socket.socket)
+                .map_err(PlatformConnectError::PeerIndeterminate)?;
             socket
                 .snapshot
                 .lock()
@@ -1100,20 +1099,26 @@ fn connect_socket(
         }
         SocketConnectionStatus::Failed(_) => ReadinessFlags::ERROR,
         SocketConnectionStatus::Unconnected => ReadinessFlags::default(),
-        _ => return Err(BrokerError::Internal),
+        _ => {
+            return Err(PlatformConnectError::PeerIndeterminate(
+                BrokerError::Internal,
+            ));
+        }
     };
-    update_snapshot(socket, Some(status), readiness)?;
+    update_snapshot(socket, Some(status), readiness)
+        .map_err(PlatformConnectError::PeerIndeterminate)?;
     Ok(status)
 }
 
 fn connect_datagram_socket(
     socket: &mut SocketEntry,
     address: SocketAddrV4,
-) -> BrokerResult<SocketConnectionStatus> {
+) -> core::result::Result<SocketConnectionStatus, PlatformConnectError> {
     loop {
         match connect(&socket.socket, &address) {
             Ok(()) | Err(Errno::ISCONN) => {
-                let local_address = local_socket_address(&socket.socket)?;
+                let local_address = local_socket_address(&socket.socket)
+                    .map_err(PlatformConnectError::PeerIndeterminate)?;
                 socket
                     .snapshot
                     .lock()
@@ -1129,13 +1134,15 @@ fn connect_datagram_socket(
                 } else {
                     readiness | ReadinessFlags::WRITE
                 };
-                update_snapshot(socket, Some(SocketConnectionStatus::Connected), readiness)?;
+                update_snapshot(socket, Some(SocketConnectionStatus::Connected), readiness)
+                    .map_err(PlatformConnectError::PeerIndeterminate)?;
                 return Ok(SocketConnectionStatus::Connected);
             }
             Err(Errno::INTR) => {}
             Err(error) => {
-                let error = socket_operation_error_from_errno(error)?;
-                consume_synchronous_error(socket)?;
+                update_local_address(socket).map_err(PlatformConnectError::PeerIndeterminate)?;
+                let error = socket_operation_error_from_errno(error)
+                    .map_err(PlatformConnectError::PeerIndeterminate)?;
                 return Ok(SocketConnectionStatus::Failed(error));
             }
         }
@@ -1265,13 +1272,18 @@ fn send_to_socket(
                 update_local_address(socket)?;
                 return Ok(SocketOutcome::Completed(sent));
             }
-            Ok(_) => return Err(BrokerError::Internal),
+            Ok(_) => {
+                update_local_address(socket)?;
+                return Err(BrokerError::Internal);
+            }
             Err(Errno::INTR) => {}
             Err(Errno::AGAIN) => {
+                update_local_address(socket)?;
                 clear_readiness(socket, ReadinessFlags::WRITE)?;
                 return Err(BrokerError::WouldBlock);
             }
             Err(error) => {
+                update_local_address(socket)?;
                 let error = socket_operation_error_from_errno(error)?;
                 consume_synchronous_error(socket)?;
                 return Ok(SocketOutcome::Failed(error));
@@ -1685,11 +1697,13 @@ fn update_local_address(socket: &SocketEntry) -> BrokerResult<()> {
         .is_none();
     if needs_address {
         let address = local_socket_address(&socket.socket)?;
-        socket
-            .snapshot
-            .lock()
-            .expect("Linux socket snapshot mutex poisoned")
-            .local_address = Some(address);
+        if address.port() != 0 {
+            socket
+                .snapshot
+                .lock()
+                .expect("Linux socket snapshot mutex poisoned")
+                .local_address = Some(address);
+        }
     }
     Ok(())
 }
@@ -1886,9 +1900,11 @@ mod tests {
     use super::*;
     use litebox_broker_core::readiness::ReadinessSink;
     use litebox_broker_core::{
-        BrokerCore, BrokerCoreLimits, CallerCredential, ObjectRights, PolicyEngine, SocketPolicy,
+        BrokerCore, BrokerCoreLimits, CallerCredential, DestinationPortRange, DestinationRule,
+        Ipv4Cidr, ObjectRights, PolicyEngine, SocketPolicy,
     };
     use litebox_broker_protocol::ObjectHandle;
+    use litebox_broker_protocol::socket::{Ipv4Address, Port};
 
     const TEST_TIMEOUT: Duration = Duration::from_secs(5);
 
@@ -2440,9 +2456,22 @@ mod tests {
         server.set_read_timeout(Some(TEST_TIMEOUT)).unwrap();
         let server_address = socket_address_v4(server.local_addr().unwrap());
         let provider = Arc::new(LinuxSocketProvider::new(2).unwrap());
+        let socket_policy = SocketPolicy::from_udp_destination_rules(&[
+            DestinationRule::new(
+                CallerCredential::Unauthenticated,
+                Ipv4Cidr::new(Ipv4Address([127, 0, 0, 0]), 8).unwrap(),
+                DestinationPortRange::new(Port(1), Port(u16::MAX)).unwrap(),
+            ),
+            DestinationRule::new(
+                CallerCredential::Unauthenticated,
+                Ipv4Cidr::new(Ipv4Address([255, 255, 255, 255]), 32).unwrap(),
+                DestinationPortRange::new(Port(9), Port(9)).unwrap(),
+            ),
+        ])
+        .unwrap();
         let broker = BrokerCore::new_with_limits(
             PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-                .with_socket_policy(SocketPolicy::Ipv4Loopback),
+                .with_socket_policy(socket_policy),
             BrokerCoreLimits::new_with_all_limits(4, 0, 2, 2),
             provider,
         )
@@ -2519,6 +2548,22 @@ mod tests {
             ),
             Ok(SocketOutcome::Failed(SocketError::PolicyDenied))
         );
+        assert_eq!(
+            litebox_broker_core::socket::send_to(
+                &session,
+                handle,
+                b"implicit bind",
+                SendFlags::NONE,
+                Some(SocketAddrV4::new(Ipv4Addr::BROADCAST, 9)),
+            ),
+            Ok(SocketOutcome::Failed(SocketError::Other))
+        );
+        let implicitly_bound = litebox_broker_core::socket::status(&session, handle)
+            .unwrap()
+            .local_address
+            .unwrap();
+        assert!(implicitly_bound.ip().is_unspecified());
+        assert_ne!(implicitly_bound.port(), 0);
         let mut no_data = [0; 1];
         assert_eq!(
             litebox_broker_core::socket::receive_from(
@@ -2633,6 +2678,49 @@ mod tests {
         assert_eq!(received, maximum.len());
         assert_eq!(&packet[..received], maximum.as_slice());
         assert_eq!(socket_address_v4(connected_source), source);
+
+        let refused_socket = UdpSocket::bind("127.0.0.1:0").unwrap();
+        let refused_address = socket_address_v4(refused_socket.local_addr().unwrap());
+        drop(refused_socket);
+        assert_eq!(
+            litebox_broker_core::socket::connect(&session, handle, refused_address),
+            Ok(SocketOutcome::Completed(SocketConnectionStatus::Connected))
+        );
+        assert_eq!(
+            litebox_broker_core::socket::send_to(
+                &session,
+                handle,
+                b"refused",
+                SendFlags::NONE,
+                None,
+            ),
+            Ok(SocketOutcome::Completed(7))
+        );
+        wait_for_readiness(&publications, handle, ReadinessFlags::ERROR);
+        assert_eq!(
+            litebox_broker_core::socket::connect(
+                &session,
+                handle,
+                SocketAddrV4::new(Ipv4Addr::BROADCAST, 9),
+            ),
+            Ok(SocketOutcome::Failed(SocketError::Other))
+        );
+        let refused_status = litebox_broker_core::socket::status(&session, handle).unwrap();
+        assert_eq!(
+            refused_status.pending_error,
+            Some(SocketError::ConnectionRefused)
+        );
+        assert!(
+            !session
+                .check_readiness(handle)
+                .unwrap()
+                .contains(ReadinessFlags::ERROR)
+        );
+        assert_eq!(
+            litebox_broker_core::socket::connect(&session, handle, server_address),
+            Ok(SocketOutcome::Completed(SocketConnectionStatus::Connected))
+        );
+
         assert_eq!(
             litebox_broker_core::socket::shutdown(&session, handle, ShutdownMode::Write),
             Ok(SocketOutcome::Completed(()))

--- a/litebox_broker_platform_linux_userland/src/socket.rs
+++ b/litebox_broker_platform_linux_userland/src/socket.rs
@@ -15,13 +15,16 @@ use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
-use litebox_broker_core::socket::{AcceptedPlatformSocket, PlatformSocket, SocketProvider};
+use litebox_broker_core::socket::{
+    AcceptedPlatformSocket, PlatformSocket, ReceivedPlatformDatagram, SocketProvider,
+};
 use litebox_broker_core::{BrokerError, Result as BrokerResult, SessionId};
 use litebox_broker_protocol::readiness::ReadinessFlags;
 use litebox_broker_protocol::socket::{
     AddressFamily, CreateSocketRequest, IpProtocol, MAX_SOCKET_PEEK_SIZE, MAX_SOCKET_TRANSFER_SIZE,
-    ReceiveFlags, ReceiveSocketResponse, SendFlags, ShutdownMode, SocketConnectionStatus,
-    SocketError, SocketOutcome, SocketStatusResponse, SocketType,
+    MAX_UDP_DATAGRAM_SIZE, ReceiveFlags, ReceiveFromFlags, ReceiveSocketResponse, SendFlags,
+    ShutdownMode, SocketConnectionStatus, SocketError, SocketOutcome, SocketStatusResponse,
+    SocketType,
 };
 use rustix::buffer::spare_capacity;
 use rustix::event::{EventfdFlags, epoll, eventfd};
@@ -29,8 +32,8 @@ use rustix::io::{Errno, ioctl_fionread, read, write};
 use rustix::net::{
     AddressFamily as LinuxAddressFamily, RecvFlags as LinuxRecvFlags, SendFlags as LinuxSendFlags,
     Shutdown as LinuxShutdown, SocketFlags as LinuxSocketFlags, SocketType as LinuxSocketType,
-    acceptfrom_with, bind, connect, getpeername, getsockname, ipproto, listen, recv, send,
-    shutdown, socket_with, sockopt,
+    acceptfrom_with, bind, connect, getpeername, getsockname, ipproto, listen, recv, recvfrom,
+    send, sendto, shutdown, socket_with, sockopt,
 };
 
 use litebox_broker_core::readiness::ReadinessRegistration;
@@ -65,14 +68,7 @@ impl SocketProvider for LinuxSocketProvider {
         request: CreateSocketRequest,
         readiness: ReadinessRegistration,
     ) -> BrokerResult<Arc<dyn PlatformSocket>> {
-        if !matches!(
-            request,
-            CreateSocketRequest {
-                address_family: AddressFamily::Ipv4,
-                socket_type: SocketType::Stream,
-                protocol: IpProtocol::Tcp,
-            }
-        ) {
+        if socket_kind(request).is_none() {
             return Err(BrokerError::UnsupportedOperation);
         }
 
@@ -182,6 +178,25 @@ impl PlatformSocket for LinuxSocket {
         })
     }
 
+    fn send_to(
+        &self,
+        data: &[u8],
+        _flags: SendFlags,
+        destination: Option<SocketAddrV4>,
+    ) -> BrokerResult<SocketOutcome<usize>> {
+        let mut owned = Vec::new();
+        owned
+            .try_reserve_exact(data.len())
+            .map_err(|_| BrokerError::OutOfMemory)?;
+        owned.extend_from_slice(data);
+        self.reactor.request(|response| ReactorCommand::SendTo {
+            id: self.id,
+            data: owned,
+            destination,
+            response,
+        })
+    }
+
     fn receive(
         &self,
         data: &mut [u8],
@@ -214,6 +229,35 @@ impl PlatformSocket for LinuxSocket {
                 Ok(SocketOutcome::Completed(ReceiveSocketResponse::EndOfStream))
             }
             ReactorReceiveOutcome::Failed(error) => Ok(SocketOutcome::Failed(error)),
+        }
+    }
+
+    fn receive_from(
+        &self,
+        data: &mut [u8],
+        flags: ReceiveFromFlags,
+    ) -> BrokerResult<SocketOutcome<ReceivedPlatformDatagram>> {
+        match self
+            .reactor
+            .request(|response| ReactorCommand::ReceiveFrom {
+                id: self.id,
+                length: data.len(),
+                flags,
+                response,
+            })? {
+            ReactorReceiveFromOutcome::Received {
+                data: received,
+                datagram_length,
+                source_address,
+            } => {
+                data[..received.len()].copy_from_slice(&received);
+                Ok(SocketOutcome::Completed(ReceivedPlatformDatagram {
+                    received: received.len(),
+                    datagram_length,
+                    source_address,
+                }))
+            }
+            ReactorReceiveFromOutcome::Failed(error) => Ok(SocketOutcome::Failed(error)),
         }
     }
 
@@ -439,6 +483,12 @@ enum ReactorCommand {
         data: Vec<u8>,
         response: SyncSender<BrokerResult<SocketOutcome<usize>>>,
     },
+    SendTo {
+        id: u64,
+        data: Vec<u8>,
+        destination: Option<SocketAddrV4>,
+        response: SyncSender<BrokerResult<SocketOutcome<usize>>>,
+    },
     Receive {
         id: u64,
         length: usize,
@@ -446,6 +496,12 @@ enum ReactorCommand {
         peek_offset: usize,
         peek_length: usize,
         response: SyncSender<BrokerResult<ReactorReceiveOutcome>>,
+    },
+    ReceiveFrom {
+        id: u64,
+        length: usize,
+        flags: ReceiveFromFlags,
+        response: SyncSender<BrokerResult<ReactorReceiveFromOutcome>>,
     },
     Shutdown {
         id: u64,
@@ -469,6 +525,15 @@ enum ReactorCommand {
 enum ReactorReceiveOutcome {
     Received(Vec<u8>),
     EndOfStream,
+    Failed(SocketError),
+}
+
+enum ReactorReceiveFromOutcome {
+    Received {
+        data: Vec<u8>,
+        datagram_length: usize,
+        source_address: SocketAddrV4,
+    },
     Failed(SocketError),
 }
 
@@ -497,12 +562,19 @@ struct PeekCache {
 /// Reactor-owned descriptor and its broker-facing readiness state.
 struct SocketEntry {
     socket: OwnedFd,
+    kind: SocketKind,
     readiness: ReadinessRegistration,
     snapshot: Arc<Mutex<SocketSnapshot>>,
     read_shutdown: bool,
     write_shutdown: bool,
     peek_waitall_threshold: Option<usize>,
     listening: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SocketKind {
+    Tcp,
+    Udp,
 }
 
 /// Cached connection and readiness state shared with the broker-facing handle.
@@ -684,6 +756,19 @@ impl Reactor {
                         .and_then(|socket| send_socket(socket, &data));
                     let _ = response.send(outcome);
                 }
+                ReactorCommand::SendTo {
+                    id,
+                    data,
+                    destination,
+                    response,
+                } => {
+                    let outcome = self
+                        .sockets
+                        .get_mut(&id)
+                        .ok_or(BrokerError::Internal)
+                        .and_then(|socket| send_to_socket(socket, &data, destination));
+                    let _ = response.send(outcome);
+                }
                 ReactorCommand::Receive {
                     id,
                     length,
@@ -704,6 +789,19 @@ impl Reactor {
                         ),
                         None => Err(BrokerError::Internal),
                     };
+                    let _ = response.send(outcome);
+                }
+                ReactorCommand::ReceiveFrom {
+                    id,
+                    length,
+                    flags,
+                    response,
+                } => {
+                    let outcome = self
+                        .sockets
+                        .get_mut(&id)
+                        .ok_or(BrokerError::Internal)
+                        .and_then(|socket| receive_from_socket(socket, length, flags));
                     let _ = response.send(outcome);
                 }
                 ReactorCommand::Shutdown { id, mode, response } => {
@@ -760,36 +858,50 @@ impl Reactor {
         if self.sockets.len() >= self.max_sockets {
             return Err(BrokerError::ResourceExhausted);
         }
-        if self.sockets.contains_key(&id)
-            || !matches!(
-                request,
-                CreateSocketRequest {
-                    address_family: AddressFamily::Ipv4,
-                    socket_type: SocketType::Stream,
-                    protocol: IpProtocol::Tcp,
-                }
-            )
-        {
+        let kind = socket_kind(request).ok_or(BrokerError::Internal)?;
+        if self.sockets.contains_key(&id) {
             return Err(BrokerError::Internal);
         }
+        let (linux_type, protocol, epoll_events, initial_readiness) = match kind {
+            SocketKind::Tcp => (
+                LinuxSocketType::STREAM,
+                ipproto::TCP,
+                idle_epoll_events(),
+                ReadinessFlags::default(),
+            ),
+            SocketKind::Udp => (
+                LinuxSocketType::DGRAM,
+                ipproto::UDP,
+                active_epoll_events(),
+                ReadinessFlags::WRITE,
+            ),
+        };
         let socket = socket_with(
             LinuxAddressFamily::INET,
-            LinuxSocketType::STREAM,
+            linux_type,
             LinuxSocketFlags::CLOEXEC | LinuxSocketFlags::NONBLOCK,
-            Some(ipproto::TCP),
+            Some(protocol),
         )
         .map_err(broker_error_from_errno)?;
         epoll::add(
             &self.epoll,
             &socket,
             epoll::EventData::new_u64(id),
-            idle_epoll_events(),
+            epoll_events,
         )
         .map_err(broker_error_from_errno)?;
+        if initial_readiness != ReadinessFlags::default() {
+            snapshot
+                .lock()
+                .expect("Linux socket snapshot mutex poisoned")
+                .readiness = initial_readiness;
+            readiness.publish(initial_readiness)?;
+        }
         self.sockets.insert(
             id,
             SocketEntry {
                 socket,
+                kind,
                 readiness,
                 snapshot,
                 read_shutdown: false,
@@ -818,7 +930,7 @@ impl Reactor {
             .sockets
             .get_mut(&listener_id)
             .ok_or(BrokerError::Internal)?;
-        if !listener.listening {
+        if listener.kind != SocketKind::Tcp || !listener.listening {
             return Ok(SocketOutcome::Failed(SocketError::NotConnected));
         }
         let (socket, remote_address) = loop {
@@ -862,6 +974,7 @@ impl Reactor {
             accepted_id,
             SocketEntry {
                 socket,
+                kind: SocketKind::Tcp,
                 readiness,
                 snapshot,
                 read_shutdown: false,
@@ -900,6 +1013,9 @@ fn connect_socket(
     socket: &mut SocketEntry,
     address: SocketAddrV4,
 ) -> BrokerResult<SocketConnectionStatus> {
+    if socket.kind == SocketKind::Udp {
+        return connect_datagram_socket(socket, address);
+    }
     if let Err(error) = epoll::modify(
         epoll_fd,
         &socket.socket,
@@ -958,6 +1074,42 @@ fn connect_socket(
     Ok(status)
 }
 
+fn connect_datagram_socket(
+    socket: &mut SocketEntry,
+    address: SocketAddrV4,
+) -> BrokerResult<SocketConnectionStatus> {
+    loop {
+        match connect(&socket.socket, &address) {
+            Ok(()) | Err(Errno::ISCONN) => {
+                let local_address = local_socket_address(&socket.socket)?;
+                socket
+                    .snapshot
+                    .lock()
+                    .expect("Linux socket snapshot mutex poisoned")
+                    .local_address = Some(local_address);
+                let readiness = socket
+                    .snapshot
+                    .lock()
+                    .expect("Linux socket snapshot mutex poisoned")
+                    .readiness;
+                let readiness = if socket.write_shutdown {
+                    ReadinessFlags(readiness.0 & !ReadinessFlags::WRITE.0)
+                } else {
+                    readiness | ReadinessFlags::WRITE
+                };
+                update_snapshot(socket, Some(SocketConnectionStatus::Connected), readiness)?;
+                return Ok(SocketConnectionStatus::Connected);
+            }
+            Err(Errno::INTR) => {}
+            Err(error) => {
+                let error = socket_operation_error_from_errno(error)?;
+                consume_synchronous_error(socket)?;
+                return Ok(SocketConnectionStatus::Failed(error));
+            }
+        }
+    }
+}
+
 fn bind_socket(
     socket: &mut SocketEntry,
     address: SocketAddrV4,
@@ -989,6 +1141,9 @@ fn listen_socket(
     socket: &mut SocketEntry,
     backlog: u32,
 ) -> BrokerResult<SocketOutcome<SocketAddrV4>> {
+    if socket.kind != SocketKind::Tcp {
+        return Ok(SocketOutcome::Failed(SocketError::InvalidArgument));
+    }
     let backlog = i32::try_from(backlog).map_err(|_| BrokerError::UnsupportedOperation)?;
     let local_address = local_socket_address(&socket.socket)?;
     let was_listening = socket.listening;
@@ -1034,12 +1189,51 @@ fn listen_socket(
 }
 
 fn send_socket(socket: &mut SocketEntry, data: &[u8]) -> BrokerResult<SocketOutcome<usize>> {
+    if socket.kind != SocketKind::Tcp {
+        return Ok(SocketOutcome::Failed(SocketError::InvalidArgument));
+    }
     if socket.write_shutdown {
         return Ok(SocketOutcome::Failed(SocketError::Other));
     }
     loop {
         match send(&socket.socket, data, LinuxSendFlags::NOSIGNAL) {
             Ok(sent) => return Ok(SocketOutcome::Completed(sent)),
+            Err(Errno::INTR) => {}
+            Err(Errno::AGAIN) => {
+                clear_readiness(socket, ReadinessFlags::WRITE)?;
+                return Err(BrokerError::WouldBlock);
+            }
+            Err(error) => {
+                let error = socket_operation_error_from_errno(error)?;
+                consume_synchronous_error(socket)?;
+                return Ok(SocketOutcome::Failed(error));
+            }
+        }
+    }
+}
+
+fn send_to_socket(
+    socket: &mut SocketEntry,
+    data: &[u8],
+    destination: Option<SocketAddrV4>,
+) -> BrokerResult<SocketOutcome<usize>> {
+    if socket.kind != SocketKind::Udp || data.len() > MAX_UDP_DATAGRAM_SIZE as usize {
+        return Ok(SocketOutcome::Failed(SocketError::InvalidArgument));
+    }
+    if socket.write_shutdown {
+        return Ok(SocketOutcome::Failed(SocketError::Other));
+    }
+    loop {
+        let result = match destination {
+            Some(address) => sendto(&socket.socket, data, LinuxSendFlags::NOSIGNAL, &address),
+            None => send(&socket.socket, data, LinuxSendFlags::NOSIGNAL),
+        };
+        match result {
+            Ok(sent) if sent == data.len() => {
+                update_local_address(socket)?;
+                return Ok(SocketOutcome::Completed(sent));
+            }
+            Ok(_) => return Err(BrokerError::Internal),
             Err(Errno::INTR) => {}
             Err(Errno::AGAIN) => {
                 clear_readiness(socket, ReadinessFlags::WRITE)?;
@@ -1063,6 +1257,9 @@ fn receive_socket(
     peek_offset: usize,
     peek_length: usize,
 ) -> BrokerResult<ReactorReceiveOutcome> {
+    if socket.kind != SocketKind::Tcp {
+        return Ok(ReactorReceiveOutcome::Failed(SocketError::InvalidArgument));
+    }
     let peek = flags.contains(ReceiveFlags::PEEK);
     if !peek {
         if peek_offset != 0 || peek_length != 0 {
@@ -1163,6 +1360,54 @@ fn receive_socket(
     Ok(ReactorReceiveOutcome::Received(data))
 }
 
+fn receive_from_socket(
+    socket: &mut SocketEntry,
+    length: usize,
+    flags: ReceiveFromFlags,
+) -> BrokerResult<ReactorReceiveFromOutcome> {
+    if socket.kind != SocketKind::Udp
+        || length > MAX_UDP_DATAGRAM_SIZE as usize
+        || flags.has_unsupported_bits()
+    {
+        return Ok(ReactorReceiveFromOutcome::Failed(
+            SocketError::InvalidArgument,
+        ));
+    }
+    if socket.read_shutdown {
+        return Ok(ReactorReceiveFromOutcome::Failed(SocketError::NotConnected));
+    }
+    let mut data = zeroed_vec(length)?;
+    let mut linux_flags = LinuxRecvFlags::TRUNC;
+    if flags.contains(ReceiveFromFlags::PEEK) {
+        linux_flags |= LinuxRecvFlags::PEEK;
+    }
+    loop {
+        match recvfrom(&socket.socket, data.as_mut_slice(), linux_flags) {
+            Ok((received, datagram_length, address)) => {
+                let source_address = SocketAddrV4::try_from(address.ok_or(BrokerError::Internal)?)
+                    .map_err(|_| BrokerError::Internal)?;
+                data.truncate(received);
+                update_local_address(socket)?;
+                return Ok(ReactorReceiveFromOutcome::Received {
+                    data,
+                    datagram_length,
+                    source_address,
+                });
+            }
+            Err(Errno::INTR) => {}
+            Err(Errno::AGAIN) => {
+                clear_readiness(socket, ReadinessFlags::READ)?;
+                return Err(BrokerError::WouldBlock);
+            }
+            Err(error) => {
+                let error = socket_operation_error_from_errno(error)?;
+                consume_synchronous_error(socket)?;
+                return Ok(ReactorReceiveFromOutcome::Failed(error));
+            }
+        }
+    }
+}
+
 fn zeroed_vec(length: usize) -> BrokerResult<Vec<u8>> {
     let mut data = Vec::new();
     data.try_reserve_exact(length)
@@ -1209,6 +1454,11 @@ fn shutdown_socket(
     socket: &mut SocketEntry,
     mode: ShutdownMode,
 ) -> BrokerResult<SocketOutcome<()>> {
+    if socket.kind == SocketKind::Udp
+        && matches!(mode, ShutdownMode::Abort | ShutdownMode::StopListening)
+    {
+        return Ok(SocketOutcome::Failed(SocketError::InvalidArgument));
+    }
     if mode == ShutdownMode::Abort {
         sockopt::set_socket_linger(&socket.socket, Some(Duration::ZERO))
             .map_err(broker_error_from_errno)?;
@@ -1255,39 +1505,11 @@ fn shutdown_socket(
     };
     loop {
         match shutdown(&socket.socket, mode) {
-            Ok(()) => {
-                if stop_listening {
-                    socket.listening = false;
-                    socket.read_shutdown = true;
-                    socket.peek_waitall_threshold = None;
-                    update_snapshot(
-                        socket,
-                        Some(SocketConnectionStatus::Failed(SocketError::NotConnected)),
-                        ReadinessFlags::WRITE | ReadinessFlags::HANGUP,
-                    )?;
-                    return Ok(SocketOutcome::Completed(()));
-                }
-                socket.read_shutdown |= shuts_down_read;
-                socket.write_shutdown |= shuts_down_write;
-                let republish_readiness =
-                    shuts_down_read && socket.peek_waitall_threshold.take().is_some();
-                if clear.0 != 0 {
-                    clear_readiness(socket, clear)?;
-                }
-                if add.0 != 0 {
-                    add_readiness(socket, add)?;
-                }
-                if republish_readiness {
-                    let readiness = socket
-                        .snapshot
-                        .lock()
-                        .expect("Linux socket snapshot mutex poisoned")
-                        .readiness;
-                    socket.readiness.republish(readiness)?;
-                }
-                return Ok(SocketOutcome::Completed(()));
-            }
-            Err(Errno::INTR) => {}
+            Ok(()) => {}
+            Err(Errno::INTR) => continue,
+            // Linux applies directional shutdown to unconnected UDP sockets even
+            // though it reports ENOTCONN.
+            Err(Errno::NOTCONN) if socket.kind == SocketKind::Udp => {}
             Err(Errno::NOTCONN) => {
                 return Ok(SocketOutcome::Failed(SocketError::NotConnected));
             }
@@ -1296,11 +1518,43 @@ fn shutdown_socket(
                 return Ok(SocketOutcome::Failed(error));
             }
         }
+        if stop_listening {
+            socket.listening = false;
+            socket.read_shutdown = true;
+            socket.peek_waitall_threshold = None;
+            update_snapshot(
+                socket,
+                Some(SocketConnectionStatus::Failed(SocketError::NotConnected)),
+                ReadinessFlags::WRITE | ReadinessFlags::HANGUP,
+            )?;
+            return Ok(SocketOutcome::Completed(()));
+        }
+        socket.read_shutdown |= shuts_down_read;
+        socket.write_shutdown |= shuts_down_write;
+        let republish_readiness = shuts_down_read && socket.peek_waitall_threshold.take().is_some();
+        if clear.0 != 0 {
+            clear_readiness(socket, clear)?;
+        }
+        if add.0 != 0 {
+            add_readiness(socket, add)?;
+        }
+        if republish_readiness {
+            let readiness = socket
+                .snapshot
+                .lock()
+                .expect("Linux socket snapshot mutex poisoned")
+                .readiness;
+            socket.readiness.republish(readiness)?;
+        }
+        return Ok(SocketOutcome::Completed(()));
     }
 }
 
 fn handle_socket_event(socket: &mut SocketEntry, events: epoll::EventFlags) -> BrokerResult<()> {
     if socket.listening {
+        return update_snapshot(socket, None, readiness_from_epoll(socket, events));
+    }
+    if socket.kind == SocketKind::Udp {
         return update_snapshot(socket, None, readiness_from_epoll(socket, events));
     }
     let republish_readiness = if events.contains(epoll::EventFlags::IN)
@@ -1390,6 +1644,24 @@ fn local_socket_address(socket: &OwnedFd) -> BrokerResult<SocketAddrV4> {
     }
 }
 
+fn update_local_address(socket: &SocketEntry) -> BrokerResult<()> {
+    let needs_address = socket
+        .snapshot
+        .lock()
+        .expect("Linux socket snapshot mutex poisoned")
+        .local_address
+        .is_none();
+    if needs_address {
+        let address = local_socket_address(&socket.socket)?;
+        socket
+            .snapshot
+            .lock()
+            .expect("Linux socket snapshot mutex poisoned")
+            .local_address = Some(address);
+    }
+    Ok(())
+}
+
 fn status_socket(socket: &mut SocketEntry) -> BrokerResult<SocketStatusResponse> {
     let query_socket_error = {
         let snapshot = socket
@@ -1397,7 +1669,8 @@ fn status_socket(socket: &mut SocketEntry) -> BrokerResult<SocketStatusResponse>
             .lock()
             .expect("Linux socket snapshot mutex poisoned");
         snapshot.pending_error.is_none()
-            && snapshot.status == SocketConnectionStatus::Connected
+            && (snapshot.status == SocketConnectionStatus::Connected
+                || socket.kind == SocketKind::Udp)
             && snapshot.readiness.contains(ReadinessFlags::ERROR)
     };
     let socket_error = if query_socket_error {
@@ -1437,10 +1710,13 @@ fn readiness_from_epoll(socket: &SocketEntry, events: epoll::EventFlags) -> Read
     if events.contains(epoll::EventFlags::OUT) && !socket.write_shutdown {
         readiness = readiness | ReadinessFlags::WRITE;
     }
-    if !socket.read_shutdown && events.intersects(epoll::EventFlags::RDHUP | epoll::EventFlags::HUP)
+    if socket.kind == SocketKind::Tcp
+        && !socket.read_shutdown
+        && events.intersects(epoll::EventFlags::RDHUP | epoll::EventFlags::HUP)
     {
         readiness = readiness | ReadinessFlags::READ | ReadinessFlags::HANGUP;
     }
+
     if events.contains(epoll::EventFlags::ERR) {
         readiness = readiness | ReadinessFlags::ERROR;
     }
@@ -1450,6 +1726,18 @@ fn readiness_from_epoll(socket: &SocketEntry, events: epoll::EventFlags) -> Read
         .expect("Linux socket snapshot mutex poisoned")
         .readiness;
     ReadinessFlags(readiness.0 | previous.0)
+}
+
+const fn socket_kind(request: CreateSocketRequest) -> Option<SocketKind> {
+    match (
+        request.address_family,
+        request.socket_type,
+        request.protocol,
+    ) {
+        (AddressFamily::Ipv4, SocketType::Stream, IpProtocol::Tcp) => Some(SocketKind::Tcp),
+        (AddressFamily::Ipv4, SocketType::Datagram, IpProtocol::Udp) => Some(SocketKind::Udp),
+        _ => None,
+    }
 }
 
 fn idle_epoll_events() -> epoll::EventFlags {
@@ -1559,7 +1847,7 @@ const fn broker_resource_error_from_errno(error: Errno) -> Option<BrokerError> {
 mod tests {
     use std::io::{Read as _, Write as _};
     use std::net::Ipv4Addr;
-    use std::net::{Shutdown, TcpListener, TcpStream};
+    use std::net::{Shutdown, TcpListener, TcpStream, UdpSocket};
     use std::sync::mpsc::{Receiver, Sender, channel};
     use std::time::{Duration, Instant};
 
@@ -2112,6 +2400,234 @@ mod tests {
                 .expect("timed out waiting for listener retirements");
             observed.push(retirements.recv_timeout(remaining).unwrap());
         }
+    }
+
+    #[test]
+    fn reactor_preserves_udp_datagram_semantics() {
+        let server = UdpSocket::bind("127.0.0.1:0").unwrap();
+        server.set_read_timeout(Some(TEST_TIMEOUT)).unwrap();
+        let server_address = socket_address_v4(server.local_addr().unwrap());
+        let provider = Arc::new(LinuxSocketProvider::new(2).unwrap());
+        let broker = BrokerCore::new_with_limits(
+            PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
+                .with_socket_policy(SocketPolicy::Ipv4LoopbackTcpUdp),
+            BrokerCoreLimits::new_with_all_limits(4, 0, 2, 2),
+            provider,
+        )
+        .unwrap();
+        let session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let (published, publications) = channel();
+        let (retired, retirements) = channel();
+        let readiness = Arc::new(TestReadinessSink { published, retired });
+        let handle = litebox_broker_core::socket::create(
+            &session,
+            CreateSocketRequest {
+                address_family: AddressFamily::Ipv4,
+                socket_type: SocketType::Datagram,
+                protocol: IpProtocol::Udp,
+            },
+            readiness.clone(),
+        )
+        .unwrap();
+
+        wait_for_readiness(&publications, handle, ReadinessFlags::WRITE);
+        let shutdown_handle = litebox_broker_core::socket::create(
+            &session,
+            CreateSocketRequest {
+                address_family: AddressFamily::Ipv4,
+                socket_type: SocketType::Datagram,
+                protocol: IpProtocol::Udp,
+            },
+            readiness,
+        )
+        .unwrap();
+        wait_for_readiness(&publications, shutdown_handle, ReadinessFlags::WRITE);
+        assert_eq!(
+            litebox_broker_core::socket::shutdown(&session, shutdown_handle, ShutdownMode::Both,),
+            Ok(SocketOutcome::Completed(()))
+        );
+        let shutdown_readiness = session.check_readiness(shutdown_handle).unwrap();
+        assert!(shutdown_readiness.contains(ReadinessFlags::READ));
+        assert!(!shutdown_readiness.contains(ReadinessFlags::WRITE));
+        assert_eq!(
+            litebox_broker_core::socket::send_to(
+                &session,
+                shutdown_handle,
+                b"after shutdown",
+                SendFlags::NONE,
+                Some(server_address),
+            ),
+            Ok(SocketOutcome::Failed(SocketError::Other))
+        );
+        let mut shutdown_data = [0; 1];
+        assert_eq!(
+            litebox_broker_core::socket::receive_from(
+                &session,
+                shutdown_handle,
+                &mut shutdown_data,
+                ReceiveFromFlags::NONE,
+            ),
+            Ok(SocketOutcome::Failed(SocketError::NotConnected))
+        );
+        session.close_object_reference(shutdown_handle).unwrap();
+        assert_eq!(
+            retirements.recv_timeout(TEST_TIMEOUT).unwrap(),
+            shutdown_handle
+        );
+
+        assert_eq!(
+            litebox_broker_core::socket::send_to(
+                &session,
+                handle,
+                b"denied",
+                SendFlags::NONE,
+                Some(SocketAddrV4::new(Ipv4Addr::new(10, 0, 0, 1), 53)),
+            ),
+            Ok(SocketOutcome::Failed(SocketError::PolicyDenied))
+        );
+        let mut no_data = [0; 1];
+        assert_eq!(
+            litebox_broker_core::socket::receive_from(
+                &session,
+                handle,
+                &mut no_data,
+                ReceiveFromFlags::NONE,
+            ),
+            Err(BrokerError::WouldBlock)
+        );
+        assert_eq!(
+            litebox_broker_core::socket::send_to(
+                &session,
+                handle,
+                b"ping",
+                SendFlags::NONE,
+                Some(server_address),
+            ),
+            Ok(SocketOutcome::Completed(4))
+        );
+        let mut packet = vec![0; MAX_UDP_DATAGRAM_SIZE as usize];
+        let (received, source) = server.recv_from(&mut packet).unwrap();
+        assert_eq!(&packet[..received], b"ping");
+        let source = socket_address_v4(source);
+        let status = litebox_broker_core::socket::status(&session, handle).unwrap();
+        assert_eq!(status.status, SocketConnectionStatus::Unconnected);
+        let local_address = status.local_address.unwrap();
+        assert!(local_address.ip().is_unspecified());
+        assert_eq!(local_address.port(), source.port());
+
+        server.send_to(&[], source).unwrap();
+        wait_for_readiness(&publications, handle, ReadinessFlags::READ);
+        let mut zero = [];
+        assert_eq!(
+            litebox_broker_core::socket::receive_from(
+                &session,
+                handle,
+                &mut zero,
+                ReceiveFromFlags::NONE,
+            ),
+            Ok(SocketOutcome::Completed(ReceivedPlatformDatagram {
+                received: 0,
+                datagram_length: 0,
+                source_address: server_address,
+            }))
+        );
+        assert_eq!(
+            litebox_broker_core::socket::receive_from(
+                &session,
+                handle,
+                &mut zero,
+                ReceiveFromFlags::NONE,
+            ),
+            Err(BrokerError::WouldBlock)
+        );
+
+        server.send_to(b"abcdef", source).unwrap();
+        wait_for_readiness(&publications, handle, ReadinessFlags::READ);
+        let mut peeked = [0; 3];
+        assert_eq!(
+            litebox_broker_core::socket::receive_from(
+                &session,
+                handle,
+                &mut peeked,
+                ReceiveFromFlags::PEEK,
+            ),
+            Ok(SocketOutcome::Completed(ReceivedPlatformDatagram {
+                received: 3,
+                datagram_length: 6,
+                source_address: server_address,
+            }))
+        );
+        assert_eq!(&peeked, b"abc");
+        let mut truncated = [0; 4];
+        assert_eq!(
+            litebox_broker_core::socket::receive_from(
+                &session,
+                handle,
+                &mut truncated,
+                ReceiveFromFlags::NONE,
+            ),
+            Ok(SocketOutcome::Completed(ReceivedPlatformDatagram {
+                received: 4,
+                datagram_length: 6,
+                source_address: server_address,
+            }))
+        );
+        assert_eq!(&truncated, b"abcd");
+        assert_eq!(
+            litebox_broker_core::socket::receive_from(
+                &session,
+                handle,
+                &mut no_data,
+                ReceiveFromFlags::NONE,
+            ),
+            Err(BrokerError::WouldBlock)
+        );
+
+        assert_eq!(
+            litebox_broker_core::socket::connect(&session, handle, server_address),
+            Ok(SocketOutcome::Completed(SocketConnectionStatus::Connected))
+        );
+        let connected_status = litebox_broker_core::socket::status(&session, handle).unwrap();
+        assert_eq!(connected_status.status, SocketConnectionStatus::Connected);
+        assert_eq!(connected_status.local_address, Some(source));
+        let maximum = vec![0x5a; MAX_UDP_DATAGRAM_SIZE as usize];
+        assert_eq!(
+            litebox_broker_core::socket::send_to(&session, handle, &maximum, SendFlags::NONE, None,),
+            Ok(SocketOutcome::Completed(maximum.len()))
+        );
+        let (received, connected_source) = server.recv_from(&mut packet).unwrap();
+        assert_eq!(received, maximum.len());
+        assert_eq!(&packet[..received], maximum.as_slice());
+        assert_eq!(socket_address_v4(connected_source), source);
+        assert_eq!(
+            litebox_broker_core::socket::shutdown(&session, handle, ShutdownMode::Write),
+            Ok(SocketOutcome::Completed(()))
+        );
+        assert_eq!(
+            litebox_broker_core::socket::connect(&session, handle, server_address),
+            Ok(SocketOutcome::Completed(SocketConnectionStatus::Connected))
+        );
+        assert!(
+            !session
+                .check_readiness(handle)
+                .unwrap()
+                .contains(ReadinessFlags::WRITE)
+        );
+        assert_eq!(
+            litebox_broker_core::socket::send_to(
+                &session,
+                handle,
+                b"after shutdown",
+                SendFlags::NONE,
+                None,
+            ),
+            Ok(SocketOutcome::Failed(SocketError::Other))
+        );
+
+        session.close_object_reference(handle).unwrap();
+        assert_eq!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), handle);
     }
 
     fn socket_address_v4(address: std::net::SocketAddr) -> SocketAddrV4 {

--- a/litebox_broker_platform_linux_userland/src/socket.rs
+++ b/litebox_broker_platform_linux_userland/src/socket.rs
@@ -1714,9 +1714,7 @@ fn status_socket(socket: &mut SocketEntry) -> BrokerResult<SocketStatusResponse>
             .snapshot
             .lock()
             .expect("Linux socket snapshot mutex poisoned");
-        snapshot.pending_error.is_none()
-            && (snapshot.status == SocketConnectionStatus::Connected
-                || socket.kind == SocketKind::Udp)
+        (snapshot.status == SocketConnectionStatus::Connected || socket.kind == SocketKind::Udp)
             && snapshot.readiness.contains(ReadinessFlags::ERROR)
     };
     let socket_error = if query_socket_error {
@@ -1724,13 +1722,15 @@ fn status_socket(socket: &mut SocketEntry) -> BrokerResult<SocketStatusResponse>
     } else {
         None
     };
-    let (response, readiness) = {
+    let (response, readiness, republish_error) = {
         let mut snapshot = socket
             .snapshot
             .lock()
             .expect("Linux socket snapshot mutex poisoned");
-        let pending_error = snapshot.pending_error.take().or(socket_error);
-        if pending_error.is_some() {
+        let cached_error = snapshot.pending_error.take();
+        let (pending_error, next_pending_error) = shift_pending_error(cached_error, socket_error);
+        snapshot.pending_error = next_pending_error;
+        if pending_error.is_some() && next_pending_error.is_none() {
             snapshot.readiness = ReadinessFlags(snapshot.readiness.0 & !ReadinessFlags::ERROR.0);
         }
         (
@@ -1740,12 +1740,25 @@ fn status_socket(socket: &mut SocketEntry) -> BrokerResult<SocketStatusResponse>
                 pending_error,
             },
             snapshot.readiness,
+            next_pending_error.is_some(),
         )
     };
-    if response.pending_error.is_some() {
+    if republish_error {
+        socket.readiness.republish(readiness)?;
+    } else if response.pending_error.is_some() {
         socket.readiness.publish(readiness)?;
     }
     Ok(response)
+}
+
+fn shift_pending_error(
+    cached_error: Option<SocketError>,
+    socket_error: Option<SocketError>,
+) -> (Option<SocketError>, Option<SocketError>) {
+    match cached_error {
+        Some(error) => (Some(error), socket_error),
+        None => (socket_error, None),
+    }
 }
 
 fn readiness_from_epoll(socket: &SocketEntry, events: epoll::EventFlags) -> ReadinessFlags {
@@ -1841,12 +1854,46 @@ fn clear_readiness(socket: &SocketEntry, readiness: ReadinessFlags) -> BrokerRes
 }
 
 fn consume_synchronous_error(socket: &SocketEntry) -> BrokerResult<()> {
-    socket
-        .snapshot
-        .lock()
-        .expect("Linux socket snapshot mutex poisoned")
-        .pending_error = None;
-    clear_readiness(socket, ReadinessFlags::ERROR)
+    let query_socket_error = {
+        let snapshot = socket
+            .snapshot
+            .lock()
+            .expect("Linux socket snapshot mutex poisoned");
+        if !can_consume_synchronous_error(socket.kind, snapshot.status) {
+            return Ok(());
+        }
+        snapshot.pending_error.is_none()
+    };
+    let socket_error = if query_socket_error {
+        take_socket_error(socket)?
+    } else {
+        None
+    };
+    let (readiness, changed) = {
+        let mut snapshot = socket
+            .snapshot
+            .lock()
+            .expect("Linux socket snapshot mutex poisoned");
+        if snapshot.pending_error.is_none() {
+            snapshot.pending_error = socket_error;
+        }
+        let readiness = if snapshot.pending_error.is_some() {
+            snapshot.readiness | ReadinessFlags::ERROR
+        } else {
+            ReadinessFlags(snapshot.readiness.0 & !ReadinessFlags::ERROR.0)
+        };
+        let changed = readiness != snapshot.readiness;
+        snapshot.readiness = readiness;
+        (readiness, changed)
+    };
+    if changed {
+        socket.readiness.publish(readiness)?;
+    }
+    Ok(())
+}
+
+const fn can_consume_synchronous_error(kind: SocketKind, status: SocketConnectionStatus) -> bool {
+    matches!(kind, SocketKind::Udp) || matches!(status, SocketConnectionStatus::Connected)
 }
 
 const fn socket_error_from_errno(error: Errno) -> SocketError {
@@ -1907,6 +1954,40 @@ mod tests {
     use litebox_broker_protocol::socket::{Ipv4Address, Port};
 
     const TEST_TIMEOUT: Duration = Duration::from_secs(5);
+
+    #[test]
+    fn cached_socket_error_precedes_a_new_kernel_error() {
+        assert_eq!(
+            shift_pending_error(
+                Some(SocketError::ConnectionRefused),
+                Some(SocketError::NetworkUnreachable),
+            ),
+            (
+                Some(SocketError::ConnectionRefused),
+                Some(SocketError::NetworkUnreachable),
+            )
+        );
+        assert_eq!(
+            shift_pending_error(None, Some(SocketError::NetworkUnreachable)),
+            (Some(SocketError::NetworkUnreachable), None)
+        );
+    }
+
+    #[test]
+    fn synchronous_errors_do_not_consume_tcp_connect_status() {
+        assert!(!can_consume_synchronous_error(
+            SocketKind::Tcp,
+            SocketConnectionStatus::Connecting,
+        ));
+        assert!(can_consume_synchronous_error(
+            SocketKind::Tcp,
+            SocketConnectionStatus::Connected,
+        ));
+        assert!(can_consume_synchronous_error(
+            SocketKind::Udp,
+            SocketConnectionStatus::Unconnected,
+        ));
+    }
 
     struct TestReadinessSink {
         published: Sender<(ObjectHandle, ReadinessFlags)>,
@@ -2695,6 +2776,38 @@ mod tests {
                 None,
             ),
             Ok(SocketOutcome::Completed(7))
+        );
+        wait_for_readiness(&publications, handle, ReadinessFlags::ERROR);
+        assert_eq!(
+            litebox_broker_core::socket::send_to(
+                &session,
+                handle,
+                b"broadcast",
+                SendFlags::NONE,
+                Some(SocketAddrV4::new(Ipv4Addr::BROADCAST, 9)),
+            ),
+            Ok(SocketOutcome::Failed(SocketError::Other))
+        );
+        let send_error_status = litebox_broker_core::socket::status(&session, handle).unwrap();
+        assert_eq!(
+            send_error_status.pending_error,
+            Some(SocketError::ConnectionRefused)
+        );
+        assert!(
+            !session
+                .check_readiness(handle)
+                .unwrap()
+                .contains(ReadinessFlags::ERROR)
+        );
+        assert_eq!(
+            litebox_broker_core::socket::send_to(
+                &session,
+                handle,
+                b"refused again",
+                SendFlags::NONE,
+                None,
+            ),
+            Ok(SocketOutcome::Completed(13))
         );
         wait_for_readiness(&publications, handle, ReadinessFlags::ERROR);
         assert_eq!(

--- a/litebox_broker_protocol/src/message.rs
+++ b/litebox_broker_protocol/src/message.rs
@@ -14,9 +14,10 @@ use crate::readiness::ReadinessFlags;
 use crate::socket::{
     AcceptSocketRequest, AcceptSocketResponse, BindSocketRequest, BindSocketResponse,
     ConnectSocketRequest, ConnectSocketResponse, CreateSocketRequest, CreateSocketResponse,
-    ListenSocketRequest, ListenSocketResponse, ReceiveSocketRequest, ReceiveSocketResponse,
-    SendSocketRequest, SendSocketResponse, ShutdownSocketRequest, SocketError, SocketStatusRequest,
-    SocketStatusResponse,
+    ListenSocketRequest, ListenSocketResponse, ReceiveFromSocketRequest, ReceiveFromSocketResponse,
+    ReceiveSocketRequest, ReceiveSocketResponse, SendSocketRequest, SendSocketResponse,
+    SendToSocketRequest, SendToSocketResponse, ShutdownSocketRequest, SocketError,
+    SocketStatusRequest, SocketStatusResponse,
 };
 use crate::{ObjectHandle, ProtocolVersion, RequestId};
 
@@ -112,8 +113,12 @@ pub enum SocketRequest {
     Accept(AcceptSocketRequest),
     /// Send bytes staged in shared memory.
     Send(SendSocketRequest),
+    /// Send one complete datagram staged in shared memory.
+    SendTo(SendToSocketRequest),
     /// Receive bytes into shared memory.
     Receive(ReceiveSocketRequest),
+    /// Receive one datagram into shared memory.
+    ReceiveFrom(ReceiveFromSocketRequest),
     /// Shut down one or both directions.
     Shutdown(ShutdownSocketRequest),
     /// Read a socket's connection state.
@@ -183,18 +188,22 @@ pub enum SocketResponse {
     Accept(AcceptSocketResponse),
     /// Send operation response.
     Send(SendSocketResponse),
+    /// Datagram send operation response.
+    SendTo(SendToSocketResponse),
     /// Receive operation response.
     Receive(ReceiveSocketResponse),
+    /// Datagram receive operation response.
+    ReceiveFrom(ReceiveFromSocketResponse),
     /// Shutdown operation completed.
     Shutdown,
     /// Status operation response.
     Status(SocketStatusResponse),
-    /// A non-connect host network operation failed.
+    /// A host network operation failed.
     ///
-    /// Connect and status responses carry terminal failures in
-    /// [`SocketConnectionStatus`] so repeated status requests remain
-    /// idempotent. Broker and request-validation failures use
-    /// [`BrokerResult::Error`] instead.
+    /// Stream connect and status responses carry terminal connection failures
+    /// in [`SocketConnectionStatus`]. Datagram connect failures and other
+    /// ordinary socket failures use this variant. Broker and request-validation
+    /// failures use [`BrokerResult::Error`] instead.
     ///
     /// [`SocketConnectionStatus`]: crate::socket::SocketConnectionStatus
     Failed(SocketError),

--- a/litebox_broker_protocol/src/shared_buffer.rs
+++ b/litebox_broker_protocol/src/shared_buffer.rs
@@ -140,6 +140,7 @@ mod tests {
     fn larger_slots_do_not_change_existing_transfer_limits() {
         assert_eq!(crate::pipe::MAX_PIPE_TRANSFER_SIZE, 32 * 1024);
         assert_eq!(crate::socket::MAX_SOCKET_TRANSFER_SIZE, 32 * 1024);
+        assert_eq!(crate::socket::MAX_UDP_DATAGRAM_SIZE, 65_507);
     }
 
     #[test]

--- a/litebox_broker_protocol/src/socket.rs
+++ b/litebox_broker_protocol/src/socket.rs
@@ -23,6 +23,14 @@ pub const MAX_SOCKET_TRANSFER_SIZE: u32 = 32 * 1024;
 
 const _: () = assert!(MAX_SOCKET_TRANSFER_SIZE <= SHARED_BUFFER_SLOT_SIZE);
 
+/// Maximum bytes carried by one IPv4 UDP datagram.
+///
+/// A complete datagram fits in one association shared-buffer slot, preserving
+/// datagram atomicity across the broker boundary.
+pub const MAX_UDP_DATAGRAM_SIZE: u32 = 65_507;
+
+const _: () = assert!(MAX_UDP_DATAGRAM_SIZE <= SHARED_BUFFER_SLOT_SIZE);
+
 /// Maximum stream prefix addressable by offset-based peek requests.
 pub const MAX_SOCKET_PEEK_SIZE: u32 = 0x80_000;
 /// Maximum TCP listen backlog accepted by the broker protocol.
@@ -42,6 +50,8 @@ pub enum AddressFamily {
 pub enum SocketType {
     /// Reliable ordered byte stream.
     Stream,
+    /// Message-oriented datagrams.
+    Datagram,
 }
 
 /// IP protocol carried by a broker socket.
@@ -50,21 +60,23 @@ pub enum SocketType {
 pub enum IpProtocol {
     /// TCP.
     Tcp,
+    /// UDP.
+    Udp,
 }
 
 /// How to stop I/O on a socket.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum ShutdownMode {
-    /// Further receives return end of stream.
+    /// Disables further receives.
     Read,
-    /// The peer sees end of stream.
+    /// Disables further sends.
     Write,
     /// Both directions.
     Both,
-    /// The final close discards queued data and resets the connection.
+    /// The final TCP close discards queued data and resets the connection.
     Abort,
-    /// Stops accepting new connections while retaining the socket object.
+    /// Stops accepting new TCP connections while retaining the socket object.
     StopListening,
 }
 
@@ -131,6 +143,36 @@ impl ReceiveFlags {
 
     /// Every receive flag this protocol version defines.
     pub const SUPPORTED: Self = Self(Self::PEEK.0 | Self::WAITALL.0);
+
+    /// Returns whether any bit outside [`Self::SUPPORTED`] is set.
+    #[must_use]
+    pub const fn has_unsupported_bits(self) -> bool {
+        self.0 & !Self::SUPPORTED.0 != 0
+    }
+
+    /// Returns whether every flag in `other` is set.
+    #[must_use]
+    pub const fn contains(self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
+
+/// Flags for receiving one datagram.
+///
+/// Stream-only flags such as [`ReceiveFlags::WAITALL`] are intentionally not
+/// representable on this operation.
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ReceiveFromFlags(pub u32);
+
+impl ReceiveFromFlags {
+    /// No flags.
+    pub const NONE: Self = Self(0);
+    /// Return the next datagram without consuming it.
+    pub const PEEK: Self = Self(1 << 0);
+
+    /// Every datagram receive flag this protocol version defines.
+    pub const SUPPORTED: Self = Self(Self::PEEK.0);
 
     /// Returns whether any bit outside [`Self::SUPPORTED`] is set.
     #[must_use]
@@ -338,8 +380,10 @@ pub struct AcceptSocketResponse {
 /// caller waits for write readiness and then reads the authoritative state with
 /// a status request.
 ///
-/// Connected and failed states are terminal and idempotent: repeated status
-/// requests return the same state.
+/// Stream connected and failed states are terminal and idempotent. Datagram
+/// connects complete immediately, may replace an existing peer, and report a
+/// synchronous failure as an operation failure rather than storing
+/// [`Self::Failed`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum SocketConnectionStatus {
@@ -367,6 +411,26 @@ pub struct SendSocketRequest {
 /// Response describing a completed send.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct SendSocketResponse {
+    /// Number of bytes accepted by the socket.
+    pub sent: u32,
+}
+
+/// Request to send one datagram staged in shared memory.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SendToSocketRequest {
+    /// Socket handle.
+    pub handle: ObjectHandle,
+    /// Leased shared-buffer region containing the complete datagram.
+    pub buffer: SharedBufferDescriptor,
+    /// Send flags.
+    pub flags: SendFlags,
+    /// Explicit destination, or `None` to use the connected peer.
+    pub destination: Option<SocketAddrV4>,
+}
+
+/// Response describing a completed atomic datagram send.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SendToSocketResponse {
     /// Number of bytes accepted by the socket.
     pub sent: u32,
 }
@@ -399,6 +463,28 @@ pub enum ReceiveSocketResponse {
     Received(u32),
     /// The socket's receive direction reached end of stream.
     EndOfStream,
+}
+
+/// Request to receive one datagram into shared memory.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ReceiveFromSocketRequest {
+    /// Socket handle.
+    pub handle: ObjectHandle,
+    /// Leased shared-buffer receive region.
+    pub buffer: SharedBufferDescriptor,
+    /// Datagram receive flags.
+    pub flags: ReceiveFromFlags,
+}
+
+/// Response describing one received datagram.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ReceiveFromSocketResponse {
+    /// Number of bytes copied into the shared-buffer region.
+    pub received: u32,
+    /// Original datagram length before any truncation.
+    pub datagram_length: u32,
+    /// Source address of the datagram.
+    pub source_address: SocketAddrV4,
 }
 
 /// Request to shut down one or both directions of a socket.

--- a/litebox_broker_protocol/src/wire.rs
+++ b/litebox_broker_protocol/src/wire.rs
@@ -354,9 +354,11 @@ mod tests {
         AcceptSocketRequest, AcceptSocketResponse, AddressFamily, BindSocketRequest,
         BindSocketResponse, ConnectSocketRequest, ConnectSocketResponse, CreateSocketRequest,
         CreateSocketResponse, IpProtocol, ListenSocketRequest, ListenSocketResponse, ReceiveFlags,
+        ReceiveFromFlags, ReceiveFromSocketRequest, ReceiveFromSocketResponse,
         ReceiveSocketRequest, ReceiveSocketResponse, SendFlags, SendSocketRequest,
-        SendSocketResponse, ShutdownMode, ShutdownSocketRequest, SocketConnectionStatus,
-        SocketError, SocketStatusRequest, SocketStatusResponse, SocketType,
+        SendSocketResponse, SendToSocketRequest, SendToSocketResponse, ShutdownMode,
+        ShutdownSocketRequest, SocketConnectionStatus, SocketError, SocketStatusRequest,
+        SocketStatusResponse, SocketType,
     };
     use crate::{ObjectHandle, ProtocolVersion, RequestId};
     use core::net::{Ipv4Addr, SocketAddrV4};
@@ -429,6 +431,11 @@ mod tests {
                 socket_type: SocketType::Stream,
                 protocol: IpProtocol::Tcp,
             })),
+            BrokerOperation::Socket(SocketRequest::Create(CreateSocketRequest {
+                address_family: AddressFamily::Ipv4,
+                socket_type: SocketType::Datagram,
+                protocol: IpProtocol::Udp,
+            })),
             BrokerOperation::Socket(SocketRequest::Bind(BindSocketRequest {
                 handle,
                 address: SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0),
@@ -450,6 +457,24 @@ mod tests {
                 },
                 flags: SendFlags::NONE,
             })),
+            BrokerOperation::Socket(SocketRequest::SendTo(SendToSocketRequest {
+                handle,
+                buffer: SharedBufferDescriptor {
+                    slot_index: SharedBufferSlotIndex(15),
+                    length: 3,
+                },
+                flags: SendFlags::NONE,
+                destination: Some(SocketAddrV4::new(Ipv4Addr::new(203, 0, 113, 7), 53)),
+            })),
+            BrokerOperation::Socket(SocketRequest::SendTo(SendToSocketRequest {
+                handle,
+                buffer: SharedBufferDescriptor {
+                    slot_index: SharedBufferSlotIndex(15),
+                    length: 0,
+                },
+                flags: SendFlags::NONE,
+                destination: None,
+            })),
             BrokerOperation::Socket(SocketRequest::Receive(ReceiveSocketRequest {
                 handle,
                 buffer: SharedBufferDescriptor {
@@ -459,6 +484,14 @@ mod tests {
                 flags: ReceiveFlags::PEEK,
                 peek_offset: 2,
                 peek_length: 5,
+            })),
+            BrokerOperation::Socket(SocketRequest::ReceiveFrom(ReceiveFromSocketRequest {
+                handle,
+                buffer: SharedBufferDescriptor {
+                    slot_index: SharedBufferSlotIndex(15),
+                    length: 3,
+                },
+                flags: ReceiveFromFlags::PEEK,
             })),
             BrokerOperation::Socket(SocketRequest::Shutdown(ShutdownSocketRequest {
                 handle,
@@ -528,6 +561,11 @@ mod tests {
                 peek_offset: 0,
                 peek_length: 0,
             })),
+            BrokerOperation::Socket(SocketRequest::ReceiveFrom(ReceiveFromSocketRequest {
+                handle,
+                buffer,
+                flags: ReceiveFromFlags(unsupported),
+            })),
         ] {
             let request = BrokerRequest {
                 request_id: TEST_REQUEST_ID,
@@ -547,6 +585,9 @@ mod tests {
         assert!(!ReceiveFlags::PEEK.has_unsupported_bits());
         assert!(ReceiveFlags::PEEK.contains(ReceiveFlags::PEEK));
         assert!(!ReceiveFlags::NONE.contains(ReceiveFlags::PEEK));
+        assert!(ReceiveFromFlags(unsupported).has_unsupported_bits());
+        assert!(!ReceiveFromFlags::PEEK.has_unsupported_bits());
+        assert!(ReceiveFromFlags::PEEK.contains(ReceiveFromFlags::PEEK));
     }
 
     #[test]
@@ -665,9 +706,20 @@ mod tests {
                 status: SocketConnectionStatus::Failed(SocketError::ConnectionRefused),
             })),
             BrokerResult::Socket(SocketResponse::Send(SendSocketResponse { sent: 3 })),
+            BrokerResult::Socket(SocketResponse::SendTo(SendToSocketResponse { sent: 3 })),
             BrokerResult::Socket(SocketResponse::Receive(ReceiveSocketResponse::Received(3))),
             BrokerResult::Socket(SocketResponse::Receive(ReceiveSocketResponse::Received(0))),
             BrokerResult::Socket(SocketResponse::Receive(ReceiveSocketResponse::EndOfStream)),
+            BrokerResult::Socket(SocketResponse::ReceiveFrom(ReceiveFromSocketResponse {
+                received: 3,
+                datagram_length: 7,
+                source_address: SocketAddrV4::new(Ipv4Addr::LOCALHOST, 49153),
+            })),
+            BrokerResult::Socket(SocketResponse::ReceiveFrom(ReceiveFromSocketResponse {
+                received: 0,
+                datagram_length: 0,
+                source_address: SocketAddrV4::new(Ipv4Addr::LOCALHOST, 49153),
+            })),
             BrokerResult::Socket(SocketResponse::Shutdown),
             BrokerResult::Socket(SocketResponse::Status(socket_status(
                 SocketConnectionStatus::Connecting,
@@ -874,6 +926,24 @@ mod tests {
         assert_eq!(
             decode_request(&connect[..connect.len() - 1]),
             Err(WireError::TruncatedFrame)
+        );
+
+        let mut unknown_send_to_destination = encode_request(BrokerRequest {
+            request_id: TEST_REQUEST_ID,
+            operation: BrokerOperation::Socket(SocketRequest::SendTo(SendToSocketRequest {
+                handle: ObjectHandle(9),
+                buffer: SharedBufferDescriptor {
+                    slot_index: SharedBufferSlotIndex(1),
+                    length: 0,
+                },
+                flags: SendFlags::NONE,
+                destination: None,
+            })),
+        });
+        *unknown_send_to_destination.last_mut().unwrap() = 2;
+        assert_eq!(
+            decode_request(&unknown_send_to_destination),
+            Err(WireError::InvalidTag)
         );
 
         let mut trailing = connect;
@@ -1133,6 +1203,28 @@ mod tests {
                 })),
             }),
             [5, 13, 0, 0, 0, 0, 0, 0, 0, 9, 9, 0, 0, 0, 0, 0, 0, 0]
+        );
+    }
+
+    #[test]
+    fn socket_send_to_request_wire_shape_is_pinned() {
+        assert_eq!(
+            encode_request(BrokerRequest {
+                request_id: RequestId(13),
+                operation: BrokerOperation::Socket(SocketRequest::SendTo(SendToSocketRequest {
+                    handle: ObjectHandle(9),
+                    buffer: SharedBufferDescriptor {
+                        slot_index: SharedBufferSlotIndex(2),
+                        length: 3,
+                    },
+                    flags: SendFlags::NONE,
+                    destination: Some(SocketAddrV4::new(Ipv4Addr::new(203, 0, 113, 7), 53,)),
+                })),
+            }),
+            [
+                5, 13, 0, 0, 0, 0, 0, 0, 0, 10, 9, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 0,
+                0, 0, 0, 1, 203, 0, 113, 7, 53, 0
+            ]
         );
     }
 

--- a/litebox_broker_protocol/src/wire/socket.rs
+++ b/litebox_broker_protocol/src/wire/socket.rs
@@ -9,9 +9,10 @@ use crate::socket::{
     AcceptSocketRequest, AcceptSocketResponse, AddressFamily, BindSocketRequest,
     BindSocketResponse, ConnectSocketRequest, ConnectSocketResponse, CreateSocketRequest,
     CreateSocketResponse, IpProtocol, ListenSocketRequest, ListenSocketResponse, ReceiveFlags,
-    ReceiveSocketRequest, ReceiveSocketResponse, SendFlags, SendSocketRequest, SendSocketResponse,
-    ShutdownMode, ShutdownSocketRequest, SocketConnectionStatus, SocketError, SocketStatusRequest,
-    SocketStatusResponse, SocketType,
+    ReceiveFromFlags, ReceiveFromSocketRequest, ReceiveFromSocketResponse, ReceiveSocketRequest,
+    ReceiveSocketResponse, SendFlags, SendSocketRequest, SendSocketResponse, SendToSocketRequest,
+    SendToSocketResponse, ShutdownMode, ShutdownSocketRequest, SocketConnectionStatus, SocketError,
+    SocketStatusRequest, SocketStatusResponse, SocketType,
 };
 
 use super::WireError;
@@ -27,12 +28,16 @@ const SOCKET_TAG_FAILED: u8 = 6;
 const SOCKET_TAG_BIND: u8 = 7;
 const SOCKET_TAG_LISTEN: u8 = 8;
 const SOCKET_TAG_ACCEPT: u8 = 9;
+const SOCKET_TAG_SEND_TO: u8 = 10;
+const SOCKET_TAG_RECEIVE_FROM: u8 = 11;
 
 const ADDRESS_FAMILY_TAG_IPV4: u8 = 0;
 
 const TYPE_TAG_STREAM: u8 = 0;
+const TYPE_TAG_DATAGRAM: u8 = 1;
 
 const IP_PROTOCOL_TAG_TCP: u8 = 0;
+const IP_PROTOCOL_TAG_UDP: u8 = 1;
 
 const SHUTDOWN_TAG_READ: u8 = 0;
 const SHUTDOWN_TAG_WRITE: u8 = 1;
@@ -57,9 +62,11 @@ pub(super) fn encode_socket_request(encoder: &mut Encoder, request: SocketReques
             });
             encoder.u8(match request.socket_type {
                 SocketType::Stream => TYPE_TAG_STREAM,
+                SocketType::Datagram => TYPE_TAG_DATAGRAM,
             });
             encoder.u8(match request.protocol {
                 IpProtocol::Tcp => IP_PROTOCOL_TAG_TCP,
+                IpProtocol::Udp => IP_PROTOCOL_TAG_UDP,
             });
         }
         SocketRequest::Connect(request) => {
@@ -87,6 +94,13 @@ pub(super) fn encode_socket_request(encoder: &mut Encoder, request: SocketReques
             encode_shared_buffer_descriptor(encoder, request.buffer);
             encoder.u32(request.flags.0);
         }
+        SocketRequest::SendTo(request) => {
+            encoder.u8(SOCKET_TAG_SEND_TO);
+            encoder.handle(request.handle);
+            encode_shared_buffer_descriptor(encoder, request.buffer);
+            encoder.u32(request.flags.0);
+            encode_optional_address(encoder, request.destination);
+        }
         SocketRequest::Receive(request) => {
             encoder.u8(SOCKET_TAG_RECEIVE);
             encoder.handle(request.handle);
@@ -94,6 +108,12 @@ pub(super) fn encode_socket_request(encoder: &mut Encoder, request: SocketReques
             encoder.u32(request.flags.0);
             encoder.u32(request.peek_offset);
             encoder.u32(request.peek_length);
+        }
+        SocketRequest::ReceiveFrom(request) => {
+            encoder.u8(SOCKET_TAG_RECEIVE_FROM);
+            encoder.handle(request.handle);
+            encode_shared_buffer_descriptor(encoder, request.buffer);
+            encoder.u32(request.flags.0);
         }
         SocketRequest::Shutdown(request) => {
             encoder.u8(SOCKET_TAG_SHUTDOWN);
@@ -122,10 +142,12 @@ pub(super) fn decode_socket_request(decoder: &mut Decoder<'_>) -> Result<SocketR
             },
             socket_type: match decoder.u8()? {
                 TYPE_TAG_STREAM => SocketType::Stream,
+                TYPE_TAG_DATAGRAM => SocketType::Datagram,
                 _ => return Err(WireError::InvalidTag),
             },
             protocol: match decoder.u8()? {
                 IP_PROTOCOL_TAG_TCP => IpProtocol::Tcp,
+                IP_PROTOCOL_TAG_UDP => IpProtocol::Udp,
                 _ => return Err(WireError::InvalidTag),
             },
         })),
@@ -149,12 +171,23 @@ pub(super) fn decode_socket_request(decoder: &mut Decoder<'_>) -> Result<SocketR
             buffer: decode_shared_buffer_descriptor(decoder)?,
             flags: SendFlags(decoder.u32()?),
         })),
+        SOCKET_TAG_SEND_TO => Ok(SocketRequest::SendTo(SendToSocketRequest {
+            handle: decoder.handle()?,
+            buffer: decode_shared_buffer_descriptor(decoder)?,
+            flags: SendFlags(decoder.u32()?),
+            destination: decode_optional_address(decoder)?,
+        })),
         SOCKET_TAG_RECEIVE => Ok(SocketRequest::Receive(ReceiveSocketRequest {
             handle: decoder.handle()?,
             buffer: decode_shared_buffer_descriptor(decoder)?,
             flags: ReceiveFlags(decoder.u32()?),
             peek_offset: decoder.u32()?,
             peek_length: decoder.u32()?,
+        })),
+        SOCKET_TAG_RECEIVE_FROM => Ok(SocketRequest::ReceiveFrom(ReceiveFromSocketRequest {
+            handle: decoder.handle()?,
+            buffer: decode_shared_buffer_descriptor(decoder)?,
+            flags: ReceiveFromFlags(decoder.u32()?),
         })),
         SOCKET_TAG_SHUTDOWN => Ok(SocketRequest::Shutdown(ShutdownSocketRequest {
             handle: decoder.handle()?,
@@ -202,6 +235,10 @@ pub(super) fn encode_socket_response(encoder: &mut Encoder, response: SocketResp
             encoder.u8(SOCKET_TAG_SEND);
             encoder.u32(response.sent);
         }
+        SocketResponse::SendTo(response) => {
+            encoder.u8(SOCKET_TAG_SEND_TO);
+            encoder.u32(response.sent);
+        }
         SocketResponse::Receive(response) => {
             encoder.u8(SOCKET_TAG_RECEIVE);
             match response {
@@ -213,6 +250,12 @@ pub(super) fn encode_socket_response(encoder: &mut Encoder, response: SocketResp
                     encoder.u8(RECEIVE_RESPONSE_TAG_END_OF_STREAM);
                 }
             }
+        }
+        SocketResponse::ReceiveFrom(response) => {
+            encoder.u8(SOCKET_TAG_RECEIVE_FROM);
+            encoder.u32(response.received);
+            encoder.u32(response.datagram_length);
+            encode_address(encoder, response.source_address);
         }
         SocketResponse::Shutdown => encoder.u8(SOCKET_TAG_SHUTDOWN),
         SocketResponse::Status(response) => {
@@ -252,10 +295,18 @@ pub(super) fn decode_socket_response(
         SOCKET_TAG_SEND => Ok(SocketResponse::Send(SendSocketResponse {
             sent: decoder.u32()?,
         })),
+        SOCKET_TAG_SEND_TO => Ok(SocketResponse::SendTo(SendToSocketResponse {
+            sent: decoder.u32()?,
+        })),
         SOCKET_TAG_RECEIVE => Ok(SocketResponse::Receive(match decoder.u8()? {
             RECEIVE_RESPONSE_TAG_RECEIVED => ReceiveSocketResponse::Received(decoder.u32()?),
             RECEIVE_RESPONSE_TAG_END_OF_STREAM => ReceiveSocketResponse::EndOfStream,
             _ => return Err(WireError::InvalidTag),
+        })),
+        SOCKET_TAG_RECEIVE_FROM => Ok(SocketResponse::ReceiveFrom(ReceiveFromSocketResponse {
+            received: decoder.u32()?,
+            datagram_length: decoder.u32()?,
+            source_address: decode_address(decoder)?,
         })),
         SOCKET_TAG_SHUTDOWN => Ok(SocketResponse::Shutdown),
         SOCKET_TAG_STATUS => Ok(SocketResponse::Status(SocketStatusResponse {

--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -19,7 +19,8 @@ use std::time::{Duration, Instant};
 use clap::Parser;
 use litebox_broker_core::{
     BrokerCore, BrokerCoreLimits, CallerCredential, Ipv4Cidr, ObjectRights, PolicyEngine,
-    SocketPolicy, SocketPolicyError, TcpDestinationRule, TcpPortRange,
+    SocketPolicy, SocketPolicyError, TcpDestinationRule, TcpPortRange, UdpDestinationRule,
+    UdpPortRange,
 };
 use litebox_broker_host::{BrokerHostAssociation, ConnectionTermination, setup_connection};
 use litebox_broker_platform_linux_userland::LinuxSocketProvider;
@@ -143,7 +144,7 @@ fn configured_socket_policy(
     allowed_destinations: &[AllowedTcpDestination],
 ) -> Result<SocketPolicy, SocketPolicyError> {
     if allowed_destinations.is_empty() {
-        return Ok(SocketPolicy::Ipv4LoopbackTcp);
+        return Ok(SocketPolicy::Ipv4LoopbackTcpUdp);
     }
     let rules = allowed_destinations
         .iter()
@@ -155,7 +156,13 @@ fn configured_socket_policy(
             )
         })
         .collect::<Vec<_>>();
-    SocketPolicy::from_tcp_destination_rules(&rules)
+    let udp_loopback = UdpDestinationRule::new(
+        CallerCredential::HostGuaranteed,
+        Ipv4Cidr::new(Ipv4Address([127, 0, 0, 0]), 8).expect("the IPv4 loopback CIDR is canonical"),
+        UdpPortRange::new(Port(1), Port(u16::MAX))
+            .expect("the full nonzero UDP port range is valid"),
+    );
+    SocketPolicy::from_tcp_udp_destination_rules(&rules, &[udp_loopback])
 }
 
 fn serve_runner(
@@ -561,7 +568,7 @@ mod tests {
     fn tcp_destination_arguments_replace_the_loopback_default() {
         assert_eq!(
             configured_socket_policy(&[]).unwrap(),
-            SocketPolicy::Ipv4LoopbackTcp
+            SocketPolicy::Ipv4LoopbackTcpUdp
         );
 
         let allowed = "0.0.0.0/0:80".parse::<AllowedTcpDestination>().unwrap();
@@ -575,6 +582,14 @@ mod tests {
                 allowed.destination,
                 allowed.ports,
             )
+        );
+        assert_eq!(
+            policy.udp_destination_rules().unwrap(),
+            &[UdpDestinationRule::new(
+                CallerCredential::HostGuaranteed,
+                Ipv4Cidr::new(Ipv4Address([127, 0, 0, 0]), 8).unwrap(),
+                UdpPortRange::new(Port(1), Port(u16::MAX)).unwrap(),
+            )]
         );
     }
 

--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -143,7 +143,7 @@ fn configured_socket_policy(
     allowed_destinations: &[AllowedTcpDestination],
 ) -> Result<SocketPolicy, SocketPolicyError> {
     if allowed_destinations.is_empty() {
-        return Ok(SocketPolicy::Ipv4LoopbackTcpUdp);
+        return Ok(SocketPolicy::Ipv4Loopback);
     }
     let rules = allowed_destinations
         .iter()
@@ -567,7 +567,7 @@ mod tests {
     fn tcp_destination_arguments_replace_the_loopback_default() {
         assert_eq!(
             configured_socket_policy(&[]).unwrap(),
-            SocketPolicy::Ipv4LoopbackTcpUdp
+            SocketPolicy::Ipv4Loopback
         );
 
         let allowed = "0.0.0.0/0:80".parse::<AllowedTcpDestination>().unwrap();

--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -18,9 +18,8 @@ use std::time::{Duration, Instant};
 
 use clap::Parser;
 use litebox_broker_core::{
-    BrokerCore, BrokerCoreLimits, CallerCredential, Ipv4Cidr, ObjectRights, PolicyEngine,
-    SocketPolicy, SocketPolicyError, TcpDestinationRule, TcpPortRange, UdpDestinationRule,
-    UdpPortRange,
+    BrokerCore, BrokerCoreLimits, CallerCredential, DestinationPortRange, Ipv4Cidr, ObjectRights,
+    PolicyEngine, SocketPolicy, SocketPolicyError, TcpDestinationRule, UdpDestinationRule,
 };
 use litebox_broker_host::{BrokerHostAssociation, ConnectionTermination, setup_connection};
 use litebox_broker_platform_linux_userland::LinuxSocketProvider;
@@ -46,7 +45,7 @@ const WORKER_COUNT: usize = 8;
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct AllowedTcpDestination {
     destination: Ipv4Cidr,
-    ports: TcpPortRange,
+    ports: DestinationPortRange,
 }
 
 impl FromStr for AllowedTcpDestination {
@@ -79,7 +78,7 @@ impl FromStr for AllowedTcpDestination {
         let end = end
             .parse::<u16>()
             .map_err(|error| format!("invalid TCP port: {error}"))?;
-        let ports = TcpPortRange::new(Port(start), Port(end))
+        let ports = DestinationPortRange::new(Port(start), Port(end))
             .ok_or_else(|| "TCP port range must be ordered and exclude port zero".to_owned())?;
 
         Ok(Self { destination, ports })
@@ -159,7 +158,7 @@ fn configured_socket_policy(
     let udp_loopback = UdpDestinationRule::new(
         CallerCredential::HostGuaranteed,
         Ipv4Cidr::new(Ipv4Address([127, 0, 0, 0]), 8).expect("the IPv4 loopback CIDR is canonical"),
-        UdpPortRange::new(Port(1), Port(u16::MAX))
+        DestinationPortRange::new(Port(1), Port(u16::MAX))
             .expect("the full nonzero UDP port range is valid"),
     );
     SocketPolicy::from_tcp_udp_destination_rules(&rules, &[udp_loopback])
@@ -553,7 +552,7 @@ mod tests {
             allowed,
             AllowedTcpDestination {
                 destination: Ipv4Cidr::new(Ipv4Address([203, 0, 113, 0]), 24).unwrap(),
-                ports: TcpPortRange::new(Port(443), Port(444)).unwrap(),
+                ports: DestinationPortRange::new(Port(443), Port(444)).unwrap(),
             }
         );
         assert!(
@@ -588,7 +587,7 @@ mod tests {
             &[UdpDestinationRule::new(
                 CallerCredential::HostGuaranteed,
                 Ipv4Cidr::new(Ipv4Address([127, 0, 0, 0]), 8).unwrap(),
-                UdpPortRange::new(Port(1), Port(u16::MAX)).unwrap(),
+                DestinationPortRange::new(Port(1), Port(u16::MAX)).unwrap(),
             )]
         );
     }

--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -18,8 +18,8 @@ use std::time::{Duration, Instant};
 
 use clap::Parser;
 use litebox_broker_core::{
-    BrokerCore, BrokerCoreLimits, CallerCredential, DestinationPortRange, Ipv4Cidr, ObjectRights,
-    PolicyEngine, SocketPolicy, SocketPolicyError, TcpDestinationRule, UdpDestinationRule,
+    BrokerCore, BrokerCoreLimits, CallerCredential, DestinationPortRange, DestinationRule,
+    Ipv4Cidr, ObjectRights, PolicyEngine, SocketPolicy, SocketPolicyError,
 };
 use litebox_broker_host::{BrokerHostAssociation, ConnectionTermination, setup_connection};
 use litebox_broker_platform_linux_userland::LinuxSocketProvider;
@@ -148,14 +148,14 @@ fn configured_socket_policy(
     let rules = allowed_destinations
         .iter()
         .map(|allowed| {
-            TcpDestinationRule::new(
+            DestinationRule::new(
                 CallerCredential::HostGuaranteed,
                 allowed.destination,
                 allowed.ports,
             )
         })
         .collect::<Vec<_>>();
-    let udp_loopback = UdpDestinationRule::new(
+    let udp_loopback = DestinationRule::new(
         CallerCredential::HostGuaranteed,
         Ipv4Cidr::new(Ipv4Address([127, 0, 0, 0]), 8).expect("the IPv4 loopback CIDR is canonical"),
         DestinationPortRange::new(Port(1), Port(u16::MAX))
@@ -576,7 +576,7 @@ mod tests {
         assert_eq!(rules.len(), 1);
         assert_eq!(
             rules[0],
-            TcpDestinationRule::new(
+            DestinationRule::new(
                 CallerCredential::HostGuaranteed,
                 allowed.destination,
                 allowed.ports,
@@ -584,7 +584,7 @@ mod tests {
         );
         assert_eq!(
             policy.udp_destination_rules().unwrap(),
-            &[UdpDestinationRule::new(
+            &[DestinationRule::new(
                 CallerCredential::HostGuaranteed,
                 Ipv4Cidr::new(Ipv4Address([127, 0, 0, 0]), 8).unwrap(),
                 DestinationPortRange::new(Port(1), Port(u16::MAX)).unwrap(),

--- a/litebox_runner_linux_userland/tests/run.rs
+++ b/litebox_runner_linux_userland/tests/run.rs
@@ -639,7 +639,7 @@ fn test_runner_broker_tcp_client_with_rewriter() {
         litebox_broker_core::PolicyEngine::with_host_guaranteed_rights(
             litebox_broker_core::ObjectRights::all(),
         )
-        .with_socket_policy(litebox_broker_core::SocketPolicy::Ipv4LoopbackTcp),
+        .with_socket_policy(litebox_broker_core::SocketPolicy::Ipv4Loopback),
         1,
     );
     Runner::new(&target, "broker_tcp_client_rewriter")
@@ -671,7 +671,7 @@ fn test_runner_broker_tcp_server_with_rewriter() {
         litebox_broker_core::PolicyEngine::with_host_guaranteed_rights(
             litebox_broker_core::ObjectRights::all(),
         )
-        .with_socket_policy(litebox_broker_core::SocketPolicy::Ipv4LoopbackTcp),
+        .with_socket_policy(litebox_broker_core::SocketPolicy::Ipv4Loopback),
         1,
     );
     let mut child = Runner::new(&target, "broker_tcp_server_rewriter")


### PR DESCRIPTION
This PR adds guest-neutral broker IPv4 UDP support across the protocol and wire codec, bounded destination policy, broker core, host and local adapters, Linux epoll reactor, and production loopback configuration, covering atomic datagram sends and receives, connected and explicit destinations, source and truncation metadata, zero-length and maximum-size datagrams, reconnect-safe state, readiness, asynchronous errors, and directional shutdown; guest syscall integration remains deferred to the following PR.