### PR TITLE
[DRAFT] LVBS/OP-TEE: Fallible `Box`/`Vec` allocation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1721,6 +1721,7 @@ dependencies = [
  "log",
  "spin 0.10.0",
  "x86_64",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1773,7 +1774,6 @@ dependencies = [
  "litebox_common_lvbs",
  "log",
  "object",
- "once_cell",
  "rangemap",
  "rsa",
  "sha2",
@@ -1824,7 +1824,6 @@ dependencies = [
  "litebox_platform_multiplex",
  "litebox_util_log",
  "num_enum",
- "once_cell",
  "p384",
  "rangemap",
  "sha2",

--- a/litebox_common_linux/src/loader.rs
+++ b/litebox_common_linux/src/loader.rs
@@ -16,7 +16,7 @@ use litebox::{
     utils::{ReinterpretSignedExt as _, TruncateExt as _},
 };
 use thiserror::Error;
-use zerocopy::FromBytes;
+use zerocopy::{FromBytes, FromZeros as _};
 
 use crate::errno::Errno;
 
@@ -134,6 +134,8 @@ pub enum ElfParseError<E> {
     UnsupportedType,
     #[error("Bad interpreter")]
     BadInterp,
+    #[error("failed to allocate ELF parsing buffer")]
+    AllocationFailed,
 }
 
 impl<E: Into<Errno>> From<ElfParseError<E>> for Errno {
@@ -147,6 +149,7 @@ impl<E: Into<Errno>> From<ElfParseError<E>> for Errno {
             | ElfParseError::BadInterp
             | ElfParseError::UnsupportedType => Errno::ENOEXEC,
             ElfParseError::Io(err) => err.into(),
+            ElfParseError::AllocationFailed => Errno::ENOMEM,
         }
     }
 }
@@ -210,7 +213,8 @@ impl ElfParsedFile {
             .checked_mul(header.e_phnum)
             .ok_or(ElfParseError::BadFormat)?;
 
-        let mut phdrs = alloc::vec![0u8; usize::from(phdr_size)];
+        let mut phdrs = u8::new_vec_zeroed(usize::from(phdr_size))
+            .map_err(|_| ElfParseError::AllocationFailed)?;
         file.read_at(header.e_phoff, &mut phdrs)
             .map_err(ElfParseError::Io)?;
 
@@ -379,7 +383,7 @@ impl ElfParsedFile {
         if !(2..4096).contains(&len) {
             return Err(ElfParseError::BadInterp);
         }
-        let mut buf = alloc::vec![0u8; len + 1];
+        let mut buf = u8::new_vec_zeroed(len + 1).map_err(|_| ElfParseError::AllocationFailed)?;
         file.read_at(ph.p_offset, &mut buf[..len])
             .map_err(ElfParseError::Io)?;
         buf.truncate(

--- a/litebox_common_linux/src/physical_pointers.rs
+++ b/litebox_common_linux/src/physical_pointers.rs
@@ -155,7 +155,10 @@ where
         let span = end_page
             .checked_sub(start_page)
             .ok_or(PhysPointerError::Overflow)?;
-        let mut pages = alloc::vec::Vec::with_capacity(span / ALIGN);
+        let mut pages = alloc::vec::Vec::new();
+        pages
+            .try_reserve_exact(span / ALIGN)
+            .map_err(|_| PhysPointerError::AllocError)?;
         let mut current_page = start_page;
         while current_page < end_page {
             pages.push(

--- a/litebox_common_lvbs/Cargo.toml
+++ b/litebox_common_lvbs/Cargo.toml
@@ -9,7 +9,7 @@ litebox = { path = "../litebox/", version = "0.1.0" }
 litebox_common_linux = { path = "../litebox_common_linux/", version = "0.1.0" }
 num_enum = { version = "0.7.3", default-features = false }
 thiserror = { version = "2.0.6", default-features = false }
-zerocopy = { version = "0.8", default-features = false, features = ["derive"] }
+zerocopy = { version = "0.8", default-features = false, features = ["alloc", "derive"] }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 x86_64 = { version = "0.15.2", default-features = false, features = ["instructions"] }

--- a/litebox_common_lvbs/src/lib.rs
+++ b/litebox_common_lvbs/src/lib.rs
@@ -8,7 +8,7 @@
 
 extern crate alloc;
 
-use alloc::vec::Vec;
+use alloc::{boxed::Box, vec::Vec};
 use core::mem;
 use litebox::utils::TruncateExt;
 use litebox_common_linux::errno::Errno;
@@ -33,6 +33,22 @@ pub const MAX_CORES: usize = 128;
 
 /// VTL call parameters (`param[0]`: function ID, `param[1..4]`: parameters)
 pub const NUM_VTLCALL_PARAMS: usize = 4;
+
+/// Fallibly allocate a boxed value without first materializing it on the heap.
+pub fn try_box<T>(value: T) -> Result<Box<T>, zerocopy::AllocError> {
+    const { assert!(core::mem::size_of::<T>() != 0) };
+    let layout = core::alloc::Layout::new::<T>();
+    // SAFETY: `layout` describes exactly one non-zero-sized `T`. A successful
+    // allocation is aligned for `T`, and the value is written before constructing
+    // the owning Box.
+    unsafe {
+        let ptr = core::ptr::NonNull::new(alloc::alloc::alloc(layout))
+            .ok_or(zerocopy::AllocError)?
+            .cast::<T>();
+        ptr.write(value);
+        Ok(Box::from_raw(ptr.as_ptr()))
+    }
+}
 
 pub const VSM_VTL_CALL_FUNC_ID_ENABLE_APS_VTL: u32 = 0x1_ffe0;
 pub const VSM_VTL_CALL_FUNC_ID_BOOT_APS: u32 = 0x1_ffe1;
@@ -261,6 +277,9 @@ pub enum VsmError {
     #[error("failed to copy data from/to VTL0")]
     Vtl0CopyFailed,
 
+    #[error("failed to allocate VTL1 memory")]
+    AllocationFailed,
+
     // Hypercall Errors
     #[error("hypercall failed: {0:?}")]
     HypercallFailed(HypervCallError),
@@ -327,6 +346,8 @@ impl From<VsmError> for Errno {
 
             // Unsupported operation
             VsmError::OperationNotSupported(_) => Errno::ENOTSUP,
+
+            VsmError::AllocationFailed => Errno::ENOMEM,
 
             // Security/verification failures - access denied
             VsmError::TextPatchSuspicious
@@ -906,7 +927,10 @@ pub trait Vtl0Gate {
         let last_page = (end - 1) & !(page_size - 1);
 
         let page_count = ((last_page - start_page) / page_size + 1).trunc();
-        let mut pages = Vec::with_capacity(page_count);
+        let mut pages = Vec::new();
+        pages
+            .try_reserve_exact(page_count)
+            .map_err(|_| VsmError::AllocationFailed)?;
         let mut p = start_page;
         loop {
             pages.push(
@@ -924,7 +948,8 @@ pub trait Vtl0Gate {
     /// Read a `FromBytes` value out of a contiguous VTL0 physical span starting
     /// at `phys_addr`.
     fn read_vtl0_val<T: FromBytes>(&self, phys_addr: u64) -> Result<T, VsmError> {
-        let mut buf = alloc::vec![0u8; core::mem::size_of::<T>()];
+        let mut buf = u8::new_vec_zeroed(core::mem::size_of::<T>())
+            .map_err(|_| VsmError::AllocationFailed)?;
         self.read_vtl0_contiguous(phys_addr, &mut buf)?;
         T::read_from_bytes(&buf).map_err(|_| VsmError::Vtl0CopyFailed)
     }

--- a/litebox_common_lvbs/src/lib.rs
+++ b/litebox_common_lvbs/src/lib.rs
@@ -34,7 +34,9 @@ pub const MAX_CORES: usize = 128;
 /// VTL call parameters (`param[0]`: function ID, `param[1..4]`: parameters)
 pub const NUM_VTLCALL_PARAMS: usize = 4;
 
-/// Fallibly allocate a boxed value without first materializing it on the heap.
+/// Fallibly allocate heap storage and move `value` into the resulting box.
+///
+/// Replace this with `Box::try_new` once the `allocator_api` feature is stable.
 pub fn try_box<T>(value: T) -> Result<Box<T>, zerocopy::AllocError> {
     const { assert!(core::mem::size_of::<T>() != 0) };
     let layout = core::alloc::Layout::new::<T>();

--- a/litebox_common_lvbs/src/lib.rs
+++ b/litebox_common_lvbs/src/lib.rs
@@ -8,7 +8,7 @@
 
 extern crate alloc;
 
-use alloc::{boxed::Box, vec::Vec};
+use alloc::vec::Vec;
 use core::mem;
 use litebox::utils::TruncateExt;
 use litebox_common_linux::errno::Errno;
@@ -33,24 +33,6 @@ pub const MAX_CORES: usize = 128;
 
 /// VTL call parameters (`param[0]`: function ID, `param[1..4]`: parameters)
 pub const NUM_VTLCALL_PARAMS: usize = 4;
-
-/// Fallibly allocate heap storage and move `value` into the resulting box.
-///
-/// Replace this with `Box::try_new` once the `allocator_api` feature is stable.
-pub fn try_box<T>(value: T) -> Result<Box<T>, zerocopy::AllocError> {
-    const { assert!(core::mem::size_of::<T>() != 0) };
-    let layout = core::alloc::Layout::new::<T>();
-    // SAFETY: `layout` describes exactly one non-zero-sized `T`. A successful
-    // allocation is aligned for `T`, and the value is written before constructing
-    // the owning Box.
-    unsafe {
-        let ptr = core::ptr::NonNull::new(alloc::alloc::alloc(layout))
-            .ok_or(zerocopy::AllocError)?
-            .cast::<T>();
-        ptr.write(value);
-        Ok(Box::from_raw(ptr.as_ptr()))
-    }
-}
 
 pub const VSM_VTL_CALL_FUNC_ID_ENABLE_APS_VTL: u32 = 0x1_ffe0;
 pub const VSM_VTL_CALL_FUNC_ID_BOOT_APS: u32 = 0x1_ffe1;

--- a/litebox_common_optee/Cargo.toml
+++ b/litebox_common_optee/Cargo.toml
@@ -9,7 +9,7 @@ elf = { version = "0.8.0", default-features = false }
 litebox = { path = "../litebox/", version = "0.1.0" }
 litebox_common_linux = { path = "../litebox_common_linux/", version = "0.1.0" }
 num_enum = { version = "0.7.3", default-features = false }
-zerocopy = { version = "0.8", features = ["derive"] }
+zerocopy = { version = "0.8", features = ["alloc", "derive"] }
 
 [lints]
 workspace = true

--- a/litebox_common_optee/src/lib.rs
+++ b/litebox_common_optee/src/lib.rs
@@ -15,7 +15,7 @@ use litebox::utils::TruncateExt;
 use litebox_common_linux::{PtRegs, errno::Errno};
 use num_enum::TryFromPrimitive;
 use syscall_nr::{LdelfSyscallNr, TeeSyscallNr};
-use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
+use zerocopy::{FromBytes, FromZeros, Immutable, IntoBytes, KnownLayout};
 
 pub mod syscall_nr;
 
@@ -1071,7 +1071,6 @@ impl TeeObjectType {
     const UNKNOWN: Self = TeeObjectType(0xffff_ffff);
 }
 
-const TEE_SUCCESS: u32 = 0x0000_0000;
 const TEE_ERROR_CORRUPT_OBJECT: u32 = 0xf010_0001;
 const TEE_ERROR_CORRUPT_OBJECT_2: u32 = 0xf010_0002;
 const TEE_ERROR_STORAGE_NOT_AVAILABLE: u32 = 0xf010_0003;
@@ -1104,10 +1103,10 @@ const TEE_ERROR_TIME_NOT_SET: u32 = 0xffff_5000;
 const TEE_ERROR_TIME_NEEDS_RESET: u32 = 0xffff_5001;
 
 /// `TEE_Result` (API error codes) from `optee_os/lib/libutee/include/tee_api_defines.h`
-#[derive(Clone, Copy, TryFromPrimitive, PartialEq, Debug)]
+#[derive(Clone, Copy, TryFromPrimitive, PartialEq, Debug, FromZeros)]
 #[repr(u32)]
 pub enum TeeResult {
-    Success = TEE_SUCCESS,
+    Success = 0, // TEE_SUCCESS
     CorruptObject = TEE_ERROR_CORRUPT_OBJECT,
     CorruptObject2 = TEE_ERROR_CORRUPT_OBJECT_2,
     StorageNotAvailable = TEE_ERROR_STORAGE_NOT_AVAILABLE,
@@ -1365,7 +1364,6 @@ impl LdelfArg {
     }
 }
 
-const OPTEE_MSG_CMD_OPEN_SESSION: u32 = 0;
 const OPTEE_MSG_CMD_INVOKE_COMMAND: u32 = 1;
 const OPTEE_MSG_CMD_CLOSE_SESSION: u32 = 2;
 const OPTEE_MSG_CMD_CANCEL: u32 = 3;
@@ -1376,10 +1374,10 @@ const OPTEE_MSG_CMD_STOP_ASYNC_NOTIF: u32 = 7;
 
 /// `OPTEE_MSG_CMD_*` from `optee_os/core/include/optee_msg.h`
 #[non_exhaustive]
-#[derive(Clone, Copy, Debug, PartialEq, TryFromPrimitive)]
+#[derive(Clone, Copy, Debug, PartialEq, TryFromPrimitive, FromZeros)]
 #[repr(u32)]
 pub enum OpteeMessageCommand {
-    OpenSession = OPTEE_MSG_CMD_OPEN_SESSION,
+    OpenSession = 0, // OPTEE_MSG_CMD_OPEN_SESSION
     InvokeCommand = OPTEE_MSG_CMD_INVOKE_COMMAND,
     CloseSession = OPTEE_MSG_CMD_CLOSE_SESSION,
     Cancel = OPTEE_MSG_CMD_CANCEL,
@@ -1401,7 +1399,6 @@ impl TryFrom<OpteeMessageCommand> for UteeEntryFunc {
     }
 }
 
-const OPTEE_MSG_RPC_CMD_LOAD_TA: u32 = 0;
 const OPTEE_MSG_RPC_CMD_RPMB: u32 = 1;
 const OPTEE_MSG_RPC_CMD_FS: u32 = 2;
 const OPTEE_MSG_RPC_CMD_GET_TIME: u32 = 3;
@@ -1424,11 +1421,11 @@ const OPTEE_MSG_RPC_CMD_RPMB_PROBE_FRAMES: u32 = 24;
 /// They live in a separate namespace from [`OpteeMessageCommand`] (which is for main
 /// messaging between the normal-world driver and OP-TEE OS).
 #[non_exhaustive]
-#[derive(Clone, Copy, Debug, PartialEq, TryFromPrimitive)]
+#[derive(Clone, Copy, Debug, PartialEq, TryFromPrimitive, FromZeros)]
 #[repr(u32)]
 pub enum OpteeRpcCommand {
     /// Load a TA into memory, defined in tee-supplicant.
-    LoadTa = OPTEE_MSG_RPC_CMD_LOAD_TA,
+    LoadTa = 0, // OPTEE_MSG_RPC_CMD_LOAD_TA
     /// Reserved
     Rpmb = OPTEE_MSG_RPC_CMD_RPMB,
     /// REE file-system access, defined in tee-supplicant.
@@ -1759,7 +1756,7 @@ impl From<OpteeRpcArgs> for OpteeMsgArgsHeader {
 /// `optee_msg_arg` from `optee_os/core/include/optee_msg.h`
 /// OP-TEE message argument structure that the normal world (or VTL0) OP-TEE driver and OP-TEE OS use to
 /// exchange messages.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, FromZeros)]
 #[repr(C)]
 pub struct OpteeMsgArgs {
     /// OP-TEE message command. This is a superset of `UteeEntryFunc`.
@@ -1983,7 +1980,7 @@ impl OpteeMsgArgs {
 ///
 /// The remaining header fields (`func`, `session`, `cancel_id`) are **unused** for RPC
 /// and always zero on the wire. They are not exposed in this struct.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, FromZeros)]
 #[repr(C)]
 pub struct OpteeRpcArgs {
     /// RPC command ID. Unlike main args, this uses [`OpteeRpcCommand`] (e.g. `LoadTa`,

--- a/litebox_platform_lvbs/src/host/lvbs_impl.rs
+++ b/litebox_platform_lvbs/src/host/lvbs_impl.rs
@@ -271,8 +271,8 @@ impl HostInterface for HostLvbsInterface {
         serial_print_string(msg);
     }
 
-    fn alloc(layout: &core::alloc::Layout) -> Option<(usize, usize)> {
-        panic!("dynamic memory allocation is not supported (layout = {layout:?})");
+    fn alloc(_layout: &core::alloc::Layout) -> Option<(usize, usize)> {
+        None
     }
 
     unsafe fn free(_addr: usize) {

--- a/litebox_platform_lvbs/src/lib.rs
+++ b/litebox_platform_lvbs/src/lib.rs
@@ -359,7 +359,6 @@ impl PageTableManager {
         let task_pt_id: usize = pt.get_physical_frame().start_address().as_u64().trunc();
 
         let mut task_pts = self.task_page_tables.write();
-        task_pts.try_reserve(1).map_err(|_| Errno::ENOMEM)?;
         task_pts.insert(task_pt_id, pt);
 
         Ok(task_pt_id)
@@ -1202,9 +1201,7 @@ unsafe impl<Host: HostInterface, const ALIGN: usize> VmapManager<ALIGN> for Linu
         // rejects duplicate/shared mappings, but this keeps the error local to the input array.
         // A single page can never collide with itself, so skip the set allocation.
         if pages.len() > 1 {
-            let mut seen = hashbrown::HashSet::new();
-            seen.try_reserve(pages.len())
-                .map_err(|_| PhysPointerError::AllocError)?;
+            let mut seen = hashbrown::HashSet::with_capacity(pages.len());
             for page in pages {
                 if !seen.insert(page.as_usize()) {
                     return Err(PhysPointerError::DuplicatePhysicalAddress(page.as_usize()));

--- a/litebox_platform_lvbs/src/lib.rs
+++ b/litebox_platform_lvbs/src/lib.rs
@@ -359,6 +359,7 @@ impl PageTableManager {
         let task_pt_id: usize = pt.get_physical_frame().start_address().as_u64().trunc();
 
         let mut task_pts = self.task_page_tables.write();
+        task_pts.try_reserve(1).map_err(|_| Errno::ENOMEM)?;
         task_pts.insert(task_pt_id, pt);
 
         Ok(task_pt_id)
@@ -1201,7 +1202,9 @@ unsafe impl<Host: HostInterface, const ALIGN: usize> VmapManager<ALIGN> for Linu
         // rejects duplicate/shared mappings, but this keeps the error local to the input array.
         // A single page can never collide with itself, so skip the set allocation.
         if pages.len() > 1 {
-            let mut seen = hashbrown::HashSet::with_capacity(pages.len());
+            let mut seen = hashbrown::HashSet::new();
+            seen.try_reserve(pages.len())
+                .map_err(|_| PhysPointerError::AllocError)?;
             for page in pages {
                 if !seen.insert(page.as_usize()) {
                     return Err(PhysPointerError::DuplicatePhysicalAddress(page.as_usize()));
@@ -1222,15 +1225,18 @@ unsafe impl<Host: HostInterface, const ALIGN: usize> VmapManager<ALIGN> for Linu
         //
         // `validate_unowned` rejects VTL1-owned PA before callers reach `vmap`, so these pages are
         // foreign and the vmap VA range never aliases VTL1-owned Rust memory.
-        let frames: alloc::vec::Vec<PhysFrame<Size4KiB>> = pages
-            .iter()
-            .map(|p| {
-                let address = p.as_usize();
+        let mut frames = alloc::vec::Vec::new();
+        frames
+            .try_reserve_exact(pages.len())
+            .map_err(|_| PhysPointerError::AllocError)?;
+        for page in pages {
+            let address = page.as_usize();
+            frames.push(
                 x86_64::PhysAddr::try_new(address as u64)
                     .map(PhysFrame::containing_address)
-                    .map_err(|_| PhysPointerError::InvalidPhysicalAddress(address))
-            })
-            .collect::<Result<_, _>>()?;
+                    .map_err(|_| PhysPointerError::InvalidPhysicalAddress(address))?,
+            );
+        }
 
         let base_va = vmap_allocator()
             .allocate_va(frames.len())

--- a/litebox_platform_lvbs/src/mshv/vsm.rs
+++ b/litebox_platform_lvbs/src/mshv/vsm.rs
@@ -319,8 +319,17 @@ impl FrameReservation {
     /// claims added by this call are rolled back.
     pub(crate) fn reserve(
         &mut self,
-        frames: impl IntoIterator<Item = PhysFrameRange<Size4KiB>>,
+        frames: &[PhysFrameRange<Size4KiB>],
     ) -> Result<Vec<ReservationStatus>, VsmError> {
+        let reserve_count = frames.len();
+        let mut statuses = Vec::new();
+        statuses
+            .try_reserve_exact(reserve_count)
+            .map_err(|_| VsmError::AllocationFailed)?;
+        self.owned_ranges
+            .try_reserve(reserve_count)
+            .map_err(|_| VsmError::AllocationFailed)?;
+
         let vtl1 = crate::platform_low().vtl1_phys_frame_range();
         let vtl1_start = vtl1.start.start_address().as_u64();
         let vtl1_end = vtl1.end.start_address().as_u64();
@@ -329,10 +338,9 @@ impl FrameReservation {
             // Idempotence applies only to ranges owned before this call.
             let owned_before = self.owned_frames.clone();
             let mut seen = RangeSet::new();
-            let mut statuses = Vec::new();
             // Frames this call adds, so a later overlap rolls back only them.
             let rollback_from = self.owned_ranges.len();
-            for phys_frame_range in frames {
+            for &phys_frame_range in frames {
                 let start = phys_frame_range.start.start_address().as_u64();
                 let end = phys_frame_range.end.start_address().as_u64();
                 if start >= end {
@@ -659,7 +667,7 @@ impl FrameTxn for PlatformFrameTxn<'_> {
         &mut self,
         ranges: &[PhysFrameRange<Size4KiB>],
     ) -> Result<Vec<ReservationStatus>, VsmError> {
-        self.guard.reserve(ranges.iter().copied())
+        self.guard.reserve(ranges)
     }
 
     fn protect(&mut self, range: PhysFrameRange<Size4KiB>, attr: MemAttr) -> Result<(), VsmError> {
@@ -698,7 +706,7 @@ impl Vtl0Gate for LvbsVtl0Gate {
         f: &mut dyn FnMut(&mut dyn FrameTxn) -> Result<(), VsmError>,
     ) -> Result<(), VsmError> {
         let mut guard = FrameReservation::new();
-        guard.reserve(initial.iter().copied())?;
+        guard.reserve(initial)?;
         let mut txn = PlatformFrameTxn { guard: &mut guard };
         let result = f(&mut txn);
         if result.is_ok() {

--- a/litebox_platform_lvbs/src/mshv/vsm.rs
+++ b/litebox_platform_lvbs/src/mshv/vsm.rs
@@ -327,7 +327,7 @@ impl FrameReservation {
             .try_reserve_exact(reserve_count)
             .map_err(|_| VsmError::AllocationFailed)?;
         self.owned_ranges
-            .try_reserve(reserve_count)
+            .try_reserve_exact(reserve_count)
             .map_err(|_| VsmError::AllocationFailed)?;
 
         let vtl1 = crate::platform_low().vtl1_phys_frame_range();

--- a/litebox_runner_lvbs/Cargo.toml
+++ b/litebox_runner_lvbs/Cargo.toml
@@ -16,6 +16,7 @@ litebox_shim_optee = { path = "../litebox_shim_optee/", version = "0.1.0" }
 litebox_util_log = { version = "0.1.0", path = "../litebox_util_log" }
 log = { version = "0.4", default-features = false }
 spin = { version = "0.10.0", default-features = false, features = ["spin_mutex"] }
+zerocopy = { version = "0.8", default-features = false, features = ["alloc"] }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 x86_64 = { version = "0.15.2", default-features = false, features = ["instructions"] }

--- a/litebox_runner_lvbs/src/lib.rs
+++ b/litebox_runner_lvbs/src/lib.rs
@@ -5,7 +5,6 @@
 
 extern crate alloc;
 
-use alloc::{boxed::Box, vec};
 use core::{ops::Neg, panic::PanicInfo};
 use litebox::{
     mm::linux::PAGE_SIZE,
@@ -44,6 +43,7 @@ use litebox_shim_optee::msg_handler::{
 };
 use litebox_shim_optee::session::{OpenSessionTarget, TaInstance, session_manager};
 use litebox_shim_optee::{NormalWorldConstPtr, NormalWorldMutPtr, UserConstPtr};
+use zerocopy::FromZeros as _;
 
 /// Seed the initial heap regions so the global allocator has enough memory
 /// for slab-backed allocations (the slab needs >= 2 MB backing pages).
@@ -806,13 +806,18 @@ fn open_session_new_instance(
         let _ = unsafe { delete_task_page_table(task_pt_id) };
     })?;
 
-    // Load ldelf and TA - Box immediately to keep at fixed heap address
-    let loaded_program = Box::new(shim.load_ldelf(LDELF_BINARY, ta_uuid).map_err(|_| {
+    let loaded_program = shim.load_ldelf(LDELF_BINARY, ta_uuid).map_err(|_| {
         // Safety: We are about to tear down this TA instance;
         // no references to user-space memory will be held afterwards.
         unsafe { teardown_ta_page_table(&shim, task_pt_id) };
         OpteeSmcReturnCode::ENomem
-    })?);
+    })?;
+    let loaded_program = litebox_common_lvbs::try_box(loaded_program)
+        .map_err(|_| OpteeSmcReturnCode::ENomem)
+        .inspect_err(|_| {
+            // Safety: No TA user-space references have been created yet.
+            unsafe { teardown_ta_page_table(&shim, task_pt_id) };
+        })?;
 
     let ta_flags = loaded_program.ta_flags;
 
@@ -1277,7 +1282,7 @@ fn write_msg_args_to_normal_world(
     )?;
 
     let msg_args_size = optee_msg_args_total_size(msg_args.num_params);
-    let mut blob = vec![0u8; msg_args_size];
+    let mut blob = u8::new_vec_zeroed(msg_args_size).map_err(|_| OpteeSmcReturnCode::ENomem)?;
     msg_args.serialize(&mut blob)?;
 
     let ptr = NormalWorldMutPtr::<u8, PAGE_SIZE>::with_contiguous_pages(
@@ -1301,7 +1306,7 @@ fn write_non_ta_msg_args_to_normal_world(
     msg_args_phys_addr: u64,
 ) -> Result<(), OpteeSmcReturnCode> {
     let msg_args_size = optee_msg_args_total_size(msg_args.num_params);
-    let mut blob = vec![0u8; msg_args_size];
+    let mut blob = u8::new_vec_zeroed(msg_args_size).map_err(|_| OpteeSmcReturnCode::ENomem)?;
     msg_args.serialize(&mut blob)?;
 
     let ptr = NormalWorldMutPtr::<u8, PAGE_SIZE>::with_contiguous_pages(
@@ -1328,7 +1333,7 @@ fn write_rpc_args_to_normal_world(
     let msg_args_size = optee_msg_args_total_size(msg_args.num_params);
 
     let rpc_args_size = optee_msg_args_total_size(rpc_args.num_params);
-    let mut blob = vec![0u8; rpc_args_size];
+    let mut blob = u8::new_vec_zeroed(rpc_args_size).map_err(|_| OpteeSmcReturnCode::ENomem)?;
     rpc_args.serialize(&mut blob)?;
 
     let rpc_pa: usize = <u64 as litebox::utils::TruncateExt<usize>>::trunc(msg_args_phys_addr)

--- a/litebox_runner_lvbs/src/lib.rs
+++ b/litebox_runner_lvbs/src/lib.rs
@@ -812,12 +812,6 @@ fn open_session_new_instance(
         unsafe { teardown_ta_page_table(&shim, task_pt_id) };
         OpteeSmcReturnCode::ENomem
     })?;
-    let loaded_program = litebox_common_lvbs::try_box(loaded_program)
-        .map_err(|_| OpteeSmcReturnCode::ENomem)
-        .inspect_err(|_| {
-            // Safety: No TA user-space references have been created yet.
-            unsafe { teardown_ta_page_table(&shim, task_pt_id) };
-        })?;
 
     let ta_flags = loaded_program.ta_flags;
 

--- a/litebox_service_heki/Cargo.toml
+++ b/litebox_service_heki/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 litebox = { path = "../litebox/", version = "0.1.0" }
 litebox_common_lvbs = { path = "../litebox_common_lvbs/", version = "0.1.0" }
 litebox_common_linux = { path = "../litebox_common_linux/", version = "0.1.0" }
-zerocopy = { version = "0.8", default-features = false, features = ["derive"] }
+zerocopy = { version = "0.8", default-features = false, features = ["alloc", "derive"] }
 x86_64 = { version = "0.15.2", default-features = false, features = ["instructions"] }
 log = { version = "0.4", default-features = false }
 spin = { version = "0.10.0", default-features = false, features = [
@@ -18,7 +18,6 @@ spin = { version = "0.10.0", default-features = false, features = [
 hashbrown = "0.15.2"
 rangemap = { version = "1.5.1", features = ["const_fn"] }
 thiserror = { version = "2.0.6", default-features = false }
-once_cell = { version = "1.20.2", default-features = false, features = ["alloc", "race"] }
 elf = { version = "0.8.0", default-features = false }
 cms = { version = "0.2.3", default-features = false, features = ["alloc"] }
 rsa = { version = "0.9.10", default-features = false }

--- a/litebox_service_heki/src/handlers.rs
+++ b/litebox_service_heki/src/handlers.rs
@@ -127,6 +127,12 @@ impl<P: Vtl0Gate> Heki<P> {
 
         let heki_pages = copy_heki_pages_from_vtl0(&self.gate, pa, nranges)
             .ok_or(VsmError::HekiPagesCopyFailed)?;
+        let range_count = heki_pages.iter().map(|page| page.iter().len()).sum();
+        system_certs_mem.try_reserve_ranges(range_count)?;
+        kexec_trampoline_metadata.try_reserve_ranges(range_count)?;
+        patch_info_mem.try_reserve_ranges(range_count)?;
+        kinfo_mem.try_reserve_ranges(range_count)?;
+        kdata_mem.try_reserve_ranges(range_count)?;
 
         for heki_page in &heki_pages {
             for heki_range in heki_page {
@@ -270,6 +276,11 @@ impl<P: Vtl0Gate> Heki<P> {
 
         let heki_pages = copy_heki_pages_from_vtl0(&self.gate, pa, nranges)
             .ok_or(VsmError::HekiPagesCopyFailed)?;
+        let range_count = heki_pages.iter().map(|page| page.iter().len()).sum();
+        module_memory_metadata.try_reserve_ranges(range_count)?;
+        module_in_memory.try_reserve_ranges(range_count)?;
+        module_as_elf.try_reserve_ranges(range_count)?;
+        patch_info_for_module.try_reserve_ranges(range_count)?;
 
         for heki_page in &heki_pages {
             for heki_range in heki_page {
@@ -288,7 +299,7 @@ impl<P: Vtl0Gate> Heki<P> {
                         if !heki_range.is_aligned(Size4KiB::SIZE) {
                             return Err(VsmError::AddressNotPageAligned);
                         }
-                        module_memory_metadata.insert_heki_range(heki_range)?;
+                        module_memory_metadata.insert_heki_range(heki_range);
                         module_in_memory
                             .extend_range(heki_range.mod_mem_type(), heki_range)
                             .map_err(|_| VsmError::InvalidInputAddress)?;
@@ -487,6 +498,10 @@ impl<P: Vtl0Gate> Heki<P> {
 
         let heki_pages = copy_heki_pages_from_vtl0(&self.gate, pa, nranges)
             .ok_or(VsmError::HekiPagesCopyFailed)?;
+        let range_count = heki_pages.iter().map(|page| page.iter().len()).sum();
+        kexec_memory_metadata.try_reserve_ranges(range_count)?;
+        kexec_image.try_reserve_ranges(range_count)?;
+        kexec_kernel_blob.try_reserve_ranges(range_count)?;
 
         for heki_page in &heki_pages {
             for heki_range in heki_page {
@@ -560,12 +575,13 @@ impl<P: Vtl0Gate> Heki<P> {
                         .map_err(|_| VsmError::AllocationFailed)?;
                     segment_frame_ranges.extend(segment_ranges.iter().map(|r| r.phys_frame_range));
                     let reservation_statuses = txn.reserve(&segment_frame_ranges)?;
+                    kexec_memory_metadata.try_reserve_ranges(segment_ranges.len())?;
                     for (segment_range, status) in
                         segment_ranges.into_iter().zip(reservation_statuses)
                     {
                         if status == ReservationStatus::New {
                             txn.protect(segment_range.phys_frame_range, MemAttr::MEM_ATTR_READ)?;
-                            kexec_memory_metadata.insert_memory_range(segment_range)?;
+                            kexec_memory_metadata.insert_memory_range(segment_range);
                         }
                     }
                 }
@@ -692,7 +708,7 @@ fn copy_heki_pages_from_vtl0<P: Vtl0Gate>(
     nranges: u64,
 ) -> Option<Vec<HekiPage>> {
     let mut heki_pages = Vec::new();
-    heki_pages.try_reserve(nranges.trunc()).ok()?;
+    heki_pages.try_reserve_exact(nranges.trunc()).ok()?;
     let mut visited_pages = HashSet::new();
     let mut range: u64 = 0;
 
@@ -722,9 +738,29 @@ fn copy_heki_pages_from_vtl0<P: Vtl0Gate>(
 
 /// Parse a concatenated run of DER-encoded X.509 certificates.
 fn parse_certs(mut buf: &[u8]) -> Result<Vec<Certificate>, VsmError> {
-    let mut certs = Vec::new();
+    const DER_SEQUENCE_TAG: u8 = 0x30;
+    const DER_TWO_BYTE_LENGTH: u8 = 0x82;
 
-    while buf.len() >= 4 && buf[0] == 0x30 && buf[1] == 0x82 {
+    let mut certs = Vec::new();
+    let mut remaining = buf;
+    let mut cert_count = 0;
+    while remaining.len() >= 4
+        && remaining[0] == DER_SEQUENCE_TAG
+        && remaining[1] == DER_TWO_BYTE_LENGTH
+    {
+        let der_len = ((remaining[2] as usize) << 8) | (remaining[3] as usize);
+        let total_len = der_len + 4;
+        if remaining.len() < total_len {
+            break;
+        }
+        cert_count += 1;
+        remaining = &remaining[total_len..];
+    }
+    certs
+        .try_reserve_exact(cert_count)
+        .map_err(|_| VsmError::AllocationFailed)?;
+
+    while buf.len() >= 4 && buf[0] == DER_SEQUENCE_TAG && buf[1] == DER_TWO_BYTE_LENGTH {
         let der_len = ((buf[2] as usize) << 8) | (buf[3] as usize);
         let total_len = der_len + 4;
 
@@ -738,9 +774,6 @@ fn parse_certs(mut buf: &[u8]) -> Result<Vec<Certificate>, VsmError> {
         let cert_bytes = &buf[..total_len];
         let cert =
             Certificate::from_der(cert_bytes).map_err(|_| VsmError::CertificateParseFailed)?;
-        certs
-            .try_reserve(1)
-            .map_err(|_| VsmError::AllocationFailed)?;
         certs.push(cert);
         buf = &buf[total_len..];
     }

--- a/litebox_service_heki/src/handlers.rs
+++ b/litebox_service_heki/src/handlers.rs
@@ -26,7 +26,7 @@ use litebox_common_lvbs::{
 };
 use x86_64::{
     PhysAddr, VirtAddr,
-    structures::paging::{PageSize, PhysFrame, Size4KiB, frame::PhysFrameRange},
+    structures::paging::{PageSize, PhysFrame, Size4KiB},
 };
 use x509_cert::{Certificate, der::Decode};
 use zerocopy::{FromBytes, FromZeros, IntoBytes};
@@ -162,18 +162,10 @@ impl<P: Vtl0Gate> Heki<P> {
             }
         }
 
-        system_certs_mem
-            .write_bytes_from_heki_range(&self.gate)
-            .map_err(|_| VsmError::Vtl0CopyFailed)?;
-        patch_info_mem
-            .write_bytes_from_heki_range(&self.gate)
-            .map_err(|_| VsmError::Vtl0CopyFailed)?;
-        kinfo_mem
-            .write_bytes_from_heki_range(&self.gate)
-            .map_err(|_| VsmError::Vtl0CopyFailed)?;
-        kdata_mem
-            .write_bytes_from_heki_range(&self.gate)
-            .map_err(|_| VsmError::Vtl0CopyFailed)?;
+        system_certs_mem.write_bytes_from_heki_range(&self.gate)?;
+        patch_info_mem.write_bytes_from_heki_range(&self.gate)?;
+        kinfo_mem.write_bytes_from_heki_range(&self.gate)?;
+        kdata_mem.write_bytes_from_heki_range(&self.gate)?;
 
         if system_certs_mem.is_empty() {
             return Err(VsmError::SystemCertificatesNotFound);
@@ -189,8 +181,9 @@ impl<P: Vtl0Gate> Heki<P> {
         // The system certificate is loaded into VTL1 and locked down before `end_of_boot` is signaled.
         // Its integrity depends on UEFI Secure Boot which ensures only trusted software is loaded during
         // the boot process.
-        self.set_system_certificates(certs.clone());
-        log::debug!("HEKI: Loaded {} system certificate(s)", certs.len());
+        let cert_count = certs.len();
+        self.set_system_certificates(certs);
+        log::debug!("HEKI: Loaded {cert_count} system certificate(s)");
 
         // ToDo: Remove kexec_trampoline_insert_failed and protect kexec_trampoline_metadata
         // once we have a better solution to handle the non-page-aligned kexec trampoline metadata.
@@ -295,7 +288,7 @@ impl<P: Vtl0Gate> Heki<P> {
                         if !heki_range.is_aligned(Size4KiB::SIZE) {
                             return Err(VsmError::AddressNotPageAligned);
                         }
-                        module_memory_metadata.insert_heki_range(heki_range);
+                        module_memory_metadata.insert_heki_range(heki_range)?;
                         module_in_memory
                             .extend_range(heki_range.mod_mem_type(), heki_range)
                             .map_err(|_| VsmError::InvalidInputAddress)?;
@@ -308,10 +301,11 @@ impl<P: Vtl0Gate> Heki<P> {
         // The reserve + freeze + validate + promote + patch-commit sequence runs transactionally: the
         // gate reserves `initial`, commits on `Ok`, and rolls back (unprotecting every newly
         // reserved range) on `Err`.
-        let initial: Vec<PhysFrameRange<Size4KiB>> = module_memory_metadata
-            .iter()
-            .map(|r| r.phys_frame_range)
-            .collect();
+        let mut initial = Vec::new();
+        initial
+            .try_reserve_exact(module_memory_metadata.iter().len())
+            .map_err(|_| VsmError::AllocationFailed)?;
+        initial.extend(module_memory_metadata.iter().map(|r| r.phys_frame_range));
         self.gate
             .protect_frames_transactionally(&initial, &mut |txn| {
                 // Freeze frames that require immutable copy/validation to avoid TOCTOU.
@@ -323,15 +317,9 @@ impl<P: Vtl0Gate> Heki<P> {
                     }
                 }
 
-                module_as_elf
-                    .write_bytes_from_heki_range(&self.gate)
-                    .map_err(|_| VsmError::Vtl0CopyFailed)?;
-                patch_info_for_module
-                    .write_bytes_from_heki_range(&self.gate)
-                    .map_err(|_| VsmError::Vtl0CopyFailed)?;
-                module_in_memory
-                    .write_bytes_from_heki_range(&self.gate)
-                    .map_err(|_| VsmError::Vtl0CopyFailed)?;
+                module_as_elf.write_bytes_from_heki_range(&self.gate)?;
+                patch_info_for_module.write_bytes_from_heki_range(&self.gate)?;
+                module_in_memory.write_bytes_from_heki_range(&self.gate)?;
 
                 let elf_size = (module_as_elf[..]).len();
                 if elf_size > MODULE_VALIDATION_MAX_SIZE {
@@ -348,9 +336,7 @@ impl<P: Vtl0Gate> Heki<P> {
 
                 verify_kernel_module_signature(original_elf_data, certs)?;
 
-                if !validate_kernel_module_against_elf(&module_in_memory, original_elf_data)
-                    .map_err(|_| VsmError::Vtl0CopyFailed)?
-                {
+                if !validate_kernel_module_against_elf(&module_in_memory, original_elf_data)? {
                     return Err(VsmError::ModuleRelocationInvalid);
                 }
 
@@ -423,7 +409,7 @@ impl<P: Vtl0Gate> Heki<P> {
 
         // Drop the init ranges from the module's metadata regardless of failures. This is intentional
         // since hypercalls shouldn't fail and avoiding double release is more important.
-        let freed_init_patch_targets = self.module_memory_metadata.remove_init_ranges(token);
+        let freed_init_patch_targets = self.module_memory_metadata.remove_init_ranges(token)?;
         // Remove the precomputed patches targeting those freed init frames so a stale init patch cannot
         // later be applied to recycled frames (no patch-after-free).
         if !freed_init_patch_targets.is_empty() {
@@ -449,7 +435,7 @@ impl<P: Vtl0Gate> Heki<P> {
             }
         }
 
-        if let Some(patch_targets) = self.module_memory_metadata.get_patch_targets(token) {
+        if let Some(patch_targets) = self.module_memory_metadata.get_patch_targets(token)? {
             self.precomputed_patches.remove_patch_data(&patch_targets);
         }
 
@@ -532,22 +518,19 @@ impl<P: Vtl0Gate> Heki<P> {
         // Reserve then freeze the protected kexec frames, rejecting overlap with VTL1 or other
         // protected frames. The reserve/protect (incl. the mid-flow segment reserve for crash kexec),
         // blob copy, and signature check run transactionally: commit on `Ok`, rollback on `Err`.
-        let initial: Vec<PhysFrameRange<Size4KiB>> = kexec_memory_metadata
-            .iter()
-            .map(|r| r.phys_frame_range)
-            .collect();
+        let mut initial = Vec::new();
+        initial
+            .try_reserve_exact(kexec_memory_metadata.iter().len())
+            .map_err(|_| VsmError::AllocationFailed)?;
+        initial.extend(kexec_memory_metadata.iter().map(|r| r.phys_frame_range));
         self.gate
             .protect_frames_transactionally(&initial, &mut |txn| {
                 for kexec_mem_range in &kexec_memory_metadata {
                     txn.protect(kexec_mem_range.phys_frame_range, MemAttr::MEM_ATTR_READ)?;
                 }
 
-                kexec_image
-                    .write_bytes_from_heki_range(&self.gate)
-                    .map_err(|_| VsmError::Vtl0CopyFailed)?;
-                kexec_kernel_blob
-                    .write_bytes_from_heki_range(&self.gate)
-                    .map_err(|_| VsmError::Vtl0CopyFailed)?;
+                kexec_image.write_bytes_from_heki_range(&self.gate)?;
+                kexec_kernel_blob.write_bytes_from_heki_range(&self.gate)?;
 
                 // If this function is called for crash kexec, we protect its kimage segments as well.
                 if is_crash {
@@ -558,6 +541,9 @@ impl<P: Vtl0Gate> Heki<P> {
                         return Err(VsmError::KexecImageSegmentsInvalid);
                     }
                     let mut segment_ranges = Vec::new();
+                    segment_ranges
+                        .try_reserve_exact(kimage.nr_segments.trunc())
+                        .map_err(|_| VsmError::AllocationFailed)?;
                     for i in 0..usize::try_from(kimage.nr_segments).unwrap_or(0) {
                         VirtAddr::try_new(kimage.segment[i].buf)
                             .map_err(|_| VsmError::InvalidVirtualAddress)?;
@@ -568,15 +554,18 @@ impl<P: Vtl0Gate> Heki<P> {
                             return Err(VsmError::KexecSegmentRangeInvalid);
                         }
                     }
-                    let segment_frame_ranges: Vec<PhysFrameRange<Size4KiB>> =
-                        segment_ranges.iter().map(|r| r.phys_frame_range).collect();
+                    let mut segment_frame_ranges = Vec::new();
+                    segment_frame_ranges
+                        .try_reserve_exact(segment_ranges.len())
+                        .map_err(|_| VsmError::AllocationFailed)?;
+                    segment_frame_ranges.extend(segment_ranges.iter().map(|r| r.phys_frame_range));
                     let reservation_statuses = txn.reserve(&segment_frame_ranges)?;
                     for (segment_range, status) in
                         segment_ranges.into_iter().zip(reservation_statuses)
                     {
                         if status == ReservationStatus::New {
                             txn.protect(segment_range.phys_frame_range, MemAttr::MEM_ATTR_READ)?;
-                            kexec_memory_metadata.insert_memory_range(segment_range);
+                            kexec_memory_metadata.insert_memory_range(segment_range)?;
                         }
                     }
                 }
@@ -749,6 +738,9 @@ fn parse_certs(mut buf: &[u8]) -> Result<Vec<Certificate>, VsmError> {
         let cert_bytes = &buf[..total_len];
         let cert =
             Certificate::from_der(cert_bytes).map_err(|_| VsmError::CertificateParseFailed)?;
+        certs
+            .try_reserve(1)
+            .map_err(|_| VsmError::AllocationFailed)?;
         certs.push(cert);
         buf = &buf[total_len..];
     }

--- a/litebox_service_heki/src/lib.rs
+++ b/litebox_service_heki/src/lib.rs
@@ -16,7 +16,7 @@ extern crate alloc;
 mod handlers;
 mod mem_integrity;
 
-use alloc::{boxed::Box, ffi::CString, string::String, vec::Vec};
+use alloc::{ffi::CString, string::String, vec::Vec};
 use core::ffi::{CStr, c_char};
 use core::{
     mem,
@@ -47,7 +47,7 @@ pub struct Heki<P: Vtl0Gate> {
     /// gate out of every handler signature.
     pub(crate) gate: P,
     pub(crate) module_memory_metadata: ModuleMemoryMetadataMap,
-    system_certs: once_cell::race::OnceBox<Box<[Certificate]>>,
+    system_certs: spin::Once<Vec<Certificate>>,
     pub(crate) kexec_metadata: KexecMemoryMetadataWrapper,
     pub(crate) crash_kexec_metadata: KexecMemoryMetadataWrapper,
     pub(crate) precomputed_patches: PatchDataMap,
@@ -65,7 +65,7 @@ impl<P: Vtl0Gate> Heki<P> {
         Self {
             gate,
             module_memory_metadata: ModuleMemoryMetadataMap::new(),
-            system_certs: once_cell::race::OnceBox::new(),
+            system_certs: spin::Once::new(),
             kexec_metadata: KexecMemoryMetadataWrapper::new(),
             crash_kexec_metadata: KexecMemoryMetadataWrapper::new(),
             precomputed_patches: PatchDataMap::new(),
@@ -75,12 +75,11 @@ impl<P: Vtl0Gate> Heki<P> {
     }
 
     pub(crate) fn set_system_certificates(&self, certs: Vec<Certificate>) {
-        let boxed_slice = certs.into_boxed_slice();
-        let _ = self.system_certs.set(boxed_slice.into());
+        self.system_certs.call_once(|| certs);
     }
 
     pub(crate) fn get_system_certificates(&self) -> Option<&[Certificate]> {
-        self.system_certs.get().map(|b| &**b)
+        self.system_certs.get().map(Vec::as_slice)
     }
 
     /// This function finds the precomputed patch data corresponding to the input patch data.
@@ -123,7 +122,7 @@ impl ModuleMemoryMetadata {
     }
 
     #[inline]
-    pub(crate) fn insert_heki_range(&mut self, heki_range: &HekiRange) {
+    pub(crate) fn insert_heki_range(&mut self, heki_range: &HekiRange) -> Result<(), VsmError> {
         // `HekiRange::is_valid` already validated these addresses.
         let pa = heki_range.pa;
         let epa = heki_range.epa;
@@ -131,17 +130,28 @@ impl ModuleMemoryMetadata {
             pa,
             epa,
             heki_range.mod_mem_type(),
-        ));
+        ))
     }
 
     #[inline]
-    pub(crate) fn insert_memory_range(&mut self, mem_range: ModuleMemoryRange) {
+    pub(crate) fn insert_memory_range(
+        &mut self,
+        mem_range: ModuleMemoryRange,
+    ) -> Result<(), VsmError> {
+        self.ranges
+            .try_reserve(1)
+            .map_err(|_| VsmError::AllocationFailed)?;
         self.ranges.push(mem_range);
+        Ok(())
     }
 
     #[inline]
-    pub(crate) fn insert_patch_target(&mut self, patch_target: PhysAddr) {
+    pub(crate) fn insert_patch_target(&mut self, patch_target: PhysAddr) -> Result<(), VsmError> {
+        self.patch_targets
+            .try_reserve(1)
+            .map_err(|_| VsmError::AllocationFailed)?;
         self.patch_targets.push(patch_target);
+        Ok(())
     }
 
     // This function returns patch targets belonging to this module to remove them
@@ -251,7 +261,7 @@ impl ModuleMemoryMetadataMap {
     /// It also returns patch targets that fell within this freed init frames. These patch targets
     /// are no longer valid (i.e., potential patch-after-free) and thus their corresponding
     /// precomputed patches should be removed (we can't remove them here due to locks).
-    pub(crate) fn remove_init_ranges(&self, key: i64) -> Vec<PhysAddr> {
+    pub(crate) fn remove_init_ranges(&self, key: i64) -> Result<Vec<PhysAddr>, VsmError> {
         let is_init = |t| {
             matches!(
                 t,
@@ -260,16 +270,24 @@ impl ModuleMemoryMetadataMap {
         };
         let mut map = self.inner.lock();
         let Some(metadata) = map.get_mut(&key) else {
-            return Vec::new();
+            return Ok(Vec::new());
         };
-        let init_ranges: Vec<PhysFrameRange<Size4KiB>> = metadata
-            .ranges
-            .iter()
-            .filter(|r| is_init(r.mod_mem_type))
-            .map(|r| r.phys_frame_range)
-            .collect();
-        metadata.ranges.retain(|r| !is_init(r.mod_mem_type));
+        let mut init_ranges = Vec::new();
+        init_ranges
+            .try_reserve_exact(metadata.ranges.len())
+            .map_err(|_| VsmError::AllocationFailed)?;
+        init_ranges.extend(
+            metadata
+                .ranges
+                .iter()
+                .filter(|r| is_init(r.mod_mem_type))
+                .map(|r| r.phys_frame_range),
+        );
         let mut freed_patch_targets = Vec::new();
+        freed_patch_targets
+            .try_reserve_exact(metadata.patch_targets.len())
+            .map_err(|_| VsmError::AllocationFailed)?;
+        metadata.ranges.retain(|r| !is_init(r.mod_mem_type));
         metadata.patch_targets.retain(|&pa| {
             let freed = init_ranges
                 .iter()
@@ -281,15 +299,21 @@ impl ModuleMemoryMetadataMap {
                 true
             }
         });
-        freed_patch_targets
+        Ok(freed_patch_targets)
     }
 
     /// Return the addresses of patch targets belonging to a module identified by `key`
-    pub(crate) fn get_patch_targets(&self, key: i64) -> Option<Vec<PhysAddr>> {
+    pub(crate) fn get_patch_targets(&self, key: i64) -> Result<Option<Vec<PhysAddr>>, VsmError> {
         let guard = self.inner.lock();
-        guard
-            .get(&key)
-            .map(|metadata| metadata.get_patch_targets().clone())
+        let Some(metadata) = guard.get(&key) else {
+            return Ok(None);
+        };
+        let targets = metadata.get_patch_targets();
+        let mut copy = Vec::new();
+        copy.try_reserve_exact(targets.len())
+            .map_err(|_| VsmError::AllocationFailed)?;
+        copy.extend_from_slice(targets);
+        Ok(Some(copy))
     }
 
     pub(crate) fn iter_entry(&self, key: i64) -> Option<ModuleMemoryMetadataIters<'_>> {
@@ -462,6 +486,9 @@ impl MemoryContainer {
             // TODO: This should be an error once patch_info is fixed from VTL0
             // It will simplify patch_info and heki_range parsing as well
         }
+        self.range
+            .try_reserve(1)
+            .map_err(|_| VsmError::AllocationFailed)?;
         self.range.push(MemoryRange {
             addr,
             phys_addr,
@@ -484,11 +511,13 @@ impl MemoryContainer {
                     .checked_add(range_len)
                     .ok_or(MemoryContainerError::Overflow)?;
             }
-            self.buf.reserve_exact(len);
+            self.buf
+                .try_reserve_exact(len)
+                .map_err(|_| MemoryContainerError::AllocationFailed)?;
         }
 
-        let range = self.range.clone();
-        for range in range {
+        for index in 0..self.range.len() {
+            let range = self.range[index];
             let phys_end = range
                 .phys_addr
                 .as_u64()
@@ -513,7 +542,13 @@ impl MemoryContainer {
         }
 
         let old_len = self.buf.len();
-        self.buf.resize(old_len + bytes_to_copy, 0);
+        let new_len = old_len
+            .checked_add(bytes_to_copy)
+            .ok_or(MemoryContainerError::Overflow)?;
+        self.buf
+            .try_reserve_exact(bytes_to_copy)
+            .map_err(|_| MemoryContainerError::AllocationFailed)?;
+        self.buf.resize(new_len, 0);
         if gate
             .read_vtl0_contiguous(phys_start.as_u64(), &mut self.buf[old_len..])
             .is_err()
@@ -541,6 +576,19 @@ pub(crate) enum MemoryContainerError {
     CopyFromVtl0Failed,
     #[error("integer overflow while processing VTL0 memory")]
     Overflow,
+    #[error("failed to allocate memory buffer")]
+    AllocationFailed,
+}
+
+impl From<MemoryContainerError> for VsmError {
+    fn from(error: MemoryContainerError) -> Self {
+        match error {
+            MemoryContainerError::AllocationFailed => VsmError::AllocationFailed,
+            MemoryContainerError::CopyFromVtl0Failed | MemoryContainerError::Overflow => {
+                VsmError::Vtl0CopyFailed
+            }
+        }
+    }
 }
 
 pub(crate) struct KexecMemoryMetadataWrapper {
@@ -596,13 +644,19 @@ impl KexecMemoryMetadata {
         }
         let pa = heki_range.pa;
         let epa = heki_range.epa;
-        self.insert_memory_range(KexecMemoryRange::new_checked(pa, epa));
-        Ok(())
+        self.insert_memory_range(KexecMemoryRange::new_checked(pa, epa))
     }
 
     #[inline]
-    pub(crate) fn insert_memory_range(&mut self, mem_range: KexecMemoryRange) {
+    pub(crate) fn insert_memory_range(
+        &mut self,
+        mem_range: KexecMemoryRange,
+    ) -> Result<(), VsmError> {
+        self.ranges
+            .try_reserve(1)
+            .map_err(|_| VsmError::AllocationFailed)?;
         self.ranges.push(mem_range);
+        Ok(())
     }
 
     #[inline]
@@ -794,6 +848,9 @@ impl PatchDataMap {
                     }
                 }
 
+                parsed
+                    .try_reserve(if straddles_second_page { 2 } else { 1 })
+                    .map_err(|_| PatchDataMapError::AllocationFailed)?;
                 parsed.push((patch_target_pa_0, patch));
                 if straddles_second_page {
                     parsed.push((patch_target_pa_1, patch));
@@ -807,7 +864,9 @@ impl PatchDataMap {
         for (target, patch) in parsed {
             inner.insert(target, patch);
             if let Some(ref mut mod_mem_meta) = module_memory_metadata {
-                mod_mem_meta.insert_patch_target(target);
+                mod_mem_meta
+                    .insert_patch_target(target)
+                    .map_err(|_| PatchDataMapError::AllocationFailed)?;
             }
         }
 
@@ -823,6 +882,8 @@ pub(crate) enum PatchDataMapError {
     InvalidHekiPatchInfo,
     #[error("invalid HEKI patch")]
     InvalidHekiPatch,
+    #[error("failed to allocate patch buffer")]
+    AllocationFailed,
 }
 
 // TODO: Use this to resolve symbols in modules

--- a/litebox_service_heki/src/lib.rs
+++ b/litebox_service_heki/src/lib.rs
@@ -122,7 +122,7 @@ impl ModuleMemoryMetadata {
     }
 
     #[inline]
-    pub(crate) fn insert_heki_range(&mut self, heki_range: &HekiRange) -> Result<(), VsmError> {
+    pub(crate) fn insert_heki_range(&mut self, heki_range: &HekiRange) {
         // `HekiRange::is_valid` already validated these addresses.
         let pa = heki_range.pa;
         let epa = heki_range.epa;
@@ -130,28 +130,29 @@ impl ModuleMemoryMetadata {
             pa,
             epa,
             heki_range.mod_mem_type(),
-        ))
+        ));
     }
 
-    #[inline]
-    pub(crate) fn insert_memory_range(
-        &mut self,
-        mem_range: ModuleMemoryRange,
-    ) -> Result<(), VsmError> {
+    pub(crate) fn try_reserve_ranges(&mut self, additional: usize) -> Result<(), VsmError> {
         self.ranges
-            .try_reserve(1)
-            .map_err(|_| VsmError::AllocationFailed)?;
-        self.ranges.push(mem_range);
-        Ok(())
+            .try_reserve_exact(additional)
+            .map_err(|_| VsmError::AllocationFailed)
     }
 
     #[inline]
-    pub(crate) fn insert_patch_target(&mut self, patch_target: PhysAddr) -> Result<(), VsmError> {
+    pub(crate) fn insert_memory_range(&mut self, mem_range: ModuleMemoryRange) {
+        self.ranges.push(mem_range);
+    }
+
+    pub(crate) fn try_reserve_patch_targets(&mut self, additional: usize) -> Result<(), VsmError> {
         self.patch_targets
-            .try_reserve(1)
-            .map_err(|_| VsmError::AllocationFailed)?;
+            .try_reserve_exact(additional)
+            .map_err(|_| VsmError::AllocationFailed)
+    }
+
+    #[inline]
+    pub(crate) fn insert_patch_target(&mut self, patch_target: PhysAddr) {
         self.patch_targets.push(patch_target);
-        Ok(())
     }
 
     // This function returns patch targets belonging to this module to remove them
@@ -376,6 +377,12 @@ impl ModuleMemory {
         }
     }
 
+    pub(crate) fn try_reserve_ranges(&mut self, additional: usize) -> Result<(), VsmError> {
+        self.text.try_reserve_ranges(additional)?;
+        self.init_text.try_reserve_ranges(additional)?;
+        self.init_rodata.try_reserve_ranges(additional)
+    }
+
     /// Return a memory container for a section of the module memory by its name
     pub(crate) fn find_section_by_name(&self, name: &str) -> Option<&MemoryContainer> {
         match name {
@@ -445,6 +452,12 @@ impl MemoryContainer {
         }
     }
 
+    pub(crate) fn try_reserve_ranges(&mut self, additional: usize) -> Result<(), VsmError> {
+        self.range
+            .try_reserve_exact(additional)
+            .map_err(|_| VsmError::AllocationFailed)
+    }
+
     /// Return the byte length of the memory container
     pub(crate) fn len(&self) -> usize {
         self.buf.len()
@@ -486,9 +499,6 @@ impl MemoryContainer {
             // TODO: This should be an error once patch_info is fixed from VTL0
             // It will simplify patch_info and heki_range parsing as well
         }
-        self.range
-            .try_reserve(1)
-            .map_err(|_| VsmError::AllocationFailed)?;
         self.range.push(MemoryRange {
             addr,
             phys_addr,
@@ -644,19 +654,19 @@ impl KexecMemoryMetadata {
         }
         let pa = heki_range.pa;
         let epa = heki_range.epa;
-        self.insert_memory_range(KexecMemoryRange::new_checked(pa, epa))
+        self.insert_memory_range(KexecMemoryRange::new_checked(pa, epa));
+        Ok(())
+    }
+
+    pub(crate) fn try_reserve_ranges(&mut self, additional: usize) -> Result<(), VsmError> {
+        self.ranges
+            .try_reserve_exact(additional)
+            .map_err(|_| VsmError::AllocationFailed)
     }
 
     #[inline]
-    pub(crate) fn insert_memory_range(
-        &mut self,
-        mem_range: KexecMemoryRange,
-    ) -> Result<(), VsmError> {
-        self.ranges
-            .try_reserve(1)
-            .map_err(|_| VsmError::AllocationFailed)?;
+    pub(crate) fn insert_memory_range(&mut self, mem_range: KexecMemoryRange) {
         self.ranges.push(mem_range);
-        Ok(())
     }
 
     #[inline]
@@ -786,6 +796,14 @@ impl PatchDataMap {
         }
 
         let mut parsed: Vec<(PhysAddr, HekiPatch)> = Vec::new();
+        let max_patch_targets = patch_info_buf
+            .len()
+            .checked_div(core::mem::size_of::<HekiPatch>())
+            .and_then(|count| count.checked_mul(2))
+            .ok_or(PatchDataMapError::InvalidHekiPatchInfo)?;
+        parsed
+            .try_reserve_exact(max_patch_targets)
+            .map_err(|_| PatchDataMapError::AllocationFailed)?;
 
         // the buffer looks like below:
         // [`HekiPatchInfo`, [`HekiPatch`, ...], `HekiPatchInfo`, [`HekiPatch`, ...], ...]
@@ -848,9 +866,6 @@ impl PatchDataMap {
                     }
                 }
 
-                parsed
-                    .try_reserve(if straddles_second_page { 2 } else { 1 })
-                    .map_err(|_| PatchDataMapError::AllocationFailed)?;
                 parsed.push((patch_target_pa_0, patch));
                 if straddles_second_page {
                     parsed.push((patch_target_pa_1, patch));
@@ -860,13 +875,16 @@ impl PatchDataMap {
         }
 
         // Commit every parsed patch and record its targets for later unload cleanup.
+        if let Some(ref mut mod_mem_meta) = module_memory_metadata {
+            mod_mem_meta
+                .try_reserve_patch_targets(parsed.len())
+                .map_err(|_| PatchDataMapError::AllocationFailed)?;
+        }
         let mut inner = self.inner.write();
         for (target, patch) in parsed {
             inner.insert(target, patch);
             if let Some(ref mut mod_mem_meta) = module_memory_metadata {
-                mod_mem_meta
-                    .insert_patch_target(target)
-                    .map_err(|_| PatchDataMapError::AllocationFailed)?;
+                mod_mem_meta.insert_patch_target(target);
             }
         }
 

--- a/litebox_service_heki/src/mem_integrity.rs
+++ b/litebox_service_heki/src/mem_integrity.rs
@@ -4,7 +4,7 @@
 //! Functions for checking the memory integrity of VTL0 kernel image and modules
 
 use crate::ModuleMemory;
-use alloc::{vec, vec::Vec};
+use alloc::vec::Vec;
 use authenticode::{AttributeCertificateIterator, AuthenticodeSignature, authenticode_digest};
 use cms::{content_info::ContentInfo, signed_data::SignedData};
 use const_oid::db::rfc5912::{ID_SHA_256, ID_SHA_512, RSA_ENCRYPTION};
@@ -32,6 +32,7 @@ use x509_cert::{
     der::{Decode, Encode, oid::ObjectIdentifier},
 };
 use zerocopy::FromBytes;
+use zerocopy::FromZeros as _;
 
 /// This function validates the memory content of a loaded kernel module against the original ELF file.
 /// In particular, it checks whether the non-relocatable/patchable bytes of certain sections
@@ -101,7 +102,8 @@ pub(crate) fn validate_kernel_module_against_elf(
                 usize::try_from(target_shdr.sh_size).map_err(|_| KernelElfError::ElfParseFailed)?,
             )
             .ok_or(KernelElfError::ElfParseFailed)?;
-        let mut section_from_elf = vec![0u8; end - start];
+        let mut section_from_elf =
+            u8::new_vec_zeroed(end - start).map_err(|_| KernelElfError::AllocationFailed)?;
         section_from_elf.copy_from_slice(&original_elf_data[start..end]);
 
         let mut reloc_ranges = RangeSet::<usize>::new();
@@ -138,6 +140,9 @@ pub(crate) fn validate_kernel_module_against_elf(
             for non_reloc in reloc_ranges.gaps(&(0..section_from_elf.len())) {
                 for i in non_reloc {
                     if section_from_elf[i] != section_in_memory[i] {
+                        diffs
+                            .try_reserve(1)
+                            .map_err(|_| KernelElfError::AllocationFailed)?;
                         diffs.push(i);
                     }
                 }
@@ -570,8 +575,12 @@ pub(crate) fn verify_kernel_pe_signature(
         }
     }
     // check whether the computed digest matches the one in the Authenticode signature
-    let computed_digest = compute_authenticode_digest(kernel_blob, digest_algorithm_oid)?;
-    if signature_verified && authenticode_signature.digest() == computed_digest {
+    let digest_matches = verify_authenticode_digest(
+        kernel_blob,
+        digest_algorithm_oid,
+        authenticode_signature.digest(),
+    )?;
+    if signature_verified && digest_matches {
         return Ok(());
     }
     Err(VerificationError::AuthenticationFailed)
@@ -599,21 +608,22 @@ fn extract_authenticode_signature(
     authenticode_signature.ok_or(VerificationError::InvalidSignature)
 }
 
-/// This function computes an Authenticode digest over a kernel blob PE.
-fn compute_authenticode_digest(
+/// This function verifies an Authenticode digest over a kernel blob PE.
+fn verify_authenticode_digest(
     kernel_blob: &[u8],
     digest_alg: ObjectIdentifier,
-) -> Result<Vec<u8>, VerificationError> {
+    expected_digest: &[u8],
+) -> Result<bool, VerificationError> {
     let pe = PeFile64::parse(kernel_blob).map_err(|_| VerificationError::ParseFailed)?;
 
     if digest_alg == ID_SHA_256 {
         let mut hasher = AuthenticodeHasher::<Sha256>::default();
         authenticode_digest(&pe, &mut hasher).map_err(|_| VerificationError::ParseFailed)?;
-        Ok(hasher.hasher.finalize().to_vec())
+        Ok(expected_digest == hasher.hasher.finalize().as_slice())
     } else if digest_alg == ID_SHA_512 {
         let mut hasher = AuthenticodeHasher::<Sha512>::default();
         authenticode_digest(&pe, &mut hasher).map_err(|_| VerificationError::ParseFailed)?;
-        Ok(hasher.hasher.finalize().to_vec())
+        Ok(expected_digest == hasher.hasher.finalize().as_slice())
     } else {
         Err(VerificationError::Unsupported)
     }
@@ -728,6 +738,17 @@ pub(crate) enum KernelElfError {
     #[cfg_attr(debug_assertions, allow(dead_code))]
     #[error("unsupported relocation type")]
     UnsupportedRelocation,
+    #[error("failed to allocate ELF validation buffer")]
+    AllocationFailed,
+}
+
+impl From<KernelElfError> for litebox_common_lvbs::VsmError {
+    fn from(error: KernelElfError) -> Self {
+        match error {
+            KernelElfError::AllocationFailed => Self::AllocationFailed,
+            _ => Self::Vtl0CopyFailed,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/litebox_service_heki/src/mem_integrity.rs
+++ b/litebox_service_heki/src/mem_integrity.rs
@@ -137,12 +137,12 @@ pub(crate) fn validate_kernel_module_against_elf(
         #[cfg(debug_assertions)]
         {
             let mut diffs = Vec::new();
+            diffs
+                .try_reserve_exact(section_from_elf.len())
+                .map_err(|_| KernelElfError::AllocationFailed)?;
             for non_reloc in reloc_ranges.gaps(&(0..section_from_elf.len())) {
                 for i in non_reloc {
                     if section_from_elf[i] != section_in_memory[i] {
-                        diffs
-                            .try_reserve(1)
-                            .map_err(|_| KernelElfError::AllocationFailed)?;
                         diffs.push(i);
                     }
                 }

--- a/litebox_shim_optee/Cargo.toml
+++ b/litebox_shim_optee/Cargo.toml
@@ -17,11 +17,10 @@ litebox_util_log = { version = "0.1.0", path = "../litebox_util_log" }
 hmac = { version = "0.12", default-features = false }
 num_enum = { version = "0.7.3", default-features = false }
 rangemap = { version = "1.5.1", features = ["const_fn"] }
-once_cell = { version = "1.20.2", default-features = false, features = ["alloc", "race"] }
 sha2 = { version = "0.10", default-features = false }
 spin = { version = "0.10.0", default-features = false, features = ["spin_mutex", "rwlock", "once"] }
 thiserror = { version = "2.0.6", default-features = false }
-zerocopy = { version = "0.8", default-features = false, features = ["derive"] }
+zerocopy = { version = "0.8", default-features = false, features = ["alloc", "derive"] }
 zeroize = { version = "1.8", default-features = false, features = ["alloc"] }
 p384 = { version = "0.13.1", default-features = false, features = ["arithmetic", "ecdsa"] }
 

--- a/litebox_shim_optee/src/lib.rs
+++ b/litebox_shim_optee/src/lib.rs
@@ -11,7 +11,7 @@ extern crate alloc;
 use crate::loader::elf::ElfLoaderError;
 use crate::syscalls::pta::PseudoTa;
 use aes::{Aes128, Aes192, Aes256};
-use alloc::{sync::Arc, vec::Vec};
+use alloc::sync::Arc;
 use core::cell::Cell;
 use ctr::Ctr128BE;
 use hashbrown::{HashMap, HashSet};
@@ -44,10 +44,6 @@ pub mod idk;
 pub use session::{OpenSessionTarget, SessionManager, SessionToken, TaInstance};
 
 const MAX_KERNEL_BUF_SIZE: usize = 0x80_000;
-
-fn allocate_zeroed_vec(len: usize) -> Result<Vec<u8>, TeeResult> {
-    u8::new_vec_zeroed(len).map_err(|_| TeeResult::OutOfMemory)
-}
 
 pub struct OpteeShimEntrypoints {
     task: Task,
@@ -433,22 +429,24 @@ impl Task {
                         #[cfg(not(debug_assertions))]
                         Err(TeeResult::NotSupported)
                     } else {
-                        allocate_zeroed_vec(buf_length as usize).and_then(|mut prop_buf| {
-                            self.sys_get_property(
-                                prop_set,
-                                index,
-                                None,
-                                None,
-                                &mut prop_buf,
-                                blen,
-                                prop_type,
-                            )
-                            .and_then(|()| {
-                                buf.copy_from_slice(0, &prop_buf)
-                                    .ok_or(TeeResult::ShortBuffer)?;
-                                Ok(())
+                        u8::new_vec_zeroed(buf_length as usize)
+                            .map_err(|_| TeeResult::OutOfMemory)
+                            .and_then(|mut prop_buf| {
+                                self.sys_get_property(
+                                    prop_set,
+                                    index,
+                                    None,
+                                    None,
+                                    &mut prop_buf,
+                                    blen,
+                                    prop_type,
+                                )
+                                .and_then(|()| {
+                                    buf.copy_from_slice(0, &prop_buf)
+                                        .ok_or(TeeResult::ShortBuffer)?;
+                                    Ok(())
+                                })
                             })
-                        })
                     }
                 } else {
                     Err(TeeResult::BadParameters)
@@ -595,13 +593,15 @@ impl Task {
                 if blen > 4096 {
                     Err(TeeResult::OutOfMemory)
                 } else {
-                    allocate_zeroed_vec(blen).and_then(|mut kernel_buf| {
-                        self.sys_cryp_random_number_generate(&mut kernel_buf)
-                            .and_then(|()| {
-                                buf.copy_from_slice(0, &kernel_buf)
-                                    .ok_or(TeeResult::AccessDenied)
-                            })
-                    })
+                    u8::new_vec_zeroed(blen)
+                        .map_err(|_| TeeResult::OutOfMemory)
+                        .and_then(|mut kernel_buf| {
+                            self.sys_cryp_random_number_generate(&mut kernel_buf)
+                                .and_then(|()| {
+                                    buf.copy_from_slice(0, &kernel_buf)
+                                        .ok_or(TeeResult::AccessDenied)
+                                })
+                        })
                 }
             }
             SyscallRequest::GetTime { cat, time } => self.sys_get_time(cat, time),
@@ -765,13 +765,15 @@ impl Task {
                 if num_bytes > 4096 {
                     Err(TeeResult::OutOfMemory)
                 } else {
-                    allocate_zeroed_vec(num_bytes).and_then(|mut kernel_buf| {
-                        self.sys_cryp_random_number_generate(&mut kernel_buf)
-                            .and_then(|()| {
-                                buf.copy_from_slice(0, &kernel_buf)
-                                    .ok_or(TeeResult::AccessDenied)
-                            })
-                    })
+                    u8::new_vec_zeroed(num_bytes)
+                        .map_err(|_| TeeResult::OutOfMemory)
+                        .and_then(|mut kernel_buf| {
+                            self.sys_cryp_random_number_generate(&mut kernel_buf)
+                                .and_then(|()| {
+                                    buf.copy_from_slice(0, &kernel_buf)
+                                        .ok_or(TeeResult::AccessDenied)
+                                })
+                        })
                 }
             }
             _ => Err(TeeResult::NotSupported),
@@ -986,7 +988,7 @@ where
         && length <= MAX_KERNEL_BUF_SIZE as u64
     {
         let mut length: usize = length.trunc();
-        let mut kernel_buf = allocate_zeroed_vec(length)?;
+        let mut kernel_buf = u8::new_vec_zeroed(length).map_err(|_| TeeResult::OutOfMemory)?;
         let result = syscall_fn(task, state, &src_slice, &mut kernel_buf, &mut length);
         match result {
             Ok(()) => {

--- a/litebox_shim_optee/src/lib.rs
+++ b/litebox_shim_optee/src/lib.rs
@@ -11,7 +11,7 @@ extern crate alloc;
 use crate::loader::elf::ElfLoaderError;
 use crate::syscalls::pta::PseudoTa;
 use aes::{Aes128, Aes192, Aes256};
-use alloc::{sync::Arc, vec};
+use alloc::{sync::Arc, vec::Vec};
 use core::cell::Cell;
 use ctr::Ctr128BE;
 use hashbrown::{HashMap, HashSet};
@@ -29,6 +29,7 @@ use litebox_common_optee::{
     TeeObjectInfo, TeeObjectType, TeeOperationMode, TeeResult, TeeUuid, UteeAttribute,
 };
 use litebox_platform_multiplex::Platform;
+use zerocopy::FromZeros as _;
 
 pub mod loader;
 pub mod session;
@@ -43,6 +44,10 @@ pub mod idk;
 pub use session::{OpenSessionTarget, SessionManager, SessionToken, TaInstance};
 
 const MAX_KERNEL_BUF_SIZE: usize = 0x80_000;
+
+fn allocate_zeroed_vec(len: usize) -> Result<Vec<u8>, TeeResult> {
+    u8::new_vec_zeroed(len).map_err(|_| TeeResult::OutOfMemory)
+}
 
 pub struct OpteeShimEntrypoints {
     task: Task,
@@ -422,26 +427,27 @@ impl Task {
                 if let Some(buf_length) = blen.read_at_offset(0)
                     && (buf_length as usize) <= MAX_KERNEL_BUF_SIZE
                 {
-                    let mut prop_buf = vec![0u8; buf_length as usize];
                     if name.as_usize() != 0 || name_len.as_usize() != 0 {
                         #[cfg(debug_assertions)]
                         todo!("return the name of a given property index");
                         #[cfg(not(debug_assertions))]
                         Err(TeeResult::NotSupported)
                     } else {
-                        self.sys_get_property(
-                            prop_set,
-                            index,
-                            None,
-                            None,
-                            &mut prop_buf,
-                            blen,
-                            prop_type,
-                        )
-                        .and_then(|()| {
-                            buf.copy_from_slice(0, &prop_buf)
-                                .ok_or(TeeResult::ShortBuffer)?;
-                            Ok(())
+                        allocate_zeroed_vec(buf_length as usize).and_then(|mut prop_buf| {
+                            self.sys_get_property(
+                                prop_set,
+                                index,
+                                None,
+                                None,
+                                &mut prop_buf,
+                                blen,
+                                prop_type,
+                            )
+                            .and_then(|()| {
+                                buf.copy_from_slice(0, &prop_buf)
+                                    .ok_or(TeeResult::ShortBuffer)?;
+                                Ok(())
+                            })
                         })
                     }
                 } else {
@@ -589,12 +595,13 @@ impl Task {
                 if blen > 4096 {
                     Err(TeeResult::OutOfMemory)
                 } else {
-                    let mut kernel_buf = vec![0u8; blen];
-                    self.sys_cryp_random_number_generate(&mut kernel_buf)
-                        .and_then(|()| {
-                            buf.copy_from_slice(0, &kernel_buf)
-                                .ok_or(TeeResult::AccessDenied)
-                        })
+                    allocate_zeroed_vec(blen).and_then(|mut kernel_buf| {
+                        self.sys_cryp_random_number_generate(&mut kernel_buf)
+                            .and_then(|()| {
+                                buf.copy_from_slice(0, &kernel_buf)
+                                    .ok_or(TeeResult::AccessDenied)
+                            })
+                    })
                 }
             }
             SyscallRequest::GetTime { cat, time } => self.sys_get_time(cat, time),
@@ -758,12 +765,13 @@ impl Task {
                 if num_bytes > 4096 {
                     Err(TeeResult::OutOfMemory)
                 } else {
-                    let mut kernel_buf = vec![0u8; num_bytes];
-                    self.sys_cryp_random_number_generate(&mut kernel_buf)
-                        .and_then(|()| {
-                            buf.copy_from_slice(0, &kernel_buf)
-                                .ok_or(TeeResult::AccessDenied)
-                        })
+                    allocate_zeroed_vec(num_bytes).and_then(|mut kernel_buf| {
+                        self.sys_cryp_random_number_generate(&mut kernel_buf)
+                            .and_then(|()| {
+                                buf.copy_from_slice(0, &kernel_buf)
+                                    .ok_or(TeeResult::AccessDenied)
+                            })
+                    })
                 }
             }
             _ => Err(TeeResult::NotSupported),
@@ -978,7 +986,7 @@ where
         && length <= MAX_KERNEL_BUF_SIZE as u64
     {
         let mut length: usize = length.trunc();
-        let mut kernel_buf = vec![0u8; length];
+        let mut kernel_buf = allocate_zeroed_vec(length)?;
         let result = syscall_fn(task, state, &src_slice, &mut kernel_buf, &mut length);
         match result {
             Ok(()) => {
@@ -1040,8 +1048,8 @@ impl TeeObj {
         self.key = None;
     }
 
-    pub fn set_key(&mut self, key: &[u8]) {
-        self.key = Some(alloc::boxed::Box::from(key));
+    pub fn set_key(&mut self, key: alloc::boxed::Box<[u8]>) {
+        self.key = Some(key);
         self.info
             .handle_flags
             .set(TeeHandleFlag::TEE_HANDLE_FLAG_KEY_SET, true);
@@ -1108,7 +1116,7 @@ impl TeeObjMap {
                 let Some(key_box) = key_ptr.to_owned_slice(key_len) else {
                     return Err(TeeResult::BadParameters);
                 };
-                tee_obj.set_key(&key_box);
+                tee_obj.set_key(key_box);
             } else {
                 #[cfg(debug_assertions)]
                 todo!(
@@ -1375,8 +1383,8 @@ impl TaUuidMap {
 
 /// Get the global TA UUID map.
 fn ta_uuid_map() -> &'static TaUuidMap {
-    static TA_UUID_MAP: once_cell::race::OnceBox<TaUuidMap> = once_cell::race::OnceBox::new();
-    TA_UUID_MAP.get_or_init(|| alloc::boxed::Box::new(TaUuidMap::new()))
+    static TA_UUID_MAP: spin::Once<TaUuidMap> = spin::Once::new();
+    TA_UUID_MAP.call_once(TaUuidMap::new)
 }
 
 /// Per-instance TA state which can be shared between sessions if it is

--- a/litebox_shim_optee/src/loader/elf.rs
+++ b/litebox_shim_optee/src/loader/elf.rs
@@ -30,6 +30,7 @@ use litebox_common_linux::{
 };
 use litebox_common_optee::{LdelfArg, TeeUuid};
 use thiserror::Error;
+use zerocopy::FromZeros as _;
 
 /// An ELF file loaded in memory
 struct ElfFileInMemory<'a> {
@@ -53,11 +54,11 @@ fn read_at(elf: &ElfFileInMemory, offset: u64, buf: &mut [u8]) -> Result<(), Err
 }
 
 impl<'a> ElfFileInMemory<'a> {
-    fn new(task: &'a Task, elf_buf: &[u8]) -> Self {
-        Self {
-            task,
-            buffer: elf_buf.into(),
-        }
+    fn new(task: &'a Task, elf_buf: &[u8]) -> Result<Self, ElfLoaderError> {
+        let mut buffer = <[u8]>::new_box_zeroed_with_elems(elf_buf.len())
+            .map_err(|_| ElfLoaderError::AllocationFailed)?;
+        buffer.copy_from_slice(elf_buf);
+        Ok(Self { task, buffer })
     }
 }
 
@@ -205,7 +206,7 @@ struct FileAndParsed<'a> {
 
 impl<'a> FileAndParsed<'a> {
     fn new(task: &'a Task, elf_buf: &[u8]) -> Result<Self, ElfLoaderError> {
-        let file = ElfFileInMemory::new(task, elf_buf);
+        let file = ElfFileInMemory::new(task, elf_buf)?;
         let mut parsed = litebox_common_linux::loader::ElfParsedFile::parse(&mut &file)
             .map_err(ElfLoaderError::ParseError)?;
         match parsed.parse_trampoline(&mut &file, task.global.platform.get_syscall_entry_point()) {
@@ -307,6 +308,8 @@ pub enum ElfLoaderError {
     MappingError(#[from] MappingError),
     #[error("TA binary UUID does not match expected UUID")]
     InvalidUuid,
+    #[error("failed to allocate ELF file buffer")]
+    AllocationFailed,
 }
 
 impl From<ElfLoaderError> for litebox_common_linux::errno::Errno {
@@ -314,9 +317,9 @@ impl From<ElfLoaderError> for litebox_common_linux::errno::Errno {
         match value {
             ElfLoaderError::OpenError(e) | ElfLoaderError::ProtectError(e) => e,
             ElfLoaderError::ParseError(e) => e.into(),
-            ElfLoaderError::InvalidStackAddr | ElfLoaderError::MappingError(_) => {
-                litebox_common_linux::errno::Errno::ENOMEM
-            }
+            ElfLoaderError::InvalidStackAddr
+            | ElfLoaderError::MappingError(_)
+            | ElfLoaderError::AllocationFailed => litebox_common_linux::errno::Errno::ENOMEM,
             ElfLoaderError::LoadError(e) => e.into(),
             ElfLoaderError::InvalidUuid => litebox_common_linux::errno::Errno::EINVAL,
         }

--- a/litebox_shim_optee/src/msg_handler.rs
+++ b/litebox_shim_optee/src/msg_handler.rs
@@ -28,8 +28,7 @@ use litebox_common_optee::{
     TeeOrigin, TeeParamType, TeeResult, TeeUuid, UteeEntryFunc, UteeParamOwned, UteeParams,
     optee_msg_args_total_size,
 };
-use once_cell::race::OnceBox;
-use zerocopy::{FromBytes, Immutable};
+use zerocopy::{FromBytes, FromZeros as _, Immutable};
 
 // OP-TEE version and build info (2.0)
 // TODO: Consider replacing it with our own version info
@@ -65,6 +64,10 @@ const MAX_NOTIF_VALUE: usize = 0;
 /// Subject to change if the memory budget increases.
 const MAX_SHM_MEMREF_SIZE: usize = 8 * 1024 * 1024;
 const MAX_SHM_REF_MAP_ENTRIES: usize = 1024;
+
+fn allocate_zeroed_vec(len: usize) -> Result<Vec<u8>, OpteeSmcReturnCode> {
+    u8::new_vec_zeroed(len).map_err(|_| OpteeSmcReturnCode::ENomem)
+}
 
 #[inline]
 fn page_align_down(address: u64) -> u64 {
@@ -117,12 +120,16 @@ fn parse_optee_msg_args(
         }
         let rpc_params = &rpc_blob[size_of::<OpteeMsgArgsHeader>()..];
         let rpc = OpteeRpcArgs::from_header_and_raw_params(&rpc_header, rpc_params)?;
-        Some(Box::new(rpc))
+        let mut boxed = OpteeRpcArgs::new_box_zeroed().map_err(|_| OpteeSmcReturnCode::ENomem)?;
+        *boxed = rpc;
+        Some(boxed)
     } else {
         None
     };
 
-    Ok((Box::new(main_args), rpc_args))
+    let mut boxed = OpteeMsgArgs::new_box_zeroed().map_err(|_| OpteeSmcReturnCode::ENomem)?;
+    *boxed = main_args;
+    Ok((boxed, rpc_args))
 }
 
 /// Read `OpteeMsgArgs` (and optional `OpteeRpcArgs`) from a VTL0 physical address.
@@ -191,7 +198,7 @@ pub fn read_optee_msg_args_from_phys(
         main_max
     };
 
-    let mut blob = alloc::vec![0u8; copy_size];
+    let mut blob = allocate_zeroed_vec(copy_size)?;
 
     let blob_ptr =
         NormalWorldConstPtr::<u8, PAGE_SIZE>::with_contiguous_pages(phys_addr, copy_size)
@@ -241,7 +248,7 @@ pub fn handle_optee_smc_args(
             // `OpteeMsgArgs` is located at the offset specified in args[3] within the shared memory region pointed by args[1]:args[2].
             let (shm_ref, offset) = smc.optee_regd_shm_ref_and_offset()?;
             let shm_info = shm_ref_map()
-                .get(shm_ref)
+                .get(shm_ref)?
                 .ok_or(OpteeSmcReturnCode::EBadAddr)?;
 
             // Compute copy size from known-good upper bounds — no untrusted data involved.
@@ -249,7 +256,7 @@ pub fn handle_optee_smc_args(
             let copy_size =
                 main_max + optee_msg_args_total_size(OpteeRpcArgs::MAX_RPC_ARG_PARAM_COUNT.trunc());
 
-            let mut blob = alloc::vec![0u8; copy_size];
+            let mut blob = allocate_zeroed_vec(copy_size)?;
             shm_info.read_at(offset, &mut blob)?;
             let (msg_args, rpc_args) = parse_optee_msg_args(&blob, true)?;
 
@@ -540,7 +547,7 @@ pub fn decode_ta_request(
                 let buffer_size = checked_memref_size(tmem.size)?;
                 let shm_info = get_shm_info_from_optee_msg_param_tmem(tmem)?;
 
-                ta_req_info.out_shm_info[i] = Some(shm_info.clone());
+                ta_req_info.out_shm_info[i] = Some(shm_info.try_clone()?);
                 build_memref_inout(&shm_info, buffer_size)?
             }
             OpteeMsgAttrType::RmemInout => {
@@ -548,7 +555,7 @@ pub fn decode_ta_request(
                 let buffer_size = checked_memref_size(rmem.size)?;
                 let shm_info = get_shm_info_from_optee_msg_param_rmem(rmem)?;
 
-                ta_req_info.out_shm_info[i] = Some(shm_info.clone());
+                ta_req_info.out_shm_info[i] = Some(shm_info.try_clone()?);
                 build_memref_inout(&shm_info, buffer_size)?
             }
             _ => return Err(OpteeSmcReturnCode::EBadCmd),
@@ -563,7 +570,7 @@ fn build_memref_input(
     shm_info: &ShmInfo<PAGE_SIZE>,
     data_size: usize,
 ) -> Result<UteeParamOwned, OpteeSmcReturnCode> {
-    let mut data = alloc::vec![0u8; data_size];
+    let mut data = allocate_zeroed_vec(data_size)?;
     shm_info.read_at(0, &mut data)?;
     Ok(UteeParamOwned::MemrefInput { data: data.into() })
 }
@@ -573,7 +580,7 @@ fn build_memref_inout(
     shm_info: &ShmInfo<PAGE_SIZE>,
     buffer_size: usize,
 ) -> Result<UteeParamOwned, OpteeSmcReturnCode> {
-    let mut buffer = alloc::vec![0u8; buffer_size];
+    let mut buffer = allocate_zeroed_vec(buffer_size)?;
     shm_info.read_at(0, &mut buffer)?;
     Ok(UteeParamOwned::MemrefInout {
         data: buffer.into(),
@@ -686,16 +693,24 @@ impl ShmRefPagesData {
 /// `page_offset` indicates the page offset of the first page (i.e., `pages[0]`) which should be
 /// smaller than `ALIGN`.
 /// `len` is the byte length of the shared memory view starting at `page_offset`.
-#[derive(Clone)]
 pub struct ShmInfo<const ALIGN: usize> {
-    page_addrs: Box<[PhysPageAddr<ALIGN>]>,
+    page_addrs: Vec<PhysPageAddr<ALIGN>>,
     page_offset: usize,
     len: usize,
 }
 
 impl<const ALIGN: usize> ShmInfo<ALIGN> {
+    fn try_clone(&self) -> Result<Self, OpteeSmcReturnCode> {
+        let mut page_addrs = Vec::new();
+        page_addrs
+            .try_reserve_exact(self.page_addrs.len())
+            .map_err(|_| OpteeSmcReturnCode::ENomem)?;
+        page_addrs.extend_from_slice(&self.page_addrs);
+        Self::new(page_addrs, self.page_offset, self.len)
+    }
+
     pub fn new(
-        page_addrs: Box<[PhysPageAddr<ALIGN>]>,
+        page_addrs: Vec<PhysPageAddr<ALIGN>>,
         page_offset: usize,
         len: usize,
     ) -> Result<Self, OpteeSmcReturnCode> {
@@ -772,6 +787,9 @@ impl<const ALIGN: usize> ShmRefMap<ALIGN> {
         } else if guard.len() >= MAX_SHM_REF_MAP_ENTRIES {
             Err(OpteeSmcReturnCode::ENomem)
         } else {
+            guard
+                .try_reserve(1)
+                .map_err(|_| OpteeSmcReturnCode::ENomem)?;
             let _ = guard.insert(shm_ref, info);
             Ok(())
         }
@@ -782,9 +800,9 @@ impl<const ALIGN: usize> ShmRefMap<ALIGN> {
         guard.remove(&shm_ref)
     }
 
-    pub fn get(&self, shm_ref: u64) -> Option<ShmInfo<ALIGN>> {
+    pub fn get(&self, shm_ref: u64) -> Result<Option<ShmInfo<ALIGN>>, OpteeSmcReturnCode> {
         let guard = self.inner.lock();
-        guard.get(&shm_ref).cloned()
+        guard.get(&shm_ref).map(ShmInfo::try_clone).transpose()
     }
 
     /// This function registers shared memory information that the normal world (VTL0) provides.
@@ -814,8 +832,14 @@ impl<const ALIGN: usize> ShmRefMap<ALIGN> {
             return Err(OpteeSmcReturnCode::ENomem);
         }
         let num_pages = aligned_size_usize / ALIGN;
-        let mut pages = Vec::with_capacity(num_pages);
+        let mut pages = Vec::new();
+        pages
+            .try_reserve_exact(num_pages)
+            .map_err(|_| OpteeSmcReturnCode::ENomem)?;
         let mut visited_pages_data = HashSet::new();
+        visited_pages_data
+            .try_reserve(num_pages)
+            .map_err(|_| OpteeSmcReturnCode::ENomem)?;
         let mut cur_addr: usize = shm_ref_pages_data_phys_addr.trunc();
         loop {
             if visited_pages_data.contains(&cur_addr) {
@@ -850,17 +874,14 @@ impl<const ALIGN: usize> ShmRefMap<ALIGN> {
             }
         }
 
-        self.insert(
-            shm_ref,
-            ShmInfo::new(pages.into_boxed_slice(), page_offset.trunc(), size)?,
-        )?;
+        self.insert(shm_ref, ShmInfo::new(pages, page_offset.trunc(), size)?)?;
         Ok(())
     }
 }
 
 fn shm_ref_map() -> &'static ShmRefMap<PAGE_SIZE> {
-    static SHM_REF_MAP: OnceBox<ShmRefMap<PAGE_SIZE>> = OnceBox::new();
-    SHM_REF_MAP.get_or_init(|| Box::new(ShmRefMap::new()))
+    static SHM_REF_MAP: spin::Once<ShmRefMap<PAGE_SIZE>> = spin::Once::new();
+    SHM_REF_MAP.call_once(ShmRefMap::new)
 }
 
 /// Get the normal world shared memory information (physical addresses and page offset) from `OpteeMsgParamTmem`.
@@ -873,7 +894,7 @@ fn get_shm_info_from_optee_msg_param_tmem(
 ) -> Result<ShmInfo<PAGE_SIZE>, OpteeSmcReturnCode> {
     if tmem.buf_ptr == 0 {
         // NULL buffer - create empty ShmInfo
-        return ShmInfo::new(Box::new([]), 0, 0);
+        return ShmInfo::new(Vec::new(), 0, 0);
     }
 
     let phys_addr = tmem.buf_ptr;
@@ -891,7 +912,10 @@ fn get_shm_info_from_optee_msg_param_tmem(
         .div_ceil(PAGE_SIZE);
 
     // Build page address list
-    let mut page_addrs = Vec::with_capacity(num_pages);
+    let mut page_addrs = Vec::new();
+    page_addrs
+        .try_reserve_exact(num_pages)
+        .map_err(|_| OpteeSmcReturnCode::ENomem)?;
     for i in 0..num_pages {
         let page_addr = aligned_addr
             .checked_add(
@@ -902,7 +926,7 @@ fn get_shm_info_from_optee_msg_param_tmem(
         page_addrs.push(PhysPageAddr::new(page_addr.trunc()).ok_or(OpteeSmcReturnCode::EBadAddr)?);
     }
 
-    ShmInfo::new(page_addrs.into_boxed_slice(), page_offset, size)
+    ShmInfo::new(page_addrs, page_offset, size)
 }
 
 /// Get the normal world shared memory information (physical addresses and page offset) from `OpteeMsgParamRmem`.
@@ -912,7 +936,7 @@ fn get_shm_info_from_optee_msg_param_tmem(
 fn get_shm_info_from_optee_msg_param_rmem(
     rmem: OpteeMsgParamRmem,
 ) -> Result<ShmInfo<PAGE_SIZE>, OpteeSmcReturnCode> {
-    let Some(shm_info) = shm_ref_map().get(rmem.shm_ref) else {
+    let Some(shm_info) = shm_ref_map().get(rmem.shm_ref)? else {
         return Err(OpteeSmcReturnCode::ENotAvail);
     };
     let page_offset = shm_info.page_offset;
@@ -934,11 +958,10 @@ fn get_shm_info_from_optee_msg_param_rmem(
     if start_page_index >= shm_info.page_addrs.len() || end_page_index > shm_info.page_addrs.len() {
         return Err(OpteeSmcReturnCode::EBadAddr);
     }
-    let mut page_addrs = Vec::with_capacity(end_page_index - start_page_index);
+    let mut page_addrs = Vec::new();
+    page_addrs
+        .try_reserve_exact(end_page_index - start_page_index)
+        .map_err(|_| OpteeSmcReturnCode::ENomem)?;
     page_addrs.extend_from_slice(&shm_info.page_addrs[start_page_index..end_page_index]);
-    ShmInfo::new(
-        page_addrs.into_boxed_slice(),
-        start % PAGE_SIZE,
-        rmem.size.trunc(),
-    )
+    ShmInfo::new(page_addrs, start % PAGE_SIZE, rmem.size.trunc())
 }

--- a/litebox_shim_optee/src/msg_handler.rs
+++ b/litebox_shim_optee/src/msg_handler.rs
@@ -787,9 +787,6 @@ impl<const ALIGN: usize> ShmRefMap<ALIGN> {
         } else if guard.len() >= MAX_SHM_REF_MAP_ENTRIES {
             Err(OpteeSmcReturnCode::ENomem)
         } else {
-            guard
-                .try_reserve(1)
-                .map_err(|_| OpteeSmcReturnCode::ENomem)?;
             let _ = guard.insert(shm_ref, info);
             Ok(())
         }
@@ -837,9 +834,6 @@ impl<const ALIGN: usize> ShmRefMap<ALIGN> {
             .try_reserve_exact(num_pages)
             .map_err(|_| OpteeSmcReturnCode::ENomem)?;
         let mut visited_pages_data = HashSet::new();
-        visited_pages_data
-            .try_reserve(num_pages)
-            .map_err(|_| OpteeSmcReturnCode::ENomem)?;
         let mut cur_addr: usize = shm_ref_pages_data_phys_addr.trunc();
         loop {
             if visited_pages_data.contains(&cur_addr) {

--- a/litebox_shim_optee/src/msg_handler.rs
+++ b/litebox_shim_optee/src/msg_handler.rs
@@ -65,10 +65,6 @@ const MAX_NOTIF_VALUE: usize = 0;
 const MAX_SHM_MEMREF_SIZE: usize = 8 * 1024 * 1024;
 const MAX_SHM_REF_MAP_ENTRIES: usize = 1024;
 
-fn allocate_zeroed_vec(len: usize) -> Result<Vec<u8>, OpteeSmcReturnCode> {
-    u8::new_vec_zeroed(len).map_err(|_| OpteeSmcReturnCode::ENomem)
-}
-
 #[inline]
 fn page_align_down(address: u64) -> u64 {
     address & !(PAGE_SIZE as u64 - 1)
@@ -198,7 +194,7 @@ pub fn read_optee_msg_args_from_phys(
         main_max
     };
 
-    let mut blob = allocate_zeroed_vec(copy_size)?;
+    let mut blob = u8::new_vec_zeroed(copy_size).map_err(|_| OpteeSmcReturnCode::ENomem)?;
 
     let blob_ptr =
         NormalWorldConstPtr::<u8, PAGE_SIZE>::with_contiguous_pages(phys_addr, copy_size)
@@ -256,7 +252,7 @@ pub fn handle_optee_smc_args(
             let copy_size =
                 main_max + optee_msg_args_total_size(OpteeRpcArgs::MAX_RPC_ARG_PARAM_COUNT.trunc());
 
-            let mut blob = allocate_zeroed_vec(copy_size)?;
+            let mut blob = u8::new_vec_zeroed(copy_size).map_err(|_| OpteeSmcReturnCode::ENomem)?;
             shm_info.read_at(offset, &mut blob)?;
             let (msg_args, rpc_args) = parse_optee_msg_args(&blob, true)?;
 
@@ -570,7 +566,7 @@ fn build_memref_input(
     shm_info: &ShmInfo<PAGE_SIZE>,
     data_size: usize,
 ) -> Result<UteeParamOwned, OpteeSmcReturnCode> {
-    let mut data = allocate_zeroed_vec(data_size)?;
+    let mut data = u8::new_vec_zeroed(data_size).map_err(|_| OpteeSmcReturnCode::ENomem)?;
     shm_info.read_at(0, &mut data)?;
     Ok(UteeParamOwned::MemrefInput { data: data.into() })
 }
@@ -580,7 +576,7 @@ fn build_memref_inout(
     shm_info: &ShmInfo<PAGE_SIZE>,
     buffer_size: usize,
 ) -> Result<UteeParamOwned, OpteeSmcReturnCode> {
-    let mut buffer = allocate_zeroed_vec(buffer_size)?;
+    let mut buffer = u8::new_vec_zeroed(buffer_size).map_err(|_| OpteeSmcReturnCode::ENomem)?;
     shm_info.read_at(0, &mut buffer)?;
     Ok(UteeParamOwned::MemrefInout {
         data: buffer.into(),

--- a/litebox_shim_optee/src/session.rs
+++ b/litebox_shim_optee/src/session.rs
@@ -129,9 +129,7 @@ pub struct TaInstance {
     /// The shim must be kept alive to keep the loaded program's memory mappings valid.
     shim: OpteeShim,
     /// The loaded TA program state including entrypoints.
-    /// Boxed to keep it at a fixed heap address - the Task inside must not be moved
-    /// after initialization because it contains internal state that may not survive moves.
-    loaded_program: alloc::boxed::Box<LoadedProgram>,
+    loaded_program: LoadedProgram,
     /// The task page table ID associated with this TA instance.
     ///
     /// Also serves as the instance's identity for sibling-tracking
@@ -766,7 +764,7 @@ impl SessionManager {
         &self,
         session_id: u32,
         shim: OpteeShim,
-        loaded_program: alloc::boxed::Box<LoadedProgram>,
+        loaded_program: LoadedProgram,
         task_page_table_id: usize,
         ta_uuid: TeeUuid,
     ) {
@@ -992,12 +990,12 @@ mod tests {
         crate::OpteeShimBuilder::new().build()
     }
 
-    fn make_loaded_program(ta_flags: TaFlags) -> alloc::boxed::Box<LoadedProgram> {
-        alloc::boxed::Box::new(LoadedProgram {
+    fn make_loaded_program(ta_flags: TaFlags) -> LoadedProgram {
+        LoadedProgram {
             entrypoints: None,
             params_address: None,
             ta_flags,
-        })
+        }
     }
 
     fn make_uuid(seed: u8) -> TeeUuid {

--- a/litebox_shim_optee/src/session.rs
+++ b/litebox_shim_optee/src/session.rs
@@ -483,9 +483,8 @@ pub struct SessionManager {
 
 /// Get the global session manager.
 pub fn session_manager() -> &'static SessionManager {
-    static SESSION_MANAGER: once_cell::race::OnceBox<SessionManager> =
-        once_cell::race::OnceBox::new();
-    SESSION_MANAGER.get_or_init(|| alloc::boxed::Box::new(SessionManager::new()))
+    static SESSION_MANAGER: spin::Once<SessionManager> = spin::Once::new();
+    SESSION_MANAGER.call_once(SessionManager::new)
 }
 
 impl SessionManager {

--- a/litebox_shim_optee/src/syscalls/pta.rs
+++ b/litebox_shim_optee/src/syscalls/pta.rs
@@ -150,7 +150,6 @@ impl Task {
             return Err(TeeResult::Busy);
         }
 
-        busy.try_reserve(1).map_err(|_| TeeResult::OutOfMemory)?;
         busy.insert(pta);
         Ok(Some(PtaBusyGuard { task: self, pta }))
     }
@@ -166,14 +165,8 @@ impl Task {
         // of PTA sessions per TA instance to prevent a TA from exhausting session
         // IDs or memory. The cap is checked while holding the lock, then the lock
         // is released before `open_session` runs.
-        {
-            let mut pta_sessions = self.pta_sessions.lock();
-            if pta_sessions.len() >= MAX_PTA_SESSIONS_PER_TASK {
-                return Err(TeeResult::Busy);
-            }
-            pta_sessions
-                .try_reserve(1)
-                .map_err(|_| TeeResult::OutOfMemory)?;
+        if self.pta_sessions.lock().len() >= MAX_PTA_SESSIONS_PER_TASK {
+            return Err(TeeResult::Busy);
         }
 
         // Run the PTA hook without holding `pta_sessions`. OP-TEE `Task` is

--- a/litebox_shim_optee/src/syscalls/pta.rs
+++ b/litebox_shim_optee/src/syscalls/pta.rs
@@ -6,7 +6,6 @@
 
 use crate::syscalls::Cleanup;
 use crate::{Task, UserConstPtr, UserMutPtr};
-use alloc::vec;
 use alloc::vec::Vec;
 use hmac::{Hmac, Mac};
 use litebox::mm::linux::PAGE_SIZE;
@@ -20,6 +19,7 @@ use litebox_common_optee::{
 };
 use num_enum::TryFromPrimitive;
 use sha2::Sha256;
+use zerocopy::FromZeros as _;
 use zeroize::{Zeroize, Zeroizing};
 
 struct SystemPta;
@@ -150,6 +150,7 @@ impl Task {
             return Err(TeeResult::Busy);
         }
 
+        busy.try_reserve(1).map_err(|_| TeeResult::OutOfMemory)?;
         busy.insert(pta);
         Ok(Some(PtaBusyGuard { task: self, pta }))
     }
@@ -166,15 +167,18 @@ impl Task {
         // IDs or memory. The cap is checked while holding the lock, then the lock
         // is released before `open_session` runs.
         {
-            let pta_sessions = self.pta_sessions.lock();
+            let mut pta_sessions = self.pta_sessions.lock();
             if pta_sessions.len() >= MAX_PTA_SESSIONS_PER_TASK {
                 return Err(TeeResult::Busy);
             }
+            pta_sessions
+                .try_reserve(1)
+                .map_err(|_| TeeResult::OutOfMemory)?;
         }
 
         // Run the PTA hook without holding `pta_sessions`. OP-TEE `Task` is
         // single-threaded, so nothing else mutates `pta_sessions` in the meantime.
-        // Keeping the hook outside the lock to avoid a self deadlock.
+        // Keeping the hook outside the lock avoids a self deadlock.
         let session_id = pta.open_session(params)?;
 
         let prev = self.pta_sessions.lock().insert(session_id, pta);
@@ -200,10 +204,18 @@ impl Task {
     }
 
     pub(crate) fn close_all_pta_sessions(&self) {
-        // Drain into a local buffer and release the lock before invoking
-        // `close_session` to avoid potential dead locks.
-        let sessions: Vec<(u32, PseudoTa)> = self.pta_sessions.lock().drain().collect();
-        for (session_id, pta) in sessions {
+        loop {
+            // Remove one entry at a time so the lock is not held across callbacks
+            // and cleanup does not require a temporary allocation.
+            let session = {
+                let mut sessions = self.pta_sessions.lock();
+                let Some((&session_id, &pta)) = sessions.iter().next() else {
+                    break;
+                };
+                sessions.remove(&session_id);
+                (session_id, pta)
+            };
+            let (session_id, pta) = session;
             pta.close_session(self, session_id);
             crate::SessionIdPool::recycle(session_id);
         }
@@ -307,7 +319,8 @@ impl SystemPta {
 
         // subkey = KDF(huk, usage || ta_uuid || extra_data)
         let ta_uuid_bytes = task.ta_app_id.to_le_bytes();
-        let mut subkey_buf = Zeroizing::new(vec![0u8; subkey_size]);
+        let mut subkey_buf =
+            Zeroizing::new(u8::new_vec_zeroed(subkey_size).map_err(|_| TeeResult::OutOfMemory)?);
         Self::huk_subkey_derive(
             task,
             HukSubkeyUsage::UniqueTa,
@@ -337,7 +350,11 @@ impl SystemPta {
 
         let kdf_context_len =
             core::mem::size_of::<u32>() + const_data.iter().map(|chunk| chunk.len()).sum::<usize>();
-        let mut kdf_context = Zeroizing::new(Vec::with_capacity(kdf_context_len));
+        let mut kdf_context = Vec::new();
+        kdf_context
+            .try_reserve_exact(kdf_context_len)
+            .map_err(|_| TeeResult::OutOfMemory)?;
+        let mut kdf_context = Zeroizing::new(kdf_context);
         kdf_context.extend_from_slice(&(usage as u32).to_le_bytes());
         for chunk in const_data {
             kdf_context.extend_from_slice(chunk);


### PR DESCRIPTION
This PR replaces most of LVBS/OP-TEE's use of infallible `Box` and `Vec` with fallible ones, avoiding kernel panics due to out of memory.