### PR TITLE
Add support for AArch64 to the Linux userland platform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,7 @@ jobs:
         -p litebox
         -p litebox_common_linux
         -p litebox_syscall_rewriter
+        -p litebox_platform_linux_userland
     steps:
       - name: Check out repo
         uses: actions/checkout@v6

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1560,6 +1560,7 @@ dependencies = [
  "litebox",
  "litebox_common_linux",
  "litebox_common_optee",
+ "litebox_syscall_rewriter",
  "seccompiler",
  "spin 0.9.8",
  "syscalls",

--- a/litebox_platform_linux_userland/Cargo.toml
+++ b/litebox_platform_linux_userland/Cargo.toml
@@ -16,6 +16,12 @@ syscalls = { version = "0.6", default-features = false }
 zerocopy = { version = "0.8", default-features = false }
 seccompiler = { version = "0.5.0" }
 
+# The signal path recognizes rewriter gates from the bytes at the interrupted
+# PC, so it needs the rewriter's classifier. x86-64 needs no classifier: its
+# gate is a single fixed-length instruction.
+[target.'cfg(target_arch = "aarch64")'.dependencies]
+litebox_syscall_rewriter = { path = "../litebox_syscall_rewriter", version = "0.1.0", default-features = false }
+
 [features]
 default = ["linux_syscall"]
 linux_syscall = []

--- a/litebox_platform_linux_userland/src/aarch64.rs
+++ b/litebox_platform_linux_userland/src/aarch64.rs
@@ -1,0 +1,2499 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//! AArch64 guest/host transitions and signal recovery. `TPIDR_EL0` remains the
+//! host anchor; the guest thread pointer is virtualized in memory.
+
+use super::*;
+use litebox_syscall_rewriter::arm64::{
+    GATE_ALIGNMENT, GateMetadata, MRS_SLOT_BYTES, MSR_FRAME_BYTES, MSR_SLOT_BYTES, SVC_FRAME_BYTES,
+    SVC_GATE_BYTES, SVC_SLOT_BYTES,
+};
+
+/// Overwrites the destination with the TLS control-block address derived from
+/// the host anchor in `TPIDR_EL0`. Callbacks entered directly from a rewritten
+/// gate must use `x16`, the only scratch register provided by the gate ABI.
+/// Valid only for local-exec TLS in the main executable.
+macro_rules! load_tls_block_base {
+    ($reg:literal) => {
+        concat!(
+            "mrs ",
+            $reg,
+            ", tpidr_el0\n",
+            "add ",
+            $reg,
+            ", ",
+            $reg,
+            ", #:tprel_hi12:litebox_tls_block, lsl #12\n",
+            "add ",
+            $reg,
+            ", ",
+            $reg,
+            ", #:tprel_lo12_nc:litebox_tls_block\n",
+        )
+    };
+}
+pub(super) use load_tls_block_base;
+
+macro_rules! tprel_offset {
+    ($var:ident) => {
+        tprel_offset!(@sym stringify!($var))
+    };
+    ($var:literal) => {
+        tprel_offset!(@sym $var)
+    };
+    (@sym $var:expr) => {{
+        let offset: usize;
+        // SAFETY: reads no memory; materializes a link-time constant only.
+        unsafe {
+            core::arch::asm!(
+                concat!("movz {0}, #:tprel_g1:", $var),
+                concat!("movk {0}, #:tprel_g0_nc:", $var),
+                out(reg) offset,
+                options(pure, nomem, nostack, preserves_flags)
+            );
+        }
+        offset
+    }};
+}
+
+/// Layout of the AArch64 TLS control block.
+///
+/// A layout witness only: the storage is the `.tbss` block reserved below, and
+/// this type is never instantiated. Every offset the transition assembly uses
+/// is derived from it with [`core::mem::offset_of`], so the two cannot drift.
+#[repr(C)]
+struct TlsBlock {
+    /// Guest thread pointer — the slot rewritten guest binaries read and write
+    /// in place of the hardware `TPIDR_EL0`.
+    ///
+    /// Also part of the `litebox_syscall_rewriter` ABI, but dynamically: the
+    /// loader patches each rewritten binary's gates with this slot's measured
+    /// address (see [`guest_thread_pointer_tp_offset`]).
+    guest_thread_pointer: usize,
+    host_sp: usize,
+    guest_context_top: usize,
+    in_guest: u8,
+    interrupt: u8,
+    is_guest_thread: u8,
+    pending_host_signals: u32,
+    wait_waker_addr: usize,
+    outbound_stub: usize,
+    outbound_pc: usize,
+    resume_frame_initialized: u8,
+    resume_frame: resume_frame::ResumeFrame,
+}
+
+/// Byte offsets of [`TlsBlock`]'s fields, for the transition assembly.
+pub(super) mod tls_offset {
+    use super::TlsBlock;
+    use core::mem::offset_of;
+
+    pub(crate) const GUEST_THREAD_POINTER: usize = offset_of!(TlsBlock, guest_thread_pointer);
+    pub(crate) const HOST_SP: usize = offset_of!(TlsBlock, host_sp);
+    pub(crate) const GUEST_CONTEXT_TOP: usize = offset_of!(TlsBlock, guest_context_top);
+    pub(crate) const IN_GUEST: usize = offset_of!(TlsBlock, in_guest);
+    pub(crate) const INTERRUPT: usize = offset_of!(TlsBlock, interrupt);
+    pub(crate) const IS_GUEST_THREAD: usize = offset_of!(TlsBlock, is_guest_thread);
+    pub(crate) const PENDING_HOST_SIGNALS: usize = offset_of!(TlsBlock, pending_host_signals);
+    pub(crate) const WAIT_WAKER_ADDR: usize = offset_of!(TlsBlock, wait_waker_addr);
+    pub(crate) const OUTBOUND_STUB: usize = offset_of!(TlsBlock, outbound_stub);
+    pub(crate) const OUTBOUND_PC: usize = offset_of!(TlsBlock, outbound_pc);
+    pub(crate) const RESUME_FRAME_INITIALIZED: usize =
+        offset_of!(TlsBlock, resume_frame_initialized);
+    pub(crate) const RESUME_FRAME: usize = offset_of!(TlsBlock, resume_frame);
+}
+
+// Storage layout and alignment must exactly match `TlsBlock`.
+core::arch::global_asm!(
+    ".section .tbss, \"awT\", @nobits",
+    ".balign {align}",
+    ".globl litebox_tls_block",
+    "litebox_tls_block:",
+    ".zero {size}",
+    ".previous",
+    align = const core::mem::align_of::<TlsBlock>(),
+    size = const core::mem::size_of::<TlsBlock>(),
+);
+
+/// Byte offset of this thread's `guest_thread_pointer` slot from the thread
+/// pointer (TP) — `TPIDR_EL0` — as fixed by this binary's link.
+///
+/// The loader patches this into every rewritten guest binary's thread-pointer
+/// gates. The linker decides it per embedder, but it is the same on every
+/// thread.
+///
+/// # Panics
+///
+/// Panics if the offset is not one a gate can be patched to reach.
+pub(super) fn guest_thread_pointer_tp_offset() -> u16 {
+    let offset = tprel_offset!(litebox_tls_block) + tls_offset::GUEST_THREAD_POINTER;
+    u16::try_from(offset)
+        .ok()
+        .filter(|off| litebox_syscall_rewriter::arm64::is_patchable_guest_tpidr_offset(*off))
+        .expect(
+            "guest_thread_pointer must sit at a thread-pointer offset a rewriter gate can reach",
+        )
+}
+
+/// Verifies the resume-frame alignment and rewriter-gate reach invariants.
+///
+/// # Panics
+///
+/// Panics if either invariant is violated.
+pub(super) fn assert_tls_block_placement() {
+    let frame = tprel_offset!(litebox_tls_block) + tls_offset::RESUME_FRAME;
+    assert!(
+        frame.is_multiple_of(core::mem::align_of::<resume_frame::ResumeFrame>()),
+        "the resume frame is at thread-pointer offset {frame}, which `sys_rt_sigreturn` would \
+         reject, failing every asynchronous guest resume",
+    );
+
+    let _ = guest_thread_pointer_tp_offset();
+}
+
+pub(super) fn set_guest_thread_pointer(value: usize) {
+    // SAFETY: an own-thread [`tls_offset`] slot access.
+    unsafe {
+        core::arch::asm! {
+            load_tls_block_base!("{tmp}"),
+            "str {val}, [{tmp}, #{off}]",
+            tmp = out(reg) _,
+            val = in(reg) value,
+            off = const tls_offset::GUEST_THREAD_POINTER,
+            options(nostack, preserves_flags)
+        }
+    }
+}
+
+pub(super) fn set_is_guest_thread(value: bool) {
+    // SAFETY: an own-thread [`tls_offset`] slot access.
+    unsafe {
+        core::arch::asm! {
+            load_tls_block_base!("{tmp}"),
+            "strb {val:w}, [{tmp}, #{off}]",
+            tmp = out(reg) _,
+            val = in(reg) u32::from(value),
+            off = const tls_offset::IS_GUEST_THREAD,
+            options(nostack, preserves_flags)
+        }
+    }
+}
+
+pub(super) fn is_guest_thread() -> bool {
+    let value: u32;
+    // SAFETY: an own-thread [`tls_offset`] slot access. Also safe from a signal
+    // handler: `TPIDR_EL0` is the host anchor at all times, guest code included.
+    unsafe {
+        core::arch::asm! {
+            load_tls_block_base!("{tmp}"),
+            "ldrb {val:w}, [{tmp}, #{off}]",
+            tmp = out(reg) _,
+            val = out(reg) value,
+            off = const tls_offset::IS_GUEST_THREAD,
+            options(nostack, preserves_flags)
+        }
+    }
+    value != 0
+}
+
+pub(super) fn get_guest_thread_pointer() -> usize {
+    let value: usize;
+    // SAFETY: an own-thread [`tls_offset`] slot access.
+    unsafe {
+        core::arch::asm! {
+            load_tls_block_base!("{tmp}"),
+            "ldr {val}, [{tmp}, #{off}]",
+            tmp = out(reg) _,
+            val = out(reg) value,
+            off = const tls_offset::GUEST_THREAD_POINTER,
+            options(nostack, preserves_flags)
+        }
+    }
+    value
+}
+
+#[unsafe(naked)]
+pub(super) unsafe extern "C-unwind" fn run_thread_arch(
+    thread_ctx: &mut ThreadContext,
+    ctx: *mut litebox_common_linux::PtRegs,
+    reenter: u8,
+) {
+    core::arch::naked_asm!(
+    "
+    .cfi_startproc
+    // Preserve every AAPCS64 callee-saved register across guest execution.
+    stp x29, x30, [sp, #-160]!
+    .cfi_def_cfa_offset 160
+    .cfi_offset x29, -160
+    .cfi_offset x30, -152
+    mov x29, sp
+    // Anchor the CFA on the frame pointer so the `sub sp, sp, #16` below (and
+    // the callbacks' wholesale `mov sp, host_sp`) do not invalidate unwinding
+    // through the `bl`s.
+    //
+    // INVARIANT: this rule is in effect for the whole FDE, including the three
+    // alternate entry points below. Each of them is reached with `x29` holding
+    // *guest* state, so each must re-establish the host `x29` before its `bl`
+    // — otherwise a panic out of a handler would make the unwinder compute
+    // `CFA = guest_x29 + 160` and read a return address from guest-controlled
+    // memory. `x29 == host_sp + 16` by construction (see the `sub sp, sp, #16`
+    // below), so each re-establishes it from `host_sp`.
+    .cfi_def_cfa x29, 160
+    stp x19, x20, [sp, #16]
+    .cfi_offset x19, -144
+    .cfi_offset x20, -136
+    stp x21, x22, [sp, #32]
+    .cfi_offset x21, -128
+    .cfi_offset x22, -120
+    stp x23, x24, [sp, #48]
+    .cfi_offset x23, -112
+    .cfi_offset x24, -104
+    stp x25, x26, [sp, #64]
+    .cfi_offset x25, -96
+    .cfi_offset x26, -88
+    stp x27, x28, [sp, #80]
+    .cfi_offset x27, -80
+    .cfi_offset x28, -72
+    stp d8,  d9,  [sp, #96]
+    .cfi_offset d8, -64
+    .cfi_offset d9, -56
+    stp d10, d11, [sp, #112]
+    .cfi_offset d10, -48
+    .cfi_offset d11, -40
+    stp d12, d13, [sp, #128]
+    .cfi_offset d12, -32
+    .cfi_offset d13, -24
+    stp d14, d15, [sp, #144]
+    .cfi_offset d14, -16
+    .cfi_offset d15, -8
+
+    sub sp, sp, #16
+    str x0, [sp]
+
+    ",
+    load_tls_block_base!("x8"),
+    "
+    mov x9, sp
+    str x9, [x8, #{HOST_SP}]
+    add x9, x1, #{GUEST_CONTEXT_SIZE}
+    str x9, [x8, #{GUEST_CONTEXT_TOP}]
+
+    // AAPCS64 leaves the upper bits of a `u8` parameter undefined.
+    tst  w2, #0xff
+    b.ne 1f
+    bl {init_handler}
+    b .Ldone_aarch64
+1:
+    bl {reenter_handler}
+    b .Ldone_aarch64
+
+    // Entered by `BR X16` from a rewriter-emitted SVC slot when the
+    // guest issues a syscall. State on entry (rewriter ABI, see
+    // `litebox_syscall_rewriter::arm64` module docs):
+    //
+    //   | Item                     | Value                                  |
+    //   | ------------------------ | -------------------------------------- |
+    //   | x16                      | clobbered (holds the callback address) |
+    //   | [sp, #0]                 | saved guest x16                        |
+    //   | [sp, #8]                 | guest resume PC (svc_site + 4)         |
+    //   | [sp, #16]                | this site's outbound stub address      |
+    //   | sp                       | guest SP minus 32 (gate frame is live) |
+    //   | x0-x15, x17-x30, NZCV    | pristine guest values                  |
+    //   | TPIDR_EL0                | host anchor                            |
+    .globl syscall_callback
+syscall_callback:
+    // Clear `in_guest`. This takes four instructions, so a pc can sit inside
+    // the prologue with `in_guest` still 1. `in_syscall_callback_prologue`
+    // tests the half-open range up to the label below; keep that label
+    // immediately after the `strb`.
+    ",
+    load_tls_block_base!("x16"),
+    "
+    strb wzr, [x16, #{IN_GUEST}]
+    .globl syscall_callback_in_guest_cleared
+syscall_callback_in_guest_cleared:
+
+    // Literal `PtRegs` offsets below are pinned by `tests::test_ptregs_layout`.
+    ldr  x16, [x16, #{GUEST_CONTEXT_TOP}]
+    sub  x16, x16, #{GUEST_CONTEXT_SIZE}
+
+    stp  x0,  x1,  [x16]
+    stp  x2,  x3,  [x16, #16]
+    stp  x4,  x5,  [x16, #32]
+    stp  x6,  x7,  [x16, #48]
+    stp  x8,  x9,  [x16, #64]
+    stp  x10, x11, [x16, #80]
+    stp  x12, x13, [x16, #96]
+    stp  x14, x15, [x16, #112]
+
+    // Guest x16 and the resume PC come off the gate frame. The pair load
+    // spells the rewriter's two offsets implicitly, so they are asserted below.
+    ldp  x0,  x1,  [sp]
+    str  x0,  [x16, #128]         // regs[16] = guest x16
+    str  x17, [x16, #136]
+    str  x18, [x16, #144]
+    stp  x19, x20, [x16, #152]
+    stp  x21, x22, [x16, #168]
+    stp  x23, x24, [x16, #184]
+    stp  x25, x26, [x16, #200]
+    stp  x27, x28, [x16, #216]
+    stp  x29, x30, [x16, #232]
+
+    add  x0,  sp,  #{SVC_FRAME_BYTES}
+    str  x0,  [x16, #248]         // sp: undo the gate's frame, so `PtRegs::sp`
+                                  // is the true guest SP the shim expects
+    str  x1,  [x16, #256]         // pc
+
+    // Publish these before leaving the guest stack: the gate frame lies below
+    // guest SP and need not survive the shim round trip.
+    ldr  x0,  [sp,  #{SVC_FRAME_OFF_STUB}]
+    ",
+    load_tls_block_base!("x17"),
+    "
+    str  x0,  [x17, #{OUTBOUND_STUB}]
+    str  x1,  [x17, #{OUTBOUND_PC}]
+
+    mrs  x0,  nzcv
+    str  x0,  [x16, #264]         // pstate
+    ldr  x0,  [x16]
+    str  x0,  [x16, #272]         // orig_x0
+    str  w8,  [x16, #280]         // syscallno
+    // regs[0] = -ENOSYS, matching what Linux leaves in x0 on syscall entry.
+    // The negative immediate assembles to `MOVN`, i.e. a sign-extended 64-bit
+    // value rather than a zero-extended 32-bit one.
+    mov  x0,  #-{ENOSYS}
+    str  x0,  [x16]
+
+    // `x29` still holds the guest's frame pointer at this point (it was
+    // spilled to `regs[29]` above). Re-establish the host value before the
+    // `bl`, or the `.cfi_def_cfa x29, 160` rule would resolve against guest
+    // memory if `syscall_handler` unwinds. `host_sp` is the frame base minus
+    // the 16-byte `thread_ctx` slot, so the host `x29` is `host_sp + 16`.
+    ",
+    load_tls_block_base!("x17"),
+    "
+    ldr  x17, [x17, #{HOST_SP}]
+    mov  sp,  x17
+    add  x29, sp,  #16
+    ldr  x0,  [sp]                // thread_ctx
+    bl   {syscall_handler}
+    b    .Ldone_aarch64
+
+    // Entered from `exception_signal_handler` via `set_signal_return`, which
+    // parks the handler arguments in `regs[0..3]` -> x0-x3 on entry here.
+    // Argument 0 is a placeholder that this stub overwrites with `thread_ctx`;
+    // arguments 1-3 (the signal number standing in for a trap number, a zero
+    // error code, and the fault address) are already in x1-x3 and must not be
+    // clobbered, so this stub scratches only x9 and above.
+    //
+    // `x29` arrives holding guest state (this is a signal return out of guest
+    // execution), so it is re-established before the `bl`; see the
+    // `.cfi_def_cfa x29, 160` invariant above.
+    .globl exception_callback
+exception_callback:
+    ",
+    load_tls_block_base!("x9"),
+    "
+    ldr x9, [x9, #{HOST_SP}]
+    mov sp, x9
+    add x29, sp, #16
+    ldr x0, [sp]                  // thread_ctx
+    bl {exception_handler}
+    b .Ldone_aarch64
+
+    // Entered either from `interrupt_signal_handler` via `set_signal_return`
+    // (all four arguments are placeholders) or by a direct branch from
+    // `switch_to_guest` when the `interrupt` byte was already set.
+    // `interrupt_handler` takes only `thread_ctx`.
+    //
+    // Both entry paths arrive with a guest `x29`, so it is re-established
+    // before the `bl`; see the `.cfi_def_cfa x29, 160` invariant above.
+    .globl interrupt_callback
+interrupt_callback:
+    ",
+    load_tls_block_base!("x9"),
+    "
+    ldr x9, [x9, #{HOST_SP}]
+    mov sp, x9
+    add x29, sp, #16
+    ldr x0, [sp]                  // thread_ctx
+    bl {interrupt_handler}
+    b .Ldone_aarch64
+
+.Ldone_aarch64:
+    add sp, sp, #16
+    ldp x19, x20, [sp, #16]
+    ldp x21, x22, [sp, #32]
+    ldp x23, x24, [sp, #48]
+    ldp x25, x26, [sp, #64]
+    ldp x27, x28, [sp, #80]
+    ldp d8,  d9,  [sp, #96]
+    ldp d10, d11, [sp, #112]
+    ldp d12, d13, [sp, #128]
+    ldp d14, d15, [sp, #144]
+    ldp x29, x30, [sp], #160
+    .cfi_def_cfa sp, 0
+    ret
+    .cfi_endproc
+",
+    GUEST_CONTEXT_SIZE = const core::mem::size_of::<litebox_common_linux::PtRegs>(),
+    HOST_SP = const tls_offset::HOST_SP,
+    GUEST_CONTEXT_TOP = const tls_offset::GUEST_CONTEXT_TOP,
+    IN_GUEST = const tls_offset::IN_GUEST,
+    OUTBOUND_STUB = const tls_offset::OUTBOUND_STUB,
+    OUTBOUND_PC = const tls_offset::OUTBOUND_PC,
+    SVC_FRAME_BYTES = const litebox_syscall_rewriter::arm64::SVC_FRAME_BYTES,
+    SVC_FRAME_OFF_STUB = const litebox_syscall_rewriter::arm64::SVC_FRAME_OFF_STUB,
+    ENOSYS = const libc::ENOSYS,
+    init_handler = sym init_handler,
+    reenter_handler = sym reenter_handler,
+    syscall_handler = sym syscall_handler,
+    exception_handler = sym exception_handler,
+    interrupt_handler = sym interrupt_handler,
+    );
+}
+
+/// `ldp x0, x1, [sp]` in `syscall_callback` reads the gate frame's two fields
+/// as a pair, which only works at these offsets.
+const _: () = assert!(
+    litebox_syscall_rewriter::arm64::SVC_FRAME_OFF_X16 == 0
+        && litebox_syscall_rewriter::arm64::SVC_FRAME_OFF_RETADDR == 8
+);
+
+/// The kernel's `struct rt_sigframe`, synthesized by the runtime so that an
+/// *asynchronous* guest resume can restore all 31 GPRs, `SP`, `PC` and
+/// `PSTATE` at once.
+///
+/// Returning through `rt_sigreturn` spends no register as a branch target, so
+/// guest `x16` survives.
+///
+/// One instance per guest thread, in this crate's TLS rather than on the guest
+/// stack, which would have to be writable at resume time and lies at a
+/// guest-controlled address. Costs ~4.7KB of `.tbss` per thread.
+///
+/// The `fpsimd_context` record's `vregs` stay zero -- LiteBox saves no guest
+/// FP/SIMD -- but the record cannot be omitted: `parse_user_sigframe` rejects
+/// a frame without one.
+pub(super) mod resume_frame {
+    use litebox_common_linux::PtRegs;
+    use litebox_common_linux::signal::{Siginfo, Ucontext};
+    use zerocopy::{FromBytes, IntoBytes, KnownLayout};
+
+    /// `FPSIMD_MAGIC` from `arch/arm64/include/uapi/asm/sigcontext.h`.
+    const FPSIMD_MAGIC: u32 = 0x4650_8001;
+
+    /// `__NR_rt_sigreturn` on the asm-generic syscall table AArch64 uses.
+    pub(crate) const NR_RT_SIGRETURN: u32 = syscalls::Sysno::rt_sigreturn as u32;
+
+    /// The kernel's `struct fpsimd_context`: a `struct _aarch64_ctx` header
+    /// followed by the FP/SIMD register file.
+    ///
+    /// `fpsr`/`fpcr` sit *between* the header and `vregs`; putting them after
+    /// `vregs` instead pads the record out past the size the kernel expects.
+    #[repr(C)]
+    #[derive(FromBytes, IntoBytes, KnownLayout)]
+    struct FpsimdContext {
+        magic: u32,
+        size: u32,
+        fpsr: u32,
+        fpcr: u32,
+        vregs: [u128; 32],
+    }
+
+    /// The kernel's `struct _aarch64_ctx`, used on its own as the `END_MAGIC`
+    /// terminator that closes the `__reserved` record list.
+    #[repr(C)]
+    #[derive(FromBytes, IntoBytes, KnownLayout)]
+    struct Aarch64Ctx {
+        magic: u32,
+        size: u32,
+    }
+
+    /// The kernel's `struct rt_sigframe`.
+    ///
+    /// `rt_sigreturn` never reads the `siginfo` back — it exists so that the
+    /// address a handler is entered with points at a complete frame — so this
+    /// one stays zero for the whole of the thread's life. It is a field so
+    /// that this type is the kernel's type and the layout test checks the
+    /// `ucontext` offset.
+    #[repr(C, align(16))]
+    #[derive(FromBytes)]
+    pub(super) struct ResumeFrame {
+        siginfo: Siginfo,
+        ucontext: Ucontext,
+    }
+
+    /// Uses pre-aligned TLS storage to avoid lazy initialization on a path that
+    /// must not panic.
+    fn state() -> (*mut ResumeFrame, *mut u8) {
+        let block: usize;
+        // SAFETY: materializes the base of this thread's own TLS control
+        // block from `TPIDR_EL0`, which always holds the host anchor. Reads no
+        // memory.
+        unsafe {
+            core::arch::asm!(
+                load_tls_block_base!("{block}"),
+                block = out(reg) block,
+                options(nomem, nostack, preserves_flags)
+            );
+        }
+        (
+            (block + super::tls_offset::RESUME_FRAME) as *mut ResumeFrame,
+            (block + super::tls_offset::RESUME_FRAME_INITIALIZED) as *mut u8,
+        )
+    }
+
+    fn init(frame: &mut ResumeFrame) {
+        let mcontext = &mut frame.ucontext.mcontext;
+
+        let (fpsimd, rest) = FpsimdContext::mut_from_prefix(&mut mcontext.__reserved)
+            .expect("__reserved is larger than both records");
+        fpsimd.magic = FPSIMD_MAGIC;
+        fpsimd.size = u32::try_from(size_of::<FpsimdContext>()).expect("record size fits in u32");
+        let (end, _) =
+            Aarch64Ctx::mut_from_prefix(rest).expect("__reserved is larger than both records");
+        end.magic = 0;
+        end.size = 0;
+
+        // `uc_stack` is deliberately left zeroed. `sys_rt_sigreturn` passes it
+        // to `restore_altstack`, which squashes every error, and
+        // `{ss_sp: NULL, ss_flags: 0, ss_size: 0}` is rejected by
+        // `do_sigaltstack` (`ss_size < MINSIGSTKSZ` gives `-ENOMEM`) before it
+        // changes anything. So this thread's alternate signal stack — which
+        // `with_signal_alt_stack` installed and which every host signal
+        // handler runs on — is left exactly as it is. Note that zeroing is not
+        // the same as writing `SS_DISABLE`, which *would* tear it down.
+    }
+
+    /// Fills this thread's frame in from `ctx` and returns it, ready for
+    /// `rt_sigreturn`.
+    pub(super) fn prepare(ctx: &PtRegs) -> *mut ResumeFrame {
+        let (frame, initialized) = state();
+        // SAFETY: own-thread [`super::tls_offset`] slot accesses. The `&mut` is
+        // exclusive: this is the only function that takes one, it cannot be
+        // reentered on this thread (it runs with `in_guest` clear, outside any
+        // signal handler, and calls nothing that re-enters the runtime), and
+        // it is dead before the frame is handed to the kernel.
+        let frame = unsafe { &mut *frame };
+        // SAFETY: as above. Volatile is not needed — nothing else writes this
+        // byte — but the read and the write are kept adjacent to the `init`
+        // they guard.
+        unsafe {
+            if *initialized == 0 {
+                init(frame);
+                *initialized = 1;
+            }
+        }
+
+        // `restore_sigframe` ends by installing this mask, so it decides the
+        // host mask after every asynchronous resume and has to say "no change".
+        // Sampled per resume: this frame outlives a single guest lifetime, and
+        // nothing stops a host thread from running another one.
+        // SAFETY: `sigset_t` is a plain bit array, so all-zero is a valid value.
+        let mut set: libc::sigset_t = unsafe { core::mem::zeroed() };
+        // SAFETY: `set` is a live, correctly typed `sigset_t`; passing a null
+        // `set` argument makes this a pure query.
+        unsafe {
+            libc::pthread_sigmask(libc::SIG_BLOCK, core::ptr::null(), &raw mut set);
+        }
+        // SAFETY: `sigset_t` is at least 8 bytes on every Linux target and its
+        // first 8 bytes are the mask for signals 1..=64, which is exactly the
+        // kernel's `sigset_t`. Read unaligned because `sigset_t`'s alignment is
+        // not part of its public API.
+        let blocked = unsafe { core::ptr::read_unaligned((&raw const set).cast::<u64>()) };
+        frame.ucontext.sigmask = litebox_common_linux::signal::SigSet::from_u64(blocked);
+
+        // `restore_fpsimd_context` installs these, so a zeroed record would
+        // reset the guest's rounding mode and flush-to-zero on every
+        // asynchronous resume. Copying the live values instead makes the resume
+        // a no-op, matching what the outbound-stub path does by not touching
+        // them at all.
+        //
+        // `FPCR` really is the guest's: it is a mode register and nothing
+        // between the guest's exit and here writes one. `FPSR` is not --- its
+        // cumulative exception bits are set by ordinary arithmetic, so the host
+        // code that ran in between has polluted them. Carrying them forward is
+        // still the better of the two options, since zeroing would discard the
+        // guest's own flags on top.
+        //
+        // TODO: preserve vector state across transitions. Asynchronous resume
+        // currently restores zeroed `vregs`, corrupting SIMD-using guests.
+        let status: u32;
+        let control: u32;
+        // SAFETY: reads two floating-point control registers; touches no
+        // memory.
+        unsafe {
+            core::arch::asm!(
+                "mrs {status:x}, fpsr",
+                "mrs {control:x}, fpcr",
+                status = out(reg) status,
+                control = out(reg) control,
+                options(nomem, nostack, preserves_flags)
+            );
+        }
+        let (fpsimd, _) = FpsimdContext::mut_from_prefix(&mut frame.ucontext.mcontext.__reserved)
+            .expect("__reserved is 4KiB");
+        fpsimd.fpsr = status;
+        fpsimd.fpcr = control;
+
+        let mcontext = &mut frame.ucontext.mcontext;
+        for (dst, src) in mcontext.regs.iter_mut().zip(ctx.regs.iter()) {
+            *dst = *src as u64;
+        }
+        mcontext.sp = ctx.sp as u64;
+        mcontext.pc = ctx.pc as u64;
+        // `rt_sigreturn` hands the whole word to the kernel, and
+        // `valid_user_regs` rejects some values rather than trimming them, so
+        // mask before the kernel sees it.
+        mcontext.pstate = ctx.pstate & litebox_common_linux::arch::SAFE_USER_PSTATE;
+
+        &raw mut *frame
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::{Aarch64Ctx, FpsimdContext, ResumeFrame};
+        use core::mem::offset_of;
+        use litebox_common_linux::PtRegs;
+        use litebox_common_linux::signal::{Siginfo, Ucontext, aarch64::Sigcontext};
+
+        /// The layout `rt_sigreturn` expects, pinned against the kernel's
+        /// `struct rt_sigframe`. This is the whole contract with the kernel:
+        /// it reads fixed offsets off a bare pointer.
+        #[test]
+        fn test_frame_layout_matches_the_kernel() {
+            assert_eq!(size_of::<Siginfo>(), 128);
+            assert_eq!(offset_of!(ResumeFrame, siginfo), 0);
+            assert_eq!(offset_of!(ResumeFrame, ucontext), 128);
+            assert_eq!(size_of::<ResumeFrame>(), 4688);
+            assert_eq!(align_of::<ResumeFrame>(), 16);
+
+            assert_eq!(offset_of!(Ucontext, flags), 0);
+            assert_eq!(offset_of!(Ucontext, link), 8);
+            assert_eq!(offset_of!(Ucontext, stack), 16);
+            assert_eq!(offset_of!(Ucontext, sigmask), 40);
+            assert_eq!(offset_of!(Ucontext, mcontext), 176);
+            assert_eq!(size_of::<Ucontext>(), 4560);
+
+            assert_eq!(offset_of!(Sigcontext, fault_address), 0);
+            assert_eq!(offset_of!(Sigcontext, regs), 8);
+            assert_eq!(offset_of!(Sigcontext, sp), 256);
+            assert_eq!(offset_of!(Sigcontext, pc), 264);
+            assert_eq!(offset_of!(Sigcontext, pstate), 272);
+            assert_eq!(offset_of!(Sigcontext, __reserved), 288);
+            assert_eq!(size_of::<Sigcontext>(), 4384);
+
+            // The two records written into `__reserved`, which the kernel
+            // walks by `size` from the start of the area.
+            assert_eq!(size_of::<FpsimdContext>(), 528);
+            // Size alone does not pin the field order: `fpsr` and `fpcr` are
+            // both `u32` and swapping them would install a guest-controlled
+            // exception word into `FPCR`, trap-enable bits and all.
+            assert_eq!(offset_of!(FpsimdContext, magic), 0);
+            assert_eq!(offset_of!(FpsimdContext, size), 4);
+            assert_eq!(offset_of!(FpsimdContext, fpsr), 8);
+            assert_eq!(offset_of!(FpsimdContext, fpcr), 12);
+            assert_eq!(offset_of!(FpsimdContext, vregs), 16);
+            assert_eq!(super::FPSIMD_MAGIC, 0x4650_8001);
+            assert_eq!(align_of::<FpsimdContext>(), 16);
+            assert_eq!(size_of::<Aarch64Ctx>(), 8);
+            assert!(size_of::<FpsimdContext>() + size_of::<Aarch64Ctx>() <= 4096);
+        }
+
+        #[test]
+        fn test_prepared_frame_round_trips_x16_through_the_kernel() {
+            const SENTINEL: usize = 0x1234_1234_1234_1234;
+            // Derive asm offsets from Rust layout so they cannot drift.
+            const MCONTEXT: usize =
+                offset_of!(ResumeFrame, ucontext) + offset_of!(Ucontext, mcontext);
+            const REGS: usize = MCONTEXT + offset_of!(Sigcontext, regs);
+
+            let mut ctx: PtRegs = unsafe { core::mem::zeroed() };
+            ctx.regs[16] = SENTINEL;
+            ctx.pc = 0;
+            ctx.sp = 0;
+            ctx.pstate = u64::MAX;
+
+            let frame = super::prepare(&ctx);
+
+            // SAFETY: `frame` is this thread's own frame, filled in above. The
+            // block writes the live `sp`, `pc` and callee-saved registers into
+            // it, so `rt_sigreturn` restores exactly the state this function
+            // is running with, plus the sentinel in `x16`, and resumes at the
+            // `99:` label. `x8` and `x16`-`x18` are declared clobbered; every
+            // other caller-saved register is restored from the frame as zero,
+            // so they are declared clobbered too via `clobber_abi("C")`.
+            let observed: u64;
+            unsafe {
+                core::arch::asm!(
+                    // Use a separate base because STP cannot reach `regs[30]`
+                    // directly from the frame base.
+                    "add x17, {f}, #{regs}",
+                    "stp x19, x20, [x17, #152]",
+                    "stp x21, x22, [x17, #168]",
+                    "stp x23, x24, [x17, #184]",
+                    "stp x25, x26, [x17, #200]",
+                    "stp x27, x28, [x17, #216]",
+                    "stp x29, x30, [x17, #232]",
+                    "mov x17, sp",
+                    "str x17, [{f}, #{sp}]",
+                    "adr x17, 99f",
+                    "str x17, [{f}, #{pc}]",
+                    "mov sp, {f}",
+                    "mov x8, #{nr}",
+                    "svc #0",
+                    "brk #0",
+                    "99:",
+                    "mov x20, x16",
+                    f = in(reg) frame,
+                    lateout("x20") observed,
+                    regs = const REGS,
+                    sp = const MCONTEXT + 256,
+                    pc = const MCONTEXT + 264,
+                    nr = const super::NR_RT_SIGRETURN,
+                    clobber_abi("C"),
+                );
+            }
+
+            assert_eq!(
+                usize::try_from(observed).unwrap(),
+                SENTINEL,
+                "the kernel must restore `regs[16]` from the synthesized frame"
+            );
+        }
+
+        /// `prepare` must sanitize `pstate` rather than pass a guest-derived
+        /// word through to `valid_user_regs`.
+        ///
+        /// The consequence of not doing so is not a permissive guest, it is a
+        /// host `SIGSEGV`: `PSR_MODE32_BIT` in a frame makes `rt_sigreturn`
+        /// take its `badframe` path. The preceding test would catch that only
+        /// by killing the test process.
+        #[test]
+        fn test_prepare_sanitizes_pstate() {
+            let mut ctx: PtRegs = unsafe { core::mem::zeroed() };
+            ctx.pstate = u64::MAX;
+            let frame = super::prepare(&ctx);
+            // SAFETY: `frame` is this thread's own frame and no `&mut` to it
+            // is live here.
+            let pstate = unsafe { (*frame).ucontext.mcontext.pstate };
+            assert_eq!(pstate, litebox_common_linux::arch::SAFE_USER_PSTATE);
+            assert_eq!(pstate & (1 << 4), 0, "PSR_MODE32_BIT must never be set");
+        }
+    }
+}
+
+/// Switches to the provided guest context.
+///
+/// # Safety
+/// The context must be a valid guest context. This can only be called if
+/// `run_thread_arch` is on the stack; after the guest exits, it will return to
+/// the interior of `run_thread_arch`. Do not call this where the stack needs
+/// unwinding to run destructors.
+///
+/// AArch64 cannot restore all 31 GPRs *and* branch, so this dispatches to
+/// [`switch_to_guest_via_outbound_stub`] or [`switch_to_guest_via_sigreturn`].
+/// The stub is usable exactly when [`tls_offset::OUTBOUND_STUB`] is recorded and
+/// `PtRegs::pc` still equals [`tls_offset::OUTBOUND_PC`]; the pair is never
+/// invalidated, so a stale record can only be selected when using it is correct.
+/// The choice happens here, before `in_guest` is set, so the frame stores cannot
+/// be attributed to the guest.
+pub(super) unsafe extern "C" fn switch_to_guest(ctx: &litebox_common_linux::PtRegs) -> ! {
+    if outbound_stub_is_current(ctx) {
+        // SAFETY: the caller's contract, plus the stub's own: a stub is
+        // recorded and `ctx.pc` is the PC it branches to, checked above.
+        unsafe { switch_to_guest_via_outbound_stub(ctx) }
+    } else {
+        let frame = resume_frame::prepare(ctx);
+        // SAFETY: the caller's contract, plus a fully prepared frame, which
+        // `resume_frame::prepare` just returned and which lives for the rest
+        // of this thread's life.
+        unsafe { switch_to_guest_via_sigreturn(frame) }
+    }
+}
+
+pub(super) fn outbound_stub_is_current(ctx: &litebox_common_linux::PtRegs) -> bool {
+    let stub: usize;
+    let pc: usize;
+    // SAFETY: own-thread [`tls_offset`] slot accesses. Read through `asm!`
+    // rather than plain loads because the transition assembly writes these
+    // slots behind the compiler's back.
+    unsafe {
+        core::arch::asm!(
+            load_tls_block_base!("{block}"),
+            "ldr {stub}, [{block}, #{stub_off}]",
+            "ldr {pc}, [{block}, #{pc_off}]",
+            block = out(reg) _,
+            stub = out(reg) stub,
+            pc = out(reg) pc,
+            stub_off = const tls_offset::OUTBOUND_STUB,
+            pc_off = const tls_offset::OUTBOUND_PC,
+            options(nostack, preserves_flags, readonly)
+        );
+    }
+    stub != 0 && pc == ctx.pc
+}
+
+/// Re-enters the guest through the rewriter's per-site outbound stub, for a
+/// resume at the `SVC` site the guest left from.
+///
+/// # Safety
+/// As [`switch_to_guest`], and additionally: a stub must be recorded in
+/// [`tls_offset::OUTBOUND_STUB`] and `ctx.pc` must be the PC it branches to.
+/// [`outbound_stub_is_current`] is the check.
+///
+/// `SP` is staged at `PtRegs::sp - SVC_FRAME_BYTES` because the stub pops the
+/// frame, and `[SP, #0]` is re-written from `PtRegs::regs[16]` so a shim that
+/// modified it is honored. That store is the only write to guest memory in any
+/// transition assembly, so it carries an exception-table fixup that skips it
+/// and takes the stub anyway.
+///
+/// The `switch_to_guest_via_outbound_stub_start`/`_end` bracket is one of the
+/// two ranges [`in_switch_to_guest`] tests: from before the `in_guest` store to
+/// the final branch, an interrupt must reach `interrupt_callback` rather than
+/// be attributed to the guest. Do not shrink it.
+#[unsafe(naked)]
+pub(super) unsafe extern "C" fn switch_to_guest_via_outbound_stub(
+    ctx: &litebox_common_linux::PtRegs,
+) -> ! {
+    core::arch::naked_asm!(
+    "
+// No `.cfi_startproc`/`.cfi_endproc`, so this function gets no FDE. That is
+// deliberate: it is `-> !` and never returns, and the doc comment above
+// forbids calling it where the stack may need unwinding, so there is no
+// correct CFA to describe. Emitting a rule here would be worse than emitting
+// none, because `sp` and `x29` are switched to guest values partway through.
+.globl switch_to_guest_via_outbound_stub_start
+switch_to_guest_via_outbound_stub_start:
+    ",
+    load_tls_block_base!("x17"),
+    "
+    mov  w16, #1
+    strb w16, [x17, #{IN_GUEST}]
+    ldrb w16, [x17, #{INTERRUPT}]
+    // The condition is inverted around an unconditional branch on purpose; do
+    // not 'simplify' this back to `cbnz w16, interrupt_callback`.
+    // `interrupt_callback` lives in `run_thread_arch`'s separate `naked_asm!`
+    // block, so the reference is a cross-section relocation resolved by the
+    // linker, not by the assembler. A conditional branch emits
+    // `R_AARCH64_CONDBR19`, which reaches only +/-1MiB and for which the
+    // linker inserts no veneer -- it hard-fails with `relocation truncated to
+    // fit` if CGU partitioning or LTO ever places the two functions further
+    // apart. `B` emits `R_AARCH64_JUMP26`: +/-128MiB and veneer-able.
+    cbz  w16, 3f
+    // The guest is not entered after all, so `in_guest` must not stay set:
+    // `interrupt_callback` runs host code, and a signal arriving there with
+    // `in_guest` set is taken for a guest fault and overwrites the saved guest
+    // context with the host register file.
+    strb wzr, [x17, #{IN_GUEST}]
+    b    interrupt_callback
+3:
+
+    // x16 carries the stub across restoration; guest x16 is staged for the
+    // stub to reload.
+    ldr  x16, [x17, #{OUTBOUND_STUB}]
+    ldr  x4,  [x0,  #248]
+    sub  x4,  x4,  #{SVC_FRAME_BYTES}
+    mov  sp,  x4
+    ldr  x5,  [x0,  #128]
+    // The one and only write to *guest* memory in the transition assembly,
+    // hence the only instruction here that a guest can make fault. It is
+    // registered in the exception table below so that a fault is recovered in
+    // place instead of being mistaken for a guest exception; see this
+    // function's doc comment.
+.globl switch_to_guest_stage_x16
+switch_to_guest_stage_x16:
+    str  x5,  [sp,  #{SVC_FRAME_OFF_X16}]
+.globl switch_to_guest_stage_x16_fixup
+switch_to_guest_stage_x16_fixup:
+    // TODO: skipping the store is not a clean recovery either way. If the
+    // guest stack is unmapped, the stub's own reload of `x16` faults next; if
+    // it is merely read-only, that reload succeeds and returns the guest's
+    // original `x16`, silently dropping any change the shim made to
+    // `regs[16]`. Diverting here to the `rt_sigreturn` path would handle both,
+    // since it reads its frame from runtime TLS and never touches guest
+    // memory -- but it must first restore `sp` from `host_sp` and clear
+    // `in_guest`, since it re-enters Rust.
+    // Exception-table entry for the store above, in the format
+    // `litebox::mm::exception_table` defines and searches: three self-relative
+    // 32-bit deltas, [start, stop) and the fixup. Written out longhand rather
+    // than through that module's `ex_table_entry!` because the macro is
+    // private to it and this body is one string literal; keep the section
+    // flags (`aR`: allocate, retain) identical to the ones there.
+    .pushsection ex_table,\"aR\"
+    .balign 4
+    .long switch_to_guest_stage_x16 - .
+    .long switch_to_guest_stage_x16_fixup - .
+    .long switch_to_guest_stage_x16_fixup - .
+    .popsection
+
+    // `msr nzcv` writes only PSTATE 31:28. SSBS and DIT are carried in
+    // `PtRegs::pstate` (see `copy_signal_context`) but are knowingly NOT
+    // restored here: writing them needs `msr ssbs`/`msr dit`, which are
+    // ARMv8.0 optional / ARMv8.4 respectively, so unconditionally emitting
+    // them would raise this crate's hardware floor. A guest that sets SSBS or
+    // DIT therefore loses them across a syscall: both are hardening hints with
+    // no architectural effect on results. (The asynchronous path does restore
+    // them, for free, because `rt_sigreturn` writes the whole SPSR; see
+    // `resume_frame::prepare`.)
+    //
+    // TODO: restore SSBS/DIT for guests that set them, gated on a runtime
+    // feature probe (HWCAP_SSBS / HWCAP2_DIT) so the hardware floor stays at
+    // ARMv8.0. Only worth doing once a guest actually depends on them.
+    ldr  x1,  [x0, #264]
+    msr  nzcv, x1
+    ldr  x1,  [x0, #8]
+    ldp  x2,  x3,  [x0, #16]
+    ldp  x4,  x5,  [x0, #32]
+    ldp  x6,  x7,  [x0, #48]
+    ldp  x8,  x9,  [x0, #64]
+    ldp  x10, x11, [x0, #80]
+    ldp  x12, x13, [x0, #96]
+    ldp  x14, x15, [x0, #112]
+    ldr  x17, [x0, #136]
+    ldr  x18, [x0, #144]
+    ldp  x19, x20, [x0, #152]
+    ldp  x21, x22, [x0, #168]
+    ldp  x23, x24, [x0, #184]
+    ldp  x25, x26, [x0, #200]
+    ldp  x27, x28, [x0, #216]
+    ldp  x29, x30, [x0, #232]
+    ldr  x0,  [x0, #0]
+    br   x16
+.globl switch_to_guest_via_outbound_stub_end
+switch_to_guest_via_outbound_stub_end:
+"
+    ,
+    IN_GUEST = const tls_offset::IN_GUEST,
+    INTERRUPT = const tls_offset::INTERRUPT,
+    OUTBOUND_STUB = const tls_offset::OUTBOUND_STUB,
+    SVC_FRAME_BYTES = const litebox_syscall_rewriter::arm64::SVC_FRAME_BYTES,
+    SVC_FRAME_OFF_X16 = const litebox_syscall_rewriter::arm64::SVC_FRAME_OFF_X16,
+    );
+}
+
+/// Re-enters the guest by `rt_sigreturn`-ing into a prepared
+/// [`resume_frame::ResumeFrame`], for a resume at an arbitrary PC.
+///
+/// # Safety
+/// As [`switch_to_guest`], and additionally: `frame` must point at a frame
+/// [`resume_frame::prepare`] has filled in from the context being resumed, and
+/// must stay valid until the guest is entered.
+///
+/// A *host* `rt_sigreturn` on the host's own thread, unrelated to the guest
+/// `rt_sigreturn` the shim emulates.
+///
+/// The second range [`in_switch_to_guest`] tests; see
+/// [`switch_to_guest_via_outbound_stub`]. During the `svc` itself is fine.
+#[unsafe(naked)]
+unsafe extern "C" fn switch_to_guest_via_sigreturn(frame: *mut resume_frame::ResumeFrame) -> ! {
+    core::arch::naked_asm!(
+    "
+// No FDE, for the reason given on `switch_to_guest_via_outbound_stub`.
+.globl switch_to_guest_via_sigreturn_start
+switch_to_guest_via_sigreturn_start:
+    ",
+    load_tls_block_base!("x17"),
+    "
+    mov  w16, #1
+    strb w16, [x17, #{IN_GUEST}]
+    ldrb w16, [x17, #{INTERRUPT}]
+    cbz  w16, 3f
+    strb wzr, [x17, #{IN_GUEST}]
+    b    interrupt_callback
+3:
+    // `sys_rt_sigreturn` takes the frame address from `SP` and nothing else;
+    // it rejects `SP & 15`, which `ResumeFrame`'s `align(16)` rules out. The
+    // guest's own `SP` is in the frame and the kernel installs it.
+    mov  sp,  x0
+    mov  x8,  #{NR_RT_SIGRETURN}
+    svc  #0
+    // Unreachable: `rt_sigreturn` does not return, and a frame it rejects is
+    // answered with a `SIGSEGV` rather than an error return. Trap rather than
+    // fall through into whatever the linker placed next.
+    brk  #0
+.globl switch_to_guest_via_sigreturn_end
+switch_to_guest_via_sigreturn_end:
+"
+    ,
+    IN_GUEST = const tls_offset::IN_GUEST,
+    INTERRUPT = const tls_offset::INTERRUPT,
+    NR_RT_SIGRETURN = const resume_frame::NR_RT_SIGRETURN,
+    );
+}
+
+impl litebox::platform::ArchSpecificProvider for LinuxUserland {
+    fn set_arch_specific_register(
+        &self,
+        reg: &litebox::platform::ArchSpecificRegister,
+        val: usize,
+    ) -> Result<(), litebox::platform::ArchSpecificError> {
+        match reg {
+            litebox::platform::ArchSpecificRegister::TpidrEl0 => {
+                if litebox_common_linux::arch::is_valid_user_tls_base(val) {
+                    set_guest_thread_pointer(val);
+                    Ok(())
+                } else {
+                    Err(litebox::platform::ArchSpecificError::RegisterUnpermittedValue)
+                }
+            }
+            _ => Err(litebox::platform::ArchSpecificError::RegisterUnsupported),
+        }
+    }
+    fn get_arch_specific_register(
+        &self,
+        reg: &litebox::platform::ArchSpecificRegister,
+    ) -> Result<usize, litebox::platform::ArchSpecificError> {
+        match reg {
+            litebox::platform::ArchSpecificRegister::TpidrEl0 => Ok(get_guest_thread_pointer()),
+            _ => Err(litebox::platform::ArchSpecificError::RegisterUnsupported),
+        }
+    }
+}
+
+unsafe extern "C" {
+    /// The compiler runtime's cache-synchronization helper: cleans the data
+    /// cache to the point of unification and invalidates the instruction cache
+    /// over `[start, end)`.
+    fn __clear_cache(start: *mut core::ffi::c_char, end: *mut core::ffi::c_char);
+}
+
+/// Make code just written to `range` visible to the instruction fetch path,
+/// before that range becomes executable.
+///
+/// AArch64's instruction cache is not architecturally coherent with the data
+/// cache. Omitting this does not fail cleanly: the fetch path may see stale
+/// bytes, intermittently and machine-dependently.
+pub(super) fn sync_instruction_stream(range: core::ops::Range<usize>) {
+    if range.start >= range.end {
+        return;
+    }
+    // SAFETY: `range` is a mapped range this platform is changing permissions
+    // on, so both ends are valid addresses within one mapping. `__clear_cache`
+    // only performs cache maintenance over it and writes no memory.
+    unsafe {
+        __clear_cache(
+            range.start as *mut core::ffi::c_char,
+            range.end as *mut core::ffi::c_char,
+        );
+    }
+}
+
+// The canonical context must remain stack-backed: boxing here would allocate in
+// a signal handler, violating the async-signal-safe contract.
+#[allow(clippy::large_enum_variant)]
+pub(super) enum Aarch64GateSignalResult {
+    NotGate,
+    Canonicalized(litebox_common_linux::PtRegs),
+    PreserveSavedContext,
+    InvalidRuntimeState,
+}
+
+fn read_usize(read: &mut impl FnMut(usize, &mut [u8]) -> bool, address: usize) -> Option<usize> {
+    let mut bytes = [0u8; size_of::<usize>()];
+    read(address, &mut bytes).then(|| usize::from_ne_bytes(bytes))
+}
+
+/// Recognizes and canonicalizes an interrupted compact gate using only bounded,
+/// caller-supplied reads. The signal-handler caller supplies exception-table
+/// reads; tests supply synthetic mappings.
+///
+/// A candidate is accepted only if its metadata word, its exact instruction
+/// template, and the inbound branch at its original site all agree. That is
+/// what makes a range registry unnecessary. A guest that forges all three
+/// changes only its own libOS semantics under LiteBox's threat model.
+pub(super) fn canonicalize_aarch64_gate_signal_context(
+    context: &libc::ucontext_t,
+    saved: &litebox_common_linux::PtRegs,
+    guest_thread_pointer_addr: usize,
+    expected_outbound_stub: usize,
+    expected_outbound_pc: usize,
+    mut read: impl FnMut(usize, &mut [u8]) -> bool,
+) -> Aarch64GateSignalResult {
+    // Every slot boundary and frame size below is the rewriter's, not this
+    // crate's: re-deriving them here would let the two drift silently.
+    const SVC_FRAME: usize = SVC_FRAME_BYTES as usize;
+    const MSR_FRAME: usize = MSR_FRAME_BYTES as usize;
+    // The widest slot spans this many `GATE_ALIGNMENT` steps, so the aligned PC
+    // is at most one step short of this many steps past the slot start.
+    const MAX_CANDIDATES: usize = SVC_SLOT_BYTES / GATE_ALIGNMENT;
+
+    let pc = context.uc_mcontext.pc;
+    let Ok(pc_usize) = usize::try_from(pc) else {
+        return Aarch64GateSignalResult::NotGate;
+    };
+    if !pc.is_multiple_of(4) {
+        return Aarch64GateSignalResult::NotGate;
+    }
+
+    let aligned = pc_usize & !(GATE_ALIGNMENT - 1);
+    let mut found = None;
+    for candidate_index in 0..MAX_CANDIDATES {
+        let Some(slot_start) = aligned.checked_sub(candidate_index * GATE_ALIGNMENT) else {
+            continue;
+        };
+        for slot_size in [MRS_SLOT_BYTES, MSR_SLOT_BYTES, SVC_SLOT_BYTES] {
+            let Some(slot_end) = slot_start.checked_add(slot_size) else {
+                continue;
+            };
+            if pc_usize < slot_start || pc_usize >= slot_end {
+                continue;
+            }
+            let mut metadata_bytes = [0u8; 4];
+            if !read(slot_end - 4, &mut metadata_bytes) {
+                continue;
+            }
+            let Some(metadata) = litebox_syscall_rewriter::arm64::decode_gate_metadata_word(
+                u32::from_le_bytes(metadata_bytes),
+            ) else {
+                continue;
+            };
+            if metadata.slot_size() != slot_size {
+                continue;
+            }
+            let mut slot = [0u8; 64];
+            if !read(slot_start, &mut slot[..slot_size]) {
+                continue;
+            }
+            // Everything up to here is a guess drawn from guest memory: the
+            // metadata word lives at `slot_end - 4`, which the guest can write.
+            // Failing to validate is the evidence that this candidate is not a
+            // gate, so it is discarded rather than treated as a corrupt one --
+            // otherwise a guest could stage a plausible metadata word, fault at
+            // a PC of its choosing and take the runtime down at will. This also
+            // covers a PC in a real gate's padding or metadata: that code never
+            // ran the prologue, so the interrupted registers are the guest's
+            // own and delivering the signal unchanged is correct.
+            let Some(classified) = litebox_syscall_rewriter::arm64::classify_copied_gate_slot(
+                &slot[..slot_size],
+                slot_start as u64,
+                pc,
+            ) else {
+                continue;
+            };
+            if found.is_some() {
+                return Aarch64GateSignalResult::InvalidRuntimeState;
+            }
+            found = Some((slot_start, classified));
+        }
+    }
+    let Some((slot_start, gate)) = found else {
+        return Aarch64GateSignalResult::NotGate;
+    };
+
+    // Guest-derived provenance failures are `NotGate`; only unreadable
+    // runtime-owned TLS is an invalid runtime state.
+    let site = gate.original_site();
+    let Ok(site_usize) = usize::try_from(site) else {
+        return Aarch64GateSignalResult::NotGate;
+    };
+    if !site.is_multiple_of(4) {
+        return Aarch64GateSignalResult::NotGate;
+    }
+    let mut original = [0u8; 4];
+    if !read(site_usize, &mut original) {
+        return Aarch64GateSignalResult::NotGate;
+    }
+    let original = u32::from_le_bytes(original);
+    if litebox_syscall_rewriter::arm64::decode_branch_target(original, site)
+        != Some(slot_start as u64)
+    {
+        return Aarch64GateSignalResult::NotGate;
+    }
+
+    let metadata = gate.metadata();
+    let offset = pc_usize - slot_start;
+    if matches!(metadata, GateMetadata::Svc) && offset >= SVC_GATE_BYTES {
+        return if expected_outbound_stub == slot_start + SVC_GATE_BYTES
+            && expected_outbound_pc == site_usize + 4
+        {
+            Aarch64GateSignalResult::PreserveSavedContext
+        } else {
+            Aarch64GateSignalResult::NotGate
+        };
+    }
+
+    let mut canonical = saved.clone();
+    copy_signal_context(&mut canonical, context);
+    canonical.pc = site_usize;
+
+    // `copy_signal_context` derived `orig_x0` from the interrupted `regs[0]`,
+    // which for `mrs x0, tpidr_el0` is the *host* anchor. Whatever the arms
+    // below repair, re-derive it afterwards rather than leaving a host address
+    // in a guest-visible field.
+    match metadata {
+        GateMetadata::MrsTpidr { destination, .. } => {
+            let destination = usize::from(destination);
+            if offset == 4 {
+                let Some(guest_tp) = read_usize(&mut read, guest_thread_pointer_addr) else {
+                    return Aarch64GateSignalResult::InvalidRuntimeState;
+                };
+                canonical.regs[destination] = guest_tp;
+                canonical.pc = site_usize + 4;
+            } else if offset == 8 {
+                canonical.pc = site_usize + 4;
+            }
+        }
+        GateMetadata::MsrTpidr { source, .. } => {
+            if offset == 4 {
+                let Some(sp) = canonical.sp.checked_add(MSR_FRAME) else {
+                    return Aarch64GateSignalResult::NotGate;
+                };
+                canonical.sp = sp;
+            } else if (8..28).contains(&offset) {
+                let mut frame = [[0u8; size_of::<usize>()]; 3];
+                let words = if offset == 8 { 2 } else { 3 };
+                if !read(canonical.sp, frame[..words].as_flattened_mut()) {
+                    return Aarch64GateSignalResult::NotGate;
+                }
+                let saved_x16 = usize::from_ne_bytes(frame[0]);
+                let saved_x17 = usize::from_ne_bytes(frame[1]);
+                if offset >= 12 {
+                    let captured = usize::from_ne_bytes(frame[2]);
+                    let architectural_source = match source {
+                        16 => saved_x16,
+                        17 => saved_x17,
+                        31 => 0,
+                        register => canonical.regs[usize::from(register)],
+                    };
+                    if captured != architectural_source {
+                        return Aarch64GateSignalResult::NotGate;
+                    }
+                }
+                canonical.regs[16] = saved_x16;
+                canonical.regs[17] = saved_x17;
+                let Some(sp) = canonical.sp.checked_add(MSR_FRAME) else {
+                    return Aarch64GateSignalResult::NotGate;
+                };
+                canonical.sp = sp;
+            } else if offset == 28 {
+                // LDP at +24 has completed, so x16/x17 are already the live
+                // guest values. ADD SP at +28 has not yet completed.
+                let Some(sp) = canonical.sp.checked_add(MSR_FRAME) else {
+                    return Aarch64GateSignalResult::NotGate;
+                };
+                canonical.sp = sp;
+            }
+            if offset > usize::from(gate.commit_offset()) {
+                canonical.pc = site_usize + 4;
+            }
+        }
+        GateMetadata::Svc => {
+            if offset == 4 {
+                let Some(sp) = canonical.sp.checked_add(SVC_FRAME) else {
+                    return Aarch64GateSignalResult::NotGate;
+                };
+                canonical.sp = sp;
+            } else if offset >= 8 {
+                let Some(saved_x16) = read_usize(&mut read, canonical.sp) else {
+                    return Aarch64GateSignalResult::NotGate;
+                };
+                canonical.regs[16] = saved_x16;
+                let Some(sp) = canonical.sp.checked_add(SVC_FRAME) else {
+                    return Aarch64GateSignalResult::NotGate;
+                };
+                canonical.sp = sp;
+            }
+        }
+    }
+    canonical.orig_x0 = canonical.regs[0];
+    Aarch64GateSignalResult::Canonicalized(canonical)
+}
+
+pub(super) fn canonicalize_runtime_aarch64_gate_signal_context(
+    context: &libc::ucontext_t,
+    saved: &litebox_common_linux::PtRegs,
+) -> Aarch64GateSignalResult {
+    let block: usize;
+    let expected_outbound_stub: usize;
+    let expected_outbound_pc: usize;
+    // SAFETY: reads the permanent host TLS anchor without touching memory.
+    unsafe {
+        core::arch::asm!(
+            load_tls_block_base!("{block}"),
+            block = out(reg) block,
+            options(nostack, nomem, preserves_flags)
+        );
+        core::arch::asm!(
+            "ldr {stub}, [{block}, #{stub_off}]",
+            "ldr {pc}, [{block}, #{pc_off}]",
+            block = in(reg) block,
+            stub = out(reg) expected_outbound_stub,
+            pc = out(reg) expected_outbound_pc,
+            stub_off = const tls_offset::OUTBOUND_STUB,
+            pc_off = const tls_offset::OUTBOUND_PC,
+            options(nostack, readonly, preserves_flags)
+        );
+    }
+    canonicalize_aarch64_gate_signal_context(
+        context,
+        saved,
+        block + tls_offset::GUEST_THREAD_POINTER,
+        expected_outbound_stub,
+        expected_outbound_pc,
+        |address, output| {
+            // SAFETY: `output` is writable for its exact length. The source is
+            // a guest-controlled address -- a gate slot, the original site,
+            // this thread's `guest_thread_pointer` slot, or the guest `SP` --
+            // so it may be unmapped or may alias host memory; it is read as raw
+            // bytes through the exception table, never as a live Rust
+            // reference. Faulting is expected rather than exceptional, and
+            // reaching the fixup requires a re-entrant handler:
+            // `exception_signal_handler` runs on `SA_NODEFER` for exactly this.
+            // Recursion is bounded at one level, because the nested fault lands
+            // on this load, which the table covers, and that lookup reads no
+            // guest memory.
+            unsafe {
+                litebox::mm::exception_table::memcpy_fallible(
+                    output.as_mut_ptr(),
+                    address as *const u8,
+                    output.len(),
+                )
+                .is_ok()
+            }
+        },
+    )
+}
+
+/// Terminates after gate canonicalization reports an invalid runtime state,
+/// such as ambiguous valid candidates or unreadable runtime-owned TLS.
+pub(super) fn fatal_aarch64_gate_runtime_state() -> ! {
+    // SAFETY: `getpid`, `gettid`, `tgkill` and `exit_group` are
+    // async-signal-safe, are admitted by this platform's seccomp filter, and
+    // involve no formatting, allocation, locks or destructors.
+    unsafe {
+        let pid = syscalls::syscall0(syscalls::Sysno::getpid).unwrap_or(0);
+        let tid = syscalls::syscall0(syscalls::Sysno::gettid).unwrap_or(0);
+        for signal in [libc::SIGABRT, libc::SIGKILL] {
+            let _ = syscalls::syscall3(
+                syscalls::Sysno::tgkill,
+                pid,
+                tid,
+                signal.cast_unsigned() as usize,
+            );
+        }
+        core::arch::asm!(
+            "mov x0, #{status}",
+            "mov x8, #{nr}",
+            "svc #0",
+            status = const libc::EXIT_FAILURE,
+            nr = const libc::SYS_exit_group,
+            options(noreturn)
+        );
+    }
+}
+
+/// Clears `in_guest` and optionally sets `interrupt`. Returns the published
+/// guest context only if `in_guest` was set; its registers may still require
+/// copying or gate canonicalization.
+pub(super) fn signal_handler_exit_guest(
+    // Kept for signature parity, so both call sites stay architecture-free.
+    _context: &libc::ucontext_t,
+    set_interrupt: bool,
+) -> Option<*mut litebox_common_linux::PtRegs> {
+    let block: usize;
+    // SAFETY: materializes the base of this thread's TLS control block from
+    // `TPIDR_EL0`, the host anchor even when this signal interrupted guest
+    // code. Reads no memory.
+    unsafe {
+        core::arch::asm!(
+            load_tls_block_base!("{0}"),
+            out(reg) block,
+            options(nostack, nomem, preserves_flags)
+        );
+    }
+    // SAFETY: own-thread [`tls_offset`] slot accesses off `block`. Volatile
+    // because the transition assembly also writes them, unseen by the compiler.
+    unsafe {
+        let in_guest = (block + tls_offset::IN_GUEST) as *mut u8;
+        let was_in_guest = in_guest.read_volatile();
+        in_guest.write_volatile(0);
+        if set_interrupt {
+            ((block + tls_offset::INTERRUPT) as *mut u8).write_volatile(1);
+        }
+        if was_in_guest == 0 {
+            return None;
+        }
+        let top = ((block + tls_offset::GUEST_CONTEXT_TOP) as *const usize).read_volatile();
+        Some((top as *mut litebox_common_linux::PtRegs).sub(1))
+    }
+}
+
+pub(super) fn copy_signal_context(
+    regs: &mut litebox_common_linux::PtRegs,
+    context: &libc::ucontext_t,
+) {
+    let m = &context.uc_mcontext;
+    for (dst, src) in regs.regs.iter_mut().zip(m.regs.iter()) {
+        *dst = (*src).trunc();
+    }
+    regs.sp = m.sp.trunc();
+    regs.pc = m.pc.trunc();
+    // Raw `m.pstate` carries privileged bits. Mask to the bits a guest may own,
+    // so the shim sees the same set of bits however the context was produced.
+    regs.pstate = m.pstate & litebox_common_linux::arch::SAFE_USER_PSTATE;
+    regs.orig_x0 = regs.regs[0];
+    // `PtRegs` is reused across guest entries, so a stale `syscallno` would
+    // tell the shim a syscall is in flight during an exception or interrupt.
+    regs.syscallno = litebox_common_linux::arch::NO_SYSCALL;
+}
+
+pub(super) fn set_signal_return(
+    context: &mut libc::ucontext_t,
+    f: unsafe extern "C" fn(),
+    p0: isize,
+    p1: isize,
+    p2: isize,
+    p3: isize,
+) {
+    let m = &mut context.uc_mcontext;
+    m.pc = f as usize as u64;
+    // AAPCS64: first four integer arguments in x0-x3.
+    m.regs[0] = p0.reinterpret_as_unsigned() as u64;
+    m.regs[1] = p1.reinterpret_as_unsigned() as u64;
+    m.regs[2] = p2.reinterpret_as_unsigned() as u64;
+    m.regs[3] = p3.reinterpret_as_unsigned() as u64;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::mem::offset_of;
+    use litebox::platform::{RawMutexProvider, SystemInfoProvider as _};
+    use litebox::shim::{ContinueOperation, EnterShim, ExceptionInfo};
+    use litebox_common_linux::PtRegs;
+    use litebox_common_linux::signal::{SigSet, Signal};
+
+    #[test]
+    fn test_gate_patching_lands_in_the_runtime_tls_block() {
+        const IMM12_SHIFT: u32 = 10;
+        const IMM12_MASK: u32 = 0x003F_FC00;
+        const ALIGN: u16 = litebox_syscall_rewriter::arm64::GUEST_TPIDR_OFFSET_ALIGN;
+
+        let mut code = 0xD53B_D049u32.to_le_bytes(); // MRS X9, TPIDR_EL0
+        let (mut tramp, trapped) =
+            litebox_syscall_rewriter::patch_code_segment(&mut code, 0x1000, 0x400000, 0).unwrap();
+        assert!(trapped.is_empty());
+        assert_eq!(
+            litebox_syscall_rewriter::arm64::find_guest_tpidr_placeholder(&tramp),
+            Some(16 + 4),
+            "the emitted gate must be in the unpatched state, or everything below \
+             passes vacuously"
+        );
+
+        let platform = LinuxUserland::new();
+        let offset = platform.guest_thread_pointer_offset().expect(
+            "an AArch64 platform must supply a guest thread-pointer offset; without one the \
+             loader leaves every gate on the placeholder, which does not fault",
+        );
+        let offset = u16::try_from(offset).expect("the guest slot must sit within a gate's reach");
+        assert_eq!(
+            litebox_syscall_rewriter::arm64::patch_guest_tpidr_offset(&mut tramp, offset).unwrap(),
+            1
+        );
+        assert_eq!(
+            litebox_syscall_rewriter::arm64::find_guest_tpidr_placeholder(&tramp),
+            None,
+            "no gate may still hold the placeholder once the loader has staged the trampoline"
+        );
+        let classified =
+            litebox_syscall_rewriter::arm64::classify_gate_pc(&tramp, 0x400000, 0x400010)
+                .expect("finalized emitted MRS slot must validate");
+        assert_eq!(classified.slot_offset(), 16);
+        assert!(matches!(
+            classified.metadata(),
+            litebox_syscall_rewriter::arm64::GateMetadata::MrsTpidr { destination: 9, .. }
+        ));
+
+        let patched = u32::from_le_bytes(tramp[16 + 4..16 + 8].try_into().unwrap());
+        let gate_offset =
+            usize::try_from((patched & IMM12_MASK) >> IMM12_SHIFT).unwrap() * usize::from(ALIGN);
+        let tp: usize;
+        // SAFETY: reads the thread pointer; touches no memory.
+        unsafe {
+            core::arch::asm!(
+                "mrs {tp}, tpidr_el0",
+                tp = out(reg) tp,
+                options(nomem, nostack, preserves_flags)
+            );
+        }
+        let gate_target = tp + gate_offset;
+
+        // Compared against the slot's address as the *linker* resolves it, so
+        // this is an independent check of the number rather than a restatement
+        // of it.
+        assert_eq!(
+            gate_target,
+            tp + tprel_offset!(litebox_tls_block) + tls_offset::GUEST_THREAD_POINTER,
+            "a patched gate must dereference this thread's own `guest_thread_pointer` slot"
+        );
+
+        let block = tp + tprel_offset!(litebox_tls_block);
+        let block_end = block + core::mem::size_of::<super::TlsBlock>();
+        assert!(
+            (block..block_end).contains(&gate_target),
+            "gate dereferences {gate_target:#x}, outside the runtime TLS control block \
+             {block:#x}..{block_end:#x}"
+        );
+    }
+
+    /// Pins the `PtRegs` field offsets that the AArch64 transition assembly
+    /// hardcodes. A field reorder or insertion in `litebox_common_linux`
+    /// would otherwise silently corrupt the guest context.
+    #[test]
+    fn test_ptregs_layout() {
+        assert_eq!(core::mem::size_of::<PtRegs>(), 288);
+        assert_eq!(core::mem::align_of::<PtRegs>(), 16);
+        assert_eq!(offset_of!(PtRegs, regs) + 16 * 8, 128);
+        assert_eq!(offset_of!(PtRegs, sp), 248);
+        assert_eq!(offset_of!(PtRegs, pc), 256);
+        assert_eq!(offset_of!(PtRegs, pstate), 264);
+        assert_eq!(offset_of!(PtRegs, orig_x0), 272);
+        assert_eq!(offset_of!(PtRegs, syscallno), 280);
+    }
+
+    fn gate_fixture(
+        original: u32,
+    ) -> (
+        Vec<u8>,
+        Vec<u8>,
+        libc::ucontext_t,
+        litebox_common_linux::PtRegs,
+    ) {
+        let mut code = original.to_le_bytes().to_vec();
+        let (trampoline, trapped) =
+            litebox_syscall_rewriter::patch_code_segment(&mut code, 0x1000, 0x400000, 0).unwrap();
+        assert!(trapped.is_empty());
+        let mut context: libc::ucontext_t = unsafe { core::mem::zeroed() };
+        for (index, reg) in context.uc_mcontext.regs.iter_mut().enumerate() {
+            *reg = 0xfeed_0000_0000_0000 | index as u64;
+        }
+        context.uc_mcontext.sp = 0x8000;
+        // NZCV, plus bits a guest must never carry out of canonicalization:
+        // `M[4]` (AArch32 execution state) and all of DAIF.
+        context.uc_mcontext.pstate = 0xf000_0000 | (1 << 4) | (0xf << 6);
+        let mut saved = litebox_common_linux::PtRegs::default();
+        for (index, reg) in saved.regs.iter_mut().enumerate() {
+            *reg = 0x6000_0000_0000_0000 | index;
+        }
+        saved.sp = 0x9000;
+        saved.pc = 0x7000;
+        (code, trampoline, context, saved)
+    }
+
+    fn fixture_reader<'a>(
+        code: &'a [u8],
+        trampoline: &'a [u8],
+        frame: &'a [u8],
+        guest_tp: &'a [u8],
+    ) -> impl FnMut(usize, &mut [u8]) -> bool + 'a {
+        move |address, output| {
+            for (base, bytes) in [
+                (0x1000usize, code),
+                (0x400000, trampoline),
+                (0x8000, frame),
+                (0x500000, guest_tp),
+            ] {
+                if let Some(offset) = address.checked_sub(base)
+                    && let Some(source) = bytes.get(offset..offset.saturating_add(output.len()))
+                {
+                    output.copy_from_slice(source);
+                    return true;
+                }
+            }
+            false
+        }
+    }
+
+    fn expected_signal_regs(
+        saved: &litebox_common_linux::PtRegs,
+        context: &libc::ucontext_t,
+    ) -> litebox_common_linux::PtRegs {
+        let mut expected = saved.clone();
+        for (destination, source) in expected.regs.iter_mut().zip(context.uc_mcontext.regs) {
+            *destination = usize::try_from(source).unwrap();
+        }
+        expected.sp = usize::try_from(context.uc_mcontext.sp).unwrap();
+        expected.pc = usize::try_from(context.uc_mcontext.pc).unwrap();
+        expected.pstate = context.uc_mcontext.pstate & litebox_common_linux::arch::SAFE_USER_PSTATE;
+        expected.orig_x0 = expected.regs[0];
+        expected.syscallno = litebox_common_linux::arch::NO_SYSCALL;
+        expected
+    }
+
+    fn assert_ptregs_eq(
+        actual: &litebox_common_linux::PtRegs,
+        expected: &litebox_common_linux::PtRegs,
+        stage: &str,
+    ) {
+        assert_eq!(actual.regs, expected.regs, "{stage}: GPRs");
+        assert_eq!(actual.sp, expected.sp, "{stage}: SP");
+        assert_eq!(actual.pc, expected.pc, "{stage}: PC");
+        assert_eq!(actual.pstate, expected.pstate, "{stage}: PSTATE");
+        // Independently of `SAFE_USER_PSTATE`: only the condition flags may
+        // reach the guest from this fixture. Comparing against the masking
+        // expression alone would still pass if the mask were widened.
+        assert_eq!(
+            actual.pstate & !0xf000_0000,
+            0,
+            "{stage}: PSTATE outside NZCV reached the guest"
+        );
+        assert_eq!(actual.orig_x0, expected.orig_x0, "{stage}: orig_x0");
+        assert_eq!(actual.syscallno, expected.syscallno, "{stage}: syscallno");
+        assert_eq!(actual.unused2, expected.unused2, "{stage}: unused2");
+    }
+
+    fn ptregs_bytes(
+        regs: &litebox_common_linux::PtRegs,
+    ) -> [u8; core::mem::size_of::<litebox_common_linux::PtRegs>()] {
+        let mut bytes = [0; core::mem::size_of::<litebox_common_linux::PtRegs>()];
+        // SAFETY: both regions are valid for exactly `size_of::<PtRegs>()`
+        // bytes; reading padding is sound here because fixtures start zeroed.
+        unsafe {
+            core::ptr::copy_nonoverlapping(
+                core::ptr::from_ref(regs).cast::<u8>(),
+                bytes.as_mut_ptr(),
+                bytes.len(),
+            );
+        }
+        bytes
+    }
+
+    #[test]
+    fn gate_canonicalization_covers_every_emitted_instruction_boundary() {
+        const HOST_ANCHOR: u64 = 0xfeed_f000_0000_0010;
+        const HOST_CALLBACK: u64 = 0xfeed_f000_0000_0011;
+        const TRAMPOLINE_ADDRESS: u64 = 0xfeed_f000_0000_0012;
+        const GUEST_X16: usize = 0x1616_1616_1616_1616;
+        const GUEST_X17: usize = 0x1717_1717_1717_1717;
+        const ORIGINAL_PC: usize = 0x1000;
+        const POST_PC: usize = 0x1004;
+        const GUEST_SP: usize = 0x8020;
+        const GUEST_TP: usize = 0x1234_5678_9abc_def0;
+        const UPDATED_GUEST_TP: usize = 0x2345_6789_abcd_ef01;
+        let guest_tp = GUEST_TP.to_le_bytes();
+
+        let (code, trampoline, mut context, saved) = gate_fixture(0xd53b_d049);
+        for offset in [0usize, 4, 8] {
+            context.uc_mcontext.pc = 0x400010 + offset as u64;
+            context.uc_mcontext.regs[9] = match offset {
+                0 => saved.regs[9] as u64,
+                4 => HOST_ANCHOR,
+                8 => UPDATED_GUEST_TP as u64,
+                _ => unreachable!(),
+            };
+            let mut reader = fixture_reader(&code, &trampoline, &[], &guest_tp);
+            let result = super::aarch64::canonicalize_aarch64_gate_signal_context(
+                &context,
+                &saved,
+                0x500000,
+                0,
+                0,
+                move |address, output| {
+                    (address != 0x500000 || offset != 8) && reader(address, output)
+                },
+            );
+            let Aarch64GateSignalResult::Canonicalized(regs) = result else {
+                panic!("MRS +{offset} did not canonicalize");
+            };
+            let mut expected = expected_signal_regs(&saved, &context);
+            expected.pc = if offset == 0 { ORIGINAL_PC } else { POST_PC };
+            expected.regs[9] = match offset {
+                0 => saved.regs[9],
+                4 => GUEST_TP,
+                8 => UPDATED_GUEST_TP,
+                _ => unreachable!(),
+            };
+            assert_ptregs_eq(&regs, &expected, &format!("MRS +{offset}"));
+            assert!(!regs.regs.contains(&usize::try_from(HOST_ANCHOR).unwrap()));
+        }
+
+        let (code, trampoline, mut context, saved) = gate_fixture(0xd51b_d045);
+        let mut saved = saved;
+        saved.regs[16] = GUEST_X16;
+        saved.regs[17] = GUEST_X17;
+        let mut frame = [0u8; 32];
+        frame[0..8].copy_from_slice(&(saved.regs[16] as u64).to_le_bytes());
+        frame[8..16].copy_from_slice(&(saved.regs[17] as u64).to_le_bytes());
+        frame[16..24].copy_from_slice(&(saved.regs[5] as u64).to_le_bytes());
+        for offset in (0usize..=32).step_by(4) {
+            context.uc_mcontext.pc = 0x400010 + offset as u64;
+            context.uc_mcontext.sp = if offset == 0 || offset >= 32 {
+                0x8020
+            } else {
+                0x8000
+            };
+            context.uc_mcontext.regs[16] = if (16..28).contains(&offset) {
+                HOST_ANCHOR
+            } else {
+                saved.regs[16] as u64
+            };
+            context.uc_mcontext.regs[17] = if (20..28).contains(&offset) {
+                HOST_CALLBACK
+            } else {
+                saved.regs[17] as u64
+            };
+            context.uc_mcontext.regs[5] = saved.regs[5] as u64;
+            let mut reader = fixture_reader(&code, &trampoline, &frame, &guest_tp);
+            let result = super::aarch64::canonicalize_aarch64_gate_signal_context(
+                &context,
+                &saved,
+                0x500000,
+                0,
+                0,
+                move |address, output| {
+                    (offset < 28 || address != 0x8000) && reader(address, output)
+                },
+            );
+            let Aarch64GateSignalResult::Canonicalized(regs) = result else {
+                panic!("MSR +{offset} did not canonicalize");
+            };
+            let mut expected = expected_signal_regs(&saved, &context);
+            expected.pc = if offset <= 20 { ORIGINAL_PC } else { POST_PC };
+            expected.sp = GUEST_SP;
+            expected.regs[16] = saved.regs[16];
+            expected.regs[17] = saved.regs[17];
+            assert_ptregs_eq(&regs, &expected, &format!("MSR +{offset}"));
+            assert!(!regs.regs.contains(&usize::try_from(HOST_ANCHOR).unwrap()));
+            assert!(!regs.regs.contains(&usize::try_from(HOST_CALLBACK).unwrap()));
+        }
+
+        let (code, trampoline, mut context, saved) = gate_fixture(0xd400_0001);
+        let mut saved = saved;
+        saved.regs[16] = GUEST_X16;
+        saved.regs[17] = GUEST_X17;
+        let mut frame = [0u8; 32];
+        frame[0..8].copy_from_slice(&(saved.regs[16] as u64).to_le_bytes());
+        let saved_before = ptregs_bytes(&saved);
+        for offset in (0usize..=44).step_by(4) {
+            context.uc_mcontext.pc = 0x400010 + offset as u64;
+            context.uc_mcontext.sp = if offset == 0 { 0x8020 } else { 0x8000 };
+            context.uc_mcontext.regs[16] = if offset < 8 {
+                saved.regs[16] as u64
+            } else if (20..28).contains(&offset) {
+                TRAMPOLINE_ADDRESS
+            } else if offset >= 28 {
+                HOST_CALLBACK
+            } else {
+                0x1004
+            };
+            let result = super::aarch64::canonicalize_aarch64_gate_signal_context(
+                &context,
+                &saved,
+                0x500000,
+                0x400010 + 36,
+                0x1004,
+                fixture_reader(&code, &trampoline, &frame, &guest_tp),
+            );
+            if offset >= 36 {
+                assert!(matches!(
+                    result,
+                    Aarch64GateSignalResult::PreserveSavedContext
+                ));
+                assert_eq!(ptregs_bytes(&saved), saved_before, "SVC outbound +{offset}");
+            } else {
+                let Aarch64GateSignalResult::Canonicalized(regs) = result else {
+                    panic!("SVC +{offset} did not canonicalize");
+                };
+                let mut expected = expected_signal_regs(&saved, &context);
+                expected.pc = ORIGINAL_PC;
+                expected.sp = GUEST_SP;
+                expected.regs[16] = saved.regs[16];
+                assert_ptregs_eq(&regs, &expected, &format!("SVC +{offset}"));
+                assert!(!regs.regs.contains(&usize::try_from(HOST_CALLBACK).unwrap()));
+                assert!(
+                    !regs
+                        .regs
+                        .contains(&usize::try_from(TRAMPOLINE_ADDRESS).unwrap())
+                );
+            }
+        }
+
+        for offset in [36usize, 40, 44] {
+            context.uc_mcontext.pc = 0x400010 + offset as u64;
+            for (stub, pc) in [(0, 0x1004), (0x400010 + 36, 0), (0x400010 + 36, 0x2004)] {
+                let result = super::aarch64::canonicalize_aarch64_gate_signal_context(
+                    &context,
+                    &saved,
+                    0x500000,
+                    stub,
+                    pc,
+                    fixture_reader(&code, &trampoline, &frame, &guest_tp),
+                );
+                assert!(matches!(result, Aarch64GateSignalResult::NotGate));
+            }
+        }
+    }
+
+    #[test]
+    fn invalid_gate_runtime_state_never_mutates_saved_ptregs() {
+        let (code, trampoline, mut context, saved) = gate_fixture(0xd51b_d045);
+        context.uc_mcontext.pc = 0x400010 + 20;
+        context.uc_mcontext.sp = 0x8000;
+        context.uc_mcontext.regs[5] = saved.regs[5] as u64;
+        let mut frame = [0u8; 24];
+        frame[0..8].copy_from_slice(&(saved.regs[16] as u64).to_le_bytes());
+        frame[8..16].copy_from_slice(&(saved.regs[17] as u64).to_le_bytes());
+        frame[16..24].copy_from_slice(&(saved.regs[5] as u64).to_le_bytes());
+
+        let before = ptregs_bytes(&saved);
+        // The slot body, the original site and the gate frame all live in guest
+        // memory, so denying any of them yields `NotGate` and leaves the signal
+        // with the guest; see the boundary on
+        // `canonicalize_aarch64_gate_signal_context`. None of them may touch
+        // the saved registers on the way out.
+        for denied_address in [0x400010usize, 0x1000, 0x8000] {
+            let mut reader = fixture_reader(&code, &trampoline, &frame, &[]);
+            let result = super::aarch64::canonicalize_aarch64_gate_signal_context(
+                &context,
+                &saved,
+                0x500000,
+                0,
+                0,
+                move |address, output| address != denied_address && reader(address, output),
+            );
+            assert!(
+                matches!(result, Aarch64GateSignalResult::NotGate),
+                "denying {denied_address:#x} should leave the signal with the guest"
+            );
+            assert_eq!(ptregs_bytes(&saved), before);
+        }
+
+        let mut wrong_branch = code.clone();
+        wrong_branch.copy_from_slice(&0x1400_0000u32.to_le_bytes());
+        let result = super::aarch64::canonicalize_aarch64_gate_signal_context(
+            &context,
+            &saved,
+            0x500000,
+            0,
+            0,
+            fixture_reader(&wrong_branch, &trampoline, &frame, &[]),
+        );
+        assert!(matches!(result, Aarch64GateSignalResult::NotGate));
+        assert_eq!(ptregs_bytes(&saved), before);
+
+        let mut wrong_template = trampoline.clone();
+        wrong_template[16 + 8..16 + 12].copy_from_slice(&0xd503_201fu32.to_le_bytes());
+        let result = super::aarch64::canonicalize_aarch64_gate_signal_context(
+            &context,
+            &saved,
+            0x500000,
+            0,
+            0,
+            fixture_reader(&code, &wrong_template, &frame, &[]),
+        );
+        assert!(matches!(result, Aarch64GateSignalResult::NotGate));
+        assert_eq!(ptregs_bytes(&saved), before);
+
+        frame[16..24].copy_from_slice(&0xdead_beef_u64.to_le_bytes());
+        let result = super::aarch64::canonicalize_aarch64_gate_signal_context(
+            &context,
+            &saved,
+            0x500000,
+            0,
+            0,
+            fixture_reader(&code, &trampoline, &frame, &[]),
+        );
+        assert!(matches!(result, Aarch64GateSignalResult::NotGate));
+        assert_eq!(ptregs_bytes(&saved), before);
+
+        context.uc_mcontext.pc = 0x400010 + 24;
+        let result = super::aarch64::canonicalize_aarch64_gate_signal_context(
+            &context,
+            &saved,
+            0x500000,
+            0,
+            0,
+            fixture_reader(&code, &trampoline, &[], &[]),
+        );
+        assert!(matches!(result, Aarch64GateSignalResult::NotGate));
+        assert_eq!(ptregs_bytes(&saved), before);
+    }
+
+    #[test]
+    fn gate_classifier_and_provenance_negatives_are_failure_atomic() {
+        let (code, trampoline, mut context, saved) = gate_fixture(0xd400_0001);
+        let before = ptregs_bytes(&saved);
+        let mut frame = [0u8; 32];
+        frame[..8].copy_from_slice(&(saved.regs[16] as u64).to_ne_bytes());
+
+        let assert_failure =
+            |result: Aarch64GateSignalResult, expected_invalid: bool, label: &str| {
+                if expected_invalid {
+                    assert!(
+                        matches!(result, Aarch64GateSignalResult::InvalidRuntimeState),
+                        "{label}"
+                    );
+                } else {
+                    assert!(
+                        matches!(result, Aarch64GateSignalResult::NotGate),
+                        "{label}"
+                    );
+                }
+                assert_eq!(
+                    ptregs_bytes(&saved),
+                    before,
+                    "{label}: saved PtRegs changed"
+                );
+            };
+
+        for (pc, expected_invalid, label) in [
+            (0x2000, false, "ordinary guest code"),
+            (0x400011, false, "unaligned gate PC"),
+            (0x400010 + 48, false, "SVC padding"),
+            (0x400010 + 60, false, "SVC metadata"),
+        ] {
+            context.uc_mcontext.pc = pc;
+            let result = super::aarch64::canonicalize_aarch64_gate_signal_context(
+                &context,
+                &saved,
+                0x500000,
+                0,
+                0,
+                fixture_reader(&code, &trampoline, &frame, &[]),
+            );
+            assert_failure(result, expected_invalid, label);
+        }
+
+        // A template that does not validate is evidence the candidate is not
+        // a gate, not evidence of a corrupt one: the metadata word that got it
+        // this far is guest-writable, so treating a mismatch as fatal would
+        // hand the guest a way to kill the runtime on demand.
+        context.uc_mcontext.pc = 0x400010 + 8;
+        context.uc_mcontext.sp = 0x8000;
+        for (word_offset, label) in [
+            (0usize, "bad first template word"),
+            (28, "bad callback load"),
+            (32, "bad inbound register branch"),
+            (48, "bad padding word"),
+        ] {
+            let mut mutated = trampoline.clone();
+            mutated[16 + word_offset..16 + word_offset + 4].copy_from_slice(&0u32.to_le_bytes());
+            let result = super::aarch64::canonicalize_aarch64_gate_signal_context(
+                &context,
+                &saved,
+                0x500000,
+                0,
+                0,
+                fixture_reader(&code, &mutated, &frame, &[]),
+            );
+            assert_failure(result, false, label);
+        }
+
+        let mut bad_metadata = trampoline.clone();
+        bad_metadata[16 + 60] ^= 0x80;
+        let result = super::aarch64::canonicalize_aarch64_gate_signal_context(
+            &context,
+            &saved,
+            0x500000,
+            0,
+            0,
+            fixture_reader(&code, &bad_metadata, &frame, &[]),
+        );
+        assert_failure(result, false, "bad metadata");
+
+        for (branch, label) in [
+            (0x940f_fc04u32, "inbound BL opcode"),
+            (0xd61f_0200, "inbound BR x16 opcode/register"),
+            (0x1400_0001, "inbound B wrong target"),
+        ] {
+            let wrong_code = branch.to_le_bytes();
+            let result = super::aarch64::canonicalize_aarch64_gate_signal_context(
+                &context,
+                &saved,
+                0x500000,
+                0,
+                0,
+                fixture_reader(&wrong_code, &trampoline, &frame, &[]),
+            );
+            assert_failure(result, false, label);
+        }
+
+        // The reader is intentionally inconsistent: it presents one valid SVC
+        // slot at each of two candidate starts. Candidate uniqueness must still
+        // fail closed rather than selecting either one.
+        let second_start = 0x400020usize;
+        let second_pc = second_start + 8;
+        let (_, second_slot, _, _) = gate_fixture(0xd400_0001);
+        let mut second_slot = second_slot[16..80].to_vec();
+        let first_slot = trampoline[16..80].to_vec();
+        let mut source = 0xd400_0001u32.to_le_bytes();
+        let (relocated, trapped) = litebox_syscall_rewriter::patch_code_segment(
+            &mut source,
+            0x1000,
+            second_start as u64 - 16,
+            0,
+        )
+        .unwrap();
+        assert!(trapped.is_empty());
+        second_slot.copy_from_slice(&relocated[16..80]);
+        context.uc_mcontext.pc = second_pc as u64;
+        let result = super::aarch64::canonicalize_aarch64_gate_signal_context(
+            &context,
+            &saved,
+            0x500000,
+            0,
+            0,
+            move |address, output| {
+                let source = if address == 0x400010 && output.len() == 64 {
+                    Some(first_slot.as_slice())
+                } else if address == second_start && output.len() == 64 {
+                    Some(second_slot.as_slice())
+                } else if address == 0x400010 + 60 && output.len() == 4 {
+                    Some(&first_slot[60..64])
+                } else if address == second_start + 60 && output.len() == 4 {
+                    Some(&second_slot[60..64])
+                } else {
+                    None
+                };
+                if let Some(source) = source {
+                    output.copy_from_slice(source);
+                    true
+                } else {
+                    false
+                }
+            },
+        );
+        assert_failure(result, true, "ambiguous candidates");
+
+        // SP restoration arithmetic must be checked before publishing a result.
+        // `sp` is a guest register, so a value that cannot be restored means
+        // this is not a gate frame rather than a broken runtime.
+        context.uc_mcontext.pc = 0x400010 + 4;
+        context.uc_mcontext.sp = u64::MAX - 15;
+        let result = super::aarch64::canonicalize_aarch64_gate_signal_context(
+            &context,
+            &saved,
+            0x500000,
+            0,
+            0,
+            fixture_reader(&code, &trampoline, &frame, &[]),
+        );
+        assert_failure(result, false, "SP overflow");
+    }
+
+    #[test]
+    fn unreadable_mrs_guest_tp_is_failure_atomic() {
+        let (code, trampoline, mut context, saved) = gate_fixture(0xd53b_d049);
+        context.uc_mcontext.pc = 0x400010 + 4;
+        let before = (saved.regs, saved.sp, saved.pc, saved.pstate, saved.orig_x0);
+        let result = super::aarch64::canonicalize_aarch64_gate_signal_context(
+            &context,
+            &saved,
+            0x500000,
+            0,
+            0,
+            fixture_reader(&code, &trampoline, &[], &[]),
+        );
+        assert!(matches!(
+            result,
+            Aarch64GateSignalResult::InvalidRuntimeState
+        ));
+        assert_eq!(
+            (saved.regs, saved.sp, saved.pc, saved.pstate, saved.orig_x0),
+            before
+        );
+    }
+
+    #[test]
+    fn gate_stage_reads_are_required_only_at_the_consuming_boundaries() {
+        const GUEST_TP: usize = 0x1234_5678_9abc_def0;
+        let guest_tp = GUEST_TP.to_ne_bytes();
+
+        let (mrs_code, mrs_slot, mut context, saved) = gate_fixture(0xd53b_d049);
+        for (offset, readable, canonical) in [
+            (0usize, false, true),
+            (4, false, false),
+            (4, true, true),
+            (8, false, true),
+        ] {
+            context.uc_mcontext.pc = 0x400010 + offset as u64;
+            context.uc_mcontext.regs[9] = if offset == 8 {
+                GUEST_TP as u64
+            } else {
+                0xfeed_f000_0000_0010
+            };
+            let result = super::aarch64::canonicalize_aarch64_gate_signal_context(
+                &context,
+                &saved,
+                0x500000,
+                0,
+                0,
+                fixture_reader(
+                    &mrs_code,
+                    &mrs_slot,
+                    &[],
+                    if readable { &guest_tp } else { &[] },
+                ),
+            );
+            assert_eq!(
+                matches!(result, Aarch64GateSignalResult::Canonicalized(_)),
+                canonical,
+                "MRS +{offset}, guest TP readable={readable}"
+            );
+        }
+
+        let (msr_code, msr_slot, mut context, saved) = gate_fixture(0xd51b_d045);
+        let mut msr_frame = [0u8; 24];
+        msr_frame[..8].copy_from_slice(&(saved.regs[16] as u64).to_ne_bytes());
+        msr_frame[8..16].copy_from_slice(&(saved.regs[17] as u64).to_ne_bytes());
+        msr_frame[16..].copy_from_slice(&(saved.regs[5] as u64).to_ne_bytes());
+        for offset in (0usize..=32).step_by(4) {
+            context.uc_mcontext.pc = 0x400010 + offset as u64;
+            context.uc_mcontext.sp = if offset == 0 || offset == 32 {
+                0x8020
+            } else {
+                0x8000
+            };
+            context.uc_mcontext.regs[5] = saved.regs[5] as u64;
+            let result = super::aarch64::canonicalize_aarch64_gate_signal_context(
+                &context,
+                &saved,
+                0x500000,
+                0,
+                0,
+                fixture_reader(&msr_code, &msr_slot, &[], &[]),
+            );
+            assert_eq!(
+                matches!(result, Aarch64GateSignalResult::Canonicalized(_)),
+                matches!(offset, 0 | 4 | 28 | 32),
+                "MSR +{offset} frame requirement"
+            );
+        }
+        // The frame value is provenance before and after commit; changing it
+        // must fail rather than reconstructing from scratch registers.
+        msr_frame[16..].copy_from_slice(&0xdead_beef_dead_beefu64.to_ne_bytes());
+        for offset in [12usize, 20, 24] {
+            context.uc_mcontext.pc = 0x400010 + offset as u64;
+            context.uc_mcontext.sp = 0x8000;
+            let result = super::aarch64::canonicalize_aarch64_gate_signal_context(
+                &context,
+                &saved,
+                0x500000,
+                0,
+                0,
+                fixture_reader(&msr_code, &msr_slot, &msr_frame, &[]),
+            );
+            assert!(
+                matches!(result, Aarch64GateSignalResult::NotGate),
+                "MSR +{offset} accepted a mutated capture"
+            );
+        }
+
+        let (svc_code, svc_slot, mut context, saved) = gate_fixture(0xd400_0001);
+        for offset in (0usize..=32).step_by(4) {
+            context.uc_mcontext.pc = 0x400010 + offset as u64;
+            context.uc_mcontext.sp = if offset == 0 { 0x8020 } else { 0x8000 };
+            let result = super::aarch64::canonicalize_aarch64_gate_signal_context(
+                &context,
+                &saved,
+                0x500000,
+                0,
+                0,
+                fixture_reader(&svc_code, &svc_slot, &[], &[]),
+            );
+            // Past the staging store the frame is required, and it lives on the
+            // guest's stack -- so an unreadable one leaves the signal with the
+            // guest rather than killing the runtime.
+            if matches!(offset, 0 | 4) {
+                assert!(
+                    matches!(result, Aarch64GateSignalResult::Canonicalized(_)),
+                    "SVC +{offset} should not need the frame"
+                );
+            } else {
+                assert!(
+                    matches!(result, Aarch64GateSignalResult::NotGate),
+                    "SVC +{offset} with an unreadable frame must stay with the guest"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn canonicalizer_rejects_mrs_xzr_metadata_without_indexing_x31() {
+        let (code, mut trampoline, mut context, saved) = gate_fixture(0xd53b_d049);
+        trampoline[28..32].copy_from_slice(&0x1f11_b807u32.to_le_bytes());
+        context.uc_mcontext.pc = 0x400010;
+
+        let result = super::aarch64::canonicalize_aarch64_gate_signal_context(
+            &context,
+            &saved,
+            0x500000,
+            0,
+            0,
+            fixture_reader(&code, &trampoline, &[], &[]),
+        );
+        assert!(matches!(result, Aarch64GateSignalResult::NotGate));
+    }
+
+    #[test]
+    fn msr_special_sources_validate_the_captured_architectural_value() {
+        for (source, expected) in [(16u8, 0x1616usize), (17, 0x1717), (31, 0)] {
+            let original = 0xd51b_d040 | u32::from(source);
+            let (code, trampoline, mut context, mut saved) = gate_fixture(original);
+            saved.regs[16] = 0x1616;
+            saved.regs[17] = 0x1717;
+            context.uc_mcontext.pc = 0x400010 + 20;
+            context.uc_mcontext.sp = 0x8000;
+            let mut frame = [0u8; 24];
+            frame[0..8].copy_from_slice(&0x1616u64.to_ne_bytes());
+            frame[8..16].copy_from_slice(&0x1717u64.to_ne_bytes());
+            frame[16..24].copy_from_slice(&(expected as u64).to_ne_bytes());
+
+            let result = super::aarch64::canonicalize_aarch64_gate_signal_context(
+                &context,
+                &saved,
+                0x500000,
+                0,
+                0,
+                fixture_reader(&code, &trampoline, &frame, &[]),
+            );
+            let Aarch64GateSignalResult::Canonicalized(regs) = result else {
+                panic!("MSR x{source} did not canonicalize");
+            };
+            assert_eq!(regs.regs[16], 0x1616);
+            assert_eq!(regs.regs[17], 0x1717);
+        }
+    }
+
+    fn tls_block_base() -> usize {
+        let tp: usize;
+        // SAFETY: reads the thread pointer; touches no memory.
+        unsafe {
+            core::arch::asm!(
+                "mrs {tp}, tpidr_el0",
+                tp = out(reg) tp,
+                options(nomem, nostack, preserves_flags)
+            );
+        }
+        tp + tprel_offset!(litebox_tls_block)
+    }
+
+    macro_rules! read_tls_slot {
+        ($ty:ty, $offset:expr) => {{
+            // SAFETY: this thread's own, naturally aligned slot.
+            unsafe { ((tls_block_base() + $offset) as *const $ty).read_volatile() }
+        }};
+    }
+
+    #[test]
+    fn test_pending_host_signals_roundtrip() {
+        let _ = super::take_pending_host_signals();
+        assert_eq!(read_tls_slot!(u32, tls_offset::PENDING_HOST_SIGNALS), 0);
+
+        // SAFETY: on AArch64 `record_pending_signal` has no precondition
+        // beyond `TPIDR_EL0` being the host anchor, which it always is. The
+        // waker slot is null on this thread (asserted below), so no waker is
+        // dereferenced.
+        assert_eq!(read_tls_slot!(usize, tls_offset::WAIT_WAKER_ADDR), 0);
+        unsafe {
+            super::record_pending_signal(Signal::SIGALRM);
+            super::record_pending_signal(Signal::SIGINT);
+        }
+
+        let expected_bits =
+            (1u32 << (Signal::SIGALRM.as_i32() - 1)) | (1u32 << (Signal::SIGINT.as_i32() - 1));
+        assert_eq!(
+            read_tls_slot!(u32, tls_offset::PENDING_HOST_SIGNALS),
+            expected_bits,
+            "record_pending_signal must OR into the slot, not overwrite it"
+        );
+
+        let taken = super::take_pending_host_signals();
+        let expected = SigSet::empty().with(Signal::SIGALRM).with(Signal::SIGINT);
+        assert_eq!(taken.as_u64(), expected.as_u64());
+        assert!(taken.contains(Signal::SIGALRM));
+        assert!(taken.contains(Signal::SIGINT));
+
+        assert!(
+            super::take_pending_host_signals().is_empty(),
+            "take_pending_host_signals must clear the slot it read"
+        );
+        assert_eq!(read_tls_slot!(u32, tls_offset::PENDING_HOST_SIGNALS), 0);
+    }
+
+    #[test]
+    fn test_update_waker_exchange() {
+        let platform = LinuxUserland::new();
+        let wait_state = litebox::event::wait::WaitState::new(platform);
+
+        assert_eq!(read_tls_slot!(usize, tls_offset::WAIT_WAKER_ADDR), 0);
+
+        platform.update_waker(Some(wait_state.context().waker().clone()));
+        let first = read_tls_slot!(usize, tls_offset::WAIT_WAKER_ADDR);
+        assert_ne!(first, 0, "update_waker must publish the boxed waker");
+
+        platform.update_waker(Some(wait_state.context().waker().clone()));
+        let second = read_tls_slot!(usize, tls_offset::WAIT_WAKER_ADDR);
+        assert_ne!(second, 0);
+
+        platform.update_waker(None);
+        assert_eq!(
+            read_tls_slot!(usize, tls_offset::WAIT_WAKER_ADDR),
+            0,
+            "update_waker(None) must clear the slot"
+        );
+    }
+
+    /// Unwinds a panic out of a shim handler, through `run_thread_arch`'s
+    /// frame, and catches it on the other side.
+    ///
+    /// `run_thread_arch`'s CFI is hand-written and nothing else checks it.
+    /// Reaching the `catch_unwind` requires the unwinder to resolve the CFA
+    /// rule correctly; a bad rule aborts the process, so a green run is the
+    /// assertion. Covers the `init_handler` entry only — the other three need
+    /// real guest code.
+    #[test]
+    fn test_unwind_through_run_thread_arch() {
+        struct PanickingShim;
+
+        impl EnterShim for PanickingShim {
+            type ExecutionContext = PtRegs;
+            fn init(&self, _ctx: &mut PtRegs) -> ContinueOperation {
+                panic!("unwind out of init_handler");
+            }
+            fn syscall(&self, _ctx: &mut PtRegs) -> ContinueOperation {
+                unreachable!()
+            }
+            fn exception(&self, _ctx: &mut PtRegs, _info: &ExceptionInfo) -> ContinueOperation {
+                unreachable!()
+            }
+            fn interrupt(&self, _ctx: &mut PtRegs) -> ContinueOperation {
+                unreachable!()
+            }
+        }
+
+        let result = std::panic::catch_unwind(|| {
+            let mut ctx = PtRegs::default();
+            // SAFETY: the shim panics out of `init` before the context is ever
+            // used to enter the guest, so no valid guest state is required.
+            unsafe { super::run_thread(PanickingShim, &mut ctx) };
+        });
+
+        assert!(result.is_err(), "the panic must propagate to the caller");
+        assert!(
+            !super::is_guest_thread(),
+            "unwinding must run `GuestThreadMarker`'s drop"
+        );
+    }
+
+    #[test]
+    fn test_guest_thread_marker() {
+        assert!(!is_guest_thread(), "a plain test thread is not a guest");
+
+        {
+            let _outer = GuestThreadMarker::enter();
+            assert!(is_guest_thread());
+            {
+                let _inner = GuestThreadMarker::enter();
+                assert!(is_guest_thread());
+            }
+            assert!(
+                is_guest_thread(),
+                "dropping a nested marker must not un-mark the thread while \
+                 an outer frame is still running the guest"
+            );
+        }
+        assert!(!is_guest_thread(), "the outermost marker must restore");
+
+        let result = std::panic::catch_unwind(|| {
+            let _marker = GuestThreadMarker::enter();
+            assert!(is_guest_thread());
+            panic!("unwind out of guest execution");
+        });
+        assert!(result.is_err());
+        assert!(
+            !is_guest_thread(),
+            "the marker must be restored when the guest frame unwinds"
+        );
+    }
+
+    /// The staging store must carry an exception-table fixup, or a fault on it
+    /// escapes into `exception_signal_handler` with `in_guest == 1` and is
+    /// mistaken for a guest fault; see [`switch_to_guest_via_outbound_stub`].
+    #[test]
+    fn test_switch_to_guest_stage_x16_has_exception_fixup() {
+        let stage = super::switch_to_guest_stage_x16 as *const () as usize;
+        let fixup = super::switch_to_guest_stage_x16_fixup as *const () as usize;
+        assert_eq!(
+            litebox::mm::exception_table::search_exception_tables(stage),
+            Some(fixup),
+            "the guest-stack staging store must be recoverable in place"
+        );
+    }
+
+    /// A SIGSEGV on that store must not be attributed to the guest.
+    ///
+    /// `in_guest` is already 1 at the fault, so without the fixup and the
+    /// `switch_to_guest` guard the handler would overwrite the guest `PtRegs`
+    /// with the host register file. Asserts that the guest context is
+    /// untouched, `in_guest` is left alone, and the context is redirected to
+    /// the fixup.
+    #[test]
+    fn test_exception_on_guest_stack_store_does_not_leak_host_state() {
+        let stage = super::switch_to_guest_stage_x16 as *const () as usize;
+        let fixup = super::switch_to_guest_stage_x16_fixup as *const () as usize;
+
+        let mut guest = std::boxed::Box::new(PtRegs::default());
+        for (i, r) in guest.regs.iter_mut().enumerate() {
+            *r = 0x6d05_7000_0000_0000 | i;
+        }
+        guest.sp = 0x6d05_7000_5000_0000;
+        guest.pc = 0x6d05_7000_6000_0000;
+        let before = std::format!("{guest:?}");
+
+        let in_guest = (tls_block_base() + tls_offset::IN_GUEST) as *mut u8;
+        let context_top = (tls_block_base() + tls_offset::GUEST_CONTEXT_TOP) as *mut usize;
+
+        // SAFETY: both are this thread's own naturally aligned TLS slots, and
+        // nothing else on this thread is in guest execution, so publishing a
+        // synthetic context here cannot be observed by anything but the call
+        // below. Both are restored before the assertions.
+        unsafe {
+            context_top.write_volatile((&raw mut *guest).add(1) as usize);
+            in_guest.write_volatile(1);
+        }
+
+        let mut context: libc::ucontext_t = unsafe { core::mem::zeroed() };
+        let mut info: libc::siginfo_t = unsafe { core::mem::zeroed() };
+        for (i, r) in context.uc_mcontext.regs.iter_mut().enumerate() {
+            *r = 0xffff_0000_0000_0000 | i as u64;
+        }
+        context.uc_mcontext.pc = stage as u64;
+        context.uc_mcontext.sp = 0xffff_0000_5000_0000;
+        context.uc_mcontext.fault_address = 0xffff_0000_5000_0000;
+
+        // SAFETY: `exception_signal_handler`'s contract is a signal number and
+        // the two pointers a `SA_SIGINFO` handler receives; both are valid
+        // here. It is reentrant with respect to this thread's TLS block, which
+        // is the only state it touches besides the context it is handed.
+        unsafe { super::exception_signal_handler(libc::SIGSEGV, &mut info, &mut context) };
+
+        // SAFETY: as above.
+        let was_in_guest = unsafe {
+            let was = in_guest.read_volatile();
+            in_guest.write_volatile(0);
+            context_top.write_volatile(0);
+            was
+        };
+
+        assert_eq!(
+            std::format!("{guest:?}"),
+            before,
+            "a fault on the guest-stack staging store must not overwrite the guest context \
+             with host register state"
+        );
+        assert_eq!(
+            was_in_guest, 1,
+            "the fault is a host fault recovered in place, so the thread is still on its way \
+             into the guest and `in_guest` must stay set"
+        );
+        assert_eq!(
+            usize::try_from(context.uc_mcontext.pc).unwrap(),
+            fixup,
+            "the signal context must be redirected to the store's fixup, not to \
+             `exception_callback`"
+        );
+    }
+}

--- a/litebox_platform_linux_userland/src/lib.rs
+++ b/litebox_platform_linux_userland/src/lib.rs
@@ -3,9 +3,10 @@
 
 //! A [LiteBox platform](../litebox/platform/index.html) for running LiteBox on userland Linux.
 
-// Restrict this crate to only work on Linux. For now, we are restricting this to only x86/x86-64
-// Linux, but we _may_ allow for more in the future, if we find it useful to do so.
-#![cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#![cfg(all(
+    target_os = "linux",
+    any(target_arch = "x86_64", target_arch = "aarch64")
+))]
 
 use std::cell::Cell;
 use std::io::IsTerminal as _;
@@ -26,7 +27,31 @@ use litebox_common_linux::{MRemapFlags, MapFlags, ProtFlags, vmap::VmapManager};
 
 use zerocopy::{FromBytes, IntoBytes};
 
+#[cfg(target_arch = "aarch64")]
+mod aarch64;
+#[cfg(target_arch = "aarch64")]
+use aarch64::{
+    Aarch64GateSignalResult, assert_tls_block_placement,
+    canonicalize_runtime_aarch64_gate_signal_context, copy_signal_context,
+    fatal_aarch64_gate_runtime_state, guest_thread_pointer_tp_offset, is_guest_thread,
+    load_tls_block_base, run_thread_arch, set_is_guest_thread, set_signal_return,
+    signal_handler_exit_guest, switch_to_guest, sync_instruction_stream, tls_offset,
+};
+
 extern crate alloc;
+
+#[cfg(target_arch = "aarch64")]
+const AT_FDCWD: usize = (litebox_common_linux::AT_FDCWD as isize).cast_unsigned();
+
+/// The admitted open syscall and its flags index must remain paired.
+#[cfg(target_arch = "x86_64")]
+const OPEN_SYSNO: i64 = libc::SYS_open;
+#[cfg(target_arch = "x86_64")]
+const OPEN_FLAGS_ARG: u8 = 1;
+#[cfg(target_arch = "aarch64")]
+const OPEN_SYSNO: i64 = libc::SYS_openat;
+#[cfg(target_arch = "aarch64")]
+const OPEN_FLAGS_ARG: u8 = 2;
 
 // ---------------------------------------------------------------------------
 // TLS (`.tbss`) access helpers
@@ -71,6 +96,7 @@ macro_rules! saved_tls_seg {
 ///
 /// Example: `tls!("pending_host_signals")` expands to
 /// `"fs:pending_host_signals@tpoff"` on x86_64.
+#[cfg(target_arch = "x86_64")]
 macro_rules! tls {
     ($var:literal) => {
         concat!(tls_seg!(), ":", $var, tls_suffix!())
@@ -82,6 +108,7 @@ macro_rules! tls {
 ///
 /// Example: `saved_tls!("in_guest")` expands to
 /// `"gs:in_guest@tpoff"` on x86_64.
+#[cfg(target_arch = "x86_64")]
 macro_rules! saved_tls {
     ($var:literal) => {
         concat!(saved_tls_seg!(), ":", $var, tls_suffix!())
@@ -123,6 +150,9 @@ struct CowRegionInfo {
 impl LinuxUserland {
     /// Create a new userland-Linux platform for use in `LiteBox`.
     pub fn new() -> &'static Self {
+        #[cfg(target_arch = "aarch64")]
+        assert_tls_block_placement();
+
         register_exception_handlers();
 
         let reserved_pages = Self::read_maps();
@@ -214,9 +244,20 @@ impl LinuxUserland {
         // We should either fix `mmap` to handle this error, or let global allocator call this function
         // whenever it get more pages from the host.
         let path = c"/proc/self/maps";
+        #[cfg(target_arch = "x86_64")]
         let fd = unsafe {
             syscalls::syscall3(
                 syscalls::Sysno::open,
+                path.as_ptr() as usize,
+                OFlags::RDONLY.bits() as usize,
+                0,
+            )
+        };
+        #[cfg(target_arch = "aarch64")]
+        let fd = unsafe {
+            syscalls::syscall4(
+                syscalls::Sysno::openat,
+                AT_FDCWD,
                 path.as_ptr() as usize,
                 OFlags::RDONLY.bits() as usize,
                 0,
@@ -289,7 +330,6 @@ impl LinuxUserland {
         }
     }
 
-    #[cfg(target_arch = "x86_64")]
     #[allow(
         clippy::missing_panics_doc,
         reason = "the seccomp filter rules are hardcoded and not expected to fail"
@@ -310,7 +350,12 @@ impl LinuxUserland {
             // Terminal and broker I/O
             (libc::SYS_read, vec![]),
             (libc::SYS_write, vec![]),
+            // The AArch64 (asm-generic) syscall table has no `poll`; glibc
+            // implements `poll(3)` there via `ppoll`.
+            #[cfg(target_arch = "x86_64")]
             (libc::SYS_poll, vec![]),
+            #[cfg(target_arch = "aarch64")]
+            (libc::SYS_ppoll, vec![]),
             // memory management
             (libc::SYS_mmap, vec![]),
             (libc::SYS_mprotect, vec![]),
@@ -349,12 +394,14 @@ impl LinuxUserland {
             (libc::SYS_brk, vec![]),
             (libc::SYS_getpid, vec![]),
             // TODO: could be removed if we pre-open files (see `try_allocate_cow_pages`)
+            //
+            // A mismatched syscall and flags index would admit arbitrary flags.
             (
-                libc::SYS_open,
+                OPEN_SYSNO,
                 vec![
                     SeccompRule::new(vec![
                         SeccompCondition::new(
-                            1,
+                            OPEN_FLAGS_ARG,
                             SeccompCmpArgLen::Dword,
                             SeccompCmpOp::Eq,
                             u64::from(OFlags::RDONLY.bits()),
@@ -462,7 +509,11 @@ impl LinuxUserland {
                 SeccompAction::Errno(libc::EINVAL.cast_unsigned())
             },
             SeccompAction::Allow,
-            seccompiler::TargetArch::x86_64,
+            if cfg!(target_arch = "x86_64") {
+                seccompiler::TargetArch::x86_64
+            } else {
+                seccompiler::TargetArch::aarch64
+            },
         )
         .unwrap();
         // TODO: bpf program can be compiled offline
@@ -490,11 +541,33 @@ fn take_pending_host_signals() -> litebox_common_linux::signal::SigSet {
     // Atomically swap the per-thread pending signals with zero.
     // Only the low 32 bits are used (covers traditional signals 1-31).
     let lo: u32;
+    #[cfg(target_arch = "x86_64")]
     unsafe {
         core::arch::asm!(
             "xor {tmp:e}, {tmp:e}",
             concat!("xchg DWORD PTR ", tls!("pending_host_signals"), ", {tmp:e}"),
             tmp = out(reg) lo,
+            options(nostack)
+        );
+    }
+    // Atomic against this thread's signal handlers; use the ARMv8.0 baseline
+    // rather than ARMv8.1 LSE.
+    #[cfg(target_arch = "aarch64")]
+    // SAFETY: reads and clears a naturally aligned `u32` in this thread's own
+    // TLS control block, whose offset from `TPIDR_EL0` is checked by
+    // `assert_tls_block_placement`.
+    unsafe {
+        core::arch::asm!(
+            load_tls_block_base!("{addr}"),
+            "add {addr}, {addr}, #{off}",
+            "2:",
+            "ldaxr {val:w}, [{addr}]",
+            "stlxr {status:w}, wzr, [{addr}]",
+            "cbnz {status:w}, 2b",
+            addr = out(reg) _,
+            val = out(reg) lo,
+            status = out(reg) _,
+            off = const tls_offset::PENDING_HOST_SIGNALS,
             options(nostack)
         );
     }
@@ -554,6 +627,7 @@ fn run_thread_inner(
 ) {
     let ctx_ptr = core::ptr::from_mut(ctx);
     let mut thread_ctx = ThreadContext { shim, ctx };
+    let _guest_thread = GuestThreadMarker::enter();
     ThreadHandle::run_with_handle(|| {
         with_signal_alt_stack(|| unsafe {
             run_thread_arch(&mut thread_ctx, ctx_ptr, u8::from(reenter));
@@ -615,6 +689,35 @@ fn get_guest_fsbase() -> usize {
         }
     }
     value
+}
+
+/// Tracks the whole guest-thread lifetime on AArch64 and preserves nested-entry
+/// state. On x86-64, `gsbase` provides the marker.
+struct GuestThreadMarker {
+    #[cfg(target_arch = "aarch64")]
+    previous: bool,
+}
+
+impl GuestThreadMarker {
+    fn enter() -> Self {
+        #[cfg(target_arch = "x86_64")]
+        {
+            Self {}
+        }
+        #[cfg(target_arch = "aarch64")]
+        {
+            let previous = is_guest_thread();
+            set_is_guest_thread(true);
+            Self { previous }
+        }
+    }
+}
+
+impl Drop for GuestThreadMarker {
+    fn drop(&mut self) {
+        #[cfg(target_arch = "aarch64")]
+        set_is_guest_thread(self.previous);
+    }
 }
 
 /// Runs the guest thread until it terminates.
@@ -964,6 +1067,8 @@ impl litebox::platform::ThreadProvider for LinuxUserland {
             );
         }
 
+        let _guest_thread = GuestThreadMarker::enter();
+
         ThreadHandle::run_with_handle(f)
     }
 }
@@ -1048,10 +1153,33 @@ impl litebox::platform::RawMutexProvider for LinuxUserland {
         Self: litebox::sync::RawSyncPrimitivesProvider,
     {
         let mut waker_ptr = waker.map_or(std::ptr::null_mut(), |w| Box::into_raw(Box::new(w)));
+        #[cfg(target_arch = "x86_64")]
         unsafe {
             core::arch::asm!(
                 concat!("xchg ", tls!("wait_waker_addr"), ", {}"),
                 inout(reg) waker_ptr,
+                options(nostack),
+            );
+        }
+        // Atomic against `record_pending_signal` in this thread's handler.
+        #[cfg(target_arch = "aarch64")]
+        // SAFETY: exchanges a naturally aligned `u64` in this thread's own TLS
+        // control block, whose offset from `TPIDR_EL0` is checked by
+        // `assert_tls_block_placement`.
+        unsafe {
+            let new_ptr = waker_ptr;
+            core::arch::asm!(
+                load_tls_block_base!("{addr}"),
+                "add {addr}, {addr}, #{off}",
+                "2:",
+                "ldaxr {old}, [{addr}]",
+                "stlxr {status:w}, {new}, [{addr}]",
+                "cbnz {status:w}, 2b",
+                addr = out(reg) _,
+                old = out(reg) waker_ptr,
+                new = in(reg) new_ptr,
+                status = out(reg) _,
+                off = const tls_offset::WAIT_WAKER_ADDR,
                 options(nostack),
             );
         }
@@ -1145,7 +1273,7 @@ impl litebox::platform::TimeProvider for LinuxUserland {
         unsafe { libc::clock_gettime(libc::CLOCK_MONOTONIC, t.as_mut_ptr()) };
         let t = unsafe { t.assume_init() };
         Instant {
-            #[cfg_attr(target_arch = "x86_64", expect(clippy::useless_conversion))]
+            #[expect(clippy::useless_conversion)]
             inner: Duration::new(
                 t.tv_sec.reinterpret_as_unsigned().into(),
                 t.tv_nsec.reinterpret_as_unsigned().trunc(),
@@ -1158,7 +1286,7 @@ impl litebox::platform::TimeProvider for LinuxUserland {
         unsafe { libc::clock_gettime(libc::CLOCK_REALTIME, t.as_mut_ptr()) };
         let t = unsafe { t.assume_init() };
         SystemTime {
-            #[cfg_attr(target_arch = "x86_64", expect(clippy::useless_conversion))]
+            #[expect(clippy::useless_conversion)]
             inner: Duration::new(
                 t.tv_sec.reinterpret_as_unsigned().into(),
                 t.tv_nsec.reinterpret_as_unsigned().trunc(),
@@ -1294,12 +1422,7 @@ fn futex_timeout(
     let uaddr2: *const AtomicU32 = uaddr2.map_or(std::ptr::null(), |u| u);
     unsafe {
         syscalls::syscall6(
-            {
-                #[cfg(target_arch = "x86_64")]
-                {
-                    syscalls::Sysno::futex
-                }
-            },
+            syscalls::Sysno::futex,
             uaddr as usize,
             usize::try_from(futex_op).unwrap(),
             val as usize,
@@ -1328,12 +1451,7 @@ fn futex_val2(
     let uaddr2: *const AtomicU32 = uaddr2.map_or(std::ptr::null(), |u| u);
     unsafe {
         syscalls::syscall6(
-            {
-                #[cfg(target_arch = "x86_64")]
-                {
-                    syscalls::Sysno::futex
-                }
-            },
+            syscalls::Sysno::futex,
             uaddr as usize,
             usize::try_from(futex_op).unwrap(),
             val as usize,
@@ -1365,10 +1483,29 @@ fn prot_flags(flags: MemoryRegionPermissions) -> ProtFlags {
     res
 }
 
+#[cfg(target_arch = "aarch64")]
+fn cache_sync_permissions(permissions: MemoryRegionPermissions) -> MemoryRegionPermissions {
+    (permissions | MemoryRegionPermissions::READ) & !MemoryRegionPermissions::EXEC
+}
+
 impl<const ALIGN: usize> litebox::platform::PageManagementProvider<ALIGN> for LinuxUserland {
     const TASK_ADDR_MIN: usize = 0x1_0000; // default linux config
     #[cfg(target_arch = "x86_64")]
     const TASK_ADDR_MAX: usize = 0x7FFF_FFFF_F000; // (1 << 47) - PAGE_SIZE;
+    /// Assumes the host kernel is configured for a 48-bit user virtual address
+    /// space. AArch64 Linux is also built with 39, 42 and 47 bits, and on those
+    /// hosts this hands out addresses the kernel then refuses to map.
+    ///
+    /// Naming the smallest configuration instead is not an option today: the
+    /// allocator in `litebox::mm` searches downwards from the highest existing
+    /// mapping, and the runtime's own mappings sit above any limit smaller than
+    /// the host's real one, leaving it unable to place anything at all.
+    ///
+    /// TODO: probe the host's limit -- this is an associated const, so that
+    /// needs `PageManagementProvider` to express a runtime bound -- and teach
+    /// the allocator to place into a region holding no existing mapping.
+    #[cfg(target_arch = "aarch64")]
+    const TASK_ADDR_MAX: usize = 0x0000_FFFF_FFFF_F000; // (1 << 48) - PAGE_SIZE;
 
     fn allocate_pages(
         &self,
@@ -1397,12 +1534,7 @@ impl<const ALIGN: usize> litebox::platform::PageManagementProvider<ALIGN> for Li
             };
         let r = unsafe {
             syscalls::syscall6(
-                {
-                    #[cfg(target_arch = "x86_64")]
-                    {
-                        syscalls::Sysno::mmap
-                    }
-                },
+                syscalls::Sysno::mmap,
                 suggested_range.start,
                 suggested_range.len(),
                 prot_flags(initial_permissions)
@@ -1461,6 +1593,7 @@ impl<const ALIGN: usize> litebox::platform::PageManagementProvider<ALIGN> for Li
         range: core::ops::Range<usize>,
         new_permissions: MemoryRegionPermissions,
     ) -> Result<(), litebox::platform::page_mgmt::PermissionUpdateError> {
+        #[cfg(target_arch = "x86_64")]
         unsafe {
             syscalls::syscall3(
                 syscalls::Sysno::mprotect,
@@ -1470,6 +1603,48 @@ impl<const ALIGN: usize> litebox::platform::PageManagementProvider<ALIGN> for Li
             )
         }
         .expect("mprotect failed");
+
+        #[cfg(target_arch = "aarch64")]
+        {
+            // Cache maintenance needs read permission. Keep execute disabled until
+            // the new instructions are visible to the fetch path.
+            //
+            // TODO: only a W->X transition needs this; `update_permissions` is not
+            // told the old permissions, so every transition to X pays for it.
+            // Revisit when the trait passes the old permissions.
+            let syncing = new_permissions.contains(MemoryRegionPermissions::EXEC);
+            let mapped_permissions = if syncing {
+                cache_sync_permissions(new_permissions)
+            } else {
+                new_permissions
+            };
+
+            unsafe {
+                syscalls::syscall3(
+                    syscalls::Sysno::mprotect,
+                    range.start,
+                    range.len(),
+                    prot_flags(mapped_permissions)
+                        .bits()
+                        .reinterpret_as_unsigned() as usize,
+                )
+            }
+            .expect("mprotect failed");
+            if syncing {
+                sync_instruction_stream(range.clone());
+                if mapped_permissions != new_permissions {
+                    unsafe {
+                        syscalls::syscall3(
+                            syscalls::Sysno::mprotect,
+                            range.start,
+                            range.len(),
+                            prot_flags(new_permissions).bits().reinterpret_as_unsigned() as usize,
+                        )
+                    }
+                    .expect("mprotect failed");
+                }
+            }
+        }
         Ok(())
     }
 
@@ -1494,9 +1669,20 @@ impl<const ALIGN: usize> litebox::platform::PageManagementProvider<ALIGN> for Li
         let file_path_cstr =
             std::ffi::CString::new(file_path.as_os_str().as_encoded_bytes()).unwrap();
         // TODO(jb): We should likely be storing pre-opened FDs, right?
+        #[cfg(target_arch = "x86_64")]
         let fd = unsafe {
             syscalls::syscall3(
                 syscalls::Sysno::open,
+                file_path_cstr.as_ptr() as usize,
+                OFlags::RDONLY.bits() as usize,
+                0,
+            )
+        };
+        #[cfg(target_arch = "aarch64")]
+        let fd = unsafe {
+            syscalls::syscall4(
+                syscalls::Sysno::openat,
+                AT_FDCWD,
                 file_path_cstr.as_ptr() as usize,
                 OFlags::RDONLY.bits() as usize,
                 0,
@@ -1513,23 +1699,13 @@ impl<const ALIGN: usize> litebox::platform::PageManagementProvider<ALIGN> for Li
 
         let result = unsafe {
             syscalls::syscall6(
-                {
-                    #[cfg(target_arch = "x86_64")]
-                    {
-                        syscalls::Sysno::mmap
-                    }
-                },
+                syscalls::Sysno::mmap,
                 suggested_start,
                 source_data.len(),
                 prot_flags(permissions).bits().reinterpret_as_unsigned() as usize,
                 flags.bits().reinterpret_as_unsigned() as usize,
                 fd,
-                {
-                    #[cfg(target_arch = "x86_64")]
-                    {
-                        file_offset
-                    }
-                },
+                file_offset,
             )
         };
 
@@ -1591,12 +1767,82 @@ impl litebox::platform::StdioProvider for LinuxUserland {
 }
 
 unsafe extern "C" {
-    // Defined in asm blocks above
     fn syscall_callback() -> isize;
+    #[cfg(target_arch = "aarch64")]
+    fn syscall_callback_in_guest_cleared();
     fn exception_callback();
     fn interrupt_callback();
+    #[cfg(target_arch = "x86_64")]
     fn switch_to_guest_start();
+    #[cfg(target_arch = "x86_64")]
     fn switch_to_guest_end();
+    #[cfg(target_arch = "aarch64")]
+    fn switch_to_guest_via_outbound_stub_start();
+    #[cfg(target_arch = "aarch64")]
+    fn switch_to_guest_via_outbound_stub_end();
+    #[cfg(target_arch = "aarch64")]
+    fn switch_to_guest_via_sigreturn_start();
+    #[cfg(target_arch = "aarch64")]
+    fn switch_to_guest_via_sigreturn_end();
+    #[cfg(all(test, target_arch = "aarch64"))]
+    fn switch_to_guest_stage_x16();
+    #[cfg(all(test, target_arch = "aarch64"))]
+    fn switch_to_guest_stage_x16_fixup();
+}
+
+/// Whether `pc` is inside a sequence switching this thread to guest state.
+///
+/// From the store that sets `in_guest` to the final branch into the guest,
+/// neither the host's nor the guest's register state is self-consistent, so a
+/// signal arriving there must not be attributed to the guest; each caller
+/// decides what to do instead.
+///
+/// AArch64 has two such sequences to x86-64's one, in separate functions, so
+/// this is a union of two ranges: one span would depend on link order.
+fn in_switch_to_guest(pc: usize) -> bool {
+    fn body(start: unsafe extern "C" fn(), end: unsafe extern "C" fn()) -> core::ops::Range<usize> {
+        start as *const () as usize..end as *const () as usize
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    {
+        body(switch_to_guest_start, switch_to_guest_end).contains(&pc)
+    }
+    #[cfg(target_arch = "aarch64")]
+    {
+        body(
+            switch_to_guest_via_outbound_stub_start,
+            switch_to_guest_via_outbound_stub_end,
+        )
+        .contains(&pc)
+            || body(
+                switch_to_guest_via_sigreturn_start,
+                switch_to_guest_via_sigreturn_end,
+            )
+            .contains(&pc)
+    }
+}
+
+/// Whether `ip` is inside `syscall_callback`'s prologue, i.e. before the guest
+/// has been fully accounted for but after control has left the guest.
+///
+/// This is `interrupt_signal_handler` case 1. Getting the bound wrong is not a
+/// benign off-by-one: an `ip` past the bound but still before `in_guest` is
+/// cleared falls through to case 4, where `copy_signal_context`
+/// overwrites the guest `PtRegs` with *host* state — a runtime pc, the gate
+/// frame's shifted sp, and `syscallno = NO_SYSCALL` — silently dropping the
+/// in-flight guest syscall.
+fn in_syscall_callback_prologue(ip: usize) -> bool {
+    let start = syscall_callback as *const () as usize;
+    #[cfg(target_arch = "x86_64")]
+    {
+        ip == start
+    }
+    // The label keeps the multi-instruction AArch64 bound tied to the asm.
+    #[cfg(target_arch = "aarch64")]
+    {
+        (start..syscall_callback_in_guest_cleared as *const () as usize).contains(&ip)
+    }
 }
 
 unsafe extern "C-unwind" fn init_handler(thread_ctx: &mut ThreadContext) {
@@ -1632,11 +1878,39 @@ extern "C-unwind" fn exception_handler(
     error: usize,
     cr2: usize,
 ) {
+    #[cfg(target_arch = "x86_64")]
     let info = litebox::shim::ExceptionInfo {
         exception: litebox::shim::Exception(trapno.try_into().unwrap()),
         error_code: error.try_into().unwrap(),
         cr2,
         kernel_mode: false,
+    };
+    // On AArch64 the hardware trap number and error code are not visible to
+    // userspace, so `exception_signal_handler` passes the signal number in
+    // `trapno` and zero in `error`, and the exception class is recovered from
+    // the signal.
+    #[cfg(target_arch = "aarch64")]
+    let info = {
+        let _ = error;
+        let exception = match i32::try_from(trapno).unwrap_or(0) {
+            libc::SIGILL => litebox::shim::Exception::INSTRUCTION_ABORT_LOWER_EL,
+            libc::SIGTRAP => litebox::shim::Exception::BRK64,
+            // Everything else reaching this handler -- SIGSEGV, SIGBUS and
+            // SIGFPE -- is reported as a data abort. SIGFPE does have a class
+            // of its own, 0x2c, but the shim cannot deliver SIGFPE yet; see
+            // its `handle_exception_request`.
+            _ => litebox::shim::Exception::DATA_ABORT_LOWER_EL,
+        };
+        litebox::shim::ExceptionInfo {
+            exception,
+            fault_address: cr2,
+            // The real ESR_EL1 is not exposed to userspace — the arm64 signal
+            // frame carries no syndrome register — so synthesize one holding
+            // just the exception class in bits 31:26. The instruction-specific
+            // syndrome (ISS) bits 24:0 are unavoidably zero.
+            esr: u64::from(exception.0) << 26,
+            kernel_mode: false,
+        }
     };
     thread_ctx.call_shim(|shim, ctx| shim.exception(ctx, &info));
 }
@@ -1657,9 +1931,21 @@ impl ThreadContext<'_> {
         // Clear the interrupt flag before calling the shim, since we've handled it
         // now (by calling into the shim), and it might be set again by the shim
         // before returning.
+        #[cfg(target_arch = "x86_64")]
         unsafe {
             core::arch::asm!(
                 concat!("mov BYTE PTR ", tls!("interrupt"), ", 0"),
+                options(nostack, preserves_flags)
+            );
+        }
+        #[cfg(target_arch = "aarch64")]
+        // SAFETY: writes a single byte in this thread's own TLS control block.
+        unsafe {
+            core::arch::asm!(
+                load_tls_block_base!("{tmp}"),
+                "strb wzr, [{tmp}, #{off}]",
+                tmp = out(reg) _,
+                off = const tls_offset::INTERRUPT,
                 options(nostack, preserves_flags)
             );
         }
@@ -1684,6 +1970,11 @@ impl litebox::platform::SystemInfoProvider for LinuxUserland {
         // TODO: implement VDSO in the shim, don't try to pass through the
         // platform VDSO.
         None
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    fn guest_thread_pointer_offset(&self) -> Option<usize> {
+        Some(guest_thread_pointer_tp_offset().into())
     }
 }
 
@@ -1764,6 +2055,17 @@ fn register_exception_handlers() {
             unsafe {
                 let mut sa: libc::sigaction = core::mem::zeroed();
                 sa.sa_flags = libc::SA_SIGINFO | libc::SA_ONSTACK;
+                // `SA_NODEFER`: the gate classifier probes memory around a guest
+                // PC that may be unmapped, and reaching the exception-table
+                // fixup for that probe needs this handler to be re-entrant.
+                // Without it the kernel force-kills on the nested fault, so a
+                // guest jumping to a bad pointer would take the host with it.
+                // Nothing on the x86-64 path probes guest memory, so leaving
+                // the flag off there keeps the kernel's recursion backstop.
+                #[cfg(target_arch = "aarch64")]
+                {
+                    sa.sa_flags |= libc::SA_NODEFER;
+                }
                 sa.sa_sigaction = exception_signal_handler as *const () as usize;
                 // Block the interrupt signal while handling exceptions to avoid
                 // saving the exception signal handler state as guest state.
@@ -1993,20 +2295,31 @@ unsafe extern "C" fn exception_signal_handler(
     info: &mut libc::siginfo_t,
     context: &mut libc::ucontext_t,
 ) {
-    // Return an error code for the syscall and log it in debug mode.
     #[cfg(debug_assertions)]
     if signum == libc::SIGSYS {
         use core::fmt::Write as _;
         #[cfg(target_arch = "x86_64")]
-        let eax_idx = libc::REG_RAX as usize;
-        let sysno = context.uc_mcontext.gregs[eax_idx];
-        context.uc_mcontext.gregs[eax_idx] = i64::from(-libc::EINVAL);
+        let (sysno, arg1) = {
+            let sysno = context.uc_mcontext.gregs[libc::REG_RAX as usize];
+            context.uc_mcontext.gregs[libc::REG_RAX as usize] = i64::from(-libc::EINVAL);
+            (
+                sysno,
+                context.uc_mcontext.gregs[libc::REG_RSI as usize] as *const core::ffi::c_char,
+            )
+        };
+        #[cfg(target_arch = "aarch64")]
+        let (sysno, arg1) = {
+            let sysno = context.uc_mcontext.regs[8].cast_signed();
+            context.uc_mcontext.regs[0] = i64::from(-libc::EINVAL).cast_unsigned();
+            (
+                sysno,
+                context.uc_mcontext.regs[1] as *const core::ffi::c_char,
+            )
+        };
         // Signal-safe: format on the stack via arrayvec (no heap allocation).
         let mut buf = arrayvec::ArrayString::<320>::new();
         if sysno == libc::SYS_openat {
-            #[cfg(target_arch = "x86_64")]
-            let rsi = context.uc_mcontext.gregs[libc::REG_RSI as usize] as *const i8;
-            let c_path = unsafe { core::ffi::CStr::from_ptr(rsi) };
+            let c_path = unsafe { core::ffi::CStr::from_ptr(arg1) };
             // libc may call `openat` for certain files that we can ignore, e.g., /proc/sys/vm/overcommit_memory.
             // Log the paths in case we need to allow some of them in the future.
             let _ = writeln!(buf, "INFO: openat with {c_path:?} is not allowed");
@@ -2024,21 +2337,78 @@ unsafe extern "C" fn exception_signal_handler(
         return;
     }
 
+    // Classify runtime transition faults before guest faults; misclassification
+    // would disclose the live host register file through guest `PtRegs`.
+    #[cfg(target_arch = "aarch64")]
+    let faulting_pc: usize = context.uc_mcontext.pc.trunc();
+
+    // The staging store is inside the `in_guest` bracket and may raise SIGSEGV
+    // or SIGBUS, so its fixup must run before consulting `in_guest`.
+    #[cfg(target_arch = "aarch64")]
+    if matches!(signum, libc::SIGSEGV | libc::SIGBUS)
+        && let Some(fixup_addr) = litebox::mm::exception_table::search_exception_tables(faulting_pc)
+    {
+        context.uc_mcontext.pc = fixup_addr as u64;
+        return;
+    }
+
+    // Remaining faults inside the transition bracket are runtime faults and
+    // cannot safely resume because `in_guest` and SP may be inconsistent.
+    #[cfg(target_arch = "aarch64")]
+    if in_switch_to_guest(faulting_pc) {
+        return unsafe { next_signal_handler(signum, info, context) };
+    }
+
     let Some(regs) = signal_handler_exit_guest(context, false) else {
         return unsafe { next_signal_handler(signum, info, context) };
     };
+    #[cfg(target_arch = "x86_64")]
     copy_signal_context(unsafe { &mut *regs }, context);
+    #[cfg(target_arch = "aarch64")]
+    match canonicalize_runtime_aarch64_gate_signal_context(context, unsafe { &*regs }) {
+        Aarch64GateSignalResult::NotGate => copy_signal_context(unsafe { &mut *regs }, context),
+        Aarch64GateSignalResult::Canonicalized(canonical) => unsafe { regs.write(canonical) },
+        Aarch64GateSignalResult::PreserveSavedContext => {
+            // The register values are already the guest's; only the syscall
+            // bookkeeping is stale. The stub runs after `syscall_callback`
+            // recorded a number, so leaving it would tell the shim a syscall is
+            // in flight during an exception or an interrupt -- the same reason
+            // `copy_signal_context` clears it on every other path.
+            unsafe { (*regs).syscallno = litebox_common_linux::arch::NO_SYSCALL };
+        }
+        Aarch64GateSignalResult::InvalidRuntimeState => {
+            fatal_aarch64_gate_runtime_state();
+        }
+    }
 
-    // Ensure that `run_thread_arch` is linked in so that `exception_callback` is visible.
     let _ = run_thread_arch as *const () as usize;
 
-    // Jump to exception_callback.
     let sigctx = &context.uc_mcontext;
     #[cfg(target_arch = "x86_64")]
     let (trapno, err, cr2) = (
         sigctx.gregs[libc::REG_TRAPNO as usize].trunc(),
         sigctx.gregs[libc::REG_ERR as usize].trunc(),
         sigctx.gregs[libc::REG_CR2 as usize].trunc(),
+    );
+    // AArch64 exposes no trap number or error code to userspace, so the signal
+    // number stands in for the trap and the error code is always zero;
+    // `exception_handler` recovers an exception class from it. The four-argument
+    // shape is kept so `exception_callback`'s x1/x2/x3 marshalling is shared.
+    //
+    // The fault address comes from `uc_mcontext.fault_address`, not
+    // `siginfo.si_addr`. That field is what the arm64 kernel copies out of
+    // `current->thread.fault_address`, i.e. FAR_EL1 — exactly what
+    // `ExceptionInfo::fault_address` is documented to carry. `si_addr` is a
+    // per-signal derived value and for SIGILL is the faulting *PC*, which
+    // would put a program counter in a field named `fault_address`.
+    #[cfg(target_arch = "aarch64")]
+    let (trapno, err, cr2) = (
+        // Widen infallibly: this runs in a signal handler, where a panic is
+        // not async-signal-safe. `i64::from` is a lossless widening and
+        // `trunc` to `isize` is exact on a 64-bit target.
+        TruncateExt::<isize>::trunc(i64::from(signum)),
+        0isize,
+        TruncateExt::<usize>::trunc(sigctx.fault_address).reinterpret_as_signed(),
     );
     set_signal_return(context, exception_callback, 0, trapno, err, cr2);
 }
@@ -2057,12 +2427,20 @@ unsafe fn next_signal_handler(
                     .reinterpret_as_unsigned()
                     .trunc()
             }
+            #[cfg(target_arch = "aarch64")]
+            {
+                context.uc_mcontext.pc.trunc()
+            }
         };
         if let Some(fixup_addr) = litebox::mm::exception_table::search_exception_tables(ip) {
             #[cfg(target_arch = "x86_64")]
             {
                 context.uc_mcontext.gregs[libc::REG_RIP as usize] =
                     fixup_addr.reinterpret_as_signed() as i64;
+            }
+            #[cfg(target_arch = "aarch64")]
+            {
+                context.uc_mcontext.pc = fixup_addr as u64;
             }
             return;
         }
@@ -2100,30 +2478,65 @@ unsafe fn next_signal_handler(
     }
 }
 
-/// Records a pending host signal in the `.tbss` bitmask and wakes any condvar
-/// the thread is blocked on.
+/// Records a pending host signal in the TLS bitmask and wakes any condvar the
+/// thread is blocked on.
 ///
 /// # Safety
 ///
-/// Must be called from a signal handler on a guest thread whose saved host TLS
-/// segment register is valid.
+/// Must be called from a signal handler on a guest thread.
+///
+/// On x86-64 that additionally requires the thread's saved host TLS segment
+/// register (`gsbase`) to be valid, since the bitmask is reached through it.
 unsafe fn record_pending_signal(signal: litebox_common_linux::signal::Signal) {
     let mask: u32 = 1u32 << (signal.as_i32() - 1);
+    let waker_addr: usize;
+
+    // SAFETY: the bitmask and waker slot are reached through this thread's own
+    // saved host TLS segment, which the caller guarantees is valid, and both
+    // accesses are naturally aligned.
+    #[cfg(target_arch = "x86_64")]
     unsafe {
         core::arch::asm!(
             concat!("lock or DWORD PTR ", saved_tls!("pending_host_signals"), ", {mask:e}"),
             mask = in(reg) mask,
             options(nostack)
         );
-    }
-    let waker_addr: usize;
-    unsafe {
         core::arch::asm!(
             concat!("mov {}, ", saved_tls!("wait_waker_addr")),
             out(reg) waker_addr,
             options(nostack, preserves_flags)
         );
     }
+
+    // Atomic against an interrupted exchange; a plain load/or/store can lose a bit.
+    //
+    // SAFETY: both slots are in this thread's own TLS control block at offsets
+    // checked by `assert_tls_block_placement`, and both accesses are naturally aligned.
+    // The exclusive monitor reservation is opened and closed within the loop.
+    #[cfg(target_arch = "aarch64")]
+    unsafe {
+        core::arch::asm!(
+            load_tls_block_base!("{block}"),
+            "add {addr}, {block}, #{pending_off}",
+            "2:",
+            "ldaxr {old:w}, [{addr}]",
+            "orr {new:w}, {old:w}, {mask:w}",
+            "stlxr {status:w}, {new:w}, [{addr}]",
+            "cbnz {status:w}, 2b",
+            "ldr {waker}, [{block}, #{waker_off}]",
+            block = out(reg) _,
+            addr = out(reg) _,
+            old = out(reg) _,
+            new = out(reg) _,
+            status = out(reg) _,
+            waker = out(reg) waker_addr,
+            mask = in(reg) mask,
+            pending_off = const tls_offset::PENDING_HOST_SIGNALS,
+            waker_off = const tls_offset::WAIT_WAKER_ADDR,
+            options(nostack)
+        );
+    }
+
     if waker_addr == 0 {
         return;
     }
@@ -2178,8 +2591,13 @@ unsafe fn interrupt_signal_handler(
             return;
         };
 
-        // Check whether the saved host TLS segment is valid (i.e. this is a
-        // guest thread). If not, re-raise the signal process-wide.
+        // Check whether this is a guest thread. If not, re-raise the signal
+        // process-wide.
+        //
+        // This is a thread-lifetime property, not `in_guest`: `in_guest` is 0
+        // whenever a guest thread sits in the host, including parked in an
+        // interruptible wait -- the case `record_pending_signal` and
+        // `wait_waker_addr` serve.
         let is_guest_thread;
         #[cfg(target_arch = "x86_64")]
         {
@@ -2187,9 +2605,14 @@ unsafe fn interrupt_signal_handler(
             unsafe { core::arch::asm!("rdgsbase {}", out(reg) gsbase) };
             is_guest_thread = gsbase != 0;
         }
+        #[cfg(target_arch = "aarch64")]
+        {
+            is_guest_thread = self::is_guest_thread();
+        }
 
         if is_guest_thread {
-            // SAFETY: we verified the saved host TLS segment is valid above.
+            // SAFETY: we verified above that this is a guest thread, which is
+            // what `record_pending_signal` requires.
             unsafe { record_pending_signal(signal) };
         } else {
             #[cfg(debug_assertions)]
@@ -2198,18 +2621,6 @@ unsafe fn interrupt_signal_handler(
         }
     }
 
-    // The interrupt signal can arrive in different contexts:
-    // 1. The thread is running in the host at the beginning of the syscall
-    //    handler. Do nothing--the syscall handler will handle the interrupt.
-    // 2. The thread is running in the host, with in_guest = 0. Just record that
-    //    an interrupt is pending; it will be checked next time we switch to the
-    //    guest.
-    // 3. The thread is running in the host, with in_guest = 1, in the middle of
-    //    restoring the guest context. We need to jump to the interrupt handler
-    //    without overwriting the saved guest context.
-    // 4. The thread is running in the guest. We need to save the context and
-    //    jump to the interrupt handler.
-    //
     // Note that this signal can't arrive while in an exception signal handler
     // since we mask the interrupt signal while handling exceptions.
 
@@ -2217,36 +2628,39 @@ unsafe fn interrupt_signal_handler(
     let ip = context.uc_mcontext.gregs[libc::REG_RIP as usize]
         .reinterpret_as_unsigned()
         .trunc();
+    #[cfg(target_arch = "aarch64")]
+    let ip = context.uc_mcontext.pc.trunc();
 
-    // Case 1: at the beginning of the syscall handler.
-    //
     // FUTURE: handle trampoline code, too. This is somewhat less important
     // because it's probably fine for the shim to observe a guest context that
     // is inside the trampoline.
-    if ip == syscall_callback as *const () as usize {
-        // No need to clear `in_guest` or set interrupt; the syscall handler will
-        // clear `in_guest` and call into the shim.
+    if in_syscall_callback_prologue(ip) {
         return;
     }
 
-    // Clear `in_guest` and set `interrupt`.
     let Some(regs) = signal_handler_exit_guest(context, true) else {
-        // Case 2: not in guest.
         return;
     };
 
-    // If the interrupt happened while returning to the guest, don't overwrite
-    // the saved context.
-    let in_switch_to_guest = (switch_to_guest_start as *const () as usize
-        ..switch_to_guest_end as *const () as usize)
-        .contains(&ip);
+    let in_switch_to_guest = in_switch_to_guest(ip);
     if in_switch_to_guest {
-        // Case 3: in the middle of restoring guest context. Don't overwrite it.
+        // The saved guest context remains authoritative during restoration.
     } else {
-        // Case 4: in guest. Copy out the context.
+        #[cfg(target_arch = "x86_64")]
         copy_signal_context(unsafe { &mut *regs }, context);
+        #[cfg(target_arch = "aarch64")]
+        match canonicalize_runtime_aarch64_gate_signal_context(context, unsafe { &*regs }) {
+            Aarch64GateSignalResult::NotGate => copy_signal_context(unsafe { &mut *regs }, context),
+            Aarch64GateSignalResult::Canonicalized(canonical) => unsafe { regs.write(canonical) },
+            Aarch64GateSignalResult::PreserveSavedContext => {
+                // The outbound path preserves registers but leaves stale syscall state.
+                unsafe { (*regs).syscallno = litebox_common_linux::arch::NO_SYSCALL };
+            }
+            Aarch64GateSignalResult::InvalidRuntimeState => {
+                fatal_aarch64_gate_runtime_state();
+            }
+        }
     }
-    // Cases 3 and 4: jump to interrupt handler.
     set_signal_return(context, interrupt_callback, 0, 0, 0, 0);
 }
 
@@ -2334,12 +2748,26 @@ mod tests {
     use std::os::unix::net::UnixStream;
     use std::thread::sleep;
 
-    use litebox::{fs::OFlags, platform::RawMutex};
+    use litebox::fs::OFlags;
+    use litebox::platform::RawMutex;
 
     use crate::LinuxUserland;
     use litebox::platform::PageManagementProvider;
 
     extern crate std;
+
+    #[cfg(target_arch = "aarch64")]
+    #[test]
+    fn cache_sync_permissions_are_readable_and_non_executable() {
+        use litebox::platform::page_mgmt::MemoryRegionPermissions;
+
+        let final_permissions = MemoryRegionPermissions::READ | MemoryRegionPermissions::EXEC;
+        let sync_permissions = super::cache_sync_permissions(final_permissions);
+
+        assert!(sync_permissions.contains(MemoryRegionPermissions::READ));
+        assert!(!sync_permissions.contains(MemoryRegionPermissions::EXEC));
+        assert!(final_permissions.contains(MemoryRegionPermissions::EXEC));
+    }
 
     #[test]
     fn test_raw_mutex() {
@@ -2439,22 +2867,64 @@ mod tests {
         assert_eq!(error.raw_os_error(), Some(libc::EINVAL));
 
         let pathname = c"/tmp/test_seccomp";
+        #[cfg(target_arch = "x86_64")]
         let mkdir_res = unsafe {
             syscalls::syscall2(syscalls::Sysno::mkdir, pathname.as_ptr() as usize, 0o755)
+        };
+        #[cfg(target_arch = "aarch64")]
+        let mkdir_res = unsafe {
+            syscalls::syscall3(
+                syscalls::Sysno::mkdirat,
+                super::AT_FDCWD,
+                pathname.as_ptr() as usize,
+                0o755,
+            )
         };
         assert_eq!(
             mkdir_res.unwrap_err(),
             syscalls::Errno::EINVAL,
-            "mkdir should be blocked by seccomp filter"
+            "mkdir/mkdirat should be blocked by seccomp filter"
         );
 
         let pathname =
             std::ffi::CString::new(format!("{}/Cargo.toml", env!("CARGO_MANIFEST_DIR"))).unwrap();
+
+        // Denying RDWR does not on its own show that the rule reads the flags
+        // argument: were it to read the path pointer instead, that too would
+        // compare unequal to `O_RDONLY` and be denied. Only an allowed RDONLY
+        // open pins the argument index `OPEN_FLAGS_ARG`.
+        #[cfg(target_arch = "aarch64")]
+        {
+            let open_rdonly = unsafe {
+                syscalls::syscall4(
+                    syscalls::Sysno::openat,
+                    super::AT_FDCWD,
+                    pathname.as_ptr() as usize,
+                    OFlags::RDONLY.bits() as usize,
+                    0,
+                )
+            };
+            let fd = open_rdonly.expect("openat with RDONLY should be allowed by seccomp filter");
+            // SAFETY: the open above just returned this as a fresh owned descriptor.
+            drop(unsafe { OwnedFd::from_raw_fd(i32::try_from(fd).unwrap()) });
+        }
+
+        #[cfg(target_arch = "x86_64")]
         let open_res = unsafe {
             syscalls::syscall2(
                 syscalls::Sysno::open,
                 pathname.as_ptr() as usize,
                 OFlags::RDWR.bits() as usize,
+            )
+        };
+        #[cfg(target_arch = "aarch64")]
+        let open_res = unsafe {
+            syscalls::syscall4(
+                syscalls::Sysno::openat,
+                super::AT_FDCWD,
+                pathname.as_ptr() as usize,
+                OFlags::RDWR.bits() as usize,
+                0,
             )
         };
         assert_eq!(

--- a/litebox_syscall_rewriter/src/arm64.rs
+++ b/litebox_syscall_rewriter/src/arm64.rs
@@ -39,9 +39,9 @@
 //!
 //! `guest_tpidr_offset` is fixed by the host binary's link and one rewritten
 //! guest must run under any host build, so gates carry a placeholder offset.
-//! **A loader must call [`patch_guest_tpidr_offset`], then prove with
-//! [`find_guest_tpidr_placeholder`] that no placeholder survives, before
-//! mapping the trampoline executable** — an unpatched gate does not fault. See
+//! **A loader must pass staged gates through [`finalize_trampoline_gates`],
+//! which patches the offset and proves no placeholder survives, before mapping
+//! the trampoline executable** — an unpatched gate does not fault. See
 //! `GUEST_TPIDR_OFFSET_PLACEHOLDER`.
 //!
 //! ## Gate scratch storage
@@ -1724,7 +1724,9 @@ fn valid_emitted_tpidr_offset(offset: u32) -> bool {
                 .contains(&offset))
 }
 
-fn decode_branch_target(word: u32, pc: u64) -> Option<u64> {
+/// Decodes an AArch64 unconditional immediate branch at `pc`.
+/// Returns `None` if `word` is not `B` or the target overflows `u64`.
+pub fn decode_branch_target(word: u32, pc: u64) -> Option<u64> {
     if word & OPCODE_TOP6_MASK != Opcode::B.bits() {
         return None;
     }
@@ -1777,6 +1779,32 @@ const LDST_UIMM12_IMM_MASK: u32 = 0x003F_FC00;
 /// Bit position of that immediate field.
 const LDST_UIMM12_IMM_SHIFT: u32 = 10;
 
+/// Patches every gate and fails if any executable placeholder remains.
+///
+/// # Errors
+///
+/// Propagates errors from [`patch_guest_tpidr_offset`] and fails if any
+/// placeholder survives.
+pub fn finalize_trampoline_gates(trampoline: &mut [u8], offset: u16) -> Result<()> {
+    patch_guest_tpidr_offset(trampoline, offset)?;
+    if let Some(at) = find_guest_tpidr_placeholder(trampoline) {
+        return Err(Error::TrampolinePatchFailure(format!(
+            "trampoline byte {at} still holds the guest thread-pointer placeholder after patching \
+             with offset {offset}"
+        )));
+    }
+    Ok(())
+}
+
+/// Whether a gate can be patched to reach `offset`: a multiple of
+/// [`GUEST_TPIDR_OFFSET_ALIGN`], far enough from the thread pointer that it
+/// cannot land on the host's own per-thread state, and below the value reserved
+/// for the unpatched placeholder.
+pub fn is_patchable_guest_tpidr_offset(offset: u16) -> bool {
+    offset.is_multiple_of(GUEST_TPIDR_OFFSET_ALIGN)
+        && (MIN_GUEST_TPIDR_OFFSET..GUEST_TPIDR_OFFSET_PLACEHOLDER).contains(&offset)
+}
+
 /// Rewrites the guest thread-pointer offset in every gate of one emitted
 /// trampoline, replacing the emitted placeholder with `offset`. The loader must
 /// call this before making the trampoline executable.
@@ -1799,9 +1827,7 @@ const LDST_UIMM12_IMM_SHIFT: u32 = 10;
 /// Panics if a validated slot is shorter than its own metadata word, which the
 /// slot templates make impossible.
 pub fn patch_guest_tpidr_offset(trampoline: &mut [u8], offset: u16) -> Result<usize> {
-    if !offset.is_multiple_of(GUEST_TPIDR_OFFSET_ALIGN)
-        || !(MIN_GUEST_TPIDR_OFFSET..GUEST_TPIDR_OFFSET_PLACEHOLDER).contains(&offset)
-    {
+    if !is_patchable_guest_tpidr_offset(offset) {
         return Err(Error::TrampolinePatchFailure(format!(
             "guest thread-pointer offset {offset} is not a legitimate gate target: it must be a \
              multiple of {GUEST_TPIDR_OFFSET_ALIGN}, at least {MIN_GUEST_TPIDR_OFFSET} so it \


### PR DESCRIPTION
This PR adds essential support for AArch64 to the Linux userland platform. It ports most stuffs that the x64 Linux userland platform provides to AArch64 including syscalls and signal handling, while enabling anchor-based guest/host TLS transition.