### PR TITLE
Share broker TCP namespace

### DIFF
--- a/dev_bench/src/main.rs
+++ b/dev_bench/src/main.rs
@@ -422,7 +422,6 @@ const BENCHMARKS: &[(&str, BenchFn)] = benchtable![
     rewriter_node,
     run_rewritten_node,
     rewriter_iperf3,
-    run_rewritten_iperf3,
     //
 ];
 
@@ -650,6 +649,10 @@ fn rewriter_iperf3(ctx: BenchCtx) -> Result<()> {
     Ok(())
 }
 
+#[expect(
+    dead_code,
+    reason = "requires explicit broker TCP publication from a later PR"
+)]
 fn run_rewritten_iperf3(ctx: BenchCtx<'_>) -> Result<()> {
     let BenchCtx {
         sh,

--- a/dev_bench/src/main.rs
+++ b/dev_bench/src/main.rs
@@ -6,7 +6,6 @@ use clap::Parser;
 use std::sync::atomic::Ordering::Relaxed;
 use std::{
     collections::{BTreeMap, BTreeSet},
-    net::{Ipv4Addr, TcpListener},
     path::{Path, PathBuf},
     sync::atomic::AtomicBool,
     time::Duration,
@@ -698,126 +697,8 @@ fn run_rewritten_iperf3(ctx: BenchCtx<'_>) -> Result<()> {
         .run()?;
         cmd!(sh, "cargo build -p litebox_broker_userland {release...}").run()?;
     } else {
-        let mode = if release_mode { "release" } else { "debug" };
-        let iperf3_host = locate_command(sh, "iperf3")?;
-        let runner = format!(
-            "{}/target/{mode}/litebox_runner_linux_userland",
-            project_root.display()
-        );
-        let broker = format!(
-            "{}/target/{mode}/litebox-broker-userland",
-            project_root.display()
-        );
-        let iperf3_rewritten = sh.current_dir().join("iperf3_rewritten");
-        let client_sh = xshell::Shell::new()?;
-        let max_server_attempts = 5;
-        let max_client_attempts = 50;
-        let mut last_failure = "sandboxed server did not become ready".to_owned();
-
-        for server_attempt in 1..=max_server_attempts {
-            let port = TcpListener::bind((Ipv4Addr::LOCALHOST, 0))?
-                .local_addr()?
-                .port()
-                .to_string();
-            let mut server_command = std::process::Command::new(&broker);
-            server_command
-                .arg("--runner")
-                .arg(&runner)
-                .arg("--")
-                .args([
-                    "--env",
-                    "LD_LIBRARY_PATH=/lib64:/lib32:/lib",
-                    "--env",
-                    "HOME=/",
-                    "--initial-files",
-                ])
-                .arg(&tar_file)
-                .arg(&iperf3_rewritten)
-                .args(["-s", "-1", "-B", "127.0.0.1", "-p", &port]);
-            if COMMAND_EXECUTION_IS_QUIET.load(Relaxed) {
-                server_command
-                    .stdout(std::process::Stdio::null())
-                    .stderr(std::process::Stdio::null());
-            }
-            let mut server = server_command.spawn()?;
-
-            debug!(
-                server_attempt,
-                "Connecting iperf3 client to sandboxed server"
-            );
-            let mut client_succeeded = false;
-            for client_attempt in 1..=max_client_attempts {
-                let result = cmd!(
-                    client_sh,
-                    "{iperf3_host} -c 127.0.0.1 -p {port} --bytes 1G --connect-timeout 50"
-                )
-                .quiet()
-                .ignore_stdout()
-                .ignore_stderr()
-                .run();
-                if result.is_ok() {
-                    client_succeeded = true;
-                    break;
-                }
-                match server.try_wait() {
-                    Ok(Some(status)) => {
-                        last_failure = format!("sandboxed server exited with {status}");
-                        break;
-                    }
-                    Ok(None) => {}
-                    Err(error) => {
-                        let _ = server.kill();
-                        let _ = server.wait();
-                        return Err(error.into());
-                    }
-                }
-                if client_attempt == max_client_attempts {
-                    last_failure = format!(
-                        "iperf3 client failed to connect after {max_client_attempts} attempts"
-                    );
-                    break;
-                }
-                debug!(client_attempt, "iperf3 client connection failed, retrying");
-                std::thread::sleep(Duration::from_millis(100));
-            }
-
-            if !client_succeeded {
-                match server.try_wait() {
-                    Ok(Some(_)) => {}
-                    Ok(None) => {
-                        let _ = server.kill();
-                        let _ = server.wait();
-                    }
-                    Err(error) => {
-                        let _ = server.kill();
-                        let _ = server.wait();
-                        return Err(error.into());
-                    }
-                }
-                debug!(
-                    server_attempt,
-                    %last_failure,
-                    "Relaunching sandboxed iperf3 server"
-                );
-                continue;
-            }
-
-            let status = match server.wait() {
-                Ok(status) => status,
-                Err(error) => {
-                    let _ = server.kill();
-                    let _ = server.wait();
-                    return Err(error.into());
-                }
-            };
-            if !status.success() {
-                return Err(anyhow!("sandboxed iperf3 server exited with {status}"));
-            }
-            return Ok(());
-        }
-
         return Err(anyhow!(
-            "sandboxed iperf3 server failed after {max_server_attempts} attempts: {last_failure}"
+            "sandboxed iperf3 server benchmarks require explicit broker TCP publication"
         ));
     }
     Ok(())

--- a/litebox_broker_core/src/lib.rs
+++ b/litebox_broker_core/src/lib.rs
@@ -40,7 +40,7 @@ pub use policy::{
 };
 use session::ObjectReference;
 pub use session::{BrokerSession, CallerCredential, ObjectRights, SessionId};
-use socket::SocketProvider;
+use socket::{BrokerSocketPorts, SocketProvider};
 
 /// BrokerCore result type.
 pub type Result<T> = core::result::Result<T, BrokerError>;
@@ -117,6 +117,7 @@ pub struct BrokerCore {
     pub(crate) reserved_pipe_capacity: Arc<AtomicUsize>,
     pub(crate) reserved_sockets: Arc<AtomicUsize>,
     pub(crate) socket_provider: Arc<dyn SocketProvider>,
+    pub(crate) socket_ports: BrokerSocketPorts,
 }
 
 static BROKER_CORE_CREATED: AtomicBool = AtomicBool::new(false);
@@ -147,6 +148,7 @@ impl BrokerCore {
             reserved_pipe_capacity: Arc::new(AtomicUsize::new(0)),
             reserved_sockets: Arc::new(AtomicUsize::new(0)),
             socket_provider,
+            socket_ports: BrokerSocketPorts::default(),
         })
     }
 

--- a/litebox_broker_core/src/socket.rs
+++ b/litebox_broker_core/src/socket.rs
@@ -7,6 +7,7 @@ use alloc::{sync::Arc, vec::Vec};
 use core::net::{Ipv4Addr, SocketAddrV4};
 use core::sync::atomic::{AtomicUsize, Ordering};
 
+use hashbrown::HashSet;
 use litebox_broker_protocol::ObjectHandle;
 use litebox_broker_protocol::readiness::ReadinessFlags;
 use litebox_broker_protocol::socket::{
@@ -15,20 +16,109 @@ use litebox_broker_protocol::socket::{
     SocketConnectionStatus, SocketError, SocketOutcome, SocketStatusResponse, SocketType,
     TcpOptionName, TcpOptionValue,
 };
-use spin::Once;
+use spin::{Mutex, Once};
 
 use crate::readiness::{ReadinessRegistration, ReadinessSink};
 use crate::session::{ObjectEntry, ObjectRights};
 use crate::{BrokerError, BrokerSession, Result, SessionId};
 
 const DEFAULT_TCP_LISTEN_ADDRESS: SocketAddrV4 = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0);
+const DEFAULT_TCP_LOCAL_ADDRESS: SocketAddrV4 = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0);
+const FIRST_EPHEMERAL_PORT: u16 = 49152;
+
+#[derive(Default)]
+struct BrokerSocketPortState {
+    guest_tcp_ports: HashSet<u16>,
+    next_guest_tcp_ephemeral: Option<u16>,
+}
+
+/// Broker-wide authority for the guest-visible TCP port namespace.
+///
+/// Sessions identify endpoint owners but do not define separate network
+/// namespaces. Guest TCP ports remain independent of backend host ports.
+#[derive(Clone, Default)]
+pub(crate) struct BrokerSocketPorts {
+    state: Arc<Mutex<BrokerSocketPortState>>,
+}
+
+impl BrokerSocketPorts {
+    fn reserve(
+        &self,
+        request: CreateSocketRequest,
+        requested_address: SocketAddrV4,
+    ) -> Result<SocketOutcome<(SocketAddrV4, GuestPortReservation)>> {
+        if !is_tcp(request) {
+            return Err(BrokerError::Internal);
+        }
+        let mut state = self.state.lock();
+        let port = if requested_address.port() == 0 {
+            state.allocate_ephemeral()?
+        } else if state.guest_tcp_ports.contains(&requested_address.port()) {
+            return Ok(SocketOutcome::Failed(SocketError::AddressInUse));
+        } else {
+            requested_address.port()
+        };
+        state
+            .guest_tcp_ports
+            .try_reserve(1)
+            .map_err(|_| BrokerError::OutOfMemory)?;
+        if !state.guest_tcp_ports.insert(port) {
+            return Err(BrokerError::Internal);
+        }
+        let local_address = SocketAddrV4::new(*requested_address.ip(), port);
+        drop(state);
+        Ok(SocketOutcome::Completed((
+            local_address,
+            GuestPortReservation {
+                ports: self.clone(),
+                port,
+            },
+        )))
+    }
+}
+
+impl BrokerSocketPortState {
+    fn allocate_ephemeral(&mut self) -> Result<u16> {
+        let start = self
+            .next_guest_tcp_ephemeral
+            .unwrap_or(FIRST_EPHEMERAL_PORT);
+        let mut port = start;
+        loop {
+            if !self.guest_tcp_ports.contains(&port) {
+                self.next_guest_tcp_ephemeral = Some(if port == u16::MAX {
+                    FIRST_EPHEMERAL_PORT
+                } else {
+                    port + 1
+                });
+                return Ok(port);
+            }
+            port = if port == u16::MAX {
+                FIRST_EPHEMERAL_PORT
+            } else {
+                port + 1
+            };
+            if port == start {
+                return Err(BrokerError::ResourceExhausted);
+            }
+        }
+    }
+}
+
+struct GuestPortReservation {
+    ports: BrokerSocketPorts,
+    port: u16,
+}
+
+impl Drop for GuestPortReservation {
+    fn drop(&mut self) {
+        self.ports.state.lock().guest_tcp_ports.remove(&self.port);
+    }
+}
 
 /// Platform socket and endpoint metadata returned by an accept operation.
 pub struct AcceptedPlatformSocket {
     /// Accepted nonblocking platform socket.
     pub socket: Arc<dyn PlatformSocket>,
-    /// Local endpoint of the accepted connection.
-    pub local_address: SocketAddrV4,
     /// Remote endpoint of the accepted connection.
     pub remote_address: SocketAddrV4,
 }
@@ -99,7 +189,12 @@ pub trait SocketProvider: Send + Sync {
 /// in flight to finish after its object handle closes. Before releasing its
 /// portable authority, core explicitly retires the platform socket.
 pub trait PlatformSocket: Send + Sync {
-    /// Binds this socket to a local address.
+    /// Binds this socket to a local address and echoes the assigned address.
+    ///
+    /// A stream socket receives a broker-reserved guest-local address with a
+    /// nonzero port and must echo it unchanged; the host endpoint backing the
+    /// socket is chosen privately by the platform. A datagram socket receives
+    /// the address requested by the guest and returns the host-assigned one.
     fn bind(&self, address: SocketAddrV4) -> Result<SocketOutcome<SocketAddrV4>>;
 
     /// Makes this socket listen for incoming connections.
@@ -224,6 +319,7 @@ pub fn create(
         platform_socket: Once::new(),
         readiness,
         _quota: quota,
+        port_reservation: Mutex::new(None),
     });
     let platform_socket = match session.core.socket_provider.create(
         session.session_id,
@@ -281,7 +377,7 @@ pub fn connect(
         return connect_datagram(&object, address);
     }
 
-    let resource = {
+    let (resource, needs_bind) = {
         let mut object = object.write();
         let ObjectEntry::Socket(socket) = &mut *object else {
             return Err(BrokerError::InvalidRights);
@@ -296,8 +392,46 @@ pub fn connect(
             return Ok(SocketOutcome::Completed(socket.connection_status));
         }
         socket.connect_in_flight = true;
-        Arc::clone(&socket.resource)
+        (Arc::clone(&socket.resource), socket.local_address.is_none())
     };
+    if needs_bind {
+        match session.core.policy.authorize_socket_bind(
+            session.caller_credential,
+            create_request,
+            DEFAULT_TCP_LOCAL_ADDRESS,
+        ) {
+            Ok(()) => {}
+            Err(BrokerError::PolicyDenied) => {
+                finish_connect(&object, SocketConnectionStatus::Unconnected);
+                return Ok(SocketOutcome::Failed(SocketError::PolicyDenied));
+            }
+            Err(error) => {
+                finish_connect(&object, SocketConnectionStatus::Unconnected);
+                return Err(error);
+            }
+        }
+        let binding = match reserve_and_bind(
+            session,
+            create_request,
+            &resource,
+            DEFAULT_TCP_LOCAL_ADDRESS,
+        ) {
+            Ok(binding) => binding,
+            Err(error) => {
+                finish_connect(&object, SocketConnectionStatus::Unconnected);
+                return Err(error);
+            }
+        };
+        match binding {
+            SocketOutcome::Completed((local_address, reservation)) => {
+                attach_binding(&object, local_address, reservation);
+            }
+            SocketOutcome::Failed(error) => {
+                finish_connect(&object, SocketConnectionStatus::Unconnected);
+                return Ok(SocketOutcome::Failed(error));
+            }
+        }
+    }
     let status = match resource.connect(address) {
         Ok(SocketConnectionStatus::Unconnected) => {
             finish_connect(&object, SocketConnectionStatus::Failed(SocketError::Other));
@@ -347,26 +481,37 @@ pub fn bind(
     ) {
         Ok(()) => {}
         Err(BrokerError::PolicyDenied) => {
-            finish_configuration(&object, None, false);
+            finish_configuration(&object, None, None, false);
             return Ok(SocketOutcome::Failed(SocketError::PolicyDenied));
         }
         Err(error) => {
-            finish_configuration(&object, None, false);
+            finish_configuration(&object, None, None, false);
             return Err(error);
         }
     }
-    let outcome = resource.bind(address);
+    let outcome = if is_tcp(create_request) {
+        match reserve_and_bind(session, create_request, &resource, address) {
+            Ok(SocketOutcome::Completed((local_address, reservation))) => {
+                finish_configuration(&object, Some(local_address), Some(reservation), false);
+                return Ok(SocketOutcome::Completed(local_address));
+            }
+            Ok(SocketOutcome::Failed(error)) => Ok(SocketOutcome::Failed(error)),
+            Err(error) => Err(error),
+        }
+    } else {
+        resource.bind(address)
+    };
     match outcome {
         Ok(SocketOutcome::Completed(local_address)) => {
-            finish_configuration(&object, Some(local_address), false);
+            finish_configuration(&object, Some(local_address), None, false);
             Ok(SocketOutcome::Completed(local_address))
         }
         Ok(SocketOutcome::Failed(error)) => {
-            finish_configuration(&object, None, false);
+            finish_configuration(&object, None, None, false);
             Ok(SocketOutcome::Failed(error))
         }
         Err(error) => {
-            finish_configuration(&object, None, false);
+            finish_configuration(&object, None, None, false);
             Err(error)
         }
     }
@@ -382,7 +527,7 @@ pub fn listen(
         return Err(BrokerError::UnsupportedOperation);
     }
     let object = session.authorized_object(handle, ObjectRights::WRITE)?;
-    let (resource, create_request, needs_bind) = {
+    let (resource, create_request, existing_local_address) = {
         let mut object = object.write();
         let ObjectEntry::Socket(socket) = &mut *object else {
             return Err(BrokerError::InvalidRights);
@@ -400,12 +545,13 @@ pub fn listen(
         (
             Arc::clone(&socket.resource),
             socket.create_request,
-            socket.local_address.is_none(),
+            socket.local_address,
         )
     };
 
-    let mut local_address = None;
-    if needs_bind {
+    let mut local_address = existing_local_address;
+    let mut port_reservation = None;
+    if local_address.is_none() {
         match session.core.policy.authorize_socket_bind(
             session.caller_credential,
             create_request,
@@ -413,39 +559,54 @@ pub fn listen(
         ) {
             Ok(()) => {}
             Err(BrokerError::PolicyDenied) => {
-                finish_configuration(&object, None, false);
+                finish_configuration(&object, None, None, false);
                 return Ok(SocketOutcome::Failed(SocketError::PolicyDenied));
             }
             Err(error) => {
-                finish_configuration(&object, None, false);
+                finish_configuration(&object, None, None, false);
                 return Err(error);
             }
         }
-        match resource.bind(DEFAULT_TCP_LISTEN_ADDRESS) {
-            Ok(SocketOutcome::Completed(address)) => local_address = Some(address),
-            Ok(SocketOutcome::Failed(error)) => {
-                finish_configuration(&object, None, false);
-                return Ok(SocketOutcome::Failed(error));
-            }
+        let binding = match reserve_and_bind(
+            session,
+            create_request,
+            &resource,
+            DEFAULT_TCP_LISTEN_ADDRESS,
+        ) {
+            Ok(binding) => binding,
             Err(error) => {
-                finish_configuration(&object, None, false);
+                finish_configuration(&object, None, None, false);
                 return Err(error);
+            }
+        };
+        match binding {
+            SocketOutcome::Completed((address, reservation)) => {
+                local_address = Some(address);
+                port_reservation = Some(reservation);
+            }
+            SocketOutcome::Failed(error) => {
+                finish_configuration(&object, None, None, false);
+                return Ok(SocketOutcome::Failed(error));
             }
         }
     }
 
     match resource.listen(backlog) {
         Ok(SocketOutcome::Completed(address)) => {
-            local_address = Some(address);
-            finish_configuration(&object, local_address, true);
+            if local_address != Some(address) {
+                resource.retire();
+                finish_retired_configuration(&object, local_address, port_reservation);
+                return Err(BrokerError::Internal);
+            }
+            finish_configuration(&object, local_address, port_reservation, true);
             Ok(SocketOutcome::Completed(address))
         }
         Ok(SocketOutcome::Failed(error)) => {
-            finish_configuration(&object, local_address, false);
+            finish_configuration(&object, local_address, port_reservation, false);
             Ok(SocketOutcome::Failed(error))
         }
         Err(error) => {
-            finish_configuration(&object, local_address, false);
+            finish_configuration(&object, local_address, port_reservation, false);
             Err(error)
         }
     }
@@ -458,7 +619,7 @@ pub fn accept(
     readiness_sink: Arc<dyn ReadinessSink>,
 ) -> Result<SocketOutcome<AcceptedBrokerSocket>> {
     let listener = session.authorized_object(handle, ObjectRights::WAIT)?;
-    let (listener_resource, create_request) = {
+    let (listener_resource, create_request, local_address) = {
         let listener = listener.read();
         let ObjectEntry::Socket(socket) = &*listener else {
             return Err(BrokerError::InvalidRights);
@@ -469,7 +630,11 @@ pub fn accept(
         if !socket.listening {
             return Ok(SocketOutcome::Failed(SocketError::NotConnected));
         }
-        (Arc::clone(&socket.resource), socket.create_request)
+        (
+            Arc::clone(&socket.resource),
+            socket.create_request,
+            socket.local_address.ok_or(BrokerError::Internal)?,
+        )
     };
     let rights = session
         .core
@@ -486,6 +651,7 @@ pub fn accept(
         platform_socket: Once::new(),
         readiness,
         _quota: quota,
+        port_reservation: Mutex::new(None),
     });
     let accepted = match listener_resource.accept(resource.readiness.clone()) {
         Ok(SocketOutcome::Completed(accepted)) => accepted,
@@ -499,12 +665,11 @@ pub fn accept(
         }
     };
     resource.platform_socket.call_once(|| accepted.socket);
-    let accepted_socket =
-        SocketObject::new_connected(resource, create_request, accepted.local_address);
+    let accepted_socket = SocketObject::new_connected(resource, create_request, local_address);
     let handle = reference.commit(ObjectEntry::Socket(accepted_socket))?;
     Ok(SocketOutcome::Completed(AcceptedBrokerSocket {
         handle,
-        local_address: accepted.local_address,
+        local_address,
         remote_address: accepted.remote_address,
     }))
 }
@@ -870,6 +1035,29 @@ fn socket_state(
     ))
 }
 
+fn reserve_and_bind(
+    session: &BrokerSession,
+    create_request: CreateSocketRequest,
+    resource: &SocketResource,
+    requested_address: SocketAddrV4,
+) -> Result<SocketOutcome<(SocketAddrV4, GuestPortReservation)>> {
+    let (local_address, reservation) = match session
+        .core
+        .socket_ports
+        .reserve(create_request, requested_address)?
+    {
+        SocketOutcome::Completed(binding) => binding,
+        SocketOutcome::Failed(error) => return Ok(SocketOutcome::Failed(error)),
+    };
+    match resource.bind(local_address)? {
+        SocketOutcome::Completed(bound_address) if bound_address == local_address => {
+            Ok(SocketOutcome::Completed((local_address, reservation)))
+        }
+        SocketOutcome::Completed(_) => Err(BrokerError::Internal),
+        SocketOutcome::Failed(error) => Ok(SocketOutcome::Failed(error)),
+    }
+}
+
 fn connect_datagram(
     object: &spin::RwLock<ObjectEntry>,
     address: SocketAddrV4,
@@ -944,16 +1132,49 @@ fn finish_connect(object: &spin::RwLock<ObjectEntry>, status: SocketConnectionSt
     }
 }
 
+fn attach_binding(
+    object: &spin::RwLock<ObjectEntry>,
+    local_address: SocketAddrV4,
+    port_reservation: GuestPortReservation,
+) {
+    let mut object = object.write();
+    if let ObjectEntry::Socket(socket) = &mut *object {
+        socket.local_address = Some(local_address);
+        socket.resource.set_port_reservation(port_reservation);
+    }
+}
+
 fn finish_configuration(
     object: &spin::RwLock<ObjectEntry>,
     local_address: Option<SocketAddrV4>,
+    port_reservation: Option<GuestPortReservation>,
     listening: bool,
 ) {
     let mut object = object.write();
     if let ObjectEntry::Socket(socket) = &mut *object {
         socket.configuration_in_flight = false;
         socket.local_address = socket.local_address.or(local_address);
+        if let Some(port_reservation) = port_reservation {
+            socket.resource.set_port_reservation(port_reservation);
+        }
         socket.listening |= listening;
+    }
+}
+
+fn finish_retired_configuration(
+    object: &spin::RwLock<ObjectEntry>,
+    local_address: Option<SocketAddrV4>,
+    port_reservation: Option<GuestPortReservation>,
+) {
+    let mut object = object.write();
+    if let ObjectEntry::Socket(socket) = &mut *object {
+        socket.configuration_in_flight = false;
+        socket.local_address = socket.local_address.or(local_address);
+        if let Some(port_reservation) = port_reservation {
+            socket.resource.set_port_reservation(port_reservation);
+        }
+        socket.listening = false;
+        socket.connection_status = SocketConnectionStatus::Failed(SocketError::Other);
     }
 }
 
@@ -1008,9 +1229,18 @@ pub(crate) struct SocketResource {
     platform_socket: Once<Arc<dyn PlatformSocket>>,
     readiness: ReadinessRegistration,
     _quota: Arc<SocketQuotaReservation>,
+    port_reservation: Mutex<Option<GuestPortReservation>>,
 }
 
 impl SocketResource {
+    fn set_port_reservation(&self, reservation: GuestPortReservation) {
+        let mut slot = self.port_reservation.lock();
+        debug_assert!(slot.is_none());
+        if slot.is_none() {
+            *slot = Some(reservation);
+        }
+    }
+
     fn platform_socket(&self) -> &dyn PlatformSocket {
         self.platform_socket
             .get()
@@ -1031,6 +1261,10 @@ impl SocketResource {
 
     fn listen(&self, backlog: u32) -> Result<SocketOutcome<SocketAddrV4>> {
         self.platform_socket().listen(backlog)
+    }
+
+    fn retire(&self) {
+        self.platform_socket().retire();
     }
 
     fn accept(
@@ -1172,6 +1406,32 @@ pub(crate) mod tests {
     use std::time::Duration;
     use std::vec;
 
+    #[test]
+    fn guest_tcp_port_namespace_is_broker_wide() {
+        let ports = BrokerSocketPorts::default();
+        let address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 80);
+
+        let SocketOutcome::Completed((_, first_reservation)) =
+            ports.reserve(create_request(), address).unwrap()
+        else {
+            panic!("first TCP reservation failed");
+        };
+        assert!(matches!(
+            ports.reserve(create_request(), address),
+            Ok(SocketOutcome::Failed(SocketError::AddressInUse))
+        ));
+        assert!(matches!(
+            ports.reserve(create_udp_request(), address),
+            Err(BrokerError::Internal)
+        ));
+
+        drop(first_reservation);
+        assert!(matches!(
+            ports.reserve(create_request(), address),
+            Ok(SocketOutcome::Completed(_))
+        ));
+    }
+
     #[derive(Clone, Default)]
     pub(crate) struct TestSocketProvider {
         state: Arc<TestSocketState>,
@@ -1249,6 +1509,7 @@ pub(crate) mod tests {
                 readiness,
                 create_request: request,
                 tcp_options: StdMutex::new(TestTcpOptions::default()),
+                guest_local_address: StdMutex::new(None),
                 active: core::sync::atomic::AtomicBool::new(true),
             });
             if self.state.retain_next_socket.swap(false, Ordering::Relaxed) {
@@ -1271,6 +1532,7 @@ pub(crate) mod tests {
         readiness: ReadinessRegistration,
         create_request: CreateSocketRequest,
         tcp_options: StdMutex<TestTcpOptions>,
+        guest_local_address: StdMutex<Option<SocketAddrV4>>,
         active: core::sync::atomic::AtomicBool,
     }
 
@@ -1283,6 +1545,10 @@ pub(crate) mod tests {
     impl PlatformSocket for TestPlatformSocket {
         fn bind(&self, address: SocketAddrV4) -> Result<SocketOutcome<SocketAddrV4>> {
             self.state.binds.lock().unwrap().push(address);
+            if is_tcp(self.create_request) {
+                *self.guest_local_address.lock().unwrap() = Some(address);
+                return Ok(SocketOutcome::Completed(address));
+            }
             let address = if address.port() == 0 {
                 SocketAddrV4::new(*address.ip(), 49152)
             } else {
@@ -1298,10 +1564,11 @@ pub(crate) mod tests {
                 started.send(()).unwrap();
                 release.recv_timeout(Duration::from_secs(5)).unwrap();
             }
-            Ok(SocketOutcome::Completed(SocketAddrV4::new(
-                Ipv4Addr::LOCALHOST,
-                49152,
-            )))
+            self.guest_local_address
+                .lock()
+                .unwrap()
+                .ok_or(BrokerError::Internal)
+                .map(SocketOutcome::Completed)
         }
 
         fn accept(
@@ -1569,6 +1836,13 @@ pub(crate) mod tests {
             connect(&session, handle, loopback_address()),
             Ok(SocketOutcome::Completed(SocketConnectionStatus::Connecting))
         );
+        let local_address = *provider
+            .state
+            .binds
+            .lock()
+            .unwrap()
+            .last()
+            .expect("automatic TCP bind was not recorded");
         assert_eq!(
             readiness.published.lock().unwrap().as_slice(),
             [(handle, ReadinessFlags::WRITE)]
@@ -1577,7 +1851,7 @@ pub(crate) mod tests {
             status(&session, handle),
             Ok(SocketStatusResponse {
                 status: SocketConnectionStatus::Connected,
-                local_address: None,
+                local_address: Some(local_address),
                 pending_error: None,
             })
         );
@@ -1849,11 +2123,13 @@ pub(crate) mod tests {
         assert_eq!(provider.state.binds.lock().unwrap().len(), binds_before);
 
         let requested_address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0);
-        let local_address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 49152);
-        assert_eq!(
-            bind(&session, listener, requested_address),
-            Ok(SocketOutcome::Completed(local_address))
-        );
+        let SocketOutcome::Completed(local_address) =
+            bind(&session, listener, requested_address).unwrap()
+        else {
+            panic!("guest TCP bind failed");
+        };
+        assert!(local_address.ip().is_loopback());
+        assert_ne!(local_address.port(), 0);
         assert_eq!(
             status(&session, listener),
             Ok(SocketStatusResponse {
@@ -1907,17 +2183,39 @@ pub(crate) mod tests {
             )))
         );
 
+        let competing_session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let competitor = create(
+            &competing_session,
+            create_request(),
+            Arc::new(TestReadinessSink::default()),
+        )
+        .unwrap();
+        assert_eq!(
+            bind(&competing_session, competitor, local_address),
+            Ok(SocketOutcome::Failed(SocketError::AddressInUse))
+        );
         session.close_object_reference(listener).unwrap();
+        assert_eq!(broker.reserved_sockets.load(Ordering::Relaxed), 1);
+        assert_eq!(
+            bind(&competing_session, competitor, local_address),
+            Ok(SocketOutcome::Completed(local_address))
+        );
+        competing_session
+            .close_object_reference(competitor)
+            .unwrap();
         assert_eq!(broker.reserved_sockets.load(Ordering::Relaxed), 0);
 
         let auto_bound = create(&session, create_request(), readiness).unwrap();
-        assert_eq!(
-            listen(&session, auto_bound, 0),
-            Ok(SocketOutcome::Completed(local_address))
-        );
+        let SocketOutcome::Completed(auto_bound_address) = listen(&session, auto_bound, 0).unwrap()
+        else {
+            panic!("automatic TCP listen failed");
+        };
+        assert_ne!(auto_bound_address.port(), 0);
         assert_eq!(
             provider.state.binds.lock().unwrap().last(),
-            Some(&DEFAULT_TCP_LISTEN_ADDRESS)
+            Some(&auto_bound_address)
         );
         session.close_object_reference(auto_bound).unwrap();
     }
@@ -2241,6 +2539,13 @@ pub(crate) mod tests {
             connect(&session, poisoned, loopback_address()),
             Err(BrokerError::Internal)
         );
+        let poisoned_local_address = *provider
+            .state
+            .binds
+            .lock()
+            .unwrap()
+            .last()
+            .expect("automatic TCP bind was not recorded");
         assert_eq!(
             connect(&session, poisoned, loopback_address()),
             Ok(SocketOutcome::Completed(SocketConnectionStatus::Failed(
@@ -2251,7 +2556,7 @@ pub(crate) mod tests {
             status(&session, poisoned),
             Ok(SocketStatusResponse {
                 status: SocketConnectionStatus::Failed(SocketError::Other),
-                local_address: None,
+                local_address: Some(poisoned_local_address),
                 pending_error: None,
             })
         );
@@ -2281,7 +2586,14 @@ pub(crate) mod tests {
             Ok(SocketOutcome::Completed(SocketConnectionStatus::Connecting))
         );
 
-        let local_address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 49152);
+        let local_address = *provider
+            .state
+            .binds
+            .lock()
+            .unwrap()
+            .last()
+            .expect("automatic TCP bind was not recorded");
+        let platform_local_address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 49152);
         *provider.state.status_responses.lock().unwrap() = std::collections::VecDeque::from([
             SocketStatusResponse {
                 status: SocketConnectionStatus::Connecting,
@@ -2290,7 +2602,7 @@ pub(crate) mod tests {
             },
             SocketStatusResponse {
                 status: SocketConnectionStatus::Connected,
-                local_address: Some(local_address),
+                local_address: Some(platform_local_address),
                 pending_error: Some(SocketError::ConnectionReset),
             },
         ]);
@@ -2339,7 +2651,13 @@ pub(crate) mod tests {
             Ok(SocketOutcome::Completed(SocketConnectionStatus::Connecting))
         );
 
-        let local_address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 49153);
+        let local_address = *provider
+            .state
+            .binds
+            .lock()
+            .unwrap()
+            .last()
+            .expect("automatic TCP bind was not recorded");
         provider
             .state
             .status_responses
@@ -2347,7 +2665,7 @@ pub(crate) mod tests {
             .unwrap()
             .push_back(SocketStatusResponse {
                 status: SocketConnectionStatus::Failed(SocketError::TimedOut),
-                local_address: Some(local_address),
+                local_address: Some(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 49153)),
                 pending_error: None,
             });
 

--- a/litebox_broker_core/src/socket.rs
+++ b/litebox_broker_core/src/socket.rs
@@ -423,12 +423,16 @@ pub fn connect(
             }
         };
         match binding {
-            SocketOutcome::Completed((local_address, reservation)) => {
+            ReserveAndBindOutcome::Completed(local_address, reservation) => {
                 attach_binding(&object, local_address, reservation);
             }
-            SocketOutcome::Failed(error) => {
+            ReserveAndBindOutcome::Failed(error) => {
                 finish_connect(&object, SocketConnectionStatus::Unconnected);
                 return Ok(SocketOutcome::Failed(error));
+            }
+            ReserveAndBindOutcome::Retired => {
+                finish_connect(&object, SocketConnectionStatus::Failed(SocketError::Other));
+                return Err(BrokerError::Internal);
             }
         }
     }
@@ -491,11 +495,15 @@ pub fn bind(
     }
     let outcome = if is_tcp(create_request) {
         match reserve_and_bind(session, create_request, &resource, address) {
-            Ok(SocketOutcome::Completed((local_address, reservation))) => {
+            Ok(ReserveAndBindOutcome::Completed(local_address, reservation)) => {
                 finish_configuration(&object, Some(local_address), Some(reservation), false);
                 return Ok(SocketOutcome::Completed(local_address));
             }
-            Ok(SocketOutcome::Failed(error)) => Ok(SocketOutcome::Failed(error)),
+            Ok(ReserveAndBindOutcome::Failed(error)) => Ok(SocketOutcome::Failed(error)),
+            Ok(ReserveAndBindOutcome::Retired) => {
+                finish_retired_configuration(&object, None, None);
+                return Err(BrokerError::Internal);
+            }
             Err(error) => Err(error),
         }
     } else {
@@ -580,13 +588,17 @@ pub fn listen(
             }
         };
         match binding {
-            SocketOutcome::Completed((address, reservation)) => {
+            ReserveAndBindOutcome::Completed(address, reservation) => {
                 local_address = Some(address);
                 port_reservation = Some(reservation);
             }
-            SocketOutcome::Failed(error) => {
+            ReserveAndBindOutcome::Failed(error) => {
                 finish_configuration(&object, None, None, false);
                 return Ok(SocketOutcome::Failed(error));
+            }
+            ReserveAndBindOutcome::Retired => {
+                finish_retired_configuration(&object, None, None);
+                return Err(BrokerError::Internal);
             }
         }
     }
@@ -1035,26 +1047,35 @@ fn socket_state(
     ))
 }
 
+enum ReserveAndBindOutcome {
+    Completed(SocketAddrV4, GuestPortReservation),
+    Failed(SocketError),
+    Retired,
+}
+
 fn reserve_and_bind(
     session: &BrokerSession,
     create_request: CreateSocketRequest,
     resource: &SocketResource,
     requested_address: SocketAddrV4,
-) -> Result<SocketOutcome<(SocketAddrV4, GuestPortReservation)>> {
+) -> Result<ReserveAndBindOutcome> {
     let (local_address, reservation) = match session
         .core
         .socket_ports
         .reserve(create_request, requested_address)?
     {
         SocketOutcome::Completed(binding) => binding,
-        SocketOutcome::Failed(error) => return Ok(SocketOutcome::Failed(error)),
+        SocketOutcome::Failed(error) => return Ok(ReserveAndBindOutcome::Failed(error)),
     };
     match resource.bind(local_address)? {
         SocketOutcome::Completed(bound_address) if bound_address == local_address => {
-            Ok(SocketOutcome::Completed((local_address, reservation)))
+            Ok(ReserveAndBindOutcome::Completed(local_address, reservation))
         }
-        SocketOutcome::Completed(_) => Err(BrokerError::Internal),
-        SocketOutcome::Failed(error) => Ok(SocketOutcome::Failed(error)),
+        SocketOutcome::Completed(_) => {
+            resource.retire();
+            Ok(ReserveAndBindOutcome::Retired)
+        }
+        SocketOutcome::Failed(error) => Ok(ReserveAndBindOutcome::Failed(error)),
     }
 }
 
@@ -1457,6 +1478,7 @@ pub(crate) mod tests {
         fail_create: core::sync::atomic::AtomicBool,
         fail_connect: core::sync::atomic::AtomicBool,
         fail_connect_indeterminate: core::sync::atomic::AtomicBool,
+        invalid_bind_address: core::sync::atomic::AtomicBool,
         fail_shutdown: core::sync::atomic::AtomicBool,
         tcp_option_sets: StdMutex<std::vec::Vec<TcpOptionValue>>,
         failed_readiness: StdMutex<Option<ReadinessRegistration>>,
@@ -1475,6 +1497,12 @@ pub(crate) mod tests {
         fn fail_next_connect_indeterminate(&self) {
             self.state
                 .fail_connect_indeterminate
+                .store(true, Ordering::Relaxed);
+        }
+
+        fn return_invalid_bind_address_once(&self) {
+            self.state
+                .invalid_bind_address
                 .store(true, Ordering::Relaxed);
         }
 
@@ -1546,8 +1574,24 @@ pub(crate) mod tests {
         fn bind(&self, address: SocketAddrV4) -> Result<SocketOutcome<SocketAddrV4>> {
             self.state.binds.lock().unwrap().push(address);
             if is_tcp(self.create_request) {
-                *self.guest_local_address.lock().unwrap() = Some(address);
-                return Ok(SocketOutcome::Completed(address));
+                let bound_address = if self
+                    .state
+                    .invalid_bind_address
+                    .swap(false, Ordering::Relaxed)
+                {
+                    SocketAddrV4::new(
+                        *address.ip(),
+                        if address.port() == u16::MAX {
+                            address.port() - 1
+                        } else {
+                            address.port() + 1
+                        },
+                    )
+                } else {
+                    address
+                };
+                *self.guest_local_address.lock().unwrap() = Some(bound_address);
+                return Ok(SocketOutcome::Completed(bound_address));
             }
             let address = if address.port() == 0 {
                 SocketAddrV4::new(*address.ip(), 49152)
@@ -1728,6 +1772,7 @@ pub(crate) mod tests {
         check_quota_waits_for_deferred_retirement(broker, provider);
         check_platform_socket_retires_before_last_arc_drop(broker, provider);
         check_socket_quotas(broker);
+        check_invalid_bind_response_retires_socket(broker, provider);
     }
 
     fn check_platform_socket_retires_before_last_arc_drop(
@@ -1798,6 +1843,93 @@ pub(crate) mod tests {
         assert_eq!(broker.pending_references.load(Ordering::Relaxed), 0);
         assert_eq!(broker.reserved_sockets.load(Ordering::Relaxed), 0);
         assert_eq!(session.reserved_sockets.load(Ordering::Relaxed), 0);
+    }
+
+    fn check_invalid_bind_response_retires_socket(
+        broker: &BrokerCore,
+        provider: &TestSocketProvider,
+    ) {
+        let first_session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let second_session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let readiness = Arc::new(TestReadinessSink::default());
+        let retired_before = provider.state.retired_sockets.load(Ordering::Relaxed);
+        let address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 42000);
+
+        let invalid = create(&first_session, create_request(), readiness.clone()).unwrap();
+        provider.return_invalid_bind_address_once();
+        assert_eq!(
+            bind(&first_session, invalid, address),
+            Err(BrokerError::Internal)
+        );
+        assert_eq!(
+            provider.state.retired_sockets.load(Ordering::Relaxed),
+            retired_before + 1
+        );
+        assert_eq!(
+            status(&first_session, invalid),
+            Ok(SocketStatusResponse {
+                status: SocketConnectionStatus::Failed(SocketError::Other),
+                local_address: None,
+                pending_error: None,
+            })
+        );
+        assert_eq!(
+            bind(&first_session, invalid, address),
+            Ok(SocketOutcome::Failed(SocketError::InvalidArgument))
+        );
+
+        let replacement = create(&second_session, create_request(), readiness.clone()).unwrap();
+        assert_eq!(
+            bind(&second_session, replacement, address),
+            Ok(SocketOutcome::Completed(address))
+        );
+        assert_eq!(
+            provider.state.retired_sockets.load(Ordering::Relaxed),
+            retired_before + 1
+        );
+        first_session.close_object_reference(invalid).unwrap();
+        assert_eq!(
+            provider.state.retired_sockets.load(Ordering::Relaxed),
+            retired_before + 1
+        );
+        second_session.close_object_reference(replacement).unwrap();
+
+        let invalid_connect = create(&first_session, create_request(), readiness).unwrap();
+        let retired_before_connect = provider.state.retired_sockets.load(Ordering::Relaxed);
+        provider.return_invalid_bind_address_once();
+        assert_eq!(
+            connect(&first_session, invalid_connect, loopback_address()),
+            Err(BrokerError::Internal)
+        );
+        assert_eq!(
+            provider.state.retired_sockets.load(Ordering::Relaxed),
+            retired_before_connect + 1
+        );
+        assert_eq!(
+            status(&first_session, invalid_connect),
+            Ok(SocketStatusResponse {
+                status: SocketConnectionStatus::Failed(SocketError::Other),
+                local_address: None,
+                pending_error: None,
+            })
+        );
+        assert_eq!(
+            connect(&first_session, invalid_connect, loopback_address()),
+            Ok(SocketOutcome::Completed(SocketConnectionStatus::Failed(
+                SocketError::Other
+            )))
+        );
+        first_session
+            .close_object_reference(invalid_connect)
+            .unwrap();
+        assert_eq!(
+            provider.state.retired_sockets.load(Ordering::Relaxed),
+            retired_before_connect + 1
+        );
     }
 
     fn check_socket_operations_and_policy(broker: &BrokerCore, provider: &TestSocketProvider) {

--- a/litebox_broker_core/src/socket.rs
+++ b/litebox_broker_core/src/socket.rs
@@ -119,7 +119,9 @@ impl Drop for GuestPortReservation {
 pub struct AcceptedPlatformSocket {
     /// Accepted nonblocking platform socket.
     pub socket: Arc<dyn PlatformSocket>,
-    /// Remote endpoint of the accepted connection.
+    /// Guest-visible remote endpoint of the accepted connection.
+    ///
+    /// Platforms must translate private backend endpoints before returning.
     pub remote_address: SocketAddrV4,
 }
 
@@ -195,6 +197,7 @@ pub trait PlatformSocket: Send + Sync {
     /// nonzero port and must echo it unchanged; the host endpoint backing the
     /// socket is chosen privately by the platform. A datagram socket receives
     /// the address requested by the guest and returns the host-assigned one.
+    /// Returning an error must leave the socket unbound and retryable.
     fn bind(&self, address: SocketAddrV4) -> Result<SocketOutcome<SocketAddrV4>>;
 
     /// Makes this socket listen for incoming connections.
@@ -424,7 +427,7 @@ pub fn connect(
         };
         match binding {
             ReserveAndBindOutcome::Completed(local_address, reservation) => {
-                attach_binding(&object, local_address, reservation);
+                attach_binding(&object, local_address, reservation)?;
             }
             ReserveAndBindOutcome::Failed(error) => {
                 finish_connect(&object, SocketConnectionStatus::Unconnected);
@@ -438,6 +441,7 @@ pub fn connect(
     }
     let status = match resource.connect(address) {
         Ok(SocketConnectionStatus::Unconnected) => {
+            resource.retire();
             finish_connect(&object, SocketConnectionStatus::Failed(SocketError::Other));
             return Err(BrokerError::Internal);
         }
@@ -447,6 +451,7 @@ pub fn connect(
             return Err(error);
         }
         Err(PlatformConnectError::PeerIndeterminate(error)) => {
+            resource.retire();
             finish_connect(&object, SocketConnectionStatus::Failed(SocketError::Other));
             return Err(error);
         }
@@ -485,23 +490,23 @@ pub fn bind(
     ) {
         Ok(()) => {}
         Err(BrokerError::PolicyDenied) => {
-            finish_configuration(&object, None, None, false);
+            finish_configuration(&object, None, None, false)?;
             return Ok(SocketOutcome::Failed(SocketError::PolicyDenied));
         }
         Err(error) => {
-            finish_configuration(&object, None, None, false);
+            finish_configuration(&object, None, None, false)?;
             return Err(error);
         }
     }
     let outcome = if is_tcp(create_request) {
         match reserve_and_bind(session, create_request, &resource, address) {
             Ok(ReserveAndBindOutcome::Completed(local_address, reservation)) => {
-                finish_configuration(&object, Some(local_address), Some(reservation), false);
+                finish_configuration(&object, Some(local_address), Some(reservation), false)?;
                 return Ok(SocketOutcome::Completed(local_address));
             }
             Ok(ReserveAndBindOutcome::Failed(error)) => Ok(SocketOutcome::Failed(error)),
             Ok(ReserveAndBindOutcome::Retired) => {
-                finish_retired_configuration(&object, None, None);
+                finish_retired_configuration(&object, None, None)?;
                 return Err(BrokerError::Internal);
             }
             Err(error) => Err(error),
@@ -511,15 +516,15 @@ pub fn bind(
     };
     match outcome {
         Ok(SocketOutcome::Completed(local_address)) => {
-            finish_configuration(&object, Some(local_address), None, false);
+            finish_configuration(&object, Some(local_address), None, false)?;
             Ok(SocketOutcome::Completed(local_address))
         }
         Ok(SocketOutcome::Failed(error)) => {
-            finish_configuration(&object, None, None, false);
+            finish_configuration(&object, None, None, false)?;
             Ok(SocketOutcome::Failed(error))
         }
         Err(error) => {
-            finish_configuration(&object, None, None, false);
+            finish_configuration(&object, None, None, false)?;
             Err(error)
         }
     }
@@ -567,11 +572,11 @@ pub fn listen(
         ) {
             Ok(()) => {}
             Err(BrokerError::PolicyDenied) => {
-                finish_configuration(&object, None, None, false);
+                finish_configuration(&object, None, None, false)?;
                 return Ok(SocketOutcome::Failed(SocketError::PolicyDenied));
             }
             Err(error) => {
-                finish_configuration(&object, None, None, false);
+                finish_configuration(&object, None, None, false)?;
                 return Err(error);
             }
         }
@@ -583,7 +588,7 @@ pub fn listen(
         ) {
             Ok(binding) => binding,
             Err(error) => {
-                finish_configuration(&object, None, None, false);
+                finish_configuration(&object, None, None, false)?;
                 return Err(error);
             }
         };
@@ -593,11 +598,11 @@ pub fn listen(
                 port_reservation = Some(reservation);
             }
             ReserveAndBindOutcome::Failed(error) => {
-                finish_configuration(&object, None, None, false);
+                finish_configuration(&object, None, None, false)?;
                 return Ok(SocketOutcome::Failed(error));
             }
             ReserveAndBindOutcome::Retired => {
-                finish_retired_configuration(&object, None, None);
+                finish_retired_configuration(&object, None, None)?;
                 return Err(BrokerError::Internal);
             }
         }
@@ -607,18 +612,18 @@ pub fn listen(
         Ok(SocketOutcome::Completed(address)) => {
             if local_address != Some(address) {
                 resource.retire();
-                finish_retired_configuration(&object, local_address, port_reservation);
+                finish_retired_configuration(&object, local_address, port_reservation)?;
                 return Err(BrokerError::Internal);
             }
-            finish_configuration(&object, local_address, port_reservation, true);
+            finish_configuration(&object, local_address, port_reservation, true)?;
             Ok(SocketOutcome::Completed(address))
         }
         Ok(SocketOutcome::Failed(error)) => {
-            finish_configuration(&object, local_address, port_reservation, false);
+            finish_configuration(&object, local_address, port_reservation, false)?;
             Ok(SocketOutcome::Failed(error))
         }
         Err(error) => {
-            finish_configuration(&object, local_address, port_reservation, false);
+            finish_configuration(&object, local_address, port_reservation, false)?;
             Err(error)
         }
     }
@@ -1157,12 +1162,30 @@ fn attach_binding(
     object: &spin::RwLock<ObjectEntry>,
     local_address: SocketAddrV4,
     port_reservation: GuestPortReservation,
-) {
-    let mut object = object.write();
-    if let ObjectEntry::Socket(socket) = &mut *object {
-        socket.local_address = Some(local_address);
-        socket.resource.set_port_reservation(port_reservation);
+) -> Result<()> {
+    let duplicate = {
+        let mut object = object.write();
+        let ObjectEntry::Socket(socket) = &mut *object else {
+            return Err(BrokerError::Internal);
+        };
+        match socket.resource.set_port_reservation(port_reservation) {
+            Ok(()) => {
+                socket.local_address = Some(local_address);
+                None
+            }
+            Err(port_reservation) => {
+                socket.connect_in_flight = false;
+                socket.connection_status = SocketConnectionStatus::Failed(SocketError::Other);
+                Some((Arc::clone(&socket.resource), port_reservation))
+            }
+        }
+    };
+    if let Some((resource, port_reservation)) = duplicate {
+        resource.retire();
+        drop(port_reservation);
+        return Err(BrokerError::Internal);
     }
+    Ok(())
 }
 
 fn finish_configuration(
@@ -1170,33 +1193,50 @@ fn finish_configuration(
     local_address: Option<SocketAddrV4>,
     port_reservation: Option<GuestPortReservation>,
     listening: bool,
-) {
-    let mut object = object.write();
-    if let ObjectEntry::Socket(socket) = &mut *object {
+) -> Result<()> {
+    let duplicate = {
+        let mut object = object.write();
+        let ObjectEntry::Socket(socket) = &mut *object else {
+            return Err(BrokerError::Internal);
+        };
         socket.configuration_in_flight = false;
-        socket.local_address = socket.local_address.or(local_address);
-        if let Some(port_reservation) = port_reservation {
-            socket.resource.set_port_reservation(port_reservation);
+        let duplicate = port_reservation.and_then(|port_reservation| {
+            socket
+                .resource
+                .set_port_reservation(port_reservation)
+                .err()
+                .map(|port_reservation| (Arc::clone(&socket.resource), port_reservation))
+        });
+        if duplicate.is_some() {
+            socket.listening = false;
+            socket.connection_status = SocketConnectionStatus::Failed(SocketError::Other);
+        } else {
+            socket.local_address = socket.local_address.or(local_address);
+            socket.listening |= listening;
         }
-        socket.listening |= listening;
+        duplicate
+    };
+    if let Some((resource, port_reservation)) = duplicate {
+        resource.retire();
+        drop(port_reservation);
+        return Err(BrokerError::Internal);
     }
+    Ok(())
 }
 
 fn finish_retired_configuration(
     object: &spin::RwLock<ObjectEntry>,
     local_address: Option<SocketAddrV4>,
     port_reservation: Option<GuestPortReservation>,
-) {
+) -> Result<()> {
+    finish_configuration(object, local_address, port_reservation, false)?;
     let mut object = object.write();
-    if let ObjectEntry::Socket(socket) = &mut *object {
-        socket.configuration_in_flight = false;
-        socket.local_address = socket.local_address.or(local_address);
-        if let Some(port_reservation) = port_reservation {
-            socket.resource.set_port_reservation(port_reservation);
-        }
-        socket.listening = false;
-        socket.connection_status = SocketConnectionStatus::Failed(SocketError::Other);
-    }
+    let ObjectEntry::Socket(socket) = &mut *object else {
+        return Err(BrokerError::Internal);
+    };
+    socket.listening = false;
+    socket.connection_status = SocketConnectionStatus::Failed(SocketError::Other);
+    Ok(())
 }
 
 pub(crate) struct SocketObject {
@@ -1254,12 +1294,16 @@ pub(crate) struct SocketResource {
 }
 
 impl SocketResource {
-    fn set_port_reservation(&self, reservation: GuestPortReservation) {
+    fn set_port_reservation(
+        &self,
+        reservation: GuestPortReservation,
+    ) -> core::result::Result<(), GuestPortReservation> {
         let mut slot = self.port_reservation.lock();
-        debug_assert!(slot.is_none());
-        if slot.is_none() {
-            *slot = Some(reservation);
+        if slot.is_some() {
+            return Err(reservation);
         }
+        *slot = Some(reservation);
+        Ok(())
     }
 
     fn platform_socket(&self) -> &dyn PlatformSocket {
@@ -1478,6 +1522,7 @@ pub(crate) mod tests {
         fail_create: core::sync::atomic::AtomicBool,
         fail_connect: core::sync::atomic::AtomicBool,
         fail_connect_indeterminate: core::sync::atomic::AtomicBool,
+        return_unconnected_connect: core::sync::atomic::AtomicBool,
         invalid_bind_address: core::sync::atomic::AtomicBool,
         fail_shutdown: core::sync::atomic::AtomicBool,
         tcp_option_sets: StdMutex<std::vec::Vec<TcpOptionValue>>,
@@ -1497,6 +1542,12 @@ pub(crate) mod tests {
         fn fail_next_connect_indeterminate(&self) {
             self.state
                 .fail_connect_indeterminate
+                .store(true, Ordering::Relaxed);
+        }
+
+        fn return_unconnected_connect_once(&self) {
+            self.state
+                .return_unconnected_connect
                 .store(true, Ordering::Relaxed);
         }
 
@@ -1639,6 +1690,13 @@ pub(crate) mod tests {
                     BrokerError::Internal,
                 ));
             }
+            if self
+                .state
+                .return_unconnected_connect
+                .swap(false, Ordering::Relaxed)
+            {
+                return Ok(SocketConnectionStatus::Unconnected);
+            }
             self.readiness
                 .publish(ReadinessFlags::WRITE)
                 .map_err(PlatformConnectError::PeerIndeterminate)?;
@@ -1773,6 +1831,7 @@ pub(crate) mod tests {
         check_platform_socket_retires_before_last_arc_drop(broker, provider);
         check_socket_quotas(broker);
         check_invalid_bind_response_retires_socket(broker, provider);
+        check_duplicate_port_reservation_retires_socket(broker, provider);
     }
 
     fn check_platform_socket_retires_before_last_arc_drop(
@@ -1929,6 +1988,65 @@ pub(crate) mod tests {
         assert_eq!(
             provider.state.retired_sockets.load(Ordering::Relaxed),
             retired_before_connect + 1
+        );
+    }
+
+    fn check_duplicate_port_reservation_retires_socket(
+        broker: &BrokerCore,
+        provider: &TestSocketProvider,
+    ) {
+        let session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let handle = create(
+            &session,
+            create_request(),
+            Arc::new(TestReadinessSink::default()),
+        )
+        .unwrap();
+        let original_address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 42001);
+        assert_eq!(
+            bind(&session, handle, original_address),
+            Ok(SocketOutcome::Completed(original_address))
+        );
+
+        let duplicate_ports = BrokerSocketPorts::default();
+        let duplicate_address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 42002);
+        let SocketOutcome::Completed((duplicate_address, duplicate_reservation)) = duplicate_ports
+            .reserve(create_request(), duplicate_address)
+            .unwrap()
+        else {
+            panic!("duplicate-reservation test could not reserve a port");
+        };
+        let object = session
+            .authorized_object(handle, ObjectRights::WRITE)
+            .unwrap();
+        let retired_before = provider.state.retired_sockets.load(Ordering::Relaxed);
+        assert_eq!(
+            attach_binding(&object, duplicate_address, duplicate_reservation),
+            Err(BrokerError::Internal)
+        );
+        assert_eq!(
+            provider.state.retired_sockets.load(Ordering::Relaxed),
+            retired_before + 1
+        );
+        assert_eq!(
+            status(&session, handle),
+            Ok(SocketStatusResponse {
+                status: SocketConnectionStatus::Failed(SocketError::Other),
+                local_address: Some(original_address),
+                pending_error: None,
+            })
+        );
+        assert!(matches!(
+            duplicate_ports.reserve(create_request(), duplicate_address),
+            Ok(SocketOutcome::Completed(_))
+        ));
+
+        session.close_object_reference(handle).unwrap();
+        assert_eq!(
+            provider.state.retired_sockets.load(Ordering::Relaxed),
+            retired_before + 1
         );
     }
 
@@ -2666,10 +2784,15 @@ pub(crate) mod tests {
             Arc::new(TestReadinessSink::default()),
         )
         .unwrap();
+        let retired_before_poisoned = provider.state.retired_sockets.load(Ordering::Relaxed);
         provider.fail_next_connect_indeterminate();
         assert_eq!(
             connect(&session, poisoned, loopback_address()),
             Err(BrokerError::Internal)
+        );
+        assert_eq!(
+            provider.state.retired_sockets.load(Ordering::Relaxed),
+            retired_before_poisoned + 1
         );
         let poisoned_local_address = *provider
             .state
@@ -2692,9 +2815,40 @@ pub(crate) mod tests {
                 pending_error: None,
             })
         );
+        session.close_object_reference(poisoned).unwrap();
+        assert_eq!(
+            provider.state.retired_sockets.load(Ordering::Relaxed),
+            retired_before_poisoned + 1
+        );
+
+        let invalid_status = create(
+            &session,
+            create_request(),
+            Arc::new(TestReadinessSink::default()),
+        )
+        .unwrap();
+        let retired_before_invalid_status = provider.state.retired_sockets.load(Ordering::Relaxed);
+        provider.return_unconnected_connect_once();
+        assert_eq!(
+            connect(&session, invalid_status, loopback_address()),
+            Err(BrokerError::Internal)
+        );
+        assert_eq!(
+            provider.state.retired_sockets.load(Ordering::Relaxed),
+            retired_before_invalid_status + 1
+        );
+        assert_eq!(
+            status(&session, invalid_status).unwrap().status,
+            SocketConnectionStatus::Failed(SocketError::Other)
+        );
+        session.close_object_reference(invalid_status).unwrap();
+        assert_eq!(
+            provider.state.retired_sockets.load(Ordering::Relaxed),
+            retired_before_invalid_status + 1
+        );
         assert_eq!(
             provider.state.connect_calls.load(Ordering::Relaxed),
-            calls_before + 3
+            calls_before + 4
         );
     }
 

--- a/litebox_broker_core/src/socket.rs
+++ b/litebox_broker_core/src/socket.rs
@@ -190,6 +190,13 @@ pub trait SocketProvider: Send + Sync {
 /// The broker retains this resource in an `Arc`, allowing an operation already
 /// in flight to finish after its object handle closes. Before releasing its
 /// portable authority, core explicitly retires the platform socket.
+///
+/// Implementations own their authoritative native lifecycle state. A request
+/// handler must record the start of a native transition before issuing it, and
+/// the corresponding synchronous result or asynchronous completion handler
+/// must finish that transition. [`status`](PlatformSocket::status) projects
+/// that platform-owned state for the guest; core may cache the projection but
+/// does not drive native teardown from it.
 pub trait PlatformSocket: Send + Sync {
     /// Binds this socket to a local address and echoes the assigned address.
     ///
@@ -216,7 +223,10 @@ pub trait PlatformSocket: Send + Sync {
     /// permits replacing its peer and treats synchronous failures as retryable
     /// operation outcomes. A datagram `Failed` status must leave the previous
     /// peer unchanged. Platform failures must distinguish a peer known to be
-    /// unchanged from one whose state is indeterminate.
+    /// unchanged from one whose state is indeterminate. Once a native connect
+    /// may have started, implementations must retain enough platform state to
+    /// settle or conservatively retire it without reconstructing its lifecycle
+    /// during teardown.
     fn connect(
         &self,
         address: SocketAddrV4,

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -766,6 +766,7 @@ mod tests {
             Ok(Arc::new(TestPlatformSocket {
                 readiness,
                 create_request: request,
+                local_address: Mutex::new(None),
             }))
         }
 
@@ -775,6 +776,7 @@ mod tests {
     struct TestPlatformSocket {
         readiness: ReadinessRegistration,
         create_request: CreateSocketRequest,
+        local_address: Mutex<Option<SocketAddrV4>>,
     }
 
     impl PlatformSocket for TestPlatformSocket {
@@ -782,11 +784,16 @@ mod tests {
             &self,
             address: SocketAddrV4,
         ) -> litebox_broker_core::Result<SocketOutcome<SocketAddrV4>> {
+            if self.create_request.socket_type == SocketType::Stream {
+                *self.local_address.lock().unwrap() = Some(address);
+                return Ok(SocketOutcome::Completed(address));
+            }
             let address = if address.port() == 0 {
                 SocketAddrV4::new(*address.ip(), 49152)
             } else {
                 address
             };
+            *self.local_address.lock().unwrap() = Some(address);
             Ok(SocketOutcome::Completed(address))
         }
 
@@ -794,10 +801,11 @@ mod tests {
             &self,
             _backlog: u32,
         ) -> litebox_broker_core::Result<SocketOutcome<SocketAddrV4>> {
-            Ok(SocketOutcome::Completed(SocketAddrV4::new(
-                Ipv4Addr::LOCALHOST,
-                49152,
-            )))
+            self.local_address
+                .lock()
+                .unwrap()
+                .ok_or(litebox_broker_core::BrokerError::Internal)
+                .map(SocketOutcome::Completed)
         }
 
         fn accept(
@@ -1365,7 +1373,7 @@ mod tests {
             ),
             BrokerResult::Socket(SocketResponse::Status(SocketStatusResponse {
                 status: SocketConnectionStatus::Connected,
-                local_address: None,
+                local_address: Some(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 49152)),
                 pending_error: None,
             }))
         );

--- a/litebox_broker_platform_linux_userland/src/socket.rs
+++ b/litebox_broker_platform_linux_userland/src/socket.rs
@@ -576,6 +576,19 @@ impl ReactorClient {
         receive.recv().unwrap()
     }
 
+    #[cfg(test)]
+    fn expire_pending_guest_connections(&self) {
+        let (response, receive) = sync_channel(1);
+        self.commands
+            .send(ReactorCommand::ExpireDeadlinedState {
+                now: Instant::now() + PENDING_CONNECT_DISCARD_LIFETIME + Duration::from_secs(1),
+                response,
+            })
+            .unwrap();
+        self.signal().unwrap();
+        receive.recv().unwrap();
+    }
+
     fn close_session(&self, session_id: SessionId) {
         let (response, receive) = sync_channel(1);
         if self
@@ -733,6 +746,11 @@ enum ReactorCommand {
     #[cfg(test)]
     RetainedConnectorCount {
         response: SyncSender<usize>,
+    },
+    #[cfg(test)]
+    ExpireDeadlinedState {
+        now: Instant,
+        response: SyncSender<()>,
     },
     Stop {
         response: SyncSender<()>,
@@ -1091,6 +1109,7 @@ impl Reactor {
     }
 
     fn retire_session_connectors(&mut self, session_id: SessionId) {
+        let discard_deadline = Instant::now() + PENDING_CONNECT_DISCARD_LIFETIME;
         let mut released = 0;
         for connection in self
             .tcp
@@ -1102,7 +1121,7 @@ impl Reactor {
                 let _ = sockopt::set_socket_linger(&connector, None);
                 drop(connector);
                 connection.discard_on_accept = true;
-                connection.discard_deadline = None;
+                connection.discard_deadline = Some(discard_deadline);
                 released += 1;
             }
         }
@@ -1854,6 +1873,11 @@ impl Reactor {
                 #[cfg(test)]
                 ReactorCommand::RetainedConnectorCount { response } => {
                     let _ = response.send(self.retained_connectors);
+                }
+                #[cfg(test)]
+                ReactorCommand::ExpireDeadlinedState { now, response } => {
+                    self.expire_deadlined_state(now);
+                    let _ = response.send(());
                 }
                 ReactorCommand::Stop { response } => {
                     self.sockets.clear();
@@ -4008,13 +4032,14 @@ mod tests {
         drop(connector_session);
         assert_eq!(provider.reactor.pending_guest_connection_count(), 1);
         assert_eq!(provider.reactor.retained_connector_count(), 0);
+        provider.reactor.expire_pending_guest_connections();
+        assert_eq!(provider.reactor.pending_guest_connection_count(), 0);
         wait_for_readiness(&publications, listener, ReadinessFlags::READ);
         assert!(matches!(
             litebox_broker_core::socket::accept(&listener_session, listener, readiness.clone(),),
             Err(BrokerError::WouldBlock)
         ));
         assert_ne!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), listener);
-        assert_eq!(provider.reactor.pending_guest_connection_count(), 0);
 
         let final_connector_session = broker
             .create_session(CallerCredential::Unauthenticated)

--- a/litebox_broker_platform_linux_userland/src/socket.rs
+++ b/litebox_broker_platform_linux_userland/src/socket.rs
@@ -43,6 +43,7 @@ use litebox_broker_core::readiness::ReadinessRegistration;
 const WAKE_TOKEN: u64 = 0;
 const MAX_QUEUED_SOCKET_COMMANDS: usize = 64;
 const MAX_EPOLL_EVENTS: usize = 64;
+const MAX_UNMATCHED_ACCEPTS_PER_COMMAND: usize = 64;
 const PENDING_CONNECT_DISCARD_LIFETIME: Duration = Duration::from_mins(5);
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -780,7 +781,7 @@ struct AcceptedEndpoints {
 #[derive(Clone, Copy)]
 enum PendingGuestConnectionDisposition {
     Retain,
-    Discard(Option<Instant>),
+    Discard,
 }
 
 /// State owned and accessed exclusively by the socket reactor thread.
@@ -1186,7 +1187,6 @@ impl Reactor {
         remote_address: SocketAddrV4,
         local_address: SocketAddrV4,
     ) -> Option<SocketAddrV4> {
-        self.expire_deadlined_state(Instant::now());
         let mut connection = self
             .tcp
             .take_pending_guest_connection(remote_address, local_address)?;
@@ -1496,15 +1496,13 @@ impl Reactor {
             .status
             == SocketConnectionStatus::Connecting;
         let disposition = match getpeername(&socket) {
-            Ok(Some(_)) if abortive_close => PendingGuestConnectionDisposition::Discard(None),
+            Ok(Some(_)) if abortive_close => PendingGuestConnectionDisposition::Discard,
             Ok(Some(_)) => PendingGuestConnectionDisposition::Retain,
             Ok(None) | Err(_) => {
                 if abortive_close || connecting {
                     let _ = sockopt::set_socket_linger(&socket, Some(Duration::ZERO));
                 }
-                PendingGuestConnectionDisposition::Discard(Some(
-                    Instant::now() + PENDING_CONNECT_DISCARD_LIFETIME,
-                ))
+                PendingGuestConnectionDisposition::Discard
             }
         };
         let mut socket = Some(socket);
@@ -1513,13 +1511,14 @@ impl Reactor {
             && pending.session_id == session_id
         {
             pending.discard_on_accept =
-                matches!(disposition, PendingGuestConnectionDisposition::Discard(_));
+                matches!(disposition, PendingGuestConnectionDisposition::Discard);
             pending.discard_deadline = match disposition {
-                PendingGuestConnectionDisposition::Retain
-                | PendingGuestConnectionDisposition::Discard(None) => None,
-                PendingGuestConnectionDisposition::Discard(Some(deadline)) => Some(deadline),
+                PendingGuestConnectionDisposition::Retain => None,
+                PendingGuestConnectionDisposition::Discard => {
+                    Some(Instant::now() + PENDING_CONNECT_DISCARD_LIFETIME)
+                }
             };
-            if pending.discard_deadline.is_none() {
+            if matches!(disposition, PendingGuestConnectionDisposition::Retain) {
                 pending.retained_connector = socket.take();
                 self.retained_connector_count = self
                     .retained_connector_count
@@ -2017,9 +2016,11 @@ impl Reactor {
                 listener.tcp_keep_alive,
             )
         };
+        self.expire_deadlined_state(Instant::now());
         if !self.has_accept_capacity(listener_id, listener_session_id)? {
             return Err(BrokerError::ResourceExhausted);
         }
+        let mut unmatched_accept_count = 0;
         let (socket, remote_address) = loop {
             let (socket, remote_address) = loop {
                 let listener = self
@@ -2055,6 +2056,12 @@ impl Reactor {
                 break (socket, guest_address);
             }
             drop(socket);
+            unmatched_accept_count += 1;
+            if unmatched_accept_count >= MAX_UNMATCHED_ACCEPTS_PER_COMMAND {
+                // Keep cached READ readiness: edge-triggered epoll will not
+                // report connections that remain queued on the listener.
+                return Err(BrokerError::WouldBlock);
+            }
         };
         if self
             .sockets
@@ -4053,6 +4060,139 @@ mod tests {
         assert_eq!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), listener);
         assert_eq!(provider.reactor.pending_guest_connection_count(), 0);
         assert_eq!(provider.reactor.retained_connector_count(), 0);
+    }
+
+    #[test]
+    fn abortive_connector_close_releases_descriptor_capacity() {
+        let provider = Arc::new(LinuxSocketProvider::new(3, 1).unwrap());
+        let broker = BrokerCore::new_with_limits(
+            PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
+                .with_socket_policy(SocketPolicy::Ipv4Loopback),
+            BrokerCoreLimits::new_with_all_limits(8, 0, 3, 3),
+            provider.clone(),
+        )
+        .unwrap();
+        let listener_session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let connector_session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let (published, publications) = channel();
+        let (retired, retirements) = channel();
+        let readiness = Arc::new(TestReadinessSink { published, retired });
+        let guest_address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8086);
+        let listener = create_socket(&listener_session, readiness.clone());
+        assert_eq!(
+            litebox_broker_core::socket::bind(&listener_session, listener, guest_address),
+            Ok(SocketOutcome::Completed(guest_address))
+        );
+        assert_eq!(
+            litebox_broker_core::socket::listen(&listener_session, listener, 1),
+            Ok(SocketOutcome::Completed(guest_address))
+        );
+
+        let connector = create_socket(&connector_session, readiness.clone());
+        assert!(matches!(
+            litebox_broker_core::socket::connect(&connector_session, connector, guest_address,),
+            Ok(SocketOutcome::Completed(
+                SocketConnectionStatus::Connecting | SocketConnectionStatus::Connected
+            ))
+        ));
+        wait_until_connected(&connector_session, connector, &publications);
+        assert_eq!(
+            litebox_broker_core::socket::shutdown(
+                &connector_session,
+                connector,
+                ShutdownMode::Abort,
+            ),
+            Ok(SocketOutcome::Completed(()))
+        );
+        connector_session.close_object_reference(connector).unwrap();
+        assert_eq!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), connector);
+        assert_eq!(provider.reactor.pending_guest_connection_count(), 1);
+        assert_eq!(provider.reactor.retained_connector_count(), 0);
+
+        let replacement = create_socket(&connector_session, readiness);
+        connector_session
+            .close_object_reference(replacement)
+            .unwrap();
+        assert_eq!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), replacement);
+        provider.reactor.expire_pending_guest_connections();
+        assert_eq!(provider.reactor.pending_guest_connection_count(), 0);
+        assert_eq!(provider.reactor.retained_connector_count(), 0);
+    }
+
+    #[test]
+    fn accept_bounds_unmatched_private_connections_per_command() {
+        let provider = Arc::new(LinuxSocketProvider::new(3, 2).unwrap());
+        let broker = BrokerCore::new_with_limits(
+            PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
+                .with_socket_policy(SocketPolicy::Ipv4Loopback),
+            BrokerCoreLimits::new_with_all_limits(8, 0, 3, 3),
+            provider.clone(),
+        )
+        .unwrap();
+        let listener_session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let connector_session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let (published, publications) = channel();
+        let (retired, _retirements) = channel();
+        let readiness = Arc::new(TestReadinessSink { published, retired });
+        let guest_address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8087);
+        let listener = create_socket(&listener_session, readiness.clone());
+        assert_eq!(
+            litebox_broker_core::socket::bind(&listener_session, listener, guest_address),
+            Ok(SocketOutcome::Completed(guest_address))
+        );
+        assert_eq!(
+            litebox_broker_core::socket::listen(
+                &listener_session,
+                listener,
+                u32::try_from(MAX_UNMATCHED_ACCEPTS_PER_COMMAND + 2).unwrap(),
+            ),
+            Ok(SocketOutcome::Completed(guest_address))
+        );
+        let private_address = provider.reactor.host_address(guest_address.port()).unwrap();
+        let _unmatched_connections = (0..MAX_UNMATCHED_ACCEPTS_PER_COMMAND)
+            .map(|_| TcpStream::connect(private_address).unwrap())
+            .collect::<Vec<_>>();
+
+        let connector = create_socket(&connector_session, readiness.clone());
+        assert!(matches!(
+            litebox_broker_core::socket::connect(&connector_session, connector, guest_address,),
+            Ok(SocketOutcome::Completed(
+                SocketConnectionStatus::Connecting | SocketConnectionStatus::Connected
+            ))
+        ));
+        wait_until_connected(&connector_session, connector, &publications);
+        let connector_address = litebox_broker_core::socket::status(&connector_session, connector)
+            .unwrap()
+            .local_address
+            .unwrap();
+        wait_for_readiness(&publications, listener, ReadinessFlags::READ);
+
+        assert!(matches!(
+            litebox_broker_core::socket::accept(&listener_session, listener, readiness.clone(),),
+            Err(BrokerError::WouldBlock)
+        ));
+        assert!(
+            listener_session
+                .check_readiness(listener)
+                .unwrap()
+                .contains(ReadinessFlags::READ)
+        );
+        let accepted =
+            match litebox_broker_core::socket::accept(&listener_session, listener, readiness)
+                .unwrap()
+            {
+                SocketOutcome::Completed(accepted) => accepted,
+                SocketOutcome::Failed(error) => panic!("guest accept failed: {error:?}"),
+            };
+        assert_eq!(accepted.remote_address, connector_address);
     }
 
     #[test]

--- a/litebox_broker_platform_linux_userland/src/socket.rs
+++ b/litebox_broker_platform_linux_userland/src/socket.rs
@@ -434,7 +434,7 @@ impl ReactorClient {
                     wake: reactor_wake,
                     commands: receiver,
                     sockets,
-                    tcp: BrokerTcpState::default(),
+                    tcp: ReactorTcpState::default(),
                     sessions: HashMap::new(),
                     max_sockets,
                     max_sockets_per_session,
@@ -789,8 +789,8 @@ struct Reactor {
     wake: Arc<OwnedFd>,
     commands: Receiver<ReactorCommand>,
     sockets: HashMap<u64, SocketEntry>,
-    tcp: BrokerTcpState,
-    sessions: HashMap<SessionId, SessionSocketState>,
+    tcp: ReactorTcpState,
+    sessions: HashMap<SessionId, ReactorSessionState>,
     max_sockets: usize,
     max_sockets_per_session: usize,
     retained_connectors: usize,
@@ -823,18 +823,18 @@ struct SocketEntry {
     tcp_keep_alive: bool,
 }
 
-/// The broker-wide guest TCP namespace and pending guest-to-guest connections.
+/// Reactor-owned realization of guest TCP bindings and pending connections.
 #[derive(Default)]
-struct BrokerTcpState {
-    bindings: HashMap<u16, GuestPortBinding>,
+struct ReactorTcpState {
+    bindings: HashMap<u16, ReactorTcpBinding>,
     pending_guest_connections: HashMap<(SocketAddrV4, SocketAddrV4), PendingGuestTcpConnection>,
 }
 
-/// Per-session socket ownership, quota, and teardown state.
+/// Reactor-side per-session socket, retained-descriptor, and teardown state.
 ///
 /// Sessions are ownership domains, not guest network namespaces.
 #[derive(Default)]
-struct SessionSocketState {
+struct ReactorSessionState {
     live_sockets: usize,
     pending_guest_connections: usize,
     retained_connectors: usize,
@@ -851,7 +851,7 @@ struct PendingGuestTcpConnection {
 }
 
 #[derive(Clone, Copy)]
-struct GuestPortBinding {
+struct ReactorTcpBinding {
     socket_id: u64,
     guest_address: SocketAddrV4,
     host_address: Option<SocketAddrV4>,
@@ -864,14 +864,14 @@ enum SocketKind {
     Udp,
 }
 
-impl BrokerTcpState {
+impl ReactorTcpState {
     fn reserve_binding(&mut self) -> BrokerResult<()> {
         self.bindings
             .try_reserve(1)
             .map_err(|_| BrokerError::OutOfMemory)
     }
 
-    fn insert_binding(&mut self, port: u16, binding: GuestPortBinding) -> BrokerResult<()> {
+    fn insert_binding(&mut self, port: u16, binding: ReactorTcpBinding) -> BrokerResult<()> {
         if binding.guest_address.port() != port || self.bindings.contains_key(&port) {
             return Err(BrokerError::Internal);
         }
@@ -889,7 +889,7 @@ impl BrokerTcpState {
         }
     }
 
-    fn guest_binding(&self, address: SocketAddrV4) -> Option<GuestPortBinding> {
+    fn guest_binding(&self, address: SocketAddrV4) -> Option<ReactorTcpBinding> {
         if !address.ip().is_loopback() {
             return None;
         }
@@ -938,7 +938,7 @@ impl BrokerTcpState {
     }
 }
 
-fn retain_session_state(state: &SessionSocketState) -> bool {
+fn retain_session_state(state: &ReactorSessionState) -> bool {
     !state.closing
         || state.live_sockets != 0
         || state.pending_guest_connections != 0
@@ -1312,7 +1312,7 @@ impl Reactor {
         let guest_address = SocketAddrV4::new(*requested_address.ip(), guest_port);
         self.tcp.insert_binding(
             guest_port,
-            GuestPortBinding {
+            ReactorTcpBinding {
                 socket_id: id,
                 guest_address,
                 host_address: None,
@@ -3303,7 +3303,7 @@ mod tests {
         let second_listener = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 5001);
         let first_guest = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 1000);
         let second_guest = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 1001);
-        let mut tcp = BrokerTcpState::default();
+        let mut tcp = ReactorTcpState::default();
         for (listener, guest) in [
             (first_listener, first_guest),
             (second_listener, second_guest),

--- a/litebox_broker_platform_linux_userland/src/socket.rs
+++ b/litebox_broker_platform_linux_userland/src/socket.rs
@@ -835,8 +835,8 @@ struct ReactorTcpState {
 /// Sessions are ownership domains, not guest network namespaces.
 #[derive(Default)]
 struct ReactorSessionState {
-    live_sockets: usize,
-    pending_guest_connections: usize,
+    live_socket_count: usize,
+    pending_guest_connection_count: usize,
     retained_connector_count: usize,
     closing: bool,
 }
@@ -938,8 +938,8 @@ impl ReactorTcpState {
 
 fn retain_session_state(state: &ReactorSessionState) -> bool {
     !state.closing
-        || state.live_sockets != 0
-        || state.pending_guest_connections != 0
+        || state.live_socket_count != 0
+        || state.pending_guest_connection_count != 0
         || state.retained_connector_count != 0
 }
 
@@ -993,7 +993,7 @@ impl Reactor {
             .ok_or(BrokerError::Internal)?;
         // Pending records can outlive connector descriptors, so bound this
         // metadata independently using the configured socket budgets.
-        if session.pending_guest_connections >= self.max_sockets_per_session
+        if session.pending_guest_connection_count >= self.max_sockets_per_session
             || self.tcp.pending_guest_connections.len() >= self.max_sockets
         {
             return Err(BrokerError::ResourceExhausted);
@@ -1009,8 +1009,8 @@ impl Reactor {
             .sessions
             .get_mut(&connection.session_id)
             .expect("pending guest connection session state missing");
-        session.pending_guest_connections = session
-            .pending_guest_connections
+        session.pending_guest_connection_count = session
+            .pending_guest_connection_count
             .checked_sub(1)
             .expect("session pending guest connection count underflow");
         if connection.retained_connector.is_some() {
@@ -1039,8 +1039,8 @@ impl Reactor {
             .sessions
             .get_mut(&session_id)
             .ok_or(BrokerError::Internal)?;
-        session.pending_guest_connections = session
-            .pending_guest_connections
+        session.pending_guest_connection_count = session
+            .pending_guest_connection_count
             .checked_add(1)
             .ok_or(BrokerError::ResourceExhausted)?;
         self.tcp.pending_guest_connections.insert(
@@ -1089,8 +1089,8 @@ impl Reactor {
                 let session = sessions
                     .get_mut(&connection.session_id)
                     .expect("pending guest connection session state missing");
-                session.pending_guest_connections = session
-                    .pending_guest_connections
+                session.pending_guest_connection_count = session
+                    .pending_guest_connection_count
                     .checked_sub(1)
                     .expect("session pending guest connection count underflow");
                 if connection.retained_connector.is_some() {
@@ -1161,8 +1161,8 @@ impl Reactor {
                 let session = sessions
                     .get_mut(&connection.session_id)
                     .expect("pending guest connection session state missing");
-                session.pending_guest_connections = session
-                    .pending_guest_connections
+                session.pending_guest_connection_count = session
+                    .pending_guest_connection_count
                     .checked_sub(1)
                     .expect("session pending guest connection count underflow");
                 if connection.retained_connector.is_some() {
@@ -1215,7 +1215,7 @@ impl Reactor {
             .get(&listener_session_id)
             .ok_or(BrokerError::Internal)?;
         let session_at_limit = listener_session
-            .live_sockets
+            .live_socket_count
             .checked_add(listener_session.retained_connector_count)
             .is_none_or(|count| count >= self.max_sockets_per_session);
         if !global_at_limit && !session_at_limit {
@@ -1537,8 +1537,8 @@ impl Reactor {
         }
         drop(socket);
         if let Some(session) = self.sessions.get_mut(&session_id) {
-            session.live_sockets = session
-                .live_sockets
+            session.live_socket_count = session
+                .live_socket_count
                 .checked_sub(1)
                 .expect("session socket count underflow");
         }
@@ -1916,7 +1916,7 @@ impl Reactor {
             return Err(BrokerError::UnknownObject);
         }
         if session
-            .live_sockets
+            .live_socket_count
             .checked_add(session.retained_connector_count)
             .is_none_or(|count| count >= self.max_sockets_per_session)
         {
@@ -1979,8 +1979,8 @@ impl Reactor {
                 tcp_keep_alive: false,
             },
         );
-        session.live_sockets = session
-            .live_sockets
+        session.live_socket_count = session
+            .live_socket_count
             .checked_add(1)
             .ok_or(BrokerError::ResourceExhausted)?;
         Ok(())
@@ -2065,7 +2065,7 @@ impl Reactor {
                 .sessions
                 .get(&listener_session_id)
                 .ok_or(BrokerError::Internal)?
-                .live_sockets
+                .live_socket_count
                 .checked_add(
                     self.sessions
                         .get(&listener_session_id)
@@ -2139,8 +2139,8 @@ impl Reactor {
             .sessions
             .get_mut(&listener_session_id)
             .ok_or(BrokerError::Internal)?;
-        session.live_sockets = session
-            .live_sockets
+        session.live_socket_count = session
+            .live_socket_count
             .checked_add(1)
             .ok_or(BrokerError::ResourceExhausted)?;
         Ok(SocketOutcome::Completed(AcceptedEndpoints {

--- a/litebox_broker_platform_linux_userland/src/socket.rs
+++ b/litebox_broker_platform_linux_userland/src/socket.rs
@@ -3894,7 +3894,12 @@ mod tests {
             ))
         ));
         wait_until_connected(&connector_session, connector, &publications);
-        wait_for_readiness(&publications, listener, ReadinessFlags::READ);
+        wait_until_ready(
+            &listener_session,
+            &publications,
+            listener,
+            ReadinessFlags::READ,
+        );
         let accepted = match litebox_broker_core::socket::accept(
             &listener_session,
             listener,
@@ -4078,7 +4083,7 @@ mod tests {
             Ok(SocketOutcome::Failed(SocketError::Other))
         );
         allow_response.send(()).unwrap();
-        wait_for_readiness(&publications, handle, ReadinessFlags::READ);
+        wait_until_ready(&session, &publications, handle, ReadinessFlags::READ);
         let current_readiness = session.check_readiness(handle).unwrap();
         assert!(!current_readiness.contains(ReadinessFlags::WRITE));
         assert!(!current_readiness.contains(ReadinessFlags::ERROR));
@@ -4144,7 +4149,12 @@ mod tests {
         read_shutdown_data_received
             .recv_timeout(TEST_TIMEOUT)
             .unwrap();
-        wait_for_readiness(&publications, read_shutdown_handle, ReadinessFlags::READ);
+        wait_until_ready(
+            &session,
+            &publications,
+            read_shutdown_handle,
+            ReadinessFlags::READ,
+        );
         let mut read_shutdown_peek = [0_u8; 2];
         assert_eq!(
             receive_into(
@@ -4165,7 +4175,12 @@ mod tests {
             ),
             Ok(SocketOutcome::Completed(()))
         );
-        wait_for_readiness(&publications, read_shutdown_handle, ReadinessFlags::READ);
+        wait_until_ready(
+            &session,
+            &publications,
+            read_shutdown_handle,
+            ReadinessFlags::READ,
+        );
         assert_eq!(
             receive_into(
                 &session,
@@ -4402,7 +4417,12 @@ mod tests {
             ))
         ));
         wait_until_connected(&connector_session, connector, &publications);
-        wait_for_readiness(&publications, listener, ReadinessFlags::READ);
+        wait_until_ready(
+            &listener_session,
+            &publications,
+            listener,
+            ReadinessFlags::READ,
+        );
         let accepted =
             match litebox_broker_core::socket::accept(&listener_session, listener, readiness)
                 .unwrap()
@@ -4414,11 +4434,17 @@ mod tests {
             send_bytes(&listener_session, accepted, b"unread", SendFlags::NONE,),
             Ok(SocketOutcome::Completed(6))
         );
-        wait_for_readiness(&publications, connector, ReadinessFlags::READ);
+        wait_until_ready(
+            &connector_session,
+            &publications,
+            connector,
+            ReadinessFlags::READ,
+        );
 
         connector_session.close_object_reference(connector).unwrap();
         assert_eq!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), connector);
-        wait_for_readiness(
+        wait_until_ready(
+            &listener_session,
             &publications,
             accepted,
             ReadinessFlags::READ | ReadinessFlags::ERROR | ReadinessFlags::HANGUP,
@@ -4481,7 +4507,7 @@ mod tests {
             .unwrap()
             .local_address
             .unwrap();
-        wait_for_readiness(&publications, listener, ReadinessFlags::READ);
+        wait_until_ready(&session, &publications, listener, ReadinessFlags::READ);
         let accepted =
             match litebox_broker_core::socket::accept(&session, listener, readiness).unwrap() {
                 SocketOutcome::Completed(accepted) => accepted,
@@ -4566,6 +4592,7 @@ mod tests {
         );
 
         let native_client = TcpStream::connect(private_address).unwrap();
+        wait_for_readiness(&publications, listener, ReadinessFlags::READ);
         let client = create_socket(&client_session, readiness.clone());
         assert!(matches!(
             litebox_broker_core::socket::connect(&client_session, client, guest_destination),
@@ -4601,7 +4628,12 @@ mod tests {
             retirements.recv_timeout(TEST_TIMEOUT).unwrap(),
             connector_probe
         );
-        wait_for_readiness(&publications, listener, ReadinessFlags::READ);
+        wait_until_ready(
+            &listener_session,
+            &publications,
+            listener,
+            ReadinessFlags::READ,
+        );
         let accepted = match litebox_broker_core::socket::accept(
             &listener_session,
             listener,
@@ -4621,7 +4653,12 @@ mod tests {
             send_bytes(&client_session, client, b"x", SendFlags::NONE),
             Ok(SocketOutcome::Completed(1))
         );
-        wait_for_readiness(&publications, accepted.handle, ReadinessFlags::READ);
+        wait_until_ready(
+            &listener_session,
+            &publications,
+            accepted.handle,
+            ReadinessFlags::READ,
+        );
         let mut byte = [0];
         assert_eq!(
             receive_into(
@@ -4764,7 +4801,12 @@ mod tests {
             blocked_connector
         );
 
-        wait_for_readiness(&publications, listener, ReadinessFlags::READ);
+        wait_until_ready(
+            &listener_session,
+            &publications,
+            listener,
+            ReadinessFlags::READ,
+        );
         assert!(matches!(
             litebox_broker_core::socket::accept(&listener_session, listener, readiness.clone(),),
             Err(BrokerError::WouldBlock)
@@ -4839,7 +4881,12 @@ mod tests {
         connector_session.close_object_reference(connector).unwrap();
         assert_eq!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), connector);
         assert_eq!(provider.reactor.retained_connector_count(), 1);
-        wait_for_readiness(&publications, listener, ReadinessFlags::READ);
+        wait_until_ready(
+            &listener_session,
+            &publications,
+            listener,
+            ReadinessFlags::READ,
+        );
 
         let accepted =
             match litebox_broker_core::socket::accept(&listener_session, listener, readiness)
@@ -5000,7 +5047,12 @@ mod tests {
             .unwrap()
             .local_address
             .unwrap();
-        wait_for_readiness(&publications, listener, ReadinessFlags::READ);
+        wait_until_ready(
+            &listener_session,
+            &publications,
+            listener,
+            ReadinessFlags::READ,
+        );
 
         assert!(matches!(
             litebox_broker_core::socket::accept(&listener_session, listener, readiness.clone(),),
@@ -5236,7 +5288,12 @@ mod tests {
             ))
         ));
         wait_until_connected(&connector_session, connector, &publications);
-        wait_for_readiness(&publications, listener, ReadinessFlags::READ);
+        wait_until_ready(
+            &listener_session,
+            &publications,
+            listener,
+            ReadinessFlags::READ,
+        );
         connector_session.close_object_reference(connector).unwrap();
         assert_eq!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), connector);
         assert_eq!(provider.reactor.pending_guest_connection_count(), 1);
@@ -5330,7 +5387,7 @@ mod tests {
             .unwrap()
             .local_address
             .unwrap();
-        wait_for_readiness(&publications, listener, ReadinessFlags::READ);
+        wait_until_ready(&session, &publications, listener, ReadinessFlags::READ);
         assert_eq!(
             litebox_broker_core::socket::listen(&session, listener, 4),
             Ok(SocketOutcome::Completed(local_address))
@@ -5395,7 +5452,7 @@ mod tests {
             ) {
                 Ok(SocketOutcome::Completed(ReceiveSocketResponse::Received(7))) => break,
                 Err(BrokerError::WouldBlock) => {
-                    wait_for_readiness(&publications, first.handle, ReadinessFlags::READ);
+                    wait_until_ready(&session, &publications, first.handle, ReadinessFlags::READ);
                 }
                 outcome => panic!("unexpected accepted receive outcome: {outcome:?}"),
             }
@@ -5417,7 +5474,7 @@ mod tests {
             ) {
                 Ok(SocketOutcome::Completed(ReceiveSocketResponse::Received(8))) => break,
                 Err(BrokerError::WouldBlock) => {
-                    wait_for_readiness(&publications, first_client, ReadinessFlags::READ);
+                    wait_until_ready(&session, &publications, first_client, ReadinessFlags::READ);
                 }
                 outcome => panic!("unexpected client receive outcome: {outcome:?}"),
             }
@@ -5427,7 +5484,7 @@ mod tests {
             litebox_broker_core::socket::shutdown(&session, listener, ShutdownMode::StopListening,),
             Ok(SocketOutcome::Completed(()))
         );
-        wait_for_readiness(&publications, listener, ReadinessFlags::HANGUP);
+        wait_until_ready(&session, &publications, listener, ReadinessFlags::HANGUP);
         assert!(
             session
                 .check_readiness(listener)
@@ -5494,7 +5551,7 @@ mod tests {
         )
         .unwrap();
 
-        wait_for_readiness(&publications, handle, ReadinessFlags::WRITE);
+        wait_until_ready(&session, &publications, handle, ReadinessFlags::WRITE);
         let shutdown_handle = litebox_broker_core::socket::create(
             &session,
             CreateSocketRequest {
@@ -5505,7 +5562,12 @@ mod tests {
             readiness,
         )
         .unwrap();
-        wait_for_readiness(&publications, shutdown_handle, ReadinessFlags::WRITE);
+        wait_until_ready(
+            &session,
+            &publications,
+            shutdown_handle,
+            ReadinessFlags::WRITE,
+        );
         assert_eq!(
             litebox_broker_core::socket::shutdown(&session, shutdown_handle, ShutdownMode::Both,),
             Ok(SocketOutcome::Completed(()))
@@ -5591,7 +5653,7 @@ mod tests {
         assert_eq!(local_address.port(), source.port());
 
         server.send_to(&[], source).unwrap();
-        wait_for_readiness(&publications, handle, ReadinessFlags::READ);
+        wait_until_ready(&session, &publications, handle, ReadinessFlags::READ);
         let mut zero = [];
         assert_eq!(
             receive_datagram_into(&session, handle, &mut zero, ReceiveFromFlags::NONE,),
@@ -5607,7 +5669,7 @@ mod tests {
         );
 
         server.send_to(b"abcdef", source).unwrap();
-        wait_for_readiness(&publications, handle, ReadinessFlags::READ);
+        wait_until_ready(&session, &publications, handle, ReadinessFlags::READ);
         let mut peeked = [0; 3];
         assert_eq!(
             receive_datagram_into(&session, handle, &mut peeked, ReceiveFromFlags::PEEK,),
@@ -5661,7 +5723,7 @@ mod tests {
             send_datagram(&session, handle, b"refused", SendFlags::NONE, None,),
             Ok(SocketOutcome::Completed(7))
         );
-        wait_for_readiness(&publications, handle, ReadinessFlags::ERROR);
+        wait_until_ready(&session, &publications, handle, ReadinessFlags::ERROR);
         assert_eq!(
             send_datagram(
                 &session,
@@ -5687,7 +5749,7 @@ mod tests {
             send_datagram(&session, handle, b"refused again", SendFlags::NONE, None,),
             Ok(SocketOutcome::Completed(13))
         );
-        wait_for_readiness(&publications, handle, ReadinessFlags::ERROR);
+        wait_until_ready(&session, &publications, handle, ReadinessFlags::ERROR);
         assert_eq!(
             litebox_broker_core::socket::connect(
                 &session,
@@ -5837,6 +5899,18 @@ mod tests {
             readiness,
             Instant::now() + TEST_TIMEOUT,
         );
+    }
+
+    fn wait_until_ready(
+        session: &litebox_broker_core::BrokerSession,
+        publications: &Receiver<(ObjectHandle, ReadinessFlags)>,
+        handle: ObjectHandle,
+        readiness: ReadinessFlags,
+    ) {
+        if session.check_readiness(handle).unwrap().contains(readiness) {
+            return;
+        }
+        wait_for_readiness(publications, handle, readiness);
     }
 
     fn wait_for_readiness_until(

--- a/litebox_broker_platform_linux_userland/src/socket.rs
+++ b/litebox_broker_platform_linux_userland/src/socket.rs
@@ -7,13 +7,13 @@ use std::collections::HashMap;
 use std::fmt;
 use std::io::{Error, ErrorKind, Result as IoResult};
 use std::mem::size_of;
-use std::net::SocketAddrV4;
+use std::net::{Ipv4Addr, SocketAddrV4};
 use std::os::fd::OwnedFd;
 use std::sync::atomic::{AtomicU8, AtomicU64, Ordering};
 use std::sync::mpsc::{Receiver, SyncSender, TryRecvError, TrySendError, sync_channel};
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use litebox_broker_core::socket::{
     AcceptedPlatformSocket, PlatformConnectError, PlatformDatagramReceive, PlatformSocket,
@@ -43,6 +43,7 @@ use litebox_broker_core::readiness::ReadinessRegistration;
 const WAKE_TOKEN: u64 = 0;
 const MAX_QUEUED_SOCKET_COMMANDS: usize = 64;
 const MAX_EPOLL_EVENTS: usize = 64;
+const PENDING_CONNECT_DISCARD_LIFETIME: Duration = Duration::from_mins(5);
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u8)]
@@ -153,10 +154,10 @@ pub struct LinuxSocketProvider {
 }
 
 impl LinuxSocketProvider {
-    /// Starts a provider whose reactor tracks at most `max_sockets` resources.
-    pub fn new(max_sockets: usize) -> IoResult<Self> {
+    /// Starts a provider with global and per-session socket limits.
+    pub fn new(max_sockets: usize, max_sockets_per_session: usize) -> IoResult<Self> {
         Ok(Self {
-            reactor: Arc::new(ReactorClient::start(max_sockets)?),
+            reactor: Arc::new(ReactorClient::start(max_sockets, max_sockets_per_session)?),
         })
     }
 }
@@ -164,7 +165,7 @@ impl LinuxSocketProvider {
 impl SocketProvider for LinuxSocketProvider {
     fn create(
         &self,
-        _session_id: SessionId,
+        session_id: SessionId,
         request: CreateSocketRequest,
         readiness: ReadinessRegistration,
     ) -> BrokerResult<Arc<dyn PlatformSocket>> {
@@ -185,6 +186,7 @@ impl SocketProvider for LinuxSocketProvider {
         });
         self.reactor.request(|response| ReactorCommand::Create {
             id,
+            session_id,
             request,
             readiness,
             snapshot,
@@ -194,7 +196,9 @@ impl SocketProvider for LinuxSocketProvider {
         Ok(socket)
     }
 
-    fn close_session(&self, _session_id: SessionId) {}
+    fn close_session(&self, session_id: SessionId) {
+        self.reactor.close_session(session_id);
+    }
 }
 
 /// Broker-core-facing handle for a reactor-owned socket.
@@ -249,7 +253,6 @@ impl PlatformSocket for LinuxSocket {
             SocketOutcome::Completed(accepted) => {
                 Ok(SocketOutcome::Completed(AcceptedPlatformSocket {
                     socket,
-                    local_address: accepted.local_address,
                     remote_address: accepted.remote_address,
                 }))
             }
@@ -401,7 +404,7 @@ struct ReactorClient {
 }
 
 impl ReactorClient {
-    fn start(max_sockets: usize) -> IoResult<Self> {
+    fn start(max_sockets: usize, max_sockets_per_session: usize) -> IoResult<Self> {
         let epoll_fd = epoll::create(epoll::CreateFlags::CLOEXEC)?;
         let wake = Arc::new(eventfd(0, EventfdFlags::CLOEXEC | EventfdFlags::NONBLOCK)?);
         epoll::add(
@@ -431,7 +434,11 @@ impl ReactorClient {
                     wake: reactor_wake,
                     commands: receiver,
                     sockets,
+                    tcp: BrokerTcpState::default(),
+                    sessions: HashMap::new(),
                     max_sockets,
+                    max_sockets_per_session,
+                    retained_connectors: 0,
                     peek_cache: None,
                     events,
                 };
@@ -483,7 +490,9 @@ impl ReactorClient {
             Err(TrySendError::Full(_)) => return Err(BrokerError::ResourceExhausted),
             Err(TrySendError::Disconnected(_)) => return Err(BrokerError::Internal),
         }
-        self.signal().map_err(|_| BrokerError::Internal)?;
+        // Once queued, wait for acknowledgement even if the wake write fails:
+        // another reactor event may still cause the command to execute.
+        let _ = self.signal();
         receive.recv().map_err(|_| BrokerError::Internal)?
     }
 
@@ -511,8 +520,9 @@ impl ReactorClient {
                 ));
             }
         }
-        self.signal()
-            .map_err(|_| PlatformConnectError::PeerIndeterminate(BrokerError::Internal))?;
+        // A queued connect has indeterminate peer state until the reactor
+        // acknowledges it, regardless of whether this wake write succeeds.
+        let _ = self.signal();
         receive
             .recv()
             .map_err(|_| PlatformConnectError::PeerIndeterminate(BrokerError::Internal))?
@@ -529,6 +539,55 @@ impl ReactorClient {
         }
         // Do not release the core's socket quota until the reactor has dropped
         // the descriptor, even if the redundant wake write fails.
+        let _ = self.signal();
+        let _ = receive.recv();
+    }
+
+    #[cfg(test)]
+    fn host_address(&self, guest_port: u16) -> Option<SocketAddrV4> {
+        let (response, receive) = sync_channel(1);
+        self.commands
+            .send(ReactorCommand::HostAddress {
+                guest_port,
+                response,
+            })
+            .unwrap();
+        self.signal().unwrap();
+        receive.recv().unwrap()
+    }
+
+    #[cfg(test)]
+    fn pending_guest_connection_count(&self) -> usize {
+        let (response, receive) = sync_channel(1);
+        self.commands
+            .send(ReactorCommand::PendingGuestConnectionCount { response })
+            .unwrap();
+        self.signal().unwrap();
+        receive.recv().unwrap()
+    }
+
+    #[cfg(test)]
+    fn retained_connector_count(&self) -> usize {
+        let (response, receive) = sync_channel(1);
+        self.commands
+            .send(ReactorCommand::RetainedConnectorCount { response })
+            .unwrap();
+        self.signal().unwrap();
+        receive.recv().unwrap()
+    }
+
+    fn close_session(&self, session_id: SessionId) {
+        let (response, receive) = sync_channel(1);
+        if self
+            .commands
+            .send(ReactorCommand::CloseSession {
+                session_id,
+                response,
+            })
+            .is_err()
+        {
+            return;
+        }
         let _ = self.signal();
         let _ = receive.recv();
     }
@@ -580,6 +639,7 @@ impl Drop for ReactorClient {
 enum ReactorCommand {
     Create {
         id: u64,
+        session_id: SessionId,
         request: CreateSocketRequest,
         readiness: ReadinessRegistration,
         snapshot: Arc<Mutex<SocketSnapshot>>,
@@ -657,6 +717,23 @@ enum ReactorCommand {
         id: u64,
         response: SyncSender<()>,
     },
+    CloseSession {
+        session_id: SessionId,
+        response: SyncSender<()>,
+    },
+    #[cfg(test)]
+    HostAddress {
+        guest_port: u16,
+        response: SyncSender<Option<SocketAddrV4>>,
+    },
+    #[cfg(test)]
+    PendingGuestConnectionCount {
+        response: SyncSender<usize>,
+    },
+    #[cfg(test)]
+    RetainedConnectorCount {
+        response: SyncSender<usize>,
+    },
     Stop {
         response: SyncSender<()>,
     },
@@ -679,8 +756,13 @@ enum ReactorReceiveFromOutcome {
 }
 
 struct AcceptedEndpoints {
-    local_address: SocketAddrV4,
     remote_address: SocketAddrV4,
+}
+
+#[derive(Clone, Copy)]
+enum PendingGuestConnectionDisposition {
+    Retain,
+    Discard(Option<Instant>),
 }
 
 /// State owned and accessed exclusively by the socket reactor thread.
@@ -689,7 +771,11 @@ struct Reactor {
     wake: Arc<OwnedFd>,
     commands: Receiver<ReactorCommand>,
     sockets: HashMap<u64, SocketEntry>,
+    tcp: BrokerTcpState,
+    sessions: HashMap<SessionId, SessionSocketState>,
     max_sockets: usize,
+    max_sockets_per_session: usize,
+    retained_connectors: usize,
     peek_cache: Option<PeekCache>,
     events: Vec<epoll::Event>,
 }
@@ -701,8 +787,10 @@ struct PeekCache {
 }
 
 /// Reactor-owned descriptor and its broker-facing readiness state.
+#[allow(clippy::struct_excessive_bools)] // Independent cached socket attributes.
 struct SocketEntry {
     socket: OwnedFd,
+    session_id: SessionId,
     kind: SocketKind,
     readiness: ReadinessRegistration,
     snapshot: Arc<Mutex<SocketSnapshot>>,
@@ -710,12 +798,133 @@ struct SocketEntry {
     write_shutdown: bool,
     peek_waitall_threshold: Option<usize>,
     listening: bool,
+    abortive_close: bool,
+    guest_local_address: Option<SocketAddrV4>,
+    host_connection: Option<(SocketAddrV4, SocketAddrV4)>,
+    tcp_no_delay: bool,
+    tcp_keep_alive: bool,
+}
+
+/// The broker-wide guest TCP namespace and pending guest-to-guest connections.
+#[derive(Default)]
+struct BrokerTcpState {
+    bindings: HashMap<u16, GuestPortBinding>,
+    pending_guest_connections: HashMap<(SocketAddrV4, SocketAddrV4), PendingGuestTcpConnection>,
+}
+
+/// Per-session socket ownership, quota, and teardown state.
+///
+/// Sessions are ownership domains, not guest network namespaces.
+#[derive(Default)]
+struct SessionSocketState {
+    live_sockets: usize,
+    pending_guest_connections: usize,
+    retained_connectors: usize,
+    closing: bool,
+}
+
+struct PendingGuestTcpConnection {
+    session_id: SessionId,
+    guest_address: SocketAddrV4,
+    listener_id: u64,
+    discard_on_accept: bool,
+    discard_deadline: Option<Instant>,
+    retained_connector: Option<OwnedFd>,
+}
+
+#[derive(Clone, Copy)]
+struct GuestPortBinding {
+    socket_id: u64,
+    guest_address: SocketAddrV4,
+    host_address: Option<SocketAddrV4>,
+    listening: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum SocketKind {
     Tcp,
     Udp,
+}
+
+impl BrokerTcpState {
+    fn reserve_binding(&mut self) -> BrokerResult<()> {
+        self.bindings
+            .try_reserve(1)
+            .map_err(|_| BrokerError::OutOfMemory)
+    }
+
+    fn insert_binding(&mut self, port: u16, binding: GuestPortBinding) -> BrokerResult<()> {
+        if binding.guest_address.port() != port || self.bindings.contains_key(&port) {
+            return Err(BrokerError::Internal);
+        }
+        self.bindings.insert(port, binding);
+        Ok(())
+    }
+
+    fn remove_binding(&mut self, port: u16, socket_id: u64) {
+        if self
+            .bindings
+            .get(&port)
+            .is_some_and(|binding| binding.socket_id == socket_id)
+        {
+            self.bindings.remove(&port);
+        }
+    }
+
+    fn guest_binding(&self, address: SocketAddrV4) -> Option<GuestPortBinding> {
+        if !address.ip().is_loopback() {
+            return None;
+        }
+        self.bindings.get(&address.port()).copied()
+    }
+
+    fn set_host_address(
+        &mut self,
+        port: u16,
+        socket_id: u64,
+        host_address: SocketAddrV4,
+    ) -> BrokerResult<()> {
+        let binding = self.bindings.get_mut(&port).ok_or(BrokerError::Internal)?;
+        if binding.socket_id != socket_id {
+            return Err(BrokerError::Internal);
+        }
+        binding.host_address = Some(host_address);
+        Ok(())
+    }
+
+    fn mark_listening(&mut self, port: u16, socket_id: u64) -> BrokerResult<()> {
+        let binding = self.bindings.get_mut(&port).ok_or(BrokerError::Internal)?;
+        if binding.socket_id != socket_id || binding.host_address.is_none() {
+            return Err(BrokerError::Internal);
+        }
+        binding.listening = true;
+        Ok(())
+    }
+
+    fn stop_listening(&mut self, port: u16, socket_id: u64) -> BrokerResult<()> {
+        let binding = self.bindings.get_mut(&port).ok_or(BrokerError::Internal)?;
+        if binding.socket_id != socket_id {
+            return Err(BrokerError::Internal);
+        }
+        binding.listening = false;
+        Ok(())
+    }
+
+    fn take_pending_guest_connection(
+        &mut self,
+        remote_address: SocketAddrV4,
+        local_address: SocketAddrV4,
+    ) -> Option<PendingGuestTcpConnection> {
+        self.pending_guest_connections
+            .remove(&(remote_address, local_address))
+    }
+}
+
+fn retain_session_state(state: &SessionSocketState) -> bool {
+    !state.closing
+        || state.live_sockets != 0
+        || state.pending_guest_connections != 0
+        || state.retained_connectors != 0
 }
 
 /// Cached connection and readiness state shared with the broker-facing handle.
@@ -761,11 +970,591 @@ impl fmt::Display for ReactorFailure {
 }
 
 impl Reactor {
+    fn reserve_pending_guest_connection(&mut self, session_id: SessionId) -> BrokerResult<()> {
+        let session = self
+            .sessions
+            .get(&session_id)
+            .ok_or(BrokerError::Internal)?;
+        if session.pending_guest_connections >= self.max_sockets_per_session
+            || self.tcp.pending_guest_connections.len() >= self.max_sockets
+        {
+            return Err(BrokerError::ResourceExhausted);
+        }
+        self.tcp
+            .pending_guest_connections
+            .try_reserve(1)
+            .map_err(|_| BrokerError::OutOfMemory)
+    }
+
+    fn finish_removed_pending_guest_connection(&mut self, connection: &PendingGuestTcpConnection) {
+        let session = self
+            .sessions
+            .get_mut(&connection.session_id)
+            .expect("pending guest connection session state missing");
+        session.pending_guest_connections = session
+            .pending_guest_connections
+            .checked_sub(1)
+            .expect("session pending guest connection count underflow");
+        if connection.retained_connector.is_some() {
+            self.retained_connectors = self
+                .retained_connectors
+                .checked_sub(1)
+                .expect("reactor retained connector count underflow");
+            session.retained_connectors = session
+                .retained_connectors
+                .checked_sub(1)
+                .expect("session retained connector count underflow");
+        }
+    }
+
+    fn insert_pending_guest_connection(
+        &mut self,
+        session_id: SessionId,
+        connection: (SocketAddrV4, SocketAddrV4),
+        guest_address: SocketAddrV4,
+        listener_id: u64,
+    ) -> BrokerResult<()> {
+        if let Some(previous) = self.tcp.pending_guest_connections.remove(&connection) {
+            self.finish_removed_pending_guest_connection(&previous);
+        }
+        let session = self
+            .sessions
+            .get_mut(&session_id)
+            .ok_or(BrokerError::Internal)?;
+        session.pending_guest_connections = session
+            .pending_guest_connections
+            .checked_add(1)
+            .ok_or(BrokerError::ResourceExhausted)?;
+        self.tcp.pending_guest_connections.insert(
+            connection,
+            PendingGuestTcpConnection {
+                session_id,
+                guest_address,
+                listener_id,
+                discard_on_accept: false,
+                discard_deadline: None,
+                retained_connector: None,
+            },
+        );
+        Ok(())
+    }
+
+    fn remove_pending_guest_connection(
+        &mut self,
+        connection: (SocketAddrV4, SocketAddrV4),
+        session_id: SessionId,
+    ) {
+        let removed = self
+            .tcp
+            .pending_guest_connections
+            .get(&connection)
+            .is_some_and(|pending| pending.session_id == session_id)
+            .then(|| self.tcp.pending_guest_connections.remove(&connection))
+            .flatten();
+        if let Some(pending) = removed {
+            self.finish_removed_pending_guest_connection(&pending);
+        }
+        self.sessions
+            .retain(|_, session| retain_session_state(session));
+    }
+
+    fn remove_pending_guest_connections_for_listener(&mut self, listener_id: u64) {
+        let Reactor {
+            tcp,
+            sessions,
+            retained_connectors,
+            ..
+        } = self;
+        tcp.pending_guest_connections.retain(|_, connection| {
+            let retain = connection.listener_id != listener_id;
+            if !retain {
+                let session = sessions
+                    .get_mut(&connection.session_id)
+                    .expect("pending guest connection session state missing");
+                session.pending_guest_connections = session
+                    .pending_guest_connections
+                    .checked_sub(1)
+                    .expect("session pending guest connection count underflow");
+                if connection.retained_connector.is_some() {
+                    session.retained_connectors = session
+                        .retained_connectors
+                        .checked_sub(1)
+                        .expect("session retained connector count underflow");
+                    *retained_connectors = retained_connectors
+                        .checked_sub(1)
+                        .expect("reactor retained connector count underflow");
+                }
+            }
+            retain
+        });
+        sessions.retain(|_, session| retain_session_state(session));
+    }
+
+    fn retire_session_connectors(&mut self, session_id: SessionId) {
+        let mut released = 0;
+        for connection in self
+            .tcp
+            .pending_guest_connections
+            .values_mut()
+            .filter(|connection| connection.session_id == session_id)
+        {
+            if let Some(connector) = connection.retained_connector.take() {
+                let _ = sockopt::set_socket_linger(&connector, None);
+                drop(connector);
+                connection.discard_on_accept = true;
+                connection.discard_deadline = None;
+                released += 1;
+            }
+        }
+        self.retained_connectors = self
+            .retained_connectors
+            .checked_sub(released)
+            .expect("reactor retained connector count underflow");
+        if let Some(session) = self.sessions.get_mut(&session_id) {
+            session.retained_connectors = session
+                .retained_connectors
+                .checked_sub(released)
+                .expect("session retained connector count underflow");
+        }
+    }
+
+    fn next_cleanup_deadline(&self) -> Option<Instant> {
+        self.tcp
+            .pending_guest_connections
+            .values()
+            .filter_map(|connection| connection.discard_deadline)
+            .min()
+    }
+
+    fn expire_deadlined_state(&mut self, now: Instant) {
+        let Reactor {
+            tcp,
+            sessions,
+            retained_connectors,
+            ..
+        } = self;
+        tcp.pending_guest_connections.retain(|_, connection| {
+            let retain = !connection.discard_on_accept
+                || connection
+                    .discard_deadline
+                    .is_none_or(|deadline| deadline > now);
+            if !retain {
+                let session = sessions
+                    .get_mut(&connection.session_id)
+                    .expect("pending guest connection session state missing");
+                session.pending_guest_connections = session
+                    .pending_guest_connections
+                    .checked_sub(1)
+                    .expect("session pending guest connection count underflow");
+                if connection.retained_connector.is_some() {
+                    session.retained_connectors = session
+                        .retained_connectors
+                        .checked_sub(1)
+                        .expect("session retained connector count underflow");
+                    *retained_connectors = retained_connectors
+                        .checked_sub(1)
+                        .expect("reactor retained connector count underflow");
+                }
+            }
+            retain
+        });
+        sessions.retain(|_, session| retain_session_state(session));
+    }
+
+    fn take_pending_guest_connection_for_accept(
+        &mut self,
+        listener_id: u64,
+        remote_address: SocketAddrV4,
+        local_address: SocketAddrV4,
+    ) -> Option<SocketAddrV4> {
+        self.expire_deadlined_state(Instant::now());
+        let mut connection = self
+            .tcp
+            .take_pending_guest_connection(remote_address, local_address)?;
+        self.finish_removed_pending_guest_connection(&connection);
+        drop(connection.retained_connector.take());
+        let guest_address = (!connection.discard_on_accept
+            && connection.listener_id == listener_id)
+            .then_some(connection.guest_address);
+        self.sessions
+            .retain(|_, session| retain_session_state(session));
+        guest_address
+    }
+
+    fn has_accept_capacity(
+        &self,
+        listener_id: u64,
+        listener_session_id: SessionId,
+    ) -> BrokerResult<bool> {
+        let global_at_limit = self
+            .sockets
+            .len()
+            .checked_add(self.retained_connectors)
+            .is_none_or(|count| count >= self.max_sockets);
+        let listener_session = self
+            .sessions
+            .get(&listener_session_id)
+            .ok_or(BrokerError::Internal)?;
+        let session_at_limit = listener_session
+            .live_sockets
+            .checked_add(listener_session.retained_connectors)
+            .is_none_or(|count| count >= self.max_sockets_per_session);
+        if !global_at_limit && !session_at_limit {
+            return Ok(true);
+        }
+
+        for connection in self
+            .tcp
+            .pending_guest_connections
+            .values()
+            .filter(|connection| connection.listener_id == listener_id)
+            .filter(|connection| !connection.discard_on_accept)
+        {
+            if global_at_limit && connection.retained_connector.is_none() {
+                return Ok(false);
+            }
+            if session_at_limit
+                && (connection.session_id != listener_session_id
+                    || connection.retained_connector.is_none())
+            {
+                return Ok(false);
+            }
+        }
+        Ok(true)
+    }
+
+    fn is_private_host_endpoint(&self, address: SocketAddrV4) -> bool {
+        self.tcp
+            .bindings
+            .values()
+            .filter_map(|binding| binding.host_address)
+            .any(|host_address| host_address == address)
+    }
+
+    fn resolve_guest_destination(
+        &self,
+        mut address: SocketAddrV4,
+    ) -> SocketOutcome<(SocketAddrV4, Option<u64>)> {
+        if address.ip().is_unspecified() {
+            address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, address.port());
+        }
+        if let Some(binding) = self.tcp.guest_binding(address) {
+            // A live guest binding owns this destination port broker-wide;
+            // only a listener may receive connections through it.
+            if !binding.listening {
+                return SocketOutcome::Failed(SocketError::ConnectionRefused);
+            }
+            return match binding.host_address {
+                Some(host_address) => {
+                    SocketOutcome::Completed((host_address, Some(binding.socket_id)))
+                }
+                None => SocketOutcome::Failed(SocketError::ConnectionRefused),
+            };
+        }
+        if self.is_private_host_endpoint(address) {
+            SocketOutcome::Failed(SocketError::ConnectionRefused)
+        } else {
+            SocketOutcome::Completed((address, None))
+        }
+    }
+
+    fn bind_socket(
+        &mut self,
+        id: u64,
+        requested_address: SocketAddrV4,
+    ) -> BrokerResult<SocketOutcome<SocketAddrV4>> {
+        let (kind, already_bound) = self
+            .sockets
+            .get(&id)
+            .map(|socket| (socket.kind, socket.guest_local_address.is_some()))
+            .ok_or(BrokerError::Internal)?;
+        if kind != SocketKind::Tcp {
+            let socket = self.sockets.get_mut(&id).ok_or(BrokerError::Internal)?;
+            return match bind_host_socket(socket, requested_address)? {
+                SocketOutcome::Completed(local_address) => {
+                    socket
+                        .snapshot
+                        .lock()
+                        .expect("Linux socket snapshot mutex poisoned")
+                        .local_address = Some(local_address);
+                    Ok(SocketOutcome::Completed(local_address))
+                }
+                SocketOutcome::Failed(error) => Ok(SocketOutcome::Failed(error)),
+            };
+        }
+        if already_bound {
+            return Ok(SocketOutcome::Failed(SocketError::InvalidArgument));
+        }
+        let guest_port = requested_address.port();
+        if guest_port == 0 {
+            return Err(BrokerError::Internal);
+        }
+        self.tcp.reserve_binding()?;
+        let guest_address = SocketAddrV4::new(*requested_address.ip(), guest_port);
+        self.tcp.insert_binding(
+            guest_port,
+            GuestPortBinding {
+                socket_id: id,
+                guest_address,
+                host_address: None,
+                listening: false,
+            },
+        )?;
+        let socket = self.sockets.get_mut(&id).ok_or(BrokerError::Internal)?;
+        socket.guest_local_address = Some(guest_address);
+        socket
+            .snapshot
+            .lock()
+            .expect("Linux socket snapshot mutex poisoned")
+            .local_address = Some(guest_address);
+        Ok(SocketOutcome::Completed(guest_address))
+    }
+
+    fn listen_socket(
+        &mut self,
+        id: u64,
+        backlog: u32,
+    ) -> BrokerResult<SocketOutcome<SocketAddrV4>> {
+        let (kind, guest_address) = self
+            .sockets
+            .get(&id)
+            .map(|socket| (socket.kind, socket.guest_local_address))
+            .ok_or(BrokerError::Internal)?;
+        if kind != SocketKind::Tcp {
+            return Ok(SocketOutcome::Failed(SocketError::InvalidArgument));
+        }
+        let guest_address = guest_address.ok_or(BrokerError::Internal)?;
+        let needs_host_bind =
+            local_socket_address(&self.sockets.get(&id).ok_or(BrokerError::Internal)?.socket)?
+                .port()
+                == 0;
+        if needs_host_bind {
+            let socket = self.sockets.get_mut(&id).ok_or(BrokerError::Internal)?;
+            let host_address =
+                match bind_host_socket(socket, SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0))? {
+                    SocketOutcome::Completed(address) => address,
+                    SocketOutcome::Failed(error) => return Ok(SocketOutcome::Failed(error)),
+                };
+            self.tcp
+                .set_host_address(guest_address.port(), id, host_address)?;
+        }
+        match listen_tcp_socket(
+            &self.epoll,
+            id,
+            self.sockets.get_mut(&id).ok_or(BrokerError::Internal)?,
+            backlog,
+        )? {
+            SocketOutcome::Completed(()) => {
+                self.tcp.mark_listening(guest_address.port(), id)?;
+                Ok(SocketOutcome::Completed(guest_address))
+            }
+            SocketOutcome::Failed(error) => Ok(SocketOutcome::Failed(error)),
+        }
+    }
+
+    fn connect_socket(
+        &mut self,
+        id: u64,
+        guest_address: SocketAddrV4,
+    ) -> core::result::Result<SocketConnectionStatus, PlatformConnectError> {
+        let kind = self.sockets.get(&id).map(|socket| socket.kind).ok_or(
+            PlatformConnectError::PeerIndeterminate(BrokerError::Internal),
+        )?;
+        if kind != SocketKind::Tcp {
+            return connect_datagram_socket(
+                self.sockets
+                    .get_mut(&id)
+                    .ok_or(PlatformConnectError::PeerIndeterminate(
+                        BrokerError::Internal,
+                    ))?,
+                guest_address,
+            );
+        }
+        let (session_id, local_guest_address) = self
+            .sockets
+            .get(&id)
+            .and_then(|socket| {
+                socket
+                    .guest_local_address
+                    .map(|address| (socket.session_id, address))
+            })
+            .ok_or(PlatformConnectError::PeerUnchanged(BrokerError::Internal))?;
+        let (network_address, guest_listener_id) =
+            match self.resolve_guest_destination(guest_address) {
+                SocketOutcome::Completed(destination) => destination,
+                SocketOutcome::Failed(error) => {
+                    let status = SocketConnectionStatus::Failed(error);
+                    update_snapshot(
+                        self.sockets
+                            .get(&id)
+                            .ok_or(PlatformConnectError::PeerUnchanged(BrokerError::Internal))?,
+                        Some(status),
+                        ReadinessFlags::ERROR,
+                    )
+                    .map_err(PlatformConnectError::PeerIndeterminate)?;
+                    return Ok(status);
+                }
+            };
+        if guest_listener_id.is_some() {
+            self.expire_deadlined_state(Instant::now());
+            self.reserve_pending_guest_connection(session_id)
+                .map_err(PlatformConnectError::PeerUnchanged)?;
+        }
+        let (status, readiness) = connect_tcp_socket(
+            &self.epoll,
+            id,
+            self.sockets
+                .get_mut(&id)
+                .ok_or(PlatformConnectError::PeerUnchanged(BrokerError::Internal))?,
+            network_address,
+        )?;
+        if matches!(
+            status,
+            SocketConnectionStatus::Connecting | SocketConnectionStatus::Connected
+        ) {
+            let host_address = local_socket_address(
+                &self
+                    .sockets
+                    .get(&id)
+                    .ok_or(PlatformConnectError::PeerIndeterminate(
+                        BrokerError::Internal,
+                    ))?
+                    .socket,
+            )
+            .map_err(PlatformConnectError::PeerIndeterminate)?;
+            self.tcp
+                .set_host_address(local_guest_address.port(), id, host_address)
+                .map_err(PlatformConnectError::PeerIndeterminate)?;
+            if let Some(listener_id) = guest_listener_id {
+                let connection = (host_address, network_address);
+                self.insert_pending_guest_connection(
+                    session_id,
+                    connection,
+                    local_guest_address,
+                    listener_id,
+                )
+                .map_err(PlatformConnectError::PeerIndeterminate)?;
+                self.sockets
+                    .get_mut(&id)
+                    .ok_or(PlatformConnectError::PeerIndeterminate(
+                        BrokerError::Internal,
+                    ))?
+                    .host_connection = Some(connection);
+            }
+        }
+        update_snapshot(
+            self.sockets
+                .get(&id)
+                .ok_or(PlatformConnectError::PeerIndeterminate(
+                    BrokerError::Internal,
+                ))?,
+            Some(status),
+            readiness,
+        )
+        .map_err(PlatformConnectError::PeerIndeterminate)?;
+        Ok(status)
+    }
+
+    fn remove_socket(&mut self, id: u64) {
+        let Some(socket) = self.sockets.remove(&id) else {
+            return;
+        };
+        let SocketEntry {
+            socket,
+            session_id,
+            kind,
+            snapshot,
+            listening,
+            abortive_close,
+            guest_local_address,
+            host_connection,
+            ..
+        } = socket;
+        if listening {
+            self.remove_pending_guest_connections_for_listener(id);
+        }
+        if kind == SocketKind::Tcp
+            && let Some(address) = guest_local_address
+        {
+            self.tcp.remove_binding(address.port(), id);
+        }
+
+        let connecting = snapshot
+            .lock()
+            .expect("Linux socket snapshot mutex poisoned")
+            .status
+            == SocketConnectionStatus::Connecting;
+        let disposition = match getpeername(&socket) {
+            Ok(Some(_)) if abortive_close => PendingGuestConnectionDisposition::Discard(None),
+            Ok(Some(_)) => PendingGuestConnectionDisposition::Retain,
+            Ok(None) | Err(_) => {
+                if abortive_close || connecting {
+                    let _ = sockopt::set_socket_linger(&socket, Some(Duration::ZERO));
+                }
+                PendingGuestConnectionDisposition::Discard(Some(
+                    Instant::now() + PENDING_CONNECT_DISCARD_LIFETIME,
+                ))
+            }
+        };
+        let mut socket = Some(socket);
+        if let Some(connection) = host_connection
+            && let Some(pending) = self.tcp.pending_guest_connections.get_mut(&connection)
+            && pending.session_id == session_id
+        {
+            pending.discard_on_accept =
+                matches!(disposition, PendingGuestConnectionDisposition::Discard(_));
+            pending.discard_deadline = match disposition {
+                PendingGuestConnectionDisposition::Retain
+                | PendingGuestConnectionDisposition::Discard(None) => None,
+                PendingGuestConnectionDisposition::Discard(Some(deadline)) => Some(deadline),
+            };
+            if pending.discard_deadline.is_none() {
+                pending.retained_connector = socket.take();
+                self.retained_connectors = self
+                    .retained_connectors
+                    .checked_add(1)
+                    .expect("reactor retained connector count overflow");
+                let session = self
+                    .sessions
+                    .get_mut(&session_id)
+                    .expect("socket session state missing");
+                session.retained_connectors = session
+                    .retained_connectors
+                    .checked_add(1)
+                    .expect("session retained connector count overflow");
+            }
+        }
+        drop(socket);
+        if let Some(session) = self.sessions.get_mut(&session_id) {
+            session.live_sockets = session
+                .live_sockets
+                .checked_sub(1)
+                .expect("session socket count underflow");
+        }
+        if self
+            .sessions
+            .get(&session_id)
+            .is_some_and(|session| session.closing)
+        {
+            self.retire_session_connectors(session_id);
+        }
+        self.sessions
+            .retain(|_, session| retain_session_state(session));
+    }
+
     fn run(&mut self) -> core::result::Result<(), ReactorFailure> {
         loop {
             let mut events = core::mem::take(&mut self.events);
             events.clear();
-            match epoll::wait(&self.epoll, spare_capacity(&mut events), None) {
+            let now = Instant::now();
+            let timeout = self.next_cleanup_deadline().map(|deadline| {
+                let duration = deadline.saturating_duration_since(now);
+                Timespec {
+                    tv_sec: i64::try_from(duration.as_secs()).unwrap_or(i64::MAX),
+                    tv_nsec: i64::from(duration.subsec_nanos()),
+                }
+            });
+            match epoll::wait(&self.epoll, spare_capacity(&mut events), timeout.as_ref()) {
                 Ok(_) => {}
                 Err(Errno::INTR) => {
                     self.events = events;
@@ -773,6 +1562,7 @@ impl Reactor {
                 }
                 Err(error) => return Err(ReactorFailure::Io(error)),
             }
+            self.expire_deadlined_state(Instant::now());
 
             // Apply readiness observed by this wait before commands. A command
             // that then reaches EAGAIN records the newer authoritative state.
@@ -781,8 +1571,24 @@ impl Reactor {
                 let id = event.data.u64();
                 if id == WAKE_TOKEN {
                     wake = true;
-                } else if let Some(socket) = self.sockets.get_mut(&id) {
-                    handle_socket_event(socket, event.flags).map_err(ReactorFailure::Broker)?;
+                } else {
+                    let failed_connection = if let Some(socket) = self.sockets.get_mut(&id) {
+                        if handle_socket_event(socket, event.flags)
+                            .map_err(ReactorFailure::Broker)?
+                        {
+                            socket
+                                .host_connection
+                                .take()
+                                .map(|connection| (connection, socket.session_id))
+                        } else {
+                            None
+                        }
+                    } else {
+                        None
+                    };
+                    if let Some((connection, session_id)) = failed_connection {
+                        self.remove_pending_guest_connection(connection, session_id);
+                    }
                 }
             }
             self.events = events;
@@ -818,16 +1624,18 @@ impl Reactor {
             match command {
                 ReactorCommand::Create {
                     id,
+                    session_id,
                     request,
                     readiness,
                     snapshot,
                     lifecycle,
                     response,
                 } => {
-                    let outcome = self.create_socket(id, request, readiness, snapshot, &lifecycle);
+                    let outcome = self
+                        .create_socket(id, session_id, request, readiness, snapshot, &lifecycle);
                     let created = outcome.is_ok();
                     if response.send(outcome).is_err() && created {
-                        self.sockets.remove(&id);
+                        self.remove_socket(id);
                         lifecycle.reactor_removed();
                     }
                 }
@@ -836,12 +1644,7 @@ impl Reactor {
                     address,
                     response,
                 } => {
-                    let outcome = match self.sockets.get_mut(&id) {
-                        Some(socket) => connect_socket(&self.epoll, id, socket, address),
-                        None => Err(PlatformConnectError::PeerIndeterminate(
-                            BrokerError::Internal,
-                        )),
-                    };
+                    let outcome = self.connect_socket(id, address);
                     let _ = response.send(outcome);
                 }
                 ReactorCommand::Bind {
@@ -849,24 +1652,20 @@ impl Reactor {
                     address,
                     response,
                 } => {
-                    let outcome = self
-                        .sockets
-                        .get_mut(&id)
-                        .ok_or(BrokerError::Internal)
-                        .and_then(|socket| bind_socket(socket, address));
-                    let _ = response.send(outcome);
+                    let outcome = self.bind_socket(id, address);
+                    if response.send(outcome).is_err() {
+                        self.remove_socket(id);
+                    }
                 }
                 ReactorCommand::Listen {
                     id,
                     backlog,
                     response,
                 } => {
-                    let outcome = self
-                        .sockets
-                        .get_mut(&id)
-                        .ok_or(BrokerError::Internal)
-                        .and_then(|socket| listen_socket(&self.epoll, id, socket, backlog));
-                    let _ = response.send(outcome);
+                    let outcome = self.listen_socket(id, backlog);
+                    if response.send(outcome).is_err() {
+                        self.remove_socket(id);
+                    }
                 }
                 ReactorCommand::Accept {
                     listener_id,
@@ -888,7 +1687,7 @@ impl Reactor {
                         Ok(SocketOutcome::Completed(AcceptedEndpoints { .. }))
                     );
                     if response.send(outcome).is_err() && accepted {
-                        self.sockets.remove(&accepted_id);
+                        self.remove_socket(accepted_id);
                         lifecycle.reactor_removed();
                     }
                 }
@@ -961,6 +1760,21 @@ impl Reactor {
                         .get_mut(&id)
                         .ok_or(BrokerError::Internal)
                         .and_then(|socket| shutdown_socket(socket, mode));
+                    if matches!(outcome, Ok(SocketOutcome::Completed(())))
+                        && mode == ShutdownMode::StopListening
+                    {
+                        self.remove_pending_guest_connections_for_listener(id);
+                        let update = self
+                            .sockets
+                            .get(&id)
+                            .and_then(|socket| socket.guest_local_address)
+                            .ok_or(BrokerError::Internal)
+                            .and_then(|address| self.tcp.stop_listening(address.port(), id));
+                        if let Err(error) = update {
+                            let _ = response.send(Err(error));
+                            continue;
+                        }
+                    }
                     let _ = response.send(outcome);
                 }
                 ReactorCommand::SetTcpOption {
@@ -970,7 +1784,7 @@ impl Reactor {
                 } => {
                     let outcome = self
                         .sockets
-                        .get(&id)
+                        .get_mut(&id)
                         .ok_or(BrokerError::Internal)
                         .and_then(|socket| set_tcp_option(socket, value));
                     let _ = response.send(outcome);
@@ -999,11 +1813,54 @@ impl Reactor {
                     {
                         self.peek_cache = None;
                     }
-                    self.sockets.remove(&id);
+                    self.remove_socket(id);
                     let _ = response.send(());
+                }
+                ReactorCommand::CloseSession {
+                    session_id,
+                    response,
+                } => {
+                    if let Some(session) = self.sessions.get_mut(&session_id) {
+                        session.closing = true;
+                    }
+                    while let Some(id) = self
+                        .sockets
+                        .iter()
+                        .find_map(|(id, socket)| (socket.session_id == session_id).then_some(*id))
+                    {
+                        self.remove_socket(id);
+                    }
+                    self.retire_session_connectors(session_id);
+                    self.sessions
+                        .retain(|_, session| retain_session_state(session));
+                    let _ = response.send(());
+                }
+                #[cfg(test)]
+                ReactorCommand::HostAddress {
+                    guest_port,
+                    response,
+                } => {
+                    let host_address = self
+                        .tcp
+                        .bindings
+                        .get(&guest_port)
+                        .and_then(|binding| binding.host_address);
+                    let _ = response.send(host_address);
+                }
+                #[cfg(test)]
+                ReactorCommand::PendingGuestConnectionCount { response } => {
+                    let _ = response.send(self.tcp.pending_guest_connections.len());
+                }
+                #[cfg(test)]
+                ReactorCommand::RetainedConnectorCount { response } => {
+                    let _ = response.send(self.retained_connectors);
                 }
                 ReactorCommand::Stop { response } => {
                     self.sockets.clear();
+                    self.tcp.bindings.clear();
+                    self.tcp.pending_guest_connections.clear();
+                    self.sessions.clear();
+                    self.retained_connectors = 0;
                     let _ = response.send(());
                     return true;
                 }
@@ -1015,17 +1872,39 @@ impl Reactor {
     fn create_socket(
         &mut self,
         id: u64,
+        session_id: SessionId,
         request: CreateSocketRequest,
         readiness: ReadinessRegistration,
         snapshot: Arc<Mutex<SocketSnapshot>>,
         lifecycle: &SocketLifecycle,
     ) -> BrokerResult<()> {
-        if self.sockets.len() >= self.max_sockets {
+        if self
+            .sockets
+            .len()
+            .checked_add(self.retained_connectors)
+            .is_none_or(|count| count >= self.max_sockets)
+        {
             return Err(BrokerError::ResourceExhausted);
         }
         let kind = socket_kind(request).ok_or(BrokerError::Internal)?;
         if self.sockets.contains_key(&id) {
             return Err(BrokerError::Internal);
+        }
+        if !self.sessions.contains_key(&session_id) {
+            self.sessions
+                .try_reserve(1)
+                .map_err(|_| BrokerError::OutOfMemory)?;
+        }
+        let session = self.sessions.entry(session_id).or_default();
+        if session.closing {
+            return Err(BrokerError::UnknownObject);
+        }
+        if session
+            .live_sockets
+            .checked_add(session.retained_connectors)
+            .is_none_or(|count| count >= self.max_sockets_per_session)
+        {
+            return Err(BrokerError::ResourceExhausted);
         }
         let (linux_type, protocol, epoll_events, initial_readiness) = match kind {
             SocketKind::Tcp => (
@@ -1069,6 +1948,7 @@ impl Reactor {
             id,
             SocketEntry {
                 socket,
+                session_id,
                 kind,
                 readiness,
                 snapshot,
@@ -1076,8 +1956,17 @@ impl Reactor {
                 write_shutdown: false,
                 peek_waitall_threshold: None,
                 listening: false,
+                abortive_close: false,
+                guest_local_address: None,
+                host_connection: None,
+                tcp_no_delay: false,
+                tcp_keep_alive: false,
             },
         );
+        session.live_sockets = session
+            .live_sockets
+            .checked_add(1)
+            .ok_or(BrokerError::ResourceExhausted)?;
         Ok(())
     }
 
@@ -1089,37 +1978,93 @@ impl Reactor {
         snapshot: Arc<Mutex<SocketSnapshot>>,
         lifecycle: &SocketLifecycle,
     ) -> BrokerResult<SocketOutcome<AcceptedEndpoints>> {
-        if self.sockets.len() >= self.max_sockets {
-            return Err(BrokerError::ResourceExhausted);
-        }
         if self.sockets.contains_key(&accepted_id) {
             return Err(BrokerError::Internal);
         }
+        let (
+            listener_session_id,
+            listener_guest_address,
+            listener_tcp_no_delay,
+            listener_tcp_keep_alive,
+        ) = {
+            let listener = self
+                .sockets
+                .get(&listener_id)
+                .ok_or(BrokerError::Internal)?;
+            if listener.kind != SocketKind::Tcp || !listener.listening {
+                return Ok(SocketOutcome::Failed(SocketError::NotConnected));
+            }
+            (
+                listener.session_id,
+                listener.guest_local_address.ok_or(BrokerError::Internal)?,
+                listener.tcp_no_delay,
+                listener.tcp_keep_alive,
+            )
+        };
+        if !self.has_accept_capacity(listener_id, listener_session_id)? {
+            return Err(BrokerError::ResourceExhausted);
+        }
+        let (socket, remote_address) = loop {
+            let (socket, remote_address) = loop {
+                let listener = self
+                    .sockets
+                    .get_mut(&listener_id)
+                    .ok_or(BrokerError::Internal)?;
+                match acceptfrom_with(
+                    &listener.socket,
+                    LinuxSocketFlags::CLOEXEC | LinuxSocketFlags::NONBLOCK,
+                ) {
+                    Ok((socket, address)) => break (socket, address),
+                    Err(Errno::INTR) => {}
+                    Err(Errno::AGAIN) => {
+                        clear_readiness(listener, ReadinessFlags::READ)?;
+                        return Err(BrokerError::WouldBlock);
+                    }
+                    Err(error) => {
+                        return Ok(SocketOutcome::Failed(socket_operation_error_from_errno(
+                            error,
+                        )?));
+                    }
+                }
+            };
+            let remote_address =
+                SocketAddrV4::try_from(remote_address.ok_or(BrokerError::Internal)?)
+                    .map_err(|_| BrokerError::Internal)?;
+            let host_local_address = local_socket_address(&socket)?;
+            if let Some(guest_address) = self.take_pending_guest_connection_for_accept(
+                listener_id,
+                remote_address,
+                host_local_address,
+            ) {
+                break (socket, guest_address);
+            }
+            drop(socket);
+        };
+        if self
+            .sockets
+            .len()
+            .checked_add(self.retained_connectors)
+            .is_none_or(|count| count >= self.max_sockets)
+            || self
+                .sessions
+                .get(&listener_session_id)
+                .ok_or(BrokerError::Internal)?
+                .live_sockets
+                .checked_add(
+                    self.sessions
+                        .get(&listener_session_id)
+                        .ok_or(BrokerError::Internal)?
+                        .retained_connectors,
+                )
+                .is_none_or(|count| count >= self.max_sockets_per_session)
+        {
+            return Err(BrokerError::ResourceExhausted);
+        }
+        apply_tcp_options(&socket, listener_tcp_no_delay, listener_tcp_keep_alive)?;
         let listener = self
             .sockets
             .get_mut(&listener_id)
             .ok_or(BrokerError::Internal)?;
-        if listener.kind != SocketKind::Tcp || !listener.listening {
-            return Ok(SocketOutcome::Failed(SocketError::NotConnected));
-        }
-        let (socket, remote_address) = loop {
-            match acceptfrom_with(
-                &listener.socket,
-                LinuxSocketFlags::CLOEXEC | LinuxSocketFlags::NONBLOCK,
-            ) {
-                Ok((socket, address)) => break (socket, address),
-                Err(Errno::INTR) => {}
-                Err(Errno::AGAIN) => {
-                    clear_readiness(listener, ReadinessFlags::READ)?;
-                    return Err(BrokerError::WouldBlock);
-                }
-                Err(error) => {
-                    return Ok(SocketOutcome::Failed(socket_operation_error_from_errno(
-                        error,
-                    )?));
-                }
-            }
-        };
         let no_wait = Timespec {
             tv_sec: 0,
             tv_nsec: 0,
@@ -1136,9 +2081,6 @@ impl Reactor {
                 Err(error) => return Err(broker_error_from_errno(error)),
             }
         }
-        let remote_address = SocketAddrV4::try_from(remote_address.ok_or(BrokerError::Internal)?)
-            .map_err(|_| BrokerError::Internal)?;
-        let local_address = local_socket_address(&socket)?;
         epoll::add(
             &self.epoll,
             &socket,
@@ -1151,7 +2093,7 @@ impl Reactor {
                 .lock()
                 .expect("Linux socket snapshot mutex poisoned");
             snapshot.status = SocketConnectionStatus::Connected;
-            snapshot.local_address = Some(local_address);
+            snapshot.local_address = Some(listener_guest_address);
             snapshot.readiness = ReadinessFlags::WRITE;
         }
         readiness.publish(ReadinessFlags::WRITE)?;
@@ -1162,6 +2104,7 @@ impl Reactor {
             accepted_id,
             SocketEntry {
                 socket,
+                session_id: listener_session_id,
                 kind: SocketKind::Tcp,
                 readiness,
                 snapshot,
@@ -1169,10 +2112,22 @@ impl Reactor {
                 write_shutdown: false,
                 peek_waitall_threshold: None,
                 listening: false,
+                abortive_close: false,
+                guest_local_address: Some(listener_guest_address),
+                host_connection: None,
+                tcp_no_delay: listener_tcp_no_delay,
+                tcp_keep_alive: listener_tcp_keep_alive,
             },
         );
+        let session = self
+            .sessions
+            .get_mut(&listener_session_id)
+            .ok_or(BrokerError::Internal)?;
+        session.live_sockets = session
+            .live_sockets
+            .checked_add(1)
+            .ok_or(BrokerError::ResourceExhausted)?;
         Ok(SocketOutcome::Completed(AcceptedEndpoints {
-            local_address,
             remote_address,
         }))
     }
@@ -1192,18 +2147,19 @@ impl Reactor {
             let _ = socket.readiness.publish(ReadinessFlags::ERROR);
         }
         self.sockets.clear();
+        self.tcp.bindings.clear();
+        self.tcp.pending_guest_connections.clear();
+        self.sessions.clear();
+        self.retained_connectors = 0;
     }
 }
 
-fn connect_socket(
+fn connect_tcp_socket(
     epoll_fd: &OwnedFd,
     id: u64,
     socket: &mut SocketEntry,
     address: SocketAddrV4,
-) -> core::result::Result<SocketConnectionStatus, PlatformConnectError> {
-    if socket.kind == SocketKind::Udp {
-        return connect_datagram_socket(socket, address);
-    }
+) -> core::result::Result<(SocketConnectionStatus, ReadinessFlags), PlatformConnectError> {
     if let Err(error) = epoll::modify(
         epoll_fd,
         &socket.socket,
@@ -1240,13 +2196,11 @@ fn connect_socket(
     };
     let readiness = match status {
         SocketConnectionStatus::Connected | SocketConnectionStatus::Connecting => {
-            let local_address = local_socket_address(&socket.socket)
-                .map_err(PlatformConnectError::PeerIndeterminate)?;
-            socket
-                .snapshot
-                .lock()
-                .expect("Linux socket snapshot mutex poisoned")
-                .local_address = Some(local_address);
+            if socket.guest_local_address.is_none() {
+                return Err(PlatformConnectError::PeerIndeterminate(
+                    BrokerError::Internal,
+                ));
+            }
             if status == SocketConnectionStatus::Connected {
                 ReadinessFlags::WRITE
             } else {
@@ -1261,9 +2215,7 @@ fn connect_socket(
             ));
         }
     };
-    update_snapshot(socket, Some(status), readiness)
-        .map_err(PlatformConnectError::PeerIndeterminate)?;
-    Ok(status)
+    Ok((status, readiness))
 }
 
 fn connect_datagram_socket(
@@ -1305,7 +2257,7 @@ fn connect_datagram_socket(
     }
 }
 
-fn bind_socket(
+fn bind_host_socket(
     socket: &mut SocketEntry,
     address: SocketAddrV4,
 ) -> BrokerResult<SocketOutcome<SocketAddrV4>> {
@@ -1313,11 +2265,6 @@ fn bind_socket(
         match bind(&socket.socket, &address) {
             Ok(()) => {
                 let local_address = local_socket_address(&socket.socket)?;
-                socket
-                    .snapshot
-                    .lock()
-                    .expect("Linux socket snapshot mutex poisoned")
-                    .local_address = Some(local_address);
                 return Ok(SocketOutcome::Completed(local_address));
             }
             Err(Errno::INTR) => {}
@@ -1330,12 +2277,12 @@ fn bind_socket(
     }
 }
 
-fn listen_socket(
+fn listen_tcp_socket(
     epoll_fd: &OwnedFd,
     id: u64,
     socket: &mut SocketEntry,
     backlog: u32,
-) -> BrokerResult<SocketOutcome<SocketAddrV4>> {
+) -> BrokerResult<SocketOutcome<()>> {
     if socket.kind != SocketKind::Tcp {
         return Ok(SocketOutcome::Failed(SocketError::InvalidArgument));
     }
@@ -1371,18 +2318,14 @@ fn listen_socket(
         }
     }
     socket.listening = true;
-    // An unbound TCP socket is implicitly bound by listen(2), so query the assigned
-    // address only after listen succeeds.
-    let local_address = local_socket_address(&socket.socket)?;
     let mut snapshot = socket
         .snapshot
         .lock()
         .expect("Linux socket snapshot mutex poisoned");
-    snapshot.local_address = Some(local_address);
     if !was_listening {
         snapshot.readiness = ReadinessFlags::default();
     }
-    Ok(SocketOutcome::Completed(local_address))
+    Ok(SocketOutcome::Completed(()))
 }
 
 fn send_socket(socket: &mut SocketEntry, data: &[u8]) -> BrokerResult<SocketOutcome<usize>> {
@@ -1665,16 +2608,28 @@ fn receive_socket_once(
     }
 }
 
-fn set_tcp_option(socket: &SocketEntry, value: TcpOptionValue) -> BrokerResult<()> {
+fn set_tcp_option(socket: &mut SocketEntry, value: TcpOptionValue) -> BrokerResult<()> {
     if socket.kind != SocketKind::Tcp {
         return Err(BrokerError::UnsupportedOperation);
     }
     match value {
-        TcpOptionValue::NoDelay(value) => sockopt::set_tcp_nodelay(&socket.socket, value),
-        TcpOptionValue::KeepAlive(value) => sockopt::set_socket_keepalive(&socket.socket, value),
+        TcpOptionValue::NoDelay(value) => {
+            sockopt::set_tcp_nodelay(&socket.socket, value).map_err(broker_error_from_errno)?;
+            socket.tcp_no_delay = value;
+        }
+        TcpOptionValue::KeepAlive(value) => {
+            sockopt::set_socket_keepalive(&socket.socket, value)
+                .map_err(broker_error_from_errno)?;
+            socket.tcp_keep_alive = value;
+        }
         _ => return Err(BrokerError::UnsupportedOperation),
     }
-    .map_err(broker_error_from_errno)
+    Ok(())
+}
+
+fn apply_tcp_options(socket: &OwnedFd, no_delay: bool, keep_alive: bool) -> BrokerResult<()> {
+    sockopt::set_tcp_nodelay(socket, no_delay).map_err(broker_error_from_errno)?;
+    sockopt::set_socket_keepalive(socket, keep_alive).map_err(broker_error_from_errno)
 }
 
 fn get_tcp_option(socket: &SocketEntry, name: TcpOptionName) -> BrokerResult<TcpOptionValue> {
@@ -1704,6 +2659,7 @@ fn shutdown_socket(
     if mode == ShutdownMode::Abort {
         sockopt::set_socket_linger(&socket.socket, Some(Duration::ZERO))
             .map_err(broker_error_from_errno)?;
+        socket.abortive_close = true;
         return Ok(SocketOutcome::Completed(()));
     }
     let stop_listening = mode == ShutdownMode::StopListening;
@@ -1792,12 +2748,14 @@ fn shutdown_socket(
     }
 }
 
-fn handle_socket_event(socket: &mut SocketEntry, events: epoll::EventFlags) -> BrokerResult<()> {
+fn handle_socket_event(socket: &mut SocketEntry, events: epoll::EventFlags) -> BrokerResult<bool> {
     if socket.listening {
-        return update_snapshot(socket, None, readiness_from_epoll(socket, events));
+        update_snapshot(socket, None, readiness_from_epoll(socket, events))?;
+        return Ok(false);
     }
     if socket.kind == SocketKind::Udp {
-        return update_snapshot(socket, None, readiness_from_epoll(socket, events));
+        update_snapshot(socket, None, readiness_from_epoll(socket, events))?;
+        return Ok(false);
     }
     let republish_readiness = if events.contains(epoll::EventFlags::IN)
         && let Some(threshold) = socket.peek_waitall_threshold
@@ -1818,19 +2776,28 @@ fn handle_socket_event(socket: &mut SocketEntry, events: epoll::EventFlags) -> B
         .lock()
         .expect("Linux socket snapshot mutex poisoned")
         .status;
-    let result = match status {
-        SocketConnectionStatus::Unconnected => Ok(()),
-        SocketConnectionStatus::Connecting => complete_connect(socket, events),
+    let failed_connector = match status {
+        SocketConnectionStatus::Unconnected => false,
+        SocketConnectionStatus::Connecting => {
+            matches!(
+                complete_connect(socket, events)?,
+                SocketConnectionStatus::Failed(_)
+            )
+        }
         SocketConnectionStatus::Connected => {
-            update_snapshot(socket, None, readiness_from_epoll(socket, events))
+            update_snapshot(socket, None, readiness_from_epoll(socket, events))?;
+            false
         }
         SocketConnectionStatus::Failed(SocketError::NotConnected) if socket.read_shutdown => {
-            update_snapshot(socket, None, ReadinessFlags::WRITE | ReadinessFlags::HANGUP)
+            update_snapshot(socket, None, ReadinessFlags::WRITE | ReadinessFlags::HANGUP)?;
+            false
         }
-        SocketConnectionStatus::Failed(_) => update_snapshot(socket, None, ReadinessFlags::ERROR),
-        _ => Err(BrokerError::Internal),
+        SocketConnectionStatus::Failed(_) => {
+            update_snapshot(socket, None, ReadinessFlags::ERROR)?;
+            false
+        }
+        _ => return Err(BrokerError::Internal),
     };
-    result?;
     if republish_readiness {
         let readiness = socket
             .snapshot
@@ -1839,21 +2806,16 @@ fn handle_socket_event(socket: &mut SocketEntry, events: epoll::EventFlags) -> B
             .readiness;
         socket.readiness.republish(readiness)?;
     }
-    Ok(())
+    Ok(failed_connector)
 }
 
-fn complete_connect(socket: &mut SocketEntry, events: epoll::EventFlags) -> BrokerResult<()> {
+fn complete_connect(
+    socket: &mut SocketEntry,
+    events: epoll::EventFlags,
+) -> BrokerResult<SocketConnectionStatus> {
     let status = match sockopt::socket_error(&socket.socket) {
         Ok(Ok(())) => match getpeername(&socket.socket) {
-            Ok(Some(_)) => {
-                let local_address = local_socket_address(&socket.socket)?;
-                socket
-                    .snapshot
-                    .lock()
-                    .expect("Linux socket snapshot mutex poisoned")
-                    .local_address = Some(local_address);
-                SocketConnectionStatus::Connected
-            }
+            Ok(Some(_)) => SocketConnectionStatus::Connected,
             Ok(None) | Err(Errno::NOTCONN) => SocketConnectionStatus::Connecting,
             Err(error) => SocketConnectionStatus::Failed(socket_error_from_errno(error)),
         },
@@ -1869,7 +2831,8 @@ fn complete_connect(socket: &mut SocketEntry, events: epoll::EventFlags) -> Brok
         SocketConnectionStatus::Failed(_) => ReadinessFlags::ERROR,
         _ => return Err(BrokerError::Internal),
     };
-    update_snapshot(socket, Some(status), readiness)
+    update_snapshot(socket, Some(status), readiness)?;
+    Ok(status)
 }
 
 fn take_socket_error(socket: &SocketEntry) -> BrokerResult<Option<SocketError>> {
@@ -2151,7 +3114,7 @@ mod tests {
     use litebox_broker_protocol::ObjectHandle;
     use litebox_broker_protocol::socket::{Ipv4Address, Port, ReceiveSocketResponse};
 
-    const TEST_TIMEOUT: Duration = Duration::from_secs(5);
+    const TEST_TIMEOUT: Duration = Duration::from_secs(10);
 
     #[derive(Clone, Copy, Debug, PartialEq, Eq)]
     struct ReceivedPlatformDatagram {
@@ -2309,6 +3272,46 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn pending_guest_connections_are_keyed_by_complete_host_tuple() {
+        let remote_address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 40000);
+        let first_listener = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 5000);
+        let second_listener = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 5001);
+        let first_guest = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 1000);
+        let second_guest = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 1001);
+        let mut tcp = BrokerTcpState::default();
+        for (listener, guest) in [
+            (first_listener, first_guest),
+            (second_listener, second_guest),
+        ] {
+            tcp.pending_guest_connections.insert(
+                (remote_address, listener),
+                PendingGuestTcpConnection {
+                    session_id: SessionId(7),
+                    guest_address: guest,
+                    listener_id: 1,
+                    discard_on_accept: false,
+                    discard_deadline: None,
+                    retained_connector: None,
+                },
+            );
+        }
+
+        assert_eq!(
+            tcp.take_pending_guest_connection(remote_address, second_listener)
+                .unwrap()
+                .guest_address,
+            second_guest
+        );
+        assert_eq!(
+            tcp.take_pending_guest_connection(remote_address, first_listener)
+                .unwrap()
+                .guest_address,
+            first_guest
+        );
+        assert!(tcp.pending_guest_connections.is_empty());
+    }
+
     struct TestReadinessSink {
         published: Sender<(ObjectHandle, ReadinessFlags)>,
         retired: Sender<ObjectHandle>,
@@ -2388,7 +3391,7 @@ mod tests {
             assert_eq!(error.kind(), std::io::ErrorKind::ConnectionReset);
         });
 
-        let provider = Arc::new(LinuxSocketProvider::new(8).unwrap());
+        let provider = Arc::new(LinuxSocketProvider::new(8, 8).unwrap());
         let broker = BrokerCore::new_with_limits(
             PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
                 .with_socket_policy(SocketPolicy::Ipv4Loopback),
@@ -2705,12 +3708,12 @@ mod tests {
 
     #[test]
     fn reactor_assigns_a_port_to_an_unbound_tcp_listener() {
-        let provider = Arc::new(LinuxSocketProvider::new(2).unwrap());
+        let provider = Arc::new(LinuxSocketProvider::new(3, 3).unwrap());
         let broker = BrokerCore::new_with_limits(
             PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
                 .with_socket_policy(SocketPolicy::Ipv4Loopback),
-            BrokerCoreLimits::new_with_all_limits(4, 0, 2, 2),
-            provider,
+            BrokerCoreLimits::new_with_all_limits(4, 0, 3, 3),
+            provider.clone(),
         )
         .unwrap();
         let session = broker
@@ -2728,36 +3731,492 @@ mod tests {
             SocketOutcome::Failed(error) => panic!("listen failed: {error:?}"),
         };
         assert_ne!(local_address.port(), 0);
+        let private_address = provider
+            .reactor
+            .host_address(local_address.port())
+            .expect("listening socket must have a private host endpoint");
+        assert!(private_address.ip().is_loopback());
+        assert_ne!(private_address.port(), 0);
 
-        let connect_address = SocketAddrV4::new(
-            if local_address.ip().is_unspecified() {
-                Ipv4Addr::LOCALHOST
-            } else {
-                *local_address.ip()
-            },
-            local_address.port(),
-        );
-        let client = TcpStream::connect(connect_address).unwrap();
+        let client = create_socket(&session, readiness.clone());
+        assert!(matches!(
+            litebox_broker_core::socket::connect(&session, client, local_address),
+            Ok(SocketOutcome::Completed(
+                SocketConnectionStatus::Connecting | SocketConnectionStatus::Connected
+            ))
+        ));
+        wait_until_connected(&session, client, &publications);
+        let client_address = litebox_broker_core::socket::status(&session, client)
+            .unwrap()
+            .local_address
+            .unwrap();
         wait_for_readiness(&publications, listener, ReadinessFlags::READ);
         let accepted =
             match litebox_broker_core::socket::accept(&session, listener, readiness).unwrap() {
                 SocketOutcome::Completed(accepted) => accepted,
                 SocketOutcome::Failed(error) => panic!("accept failed: {error:?}"),
             };
-        assert_eq!(accepted.local_address, connect_address);
+        assert_eq!(accepted.local_address, local_address);
+        assert_eq!(accepted.remote_address, client_address);
+    }
+
+    #[test]
+    fn guest_tcp_namespace_routes_across_sessions_and_hides_private_backend() {
+        let provider = Arc::new(LinuxSocketProvider::new(5, 3).unwrap());
+        let broker = BrokerCore::new_with_limits(
+            PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
+                .with_socket_policy(SocketPolicy::Ipv4Loopback),
+            BrokerCoreLimits::new_with_all_limits(8, 0, 5, 4),
+            provider.clone(),
+        )
+        .unwrap();
+        let listener_session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let client_session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let (published, publications) = channel();
+        let (retired, retirements) = channel();
+        let readiness = Arc::new(TestReadinessSink { published, retired });
+        let shadowed_host_listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+        shadowed_host_listener.set_nonblocking(true).unwrap();
+        let guest_port = shadowed_host_listener.local_addr().unwrap().port();
+        let guest_address = SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 2), guest_port);
+        let guest_destination = SocketAddrV4::new(Ipv4Addr::LOCALHOST, guest_port);
+        let listener = create_socket(&listener_session, readiness.clone());
         assert_eq!(
-            accepted.remote_address,
-            socket_address_v4(client.local_addr().unwrap())
+            litebox_broker_core::socket::bind(&listener_session, listener, guest_address),
+            Ok(SocketOutcome::Completed(guest_address))
+        );
+        assert_eq!(provider.reactor.host_address(guest_address.port()), None);
+
+        let early_client = create_socket(&client_session, readiness.clone());
+        assert_eq!(
+            litebox_broker_core::socket::connect(&client_session, early_client, guest_destination,),
+            Ok(SocketOutcome::Completed(SocketConnectionStatus::Failed(
+                SocketError::ConnectionRefused,
+            )))
+        );
+        assert_eq!(
+            shadowed_host_listener.accept().unwrap_err().kind(),
+            ErrorKind::WouldBlock
+        );
+        client_session.close_object_reference(early_client).unwrap();
+        assert_eq!(
+            retirements.recv_timeout(TEST_TIMEOUT).unwrap(),
+            early_client
+        );
+
+        assert_eq!(
+            litebox_broker_core::socket::listen(&listener_session, listener, 3),
+            Ok(SocketOutcome::Completed(guest_address))
+        );
+        let private_address = provider
+            .reactor
+            .host_address(guest_address.port())
+            .expect("listener backend must be realized");
+        assert!(private_address.ip().is_loopback());
+        assert_ne!(private_address, guest_address);
+
+        let direct_client = create_socket(&client_session, readiness.clone());
+        assert_eq!(
+            litebox_broker_core::socket::connect(&client_session, direct_client, private_address,),
+            Ok(SocketOutcome::Completed(SocketConnectionStatus::Failed(
+                SocketError::ConnectionRefused,
+            )))
+        );
+        client_session
+            .close_object_reference(direct_client)
+            .unwrap();
+        assert_eq!(
+            retirements.recv_timeout(TEST_TIMEOUT).unwrap(),
+            direct_client
+        );
+
+        let native_client = TcpStream::connect(private_address).unwrap();
+        let client = create_socket(&client_session, readiness.clone());
+        assert!(matches!(
+            litebox_broker_core::socket::connect(&client_session, client, guest_destination),
+            Ok(SocketOutcome::Completed(
+                SocketConnectionStatus::Connecting | SocketConnectionStatus::Connected
+            ))
+        ));
+        wait_until_connected(&client_session, client, &publications);
+        let client_address = litebox_broker_core::socket::status(&client_session, client)
+            .unwrap()
+            .local_address
+            .unwrap();
+        let connector_private_address = provider
+            .reactor
+            .host_address(client_address.port())
+            .expect("connector backend must be realized");
+        assert_ne!(connector_private_address, client_address);
+        let connector_probe = create_socket(&client_session, readiness.clone());
+        assert_eq!(
+            litebox_broker_core::socket::connect(
+                &client_session,
+                connector_probe,
+                connector_private_address,
+            ),
+            Ok(SocketOutcome::Completed(SocketConnectionStatus::Failed(
+                SocketError::ConnectionRefused,
+            )))
+        );
+        client_session
+            .close_object_reference(connector_probe)
+            .unwrap();
+        assert_eq!(
+            retirements.recv_timeout(TEST_TIMEOUT).unwrap(),
+            connector_probe
+        );
+        wait_for_readiness(&publications, listener, ReadinessFlags::READ);
+        let accepted = match litebox_broker_core::socket::accept(
+            &listener_session,
+            listener,
+            readiness.clone(),
+        )
+        .unwrap()
+        {
+            SocketOutcome::Completed(accepted) => accepted,
+            SocketOutcome::Failed(error) => panic!("accept failed: {error:?}"),
+        };
+        assert_eq!(accepted.local_address, guest_address);
+        assert_eq!(accepted.remote_address, client_address);
+        assert_eq!(provider.reactor.pending_guest_connection_count(), 0);
+        assert_eq!(provider.reactor.retained_connector_count(), 0);
+
+        assert_eq!(
+            send_bytes(&client_session, client, b"x", SendFlags::NONE),
+            Ok(SocketOutcome::Completed(1))
+        );
+        wait_for_readiness(&publications, accepted.handle, ReadinessFlags::READ);
+        let mut byte = [0];
+        assert_eq!(
+            receive_into(
+                &listener_session,
+                accepted.handle,
+                &mut byte,
+                ReceiveFlags::NONE,
+                0,
+                0,
+            ),
+            Ok(SocketOutcome::Completed(ReceiveSocketResponse::Received(1)))
+        );
+        assert_eq!(byte, *b"x");
+        assert_eq!(
+            shadowed_host_listener.accept().unwrap_err().kind(),
+            ErrorKind::WouldBlock
+        );
+        drop(native_client);
+    }
+
+    #[test]
+    fn duplicate_guest_tcp_ports_are_rejected_by_core_before_platform_bind() {
+        let provider = Arc::new(LinuxSocketProvider::new(2, 1).unwrap());
+        let broker = BrokerCore::new_with_limits(
+            PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
+                .with_socket_policy(SocketPolicy::Ipv4Loopback),
+            BrokerCoreLimits::new_with_all_limits(4, 0, 2, 1),
+            provider,
+        )
+        .unwrap();
+        let first_session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let second_session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let (published, _publications) = channel();
+        let (retired, retirements) = channel();
+        let readiness = Arc::new(TestReadinessSink { published, retired });
+        let first = create_socket(&first_session, readiness.clone());
+        let second = create_socket(&second_session, readiness);
+        let address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8081);
+        assert_eq!(
+            litebox_broker_core::socket::bind(&first_session, first, address),
+            Ok(SocketOutcome::Completed(address))
+        );
+        assert_eq!(
+            litebox_broker_core::socket::bind(&second_session, second, address),
+            Ok(SocketOutcome::Failed(SocketError::AddressInUse))
+        );
+        first_session.close_object_reference(first).unwrap();
+        assert_eq!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), first);
+        assert_eq!(
+            litebox_broker_core::socket::bind(&second_session, second, address),
+            Ok(SocketOutcome::Completed(address))
         );
     }
 
     #[test]
-    fn reactor_drives_a_loopback_tcp_listener() {
-        let provider = Arc::new(LinuxSocketProvider::new(4).unwrap());
+    fn connector_and_session_teardown_clean_bounded_pending_state() {
+        let provider = Arc::new(LinuxSocketProvider::new(3, 1).unwrap());
         let broker = BrokerCore::new_with_limits(
             PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
                 .with_socket_policy(SocketPolicy::Ipv4Loopback),
-            BrokerCoreLimits::new_with_all_limits(8, 0, 4, 4),
+            BrokerCoreLimits::new_with_all_limits(8, 0, 3, 3),
+            provider.clone(),
+        )
+        .unwrap();
+        let listener_session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let connector_session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let (published, publications) = channel();
+        let (retired, retirements) = channel();
+        let readiness = Arc::new(TestReadinessSink { published, retired });
+        let guest_address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8082);
+        let listener = create_socket(&listener_session, readiness.clone());
+        assert_eq!(
+            litebox_broker_core::socket::bind(&listener_session, listener, guest_address),
+            Ok(SocketOutcome::Completed(guest_address))
+        );
+        assert_eq!(
+            litebox_broker_core::socket::listen(&listener_session, listener, 2),
+            Ok(SocketOutcome::Completed(guest_address))
+        );
+
+        let connector = create_socket(&connector_session, readiness.clone());
+        assert!(matches!(
+            litebox_broker_core::socket::connect(&connector_session, connector, guest_address,),
+            Ok(SocketOutcome::Completed(
+                SocketConnectionStatus::Connecting | SocketConnectionStatus::Connected
+            ))
+        ));
+        wait_until_connected(&connector_session, connector, &publications);
+        connector_session.close_object_reference(connector).unwrap();
+        assert_eq!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), connector);
+        assert_eq!(provider.reactor.pending_guest_connection_count(), 1);
+        assert_eq!(provider.reactor.retained_connector_count(), 1);
+        assert_eq!(
+            litebox_broker_core::socket::create(
+                &connector_session,
+                CreateSocketRequest {
+                    address_family: AddressFamily::Ipv4,
+                    socket_type: SocketType::Stream,
+                    protocol: IpProtocol::Tcp,
+                },
+                readiness.clone(),
+            ),
+            Err(BrokerError::ResourceExhausted)
+        );
+        assert_ne!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), listener);
+
+        drop(connector_session);
+        assert_eq!(provider.reactor.pending_guest_connection_count(), 1);
+        assert_eq!(provider.reactor.retained_connector_count(), 0);
+        wait_for_readiness(&publications, listener, ReadinessFlags::READ);
+        assert!(matches!(
+            litebox_broker_core::socket::accept(&listener_session, listener, readiness.clone(),),
+            Err(BrokerError::WouldBlock)
+        ));
+        assert_ne!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), listener);
+        assert_eq!(provider.reactor.pending_guest_connection_count(), 0);
+
+        let final_connector_session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let final_connector = create_socket(&final_connector_session, readiness);
+        assert!(matches!(
+            litebox_broker_core::socket::connect(
+                &final_connector_session,
+                final_connector,
+                guest_address,
+            ),
+            Ok(SocketOutcome::Completed(
+                SocketConnectionStatus::Connecting | SocketConnectionStatus::Connected
+            ))
+        ));
+        wait_until_connected(&final_connector_session, final_connector, &publications);
+        assert_eq!(provider.reactor.pending_guest_connection_count(), 1);
+        listener_session.close_object_reference(listener).unwrap();
+        assert_eq!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), listener);
+        assert_eq!(provider.reactor.pending_guest_connection_count(), 0);
+        assert_eq!(provider.reactor.retained_connector_count(), 0);
+    }
+
+    #[test]
+    fn accept_preserves_a_queued_connection_when_retained_capacity_is_unrelated() {
+        let provider = Arc::new(LinuxSocketProvider::new(4, 4).unwrap());
+        let broker = BrokerCore::new_with_limits(
+            PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
+                .with_socket_policy(SocketPolicy::Ipv4Loopback),
+            BrokerCoreLimits::new_with_all_limits(8, 0, 5, 5),
+            provider.clone(),
+        )
+        .unwrap();
+        let target_listener_session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let target_connector_session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let other_listener_session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let other_connector_session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let (published, publications) = channel();
+        let (retired, _retirements) = channel();
+        let readiness = Arc::new(TestReadinessSink { published, retired });
+        let target_address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8084);
+        let other_address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8085);
+
+        let target_listener = create_socket(&target_listener_session, readiness.clone());
+        let other_listener = create_socket(&other_listener_session, readiness.clone());
+        for (session, listener, address) in [
+            (&target_listener_session, target_listener, target_address),
+            (&other_listener_session, other_listener, other_address),
+        ] {
+            assert_eq!(
+                litebox_broker_core::socket::bind(session, listener, address),
+                Ok(SocketOutcome::Completed(address))
+            );
+            assert_eq!(
+                litebox_broker_core::socket::listen(session, listener, 1),
+                Ok(SocketOutcome::Completed(address))
+            );
+        }
+
+        let target_connector = create_socket(&target_connector_session, readiness.clone());
+        let other_connector = create_socket(&other_connector_session, readiness.clone());
+        for (session, connector, address) in [
+            (&target_connector_session, target_connector, target_address),
+            (&other_connector_session, other_connector, other_address),
+        ] {
+            assert!(matches!(
+                litebox_broker_core::socket::connect(session, connector, address),
+                Ok(SocketOutcome::Completed(
+                    SocketConnectionStatus::Connecting | SocketConnectionStatus::Connected
+                ))
+            ));
+            wait_until_connected(session, connector, &publications);
+        }
+        let target_connector_address =
+            litebox_broker_core::socket::status(&target_connector_session, target_connector)
+                .unwrap()
+                .local_address
+                .unwrap();
+        other_connector_session
+            .close_object_reference(other_connector)
+            .unwrap();
+        assert_eq!(provider.reactor.pending_guest_connection_count(), 2);
+        assert_eq!(provider.reactor.retained_connector_count(), 1);
+
+        let deadline = Instant::now() + TEST_TIMEOUT;
+        while !target_listener_session
+            .check_readiness(target_listener)
+            .unwrap()
+            .contains(ReadinessFlags::READ)
+        {
+            assert!(
+                Instant::now() < deadline,
+                "target listener did not become ready"
+            );
+            std::thread::yield_now();
+        }
+        assert!(matches!(
+            litebox_broker_core::socket::accept(
+                &target_listener_session,
+                target_listener,
+                readiness.clone(),
+            ),
+            Err(BrokerError::ResourceExhausted)
+        ));
+        assert_eq!(provider.reactor.pending_guest_connection_count(), 2);
+
+        other_listener_session
+            .close_object_reference(other_listener)
+            .unwrap();
+        assert_eq!(provider.reactor.pending_guest_connection_count(), 1);
+        assert_eq!(provider.reactor.retained_connector_count(), 0);
+        let accepted = match litebox_broker_core::socket::accept(
+            &target_listener_session,
+            target_listener,
+            readiness,
+        )
+        .unwrap()
+        {
+            SocketOutcome::Completed(accepted) => accepted,
+            SocketOutcome::Failed(error) => panic!("target accept failed: {error:?}"),
+        };
+        assert_eq!(accepted.remote_address, target_connector_address);
+    }
+
+    #[test]
+    fn stopped_listener_retains_guest_binding_until_close() {
+        let provider = Arc::new(LinuxSocketProvider::new(2, 2).unwrap());
+        let broker = BrokerCore::new_with_limits(
+            PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
+                .with_socket_policy(SocketPolicy::Ipv4Loopback),
+            BrokerCoreLimits::new_with_all_limits(4, 0, 2, 2),
+            provider.clone(),
+        )
+        .unwrap();
+        let session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let (published, publications) = channel();
+        let (retired, retirements) = channel();
+        let readiness = Arc::new(TestReadinessSink { published, retired });
+        let guest_address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8083);
+        let listener = create_socket(&session, readiness.clone());
+        assert_eq!(
+            litebox_broker_core::socket::bind(&session, listener, guest_address),
+            Ok(SocketOutcome::Completed(guest_address))
+        );
+        assert_eq!(
+            litebox_broker_core::socket::listen(&session, listener, 1),
+            Ok(SocketOutcome::Completed(guest_address))
+        );
+        let private_address = provider.reactor.host_address(guest_address.port()).unwrap();
+        let connector = create_socket(&session, readiness.clone());
+        assert!(matches!(
+            litebox_broker_core::socket::connect(&session, connector, guest_address),
+            Ok(SocketOutcome::Completed(
+                SocketConnectionStatus::Connecting | SocketConnectionStatus::Connected
+            ))
+        ));
+        wait_until_connected(&session, connector, &publications);
+        assert_eq!(provider.reactor.pending_guest_connection_count(), 1);
+
+        assert_eq!(
+            litebox_broker_core::socket::shutdown(&session, listener, ShutdownMode::StopListening,),
+            Ok(SocketOutcome::Completed(()))
+        );
+        assert_eq!(provider.reactor.pending_guest_connection_count(), 0);
+        assert_eq!(
+            provider.reactor.host_address(guest_address.port()),
+            Some(private_address)
+        );
+        session.close_object_reference(connector).unwrap();
+        assert_eq!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), connector);
+
+        let refused = create_socket(&session, readiness);
+        assert_eq!(
+            litebox_broker_core::socket::connect(&session, refused, guest_address),
+            Ok(SocketOutcome::Completed(SocketConnectionStatus::Failed(
+                SocketError::ConnectionRefused,
+            )))
+        );
+        session.close_object_reference(refused).unwrap();
+        assert_eq!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), refused);
+        session.close_object_reference(listener).unwrap();
+        assert_eq!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), listener);
+        assert_eq!(provider.reactor.host_address(guest_address.port()), None);
+    }
+
+    #[test]
+    fn reactor_drives_a_loopback_tcp_listener() {
+        let provider = Arc::new(LinuxSocketProvider::new(6, 6).unwrap());
+        let broker = BrokerCore::new_with_limits(
+            PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
+                .with_socket_policy(SocketPolicy::Ipv4Loopback),
+            BrokerCoreLimits::new_with_all_limits(8, 0, 6, 6),
             provider,
         )
         .unwrap();
@@ -2798,10 +4257,25 @@ mod tests {
                 .contains(ReadinessFlags::READ)
         );
 
-        let mut first_client = TcpStream::connect(local_address).unwrap();
-        let second_client = TcpStream::connect(local_address).unwrap();
-        first_client.set_read_timeout(Some(TEST_TIMEOUT)).unwrap();
-        first_client.set_write_timeout(Some(TEST_TIMEOUT)).unwrap();
+        let first_client = create_socket(&session, readiness.clone());
+        let second_client = create_socket(&session, readiness.clone());
+        for client in [first_client, second_client] {
+            assert!(matches!(
+                litebox_broker_core::socket::connect(&session, client, local_address),
+                Ok(SocketOutcome::Completed(
+                    SocketConnectionStatus::Connecting | SocketConnectionStatus::Connected
+                ))
+            ));
+            wait_until_connected(&session, client, &publications);
+        }
+        let first_client_address = litebox_broker_core::socket::status(&session, first_client)
+            .unwrap()
+            .local_address
+            .unwrap();
+        let second_client_address = litebox_broker_core::socket::status(&session, second_client)
+            .unwrap()
+            .local_address
+            .unwrap();
         wait_for_readiness(&publications, listener, ReadinessFlags::READ);
         assert_eq!(
             litebox_broker_core::socket::listen(&session, listener, 4),
@@ -2815,10 +4289,7 @@ mod tests {
             SocketOutcome::Failed(error) => panic!("first accept failed: {error:?}"),
         };
         assert_eq!(first.local_address, local_address);
-        assert_eq!(
-            first.remote_address,
-            socket_address_v4(first_client.local_addr().unwrap())
-        );
+        assert_eq!(first.remote_address, first_client_address);
         assert!(
             session
                 .check_readiness(listener)
@@ -2835,10 +4306,7 @@ mod tests {
                 SocketOutcome::Failed(error) => panic!("second accept failed: {error:?}"),
             };
         assert_eq!(second.local_address, local_address);
-        assert_eq!(
-            second.remote_address,
-            socket_address_v4(second_client.local_addr().unwrap())
-        );
+        assert_eq!(second.remote_address, second_client_address);
         assert!(
             !session
                 .check_readiness(listener)
@@ -2857,7 +4325,10 @@ mod tests {
                 .contains(ReadinessFlags::READ)
         );
 
-        first_client.write_all(b"request").unwrap();
+        assert_eq!(
+            send_bytes(&session, first_client, b"request", SendFlags::NONE),
+            Ok(SocketOutcome::Completed(7))
+        );
         let mut request = [0_u8; 7];
         loop {
             match receive_into(
@@ -2881,7 +4352,22 @@ mod tests {
             Ok(SocketOutcome::Completed(8))
         );
         let mut response = [0_u8; 8];
-        first_client.read_exact(&mut response).unwrap();
+        loop {
+            match receive_into(
+                &session,
+                first_client,
+                &mut response,
+                ReceiveFlags::NONE,
+                0,
+                0,
+            ) {
+                Ok(SocketOutcome::Completed(ReceiveSocketResponse::Received(8))) => break,
+                Err(BrokerError::WouldBlock) => {
+                    wait_for_readiness(&publications, first_client, ReadinessFlags::READ);
+                }
+                outcome => panic!("unexpected client receive outcome: {outcome:?}"),
+            }
+        }
         assert_eq!(&response, b"response");
         assert_eq!(
             litebox_broker_core::socket::shutdown(&session, listener, ShutdownMode::StopListening,),
@@ -2916,7 +4402,7 @@ mod tests {
         let server = UdpSocket::bind("127.0.0.1:0").unwrap();
         server.set_read_timeout(Some(TEST_TIMEOUT)).unwrap();
         let server_address = socket_address_v4(server.local_addr().unwrap());
-        let provider = Arc::new(LinuxSocketProvider::new(2).unwrap());
+        let provider = Arc::new(LinuxSocketProvider::new(2, 2).unwrap());
         let socket_policy = SocketPolicy::from_udp_destination_rules(&[
             DestinationRule::new(
                 CallerCredential::Unauthenticated,

--- a/litebox_broker_platform_linux_userland/src/socket.rs
+++ b/litebox_broker_platform_linux_userland/src/socket.rs
@@ -991,6 +991,8 @@ impl Reactor {
             .sessions
             .get(&session_id)
             .ok_or(BrokerError::Internal)?;
+        // Pending records can outlive connector descriptors, so bound this
+        // metadata independently using the configured socket budgets.
         if session.pending_guest_connections >= self.max_sockets_per_session
             || self.tcp.pending_guest_connections.len() >= self.max_sockets
         {

--- a/litebox_broker_platform_linux_userland/src/socket.rs
+++ b/litebox_broker_platform_linux_userland/src/socket.rs
@@ -865,16 +865,14 @@ enum SocketKind {
 }
 
 impl ReactorTcpState {
-    fn reserve_binding(&mut self) -> BrokerResult<()> {
-        self.bindings
-            .try_reserve(1)
-            .map_err(|_| BrokerError::OutOfMemory)
-    }
-
-    fn insert_binding(&mut self, port: u16, binding: ReactorTcpBinding) -> BrokerResult<()> {
-        if binding.guest_address.port() != port || self.bindings.contains_key(&port) {
+    fn insert_binding(&mut self, binding: ReactorTcpBinding) -> BrokerResult<()> {
+        let port = binding.guest_address.port();
+        if port == 0 || self.bindings.contains_key(&port) {
             return Err(BrokerError::Internal);
         }
+        self.bindings
+            .try_reserve(1)
+            .map_err(|_| BrokerError::OutOfMemory)?;
         self.bindings.insert(port, binding);
         Ok(())
     }
@@ -1304,21 +1302,13 @@ impl Reactor {
         if already_bound {
             return Ok(SocketOutcome::Failed(SocketError::InvalidArgument));
         }
-        let guest_port = requested_address.port();
-        if guest_port == 0 {
-            return Err(BrokerError::Internal);
-        }
-        self.tcp.reserve_binding()?;
-        let guest_address = SocketAddrV4::new(*requested_address.ip(), guest_port);
-        self.tcp.insert_binding(
-            guest_port,
-            ReactorTcpBinding {
-                socket_id: id,
-                guest_address,
-                host_address: None,
-                listening: false,
-            },
-        )?;
+        let guest_address = requested_address;
+        self.tcp.insert_binding(ReactorTcpBinding {
+            socket_id: id,
+            guest_address,
+            host_address: None,
+            listening: false,
+        })?;
         let socket = self.sockets.get_mut(&id).ok_or(BrokerError::Internal)?;
         socket.guest_local_address = Some(guest_address);
         socket

--- a/litebox_broker_platform_linux_userland/src/socket.rs
+++ b/litebox_broker_platform_linux_userland/src/socket.rs
@@ -781,7 +781,7 @@ struct AcceptedEndpoints {
 #[derive(Clone, Copy)]
 enum PendingGuestConnectionDisposition {
     Retain,
-    Discard,
+    Discard { established: bool },
 }
 
 /// State owned and accessed exclusively by the socket reactor thread.
@@ -817,6 +817,7 @@ struct SocketEntry {
     write_shutdown: bool,
     peek_waitall_threshold: Option<usize>,
     listening: bool,
+    was_listener: bool,
     abortive_close: bool,
     guest_local_address: Option<SocketAddrV4>,
     host_connection: Option<(SocketAddrV4, SocketAddrV4)>,
@@ -857,6 +858,7 @@ struct ReactorTcpBinding {
     guest_address: SocketAddrV4,
     host_address: Option<SocketAddrV4>,
     listening: bool,
+    requires_backlog_drain: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -924,6 +926,25 @@ impl ReactorTcpState {
             return Err(BrokerError::Internal);
         }
         binding.listening = false;
+        binding.requires_backlog_drain = false;
+        Ok(())
+    }
+
+    fn require_listener_backlog_drain(&mut self, listener_id: u64) {
+        self.bindings
+            .values_mut()
+            .find(|binding| binding.socket_id == listener_id)
+            .expect("pending guest connection listener binding missing")
+            .requires_backlog_drain = true;
+    }
+
+    fn finish_listener_backlog_drain(&mut self, listener_id: u64) -> BrokerResult<()> {
+        let binding = self
+            .bindings
+            .values_mut()
+            .find(|binding| binding.socket_id == listener_id)
+            .ok_or(BrokerError::Internal)?;
+        binding.requires_backlog_drain = false;
         Ok(())
     }
 
@@ -934,6 +955,18 @@ impl ReactorTcpState {
     ) -> Option<PendingGuestTcpConnection> {
         self.pending_guest_connections
             .remove(&(remote_address, local_address))
+    }
+
+    fn insert_pending_guest_connection(
+        &mut self,
+        connection: (SocketAddrV4, SocketAddrV4),
+        pending: PendingGuestTcpConnection,
+    ) -> BrokerResult<()> {
+        if self.pending_guest_connections.contains_key(&connection) {
+            return Err(BrokerError::ResourceExhausted);
+        }
+        self.pending_guest_connections.insert(connection, pending);
+        Ok(())
     }
 }
 
@@ -1033,18 +1066,14 @@ impl Reactor {
         guest_address: SocketAddrV4,
         listener_id: u64,
     ) -> BrokerResult<()> {
-        if let Some(previous) = self.tcp.pending_guest_connections.remove(&connection) {
-            self.finish_removed_pending_guest_connection(&previous);
-        }
-        let session = self
+        let pending_count = self
             .sessions
-            .get_mut(&session_id)
-            .ok_or(BrokerError::Internal)?;
-        session.pending_guest_connection_count = session
+            .get(&session_id)
+            .ok_or(BrokerError::Internal)?
             .pending_guest_connection_count
             .checked_add(1)
             .ok_or(BrokerError::ResourceExhausted)?;
-        self.tcp.pending_guest_connections.insert(
+        self.tcp.insert_pending_guest_connection(
             connection,
             PendingGuestTcpConnection {
                 session_id,
@@ -1054,7 +1083,11 @@ impl Reactor {
                 discard_deadline: None,
                 retained_connector: None,
             },
-        );
+        )?;
+        self.sessions
+            .get_mut(&session_id)
+            .expect("pending guest connection session state missing")
+            .pending_guest_connection_count = pending_count;
         Ok(())
     }
 
@@ -1112,9 +1145,11 @@ impl Reactor {
     fn retire_session_connectors(&mut self, session_id: SessionId) {
         let discard_deadline = Instant::now() + PENDING_CONNECT_DISCARD_LIFETIME;
         let mut released = 0;
-        for connection in self
-            .tcp
-            .pending_guest_connections
+        let ReactorTcpState {
+            bindings,
+            pending_guest_connections,
+        } = &mut self.tcp;
+        for connection in pending_guest_connections
             .values_mut()
             .filter(|connection| connection.session_id == session_id)
         {
@@ -1123,6 +1158,11 @@ impl Reactor {
                 drop(connector);
                 connection.discard_on_accept = true;
                 connection.discard_deadline = Some(discard_deadline);
+                bindings
+                    .values_mut()
+                    .find(|binding| binding.socket_id == connection.listener_id)
+                    .expect("pending guest connection listener binding missing")
+                    .requires_backlog_drain = true;
                 released += 1;
             }
         }
@@ -1259,8 +1299,9 @@ impl Reactor {
         }
         if let Some(binding) = self.tcp.guest_binding(address) {
             // A live guest binding owns this destination port broker-wide;
-            // only a listener may receive connections through it.
-            if !binding.listening {
+            // only a listener with a fully classified backlog may receive
+            // new guest connections through it.
+            if !binding.listening || binding.requires_backlog_drain {
                 return SocketOutcome::Failed(SocketError::ConnectionRefused);
             }
             return match binding.host_address {
@@ -1310,6 +1351,7 @@ impl Reactor {
             guest_address,
             host_address: None,
             listening: false,
+            requires_backlog_drain: false,
         })?;
         let socket = self.sockets.get_mut(&id).ok_or(BrokerError::Internal)?;
         socket.guest_local_address = Some(guest_address);
@@ -1475,13 +1517,13 @@ impl Reactor {
             session_id,
             kind,
             snapshot,
-            listening,
+            was_listener,
             abortive_close,
             guest_local_address,
             host_connection,
             ..
         } = socket;
-        if listening {
+        if was_listener {
             self.remove_pending_guest_connections_for_listener(id);
         }
         if kind == SocketKind::Tcp
@@ -1496,25 +1538,33 @@ impl Reactor {
             .status
             == SocketConnectionStatus::Connecting;
         let disposition = match getpeername(&socket) {
-            Ok(Some(_)) if abortive_close => PendingGuestConnectionDisposition::Discard,
+            Ok(Some(_)) if abortive_close => {
+                PendingGuestConnectionDisposition::Discard { established: true }
+            }
             Ok(Some(_)) => PendingGuestConnectionDisposition::Retain,
             Ok(None) | Err(_) => {
                 if abortive_close || connecting {
                     let _ = sockopt::set_socket_linger(&socket, Some(Duration::ZERO));
                 }
-                PendingGuestConnectionDisposition::Discard
+                PendingGuestConnectionDisposition::Discard { established: false }
             }
         };
         let mut socket = Some(socket);
+        let mut listener_requiring_backlog_drain = None;
         if let Some(connection) = host_connection
             && let Some(pending) = self.tcp.pending_guest_connections.get_mut(&connection)
             && pending.session_id == session_id
         {
-            pending.discard_on_accept =
-                matches!(disposition, PendingGuestConnectionDisposition::Discard);
+            pending.discard_on_accept = matches!(
+                disposition,
+                PendingGuestConnectionDisposition::Discard { .. }
+            );
             pending.discard_deadline = match disposition {
                 PendingGuestConnectionDisposition::Retain => None,
-                PendingGuestConnectionDisposition::Discard => {
+                PendingGuestConnectionDisposition::Discard { established } => {
+                    if established {
+                        listener_requiring_backlog_drain = Some(pending.listener_id);
+                    }
                     Some(Instant::now() + PENDING_CONNECT_DISCARD_LIFETIME)
                 }
             };
@@ -1533,6 +1583,9 @@ impl Reactor {
                     .checked_add(1)
                     .expect("session retained connector count overflow");
             }
+        }
+        if let Some(listener_id) = listener_requiring_backlog_drain {
+            self.tcp.require_listener_backlog_drain(listener_id);
         }
         drop(socket);
         if let Some(session) = self.sessions.get_mut(&session_id) {
@@ -1765,14 +1818,19 @@ impl Reactor {
                     {
                         self.peek_cache = None;
                     }
-                    let outcome = self
+                    let was_listening = mode == ShutdownMode::StopListening
+                        && self.sockets.get(&id).is_some_and(|socket| socket.listening);
+                    let mut outcome = self
                         .sockets
                         .get_mut(&id)
                         .ok_or(BrokerError::Internal)
                         .and_then(|socket| shutdown_socket(socket, mode));
-                    if matches!(outcome, Ok(SocketOutcome::Completed(())))
-                        && mode == ShutdownMode::StopListening
-                    {
+                    let stopped_listening = was_listening
+                        && self
+                            .sockets
+                            .get(&id)
+                            .is_some_and(|socket| !socket.listening);
+                    if stopped_listening {
                         self.remove_pending_guest_connections_for_listener(id);
                         let update = self
                             .sockets
@@ -1781,8 +1839,7 @@ impl Reactor {
                             .ok_or(BrokerError::Internal)
                             .and_then(|address| self.tcp.stop_listening(address.port(), id));
                         if let Err(error) = update {
-                            let _ = response.send(Err(error));
-                            continue;
+                            outcome = Err(error);
                         }
                     }
                     let _ = response.send(outcome);
@@ -1971,6 +2028,7 @@ impl Reactor {
                 write_shutdown: false,
                 peek_waitall_threshold: None,
                 listening: false,
+                was_listener: false,
                 abortive_close: false,
                 guest_local_address: None,
                 host_connection: None,
@@ -2035,6 +2093,7 @@ impl Reactor {
                     Err(Errno::INTR) => {}
                     Err(Errno::AGAIN) => {
                         clear_readiness(listener, ReadinessFlags::READ)?;
+                        self.tcp.finish_listener_backlog_drain(listener_id)?;
                         return Err(BrokerError::WouldBlock);
                     }
                     Err(error) => {
@@ -2135,6 +2194,7 @@ impl Reactor {
                 write_shutdown: false,
                 peek_waitall_threshold: None,
                 listening: false,
+                was_listener: false,
                 abortive_close: false,
                 guest_local_address: Some(listener_guest_address),
                 host_connection: None,
@@ -2341,6 +2401,7 @@ fn listen_tcp_socket(
         }
     }
     socket.listening = true;
+    socket.was_listener = true;
     let mut snapshot = socket
         .snapshot
         .lock()
@@ -3307,7 +3368,7 @@ mod tests {
             (first_listener, first_guest),
             (second_listener, second_guest),
         ] {
-            tcp.pending_guest_connections.insert(
+            tcp.insert_pending_guest_connection(
                 (remote_address, listener),
                 PendingGuestTcpConnection {
                     session_id: SessionId(7),
@@ -3317,8 +3378,23 @@ mod tests {
                     discard_deadline: None,
                     retained_connector: None,
                 },
-            );
+            )
+            .unwrap();
         }
+        assert_eq!(
+            tcp.insert_pending_guest_connection(
+                (remote_address, first_listener),
+                PendingGuestTcpConnection {
+                    session_id: SessionId(8),
+                    guest_address: SocketAddrV4::new(Ipv4Addr::LOCALHOST, 1002),
+                    listener_id: 1,
+                    discard_on_accept: false,
+                    discard_deadline: None,
+                    retained_connector: None,
+                },
+            ),
+            Err(BrokerError::ResourceExhausted)
+        );
 
         assert_eq!(
             tcp.take_pending_guest_connection(remote_address, second_listener)
@@ -3357,6 +3433,41 @@ mod tests {
 
         fn retire(&self, handle: ObjectHandle) {
             let _ = self.retired.send(handle);
+        }
+    }
+
+    struct FailingReadinessSink {
+        inner: TestReadinessSink,
+        fail_next_publish: Mutex<Option<ObjectHandle>>,
+    }
+
+    impl FailingReadinessSink {
+        fn fail_next_publish_for(&self, handle: ObjectHandle) {
+            *self.fail_next_publish.lock().unwrap() = Some(handle);
+        }
+    }
+
+    impl ReadinessSink for FailingReadinessSink {
+        fn max_tracked_objects(&self) -> usize {
+            self.inner.max_tracked_objects()
+        }
+
+        fn publish(&self, handle: ObjectHandle, readiness: ReadinessFlags) -> BrokerResult<()> {
+            let mut fail_next_publish = self.fail_next_publish.lock().unwrap();
+            if *fail_next_publish == Some(handle) {
+                *fail_next_publish = None;
+                return Err(BrokerError::ResourceExhausted);
+            }
+            drop(fail_next_publish);
+            self.inner.publish(handle, readiness)
+        }
+
+        fn republish(&self, handle: ObjectHandle, readiness: ReadinessFlags) -> BrokerResult<()> {
+            self.publish(handle, readiness)
+        }
+
+        fn retire(&self, handle: ObjectHandle) {
+            self.inner.retire(handle);
         }
     }
 
@@ -3643,6 +3754,14 @@ mod tests {
         );
         assert_eq!(
             litebox_broker_core::socket::shutdown(&session, unconnected_handle, ShutdownMode::Both,),
+            Ok(SocketOutcome::Failed(SocketError::NotConnected))
+        );
+        assert_eq!(
+            litebox_broker_core::socket::shutdown(
+                &session,
+                unconnected_handle,
+                ShutdownMode::StopListening,
+            ),
             Ok(SocketOutcome::Failed(SocketError::NotConnected))
         );
         assert!(
@@ -4033,6 +4152,29 @@ mod tests {
         assert_eq!(provider.reactor.retained_connector_count(), 0);
         provider.reactor.expire_pending_guest_connections();
         assert_eq!(provider.reactor.pending_guest_connection_count(), 0);
+
+        let blocked_connector_session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let blocked_connector = create_socket(&blocked_connector_session, readiness.clone());
+        assert_eq!(
+            litebox_broker_core::socket::connect(
+                &blocked_connector_session,
+                blocked_connector,
+                guest_address,
+            ),
+            Ok(SocketOutcome::Completed(SocketConnectionStatus::Failed(
+                SocketError::ConnectionRefused
+            )))
+        );
+        blocked_connector_session
+            .close_object_reference(blocked_connector)
+            .unwrap();
+        assert_eq!(
+            retirements.recv_timeout(TEST_TIMEOUT).unwrap(),
+            blocked_connector
+        );
+
         wait_for_readiness(&publications, listener, ReadinessFlags::READ);
         assert!(matches!(
             litebox_broker_core::socket::accept(&listener_session, listener, readiness.clone(),),
@@ -4113,14 +4255,48 @@ mod tests {
         assert_eq!(provider.reactor.pending_guest_connection_count(), 1);
         assert_eq!(provider.reactor.retained_connector_count(), 0);
 
-        let replacement = create_socket(&connector_session, readiness);
+        provider.reactor.expire_pending_guest_connections();
+        assert_eq!(provider.reactor.pending_guest_connection_count(), 0);
+        assert_eq!(provider.reactor.retained_connector_count(), 0);
+
+        let replacement = create_socket(&connector_session, readiness.clone());
+        assert_eq!(
+            litebox_broker_core::socket::connect(&connector_session, replacement, guest_address,),
+            Ok(SocketOutcome::Completed(SocketConnectionStatus::Failed(
+                SocketError::ConnectionRefused
+            )))
+        );
         connector_session
             .close_object_reference(replacement)
             .unwrap();
         assert_eq!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), replacement);
-        provider.reactor.expire_pending_guest_connections();
-        assert_eq!(provider.reactor.pending_guest_connection_count(), 0);
-        assert_eq!(provider.reactor.retained_connector_count(), 0);
+
+        loop {
+            match litebox_broker_core::socket::accept(
+                &listener_session,
+                listener,
+                readiness.clone(),
+            ) {
+                Err(BrokerError::WouldBlock) => break,
+                Ok(SocketOutcome::Failed(
+                    SocketError::ConnectionAborted | SocketError::ConnectionReset,
+                )) => {}
+                _ => panic!("unexpected stale accept outcome"),
+            }
+        }
+
+        let final_connector = create_socket(&connector_session, readiness);
+        assert!(matches!(
+            litebox_broker_core::socket::connect(
+                &connector_session,
+                final_connector,
+                guest_address,
+            ),
+            Ok(SocketOutcome::Completed(
+                SocketConnectionStatus::Connecting | SocketConnectionStatus::Connected
+            ))
+        ));
+        wait_until_connected(&connector_session, final_connector, &publications);
     }
 
     #[test]
@@ -4365,6 +4541,71 @@ mod tests {
         session.close_object_reference(listener).unwrap();
         assert_eq!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), listener);
         assert_eq!(provider.reactor.host_address(guest_address.port()), None);
+    }
+
+    #[test]
+    fn stop_listening_cleanup_survives_readiness_failure() {
+        let provider = Arc::new(LinuxSocketProvider::new(3, 1).unwrap());
+        let broker = BrokerCore::new_with_limits(
+            PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
+                .with_socket_policy(SocketPolicy::Ipv4Loopback),
+            BrokerCoreLimits::new_with_all_limits(8, 0, 3, 3),
+            provider.clone(),
+        )
+        .unwrap();
+        let listener_session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let connector_session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let (published, publications) = channel();
+        let (retired, retirements) = channel();
+        let readiness = Arc::new(FailingReadinessSink {
+            inner: TestReadinessSink { published, retired },
+            fail_next_publish: Mutex::new(None),
+        });
+        let guest_address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8088);
+        let listener = create_socket(&listener_session, readiness.clone());
+        assert_eq!(
+            litebox_broker_core::socket::bind(&listener_session, listener, guest_address),
+            Ok(SocketOutcome::Completed(guest_address))
+        );
+        assert_eq!(
+            litebox_broker_core::socket::listen(&listener_session, listener, 1),
+            Ok(SocketOutcome::Completed(guest_address))
+        );
+
+        let connector = create_socket(&connector_session, readiness.clone());
+        assert!(matches!(
+            litebox_broker_core::socket::connect(&connector_session, connector, guest_address,),
+            Ok(SocketOutcome::Completed(
+                SocketConnectionStatus::Connecting | SocketConnectionStatus::Connected
+            ))
+        ));
+        wait_until_connected(&connector_session, connector, &publications);
+        wait_for_readiness(&publications, listener, ReadinessFlags::READ);
+        connector_session.close_object_reference(connector).unwrap();
+        assert_eq!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), connector);
+        assert_eq!(provider.reactor.pending_guest_connection_count(), 1);
+        assert_eq!(provider.reactor.retained_connector_count(), 1);
+
+        readiness.fail_next_publish_for(listener);
+        assert_eq!(
+            litebox_broker_core::socket::shutdown(
+                &listener_session,
+                listener,
+                ShutdownMode::StopListening,
+            ),
+            Err(BrokerError::ResourceExhausted)
+        );
+        assert_eq!(provider.reactor.pending_guest_connection_count(), 0);
+        assert_eq!(provider.reactor.retained_connector_count(), 0);
+
+        listener_session.close_object_reference(listener).unwrap();
+        assert_eq!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), listener);
+        assert_eq!(provider.reactor.pending_guest_connection_count(), 0);
+        assert_eq!(provider.reactor.retained_connector_count(), 0);
     }
 
     #[test]
@@ -4847,7 +5088,7 @@ mod tests {
 
     fn create_socket(
         session: &litebox_broker_core::BrokerSession,
-        readiness: Arc<TestReadinessSink>,
+        readiness: Arc<dyn ReadinessSink>,
     ) -> ObjectHandle {
         litebox_broker_core::socket::create(
             session,

--- a/litebox_broker_platform_linux_userland/src/socket.rs
+++ b/litebox_broker_platform_linux_userland/src/socket.rs
@@ -33,8 +33,8 @@ use rustix::io::{Errno, ioctl_fionread, read, write};
 use rustix::net::{
     AddressFamily as LinuxAddressFamily, RecvFlags as LinuxRecvFlags, SendFlags as LinuxSendFlags,
     Shutdown as LinuxShutdown, SocketFlags as LinuxSocketFlags, SocketType as LinuxSocketType,
-    acceptfrom_with, bind, connect, getpeername, getsockname, ipproto, listen, recv, recvfrom,
-    send, sendto, shutdown, socket_with, sockopt,
+    acceptfrom_with, bind, connect, getsockname, ipproto, listen, recv, recvfrom, send, sendto,
+    shutdown, socket_with, sockopt,
 };
 
 use litebox_broker_core::readiness::ReadinessRegistration;
@@ -590,6 +590,19 @@ impl ReactorClient {
         receive.recv().unwrap();
     }
 
+    #[cfg(test)]
+    fn defer_untracked_guest_connection(&self, guest_port: u16) {
+        let (response, receive) = sync_channel(1);
+        self.commands
+            .send(ReactorCommand::DeferUntrackedGuestConnection {
+                guest_port,
+                response,
+            })
+            .unwrap();
+        self.signal().unwrap();
+        receive.recv().unwrap();
+    }
+
     fn close_session(&self, session_id: SessionId) {
         let (response, receive) = sync_channel(1);
         if self
@@ -753,6 +766,11 @@ enum ReactorCommand {
         now: Instant,
         response: SyncSender<()>,
     },
+    #[cfg(test)]
+    DeferUntrackedGuestConnection {
+        guest_port: u16,
+        response: SyncSender<()>,
+    },
     Stop {
         response: SyncSender<()>,
     },
@@ -776,12 +794,6 @@ enum ReactorReceiveFromOutcome {
 
 struct AcceptedEndpoints {
     remote_address: SocketAddrV4,
-}
-
-#[derive(Clone, Copy)]
-enum PendingGuestConnectionDisposition {
-    Retain,
-    Discard { established: bool },
 }
 
 /// State owned and accessed exclusively by the socket reactor thread.
@@ -813,6 +825,8 @@ struct SocketEntry {
     kind: SocketKind,
     readiness: ReadinessRegistration,
     snapshot: Arc<Mutex<SocketSnapshot>>,
+    connection_status: SocketConnectionStatus,
+    untracked_guest_listener_id: Option<u64>,
     read_shutdown: bool,
     write_shutdown: bool,
     peek_waitall_threshold: Option<usize>,
@@ -848,8 +862,14 @@ struct PendingGuestTcpConnection {
     guest_address: SocketAddrV4,
     listener_id: u64,
     discard_on_accept: bool,
+    discard_until_deadline: bool,
     discard_deadline: Option<Instant>,
     retained_connector: Option<OwnedFd>,
+}
+
+enum PendingGuestConnectionMatch {
+    PersistentDiscard,
+    Take(PendingGuestTcpConnection),
 }
 
 #[derive(Clone, Copy)]
@@ -859,6 +879,7 @@ struct ReactorTcpBinding {
     host_address: Option<SocketAddrV4>,
     listening: bool,
     requires_backlog_drain: bool,
+    untracked_connection_deadline: Option<Instant>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -927,15 +948,43 @@ impl ReactorTcpState {
         }
         binding.listening = false;
         binding.requires_backlog_drain = false;
+        binding.untracked_connection_deadline = None;
         Ok(())
     }
 
-    fn require_listener_backlog_drain(&mut self, listener_id: u64) {
-        self.bindings
+    fn defer_untracked_connection(&mut self, listener_id: u64, deadline: Instant) {
+        let binding = self
+            .bindings
             .values_mut()
             .find(|binding| binding.socket_id == listener_id)
-            .expect("pending guest connection listener binding missing")
-            .requires_backlog_drain = true;
+            .expect("untracked guest connection listener binding missing");
+        binding.untracked_connection_deadline = Some(
+            binding
+                .untracked_connection_deadline
+                .map_or(deadline, |current| current.max(deadline)),
+        );
+    }
+
+    fn persist_discard_marker_for_collision(
+        &mut self,
+        connection: (SocketAddrV4, SocketAddrV4),
+        listener_id: u64,
+        deadline: Instant,
+    ) -> bool {
+        let Some(pending) = self.pending_guest_connections.get_mut(&connection) else {
+            return false;
+        };
+        if !pending.discard_on_accept || pending.listener_id != listener_id {
+            return false;
+        }
+        // A collision can represent both the old ambiguous child and the new
+        // one. Keep dropping this tuple until the refreshed deadline instead
+        // of blocking unrelated connections to the listener. The marker stays
+        // charged to its original session even when another session refreshes
+        // it; identity protection is broker-wide and adds no new record.
+        pending.discard_until_deadline = true;
+        pending.discard_deadline = Some(deadline);
+        true
     }
 
     fn finish_listener_backlog_drain(&mut self, listener_id: u64) -> BrokerResult<()> {
@@ -944,6 +993,8 @@ impl ReactorTcpState {
             .values_mut()
             .find(|binding| binding.socket_id == listener_id)
             .ok_or(BrokerError::Internal)?;
+        // A tuple-unknown connect can still complete after an empty drain
+        // observation, so only its maturation deadline may release that block.
         binding.requires_backlog_drain = false;
         Ok(())
     }
@@ -952,9 +1003,19 @@ impl ReactorTcpState {
         &mut self,
         remote_address: SocketAddrV4,
         local_address: SocketAddrV4,
-    ) -> Option<PendingGuestTcpConnection> {
+    ) -> Option<PendingGuestConnectionMatch> {
+        if self
+            .pending_guest_connections
+            .get(&(remote_address, local_address))
+            .is_some_and(|connection| {
+                connection.discard_on_accept && connection.discard_until_deadline
+            })
+        {
+            return Some(PendingGuestConnectionMatch::PersistentDiscard);
+        }
         self.pending_guest_connections
             .remove(&(remote_address, local_address))
+            .map(PendingGuestConnectionMatch::Take)
     }
 
     fn insert_pending_guest_connection(
@@ -975,6 +1036,31 @@ fn retain_session_state(state: &ReactorSessionState) -> bool {
         || state.live_socket_count != 0
         || state.pending_guest_connection_count != 0
         || state.retained_connector_count != 0
+}
+
+fn listener_backlog_is_nonempty(sockets: &HashMap<u64, SocketEntry>, listener_id: u64) -> bool {
+    let Some(listener) = sockets.get(&listener_id) else {
+        return false;
+    };
+    if !listener.listening {
+        return false;
+    }
+    socket_backlog_is_nonempty(&listener.socket)
+}
+
+fn socket_backlog_is_nonempty(socket: &OwnedFd) -> bool {
+    let no_wait = Timespec {
+        tv_sec: 0,
+        tv_nsec: 0,
+    };
+    loop {
+        let mut poll_fd = [PollFd::new(socket, PollFlags::IN)];
+        match poll(&mut poll_fd, Some(&no_wait)) {
+            Ok(_) => return !poll_fd[0].revents().is_empty(),
+            Err(Errno::INTR) => {}
+            Err(_) => return true,
+        }
+    }
 }
 
 /// Cached connection and readiness state shared with the broker-facing handle.
@@ -1020,6 +1106,24 @@ impl fmt::Display for ReactorFailure {
 }
 
 impl Reactor {
+    fn discard_failed_connect_after_command(&mut self, id: u64, was_connecting: bool) {
+        if !was_connecting {
+            return;
+        }
+        let failed_connection = self.sockets.get(&id).and_then(|socket| {
+            matches!(socket.connection_status, SocketConnectionStatus::Failed(_))
+                .then(|| {
+                    socket
+                        .host_connection
+                        .map(|connection| (connection, socket.session_id))
+                })
+                .flatten()
+        });
+        if let Some((connection, session_id)) = failed_connection {
+            self.discard_pending_guest_connection(connection, session_id);
+        }
+    }
+
     fn reserve_pending_guest_connection(&mut self, session_id: SessionId) -> BrokerResult<()> {
         let session = self
             .sessions
@@ -1080,6 +1184,7 @@ impl Reactor {
                 guest_address,
                 listener_id,
                 discard_on_accept: false,
+                discard_until_deadline: false,
                 discard_deadline: None,
                 retained_connector: None,
             },
@@ -1091,23 +1196,19 @@ impl Reactor {
         Ok(())
     }
 
-    fn remove_pending_guest_connection(
+    fn discard_pending_guest_connection(
         &mut self,
         connection: (SocketAddrV4, SocketAddrV4),
         session_id: SessionId,
     ) {
-        let removed = self
-            .tcp
-            .pending_guest_connections
-            .get(&connection)
-            .is_some_and(|pending| pending.session_id == session_id)
-            .then(|| self.tcp.pending_guest_connections.remove(&connection))
-            .flatten();
-        if let Some(pending) = removed {
-            self.finish_removed_pending_guest_connection(&pending);
+        if let Some(pending) = self.tcp.pending_guest_connections.get_mut(&connection)
+            && pending.session_id == session_id
+        {
+            // The descriptor remains open and pins the native tuple. Final
+            // close starts the bounded discard deadline.
+            pending.discard_on_accept = true;
+            pending.discard_deadline = None;
         }
-        self.sessions
-            .retain(|_, session| retain_session_state(session));
     }
 
     fn remove_pending_guest_connections_for_listener(&mut self, listener_id: u64) {
@@ -1145,11 +1246,9 @@ impl Reactor {
     fn retire_session_connectors(&mut self, session_id: SessionId) {
         let discard_deadline = Instant::now() + PENDING_CONNECT_DISCARD_LIFETIME;
         let mut released = 0;
-        let ReactorTcpState {
-            bindings,
-            pending_guest_connections,
-        } = &mut self.tcp;
-        for connection in pending_guest_connections
+        for connection in self
+            .tcp
+            .pending_guest_connections
             .values_mut()
             .filter(|connection| connection.session_id == session_id)
         {
@@ -1158,11 +1257,6 @@ impl Reactor {
                 drop(connector);
                 connection.discard_on_accept = true;
                 connection.discard_deadline = Some(discard_deadline);
-                bindings
-                    .values_mut()
-                    .find(|binding| binding.socket_id == connection.listener_id)
-                    .expect("pending guest connection listener binding missing")
-                    .requires_backlog_drain = true;
                 released += 1;
             }
         }
@@ -1183,17 +1277,53 @@ impl Reactor {
             .pending_guest_connections
             .values()
             .filter_map(|connection| connection.discard_deadline)
+            .chain(
+                self.tcp
+                    .bindings
+                    .values()
+                    .filter_map(|binding| binding.untracked_connection_deadline),
+            )
             .min()
     }
 
     fn expire_deadlined_state(&mut self, now: Instant) {
         let Reactor {
             tcp,
+            sockets,
             sessions,
             retained_connector_count,
             ..
         } = self;
-        tcp.pending_guest_connections.retain(|_, connection| {
+        let ReactorTcpState {
+            bindings,
+            pending_guest_connections,
+        } = tcp;
+        for binding in bindings.values_mut() {
+            if binding
+                .untracked_connection_deadline
+                .is_some_and(|deadline| deadline <= now)
+            {
+                if listener_backlog_is_nonempty(sockets, binding.socket_id) {
+                    binding.requires_backlog_drain = true;
+                }
+                binding.untracked_connection_deadline = None;
+            }
+        }
+        for connection in pending_guest_connections.values().filter(|connection| {
+            connection.discard_on_accept
+                && connection
+                    .discard_deadline
+                    .is_some_and(|deadline| deadline <= now)
+        }) {
+            if listener_backlog_is_nonempty(sockets, connection.listener_id) {
+                bindings
+                    .values_mut()
+                    .find(|binding| binding.socket_id == connection.listener_id)
+                    .expect("pending guest connection listener binding missing")
+                    .requires_backlog_drain = true;
+            }
+        }
+        pending_guest_connections.retain(|_, connection| {
             let retain = !connection.discard_on_accept
                 || connection
                     .discard_deadline
@@ -1227,9 +1357,12 @@ impl Reactor {
         remote_address: SocketAddrV4,
         local_address: SocketAddrV4,
     ) -> Option<SocketAddrV4> {
-        let mut connection = self
+        let PendingGuestConnectionMatch::Take(mut connection) = self
             .tcp
-            .take_pending_guest_connection(remote_address, local_address)?;
+            .take_pending_guest_connection(remote_address, local_address)?
+        else {
+            return None;
+        };
         self.finish_removed_pending_guest_connection(&connection);
         drop(connection.retained_connector.take());
         let guest_address = (!connection.discard_on_accept
@@ -1301,7 +1434,12 @@ impl Reactor {
             // A live guest binding owns this destination port broker-wide;
             // only a listener with a fully classified backlog may receive
             // new guest connections through it.
-            if !binding.listening || binding.requires_backlog_drain {
+            if !binding.listening
+                || binding.requires_backlog_drain
+                // Defence in depth for failures after connect(2) but before a
+                // complete host tuple can be recorded.
+                || binding.untracked_connection_deadline.is_some()
+            {
                 return SocketOutcome::Failed(SocketError::ConnectionRefused);
             }
             return match binding.host_address {
@@ -1352,6 +1490,7 @@ impl Reactor {
             host_address: None,
             listening: false,
             requires_backlog_drain: false,
+            untracked_connection_deadline: None,
         })?;
         let socket = self.sockets.get_mut(&id).ok_or(BrokerError::Internal)?;
         socket.guest_local_address = Some(guest_address);
@@ -1437,14 +1576,13 @@ impl Reactor {
                 SocketOutcome::Completed(destination) => destination,
                 SocketOutcome::Failed(error) => {
                     let status = SocketConnectionStatus::Failed(error);
-                    update_snapshot(
-                        self.sockets
-                            .get(&id)
-                            .ok_or(PlatformConnectError::PeerUnchanged(BrokerError::Internal))?,
-                        Some(status),
-                        ReadinessFlags::ERROR,
-                    )
-                    .map_err(PlatformConnectError::PeerIndeterminate)?;
+                    let socket = self
+                        .sockets
+                        .get_mut(&id)
+                        .ok_or(PlatformConnectError::PeerUnchanged(BrokerError::Internal))?;
+                    socket.connection_status = status;
+                    update_snapshot(socket, Some(status), ReadinessFlags::ERROR)
+                        .map_err(PlatformConnectError::PeerIndeterminate)?;
                     return Ok(status);
                 }
             };
@@ -1460,6 +1598,7 @@ impl Reactor {
                 .get_mut(&id)
                 .ok_or(PlatformConnectError::PeerUnchanged(BrokerError::Internal))?,
             network_address,
+            guest_listener_id,
         )?;
         if matches!(
             status,
@@ -1480,6 +1619,21 @@ impl Reactor {
                 .map_err(PlatformConnectError::PeerIndeterminate)?;
             if let Some(listener_id) = guest_listener_id {
                 let connection = (host_address, network_address);
+                if self.tcp.persist_discard_marker_for_collision(
+                    connection,
+                    listener_id,
+                    Instant::now() + PENDING_CONNECT_DISCARD_LIFETIME,
+                ) {
+                    self.sockets
+                        .get_mut(&id)
+                        .ok_or(PlatformConnectError::PeerIndeterminate(
+                            BrokerError::Internal,
+                        ))?
+                        .untracked_guest_listener_id = None;
+                    return Err(PlatformConnectError::PeerIndeterminate(
+                        BrokerError::ResourceExhausted,
+                    ));
+                }
                 self.insert_pending_guest_connection(
                     session_id,
                     connection,
@@ -1487,15 +1641,17 @@ impl Reactor {
                     listener_id,
                 )
                 .map_err(PlatformConnectError::PeerIndeterminate)?;
-                self.sockets
-                    .get_mut(&id)
-                    .ok_or(PlatformConnectError::PeerIndeterminate(
-                        BrokerError::Internal,
-                    ))?
-                    .host_connection = Some(connection);
+                let socket =
+                    self.sockets
+                        .get_mut(&id)
+                        .ok_or(PlatformConnectError::PeerIndeterminate(
+                            BrokerError::Internal,
+                        ))?;
+                socket.host_connection = Some(connection);
+                socket.untracked_guest_listener_id = None;
             }
         }
-        update_snapshot(
+        if let Err(error) = update_snapshot(
             self.sockets
                 .get(&id)
                 .ok_or(PlatformConnectError::PeerIndeterminate(
@@ -1503,8 +1659,16 @@ impl Reactor {
                 ))?,
             Some(status),
             readiness,
-        )
-        .map_err(PlatformConnectError::PeerIndeterminate)?;
+        ) {
+            if let Some(connection) = self
+                .sockets
+                .get(&id)
+                .and_then(|socket| socket.host_connection)
+            {
+                self.discard_pending_guest_connection(connection, session_id);
+            }
+            return Err(PlatformConnectError::PeerIndeterminate(error));
+        }
         Ok(status)
     }
 
@@ -1516,13 +1680,21 @@ impl Reactor {
             socket,
             session_id,
             kind,
-            snapshot,
+            connection_status,
+            untracked_guest_listener_id,
             was_listener,
             abortive_close,
             guest_local_address,
             host_connection,
             ..
         } = socket;
+        let guest_connector = untracked_guest_listener_id.is_some()
+            || host_connection.is_some_and(|connection| {
+                self.tcp
+                    .pending_guest_connections
+                    .get(&connection)
+                    .is_some_and(|pending| pending.session_id == session_id)
+            });
         if was_listener {
             self.remove_pending_guest_connections_for_listener(id);
         }
@@ -1532,43 +1704,33 @@ impl Reactor {
             self.tcp.remove_binding(address.port(), id);
         }
 
-        let connecting = snapshot
-            .lock()
-            .expect("Linux socket snapshot mutex poisoned")
-            .status
-            == SocketConnectionStatus::Connecting;
-        let disposition = match getpeername(&socket) {
-            Ok(Some(_)) if abortive_close => {
-                PendingGuestConnectionDisposition::Discard { established: true }
-            }
-            Ok(Some(_)) => PendingGuestConnectionDisposition::Retain,
-            Ok(None) | Err(_) => {
-                if abortive_close || connecting {
-                    let _ = sockopt::set_socket_linger(&socket, Some(Duration::ZERO));
-                }
-                PendingGuestConnectionDisposition::Discard { established: false }
-            }
-        };
         let mut socket = Some(socket);
-        let mut listener_requiring_backlog_drain = None;
+        if kind == SocketKind::Tcp
+            && !abortive_close
+            && guest_connector
+            && matches!(
+                connection_status,
+                SocketConnectionStatus::Connecting | SocketConnectionStatus::Connected
+            )
+        {
+            let _ = shutdown(
+                socket.as_ref().expect("connector descriptor missing"),
+                LinuxShutdown::Both,
+            );
+        }
         if let Some(connection) = host_connection
             && let Some(pending) = self.tcp.pending_guest_connections.get_mut(&connection)
             && pending.session_id == session_id
         {
-            pending.discard_on_accept = matches!(
-                disposition,
-                PendingGuestConnectionDisposition::Discard { .. }
-            );
-            pending.discard_deadline = match disposition {
-                PendingGuestConnectionDisposition::Retain => None,
-                PendingGuestConnectionDisposition::Discard { established } => {
-                    if established {
-                        listener_requiring_backlog_drain = Some(pending.listener_id);
-                    }
-                    Some(Instant::now() + PENDING_CONNECT_DISCARD_LIFETIME)
-                }
-            };
-            if matches!(disposition, PendingGuestConnectionDisposition::Retain) {
+            let retain = !abortive_close
+                && connection_status == SocketConnectionStatus::Connected
+                && !pending.discard_on_accept;
+            // A close that wins before native completion is observed is
+            // deliberately non-deliverable; teardown never re-infers it.
+            pending.discard_on_accept = !retain;
+            pending.discard_deadline =
+                (!retain).then(|| Instant::now() + PENDING_CONNECT_DISCARD_LIFETIME);
+            if retain {
                 pending.retained_connector = socket.take();
                 self.retained_connector_count = self
                     .retained_connector_count
@@ -1584,8 +1746,20 @@ impl Reactor {
                     .expect("session retained connector count overflow");
             }
         }
-        if let Some(listener_id) = listener_requiring_backlog_drain {
-            self.tcp.require_listener_backlog_drain(listener_id);
+        if let Some(listener_id) = untracked_guest_listener_id
+            && self
+                .tcp
+                .bindings
+                .values()
+                .any(|binding| binding.socket_id == listener_id)
+        {
+            // No tuple exists to key a discard marker. Block later routes for
+            // the same bounded maturation period, then probe the listener just
+            // like an expiring keyed marker.
+            self.tcp.defer_untracked_connection(
+                listener_id,
+                Instant::now() + PENDING_CONNECT_DISCARD_LIFETIME,
+            );
         }
         drop(socket);
         if let Some(session) = self.sessions.get_mut(&session_id) {
@@ -1641,7 +1815,6 @@ impl Reactor {
                         {
                             socket
                                 .host_connection
-                                .take()
                                 .map(|connection| (connection, socket.session_id))
                         } else {
                             None
@@ -1650,7 +1823,7 @@ impl Reactor {
                         None
                     };
                     if let Some((connection, session_id)) = failed_connection {
-                        self.remove_pending_guest_connection(connection, session_id);
+                        self.discard_pending_guest_connection(connection, session_id);
                     }
                 }
             }
@@ -1755,11 +1928,15 @@ impl Reactor {
                     }
                 }
                 ReactorCommand::Send { id, data, response } => {
+                    let was_connecting = self.sockets.get(&id).is_some_and(|socket| {
+                        socket.connection_status == SocketConnectionStatus::Connecting
+                    });
                     let outcome = self
                         .sockets
                         .get_mut(&id)
                         .ok_or(BrokerError::Internal)
                         .and_then(|socket| send_socket(socket, &data));
+                    self.discard_failed_connect_after_command(id, was_connecting);
                     let _ = response.send(outcome);
                 }
                 ReactorCommand::SendTo {
@@ -1783,6 +1960,9 @@ impl Reactor {
                     peek_length,
                     response,
                 } => {
+                    let was_connecting = self.sockets.get(&id).is_some_and(|socket| {
+                        socket.connection_status == SocketConnectionStatus::Connecting
+                    });
                     let outcome = match self.sockets.get_mut(&id) {
                         Some(socket) => receive_socket(
                             socket,
@@ -1795,6 +1975,7 @@ impl Reactor {
                         ),
                         None => Err(BrokerError::Internal),
                     };
+                    self.discard_failed_connect_after_command(id, was_connecting);
                     let _ = response.send(outcome);
                 }
                 ReactorCommand::ReceiveFrom {
@@ -1820,6 +2001,9 @@ impl Reactor {
                     }
                     let was_listening = mode == ShutdownMode::StopListening
                         && self.sockets.get(&id).is_some_and(|socket| socket.listening);
+                    let was_connecting = self.sockets.get(&id).is_some_and(|socket| {
+                        socket.connection_status == SocketConnectionStatus::Connecting
+                    });
                     let mut outcome = self
                         .sockets
                         .get_mut(&id)
@@ -1842,6 +2026,7 @@ impl Reactor {
                             outcome = Err(error);
                         }
                     }
+                    self.discard_failed_connect_after_command(id, was_connecting);
                     let _ = response.send(outcome);
                 }
                 ReactorCommand::SetTcpOption {
@@ -1925,6 +2110,23 @@ impl Reactor {
                 #[cfg(test)]
                 ReactorCommand::ExpireDeadlinedState { now, response } => {
                     self.expire_deadlined_state(now);
+                    let _ = response.send(());
+                }
+                #[cfg(test)]
+                ReactorCommand::DeferUntrackedGuestConnection {
+                    guest_port,
+                    response,
+                } => {
+                    let listener_id = self
+                        .tcp
+                        .bindings
+                        .get(&guest_port)
+                        .expect("test guest listener binding missing")
+                        .socket_id;
+                    self.tcp.defer_untracked_connection(
+                        listener_id,
+                        Instant::now() + PENDING_CONNECT_DISCARD_LIFETIME,
+                    );
                     let _ = response.send(());
                 }
                 ReactorCommand::Stop { response } => {
@@ -2024,6 +2226,8 @@ impl Reactor {
                 kind,
                 readiness,
                 snapshot,
+                connection_status: SocketConnectionStatus::Unconnected,
+                untracked_guest_listener_id: None,
                 read_shutdown: false,
                 write_shutdown: false,
                 peek_waitall_threshold: None,
@@ -2153,25 +2357,30 @@ impl Reactor {
             return Err(BrokerError::ResourceExhausted);
         }
         apply_tcp_options(&socket, listener_tcp_no_delay, listener_tcp_keep_alive)?;
-        let listener = self
-            .sockets
-            .get_mut(&listener_id)
-            .ok_or(BrokerError::Internal)?;
-        let no_wait = Timespec {
-            tv_sec: 0,
-            tv_nsec: 0,
-        };
-        loop {
-            let mut poll_fd = [PollFd::new(&listener.socket, PollFlags::IN)];
-            match poll(&mut poll_fd, Some(&no_wait)) {
-                Ok(_) if poll_fd[0].revents().contains(PollFlags::IN) => break,
-                Ok(_) => {
-                    clear_readiness(listener, ReadinessFlags::READ)?;
-                    break;
+        let backlog_empty = {
+            let listener = self
+                .sockets
+                .get_mut(&listener_id)
+                .ok_or(BrokerError::Internal)?;
+            let no_wait = Timespec {
+                tv_sec: 0,
+                tv_nsec: 0,
+            };
+            loop {
+                let mut poll_fd = [PollFd::new(&listener.socket, PollFlags::IN)];
+                match poll(&mut poll_fd, Some(&no_wait)) {
+                    Ok(_) if poll_fd[0].revents().contains(PollFlags::IN) => break false,
+                    Ok(_) => {
+                        clear_readiness(listener, ReadinessFlags::READ)?;
+                        break true;
+                    }
+                    Err(Errno::INTR) => {}
+                    Err(error) => return Err(broker_error_from_errno(error)),
                 }
-                Err(Errno::INTR) => {}
-                Err(error) => return Err(broker_error_from_errno(error)),
             }
+        };
+        if backlog_empty {
+            self.tcp.finish_listener_backlog_drain(listener_id)?;
         }
         epoll::add(
             &self.epoll,
@@ -2200,6 +2409,8 @@ impl Reactor {
                 kind: SocketKind::Tcp,
                 readiness,
                 snapshot,
+                connection_status: SocketConnectionStatus::Connected,
+                untracked_guest_listener_id: None,
                 read_shutdown: false,
                 write_shutdown: false,
                 peek_waitall_threshold: None,
@@ -2226,7 +2437,8 @@ impl Reactor {
     }
 
     fn fail_all_sockets(&mut self) {
-        for socket in self.sockets.values() {
+        for socket in self.sockets.values_mut() {
+            socket.connection_status = SocketConnectionStatus::Failed(SocketError::Other);
             let mut snapshot = socket
                 .snapshot
                 .lock()
@@ -2252,6 +2464,7 @@ fn connect_tcp_socket(
     id: u64,
     socket: &mut SocketEntry,
     address: SocketAddrV4,
+    guest_listener_id: Option<u64>,
 ) -> core::result::Result<(SocketConnectionStatus, ReadinessFlags), PlatformConnectError> {
     if let Err(error) = epoll::modify(
         epoll_fd,
@@ -2263,6 +2476,14 @@ fn connect_tcp_socket(
             broker_error_from_errno(error),
         ));
     }
+    if socket.connection_status != SocketConnectionStatus::Unconnected {
+        return Err(PlatformConnectError::PeerUnchanged(BrokerError::Internal));
+    }
+    // Record the first half of the native transition before connect(2). Any
+    // later failure can then be settled or conservatively retired without
+    // reconstructing whether a SYN may have reached a guest listener.
+    socket.connection_status = SocketConnectionStatus::Connecting;
+    socket.untracked_guest_listener_id = guest_listener_id;
     let status = loop {
         match connect(&socket.socket, &address) {
             Ok(()) | Err(Errno::ISCONN) => break SocketConnectionStatus::Connected,
@@ -2274,6 +2495,8 @@ fn connect_tcp_socket(
                 let error = match socket_operation_error_from_errno(error) {
                     Ok(error) => error,
                     Err(error) => {
+                        socket.connection_status =
+                            SocketConnectionStatus::Failed(SocketError::Other);
                         update_snapshot(
                             socket,
                             Some(SocketConnectionStatus::Failed(SocketError::Other)),
@@ -2287,6 +2510,10 @@ fn connect_tcp_socket(
             }
         }
     };
+    socket.connection_status = status;
+    if matches!(status, SocketConnectionStatus::Failed(_)) {
+        socket.untracked_guest_listener_id = None;
+    }
     let readiness = match status {
         SocketConnectionStatus::Connected | SocketConnectionStatus::Connecting => {
             if socket.guest_local_address.is_none() {
@@ -2335,6 +2562,7 @@ fn connect_datagram_socket(
                 } else {
                     readiness | ReadinessFlags::WRITE
                 };
+                socket.connection_status = SocketConnectionStatus::Connected;
                 update_snapshot(socket, Some(SocketConnectionStatus::Connected), readiness)
                     .map_err(PlatformConnectError::PeerIndeterminate)?;
                 return Ok(SocketConnectionStatus::Connected);
@@ -2431,7 +2659,12 @@ fn send_socket(socket: &mut SocketEntry, data: &[u8]) -> BrokerResult<SocketOutc
     }
     loop {
         match send(&socket.socket, data, LinuxSendFlags::NOSIGNAL) {
-            Ok(sent) => return Ok(SocketOutcome::Completed(sent)),
+            Ok(sent) => {
+                if sent != 0 {
+                    confirm_tcp_connected(socket)?;
+                }
+                return Ok(SocketOutcome::Completed(sent));
+            }
             Err(Errno::INTR) => {}
             Err(Errno::AGAIN) => {
                 clear_readiness(socket, ReadinessFlags::WRITE)?;
@@ -2439,6 +2672,7 @@ fn send_socket(socket: &mut SocketEntry, data: &[u8]) -> BrokerResult<SocketOutc
             }
             Err(error) => {
                 let error = socket_operation_error_from_errno(error)?;
+                fail_connect(socket, error)?;
                 consume_synchronous_error(socket)?;
                 return Ok(SocketOutcome::Failed(error));
             }
@@ -2534,7 +2768,7 @@ fn receive_socket(
         let terminal = socket.read_shutdown
             || snapshot.readiness.contains(ReadinessFlags::HANGUP)
             || snapshot.readiness.contains(ReadinessFlags::ERROR);
-        if snapshot.status == SocketConnectionStatus::Connected
+        if socket.connection_status == SocketConnectionStatus::Connected
             && !terminal
             && ioctl_fionread(&socket.socket).map_err(broker_error_from_errno)?
                 < peek_length.try_into().map_err(|_| BrokerError::Internal)?
@@ -2663,6 +2897,7 @@ fn receive_socket_once(
     loop {
         match recv(&socket.socket, data.as_mut_slice(), flags) {
             Ok((_buffer, 0)) => {
+                confirm_tcp_connected(socket)?;
                 let readiness = if socket.read_shutdown {
                     ReadinessFlags::READ
                 } else {
@@ -2672,6 +2907,7 @@ fn receive_socket_once(
                 return Ok(ReactorReceiveOutcome::EndOfStream);
             }
             Ok((_buffer, received)) => {
+                confirm_tcp_connected(socket)?;
                 data.truncate(received);
                 let terminal_readable = socket.read_shutdown
                     || socket
@@ -2695,6 +2931,7 @@ fn receive_socket_once(
             }
             Err(error) => {
                 let error = socket_operation_error_from_errno(error)?;
+                fail_connect(socket, error)?;
                 consume_synchronous_error(socket)?;
                 return Ok(ReactorReceiveOutcome::Failed(error));
             }
@@ -2803,10 +3040,12 @@ fn shutdown_socket(
             // though it reports ENOTCONN.
             Err(Errno::NOTCONN) if socket.kind == SocketKind::Udp => {}
             Err(Errno::NOTCONN) => {
+                fail_connect(socket, SocketError::NotConnected)?;
                 return Ok(SocketOutcome::Failed(SocketError::NotConnected));
             }
             Err(error) => {
                 let error = socket_operation_error_from_errno(error)?;
+                fail_connect(socket, error)?;
                 return Ok(SocketOutcome::Failed(error));
             }
         }
@@ -2814,6 +3053,7 @@ fn shutdown_socket(
             socket.listening = false;
             socket.read_shutdown = true;
             socket.peek_waitall_threshold = None;
+            socket.connection_status = SocketConnectionStatus::Failed(SocketError::NotConnected);
             // The native transition is complete and the cached terminal
             // snapshot is authoritative even if its notification cannot be
             // published. Acknowledge completion so core listener state cannot
@@ -2869,12 +3109,7 @@ fn handle_socket_event(socket: &mut SocketEntry, events: epoll::EventFlags) -> B
     } else {
         false
     };
-    let status = socket
-        .snapshot
-        .lock()
-        .expect("Linux socket snapshot mutex poisoned")
-        .status;
-    let failed_connector = match status {
+    let failed_connector = match socket.connection_status {
         SocketConnectionStatus::Unconnected => false,
         SocketConnectionStatus::Connecting => {
             matches!(
@@ -2911,12 +3146,11 @@ fn complete_connect(
     socket: &mut SocketEntry,
     events: epoll::EventFlags,
 ) -> BrokerResult<SocketConnectionStatus> {
+    // Epoll re-polls the descriptor when waiting, so OUT here reflects the
+    // current post-connect state rather than readiness cached before connect.
     let status = match sockopt::socket_error(&socket.socket) {
-        Ok(Ok(())) => match getpeername(&socket.socket) {
-            Ok(Some(_)) => SocketConnectionStatus::Connected,
-            Ok(None) | Err(Errno::NOTCONN) => SocketConnectionStatus::Connecting,
-            Err(error) => SocketConnectionStatus::Failed(socket_error_from_errno(error)),
-        },
+        Ok(Ok(())) if events.contains(epoll::EventFlags::OUT) => SocketConnectionStatus::Connected,
+        Ok(Ok(())) => SocketConnectionStatus::Connecting,
         Ok(Err(error)) | Err(error) => {
             SocketConnectionStatus::Failed(socket_error_from_errno(error))
         }
@@ -2929,6 +3163,7 @@ fn complete_connect(
         SocketConnectionStatus::Failed(_) => ReadinessFlags::ERROR,
         _ => return Err(BrokerError::Internal),
     };
+    socket.connection_status = status;
     update_snapshot(socket, Some(status), readiness)?;
     Ok(status)
 }
@@ -2973,7 +3208,8 @@ fn status_socket(socket: &mut SocketEntry) -> BrokerResult<SocketStatusResponse>
             .snapshot
             .lock()
             .expect("Linux socket snapshot mutex poisoned");
-        (snapshot.status == SocketConnectionStatus::Connected || socket.kind == SocketKind::Udp)
+        (socket.connection_status == SocketConnectionStatus::Connected
+            || socket.kind == SocketKind::Udp)
             && snapshot.readiness.contains(ReadinessFlags::ERROR)
     };
     let socket_error = if query_socket_error {
@@ -2994,7 +3230,7 @@ fn status_socket(socket: &mut SocketEntry) -> BrokerResult<SocketStatusResponse>
         }
         (
             SocketStatusResponse {
-                status: snapshot.status,
+                status: socket.connection_status,
                 local_address: snapshot.local_address,
                 pending_error,
             },
@@ -3082,6 +3318,7 @@ fn update_snapshot(
             .lock()
             .expect("Linux socket snapshot mutex poisoned");
         if let Some(status) = status {
+            debug_assert_eq!(socket.connection_status, status);
             snapshot.status = status;
         }
         let changed = snapshot.readiness != readiness;
@@ -3092,6 +3329,46 @@ fn update_snapshot(
         socket.readiness.publish(readiness)?;
     }
     Ok(())
+}
+
+fn confirm_tcp_connected(socket: &mut SocketEntry) -> BrokerResult<()> {
+    if socket.kind != SocketKind::Tcp
+        || socket.connection_status != SocketConnectionStatus::Connecting
+    {
+        return Ok(());
+    }
+    socket.connection_status = SocketConnectionStatus::Connected;
+    let readiness = socket
+        .snapshot
+        .lock()
+        .expect("Linux socket snapshot mutex poisoned")
+        .readiness;
+    update_snapshot(socket, Some(SocketConnectionStatus::Connected), readiness)
+}
+
+/// Records a terminal native operation while a connect is pending.
+///
+/// A reactor command that can call this helper must subsequently invoke
+/// `Reactor::discard_failed_connect_after_command` after releasing its socket
+/// table borrow.
+fn fail_connect(socket: &mut SocketEntry, error: SocketError) -> BrokerResult<()> {
+    if socket.kind != SocketKind::Tcp
+        || socket.connection_status != SocketConnectionStatus::Connecting
+    {
+        return Ok(());
+    }
+    socket.connection_status = SocketConnectionStatus::Failed(error);
+    let readiness = socket
+        .snapshot
+        .lock()
+        .expect("Linux socket snapshot mutex poisoned")
+        .readiness
+        | ReadinessFlags::ERROR;
+    update_snapshot(
+        socket,
+        Some(SocketConnectionStatus::Failed(error)),
+        readiness,
+    )
 }
 
 fn add_readiness(socket: &SocketEntry, readiness: ReadinessFlags) -> BrokerResult<()> {
@@ -3118,7 +3395,7 @@ fn consume_synchronous_error(socket: &SocketEntry) -> BrokerResult<()> {
             .snapshot
             .lock()
             .expect("Linux socket snapshot mutex poisoned");
-        if !can_consume_synchronous_error(socket.kind, snapshot.status) {
+        if !can_consume_synchronous_error(socket.kind, socket.connection_status) {
             return Ok(());
         }
         snapshot.pending_error.is_none()
@@ -3212,7 +3489,7 @@ mod tests {
     use litebox_broker_protocol::ObjectHandle;
     use litebox_broker_protocol::socket::{Ipv4Address, Port, ReceiveSocketResponse};
 
-    const TEST_TIMEOUT: Duration = Duration::from_secs(10);
+    const TEST_TIMEOUT: Duration = Duration::from_secs(30);
 
     #[derive(Clone, Copy, Debug, PartialEq, Eq)]
     struct ReceivedPlatformDatagram {
@@ -3389,6 +3666,7 @@ mod tests {
                     guest_address: guest,
                     listener_id: 1,
                     discard_on_accept: false,
+                    discard_until_deadline: false,
                     discard_deadline: None,
                     retained_connector: None,
                 },
@@ -3403,6 +3681,7 @@ mod tests {
                     guest_address: SocketAddrV4::new(Ipv4Addr::LOCALHOST, 1002),
                     listener_id: 1,
                     discard_on_accept: false,
+                    discard_until_deadline: false,
                     discard_deadline: None,
                     retained_connector: None,
                 },
@@ -3411,18 +3690,96 @@ mod tests {
         );
 
         assert_eq!(
-            tcp.take_pending_guest_connection(remote_address, second_listener)
+            match tcp
+                .take_pending_guest_connection(remote_address, second_listener)
                 .unwrap()
-                .guest_address,
+            {
+                PendingGuestConnectionMatch::Take(connection) => connection.guest_address,
+                PendingGuestConnectionMatch::PersistentDiscard => {
+                    panic!("deliverable connection became a discard marker")
+                }
+            },
             second_guest
         );
         assert_eq!(
-            tcp.take_pending_guest_connection(remote_address, first_listener)
+            match tcp
+                .take_pending_guest_connection(remote_address, first_listener)
                 .unwrap()
-                .guest_address,
+            {
+                PendingGuestConnectionMatch::Take(connection) => connection.guest_address,
+                PendingGuestConnectionMatch::PersistentDiscard => {
+                    panic!("deliverable connection became a discard marker")
+                }
+            },
             first_guest
         );
         assert!(tcp.pending_guest_connections.is_empty());
+    }
+
+    #[test]
+    fn tuple_collision_persists_its_discard_marker() {
+        let guest_address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 5000);
+        let remote_address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 40000);
+        let host_address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 41000);
+        let connection = (remote_address, host_address);
+        let deadline = Instant::now() + PENDING_CONNECT_DISCARD_LIFETIME;
+        let mut tcp = ReactorTcpState::default();
+        tcp.insert_binding(ReactorTcpBinding {
+            socket_id: 1,
+            guest_address,
+            host_address: Some(host_address),
+            listening: true,
+            requires_backlog_drain: false,
+            untracked_connection_deadline: None,
+        })
+        .unwrap();
+        assert!(!tcp.persist_discard_marker_for_collision(connection, 1, deadline));
+        tcp.insert_pending_guest_connection(
+            connection,
+            PendingGuestTcpConnection {
+                session_id: SessionId(7),
+                guest_address,
+                listener_id: 1,
+                discard_on_accept: false,
+                discard_until_deadline: false,
+                discard_deadline: Some(Instant::now()),
+                retained_connector: None,
+            },
+        )
+        .unwrap();
+        assert!(!tcp.persist_discard_marker_for_collision(connection, 1, deadline));
+        tcp.pending_guest_connections
+            .get_mut(&connection)
+            .unwrap()
+            .discard_on_accept = true;
+
+        assert!(tcp.persist_discard_marker_for_collision(connection, 1, deadline));
+        let marker = tcp.pending_guest_connections.get(&connection).unwrap();
+        assert!(marker.discard_until_deadline);
+        assert_eq!(marker.discard_deadline, Some(deadline));
+        assert!(
+            !tcp.bindings
+                .get(&guest_address.port())
+                .unwrap()
+                .requires_backlog_drain
+        );
+        assert!(matches!(
+            tcp.take_pending_guest_connection(remote_address, host_address),
+            Some(PendingGuestConnectionMatch::PersistentDiscard)
+        ));
+        assert!(tcp.pending_guest_connections.contains_key(&connection));
+    }
+
+    #[test]
+    fn listener_backlog_probe_distinguishes_empty_and_queued_children() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let address = listener.local_addr().unwrap();
+        let listener: OwnedFd = listener.into();
+        assert!(!socket_backlog_is_nonempty(&listener));
+
+        let _connector = TcpStream::connect(address).unwrap();
+        assert!(socket_backlog_is_nonempty(&listener));
     }
 
     struct TestReadinessSink {
@@ -3483,6 +3840,108 @@ mod tests {
         fn retire(&self, handle: ObjectHandle) {
             self.inner.retire(handle);
         }
+    }
+
+    #[test]
+    fn untracked_guest_connection_cleanup_is_bounded_and_drains_backlog() {
+        let provider = Arc::new(LinuxSocketProvider::new(6, 3).unwrap());
+        let broker = BrokerCore::new_with_limits(
+            PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
+                .with_socket_policy(SocketPolicy::Ipv4Loopback),
+            BrokerCoreLimits::new_with_all_limits(12, 0, 6, 6),
+            provider.clone(),
+        )
+        .unwrap();
+        let listener_session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let connector_session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let (published, publications) = channel();
+        let (retired, retirements) = channel();
+        let readiness = Arc::new(TestReadinessSink { published, retired });
+        let guest_address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8090);
+        let listener = create_socket(&listener_session, readiness.clone());
+        assert_eq!(
+            litebox_broker_core::socket::bind(&listener_session, listener, guest_address),
+            Ok(SocketOutcome::Completed(guest_address))
+        );
+        assert_eq!(
+            litebox_broker_core::socket::listen(&listener_session, listener, 4),
+            Ok(SocketOutcome::Completed(guest_address))
+        );
+
+        provider
+            .reactor
+            .defer_untracked_guest_connection(guest_address.port());
+        let blocked = create_socket(&connector_session, readiness.clone());
+        assert_eq!(
+            litebox_broker_core::socket::connect(&connector_session, blocked, guest_address),
+            Ok(SocketOutcome::Completed(SocketConnectionStatus::Failed(
+                SocketError::ConnectionRefused
+            )))
+        );
+        connector_session.close_object_reference(blocked).unwrap();
+        assert_eq!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), blocked);
+
+        provider.reactor.expire_pending_guest_connections();
+        let connector = create_socket(&connector_session, readiness.clone());
+        assert!(matches!(
+            litebox_broker_core::socket::connect(&connector_session, connector, guest_address),
+            Ok(SocketOutcome::Completed(
+                SocketConnectionStatus::Connecting | SocketConnectionStatus::Connected
+            ))
+        ));
+        wait_until_connected(&connector_session, connector, &publications);
+        wait_for_readiness(&publications, listener, ReadinessFlags::READ);
+        let accepted = match litebox_broker_core::socket::accept(
+            &listener_session,
+            listener,
+            readiness.clone(),
+        )
+        .unwrap()
+        {
+            SocketOutcome::Completed(accepted) => accepted.handle,
+            SocketOutcome::Failed(error) => panic!("guest accept failed: {error:?}"),
+        };
+        listener_session.close_object_reference(accepted).unwrap();
+        assert_eq!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), accepted);
+        connector_session.close_object_reference(connector).unwrap();
+        assert_eq!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), connector);
+
+        let private_address = provider.reactor.host_address(guest_address.port()).unwrap();
+        let _unmatched = TcpStream::connect(private_address).unwrap();
+        provider
+            .reactor
+            .defer_untracked_guest_connection(guest_address.port());
+        provider.reactor.expire_pending_guest_connections();
+
+        let gated = create_socket(&connector_session, readiness.clone());
+        assert_eq!(
+            litebox_broker_core::socket::connect(&connector_session, gated, guest_address),
+            Ok(SocketOutcome::Completed(SocketConnectionStatus::Failed(
+                SocketError::ConnectionRefused
+            )))
+        );
+        connector_session.close_object_reference(gated).unwrap();
+        assert_eq!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), gated);
+        assert!(matches!(
+            litebox_broker_core::socket::accept(&listener_session, listener, readiness.clone(),),
+            Err(BrokerError::WouldBlock)
+        ));
+
+        let final_connector = create_socket(&connector_session, readiness);
+        assert!(matches!(
+            litebox_broker_core::socket::connect(
+                &connector_session,
+                final_connector,
+                guest_address,
+            ),
+            Ok(SocketOutcome::Completed(
+                SocketConnectionStatus::Connecting | SocketConnectionStatus::Connected
+            ))
+        ));
     }
 
     #[test]
@@ -3863,6 +4322,122 @@ mod tests {
     }
 
     #[test]
+    fn external_tcp_close_with_unread_data_preserves_reset() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let (data_sent, wait_for_data) = channel();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            stream.set_read_timeout(Some(TEST_TIMEOUT)).unwrap();
+            stream.set_write_timeout(Some(TEST_TIMEOUT)).unwrap();
+            stream.write_all(b"unread").unwrap();
+            data_sent.send(()).unwrap();
+            let error = stream.read(&mut [0_u8; 1]).unwrap_err();
+            assert_eq!(error.kind(), std::io::ErrorKind::ConnectionReset);
+        });
+
+        let provider = Arc::new(LinuxSocketProvider::new(1, 1).unwrap());
+        let broker = BrokerCore::new_with_limits(
+            PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
+                .with_socket_policy(SocketPolicy::Ipv4Loopback),
+            BrokerCoreLimits::new_with_all_limits(2, 0, 1, 1),
+            provider,
+        )
+        .unwrap();
+        let session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let (published, publications) = channel();
+        let (retired, retirements) = channel();
+        let readiness = Arc::new(TestReadinessSink { published, retired });
+        let handle = create_socket(&session, readiness);
+        assert!(matches!(
+            litebox_broker_core::socket::connect(&session, handle, socket_address_v4(address),),
+            Ok(SocketOutcome::Completed(
+                SocketConnectionStatus::Connecting | SocketConnectionStatus::Connected
+            ))
+        ));
+        wait_until_connected(&session, handle, &publications);
+        wait_for_data.recv_timeout(TEST_TIMEOUT).unwrap();
+        session.close_object_reference(handle).unwrap();
+        assert_eq!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), handle);
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn accepted_guest_tcp_close_with_unread_data_preserves_reset() {
+        let provider = Arc::new(LinuxSocketProvider::new(3, 2).unwrap());
+        let broker = BrokerCore::new_with_limits(
+            PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
+                .with_socket_policy(SocketPolicy::Ipv4Loopback),
+            BrokerCoreLimits::new_with_all_limits(6, 0, 3, 3),
+            provider,
+        )
+        .unwrap();
+        let listener_session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let connector_session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let (published, publications) = channel();
+        let (retired, retirements) = channel();
+        let readiness = Arc::new(TestReadinessSink { published, retired });
+        let guest_address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8091);
+        let listener = create_socket(&listener_session, readiness.clone());
+        assert_eq!(
+            litebox_broker_core::socket::bind(&listener_session, listener, guest_address),
+            Ok(SocketOutcome::Completed(guest_address))
+        );
+        assert_eq!(
+            litebox_broker_core::socket::listen(&listener_session, listener, 1),
+            Ok(SocketOutcome::Completed(guest_address))
+        );
+
+        let connector = create_socket(&connector_session, readiness.clone());
+        assert!(matches!(
+            litebox_broker_core::socket::connect(&connector_session, connector, guest_address),
+            Ok(SocketOutcome::Completed(
+                SocketConnectionStatus::Connecting | SocketConnectionStatus::Connected
+            ))
+        ));
+        wait_until_connected(&connector_session, connector, &publications);
+        wait_for_readiness(&publications, listener, ReadinessFlags::READ);
+        let accepted =
+            match litebox_broker_core::socket::accept(&listener_session, listener, readiness)
+                .unwrap()
+            {
+                SocketOutcome::Completed(accepted) => accepted.handle,
+                SocketOutcome::Failed(error) => panic!("guest accept failed: {error:?}"),
+            };
+        assert_eq!(
+            send_bytes(&listener_session, accepted, b"unread", SendFlags::NONE,),
+            Ok(SocketOutcome::Completed(6))
+        );
+        wait_for_readiness(&publications, connector, ReadinessFlags::READ);
+
+        connector_session.close_object_reference(connector).unwrap();
+        assert_eq!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), connector);
+        wait_for_readiness(
+            &publications,
+            accepted,
+            ReadinessFlags::READ | ReadinessFlags::ERROR | ReadinessFlags::HANGUP,
+        );
+        let mut byte = [0_u8; 1];
+        assert_eq!(
+            receive_into(
+                &listener_session,
+                accepted,
+                &mut byte,
+                ReceiveFlags::NONE,
+                0,
+                0,
+            ),
+            Ok(SocketOutcome::Failed(SocketError::ConnectionReset))
+        );
+    }
+
+    #[test]
     fn reactor_assigns_a_port_to_an_unbound_tcp_listener() {
         let provider = Arc::new(LinuxSocketProvider::new(3, 3).unwrap());
         let broker = BrokerCore::new_with_limits(
@@ -4216,6 +4791,67 @@ mod tests {
         assert_eq!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), listener);
         assert_eq!(provider.reactor.pending_guest_connection_count(), 0);
         assert_eq!(provider.reactor.retained_connector_count(), 0);
+    }
+
+    #[test]
+    fn graceful_connector_close_preserves_late_accept_and_eof() {
+        let provider = Arc::new(LinuxSocketProvider::new(4, 2).unwrap());
+        let broker = BrokerCore::new_with_limits(
+            PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
+                .with_socket_policy(SocketPolicy::Ipv4Loopback),
+            BrokerCoreLimits::new_with_all_limits(8, 0, 4, 4),
+            provider.clone(),
+        )
+        .unwrap();
+        let listener_session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let connector_session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let (published, publications) = channel();
+        let (retired, retirements) = channel();
+        let readiness = Arc::new(TestReadinessSink { published, retired });
+        let guest_address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8089);
+        let listener = create_socket(&listener_session, readiness.clone());
+        assert_eq!(
+            litebox_broker_core::socket::bind(&listener_session, listener, guest_address),
+            Ok(SocketOutcome::Completed(guest_address))
+        );
+        assert_eq!(
+            litebox_broker_core::socket::listen(&listener_session, listener, 1),
+            Ok(SocketOutcome::Completed(guest_address))
+        );
+
+        let connector = create_socket(&connector_session, readiness.clone());
+        assert!(matches!(
+            litebox_broker_core::socket::connect(&connector_session, connector, guest_address,),
+            Ok(SocketOutcome::Completed(
+                SocketConnectionStatus::Connecting | SocketConnectionStatus::Connected
+            ))
+        ));
+        wait_until_connected(&connector_session, connector, &publications);
+        let connector_address = litebox_broker_core::socket::status(&connector_session, connector)
+            .unwrap()
+            .local_address
+            .unwrap();
+
+        connector_session.close_object_reference(connector).unwrap();
+        assert_eq!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), connector);
+        assert_eq!(provider.reactor.retained_connector_count(), 1);
+        wait_for_readiness(&publications, listener, ReadinessFlags::READ);
+
+        let accepted =
+            match litebox_broker_core::socket::accept(&listener_session, listener, readiness)
+                .unwrap()
+            {
+                SocketOutcome::Completed(accepted) => accepted,
+                SocketOutcome::Failed(error) => panic!("late accept failed: {error:?}"),
+            };
+        assert_eq!(accepted.remote_address, connector_address);
+        assert_eq!(provider.reactor.pending_guest_connection_count(), 0);
+        assert_eq!(provider.reactor.retained_connector_count(), 0);
+        wait_for_end_of_stream(&listener_session, accepted.handle, &publications);
     }
 
     #[test]

--- a/litebox_broker_platform_linux_userland/src/socket.rs
+++ b/litebox_broker_platform_linux_userland/src/socket.rs
@@ -2117,8 +2117,18 @@ impl Reactor {
             drop(socket);
             unmatched_accept_count += 1;
             if unmatched_accept_count >= MAX_UNMATCHED_ACCEPTS_PER_COMMAND {
-                // Keep cached READ readiness: edge-triggered epoll will not
-                // report connections that remain queued on the listener.
+                let listener = self
+                    .sockets
+                    .get(&listener_id)
+                    .ok_or(BrokerError::Internal)?;
+                let readiness = listener
+                    .snapshot
+                    .lock()
+                    .expect("Linux socket snapshot mutex poisoned")
+                    .readiness;
+                // Edge-triggered epoll will not report connections that remain
+                // queued, so wake a blocking accept waiter to continue draining.
+                listener.readiness.republish(readiness)?;
                 return Err(BrokerError::WouldBlock);
             }
         };
@@ -2804,11 +2814,15 @@ fn shutdown_socket(
             socket.listening = false;
             socket.read_shutdown = true;
             socket.peek_waitall_threshold = None;
-            update_snapshot(
+            // The native transition is complete and the cached terminal
+            // snapshot is authoritative even if its notification cannot be
+            // published. Acknowledge completion so core listener state cannot
+            // diverge from the platform.
+            let _ = update_snapshot(
                 socket,
                 Some(SocketConnectionStatus::Failed(SocketError::NotConnected)),
                 ReadinessFlags::WRITE | ReadinessFlags::HANGUP,
-            )?;
+            );
             return Ok(SocketOutcome::Completed(()));
         }
         socket.read_shutdown |= shuts_down_read;
@@ -4324,16 +4338,17 @@ mod tests {
             litebox_broker_core::socket::bind(&listener_session, listener, guest_address),
             Ok(SocketOutcome::Completed(guest_address))
         );
+        let unmatched_connection_count = MAX_UNMATCHED_ACCEPTS_PER_COMMAND;
         assert_eq!(
             litebox_broker_core::socket::listen(
                 &listener_session,
                 listener,
-                u32::try_from(MAX_UNMATCHED_ACCEPTS_PER_COMMAND + 2).unwrap(),
+                u32::try_from(unmatched_connection_count + 2).unwrap(),
             ),
             Ok(SocketOutcome::Completed(guest_address))
         );
         let private_address = provider.reactor.host_address(guest_address.port()).unwrap();
-        let _unmatched_connections = (0..MAX_UNMATCHED_ACCEPTS_PER_COMMAND)
+        let _unmatched_connections = (0..unmatched_connection_count)
             .map(|_| TcpStream::connect(private_address).unwrap())
             .collect::<Vec<_>>();
 
@@ -4361,6 +4376,7 @@ mod tests {
                 .unwrap()
                 .contains(ReadinessFlags::READ)
         );
+        wait_for_readiness(&publications, listener, ReadinessFlags::READ);
         let accepted =
             match litebox_broker_core::socket::accept(&listener_session, listener, readiness)
                 .unwrap()
@@ -4597,10 +4613,14 @@ mod tests {
                 listener,
                 ShutdownMode::StopListening,
             ),
-            Err(BrokerError::ResourceExhausted)
+            Ok(SocketOutcome::Completed(()))
         );
         assert_eq!(provider.reactor.pending_guest_connection_count(), 0);
         assert_eq!(provider.reactor.retained_connector_count(), 0);
+        assert_eq!(
+            litebox_broker_core::socket::listen(&listener_session, listener, 1),
+            Ok(SocketOutcome::Failed(SocketError::InvalidArgument))
+        );
 
         listener_session.close_object_reference(listener).unwrap();
         assert_eq!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), listener);

--- a/litebox_broker_platform_linux_userland/src/socket.rs
+++ b/litebox_broker_platform_linux_userland/src/socket.rs
@@ -438,7 +438,7 @@ impl ReactorClient {
                     sessions: HashMap::new(),
                     max_sockets,
                     max_sockets_per_session,
-                    retained_connectors: 0,
+                    retained_connector_count: 0,
                     peek_cache: None,
                     events,
                 };
@@ -793,7 +793,7 @@ struct Reactor {
     sessions: HashMap<SessionId, ReactorSessionState>,
     max_sockets: usize,
     max_sockets_per_session: usize,
-    retained_connectors: usize,
+    retained_connector_count: usize,
     peek_cache: Option<PeekCache>,
     events: Vec<epoll::Event>,
 }
@@ -837,7 +837,7 @@ struct ReactorTcpState {
 struct ReactorSessionState {
     live_sockets: usize,
     pending_guest_connections: usize,
-    retained_connectors: usize,
+    retained_connector_count: usize,
     closing: bool,
 }
 
@@ -940,7 +940,7 @@ fn retain_session_state(state: &ReactorSessionState) -> bool {
     !state.closing
         || state.live_sockets != 0
         || state.pending_guest_connections != 0
-        || state.retained_connectors != 0
+        || state.retained_connector_count != 0
 }
 
 /// Cached connection and readiness state shared with the broker-facing handle.
@@ -1014,12 +1014,12 @@ impl Reactor {
             .checked_sub(1)
             .expect("session pending guest connection count underflow");
         if connection.retained_connector.is_some() {
-            self.retained_connectors = self
-                .retained_connectors
+            self.retained_connector_count = self
+                .retained_connector_count
                 .checked_sub(1)
                 .expect("reactor retained connector count underflow");
-            session.retained_connectors = session
-                .retained_connectors
+            session.retained_connector_count = session
+                .retained_connector_count
                 .checked_sub(1)
                 .expect("session retained connector count underflow");
         }
@@ -1080,7 +1080,7 @@ impl Reactor {
         let Reactor {
             tcp,
             sessions,
-            retained_connectors,
+            retained_connector_count,
             ..
         } = self;
         tcp.pending_guest_connections.retain(|_, connection| {
@@ -1094,11 +1094,11 @@ impl Reactor {
                     .checked_sub(1)
                     .expect("session pending guest connection count underflow");
                 if connection.retained_connector.is_some() {
-                    session.retained_connectors = session
-                        .retained_connectors
+                    session.retained_connector_count = session
+                        .retained_connector_count
                         .checked_sub(1)
                         .expect("session retained connector count underflow");
-                    *retained_connectors = retained_connectors
+                    *retained_connector_count = retained_connector_count
                         .checked_sub(1)
                         .expect("reactor retained connector count underflow");
                 }
@@ -1125,13 +1125,13 @@ impl Reactor {
                 released += 1;
             }
         }
-        self.retained_connectors = self
-            .retained_connectors
+        self.retained_connector_count = self
+            .retained_connector_count
             .checked_sub(released)
             .expect("reactor retained connector count underflow");
         if let Some(session) = self.sessions.get_mut(&session_id) {
-            session.retained_connectors = session
-                .retained_connectors
+            session.retained_connector_count = session
+                .retained_connector_count
                 .checked_sub(released)
                 .expect("session retained connector count underflow");
         }
@@ -1149,7 +1149,7 @@ impl Reactor {
         let Reactor {
             tcp,
             sessions,
-            retained_connectors,
+            retained_connector_count,
             ..
         } = self;
         tcp.pending_guest_connections.retain(|_, connection| {
@@ -1166,11 +1166,11 @@ impl Reactor {
                     .checked_sub(1)
                     .expect("session pending guest connection count underflow");
                 if connection.retained_connector.is_some() {
-                    session.retained_connectors = session
-                        .retained_connectors
+                    session.retained_connector_count = session
+                        .retained_connector_count
                         .checked_sub(1)
                         .expect("session retained connector count underflow");
-                    *retained_connectors = retained_connectors
+                    *retained_connector_count = retained_connector_count
                         .checked_sub(1)
                         .expect("reactor retained connector count underflow");
                 }
@@ -1208,7 +1208,7 @@ impl Reactor {
         let global_at_limit = self
             .sockets
             .len()
-            .checked_add(self.retained_connectors)
+            .checked_add(self.retained_connector_count)
             .is_none_or(|count| count >= self.max_sockets);
         let listener_session = self
             .sessions
@@ -1216,7 +1216,7 @@ impl Reactor {
             .ok_or(BrokerError::Internal)?;
         let session_at_limit = listener_session
             .live_sockets
-            .checked_add(listener_session.retained_connectors)
+            .checked_add(listener_session.retained_connector_count)
             .is_none_or(|count| count >= self.max_sockets_per_session);
         if !global_at_limit && !session_at_limit {
             return Ok(true);
@@ -1521,16 +1521,16 @@ impl Reactor {
             };
             if pending.discard_deadline.is_none() {
                 pending.retained_connector = socket.take();
-                self.retained_connectors = self
-                    .retained_connectors
+                self.retained_connector_count = self
+                    .retained_connector_count
                     .checked_add(1)
                     .expect("reactor retained connector count overflow");
                 let session = self
                     .sessions
                     .get_mut(&session_id)
                     .expect("socket session state missing");
-                session.retained_connectors = session
-                    .retained_connectors
+                session.retained_connector_count = session
+                    .retained_connector_count
                     .checked_add(1)
                     .expect("session retained connector count overflow");
             }
@@ -1864,7 +1864,7 @@ impl Reactor {
                 }
                 #[cfg(test)]
                 ReactorCommand::RetainedConnectorCount { response } => {
-                    let _ = response.send(self.retained_connectors);
+                    let _ = response.send(self.retained_connector_count);
                 }
                 #[cfg(test)]
                 ReactorCommand::ExpireDeadlinedState { now, response } => {
@@ -1876,7 +1876,7 @@ impl Reactor {
                     self.tcp.bindings.clear();
                     self.tcp.pending_guest_connections.clear();
                     self.sessions.clear();
-                    self.retained_connectors = 0;
+                    self.retained_connector_count = 0;
                     let _ = response.send(());
                     return true;
                 }
@@ -1897,7 +1897,7 @@ impl Reactor {
         if self
             .sockets
             .len()
-            .checked_add(self.retained_connectors)
+            .checked_add(self.retained_connector_count)
             .is_none_or(|count| count >= self.max_sockets)
         {
             return Err(BrokerError::ResourceExhausted);
@@ -1917,7 +1917,7 @@ impl Reactor {
         }
         if session
             .live_sockets
-            .checked_add(session.retained_connectors)
+            .checked_add(session.retained_connector_count)
             .is_none_or(|count| count >= self.max_sockets_per_session)
         {
             return Err(BrokerError::ResourceExhausted);
@@ -2059,7 +2059,7 @@ impl Reactor {
         if self
             .sockets
             .len()
-            .checked_add(self.retained_connectors)
+            .checked_add(self.retained_connector_count)
             .is_none_or(|count| count >= self.max_sockets)
             || self
                 .sessions
@@ -2070,7 +2070,7 @@ impl Reactor {
                     self.sessions
                         .get(&listener_session_id)
                         .ok_or(BrokerError::Internal)?
-                        .retained_connectors,
+                        .retained_connector_count,
                 )
                 .is_none_or(|count| count >= self.max_sockets_per_session)
         {
@@ -2166,7 +2166,7 @@ impl Reactor {
         self.tcp.bindings.clear();
         self.tcp.pending_guest_connections.clear();
         self.sessions.clear();
-        self.retained_connectors = 0;
+        self.retained_connector_count = 0;
     }
 }
 

--- a/litebox_broker_userland/src/linux.rs
+++ b/litebox_broker_userland/src/linux.rs
@@ -54,7 +54,10 @@ pub(super) fn run(args: super::CliArgs) -> Result<(), Box<dyn Error>> {
         PolicyEngine::with_host_guaranteed_rights(ObjectRights::all())
             .with_socket_policy(configured_socket_policy(&args.allow_tcp_destination)?),
         limits,
-        Arc::new(LinuxSocketProvider::new(limits.max_sockets)?),
+        Arc::new(LinuxSocketProvider::new(
+            limits.max_sockets,
+            limits.max_sockets_per_session,
+        )?),
     )?;
 
     crate::run_runner_process(

--- a/litebox_runner_linux_userland/tests/run.rs
+++ b/litebox_runner_linux_userland/tests/run.rs
@@ -359,6 +359,7 @@ fn spawn_test_broker(
                 std::sync::Arc::new(
                     litebox_broker_platform_linux_userland::LinuxSocketProvider::new(
                         limits.max_sockets,
+                        limits.max_sockets_per_session,
                     )
                     .expect("failed to create broker test socket provider"),
                 ),
@@ -731,8 +732,7 @@ fn test_runner_broker_udp_with_rewriter() {
 #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
 #[test]
 fn test_runner_broker_tcp_server_with_rewriter() {
-    use std::io::{BufRead as _, BufReader, Read as _, Write as _};
-    use std::net::{Ipv4Addr, TcpStream};
+    use std::io::{BufRead as _, BufReader};
     use std::process::Stdio;
 
     let target = common::compile(
@@ -782,26 +782,24 @@ fn test_runner_broker_tcp_server_with_rewriter() {
         };
 
     let listen = next_marker("LISTEN ");
-    let port = listen.split_whitespace().nth(1).unwrap().parse().unwrap();
-    let mut first = TcpStream::connect((Ipv4Addr::LOCALHOST, port)).unwrap();
-    first.set_read_timeout(Some(BROKER_HELPER_TIMEOUT)).unwrap();
-    first
-        .set_write_timeout(Some(BROKER_HELPER_TIMEOUT))
-        .unwrap();
-    let first_port = first.local_addr().unwrap().port();
-    first.write_all(&[0x31]).unwrap();
-    let mut response = [0];
-    first.read_exact(&mut response).unwrap();
-    assert_eq!(response, [0x41]);
+    assert_ne!(
+        listen
+            .split_whitespace()
+            .nth(1)
+            .unwrap()
+            .parse::<u16>()
+            .unwrap(),
+        0
+    );
     let first_marker = next_marker("FIRST ");
-    assert_eq!(
+    assert_ne!(
         first_marker
             .split_whitespace()
             .nth(1)
             .unwrap()
             .parse::<u16>()
             .unwrap(),
-        first_port
+        0
     );
 
     assert_eq!(next_marker("BLOCKING"), "BLOCKING");
@@ -809,26 +807,15 @@ fn test_runner_broker_tcp_server_with_rewriter() {
         child.try_wait().unwrap().is_none(),
         "blocking accept returned before a client connected"
     );
-    let mut second = TcpStream::connect((Ipv4Addr::LOCALHOST, port)).unwrap();
-    second
-        .set_read_timeout(Some(BROKER_HELPER_TIMEOUT))
-        .unwrap();
-    second
-        .set_write_timeout(Some(BROKER_HELPER_TIMEOUT))
-        .unwrap();
-    let second_port = second.local_addr().unwrap().port();
-    second.write_all(&[0x32]).unwrap();
-    second.read_exact(&mut response).unwrap();
-    assert_eq!(response, [0x42]);
     let second_marker = next_marker("SECOND ");
-    assert_eq!(
+    assert_ne!(
         second_marker
             .split_whitespace()
             .nth(1)
             .unwrap()
             .parse::<u16>()
             .unwrap(),
-        second_port
+        0
     );
 
     let deadline = std::time::Instant::now() + BROKER_HELPER_TIMEOUT;
@@ -848,7 +835,7 @@ fn test_runner_broker_tcp_server_with_rewriter() {
         status.success(),
         "broker TCP server guest failed with {status}; output:\n{output}"
     );
-    assert_eq!(broker.next_close_object_count(), 3);
+    assert_eq!(broker.next_close_object_count(), 5);
     broker.join();
 }
 

--- a/litebox_runner_linux_userland/tests/tcp_broker_server.c
+++ b/litebox_runner_linux_userland/tests/tcp_broker_server.c
@@ -50,11 +50,38 @@ struct blocking_accept {
     int error;
 };
 
+struct client_exchange {
+    struct sockaddr_in server;
+    struct sockaddr_in local;
+    unsigned char request;
+    unsigned char expected_response;
+};
+
 static void *blocking_accept_thread(void *argument) {
     struct blocking_accept *accept = argument;
     errno = 0;
     accept->result = accept4(accept->fd, NULL, NULL, 0);
     accept->error = errno;
+    return NULL;
+}
+
+static void *client_exchange_thread(void *argument) {
+    struct client_exchange *exchange = argument;
+    usleep(100 * 1000);
+
+    int fd = socket(AF_INET, SOCK_STREAM, 0);
+    assert(fd >= 0);
+    assert(connect(fd, (const struct sockaddr *)&exchange->server,
+                   sizeof(exchange->server)) == 0);
+    socklen_t length = sizeof(exchange->local);
+    assert(getsockname(fd, (struct sockaddr *)&exchange->local, &length) == 0);
+    assert(length == sizeof(exchange->local));
+    assert(write(fd, &exchange->request, sizeof(exchange->request)) ==
+           sizeof(exchange->request));
+    unsigned char response = 0;
+    assert(read(fd, &response, sizeof(response)) == sizeof(response));
+    assert(response == exchange->expected_response);
+    assert(close(fd) == 0);
     return NULL;
 }
 
@@ -82,6 +109,19 @@ int main(void) {
     assert(errno == EAGAIN);
     printf("LISTEN %u\n", (unsigned int)ntohs(local.sin_port));
 
+    int first_client = socket(AF_INET, SOCK_STREAM, 0);
+    assert(first_client >= 0);
+    assert(connect(first_client, (const struct sockaddr *)&local, sizeof(local)) ==
+           0);
+    struct sockaddr_in first_client_local;
+    length = sizeof(first_client_local);
+    assert(getsockname(first_client, (struct sockaddr *)&first_client_local,
+                       &length) == 0);
+    assert(length == sizeof(first_client_local));
+    unsigned char first_request = 0x31;
+    assert(write(first_client, &first_request, sizeof(first_request)) ==
+           sizeof(first_request));
+
     struct pollfd ready = {.fd = listener, .events = POLLIN};
     assert(poll(&ready, 1, 5000) == 1);
     assert((ready.revents & POLLIN) != 0);
@@ -95,6 +135,13 @@ int main(void) {
     assert((fcntl(first, F_GETFD) & FD_CLOEXEC) != 0);
     verify_endpoints(first, &local, &first_peer);
     exchange_byte(first, 0x31, 0x41);
+    unsigned char first_response = 0;
+    assert(read(first_client, &first_response, sizeof(first_response)) ==
+           sizeof(first_response));
+    assert(first_response == 0x41);
+    assert(first_peer.sin_addr.s_addr == first_client_local.sin_addr.s_addr);
+    assert(first_peer.sin_port == first_client_local.sin_port);
+    assert(close(first_client) == 0);
     printf("FIRST %u\n", (unsigned int)ntohs(first_peer.sin_port));
 
     int listener_flags = fcntl(listener, F_GETFL);
@@ -102,6 +149,14 @@ int main(void) {
     assert(fcntl(listener, F_SETFL, listener_flags & ~O_NONBLOCK) == 0);
     printf("BLOCKING\n");
 
+    struct client_exchange second_exchange = {
+        .server = local,
+        .request = 0x32,
+        .expected_response = 0x42,
+    };
+    pthread_t client_thread;
+    assert(pthread_create(&client_thread, NULL, client_exchange_thread,
+                          &second_exchange) == 0);
     struct sockaddr_in second_peer;
     length = sizeof(second_peer);
     int second =
@@ -112,6 +167,10 @@ int main(void) {
     assert((fcntl(second, F_GETFD) & FD_CLOEXEC) == 0);
     verify_endpoints(second, &local, &second_peer);
     exchange_byte(second, 0x32, 0x42);
+    assert(pthread_join(client_thread, NULL) == 0);
+    assert(second_peer.sin_addr.s_addr ==
+           second_exchange.local.sin_addr.s_addr);
+    assert(second_peer.sin_port == second_exchange.local.sin_port);
     printf("SECOND %u\n", (unsigned int)ntohs(second_peer.sin_port));
 
     struct blocking_accept accept = {


### PR DESCRIPTION
This PR gives all broker sessions one shared guest TCP namespace by moving guest TCP port reservation and ephemeral allocation into broker core and routing guest-to-guest connections through private Linux endpoints with guest-visible accept translation. It adds platform-owned TCP lifecycle tracking, bounded pending and stale-connection state, retained connector accounting, backlog-drain safeguards, and blocking-accept readiness coverage, and updates the Linux runner TCP server integration to use the shared namespace.