### PR TITLE
Retire broker platform sockets explicitly

### DIFF
--- a/litebox_broker_core/src/socket.rs
+++ b/litebox_broker_core/src/socket.rs
@@ -80,7 +80,8 @@ pub struct PlatformDatagramReceive {
 pub trait SocketProvider: Send + Sync {
     /// Creates one nonblocking socket resource for an authenticated session.
     ///
-    /// The returned socket must not retain authority beyond its `Arc` lifetime.
+    /// Any provider-retained clones must become inert when
+    /// [`PlatformSocket::retire`] is called.
     fn create(
         &self,
         session_id: SessionId,
@@ -95,8 +96,8 @@ pub trait SocketProvider: Send + Sync {
 /// One nonblocking socket resource created by [`SocketProvider`].
 ///
 /// The broker retains this resource in an `Arc`, allowing an operation already
-/// in flight to finish after its object handle closes. Dropping the final `Arc`
-/// releases the platform socket.
+/// in flight to finish after its object handle closes. Before releasing its
+/// portable authority, core explicitly retires the platform socket.
 pub trait PlatformSocket: Send + Sync {
     /// Binds this socket to a local address.
     fn bind(&self, address: SocketAddrV4) -> Result<SocketOutcome<SocketAddrV4>>;
@@ -178,6 +179,9 @@ pub trait PlatformSocket: Send + Sync {
     /// `Connected`, or `Failed`. Datagram sockets return `Unconnected` or
     /// `Connected` and may change between those states through peer updates.
     fn status(&self) -> Result<SocketStatusResponse>;
+
+    /// Synchronously and idempotently ends this socket's platform authority.
+    fn retire(&self);
 
     /// Returns the current readiness snapshot.
     fn readiness(&self) -> ReadinessFlags;
@@ -1105,6 +1109,9 @@ const fn is_udp(request: CreateSocketRequest) -> bool {
 
 impl Drop for SocketResource {
     fn drop(&mut self) {
+        if let Some(platform_socket) = self.platform_socket.get() {
+            platform_socket.retire();
+        }
         self.readiness.retire();
     }
 }
@@ -1183,7 +1190,10 @@ pub(crate) mod tests {
         listens: StdMutex<std::vec::Vec<u32>>,
         listen_block: StdMutex<Option<(mpsc::Sender<()>, mpsc::Receiver<()>)>>,
         shutdown_calls: AtomicUsize,
+        retired_sockets: AtomicUsize,
         dropped_sockets: AtomicUsize,
+        retained_platform_sockets: StdMutex<std::vec::Vec<Arc<TestPlatformSocket>>>,
+        retain_next_socket: core::sync::atomic::AtomicBool,
         fail_create: core::sync::atomic::AtomicBool,
         fail_connect: core::sync::atomic::AtomicBool,
         fail_connect_indeterminate: core::sync::atomic::AtomicBool,
@@ -1211,6 +1221,10 @@ pub(crate) mod tests {
         fn fail_next_shutdown(&self) {
             self.state.fail_shutdown.store(true, Ordering::Relaxed);
         }
+
+        fn retain_next_socket(&self) {
+            self.state.retain_next_socket.store(true, Ordering::Relaxed);
+        }
     }
 
     impl SocketProvider for TestSocketProvider {
@@ -1230,12 +1244,21 @@ pub(crate) mod tests {
                 return Err(BrokerError::OutOfMemory);
             }
             *self.state.live_readiness.lock().unwrap() = Some(readiness.clone());
-            Ok(Arc::new(TestPlatformSocket {
+            let socket = Arc::new(TestPlatformSocket {
                 state: Arc::clone(&self.state),
                 readiness,
                 create_request: request,
                 tcp_options: StdMutex::new(TestTcpOptions::default()),
-            }))
+                active: core::sync::atomic::AtomicBool::new(true),
+            });
+            if self.state.retain_next_socket.swap(false, Ordering::Relaxed) {
+                self.state
+                    .retained_platform_sockets
+                    .lock()
+                    .unwrap()
+                    .push(Arc::clone(&socket));
+            }
+            Ok(socket)
         }
 
         fn close_session(&self, session_id: SessionId) {
@@ -1248,6 +1271,7 @@ pub(crate) mod tests {
         readiness: ReadinessRegistration,
         create_request: CreateSocketRequest,
         tcp_options: StdMutex<TestTcpOptions>,
+        active: core::sync::atomic::AtomicBool,
     }
 
     #[derive(Default)]
@@ -1404,6 +1428,12 @@ pub(crate) mod tests {
             Ok(response)
         }
 
+        fn retire(&self) {
+            if self.active.swap(false, Ordering::AcqRel) {
+                self.state.retired_sockets.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+
         fn readiness(&self) -> ReadinessFlags {
             ReadinessFlags::READ | ReadinessFlags::WRITE
         }
@@ -1411,6 +1441,7 @@ pub(crate) mod tests {
 
     impl Drop for TestPlatformSocket {
         fn drop(&mut self) {
+            self.retire();
             self.state.dropped_sockets.fetch_add(1, Ordering::Relaxed);
         }
     }
@@ -1428,7 +1459,52 @@ pub(crate) mod tests {
         check_concurrent_status_preserves_terminal_state(broker, provider);
         check_failed_status_preserves_local_address(broker, provider);
         check_quota_waits_for_deferred_retirement(broker, provider);
+        check_platform_socket_retires_before_last_arc_drop(broker, provider);
         check_socket_quotas(broker);
+    }
+
+    fn check_platform_socket_retires_before_last_arc_drop(
+        broker: &BrokerCore,
+        provider: &TestSocketProvider,
+    ) {
+        let session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let retired_before = provider.state.retired_sockets.load(Ordering::Relaxed);
+        let dropped_before = provider.state.dropped_sockets.load(Ordering::Relaxed);
+
+        provider.retain_next_socket();
+        let handle = create(
+            &session,
+            create_request(),
+            Arc::new(TestReadinessSink::default()),
+        )
+        .unwrap();
+        session.close_object_reference(handle).unwrap();
+
+        assert_eq!(
+            provider.state.retired_sockets.load(Ordering::Relaxed),
+            retired_before + 1
+        );
+        assert_eq!(
+            provider.state.dropped_sockets.load(Ordering::Relaxed),
+            dropped_before
+        );
+
+        provider
+            .state
+            .retained_platform_sockets
+            .lock()
+            .unwrap()
+            .clear();
+        assert_eq!(
+            provider.state.retired_sockets.load(Ordering::Relaxed),
+            retired_before + 1
+        );
+        assert_eq!(
+            provider.state.dropped_sockets.load(Ordering::Relaxed),
+            dropped_before + 1
+        );
     }
 
     fn check_failed_create_rolls_back(broker: &BrokerCore, provider: &TestSocketProvider) {

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -891,6 +891,8 @@ mod tests {
             })
         }
 
+        fn retire(&self) {}
+
         fn readiness(&self) -> litebox_broker_protocol::readiness::ReadinessFlags {
             litebox_broker_protocol::readiness::ReadinessFlags::READ
                 | litebox_broker_protocol::readiness::ReadinessFlags::WRITE

--- a/litebox_broker_platform_linux_userland/src/socket.rs
+++ b/litebox_broker_platform_linux_userland/src/socket.rs
@@ -43,10 +43,27 @@ use litebox_broker_core::readiness::ReadinessRegistration;
 const WAKE_TOKEN: u64 = 0;
 const MAX_QUEUED_SOCKET_COMMANDS: usize = 64;
 const MAX_EPOLL_EVENTS: usize = 64;
-const SOCKET_PENDING: u8 = 0;
-const SOCKET_ACTIVE: u8 = 1;
-const SOCKET_RETIRING: u8 = 2;
-const SOCKET_RETIRED: u8 = 3;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+enum SocketLifecycleState {
+    Pending = 0,
+    Active = 1,
+    Retiring = 2,
+    Retired = 3,
+}
+
+impl SocketLifecycleState {
+    fn from_raw(value: u8) -> Self {
+        match value {
+            0 => Self::Pending,
+            1 => Self::Active,
+            2 => Self::Retiring,
+            3 => Self::Retired,
+            _ => unreachable!("invalid Linux socket lifecycle state"),
+        }
+    }
+}
 
 struct SocketLifecycle {
     state: AtomicU8,
@@ -55,15 +72,19 @@ struct SocketLifecycle {
 impl SocketLifecycle {
     fn pending() -> Self {
         Self {
-            state: AtomicU8::new(SOCKET_PENDING),
+            state: AtomicU8::new(SocketLifecycleState::Pending as u8),
         }
+    }
+
+    fn load(&self) -> SocketLifecycleState {
+        SocketLifecycleState::from_raw(self.state.load(Ordering::Acquire))
     }
 
     fn activate(&self) -> bool {
         self.state
             .compare_exchange(
-                SOCKET_PENDING,
-                SOCKET_ACTIVE,
+                SocketLifecycleState::Pending as u8,
+                SocketLifecycleState::Active as u8,
                 Ordering::AcqRel,
                 Ordering::Acquire,
             )
@@ -73,13 +94,13 @@ impl SocketLifecycle {
     fn retire(&self, close: impl FnOnce()) {
         let mut close = Some(close);
         loop {
-            match self.state.load(Ordering::Acquire) {
-                SOCKET_PENDING => {
+            match self.load() {
+                SocketLifecycleState::Pending => {
                     if self
                         .state
                         .compare_exchange(
-                            SOCKET_PENDING,
-                            SOCKET_RETIRED,
+                            SocketLifecycleState::Pending as u8,
+                            SocketLifecycleState::Retired as u8,
                             Ordering::AcqRel,
                             Ordering::Acquire,
                         )
@@ -88,36 +109,37 @@ impl SocketLifecycle {
                         return;
                     }
                 }
-                SOCKET_ACTIVE => {
+                SocketLifecycleState::Active => {
                     if self
                         .state
                         .compare_exchange(
-                            SOCKET_ACTIVE,
-                            SOCKET_RETIRING,
+                            SocketLifecycleState::Active as u8,
+                            SocketLifecycleState::Retiring as u8,
                             Ordering::AcqRel,
                             Ordering::Acquire,
                         )
                         .is_ok()
                     {
                         close.take().expect("socket close action missing")();
-                        self.state.store(SOCKET_RETIRED, Ordering::Release);
+                        self.state
+                            .store(SocketLifecycleState::Retired as u8, Ordering::Release);
                         return;
                     }
                 }
-                SOCKET_RETIRING => {
-                    while self.state.load(Ordering::Acquire) != SOCKET_RETIRED {
+                SocketLifecycleState::Retiring => {
+                    while self.load() != SocketLifecycleState::Retired {
                         thread::yield_now();
                     }
                     return;
                 }
-                SOCKET_RETIRED => return,
-                _ => unreachable!("invalid Linux socket lifecycle state"),
+                SocketLifecycleState::Retired => return,
             }
         }
     }
 
     fn reactor_removed(&self) {
-        self.state.store(SOCKET_RETIRED, Ordering::Release);
+        self.state
+            .store(SocketLifecycleState::Retired as u8, Ordering::Release);
     }
 }
 
@@ -2143,7 +2165,7 @@ mod tests {
         let lifecycle = SocketLifecycle::pending();
         lifecycle.retire(|| panic!("pending sockets have no reactor resource to close"));
         assert!(!lifecycle.activate());
-        assert_eq!(lifecycle.state.load(Ordering::Acquire), SOCKET_RETIRED);
+        assert_eq!(lifecycle.load(), SocketLifecycleState::Retired);
     }
 
     #[test]
@@ -2180,7 +2202,7 @@ mod tests {
         first.join().unwrap();
         second_finished_receive.recv_timeout(TEST_TIMEOUT).unwrap();
         second.join().unwrap();
-        assert_eq!(lifecycle.state.load(Ordering::Acquire), SOCKET_RETIRED);
+        assert_eq!(lifecycle.load(), SocketLifecycleState::Retired);
     }
 
     fn send_bytes(

--- a/litebox_broker_platform_linux_userland/src/socket.rs
+++ b/litebox_broker_platform_linux_userland/src/socket.rs
@@ -275,6 +275,12 @@ impl PlatformSocket for LinuxSocket {
         })
     }
 
+    fn retire(&self) {
+        if self.active.swap(false, Ordering::AcqRel) {
+            self.reactor.close_socket(self.id);
+        }
+    }
+
     fn readiness(&self) -> ReadinessFlags {
         self.snapshot
             .lock()
@@ -285,9 +291,7 @@ impl PlatformSocket for LinuxSocket {
 
 impl Drop for LinuxSocket {
     fn drop(&mut self) {
-        if self.active.swap(false, Ordering::AcqRel) {
-            self.reactor.close_socket(self.id);
-        }
+        self.retire();
     }
 }
 

--- a/litebox_broker_platform_linux_userland/src/socket.rs
+++ b/litebox_broker_platform_linux_userland/src/socket.rs
@@ -9,7 +9,7 @@ use std::io::{Error, ErrorKind, Result as IoResult};
 use std::mem::size_of;
 use std::net::SocketAddrV4;
 use std::os::fd::OwnedFd;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering};
 use std::sync::mpsc::{Receiver, SyncSender, TryRecvError, TrySendError, sync_channel};
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
@@ -43,6 +43,9 @@ use litebox_broker_core::readiness::ReadinessRegistration;
 const WAKE_TOKEN: u64 = 0;
 const MAX_QUEUED_SOCKET_COMMANDS: usize = 64;
 const MAX_EPOLL_EVENTS: usize = 64;
+const RETIREMENT_ACTIVE: u8 = 0;
+const RETIREMENT_IN_PROGRESS: u8 = 1;
+const RETIREMENT_COMPLETE: u8 = 2;
 
 /// Linux-userland socket provider.
 ///
@@ -83,7 +86,7 @@ impl SocketProvider for LinuxSocketProvider {
             reactor: Arc::clone(&self.reactor),
             snapshot: Arc::clone(&snapshot),
             active: Arc::clone(&active),
-            retirement: Mutex::new(()),
+            retirement: AtomicU8::new(RETIREMENT_ACTIVE),
         });
         self.reactor.request(|response| ReactorCommand::Create {
             id,
@@ -108,16 +111,7 @@ struct LinuxSocket {
     reactor: Arc<ReactorClient>,
     snapshot: Arc<Mutex<SocketSnapshot>>,
     active: Arc<AtomicBool>,
-    retirement: Mutex<()>,
-}
-
-fn retire_socket(active: &AtomicBool, retirement: &Mutex<()>, close: impl FnOnce()) {
-    let _retirement = retirement
-        .lock()
-        .expect("Linux socket retirement mutex poisoned");
-    if active.swap(false, Ordering::AcqRel) {
-        close();
-    }
+    retirement: AtomicU8,
 }
 
 impl PlatformSocket for LinuxSocket {
@@ -149,7 +143,7 @@ impl PlatformSocket for LinuxSocket {
             reactor: Arc::clone(&self.reactor),
             snapshot: Arc::clone(&snapshot),
             active: Arc::clone(&active),
-            retirement: Mutex::new(()),
+            retirement: AtomicU8::new(RETIREMENT_ACTIVE),
         });
         match self.reactor.request(|response| ReactorCommand::Accept {
             listener_id: self.id,
@@ -288,9 +282,27 @@ impl PlatformSocket for LinuxSocket {
     }
 
     fn retire(&self) {
-        retire_socket(&self.active, &self.retirement, || {
-            self.reactor.close_socket(self.id);
-        });
+        match self.retirement.compare_exchange(
+            RETIREMENT_ACTIVE,
+            RETIREMENT_IN_PROGRESS,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        ) {
+            Ok(_) => {
+                if self.active.swap(false, Ordering::AcqRel) {
+                    self.reactor.close_socket(self.id);
+                }
+                self.retirement
+                    .store(RETIREMENT_COMPLETE, Ordering::Release);
+            }
+            Err(RETIREMENT_IN_PROGRESS) => {
+                while self.retirement.load(Ordering::Acquire) != RETIREMENT_COMPLETE {
+                    thread::yield_now();
+                }
+            }
+            Err(RETIREMENT_COMPLETE) => {}
+            Err(_) => unreachable!("invalid Linux socket retirement state"),
+        }
     }
 
     fn readiness(&self) -> ReadinessFlags {
@@ -2063,46 +2075,6 @@ mod tests {
         received: usize,
         datagram_length: usize,
         source_address: SocketAddrV4,
-    }
-
-    #[test]
-    fn concurrent_retirement_waits_for_close_acknowledgement() {
-        let active = Arc::new(AtomicBool::new(true));
-        let retirement = Arc::new(Mutex::new(()));
-        let (close_started, close_started_receive) = sync_channel(1);
-        let (release_close, release_close_receive) = sync_channel(1);
-        let first_active = Arc::clone(&active);
-        let first_retirement = Arc::clone(&retirement);
-        let first = thread::spawn(move || {
-            retire_socket(&first_active, &first_retirement, || {
-                close_started.send(()).unwrap();
-                release_close_receive.recv_timeout(TEST_TIMEOUT).unwrap();
-            });
-        });
-        close_started_receive.recv_timeout(TEST_TIMEOUT).unwrap();
-
-        let (second_started, second_started_receive) = sync_channel(1);
-        let (second_finished, second_finished_receive) = sync_channel(1);
-        let second_active = Arc::clone(&active);
-        let second_retirement = Arc::clone(&retirement);
-        let second = thread::spawn(move || {
-            second_started.send(()).unwrap();
-            retire_socket(&second_active, &second_retirement, || {
-                panic!("only the first retirement may close the socket");
-            });
-            second_finished.send(()).unwrap();
-        });
-        second_started_receive.recv_timeout(TEST_TIMEOUT).unwrap();
-        assert!(
-            second_finished_receive
-                .recv_timeout(Duration::from_millis(100))
-                .is_err()
-        );
-
-        release_close.send(()).unwrap();
-        first.join().unwrap();
-        second_finished_receive.recv_timeout(TEST_TIMEOUT).unwrap();
-        second.join().unwrap();
     }
 
     fn send_bytes(

--- a/litebox_broker_platform_linux_userland/src/socket.rs
+++ b/litebox_broker_platform_linux_userland/src/socket.rs
@@ -83,6 +83,7 @@ impl SocketProvider for LinuxSocketProvider {
             reactor: Arc::clone(&self.reactor),
             snapshot: Arc::clone(&snapshot),
             active: Arc::clone(&active),
+            retirement: Mutex::new(()),
         });
         self.reactor.request(|response| ReactorCommand::Create {
             id,
@@ -107,6 +108,16 @@ struct LinuxSocket {
     reactor: Arc<ReactorClient>,
     snapshot: Arc<Mutex<SocketSnapshot>>,
     active: Arc<AtomicBool>,
+    retirement: Mutex<()>,
+}
+
+fn retire_socket(active: &AtomicBool, retirement: &Mutex<()>, close: impl FnOnce()) {
+    let _retirement = retirement
+        .lock()
+        .expect("Linux socket retirement mutex poisoned");
+    if active.swap(false, Ordering::AcqRel) {
+        close();
+    }
 }
 
 impl PlatformSocket for LinuxSocket {
@@ -138,6 +149,7 @@ impl PlatformSocket for LinuxSocket {
             reactor: Arc::clone(&self.reactor),
             snapshot: Arc::clone(&snapshot),
             active: Arc::clone(&active),
+            retirement: Mutex::new(()),
         });
         match self.reactor.request(|response| ReactorCommand::Accept {
             listener_id: self.id,
@@ -276,9 +288,9 @@ impl PlatformSocket for LinuxSocket {
     }
 
     fn retire(&self) {
-        if self.active.swap(false, Ordering::AcqRel) {
+        retire_socket(&self.active, &self.retirement, || {
             self.reactor.close_socket(self.id);
-        }
+        });
     }
 
     fn readiness(&self) -> ReadinessFlags {
@@ -2051,6 +2063,46 @@ mod tests {
         received: usize,
         datagram_length: usize,
         source_address: SocketAddrV4,
+    }
+
+    #[test]
+    fn concurrent_retirement_waits_for_close_acknowledgement() {
+        let active = Arc::new(AtomicBool::new(true));
+        let retirement = Arc::new(Mutex::new(()));
+        let (close_started, close_started_receive) = sync_channel(1);
+        let (release_close, release_close_receive) = sync_channel(1);
+        let first_active = Arc::clone(&active);
+        let first_retirement = Arc::clone(&retirement);
+        let first = thread::spawn(move || {
+            retire_socket(&first_active, &first_retirement, || {
+                close_started.send(()).unwrap();
+                release_close_receive.recv_timeout(TEST_TIMEOUT).unwrap();
+            });
+        });
+        close_started_receive.recv_timeout(TEST_TIMEOUT).unwrap();
+
+        let (second_started, second_started_receive) = sync_channel(1);
+        let (second_finished, second_finished_receive) = sync_channel(1);
+        let second_active = Arc::clone(&active);
+        let second_retirement = Arc::clone(&retirement);
+        let second = thread::spawn(move || {
+            second_started.send(()).unwrap();
+            retire_socket(&second_active, &second_retirement, || {
+                panic!("only the first retirement may close the socket");
+            });
+            second_finished.send(()).unwrap();
+        });
+        second_started_receive.recv_timeout(TEST_TIMEOUT).unwrap();
+        assert!(
+            second_finished_receive
+                .recv_timeout(Duration::from_millis(100))
+                .is_err()
+        );
+
+        release_close.send(()).unwrap();
+        first.join().unwrap();
+        second_finished_receive.recv_timeout(TEST_TIMEOUT).unwrap();
+        second.join().unwrap();
     }
 
     fn send_bytes(

--- a/litebox_broker_platform_linux_userland/src/socket.rs
+++ b/litebox_broker_platform_linux_userland/src/socket.rs
@@ -9,7 +9,7 @@ use std::io::{Error, ErrorKind, Result as IoResult};
 use std::mem::size_of;
 use std::net::SocketAddrV4;
 use std::os::fd::OwnedFd;
-use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU8, AtomicU64, Ordering};
 use std::sync::mpsc::{Receiver, SyncSender, TryRecvError, TrySendError, sync_channel};
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
@@ -43,9 +43,83 @@ use litebox_broker_core::readiness::ReadinessRegistration;
 const WAKE_TOKEN: u64 = 0;
 const MAX_QUEUED_SOCKET_COMMANDS: usize = 64;
 const MAX_EPOLL_EVENTS: usize = 64;
-const RETIREMENT_ACTIVE: u8 = 0;
-const RETIREMENT_IN_PROGRESS: u8 = 1;
-const RETIREMENT_COMPLETE: u8 = 2;
+const SOCKET_PENDING: u8 = 0;
+const SOCKET_ACTIVE: u8 = 1;
+const SOCKET_RETIRING: u8 = 2;
+const SOCKET_RETIRED: u8 = 3;
+
+struct SocketLifecycle {
+    state: AtomicU8,
+}
+
+impl SocketLifecycle {
+    fn pending() -> Self {
+        Self {
+            state: AtomicU8::new(SOCKET_PENDING),
+        }
+    }
+
+    fn activate(&self) -> bool {
+        self.state
+            .compare_exchange(
+                SOCKET_PENDING,
+                SOCKET_ACTIVE,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_ok()
+    }
+
+    fn retire(&self, close: impl FnOnce()) {
+        let mut close = Some(close);
+        loop {
+            match self.state.load(Ordering::Acquire) {
+                SOCKET_PENDING => {
+                    if self
+                        .state
+                        .compare_exchange(
+                            SOCKET_PENDING,
+                            SOCKET_RETIRED,
+                            Ordering::AcqRel,
+                            Ordering::Acquire,
+                        )
+                        .is_ok()
+                    {
+                        return;
+                    }
+                }
+                SOCKET_ACTIVE => {
+                    if self
+                        .state
+                        .compare_exchange(
+                            SOCKET_ACTIVE,
+                            SOCKET_RETIRING,
+                            Ordering::AcqRel,
+                            Ordering::Acquire,
+                        )
+                        .is_ok()
+                    {
+                        close.take().expect("socket close action missing")();
+                        self.state.store(SOCKET_RETIRED, Ordering::Release);
+                        return;
+                    }
+                }
+                SOCKET_RETIRING => {
+                    while self.state.load(Ordering::Acquire) != SOCKET_RETIRED {
+                        thread::yield_now();
+                    }
+                    return;
+                }
+                SOCKET_RETIRED => return,
+                _ => unreachable!("invalid Linux socket lifecycle state"),
+            }
+        }
+    }
+
+    fn reactor_removed(&self) {
+        self.state.store(SOCKET_RETIRED, Ordering::Release);
+    }
+}
 
 /// Linux-userland socket provider.
 ///
@@ -78,22 +152,21 @@ impl SocketProvider for LinuxSocketProvider {
 
         let id = self.reactor.allocate_socket_id()?;
         let snapshot = Arc::new(Mutex::new(SocketSnapshot::default()));
-        let active = Arc::new(AtomicBool::new(false));
+        let lifecycle = Arc::new(SocketLifecycle::pending());
         // Allocate the provider object before the reactor creates an external
         // resource, so successful creation has no remaining Arc allocation.
         let socket = Arc::new(LinuxSocket {
             id,
             reactor: Arc::clone(&self.reactor),
             snapshot: Arc::clone(&snapshot),
-            active: Arc::clone(&active),
-            retirement: AtomicU8::new(RETIREMENT_ACTIVE),
+            lifecycle: Arc::clone(&lifecycle),
         });
         self.reactor.request(|response| ReactorCommand::Create {
             id,
             request,
             readiness,
             snapshot,
-            active,
+            lifecycle,
             response,
         })?;
         Ok(socket)
@@ -110,8 +183,7 @@ struct LinuxSocket {
     id: u64,
     reactor: Arc<ReactorClient>,
     snapshot: Arc<Mutex<SocketSnapshot>>,
-    active: Arc<AtomicBool>,
-    retirement: AtomicU8,
+    lifecycle: Arc<SocketLifecycle>,
 }
 
 impl PlatformSocket for LinuxSocket {
@@ -137,20 +209,19 @@ impl PlatformSocket for LinuxSocket {
     ) -> BrokerResult<SocketOutcome<AcceptedPlatformSocket>> {
         let id = self.reactor.allocate_socket_id()?;
         let snapshot = Arc::new(Mutex::new(SocketSnapshot::default()));
-        let active = Arc::new(AtomicBool::new(false));
+        let lifecycle = Arc::new(SocketLifecycle::pending());
         let socket = Arc::new(LinuxSocket {
             id,
             reactor: Arc::clone(&self.reactor),
             snapshot: Arc::clone(&snapshot),
-            active: Arc::clone(&active),
-            retirement: AtomicU8::new(RETIREMENT_ACTIVE),
+            lifecycle: Arc::clone(&lifecycle),
         });
         match self.reactor.request(|response| ReactorCommand::Accept {
             listener_id: self.id,
             accepted_id: id,
             readiness,
             snapshot,
-            active,
+            lifecycle,
             response,
         })? {
             SocketOutcome::Completed(accepted) => {
@@ -282,27 +353,7 @@ impl PlatformSocket for LinuxSocket {
     }
 
     fn retire(&self) {
-        match self.retirement.compare_exchange(
-            RETIREMENT_ACTIVE,
-            RETIREMENT_IN_PROGRESS,
-            Ordering::AcqRel,
-            Ordering::Acquire,
-        ) {
-            Ok(_) => {
-                if self.active.swap(false, Ordering::AcqRel) {
-                    self.reactor.close_socket(self.id);
-                }
-                self.retirement
-                    .store(RETIREMENT_COMPLETE, Ordering::Release);
-            }
-            Err(RETIREMENT_IN_PROGRESS) => {
-                while self.retirement.load(Ordering::Acquire) != RETIREMENT_COMPLETE {
-                    thread::yield_now();
-                }
-            }
-            Err(RETIREMENT_COMPLETE) => {}
-            Err(_) => unreachable!("invalid Linux socket retirement state"),
-        }
+        self.lifecycle.retire(|| self.reactor.close_socket(self.id));
     }
 
     fn readiness(&self) -> ReadinessFlags {
@@ -510,7 +561,7 @@ enum ReactorCommand {
         request: CreateSocketRequest,
         readiness: ReadinessRegistration,
         snapshot: Arc<Mutex<SocketSnapshot>>,
-        active: Arc<AtomicBool>,
+        lifecycle: Arc<SocketLifecycle>,
         response: SyncSender<BrokerResult<()>>,
     },
     Connect {
@@ -533,7 +584,7 @@ enum ReactorCommand {
         accepted_id: u64,
         readiness: ReadinessRegistration,
         snapshot: Arc<Mutex<SocketSnapshot>>,
-        active: Arc<AtomicBool>,
+        lifecycle: Arc<SocketLifecycle>,
         response: SyncSender<BrokerResult<SocketOutcome<AcceptedEndpoints>>>,
     },
     Send {
@@ -748,16 +799,14 @@ impl Reactor {
                     request,
                     readiness,
                     snapshot,
-                    active,
+                    lifecycle,
                     response,
                 } => {
-                    let outcome = self.create_socket(id, request, readiness, snapshot);
+                    let outcome = self.create_socket(id, request, readiness, snapshot, &lifecycle);
                     let created = outcome.is_ok();
-                    if created {
-                        active.store(true, Ordering::Release);
-                    }
                     if response.send(outcome).is_err() && created {
                         self.sockets.remove(&id);
+                        lifecycle.reactor_removed();
                     }
                 }
                 ReactorCommand::Connect {
@@ -802,19 +851,23 @@ impl Reactor {
                     accepted_id,
                     readiness,
                     snapshot,
-                    active,
+                    lifecycle,
                     response,
                 } => {
-                    let outcome = self.accept_socket(listener_id, accepted_id, readiness, snapshot);
+                    let outcome = self.accept_socket(
+                        listener_id,
+                        accepted_id,
+                        readiness,
+                        snapshot,
+                        &lifecycle,
+                    );
                     let accepted = matches!(
                         &outcome,
                         Ok(SocketOutcome::Completed(AcceptedEndpoints { .. }))
                     );
-                    if accepted {
-                        active.store(true, Ordering::Release);
-                    }
                     if response.send(outcome).is_err() && accepted {
                         self.sockets.remove(&accepted_id);
+                        lifecycle.reactor_removed();
                     }
                 }
                 ReactorCommand::Send { id, data, response } => {
@@ -943,6 +996,7 @@ impl Reactor {
         request: CreateSocketRequest,
         readiness: ReadinessRegistration,
         snapshot: Arc<Mutex<SocketSnapshot>>,
+        lifecycle: &SocketLifecycle,
     ) -> BrokerResult<()> {
         if self.sockets.len() >= self.max_sockets {
             return Err(BrokerError::ResourceExhausted);
@@ -986,6 +1040,9 @@ impl Reactor {
                 .readiness = initial_readiness;
             readiness.publish(initial_readiness)?;
         }
+        if !lifecycle.activate() {
+            return Err(BrokerError::Internal);
+        }
         self.sockets.insert(
             id,
             SocketEntry {
@@ -1008,6 +1065,7 @@ impl Reactor {
         accepted_id: u64,
         readiness: ReadinessRegistration,
         snapshot: Arc<Mutex<SocketSnapshot>>,
+        lifecycle: &SocketLifecycle,
     ) -> BrokerResult<SocketOutcome<AcceptedEndpoints>> {
         if self.sockets.len() >= self.max_sockets {
             return Err(BrokerError::ResourceExhausted);
@@ -1075,6 +1133,9 @@ impl Reactor {
             snapshot.readiness = ReadinessFlags::WRITE;
         }
         readiness.publish(ReadinessFlags::WRITE)?;
+        if !lifecycle.activate() {
+            return Err(BrokerError::Internal);
+        }
         self.sockets.insert(
             accepted_id,
             SocketEntry {
@@ -2075,6 +2136,51 @@ mod tests {
         received: usize,
         datagram_length: usize,
         source_address: SocketAddrV4,
+    }
+
+    #[test]
+    fn pending_socket_retirement_prevents_reactor_activation() {
+        let lifecycle = SocketLifecycle::pending();
+        lifecycle.retire(|| panic!("pending sockets have no reactor resource to close"));
+        assert!(!lifecycle.activate());
+        assert_eq!(lifecycle.state.load(Ordering::Acquire), SOCKET_RETIRED);
+    }
+
+    #[test]
+    fn concurrent_socket_retirement_waits_for_close_acknowledgement() {
+        let lifecycle = Arc::new(SocketLifecycle::pending());
+        assert!(lifecycle.activate());
+        let (close_started, close_started_receive) = sync_channel(1);
+        let (release_close, release_close_receive) = sync_channel(1);
+        let first_lifecycle = Arc::clone(&lifecycle);
+        let first = thread::spawn(move || {
+            first_lifecycle.retire(|| {
+                close_started.send(()).unwrap();
+                release_close_receive.recv_timeout(TEST_TIMEOUT).unwrap();
+            });
+        });
+        close_started_receive.recv_timeout(TEST_TIMEOUT).unwrap();
+
+        let (second_started, second_started_receive) = sync_channel(1);
+        let (second_finished, second_finished_receive) = sync_channel(1);
+        let second_lifecycle = Arc::clone(&lifecycle);
+        let second = thread::spawn(move || {
+            second_started.send(()).unwrap();
+            second_lifecycle.retire(|| panic!("only the active caller may close the socket"));
+            second_finished.send(()).unwrap();
+        });
+        second_started_receive.recv_timeout(TEST_TIMEOUT).unwrap();
+        assert!(
+            second_finished_receive
+                .recv_timeout(Duration::from_millis(100))
+                .is_err()
+        );
+
+        release_close.send(()).unwrap();
+        first.join().unwrap();
+        second_finished_receive.recv_timeout(TEST_TIMEOUT).unwrap();
+        second.join().unwrap();
+        assert_eq!(lifecycle.state.load(Ordering::Acquire), SOCKET_RETIRED);
     }
 
     fn send_bytes(


### PR DESCRIPTION
This PR adds an explicit synchronous, idempotent `PlatformSocket::retire` contract so broker core can end platform socket authority even when a provider retains another `Arc`. The Linux implementation uses one shared pending/active/retiring/retired lifecycle state to coordinate reactor activation, prevent retired sockets from being installed, close exactly once, and make concurrent callers wait for reactor acknowledgement.