### PR TITLE
Add brokered IPv4 UDP guest support

### DIFF
--- a/litebox/src/broker/mod.rs
+++ b/litebox/src/broker/mod.rs
@@ -15,9 +15,10 @@ use litebox_broker_protocol::event::{ConsumeEventResponse, EventConsumeMode};
 use litebox_broker_protocol::pipe::{CreatePipeResponse, MAX_PIPE_TRANSFER_SIZE};
 use litebox_broker_protocol::readiness::ReadinessFlags;
 use litebox_broker_protocol::socket::{
-    AcceptSocketResponse, MAX_SOCKET_TRANSFER_SIZE, ReceiveFlags as BrokerReceiveFlags,
-    ReceiveSocketResponse, SendFlags as BrokerSendFlags, ShutdownMode, SocketConnectionStatus,
-    SocketOutcome, SocketStatusResponse,
+    AcceptSocketResponse, MAX_SOCKET_TRANSFER_SIZE, MAX_UDP_DATAGRAM_SIZE,
+    ReceiveFlags as BrokerReceiveFlags, ReceiveFromFlags as BrokerReceiveFromFlags,
+    ReceiveFromSocketResponse, ReceiveSocketResponse, SendFlags as BrokerSendFlags, ShutdownMode,
+    SocketConnectionStatus, SocketOutcome, SocketStatusResponse,
 };
 use litebox_broker_transport::channel::LocalCallChannel;
 
@@ -41,6 +42,8 @@ use shared_buffer::{SlotAllocator, SlotLease};
 /// once the local-core wait and notification model supports that shape.
 pub(crate) trait BrokerControl: Send + Sync {
     fn create_tcp_socket(&self) -> core::result::Result<ObjectHandle, BrokerControlError>;
+
+    fn create_udp_socket(&self) -> core::result::Result<ObjectHandle, BrokerControlError>;
 
     fn connect_socket(
         &self,
@@ -86,6 +89,21 @@ pub(crate) trait BrokerControl: Send + Sync {
         peek_length: u32,
         discard: bool,
     ) -> core::result::Result<SocketOutcome<ReceiveSocketResponse>, BrokerControlError>;
+
+    fn send_to_socket(
+        &self,
+        handle: ObjectHandle,
+        data: &[u8],
+        flags: BrokerSendFlags,
+        destination: Option<SocketAddrV4>,
+    ) -> core::result::Result<SocketOutcome<usize>, BrokerControlError>;
+
+    fn receive_from_socket(
+        &self,
+        handle: ObjectHandle,
+        data: &mut [u8],
+        flags: BrokerReceiveFromFlags,
+    ) -> core::result::Result<SocketOutcome<ReceiveFromSocketResponse>, BrokerControlError>;
 
     fn shutdown_socket(
         &self,
@@ -274,6 +292,10 @@ where
         self.request(BrokerLocal::create_tcp_socket)
     }
 
+    fn create_udp_socket(&self) -> core::result::Result<ObjectHandle, BrokerControlError> {
+        self.request(BrokerLocal::create_udp_socket)
+    }
+
     fn connect_socket(
         &self,
         handle: ObjectHandle,
@@ -379,6 +401,47 @@ where
             Ok(received) => SocketOutcome::Completed(received),
             Err(error) => SocketOutcome::Failed(error),
         })
+    }
+
+    fn send_to_socket(
+        &self,
+        handle: ObjectHandle,
+        data: &[u8],
+        flags: BrokerSendFlags,
+        destination: Option<SocketAddrV4>,
+    ) -> core::result::Result<SocketOutcome<usize>, BrokerControlError> {
+        if data.len() > MAX_UDP_DATAGRAM_SIZE as usize {
+            return Err(BrokerControlError::Broker(ErrorCode::ResourceExhausted));
+        }
+        let length =
+            u32::try_from(data.len()).expect("validated UDP datagram length must fit in u32");
+        let lease = self.acquire_shared_buffer(length)?;
+        self.request(|local| {
+            local.send_to_socket(handle, lease.descriptor(), data, flags, destination)
+        })
+        .map(|result| match result {
+            Ok(sent) => SocketOutcome::Completed(sent),
+            Err(error) => SocketOutcome::Failed(error),
+        })
+    }
+
+    fn receive_from_socket(
+        &self,
+        handle: ObjectHandle,
+        data: &mut [u8],
+        flags: BrokerReceiveFromFlags,
+    ) -> core::result::Result<SocketOutcome<ReceiveFromSocketResponse>, BrokerControlError> {
+        if data.len() > MAX_UDP_DATAGRAM_SIZE as usize {
+            return Err(BrokerControlError::Broker(ErrorCode::ResourceExhausted));
+        }
+        let length =
+            u32::try_from(data.len()).expect("validated UDP receive length must fit in u32");
+        let lease = self.acquire_shared_buffer(length)?;
+        self.request(|local| local.receive_from_socket(handle, lease.descriptor(), data, flags))
+            .map(|result| match result {
+                Ok(received) => SocketOutcome::Completed(received),
+                Err(error) => SocketOutcome::Failed(error),
+            })
     }
 
     fn shutdown_socket(

--- a/litebox/src/net/broker_socket.rs
+++ b/litebox/src/net/broker_socket.rs
@@ -525,6 +525,20 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
                 .notify_observers(Events::IN | Events::OUT | Events::HUP);
         }
     }
+
+    pub(super) fn close(&self, abortive: bool) {
+        if self.closed.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        self.pollable_registry.unregister_pollable(self.handle);
+        if abortive {
+            let _ = self
+                .broker
+                .shutdown_socket(self.handle, ShutdownMode::Abort);
+        }
+        let _ = self.broker.close_object(self.handle);
+        self.pollee.notify_observers(Events::OUT | Events::HUP);
+    }
 }
 
 impl<Platform: RawSyncPrimitivesProvider + TimeProvider> IOPollable for BrokerTcpSocket<Platform> {
@@ -568,22 +582,6 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> IOPollable for BrokerTc
             events.insert(Events::OUT);
         }
         events
-    }
-}
-
-impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platform> {
-    pub(super) fn close(&self, abortive: bool) {
-        if self.closed.swap(true, Ordering::AcqRel) {
-            return;
-        }
-        self.pollable_registry.unregister_pollable(self.handle);
-        if abortive {
-            let _ = self
-                .broker
-                .shutdown_socket(self.handle, ShutdownMode::Abort);
-        }
-        let _ = self.broker.close_object(self.handle);
-        self.pollee.notify_observers(Events::OUT | Events::HUP);
     }
 }
 
@@ -1014,6 +1012,15 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerUdpSocket<Platfor
             state.async_error = SocketAsyncError::from(error) as u32;
         }
     }
+
+    pub(super) fn close(&self) {
+        if self.closed.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        self.pollable_registry.unregister_pollable(self.handle);
+        let _ = self.broker.close_object(self.handle);
+        self.pollee.notify_observers(Events::OUT | Events::HUP);
+    }
 }
 
 impl<Platform: RawSyncPrimitivesProvider + TimeProvider> IOPollable for BrokerUdpSocket<Platform> {
@@ -1046,17 +1053,6 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> IOPollable for BrokerUd
             events.insert(Events::HUP);
         }
         events
-    }
-}
-
-impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerUdpSocket<Platform> {
-    pub(super) fn close(&self) {
-        if self.closed.swap(true, Ordering::AcqRel) {
-            return;
-        }
-        self.pollable_registry.unregister_pollable(self.handle);
-        let _ = self.broker.close_object(self.handle);
-        self.pollee.notify_observers(Events::OUT | Events::HUP);
     }
 }
 

--- a/litebox/src/net/broker_socket.rs
+++ b/litebox/src/net/broker_socket.rs
@@ -31,7 +31,7 @@ use crate::{
 
 const _: () = assert!(MAX_SOCKET_PEEK_SIZE as usize == super::SOCKET_RECEIVE_OPERATION_SIZE);
 
-struct BrokerSocketState {
+struct BrokerTcpSocketState {
     connection: SocketConnectionStatus,
     local_address: Option<SocketAddrV4>,
     remote_address: Option<SocketAddrV4>,
@@ -39,7 +39,7 @@ struct BrokerSocketState {
     listening: bool,
 }
 
-impl BrokerSocketState {
+impl BrokerTcpSocketState {
     fn update_connection(&mut self, connection: SocketConnectionStatus) -> SocketConnectionStatus {
         if matches!(
             self.connection,
@@ -59,7 +59,7 @@ pub struct BrokerTcpSocket<Platform: RawSyncPrimitivesProvider + TimeProvider> {
     pollable_registry: Arc<BrokerPollableRegistry<Platform>>,
     pollee: Arc<Pollee<Platform>>,
     receive_lock: Mutex<Platform, ()>,
-    state: Mutex<Platform, BrokerSocketState>,
+    state: Mutex<Platform, BrokerTcpSocketState>,
     write_shutdown: AtomicBool,
     closed: AtomicBool,
 }
@@ -78,7 +78,7 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
             pollable_registry,
             pollee: Arc::new(Pollee::new()),
             receive_lock: Mutex::new(()),
-            state: Mutex::new(BrokerSocketState {
+            state: Mutex::new(BrokerTcpSocketState {
                 connection: SocketConnectionStatus::Unconnected,
                 local_address: None,
                 remote_address: None,
@@ -105,7 +105,7 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
             pollable_registry,
             pollee: Arc::new(Pollee::new()),
             receive_lock: Mutex::new(()),
-            state: Mutex::new(BrokerSocketState {
+            state: Mutex::new(BrokerTcpSocketState {
                 connection: SocketConnectionStatus::Connected,
                 local_address: Some(accepted.local_address),
                 remote_address: Some(accepted.remote_address),

--- a/litebox/src/net/broker_socket.rs
+++ b/litebox/src/net/broker_socket.rs
@@ -9,10 +9,10 @@ use core::{
 
 use litebox_broker_protocol::ObjectHandle;
 use litebox_broker_protocol::socket::{
-    AcceptSocketResponse, MAX_SOCKET_PEEK_SIZE, MAX_SOCKET_TRANSFER_SIZE,
-    ReceiveFlags as BrokerReceiveFlags, ReceiveSocketResponse, SendFlags as BrokerSendFlags,
-    ShutdownMode, SocketConnectionStatus, SocketError as BrokerSocketError, SocketOutcome,
-    SocketStatusResponse,
+    AcceptSocketResponse, MAX_SOCKET_PEEK_SIZE, MAX_SOCKET_TRANSFER_SIZE, MAX_UDP_DATAGRAM_SIZE,
+    ReceiveFlags as BrokerReceiveFlags, ReceiveFromFlags as BrokerReceiveFromFlags,
+    ReceiveFromSocketResponse, ReceiveSocketResponse, SendFlags as BrokerSendFlags, ShutdownMode,
+    SocketConnectionStatus, SocketError as BrokerSocketError, SocketOutcome, SocketStatusResponse,
 };
 
 use super::{
@@ -587,6 +587,479 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
     }
 }
 
+struct BrokerUdpSocketState {
+    connection: SocketConnectionStatus,
+    local_address: Option<SocketAddrV4>,
+    remote_address: Option<SocketAddrV4>,
+    async_error: u32,
+    next_async_error: u32,
+}
+
+impl BrokerUdpSocketState {
+    fn prepend_async_error(&mut self, error: SocketAsyncError) {
+        if self.async_error != 0 {
+            self.next_async_error = self.async_error;
+        }
+        self.async_error = error as u32;
+    }
+
+    fn take_async_error(&mut self) -> u32 {
+        let error = self.async_error;
+        self.async_error = self.next_async_error;
+        self.next_async_error = 0;
+        error
+    }
+}
+
+/// Local state and readiness adapter for one broker-owned UDP socket.
+pub struct BrokerUdpSocket<Platform: RawSyncPrimitivesProvider + TimeProvider> {
+    broker: Arc<dyn BrokerControl>,
+    handle: ObjectHandle,
+    pollable_registry: Arc<BrokerPollableRegistry<Platform>>,
+    pollee: Arc<Pollee<Platform>>,
+    configuration_lock: Mutex<Platform, ()>,
+    receive_lock: Mutex<Platform, ()>,
+    send_lock: Mutex<Platform, ()>,
+    state: Mutex<Platform, BrokerUdpSocketState>,
+    read_shutdown: AtomicBool,
+    write_shutdown: AtomicBool,
+    closed: AtomicBool,
+}
+
+impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerUdpSocket<Platform> {
+    pub(super) fn new(
+        broker: Arc<dyn BrokerControl>,
+        pollable_registry: Arc<BrokerPollableRegistry<Platform>>,
+    ) -> Result<Arc<Self>, BrokerObjectError> {
+        let handle = broker
+            .create_udp_socket()
+            .map_err(BrokerObjectError::from)?;
+        let socket = Arc::new(Self {
+            broker,
+            handle,
+            pollable_registry,
+            pollee: Arc::new(Pollee::new()),
+            configuration_lock: Mutex::new(()),
+            receive_lock: Mutex::new(()),
+            send_lock: Mutex::new(()),
+            state: Mutex::new(BrokerUdpSocketState {
+                connection: SocketConnectionStatus::Unconnected,
+                local_address: None,
+                remote_address: None,
+                async_error: 0,
+                next_async_error: 0,
+            }),
+            read_shutdown: AtomicBool::new(false),
+            write_shutdown: AtomicBool::new(false),
+            closed: AtomicBool::new(false),
+        });
+        socket
+            .pollable_registry
+            .register_pollable(handle, &socket.pollee);
+        Ok(socket)
+    }
+
+    pub(super) fn bind(&self, address: SocketAddrV4) -> Result<(), BindError> {
+        let _configuration = self.configuration_lock.lock();
+        self.refresh_status_locked();
+        if self.state.lock().local_address.is_some() {
+            return Err(BindError::AlreadyBound);
+        }
+        let outcome = self
+            .broker
+            .bind_socket(self.handle, address)
+            .map_err(|error| BindError::OperationFailed(BrokerObjectError::from(error).into()))?;
+        match outcome {
+            SocketOutcome::Completed(local_address) => {
+                self.state.lock().local_address = Some(local_address);
+                Ok(())
+            }
+            SocketOutcome::Failed(error) => {
+                Err(BindError::OperationFailed(SocketAsyncError::from(error)))
+            }
+        }
+    }
+
+    pub(super) fn start_connect(&self, address: SocketAddrV4) -> Result<(), ConnectError> {
+        let _configuration = self.configuration_lock.lock();
+        let outcome = self
+            .broker
+            .connect_socket(self.handle, address)
+            .map_err(|error| {
+                ConnectError::OperationFailed(BrokerObjectError::from(error).into())
+            })?;
+        match outcome {
+            SocketOutcome::Completed(SocketConnectionStatus::Connected) => {
+                let mut state = self.state.lock();
+                state.connection = SocketConnectionStatus::Connected;
+                state.remote_address = Some(address);
+                Ok(())
+            }
+            SocketOutcome::Completed(_) => Err(ConnectError::OperationFailed(
+                SocketAsyncError::BackendFailure,
+            )),
+            SocketOutcome::Failed(error) => {
+                Err(ConnectError::OperationFailed(SocketAsyncError::from(error)))
+            }
+        }
+    }
+
+    pub(super) fn check_connect_progress(&self) -> Result<(), ConnectError> {
+        self.refresh_status();
+        match self.state.lock().connection {
+            SocketConnectionStatus::Connected => Ok(()),
+            SocketConnectionStatus::Failed(error) => {
+                Err(ConnectError::OperationFailed(SocketAsyncError::from(error)))
+            }
+            _ => Err(ConnectError::InvalidState),
+        }
+    }
+
+    pub(super) fn local_addr(&self) -> SocketAddr {
+        self.refresh_status();
+        self.state.lock().local_address.map_or_else(
+            || SocketAddr::V4(SocketAddrV4::new(core::net::Ipv4Addr::UNSPECIFIED, 0)),
+            SocketAddr::V4,
+        )
+    }
+
+    pub(super) fn remote_addr(&self) -> Result<SocketAddr, RemoteAddrError> {
+        self.refresh_status();
+        let state = self.state.lock();
+        if state.connection != SocketConnectionStatus::Connected {
+            return Err(RemoteAddrError::NotConnected);
+        }
+        state
+            .remote_address
+            .map(SocketAddr::V4)
+            .ok_or(RemoteAddrError::NotConnected)
+    }
+
+    pub(super) fn shutdown(&self, mode: ShutdownMode) -> Result<(), SocketAsyncError> {
+        let _configuration = self.configuration_lock.lock();
+        let _receive = matches!(mode, ShutdownMode::Read | ShutdownMode::Both)
+            .then(|| self.receive_lock.lock());
+        let _send =
+            matches!(mode, ShutdownMode::Write | ShutdownMode::Both).then(|| self.send_lock.lock());
+        let connected = self.state.lock().connection == SocketConnectionStatus::Connected;
+        match self
+            .broker
+            .shutdown_socket(self.handle, mode)
+            .map_err(|error| SocketAsyncError::from(BrokerObjectError::from(error)))?
+        {
+            SocketOutcome::Completed(()) => {
+                let mut events = Events::empty();
+                if matches!(mode, ShutdownMode::Read | ShutdownMode::Both) {
+                    self.read_shutdown.store(true, Ordering::Release);
+                    events.insert(Events::IN | Events::RDHUP);
+                }
+                if matches!(mode, ShutdownMode::Write | ShutdownMode::Both) {
+                    self.write_shutdown.store(true, Ordering::Release);
+                    events.insert(Events::OUT);
+                }
+                if self.read_shutdown.load(Ordering::Acquire)
+                    && self.write_shutdown.load(Ordering::Acquire)
+                {
+                    events.insert(Events::HUP);
+                }
+                self.pollee.notify_observers(events);
+                if connected {
+                    Ok(())
+                } else {
+                    Err(SocketAsyncError::NotConnected)
+                }
+            }
+            SocketOutcome::Failed(error) => Err(error.into()),
+        }
+    }
+
+    pub(super) fn set_state(&self, state: SocketState) {
+        if state == SocketState::Closed {
+            self.close();
+            return;
+        }
+        if self.closed.load(Ordering::Acquire) {
+            return;
+        }
+        match state {
+            SocketState::Initial => {
+                self.state.lock().connection = SocketConnectionStatus::Unconnected;
+            }
+            SocketState::Connected => {
+                self.state.lock().connection = SocketConnectionStatus::Connected;
+            }
+            SocketState::Connecting
+            | SocketState::Listening
+            | SocketState::Error
+            | SocketState::Closed => {}
+        }
+    }
+
+    pub(super) fn set_async_error(&self, error: SocketAsyncError) {
+        if self.closed.load(Ordering::Acquire) {
+            return;
+        }
+        let configuration = self.configuration_lock.lock();
+        self.state.lock().prepend_async_error(error);
+        drop(configuration);
+        self.pollee.notify_observers(Events::ERR);
+    }
+
+    pub(super) fn get_async_error(&self, clear: bool) -> Option<SocketAsyncError> {
+        if self.closed.load(Ordering::Acquire) {
+            return None;
+        }
+        let configuration = self.configuration_lock.lock();
+        self.refresh_status_locked();
+        let mut state = self.state.lock();
+        let raw = state.async_error;
+        if clear {
+            state.take_async_error();
+        }
+        drop(state);
+        if clear && raw != 0 {
+            if self.state.lock().async_error == 0 {
+                self.refresh_status_locked();
+            }
+            drop(configuration);
+            self.pollee.wake_observers();
+        }
+        SocketAsyncError::from_u32(raw)
+    }
+
+    fn take_async_error(&self) -> Option<SocketAsyncError> {
+        let configuration = self.configuration_lock.lock();
+        let mut state = self.state.lock();
+        let raw = state.take_async_error();
+        let needs_refill = raw != 0 && state.async_error == 0;
+        drop(state);
+        if raw != 0 {
+            if needs_refill {
+                self.refresh_status_locked();
+            }
+            drop(configuration);
+            self.pollee.wake_observers();
+        }
+        SocketAsyncError::from_u32(raw)
+    }
+
+    pub(super) fn try_read(
+        &self,
+        buffer: &mut [u8],
+        flags: ReceiveFlags,
+        mut source_address: Option<&mut Option<SocketAddr>>,
+    ) -> Result<usize, ChannelReadError> {
+        if self.closed.load(Ordering::Acquire) {
+            return Err(ChannelReadError::ConnectionClosed);
+        }
+        if let Some(error) = self.take_async_error() {
+            return Err(ChannelReadError::Socket(error));
+        }
+        if self.read_shutdown.load(Ordering::Acquire) {
+            return Err(ChannelReadError::ReadShutdown);
+        }
+        if let Some(source_address) = &mut source_address {
+            **source_address = None;
+        }
+        let receive = self.receive_lock.lock();
+        if self.read_shutdown.load(Ordering::Acquire) {
+            return Err(ChannelReadError::ReadShutdown);
+        }
+        let mut broker_flags = BrokerReceiveFromFlags::NONE;
+        if flags.contains(ReceiveFlags::PEEK) {
+            broker_flags.0 |= BrokerReceiveFromFlags::PEEK.0;
+        }
+        let target_length = if flags.contains(ReceiveFlags::DISCARD) {
+            0
+        } else {
+            buffer.len().min(MAX_UDP_DATAGRAM_SIZE as usize)
+        };
+        let outcome = self.broker.receive_from_socket(
+            self.handle,
+            &mut buffer[..target_length],
+            broker_flags,
+        );
+        drop(receive);
+        let outcome = match outcome {
+            Ok(outcome) => outcome,
+            Err(error) => {
+                if self.closed.load(Ordering::Acquire) {
+                    return Err(ChannelReadError::ConnectionClosed);
+                }
+                let error = BrokerObjectError::from(error);
+                if error == BrokerObjectError::WouldBlock
+                    && let Some(error) = self.take_async_error()
+                {
+                    return Err(ChannelReadError::Socket(error));
+                }
+                return Err(ChannelReadError::from(error));
+            }
+        };
+        match outcome {
+            SocketOutcome::Completed(ReceiveFromSocketResponse {
+                received,
+                datagram_length,
+                source_address: response_source_address,
+            }) => {
+                if let Some(source_address) = source_address {
+                    *source_address = Some(SocketAddr::V4(response_source_address));
+                }
+                let received = usize::try_from(received)
+                    .map_err(|_| ChannelReadError::Socket(SocketAsyncError::BackendFailure))?;
+                let datagram_length = usize::try_from(datagram_length)
+                    .map_err(|_| ChannelReadError::Socket(SocketAsyncError::BackendFailure))?;
+                debug_assert!(received <= target_length);
+                Ok(datagram_length)
+            }
+            SocketOutcome::Failed(BrokerSocketError::NotConnected)
+                if self.read_shutdown.load(Ordering::Acquire) =>
+            {
+                Err(ChannelReadError::ReadShutdown)
+            }
+            SocketOutcome::Failed(error) => {
+                self.refresh_status();
+                Err(ChannelReadError::Socket(error.into()))
+            }
+        }
+    }
+
+    pub(super) fn try_write(
+        &self,
+        buffer: &[u8],
+        destination: Option<SocketAddr>,
+    ) -> Result<usize, ChannelWriteError> {
+        if self.closed.load(Ordering::Acquire) {
+            return Err(ChannelWriteError::ConnectionClosed);
+        }
+        if let Some(error) = self.take_async_error() {
+            return Err(ChannelWriteError::Socket(error));
+        }
+        if self.write_shutdown.load(Ordering::Acquire) {
+            return Err(ChannelWriteError::WriteShutdown);
+        }
+        let send_operation = self.send_lock.lock();
+        if self.write_shutdown.load(Ordering::Acquire) {
+            return Err(ChannelWriteError::WriteShutdown);
+        }
+        if buffer.len() > MAX_UDP_DATAGRAM_SIZE as usize {
+            return Err(ChannelWriteError::MessageTooLong);
+        }
+        let destination = match destination {
+            Some(SocketAddr::V4(address)) => Some(address),
+            Some(SocketAddr::V6(_)) => return Err(ChannelWriteError::Unaddressable),
+            None => None,
+        };
+        if destination.is_none()
+            && self.state.lock().connection != SocketConnectionStatus::Connected
+        {
+            return Err(ChannelWriteError::DestinationAddressRequired);
+        }
+        let outcome =
+            self.broker
+                .send_to_socket(self.handle, buffer, BrokerSendFlags::NONE, destination);
+        drop(send_operation);
+        let outcome = match outcome {
+            Ok(outcome) => outcome,
+            Err(error) => {
+                if self.closed.load(Ordering::Acquire) {
+                    return Err(ChannelWriteError::ConnectionClosed);
+                }
+                let error = BrokerObjectError::from(error);
+                if error == BrokerObjectError::WouldBlock
+                    && let Some(error) = self.take_async_error()
+                {
+                    return Err(ChannelWriteError::Socket(error));
+                }
+                return Err(ChannelWriteError::from(error));
+            }
+        };
+        match outcome {
+            SocketOutcome::Completed(sent) => Ok(sent),
+            SocketOutcome::Failed(error) => {
+                self.refresh_status();
+                Err(ChannelWriteError::Socket(error.into()))
+            }
+        }
+    }
+
+    fn refresh_status(&self) {
+        let _configuration = self.configuration_lock.lock();
+        self.refresh_status_locked();
+    }
+
+    fn refresh_status_locked(&self) {
+        if self.closed.load(Ordering::Acquire) || self.state.lock().async_error != 0 {
+            return;
+        }
+        match self.broker.socket_status(self.handle) {
+            Ok(response) => self.apply_socket_status(response),
+            Err(error) if !self.closed.load(Ordering::Acquire) => {
+                self.state
+                    .lock()
+                    .prepend_async_error(BrokerObjectError::from(error).into());
+            }
+            Err(_) => {}
+        }
+    }
+
+    fn apply_socket_status(&self, response: SocketStatusResponse) {
+        let mut state = self.state.lock();
+        state.connection = response.status;
+        if let Some(address) = response.local_address {
+            state.local_address = Some(address);
+        }
+        if state.async_error == 0
+            && let Some(error) = response.pending_error
+        {
+            state.async_error = SocketAsyncError::from(error) as u32;
+        }
+    }
+}
+
+impl<Platform: RawSyncPrimitivesProvider + TimeProvider> IOPollable for BrokerUdpSocket<Platform> {
+    fn register_observer(&self, observer: Weak<dyn Observer<Events>>, filter: Events) {
+        self.pollee.register_observer(observer, filter);
+    }
+
+    fn check_io_events(&self) -> Events {
+        if self.closed.load(Ordering::Acquire) {
+            return Events::OUT | Events::HUP;
+        }
+        let mut events = match self.broker.check_readiness(self.handle) {
+            Ok(readiness) => socket_readiness_events(readiness),
+            Err(_) => Events::ERR,
+        };
+        if events.contains(Events::ERR) && self.state.lock().async_error == 0 {
+            self.refresh_status();
+        }
+        if self.state.lock().async_error != 0 {
+            events.insert(Events::ERR);
+        }
+        if self.read_shutdown.load(Ordering::Acquire) {
+            events.insert(Events::IN | Events::RDHUP);
+        }
+        if self.write_shutdown.load(Ordering::Acquire) {
+            events.insert(Events::OUT);
+        }
+        if self.read_shutdown.load(Ordering::Acquire) && self.write_shutdown.load(Ordering::Acquire)
+        {
+            events.insert(Events::HUP);
+        }
+        events
+    }
+}
+
+impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerUdpSocket<Platform> {
+    pub(super) fn close(&self) {
+        if self.closed.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        self.pollable_registry.unregister_pollable(self.handle);
+        let _ = self.broker.close_object(self.handle);
+        self.pollee.notify_observers(Events::OUT | Events::HUP);
+    }
+}
+
 fn socket_readiness_events(
     readiness: litebox_broker_protocol::readiness::ReadinessFlags,
 ) -> Events {
@@ -602,6 +1075,12 @@ fn socket_readiness_events(
 impl<Platform: RawSyncPrimitivesProvider + TimeProvider> Drop for BrokerTcpSocket<Platform> {
     fn drop(&mut self) {
         self.close(false);
+    }
+}
+
+impl<Platform: RawSyncPrimitivesProvider + TimeProvider> Drop for BrokerUdpSocket<Platform> {
+    fn drop(&mut self) {
+        self.close();
     }
 }
 
@@ -657,5 +1136,32 @@ impl From<BrokerSocketError> for SocketAsyncError {
             BrokerSocketError::PolicyDenied => Self::PolicyDenied,
             _ => Self::BackendFailure,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn restored_udp_error_precedes_prefetched_successor() {
+        let mut state = BrokerUdpSocketState {
+            connection: SocketConnectionStatus::Connected,
+            local_address: None,
+            remote_address: None,
+            async_error: SocketAsyncError::NetworkUnreachable as u32,
+            next_async_error: 0,
+        };
+
+        state.prepend_async_error(SocketAsyncError::ConnectionRefused);
+
+        assert_eq!(
+            SocketAsyncError::from_u32(state.take_async_error()),
+            Some(SocketAsyncError::ConnectionRefused)
+        );
+        assert_eq!(
+            SocketAsyncError::from_u32(state.take_async_error()),
+            Some(SocketAsyncError::NetworkUnreachable)
+        );
     }
 }

--- a/litebox/src/net/errors.rs
+++ b/litebox/src/net/errors.rs
@@ -157,6 +157,8 @@ pub enum SendError {
     Unaddressable,
     #[error("Buffer is full")]
     BufferFull,
+    #[error("Datagram is too large")]
+    MessageTooLong,
     #[error("port allocation failed: {0}")]
     PortAllocationFailure(#[from] LocalPortAllocationError),
     #[error("unnecessary destination address provided")]

--- a/litebox/src/net/mod.rs
+++ b/litebox/src/net/mod.rs
@@ -23,7 +23,7 @@ pub mod local_ports;
 mod phy;
 pub mod socket_channel;
 
-pub use broker_socket::BrokerTcpSocket;
+pub use broker_socket::{BrokerTcpSocket, BrokerUdpSocket};
 
 #[cfg(test)]
 mod tests;
@@ -61,6 +61,9 @@ const GATEWAY_IP_ADDR: Ipv4Addr = Ipv4Addr::new(10, 0, 0, 1);
 pub const SOCKET_BUFFER_SIZE: usize = 65536 * 4;
 /// Maximum bytes one socket receive syscall stages before returning.
 pub const SOCKET_RECEIVE_OPERATION_SIZE: usize = 0x80_000;
+/// Maximum payload size of one IPv4 UDP datagram.
+pub const MAX_UDP_DATAGRAM_SIZE: usize =
+    litebox_broker_protocol::socket::MAX_UDP_DATAGRAM_SIZE as usize;
 
 /// Directions of a socket to shut down.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -167,13 +170,27 @@ pub(crate) struct SocketHandle<Platform: RawSyncPrimitivesProvider + TimeProvide
     consider_closed: bool,
     /// The handle into the `socket_set`, absent for broker-owned sockets.
     handle: Option<smoltcp::iface::SocketHandle>,
-    /// Broker-owned TCP state, absent for locally implemented sockets.
-    broker_socket: Option<alloc::sync::Arc<BrokerTcpSocket<Platform>>>,
+    /// Broker-owned socket state, absent for locally implemented sockets.
+    broker_socket: Option<BrokerSocket<Platform>>,
     // Protocol-specific data
     specific: ProtocolSpecific,
     /// The proxy associated with this socket to enable lock-free data transfer
     /// and event notification
     proxy: Option<alloc::sync::Arc<NetworkProxy<Platform>>>,
+}
+
+enum BrokerSocket<Platform: RawSyncPrimitivesProvider + TimeProvider> {
+    Tcp(alloc::sync::Arc<BrokerTcpSocket<Platform>>),
+    Udp(alloc::sync::Arc<BrokerUdpSocket<Platform>>),
+}
+
+impl<Platform: RawSyncPrimitivesProvider + TimeProvider> Clone for BrokerSocket<Platform> {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Tcp(socket) => Self::Tcp(alloc::sync::Arc::clone(socket)),
+            Self::Udp(socket) => Self::Udp(alloc::sync::Arc::clone(socket)),
+        }
+    }
 }
 
 impl<Platform: RawSyncPrimitivesProvider + TimeProvider> SocketHandle<Platform> {
@@ -742,7 +759,12 @@ where
             (Protocol::Icmp | Protocol::Raw { .. }, _) => {
                 unimplemented!()
             }
-            (Protocol::Tcp, NetworkProxy::BrokerStream(_)) => unreachable!(),
+            (
+                Protocol::Tcp | Protocol::Udp,
+                NetworkProxy::BrokerStream(_) | NetworkProxy::BrokerDatagram(_),
+            ) => {
+                unreachable!()
+            }
             _ => panic!("Mismatched protocol and proxy type"),
         }
     }
@@ -776,19 +798,19 @@ where
     /// By default, the created socket has no associated proxy; to set a proxy, use
     /// [`attach_socket_proxy`](Self::attach_socket_proxy).
     pub fn socket(&mut self, protocol: Protocol) -> Result<SocketFd<Platform>, SocketError> {
-        let broker_socket = if matches!(protocol, Protocol::Tcp) {
-            self.litebox
-                .broker_control()
-                .map(|broker| {
-                    BrokerTcpSocket::new(broker, self.litebox.broker_pollable_registry())
-                        .map_err(SocketError::from)
-                })
-                .transpose()?
-        } else {
-            None
+        let broker_socket = match (&protocol, self.litebox.broker_control()) {
+            (Protocol::Tcp, Some(broker)) => Some(BrokerSocket::Tcp(
+                BrokerTcpSocket::new(broker, self.litebox.broker_pollable_registry())
+                    .map_err(SocketError::from)?,
+            )),
+            (Protocol::Udp, Some(broker)) => Some(BrokerSocket::Udp(
+                BrokerUdpSocket::new(broker, self.litebox.broker_pollable_registry())
+                    .map_err(SocketError::from)?,
+            )),
+            _ => None,
         };
         let handle = match protocol {
-            Protocol::Tcp if broker_socket.is_some() => None,
+            Protocol::Tcp | Protocol::Udp if broker_socket.is_some() => None,
             Protocol::Tcp => Some(self.socket_set.add(tcp::Socket::new(
                 smoltcp::storage::RingBuffer::new(vec![0u8; SOCKET_BUFFER_SIZE]),
                 smoltcp::storage::RingBuffer::new(vec![0u8; SOCKET_BUFFER_SIZE]),
@@ -867,7 +889,7 @@ where
     /// Creates and attaches the userspace I/O proxy matching the backend of `fd`.
     ///
     /// Locally implemented sockets receive a channel that transfers data to and from smoltcp.
-    /// Broker-owned TCP sockets instead receive a proxy for their existing broker socket. The
+    /// Broker-owned sockets instead receive a proxy for their existing broker socket. The
     /// returned [`Arc`](alloc::sync::Arc) is the same proxy stored by the network subsystem for
     /// event notification and backend interaction.
     ///
@@ -886,7 +908,14 @@ where
             return Some(alloc::sync::Arc::clone(proxy));
         }
         let proxy = if let Some(socket) = &socket_handle.broker_socket {
-            NetworkProxy::BrokerStream(alloc::sync::Arc::clone(socket))
+            match socket {
+                BrokerSocket::Tcp(socket) => {
+                    NetworkProxy::BrokerStream(alloc::sync::Arc::clone(socket))
+                }
+                BrokerSocket::Udp(socket) => {
+                    NetworkProxy::BrokerDatagram(alloc::sync::Arc::clone(socket))
+                }
+            }
         } else {
             match socket_handle.protocol() {
                 Protocol::Tcp => NetworkProxy::Stream(socket_channel::StreamSocketChannel::new()),
@@ -1003,8 +1032,13 @@ where
             proxy,
         } = socket_handle;
         if let Some(socket) = broker_socket {
-            let abortive = specific.tcp().immediate_close.load(Ordering::SeqCst);
-            socket.close(abortive);
+            match socket {
+                BrokerSocket::Tcp(socket) => {
+                    let abortive = specific.tcp().immediate_close.load(Ordering::SeqCst);
+                    socket.close(abortive);
+                }
+                BrokerSocket::Udp(socket) => socket.close(),
+            }
             return;
         }
         let handle = handle.expect("local socket must have a smoltcp handle");
@@ -1070,7 +1104,7 @@ where
         let now = self.now();
         let ret = match socket_handle.protocol() {
             Protocol::Tcp => {
-                if let Some(socket) = &socket_handle.broker_socket {
+                if let Some(BrokerSocket::Tcp(socket)) = &socket_handle.broker_socket {
                     if check_progress {
                         socket.check_connect_progress()
                     } else {
@@ -1122,21 +1156,30 @@ where
                 }
             }
             Protocol::Udp => {
-                if addr.port() == 0 {
-                    return Err(ConnectError::Unaddressable);
+                if let Some(BrokerSocket::Udp(socket)) = &socket_handle.broker_socket {
+                    if check_progress {
+                        socket.check_connect_progress()
+                    } else {
+                        socket.start_connect(*addr)
+                    }
+                } else {
+                    if addr.port() == 0 {
+                        return Err(ConnectError::Unaddressable);
+                    }
+                    let socket: &mut udp::Socket =
+                        self.socket_set.get_mut(socket_handle.smoltcp_handle());
+                    if !socket.is_open() {
+                        let local_port = self.local_port_allocator.ephemeral_port()?;
+                        let local_endpoint: smoltcp::wire::IpListenEndpoint =
+                            local_port.port().into();
+                        let Ok(()) = socket.bind(local_endpoint) else {
+                            unreachable!("binding to a free port cannot fail")
+                        };
+                    }
+                    let addr: smoltcp::wire::IpEndpoint = (*addr).into();
+                    socket_handle.udp_mut().remote_endpoint = Some(addr);
+                    Ok(())
                 }
-                let socket: &mut udp::Socket =
-                    self.socket_set.get_mut(socket_handle.smoltcp_handle());
-                if !socket.is_open() {
-                    let local_port = self.local_port_allocator.ephemeral_port()?;
-                    let local_endpoint: smoltcp::wire::IpListenEndpoint = local_port.port().into();
-                    let Ok(()) = socket.bind(local_endpoint) else {
-                        unreachable!("binding to a free port cannot fail")
-                    };
-                }
-                let addr: smoltcp::wire::IpEndpoint = (*addr).into();
-                socket_handle.udp_mut().remote_endpoint = Some(addr);
-                Ok(())
             }
             Protocol::Icmp => unimplemented!(),
             Protocol::Raw { protocol: _ } => unimplemented!(),
@@ -1149,10 +1192,9 @@ where
                 Err(ConnectError::InProgress) => {
                     proxy.set_state(socket_channel::SocketState::Connecting);
                 }
-                Err(ConnectError::Unaddressable) => {
-                    proxy.set_async_error(errors::SocketAsyncError::ConnectionRefused);
-                }
-                Err(ConnectError::InvalidState) => {
+                Err(ConnectError::InvalidState)
+                    if matches!(socket_handle.protocol(), Protocol::Tcp) =>
+                {
                     // Distinguish timeout from RST using elapsed time
                     match socket_handle.tcp().connect_initiated_at_us {
                         Some(initiated_at) if now - initiated_at >= TCP_CONNECT_TIMEOUT => {
@@ -1161,6 +1203,9 @@ where
                         }
                         _ => proxy.set_async_error(errors::SocketAsyncError::ConnectionRefused),
                     }
+                }
+                Err(ConnectError::Unaddressable | ConnectError::InvalidState) => {
+                    proxy.set_async_error(errors::SocketAsyncError::ConnectionRefused);
                 }
                 Err(_) => {}
             }
@@ -1180,11 +1225,15 @@ where
             .ok_or(LocalAddrError::InvalidFd)?;
         let socket_handle = &mut table_entry.entry;
 
+        if let Some(socket) = &socket_handle.broker_socket {
+            return Ok(match socket {
+                BrokerSocket::Tcp(socket) => socket.local_addr(),
+                BrokerSocket::Udp(socket) => socket.local_addr(),
+            });
+        }
+
         match socket_handle.protocol() {
             Protocol::Tcp => {
-                if let Some(socket) = &socket_handle.broker_socket {
-                    return Ok(socket.local_addr());
-                }
                 let socket: &tcp::Socket = self.socket_set.get(socket_handle.smoltcp_handle());
                 match socket.local_endpoint() {
                     Some(endpoint) => match endpoint.addr {
@@ -1238,17 +1287,21 @@ where
             .broker_socket
             .as_ref()
             .ok_or(errors::ShutdownError::UnsupportedOperation)?;
-        if socket.is_listening() {
-            return Err(errors::ShutdownError::Listening);
-        }
         let mode = match direction {
             ShutdownDirection::Read => litebox_broker_protocol::socket::ShutdownMode::Read,
             ShutdownDirection::Write => litebox_broker_protocol::socket::ShutdownMode::Write,
             ShutdownDirection::Both => litebox_broker_protocol::socket::ShutdownMode::Both,
         };
-        socket
-            .shutdown(mode)
-            .map_err(errors::ShutdownError::OperationFailed)
+        match socket {
+            BrokerSocket::Tcp(socket) => {
+                if socket.is_listening() {
+                    return Err(errors::ShutdownError::Listening);
+                }
+                socket.shutdown(mode)
+            }
+            BrokerSocket::Udp(socket) => socket.shutdown(mode),
+        }
+        .map_err(errors::ShutdownError::OperationFailed)
     }
 
     /// Stops a broker-owned listener without closing its socket object.
@@ -1262,6 +1315,9 @@ where
             .broker_socket
             .as_ref()
             .ok_or(errors::ShutdownError::UnsupportedOperation)?;
+        let BrokerSocket::Tcp(socket) = socket else {
+            return Err(errors::ShutdownError::UnsupportedOperation);
+        };
         if !socket.is_listening() {
             return Err(errors::ShutdownError::OperationFailed(
                 errors::SocketAsyncError::NotConnected,
@@ -1278,7 +1334,10 @@ where
         socket_handle: &SocketHandle<Platform>,
     ) -> Result<SocketAddr, RemoteAddrError> {
         if let Some(socket) = &socket_handle.broker_socket {
-            return socket.remote_addr();
+            return match socket {
+                BrokerSocket::Tcp(socket) => socket.remote_addr(),
+                BrokerSocket::Udp(socket) => socket.remote_addr(),
+            };
         }
         let endpoint = match socket_handle.protocol() {
             Protocol::Tcp => self
@@ -1315,14 +1374,13 @@ where
             .get_entry_mut(fd)
             .ok_or(BindError::InvalidFd)?;
         let socket_handle = &mut table_entry.entry;
-        if let Some(socket) = socket_handle
-            .broker_socket
-            .as_ref()
-            .map(alloc::sync::Arc::clone)
-        {
+        if let Some(socket) = socket_handle.broker_socket.clone() {
             drop(table_entry);
             drop(descriptor_table);
-            return socket.bind(*addr);
+            return match socket {
+                BrokerSocket::Tcp(socket) => socket.bind(*addr),
+                BrokerSocket::Udp(socket) => socket.bind(*addr),
+            };
         }
         match socket_handle.protocol() {
             Protocol::Tcp => {
@@ -1394,11 +1452,11 @@ where
             .get_entry_mut(fd)
             .ok_or(ListenError::InvalidFd)?;
         let socket_handle = &mut table_entry.entry;
-        if let Some(socket) = socket_handle
-            .broker_socket
-            .as_ref()
-            .map(alloc::sync::Arc::clone)
-        {
+        if let Some(socket) = socket_handle.broker_socket.as_ref() {
+            let BrokerSocket::Tcp(socket) = socket else {
+                return Err(ListenError::UnsupportedOperation);
+            };
+            let socket = alloc::sync::Arc::clone(socket);
             drop(table_entry);
             drop(descriptor_table);
             return socket.listen(
@@ -1499,11 +1557,11 @@ where
             .get_entry_mut(fd)
             .ok_or(AcceptError::InvalidFd)?;
         let socket_handle = &mut table_entry.entry;
-        if let Some(listener) = socket_handle
-            .broker_socket
-            .as_ref()
-            .map(alloc::sync::Arc::clone)
-        {
+        if let Some(listener) = socket_handle.broker_socket.as_ref() {
+            let BrokerSocket::Tcp(listener) = listener else {
+                return Err(AcceptError::UnsupportedOperation);
+            };
+            let listener = alloc::sync::Arc::clone(listener);
             drop(table_entry);
             drop(descriptor_table);
             let accepted = listener.accept()?;
@@ -1515,7 +1573,7 @@ where
             return Ok(self.new_socket_fd_for(SocketHandle {
                 consider_closed: false,
                 handle: None,
-                broker_socket: Some(accepted),
+                broker_socket: Some(BrokerSocket::Tcp(accepted)),
                 specific: ProtocolSpecific::Tcp(TcpSpecific {
                     local_port: None,
                     server_socket: None,
@@ -1614,11 +1672,18 @@ where
             unimplemented!()
         }
         if let Some(socket) = &socket_handle.broker_socket {
-            if destination.is_some() {
-                return Err(SendError::UnnecessaryDestinationAddress);
-            }
-            return socket.try_write(buf).map_err(|error| match error {
+            let outcome = match socket {
+                BrokerSocket::Tcp(socket) => {
+                    if destination.is_some() {
+                        return Err(SendError::UnnecessaryDestinationAddress);
+                    }
+                    socket.try_write(buf)
+                }
+                BrokerSocket::Udp(socket) => socket.try_write(buf, destination),
+            };
+            return outcome.map_err(|error| match error {
                 socket_channel::ChannelWriteError::BufferFull => SendError::BufferFull,
+                socket_channel::ChannelWriteError::MessageTooLong => SendError::MessageTooLong,
                 socket_channel::ChannelWriteError::Unaddressable => SendError::Unaddressable,
                 socket_channel::ChannelWriteError::DestinationAddressRequired => {
                     SendError::DestinationAddressRequired
@@ -1714,19 +1779,29 @@ where
             unimplemented!("flags: {:?}", flags);
         }
         if let Some(socket) = &socket_handle.broker_socket {
-            return socket
-                .try_read(buf, flags, source_addr)
-                .or_else(|error| match error {
-                    socket_channel::ChannelReadError::WouldBlock => Ok(0),
-                    socket_channel::ChannelReadError::ReadShutdown
-                    | socket_channel::ChannelReadError::ConnectionClosed => {
-                        Err(ReceiveError::OperationFinished)
-                    }
-                    socket_channel::ChannelReadError::NotConnected
-                    | socket_channel::ChannelReadError::Socket(_) => {
-                        Err(ReceiveError::SocketInInvalidState)
-                    }
-                });
+            let outcome = match socket {
+                BrokerSocket::Tcp(socket) => socket.try_read(buf, flags, source_addr),
+                BrokerSocket::Udp(socket) => {
+                    socket.try_read(buf, flags, source_addr).map(|received| {
+                        if flags.intersects(ReceiveFlags::TRUNC | ReceiveFlags::DISCARD) {
+                            received
+                        } else {
+                            received.min(buf.len())
+                        }
+                    })
+                }
+            };
+            return outcome.or_else(|error| match error {
+                socket_channel::ChannelReadError::WouldBlock => Ok(0),
+                socket_channel::ChannelReadError::ReadShutdown
+                | socket_channel::ChannelReadError::ConnectionClosed => {
+                    Err(ReceiveError::OperationFinished)
+                }
+                socket_channel::ChannelReadError::NotConnected
+                | socket_channel::ChannelReadError::Socket(_) => {
+                    Err(ReceiveError::SocketInInvalidState)
+                }
+            });
         }
 
         let ret = match socket_handle.protocol() {
@@ -1815,7 +1890,7 @@ where
             .get_entry_mut(fd)
             .ok_or(errors::SetTcpOptionError::InvalidFd)?;
         let socket_handle = &mut table_entry.entry;
-        if socket_handle.broker_socket.is_some() {
+        if matches!(&socket_handle.broker_socket, Some(BrokerSocket::Tcp(_))) {
             return Err(errors::SetTcpOptionError::Unsupported);
         }
         match socket_handle.protocol() {
@@ -1855,7 +1930,7 @@ where
             .get_entry_mut(fd)
             .ok_or(errors::GetTcpOptionError::InvalidFd)?;
         let socket_handle = &mut table_entry.entry;
-        if socket_handle.broker_socket.is_some() {
+        if matches!(&socket_handle.broker_socket, Some(BrokerSocket::Tcp(_))) {
             return Err(errors::GetTcpOptionError::Unsupported);
         }
         match socket_handle.protocol() {

--- a/litebox/src/net/mod.rs
+++ b/litebox/src/net/mod.rs
@@ -1890,6 +1890,7 @@ where
             .get_entry_mut(fd)
             .ok_or(errors::SetTcpOptionError::InvalidFd)?;
         let socket_handle = &mut table_entry.entry;
+        // Broker-owned TCP sockets have no smoltcp handle, and their TCP options are not exposed.
         if matches!(&socket_handle.broker_socket, Some(BrokerSocket::Tcp(_))) {
             return Err(errors::SetTcpOptionError::Unsupported);
         }
@@ -1930,6 +1931,7 @@ where
             .get_entry_mut(fd)
             .ok_or(errors::GetTcpOptionError::InvalidFd)?;
         let socket_handle = &mut table_entry.entry;
+        // Broker-owned TCP sockets have no smoltcp handle, and their TCP options are not exposed.
         if matches!(&socket_handle.broker_socket, Some(BrokerSocket::Tcp(_))) {
             return Err(errors::GetTcpOptionError::Unsupported);
         }

--- a/litebox/src/net/socket_channel.rs
+++ b/litebox/src/net/socket_channel.rs
@@ -159,6 +159,8 @@ pub enum ChannelWriteError {
     Unaddressable,
     /// The transmit buffer is full.
     BufferFull,
+    /// The datagram exceeds the protocol maximum.
+    MessageTooLong,
     /// A destination address is required but was not provided.
     DestinationAddressRequired,
     /// The host network operation failed.
@@ -192,6 +194,8 @@ pub enum NetworkProxy<Platform: RawSyncPrimitivesProvider + TimeProvider> {
     Raw,
     /// Broker-owned TCP stream proxy.
     BrokerStream(alloc::sync::Arc<super::BrokerTcpSocket<Platform>>),
+    /// Broker-owned UDP datagram proxy.
+    BrokerDatagram(alloc::sync::Arc<super::BrokerUdpSocket<Platform>>),
 }
 
 impl<Platform: RawSyncPrimitivesProvider + TimeProvider> NetworkProxy<Platform> {
@@ -208,6 +212,7 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> NetworkProxy<Platform> 
             }
             NetworkProxy::Raw => {}
             NetworkProxy::BrokerStream(socket) => socket.set_state(state),
+            NetworkProxy::BrokerDatagram(socket) => socket.set_state(state),
         }
     }
 
@@ -218,6 +223,7 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> NetworkProxy<Platform> 
             NetworkProxy::Datagram(channel) => channel.set_async_error(error),
             NetworkProxy::Raw => {}
             NetworkProxy::BrokerStream(socket) => socket.set_async_error(error),
+            NetworkProxy::BrokerDatagram(socket) => socket.set_async_error(error),
         }
     }
 
@@ -228,6 +234,7 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> NetworkProxy<Platform> 
             NetworkProxy::Datagram(channel) => channel.get_async_error(clear),
             NetworkProxy::Raw => None,
             NetworkProxy::BrokerStream(socket) => socket.get_async_error(clear),
+            NetworkProxy::BrokerDatagram(socket) => socket.get_async_error(clear),
         }
     }
 
@@ -246,6 +253,7 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> NetworkProxy<Platform> 
             NetworkProxy::Datagram(channel) => channel.try_read(buf, flags, source_addr),
             NetworkProxy::Raw => unimplemented!(),
             NetworkProxy::BrokerStream(socket) => socket.try_read(buf, flags, source_addr),
+            NetworkProxy::BrokerDatagram(socket) => socket.try_read(buf, flags, source_addr),
         }
     }
 
@@ -272,6 +280,7 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> NetworkProxy<Platform> 
             NetworkProxy::Datagram(channel) => channel.send_to(buf, destination),
             NetworkProxy::Raw => unimplemented!(),
             NetworkProxy::BrokerStream(socket) => socket.try_write(buf),
+            NetworkProxy::BrokerDatagram(socket) => socket.try_write(buf, destination),
         }
     }
 }
@@ -282,6 +291,7 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> IOPollable for NetworkP
             NetworkProxy::Datagram(channel) => channel.register_observer(observer, mask),
             NetworkProxy::Raw => {}
             NetworkProxy::BrokerStream(socket) => socket.register_observer(observer, mask),
+            NetworkProxy::BrokerDatagram(socket) => socket.register_observer(observer, mask),
         }
     }
 
@@ -291,6 +301,7 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> IOPollable for NetworkP
             NetworkProxy::Datagram(channel) => channel.check_io_events(),
             NetworkProxy::Raw => unimplemented!(),
             NetworkProxy::BrokerStream(socket) => socket.check_io_events(),
+            NetworkProxy::BrokerDatagram(socket) => socket.check_io_events(),
         }
     }
 }
@@ -303,7 +314,8 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> NetworkProxy<Platform> 
         match self {
             NetworkProxy::Stream(channel) => channel.set_readable(readable),
             NetworkProxy::Datagram(channel) => channel.set_readable(readable),
-            NetworkProxy::Raw | NetworkProxy::BrokerStream(_) => {}
+            NetworkProxy::Raw | NetworkProxy::BrokerStream(_) | NetworkProxy::BrokerDatagram(_) => {
+            }
         }
     }
 
@@ -312,7 +324,9 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> NetworkProxy<Platform> 
         match self {
             NetworkProxy::Stream(channel) => channel.has_pending_tx(),
             NetworkProxy::Datagram(channel) => channel.has_pending_tx(),
-            NetworkProxy::Raw | NetworkProxy::BrokerStream(_) => false,
+            NetworkProxy::Raw | NetworkProxy::BrokerStream(_) | NetworkProxy::BrokerDatagram(_) => {
+                false
+            }
         }
     }
 }

--- a/litebox/src/sync/mutex.rs
+++ b/litebox/src/sync/mutex.rs
@@ -222,15 +222,15 @@ impl<Platform: RawSyncPrimitivesProvider, T> Mutex<Platform, T> {
         self.creation
             .ensure_registered(LockType::Mutex, || self.raw.raw.underlying_atomic());
 
-        if !self.raw.try_lock() {
-            return None;
-        }
-
         #[cfg(feature = "lock_tracing")]
         let attempt = super::lock_tracing::LockTracker::begin_lock_attempt(
             LockType::Mutex,
             self.raw.raw.underlying_atomic(),
         );
+
+        if !self.raw.try_lock() {
+            return None;
+        }
 
         Some(MutexGuard {
             mutex: self,

--- a/litebox/src/sync/mutex.rs
+++ b/litebox/src/sync/mutex.rs
@@ -214,6 +214,31 @@ unsafe impl<Platform: RawSyncPrimitivesProvider, T: Send> Send for Mutex<Platfor
 unsafe impl<Platform: RawSyncPrimitivesProvider, T: Send> Sync for Mutex<Platform, T> {}
 
 impl<Platform: RawSyncPrimitivesProvider, T> Mutex<Platform, T> {
+    /// Attempts to acquire this mutex without blocking.
+    #[inline]
+    #[track_caller]
+    pub fn try_lock(&self) -> Option<MutexGuard<'_, Platform, T>> {
+        #[cfg(feature = "lock_tracing")]
+        self.creation
+            .ensure_registered(LockType::Mutex, || self.raw.raw.underlying_atomic());
+
+        if !self.raw.try_lock() {
+            return None;
+        }
+
+        #[cfg(feature = "lock_tracing")]
+        let attempt = super::lock_tracing::LockTracker::begin_lock_attempt(
+            LockType::Mutex,
+            self.raw.raw.underlying_atomic(),
+        );
+
+        Some(MutexGuard {
+            mutex: self,
+            #[cfg(feature = "lock_tracing")]
+            locked_witness: attempt.map(super::lock_tracing::LockTracker::mark_lock),
+        })
+    }
+
     #[inline]
     #[track_caller]
     pub fn lock(&self) -> MutexGuard<'_, Platform, T> {

--- a/litebox_common_linux/src/errno/mod.rs
+++ b/litebox_common_linux/src/errno/mod.rs
@@ -510,6 +510,7 @@ impl From<litebox::net::errors::SendError> for Errno {
             litebox::net::errors::SendError::SocketInInvalidState => Errno::EPIPE,
             litebox::net::errors::SendError::Unaddressable => Errno::EINVAL,
             litebox::net::errors::SendError::BufferFull => Errno::EAGAIN,
+            litebox::net::errors::SendError::MessageTooLong => Errno::EMSGSIZE,
             litebox::net::errors::SendError::PortAllocationFailure(e) => e.into(),
             litebox::net::errors::SendError::UnnecessaryDestinationAddress => Errno::EISCONN,
             litebox::net::errors::SendError::DestinationAddressRequired => Errno::EDESTADDRREQ,
@@ -526,6 +527,7 @@ impl From<litebox::net::socket_channel::ChannelWriteError> for Errno {
             | litebox::net::socket_channel::ChannelWriteError::ConnectionClosed => Errno::EPIPE,
             litebox::net::socket_channel::ChannelWriteError::Unaddressable => Errno::EINVAL,
             litebox::net::socket_channel::ChannelWriteError::BufferFull => Errno::EAGAIN,
+            litebox::net::socket_channel::ChannelWriteError::MessageTooLong => Errno::EMSGSIZE,
             litebox::net::socket_channel::ChannelWriteError::DestinationAddressRequired => {
                 Errno::EDESTADDRREQ
             }

--- a/litebox_runner_linux_userland/tests/run.rs
+++ b/litebox_runner_linux_userland/tests/run.rs
@@ -15,6 +15,7 @@ const BROKER_ONLY_C_TESTS: &[&str] = &[
     "pipe_broker.c",
     "tcp_broker.c",
     "tcp_broker_server.c",
+    "udp_broker.c",
 ];
 
 #[must_use]
@@ -648,6 +649,95 @@ fn test_runner_broker_tcp_client_with_rewriter() {
         .broker_socket(&control_socket_path)
         .run();
     assert_eq!(broker.next_close_object_count(), 9);
+    broker.join();
+    server.join().unwrap();
+}
+
+#[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+#[test]
+fn test_runner_broker_udp_with_rewriter() {
+    use std::net::{Ipv4Addr, UdpSocket};
+
+    let target = common::compile("./tests/udp_broker.c", "broker_udp_rewriter", false, false);
+    let server = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let port = server.local_addr().unwrap().port();
+    let refused = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let refused_port = refused.local_addr().unwrap().port();
+    drop(refused);
+    let mut runner = Runner::new(&target, "broker_udp_rewriter");
+    server
+        .set_read_timeout(Some(BROKER_HELPER_TIMEOUT))
+        .unwrap();
+    let server = std::thread::spawn(move || {
+        let mut packet = [0_u8; 64];
+
+        let (received, client) = server.recv_from(&mut packet).unwrap();
+        assert_eq!(&packet[..received], b"unconnected");
+        server.send_to(b"0123456789", client).unwrap();
+
+        let (received, source) = server.recv_from(&mut packet).unwrap();
+        assert_eq!(&packet[..received], b"read");
+        assert_eq!(source, client);
+        server.send_to(b"abcdefghij", client).unwrap();
+
+        let (received, source) = server.recv_from(&mut packet).unwrap();
+        assert_eq!(&packet[..received], b"readv");
+        assert_eq!(source, client);
+        server.send_to(b"abcdefghij", client).unwrap();
+
+        let (received, source) = server.recv_from(&mut packet).unwrap();
+        assert_eq!(&packet[..received], b"readv-fault");
+        assert_eq!(source, client);
+        server.send_to(b"abcdefghij", client).unwrap();
+
+        let (received, source) = server.recv_from(&mut packet).unwrap();
+        assert_eq!(received, 0);
+        assert_eq!(source, client);
+        server.send_to(&[], client).unwrap();
+
+        let (received, source) = server.recv_from(&mut packet).unwrap();
+        assert_eq!(&packet[..received], b"connected");
+        assert_eq!(source, client);
+        server.send_to(b"connected-reply", client).unwrap();
+
+        let (received, source) = server.recv_from(&mut packet).unwrap();
+        assert_eq!(&packet[..received], b"writev");
+        assert_eq!(source, client);
+        server.send_to(b"writev-reply", client).unwrap();
+
+        let (received, source) = server.recv_from(&mut packet).unwrap();
+        assert_eq!(&packet[..received], b"explicit");
+        assert_eq!(source, client);
+        server.send_to(b"explicit-reply", client).unwrap();
+
+        let mut maximum = vec![0_u8; 65_507];
+        let (received, source) = server.recv_from(&mut maximum).unwrap();
+        assert_eq!(received, maximum.len());
+        assert!(maximum.iter().all(|byte| *byte == 0x5a));
+        assert_eq!(source, client);
+        server.send_to(b"maximum-reply", client).unwrap();
+
+        let (received, source) = server.recv_from(&mut packet).unwrap();
+        assert_eq!(&packet[..received], b"preserved");
+        assert_eq!(source, client);
+        server.send_to(b"preserved-reply", client).unwrap();
+    });
+
+    let control_socket_path = unique_test_socket_path("runner-broker-udp-control");
+    let broker = spawn_test_broker(
+        &control_socket_path,
+        litebox_broker_core::PolicyEngine::with_host_guaranteed_rights(
+            litebox_broker_core::ObjectRights::all(),
+        )
+        .with_socket_policy(litebox_broker_core::SocketPolicy::Ipv4Loopback),
+        1,
+    );
+    runner
+        .arg(port.to_string())
+        .arg(refused_port.to_string())
+        .broker_socket(&control_socket_path)
+        .run();
+    assert_eq!(broker.next_close_object_count(), 3);
     broker.join();
     server.join().unwrap();
 }

--- a/litebox_runner_linux_userland/tests/run.rs
+++ b/litebox_runner_linux_userland/tests/run.rs
@@ -663,17 +663,16 @@ fn test_runner_broker_udp_with_rewriter() {
     let port = server.local_addr().unwrap().port();
     let refused = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
     let refused_port = refused.local_addr().unwrap().port();
-    drop(refused);
     let mut runner = Runner::new(&target, "broker_udp_rewriter");
-    server
-        .set_read_timeout(Some(BROKER_HELPER_TIMEOUT))
-        .unwrap();
     let server = std::thread::spawn(move || {
         let mut packet = [0_u8; 64];
 
         let (received, client) = server.recv_from(&mut packet).unwrap();
         assert_eq!(&packet[..received], b"unconnected");
         server.send_to(b"0123456789", client).unwrap();
+        server
+            .set_read_timeout(Some(BROKER_HELPER_TIMEOUT))
+            .unwrap();
 
         let (received, source) = server.recv_from(&mut packet).unwrap();
         assert_eq!(&packet[..received], b"read");
@@ -720,6 +719,7 @@ fn test_runner_broker_udp_with_rewriter() {
         let (received, source) = server.recv_from(&mut packet).unwrap();
         assert_eq!(&packet[..received], b"preserved");
         assert_eq!(source, client);
+        drop(refused);
         server.send_to(b"preserved-reply", client).unwrap();
     });
 

--- a/litebox_runner_linux_userland/tests/udp_broker.c
+++ b/litebox_runner_linux_userland/tests/udp_broker.c
@@ -1,7 +1,7 @@
-#define _GNU_SOURCE
-
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+
+#define _GNU_SOURCE
 
 #include <arpa/inet.h>
 #include <assert.h>

--- a/litebox_runner_linux_userland/tests/udp_broker.c
+++ b/litebox_runner_linux_userland/tests/udp_broker.c
@@ -161,10 +161,14 @@ int main(int argc, char **argv) {
                   sizeof(server)) == 0);
     wait_readable(fd);
     unsigned char empty = 0xff;
+    memset(&source, 0xa5, sizeof(source));
     address_length = sizeof(source);
     assert(recvfrom(fd, &empty, sizeof(empty), 0,
                     (struct sockaddr *)&source, &address_length) == 0);
     assert(empty == 0xff);
+    assert(address_length == sizeof(source));
+    assert(source.sin_family == AF_INET);
+    assert(source.sin_addr.s_addr == htonl(INADDR_LOOPBACK));
     assert(source.sin_port == server.sin_port);
     retract_readable(fd);
 
@@ -242,6 +246,17 @@ int main(int argc, char **argv) {
     assert(peer.sin_addr.s_addr == server.sin_addr.s_addr);
     assert(peer.sin_port == server.sin_port);
 
+    int refused_fd = socket(AF_INET, SOCK_DGRAM | SOCK_NONBLOCK | SOCK_CLOEXEC,
+                            0);
+    assert(refused_fd >= 0);
+    struct sockaddr_in refused = {
+        .sin_family = AF_INET,
+        .sin_port = htons((uint16_t)strtoul(argv[2], NULL, 10)),
+    };
+    assert(inet_pton(AF_INET, "127.0.0.1", &refused.sin_addr) == 1);
+    assert(connect(refused_fd, (const struct sockaddr *)&refused,
+                   sizeof(refused)) == 0);
+
     const char preserved[] = "preserved";
     assert(send(fd, preserved, sizeof(preserved) - 1, 0) ==
            (ssize_t)(sizeof(preserved) - 1));
@@ -250,6 +265,19 @@ int main(int argc, char **argv) {
     assert(recv(fd, reply, sizeof(reply), 0) == 15);
     assert(memcmp(reply, "preserved-reply", 15) == 0);
     retract_readable(fd);
+
+    assert(send(refused_fd, "x", 1, 0) == 1);
+    struct pollfd failed = {.fd = refused_fd, .events = POLLERR};
+    assert(poll(&failed, 1, 5000) == 1);
+    assert((failed.revents & POLLERR) != 0);
+    assert(recv(refused_fd, reply, sizeof(reply), 0) == -1);
+    assert(errno == ECONNREFUSED);
+    int socket_error = -1;
+    socklen_t socket_error_length = sizeof(socket_error);
+    assert(getsockopt(refused_fd, SOL_SOCKET, SO_ERROR, &socket_error,
+                      &socket_error_length) == 0);
+    assert(socket_error == 0);
+    assert(close(refused_fd) == 0);
 
     assert(shutdown(fd, SHUT_WR) == 0);
     writable.revents = 0;
@@ -305,27 +333,6 @@ int main(int argc, char **argv) {
     assert(getsockname(fd, (struct sockaddr *)&local, &address_length) == 0);
     assert(local.sin_addr.s_addr == htonl(INADDR_LOOPBACK));
     assert(local.sin_port != 0);
-    assert(close(fd) == 0);
-
-    fd = socket(AF_INET, SOCK_DGRAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0);
-    assert(fd >= 0);
-    struct sockaddr_in refused = {
-        .sin_family = AF_INET,
-        .sin_port = htons((uint16_t)strtoul(argv[2], NULL, 10)),
-    };
-    assert(inet_pton(AF_INET, "127.0.0.1", &refused.sin_addr) == 1);
-    assert(connect(fd, (const struct sockaddr *)&refused, sizeof(refused)) == 0);
-    assert(send(fd, "x", 1, 0) == 1);
-    struct pollfd failed = {.fd = fd, .events = POLLERR};
-    assert(poll(&failed, 1, 5000) == 1);
-    assert((failed.revents & POLLERR) != 0);
-    assert(recv(fd, reply, sizeof(reply), 0) == -1);
-    assert(errno == ECONNREFUSED);
-    int socket_error = -1;
-    socklen_t socket_error_length = sizeof(socket_error);
-    assert(getsockopt(fd, SOL_SOCKET, SO_ERROR, &socket_error,
-                      &socket_error_length) == 0);
-    assert(socket_error == 0);
     assert(close(fd) == 0);
     return 0;
 }

--- a/litebox_runner_linux_userland/tests/udp_broker.c
+++ b/litebox_runner_linux_userland/tests/udp_broker.c
@@ -48,6 +48,7 @@ int main(int argc, char **argv) {
     assert(argc == 3);
     int fd = socket(AF_INET, SOCK_DGRAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0);
     assert(fd >= 0);
+    assert(read(fd, NULL, 0) == 0);
     assert(readv(fd, NULL, 0) == 0);
     assert(writev(fd, NULL, 0) == 0);
 
@@ -83,6 +84,7 @@ int main(int argc, char **argv) {
     assert(errno == ENOTCONN);
 
     wait_readable(fd);
+    assert(read(fd, NULL, 0) == 0);
     char truncated[4] = {0};
     struct iovec iov = {.iov_base = truncated, .iov_len = sizeof(truncated)};
     struct sockaddr_in source;

--- a/litebox_runner_linux_userland/tests/udp_broker.c
+++ b/litebox_runner_linux_userland/tests/udp_broker.c
@@ -1,0 +1,329 @@
+#define _GNU_SOURCE
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include <arpa/inet.h>
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <netinet/tcp.h>
+#include <poll.h>
+#include <signal.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <sys/uio.h>
+#include <unistd.h>
+
+enum {
+    MAX_UDP_PAYLOAD = 65507,
+};
+
+static volatile sig_atomic_t sigpipe_count;
+
+static void record_sigpipe(int signal_number) {
+    if (signal_number == SIGPIPE) {
+        ++sigpipe_count;
+    }
+}
+
+static void wait_readable(int fd) {
+    struct pollfd ready = {.fd = fd, .events = POLLIN};
+    assert(poll(&ready, 1, 5000) == 1);
+    assert((ready.revents & POLLIN) != 0);
+}
+
+static void retract_readable(int fd) {
+    unsigned char byte;
+    assert(recv(fd, &byte, sizeof(byte), MSG_DONTWAIT) == -1);
+    assert(errno == EAGAIN);
+    struct pollfd ready = {.fd = fd, .events = POLLIN};
+    assert(poll(&ready, 1, 0) == 0);
+}
+
+int main(int argc, char **argv) {
+    assert(argc == 3);
+    int fd = socket(AF_INET, SOCK_DGRAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0);
+    assert(fd >= 0);
+    assert(readv(fd, NULL, 0) == 0);
+    assert(writev(fd, NULL, 0) == 0);
+
+    int enabled = 1;
+    assert(setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &enabled,
+                      sizeof(enabled)) == -1);
+    assert(errno == ENOPROTOOPT);
+
+    struct pollfd writable = {.fd = fd, .events = POLLOUT};
+    assert(poll(&writable, 1, 0) == 1);
+    assert((writable.revents & POLLOUT) != 0);
+
+    struct sockaddr_in server = {
+        .sin_family = AF_INET,
+        .sin_port = htons((uint16_t)strtoul(argv[1], NULL, 10)),
+    };
+    assert(inet_pton(AF_INET, "127.0.0.1", &server.sin_addr) == 1);
+
+    const char unconnected[] = "unconnected";
+    assert(sendto(fd, unconnected, sizeof(unconnected) - 1, 0,
+                  (const struct sockaddr *)&server, sizeof(server)) ==
+           (ssize_t)(sizeof(unconnected) - 1));
+
+    struct sockaddr_in local;
+    socklen_t address_length = sizeof(local);
+    assert(getsockname(fd, (struct sockaddr *)&local, &address_length) == 0);
+    assert(local.sin_family == AF_INET);
+    assert(local.sin_addr.s_addr == htonl(INADDR_ANY));
+    assert(local.sin_port != 0);
+    struct sockaddr_in peer;
+    address_length = sizeof(peer);
+    assert(getpeername(fd, (struct sockaddr *)&peer, &address_length) == -1);
+    assert(errno == ENOTCONN);
+
+    wait_readable(fd);
+    char truncated[4] = {0};
+    struct iovec iov = {.iov_base = truncated, .iov_len = sizeof(truncated)};
+    struct sockaddr_in source;
+    struct msghdr message = {
+        .msg_name = &source,
+        .msg_namelen = sizeof(source),
+        .msg_iov = &iov,
+        .msg_iovlen = 1,
+    };
+    assert(recvmsg(fd, &message, 0) == sizeof(truncated));
+    assert(memcmp(truncated, "0123", sizeof(truncated)) == 0);
+    assert((message.msg_flags & MSG_TRUNC) != 0);
+    assert(source.sin_addr.s_addr == htonl(INADDR_LOOPBACK));
+    assert(source.sin_port == server.sin_port);
+    retract_readable(fd);
+
+    const char read_request[] = "read";
+    assert(sendto(fd, read_request, sizeof(read_request) - 1, 0,
+                  (const struct sockaddr *)&server, sizeof(server)) ==
+           (ssize_t)(sizeof(read_request) - 1));
+    wait_readable(fd);
+    memset(truncated, 0, sizeof(truncated));
+    assert(read(fd, truncated, sizeof(truncated)) == sizeof(truncated));
+    assert(memcmp(truncated, "abcd", sizeof(truncated)) == 0);
+    retract_readable(fd);
+
+    const char readv_request[] = "readv";
+    assert(sendto(fd, readv_request, sizeof(readv_request) - 1, 0,
+                  (const struct sockaddr *)&server, sizeof(server)) ==
+           (ssize_t)(sizeof(readv_request) - 1));
+    wait_readable(fd);
+    int vector_fd = dup(fd);
+    assert(vector_fd >= 0);
+    char readv_first[2] = {0};
+    char readv_second[2] = {0};
+    struct iovec read_vector[] = {
+        {
+            .iov_base = readv_first,
+            .iov_len = sizeof(readv_first),
+        },
+        {
+            .iov_base = readv_second,
+            .iov_len = sizeof(readv_second),
+        },
+    };
+    assert(readv(vector_fd, read_vector, 2) ==
+           sizeof(readv_first) + sizeof(readv_second));
+    assert(memcmp(readv_first, "ab", sizeof(readv_first)) == 0);
+    assert(memcmp(readv_second, "cd", sizeof(readv_second)) == 0);
+    retract_readable(fd);
+
+    const char readv_fault_request[] = "readv-fault";
+    assert(sendto(fd, readv_fault_request, sizeof(readv_fault_request) - 1, 0,
+                  (const struct sockaddr *)&server, sizeof(server)) ==
+           (ssize_t)(sizeof(readv_fault_request) - 1));
+    wait_readable(fd);
+    memset(readv_first, 0, sizeof(readv_first));
+    struct iovec faulting_read_vector[] = {
+        {
+            .iov_base = readv_first,
+            .iov_len = sizeof(readv_first),
+        },
+        {
+            .iov_base = (void *)1,
+            .iov_len = sizeof(readv_second),
+        },
+    };
+    assert(readv(vector_fd, faulting_read_vector, 2) == -1);
+    assert(errno == EFAULT);
+    assert(memcmp(readv_first, "ab", sizeof(readv_first)) == 0);
+    retract_readable(fd);
+
+    assert(sendto(fd, NULL, 0, 0, (const struct sockaddr *)&server,
+                  sizeof(server)) == 0);
+    wait_readable(fd);
+    unsigned char empty = 0xff;
+    address_length = sizeof(source);
+    assert(recvfrom(fd, &empty, sizeof(empty), 0,
+                    (struct sockaddr *)&source, &address_length) == 0);
+    assert(empty == 0xff);
+    assert(source.sin_port == server.sin_port);
+    retract_readable(fd);
+
+    assert(connect(fd, (const struct sockaddr *)&server, sizeof(server)) == 0);
+    address_length = sizeof(local);
+    assert(getsockname(fd, (struct sockaddr *)&local, &address_length) == 0);
+    assert(local.sin_addr.s_addr == htonl(INADDR_LOOPBACK));
+    assert(local.sin_port != 0);
+    address_length = sizeof(peer);
+    assert(getpeername(fd, (struct sockaddr *)&peer, &address_length) == 0);
+    assert(peer.sin_addr.s_addr == server.sin_addr.s_addr);
+    assert(peer.sin_port == server.sin_port);
+
+    const char connected[] = "connected";
+    assert(send(fd, connected, sizeof(connected) - 1, 0) ==
+           (ssize_t)(sizeof(connected) - 1));
+    wait_readable(fd);
+    char reply[32] = {0};
+    assert(recv(fd, reply, sizeof(reply), 0) == 15);
+    assert(memcmp(reply, "connected-reply", 15) == 0);
+    retract_readable(fd);
+
+    const char writev_first[] = "write";
+    const char writev_second[] = "v";
+    struct iovec write_vector[] = {
+        {
+            .iov_base = (void *)writev_first,
+            .iov_len = sizeof(writev_first) - 1,
+        },
+        {
+            .iov_base = (void *)writev_second,
+            .iov_len = sizeof(writev_second) - 1,
+        },
+    };
+    assert(writev(vector_fd, write_vector, 2) == 6);
+    wait_readable(fd);
+    char writev_reply[16] = {0};
+    assert(recv(fd, writev_reply, sizeof(writev_reply), 0) == 12);
+    assert(memcmp(writev_reply, "writev-reply", 12) == 0);
+    retract_readable(fd);
+    assert(close(vector_fd) == 0);
+
+    const char explicit[] = "explicit";
+    assert(sendto(fd, explicit, sizeof(explicit) - 1, 0,
+                  (const struct sockaddr *)&server, sizeof(server)) ==
+           (ssize_t)(sizeof(explicit) - 1));
+    wait_readable(fd);
+    memset(reply, 0, sizeof(reply));
+    assert(recv(fd, reply, sizeof(reply), 0) == 14);
+    assert(memcmp(reply, "explicit-reply", 14) == 0);
+    retract_readable(fd);
+
+    unsigned char *maximum = malloc(MAX_UDP_PAYLOAD + 1);
+    assert(maximum != NULL);
+    memset(maximum, 0x5a, MAX_UDP_PAYLOAD);
+    assert(send(fd, maximum, MAX_UDP_PAYLOAD, 0) == MAX_UDP_PAYLOAD);
+    wait_readable(fd);
+    memset(reply, 0, sizeof(reply));
+    assert(recv(fd, reply, sizeof(reply), 0) == 13);
+    assert(memcmp(reply, "maximum-reply", 13) == 0);
+    retract_readable(fd);
+    assert(send(fd, maximum, MAX_UDP_PAYLOAD + 1, 0) == -1);
+    assert(errno == EMSGSIZE);
+    free(maximum);
+
+    struct sockaddr_in denied = {
+        .sin_family = AF_INET,
+        .sin_port = htons(80),
+    };
+    assert(inet_pton(AF_INET, "192.0.2.1", &denied.sin_addr) == 1);
+    assert(connect(fd, (const struct sockaddr *)&denied, sizeof(denied)) == -1);
+    assert(errno == EACCES);
+    address_length = sizeof(peer);
+    assert(getpeername(fd, (struct sockaddr *)&peer, &address_length) == 0);
+    assert(peer.sin_addr.s_addr == server.sin_addr.s_addr);
+    assert(peer.sin_port == server.sin_port);
+
+    const char preserved[] = "preserved";
+    assert(send(fd, preserved, sizeof(preserved) - 1, 0) ==
+           (ssize_t)(sizeof(preserved) - 1));
+    wait_readable(fd);
+    memset(reply, 0, sizeof(reply));
+    assert(recv(fd, reply, sizeof(reply), 0) == 15);
+    assert(memcmp(reply, "preserved-reply", 15) == 0);
+    retract_readable(fd);
+
+    assert(shutdown(fd, SHUT_WR) == 0);
+    writable.revents = 0;
+    assert(poll(&writable, 1, 0) == 1);
+    assert((writable.revents & POLLOUT) != 0);
+    assert(signal(SIGPIPE, record_sigpipe) != SIG_ERR);
+    assert(writev(fd, write_vector, 2) == -1);
+    assert(errno == EPIPE);
+    assert(sigpipe_count == 0);
+    assert(send(fd, connected, sizeof(connected) - 1, 0) == -1);
+    assert(errno == EPIPE);
+    assert(sigpipe_count == 0);
+
+    assert(shutdown(fd, SHUT_RD) == 0);
+    struct pollfd fully_shutdown = {
+        .fd = fd,
+        .events = POLLIN | POLLRDHUP | POLLHUP,
+    };
+    assert(poll(&fully_shutdown, 1, 0) == 1);
+    assert((fully_shutdown.revents & POLLIN) != 0);
+    assert((fully_shutdown.revents & POLLRDHUP) != 0);
+    assert((fully_shutdown.revents & POLLHUP) != 0);
+    assert(recv(fd, reply, sizeof(reply), 0) == -1);
+    assert(errno == EAGAIN);
+    int status_flags = fcntl(fd, F_GETFL);
+    assert(status_flags >= 0);
+    assert(fcntl(fd, F_SETFL, status_flags & ~O_NONBLOCK) == 0);
+    struct timeval shutdown_timeout = {.tv_sec = 1};
+    assert(setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &shutdown_timeout,
+                      sizeof(shutdown_timeout)) == 0);
+    assert(recv(fd, reply, sizeof(reply), 0) == 0);
+
+    assert(close(fd) == 0);
+
+    fd = socket(AF_INET, SOCK_DGRAM | SOCK_CLOEXEC, 0);
+    assert(fd >= 0);
+    assert(shutdown(fd, SHUT_RD) == -1);
+    assert(errno == ENOTCONN);
+    struct pollfd read_shutdown = {.fd = fd, .events = POLLIN | POLLRDHUP};
+    assert(poll(&read_shutdown, 1, 0) == 1);
+    assert((read_shutdown.revents & POLLIN) != 0);
+    assert((read_shutdown.revents & POLLRDHUP) != 0);
+    assert(recv(fd, reply, sizeof(reply), MSG_DONTWAIT) == -1);
+    assert(errno == EAGAIN);
+    struct sockaddr_in bind_address = {
+        .sin_family = AF_INET,
+        .sin_port = 0,
+        .sin_addr.s_addr = htonl(INADDR_LOOPBACK),
+    };
+    assert(bind(fd, (const struct sockaddr *)&bind_address,
+                sizeof(bind_address)) == 0);
+    address_length = sizeof(local);
+    assert(getsockname(fd, (struct sockaddr *)&local, &address_length) == 0);
+    assert(local.sin_addr.s_addr == htonl(INADDR_LOOPBACK));
+    assert(local.sin_port != 0);
+    assert(close(fd) == 0);
+
+    fd = socket(AF_INET, SOCK_DGRAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0);
+    assert(fd >= 0);
+    struct sockaddr_in refused = {
+        .sin_family = AF_INET,
+        .sin_port = htons((uint16_t)strtoul(argv[2], NULL, 10)),
+    };
+    assert(inet_pton(AF_INET, "127.0.0.1", &refused.sin_addr) == 1);
+    assert(connect(fd, (const struct sockaddr *)&refused, sizeof(refused)) == 0);
+    assert(send(fd, "x", 1, 0) == 1);
+    struct pollfd failed = {.fd = fd, .events = POLLERR};
+    assert(poll(&failed, 1, 5000) == 1);
+    assert((failed.revents & POLLERR) != 0);
+    assert(recv(fd, reply, sizeof(reply), 0) == -1);
+    assert(errno == ECONNREFUSED);
+    int socket_error = -1;
+    socklen_t socket_error_length = sizeof(socket_error);
+    assert(getsockopt(fd, SOL_SOCKET, SO_ERROR, &socket_error,
+                      &socket_error_length) == 0);
+    assert(socket_error == 0);
+    assert(close(fd) == 0);
+    return 0;
+}

--- a/litebox_shim_linux/src/syscalls/file.rs
+++ b/litebox_shim_linux/src/syscalls/file.rs
@@ -464,12 +464,17 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             return Err(Errno::EBADF);
         };
         let files = self.files.borrow();
+        let is_inet_datagram = core::cell::Cell::new(false);
         let res = files
             .run_on_raw_fd(
                 raw_fd,
                 |fd| files.fs.write(fd, buf, offset).map_err(Errno::from),
                 |fd| {
                     espipe_for_non_seekable_offset(offset)?;
+                    is_inet_datagram.set(matches!(
+                        self.global.get_socket_type(fd)?,
+                        litebox_common_linux::SockType::Datagram
+                    ));
                     self.global.sendto(
                         &self.wait_cx(),
                         fd,
@@ -517,7 +522,9 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                 },
             )
             .flatten();
-        if let Err(Errno::EPIPE) = res {
+        if let Err(Errno::EPIPE) = res
+            && !is_inet_datagram.get()
+        {
             self.send_signal(Signal::SIGPIPE, signal::siginfo_kill(Signal::SIGPIPE));
         }
         res
@@ -911,6 +918,9 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         let iovs: &[IoReadVec] = &iovec
             .to_owned_slice::<Platform>(iovcnt)
             .ok_or(Errno::EFAULT)?;
+        if let Some(received) = self.try_read_datagram_from_iovec(fd, iovs)? {
+            return Ok(received);
+        }
         let mut kernel_buffer = vec![0u8; PAGE_SIZE];
         // TODO: The data transfers performed by readv() and writev() are atomic: the data
         // written by writev() is written as a single block that is not intermingled with
@@ -918,6 +928,126 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         read_from_iovec::<_, Platform>(iovs, &mut kernel_buffer, |buf, _total| {
             self.sys_read(fd, buf, None)
         })
+    }
+
+    fn try_read_datagram_from_iovec(
+        &self,
+        fd: i32,
+        iovs: &[IoReadVec],
+    ) -> Result<Option<usize>, Errno> {
+        let raw_fd = usize::try_from(fd).map_err(|_| Errno::EBADF)?;
+        let Some(socket) = self
+            .files
+            .borrow()
+            .try_pin_inet_socket(&self.global, raw_fd)?
+        else {
+            return Ok(None);
+        };
+        if socket.is_broker_datagram() {
+            self.read_datagram_from_iovec(&socket, iovs).map(Some)
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn read_datagram_from_iovec(
+        &self,
+        socket: &super::net::InetSocketPin<'_, Platform, FS>,
+        iovs: &[IoReadVec],
+    ) -> Result<usize, Errno> {
+        check_iov_lens(iovs.iter().map(|iov| iov.iov_len))?;
+        let capacity = iovs.iter().map(|iov| iov.iov_len).sum::<usize>();
+        if capacity == 0 {
+            return Ok(0);
+        }
+        let mut buffer = alloc::vec::Vec::new();
+        let capacity = capacity.min(litebox::net::SOCKET_RECEIVE_OPERATION_SIZE);
+        buffer
+            .try_reserve_exact(capacity)
+            .map_err(|_| Errno::ENOMEM)?;
+        buffer.resize(capacity, 0);
+        let received = self
+            .global
+            .receive_from_socket(
+                &self.wait_cx(),
+                socket,
+                &mut buffer,
+                litebox_common_linux::ReceiveFlags::empty(),
+                super::net::ReceiveContext::new(None, false),
+                None,
+            )?
+            .min(buffer.len());
+        let mut copied = 0;
+        for iov in iovs {
+            if copied == received {
+                break;
+            }
+            let length = (received - copied).min(iov.iov_len);
+            if iov
+                .iov_base
+                .copy_from_slice::<Platform>(0, &buffer[copied..copied + length])
+                .is_none()
+            {
+                return Err(Errno::EFAULT);
+            }
+            copied += length;
+        }
+        Ok(received)
+    }
+
+    fn try_write_datagram_to_iovec(
+        &self,
+        fd: i32,
+        iovs: &[IoWriteVec],
+    ) -> Result<Option<usize>, Errno> {
+        let raw_fd = usize::try_from(fd).map_err(|_| Errno::EBADF)?;
+        let Some(socket) = self
+            .files
+            .borrow()
+            .try_pin_inet_socket(&self.global, raw_fd)?
+        else {
+            return Ok(None);
+        };
+        if socket.is_broker_datagram() {
+            self.write_datagram_to_iovec(&socket, iovs).map(Some)
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn write_datagram_to_iovec(
+        &self,
+        socket: &super::net::InetSocketPin<'_, Platform, FS>,
+        iovs: &[IoWriteVec],
+    ) -> Result<usize, Errno> {
+        check_iov_lens(iovs.iter().map(|iov| iov.iov_len))?;
+        let length = iovs.iter().map(|iov| iov.iov_len).sum::<usize>();
+        if length == 0 {
+            return Ok(0);
+        }
+        if length > litebox::net::MAX_UDP_DATAGRAM_SIZE {
+            return Err(Errno::EMSGSIZE);
+        }
+        let mut buffer = alloc::vec::Vec::new();
+        buffer
+            .try_reserve_exact(length)
+            .map_err(|_| Errno::ENOMEM)?;
+        for iov in iovs {
+            for offset in 0..iov.iov_len {
+                let offset = isize::try_from(offset).map_err(|_| Errno::EFAULT)?;
+                buffer.push(
+                    iov.iov_base
+                        .read_at_offset::<Platform>(offset)
+                        .ok_or(Errno::EFAULT)?,
+                );
+            }
+        }
+        self.global.send_to_pinned_socket(
+            &self.wait_cx(),
+            socket,
+            &buffer,
+            litebox_common_linux::SendFlags::empty(),
+        )
     }
 }
 
@@ -1072,6 +1202,11 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         let iovs: &[IoWriteVec] = &iovec
             .to_owned_slice::<Platform>(iovcnt)
             .ok_or(Errno::EFAULT)?;
+        match self.try_write_datagram_to_iovec(fd, iovs) {
+            Ok(Some(written)) => return Ok(written),
+            Ok(None) => {}
+            Err(error) => return Err(error),
+        }
         // TODO: The data transfers performed by readv() and writev() are atomic: the data
         // written by writev() is written as a single block that is not intermingled with
         // output from writes in other processes

--- a/litebox_shim_linux/src/syscalls/net.rs
+++ b/litebox_shim_linux/src/syscalls/net.rs
@@ -291,8 +291,10 @@ pub(crate) struct SocketOFlags(pub OFlags);
 pub(crate) struct SocketProxy<Platform: ShimPlatform>(pub Arc<NetworkProxy<Platform>>);
 #[derive(Clone)]
 struct SocketIoState(Arc<core::sync::atomic::AtomicUsize>);
+/// Entry metadata that shares `recvmmsg` serialization across duplicated descriptors.
 struct SocketRecvmmsgLock<Platform: ShimPlatform>(Arc<RecvmmsgLock<Platform>>);
 
+/// Serializes multi-message receives while allowing contended waits to be interrupted or timed out.
 struct RecvmmsgLock<Platform: ShimPlatform> {
     mutex: Mutex<Platform, ()>,
     pollee: Pollee<Platform>,

--- a/litebox_shim_linux/src/syscalls/net.rs
+++ b/litebox_shim_linux/src/syscalls/net.rs
@@ -1007,6 +1007,9 @@ impl<Platform: ShimPlatform, FS: ShimFS> GlobalState<Platform, FS> {
         source_addr: Option<&mut Option<SocketAddr>>,
     ) -> Result<usize, Errno> {
         let socket = self.pin_socket(fd)?;
+        if buf.is_empty() {
+            return Ok(0);
+        }
         let received = self.receive_from_socket(cx, &socket, buf, flags, context, source_addr)?;
         Ok(if flags.contains(ReceiveFlags::TRUNC) {
             received

--- a/litebox_shim_linux/src/syscalls/net.rs
+++ b/litebox_shim_linux/src/syscalls/net.rs
@@ -14,7 +14,7 @@ use alloc::sync::Arc;
 use litebox::{
     event::{
         Events, IOPollable,
-        polling::TryOpError,
+        polling::{Pollee, TryOpError},
         wait::{WaitContext, WaitError},
     },
     fd::EntryHandle,
@@ -26,6 +26,7 @@ use litebox::{
         socket_channel::{ChannelReadError, ChannelWriteError, NetworkProxy, SocketState},
     },
     platform::{Instant as _, page_mgmt::MemoryRegionPermissions},
+    sync::{Mutex, MutexGuard},
     utils::TruncateExt as _,
 };
 use litebox_common_linux::{
@@ -80,33 +81,41 @@ impl<Instant> ReceiveContext<Instant> {
     }
 }
 
-struct InetReceiveSocket<'a, Platform: ShimPlatform, FS: ShimFS> {
+pub(crate) struct InetSocketPin<'a, Platform: ShimPlatform, FS: ShimFS> {
     global: &'a GlobalState<Platform, FS>,
     entry: Option<EntryHandle<Platform, litebox::net::Network<Platform>>>,
-    state: SocketReceiveState,
+    state: SocketIoState,
     proxy: Arc<NetworkProxy<Platform>>,
     recv_timeout: Option<core::time::Duration>,
+    send_timeout: Option<core::time::Duration>,
     is_nonblock: bool,
     socket_type: SockType,
+    recvmmsg_lock: SocketRecvmmsgLock<Platform>,
 }
 
-impl<Platform: ShimPlatform, FS: ShimFS> Drop for InetReceiveSocket<'_, Platform, FS> {
+impl<Platform: ShimPlatform, FS: ShimFS> InetSocketPin<'_, Platform, FS> {
+    pub(crate) fn is_broker_datagram(&self) -> bool {
+        matches!(self.proxy.as_ref(), NetworkProxy::BrokerDatagram(_))
+    }
+}
+
+impl<Platform: ShimPlatform, FS: ShimFS> Drop for InetSocketPin<'_, Platform, FS> {
     fn drop(&mut self) {
         drop(self.entry.take());
         let previous = self
             .state
             .0
             .fetch_sub(1, core::sync::atomic::Ordering::AcqRel);
-        let active_pins = previous & SOCKET_RECEIVE_PIN_COUNT_MASK;
-        assert_ne!(active_pins, 0, "receive pin count underflow");
-        if active_pins != 1 || previous & SOCKET_RECEIVE_CLOSE_PENDING == 0 {
+        let active_pins = previous & SOCKET_IO_PIN_COUNT_MASK;
+        assert_ne!(active_pins, 0, "socket I/O pin count underflow");
+        if active_pins != 1 || previous & SOCKET_IO_CLOSE_PENDING == 0 {
             return;
         }
         let mut net = self.global.net.lock();
         let pending = net.finish_deferred_closes();
         if !pending {
             self.state.0.fetch_and(
-                !SOCKET_RECEIVE_CLOSE_PENDING,
+                !SOCKET_IO_CLOSE_PENDING,
                 core::sync::atomic::Ordering::Release,
             );
         }
@@ -114,11 +123,27 @@ impl<Platform: ShimPlatform, FS: ShimFS> Drop for InetReceiveSocket<'_, Platform
 }
 
 enum ReceiveSocket<'a, Platform: ShimPlatform, FS: ShimFS> {
-    Inet(InetReceiveSocket<'a, Platform, FS>),
+    Inet(InetSocketPin<'a, Platform, FS>),
     Unix(EntryHandle<Platform, UnixSocketSubsystem<Platform, FS>>),
 }
 
 impl<Platform: ShimPlatform, FS: ShimFS> super::file::FilesState<Platform, FS> {
+    pub(crate) fn try_pin_inet_socket<'a>(
+        &self,
+        global: &'a GlobalState<Platform, FS>,
+        raw_fd: usize,
+    ) -> Result<Option<InetSocketPin<'a, Platform, FS>>, Errno> {
+        let rds = self.raw_descriptor_store.read();
+        let fd = match rds.fd_from_raw_integer(raw_fd) {
+            Ok(fd) => fd,
+            Err(litebox::fd::ErrRawIntFd::NotFound) => return Err(Errno::EBADF),
+            Err(litebox::fd::ErrRawIntFd::InvalidSubsystem) => return Ok(None),
+        };
+        let socket = global.pin_socket(&fd)?;
+        drop(rds);
+        Ok(Some(socket))
+    }
+
     /// Helper to dispatch socket operations based on socket type (INET vs Unix).
     ///
     /// This method handles the common pattern of:
@@ -168,7 +193,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> super::file::FilesState<Platform, FS> {
         let raw_fd = sockfd as usize;
         let rds = self.raw_descriptor_store.read();
         if let Ok(fd) = rds.fd_from_raw_integer(raw_fd) {
-            let socket = ReceiveSocket::Inet(global.pin_receive_socket(&fd)?);
+            let socket = ReceiveSocket::Inet(global.pin_socket(&fd)?);
             drop(rds);
             return Ok(socket);
         }
@@ -265,10 +290,66 @@ pub(super) struct SocketOptions {
 pub(crate) struct SocketOFlags(pub OFlags);
 pub(crate) struct SocketProxy<Platform: ShimPlatform>(pub Arc<NetworkProxy<Platform>>);
 #[derive(Clone)]
-struct SocketReceiveState(Arc<core::sync::atomic::AtomicUsize>);
+struct SocketIoState(Arc<core::sync::atomic::AtomicUsize>);
+struct SocketRecvmmsgLock<Platform: ShimPlatform>(Arc<RecvmmsgLock<Platform>>);
 
-const SOCKET_RECEIVE_CLOSE_PENDING: usize = 1 << (usize::BITS - 1);
-const SOCKET_RECEIVE_PIN_COUNT_MASK: usize = SOCKET_RECEIVE_CLOSE_PENDING - 1;
+struct RecvmmsgLock<Platform: ShimPlatform> {
+    mutex: Mutex<Platform, ()>,
+    pollee: Pollee<Platform>,
+}
+
+struct RecvmmsgGuard<'a, Platform: ShimPlatform> {
+    guard: Option<MutexGuard<'a, Platform, ()>>,
+    lock: &'a RecvmmsgLock<Platform>,
+}
+
+impl<Platform: ShimPlatform> RecvmmsgLock<Platform> {
+    fn new() -> Self {
+        Self {
+            mutex: Mutex::new(()),
+            pollee: Pollee::new(),
+        }
+    }
+
+    fn try_lock(&self) -> Option<RecvmmsgGuard<'_, Platform>> {
+        Some(RecvmmsgGuard {
+            guard: Some(self.mutex.try_lock()?),
+            lock: self,
+        })
+    }
+
+    fn lock_interruptibly(
+        &self,
+        cx: &WaitContext<'_, Platform>,
+    ) -> Result<RecvmmsgGuard<'_, Platform>, Errno> {
+        cx.wait_on_events(
+            false,
+            Events::IN,
+            |observer, filter| {
+                self.pollee.register_observer(observer, filter);
+                Ok(())
+            },
+            || self.try_lock().ok_or(TryOpError::TryAgain),
+        )
+        .map_err(socket_io_errno)
+    }
+}
+
+impl<Platform: ShimPlatform> Drop for RecvmmsgGuard<'_, Platform> {
+    fn drop(&mut self) {
+        drop(self.guard.take());
+        self.lock.pollee.notify_observers(Events::IN);
+    }
+}
+
+impl<Platform: ShimPlatform> Clone for SocketRecvmmsgLock<Platform> {
+    fn clone(&self) -> Self {
+        Self(Arc::clone(&self.0))
+    }
+}
+
+const SOCKET_IO_CLOSE_PENDING: usize = 1 << (usize::BITS - 1);
+const SOCKET_IO_PIN_COUNT_MASK: usize = SOCKET_IO_CLOSE_PENDING - 1;
 
 impl<Platform: ShimPlatform> Clone for SocketProxy<Platform> {
     fn clone(&self) -> Self {
@@ -302,13 +383,18 @@ impl<Platform: ShimPlatform, FS: ShimFS> GlobalState<Platform, FS> {
             let old = dt.set_fd_metadata(fd, litebox_common_linux::FileDescriptorFlags::FD_CLOEXEC);
             assert!(old.is_none());
         }
-        let old = dt.set_fd_metadata(fd, sock_type);
+        let old = dt.set_entry_metadata(fd, sock_type);
         assert!(old.is_none());
         let old = dt.set_entry_metadata(fd, SocketOFlags(status));
         assert!(old.is_none());
         let old = dt.set_entry_metadata(
             fd,
-            SocketReceiveState(Arc::new(core::sync::atomic::AtomicUsize::new(0))),
+            SocketIoState(Arc::new(core::sync::atomic::AtomicUsize::new(0))),
+        );
+        assert!(old.is_none());
+        let old = dt.set_entry_metadata(
+            fd,
+            SocketRecvmmsgLock(Arc::new(RecvmmsgLock::<Platform>::new())),
         );
         assert!(old.is_none());
         drop(dt);
@@ -920,14 +1006,19 @@ impl<Platform: ShimPlatform, FS: ShimFS> GlobalState<Platform, FS> {
         context: ReceiveContext<Platform::Instant>,
         source_addr: Option<&mut Option<SocketAddr>>,
     ) -> Result<usize, Errno> {
-        let socket = self.pin_receive_socket(fd)?;
-        self.receive_from_socket(cx, &socket, buf, flags, context, source_addr)
+        let socket = self.pin_socket(fd)?;
+        let received = self.receive_from_socket(cx, &socket, buf, flags, context, source_addr)?;
+        Ok(if flags.contains(ReceiveFlags::TRUNC) {
+            received
+        } else {
+            received.min(buf.len())
+        })
     }
 
-    fn pin_receive_socket(
+    pub(crate) fn pin_socket(
         &self,
         fd: &SocketFd<Platform>,
-    ) -> Result<InetReceiveSocket<'_, Platform, FS>, Errno> {
+    ) -> Result<InetSocketPin<'_, Platform, FS>, Errno> {
         let descriptor_table = self.litebox.descriptor_table();
         let entry = descriptor_table.entry_handle(fd).ok_or(Errno::EBADF)?;
         let proxy = descriptor_table
@@ -936,8 +1027,10 @@ impl<Platform: ShimPlatform, FS: ShimFS> GlobalState<Platform, FS> {
                 litebox::fd::MetadataError::NoSuchMetadata => unreachable!(),
                 litebox::fd::MetadataError::ClosedFd => Errno::EBADF,
             })?;
-        let recv_timeout = descriptor_table
-            .with_metadata(fd, |options: &SocketOptions| options.recv_timeout)
+        let (recv_timeout, send_timeout) = descriptor_table
+            .with_metadata(fd, |options: &SocketOptions| {
+                (options.recv_timeout, options.send_timeout)
+            })
             .map_err(|error| match error {
                 litebox::fd::MetadataError::NoSuchMetadata => unreachable!(),
                 litebox::fd::MetadataError::ClosedFd => Errno::EBADF,
@@ -955,33 +1048,41 @@ impl<Platform: ShimPlatform, FS: ShimFS> GlobalState<Platform, FS> {
                 litebox::fd::MetadataError::ClosedFd => Errno::EBADF,
             })?;
         let state = descriptor_table
-            .with_metadata(fd, |state: &SocketReceiveState| state.clone())
+            .with_metadata(fd, |state: &SocketIoState| state.clone())
+            .map_err(|error| match error {
+                litebox::fd::MetadataError::NoSuchMetadata => unreachable!(),
+                litebox::fd::MetadataError::ClosedFd => Errno::EBADF,
+            })?;
+        let recvmmsg_lock = descriptor_table
+            .with_metadata(fd, |lock: &SocketRecvmmsgLock<Platform>| lock.clone())
             .map_err(|error| match error {
                 litebox::fd::MetadataError::NoSuchMetadata => unreachable!(),
                 litebox::fd::MetadataError::ClosedFd => Errno::EBADF,
             })?;
         let previous = state.0.fetch_add(1, core::sync::atomic::Ordering::AcqRel);
         assert_ne!(
-            previous & SOCKET_RECEIVE_PIN_COUNT_MASK,
-            SOCKET_RECEIVE_PIN_COUNT_MASK,
-            "receive pin count overflow"
+            previous & SOCKET_IO_PIN_COUNT_MASK,
+            SOCKET_IO_PIN_COUNT_MASK,
+            "socket I/O pin count overflow"
         );
         drop(descriptor_table);
-        Ok(InetReceiveSocket {
+        Ok(InetSocketPin {
             global: self,
             entry: Some(entry),
             state,
             proxy,
             recv_timeout,
+            send_timeout,
             is_nonblock,
             socket_type,
+            recvmmsg_lock,
         })
     }
 
-    fn receive_from_socket(
+    pub(crate) fn receive_from_socket(
         &self,
         cx: &WaitContext<'_, Platform>,
-        socket: &InetReceiveSocket<'_, Platform, FS>,
+        socket: &InetSocketPin<'_, Platform, FS>,
         buf: &mut [u8],
         flags: ReceiveFlags,
         context: ReceiveContext<Platform::Instant>,
@@ -1069,6 +1170,11 @@ impl<Platform: ShimPlatform, FS: ShimFS> GlobalState<Platform, FS> {
                             return Ok(received);
                         }
                     }
+                    Err(ChannelReadError::ReadShutdown)
+                        if is_nonblock && matches!(socket_type, SockType::Datagram) =>
+                    {
+                        return Err(TryOpError::TryAgain);
+                    }
                     Err(ChannelReadError::ReadShutdown) => return Ok(received),
                     Err(ChannelReadError::WouldBlock) => return Err(TryOpError::TryAgain),
                     Err(ChannelReadError::ConnectionClosed) => {
@@ -1119,11 +1225,47 @@ impl<Platform: ShimPlatform, FS: ShimFS> GlobalState<Platform, FS> {
                     Err(ChannelReadError::WouldBlock) => Err(socket_io_errno(error)),
                 }
             }
+
             Err(error) => Err(socket_io_errno(error)),
         }
     }
 
-    fn get_socket_type(&self, fd: &SocketFd<Platform>) -> Result<SockType, Errno> {
+    pub(crate) fn send_to_pinned_socket(
+        &self,
+        cx: &WaitContext<'_, Platform>,
+        socket: &InetSocketPin<'_, Platform, FS>,
+        buf: &[u8],
+        flags: SendFlags,
+    ) -> Result<usize, Errno> {
+        let new_flags = convert_flags!(
+            flags,
+            SendFlags,
+            litebox::net::SendFlags,
+            CONFIRM,
+            DONTROUTE,
+            EOR,
+            MORE,
+            OOB,
+        );
+        cx.with_timeout(socket.send_timeout)
+            .wait_on_events(
+                socket.is_nonblock || flags.contains(SendFlags::DONTWAIT),
+                Events::OUT,
+                |observer, filter| {
+                    socket.proxy.register_observer(observer, filter);
+                    Ok(())
+                },
+                || match socket.proxy.try_write(buf, new_flags, None) {
+                    Ok(0) if buf.is_empty() => Ok(0),
+                    Ok(0) | Err(ChannelWriteError::BufferFull) => Err(TryOpError::TryAgain),
+                    Ok(n) => Ok(n),
+                    Err(error) => Err(TryOpError::Other(Errno::from(error))),
+                },
+            )
+            .map_err(socket_io_errno)
+    }
+
+    pub(crate) fn get_socket_type(&self, fd: &SocketFd<Platform>) -> Result<SockType, Errno> {
         self.litebox
             .descriptor_table()
             .with_metadata(fd, |sock_type: &SockType| *sock_type)
@@ -1198,22 +1340,22 @@ impl<Platform: ShimPlatform, FS: ShimFS> GlobalState<Platform, FS> {
         let state = self
             .litebox
             .descriptor_table()
-            .with_metadata(fd, |state: &SocketReceiveState| state.clone())
+            .with_metadata(fd, |state: &SocketIoState| state.clone())
             .map_err(|_| litebox::net::errors::CloseError::InvalidFd)?;
         state.0.fetch_or(
-            SOCKET_RECEIVE_CLOSE_PENDING,
+            SOCKET_IO_CLOSE_PENDING,
             core::sync::atomic::Ordering::AcqRel,
         );
         let mut net = self.net.lock();
         state.0.fetch_or(
-            SOCKET_RECEIVE_CLOSE_PENDING,
+            SOCKET_IO_CLOSE_PENDING,
             core::sync::atomic::Ordering::AcqRel,
         );
         let result = net.close(fd, behavior);
         let pending = net.finish_deferred_closes();
         if !pending {
             state.0.fetch_and(
-                !SOCKET_RECEIVE_CLOSE_PENDING,
+                !SOCKET_IO_CLOSE_PENDING,
                 core::sync::atomic::Ordering::Release,
             );
         }
@@ -1746,10 +1888,15 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         flags: SendFlags,
         sockaddr: Option<SocketAddress>,
     ) -> Result<usize, Errno> {
+        let is_inet_datagram = core::cell::Cell::new(false);
         let res = self.files.borrow().with_socket(
             &self.global,
             sockfd,
             |fd| {
+                is_inet_datagram.set(matches!(
+                    self.global.get_socket_type(fd)?,
+                    SockType::Datagram
+                ));
                 let sockaddr = sockaddr
                     .clone()
                     .map(|addr| addr.inet().ok_or(Errno::EAFNOSUPPORT))
@@ -1767,6 +1914,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         );
         if let Err(Errno::EPIPE) = res
             && !flags.contains(SendFlags::NOSIGNAL)
+            && !is_inet_datagram.get()
         {
             self.send_signal(Signal::SIGPIPE, signal::siginfo_kill(Signal::SIGPIPE));
         }
@@ -1817,10 +1965,15 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                     .ok_or(Errno::EFAULT)?,
             )
         };
+        let is_inet_datagram = core::cell::Cell::new(false);
         let res = self.files.borrow().with_socket(
             &self.global,
             sockfd,
             |fd| {
+                is_inet_datagram.set(matches!(
+                    self.global.get_socket_type(fd)?,
+                    SockType::Datagram
+                ));
                 let sock_addr = sock_addr
                     .clone()
                     .map(|addr| addr.inet().ok_or(Errno::EAFNOSUPPORT))
@@ -1840,6 +1993,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         );
         if let Err(Errno::EPIPE) = res
             && !flags.contains(SendFlags::NOSIGNAL)
+            && !is_inet_datagram.get()
         {
             self.send_signal(Signal::SIGPIPE, signal::siginfo_kill(Signal::SIGPIPE));
         }
@@ -2380,7 +2534,6 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         // A `None` deadline means either no user-supplied timeout or a saturating overflow
         // — both are treated as "no deadline".
         let deadline = timeout_duration.and_then(|d| self.global.platform.now().checked_add(d));
-
         let stride = size_of::<UserMmsgHdr>();
         let msg_len_off = offset_of!(UserMmsgHdr, msg_len);
         let msgvec_base = msgvec.as_usize();
@@ -2388,6 +2541,24 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         if msgvec_base.checked_add(msgvec_len).is_none() {
             return Err(Errno::EFAULT);
         }
+
+        let _recvmmsg = if vlen <= 1 {
+            None
+        } else {
+            match &socket {
+                ReceiveSocket::Inet(socket)
+                    if timeout_duration.is_some()
+                        || flags.contains(ReceiveFlags::DONTWAIT)
+                        || socket.is_nonblock =>
+                {
+                    Some(socket.recvmmsg_lock.0.try_lock().ok_or(Errno::EAGAIN)?)
+                }
+                ReceiveSocket::Inet(socket) => {
+                    Some(socket.recvmmsg_lock.0.lock_interruptibly(&self.wait_cx())?)
+                }
+                ReceiveSocket::Unix(_) => None,
+            }
+        };
 
         // WAITFORONE is mmsg-only; the inner recvmsg doesn't recognize it.
         let waitforone = flags.contains(ReceiveFlags::WAITFORONE);
@@ -2680,7 +2851,7 @@ mod tests {
     }
 
     #[test]
-    fn dropping_inet_receive_pin_reaps_deferred_close() {
+    fn dropping_inet_socket_pin_reaps_deferred_close() {
         let task = init_platform(None);
         let fd = task
             .do_socket(AddressFamily::INET, SockType::Stream, SockFlags::empty(), 0)
@@ -2697,13 +2868,151 @@ mod tests {
 
         close_socket(&task, fd);
         assert!(
-            state.0.load(core::sync::atomic::Ordering::Acquire)
-                & super::SOCKET_RECEIVE_CLOSE_PENDING
+            state.0.load(core::sync::atomic::Ordering::Acquire) & super::SOCKET_IO_CLOSE_PENDING
                 != 0
         );
 
         drop(socket);
         assert_eq!(state.0.load(core::sync::atomic::Ordering::Acquire), 0);
+    }
+
+    #[test]
+    fn socket_io_pin_keeps_backend_alive_for_send_after_close() {
+        let task = init_platform(None);
+        let fd = task
+            .do_socket(
+                AddressFamily::INET,
+                SockType::Datagram,
+                SockFlags::NONBLOCK,
+                0,
+            )
+            .unwrap();
+        let socket = task
+            .files
+            .borrow()
+            .pin_receive_socket(&task.global, fd)
+            .unwrap();
+        let state = match &socket {
+            super::ReceiveSocket::Inet(socket) => socket.state.clone(),
+            super::ReceiveSocket::Unix(_) => unreachable!(),
+        };
+
+        close_socket(&task, fd);
+        assert!(
+            state.0.load(core::sync::atomic::Ordering::Acquire) & super::SOCKET_IO_CLOSE_PENDING
+                != 0
+        );
+        let result = match &socket {
+            super::ReceiveSocket::Inet(socket) => task.global.send_to_pinned_socket(
+                &task.wait_cx(),
+                socket,
+                b"pinned",
+                SendFlags::empty(),
+            ),
+            super::ReceiveSocket::Unix(_) => unreachable!(),
+        };
+        assert_eq!(result, Err(Errno::EDESTADDRREQ));
+
+        drop(socket);
+        assert_eq!(state.0.load(core::sync::atomic::Ordering::Acquire), 0);
+    }
+
+    #[test]
+    fn raw_inet_socket_pin_does_not_follow_dup2_replacement() {
+        let task = init_platform(None);
+        let old_fd = task
+            .do_socket(
+                AddressFamily::INET,
+                SockType::Datagram,
+                SockFlags::NONBLOCK,
+                0,
+            )
+            .unwrap();
+        let new_fd = task
+            .do_socket(
+                AddressFamily::INET,
+                SockType::Datagram,
+                SockFlags::NONBLOCK,
+                0,
+            )
+            .unwrap();
+        let old_socket = task
+            .files
+            .borrow()
+            .try_pin_inet_socket(&task.global, old_fd as usize)
+            .unwrap()
+            .unwrap();
+        let old_state = old_socket.state.clone();
+        let new_socket = task
+            .files
+            .borrow()
+            .try_pin_inet_socket(&task.global, new_fd as usize)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            task.sys_dup(
+                new_fd.try_into().unwrap(),
+                Some(old_fd.try_into().unwrap()),
+                None,
+            )
+            .unwrap(),
+            old_fd
+        );
+        assert!(
+            old_state.0.load(core::sync::atomic::Ordering::Acquire)
+                & super::SOCKET_IO_CLOSE_PENDING
+                != 0
+        );
+        let replacement = task
+            .files
+            .borrow()
+            .try_pin_inet_socket(&task.global, old_fd as usize)
+            .unwrap()
+            .unwrap();
+        assert!(alloc::sync::Arc::ptr_eq(
+            &replacement.proxy,
+            &new_socket.proxy
+        ));
+        assert!(!alloc::sync::Arc::ptr_eq(
+            &replacement.proxy,
+            &old_socket.proxy
+        ));
+
+        drop(old_socket);
+        assert_eq!(old_state.0.load(core::sync::atomic::Ordering::Acquire), 0);
+        drop(replacement);
+        drop(new_socket);
+        close_socket(&task, old_fd);
+        close_socket(&task, new_fd);
+    }
+
+    #[test]
+    fn recvmmsg_lock_wakes_contended_waiter() {
+        let task = init_platform(None);
+        let lock = alloc::sync::Arc::new(super::RecvmmsgLock::new());
+        let guard = lock.try_lock().unwrap();
+        let (started_tx, started_rx) = std::sync::mpsc::channel();
+        let (acquired_tx, acquired_rx) = std::sync::mpsc::channel();
+        let worker_lock = alloc::sync::Arc::clone(&lock);
+        task.spawn_clone_for_test(move |task| {
+            started_tx.send(()).unwrap();
+            let _guard = worker_lock.lock_interruptibly(&task.wait_cx()).unwrap();
+            acquired_tx.send(()).unwrap();
+        });
+
+        started_rx
+            .recv_timeout(core::time::Duration::from_secs(1))
+            .unwrap();
+        assert!(
+            acquired_rx
+                .recv_timeout(core::time::Duration::from_millis(20))
+                .is_err()
+        );
+        drop(guard);
+        acquired_rx
+            .recv_timeout(core::time::Duration::from_secs(1))
+            .unwrap();
     }
 
     #[test]

--- a/litebox_shim_linux/src/syscalls/net.rs
+++ b/litebox_shim_linux/src/syscalls/net.rs
@@ -2547,14 +2547,13 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         } else {
             match &socket {
                 ReceiveSocket::Inet(socket)
-                    if timeout_duration.is_some()
-                        || flags.contains(ReceiveFlags::DONTWAIT)
-                        || socket.is_nonblock =>
+                    if flags.contains(ReceiveFlags::DONTWAIT) || socket.is_nonblock =>
                 {
                     Some(socket.recvmmsg_lock.0.try_lock().ok_or(Errno::EAGAIN)?)
                 }
                 ReceiveSocket::Inet(socket) => {
-                    Some(socket.recvmmsg_lock.0.lock_interruptibly(&self.wait_cx())?)
+                    let wait_cx = self.wait_cx().with_deadline(deadline);
+                    Some(socket.recvmmsg_lock.0.lock_interruptibly(&wait_cx)?)
                 }
                 ReceiveSocket::Unix(_) => None,
             }
@@ -3013,6 +3012,22 @@ mod tests {
         acquired_rx
             .recv_timeout(core::time::Duration::from_secs(1))
             .unwrap();
+    }
+
+    #[test]
+    fn recvmmsg_lock_honors_wait_deadline() {
+        let task = init_platform(None);
+        let lock = super::RecvmmsgLock::new();
+        let guard = lock.try_lock().unwrap();
+        let wait_cx = task
+            .wait_cx()
+            .with_timeout(core::time::Duration::from_millis(20));
+
+        assert!(matches!(
+            lock.lock_interruptibly(&wait_cx),
+            Err(Errno::EAGAIN)
+        ));
+        drop(guard);
     }
 
     #[test]


### PR DESCRIPTION
This PR adds Linux guest support for broker-owned IPv4 UDP sockets, routing socket lifecycle and datagram I/O through the broker while preserving Linux syscall behavior.