### PR TITLE
Add support for AArch64 to the Linux shim

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,7 @@ jobs:
         -p litebox_common_linux
         -p litebox_syscall_rewriter
         -p litebox_platform_linux_userland
+        -p litebox_shim_linux
     steps:
       - name: Check out repo
         uses: actions/checkout@v6

--- a/litebox_common_linux/src/lib.rs
+++ b/litebox_common_linux/src/lib.rs
@@ -1443,10 +1443,24 @@ pub enum EpollOp {
 }
 
 #[derive(Clone, Copy, Debug, FromBytes, IntoBytes)]
-#[repr(C, packed)]
+#[cfg_attr(target_arch = "x86_64", repr(C, packed))]
+#[cfg_attr(target_arch = "aarch64", repr(C))]
 pub struct EpollEvent {
     pub events: u32,
+    #[cfg(target_arch = "aarch64")]
+    pub padding: u32,
     pub data: u64,
+}
+
+impl EpollEvent {
+    pub fn new(events: u32, data: u64) -> Self {
+        Self {
+            events,
+            #[cfg(target_arch = "aarch64")]
+            padding: 0,
+            data,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, FromBytes, IntoBytes)]
@@ -3213,12 +3227,7 @@ pub mod arch {
     /// tell an in-flight syscall from one that never happened.
     pub const NO_SYSCALL: i32 = -1;
 
-    /// Returns whether `base` is a valid AArch64 Linux user thread-pointer
-    /// (`TPIDR_EL0`) value: it must lie below the top of the user address space.
-    ///
-    /// Same rule as x86-64's `is_valid_user_fs_base`, but unlike `wrfsbase`,
-    /// where a non-canonical operand raises #GP, `MSR TPIDR_EL0` accepts any
-    /// value, so this is purely containment.
+    /// Returns whether `base` lies within LiteBox's guest address range.
     #[must_use]
     pub fn is_valid_user_tls_base(base: usize) -> bool {
         base < USER_ADDR_END

--- a/litebox_common_linux/src/loader.rs
+++ b/litebox_common_linux/src/loader.rs
@@ -514,6 +514,10 @@ impl ElfParsedFile {
         let trampoline = self.trampoline.as_ref().unwrap();
         let trampoline_start = info.base_addr + trampoline.vaddr;
         let trampoline_end = page_align_up(info.base_addr + trampoline.vaddr + trampoline.size);
+        if M::POPULATES_TRAMPOLINE {
+            info.brk = info.brk.max(trampoline_end);
+            return Ok(());
+        }
         mapper
             .map_file(
                 trampoline_start,
@@ -593,6 +597,10 @@ pub trait ReadAt {
 
 pub trait MapMemory {
     type Error;
+
+    /// When true, trampoline setup occurs outside [`ElfParsedFile::load`]; the
+    /// loader only advances `brk` past the declared range.
+    const POPULATES_TRAMPOLINE: bool = false;
 
     /// Reserve a region of memory with the given length and alignment,
     /// returning the chosen address.

--- a/litebox_platform_linux_userland/src/aarch64.rs
+++ b/litebox_platform_linux_userland/src/aarch64.rs
@@ -5,7 +5,7 @@
 //! host anchor; the guest thread pointer is virtualized in memory.
 
 use super::*;
-use litebox_syscall_rewriter::arm64::{
+use litebox_syscall_rewriter::aarch64::{
     GATE_ALIGNMENT, GateMetadata, MRS_SLOT_BYTES, MSR_FRAME_BYTES, MSR_SLOT_BYTES, SVC_FRAME_BYTES,
     SVC_GATE_BYTES, SVC_SLOT_BYTES,
 };
@@ -130,7 +130,7 @@ pub(super) fn guest_thread_pointer_tp_offset() -> u16 {
     let offset = tprel_offset!(litebox_tls_block) + tls_offset::GUEST_THREAD_POINTER;
     u16::try_from(offset)
         .ok()
-        .filter(|off| litebox_syscall_rewriter::arm64::is_patchable_guest_tpidr_offset(*off))
+        .filter(|off| litebox_syscall_rewriter::aarch64::is_patchable_guest_tpidr_offset(*off))
         .expect(
             "guest_thread_pointer must sit at a thread-pointer offset a rewriter gate can reach",
         )
@@ -290,7 +290,7 @@ pub(super) unsafe extern "C-unwind" fn run_thread_arch(
 
     // Entered by `BR X16` from a rewriter-emitted SVC slot when the
     // guest issues a syscall. State on entry (rewriter ABI, see
-    // `litebox_syscall_rewriter::arm64` module docs):
+    // `litebox_syscall_rewriter::aarch64` module docs):
     //
     //   | Item                     | Value                                  |
     //   | ------------------------ | -------------------------------------- |
@@ -443,8 +443,8 @@ interrupt_callback:
     IN_GUEST = const tls_offset::IN_GUEST,
     OUTBOUND_STUB = const tls_offset::OUTBOUND_STUB,
     OUTBOUND_PC = const tls_offset::OUTBOUND_PC,
-    SVC_FRAME_BYTES = const litebox_syscall_rewriter::arm64::SVC_FRAME_BYTES,
-    SVC_FRAME_OFF_STUB = const litebox_syscall_rewriter::arm64::SVC_FRAME_OFF_STUB,
+    SVC_FRAME_BYTES = const litebox_syscall_rewriter::aarch64::SVC_FRAME_BYTES,
+    SVC_FRAME_OFF_STUB = const litebox_syscall_rewriter::aarch64::SVC_FRAME_OFF_STUB,
     ENOSYS = const libc::ENOSYS,
     init_handler = sym init_handler,
     reenter_handler = sym reenter_handler,
@@ -457,8 +457,8 @@ interrupt_callback:
 /// `ldp x0, x1, [sp]` in `syscall_callback` reads the gate frame's two fields
 /// as a pair, which only works at these offsets.
 const _: () = assert!(
-    litebox_syscall_rewriter::arm64::SVC_FRAME_OFF_X16 == 0
-        && litebox_syscall_rewriter::arm64::SVC_FRAME_OFF_RETADDR == 8
+    litebox_syscall_rewriter::aarch64::SVC_FRAME_OFF_X16 == 0
+        && litebox_syscall_rewriter::aarch64::SVC_FRAME_OFF_RETADDR == 8
 );
 
 /// The kernel's `struct rt_sigframe`, synthesized by the runtime so that an
@@ -968,8 +968,8 @@ switch_to_guest_via_outbound_stub_end:
     IN_GUEST = const tls_offset::IN_GUEST,
     INTERRUPT = const tls_offset::INTERRUPT,
     OUTBOUND_STUB = const tls_offset::OUTBOUND_STUB,
-    SVC_FRAME_BYTES = const litebox_syscall_rewriter::arm64::SVC_FRAME_BYTES,
-    SVC_FRAME_OFF_X16 = const litebox_syscall_rewriter::arm64::SVC_FRAME_OFF_X16,
+    SVC_FRAME_BYTES = const litebox_syscall_rewriter::aarch64::SVC_FRAME_BYTES,
+    SVC_FRAME_OFF_X16 = const litebox_syscall_rewriter::aarch64::SVC_FRAME_OFF_X16,
     );
 }
 
@@ -1144,7 +1144,7 @@ pub(super) fn canonicalize_aarch64_gate_signal_context(
             if !read(slot_end - 4, &mut metadata_bytes) {
                 continue;
             }
-            let Some(metadata) = litebox_syscall_rewriter::arm64::decode_gate_metadata_word(
+            let Some(metadata) = litebox_syscall_rewriter::aarch64::decode_gate_metadata_word(
                 u32::from_le_bytes(metadata_bytes),
             ) else {
                 continue;
@@ -1165,7 +1165,7 @@ pub(super) fn canonicalize_aarch64_gate_signal_context(
             // covers a PC in a real gate's padding or metadata: that code never
             // ran the prologue, so the interrupted registers are the guest's
             // own and delivering the signal unchanged is correct.
-            let Some(classified) = litebox_syscall_rewriter::arm64::classify_copied_gate_slot(
+            let Some(classified) = litebox_syscall_rewriter::aarch64::classify_copied_gate_slot(
                 &slot[..slot_size],
                 slot_start as u64,
                 pc,
@@ -1196,7 +1196,7 @@ pub(super) fn canonicalize_aarch64_gate_signal_context(
         return Aarch64GateSignalResult::NotGate;
     }
     let original = u32::from_le_bytes(original);
-    if litebox_syscall_rewriter::arm64::decode_branch_target(original, site)
+    if litebox_syscall_rewriter::aarch64::decode_branch_target(original, site)
         != Some(slot_start as u64)
     {
         return Aarch64GateSignalResult::NotGate;
@@ -1469,14 +1469,14 @@ mod tests {
     fn test_gate_patching_lands_in_the_runtime_tls_block() {
         const IMM12_SHIFT: u32 = 10;
         const IMM12_MASK: u32 = 0x003F_FC00;
-        const ALIGN: u16 = litebox_syscall_rewriter::arm64::GUEST_TPIDR_OFFSET_ALIGN;
+        const ALIGN: u16 = litebox_syscall_rewriter::aarch64::GUEST_TPIDR_OFFSET_ALIGN;
 
         let mut code = 0xD53B_D049u32.to_le_bytes(); // MRS X9, TPIDR_EL0
         let (mut tramp, trapped) =
             litebox_syscall_rewriter::patch_code_segment(&mut code, 0x1000, 0x400000, 0).unwrap();
         assert!(trapped.is_empty());
         assert_eq!(
-            litebox_syscall_rewriter::arm64::find_guest_tpidr_placeholder(&tramp),
+            litebox_syscall_rewriter::aarch64::find_guest_tpidr_placeholder(&tramp),
             Some(16 + 4),
             "the emitted gate must be in the unpatched state, or everything below \
              passes vacuously"
@@ -1489,21 +1489,22 @@ mod tests {
         );
         let offset = u16::try_from(offset).expect("the guest slot must sit within a gate's reach");
         assert_eq!(
-            litebox_syscall_rewriter::arm64::patch_guest_tpidr_offset(&mut tramp, offset).unwrap(),
+            litebox_syscall_rewriter::aarch64::patch_guest_tpidr_offset(&mut tramp, offset)
+                .unwrap(),
             1
         );
         assert_eq!(
-            litebox_syscall_rewriter::arm64::find_guest_tpidr_placeholder(&tramp),
+            litebox_syscall_rewriter::aarch64::find_guest_tpidr_placeholder(&tramp),
             None,
             "no gate may still hold the placeholder once the loader has staged the trampoline"
         );
         let classified =
-            litebox_syscall_rewriter::arm64::classify_gate_pc(&tramp, 0x400000, 0x400010)
+            litebox_syscall_rewriter::aarch64::classify_gate_pc(&tramp, 0x400000, 0x400010)
                 .expect("finalized emitted MRS slot must validate");
         assert_eq!(classified.slot_offset(), 16);
         assert!(matches!(
             classified.metadata(),
-            litebox_syscall_rewriter::arm64::GateMetadata::MrsTpidr { destination: 9, .. }
+            litebox_syscall_rewriter::aarch64::GateMetadata::MrsTpidr { destination: 9, .. }
         ));
 
         let patched = u32::from_le_bytes(tramp[16 + 4..16 + 8].try_into().unwrap());

--- a/litebox_runner_linux_userland/tests/run.rs
+++ b/litebox_runner_linux_userland/tests/run.rs
@@ -9,6 +9,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
+#[cfg(target_arch = "x86_64")]
 const BROKER_HELPER_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 const BROKER_ONLY_C_TESTS: &[&str] = &[
     "eventfd.c",

--- a/litebox_shim_linux/src/lib.rs
+++ b/litebox_shim_linux/src/lib.rs
@@ -154,6 +154,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> litebox::shim::EnterShim
         ctx: &mut Self::ExecutionContext,
         info: &litebox::shim::ExceptionInfo,
     ) -> ContinueOperation {
+        #[cfg(target_arch = "x86_64")]
         if info.kernel_mode && info.exception == litebox::shim::Exception::PAGE_FAULT {
             if unsafe {
                 self.task
@@ -167,6 +168,18 @@ impl<Platform: ShimPlatform, FS: ShimFS> litebox::shim::EnterShim
             } else {
                 return ContinueOperation::Terminate;
             }
+        }
+        #[cfg(target_arch = "aarch64")]
+        if info.kernel_mode
+            && (info.exception == litebox::shim::Exception::DATA_ABORT_CURRENT_EL
+                || info.exception == litebox::shim::Exception::INSTRUCTION_ABORT_CURRENT_EL)
+        {
+            unimplemented!(
+                "aarch64: kernel-mode demand paging needs the ESR_EL1 ISS access bits, \
+                 which no aarch64 platform currently supplies (esr={:#x}, far={:#x})",
+                info.esr,
+                info.fault_address
+            );
         }
         self.enter_shim(false, ctx, |task, _ctx| task.handle_exception_request(info))
     }
@@ -565,6 +578,10 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         {
             ctx.rax = return_value;
         }
+        #[cfg(target_arch = "aarch64")]
+        {
+            ctx.regs[0] = return_value;
+        }
     }
 
     fn do_syscall(&self, ctx: &mut litebox_common_linux::PtRegs) -> Result<usize, Errno> {
@@ -577,6 +594,9 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
 
         #[cfg(target_arch = "x86_64")]
         let syscall_number = ctx.orig_rax;
+        // AArch64 syscall ABI: `w8`, mirrored in `pt_regs::syscallno`.
+        #[cfg(target_arch = "aarch64")]
+        let syscall_number = ctx.syscallno.cast_unsigned() as usize;
         let request = SyscallRequest::try_from_raw(syscall_number, ctx, log_unsupported_fmt)?;
 
         match request {
@@ -1010,7 +1030,6 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                     .ok_or(Errno::EFAULT)
                     .map(|()| 0)
             }),
-            #[cfg(target_arch = "x86_64")]
             SyscallRequest::Newfstatat {
                 dirfd,
                 pathname,
@@ -1066,11 +1085,9 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             SyscallRequest::Clone { args } => self.sys_clone(ctx, &args),
             SyscallRequest::Clone3 { args } => self.sys_clone3(ctx, args),
             SyscallRequest::SetThreadArea { user_desc } => {
-                #[cfg(target_arch = "x86_64")]
-                {
-                    let _ = user_desc;
-                    Err(Errno::ENOSYS) // x86_64 does not support set_thread_area
-                }
+                // Neither x86-64 nor AArch64 supports `set_thread_area`.
+                let _ = user_desc;
+                Err(Errno::ENOSYS)
             }
             SyscallRequest::SetTidAddress { tidptr } => {
                 Ok(self.sys_set_tid_address(tidptr).reinterpret_as_unsigned() as usize)

--- a/litebox_shim_linux/src/loader/elf.rs
+++ b/litebox_shim_linux/src/loader/elf.rs
@@ -70,7 +70,15 @@ impl<Platform: ShimPlatform, FS: ShimFS> litebox_common_linux::loader::ReadAt
     }
 
     fn size(&mut self) -> Result<u64, Self::Error> {
-        Ok(self.task.sys_fstat(self.fd)?.st_size as u64)
+        #[cfg(target_arch = "x86_64")]
+        {
+            Ok(self.task.sys_fstat(self.fd)?.st_size as u64)
+        }
+        #[cfg(target_arch = "aarch64")]
+        {
+            // The asm-generic ABI uses signed `st_size`; reject negative sizes.
+            u64::try_from(self.task.sys_fstat(self.fd)?.st_size).map_err(|_| Errno::EINVAL)
+        }
     }
 }
 
@@ -78,6 +86,10 @@ impl<Platform: ShimPlatform, FS: ShimFS> litebox_common_linux::loader::MapMemory
     for ElfFile<'_, Platform, FS>
 {
     type Error = Errno;
+
+    // TODO: move AArch64 gate finalization into the common loader, then remove
+    // this architecture-specific trampoline ownership split.
+    const POPULATES_TRAMPOLINE: bool = cfg!(target_arch = "aarch64");
 
     fn reserve(&mut self, len: usize, align: usize) -> Result<usize, Self::Error> {
         // Allocate a mapping large enough that even if it's maximally misaligned we can
@@ -202,13 +214,22 @@ impl<'a, Platform: ShimPlatform, FS: ShimFS> FileAndParsed<'a, Platform, FS> {
             .map_err(ElfLoaderError::ParseError)?;
 
         let syscall_entry_point = task.global.platform.get_syscall_entry_point();
+        #[cfg(target_arch = "aarch64")]
+        let parse_entry_point = {
+            // TODO: split trampoline detection from x86 callback-slot setup in
+            // the common parser. AArch64 has no callback slot to initialize.
+            const AARCH64_UNUSED_ENTRY_POINT: usize = 1;
+            syscall_entry_point.max(AARCH64_UNUSED_ENTRY_POINT)
+        };
+        #[cfg(target_arch = "x86_64")]
+        let parse_entry_point = syscall_entry_point;
 
         // Try to parse an embedded trampoline. For pre-patched binaries this
         // succeeds and load_trampoline() will map it. For unpatched binaries
         // (UnpatchedBinary error), the runtime patching during mmap will patch
         // code segments as they are mapped.
-        if syscall_entry_point != 0 {
-            match parsed.parse_trampoline(&mut &file, syscall_entry_point) {
+        if parse_entry_point != 0 {
+            match parsed.parse_trampoline(&mut &file, parse_entry_point) {
                 Ok(()) | Err(litebox_common_linux::loader::ElfParseError::UnpatchedBinary) => {
                     // Ok: pre-patched trampoline found, or unpatched binary
                     // that the runtime mmap hook will handle.
@@ -234,8 +255,24 @@ impl<'a, Platform: ShimPlatform, FS: ShimFS> FileAndParsed<'a, Platform, FS> {
         } else {
             None
         };
-        let result = self.parsed.load(&mut self.file, &mut &*platform, reserve);
-        Ok(result?)
+        let result = self.parsed.load(&mut self.file, &mut &*platform, reserve)?;
+        #[cfg(target_arch = "aarch64")]
+        if self.parsed.has_trampoline()
+            && !self
+                .file
+                .task
+                .global
+                .elf_patch_cache
+                .lock()
+                .get(&self.file.fd)
+                .is_some_and(crate::syscalls::mm::ElfPatchState::trampoline_is_populated)
+        {
+            litebox_util_log::error!(fd:? = self.file.fd; "AArch64 trampoline was not populated while loading the ELF");
+            return Err(ElfLoaderError::LoadError(
+                litebox_common_linux::loader::ElfLoadError::InvalidProgramHeader,
+            ));
+        }
+        Ok(result)
     }
 }
 
@@ -367,7 +404,10 @@ mod tests {
     const PROGRAM_HEADER_SIZE_U16: u16 = 56;
     const ET_EXEC: u16 = 2;
     const ET_DYN: u16 = 3;
-    const EM_X86_64: u16 = 62;
+    #[cfg(target_arch = "x86_64")]
+    const EM_HOST: u16 = 62; // EM_X86_64
+    #[cfg(target_arch = "aarch64")]
+    const EM_HOST: u16 = 183; // EM_AARCH64
     const PT_LOAD: u32 = 1;
     const PT_INTERP: u32 = 3;
     const PF_X: u32 = 1;
@@ -404,7 +444,7 @@ mod tests {
         buf.extend_from_slice(&[2, 1, 1, 0]);
         buf.extend_from_slice(&[0; 8]);
         push_u16(buf, elf_type);
-        push_u16(buf, EM_X86_64);
+        push_u16(buf, EM_HOST);
         push_u32(buf, 1);
         push_u64(buf, entry);
         push_u64(buf, u64::from(ELF_HEADER_SIZE_U16));

--- a/litebox_shim_linux/src/loader/mod.rs
+++ b/litebox_shim_linux/src/loader/mod.rs
@@ -3,7 +3,6 @@
 
 //! This module contains the loader for the LiteBox shim.
 
-#![cfg(target_arch = "x86_64")]
 pub mod auxv;
 pub mod elf;
 mod stack;

--- a/litebox_shim_linux/src/syscalls/epoll.rs
+++ b/litebox_shim_linux/src/syscalls/epoll.rs
@@ -391,10 +391,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> EpollEntry<Platform, FS> {
         if events.is_empty() {
             Some((None, false))
         } else {
-            let event = Some(EpollEvent {
-                events: events.bits(),
-                data: inner.data,
-            });
+            let event = Some(EpollEvent::new(events.bits(), inner.data));
 
             // keep the entry in the ready list if it is not edge-triggered or one-shot
             let is_still_ready = event.is_some()
@@ -680,10 +677,7 @@ mod test {
                 &task.global,
                 10,
                 &reader,
-                EpollEvent {
-                    events: Events::IN.bits(),
-                    data: 0,
-                },
+                EpollEvent::new(Events::IN.bits(), 0),
             )
             .unwrap();
 

--- a/litebox_shim_linux/src/syscalls/file.rs
+++ b/litebox_shim_linux/src/syscalls/file.rs
@@ -1390,7 +1390,14 @@ where
         st_gid: 0,
         st_rdev: 0,
         st_size: 0,
+        #[cfg(target_arch = "x86_64")]
         st_blksize: blksize,
+        #[cfg(target_arch = "aarch64")]
+        st_blksize: {
+            // The asm-generic ABI uses signed `st_blksize`.
+            let blksize: u32 = blksize.trunc();
+            blksize.reinterpret_as_signed()
+        },
         st_blocks: 0,
         ..Default::default()
     };

--- a/litebox_shim_linux/src/syscalls/misc.rs
+++ b/litebox_shim_linux/src/syscalls/misc.rs
@@ -61,6 +61,8 @@ const SYS_INFO: litebox_common_linux::Utsname = litebox_common_linux::Utsname {
     version: to_fixed_size_array::<65>("5.11.0"),
     #[cfg(target_arch = "x86_64")]
     machine: to_fixed_size_array::<65>("x86_64"),
+    #[cfg(target_arch = "aarch64")]
+    machine: to_fixed_size_array::<65>("aarch64"),
     domainname: to_fixed_size_array::<65>(""),
 };
 

--- a/litebox_shim_linux/src/syscalls/mm.rs
+++ b/litebox_shim_linux/src/syscalls/mm.rs
@@ -18,6 +18,14 @@ use crate::ShimFS;
 use crate::ShimPlatform;
 use crate::Task;
 use crate::UserPtrMut;
+#[cfg(target_arch = "aarch64")]
+use alloc::vec::Vec;
+#[cfg(target_arch = "aarch64")]
+use core::ops::Range;
+#[cfg(target_arch = "aarch64")]
+use litebox::mm::linux::VmFlags;
+#[cfg(target_arch = "aarch64")]
+use litebox::utils::ReinterpretUnsignedExt as _;
 use litebox::utils::TruncateExt as _;
 use object::elf::{ET_DYN, FileHeader64, PT_LOAD, ProgramHeader64};
 use object::endian::LittleEndian;
@@ -27,10 +35,41 @@ compile_error!("ELF patching code assumes 64-bit pointers (u64 <-> usize is loss
 
 const ENDIAN: LittleEndian = LittleEndian;
 
+/// Finalizes every gate with the platform's guest thread-pointer offset.
+///
+/// # Errors
+///
+/// Missing, unencodable, or unpatched offsets return an error.
+#[cfg(target_arch = "aarch64")]
+fn finalize_trampoline_gates(
+    platform: &impl litebox::platform::SystemInfoProvider,
+    trampoline: &mut [u8],
+) -> Result<(), alloc::string::String> {
+    use alloc::format;
+
+    let Some(offset) = platform.guest_thread_pointer_offset() else {
+        return Err(alloc::string::String::from(
+            "platform supplied no guest thread-pointer offset",
+        ));
+    };
+    // Gates encode a scaled `u16`; the platform API remains pointer-width.
+    let offset = u16::try_from(offset)
+        .map_err(|_| format!("guest thread-pointer offset {offset} is too large for a gate"))?;
+    litebox_syscall_rewriter::aarch64::finalize_trampoline_gates(trampoline, offset)
+        .map_err(|e| format!("failed to patch guest thread-pointer offset {offset}: {e}"))
+}
+
 /// Per-fd state for the shim's runtime ELF syscall rewriter.
 ///
 /// Tracks base address and trampoline write cursor for each ELF file that
 /// has executable segments mapped via `do_mmap_file()`.
+#[cfg_attr(
+    target_arch = "aarch64",
+    expect(
+        clippy::struct_excessive_bools,
+        reason = "independent ELF patch state flags"
+    )
+)]
 pub(crate) struct ElfPatchState {
     /// Whether this file is already pre-patched (trampoline magic found at file tail).
     pre_patched: bool,
@@ -39,6 +78,8 @@ pub(crate) struct ElfPatchState {
     trampoline_file_size: usize,
     /// Start address of the trampoline region (runtime).
     trampoline_addr: usize,
+    #[cfg(target_arch = "aarch64")]
+    load_span: Option<Range<usize>>,
     /// Current write position within the trampoline (byte offset from `trampoline_addr`).
     trampoline_cursor: usize,
     /// Whether the trampoline region has been allocated.
@@ -48,6 +89,8 @@ pub(crate) struct ElfPatchState {
     /// Whether any runtime-generated stubs were successfully linked from code
     /// in this fd to the trampoline.
     runtime_patches_committed: bool,
+    #[cfg(target_arch = "aarch64")]
+    trampoline_invalidated: bool,
     /// Tracks file-backed mappings for this fd as (vaddr, len) pairs.
     /// Used to find mappings that need patching when mprotect adds PROT_EXEC.
     /// Cleared on munmap to allow re-patching.
@@ -59,8 +102,42 @@ pub(crate) struct ElfPatchState {
     patched_ranges: BTreeSet<(usize, usize)>,
 }
 
+impl ElfPatchState {
+    #[cfg(target_arch = "aarch64")]
+    pub(crate) fn trampoline_is_populated(&self) -> bool {
+        self.trampoline_mapped && !self.trampoline_invalidated
+    }
+}
+
 /// Per-process collection of ELF patching state, keyed by fd number.
 pub(crate) type ElfPatchCache = BTreeMap<i32, ElfPatchState>;
+
+/// Returns `range` minus possibly unsorted, overlapping `excluded` ranges.
+#[cfg(target_arch = "aarch64")]
+fn subtract_ranges(range: Range<usize>, excluded: &[Range<usize>]) -> Vec<Range<usize>> {
+    let mut blocks: Vec<Range<usize>> = excluded
+        .iter()
+        .filter(|block| block.start < range.end && range.start < block.end)
+        .cloned()
+        .collect();
+    blocks.sort_unstable_by_key(|block| (block.start, block.end));
+
+    let mut out = Vec::new();
+    let mut cursor = range.start;
+    for block in blocks {
+        if block.start > cursor {
+            out.push(cursor..block.start);
+        }
+        cursor = cursor.max(block.end);
+        if cursor >= range.end {
+            return out;
+        }
+    }
+    if cursor < range.end {
+        out.push(cursor..range.end);
+    }
+    out
+}
 
 #[inline]
 fn align_up(addr: usize, align: usize) -> usize {
@@ -97,7 +174,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
     }
 
     #[inline]
-    fn do_mmap_anonymous(
+    pub(crate) fn do_mmap_anonymous(
         &self,
         suggested_addr: Option<usize>,
         len: usize,
@@ -382,7 +459,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
     pub(crate) fn sys_munmap(&self, addr: UserPtrMut<u8>, len: usize) -> Result<(), Errno> {
         let result = self.sys_munmap_raw(addr, len);
         if result.is_ok() {
-            self.clear_file_mappings_for_range(addr.as_usize(), len);
+            self.clear_file_mappings_for_range(addr.as_usize(), len.next_multiple_of(PAGE_SIZE));
         }
         result
     }
@@ -397,10 +474,29 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
     /// Clear `file_mappings` entries for any segments that overlap the
     /// unmapped range, so that re-mapping the same file region will be
     /// re-patched instead of skipped.
+    ///
     fn clear_file_mappings_for_range(&self, unmap_start: usize, unmap_len: usize) {
         let unmap_end = unmap_start.saturating_add(unmap_len);
         let mut cache = self.global.elf_patch_cache.lock();
         for state in cache.values_mut() {
+            #[cfg(target_arch = "aarch64")]
+            if state.trampoline_mapped && state.trampoline_mapped_len > 0 {
+                // Stop excluding unmapped trampoline ranges from later
+                // `mprotect` requests.
+                let trampoline_end = state
+                    .trampoline_addr
+                    .saturating_add(state.trampoline_mapped_len);
+                let overlaps = state.trampoline_addr < unmap_end && unmap_start < trampoline_end;
+                let removes_all =
+                    unmap_start <= state.trampoline_addr && unmap_end >= trampoline_end;
+                if overlaps && !removes_all {
+                    state.trampoline_invalidated = true;
+                }
+                if removes_all {
+                    state.trampoline_mapped = false;
+                    state.trampoline_mapped_len = 0;
+                }
+            }
             state.file_mappings.retain(|&(vaddr, seg_len)| {
                 let seg_end = vaddr.saturating_add(seg_len);
                 seg_end <= unmap_start || vaddr >= unmap_end
@@ -424,16 +520,70 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         if prot.contains(ProtFlags::PROT_EXEC) {
             let syscall_entry = self.global.platform.get_syscall_entry_point();
             if syscall_entry != 0 {
+                #[cfg(target_arch = "x86_64")]
                 self.maybe_patch_on_mprotect_exec(addr, len, syscall_entry);
+                #[cfg(target_arch = "aarch64")]
+                if !self.maybe_patch_on_mprotect_exec(addr, len, syscall_entry) {
+                    return Err(Errno::ENOMEM);
+                }
             }
         }
-        self.sys_mprotect_raw(addr, len, prot)
+        // Only AArch64 needs protection from loader reprotection of its holes;
+        // x86-64 must retain whole-request behavior.
+        #[cfg(target_arch = "aarch64")]
+        let result = self.mprotect_around_trampolines(addr.as_usize(), len, prot);
+        #[cfg(target_arch = "x86_64")]
+        let result = self.sys_mprotect_raw(addr, len, prot);
+        result
+    }
+
+    /// Applies `prot`, excluding AOT trampolines placed inside their load spans.
+    /// Runtime trampolines are outside the span and are not excluded.
+    #[cfg(target_arch = "aarch64")]
+    fn mprotect_around_trampolines(
+        &self,
+        start: usize,
+        len: usize,
+        prot: ProtFlags,
+    ) -> Result<(), Errno> {
+        let range = start..start.saturating_add(len);
+        let excluded: alloc::vec::Vec<Range<usize>> = {
+            let cache = self.global.elf_patch_cache.lock();
+            cache
+                .values()
+                .filter(|state| {
+                    !state.trampoline_invalidated
+                        && state.trampoline_mapped
+                        && state.trampoline_mapped_len > 0
+                })
+                .filter_map(|state| {
+                    let addr = state.trampoline_addr;
+                    let range = addr..addr.saturating_add(state.trampoline_mapped_len);
+                    let span = state.load_span.as_ref()?;
+                    (range.start >= span.start && range.end <= span.end).then_some(range)
+                })
+                .collect()
+        };
+
+        let subranges = subtract_ranges(range.clone(), &excluded);
+        if subranges.is_empty() {
+            // Exclusions consume the whole request; no protection change is needed.
+            return self.sys_mprotect_raw(UserPtrMut::<u8>::from_usize(range.start), 0, prot);
+        }
+        for sub in subranges {
+            self.sys_mprotect_raw(
+                UserPtrMut::<u8>::from_usize(sub.start),
+                sub.len(),
+                prot.clone(),
+            )?;
+        }
+        Ok(())
     }
 
     /// Raw mprotect without exec interception — used internally by the
     /// patching logic to avoid deadlocks (the patch path holds elf_patch_cache).
     #[inline]
-    fn sys_mprotect_raw(
+    pub(crate) fn sys_mprotect_raw(
         &self,
         addr: UserPtrMut<u8>,
         len: usize,
@@ -483,7 +633,12 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
     /// Check all tracked file mappings for unpatched regions that overlap the
     /// mprotect range. If found, run the runtime rewriter before the region
     /// becomes executable.
-    fn maybe_patch_on_mprotect_exec(&self, addr: UserPtrMut<u8>, len: usize, syscall_entry: usize) {
+    fn maybe_patch_on_mprotect_exec(
+        &self,
+        addr: UserPtrMut<u8>,
+        len: usize,
+        syscall_entry: usize,
+    ) -> bool {
         let mprotect_start = addr.as_usize();
         let mprotect_end = mprotect_start.saturating_add(len);
 
@@ -494,6 +649,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             let cache = self.global.elf_patch_cache.lock();
             let mut result = alloc::vec::Vec::new();
             for (&fd, state) in cache.iter() {
+                #[cfg(target_arch = "x86_64")]
                 if state.pre_patched {
                     continue;
                 }
@@ -533,15 +689,16 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                 continue;
             }
             let mapped_addr = UserPtrMut::<u8>::from_usize(patch_start);
-            self.maybe_patch_exec_segment(mapped_addr, patch_len, fd, syscall_entry, None);
+            if !self.maybe_patch_exec_segment(mapped_addr, patch_len, fd, syscall_entry, None) {
+                return false;
+            }
         }
+        true
     }
 
     /// Initialize ELF patch state for an fd on its first mmap.
     ///
-    /// Reads the ELF header to determine the trampoline address (page-aligned
-    /// end of the highest PT_LOAD segment) and checks the file tail for the
-    /// trampoline magic to determine if it's pre-patched.
+    /// Derives patch state and the architecture-specific trampoline fallback.
     ///
     /// For ET_DYN binaries (PIE/shared libs), virtual addresses in program
     /// headers are relative to a base address chosen at load time. We derive
@@ -549,7 +706,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
     /// the segment being mapped. The `file_offset` parameter identifies which
     /// segment is being mapped so we can look up its `p_vaddr`.
     ///
-    /// x86_64 only: assumes 64-bit ELF layout and program header offsets.
+    /// Requires the supported architectures' common 64-bit ELF layout.
     fn init_elf_patch_state(&self, fd: i32, mapped_addr: usize, file_offset: usize) {
         // Quick check: skip if already initialized.
         if self.global.elf_patch_cache.lock().contains_key(&fd) {
@@ -574,6 +731,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         }
 
         let e_type = ehdr.e_type.get(ENDIAN);
+        let e_machine = ehdr.e_machine.get(ENDIAN);
         let e_phoff: usize = ehdr.e_phoff.get(ENDIAN).trunc();
         let e_phentsize = ehdr.e_phentsize.get(ENDIAN) as usize;
         let e_phnum = ehdr.e_phnum.get(ENDIAN) as usize;
@@ -599,6 +757,8 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         // Find highest PT_LOAD end (p_vaddr + p_memsz) and compute base_addr
         // by matching the segment whose p_offset corresponds to file_offset.
         let mut max_load_end: u64 = 0;
+        let mut min_load_start: u64 = u64::MAX;
+        let mut max_load_align: u64 = 0;
         let mut base_addr: Option<usize> = None;
         for i in 0..e_phnum {
             let ph_bytes = &phdrs_buf[i * e_phentsize..][..e_phentsize];
@@ -621,6 +781,8 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             if end > max_load_end {
                 max_load_end = end;
             }
+            min_load_start = min_load_start.min(align_down(p_vaddr.trunc(), PAGE_SIZE) as u64);
+            max_load_align = max_load_align.max(ph.p_align.get(ENDIAN));
             // Match segment by page-aligned file offset to derive base address.
             if base_addr.is_none()
                 && align_down(p_offset, PAGE_SIZE) == align_down(file_offset, PAGE_SIZE)
@@ -640,8 +802,10 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         // Compute the trampoline virtual address.
         // - Pre-patched: use the exact address from the trampoline header (the
         //   code already contains JMPs there, so we MUST map at this address).
-        // - Unpatched: place it just past the highest PT_LOAD end (this is just
-        //   a hint — validated by the ±2GB distance check with trap fallback).
+        // - Unpatched: use the architecture-specific fallback past the loader's
+        //   alignment slack. This is only a hint; the runtime path re-checks
+        //   the chosen address against the branch-reach limit below, and falls
+        //   back to traps.
         // For ET_DYN, virtual addresses are relative to the load base.
         let trampoline_vaddr = if pre_patched {
             if e_type == ET_DYN {
@@ -661,8 +825,32 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             } else {
                 0
             };
-            let max_end: usize = max_load_end.trunc();
-            base + max_end.next_multiple_of(PAGE_SIZE)
+            // On x86-64, the fallback is the page-aligned end of the highest
+            // PT_LOAD segment.
+            // No trustworthy program-header view of a partially mapped file
+            // here, so take the `trampoline_addr_for` fallback rather than the
+            // hole `trampoline_placement_for` would pick.
+            let Ok(offset) = litebox_syscall_rewriter::trampoline_addr_for(
+                max_load_end,
+                max_load_align,
+                e_machine,
+            ) else {
+                return;
+            };
+            let offset: usize = offset.trunc();
+            base + offset
+        };
+
+        // Never synthesize an ET_DYN span from an unknown base: it could cover
+        // unrelated mappings.
+        #[cfg(target_arch = "aarch64")]
+        let load_span = if e_type == ET_DYN {
+            base_addr.map(|load_base| {
+                load_base.wrapping_add(min_load_start.trunc())
+                    ..load_base.wrapping_add(align_up(max_load_end.trunc(), PAGE_SIZE))
+            })
+        } else {
+            Some(min_load_start.trunc()..align_up(max_load_end.trunc(), PAGE_SIZE))
         };
 
         // Insert under lock (re-check for races).
@@ -672,13 +860,52 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             trampoline_file_offset: tramp_file_offset,
             trampoline_file_size: tramp_file_size.trunc(),
             trampoline_addr: trampoline_vaddr,
+            #[cfg(target_arch = "aarch64")]
+            load_span,
             trampoline_cursor: 0,
             trampoline_mapped: false,
             trampoline_mapped_len: 0,
             runtime_patches_committed: false,
+            #[cfg(target_arch = "aarch64")]
+            trampoline_invalidated: false,
             file_mappings: BTreeSet::new(),
             patched_ranges: BTreeSet::new(),
         });
+    }
+
+    /// Allows `MAP_FIXED` inside the computed load span. Outside it, rejects
+    /// overlap with accessible mappings. This does not prove current ownership.
+    #[cfg(target_arch = "aarch64")]
+    fn trampoline_range_is_safe_to_map(
+        &self,
+        state: &ElfPatchState,
+        start: usize,
+        len: usize,
+    ) -> bool {
+        let range = start..start.saturating_add(len);
+        let end = range.end;
+        if state
+            .load_span
+            .as_ref()
+            .is_some_and(|span| range.start >= span.start && range.end <= span.end)
+        {
+            return true;
+        }
+        for (range, flags) in self.global.pm.mappings() {
+            if range.end <= start || range.start >= end {
+                continue;
+            }
+            if flags.intersects(VmFlags::VM_ACCESS_FLAGS) {
+                litebox_util_log::error!(
+                    tramp_start:? = start, tramp_end:? = end,
+                    victim_start:? = range.start, victim_end:? = range.end,
+                    victim_flags:? = flags;
+                    "refusing to map a trampoline over another mapping's live pages"
+                );
+                return false;
+            }
+        }
+        true
     }
 
     /// Check if a file has the LITEBOX trampoline magic at its tail.
@@ -688,7 +915,13 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         let Ok(stat) = self.sys_fstat(fd) else {
             return (false, 0, 0, 0);
         };
-        let file_size = stat.st_size;
+        #[cfg(target_arch = "x86_64")]
+        let file_size: usize = stat.st_size;
+        #[cfg(target_arch = "aarch64")]
+        let file_size: usize = {
+            // The asm-generic ABI uses signed `st_size`.
+            stat.st_size.reinterpret_as_unsigned().trunc()
+        };
         if file_size < HEADER_SIZE {
             return (false, 0, 0, 0);
         }
@@ -706,8 +939,8 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         (true, file_offset, vaddr, trampoline_size)
     }
 
-    /// Apply the trap fallback to a mapped code segment: replace all `syscall`
-    /// instructions with traps (`ICEBP;HLT`), then restore RX.
+    /// Apply the trap fallback to a mapped code segment: replace every patch
+    /// site with the rewriter's trap, then restore RX.
     ///
     /// If `already_rw` is true, the segment is assumed to already be writable
     /// and the initial mprotect RW is skipped.
@@ -788,6 +1021,10 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         let Some(state) = cache.get_mut(&fd) else {
             return true; // No patch state — not an ELF we're tracking
         };
+        #[cfg(target_arch = "aarch64")]
+        if state.trampoline_invalidated {
+            return false;
+        }
 
         if state.pre_patched {
             // Pre-patched binary: map the trampoline data from the file.
@@ -795,11 +1032,12 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                 let tramp_addr = state.trampoline_addr;
                 let tramp_len = align_up(state.trampoline_file_size, PAGE_SIZE);
 
-                // Allocate RW region at the trampoline address. Use MAP_FIXED
-                // because the code already contains JMPs to this exact address
-                // and we MUST map here. The region may already be reserved as
-                // PROT_NONE by the ElfLoader's reserve() call, which would
-                // cause MAP_FIXED_NOREPLACE to fail with EEXIST.
+                // MAP_FIXED_NOREPLACE would reject the legitimate PROT_NONE or
+                // object-span reservation, so validate ownership before MAP_FIXED.
+                #[cfg(target_arch = "aarch64")]
+                if !self.trampoline_range_is_safe_to_map(state, tramp_addr, tramp_len) {
+                    return false;
+                }
                 let alloc_result = self.do_mmap_anonymous(
                     Some(tramp_addr),
                     tramp_len,
@@ -831,6 +1069,14 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                 // Write syscall entry point to the first 8 bytes.
                 if tramp_data.len() >= 8 {
                     tramp_data[..8].copy_from_slice(&syscall_entry.to_le_bytes());
+                }
+
+                // Finalize in staging so an unpatched gate is never published.
+                #[cfg(target_arch = "aarch64")]
+                if let Err(e) = finalize_trampoline_gates(self.global.platform, &mut tramp_data) {
+                    litebox_util_log::error!(err:% = e; "refusing to map a trampoline whose guest thread-pointer gates are not patched");
+                    let _ = self.sys_munmap_raw(tramp_ptr, tramp_len);
+                    return false;
                 }
 
                 // Write to the mapped region.
@@ -894,13 +1140,11 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             };
             let actual_addr = actual_addr_ptr.as_usize();
 
-            // Verify the trampoline is within JMP rel32 range (+-2GB) of the
-            // entire code segment, not just its start.
             let far_end = addr_usize.saturating_add(len);
             let distance = actual_addr
                 .abs_diff(addr_usize)
                 .max(actual_addr.abs_diff(far_end));
-            if distance > 0x7FFF_0000 {
+            if distance > litebox_syscall_rewriter::MAX_TRAMPOLINE_DISPLACEMENT {
                 litebox_util_log::warn!(
                     distance:? = distance;
                     "trampoline too far from code segment, skipping patching"
@@ -912,18 +1156,22 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
 
             state.trampoline_addr = actual_addr;
 
-            // Write the 8-byte syscall entry point at the start.
-            let entry_ptr = UserPtrMut::<u8>::from_usize(actual_addr);
-            if entry_ptr
-                .copy_from_slice::<Platform>(0, &syscall_entry.to_le_bytes())
-                .is_none()
-            {
-                litebox_util_log::warn!("failed to write syscall entry point to trampoline");
-                let _ = self.sys_munmap_raw(UserPtrMut::<u8>::from_usize(actual_addr), PAGE_SIZE);
-                self.apply_trap_fallback(mapped_addr, len, false);
-                return true;
+            if litebox_syscall_rewriter::TRAMPOLINE_ENTRY_POINT_BYTES != 0 {
+                let entry_ptr = UserPtrMut::<u8>::from_usize(actual_addr);
+                if entry_ptr
+                    .copy_from_slice::<Platform>(0, &syscall_entry.to_le_bytes())
+                    .is_none()
+                {
+                    litebox_util_log::warn!("failed to write syscall entry point to trampoline");
+                    let _ =
+                        self.sys_munmap_raw(UserPtrMut::<u8>::from_usize(actual_addr), PAGE_SIZE);
+                    self.apply_trap_fallback(mapped_addr, len, false);
+                    return true;
+                }
+                state.trampoline_cursor = litebox_syscall_rewriter::TRAMPOLINE_ENTRY_POINT_BYTES;
+            } else {
+                state.trampoline_cursor = 0;
             }
-            state.trampoline_cursor = 8; // stubs start after the 8-byte entry
             state.trampoline_mapped = true;
             state.trampoline_mapped_len = PAGE_SIZE;
         }
@@ -983,8 +1231,16 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         let original_code = code_buf.clone();
 
         let code_vaddr = addr_usize as u64;
+        state.trampoline_cursor = align_up(
+            state.trampoline_cursor,
+            litebox_syscall_rewriter::TRAMPOLINE_CURSOR_ALIGN,
+        );
         let trampoline_write_vaddr = (state.trampoline_addr + state.trampoline_cursor) as u64;
-        let syscall_entry_addr = state.trampoline_addr as u64;
+        let syscall_entry_addr = if litebox_syscall_rewriter::TRAMPOLINE_ENTRY_POINT_BYTES != 0 {
+            state.trampoline_addr as u64
+        } else {
+            syscall_entry as u64
+        };
 
         let patch_result = litebox_syscall_rewriter::patch_code_segment(
             &mut code_buf,
@@ -1006,6 +1262,19 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         };
         match patch_result {
             Ok(stubs) if !stubs.is_empty() => {
+                // Replace recognized sites with traps before discarding gates
+                // whose thread-pointer placeholder could not be finalized.
+                #[cfg(target_arch = "aarch64")]
+                let stubs = {
+                    let mut stubs = stubs;
+                    if let Err(e) = finalize_trampoline_gates(self.global.platform, &mut stubs) {
+                        litebox_util_log::error!(err:% = e; "refusing to install runtime gates whose guest thread-pointer is not patched");
+                        self.apply_trap_fallback(mapped_addr, len, true);
+                        restore_trampoline_rx(self, state);
+                        return true;
+                    }
+                    stubs
+                };
                 let Some(new_cursor) = state.trampoline_cursor.checked_add(stubs.len()) else {
                     litebox_util_log::warn!("trampoline cursor overflow");
                     self.apply_trap_fallback(mapped_addr, len, true);
@@ -1106,6 +1375,9 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
     /// Removes the cache entry (preventing stale state if the fd is reused)
     /// and unmaps any trampoline that was allocated but never used.
     pub(crate) fn finalize_elf_patch(&self, fd: i32) {
+        // TODO: retain patch state for mappings that outlive `fd`, together
+        // with an owned backing-file handle. Dropping it here makes a later
+        // mprotect(PROT_EXEC) unable to patch those mappings.
         let state = self.global.elf_patch_cache.lock().remove(&fd);
         if let Some(state) = state
             && state.trampoline_mapped
@@ -1133,6 +1405,133 @@ mod tests {
 
     use crate::syscalls::tests::TestPlatform as Platform;
     use crate::{UserPtrMut, syscalls::tests::init_platform};
+
+    /// Fail closed: an unpatched placeholder executes silently.
+    #[cfg(target_arch = "aarch64")]
+    mod aarch64_trampoline_gates {
+        use litebox::platform::SystemInfoProvider;
+
+        struct StubPlatform(Option<usize>);
+
+        impl SystemInfoProvider for StubPlatform {
+            fn get_syscall_entry_point(&self) -> usize {
+                0
+            }
+            fn get_vdso_address(&self) -> Option<usize> {
+                None
+            }
+            fn guest_thread_pointer_offset(&self) -> Option<usize> {
+                self.0
+            }
+        }
+
+        fn unpatched_trampoline() -> alloc::vec::Vec<u8> {
+            let mut code = 0xD53B_D049u32.to_le_bytes(); // MRS X9, TPIDR_EL0
+            let (tramp, trapped) =
+                litebox_syscall_rewriter::patch_code_segment(&mut code, 0x1000, 0x400000, 0)
+                    .unwrap();
+            assert!(trapped.is_empty());
+            assert_eq!(
+                litebox_syscall_rewriter::aarch64::find_guest_tpidr_placeholder(&tramp),
+                Some(16 + 4),
+                "the fixture must start out unpatched, or these tests prove nothing"
+            );
+            let classified =
+                litebox_syscall_rewriter::aarch64::classify_gate_pc(&tramp, 0x400000, 0x400010)
+                    .expect("emitted MRS slot must validate");
+            assert_eq!(classified.slot_offset(), 16);
+            assert!(matches!(
+                classified.metadata(),
+                litebox_syscall_rewriter::aarch64::GateMetadata::MrsTpidr { destination: 9, .. }
+            ));
+            tramp
+        }
+
+        /// Runtime gates receive the callback address, not a callback-slot address.
+        #[test]
+        fn the_runtime_paths_argument_shape_produces_installable_gates() {
+            const TRAMPOLINE_BASE: u64 = 0x40_0000;
+            const SYSCALL_ENTRY: u64 = 0xDEAD_0000;
+            const GUEST_THREAD_POINTER_OFFSET: usize = 96;
+
+            let mut code = 0xD400_0001u32.to_le_bytes(); // SVC #0
+            let (mut stubs, trapped) = litebox_syscall_rewriter::patch_code_segment(
+                &mut code,
+                0x1000,
+                TRAMPOLINE_BASE,
+                SYSCALL_ENTRY,
+            )
+            .expect("a gate-aligned base and a real callback must be accepted");
+            assert!(trapped.is_empty());
+
+            assert_eq!(
+                u64::from_le_bytes(stubs[..8].try_into().unwrap()),
+                SYSCALL_ENTRY
+            );
+
+            super::super::finalize_trampoline_gates(
+                &StubPlatform(Some(GUEST_THREAD_POINTER_OFFSET)),
+                &mut stubs,
+            )
+            .expect("runtime gates must be patchable exactly like ahead-of-time ones");
+            assert_eq!(
+                litebox_syscall_rewriter::aarch64::find_guest_tpidr_placeholder(&stubs),
+                None
+            );
+            litebox_syscall_rewriter::aarch64::classify_gate_pc(
+                &stubs,
+                TRAMPOLINE_BASE,
+                TRAMPOLINE_BASE + 16,
+            )
+            .expect("the installed gate must classify at runtime");
+
+            let mut code = 0xD400_0001u32.to_le_bytes();
+            assert!(
+                litebox_syscall_rewriter::patch_code_segment(
+                    &mut code,
+                    0x1000,
+                    TRAMPOLINE_BASE + 8,
+                    TRAMPOLINE_BASE,
+                )
+                .is_err(),
+                "a base-relative callback has to be rejected, or this test proves nothing"
+            );
+        }
+
+        #[test]
+        fn a_supplied_offset_is_baked_into_every_gate() {
+            let mut tramp = unpatched_trampoline();
+            super::super::finalize_trampoline_gates(&StubPlatform(Some(96)), &mut tramp)
+                .expect("a well-formed trampoline and a valid offset must be accepted");
+            assert_eq!(
+                litebox_syscall_rewriter::aarch64::find_guest_tpidr_placeholder(&tramp),
+                None
+            );
+        }
+
+        #[test]
+        fn a_platform_with_no_offset_is_refused() {
+            let mut tramp = unpatched_trampoline();
+            let err = super::super::finalize_trampoline_gates(&StubPlatform(None), &mut tramp)
+                .expect_err(
+                    "an AArch64 platform that supplies no offset must be fatal for the \
+                         binary, not a silent skip",
+                );
+            assert!(err.contains("no guest thread-pointer offset"), "{err}");
+            assert_eq!(
+                litebox_syscall_rewriter::aarch64::find_guest_tpidr_placeholder(&tramp),
+                Some(16 + 4)
+            );
+        }
+
+        #[test]
+        fn an_offset_no_gate_can_encode_is_refused() {
+            let mut tramp = unpatched_trampoline();
+            let err = super::super::finalize_trampoline_gates(&StubPlatform(Some(4)), &mut tramp)
+                .expect_err("an offset the gates' scaled immediate cannot hold is fatal");
+            assert!(err.contains("failed to patch"), "{err}");
+        }
+    }
 
     #[test]
     fn test_anonymous_mmap() {
@@ -1571,5 +1970,50 @@ mod tests {
         let ptr = UserPtrMut::<u8>::from_usize(0xdeadbeef);
         let result = ptr.read_at_offset::<Platform>(0);
         assert!(result.is_none());
+    }
+
+    #[test]
+    #[cfg(target_arch = "aarch64")]
+    fn subtract_ranges_yields_every_unowned_subrange() {
+        use super::subtract_ranges;
+        use core::ops::Range;
+
+        fn r(start: usize, end: usize) -> Range<usize> {
+            start..end
+        }
+
+        assert_eq!(
+            subtract_ranges(r(0x1000, 0x3000), &[]),
+            alloc::vec![r(0x1000, 0x3000)]
+        );
+
+        assert_eq!(
+            subtract_ranges(r(0x1000, 0x3000), &[r(0x1000, 0x2000)]),
+            alloc::vec![r(0x2000, 0x3000)]
+        );
+        assert_eq!(
+            subtract_ranges(r(0x1000, 0x3000), &[r(0x2000, 0x3000)]),
+            alloc::vec![r(0x1000, 0x2000)]
+        );
+
+        assert_eq!(
+            subtract_ranges(r(0x1000, 0x4000), &[r(0x2000, 0x3000)]),
+            alloc::vec![r(0x1000, 0x2000), r(0x3000, 0x4000)]
+        );
+
+        assert_eq!(
+            subtract_ranges(r(0x1000, 0x3000), &[r(0x0000, 0x9000)]),
+            alloc::vec![]
+        );
+
+        assert_eq!(
+            subtract_ranges(r(0x1000, 0x5000), &[r(0x3000, 0x4000), r(0x2000, 0x3500)]),
+            alloc::vec![r(0x1000, 0x2000), r(0x4000, 0x5000)]
+        );
+
+        assert_eq!(
+            subtract_ranges(r(0x1000, 0x2000), &[r(0x5000, 0x6000)]),
+            alloc::vec![r(0x1000, 0x2000)]
+        );
     }
 }

--- a/litebox_shim_linux/src/syscalls/net.rs
+++ b/litebox_shim_linux/src/syscalls/net.rs
@@ -3075,10 +3075,7 @@ mod tests {
     }
 
     fn epoll_add(task: &TestTask, epfd: i32, target_fd: u32, events: litebox::event::Events) {
-        let ev = litebox_common_linux::EpollEvent {
-            events: events.bits(),
-            data: u64::from(target_fd),
-        };
+        let ev = litebox_common_linux::EpollEvent::new(events.bits(), u64::from(target_fd));
         let ev_ptr = (&raw const ev).cast::<litebox_common_linux::EpollEvent>();
         let ev_const = UserPtr::from_usize(ev_ptr as usize);
         task.sys_epoll_ctl(
@@ -3162,7 +3159,7 @@ mod tests {
 
         if is_nonblocking {
             // wait on epoll for server to be readable (incoming connection)
-            let mut events = [litebox_common_linux::EpollEvent { events: 0, data: 0 }; 2];
+            let mut events = [litebox_common_linux::EpollEvent::new(0, 0); 2];
             let n = epoll_wait(task, epfd, &mut events);
             assert_eq!(n, 1);
             for ev in &events[..n] {
@@ -3238,7 +3235,7 @@ mod tests {
             "recvfrom" | "recvmsg" => {
                 if is_nonblocking {
                     epoll_add(task, epfd, client_fd, litebox::event::Events::IN);
-                    let mut events = [litebox_common_linux::EpollEvent { events: 0, data: 0 }; 2];
+                    let mut events = [litebox_common_linux::EpollEvent::new(0, 0); 2];
                     let n = epoll_wait(task, epfd, &mut events);
                     for ev in &events[..n] {
                         assert!(ev.events & litebox::event::Events::IN.bits() != 0);
@@ -3524,7 +3521,7 @@ mod tests {
             recv_flags.insert(ReceiveFlags::TRUNC);
         }
         if is_nonblocking {
-            let mut events = [litebox_common_linux::EpollEvent { events: 0, data: 0 }; 2];
+            let mut events = [litebox_common_linux::EpollEvent::new(0, 0); 2];
             let n = epoll_wait(task, epfd, &mut events);
             assert_eq!(n, 1);
             for ev in &events[..n] {

--- a/litebox_shim_linux/src/syscalls/process.rs
+++ b/litebox_shim_linux/src/syscalls/process.rs
@@ -122,6 +122,8 @@ pub(crate) struct Process<Platform: ShimPlatform> {
     pub(crate) limits: ResourceLimits,
     /// Process-wide alarm timer.
     pub(crate) alarm_timer: Mutex<Platform, Alarm<Platform>>,
+    #[cfg(target_arch = "aarch64")]
+    pub(crate) sigreturn_trampoline: Mutex<Platform, Option<usize>>,
 }
 
 pub(crate) struct Alarm<Platform: ShimPlatform> {
@@ -182,6 +184,8 @@ impl<Platform: ShimPlatform> Process<Platform> {
                 handle: None,
                 deadline: None,
             }),
+            #[cfg(target_arch = "aarch64")]
+            sigreturn_trampoline: Mutex::new(None),
         }
     }
 
@@ -520,7 +524,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
 ///
 /// On `x86_64`, this is represented as a `*mut u8`. The TLS pointer can point to
 /// an arbitrary-sized memory region.
-#[cfg(target_arch = "x86_64")]
+/// On AArch64, it is the `TPIDR_EL0` value.
 type ThreadLocalDescriptor = UserPtrMut<u8>;
 
 struct NewThreadArgs<Platform: ShimPlatform, FS: ShimFS> {
@@ -639,21 +643,33 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             return Err(Errno::EINVAL);
         }
 
-        let tls = if flags.contains(CloneFlags::SETTLS) {
+        let explicit_tls = if flags.contains(CloneFlags::SETTLS) {
             let addr = tls.trunc();
+            // Validate the user-controlled TLS base before spawning the thread.
             #[cfg(target_arch = "x86_64")]
-            {
-                // Validate the user-controlled TLS base before spawning the thread.
-                if !litebox_common_linux::arch::is_valid_user_fs_base(addr) {
-                    return Err(Errno::EPERM);
-                }
+            let valid = litebox_common_linux::arch::is_valid_user_fs_base(addr);
+            #[cfg(target_arch = "aarch64")]
+            let valid = litebox_common_linux::arch::is_valid_user_tls_base(addr);
+            if !valid {
+                return Err(Errno::EPERM);
             }
-            #[cfg(target_arch = "x86_64")]
-            let desc = UserPtrMut::from_usize(addr);
-            Some(desc)
+            Some(addr)
         } else {
             None
         };
+        // AArch64 inherits live TPIDR_EL0 unless CLONE_SETTLS replaces it.
+        #[cfg(target_arch = "aarch64")]
+        let tls_value = Some(match explicit_tls {
+            Some(addr) => addr,
+            None => self
+                .global
+                .platform
+                .get_arch_specific_register(&ArchSpecificRegister::TpidrEl0)
+                .map_err(|_| Errno::EPERM)?,
+        });
+        #[cfg(target_arch = "x86_64")]
+        let tls_value = explicit_tls;
+        let tls: Option<ThreadLocalDescriptor> = tls_value.map(UserPtrMut::from_usize);
 
         let child_tid = if child_tid == 0 {
             None
@@ -1454,19 +1470,19 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
     /// Handle syscall `execve`.
     pub(crate) fn sys_execve(
         &self,
-        pathname: UserPtr<i8>,
-        argv: UserPtr<UserPtr<i8>>,
-        envp: UserPtr<UserPtr<i8>>,
+        pathname: UserPtr<core::ffi::c_char>,
+        argv: UserPtr<UserPtr<core::ffi::c_char>>,
+        envp: UserPtr<UserPtr<core::ffi::c_char>>,
         ctx: &mut litebox_common_linux::PtRegs,
     ) -> Result<usize, Errno> {
         fn copy_vector<Platform: ShimPlatform>(
-            mut base: UserPtr<UserPtr<i8>>,
+            mut base: UserPtr<UserPtr<core::ffi::c_char>>,
             _which: &str,
         ) -> Result<alloc::vec::Vec<alloc::ffi::CString>, Errno> {
             let mut out = alloc::vec::Vec::new();
             let mut total = 0usize;
             for _ in 0..MAX_VEC {
-                let p: UserPtr<i8> = {
+                let p: UserPtr<core::ffi::c_char> = {
                     // read pointer-sized entries
                     match base.read_at_offset::<Platform>(0) {
                         Some(ptr) => ptr,
@@ -1532,14 +1548,33 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
 
         self.signals.reset_for_exec();
 
+        #[cfg(target_arch = "aarch64")]
+        {
+            *self.process().sigreturn_trampoline.lock() = None;
+        }
+
         // Don't release reserved mappings.
         let release = |_r: Range<usize>, vm: VmFlags| !vm.is_empty();
         unsafe { self.global.pm.release_memory(release) }
             .expect("failed to release memory mappings");
 
+        // AArch64 patch state contains addresses from the discarded image.
+        // TODO: clear x86-64 patch state here too; it also contains addresses
+        // from the discarded image.
+        #[cfg(target_arch = "aarch64")]
+        self.global.elf_patch_cache.lock().clear();
+
+        // TODO: on AArch64, clear the platform's cached outbound stub and PC
+        // here. They address the discarded image, but the core platform API
+        // exposes no address-space-reset hook for transition metadata.
+
+        #[cfg(target_arch = "x86_64")]
+        let tls_reg = ArchSpecificRegister::FsBase;
+        #[cfg(target_arch = "aarch64")]
+        let tls_reg = ArchSpecificRegister::TpidrEl0;
         self.global
             .platform
-            .set_arch_specific_register(&ArchSpecificRegister::FsBase, 0)
+            .set_arch_specific_register(&tls_reg, 0)
             .expect("failed to clear guest TLS on execve");
 
         self.load_program(loader, argv_vec, envp_vec)
@@ -1609,6 +1644,21 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                         ss: 0x2b, // __USER_DS
                     };
                 }
+                #[cfg(target_arch = "aarch64")]
+                {
+                    // The arm64 kernel's `start_thread` zeroes every GPR and
+                    // PSTATE (EL0t, all interrupts unmasked) before entering the
+                    // new image; only PC and SP carry information.
+                    *ctx = litebox_common_linux::PtRegs {
+                        regs: [0; litebox_common_linux::AARCH64_GENERAL_REGISTER_COUNT],
+                        sp: load_info.user_stack_top,
+                        pc: load_info.entry_point,
+                        pstate: 0,
+                        orig_x0: 0,
+                        syscallno: litebox_common_linux::arch::NO_SYSCALL,
+                        unused2: 0,
+                    };
+                }
             }
             ThreadInitState::NewThread {
                 tls,
@@ -1623,6 +1673,13 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                     }
                     ctx.rax = 0;
                 }
+                #[cfg(target_arch = "aarch64")]
+                {
+                    if let Some(stack) = stack {
+                        ctx.sp = stack;
+                    }
+                    ctx.regs[0] = 0;
+                }
 
                 // Set the TLS for the new thread.
                 if let Some(tls) = tls {
@@ -1630,6 +1687,16 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                     {
                         self.sys_arch_prctl(ArchPrctlArg::SetFs(tls.as_usize()))
                             .unwrap();
+                    }
+                    #[cfg(target_arch = "aarch64")]
+                    {
+                        self.global
+                            .platform
+                            .set_arch_specific_register(
+                                &ArchSpecificRegister::TpidrEl0,
+                                tls.as_usize(),
+                            )
+                            .expect("failed to set guest TLS for the new thread");
                     }
                 }
 
@@ -1803,9 +1870,11 @@ mod tests {
             );
 
              // `process_signals` is called when about to switch back to userspace, so simulate that here.
-             let mut stack = [0u8; 4096];
+            let mut stack = [0u8; 2 * litebox::mm::linux::PAGE_SIZE];
              #[cfg(target_arch = "x86_64")]
              let mut regs = litebox_common_linux::PtRegs { rsp: stack.as_mut_ptr() as usize + stack.len(), ..Default::default() };
+             #[cfg(target_arch = "aarch64")]
+             let mut regs = litebox_common_linux::PtRegs { sp: stack.as_mut_ptr() as usize + stack.len(), ..Default::default() };
              task.process_signals(&mut regs);
             assert_eq!(
                 regs.get_ip(), callback_addr,

--- a/litebox_shim_linux/src/syscalls/signal/aarch64.rs
+++ b/litebox_shim_linux/src/syscalls/signal/aarch64.rs
@@ -1,0 +1,239 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//! Partial implementation of the AArch64 Linux signal-frame ABI.
+//!
+//! LiteBox supplies a fallback restorer because it exposes no guest vDSO.
+
+use crate::syscalls::signal::{DeliverFault, SignalState};
+use crate::{ShimFS, ShimPlatform, Task, UserPtrMut};
+use core::mem::offset_of;
+use litebox::mm::linux::PAGE_SIZE;
+use litebox::utils::{ReinterpretUnsignedExt as _, TruncateExt as _};
+use litebox_common_linux::{
+    AARCH64_GENERAL_REGISTER_COUNT, MapFlags, ProtFlags, PtRegs,
+    signal::{SaFlags, SigAction, Siginfo, Ucontext, aarch64::Sigcontext},
+};
+use litebox_syscall_rewriter::aarch64::{
+    RT_SIGRETURN_TRAMPOLINE_BYTES, emit_rt_sigreturn_trampoline,
+};
+use zerocopy::{FromBytes, IntoBytes};
+
+/// Linux `rt_sigframe` followed by an unwind-link frame record. Dynamic extra
+/// context is omitted.
+#[repr(C)]
+#[derive(Clone, FromBytes, IntoBytes)]
+struct SignalFrame {
+    siginfo: Siginfo,
+    ucontext: Ucontext,
+    next_frame_fp: usize,
+    next_frame_lr: usize,
+}
+
+pub(super) fn uctx_addr(ctx: &PtRegs) -> usize {
+    ctx.sp.wrapping_add(offset_of!(SignalFrame, ucontext))
+}
+
+pub(super) fn sp(ctx: &PtRegs) -> usize {
+    ctx.sp
+}
+
+pub(super) fn get_signal_frame(sp: usize, _action: &SigAction) -> usize {
+    let frame_addr = sp.wrapping_sub(core::mem::size_of::<SignalFrame>());
+    // Linux AArch64 signal entry requires a 16-byte-aligned stack pointer.
+    frame_addr & !15
+}
+
+fn requested_restorer(action: &SigAction) -> Option<usize> {
+    action
+        .flags
+        .contains(SaFlags::RESTORER)
+        .then_some(action.restorer)
+}
+
+fn handler_arguments(action: &SigAction, frame_addr: usize) -> Option<(usize, usize)> {
+    action.flags.contains(SaFlags::SIGINFO).then(|| {
+        (
+            frame_addr.wrapping_add(offset_of!(SignalFrame, siginfo)),
+            frame_addr.wrapping_add(offset_of!(SignalFrame, ucontext)),
+        )
+    })
+}
+
+/// Returns a cached synthetic `rt_sigreturn` guest mapping.
+/// The cache is reset on `execve`; guest VM operations can invalidate it.
+pub(super) fn sigreturn_trampoline<Platform: ShimPlatform, FS: ShimFS>(
+    task: &Task<Platform, FS>,
+    action: &SigAction,
+) -> Result<usize, DeliverFault> {
+    if let Some(restorer) = requested_restorer(action) {
+        return Ok(restorer);
+    }
+
+    let mut cached = task.process().sigreturn_trampoline.lock();
+    if let Some(addr) = *cached {
+        return Ok(addr);
+    }
+
+    const { assert!(RT_SIGRETURN_TRAMPOLINE_BYTES <= PAGE_SIZE) };
+
+    let page = task
+        .do_mmap_anonymous(
+            None,
+            PAGE_SIZE,
+            ProtFlags::PROT_READ | ProtFlags::PROT_WRITE,
+            MapFlags::MAP_PRIVATE | MapFlags::MAP_ANONYMOUS,
+        )
+        .map_err(|_| DeliverFault)?;
+
+    let callback = task.global.platform.get_syscall_entry_point();
+    page.cast::<[u8; RT_SIGRETURN_TRAMPOLINE_BYTES]>()
+        .write_at_offset::<Platform>(
+            0,
+            emit_rt_sigreturn_trampoline(callback).map_err(|_| DeliverFault)?,
+        )
+        .ok_or(DeliverFault)?;
+
+    // Drop write before execute; the guest never needs write access.
+    task.sys_mprotect_raw(page, PAGE_SIZE, ProtFlags::PROT_READ | ProtFlags::PROT_EXEC)
+        .map_err(|_| DeliverFault)?;
+
+    let addr = page.as_usize();
+    *cached = Some(addr);
+    Ok(addr)
+}
+
+impl<Platform: ShimPlatform> SignalState<Platform> {
+    pub(super) fn write_signal_frame(
+        &self,
+        frame_addr: usize,
+        siginfo: &Siginfo,
+        action: &SigAction,
+        ctx: &mut PtRegs,
+        sigreturn_trampoline: usize,
+    ) -> Result<(), DeliverFault> {
+        let last_exception = self.last_exception.get();
+
+        let mut regs = [0u64; AARCH64_GENERAL_REGISTER_COUNT];
+        for (dst, src) in regs.iter_mut().zip(ctx.regs.iter()) {
+            *dst = *src as u64;
+        }
+
+        let frame = SignalFrame {
+            siginfo: siginfo.clone(),
+            ucontext: Ucontext {
+                flags: 0,
+                link: 0, // core::ptr::null_mut(),
+                stack: self.altstack.get(),
+                sigmask: self.blocked.get(),
+                __unused: [0; _],
+                __align_pad: [0; _],
+                mcontext: Sigcontext {
+                    fault_address: last_exception.fault_address as u64,
+                    regs,
+                    sp: ctx.sp as u64,
+                    pc: ctx.pc as u64,
+                    pstate: ctx.pstate,
+                    __reserved_pad: [0; _],
+                    // LiteBox writes only the terminating `_aarch64_ctx` and
+                    // omits Linux's required FP/SIMD context.
+                    // TODO: save and restore the guest FP/SIMD context. The
+                    // transition path does not save V registers, so their values
+                    // are unavailable when the frame is built. See
+                    // `run_thread_arch` in `litebox_platform_linux_userland`.
+                    __reserved: [0; _],
+                },
+            },
+            next_frame_fp: ctx.regs[29],
+            next_frame_lr: ctx.regs[30],
+        };
+
+        let frame_ptr = UserPtrMut::from_usize(frame_addr);
+        frame_ptr
+            .write_at_offset::<Platform>(0, frame)
+            .ok_or(DeliverFault)?;
+
+        ctx.sp = frame_addr;
+        ctx.pc = action.sigaction;
+        ctx.regs[0] = usize::try_from(siginfo.signo.reinterpret_as_unsigned())
+            .expect("a u32 always fits in a 64-bit usize");
+        if let Some((siginfo, ucontext)) = handler_arguments(action, frame_addr) {
+            ctx.regs[1] = siginfo;
+            ctx.regs[2] = ucontext;
+        }
+        // Link the handler's frame chain to the interrupted frame.
+        ctx.regs[29] = frame_addr.wrapping_add(offset_of!(SignalFrame, next_frame_fp));
+        ctx.regs[30] = sigreturn_trampoline;
+        // PSTATE carries over into the handler: `setup_return` adjusts only
+        // TCO and BTYPE, neither of which LiteBox models. `copy_signal_context`
+        // has already masked it to the bits a guest may own.
+        ctx.syscallno = litebox_common_linux::arch::NO_SYSCALL;
+        Ok(())
+    }
+}
+
+pub(super) fn restore_sigcontext(ctx: &mut PtRegs, sigctx: &Sigcontext) -> usize {
+    let Sigcontext {
+        fault_address: _,
+        regs,
+        sp,
+        pc,
+        pstate,
+        __reserved_pad: _,
+        // TODO: restore guest FP/SIMD state from extra context records. This
+        // first requires the transition path to save V registers; see
+        // `litebox_platform_linux_userland`.
+        __reserved: _,
+    } = sigctx;
+
+    for (dst, src) in ctx.regs.iter_mut().zip(regs.iter()) {
+        *dst = src.trunc();
+    }
+    ctx.sp = sp.trunc();
+    ctx.pc = pc.trunc();
+    // The guest chose this value, so only the bits a guest may set survive.
+    ctx.pstate = *pstate & litebox_common_linux::arch::SAFE_USER_PSTATE;
+    ctx.syscallno = litebox_common_linux::arch::NO_SYSCALL;
+
+    ctx.regs[0]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use litebox_common_linux::signal::{SaFlags, SigSet};
+
+    fn action(flags: SaFlags, restorer: usize) -> SigAction {
+        SigAction {
+            sigaction: 0x1000,
+            flags,
+            __pad: 0,
+            restorer,
+            mask: SigSet::empty(),
+        }
+    }
+
+    #[test]
+    fn sa_restorer_selects_the_guest_restorer() {
+        let set = action(SaFlags::RESTORER, 0x1234_5678);
+        assert_eq!(requested_restorer(&set), Some(0x1234_5678));
+
+        let unset = action(SaFlags::empty(), 0x1234_5678);
+        assert_eq!(requested_restorer(&unset), None);
+    }
+
+    #[test]
+    fn handler_arguments_are_only_supplied_for_sa_siginfo() {
+        let plain = action(SaFlags::empty(), 0);
+        assert_eq!(handler_arguments(&plain, 0x8000), None);
+
+        let siginfo = action(SaFlags::SIGINFO, 0);
+        assert_eq!(
+            handler_arguments(&siginfo, 0x8000),
+            Some((
+                0x8000 + offset_of!(SignalFrame, siginfo),
+                0x8000 + offset_of!(SignalFrame, ucontext),
+            ))
+        );
+    }
+}

--- a/litebox_shim_linux/src/syscalls/signal/mod.rs
+++ b/litebox_shim_linux/src/syscalls/signal/mod.rs
@@ -3,12 +3,17 @@
 
 //! Signal handling syscalls and support.
 
+#[cfg(target_arch = "aarch64")]
+mod aarch64;
 #[cfg(target_arch = "x86_64")]
 mod x86_64;
 
-use litebox_common_linux::signal::SignalDisposition;
+#[cfg(target_arch = "aarch64")]
+use aarch64 as arch;
 #[cfg(target_arch = "x86_64")]
 use x86_64 as arch;
+
+use litebox_common_linux::signal::SignalDisposition;
 use zerocopy::FromZeros;
 
 use crate::syscalls::process::ExitStatus;
@@ -49,13 +54,18 @@ impl<Platform: ShimPlatform> SignalState<Platform> {
                 sp: 0,
                 flags: SsFlags::DISABLE,
                 size: 0,
-                #[cfg(target_arch = "x86_64")]
                 __pad: 0,
             }),
             last_exception: Cell::new(litebox::shim::ExceptionInfo {
                 exception: litebox::shim::Exception(0),
+                #[cfg(target_arch = "x86_64")]
                 error_code: 0,
+                #[cfg(target_arch = "x86_64")]
                 cr2: 0,
+                #[cfg(target_arch = "aarch64")]
+                fault_address: 0,
+                #[cfg(target_arch = "aarch64")]
+                esr: 0,
                 kernel_mode: false,
             }),
         }
@@ -76,7 +86,6 @@ impl<Platform: ShimPlatform> SignalState<Platform> {
                 flags: SsFlags::DISABLE,
                 sp: 0,
                 size: 0,
-                #[cfg(target_arch = "x86_64")]
                 __pad: 0,
             }
             .into(),
@@ -101,7 +110,6 @@ impl<Platform: ShimPlatform> SignalState<Platform> {
                 restorer: 0,
                 flags: SaFlags::empty(),
                 mask: SigSet::empty(),
-                #[cfg(target_arch = "x86_64")]
                 __pad: 0,
             };
         }
@@ -156,7 +164,6 @@ impl<Platform: ShimPlatform> SignalHandlers<Platform> {
                         restorer: 0,
                         flags: SaFlags::empty(),
                         mask: SigSet::empty(),
-                        #[cfg(target_arch = "x86_64")]
                         __pad: 0,
                     },
                     immutable: i == SignalHandlersInner::sig_index(Signal::SIGKILL)
@@ -268,7 +275,6 @@ fn siginfo_exception(signal: Signal, fault_address: usize) -> Siginfo {
         signo: signal.as_i32(),
         errno: 0,
         code: SI_KERNEL,
-        #[cfg(target_arch = "x86_64")]
         __pad: 0,
         data: SiginfoData::new_addr(fault_address),
     }
@@ -281,7 +287,6 @@ pub(crate) fn siginfo_kill(signal: Signal) -> Siginfo {
         signo: signal.as_i32(),
         errno: 0,
         code: SI_USER,
-        #[cfg(target_arch = "x86_64")]
         __pad: 0,
         data: SiginfoData::new_zeroed(),
     }
@@ -313,7 +318,6 @@ impl<Platform: ShimPlatform> SignalState<Platform> {
                 sp: ss.sp,
                 flags: ss.flags & SsFlags::AUTODISARM,
                 size: ss.size,
-                #[cfg(target_arch = "x86_64")]
                 __pad: 0,
             });
             Ok(())
@@ -326,7 +330,6 @@ impl<Platform: ShimPlatform> SignalState<Platform> {
             sp: 0,
             flags: SsFlags::DISABLE,
             size: 0,
-            #[cfg(target_arch = "x86_64")]
             __pad: 0,
         });
     }
@@ -337,6 +340,7 @@ impl<Platform: ShimPlatform> SignalState<Platform> {
         siginfo: &Siginfo,
         action: &SigAction,
         ctx: &mut PtRegs,
+        sigreturn_trampoline: usize,
     ) -> Result<(), DeliverFault> {
         let sp = arch::sp(ctx);
         let on_alt_stack = is_on_stack(&self.altstack.get(), sp);
@@ -351,12 +355,21 @@ impl<Platform: ShimPlatform> SignalState<Platform> {
         };
 
         let frame_addr = arch::get_signal_frame(sp, action);
+        #[cfg(target_arch = "aarch64")]
+        let frame_prefix = if action.flags.contains(SaFlags::RESTORER) {
+            0
+        } else {
+            litebox_syscall_rewriter::aarch64::SVC_FRAME_BYTES as usize
+        };
+        #[cfg(target_arch = "x86_64")]
+        let frame_prefix = 0;
+        let frame_start = frame_addr.checked_sub(frame_prefix).ok_or(DeliverFault)?;
 
-        if (switch_stacks || on_alt_stack) && !is_on_stack(&altstack, frame_addr) {
+        if (switch_stacks || on_alt_stack) && !is_on_stack(&altstack, frame_start) {
             return Err(DeliverFault);
         }
 
-        self.write_signal_frame(frame_addr, siginfo, action, ctx)?;
+        self.write_signal_frame(frame_addr, siginfo, action, ctx, sigreturn_trampoline)?;
 
         let mut mask = self.blocked.get() | action.mask;
         if !action.flags.contains(SaFlags::NODEFER) {
@@ -602,9 +615,12 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                 }
                 SIG_IGN => {}
                 _ => {
-                    if let Err(DeliverFault) =
-                        self.signals.deliver_signal(signal, &siginfo, &action, ctx)
-                    {
+                    let delivered =
+                        arch::sigreturn_trampoline(self, &action).and_then(|trampoline| {
+                            self.signals
+                                .deliver_signal(signal, &siginfo, &action, ctx, trampoline)
+                        });
+                    if let Err(DeliverFault) = delivered {
                         // Failed to deliver signal. Inject a SIGSEGV
                         // (terminating the process if we were trying to deliver
                         // a SIGSEGV).
@@ -699,7 +715,6 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             signo: signal.as_i32(),
             errno: 0,
             code: SI_KERNEL,
-            #[cfg(target_arch = "x86_64")]
             __pad: 0,
             data: SiginfoData::new_zeroed(),
         };
@@ -730,7 +745,6 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                 restorer: 0,
                 flags: SaFlags::empty(),
                 mask: SigSet::empty(),
-                #[cfg(target_arch = "x86_64")]
                 __pad: 0,
             };
             // Don't allow further changes to this action.
@@ -739,19 +753,42 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
     }
 
     pub(crate) fn handle_exception_request(&self, info: &litebox::shim::ExceptionInfo) {
-        let signal = match info.exception {
-            Exception::DIVIDE_ERROR => Signal::SIGFPE,
-            Exception::BREAKPOINT => Signal::SIGTRAP,
-            Exception::INVALID_OPCODE => Signal::SIGILL,
-            // Page faults and unknown exceptions map to SIGSEGV. There may be
-            // more appropriate signals in some other cases (e.g., SIGBUS).
-            _ => Signal::SIGSEGV,
+        #[cfg(target_arch = "x86_64")]
+        let (signal, fault_address) = {
+            let signal = match info.exception {
+                Exception::DIVIDE_ERROR => Signal::SIGFPE,
+                Exception::BREAKPOINT => Signal::SIGTRAP,
+                Exception::INVALID_OPCODE => Signal::SIGILL,
+                // Page faults and unknown exceptions map to SIGSEGV. There may be
+                // more appropriate signals in some other cases (e.g., SIGBUS).
+                _ => Signal::SIGSEGV,
+            };
+            // For page faults, provide the faulting address.
+            let fault_address = if info.exception == Exception::PAGE_FAULT {
+                info.cr2
+            } else {
+                0
+            };
+            (signal, fault_address)
         };
-        // For page faults, provide the faulting address.
-        let fault_address = if info.exception == Exception::PAGE_FAULT {
-            info.cr2
-        } else {
-            0
+        // Inverts the mapping `litebox_platform_linux_userland`'s
+        // `exception_signal_handler` performs. That mapping is lossy: SIGSEGV,
+        // SIGBUS and SIGFPE all fold into `DATA_ABORT_LOWER_EL`, so a guest
+        // SIGBUS or SIGFPE arrives here as SIGSEGV.
+        //
+        // TODO: carry SIGFPE exactly, as exception class 0x2c, once
+        // `force_signal_with_info` accepts signals beyond SIGKILL and SIGSEGV.
+        // Selecting SIGFPE here would trip its assert today.
+        #[cfg(target_arch = "aarch64")]
+        let (signal, fault_address) = match info.exception {
+            Exception::BRK64
+            | Exception::BREAKPOINT_LOWER_EL
+            | Exception::BREAKPOINT_CURRENT_EL => (Signal::SIGTRAP, 0),
+            Exception::INSTRUCTION_ABORT_LOWER_EL | Exception::INSTRUCTION_ABORT_CURRENT_EL => {
+                (Signal::SIGILL, info.fault_address)
+            }
+            // Data aborts and unknown exception classes map to SIGSEGV.
+            _ => (Signal::SIGSEGV, info.fault_address),
         };
         self.signals.last_exception.set(*info);
         self.force_signal_with_info(signal, false, siginfo_exception(signal, fault_address));

--- a/litebox_shim_linux/src/syscalls/signal/x86_64.rs
+++ b/litebox_shim_linux/src/syscalls/signal/x86_64.rs
@@ -1,9 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-use crate::ShimPlatform;
-use crate::UserPtrMut;
 use crate::syscalls::signal::{DeliverFault, SignalState};
+use crate::{ShimFS, ShimPlatform, Task, UserPtrMut};
 use core::mem::offset_of;
 use litebox::utils::{ReinterpretUnsignedExt as _, TruncateExt as _};
 use litebox_common_linux::{
@@ -44,6 +43,17 @@ pub(super) fn get_signal_frame(sp: usize, _action: &SigAction) -> usize {
     frame_addr
 }
 
+/// Requires the guest's own `sa_restorer`; LiteBox has no x86-64 vDSO fallback.
+pub(super) fn sigreturn_trampoline<Platform: ShimPlatform, FS: ShimFS>(
+    _task: &Task<Platform, FS>,
+    action: &SigAction,
+) -> Result<usize, DeliverFault> {
+    if !action.flags.contains(SaFlags::RESTORER) {
+        return Err(DeliverFault);
+    }
+    Ok(action.restorer)
+}
+
 impl<Platform: ShimPlatform> SignalState<Platform> {
     pub(super) fn write_signal_frame(
         &self,
@@ -51,14 +61,11 @@ impl<Platform: ShimPlatform> SignalState<Platform> {
         siginfo: &Siginfo,
         action: &SigAction,
         ctx: &mut PtRegs,
+        sigreturn_trampoline: usize,
     ) -> Result<(), DeliverFault> {
-        if !action.flags.contains(SaFlags::RESTORER) {
-            return Err(DeliverFault);
-        }
-
         let last_exception = self.last_exception.get();
         let frame = SignalFrame {
-            return_address: action.restorer,
+            return_address: sigreturn_trampoline,
             ucontext: Ucontext {
                 flags: 0,
                 link: 0, // core::ptr::null_mut(),

--- a/litebox_syscall_rewriter/src/aarch64.rs
+++ b/litebox_syscall_rewriter/src/aarch64.rs
@@ -258,6 +258,7 @@ impl EncodedGateMetadata {
 
 /// First scratch register (IP0).
 const X16: u8 = 16;
+const X8: u8 = 8;
 /// Second scratch register (IP1).
 const X17: u8 = 17;
 /// Stack pointer (encoded as register 31 in a base-register field).
@@ -344,6 +345,65 @@ pub const SVC_FRAME_OFF_RETADDR: u16 = 8;
 /// Address of this site's outbound stub. ABI: the runtime's syscall callback
 /// branches here to resume at the original syscall site.
 pub const SVC_FRAME_OFF_STUB: u16 = 16;
+
+pub const RT_SIGRETURN_TRAMPOLINE_BYTES: usize = 48;
+
+/// Emits a synthetic AArch64 `rt_sigreturn` restorer that dispatches through
+/// `callback` using the rewriter's SVC frame ABI.
+pub fn emit_rt_sigreturn_trampoline(
+    callback: usize,
+) -> Result<[u8; RT_SIGRETURN_TRAMPOLINE_BYTES]> {
+    const NR_RT_SIGRETURN: u16 = 139;
+    const CALLBACK_OFFSET: usize = 40;
+    const CONTINUATION_OFFSET: i64 = 32;
+    const ADR_OFFSET: i64 = 12;
+    const LDR_OFFSET: i64 = 24;
+    let instructions = [
+        Insn::Movz {
+            rd: X8,
+            imm16: NR_RT_SIGRETURN,
+        },
+        Insn::SubSp(SVC_FRAME_BYTES),
+        Insn::StrUimm {
+            rt: X16,
+            rn: SP,
+            imm_bytes: SVC_FRAME_OFF_X16,
+        },
+        Insn::Adr {
+            rd: X16,
+            byte_off: CONTINUATION_OFFSET - ADR_OFFSET,
+        },
+        Insn::StrUimm {
+            rt: X16,
+            rn: SP,
+            imm_bytes: SVC_FRAME_OFF_RETADDR,
+        },
+        Insn::StrUimm {
+            rt: XZR,
+            rn: SP,
+            imm_bytes: SVC_FRAME_OFF_STUB,
+        },
+        Insn::LdrLiteral {
+            rt: X16,
+            off: i64::try_from(CALLBACK_OFFSET).map_err(|_| {
+                Error::AddressOverflow("callback offset does not fit in i64".into())
+            })? - LDR_OFFSET,
+        },
+        Insn::Br(X16),
+        Insn::Nop,
+        Insn::Nop,
+    ];
+
+    let mut out = [0; RT_SIGRETURN_TRAMPOLINE_BYTES];
+    for (index, instruction) in instructions.into_iter().enumerate() {
+        let word = instruction.encode().ok_or_else(|| {
+            Error::AddressOverflow("rt_sigreturn trampoline instruction is not encodable".into())
+        })?;
+        out[index * INSN_BYTES..][..INSN_BYTES].copy_from_slice(&word.to_le_bytes());
+    }
+    out[CALLBACK_OFFSET..].copy_from_slice(&callback.to_ne_bytes());
+    Ok(out)
+}
 
 // The gate carves the frame out of the guest stack with `SUB SP`, so the frame
 // must keep `SP` 16-byte aligned, and it must be large enough for the three
@@ -488,6 +548,7 @@ enum Opcode {
     Adr = 0x1000_0000,
     Adrp = 0x9000_0000,
     Br = 0xD61F_0000,
+    Movz = 0xD280_0000,
     SubImm = 0xD100_0000,
     AddImm = 0x9100_0000,
     StrUimm = 0xF900_0000,
@@ -610,23 +671,50 @@ enum Insn {
     /// `B` (unconditional branch), PC-relative, ±128MB, 4-byte aligned.
     B(i64),
     /// `ADR Xd, #byte_off` — PC-relative address, ±1MB (byte granularity).
-    Adr { rd: u8, byte_off: i64 },
+    Adr {
+        rd: u8,
+        byte_off: i64,
+    },
     /// `ADRP Xd, #page_off` — page-relative address, ±4GB (in 4KB pages).
-    Adrp { rd: u8, page_off: i64 },
+    Adrp {
+        rd: u8,
+        page_off: i64,
+    },
     /// `LDR Xt, <literal>` (PC-relative literal load), ±1MB, 4-byte aligned.
-    LdrLiteral { rt: u8, off: i64 },
+    LdrLiteral {
+        rt: u8,
+        off: i64,
+    },
     /// `BR Xn` (branch to register).
     Br(u8),
+    /// `MOVZ Xd, #imm16`.
+    Movz {
+        rd: u8,
+        imm16: u16,
+    },
+    Nop,
     /// `SUB SP, SP, #imm12`.
     SubSp(u16),
     /// `ADD SP, SP, #imm12`.
     AddSp(u16),
     /// `ADD Xd, Xn, #imm12`.
-    AddImm { rd: u8, rn: u8, imm12: u16 },
+    AddImm {
+        rd: u8,
+        rn: u8,
+        imm12: u16,
+    },
     /// `STR Xt, [Xn, #imm_bytes]` (unsigned scaled; `imm_bytes` multiple of 8).
-    StrUimm { rt: u8, rn: u8, imm_bytes: u16 },
+    StrUimm {
+        rt: u8,
+        rn: u8,
+        imm_bytes: u16,
+    },
     /// `LDR Xt, [Xn, #imm_bytes]` (unsigned scaled; `imm_bytes` multiple of 8).
-    LdrUimm { rt: u8, rn: u8, imm_bytes: u16 },
+    LdrUimm {
+        rt: u8,
+        rn: u8,
+        imm_bytes: u16,
+    },
     /// `STP Xt, Xt2, [Xn, #imm_bytes]` (signed scaled; `imm_bytes` multiple of 8).
     Stp {
         rt: u8,
@@ -657,6 +745,10 @@ impl Insn {
             Insn::Adrp { rd, page_off } => pcrel_imm21(Opcode::Adrp, rd, page_off),
             Insn::LdrLiteral { rt, off } => pcrel_imm19(Opcode::LdrLiteral, off, u32::from(rt)),
             Insn::Br(rn) => Some(Opcode::Br.bits() | (u32::from(rn) << RN_SHIFT)),
+            Insn::Movz { rd, imm16 } => {
+                Some(Opcode::Movz.bits() | (u32::from(imm16) << RN_SHIFT) | u32::from(rd))
+            }
+            Insn::Nop => Some(NOP),
             Insn::SubSp(imm12) => data_imm12(Opcode::SubImm, SP, SP, imm12),
             Insn::AddSp(imm12) => data_imm12(Opcode::AddImm, SP, SP, imm12),
             Insn::AddImm { rd, rn, imm12 } => data_imm12(Opcode::AddImm, rd, rn, imm12),
@@ -2096,6 +2188,15 @@ impl Asm {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn rt_sigreturn_trampoline_uses_the_svc_gate_frame_abi() {
+        let callback = 0x1122_3344_5566_7788usize;
+        let code = emit_rt_sigreturn_trampoline(callback).unwrap();
+
+        assert_eq!(&code[code.len() - 8..], &callback.to_ne_bytes());
+        assert_eq!(code.len(), 48);
+    }
     use alloc::vec;
 
     // The emitters append each gate at `trampoline_data.len()`, so these sizes

--- a/litebox_syscall_rewriter/src/lib.rs
+++ b/litebox_syscall_rewriter/src/lib.rs
@@ -20,7 +20,7 @@
 //! (`MSR TPIDR_EL0` writes and `MRS TPIDR_EL0` reads): the host owns the hardware `TPIDR_EL0`
 //! anchor and the guest thread pointer is fully virtualized to a host-managed memory slot. This
 //! thread-pointer virtualization is Linux-host-specific; other hosts (Linux-on-Windows,
-//! Linux-on-macOS) must anchor and virtualize TLS differently. See the `arm64` module for details.
+//! Linux-on-macOS) must anchor and virtualize TLS differently. See the `aarch64` module for details.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 extern crate alloc;
@@ -32,7 +32,30 @@ compile_error!(
     "litebox_syscall_rewriter's runtime patching entry points support only x86-64 and AArch64 hosts"
 );
 
-pub mod arm64;
+pub mod aarch64;
+
+/// Callback-slot bytes the caller must populate; zero when emitted inline.
+#[cfg(target_arch = "x86_64")]
+pub const TRAMPOLINE_ENTRY_POINT_BYTES: usize = size_of::<u64>();
+#[cfg(target_arch = "aarch64")]
+pub const TRAMPOLINE_ENTRY_POINT_BYTES: usize = 0;
+
+/// Furthest a trampoline may sit from any byte of the code segment reaching it.
+///
+/// A rewritten site branches to its stub with a single direct branch, so a
+/// trampoline beyond this displacement cannot be reached and the site has to
+/// fall back to a trap. Each architecture's value is its direct-branch range
+/// less a margin for the last stub in the trampoline.
+#[cfg(target_arch = "x86_64")]
+pub const MAX_TRAMPOLINE_DISPLACEMENT: usize = 0x7FFF_0000;
+#[cfg(target_arch = "aarch64")]
+pub const MAX_TRAMPOLINE_DISPLACEMENT: usize = 0x07FF_0000;
+
+/// Alignment every write cursor into a trampoline must satisfy.
+#[cfg(target_arch = "x86_64")]
+pub const TRAMPOLINE_CURSOR_ALIGN: usize = 1;
+#[cfg(target_arch = "aarch64")]
+pub const TRAMPOLINE_CURSOR_ALIGN: usize = aarch64::GATE_ALIGNMENT;
 
 use alloc::collections::{BTreeMap, BTreeSet};
 use alloc::format;
@@ -172,10 +195,10 @@ const NT_SYSNO_REWRITE_LOOKBACK: usize = 16;
 /// loader can distinguish "processed, nothing to patch" from "never processed";
 /// no instructions are rewritten in that case.
 ///
-/// AArch64 differs in one way: it also rewrites guest thread-pointer accesses
+/// For patch-site discovery, AArch64 also rewrites guest thread-pointer accesses
 /// (`MSR TPIDR_EL0` writes and `MRS TPIDR_EL0` reads), so a binary containing one
 /// is patched (and gets a non-empty trampoline) even when it has no syscall
-/// (`SVC`) instructions at all. (See the `arm64` module docs.)
+/// (`SVC`) instructions at all. (See the `aarch64` module docs.)
 ///
 /// Returns the rewritten binary. Binaries that cannot or do not need to be
 /// patched (relocatable objects, non-ELF files, already-hooked binaries,
@@ -271,7 +294,7 @@ pub fn hook_syscalls_in_elf(input_binary: &[u8], trampoline: Option<u64>) -> Res
     // AArch64 uses a fully separate rewriting strategy (single-instruction
     // branch replacement, no instruction borrowing). Dispatch to it before any
     // x86-only work (iced-x86 decoding would misinterpret AArch64 bytes).
-    // See the `arm64` module docs.
+    // See the `aarch64` module docs.
     if arch == Arch::Aarch64 {
         return hook_aarch64_elf(
             input_binary,
@@ -865,12 +888,12 @@ fn hook_aarch64_elf_at(
     trampoline_limit: Option<u64>,
     callback: u64,
 ) -> Result<Vec<u8>> {
-    let Some(outcome) = arm64::hook_syscalls_aarch64(
+    let Some(outcome) = aarch64::hook_syscalls_aarch64(
         buf,
         text_sections,
         trampoline_base_addr,
         callback,
-        arm64::Host::Linux,
+        aarch64::Host::Linux,
     )?
     else {
         // No patch sites: emit the original binary with a size-0 sentinel
@@ -1455,8 +1478,16 @@ fn rel32_bytes(target: u64, base: u64, context: &'static str) -> Result<[u8; 4]>
 /// already-mapped code region. The caller makes the region writable before
 /// calling and restores permissions afterwards.
 ///
-/// The region is rewritten for the architecture this crate is running on, and
-/// `syscall_entry_addr` is interpreted per that architecture's stub ABI.
+/// The region is rewritten for the architecture this crate is running on.
+/// `syscall_entry_addr` means:
+/// * x86-64: the address of the shared [`TRAMPOLINE_ENTRY_POINT_BYTES`]-sized
+///   slot the caller placed at the trampoline base, which holds the callback.
+/// * AArch64: the callback address itself; the emitter writes its callback slot.
+///
+/// TODO: give both architectures the same meaning -- always the callback
+/// address -- once the x86-64 stubs branch directly rather than through the
+/// slot. Drop this list when `TRAMPOLINE_ENTRY_POINT_BYTES` is zero on every
+/// supported architecture.
 ///
 /// # Returns
 ///
@@ -1469,9 +1500,8 @@ fn rel32_bytes(target: u64, base: u64, context: &'static str) -> Result<[u8; 4]>
 ///
 /// The I-cache is not coherent with the D-cache, so the caller **must**
 /// synchronize the instruction stream over the patched `code` and the written
-/// stubs before either is fetched, and must patch the emitted gates' guest
-/// thread-pointer placeholder. Neither omission fails cleanly. See the
-/// [`arm64`] module docs. x86-64 needs neither.
+/// stubs before either is fetched, and must pass the emitted gates through
+/// [`aarch64::finalize_trampoline_gates`]. Neither omission fails cleanly.
 pub fn patch_code_segment(
     code: &mut [u8],
     code_vaddr: u64,
@@ -1530,11 +1560,8 @@ fn patch_x86_64_code_segment(
 /// [`patch_code_segment`] for an AArch64 host, where `syscall_entry_addr` is
 /// the callback address itself, not a slot holding it.
 ///
-/// The gates are identical to the ahead-of-time path's and carry the same guest
-/// thread-pointer placeholder, so the caller must run
-/// [`arm64::patch_guest_tpidr_offset`] over the returned stubs and prove with
-/// [`arm64::find_guest_tpidr_placeholder`] that none survives before writing
-/// them anywhere the guest can execute.
+/// The caller must pass the returned gates through
+/// [`aarch64::finalize_trampoline_gates`] before making them executable.
 #[cfg(any(test, target_arch = "aarch64"))]
 fn patch_aarch64_code_segment(
     code: &mut [u8],
@@ -1547,12 +1574,12 @@ fn patch_aarch64_code_segment(
         file_offset: 0,
         size: code.len() as u64,
     };
-    let Some(outcome) = arm64::hook_syscalls_aarch64(
+    let Some(outcome) = aarch64::hook_syscalls_aarch64(
         code,
         &[section],
         trampoline_write_vaddr,
         syscall_entry_addr,
-        arm64::Host::Linux,
+        aarch64::Host::Linux,
     )?
     else {
         return Ok((Vec::new(), Vec::new()));
@@ -1608,7 +1635,7 @@ fn trap_all_aarch64_patch_sites(code: &mut [u8], code_vaddr: u64) -> Result<usiz
         file_offset: 0,
         size: code.len() as u64,
     };
-    arm64::trap_all_patch_sites(code, &[section])
+    aarch64::trap_all_patch_sites(code, &[section])
 }
 
 /// The guest page size assumed when laying out the appended trampoline.
@@ -1618,9 +1645,9 @@ pub(crate) const TRAMPOLINE_PAGE_SIZE: u64 = 0x1000;
 /// goes. `max_load_end` is the highest `p_vaddr + p_memsz`, `max_align` the
 /// largest `p_align`.
 ///
-/// AArch64 objects skip one further `max_align`, because the guest loader
-/// reserves `maplength + p_align` and trims the tail. Every other architecture
-/// keeps the page-granular rule, so its placement cannot move.
+/// For AArch64 objects, where large `p_align` is common, this implementation
+/// skips one further alignment unit. Other architectures retain the existing
+/// page-granular placement.
 ///
 /// **Nothing reserves the returned address**, and glibc packs objects
 /// adjacently, so with several shared objects there may be no free gap here at
@@ -1629,8 +1656,6 @@ pub(crate) const TRAMPOLINE_PAGE_SIZE: u64 = 0x1000;
 /// first (`litebox_shim_linux`'s `trampoline_range_is_safe_to_map`).
 pub fn trampoline_addr_for(max_load_end: u64, max_align: u64, e_machine: u16) -> Result<u64> {
     // Guard against a bogus `p_align`: the masking below requires a power of two.
-    // Non-AArch64 objects keep the historical page-granular rule verbatim, so
-    // their placement cannot move.
     let align = if e_machine == object::elf::EM_AARCH64 && max_align.is_power_of_two() {
         max_align.max(TRAMPOLINE_PAGE_SIZE)
     } else {
@@ -1738,8 +1763,7 @@ pub(crate) fn trampoline_placement_for(
         addr: fallback_addr,
     };
 
-    // Only AArch64 objects are placed in a hole: changing x86-64 placement is
-    // held back, as on `trampoline_addr_for`.
+    // Compatibility gate: preserve past-last-segment placement off AArch64.
     if e_machine != object::elf::EM_AARCH64 {
         return Ok(fallback);
     }
@@ -2635,14 +2659,14 @@ mod tests {
             patch_aarch64_code_segment(&mut code, 0x1000, 0x2000, 0x3000).unwrap();
         assert!(trapped.is_empty());
         assert!(
-            arm64::find_guest_tpidr_placeholder(&trampoline).is_some(),
+            aarch64::find_guest_tpidr_placeholder(&trampoline).is_some(),
             "a runtime-emitted thread-pointer gate must arrive unpatched"
         );
         assert_eq!(
-            arm64::patch_guest_tpidr_offset(&mut trampoline, 96).unwrap(),
+            aarch64::patch_guest_tpidr_offset(&mut trampoline, 96).unwrap(),
             1
         );
-        assert!(arm64::find_guest_tpidr_placeholder(&trampoline).is_none());
+        assert!(aarch64::find_guest_tpidr_placeholder(&trampoline).is_none());
     }
 
     #[test]
@@ -2665,12 +2689,12 @@ mod tests {
             file_offset: 0,
             size: aot_code.len() as u64,
         };
-        let aot = arm64::hook_syscalls_aarch64(
+        let aot = aarch64::hook_syscalls_aarch64(
             &mut aot_code,
             &[section],
             trampoline_vaddr,
             0x1234,
-            arm64::Host::Linux,
+            aarch64::Host::Linux,
         )
         .unwrap()
         .unwrap();
@@ -2691,7 +2715,7 @@ mod tests {
             for (slot_offset, count) in boundaries {
                 for instruction in 0..count {
                     let pc = trampoline_vaddr + (slot_offset + instruction * 4) as u64;
-                    let gate = arm64::classify_gate_pc(product, trampoline_vaddr, pc)
+                    let gate = aarch64::classify_gate_pc(product, trampoline_vaddr, pc)
                         .unwrap_or_else(|| panic!("slot {slot_offset} boundary {instruction}"));
                     assert_eq!(gate.slot_offset(), slot_offset);
                     classified += 1;


### PR DESCRIPTION
This PR adds support for AArch64 to the Linux shim, including loading, syscalls, trampoline, and signal handling.