### PR TITLE
Share broker transport coordination

### DIFF
--- a/litebox_broker_transport/src/control_ring.rs
+++ b/litebox_broker_transport/src/control_ring.rs
@@ -61,6 +61,38 @@ const PRODUCER_EPOCH_OFFSET: usize = 0;
 const CONSUMER_EPOCH_OFFSET: usize = 4;
 const CONSUMER_HEAD_OFFSET: usize = 8;
 
+/// Access model enforced by a concrete shared-memory mapping.
+///
+/// This keeps byte-copy memory from exposing typed control-ring operations and
+/// constrains control-ring accesses to the disjoint regions defined by its ABI.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MemoryAccessPolicy {
+    /// General shared memory supporting only byte copies.
+    Bytes,
+    /// Control-ring memory supporting its ABI-defined byte and word accesses.
+    ControlRing,
+}
+
+impl MemoryAccessPolicy {
+    /// Returns whether this policy permits a byte-copy range.
+    pub const fn permits_byte_range(self, offset: usize, length: usize) -> bool {
+        match self {
+            Self::Bytes => true,
+            Self::ControlRing => memory_permits_byte_range(offset, length),
+        }
+    }
+
+    /// Returns whether this policy permits a `u32` access at `offset`.
+    pub const fn permits_u32(self, offset: usize) -> bool {
+        matches!(self, Self::ControlRing) && memory_permits_u32(offset)
+    }
+
+    /// Returns whether this policy permits a `u64` access at `offset`.
+    pub const fn permits_u64(self, offset: usize) -> bool {
+        matches!(self, Self::ControlRing) && memory_permits_u64(offset)
+    }
+}
+
 /// Returns whether the control-ring ABI permits a byte-copy range.
 ///
 /// Concrete shared-memory implementations use this together with

--- a/litebox_broker_transport/src/lib.rs
+++ b/litebox_broker_transport/src/lib.rs
@@ -30,4 +30,6 @@ extern crate std;
 
 pub mod channel;
 pub mod control_ring;
+pub mod pending_calls;
+pub mod setup_frame;
 pub mod shared_memory;

--- a/litebox_broker_transport/src/pending_calls.rs
+++ b/litebox_broker_transport/src/pending_calls.rs
@@ -1,0 +1,215 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//! Portable pending-call coordination over caller-supplied synchronization.
+
+use alloc::collections::BTreeMap;
+use alloc::collections::btree_map::Entry;
+use alloc::sync::Arc;
+use core::ops::{Deref, DerefMut};
+
+use litebox_broker_protocol::RequestId;
+use litebox_broker_protocol::message::BrokerResponse;
+
+/// Maximum number of active calls waiting for broker responses.
+pub const MAX_PENDING_CALLS: usize = 64;
+
+/// A mutex usable by [`PendingCalls`].
+pub trait PendingCallsMutex<T> {
+    /// Guard granting access to the protected value.
+    type Guard<'a>: Deref<Target = T> + DerefMut
+    where
+        Self: 'a,
+        T: 'a;
+
+    /// Locks the mutex.
+    fn lock(&self) -> Self::Guard<'_>;
+}
+
+/// A condition variable paired with a [`PendingCallsMutex`].
+pub trait PendingCallsCondvar<T> {
+    /// Mutex type whose guard this condition variable waits on.
+    type Mutex: PendingCallsMutex<T>;
+
+    /// Atomically releases the guard and waits for a notification.
+    fn wait<'a>(
+        &self,
+        guard: <Self::Mutex as PendingCallsMutex<T>>::Guard<'a>,
+    ) -> <Self::Mutex as PendingCallsMutex<T>>::Guard<'a>
+    where
+        Self::Mutex: 'a,
+        T: 'a;
+
+    /// Wakes one waiter.
+    fn notify_one(&self);
+
+    /// Wakes all waiters.
+    fn notify_all(&self);
+}
+
+/// Supplies synchronization primitives for [`PendingCalls`].
+pub trait PendingCallsSync {
+    /// Mutex protecting a value of type `T`.
+    type Mutex<T>: PendingCallsMutex<T>;
+
+    /// Condition variable paired with [`Self::Mutex`].
+    type Condvar<T>: PendingCallsCondvar<T, Mutex = Self::Mutex<T>>;
+
+    /// Creates a mutex protecting `value`.
+    fn mutex<T>(value: T) -> Self::Mutex<T>;
+
+    /// Creates a condition variable.
+    fn condvar<T>() -> Self::Condvar<T>;
+}
+
+/// Failure from pending-call registry coordination.
+#[derive(Debug)]
+pub enum PendingCallsError<Error> {
+    /// The association had already failed.
+    AssociationFailed(Arc<Error>),
+    /// The guarded operation failed.
+    Operation(Error),
+    /// A request reused an active request identifier.
+    DuplicateRequestId,
+    /// A response did not identify an active request.
+    UnknownResponseId,
+}
+
+/// Concurrent registry of requests awaiting broker responses.
+pub struct PendingCalls<Sync: PendingCallsSync, Error> {
+    state: Sync::Mutex<PendingCallsState<Sync, Error>>,
+    capacity_available: Sync::Condvar<PendingCallsState<Sync, Error>>,
+}
+
+struct PendingCallsState<Sync: PendingCallsSync, Error> {
+    calls: BTreeMap<RequestId, Arc<PendingCall<Sync, Error>>>,
+    failure: Option<Arc<Error>>,
+}
+
+/// Completion state for one request awaiting a broker response.
+pub struct PendingCall<Sync: PendingCallsSync, Error> {
+    result: Sync::Mutex<Option<Result<BrokerResponse, Arc<Error>>>>,
+    result_ready: Sync::Condvar<Option<Result<BrokerResponse, Arc<Error>>>>,
+}
+
+impl<Sync: PendingCallsSync, Error> PendingCall<Sync, Error> {
+    fn new() -> Self {
+        Self {
+            result: Sync::mutex(None),
+            result_ready: Sync::condvar(),
+        }
+    }
+
+    fn resolve(&self, result: Result<BrokerResponse, Arc<Error>>) {
+        let mut stored = self.result.lock();
+        assert!(stored.is_none(), "broker pending call already resolved");
+        *stored = Some(result);
+        self.result_ready.notify_one();
+    }
+
+    /// Blocks until the broker responds or the association fails.
+    pub fn wait(&self) -> Result<BrokerResponse, Arc<Error>> {
+        let mut result = self.result.lock();
+        loop {
+            if let Some(result) = result.take() {
+                return result;
+            }
+            result = self.result_ready.wait(result);
+        }
+    }
+}
+
+impl<Sync: PendingCallsSync, Error> PendingCalls<Sync, Error> {
+    /// Creates an empty live pending-call registry.
+    pub fn new() -> Self {
+        Self {
+            state: Sync::mutex(PendingCallsState {
+                calls: BTreeMap::new(),
+                failure: None,
+            }),
+            capacity_available: Sync::condvar(),
+        }
+    }
+
+    /// Registers a request, blocking while the pending-call limit is full.
+    pub fn register(
+        &self,
+        request_id: RequestId,
+    ) -> Result<Arc<PendingCall<Sync, Error>>, PendingCallsError<Error>> {
+        let pending_call = Arc::new(PendingCall::new());
+        let mut state = self.state.lock();
+        while state.calls.len() == MAX_PENDING_CALLS && state.failure.is_none() {
+            state = self.capacity_available.wait(state);
+        }
+        if let Some(error) = state.failure.as_ref() {
+            return Err(PendingCallsError::AssociationFailed(Arc::clone(error)));
+        }
+        match state.calls.entry(request_id) {
+            Entry::Vacant(entry) => {
+                entry.insert(Arc::clone(&pending_call));
+            }
+            Entry::Occupied(_) => return Err(PendingCallsError::DuplicateRequestId),
+        }
+        Ok(pending_call)
+    }
+
+    /// Completes the pending call identified by `response`.
+    pub fn complete(&self, response: BrokerResponse) -> Result<(), PendingCallsError<Error>> {
+        let pending_call = {
+            let mut state = self.state.lock();
+            if let Some(error) = state.failure.as_ref() {
+                return Err(PendingCallsError::AssociationFailed(Arc::clone(error)));
+            }
+            let Some(pending_call) = state.calls.remove(&response.request_id) else {
+                return Err(PendingCallsError::UnknownResponseId);
+            };
+            self.capacity_available.notify_one();
+            pending_call
+        };
+        pending_call.resolve(Ok(response));
+        Ok(())
+    }
+
+    /// Records the first terminal failure and resolves every pending call.
+    ///
+    /// Returns whether this call recorded the first failure.
+    pub fn record_failure(&self, error: Arc<Error>) -> bool {
+        let pending_calls = {
+            let mut state = self.state.lock();
+            if state.failure.is_some() {
+                return false;
+            }
+            state.failure = Some(Arc::clone(&error));
+            let pending_calls = core::mem::take(&mut state.calls);
+            self.capacity_available.notify_all();
+            pending_calls
+        };
+        for pending_call in pending_calls.into_values() {
+            pending_call.resolve(Err(Arc::clone(&error)));
+        }
+        true
+    }
+
+    /// Returns the association's terminal failure, if one was recorded.
+    pub fn current_failure(&self) -> Option<Arc<Error>> {
+        self.state.lock().failure.as_ref().map(Arc::clone)
+    }
+
+    /// Runs an operation while excluding failure recording.
+    pub fn run_if_live<T>(
+        &self,
+        operation: impl FnOnce() -> Result<T, Error>,
+    ) -> Result<T, PendingCallsError<Error>> {
+        let state = self.state.lock();
+        if let Some(error) = state.failure.as_ref() {
+            return Err(PendingCallsError::AssociationFailed(Arc::clone(error)));
+        }
+        operation().map_err(PendingCallsError::Operation)
+    }
+}
+
+impl<Sync: PendingCallsSync, Error> Default for PendingCalls<Sync, Error> {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/litebox_broker_transport/src/setup_frame.rs
+++ b/litebox_broker_transport/src/setup_frame.rs
@@ -117,34 +117,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn partial_io_round_trips() {
-        let mut encoded = Vec::new();
-        write_setup_frame::<()>(
-            b"frame",
-            |bytes| {
-                let written = bytes.len().min(2);
-                encoded.extend_from_slice(&bytes[..written]);
-                Ok(written)
-            },
-            |()| false,
-        )
-        .unwrap();
-
-        let mut remaining = encoded.as_slice();
-        let decoded = read_setup_frame::<()>(
-            |buffer| {
-                let read = remaining.len().min(buffer.len()).min(1);
-                buffer[..read].copy_from_slice(&remaining[..read]);
-                remaining = &remaining[read..];
-                Ok(read)
-            },
-            |()| false,
-        )
-        .unwrap();
-        assert_eq!(decoded.as_deref(), Some(b"frame".as_slice()));
-    }
-
-    #[test]
     fn interruption_retries_remaining_prefix() {
         let encoded = [1, 0, 0, 0, 42];
         let mut call = 0;
@@ -181,22 +153,5 @@ mod tests {
         )
         .unwrap();
         assert_eq!(decoded.as_deref(), Some([42].as_slice()));
-    }
-
-    #[test]
-    fn rejects_invalid_boundaries_and_io_counts() {
-        assert_eq!(read_setup_frame::<()>(|_| Ok(0), |()| false), Ok(None));
-        assert_eq!(
-            write_setup_frame::<()>(b"", |_| Ok(0), |()| false),
-            Err(SetupFrameError::InvalidLength),
-        );
-        assert_eq!(
-            read_setup_frame::<()>(|buffer| Ok(buffer.len() + 1), |()| false),
-            Err(SetupFrameError::InvalidIoCount),
-        );
-        assert_eq!(
-            write_setup_frame::<()>(b"frame", |buffer| Ok(buffer.len() + 1), |()| false),
-            Err(SetupFrameError::InvalidIoCount),
-        );
     }
 }

--- a/litebox_broker_transport/src/setup_frame.rs
+++ b/litebox_broker_transport/src/setup_frame.rs
@@ -1,0 +1,202 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//! Portable length-prefixed setup framing.
+
+use alloc::vec;
+use alloc::vec::Vec;
+
+/// Largest setup frame accepted or produced by broker transports.
+pub const MAX_SETUP_FRAME_LEN: usize = 64 * 1024;
+
+/// Failure while reading or writing a setup frame.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SetupFrameError<Error> {
+    /// The concrete transport I/O operation failed.
+    Io(Error),
+    /// The peer closed after sending only part of the length prefix.
+    TruncatedLength,
+    /// The frame length was zero or exceeded [`MAX_SETUP_FRAME_LEN`].
+    InvalidLength,
+    /// The peer closed after sending only part of the frame body.
+    TruncatedFrame,
+    /// The concrete transport reported a zero-length write.
+    WriteZero,
+    /// The concrete transport reported more bytes than the supplied buffer.
+    InvalidIoCount,
+}
+
+/// Reads one length-prefixed setup frame through `read`.
+///
+/// Returns `Ok(None)` when the peer closes before starting a new frame. The
+/// callback must handle platform-specific deadlines. Errors selected by
+/// `is_interrupted` are retried without discarding partial frame progress.
+pub fn read_setup_frame<Error>(
+    mut read: impl FnMut(&mut [u8]) -> Result<usize, Error>,
+    mut is_interrupted: impl FnMut(&Error) -> bool,
+) -> Result<Option<Vec<u8>>, SetupFrameError<Error>> {
+    let mut length = [0; 4];
+    let mut completed = 0;
+    while completed < length.len() {
+        let remaining = length.len() - completed;
+        let read = match read(&mut length[completed..]) {
+            Ok(read) => read,
+            Err(error) if is_interrupted(&error) => continue,
+            Err(error) => return Err(SetupFrameError::Io(error)),
+        };
+        match read {
+            0 if completed == 0 => return Ok(None),
+            0 => return Err(SetupFrameError::TruncatedLength),
+            read if read > remaining => return Err(SetupFrameError::InvalidIoCount),
+            read => completed += read,
+        }
+    }
+
+    let length = u32::from_le_bytes(length) as usize;
+    if length == 0 || length > MAX_SETUP_FRAME_LEN {
+        return Err(SetupFrameError::InvalidLength);
+    }
+
+    let mut frame = vec![0; length];
+    let mut completed = 0;
+    while completed < frame.len() {
+        let remaining = frame.len() - completed;
+        let read = match read(&mut frame[completed..]) {
+            Ok(read) => read,
+            Err(error) if is_interrupted(&error) => continue,
+            Err(error) => return Err(SetupFrameError::Io(error)),
+        };
+        match read {
+            0 => return Err(SetupFrameError::TruncatedFrame),
+            read if read > remaining => return Err(SetupFrameError::InvalidIoCount),
+            read => completed += read,
+        }
+    }
+    Ok(Some(frame))
+}
+
+/// Writes one length-prefixed setup frame through `write`.
+///
+/// The callback must handle platform-specific deadlines. Errors selected by
+/// `is_interrupted` are retried without discarding partial frame progress.
+pub fn write_setup_frame<Error>(
+    frame: &[u8],
+    mut write: impl FnMut(&[u8]) -> Result<usize, Error>,
+    mut is_interrupted: impl FnMut(&Error) -> bool,
+) -> Result<(), SetupFrameError<Error>> {
+    if frame.is_empty() || frame.len() > MAX_SETUP_FRAME_LEN {
+        return Err(SetupFrameError::InvalidLength);
+    }
+    let length = u32::try_from(frame.len()).map_err(|_| SetupFrameError::InvalidLength)?;
+    write_all(&length.to_le_bytes(), &mut write, &mut is_interrupted)?;
+    write_all(frame, write, is_interrupted)
+}
+
+fn write_all<Error>(
+    mut bytes: &[u8],
+    mut write: impl FnMut(&[u8]) -> Result<usize, Error>,
+    mut is_interrupted: impl FnMut(&Error) -> bool,
+) -> Result<(), SetupFrameError<Error>> {
+    while !bytes.is_empty() {
+        let written = match write(bytes) {
+            Ok(written) => written,
+            Err(error) if is_interrupted(&error) => continue,
+            Err(error) => return Err(SetupFrameError::Io(error)),
+        };
+        match written {
+            0 => return Err(SetupFrameError::WriteZero),
+            written if written > bytes.len() => return Err(SetupFrameError::InvalidIoCount),
+            written => bytes = &bytes[written..],
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn partial_io_round_trips() {
+        let mut encoded = Vec::new();
+        write_setup_frame::<()>(
+            b"frame",
+            |bytes| {
+                let written = bytes.len().min(2);
+                encoded.extend_from_slice(&bytes[..written]);
+                Ok(written)
+            },
+            |()| false,
+        )
+        .unwrap();
+
+        let mut remaining = encoded.as_slice();
+        let decoded = read_setup_frame::<()>(
+            |buffer| {
+                let read = remaining.len().min(buffer.len()).min(1);
+                buffer[..read].copy_from_slice(&remaining[..read]);
+                remaining = &remaining[read..];
+                Ok(read)
+            },
+            |()| false,
+        )
+        .unwrap();
+        assert_eq!(decoded.as_deref(), Some(b"frame".as_slice()));
+    }
+
+    #[test]
+    fn interruption_retries_remaining_prefix() {
+        let encoded = [1, 0, 0, 0, 42];
+        let mut call = 0;
+        let mut remaining = encoded.as_slice();
+        let decoded = read_setup_frame(
+            |buffer| {
+                call += 1;
+                match call {
+                    1 => {
+                        assert_eq!(buffer.len(), 4);
+                        buffer[0] = remaining[0];
+                        remaining = &remaining[1..];
+                        Ok(1)
+                    }
+                    2 => {
+                        assert_eq!(buffer.len(), 3);
+                        Err(true)
+                    }
+                    3 => {
+                        assert_eq!(buffer.len(), 3);
+                        buffer.copy_from_slice(&remaining[..3]);
+                        remaining = &remaining[3..];
+                        Ok(3)
+                    }
+                    _ => {
+                        assert_eq!(buffer.len(), 1);
+                        buffer[0] = remaining[0];
+                        remaining = &remaining[1..];
+                        Ok(1)
+                    }
+                }
+            },
+            |error| *error,
+        )
+        .unwrap();
+        assert_eq!(decoded.as_deref(), Some([42].as_slice()));
+    }
+
+    #[test]
+    fn rejects_invalid_boundaries_and_io_counts() {
+        assert_eq!(read_setup_frame::<()>(|_| Ok(0), |()| false), Ok(None));
+        assert_eq!(
+            write_setup_frame::<()>(b"", |_| Ok(0), |()| false),
+            Err(SetupFrameError::InvalidLength),
+        );
+        assert_eq!(
+            read_setup_frame::<()>(|buffer| Ok(buffer.len() + 1), |()| false),
+            Err(SetupFrameError::InvalidIoCount),
+        );
+        assert_eq!(
+            write_setup_frame::<()>(b"frame", |buffer| Ok(buffer.len() + 1), |()| false),
+            Err(SetupFrameError::InvalidIoCount),
+        );
+    }
+}

--- a/litebox_broker_transport_linux_userland/src/lib.rs
+++ b/litebox_broker_transport_linux_userland/src/lib.rs
@@ -19,6 +19,7 @@
 
 #![cfg(target_os = "linux")]
 
+mod pending_calls;
 mod setup;
 
 pub mod memfd;

--- a/litebox_broker_transport_linux_userland/src/memfd.rs
+++ b/litebox_broker_transport_linux_userland/src/memfd.rs
@@ -30,10 +30,12 @@ use rustix::net::{
     SendAncillaryMessage, SendFlags,
 };
 
-use litebox_broker_protocol::shared_buffer::SHARED_BUFFER_POOL_SIZE;
 use litebox_broker_transport::control_ring::{
-    CONTROL_RING_MEMORY_SIZE, WaitableSharedMemory, memory_permits_byte_range, memory_permits_u32,
-    memory_permits_u64,
+    CONTROL_RING_MEMORY_SIZE, MemoryAccessPolicy, WaitableSharedMemory,
+};
+#[cfg(test)]
+use litebox_broker_transport::control_ring::{
+    memory_permits_byte_range, memory_permits_u32, memory_permits_u64,
 };
 use litebox_broker_transport::shared_memory::{ControlRingMemory, SharedMemory, SharedMemoryError};
 
@@ -44,8 +46,6 @@ use crate::unix_io::{
 const REQUIRED_MEMFD_SEALS: SealFlags = SealFlags::from_bits_retain(
     SealFlags::GROW.bits() | SealFlags::SHRINK.bits() | SealFlags::SEAL.bits(),
 );
-const _: () = assert!(SHARED_BUFFER_POOL_SIZE != CONTROL_RING_MEMORY_SIZE);
-
 /// Linux memfd-backed shared memory usable by broker transports.
 pub struct MemfdSharedMemory {
     fd: OwnedFd,
@@ -56,47 +56,6 @@ pub struct MemfdSharedMemory {
 struct MappedRegion {
     address: NonNull<u8>,
     length: usize,
-}
-
-/// Restricts each memfd to one non-overlapping portable access model.
-///
-/// Shared-buffer memfds permit only byte copies. Control-ring memfds permit
-/// byte and typed-word operations only at offsets defined by the ring ABI.
-#[derive(Clone, Copy)]
-enum MemoryAccessPolicy {
-    Bytes,
-    ControlRing,
-}
-
-impl MemoryAccessPolicy {
-    const fn for_length(length: usize) -> Self {
-        if length == CONTROL_RING_MEMORY_SIZE {
-            Self::ControlRing
-        } else {
-            Self::Bytes
-        }
-    }
-
-    const fn permits_byte_range(self, offset: usize, length: usize) -> bool {
-        match self {
-            Self::Bytes => true,
-            Self::ControlRing => memory_permits_byte_range(offset, length),
-        }
-    }
-
-    const fn permits_u32(self, offset: usize) -> bool {
-        match self {
-            Self::Bytes => false,
-            Self::ControlRing => memory_permits_u32(offset),
-        }
-    }
-
-    const fn permits_u64(self, offset: usize) -> bool {
-        match self {
-            Self::Bytes => false,
-            Self::ControlRing => memory_permits_u64(offset),
-        }
-    }
 }
 
 // SAFETY: Moving or sharing this owner does not move or invalidate its OS
@@ -282,8 +241,17 @@ fn futex_wake_one(address: *mut u32) -> IoResult<()> {
 }
 
 impl MemfdSharedMemory {
-    /// Creates and maps a sealed memfd with `length` bytes.
+    /// Creates and maps a sealed byte-copy memfd with `length` bytes.
     pub fn create(length: usize) -> IoResult<Self> {
+        Self::create_with_policy(length, MemoryAccessPolicy::Bytes)
+    }
+
+    /// Creates and maps a sealed memfd for one control ring.
+    pub fn create_control_ring() -> IoResult<Self> {
+        Self::create_with_policy(CONTROL_RING_MEMORY_SIZE, MemoryAccessPolicy::ControlRing)
+    }
+
+    fn create_with_policy(length: usize, policy: MemoryAccessPolicy) -> IoResult<Self> {
         if length == 0 {
             return Err(invalid_data("shared memory cannot be empty"));
         }
@@ -298,14 +266,31 @@ impl MemfdSharedMemory {
                 .map_err(|_| invalid_data("shared-memory length exceeds u64"))?,
         )?;
         fcntl_add_seals(&fd, REQUIRED_MEMFD_SEALS)?;
-        Self::map(fd, length)
+        Self::map(fd, length, policy)
     }
 
-    /// Validates and maps a received memfd with `expected_length` bytes.
+    /// Validates and maps a received byte-copy memfd with `expected_length` bytes.
     ///
     /// The descriptor must have the expected nonzero size sealed against
     /// changes.
     pub fn from_received_fd(fd: OwnedFd, expected_length: usize) -> IoResult<Self> {
+        Self::from_received_fd_with_policy(fd, expected_length, MemoryAccessPolicy::Bytes)
+    }
+
+    /// Validates and maps a received control-ring memfd.
+    pub fn control_ring_from_received_fd(fd: OwnedFd) -> IoResult<Self> {
+        Self::from_received_fd_with_policy(
+            fd,
+            CONTROL_RING_MEMORY_SIZE,
+            MemoryAccessPolicy::ControlRing,
+        )
+    }
+
+    fn from_received_fd_with_policy(
+        fd: OwnedFd,
+        expected_length: usize,
+        policy: MemoryAccessPolicy,
+    ) -> IoResult<Self> {
         if expected_length == 0 {
             return Err(invalid_data("shared memory cannot be empty"));
         }
@@ -322,10 +307,10 @@ impl MemfdSharedMemory {
                 "shared-memory length does not match expected size",
             ));
         }
-        Self::map(fd, length)
+        Self::map(fd, length, policy)
     }
 
-    fn map(fd: OwnedFd, length: usize) -> IoResult<Self> {
+    fn map(fd: OwnedFd, length: usize, policy: MemoryAccessPolicy) -> IoResult<Self> {
         if length > isize::MAX as usize {
             return Err(invalid_data(
                 "shared-memory length exceeds pointer offset range",
@@ -349,7 +334,7 @@ impl MemfdSharedMemory {
         Ok(Self {
             fd,
             mapping: MappedRegion { address, length },
-            policy: MemoryAccessPolicy::for_length(length),
+            policy,
         })
     }
 }
@@ -482,6 +467,15 @@ pub fn receive_memfd(
 ) -> IoResult<MemfdSharedMemory> {
     let fd = with_read_deadline(stream, deadline, receive_fd)?;
     MemfdSharedMemory::from_received_fd(fd, expected_length)
+}
+
+/// Receives, validates, and maps one control-ring memfd.
+pub fn receive_control_ring_memfd(
+    stream: &mut UnixStream,
+    deadline: Option<Instant>,
+) -> IoResult<MemfdSharedMemory> {
+    let fd = with_read_deadline(stream, deadline, receive_fd)?;
+    MemfdSharedMemory::control_ring_from_received_fd(fd)
 }
 
 fn send_fd(stream: &mut UnixStream, fd: BorrowedFd<'_>, deadline: Option<Instant>) -> IoResult<()> {
@@ -644,10 +638,9 @@ mod tests {
 
     #[test]
     fn mappings_enforce_control_ring_typed_access() {
-        let first = MemfdSharedMemory::create(CONTROL_RING_MEMORY_SIZE).unwrap();
-        let second = MemfdSharedMemory::from_received_fd(
+        let first = MemfdSharedMemory::create_control_ring().unwrap();
+        let second = MemfdSharedMemory::control_ring_from_received_fd(
             first.fd.as_fd().try_clone_to_owned().unwrap(),
-            CONTROL_RING_MEMORY_SIZE,
         )
         .unwrap();
         let sequence_offset = (0..CONTROL_RING_MEMORY_SIZE)
@@ -727,7 +720,7 @@ mod tests {
 
     #[test]
     fn futex_wait_returns_without_peer_cooperation() {
-        let memory = MemfdSharedMemory::create(CONTROL_RING_MEMORY_SIZE).unwrap();
+        let memory = MemfdSharedMemory::create_control_ring().unwrap();
         let epoch_offset = (0..CONTROL_RING_MEMORY_SIZE)
             .find(|offset| memory_permits_u32(*offset))
             .unwrap();
@@ -740,7 +733,7 @@ mod tests {
 
     #[test]
     fn peer_descriptor_writes_are_read_as_untrusted_snapshots() {
-        let memory = MemfdSharedMemory::create(CONTROL_RING_MEMORY_SIZE).unwrap();
+        let memory = MemfdSharedMemory::create_control_ring().unwrap();
         let peer_fd = memory.as_fd().try_clone_to_owned().unwrap();
         let sequence_offset = (0..CONTROL_RING_MEMORY_SIZE)
             .find(|offset| memory_permits_u64(*offset))
@@ -802,7 +795,7 @@ mod tests {
 
         let fd = memfd_create("litebox-broker-shm-test", MemfdFlags::CLOEXEC).unwrap();
         assert_eq!(
-            MemfdSharedMemory::map(fd, isize::MAX as usize + 1)
+            MemfdSharedMemory::map(fd, isize::MAX as usize + 1, MemoryAccessPolicy::Bytes,)
                 .err()
                 .expect("oversized mapping should fail")
                 .kind(),
@@ -840,12 +833,12 @@ mod tests {
 
     #[test]
     fn transfers_exact_sealed_control_ring_mapping() {
-        let memory = MemfdSharedMemory::create(CONTROL_RING_MEMORY_SIZE).unwrap();
+        let memory = MemfdSharedMemory::create_control_ring().unwrap();
         let ring = ControlRing::new(memory).unwrap();
         let (mut receiver, mut sender) = UnixStream::pair().unwrap();
 
         send_memfd(&mut sender, ring.memory(), None).unwrap();
-        let mapped = receive_memfd(&mut receiver, CONTROL_RING_MEMORY_SIZE, None).unwrap();
+        let mapped = receive_control_ring_memfd(&mut receiver, None).unwrap();
         let mapped_ring = ControlRing::new(mapped).unwrap();
         ring.memory().write(13, &[1, 2, 3]).unwrap();
         let mut bytes = [0; 3];
@@ -861,10 +854,9 @@ mod tests {
 
     #[test]
     fn shared_futex_wakeup_prevents_missed_cross_mapping_work() {
-        let local_memory = MemfdSharedMemory::create(CONTROL_RING_MEMORY_SIZE).unwrap();
-        let broker_memory = MemfdSharedMemory::from_received_fd(
+        let local_memory = MemfdSharedMemory::create_control_ring().unwrap();
+        let broker_memory = MemfdSharedMemory::control_ring_from_received_fd(
             local_memory.fd.as_fd().try_clone_to_owned().unwrap(),
-            CONTROL_RING_MEMORY_SIZE,
         )
         .unwrap();
         let mut producer = ControlRing::new(local_memory)
@@ -948,6 +940,23 @@ mod tests {
         producer.wake_consumer().unwrap();
 
         broker.join().unwrap();
+    }
+
+    #[test]
+    fn byte_memory_does_not_infer_control_ring_from_length() {
+        let memory = MemfdSharedMemory::create(CONTROL_RING_MEMORY_SIZE).unwrap();
+        let epoch_offset = (0..CONTROL_RING_MEMORY_SIZE)
+            .find(|offset| memory_permits_u32(*offset))
+            .unwrap();
+
+        assert_eq!(
+            memory.load_u32_acquire(epoch_offset),
+            Err(SharedMemoryError::InvalidRange)
+        );
+        assert_eq!(
+            memory.wake_one(epoch_offset).unwrap_err().kind(),
+            ErrorKind::InvalidInput
+        );
     }
 
     #[test]

--- a/litebox_broker_transport_linux_userland/src/memfd.rs
+++ b/litebox_broker_transport_linux_userland/src/memfd.rs
@@ -943,23 +943,6 @@ mod tests {
     }
 
     #[test]
-    fn byte_memory_does_not_infer_control_ring_from_length() {
-        let memory = MemfdSharedMemory::create(CONTROL_RING_MEMORY_SIZE).unwrap();
-        let epoch_offset = (0..CONTROL_RING_MEMORY_SIZE)
-            .find(|offset| memory_permits_u32(*offset))
-            .unwrap();
-
-        assert_eq!(
-            memory.load_u32_acquire(epoch_offset),
-            Err(SharedMemoryError::InvalidRange)
-        );
-        assert_eq!(
-            memory.wake_one(epoch_offset).unwrap_err().kind(),
-            ErrorKind::InvalidInput
-        );
-    }
-
-    #[test]
     fn rejects_missing_multiple_and_truncated_descriptors() {
         let length = 8;
 

--- a/litebox_broker_transport_linux_userland/src/pending_calls.rs
+++ b/litebox_broker_transport_linux_userland/src/pending_calls.rs
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+use std::io::Error;
+use std::marker::PhantomData;
+use std::sync::{Condvar, Mutex, MutexGuard};
+
+use litebox_broker_transport::pending_calls::{
+    PendingCalls as GenericPendingCalls, PendingCallsCondvar, PendingCallsError, PendingCallsMutex,
+    PendingCallsSync,
+};
+
+use crate::setup::{copy_io_error, invalid_data};
+
+pub(crate) type PendingCalls = GenericPendingCalls<StdPendingCallsSync, Error>;
+
+pub(crate) struct StdPendingCallsSync;
+
+pub(crate) struct StdPendingCallsMutex<T>(Mutex<T>);
+
+pub(crate) struct StdPendingCallsCondvar<T>(Condvar, PhantomData<fn(T)>);
+
+impl<T> PendingCallsMutex<T> for StdPendingCallsMutex<T> {
+    type Guard<'a>
+        = MutexGuard<'a, T>
+    where
+        T: 'a;
+
+    fn lock(&self) -> Self::Guard<'_> {
+        self.0.lock().expect("broker pending mutex poisoned")
+    }
+}
+
+impl<T> PendingCallsCondvar<T> for StdPendingCallsCondvar<T> {
+    type Mutex = StdPendingCallsMutex<T>;
+
+    fn wait<'a>(&self, guard: MutexGuard<'a, T>) -> MutexGuard<'a, T>
+    where
+        Self::Mutex: 'a,
+        T: 'a,
+    {
+        self.0.wait(guard).expect("broker pending mutex poisoned")
+    }
+
+    fn notify_one(&self) {
+        self.0.notify_one();
+    }
+
+    fn notify_all(&self) {
+        self.0.notify_all();
+    }
+}
+
+impl PendingCallsSync for StdPendingCallsSync {
+    type Mutex<T> = StdPendingCallsMutex<T>;
+    type Condvar<T> = StdPendingCallsCondvar<T>;
+
+    fn mutex<T>(value: T) -> Self::Mutex<T> {
+        StdPendingCallsMutex(Mutex::new(value))
+    }
+
+    fn condvar<T>() -> Self::Condvar<T> {
+        StdPendingCallsCondvar(Condvar::new(), PhantomData)
+    }
+}
+
+pub(crate) fn pending_calls_error(error: PendingCallsError<Error>) -> Error {
+    match error {
+        PendingCallsError::AssociationFailed(error) => copy_io_error(&error),
+        PendingCallsError::Operation(error) => error,
+        PendingCallsError::DuplicateRequestId => invalid_data("duplicate broker request ID"),
+        PendingCallsError::UnknownResponseId => {
+            invalid_data("broker returned an unknown response ID")
+        }
+    }
+}

--- a/litebox_broker_transport_linux_userland/src/setup.rs
+++ b/litebox_broker_transport_linux_userland/src/setup.rs
@@ -18,13 +18,15 @@ use std::time::Instant;
 
 use litebox_broker_protocol::wire::WireError;
 use litebox_broker_transport::control_ring::ControlRingError;
+#[cfg(test)]
+use litebox_broker_transport::setup_frame::MAX_SETUP_FRAME_LEN;
+use litebox_broker_transport::setup_frame::{
+    SetupFrameError, read_setup_frame as read_frame, write_setup_frame as write_frame,
+};
 
 use crate::unix_io::{
     refresh_read_deadline, refresh_write_deadline, with_read_deadline, with_write_deadline,
 };
-
-/// Largest setup frame either endpoint accepts or produces.
-const MAX_SETUP_FRAME_LEN: usize = 64 * 1024;
 
 /// Reads one length-prefixed setup frame, bounded by `deadline`.
 ///
@@ -34,36 +36,14 @@ pub(crate) fn read_setup_frame(
     deadline: Option<Instant>,
 ) -> IoResult<Option<Vec<u8>>> {
     with_read_deadline(stream, deadline, |stream, deadline| {
-        let mut len_buf = [0; 4];
-        let mut read = 0;
-        while read < len_buf.len() {
-            refresh_read_deadline(stream, deadline)?;
-            match stream.read(&mut len_buf[read..]) {
-                Ok(0) if read == 0 => return Ok(None),
-                Ok(0) => return Err(invalid_data("truncated broker setup frame length")),
-                Ok(len) => read += len,
-                Err(error) if error.kind() == ErrorKind::Interrupted => {}
-                Err(error) => return Err(error),
-            }
-        }
-
-        let len = u32::from_le_bytes(len_buf) as usize;
-        if len == 0 || len > MAX_SETUP_FRAME_LEN {
-            return Err(invalid_data("invalid broker setup frame length"));
-        }
-
-        let mut frame = vec![0; len];
-        let mut read = 0;
-        while read < frame.len() {
-            refresh_read_deadline(stream, deadline)?;
-            match stream.read(&mut frame[read..]) {
-                Ok(0) => return Err(invalid_data("truncated broker setup frame")),
-                Ok(len) => read += len,
-                Err(error) if error.kind() == ErrorKind::Interrupted => {}
-                Err(error) => return Err(error),
-            }
-        }
-        Ok(Some(frame))
+        read_frame(
+            |buffer| {
+                refresh_read_deadline(stream, deadline)?;
+                stream.read(buffer)
+            },
+            |error| error.kind() == ErrorKind::Interrupted,
+        )
+        .map_err(frame_error)
     })
 }
 
@@ -74,36 +54,29 @@ pub(crate) fn write_setup_frame(
     deadline: Option<Instant>,
 ) -> IoResult<()> {
     with_write_deadline(stream, deadline, |stream, deadline| {
-        if frame.is_empty() || frame.len() > MAX_SETUP_FRAME_LEN {
-            return Err(invalid_data("invalid broker setup frame length"));
-        }
-        let len =
-            u32::try_from(frame.len()).map_err(|_| invalid_data("broker setup frame too large"))?;
-        write_all_with_deadline(stream, &len.to_le_bytes(), deadline)?;
-        write_all_with_deadline(stream, frame, deadline)
+        write_frame(
+            frame,
+            |buffer| {
+                refresh_write_deadline(stream, deadline)?;
+                stream.write(buffer)
+            },
+            |error| error.kind() == ErrorKind::Interrupted,
+        )
+        .map_err(frame_error)
     })
 }
 
-fn write_all_with_deadline(
-    stream: &mut UnixStream,
-    mut buffer: &[u8],
-    deadline: Option<Instant>,
-) -> IoResult<()> {
-    while !buffer.is_empty() {
-        refresh_write_deadline(stream, deadline)?;
-        match stream.write(buffer) {
-            Ok(0) => {
-                return Err(Error::new(
-                    ErrorKind::WriteZero,
-                    "failed to write broker setup frame",
-                ));
-            }
-            Ok(written) => buffer = &buffer[written..],
-            Err(error) if error.kind() == ErrorKind::Interrupted => {}
-            Err(error) => return Err(error),
+fn frame_error(error: SetupFrameError<Error>) -> Error {
+    match error {
+        SetupFrameError::Io(error) => error,
+        SetupFrameError::TruncatedLength => invalid_data("truncated broker setup frame length"),
+        SetupFrameError::InvalidLength => invalid_data("invalid broker setup frame length"),
+        SetupFrameError::TruncatedFrame => invalid_data("truncated broker setup frame"),
+        SetupFrameError::WriteZero => {
+            Error::new(ErrorKind::WriteZero, "failed to write broker setup frame")
         }
+        SetupFrameError::InvalidIoCount => Error::other("invalid broker setup frame I/O count"),
     }
-    Ok(())
 }
 
 /// Shuts down both directions of an association socket, tolerating a peer that

--- a/litebox_broker_transport_linux_userland/src/unix_socket/host.rs
+++ b/litebox_broker_transport_linux_userland/src/unix_socket/host.rs
@@ -527,8 +527,7 @@ mod tests {
         LocalCallChannel, LocalNotificationChannel, LocalSetupChannel,
     };
     use litebox_broker_transport::control_ring::{
-        CONTROL_RING_MEMORY_SIZE, CONTROL_RING_NOTIFICATION_SLOT_COUNT, CONTROL_RING_SLOT_COUNT,
-        LocalControlRingEndpoints,
+        CONTROL_RING_NOTIFICATION_SLOT_COUNT, CONTROL_RING_SLOT_COUNT, LocalControlRingEndpoints,
     };
 
     use crate::unix_socket::local::{
@@ -546,10 +545,9 @@ mod tests {
         ControlRing<MemfdSharedMemory>,
         ControlRing<MemfdSharedMemory>,
     ) {
-        let first = MemfdSharedMemory::create(CONTROL_RING_MEMORY_SIZE).unwrap();
-        let second = MemfdSharedMemory::from_received_fd(
+        let first = MemfdSharedMemory::create_control_ring().unwrap();
+        let second = MemfdSharedMemory::control_ring_from_received_fd(
             first.as_fd().try_clone_to_owned().unwrap(),
-            CONTROL_RING_MEMORY_SIZE,
         )
         .unwrap();
         (

--- a/litebox_broker_transport_linux_userland/src/unix_socket/local.rs
+++ b/litebox_broker_transport_linux_userland/src/unix_socket/local.rs
@@ -11,9 +11,9 @@ use std::io::{Error, ErrorKind, Read, Result as IoResult};
 use std::os::fd::{AsFd, BorrowedFd, OwnedFd};
 use std::os::unix::net::UnixStream;
 use std::path::Path;
-use std::sync::{Arc, Condvar, Mutex};
+use std::sync::{Arc, Mutex};
+use std::thread;
 use std::time::{Duration, Instant};
-use std::{collections::HashMap, thread};
 
 use rustix::event::{PollFd, PollFlags, Timespec, poll};
 use rustix::io::Errno;
@@ -21,7 +21,6 @@ use rustix::net::{
     AddressFamily, SocketAddrUnix, SocketFlags, SocketType, connect, socket_with, sockopt,
 };
 
-use litebox_broker_protocol::RequestId;
 use litebox_broker_protocol::message::{
     BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerNotification, BrokerRequest,
     BrokerResponse,
@@ -37,8 +36,10 @@ use litebox_broker_transport::control_ring::{
     CONTROL_RING_READY, ControlRing, ControlRingConsumer, ControlRingProducer,
     ControlRingReadError, ControlRingReadStatus, ControlRingWakeHandle, ControlRingWriteStatus,
 };
+pub use litebox_broker_transport::pending_calls::MAX_PENDING_CALLS;
 
 use crate::memfd::MemfdSharedMemory;
+use crate::pending_calls::{PendingCalls, pending_calls_error};
 use crate::setup::{
     copy_io_error, invalid_data, read_setup_frame, ring_error, shutdown_socket, wire_error,
     write_setup_frame,
@@ -46,9 +47,6 @@ use crate::setup::{
 use crate::unix_io::io_timeout_for_deadline;
 
 const CONNECT_RETRY_DELAY: Duration = Duration::from_millis(10);
-
-/// Maximum number of active calls waiting for broker responses.
-pub const MAX_PENDING_CALLS: usize = 64;
 
 /// Local-side broker association setup channel over a Unix stream.
 pub struct UnixStreamLocalSetupChannel {
@@ -121,6 +119,14 @@ impl UnixStreamLocalSetupChannel {
         deadline: Option<Instant>,
     ) -> IoResult<MemfdSharedMemory> {
         crate::memfd::receive_memfd(&mut self.stream, expected_len, deadline)
+    }
+
+    /// Receives the control-ring memfd offered by the broker during setup.
+    pub fn receive_control_ring(
+        &mut self,
+        deadline: Option<Instant>,
+    ) -> IoResult<MemfdSharedMemory> {
+        crate::memfd::receive_control_ring_memfd(&mut self.stream, deadline)
     }
 
     /// Consumes a negotiated setup channel into independently usable active
@@ -315,7 +321,10 @@ impl LocalCallChannel for UnixControlRingLocalCallChannel {
     fn call(&self, request: BrokerRequest) -> IoResult<BrokerResponse> {
         let association = &self.association;
         let request_id = request.request_id;
-        let pending_call = association.pending_calls.register(request_id)?;
+        let pending_call = association
+            .pending_calls
+            .register(request_id)
+            .map_err(pending_calls_error)?;
         let request_frame = encode_request(request);
 
         let write_result = {
@@ -326,7 +335,8 @@ impl LocalCallChannel for UnixControlRingLocalCallChannel {
             loop {
                 let write_status = association
                     .pending_calls
-                    .run_if_live(|| producer.try_write(&request_frame).map_err(ring_error));
+                    .run_if_live(|| producer.try_write(&request_frame).map_err(ring_error))
+                    .map_err(pending_calls_error);
                 match write_status {
                     Ok(ControlRingWriteStatus::Written) => {
                         if let Err(error) = producer.wake_consumer() {
@@ -347,7 +357,7 @@ impl LocalCallChannel for UnixControlRingLocalCallChannel {
             let _ = association.fail(error);
         }
 
-        pending_call.wait()
+        pending_call.wait().map_err(|error| copy_io_error(&error))
     }
 }
 
@@ -392,161 +402,20 @@ impl LocalNotificationChannel for UnixControlRingLocalNotificationChannel {
     }
 }
 
-struct PendingCalls {
-    state: Mutex<PendingCallsState>,
-    capacity_available: Condvar,
-}
-
-struct PendingCallsState {
-    calls: HashMap<RequestId, Arc<PendingCall>>,
-    failure: Option<Arc<Error>>,
-}
-
-struct PendingCall {
-    result: Mutex<Option<PendingCallResult>>,
-    result_ready: Condvar,
-}
-
-enum PendingCallResult {
-    Response(BrokerResponse),
-    Failure(Arc<Error>),
-}
-
-impl PendingCall {
-    fn new() -> Self {
-        Self {
-            result: Mutex::new(None),
-            result_ready: Condvar::new(),
-        }
-    }
-
-    fn resolve(&self, result: PendingCallResult) {
-        let mut stored = self
-            .result
-            .lock()
-            .expect("broker pending-call result mutex poisoned");
-        assert!(stored.is_none(), "broker pending call already resolved");
-        *stored = Some(result);
-        self.result_ready.notify_one();
-    }
-
-    fn wait(&self) -> IoResult<BrokerResponse> {
-        let mut result = self
-            .result
-            .lock()
-            .expect("broker pending-call result mutex poisoned");
-        loop {
-            if let Some(result) = result.take() {
-                return match result {
-                    PendingCallResult::Response(response) => Ok(response),
-                    PendingCallResult::Failure(error) => Err(copy_io_error(&error)),
-                };
-            }
-            result = self
-                .result_ready
-                .wait(result)
-                .expect("broker pending-call result mutex poisoned");
-        }
-    }
-}
-
-impl PendingCalls {
-    fn new() -> Self {
-        Self {
-            state: Mutex::new(PendingCallsState {
-                calls: HashMap::new(),
-                failure: None,
-            }),
-            capacity_available: Condvar::new(),
-        }
-    }
-
-    fn register(&self, request_id: RequestId) -> IoResult<Arc<PendingCall>> {
-        let pending_call = Arc::new(PendingCall::new());
-        let mut state = self.state.lock().expect("broker pending mutex poisoned");
-        while state.calls.len() == MAX_PENDING_CALLS && state.failure.is_none() {
-            state = self
-                .capacity_available
-                .wait(state)
-                .expect("broker pending mutex poisoned");
-        }
-        if let Some(error) = state.failure.as_ref() {
-            return Err(copy_io_error(error));
-        }
-        match state.calls.entry(request_id) {
-            std::collections::hash_map::Entry::Vacant(entry) => {
-                entry.insert(Arc::clone(&pending_call));
-            }
-            std::collections::hash_map::Entry::Occupied(_) => {
-                return Err(invalid_data("duplicate broker request ID"));
-            }
-        }
-        Ok(pending_call)
-    }
-
-    fn complete(&self, response: BrokerResponse) -> IoResult<()> {
-        let pending_call = {
-            let mut state = self.state.lock().expect("broker pending mutex poisoned");
-            if let Some(error) = state.failure.as_ref() {
-                return Err(copy_io_error(error));
-            }
-            let Some(pending_call) = state.calls.remove(&response.request_id) else {
-                return Err(invalid_data("broker returned an unknown response ID"));
-            };
-            self.capacity_available.notify_one();
-            pending_call
-        };
-        pending_call.resolve(PendingCallResult::Response(response));
-        Ok(())
-    }
-
-    fn record_failure(&self, error: Arc<Error>) -> bool {
-        let pending_calls = {
-            let mut state = self.state.lock().expect("broker pending mutex poisoned");
-            if state.failure.is_some() {
-                return false;
-            }
-            state.failure = Some(Arc::clone(&error));
-            let pending_calls = core::mem::take(&mut state.calls);
-            self.capacity_available.notify_all();
-            pending_calls
-        };
-        for pending_call in pending_calls.into_values() {
-            pending_call.resolve(PendingCallResult::Failure(Arc::clone(&error)));
-        }
-        true
-    }
-
-    fn current_failure(&self) -> Option<Arc<Error>> {
-        self.state
-            .lock()
-            .expect("broker pending mutex poisoned")
-            .failure
-            .as_ref()
-            .map(Arc::clone)
-    }
-
-    /// Runs a nonblocking publication while excluding failure recording.
-    fn run_if_live<T>(&self, operation: impl FnOnce() -> IoResult<T>) -> IoResult<T> {
-        let state = self.state.lock().expect("broker pending mutex poisoned");
-        if let Some(error) = state.failure.as_ref() {
-            return Err(copy_io_error(error));
-        }
-        operation()
-    }
-}
-
 impl LocalRingAssociation {
     fn acknowledge_notification(
         &self,
         consumer: &mut ControlRingConsumer<MemfdSharedMemory>,
     ) -> IoResult<()> {
-        let result = self.pending_calls.run_if_live(|| {
-            consumer
-                .publish_head()
-                .map_err(ring_error)
-                .and_then(|()| consumer.wake_producer())
-        });
+        let result = self
+            .pending_calls
+            .run_if_live(|| {
+                consumer
+                    .publish_head()
+                    .map_err(ring_error)
+                    .and_then(|()| consumer.wake_producer())
+            })
+            .map_err(pending_calls_error);
         if let Err(error) = result {
             let result = Err(copy_io_error(&error));
             let _ = self.fail(error);
@@ -606,7 +475,12 @@ fn dispatch_responses(
                     .publish_head()
                     .map_err(ring_error)
                     .and_then(|()| consumer.wake_producer())
-                    .and_then(|()| association.pending_calls.complete(response))
+                    .and_then(|()| {
+                        association
+                            .pending_calls
+                            .complete(response)
+                            .map_err(pending_calls_error)
+                    })
                 {
                     let _ = association.fail(error);
                     return;
@@ -644,7 +518,6 @@ mod control_ring_tests {
     };
     use litebox_broker_protocol::{ObjectHandle, RequestId};
     use litebox_broker_transport::channel::{LocalCallChannel, LocalSetupChannel};
-    use litebox_broker_transport::control_ring::CONTROL_RING_MEMORY_SIZE;
     use rustix::fs::{OFlags, fcntl_getfl};
     use std::io::{Read, Write};
     use std::os::fd::AsFd;
@@ -706,10 +579,9 @@ mod control_ring_tests {
         ControlRing<MemfdSharedMemory>,
         ControlRing<MemfdSharedMemory>,
     ) {
-        let first = MemfdSharedMemory::create(CONTROL_RING_MEMORY_SIZE).unwrap();
-        let second = MemfdSharedMemory::from_received_fd(
+        let first = MemfdSharedMemory::create_control_ring().unwrap();
+        let second = MemfdSharedMemory::control_ring_from_received_fd(
             first.as_fd().try_clone_to_owned().unwrap(),
-            CONTROL_RING_MEMORY_SIZE,
         )
         .unwrap();
         (
@@ -1164,7 +1036,7 @@ mod control_ring_tests {
     fn duplicate_pending_registration_preserves_original() {
         let pending = PendingCalls::new();
         let original = pending.register(RequestId(1)).unwrap();
-        let Err(error) = pending.register(RequestId(1)) else {
+        let Err(error) = pending.register(RequestId(1)).map_err(pending_calls_error) else {
             panic!("duplicate registration unexpectedly succeeded");
         };
         assert_eq!(error.kind(), ErrorKind::InvalidData);

--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -27,7 +27,7 @@ use litebox_broker_protocol::message::BrokerRequest;
 use litebox_broker_protocol::shared_buffer::{SHARED_BUFFER_LAYOUT, SHARED_BUFFER_POOL_SIZE};
 use litebox_broker_protocol::socket::{Ipv4Address, Port};
 use litebox_broker_transport::channel::HostReceive;
-use litebox_broker_transport::control_ring::{CONTROL_RING_MEMORY_SIZE, ControlRing};
+use litebox_broker_transport::control_ring::ControlRing;
 use litebox_broker_transport::shared_memory::{SharedBufferPool, SharedMemory};
 use litebox_broker_transport_linux_userland::memfd::MemfdSharedMemory;
 use litebox_broker_transport_linux_userland::unix_socket::{
@@ -180,7 +180,7 @@ fn serve_runner(
     )?;
     let shared_memory = MemfdSharedMemory::create(SHARED_BUFFER_POOL_SIZE)?;
     let shared_buffers = SharedBufferPool::new(shared_memory, SHARED_BUFFER_LAYOUT)?;
-    let control_memory = MemfdSharedMemory::create(CONTROL_RING_MEMORY_SIZE)?;
+    let control_memory = MemfdSharedMemory::create_control_ring()?;
     let control_ring = ControlRing::new(control_memory)
         .map_err(|error| IoError::other(format!("failed to create control ring: {error:?}")))?;
     let mut control_channel =
@@ -616,10 +616,9 @@ mod tests {
             })
             .unwrap();
         local_setup.recv_handshake_response().unwrap().unwrap();
-        let local_memory = MemfdSharedMemory::create(CONTROL_RING_MEMORY_SIZE).unwrap();
-        let host_memory = MemfdSharedMemory::from_received_fd(
+        let local_memory = MemfdSharedMemory::create_control_ring().unwrap();
+        let host_memory = MemfdSharedMemory::control_ring_from_received_fd(
             local_memory.as_fd().try_clone_to_owned().unwrap(),
-            CONTROL_RING_MEMORY_SIZE,
         )
         .unwrap();
         let local_ring = ControlRing::new(local_memory).unwrap();
@@ -662,7 +661,7 @@ mod tests {
             UnixStreamLocalSetupChannel::from_connected(stream),
             |mut setup| {
                 let shared_memory = setup.receive_memfd(SHARED_BUFFER_POOL_SIZE, None)?;
-                let control_memory = setup.receive_memfd(CONTROL_RING_MEMORY_SIZE, None)?;
+                let control_memory = setup.receive_control_ring(None)?;
                 let control_ring = ControlRing::new(control_memory).map_err(|error| {
                     IoError::new(
                         ErrorKind::InvalidData,
@@ -705,7 +704,7 @@ mod tests {
             let shared_memory = MemfdSharedMemory::create(SHARED_BUFFER_POOL_SIZE).unwrap();
             let shared_buffers =
                 SharedBufferPool::new(shared_memory, SHARED_BUFFER_LAYOUT).unwrap();
-            let control_memory = MemfdSharedMemory::create(CONTROL_RING_MEMORY_SIZE).unwrap();
+            let control_memory = MemfdSharedMemory::create_control_ring().unwrap();
             let control_ring = ControlRing::new(control_memory).unwrap();
             let mut control = UnixStreamHostSetupChannel::from_host_guaranteed(
                 host_stream,

--- a/litebox_broker_userland/tests/notification_runtime.rs
+++ b/litebox_broker_userland/tests/notification_runtime.rs
@@ -16,9 +16,7 @@ use litebox_broker_protocol::message::{BrokerNotification, ReadinessNotification
 use litebox_broker_protocol::readiness::ReadinessFlags;
 use litebox_broker_protocol::shared_buffer::{SHARED_BUFFER_LAYOUT, SHARED_BUFFER_POOL_SIZE};
 use litebox_broker_transport::channel::{HostNotificationChannel, HostReceive};
-use litebox_broker_transport::control_ring::{
-    CONTROL_RING_MEMORY_SIZE, CONTROL_RING_NOTIFICATION_SLOT_COUNT, ControlRing,
-};
+use litebox_broker_transport::control_ring::{CONTROL_RING_NOTIFICATION_SLOT_COUNT, ControlRing};
 use litebox_broker_transport::shared_memory::SharedBufferPool;
 use litebox_broker_transport_linux_userland::memfd::MemfdSharedMemory;
 use litebox_broker_transport_linux_userland::unix_socket::{
@@ -55,7 +53,7 @@ fn spawn_host(
         .unwrap();
         let shared_memory = MemfdSharedMemory::create(SHARED_BUFFER_POOL_SIZE).unwrap();
         let shared_buffers = SharedBufferPool::new(shared_memory, SHARED_BUFFER_LAYOUT).unwrap();
-        let control_memory = MemfdSharedMemory::create(CONTROL_RING_MEMORY_SIZE).unwrap();
+        let control_memory = MemfdSharedMemory::create_control_ring().unwrap();
         let control_ring = ControlRing::new(control_memory).unwrap();
         let mut control = UnixStreamHostSetupChannel::from_accepted(stream);
         let association = setup_connection(
@@ -96,7 +94,7 @@ fn negotiate_local(
         UnixStreamLocalSetupChannel::from_connected(stream),
         |mut setup| {
             let shared_memory = setup.receive_memfd(SHARED_BUFFER_POOL_SIZE, None)?;
-            let control_memory = setup.receive_memfd(CONTROL_RING_MEMORY_SIZE, None)?;
+            let control_memory = setup.receive_control_ring(None)?;
             let control_ring = ControlRing::new(control_memory).map_err(|error| {
                 std::io::Error::new(
                     std::io::ErrorKind::InvalidData,
@@ -139,7 +137,7 @@ fn host_serves_control_requests_and_notifications_over_shared_rings() {
     let host_shared_memory = MemfdSharedMemory::create(SHARED_BUFFER_POOL_SIZE).unwrap();
     let host_shared_buffers =
         SharedBufferPool::new(host_shared_memory, SHARED_BUFFER_LAYOUT).unwrap();
-    let host_control_memory = MemfdSharedMemory::create(CONTROL_RING_MEMORY_SIZE).unwrap();
+    let host_control_memory = MemfdSharedMemory::create_control_ring().unwrap();
     let host_control_ring = ControlRing::new(host_control_memory).unwrap();
     let notification = BrokerNotification::Readiness(ReadinessNotification {
         handle: ObjectHandle(7),
@@ -181,7 +179,7 @@ fn host_serves_control_requests_and_notifications_over_shared_rings() {
         UnixStreamLocalSetupChannel::from_connected(local_control),
         |mut setup| {
             let shared_memory = setup.receive_memfd(SHARED_BUFFER_POOL_SIZE, None)?;
-            let control_memory = setup.receive_memfd(CONTROL_RING_MEMORY_SIZE, None)?;
+            let control_memory = setup.receive_control_ring(None)?;
             let control_ring = ControlRing::new(control_memory).map_err(|error| {
                 std::io::Error::new(
                     std::io::ErrorKind::InvalidData,

--- a/litebox_broker_userland/tests/userland_broker.rs
+++ b/litebox_broker_userland/tests/userland_broker.rs
@@ -13,7 +13,7 @@ use litebox_broker_protocol::readiness::ReadinessFlags;
 use litebox_broker_protocol::shared_buffer::{
     SHARED_BUFFER_POOL_SIZE, SharedBufferDescriptor, SharedBufferSlotIndex,
 };
-use litebox_broker_transport::control_ring::{CONTROL_RING_MEMORY_SIZE, ControlRing};
+use litebox_broker_transport::control_ring::ControlRing;
 use litebox_broker_transport_linux_userland::unix_socket::UnixStreamLocalSetupChannel;
 
 const RUNNER_ARGUMENT: &str = "broker-userland-test-runner";
@@ -123,10 +123,8 @@ fn run_fake_runner(args: &[OsString]) {
             SHARED_BUFFER_POOL_SIZE,
             Some(Instant::now() + Duration::from_secs(5)),
         )?;
-        let control_memory = setup.receive_memfd(
-            CONTROL_RING_MEMORY_SIZE,
-            Some(Instant::now() + Duration::from_secs(5)),
-        )?;
+        let control_memory =
+            setup.receive_control_ring(Some(Instant::now() + Duration::from_secs(5)))?;
         let control_ring = ControlRing::new(control_memory).map_err(|error| {
             std::io::Error::new(
                 ErrorKind::InvalidData,

--- a/litebox_runner_linux_userland/src/broker.rs
+++ b/litebox_runner_linux_userland/src/broker.rs
@@ -15,7 +15,7 @@ use anyhow::{Context as _, Result};
 use litebox_broker_local::{BrokerLocal, BrokerNotifications};
 use litebox_broker_protocol::message::BrokerNotification;
 use litebox_broker_protocol::shared_buffer::SHARED_BUFFER_POOL_SIZE;
-use litebox_broker_transport::control_ring::{CONTROL_RING_MEMORY_SIZE, ControlRing};
+use litebox_broker_transport::control_ring::ControlRing;
 use litebox_broker_transport_linux_userland::unix_socket::{
     UnixControlRingLocalCallChannel, UnixControlRingLocalNotificationChannel,
     UnixControlRingLocalShutdown, UnixStreamLocalSetupChannel,
@@ -51,8 +51,7 @@ pub(crate) fn connect(control_socket_path: &Path) -> Result<BrokerConnection> {
         BrokerLocal::negotiate(setup_channel, |mut setup| {
             let shared_memory =
                 setup.receive_memfd(SHARED_BUFFER_POOL_SIZE, Some(setup_deadline))?;
-            let control_memory =
-                setup.receive_memfd(CONTROL_RING_MEMORY_SIZE, Some(setup_deadline))?;
+            let control_memory = setup.receive_control_ring(Some(setup_deadline))?;
             let positional_io_fds = [
                 shared_memory.as_fd().as_raw_fd(),
                 control_memory.as_fd().as_raw_fd(),
@@ -271,10 +270,9 @@ mod tests {
         UnixControlRingHostNotificationChannel,
         UnixControlRingHostShutdown,
     ) {
-        let local_memory = MemfdSharedMemory::create(CONTROL_RING_MEMORY_SIZE).unwrap();
-        let host_memory = MemfdSharedMemory::from_received_fd(
+        let local_memory = MemfdSharedMemory::create_control_ring().unwrap();
+        let host_memory = MemfdSharedMemory::control_ring_from_received_fd(
             local_memory.as_fd().try_clone_to_owned().unwrap(),
-            CONTROL_RING_MEMORY_SIZE,
         )
         .unwrap();
         let local_ring = ControlRing::new(local_memory).unwrap();

--- a/litebox_runner_linux_userland/tests/run.rs
+++ b/litebox_runner_linux_userland/tests/run.rs
@@ -383,10 +383,7 @@ fn spawn_test_broker(
                         litebox_broker_protocol::shared_buffer::SHARED_BUFFER_LAYOUT,
                     )
                     .expect("failed to attach broker test shared-buffer layout");
-                let control_memory =
-                    litebox_broker_transport_linux_userland::memfd::MemfdSharedMemory::create(
-                        litebox_broker_transport::control_ring::CONTROL_RING_MEMORY_SIZE,
-                    )
+                let control_memory = litebox_broker_transport_linux_userland::memfd::MemfdSharedMemory::create_control_ring()
                     .expect("failed to create broker test control ring");
                 let control_ring =
                     litebox_broker_transport::control_ring::ControlRing::new(control_memory)


### PR DESCRIPTION
To reduce the duplication on broker transport between Linux and Window platforms, this PR extracts platform-neutral broker transport coordination from the existing Linux implementation, including:

- Share pending-call coordination across transports.
- Share setup frame encoding and decoding while preserving partial I/O progress.
- Make control-ring memory access policy explicit and align Linux shared-memory setup.

I also did some clean up on shared memory construction to distinguish control ring buffer from regular ones.