### PR TITLE
Improve AArch64 code identification using ELF metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -892,6 +892,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1829,6 +1835,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "gimli",
  "iced-x86",
  "insta",
  "litebox_common_windows",

--- a/litebox_shim_linux/Cargo.toml
+++ b/litebox_shim_linux/Cargo.toml
@@ -14,7 +14,7 @@ once_cell = { version = "1.20.2", default-features = false, features = ["alloc",
 thiserror = { version = "2.0.6", default-features = false }
 syscalls = { version = "0.6", default-features = false }
 ringbuf = { version = "0.4.8", default-features = false, features = ["alloc"] }
-zerocopy = { version = "0.8", default-features = false, features = ["derive"] }
+zerocopy = { version = "0.8", default-features = false, features = ["alloc", "derive"] }
 litebox_syscall_rewriter = { version = "0.1.0", path = "../litebox_syscall_rewriter", default-features = false }
 object = { version = "0.36.7", default-features = false, features = ["elf", "read_core"] }
 

--- a/litebox_shim_linux/src/syscalls/mm.rs
+++ b/litebox_shim_linux/src/syscalls/mm.rs
@@ -29,7 +29,7 @@ use litebox::utils::ReinterpretUnsignedExt as _;
 use litebox::utils::TruncateExt as _;
 use object::elf::{ET_DYN, FileHeader64, PT_LOAD, ProgramHeader64};
 use object::endian::LittleEndian;
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", feature = "aarch64_virtualize_x18"))]
 use zerocopy::FromZeros as _;
 
 #[cfg(not(target_pointer_width = "64"))]
@@ -106,7 +106,7 @@ pub(crate) struct ElfPatchState {
     runtime_patches_committed: bool,
     #[cfg(target_arch = "aarch64")]
     trampoline_invalidated: bool,
-    #[cfg(target_arch = "aarch64")]
+    #[cfg(all(target_arch = "aarch64", feature = "aarch64_virtualize_x18"))]
     code_metadata: Option<litebox_syscall_rewriter::aarch64::ElfCodeMetadata>,
     /// Tracks file-backed mappings for this fd as (vaddr, len) pairs.
     /// Used to find mappings that need patching when mprotect adds PROT_EXEC.
@@ -816,7 +816,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         let (pre_patched, tramp_file_offset, tramp_vaddr, tramp_file_size) =
             self.check_trampoline_magic(fd);
 
-        #[cfg(target_arch = "aarch64")]
+        #[cfg(all(target_arch = "aarch64", feature = "aarch64_virtualize_x18"))]
         let code_metadata = if pre_patched {
             None
         } else {
@@ -827,15 +827,10 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                 let bytes = zerocopy::IntoBytes::as_mut_bytes(words.as_mut_slice());
                 match self.sys_read(fd, &mut bytes[..file_size], Some(0)) {
                     Ok(n) if n == file_size => {
-                        #[cfg(feature = "aarch64_virtualize_x18")]
-                        let metadata = litebox_syscall_rewriter::aarch64::ElfCodeMetadata::parse_aligned_in_place(
-                                &mut words, file_size,
-                            );
-                        #[cfg(not(feature = "aarch64_virtualize_x18"))]
-                        let metadata = litebox_syscall_rewriter::aarch64::ElfCodeMetadata::parse_executable_in_place(
-                                &mut words, file_size,
-                            );
-                        metadata.ok()
+                        litebox_syscall_rewriter::aarch64::ElfCodeMetadata::parse_aligned_in_place(
+                            &mut words, file_size,
+                        )
+                        .ok()
                     }
                     _ => None,
                 }
@@ -911,7 +906,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             runtime_patches_committed: false,
             #[cfg(target_arch = "aarch64")]
             trampoline_invalidated: false,
-            #[cfg(target_arch = "aarch64")]
+            #[cfg(all(target_arch = "aarch64", feature = "aarch64_virtualize_x18"))]
             code_metadata,
             file_mappings: BTreeSet::new(),
             patched_ranges: BTreeSet::new(),
@@ -1215,13 +1210,15 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
 
         // ── Runtime patching path (unpatched binaries) ───────────────
 
-        #[cfg(target_arch = "aarch64")]
+        #[cfg(all(target_arch = "aarch64", feature = "aarch64_virtualize_x18"))]
         let scan_ranges = file_offset.and_then(|file_offset| {
             state
                 .code_metadata
                 .as_ref()
                 .and_then(|metadata| metadata.ranges_for_mapping(file_offset as u64, len).ok())
         });
+        #[cfg(all(target_arch = "aarch64", not(feature = "aarch64_virtualize_x18")))]
+        let scan_ranges: Option<litebox_syscall_rewriter::aarch64::CodeScanRanges> = None;
         #[cfg(target_arch = "aarch64")]
         let apply_trap_fallback = |mapped_addr, len, already_rw| {
             self.apply_aarch64_trap_fallback(mapped_addr, len, already_rw, scan_ranges.as_ref());

--- a/litebox_shim_linux/src/syscalls/mm.rs
+++ b/litebox_shim_linux/src/syscalls/mm.rs
@@ -104,10 +104,12 @@ pub(crate) struct ElfPatchState {
     runtime_patches_committed: bool,
     #[cfg(target_arch = "aarch64")]
     trampoline_invalidated: bool,
-    /// Tracks file-backed mappings for this fd as (vaddr, len) pairs.
+    #[cfg(target_arch = "aarch64")]
+    code_metadata: Option<litebox_syscall_rewriter::Aarch64ElfCodeMetadata>,
+    /// Tracks file-backed mappings as (vaddr, len, file offset).
     /// Used to find mappings that need patching when mprotect adds PROT_EXEC.
     /// Cleared on munmap to allow re-patching.
-    file_mappings: BTreeSet<(usize, usize)>,
+    file_mappings: BTreeSet<(usize, usize, usize)>,
     /// Ranges that have already been patched by the runtime rewriter.
     /// This is a performance guard only — re-running the rewriter on
     /// already-patched code is safe because the second run will not see
@@ -150,6 +152,19 @@ fn subtract_ranges(range: Range<usize>, excluded: &[Range<usize>]) -> Vec<Range<
         out.push(cursor..range.end);
     }
     out
+}
+
+fn replace_file_mapping(
+    mappings: &mut BTreeSet<(usize, usize, usize)>,
+    patched_ranges: &mut BTreeSet<(usize, usize)>,
+    mapping: (usize, usize, usize),
+) {
+    let (address, len, _) = mapping;
+    mappings.retain(|&(existing_address, existing_len, _)| {
+        existing_address != address || existing_len != len
+    });
+    patched_ranges.remove(&(address, len));
+    mappings.insert(mapping);
 }
 
 #[inline]
@@ -222,7 +237,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         if is_exec {
             let syscall_entry = self.global.platform.get_syscall_entry_point();
             if syscall_entry != 0
-                && !self.maybe_patch_exec_segment(result, len, fd, syscall_entry, Some(offset))
+                && !self.maybe_patch_exec_segment(result, len, fd, syscall_entry, offset)
             {
                 // Trampoline setup failed for a pre-patched binary whose
                 // .text already contains JMPs to the trampoline address.
@@ -238,12 +253,12 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             // gain PROT_EXEC via mprotect.
             let mut cache = self.global.elf_patch_cache.lock();
             if let Some(state) = cache.get_mut(&fd) {
-                let mapping_key = (result.as_usize(), len);
-                // Overlapping entries are safe here: file_mappings is only used
-                // to know which (addr, len) ranges belong to this fd so we can
-                // patch them later if mprotect adds PROT_EXEC.  Duplicates or
-                // overlaps are harmless — the patching logic is idempotent.
-                state.file_mappings.insert(mapping_key);
+                let mapping_key = (result.as_usize(), len, offset);
+                replace_file_mapping(
+                    &mut state.file_mappings,
+                    &mut state.patched_ranges,
+                    mapping_key,
+                );
             }
         }
 
@@ -510,7 +525,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                     state.trampoline_mapped_len = 0;
                 }
             }
-            state.file_mappings.retain(|&(vaddr, seg_len)| {
+            state.file_mappings.retain(|&(vaddr, seg_len, _)| {
                 let seg_end = vaddr.saturating_add(seg_len);
                 seg_end <= unmap_start || vaddr >= unmap_end
             });
@@ -658,7 +673,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         // Find unpatched file mappings that overlap this mprotect range.
         // We collect (fd, vaddr, seg_len, file_offset) to avoid holding
         // the lock while patching.
-        let to_patch: alloc::vec::Vec<(i32, usize, usize)> = {
+        let to_patch: alloc::vec::Vec<(i32, usize, usize, usize)> = {
             let cache = self.global.elf_patch_cache.lock();
             let mut result = alloc::vec::Vec::new();
             for (&fd, state) in cache.iter() {
@@ -666,11 +681,11 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                 if state.pre_patched {
                     continue;
                 }
-                for &(seg_start, seg_len) in &state.file_mappings {
+                for &(seg_start, seg_len, file_offset) in &state.file_mappings {
                     let seg_end = seg_start.saturating_add(seg_len);
                     // Check overlap with the mprotect range.
                     if seg_start < mprotect_end && seg_end > mprotect_start {
-                        result.push((fd, seg_start, seg_len));
+                        result.push((fd, seg_start, seg_len, file_offset));
                     }
                 }
             }
@@ -680,7 +695,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         // A single mprotect range should only overlap mappings from one fd
         // (a given vaddr range is backed by at most one file at a time).
         if to_patch.len() > 1 {
-            let fds: BTreeSet<i32> = to_patch.iter().map(|(fd, _, _)| *fd).collect();
+            let fds: BTreeSet<i32> = to_patch.iter().map(|(fd, _, _, _)| *fd).collect();
             if fds.len() > 1 {
                 litebox_util_log::warn!(
                     addr:? = mprotect_start, len:? = len, fds:? = fds;
@@ -689,7 +704,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             }
         }
 
-        for (fd, seg_start, seg_len) in to_patch {
+        for (fd, seg_start, seg_len, file_offset) in to_patch {
             // Clamp to the intersection of the tracked mapping and the
             // mprotect range — only patch the portion becoming executable.
             // Re-running the rewriter on already-patched bytes is safe,
@@ -702,7 +717,14 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                 continue;
             }
             let mapped_addr = UserPtrMut::<u8>::from_usize(patch_start);
-            if !self.maybe_patch_exec_segment(mapped_addr, patch_len, fd, syscall_entry, None) {
+            let patch_file_offset = file_offset.saturating_add(patch_start - seg_start);
+            if !self.maybe_patch_exec_segment(
+                mapped_addr,
+                patch_len,
+                fd,
+                syscall_entry,
+                patch_file_offset,
+            ) {
                 return false;
             }
         }
@@ -812,6 +834,31 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         let (pre_patched, tramp_file_offset, tramp_vaddr, tramp_file_size) =
             self.check_trampoline_magic(fd);
 
+        #[cfg(target_arch = "aarch64")]
+        let code_metadata = if pre_patched {
+            None
+        } else {
+            self.sys_fstat(fd).ok().and_then(|stat| {
+                let file_size: usize = stat.st_size.reinterpret_as_unsigned().trunc();
+                let word_len = file_size.div_ceil(8);
+                let mut words = Vec::new();
+                if words.try_reserve_exact(word_len).is_err() {
+                    return None;
+                }
+                words.resize(word_len, 0u64);
+                let bytes = zerocopy::IntoBytes::as_mut_bytes(words.as_mut_slice());
+                match self.sys_read(fd, &mut bytes[..file_size], Some(0)) {
+                    Ok(n) if n == file_size => {
+                        litebox_syscall_rewriter::Aarch64ElfCodeMetadata::parse_aligned(
+                            &mut words, file_size,
+                        )
+                        .ok()
+                    }
+                    _ => None,
+                }
+            })
+        };
+
         // Compute the trampoline virtual address.
         // - Pre-patched: use the exact address from the trampoline header (the
         //   code already contains JMPs there, so we MUST map at this address).
@@ -881,6 +928,8 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             runtime_patches_committed: false,
             #[cfg(target_arch = "aarch64")]
             trampoline_invalidated: false,
+            #[cfg(target_arch = "aarch64")]
+            code_metadata,
             file_mappings: BTreeSet::new(),
             patched_ranges: BTreeSet::new(),
         });
@@ -959,7 +1008,14 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
     /// and the initial mprotect RW is skipped.
     ///
     /// Panics on infrastructure failures (mprotect/read/write/disassembly).
-    fn apply_trap_fallback(&self, mapped_addr: UserPtrMut<u8>, len: usize, already_rw: bool) {
+    #[cfg(target_arch = "aarch64")]
+    fn apply_aarch64_trap_fallback(
+        &self,
+        mapped_addr: UserPtrMut<u8>,
+        len: usize,
+        already_rw: bool,
+        ranges: &litebox_syscall_rewriter::Aarch64CodeScanRanges,
+    ) {
         if !already_rw {
             self.sys_mprotect_raw(
                 mapped_addr,
@@ -975,16 +1031,52 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         };
         let mut code_buf = code_owned.into_vec();
         let code_vaddr = mapped_addr.as_usize() as u64;
-        #[cfg(target_arch = "aarch64")]
-        let count = litebox_syscall_rewriter::trap_all_syscalls_in_code_with_options(
+        let count = litebox_syscall_rewriter::trap_all_aarch64_patch_sites_with_options_and_ranges(
             &mut code_buf,
             code_vaddr,
+            ranges,
             crate::aarch64_rewrite_options(),
         )
         .unwrap_or_else(|e| {
             panic!("fatal: failed to disassemble code segment for trap fallback: {e:?}");
         });
-        #[cfg(target_arch = "x86_64")]
+        if count > 0 {
+            litebox_util_log::warn!(
+                count:? = count, addr:? = mapped_addr.as_usize(), len:? = len;
+                "applied trap fallback to syscall instructions"
+            );
+        }
+        assert!(
+            mapped_addr
+                .copy_from_slice::<Platform>(0, &code_buf)
+                .is_some(),
+            "fatal: failed to write trap bytes back to code segment"
+        );
+
+        // Restore RX.
+        self.sys_mprotect_raw(
+            mapped_addr,
+            len,
+            ProtFlags::PROT_READ | ProtFlags::PROT_EXEC,
+        )
+        .expect("fatal: failed to restore code segment to RX after trap fallback");
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    fn apply_trap_fallback(&self, mapped_addr: UserPtrMut<u8>, len: usize, already_rw: bool) {
+        if !already_rw {
+            self.sys_mprotect_raw(
+                mapped_addr,
+                len,
+                ProtFlags::PROT_READ | ProtFlags::PROT_WRITE,
+            )
+            .expect("fatal: failed to mprotect code segment RW for trap fallback");
+        }
+        let Some(code_owned) = mapped_addr.to_owned_slice::<Platform>(len) else {
+            panic!("fatal: failed to read code segment for trap fallback");
+        };
+        let mut code_buf = code_owned.into_vec();
+        let code_vaddr = mapped_addr.as_usize() as u64;
         let count = litebox_syscall_rewriter::trap_all_syscalls_in_code(&mut code_buf, code_vaddr)
             .unwrap_or_else(|e| {
                 panic!("fatal: failed to disassemble code segment for trap fallback: {e:?}");
@@ -1001,8 +1093,6 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                 .is_some(),
             "fatal: failed to write trap bytes back to code segment"
         );
-
-        // Restore RX.
         self.sys_mprotect_raw(
             mapped_addr,
             len,
@@ -1028,13 +1118,13 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         len: usize,
         fd: i32,
         syscall_entry: usize,
-        file_offset: Option<usize>,
+        file_offset: usize,
     ) -> bool {
         // Initialize patch state if this is the first mmap for this fd.
         // Typically the first mapping is at offset 0 (the ELF header), but
         // some loaders may map an executable segment at a non-zero offset first.
         if !self.global.elf_patch_cache.lock().contains_key(&fd) {
-            self.init_elf_patch_state(fd, mapped_addr.as_usize(), file_offset.unwrap_or(0));
+            self.init_elf_patch_state(fd, mapped_addr.as_usize(), file_offset);
         }
 
         // This lock guards the elf_patch_cache and is held for the entire
@@ -1130,7 +1220,31 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             return true;
         }
 
+        #[cfg(all(target_arch = "aarch64", feature = "aarch64_virtualize_x18"))]
+        if state.code_metadata.is_none() {
+            litebox_util_log::error!(fd:? = fd; "cannot virtualize x18 without ELF code metadata");
+            return false;
+        }
+
         // ── Runtime patching path (unpatched binaries) ───────────────
+
+        #[cfg(target_arch = "aarch64")]
+        let scan_ranges = state
+            .code_metadata
+            .as_ref()
+            .and_then(|metadata| metadata.ranges_for_mapping(file_offset as u64, len).ok())
+            .unwrap_or_else(|| litebox_syscall_rewriter::Aarch64CodeScanRanges {
+                executable: alloc::vec![0..len],
+                identified: alloc::vec::Vec::new(),
+            });
+        #[cfg(target_arch = "aarch64")]
+        let apply_trap_fallback = |mapped_addr, len, already_rw| {
+            self.apply_aarch64_trap_fallback(mapped_addr, len, already_rw, &scan_ranges);
+        };
+        #[cfg(target_arch = "x86_64")]
+        let apply_trap_fallback = |mapped_addr, len, already_rw| {
+            self.apply_trap_fallback(mapped_addr, len, already_rw);
+        };
 
         // Allocate the trampoline region if not yet done.
         let addr_usize = mapped_addr.as_usize();
@@ -1158,7 +1272,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                 });
             let Ok(actual_addr_ptr) = actual_addr else {
                 litebox_util_log::warn!("failed to allocate trampoline region");
-                self.apply_trap_fallback(mapped_addr, len, false);
+                apply_trap_fallback(mapped_addr, len, false);
                 return true;
             };
             let actual_addr = actual_addr_ptr.as_usize();
@@ -1173,7 +1287,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                     "trampoline too far from code segment, skipping patching"
                 );
                 let _ = self.sys_munmap_raw(UserPtrMut::<u8>::from_usize(actual_addr), PAGE_SIZE);
-                self.apply_trap_fallback(mapped_addr, len, false);
+                apply_trap_fallback(mapped_addr, len, false);
                 return true;
             }
 
@@ -1188,7 +1302,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                     litebox_util_log::warn!("failed to write syscall entry point to trampoline");
                     let _ =
                         self.sys_munmap_raw(UserPtrMut::<u8>::from_usize(actual_addr), PAGE_SIZE);
-                    self.apply_trap_fallback(mapped_addr, len, false);
+                    apply_trap_fallback(mapped_addr, len, false);
                     return true;
                 }
                 state.trampoline_cursor = litebox_syscall_rewriter::TRAMPOLINE_ENTRY_POINT_BYTES;
@@ -1266,13 +1380,15 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         };
 
         #[cfg(target_arch = "aarch64")]
-        let patch_result = litebox_syscall_rewriter::patch_code_segment_with_options(
-            &mut code_buf,
-            code_vaddr,
-            trampoline_write_vaddr,
-            syscall_entry_addr,
-            crate::aarch64_rewrite_options(),
-        );
+        let patch_result =
+            litebox_syscall_rewriter::patch_aarch64_code_segment_with_options_and_ranges(
+                &mut code_buf,
+                code_vaddr,
+                &scan_ranges,
+                trampoline_write_vaddr,
+                syscall_entry_addr,
+                crate::aarch64_rewrite_options(),
+            );
         #[cfg(target_arch = "x86_64")]
         let patch_result = litebox_syscall_rewriter::patch_code_segment(
             &mut code_buf,
@@ -1301,7 +1417,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                     let mut stubs = stubs;
                     if let Err(e) = finalize_trampoline_gates(self.global.platform, &mut stubs) {
                         litebox_util_log::error!(err:% = e; "refusing to install runtime gates whose guest thread-pointer is not patched");
-                        self.apply_trap_fallback(mapped_addr, len, true);
+                        apply_trap_fallback(mapped_addr, len, true);
                         restore_trampoline_rx(self, state);
                         return true;
                     }
@@ -1309,7 +1425,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                 };
                 let Some(new_cursor) = state.trampoline_cursor.checked_add(stubs.len()) else {
                     litebox_util_log::warn!("trampoline cursor overflow");
-                    self.apply_trap_fallback(mapped_addr, len, true);
+                    apply_trap_fallback(mapped_addr, len, true);
                     restore_trampoline_rx(self, state);
                     return true;
                 };
@@ -1329,7 +1445,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                         .is_err()
                     {
                         litebox_util_log::warn!("failed to expand trampoline region");
-                        self.apply_trap_fallback(mapped_addr, len, true);
+                        apply_trap_fallback(mapped_addr, len, true);
                         restore_trampoline_rx(self, state);
                         return true;
                     }
@@ -1386,7 +1502,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             }
             Err(e) => {
                 litebox_util_log::warn!(err:? = e; "patch_code_segment failed");
-                self.apply_trap_fallback(mapped_addr, len, true);
+                apply_trap_fallback(mapped_addr, len, true);
                 restore_trampoline_rx(self, state);
                 return true;
             }

--- a/litebox_shim_linux/src/syscalls/mm.rs
+++ b/litebox_shim_linux/src/syscalls/mm.rs
@@ -29,6 +29,8 @@ use litebox::utils::ReinterpretUnsignedExt as _;
 use litebox::utils::TruncateExt as _;
 use object::elf::{ET_DYN, FileHeader64, PT_LOAD, ProgramHeader64};
 use object::endian::LittleEndian;
+#[cfg(all(target_arch = "aarch64", feature = "aarch64_virtualize_x18"))]
+use zerocopy::FromZeros as _;
 
 #[cfg(not(target_pointer_width = "64"))]
 compile_error!("ELF patching code assumes 64-bit pointers (u64 <-> usize is lossless)");
@@ -104,12 +106,12 @@ pub(crate) struct ElfPatchState {
     runtime_patches_committed: bool,
     #[cfg(target_arch = "aarch64")]
     trampoline_invalidated: bool,
-    #[cfg(target_arch = "aarch64")]
-    code_metadata: Option<litebox_syscall_rewriter::Aarch64ElfCodeMetadata>,
-    /// Tracks file-backed mappings as (vaddr, len, file offset).
+    #[cfg(all(target_arch = "aarch64", feature = "aarch64_virtualize_x18"))]
+    code_metadata: Option<litebox_syscall_rewriter::aarch64::ElfCodeMetadata>,
+    /// Tracks file-backed mappings for this fd as (vaddr, len) pairs.
     /// Used to find mappings that need patching when mprotect adds PROT_EXEC.
     /// Cleared on munmap to allow re-patching.
-    file_mappings: BTreeSet<(usize, usize, usize)>,
+    file_mappings: BTreeSet<(usize, usize)>,
     /// Ranges that have already been patched by the runtime rewriter.
     /// This is a performance guard only — re-running the rewriter on
     /// already-patched code is safe because the second run will not see
@@ -152,19 +154,6 @@ fn subtract_ranges(range: Range<usize>, excluded: &[Range<usize>]) -> Vec<Range<
         out.push(cursor..range.end);
     }
     out
-}
-
-fn replace_file_mapping(
-    mappings: &mut BTreeSet<(usize, usize, usize)>,
-    patched_ranges: &mut BTreeSet<(usize, usize)>,
-    mapping: (usize, usize, usize),
-) {
-    let (address, len, _) = mapping;
-    mappings.retain(|&(existing_address, existing_len, _)| {
-        existing_address != address || existing_len != len
-    });
-    patched_ranges.remove(&(address, len));
-    mappings.insert(mapping);
 }
 
 #[inline]
@@ -237,7 +226,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         if is_exec {
             let syscall_entry = self.global.platform.get_syscall_entry_point();
             if syscall_entry != 0
-                && !self.maybe_patch_exec_segment(result, len, fd, syscall_entry, offset)
+                && !self.maybe_patch_exec_segment(result, len, fd, syscall_entry, Some(offset))
             {
                 // Trampoline setup failed for a pre-patched binary whose
                 // .text already contains JMPs to the trampoline address.
@@ -253,12 +242,12 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             // gain PROT_EXEC via mprotect.
             let mut cache = self.global.elf_patch_cache.lock();
             if let Some(state) = cache.get_mut(&fd) {
-                let mapping_key = (result.as_usize(), len, offset);
-                replace_file_mapping(
-                    &mut state.file_mappings,
-                    &mut state.patched_ranges,
-                    mapping_key,
-                );
+                let mapping_key = (result.as_usize(), len);
+                // Overlapping entries are safe here: file_mappings is only used
+                // to know which (addr, len) ranges belong to this fd so we can
+                // patch them later if mprotect adds PROT_EXEC.  Duplicates or
+                // overlaps are harmless — the patching logic is idempotent.
+                state.file_mappings.insert(mapping_key);
             }
         }
 
@@ -525,7 +514,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                     state.trampoline_mapped_len = 0;
                 }
             }
-            state.file_mappings.retain(|&(vaddr, seg_len, _)| {
+            state.file_mappings.retain(|&(vaddr, seg_len)| {
                 let seg_end = vaddr.saturating_add(seg_len);
                 seg_end <= unmap_start || vaddr >= unmap_end
             });
@@ -673,7 +662,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         // Find unpatched file mappings that overlap this mprotect range.
         // We collect (fd, vaddr, seg_len, file_offset) to avoid holding
         // the lock while patching.
-        let to_patch: alloc::vec::Vec<(i32, usize, usize, usize)> = {
+        let to_patch: alloc::vec::Vec<(i32, usize, usize)> = {
             let cache = self.global.elf_patch_cache.lock();
             let mut result = alloc::vec::Vec::new();
             for (&fd, state) in cache.iter() {
@@ -681,11 +670,11 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                 if state.pre_patched {
                     continue;
                 }
-                for &(seg_start, seg_len, file_offset) in &state.file_mappings {
+                for &(seg_start, seg_len) in &state.file_mappings {
                     let seg_end = seg_start.saturating_add(seg_len);
                     // Check overlap with the mprotect range.
                     if seg_start < mprotect_end && seg_end > mprotect_start {
-                        result.push((fd, seg_start, seg_len, file_offset));
+                        result.push((fd, seg_start, seg_len));
                     }
                 }
             }
@@ -695,7 +684,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         // A single mprotect range should only overlap mappings from one fd
         // (a given vaddr range is backed by at most one file at a time).
         if to_patch.len() > 1 {
-            let fds: BTreeSet<i32> = to_patch.iter().map(|(fd, _, _, _)| *fd).collect();
+            let fds: BTreeSet<i32> = to_patch.iter().map(|(fd, _, _)| *fd).collect();
             if fds.len() > 1 {
                 litebox_util_log::warn!(
                     addr:? = mprotect_start, len:? = len, fds:? = fds;
@@ -704,7 +693,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             }
         }
 
-        for (fd, seg_start, seg_len, file_offset) in to_patch {
+        for (fd, seg_start, seg_len) in to_patch {
             // Clamp to the intersection of the tracked mapping and the
             // mprotect range — only patch the portion becoming executable.
             // Re-running the rewriter on already-patched bytes is safe,
@@ -717,14 +706,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                 continue;
             }
             let mapped_addr = UserPtrMut::<u8>::from_usize(patch_start);
-            let patch_file_offset = file_offset.saturating_add(patch_start - seg_start);
-            if !self.maybe_patch_exec_segment(
-                mapped_addr,
-                patch_len,
-                fd,
-                syscall_entry,
-                patch_file_offset,
-            ) {
+            if !self.maybe_patch_exec_segment(mapped_addr, patch_len, fd, syscall_entry, None) {
                 return false;
             }
         }
@@ -834,22 +816,18 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         let (pre_patched, tramp_file_offset, tramp_vaddr, tramp_file_size) =
             self.check_trampoline_magic(fd);
 
-        #[cfg(target_arch = "aarch64")]
+        #[cfg(all(target_arch = "aarch64", feature = "aarch64_virtualize_x18"))]
         let code_metadata = if pre_patched {
             None
         } else {
             self.sys_fstat(fd).ok().and_then(|stat| {
                 let file_size: usize = stat.st_size.reinterpret_as_unsigned().trunc();
                 let word_len = file_size.div_ceil(8);
-                let mut words = Vec::new();
-                if words.try_reserve_exact(word_len).is_err() {
-                    return None;
-                }
-                words.resize(word_len, 0u64);
+                let mut words = u64::new_vec_zeroed(word_len).ok()?;
                 let bytes = zerocopy::IntoBytes::as_mut_bytes(words.as_mut_slice());
                 match self.sys_read(fd, &mut bytes[..file_size], Some(0)) {
                     Ok(n) if n == file_size => {
-                        litebox_syscall_rewriter::Aarch64ElfCodeMetadata::parse_aligned(
+                        litebox_syscall_rewriter::aarch64::ElfCodeMetadata::parse_aligned_in_place(
                             &mut words, file_size,
                         )
                         .ok()
@@ -928,7 +906,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             runtime_patches_committed: false,
             #[cfg(target_arch = "aarch64")]
             trampoline_invalidated: false,
-            #[cfg(target_arch = "aarch64")]
+            #[cfg(all(target_arch = "aarch64", feature = "aarch64_virtualize_x18"))]
             code_metadata,
             file_mappings: BTreeSet::new(),
             patched_ranges: BTreeSet::new(),
@@ -1014,7 +992,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         mapped_addr: UserPtrMut<u8>,
         len: usize,
         already_rw: bool,
-        ranges: &litebox_syscall_rewriter::Aarch64CodeScanRanges,
+        ranges: Option<&litebox_syscall_rewriter::aarch64::CodeScanRanges>,
     ) {
         if !already_rw {
             self.sys_mprotect_raw(
@@ -1031,19 +1009,27 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         };
         let mut code_buf = code_owned.into_vec();
         let code_vaddr = mapped_addr.as_usize() as u64;
-        let count = litebox_syscall_rewriter::trap_all_aarch64_patch_sites_with_options_and_ranges(
-            &mut code_buf,
-            code_vaddr,
-            ranges,
-            crate::aarch64_rewrite_options(),
-        )
+        let count = if let Some(ranges) = ranges {
+            litebox_syscall_rewriter::trap_all_aarch64_patch_sites_with_options_and_ranges(
+                &mut code_buf,
+                code_vaddr,
+                ranges,
+                crate::aarch64_rewrite_options(),
+            )
+        } else {
+            litebox_syscall_rewriter::trap_all_syscalls_in_code_with_options(
+                &mut code_buf,
+                code_vaddr,
+                crate::aarch64_rewrite_options(),
+            )
+        }
         .unwrap_or_else(|e| {
             panic!("fatal: failed to disassemble code segment for trap fallback: {e:?}");
         });
         if count > 0 {
             litebox_util_log::warn!(
                 count:? = count, addr:? = mapped_addr.as_usize(), len:? = len;
-                "applied trap fallback to syscall instructions"
+                "applied trap fallback to AArch64 patch sites"
             );
         }
         assert!(
@@ -1120,13 +1106,13 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         len: usize,
         fd: i32,
         syscall_entry: usize,
-        file_offset: usize,
+        file_offset: Option<usize>,
     ) -> bool {
         // Initialize patch state if this is the first mmap for this fd.
         // Typically the first mapping is at offset 0 (the ELF header), but
         // some loaders may map an executable segment at a non-zero offset first.
         if !self.global.elf_patch_cache.lock().contains_key(&fd) {
-            self.init_elf_patch_state(fd, mapped_addr.as_usize(), file_offset);
+            self.init_elf_patch_state(fd, mapped_addr.as_usize(), file_offset.unwrap_or(0));
         }
 
         // This lock guards the elf_patch_cache and is held for the entire
@@ -1222,26 +1208,20 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             return true;
         }
 
-        #[cfg(all(target_arch = "aarch64", feature = "aarch64_virtualize_x18"))]
-        if state.code_metadata.is_none() {
-            litebox_util_log::error!(fd:? = fd; "cannot virtualize x18 without ELF code metadata");
-            return false;
-        }
-
         // ── Runtime patching path (unpatched binaries) ───────────────
 
-        #[cfg(target_arch = "aarch64")]
-        let scan_ranges = state
-            .code_metadata
-            .as_ref()
-            .and_then(|metadata| metadata.ranges_for_mapping(file_offset as u64, len).ok())
-            .unwrap_or_else(|| litebox_syscall_rewriter::Aarch64CodeScanRanges {
-                executable: alloc::vec![0..len],
-                identified: alloc::vec::Vec::new(),
-            });
+        #[cfg(all(target_arch = "aarch64", feature = "aarch64_virtualize_x18"))]
+        let scan_ranges = file_offset.and_then(|file_offset| {
+            state
+                .code_metadata
+                .as_ref()
+                .and_then(|metadata| metadata.ranges_for_mapping(file_offset as u64, len).ok())
+        });
+        #[cfg(all(target_arch = "aarch64", not(feature = "aarch64_virtualize_x18")))]
+        let scan_ranges: Option<litebox_syscall_rewriter::aarch64::CodeScanRanges> = None;
         #[cfg(target_arch = "aarch64")]
         let apply_trap_fallback = |mapped_addr, len, already_rw| {
-            self.apply_aarch64_trap_fallback(mapped_addr, len, already_rw, &scan_ranges);
+            self.apply_aarch64_trap_fallback(mapped_addr, len, already_rw, scan_ranges.as_ref());
         };
         #[cfg(target_arch = "x86_64")]
         let apply_trap_fallback = |mapped_addr, len, already_rw| {
@@ -1382,15 +1362,24 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         };
 
         #[cfg(target_arch = "aarch64")]
-        let patch_result =
+        let patch_result = if let Some(ranges) = &scan_ranges {
             litebox_syscall_rewriter::patch_aarch64_code_segment_with_options_and_ranges(
                 &mut code_buf,
                 code_vaddr,
-                &scan_ranges,
+                ranges,
                 trampoline_write_vaddr,
                 syscall_entry_addr,
                 crate::aarch64_rewrite_options(),
-            );
+            )
+        } else {
+            litebox_syscall_rewriter::patch_code_segment_with_options(
+                &mut code_buf,
+                code_vaddr,
+                trampoline_write_vaddr,
+                syscall_entry_addr,
+                crate::aarch64_rewrite_options(),
+            )
+        };
         #[cfg(target_arch = "x86_64")]
         let patch_result = litebox_syscall_rewriter::patch_code_segment(
             &mut code_buf,

--- a/litebox_shim_linux/src/syscalls/mm.rs
+++ b/litebox_shim_linux/src/syscalls/mm.rs
@@ -836,6 +836,23 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                 }
             })
         };
+        #[cfg(all(target_arch = "aarch64", feature = "aarch64_virtualize_x18"))]
+        if !pre_patched {
+            if let Some(metadata) = &code_metadata {
+                let (executable_bytes, identified_bytes) = metadata.coverage_bytes();
+                litebox_util_log::debug!(
+                    fd:? = fd,
+                    executable_bytes:? = executable_bytes,
+                    identified_bytes:? = identified_bytes;
+                    "collected AArch64 code metadata"
+                );
+            } else {
+                litebox_util_log::warn!(
+                    fd:? = fd;
+                    "AArch64 code metadata unavailable; falling back to whole-mapping x18 scan"
+                );
+            }
+        }
 
         // Compute the trampoline virtual address.
         // - Pre-patched: use the exact address from the trampoline header (the

--- a/litebox_shim_linux/src/syscalls/mm.rs
+++ b/litebox_shim_linux/src/syscalls/mm.rs
@@ -1093,6 +1093,8 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                 .is_some(),
             "fatal: failed to write trap bytes back to code segment"
         );
+
+        // Restore RX.
         self.sys_mprotect_raw(
             mapped_addr,
             len,

--- a/litebox_shim_linux/src/syscalls/mm.rs
+++ b/litebox_shim_linux/src/syscalls/mm.rs
@@ -29,7 +29,7 @@ use litebox::utils::ReinterpretUnsignedExt as _;
 use litebox::utils::TruncateExt as _;
 use object::elf::{ET_DYN, FileHeader64, PT_LOAD, ProgramHeader64};
 use object::endian::LittleEndian;
-#[cfg(all(target_arch = "aarch64", feature = "aarch64_virtualize_x18"))]
+#[cfg(target_arch = "aarch64")]
 use zerocopy::FromZeros as _;
 
 #[cfg(not(target_pointer_width = "64"))]
@@ -106,7 +106,7 @@ pub(crate) struct ElfPatchState {
     runtime_patches_committed: bool,
     #[cfg(target_arch = "aarch64")]
     trampoline_invalidated: bool,
-    #[cfg(all(target_arch = "aarch64", feature = "aarch64_virtualize_x18"))]
+    #[cfg(target_arch = "aarch64")]
     code_metadata: Option<litebox_syscall_rewriter::aarch64::ElfCodeMetadata>,
     /// Tracks file-backed mappings for this fd as (vaddr, len) pairs.
     /// Used to find mappings that need patching when mprotect adds PROT_EXEC.
@@ -816,7 +816,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         let (pre_patched, tramp_file_offset, tramp_vaddr, tramp_file_size) =
             self.check_trampoline_magic(fd);
 
-        #[cfg(all(target_arch = "aarch64", feature = "aarch64_virtualize_x18"))]
+        #[cfg(target_arch = "aarch64")]
         let code_metadata = if pre_patched {
             None
         } else {
@@ -827,10 +827,15 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                 let bytes = zerocopy::IntoBytes::as_mut_bytes(words.as_mut_slice());
                 match self.sys_read(fd, &mut bytes[..file_size], Some(0)) {
                     Ok(n) if n == file_size => {
-                        litebox_syscall_rewriter::aarch64::ElfCodeMetadata::parse_aligned_in_place(
-                            &mut words, file_size,
-                        )
-                        .ok()
+                        #[cfg(feature = "aarch64_virtualize_x18")]
+                        let metadata = litebox_syscall_rewriter::aarch64::ElfCodeMetadata::parse_aligned_in_place(
+                                &mut words, file_size,
+                            );
+                        #[cfg(not(feature = "aarch64_virtualize_x18"))]
+                        let metadata = litebox_syscall_rewriter::aarch64::ElfCodeMetadata::parse_executable_in_place(
+                                &mut words, file_size,
+                            );
+                        metadata.ok()
                     }
                     _ => None,
                 }
@@ -906,7 +911,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             runtime_patches_committed: false,
             #[cfg(target_arch = "aarch64")]
             trampoline_invalidated: false,
-            #[cfg(all(target_arch = "aarch64", feature = "aarch64_virtualize_x18"))]
+            #[cfg(target_arch = "aarch64")]
             code_metadata,
             file_mappings: BTreeSet::new(),
             patched_ranges: BTreeSet::new(),
@@ -1210,15 +1215,13 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
 
         // ── Runtime patching path (unpatched binaries) ───────────────
 
-        #[cfg(all(target_arch = "aarch64", feature = "aarch64_virtualize_x18"))]
+        #[cfg(target_arch = "aarch64")]
         let scan_ranges = file_offset.and_then(|file_offset| {
             state
                 .code_metadata
                 .as_ref()
                 .and_then(|metadata| metadata.ranges_for_mapping(file_offset as u64, len).ok())
         });
-        #[cfg(all(target_arch = "aarch64", not(feature = "aarch64_virtualize_x18")))]
-        let scan_ranges: Option<litebox_syscall_rewriter::aarch64::CodeScanRanges> = None;
         #[cfg(target_arch = "aarch64")]
         let apply_trap_fallback = |mapped_addr, len, already_rw| {
             self.apply_aarch64_trap_fallback(mapped_addr, len, already_rw, scan_ranges.as_ref());

--- a/litebox_syscall_rewriter/Cargo.toml
+++ b/litebox_syscall_rewriter/Cargo.toml
@@ -10,6 +10,7 @@ anyhow = ["dep:anyhow"]
 clap = ["dep:clap"]
 
 [dependencies]
+gimli = { version = "0.32", default-features = false, features = ["read-core"] }
 iced-x86 = { version = "1.21", default-features = false, features = ["no_std", "decoder", "encoder", "instr_info"] }
 litebox_common_windows = { path = "../litebox_common_windows/", version = "0.1.0" }
 object = { version = "0.36.7", default-features = false, features = ["elf", "pe", "read_core"] }

--- a/litebox_syscall_rewriter/src/aarch64.rs
+++ b/litebox_syscall_rewriter/src/aarch64.rs
@@ -111,12 +111,44 @@
 
 use alloc::format;
 use alloc::vec::Vec;
+use core::ops::Range;
 use yaxpeax_arch::{Decoder, U8Reader};
 use yaxpeax_arm::armv8::a64::{
     InstDecoder, Instruction as DecodedInstruction, Opcode as DecodedOpcode, Operand,
 };
 
 use crate::{Error, Result, TextSectionInfo, checked_add_u64};
+
+#[derive(Clone, Copy)]
+pub(crate) struct ScanSections<'a> {
+    pub(crate) executable: &'a [TextSectionInfo],
+    pub(crate) code: &'a [TextSectionInfo],
+}
+
+/// Mapping-relative ranges used by AArch64 patch-site scanning.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CodeScanRanges {
+    pub(crate) executable: Vec<Range<usize>>,
+    pub(crate) identified: Vec<Range<usize>>,
+}
+
+impl CodeScanRanges {
+    /// Mapping-relative executable ranges.
+    pub fn executable(&self) -> &[Range<usize>] {
+        &self.executable
+    }
+
+    /// Mapping-relative ranges positively identified as code.
+    pub fn identified(&self) -> &[Range<usize>] {
+        &self.identified
+    }
+}
+
+/// Owned AArch64 ELF code metadata, independent of the parsed ELF buffer.
+pub struct ElfCodeMetadata {
+    pub(crate) executable: Vec<TextSectionInfo>,
+    pub(crate) identified: Vec<TextSectionInfo>,
+}
 
 // ============================================================
 // Constants

--- a/litebox_syscall_rewriter/src/aarch64.rs
+++ b/litebox_syscall_rewriter/src/aarch64.rs
@@ -2150,7 +2150,7 @@ enum PatchKind {
 ///
 /// `MRS XZR, TPIDR_EL0` is a discarded read (register 31 as an `LDR` base would
 /// mean `SP`), so it is left native; every other `MRS Xd, TPIDR_EL0` is gated.
-#[cfg(any(test, target_arch = "aarch64"))]
+#[cfg(test)]
 fn find_patch_sites(
     sections: &[TextSectionInfo],
     buf: &[u8],
@@ -2335,7 +2335,7 @@ pub(crate) struct HookOutcome {
 /// whose gate cannot branch back, is replaced with a trap and listed in
 /// [`HookOutcome::trapped_sites`] so the caller can reject the incomplete
 /// rewrite, mirroring the x86-64 unpatchable-syscall path.
-#[cfg(any(test, target_arch = "aarch64"))]
+#[cfg(test)]
 pub(crate) fn hook_syscalls_aarch64(
     buf: &mut [u8],
     text_sections: &[TextSectionInfo],
@@ -2487,13 +2487,13 @@ fn trap_site(buf: &mut [u8], file_offset: usize) {
 ///
 /// The `cfg` tracks reachability, not capability: the scan and the rewrite are
 /// host-agnostic, but nothing calls this in an x86-64 build.
-#[cfg(any(test, target_arch = "aarch64"))]
-pub(crate) fn trap_all_patch_sites(
+pub(crate) fn trap_all_patch_sites_with_code_ranges(
     buf: &mut [u8],
-    text_sections: &[TextSectionInfo],
+    executable_sections: &[TextSectionInfo],
+    code_sections: &[TextSectionInfo],
     config: RewriteConfig,
 ) -> Result<usize> {
-    let sites = find_patch_sites(text_sections, buf, config)?;
+    let sites = find_patch_sites_with_code_ranges(executable_sections, code_sections, buf, config)?;
     for site in &sites {
         trap_site(buf, site.file_offset);
     }

--- a/litebox_syscall_rewriter/src/aarch64.rs
+++ b/litebox_syscall_rewriter/src/aarch64.rs
@@ -195,6 +195,16 @@ impl ElfCodeMetadata {
             identified: project_file_ranges(&self.identified, file_offset, mapping_len)?,
         })
     }
+
+    /// Total executable and identified-code bytes represented by this metadata.
+    pub fn coverage_bytes(&self) -> (u64, u64) {
+        let total = |ranges: &[TextSectionInfo]| {
+            ranges
+                .iter()
+                .fold(0u64, |total, range| total.saturating_add(range.size))
+        };
+        (total(&self.executable), total(&self.identified))
+    }
 }
 
 pub(crate) fn elf_code_metadata(
@@ -252,14 +262,13 @@ fn code_sections(file: &object::File<'_>, executable: &[TextSectionInfo]) -> Vec
 
     if let Some(section) = file.section_by_name(".eh_frame")
         && let Ok(data) = section.uncompressed_data()
-        && let Some(eh_frame_ranges) = eh_frame_ranges(
+    {
+        ranges.extend(eh_frame_ranges(
             &data,
             section.address(),
             file.section_by_name(".text").map(|text| text.address()),
             file.section_by_name(".got").map(|got| got.address()),
-        )
-    {
-        ranges.extend(eh_frame_ranges);
+        ));
     }
 
     let has_function_metadata = !ranges_to_sections(ranges.clone(), executable).is_empty();
@@ -286,7 +295,7 @@ fn eh_frame_ranges(
     eh_frame_address: u64,
     text_address: Option<u64>,
     got_address: Option<u64>,
-) -> Option<Vec<(u64, u64)>> {
+) -> Vec<(u64, u64)> {
     let mut section = gimli::EhFrame::new(data, gimli::LittleEndian);
     section.set_address_size(8);
     let mut bases = gimli::BaseAddresses::default().set_eh_frame(eh_frame_address);
@@ -299,14 +308,12 @@ fn eh_frame_ranges(
     let mut entries = gimli::UnwindSection::entries(&section, &bases);
     let mut ranges = Vec::new();
     loop {
-        let entry = match entries.next() {
-            Ok(Some(entry)) => entry,
-            Ok(None) => return Some(ranges),
-            Err(_) => return None,
+        let Ok(Some(entry)) = entries.next() else {
+            return ranges;
         };
         if let gimli::CieOrFde::Fde(partial) = entry {
             let Ok(fde) = partial.parse(gimli::UnwindSection::cie_from_offset) else {
-                return None;
+                continue;
             };
             if fde.len() != 0
                 && let Some(end) = fde.initial_address().checked_add(fde.len())

--- a/litebox_syscall_rewriter/src/aarch64.rs
+++ b/litebox_syscall_rewriter/src/aarch64.rs
@@ -1725,7 +1725,7 @@ const LDR_LITERAL_SHAPE_MASK: u32 = 0xFF00_001F;
 /// fields zeroed. An encoder selects a variant and ORs in its operands via
 /// [`Opcode::bits`]. (`MRS TPIDR_EL0` is encoded from [`Opcode::MrsTpidrEl0`],
 /// whose bits equal [`MRS_TPIDR_EL0_BITS`] — the scan-detection pattern in
-/// [`find_patch_sites`].)
+/// [`find_patch_sites_with_code_ranges`].)
 #[repr(u32)]
 #[derive(Clone, Copy)]
 enum Opcode {

--- a/litebox_syscall_rewriter/src/aarch64.rs
+++ b/litebox_syscall_rewriter/src/aarch64.rs
@@ -110,14 +110,20 @@
 //! traps during runtime rewriting.
 
 use alloc::format;
+use alloc::string::ToString as _;
 use alloc::vec::Vec;
 use core::ops::Range;
+use object::read::{Object as _, ObjectSection as _, ObjectSymbol as _};
 use yaxpeax_arch::{Decoder, U8Reader};
 use yaxpeax_arm::armv8::a64::{
     InstDecoder, Instruction as DecodedInstruction, Opcode as DecodedOpcode, Operand,
 };
+use zerocopy::IntoBytes as _;
 
-use crate::{Error, Result, TextSectionInfo, checked_add_u64};
+use crate::{
+    Error, InternalError, Result, TextSectionInfo, checked_add_u64, fixup_phdr_alignment,
+    text_sections,
+};
 
 #[derive(Clone, Copy)]
 pub(crate) struct ScanSections<'a> {
@@ -148,6 +154,211 @@ impl CodeScanRanges {
 pub struct ElfCodeMetadata {
     pub(crate) executable: Vec<TextSectionInfo>,
     pub(crate) identified: Vec<TextSectionInfo>,
+}
+
+impl ElfCodeMetadata {
+    /// Parse an ELF image in aligned storage, relocating an unaligned program
+    /// header table within that storage if required by the object parser.
+    pub fn parse_aligned_in_place(aligned: &mut [u64], byte_len: usize) -> Result<Self> {
+        let bytes = aligned.as_mut_bytes();
+        if byte_len > bytes.len() {
+            return Err(Error::ParseError(
+                "aligned ELF byte length exceeds storage".into(),
+            ));
+        }
+        fixup_phdr_alignment(&mut bytes[..byte_len]);
+        let file = object::File::parse(&bytes[..byte_len])
+            .map_err(|error| Error::ParseError(error.to_string()))?;
+        if file.architecture() != object::Architecture::Aarch64 {
+            return Err(Error::UnsupportedExecutable(
+                "code metadata requires an AArch64 ELF".into(),
+            ));
+        }
+        match elf_code_metadata(&file) {
+            Ok(metadata) => Ok(metadata),
+            Err(InternalError::Public(error)) => Err(error),
+            Err(InternalError::NoTextSectionFound) => Err(Error::UnsupportedExecutable(
+                "AArch64 ELF has no executable code ranges".into(),
+            )),
+            Err(error) => unreachable!("unexpected metadata error: {error:?}"),
+        }
+    }
+
+    /// Project ELF file ranges into one file-backed mapping.
+    pub fn ranges_for_mapping(
+        &self,
+        file_offset: u64,
+        mapping_len: usize,
+    ) -> Result<CodeScanRanges> {
+        Ok(CodeScanRanges {
+            executable: project_file_ranges(&self.executable, file_offset, mapping_len)?,
+            identified: project_file_ranges(&self.identified, file_offset, mapping_len)?,
+        })
+    }
+}
+
+pub(crate) fn elf_code_metadata(
+    file: &object::File<'_>,
+) -> core::result::Result<ElfCodeMetadata, InternalError> {
+    let executable = text_sections(file)?;
+    let identified = code_sections(file, &executable);
+    Ok(ElfCodeMetadata {
+        executable,
+        identified,
+    })
+}
+
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "the crate requires 64-bit pointers"
+)]
+fn project_file_ranges(
+    ranges: &[TextSectionInfo],
+    mapping_file_offset: u64,
+    mapping_len: usize,
+) -> Result<Vec<Range<usize>>> {
+    let mapping_end = mapping_file_offset
+        .checked_add(mapping_len as u64)
+        .ok_or_else(|| Error::AddressOverflow("mapping file range".into()))?;
+    let mut projected = Vec::new();
+    for range in ranges {
+        let range_end = range
+            .file_offset
+            .checked_add(range.size)
+            .ok_or_else(|| Error::AddressOverflow("ELF code file range".into()))?;
+        let start = range.file_offset.max(mapping_file_offset);
+        let end = range_end.min(mapping_end);
+        if start < end {
+            projected
+                .push((start - mapping_file_offset) as usize..(end - mapping_file_offset) as usize);
+        }
+    }
+    Ok(projected)
+}
+
+/// Builds ranges where metadata positively identifies AArch64 code. Executable
+/// bytes outside these ranges remain eligible for exact mandatory-site scans,
+/// but not heuristic x18 classification.
+fn code_sections(file: &object::File<'_>, executable: &[TextSectionInfo]) -> Vec<TextSectionInfo> {
+    let mut ranges = Vec::new();
+    for symbol in file.symbols().chain(file.dynamic_symbols()) {
+        if symbol.kind() == object::SymbolKind::Text
+            && symbol.size() != 0
+            && let Some(end) = symbol.address().checked_add(symbol.size())
+        {
+            ranges.push((symbol.address(), end));
+        }
+    }
+
+    if let Some(section) = file.section_by_name(".eh_frame")
+        && let Ok(data) = section.uncompressed_data()
+        && let Some(eh_frame_ranges) = eh_frame_ranges(
+            &data,
+            section.address(),
+            file.section_by_name(".text").map(|text| text.address()),
+            file.section_by_name(".got").map(|got| got.address()),
+        )
+    {
+        ranges.extend(eh_frame_ranges);
+    }
+
+    let has_function_metadata = !ranges_to_sections(ranges.clone(), executable).is_empty();
+    if !has_function_metadata {
+        return executable.to_vec();
+    }
+
+    for section in file.sections() {
+        let Ok(name) = section.name() else {
+            continue;
+        };
+        if (matches!(name, ".init" | ".fini" | ".plt" | ".iplt") || name.starts_with(".plt."))
+            && let Some(end) = section.address().checked_add(section.size())
+        {
+            ranges.push((section.address(), end));
+        }
+    }
+
+    ranges_to_sections(ranges, executable)
+}
+
+fn eh_frame_ranges(
+    data: &[u8],
+    eh_frame_address: u64,
+    text_address: Option<u64>,
+    got_address: Option<u64>,
+) -> Option<Vec<(u64, u64)>> {
+    let mut section = gimli::EhFrame::new(data, gimli::LittleEndian);
+    section.set_address_size(8);
+    let mut bases = gimli::BaseAddresses::default().set_eh_frame(eh_frame_address);
+    if let Some(text_address) = text_address {
+        bases = bases.set_text(text_address);
+    }
+    if let Some(got_address) = got_address {
+        bases = bases.set_got(got_address);
+    }
+    let mut entries = gimli::UnwindSection::entries(&section, &bases);
+    let mut ranges = Vec::new();
+    loop {
+        let entry = match entries.next() {
+            Ok(Some(entry)) => entry,
+            Ok(None) => return Some(ranges),
+            Err(_) => return None,
+        };
+        if let gimli::CieOrFde::Fde(partial) = entry {
+            let Ok(fde) = partial.parse(gimli::UnwindSection::cie_from_offset) else {
+                return None;
+            };
+            if fde.len() != 0
+                && let Some(end) = fde.initial_address().checked_add(fde.len())
+            {
+                ranges.push((fde.initial_address(), end));
+            }
+        }
+    }
+}
+
+fn ranges_to_sections(
+    ranges: Vec<(u64, u64)>,
+    executable: &[TextSectionInfo],
+) -> Vec<TextSectionInfo> {
+    let mut clipped = Vec::new();
+    for (start, end) in ranges {
+        for section in executable {
+            let section_end = section.vaddr.saturating_add(section.size);
+            let start = start
+                .max(section.vaddr)
+                .checked_add(3)
+                .map_or(u64::MAX, |start| start & !3);
+            let end = end.min(section_end) & !3;
+            if start < end {
+                clipped.push((start, end, section));
+            }
+        }
+    }
+    clipped.sort_unstable_by_key(|(start, _, _)| *start);
+
+    let mut code: Vec<TextSectionInfo> = Vec::new();
+    for (start, end, section) in clipped {
+        if let Some(previous) = code.last_mut()
+            && start >= previous.vaddr
+            && previous.vaddr.saturating_add(previous.size) >= start
+            && previous.file_offset.saturating_add(start - previous.vaddr)
+                == section.file_offset.saturating_add(start - section.vaddr)
+        {
+            previous.size = end
+                .max(previous.vaddr.saturating_add(previous.size))
+                .saturating_sub(previous.vaddr);
+            continue;
+        }
+        code.push(TextSectionInfo {
+            vaddr: start,
+            file_offset: section
+                .file_offset
+                .saturating_add(start.saturating_sub(section.vaddr)),
+            size: end - start,
+        });
+    }
+    code
 }
 
 // ============================================================
@@ -5026,6 +5237,25 @@ mod tests {
         assert_eq!(sites.len(), 1);
         assert_eq!(sites[0].vaddr, 0x1000);
         assert_eq!(sites[0].kind, PatchKind::Svc);
+    }
+
+    #[test]
+    fn metadata_ranges_are_clipped_aligned_and_merged() {
+        let executable = [TextSectionInfo {
+            vaddr: 0x1000,
+            file_offset: 0x200,
+            size: 0x20,
+        }];
+
+        let ranges = ranges_to_sections(
+            vec![(0x0fff, 0x1006), (0x1004, 0x100d), (0x101e, 0x1024)],
+            &executable,
+        );
+
+        assert_eq!(ranges.len(), 1);
+        assert_eq!(ranges[0].vaddr, 0x1000);
+        assert_eq!(ranges[0].file_offset, 0x200);
+        assert_eq!(ranges[0].size, 0xc);
     }
 
     #[test]

--- a/litebox_syscall_rewriter/src/aarch64.rs
+++ b/litebox_syscall_rewriter/src/aarch64.rs
@@ -2150,14 +2150,24 @@ enum PatchKind {
 ///
 /// `MRS XZR, TPIDR_EL0` is a discarded read (register 31 as an `LDR` base would
 /// mean `SP`), so it is left native; every other `MRS Xd, TPIDR_EL0` is gated.
+#[cfg(any(test, target_arch = "aarch64"))]
 fn find_patch_sites(
     sections: &[TextSectionInfo],
     buf: &[u8],
     config: RewriteConfig,
 ) -> Result<Vec<PatchSite>> {
+    find_patch_sites_with_code_ranges(sections, sections, buf, config)
+}
+
+fn find_patch_sites_with_code_ranges(
+    executable_sections: &[TextSectionInfo],
+    code_sections: &[TextSectionInfo],
+    buf: &[u8],
+    config: RewriteConfig,
+) -> Result<Vec<PatchSite>> {
     let mut sites = Vec::new();
 
-    for section in sections {
+    for section in executable_sections {
         let start = usize::try_from(section.file_offset)
             .map_err(|_| Error::ParseError("section file offset too large".into()))?;
         let size = usize::try_from(section.size)
@@ -2179,18 +2189,38 @@ fn find_patch_sites(
         }
         let section_data = &buf[start..end];
         let mut inside_exclusive_sequence = false;
+        let mut was_known_code = false;
+        let mut code_index = 0;
 
         for i in (0..section_data.len()).step_by(INSN_BYTES) {
             if i + INSN_BYTES > section_data.len() {
                 break;
             }
             let insn = u32::from_le_bytes(section_data[i..i + INSN_BYTES].try_into().unwrap());
-            let exclusive_boundary = exclusive_boundary(insn);
-            if exclusive_boundary == Some(ExclusiveBoundary::Load) {
-                inside_exclusive_sequence = true;
-            } else if exclusive_boundary == Some(ExclusiveBoundary::Store) {
+            let vaddr = checked_add_u64(section.vaddr, i as u64, "patch site")?;
+            while code_index < code_sections.len()
+                && code_sections[code_index]
+                    .vaddr
+                    .saturating_add(code_sections[code_index].size)
+                    <= vaddr
+            {
+                code_index += 1;
+            }
+            let known_code = code_sections.get(code_index).is_some_and(|code| {
+                vaddr >= code.vaddr && vaddr < code.vaddr.saturating_add(code.size)
+            });
+            if !known_code || !was_known_code {
                 inside_exclusive_sequence = false;
             }
+            if known_code {
+                let exclusive_boundary = exclusive_boundary(insn);
+                if exclusive_boundary == Some(ExclusiveBoundary::Load) {
+                    inside_exclusive_sequence = true;
+                } else if exclusive_boundary == Some(ExclusiveBoundary::Store) {
+                    inside_exclusive_sequence = false;
+                }
+            }
+            was_known_code = known_code;
             let kind = if (insn & SVC_OPCODE_MASK) == SVC_OPCODE_BITS {
                 if config.host != Host::Linux {
                     return Err(Error::UnsupportedExecutable(format!(
@@ -2235,8 +2265,7 @@ fn find_patch_sites(
                 } else {
                     PatchKind::MrsTpidr(rd)
                 }
-            } else if config.virtualize_x18 {
-                let vaddr = checked_add_u64(section.vaddr, i as u64, "x18 site")?;
+            } else if config.virtualize_x18 && known_code {
                 if let Some(branch) = classify_x18_conditional_branch(insn, vaddr) {
                     PatchKind::X18CompareBranch(branch)
                 } else if let Some(adr) = classify_adr_x18(insn, vaddr) {
@@ -2265,7 +2294,7 @@ fn find_patch_sites(
             }
             sites.push(PatchSite {
                 file_offset: start + i,
-                vaddr: checked_add_u64(section.vaddr, i as u64, "patch site")?,
+                vaddr,
                 kind,
             });
         }
@@ -2306,9 +2335,28 @@ pub(crate) struct HookOutcome {
 /// whose gate cannot branch back, is replaced with a trap and listed in
 /// [`HookOutcome::trapped_sites`] so the caller can reject the incomplete
 /// rewrite, mirroring the x86-64 unpatchable-syscall path.
+#[cfg(any(test, target_arch = "aarch64"))]
 pub(crate) fn hook_syscalls_aarch64(
     buf: &mut [u8],
     text_sections: &[TextSectionInfo],
+    trampoline_base_addr: u64,
+    callback: u64,
+    config: RewriteConfig,
+) -> Result<Option<HookOutcome>> {
+    hook_syscalls_aarch64_with_code_ranges(
+        buf,
+        text_sections,
+        text_sections,
+        trampoline_base_addr,
+        callback,
+        config,
+    )
+}
+
+pub(crate) fn hook_syscalls_aarch64_with_code_ranges(
+    buf: &mut [u8],
+    executable_sections: &[TextSectionInfo],
+    code_sections: &[TextSectionInfo],
     trampoline_base_addr: u64,
     callback: u64,
     config: RewriteConfig,
@@ -2318,7 +2366,7 @@ pub(crate) fn hook_syscalls_aarch64(
             "AArch64 trampoline base {trampoline_base_addr:#x} is not {GATE_ALIGNMENT}-byte aligned"
         )));
     }
-    let sites = find_patch_sites(text_sections, buf, config)?;
+    let sites = find_patch_sites_with_code_ranges(executable_sections, code_sections, buf, config)?;
 
     if sites.is_empty() {
         // No patch sites: nothing to redirect, so no trampoline is
@@ -4924,6 +4972,28 @@ mod tests {
             outcome.trampoline.len(),
             GATES_START_OFFSET + MSR_GATE_SIZE + MRS_GATE_SIZE
         );
+    }
+
+    #[test]
+    fn unknown_executable_bytes_scan_mandatory_sites_but_not_heuristic_x18() {
+        let words: [u32; 2] = [0xd400_0001, 0x5d56_4f48];
+        let bytes = words
+            .iter()
+            .flat_map(|word| word.to_le_bytes())
+            .collect::<Vec<_>>();
+        let executable = [TextSectionInfo {
+            vaddr: 0x1000,
+            file_offset: 0,
+            size: bytes.len() as u64,
+        }];
+
+        let sites =
+            find_patch_sites_with_code_ranges(&executable, &[], &bytes, x18_config(Host::Linux))
+                .unwrap();
+
+        assert_eq!(sites.len(), 1);
+        assert_eq!(sites[0].vaddr, 0x1000);
+        assert_eq!(sites[0].kind, PatchKind::Svc);
     }
 
     #[test]

--- a/litebox_syscall_rewriter/src/lib.rs
+++ b/litebox_syscall_rewriter/src/lib.rs
@@ -219,28 +219,12 @@ impl aarch64::ElfCodeMetadata {
     /// Parse an ELF image in aligned storage, relocating an unaligned program
     /// header table within that storage if required by the object parser.
     pub fn parse_aligned_in_place(aligned: &mut [u64], byte_len: usize) -> Result<Self> {
-        let bytes = aligned.as_mut_bytes();
-        if byte_len > bytes.len() {
-            return Err(Error::ParseError(
-                "aligned ELF byte length exceeds storage".into(),
-            ));
-        }
-        fixup_phdr_alignment(&mut bytes[..byte_len]);
-        let file = object::File::parse(&bytes[..byte_len])
-            .map_err(|error| Error::ParseError(error.to_string()))?;
-        if file.architecture() != object::Architecture::Aarch64 {
-            return Err(Error::UnsupportedExecutable(
-                "code metadata requires an AArch64 ELF".into(),
-            ));
-        }
-        match aarch64_elf_code_metadata(&file) {
-            Ok(metadata) => Ok(metadata),
-            Err(InternalError::Public(error)) => Err(error),
-            Err(InternalError::NoTextSectionFound) => Err(Error::UnsupportedExecutable(
-                "AArch64 ELF has no executable code ranges".into(),
-            )),
-            Err(error) => unreachable!("unexpected metadata error: {error:?}"),
-        }
+        parse_aarch64_metadata_in_place(aligned, byte_len, true)
+    }
+
+    /// Parse only executable ELF section ranges, without symbols or unwind data.
+    pub fn parse_executable_in_place(aligned: &mut [u64], byte_len: usize) -> Result<Self> {
+        parse_aarch64_metadata_in_place(aligned, byte_len, false)
     }
 
     /// Project ELF file ranges into one file-backed mapping.
@@ -253,6 +237,35 @@ impl aarch64::ElfCodeMetadata {
             executable: project_file_ranges(&self.executable, file_offset, mapping_len)?,
             identified: project_file_ranges(&self.identified, file_offset, mapping_len)?,
         })
+    }
+}
+
+fn parse_aarch64_metadata_in_place(
+    aligned: &mut [u64],
+    byte_len: usize,
+    identify_code: bool,
+) -> Result<aarch64::ElfCodeMetadata> {
+    let bytes = aligned.as_mut_bytes();
+    if byte_len > bytes.len() {
+        return Err(Error::ParseError(
+            "aligned ELF byte length exceeds storage".into(),
+        ));
+    }
+    fixup_phdr_alignment(&mut bytes[..byte_len]);
+    let file = object::File::parse(&bytes[..byte_len])
+        .map_err(|error| Error::ParseError(error.to_string()))?;
+    if file.architecture() != object::Architecture::Aarch64 {
+        return Err(Error::UnsupportedExecutable(
+            "code metadata requires an AArch64 ELF".into(),
+        ));
+    }
+    match aarch64_elf_code_metadata(&file, identify_code) {
+        Ok(metadata) => Ok(metadata),
+        Err(InternalError::Public(error)) => Err(error),
+        Err(InternalError::NoTextSectionFound) => Err(Error::UnsupportedExecutable(
+            "AArch64 ELF has no executable code ranges".into(),
+        )),
+        Err(error) => unreachable!("unexpected metadata error: {error:?}"),
     }
 }
 
@@ -378,7 +391,7 @@ pub fn hook_syscalls_in_elf_with_options(
         };
 
         let (text_sections, aarch64_code_sections) = if arch == Arch::Aarch64 {
-            let metadata = match aarch64_elf_code_metadata(&file) {
+            let metadata = match aarch64_elf_code_metadata(&file, true) {
                 Ok(metadata) => metadata,
                 Err(InternalError::NoTextSectionFound) => return Ok(input_binary.to_vec()),
                 Err(InternalError::Public(error)) => return Err(error),
@@ -1090,9 +1103,14 @@ fn text_sections(
 
 fn aarch64_elf_code_metadata(
     file: &object::File<'_>,
+    identify_code: bool,
 ) -> core::result::Result<aarch64::ElfCodeMetadata, InternalError> {
     let executable = text_sections(file)?;
-    let identified = aarch64_code_sections(file, &executable);
+    let identified = if identify_code {
+        aarch64_code_sections(file, &executable)
+    } else {
+        Vec::new()
+    };
     Ok(aarch64::ElfCodeMetadata {
         executable,
         identified,

--- a/litebox_syscall_rewriter/src/lib.rs
+++ b/litebox_syscall_rewriter/src/lib.rs
@@ -64,7 +64,7 @@ use alloc::vec::Vec;
 use litebox_common_windows::NtSysno;
 use object::pe::{IMAGE_SCN_CNT_CODE, IMAGE_SCN_MEM_EXECUTE};
 use object::read::pe::{ImageNtHeaders as _, ImageOptionalHeader as _, PeFile64};
-use object::read::{Object as _, ObjectSection as _, ObjectSegment as _};
+use object::read::{Object as _, ObjectSection as _, ObjectSegment as _, ObjectSymbol as _};
 use thiserror::Error;
 use zerocopy::{FromBytes, Immutable, IntoBytes};
 
@@ -204,6 +204,7 @@ struct TrampolineHeader64 {
 }
 
 /// Metadata about an executable section, extracted from a read-only object parse.
+#[derive(Clone, Copy)]
 struct TextSectionInfo {
     /// Virtual address of the section
     vaddr: u64,
@@ -211,6 +212,12 @@ struct TextSectionInfo {
     file_offset: u64,
     /// Size of the section data in bytes
     size: u64,
+}
+
+#[derive(Clone, Copy)]
+struct Aarch64ScanSections<'a> {
+    executable: &'a [TextSectionInfo],
+    code: &'a [TextSectionInfo],
 }
 
 struct SyscallPatchResult {
@@ -322,7 +329,7 @@ pub fn hook_syscalls_in_elf_with_options(
     fixup_phdr_alignment(buf);
 
     // Parse the ELF and extract all metadata we need, then drop the borrow so we can mutate buf.
-    let (arch, text_sections, placement) = {
+    let (arch, text_sections, aarch64_code_sections, placement) = {
         let file = object::File::parse(&*buf).map_err(|e| Error::ParseError(e.to_string()))?;
 
         let arch = match file {
@@ -334,11 +341,24 @@ pub fn hook_syscalls_in_elf_with_options(
             _ => return Ok(input_binary.to_vec()),
         };
 
-        let text_sections = match text_sections(&file) {
+        let executable_sections = match if arch == Arch::Aarch64 {
+            text_sections(&file).or_else(|error| match error {
+                InternalError::NoTextSectionFound => aarch64_executable_segments(&file),
+                other => Err(other),
+            })
+        } else {
+            text_sections(&file)
+        } {
             Ok(sections) => sections,
             Err(InternalError::NoTextSectionFound) => return Ok(input_binary.to_vec()),
             Err(InternalError::Public(e)) => return Err(e),
             Err(e) => unreachable!("unexpected internal error: {e:?}"),
+        };
+        let (text_sections, aarch64_code_sections) = if arch == Arch::Aarch64 {
+            let code = aarch64_code_sections(&file, &executable_sections);
+            (executable_sections, code)
+        } else {
+            (executable_sections, Vec::new())
         };
 
         if is_already_hooked(&*buf, arch) {
@@ -347,7 +367,7 @@ pub fn hook_syscalls_in_elf_with_options(
 
         let placement = find_addr_for_trampoline_code(&file)?;
 
-        (arch, text_sections, placement)
+        (arch, text_sections, aarch64_code_sections, placement)
     };
 
     // AArch64 uses a fully separate rewriting strategy (single-instruction
@@ -358,7 +378,10 @@ pub fn hook_syscalls_in_elf_with_options(
         return hook_aarch64_elf(
             input_binary,
             buf,
-            &text_sections,
+            Aarch64ScanSections {
+                executable: &text_sections,
+                code: &aarch64_code_sections,
+            },
             placement,
             trampoline.unwrap_or(0),
             options,
@@ -888,7 +911,7 @@ fn append_trampoline_footer(
 fn hook_aarch64_elf(
     input_binary: &[u8],
     buf: &mut [u8],
-    text_sections: &[TextSectionInfo],
+    sections: Aarch64ScanSections<'_>,
     placement: TrampolinePlacement,
     callback: u64,
     options: RewriteOptions,
@@ -898,7 +921,7 @@ fn hook_aarch64_elf(
         let out = hook_aarch64_elf_at(
             input_binary,
             &mut attempt,
-            text_sections,
+            sections,
             addr,
             Some(limit),
             callback,
@@ -921,7 +944,7 @@ fn hook_aarch64_elf(
     hook_aarch64_elf_at(
         input_binary,
         buf,
-        text_sections,
+        sections,
         placement.fallback_addr(),
         None,
         callback,
@@ -946,15 +969,16 @@ fn hook_aarch64_elf(
 fn hook_aarch64_elf_at(
     input_binary: &[u8],
     buf: &mut [u8],
-    text_sections: &[TextSectionInfo],
+    sections: Aarch64ScanSections<'_>,
     trampoline_base_addr: u64,
     trampoline_limit: Option<u64>,
     callback: u64,
     options: RewriteOptions,
 ) -> Result<Vec<u8>> {
-    let Some(outcome) = aarch64::hook_syscalls_aarch64(
+    let Some(outcome) = aarch64::hook_syscalls_aarch64_with_code_ranges(
         buf,
-        text_sections,
+        sections.executable,
+        sections.code,
         trampoline_base_addr,
         callback,
         aarch64::RewriteConfig::new(options.target_host(), options.effective_virtualize_x18()),
@@ -1028,6 +1052,165 @@ fn text_sections(
         return Err(InternalError::NoTextSectionFound);
     }
     Ok(text_sections)
+}
+
+/// Returns executable load segments only as a fallback for AArch64 ELFs whose
+/// section table is absent. When executable sections exist, scanning them avoids
+/// treating unrelated headers, metadata, or padding in an RX segment as code.
+fn aarch64_executable_segments(
+    file: &object::File<'_>,
+) -> core::result::Result<Vec<TextSectionInfo>, InternalError> {
+    let mut segments: Vec<_> = file
+        .segments()
+        .filter_map(|segment| {
+            let object::SegmentFlags::Elf { p_flags } = segment.flags() else {
+                return None;
+            };
+            if p_flags & object::elf::PF_X == 0 {
+                return None;
+            }
+            let (file_offset, size) = segment.file_range();
+            Some(TextSectionInfo {
+                vaddr: segment.address(),
+                file_offset,
+                size,
+            })
+        })
+        .collect();
+    segments.sort_unstable_by_key(|segment| segment.vaddr);
+    if segments.is_empty() {
+        return Err(InternalError::NoTextSectionFound);
+    }
+    Ok(segments)
+}
+
+/// Builds ranges where metadata positively identifies AArch64 code. Executable
+/// bytes outside these ranges remain eligible for exact mandatory-site scans,
+/// but not heuristic x18 classification.
+fn aarch64_code_sections(
+    file: &object::File<'_>,
+    executable: &[TextSectionInfo],
+) -> Vec<TextSectionInfo> {
+    let mut ranges = Vec::new();
+    for symbol in file.symbols().chain(file.dynamic_symbols()) {
+        if symbol.kind() == object::SymbolKind::Text
+            && symbol.size() != 0
+            && let Some(end) = symbol.address().checked_add(symbol.size())
+        {
+            ranges.push((symbol.address(), end));
+        }
+    }
+
+    if let Some(section) = file.section_by_name(".eh_frame")
+        && let Ok(data) = section.uncompressed_data()
+    {
+        ranges.extend(eh_frame_ranges(
+            &data,
+            section.address(),
+            file.section_by_name(".text").map(|text| text.address()),
+            file.section_by_name(".got").map(|got| got.address()),
+        ));
+    }
+
+    let has_function_metadata = !aarch64_ranges_to_sections(ranges.clone(), executable).is_empty();
+
+    for section in file.sections() {
+        let Ok(name) = section.name() else {
+            continue;
+        };
+        if (matches!(name, ".init" | ".fini" | ".plt" | ".iplt") || name.starts_with(".plt."))
+            && let Some(end) = section.address().checked_add(section.size())
+        {
+            ranges.push((section.address(), end));
+        }
+    }
+
+    if !has_function_metadata
+        && let Some(text) = file.section_by_name(".text")
+        && let Some(end) = text.address().checked_add(text.size())
+    {
+        ranges.push((text.address(), end));
+    }
+
+    aarch64_ranges_to_sections(ranges, executable)
+}
+
+fn eh_frame_ranges(
+    data: &[u8],
+    eh_frame_address: u64,
+    text_address: Option<u64>,
+    got_address: Option<u64>,
+) -> Vec<(u64, u64)> {
+    let mut section = gimli::EhFrame::new(data, gimli::LittleEndian);
+    section.set_address_size(8);
+    let mut bases = gimli::BaseAddresses::default().set_eh_frame(eh_frame_address);
+    if let Some(text_address) = text_address {
+        bases = bases.set_text(text_address);
+    }
+    if let Some(got_address) = got_address {
+        bases = bases.set_got(got_address);
+    }
+    let mut entries = gimli::UnwindSection::entries(&section, &bases);
+    let mut ranges = Vec::new();
+    loop {
+        let Ok(Some(entry)) = entries.next() else {
+            return ranges;
+        };
+        if let gimli::CieOrFde::Fde(partial) = entry {
+            let Ok(fde) = partial.parse(gimli::UnwindSection::cie_from_offset) else {
+                return ranges;
+            };
+            if fde.len() != 0
+                && let Some(end) = fde.initial_address().checked_add(fde.len())
+            {
+                ranges.push((fde.initial_address(), end));
+            }
+        }
+    }
+}
+
+fn aarch64_ranges_to_sections(
+    ranges: Vec<(u64, u64)>,
+    executable: &[TextSectionInfo],
+) -> Vec<TextSectionInfo> {
+    let mut clipped = Vec::new();
+    for (start, end) in ranges {
+        for section in executable {
+            let section_end = section.vaddr.saturating_add(section.size);
+            let start = start
+                .max(section.vaddr)
+                .checked_add(3)
+                .map_or(u64::MAX, |start| start & !3);
+            let end = end.min(section_end) & !3;
+            if start < end {
+                clipped.push((start, end, section));
+            }
+        }
+    }
+    clipped.sort_unstable_by_key(|(start, _, _)| *start);
+
+    let mut code: Vec<TextSectionInfo> = Vec::new();
+    for (start, end, section) in clipped {
+        if let Some(previous) = code.last_mut()
+            && start >= previous.vaddr
+            && previous.vaddr.saturating_add(previous.size) >= start
+            && previous.file_offset.saturating_add(start - previous.vaddr)
+                == section.file_offset.saturating_add(start - section.vaddr)
+        {
+            previous.size = end
+                .max(previous.vaddr.saturating_add(previous.size))
+                .saturating_sub(previous.vaddr);
+            continue;
+        }
+        code.push(TextSectionInfo {
+            vaddr: start,
+            file_offset: section
+                .file_offset
+                .saturating_add(start.saturating_sub(section.vaddr)),
+            size: end - start,
+        });
+    }
+    code
 }
 
 /// Check if the binary is already hooked by looking for TRAMPOLINE_MAGIC at the end of the file.
@@ -2273,6 +2456,25 @@ fn hook_syscall_and_after(
 mod tests {
     use super::*;
 
+    #[test]
+    fn aarch64_ranges_are_clipped_aligned_and_merged() {
+        let executable = [TextSectionInfo {
+            vaddr: 0x1000,
+            file_offset: 0x200,
+            size: 0x20,
+        }];
+
+        let ranges = aarch64_ranges_to_sections(
+            vec![(0x0fff, 0x1006), (0x1004, 0x100d), (0x101e, 0x1024)],
+            &executable,
+        );
+
+        assert_eq!(ranges.len(), 1);
+        assert_eq!(ranges[0].vaddr, 0x1000);
+        assert_eq!(ranges[0].file_offset, 0x200);
+        assert_eq!(ranges[0].size, 0xc);
+    }
+
     fn seg(vaddr: u64, filesz: u64, memsz: u64, align: u64) -> LoadSegment {
         LoadSegment {
             vaddr,
@@ -2525,7 +2727,10 @@ mod tests {
         let out = hook_aarch64_elf_at(
             &input,
             &mut elf,
-            &[section],
+            Aarch64ScanSections {
+                executable: &[section],
+                code: &[section],
+            },
             0x220000,
             None,
             0,
@@ -2548,8 +2753,12 @@ mod tests {
         elf[..4].copy_from_slice(b"\x7fELF");
         elf[4] = object::elf::ELFCLASS64;
         elf[5] = object::elf::ELFDATA2LSB;
+        elf[6] = object::elf::EV_CURRENT;
+        elf[16..18].copy_from_slice(&object::elf::ET_EXEC.to_le_bytes());
         elf[18..20].copy_from_slice(&object::elf::EM_AARCH64.to_le_bytes());
+        elf[20..24].copy_from_slice(&u32::from(object::elf::EV_CURRENT).to_le_bytes());
         elf[32..40].copy_from_slice(&(ELF_HEADER_BYTES as u64).to_le_bytes());
+        elf[52..54].copy_from_slice(&u16::try_from(ELF_HEADER_BYTES).unwrap().to_le_bytes());
         elf[54..56].copy_from_slice(&u16::try_from(PROGRAM_HEADER_BYTES).unwrap().to_le_bytes());
         elf[56..58].copy_from_slice(&1u16.to_le_bytes());
 
@@ -2557,6 +2766,8 @@ mod tests {
         elf[text..text + 4].copy_from_slice(&object::elf::PT_LOAD.to_le_bytes());
         elf[text + 4..text + 8]
             .copy_from_slice(&(object::elf::PF_R | object::elf::PF_X).to_le_bytes());
+        elf[text + 8..text + 16]
+            .copy_from_slice(&((ELF_HEADER_BYTES + PROGRAM_HEADER_BYTES) as u64).to_le_bytes());
         elf[text + 16..text + 24].copy_from_slice(&0x1000u64.to_le_bytes());
         elf[text + 32..text + 40].copy_from_slice(&4u64.to_le_bytes());
         elf[text + 40..text + 48].copy_from_slice(&4u64.to_le_bytes());
@@ -2564,6 +2775,15 @@ mod tests {
 
         elf.extend(0xD400_0001u32.to_le_bytes());
         elf
+    }
+
+    #[test]
+    fn aarch64_sectionless_elf_still_rewrites_svc_from_executable_segment() {
+        let input = aarch64_elf_with_one_svc();
+        let output = hook_syscalls_in_elf(&input, None).unwrap();
+
+        let patched = u32::from_le_bytes(output[input.len() - 4..input.len()].try_into().unwrap());
+        assert_eq!(patched & 0xfc00_0000, 0x1400_0000);
     }
 
     /// A gap the gates cannot branch back from is retried at the fallback
@@ -2589,7 +2809,10 @@ mod tests {
                 hook_aarch64_elf_at(
                     &input,
                     &mut direct,
-                    &[section()],
+                    Aarch64ScanSections {
+                        executable: &[section()],
+                        code: &[section()],
+                    },
                     UNREACHABLE_GAP,
                     None,
                     0,
@@ -2609,7 +2832,10 @@ mod tests {
         hook_aarch64_elf(
             &input,
             &mut elf,
-            &[section()],
+            Aarch64ScanSections {
+                executable: &[section()],
+                code: &[section()],
+            },
             placement,
             0,
             RewriteOptions::default(),
@@ -2723,7 +2949,10 @@ mod tests {
         let err = hook_aarch64_elf(
             &input,
             &mut buf,
-            &sections,
+            Aarch64ScanSections {
+                executable: &sections,
+                code: &sections,
+            },
             placement,
             0,
             RewriteOptions::default(),

--- a/litebox_syscall_rewriter/src/lib.rs
+++ b/litebox_syscall_rewriter/src/lib.rs
@@ -65,7 +65,7 @@ use core::ops::Range;
 use litebox_common_windows::NtSysno;
 use object::pe::{IMAGE_SCN_CNT_CODE, IMAGE_SCN_MEM_EXECUTE};
 use object::read::pe::{ImageNtHeaders as _, ImageOptionalHeader as _, PeFile64};
-use object::read::{Object as _, ObjectSection as _, ObjectSegment as _, ObjectSymbol as _};
+use object::read::{Object as _, ObjectSection as _, ObjectSegment as _};
 use thiserror::Error;
 use zerocopy::{FromBytes, Immutable, IntoBytes};
 
@@ -215,47 +215,6 @@ struct TextSectionInfo {
     size: u64,
 }
 
-impl aarch64::ElfCodeMetadata {
-    /// Parse an ELF image in aligned storage, relocating an unaligned program
-    /// header table within that storage if required by the object parser.
-    pub fn parse_aligned_in_place(aligned: &mut [u64], byte_len: usize) -> Result<Self> {
-        let bytes = aligned.as_mut_bytes();
-        if byte_len > bytes.len() {
-            return Err(Error::ParseError(
-                "aligned ELF byte length exceeds storage".into(),
-            ));
-        }
-        fixup_phdr_alignment(&mut bytes[..byte_len]);
-        let file = object::File::parse(&bytes[..byte_len])
-            .map_err(|error| Error::ParseError(error.to_string()))?;
-        if file.architecture() != object::Architecture::Aarch64 {
-            return Err(Error::UnsupportedExecutable(
-                "code metadata requires an AArch64 ELF".into(),
-            ));
-        }
-        match aarch64_elf_code_metadata(&file) {
-            Ok(metadata) => Ok(metadata),
-            Err(InternalError::Public(error)) => Err(error),
-            Err(InternalError::NoTextSectionFound) => Err(Error::UnsupportedExecutable(
-                "AArch64 ELF has no executable code ranges".into(),
-            )),
-            Err(error) => unreachable!("unexpected metadata error: {error:?}"),
-        }
-    }
-
-    /// Project ELF file ranges into one file-backed mapping.
-    pub fn ranges_for_mapping(
-        &self,
-        file_offset: u64,
-        mapping_len: usize,
-    ) -> Result<aarch64::CodeScanRanges> {
-        Ok(aarch64::CodeScanRanges {
-            executable: project_file_ranges(&self.executable, file_offset, mapping_len)?,
-            identified: project_file_ranges(&self.identified, file_offset, mapping_len)?,
-        })
-    }
-}
-
 struct SyscallPatchResult {
     found_syscall: bool,
     skipped_addrs: Vec<u64>,
@@ -378,7 +337,7 @@ pub fn hook_syscalls_in_elf_with_options(
         };
 
         let (text_sections, aarch64_code_sections) = if arch == Arch::Aarch64 {
-            let metadata = match aarch64_elf_code_metadata(&file) {
+            let metadata = match aarch64::elf_code_metadata(&file) {
                 Ok(metadata) => metadata,
                 Err(InternalError::NoTextSectionFound) => return Ok(input_binary.to_vec()),
                 Err(InternalError::Public(error)) => return Err(error),
@@ -1086,175 +1045,6 @@ fn text_sections(
         return Err(InternalError::NoTextSectionFound);
     }
     Ok(text_sections)
-}
-
-fn aarch64_elf_code_metadata(
-    file: &object::File<'_>,
-) -> core::result::Result<aarch64::ElfCodeMetadata, InternalError> {
-    let executable = text_sections(file)?;
-    let identified = aarch64_code_sections(file, &executable);
-    Ok(aarch64::ElfCodeMetadata {
-        executable,
-        identified,
-    })
-}
-
-fn project_file_ranges(
-    ranges: &[TextSectionInfo],
-    mapping_file_offset: u64,
-    mapping_len: usize,
-) -> Result<Vec<Range<usize>>> {
-    let mapping_len =
-        u64::try_from(mapping_len).map_err(|_| Error::AddressOverflow("mapping length".into()))?;
-    let mapping_end = mapping_file_offset
-        .checked_add(mapping_len)
-        .ok_or_else(|| Error::AddressOverflow("mapping file range".into()))?;
-    let mut projected = Vec::new();
-    for range in ranges {
-        let range_end = range
-            .file_offset
-            .checked_add(range.size)
-            .ok_or_else(|| Error::AddressOverflow("ELF code file range".into()))?;
-        let start = range.file_offset.max(mapping_file_offset);
-        let end = range_end.min(mapping_end);
-        if start < end {
-            projected.push(
-                usize::try_from(start - mapping_file_offset)
-                    .map_err(|_| Error::AddressOverflow("projected range start".into()))?
-                    ..usize::try_from(end - mapping_file_offset)
-                        .map_err(|_| Error::AddressOverflow("projected range end".into()))?,
-            );
-        }
-    }
-    Ok(projected)
-}
-
-/// Builds ranges where metadata positively identifies AArch64 code. Executable
-/// bytes outside these ranges remain eligible for exact mandatory-site scans,
-/// but not heuristic x18 classification.
-fn aarch64_code_sections(
-    file: &object::File<'_>,
-    executable: &[TextSectionInfo],
-) -> Vec<TextSectionInfo> {
-    let mut ranges = Vec::new();
-    for symbol in file.symbols().chain(file.dynamic_symbols()) {
-        if symbol.kind() == object::SymbolKind::Text
-            && symbol.size() != 0
-            && let Some(end) = symbol.address().checked_add(symbol.size())
-        {
-            ranges.push((symbol.address(), end));
-        }
-    }
-
-    if let Some(section) = file.section_by_name(".eh_frame")
-        && let Ok(data) = section.uncompressed_data()
-        && let Some(eh_frame_ranges) = eh_frame_ranges(
-            &data,
-            section.address(),
-            file.section_by_name(".text").map(|text| text.address()),
-            file.section_by_name(".got").map(|got| got.address()),
-        )
-    {
-        ranges.extend(eh_frame_ranges);
-    }
-
-    let has_function_metadata = !aarch64_ranges_to_sections(ranges.clone(), executable).is_empty();
-    if !has_function_metadata {
-        return executable.to_vec();
-    }
-
-    for section in file.sections() {
-        let Ok(name) = section.name() else {
-            continue;
-        };
-        if (matches!(name, ".init" | ".fini" | ".plt" | ".iplt") || name.starts_with(".plt."))
-            && let Some(end) = section.address().checked_add(section.size())
-        {
-            ranges.push((section.address(), end));
-        }
-    }
-
-    aarch64_ranges_to_sections(ranges, executable)
-}
-
-fn eh_frame_ranges(
-    data: &[u8],
-    eh_frame_address: u64,
-    text_address: Option<u64>,
-    got_address: Option<u64>,
-) -> Option<Vec<(u64, u64)>> {
-    let mut section = gimli::EhFrame::new(data, gimli::LittleEndian);
-    section.set_address_size(8);
-    let mut bases = gimli::BaseAddresses::default().set_eh_frame(eh_frame_address);
-    if let Some(text_address) = text_address {
-        bases = bases.set_text(text_address);
-    }
-    if let Some(got_address) = got_address {
-        bases = bases.set_got(got_address);
-    }
-    let mut entries = gimli::UnwindSection::entries(&section, &bases);
-    let mut ranges = Vec::new();
-    loop {
-        let entry = match entries.next() {
-            Ok(Some(entry)) => entry,
-            Ok(None) => return Some(ranges),
-            Err(_) => return None,
-        };
-        if let gimli::CieOrFde::Fde(partial) = entry {
-            let Ok(fde) = partial.parse(gimli::UnwindSection::cie_from_offset) else {
-                return None;
-            };
-            if fde.len() != 0
-                && let Some(end) = fde.initial_address().checked_add(fde.len())
-            {
-                ranges.push((fde.initial_address(), end));
-            }
-        }
-    }
-}
-
-fn aarch64_ranges_to_sections(
-    ranges: Vec<(u64, u64)>,
-    executable: &[TextSectionInfo],
-) -> Vec<TextSectionInfo> {
-    let mut clipped = Vec::new();
-    for (start, end) in ranges {
-        for section in executable {
-            let section_end = section.vaddr.saturating_add(section.size);
-            let start = start
-                .max(section.vaddr)
-                .checked_add(3)
-                .map_or(u64::MAX, |start| start & !3);
-            let end = end.min(section_end) & !3;
-            if start < end {
-                clipped.push((start, end, section));
-            }
-        }
-    }
-    clipped.sort_unstable_by_key(|(start, _, _)| *start);
-
-    let mut code: Vec<TextSectionInfo> = Vec::new();
-    for (start, end, section) in clipped {
-        if let Some(previous) = code.last_mut()
-            && start >= previous.vaddr
-            && previous.vaddr.saturating_add(previous.size) >= start
-            && previous.file_offset.saturating_add(start - previous.vaddr)
-                == section.file_offset.saturating_add(start - section.vaddr)
-        {
-            previous.size = end
-                .max(previous.vaddr.saturating_add(previous.size))
-                .saturating_sub(previous.vaddr);
-            continue;
-        }
-        code.push(TextSectionInfo {
-            vaddr: start,
-            file_offset: section
-                .file_offset
-                .saturating_add(start.saturating_sub(section.vaddr)),
-            size: end - start,
-        });
-    }
-    code
 }
 
 /// Check if the binary is already hooked by looking for TRAMPOLINE_MAGIC at the end of the file.
@@ -2560,25 +2350,6 @@ fn hook_syscall_and_after(
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn aarch64_ranges_are_clipped_aligned_and_merged() {
-        let executable = [TextSectionInfo {
-            vaddr: 0x1000,
-            file_offset: 0x200,
-            size: 0x20,
-        }];
-
-        let ranges = aarch64_ranges_to_sections(
-            vec![(0x0fff, 0x1006), (0x1004, 0x100d), (0x101e, 0x1024)],
-            &executable,
-        );
-
-        assert_eq!(ranges.len(), 1);
-        assert_eq!(ranges[0].vaddr, 0x1000);
-        assert_eq!(ranges[0].file_offset, 0x200);
-        assert_eq!(ranges[0].size, 0xc);
-    }
 
     fn seg(vaddr: u64, filesz: u64, memsz: u64, align: u64) -> LoadSegment {
         LoadSegment {

--- a/litebox_syscall_rewriter/src/lib.rs
+++ b/litebox_syscall_rewriter/src/lib.rs
@@ -215,42 +215,10 @@ struct TextSectionInfo {
     size: u64,
 }
 
-#[derive(Clone, Copy)]
-struct Aarch64ScanSections<'a> {
-    executable: &'a [TextSectionInfo],
-    code: &'a [TextSectionInfo],
-}
-
-/// Mapping-relative ranges used by AArch64 patch-site scanning.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct Aarch64CodeScanRanges {
-    pub executable: Vec<Range<usize>>,
-    pub identified: Vec<Range<usize>>,
-}
-
-/// Owned AArch64 ELF code metadata, independent of the parsed ELF buffer.
-#[derive(Clone)]
-pub struct Aarch64ElfCodeMetadata {
-    executable: Vec<TextSectionInfo>,
-    identified: Vec<TextSectionInfo>,
-}
-
-impl Aarch64ElfCodeMetadata {
-    /// Parse executable and positively identified code ranges from an ELF64 image.
-    pub fn parse(elf: &[u8]) -> Result<Self> {
-        let word_len = elf.len().div_ceil(8);
-        let mut aligned = Vec::new();
-        aligned
-            .try_reserve_exact(word_len)
-            .map_err(|_| Error::ParseError("ELF metadata allocation failed".into()))?;
-        aligned.resize(word_len, 0u64);
-        let bytes = aligned.as_mut_bytes();
-        bytes[..elf.len()].copy_from_slice(elf);
-        Self::parse_aligned(&mut aligned, elf.len())
-    }
-
-    /// Parse an ELF image already stored in 8-byte-aligned words without copying it.
-    pub fn parse_aligned(aligned: &mut [u64], byte_len: usize) -> Result<Self> {
+impl aarch64::ElfCodeMetadata {
+    /// Parse an ELF image in aligned storage, relocating an unaligned program
+    /// header table within that storage if required by the object parser.
+    pub fn parse_aligned_in_place(aligned: &mut [u64], byte_len: usize) -> Result<Self> {
         let bytes = aligned.as_mut_bytes();
         if byte_len > bytes.len() {
             return Err(Error::ParseError(
@@ -280,8 +248,8 @@ impl Aarch64ElfCodeMetadata {
         &self,
         file_offset: u64,
         mapping_len: usize,
-    ) -> Result<Aarch64CodeScanRanges> {
-        Ok(Aarch64CodeScanRanges {
+    ) -> Result<aarch64::CodeScanRanges> {
+        Ok(aarch64::CodeScanRanges {
             executable: project_file_ranges(&self.executable, file_offset, mapping_len)?,
             identified: project_file_ranges(&self.identified, file_offset, mapping_len)?,
         })
@@ -444,7 +412,7 @@ pub fn hook_syscalls_in_elf_with_options(
         return hook_aarch64_elf(
             input_binary,
             buf,
-            Aarch64ScanSections {
+            aarch64::ScanSections {
                 executable: &text_sections,
                 code: &aarch64_code_sections,
             },
@@ -977,7 +945,7 @@ fn append_trampoline_footer(
 fn hook_aarch64_elf(
     input_binary: &[u8],
     buf: &mut [u8],
-    sections: Aarch64ScanSections<'_>,
+    sections: aarch64::ScanSections<'_>,
     placement: TrampolinePlacement,
     callback: u64,
     options: RewriteOptions,
@@ -1035,7 +1003,7 @@ fn hook_aarch64_elf(
 fn hook_aarch64_elf_at(
     input_binary: &[u8],
     buf: &mut [u8],
-    sections: Aarch64ScanSections<'_>,
+    sections: aarch64::ScanSections<'_>,
     trampoline_base_addr: u64,
     trampoline_limit: Option<u64>,
     callback: u64,
@@ -1120,45 +1088,12 @@ fn text_sections(
     Ok(text_sections)
 }
 
-/// Returns executable load segments only as a fallback for AArch64 ELFs whose
-/// section table is absent. When executable sections exist, scanning them avoids
-/// treating unrelated headers, metadata, or padding in an RX segment as code.
-fn aarch64_executable_segments(
-    file: &object::File<'_>,
-) -> core::result::Result<Vec<TextSectionInfo>, InternalError> {
-    let mut segments: Vec<_> = file
-        .segments()
-        .filter_map(|segment| {
-            let object::SegmentFlags::Elf { p_flags } = segment.flags() else {
-                return None;
-            };
-            if p_flags & object::elf::PF_X == 0 {
-                return None;
-            }
-            let (file_offset, size) = segment.file_range();
-            Some(TextSectionInfo {
-                vaddr: segment.address(),
-                file_offset,
-                size,
-            })
-        })
-        .collect();
-    segments.sort_unstable_by_key(|segment| segment.vaddr);
-    if segments.is_empty() {
-        return Err(InternalError::NoTextSectionFound);
-    }
-    Ok(segments)
-}
-
 fn aarch64_elf_code_metadata(
     file: &object::File<'_>,
-) -> core::result::Result<Aarch64ElfCodeMetadata, InternalError> {
-    let executable = text_sections(file).or_else(|error| match error {
-        InternalError::NoTextSectionFound => aarch64_executable_segments(file),
-        other => Err(other),
-    })?;
+) -> core::result::Result<aarch64::ElfCodeMetadata, InternalError> {
+    let executable = text_sections(file)?;
     let identified = aarch64_code_sections(file, &executable);
-    Ok(Aarch64ElfCodeMetadata {
+    Ok(aarch64::ElfCodeMetadata {
         executable,
         identified,
     })
@@ -1213,16 +1148,20 @@ fn aarch64_code_sections(
 
     if let Some(section) = file.section_by_name(".eh_frame")
         && let Ok(data) = section.uncompressed_data()
-    {
-        ranges.extend(eh_frame_ranges(
+        && let Some(eh_frame_ranges) = eh_frame_ranges(
             &data,
             section.address(),
             file.section_by_name(".text").map(|text| text.address()),
             file.section_by_name(".got").map(|got| got.address()),
-        ));
+        )
+    {
+        ranges.extend(eh_frame_ranges);
     }
 
     let has_function_metadata = !aarch64_ranges_to_sections(ranges.clone(), executable).is_empty();
+    if !has_function_metadata {
+        return executable.to_vec();
+    }
 
     for section in file.sections() {
         let Ok(name) = section.name() else {
@@ -1235,13 +1174,6 @@ fn aarch64_code_sections(
         }
     }
 
-    if !has_function_metadata
-        && let Some(text) = file.section_by_name(".text")
-        && let Some(end) = text.address().checked_add(text.size())
-    {
-        ranges.push((text.address(), end));
-    }
-
     aarch64_ranges_to_sections(ranges, executable)
 }
 
@@ -1250,7 +1182,7 @@ fn eh_frame_ranges(
     eh_frame_address: u64,
     text_address: Option<u64>,
     got_address: Option<u64>,
-) -> Vec<(u64, u64)> {
+) -> Option<Vec<(u64, u64)>> {
     let mut section = gimli::EhFrame::new(data, gimli::LittleEndian);
     section.set_address_size(8);
     let mut bases = gimli::BaseAddresses::default().set_eh_frame(eh_frame_address);
@@ -1263,12 +1195,14 @@ fn eh_frame_ranges(
     let mut entries = gimli::UnwindSection::entries(&section, &bases);
     let mut ranges = Vec::new();
     loop {
-        let Ok(Some(entry)) = entries.next() else {
-            return ranges;
+        let entry = match entries.next() {
+            Ok(Some(entry)) => entry,
+            Ok(None) => return Some(ranges),
+            Err(_) => return None,
         };
         if let gimli::CieOrFde::Fde(partial) = entry {
             let Ok(fde) = partial.parse(gimli::UnwindSection::cie_from_offset) else {
-                return ranges;
+                return None;
             };
             if fde.len() != 0
                 && let Some(end) = fde.initial_address().checked_add(fde.len())
@@ -1964,10 +1898,10 @@ fn patch_aarch64_code_segment(
 }
 
 #[cfg(any(test, target_arch = "aarch64"))]
-fn whole_code_scan_ranges(code_len: usize) -> Aarch64CodeScanRanges {
+fn whole_code_scan_ranges(code_len: usize) -> aarch64::CodeScanRanges {
     let executable: Vec<Range<usize>> = core::iter::once(0..code_len).collect();
     let identified = executable.clone();
-    Aarch64CodeScanRanges {
+    aarch64::CodeScanRanges {
         executable,
         identified,
     }
@@ -1977,7 +1911,7 @@ fn whole_code_scan_ranges(code_len: usize) -> Aarch64CodeScanRanges {
 pub fn patch_aarch64_code_segment_with_options_and_ranges(
     code: &mut [u8],
     code_vaddr: u64,
-    ranges: &Aarch64CodeScanRanges,
+    ranges: &aarch64::CodeScanRanges,
     trampoline_write_vaddr: u64,
     syscall_entry_addr: u64,
     options: RewriteOptions,
@@ -2087,7 +2021,7 @@ fn trap_all_aarch64_patch_sites(
 pub fn trap_all_aarch64_patch_sites_with_options_and_ranges(
     code: &mut [u8],
     code_vaddr: u64,
-    ranges: &Aarch64CodeScanRanges,
+    ranges: &aarch64::CodeScanRanges,
     options: RewriteOptions,
 ) -> Result<usize> {
     let executable = scan_sections(code_vaddr, &ranges.executable, code.len())?;
@@ -2898,7 +2832,7 @@ mod tests {
         let out = hook_aarch64_elf_at(
             &input,
             &mut elf,
-            Aarch64ScanSections {
+            aarch64::ScanSections {
                 executable: &[section],
                 code: &[section],
             },
@@ -2948,15 +2882,6 @@ mod tests {
         elf
     }
 
-    #[test]
-    fn aarch64_sectionless_elf_still_rewrites_svc_from_executable_segment() {
-        let input = aarch64_elf_with_one_svc();
-        let output = hook_syscalls_in_elf(&input, None).unwrap();
-
-        let patched = u32::from_le_bytes(output[input.len() - 4..input.len()].try_into().unwrap());
-        assert_eq!(patched & 0xfc00_0000, 0x1400_0000);
-    }
-
     /// A gap the gates cannot branch back from is retried at the fallback
     /// address rather than failing the whole binary.
     #[test]
@@ -2980,7 +2905,7 @@ mod tests {
                 hook_aarch64_elf_at(
                     &input,
                     &mut direct,
-                    Aarch64ScanSections {
+                    aarch64::ScanSections {
                         executable: &[section()],
                         code: &[section()],
                     },
@@ -3003,7 +2928,7 @@ mod tests {
         hook_aarch64_elf(
             &input,
             &mut elf,
-            Aarch64ScanSections {
+            aarch64::ScanSections {
                 executable: &[section()],
                 code: &[section()],
             },
@@ -3120,7 +3045,7 @@ mod tests {
         let err = hook_aarch64_elf(
             &input,
             &mut buf,
-            Aarch64ScanSections {
+            aarch64::ScanSections {
                 executable: &sections,
                 code: &sections,
             },

--- a/litebox_syscall_rewriter/src/lib.rs
+++ b/litebox_syscall_rewriter/src/lib.rs
@@ -60,6 +60,7 @@ use alloc::format;
 use alloc::string::{String, ToString};
 use alloc::vec;
 use alloc::vec::Vec;
+use core::ops::Range;
 
 use litebox_common_windows::NtSysno;
 use object::pe::{IMAGE_SCN_CNT_CODE, IMAGE_SCN_MEM_EXECUTE};
@@ -220,6 +221,73 @@ struct Aarch64ScanSections<'a> {
     code: &'a [TextSectionInfo],
 }
 
+/// Mapping-relative ranges used by AArch64 patch-site scanning.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Aarch64CodeScanRanges {
+    pub executable: Vec<Range<usize>>,
+    pub identified: Vec<Range<usize>>,
+}
+
+/// Owned AArch64 ELF code metadata, independent of the parsed ELF buffer.
+#[derive(Clone)]
+pub struct Aarch64ElfCodeMetadata {
+    executable: Vec<TextSectionInfo>,
+    identified: Vec<TextSectionInfo>,
+}
+
+impl Aarch64ElfCodeMetadata {
+    /// Parse executable and positively identified code ranges from an ELF64 image.
+    pub fn parse(elf: &[u8]) -> Result<Self> {
+        let word_len = elf.len().div_ceil(8);
+        let mut aligned = Vec::new();
+        aligned
+            .try_reserve_exact(word_len)
+            .map_err(|_| Error::ParseError("ELF metadata allocation failed".into()))?;
+        aligned.resize(word_len, 0u64);
+        let bytes = aligned.as_mut_bytes();
+        bytes[..elf.len()].copy_from_slice(elf);
+        Self::parse_aligned(&mut aligned, elf.len())
+    }
+
+    /// Parse an ELF image already stored in 8-byte-aligned words without copying it.
+    pub fn parse_aligned(aligned: &mut [u64], byte_len: usize) -> Result<Self> {
+        let bytes = aligned.as_mut_bytes();
+        if byte_len > bytes.len() {
+            return Err(Error::ParseError(
+                "aligned ELF byte length exceeds storage".into(),
+            ));
+        }
+        fixup_phdr_alignment(&mut bytes[..byte_len]);
+        let file = object::File::parse(&bytes[..byte_len])
+            .map_err(|error| Error::ParseError(error.to_string()))?;
+        if file.architecture() != object::Architecture::Aarch64 {
+            return Err(Error::UnsupportedExecutable(
+                "code metadata requires an AArch64 ELF".into(),
+            ));
+        }
+        match aarch64_elf_code_metadata(&file) {
+            Ok(metadata) => Ok(metadata),
+            Err(InternalError::Public(error)) => Err(error),
+            Err(InternalError::NoTextSectionFound) => Err(Error::UnsupportedExecutable(
+                "AArch64 ELF has no executable code ranges".into(),
+            )),
+            Err(error) => unreachable!("unexpected metadata error: {error:?}"),
+        }
+    }
+
+    /// Project ELF file ranges into one file-backed mapping.
+    pub fn ranges_for_mapping(
+        &self,
+        file_offset: u64,
+        mapping_len: usize,
+    ) -> Result<Aarch64CodeScanRanges> {
+        Ok(Aarch64CodeScanRanges {
+            executable: project_file_ranges(&self.executable, file_offset, mapping_len)?,
+            identified: project_file_ranges(&self.identified, file_offset, mapping_len)?,
+        })
+    }
+}
+
 struct SyscallPatchResult {
     found_syscall: bool,
     skipped_addrs: Vec<u64>,
@@ -341,24 +409,22 @@ pub fn hook_syscalls_in_elf_with_options(
             _ => return Ok(input_binary.to_vec()),
         };
 
-        let executable_sections = match if arch == Arch::Aarch64 {
-            text_sections(&file).or_else(|error| match error {
-                InternalError::NoTextSectionFound => aarch64_executable_segments(&file),
-                other => Err(other),
-            })
-        } else {
-            text_sections(&file)
-        } {
-            Ok(sections) => sections,
-            Err(InternalError::NoTextSectionFound) => return Ok(input_binary.to_vec()),
-            Err(InternalError::Public(e)) => return Err(e),
-            Err(e) => unreachable!("unexpected internal error: {e:?}"),
-        };
         let (text_sections, aarch64_code_sections) = if arch == Arch::Aarch64 {
-            let code = aarch64_code_sections(&file, &executable_sections);
-            (executable_sections, code)
+            let metadata = match aarch64_elf_code_metadata(&file) {
+                Ok(metadata) => metadata,
+                Err(InternalError::NoTextSectionFound) => return Ok(input_binary.to_vec()),
+                Err(InternalError::Public(error)) => return Err(error),
+                Err(error) => unreachable!("unexpected metadata error: {error:?}"),
+            };
+            (metadata.executable, metadata.identified)
         } else {
-            (executable_sections, Vec::new())
+            let sections = match text_sections(&file) {
+                Ok(sections) => sections,
+                Err(InternalError::NoTextSectionFound) => return Ok(input_binary.to_vec()),
+                Err(InternalError::Public(error)) => return Err(error),
+                Err(error) => unreachable!("unexpected internal error: {error:?}"),
+            };
+            (sections, Vec::new())
         };
 
         if is_already_hooked(&*buf, arch) {
@@ -1082,6 +1148,50 @@ fn aarch64_executable_segments(
         return Err(InternalError::NoTextSectionFound);
     }
     Ok(segments)
+}
+
+fn aarch64_elf_code_metadata(
+    file: &object::File<'_>,
+) -> core::result::Result<Aarch64ElfCodeMetadata, InternalError> {
+    let executable = text_sections(file).or_else(|error| match error {
+        InternalError::NoTextSectionFound => aarch64_executable_segments(file),
+        other => Err(other),
+    })?;
+    let identified = aarch64_code_sections(file, &executable);
+    Ok(Aarch64ElfCodeMetadata {
+        executable,
+        identified,
+    })
+}
+
+fn project_file_ranges(
+    ranges: &[TextSectionInfo],
+    mapping_file_offset: u64,
+    mapping_len: usize,
+) -> Result<Vec<Range<usize>>> {
+    let mapping_len =
+        u64::try_from(mapping_len).map_err(|_| Error::AddressOverflow("mapping length".into()))?;
+    let mapping_end = mapping_file_offset
+        .checked_add(mapping_len)
+        .ok_or_else(|| Error::AddressOverflow("mapping file range".into()))?;
+    let mut projected = Vec::new();
+    for range in ranges {
+        let range_end = range
+            .file_offset
+            .checked_add(range.size)
+            .ok_or_else(|| Error::AddressOverflow("ELF code file range".into()))?;
+        let start = range.file_offset.max(mapping_file_offset);
+        let end = range_end.min(mapping_end);
+        if start < end {
+            projected.push(
+                usize::try_from(start - mapping_file_offset)
+                    .map_err(|_| Error::AddressOverflow("projected range start".into()))?
+                    ..usize::try_from(end - mapping_file_offset)
+                        .map_err(|_| Error::AddressOverflow("projected range end".into()))?,
+            );
+        }
+    }
+    Ok(projected)
 }
 
 /// Builds ranges where metadata positively identifies AArch64 code. Executable
@@ -1842,14 +1952,42 @@ fn patch_aarch64_code_segment(
     syscall_entry_addr: u64,
     options: RewriteOptions,
 ) -> Result<(Vec<u8>, Vec<u64>)> {
-    let section = TextSectionInfo {
-        vaddr: code_vaddr,
-        file_offset: 0,
-        size: code.len() as u64,
-    };
-    let Some(outcome) = aarch64::hook_syscalls_aarch64(
+    let ranges = whole_code_scan_ranges(code.len());
+    patch_aarch64_code_segment_with_options_and_ranges(
         code,
-        &[section],
+        code_vaddr,
+        &ranges,
+        trampoline_write_vaddr,
+        syscall_entry_addr,
+        options,
+    )
+}
+
+#[cfg(any(test, target_arch = "aarch64"))]
+fn whole_code_scan_ranges(code_len: usize) -> Aarch64CodeScanRanges {
+    let executable: Vec<Range<usize>> = core::iter::once(0..code_len).collect();
+    let identified = executable.clone();
+    Aarch64CodeScanRanges {
+        executable,
+        identified,
+    }
+}
+
+/// Runtime AArch64 rewriting constrained by mapping-relative ELF code ranges.
+pub fn patch_aarch64_code_segment_with_options_and_ranges(
+    code: &mut [u8],
+    code_vaddr: u64,
+    ranges: &Aarch64CodeScanRanges,
+    trampoline_write_vaddr: u64,
+    syscall_entry_addr: u64,
+    options: RewriteOptions,
+) -> Result<(Vec<u8>, Vec<u64>)> {
+    let executable = scan_sections(code_vaddr, &ranges.executable, code.len())?;
+    let identified = scan_sections(code_vaddr, &ranges.identified, code.len())?;
+    let Some(outcome) = aarch64::hook_syscalls_aarch64_with_code_ranges(
+        code,
+        &executable,
+        &identified,
         trampoline_write_vaddr,
         syscall_entry_addr,
         aarch64::RewriteConfig::new(options.target_host(), options.effective_virtualize_x18()),
@@ -1859,6 +1997,30 @@ fn patch_aarch64_code_segment(
     };
 
     Ok((outcome.trampoline, outcome.trapped_sites))
+}
+
+fn scan_sections(
+    code_vaddr: u64,
+    ranges: &[Range<usize>],
+    code_len: usize,
+) -> Result<Vec<TextSectionInfo>> {
+    ranges
+        .iter()
+        .map(|range| {
+            if range.start > range.end || range.end > code_len {
+                return Err(Error::ParseError(
+                    "scan range extends beyond mapping".into(),
+                ));
+            }
+            Ok(TextSectionInfo {
+                vaddr: code_vaddr
+                    .checked_add(range.start as u64)
+                    .ok_or_else(|| Error::AddressOverflow("scan range address".into()))?,
+                file_offset: range.start as u64,
+                size: (range.end - range.start) as u64,
+            })
+        })
+        .collect()
 }
 
 /// Replace every syscall patch site in `code` with a trap instruction, so that
@@ -1917,14 +2079,23 @@ fn trap_all_aarch64_patch_sites(
     code_vaddr: u64,
     options: RewriteOptions,
 ) -> Result<usize> {
-    let section = TextSectionInfo {
-        vaddr: code_vaddr,
-        file_offset: 0,
-        size: code.len() as u64,
-    };
-    aarch64::trap_all_patch_sites(
+    let ranges = whole_code_scan_ranges(code.len());
+    trap_all_aarch64_patch_sites_with_options_and_ranges(code, code_vaddr, &ranges, options)
+}
+
+/// Trap runtime AArch64 patch sites selected by mapping-relative ELF ranges.
+pub fn trap_all_aarch64_patch_sites_with_options_and_ranges(
+    code: &mut [u8],
+    code_vaddr: u64,
+    ranges: &Aarch64CodeScanRanges,
+    options: RewriteOptions,
+) -> Result<usize> {
+    let executable = scan_sections(code_vaddr, &ranges.executable, code.len())?;
+    let identified = scan_sections(code_vaddr, &ranges.identified, code.len())?;
+    aarch64::trap_all_patch_sites_with_code_ranges(
         code,
-        &[section],
+        &executable,
+        &identified,
         aarch64::RewriteConfig::new(options.target_host(), options.effective_virtualize_x18()),
     )
 }

--- a/litebox_syscall_rewriter/src/lib.rs
+++ b/litebox_syscall_rewriter/src/lib.rs
@@ -219,12 +219,28 @@ impl aarch64::ElfCodeMetadata {
     /// Parse an ELF image in aligned storage, relocating an unaligned program
     /// header table within that storage if required by the object parser.
     pub fn parse_aligned_in_place(aligned: &mut [u64], byte_len: usize) -> Result<Self> {
-        parse_aarch64_metadata_in_place(aligned, byte_len, true)
-    }
-
-    /// Parse only executable ELF section ranges, without symbols or unwind data.
-    pub fn parse_executable_in_place(aligned: &mut [u64], byte_len: usize) -> Result<Self> {
-        parse_aarch64_metadata_in_place(aligned, byte_len, false)
+        let bytes = aligned.as_mut_bytes();
+        if byte_len > bytes.len() {
+            return Err(Error::ParseError(
+                "aligned ELF byte length exceeds storage".into(),
+            ));
+        }
+        fixup_phdr_alignment(&mut bytes[..byte_len]);
+        let file = object::File::parse(&bytes[..byte_len])
+            .map_err(|error| Error::ParseError(error.to_string()))?;
+        if file.architecture() != object::Architecture::Aarch64 {
+            return Err(Error::UnsupportedExecutable(
+                "code metadata requires an AArch64 ELF".into(),
+            ));
+        }
+        match aarch64_elf_code_metadata(&file) {
+            Ok(metadata) => Ok(metadata),
+            Err(InternalError::Public(error)) => Err(error),
+            Err(InternalError::NoTextSectionFound) => Err(Error::UnsupportedExecutable(
+                "AArch64 ELF has no executable code ranges".into(),
+            )),
+            Err(error) => unreachable!("unexpected metadata error: {error:?}"),
+        }
     }
 
     /// Project ELF file ranges into one file-backed mapping.
@@ -237,35 +253,6 @@ impl aarch64::ElfCodeMetadata {
             executable: project_file_ranges(&self.executable, file_offset, mapping_len)?,
             identified: project_file_ranges(&self.identified, file_offset, mapping_len)?,
         })
-    }
-}
-
-fn parse_aarch64_metadata_in_place(
-    aligned: &mut [u64],
-    byte_len: usize,
-    identify_code: bool,
-) -> Result<aarch64::ElfCodeMetadata> {
-    let bytes = aligned.as_mut_bytes();
-    if byte_len > bytes.len() {
-        return Err(Error::ParseError(
-            "aligned ELF byte length exceeds storage".into(),
-        ));
-    }
-    fixup_phdr_alignment(&mut bytes[..byte_len]);
-    let file = object::File::parse(&bytes[..byte_len])
-        .map_err(|error| Error::ParseError(error.to_string()))?;
-    if file.architecture() != object::Architecture::Aarch64 {
-        return Err(Error::UnsupportedExecutable(
-            "code metadata requires an AArch64 ELF".into(),
-        ));
-    }
-    match aarch64_elf_code_metadata(&file, identify_code) {
-        Ok(metadata) => Ok(metadata),
-        Err(InternalError::Public(error)) => Err(error),
-        Err(InternalError::NoTextSectionFound) => Err(Error::UnsupportedExecutable(
-            "AArch64 ELF has no executable code ranges".into(),
-        )),
-        Err(error) => unreachable!("unexpected metadata error: {error:?}"),
     }
 }
 
@@ -391,7 +378,7 @@ pub fn hook_syscalls_in_elf_with_options(
         };
 
         let (text_sections, aarch64_code_sections) = if arch == Arch::Aarch64 {
-            let metadata = match aarch64_elf_code_metadata(&file, true) {
+            let metadata = match aarch64_elf_code_metadata(&file) {
                 Ok(metadata) => metadata,
                 Err(InternalError::NoTextSectionFound) => return Ok(input_binary.to_vec()),
                 Err(InternalError::Public(error)) => return Err(error),
@@ -1103,14 +1090,9 @@ fn text_sections(
 
 fn aarch64_elf_code_metadata(
     file: &object::File<'_>,
-    identify_code: bool,
 ) -> core::result::Result<aarch64::ElfCodeMetadata, InternalError> {
     let executable = text_sections(file)?;
-    let identified = if identify_code {
-        aarch64_code_sections(file, &executable)
-    } else {
-        Vec::new()
-    };
+    let identified = aarch64_code_sections(file, &executable);
     Ok(aarch64::ElfCodeMetadata {
         executable,
         identified,

--- a/litebox_syscall_rewriter/tests/aarch64_tests.rs
+++ b/litebox_syscall_rewriter/tests/aarch64_tests.rs
@@ -14,7 +14,7 @@
 
 use litebox_syscall_rewriter::{
     Error, RewriteOptions, TRAMPOLINE_MAGIC, TargetHost, hook_syscalls_in_elf,
-    hook_syscalls_in_elf_with_options,
+    hook_syscalls_in_elf_with_options, patch_aarch64_code_segment_with_options_and_ranges,
 };
 
 const HELLO_AARCH64: &[u8] = include_bytes!("hello-aarch64");
@@ -232,6 +232,31 @@ fn aarch64_metadata_projects_text_into_file_mapping() {
     assert_eq!(ranges.executable()[0], 0x10..0x40);
     assert_eq!(ranges.identified().len(), 1);
     assert_eq!(ranges.identified()[0], 0x10..0x40);
+
+    let metadata = litebox_syscall_rewriter::aarch64::ElfCodeMetadata::parse_executable_in_place(
+        &mut aligned,
+        HELLO_AARCH64.len(),
+    )
+    .unwrap();
+    let ranges = metadata.ranges_for_mapping(0, 0x140).unwrap();
+    assert_eq!(ranges.executable().len(), 1);
+    assert_eq!(ranges.executable()[0], 0x110..0x140);
+    assert!(ranges.identified().is_empty());
+
+    let ranges = metadata.ranges_for_mapping(0x110, 4).unwrap();
+    let mut code = SVC_0.to_le_bytes();
+    let (gates, trapped) = patch_aarch64_code_segment_with_options_and_ranges(
+        &mut code,
+        0x1000,
+        &ranges,
+        0x2000,
+        0,
+        RewriteOptions::default(),
+    )
+    .unwrap();
+    assert!(!gates.is_empty());
+    assert!(trapped.is_empty());
+    assert_eq!(read_u32(&code, 0) & 0xFC00_0000, 0x1400_0000);
 }
 
 #[test]

--- a/litebox_syscall_rewriter/tests/aarch64_tests.rs
+++ b/litebox_syscall_rewriter/tests/aarch64_tests.rs
@@ -14,7 +14,7 @@
 
 use litebox_syscall_rewriter::{
     Error, RewriteOptions, TRAMPOLINE_MAGIC, TargetHost, hook_syscalls_in_elf,
-    hook_syscalls_in_elf_with_options, patch_aarch64_code_segment_with_options_and_ranges,
+    hook_syscalls_in_elf_with_options,
 };
 
 const HELLO_AARCH64: &[u8] = include_bytes!("hello-aarch64");
@@ -232,31 +232,6 @@ fn aarch64_metadata_projects_text_into_file_mapping() {
     assert_eq!(ranges.executable()[0], 0x10..0x40);
     assert_eq!(ranges.identified().len(), 1);
     assert_eq!(ranges.identified()[0], 0x10..0x40);
-
-    let metadata = litebox_syscall_rewriter::aarch64::ElfCodeMetadata::parse_executable_in_place(
-        &mut aligned,
-        HELLO_AARCH64.len(),
-    )
-    .unwrap();
-    let ranges = metadata.ranges_for_mapping(0, 0x140).unwrap();
-    assert_eq!(ranges.executable().len(), 1);
-    assert_eq!(ranges.executable()[0], 0x110..0x140);
-    assert!(ranges.identified().is_empty());
-
-    let ranges = metadata.ranges_for_mapping(0x110, 4).unwrap();
-    let mut code = SVC_0.to_le_bytes();
-    let (gates, trapped) = patch_aarch64_code_segment_with_options_and_ranges(
-        &mut code,
-        0x1000,
-        &ranges,
-        0x2000,
-        0,
-        RewriteOptions::default(),
-    )
-    .unwrap();
-    assert!(!gates.is_empty());
-    assert!(trapped.is_empty());
-    assert_eq!(read_u32(&code, 0) & 0xFC00_0000, 0x1400_0000);
 }
 
 #[test]

--- a/litebox_syscall_rewriter/tests/aarch64_tests.rs
+++ b/litebox_syscall_rewriter/tests/aarch64_tests.rs
@@ -13,10 +13,8 @@
 #![allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 
 use litebox_syscall_rewriter::{
-    Aarch64ElfCodeMetadata, Error, RewriteOptions, TRAMPOLINE_MAGIC, TargetHost,
-    hook_syscalls_in_elf, hook_syscalls_in_elf_with_options,
-    patch_aarch64_code_segment_with_options_and_ranges,
-    trap_all_aarch64_patch_sites_with_options_and_ranges,
+    Error, RewriteOptions, TRAMPOLINE_MAGIC, TargetHost, hook_syscalls_in_elf,
+    hook_syscalls_in_elf_with_options,
 };
 
 const HELLO_AARCH64: &[u8] = include_bytes!("hello-aarch64");
@@ -214,56 +212,26 @@ fn aarch64_rx_segment_padding_is_not_scanned_when_sections_exist() {
 
 #[test]
 fn aarch64_metadata_projects_text_into_file_mapping() {
-    let metadata = Aarch64ElfCodeMetadata::parse(HELLO_AARCH64).unwrap();
-    let ranges = metadata.ranges_for_mapping(0, 0x140).unwrap();
-
-    assert_eq!(ranges.executable, vec![0x110..0x140]);
-    assert_eq!(ranges.identified, vec![0x110..0x140]);
-
-    let ranges = metadata.ranges_for_mapping(0x100, 0x40).unwrap();
-    assert_eq!(ranges.executable, vec![0x10..0x40]);
-    assert_eq!(ranges.identified, vec![0x10..0x40]);
-}
-
-#[test]
-fn aarch64_runtime_ranges_exclude_padding_from_x18_scan() {
-    let mut code = vec![0u8; 8];
-    code[..4].copy_from_slice(&0x5D56_4F48u32.to_le_bytes());
-    code[4..].copy_from_slice(&0xAA12_03E0u32.to_le_bytes());
-    let ranges = litebox_syscall_rewriter::Aarch64CodeScanRanges {
-        executable: core::iter::once(0..8).collect(),
-        identified: core::iter::once(4..8).collect(),
-    };
-
-    let (gates, trapped) = patch_aarch64_code_segment_with_options_and_ranges(
-        &mut code,
-        0x1000,
-        &ranges,
-        0x2000,
-        0,
-        RewriteOptions::new(TargetHost::Linux, true),
+    let mut aligned = vec![0u64; HELLO_AARCH64.len().div_ceil(8)];
+    zerocopy::IntoBytes::as_mut_bytes(aligned.as_mut_slice())[..HELLO_AARCH64.len()]
+        .copy_from_slice(HELLO_AARCH64);
+    let metadata = litebox_syscall_rewriter::aarch64::ElfCodeMetadata::parse_aligned_in_place(
+        &mut aligned,
+        HELLO_AARCH64.len(),
     )
     .unwrap();
+    let ranges = metadata.ranges_for_mapping(0, 0x140).unwrap();
 
-    assert!(!gates.is_empty());
-    assert!(trapped.is_empty());
-    assert_eq!(read_u32(&code, 0), 0x5D56_4F48);
-    assert_eq!(read_u32(&code, 4) & 0xFC00_0000, 0x1400_0000);
+    assert_eq!(ranges.executable().len(), 1);
+    assert_eq!(ranges.executable()[0], 0x110..0x140);
+    assert_eq!(ranges.identified().len(), 1);
+    assert_eq!(ranges.identified()[0], 0x110..0x140);
 
-    let mut trapped_code = vec![0u8; 8];
-    trapped_code[..4].copy_from_slice(&0x5D56_4F48u32.to_le_bytes());
-    trapped_code[4..].copy_from_slice(&0xAA12_03E0u32.to_le_bytes());
-    assert_eq!(
-        trap_all_aarch64_patch_sites_with_options_and_ranges(
-            &mut trapped_code,
-            0x1000,
-            &ranges,
-            RewriteOptions::new(TargetHost::Linux, true),
-        )
-        .unwrap(),
-        1
-    );
-    assert_eq!(read_u32(&trapped_code, 0), 0x5D56_4F48);
+    let ranges = metadata.ranges_for_mapping(0x100, 0x40).unwrap();
+    assert_eq!(ranges.executable().len(), 1);
+    assert_eq!(ranges.executable()[0], 0x10..0x40);
+    assert_eq!(ranges.identified().len(), 1);
+    assert_eq!(ranges.identified()[0], 0x10..0x40);
 }
 
 #[test]

--- a/litebox_syscall_rewriter/tests/aarch64_tests.rs
+++ b/litebox_syscall_rewriter/tests/aarch64_tests.rs
@@ -12,7 +12,10 @@
 // Deliberate, range-checked casts on a 64-bit host throughout this test.
 #![allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 
-use litebox_syscall_rewriter::{Error, TRAMPOLINE_MAGIC, hook_syscalls_in_elf};
+use litebox_syscall_rewriter::{
+    Error, RewriteOptions, TRAMPOLINE_MAGIC, TargetHost, hook_syscalls_in_elf,
+    hook_syscalls_in_elf_with_options,
+};
 
 const HELLO_AARCH64: &[u8] = include_bytes!("hello-aarch64");
 
@@ -189,6 +192,41 @@ fn aarch64_hello_world_is_hooked() {
         0x1400_0000,
         "MRS TPIDR_EL0 should be rewritten to B"
     );
+}
+
+#[test]
+fn aarch64_rx_segment_padding_is_not_scanned_when_sections_exist() {
+    let mut elf = HELLO_AARCH64.to_vec();
+    let padding = 0x100;
+    assert!(
+        exec_sections(&elf)
+            .iter()
+            .all(|(offset, _, size)| !(padding >= *offset && padding < offset + size))
+    );
+    elf[padding..padding + 4].copy_from_slice(&SVC_0.to_le_bytes());
+
+    let out = hook_syscalls_in_elf(&elf, Some(0)).unwrap();
+
+    assert_eq!(read_u32(&out, padding), SVC_0);
+}
+
+#[test]
+fn aarch64_text_section_confirms_x18_code_without_symbols_or_fdes() {
+    let mut elf = HELLO_AARCH64.to_vec();
+    let sections = exec_sections(&elf);
+    assert_eq!(sections.len(), 1, "fixture should contain only .text");
+    let (text_offset, _, _) = sections[0];
+    let mov_x0_x18 = 0xAA12_03E0u32;
+    elf[text_offset..text_offset + 4].copy_from_slice(&mov_x0_x18.to_le_bytes());
+
+    let out = hook_syscalls_in_elf_with_options(
+        &elf,
+        Some(0),
+        RewriteOptions::new(TargetHost::Linux, true),
+    )
+    .unwrap();
+
+    assert_eq!(read_u32(&out, text_offset) & 0xFC00_0000, 0x1400_0000);
 }
 
 #[test]

--- a/litebox_syscall_rewriter/tests/aarch64_tests.rs
+++ b/litebox_syscall_rewriter/tests/aarch64_tests.rs
@@ -13,8 +13,10 @@
 #![allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 
 use litebox_syscall_rewriter::{
-    Error, RewriteOptions, TRAMPOLINE_MAGIC, TargetHost, hook_syscalls_in_elf,
-    hook_syscalls_in_elf_with_options,
+    Aarch64ElfCodeMetadata, Error, RewriteOptions, TRAMPOLINE_MAGIC, TargetHost,
+    hook_syscalls_in_elf, hook_syscalls_in_elf_with_options,
+    patch_aarch64_code_segment_with_options_and_ranges,
+    trap_all_aarch64_patch_sites_with_options_and_ranges,
 };
 
 const HELLO_AARCH64: &[u8] = include_bytes!("hello-aarch64");
@@ -208,6 +210,60 @@ fn aarch64_rx_segment_padding_is_not_scanned_when_sections_exist() {
     let out = hook_syscalls_in_elf(&elf, Some(0)).unwrap();
 
     assert_eq!(read_u32(&out, padding), SVC_0);
+}
+
+#[test]
+fn aarch64_metadata_projects_text_into_file_mapping() {
+    let metadata = Aarch64ElfCodeMetadata::parse(HELLO_AARCH64).unwrap();
+    let ranges = metadata.ranges_for_mapping(0, 0x140).unwrap();
+
+    assert_eq!(ranges.executable, vec![0x110..0x140]);
+    assert_eq!(ranges.identified, vec![0x110..0x140]);
+
+    let ranges = metadata.ranges_for_mapping(0x100, 0x40).unwrap();
+    assert_eq!(ranges.executable, vec![0x10..0x40]);
+    assert_eq!(ranges.identified, vec![0x10..0x40]);
+}
+
+#[test]
+fn aarch64_runtime_ranges_exclude_padding_from_x18_scan() {
+    let mut code = vec![0u8; 8];
+    code[..4].copy_from_slice(&0x5D56_4F48u32.to_le_bytes());
+    code[4..].copy_from_slice(&0xAA12_03E0u32.to_le_bytes());
+    let ranges = litebox_syscall_rewriter::Aarch64CodeScanRanges {
+        executable: core::iter::once(0..8).collect(),
+        identified: core::iter::once(4..8).collect(),
+    };
+
+    let (gates, trapped) = patch_aarch64_code_segment_with_options_and_ranges(
+        &mut code,
+        0x1000,
+        &ranges,
+        0x2000,
+        0,
+        RewriteOptions::new(TargetHost::Linux, true),
+    )
+    .unwrap();
+
+    assert!(!gates.is_empty());
+    assert!(trapped.is_empty());
+    assert_eq!(read_u32(&code, 0), 0x5D56_4F48);
+    assert_eq!(read_u32(&code, 4) & 0xFC00_0000, 0x1400_0000);
+
+    let mut trapped_code = vec![0u8; 8];
+    trapped_code[..4].copy_from_slice(&0x5D56_4F48u32.to_le_bytes());
+    trapped_code[4..].copy_from_slice(&0xAA12_03E0u32.to_le_bytes());
+    assert_eq!(
+        trap_all_aarch64_patch_sites_with_options_and_ranges(
+            &mut trapped_code,
+            0x1000,
+            &ranges,
+            RewriteOptions::new(TargetHost::Linux, true),
+        )
+        .unwrap(),
+        1
+    );
+    assert_eq!(read_u32(&trapped_code, 0), 0x5D56_4F48);
 }
 
 #[test]


### PR DESCRIPTION
This PR improves AArch64 rewriter's code identification using metadata. The metadata includes ELF symbols and exception frames.