### PR TITLE
Enable AArch64 Linux tests and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,7 @@ jobs:
         -p litebox_syscall_rewriter
         -p litebox_platform_linux_userland
         -p litebox_shim_linux
+        -p litebox_runner_linux_userland
     steps:
       - name: Check out repo
         uses: actions/checkout@v6
@@ -104,15 +105,31 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: nextest@${{ env.NEXTEST_VERSION }}
+      - name: Install iperf3
+        run: |
+          sudo apt install -y iperf3
       - name: Install diod
         run: |
           sudo apt install -y diod
       - uses: Swatinem/rust-cache@v2
+      - name: Cache custom out directories
+        uses: actions/cache@v5
+        with:
+          path: |
+            target/*/build/litebox_runner_linux_userland-*/out
+          key: custom-out-${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('**/litebox_syscall_rewriter/**/*.rs') }}
       - run: ./.github/tools/github_actions_run_cargo fmt
       - run: |
           ./.github/tools/github_actions_run_cargo clippy --all-targets --all-features $AARCH64_CRATES
-          ./.github/tools/github_actions_run_cargo build $AARCH64_CRATES
-          ./.github/tools/github_actions_run_cargo nextest $AARCH64_CRATES
+      - run: ./.github/tools/github_actions_run_cargo build $AARCH64_CRATES
+      - run: ./.github/tools/github_actions_run_cargo nextest $AARCH64_CRATES
+      # Nextest does not run doctests.
+      - run: |
+          ./.github/tools/github_actions_run_cargo test --doc $AARCH64_CRATES
+      - name: Build documentation (fail on warnings)
+        env:
+          RUSTDOCFLAGS: -Dwarnings
+        run: ./.github/tools/github_actions_run_cargo doc --no-deps --all-features --document-private-items $AARCH64_CRATES
 
   build_and_test_lvbs:
     name: Build and Test LVBS

--- a/litebox_runner_linux_userland/src/lib.rs
+++ b/litebox_runner_linux_userland/src/lib.rs
@@ -370,7 +370,6 @@ pub fn run(cli_args: CliArgs) -> Result<()> {
         envp
     };
 
-    #[cfg(target_arch = "x86_64")]
     litebox_platform_linux_userland::LinuxUserland::enable_seccomp_filter(
         &broker_positional_io_fds,
         &broker_shutdown_fds,

--- a/litebox_runner_linux_userland/tests/async_x16.c
+++ b/litebox_runner_linux_userland/tests/async_x16.c
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// x16 must survive asynchronous entry to a signal handler and rt_sigreturn;
+// neither resume has a rewritten syscall site's outbound stub.
+
+#include "helpers.h"
+
+#include <signal.h>
+
+static volatile sig_atomic_t alarm_count = 0;
+
+static void alarm_handler(int signo) {
+    (void)signo;
+    alarm_count++;
+}
+
+static void install_alarm_handler(void) {
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = alarm_handler;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = 0;
+    TEST_ASSERT(sigaction(SIGALRM, &sa, NULL) == 0, "sigaction(SIGALRM) failed");
+}
+
+#ifdef __aarch64__
+
+#define SENTINEL_X16 0x1234123412341234L
+
+// One asm block prevents the compiler from spilling or reloading x16.
+static long spin_with_sentinel_in_x16(volatile sig_atomic_t *flag) {
+    register long x16 asm("x16") = SENTINEL_X16;
+    long observed;
+
+    asm volatile("1:\n\t"
+                 "ldr w0, [%[flag]]\n\t"
+                 "cbz w0, 1b\n\t"
+                 "mov %[out], x16"
+                 : [out] "=r"(observed), "+r"(x16)
+                 : [flag] "r"(flag)
+                 : "x0", "memory");
+
+    return observed;
+}
+
+#else // !__aarch64__
+
+static long spin_with_sentinel_in_x16(volatile sig_atomic_t *flag) {
+    while (*flag == 0) {
+    }
+    return 0;
+}
+
+#endif // __aarch64__
+
+int main(void) {
+    install_alarm_handler();
+
+    alarm_count = 0;
+    alarm(1);
+
+    long observed = spin_with_sentinel_in_x16(&alarm_count);
+
+    TEST_ASSERT(alarm_count == 1, "SIGALRM was not delivered during the userspace spin");
+
+#ifdef __aarch64__
+    if (observed != SENTINEL_X16) {
+        fprintf(stderr, "FAIL: x16 not preserved across an asynchronous resume: got 0x%lx, want 0x%lx\n",
+                observed, SENTINEL_X16);
+        return 1;
+    }
+#else
+    (void)observed;
+#endif
+
+    TEST_ASSERT(write(1, "async x16 ok\n", 13) == 13, "write after the spin failed");
+    return 0;
+}

--- a/litebox_runner_linux_userland/tests/common/mod.rs
+++ b/litebox_runner_linux_userland/tests/common/mod.rs
@@ -7,6 +7,11 @@ use std::path::{Path, PathBuf};
 #[cfg(target_os = "linux")]
 pub mod pty;
 
+#[cfg(target_arch = "x86_64")]
+const MULTIARCH: &str = "x86_64-linux-gnu";
+#[cfg(target_arch = "aarch64")]
+const MULTIARCH: &str = "aarch64-linux-gnu";
+
 /// Find all dependencies of a given binary via `ldd`
 #[allow(dead_code, reason = "not used by loader.rs for x86")]
 pub fn find_dependencies(prog: &str) -> Vec<String> {
@@ -55,18 +60,31 @@ pub fn find_dependencies(prog: &str) -> Vec<String> {
     // libgcc_s.so.1 is not always a direct link-time dependency (ldd won't list it), but
     // glibc's pthread_cancel needs it at runtime for forced stack unwinding. Without it the
     // we get SIGABRTs.
-    let libgcc_s: Option<String> = [
-        "/usr/lib/x86_64-linux-gnu/libgcc_s.so.1",
-        "/lib/x86_64-linux-gnu/libgcc_s.so.1",
-        "/usr/lib64/libgcc_s.so.1",
-        "/lib64/libgcc_s.so.1",
-    ]
-    .into_iter()
-    .map(String::from)
-    .find(|p| Path::new(p).exists());
-    if let Some(libgcc_s) = libgcc_s
-        && !paths.contains(&libgcc_s)
-    {
+    let libgcc_s = std::process::Command::new("gcc")
+        .arg("-print-file-name=libgcc_s.so.1")
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .map(|path| PathBuf::from(path.trim()))
+        .filter(|path| path.is_absolute() && path.is_file())
+        .or_else(|| {
+            [
+                format!("/usr/lib/{MULTIARCH}/libgcc_s.so.1"),
+                format!("/lib/{MULTIARCH}/libgcc_s.so.1"),
+                String::from("/usr/lib64/libgcc_s.so.1"),
+                String::from("/lib64/libgcc_s.so.1"),
+            ]
+            .into_iter()
+            .map(PathBuf::from)
+            .find(|path| path.is_file())
+        })
+        .expect("libgcc_s.so.1 not found via gcc or known library paths")
+        .canonicalize()
+        .unwrap()
+        .to_string_lossy()
+        .into_owned();
+    if !paths.contains(&libgcc_s) {
         paths.push(libgcc_s);
     }
 
@@ -112,11 +130,13 @@ pub fn compile(src_path: &str, unique_name: &str, exec_or_lib: bool, nolibc: boo
     if nolibc {
         args.push("-nostdlib");
     }
-    args.push(match std::env::consts::ARCH {
-        "x86_64" => "-m64",
-        "x86" => "-m32",
-        _ => unimplemented!(),
-    });
+    // Select the x86 ABI explicitly; AArch64 gcc rejects both x86 flags.
+    match std::env::consts::ARCH {
+        "x86_64" => args.push("-m64"),
+        "x86" => args.push("-m32"),
+        "aarch64" => (),
+        arch => unimplemented!("no gcc ABI flag known for {arch}"),
+    }
 
     // Create command string for caching
     let mut command_parts = vec!["gcc"];

--- a/litebox_runner_linux_userland/tests/execve.c
+++ b/litebox_runner_linux_userland/tests/execve.c
@@ -27,9 +27,18 @@ static void die(const char *msg) {
     exit(2);
 }
 
+// Keep this copy in sync with helpers.h; including it would redefine die().
+#if defined(__x86_64__) || defined(__i386__)
+#define SPIN_HINT() __asm__ __volatile__("pause")
+#elif defined(__aarch64__)
+#define SPIN_HINT() __asm__ __volatile__("yield")
+#else
+#define SPIN_HINT() __asm__ __volatile__("")
+#endif
+
 void* spin_thread(void* arg) {
     for (;;) {
-        __asm__ __volatile__("pause");
+        SPIN_HINT();
     }
 }
 

--- a/litebox_runner_linux_userland/tests/gate_signals.c
+++ b/litebox_runner_linux_userland/tests/gate_signals.c
@@ -1,0 +1,100 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include "helpers.h"
+
+#include <signal.h>
+#include <stdint.h>
+
+static volatile sig_atomic_t alarm_count;
+
+static void alarm_handler(int signo) {
+    (void)signo;
+    alarm_count++;
+}
+
+static void install_alarm_handler(void) {
+    struct sigaction sa;
+
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = alarm_handler;
+    sigemptyset(&sa.sa_mask);
+    TEST_ASSERT(sigaction(SIGALRM, &sa, NULL) == 0, "sigaction(SIGALRM) failed");
+}
+
+#ifdef __aarch64__
+
+#define GUEST_X16 0x1616161616161616UL
+#define GUEST_X17 0x1717171717171717UL
+
+static unsigned long read_guest_tp(void) {
+    unsigned long value;
+    asm volatile("mrs %0, tpidr_el0" : "=r"(value));
+    return value;
+}
+
+static int exercise_mrs_gate(void) {
+    unsigned long expected = read_guest_tp();
+    unsigned long observed = 0;
+    sig_atomic_t start = alarm_count;
+
+    alarm(1);
+    while (alarm_count == start) {
+        asm volatile("mrs %0, tpidr_el0" : "=r"(observed));
+        if (observed != expected)
+            return 0;
+    }
+    return 1;
+}
+
+static int exercise_msr_gate(void) {
+    unsigned long expected = read_guest_tp();
+    sig_atomic_t start = alarm_count;
+
+    alarm(1);
+    while (alarm_count == start) {
+        // Writing back the current virtual guest TP is semantically inert but
+        // still forces every iteration through an MSR gate.
+        asm volatile("msr tpidr_el0, %0" : : "r"(expected) : "memory");
+        if (read_guest_tp() != expected)
+            return 0;
+    }
+    return 1;
+}
+
+static int exercise_svc_gate(void) {
+    sig_atomic_t start = alarm_count;
+
+    alarm(1);
+    while (alarm_count == start) {
+        register unsigned long x8 asm("x8") = SYS_getpid;
+        register unsigned long x16 asm("x16") = GUEST_X16;
+        register unsigned long x17 asm("x17") = GUEST_X17;
+        register long result asm("x0");
+        asm volatile("svc #0"
+                     : "=r"(result), "+r"(x8), "+r"(x16), "+r"(x17)
+                     :
+                     : "memory", "cc");
+        if (result <= 0 || x16 != GUEST_X16 || x17 != GUEST_X17)
+            return 0;
+    }
+    return 1;
+}
+
+#else
+
+static int exercise_mrs_gate(void) { return 1; }
+static int exercise_msr_gate(void) { return 1; }
+static int exercise_svc_gate(void) { return 1; }
+
+#endif
+
+int main(void) {
+    install_alarm_handler();
+    TEST_ASSERT(exercise_mrs_gate(), "MRS semantics changed while signals were active");
+    TEST_ASSERT(exercise_msr_gate(), "MSR semantics changed while signals were active");
+    TEST_ASSERT(exercise_svc_gate(), "SVC registers changed while signals were active");
+    TEST_ASSERT(alarm_count == 3, "one signal was not delivered in each gate loop");
+    TEST_ASSERT(write(1, "gate signals ok\n", 16) == 16, "write after gate loops failed");
+    return 0;
+}

--- a/litebox_runner_linux_userland/tests/helpers.h
+++ b/litebox_runner_linux_userland/tests/helpers.h
@@ -171,4 +171,12 @@ static inline void expect_poll_lacks(int fd, short events_mask, short forbidden,
     }
 }
 
+#if defined(__x86_64__) || defined(__i386__)
+#define SPIN_HINT() __asm__ __volatile__("pause")
+#elif defined(__aarch64__)
+#define SPIN_HINT() __asm__ __volatile__("yield")
+#else
+#define SPIN_HINT() __asm__ __volatile__("")
+#endif
+
 #endif // LITEBOX_TESTS_HELPERS_H

--- a/litebox_runner_linux_userland/tests/loader.rs
+++ b/litebox_runner_linux_userland/tests/loader.rs
@@ -109,7 +109,6 @@ impl TestLauncher {
     }
 }
 
-#[cfg(target_arch = "x86_64")]
 #[test]
 fn test_load_exec_dynamic() {
     let path = common::compile("./tests/hello.c", "hello_dylib", false, false);
@@ -130,7 +129,6 @@ fn test_load_exec_dynamic() {
     launcher.test_load_exec_common(executable_path);
 }
 
-#[cfg(target_arch = "x86_64")]
 #[test]
 fn test_load_exec_static() {
     let path = common::compile("./tests/hello.c", "hello_exec", true, false);
@@ -159,7 +157,7 @@ int write(int fd, const char *buf, int length)
         "syscall\n\t"
         "mov %%eax, %0"
         : "=r" (ret)
-        : "i" (1), // #define SYS_write 1
+        : "i" (1), // x86-64 SYS_write
           "r" (fd),
           "r" (buf),
           "r" (length)
@@ -170,13 +168,12 @@ int write(int fd, const char *buf, int length)
 
 _Noreturn void exit_group(int code)
 {
-    /* Infinite for-loop since this function can't return */
     for (;;) {
         asm("mov %0, %%eax\n\t"
             "mov %1, %%edi\n\t"
             "syscall\n\t"
             :
-            : "i" (231), // #define SYS_exit_group 231
+            : "i" (231), // x86-64 SYS_exit_group
               "r" (code)
             : "%eax", "%edi");
     }
@@ -193,7 +190,7 @@ int write(int fd, const char *buf, int length)
         "int $0x80\n\t"
         "mov %%eax, %0"
         : "=r" (ret)
-        : "i" (4), // #define SYS_write 4
+        : "i" (4), // i386 SYS_write
           "g" (fd),
           "g" (buf),
           "g" (length)
@@ -203,15 +200,42 @@ int write(int fd, const char *buf, int length)
 }
 _Noreturn void exit_group(int code)
 {
-    /* Infinite for-loop since this function can't return */
     for (;;) {
         asm("mov %0, %%eax\n\t"
             "mov %1, %%ebx\n\t"
             "int $0x80\n\t"
             :
-            : "i" (252), // #define SYS_exit_group 252
+            : "i" (252), // i386 SYS_exit_group
               "r" (code)
             : "%eax", "%ebx");
+    }
+}
+#elif defined(__aarch64__)
+int write(int fd, const char *buf, int length)
+{
+    register long x8 asm("x8") = 64; // AArch64 SYS_write
+    register long x0 asm("x0") = fd;
+    register long x1 asm("x1") = (long)buf;
+    register long x2 asm("x2") = length;
+
+    asm volatile("svc #0"
+        : "+r" (x0)
+        : "r" (x8), "r" (x1), "r" (x2)
+        : "memory");
+
+    return (int)x0;
+}
+
+_Noreturn void exit_group(int code)
+{
+    for (;;) {
+        register long x8 asm("x8") = 94; // AArch64 SYS_exit_group
+        register long x0 asm("x0") = code;
+
+        asm volatile("svc #0"
+            :
+            : "r" (x8), "r" (x0)
+            : "memory");
     }
 }
 #else

--- a/litebox_runner_linux_userland/tests/pause.c
+++ b/litebox_runner_linux_userland/tests/pause.c
@@ -53,8 +53,8 @@ int test_pause_returns_eintr(void) {
     return 0;
 }
 
-// Same check but via the raw syscall (no libc wrapper munging), since the
-// shim intercepts the raw syscall.
+// AArch64 has no raw pause syscall; glibc implements pause() with ppoll.
+#ifdef SYS_pause
 int test_pause_raw_syscall(void) {
     struct sigaction sa;
     sa.sa_handler = alarm_handler;
@@ -79,6 +79,7 @@ int test_pause_raw_syscall(void) {
     printf("pause_raw_syscall: PASS\n");
     return 0;
 }
+#endif // SYS_pause
 
 // pause() is never restarted, even when the catching handler was installed
 // with SA_RESTART. See `man 7 signal`: pause is one of the syscalls that
@@ -162,7 +163,11 @@ int main(void) {
     printf("Starting pause tests...\n");
 
     if (test_pause_returns_eintr() != 0) return 1;
+#ifdef SYS_pause
     if (test_pause_raw_syscall() != 0) return 1;
+#else
+    printf("pause_raw_syscall: SKIP (no SYS_pause on this architecture)\n");
+#endif
     if (test_pause_not_restarted_under_sa_restart() != 0) return 1;
     if (test_pause_ignores_ignored_signal() != 0) return 1;
 

--- a/litebox_runner_linux_userland/tests/rewritten_guests.rs
+++ b/litebox_runner_linux_userland/tests/rewritten_guests.rs
@@ -1,0 +1,128 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//! Tests for guests whose syscall sites the rewriter redirected.
+//!
+//! Guests run under `--rewrite-syscalls` with no tar rootfs; broker-backed
+//! guests live in `run.rs`.
+
+#[allow(dead_code, reason = "shared with the other test binaries")]
+mod cache;
+#[allow(dead_code, reason = "shared with the other test binaries")]
+mod common;
+
+fn run_rewritten_fixture(source: &str, unique_name: &str) -> std::process::Output {
+    let target = common::compile(source, unique_name, true, false);
+    let binary_path = std::env::var("NEXTEST_BIN_EXE_litebox_runner_linux_userland")
+        .unwrap_or_else(|_| env!("CARGO_BIN_EXE_litebox_runner_linux_userland").to_string());
+
+    std::process::Command::new(binary_path)
+        .args(["--unstable", "--rewrite-syscalls"])
+        .arg(target)
+        .output()
+        .expect("Failed to run litebox_runner_linux_userland")
+}
+
+#[test]
+fn test_host_program_with_rewrite_syscalls() {
+    let output = run_rewritten_fixture("./tests/hello.c", "host_program_rewriter");
+
+    assert!(
+        output.status.success(),
+        "failed to run litebox_runner_linux_userland: {}",
+        output.status
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    println!("{stdout}");
+    assert!(stdout.contains("argv[0] = "), "unexpected stdout: {stdout}");
+}
+
+/// Linux AArch64 SVC preserves x16/x17 despite their AAPCS veneer role.
+/// On non-AArch64 the fixture is a no-op.
+#[test]
+fn test_svc_scratch_registers_survive_rewritten_syscall() {
+    let output = run_rewritten_fixture("./tests/svc_scratch_regs.c", "svc_scratch_regs_rewriter");
+
+    assert!(
+        output.status.success(),
+        "guest scratch registers did not survive a rewritten syscall ({}): {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+/// The synthetic AArch64 restorer must invoke rt_sigreturn, which restores
+/// caller-saved registers and sp after the handler returns. Other architectures
+/// cover handler entry and return without register checks.
+#[test]
+fn test_signal_handler_returns_through_sigreturn() {
+    let output = run_rewritten_fixture("./tests/sigreturn.c", "sigreturn_rewriter");
+
+    assert!(
+        output.status.success(),
+        "signal handler did not return cleanly through rt_sigreturn ({}): {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("sigreturn ok"),
+        "guest did not reach the post-sigreturn write: {}",
+        String::from_utf8_lossy(&output.stdout),
+    );
+}
+
+/// An asynchronous resume has no outbound stub, so x16 must survive the direct
+/// resume into the handler and the rt_sigreturn resume to the caller.
+/// Other architectures cover signal delivery to a busy guest without x16
+/// checks.
+#[test]
+fn test_guest_x16_survives_asynchronous_resume() {
+    let output = run_rewritten_fixture("./tests/async_x16.c", "async_x16_rewriter");
+
+    assert!(
+        output.status.success(),
+        "guest x16 did not survive an asynchronous resume ({}): {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("async x16 ok"),
+        "guest did not resume after the interruption: {}",
+        String::from_utf8_lossy(&output.stdout),
+    );
+}
+
+#[test]
+#[cfg(target_arch = "aarch64")]
+#[ignore = "AArch64 FP/SIMD state is not preserved across guest transitions"]
+fn test_guest_simd_survives_signal_delivery() {
+    let output = run_rewritten_fixture("./tests/sigreturn_simd.c", "sigreturn_simd_rewriter");
+
+    assert!(
+        output.status.success(),
+        "guest SIMD state did not survive signal delivery ({}): {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+/// Semantic stress only: sampling cannot prove a signal PC landed inside a
+/// short gate; synthetic tests cover each gate instruction boundary.
+#[test]
+#[cfg(target_arch = "aarch64")]
+fn test_signals_while_exercising_each_aarch64_gate_kind() {
+    let output = run_rewritten_fixture("./tests/gate_signals.c", "gate_signals_rewriter");
+
+    assert!(
+        output.status.success(),
+        "AArch64 gate semantics changed while signals were active ({}): {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("gate signals ok"),
+        "guest did not finish all gate loops: {}",
+        String::from_utf8_lossy(&output.stdout),
+    );
+}

--- a/litebox_runner_linux_userland/tests/run.rs
+++ b/litebox_runner_linux_userland/tests/run.rs
@@ -11,6 +11,16 @@ use std::{
 
 #[cfg(target_arch = "x86_64")]
 const BROKER_HELPER_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+// Dedicated fixtures build static binaries concurrently; exclude them to avoid
+// colliding with this sweep's dynamic `<stem>_rewriter` outputs.
+const DEDICATED_C_TESTS: &[&str] = &[
+    "async_x16.c",
+    "gate_signals.c",
+    "sigreturn.c",
+    "sigreturn_simd.c",
+    "svc_scratch_regs.c",
+];
+
 const BROKER_ONLY_C_TESTS: &[&str] = &[
     "eventfd.c",
     "pipe_broker.c",
@@ -18,6 +28,12 @@ const BROKER_ONLY_C_TESTS: &[&str] = &[
     "tcp_broker_server.c",
     "udp_broker.c",
 ];
+
+/// Debian multiarch library directory preserved at its guest-relative path.
+#[cfg(target_arch = "x86_64")]
+const MULTIARCH_LIB_DIR: &str = "lib/x86_64-linux-gnu";
+#[cfg(target_arch = "aarch64")]
+const MULTIARCH_LIB_DIR: &str = "lib/aarch64-linux-gnu";
 
 #[must_use]
 struct Runner {
@@ -36,7 +52,7 @@ impl Runner {
 
         // create tar file containing the rewritten executable and all dependencies
         let tar_dir = dir_path.join(format!("tar_files_{unique_name}"));
-        let dirs_to_create = ["lib64", "lib/x86_64-linux-gnu", "lib32"];
+        let dirs_to_create = ["lib64", MULTIARCH_LIB_DIR, "lib32"];
         for dir in dirs_to_create {
             std::fs::create_dir_all(tar_dir.join(dir)).unwrap();
         }
@@ -88,12 +104,15 @@ impl Runner {
         }
     }
 
+    fn tar_dir(&self) -> &Path {
+        &self.tar_dir
+    }
+
     fn env(&mut self, env: impl AsRef<std::ffi::OsStr>) -> &mut Self {
         self.command.arg("--env").arg(env);
         self
     }
 
-    #[cfg_attr(not(target_arch = "x86_64"), expect(dead_code))]
     fn envs(&mut self, envs: impl IntoIterator<Item = impl AsRef<std::ffi::OsStr>>) -> &mut Self {
         for env in envs {
             self.env(env);
@@ -106,7 +125,6 @@ impl Runner {
         self
     }
 
-    #[cfg_attr(not(target_arch = "x86_64"), expect(dead_code))]
     fn args(&mut self, args: impl IntoIterator<Item = impl AsRef<std::ffi::OsStr>>) -> &mut Self {
         for arg in args {
             self.arg(arg);
@@ -114,7 +132,6 @@ impl Runner {
         self
     }
 
-    #[cfg(target_arch = "x86_64")]
     fn guest_program_path(&mut self, guest_path: &str) -> &mut Self {
         self.cmd_path = PathBuf::from(guest_path);
         self
@@ -128,7 +145,6 @@ impl Runner {
         self
     }
 
-    #[cfg_attr(not(target_arch = "x86_64"), expect(dead_code))]
     fn with_fs_path(&mut self, f: impl FnOnce(&Path)) -> &mut Self {
         f(&self.tar_dir);
         self
@@ -139,7 +155,6 @@ impl Runner {
     }
 
     #[must_use]
-    #[cfg_attr(not(target_arch = "x86_64"), expect(dead_code))]
     fn output(&mut self) -> Vec<u8> {
         self.run_inner(true)
     }
@@ -182,7 +197,7 @@ impl Runner {
         output.stdout
     }
 
-    #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+    #[cfg(target_os = "linux")]
     fn spawn_with_stdio(
         &mut self,
         stdin: std::process::Stdio,
@@ -220,10 +235,16 @@ fn is_broker_only_c_test(path: &Path) -> bool {
         .is_some_and(|name| BROKER_ONLY_C_TESTS.contains(&name))
 }
 
+fn has_dedicated_c_test(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| DEDICATED_C_TESTS.contains(&name))
+}
+
 #[test]
 fn test_dynamic_lib_with_rewriter() {
     for path in find_c_test_files("./tests") {
-        if is_broker_only_c_test(&path) {
+        if is_broker_only_c_test(&path) || has_dedicated_c_test(&path) {
             continue;
         }
         let stem = path
@@ -239,7 +260,7 @@ fn test_dynamic_lib_with_rewriter() {
 #[test]
 fn test_static_exec_with_rewriter() {
     for path in find_c_test_files("./tests") {
-        if is_broker_only_c_test(&path) {
+        if is_broker_only_c_test(&path) || has_dedicated_c_test(&path) {
             continue;
         }
         let stem = path
@@ -252,31 +273,7 @@ fn test_static_exec_with_rewriter() {
     }
 }
 
-#[test]
-fn test_host_program_with_rewrite_syscalls() {
-    let target = common::compile("./tests/hello.c", "host_program_rewriter", true, false);
-    let binary_path = std::env::var("NEXTEST_BIN_EXE_litebox_runner_linux_userland")
-        .unwrap_or_else(|_| env!("CARGO_BIN_EXE_litebox_runner_linux_userland").to_string());
-
-    let output = std::process::Command::new(binary_path)
-        .args(["--unstable", "--rewrite-syscalls"])
-        .arg(target)
-        .output()
-        .expect("Failed to run litebox_runner_linux_userland");
-
-    assert!(
-        output.status.success(),
-        "failed to run litebox_runner_linux_userland: {}",
-        output.status
-    );
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    println!("{stdout}");
-    assert!(stdout.contains("argv[0] = "), "unexpected stdout: {stdout}");
-}
-
 /// Get the path of a program using `which`
-#[cfg(target_arch = "x86_64")]
 fn run_which(prog: &str) -> std::path::PathBuf {
     let prog_path_str = std::process::Command::new("which")
         .arg(prog)
@@ -478,6 +475,7 @@ fn spawn_test_broker(
     }
 }
 
+// TODO: un-gate when an AArch64 broker exists.
 #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
 #[test]
 fn test_runner_broker_integration_with_rewriter() {
@@ -857,37 +855,87 @@ fn test_runner_broker_tcp_server_with_rewriter() {
     broker.join();
 }
 
-#[cfg(target_arch = "x86_64")]
-#[test]
-fn test_runner_with_ls() {
-    let ls_path = run_which("ls");
-    let output = Runner::new(&ls_path, "ls_rewriter").arg("-a").output();
-
-    let output_str = String::from_utf8_lossy(&output);
-    let normalized = output_str.split_whitespace().collect::<Vec<_>>();
-    for each in [".", "..", "lib", "lib64"] {
-        assert!(
-            normalized.contains(&each),
-            "unexpected ls output:\n{output_str}\n{each} not found",
-        );
+fn dir_entries(dir: &Path) -> Vec<String> {
+    // Empty staging directories do not survive into the guest tar.
+    fn holds_a_file(path: &Path) -> bool {
+        if path.is_file() {
+            return true;
+        }
+        std::fs::read_dir(path)
+            .is_ok_and(|entries| entries.flatten().any(|e| holds_a_file(&e.path())))
     }
 
-    // test `ls` subdir
-    let output = Runner::new(&ls_path, "ls_lib_rewriter")
-        .args(["-a", "/lib/x86_64-linux-gnu"])
-        .output();
+    let mut names = std::fs::read_dir(dir)
+        .unwrap_or_else(|e| panic!("cannot read staged rootfs {}: {e}", dir.display()))
+        .flatten()
+        .filter(|entry| holds_a_file(&entry.path()))
+        // The tar excludes cache bookkeeping files.
+        .filter(|entry| {
+            entry
+                .path()
+                .extension()
+                .is_none_or(|ext| ext != "cache-checksum")
+        })
+        .map(|entry| entry.file_name().to_string_lossy().into_owned())
+        .collect::<Vec<_>>();
+    names.sort();
+    names
+}
 
-    let output_str = String::from_utf8_lossy(&output);
-    let normalized = output_str.split_whitespace().collect::<Vec<_>>();
-    for each in [".", "..", "libc.so.6", "libpcre2-8.so.0", "libselinux.so.1"] {
+fn assert_ls_listed(output: &[u8], dir: &Path, expected: &[String]) {
+    let output_str = String::from_utf8_lossy(output);
+    let listed = output_str.split_whitespace().collect::<Vec<_>>();
+    assert!(!expected.is_empty(), "nothing staged in {}", dir.display());
+    for each in [".", ".."]
+        .iter()
+        .copied()
+        .chain(expected.iter().map(String::as_str))
+    {
         assert!(
-            normalized.contains(&each),
-            "unexpected ls output:\n{output_str}\n{each} not found",
+            listed.contains(&each),
+            "ls of {} did not list {each}:\n{output_str}",
+            dir.display(),
         );
     }
 }
 
-#[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+/// Rewrites dynamic `ls` and its shared objects, checking that their appended
+/// trampolines coexist and that every staged non-cache entry remains visible.
+#[test]
+fn test_runner_with_ls() {
+    let ls_path = run_which("ls");
+
+    let mut runner = Runner::new(&ls_path, "ls_rewriter");
+    let expected_root = dir_entries(runner.tar_dir());
+    let output = runner.arg("-a").output();
+    assert_ls_listed(&output, Path::new("/"), &expected_root);
+
+    // Derive the library directory from ldd because host layouts vary.
+    let libs = common::find_dependencies(ls_path.to_str().unwrap());
+    let lib_guest_dir = libs
+        .iter()
+        .map(PathBuf::from)
+        .find(|lib| {
+            !lib.file_name()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .starts_with("ld-")
+        })
+        .and_then(|lib| lib.parent().map(Path::to_path_buf))
+        .expect("ls has no resolvable shared-library dependency to list");
+
+    let mut runner = Runner::new(&ls_path, "ls_lib_rewriter");
+    let staged_lib_dir = runner
+        .tar_dir()
+        .join(lib_guest_dir.strip_prefix("/").unwrap());
+    let expected_libs = dir_entries(&staged_lib_dir);
+    let output = runner
+        .args(["-a", lib_guest_dir.to_str().unwrap()])
+        .output();
+    assert_ls_listed(&output, &staged_lib_dir, &expected_libs);
+}
+
+#[cfg(target_os = "linux")]
 fn run_python(args: &[&str]) -> String {
     let output = std::process::Command::new("python3")
         .args(args)
@@ -897,7 +945,7 @@ fn run_python(args: &[&str]) -> String {
     String::from_utf8(output.stdout).unwrap()
 }
 
-#[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+#[cfg(target_os = "linux")]
 fn python_runner(unique_name: &str) -> Runner {
     let python_path = run_which("python3");
     let python_guest_dir = python_path.parent().unwrap().to_str().unwrap().to_string();
@@ -1024,7 +1072,7 @@ fn python_runner(unique_name: &str) -> Runner {
     runner
 }
 
-#[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+#[cfg(target_os = "linux")]
 #[test]
 fn test_runner_with_python() {
     const HELLO_WORLD_PY: &str = "print(\"Hello, World from litebox!\")";
@@ -1033,7 +1081,7 @@ fn test_runner_with_python() {
         .run();
 }
 
-#[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+#[cfg(target_os = "linux")]
 #[test]
 fn test_runner_with_python_repl_pty() {
     let mut runner = python_runner("python_repl_pty_rewriter");
@@ -1250,8 +1298,11 @@ fn test_broker_with_iperf3() {
     broker.join();
 }
 
-#[cfg(target_arch = "x86_64")]
 #[test]
+#[cfg_attr(
+    target_arch = "aarch64",
+    ignore = "AArch64 bash requires the unsupported getpgid syscall"
+)]
 fn test_shebang() {
     let bash_path = run_which("bash");
 

--- a/litebox_runner_linux_userland/tests/sigreturn.c
+++ b/litebox_runner_linux_userland/tests/sigreturn.c
@@ -1,0 +1,116 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// AArch64 glibc supplies no restorer, and LiteBox has no vDSO, so LiteBox
+// supplies a trampoline that invokes rt_sigreturn to restore saved context.
+
+#include "helpers.h"
+
+#include <signal.h>
+#include <stdint.h>
+
+static volatile sig_atomic_t handler_runs = 0;
+static volatile sig_atomic_t handler_signo = 0;
+
+// Caller-saved x9/x10 are not compiler-restored, so only sigcontext can recover
+// them. x19 is a weaker slot-validity check because the compiler restores it.
+static void clobber_sentinel_registers(void) {
+#ifdef __aarch64__
+    long junk = (long)handler_runs * 0x5eed5eed5eed5eedL + 1;
+    asm volatile("mov x9, %[j]\n\t"
+                 "mov x10, %[j]\n\t"
+                 "mov x19, %[j]"
+                 :
+                 : [j] "r"(junk)
+                 : "x9", "x10", "x19");
+#endif
+}
+
+static void handler(int signo, siginfo_t *info, void *ucontext) {
+    (void)info;
+    (void)ucontext;
+    handler_runs++;
+    handler_signo = signo;
+    clobber_sentinel_registers();
+}
+
+static void install_handler(int signo) {
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_sigaction = handler;
+    sa.sa_flags = SA_SIGINFO;
+    sigemptyset(&sa.sa_mask);
+    TEST_ASSERT(sigaction(signo, &sa, NULL) == 0, "sigaction failed");
+}
+
+#ifdef __aarch64__
+
+#define SENTINEL_X9 0x0909090909090909L
+#define SENTINEL_X10 0x1010101010101010L
+#define SENTINEL_X19 0x1919191919191919L
+
+static long out_x9, out_x10, out_x19, out_sp_delta;
+
+// SVC preserves x9/x10; after the handler clobbers them, only rt_sigreturn can.
+static void raise_with_sentinels(int pid, int signo) {
+    register long x8 asm("x8") = SYS_kill;
+    register long x0 asm("x0") = pid;
+    register long x1 asm("x1") = signo;
+    register long x9 asm("x9") = SENTINEL_X9;
+    register long x10 asm("x10") = SENTINEL_X10;
+    register long x19 asm("x19") = SENTINEL_X19;
+    long sp_before, sp_after;
+
+    asm volatile("mov %[spb], sp\n\t"
+                 "svc #0\n\t"
+                 "mov %[spa], sp"
+                 : "+r"(x0), "+r"(x9), "+r"(x10), "+r"(x19), [spb] "=&r"(sp_before),
+                   [spa] "=&r"(sp_after)
+                 : "r"(x8), "r"(x1)
+                 : "memory");
+
+    TEST_ASSERT(x0 == 0, "kill(getpid(), signo) should return 0");
+    out_x9 = x9;
+    out_x10 = x10;
+    out_x19 = x19;
+    out_sp_delta = sp_after - sp_before;
+}
+
+static void check_registers_survived(void) {
+    TEST_ASSERT(out_x9 == SENTINEL_X9, "x9 clobbered across signal delivery");
+    TEST_ASSERT(out_x10 == SENTINEL_X10, "x10 clobbered across signal delivery");
+    TEST_ASSERT(out_x19 == SENTINEL_X19, "x19 clobbered across signal delivery");
+    TEST_ASSERT(out_sp_delta == 0, "sp not restored across signal delivery");
+}
+
+#else // !__aarch64__
+
+static void raise_with_sentinels(int pid, int signo) {
+    TEST_ASSERT(kill(pid, signo) == 0, "kill failed");
+}
+
+static void check_registers_survived(void) {}
+
+#endif // __aarch64__
+
+int main(void) {
+    int pid = (int)getpid();
+
+    install_handler(SIGUSR1);
+
+    volatile long counter = 0;
+
+    for (int i = 0; i < 3; i++) {
+        raise_with_sentinels(pid, SIGUSR1);
+        check_registers_survived();
+        counter++;
+    }
+
+    TEST_ASSERT(handler_runs == 3, "handler did not run exactly three times");
+    TEST_ASSERT(handler_signo == SIGUSR1, "handler saw the wrong signal number");
+    TEST_ASSERT(counter == 3, "execution did not resume after the handler returned");
+
+    TEST_ASSERT(write(1, "sigreturn ok\n", 13) == 13, "write after sigreturn failed");
+
+    return 0;
+}

--- a/litebox_runner_linux_userland/tests/sigreturn_simd.c
+++ b/litebox_runner_linux_userland/tests/sigreturn_simd.c
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include "helpers.h"
+
+#include <signal.h>
+#include <stdint.h>
+
+#ifdef __aarch64__
+
+static volatile sig_atomic_t handler_ran;
+
+static void handler(int signo) {
+    (void)signo;
+    handler_ran = 1;
+}
+
+int main(void) {
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = handler;
+    sigemptyset(&sa.sa_mask);
+    TEST_ASSERT(sigaction(SIGUSR1, &sa, NULL) == 0, "sigaction failed");
+
+    uint64_t expected = UINT64_C(0x8877665544332211);
+    uint64_t observed;
+
+    asm volatile("fmov d8, %0" : : "r"(expected) : "d8");
+    TEST_ASSERT(raise(SIGUSR1) == 0, "raise failed");
+    asm volatile("fmov %0, d8" : "=r"(observed));
+
+    TEST_ASSERT(handler_ran, "handler did not run");
+    TEST_ASSERT(observed == expected, "d8 was not restored after signal delivery");
+    return 0;
+}
+
+#else
+
+int main(void) {
+    return 0;
+}
+
+#endif

--- a/litebox_runner_linux_userland/tests/svc_scratch_regs.c
+++ b/litebox_runner_linux_userland/tests/svc_scratch_regs.c
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// Linux AArch64 SVC preserves x16/x17; unlike a function-call veneer, the
+// syscall ABI permits the compiler to keep both registers live across SVC.
+
+#include "helpers.h"
+
+#ifdef __aarch64__
+
+#define SENTINEL_X16 12345L
+#define SENTINEL_X17 54321L
+
+static long probe_x16(void) {
+    register long x8 asm("x8") = __NR_write;
+    register long x0 asm("x0") = 1;
+    register long x1 asm("x1") = (long)"";
+    register long x2 asm("x2") = 0;
+    register long x16 asm("x16") = SENTINEL_X16;
+
+    asm volatile("svc #0"
+                 : "+r"(x0), "+r"(x16)
+                 : "r"(x8), "r"(x1), "r"(x2)
+                 : "memory");
+
+    TEST_ASSERT(x0 == 0, "write(1, \"\", 0) should return 0");
+    return x16;
+}
+
+static long probe_x17(void) {
+    register long x8 asm("x8") = __NR_write;
+    register long x0 asm("x0") = 1;
+    register long x1 asm("x1") = (long)"";
+    register long x2 asm("x2") = 0;
+    register long x17 asm("x17") = SENTINEL_X17;
+
+    asm volatile("svc #0"
+                 : "+r"(x0), "+r"(x17)
+                 : "r"(x8), "r"(x1), "r"(x2)
+                 : "memory");
+
+    TEST_ASSERT(x0 == 0, "write(1, \"\", 0) should return 0");
+    return x17;
+}
+
+int main(void) {
+    long x16 = probe_x16();
+    if (x16 != SENTINEL_X16) {
+        fprintf(stderr, "FAIL: x16 not preserved across svc: got %ld, want %ld\n", x16,
+                SENTINEL_X16);
+        return 1;
+    }
+
+    long x17 = probe_x17();
+    if (x17 != SENTINEL_X17) {
+        fprintf(stderr, "FAIL: x17 not preserved across svc: got %ld, want %ld\n", x17,
+                SENTINEL_X17);
+        return 1;
+    }
+
+    return 0;
+}
+
+#else // !__aarch64__
+
+int main(void) {
+    return 0;
+}
+
+#endif // __aarch64__

--- a/litebox_runner_linux_userland/tests/thread_exit.c
+++ b/litebox_runner_linux_userland/tests/thread_exit.c
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+#include "helpers.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <pthread.h>
@@ -19,7 +21,7 @@ void* yield_thread(void* arg) {
 
 void* spin_thread(void* arg) {
     for (;;) {
-        __asm__ __volatile__("pause");
+        SPIN_HINT();
     }
 }
 

--- a/litebox_runner_linux_userland/tests/wild_jump.c
+++ b/litebox_runner_linux_userland/tests/wild_jump.c
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// An unreadable fault PC must reach the guest handler after gate probing.
+#include "helpers.h"
+#include <signal.h>
+#include <stdio.h>
+#include <unistd.h>
+
+static void segv_handler(int signum, siginfo_t *info, void *ucontext)
+{
+    (void)signum;
+    (void)info;
+    (void)ucontext;
+    static const char msg[] = "guest handled the wild jump\n";
+    write(1, msg, sizeof(msg) - 1);
+    _exit(0);
+}
+
+int main(void)
+{
+    struct sigaction sa;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_sigaction = segv_handler;
+    sa.sa_flags = SA_SIGINFO;
+    TEST_ASSERT(sigaction(SIGSEGV, &sa, NULL) == 0, "sigaction(SIGSEGV) failed");
+
+    ((void (*)(void))0)();
+
+    TEST_ASSERT(0, "the jump to an unmapped PC did not fault");
+    return 1;
+}


### PR DESCRIPTION
This PR enables AArch64 Linux tests and CI. It enables most of the tests x86_64 exercises except for ones requiring broker support and shebang (AArch64 Bash requires the unsupported `getpgid` syscall for it).