### PR TITLE
Fix Rust 1.98 Clippy failures

### DIFF
--- a/litebox_broker_transport_windows_userland/src/local.rs
+++ b/litebox_broker_transport_windows_userland/src/local.rs
@@ -425,9 +425,11 @@ fn decode_transfer(frame: &[u8]) -> IoResult<TransferredSharedMemory> {
         return Err(invalid_data("invalid shared-memory transfer frame length"));
     }
     let handles = frame[13..]
-        .chunks_exact(8)
+        .as_chunks::<8>()
+        .0
+        .iter()
         .map(|bytes| {
-            usize::try_from(u64::from_le_bytes(bytes.try_into().unwrap()))
+            usize::try_from(u64::from_le_bytes(*bytes))
                 .map_err(|_| invalid_data("transferred handle is too large"))
         })
         .collect::<IoResult<Vec<_>>>()?;

--- a/litebox_shim_windows/src/loader/pe.rs
+++ b/litebox_shim_windows/src/loader/pe.rs
@@ -1579,7 +1579,7 @@ mod tests {
     include!("api_set_mappings.rs");
 
     use alloc::{string::String, vec, vec::Vec};
-    use litebox::platform::{RawConstPointer as _, RawPointerProvider};
+    use litebox::platform::RawPointerProvider;
     use litebox_common_windows::loader::{
         ApiSetHashEntry, ApiSetNamespace, ApiSetNamespaceEntry, ApiSetValueEntry,
         MAX_API_SET_NAMESPACE_SIZE, api_set_hash_prefix,

--- a/litebox_shim_windows/src/loader/pe.rs
+++ b/litebox_shim_windows/src/loader/pe.rs
@@ -1648,13 +1648,13 @@ mod tests {
         let len = len as usize;
         let end = offset.checked_add(len)?;
         let bytes = bytes.get(offset..end)?;
-        let mut chunks = bytes.chunks_exact(size_of::<u16>());
-        if !chunks.remainder().is_empty() {
+        let (chunks, remainder) = bytes.as_chunks::<{ size_of::<u16>() }>();
+        if !remainder.is_empty() {
             return None;
         }
         let units = chunks
-            .by_ref()
-            .map(|chunk| u16::from_le_bytes(chunk.try_into().expect("u16 byte chunk")))
+            .iter()
+            .map(|chunk| u16::from_le_bytes(*chunk))
             .collect::<Vec<_>>();
         Some(String::from_utf16_lossy(&units))
     }

--- a/litebox_shim_windows/src/syscalls/file.rs
+++ b/litebox_shim_windows/src/syscalls/file.rs
@@ -2916,8 +2916,10 @@ mod tests {
             let name_end = name_start + name_length;
             assert!(name_end <= information);
             let name: std::vec::Vec<u16> = output[name_start..name_end]
-                .chunks_exact(2)
-                .map(|bytes| u16::from_ne_bytes(bytes.try_into().unwrap()))
+                .as_chunks::<2>()
+                .0
+                .iter()
+                .map(|bytes| u16::from_ne_bytes(*bytes))
                 .collect();
             names.push(std::string::String::from_utf16(&name).unwrap());
             let next_offset =

--- a/litebox_shim_windows/src/syscalls/ksecdd.rs
+++ b/litebox_shim_windows/src/syscalls/ksecdd.rs
@@ -379,8 +379,10 @@ fn read_utf16_at_offset<Platform: crate::ShimPlatform>(
     let address = buffer.as_usize().checked_add(offset)?;
     let bytes = ConstPtr::<Platform, u8>::from_usize(address).to_owned_slice(byte_length)?;
     let units = bytes
-        .chunks_exact(size_of::<u16>())
-        .map(|bytes| u16::from_le_bytes(bytes.try_into().unwrap()))
+        .as_chunks::<{ size_of::<u16>() }>()
+        .0
+        .iter()
+        .map(|bytes| u16::from_le_bytes(*bytes))
         .collect::<alloc::vec::Vec<_>>();
     let terminator = units.iter().position(|&unit| unit == 0)?;
     String::from_utf16(&units[..terminator]).ok()

--- a/litebox_shim_windows/src/syscalls/object_manager.rs
+++ b/litebox_shim_windows/src/syscalls/object_manager.rs
@@ -1480,8 +1480,10 @@ mod tests {
             "string buffer range stays inside output buffer"
         );
         let units: alloc::vec::Vec<u16> = buffer[offset..offset + length]
-            .chunks_exact(2)
-            .map(|bytes| u16::from_le_bytes(bytes.try_into().expect("u16 bytes")))
+            .as_chunks::<2>()
+            .0
+            .iter()
+            .map(|bytes| u16::from_le_bytes(*bytes))
             .collect();
         String::from_utf16_lossy(&units)
     }

--- a/litebox_shim_windows/src/syscalls/section.rs
+++ b/litebox_shim_windows/src/syscalls/section.rs
@@ -1254,7 +1254,6 @@ mod tests {
 
     use core::mem::{size_of, size_of_val};
 
-    use litebox::platform::{RawConstPointer as _, RawMutPointer as _};
     use litebox_common_windows::nt_status::NtStatus;
 
     use super::*;

--- a/litebox_syscall_rewriter/src/aarch64.rs
+++ b/litebox_syscall_rewriter/src/aarch64.rs
@@ -3964,8 +3964,10 @@ fn validate_trampoline_and_collect_offsets(
         ));
     }
     if trampoline[8..GATES_START_OFFSET]
-        .chunks_exact(4)
-        .any(|word| u32::from_le_bytes(word.try_into().unwrap()) != NOP)
+        .as_chunks::<4>()
+        .0
+        .iter()
+        .any(|word| u32::from_le_bytes(*word) != NOP)
     {
         return Err(Error::TrampolinePatchFailure(
             "malformed AArch64 trampoline header padding".into(),

--- a/litebox_syscall_rewriter/src/lib.rs
+++ b/litebox_syscall_rewriter/src/lib.rs
@@ -2903,8 +2903,8 @@ mod tests {
             trap_all_aarch64_patch_sites(&mut code, 0x1000, RewriteOptions::default()).unwrap();
 
         assert_eq!(count, 3, "SVC and both thread-pointer accesses are sites");
-        for (index, word) in code.chunks_exact(4).enumerate() {
-            let insn = u32::from_le_bytes(word.try_into().unwrap());
+        for (index, word) in code.as_chunks::<4>().0.iter().enumerate() {
+            let insn = u32::from_le_bytes(*word);
             if index == 1 {
                 assert_eq!(insn, 0xD503_201F, "the NOP is not a patch site");
             } else {


### PR DESCRIPTION
This PR replaces constant-sized `chunks_exact` iteration with fixed-size array chunks, fixing the Rust 1.98 `clippy::chunks-exact-to-as-chunks` failures across the Linux, AArch64, and Windows CI jobs while preserving the existing instruction, handle, and UTF-16 decoding behavior.