### PR TITLE
Skip empty embedded TA binaries during registration

### DIFF
--- a/litebox_runner_lvbs/src/lib.rs
+++ b/litebox_runner_lvbs/src/lib.rs
@@ -1355,7 +1355,9 @@ fn register_embedded_ta(shim: &litebox_shim_optee::OpteeShim, ta_binary: &'stati
 /// Register all TA binaries embedded in the runner image.
 fn register_embedded_tas(shim: &litebox_shim_optee::OpteeShim) {
     for ta_binary in TA_BINARIES {
-        assert!(register_embedded_ta(shim, ta_binary));
+        if !ta_binary.is_empty() {
+            assert!(register_embedded_ta(shim, ta_binary));
+        }
     }
 }
 


### PR DESCRIPTION
Avoid panicking during initialization when an embedded TA binary is an empty placeholder.

Fixes: e33f6ffd: share TA binaries through a global UUID map