### PR TITLE
Add support for AArch64 to the packager

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,7 @@ jobs:
         -p litebox
         -p litebox_common_linux
         -p litebox_syscall_rewriter
+        -p litebox_packager
         -p litebox_platform_linux_userland
         -p litebox_shim_linux
         -p litebox_runner_linux_userland

--- a/litebox_packager/Cargo.toml
+++ b/litebox_packager/Cargo.toml
@@ -10,10 +10,6 @@ litebox_syscall_rewriter = { version = "0.1.0", path = "../litebox_syscall_rewri
 rayon = "1.10"
 tar = "0.4"
 object = { version = "0.36.7", default-features = false, features = ["elf", "read_core"] }
-
-# OCI image support — only on x86_64 (the images we pull are amd64 and the
-# native-tls feature pulls in openssl-sys which requires a matching libssl).
-[target.'cfg(target_arch = "x86_64")'.dependencies]
 flate2 = "1.1"
 oci-client = { version = "0.16", default-features = false, features = ["native-tls"] }
 oci-spec = { version = "0.9", features = ["image"] }

--- a/litebox_packager/Cargo.toml
+++ b/litebox_packager/Cargo.toml
@@ -11,6 +11,7 @@ rayon = "1.10"
 tar = "0.4"
 object = { version = "0.36.7", default-features = false, features = ["elf", "read_core"] }
 flate2 = "1.1"
+# Supported build platforms are expected to provide a `native-tls` backend.
 oci-client = { version = "0.16", default-features = false, features = ["native-tls"] }
 oci-spec = { version = "0.9", features = ["image"] }
 tempfile = "3"

--- a/litebox_packager/src/lib.rs
+++ b/litebox_packager/src/lib.rs
@@ -60,12 +60,18 @@ pub struct CliArgs {
     #[arg(long = "no-rewrite", value_name = "PATH")]
     pub no_rewrite: Vec<PathBuf>,
 
-    /// Host ABI targeted by AArch64 rewriting.
+    /// Host ABI expected by packaged AArch64 binaries; ignored for x86-64 binaries.
     #[arg(long, value_enum, default_value_t)]
     pub target_host: CliTargetHost,
 
-    /// Virtualize x18 on AArch64 Linux; ignored on x86-64. Requires the runner's
-    /// `aarch64_virtualize_x18` feature. Always enabled on macOS and Windows.
+    /// CPU architecture of binaries selected and rewritten for the package.
+    /// Cross-architecture packaging is supported only with `--oci-image`.
+    #[arg(long, value_enum, default_value_t)]
+    pub target_arch: CliTargetArch,
+
+    /// Virtualize x18 in packaged AArch64 binaries targeting Linux; ignored for
+    /// x86-64 binaries and always enabled for macOS and Windows host ABIs.
+    /// Requires the runner's `aarch64_virtualize_x18` feature.
     #[arg(long = "virtualize-x18")]
     pub virtualize_x18: bool,
 
@@ -89,6 +95,46 @@ impl Default for CliTargetHost {
             Self::Windows
         } else {
             Self::Linux
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+pub enum CliTargetArch {
+    #[value(name = "x86-64")]
+    X86_64,
+    Aarch64,
+}
+
+impl CliTargetArch {
+    fn elf_machine(self) -> u16 {
+        match self {
+            Self::X86_64 => EM_X86_64,
+            Self::Aarch64 => EM_AARCH64,
+        }
+    }
+
+    fn name(self) -> &'static str {
+        match self {
+            Self::X86_64 => "x86-64",
+            Self::Aarch64 => "aarch64",
+        }
+    }
+
+    fn oci_arch(self) -> oci_spec::image::Arch {
+        match self {
+            Self::X86_64 => oci_spec::image::Arch::Amd64,
+            Self::Aarch64 => oci_spec::image::Arch::ARM64,
+        }
+    }
+}
+
+impl Default for CliTargetArch {
+    fn default() -> Self {
+        if cfg!(target_arch = "aarch64") {
+            Self::Aarch64
+        } else {
+            Self::X86_64
         }
     }
 }
@@ -134,6 +180,8 @@ pub fn run(args: CliArgs) -> anyhow::Result<()> {
     if let Some(ref image_ref) = args.oci_image {
         return run_oci(image_ref, &args, rewrite_options);
     }
+
+    validate_host_target_arch(args.target_arch)?;
 
     // Host mode (local ELF files + ldd dependency discovery) is Linux-only.
     #[cfg(target_os = "linux")]
@@ -223,7 +271,7 @@ fn run_host_mode(
                 }
                 data
             } else {
-                rewrite_elf(&data, real_path, verbose, rewrite_options)
+                rewrite_elf(&data, real_path, verbose, rewrite_options, args.target_arch)
             };
 
             let mut entries = Vec::new();
@@ -276,7 +324,13 @@ fn run_host_mode(
             use std::os::unix::fs::MetadataExt as _;
             std::fs::metadata(&inc.host_path).map_or(0o755, |m| m.mode())
         };
-        let rewritten = rewrite_elf(&data, &inc.host_path, args.verbose, rewrite_options);
+        let rewritten = rewrite_elf(
+            &data,
+            &inc.host_path,
+            args.verbose,
+            rewrite_options,
+            args.target_arch,
+        );
         if args.verbose {
             eprintln!(
                 "  including {} as {}",
@@ -304,7 +358,7 @@ fn run_oci(
 ) -> anyhow::Result<()> {
     // --- Phase 1: Pull and extract OCI image ---
     eprintln!("Pulling OCI image: {image_ref}");
-    let extracted = oci::pull_and_extract(image_ref, args.verbose)?;
+    let extracted = oci::pull_and_extract(image_ref, args.target_arch, args.verbose)?;
 
     // --- Phase 2: Scan rootfs for files ---
     eprintln!("Scanning rootfs...");
@@ -346,7 +400,13 @@ fn run_oci(
                 .with_context(|| format!("failed to read {}", entry.read_path.display()))?;
 
             let rewritten = if entry.is_executable && !no_rewrite.contains(&entry.read_path) {
-                rewrite_elf(&data, &entry.read_path, verbose, rewrite_options)
+                rewrite_elf(
+                    &data,
+                    &entry.read_path,
+                    verbose,
+                    rewrite_options,
+                    args.target_arch,
+                )
             } else {
                 data
             };
@@ -618,15 +678,17 @@ fn elf_machine(data: &[u8]) -> Option<u16> {
     }
 }
 
-/// Returns the expected ELF e_machine value for the current target architecture.
-fn target_elf_machine() -> u16 {
-    if cfg!(target_arch = "x86_64") {
-        EM_X86_64
-    } else if cfg!(target_arch = "aarch64") {
-        EM_AARCH64
-    } else {
-        0 // Unknown — skip arch check
+/// Reject cross-architecture dependency discovery in host mode.
+fn validate_host_target_arch(target_arch: CliTargetArch) -> anyhow::Result<()> {
+    let build_arch = CliTargetArch::default();
+    if target_arch != build_arch {
+        bail!(
+            "host mode cannot target {} from {} build; use --oci-image for cross-architecture packaging",
+            target_arch.name(),
+            build_arch.name()
+        );
     }
+    Ok(())
 }
 
 /// Rewrite an ELF file's syscall instructions using the litebox syscall rewriter.
@@ -635,12 +697,14 @@ fn target_elf_machine() -> u16 {
 /// detected via a magic-byte check and returned unmodified without being sent
 /// through the rewriter. For actual ELF files, benign rewriter errors (already
 /// hooked, no syscalls, unsupported object, missing `.text`) are treated as
-/// warnings and the original bytes are returned.
+/// warnings and the original bytes are returned. ELF files for other target
+/// architectures are included unchanged.
 fn rewrite_elf(
     data: &[u8],
     path: &Path,
     verbose: bool,
     options: litebox_syscall_rewriter::RewriteOptions,
+    target_arch: CliTargetArch,
 ) -> Vec<u8> {
     // Fast-path: skip the rewriter entirely for non-ELF files.
     if data.len() < 4 || data[..4] != ELF_MAGIC {
@@ -652,9 +716,8 @@ fn rewrite_elf(
 
     // Skip ELF files whose architecture doesn't match the target. OCI images
     // may contain cross-architecture binaries (e.g., aarch64 in an x86_64
-    // image) which the rewriter cannot handle.
-    let target_machine = target_elf_machine();
-    if target_machine != 0 && elf_machine(data).is_some_and(|machine| machine != target_machine) {
+    // image), which are not part of the selected guest architecture.
+    if elf_machine(data).is_some_and(|machine| machine != target_arch.elf_machine()) {
         if verbose {
             eprintln!(
                 "  {} (wrong ELF architecture, skipping rewrite)",

--- a/litebox_packager/src/lib.rs
+++ b/litebox_packager/src/lib.rs
@@ -1,11 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-#[cfg(target_arch = "x86_64")]
 pub mod oci;
 
 use anyhow::{Context, bail};
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use rayon::prelude::*;
 #[cfg(target_os = "linux")]
 use std::collections::BTreeMap;
@@ -61,9 +60,48 @@ pub struct CliArgs {
     #[arg(long = "no-rewrite", value_name = "PATH")]
     pub no_rewrite: Vec<PathBuf>,
 
+    /// Host ABI targeted by AArch64 rewriting.
+    #[arg(long, value_enum, default_value_t)]
+    pub target_host: CliTargetHost,
+
+    /// Virtualize x18 on AArch64 Linux; ignored on x86-64. Requires the runner's
+    /// `aarch64_virtualize_x18` feature. Always enabled on macOS and Windows.
+    #[arg(long = "virtualize-x18")]
+    pub virtualize_x18: bool,
+
     /// Print verbose output during packaging.
     #[arg(short = 'v', long = "verbose")]
     pub verbose: bool,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+pub enum CliTargetHost {
+    Linux,
+    Macos,
+    Windows,
+}
+
+impl Default for CliTargetHost {
+    fn default() -> Self {
+        if cfg!(target_os = "macos") {
+            Self::Macos
+        } else if cfg!(target_os = "windows") {
+            Self::Windows
+        } else {
+            Self::Linux
+        }
+    }
+}
+
+impl CliArgs {
+    fn rewrite_options(&self) -> litebox_syscall_rewriter::RewriteOptions {
+        let target_host = match self.target_host {
+            CliTargetHost::Linux => litebox_syscall_rewriter::TargetHost::Linux,
+            CliTargetHost::Macos => litebox_syscall_rewriter::TargetHost::MacOs,
+            CliTargetHost::Windows => litebox_syscall_rewriter::TargetHost::Windows,
+        };
+        litebox_syscall_rewriter::RewriteOptions::new(target_host, self.virtualize_x18)
+    }
 }
 
 /// Parsed `--include` entry.
@@ -92,22 +130,15 @@ fn parse_include(spec: &str) -> anyhow::Result<IncludeEntry> {
 
 /// Run the packaging tool.
 pub fn run(args: CliArgs) -> anyhow::Result<()> {
+    let rewrite_options = args.rewrite_options();
     if let Some(ref image_ref) = args.oci_image {
-        #[cfg(target_arch = "x86_64")]
-        {
-            return run_oci(image_ref, &args);
-        }
-        #[cfg(not(target_arch = "x86_64"))]
-        {
-            let _ = image_ref;
-            bail!("--oci-image is only supported on x86_64");
-        }
+        return run_oci(image_ref, &args, rewrite_options);
     }
 
     // Host mode (local ELF files + ldd dependency discovery) is Linux-only.
     #[cfg(target_os = "linux")]
     {
-        run_host_mode(args)
+        run_host_mode(args, rewrite_options)
     }
 
     #[cfg(not(target_os = "linux"))]
@@ -121,7 +152,10 @@ pub fn run(args: CliArgs) -> anyhow::Result<()> {
 
 /// Host mode: package local ELF files with ldd-based dependency discovery.
 #[cfg(target_os = "linux")]
-fn run_host_mode(args: CliArgs) -> anyhow::Result<()> {
+fn run_host_mode(
+    args: CliArgs,
+    rewrite_options: litebox_syscall_rewriter::RewriteOptions,
+) -> anyhow::Result<()> {
     let input_files: Vec<PathBuf> = args
         .input_files
         .iter()
@@ -189,7 +223,7 @@ fn run_host_mode(args: CliArgs) -> anyhow::Result<()> {
                 }
                 data
             } else {
-                rewrite_elf(&data, real_path, verbose)
+                rewrite_elf(&data, real_path, verbose, rewrite_options)
             };
 
             let mut entries = Vec::new();
@@ -242,7 +276,7 @@ fn run_host_mode(args: CliArgs) -> anyhow::Result<()> {
             use std::os::unix::fs::MetadataExt as _;
             std::fs::metadata(&inc.host_path).map_or(0o755, |m| m.mode())
         };
-        let rewritten = rewrite_elf(&data, &inc.host_path, args.verbose);
+        let rewritten = rewrite_elf(&data, &inc.host_path, args.verbose, rewrite_options);
         if args.verbose {
             eprintln!(
                 "  including {} as {}",
@@ -263,8 +297,11 @@ fn run_host_mode(args: CliArgs) -> anyhow::Result<()> {
 }
 
 /// Run the packager in OCI mode: pull image, extract rootfs, rewrite ELFs, build tar.
-#[cfg(target_arch = "x86_64")]
-fn run_oci(image_ref: &str, args: &CliArgs) -> anyhow::Result<()> {
+fn run_oci(
+    image_ref: &str,
+    args: &CliArgs,
+    rewrite_options: litebox_syscall_rewriter::RewriteOptions,
+) -> anyhow::Result<()> {
     // --- Phase 1: Pull and extract OCI image ---
     eprintln!("Pulling OCI image: {image_ref}");
     let extracted = oci::pull_and_extract(image_ref, args.verbose)?;
@@ -309,7 +346,7 @@ fn run_oci(image_ref: &str, args: &CliArgs) -> anyhow::Result<()> {
                 .with_context(|| format!("failed to read {}", entry.read_path.display()))?;
 
             let rewritten = if entry.is_executable && !no_rewrite.contains(&entry.read_path) {
-                rewrite_elf(&data, &entry.read_path, verbose)
+                rewrite_elf(&data, &entry.read_path, verbose, rewrite_options)
             } else {
                 data
             };
@@ -599,7 +636,12 @@ fn target_elf_machine() -> u16 {
 /// through the rewriter. For actual ELF files, benign rewriter errors (already
 /// hooked, no syscalls, unsupported object, missing `.text`) are treated as
 /// warnings and the original bytes are returned.
-fn rewrite_elf(data: &[u8], path: &Path, verbose: bool) -> Vec<u8> {
+fn rewrite_elf(
+    data: &[u8],
+    path: &Path,
+    verbose: bool,
+    options: litebox_syscall_rewriter::RewriteOptions,
+) -> Vec<u8> {
     // Fast-path: skip the rewriter entirely for non-ELF files.
     if data.len() < 4 || data[..4] != ELF_MAGIC {
         if verbose {
@@ -622,7 +664,7 @@ fn rewrite_elf(data: &[u8], path: &Path, verbose: bool) -> Vec<u8> {
         return data.to_vec();
     }
 
-    match litebox_syscall_rewriter::hook_syscalls_in_elf(data, None) {
+    match litebox_syscall_rewriter::hook_syscalls_in_elf_with_options(data, None, options) {
         Ok(rewritten) => {
             if verbose {
                 eprintln!("  {} (rewritten)", path.display());

--- a/litebox_packager/src/oci.rs
+++ b/litebox_packager/src/oci.rs
@@ -17,27 +17,20 @@ use oci_client::config::ConfigFile;
 use oci_client::secrets::RegistryAuth;
 use oci_client::{Client, Reference};
 
-/// Return the OCI platform matching the packager build architecture.
-fn build_platform() -> (oci_spec::image::Os, oci_spec::image::Arch) {
-    let architecture = if cfg!(target_arch = "x86_64") {
-        oci_spec::image::Arch::Amd64
-    } else if cfg!(target_arch = "aarch64") {
-        oci_spec::image::Arch::ARM64
-    } else {
-        panic!("unsupported packager architecture")
-    };
-    (oci_spec::image::Os::Linux, architecture)
-}
+use crate::CliTargetArch;
 
-fn select_build_manifest(entries: &[oci_client::manifest::ImageIndexEntry]) -> Option<String> {
-    let (os, architecture) = build_platform();
+/// Select the Linux manifest for the requested guest architecture.
+fn select_manifest(
+    entries: &[oci_client::manifest::ImageIndexEntry],
+    target_arch: CliTargetArch,
+) -> Option<String> {
+    let architecture = target_arch.oci_arch();
     entries
         .iter()
         .find(|entry| {
-            entry
-                .platform
-                .as_ref()
-                .is_some_and(|platform| platform.os == os && platform.architecture == architecture)
+            entry.platform.as_ref().is_some_and(|platform| {
+                platform.os == oci_spec::image::Os::Linux && platform.architecture == architecture
+            })
         })
         .map(|entry| entry.digest.clone())
 }
@@ -108,7 +101,11 @@ pub struct RootfsEntry {
 /// Currently only anonymous (unauthenticated) pulls are supported. Private
 /// registries or images that require credentials will fail with an
 /// authorization error from the registry.
-pub fn pull_and_extract(image_ref: &str, verbose: bool) -> anyhow::Result<ExtractedImage> {
+pub fn pull_and_extract(
+    image_ref: &str,
+    target_arch: CliTargetArch,
+    verbose: bool,
+) -> anyhow::Result<ExtractedImage> {
     // Parse the image reference
     let reference: Reference = image_ref
         .parse()
@@ -127,8 +124,9 @@ pub fn pull_and_extract(image_ref: &str, verbose: bool) -> anyhow::Result<Extrac
     let image_data = rt.block_on(async {
         let config = ClientConfig {
             protocol: ClientProtocol::Https,
-            // Pull the Linux image matching the packager build architecture.
-            platform_resolver: Some(Box::new(select_build_manifest)),
+            platform_resolver: Some(Box::new(move |entries| {
+                select_manifest(entries, target_arch)
+            })),
             ..Default::default()
         };
         let client = Client::new(config);
@@ -152,7 +150,12 @@ pub fn pull_and_extract(image_ref: &str, verbose: bool) -> anyhow::Result<Extrac
                 ],
             )
             .await
-            .with_context(|| format!("failed to pull image {reference}"))?;
+            .with_context(|| {
+                format!(
+                    "failed to pull image {reference} for linux/{}",
+                    target_arch.name()
+                )
+            })?;
 
         if verbose {
             eprintln!("  Pulled {} layer(s)", image_data.layers.len());
@@ -160,6 +163,20 @@ pub fn pull_and_extract(image_ref: &str, verbose: bool) -> anyhow::Result<Extrac
 
         Ok::<_, anyhow::Error>(image_data)
     })?;
+
+    let config_json = image_data.config.data.to_vec();
+    let config_file = ConfigFile::try_from(image_data.config);
+    if let Ok(config_file) = &config_file
+        && (config_file.os != oci_spec::image::Os::Linux
+            || config_file.architecture != target_arch.oci_arch())
+    {
+        anyhow::bail!(
+            "pulled OCI image targets {}/{}, expected linux/{}",
+            config_file.os,
+            config_file.architecture,
+            target_arch.name(),
+        );
+    }
 
     // Create temp directory for extraction
     let tempdir = tempfile::tempdir().context("failed to create temporary directory for rootfs")?;
@@ -205,37 +222,33 @@ pub fn pull_and_extract(image_ref: &str, verbose: bool) -> anyhow::Result<Extrac
         eprintln!("  Rootfs extracted to {}", rootfs_path.display());
     }
 
-    // Save the raw config JSON before parsing (try_from consumes it).
-    let config_json = image_data.config.data.to_vec();
-
     // Parse image config for ENTRYPOINT, CMD, ENV, WORKDIR.
-    let config = match ConfigFile::try_from(image_data.config) {
-        Ok(cf) => {
-            let exec_config = cf.config.as_ref();
-            let ic = ImageConfig {
+    let config = match config_file {
+        Ok(config_file) => {
+            let exec_config = config_file.config.as_ref();
+            ImageConfig {
                 entrypoint: exec_config.and_then(|c| c.entrypoint.clone()),
                 cmd: exec_config.and_then(|c| c.cmd.clone()),
                 env: exec_config.and_then(|c| c.env.clone()),
                 working_dir: exec_config.and_then(|c| c.working_dir.clone()),
-            };
-            if verbose {
-                eprintln!(
-                    "  Image config: ENTRYPOINT={:?} CMD={:?} WORKDIR={:?} ENV=({} vars)",
-                    ic.entrypoint,
-                    ic.cmd,
-                    ic.working_dir,
-                    ic.env.as_ref().map_or(0, Vec::len)
-                );
             }
-            ic
         }
         Err(e) => {
             eprintln!(
-                "warning: failed to parse image config: {e}; config_and_run.sh will not be generated"
+                "warning: failed to parse image config: {e}; config_and_run.sh will use defaults"
             );
             ImageConfig::default()
         }
     };
+    if verbose {
+        eprintln!(
+            "  Image config: ENTRYPOINT={:?} CMD={:?} WORKDIR={:?} ENV=({} vars)",
+            config.entrypoint,
+            config.cmd,
+            config.working_dir,
+            config.env.as_ref().map_or(0, Vec::len)
+        );
+    }
 
     Ok(ExtractedImage {
         tempdir,

--- a/litebox_packager/src/oci.rs
+++ b/litebox_packager/src/oci.rs
@@ -17,6 +17,31 @@ use oci_client::config::ConfigFile;
 use oci_client::secrets::RegistryAuth;
 use oci_client::{Client, Reference};
 
+/// Return the OCI platform matching the packager build architecture.
+fn build_platform() -> (oci_spec::image::Os, oci_spec::image::Arch) {
+    let architecture = if cfg!(target_arch = "x86_64") {
+        oci_spec::image::Arch::Amd64
+    } else if cfg!(target_arch = "aarch64") {
+        oci_spec::image::Arch::ARM64
+    } else {
+        panic!("unsupported packager architecture")
+    };
+    (oci_spec::image::Os::Linux, architecture)
+}
+
+fn select_build_manifest(entries: &[oci_client::manifest::ImageIndexEntry]) -> Option<String> {
+    let (os, architecture) = build_platform();
+    entries
+        .iter()
+        .find(|entry| {
+            entry
+                .platform
+                .as_ref()
+                .is_some_and(|platform| platform.os == os && platform.architecture == architecture)
+        })
+        .map(|entry| entry.digest.clone())
+}
+
 /// Parsed OCI image execution configuration (ENTRYPOINT, CMD, ENV, WORKDIR).
 #[derive(Debug, Default)]
 pub struct ImageConfig {
@@ -102,18 +127,8 @@ pub fn pull_and_extract(image_ref: &str, verbose: bool) -> anyhow::Result<Extrac
     let image_data = rt.block_on(async {
         let config = ClientConfig {
             protocol: ClientProtocol::Https,
-            // Always pull linux/amd64 images regardless of host platform.
-            platform_resolver: Some(Box::new(|entries| {
-                entries
-                    .iter()
-                    .find(|entry| {
-                        entry.platform.as_ref().is_some_and(|p| {
-                            p.os == oci_spec::image::Os::Linux
-                                && p.architecture == oci_spec::image::Arch::Amd64
-                        })
-                    })
-                    .map(|e| e.digest.clone())
-            })),
+            // Pull the Linux image matching the packager build architecture.
+            platform_resolver: Some(Box::new(select_build_manifest)),
             ..Default::default()
         };
         let client = Client::new(config);


### PR DESCRIPTION
This PR adds support for AArch64 to the LiteBox packager. It also adds options to enable cross-architecture packaging.