### PR TITLE
Add bottom-up mmap to OP-TEE shim

### DIFF
--- a/litebox_shim_optee/src/syscalls/mm.rs
+++ b/litebox_shim_optee/src/syscalls/mm.rs
@@ -3,10 +3,14 @@
 
 //! Implementation of memory management related syscalls, eg., `mmap`, `munmap`, etc.
 
-use litebox::mm::linux::{MappingError, PAGE_SIZE};
+use litebox::mm::linux::{MappingError, PAGE_SIZE, VmFlags};
+use litebox::platform::page_mgmt::PageManagementProvider;
 use litebox_common_linux::{MapFlags, ProtFlags, errno::Errno, user_pointers::UserPtrMut};
 
 use crate::{Platform, Task, UserMutPtr};
+
+// Keep bottom-up placement consistent with LiteBox's private Vmem stack policy.
+const STACK_GUARD_GAP: usize = 256 << 12;
 
 #[inline]
 fn align_up(addr: usize, align: usize) -> Option<usize> {
@@ -15,6 +19,39 @@ fn align_up(addr: usize, align: usize) -> Option<usize> {
 }
 
 impl Task {
+    /// Finds the first address-space gap from low to high.
+    ///
+    /// OP-TEE chooses user VAs bottom-up. Matching that order matters because
+    /// `ldelf`'s sequential segment allocations with padding rely on it, while
+    /// LiteBox's default VA placement is top-down.
+    fn find_bottom_up_gap(&self, len: usize) -> Option<usize> {
+        debug_assert!(len.is_multiple_of(PAGE_SIZE));
+        let task_addr_min = <Platform as PageManagementProvider<PAGE_SIZE>>::TASK_ADDR_MIN;
+        let task_addr_max = <Platform as PageManagementProvider<PAGE_SIZE>>::TASK_ADDR_MAX;
+        let mut candidate = task_addr_min..task_addr_min.checked_add(len)?;
+        if candidate.end > task_addr_max {
+            return None;
+        }
+        // `PageManager::mappings()` returns mappings ordered by ascending start address.
+        for (range, flags) in self.global.pm.mappings() {
+            let protected_range = if flags.contains(VmFlags::VM_GROWSDOWN) {
+                range.start.saturating_sub(STACK_GUARD_GAP << 1)
+            } else {
+                range.start
+            }..range.end;
+            if candidate.end <= protected_range.start {
+                return Some(candidate.start);
+            }
+            if candidate.start < protected_range.end {
+                candidate = protected_range.end..protected_range.end.checked_add(len)?;
+                if candidate.end > task_addr_max {
+                    return None;
+                }
+            }
+        }
+        Some(candidate.start)
+    }
+
     #[inline]
     fn do_mmap_anonymous(
         &self,
@@ -75,7 +112,28 @@ impl Task {
             return Err(Errno::EOVERFLOW);
         }
 
-        let suggested_addr = if addr == 0 { None } else { Some(addr) };
+        let (suggested_addr, flags) = if addr == 0
+            && !flags.intersects(MapFlags::MAP_FIXED | MapFlags::MAP_FIXED_NOREPLACE)
+        {
+            debug_assert_ne!(
+                <Platform as PageManagementProvider<PAGE_SIZE>>::TASK_ADDR_MIN,
+                0,
+                "sys_mmap treats address zero as no hint"
+            );
+            // The mapping snapshot and fixed-address claim are separate operations.
+            // Since OP-TEE OS doesn't support multithreading and we serialize each TA
+            // instance's execution, this address space cannot change between them.
+            // We can use a bounded retry loop for the search and claim on EEXIST
+            // if we need to consider multithreaded TAs in the future.
+            (
+                Some(self.find_bottom_up_gap(aligned_len).ok_or(Errno::ENOMEM)?),
+                flags | MapFlags::MAP_FIXED_NOREPLACE,
+            )
+        } else if addr == 0 {
+            (None, flags)
+        } else {
+            (Some(addr), flags)
+        };
         let result = if flags.contains(MapFlags::MAP_ANONYMOUS) {
             self.do_mmap_anonymous(suggested_addr, aligned_len, prot, flags)
         } else {

--- a/litebox_shim_optee/src/syscalls/mm.rs
+++ b/litebox_shim_optee/src/syscalls/mm.rs
@@ -23,7 +23,7 @@ impl Task {
     ///
     /// OP-TEE chooses user VAs bottom-up. Matching that order matters because
     /// `ldelf`'s sequential segment allocations with padding rely on it, while
-    /// LiteBox's default VA placement is top-down.
+    /// LiteBox's `get_unmmaped_area` searches for free VAs top-down by default.
     fn find_bottom_up_gap(&self, len: usize) -> Option<usize> {
         debug_assert!(len.is_multiple_of(PAGE_SIZE));
         let task_addr_min = <Platform as PageManagementProvider<PAGE_SIZE>>::TASK_ADDR_MIN;

--- a/litebox_shim_optee/src/syscalls/tests.rs
+++ b/litebox_shim_optee/src/syscalls/tests.rs
@@ -66,3 +66,27 @@ fn test_sys_get_time_system_is_monotonic() {
     let second_ms = u64::from(second.seconds) * 1000 + u64::from(second.millis);
     assert!(second_ms >= first_ms, "system time went backwards");
 }
+
+#[test]
+fn test_sys_map_zi_uses_bottom_up_placement() {
+    use litebox::mm::linux::PAGE_SIZE;
+    use litebox_common_optee::LdelfMapFlags;
+
+    let task = init_platform();
+    let (header, header_cleanup) = task
+        .sys_map_zi(0, PAGE_SIZE, 0, 0, LdelfMapFlags::empty())
+        .expect("header mapping should succeed");
+    let (image, image_cleanup) = task
+        .sys_map_zi(
+            0,
+            PAGE_SIZE,
+            PAGE_SIZE,
+            2 * PAGE_SIZE,
+            LdelfMapFlags::empty(),
+        )
+        .expect("padded image mapping should succeed");
+
+    assert!(header < image, "OP-TEE-chosen mappings must grow upward");
+    image_cleanup.run(&task);
+    header_cleanup.run(&task);
+}


### PR DESCRIPTION
This PR makes the OP-TEE shim's mmap allocate virtual addresses (VAs) from low to high addresses. OP-TEE allocates userspace VAs bottom-up, whereas LiteBox allocates them top-down. This mismatch can lead to incompatibilities (e.g., padding management).