### PR TITLE
Fix forced signal delivery

### DIFF
--- a/litebox_common_linux/src/signal/mod.rs
+++ b/litebox_common_linux/src/signal/mod.rs
@@ -319,6 +319,10 @@ pub const SI_TKILL: i32 = -6;
 pub const SI_DETHREAD: i32 = -7;
 pub const SI_ASYNCNL: i32 = -60;
 
+pub const ILL_ILLOPN: i32 = 2;
+
+pub const FPE_INTDIV: i32 = 1;
+
 #[cfg(target_arch = "x86_64")]
 #[repr(C)]
 #[derive(Clone, FromBytes, IntoBytes)]

--- a/litebox_shim_linux/src/lib.rs
+++ b/litebox_shim_linux/src/lib.rs
@@ -170,7 +170,9 @@ impl<Platform: ShimPlatform, FS: ShimFS> litebox::shim::EnterShim
                 return ContinueOperation::Terminate;
             }
         }
-        self.enter_shim(false, ctx, |task, _ctx| task.handle_exception_request(info))
+        self.enter_shim(false, ctx, |task, ctx| {
+            task.handle_exception_request(info, ctx);
+        })
     }
 
     fn interrupt(&self, ctx: &mut Self::ExecutionContext) -> ContinueOperation {

--- a/litebox_shim_linux/src/syscalls/signal/mod.rs
+++ b/litebox_shim_linux/src/syscalls/signal/mod.rs
@@ -712,7 +712,10 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
     }
 
     fn force_signal_with_info(&self, signal: Signal, force_exit: bool, siginfo: Siginfo) {
-        assert!(matches!(signal, Signal::SIGKILL | Signal::SIGSEGV));
+        assert!(matches!(
+            signal,
+            Signal::SIGKILL | Signal::SIGSEGV | Signal::SIGFPE | Signal::SIGTRAP | Signal::SIGILL
+        ));
 
         self.signals
             .pending

--- a/litebox_shim_linux/src/syscalls/signal/mod.rs
+++ b/litebox_shim_linux/src/syscalls/signal/mod.rs
@@ -18,8 +18,8 @@ use alloc::sync::Arc;
 use core::cell::{Cell, RefCell};
 use litebox::{shim::Exception, sync::Mutex, utils::ReinterpretUnsignedExt as _};
 use litebox_common_linux::signal::{
-    MINSIGSTKSZ, NSIG, SI_KERNEL, SI_USER, SIG_DFL, SIG_IGN, SaFlags, SigAction, SigAltStack,
-    SigSet, Siginfo, SiginfoData, SigmaskHow, Signal, SsFlags, Ucontext,
+    FPE_INTDIV, ILL_ILLOPN, MINSIGSTKSZ, NSIG, SI_KERNEL, SI_USER, SIG_DFL, SIG_IGN, SaFlags,
+    SigAction, SigAltStack, SigSet, Siginfo, SiginfoData, SigmaskHow, Signal, SsFlags, Ucontext,
 };
 use litebox_common_linux::{PtRegs, errno::Errno};
 
@@ -245,7 +245,7 @@ impl PendingSignals {
         }
 
         // Restrict maximum queued signals via rlimits when Linux would do so.
-        if signal.is_rt_signal() || (siginfo.code != SI_USER && siginfo.code != SI_KERNEL) {
+        if signal.is_rt_signal() || siginfo.code < 0 {
             let limit = rlimits.get_rlimit_cur(litebox_common_linux::RlimitResource::SIGPENDING);
             if self.queue.len() >= limit {
                 // Drop the signal.
@@ -269,10 +269,17 @@ fn is_on_stack(stack: &SigAltStack, sp: usize) -> bool {
 
 /// Creates a `Siginfo` for an exception signal.
 fn siginfo_exception(signal: Signal, fault_address: usize) -> Siginfo {
+    // TODO: Extend ExceptionInfo with architecture-specific cause details,
+    // then use them in handle_exception_request to select the precise si_code.
+    let code = match signal {
+        Signal::SIGFPE => FPE_INTDIV,
+        Signal::SIGILL => ILL_ILLOPN,
+        _ => SI_KERNEL,
+    };
     Siginfo {
         signo: signal.as_i32(),
         errno: 0,
-        code: SI_KERNEL,
+        code,
         #[cfg(target_arch = "x86_64")]
         __pad: 0,
         data: SiginfoData::new_addr(fault_address),
@@ -557,6 +564,11 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         thread | shared
     }
 
+    #[cfg(test)]
+    pub(crate) fn take_pending_siginfo(&self, signal: Signal) -> Siginfo {
+        self.signals.pending.borrow_mut().remove(signal)
+    }
+
     /// Deliver any pending signals.
     pub(crate) fn process_signals(&self, ctx: &mut PtRegs) {
         loop {
@@ -746,20 +758,20 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         }
     }
 
-    pub(crate) fn handle_exception_request(&self, info: &litebox::shim::ExceptionInfo) {
-        let signal = match info.exception {
-            Exception::DIVIDE_ERROR => Signal::SIGFPE,
-            Exception::BREAKPOINT => Signal::SIGTRAP,
-            Exception::INVALID_OPCODE => Signal::SIGILL,
+    pub(crate) fn handle_exception_request(
+        &self,
+        info: &litebox::shim::ExceptionInfo,
+        ctx: &PtRegs,
+    ) {
+        let pc = arch::pc(ctx);
+        let (signal, fault_address) = match info.exception {
+            Exception::DIVIDE_ERROR => (Signal::SIGFPE, pc),
+            Exception::BREAKPOINT => (Signal::SIGTRAP, 0),
+            Exception::INVALID_OPCODE => (Signal::SIGILL, pc),
+            Exception::PAGE_FAULT => (Signal::SIGSEGV, info.cr2),
             // Page faults and unknown exceptions map to SIGSEGV. There may be
             // more appropriate signals in some other cases (e.g., SIGBUS).
-            _ => Signal::SIGSEGV,
-        };
-        // For page faults, provide the faulting address.
-        let fault_address = if info.exception == Exception::PAGE_FAULT {
-            info.cr2
-        } else {
-            0
+            _ => (Signal::SIGSEGV, 0),
         };
         self.signals.last_exception.set(*info);
         self.force_signal_with_info(signal, false, siginfo_exception(signal, fault_address));

--- a/litebox_shim_linux/src/syscalls/signal/mod.rs
+++ b/litebox_shim_linux/src/syscalls/signal/mod.rs
@@ -707,7 +707,10 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
     }
 
     fn force_signal_with_info(&self, signal: Signal, force_exit: bool, siginfo: Siginfo) {
-        assert!(matches!(signal, Signal::SIGKILL | Signal::SIGSEGV));
+        assert!(matches!(
+            signal,
+            Signal::SIGKILL | Signal::SIGSEGV | Signal::SIGFPE | Signal::SIGTRAP | Signal::SIGILL
+        ));
 
         self.signals
             .pending

--- a/litebox_shim_linux/src/syscalls/signal/x86_64.rs
+++ b/litebox_shim_linux/src/syscalls/signal/x86_64.rs
@@ -28,6 +28,10 @@ pub(super) fn sp(ctx: &PtRegs) -> usize {
     ctx.rsp
 }
 
+pub(super) fn pc(ctx: &PtRegs) -> usize {
+    ctx.rip
+}
+
 pub(super) fn get_signal_frame(sp: usize, _action: &SigAction) -> usize {
     let mut frame_addr = sp;
 

--- a/litebox_shim_linux/src/syscalls/tests.rs
+++ b/litebox_shim_linux/src/syscalls/tests.rs
@@ -10,7 +10,9 @@ use crate::UserPtrMut;
 #[cfg(target_arch = "x86_64")]
 use litebox::shim::{Exception, ExceptionInfo};
 #[cfg(target_arch = "x86_64")]
-use litebox_common_linux::signal::Signal;
+use litebox_common_linux::PtRegs;
+#[cfg(target_arch = "x86_64")]
+use litebox_common_linux::signal::{FPE_INTDIV, ILL_ILLOPN, SI_KERNEL, SiginfoData, Signal};
 
 extern crate std;
 
@@ -86,20 +88,44 @@ pub(crate) fn init_platform(
 #[cfg(target_arch = "x86_64")]
 #[test]
 fn exceptions_queue_their_corresponding_signals() {
-    let task = init_platform(None);
+    const FAULT_PC: usize = 0x4444_0000;
 
-    for (exception, signal) in [
-        (Exception::DIVIDE_ERROR, Signal::SIGFPE),
-        (Exception::BREAKPOINT, Signal::SIGTRAP),
-        (Exception::INVALID_OPCODE, Signal::SIGILL),
+    let task = init_platform(None);
+    let ctx = PtRegs {
+        rip: FAULT_PC,
+        ..Default::default()
+    };
+
+    for (exception, signal, code, addr) in [
+        (
+            Exception::DIVIDE_ERROR,
+            Signal::SIGFPE,
+            FPE_INTDIV,
+            FAULT_PC,
+        ),
+        (Exception::BREAKPOINT, Signal::SIGTRAP, SI_KERNEL, 0),
+        (
+            Exception::INVALID_OPCODE,
+            Signal::SIGILL,
+            ILL_ILLOPN,
+            FAULT_PC,
+        ),
     ] {
-        task.handle_exception_request(&ExceptionInfo {
-            exception,
-            error_code: 0,
-            cr2: 0,
-            kernel_mode: false,
-        });
-        assert!(task.pending_signal_set().contains(signal));
+        task.handle_exception_request(
+            &ExceptionInfo {
+                exception,
+                error_code: 0,
+                cr2: 0,
+                kernel_mode: false,
+            },
+            &ctx,
+        );
+
+        let siginfo = task.take_pending_siginfo(signal);
+        assert_eq!(siginfo.code, code);
+        let actual_data = siginfo.data.pad;
+        let expected_data = SiginfoData::new_addr(addr).pad;
+        assert_eq!(actual_data, expected_data);
     }
 }
 

--- a/litebox_shim_linux/src/syscalls/tests.rs
+++ b/litebox_shim_linux/src/syscalls/tests.rs
@@ -7,6 +7,11 @@ use zerocopy::FromBytes as _;
 
 use crate::UserPtrMut;
 
+#[cfg(target_arch = "x86_64")]
+use litebox::shim::{Exception, ExceptionInfo};
+#[cfg(target_arch = "x86_64")]
+use litebox_common_linux::signal::Signal;
+
 extern crate std;
 
 const TEST_TAR_FILE: &[u8] = include_bytes!("../../../litebox/src/fs/test.tar");
@@ -76,6 +81,26 @@ pub(crate) fn init_platform(
         });
     }
     task
+}
+
+#[cfg(target_arch = "x86_64")]
+#[test]
+fn exceptions_queue_their_corresponding_signals() {
+    let task = init_platform(None);
+
+    for (exception, signal) in [
+        (Exception::DIVIDE_ERROR, Signal::SIGFPE),
+        (Exception::BREAKPOINT, Signal::SIGTRAP),
+        (Exception::INVALID_OPCODE, Signal::SIGILL),
+    ] {
+        task.handle_exception_request(&ExceptionInfo {
+            exception,
+            error_code: 0,
+            cr2: 0,
+            kernel_mode: false,
+        });
+        assert!(task.pending_signal_set().contains(signal));
+    }
 }
 
 #[test]


### PR DESCRIPTION
This PR fixes forced delivery of a signal. Two issues fixed:
1. `handle_exception_request` covers `SIGFPE`, `SIGTRAP`, and `SIGILL`, but `force_signal_with_info` asserts the signal is `SIGKILL` or `SIGSEGV`.
2. `siginfo_exception` is used to return `SigInfo` with a fixed code (`SI_KERNEL`), ignoring other codes like `FPE_INTDIV` and `ILL_ILLOPN`.