### PR TITLE
Move broker socket payload buffers

### DIFF
--- a/litebox_broker_core/src/socket.rs
+++ b/litebox_broker_core/src/socket.rs
@@ -11,9 +11,9 @@ use litebox_broker_protocol::ObjectHandle;
 use litebox_broker_protocol::readiness::ReadinessFlags;
 use litebox_broker_protocol::socket::{
     CreateSocketRequest, IpProtocol, MAX_SOCKET_TRANSFER_SIZE, MAX_TCP_LISTEN_BACKLOG,
-    MAX_UDP_DATAGRAM_SIZE, ReceiveFlags, ReceiveFromFlags, ReceiveSocketResponse, SendFlags,
-    ShutdownMode, SocketConnectionStatus, SocketError, SocketOutcome, SocketStatusResponse,
-    SocketType, TcpOptionName, TcpOptionValue,
+    MAX_UDP_DATAGRAM_SIZE, ReceiveFlags, ReceiveFromFlags, SendFlags, ShutdownMode,
+    SocketConnectionStatus, SocketError, SocketOutcome, SocketStatusResponse, SocketType,
+    TcpOptionName, TcpOptionValue,
 };
 use spin::Once;
 
@@ -50,17 +50,6 @@ pub struct AcceptedBrokerSocket {
     pub local_address: SocketAddrV4,
     /// Remote endpoint of the accepted connection.
     pub remote_address: SocketAddrV4,
-}
-
-/// Platform result for one datagram receive.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct ReceivedPlatformDatagram {
-    /// Number of bytes copied into the caller's buffer.
-    pub received: usize,
-    /// Original datagram length before truncation.
-    pub datagram_length: usize,
-    /// Source address of the datagram.
-    pub source_address: SocketAddrV4,
 }
 
 /// Owned platform result for one stream receive.
@@ -138,16 +127,7 @@ pub trait PlatformSocket: Send + Sync {
     ///
     /// A temporarily full socket returns [`BrokerError::WouldBlock`]. Ordinary
     /// network failures return [`SocketOutcome::Failed`].
-    fn send(&self, data: &[u8], flags: SendFlags) -> Result<SocketOutcome<usize>>;
-
-    /// Sends owned bytes without waiting for platform readiness.
-    ///
-    /// Threaded implementations can override this method to move the payload
-    /// into their command queue. The default preserves compatibility with
-    /// slice-based platform implementations.
-    fn send_owned(&self, data: Vec<u8>, flags: SendFlags) -> Result<SocketOutcome<usize>> {
-        self.send(&data, flags)
-    }
+    fn send(&self, data: Vec<u8>, flags: SendFlags) -> Result<SocketOutcome<usize>>;
 
     /// Sends one complete datagram without waiting for platform readiness.
     ///
@@ -155,61 +135,23 @@ pub trait PlatformSocket: Send + Sync {
     /// the socket's connected peer. Partial successful sends are invalid.
     fn send_to(
         &self,
-        data: &[u8],
+        data: Vec<u8>,
         flags: SendFlags,
         destination: Option<SocketAddrV4>,
     ) -> Result<SocketOutcome<usize>>;
 
-    /// Sends one owned datagram without waiting for platform readiness.
-    fn send_to_owned(
-        &self,
-        data: Vec<u8>,
-        flags: SendFlags,
-        destination: Option<SocketAddrV4>,
-    ) -> Result<SocketOutcome<usize>> {
-        self.send_to(&data, flags, destination)
-    }
-
     /// Receives bytes without waiting for platform readiness.
     ///
     /// A temporarily empty socket returns [`BrokerError::WouldBlock`]. End of
-    /// stream returns [`ReceiveSocketResponse::EndOfStream`]; `Received(0)` is
-    /// reserved for a zero-length input buffer handled by the core.
+    /// stream returns [`PlatformStreamReceive::EndOfStream`]. The core handles
+    /// zero-length receives without invoking the platform.
     fn receive(
-        &self,
-        data: &mut [u8],
-        flags: ReceiveFlags,
-        peek_offset: u32,
-        peek_length: u32,
-    ) -> Result<SocketOutcome<ReceiveSocketResponse>>;
-
-    /// Receives bytes into an owned platform buffer without waiting.
-    fn receive_owned(
         &self,
         length: usize,
         flags: ReceiveFlags,
         peek_offset: u32,
         peek_length: u32,
-    ) -> Result<SocketOutcome<PlatformStreamReceive>> {
-        let mut data = zeroed_vec(length)?;
-        match self.receive(&mut data, flags, peek_offset, peek_length)? {
-            SocketOutcome::Completed(ReceiveSocketResponse::Received(received)) => {
-                let received = usize::try_from(received).map_err(|_| BrokerError::Internal)?;
-                if received > data.len() {
-                    return Err(BrokerError::Internal);
-                }
-                data.truncate(received);
-                Ok(SocketOutcome::Completed(PlatformStreamReceive::Received(
-                    data,
-                )))
-            }
-            SocketOutcome::Completed(ReceiveSocketResponse::EndOfStream) => {
-                Ok(SocketOutcome::Completed(PlatformStreamReceive::EndOfStream))
-            }
-            SocketOutcome::Completed(_) => Err(BrokerError::Internal),
-            SocketOutcome::Failed(error) => Ok(SocketOutcome::Failed(error)),
-        }
-    }
+    ) -> Result<SocketOutcome<PlatformStreamReceive>>;
 
     /// Receives one datagram without waiting for platform readiness.
     ///
@@ -217,32 +159,9 @@ pub trait PlatformSocket: Send + Sync {
     /// is smaller, and zero-length datagrams are successful receives.
     fn receive_from(
         &self,
-        data: &mut [u8],
-        flags: ReceiveFromFlags,
-    ) -> Result<SocketOutcome<ReceivedPlatformDatagram>>;
-
-    /// Receives one datagram into an owned platform buffer without waiting.
-    fn receive_from_owned(
-        &self,
         length: usize,
         flags: ReceiveFromFlags,
-    ) -> Result<SocketOutcome<PlatformDatagramReceive>> {
-        let mut data = zeroed_vec(length)?;
-        match self.receive_from(&mut data, flags)? {
-            SocketOutcome::Completed(received) => {
-                if received.received > data.len() {
-                    return Err(BrokerError::Internal);
-                }
-                data.truncate(received.received);
-                Ok(SocketOutcome::Completed(PlatformDatagramReceive {
-                    data,
-                    datagram_length: received.datagram_length,
-                    source_address: received.source_address,
-                }))
-            }
-            SocketOutcome::Failed(error) => Ok(SocketOutcome::Failed(error)),
-        }
-    }
+    ) -> Result<SocketOutcome<PlatformDatagramReceive>>;
 
     /// Shuts down one or both socket directions.
     fn shutdown(&self, mode: ShutdownMode) -> Result<SocketOutcome<()>>;
@@ -590,32 +509,6 @@ pub fn accept(
 pub fn send(
     session: &BrokerSession,
     handle: ObjectHandle,
-    data: &[u8],
-    flags: SendFlags,
-) -> Result<SocketOutcome<usize>> {
-    if flags.has_unsupported_bits() {
-        return Err(BrokerError::UnsupportedOperation);
-    }
-    let (resource, create_request, _) = socket_state(session, handle, ObjectRights::WRITE)?;
-    if !is_tcp(create_request) {
-        return Ok(SocketOutcome::Failed(SocketError::InvalidArgument));
-    }
-    let outcome = resource.send(data, flags)?;
-    if let SocketOutcome::Completed(sent) = outcome
-        && sent > data.len()
-    {
-        return Err(BrokerError::Internal);
-    }
-    Ok(outcome)
-}
-
-/// Sends owned bytes without waiting for readiness.
-///
-/// Ownership is passed through to the platform so threaded implementations can
-/// avoid copying the payload into a separate command buffer.
-pub fn send_owned(
-    session: &BrokerSession,
-    handle: ObjectHandle,
     data: Vec<u8>,
     flags: SendFlags,
 ) -> Result<SocketOutcome<usize>> {
@@ -627,7 +520,7 @@ pub fn send_owned(
     if !is_tcp(create_request) {
         return Ok(SocketOutcome::Failed(SocketError::InvalidArgument));
     }
-    let outcome = resource.send_owned(data, flags)?;
+    let outcome = resource.send(data, flags)?;
     if let SocketOutcome::Completed(sent) = outcome
         && sent > length
     {
@@ -640,13 +533,14 @@ pub fn send_owned(
 pub fn send_to(
     session: &BrokerSession,
     handle: ObjectHandle,
-    data: &[u8],
+    data: Vec<u8>,
     flags: SendFlags,
     destination: Option<SocketAddrV4>,
 ) -> Result<SocketOutcome<usize>> {
     if flags.has_unsupported_bits() || data.len() > MAX_UDP_DATAGRAM_SIZE as usize {
         return Err(BrokerError::UnsupportedOperation);
     }
+    let length = data.len();
     let (resource, create_request, connection_status) =
         socket_state(session, handle, ObjectRights::WRITE)?;
     if !is_udp(create_request) {
@@ -669,50 +563,6 @@ pub fn send_to(
     }
     let outcome = resource.send_to(data, flags, destination)?;
     if let SocketOutcome::Completed(sent) = outcome
-        && sent != data.len()
-    {
-        return Err(BrokerError::Internal);
-    }
-    Ok(outcome)
-}
-
-/// Sends one owned datagram without waiting for readiness.
-///
-/// Ownership is passed through to the platform so threaded implementations can
-/// avoid copying the payload into a separate command buffer.
-pub fn send_to_owned(
-    session: &BrokerSession,
-    handle: ObjectHandle,
-    data: Vec<u8>,
-    flags: SendFlags,
-    destination: Option<SocketAddrV4>,
-) -> Result<SocketOutcome<usize>> {
-    if flags.has_unsupported_bits() || data.len() > MAX_UDP_DATAGRAM_SIZE as usize {
-        return Err(BrokerError::UnsupportedOperation);
-    }
-    let length = data.len();
-    let (resource, create_request, connection_status) =
-        socket_state(session, handle, ObjectRights::WRITE)?;
-    if !is_udp(create_request) {
-        return Ok(SocketOutcome::Failed(SocketError::InvalidArgument));
-    }
-    if let Some(destination) = destination {
-        match session.core.policy.authorize_socket_connect(
-            session.caller_credential,
-            create_request,
-            destination,
-        ) {
-            Ok(()) => {}
-            Err(BrokerError::PolicyDenied) => {
-                return Ok(SocketOutcome::Failed(SocketError::PolicyDenied));
-            }
-            Err(error) => return Err(error),
-        }
-    } else if connection_status != SocketConnectionStatus::Connected {
-        return Ok(SocketOutcome::Failed(SocketError::NotConnected));
-    }
-    let outcome = resource.send_to_owned(data, flags, destination)?;
-    if let SocketOutcome::Completed(sent) = outcome
         && sent != length
     {
         return Err(BrokerError::Internal);
@@ -720,52 +570,8 @@ pub fn send_to_owned(
     Ok(outcome)
 }
 
-/// Receives bytes without waiting for readiness.
+/// Receives stream bytes without waiting for readiness.
 pub fn receive(
-    session: &BrokerSession,
-    handle: ObjectHandle,
-    data: &mut [u8],
-    flags: ReceiveFlags,
-    peek_offset: u32,
-    peek_length: u32,
-) -> Result<SocketOutcome<ReceiveSocketResponse>> {
-    if flags.has_unsupported_bits() {
-        return Err(BrokerError::UnsupportedOperation);
-    }
-    let peek = flags.contains(ReceiveFlags::PEEK);
-    let end = peek_offset
-        .checked_add(data.len().try_into().map_err(|_| BrokerError::Internal)?)
-        .ok_or(BrokerError::UnsupportedOperation)?;
-    let canonical_peek_length = peek_length
-        .checked_sub(peek_offset)
-        .map(|remaining| remaining.min(MAX_SOCKET_TRANSFER_SIZE));
-    if (!peek && (peek_offset != 0 || peek_length != 0))
-        || (peek
-            && (!peek_offset.is_multiple_of(MAX_SOCKET_TRANSFER_SIZE)
-                || canonical_peek_length != data.len().try_into().ok()
-                || peek_length < end
-                || peek_length > litebox_broker_protocol::socket::MAX_SOCKET_PEEK_SIZE))
-    {
-        return Err(BrokerError::UnsupportedOperation);
-    }
-    let (resource, create_request, _) = socket_state(session, handle, ObjectRights::WAIT)?;
-    if !is_tcp(create_request) {
-        return Ok(SocketOutcome::Failed(SocketError::InvalidArgument));
-    }
-    if data.is_empty() {
-        return Ok(SocketOutcome::Completed(ReceiveSocketResponse::Received(0)));
-    }
-    let outcome = resource.receive(data, flags, peek_offset, peek_length)?;
-    if let SocketOutcome::Completed(ReceiveSocketResponse::Received(received)) = outcome
-        && (received as usize > data.len() || received == 0)
-    {
-        return Err(BrokerError::Internal);
-    }
-    Ok(outcome)
-}
-
-/// Receives stream bytes into an owned platform buffer without waiting.
-pub fn receive_owned(
     session: &BrokerSession,
     handle: ObjectHandle,
     length: usize,
@@ -801,7 +607,7 @@ pub fn receive_owned(
             Vec::new(),
         )));
     }
-    let outcome = resource.receive_owned(length, flags, peek_offset, peek_length)?;
+    let outcome = resource.receive(length, flags, peek_offset, peek_length)?;
     if let SocketOutcome::Completed(PlatformStreamReceive::Received(received)) = &outcome
         && (received.len() > length || received.is_empty())
     {
@@ -814,31 +620,6 @@ pub fn receive_owned(
 pub fn receive_from(
     session: &BrokerSession,
     handle: ObjectHandle,
-    data: &mut [u8],
-    flags: ReceiveFromFlags,
-) -> Result<SocketOutcome<ReceivedPlatformDatagram>> {
-    if flags.has_unsupported_bits() || data.len() > MAX_UDP_DATAGRAM_SIZE as usize {
-        return Err(BrokerError::UnsupportedOperation);
-    }
-    let (resource, create_request, _) = socket_state(session, handle, ObjectRights::WAIT)?;
-    if !is_udp(create_request) {
-        return Ok(SocketOutcome::Failed(SocketError::InvalidArgument));
-    }
-    let outcome = resource.receive_from(data, flags)?;
-    if let SocketOutcome::Completed(received) = outcome
-        && (received.received > data.len()
-            || received.datagram_length < received.received
-            || received.datagram_length > MAX_UDP_DATAGRAM_SIZE as usize)
-    {
-        return Err(BrokerError::Internal);
-    }
-    Ok(outcome)
-}
-
-/// Receives one datagram into an owned platform buffer without waiting.
-pub fn receive_from_owned(
-    session: &BrokerSession,
-    handle: ObjectHandle,
     length: usize,
     flags: ReceiveFromFlags,
 ) -> Result<SocketOutcome<PlatformDatagramReceive>> {
@@ -849,7 +630,7 @@ pub fn receive_from_owned(
     if !is_udp(create_request) {
         return Ok(SocketOutcome::Failed(SocketError::InvalidArgument));
     }
-    let outcome = resource.receive_from_owned(length, flags)?;
+    let outcome = resource.receive_from(length, flags)?;
     if let SocketOutcome::Completed(received) = &outcome
         && (received.data.len() > length
             || received.datagram_length < received.data.len()
@@ -858,14 +639,6 @@ pub fn receive_from_owned(
         return Err(BrokerError::Internal);
     }
     Ok(outcome)
-}
-
-fn zeroed_vec(length: usize) -> Result<Vec<u8>> {
-    let mut data = Vec::new();
-    data.try_reserve_exact(length)
-        .map_err(|_| BrokerError::OutOfMemory)?;
-    data.resize(length, 0);
-    Ok(data)
 }
 
 /// Sets a typed option on a broker-owned TCP socket.
@@ -1263,45 +1036,20 @@ impl SocketResource {
         self.platform_socket().accept(readiness)
     }
 
-    fn send(&self, data: &[u8], flags: SendFlags) -> Result<SocketOutcome<usize>> {
+    fn send(&self, data: Vec<u8>, flags: SendFlags) -> Result<SocketOutcome<usize>> {
         self.platform_socket().send(data, flags)
-    }
-
-    fn send_owned(&self, data: Vec<u8>, flags: SendFlags) -> Result<SocketOutcome<usize>> {
-        self.platform_socket().send_owned(data, flags)
     }
 
     fn send_to(
         &self,
-        data: &[u8],
+        data: Vec<u8>,
         flags: SendFlags,
         destination: Option<SocketAddrV4>,
     ) -> Result<SocketOutcome<usize>> {
         self.platform_socket().send_to(data, flags, destination)
     }
 
-    fn send_to_owned(
-        &self,
-        data: Vec<u8>,
-        flags: SendFlags,
-        destination: Option<SocketAddrV4>,
-    ) -> Result<SocketOutcome<usize>> {
-        self.platform_socket()
-            .send_to_owned(data, flags, destination)
-    }
-
     fn receive(
-        &self,
-        data: &mut [u8],
-        flags: ReceiveFlags,
-        peek_offset: u32,
-        peek_length: u32,
-    ) -> Result<SocketOutcome<ReceiveSocketResponse>> {
-        self.platform_socket()
-            .receive(data, flags, peek_offset, peek_length)
-    }
-
-    fn receive_owned(
         &self,
         length: usize,
         flags: ReceiveFlags,
@@ -1309,23 +1057,15 @@ impl SocketResource {
         peek_length: u32,
     ) -> Result<SocketOutcome<PlatformStreamReceive>> {
         self.platform_socket()
-            .receive_owned(length, flags, peek_offset, peek_length)
+            .receive(length, flags, peek_offset, peek_length)
     }
 
     fn receive_from(
         &self,
-        data: &mut [u8],
-        flags: ReceiveFromFlags,
-    ) -> Result<SocketOutcome<ReceivedPlatformDatagram>> {
-        self.platform_socket().receive_from(data, flags)
-    }
-
-    fn receive_from_owned(
-        &self,
         length: usize,
         flags: ReceiveFromFlags,
     ) -> Result<SocketOutcome<PlatformDatagramReceive>> {
-        self.platform_socket().receive_from_owned(length, flags)
+        self.platform_socket().receive_from(length, flags)
     }
 
     fn shutdown(&self, mode: ShutdownMode) -> Result<SocketOutcome<()>> {
@@ -1423,6 +1163,7 @@ pub(crate) mod tests {
     use litebox_broker_protocol::socket::{AddressFamily, IpProtocol, SocketType};
     use std::sync::{Mutex as StdMutex, mpsc};
     use std::time::Duration;
+    use std::vec;
 
     #[derive(Clone, Default)]
     pub(crate) struct TestSocketProvider {
@@ -1573,44 +1314,42 @@ pub(crate) mod tests {
             }
         }
 
-        fn send(&self, data: &[u8], _flags: SendFlags) -> Result<SocketOutcome<usize>> {
-            self.state.sent.lock().unwrap().extend_from_slice(data);
+        fn send(&self, data: Vec<u8>, _flags: SendFlags) -> Result<SocketOutcome<usize>> {
+            self.state.sent.lock().unwrap().extend_from_slice(&data);
             Ok(SocketOutcome::Completed(data.len()))
         }
 
         fn send_to(
             &self,
-            data: &[u8],
+            data: Vec<u8>,
             _flags: SendFlags,
             _destination: Option<SocketAddrV4>,
         ) -> Result<SocketOutcome<usize>> {
-            self.state.sent.lock().unwrap().extend_from_slice(data);
+            self.state.sent.lock().unwrap().extend_from_slice(&data);
             Ok(SocketOutcome::Completed(data.len()))
         }
 
         fn receive(
             &self,
-            data: &mut [u8],
+            length: usize,
             _flags: ReceiveFlags,
             _peek_offset: u32,
             _peek_length: u32,
-        ) -> Result<SocketOutcome<ReceiveSocketResponse>> {
-            let received = data.len().min(2);
-            data[..received].copy_from_slice(&[7, 9][..received]);
-            Ok(SocketOutcome::Completed(ReceiveSocketResponse::Received(
-                u32::try_from(received).unwrap(),
+        ) -> Result<SocketOutcome<PlatformStreamReceive>> {
+            let received = length.min(2);
+            Ok(SocketOutcome::Completed(PlatformStreamReceive::Received(
+                [7, 9][..received].to_vec(),
             )))
         }
 
         fn receive_from(
             &self,
-            data: &mut [u8],
+            length: usize,
             _flags: ReceiveFromFlags,
-        ) -> Result<SocketOutcome<ReceivedPlatformDatagram>> {
-            let received = data.len().min(2);
-            data[..received].copy_from_slice(&[7, 9][..received]);
-            Ok(SocketOutcome::Completed(ReceivedPlatformDatagram {
-                received,
+        ) -> Result<SocketOutcome<PlatformDatagramReceive>> {
+            let received = length.min(2);
+            Ok(SocketOutcome::Completed(PlatformDatagramReceive {
+                data: [7, 9][..received].to_vec(),
                 datagram_length: 4,
                 source_address: SocketAddrV4::new(Ipv4Addr::LOCALHOST, 49153),
             }))
@@ -1771,26 +1510,21 @@ pub(crate) mod tests {
             Ok(ReadinessFlags::READ | ReadinessFlags::WRITE)
         );
         assert_eq!(
-            send(&session, handle, &[1, 2, 3], SendFlags::NONE),
+            send(&session, handle, vec![1, 2, 3], SendFlags::NONE),
             Ok(SocketOutcome::Completed(3))
         );
-        let mut data = [0; 4];
         assert_eq!(
-            receive(&session, handle, &mut data, ReceiveFlags::PEEK, 0, 4),
-            Ok(SocketOutcome::Completed(ReceiveSocketResponse::Received(2)))
+            receive(&session, handle, 4, ReceiveFlags::PEEK, 0, 4),
+            Ok(SocketOutcome::Completed(PlatformStreamReceive::Received(
+                vec![7, 9],
+            )))
         );
-        assert_eq!(data, [7, 9, 0, 0]);
         assert_eq!(
-            receive(&session, handle, &mut data[..1], ReceiveFlags::PEEK, 1, 2),
+            receive(&session, handle, 1, ReceiveFlags::PEEK, 1, 2),
             Err(BrokerError::UnsupportedOperation)
         );
-        let mut oversized = std::vec![0; MAX_SOCKET_TRANSFER_SIZE as usize + 1];
         assert_eq!(
-            receive(&session, handle, &mut oversized, ReceiveFlags::NONE, 0, 0,),
-            Ok(SocketOutcome::Completed(ReceiveSocketResponse::Received(2)))
-        );
-        assert_eq!(
-            receive_owned(
+            receive(
                 &session,
                 handle,
                 MAX_SOCKET_TRANSFER_SIZE as usize + 1,
@@ -1821,7 +1555,7 @@ pub(crate) mod tests {
             Ok(SocketOutcome::Completed(()))
         );
         assert_eq!(
-            send(&session, handle, &[], SendFlags(1)),
+            send(&session, handle, Vec::new(), SendFlags(1)),
             Err(BrokerError::UnsupportedOperation)
         );
         let in_flight = socket_resource(&session, handle, ObjectRights::WAIT).unwrap();
@@ -1918,14 +1652,14 @@ pub(crate) mod tests {
             Err(BrokerError::UnsupportedOperation)
         );
         assert_eq!(
-            send_to(&session, handle, b"x", SendFlags::NONE, None),
+            send_to(&session, handle, b"x".to_vec(), SendFlags::NONE, None),
             Ok(SocketOutcome::Failed(SocketError::NotConnected))
         );
         assert_eq!(
             send_to(
                 &session,
                 handle,
-                b"x",
+                b"x".to_vec(),
                 SendFlags::NONE,
                 Some(SocketAddrV4::new(Ipv4Addr::new(10, 0, 0, 1), 53)),
             ),
@@ -1935,22 +1669,20 @@ pub(crate) mod tests {
             send_to(
                 &session,
                 handle,
-                b"udp",
+                b"udp".to_vec(),
                 SendFlags::NONE,
                 Some(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 53)),
             ),
             Ok(SocketOutcome::Completed(3))
         );
-        let mut data = [0; 2];
         assert_eq!(
-            receive_from(&session, handle, &mut data, ReceiveFromFlags::PEEK),
-            Ok(SocketOutcome::Completed(ReceivedPlatformDatagram {
-                received: 2,
+            receive_from(&session, handle, 2, ReceiveFromFlags::PEEK),
+            Ok(SocketOutcome::Completed(PlatformDatagramReceive {
+                data: vec![7, 9],
                 datagram_length: 4,
                 source_address: SocketAddrV4::new(Ipv4Addr::LOCALHOST, 49153),
             }))
         );
-        assert_eq!(data, [7, 9]);
         assert_eq!(
             connect(&session, handle, SocketAddrV4::new(Ipv4Addr::LOCALHOST, 53),),
             Ok(SocketOutcome::Completed(SocketConnectionStatus::Connected))
@@ -1965,7 +1697,7 @@ pub(crate) mod tests {
             SocketConnectionStatus::Connected
         );
         assert_eq!(
-            send_to(&session, handle, b"peer", SendFlags::NONE, None),
+            send_to(&session, handle, b"peer".to_vec(), SendFlags::NONE, None),
             Ok(SocketOutcome::Completed(4))
         );
         provider.fail_next_connect_indeterminate();
@@ -1992,7 +1724,7 @@ pub(crate) mod tests {
             })
         );
         assert_eq!(
-            send_to(&session, handle, b"peer", SendFlags::NONE, None),
+            send_to(&session, handle, b"peer".to_vec(), SendFlags::NONE, None),
             Ok(SocketOutcome::Failed(SocketError::NotConnected))
         );
         assert_eq!(
@@ -2000,11 +1732,11 @@ pub(crate) mod tests {
             Ok(SocketOutcome::Completed(SocketConnectionStatus::Connected))
         );
         assert_eq!(
-            send_to(&session, handle, b"peer", SendFlags::NONE, None),
+            send_to(&session, handle, b"peer".to_vec(), SendFlags::NONE, None),
             Ok(SocketOutcome::Completed(4))
         );
         assert_eq!(
-            send(&session, handle, b"x", SendFlags::NONE),
+            send(&session, handle, b"x".to_vec(), SendFlags::NONE),
             Ok(SocketOutcome::Failed(SocketError::InvalidArgument))
         );
         assert_eq!(

--- a/litebox_broker_core/src/socket.rs
+++ b/litebox_broker_core/src/socket.rs
@@ -3,7 +3,7 @@
 
 //! Broker-owned platform socket authority.
 
-use alloc::sync::Arc;
+use alloc::{sync::Arc, vec::Vec};
 use core::net::{Ipv4Addr, SocketAddrV4};
 use core::sync::atomic::{AtomicUsize, Ordering};
 
@@ -57,6 +57,26 @@ pub struct AcceptedBrokerSocket {
 pub struct ReceivedPlatformDatagram {
     /// Number of bytes copied into the caller's buffer.
     pub received: usize,
+    /// Original datagram length before truncation.
+    pub datagram_length: usize,
+    /// Source address of the datagram.
+    pub source_address: SocketAddrV4,
+}
+
+/// Owned platform result for one stream receive.
+#[derive(Debug, PartialEq, Eq)]
+pub enum PlatformStreamReceive {
+    /// Bytes received from the stream.
+    Received(Vec<u8>),
+    /// The stream's receive direction reached end of stream.
+    EndOfStream,
+}
+
+/// Owned platform result for one datagram receive.
+#[derive(Debug, PartialEq, Eq)]
+pub struct PlatformDatagramReceive {
+    /// Received datagram prefix, truncated to the requested capacity.
+    pub data: Vec<u8>,
     /// Original datagram length before truncation.
     pub datagram_length: usize,
     /// Source address of the datagram.
@@ -120,6 +140,15 @@ pub trait PlatformSocket: Send + Sync {
     /// network failures return [`SocketOutcome::Failed`].
     fn send(&self, data: &[u8], flags: SendFlags) -> Result<SocketOutcome<usize>>;
 
+    /// Sends owned bytes without waiting for platform readiness.
+    ///
+    /// Threaded implementations can override this method to move the payload
+    /// into their command queue. The default preserves compatibility with
+    /// slice-based platform implementations.
+    fn send_owned(&self, data: Vec<u8>, flags: SendFlags) -> Result<SocketOutcome<usize>> {
+        self.send(&data, flags)
+    }
+
     /// Sends one complete datagram without waiting for platform readiness.
     ///
     /// A destination is required for an unconnected socket and omitted to use
@@ -130,6 +159,16 @@ pub trait PlatformSocket: Send + Sync {
         flags: SendFlags,
         destination: Option<SocketAddrV4>,
     ) -> Result<SocketOutcome<usize>>;
+
+    /// Sends one owned datagram without waiting for platform readiness.
+    fn send_to_owned(
+        &self,
+        data: Vec<u8>,
+        flags: SendFlags,
+        destination: Option<SocketAddrV4>,
+    ) -> Result<SocketOutcome<usize>> {
+        self.send_to(&data, flags, destination)
+    }
 
     /// Receives bytes without waiting for platform readiness.
     ///
@@ -144,6 +183,34 @@ pub trait PlatformSocket: Send + Sync {
         peek_length: u32,
     ) -> Result<SocketOutcome<ReceiveSocketResponse>>;
 
+    /// Receives bytes into an owned platform buffer without waiting.
+    fn receive_owned(
+        &self,
+        length: usize,
+        flags: ReceiveFlags,
+        peek_offset: u32,
+        peek_length: u32,
+    ) -> Result<SocketOutcome<PlatformStreamReceive>> {
+        let mut data = zeroed_vec(length)?;
+        match self.receive(&mut data, flags, peek_offset, peek_length)? {
+            SocketOutcome::Completed(ReceiveSocketResponse::Received(received)) => {
+                let received = usize::try_from(received).map_err(|_| BrokerError::Internal)?;
+                if received > data.len() {
+                    return Err(BrokerError::Internal);
+                }
+                data.truncate(received);
+                Ok(SocketOutcome::Completed(PlatformStreamReceive::Received(
+                    data,
+                )))
+            }
+            SocketOutcome::Completed(ReceiveSocketResponse::EndOfStream) => {
+                Ok(SocketOutcome::Completed(PlatformStreamReceive::EndOfStream))
+            }
+            SocketOutcome::Completed(_) => Err(BrokerError::Internal),
+            SocketOutcome::Failed(error) => Ok(SocketOutcome::Failed(error)),
+        }
+    }
+
     /// Receives one datagram without waiting for platform readiness.
     ///
     /// The original datagram length is returned even when the caller's buffer
@@ -153,6 +220,29 @@ pub trait PlatformSocket: Send + Sync {
         data: &mut [u8],
         flags: ReceiveFromFlags,
     ) -> Result<SocketOutcome<ReceivedPlatformDatagram>>;
+
+    /// Receives one datagram into an owned platform buffer without waiting.
+    fn receive_from_owned(
+        &self,
+        length: usize,
+        flags: ReceiveFromFlags,
+    ) -> Result<SocketOutcome<PlatformDatagramReceive>> {
+        let mut data = zeroed_vec(length)?;
+        match self.receive_from(&mut data, flags)? {
+            SocketOutcome::Completed(received) => {
+                if received.received > data.len() {
+                    return Err(BrokerError::Internal);
+                }
+                data.truncate(received.received);
+                Ok(SocketOutcome::Completed(PlatformDatagramReceive {
+                    data,
+                    datagram_length: received.datagram_length,
+                    source_address: received.source_address,
+                }))
+            }
+            SocketOutcome::Failed(error) => Ok(SocketOutcome::Failed(error)),
+        }
+    }
 
     /// Shuts down one or both socket directions.
     fn shutdown(&self, mode: ShutdownMode) -> Result<SocketOutcome<()>>;
@@ -519,6 +609,33 @@ pub fn send(
     Ok(outcome)
 }
 
+/// Sends owned bytes without waiting for readiness.
+///
+/// Ownership is passed through to the platform so threaded implementations can
+/// avoid copying the payload into a separate command buffer.
+pub fn send_owned(
+    session: &BrokerSession,
+    handle: ObjectHandle,
+    data: Vec<u8>,
+    flags: SendFlags,
+) -> Result<SocketOutcome<usize>> {
+    if flags.has_unsupported_bits() {
+        return Err(BrokerError::UnsupportedOperation);
+    }
+    let length = data.len();
+    let (resource, create_request, _) = socket_state(session, handle, ObjectRights::WRITE)?;
+    if !is_tcp(create_request) {
+        return Ok(SocketOutcome::Failed(SocketError::InvalidArgument));
+    }
+    let outcome = resource.send_owned(data, flags)?;
+    if let SocketOutcome::Completed(sent) = outcome
+        && sent > length
+    {
+        return Err(BrokerError::Internal);
+    }
+    Ok(outcome)
+}
+
 /// Sends one complete datagram without waiting for readiness.
 pub fn send_to(
     session: &BrokerSession,
@@ -553,6 +670,50 @@ pub fn send_to(
     let outcome = resource.send_to(data, flags, destination)?;
     if let SocketOutcome::Completed(sent) = outcome
         && sent != data.len()
+    {
+        return Err(BrokerError::Internal);
+    }
+    Ok(outcome)
+}
+
+/// Sends one owned datagram without waiting for readiness.
+///
+/// Ownership is passed through to the platform so threaded implementations can
+/// avoid copying the payload into a separate command buffer.
+pub fn send_to_owned(
+    session: &BrokerSession,
+    handle: ObjectHandle,
+    data: Vec<u8>,
+    flags: SendFlags,
+    destination: Option<SocketAddrV4>,
+) -> Result<SocketOutcome<usize>> {
+    if flags.has_unsupported_bits() || data.len() > MAX_UDP_DATAGRAM_SIZE as usize {
+        return Err(BrokerError::UnsupportedOperation);
+    }
+    let length = data.len();
+    let (resource, create_request, connection_status) =
+        socket_state(session, handle, ObjectRights::WRITE)?;
+    if !is_udp(create_request) {
+        return Ok(SocketOutcome::Failed(SocketError::InvalidArgument));
+    }
+    if let Some(destination) = destination {
+        match session.core.policy.authorize_socket_connect(
+            session.caller_credential,
+            create_request,
+            destination,
+        ) {
+            Ok(()) => {}
+            Err(BrokerError::PolicyDenied) => {
+                return Ok(SocketOutcome::Failed(SocketError::PolicyDenied));
+            }
+            Err(error) => return Err(error),
+        }
+    } else if connection_status != SocketConnectionStatus::Connected {
+        return Ok(SocketOutcome::Failed(SocketError::NotConnected));
+    }
+    let outcome = resource.send_to_owned(data, flags, destination)?;
+    if let SocketOutcome::Completed(sent) = outcome
+        && sent != length
     {
         return Err(BrokerError::Internal);
     }
@@ -603,6 +764,52 @@ pub fn receive(
     Ok(outcome)
 }
 
+/// Receives stream bytes into an owned platform buffer without waiting.
+pub fn receive_owned(
+    session: &BrokerSession,
+    handle: ObjectHandle,
+    length: usize,
+    flags: ReceiveFlags,
+    peek_offset: u32,
+    peek_length: u32,
+) -> Result<SocketOutcome<PlatformStreamReceive>> {
+    if flags.has_unsupported_bits() || length > MAX_SOCKET_TRANSFER_SIZE as usize {
+        return Err(BrokerError::UnsupportedOperation);
+    }
+    let peek = flags.contains(ReceiveFlags::PEEK);
+    let end = peek_offset
+        .checked_add(length.try_into().map_err(|_| BrokerError::Internal)?)
+        .ok_or(BrokerError::UnsupportedOperation)?;
+    let canonical_peek_length = peek_length
+        .checked_sub(peek_offset)
+        .map(|remaining| remaining.min(MAX_SOCKET_TRANSFER_SIZE));
+    if (!peek && (peek_offset != 0 || peek_length != 0))
+        || (peek
+            && (!peek_offset.is_multiple_of(MAX_SOCKET_TRANSFER_SIZE)
+                || canonical_peek_length != length.try_into().ok()
+                || peek_length < end
+                || peek_length > litebox_broker_protocol::socket::MAX_SOCKET_PEEK_SIZE))
+    {
+        return Err(BrokerError::UnsupportedOperation);
+    }
+    let (resource, create_request, _) = socket_state(session, handle, ObjectRights::WAIT)?;
+    if !is_tcp(create_request) {
+        return Ok(SocketOutcome::Failed(SocketError::InvalidArgument));
+    }
+    if length == 0 {
+        return Ok(SocketOutcome::Completed(PlatformStreamReceive::Received(
+            Vec::new(),
+        )));
+    }
+    let outcome = resource.receive_owned(length, flags, peek_offset, peek_length)?;
+    if let SocketOutcome::Completed(PlatformStreamReceive::Received(received)) = &outcome
+        && (received.len() > length || received.is_empty())
+    {
+        return Err(BrokerError::Internal);
+    }
+    Ok(outcome)
+}
+
 /// Receives one datagram without waiting for readiness.
 pub fn receive_from(
     session: &BrokerSession,
@@ -626,6 +833,39 @@ pub fn receive_from(
         return Err(BrokerError::Internal);
     }
     Ok(outcome)
+}
+
+/// Receives one datagram into an owned platform buffer without waiting.
+pub fn receive_from_owned(
+    session: &BrokerSession,
+    handle: ObjectHandle,
+    length: usize,
+    flags: ReceiveFromFlags,
+) -> Result<SocketOutcome<PlatformDatagramReceive>> {
+    if flags.has_unsupported_bits() || length > MAX_UDP_DATAGRAM_SIZE as usize {
+        return Err(BrokerError::UnsupportedOperation);
+    }
+    let (resource, create_request, _) = socket_state(session, handle, ObjectRights::WAIT)?;
+    if !is_udp(create_request) {
+        return Ok(SocketOutcome::Failed(SocketError::InvalidArgument));
+    }
+    let outcome = resource.receive_from_owned(length, flags)?;
+    if let SocketOutcome::Completed(received) = &outcome
+        && (received.data.len() > length
+            || received.datagram_length < received.data.len()
+            || received.datagram_length > MAX_UDP_DATAGRAM_SIZE as usize)
+    {
+        return Err(BrokerError::Internal);
+    }
+    Ok(outcome)
+}
+
+fn zeroed_vec(length: usize) -> Result<Vec<u8>> {
+    let mut data = Vec::new();
+    data.try_reserve_exact(length)
+        .map_err(|_| BrokerError::OutOfMemory)?;
+    data.resize(length, 0);
+    Ok(data)
 }
 
 /// Sets a typed option on a broker-owned TCP socket.
@@ -1027,6 +1267,10 @@ impl SocketResource {
         self.platform_socket().send(data, flags)
     }
 
+    fn send_owned(&self, data: Vec<u8>, flags: SendFlags) -> Result<SocketOutcome<usize>> {
+        self.platform_socket().send_owned(data, flags)
+    }
+
     fn send_to(
         &self,
         data: &[u8],
@@ -1034,6 +1278,16 @@ impl SocketResource {
         destination: Option<SocketAddrV4>,
     ) -> Result<SocketOutcome<usize>> {
         self.platform_socket().send_to(data, flags, destination)
+    }
+
+    fn send_to_owned(
+        &self,
+        data: Vec<u8>,
+        flags: SendFlags,
+        destination: Option<SocketAddrV4>,
+    ) -> Result<SocketOutcome<usize>> {
+        self.platform_socket()
+            .send_to_owned(data, flags, destination)
     }
 
     fn receive(
@@ -1047,12 +1301,31 @@ impl SocketResource {
             .receive(data, flags, peek_offset, peek_length)
     }
 
+    fn receive_owned(
+        &self,
+        length: usize,
+        flags: ReceiveFlags,
+        peek_offset: u32,
+        peek_length: u32,
+    ) -> Result<SocketOutcome<PlatformStreamReceive>> {
+        self.platform_socket()
+            .receive_owned(length, flags, peek_offset, peek_length)
+    }
+
     fn receive_from(
         &self,
         data: &mut [u8],
         flags: ReceiveFromFlags,
     ) -> Result<SocketOutcome<ReceivedPlatformDatagram>> {
         self.platform_socket().receive_from(data, flags)
+    }
+
+    fn receive_from_owned(
+        &self,
+        length: usize,
+        flags: ReceiveFromFlags,
+    ) -> Result<SocketOutcome<PlatformDatagramReceive>> {
+        self.platform_socket().receive_from_owned(length, flags)
     }
 
     fn shutdown(&self, mode: ShutdownMode) -> Result<SocketOutcome<()>> {
@@ -1509,6 +1782,22 @@ pub(crate) mod tests {
         assert_eq!(data, [7, 9, 0, 0]);
         assert_eq!(
             receive(&session, handle, &mut data[..1], ReceiveFlags::PEEK, 1, 2),
+            Err(BrokerError::UnsupportedOperation)
+        );
+        let mut oversized = std::vec![0; MAX_SOCKET_TRANSFER_SIZE as usize + 1];
+        assert_eq!(
+            receive(&session, handle, &mut oversized, ReceiveFlags::NONE, 0, 0,),
+            Ok(SocketOutcome::Completed(ReceiveSocketResponse::Received(2)))
+        );
+        assert_eq!(
+            receive_owned(
+                &session,
+                handle,
+                MAX_SOCKET_TRANSFER_SIZE as usize + 1,
+                ReceiveFlags::NONE,
+                0,
+                0,
+            ),
             Err(BrokerError::UnsupportedOperation)
         );
         assert_eq!(

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -438,8 +438,13 @@ fn handle_socket_request<Memory: SharedMemory>(
             shared_buffers
                 .read(request.buffer.slot_index, &mut data)
                 .map_err(|_| RequestFailure::Abort(ErrorCode::Internal))?;
-            match litebox_broker_core::socket::send(session, request.handle, &data, request.flags)
-                .map_err(RequestFailure::from)?
+            match litebox_broker_core::socket::send_owned(
+                session,
+                request.handle,
+                data,
+                request.flags,
+            )
+            .map_err(RequestFailure::from)?
             {
                 SocketOutcome::Completed(sent) => {
                     let sent = sent
@@ -464,10 +469,10 @@ fn handle_socket_request<Memory: SharedMemory>(
             shared_buffers
                 .read(request.buffer.slot_index, &mut data)
                 .map_err(|_| RequestFailure::Abort(ErrorCode::Internal))?;
-            match litebox_broker_core::socket::send_to(
+            match litebox_broker_core::socket::send_to_owned(
                 session,
                 request.handle,
-                &data,
+                data,
                 request.flags,
                 request.destination,
             )
@@ -502,27 +507,33 @@ fn handle_socket_request<Memory: SharedMemory>(
                 return Err(RequestFailure::Abort(ErrorCode::MalformedRequest));
             }
             let length = request.buffer.length as usize;
-            let mut data = Vec::new();
-            if data.try_reserve_exact(length).is_err() {
-                return Err(RequestFailure::Respond(ErrorCode::OutOfMemory));
-            }
-            data.resize(length, 0);
-            match litebox_broker_core::socket::receive(
+            match litebox_broker_core::socket::receive_owned(
                 session,
                 request.handle,
-                &mut data,
+                length,
                 request.flags,
                 request.peek_offset,
                 request.peek_length,
             )
             .map_err(RequestFailure::from)?
             {
-                SocketOutcome::Completed(response) => {
-                    if let ReceiveSocketResponse::Received(received) = response {
-                        shared_buffers
-                            .write(request.buffer.slot_index, &data[..received as usize])
-                            .map_err(|_| RequestFailure::Abort(ErrorCode::Internal))?;
-                    }
+                SocketOutcome::Completed(received) => {
+                    let response = match received {
+                        litebox_broker_core::socket::PlatformStreamReceive::Received(data) => {
+                            let received = data.len();
+                            shared_buffers
+                                .write(request.buffer.slot_index, &data)
+                                .map_err(|_| RequestFailure::Abort(ErrorCode::Internal))?;
+                            ReceiveSocketResponse::Received(
+                                received
+                                    .try_into()
+                                    .map_err(|_| RequestFailure::Abort(ErrorCode::Internal))?,
+                            )
+                        }
+                        litebox_broker_core::socket::PlatformStreamReceive::EndOfStream => {
+                            ReceiveSocketResponse::EndOfStream
+                        }
+                    };
                     Ok(SocketResponse::Receive(response))
                 }
                 SocketOutcome::Failed(error) => Ok(SocketResponse::Failed(error)),
@@ -534,26 +545,22 @@ fn handle_socket_request<Memory: SharedMemory>(
                 return Err(RequestFailure::Abort(ErrorCode::MalformedRequest));
             }
             let length = request.buffer.length as usize;
-            let mut data = Vec::new();
-            if data.try_reserve_exact(length).is_err() {
-                return Err(RequestFailure::Respond(ErrorCode::OutOfMemory));
-            }
-            data.resize(length, 0);
-            match litebox_broker_core::socket::receive_from(
+            match litebox_broker_core::socket::receive_from_owned(
                 session,
                 request.handle,
-                &mut data,
+                length,
                 request.flags,
             )
             .map_err(RequestFailure::from)?
             {
                 SocketOutcome::Completed(received) => {
                     shared_buffers
-                        .write(request.buffer.slot_index, &data[..received.received])
+                        .write(request.buffer.slot_index, &received.data)
                         .map_err(|_| RequestFailure::Abort(ErrorCode::Internal))?;
                     Ok(SocketResponse::ReceiveFrom(ReceiveFromSocketResponse {
                         received: received
-                            .received
+                            .data
+                            .len()
                             .try_into()
                             .map_err(|_| RequestFailure::Abort(ErrorCode::Internal))?,
                         datagram_length: received

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -438,13 +438,8 @@ fn handle_socket_request<Memory: SharedMemory>(
             shared_buffers
                 .read(request.buffer.slot_index, &mut data)
                 .map_err(|_| RequestFailure::Abort(ErrorCode::Internal))?;
-            match litebox_broker_core::socket::send_owned(
-                session,
-                request.handle,
-                data,
-                request.flags,
-            )
-            .map_err(RequestFailure::from)?
+            match litebox_broker_core::socket::send(session, request.handle, data, request.flags)
+                .map_err(RequestFailure::from)?
             {
                 SocketOutcome::Completed(sent) => {
                     let sent = sent
@@ -469,7 +464,7 @@ fn handle_socket_request<Memory: SharedMemory>(
             shared_buffers
                 .read(request.buffer.slot_index, &mut data)
                 .map_err(|_| RequestFailure::Abort(ErrorCode::Internal))?;
-            match litebox_broker_core::socket::send_to_owned(
+            match litebox_broker_core::socket::send_to(
                 session,
                 request.handle,
                 data,
@@ -507,7 +502,7 @@ fn handle_socket_request<Memory: SharedMemory>(
                 return Err(RequestFailure::Abort(ErrorCode::MalformedRequest));
             }
             let length = request.buffer.length as usize;
-            match litebox_broker_core::socket::receive_owned(
+            match litebox_broker_core::socket::receive(
                 session,
                 request.handle,
                 length,
@@ -545,7 +540,7 @@ fn handle_socket_request<Memory: SharedMemory>(
                 return Err(RequestFailure::Abort(ErrorCode::MalformedRequest));
             }
             let length = request.buffer.length as usize;
-            match litebox_broker_core::socket::receive_from_owned(
+            match litebox_broker_core::socket::receive_from(
                 session,
                 request.handle,
                 length,
@@ -702,8 +697,8 @@ mod tests {
     use core::net::{Ipv4Addr, SocketAddrV4};
     use litebox_broker_core::readiness::ReadinessRegistration;
     use litebox_broker_core::socket::{
-        AcceptedPlatformSocket, PlatformConnectError, PlatformSocket, ReceivedPlatformDatagram,
-        SocketProvider,
+        AcceptedPlatformSocket, PlatformConnectError, PlatformDatagramReceive, PlatformSocket,
+        PlatformStreamReceive, SocketProvider,
     };
     use litebox_broker_core::{ObjectRights, PolicyEngine, SessionId, SocketPolicy};
     use litebox_broker_protocol::event::{
@@ -828,7 +823,7 @@ mod tests {
 
         fn send(
             &self,
-            data: &[u8],
+            data: Vec<u8>,
             _flags: SendFlags,
         ) -> litebox_broker_core::Result<SocketOutcome<usize>> {
             Ok(SocketOutcome::Completed(data.len()))
@@ -836,7 +831,7 @@ mod tests {
 
         fn send_to(
             &self,
-            data: &[u8],
+            data: Vec<u8>,
             _flags: SendFlags,
             _destination: Option<SocketAddrV4>,
         ) -> litebox_broker_core::Result<SocketOutcome<usize>> {
@@ -845,27 +840,25 @@ mod tests {
 
         fn receive(
             &self,
-            data: &mut [u8],
+            length: usize,
             _flags: ReceiveFlags,
             _peek_offset: u32,
             _peek_length: u32,
-        ) -> litebox_broker_core::Result<SocketOutcome<ReceiveSocketResponse>> {
-            let received = data.len().min(3);
-            data[..received].copy_from_slice(&[4, 5, 6][..received]);
-            Ok(SocketOutcome::Completed(ReceiveSocketResponse::Received(
-                u32::try_from(received).unwrap(),
+        ) -> litebox_broker_core::Result<SocketOutcome<PlatformStreamReceive>> {
+            let received = length.min(3);
+            Ok(SocketOutcome::Completed(PlatformStreamReceive::Received(
+                [4, 5, 6][..received].to_vec(),
             )))
         }
 
         fn receive_from(
             &self,
-            data: &mut [u8],
+            length: usize,
             _flags: ReceiveFromFlags,
-        ) -> litebox_broker_core::Result<SocketOutcome<ReceivedPlatformDatagram>> {
-            let received = data.len().min(3);
-            data[..received].copy_from_slice(&[4, 5, 6][..received]);
-            Ok(SocketOutcome::Completed(ReceivedPlatformDatagram {
-                received,
+        ) -> litebox_broker_core::Result<SocketOutcome<PlatformDatagramReceive>> {
+            let received = length.min(3);
+            Ok(SocketOutcome::Completed(PlatformDatagramReceive {
+                data: [4, 5, 6][..received].to_vec(),
                 datagram_length: 4,
                 source_address: SocketAddrV4::new(Ipv4Addr::LOCALHOST, 49153),
             }))

--- a/litebox_broker_platform_linux_userland/src/socket.rs
+++ b/litebox_broker_platform_linux_userland/src/socket.rs
@@ -16,8 +16,8 @@ use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
 use litebox_broker_core::socket::{
-    AcceptedPlatformSocket, PlatformConnectError, PlatformSocket, ReceivedPlatformDatagram,
-    SocketProvider,
+    AcceptedPlatformSocket, PlatformConnectError, PlatformDatagramReceive, PlatformSocket,
+    PlatformStreamReceive, ReceivedPlatformDatagram, SocketProvider,
 };
 use litebox_broker_core::{BrokerError, Result as BrokerResult, SessionId};
 use litebox_broker_protocol::readiness::ReadinessFlags;
@@ -165,15 +165,19 @@ impl PlatformSocket for LinuxSocket {
         self.reactor.connect(self.id, address)
     }
 
-    fn send(&self, data: &[u8], _flags: SendFlags) -> BrokerResult<SocketOutcome<usize>> {
+    fn send(&self, data: &[u8], flags: SendFlags) -> BrokerResult<SocketOutcome<usize>> {
         let mut owned = Vec::new();
         owned
             .try_reserve_exact(data.len())
             .map_err(|_| BrokerError::OutOfMemory)?;
         owned.extend_from_slice(data);
+        self.send_owned(owned, flags)
+    }
+
+    fn send_owned(&self, data: Vec<u8>, _flags: SendFlags) -> BrokerResult<SocketOutcome<usize>> {
         self.reactor.request(|response| ReactorCommand::Send {
             id: self.id,
-            data: owned,
+            data,
             response,
         })
     }
@@ -181,7 +185,7 @@ impl PlatformSocket for LinuxSocket {
     fn send_to(
         &self,
         data: &[u8],
-        _flags: SendFlags,
+        flags: SendFlags,
         destination: Option<SocketAddrV4>,
     ) -> BrokerResult<SocketOutcome<usize>> {
         let mut owned = Vec::new();
@@ -189,9 +193,18 @@ impl PlatformSocket for LinuxSocket {
             .try_reserve_exact(data.len())
             .map_err(|_| BrokerError::OutOfMemory)?;
         owned.extend_from_slice(data);
+        self.send_to_owned(owned, flags, destination)
+    }
+
+    fn send_to_owned(
+        &self,
+        data: Vec<u8>,
+        _flags: SendFlags,
+        destination: Option<SocketAddrV4>,
+    ) -> BrokerResult<SocketOutcome<usize>> {
         self.reactor.request(|response| ReactorCommand::SendTo {
             id: self.id,
-            data: owned,
+            data,
             destination,
             response,
         })
@@ -204,19 +217,8 @@ impl PlatformSocket for LinuxSocket {
         peek_offset: u32,
         peek_length: u32,
     ) -> BrokerResult<SocketOutcome<ReceiveSocketResponse>> {
-        let peek_offset =
-            usize::try_from(peek_offset).map_err(|_| BrokerError::UnsupportedOperation)?;
-        let peek_length =
-            usize::try_from(peek_length).map_err(|_| BrokerError::UnsupportedOperation)?;
-        match self.reactor.request(|response| ReactorCommand::Receive {
-            id: self.id,
-            length: data.len(),
-            flags,
-            peek_offset,
-            peek_length,
-            response,
-        })? {
-            ReactorReceiveOutcome::Received(received) => {
+        match self.receive_owned(data.len(), flags, peek_offset, peek_length)? {
+            SocketOutcome::Completed(PlatformStreamReceive::Received(received)) => {
                 data[..received.len()].copy_from_slice(&received);
                 Ok(SocketOutcome::Completed(ReceiveSocketResponse::Received(
                     received
@@ -225,8 +227,37 @@ impl PlatformSocket for LinuxSocket {
                         .map_err(|_| BrokerError::Internal)?,
                 )))
             }
-            ReactorReceiveOutcome::EndOfStream => {
+            SocketOutcome::Completed(PlatformStreamReceive::EndOfStream) => {
                 Ok(SocketOutcome::Completed(ReceiveSocketResponse::EndOfStream))
+            }
+            SocketOutcome::Failed(error) => Ok(SocketOutcome::Failed(error)),
+        }
+    }
+
+    fn receive_owned(
+        &self,
+        length: usize,
+        flags: ReceiveFlags,
+        peek_offset: u32,
+        peek_length: u32,
+    ) -> BrokerResult<SocketOutcome<PlatformStreamReceive>> {
+        let peek_offset =
+            usize::try_from(peek_offset).map_err(|_| BrokerError::UnsupportedOperation)?;
+        let peek_length =
+            usize::try_from(peek_length).map_err(|_| BrokerError::UnsupportedOperation)?;
+        match self.reactor.request(|response| ReactorCommand::Receive {
+            id: self.id,
+            length,
+            flags,
+            peek_offset,
+            peek_length,
+            response,
+        })? {
+            ReactorReceiveOutcome::Received(received) => Ok(SocketOutcome::Completed(
+                PlatformStreamReceive::Received(received),
+            )),
+            ReactorReceiveOutcome::EndOfStream => {
+                Ok(SocketOutcome::Completed(PlatformStreamReceive::EndOfStream))
             }
             ReactorReceiveOutcome::Failed(error) => Ok(SocketOutcome::Failed(error)),
         }
@@ -237,11 +268,29 @@ impl PlatformSocket for LinuxSocket {
         data: &mut [u8],
         flags: ReceiveFromFlags,
     ) -> BrokerResult<SocketOutcome<ReceivedPlatformDatagram>> {
+        match self.receive_from_owned(data.len(), flags)? {
+            SocketOutcome::Completed(received) => {
+                data[..received.data.len()].copy_from_slice(&received.data);
+                Ok(SocketOutcome::Completed(ReceivedPlatformDatagram {
+                    received: received.data.len(),
+                    datagram_length: received.datagram_length,
+                    source_address: received.source_address,
+                }))
+            }
+            SocketOutcome::Failed(error) => Ok(SocketOutcome::Failed(error)),
+        }
+    }
+
+    fn receive_from_owned(
+        &self,
+        length: usize,
+        flags: ReceiveFromFlags,
+    ) -> BrokerResult<SocketOutcome<PlatformDatagramReceive>> {
         match self
             .reactor
             .request(|response| ReactorCommand::ReceiveFrom {
                 id: self.id,
-                length: data.len(),
+                length,
                 flags,
                 response,
             })? {
@@ -249,14 +298,11 @@ impl PlatformSocket for LinuxSocket {
                 data: received,
                 datagram_length,
                 source_address,
-            } => {
-                data[..received.len()].copy_from_slice(&received);
-                Ok(SocketOutcome::Completed(ReceivedPlatformDatagram {
-                    received: received.len(),
-                    datagram_length,
-                    source_address,
-                }))
-            }
+            } => Ok(SocketOutcome::Completed(PlatformDatagramReceive {
+                data: received,
+                datagram_length,
+                source_address,
+            })),
             ReactorReceiveFromOutcome::Failed(error) => Ok(SocketOutcome::Failed(error)),
         }
     }

--- a/litebox_broker_platform_linux_userland/src/socket.rs
+++ b/litebox_broker_platform_linux_userland/src/socket.rs
@@ -17,15 +17,15 @@ use std::time::Duration;
 
 use litebox_broker_core::socket::{
     AcceptedPlatformSocket, PlatformConnectError, PlatformDatagramReceive, PlatformSocket,
-    PlatformStreamReceive, ReceivedPlatformDatagram, SocketProvider,
+    PlatformStreamReceive, SocketProvider,
 };
 use litebox_broker_core::{BrokerError, Result as BrokerResult, SessionId};
 use litebox_broker_protocol::readiness::ReadinessFlags;
 use litebox_broker_protocol::socket::{
     AddressFamily, CreateSocketRequest, IpProtocol, MAX_SOCKET_PEEK_SIZE, MAX_SOCKET_TRANSFER_SIZE,
-    MAX_UDP_DATAGRAM_SIZE, ReceiveFlags, ReceiveFromFlags, ReceiveSocketResponse, SendFlags,
-    ShutdownMode, SocketConnectionStatus, SocketError, SocketOutcome, SocketStatusResponse,
-    SocketType, TcpOptionName, TcpOptionValue,
+    MAX_UDP_DATAGRAM_SIZE, ReceiveFlags, ReceiveFromFlags, SendFlags, ShutdownMode,
+    SocketConnectionStatus, SocketError, SocketOutcome, SocketStatusResponse, SocketType,
+    TcpOptionName, TcpOptionValue,
 };
 use rustix::buffer::spare_capacity;
 use rustix::event::{EventfdFlags, PollFd, PollFlags, Timespec, epoll, eventfd, poll};
@@ -165,16 +165,7 @@ impl PlatformSocket for LinuxSocket {
         self.reactor.connect(self.id, address)
     }
 
-    fn send(&self, data: &[u8], flags: SendFlags) -> BrokerResult<SocketOutcome<usize>> {
-        let mut owned = Vec::new();
-        owned
-            .try_reserve_exact(data.len())
-            .map_err(|_| BrokerError::OutOfMemory)?;
-        owned.extend_from_slice(data);
-        self.send_owned(owned, flags)
-    }
-
-    fn send_owned(&self, data: Vec<u8>, _flags: SendFlags) -> BrokerResult<SocketOutcome<usize>> {
+    fn send(&self, data: Vec<u8>, _flags: SendFlags) -> BrokerResult<SocketOutcome<usize>> {
         self.reactor.request(|response| ReactorCommand::Send {
             id: self.id,
             data,
@@ -183,20 +174,6 @@ impl PlatformSocket for LinuxSocket {
     }
 
     fn send_to(
-        &self,
-        data: &[u8],
-        flags: SendFlags,
-        destination: Option<SocketAddrV4>,
-    ) -> BrokerResult<SocketOutcome<usize>> {
-        let mut owned = Vec::new();
-        owned
-            .try_reserve_exact(data.len())
-            .map_err(|_| BrokerError::OutOfMemory)?;
-        owned.extend_from_slice(data);
-        self.send_to_owned(owned, flags, destination)
-    }
-
-    fn send_to_owned(
         &self,
         data: Vec<u8>,
         _flags: SendFlags,
@@ -211,30 +188,6 @@ impl PlatformSocket for LinuxSocket {
     }
 
     fn receive(
-        &self,
-        data: &mut [u8],
-        flags: ReceiveFlags,
-        peek_offset: u32,
-        peek_length: u32,
-    ) -> BrokerResult<SocketOutcome<ReceiveSocketResponse>> {
-        match self.receive_owned(data.len(), flags, peek_offset, peek_length)? {
-            SocketOutcome::Completed(PlatformStreamReceive::Received(received)) => {
-                data[..received.len()].copy_from_slice(&received);
-                Ok(SocketOutcome::Completed(ReceiveSocketResponse::Received(
-                    received
-                        .len()
-                        .try_into()
-                        .map_err(|_| BrokerError::Internal)?,
-                )))
-            }
-            SocketOutcome::Completed(PlatformStreamReceive::EndOfStream) => {
-                Ok(SocketOutcome::Completed(ReceiveSocketResponse::EndOfStream))
-            }
-            SocketOutcome::Failed(error) => Ok(SocketOutcome::Failed(error)),
-        }
-    }
-
-    fn receive_owned(
         &self,
         length: usize,
         flags: ReceiveFlags,
@@ -264,24 +217,6 @@ impl PlatformSocket for LinuxSocket {
     }
 
     fn receive_from(
-        &self,
-        data: &mut [u8],
-        flags: ReceiveFromFlags,
-    ) -> BrokerResult<SocketOutcome<ReceivedPlatformDatagram>> {
-        match self.receive_from_owned(data.len(), flags)? {
-            SocketOutcome::Completed(received) => {
-                data[..received.data.len()].copy_from_slice(&received.data);
-                Ok(SocketOutcome::Completed(ReceivedPlatformDatagram {
-                    received: received.data.len(),
-                    datagram_length: received.datagram_length,
-                    source_address: received.source_address,
-                }))
-            }
-            SocketOutcome::Failed(error) => Ok(SocketOutcome::Failed(error)),
-        }
-    }
-
-    fn receive_from_owned(
         &self,
         length: usize,
         flags: ReceiveFromFlags,
@@ -2099,13 +2034,90 @@ mod tests {
     use super::*;
     use litebox_broker_core::readiness::ReadinessSink;
     use litebox_broker_core::{
-        BrokerCore, BrokerCoreLimits, CallerCredential, DestinationPortRange, DestinationRule,
-        Ipv4Cidr, ObjectRights, PolicyEngine, SocketPolicy,
+        BrokerCore, BrokerCoreLimits, BrokerSession, CallerCredential, DestinationPortRange,
+        DestinationRule, Ipv4Cidr, ObjectRights, PolicyEngine, SocketPolicy,
     };
     use litebox_broker_protocol::ObjectHandle;
-    use litebox_broker_protocol::socket::{Ipv4Address, Port};
+    use litebox_broker_protocol::socket::{Ipv4Address, Port, ReceiveSocketResponse};
 
     const TEST_TIMEOUT: Duration = Duration::from_secs(5);
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    struct ReceivedPlatformDatagram {
+        received: usize,
+        datagram_length: usize,
+        source_address: SocketAddrV4,
+    }
+
+    fn send_bytes(
+        session: &BrokerSession,
+        handle: ObjectHandle,
+        data: &[u8],
+        flags: SendFlags,
+    ) -> BrokerResult<SocketOutcome<usize>> {
+        litebox_broker_core::socket::send(session, handle, data.to_vec(), flags)
+    }
+
+    fn send_datagram(
+        session: &BrokerSession,
+        handle: ObjectHandle,
+        data: &[u8],
+        flags: SendFlags,
+        destination: Option<SocketAddrV4>,
+    ) -> BrokerResult<SocketOutcome<usize>> {
+        litebox_broker_core::socket::send_to(session, handle, data.to_vec(), flags, destination)
+    }
+
+    fn receive_into(
+        session: &BrokerSession,
+        handle: ObjectHandle,
+        data: &mut [u8],
+        flags: ReceiveFlags,
+        peek_offset: u32,
+        peek_length: u32,
+    ) -> BrokerResult<SocketOutcome<ReceiveSocketResponse>> {
+        match litebox_broker_core::socket::receive(
+            session,
+            handle,
+            data.len(),
+            flags,
+            peek_offset,
+            peek_length,
+        )? {
+            SocketOutcome::Completed(PlatformStreamReceive::Received(received)) => {
+                data[..received.len()].copy_from_slice(&received);
+                Ok(SocketOutcome::Completed(ReceiveSocketResponse::Received(
+                    received
+                        .len()
+                        .try_into()
+                        .map_err(|_| BrokerError::Internal)?,
+                )))
+            }
+            SocketOutcome::Completed(PlatformStreamReceive::EndOfStream) => {
+                Ok(SocketOutcome::Completed(ReceiveSocketResponse::EndOfStream))
+            }
+            SocketOutcome::Failed(error) => Ok(SocketOutcome::Failed(error)),
+        }
+    }
+
+    fn receive_datagram_into(
+        session: &BrokerSession,
+        handle: ObjectHandle,
+        data: &mut [u8],
+        flags: ReceiveFromFlags,
+    ) -> BrokerResult<SocketOutcome<ReceivedPlatformDatagram>> {
+        match litebox_broker_core::socket::receive_from(session, handle, data.len(), flags)? {
+            SocketOutcome::Completed(received) => {
+                data[..received.data.len()].copy_from_slice(&received.data);
+                Ok(SocketOutcome::Completed(ReceivedPlatformDatagram {
+                    received: received.data.len(),
+                    datagram_length: received.datagram_length,
+                    source_address: received.source_address,
+                }))
+            }
+            SocketOutcome::Failed(error) => Ok(SocketOutcome::Failed(error)),
+        }
+    }
 
     #[test]
     fn cached_socket_error_precedes_a_new_kernel_error() {
@@ -2284,18 +2296,11 @@ mod tests {
 
         let mut unavailable = [0_u8; 1];
         assert_eq!(
-            litebox_broker_core::socket::receive(
-                &session,
-                handle,
-                &mut unavailable,
-                ReceiveFlags::NONE,
-                0,
-                0,
-            ),
+            receive_into(&session, handle, &mut unavailable, ReceiveFlags::NONE, 0, 0,),
             Err(BrokerError::WouldBlock)
         );
         assert_eq!(
-            litebox_broker_core::socket::send(&session, handle, b"ping", SendFlags::NONE,),
+            send_bytes(&session, handle, b"ping", SendFlags::NONE,),
             Ok(SocketOutcome::Completed(4))
         );
         assert_eq!(
@@ -2303,7 +2308,7 @@ mod tests {
             Ok(SocketOutcome::Completed(()))
         );
         assert_eq!(
-            litebox_broker_core::socket::send(&session, handle, b"after shutdown", SendFlags::NONE),
+            send_bytes(&session, handle, b"after shutdown", SendFlags::NONE),
             Ok(SocketOutcome::Failed(SocketError::Other))
         );
         allow_response.send(()).unwrap();
@@ -2314,14 +2319,7 @@ mod tests {
 
         let mut first = [0_u8; 1];
         assert_eq!(
-            litebox_broker_core::socket::receive(
-                &session,
-                handle,
-                &mut first,
-                ReceiveFlags::NONE,
-                0,
-                0,
-            ),
+            receive_into(&session, handle, &mut first, ReceiveFlags::NONE, 0, 0,),
             Ok(SocketOutcome::Completed(ReceiveSocketResponse::Received(1)))
         );
         assert_eq!(&first, b"p");
@@ -2333,27 +2331,13 @@ mod tests {
         );
         let mut peeked = [0_u8; 3];
         assert_eq!(
-            litebox_broker_core::socket::receive(
-                &session,
-                handle,
-                &mut peeked,
-                ReceiveFlags::PEEK,
-                0,
-                3,
-            ),
+            receive_into(&session, handle, &mut peeked, ReceiveFlags::PEEK, 0, 3,),
             Ok(SocketOutcome::Completed(ReceiveSocketResponse::Received(3)))
         );
         assert_eq!(&peeked, b"ong");
         let mut received = [0_u8; 3];
         assert_eq!(
-            litebox_broker_core::socket::receive(
-                &session,
-                handle,
-                &mut received,
-                ReceiveFlags::NONE,
-                0,
-                0,
-            ),
+            receive_into(&session, handle, &mut received, ReceiveFlags::NONE, 0, 0,),
             Ok(SocketOutcome::Completed(ReceiveSocketResponse::Received(3)))
         );
         assert_eq!(&received, b"ong");
@@ -2364,14 +2348,7 @@ mod tests {
                 .contains(ReadinessFlags::READ)
         );
         assert_eq!(
-            litebox_broker_core::socket::receive(
-                &session,
-                handle,
-                &mut unavailable,
-                ReceiveFlags::NONE,
-                0,
-                0,
-            ),
+            receive_into(&session, handle, &mut unavailable, ReceiveFlags::NONE, 0, 0,),
             Err(BrokerError::WouldBlock)
         );
         assert!(
@@ -2404,7 +2381,7 @@ mod tests {
         wait_for_readiness(&publications, read_shutdown_handle, ReadinessFlags::READ);
         let mut read_shutdown_peek = [0_u8; 2];
         assert_eq!(
-            litebox_broker_core::socket::receive(
+            receive_into(
                 &session,
                 read_shutdown_handle,
                 &mut read_shutdown_peek,
@@ -2424,7 +2401,7 @@ mod tests {
         );
         wait_for_readiness(&publications, read_shutdown_handle, ReadinessFlags::READ);
         assert_eq!(
-            litebox_broker_core::socket::receive(
+            receive_into(
                 &session,
                 read_shutdown_handle,
                 &mut read_shutdown_peek,
@@ -2437,7 +2414,7 @@ mod tests {
         assert_eq!(read_shutdown_peek[0], b'x');
         let mut queued_after_shutdown = [0_u8; 1];
         assert_eq!(
-            litebox_broker_core::socket::receive(
+            receive_into(
                 &session,
                 read_shutdown_handle,
                 &mut queued_after_shutdown,
@@ -2455,7 +2432,7 @@ mod tests {
                 .contains(ReadinessFlags::READ)
         );
         assert_eq!(
-            litebox_broker_core::socket::receive(
+            receive_into(
                 &session,
                 read_shutdown_handle,
                 &mut queued_after_shutdown,
@@ -2472,7 +2449,7 @@ mod tests {
 
         let unconnected_handle = create_socket(&session, readiness.clone());
         assert_eq!(
-            litebox_broker_core::socket::receive(
+            receive_into(
                 &session,
                 unconnected_handle,
                 &mut unavailable,
@@ -2727,7 +2704,7 @@ mod tests {
         first_client.write_all(b"request").unwrap();
         let mut request = [0_u8; 7];
         loop {
-            match litebox_broker_core::socket::receive(
+            match receive_into(
                 &session,
                 first.handle,
                 &mut request,
@@ -2744,7 +2721,7 @@ mod tests {
         }
         assert_eq!(&request, b"request");
         assert_eq!(
-            litebox_broker_core::socket::send(&session, first.handle, b"response", SendFlags::NONE,),
+            send_bytes(&session, first.handle, b"response", SendFlags::NONE,),
             Ok(SocketOutcome::Completed(8))
         );
         let mut response = [0_u8; 8];
@@ -2841,7 +2818,7 @@ mod tests {
         assert!(shutdown_readiness.contains(ReadinessFlags::READ));
         assert!(!shutdown_readiness.contains(ReadinessFlags::WRITE));
         assert_eq!(
-            litebox_broker_core::socket::send_to(
+            send_datagram(
                 &session,
                 shutdown_handle,
                 b"after shutdown",
@@ -2852,7 +2829,7 @@ mod tests {
         );
         let mut shutdown_data = [0; 1];
         assert_eq!(
-            litebox_broker_core::socket::receive_from(
+            receive_datagram_into(
                 &session,
                 shutdown_handle,
                 &mut shutdown_data,
@@ -2867,7 +2844,7 @@ mod tests {
         );
 
         assert_eq!(
-            litebox_broker_core::socket::send_to(
+            send_datagram(
                 &session,
                 handle,
                 b"denied",
@@ -2877,7 +2854,7 @@ mod tests {
             Ok(SocketOutcome::Failed(SocketError::PolicyDenied))
         );
         assert_eq!(
-            litebox_broker_core::socket::send_to(
+            send_datagram(
                 &session,
                 handle,
                 b"implicit bind",
@@ -2894,16 +2871,11 @@ mod tests {
         assert_ne!(implicitly_bound.port(), 0);
         let mut no_data = [0; 1];
         assert_eq!(
-            litebox_broker_core::socket::receive_from(
-                &session,
-                handle,
-                &mut no_data,
-                ReceiveFromFlags::NONE,
-            ),
+            receive_datagram_into(&session, handle, &mut no_data, ReceiveFromFlags::NONE,),
             Err(BrokerError::WouldBlock)
         );
         assert_eq!(
-            litebox_broker_core::socket::send_to(
+            send_datagram(
                 &session,
                 handle,
                 b"ping",
@@ -2926,12 +2898,7 @@ mod tests {
         wait_for_readiness(&publications, handle, ReadinessFlags::READ);
         let mut zero = [];
         assert_eq!(
-            litebox_broker_core::socket::receive_from(
-                &session,
-                handle,
-                &mut zero,
-                ReceiveFromFlags::NONE,
-            ),
+            receive_datagram_into(&session, handle, &mut zero, ReceiveFromFlags::NONE,),
             Ok(SocketOutcome::Completed(ReceivedPlatformDatagram {
                 received: 0,
                 datagram_length: 0,
@@ -2939,12 +2906,7 @@ mod tests {
             }))
         );
         assert_eq!(
-            litebox_broker_core::socket::receive_from(
-                &session,
-                handle,
-                &mut zero,
-                ReceiveFromFlags::NONE,
-            ),
+            receive_datagram_into(&session, handle, &mut zero, ReceiveFromFlags::NONE,),
             Err(BrokerError::WouldBlock)
         );
 
@@ -2952,12 +2914,7 @@ mod tests {
         wait_for_readiness(&publications, handle, ReadinessFlags::READ);
         let mut peeked = [0; 3];
         assert_eq!(
-            litebox_broker_core::socket::receive_from(
-                &session,
-                handle,
-                &mut peeked,
-                ReceiveFromFlags::PEEK,
-            ),
+            receive_datagram_into(&session, handle, &mut peeked, ReceiveFromFlags::PEEK,),
             Ok(SocketOutcome::Completed(ReceivedPlatformDatagram {
                 received: 3,
                 datagram_length: 6,
@@ -2967,12 +2924,7 @@ mod tests {
         assert_eq!(&peeked, b"abc");
         let mut truncated = [0; 4];
         assert_eq!(
-            litebox_broker_core::socket::receive_from(
-                &session,
-                handle,
-                &mut truncated,
-                ReceiveFromFlags::NONE,
-            ),
+            receive_datagram_into(&session, handle, &mut truncated, ReceiveFromFlags::NONE,),
             Ok(SocketOutcome::Completed(ReceivedPlatformDatagram {
                 received: 4,
                 datagram_length: 6,
@@ -2981,12 +2933,7 @@ mod tests {
         );
         assert_eq!(&truncated, b"abcd");
         assert_eq!(
-            litebox_broker_core::socket::receive_from(
-                &session,
-                handle,
-                &mut no_data,
-                ReceiveFromFlags::NONE,
-            ),
+            receive_datagram_into(&session, handle, &mut no_data, ReceiveFromFlags::NONE,),
             Err(BrokerError::WouldBlock)
         );
 
@@ -2999,7 +2946,7 @@ mod tests {
         assert_eq!(connected_status.local_address, Some(source));
         let maximum = vec![0x5a; MAX_UDP_DATAGRAM_SIZE as usize];
         assert_eq!(
-            litebox_broker_core::socket::send_to(&session, handle, &maximum, SendFlags::NONE, None,),
+            send_datagram(&session, handle, &maximum, SendFlags::NONE, None,),
             Ok(SocketOutcome::Completed(maximum.len()))
         );
         let (received, connected_source) = server.recv_from(&mut packet).unwrap();
@@ -3015,18 +2962,12 @@ mod tests {
             Ok(SocketOutcome::Completed(SocketConnectionStatus::Connected))
         );
         assert_eq!(
-            litebox_broker_core::socket::send_to(
-                &session,
-                handle,
-                b"refused",
-                SendFlags::NONE,
-                None,
-            ),
+            send_datagram(&session, handle, b"refused", SendFlags::NONE, None,),
             Ok(SocketOutcome::Completed(7))
         );
         wait_for_readiness(&publications, handle, ReadinessFlags::ERROR);
         assert_eq!(
-            litebox_broker_core::socket::send_to(
+            send_datagram(
                 &session,
                 handle,
                 b"broadcast",
@@ -3047,13 +2988,7 @@ mod tests {
                 .contains(ReadinessFlags::ERROR)
         );
         assert_eq!(
-            litebox_broker_core::socket::send_to(
-                &session,
-                handle,
-                b"refused again",
-                SendFlags::NONE,
-                None,
-            ),
+            send_datagram(&session, handle, b"refused again", SendFlags::NONE, None,),
             Ok(SocketOutcome::Completed(13))
         );
         wait_for_readiness(&publications, handle, ReadinessFlags::ERROR);
@@ -3096,13 +3031,7 @@ mod tests {
                 .contains(ReadinessFlags::WRITE)
         );
         assert_eq!(
-            litebox_broker_core::socket::send_to(
-                &session,
-                handle,
-                b"after shutdown",
-                SendFlags::NONE,
-                None,
-            ),
+            send_datagram(&session, handle, b"after shutdown", SendFlags::NONE, None,),
             Ok(SocketOutcome::Failed(SocketError::Other))
         );
 
@@ -3186,14 +3115,7 @@ mod tests {
         let deadline = Instant::now() + TEST_TIMEOUT;
         loop {
             let mut byte = [0_u8; 1];
-            match litebox_broker_core::socket::receive(
-                session,
-                handle,
-                &mut byte,
-                ReceiveFlags::NONE,
-                0,
-                0,
-            ) {
+            match receive_into(session, handle, &mut byte, ReceiveFlags::NONE, 0, 0) {
                 Ok(SocketOutcome::Completed(ReceiveSocketResponse::EndOfStream)) => return,
                 Err(BrokerError::WouldBlock) => {
                     wait_for_readiness_until(


### PR DESCRIPTION
This PR removes the slice-based broker socket APIs and passes owned `Vec<u8>` payloads end to end through the broker host, core, and Linux reactor, eliminating the extra platform-boundary copies on send and receive without changing the broker protocol wire format or version.