### PR TITLE
Delegate TCP congestion support to socket backend

### DIFF
--- a/litebox_shim_linux/src/syscalls/net.rs
+++ b/litebox_shim_linux/src/syscalls/net.rs
@@ -635,10 +635,12 @@ impl<Platform: ShimPlatform, FS: ShimFS> GlobalState<Platform, FS> {
                     self.net.lock().set_tcp_option(
                         fd,
                         match name {
-                            "reno" | "cubic" => {
-                                log_unsupported!("enable {} for smoltcp?", name);
-                                return Err(Errno::EINVAL);
-                            }
+                            "reno" => litebox::net::TcpOptionData::CONGESTION(
+                                litebox::net::CongestionControl::Reno,
+                            ),
+                            "cubic" => litebox::net::TcpOptionData::CONGESTION(
+                                litebox::net::CongestionControl::Cubic,
+                            ),
                             "none" => litebox::net::TcpOptionData::CONGESTION(
                                 litebox::net::CongestionControl::None,
                             ),


### PR DESCRIPTION
This PR lets the LiteBox socket backend decide whether Reno or CUBIC congestion control is supported by translating recognized `TCP_CONGESTION` names in the shim, while continuing to reject unknown names with `EINVAL`.