### PR TITLE
Add shared guest IPv4 identity

### DIFF
--- a/litebox_broker_core/src/lib.rs
+++ b/litebox_broker_core/src/lib.rs
@@ -35,8 +35,8 @@ use spin::rwlock::RwLock;
 
 pub use error::BrokerError;
 pub use policy::{
-    DestinationPolicy, DestinationPortRange, DestinationRule, Ipv4Cidr, MAX_DESTINATION_RULES,
-    PolicyEngine, PolicyProfile, SocketPolicy, SocketPolicyError,
+    DestinationPortRange, DestinationRule, Ipv4Cidr, MAX_DESTINATION_RULES, PolicyEngine,
+    PolicyProfile, SocketPolicy, SocketPolicyError,
 };
 use session::ObjectReference;
 pub use session::{BrokerSession, CallerCredential, ObjectRights, SessionId};

--- a/litebox_broker_core/src/policy.rs
+++ b/litebox_broker_core/src/policy.rs
@@ -3,6 +3,7 @@
 
 use core::net::SocketAddrV4;
 
+use crate::socket::is_guest_network_address;
 use crate::{BrokerError, CallerCredential, ObjectRights};
 use litebox_broker_protocol::socket::{
     AddressFamily, CreateSocketRequest, IpProtocol, Ipv4Address, Port, SocketType,
@@ -208,13 +209,13 @@ pub enum SocketPolicy {
     /// Deny all socket creation and connection attempts.
     #[default]
     Deny,
-    /// Allow IPv4 TCP and UDP sockets with destinations in the IPv4 loopback network.
-    Ipv4Loopback,
-    /// Apply bounded TCP destination rules.
+    /// Allow IPv4 TCP and UDP sockets within the shared guest network.
+    GuestNetwork,
+    /// Allow guest-network TCP plus bounded native TCP destination rules.
     TcpDestinationRules(DestinationPolicy),
-    /// Apply bounded UDP destination rules.
+    /// Allow guest-network UDP plus bounded native UDP destination rules.
     UdpDestinationRules(DestinationPolicy),
-    /// Apply independent bounded TCP and UDP destination rules.
+    /// Allow guest-network TCP and UDP plus independent native destination rules.
     TcpUdpDestinationRules {
         /// TCP destination policy.
         tcp: DestinationPolicy,
@@ -255,7 +256,7 @@ impl SocketPolicy {
         match self {
             Self::TcpDestinationRules(policy)
             | Self::TcpUdpDestinationRules { tcp: policy, .. } => Some(policy.rules()),
-            Self::Deny | Self::Ipv4Loopback | Self::UdpDestinationRules(_) => None,
+            Self::Deny | Self::GuestNetwork | Self::UdpDestinationRules(_) => None,
         }
     }
 
@@ -265,32 +266,16 @@ impl SocketPolicy {
         match self {
             Self::UdpDestinationRules(policy)
             | Self::TcpUdpDestinationRules { udp: policy, .. } => Some(policy.rules()),
-            Self::Deny | Self::Ipv4Loopback | Self::TcpDestinationRules(_) => None,
+            Self::Deny | Self::GuestNetwork | Self::TcpDestinationRules(_) => None,
         }
     }
 
-    fn permits_tcp_socket(self, caller_credential: CallerCredential) -> bool {
-        match self {
-            Self::Deny | Self::UdpDestinationRules(_) => false,
-            Self::Ipv4Loopback => true,
-            Self::TcpDestinationRules(policy)
-            | Self::TcpUdpDestinationRules { tcp: policy, .. } => policy
-                .rules()
-                .iter()
-                .any(|rule| rule.caller_credential == caller_credential),
-        }
+    fn permits_tcp_socket(self) -> bool {
+        !matches!(self, Self::Deny | Self::UdpDestinationRules(_))
     }
 
-    fn permits_udp_socket(self, caller_credential: CallerCredential) -> bool {
-        match self {
-            Self::Deny | Self::TcpDestinationRules(_) => false,
-            Self::Ipv4Loopback => true,
-            Self::UdpDestinationRules(policy)
-            | Self::TcpUdpDestinationRules { udp: policy, .. } => policy
-                .rules()
-                .iter()
-                .any(|rule| rule.caller_credential == caller_credential),
-        }
+    fn permits_udp_socket(self) -> bool {
+        !matches!(self, Self::Deny | Self::TcpDestinationRules(_))
     }
 
     fn permits_tcp_destination(
@@ -300,12 +285,15 @@ impl SocketPolicy {
     ) -> bool {
         match self {
             Self::Deny | Self::UdpDestinationRules(_) => false,
-            Self::Ipv4Loopback => address.ip().is_loopback(),
+            Self::GuestNetwork => is_guest_network_address(*address.ip()),
             Self::TcpDestinationRules(policy)
-            | Self::TcpUdpDestinationRules { tcp: policy, .. } => policy
-                .rules()
-                .iter()
-                .any(|rule| rule.permits(caller_credential, address)),
+            | Self::TcpUdpDestinationRules { tcp: policy, .. } => {
+                is_guest_network_address(*address.ip())
+                    || policy
+                        .rules()
+                        .iter()
+                        .any(|rule| rule.permits(caller_credential, address))
+            }
         }
     }
 
@@ -316,12 +304,15 @@ impl SocketPolicy {
     ) -> bool {
         match self {
             Self::Deny | Self::TcpDestinationRules(_) => false,
-            Self::Ipv4Loopback => address.ip().is_loopback(),
+            Self::GuestNetwork => is_guest_network_address(*address.ip()),
             Self::UdpDestinationRules(policy)
-            | Self::TcpUdpDestinationRules { udp: policy, .. } => policy
-                .rules()
-                .iter()
-                .any(|rule| rule.permits(caller_credential, address)),
+            | Self::TcpUdpDestinationRules { udp: policy, .. } => {
+                is_guest_network_address(*address.ip())
+                    || policy
+                        .rules()
+                        .iter()
+                        .any(|rule| rule.permits(caller_credential, address))
+            }
         }
     }
 }
@@ -421,12 +412,8 @@ impl PolicyEngine {
     ) -> Result<ObjectRights, BrokerError> {
         let rights = self.principal_object_rights(caller_credential)?;
         let permitted = match (request.socket_type, request.protocol) {
-            (SocketType::Stream, IpProtocol::Tcp) => {
-                self.socket_policy.permits_tcp_socket(caller_credential)
-            }
-            (SocketType::Datagram, IpProtocol::Udp) => {
-                self.socket_policy.permits_udp_socket(caller_credential)
-            }
+            (SocketType::Stream, IpProtocol::Tcp) => self.socket_policy.permits_tcp_socket(),
+            (SocketType::Datagram, IpProtocol::Udp) => self.socket_policy.permits_udp_socket(),
             _ => false,
         };
         if request.address_family == AddressFamily::Ipv4 && permitted {
@@ -647,6 +634,14 @@ mod tests {
             ),
             Ok(())
         );
+        assert_eq!(
+            unauthenticated.authorize_socket_connect(
+                CallerCredential::Unauthenticated,
+                IpProtocol::Tcp,
+                address([10, 0, 2, 15], 1),
+            ),
+            Ok(())
+        );
         for denied in [
             address([10, 16, 0, 1], 443),
             address([10, 15, 0, 1], 445),
@@ -665,14 +660,22 @@ mod tests {
     }
 
     #[test]
-    fn loopback_policy_allows_tcp_and_udp_only_within_loopback() {
+    fn guest_network_policy_allows_tcp_and_udp_only_within_the_guest_network() {
         let policy = PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback);
+            .with_socket_policy(SocketPolicy::GuestNetwork);
         assert_eq!(
             policy.authorize_socket_connect(
                 CallerCredential::Unauthenticated,
                 IpProtocol::Tcp,
                 address([127, 255, 0, 1], 80),
+            ),
+            Ok(())
+        );
+        assert_eq!(
+            policy.authorize_socket_connect(
+                CallerCredential::Unauthenticated,
+                IpProtocol::Tcp,
+                address([10, 0, 2, 15], 80),
             ),
             Ok(())
         );
@@ -704,6 +707,14 @@ mod tests {
             policy.authorize_socket_connect(
                 CallerCredential::Unauthenticated,
                 IpProtocol::Udp,
+                address([10, 0, 2, 15], 53),
+            ),
+            Ok(())
+        );
+        assert_eq!(
+            policy.authorize_socket_connect(
+                CallerCredential::Unauthenticated,
+                IpProtocol::Udp,
                 address([10, 0, 0, 1], 53),
             ),
             Err(BrokerError::PolicyDenied)
@@ -717,14 +728,9 @@ mod tests {
             cidr([192, 0, 2, 0], 24),
             ports(443, 443),
         );
-        let udp_rule = DestinationRule::new(
-            CallerCredential::Unauthenticated,
-            cidr([127, 0, 0, 0], 8),
-            ports(53, 53),
-        );
         let policy = PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
             .with_socket_policy(
-                SocketPolicy::from_tcp_udp_destination_rules(&[tcp_rule], &[udp_rule]).unwrap(),
+                SocketPolicy::from_tcp_udp_destination_rules(&[tcp_rule], &[]).unwrap(),
             );
 
         assert_eq!(
@@ -735,7 +741,7 @@ mod tests {
             policy.authorize_socket_connect(
                 CallerCredential::Unauthenticated,
                 IpProtocol::Udp,
-                address([127, 0, 0, 1], 53),
+                address([10, 0, 2, 15], 53),
             ),
             Ok(())
         );

--- a/litebox_broker_core/src/policy.rs
+++ b/litebox_broker_core/src/policy.rs
@@ -224,35 +224,22 @@ impl SocketPolicy {
         }
     }
 
-    /// Creates a bounded policy from static IPv4 TCP destination rules.
-    pub fn from_tcp_destination_rules(
+    /// Enables TCP with bounded native IPv4 destination rules.
+    pub fn with_tcp_destination_rules(
+        mut self,
         rules: &[DestinationRule],
     ) -> Result<Self, SocketPolicyError> {
-        Ok(Self {
-            tcp: Some(copy_destination_rules(rules)?),
-            udp: None,
-        })
+        self.tcp = Some(copy_destination_rules(rules)?);
+        Ok(self)
     }
 
-    /// Creates a bounded policy from static IPv4 UDP destination rules.
-    pub fn from_udp_destination_rules(
+    /// Enables UDP with bounded native IPv4 destination rules.
+    pub fn with_udp_destination_rules(
+        mut self,
         rules: &[DestinationRule],
     ) -> Result<Self, SocketPolicyError> {
-        Ok(Self {
-            tcp: None,
-            udp: Some(copy_destination_rules(rules)?),
-        })
-    }
-
-    /// Creates a policy with independent static IPv4 TCP and UDP rules.
-    pub fn from_tcp_udp_destination_rules(
-        tcp_rules: &[DestinationRule],
-        udp_rules: &[DestinationRule],
-    ) -> Result<Self, SocketPolicyError> {
-        Ok(Self {
-            tcp: Some(copy_destination_rules(tcp_rules)?),
-            udp: Some(copy_destination_rules(udp_rules)?),
-        })
+        self.udp = Some(copy_destination_rules(rules)?);
+        Ok(self)
     }
 
     /// Returns the native TCP destination rules, or `None` when TCP is denied.
@@ -554,14 +541,16 @@ mod tests {
         );
         let maximum = [rule; MAX_DESTINATION_RULES];
         assert_eq!(
-            SocketPolicy::from_tcp_destination_rules(&maximum)
+            SocketPolicy::deny()
+                .with_tcp_destination_rules(&maximum)
                 .unwrap()
                 .tcp_destination_rules()
                 .unwrap(),
             &maximum
         );
         assert_eq!(
-            SocketPolicy::from_tcp_destination_rules(&maximum)
+            SocketPolicy::deny()
+                .with_tcp_destination_rules(&maximum)
                 .unwrap()
                 .udp_destination_rules(),
             None
@@ -569,7 +558,7 @@ mod tests {
 
         let excessive = [rule; MAX_DESTINATION_RULES + 1];
         assert_eq!(
-            SocketPolicy::from_tcp_destination_rules(&excessive),
+            SocketPolicy::deny().with_tcp_destination_rules(&excessive),
             Err(SocketPolicyError::TooManyRules {
                 maximum: MAX_DESTINATION_RULES,
                 actual: MAX_DESTINATION_RULES + 1,
@@ -586,14 +575,16 @@ mod tests {
         );
         let maximum = [rule; MAX_DESTINATION_RULES];
         assert_eq!(
-            SocketPolicy::from_udp_destination_rules(&maximum)
+            SocketPolicy::deny()
+                .with_udp_destination_rules(&maximum)
                 .unwrap()
                 .udp_destination_rules()
                 .unwrap(),
             &maximum
         );
         assert_eq!(
-            SocketPolicy::from_udp_destination_rules(&maximum)
+            SocketPolicy::deny()
+                .with_udp_destination_rules(&maximum)
                 .unwrap()
                 .tcp_destination_rules(),
             None
@@ -601,7 +592,7 @@ mod tests {
 
         let excessive = [rule; MAX_DESTINATION_RULES + 1];
         assert_eq!(
-            SocketPolicy::from_udp_destination_rules(&excessive),
+            SocketPolicy::deny().with_udp_destination_rules(&excessive),
             Err(SocketPolicyError::TooManyRules {
                 maximum: MAX_DESTINATION_RULES,
                 actual: MAX_DESTINATION_RULES + 1,
@@ -611,19 +602,20 @@ mod tests {
 
     #[test]
     fn destination_rules_enforce_principal_cidr_and_port() {
-        let socket_policy = SocketPolicy::from_tcp_destination_rules(&[
-            DestinationRule::new(
-                CallerCredential::Unauthenticated,
-                cidr([10, 8, 0, 0], 13),
-                ports(443, 444),
-            ),
-            DestinationRule::new(
-                CallerCredential::HostGuaranteed,
-                cidr([192, 0, 2, 7], 32),
-                ports(8443, 8443),
-            ),
-        ])
-        .unwrap();
+        let socket_policy = SocketPolicy::deny()
+            .with_tcp_destination_rules(&[
+                DestinationRule::new(
+                    CallerCredential::Unauthenticated,
+                    cidr([10, 8, 0, 0], 13),
+                    ports(443, 444),
+                ),
+                DestinationRule::new(
+                    CallerCredential::HostGuaranteed,
+                    cidr([192, 0, 2, 7], 32),
+                    ports(8443, 8443),
+                ),
+            ])
+            .unwrap();
         let unauthenticated = PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
             .with_socket_policy(socket_policy);
         assert_eq!(
@@ -737,7 +729,9 @@ mod tests {
         );
         let policy = PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
             .with_socket_policy(
-                SocketPolicy::from_tcp_udp_destination_rules(&[tcp_rule], &[]).unwrap(),
+                SocketPolicy::guest_network()
+                    .with_tcp_destination_rules(&[tcp_rule])
+                    .unwrap(),
             );
 
         assert_eq!(

--- a/litebox_broker_core/src/policy.rs
+++ b/litebox_broker_core/src/policy.rs
@@ -175,7 +175,7 @@ pub enum SocketPolicyError {
 
 /// Bounded static IPv4 destination rules for one transport protocol.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct DestinationPolicy {
+struct DestinationPolicy {
     destination_rules: [DestinationRule; MAX_DESTINATION_RULES],
     destination_rule_count: usize,
 }
@@ -200,44 +200,48 @@ impl DestinationPolicy {
 /// Local bind authority is separate from egress destination rules and is
 /// enforced by the broker's guest binding namespace.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-#[non_exhaustive]
-#[expect(
-    clippy::large_enum_variant,
-    reason = "fixed-capacity policy storage avoids infallible allocation in no_std configuration"
-)]
-pub enum SocketPolicy {
-    /// Deny all socket creation and connection attempts.
-    #[default]
-    Deny,
-    /// Allow IPv4 TCP and UDP sockets within the shared guest network.
-    GuestNetwork,
-    /// Allow guest-network TCP plus bounded native TCP destination rules.
-    TcpDestinationRules(DestinationPolicy),
-    /// Allow guest-network UDP plus bounded native UDP destination rules.
-    UdpDestinationRules(DestinationPolicy),
-    /// Allow guest-network TCP and UDP plus independent native destination rules.
-    TcpUdpDestinationRules {
-        /// TCP destination policy.
-        tcp: DestinationPolicy,
-        /// UDP destination policy.
-        udp: DestinationPolicy,
-    },
+pub struct SocketPolicy {
+    tcp: Option<DestinationPolicy>,
+    udp: Option<DestinationPolicy>,
 }
 
 impl SocketPolicy {
+    /// Creates a policy that denies all socket creation and connection attempts.
+    #[must_use]
+    pub const fn deny() -> Self {
+        Self {
+            tcp: None,
+            udp: None,
+        }
+    }
+
+    /// Creates a policy allowing IPv4 TCP and UDP within the shared guest network.
+    #[must_use]
+    pub const fn guest_network() -> Self {
+        Self {
+            tcp: Some(DestinationPolicy::empty()),
+            udp: Some(DestinationPolicy::empty()),
+        }
+    }
+
     /// Creates a bounded policy from static IPv4 TCP destination rules.
     pub fn from_tcp_destination_rules(
         rules: &[DestinationRule],
     ) -> Result<Self, SocketPolicyError> {
-        Ok(Self::TcpDestinationRules(copy_destination_rules(rules)?))
+        Ok(Self {
+            tcp: Some(copy_destination_rules(rules)?),
+            udp: None,
+        })
     }
 
     /// Creates a bounded policy from static IPv4 UDP destination rules.
     pub fn from_udp_destination_rules(
         rules: &[DestinationRule],
     ) -> Result<Self, SocketPolicyError> {
-        let policy = copy_destination_rules(rules)?;
-        Ok(Self::UdpDestinationRules(policy))
+        Ok(Self {
+            tcp: None,
+            udp: Some(copy_destination_rules(rules)?),
+        })
     }
 
     /// Creates a policy with independent static IPv4 TCP and UDP rules.
@@ -245,37 +249,30 @@ impl SocketPolicy {
         tcp_rules: &[DestinationRule],
         udp_rules: &[DestinationRule],
     ) -> Result<Self, SocketPolicyError> {
-        let tcp = copy_destination_rules(tcp_rules)?;
-        let udp = copy_destination_rules(udp_rules)?;
-        Ok(Self::TcpUdpDestinationRules { tcp, udp })
+        Ok(Self {
+            tcp: Some(copy_destination_rules(tcp_rules)?),
+            udp: Some(copy_destination_rules(udp_rules)?),
+        })
     }
 
-    /// Returns the configured rules for a bounded destination policy.
+    /// Returns the native TCP destination rules, or `None` when TCP is denied.
     #[must_use]
     pub fn tcp_destination_rules(&self) -> Option<&[DestinationRule]> {
-        match self {
-            Self::TcpDestinationRules(policy)
-            | Self::TcpUdpDestinationRules { tcp: policy, .. } => Some(policy.rules()),
-            Self::Deny | Self::GuestNetwork | Self::UdpDestinationRules(_) => None,
-        }
+        self.tcp.as_ref().map(DestinationPolicy::rules)
     }
 
-    /// Returns the configured UDP rules for a bounded destination policy.
+    /// Returns the native UDP destination rules, or `None` when UDP is denied.
     #[must_use]
     pub fn udp_destination_rules(&self) -> Option<&[DestinationRule]> {
-        match self {
-            Self::UdpDestinationRules(policy)
-            | Self::TcpUdpDestinationRules { udp: policy, .. } => Some(policy.rules()),
-            Self::Deny | Self::GuestNetwork | Self::TcpDestinationRules(_) => None,
-        }
+        self.udp.as_ref().map(DestinationPolicy::rules)
     }
 
-    fn permits_tcp_socket(self) -> bool {
-        !matches!(self, Self::Deny | Self::UdpDestinationRules(_))
+    const fn permits_tcp_socket(self) -> bool {
+        self.tcp.is_some()
     }
 
-    fn permits_udp_socket(self) -> bool {
-        !matches!(self, Self::Deny | Self::TcpDestinationRules(_))
+    const fn permits_udp_socket(self) -> bool {
+        self.udp.is_some()
     }
 
     fn permits_tcp_destination(
@@ -283,18 +280,13 @@ impl SocketPolicy {
         caller_credential: CallerCredential,
         address: SocketAddrV4,
     ) -> bool {
-        match self {
-            Self::Deny | Self::UdpDestinationRules(_) => false,
-            Self::GuestNetwork => is_guest_network_address(*address.ip()),
-            Self::TcpDestinationRules(policy)
-            | Self::TcpUdpDestinationRules { tcp: policy, .. } => {
-                is_guest_network_address(*address.ip())
-                    || policy
-                        .rules()
-                        .iter()
-                        .any(|rule| rule.permits(caller_credential, address))
-            }
-        }
+        self.tcp.is_some_and(|policy| {
+            is_guest_network_address(*address.ip())
+                || policy
+                    .rules()
+                    .iter()
+                    .any(|rule| rule.permits(caller_credential, address))
+        })
     }
 
     fn permits_udp_destination(
@@ -302,18 +294,13 @@ impl SocketPolicy {
         caller_credential: CallerCredential,
         address: SocketAddrV4,
     ) -> bool {
-        match self {
-            Self::Deny | Self::TcpDestinationRules(_) => false,
-            Self::GuestNetwork => is_guest_network_address(*address.ip()),
-            Self::UdpDestinationRules(policy)
-            | Self::TcpUdpDestinationRules { udp: policy, .. } => {
-                is_guest_network_address(*address.ip())
-                    || policy
-                        .rules()
-                        .iter()
-                        .any(|rule| rule.permits(caller_credential, address))
-            }
-        }
+        self.udp.is_some_and(|policy| {
+            is_guest_network_address(*address.ip())
+                || policy
+                    .rules()
+                    .iter()
+                    .any(|rule| rule.permits(caller_credential, address))
+        })
     }
 }
 
@@ -362,7 +349,7 @@ impl PolicyEngine {
     pub const fn new(profile: PolicyProfile) -> Self {
         Self {
             profile,
-            socket_policy: SocketPolicy::Deny,
+            socket_policy: SocketPolicy::deny(),
         }
     }
 
@@ -516,6 +503,11 @@ mod tests {
 
     #[test]
     fn socket_policy_defaults_to_deny() {
+        let socket_policy = SocketPolicy::default();
+        assert_eq!(socket_policy, SocketPolicy::deny());
+        assert_eq!(socket_policy.tcp_destination_rules(), None);
+        assert_eq!(socket_policy.udp_destination_rules(), None);
+
         let policy = PolicyEngine::with_unauthenticated_rights(ObjectRights::all());
         assert_eq!(
             policy.authorize_socket_create(CallerCredential::Unauthenticated, IPV4_TCP),
@@ -568,6 +560,12 @@ mod tests {
                 .unwrap(),
             &maximum
         );
+        assert_eq!(
+            SocketPolicy::from_tcp_destination_rules(&maximum)
+                .unwrap()
+                .udp_destination_rules(),
+            None
+        );
 
         let excessive = [rule; MAX_DESTINATION_RULES + 1];
         assert_eq!(
@@ -593,6 +591,12 @@ mod tests {
                 .udp_destination_rules()
                 .unwrap(),
             &maximum
+        );
+        assert_eq!(
+            SocketPolicy::from_udp_destination_rules(&maximum)
+                .unwrap()
+                .tcp_destination_rules(),
+            None
         );
 
         let excessive = [rule; MAX_DESTINATION_RULES + 1];
@@ -661,8 +665,11 @@ mod tests {
 
     #[test]
     fn guest_network_policy_allows_tcp_and_udp_only_within_the_guest_network() {
+        let socket_policy = SocketPolicy::guest_network();
+        assert_eq!(socket_policy.tcp_destination_rules(), Some([].as_slice()));
+        assert_eq!(socket_policy.udp_destination_rules(), Some([].as_slice()));
         let policy = PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::GuestNetwork);
+            .with_socket_policy(socket_policy);
         assert_eq!(
             policy.authorize_socket_connect(
                 CallerCredential::Unauthenticated,

--- a/litebox_broker_core/src/session.rs
+++ b/litebox_broker_core/src/session.rs
@@ -541,7 +541,7 @@ mod tests {
         let socket_provider = Arc::new(crate::socket::tests::TestSocketProvider::default());
         let broker = BrokerCore::new_with_limits(
             PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-                .with_socket_policy(SocketPolicy::Ipv4Loopback),
+                .with_socket_policy(SocketPolicy::GuestNetwork),
             BrokerCoreLimits::new_with_all_limits(2, 4, 2, 1),
             socket_provider.clone(),
         )

--- a/litebox_broker_core/src/session.rs
+++ b/litebox_broker_core/src/session.rs
@@ -541,7 +541,7 @@ mod tests {
         let socket_provider = Arc::new(crate::socket::tests::TestSocketProvider::default());
         let broker = BrokerCore::new_with_limits(
             PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-                .with_socket_policy(SocketPolicy::GuestNetwork),
+                .with_socket_policy(SocketPolicy::guest_network()),
             BrokerCoreLimits::new_with_all_limits(2, 4, 2, 1),
             socket_provider.clone(),
         )

--- a/litebox_broker_core/src/socket.rs
+++ b/litebox_broker_core/src/socket.rs
@@ -653,7 +653,7 @@ pub fn connect(
     };
     if needs_bind {
         let default_local_address = if *address.ip() == GUEST_IPV4_ADDRESS {
-            SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0)
+            SocketAddrV4::new(GUEST_IPV4_ADDRESS, 0)
         } else {
             DEFAULT_TCP_LOCAL_ADDRESS
         };
@@ -2484,6 +2484,7 @@ pub(crate) mod tests {
     pub(crate) fn check_socket_lifecycle(broker: &BrokerCore, provider: &TestSocketProvider) {
         check_failed_create_rolls_back(broker, provider);
         check_socket_operations_and_policy(broker, provider);
+        check_private_tcp_connect_uses_exact_implicit_binding(broker, provider);
         check_tcp_option_state_is_per_socket(broker);
         check_udp_socket_operations(broker, provider);
         check_udp_status_validates_local_address(broker, provider);
@@ -2902,6 +2903,37 @@ pub(crate) mod tests {
         );
 
         assert_eq!(session.close_object_reference(second), Ok(()));
+    }
+
+    fn check_private_tcp_connect_uses_exact_implicit_binding(
+        broker: &BrokerCore,
+        provider: &TestSocketProvider,
+    ) {
+        let session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let handle = create(
+            &session,
+            create_request(),
+            Arc::new(TestReadinessSink::default()),
+        )
+        .unwrap();
+        assert!(matches!(
+            connect(&session, handle, SocketAddrV4::new(GUEST_IPV4_ADDRESS, 80),),
+            Ok(SocketOutcome::Completed(
+                SocketConnectionStatus::Connecting | SocketConnectionStatus::Connected
+            ))
+        ));
+        let bound_address = *provider
+            .state
+            .binds
+            .lock()
+            .unwrap()
+            .last()
+            .expect("automatic private TCP bind was not recorded");
+        assert_eq!(*bound_address.ip(), GUEST_IPV4_ADDRESS);
+        assert_ne!(bound_address.port(), 0);
+        session.close_object_reference(handle).unwrap();
     }
 
     fn check_udp_socket_operations(broker: &BrokerCore, provider: &TestSocketProvider) {

--- a/litebox_broker_core/src/socket.rs
+++ b/litebox_broker_core/src/socket.rs
@@ -29,6 +29,13 @@ const DEFAULT_TCP_LOCAL_ADDRESS: SocketAddrV4 = SocketAddrV4::new(Ipv4Addr::LOCA
 const DEFAULT_UDP_LOCAL_ADDRESS: SocketAddrV4 = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0);
 const FIRST_EPHEMERAL_PORT: u16 = 49152;
 
+/// Fixed broker-wide private IPv4 identity of the shared guest network.
+pub const GUEST_IPV4_ADDRESS: Ipv4Addr = Ipv4Addr::new(10, 0, 2, 15);
+
+pub(crate) fn is_guest_network_address(address: Ipv4Addr) -> bool {
+    address.is_loopback() || address == GUEST_IPV4_ADDRESS
+}
+
 /// Platform-observed socket state returned to the broker for reconciliation.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PlatformSocketStatus {
@@ -137,8 +144,7 @@ struct GuestBindingReservation {
 
 impl GuestBindingReservation {
     fn covers(&self, address: SocketAddrV4) -> bool {
-        // TODO: Allow the configured guest private address once shared guest identity is added.
-        if address.port() == 0 || !address.ip().is_loopback() {
+        if address.port() == 0 || !is_guest_network_address(*address.ip()) {
             return false;
         }
         match self.key {
@@ -210,7 +216,7 @@ impl BrokerSocketPorts {
 }
 
 fn guest_binding_address_is_valid(address: SocketAddrV4) -> bool {
-    address.ip().is_unspecified() || address.ip().is_loopback()
+    address.ip().is_unspecified() || is_guest_network_address(*address.ip())
 }
 
 impl Drop for GuestBindingReservation {
@@ -264,17 +270,38 @@ impl GuestSocketBinding {
         self.transport == GuestTransport::Tcp
     }
 
-    /// Returns whether this binding covers one concrete guest loopback address.
+    /// Returns whether this binding covers one concrete guest-network address.
     #[must_use]
     pub fn covers(&self, address: SocketAddrV4) -> bool {
         self.is_valid()
             && address.port() != 0
-            && address.ip().is_loopback()
+            && is_guest_network_address(*address.ip())
             && if self.is_wildcard() {
                 address.port() == self.requested.port()
             } else {
                 address == self.requested
             }
+    }
+
+    /// Selects this binding's guest-visible source for a guest destination.
+    #[must_use]
+    pub fn guest_source_address(&self, destination: SocketAddrV4) -> Option<SocketAddrV4> {
+        if !self.is_valid()
+            || destination.port() == 0
+            || !is_guest_network_address(*destination.ip())
+        {
+            return None;
+        }
+        if self.is_wildcard() {
+            let source_ip = if *destination.ip() == GUEST_IPV4_ADDRESS {
+                GUEST_IPV4_ADDRESS
+            } else {
+                Ipv4Addr::LOCALHOST
+            };
+            Some(SocketAddrV4::new(source_ip, self.requested.port()))
+        } else {
+            Some(self.requested)
+        }
     }
 }
 
@@ -625,18 +652,19 @@ pub fn connect(
         (Arc::clone(&socket.resource), socket.local_address.is_none())
     };
     if needs_bind {
-        let binding = match reserve_and_bind(
-            session,
-            create_request,
-            &resource,
-            DEFAULT_TCP_LOCAL_ADDRESS,
-        ) {
-            Ok(binding) => binding,
-            Err(error) => {
-                finish_connect(&object, SocketConnectionStatus::Unconnected);
-                return Err(error);
-            }
+        let default_local_address = if *address.ip() == GUEST_IPV4_ADDRESS {
+            SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0)
+        } else {
+            DEFAULT_TCP_LOCAL_ADDRESS
         };
+        let binding =
+            match reserve_and_bind(session, create_request, &resource, default_local_address) {
+                Ok(binding) => binding,
+                Err(error) => {
+                    finish_connect(&object, SocketConnectionStatus::Unconnected);
+                    return Err(error);
+                }
+            };
         match binding {
             ReserveAndBindOutcome::Completed(local_address, reservation) => {
                 attach_binding(&object, local_address, reservation)?;
@@ -1244,7 +1272,9 @@ fn stream_status(object: &spin::RwLock<ObjectEntry>) -> Result<SocketStatusRespo
     if let Some(observed) = platform_status.local_address {
         match socket.local_address {
             Some(broker_address) if broker_address.ip().is_unspecified() => {
-                if observed.port() != broker_address.port() || !observed.ip().is_loopback() {
+                if observed.port() != broker_address.port()
+                    || !is_guest_network_address(*observed.ip())
+                {
                     socket.listening = false;
                     socket.connection_status = SocketConnectionStatus::Failed(SocketError::Other);
                     socket.resource_retired = true;
@@ -1984,6 +2014,7 @@ pub(crate) mod tests {
     use crate::readiness::tests::TestReadinessSink;
     use crate::{BrokerCore, CallerCredential};
     use litebox_broker_protocol::socket::{AddressFamily, IpProtocol, SocketType};
+    use std::net::Ipv4Addr;
     use std::sync::{Mutex as StdMutex, mpsc};
     use std::time::Duration;
     use std::vec;
@@ -2029,10 +2060,11 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn guest_binding_namespaces_support_exact_and_wildcard_loopback() {
+    fn guest_binding_namespaces_support_exact_and_wildcard_guest_addresses() {
         let ports = BrokerSocketPorts::default();
         let first = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8080);
         let second = SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 2), 8080);
+        let private = SocketAddrV4::new(GUEST_IPV4_ADDRESS, 8080);
         let wildcard = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 8080);
 
         let SocketOutcome::Completed((_, first_lease)) =
@@ -2045,6 +2077,11 @@ pub(crate) mod tests {
         else {
             panic!("second exact reservation failed");
         };
+        let SocketOutcome::Completed((_, private_lease)) =
+            ports.reserve(create_request(), private).unwrap()
+        else {
+            panic!("private exact reservation failed");
+        };
         assert!(matches!(
             ports.reserve(create_request(), wildcard),
             Ok(SocketOutcome::Failed(SocketError::AddressInUse))
@@ -2052,6 +2089,7 @@ pub(crate) mod tests {
 
         drop(first_lease);
         drop(second_lease);
+        drop(private_lease);
         let SocketOutcome::Completed((_, wildcard_lease)) =
             ports.reserve(create_request(), wildcard).unwrap()
         else {
@@ -2061,8 +2099,19 @@ pub(crate) mod tests {
             ports.reserve(create_request(), first),
             Ok(SocketOutcome::Failed(SocketError::AddressInUse))
         ));
+        assert!(matches!(
+            ports.reserve(create_request(), private),
+            Ok(SocketOutcome::Failed(SocketError::AddressInUse))
+        ));
         assert!(wildcard_lease.covers(first));
         assert!(wildcard_lease.covers(second));
+        assert!(wildcard_lease.covers(private));
+        let binding = GuestSocketBinding::new(&wildcard_lease);
+        assert_eq!(
+            binding.guest_source_address(first),
+            Some(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8080))
+        );
+        assert_eq!(binding.guest_source_address(private), Some(private));
     }
 
     #[test]

--- a/litebox_broker_core/src/socket.rs
+++ b/litebox_broker_core/src/socket.rs
@@ -25,7 +25,6 @@ use crate::session::{ObjectEntry, ObjectRights};
 use crate::{BrokerError, BrokerSession, Result, SessionId};
 
 const DEFAULT_TCP_LISTEN_ADDRESS: SocketAddrV4 = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0);
-const DEFAULT_TCP_LOCAL_ADDRESS: SocketAddrV4 = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0);
 const DEFAULT_UDP_LOCAL_ADDRESS: SocketAddrV4 = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0);
 const FIRST_EPHEMERAL_PORT: u16 = 49152;
 
@@ -652,11 +651,12 @@ pub fn connect(
         (Arc::clone(&socket.resource), socket.local_address.is_none())
     };
     if needs_bind {
-        let default_local_address = if *address.ip() == GUEST_IPV4_ADDRESS {
-            SocketAddrV4::new(GUEST_IPV4_ADDRESS, 0)
+        let local_ip = if *address.ip() == GUEST_IPV4_ADDRESS {
+            GUEST_IPV4_ADDRESS
         } else {
-            DEFAULT_TCP_LOCAL_ADDRESS
+            Ipv4Addr::LOCALHOST
         };
+        let default_local_address = SocketAddrV4::new(local_ip, 0);
         let binding =
             match reserve_and_bind(session, create_request, &resource, default_local_address) {
                 Ok(binding) => binding,

--- a/litebox_broker_core/src/socket.rs
+++ b/litebox_broker_core/src/socket.rs
@@ -142,6 +142,10 @@ struct GuestBindingReservation {
 }
 
 impl GuestBindingReservation {
+    fn is_wildcard(&self) -> bool {
+        matches!(self.key, GuestBindingKey::Wildcard(_))
+    }
+
     fn covers(&self, address: SocketAddrV4) -> bool {
         if address.port() == 0 || !is_guest_network_address(*address.ip()) {
             return false;
@@ -1314,6 +1318,7 @@ fn datagram_status(object: &spin::RwLock<ObjectEntry>) -> Result<SocketStatusRes
         configuration_in_flight,
         datagram_connect_generation,
         resource_retired,
+        wildcard_binding,
     ) = {
         let object = object.read();
         let ObjectEntry::Socket(socket) = &*object else {
@@ -1326,6 +1331,7 @@ fn datagram_status(object: &spin::RwLock<ObjectEntry>) -> Result<SocketStatusRes
             socket.configuration_in_flight,
             socket.datagram_connect_generation,
             socket.resource_retired,
+            socket.resource.port_reservation_is_wildcard(),
         )
     };
     if configuration_in_flight || resource_retired {
@@ -1394,7 +1400,9 @@ fn datagram_status(object: &spin::RwLock<ObjectEntry>) -> Result<SocketStatusRes
             return Err(BrokerError::Internal);
         }
         let local_address_refinement = match (socket.local_address, platform_status.local_address) {
-            (Some(broker_address), Some(observed)) if broker_address.ip().is_unspecified() => {
+            (Some(broker_address), Some(observed))
+                if wildcard_binding || broker_address.ip().is_unspecified() =>
+            {
                 Some(observed)
             }
             _ => None,
@@ -1839,6 +1847,13 @@ impl SocketResource {
             .lock()
             .as_ref()
             .is_some_and(|reservation| reservation.covers(address))
+    }
+
+    fn port_reservation_is_wildcard(&self) -> bool {
+        self.port_reservation
+            .lock()
+            .as_ref()
+            .is_some_and(GuestBindingReservation::is_wildcard)
     }
 
     fn platform_socket(&self) -> &dyn PlatformSocket {

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -912,7 +912,7 @@ mod tests {
     fn host_request_handling_uses_one_broker_core() {
         let broker = BrokerCore::new(
             PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-                .with_socket_policy(SocketPolicy::Ipv4Loopback),
+                .with_socket_policy(SocketPolicy::GuestNetwork),
             Arc::new(TestSocketProvider),
         )
         .unwrap();

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -912,7 +912,7 @@ mod tests {
     fn host_request_handling_uses_one_broker_core() {
         let broker = BrokerCore::new(
             PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-                .with_socket_policy(SocketPolicy::GuestNetwork),
+                .with_socket_policy(SocketPolicy::guest_network()),
             Arc::new(TestSocketProvider),
         )
         .unwrap();

--- a/litebox_broker_platform_linux_userland/src/socket.rs
+++ b/litebox_broker_platform_linux_userland/src/socket.rs
@@ -6,7 +6,7 @@
 use std::collections::HashMap;
 use std::fmt;
 use std::io::{Error, ErrorKind, Result as IoResult};
-use std::net::{Ipv4Addr, SocketAddrV4};
+use std::net::SocketAddrV4;
 use std::os::fd::OwnedFd;
 use std::sync::atomic::{AtomicU8, AtomicU64, Ordering};
 use std::sync::mpsc::{Receiver, SyncSender, TryRecvError, sync_channel};
@@ -1100,18 +1100,11 @@ impl Reactor {
             if already_bound {
                 return Ok(SocketOutcome::Failed(SocketError::InvalidArgument));
             }
-            let internal_address = if binding.is_wildcard() {
-                SocketAddrV4::new(Ipv4Addr::LOCALHOST, requested_address.port())
-            } else {
-                requested_address
-            };
             self.udp.insert_binding(ReactorUdpBinding {
                 socket_id: id,
                 guest_binding: binding,
             })?;
             let socket = self.sockets.get_mut(&id).ok_or(BrokerError::Internal)?;
-            let udp = socket.udp_state_mut()?;
-            udp.internal_address = Some(internal_address);
             socket.guest_local_address = Some(requested_address);
             socket
                 .snapshot
@@ -1189,7 +1182,12 @@ impl Reactor {
                     .ok_or(BrokerError::Internal)?;
                 if binding.guest_binding.is_wildcard() {
                     let ip = match (&peer, &staged_endpoint, reused_host_address) {
-                        (ReactorUdpPeer::Guest { .. }, _, _) => Ipv4Addr::LOCALHOST,
+                        (ReactorUdpPeer::Guest { guest_address, .. }, _, _) => {
+                            return binding
+                                .guest_binding
+                                .guest_source_address(*guest_address)
+                                .ok_or(BrokerError::Internal);
+                        }
                         (ReactorUdpPeer::External(_), Some(endpoint), _) => {
                             *endpoint.host_address.ip()
                         }
@@ -1275,6 +1273,11 @@ impl Reactor {
                 socket_generation,
                 guest_address,
             } => {
+                let source_address = self
+                    .udp
+                    .binding_for_socket(id)
+                    .and_then(|binding| binding.guest_binding.guest_source_address(guest_address))
+                    .ok_or(BrokerError::Internal)?;
                 if self
                     .udp
                     .binding_for_socket(socket_generation)
@@ -1282,7 +1285,7 @@ impl Reactor {
                 {
                     return Ok(SocketOutcome::Failed(SocketError::ConnectionRefused));
                 }
-                self.enqueue_guest_datagram(id, socket_generation, data)
+                self.enqueue_guest_datagram(id, socket_generation, source_address, data)
             }
             ReactorUdpPeer::External(address) => {
                 let external_peer_added = if authorize_external_reply {

--- a/litebox_broker_platform_linux_userland/src/socket/tcp.rs
+++ b/litebox_broker_platform_linux_userland/src/socket/tcp.rs
@@ -10,7 +10,7 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use litebox_broker_core::readiness::ReadinessRegistration;
-use litebox_broker_core::socket::{GuestSocketBinding, PlatformConnectError};
+use litebox_broker_core::socket::{GUEST_IPV4_ADDRESS, GuestSocketBinding, PlatformConnectError};
 use litebox_broker_core::{BrokerError, Result as BrokerResult, SessionId};
 use litebox_broker_protocol::readiness::ReadinessFlags;
 use litebox_broker_protocol::socket::{
@@ -337,13 +337,11 @@ impl ReactorTcpState {
     }
 
     pub(super) fn guest_binding(&self, address: SocketAddrV4) -> Option<ReactorTcpBinding> {
-        if !address.ip().is_loopback() {
-            return None;
-        }
         self.bindings
             .exact
             .get(&address)
             .or_else(|| self.bindings.wildcard.get(&address.port()))
+            .filter(|binding| binding.guest_binding.covers(address))
             .cloned()
     }
 
@@ -1339,22 +1337,15 @@ impl Reactor {
                     .map(|address| (socket.session_id, address))
             })
             .ok_or(PlatformConnectError::PeerUnchanged(BrokerError::Internal))?;
-        let local_guest_address = if self
-            .tcp
-            .binding_for_socket(id)
-            .ok_or(PlatformConnectError::PeerUnchanged(BrokerError::Internal))?
-            .guest_binding
-            .is_wildcard()
-        {
-            SocketAddrV4::new(Ipv4Addr::LOCALHOST, reserved_local_address.port())
-        } else {
-            reserved_local_address
-        };
         let concrete_guest_destination = if guest_address.ip().is_unspecified() {
             SocketAddrV4::new(Ipv4Addr::LOCALHOST, guest_address.port())
         } else {
             guest_address
         };
+        let binding = self
+            .tcp
+            .binding_for_socket(id)
+            .ok_or(PlatformConnectError::PeerUnchanged(BrokerError::Internal))?;
         let (network_address, guest_listener_id) =
             match self.resolve_guest_destination(guest_address) {
                 SocketOutcome::Completed(destination) => destination,
@@ -1370,6 +1361,16 @@ impl Reactor {
                     return Ok(status);
                 }
             };
+        let local_guest_address = if guest_listener_id.is_some() {
+            binding
+                .guest_binding
+                .guest_source_address(concrete_guest_destination)
+                .ok_or(PlatformConnectError::PeerUnchanged(BrokerError::Internal))?
+        } else if binding.guest_binding.is_wildcard() {
+            SocketAddrV4::new(Ipv4Addr::LOCALHOST, reserved_local_address.port())
+        } else {
+            reserved_local_address
+        };
         if guest_listener_id.is_some() {
             self.expire_deadlined_state(Instant::now());
             self.reserve_pending_guest_connection(session_id)
@@ -1955,7 +1956,9 @@ impl Reactor {
                 None => SocketOutcome::Failed(SocketError::ConnectionRefused),
             };
         }
-        if address.ip().is_loopback() && self.tcp.has_binding_on_port(address.port()) {
+        if *address.ip() == GUEST_IPV4_ADDRESS
+            || (address.ip().is_loopback() && self.tcp.has_binding_on_port(address.port()))
+        {
             return SocketOutcome::Failed(SocketError::ConnectionRefused);
         }
         if self.is_private_tcp_host_endpoint(address) {

--- a/litebox_broker_platform_linux_userland/src/socket/tcp.rs
+++ b/litebox_broker_platform_linux_userland/src/socket/tcp.rs
@@ -1956,6 +1956,8 @@ impl Reactor {
                 None => SocketOutcome::Failed(SocketError::ConnectionRefused),
             };
         }
+        // TODO: Once gateway routing replaces host-loopback fallback, fail all
+        // unmatched guest-network destinations closed.
         if *address.ip() == GUEST_IPV4_ADDRESS
             || (address.ip().is_loopback() && self.tcp.has_binding_on_port(address.port()))
         {

--- a/litebox_broker_platform_linux_userland/src/socket/tests/mod.rs
+++ b/litebox_broker_platform_linux_userland/src/socket/tests/mod.rs
@@ -304,7 +304,7 @@ fn directional_shutdown_survives_readiness_publication_failure() {
     let provider = Arc::new(LinuxSocketProvider::new(2, 2).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::GuestNetwork),
+            .with_socket_policy(SocketPolicy::guest_network()),
         BrokerCoreLimits::new_with_all_limits(4, 0, 2, 2),
         provider,
     )

--- a/litebox_broker_platform_linux_userland/src/socket/tests/mod.rs
+++ b/litebox_broker_platform_linux_userland/src/socket/tests/mod.rs
@@ -9,6 +9,7 @@ use std::time::{Duration, Instant};
 
 use super::*;
 use litebox_broker_core::readiness::ReadinessSink;
+use litebox_broker_core::socket::GUEST_IPV4_ADDRESS;
 use litebox_broker_core::{
     BrokerCore, BrokerCoreLimits, BrokerSession, CallerCredential, DestinationPortRange,
     DestinationRule, Ipv4Cidr, ObjectRights, PolicyEngine, SocketPolicy,
@@ -303,7 +304,7 @@ fn directional_shutdown_survives_readiness_publication_failure() {
     let provider = Arc::new(LinuxSocketProvider::new(2, 2).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+            .with_socket_policy(SocketPolicy::GuestNetwork),
         BrokerCoreLimits::new_with_all_limits(4, 0, 2, 2),
         provider,
     )

--- a/litebox_broker_platform_linux_userland/src/socket/tests/tcp.rs
+++ b/litebox_broker_platform_linux_userland/src/socket/tests/tcp.rs
@@ -119,7 +119,7 @@ fn untracked_guest_connection_cleanup_is_bounded_and_drains_backlog() {
     let provider = Arc::new(LinuxSocketProvider::new(6, 3).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+            .with_socket_policy(SocketPolicy::GuestNetwork),
         BrokerCoreLimits::new_with_all_limits(12, 0, 6, 6),
         provider.clone(),
     )
@@ -271,7 +271,7 @@ fn reactor_drives_a_loopback_tcp_socket() {
     let provider = Arc::new(LinuxSocketProvider::new(8, 8).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+            .with_socket_policy(SocketPolicy::GuestNetwork),
         BrokerCoreLimits::new_with_all_limits(16, 0, 8, 8),
         provider,
     )
@@ -604,7 +604,7 @@ fn tcp_receive_survives_readiness_publication_failure() {
     let provider = Arc::new(LinuxSocketProvider::new(1, 1).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+            .with_socket_policy(SocketPolicy::GuestNetwork),
         BrokerCoreLimits::new_with_all_limits(2, 0, 1, 1),
         provider,
     )
@@ -662,7 +662,7 @@ fn tcp_status_publication_failure_preserves_consumed_error() {
     let provider = Arc::new(LinuxSocketProvider::new(1, 1).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+            .with_socket_policy(SocketPolicy::GuestNetwork),
         BrokerCoreLimits::new_with_all_limits(2, 0, 1, 1),
         provider,
     )
@@ -722,7 +722,7 @@ fn exhausted_tcp_peek_cache_refreshes_before_terminal_eof() {
     let provider = Arc::new(LinuxSocketProvider::new(1, 1).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+            .with_socket_policy(SocketPolicy::GuestNetwork),
         BrokerCoreLimits::new_with_all_limits(2, 0, 1, 1),
         provider,
     )
@@ -791,7 +791,7 @@ fn accepted_guest_tcp_close_with_unread_data_preserves_reset() {
     let provider = Arc::new(LinuxSocketProvider::new(3, 2).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+            .with_socket_policy(SocketPolicy::GuestNetwork),
         BrokerCoreLimits::new_with_all_limits(6, 0, 3, 3),
         provider,
     )
@@ -874,7 +874,7 @@ fn guest_tcp_namespace_routes_across_sessions_and_hides_private_backend() {
     let provider = Arc::new(LinuxSocketProvider::new(5, 3).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+            .with_socket_policy(SocketPolicy::GuestNetwork),
         BrokerCoreLimits::new_with_all_limits(8, 0, 5, 4),
         provider.clone(),
     )
@@ -891,7 +891,7 @@ fn guest_tcp_namespace_routes_across_sessions_and_hides_private_backend() {
     let shadowed_host_listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
     shadowed_host_listener.set_nonblocking(true).unwrap();
     let guest_port = shadowed_host_listener.local_addr().unwrap().port();
-    let guest_address = SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 2), guest_port);
+    let guest_address = SocketAddrV4::new(GUEST_IPV4_ADDRESS, guest_port);
     let claimed_port_miss = SocketAddrV4::new(Ipv4Addr::LOCALHOST, guest_port);
     let guest_destination = guest_address;
     let listener = create_socket(&listener_session, readiness.clone());
@@ -916,6 +916,29 @@ fn guest_tcp_namespace_routes_across_sessions_and_hides_private_backend() {
     assert_eq!(
         retirements.recv_timeout(TEST_TIMEOUT).unwrap(),
         early_client
+    );
+    let unbound_private_port = if guest_port == u16::MAX {
+        guest_port - 1
+    } else {
+        guest_port + 1
+    };
+    let unbound_private_client = create_socket(&client_session, readiness.clone());
+    assert_eq!(
+        litebox_broker_core::socket::connect(
+            &client_session,
+            unbound_private_client,
+            SocketAddrV4::new(GUEST_IPV4_ADDRESS, unbound_private_port),
+        ),
+        Ok(SocketOutcome::Completed(SocketConnectionStatus::Failed(
+            SocketError::ConnectionRefused,
+        )))
+    );
+    client_session
+        .close_object_reference(unbound_private_client)
+        .unwrap();
+    assert_eq!(
+        retirements.recv_timeout(TEST_TIMEOUT).unwrap(),
+        unbound_private_client
     );
 
     assert_eq!(
@@ -958,6 +981,7 @@ fn guest_tcp_namespace_routes_across_sessions_and_hides_private_backend() {
         .unwrap()
         .local_address
         .unwrap();
+    assert_eq!(*client_address.ip(), GUEST_IPV4_ADDRESS);
     let connector_private_address = provider
         .reactor
         .host_address(client_address.port())
@@ -1131,8 +1155,7 @@ fn tcp_exact_bindings_coexist_and_wildcard_accepts_concrete_destinations() {
         litebox_broker_core::socket::listen(&listener_session, wildcard_listener, 2),
         Ok(SocketOutcome::Completed(wildcard_address))
     );
-    let concrete_destination =
-        SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 4), wildcard_address.port());
+    let concrete_destination = SocketAddrV4::new(GUEST_IPV4_ADDRESS, wildcard_address.port());
     let connector = create_socket(&connector_session, readiness.clone());
     let SocketOutcome::Completed(connector_binding) = litebox_broker_core::socket::bind(
         &connector_session,
@@ -1154,7 +1177,7 @@ fn tcp_exact_bindings_coexist_and_wildcard_accepts_concrete_destinations() {
             .unwrap()
             .local_address,
         Some(SocketAddrV4::new(
-            Ipv4Addr::LOCALHOST,
+            GUEST_IPV4_ADDRESS,
             connector_binding.port(),
         ))
     );
@@ -1177,7 +1200,7 @@ fn tcp_exact_bindings_coexist_and_wildcard_accepts_concrete_destinations() {
     assert_eq!(accepted.local_address, concrete_destination);
     assert_eq!(
         accepted.remote_address,
-        SocketAddrV4::new(Ipv4Addr::LOCALHOST, connector_binding.port())
+        SocketAddrV4::new(GUEST_IPV4_ADDRESS, connector_binding.port())
     );
 
     let unspecified_connector = create_socket(&connector_session, readiness.clone());
@@ -1216,7 +1239,7 @@ fn connector_and_session_teardown_clean_bounded_pending_state() {
     let provider = Arc::new(LinuxSocketProvider::new(3, 1).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+            .with_socket_policy(SocketPolicy::GuestNetwork),
         BrokerCoreLimits::new_with_all_limits(8, 0, 3, 3),
         provider.clone(),
     )
@@ -1334,7 +1357,7 @@ fn graceful_connector_close_preserves_late_accept_and_eof() {
     let provider = Arc::new(LinuxSocketProvider::new(4, 2).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+            .with_socket_policy(SocketPolicy::GuestNetwork),
         BrokerCoreLimits::new_with_all_limits(8, 0, 4, 4),
         provider.clone(),
     )
@@ -1399,7 +1422,7 @@ fn abortive_connector_close_releases_descriptor_capacity() {
     let provider = Arc::new(LinuxSocketProvider::new(3, 1).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+            .with_socket_policy(SocketPolicy::GuestNetwork),
         BrokerCoreLimits::new_with_all_limits(8, 0, 3, 3),
         provider.clone(),
     )
@@ -1482,7 +1505,7 @@ fn accept_bounds_unmatched_private_connections_per_command() {
     let provider = Arc::new(LinuxSocketProvider::new(3, 2).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+            .with_socket_policy(SocketPolicy::GuestNetwork),
         BrokerCoreLimits::new_with_all_limits(8, 0, 3, 3),
         provider.clone(),
     )
@@ -1562,7 +1585,7 @@ fn accept_preserves_a_queued_connection_when_retained_capacity_is_unrelated() {
     let provider = Arc::new(LinuxSocketProvider::new(4, 4).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+            .with_socket_policy(SocketPolicy::GuestNetwork),
         BrokerCoreLimits::new_with_all_limits(8, 0, 5, 5),
         provider.clone(),
     )
@@ -1671,7 +1694,7 @@ fn stop_listening_cleanup_survives_readiness_failure() {
     let provider = Arc::new(LinuxSocketProvider::new(3, 1).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+            .with_socket_policy(SocketPolicy::GuestNetwork),
         BrokerCoreLimits::new_with_all_limits(8, 0, 3, 3),
         provider.clone(),
     )
@@ -1765,7 +1788,7 @@ fn reactor_drives_a_loopback_tcp_listener() {
     let provider = Arc::new(LinuxSocketProvider::new(6, 6).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+            .with_socket_policy(SocketPolicy::GuestNetwork),
         BrokerCoreLimits::new_with_all_limits(8, 0, 6, 6),
         provider.clone(),
     )

--- a/litebox_broker_platform_linux_userland/src/socket/tests/tcp.rs
+++ b/litebox_broker_platform_linux_userland/src/socket/tests/tcp.rs
@@ -1056,12 +1056,13 @@ fn guest_tcp_namespace_routes_across_sessions_and_hides_private_backend() {
 #[test]
 fn tcp_exact_bindings_coexist_and_wildcard_accepts_concrete_destinations() {
     let provider = Arc::new(LinuxSocketProvider::new(12, 8).unwrap());
-    let policy = SocketPolicy::from_tcp_destination_rules(&[DestinationRule::new(
-        CallerCredential::Unauthenticated,
-        Ipv4Cidr::new(Ipv4Address([0, 0, 0, 0]), 0).unwrap(),
-        DestinationPortRange::new(Port(1), Port(u16::MAX)).unwrap(),
-    )])
-    .unwrap();
+    let policy = SocketPolicy::deny()
+        .with_tcp_destination_rules(&[DestinationRule::new(
+            CallerCredential::Unauthenticated,
+            Ipv4Cidr::new(Ipv4Address([0, 0, 0, 0]), 0).unwrap(),
+            DestinationPortRange::new(Port(1), Port(u16::MAX)).unwrap(),
+        )])
+        .unwrap();
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all()).with_socket_policy(policy),
         BrokerCoreLimits::new_with_all_limits(20, 0, 12, 12),

--- a/litebox_broker_platform_linux_userland/src/socket/tests/tcp.rs
+++ b/litebox_broker_platform_linux_userland/src/socket/tests/tcp.rs
@@ -119,7 +119,7 @@ fn untracked_guest_connection_cleanup_is_bounded_and_drains_backlog() {
     let provider = Arc::new(LinuxSocketProvider::new(6, 3).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::GuestNetwork),
+            .with_socket_policy(SocketPolicy::guest_network()),
         BrokerCoreLimits::new_with_all_limits(12, 0, 6, 6),
         provider.clone(),
     )
@@ -271,7 +271,7 @@ fn reactor_drives_a_loopback_tcp_socket() {
     let provider = Arc::new(LinuxSocketProvider::new(8, 8).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::GuestNetwork),
+            .with_socket_policy(SocketPolicy::guest_network()),
         BrokerCoreLimits::new_with_all_limits(16, 0, 8, 8),
         provider,
     )
@@ -604,7 +604,7 @@ fn tcp_receive_survives_readiness_publication_failure() {
     let provider = Arc::new(LinuxSocketProvider::new(1, 1).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::GuestNetwork),
+            .with_socket_policy(SocketPolicy::guest_network()),
         BrokerCoreLimits::new_with_all_limits(2, 0, 1, 1),
         provider,
     )
@@ -662,7 +662,7 @@ fn tcp_status_publication_failure_preserves_consumed_error() {
     let provider = Arc::new(LinuxSocketProvider::new(1, 1).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::GuestNetwork),
+            .with_socket_policy(SocketPolicy::guest_network()),
         BrokerCoreLimits::new_with_all_limits(2, 0, 1, 1),
         provider,
     )
@@ -722,7 +722,7 @@ fn exhausted_tcp_peek_cache_refreshes_before_terminal_eof() {
     let provider = Arc::new(LinuxSocketProvider::new(1, 1).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::GuestNetwork),
+            .with_socket_policy(SocketPolicy::guest_network()),
         BrokerCoreLimits::new_with_all_limits(2, 0, 1, 1),
         provider,
     )
@@ -791,7 +791,7 @@ fn accepted_guest_tcp_close_with_unread_data_preserves_reset() {
     let provider = Arc::new(LinuxSocketProvider::new(3, 2).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::GuestNetwork),
+            .with_socket_policy(SocketPolicy::guest_network()),
         BrokerCoreLimits::new_with_all_limits(6, 0, 3, 3),
         provider,
     )
@@ -874,7 +874,7 @@ fn guest_tcp_namespace_routes_across_sessions_and_hides_private_backend() {
     let provider = Arc::new(LinuxSocketProvider::new(5, 3).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::GuestNetwork),
+            .with_socket_policy(SocketPolicy::guest_network()),
         BrokerCoreLimits::new_with_all_limits(8, 0, 5, 4),
         provider.clone(),
     )
@@ -1239,7 +1239,7 @@ fn connector_and_session_teardown_clean_bounded_pending_state() {
     let provider = Arc::new(LinuxSocketProvider::new(3, 1).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::GuestNetwork),
+            .with_socket_policy(SocketPolicy::guest_network()),
         BrokerCoreLimits::new_with_all_limits(8, 0, 3, 3),
         provider.clone(),
     )
@@ -1357,7 +1357,7 @@ fn graceful_connector_close_preserves_late_accept_and_eof() {
     let provider = Arc::new(LinuxSocketProvider::new(4, 2).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::GuestNetwork),
+            .with_socket_policy(SocketPolicy::guest_network()),
         BrokerCoreLimits::new_with_all_limits(8, 0, 4, 4),
         provider.clone(),
     )
@@ -1422,7 +1422,7 @@ fn abortive_connector_close_releases_descriptor_capacity() {
     let provider = Arc::new(LinuxSocketProvider::new(3, 1).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::GuestNetwork),
+            .with_socket_policy(SocketPolicy::guest_network()),
         BrokerCoreLimits::new_with_all_limits(8, 0, 3, 3),
         provider.clone(),
     )
@@ -1505,7 +1505,7 @@ fn accept_bounds_unmatched_private_connections_per_command() {
     let provider = Arc::new(LinuxSocketProvider::new(3, 2).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::GuestNetwork),
+            .with_socket_policy(SocketPolicy::guest_network()),
         BrokerCoreLimits::new_with_all_limits(8, 0, 3, 3),
         provider.clone(),
     )
@@ -1585,7 +1585,7 @@ fn accept_preserves_a_queued_connection_when_retained_capacity_is_unrelated() {
     let provider = Arc::new(LinuxSocketProvider::new(4, 4).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::GuestNetwork),
+            .with_socket_policy(SocketPolicy::guest_network()),
         BrokerCoreLimits::new_with_all_limits(8, 0, 5, 5),
         provider.clone(),
     )
@@ -1694,7 +1694,7 @@ fn stop_listening_cleanup_survives_readiness_failure() {
     let provider = Arc::new(LinuxSocketProvider::new(3, 1).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::GuestNetwork),
+            .with_socket_policy(SocketPolicy::guest_network()),
         BrokerCoreLimits::new_with_all_limits(8, 0, 3, 3),
         provider.clone(),
     )
@@ -1788,7 +1788,7 @@ fn reactor_drives_a_loopback_tcp_listener() {
     let provider = Arc::new(LinuxSocketProvider::new(6, 6).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::GuestNetwork),
+            .with_socket_policy(SocketPolicy::guest_network()),
         BrokerCoreLimits::new_with_all_limits(8, 0, 6, 6),
         provider.clone(),
     )

--- a/litebox_broker_platform_linux_userland/src/socket/tests/udp.rs
+++ b/litebox_broker_platform_linux_userland/src/socket/tests/udp.rs
@@ -8,7 +8,7 @@ fn guest_udp_readiness_failure_rolls_back_enqueue() {
     let provider = Arc::new(LinuxSocketProvider::new(2, 1).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::GuestNetwork),
+            .with_socket_policy(SocketPolicy::guest_network()),
         BrokerCoreLimits::new_with_all_limits(4, 0, 2, 1),
         provider.clone(),
     )
@@ -105,7 +105,7 @@ fn native_udp_readiness_failure_does_not_fail_shared_reactor() {
     let provider = Arc::new(LinuxSocketProvider::new(2, 2).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::GuestNetwork),
+            .with_socket_policy(SocketPolicy::guest_network()),
         BrokerCoreLimits::new_with_all_limits(4, 0, 2, 2),
         provider,
     )
@@ -217,7 +217,7 @@ fn udp_status_publication_failure_still_rearms_native_endpoint() {
     let provider = Arc::new(LinuxSocketProvider::new(1, 1).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::GuestNetwork),
+            .with_socket_policy(SocketPolicy::guest_network()),
         BrokerCoreLimits::new_with_all_limits(2, 0, 1, 1),
         provider,
     )
@@ -290,7 +290,7 @@ fn udp_status_republishes_when_another_error_remains_pending() {
     let provider = Arc::new(LinuxSocketProvider::new(1, 1).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::GuestNetwork),
+            .with_socket_policy(SocketPolicy::guest_network()),
         BrokerCoreLimits::new_with_all_limits(2, 0, 1, 1),
         provider.clone(),
     )
@@ -342,7 +342,7 @@ fn guest_udp_queue_pressure_drops_new_datagrams_successfully() {
     let provider = Arc::new(LinuxSocketProvider::new(2, 1).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::GuestNetwork),
+            .with_socket_policy(SocketPolicy::guest_network()),
         BrokerCoreLimits::new_with_all_limits(4, 0, 2, 1),
         provider.clone(),
     )
@@ -433,7 +433,7 @@ fn udp_external_peer_authorization_is_bounded_without_eviction() {
     let provider = Arc::new(LinuxSocketProvider::new(1, 1).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::GuestNetwork),
+            .with_socket_policy(SocketPolicy::guest_network()),
         BrokerCoreLimits::new_with_all_limits(2, 0, 1, 1),
         provider,
     )
@@ -876,7 +876,7 @@ fn guest_udp_namespace_routes_across_sessions_and_filters_private_endpoints() {
     let provider = Arc::new(LinuxSocketProvider::new(6, 3).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::GuestNetwork),
+            .with_socket_policy(SocketPolicy::guest_network()),
         BrokerCoreLimits::new_with_all_limits(8, 0, 6, 3),
         provider.clone(),
     )
@@ -1138,7 +1138,7 @@ fn udp_exact_bindings_coexist_and_wildcard_covers_guest_addresses() {
     let provider = Arc::new(LinuxSocketProvider::new(8, 5).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::GuestNetwork),
+            .with_socket_policy(SocketPolicy::guest_network()),
         BrokerCoreLimits::new_with_all_limits(12, 0, 8, 8),
         provider,
     )
@@ -1326,7 +1326,7 @@ fn udp_native_endpoint_is_reused_and_retired() {
     let provider = Arc::new(LinuxSocketProvider::new(2, 2).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::GuestNetwork),
+            .with_socket_policy(SocketPolicy::guest_network()),
         BrokerCoreLimits::new_with_all_limits(4, 0, 2, 2),
         provider.clone(),
     )
@@ -1391,7 +1391,7 @@ fn udp_endpoint_staging_error_rolls_back_external_peer_reservation() {
     let provider = Arc::new(LinuxSocketProvider::new(2, 2).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::GuestNetwork),
+            .with_socket_policy(SocketPolicy::guest_network()),
         BrokerCoreLimits::new_with_all_limits(4, 0, 2, 2),
         provider.clone(),
     )
@@ -1429,7 +1429,7 @@ fn stale_udp_datagrams_are_not_relabelled_after_guest_port_reuse() {
     let provider = Arc::new(LinuxSocketProvider::new(5, 3).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::GuestNetwork),
+            .with_socket_policy(SocketPolicy::guest_network()),
         BrokerCoreLimits::new_with_all_limits(8, 0, 5, 3),
         provider.clone(),
     )
@@ -1536,7 +1536,7 @@ fn udp_queued_datagrams_survive_source_session_teardown() {
     let provider = Arc::new(LinuxSocketProvider::new(3, 1).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::GuestNetwork),
+            .with_socket_policy(SocketPolicy::guest_network()),
         BrokerCoreLimits::new_with_all_limits(6, 0, 3, 1),
         provider.clone(),
     )
@@ -1669,7 +1669,7 @@ fn connected_guest_udp_enforces_barriers_peek_and_peer_generations() {
     let provider = Arc::new(LinuxSocketProvider::new(4, 2).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::GuestNetwork),
+            .with_socket_policy(SocketPolicy::guest_network()),
         BrokerCoreLimits::new_with_all_limits(8, 0, 4, 2),
         provider.clone(),
     )
@@ -1936,7 +1936,7 @@ fn guest_connected_udp_drains_native_ingress_without_delivering_it() {
     let provider = Arc::new(LinuxSocketProvider::new(4, 2).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::GuestNetwork),
+            .with_socket_policy(SocketPolicy::guest_network()),
         BrokerCoreLimits::new_with_all_limits(8, 0, 4, 2),
         provider.clone(),
     )

--- a/litebox_broker_platform_linux_userland/src/socket/tests/udp.rs
+++ b/litebox_broker_platform_linux_userland/src/socket/tests/udp.rs
@@ -8,7 +8,7 @@ fn guest_udp_readiness_failure_rolls_back_enqueue() {
     let provider = Arc::new(LinuxSocketProvider::new(2, 1).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+            .with_socket_policy(SocketPolicy::GuestNetwork),
         BrokerCoreLimits::new_with_all_limits(4, 0, 2, 1),
         provider.clone(),
     )
@@ -105,7 +105,7 @@ fn native_udp_readiness_failure_does_not_fail_shared_reactor() {
     let provider = Arc::new(LinuxSocketProvider::new(2, 2).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+            .with_socket_policy(SocketPolicy::GuestNetwork),
         BrokerCoreLimits::new_with_all_limits(4, 0, 2, 2),
         provider,
     )
@@ -217,7 +217,7 @@ fn udp_status_publication_failure_still_rearms_native_endpoint() {
     let provider = Arc::new(LinuxSocketProvider::new(1, 1).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+            .with_socket_policy(SocketPolicy::GuestNetwork),
         BrokerCoreLimits::new_with_all_limits(2, 0, 1, 1),
         provider,
     )
@@ -290,7 +290,7 @@ fn udp_status_republishes_when_another_error_remains_pending() {
     let provider = Arc::new(LinuxSocketProvider::new(1, 1).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+            .with_socket_policy(SocketPolicy::GuestNetwork),
         BrokerCoreLimits::new_with_all_limits(2, 0, 1, 1),
         provider.clone(),
     )
@@ -342,7 +342,7 @@ fn guest_udp_queue_pressure_drops_new_datagrams_successfully() {
     let provider = Arc::new(LinuxSocketProvider::new(2, 1).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+            .with_socket_policy(SocketPolicy::GuestNetwork),
         BrokerCoreLimits::new_with_all_limits(4, 0, 2, 1),
         provider.clone(),
     )
@@ -433,7 +433,7 @@ fn udp_external_peer_authorization_is_bounded_without_eviction() {
     let provider = Arc::new(LinuxSocketProvider::new(1, 1).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+            .with_socket_policy(SocketPolicy::GuestNetwork),
         BrokerCoreLimits::new_with_all_limits(2, 0, 1, 1),
         provider,
     )
@@ -876,7 +876,7 @@ fn guest_udp_namespace_routes_across_sessions_and_filters_private_endpoints() {
     let provider = Arc::new(LinuxSocketProvider::new(6, 3).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+            .with_socket_policy(SocketPolicy::GuestNetwork),
         BrokerCoreLimits::new_with_all_limits(8, 0, 6, 3),
         provider.clone(),
     )
@@ -896,7 +896,7 @@ fn guest_udp_namespace_routes_across_sessions_and_filters_private_endpoints() {
         .set_nonblocking(true)
         .expect("failed to make shadow socket nonblocking");
     let guest_port = shadowed_host_socket.local_addr().unwrap().port();
-    let receiver_guest_address = SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 2), guest_port);
+    let receiver_guest_address = SocketAddrV4::new(GUEST_IPV4_ADDRESS, guest_port);
     let receiver = create_udp_socket(&receiver_session, readiness.clone());
     assert_eq!(
         litebox_broker_core::socket::bind(&receiver_session, receiver, receiver_guest_address,),
@@ -924,6 +924,22 @@ fn guest_udp_namespace_routes_across_sessions_and_filters_private_endpoints() {
         ),
         Ok(SocketOutcome::Failed(SocketError::ConnectionRefused))
     );
+    let unbound_private_port = if guest_port == u16::MAX {
+        guest_port - 1
+    } else {
+        guest_port + 1
+    };
+    assert_eq!(
+        send_datagram(
+            &sender_session,
+            sender,
+            b"private miss",
+            SendFlags::NONE,
+            Some(SocketAddrV4::new(GUEST_IPV4_ADDRESS, unbound_private_port,)),
+        ),
+        Ok(SocketOutcome::Failed(SocketError::ConnectionRefused))
+    );
+    assert_eq!(provider.reactor.udp_native_endpoint_count(), 0);
     assert_eq!(
         send_datagram(
             &sender_session,
@@ -938,7 +954,7 @@ fn guest_udp_namespace_routes_across_sessions_and_filters_private_endpoints() {
         .unwrap()
         .local_address
         .expect("implicit UDP bind missing");
-    let sender_source_address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, sender_guest_address.port());
+    let sender_source_address = SocketAddrV4::new(GUEST_IPV4_ADDRESS, sender_guest_address.port());
     wait_until_ready(
         &receiver_session,
         &publications,
@@ -1118,11 +1134,11 @@ fn guest_udp_namespace_routes_across_sessions_and_filters_private_endpoints() {
 }
 
 #[test]
-fn udp_exact_bindings_coexist_and_wildcard_covers_loopback() {
+fn udp_exact_bindings_coexist_and_wildcard_covers_guest_addresses() {
     let provider = Arc::new(LinuxSocketProvider::new(8, 5).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+            .with_socket_policy(SocketPolicy::GuestNetwork),
         BrokerCoreLimits::new_with_all_limits(12, 0, 8, 8),
         provider,
     )
@@ -1216,8 +1232,7 @@ fn udp_exact_bindings_coexist_and_wildcard_covers_loopback() {
     .unwrap() else {
         panic!("wildcard UDP bind failed");
     };
-    let concrete_destination =
-        SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 4), wildcard_address.port());
+    let concrete_destination = SocketAddrV4::new(GUEST_IPV4_ADDRESS, wildcard_address.port());
     assert_eq!(
         send_datagram(
             &sender_session,
@@ -1299,7 +1314,7 @@ fn udp_exact_bindings_coexist_and_wildcard_covers_loopback() {
             datagram_length: 4,
             source_address,
         })) if source_address == SocketAddrV4::new(
-            Ipv4Addr::LOCALHOST,
+            GUEST_IPV4_ADDRESS,
             wildcard_address.port(),
         )
     ));
@@ -1311,7 +1326,7 @@ fn udp_native_endpoint_is_reused_and_retired() {
     let provider = Arc::new(LinuxSocketProvider::new(2, 2).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+            .with_socket_policy(SocketPolicy::GuestNetwork),
         BrokerCoreLimits::new_with_all_limits(4, 0, 2, 2),
         provider.clone(),
     )
@@ -1376,7 +1391,7 @@ fn udp_endpoint_staging_error_rolls_back_external_peer_reservation() {
     let provider = Arc::new(LinuxSocketProvider::new(2, 2).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+            .with_socket_policy(SocketPolicy::GuestNetwork),
         BrokerCoreLimits::new_with_all_limits(4, 0, 2, 2),
         provider.clone(),
     )
@@ -1414,7 +1429,7 @@ fn stale_udp_datagrams_are_not_relabelled_after_guest_port_reuse() {
     let provider = Arc::new(LinuxSocketProvider::new(5, 3).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+            .with_socket_policy(SocketPolicy::GuestNetwork),
         BrokerCoreLimits::new_with_all_limits(8, 0, 5, 3),
         provider.clone(),
     )
@@ -1521,7 +1536,7 @@ fn udp_queued_datagrams_survive_source_session_teardown() {
     let provider = Arc::new(LinuxSocketProvider::new(3, 1).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+            .with_socket_policy(SocketPolicy::GuestNetwork),
         BrokerCoreLimits::new_with_all_limits(6, 0, 3, 1),
         provider.clone(),
     )
@@ -1654,7 +1669,7 @@ fn connected_guest_udp_enforces_barriers_peek_and_peer_generations() {
     let provider = Arc::new(LinuxSocketProvider::new(4, 2).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+            .with_socket_policy(SocketPolicy::GuestNetwork),
         BrokerCoreLimits::new_with_all_limits(8, 0, 4, 2),
         provider.clone(),
     )
@@ -1921,7 +1936,7 @@ fn guest_connected_udp_drains_native_ingress_without_delivering_it() {
     let provider = Arc::new(LinuxSocketProvider::new(4, 2).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::Ipv4Loopback),
+            .with_socket_policy(SocketPolicy::GuestNetwork),
         BrokerCoreLimits::new_with_all_limits(8, 0, 4, 2),
         provider.clone(),
     )

--- a/litebox_broker_platform_linux_userland/src/socket/tests/udp.rs
+++ b/litebox_broker_platform_linux_userland/src/socket/tests/udp.rs
@@ -507,19 +507,20 @@ fn reactor_preserves_udp_datagram_semantics() {
     server.set_read_timeout(Some(TEST_TIMEOUT)).unwrap();
     let server_address = socket_address_v4(server.local_addr().unwrap());
     let provider = Arc::new(LinuxSocketProvider::new(2, 2).unwrap());
-    let socket_policy = SocketPolicy::from_udp_destination_rules(&[
-        DestinationRule::new(
-            CallerCredential::Unauthenticated,
-            Ipv4Cidr::new(Ipv4Address([127, 0, 0, 0]), 8).unwrap(),
-            DestinationPortRange::new(Port(1), Port(u16::MAX)).unwrap(),
-        ),
-        DestinationRule::new(
-            CallerCredential::Unauthenticated,
-            Ipv4Cidr::new(Ipv4Address([255, 255, 255, 255]), 32).unwrap(),
-            DestinationPortRange::new(Port(9), Port(9)).unwrap(),
-        ),
-    ])
-    .unwrap();
+    let socket_policy = SocketPolicy::deny()
+        .with_udp_destination_rules(&[
+            DestinationRule::new(
+                CallerCredential::Unauthenticated,
+                Ipv4Cidr::new(Ipv4Address([127, 0, 0, 0]), 8).unwrap(),
+                DestinationPortRange::new(Port(1), Port(u16::MAX)).unwrap(),
+            ),
+            DestinationRule::new(
+                CallerCredential::Unauthenticated,
+                Ipv4Cidr::new(Ipv4Address([255, 255, 255, 255]), 32).unwrap(),
+                DestinationPortRange::new(Port(9), Port(9)).unwrap(),
+            ),
+        ])
+        .unwrap();
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
             .with_socket_policy(socket_policy),
@@ -1812,19 +1813,20 @@ fn externally_connected_udp_preserves_guest_routing_identity() {
     external.set_read_timeout(Some(TEST_TIMEOUT)).unwrap();
     let external_address = socket_address_v4(external.local_addr().unwrap());
     let provider = Arc::new(LinuxSocketProvider::new(4, 2).unwrap());
-    let policy = SocketPolicy::from_udp_destination_rules(&[
-        DestinationRule::new(
-            CallerCredential::Unauthenticated,
-            Ipv4Cidr::new(Ipv4Address([127, 0, 0, 0]), 8).unwrap(),
-            DestinationPortRange::new(Port(1), Port(u16::MAX)).unwrap(),
-        ),
-        DestinationRule::new(
-            CallerCredential::Unauthenticated,
-            Ipv4Cidr::new(Ipv4Address(local_ip.octets()), 32).unwrap(),
-            DestinationPortRange::new(Port(1), Port(u16::MAX)).unwrap(),
-        ),
-    ])
-    .unwrap();
+    let policy = SocketPolicy::deny()
+        .with_udp_destination_rules(&[
+            DestinationRule::new(
+                CallerCredential::Unauthenticated,
+                Ipv4Cidr::new(Ipv4Address([127, 0, 0, 0]), 8).unwrap(),
+                DestinationPortRange::new(Port(1), Port(u16::MAX)).unwrap(),
+            ),
+            DestinationRule::new(
+                CallerCredential::Unauthenticated,
+                Ipv4Cidr::new(Ipv4Address(local_ip.octets()), 32).unwrap(),
+                DestinationPortRange::new(Port(1), Port(u16::MAX)).unwrap(),
+            ),
+        ])
+        .unwrap();
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all()).with_socket_policy(policy),
         BrokerCoreLimits::new_with_all_limits(6, 0, 4, 2),

--- a/litebox_broker_platform_linux_userland/src/socket/tests/udp.rs
+++ b/litebox_broker_platform_linux_userland/src/socket/tests/udp.rs
@@ -1798,6 +1798,67 @@ fn connected_guest_udp_enforces_barriers_peek_and_peer_generations() {
 }
 
 #[test]
+fn wildcard_udp_reconnect_updates_guest_source_identity() {
+    let provider = Arc::new(LinuxSocketProvider::new(3, 3).unwrap());
+    let broker = BrokerCore::new_with_limits(
+        PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
+            .with_socket_policy(SocketPolicy::guest_network()),
+        BrokerCoreLimits::new_with_all_limits(6, 0, 3, 3),
+        provider,
+    )
+    .unwrap();
+    let session = broker
+        .create_session(CallerCredential::Unauthenticated)
+        .unwrap();
+    let (published, _publications) = channel();
+    let (retired, _retirements) = channel();
+    let readiness = Arc::new(TestReadinessSink { published, retired });
+
+    let private_receiver = create_udp_socket(&session, readiness.clone());
+    let SocketOutcome::Completed(private_address) = litebox_broker_core::socket::bind(
+        &session,
+        private_receiver,
+        SocketAddrV4::new(GUEST_IPV4_ADDRESS, 0),
+    )
+    .unwrap() else {
+        panic!("private UDP bind failed");
+    };
+    let loopback_receiver = create_udp_socket(&session, readiness.clone());
+    let SocketOutcome::Completed(loopback_address) = litebox_broker_core::socket::bind(
+        &session,
+        loopback_receiver,
+        SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0),
+    )
+    .unwrap() else {
+        panic!("loopback UDP bind failed");
+    };
+
+    let sender = create_udp_socket(&session, readiness);
+    assert_eq!(
+        litebox_broker_core::socket::connect(&session, sender, private_address),
+        Ok(SocketOutcome::Completed(SocketConnectionStatus::Connected))
+    );
+    let private_source = litebox_broker_core::socket::status(&session, sender)
+        .unwrap()
+        .local_address
+        .expect("private UDP connect lost its local address");
+    assert_eq!(*private_source.ip(), GUEST_IPV4_ADDRESS);
+
+    assert_eq!(
+        litebox_broker_core::socket::connect(&session, sender, loopback_address),
+        Ok(SocketOutcome::Completed(SocketConnectionStatus::Connected))
+    );
+    let loopback_source = litebox_broker_core::socket::status(&session, sender)
+        .unwrap()
+        .local_address
+        .expect("loopback UDP reconnect lost its local address");
+    assert_eq!(
+        loopback_source,
+        SocketAddrV4::new(Ipv4Addr::LOCALHOST, private_source.port())
+    );
+}
+
+#[test]
 fn externally_connected_udp_preserves_guest_routing_identity() {
     let local_ip = non_loopback_local_ipv4();
     if std::env::var_os("CI").is_some() {

--- a/litebox_broker_platform_linux_userland/src/socket/udp.rs
+++ b/litebox_broker_platform_linux_userland/src/socket/udp.rs
@@ -319,6 +319,8 @@ impl Reactor {
                 guest_address: address,
             });
         }
+        // TODO: Once gateway routing replaces host-loopback fallback, fail all
+        // unmatched guest-network destinations closed.
         if *address.ip() == GUEST_IPV4_ADDRESS
             || (address.ip().is_loopback() && self.udp.has_binding_on_port(address.port()))
         {

--- a/litebox_broker_platform_linux_userland/src/socket/udp.rs
+++ b/litebox_broker_platform_linux_userland/src/socket/udp.rs
@@ -12,7 +12,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::net::{Ipv4Addr, SocketAddrV4};
 use std::os::fd::OwnedFd;
 
-use litebox_broker_core::socket::{GuestSocketBinding, PlatformConnectError};
+use litebox_broker_core::socket::{GUEST_IPV4_ADDRESS, GuestSocketBinding, PlatformConnectError};
 use litebox_broker_core::{BrokerError, Result as BrokerResult, SessionId};
 use litebox_broker_protocol::readiness::ReadinessFlags;
 use litebox_broker_protocol::socket::{
@@ -119,7 +119,6 @@ pub(super) struct ReactorUdpBinding {
 }
 
 pub(super) struct UdpSocketState {
-    pub(super) internal_address: Option<SocketAddrV4>,
     pub(super) peer: Option<ReactorUdpPeer>,
     guest_receive_queue: VecDeque<GuestDatagram>,
     guest_receive_bytes: usize,
@@ -133,7 +132,6 @@ pub(super) struct UdpSocketState {
 impl Default for UdpSocketState {
     fn default() -> Self {
         Self {
-            internal_address: None,
             peer: None,
             guest_receive_queue: VecDeque::new(),
             guest_receive_bytes: 0,
@@ -276,13 +274,11 @@ impl ReactorUdpState {
     }
 
     fn guest_binding(&self, address: SocketAddrV4) -> Option<ReactorUdpBinding> {
-        if !address.ip().is_loopback() {
-            return None;
-        }
         self.bindings
             .exact
             .get(&address)
             .or_else(|| self.bindings.wildcard.get(&address.port()))
+            .filter(|binding| binding.guest_binding.covers(address))
             .cloned()
     }
 
@@ -323,7 +319,9 @@ impl Reactor {
                 guest_address: address,
             });
         }
-        if address.ip().is_loopback() && self.udp.has_binding_on_port(address.port()) {
+        if *address.ip() == GUEST_IPV4_ADDRESS
+            || (address.ip().is_loopback() && self.udp.has_binding_on_port(address.port()))
+        {
             return SocketOutcome::Failed(SocketError::ConnectionRefused);
         }
         if self.is_private_udp_host_endpoint(address) {
@@ -689,20 +687,16 @@ impl Reactor {
         &mut self,
         source_socket_id: u64,
         destination_generation: u64,
+        source_guest_address: SocketAddrV4,
         payload: &[u8],
     ) -> BrokerResult<SocketOutcome<usize>> {
-        let (source_session_id, source_guest_address) = {
+        let source_session_id = {
             let source = self
                 .sockets
                 .get(&source_socket_id)
                 .ok_or(BrokerError::Internal)?;
-            (
-                source.session_id,
-                source
-                    .udp_state()?
-                    .internal_address
-                    .ok_or(BrokerError::Internal)?,
-            )
+            source.udp_state()?;
+            source.session_id
         };
         let destination_id = destination_generation;
         let accepts_source = {

--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -139,7 +139,7 @@ fn configured_socket_policy(
             )
         })
         .collect::<Vec<_>>();
-    SocketPolicy::from_tcp_udp_destination_rules(&rules, &[])
+    SocketPolicy::guest_network().with_tcp_destination_rules(&rules)
 }
 
 fn serve_runner<Memory, SetupChannel, RequestSource, ResponseSink, NotificationChannel, Shutdown>(

--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -87,7 +87,7 @@ impl FromStr for AllowedTcpDestination {
 struct CliArgs {
     /// Permit outbound TCP connections to a destination CIDR and port range.
     ///
-    /// May be repeated. Supplying any rule replaces the default loopback-only policy.
+    /// May be repeated to extend the default guest-network policy for TCP.
     /// `0.0.0.0/0:1-65535` permits every nonzero IPv4 TCP destination.
     #[arg(long, value_name = "CIDR:PORT[-PORT]")]
     allow_tcp_destination: Vec<AllowedTcpDestination>,
@@ -127,7 +127,7 @@ fn configured_socket_policy(
     allowed_destinations: &[AllowedTcpDestination],
 ) -> Result<SocketPolicy, SocketPolicyError> {
     if allowed_destinations.is_empty() {
-        return Ok(SocketPolicy::Ipv4Loopback);
+        return Ok(SocketPolicy::GuestNetwork);
     }
     let rules = allowed_destinations
         .iter()
@@ -139,13 +139,7 @@ fn configured_socket_policy(
             )
         })
         .collect::<Vec<_>>();
-    let udp_loopback = DestinationRule::new(
-        CallerCredential::HostGuaranteed,
-        Ipv4Cidr::new(Ipv4Address([127, 0, 0, 0]), 8).expect("the IPv4 loopback CIDR is canonical"),
-        DestinationPortRange::new(Port(1), Port(u16::MAX))
-            .expect("the full nonzero UDP port range is valid"),
-    );
-    SocketPolicy::from_tcp_udp_destination_rules(&rules, &[udp_loopback])
+    SocketPolicy::from_tcp_udp_destination_rules(&rules, &[])
 }
 
 fn serve_runner<Memory, SetupChannel, RequestSource, ResponseSink, NotificationChannel, Shutdown>(
@@ -587,10 +581,10 @@ mod cli_tests {
     }
 
     #[test]
-    fn tcp_destination_arguments_replace_the_loopback_default() {
+    fn tcp_destination_arguments_extend_the_guest_network_default() {
         assert_eq!(
             configured_socket_policy(&[]).unwrap(),
-            SocketPolicy::Ipv4Loopback
+            SocketPolicy::GuestNetwork
         );
 
         let allowed = "0.0.0.0/0:80".parse::<AllowedTcpDestination>().unwrap();
@@ -605,14 +599,7 @@ mod cli_tests {
                 allowed.ports,
             )
         );
-        assert_eq!(
-            policy.udp_destination_rules().unwrap(),
-            &[DestinationRule::new(
-                CallerCredential::HostGuaranteed,
-                Ipv4Cidr::new(Ipv4Address([127, 0, 0, 0]), 8).unwrap(),
-                DestinationPortRange::new(Port(1), Port(u16::MAX)).unwrap(),
-            )]
-        );
+        assert_eq!(policy.udp_destination_rules().unwrap(), &[]);
     }
 }
 

--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -127,7 +127,7 @@ fn configured_socket_policy(
     allowed_destinations: &[AllowedTcpDestination],
 ) -> Result<SocketPolicy, SocketPolicyError> {
     if allowed_destinations.is_empty() {
-        return Ok(SocketPolicy::GuestNetwork);
+        return Ok(SocketPolicy::guest_network());
     }
     let rules = allowed_destinations
         .iter()
@@ -584,7 +584,7 @@ mod cli_tests {
     fn tcp_destination_arguments_extend_the_guest_network_default() {
         assert_eq!(
             configured_socket_policy(&[]).unwrap(),
-            SocketPolicy::GuestNetwork
+            SocketPolicy::guest_network()
         );
 
         let allowed = "0.0.0.0/0:80".parse::<AllowedTcpDestination>().unwrap();

--- a/litebox_runner_linux_userland/tests/run.rs
+++ b/litebox_runner_linux_userland/tests/run.rs
@@ -667,7 +667,7 @@ fn test_runner_broker_tcp_client_with_rewriter() {
         litebox_broker_core::PolicyEngine::with_host_guaranteed_rights(
             litebox_broker_core::ObjectRights::all(),
         )
-        .with_socket_policy(litebox_broker_core::SocketPolicy::GuestNetwork),
+        .with_socket_policy(litebox_broker_core::SocketPolicy::guest_network()),
         1,
     );
     Runner::new(&target, "broker_tcp_client_rewriter")
@@ -756,7 +756,7 @@ fn test_runner_broker_udp_with_rewriter() {
         litebox_broker_core::PolicyEngine::with_host_guaranteed_rights(
             litebox_broker_core::ObjectRights::all(),
         )
-        .with_socket_policy(litebox_broker_core::SocketPolicy::GuestNetwork),
+        .with_socket_policy(litebox_broker_core::SocketPolicy::guest_network()),
         1,
     );
     runner
@@ -787,7 +787,7 @@ fn test_runner_broker_udp_namespace_delivers_after_sender_close() {
         litebox_broker_core::PolicyEngine::with_host_guaranteed_rights(
             litebox_broker_core::ObjectRights::all(),
         )
-        .with_socket_policy(litebox_broker_core::SocketPolicy::GuestNetwork),
+        .with_socket_policy(litebox_broker_core::SocketPolicy::guest_network()),
         2,
     );
     let mut server = Runner::new(&target, "broker_udp_namespace_server_rewriter")
@@ -856,7 +856,7 @@ fn test_runner_broker_tcp_server_with_rewriter() {
         litebox_broker_core::PolicyEngine::with_host_guaranteed_rights(
             litebox_broker_core::ObjectRights::all(),
         )
-        .with_socket_policy(litebox_broker_core::SocketPolicy::GuestNetwork),
+        .with_socket_policy(litebox_broker_core::SocketPolicy::guest_network()),
         1,
     );
     let mut child = Runner::new(&target, "broker_tcp_server_rewriter")
@@ -1279,7 +1279,7 @@ fn test_broker_with_curl() {
         litebox_broker_core::PolicyEngine::with_host_guaranteed_rights(
             litebox_broker_core::ObjectRights::all(),
         )
-        .with_socket_policy(litebox_broker_core::SocketPolicy::GuestNetwork),
+        .with_socket_policy(litebox_broker_core::SocketPolicy::guest_network()),
         1,
     );
     let url = format!("http://127.0.0.1:{port}/something");
@@ -1318,7 +1318,7 @@ fn test_broker_with_iperf3() {
         litebox_broker_core::PolicyEngine::with_host_guaranteed_rights(
             litebox_broker_core::ObjectRights::all(),
         )
-        .with_socket_policy(litebox_broker_core::SocketPolicy::GuestNetwork),
+        .with_socket_policy(litebox_broker_core::SocketPolicy::guest_network()),
         1,
     );
 

--- a/litebox_runner_linux_userland/tests/run.rs
+++ b/litebox_runner_linux_userland/tests/run.rs
@@ -667,7 +667,7 @@ fn test_runner_broker_tcp_client_with_rewriter() {
         litebox_broker_core::PolicyEngine::with_host_guaranteed_rights(
             litebox_broker_core::ObjectRights::all(),
         )
-        .with_socket_policy(litebox_broker_core::SocketPolicy::Ipv4Loopback),
+        .with_socket_policy(litebox_broker_core::SocketPolicy::GuestNetwork),
         1,
     );
     Runner::new(&target, "broker_tcp_client_rewriter")
@@ -756,7 +756,7 @@ fn test_runner_broker_udp_with_rewriter() {
         litebox_broker_core::PolicyEngine::with_host_guaranteed_rights(
             litebox_broker_core::ObjectRights::all(),
         )
-        .with_socket_policy(litebox_broker_core::SocketPolicy::Ipv4Loopback),
+        .with_socket_policy(litebox_broker_core::SocketPolicy::GuestNetwork),
         1,
     );
     runner
@@ -787,7 +787,7 @@ fn test_runner_broker_udp_namespace_delivers_after_sender_close() {
         litebox_broker_core::PolicyEngine::with_host_guaranteed_rights(
             litebox_broker_core::ObjectRights::all(),
         )
-        .with_socket_policy(litebox_broker_core::SocketPolicy::Ipv4Loopback),
+        .with_socket_policy(litebox_broker_core::SocketPolicy::GuestNetwork),
         2,
     );
     let mut server = Runner::new(&target, "broker_udp_namespace_server_rewriter")
@@ -856,7 +856,7 @@ fn test_runner_broker_tcp_server_with_rewriter() {
         litebox_broker_core::PolicyEngine::with_host_guaranteed_rights(
             litebox_broker_core::ObjectRights::all(),
         )
-        .with_socket_policy(litebox_broker_core::SocketPolicy::Ipv4Loopback),
+        .with_socket_policy(litebox_broker_core::SocketPolicy::GuestNetwork),
         1,
     );
     let mut child = Runner::new(&target, "broker_tcp_server_rewriter")
@@ -1279,7 +1279,7 @@ fn test_broker_with_curl() {
         litebox_broker_core::PolicyEngine::with_host_guaranteed_rights(
             litebox_broker_core::ObjectRights::all(),
         )
-        .with_socket_policy(litebox_broker_core::SocketPolicy::Ipv4Loopback),
+        .with_socket_policy(litebox_broker_core::SocketPolicy::GuestNetwork),
         1,
     );
     let url = format!("http://127.0.0.1:{port}/something");
@@ -1318,7 +1318,7 @@ fn test_broker_with_iperf3() {
         litebox_broker_core::PolicyEngine::with_host_guaranteed_rights(
             litebox_broker_core::ObjectRights::all(),
         )
-        .with_socket_policy(litebox_broker_core::SocketPolicy::Ipv4Loopback),
+        .with_socket_policy(litebox_broker_core::SocketPolicy::GuestNetwork),
         1,
     );
 


### PR DESCRIPTION
This PR adds the fixed shared guest IPv4 identity `10.0.2.15` to the existing broker-wide TCP and UDP namespaces, simplifies socket policy into independent per-protocol settings, supports exact and wildcard guest bindings with destination-correct source addresses, and makes unmatched private guest destinations fail closed without changing native endpoint lifecycle or gateway routing.