### PR TITLE
Fix python test

### DIFF
--- a/litebox_runner_linux_userland/tests/run.rs
+++ b/litebox_runner_linux_userland/tests/run.rs
@@ -966,7 +966,8 @@ fn python_runner(unique_name: &str) -> Runner {
 
                 if source_path.is_dir() {
                     let python_lib_dst = out_dir.join(source_path.strip_prefix("/").unwrap());
-                    if !python_lib_dst.exists() {
+                    let stage_marker = python_lib_dst.join(".stage-complete.cache-checksum");
+                    if !stage_marker.exists() {
                         std::fs::create_dir_all(&python_lib_dst).unwrap();
                         println!(
                             "Copying python3 lib from {} to {}",
@@ -990,6 +991,7 @@ fn python_runner(unique_name: &str) -> Runner {
                                 std::str::from_utf8(output.stderr.as_slice()).unwrap_or("");
                             eprintln!("Warning: cp finished with errors (non-critical):\n{stderr}");
                         }
+                        std::fs::write(&stage_marker, b"").unwrap();
                     }
 
                     // Rewrite shared objects (.so, .so.1, .so.1.2.3, etc.) under the python lib directory.


### PR DESCRIPTION
Cherry-picks e7984422ce1aab181305ac7b9085c3e84e7bb27c to ulitebox.

Fixes Python runner tests failing with `ModuleNotFoundError` for encodings by using a cache-excluded completion marker for staged Python library directories.