### PR TITLE
Enable clippy checks on Windows shim

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,7 +206,7 @@ jobs:
         with:
           tool: nextest@${{ env.NEXTEST_VERSION }}
       - uses: Swatinem/rust-cache@v2
-      - run: cargo clippy --locked --verbose --all-targets --all-features -p litebox_runner_linux_on_windows_userland -p litebox_runner_windows_userland
+      - run: cargo clippy --locked --verbose --all-targets --all-features -p litebox_runner_linux_on_windows_userland -p litebox_runner_windows_userland -p litebox_shim_windows
       - run: cargo build --locked --verbose -p litebox_runner_linux_on_windows_userland -p litebox_runner_windows_userland
       - run: cargo nextest run --locked --profile ci -p litebox_runner_linux_on_windows_userland -p litebox_runner_windows_userland
       - run: cargo nextest run --locked --profile ci -p litebox_shim_linux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,6 +195,23 @@ jobs:
     env:
       RUSTFLAGS: -Dwarnings
       RUSTDOCFLAGS: -Dwarnings
+      # Crates that build and run on Windows.
+      WINDOWS_CRATES: >-
+        -p litebox_common_linux
+        -p litebox_common_windows
+        -p litebox_syscall_rewriter
+        -p litebox_packager
+        -p litebox_broker_protocol
+        -p litebox_broker_transport
+        -p litebox_broker_core
+        -p litebox_broker_local
+        -p litebox_broker_host
+        -p litebox_broker_transport_windows_userland
+        -p litebox_platform_windows_userland
+        -p litebox_shim_linux
+        -p litebox_shim_windows
+        -p litebox_runner_linux_on_windows_userland
+        -p litebox_runner_windows_userland
     steps:
       - name: Check out repo
         uses: actions/checkout@v6
@@ -206,18 +223,16 @@ jobs:
         with:
           tool: nextest@${{ env.NEXTEST_VERSION }}
       - uses: Swatinem/rust-cache@v2
-      - run: cargo clippy --locked --verbose --all-targets --all-features -p litebox_runner_linux_on_windows_userland -p litebox_runner_windows_userland -p litebox_shim_windows
-      - run: cargo build --locked --verbose -p litebox_runner_linux_on_windows_userland -p litebox_runner_windows_userland
-      - run: cargo nextest run --locked --profile ci -p litebox_runner_linux_on_windows_userland -p litebox_runner_windows_userland
-      - run: cargo nextest run --locked --profile ci -p litebox_shim_linux
-      - run: cargo nextest run --locked --profile ci -p litebox_shim_windows
+      - run: cargo clippy --locked --verbose --all-targets --all-features ($env:WINDOWS_CRATES -split ' ')
+      - run: cargo build --locked --verbose ($env:WINDOWS_CRATES -split ' ')
+      - run: cargo nextest run --locked --profile ci ($env:WINDOWS_CRATES -split ' ')
       - run: |
-          cargo test --locked --verbose --doc -p litebox_runner_linux_on_windows_userland -p litebox_runner_windows_userland
+          cargo test --locked --verbose --doc ($env:WINDOWS_CRATES -split ' ')
           # We need to run `cargo test --doc` separately because doc tests
           # aren't included in nextest at the moment. See relevant discussion at
           # https://github.com/nextest-rs/nextest/issues/16
       - name: Build documentation (fail on warnings)
-        run: cargo doc --locked --verbose --no-deps --all-features --document-private-items -p litebox_runner_linux_on_windows_userland -p litebox_runner_windows_userland
+        run: cargo doc --locked --verbose --no-deps --all-features --document-private-items ($env:WINDOWS_CRATES -split ' ')
 
   confirm_no_std:
     name: Confirm no_std

--- a/litebox_platform_windows_userland/src/lib.rs
+++ b/litebox_platform_windows_userland/src/lib.rs
@@ -351,7 +351,7 @@ impl litebox::platform::SignalProvider for WindowsUserland {
 /// Ensures the module-wide TLS slot index ([`TLS_INDEX`]) has been allocated.
 ///
 /// This must be called before any code that reads `TLS_INDEX`. Both
-/// [`run_thread`] (guest threads) and [`run_test_thread`](WindowsUserland::run_test_thread)
+/// [`run_thread`] (guest threads) and `WindowsUserland::run_test_thread`
 /// (test threads) go through here.
 fn ensure_tls_index() {
     // Allocate a TLS slot for this module if not already done. This is used as

--- a/litebox_shim_windows/src/nt_types.rs
+++ b/litebox_shim_windows/src/nt_types.rs
@@ -13,7 +13,7 @@ bitflags::bitflags! {
     /// Flags carried in `CONTEXT.ContextFlags`, selecting which register groups
     /// a `CONTEXT` structure describes.
     #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-    pub struct ContextFlags: u32 {
+    pub(crate) struct ContextFlags: u32 {
         const CONTROL = 0x0010_0001;
         const INTEGER = 0x0010_0002;
         const FLOATING_POINT = 0x0010_0008;
@@ -38,46 +38,46 @@ pub(crate) struct Luid {
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, FromBytes, IntoBytes, Immutable)]
-pub struct X64Context {
-    pub p1_home: u64,
-    pub p2_home: u64,
-    pub p3_home: u64,
-    pub p4_home: u64,
-    pub p5_home: u64,
-    pub p6_home: u64,
-    pub context_flags: u32,
-    pub mx_csr: u32,
-    pub seg_cs: u16,
-    pub seg_ds: u16,
-    pub seg_es: u16,
-    pub seg_fs: u16,
-    pub seg_gs: u16,
-    pub seg_ss: u16,
-    pub e_flags: u32,
-    pub dr0: u64,
-    pub dr1: u64,
-    pub dr2: u64,
-    pub dr3: u64,
-    pub dr6: u64,
-    pub dr7: u64,
-    pub rax: u64,
-    pub rcx: u64,
-    pub rdx: u64,
-    pub rbx: u64,
-    pub rsp: u64,
-    pub rbp: u64,
-    pub rsi: u64,
-    pub rdi: u64,
-    pub r8: u64,
-    pub r9: u64,
-    pub r10: u64,
-    pub r11: u64,
-    pub r12: u64,
-    pub r13: u64,
-    pub r14: u64,
-    pub r15: u64,
-    pub rip: u64,
-    pub extended_state: [u8; 0x3d0],
+pub(crate) struct X64Context {
+    pub(crate) p1_home: u64,
+    pub(crate) p2_home: u64,
+    pub(crate) p3_home: u64,
+    pub(crate) p4_home: u64,
+    pub(crate) p5_home: u64,
+    pub(crate) p6_home: u64,
+    pub(crate) context_flags: u32,
+    pub(crate) mx_csr: u32,
+    pub(crate) seg_cs: u16,
+    pub(crate) seg_ds: u16,
+    pub(crate) seg_es: u16,
+    pub(crate) seg_fs: u16,
+    pub(crate) seg_gs: u16,
+    pub(crate) seg_ss: u16,
+    pub(crate) e_flags: u32,
+    pub(crate) dr0: u64,
+    pub(crate) dr1: u64,
+    pub(crate) dr2: u64,
+    pub(crate) dr3: u64,
+    pub(crate) dr6: u64,
+    pub(crate) dr7: u64,
+    pub(crate) rax: u64,
+    pub(crate) rcx: u64,
+    pub(crate) rdx: u64,
+    pub(crate) rbx: u64,
+    pub(crate) rsp: u64,
+    pub(crate) rbp: u64,
+    pub(crate) rsi: u64,
+    pub(crate) rdi: u64,
+    pub(crate) r8: u64,
+    pub(crate) r9: u64,
+    pub(crate) r10: u64,
+    pub(crate) r11: u64,
+    pub(crate) r12: u64,
+    pub(crate) r13: u64,
+    pub(crate) r14: u64,
+    pub(crate) r15: u64,
+    pub(crate) rip: u64,
+    pub(crate) extended_state: [u8; 0x3d0],
 }
 
 impl Default for X64Context {
@@ -346,7 +346,7 @@ pub(crate) struct AhcServiceData {
 bitflags::bitflags! {
     /// Packed process flags stored in `PEB.BitField`.
     #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-    pub struct PebBitField: u8 {
+    pub(crate) struct PebBitField: u8 {
         const IMAGE_USES_LARGE_PAGES = 1 << 0;
         const IS_PROTECTED_PROCESS = 1 << 1;
         const IS_IMAGE_DYNAMICALLY_RELOCATED = 1 << 2;
@@ -360,126 +360,126 @@ bitflags::bitflags! {
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, FromBytes, IntoBytes, Immutable)]
-pub struct ProcessEnvironmentBlock {
-    pub inherited_address_space: u8,
-    pub read_image_file_exec_options: u8,
-    pub being_debugged: u8,
+pub(crate) struct ProcessEnvironmentBlock {
+    pub(crate) inherited_address_space: u8,
+    pub(crate) read_image_file_exec_options: u8,
+    pub(crate) being_debugged: u8,
     /// [`PebBitField`]
-    pub bit_field: u8,
-    pub padding_0: [u8; 4],
-    pub mutant: usize,
-    pub image_base_address: usize,
-    pub ldr: usize,
+    pub(crate) bit_field: u8,
+    pub(crate) padding_0: [u8; 4],
+    pub(crate) mutant: usize,
+    pub(crate) image_base_address: usize,
+    pub(crate) ldr: usize,
     /// Pointer to [`RtlUserProcessParameters`].
-    pub process_parameters: usize,
-    pub sub_system_data: usize,
-    pub process_heap: usize,
-    pub fast_peb_lock: usize,
-    pub atl_thunk_s_list_ptr: usize,
-    pub ifeo_key: usize,
-    pub cross_process_flags: u32,
-    pub padding_1: [u8; 4],
-    pub kernel_callback_table: usize,
-    pub system_reserved: u32,
-    pub atl_thunk_s_list_ptr_32: u32,
-    pub api_set_map: usize,
-    pub tls_expansion_counter: u32,
-    pub padding_2: [u8; 4],
-    pub tls_bitmap: usize,
-    pub tls_bitmap_bits: [u32; 2],
-    pub read_only_shared_memory_base: usize,
-    pub shared_data: usize,
-    pub read_only_static_server_data: usize,
-    pub ansi_code_page_data: usize,
-    pub oem_code_page_data: usize,
-    pub unicode_case_table_data: usize,
-    pub number_of_processors: u32,
-    pub nt_global_flag: u32,
-    pub critical_section_timeout: i64,
-    pub heap_segment_reserve: u64,
-    pub heap_segment_commit: u64,
-    pub heap_de_commit_total_free_threshold: u64,
-    pub heap_de_commit_free_block_threshold: u64,
-    pub number_of_heaps: u32,
-    pub maximum_number_of_heaps: u32,
-    pub process_heaps: usize,
-    pub gdi_shared_handle_table: usize,
-    pub process_starter_helper: usize,
-    pub gdi_dc_attribute_list: u32,
-    pub padding_3: [u8; 4],
-    pub loader_lock: usize,
-    pub os_major_version: u32,
-    pub os_minor_version: u32,
-    pub os_build_number: u16,
-    pub os_csd_version: u16,
-    pub os_platform_id: u32,
-    pub image_subsystem: u32,
-    pub image_subsystem_major_version: u32,
-    pub image_subsystem_minor_version: u32,
-    pub padding_4: [u8; 4],
-    pub active_process_affinity_mask: u64,
-    pub gdi_handle_buffer: [u32; 60],
-    pub post_process_init_routine: usize,
-    pub tls_expansion_bitmap: usize,
-    pub tls_expansion_bitmap_bits: [u32; 32],
-    pub session_id: u32,
-    pub padding_5: [u8; 4],
-    pub app_compat_flags: u64,
-    pub app_compat_flags_user: u64,
-    pub p_shim_data: usize,
-    pub app_compat_info: usize,
-    pub csd_version: UnicodeString,
-    pub activation_context_data: usize,
-    pub process_assembly_storage_map: usize,
-    pub system_default_activation_context_data: usize,
-    pub system_assembly_storage_map: usize,
-    pub minimum_stack_commit: u64,
-    pub spare_pointers: [usize; 2],
-    pub patch_loader_data: usize,
-    pub chpe_v2_process_info: usize,
-    pub app_model_feature_state: u32,
-    pub spare_ulongs: [u32; 2],
-    pub active_code_page: u16,
-    pub oem_code_page: u16,
-    pub use_case_mapping: u16,
-    pub unused_nls_field: u16,
-    pub padding_6a: [u8; 4],
-    pub wer_registration_data: usize,
-    pub wer_ship_assert_ptr: usize,
-    pub ec_code_bit_map: usize,
-    pub p_image_header_hash: usize,
-    pub tracing_flags: u32,
-    pub padding_6: [u8; 4],
-    pub csr_server_read_only_shared_memory_base: u64,
-    pub tpp_workerp_list_lock: u64,
-    pub tpp_workerp_list: ListEntry,
-    pub wait_on_address_hash_table: [usize; 128],
-    pub telemetry_coverage_header: usize,
-    pub cloud_file_flags: u32,
-    pub cloud_file_diag_flags: u32,
-    pub placeholder_compatibility_mode: i8,
-    pub placeholder_compatibility_mode_reserved: [i8; 7],
-    pub leap_second_data: usize,
-    pub leap_second_flags: u32,
-    pub nt_global_flag_2: u32,
-    pub extended_feature_disable_mask: u64,
+    pub(crate) process_parameters: usize,
+    pub(crate) sub_system_data: usize,
+    pub(crate) process_heap: usize,
+    pub(crate) fast_peb_lock: usize,
+    pub(crate) atl_thunk_s_list_ptr: usize,
+    pub(crate) ifeo_key: usize,
+    pub(crate) cross_process_flags: u32,
+    pub(crate) padding_1: [u8; 4],
+    pub(crate) kernel_callback_table: usize,
+    pub(crate) system_reserved: u32,
+    pub(crate) atl_thunk_s_list_ptr_32: u32,
+    pub(crate) api_set_map: usize,
+    pub(crate) tls_expansion_counter: u32,
+    pub(crate) padding_2: [u8; 4],
+    pub(crate) tls_bitmap: usize,
+    pub(crate) tls_bitmap_bits: [u32; 2],
+    pub(crate) read_only_shared_memory_base: usize,
+    pub(crate) shared_data: usize,
+    pub(crate) read_only_static_server_data: usize,
+    pub(crate) ansi_code_page_data: usize,
+    pub(crate) oem_code_page_data: usize,
+    pub(crate) unicode_case_table_data: usize,
+    pub(crate) number_of_processors: u32,
+    pub(crate) nt_global_flag: u32,
+    pub(crate) critical_section_timeout: i64,
+    pub(crate) heap_segment_reserve: u64,
+    pub(crate) heap_segment_commit: u64,
+    pub(crate) heap_de_commit_total_free_threshold: u64,
+    pub(crate) heap_de_commit_free_block_threshold: u64,
+    pub(crate) number_of_heaps: u32,
+    pub(crate) maximum_number_of_heaps: u32,
+    pub(crate) process_heaps: usize,
+    pub(crate) gdi_shared_handle_table: usize,
+    pub(crate) process_starter_helper: usize,
+    pub(crate) gdi_dc_attribute_list: u32,
+    pub(crate) padding_3: [u8; 4],
+    pub(crate) loader_lock: usize,
+    pub(crate) os_major_version: u32,
+    pub(crate) os_minor_version: u32,
+    pub(crate) os_build_number: u16,
+    pub(crate) os_csd_version: u16,
+    pub(crate) os_platform_id: u32,
+    pub(crate) image_subsystem: u32,
+    pub(crate) image_subsystem_major_version: u32,
+    pub(crate) image_subsystem_minor_version: u32,
+    pub(crate) padding_4: [u8; 4],
+    pub(crate) active_process_affinity_mask: u64,
+    pub(crate) gdi_handle_buffer: [u32; 60],
+    pub(crate) post_process_init_routine: usize,
+    pub(crate) tls_expansion_bitmap: usize,
+    pub(crate) tls_expansion_bitmap_bits: [u32; 32],
+    pub(crate) session_id: u32,
+    pub(crate) padding_5: [u8; 4],
+    pub(crate) app_compat_flags: u64,
+    pub(crate) app_compat_flags_user: u64,
+    pub(crate) p_shim_data: usize,
+    pub(crate) app_compat_info: usize,
+    pub(crate) csd_version: UnicodeString,
+    pub(crate) activation_context_data: usize,
+    pub(crate) process_assembly_storage_map: usize,
+    pub(crate) system_default_activation_context_data: usize,
+    pub(crate) system_assembly_storage_map: usize,
+    pub(crate) minimum_stack_commit: u64,
+    pub(crate) spare_pointers: [usize; 2],
+    pub(crate) patch_loader_data: usize,
+    pub(crate) chpe_v2_process_info: usize,
+    pub(crate) app_model_feature_state: u32,
+    pub(crate) spare_ulongs: [u32; 2],
+    pub(crate) active_code_page: u16,
+    pub(crate) oem_code_page: u16,
+    pub(crate) use_case_mapping: u16,
+    pub(crate) unused_nls_field: u16,
+    pub(crate) padding_6a: [u8; 4],
+    pub(crate) wer_registration_data: usize,
+    pub(crate) wer_ship_assert_ptr: usize,
+    pub(crate) ec_code_bit_map: usize,
+    pub(crate) p_image_header_hash: usize,
+    pub(crate) tracing_flags: u32,
+    pub(crate) padding_6: [u8; 4],
+    pub(crate) csr_server_read_only_shared_memory_base: u64,
+    pub(crate) tpp_workerp_list_lock: u64,
+    pub(crate) tpp_workerp_list: ListEntry,
+    pub(crate) wait_on_address_hash_table: [usize; 128],
+    pub(crate) telemetry_coverage_header: usize,
+    pub(crate) cloud_file_flags: u32,
+    pub(crate) cloud_file_diag_flags: u32,
+    pub(crate) placeholder_compatibility_mode: i8,
+    pub(crate) placeholder_compatibility_mode_reserved: [i8; 7],
+    pub(crate) leap_second_data: usize,
+    pub(crate) leap_second_flags: u32,
+    pub(crate) nt_global_flag_2: u32,
+    pub(crate) extended_feature_disable_mask: u64,
 }
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, FromBytes, IntoBytes, Immutable)]
-pub struct NtTib {
-    pub exception_list: usize,
-    pub stack_base: usize,
-    pub stack_limit: usize,
-    pub sub_system_tib: usize,
-    pub fiber_data_or_version: usize,
-    pub arbitrary_user_pointer: usize,
-    pub self_pointer: usize,
+pub(crate) struct NtTib {
+    pub(crate) exception_list: usize,
+    pub(crate) stack_base: usize,
+    pub(crate) stack_limit: usize,
+    pub(crate) sub_system_tib: usize,
+    pub(crate) fiber_data_or_version: usize,
+    pub(crate) arbitrary_user_pointer: usize,
+    pub(crate) self_pointer: usize,
 }
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, FromBytes, IntoBytes, Immutable)]
-pub struct ActivationContextStack {
+pub(crate) struct ActivationContextStack {
     pub(crate) active_frame: usize,
     pub(crate) frame_list_cache: ListEntry,
     pub(crate) flags: u32,
@@ -492,164 +492,164 @@ const _: () = assert!(core::mem::size_of::<ActivationContextStack>() == 0x28);
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, FromBytes, IntoBytes, Immutable)]
-pub struct GdiTebBatch {
+pub(crate) struct GdiTebBatch {
     _reserved: [u8; 0x4e8],
 }
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, FromBytes, IntoBytes, Immutable)]
-pub struct ClientId {
-    pub unique_process: usize,
-    pub unique_thread: usize,
+pub(crate) struct ClientId {
+    pub(crate) unique_process: usize,
+    pub(crate) unique_thread: usize,
 }
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, FromBytes, IntoBytes, Immutable)]
-pub struct ListEntry {
-    pub flink: usize,
-    pub blink: usize,
+pub(crate) struct ListEntry {
+    pub(crate) flink: usize,
+    pub(crate) blink: usize,
 }
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, FromBytes, IntoBytes, Immutable)]
-pub struct Guid {
-    pub data: [u8; 16],
+pub(crate) struct Guid {
+    pub(crate) data: [u8; 16],
 }
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, FromBytes, IntoBytes, Immutable)]
-pub struct GroupAffinity {
-    pub mask: usize,
-    pub group: u16,
-    pub reserved: [u16; 3],
+pub(crate) struct GroupAffinity {
+    pub(crate) mask: usize,
+    pub(crate) group: u16,
+    pub(crate) reserved: [u16; 3],
 }
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, FromBytes, IntoBytes, Immutable)]
-pub struct ThreadEnvironmentBlock {
-    pub nt_tib: NtTib,
-    pub environment_pointer: usize,
-    pub client_id: ClientId,
-    pub active_rpc_handle: usize,
-    pub thread_local_storage_pointer: usize,
+pub(crate) struct ThreadEnvironmentBlock {
+    pub(crate) nt_tib: NtTib,
+    pub(crate) environment_pointer: usize,
+    pub(crate) client_id: ClientId,
+    pub(crate) active_rpc_handle: usize,
+    pub(crate) thread_local_storage_pointer: usize,
     /// Pointer to [`ProcessEnvironmentBlock`].
-    pub process_environment_block: usize,
-    pub last_error_value: u32,
-    pub count_of_owned_critical_sections: u32,
-    pub csr_client_thread: usize,
-    pub win_32_thread_info: usize,
-    pub user_32_reserved: [u32; 26],
-    pub user_reserved: [u32; 5],
-    pub padding_user_reserved: [u8; 4],
-    pub wow_32_reserved: usize,
-    pub current_locale: u32,
-    pub fp_software_status_register: u32,
-    pub reserved_for_debugger_instrumentation: [usize; 16],
-    pub system_reserved_1: [usize; 25],
-    pub heap_fls_data: usize,
-    pub rng_state: [u64; 4],
-    pub placeholder_compatibility_mode: i8,
-    pub placeholder_hydration_always_explicit: u8,
-    pub placeholder_reserved: [i8; 10],
-    pub proxied_process_id: u32,
-    pub activation_stack: ActivationContextStack,
-    pub working_on_behalf_ticket: [u8; 8],
-    pub exception_code: i32,
-    pub padding_0: [u8; 4],
-    pub activation_context_stack_pointer: usize,
-    pub instrumentation_callback_sp: u64,
-    pub instrumentation_callback_previous_pc: u64,
-    pub instrumentation_callback_previous_sp: u64,
-    pub tx_fs_context: u32,
-    pub instrumentation_callback_disabled: u8,
-    pub unaligned_load_store_exceptions: u8,
-    pub padding_1: [u8; 2],
-    pub gdi_teb_batch: GdiTebBatch,
-    pub real_client_id: ClientId,
-    pub gdi_cached_process_handle: usize,
-    pub gdi_client_pid: u32,
-    pub gdi_client_tid: u32,
-    pub gdi_thread_local_info: usize,
-    pub win_32_client_info: [u64; 62],
-    pub gl_dispatch_table: [usize; 233],
-    pub gl_reserved_1: [u64; 29],
-    pub gl_reserved_2: usize,
-    pub gl_section_info: usize,
-    pub gl_section: usize,
-    pub gl_table: usize,
-    pub gl_current_rc: usize,
-    pub gl_context: usize,
-    pub last_status_value: u32,
-    pub padding_2: [u8; 4],
-    pub static_unicode_string: UnicodeString,
-    pub static_unicode_buffer: [u16; 261],
-    pub padding_3: [u8; 6],
-    pub deallocation_stack: usize,
-    pub tls_slots: [usize; 64],
-    pub tls_links: ListEntry,
-    pub vdm: usize,
-    pub reserved_for_nt_rpc: usize,
-    pub dbg_ss_reserved: [usize; 2],
-    pub hard_error_mode: u32,
-    pub padding_4: [u8; 4],
-    pub instrumentation: [usize; 11],
-    pub activity_id: Guid,
-    pub sub_process_tag: usize,
-    pub perflib_data: usize,
-    pub etw_trace_data: usize,
-    pub win_sock_data: usize,
-    pub gdi_batch_count: u32,
-    pub ideal_processor_value: u32,
-    pub guaranteed_stack_bytes: u32,
-    pub padding_5: [u8; 4],
-    pub reserved_for_perf: usize,
-    pub reserved_for_ole: usize,
-    pub waiting_on_loader_lock: u32,
-    pub padding_6: [u8; 4],
-    pub saved_priority_state: usize,
-    pub reserved_for_code_coverage: u64,
-    pub thread_pool_data: usize,
-    pub tls_expansion_slots: usize,
-    pub chpe_v_2_cpu_area_info: usize,
-    pub unused: usize,
-    pub mui_generation: u32,
-    pub is_impersonating: u32,
-    pub nls_cache: usize,
-    pub p_shim_data: usize,
-    pub heap_data: u32,
-    pub padding_7: [u8; 4],
-    pub current_transaction_handle: usize,
-    pub active_frame: usize,
-    pub fls_data: usize,
-    pub preferred_languages: usize,
-    pub user_pref_languages: usize,
-    pub merged_pref_languages: usize,
-    pub mui_impersonation: u32,
-    pub cross_teb_flags: u16,
-    pub same_teb_flags: u16,
-    pub txn_scope_enter_callback: usize,
-    pub txn_scope_exit_callback: usize,
-    pub txn_scope_context: usize,
-    pub lock_count: u32,
-    pub wow_teb_offset: i32,
-    pub resource_ret_value: usize,
-    pub reserved_for_wdf: usize,
-    pub reserved_for_crt: u64,
-    pub effective_container_id: Guid,
-    pub last_sleep_counter: u64,
-    pub spin_call_count: u32,
-    pub padding_8: [u8; 4],
-    pub extended_feature_disable_mask: u64,
-    pub scheduler_shared_data_slot: usize,
-    pub heap_walk_context: usize,
-    pub primary_group_affinity: GroupAffinity,
-    pub rcu: [u32; 2],
+    pub(crate) process_environment_block: usize,
+    pub(crate) last_error_value: u32,
+    pub(crate) count_of_owned_critical_sections: u32,
+    pub(crate) csr_client_thread: usize,
+    pub(crate) win_32_thread_info: usize,
+    pub(crate) user_32_reserved: [u32; 26],
+    pub(crate) user_reserved: [u32; 5],
+    pub(crate) padding_user_reserved: [u8; 4],
+    pub(crate) wow_32_reserved: usize,
+    pub(crate) current_locale: u32,
+    pub(crate) fp_software_status_register: u32,
+    pub(crate) reserved_for_debugger_instrumentation: [usize; 16],
+    pub(crate) system_reserved_1: [usize; 25],
+    pub(crate) heap_fls_data: usize,
+    pub(crate) rng_state: [u64; 4],
+    pub(crate) placeholder_compatibility_mode: i8,
+    pub(crate) placeholder_hydration_always_explicit: u8,
+    pub(crate) placeholder_reserved: [i8; 10],
+    pub(crate) proxied_process_id: u32,
+    pub(crate) activation_stack: ActivationContextStack,
+    pub(crate) working_on_behalf_ticket: [u8; 8],
+    pub(crate) exception_code: i32,
+    pub(crate) padding_0: [u8; 4],
+    pub(crate) activation_context_stack_pointer: usize,
+    pub(crate) instrumentation_callback_sp: u64,
+    pub(crate) instrumentation_callback_previous_pc: u64,
+    pub(crate) instrumentation_callback_previous_sp: u64,
+    pub(crate) tx_fs_context: u32,
+    pub(crate) instrumentation_callback_disabled: u8,
+    pub(crate) unaligned_load_store_exceptions: u8,
+    pub(crate) padding_1: [u8; 2],
+    pub(crate) gdi_teb_batch: GdiTebBatch,
+    pub(crate) real_client_id: ClientId,
+    pub(crate) gdi_cached_process_handle: usize,
+    pub(crate) gdi_client_pid: u32,
+    pub(crate) gdi_client_tid: u32,
+    pub(crate) gdi_thread_local_info: usize,
+    pub(crate) win_32_client_info: [u64; 62],
+    pub(crate) gl_dispatch_table: [usize; 233],
+    pub(crate) gl_reserved_1: [u64; 29],
+    pub(crate) gl_reserved_2: usize,
+    pub(crate) gl_section_info: usize,
+    pub(crate) gl_section: usize,
+    pub(crate) gl_table: usize,
+    pub(crate) gl_current_rc: usize,
+    pub(crate) gl_context: usize,
+    pub(crate) last_status_value: u32,
+    pub(crate) padding_2: [u8; 4],
+    pub(crate) static_unicode_string: UnicodeString,
+    pub(crate) static_unicode_buffer: [u16; 261],
+    pub(crate) padding_3: [u8; 6],
+    pub(crate) deallocation_stack: usize,
+    pub(crate) tls_slots: [usize; 64],
+    pub(crate) tls_links: ListEntry,
+    pub(crate) vdm: usize,
+    pub(crate) reserved_for_nt_rpc: usize,
+    pub(crate) dbg_ss_reserved: [usize; 2],
+    pub(crate) hard_error_mode: u32,
+    pub(crate) padding_4: [u8; 4],
+    pub(crate) instrumentation: [usize; 11],
+    pub(crate) activity_id: Guid,
+    pub(crate) sub_process_tag: usize,
+    pub(crate) perflib_data: usize,
+    pub(crate) etw_trace_data: usize,
+    pub(crate) win_sock_data: usize,
+    pub(crate) gdi_batch_count: u32,
+    pub(crate) ideal_processor_value: u32,
+    pub(crate) guaranteed_stack_bytes: u32,
+    pub(crate) padding_5: [u8; 4],
+    pub(crate) reserved_for_perf: usize,
+    pub(crate) reserved_for_ole: usize,
+    pub(crate) waiting_on_loader_lock: u32,
+    pub(crate) padding_6: [u8; 4],
+    pub(crate) saved_priority_state: usize,
+    pub(crate) reserved_for_code_coverage: u64,
+    pub(crate) thread_pool_data: usize,
+    pub(crate) tls_expansion_slots: usize,
+    pub(crate) chpe_v_2_cpu_area_info: usize,
+    pub(crate) unused: usize,
+    pub(crate) mui_generation: u32,
+    pub(crate) is_impersonating: u32,
+    pub(crate) nls_cache: usize,
+    pub(crate) p_shim_data: usize,
+    pub(crate) heap_data: u32,
+    pub(crate) padding_7: [u8; 4],
+    pub(crate) current_transaction_handle: usize,
+    pub(crate) active_frame: usize,
+    pub(crate) fls_data: usize,
+    pub(crate) preferred_languages: usize,
+    pub(crate) user_pref_languages: usize,
+    pub(crate) merged_pref_languages: usize,
+    pub(crate) mui_impersonation: u32,
+    pub(crate) cross_teb_flags: u16,
+    pub(crate) same_teb_flags: u16,
+    pub(crate) txn_scope_enter_callback: usize,
+    pub(crate) txn_scope_exit_callback: usize,
+    pub(crate) txn_scope_context: usize,
+    pub(crate) lock_count: u32,
+    pub(crate) wow_teb_offset: i32,
+    pub(crate) resource_ret_value: usize,
+    pub(crate) reserved_for_wdf: usize,
+    pub(crate) reserved_for_crt: u64,
+    pub(crate) effective_container_id: Guid,
+    pub(crate) last_sleep_counter: u64,
+    pub(crate) spin_call_count: u32,
+    pub(crate) padding_8: [u8; 4],
+    pub(crate) extended_feature_disable_mask: u64,
+    pub(crate) scheduler_shared_data_slot: usize,
+    pub(crate) heap_walk_context: usize,
+    pub(crate) primary_group_affinity: GroupAffinity,
+    pub(crate) rcu: [u32; 2],
 }
 
 bitflags::bitflags! {
     /// Flags stored in `RTL_USER_PROCESS_PARAMETERS.Flags`.
     #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-    pub struct RtlUserProcFlags: u32 {
+    pub(crate) struct RtlUserProcFlags: u32 {
         /// Pointers in the process-parameter block are absolute addresses.
         const NORMALIZED = 0x0000_0001;
         const PROFILE_USER = 0x0000_0002;
@@ -688,22 +688,22 @@ bitflags::bitflags! {
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, FromBytes, IntoBytes, Immutable)]
-pub struct CurDir {
-    pub dos_path: UnicodeString,
-    pub handle: usize,
+pub(crate) struct CurDir {
+    pub(crate) dos_path: UnicodeString,
+    pub(crate) handle: usize,
 }
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, FromBytes, IntoBytes, Immutable)]
-pub struct RtlDriveLetterCurdir {
+pub(crate) struct RtlDriveLetterCurdir {
     /// Per-drive current-directory flags.
-    pub flags: u16,
+    pub(crate) flags: u16,
     /// Length of the drive current-directory entry.
-    pub length: u16,
+    pub(crate) length: u16,
     /// Timestamp associated with this drive current-directory entry.
-    pub time_stamp: u32,
+    pub(crate) time_stamp: u32,
     /// DOS path for this drive's current directory.
-    pub dos_path: UnicodeString,
+    pub(crate) dos_path: UnicodeString,
 }
 
 /// Memory layout of this struct:
@@ -737,91 +737,91 @@ pub struct RtlDriveLetterCurdir {
 /// See <https://ntdoc.m417z.com/rtl_user_process_parameters> for details on the fields of this struct.
 #[repr(C)]
 #[derive(Clone, Copy, Debug, FromBytes, IntoBytes, Immutable)]
-pub struct RtlUserProcessParameters {
+pub(crate) struct RtlUserProcessParameters {
     /// Total allocated size of this process-parameter buffer, in bytes.
-    pub maximum_length: u32,
+    pub(crate) maximum_length: u32,
     /// Size of the process-parameter block, including any inline variable-length strings.
-    pub length: u32,
+    pub(crate) length: u32,
     /// Process-parameter flags (see [`RtlUserProcFlags`]).
-    pub flags: u32,
+    pub(crate) flags: u32,
     /// Debug flags associated with these process parameters.
-    pub debug_flags: u32,
+    pub(crate) debug_flags: u32,
     /// Console session handle, inherited or derived from process creation options.
-    pub console_handle: usize,
+    pub(crate) console_handle: usize,
     /// Console behavior flags, such as ignoring Ctrl+C requests.
-    pub console_flags: u32,
+    pub(crate) console_flags: u32,
     /// Reserved alignment padding.
-    pub padding_0: [u8; 4],
+    pub(crate) padding_0: [u8; 4],
     /// Standard input handle from `STARTUPINFO.hStdInput`.
-    pub standard_input: usize,
+    pub(crate) standard_input: usize,
     /// Standard output handle from `STARTUPINFO.hStdOutput`.
-    pub standard_output: usize,
+    pub(crate) standard_output: usize,
     /// Standard error handle from `STARTUPINFO.hStdError`.
-    pub standard_error: usize,
+    pub(crate) standard_error: usize,
     /// Current directory path and handle.
-    pub current_directory: CurDir,
+    pub(crate) current_directory: CurDir,
     /// Semicolon-separated DOS-style DLL search paths.
-    pub dll_path: UnicodeString,
+    pub(crate) dll_path: UnicodeString,
     /// Full DOS-style path to the executable image.
-    pub image_path_name: UnicodeString,
+    pub(crate) image_path_name: UnicodeString,
     /// Command line string passed to the process.
-    pub command_line: UnicodeString,
+    pub(crate) command_line: UnicodeString,
     /// Pointer to the separately allocated environment block.
-    pub environment: usize,
+    pub(crate) environment: usize,
     /// Initial window X position when `window_flags` requests a position.
-    pub starting_x: u32,
+    pub(crate) starting_x: u32,
     /// Initial window Y position when `window_flags` requests a position.
-    pub starting_y: u32,
+    pub(crate) starting_y: u32,
     /// Initial window width when `window_flags` requests a size.
-    pub count_x: u32,
+    pub(crate) count_x: u32,
     /// Initial window height when `window_flags` requests a size.
-    pub count_y: u32,
+    pub(crate) count_y: u32,
     /// Initial console screen-buffer width in character cells.
-    pub count_chars_x: u32,
+    pub(crate) count_chars_x: u32,
     /// Initial console screen-buffer height in character cells.
-    pub count_chars_y: u32,
+    pub(crate) count_chars_y: u32,
     /// Initial console text/background color attributes.
-    pub fill_attribute: u32,
+    pub(crate) fill_attribute: u32,
     /// `STARTUPINFO` flags describing which startup fields are valid.
-    pub window_flags: u32,
+    pub(crate) window_flags: u32,
     /// `ShowWindow` value used when `window_flags` includes `STARTF_USESHOWWINDOW`.
-    pub show_window_flags: u32,
+    pub(crate) show_window_flags: u32,
     /// Reserved alignment padding.
-    pub padding_1: [u8; 4],
+    pub(crate) padding_1: [u8; 4],
     /// Console window title, shortcut path, or AppUserModelID depending on `window_flags`.
-    pub window_title: UnicodeString,
+    pub(crate) window_title: UnicodeString,
     /// Window station and desktop name, such as `WinSta0\Default`.
-    pub desktop_info: UnicodeString,
+    pub(crate) desktop_info: UnicodeString,
     /// Startup shell data corresponding to `STARTUPINFO.lpReserved`.
-    pub shell_info: UnicodeString,
+    pub(crate) shell_info: UnicodeString,
     /// Runtime data corresponding to `STARTUPINFO.lpReserved2` and `cbReserved2`.
-    pub runtime_data: UnicodeString,
+    pub(crate) runtime_data: UnicodeString,
     /// Per-drive current-directory entries for the 32 DOS drive letters.
-    pub current_directories: [RtlDriveLetterCurdir; 32],
+    pub(crate) current_directories: [RtlDriveLetterCurdir; 32],
     /// Allocated size of the environment block, in bytes.
-    pub environment_size: u64,
+    pub(crate) environment_size: u64,
     /// Environment version incremented when environment strings change.
-    pub environment_version: u64,
+    pub(crate) environment_version: u64,
     /// Package dependency metadata pointer.
-    pub package_dependency_data: usize,
+    pub(crate) package_dependency_data: usize,
     /// Console process group identifier used to scope control-signal delivery.
-    pub process_group_id: u32,
+    pub(crate) process_group_id: u32,
     /// Requested worker-thread count for parallel DLL loading.
-    pub loader_threads: u32,
+    pub(crate) loader_threads: u32,
     /// DLL path used for packaged-app import redirection.
-    pub redirection_dll_name: UnicodeString,
+    pub(crate) redirection_dll_name: UnicodeString,
     /// Heap partition name.
-    pub heap_partition_name: UnicodeString,
+    pub(crate) heap_partition_name: UnicodeString,
     /// Pointer to default thread-pool CPU-set masks.
-    pub default_threadpool_cpu_set_masks: usize,
+    pub(crate) default_threadpool_cpu_set_masks: usize,
     /// Number of default thread-pool CPU-set masks.
-    pub default_threadpool_cpu_set_mask_count: u32,
+    pub(crate) default_threadpool_cpu_set_mask_count: u32,
     /// Maximum default thread-pool thread count.
-    pub default_threadpool_thread_maximum: u32,
+    pub(crate) default_threadpool_thread_maximum: u32,
     /// Heap memory type mask.
-    pub heap_memory_type_mask: u32,
+    pub(crate) heap_memory_type_mask: u32,
     /// Reserved tail padding.
-    pub padding_2: [u8; 4],
+    pub(crate) padding_2: [u8; 4],
 }
 
 const _: [(); 0x1878] = [(); core::mem::size_of::<ThreadEnvironmentBlock>()];
@@ -831,10 +831,10 @@ const _: [(); 0x448] = [(); core::mem::size_of::<RtlUserProcessParameters>()];
 
 #[repr(C)]
 #[derive(Clone, Copy, FromBytes, Immutable, IntoBytes, KnownLayout)]
-pub struct KSystemTime {
-    pub low_part: u32,
-    pub high_1_time: i32,
-    pub high_2_time: i32,
+pub(crate) struct KSystemTime {
+    pub(crate) low_part: u32,
+    pub(crate) high_1_time: i32,
+    pub(crate) high_2_time: i32,
 }
 
 #[cfg(not(target_os = "windows"))]
@@ -844,7 +844,7 @@ const WINDOWS_KUSER_SHARED_DATA_XSTATE_CONFIGURATION_SIZE: usize = 0x348;
 #[cfg(not(target_os = "windows"))]
 #[repr(C)]
 #[derive(Clone, Copy, FromBytes, Immutable, IntoBytes, KnownLayout)]
-pub struct KUserSharedData {
+pub(crate) struct KUserSharedData {
     tick_count_low_deprecated: u32,
     tick_count_multiplier: u32,
     interrupt_time: KSystemTime,
@@ -852,7 +852,7 @@ pub struct KUserSharedData {
     time_zone_bias: KSystemTime,
     image_number_low: u16,
     image_number_high: u16,
-    pub nt_system_root: [u16; 260],
+    pub(crate) nt_system_root: [u16; 260],
     max_stack_trace_depth: u32,
     crypto_exponent: u32,
     time_zone_id: u32,
@@ -862,13 +862,13 @@ pub struct KUserSharedData {
     rng_seed_version: u64,
     global_validation_run_level: u32,
     time_zone_bias_stamp: u32,
-    pub nt_build_number: u32,
-    pub nt_product_type: u32,
-    pub product_type_is_valid: u8,
+    pub(crate) nt_build_number: u32,
+    pub(crate) nt_product_type: u32,
+    pub(crate) product_type_is_valid: u8,
     reserved_0: u8,
     native_processor_architecture: u16,
-    pub nt_major_version: u32,
-    pub nt_minor_version: u32,
+    pub(crate) nt_major_version: u32,
+    pub(crate) nt_minor_version: u32,
     processor_features: [u8; 64],
     reserved_1: u32,
     reserved_3: u32,

--- a/litebox_syscall_rewriter/tests/snapshot_tests.rs
+++ b/litebox_syscall_rewriter/tests/snapshot_tests.rs
@@ -19,7 +19,12 @@ fn objdump(objdump_cmd: &str, binary: &[u8]) -> String {
 
     let mut lines = String::from_utf8_lossy(&output.stdout)
         .lines()
-        .filter(|l| !l.contains("/tmp/"))
+        // Drop objdump's banner because its temporary filename varies by platform and invocation.
+        .filter(|line| {
+            !line.rsplit_once(':').is_some_and(|(_, banner)| {
+                banner.trim_start().starts_with("file format ")
+            })
+        })
         .map(|line| normalize_objdump_line(line, trampoline_range.as_ref()))
         .collect::<Vec<_>>();
     let first_content = lines

--- a/litebox_syscall_rewriter/tests/snapshot_tests.rs
+++ b/litebox_syscall_rewriter/tests/snapshot_tests.rs
@@ -21,9 +21,9 @@ fn objdump(objdump_cmd: &str, binary: &[u8]) -> String {
         .lines()
         // Drop objdump's banner because its temporary filename varies by platform and invocation.
         .filter(|line| {
-            !line.rsplit_once(':').is_some_and(|(_, banner)| {
-                banner.trim_start().starts_with("file format ")
-            })
+            !line
+                .rsplit_once(':')
+                .is_some_and(|(_, banner)| banner.trim_start().starts_with("file format "))
         })
         .map(|line| normalize_objdump_line(line, trampoline_range.as_ref()))
         .collect::<Vec<_>>();


### PR DESCRIPTION
Restrict Windows NT type definitions to crate-level visibility to address new Clippy warnings.