### PR TITLE
litebox_shim_linux: fix race in prepare_for_exit child TID write

### DIFF
--- a/litebox_shim_linux/src/syscalls/process.rs
+++ b/litebox_shim_linux/src/syscalls/process.rs
@@ -499,8 +499,6 @@ fn wake_robust_list(
 impl<FS: ShimFS> Task<FS> {
     /// Called when the task is exiting.
     pub(crate) fn prepare_for_exit(&mut self) {
-        self.thread.detach_from_process();
-
         if let Some(clear_child_tid) = self.thread.clear_child_tid.take() {
             // Clear the child TID if requested
             // TODO: if we are the last thread, we don't need to clear it
@@ -516,6 +514,14 @@ impl<FS: ShimFS> Task<FS> {
         if let Some(robust_list) = self.thread.robust_list.take() {
             let _ = wake_robust_list(robust_list);
         }
+
+        // This must run last, after all of this task's remaining accesses to
+        // guest memory have completed. Otherwise, because this decrements the
+        // `nr_threads` counter, other tasks may assume that the memory of this
+        // task isn't referenced any more, and therefore can be de-allocated and
+        // re-used (e.g., for an `exec`d process). See
+        // https://github.com/microsoft/litebox/pull/1155.
+        self.thread.detach_from_process();
     }
 
     pub(crate) fn sys_exit(&self, status: i32) {


### PR DESCRIPTION
This fixes a bug in `prepare_for_exit` in the LiteBox Linux shim. When a thread exits, it may indicate this by writing its child TID to a location in user memory. However, prior to this, `detach_from_process` is run, which decrements `nr_threads`. This is a signal for other tasks that this task no longer holds any references to process memory, and thus is ready to be deallocated. In the case of, e.g., an `exec` system call, this in turn introduces a "confused deputy" style write where the LiteBox kernel will either attempt to write to some unmapped pages (caught by the exception handlers and silently turned into a no-op), or writes into and corrupts the new process' memory.