### PR TITLE
Add shared guest network routing

### DIFF
--- a/litebox/src/net/broker_socket.rs
+++ b/litebox/src/net/broker_socket.rs
@@ -33,6 +33,20 @@ use crate::{
 
 const _: () = assert!(MAX_SOCKET_PEEK_SIZE as usize == super::SOCKET_RECEIVE_OPERATION_SIZE);
 
+/// Normalizes the IPv4 unspecified destination to loopback.
+///
+/// A guest that names `0.0.0.0` with a nonzero port means the local host, so
+/// the broker request and the cached peer both use the loopback address it
+/// resolves to. The reserved port zero keeps its address, leaving the broker to
+/// report the ordinary port-zero failure.
+pub(super) fn normalize_ipv4_destination(address: SocketAddrV4) -> SocketAddrV4 {
+    if address.port() != 0 && address.ip().is_unspecified() {
+        SocketAddrV4::new(core::net::Ipv4Addr::LOCALHOST, address.port())
+    } else {
+        address
+    }
+}
+
 struct BrokerTcpSocketState {
     connection: SocketConnectionStatus,
     local_address: Option<SocketAddrV4>,
@@ -184,6 +198,7 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
     }
 
     pub(super) fn start_connect(&self, address: SocketAddrV4) -> Result<(), ConnectError> {
+        let address = normalize_ipv4_destination(address);
         let previous = self.state.lock().connection;
         let outcome = self
             .broker
@@ -726,6 +741,7 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerUdpSocket<Platfor
     }
 
     pub(super) fn start_connect(&self, address: SocketAddrV4) -> Result<(), ConnectError> {
+        let address = normalize_ipv4_destination(address);
         let _configuration = self.configuration_lock.lock();
         let outcome = self
             .broker
@@ -1185,6 +1201,28 @@ impl From<BrokerSocketError> for SocketAsyncError {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn unspecified_destinations_normalize_to_loopback_above_port_zero() {
+        use core::net::Ipv4Addr;
+
+        assert_eq!(
+            normalize_ipv4_destination(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 80)),
+            SocketAddrV4::new(Ipv4Addr::LOCALHOST, 80)
+        );
+        // Port zero keeps the reserved destination the broker refuses.
+        assert_eq!(
+            normalize_ipv4_destination(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0)),
+            SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0)
+        );
+        for unchanged in [
+            SocketAddrV4::new(Ipv4Addr::LOCALHOST, 80),
+            SocketAddrV4::new(Ipv4Addr::new(10, 0, 2, 1), 80),
+            SocketAddrV4::new(Ipv4Addr::new(10, 0, 2, 15), 0),
+        ] {
+            assert_eq!(normalize_ipv4_destination(unchanged), unchanged);
+        }
+    }
 
     #[test]
     fn restored_udp_error_precedes_prefetched_successor() {

--- a/litebox/src/net/socket_channel.rs
+++ b/litebox/src/net/socket_channel.rs
@@ -121,11 +121,15 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> NetworkProxy<Platform> 
         if !flags.is_empty() {
             unimplemented!()
         }
-        if let Some(addr) = destination
-            && (addr.port() == 0 || addr.ip().is_unspecified())
-        {
+        if destination.is_some_and(|addr| addr.port() == 0) {
             return Err(ChannelWriteError::Unaddressable);
         }
+        let destination = destination.map(|addr| match addr {
+            SocketAddr::V4(addr) => {
+                SocketAddr::V4(super::broker_socket::normalize_ipv4_destination(addr))
+            }
+            SocketAddr::V6(_) => addr,
+        });
         match self {
             Self::BrokerStream(socket) => socket.try_write(buf),
             Self::BrokerDatagram(socket) => socket.try_write(buf, destination),

--- a/litebox_broker_core/src/lib.rs
+++ b/litebox_broker_core/src/lib.rs
@@ -35,12 +35,13 @@ use spin::rwlock::RwLock;
 
 pub use error::BrokerError;
 pub use policy::{
-    DestinationPolicy, DestinationPortRange, DestinationRule, Ipv4Cidr, MAX_DESTINATION_RULES,
-    PolicyEngine, PolicyProfile, SocketPolicy, SocketPolicyError,
+    DestinationPolicy, DestinationPortRange, DestinationRule, GatewayPortRule, Ipv4Cidr,
+    MAX_DESTINATION_RULES, MAX_GATEWAY_RULES, PolicyEngine, PolicyProfile, SocketPolicy,
+    SocketPolicyError,
 };
 use session::ObjectReference;
 pub use session::{BrokerSession, CallerCredential, ObjectRights, SessionId};
-use socket::{BrokerSocketPorts, SocketProvider};
+use socket::{BrokerNetworkConfig, BrokerSocketPorts, SocketProvider};
 
 /// BrokerCore result type.
 pub type Result<T> = core::result::Result<T, BrokerError>;
@@ -110,6 +111,7 @@ impl Default for BrokerCoreLimits {
 pub struct BrokerCore {
     pub(crate) policy: Arc<PolicyEngine>,
     pub(crate) limits: BrokerCoreLimits,
+    pub(crate) network_config: Arc<BrokerNetworkConfig>,
     pub(crate) next_session_id: Arc<RwLock<u64>>,
     pub(crate) next_reference_handle: Arc<RwLock<u64>>,
     pub(crate) references: Arc<RwLock<HashMap<ObjectHandle, ObjectReference>>>,
@@ -124,14 +126,27 @@ static BROKER_CORE_CREATED: AtomicBool = AtomicBool::new(false);
 
 impl BrokerCore {
     /// Creates the broker core with a broker-wide platform socket provider.
-    pub fn new(policy: PolicyEngine, socket_provider: Arc<dyn SocketProvider>) -> Result<Self> {
-        Self::new_with_limits(policy, BrokerCoreLimits::DEFAULT, socket_provider)
+    ///
+    /// The network configuration is the broker-wide guest identity shared with
+    /// the socket provider; both must agree on the same value.
+    pub fn new(
+        policy: PolicyEngine,
+        network_config: Arc<BrokerNetworkConfig>,
+        socket_provider: Arc<dyn SocketProvider>,
+    ) -> Result<Self> {
+        Self::new_with_limits(
+            policy,
+            BrokerCoreLimits::DEFAULT,
+            network_config,
+            socket_provider,
+        )
     }
 
     /// Creates the broker core with explicit limits and a socket provider.
     pub fn new_with_limits(
         policy: PolicyEngine,
         limits: BrokerCoreLimits,
+        network_config: Arc<BrokerNetworkConfig>,
         socket_provider: Arc<dyn SocketProvider>,
     ) -> Result<Self> {
         BROKER_CORE_CREATED
@@ -141,6 +156,7 @@ impl BrokerCore {
         Ok(Self {
             policy: Arc::new(policy),
             limits,
+            network_config,
             next_session_id: Arc::new(RwLock::new(1)),
             next_reference_handle: Arc::new(RwLock::new(1)),
             references: Arc::new(RwLock::new(HashMap::new())),
@@ -156,6 +172,12 @@ impl BrokerCore {
     #[must_use]
     pub const fn limits(&self) -> BrokerCoreLimits {
         self.limits
+    }
+
+    /// Returns the immutable broker-wide network configuration.
+    #[must_use]
+    pub fn network_config(&self) -> Arc<BrokerNetworkConfig> {
+        Arc::clone(&self.network_config)
     }
 
     pub(crate) fn allocate_reference_handle(&self) -> Result<ObjectHandle> {

--- a/litebox_broker_core/src/policy.rs
+++ b/litebox_broker_core/src/policy.rs
@@ -3,6 +3,7 @@
 
 use core::net::SocketAddrV4;
 
+use crate::socket::SocketDestination;
 use crate::{BrokerError, CallerCredential, ObjectRights};
 use litebox_broker_protocol::socket::{
     AddressFamily, CreateSocketRequest, IpProtocol, Ipv4Address, Port, SocketType,
@@ -11,6 +12,9 @@ use thiserror::Error;
 
 /// Maximum number of destination rules in one transport policy.
 pub const MAX_DESTINATION_RULES: usize = 64;
+
+/// Maximum number of host-gateway port rules for one transport protocol.
+pub const MAX_GATEWAY_RULES: usize = 64;
 
 /// An IPv4 network in canonical CIDR form.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -158,6 +162,52 @@ const EMPTY_DESTINATION_RULE: DestinationRule = DestinationRule {
     },
 };
 
+/// One static host-gateway port authorization rule.
+///
+/// A gateway rule authorizes replacement access to a host service reached
+/// through the guest-visible gateway address. It is destination-port scoped
+/// because the gateway address itself is fixed by the broker configuration.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct GatewayPortRule {
+    caller_credential: CallerCredential,
+    ports: DestinationPortRange,
+}
+
+impl GatewayPortRule {
+    /// Creates a rule for one caller and destination-port range.
+    #[must_use]
+    pub const fn new(caller_credential: CallerCredential, ports: DestinationPortRange) -> Self {
+        Self {
+            caller_credential,
+            ports,
+        }
+    }
+
+    /// Returns the caller authorized by this rule.
+    #[must_use]
+    pub const fn caller_credential(self) -> CallerCredential {
+        self.caller_credential
+    }
+
+    /// Returns the authorized destination-port range.
+    #[must_use]
+    pub const fn ports(self) -> DestinationPortRange {
+        self.ports
+    }
+
+    fn permits(self, caller_credential: CallerCredential, port: Port) -> bool {
+        self.caller_credential == caller_credential && self.ports.contains(port)
+    }
+}
+
+const EMPTY_GATEWAY_RULE: GatewayPortRule = GatewayPortRule {
+    caller_credential: CallerCredential::Unauthenticated,
+    ports: DestinationPortRange {
+        start: Port(1),
+        end: Port(1),
+    },
+};
+
 /// Invalid socket-policy configuration.
 #[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
 #[non_exhaustive]
@@ -169,6 +219,12 @@ pub enum SocketPolicyError {
         maximum: usize,
         /// Requested rule count.
         actual: usize,
+    },
+    /// External rules were supplied for a protocol whose sockets are denied.
+    #[error("destination rules were supplied for denied protocol {protocol:?}")]
+    RulesForDeniedProtocol {
+        /// Protocol whose guest-network admission is false.
+        protocol: IpProtocol,
     },
 }
 
@@ -194,21 +250,40 @@ impl DestinationPolicy {
     }
 }
 
+/// Bounded host-gateway port rules for one transport protocol.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct GatewayPolicy {
+    rules: [GatewayPortRule; MAX_GATEWAY_RULES],
+    rule_count: usize,
+}
+
+impl GatewayPolicy {
+    const fn empty() -> Self {
+        Self {
+            rules: [EMPTY_GATEWAY_RULE; MAX_GATEWAY_RULES],
+            rule_count: 0,
+        }
+    }
+
+    fn permits(&self, caller_credential: CallerCredential, port: Port) -> bool {
+        self.rules[..self.rule_count]
+            .iter()
+            .any(|rule| rule.permits(caller_credential, port))
+    }
+}
+
 /// Socket creation and outbound destination access available to broker-owned sockets.
 ///
 /// Local bind authority is separate from egress destination rules and is
 /// enforced by the broker's guest binding namespace.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[non_exhaustive]
-#[expect(
-    clippy::large_enum_variant,
-    reason = "fixed-capacity policy storage avoids infallible allocation in no_std configuration"
-)]
 pub enum SocketPolicy {
     /// Deny all socket creation and connection attempts.
     #[default]
     Deny,
-    /// Allow IPv4 TCP and UDP sockets with destinations in the IPv4 loopback network.
+    /// Allow IPv4 TCP and UDP sockets to reach only the literal IPv4 loopback
+    /// network inside the guest namespace.
     Ipv4Loopback,
     /// Apply bounded TCP destination rules.
     TcpDestinationRules(DestinationPolicy),
@@ -219,6 +294,22 @@ pub enum SocketPolicy {
         /// TCP destination policy.
         tcp: DestinationPolicy,
         /// UDP destination policy.
+        udp: DestinationPolicy,
+    },
+    /// Admit guest networking independently per protocol, with bounded
+    /// external destination rules.
+    ///
+    /// An admitted protocol reaches the whole guest namespace, including the
+    /// configured private guest address, and may reach the host gateway when a
+    /// matching gateway port rule also exists.
+    GuestNetwork {
+        /// Whether IPv4 TCP socket creation and guest routing are admitted.
+        admit_tcp: bool,
+        /// TCP external destination policy.
+        tcp: DestinationPolicy,
+        /// Whether IPv4 UDP socket creation and guest routing are admitted.
+        admit_udp: bool,
+        /// UDP external destination policy.
         udp: DestinationPolicy,
     },
 }
@@ -249,13 +340,48 @@ impl SocketPolicy {
         Ok(Self::TcpUdpDestinationRules { tcp, udp })
     }
 
+    /// Creates independently admitted guest networking with bounded external rules.
+    pub fn from_guest_network_destination_rules(
+        admit_tcp: bool,
+        tcp_rules: &[DestinationRule],
+        admit_udp: bool,
+        udp_rules: &[DestinationRule],
+    ) -> Result<Self, SocketPolicyError> {
+        if !admit_tcp && !tcp_rules.is_empty() {
+            return Err(SocketPolicyError::RulesForDeniedProtocol {
+                protocol: IpProtocol::Tcp,
+            });
+        }
+        if !admit_udp && !udp_rules.is_empty() {
+            return Err(SocketPolicyError::RulesForDeniedProtocol {
+                protocol: IpProtocol::Udp,
+            });
+        }
+        Ok(Self::GuestNetwork {
+            admit_tcp,
+            tcp: copy_destination_rules(tcp_rules)?,
+            admit_udp,
+            udp: copy_destination_rules(udp_rules)?,
+        })
+    }
+
     /// Returns the configured rules for a bounded destination policy.
     #[must_use]
     pub fn tcp_destination_rules(&self) -> Option<&[DestinationRule]> {
         match self {
             Self::TcpDestinationRules(policy)
-            | Self::TcpUdpDestinationRules { tcp: policy, .. } => Some(policy.rules()),
-            Self::Deny | Self::Ipv4Loopback | Self::UdpDestinationRules(_) => None,
+            | Self::TcpUdpDestinationRules { tcp: policy, .. }
+            | Self::GuestNetwork {
+                admit_tcp: true,
+                tcp: policy,
+                ..
+            } => Some(policy.rules()),
+            Self::Deny
+            | Self::Ipv4Loopback
+            | Self::UdpDestinationRules(_)
+            | Self::GuestNetwork {
+                admit_tcp: false, ..
+            } => None,
         }
     }
 
@@ -264,8 +390,18 @@ impl SocketPolicy {
     pub fn udp_destination_rules(&self) -> Option<&[DestinationRule]> {
         match self {
             Self::UdpDestinationRules(policy)
-            | Self::TcpUdpDestinationRules { udp: policy, .. } => Some(policy.rules()),
-            Self::Deny | Self::Ipv4Loopback | Self::TcpDestinationRules(_) => None,
+            | Self::TcpUdpDestinationRules { udp: policy, .. }
+            | Self::GuestNetwork {
+                admit_udp: true,
+                udp: policy,
+                ..
+            } => Some(policy.rules()),
+            Self::Deny
+            | Self::Ipv4Loopback
+            | Self::TcpDestinationRules(_)
+            | Self::GuestNetwork {
+                admit_udp: false, ..
+            } => None,
         }
     }
 
@@ -273,6 +409,7 @@ impl SocketPolicy {
         match self {
             Self::Deny | Self::UdpDestinationRules(_) => false,
             Self::Ipv4Loopback => true,
+            Self::GuestNetwork { admit_tcp, .. } => admit_tcp,
             Self::TcpDestinationRules(policy)
             | Self::TcpUdpDestinationRules { tcp: policy, .. } => policy
                 .rules()
@@ -285,6 +422,7 @@ impl SocketPolicy {
         match self {
             Self::Deny | Self::TcpDestinationRules(_) => false,
             Self::Ipv4Loopback => true,
+            Self::GuestNetwork { admit_udp, .. } => admit_udp,
             Self::UdpDestinationRules(policy)
             | Self::TcpUdpDestinationRules { udp: policy, .. } => policy
                 .rules()
@@ -293,32 +431,99 @@ impl SocketPolicy {
         }
     }
 
-    fn permits_tcp_destination(
+    /// Returns whether TCP may reach one guest-namespace destination.
+    ///
+    /// Literal loopback policy stays literal: it admits the loopback network
+    /// but not the configured private guest address.
+    fn permits_tcp_guest_destination(self, address: SocketAddrV4) -> bool {
+        match self {
+            Self::Deny
+            | Self::TcpDestinationRules(_)
+            | Self::UdpDestinationRules(_)
+            | Self::TcpUdpDestinationRules { .. } => false,
+            Self::Ipv4Loopback => address.ip().is_loopback(),
+            Self::GuestNetwork { admit_tcp, .. } => admit_tcp,
+        }
+    }
+
+    /// Returns whether UDP may reach one guest-namespace destination.
+    fn permits_udp_guest_destination(self, address: SocketAddrV4) -> bool {
+        match self {
+            Self::Deny
+            | Self::TcpDestinationRules(_)
+            | Self::UdpDestinationRules(_)
+            | Self::TcpUdpDestinationRules { .. } => false,
+            Self::Ipv4Loopback => address.ip().is_loopback(),
+            Self::GuestNetwork { admit_udp, .. } => admit_udp,
+        }
+    }
+
+    /// Returns whether the policy shape admits any TCP host-gateway route.
+    fn admits_tcp_gateway(self) -> bool {
+        matches!(
+            self,
+            Self::GuestNetwork {
+                admit_tcp: true,
+                ..
+            }
+        )
+    }
+
+    /// Returns whether the policy shape admits any UDP host-gateway route.
+    fn admits_udp_gateway(self) -> bool {
+        matches!(
+            self,
+            Self::GuestNetwork {
+                admit_udp: true,
+                ..
+            }
+        )
+    }
+
+    fn permits_tcp_external_destination(
         self,
         caller_credential: CallerCredential,
         address: SocketAddrV4,
     ) -> bool {
         match self {
-            Self::Deny | Self::UdpDestinationRules(_) => false,
-            Self::Ipv4Loopback => address.ip().is_loopback(),
+            Self::Deny
+            | Self::Ipv4Loopback
+            | Self::UdpDestinationRules(_)
+            | Self::GuestNetwork {
+                admit_tcp: false, ..
+            } => false,
             Self::TcpDestinationRules(policy)
-            | Self::TcpUdpDestinationRules { tcp: policy, .. } => policy
+            | Self::TcpUdpDestinationRules { tcp: policy, .. }
+            | Self::GuestNetwork {
+                admit_tcp: true,
+                tcp: policy,
+                ..
+            } => policy
                 .rules()
                 .iter()
                 .any(|rule| rule.permits(caller_credential, address)),
         }
     }
 
-    fn permits_udp_destination(
+    fn permits_udp_external_destination(
         self,
         caller_credential: CallerCredential,
         address: SocketAddrV4,
     ) -> bool {
         match self {
-            Self::Deny | Self::TcpDestinationRules(_) => false,
-            Self::Ipv4Loopback => address.ip().is_loopback(),
+            Self::Deny
+            | Self::Ipv4Loopback
+            | Self::TcpDestinationRules(_)
+            | Self::GuestNetwork {
+                admit_udp: false, ..
+            } => false,
             Self::UdpDestinationRules(policy)
-            | Self::TcpUdpDestinationRules { udp: policy, .. } => policy
+            | Self::TcpUdpDestinationRules { udp: policy, .. }
+            | Self::GuestNetwork {
+                admit_udp: true,
+                udp: policy,
+                ..
+            } => policy
                 .rules()
                 .iter()
                 .any(|rule| rule.permits(caller_credential, address)),
@@ -338,6 +543,19 @@ fn copy_destination_rules(
     let mut policy = DestinationPolicy::empty();
     policy.destination_rules[..rules.len()].copy_from_slice(rules);
     policy.destination_rule_count = rules.len();
+    Ok(policy)
+}
+
+fn copy_gateway_rules(rules: &[GatewayPortRule]) -> Result<GatewayPolicy, SocketPolicyError> {
+    if rules.len() > MAX_GATEWAY_RULES {
+        return Err(SocketPolicyError::TooManyRules {
+            maximum: MAX_GATEWAY_RULES,
+            actual: rules.len(),
+        });
+    }
+    let mut policy = GatewayPolicy::empty();
+    policy.rules[..rules.len()].copy_from_slice(rules);
+    policy.rule_count = rules.len();
     Ok(policy)
 }
 
@@ -364,6 +582,8 @@ pub enum PolicyProfile {
 pub struct PolicyEngine {
     profile: PolicyProfile,
     socket_policy: SocketPolicy,
+    tcp_gateway_policy: GatewayPolicy,
+    udp_gateway_policy: GatewayPolicy,
 }
 
 impl PolicyEngine {
@@ -372,6 +592,8 @@ impl PolicyEngine {
         Self {
             profile,
             socket_policy: SocketPolicy::Deny,
+            tcp_gateway_policy: GatewayPolicy::empty(),
+            udp_gateway_policy: GatewayPolicy::empty(),
         }
     }
 
@@ -395,6 +617,20 @@ impl PolicyEngine {
     pub const fn with_socket_policy(mut self, socket_policy: SocketPolicy) -> Self {
         self.socket_policy = socket_policy;
         self
+    }
+
+    /// Replaces the bounded TCP and UDP host-gateway port rules.
+    ///
+    /// A gateway rule alone never authorizes a route; the socket policy must
+    /// also admit host-gateway access for that protocol.
+    pub fn with_gateway_rules(
+        mut self,
+        tcp_rules: &[GatewayPortRule],
+        udp_rules: &[GatewayPortRule],
+    ) -> Result<Self, SocketPolicyError> {
+        self.tcp_gateway_policy = copy_gateway_rules(tcp_rules)?;
+        self.udp_gateway_policy = copy_gateway_rules(udp_rules)?;
+        Ok(self)
     }
 
     pub(crate) fn principal_object_rights(
@@ -439,19 +675,40 @@ impl PolicyEngine {
     pub(crate) fn authorize_socket_connect(
         &self,
         caller_credential: CallerCredential,
-        protocol: IpProtocol,
-        address: SocketAddrV4,
+        request: CreateSocketRequest,
+        destination: SocketDestination,
     ) -> Result<(), BrokerError> {
-        let permitted = match protocol {
-            IpProtocol::Tcp => self
-                .socket_policy
-                .permits_tcp_destination(caller_credential, address),
-            IpProtocol::Udp => self
-                .socket_policy
-                .permits_udp_destination(caller_credential, address),
+        self.principal_object_rights(caller_credential)?;
+        let permitted = match (request.socket_type, request.protocol, destination) {
+            (SocketType::Stream, IpProtocol::Tcp, SocketDestination::Guest { requested }) => {
+                self.socket_policy.permits_tcp_guest_destination(requested)
+            }
+            (SocketType::Stream, IpProtocol::Tcp, SocketDestination::Gateway { requested }) => {
+                self.socket_policy.admits_tcp_gateway()
+                    && self
+                        .tcp_gateway_policy
+                        .permits(caller_credential, Port(requested.port()))
+            }
+            (SocketType::Stream, IpProtocol::Tcp, SocketDestination::External { requested }) => {
+                self.socket_policy
+                    .permits_tcp_external_destination(caller_credential, requested)
+            }
+            (SocketType::Datagram, IpProtocol::Udp, SocketDestination::Guest { requested }) => {
+                self.socket_policy.permits_udp_guest_destination(requested)
+            }
+            (SocketType::Datagram, IpProtocol::Udp, SocketDestination::Gateway { requested }) => {
+                self.socket_policy.admits_udp_gateway()
+                    && self
+                        .udp_gateway_policy
+                        .permits(caller_credential, Port(requested.port()))
+            }
+            (SocketType::Datagram, IpProtocol::Udp, SocketDestination::External { requested }) => {
+                self.socket_policy
+                    .permits_udp_external_destination(caller_credential, requested)
+            }
             _ => false,
         };
-        if permitted {
+        if request.address_family == AddressFamily::Ipv4 && permitted {
             Ok(())
         } else {
             Err(BrokerError::PolicyDenied)
@@ -468,6 +725,7 @@ impl Default for PolicyEngine {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::socket::BrokerNetworkConfig;
     use core::net::Ipv4Addr;
 
     const IPV4_TCP: CreateSocketRequest = CreateSocketRequest {
@@ -491,6 +749,16 @@ mod tests {
 
     fn address(address: [u8; 4], port: u16) -> SocketAddrV4 {
         SocketAddrV4::new(Ipv4Addr::from(address), port)
+    }
+
+    fn route(config: &BrokerNetworkConfig, address: SocketAddrV4) -> SocketDestination {
+        config
+            .classify_destination(address)
+            .expect("test destinations are routable")
+    }
+
+    fn gateway_ports(start: u16, end: u16) -> GatewayPortRule {
+        GatewayPortRule::new(CallerCredential::Unauthenticated, ports(start, end))
     }
 
     #[test]
@@ -620,6 +888,7 @@ mod tests {
 
     #[test]
     fn destination_rules_enforce_principal_cidr_and_port() {
+        let network_config = BrokerNetworkConfig::default();
         let socket_policy = SocketPolicy::from_tcp_destination_rules(&[
             DestinationRule::new(
                 CallerCredential::Unauthenticated,
@@ -642,8 +911,8 @@ mod tests {
         assert_eq!(
             unauthenticated.authorize_socket_connect(
                 CallerCredential::Unauthenticated,
-                IpProtocol::Tcp,
-                address([10, 15, 0, 1], 443),
+                IPV4_TCP,
+                route(&network_config, address([10, 15, 0, 1], 443)),
             ),
             Ok(())
         );
@@ -651,13 +920,28 @@ mod tests {
             address([10, 16, 0, 1], 443),
             address([10, 15, 0, 1], 445),
             address([192, 0, 2, 7], 8443),
-            address([10, 15, 0, 1], 0),
         ] {
             assert_eq!(
                 unauthenticated.authorize_socket_connect(
                     CallerCredential::Unauthenticated,
-                    IpProtocol::Tcp,
-                    denied,
+                    IPV4_TCP,
+                    route(&network_config, denied),
+                ),
+                Err(BrokerError::PolicyDenied)
+            );
+        }
+        // External destination rules never reach the guest namespace or the
+        // host gateway, even when their network would match.
+        for guest_or_gateway in [
+            address([127, 0, 0, 1], 443),
+            SocketAddrV4::new(network_config.guest_ipv4_address(), 443),
+            SocketAddrV4::new(network_config.gateway_ipv4_address(), 443),
+        ] {
+            assert_eq!(
+                unauthenticated.authorize_socket_connect(
+                    CallerCredential::Unauthenticated,
+                    IPV4_TCP,
+                    route(&network_config, guest_or_gateway),
                 ),
                 Err(BrokerError::PolicyDenied)
             );
@@ -665,53 +949,59 @@ mod tests {
     }
 
     #[test]
-    fn loopback_policy_allows_tcp_and_udp_only_within_loopback() {
+    fn loopback_policy_allows_only_literal_loopback_destinations() {
+        let network_config = BrokerNetworkConfig::default();
         let policy = PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback);
+            .with_socket_policy(SocketPolicy::Ipv4Loopback)
+            .with_gateway_rules(&[gateway_ports(1, u16::MAX)], &[gateway_ports(1, u16::MAX)])
+            .unwrap();
+        assert_eq!(
+            policy.authorize_socket_create(CallerCredential::Unauthenticated, IPV4_TCP),
+            Ok(ObjectRights::all())
+        );
+        assert_eq!(
+            policy.authorize_socket_create(CallerCredential::Unauthenticated, IPV4_UDP),
+            Ok(ObjectRights::all())
+        );
         assert_eq!(
             policy.authorize_socket_connect(
                 CallerCredential::Unauthenticated,
-                IpProtocol::Tcp,
-                address([127, 255, 0, 1], 80),
+                IPV4_TCP,
+                route(&network_config, address([127, 255, 0, 1], 80)),
             ),
             Ok(())
         );
         assert_eq!(
             policy.authorize_socket_connect(
                 CallerCredential::Unauthenticated,
-                IpProtocol::Tcp,
-                address([10, 0, 0, 1], 80),
-            ),
-            Err(BrokerError::PolicyDenied)
-        );
-        assert_eq!(
-            policy.authorize_socket_connect(
-                CallerCredential::Unauthenticated,
-                IpProtocol::Tcp,
-                address([127, 0, 0, 1], 0),
+                IPV4_UDP,
+                route(&network_config, address([127, 0, 0, 1], 53)),
             ),
             Ok(())
         );
-        assert_eq!(
-            policy.authorize_socket_connect(
-                CallerCredential::Unauthenticated,
-                IpProtocol::Udp,
-                address([127, 0, 0, 1], 53),
-            ),
-            Ok(())
-        );
-        assert_eq!(
-            policy.authorize_socket_connect(
-                CallerCredential::Unauthenticated,
-                IpProtocol::Udp,
-                address([10, 0, 0, 1], 53),
-            ),
-            Err(BrokerError::PolicyDenied)
-        );
+        // The private guest address, the host gateway, and external networks
+        // remain denied even though a gateway rule exists.
+        for denied in [
+            SocketAddrV4::new(network_config.guest_ipv4_address(), 80),
+            SocketAddrV4::new(network_config.gateway_ipv4_address(), 80),
+            address([10, 0, 0, 1], 80),
+        ] {
+            for request in [IPV4_TCP, IPV4_UDP] {
+                assert_eq!(
+                    policy.authorize_socket_connect(
+                        CallerCredential::Unauthenticated,
+                        request,
+                        route(&network_config, denied),
+                    ),
+                    Err(BrokerError::PolicyDenied)
+                );
+            }
+        }
     }
 
     #[test]
     fn mixed_policy_authorizes_udp_independently_from_tcp() {
+        let network_config = BrokerNetworkConfig::default();
         let tcp_rule = DestinationRule::new(
             CallerCredential::Unauthenticated,
             cidr([192, 0, 2, 0], 24),
@@ -719,7 +1009,7 @@ mod tests {
         );
         let udp_rule = DestinationRule::new(
             CallerCredential::Unauthenticated,
-            cidr([127, 0, 0, 0], 8),
+            cidr([198, 51, 100, 0], 24),
             ports(53, 53),
         );
         let policy = PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
@@ -734,18 +1024,231 @@ mod tests {
         assert_eq!(
             policy.authorize_socket_connect(
                 CallerCredential::Unauthenticated,
-                IpProtocol::Udp,
-                address([127, 0, 0, 1], 53),
+                IPV4_UDP,
+                route(&network_config, address([198, 51, 100, 1], 53)),
             ),
             Ok(())
         );
         assert_eq!(
             policy.authorize_socket_connect(
                 CallerCredential::Unauthenticated,
-                IpProtocol::Udp,
-                address([192, 0, 2, 1], 443),
+                IPV4_UDP,
+                route(&network_config, address([192, 0, 2, 1], 443)),
             ),
             Err(BrokerError::PolicyDenied)
+        );
+        assert_eq!(
+            policy.authorize_socket_connect(
+                CallerCredential::Unauthenticated,
+                IPV4_TCP,
+                route(&network_config, address([198, 51, 100, 1], 53)),
+            ),
+            Err(BrokerError::PolicyDenied)
+        );
+        // A socket request whose type and protocol disagree is never routable.
+        assert_eq!(
+            policy.authorize_socket_connect(
+                CallerCredential::Unauthenticated,
+                CreateSocketRequest {
+                    address_family: AddressFamily::Ipv4,
+                    socket_type: SocketType::Stream,
+                    protocol: IpProtocol::Udp,
+                },
+                route(&network_config, address([198, 51, 100, 1], 53)),
+            ),
+            Err(BrokerError::PolicyDenied)
+        );
+    }
+
+    #[test]
+    fn guest_network_policy_separates_guest_gateway_and_external_routes() {
+        let network_config = BrokerNetworkConfig::default();
+        let external_rule = DestinationRule::new(
+            CallerCredential::Unauthenticated,
+            cidr([203, 0, 113, 0], 24),
+            ports(80, 80),
+        );
+        let socket_policy = SocketPolicy::from_guest_network_destination_rules(
+            true,
+            &[external_rule],
+            true,
+            &[external_rule],
+        )
+        .unwrap();
+        let without_gateway = PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
+            .with_socket_policy(socket_policy);
+        let with_gateway = without_gateway
+            .clone()
+            .with_gateway_rules(&[gateway_ports(8080, 8080)], &[gateway_ports(53, 53)])
+            .unwrap();
+        let loopback = address([127, 0, 0, 1], 80);
+        let guest = SocketAddrV4::new(network_config.guest_ipv4_address(), 80);
+        let external = address([203, 0, 113, 9], 80);
+        let unauthorized_external = address([203, 0, 113, 9], 81);
+
+        for request in [IPV4_TCP, IPV4_UDP] {
+            for permitted in [loopback, guest, external] {
+                assert_eq!(
+                    without_gateway.authorize_socket_connect(
+                        CallerCredential::Unauthenticated,
+                        request,
+                        route(&network_config, permitted),
+                    ),
+                    Ok(())
+                );
+            }
+            assert_eq!(
+                without_gateway.authorize_socket_connect(
+                    CallerCredential::Unauthenticated,
+                    request,
+                    route(&network_config, unauthorized_external),
+                ),
+                Err(BrokerError::PolicyDenied)
+            );
+        }
+
+        // Guest networking alone never reaches the host gateway.
+        for (request, port) in [(IPV4_TCP, 8080), (IPV4_UDP, 53)] {
+            let gateway = SocketAddrV4::new(network_config.gateway_ipv4_address(), port);
+            assert_eq!(
+                without_gateway.authorize_socket_connect(
+                    CallerCredential::Unauthenticated,
+                    request,
+                    route(&network_config, gateway),
+                ),
+                Err(BrokerError::PolicyDenied)
+            );
+            assert_eq!(
+                with_gateway.authorize_socket_connect(
+                    CallerCredential::Unauthenticated,
+                    request,
+                    route(&network_config, gateway),
+                ),
+                Ok(())
+            );
+        }
+    }
+
+    #[test]
+    fn guest_network_admits_protocols_independently() {
+        let network_config = BrokerNetworkConfig::default();
+        let policy = PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
+            .with_socket_policy(
+                SocketPolicy::from_guest_network_destination_rules(true, &[], false, &[]).unwrap(),
+            )
+            .with_gateway_rules(&[gateway_ports(80, 80)], &[gateway_ports(53, 53)])
+            .unwrap();
+        let loopback = address([127, 0, 0, 1], 80);
+        let gateway = SocketAddrV4::new(network_config.gateway_ipv4_address(), 80);
+
+        assert_eq!(
+            policy.authorize_socket_create(CallerCredential::Unauthenticated, IPV4_TCP),
+            Ok(ObjectRights::all())
+        );
+        assert_eq!(
+            policy.authorize_socket_create(CallerCredential::Unauthenticated, IPV4_UDP),
+            Err(BrokerError::PolicyDenied)
+        );
+        assert_eq!(
+            policy.authorize_socket_connect(
+                CallerCredential::Unauthenticated,
+                IPV4_TCP,
+                route(&network_config, loopback),
+            ),
+            Ok(())
+        );
+        assert_eq!(
+            policy.authorize_socket_connect(
+                CallerCredential::Unauthenticated,
+                IPV4_TCP,
+                route(&network_config, gateway),
+            ),
+            Ok(())
+        );
+        for denied in [loopback, gateway] {
+            assert_eq!(
+                policy.authorize_socket_connect(
+                    CallerCredential::Unauthenticated,
+                    IPV4_UDP,
+                    route(&network_config, denied),
+                ),
+                Err(BrokerError::PolicyDenied)
+            );
+        }
+        assert_eq!(
+            SocketPolicy::from_guest_network_destination_rules(
+                false,
+                &[DestinationRule::new(
+                    CallerCredential::Unauthenticated,
+                    cidr([203, 0, 113, 0], 24),
+                    ports(80, 80),
+                )],
+                true,
+                &[],
+            ),
+            Err(SocketPolicyError::RulesForDeniedProtocol {
+                protocol: IpProtocol::Tcp,
+            })
+        );
+    }
+
+    #[test]
+    fn gateway_rules_are_credential_scoped_and_bounded() {
+        let network_config = BrokerNetworkConfig::default();
+        let policy = PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
+            .with_socket_policy(
+                SocketPolicy::from_guest_network_destination_rules(true, &[], true, &[]).unwrap(),
+            )
+            .with_gateway_rules(
+                &[GatewayPortRule::new(
+                    CallerCredential::HostGuaranteed,
+                    ports(8080, 8080),
+                )],
+                &[gateway_ports(53, 53)],
+            )
+            .unwrap();
+        let tcp_gateway = SocketAddrV4::new(network_config.gateway_ipv4_address(), 8080);
+        let udp_gateway = SocketAddrV4::new(network_config.gateway_ipv4_address(), 53);
+
+        assert_eq!(
+            policy.authorize_socket_connect(
+                CallerCredential::Unauthenticated,
+                IPV4_TCP,
+                route(&network_config, tcp_gateway),
+            ),
+            Err(BrokerError::PolicyDenied)
+        );
+        assert_eq!(
+            policy.authorize_socket_connect(
+                CallerCredential::Unauthenticated,
+                IPV4_UDP,
+                route(&network_config, udp_gateway),
+            ),
+            Ok(())
+        );
+        assert_eq!(
+            policy.authorize_socket_connect(
+                CallerCredential::Unauthenticated,
+                IPV4_UDP,
+                route(&network_config, tcp_gateway),
+            ),
+            Err(BrokerError::PolicyDenied)
+        );
+
+        let maximum = [gateway_ports(1, u16::MAX); MAX_GATEWAY_RULES];
+        assert!(
+            PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
+                .with_gateway_rules(&maximum, &maximum)
+                .is_ok()
+        );
+        let excessive = [gateway_ports(1, u16::MAX); MAX_GATEWAY_RULES + 1];
+        assert_eq!(
+            PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
+                .with_gateway_rules(&excessive, &maximum),
+            Err(SocketPolicyError::TooManyRules {
+                maximum: MAX_GATEWAY_RULES,
+                actual: MAX_GATEWAY_RULES + 1,
+            })
         );
     }
 }

--- a/litebox_broker_core/src/session.rs
+++ b/litebox_broker_core/src/session.rs
@@ -505,6 +505,7 @@ mod tests {
     use core::sync::atomic::{AtomicUsize, Ordering};
 
     use super::{SessionReferences, release_pending_reference};
+    use crate::socket::BrokerNetworkConfig;
     use crate::{
         BrokerCore, BrokerCoreLimits, BrokerError, CallerCredential, ObjectRights, PolicyEngine,
         SocketPolicy,
@@ -543,6 +544,7 @@ mod tests {
             PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
                 .with_socket_policy(SocketPolicy::Ipv4Loopback),
             BrokerCoreLimits::new_with_all_limits(2, 4, 2, 1),
+            Arc::new(BrokerNetworkConfig::default()),
             socket_provider.clone(),
         )
         .unwrap();

--- a/litebox_broker_core/src/socket.rs
+++ b/litebox_broker_core/src/socket.rs
@@ -4,8 +4,9 @@
 //! Broker authority for socket policy, guest-visible endpoints, and platform
 //! lifecycle.
 
+mod network;
+
 use alloc::{sync::Arc, vec::Vec};
-use core::fmt;
 use core::net::{Ipv4Addr, SocketAddrV4};
 use core::sync::atomic::{AtomicUsize, Ordering};
 
@@ -24,9 +25,10 @@ use crate::readiness::{ReadinessRegistration, ReadinessSink};
 use crate::session::{ObjectEntry, ObjectRights};
 use crate::{BrokerError, BrokerSession, Result, SessionId};
 
-const DEFAULT_TCP_LISTEN_ADDRESS: SocketAddrV4 = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0);
-const DEFAULT_TCP_LOCAL_ADDRESS: SocketAddrV4 = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0);
-const DEFAULT_UDP_LOCAL_ADDRESS: SocketAddrV4 = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0);
+pub use network::{BrokerNetworkConfig, GuestSocketBinding, SocketDestination};
+
+/// Implicit local endpoint reserved by an unbound connect, listen, or send.
+const DEFAULT_LOCAL_ADDRESS: SocketAddrV4 = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0);
 const FIRST_EPHEMERAL_PORT: u16 = 49152;
 
 /// Platform-observed socket state returned to the broker for reconciliation.
@@ -136,22 +138,15 @@ struct GuestBindingReservation {
 }
 
 impl GuestBindingReservation {
-    fn covers(&self, address: SocketAddrV4) -> bool {
-        // TODO: Allow the configured guest private address once shared guest identity is added.
-        if address.port() == 0 || !address.ip().is_loopback() {
-            return false;
-        }
-        match self.key {
-            GuestBindingKey::Wildcard(port) => address.port() == port,
-            GuestBindingKey::Exact(reserved) => reserved == address,
-        }
-    }
-
     fn requested_address(&self) -> SocketAddrV4 {
         match self.key {
             GuestBindingKey::Wildcard(port) => SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, port),
             GuestBindingKey::Exact(address) => address,
         }
+    }
+
+    const fn transport(&self) -> GuestTransport {
+        self.transport
     }
 }
 
@@ -169,10 +164,11 @@ pub(crate) struct BrokerSocketPorts {
 impl BrokerSocketPorts {
     fn reserve(
         &self,
+        config: &BrokerNetworkConfig,
         request: CreateSocketRequest,
         requested_address: SocketAddrV4,
     ) -> Result<SocketOutcome<(SocketAddrV4, GuestBindingReservation)>> {
-        if !guest_binding_address_is_valid(requested_address) {
+        if !config.binding_is_valid(requested_address) {
             return Ok(SocketOutcome::Failed(SocketError::AddressNotAvailable));
         }
         let transport = guest_transport(request).ok_or(BrokerError::Internal)?;
@@ -209,10 +205,6 @@ impl BrokerSocketPorts {
     }
 }
 
-fn guest_binding_address_is_valid(address: SocketAddrV4) -> bool {
-    address.ip().is_unspecified() || address.ip().is_loopback()
-}
-
 impl Drop for GuestBindingReservation {
     fn drop(&mut self) {
         let mut state = self.ports.state.lock();
@@ -225,88 +217,18 @@ impl Drop for GuestBindingReservation {
     }
 }
 
-/// Broker-authorized guest binding passed to a platform provider.
-#[derive(Clone)]
-pub struct GuestSocketBinding {
-    requested: SocketAddrV4,
-    transport: GuestTransport,
-}
-
-impl GuestSocketBinding {
-    fn new(reservation: &GuestBindingReservation) -> Self {
-        Self {
-            requested: reservation.requested_address(),
-            transport: reservation.transport,
-        }
-    }
-
-    /// Returns the broker-reserved guest-visible binding.
-    #[must_use]
-    pub const fn requested(&self) -> SocketAddrV4 {
-        self.requested
-    }
-
-    /// Returns whether the original binding used the wildcard address.
-    #[must_use]
-    pub const fn is_wildcard(&self) -> bool {
-        self.requested.ip().is_unspecified()
-    }
-
-    /// Checks that this value represents a supported guest binding.
-    #[must_use]
-    pub fn is_valid(&self) -> bool {
-        self.requested.port() != 0 && guest_binding_address_is_valid(self.requested)
-    }
-
-    /// Returns whether this binding belongs to the TCP guest namespace.
-    #[must_use]
-    pub fn is_tcp(&self) -> bool {
-        self.transport == GuestTransport::Tcp
-    }
-
-    /// Returns whether this binding covers one concrete guest loopback address.
-    #[must_use]
-    pub fn covers(&self, address: SocketAddrV4) -> bool {
-        self.is_valid()
-            && address.port() != 0
-            && address.ip().is_loopback()
-            && if self.is_wildcard() {
-                address.port() == self.requested.port()
-            } else {
-                address == self.requested
-            }
-    }
-}
-
-impl fmt::Debug for GuestSocketBinding {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter
-            .debug_struct("GuestSocketBinding")
-            .field("requested", &self.requested)
-            .finish_non_exhaustive()
-    }
-}
-
-impl PartialEq for GuestSocketBinding {
-    fn eq(&self, other: &Self) -> bool {
-        self.requested == other.requested && self.transport == other.transport
-    }
-}
-
-impl Eq for GuestSocketBinding {}
-
 /// Platform socket and endpoint metadata returned by an accept operation.
 pub struct AcceptedPlatformSocket {
     /// Accepted, connected nonblocking platform socket.
     pub socket: Arc<dyn PlatformSocket>,
     /// Exact guest destination reached by the connector.
     pub local_address: SocketAddrV4,
-    /// Guest-visible peer endpoint of the accepted connection.
+    /// Route-tagged guest-visible peer endpoint of the accepted connection.
     ///
-    /// For a guest-to-guest connection, this must be the connector's
-    /// guest-namespace endpoint; broker-internal native routing endpoints must
-    /// not be exposed.
-    pub remote_address: SocketAddrV4,
+    /// Only a [`SocketDestination::Guest`] route may be accepted, and it must
+    /// carry the connector's guest-namespace endpoint; broker-internal native
+    /// routing endpoints must not be exposed.
+    pub remote: SocketDestination,
 }
 
 /// Broker failure from a platform connect operation.
@@ -347,11 +269,23 @@ pub struct PlatformDatagramReceive {
     /// Original datagram length before truncation.
     pub datagram_length: usize,
     /// Guest-visible source address of the datagram.
-    ///
-    /// Platforms must return the sender's stable guest-namespace endpoint for
-    /// guest-to-guest datagrams. Broker-internal native endpoints must not be
-    /// exposed.
     pub source_address: SocketAddrV4,
+}
+
+/// Trusted platform result for one routed datagram receive.
+#[derive(Debug, PartialEq, Eq)]
+pub struct RoutedPlatformDatagramReceive {
+    /// Received datagram prefix, truncated to the requested capacity.
+    pub data: Vec<u8>,
+    /// Original datagram length before truncation.
+    pub datagram_length: usize,
+    /// Route-tagged guest-visible source address of the datagram.
+    ///
+    /// Platforms must tag the sender's stable guest-visible endpoint with the
+    /// route that delivered it. Broker-internal native endpoints must not be
+    /// exposed, and core rejects a tag that disagrees with the broker network
+    /// configuration.
+    pub source: SocketDestination,
 }
 
 /// Broker-wide socket provider supplied by the host platform.
@@ -416,7 +350,9 @@ pub trait PlatformSocket: Send + Sync {
 
     /// Starts a connection attempt.
     ///
-    /// A stream attempt may return `Connecting` and stores ordinary failures as
+    /// The destination is a broker-classified route that core has already
+    /// validated against the shared network configuration and policy. A stream
+    /// attempt may return `Connecting` and stores ordinary failures as
     /// terminal state. A datagram connect completes immediately; the core
     /// permits replacing its peer and treats synchronous failures as retryable
     /// operation outcomes. A datagram `Failed` status must leave the previous
@@ -427,7 +363,7 @@ pub trait PlatformSocket: Send + Sync {
     /// during teardown.
     fn connect(
         &self,
-        address: SocketAddrV4,
+        destination: SocketDestination,
     ) -> core::result::Result<SocketConnectionStatus, PlatformConnectError>;
 
     /// Sends bytes without waiting for platform readiness.
@@ -438,15 +374,15 @@ pub trait PlatformSocket: Send + Sync {
 
     /// Sends one complete datagram without waiting for platform readiness.
     ///
-    /// A destination is required for an unconnected socket and omitted to use
-    /// the socket's connected peer. Partial successful sends are invalid.
-    /// Resource failures are broker errors rather than ordinary socket
-    /// failures.
+    /// A broker-classified destination is required for an unconnected socket
+    /// and omitted to use the socket's connected peer. Partial successful
+    /// sends are invalid. Resource failures are broker errors rather than
+    /// ordinary socket failures.
     fn send_to(
         &self,
         data: Vec<u8>,
         flags: SendFlags,
-        destination: Option<SocketAddrV4>,
+        destination: Option<SocketDestination>,
     ) -> Result<SocketOutcome<usize>>;
 
     /// Receives bytes without waiting for platform readiness.
@@ -466,12 +402,12 @@ pub trait PlatformSocket: Send + Sync {
     ///
     /// The original datagram length is returned even when the caller's buffer
     /// is smaller, and zero-length datagrams are successful receives. The
-    /// source address follows [`PlatformDatagramReceive::source_address`].
+    /// source follows [`RoutedPlatformDatagramReceive::source`].
     fn receive_from(
         &self,
         length: usize,
         flags: ReceiveFromFlags,
-    ) -> Result<SocketOutcome<PlatformDatagramReceive>>;
+    ) -> Result<SocketOutcome<RoutedPlatformDatagramReceive>>;
 
     /// Applies a directional or TCP lifecycle shutdown mode.
     ///
@@ -491,8 +427,9 @@ pub trait PlatformSocket: Send + Sync {
     /// For stream sockets, this advances an asynchronous connection attempt
     /// from `Connecting` to `Connected` or `Failed`. For datagram sockets, the
     /// broker owns the peer state; the platform reports pending asynchronous
-    /// errors and may specialize the local IP address after external routing,
-    /// but it must preserve the broker-reserved local port.
+    /// errors. A reported local address must be either absent or exactly the
+    /// guest-visible address core selected for this socket; core owns the
+    /// route-specific source identity and rejects any other observation.
     fn status(&self) -> Result<PlatformSocketStatus>;
 
     /// Synchronously and idempotently ends this socket's platform authority.
@@ -570,8 +507,9 @@ pub fn create(
 /// Policy denial is returned as a per-request [`SocketOutcome::Failed`] and
 /// does not alter the socket's existing connection or peer state, so a later
 /// authorized destination may still be attempted. An authorized attempt on an
-/// unbound stream or datagram socket first reserves a guest-visible local
-/// endpoint.
+/// unbound stream or datagram socket first reserves a wildcard guest-visible
+/// local endpoint, whose concrete guest source is then selected by the
+/// classified route.
 pub fn connect(
     session: &BrokerSession,
     handle: ObjectHandle,
@@ -585,13 +523,20 @@ pub fn connect(
         };
         socket.create_request
     };
+    if address.port() == 0 {
+        return connect_reserved_port(&object, create_request);
+    }
+    let destination = match session.core.network_config.classify_destination(address) {
+        Ok(destination) => destination,
+        Err(error) => return Ok(SocketOutcome::Failed(error)),
+    };
 
     // Destination denial is an operation-level socket failure. Failures while
     // evaluating policy remain broker errors.
     match session.core.policy.authorize_socket_connect(
         session.caller_credential,
-        create_request.protocol,
-        address,
+        create_request,
+        destination,
     ) {
         Ok(()) => {}
         Err(BrokerError::PolicyDenied) => {
@@ -601,7 +546,7 @@ pub fn connect(
     }
 
     if is_udp(create_request) {
-        return connect_datagram(session, &object, create_request, address);
+        return connect_datagram(session, &object, create_request, destination);
     }
 
     let (resource, needs_bind) = {
@@ -625,24 +570,20 @@ pub fn connect(
         (Arc::clone(&socket.resource), socket.local_address.is_none())
     };
     if needs_bind {
-        let binding = match reserve_and_bind(
-            session,
-            create_request,
-            &resource,
-            DEFAULT_TCP_LOCAL_ADDRESS,
-        ) {
-            Ok(binding) => binding,
-            Err(error) => {
-                finish_connect(&object, SocketConnectionStatus::Unconnected);
-                return Err(error);
-            }
-        };
+        let binding =
+            match reserve_and_bind(session, create_request, &resource, DEFAULT_LOCAL_ADDRESS) {
+                Ok(binding) => binding,
+                Err(error) => {
+                    finish_connect(&object, SocketConnectionStatus::Unconnected, None);
+                    return Err(error);
+                }
+            };
         match binding {
             ReserveAndBindOutcome::Completed(local_address, reservation) => {
                 attach_binding(&object, local_address, reservation)?;
             }
             ReserveAndBindOutcome::Failed(error) => {
-                finish_connect(&object, SocketConnectionStatus::Unconnected);
+                finish_connect(&object, SocketConnectionStatus::Unconnected, None);
                 return Ok(SocketOutcome::Failed(error));
             }
             ReserveAndBindOutcome::Retired => {
@@ -652,7 +593,21 @@ pub fn connect(
             }
         }
     }
-    let status = match resource.connect(address) {
+    let Some(binding) = resource.guest_binding() else {
+        finish_retired_connect(&object);
+        resource.retire();
+        return Err(BrokerError::Internal);
+    };
+    let Some(concrete_local_address) =
+        binding.concrete_address_for(&session.core.network_config, destination)
+    else {
+        // A reserved source that cannot reach this route fails the request
+        // rather than silently selecting another guest identity.
+        let status = SocketConnectionStatus::Failed(SocketError::InvalidArgument);
+        finish_connect(&object, status, None);
+        return Ok(SocketOutcome::Completed(status));
+    };
+    let status = match resource.connect(destination) {
         Ok(SocketConnectionStatus::Unconnected) => {
             finish_retired_connect(&object);
             resource.retire();
@@ -660,7 +615,7 @@ pub fn connect(
         }
         Ok(status) => status,
         Err(PlatformConnectError::PeerUnchanged(error)) => {
-            finish_connect(&object, SocketConnectionStatus::Unconnected);
+            finish_connect(&object, SocketConnectionStatus::Unconnected, None);
             return Err(error);
         }
         Err(PlatformConnectError::PeerIndeterminate(error)) => {
@@ -669,8 +624,36 @@ pub fn connect(
             return Err(error);
         }
     };
-    finish_connect(&object, status);
+    finish_connect(&object, status, Some(concrete_local_address));
     Ok(SocketOutcome::Completed(status))
+}
+
+/// Fails a connect to the reserved port zero without reaching the platform.
+fn connect_reserved_port(
+    object: &spin::RwLock<ObjectEntry>,
+    create_request: CreateSocketRequest,
+) -> Result<SocketOutcome<SocketConnectionStatus>> {
+    if is_udp(create_request) {
+        return Ok(SocketOutcome::Failed(SocketError::ConnectionRefused));
+    }
+    let mut object = object.write();
+    let ObjectEntry::Socket(socket) = &mut *object else {
+        return Err(BrokerError::InvalidRights);
+    };
+    if socket.resource_retired {
+        return Ok(SocketOutcome::Completed(socket.connection_status));
+    }
+    if socket.connect_in_flight {
+        return Ok(SocketOutcome::Completed(SocketConnectionStatus::Connecting));
+    }
+    if socket.configuration_in_flight || socket.listening {
+        return Ok(SocketOutcome::Failed(SocketError::Other));
+    }
+    if socket.connection_status != SocketConnectionStatus::Unconnected {
+        return Ok(SocketOutcome::Completed(socket.connection_status));
+    }
+    socket.connection_status = SocketConnectionStatus::Failed(SocketError::ConnectionRefused);
+    Ok(SocketOutcome::Completed(socket.connection_status))
 }
 
 /// Binds a socket to a supported guest-namespace address.
@@ -763,18 +746,14 @@ pub fn listen(
     let mut local_address = existing_local_address;
     let mut port_reservation = None;
     if local_address.is_none() {
-        let binding = match reserve_and_bind(
-            session,
-            create_request,
-            &resource,
-            DEFAULT_TCP_LISTEN_ADDRESS,
-        ) {
-            Ok(binding) => binding,
-            Err(error) => {
-                finish_configuration(&object, None, None, false)?;
-                return Err(error);
-            }
-        };
+        let binding =
+            match reserve_and_bind(session, create_request, &resource, DEFAULT_LOCAL_ADDRESS) {
+                Ok(binding) => binding,
+                Err(error) => {
+                    finish_configuration(&object, None, None, false)?;
+                    return Err(error);
+                }
+            };
         match binding {
             ReserveAndBindOutcome::Completed(address, reservation) => {
                 local_address = Some(address);
@@ -861,7 +840,13 @@ pub fn accept(
             return Err(error);
         }
     };
-    if !listener_resource.port_reservation_covers(accepted.local_address) {
+    let network_config = &session.core.network_config;
+    let Some(remote_address) = guest_remote_address(network_config, accepted.remote) else {
+        accepted.socket.retire();
+        resource.readiness.retire();
+        return Err(BrokerError::Internal);
+    };
+    if !listener_resource.port_reservation_covers(network_config, accepted.local_address) {
         accepted.socket.retire();
         resource.readiness.retire();
         return Err(BrokerError::Internal);
@@ -873,8 +858,24 @@ pub fn accept(
     Ok(SocketOutcome::Completed(AcceptedBrokerSocket {
         handle,
         local_address: accepted.local_address,
-        remote_address: accepted.remote_address,
+        remote_address,
     }))
+}
+
+/// Converts a routed accept source back to one guest-visible peer address.
+///
+/// An accepted connection may only originate inside the guest namespace, and
+/// its route tag must agree with the broker network configuration.
+fn guest_remote_address(
+    config: &BrokerNetworkConfig,
+    remote: SocketDestination,
+) -> Option<SocketAddrV4> {
+    match remote {
+        SocketDestination::Guest { requested } if remote.is_valid_for(config) => Some(requested),
+        SocketDestination::Guest { .. }
+        | SocketDestination::Gateway { .. }
+        | SocketDestination::External { .. } => None,
+    }
 }
 
 /// Sends TCP stream bytes without waiting for readiness.
@@ -908,8 +909,8 @@ pub fn send(
 /// Sends one complete datagram without waiting for readiness.
 ///
 /// The first valid send with an explicit destination on an unbound datagram
-/// socket reserves and binds a guest-visible local endpoint before invoking
-/// the platform.
+/// socket reserves and binds a wildcard guest-visible local endpoint before
+/// invoking the platform.
 pub fn send_to(
     session: &BrokerSession,
     handle: ObjectHandle,
@@ -929,10 +930,24 @@ pub fn send_to(
         };
         socket.create_request
     };
+    let destination = match destination {
+        Some(destination) if destination.port() == 0 => {
+            return Ok(SocketOutcome::Failed(SocketError::InvalidArgument));
+        }
+        Some(destination) => match session
+            .core
+            .network_config
+            .classify_destination(destination)
+        {
+            Ok(destination) => Some(destination),
+            Err(error) => return Ok(SocketOutcome::Failed(error)),
+        },
+        None => None,
+    };
     if let Some(destination) = destination {
         match session.core.policy.authorize_socket_connect(
             session.caller_credential,
-            create_request.protocol,
+            create_request,
             destination,
         ) {
             Ok(()) => {}
@@ -966,12 +981,7 @@ pub fn send_to(
         (Arc::clone(&socket.resource), needs_bind)
     };
     if needs_bind {
-        match reserve_and_bind(
-            session,
-            create_request,
-            &resource,
-            DEFAULT_UDP_LOCAL_ADDRESS,
-        ) {
+        match reserve_and_bind(session, create_request, &resource, DEFAULT_LOCAL_ADDRESS) {
             Ok(ReserveAndBindOutcome::Completed(local_address, reservation)) => {
                 finish_configuration(&object, Some(local_address), Some(reservation), false)?;
             }
@@ -988,6 +998,15 @@ pub fn send_to(
                 finish_configuration(&object, None, None, false)?;
                 return Err(error);
             }
+        }
+    }
+    if let Some(destination) = destination {
+        let binding = resource.guest_binding().ok_or(BrokerError::Internal)?;
+        if binding
+            .concrete_address_for(&session.core.network_config, destination)
+            .is_none()
+        {
+            return Ok(SocketOutcome::Failed(SocketError::InvalidArgument));
         }
     }
     let outcome = resource.send_to(data, flags, destination)?;
@@ -1050,6 +1069,10 @@ pub fn receive(
 }
 
 /// Receives one datagram without waiting for readiness.
+///
+/// The platform's route-tagged source is converted back to a guest-visible
+/// address only after the tag is validated against the broker network
+/// configuration.
 pub fn receive_from(
     session: &BrokerSession,
     handle: ObjectHandle,
@@ -1059,23 +1082,59 @@ pub fn receive_from(
     if flags.has_unsupported_bits() || length > MAX_UDP_DATAGRAM_SIZE as usize {
         return Err(BrokerError::UnsupportedOperation);
     }
-    let (resource, create_request, _, resource_retired) =
-        socket_state(session, handle, ObjectRights::WAIT)?;
+    let object = session.authorized_object(handle, ObjectRights::WAIT)?;
+    let (resource, create_request, resource_retired) = {
+        let object = object.read();
+        let ObjectEntry::Socket(socket) = &*object else {
+            return Err(BrokerError::InvalidRights);
+        };
+        (
+            Arc::clone(&socket.resource),
+            socket.create_request,
+            socket.resource_retired,
+        )
+    };
     if !is_udp(create_request) {
         return Ok(SocketOutcome::Failed(SocketError::InvalidArgument));
     }
     if resource_retired {
         return Ok(SocketOutcome::Failed(SocketError::NotConnected));
     }
-    let outcome = resource.receive_from(length, flags)?;
-    if let SocketOutcome::Completed(received) = &outcome
-        && (received.data.len() > length
-            || received.datagram_length < received.data.len()
-            || received.datagram_length > MAX_UDP_DATAGRAM_SIZE as usize)
-    {
-        return Err(BrokerError::Internal);
+    match resource.receive_from(length, flags)? {
+        SocketOutcome::Completed(received)
+            if received.data.len() <= length
+                && received.datagram_length >= received.data.len()
+                && received.datagram_length <= MAX_UDP_DATAGRAM_SIZE as usize
+                && received.source.is_valid_for(&session.core.network_config) =>
+        {
+            Ok(SocketOutcome::Completed(PlatformDatagramReceive {
+                data: received.data,
+                datagram_length: received.datagram_length,
+                source_address: received.source.requested(),
+            }))
+        }
+        SocketOutcome::Completed(_) => {
+            retire_socket(&object, &resource);
+            Err(BrokerError::Internal)
+        }
+        SocketOutcome::Failed(error) => Ok(SocketOutcome::Failed(error)),
     }
-    Ok(outcome)
+}
+
+/// Ends a socket's platform authority after an unusable platform response.
+fn retire_socket(object: &spin::RwLock<ObjectEntry>, resource: &SocketResource) {
+    {
+        let mut object = object.write();
+        if let ObjectEntry::Socket(socket) = &mut *object {
+            socket.connection_status = SocketConnectionStatus::Failed(SocketError::Other);
+            if is_udp(socket.create_request) {
+                socket.datagram_connect_generation =
+                    socket.datagram_connect_generation.wrapping_add(1);
+            }
+            socket.resource_retired = true;
+        }
+    }
+    resource.retire();
 }
 
 /// Sets a typed option on a broker-owned TCP socket.
@@ -1206,7 +1265,7 @@ pub fn status(session: &BrokerSession, handle: ObjectHandle) -> Result<SocketSta
 
 /// Reconciles broker stream state with an asynchronous platform connection.
 fn stream_status(object: &spin::RwLock<ObjectEntry>) -> Result<SocketStatusResponse> {
-    let (resource, status, local_address, connect_in_flight) = {
+    let (resource, status, local_address, concrete_local_address, connect_in_flight) = {
         let object = object.read();
         let ObjectEntry::Socket(socket) = &*object else {
             return Err(BrokerError::InvalidRights);
@@ -1215,6 +1274,7 @@ fn stream_status(object: &spin::RwLock<ObjectEntry>) -> Result<SocketStatusRespo
             Arc::clone(&socket.resource),
             socket.connection_status,
             socket.local_address,
+            socket.concrete_local_address,
             socket.connect_in_flight,
         )
     };
@@ -1231,7 +1291,7 @@ fn stream_status(object: &spin::RwLock<ObjectEntry>) -> Result<SocketStatusRespo
     ) {
         return Ok(SocketStatusResponse {
             status,
-            local_address,
+            local_address: project_local_address(local_address, concrete_local_address),
             pending_error: None,
         });
     }
@@ -1241,22 +1301,18 @@ fn stream_status(object: &spin::RwLock<ObjectEntry>) -> Result<SocketStatusRespo
     let ObjectEntry::Socket(socket) = &mut *object else {
         return Err(BrokerError::InvalidRights);
     };
-    if let Some(observed) = platform_status.local_address {
-        match socket.local_address {
-            Some(broker_address) if broker_address.ip().is_unspecified() => {
-                if observed.port() != broker_address.port() || !observed.ip().is_loopback() {
-                    socket.listening = false;
-                    socket.connection_status = SocketConnectionStatus::Failed(SocketError::Other);
-                    socket.resource_retired = true;
-                    drop(object);
-                    resource.retire();
-                    return Err(BrokerError::Internal);
-                }
-                socket.local_address = Some(observed);
-            }
-            None => socket.local_address = Some(observed),
-            Some(_) => {}
-        }
+    if !platform_local_address_is_valid(
+        socket.local_address,
+        socket.concrete_local_address,
+        platform_status.local_address,
+    ) {
+        socket.listening = false;
+        socket.connection_status = SocketConnectionStatus::Failed(SocketError::Other);
+        socket.concrete_local_address = None;
+        socket.resource_retired = true;
+        drop(object);
+        resource.retire();
+        return Err(BrokerError::Internal);
     }
     if socket.connection_status == SocketConnectionStatus::Connecting
         && platform_status.status == SocketConnectionStatus::Unconnected
@@ -1269,18 +1325,19 @@ fn stream_status(object: &spin::RwLock<ObjectEntry>) -> Result<SocketStatusRespo
     // Return the latest broker state rather than this potentially stale platform snapshot.
     Ok(SocketStatusResponse {
         status: socket.connection_status,
-        local_address: socket.local_address,
+        local_address: project_local_address(socket.local_address, socket.concrete_local_address),
         pending_error: platform_status.pending_error,
     })
 }
 
-/// Queries datagram errors and address refinement without surrendering the
+/// Queries datagram errors and route selection without surrendering the
 /// broker-owned peer state to a potentially stale platform snapshot.
 fn datagram_status(object: &spin::RwLock<ObjectEntry>) -> Result<SocketStatusResponse> {
     let (
         resource,
         status,
         local_address,
+        concrete_local_address,
         configuration_in_flight,
         datagram_connect_generation,
         resource_retired,
@@ -1293,6 +1350,7 @@ fn datagram_status(object: &spin::RwLock<ObjectEntry>) -> Result<SocketStatusRes
             Arc::clone(&socket.resource),
             socket.connection_status,
             socket.local_address,
+            socket.concrete_local_address,
             socket.configuration_in_flight,
             socket.datagram_connect_generation,
             socket.resource_retired,
@@ -1301,7 +1359,7 @@ fn datagram_status(object: &spin::RwLock<ObjectEntry>) -> Result<SocketStatusRes
     if configuration_in_flight || resource_retired {
         return Ok(SocketStatusResponse {
             status,
-            local_address,
+            local_address: project_local_address(local_address, concrete_local_address),
             pending_error: None,
         });
     }
@@ -1309,7 +1367,7 @@ fn datagram_status(object: &spin::RwLock<ObjectEntry>) -> Result<SocketStatusRes
     let mut retried_datagram_status = false;
     let mut pending_error = None;
     loop {
-        let (resource_retired, status, local_address) = {
+        let (resource_retired, status, local_address, concrete_local_address) = {
             let object = object.read();
             let ObjectEntry::Socket(socket) = &*object else {
                 return Err(BrokerError::InvalidRights);
@@ -1318,12 +1376,13 @@ fn datagram_status(object: &spin::RwLock<ObjectEntry>) -> Result<SocketStatusRes
                 socket.resource_retired,
                 socket.connection_status,
                 socket.local_address,
+                socket.concrete_local_address,
             )
         };
         if resource_retired {
             return Ok(SocketStatusResponse {
                 status,
-                local_address,
+                local_address: project_local_address(local_address, concrete_local_address),
                 pending_error: None,
             });
         }
@@ -1336,44 +1395,22 @@ fn datagram_status(object: &spin::RwLock<ObjectEntry>) -> Result<SocketStatusRes
         if socket.resource_retired {
             return Ok(SocketStatusResponse {
                 status: socket.connection_status,
-                local_address: socket.local_address,
+                local_address: project_local_address(
+                    socket.local_address,
+                    socket.concrete_local_address,
+                ),
                 pending_error: None,
             });
         }
         if socket.configuration_in_flight {
             return Ok(SocketStatusResponse {
                 status: socket.connection_status,
-                local_address: socket.local_address,
+                local_address: project_local_address(
+                    socket.local_address,
+                    socket.concrete_local_address,
+                ),
                 pending_error,
             });
-        }
-        let invalid_local_address = match (socket.local_address, platform_status.local_address) {
-            (None, Some(_)) => true,
-            (Some(broker_address), Some(observed)) if broker_address.port() != observed.port() => {
-                true
-            }
-            _ => false,
-        };
-        if invalid_local_address {
-            socket.configuration_in_flight = false;
-            socket.connection_status = SocketConnectionStatus::Failed(SocketError::Other);
-            socket.datagram_connect_generation = socket.datagram_connect_generation.wrapping_add(1);
-            socket.resource_retired = true;
-            drop(object);
-            resource.retire();
-            return Err(BrokerError::Internal);
-        }
-        let local_address_refinement = match (socket.local_address, platform_status.local_address) {
-            (Some(broker_address), Some(observed)) if broker_address.ip().is_unspecified() => {
-                Some(observed)
-            }
-            _ => None,
-        };
-        if matches!(
-            platform_status.status,
-            SocketConnectionStatus::Connecting | SocketConnectionStatus::Failed(_)
-        ) {
-            return Err(BrokerError::Internal);
         }
         if socket.datagram_connect_generation != expected_datagram_generation {
             if !retried_datagram_status && pending_error.is_none() {
@@ -1385,20 +1422,69 @@ fn datagram_status(object: &spin::RwLock<ObjectEntry>) -> Result<SocketStatusRes
             // Continuous peer replacement can race both bounded queries.
             // Do not let an unordered platform snapshot overwrite newer
             // broker observations.
-            socket.local_address = socket.local_address.or(local_address_refinement);
             return Ok(SocketStatusResponse {
                 status: socket.connection_status,
-                local_address: socket.local_address,
+                local_address: project_local_address(
+                    socket.local_address,
+                    socket.concrete_local_address,
+                ),
                 pending_error,
             });
         }
-        socket.local_address = local_address_refinement.or(socket.local_address);
+        if !platform_local_address_is_valid(
+            socket.local_address,
+            socket.concrete_local_address,
+            platform_status.local_address,
+        ) {
+            socket.configuration_in_flight = false;
+            socket.connection_status = SocketConnectionStatus::Failed(SocketError::Other);
+            socket.concrete_local_address = None;
+            socket.datagram_connect_generation = socket.datagram_connect_generation.wrapping_add(1);
+            socket.resource_retired = true;
+            drop(object);
+            resource.retire();
+            return Err(BrokerError::Internal);
+        }
+        if matches!(
+            platform_status.status,
+            SocketConnectionStatus::Connecting | SocketConnectionStatus::Failed(_)
+        ) {
+            return Err(BrokerError::Internal);
+        }
         return Ok(SocketStatusResponse {
             status: socket.connection_status,
-            local_address: socket.local_address,
+            local_address: project_local_address(
+                socket.local_address,
+                socket.concrete_local_address,
+            ),
             pending_error,
         });
     }
+}
+
+/// Checks a platform observation against the broker-owned local identity.
+///
+/// Core owns the guest-visible local address, so the platform may only echo
+/// the reserved address or the route-selected concrete address.
+fn platform_local_address_is_valid(
+    reserved: Option<SocketAddrV4>,
+    concrete: Option<SocketAddrV4>,
+    platform: Option<SocketAddrV4>,
+) -> bool {
+    match (reserved, concrete, platform) {
+        (_, _, None) => true,
+        (None, _, Some(_)) => false,
+        (Some(reserved), None, Some(platform)) => platform == reserved,
+        (Some(_), Some(concrete), Some(platform)) => platform == concrete,
+    }
+}
+
+/// Projects a wildcard reservation onto its route-selected guest identity.
+fn project_local_address(
+    reserved: Option<SocketAddrV4>,
+    concrete: Option<SocketAddrV4>,
+) -> Option<SocketAddrV4> {
+    concrete.or(reserved)
 }
 
 #[cfg(test)]
@@ -1450,11 +1536,11 @@ fn reserve_and_bind(
     resource: &SocketResource,
     requested_address: SocketAddrV4,
 ) -> Result<ReserveAndBindOutcome> {
-    let (local_address, reservation) = match session
-        .core
-        .socket_ports
-        .reserve(create_request, requested_address)?
-    {
+    let (local_address, reservation) = match session.core.socket_ports.reserve(
+        &session.core.network_config,
+        create_request,
+        requested_address,
+    )? {
         SocketOutcome::Completed(binding) => binding,
         SocketOutcome::Failed(error) => return Ok(ReserveAndBindOutcome::Failed(error)),
     };
@@ -1472,7 +1558,7 @@ fn connect_datagram(
     session: &BrokerSession,
     object: &spin::RwLock<ObjectEntry>,
     create_request: CreateSocketRequest,
-    address: SocketAddrV4,
+    destination: SocketDestination,
 ) -> Result<SocketOutcome<SocketConnectionStatus>> {
     let (resource, previous_status, needs_bind) = {
         let mut object = object.write();
@@ -1493,24 +1579,20 @@ fn connect_datagram(
         )
     };
     if needs_bind {
-        let binding = match reserve_and_bind(
-            session,
-            create_request,
-            &resource,
-            DEFAULT_UDP_LOCAL_ADDRESS,
-        ) {
-            Ok(binding) => binding,
-            Err(error) => {
-                finish_datagram_connect(object, previous_status, false);
-                return Err(error);
-            }
-        };
+        let binding =
+            match reserve_and_bind(session, create_request, &resource, DEFAULT_LOCAL_ADDRESS) {
+                Ok(binding) => binding,
+                Err(error) => {
+                    finish_datagram_connect(object, previous_status, None);
+                    return Err(error);
+                }
+            };
         match binding {
             ReserveAndBindOutcome::Completed(local_address, reservation) => {
                 attach_datagram_binding(object, local_address, reservation)?;
             }
             ReserveAndBindOutcome::Failed(error) => {
-                finish_datagram_connect(object, previous_status, false);
+                finish_datagram_connect(object, previous_status, None);
                 return Ok(SocketOutcome::Failed(error));
             }
             ReserveAndBindOutcome::Retired => {
@@ -1520,13 +1602,30 @@ fn connect_datagram(
             }
         }
     }
-    match resource.connect(address) {
+    let Some(binding) = resource.guest_binding() else {
+        finish_retired_datagram_connect(object);
+        resource.retire();
+        return Err(BrokerError::Internal);
+    };
+    let Some(concrete_local_address) =
+        binding.concrete_address_for(&session.core.network_config, destination)
+    else {
+        // A reserved source that cannot reach this route leaves the existing
+        // peer unchanged instead of selecting another guest identity.
+        finish_datagram_connect(object, previous_status, None);
+        return Ok(SocketOutcome::Failed(SocketError::InvalidArgument));
+    };
+    match resource.connect(destination) {
         Ok(SocketConnectionStatus::Connected) => {
-            finish_datagram_connect(object, SocketConnectionStatus::Connected, true);
+            finish_datagram_connect(
+                object,
+                SocketConnectionStatus::Connected,
+                Some(concrete_local_address),
+            );
             Ok(SocketOutcome::Completed(SocketConnectionStatus::Connected))
         }
         Ok(SocketConnectionStatus::Failed(error)) => {
-            finish_datagram_connect(object, previous_status, false);
+            finish_datagram_connect(object, previous_status, None);
             Ok(SocketOutcome::Failed(error))
         }
         Ok(_) => {
@@ -1535,7 +1634,7 @@ fn connect_datagram(
             Err(BrokerError::Internal)
         }
         Err(PlatformConnectError::PeerUnchanged(error)) => {
-            finish_datagram_connect(object, previous_status, false);
+            finish_datagram_connect(object, previous_status, None);
             Err(error)
         }
         Err(PlatformConnectError::PeerIndeterminate(error)) => {
@@ -1580,13 +1679,14 @@ fn attach_datagram_binding(
 fn finish_datagram_connect(
     object: &spin::RwLock<ObjectEntry>,
     status: SocketConnectionStatus,
-    peer_state_changed: bool,
+    concrete_local_address: Option<SocketAddrV4>,
 ) {
     let mut object = object.write();
     if let ObjectEntry::Socket(socket) = &mut *object {
         socket.configuration_in_flight = false;
         socket.connection_status = status;
-        if peer_state_changed {
+        if let Some(concrete_local_address) = concrete_local_address {
+            socket.concrete_local_address = Some(concrete_local_address);
             // This distinguishes status snapshots from before a successful
             // peer replacement or an indeterminate platform failure. A status
             // call cannot overlap enough connects for wrapping to make a stale
@@ -1601,16 +1701,22 @@ fn finish_retired_datagram_connect(object: &spin::RwLock<ObjectEntry>) {
     if let ObjectEntry::Socket(socket) = &mut *object {
         socket.configuration_in_flight = false;
         socket.connection_status = SocketConnectionStatus::Failed(SocketError::Other);
+        socket.concrete_local_address = None;
         socket.datagram_connect_generation = socket.datagram_connect_generation.wrapping_add(1);
         socket.resource_retired = true;
     }
 }
 
-fn finish_connect(object: &spin::RwLock<ObjectEntry>, status: SocketConnectionStatus) {
+fn finish_connect(
+    object: &spin::RwLock<ObjectEntry>,
+    status: SocketConnectionStatus,
+    concrete_local_address: Option<SocketAddrV4>,
+) {
     let mut object = object.write();
     if let ObjectEntry::Socket(socket) = &mut *object {
         socket.connect_in_flight = false;
         socket.connection_status = status;
+        socket.concrete_local_address = concrete_local_address;
     }
 }
 
@@ -1619,6 +1725,7 @@ fn finish_retired_connect(object: &spin::RwLock<ObjectEntry>) {
     if let ObjectEntry::Socket(socket) = &mut *object {
         socket.connect_in_flight = false;
         socket.connection_status = SocketConnectionStatus::Failed(SocketError::Other);
+        socket.concrete_local_address = None;
         socket.resource_retired = true;
     }
 }
@@ -1641,6 +1748,7 @@ fn attach_binding(
             Err(port_reservation) => {
                 socket.connect_in_flight = false;
                 socket.connection_status = SocketConnectionStatus::Failed(SocketError::Other);
+                socket.concrete_local_address = None;
                 socket.resource_retired = true;
                 Some((Arc::clone(&socket.resource), port_reservation))
             }
@@ -1676,6 +1784,7 @@ fn finish_configuration(
         if duplicate.is_some() {
             socket.listening = false;
             socket.connection_status = SocketConnectionStatus::Failed(SocketError::Other);
+            socket.concrete_local_address = None;
             if is_udp(socket.create_request) {
                 socket.datagram_connect_generation =
                     socket.datagram_connect_generation.wrapping_add(1);
@@ -1716,6 +1825,7 @@ fn finish_retired_configuration(
         socket.local_address = socket.local_address.or(local_address);
         socket.listening = false;
         socket.connection_status = SocketConnectionStatus::Failed(SocketError::Other);
+        socket.concrete_local_address = None;
         if is_udp(socket.create_request) {
             socket.datagram_connect_generation = socket.datagram_connect_generation.wrapping_add(1);
         }
@@ -1739,6 +1849,7 @@ pub(crate) struct SocketObject {
     create_request: CreateSocketRequest,
     connection_status: SocketConnectionStatus,
     local_address: Option<SocketAddrV4>,
+    concrete_local_address: Option<SocketAddrV4>,
     connect_in_flight: bool,
     configuration_in_flight: bool,
     listening: bool,
@@ -1753,6 +1864,7 @@ impl SocketObject {
             create_request,
             connection_status: SocketConnectionStatus::Unconnected,
             local_address: None,
+            concrete_local_address: None,
             connect_in_flight: false,
             configuration_in_flight: false,
             listening: false,
@@ -1771,6 +1883,7 @@ impl SocketObject {
             create_request,
             connection_status: SocketConnectionStatus::Connected,
             local_address: Some(local_address),
+            concrete_local_address: Some(local_address),
             connect_in_flight: false,
             configuration_in_flight: false,
             listening: false,
@@ -1804,11 +1917,19 @@ impl SocketResource {
         Ok(())
     }
 
-    fn port_reservation_covers(&self, address: SocketAddrV4) -> bool {
+    fn guest_binding(&self) -> Option<GuestSocketBinding> {
         self.port_reservation
             .lock()
             .as_ref()
-            .is_some_and(|reservation| reservation.covers(address))
+            .map(GuestSocketBinding::new)
+    }
+
+    fn port_reservation_covers(&self, config: &BrokerNetworkConfig, address: SocketAddrV4) -> bool {
+        self.port_reservation
+            .lock()
+            .as_ref()
+            .map(GuestSocketBinding::new)
+            .is_some_and(|binding| binding.covers(config, address))
     }
 
     fn platform_socket(&self) -> &dyn PlatformSocket {
@@ -1820,9 +1941,9 @@ impl SocketResource {
 
     fn connect(
         &self,
-        address: SocketAddrV4,
+        destination: SocketDestination,
     ) -> core::result::Result<SocketConnectionStatus, PlatformConnectError> {
-        self.platform_socket().connect(address)
+        self.platform_socket().connect(destination)
     }
 
     fn bind(&self, binding: GuestSocketBinding) -> Result<SocketOutcome<SocketAddrV4>> {
@@ -1853,7 +1974,7 @@ impl SocketResource {
         &self,
         data: Vec<u8>,
         flags: SendFlags,
-        destination: Option<SocketAddrV4>,
+        destination: Option<SocketDestination>,
     ) -> Result<SocketOutcome<usize>> {
         self.platform_socket().send_to(data, flags, destination)
     }
@@ -1873,7 +1994,7 @@ impl SocketResource {
         &self,
         length: usize,
         flags: ReceiveFromFlags,
-    ) -> Result<SocketOutcome<PlatformDatagramReceive>> {
+    ) -> Result<SocketOutcome<RoutedPlatformDatagramReceive>> {
         self.platform_socket().receive_from(length, flags)
     }
 
@@ -1990,98 +2111,125 @@ pub(crate) mod tests {
 
     #[test]
     fn guest_transport_port_namespaces_are_broker_wide_and_independent() {
+        let config = BrokerNetworkConfig::default();
         let ports = BrokerSocketPorts::default();
         let address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 80);
 
         let SocketOutcome::Completed((_, first_reservation)) =
-            ports.reserve(create_request(), address).unwrap()
+            ports.reserve(&config, create_request(), address).unwrap()
         else {
             panic!("first TCP reservation failed");
         };
         assert!(matches!(
-            ports.reserve(create_request(), address),
+            ports.reserve(&config, create_request(), address),
             Ok(SocketOutcome::Failed(SocketError::AddressInUse))
         ));
-        let SocketOutcome::Completed((_, udp_reservation)) =
-            ports.reserve(create_udp_request(), address).unwrap()
+        let SocketOutcome::Completed((_, udp_reservation)) = ports
+            .reserve(&config, create_udp_request(), address)
+            .unwrap()
         else {
             panic!("UDP reservation must be independent from TCP");
         };
         assert!(matches!(
-            ports.reserve(create_udp_request(), address),
+            ports.reserve(&config, create_udp_request(), address),
             Ok(SocketOutcome::Failed(SocketError::AddressInUse))
         ));
 
         drop(first_reservation);
         assert!(matches!(
-            ports.reserve(create_request(), address),
+            ports.reserve(&config, create_request(), address),
             Ok(SocketOutcome::Completed(_))
         ));
         assert!(matches!(
-            ports.reserve(create_udp_request(), address),
+            ports.reserve(&config, create_udp_request(), address),
             Ok(SocketOutcome::Failed(SocketError::AddressInUse))
         ));
         drop(udp_reservation);
         assert!(matches!(
-            ports.reserve(create_udp_request(), address),
+            ports.reserve(&config, create_udp_request(), address),
             Ok(SocketOutcome::Completed(_))
         ));
     }
 
     #[test]
-    fn guest_binding_namespaces_support_exact_and_wildcard_loopback() {
+    fn guest_binding_namespaces_support_exact_and_wildcard_guest_addresses() {
+        let config = BrokerNetworkConfig::default();
         let ports = BrokerSocketPorts::default();
         let first = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8080);
         let second = SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 2), 8080);
+        let private = SocketAddrV4::new(config.guest_ipv4_address(), 8080);
         let wildcard = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 8080);
 
         let SocketOutcome::Completed((_, first_lease)) =
-            ports.reserve(create_request(), first).unwrap()
+            ports.reserve(&config, create_request(), first).unwrap()
         else {
             panic!("first exact reservation failed");
         };
         let SocketOutcome::Completed((_, second_lease)) =
-            ports.reserve(create_request(), second).unwrap()
+            ports.reserve(&config, create_request(), second).unwrap()
         else {
             panic!("second exact reservation failed");
         };
+        let SocketOutcome::Completed((_, private_lease)) =
+            ports.reserve(&config, create_request(), private).unwrap()
+        else {
+            panic!("private guest reservation failed");
+        };
         assert!(matches!(
-            ports.reserve(create_request(), wildcard),
+            ports.reserve(&config, create_request(), wildcard),
+            Ok(SocketOutcome::Failed(SocketError::AddressInUse))
+        ));
+        assert!(matches!(
+            ports.reserve(&config, create_request(), private),
             Ok(SocketOutcome::Failed(SocketError::AddressInUse))
         ));
 
         drop(first_lease);
         drop(second_lease);
+        drop(private_lease);
         let SocketOutcome::Completed((_, wildcard_lease)) =
-            ports.reserve(create_request(), wildcard).unwrap()
+            ports.reserve(&config, create_request(), wildcard).unwrap()
         else {
             panic!("wildcard reservation failed");
         };
         assert!(matches!(
-            ports.reserve(create_request(), first),
+            ports.reserve(&config, create_request(), first),
             Ok(SocketOutcome::Failed(SocketError::AddressInUse))
         ));
-        assert!(wildcard_lease.covers(first));
-        assert!(wildcard_lease.covers(second));
+        assert!(matches!(
+            ports.reserve(&config, create_request(), private),
+            Ok(SocketOutcome::Failed(SocketError::AddressInUse))
+        ));
+        let wildcard_binding = GuestSocketBinding::new(&wildcard_lease);
+        assert!(wildcard_binding.covers(&config, first));
+        assert!(wildcard_binding.covers(&config, second));
+        assert!(wildcard_binding.covers(&config, private));
     }
 
     #[test]
     fn guest_binding_validation_and_ephemeral_allocation_are_address_aware() {
+        let config = BrokerNetworkConfig::default();
         let ports = BrokerSocketPorts::default();
-        let invalid = SocketAddrV4::new(Ipv4Addr::new(192, 0, 2, 1), 8080);
-        assert!(matches!(
-            ports.reserve(create_request(), invalid),
-            Ok(SocketOutcome::Failed(SocketError::AddressNotAvailable))
-        ));
+        for invalid in [
+            SocketAddrV4::new(Ipv4Addr::new(192, 0, 2, 1), 8080),
+            SocketAddrV4::new(config.gateway_ipv4_address(), 8080),
+            SocketAddrV4::new(Ipv4Addr::BROADCAST, 8080),
+        ] {
+            assert!(matches!(
+                ports.reserve(&config, create_request(), invalid),
+                Ok(SocketOutcome::Failed(SocketError::AddressNotAvailable))
+            ));
+        }
 
         let occupied = SocketAddrV4::new(Ipv4Addr::LOCALHOST, FIRST_EPHEMERAL_PORT);
         let SocketOutcome::Completed((_, occupied_lease)) =
-            ports.reserve(create_request(), occupied).unwrap()
+            ports.reserve(&config, create_request(), occupied).unwrap()
         else {
             panic!("exact reservation failed");
         };
         let SocketOutcome::Completed((wildcard, wildcard_lease)) = ports
             .reserve(
+                &config,
                 create_request(),
                 SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0),
             )
@@ -2090,25 +2238,39 @@ pub(crate) mod tests {
             panic!("wildcard ephemeral reservation failed");
         };
         assert_eq!(wildcard.port(), FIRST_EPHEMERAL_PORT + 1);
+        let SocketOutcome::Completed((private, private_lease)) = ports
+            .reserve(
+                &config,
+                create_request(),
+                SocketAddrV4::new(config.guest_ipv4_address(), 0),
+            )
+            .unwrap()
+        else {
+            panic!("private guest ephemeral reservation failed");
+        };
+        assert_eq!(*private.ip(), config.guest_ipv4_address());
+        assert_eq!(private.port(), FIRST_EPHEMERAL_PORT + 2);
         drop(occupied_lease);
         drop(wildcard_lease);
+        drop(private_lease);
     }
 
     #[test]
     fn provider_binding_metadata_does_not_own_the_reservation() {
+        let config = BrokerNetworkConfig::default();
         let ports = BrokerSocketPorts::default();
         let address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8080);
         let SocketOutcome::Completed((_, reservation)) =
-            ports.reserve(create_request(), address).unwrap()
+            ports.reserve(&config, create_request(), address).unwrap()
         else {
             panic!("reservation failed");
         };
         let binding = GuestSocketBinding::new(&reservation);
         drop(reservation);
-        assert!(binding.is_valid());
-        assert!(binding.covers(address));
+        assert!(binding.is_valid_for(&config));
+        assert!(binding.covers(&config, address));
         assert!(matches!(
-            ports.reserve(create_request(), address),
+            ports.reserve(&config, create_request(), address),
             Ok(SocketOutcome::Completed(_))
         ));
     }
@@ -2124,6 +2286,9 @@ pub(crate) mod tests {
         closed_sessions: StdMutex<std::vec::Vec<SessionId>>,
         sent: StdMutex<std::vec::Vec<u8>>,
         connect_calls: AtomicUsize,
+        connect_destinations: StdMutex<std::vec::Vec<SocketDestination>>,
+        send_to_destinations: StdMutex<std::vec::Vec<Option<SocketDestination>>>,
+        datagram_source: StdMutex<Option<SocketDestination>>,
         status_calls: AtomicUsize,
         status_responses: StdMutex<std::collections::VecDeque<PlatformSocketStatus>>,
         status_block: StdMutex<Option<(mpsc::Sender<()>, mpsc::Receiver<()>)>>,
@@ -2179,6 +2344,10 @@ pub(crate) mod tests {
 
         fn retain_next_socket(&self) {
             self.state.retain_next_socket.store(true, Ordering::Relaxed);
+        }
+
+        fn return_datagram_source_once(&self, source: SocketDestination) {
+            *self.state.datagram_source.lock().unwrap() = Some(source);
         }
     }
 
@@ -2292,9 +2461,14 @@ pub(crate) mod tests {
 
         fn connect(
             &self,
-            _address: SocketAddrV4,
+            destination: SocketDestination,
         ) -> core::result::Result<SocketConnectionStatus, PlatformConnectError> {
             self.state.connect_calls.fetch_add(1, Ordering::Relaxed);
+            self.state
+                .connect_destinations
+                .lock()
+                .unwrap()
+                .push(destination);
             if self.state.fail_connect.swap(false, Ordering::Relaxed) {
                 return Err(PlatformConnectError::PeerUnchanged(BrokerError::Internal));
             }
@@ -2333,8 +2507,13 @@ pub(crate) mod tests {
             &self,
             data: Vec<u8>,
             _flags: SendFlags,
-            _destination: Option<SocketAddrV4>,
+            destination: Option<SocketDestination>,
         ) -> Result<SocketOutcome<usize>> {
+            self.state
+                .send_to_destinations
+                .lock()
+                .unwrap()
+                .push(destination);
             self.state.sent.lock().unwrap().extend_from_slice(&data);
             Ok(SocketOutcome::Completed(data.len()))
         }
@@ -2356,12 +2535,17 @@ pub(crate) mod tests {
             &self,
             length: usize,
             _flags: ReceiveFromFlags,
-        ) -> Result<SocketOutcome<PlatformDatagramReceive>> {
+        ) -> Result<SocketOutcome<RoutedPlatformDatagramReceive>> {
             let received = length.min(2);
-            Ok(SocketOutcome::Completed(PlatformDatagramReceive {
+            let source = self.state.datagram_source.lock().unwrap().take().unwrap_or(
+                SocketDestination::Guest {
+                    requested: SocketAddrV4::new(Ipv4Addr::LOCALHOST, 49153),
+                },
+            );
+            Ok(SocketOutcome::Completed(RoutedPlatformDatagramReceive {
                 data: [7, 9][..received].to_vec(),
                 datagram_length: 4,
-                source_address: SocketAddrV4::new(Ipv4Addr::LOCALHOST, 49153),
+                source,
             }))
         }
 
@@ -2436,6 +2620,10 @@ pub(crate) mod tests {
         check_failed_create_rolls_back(broker, provider);
         check_socket_operations_and_policy(broker, provider);
         check_tcp_option_state_is_per_socket(broker);
+        check_invalid_destinations_never_reach_the_platform(broker, provider);
+        check_private_guest_bind_is_socket_admission_based(broker, provider);
+        check_implicit_binds_reserve_the_guest_wildcard(broker, provider);
+        check_malformed_datagram_source_fails_closed(broker, provider);
         check_udp_socket_operations(broker, provider);
         check_udp_status_validates_local_address(broker, provider);
         check_concurrent_udp_status_does_not_regress_connection(broker, provider);
@@ -2632,7 +2820,7 @@ pub(crate) mod tests {
         let duplicate_ports = BrokerSocketPorts::default();
         let duplicate_address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 42002);
         let SocketOutcome::Completed((duplicate_address, duplicate_reservation)) = duplicate_ports
-            .reserve(create_request(), duplicate_address)
+            .reserve(&broker.network_config, create_request(), duplicate_address)
             .unwrap()
         else {
             panic!("duplicate-reservation test could not reserve a port");
@@ -2660,11 +2848,11 @@ pub(crate) mod tests {
         assert!(matches!(
             broker
                 .socket_ports
-                .reserve(create_request(), original_address),
+                .reserve(&broker.network_config, create_request(), original_address),
             Ok(SocketOutcome::Completed(_))
         ));
         assert!(matches!(
-            duplicate_ports.reserve(create_request(), duplicate_address),
+            duplicate_ports.reserve(&broker.network_config, create_request(), duplicate_address),
             Ok(SocketOutcome::Completed(_))
         ));
 
@@ -2711,13 +2899,29 @@ pub(crate) mod tests {
             connect(&session, handle, loopback_address()),
             Ok(SocketOutcome::Completed(SocketConnectionStatus::Connecting))
         );
-        let local_address = *provider
+        let reserved_address = *provider
             .state
             .binds
             .lock()
             .unwrap()
             .last()
             .expect("automatic TCP bind was not recorded");
+        // An implicit connect bind reserves the guest wildcard address and the
+        // guest-visible local identity follows the selected loopback route.
+        assert!(reserved_address.ip().is_unspecified());
+        let local_address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, reserved_address.port());
+        assert_eq!(
+            provider
+                .state
+                .connect_destinations
+                .lock()
+                .unwrap()
+                .last()
+                .copied(),
+            Some(SocketDestination::Guest {
+                requested: loopback_address()
+            })
+        );
         assert_eq!(
             readiness.published.lock().unwrap().as_slice(),
             [(handle, ReadinessFlags::WRITE)]
@@ -2855,6 +3059,356 @@ pub(crate) mod tests {
         assert_eq!(session.close_object_reference(second), Ok(()));
     }
 
+    fn check_invalid_destinations_never_reach_the_platform(
+        broker: &BrokerCore,
+        provider: &TestSocketProvider,
+    ) {
+        let session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let stream = create(
+            &session,
+            create_request(),
+            Arc::new(TestReadinessSink::default()),
+        )
+        .unwrap();
+        let connect_calls = provider.state.connect_calls.load(Ordering::Relaxed);
+        let binds = provider.state.binds.lock().unwrap().len();
+        let unroutable = [
+            SocketAddrV4::new(Ipv4Addr::BROADCAST, 80),
+            SocketAddrV4::new(Ipv4Addr::new(224, 0, 0, 1), 80),
+            SocketAddrV4::new(Ipv4Addr::new(240, 0, 0, 1), 80),
+            SocketAddrV4::new(Ipv4Addr::new(0, 1, 2, 3), 80),
+        ];
+        for invalid in unroutable {
+            assert_eq!(
+                connect(&session, stream, invalid),
+                Ok(SocketOutcome::Failed(SocketError::InvalidArgument))
+            );
+        }
+        // Loopback policy denies the private guest address and the gateway
+        // before any local endpoint or platform call exists.
+        for denied in [
+            SocketAddrV4::new(broker.network_config.guest_ipv4_address(), 80),
+            SocketAddrV4::new(broker.network_config.gateway_ipv4_address(), 80),
+        ] {
+            assert_eq!(
+                connect(&session, stream, denied),
+                Ok(SocketOutcome::Failed(SocketError::PolicyDenied))
+            );
+        }
+        // A stream connect to the reserved port is an ordinary refusal.
+        assert_eq!(
+            connect(&session, stream, SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0)),
+            Ok(SocketOutcome::Completed(SocketConnectionStatus::Failed(
+                SocketError::ConnectionRefused
+            )))
+        );
+        assert_eq!(
+            status(&session, stream),
+            Ok(SocketStatusResponse {
+                status: SocketConnectionStatus::Failed(SocketError::ConnectionRefused),
+                local_address: None,
+                pending_error: None,
+            })
+        );
+        assert_eq!(
+            provider.state.connect_calls.load(Ordering::Relaxed),
+            connect_calls
+        );
+        assert_eq!(provider.state.binds.lock().unwrap().len(), binds);
+        session.close_object_reference(stream).unwrap();
+
+        let datagram = create(
+            &session,
+            create_udp_request(),
+            Arc::new(TestReadinessSink::default()),
+        )
+        .unwrap();
+        let sent = provider.state.sent.lock().unwrap().len();
+        for invalid in unroutable
+            .into_iter()
+            .chain([SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0)])
+        {
+            assert_eq!(
+                send_to(
+                    &session,
+                    datagram,
+                    b"x".to_vec(),
+                    SendFlags::NONE,
+                    Some(invalid),
+                ),
+                Ok(SocketOutcome::Failed(SocketError::InvalidArgument))
+            );
+            assert_eq!(
+                connect(&session, datagram, invalid),
+                Ok(SocketOutcome::Failed(if invalid.port() == 0 {
+                    SocketError::ConnectionRefused
+                } else {
+                    SocketError::InvalidArgument
+                }))
+            );
+        }
+        assert_eq!(
+            status(&session, datagram),
+            Ok(SocketStatusResponse {
+                status: SocketConnectionStatus::Unconnected,
+                local_address: None,
+                pending_error: None,
+            })
+        );
+        assert_eq!(provider.state.sent.lock().unwrap().len(), sent);
+        assert_eq!(
+            provider.state.connect_calls.load(Ordering::Relaxed),
+            connect_calls
+        );
+        assert_eq!(provider.state.binds.lock().unwrap().len(), binds);
+        session.close_object_reference(datagram).unwrap();
+    }
+
+    fn check_private_guest_bind_is_socket_admission_based(
+        broker: &BrokerCore,
+        provider: &TestSocketProvider,
+    ) {
+        let session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let handle = create(
+            &session,
+            create_request(),
+            Arc::new(TestReadinessSink::default()),
+        )
+        .unwrap();
+        let private_address = SocketAddrV4::new(broker.network_config.guest_ipv4_address(), 41000);
+        // Bind authority follows socket admission, so literal loopback policy
+        // still reserves the configured private guest address.
+        assert_eq!(
+            bind(&session, handle, private_address),
+            Ok(SocketOutcome::Completed(private_address))
+        );
+        assert_eq!(
+            provider.state.binds.lock().unwrap().last(),
+            Some(&private_address)
+        );
+        // Routing to that address is a separate, denied decision.
+        assert_eq!(
+            connect(
+                &session,
+                handle,
+                SocketAddrV4::new(broker.network_config.guest_ipv4_address(), 80),
+            ),
+            Ok(SocketOutcome::Failed(SocketError::PolicyDenied))
+        );
+        // An exact private binding keeps its own source on a loopback route.
+        assert_eq!(
+            connect(&session, handle, loopback_address()),
+            Ok(SocketOutcome::Completed(SocketConnectionStatus::Connecting))
+        );
+        assert_eq!(
+            status(&session, handle).unwrap().local_address,
+            Some(private_address)
+        );
+        session.close_object_reference(handle).unwrap();
+
+        let gateway = create(
+            &session,
+            create_request(),
+            Arc::new(TestReadinessSink::default()),
+        )
+        .unwrap();
+        let binds = provider.state.binds.lock().unwrap().len();
+        assert_eq!(
+            bind(
+                &session,
+                gateway,
+                SocketAddrV4::new(broker.network_config.gateway_ipv4_address(), 41000),
+            ),
+            Ok(SocketOutcome::Failed(SocketError::AddressNotAvailable))
+        );
+        assert_eq!(provider.state.binds.lock().unwrap().len(), binds);
+        session.close_object_reference(gateway).unwrap();
+    }
+
+    fn check_implicit_binds_reserve_the_guest_wildcard(
+        broker: &BrokerCore,
+        provider: &TestSocketProvider,
+    ) {
+        let session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let listener = create(
+            &session,
+            create_request(),
+            Arc::new(TestReadinessSink::default()),
+        )
+        .unwrap();
+        let SocketOutcome::Completed(listen_address) = listen(&session, listener, 4).unwrap()
+        else {
+            panic!("implicit TCP listen bind failed");
+        };
+        assert!(listen_address.ip().is_unspecified());
+        assert_ne!(listen_address.port(), 0);
+        assert_eq!(
+            provider.state.binds.lock().unwrap().last(),
+            Some(&listen_address)
+        );
+        session.close_object_reference(listener).unwrap();
+
+        let datagram = create(
+            &session,
+            create_udp_request(),
+            Arc::new(TestReadinessSink::default()),
+        )
+        .unwrap();
+        // A normalized wildcard destination becomes the loopback guest route.
+        assert_eq!(
+            send_to(
+                &session,
+                datagram,
+                b"x".to_vec(),
+                SendFlags::NONE,
+                Some(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 53)),
+            ),
+            Ok(SocketOutcome::Completed(1))
+        );
+        let reserved_address = *provider
+            .state
+            .binds
+            .lock()
+            .unwrap()
+            .last()
+            .expect("implicit UDP bind was not recorded");
+        assert!(reserved_address.ip().is_unspecified());
+        assert_eq!(
+            provider
+                .state
+                .send_to_destinations
+                .lock()
+                .unwrap()
+                .last()
+                .copied(),
+            Some(Some(SocketDestination::Guest {
+                requested: SocketAddrV4::new(Ipv4Addr::LOCALHOST, 53)
+            }))
+        );
+        // An unconnected datagram socket keeps its reserved wildcard identity.
+        assert_eq!(
+            status(&session, datagram).unwrap().local_address,
+            Some(reserved_address)
+        );
+        assert_eq!(
+            connect(
+                &session,
+                datagram,
+                SocketAddrV4::new(Ipv4Addr::LOCALHOST, 53),
+            ),
+            Ok(SocketOutcome::Completed(SocketConnectionStatus::Connected))
+        );
+        assert_eq!(
+            status(&session, datagram).unwrap().local_address,
+            Some(SocketAddrV4::new(
+                Ipv4Addr::LOCALHOST,
+                reserved_address.port()
+            ))
+        );
+        session.close_object_reference(datagram).unwrap();
+    }
+
+    fn check_malformed_datagram_source_fails_closed(
+        broker: &BrokerCore,
+        provider: &TestSocketProvider,
+    ) {
+        let session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let handle = create(
+            &session,
+            create_udp_request(),
+            Arc::new(TestReadinessSink::default()),
+        )
+        .unwrap();
+        assert_eq!(
+            send_to(
+                &session,
+                handle,
+                b"x".to_vec(),
+                SendFlags::NONE,
+                Some(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 53)),
+            ),
+            Ok(SocketOutcome::Completed(1))
+        );
+        assert_eq!(
+            receive_from(&session, handle, 2, ReceiveFromFlags::NONE),
+            Ok(SocketOutcome::Completed(PlatformDatagramReceive {
+                data: vec![7, 9],
+                datagram_length: 4,
+                source_address: SocketAddrV4::new(Ipv4Addr::LOCALHOST, 49153),
+            }))
+        );
+
+        // A route tag that disagrees with the broker configuration is never
+        // translated back into a guest-visible source.
+        provider.return_datagram_source_once(SocketDestination::External {
+            requested: SocketAddrV4::new(Ipv4Addr::LOCALHOST, 49153),
+        });
+        let retired_before = provider.state.retired_sockets.load(Ordering::Relaxed);
+        assert_eq!(
+            receive_from(&session, handle, 2, ReceiveFromFlags::NONE),
+            Err(BrokerError::Internal)
+        );
+        assert_eq!(
+            provider.state.retired_sockets.load(Ordering::Relaxed),
+            retired_before + 1
+        );
+        assert_eq!(
+            receive_from(&session, handle, 2, ReceiveFromFlags::NONE),
+            Ok(SocketOutcome::Failed(SocketError::NotConnected))
+        );
+        assert_eq!(
+            status(&session, handle).unwrap().status,
+            SocketConnectionStatus::Failed(SocketError::Other)
+        );
+        session.close_object_reference(handle).unwrap();
+        assert_eq!(
+            provider.state.retired_sockets.load(Ordering::Relaxed),
+            retired_before + 1
+        );
+    }
+
+    #[test]
+    fn routed_accept_sources_must_be_valid_guest_routes() {
+        let config = BrokerNetworkConfig::default();
+        let loopback = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 49153);
+        let private = SocketAddrV4::new(config.guest_ipv4_address(), 49153);
+        let gateway = SocketAddrV4::new(config.gateway_ipv4_address(), 49153);
+        let external = SocketAddrV4::new(Ipv4Addr::new(203, 0, 113, 9), 49153);
+
+        for guest in [loopback, private] {
+            assert_eq!(
+                guest_remote_address(&config, SocketDestination::Guest { requested: guest }),
+                Some(guest)
+            );
+        }
+        for malformed in [
+            SocketDestination::Guest { requested: gateway },
+            SocketDestination::Guest {
+                requested: external,
+            },
+            SocketDestination::Guest {
+                requested: SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 49153),
+            },
+            SocketDestination::Gateway { requested: gateway },
+            SocketDestination::External {
+                requested: external,
+            },
+            SocketDestination::External {
+                requested: loopback,
+            },
+        ] {
+            assert_eq!(guest_remote_address(&config, malformed), None);
+        }
+    }
+
     fn check_udp_socket_operations(broker: &BrokerCore, provider: &TestSocketProvider) {
         let connect_calls_before = provider.state.connect_calls.load(Ordering::Relaxed);
         let session = broker
@@ -2900,6 +3454,14 @@ pub(crate) mod tests {
             ),
             Ok(SocketOutcome::Completed(3))
         );
+        let reserved_address = *provider
+            .state
+            .binds
+            .lock()
+            .unwrap()
+            .last()
+            .expect("implicit UDP bind was not recorded");
+        assert!(reserved_address.ip().is_unspecified());
         assert_eq!(
             receive_from(&session, handle, 2, ReceiveFromFlags::PEEK),
             Ok(SocketOutcome::Completed(PlatformDatagramReceive {
@@ -2934,7 +3496,7 @@ pub(crate) mod tests {
             status(&session, handle),
             Ok(SocketStatusResponse {
                 status: SocketConnectionStatus::Failed(SocketError::Other),
-                local_address: Some(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 49152)),
+                local_address: Some(reserved_address),
                 pending_error: None,
             })
         );
@@ -3131,7 +3693,7 @@ pub(crate) mod tests {
             .unwrap()
             .push_back(PlatformSocketStatus {
                 status: SocketConnectionStatus::Unconnected,
-                local_address: Some(SocketAddrV4::new(Ipv4Addr::LOCALHOST, exact_address.port())),
+                local_address: Some(exact_address),
                 pending_error: None,
             });
         let retired_before = provider.state.retired_sockets.load(Ordering::Relaxed);
@@ -3147,12 +3709,30 @@ pub(crate) mod tests {
             provider.state.retired_sockets.load(Ordering::Relaxed),
             retired_before
         );
+        // Core owns the guest-visible identity, so a platform observation that
+        // renames an exact binding fails closed.
+        provider
+            .state
+            .status_responses
+            .lock()
+            .unwrap()
+            .push_back(PlatformSocketStatus {
+                status: SocketConnectionStatus::Unconnected,
+                local_address: Some(SocketAddrV4::new(Ipv4Addr::LOCALHOST, exact_address.port())),
+                pending_error: None,
+            });
+        assert_eq!(status(&session, exact), Err(BrokerError::Internal));
+        assert_eq!(
+            provider.state.retired_sockets.load(Ordering::Relaxed),
+            retired_before + 1
+        );
         session.close_object_reference(exact).unwrap();
 
-        for observed_ip in [
-            Ipv4Addr::UNSPECIFIED,
-            Ipv4Addr::LOCALHOST,
-            Ipv4Addr::new(10, 0, 0, 1),
+        for (observed_ip, valid) in [
+            (Ipv4Addr::UNSPECIFIED, true),
+            (Ipv4Addr::LOCALHOST, false),
+            (broker.network_config.guest_ipv4_address(), false),
+            (Ipv4Addr::new(10, 0, 0, 1), false),
         ] {
             let wildcard = create(
                 &session,
@@ -3180,18 +3760,28 @@ pub(crate) mod tests {
                     pending_error: None,
                 });
             let retired_before = provider.state.retired_sockets.load(Ordering::Relaxed);
-            assert_eq!(
-                status(&session, wildcard),
-                Ok(SocketStatusResponse {
-                    status: SocketConnectionStatus::Unconnected,
-                    local_address: Some(observed_address),
-                    pending_error: None,
-                })
-            );
-            assert_eq!(
-                provider.state.retired_sockets.load(Ordering::Relaxed),
-                retired_before
-            );
+            // An unconnected wildcard socket has selected no route, so only the
+            // reserved guest identity is an acceptable observation.
+            if valid {
+                assert_eq!(
+                    status(&session, wildcard),
+                    Ok(SocketStatusResponse {
+                        status: SocketConnectionStatus::Unconnected,
+                        local_address: Some(wildcard_address),
+                        pending_error: None,
+                    })
+                );
+                assert_eq!(
+                    provider.state.retired_sockets.load(Ordering::Relaxed),
+                    retired_before
+                );
+            } else {
+                assert_eq!(status(&session, wildcard), Err(BrokerError::Internal));
+                assert_eq!(
+                    provider.state.retired_sockets.load(Ordering::Relaxed),
+                    retired_before + 1
+                );
+            }
             session.close_object_reference(wildcard).unwrap();
         }
     }
@@ -3346,20 +3936,23 @@ pub(crate) mod tests {
             connect(&session, handle, loopback_address()),
             Ok(SocketOutcome::Completed(SocketConnectionStatus::Connected))
         );
-        let local_address = *provider
+        let reserved_address = *provider
             .state
             .binds
             .lock()
             .unwrap()
             .last()
             .expect("automatic UDP bind was not recorded");
+        assert!(reserved_address.ip().is_unspecified());
+        // The connected loopback route selects the loopback guest identity.
+        let local_address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, reserved_address.port());
         release_tx.send(()).unwrap();
         let stale = in_flight.join().unwrap();
         assert_eq!(stale.status, SocketConnectionStatus::Connected);
         assert_eq!(stale.local_address, Some(local_address));
         assert_eq!(stale.pending_error, None);
 
-        let next_local_address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, local_address.port());
+        let next_local_address = local_address;
         let stale_local_address =
             SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 2), local_address.port());
         *provider.state.status_responses.lock().unwrap() = std::collections::VecDeque::from([
@@ -3775,14 +4368,16 @@ pub(crate) mod tests {
             Ok(SocketOutcome::Completed(SocketConnectionStatus::Connecting))
         );
 
-        let local_address = *provider
+        let reserved_address = *provider
             .state
             .binds
             .lock()
             .unwrap()
             .last()
             .expect("automatic TCP bind was not recorded");
-        let platform_local_address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 49152);
+        assert!(reserved_address.ip().is_unspecified());
+        let local_address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, reserved_address.port());
+        let platform_local_address = local_address;
         *provider.state.status_responses.lock().unwrap() = std::collections::VecDeque::from([
             PlatformSocketStatus {
                 status: SocketConnectionStatus::Connecting,
@@ -3881,6 +4476,11 @@ pub(crate) mod tests {
                 Ipv4Addr::new(10, 0, 0, 1),
                 false,
             ),
+            (
+                SocketConnectionStatus::Connected,
+                broker.network_config.guest_ipv4_address(),
+                false,
+            ),
             (SocketConnectionStatus::Connected, Ipv4Addr::LOCALHOST, true),
         ] {
             let handle = create(
@@ -3970,13 +4570,15 @@ pub(crate) mod tests {
             Ok(SocketOutcome::Completed(SocketConnectionStatus::Connecting))
         );
 
-        let local_address = *provider
+        let reserved_address = *provider
             .state
             .binds
             .lock()
             .unwrap()
             .last()
             .expect("automatic TCP bind was not recorded");
+        assert!(reserved_address.ip().is_unspecified());
+        let local_address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, reserved_address.port());
         provider
             .state
             .status_responses
@@ -3984,7 +4586,7 @@ pub(crate) mod tests {
             .unwrap()
             .push_back(PlatformSocketStatus {
                 status: SocketConnectionStatus::Failed(SocketError::TimedOut),
-                local_address: Some(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 49153)),
+                local_address: Some(local_address),
                 pending_error: None,
             });
 

--- a/litebox_broker_core/src/socket/network.rs
+++ b/litebox_broker_core/src/socket/network.rs
@@ -1,0 +1,520 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//! Broker-owned IPv4 identity and trusted socket routing values.
+
+use core::fmt;
+use core::net::{Ipv4Addr, SocketAddrV4};
+
+use litebox_broker_protocol::socket::SocketError;
+
+use super::{GuestBindingReservation, GuestTransport};
+
+/// Immutable network identity shared by broker core and its socket provider.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BrokerNetworkConfig {
+    guest_ipv4_address: Ipv4Addr,
+    gateway_ipv4_address: Ipv4Addr,
+}
+
+impl BrokerNetworkConfig {
+    /// Creates a configuration for distinct RFC1918 guest and gateway addresses.
+    #[must_use]
+    pub fn new(guest_ipv4_address: Ipv4Addr, gateway_ipv4_address: Ipv4Addr) -> Option<Self> {
+        if !is_private_unicast(guest_ipv4_address)
+            || !is_private_unicast(gateway_ipv4_address)
+            || guest_ipv4_address == gateway_ipv4_address
+        {
+            return None;
+        }
+        Some(Self {
+            guest_ipv4_address,
+            gateway_ipv4_address,
+        })
+    }
+
+    /// Returns the broker-wide guest IPv4 identity.
+    #[must_use]
+    pub const fn guest_ipv4_address(&self) -> Ipv4Addr {
+        self.guest_ipv4_address
+    }
+
+    /// Returns the guest-visible gateway IPv4 address.
+    #[must_use]
+    pub const fn gateway_ipv4_address(&self) -> Ipv4Addr {
+        self.gateway_ipv4_address
+    }
+
+    /// Normalizes and classifies one guest-requested destination.
+    ///
+    /// A nonzero unspecified destination becomes loopback, and destination
+    /// classes that no broker route can represent are rejected before any
+    /// provider dispatch.
+    pub(crate) fn classify_destination(
+        &self,
+        requested: SocketAddrV4,
+    ) -> Result<SocketDestination, SocketError> {
+        if requested.port() == 0 {
+            return Err(SocketError::InvalidArgument);
+        }
+        let requested = if requested.ip().is_unspecified() {
+            SocketAddrV4::new(Ipv4Addr::LOCALHOST, requested.port())
+        } else {
+            requested
+        };
+        if is_invalid_destination(*requested.ip()) {
+            return Err(SocketError::InvalidArgument);
+        }
+        if self.is_guest_local_ip(*requested.ip()) {
+            Ok(SocketDestination::Guest { requested })
+        } else if *requested.ip() == self.gateway_ipv4_address {
+            Ok(SocketDestination::Gateway { requested })
+        } else {
+            Ok(SocketDestination::External { requested })
+        }
+    }
+
+    /// Returns whether an address may be reserved in a guest binding namespace.
+    pub(crate) fn binding_is_valid(&self, requested: SocketAddrV4) -> bool {
+        requested.ip().is_unspecified() || self.is_guest_local_ip(*requested.ip())
+    }
+
+    /// Returns whether one concrete address names this broker's guest identity.
+    pub(crate) fn is_guest_local_ip(&self, address: Ipv4Addr) -> bool {
+        address.is_loopback() || address == self.guest_ipv4_address
+    }
+}
+
+impl Default for BrokerNetworkConfig {
+    fn default() -> Self {
+        Self::new(Ipv4Addr::new(10, 0, 2, 15), Ipv4Addr::new(10, 0, 2, 1))
+            .expect("the default broker network addresses are valid")
+    }
+}
+
+fn is_private_unicast(address: Ipv4Addr) -> bool {
+    address.is_private()
+        && !address.is_unspecified()
+        && !address.is_loopback()
+        && !address.is_broadcast()
+        && !address.is_multicast()
+}
+
+fn is_invalid_destination(address: Ipv4Addr) -> bool {
+    let first = address.octets()[0];
+    address.is_broadcast()
+        || address.is_multicast()
+        || first >= 240
+        || (first == 0 && !address.is_unspecified())
+}
+
+/// Trusted classification of one validated socket destination.
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+pub enum SocketDestination {
+    /// Route only through the broker-wide guest namespace.
+    Guest {
+        /// Normalized guest-requested destination.
+        requested: SocketAddrV4,
+    },
+    /// Translate through the explicitly authorized host gateway.
+    Gateway {
+        /// Guest-visible gateway destination.
+        requested: SocketAddrV4,
+    },
+    /// Route only through the platform's native external path.
+    External {
+        /// Guest-requested external destination.
+        requested: SocketAddrV4,
+    },
+}
+
+impl SocketDestination {
+    /// Returns the normalized guest-requested destination.
+    #[must_use]
+    pub const fn requested(self) -> SocketAddrV4 {
+        match self {
+            Self::Guest { requested }
+            | Self::Gateway { requested }
+            | Self::External { requested } => requested,
+        }
+    }
+
+    /// Checks that this classification is valid for a shared configuration.
+    ///
+    /// A route tag that disagrees with the configuration's own classification
+    /// is rejected, so untrusted or stale metadata cannot select a route.
+    #[must_use]
+    pub fn is_valid_for(self, config: &BrokerNetworkConfig) -> bool {
+        config.classify_destination(self.requested()) == Ok(self)
+    }
+}
+
+/// Broker-authorized guest binding passed to a platform provider.
+#[derive(Clone)]
+pub struct GuestSocketBinding {
+    requested: SocketAddrV4,
+    transport: GuestTransport,
+}
+
+impl GuestSocketBinding {
+    pub(super) fn new(reservation: &GuestBindingReservation) -> Self {
+        Self {
+            requested: reservation.requested_address(),
+            transport: reservation.transport(),
+        }
+    }
+
+    /// Returns the broker-reserved guest-visible binding.
+    #[must_use]
+    pub const fn requested(&self) -> SocketAddrV4 {
+        self.requested
+    }
+
+    /// Returns whether the original binding used the wildcard address.
+    #[must_use]
+    pub const fn is_wildcard(&self) -> bool {
+        self.requested.ip().is_unspecified()
+    }
+
+    /// Checks that this value is valid for a provider's shared configuration.
+    #[must_use]
+    pub fn is_valid_for(&self, config: &BrokerNetworkConfig) -> bool {
+        self.requested.port() != 0 && config.binding_is_valid(self.requested)
+    }
+
+    /// Returns whether this binding belongs to the TCP guest namespace.
+    #[must_use]
+    pub fn is_tcp(&self) -> bool {
+        self.transport == GuestTransport::Tcp
+    }
+
+    /// Returns whether this binding covers one concrete guest address.
+    #[must_use]
+    pub fn covers(&self, config: &BrokerNetworkConfig, address: SocketAddrV4) -> bool {
+        self.is_valid_for(config)
+            && address.port() != 0
+            && config.is_guest_local_ip(*address.ip())
+            && if self.is_wildcard() {
+                address.port() == self.requested.port()
+            } else {
+                address == self.requested
+            }
+    }
+
+    /// Selects the concrete guest source identity for one route.
+    ///
+    /// A wildcard binding answers a guest loopback destination with the
+    /// loopback identity and every other route with the configured private
+    /// guest address. An exact loopback binding cannot leave the guest
+    /// namespace, and an exact private guest binding always keeps itself.
+    #[must_use]
+    pub fn concrete_address_for(
+        &self,
+        config: &BrokerNetworkConfig,
+        destination: SocketDestination,
+    ) -> Option<SocketAddrV4> {
+        if !self.is_valid_for(config) || !destination.is_valid_for(config) {
+            return None;
+        }
+        if !self.is_wildcard() {
+            if self.requested.ip().is_loopback()
+                && !matches!(destination, SocketDestination::Guest { .. })
+            {
+                return None;
+            }
+            return Some(self.requested);
+        }
+        let ip = match destination {
+            SocketDestination::Guest { requested } if requested.ip().is_loopback() => {
+                *requested.ip()
+            }
+            SocketDestination::Guest { .. }
+            | SocketDestination::Gateway { .. }
+            | SocketDestination::External { .. } => config.guest_ipv4_address,
+        };
+        Some(SocketAddrV4::new(ip, self.requested.port()))
+    }
+}
+
+impl fmt::Debug for GuestSocketBinding {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("GuestSocketBinding")
+            .field("requested", &self.requested)
+            .finish_non_exhaustive()
+    }
+}
+
+impl PartialEq for GuestSocketBinding {
+    fn eq(&self, other: &Self) -> bool {
+        self.requested == other.requested && self.transport == other.transport
+    }
+}
+
+impl Eq for GuestSocketBinding {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::socket::BrokerSocketPorts;
+    use litebox_broker_protocol::socket::{
+        AddressFamily, CreateSocketRequest, IpProtocol, SocketOutcome, SocketType,
+    };
+
+    const fn create_request() -> CreateSocketRequest {
+        CreateSocketRequest {
+            address_family: AddressFamily::Ipv4,
+            socket_type: SocketType::Stream,
+            protocol: IpProtocol::Tcp,
+        }
+    }
+
+    fn binding(config: &BrokerNetworkConfig, requested: SocketAddrV4) -> GuestSocketBinding {
+        let ports = BrokerSocketPorts::default();
+        let SocketOutcome::Completed((_, reservation)) =
+            ports.reserve(config, create_request(), requested).unwrap()
+        else {
+            panic!("guest binding reservation failed");
+        };
+        GuestSocketBinding::new(&reservation)
+    }
+
+    #[test]
+    fn network_config_validates_distinct_private_unicast_addresses() {
+        let config = BrokerNetworkConfig::default();
+        assert_eq!(config.guest_ipv4_address(), Ipv4Addr::new(10, 0, 2, 15));
+        assert_eq!(config.gateway_ipv4_address(), Ipv4Addr::new(10, 0, 2, 1));
+        assert!(
+            BrokerNetworkConfig::new(Ipv4Addr::new(172, 16, 0, 2), Ipv4Addr::new(172, 16, 0, 1))
+                .is_some()
+        );
+        for invalid in [
+            Ipv4Addr::UNSPECIFIED,
+            Ipv4Addr::LOCALHOST,
+            Ipv4Addr::BROADCAST,
+            Ipv4Addr::new(224, 0, 0, 1),
+            Ipv4Addr::new(192, 0, 2, 1),
+        ] {
+            assert_eq!(
+                BrokerNetworkConfig::new(invalid, Ipv4Addr::new(10, 0, 2, 1)),
+                None
+            );
+            assert_eq!(
+                BrokerNetworkConfig::new(Ipv4Addr::new(10, 0, 2, 15), invalid),
+                None
+            );
+        }
+        assert_eq!(
+            BrokerNetworkConfig::new(Ipv4Addr::new(10, 0, 2, 15), Ipv4Addr::new(10, 0, 2, 15)),
+            None
+        );
+    }
+
+    #[test]
+    fn destination_classification_normalizes_and_separates_routes() {
+        let config = BrokerNetworkConfig::default();
+        let guest = SocketAddrV4::new(config.guest_ipv4_address(), 80);
+        let gateway = SocketAddrV4::new(config.gateway_ipv4_address(), 80);
+        let loopback = SocketAddrV4::new(Ipv4Addr::new(127, 2, 3, 4), 80);
+        let external = SocketAddrV4::new(Ipv4Addr::new(203, 0, 113, 9), 80);
+
+        assert_eq!(
+            config.classify_destination(guest),
+            Ok(SocketDestination::Guest { requested: guest })
+        );
+        assert_eq!(
+            config.classify_destination(loopback),
+            Ok(SocketDestination::Guest {
+                requested: loopback
+            })
+        );
+        assert_eq!(
+            config.classify_destination(gateway),
+            Ok(SocketDestination::Gateway { requested: gateway })
+        );
+        assert_eq!(
+            config.classify_destination(external),
+            Ok(SocketDestination::External {
+                requested: external
+            })
+        );
+        assert_eq!(
+            config.classify_destination(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 80)),
+            Ok(SocketDestination::Guest {
+                requested: SocketAddrV4::new(Ipv4Addr::LOCALHOST, 80)
+            })
+        );
+    }
+
+    #[test]
+    fn invalid_destination_classes_are_rejected_before_routing() {
+        let config = BrokerNetworkConfig::default();
+        for invalid in [
+            SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0),
+            SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0),
+            SocketAddrV4::new(Ipv4Addr::BROADCAST, 80),
+            SocketAddrV4::new(Ipv4Addr::new(224, 0, 0, 1), 80),
+            SocketAddrV4::new(Ipv4Addr::new(240, 0, 0, 1), 80),
+            SocketAddrV4::new(Ipv4Addr::new(255, 0, 0, 1), 80),
+            SocketAddrV4::new(Ipv4Addr::new(0, 1, 2, 3), 80),
+        ] {
+            assert_eq!(
+                config.classify_destination(invalid),
+                Err(SocketError::InvalidArgument)
+            );
+        }
+    }
+
+    #[test]
+    fn malformed_route_tags_are_invalid_for_the_configuration() {
+        let config = BrokerNetworkConfig::default();
+        let guest = SocketAddrV4::new(config.guest_ipv4_address(), 80);
+        let gateway = SocketAddrV4::new(config.gateway_ipv4_address(), 80);
+        let loopback = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 80);
+        let external = SocketAddrV4::new(Ipv4Addr::new(203, 0, 113, 9), 80);
+
+        for valid in [
+            SocketDestination::Guest { requested: guest },
+            SocketDestination::Guest {
+                requested: loopback,
+            },
+            SocketDestination::Gateway { requested: gateway },
+            SocketDestination::External {
+                requested: external,
+            },
+        ] {
+            assert!(valid.is_valid_for(&config));
+        }
+        for malformed in [
+            SocketDestination::External {
+                requested: loopback,
+            },
+            SocketDestination::External { requested: guest },
+            SocketDestination::External { requested: gateway },
+            SocketDestination::Guest { requested: gateway },
+            SocketDestination::Guest {
+                requested: external,
+            },
+            SocketDestination::Guest {
+                requested: SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 80),
+            },
+            SocketDestination::Gateway { requested: guest },
+            SocketDestination::Gateway {
+                requested: SocketAddrV4::new(config.gateway_ipv4_address(), 0),
+            },
+            SocketDestination::External {
+                requested: SocketAddrV4::new(Ipv4Addr::new(224, 0, 0, 1), 80),
+            },
+        ] {
+            assert!(!malformed.is_valid_for(&config));
+        }
+    }
+
+    #[test]
+    fn wildcard_bindings_select_route_specific_guest_sources() {
+        let config = BrokerNetworkConfig::default();
+        let binding = binding(&config, SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 49152));
+        assert!(binding.is_wildcard());
+        assert!(binding.is_valid_for(&config));
+
+        for (destination, expected_ip) in [
+            (
+                SocketDestination::Guest {
+                    requested: SocketAddrV4::new(Ipv4Addr::new(127, 2, 3, 4), 80),
+                },
+                Ipv4Addr::new(127, 2, 3, 4),
+            ),
+            (
+                SocketDestination::Guest {
+                    requested: SocketAddrV4::new(config.guest_ipv4_address(), 80),
+                },
+                config.guest_ipv4_address(),
+            ),
+            (
+                SocketDestination::Gateway {
+                    requested: SocketAddrV4::new(config.gateway_ipv4_address(), 80),
+                },
+                config.guest_ipv4_address(),
+            ),
+            (
+                SocketDestination::External {
+                    requested: SocketAddrV4::new(Ipv4Addr::new(203, 0, 113, 9), 80),
+                },
+                config.guest_ipv4_address(),
+            ),
+        ] {
+            assert_eq!(
+                binding.concrete_address_for(&config, destination),
+                Some(SocketAddrV4::new(expected_ip, 49152))
+            );
+        }
+        assert_eq!(
+            binding.concrete_address_for(
+                &config,
+                SocketDestination::External {
+                    requested: SocketAddrV4::new(Ipv4Addr::LOCALHOST, 80)
+                }
+            ),
+            None
+        );
+        assert!(binding.covers(&config, SocketAddrV4::new(Ipv4Addr::LOCALHOST, 49152)));
+        assert!(binding.covers(
+            &config,
+            SocketAddrV4::new(config.guest_ipv4_address(), 49152)
+        ));
+        assert!(!binding.covers(&config, SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 49152)));
+        assert!(!binding.covers(
+            &config,
+            SocketAddrV4::new(Ipv4Addr::new(203, 0, 113, 9), 49152)
+        ));
+    }
+
+    #[test]
+    fn exact_bindings_keep_their_identity_and_cannot_escape_loopback() {
+        let config = BrokerNetworkConfig::default();
+        let loopback_source = SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 2), 49153);
+        let guest_source = SocketAddrV4::new(config.guest_ipv4_address(), 49154);
+        let loopback = binding(&config, loopback_source);
+        let private = binding(&config, guest_source);
+        let guest_destination = SocketDestination::Guest {
+            requested: SocketAddrV4::new(config.guest_ipv4_address(), 80),
+        };
+        let gateway_destination = SocketDestination::Gateway {
+            requested: SocketAddrV4::new(config.gateway_ipv4_address(), 80),
+        };
+        let external_destination = SocketDestination::External {
+            requested: SocketAddrV4::new(Ipv4Addr::new(203, 0, 113, 9), 80),
+        };
+
+        assert_eq!(
+            loopback.concrete_address_for(
+                &config,
+                SocketDestination::Guest {
+                    requested: SocketAddrV4::new(Ipv4Addr::LOCALHOST, 80)
+                }
+            ),
+            Some(loopback_source)
+        );
+        assert_eq!(
+            loopback.concrete_address_for(&config, guest_destination),
+            Some(loopback_source)
+        );
+        assert_eq!(
+            loopback.concrete_address_for(&config, gateway_destination),
+            None
+        );
+        assert_eq!(
+            loopback.concrete_address_for(&config, external_destination),
+            None
+        );
+
+        for destination in [guest_destination, gateway_destination, external_destination] {
+            assert_eq!(
+                private.concrete_address_for(&config, destination),
+                Some(guest_source)
+            );
+        }
+        assert!(private.covers(&config, guest_source));
+        assert!(!private.covers(&config, SocketAddrV4::new(Ipv4Addr::LOCALHOST, 49154)));
+    }
+}

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -697,10 +697,13 @@ mod tests {
     use core::net::{Ipv4Addr, SocketAddrV4};
     use litebox_broker_core::readiness::ReadinessRegistration;
     use litebox_broker_core::socket::{
-        AcceptedPlatformSocket, PlatformConnectError, PlatformDatagramReceive, PlatformSocket,
-        PlatformSocketStatus, PlatformStreamReceive, SocketProvider,
+        AcceptedPlatformSocket, BrokerNetworkConfig, PlatformConnectError, PlatformSocket,
+        PlatformSocketStatus, PlatformStreamReceive, RoutedPlatformDatagramReceive,
+        SocketDestination, SocketProvider,
     };
-    use litebox_broker_core::{ObjectRights, PolicyEngine, SessionId, SocketPolicy};
+    use litebox_broker_core::{
+        DestinationPortRange, GatewayPortRule, ObjectRights, PolicyEngine, SessionId, SocketPolicy,
+    };
     use litebox_broker_protocol::event::{
         AddEventRequest, ConsumeEventRequest, CreateEventRequest, EventConsumeMode,
     };
@@ -711,7 +714,7 @@ mod tests {
         SharedBufferDescriptor,
     };
     use litebox_broker_protocol::socket::{
-        AddressFamily, ConnectSocketRequest, CreateSocketRequest, IpProtocol, ReceiveFlags,
+        AddressFamily, ConnectSocketRequest, CreateSocketRequest, IpProtocol, Port, ReceiveFlags,
         ReceiveFromFlags, ReceiveFromSocketRequest, ReceiveFromSocketResponse,
         ReceiveSocketRequest, SendFlags, SendSocketRequest, SendToSocketRequest,
         SendToSocketResponse, ShutdownMode, ShutdownSocketRequest, SocketConnectionStatus,
@@ -818,7 +821,7 @@ mod tests {
 
         fn connect(
             &self,
-            _address: SocketAddrV4,
+            _destination: SocketDestination,
         ) -> core::result::Result<SocketConnectionStatus, PlatformConnectError> {
             self.readiness
                 .publish(litebox_broker_protocol::readiness::ReadinessFlags::WRITE)
@@ -842,7 +845,7 @@ mod tests {
             &self,
             data: Vec<u8>,
             _flags: SendFlags,
-            _destination: Option<SocketAddrV4>,
+            _destination: Option<SocketDestination>,
         ) -> litebox_broker_core::Result<SocketOutcome<usize>> {
             Ok(SocketOutcome::Completed(data.len()))
         }
@@ -864,12 +867,14 @@ mod tests {
             &self,
             length: usize,
             _flags: ReceiveFromFlags,
-        ) -> litebox_broker_core::Result<SocketOutcome<PlatformDatagramReceive>> {
+        ) -> litebox_broker_core::Result<SocketOutcome<RoutedPlatformDatagramReceive>> {
             let received = length.min(3);
-            Ok(SocketOutcome::Completed(PlatformDatagramReceive {
+            Ok(SocketOutcome::Completed(RoutedPlatformDatagramReceive {
                 data: [4, 5, 6][..received].to_vec(),
                 datagram_length: 4,
-                source_address: SocketAddrV4::new(Ipv4Addr::LOCALHOST, 49153),
+                source: SocketDestination::Guest {
+                    requested: SocketAddrV4::new(Ipv4Addr::LOCALHOST, 49153),
+                },
             }))
         }
 
@@ -910,9 +915,23 @@ mod tests {
 
     #[test]
     fn host_request_handling_uses_one_broker_core() {
+        // Guest networking admits both protocols inside the guest namespace,
+        // and the TCP gateway rule authorizes the one host service below.
+        let policy = PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
+            .with_socket_policy(
+                SocketPolicy::from_guest_network_destination_rules(true, &[], true, &[]).unwrap(),
+            )
+            .with_gateway_rules(
+                &[GatewayPortRule::new(
+                    CallerCredential::Unauthenticated,
+                    DestinationPortRange::new(Port(8080), Port(8080)).unwrap(),
+                )],
+                &[],
+            )
+            .unwrap();
         let broker = BrokerCore::new(
-            PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-                .with_socket_policy(SocketPolicy::Ipv4Loopback),
+            policy,
+            Arc::new(BrokerNetworkConfig::default()),
             Arc::new(TestSocketProvider),
         )
         .unwrap();
@@ -1356,7 +1375,10 @@ mod tests {
                 &session,
                 BrokerOperation::Socket(SocketRequest::Connect(ConnectSocketRequest {
                     handle: response.handle,
-                    address: SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8080),
+                    address: SocketAddrV4::new(
+                        BrokerNetworkConfig::default().gateway_ipv4_address(),
+                        8080,
+                    ),
                 })),
                 &shared_buffers,
             ),
@@ -1374,7 +1396,12 @@ mod tests {
             ),
             BrokerResult::Socket(SocketResponse::Status(SocketStatusResponse {
                 status: SocketConnectionStatus::Connected,
-                local_address: Some(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 49152)),
+                // A wildcard reservation reaches the gateway as the private
+                // guest identity.
+                local_address: Some(SocketAddrV4::new(
+                    BrokerNetworkConfig::default().guest_ipv4_address(),
+                    49152,
+                )),
                 pending_error: None,
             }))
         );

--- a/litebox_broker_platform_linux_userland/src/socket.rs
+++ b/litebox_broker_platform_linux_userland/src/socket.rs
@@ -18,8 +18,9 @@ use std::time::Instant;
 use std::time::Duration;
 
 use litebox_broker_core::socket::{
-    AcceptedPlatformSocket, GuestSocketBinding, PlatformConnectError, PlatformDatagramReceive,
-    PlatformSocket, PlatformSocketStatus, PlatformStreamReceive, SocketProvider,
+    AcceptedPlatformSocket, BrokerNetworkConfig, GuestSocketBinding, PlatformConnectError,
+    PlatformSocket, PlatformSocketStatus, PlatformStreamReceive, RoutedPlatformDatagramReceive,
+    SocketDestination, SocketProvider,
 };
 use litebox_broker_core::{BrokerError, Result as BrokerResult, SessionId};
 use litebox_broker_protocol::readiness::ReadinessFlags;
@@ -173,10 +174,23 @@ pub struct LinuxSocketProvider {
 }
 
 impl LinuxSocketProvider {
-    /// Starts a provider with global and per-session socket limits.
-    pub fn new(max_sockets: usize, max_sockets_per_session: usize) -> IoResult<Self> {
+    /// Starts a provider with a shared network configuration and socket limits.
+    ///
+    /// The configuration is the broker-wide guest identity; the caller must
+    /// pass the same value it gave [`litebox_broker_core::BrokerCore`], because
+    /// this provider validates every broker-issued binding and destination
+    /// against it before touching native state.
+    pub fn new(
+        network_config: Arc<BrokerNetworkConfig>,
+        max_sockets: usize,
+        max_sockets_per_session: usize,
+    ) -> IoResult<Self> {
         Ok(Self {
-            reactor: Arc::new(ReactorClient::start(max_sockets, max_sockets_per_session)?),
+            reactor: Arc::new(ReactorClient::start(
+                network_config,
+                max_sockets,
+                max_sockets_per_session,
+            )?),
         })
     }
 }
@@ -273,7 +287,7 @@ impl PlatformSocket for LinuxSocket {
                 Ok(SocketOutcome::Completed(AcceptedPlatformSocket {
                     socket,
                     local_address: accepted.local_address,
-                    remote_address: accepted.remote_address,
+                    remote: accepted.remote,
                 }))
             }
             SocketOutcome::Failed(error) => Ok(SocketOutcome::Failed(error)),
@@ -282,9 +296,9 @@ impl PlatformSocket for LinuxSocket {
 
     fn connect(
         &self,
-        address: SocketAddrV4,
+        destination: SocketDestination,
     ) -> core::result::Result<SocketConnectionStatus, PlatformConnectError> {
-        self.reactor.connect(self.id, address)
+        self.reactor.connect(self.id, destination)
     }
 
     fn send(&self, data: Vec<u8>, _flags: SendFlags) -> BrokerResult<SocketOutcome<usize>> {
@@ -299,7 +313,7 @@ impl PlatformSocket for LinuxSocket {
         &self,
         data: Vec<u8>,
         _flags: SendFlags,
-        destination: Option<SocketAddrV4>,
+        destination: Option<SocketDestination>,
     ) -> BrokerResult<SocketOutcome<usize>> {
         self.reactor.request(|response| ReactorCommand::SendTo {
             id: self.id,
@@ -342,7 +356,7 @@ impl PlatformSocket for LinuxSocket {
         &self,
         length: usize,
         flags: ReceiveFromFlags,
-    ) -> BrokerResult<SocketOutcome<PlatformDatagramReceive>> {
+    ) -> BrokerResult<SocketOutcome<RoutedPlatformDatagramReceive>> {
         match self
             .reactor
             .request(|response| ReactorCommand::ReceiveFrom {
@@ -354,11 +368,11 @@ impl PlatformSocket for LinuxSocket {
             ReactorReceiveFromOutcome::Received {
                 data: received,
                 datagram_length,
-                source_address,
-            } => Ok(SocketOutcome::Completed(PlatformDatagramReceive {
+                source,
+            } => Ok(SocketOutcome::Completed(RoutedPlatformDatagramReceive {
                 data: received,
                 datagram_length,
-                source_address,
+                source,
             })),
             ReactorReceiveFromOutcome::Failed(error) => Ok(SocketOutcome::Failed(error)),
         }
@@ -424,7 +438,11 @@ struct ReactorClient {
 }
 
 impl ReactorClient {
-    fn start(max_sockets: usize, max_sockets_per_session: usize) -> IoResult<Self> {
+    fn start(
+        network_config: Arc<BrokerNetworkConfig>,
+        max_sockets: usize,
+        max_sockets_per_session: usize,
+    ) -> IoResult<Self> {
         let epoll_fd = epoll::create(epoll::CreateFlags::CLOEXEC)?;
         let wake = Arc::new(eventfd(0, EventfdFlags::CLOEXEC | EventfdFlags::NONBLOCK)?);
         epoll::add(
@@ -454,6 +472,7 @@ impl ReactorClient {
                     wake: reactor_wake,
                     commands: receiver,
                     sockets,
+                    network_config,
                     tcp: ReactorTcpState::default(),
                     udp: ReactorUdpState::default(),
                     sessions: HashMap::new(),
@@ -524,12 +543,12 @@ impl ReactorClient {
     fn connect(
         &self,
         id: u64,
-        address: SocketAddrV4,
+        destination: SocketDestination,
     ) -> core::result::Result<SocketConnectionStatus, PlatformConnectError> {
         let (response, receive) = sync_channel(1);
         let command = ReactorCommand::Connect {
             id,
-            address,
+            destination,
             response,
         };
         // Block until the reactor has queue space (see `request`): a transiently
@@ -661,10 +680,10 @@ impl ReactorClient {
     }
 
     #[cfg(test)]
-    fn udp_external_peer_count(&self) -> usize {
+    fn udp_native_peer_count(&self) -> usize {
         let (response, receive) = sync_channel(1);
         self.commands
-            .send(ReactorCommand::UdpExternalPeerCount { response })
+            .send(ReactorCommand::UdpNativePeerCount { response })
             .unwrap();
         self.signal().unwrap();
         receive.recv().unwrap()
@@ -791,7 +810,7 @@ enum ReactorCommand {
     },
     Connect {
         id: u64,
-        address: SocketAddrV4,
+        destination: SocketDestination,
         response: SyncSender<core::result::Result<SocketConnectionStatus, PlatformConnectError>>,
     },
     Bind {
@@ -820,7 +839,7 @@ enum ReactorCommand {
     SendTo {
         id: u64,
         data: Vec<u8>,
-        destination: Option<SocketAddrV4>,
+        destination: Option<SocketDestination>,
         response: SyncSender<BrokerResult<SocketOutcome<usize>>>,
     },
     Receive {
@@ -902,7 +921,7 @@ enum ReactorCommand {
         response: SyncSender<BrokerResult<Option<usize>>>,
     },
     #[cfg(test)]
-    UdpExternalPeerCount {
+    UdpNativePeerCount {
         response: SyncSender<usize>,
     },
     #[cfg(test)]
@@ -940,7 +959,7 @@ enum ReactorReceiveFromOutcome {
     Received {
         data: Vec<u8>,
         datagram_length: usize,
-        source_address: SocketAddrV4,
+        source: SocketDestination,
     },
     Failed(SocketError),
 }
@@ -951,6 +970,8 @@ struct Reactor {
     wake: Arc<OwnedFd>,
     commands: Receiver<ReactorCommand>,
     sockets: HashMap<u64, SocketEntry>,
+    /// Broker-wide guest identity shared with the broker core.
+    network_config: Arc<BrokerNetworkConfig>,
     tcp: ReactorTcpState,
     udp: ReactorUdpState,
     sessions: HashMap<SessionId, ReactorSessionState>,
@@ -1008,7 +1029,7 @@ struct ReactorSessionState {
     live_socket_count: usize,
     pending_guest_connection_count: usize,
     retained_connector_count: usize,
-    udp_external_peer_count: usize,
+    udp_native_peer_count: usize,
     udp_queued_datagrams: usize,
     udp_queued_bytes: usize,
     closing: bool,
@@ -1025,7 +1046,7 @@ fn retain_session_state(state: &ReactorSessionState) -> bool {
         || state.live_socket_count != 0
         || state.pending_guest_connection_count != 0
         || state.retained_connector_count != 0
-        || state.udp_external_peer_count != 0
+        || state.udp_native_peer_count != 0
         || state.udp_queued_datagrams != 0
         || state.udp_queued_bytes != 0
 }
@@ -1093,25 +1114,21 @@ impl Reactor {
         } else {
             SocketKind::Udp
         };
-        if !binding.is_valid() || binding_kind != kind {
+        if !binding.is_valid_for(&self.network_config) || binding_kind != kind {
             return Err(BrokerError::Internal);
         }
         if kind == SocketKind::Udp {
             if already_bound {
                 return Ok(SocketOutcome::Failed(SocketError::InvalidArgument));
             }
-            let internal_address = if binding.is_wildcard() {
-                SocketAddrV4::new(Ipv4Addr::LOCALHOST, requested_address.port())
-            } else {
-                requested_address
-            };
-            self.udp.insert_binding(ReactorUdpBinding {
-                socket_id: id,
-                guest_binding: binding,
-            })?;
+            self.udp.insert_binding(
+                &self.network_config,
+                ReactorUdpBinding {
+                    socket_id: id,
+                    guest_binding: binding,
+                },
+            )?;
             let socket = self.sockets.get_mut(&id).ok_or(BrokerError::Internal)?;
-            let udp = socket.udp_state_mut()?;
-            udp.internal_address = Some(internal_address);
             socket.guest_local_address = Some(requested_address);
             socket
                 .snapshot
@@ -1126,22 +1143,37 @@ impl Reactor {
     fn connect_socket(
         &mut self,
         id: u64,
-        guest_address: SocketAddrV4,
+        destination: SocketDestination,
     ) -> core::result::Result<SocketConnectionStatus, PlatformConnectError> {
         let kind = self.sockets.get(&id).map(SocketEntry::kind).ok_or(
             PlatformConnectError::PeerIndeterminate(BrokerError::Internal),
         )?;
         if kind == SocketKind::Udp {
-            let peer = match self.resolve_udp_destination(guest_address) {
+            // Route classification and the guest-visible source are decided
+            // before any native state changes, so malformed trusted metadata
+            // fails closed with the peer unchanged.
+            let peer = match self
+                .resolve_udp_destination(destination)
+                .map_err(PlatformConnectError::PeerUnchanged)?
+            {
                 SocketOutcome::Completed(peer) => peer,
                 SocketOutcome::Failed(error) => {
                     return Ok(SocketConnectionStatus::Failed(error));
                 }
             };
-            let mut reused_host_address = None;
+            let guest_local_address = self
+                .udp
+                .binding_for_socket(id)
+                .and_then(|binding| {
+                    binding
+                        .guest_binding
+                        .concrete_address_for(&self.network_config, destination)
+                })
+                .ok_or(PlatformConnectError::PeerUnchanged(BrokerError::Internal))?;
+            let mut reused_endpoint = false;
             let mut staged_endpoint = match peer {
                 ReactorUdpPeer::Guest { .. } => None,
-                ReactorUdpPeer::External(address) => {
+                ReactorUdpPeer::Native { host_address, .. } => {
                     if self
                         .sockets
                         .get(&id)
@@ -1152,9 +1184,9 @@ impl Reactor {
                         .as_ref()
                         .is_some()
                     {
-                        match self.connect_existing_udp_endpoint(id, address)? {
-                            SocketOutcome::Completed(host_address) => {
-                                reused_host_address = Some(host_address);
+                        match self.connect_existing_udp_endpoint(id, host_address)? {
+                            SocketOutcome::Completed(()) => {
+                                reused_endpoint = true;
                                 None
                             }
                             SocketOutcome::Failed(error) => {
@@ -1163,7 +1195,7 @@ impl Reactor {
                         }
                     } else {
                         match self
-                            .stage_udp_endpoint(id, address, Some(address))
+                            .stage_udp_endpoint(id, host_address, Some(host_address))
                             .map_err(PlatformConnectError::PeerUnchanged)?
                         {
                             SocketOutcome::Completed(endpoint) => Some(endpoint),
@@ -1180,42 +1212,11 @@ impl Reactor {
                 }
                 return Err(PlatformConnectError::PeerIndeterminate(error));
             }
-            let guest_local_address = match (|| {
-                let socket = self.sockets.get(&id).ok_or(BrokerError::Internal)?;
-                let current = socket.guest_local_address.ok_or(BrokerError::Internal)?;
-                let binding = self
-                    .udp
-                    .binding_for_socket(id)
-                    .ok_or(BrokerError::Internal)?;
-                if binding.guest_binding.is_wildcard() {
-                    let ip = match (&peer, &staged_endpoint, reused_host_address) {
-                        (ReactorUdpPeer::Guest { .. }, _, _) => Ipv4Addr::LOCALHOST,
-                        (ReactorUdpPeer::External(_), Some(endpoint), _) => {
-                            *endpoint.host_address.ip()
-                        }
-                        (ReactorUdpPeer::External(_), None, Some(host_address)) => {
-                            *host_address.ip()
-                        }
-                        _ => return Err(BrokerError::Internal),
-                    };
-                    Ok(SocketAddrV4::new(ip, current.port()))
-                } else {
-                    Ok(current)
-                }
-            })() {
-                Ok(address) => address,
-                Err(error) => {
-                    if let Some(endpoint) = staged_endpoint.take() {
-                        self.unregister_udp_endpoint(endpoint);
-                    }
-                    return Err(PlatformConnectError::PeerIndeterminate(error));
-                }
-            };
-            if reused_host_address.is_none() {
+            if !reused_endpoint {
                 self.replace_udp_endpoint(id, staged_endpoint.take())
                     .map_err(PlatformConnectError::PeerIndeterminate)?;
             }
-            self.clear_udp_external_peers(id)
+            self.clear_udp_native_peers(id)
                 .map_err(PlatformConnectError::PeerIndeterminate)?;
             let readiness = self
                 .udp_readiness(id)
@@ -1241,16 +1242,16 @@ impl Reactor {
                 .map_err(PlatformConnectError::PeerIndeterminate)?;
             return Ok(SocketConnectionStatus::Connected);
         }
-        self.connect_tcp_guest(id, guest_address)
+        self.connect_tcp_guest(id, destination)
     }
 
     fn send_to_socket(
         &mut self,
         id: u64,
         data: &[u8],
-        destination: Option<SocketAddrV4>,
+        destination: Option<SocketDestination>,
     ) -> BrokerResult<SocketOutcome<usize>> {
-        let (peer, authorize_external_reply) = {
+        let (peer, authorize_native_reply) = {
             let socket = self.sockets.get(&id).ok_or(BrokerError::Internal)?;
             if socket.kind() != SocketKind::Udp || data.len() > MAX_UDP_DATAGRAM_SIZE as usize {
                 return Ok(SocketOutcome::Failed(SocketError::InvalidArgument));
@@ -1260,7 +1261,7 @@ impl Reactor {
             }
             let udp = socket.udp_state()?;
             match destination {
-                Some(address) => match self.resolve_udp_destination(address) {
+                Some(destination) => match self.resolve_udp_destination(destination)? {
                     SocketOutcome::Completed(peer) => (peer, udp.peer.is_none()),
                     SocketOutcome::Failed(error) => return Ok(SocketOutcome::Failed(error)),
                 },
@@ -1273,20 +1274,27 @@ impl Reactor {
         match peer {
             ReactorUdpPeer::Guest {
                 socket_generation,
-                guest_address,
+                destination,
             } => {
                 if self
                     .udp
                     .binding_for_socket(socket_generation)
-                    .is_none_or(|binding| !binding.guest_binding.covers(guest_address))
+                    .is_none_or(|binding| {
+                        !binding
+                            .guest_binding
+                            .covers(&self.network_config, destination.requested())
+                    })
                 {
                     return Ok(SocketOutcome::Failed(SocketError::ConnectionRefused));
                 }
-                self.enqueue_guest_datagram(id, socket_generation, data)
+                self.enqueue_guest_datagram(id, socket_generation, destination, data)
             }
-            ReactorUdpPeer::External(address) => {
-                let external_peer_added = if authorize_external_reply {
-                    self.reserve_udp_external_peer(id, address)?
+            ReactorUdpPeer::Native {
+                host_address,
+                destination,
+            } => {
+                let native_peer_added = if authorize_native_reply {
+                    self.reserve_udp_native_peer(id, host_address, destination)?
                 } else {
                     false
                 };
@@ -1299,26 +1307,26 @@ impl Reactor {
                     .as_ref()
                     .is_none()
                 {
-                    let endpoint = match self.stage_udp_endpoint(id, address, None) {
+                    let endpoint = match self.stage_udp_endpoint(id, host_address, None) {
                         Ok(SocketOutcome::Completed(endpoint)) => endpoint,
                         Ok(SocketOutcome::Failed(error)) => {
-                            if external_peer_added {
-                                self.remove_udp_external_peer(id, address);
+                            if native_peer_added {
+                                self.remove_udp_native_peer(id, host_address);
                             }
                             return Ok(SocketOutcome::Failed(error));
                         }
                         Err(error) => {
-                            if external_peer_added {
-                                self.remove_udp_external_peer(id, address);
+                            if native_peer_added {
+                                self.remove_udp_native_peer(id, host_address);
                             }
                             return Err(error);
                         }
                     };
                     self.replace_udp_endpoint(id, Some(endpoint))?;
                 }
-                let outcome = self.send_external_udp(id, data, address);
-                if !matches!(outcome, Ok(SocketOutcome::Completed(_))) && external_peer_added {
-                    self.remove_udp_external_peer(id, address);
+                let outcome = self.send_native_udp(id, data, host_address);
+                if !matches!(outcome, Ok(SocketOutcome::Completed(_))) && native_peer_added {
+                    self.remove_udp_native_peer(id, host_address);
                 }
                 outcome
             }
@@ -1455,24 +1463,24 @@ impl Reactor {
                 self.udp
                     .remove_binding(binding.guest_binding.requested().port(), id);
             }
-            let external_peer_count = self
+            let native_peer_count = self
                 .sockets
                 .get(&id)
                 .and_then(|socket| socket.udp_state().ok())
-                .map_or(0, |udp| udp.external_peers.len());
-            self.udp.external_peer_count = self
+                .map_or(0, |udp| udp.native_peers.len());
+            self.udp.native_peer_count = self
                 .udp
-                .external_peer_count
-                .checked_sub(external_peer_count)
-                .expect("reactor UDP external peer count underflow");
+                .native_peer_count
+                .checked_sub(native_peer_count)
+                .expect("reactor UDP native peer count underflow");
             let session = self
                 .sessions
                 .get_mut(&session_id)
                 .expect("UDP socket session state missing");
-            session.udp_external_peer_count = session
-                .udp_external_peer_count
-                .checked_sub(external_peer_count)
-                .expect("session UDP external peer count underflow");
+            session.udp_native_peer_count = session
+                .udp_native_peer_count
+                .checked_sub(native_peer_count)
+                .expect("session UDP native peer count underflow");
             self.sockets.remove(&id);
             session.live_socket_count = session
                 .live_socket_count
@@ -1589,10 +1597,10 @@ impl Reactor {
                 }
                 ReactorCommand::Connect {
                     id,
-                    address,
+                    destination,
                     response,
                 } => {
-                    let outcome = self.connect_socket(id, address);
+                    let outcome = self.connect_socket(id, destination);
                     let _ = response.send(outcome);
                 }
                 ReactorCommand::Bind {
@@ -1788,8 +1796,8 @@ impl Reactor {
                     let _ = response.send(size);
                 }
                 #[cfg(test)]
-                ReactorCommand::UdpExternalPeerCount { response } => {
-                    let _ = response.send(self.udp.external_peer_count);
+                ReactorCommand::UdpNativePeerCount { response } => {
+                    let _ = response.send(self.udp.native_peer_count);
                 }
                 #[cfg(test)]
                 ReactorCommand::UdpNativeHeadDatagramBytes {
@@ -2082,6 +2090,21 @@ const fn socket_kind(request: CreateSocketRequest) -> Option<SocketKind> {
         (AddressFamily::Ipv4, SocketType::Stream, IpProtocol::Tcp) => Some(SocketKind::Tcp),
         (AddressFamily::Ipv4, SocketType::Datagram, IpProtocol::Udp) => Some(SocketKind::Udp),
         _ => None,
+    }
+}
+
+/// Translates one non-guest route to the host address realized natively.
+///
+/// An authorized gateway route reaches the host through loopback on the same
+/// port, and an external route keeps its requested address. A guest route has
+/// no native host address because it never leaves the broker's namespace.
+const fn native_host_address(destination: SocketDestination) -> Option<SocketAddrV4> {
+    match destination {
+        SocketDestination::Guest { .. } => None,
+        SocketDestination::Gateway { requested } => {
+            Some(SocketAddrV4::new(Ipv4Addr::LOCALHOST, requested.port()))
+        }
+        SocketDestination::External { requested } => Some(requested),
     }
 }
 

--- a/litebox_broker_platform_linux_userland/src/socket/tcp.rs
+++ b/litebox_broker_platform_linux_userland/src/socket/tcp.rs
@@ -10,7 +10,9 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use litebox_broker_core::readiness::ReadinessRegistration;
-use litebox_broker_core::socket::{GuestSocketBinding, PlatformConnectError};
+use litebox_broker_core::socket::{
+    BrokerNetworkConfig, GuestSocketBinding, PlatformConnectError, SocketDestination,
+};
 use litebox_broker_core::{BrokerError, Result as BrokerResult, SessionId};
 use litebox_broker_protocol::readiness::ReadinessFlags;
 use litebox_broker_protocol::socket::{
@@ -29,8 +31,8 @@ use rustix::net::{
 use super::{
     Reactor, SocketEntry, SocketKind, SocketLifecycle, SocketSnapshot, SocketTransportState,
     broker_error_from_errno, can_consume_synchronous_error, local_socket_address,
-    retain_session_state, socket_error_from_errno, socket_operation_error_from_errno,
-    take_socket_error, update_snapshot, zeroed_vec,
+    native_host_address, retain_session_state, socket_error_from_errno,
+    socket_operation_error_from_errno, take_socket_error, update_snapshot, zeroed_vec,
 };
 
 pub(super) const MAX_UNMATCHED_ACCEPTS_PER_COMMAND: usize = 64;
@@ -38,7 +40,7 @@ pub(super) const PENDING_CONNECT_DISCARD_LIFETIME: Duration = Duration::from_min
 
 pub(super) struct AcceptedEndpoints {
     pub(super) local_address: SocketAddrV4,
-    pub(super) remote_address: SocketAddrV4,
+    pub(super) remote: SocketDestination,
 }
 
 pub(super) enum ReactorReceiveOutcome {
@@ -286,9 +288,13 @@ impl ReactorTcpState {
         self.peek_cache = None;
     }
 
-    pub(super) fn insert_binding(&mut self, binding: ReactorTcpBinding) -> BrokerResult<()> {
+    pub(super) fn insert_binding(
+        &mut self,
+        config: &BrokerNetworkConfig,
+        binding: ReactorTcpBinding,
+    ) -> BrokerResult<()> {
         let requested = binding.guest_binding.requested();
-        if !binding.guest_binding.is_valid()
+        if !binding.guest_binding.is_valid_for(config)
             || if binding.guest_binding.is_wildcard() {
                 self.bindings.wildcard.contains_key(&requested.port())
                     || self
@@ -336,24 +342,25 @@ impl ReactorTcpState {
         }
     }
 
-    pub(super) fn guest_binding(&self, address: SocketAddrV4) -> Option<ReactorTcpBinding> {
-        if !address.ip().is_loopback() {
-            return None;
-        }
-        self.bindings
+    /// Finds the binding that owns one concrete guest-namespace address.
+    ///
+    /// An exact binding answers only its own address; a wildcard binding
+    /// answers every guest-local address on its port, including the
+    /// configured private guest address.
+    pub(super) fn guest_binding(
+        &self,
+        config: &BrokerNetworkConfig,
+        requested: SocketAddrV4,
+    ) -> Option<ReactorTcpBinding> {
+        let binding = self
+            .bindings
             .exact
-            .get(&address)
-            .or_else(|| self.bindings.wildcard.get(&address.port()))
-            .cloned()
-    }
-
-    pub(super) fn has_binding_on_port(&self, port: u16) -> bool {
-        self.bindings.wildcard.contains_key(&port)
-            || self
-                .bindings
-                .exact
-                .keys()
-                .any(|address| address.port() == port)
+            .get(&requested)
+            .or_else(|| self.bindings.wildcard.get(&requested.port()))?;
+        binding
+            .guest_binding
+            .covers(config, requested)
+            .then(|| binding.clone())
     }
 
     pub(super) fn binding_for_socket(&self, socket_id: u64) -> Option<ReactorTcpBinding> {
@@ -1307,14 +1314,17 @@ impl Reactor {
             return Ok(SocketOutcome::Failed(SocketError::InvalidArgument));
         }
         let guest_address = binding.requested();
-        self.tcp.insert_binding(ReactorTcpBinding {
-            socket_id: id,
-            guest_binding: binding,
-            host_address: None,
-            listening: false,
-            requires_backlog_drain: false,
-            untracked_connection_deadline: None,
-        })?;
+        self.tcp.insert_binding(
+            &self.network_config,
+            ReactorTcpBinding {
+                socket_id: id,
+                guest_binding: binding,
+                host_address: None,
+                listening: false,
+                requires_backlog_drain: false,
+                untracked_connection_deadline: None,
+            },
+        )?;
         let socket = self.sockets.get_mut(&id).ok_or(BrokerError::Internal)?;
         socket.guest_local_address = Some(guest_address);
         socket
@@ -1328,48 +1338,43 @@ impl Reactor {
     pub(super) fn connect_tcp_guest(
         &mut self,
         id: u64,
-        guest_address: SocketAddrV4,
+        destination: SocketDestination,
     ) -> core::result::Result<SocketConnectionStatus, PlatformConnectError> {
-        let (session_id, reserved_local_address) = self
+        let session_id = self
             .sockets
             .get(&id)
-            .and_then(|socket| {
-                socket
-                    .guest_local_address
-                    .map(|address| (socket.session_id, address))
-            })
+            .filter(|socket| socket.guest_local_address.is_some())
+            .map(|socket| socket.session_id)
             .ok_or(PlatformConnectError::PeerUnchanged(BrokerError::Internal))?;
-        let local_guest_address = if self
+        // The broker-issued binding and the route decide the visible source
+        // before any native state changes; disagreement fails closed.
+        let local_guest_address = self
             .tcp
             .binding_for_socket(id)
-            .ok_or(PlatformConnectError::PeerUnchanged(BrokerError::Internal))?
-            .guest_binding
-            .is_wildcard()
-        {
-            SocketAddrV4::new(Ipv4Addr::LOCALHOST, reserved_local_address.port())
-        } else {
-            reserved_local_address
+            .and_then(|binding| {
+                binding
+                    .guest_binding
+                    .concrete_address_for(&self.network_config, destination)
+            })
+            .ok_or(PlatformConnectError::PeerUnchanged(BrokerError::Internal))?;
+        let concrete_guest_destination = destination.requested();
+        let route = self
+            .resolve_tcp_destination(destination)
+            .map_err(PlatformConnectError::PeerUnchanged)?;
+        let (network_address, guest_listener_id) = match route {
+            SocketOutcome::Completed(route) => route,
+            SocketOutcome::Failed(error) => {
+                let status = SocketConnectionStatus::Failed(error);
+                let socket = self
+                    .sockets
+                    .get_mut(&id)
+                    .ok_or(PlatformConnectError::PeerUnchanged(BrokerError::Internal))?;
+                socket.connection_status = status;
+                update_snapshot(socket, Some(status), ReadinessFlags::ERROR)
+                    .map_err(PlatformConnectError::PeerIndeterminate)?;
+                return Ok(status);
+            }
         };
-        let concrete_guest_destination = if guest_address.ip().is_unspecified() {
-            SocketAddrV4::new(Ipv4Addr::LOCALHOST, guest_address.port())
-        } else {
-            guest_address
-        };
-        let (network_address, guest_listener_id) =
-            match self.resolve_guest_destination(guest_address) {
-                SocketOutcome::Completed(destination) => destination,
-                SocketOutcome::Failed(error) => {
-                    let status = SocketConnectionStatus::Failed(error);
-                    let socket = self
-                        .sockets
-                        .get_mut(&id)
-                        .ok_or(PlatformConnectError::PeerUnchanged(BrokerError::Internal))?;
-                    socket.connection_status = status;
-                    update_snapshot(socket, Some(status), ReadinessFlags::ERROR)
-                        .map_err(PlatformConnectError::PeerIndeterminate)?;
-                    return Ok(status);
-                }
-            };
         if guest_listener_id.is_some() {
             self.expire_deadlined_state(Instant::now());
             self.reserve_pending_guest_connection(session_id)
@@ -1923,46 +1928,46 @@ impl Reactor {
             .any(|host_address| host_address == address)
     }
 
-    /// Reports whether an address names a live broker-private native UDP endpoint.
+    /// Resolves one broker-classified TCP destination to a native target.
     ///
-    /// Native UDP endpoints reserve their host port through an initial wildcard
-    /// bind, so a local address plus a registered host port identifies the
-    /// endpoint. Guest routing must check its namespace first because guest and
-    /// native ports may numerically collide.
-    pub(super) fn resolve_guest_destination(
+    /// A guest route resolves only inside the broker's guest namespace and
+    /// never falls back to a native connection, while gateway and external
+    /// routes translate to a host address that must not name a broker-private
+    /// guest listener endpoint. Guest routing owns its namespace first because
+    /// guest and native ports may numerically collide.
+    pub(super) fn resolve_tcp_destination(
         &self,
-        mut address: SocketAddrV4,
-    ) -> SocketOutcome<(SocketAddrV4, Option<u64>)> {
-        if address.ip().is_unspecified() {
-            address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, address.port());
+        destination: SocketDestination,
+    ) -> BrokerResult<SocketOutcome<(SocketAddrV4, Option<u64>)>> {
+        if !destination.is_valid_for(&self.network_config) {
+            return Err(BrokerError::Internal);
         }
-        if let Some(binding) = self.tcp.guest_binding(address) {
-            // A live guest binding owns this destination port broker-wide;
-            // only a listener with a fully classified backlog may receive
-            // new guest connections through it.
-            if !binding.listening
-                || binding.requires_backlog_drain
-                // Defence in depth for failures after connect(2) but before a
-                // complete host tuple can be recorded.
-                || binding.untracked_connection_deadline.is_some()
-            {
-                return SocketOutcome::Failed(SocketError::ConnectionRefused);
-            }
-            return match binding.host_address {
-                Some(host_address) => {
-                    SocketOutcome::Completed((host_address, Some(binding.socket_id)))
-                }
-                None => SocketOutcome::Failed(SocketError::ConnectionRefused),
-            };
+        let SocketDestination::Guest { requested } = destination else {
+            let host_address = native_host_address(destination).ok_or(BrokerError::Internal)?;
+            return Ok(if self.is_private_tcp_host_endpoint(host_address) {
+                SocketOutcome::Failed(SocketError::ConnectionRefused)
+            } else {
+                SocketOutcome::Completed((host_address, None))
+            });
+        };
+        let Some(binding) = self.tcp.guest_binding(&self.network_config, requested) else {
+            return Ok(SocketOutcome::Failed(SocketError::ConnectionRefused));
+        };
+        // A live guest binding owns this destination port broker-wide; only a
+        // listener with a fully classified backlog may receive new guest
+        // connections through it.
+        if !binding.listening
+            || binding.requires_backlog_drain
+            // Defence in depth for failures after connect(2) but before a
+            // complete host tuple can be recorded.
+            || binding.untracked_connection_deadline.is_some()
+        {
+            return Ok(SocketOutcome::Failed(SocketError::ConnectionRefused));
         }
-        if address.ip().is_loopback() && self.tcp.has_binding_on_port(address.port()) {
-            return SocketOutcome::Failed(SocketError::ConnectionRefused);
-        }
-        if self.is_private_tcp_host_endpoint(address) {
-            SocketOutcome::Failed(SocketError::ConnectionRefused)
-        } else {
-            SocketOutcome::Completed((address, None))
-        }
+        Ok(match binding.host_address {
+            Some(host_address) => SocketOutcome::Completed((host_address, Some(binding.socket_id))),
+            None => SocketOutcome::Failed(SocketError::ConnectionRefused),
+        })
     }
 
     pub(super) fn listen_socket(
@@ -2043,7 +2048,7 @@ impl Reactor {
             return Err(BrokerError::ResourceExhausted);
         }
         let mut unmatched_accept_count = 0;
-        let (socket, remote_address, accepted_local_address) = loop {
+        let (socket, guest_remote_address, accepted_local_address) = loop {
             let (socket, remote_address) = loop {
                 let listener = self
                     .sockets
@@ -2098,6 +2103,23 @@ impl Reactor {
                 return Err(BrokerError::WouldBlock);
             }
         };
+        // Only a guest-namespace peer may be accepted, and both accepted
+        // identities must agree with the shared configuration.
+        let remote = SocketDestination::Guest {
+            requested: guest_remote_address,
+        };
+        if !remote.is_valid_for(&self.network_config)
+            || !self
+                .tcp
+                .binding_for_socket(listener_id)
+                .is_some_and(|binding| {
+                    binding
+                        .guest_binding
+                        .covers(&self.network_config, accepted_local_address)
+                })
+        {
+            return Err(BrokerError::Internal);
+        }
         let listener_session = self
             .sessions
             .get(&listener_session_id)
@@ -2192,7 +2214,7 @@ impl Reactor {
             .ok_or(BrokerError::ResourceExhausted)?;
         Ok(SocketOutcome::Completed(AcceptedEndpoints {
             local_address: accepted_local_address,
-            remote_address,
+            remote,
         }))
     }
 }

--- a/litebox_broker_platform_linux_userland/src/socket/tests/mod.rs
+++ b/litebox_broker_platform_linux_userland/src/socket/tests/mod.rs
@@ -11,13 +11,13 @@ use super::*;
 use litebox_broker_core::readiness::ReadinessSink;
 use litebox_broker_core::{
     BrokerCore, BrokerCoreLimits, BrokerSession, CallerCredential, DestinationPortRange,
-    DestinationRule, Ipv4Cidr, ObjectRights, PolicyEngine, SocketPolicy,
+    DestinationRule, GatewayPortRule, Ipv4Cidr, ObjectRights, PolicyEngine, SocketPolicy,
 };
 use litebox_broker_protocol::ObjectHandle;
 use litebox_broker_protocol::socket::{Ipv4Address, Port, ReceiveSocketResponse};
 
 use super::udp::{
-    MAX_REJECTED_UDP_DATAGRAMS_PER_COMMAND, MAX_UDP_EXTERNAL_PEERS_PER_SOCKET,
+    MAX_REJECTED_UDP_DATAGRAMS_PER_COMMAND, MAX_UDP_NATIVE_PEERS_PER_SOCKET,
     MAX_UDP_NATIVE_RECEIVE_BUFFER, MAX_UDP_QUEUE_DATAGRAMS_PER_SOURCE,
 };
 
@@ -25,6 +25,97 @@ mod tcp;
 mod udp;
 
 const TEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Creates a broker core and Linux provider that share one network configuration.
+///
+/// Every test authorizes the whole host-gateway port range so gateway routing
+/// is exercised by destination classification rather than by policy shape.
+fn broker_with_sockets(
+    socket_policy: &SocketPolicy,
+    limits: BrokerCoreLimits,
+    max_sockets: usize,
+    max_sockets_per_session: usize,
+) -> (BrokerCore, Arc<LinuxSocketProvider>) {
+    // One configuration value reaches both the core and its provider.
+    let network_config = Arc::new(BrokerNetworkConfig::default());
+    broker_with_network_configs(
+        socket_policy,
+        limits,
+        max_sockets,
+        max_sockets_per_session,
+        Arc::clone(&network_config),
+        network_config,
+    )
+}
+
+/// Creates a broker core and provider from explicit network configurations.
+///
+/// Passing a provider configuration that differs from the core's exercises the
+/// provider's fail-closed validation of trusted broker metadata.
+fn broker_with_network_configs(
+    socket_policy: &SocketPolicy,
+    limits: BrokerCoreLimits,
+    max_sockets: usize,
+    max_sockets_per_session: usize,
+    core_config: Arc<BrokerNetworkConfig>,
+    provider_config: Arc<BrokerNetworkConfig>,
+) -> (BrokerCore, Arc<LinuxSocketProvider>) {
+    let provider = Arc::new(
+        LinuxSocketProvider::new(provider_config, max_sockets, max_sockets_per_session).unwrap(),
+    );
+    let gateway_rules = [GatewayPortRule::new(
+        CallerCredential::Unauthenticated,
+        DestinationPortRange::new(Port(1), Port(u16::MAX)).unwrap(),
+    )];
+    let broker = BrokerCore::new_with_limits(
+        PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
+            .with_socket_policy(*socket_policy)
+            .with_gateway_rules(&gateway_rules, &gateway_rules)
+            .unwrap(),
+        limits,
+        core_config,
+        Arc::clone(&provider) as Arc<dyn SocketProvider>,
+    )
+    .unwrap();
+    (broker, provider)
+}
+
+/// Admits the guest namespace for both transports without external rules.
+fn guest_network_policy() -> SocketPolicy {
+    SocketPolicy::from_guest_network_destination_rules(true, &[], true, &[]).unwrap()
+}
+
+/// Returns the shared default guest identity used by every platform test.
+fn test_network_config() -> BrokerNetworkConfig {
+    BrokerNetworkConfig::default()
+}
+
+/// Returns the configured private guest address.
+fn guest_ipv4_address() -> Ipv4Addr {
+    test_network_config().guest_ipv4_address()
+}
+
+/// Returns the guest-visible host gateway address.
+fn gateway_ipv4_address() -> Ipv4Addr {
+    test_network_config().gateway_ipv4_address()
+}
+
+/// Returns the guest-visible gateway address for one host loopback service.
+fn gateway_route(host_address: SocketAddrV4) -> SocketAddrV4 {
+    assert!(
+        host_address.ip().is_loopback(),
+        "a gateway route replaces host loopback access"
+    );
+    SocketAddrV4::new(
+        test_network_config().gateway_ipv4_address(),
+        host_address.port(),
+    )
+}
+
+/// Returns the guest-visible gateway address for one host listener address.
+fn gateway_address(host_address: std::net::SocketAddr) -> SocketAddrV4 {
+    gateway_route(socket_address_v4(host_address))
+}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct ReceivedPlatformDatagram {
@@ -184,6 +275,102 @@ fn synchronous_errors_do_not_consume_tcp_connect_status() {
     ));
 }
 
+#[test]
+fn only_translated_routes_have_a_native_host_address() {
+    let config = test_network_config();
+    let port = 8080;
+    assert_eq!(
+        native_host_address(SocketDestination::Guest {
+            requested: SocketAddrV4::new(Ipv4Addr::LOCALHOST, port)
+        }),
+        None
+    );
+    assert_eq!(
+        native_host_address(SocketDestination::Guest {
+            requested: SocketAddrV4::new(config.guest_ipv4_address(), port)
+        }),
+        None
+    );
+    assert_eq!(
+        native_host_address(SocketDestination::Gateway {
+            requested: SocketAddrV4::new(config.gateway_ipv4_address(), port)
+        }),
+        Some(SocketAddrV4::new(Ipv4Addr::LOCALHOST, port))
+    );
+    let external = SocketAddrV4::new(Ipv4Addr::new(203, 0, 113, 9), port);
+    assert_eq!(
+        native_host_address(SocketDestination::External {
+            requested: external
+        }),
+        Some(external)
+    );
+}
+
+#[test]
+fn provider_configuration_disagreement_fails_closed() {
+    let provider_config = Arc::new(
+        BrokerNetworkConfig::new(Ipv4Addr::new(172, 16, 0, 2), Ipv4Addr::new(172, 16, 0, 1))
+            .expect("the divergent provider addresses are valid"),
+    );
+    let (broker, provider) = broker_with_network_configs(
+        &guest_network_policy(),
+        BrokerCoreLimits::new_with_all_limits(8, 0, 4, 4),
+        4,
+        4,
+        Arc::new(BrokerNetworkConfig::default()),
+        provider_config,
+    );
+    let session = broker
+        .create_session(CallerCredential::Unauthenticated)
+        .unwrap();
+    let (published, _publications) = channel();
+    let (retired, _retirements) = channel();
+    let readiness = Arc::new(TestReadinessSink { published, retired });
+
+    // A binding the provider's configuration cannot represent is rejected
+    // before any guest or native state exists for it.
+    let datagram = create_udp_socket(&session, readiness.clone());
+    assert_eq!(
+        litebox_broker_core::socket::bind(
+            &session,
+            datagram,
+            SocketAddrV4::new(guest_ipv4_address(), 0),
+        ),
+        Err(BrokerError::Internal)
+    );
+    // A route tag that disagrees with the provider's configuration cannot
+    // select a native destination.
+    assert_eq!(
+        send_datagram(
+            &session,
+            datagram,
+            b"gateway",
+            SendFlags::NONE,
+            Some(SocketAddrV4::new(gateway_ipv4_address(), 9000)),
+        ),
+        Err(BrokerError::Internal)
+    );
+    assert_eq!(provider.reactor.udp_native_endpoint_count(), 0);
+    assert_eq!(provider.reactor.udp_native_event_token_count(), 0);
+    assert_eq!(provider.reactor.udp_native_peer_count(), 0);
+
+    let stream = create_socket(&session, readiness);
+    assert_eq!(
+        litebox_broker_core::socket::connect(
+            &session,
+            stream,
+            SocketAddrV4::new(gateway_ipv4_address(), 9000),
+        ),
+        Err(BrokerError::Internal)
+    );
+    assert_eq!(
+        litebox_broker_core::socket::status(&session, stream)
+            .unwrap()
+            .status,
+        SocketConnectionStatus::Unconnected
+    );
+}
+
 struct TestReadinessSink {
     published: Sender<(ObjectHandle, ReadinessFlags)>,
     retired: Sender<ObjectHandle>,
@@ -300,14 +487,12 @@ fn directional_shutdown_survives_readiness_publication_failure() {
         wait_to_release_server.recv_timeout(TEST_TIMEOUT).unwrap();
     });
 
-    let provider = Arc::new(LinuxSocketProvider::new(2, 2).unwrap());
-    let broker = BrokerCore::new_with_limits(
-        PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+    let (broker, _provider) = broker_with_sockets(
+        &guest_network_policy(),
         BrokerCoreLimits::new_with_all_limits(4, 0, 2, 2),
-        provider,
-    )
-    .unwrap();
+        2,
+        2,
+    );
     let session = broker
         .create_session(CallerCredential::Unauthenticated)
         .unwrap();
@@ -320,7 +505,7 @@ fn directional_shutdown_survives_readiness_publication_failure() {
 
     let tcp = create_socket(&session, readiness.clone());
     assert!(matches!(
-        litebox_broker_core::socket::connect(&session, tcp, socket_address_v4(address)),
+        litebox_broker_core::socket::connect(&session, tcp, gateway_address(address)),
         Ok(SocketOutcome::Completed(
             SocketConnectionStatus::Connecting | SocketConnectionStatus::Connected
         ))

--- a/litebox_broker_platform_linux_userland/src/socket/tests/tcp.rs
+++ b/litebox_broker_platform_linux_userland/src/socket/tests/tcp.rs
@@ -116,14 +116,12 @@ fn tuple_collision_persists_its_discard_marker() {
 
 #[test]
 fn untracked_guest_connection_cleanup_is_bounded_and_drains_backlog() {
-    let provider = Arc::new(LinuxSocketProvider::new(6, 3).unwrap());
-    let broker = BrokerCore::new_with_limits(
-        PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+    let (broker, provider) = broker_with_sockets(
+        &guest_network_policy(),
         BrokerCoreLimits::new_with_all_limits(12, 0, 6, 6),
-        provider.clone(),
-    )
-    .unwrap();
+        6,
+        3,
+    );
     let listener_session = broker
         .create_session(CallerCredential::Unauthenticated)
         .unwrap();
@@ -268,14 +266,12 @@ fn reactor_drives_a_loopback_tcp_socket() {
         assert_eq!(error.kind(), std::io::ErrorKind::ConnectionReset);
     });
 
-    let provider = Arc::new(LinuxSocketProvider::new(8, 8).unwrap());
-    let broker = BrokerCore::new_with_limits(
-        PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+    let (broker, _provider) = broker_with_sockets(
+        &guest_network_policy(),
         BrokerCoreLimits::new_with_all_limits(16, 0, 8, 8),
-        provider,
-    )
-    .unwrap();
+        8,
+        8,
+    );
     let session = broker
         .create_session(CallerCredential::Unauthenticated)
         .unwrap();
@@ -284,7 +280,7 @@ fn reactor_drives_a_loopback_tcp_socket() {
     let readiness = Arc::new(TestReadinessSink { published, retired });
     let handle = create_socket(&session, readiness.clone());
     let connect =
-        litebox_broker_core::socket::connect(&session, handle, socket_address_v4(address)).unwrap();
+        litebox_broker_core::socket::connect(&session, handle, gateway_address(address)).unwrap();
     assert!(matches!(
         connect,
         SocketOutcome::Completed(
@@ -297,7 +293,9 @@ fn reactor_drives_a_loopback_tcp_socket() {
     let local_address = status
         .local_address
         .expect("connected socket must expose its local address");
-    assert_eq!(*local_address.ip(), Ipv4Addr::LOCALHOST);
+    // An implicit wildcard binding answers a gateway route with the shared
+    // private guest identity rather than a host-selected source.
+    assert_eq!(*local_address.ip(), guest_ipv4_address());
     assert_ne!(local_address.port(), 0);
     assert_eq!(status.pending_error, None);
     assert_eq!(
@@ -391,7 +389,7 @@ fn reactor_drives_a_loopback_tcp_socket() {
     let read_shutdown_connect = litebox_broker_core::socket::connect(
         &session,
         read_shutdown_handle,
-        socket_address_v4(read_shutdown_address),
+        gateway_address(read_shutdown_address),
     )
     .unwrap();
     assert!(matches!(
@@ -518,7 +516,7 @@ fn reactor_drives_a_loopback_tcp_socket() {
     let refused_connect = litebox_broker_core::socket::connect(
         &session,
         refused_handle,
-        socket_address_v4(refused_address),
+        gateway_address(refused_address),
     )
     .unwrap();
     assert!(matches!(
@@ -542,7 +540,7 @@ fn reactor_drives_a_loopback_tcp_socket() {
     let abort_connect = litebox_broker_core::socket::connect(
         &session,
         abort_handle,
-        socket_address_v4(abort_address),
+        gateway_address(abort_address),
     )
     .unwrap();
     assert!(matches!(
@@ -601,14 +599,12 @@ fn tcp_receive_survives_readiness_publication_failure() {
         wait_to_release_server.recv_timeout(TEST_TIMEOUT).unwrap();
     });
 
-    let provider = Arc::new(LinuxSocketProvider::new(1, 1).unwrap());
-    let broker = BrokerCore::new_with_limits(
-        PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+    let (broker, _provider) = broker_with_sockets(
+        &guest_network_policy(),
         BrokerCoreLimits::new_with_all_limits(2, 0, 1, 1),
-        provider,
-    )
-    .unwrap();
+        1,
+        1,
+    );
     let session = broker
         .create_session(CallerCredential::Unauthenticated)
         .unwrap();
@@ -620,7 +616,7 @@ fn tcp_receive_survives_readiness_publication_failure() {
     });
     let handle = create_socket(&session, readiness.clone());
     assert!(matches!(
-        litebox_broker_core::socket::connect(&session, handle, socket_address_v4(address),),
+        litebox_broker_core::socket::connect(&session, handle, gateway_address(address),),
         Ok(SocketOutcome::Completed(
             SocketConnectionStatus::Connecting | SocketConnectionStatus::Connected
         ))
@@ -659,14 +655,12 @@ fn tcp_status_publication_failure_preserves_consumed_error() {
         sockopt::set_socket_linger(&stream, Some(Duration::ZERO)).unwrap();
     });
 
-    let provider = Arc::new(LinuxSocketProvider::new(1, 1).unwrap());
-    let broker = BrokerCore::new_with_limits(
-        PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+    let (broker, _provider) = broker_with_sockets(
+        &guest_network_policy(),
         BrokerCoreLimits::new_with_all_limits(2, 0, 1, 1),
-        provider,
-    )
-    .unwrap();
+        1,
+        1,
+    );
     let session = broker
         .create_session(CallerCredential::Unauthenticated)
         .unwrap();
@@ -678,7 +672,7 @@ fn tcp_status_publication_failure_preserves_consumed_error() {
     });
     let handle = create_socket(&session, readiness.clone());
     assert!(matches!(
-        litebox_broker_core::socket::connect(&session, handle, socket_address_v4(address),),
+        litebox_broker_core::socket::connect(&session, handle, gateway_address(address),),
         Ok(SocketOutcome::Completed(
             SocketConnectionStatus::Connecting | SocketConnectionStatus::Connected
         ))
@@ -719,14 +713,12 @@ fn exhausted_tcp_peek_cache_refreshes_before_terminal_eof() {
         stream.shutdown(Shutdown::Write).unwrap();
     });
 
-    let provider = Arc::new(LinuxSocketProvider::new(1, 1).unwrap());
-    let broker = BrokerCore::new_with_limits(
-        PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+    let (broker, _provider) = broker_with_sockets(
+        &guest_network_policy(),
         BrokerCoreLimits::new_with_all_limits(2, 0, 1, 1),
-        provider,
-    )
-    .unwrap();
+        1,
+        1,
+    );
     let session = broker
         .create_session(CallerCredential::Unauthenticated)
         .unwrap();
@@ -735,7 +727,7 @@ fn exhausted_tcp_peek_cache_refreshes_before_terminal_eof() {
     let readiness = Arc::new(TestReadinessSink { published, retired });
     let handle = create_socket(&session, readiness);
     assert!(matches!(
-        litebox_broker_core::socket::connect(&session, handle, socket_address_v4(address),),
+        litebox_broker_core::socket::connect(&session, handle, gateway_address(address),),
         Ok(SocketOutcome::Completed(
             SocketConnectionStatus::Connecting | SocketConnectionStatus::Connected
         ))
@@ -788,14 +780,12 @@ fn exhausted_tcp_peek_cache_refreshes_before_terminal_eof() {
 
 #[test]
 fn accepted_guest_tcp_close_with_unread_data_preserves_reset() {
-    let provider = Arc::new(LinuxSocketProvider::new(3, 2).unwrap());
-    let broker = BrokerCore::new_with_limits(
-        PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+    let (broker, _provider) = broker_with_sockets(
+        &guest_network_policy(),
         BrokerCoreLimits::new_with_all_limits(6, 0, 3, 3),
-        provider,
-    )
-    .unwrap();
+        3,
+        2,
+    );
     let listener_session = broker
         .create_session(CallerCredential::Unauthenticated)
         .unwrap();
@@ -871,14 +861,12 @@ fn accepted_guest_tcp_close_with_unread_data_preserves_reset() {
 
 #[test]
 fn guest_tcp_namespace_routes_across_sessions_and_hides_private_backend() {
-    let provider = Arc::new(LinuxSocketProvider::new(5, 3).unwrap());
-    let broker = BrokerCore::new_with_limits(
-        PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+    let (broker, provider) = broker_with_sockets(
+        &guest_network_policy(),
         BrokerCoreLimits::new_with_all_limits(8, 0, 5, 4),
-        provider.clone(),
-    )
-    .unwrap();
+        5,
+        3,
+    );
     let listener_session = broker
         .create_session(CallerCredential::Unauthenticated)
         .unwrap();
@@ -1031,19 +1019,12 @@ fn guest_tcp_namespace_routes_across_sessions_and_hides_private_backend() {
 
 #[test]
 fn tcp_exact_bindings_coexist_and_wildcard_accepts_concrete_destinations() {
-    let provider = Arc::new(LinuxSocketProvider::new(12, 8).unwrap());
-    let policy = SocketPolicy::from_tcp_destination_rules(&[DestinationRule::new(
-        CallerCredential::Unauthenticated,
-        Ipv4Cidr::new(Ipv4Address([0, 0, 0, 0]), 0).unwrap(),
-        DestinationPortRange::new(Port(1), Port(u16::MAX)).unwrap(),
-    )])
-    .unwrap();
-    let broker = BrokerCore::new_with_limits(
-        PolicyEngine::with_unauthenticated_rights(ObjectRights::all()).with_socket_policy(policy),
+    let (broker, _provider) = broker_with_sockets(
+        &guest_network_policy(),
         BrokerCoreLimits::new_with_all_limits(20, 0, 12, 12),
-        provider,
-    )
-    .unwrap();
+        12,
+        8,
+    );
     let listener_session = broker
         .create_session(CallerCredential::Unauthenticated)
         .unwrap();
@@ -1154,7 +1135,7 @@ fn tcp_exact_bindings_coexist_and_wildcard_accepts_concrete_destinations() {
             .unwrap()
             .local_address,
         Some(SocketAddrV4::new(
-            Ipv4Addr::LOCALHOST,
+            *concrete_destination.ip(),
             connector_binding.port(),
         ))
     );
@@ -1177,7 +1158,7 @@ fn tcp_exact_bindings_coexist_and_wildcard_accepts_concrete_destinations() {
     assert_eq!(accepted.local_address, concrete_destination);
     assert_eq!(
         accepted.remote_address,
-        SocketAddrV4::new(Ipv4Addr::LOCALHOST, connector_binding.port())
+        SocketAddrV4::new(*concrete_destination.ip(), connector_binding.port())
     );
 
     let unspecified_connector = create_socket(&connector_session, readiness.clone());
@@ -1213,14 +1194,12 @@ fn tcp_exact_bindings_coexist_and_wildcard_accepts_concrete_destinations() {
 
 #[test]
 fn connector_and_session_teardown_clean_bounded_pending_state() {
-    let provider = Arc::new(LinuxSocketProvider::new(3, 1).unwrap());
-    let broker = BrokerCore::new_with_limits(
-        PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+    let (broker, provider) = broker_with_sockets(
+        &guest_network_policy(),
         BrokerCoreLimits::new_with_all_limits(8, 0, 3, 3),
-        provider.clone(),
-    )
-    .unwrap();
+        3,
+        1,
+    );
     let listener_session = broker
         .create_session(CallerCredential::Unauthenticated)
         .unwrap();
@@ -1331,14 +1310,12 @@ fn connector_and_session_teardown_clean_bounded_pending_state() {
 
 #[test]
 fn graceful_connector_close_preserves_late_accept_and_eof() {
-    let provider = Arc::new(LinuxSocketProvider::new(4, 2).unwrap());
-    let broker = BrokerCore::new_with_limits(
-        PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+    let (broker, provider) = broker_with_sockets(
+        &guest_network_policy(),
         BrokerCoreLimits::new_with_all_limits(8, 0, 4, 4),
-        provider.clone(),
-    )
-    .unwrap();
+        4,
+        2,
+    );
     let listener_session = broker
         .create_session(CallerCredential::Unauthenticated)
         .unwrap();
@@ -1396,14 +1373,12 @@ fn graceful_connector_close_preserves_late_accept_and_eof() {
 
 #[test]
 fn abortive_connector_close_releases_descriptor_capacity() {
-    let provider = Arc::new(LinuxSocketProvider::new(3, 1).unwrap());
-    let broker = BrokerCore::new_with_limits(
-        PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+    let (broker, provider) = broker_with_sockets(
+        &guest_network_policy(),
         BrokerCoreLimits::new_with_all_limits(8, 0, 3, 3),
-        provider.clone(),
-    )
-    .unwrap();
+        3,
+        1,
+    );
     let listener_session = broker
         .create_session(CallerCredential::Unauthenticated)
         .unwrap();
@@ -1479,14 +1454,12 @@ fn abortive_connector_close_releases_descriptor_capacity() {
 
 #[test]
 fn accept_bounds_unmatched_private_connections_per_command() {
-    let provider = Arc::new(LinuxSocketProvider::new(3, 2).unwrap());
-    let broker = BrokerCore::new_with_limits(
-        PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+    let (broker, provider) = broker_with_sockets(
+        &guest_network_policy(),
         BrokerCoreLimits::new_with_all_limits(8, 0, 3, 3),
-        provider.clone(),
-    )
-    .unwrap();
+        3,
+        2,
+    );
     let listener_session = broker
         .create_session(CallerCredential::Unauthenticated)
         .unwrap();
@@ -1559,14 +1532,12 @@ fn accept_bounds_unmatched_private_connections_per_command() {
 
 #[test]
 fn accept_preserves_a_queued_connection_when_retained_capacity_is_unrelated() {
-    let provider = Arc::new(LinuxSocketProvider::new(4, 4).unwrap());
-    let broker = BrokerCore::new_with_limits(
-        PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+    let (broker, provider) = broker_with_sockets(
+        &guest_network_policy(),
         BrokerCoreLimits::new_with_all_limits(8, 0, 5, 5),
-        provider.clone(),
-    )
-    .unwrap();
+        4,
+        4,
+    );
     let target_listener_session = broker
         .create_session(CallerCredential::Unauthenticated)
         .unwrap();
@@ -1668,14 +1639,12 @@ fn accept_preserves_a_queued_connection_when_retained_capacity_is_unrelated() {
 
 #[test]
 fn stop_listening_cleanup_survives_readiness_failure() {
-    let provider = Arc::new(LinuxSocketProvider::new(3, 1).unwrap());
-    let broker = BrokerCore::new_with_limits(
-        PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+    let (broker, provider) = broker_with_sockets(
+        &guest_network_policy(),
         BrokerCoreLimits::new_with_all_limits(8, 0, 3, 3),
-        provider.clone(),
-    )
-    .unwrap();
+        3,
+        1,
+    );
     let listener_session = broker
         .create_session(CallerCredential::Unauthenticated)
         .unwrap();
@@ -1762,14 +1731,12 @@ fn stop_listening_cleanup_survives_readiness_failure() {
 
 #[test]
 fn reactor_drives_a_loopback_tcp_listener() {
-    let provider = Arc::new(LinuxSocketProvider::new(6, 6).unwrap());
-    let broker = BrokerCore::new_with_limits(
-        PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+    let (broker, provider) = broker_with_sockets(
+        &guest_network_policy(),
         BrokerCoreLimits::new_with_all_limits(8, 0, 6, 6),
-        provider.clone(),
-    )
-    .unwrap();
+        6,
+        6,
+    );
     let session = broker
         .create_session(CallerCredential::Unauthenticated)
         .unwrap();
@@ -1783,8 +1750,10 @@ fn reactor_drives_a_loopback_tcp_listener() {
         SocketOutcome::Completed(address) => address,
         SocketOutcome::Failed(error) => panic!("listen failed: {error:?}"),
     };
-    assert!(local_address.ip().is_loopback());
+    // An implicit listen reserves the whole guest namespace on one port.
+    assert!(local_address.ip().is_unspecified());
     assert_ne!(local_address.port(), 0);
+    let accepted_local_address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, local_address.port());
     let private_address = provider
         .reactor
         .host_address(local_address.port())
@@ -1838,7 +1807,7 @@ fn reactor_drives_a_loopback_tcp_listener() {
             SocketOutcome::Completed(accepted) => accepted,
             SocketOutcome::Failed(error) => panic!("first accept failed: {error:?}"),
         };
-    assert_eq!(first.local_address, local_address);
+    assert_eq!(first.local_address, accepted_local_address);
     assert_eq!(first.remote_address, first_client_address);
     assert!(
         session
@@ -1853,7 +1822,7 @@ fn reactor_drives_a_loopback_tcp_listener() {
             SocketOutcome::Completed(accepted) => accepted,
             SocketOutcome::Failed(error) => panic!("second accept failed: {error:?}"),
         };
-    assert_eq!(second.local_address, local_address);
+    assert_eq!(second.local_address, accepted_local_address);
     assert_eq!(second.remote_address, second_client_address);
     assert!(
         !session
@@ -1942,5 +1911,337 @@ fn reactor_drives_a_loopback_tcp_listener() {
             .checked_duration_since(Instant::now())
             .expect("timed out waiting for listener retirements");
         observed.push(retirements.recv_timeout(remaining).unwrap());
+    }
+}
+
+#[test]
+fn guest_tcp_routes_private_addresses_without_native_fallback() {
+    let (broker, _provider) = broker_with_sockets(
+        &guest_network_policy(),
+        BrokerCoreLimits::new_with_all_limits(16, 0, 10, 10),
+        10,
+        10,
+    );
+    let listener_session = broker
+        .create_session(CallerCredential::Unauthenticated)
+        .unwrap();
+    let connector_session = broker
+        .create_session(CallerCredential::Unauthenticated)
+        .unwrap();
+    let (published, publications) = channel();
+    let (retired, retirements) = channel();
+    let readiness = Arc::new(TestReadinessSink { published, retired });
+
+    let host_listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    host_listener.set_nonblocking(true).unwrap();
+    let shadowed_port = host_listener.local_addr().unwrap().port();
+    for shadowed in [
+        SocketAddrV4::new(Ipv4Addr::LOCALHOST, shadowed_port),
+        SocketAddrV4::new(guest_ipv4_address(), shadowed_port),
+    ] {
+        let miss = create_socket(&connector_session, readiness.clone());
+        assert_eq!(
+            litebox_broker_core::socket::connect(&connector_session, miss, shadowed),
+            Ok(SocketOutcome::Completed(SocketConnectionStatus::Failed(
+                SocketError::ConnectionRefused,
+            )))
+        );
+        connector_session.close_object_reference(miss).unwrap();
+        assert_eq!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), miss);
+    }
+    // A guest miss never falls through to the host service holding that port.
+    assert_eq!(
+        host_listener.accept().unwrap_err().kind(),
+        ErrorKind::WouldBlock
+    );
+
+    let exact_listener = create_socket(&listener_session, readiness.clone());
+    let SocketOutcome::Completed(exact_address) = litebox_broker_core::socket::bind(
+        &listener_session,
+        exact_listener,
+        SocketAddrV4::new(guest_ipv4_address(), 0),
+    )
+    .unwrap() else {
+        panic!("exact private guest bind failed");
+    };
+    assert_eq!(*exact_address.ip(), guest_ipv4_address());
+    assert_eq!(
+        litebox_broker_core::socket::listen(&listener_session, exact_listener, 2),
+        Ok(SocketOutcome::Completed(exact_address))
+    );
+
+    let wildcard_listener = create_socket(&listener_session, readiness.clone());
+    let SocketOutcome::Completed(wildcard_address) = litebox_broker_core::socket::bind(
+        &listener_session,
+        wildcard_listener,
+        SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0),
+    )
+    .unwrap() else {
+        panic!("wildcard guest bind failed");
+    };
+    assert_eq!(
+        litebox_broker_core::socket::listen(&listener_session, wildcard_listener, 2),
+        Ok(SocketOutcome::Completed(wildcard_address))
+    );
+    let wildcard_private_destination =
+        SocketAddrV4::new(guest_ipv4_address(), wildcard_address.port());
+
+    for (listener, destination) in [
+        (exact_listener, exact_address),
+        (wildcard_listener, wildcard_private_destination),
+    ] {
+        let connector = create_socket(&connector_session, readiness.clone());
+        assert!(matches!(
+            litebox_broker_core::socket::connect(&connector_session, connector, destination),
+            Ok(SocketOutcome::Completed(
+                SocketConnectionStatus::Connecting | SocketConnectionStatus::Connected
+            ))
+        ));
+        wait_until_connected(&connector_session, connector, &publications);
+        let connector_address = litebox_broker_core::socket::status(&connector_session, connector)
+            .unwrap()
+            .local_address
+            .unwrap();
+        assert_eq!(*connector_address.ip(), guest_ipv4_address());
+        wait_until_ready(
+            &listener_session,
+            &publications,
+            listener,
+            ReadinessFlags::READ,
+        );
+        let accepted = match litebox_broker_core::socket::accept(
+            &listener_session,
+            listener,
+            readiness.clone(),
+        )
+        .unwrap()
+        {
+            SocketOutcome::Completed(accepted) => accepted,
+            SocketOutcome::Failed(error) => panic!("private guest accept failed: {error:?}"),
+        };
+        assert_eq!(accepted.local_address, destination);
+        assert_eq!(accepted.remote_address, connector_address);
+    }
+    assert_eq!(
+        host_listener.accept().unwrap_err().kind(),
+        ErrorKind::WouldBlock
+    );
+}
+
+#[test]
+fn gateway_tcp_reaches_the_host_only_through_the_translated_route() {
+    let host_listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let host_address = socket_address_v4(host_listener.local_addr().unwrap());
+    let closed_listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let closed_address = socket_address_v4(closed_listener.local_addr().unwrap());
+    drop(closed_listener);
+    host_listener.set_nonblocking(true).unwrap();
+
+    let (broker, provider) = broker_with_sockets(
+        &guest_network_policy(),
+        BrokerCoreLimits::new_with_all_limits(12, 0, 8, 8),
+        8,
+        8,
+    );
+    let session = broker
+        .create_session(CallerCredential::Unauthenticated)
+        .unwrap();
+    let (published, publications) = channel();
+    let (retired, _retirements) = channel();
+    let readiness = Arc::new(TestReadinessSink { published, retired });
+
+    // The literal host address is guest-internal and cannot reach the host.
+    let literal = create_socket(&session, readiness.clone());
+    assert_eq!(
+        litebox_broker_core::socket::connect(&session, literal, host_address),
+        Ok(SocketOutcome::Completed(SocketConnectionStatus::Failed(
+            SocketError::ConnectionRefused,
+        )))
+    );
+    assert_eq!(
+        host_listener.accept().unwrap_err().kind(),
+        ErrorKind::WouldBlock
+    );
+
+    let gateway = create_socket(&session, readiness.clone());
+    assert!(matches!(
+        litebox_broker_core::socket::connect(&session, gateway, gateway_route(host_address)),
+        Ok(SocketOutcome::Completed(
+            SocketConnectionStatus::Connecting | SocketConnectionStatus::Connected
+        ))
+    ));
+    wait_until_connected(&session, gateway, &publications);
+    host_listener.set_nonblocking(false).unwrap();
+    let (_accepted, host_peer) = host_listener.accept().unwrap();
+    assert!(socket_address_v4(host_peer).ip().is_loopback());
+    assert_eq!(
+        litebox_broker_core::socket::status(&session, gateway)
+            .unwrap()
+            .local_address
+            .map(|address| *address.ip()),
+        Some(guest_ipv4_address())
+    );
+
+    // A gateway failure stays on the translated route instead of retrying the
+    // literal gateway address, which no host service answers.
+    let refused = create_socket(&session, readiness.clone());
+    assert!(matches!(
+        litebox_broker_core::socket::connect(&session, refused, gateway_route(closed_address)),
+        Ok(SocketOutcome::Completed(
+            SocketConnectionStatus::Connecting | SocketConnectionStatus::Failed(_)
+        ))
+    ));
+    assert_eq!(
+        wait_until_failed(&session, refused, &publications),
+        SocketError::ConnectionRefused
+    );
+
+    // A gateway port that collides with a broker-private listener endpoint is
+    // refused rather than injected into the guest namespace.
+    let guest_listener = create_socket(&session, readiness.clone());
+    let SocketOutcome::Completed(guest_address) = litebox_broker_core::socket::bind(
+        &session,
+        guest_listener,
+        SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0),
+    )
+    .unwrap() else {
+        panic!("guest listener bind failed");
+    };
+    assert_eq!(
+        litebox_broker_core::socket::listen(&session, guest_listener, 1),
+        Ok(SocketOutcome::Completed(guest_address))
+    );
+    let private_address = provider
+        .reactor
+        .host_address(guest_address.port())
+        .expect("guest listener backend must be realized");
+    let collision = create_socket(&session, readiness.clone());
+    assert_eq!(
+        litebox_broker_core::socket::connect(&session, collision, gateway_route(private_address)),
+        Ok(SocketOutcome::Completed(SocketConnectionStatus::Failed(
+            SocketError::ConnectionRefused,
+        )))
+    );
+    assert!(matches!(
+        litebox_broker_core::socket::accept(&session, guest_listener, readiness),
+        Err(BrokerError::WouldBlock)
+    ));
+}
+
+#[test]
+fn tcp_source_identity_follows_the_binding_and_route() {
+    let host_listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let host_address = socket_address_v4(host_listener.local_addr().unwrap());
+    host_listener.set_nonblocking(true).unwrap();
+
+    let (broker, _provider) = broker_with_sockets(
+        &guest_network_policy(),
+        BrokerCoreLimits::new_with_all_limits(16, 0, 10, 10),
+        10,
+        10,
+    );
+    let session = broker
+        .create_session(CallerCredential::Unauthenticated)
+        .unwrap();
+    let (published, publications) = channel();
+    let (retired, _retirements) = channel();
+    let readiness = Arc::new(TestReadinessSink { published, retired });
+
+    // An exact loopback binding may never leave the guest namespace.
+    let loopback_bound = create_socket(&session, readiness.clone());
+    let SocketOutcome::Completed(loopback_source) = litebox_broker_core::socket::bind(
+        &session,
+        loopback_bound,
+        SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0),
+    )
+    .unwrap() else {
+        panic!("exact loopback bind failed");
+    };
+    assert_eq!(
+        litebox_broker_core::socket::connect(&session, loopback_bound, gateway_route(host_address)),
+        Ok(SocketOutcome::Completed(SocketConnectionStatus::Failed(
+            SocketError::InvalidArgument,
+        )))
+    );
+    assert_eq!(
+        host_listener.accept().unwrap_err().kind(),
+        ErrorKind::WouldBlock
+    );
+
+    // An exact private binding keeps its own identity on a gateway route.
+    let private_bound = create_socket(&session, readiness.clone());
+    let SocketOutcome::Completed(private_source) = litebox_broker_core::socket::bind(
+        &session,
+        private_bound,
+        SocketAddrV4::new(guest_ipv4_address(), 0),
+    )
+    .unwrap() else {
+        panic!("exact private bind failed");
+    };
+    assert!(matches!(
+        litebox_broker_core::socket::connect(&session, private_bound, gateway_route(host_address)),
+        Ok(SocketOutcome::Completed(
+            SocketConnectionStatus::Connecting | SocketConnectionStatus::Connected
+        ))
+    ));
+    wait_until_connected(&session, private_bound, &publications);
+    assert_eq!(
+        litebox_broker_core::socket::status(&session, private_bound)
+            .unwrap()
+            .local_address,
+        Some(private_source)
+    );
+    assert_ne!(loopback_source, private_source);
+
+    // A wildcard binding selects one concrete source per route.
+    let listener = create_socket(&session, readiness.clone());
+    let SocketOutcome::Completed(listener_address) = litebox_broker_core::socket::bind(
+        &session,
+        listener,
+        SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0),
+    )
+    .unwrap() else {
+        panic!("wildcard listener bind failed");
+    };
+    assert_eq!(
+        litebox_broker_core::socket::listen(&session, listener, 2),
+        Ok(SocketOutcome::Completed(listener_address))
+    );
+    for (destination, expected_source_ip) in [
+        (
+            SocketAddrV4::new(Ipv4Addr::LOCALHOST, listener_address.port()),
+            Ipv4Addr::LOCALHOST,
+        ),
+        (
+            SocketAddrV4::new(guest_ipv4_address(), listener_address.port()),
+            guest_ipv4_address(),
+        ),
+        (gateway_route(host_address), guest_ipv4_address()),
+    ] {
+        let connector = create_socket(&session, readiness.clone());
+        assert!(matches!(
+            litebox_broker_core::socket::connect(&session, connector, destination),
+            Ok(SocketOutcome::Completed(
+                SocketConnectionStatus::Connecting | SocketConnectionStatus::Connected
+            ))
+        ));
+        wait_until_connected(&session, connector, &publications);
+        let source = litebox_broker_core::socket::status(&session, connector)
+            .unwrap()
+            .local_address
+            .expect("connected socket must expose its source");
+        assert_eq!(*source.ip(), expected_source_ip);
+        if destination != gateway_route(host_address) {
+            wait_until_ready(&session, &publications, listener, ReadinessFlags::READ);
+            let accepted =
+                match litebox_broker_core::socket::accept(&session, listener, readiness.clone())
+                    .unwrap()
+                {
+                    SocketOutcome::Completed(accepted) => accepted,
+                    SocketOutcome::Failed(error) => panic!("guest accept failed: {error:?}"),
+                };
+            assert_eq!(accepted.local_address, destination);
+            assert_eq!(accepted.remote_address, source);
+        }
     }
 }

--- a/litebox_broker_platform_linux_userland/src/socket/tests/udp.rs
+++ b/litebox_broker_platform_linux_userland/src/socket/tests/udp.rs
@@ -5,14 +5,12 @@ use super::*;
 
 #[test]
 fn guest_udp_readiness_failure_rolls_back_enqueue() {
-    let provider = Arc::new(LinuxSocketProvider::new(2, 1).unwrap());
-    let broker = BrokerCore::new_with_limits(
-        PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+    let (broker, provider) = broker_with_sockets(
+        &guest_network_policy(),
         BrokerCoreLimits::new_with_all_limits(4, 0, 2, 1),
-        provider.clone(),
-    )
-    .unwrap();
+        2,
+        1,
+    );
     let receiver_session = broker
         .create_session(CallerCredential::Unauthenticated)
         .unwrap();
@@ -102,14 +100,12 @@ fn guest_udp_readiness_failure_rolls_back_enqueue() {
 
 #[test]
 fn native_udp_readiness_failure_does_not_fail_shared_reactor() {
-    let provider = Arc::new(LinuxSocketProvider::new(2, 2).unwrap());
-    let broker = BrokerCore::new_with_limits(
-        PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+    let (broker, _provider) = broker_with_sockets(
+        &guest_network_policy(),
         BrokerCoreLimits::new_with_all_limits(4, 0, 2, 2),
-        provider,
-    )
-    .unwrap();
+        2,
+        2,
+    );
     let session = broker
         .create_session(CallerCredential::Unauthenticated)
         .unwrap();
@@ -120,25 +116,25 @@ fn native_udp_readiness_failure_does_not_fail_shared_reactor() {
         fail_next_publish: Mutex::new(None),
     });
     let socket = create_udp_socket(&session, readiness.clone());
-    let external = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
-    external.set_read_timeout(Some(TEST_TIMEOUT)).unwrap();
-    let external_address = socket_address_v4(external.local_addr().unwrap());
+    let gateway_peer = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    gateway_peer.set_read_timeout(Some(TEST_TIMEOUT)).unwrap();
+    let gateway_peer_route = gateway_address(gateway_peer.local_addr().unwrap());
     assert_eq!(
         send_datagram(
             &session,
             socket,
             b"contact",
             SendFlags::NONE,
-            Some(external_address),
+            Some(gateway_peer_route),
         ),
         Ok(SocketOutcome::Completed(7))
     );
     let mut contact = [0; 7];
-    let (_, native_address) = external.recv_from(&mut contact).unwrap();
+    let (_, native_address) = gateway_peer.recv_from(&mut contact).unwrap();
     assert_eq!(&contact, b"contact");
 
     readiness.fail_next_publish_matching(socket, ReadinessFlags::READ, ReadinessFlags::default());
-    external.send_to(b"reply", native_address).unwrap();
+    gateway_peer.send_to(b"reply", native_address).unwrap();
     let deadline = Instant::now() + TEST_TIMEOUT;
     while !session
         .check_readiness(socket)
@@ -159,7 +155,7 @@ fn native_udp_readiness_failure_does_not_fail_shared_reactor() {
         Ok(SocketOutcome::Completed(ReceivedPlatformDatagram {
             received: 5,
             datagram_length: 5,
-            source_address: external_address,
+            source_address: gateway_peer_route,
         }))
     );
     assert_eq!(&reply, b"reply");
@@ -171,8 +167,8 @@ fn native_udp_readiness_failure_does_not_fail_shared_reactor() {
             .contains(ReadinessFlags::READ)
     );
 
-    external.send_to(b"first", native_address).unwrap();
-    external.send_to(b"second", native_address).unwrap();
+    gateway_peer.send_to(b"first", native_address).unwrap();
+    gateway_peer.send_to(b"second", native_address).unwrap();
     wait_until_ready(&session, &publications, socket, ReadinessFlags::READ);
     readiness.fail_next_publish_matching(socket, ReadinessFlags::default(), ReadinessFlags::READ);
     for (index, expected) in [b"first".as_slice(), b"second".as_slice()]
@@ -190,7 +186,7 @@ fn native_udp_readiness_failure_does_not_fail_shared_reactor() {
             Ok(SocketOutcome::Completed(ReceivedPlatformDatagram {
                 received: expected.len(),
                 datagram_length: expected.len(),
-                source_address: external_address,
+                source_address: gateway_peer_route,
             }))
         );
         assert_eq!(&data[..expected.len()], expected);
@@ -214,14 +210,12 @@ fn native_udp_readiness_failure_does_not_fail_shared_reactor() {
 
 #[test]
 fn udp_status_publication_failure_still_rearms_native_endpoint() {
-    let provider = Arc::new(LinuxSocketProvider::new(1, 1).unwrap());
-    let broker = BrokerCore::new_with_limits(
-        PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+    let (broker, _provider) = broker_with_sockets(
+        &guest_network_policy(),
         BrokerCoreLimits::new_with_all_limits(2, 0, 1, 1),
-        provider,
-    )
-    .unwrap();
+        1,
+        1,
+    );
     let session = broker
         .create_session(CallerCredential::Unauthenticated)
         .unwrap();
@@ -233,7 +227,7 @@ fn udp_status_publication_failure_still_rearms_native_endpoint() {
     });
     let socket = create_udp_socket(&session, readiness.clone());
     let refused = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
-    let refused_address = socket_address_v4(refused.local_addr().unwrap());
+    let refused_address = gateway_address(refused.local_addr().unwrap());
     drop(refused);
     assert_eq!(
         litebox_broker_core::socket::connect(&session, socket, refused_address),
@@ -287,14 +281,12 @@ fn udp_status_publication_failure_still_rearms_native_endpoint() {
 
 #[test]
 fn udp_status_republishes_when_another_error_remains_pending() {
-    let provider = Arc::new(LinuxSocketProvider::new(1, 1).unwrap());
-    let broker = BrokerCore::new_with_limits(
-        PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+    let (broker, provider) = broker_with_sockets(
+        &guest_network_policy(),
         BrokerCoreLimits::new_with_all_limits(2, 0, 1, 1),
-        provider.clone(),
-    )
-    .unwrap();
+        1,
+        1,
+    );
     let session = broker
         .create_session(CallerCredential::Unauthenticated)
         .unwrap();
@@ -303,7 +295,7 @@ fn udp_status_republishes_when_another_error_remains_pending() {
     let readiness = Arc::new(TestReadinessSink { published, retired });
     let socket = create_udp_socket(&session, readiness);
     let peer = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
-    let peer_address = socket_address_v4(peer.local_addr().unwrap());
+    let peer_address = gateway_address(peer.local_addr().unwrap());
     assert_eq!(
         litebox_broker_core::socket::connect(&session, socket, peer_address),
         Ok(SocketOutcome::Completed(SocketConnectionStatus::Connected))
@@ -339,14 +331,12 @@ fn udp_status_republishes_when_another_error_remains_pending() {
 
 #[test]
 fn guest_udp_queue_pressure_drops_new_datagrams_successfully() {
-    let provider = Arc::new(LinuxSocketProvider::new(2, 1).unwrap());
-    let broker = BrokerCore::new_with_limits(
-        PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+    let (broker, provider) = broker_with_sockets(
+        &guest_network_policy(),
         BrokerCoreLimits::new_with_all_limits(4, 0, 2, 1),
-        provider.clone(),
-    )
-    .unwrap();
+        2,
+        1,
+    );
     let receiver_session = broker
         .create_session(CallerCredential::Unauthenticated)
         .unwrap();
@@ -429,15 +419,13 @@ fn guest_udp_queue_pressure_drops_new_datagrams_successfully() {
 }
 
 #[test]
-fn udp_external_peer_authorization_is_bounded_without_eviction() {
-    let provider = Arc::new(LinuxSocketProvider::new(1, 1).unwrap());
-    let broker = BrokerCore::new_with_limits(
-        PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+fn udp_native_peer_authorization_is_bounded_without_eviction() {
+    let (broker, _provider) = broker_with_sockets(
+        &guest_network_policy(),
         BrokerCoreLimits::new_with_all_limits(2, 0, 1, 1),
-        provider,
-    )
-    .unwrap();
+        1,
+        1,
+    );
     let session = broker
         .create_session(CallerCredential::Unauthenticated)
         .unwrap();
@@ -448,7 +436,7 @@ fn udp_external_peer_authorization_is_bounded_without_eviction() {
 
     let first = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
     first.set_read_timeout(Some(TEST_TIMEOUT)).unwrap();
-    let first_address = socket_address_v4(first.local_addr().unwrap());
+    let first_address = gateway_address(first.local_addr().unwrap());
     assert_eq!(
         send_datagram(&session, handle, b"x", SendFlags::NONE, Some(first_address),),
         Ok(SocketOutcome::Completed(1))
@@ -458,9 +446,9 @@ fn udp_external_peer_authorization_is_bounded_without_eviction() {
     let native_source = socket_address_v4(native_source);
 
     let mut peers = Vec::new();
-    while peers.len() < MAX_UDP_EXTERNAL_PEERS_PER_SOCKET - 1 {
+    while peers.len() < MAX_UDP_NATIVE_PEERS_PER_SOCKET - 1 {
         let peer = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
-        let address = socket_address_v4(peer.local_addr().unwrap());
+        let address = gateway_address(peer.local_addr().unwrap());
         if address.port() == native_source.port() {
             continue;
         }
@@ -482,7 +470,7 @@ fn udp_external_peer_authorization_is_bounded_without_eviction() {
             handle,
             b"overflow",
             SendFlags::NONE,
-            Some(socket_address_v4(overflow.local_addr().unwrap())),
+            Some(gateway_address(overflow.local_addr().unwrap())),
         ),
         Err(BrokerError::ResourceExhausted)
     );
@@ -505,28 +493,13 @@ fn udp_external_peer_authorization_is_bounded_without_eviction() {
 fn reactor_preserves_udp_datagram_semantics() {
     let server = UdpSocket::bind("127.0.0.1:0").unwrap();
     server.set_read_timeout(Some(TEST_TIMEOUT)).unwrap();
-    let server_address = socket_address_v4(server.local_addr().unwrap());
-    let provider = Arc::new(LinuxSocketProvider::new(2, 2).unwrap());
-    let socket_policy = SocketPolicy::from_udp_destination_rules(&[
-        DestinationRule::new(
-            CallerCredential::Unauthenticated,
-            Ipv4Cidr::new(Ipv4Address([127, 0, 0, 0]), 8).unwrap(),
-            DestinationPortRange::new(Port(1), Port(u16::MAX)).unwrap(),
-        ),
-        DestinationRule::new(
-            CallerCredential::Unauthenticated,
-            Ipv4Cidr::new(Ipv4Address([255, 255, 255, 255]), 32).unwrap(),
-            DestinationPortRange::new(Port(9), Port(9)).unwrap(),
-        ),
-    ])
-    .unwrap();
-    let broker = BrokerCore::new_with_limits(
-        PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(socket_policy),
+    let server_route = gateway_address(server.local_addr().unwrap());
+    let (broker, provider) = broker_with_sockets(
+        &guest_network_policy(),
         BrokerCoreLimits::new_with_all_limits(4, 0, 2, 2),
-        provider.clone(),
-    )
-    .unwrap();
+        2,
+        2,
+    );
     let session = broker
         .create_session(CallerCredential::Unauthenticated)
         .unwrap();
@@ -574,7 +547,7 @@ fn reactor_preserves_udp_datagram_semantics() {
             shutdown_handle,
             b"after shutdown",
             SendFlags::NONE,
-            Some(server_address),
+            Some(server_route),
         ),
         Ok(SocketOutcome::Failed(SocketError::Other))
     );
@@ -600,7 +573,7 @@ fn reactor_preserves_udp_datagram_semantics() {
             read_shutdown_handle,
             b"before shutdown",
             SendFlags::NONE,
-            Some(server_address),
+            Some(server_route),
         ),
         Ok(SocketOutcome::Completed(15))
     );
@@ -617,7 +590,7 @@ fn reactor_preserves_udp_datagram_semantics() {
             read_shutdown_handle,
             b"write only",
             SendFlags::NONE,
-            Some(server_address),
+            Some(server_route),
         ),
         Ok(SocketOutcome::Completed(10))
     );
@@ -657,18 +630,20 @@ fn reactor_preserves_udp_datagram_semantics() {
         send_datagram(
             &session,
             handle,
-            b"implicit bind",
+            b"invalid class",
             SendFlags::NONE,
             Some(SocketAddrV4::new(Ipv4Addr::BROADCAST, 9)),
         ),
-        Ok(SocketOutcome::Failed(SocketError::Other))
+        Ok(SocketOutcome::Failed(SocketError::InvalidArgument))
     );
-    let implicitly_bound = litebox_broker_core::socket::status(&session, handle)
-        .unwrap()
-        .local_address
-        .unwrap();
-    assert!(implicitly_bound.ip().is_unspecified());
-    assert_ne!(implicitly_bound.port(), 0);
+    // A destination that no route can represent is rejected before the
+    // implicit bind reserves a guest endpoint.
+    assert_eq!(
+        litebox_broker_core::socket::status(&session, handle)
+            .unwrap()
+            .local_address,
+        None
+    );
     let mut no_data = [0; 1];
     assert_eq!(
         receive_datagram_into(&session, handle, &mut no_data, ReceiveFromFlags::NONE,),
@@ -680,7 +655,7 @@ fn reactor_preserves_udp_datagram_semantics() {
             handle,
             b"ping",
             SendFlags::NONE,
-            Some(server_address),
+            Some(server_route),
         ),
         Ok(SocketOutcome::Completed(4))
     );
@@ -692,7 +667,7 @@ fn reactor_preserves_udp_datagram_semantics() {
     assert_eq!(status.status, SocketConnectionStatus::Unconnected);
     let local_address = status.local_address.unwrap();
     assert!(local_address.ip().is_unspecified());
-    assert_eq!(local_address, implicitly_bound);
+    assert_ne!(local_address.port(), 0);
     assert!(source.ip().is_loopback());
 
     server.send_to(&[], source).unwrap();
@@ -703,7 +678,7 @@ fn reactor_preserves_udp_datagram_semantics() {
         Ok(SocketOutcome::Completed(ReceivedPlatformDatagram {
             received: 0,
             datagram_length: 0,
-            source_address: server_address,
+            source_address: server_route,
         }))
     );
     assert_eq!(
@@ -719,7 +694,7 @@ fn reactor_preserves_udp_datagram_semantics() {
         Ok(SocketOutcome::Completed(ReceivedPlatformDatagram {
             received: 3,
             datagram_length: 6,
-            source_address: server_address,
+            source_address: server_route,
         }))
     );
     assert_eq!(&peeked, b"abc");
@@ -729,7 +704,7 @@ fn reactor_preserves_udp_datagram_semantics() {
         Ok(SocketOutcome::Completed(ReceivedPlatformDatagram {
             received: 3,
             datagram_length: 6,
-            source_address: server_address,
+            source_address: server_route,
         }))
     );
     assert_eq!(&peeked, b"abc");
@@ -739,7 +714,7 @@ fn reactor_preserves_udp_datagram_semantics() {
         Ok(SocketOutcome::Completed(ReceivedPlatformDatagram {
             received: 4,
             datagram_length: 6,
-            source_address: server_address,
+            source_address: server_route,
         }))
     );
     assert_eq!(&truncated, b"abcd");
@@ -749,14 +724,17 @@ fn reactor_preserves_udp_datagram_semantics() {
     );
 
     assert_eq!(
-        litebox_broker_core::socket::connect(&session, handle, server_address),
+        litebox_broker_core::socket::connect(&session, handle, server_route),
         Ok(SocketOutcome::Completed(SocketConnectionStatus::Connected))
     );
     let connected_status = litebox_broker_core::socket::status(&session, handle).unwrap();
     assert_eq!(connected_status.status, SocketConnectionStatus::Connected);
     assert_eq!(
         connected_status.local_address,
-        Some(SocketAddrV4::new(Ipv4Addr::LOCALHOST, local_address.port()))
+        Some(SocketAddrV4::new(
+            guest_ipv4_address(),
+            local_address.port()
+        ))
     );
     let maximum = vec![0x5a; MAX_UDP_DATAGRAM_SIZE as usize];
     assert_eq!(
@@ -776,7 +754,7 @@ fn reactor_preserves_udp_datagram_semantics() {
             handle,
             SocketAddrV4::new(Ipv4Addr::BROADCAST, 9),
         ),
-        Ok(SocketOutcome::Failed(SocketError::Other))
+        Ok(SocketOutcome::Failed(SocketError::InvalidArgument))
     );
     assert_eq!(
         send_datagram(&session, handle, b"old peer", SendFlags::NONE, None),
@@ -787,10 +765,10 @@ fn reactor_preserves_udp_datagram_semantics() {
     assert_eq!(socket_address_v4(preserved_source), source);
 
     let refused_socket = UdpSocket::bind("127.0.0.1:0").unwrap();
-    let refused_address = socket_address_v4(refused_socket.local_addr().unwrap());
+    let refused_route = gateway_address(refused_socket.local_addr().unwrap());
     drop(refused_socket);
     assert_eq!(
-        litebox_broker_core::socket::connect(&session, handle, refused_address),
+        litebox_broker_core::socket::connect(&session, handle, refused_route),
         Ok(SocketOutcome::Completed(SocketConnectionStatus::Connected))
     );
     assert_eq!(
@@ -806,7 +784,7 @@ fn reactor_preserves_udp_datagram_semantics() {
             SendFlags::NONE,
             Some(SocketAddrV4::new(Ipv4Addr::BROADCAST, 9)),
         ),
-        Ok(SocketOutcome::Failed(SocketError::Other))
+        Ok(SocketOutcome::Failed(SocketError::InvalidArgument))
     );
     let send_error_status = litebox_broker_core::socket::status(&session, handle).unwrap();
     assert_eq!(
@@ -830,7 +808,7 @@ fn reactor_preserves_udp_datagram_semantics() {
             handle,
             SocketAddrV4::new(Ipv4Addr::BROADCAST, 9),
         ),
-        Ok(SocketOutcome::Failed(SocketError::Other))
+        Ok(SocketOutcome::Failed(SocketError::InvalidArgument))
     );
     let refused_status = litebox_broker_core::socket::status(&session, handle).unwrap();
     assert_eq!(
@@ -844,7 +822,7 @@ fn reactor_preserves_udp_datagram_semantics() {
             .contains(ReadinessFlags::ERROR)
     );
     assert_eq!(
-        litebox_broker_core::socket::connect(&session, handle, server_address),
+        litebox_broker_core::socket::connect(&session, handle, server_route),
         Ok(SocketOutcome::Completed(SocketConnectionStatus::Connected))
     );
 
@@ -853,7 +831,7 @@ fn reactor_preserves_udp_datagram_semantics() {
         Ok(SocketOutcome::Completed(()))
     );
     assert_eq!(
-        litebox_broker_core::socket::connect(&session, handle, server_address),
+        litebox_broker_core::socket::connect(&session, handle, server_route),
         Ok(SocketOutcome::Completed(SocketConnectionStatus::Connected))
     );
     assert!(
@@ -873,14 +851,12 @@ fn reactor_preserves_udp_datagram_semantics() {
 
 #[test]
 fn guest_udp_namespace_routes_across_sessions_and_filters_private_endpoints() {
-    let provider = Arc::new(LinuxSocketProvider::new(6, 3).unwrap());
-    let broker = BrokerCore::new_with_limits(
-        PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+    let (broker, provider) = broker_with_sockets(
+        &guest_network_policy(),
         BrokerCoreLimits::new_with_all_limits(8, 0, 6, 3),
-        provider.clone(),
-    )
-    .unwrap();
+        6,
+        3,
+    );
     let receiver_session = broker
         .create_session(CallerCredential::Unauthenticated)
         .unwrap();
@@ -896,7 +872,9 @@ fn guest_udp_namespace_routes_across_sessions_and_filters_private_endpoints() {
         .set_nonblocking(true)
         .expect("failed to make shadow socket nonblocking");
     let guest_port = shadowed_host_socket.local_addr().unwrap().port();
-    let receiver_guest_address = SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 2), guest_port);
+    // An exact private guest binding shadows the identical host loopback port
+    // and still reaches the host gateway.
+    let receiver_guest_address = SocketAddrV4::new(guest_ipv4_address(), guest_port);
     let receiver = create_udp_socket(&receiver_session, readiness.clone());
     assert_eq!(
         litebox_broker_core::socket::bind(&receiver_session, receiver, receiver_guest_address,),
@@ -938,7 +916,10 @@ fn guest_udp_namespace_routes_across_sessions_and_filters_private_endpoints() {
         .unwrap()
         .local_address
         .expect("implicit UDP bind missing");
-    let sender_source_address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, sender_guest_address.port());
+    // A wildcard sender answers a private guest destination with the shared
+    // private guest identity.
+    let sender_source_address =
+        SocketAddrV4::new(guest_ipv4_address(), sender_guest_address.port());
     wait_until_ready(
         &receiver_session,
         &publications,
@@ -998,22 +979,22 @@ fn guest_udp_namespace_routes_across_sessions_and_filters_private_endpoints() {
         ErrorKind::WouldBlock
     );
 
-    let external = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
-    external.set_read_timeout(Some(TEST_TIMEOUT)).unwrap();
-    let external_address = socket_address_v4(external.local_addr().unwrap());
+    let host_service = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    host_service.set_read_timeout(Some(TEST_TIMEOUT)).unwrap();
+    let host_service_route = gateway_address(host_service.local_addr().unwrap());
     assert_eq!(
         send_datagram(
             &receiver_session,
             receiver,
             b"contact",
             SendFlags::NONE,
-            Some(external_address),
+            Some(host_service_route),
         ),
         Ok(SocketOutcome::Completed(7))
     );
-    let mut external_packet = [0; 7];
-    let (_, receiver_source) = external.recv_from(&mut external_packet).unwrap();
-    assert_eq!(&external_packet, b"contact");
+    let mut service_packet = [0; 7];
+    let (_, receiver_source) = host_service.recv_from(&mut service_packet).unwrap();
+    assert_eq!(&service_packet, b"contact");
     assert_eq!(provider.reactor.udp_native_endpoint_count(), 1);
     assert!(
         provider
@@ -1053,7 +1034,7 @@ fn guest_udp_namespace_routes_across_sessions_and_filters_private_endpoints() {
         ),
         Ok(SocketOutcome::Failed(SocketError::ConnectionRefused))
     );
-    external.send_to(b"reply", receiver_source).unwrap();
+    host_service.send_to(b"reply", receiver_source).unwrap();
     wait_until_ready(
         &receiver_session,
         &publications,
@@ -1081,7 +1062,7 @@ fn guest_udp_namespace_routes_across_sessions_and_filters_private_endpoints() {
         Ok(SocketOutcome::Completed(ReceivedPlatformDatagram {
             received: 5,
             datagram_length: 5,
-            source_address: external_address,
+            source_address: host_service_route,
         }))
     );
     assert_eq!(&reply, b"reply");
@@ -1096,7 +1077,7 @@ fn guest_udp_namespace_routes_across_sessions_and_filters_private_endpoints() {
         Ok(SocketOutcome::Completed(ReceivedPlatformDatagram {
             received: 5,
             datagram_length: 5,
-            source_address: external_address,
+            source_address: host_service_route,
         }))
     );
     assert_eq!(&reply, b"reply");
@@ -1119,14 +1100,12 @@ fn guest_udp_namespace_routes_across_sessions_and_filters_private_endpoints() {
 
 #[test]
 fn udp_exact_bindings_coexist_and_wildcard_covers_loopback() {
-    let provider = Arc::new(LinuxSocketProvider::new(8, 5).unwrap());
-    let broker = BrokerCore::new_with_limits(
-        PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+    let (broker, _provider) = broker_with_sockets(
+        &guest_network_policy(),
         BrokerCoreLimits::new_with_all_limits(12, 0, 8, 8),
-        provider,
-    )
-    .unwrap();
+        8,
+        5,
+    );
     let receiver_session = broker
         .create_session(CallerCredential::Unauthenticated)
         .unwrap();
@@ -1195,7 +1174,7 @@ fn udp_exact_bindings_coexist_and_wildcard_covers_loopback() {
                 received: payload.len(),
                 datagram_length: payload.len(),
                 source_address: SocketAddrV4::new(
-                    Ipv4Addr::LOCALHOST,
+                    *destination.ip(),
                     litebox_broker_core::socket::status(&sender_session, sender)
                         .unwrap()
                         .local_address
@@ -1299,7 +1278,7 @@ fn udp_exact_bindings_coexist_and_wildcard_covers_loopback() {
             datagram_length: 4,
             source_address,
         })) if source_address == SocketAddrV4::new(
-            Ipv4Addr::LOCALHOST,
+            *concrete_destination.ip(),
             wildcard_address.port(),
         )
     ));
@@ -1308,14 +1287,12 @@ fn udp_exact_bindings_coexist_and_wildcard_covers_loopback() {
 
 #[test]
 fn udp_native_endpoint_is_reused_and_retired() {
-    let provider = Arc::new(LinuxSocketProvider::new(2, 2).unwrap());
-    let broker = BrokerCore::new_with_limits(
-        PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+    let (broker, provider) = broker_with_sockets(
+        &guest_network_policy(),
         BrokerCoreLimits::new_with_all_limits(4, 0, 2, 2),
-        provider.clone(),
-    )
-    .unwrap();
+        2,
+        2,
+    );
     let session = broker
         .create_session(CallerCredential::Unauthenticated)
         .unwrap();
@@ -1327,8 +1304,8 @@ fn udp_native_endpoint_is_reused_and_retired() {
     let second = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
     first.set_read_timeout(Some(TEST_TIMEOUT)).unwrap();
     second.set_read_timeout(Some(TEST_TIMEOUT)).unwrap();
-    let first_address = socket_address_v4(first.local_addr().unwrap());
-    let second_address = socket_address_v4(second.local_addr().unwrap());
+    let first_address = gateway_address(first.local_addr().unwrap());
+    let second_address = gateway_address(second.local_addr().unwrap());
 
     assert_eq!(provider.reactor.udp_native_endpoint_count(), 0);
     assert_eq!(provider.reactor.udp_native_event_token_count(), 0);
@@ -1372,15 +1349,13 @@ fn udp_native_endpoint_is_reused_and_retired() {
 }
 
 #[test]
-fn udp_endpoint_staging_error_rolls_back_external_peer_reservation() {
-    let provider = Arc::new(LinuxSocketProvider::new(2, 2).unwrap());
-    let broker = BrokerCore::new_with_limits(
-        PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+fn udp_endpoint_staging_error_rolls_back_native_peer_reservation() {
+    let (broker, provider) = broker_with_sockets(
+        &guest_network_policy(),
         BrokerCoreLimits::new_with_all_limits(4, 0, 2, 2),
-        provider.clone(),
-    )
-    .unwrap();
+        2,
+        2,
+    );
     let session = broker
         .create_session(CallerCredential::Unauthenticated)
         .unwrap();
@@ -1388,8 +1363,8 @@ fn udp_endpoint_staging_error_rolls_back_external_peer_reservation() {
     let (retired, _retirements) = channel();
     let readiness = Arc::new(TestReadinessSink { published, retired });
     let socket = create_udp_socket(&session, readiness);
-    let external = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
-    let external_address = socket_address_v4(external.local_addr().unwrap());
+    let gateway_peer = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let gateway_peer_route = gateway_address(gateway_peer.local_addr().unwrap());
 
     provider.reactor.exhaust_udp_event_tokens();
     assert_eq!(
@@ -1398,11 +1373,11 @@ fn udp_endpoint_staging_error_rolls_back_external_peer_reservation() {
             socket,
             b"not sent",
             SendFlags::NONE,
-            Some(external_address),
+            Some(gateway_peer_route),
         ),
         Err(BrokerError::ResourceExhausted)
     );
-    assert_eq!(provider.reactor.udp_external_peer_count(), 0);
+    assert_eq!(provider.reactor.udp_native_peer_count(), 0);
     assert_eq!(provider.reactor.udp_native_endpoint_count(), 0);
     assert_eq!(provider.reactor.udp_native_event_token_count(), 0);
 
@@ -1411,14 +1386,12 @@ fn udp_endpoint_staging_error_rolls_back_external_peer_reservation() {
 
 #[test]
 fn stale_udp_datagrams_are_not_relabelled_after_guest_port_reuse() {
-    let provider = Arc::new(LinuxSocketProvider::new(5, 3).unwrap());
-    let broker = BrokerCore::new_with_limits(
-        PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+    let (broker, provider) = broker_with_sockets(
+        &guest_network_policy(),
         BrokerCoreLimits::new_with_all_limits(8, 0, 5, 3),
-        provider.clone(),
-    )
-    .unwrap();
+        5,
+        3,
+    );
     let receiver_session = broker
         .create_session(CallerCredential::Unauthenticated)
         .unwrap();
@@ -1518,14 +1491,12 @@ fn stale_udp_datagrams_are_not_relabelled_after_guest_port_reuse() {
 
 #[test]
 fn udp_queued_datagrams_survive_source_session_teardown() {
-    let provider = Arc::new(LinuxSocketProvider::new(3, 1).unwrap());
-    let broker = BrokerCore::new_with_limits(
-        PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+    let (broker, provider) = broker_with_sockets(
+        &guest_network_policy(),
         BrokerCoreLimits::new_with_all_limits(6, 0, 3, 1),
-        provider.clone(),
-    )
-    .unwrap();
+        3,
+        1,
+    );
     let source_session = broker
         .create_session(CallerCredential::Unauthenticated)
         .unwrap();
@@ -1651,14 +1622,12 @@ fn udp_queued_datagrams_survive_source_session_teardown() {
 
 #[test]
 fn connected_guest_udp_enforces_barriers_peek_and_peer_generations() {
-    let provider = Arc::new(LinuxSocketProvider::new(4, 2).unwrap());
-    let broker = BrokerCore::new_with_limits(
-        PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+    let (broker, provider) = broker_with_sockets(
+        &guest_network_policy(),
         BrokerCoreLimits::new_with_all_limits(8, 0, 4, 2),
-        provider.clone(),
-    )
-    .unwrap();
+        4,
+        2,
+    );
     let first_session = broker
         .create_session(CallerCredential::Unauthenticated)
         .unwrap();
@@ -1796,26 +1765,23 @@ fn externally_connected_udp_preserves_guest_routing_identity() {
     let external = UdpSocket::bind((local_ip, 0)).unwrap();
     external.set_read_timeout(Some(TEST_TIMEOUT)).unwrap();
     let external_address = socket_address_v4(external.local_addr().unwrap());
-    let provider = Arc::new(LinuxSocketProvider::new(4, 2).unwrap());
-    let policy = SocketPolicy::from_udp_destination_rules(&[
-        DestinationRule::new(
-            CallerCredential::Unauthenticated,
-            Ipv4Cidr::new(Ipv4Address([127, 0, 0, 0]), 8).unwrap(),
-            DestinationPortRange::new(Port(1), Port(u16::MAX)).unwrap(),
-        ),
-        DestinationRule::new(
+    let policy = SocketPolicy::from_guest_network_destination_rules(
+        true,
+        &[],
+        true,
+        &[DestinationRule::new(
             CallerCredential::Unauthenticated,
             Ipv4Cidr::new(Ipv4Address(local_ip.octets()), 32).unwrap(),
             DestinationPortRange::new(Port(1), Port(u16::MAX)).unwrap(),
-        ),
-    ])
-    .unwrap();
-    let broker = BrokerCore::new_with_limits(
-        PolicyEngine::with_unauthenticated_rights(ObjectRights::all()).with_socket_policy(policy),
-        BrokerCoreLimits::new_with_all_limits(6, 0, 4, 2),
-        provider.clone(),
+        )],
     )
     .unwrap();
+    let (broker, provider) = broker_with_sockets(
+        &policy,
+        BrokerCoreLimits::new_with_all_limits(6, 0, 4, 2),
+        4,
+        2,
+    );
     let source_session = broker
         .create_session(CallerCredential::Unauthenticated)
         .unwrap();
@@ -1840,7 +1806,9 @@ fn externally_connected_udp_preserves_guest_routing_identity() {
         .unwrap()
         .local_address
         .expect("connected UDP source address missing");
-    assert_eq!(source_address.ip(), &local_ip);
+    // An external route answers with the shared private guest identity, not
+    // the host source the kernel selected.
+    assert_eq!(source_address.ip(), &guest_ipv4_address());
     let internal_source_address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, source_address.port());
 
     assert_eq!(
@@ -1918,14 +1886,12 @@ fn externally_connected_udp_preserves_guest_routing_identity() {
 
 #[test]
 fn guest_connected_udp_drains_native_ingress_without_delivering_it() {
-    let provider = Arc::new(LinuxSocketProvider::new(4, 2).unwrap());
-    let broker = BrokerCore::new_with_limits(
-        PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+    let (broker, provider) = broker_with_sockets(
+        &guest_network_policy(),
         BrokerCoreLimits::new_with_all_limits(8, 0, 4, 2),
-        provider.clone(),
-    )
-    .unwrap();
+        4,
+        2,
+    );
     let receiver_session = broker
         .create_session(CallerCredential::Unauthenticated)
         .unwrap();
@@ -1940,7 +1906,9 @@ fn guest_connected_udp_drains_native_ingress_without_delivering_it() {
         .local_addr()
         .unwrap()
         .port();
-    let receiver_address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, guest_port);
+    // A private guest binding can still reach the host gateway, so this socket
+    // owns both a guest peer and one native endpoint.
+    let receiver_address = SocketAddrV4::new(guest_ipv4_address(), guest_port);
     let receiver = create_udp_socket(&receiver_session, readiness.clone());
     assert_eq!(
         litebox_broker_core::socket::bind(&receiver_session, receiver, receiver_address,),
@@ -1961,7 +1929,7 @@ fn guest_connected_udp_drains_native_ingress_without_delivering_it() {
     let source_address = litebox_broker_core::socket::status(&sender_session, sender)
         .unwrap()
         .local_address
-        .map(|address| SocketAddrV4::new(Ipv4Addr::LOCALHOST, address.port()))
+        .map(|address| SocketAddrV4::new(guest_ipv4_address(), address.port()))
         .unwrap();
     let mut warmup = [0; 6];
     assert_eq!(
@@ -1985,7 +1953,7 @@ fn guest_connected_udp_drains_native_ingress_without_delivering_it() {
 
     let attacker = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
     attacker.set_read_timeout(Some(TEST_TIMEOUT)).unwrap();
-    let attacker_address = socket_address_v4(attacker.local_addr().unwrap());
+    let attacker_address = gateway_address(attacker.local_addr().unwrap());
     assert_eq!(
         send_datagram(
             &receiver_session,
@@ -2059,4 +2027,235 @@ fn guest_connected_udp_drains_native_ingress_without_delivering_it() {
         }))
     );
     assert_eq!(&payload, b"ok");
+}
+
+#[test]
+fn guest_udp_misses_never_create_native_state() {
+    let (broker, provider) = broker_with_sockets(
+        &guest_network_policy(),
+        BrokerCoreLimits::new_with_all_limits(4, 0, 2, 2),
+        2,
+        2,
+    );
+    let session = broker
+        .create_session(CallerCredential::Unauthenticated)
+        .unwrap();
+    let (published, _publications) = channel();
+    let (retired, _retirements) = channel();
+    let readiness = Arc::new(TestReadinessSink { published, retired });
+    let socket = create_udp_socket(&session, readiness);
+
+    let host_socket = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    host_socket.set_nonblocking(true).unwrap();
+    let shadowed_port = host_socket.local_addr().unwrap().port();
+    for destination in [
+        SocketAddrV4::new(Ipv4Addr::LOCALHOST, shadowed_port),
+        SocketAddrV4::new(guest_ipv4_address(), shadowed_port),
+    ] {
+        assert_eq!(
+            send_datagram(
+                &session,
+                socket,
+                b"miss",
+                SendFlags::NONE,
+                Some(destination)
+            ),
+            Ok(SocketOutcome::Failed(SocketError::ConnectionRefused))
+        );
+        assert_eq!(
+            litebox_broker_core::socket::connect(&session, socket, destination),
+            Ok(SocketOutcome::Failed(SocketError::ConnectionRefused))
+        );
+    }
+    // A guest miss neither reaches the host nor allocates native state.
+    assert_eq!(
+        host_socket.recv_from(&mut [0; 4]).unwrap_err().kind(),
+        ErrorKind::WouldBlock
+    );
+    assert_eq!(provider.reactor.udp_native_endpoint_count(), 0);
+    assert_eq!(provider.reactor.udp_native_event_token_count(), 0);
+    assert_eq!(provider.reactor.udp_native_peer_count(), 0);
+}
+
+#[test]
+fn udp_gateway_and_external_reuse_one_native_endpoint() {
+    let local_ip = non_loopback_local_ipv4();
+    if std::env::var_os("CI").is_some() {
+        assert!(
+            local_ip.is_some(),
+            "CI runner must provide a routable non-loopback IPv4 address"
+        );
+    }
+    let Some(local_ip) = local_ip else {
+        return;
+    };
+    let gateway_peer = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    gateway_peer.set_read_timeout(Some(TEST_TIMEOUT)).unwrap();
+    let gateway_peer_route = gateway_address(gateway_peer.local_addr().unwrap());
+    let external_peer = UdpSocket::bind((local_ip, 0)).unwrap();
+    external_peer.set_read_timeout(Some(TEST_TIMEOUT)).unwrap();
+    let external_peer_address = socket_address_v4(external_peer.local_addr().unwrap());
+    let policy = SocketPolicy::from_guest_network_destination_rules(
+        true,
+        &[],
+        true,
+        &[DestinationRule::new(
+            CallerCredential::Unauthenticated,
+            Ipv4Cidr::new(Ipv4Address(local_ip.octets()), 32).unwrap(),
+            DestinationPortRange::new(Port(1), Port(u16::MAX)).unwrap(),
+        )],
+    )
+    .unwrap();
+    let (broker, provider) = broker_with_sockets(
+        &policy,
+        BrokerCoreLimits::new_with_all_limits(4, 0, 2, 2),
+        2,
+        2,
+    );
+    let session = broker
+        .create_session(CallerCredential::Unauthenticated)
+        .unwrap();
+    let (published, publications) = channel();
+    let (retired, _retirements) = channel();
+    let readiness = Arc::new(TestReadinessSink { published, retired });
+    let socket = create_udp_socket(&session, readiness);
+
+    assert_eq!(
+        send_datagram(
+            &session,
+            socket,
+            b"gateway",
+            SendFlags::NONE,
+            Some(gateway_peer_route),
+        ),
+        Ok(SocketOutcome::Completed(7))
+    );
+    let mut payload = [0; 8];
+    let (_, gateway_native_source) = gateway_peer.recv_from(&mut payload).unwrap();
+    let gateway_native_source = socket_address_v4(gateway_native_source);
+    assert!(gateway_native_source.ip().is_loopback());
+    assert_eq!(provider.reactor.udp_native_endpoint_count(), 1);
+    assert_eq!(provider.reactor.udp_native_event_token_count(), 1);
+
+    assert_eq!(
+        send_datagram(
+            &session,
+            socket,
+            b"external",
+            SendFlags::NONE,
+            Some(external_peer_address),
+        ),
+        Ok(SocketOutcome::Completed(8))
+    );
+    let (_, external_native_source) = external_peer.recv_from(&mut payload).unwrap();
+    let external_native_source = socket_address_v4(external_native_source);
+    // One endpoint serves both routes, so the host-visible source port is
+    // reused instead of allocating another descriptor or epoll token.
+    assert_eq!(external_native_source.port(), gateway_native_source.port());
+    assert_eq!(provider.reactor.udp_native_endpoint_count(), 1);
+    assert_eq!(provider.reactor.udp_native_event_token_count(), 1);
+    assert_eq!(provider.reactor.udp_native_peer_count(), 2);
+
+    gateway_peer.send_to(b"gr", gateway_native_source).unwrap();
+    wait_until_ready(&session, &publications, socket, ReadinessFlags::READ);
+    let mut reply = [0; 2];
+    assert_eq!(
+        receive_datagram_into(&session, socket, &mut reply, ReceiveFromFlags::NONE),
+        Ok(SocketOutcome::Completed(ReceivedPlatformDatagram {
+            received: 2,
+            datagram_length: 2,
+            source_address: gateway_peer_route,
+        }))
+    );
+    assert_eq!(&reply, b"gr");
+
+    external_peer
+        .send_to(b"er", external_native_source)
+        .unwrap();
+    wait_until_ready(&session, &publications, socket, ReadinessFlags::READ);
+    assert_eq!(
+        receive_datagram_into(&session, socket, &mut reply, ReceiveFromFlags::NONE),
+        Ok(SocketOutcome::Completed(ReceivedPlatformDatagram {
+            received: 2,
+            datagram_length: 2,
+            source_address: external_peer_address,
+        }))
+    );
+    assert_eq!(&reply, b"er");
+    assert_eq!(provider.reactor.udp_native_endpoint_count(), 1);
+    assert_eq!(provider.reactor.udp_native_event_token_count(), 1);
+}
+
+#[test]
+fn gateway_udp_replies_report_the_gateway_and_reject_other_host_sources() {
+    let (broker, provider) = broker_with_sockets(
+        &guest_network_policy(),
+        BrokerCoreLimits::new_with_all_limits(4, 0, 2, 2),
+        2,
+        2,
+    );
+    let session = broker
+        .create_session(CallerCredential::Unauthenticated)
+        .unwrap();
+    let (published, publications) = channel();
+    let (retired, _retirements) = channel();
+    let readiness = Arc::new(TestReadinessSink { published, retired });
+    let socket = create_udp_socket(&session, readiness);
+
+    let service = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    service.set_read_timeout(Some(TEST_TIMEOUT)).unwrap();
+    let service_route = gateway_address(service.local_addr().unwrap());
+    assert_eq!(
+        send_datagram(
+            &session,
+            socket,
+            b"request",
+            SendFlags::NONE,
+            Some(service_route),
+        ),
+        Ok(SocketOutcome::Completed(7))
+    );
+    let mut request = [0; 7];
+    let (_, native_source) = service.recv_from(&mut request).unwrap();
+    let native_source = socket_address_v4(native_source);
+    assert_eq!(&request, b"request");
+    assert_eq!(provider.reactor.udp_native_peer_count(), 1);
+
+    // The broker's own endpoint is never a reachable gateway destination.
+    assert_eq!(
+        send_datagram(
+            &session,
+            socket,
+            b"self",
+            SendFlags::NONE,
+            Some(SocketAddrV4::new(
+                gateway_ipv4_address(),
+                native_source.port(),
+            )),
+        ),
+        Ok(SocketOutcome::Failed(SocketError::ConnectionRefused))
+    );
+
+    // Another host loopback source may not masquerade as the gateway.
+    let alias_impostor = UdpSocket::bind((Ipv4Addr::new(127, 0, 0, 2), 0)).unwrap();
+    alias_impostor.send_to(b"spoofed", native_source).unwrap();
+    let port_impostor = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    port_impostor.send_to(b"spoofed", native_source).unwrap();
+    service.send_to(b"reply", native_source).unwrap();
+    wait_until_ready(&session, &publications, socket, ReadinessFlags::READ);
+    let mut reply = [0; 7];
+    assert_eq!(
+        receive_datagram_into(&session, socket, &mut reply[..5], ReceiveFromFlags::NONE),
+        Ok(SocketOutcome::Completed(ReceivedPlatformDatagram {
+            received: 5,
+            datagram_length: 5,
+            source_address: service_route,
+        }))
+    );
+    assert_eq!(&reply[..5], b"reply");
+    assert_eq!(
+        receive_datagram_into(&session, socket, &mut reply, ReceiveFromFlags::NONE),
+        Err(BrokerError::WouldBlock)
+    );
+    assert_eq!(provider.reactor.udp_native_peer_count(), 1);
 }

--- a/litebox_broker_platform_linux_userland/src/socket/udp.rs
+++ b/litebox_broker_platform_linux_userland/src/socket/udp.rs
@@ -12,7 +12,9 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::net::{Ipv4Addr, SocketAddrV4};
 use std::os::fd::OwnedFd;
 
-use litebox_broker_core::socket::{GuestSocketBinding, PlatformConnectError};
+use litebox_broker_core::socket::{
+    BrokerNetworkConfig, GuestSocketBinding, PlatformConnectError, SocketDestination,
+};
 use litebox_broker_core::{BrokerError, Result as BrokerResult, SessionId};
 use litebox_broker_protocol::readiness::ReadinessFlags;
 use litebox_broker_protocol::socket::{
@@ -30,12 +32,12 @@ use rustix::net::{
 
 use super::{
     PlatformSocketStatus, Reactor, ReactorReceiveFromOutcome, SocketKind, WAKE_TOKEN,
-    broker_error_from_errno, local_socket_address, socket_operation_error_from_errno,
-    update_snapshot, zeroed_vec,
+    broker_error_from_errno, local_socket_address, native_host_address,
+    socket_operation_error_from_errno, update_snapshot, zeroed_vec,
 };
 
 pub(super) const MAX_REJECTED_UDP_DATAGRAMS_PER_COMMAND: usize = 64;
-pub(super) const MAX_UDP_EXTERNAL_PEERS_PER_SOCKET: usize = 64;
+pub(super) const MAX_UDP_NATIVE_PEERS_PER_SOCKET: usize = 64;
 const MAX_UDP_QUEUE_DATAGRAMS_PER_SOCKET: usize = 64;
 const MAX_UDP_QUEUE_BYTES_PER_SOCKET: usize = 4 * 65_507;
 pub(super) const MAX_UDP_QUEUE_DATAGRAMS_PER_SOURCE: usize = 16;
@@ -50,7 +52,7 @@ pub(super) const UDP_EVENT_TOKEN_FLAG: u64 = 1 << 63;
 pub(super) struct ReactorUdpState {
     pub(super) bindings: ReactorUdpBindings,
     pub(super) native_endpoints: HashSet<u16>,
-    pub(super) external_peer_count: usize,
+    pub(super) native_peer_count: usize,
     pub(super) queued_datagrams: usize,
     pub(super) queued_bytes: usize,
     pub(super) queued_by_source: HashMap<SessionId, UdpQueueAccounting>,
@@ -89,7 +91,7 @@ impl Default for ReactorUdpState {
         Self {
             bindings: ReactorUdpBindings::default(),
             native_endpoints: HashSet::new(),
-            external_peer_count: 0,
+            native_peer_count: 0,
             queued_datagrams: 0,
             queued_bytes: 0,
             queued_by_source: HashMap::new(),
@@ -106,7 +108,7 @@ impl ReactorUdpState {
         self.native_endpoints.clear();
         self.event_tokens.clear();
         self.queued_by_source.clear();
-        self.external_peer_count = 0;
+        self.native_peer_count = 0;
         self.queued_datagrams = 0;
         self.queued_bytes = 0;
     }
@@ -119,7 +121,6 @@ pub(super) struct ReactorUdpBinding {
 }
 
 pub(super) struct UdpSocketState {
-    pub(super) internal_address: Option<SocketAddrV4>,
     pub(super) peer: Option<ReactorUdpPeer>,
     guest_receive_queue: VecDeque<GuestDatagram>,
     guest_receive_bytes: usize,
@@ -127,13 +128,16 @@ pub(super) struct UdpSocketState {
     pub(super) peeked_origin: Option<UdpReceiveOrigin>,
     pub(super) next_receive_origin: UdpReceiveOrigin,
     pub(super) native_endpoint: Option<UdpNativeEndpoint>,
-    pub(super) external_peers: HashSet<SocketAddrV4>,
+    /// Host peers authorized to answer this socket, keyed by native address.
+    ///
+    /// Each entry keeps the logical route that authorized it so an authorized
+    /// reply is reported with its original guest-visible destination.
+    pub(super) native_peers: HashMap<SocketAddrV4, SocketDestination>,
 }
 
 impl Default for UdpSocketState {
     fn default() -> Self {
         Self {
-            internal_address: None,
             peer: None,
             guest_receive_queue: VecDeque::new(),
             guest_receive_bytes: 0,
@@ -141,7 +145,7 @@ impl Default for UdpSocketState {
             peeked_origin: None,
             next_receive_origin: UdpReceiveOrigin::Guest,
             native_endpoint: None,
-            external_peers: HashSet::new(),
+            native_peers: HashMap::new(),
         }
     }
 }
@@ -211,15 +215,22 @@ pub(super) enum UdpReceiveOrigin {
 pub(super) enum ReactorUdpPeer {
     Guest {
         socket_generation: u64,
-        guest_address: SocketAddrV4,
+        destination: SocketDestination,
     },
-    External(SocketAddrV4),
+    Native {
+        host_address: SocketAddrV4,
+        destination: SocketDestination,
+    },
 }
 
 impl ReactorUdpState {
-    pub(super) fn reserve_binding(&mut self, binding: &GuestSocketBinding) -> BrokerResult<()> {
+    pub(super) fn reserve_binding(
+        &mut self,
+        config: &BrokerNetworkConfig,
+        binding: &GuestSocketBinding,
+    ) -> BrokerResult<()> {
         let requested = binding.requested();
-        if !binding.is_valid()
+        if !binding.is_valid_for(config)
             || if binding.is_wildcard() {
                 self.bindings.wildcard.contains_key(&requested.port())
                     || self
@@ -247,9 +258,13 @@ impl ReactorUdpState {
         }
     }
 
-    pub(super) fn insert_binding(&mut self, binding: ReactorUdpBinding) -> BrokerResult<()> {
+    pub(super) fn insert_binding(
+        &mut self,
+        config: &BrokerNetworkConfig,
+        binding: ReactorUdpBinding,
+    ) -> BrokerResult<()> {
         let requested = binding.guest_binding.requested();
-        self.reserve_binding(&binding.guest_binding)?;
+        self.reserve_binding(config, &binding.guest_binding)?;
         if binding.guest_binding.is_wildcard() {
             self.bindings.wildcard.insert(requested.port(), binding);
         } else {
@@ -275,24 +290,25 @@ impl ReactorUdpState {
         }
     }
 
-    fn guest_binding(&self, address: SocketAddrV4) -> Option<ReactorUdpBinding> {
-        if !address.ip().is_loopback() {
-            return None;
-        }
-        self.bindings
+    /// Finds the binding that owns one concrete guest-namespace address.
+    ///
+    /// An exact binding answers only its own address; a wildcard binding
+    /// answers every guest-local address on its port, including the
+    /// configured private guest address.
+    fn guest_binding(
+        &self,
+        config: &BrokerNetworkConfig,
+        requested: SocketAddrV4,
+    ) -> Option<ReactorUdpBinding> {
+        let binding = self
+            .bindings
             .exact
-            .get(&address)
-            .or_else(|| self.bindings.wildcard.get(&address.port()))
-            .cloned()
-    }
-
-    pub(super) fn has_binding_on_port(&self, port: u16) -> bool {
-        self.bindings.wildcard.contains_key(&port)
-            || self
-                .bindings
-                .exact
-                .keys()
-                .any(|address| address.port() == port)
+            .get(&requested)
+            .or_else(|| self.bindings.wildcard.get(&requested.port()))?;
+        binding
+            .guest_binding
+            .covers(config, requested)
+            .then(|| binding.clone())
     }
 
     pub(super) fn binding_for_socket(&self, socket_id: u64) -> Option<ReactorUdpBinding> {
@@ -308,43 +324,59 @@ impl ReactorUdpState {
 }
 
 impl Reactor {
-    /// Resolves a UDP destination with guest bindings taking precedence over
-    /// private native endpoints and external routing.
+    /// Resolves one broker-classified UDP destination.
+    ///
+    /// A guest route stays inside the broker namespace and never falls back to
+    /// a native endpoint, while gateway and external routes translate to the
+    /// host address realized by the shared native endpoint. Route metadata that
+    /// disagrees with the shared configuration fails closed.
     pub(super) fn resolve_udp_destination(
         &self,
-        mut address: SocketAddrV4,
-    ) -> SocketOutcome<ReactorUdpPeer> {
-        if address.ip().is_unspecified() {
-            address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, address.port());
+        destination: SocketDestination,
+    ) -> BrokerResult<SocketOutcome<ReactorUdpPeer>> {
+        if !destination.is_valid_for(&self.network_config) {
+            return Err(BrokerError::Internal);
         }
-        if let Some(binding) = self.udp.guest_binding(address) {
-            return SocketOutcome::Completed(ReactorUdpPeer::Guest {
-                socket_generation: binding.socket_id,
-                guest_address: address,
+        let SocketDestination::Guest { requested } = destination else {
+            let host_address = native_host_address(destination).ok_or(BrokerError::Internal)?;
+            // A translated route must never reach a broker-private endpoint.
+            return Ok(if self.is_private_udp_host_endpoint(host_address) {
+                SocketOutcome::Failed(SocketError::ConnectionRefused)
+            } else {
+                SocketOutcome::Completed(ReactorUdpPeer::Native {
+                    host_address,
+                    destination,
+                })
             });
-        }
-        if address.ip().is_loopback() && self.udp.has_binding_on_port(address.port()) {
-            return SocketOutcome::Failed(SocketError::ConnectionRefused);
-        }
-        if self.is_private_udp_host_endpoint(address) {
-            SocketOutcome::Failed(SocketError::ConnectionRefused)
-        } else {
-            SocketOutcome::Completed(ReactorUdpPeer::External(address))
-        }
+        };
+        Ok(
+            match self.udp.guest_binding(&self.network_config, requested) {
+                Some(binding) => SocketOutcome::Completed(ReactorUdpPeer::Guest {
+                    socket_generation: binding.socket_id,
+                    destination,
+                }),
+                None => SocketOutcome::Failed(SocketError::ConnectionRefused),
+            },
+        )
     }
 
-    pub(super) fn reserve_udp_external_peer(
+    pub(super) fn reserve_udp_native_peer(
         &mut self,
         socket_id: u64,
-        address: SocketAddrV4,
+        host_address: SocketAddrV4,
+        destination: SocketDestination,
     ) -> BrokerResult<bool> {
         let session_id = {
             let socket = self.sockets.get(&socket_id).ok_or(BrokerError::Internal)?;
             let udp = socket.udp_state()?;
-            if udp.external_peers.contains(&address) {
+            if let Some(authorized) = udp.native_peers.get(&host_address) {
+                // One host address belongs to exactly one logical route.
+                if *authorized != destination {
+                    return Err(BrokerError::Internal);
+                }
                 return Ok(false);
             }
-            if udp.external_peers.len() >= MAX_UDP_EXTERNAL_PEERS_PER_SOCKET {
+            if udp.native_peers.len() >= MAX_UDP_NATIVE_PEERS_PER_SOCKET {
                 return Err(BrokerError::ResourceExhausted);
             }
             socket.session_id
@@ -353,14 +385,14 @@ impl Reactor {
             .sessions
             .get(&session_id)
             .ok_or(BrokerError::Internal)?;
-        if self.udp.external_peer_count
+        if self.udp.native_peer_count
             >= self
                 .max_sockets
-                .saturating_mul(MAX_UDP_EXTERNAL_PEERS_PER_SOCKET)
-            || session.udp_external_peer_count
+                .saturating_mul(MAX_UDP_NATIVE_PEERS_PER_SOCKET)
+            || session.udp_native_peer_count
                 >= self
                     .max_sockets_per_session
-                    .saturating_mul(MAX_UDP_EXTERNAL_PEERS_PER_SOCKET)
+                    .saturating_mul(MAX_UDP_NATIVE_PEERS_PER_SOCKET)
         {
             return Err(BrokerError::ResourceExhausted);
         }
@@ -368,61 +400,62 @@ impl Reactor {
             .get_mut(&socket_id)
             .ok_or(BrokerError::Internal)?
             .udp_state_mut()?
-            .external_peers
+            .native_peers
             .try_reserve(1)
             .map_err(|_| BrokerError::OutOfMemory)?;
-        if !self
+        if self
             .sockets
             .get_mut(&socket_id)
             .ok_or(BrokerError::Internal)?
             .udp_state_mut()?
-            .external_peers
-            .insert(address)
+            .native_peers
+            .insert(host_address, destination)
+            .is_some()
         {
             return Err(BrokerError::Internal);
         }
-        self.udp.external_peer_count = self
+        self.udp.native_peer_count = self
             .udp
-            .external_peer_count
+            .native_peer_count
             .checked_add(1)
             .ok_or(BrokerError::ResourceExhausted)?;
         let session = self
             .sessions
             .get_mut(&session_id)
             .ok_or(BrokerError::Internal)?;
-        session.udp_external_peer_count = session
-            .udp_external_peer_count
+        session.udp_native_peer_count = session
+            .udp_native_peer_count
             .checked_add(1)
             .ok_or(BrokerError::ResourceExhausted)?;
         Ok(true)
     }
 
-    pub(super) fn remove_udp_external_peer(&mut self, socket_id: u64, address: SocketAddrV4) {
+    pub(super) fn remove_udp_native_peer(&mut self, socket_id: u64, host_address: SocketAddrV4) {
         let Some(socket) = self.sockets.get_mut(&socket_id) else {
             return;
         };
         let Ok(udp) = socket.udp_state_mut() else {
             return;
         };
-        if !udp.external_peers.remove(&address) {
+        if udp.native_peers.remove(&host_address).is_none() {
             return;
         }
-        self.udp.external_peer_count = self
+        self.udp.native_peer_count = self
             .udp
-            .external_peer_count
+            .native_peer_count
             .checked_sub(1)
-            .expect("reactor UDP external peer count underflow");
+            .expect("reactor UDP native peer count underflow");
         let session = self
             .sessions
             .get_mut(&socket.session_id)
-            .expect("UDP external peer session state missing");
-        session.udp_external_peer_count = session
-            .udp_external_peer_count
+            .expect("UDP native peer session state missing");
+        session.udp_native_peer_count = session
+            .udp_native_peer_count
             .checked_sub(1)
-            .expect("session UDP external peer count underflow");
+            .expect("session UDP native peer count underflow");
     }
 
-    pub(super) fn clear_udp_external_peers(&mut self, socket_id: u64) -> BrokerResult<()> {
+    pub(super) fn clear_udp_native_peers(&mut self, socket_id: u64) -> BrokerResult<()> {
         let (session_id, count) = {
             let socket = self
                 .sockets
@@ -430,21 +463,21 @@ impl Reactor {
                 .ok_or(BrokerError::Internal)?;
             let session_id = socket.session_id;
             let udp = socket.udp_state_mut()?;
-            let count = udp.external_peers.len();
-            udp.external_peers.clear();
+            let count = udp.native_peers.len();
+            udp.native_peers.clear();
             (session_id, count)
         };
-        self.udp.external_peer_count = self
+        self.udp.native_peer_count = self
             .udp
-            .external_peer_count
+            .native_peer_count
             .checked_sub(count)
             .ok_or(BrokerError::Internal)?;
         let session = self
             .sessions
             .get_mut(&session_id)
             .ok_or(BrokerError::Internal)?;
-        session.udp_external_peer_count = session
-            .udp_external_peer_count
+        session.udp_native_peer_count = session
+            .udp_native_peer_count
             .checked_sub(count)
             .ok_or(BrokerError::Internal)?;
         Ok(())
@@ -689,21 +722,25 @@ impl Reactor {
         &mut self,
         source_socket_id: u64,
         destination_generation: u64,
+        destination_route: SocketDestination,
         payload: &[u8],
     ) -> BrokerResult<SocketOutcome<usize>> {
-        let (source_session_id, source_guest_address) = {
-            let source = self
-                .sockets
-                .get(&source_socket_id)
-                .ok_or(BrokerError::Internal)?;
-            (
-                source.session_id,
-                source
-                    .udp_state()?
-                    .internal_address
-                    .ok_or(BrokerError::Internal)?,
-            )
-        };
+        let source_session_id = self
+            .sockets
+            .get(&source_socket_id)
+            .ok_or(BrokerError::Internal)?
+            .session_id;
+        // The visible source follows the sender's broker-issued binding and
+        // the route it answered, never a native descriptor.
+        let source_guest_address = self
+            .udp
+            .binding_for_socket(source_socket_id)
+            .and_then(|binding| {
+                binding
+                    .guest_binding
+                    .concrete_address_for(&self.network_config, destination_route)
+            })
+            .ok_or(BrokerError::Internal)?;
         let destination_id = destination_generation;
         let accepts_source = {
             let Some(destination) = self.sockets.get(&destination_id) else {
@@ -718,7 +755,7 @@ impl Reactor {
                 Some(ReactorUdpPeer::Guest {
                     socket_generation, ..
                 }) => socket_generation == source_socket_id,
-                Some(ReactorUdpPeer::External(_)) => false,
+                Some(ReactorUdpPeer::Native { .. }) => false,
             }
         };
         if !accepts_source
@@ -947,13 +984,13 @@ impl Reactor {
             || self.udp.native_endpoints.contains(&port)
             || self.sockets.values().any(|socket| {
                 socket.udp_state().is_ok_and(|udp| {
-                    udp.external_peers
-                        .iter()
+                    udp.native_peers
+                        .keys()
                         .any(|peer| udp_address_matches_host_port(*peer, port))
                         || matches!(
                             udp.peer,
-                            Some(ReactorUdpPeer::External(peer))
-                                if udp_address_matches_host_port(peer, port)
+                            Some(ReactorUdpPeer::Native { host_address, .. })
+                                if udp_address_matches_host_port(host_address, port)
                         )
                 })
             }))
@@ -1070,7 +1107,7 @@ impl Reactor {
         &mut self,
         socket_id: u64,
         peer: SocketAddrV4,
-    ) -> core::result::Result<SocketOutcome<SocketAddrV4>, PlatformConnectError> {
+    ) -> core::result::Result<SocketOutcome<()>, PlatformConnectError> {
         {
             let socket =
                 self.sockets
@@ -1120,12 +1157,9 @@ impl Reactor {
                     receive_datagram_fd(&endpoint.socket, 0, ReceiveFromFlags::NONE)
                 };
             match outcome {
-                Ok(
-                    ReactorReceiveFromOutcome::Received { .. }
-                    | ReactorReceiveFromOutcome::Failed(_),
-                ) => {}
+                Ok(NativeDatagramOutcome::Received { .. } | NativeDatagramOutcome::Failed(_)) => {}
                 Err(BrokerError::WouldBlock) => {
-                    let host_address = {
+                    {
                         let socket = self.sockets.get_mut(&socket_id).ok_or(
                             PlatformConnectError::PeerIndeterminate(BrokerError::Internal),
                         )?;
@@ -1141,14 +1175,14 @@ impl Reactor {
                         endpoint.write_blocked = false;
                         endpoint.error = UdpNativeErrorState::None;
                         endpoint.readable = false;
-                        let host_address = local_socket_address(&endpoint.socket)
+                        // The bound port never changes, but a connected
+                        // descriptor reports its selected host source.
+                        endpoint.host_address = local_socket_address(&endpoint.socket)
                             .map_err(PlatformConnectError::PeerIndeterminate)?;
-                        endpoint.host_address = host_address;
-                        host_address
-                    };
+                    }
                     self.rearm_udp_endpoint(socket_id)
                         .map_err(PlatformConnectError::PeerIndeterminate)?;
-                    return Ok(SocketOutcome::Completed(host_address));
+                    return Ok(SocketOutcome::Completed(()));
                 }
                 Err(error) => return Err(PlatformConnectError::PeerIndeterminate(error)),
             }
@@ -1287,23 +1321,31 @@ impl Reactor {
         Ok(())
     }
 
-    fn udp_native_source_authorized(
+    /// Returns the logical route that authorizes one native datagram source.
+    ///
+    /// An unauthorized source, a broker-private endpoint, a guest-connected
+    /// socket, and a read-shutdown socket all return `None`, so a host peer
+    /// can never masquerade as another route.
+    fn udp_native_source_destination(
         &self,
         socket_id: u64,
         source_address: SocketAddrV4,
-    ) -> BrokerResult<bool> {
+    ) -> BrokerResult<Option<SocketDestination>> {
         let socket = self.sockets.get(&socket_id).ok_or(BrokerError::Internal)?;
         if socket.read_shutdown {
-            return Ok(false);
+            return Ok(None);
         }
         let udp = socket.udp_state()?;
         Ok(if self.is_private_udp_host_endpoint(source_address) {
-            false
+            None
         } else {
             match udp.peer {
-                Some(ReactorUdpPeer::Guest { .. }) => false,
-                Some(ReactorUdpPeer::External(peer)) => peer == source_address,
-                None => udp.external_peers.contains(&source_address),
+                Some(ReactorUdpPeer::Guest { .. }) => None,
+                Some(ReactorUdpPeer::Native {
+                    host_address,
+                    destination,
+                }) => (host_address == source_address).then_some(destination),
+                None => udp.native_peers.get(&source_address).copied(),
             }
         })
     }
@@ -1372,8 +1414,8 @@ impl Reactor {
                 receive_datagram_fd(&endpoint.socket, 0, ReceiveFromFlags::PEEK)
             };
             let source_address = match peek {
-                Ok(ReactorReceiveFromOutcome::Received { source_address, .. }) => source_address,
-                Ok(ReactorReceiveFromOutcome::Failed(error)) => {
+                Ok(NativeDatagramOutcome::Received { source_address, .. }) => source_address,
+                Ok(NativeDatagramOutcome::Failed(error)) => {
                     self.record_udp_endpoint_error(socket_id, error)?;
                     self.sockets
                         .get_mut(&socket_id)
@@ -1400,7 +1442,10 @@ impl Reactor {
                 }
                 Err(error) => return Err(error),
             };
-            if self.udp_native_source_authorized(socket_id, source_address)? {
+            if self
+                .udp_native_source_destination(socket_id, source_address)?
+                .is_some()
+            {
                 self.sockets
                     .get_mut(&socket_id)
                     .ok_or(BrokerError::Internal)?
@@ -1421,8 +1466,8 @@ impl Reactor {
                 receive_datagram_fd(&endpoint.socket, 0, ReceiveFromFlags::NONE)
             };
             match consumed {
-                Ok(ReactorReceiveFromOutcome::Received { .. }) => {}
-                Ok(ReactorReceiveFromOutcome::Failed(error)) => {
+                Ok(NativeDatagramOutcome::Received { .. }) => {}
+                Ok(NativeDatagramOutcome::Failed(error)) => {
                     self.record_udp_endpoint_error(socket_id, error)?;
                     self.sockets
                         .get_mut(&socket_id)
@@ -1449,13 +1494,12 @@ impl Reactor {
         Ok(())
     }
 
-    pub(super) fn send_external_udp(
+    pub(super) fn send_native_udp(
         &mut self,
         socket_id: u64,
         data: &[u8],
-        address: SocketAddrV4,
+        host_address: SocketAddrV4,
     ) -> BrokerResult<SocketOutcome<usize>> {
-        let destination = address;
         let result = loop {
             let socket = self.sockets.get(&socket_id).ok_or(BrokerError::Internal)?;
             let endpoint = socket
@@ -1467,7 +1511,7 @@ impl Reactor {
                 &endpoint.socket,
                 data,
                 LinuxSendFlags::NOSIGNAL,
-                &destination,
+                &host_address,
             ) {
                 Ok(sent) if sent == data.len() => break Ok(SocketOutcome::Completed(sent)),
                 Ok(_) => break Err(BrokerError::Internal),
@@ -1562,7 +1606,9 @@ impl Reactor {
         Ok(Some(ReactorReceiveFromOutcome::Received {
             data,
             datagram_length,
-            source_address,
+            source: SocketDestination::Guest {
+                requested: source_address,
+            },
         }))
     }
 
@@ -1595,12 +1641,12 @@ impl Reactor {
                 receive_datagram_fd(&endpoint.socket, length, ReceiveFromFlags::PEEK)
             };
             let (data, datagram_length, source_address) = match outcome {
-                Ok(ReactorReceiveFromOutcome::Received {
+                Ok(NativeDatagramOutcome::Received {
                     data,
                     datagram_length,
                     source_address,
                 }) => (data, datagram_length, source_address),
-                Ok(ReactorReceiveFromOutcome::Failed(error)) => {
+                Ok(NativeDatagramOutcome::Failed(error)) => {
                     return self.finish_udp_receive_error(socket_id, error);
                 }
                 Err(BrokerError::WouldBlock) => {
@@ -1618,8 +1664,8 @@ impl Reactor {
                 }
                 Err(error) => return Err(error),
             };
-            let authorized = self.udp_native_source_authorized(socket_id, source_address)?;
-            if authorized {
+            let authorized = self.udp_native_source_destination(socket_id, source_address)?;
+            if let Some(source) = authorized {
                 if flags.contains(ReceiveFromFlags::PEEK) {
                     self.sockets
                         .get_mut(&socket_id)
@@ -1629,7 +1675,7 @@ impl Reactor {
                     return Ok(Some(ReactorReceiveFromOutcome::Received {
                         data,
                         datagram_length,
-                        source_address,
+                        source,
                     }));
                 }
 
@@ -1668,8 +1714,8 @@ impl Reactor {
                     receive_datagram_fd(&endpoint.socket, 0, ReceiveFromFlags::NONE)
                 };
                 match consumed {
-                    Ok(ReactorReceiveFromOutcome::Received { .. }) => {}
-                    Ok(ReactorReceiveFromOutcome::Failed(error)) => {
+                    Ok(NativeDatagramOutcome::Received { .. }) => {}
+                    Ok(NativeDatagramOutcome::Failed(error)) => {
                         return self.finish_udp_receive_error(socket_id, error);
                     }
                     Err(BrokerError::WouldBlock) => {
@@ -1706,7 +1752,7 @@ impl Reactor {
                 return Ok(Some(ReactorReceiveFromOutcome::Received {
                     data,
                     datagram_length,
-                    source_address,
+                    source,
                 }));
             }
             let socket = self.sockets.get(&socket_id).ok_or(BrokerError::Internal)?;
@@ -1716,8 +1762,8 @@ impl Reactor {
                 .as_ref()
                 .ok_or(BrokerError::Internal)?;
             match receive_datagram_fd(&endpoint.socket, 0, ReceiveFromFlags::NONE) {
-                Ok(ReactorReceiveFromOutcome::Received { .. }) => {}
-                Ok(ReactorReceiveFromOutcome::Failed(error)) => {
+                Ok(NativeDatagramOutcome::Received { .. }) => {}
+                Ok(NativeDatagramOutcome::Failed(error)) => {
                     return self.finish_udp_receive_error(socket_id, error);
                 }
                 Err(BrokerError::WouldBlock) => {
@@ -1761,15 +1807,26 @@ impl Reactor {
     }
 }
 
+/// One datagram observed directly on a native descriptor.
+///
+/// This carries the untranslated host source, which only becomes a
+/// guest-visible route after peer authorization.
+enum NativeDatagramOutcome {
+    Received {
+        data: Vec<u8>,
+        datagram_length: usize,
+        source_address: SocketAddrV4,
+    },
+    Failed(SocketError),
+}
+
 fn receive_datagram_fd(
     socket: &OwnedFd,
     length: usize,
     flags: ReceiveFromFlags,
-) -> BrokerResult<ReactorReceiveFromOutcome> {
+) -> BrokerResult<NativeDatagramOutcome> {
     if length > MAX_UDP_DATAGRAM_SIZE as usize || flags.has_unsupported_bits() {
-        return Ok(ReactorReceiveFromOutcome::Failed(
-            SocketError::InvalidArgument,
-        ));
+        return Ok(NativeDatagramOutcome::Failed(SocketError::InvalidArgument));
     }
     let mut data = zeroed_vec(length)?;
     let mut linux_flags = LinuxRecvFlags::TRUNC;
@@ -1782,7 +1839,7 @@ fn receive_datagram_fd(
                 let source_address = SocketAddrV4::try_from(address.ok_or(BrokerError::Internal)?)
                     .map_err(|_| BrokerError::Internal)?;
                 data.truncate(received);
-                return Ok(ReactorReceiveFromOutcome::Received {
+                return Ok(NativeDatagramOutcome::Received {
                     data,
                     datagram_length,
                     source_address,
@@ -1791,7 +1848,7 @@ fn receive_datagram_fd(
             Err(Errno::INTR) => {}
             Err(Errno::AGAIN) => return Err(BrokerError::WouldBlock),
             Err(error) => {
-                return Ok(ReactorReceiveFromOutcome::Failed(
+                return Ok(NativeDatagramOutcome::Failed(
                     socket_operation_error_from_errno(error)?,
                 ));
             }

--- a/litebox_broker_userland/src/linux.rs
+++ b/litebox_broker_userland/src/linux.rs
@@ -8,6 +8,7 @@ use std::process::Child;
 use std::sync::Arc;
 use std::time::Instant;
 
+use litebox_broker_core::socket::BrokerNetworkConfig;
 use litebox_broker_core::{BrokerCore, BrokerCoreLimits, ObjectRights, PolicyEngine};
 use litebox_broker_platform_linux_userland::LinuxSocketProvider;
 use litebox_broker_protocol::message::{BrokerRequest, BrokerResponse};
@@ -21,7 +22,7 @@ use litebox_broker_transport_linux_userland::unix_socket::{
 
 use super::{
     HostAssociationShutdown, HostRequestSource, HostResponseSink, SETUP_TIMEOUT,
-    configured_socket_policy,
+    configured_gateway_rules, configured_socket_policy,
 };
 
 impl HostRequestSource for UnixControlRingHostRequestSource {
@@ -50,11 +51,24 @@ pub(super) fn run(args: super::CliArgs) -> Result<(), Box<dyn Error>> {
     let control_listener = UnixListener::bind(&control_socket_path)?;
     control_listener.set_nonblocking(true)?;
     let limits = BrokerCoreLimits::DEFAULT;
+    // The broker core and its socket provider must share one network identity.
+    let network_config = Arc::new(BrokerNetworkConfig::default());
+    let policy = PolicyEngine::with_host_guaranteed_rights(ObjectRights::all())
+        .with_socket_policy(configured_socket_policy(
+            &args.allow_tcp_destination,
+            &args.allow_host_gateway_tcp_port,
+            &args.allow_host_gateway_udp_port,
+        )?)
+        .with_gateway_rules(
+            &configured_gateway_rules(&args.allow_host_gateway_tcp_port),
+            &configured_gateway_rules(&args.allow_host_gateway_udp_port),
+        )?;
     let broker = BrokerCore::new_with_limits(
-        PolicyEngine::with_host_guaranteed_rights(ObjectRights::all())
-            .with_socket_policy(configured_socket_policy(&args.allow_tcp_destination)?),
+        policy,
         limits,
+        Arc::clone(&network_config),
         Arc::new(LinuxSocketProvider::new(
+            network_config,
             limits.max_sockets,
             limits.max_sockets_per_session,
         )?),

--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -17,8 +17,8 @@ use std::time::{Duration, Instant};
 
 use clap::Parser;
 use litebox_broker_core::{
-    BrokerCore, CallerCredential, DestinationPortRange, DestinationRule, Ipv4Cidr, SocketPolicy,
-    SocketPolicyError,
+    BrokerCore, CallerCredential, DestinationPortRange, DestinationRule, GatewayPortRule, Ipv4Cidr,
+    SocketPolicy, SocketPolicyError,
 };
 use litebox_broker_host::{BrokerHostAssociation, ConnectionTermination, setup_connection};
 use litebox_broker_protocol::message::{BrokerRequest, BrokerResponse};
@@ -67,30 +67,64 @@ impl FromStr for AllowedTcpDestination {
                 "IPv4 CIDR must have a valid prefix and canonical network address".to_owned()
             })?;
 
-        let (start, end) = ports
-            .split_once('-')
-            .map_or((ports, ports), |(start, end)| (start, end));
-        let start = start
-            .parse::<u16>()
-            .map_err(|error| format!("invalid TCP port: {error}"))?;
-        let end = end
-            .parse::<u16>()
-            .map_err(|error| format!("invalid TCP port: {error}"))?;
-        let ports = DestinationPortRange::new(Port(start), Port(end))
-            .ok_or_else(|| "TCP port range must be ordered and exclude port zero".to_owned())?;
+        let ports = parse_port_range(ports, "TCP")?;
 
         Ok(Self { destination, ports })
     }
+}
+
+/// One host-gateway destination port range authorized on the command line.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct AllowedGatewayPort(DestinationPortRange);
+
+impl FromStr for AllowedGatewayPort {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        parse_port_range(value, "gateway").map(Self)
+    }
+}
+
+/// Parses one `PORT` or `START-END` destination port range.
+fn parse_port_range(value: &str, label: &str) -> Result<DestinationPortRange, String> {
+    let (start, end) = value
+        .split_once('-')
+        .map_or((value, value), |(start, end)| (start, end));
+    let start = start
+        .parse::<u16>()
+        .map_err(|error| format!("invalid {label} port: {error}"))?;
+    let end = end
+        .parse::<u16>()
+        .map_err(|error| format!("invalid {label} port: {error}"))?;
+    DestinationPortRange::new(Port(start), Port(end))
+        .ok_or_else(|| format!("{label} port range must be ordered and exclude port zero"))
 }
 
 #[derive(Parser, Debug)]
 struct CliArgs {
     /// Permit outbound TCP connections to a destination CIDR and port range.
     ///
-    /// May be repeated. Supplying any rule replaces the default loopback-only policy.
+    /// May be repeated. Supplying any rule replaces the default loopback-only
+    /// policy with guest networking plus these external destinations.
     /// `0.0.0.0/0:1-65535` permits every nonzero IPv4 TCP destination.
     #[arg(long, value_name = "CIDR:PORT[-PORT]")]
     allow_tcp_destination: Vec<AllowedTcpDestination>,
+    /// Permit TCP access to a host service through the guest-visible gateway
+    /// address 10.0.2.1, which reaches host loopback on the same port.
+    ///
+    /// May be repeated. Each rule authorizes one destination port or range and
+    /// selects guest networking, because guests no longer reach host loopback
+    /// directly.
+    #[arg(long, value_name = "PORT[-PORT]")]
+    allow_host_gateway_tcp_port: Vec<AllowedGatewayPort>,
+    /// Permit UDP access to a host service through the guest-visible gateway
+    /// address 10.0.2.1, which reaches host loopback on the same port.
+    ///
+    /// May be repeated. Each rule authorizes one destination port or range and
+    /// selects guest networking, because guests no longer reach host loopback
+    /// directly.
+    #[arg(long, value_name = "PORT[-PORT]")]
+    allow_host_gateway_udp_port: Vec<AllowedGatewayPort>,
     /// Local runner executable to launch.
     #[arg(long, value_name = "PATH", value_hint = clap::ValueHint::ExecutablePath)]
     runner: PathBuf,
@@ -125,8 +159,16 @@ fn run_runner_process(
 
 fn configured_socket_policy(
     allowed_destinations: &[AllowedTcpDestination],
+    tcp_gateway_ports: &[AllowedGatewayPort],
+    udp_gateway_ports: &[AllowedGatewayPort],
 ) -> Result<SocketPolicy, SocketPolicyError> {
-    if allowed_destinations.is_empty() {
+    // A gateway rule authorizes a route only under a guest-network policy, so
+    // the literal loopback default survives only without any external
+    // destination or gateway configuration.
+    if allowed_destinations.is_empty()
+        && tcp_gateway_ports.is_empty()
+        && udp_gateway_ports.is_empty()
+    {
         return Ok(SocketPolicy::Ipv4Loopback);
     }
     let rules = allowed_destinations
@@ -139,13 +181,15 @@ fn configured_socket_policy(
             )
         })
         .collect::<Vec<_>>();
-    let udp_loopback = DestinationRule::new(
-        CallerCredential::HostGuaranteed,
-        Ipv4Cidr::new(Ipv4Address([127, 0, 0, 0]), 8).expect("the IPv4 loopback CIDR is canonical"),
-        DestinationPortRange::new(Port(1), Port(u16::MAX))
-            .expect("the full nonzero UDP port range is valid"),
-    );
-    SocketPolicy::from_tcp_udp_destination_rules(&rules, &[udp_loopback])
+    SocketPolicy::from_guest_network_destination_rules(true, &rules, true, &[])
+}
+
+/// Builds the bounded gateway port rules for one transport protocol.
+fn configured_gateway_rules(allowed_ports: &[AllowedGatewayPort]) -> Vec<GatewayPortRule> {
+    allowed_ports
+        .iter()
+        .map(|allowed| GatewayPortRule::new(CallerCredential::HostGuaranteed, allowed.0))
+        .collect()
 }
 
 fn serve_runner<Memory, SetupChannel, RequestSource, ResponseSink, NotificationChannel, Shutdown>(
@@ -556,6 +600,10 @@ mod cli_tests {
             "litebox-broker-userland",
             "--allow-tcp-destination",
             "127.0.0.0/8:80",
+            "--allow-host-gateway-tcp-port",
+            "8080",
+            "--allow-host-gateway-udp-port",
+            "53-54",
             "--runner",
             "runner",
             "guest",
@@ -563,6 +611,18 @@ mod cli_tests {
         .unwrap();
 
         assert_eq!(args.allow_tcp_destination.len(), 1);
+        assert_eq!(
+            args.allow_host_gateway_tcp_port,
+            [AllowedGatewayPort(
+                DestinationPortRange::new(Port(8080), Port(8080)).unwrap()
+            )]
+        );
+        assert_eq!(
+            args.allow_host_gateway_udp_port,
+            [AllowedGatewayPort(
+                DestinationPortRange::new(Port(53), Port(54)).unwrap()
+            )]
+        );
     }
 
     #[test]
@@ -589,30 +649,77 @@ mod cli_tests {
     #[test]
     fn tcp_destination_arguments_replace_the_loopback_default() {
         assert_eq!(
-            configured_socket_policy(&[]).unwrap(),
+            configured_socket_policy(&[], &[], &[]).unwrap(),
             SocketPolicy::Ipv4Loopback
         );
 
         let allowed = "0.0.0.0/0:80".parse::<AllowedTcpDestination>().unwrap();
-        let policy = configured_socket_policy(&[allowed]).unwrap();
-        let rules = policy.tcp_destination_rules().unwrap();
-        assert_eq!(rules.len(), 1);
+        let policy = configured_socket_policy(&[allowed], &[], &[]).unwrap();
+        // Guest traffic is admitted for both protocols; UDP keeps no external
+        // destination rules of its own.
+        assert!(matches!(
+            policy,
+            SocketPolicy::GuestNetwork {
+                admit_tcp: true,
+                admit_udp: true,
+                ..
+            }
+        ));
         assert_eq!(
-            rules[0],
-            DestinationRule::new(
-                CallerCredential::HostGuaranteed,
-                allowed.destination,
-                allowed.ports,
+            policy.tcp_destination_rules(),
+            Some(
+                [DestinationRule::new(
+                    CallerCredential::HostGuaranteed,
+                    allowed.destination,
+                    allowed.ports,
+                )]
+                .as_slice()
             )
         );
+        assert_eq!(policy.udp_destination_rules(), Some([].as_slice()));
+    }
+
+    #[test]
+    fn gateway_port_arguments_are_protocol_specific() {
+        let tcp = "443-444".parse::<AllowedGatewayPort>().unwrap();
+        let udp = "53".parse::<AllowedGatewayPort>().unwrap();
+
         assert_eq!(
-            policy.udp_destination_rules().unwrap(),
-            &[DestinationRule::new(
+            configured_gateway_rules(&[tcp]),
+            [GatewayPortRule::new(
                 CallerCredential::HostGuaranteed,
-                Ipv4Cidr::new(Ipv4Address([127, 0, 0, 0]), 8).unwrap(),
-                DestinationPortRange::new(Port(1), Port(u16::MAX)).unwrap(),
+                DestinationPortRange::new(Port(443), Port(444)).unwrap(),
             )]
         );
+        assert_eq!(
+            configured_gateway_rules(&[udp]),
+            [GatewayPortRule::new(
+                CallerCredential::HostGuaranteed,
+                DestinationPortRange::new(Port(53), Port(53)).unwrap(),
+            )]
+        );
+        assert_eq!(configured_gateway_rules(&[]), []);
+        for malformed in ["0", "1-0", "53-0", "", "80-", "http"] {
+            assert!(malformed.parse::<AllowedGatewayPort>().is_err());
+        }
+    }
+
+    #[test]
+    fn gateway_ports_alone_select_the_guest_network_policy() {
+        let gateway = "8080".parse::<AllowedGatewayPort>().unwrap();
+
+        for (tcp_ports, udp_ports) in [
+            ([gateway].as_slice(), [].as_slice()),
+            ([].as_slice(), [gateway].as_slice()),
+        ] {
+            let policy = configured_socket_policy(&[], tcp_ports, udp_ports).unwrap();
+            assert_eq!(
+                policy,
+                SocketPolicy::from_guest_network_destination_rules(true, &[], true, &[]).unwrap()
+            );
+            assert_eq!(policy.tcp_destination_rules(), Some([].as_slice()));
+            assert_eq!(policy.udp_destination_rules(), Some([].as_slice()));
+        }
     }
 }
 
@@ -625,7 +732,7 @@ mod tests {
     use std::sync::mpsc::{Receiver, sync_channel};
     use std::time::{Duration, Instant};
 
-    use litebox_broker_core::socket::UnsupportedSocketProvider;
+    use litebox_broker_core::socket::{BrokerNetworkConfig, UnsupportedSocketProvider};
     use litebox_broker_core::{BrokerCore, ObjectRights, PolicyEngine};
     use litebox_broker_host::setup_connection;
     use litebox_broker_protocol::BROKER_PROTOCOL_VERSION;
@@ -747,6 +854,7 @@ mod tests {
         let host = std::thread::spawn(move || {
             let broker = BrokerCore::new(
                 PolicyEngine::with_host_guaranteed_rights(ObjectRights::all()),
+                Arc::new(BrokerNetworkConfig::default()),
                 Arc::new(UnsupportedSocketProvider),
             )
             .unwrap();

--- a/litebox_broker_userland/src/windows.rs
+++ b/litebox_broker_userland/src/windows.rs
@@ -11,7 +11,7 @@ use std::process::Child;
 use std::sync::Arc;
 use std::time::Instant;
 
-use litebox_broker_core::socket::UnsupportedSocketProvider;
+use litebox_broker_core::socket::{BrokerNetworkConfig, UnsupportedSocketProvider};
 use litebox_broker_core::{BrokerCore, ObjectRights, PolicyEngine};
 use litebox_broker_protocol::message::{BrokerRequest, BrokerResponse};
 use litebox_broker_protocol::shared_buffer::SHARED_BUFFER_POOL_SIZE;
@@ -27,7 +27,7 @@ use litebox_broker_transport_windows_userland::shared_memory::WindowsSharedMemor
 
 use super::{
     HostAssociationShutdown, HostRequestSource, HostResponseSink, SETUP_TIMEOUT,
-    configured_socket_policy,
+    configured_gateway_rules, configured_socket_policy,
 };
 
 impl HostRequestSource for WindowsControlRingHostRequestSource {
@@ -51,9 +51,19 @@ impl HostAssociationShutdown for WindowsControlRingHostShutdown {
 pub(super) fn run(args: super::CliArgs) -> Result<(), Box<dyn Error>> {
     let control_pipe = unique_control_pipe_name();
     let control_listener = WindowsNamedPipeListener::bind(&control_pipe)?;
+    let policy = PolicyEngine::with_host_guaranteed_rights(ObjectRights::all())
+        .with_socket_policy(configured_socket_policy(
+            &args.allow_tcp_destination,
+            &args.allow_host_gateway_tcp_port,
+            &args.allow_host_gateway_udp_port,
+        )?)
+        .with_gateway_rules(
+            &configured_gateway_rules(&args.allow_host_gateway_tcp_port),
+            &configured_gateway_rules(&args.allow_host_gateway_udp_port),
+        )?;
     let broker = BrokerCore::new(
-        PolicyEngine::with_host_guaranteed_rights(ObjectRights::all())
-            .with_socket_policy(configured_socket_policy(&args.allow_tcp_destination)?),
+        policy,
+        Arc::new(BrokerNetworkConfig::default()),
         Arc::new(UnsupportedSocketProvider),
     )?;
 

--- a/litebox_broker_userland/tests/notification_runtime.rs
+++ b/litebox_broker_userland/tests/notification_runtime.rs
@@ -7,7 +7,7 @@ use std::sync::mpsc::{Receiver, channel};
 use std::thread::JoinHandle;
 use std::time::Duration;
 
-use litebox_broker_core::socket::UnsupportedSocketProvider;
+use litebox_broker_core::socket::{BrokerNetworkConfig, UnsupportedSocketProvider};
 use litebox_broker_core::{BrokerCore, ObjectRights, PolicyEngine};
 use litebox_broker_host::{ConnectionTermination, setup_connection};
 use litebox_broker_local::{BrokerLocal, BrokerNotifications};
@@ -48,6 +48,7 @@ fn spawn_host(
     std::thread::spawn(move || {
         let broker = BrokerCore::new(
             PolicyEngine::with_unauthenticated_rights(ObjectRights::all()),
+            Arc::new(BrokerNetworkConfig::default()),
             Arc::new(UnsupportedSocketProvider),
         )
         .unwrap();
@@ -130,6 +131,7 @@ fn readiness_of(notification: Option<BrokerNotification>) -> ReadinessNotificati
 fn host_serves_control_requests_and_notifications_over_shared_rings() {
     let broker = BrokerCore::new(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all()),
+        Arc::new(BrokerNetworkConfig::default()),
         Arc::new(UnsupportedSocketProvider),
     )
     .unwrap();

--- a/litebox_runner_linux_userland/tests/run.rs
+++ b/litebox_runner_linux_userland/tests/run.rs
@@ -344,6 +344,43 @@ fn spawn_test_broker(
     spawn_test_broker_with_mode(control_socket_path, policy, connection_count, false)
 }
 
+/// Builds a guest-network policy that authorizes the given host gateway ports.
+///
+/// Gateway rules authorize a route only under a guest-network socket policy,
+/// which is what replaces direct guest access to host loopback services.
+#[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+fn gateway_policy(tcp_ports: &[u16], udp_ports: &[u16]) -> litebox_broker_core::PolicyEngine {
+    let rules = |ports: &[u16]| {
+        ports
+            .iter()
+            .map(|port| {
+                litebox_broker_core::GatewayPortRule::new(
+                    litebox_broker_core::CallerCredential::HostGuaranteed,
+                    litebox_broker_core::DestinationPortRange::new(
+                        litebox_broker_protocol::socket::Port(*port),
+                        litebox_broker_protocol::socket::Port(*port),
+                    )
+                    .expect("test gateway ports are nonzero"),
+                )
+            })
+            .collect::<Vec<_>>()
+    };
+    litebox_broker_core::PolicyEngine::with_host_guaranteed_rights(
+        litebox_broker_core::ObjectRights::all(),
+    )
+    .with_socket_policy(
+        litebox_broker_core::SocketPolicy::from_guest_network_destination_rules(
+            true,
+            &[],
+            true,
+            &[],
+        )
+        .expect("the guest network policy has no external rules"),
+    )
+    .with_gateway_rules(&rules(tcp_ports), &rules(udp_ports))
+    .expect("test gateway rules are within the policy bound")
+}
+
 #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
 fn spawn_concurrent_test_broker(
     control_socket_path: &Path,
@@ -373,11 +410,15 @@ fn spawn_test_broker_with_mode(
                 std::os::unix::net::UnixListener::bind(&server_control_socket_path)
                     .expect("failed to bind broker test control socket");
             let limits = litebox_broker_core::BrokerCoreLimits::DEFAULT;
+            let network_config =
+                std::sync::Arc::new(litebox_broker_core::socket::BrokerNetworkConfig::default());
             let broker = litebox_broker_core::BrokerCore::new_with_limits(
                 policy,
                 limits,
+                std::sync::Arc::clone(&network_config),
                 std::sync::Arc::new(
                     litebox_broker_platform_linux_userland::LinuxSocketProvider::new(
+                        network_config,
                         limits.max_sockets,
                         limits.max_sockets_per_session,
                     )
@@ -664,10 +705,7 @@ fn test_runner_broker_tcp_client_with_rewriter() {
     let control_socket_path = unique_test_socket_path("runner-broker-tcp-control");
     let broker = spawn_test_broker(
         &control_socket_path,
-        litebox_broker_core::PolicyEngine::with_host_guaranteed_rights(
-            litebox_broker_core::ObjectRights::all(),
-        )
-        .with_socket_policy(litebox_broker_core::SocketPolicy::Ipv4Loopback),
+        gateway_policy(&[port, refused_port], &[]),
         1,
     );
     Runner::new(&target, "broker_tcp_client_rewriter")
@@ -675,7 +713,7 @@ fn test_runner_broker_tcp_client_with_rewriter() {
         .arg(refused_port.to_string())
         .broker_socket(&control_socket_path)
         .run();
-    assert_eq!(broker.next_close_object_count(), 9);
+    assert_eq!(broker.next_close_object_count(), 10);
     broker.join();
     server.join().unwrap();
 }
@@ -753,10 +791,7 @@ fn test_runner_broker_udp_with_rewriter() {
     let control_socket_path = unique_test_socket_path("runner-broker-udp-control");
     let broker = spawn_test_broker(
         &control_socket_path,
-        litebox_broker_core::PolicyEngine::with_host_guaranteed_rights(
-            litebox_broker_core::ObjectRights::all(),
-        )
-        .with_socket_policy(litebox_broker_core::SocketPolicy::Ipv4Loopback),
+        gateway_policy(&[], &[port, refused_port]),
         1,
     );
     runner
@@ -1274,15 +1309,8 @@ fn test_broker_with_curl() {
 
     let curl_path = run_which("curl");
     let control_socket_path = unique_test_socket_path("runner-broker-curl-control");
-    let broker = spawn_test_broker(
-        &control_socket_path,
-        litebox_broker_core::PolicyEngine::with_host_guaranteed_rights(
-            litebox_broker_core::ObjectRights::all(),
-        )
-        .with_socket_policy(litebox_broker_core::SocketPolicy::Ipv4Loopback),
-        1,
-    );
-    let url = format!("http://127.0.0.1:{port}/something");
+    let broker = spawn_test_broker(&control_socket_path, gateway_policy(&[port], &[]), 1);
+    let url = format!("http://10.0.2.1:{port}/something");
     let output = Runner::new(&curl_path, "curl_rewriter")
         .args(["-sS", &url])
         .broker_socket(&control_socket_path)
@@ -1313,14 +1341,6 @@ fn test_broker_with_iperf3() {
 
     let iperf3_path = run_which("iperf3");
     let control_socket_path = unique_test_socket_path("runner-broker-iperf3-control");
-    let broker = spawn_test_broker(
-        &control_socket_path,
-        litebox_broker_core::PolicyEngine::with_host_guaranteed_rights(
-            litebox_broker_core::ObjectRights::all(),
-        )
-        .with_socket_policy(litebox_broker_core::SocketPolicy::Ipv4Loopback),
-        1,
-    );
 
     let mut last_server_output = String::new();
     let mut started_server = None;
@@ -1377,12 +1397,14 @@ fn test_broker_with_iperf3() {
     }
     let (port, mut server, server_output) = started_server
         .unwrap_or_else(|| panic!("iperf3 server did not start; output:\n{last_server_output}"));
+    // The gateway rule names the port the server actually bound.
+    let broker = spawn_test_broker(&control_socket_path, gateway_policy(&[port], &[]), 1);
 
     let mut runner = Runner::new(&iperf3_path, "broker_iperf3_client_rewriter");
     runner
         .args([
             "-c",
-            "127.0.0.1",
+            "10.0.2.1",
             "-p",
             &port.to_string(),
             "--connect-timeout",

--- a/litebox_runner_linux_userland/tests/tcp_broker.c
+++ b/litebox_runner_linux_userland/tests/tcp_broker.c
@@ -35,7 +35,10 @@ int main(int argc, char **argv) {
         .sin_family = AF_INET,
         .sin_port = htons((uint16_t)strtoul(argv[1], NULL, 10)),
     };
-    assert(inet_pton(AF_INET, "127.0.0.1", &address.sin_addr) == 1);
+    // Host services are reachable only through the guest-visible gateway.
+    assert(inet_pton(AF_INET, "10.0.2.1", &address.sin_addr) == 1);
+    struct in_addr guest_address;
+    assert(inet_pton(AF_INET, "10.0.2.15", &guest_address) == 1);
     int result = connect(fd, (const struct sockaddr *)&address, sizeof(address));
     assert(result == 0 || (result == -1 && errno == EINPROGRESS));
 
@@ -44,7 +47,7 @@ int main(int argc, char **argv) {
         socklen_t connecting_address_length = sizeof(connecting_address);
         assert(getsockname(fd, (struct sockaddr *)&connecting_address,
                            &connecting_address_length) == 0);
-        assert(connecting_address.sin_addr.s_addr == htonl(INADDR_LOOPBACK));
+        assert(connecting_address.sin_addr.s_addr == guest_address.s_addr);
         assert(connecting_address.sin_port != 0);
         int epoll_fd = epoll_create1(EPOLL_CLOEXEC);
         assert(epoll_fd >= 0);
@@ -63,14 +66,14 @@ int main(int argc, char **argv) {
     socklen_t address_length = sizeof(local_address);
     assert(getsockname(fd, (struct sockaddr *)&local_address, &address_length) == 0);
     assert(local_address.sin_family == AF_INET);
-    assert(local_address.sin_addr.s_addr == htonl(INADDR_LOOPBACK));
+    assert(local_address.sin_addr.s_addr == guest_address.s_addr);
     assert(local_address.sin_port != 0);
     assert(accept(fd, NULL, NULL) == -1);
     assert(errno == EINVAL);
     struct sockaddr_in peer_address;
     address_length = sizeof(peer_address);
     assert(getpeername(fd, (struct sockaddr *)&peer_address, &address_length) == 0);
-    assert(peer_address.sin_addr.s_addr == htonl(INADDR_LOOPBACK));
+    assert(peer_address.sin_addr.s_addr == address.sin_addr.s_addr);
     assert(peer_address.sin_port == address.sin_port);
     int option = 1;
     assert(setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &option,
@@ -351,6 +354,18 @@ int main(int argc, char **argv) {
     } else {
         assert(errno == ECONNREFUSED);
     }
+    assert(close(fd) == 0);
+
+    // The reserved port zero fails the socket without reaching the gateway,
+    // and the failure persists for a later authorized destination.
+    fd = socket(AF_INET, SOCK_STREAM | SOCK_CLOEXEC, 0);
+    assert(fd >= 0);
+    address.sin_port = 0;
+    assert(connect(fd, (const struct sockaddr *)&address, sizeof(address)) == -1);
+    assert(errno == ECONNREFUSED);
+    address.sin_port = htons((uint16_t)strtoul(argv[1], NULL, 10));
+    assert(connect(fd, (const struct sockaddr *)&address, sizeof(address)) == -1);
+    assert(errno == ECONNREFUSED);
     assert(close(fd) == 0);
 
     fd = socket(AF_INET, SOCK_STREAM | SOCK_CLOEXEC, 0);

--- a/litebox_runner_linux_userland/tests/udp_broker.c
+++ b/litebox_runner_linux_userland/tests/udp_broker.c
@@ -85,7 +85,10 @@ int main(int argc, char **argv) {
         .sin_family = AF_INET,
         .sin_port = htons((uint16_t)strtoul(argv[1], NULL, 10)),
     };
-    assert(inet_pton(AF_INET, "127.0.0.1", &server.sin_addr) == 1);
+    // Host services are reachable only through the guest-visible gateway.
+    assert(inet_pton(AF_INET, "10.0.2.1", &server.sin_addr) == 1);
+    struct in_addr guest_address;
+    assert(inet_pton(AF_INET, "10.0.2.15", &guest_address) == 1);
 
     const char unconnected[] = "unconnected";
     assert(sendto(fd, unconnected, sizeof(unconnected) - 1, 0,
@@ -117,7 +120,7 @@ int main(int argc, char **argv) {
     assert(recvmsg(fd, &message, 0) == sizeof(truncated));
     assert(memcmp(truncated, "0123", sizeof(truncated)) == 0);
     assert((message.msg_flags & MSG_TRUNC) != 0);
-    assert(source.sin_addr.s_addr == htonl(INADDR_LOOPBACK));
+    assert(source.sin_addr.s_addr == server.sin_addr.s_addr);
     assert(source.sin_port == server.sin_port);
     retract_readable(fd);
 
@@ -188,14 +191,14 @@ int main(int argc, char **argv) {
     assert(empty == 0xff);
     assert(address_length == sizeof(source));
     assert(source.sin_family == AF_INET);
-    assert(source.sin_addr.s_addr == htonl(INADDR_LOOPBACK));
+    assert(source.sin_addr.s_addr == server.sin_addr.s_addr);
     assert(source.sin_port == server.sin_port);
     retract_readable(fd);
 
     assert(connect(fd, (const struct sockaddr *)&server, sizeof(server)) == 0);
     address_length = sizeof(local);
     assert(getsockname(fd, (struct sockaddr *)&local, &address_length) == 0);
-    assert(local.sin_addr.s_addr == htonl(INADDR_LOOPBACK));
+    assert(local.sin_addr.s_addr == guest_address.s_addr);
     assert(local.sin_port != 0);
     address_length = sizeof(peer);
     assert(getpeername(fd, (struct sockaddr *)&peer, &address_length) == 0);
@@ -273,7 +276,7 @@ int main(int argc, char **argv) {
         .sin_family = AF_INET,
         .sin_port = htons((uint16_t)strtoul(argv[2], NULL, 10)),
     };
-    assert(inet_pton(AF_INET, "127.0.0.1", &refused.sin_addr) == 1);
+    assert(inet_pton(AF_INET, "10.0.2.1", &refused.sin_addr) == 1);
     assert(connect(refused_fd, (const struct sockaddr *)&refused,
                    sizeof(refused)) == 0);
 

--- a/litebox_shim_linux/src/syscalls/net.rs
+++ b/litebox_shim_linux/src/syscalls/net.rs
@@ -907,9 +907,6 @@ impl<Platform: ShimPlatform, FS: ShimFS> GlobalState<Platform, FS> {
         fd: &SocketFd<Platform>,
         sockaddr: SocketAddr,
     ) -> Result<(), Errno> {
-        if sockaddr.port() == 0 || sockaddr.ip().is_unspecified() {
-            return Err(Errno::ECONNREFUSED);
-        }
         let mut check_progress = false;
         cx.wait_on_events::<_, Errno>(
             self.get_status(fd).contains(OFlags::NONBLOCK),


### PR DESCRIPTION
## Summary

- add explicit broker-wide guest and gateway identity with typed guest, gateway, and external routing
- enforce guest-network, external destination, and protocol-specific gateway policy, translating authorized gateway traffic to host loopback
- route private guest TCP/UDP and runner traffic while retaining one native UDP endpoint for all destinations outside the sandbox

Custom address configuration and virtual TCP remain separate follow-up work.

## Testing

- `cargo fmt`
- targeted build and Clippy for changed packages
- targeted Nextest and runner integration suites (333 tests)
- `cargo test -p litebox_broker_userland --test userland_broker`