### PR TITLE
Join the spawned handles in tests

### DIFF
--- a/litebox_shim_linux/src/lib.rs
+++ b/litebox_shim_linux/src/lib.rs
@@ -1295,6 +1295,7 @@ mod test_utils {
         ///
         /// # Panics
         /// Panics if the test process is already terminating.
+        #[must_use]
         pub(crate) fn spawn_clone_for_test<R>(
             &self,
             f: impl 'static + Send + FnOnce(Task<Platform, FS>) -> R,

--- a/litebox_shim_linux/src/syscalls/epoll.rs
+++ b/litebox_shim_linux/src/syscalls/epoll.rs
@@ -692,7 +692,7 @@ mod test {
             .unwrap();
 
         // spawn a thread to write to the eventfd
-        {
+        let writer = {
             let global = task.global.clone();
             let files = Arc::clone(&files);
             std::thread::spawn(move || {
@@ -707,11 +707,12 @@ mod test {
                     .with_entry(&typed, |entry| {
                         entry.write(&WaitState::new(platform()).context(), 1)
                     });
-            });
-        }
+            })
+        };
         epoll
             .wait(&task.global, &WaitState::new(platform()).context(), 1024)
             .unwrap();
+        writer.join().unwrap();
     }
 
     #[test]
@@ -737,7 +738,7 @@ mod test {
 
         // spawn a thread to write to the pipe
         let global = task.global.clone();
-        std::thread::spawn(move || {
+        let writer = std::thread::spawn(move || {
             std::thread::sleep(core::time::Duration::from_millis(100));
             assert_eq!(
                 global
@@ -756,6 +757,7 @@ mod test {
             .read(&WaitState::new(platform()).context(), &consumer, &mut buf)
             .unwrap();
         assert_eq!(buf, [1, 2]);
+        writer.join().unwrap();
     }
 
     #[test]
@@ -835,7 +837,7 @@ mod test {
         // spawn a thread to write to the eventfd
         let global = task.global.clone();
         let fds_for_thread = Arc::clone(&fds);
-        std::thread::spawn(move || {
+        let writer = std::thread::spawn(move || {
             let typed = fds_for_thread
                 .raw_descriptor_store
                 .read()
@@ -855,6 +857,7 @@ mod test {
         set.wait(&task.global, &WaitState::new(platform()).context(), &fds)
             .unwrap();
         assert_eq!(revents(&set), Events::IN);
+        writer.join().unwrap();
     }
 
     #[test]
@@ -867,7 +870,7 @@ mod test {
         let rfd = i32::try_from(rfd_u).unwrap();
         let wfd = i32::try_from(wfd_u).unwrap();
 
-        task.spawn_clone_for_test(move |task| {
+        let writer = task.spawn_clone_for_test(move |task| {
             std::thread::sleep(core::time::Duration::from_millis(100));
             // write a byte
             let buf = [0x41u8];
@@ -894,6 +897,7 @@ mod test {
 
         let _ = task.sys_close(rfd);
         let _ = task.sys_close(wfd);
+        writer.join().unwrap();
     }
 
     #[test]
@@ -906,7 +910,7 @@ mod test {
         let rfd = i32::try_from(rfd_u).unwrap();
         let wfd = i32::try_from(wfd_u).unwrap();
 
-        task.spawn_clone_for_test(move |task| {
+        let closer = task.spawn_clone_for_test(move |task| {
             std::thread::sleep(core::time::Duration::from_millis(100));
             task.sys_close(wfd).expect("close writer failed");
         });
@@ -935,6 +939,7 @@ mod test {
         assert_eq!(n, 0, "read should return 0 on EOF");
 
         let _ = task.sys_close(rfd);
+        closer.join().unwrap();
     }
 
     #[test]

--- a/litebox_shim_linux/src/syscalls/net.rs
+++ b/litebox_shim_linux/src/syscalls/net.rs
@@ -3102,7 +3102,7 @@ mod unix_tests {
         )
         .unwrap();
 
-        task.spawn_clone_for_test(move |task| {
+        let client = task.spawn_clone_for_test(move |task| {
             let mut client_fds = Vec::new();
             for _ in 0..10 {
                 let client_fd = create_unix_socket(
@@ -3174,6 +3174,7 @@ mod unix_tests {
             close_socket(&task, server_conn_fd);
         }
         close_socket(&task, server_fd);
+        client.join().unwrap();
     }
 
     #[test]
@@ -3289,7 +3290,7 @@ mod unix_tests {
         let sock2 = sv_ptr[1];
 
         // Receive on sock2 (from sock1)
-        task.spawn_clone_for_test(move |task| {
+        let receiver2 = task.spawn_clone_for_test(move |task| {
             let mut buf = [0u8; 64];
             if is_nonblocking {
                 ppoll(&task, sock2, Events::IN);
@@ -3306,7 +3307,7 @@ mod unix_tests {
         task.do_sendto(sock1, msg1.as_bytes(), SendFlags::empty(), None)
             .expect("sendto failed");
 
-        task.spawn_clone_for_test(move |task| {
+        let receiver1 = task.spawn_clone_for_test(move |task| {
             // Receive on sock1 (from sock2)
             let mut buf = [0u8; 64];
             if is_nonblocking {
@@ -3327,6 +3328,8 @@ mod unix_tests {
         std::thread::sleep(core::time::Duration::from_millis(500));
         close_socket(&task, sock1);
         close_socket(&task, sock2);
+        receiver2.join().unwrap();
+        receiver1.join().unwrap();
     }
 
     #[test]


### PR DESCRIPTION
This PR fixes some rare deadlocks that occur on Windows.  Specifically, a still-running thread races with process teardown, which on Windows can in rare cases get stuck.  Doing a `join` fixes this.  It also helps surface panics _if_ they occur on the thread.