### PR TITLE
Stop mapping eventfd resource exhaustion to EAGAIN

### DIFF
--- a/litebox_common_linux/src/errno/mod.rs
+++ b/litebox_common_linux/src/errno/mod.rs
@@ -576,8 +576,12 @@ impl From<litebox::event::counter::EventCounterError> for Errno {
     fn from(value: litebox::event::counter::EventCounterError) -> Self {
         match value {
             litebox::event::counter::EventCounterError::InvalidInput => Errno::EINVAL,
-            litebox::event::counter::EventCounterError::WouldBlock
-            | litebox::event::counter::EventCounterError::ResourceExhausted => Errno::EAGAIN,
+            litebox::event::counter::EventCounterError::WouldBlock => Errno::EAGAIN,
+            // A resource limit or allocation failure is not retryable; EAGAIN
+            // would tell a caller to spin on `eventfd2`/read/write against a
+            // permanent condition. ENOMEM is the documented eventfd2 exhaustion
+            // errno and honestly covers the folded out-of-memory case.
+            litebox::event::counter::EventCounterError::ResourceExhausted => Errno::ENOMEM,
             litebox::event::counter::EventCounterError::PermissionDenied => Errno::EACCES,
             litebox::event::counter::EventCounterError::Io
             | litebox::event::counter::EventCounterError::Unavailable => Errno::EIO,


### PR DESCRIPTION
EventCounterError::ResourceExhausted mapped to EAGAIN, which tells a guest to retry eventfd operations against a permanent object-reference limit or allocation failure. In practice this arm is only reachable on eventfd2() creation, so it now maps to ENOMEM (eventfd2's documented exhaustion errno) while WouldBlock stays on EAGAIN, matching how the socket path already surfaces ResourceExhausted as ENOBUFS. If events ever gain an externally-backed readiness-sink path, the transient sink-full case should be split out rather than re-widening this arm, so a transient backpressure condition does not surface as ENOMEM on read/write.