### PR TITLE
Adding object information syscalls to Windows shim

### DIFF
--- a/litebox_shim_windows/src/lib.rs
+++ b/litebox_shim_windows/src/lib.rs
@@ -1887,6 +1887,30 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                 section_information_length,
                 return_length,
             ),
+            SyscallRequest::NtQueryObject {
+                handle,
+                object_information_class,
+                object_information,
+                object_information_length,
+                return_length,
+            } => self.sys_nt_query_object(
+                handle,
+                object_information_class,
+                object_information,
+                object_information_length,
+                return_length,
+            ),
+            SyscallRequest::NtSetInformationObject {
+                handle,
+                object_information_class,
+                object_information,
+                object_information_length,
+            } => self.sys_nt_set_information_object(
+                handle,
+                object_information_class,
+                object_information,
+                object_information_length,
+            ),
             SyscallRequest::NtQueryInformationProcess {
                 process_handle,
                 process_information_class,
@@ -2333,6 +2357,110 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
 
     pub(crate) fn sys_nt_close(&self, handle: syscalls::Handle) -> NtStatus {
         self.close_handle(handle, CloseRawHandleVisitor { task: self })
+    }
+
+    fn handle_metadata(&self, handle: syscalls::Handle) -> Result<WindowsHandleMetadata, NtStatus> {
+        macro_rules! try_metadata {
+            ($subsystem:ty) => {
+                if let Some(result) =
+                    self.try_get_handle_metadata_for_subsystem::<$subsystem>(handle)
+                {
+                    return result;
+                }
+            };
+        }
+
+        try_metadata!(FileObjectSubsystem<FS>);
+        try_metadata!(RegistryKeySubsystem<Platform>);
+        try_metadata!(EventSubsystem<Platform>);
+        try_metadata!(SemaphoreSubsystem<Platform>);
+        try_metadata!(DirectoryObjectSubsystem<Platform>);
+        try_metadata!(SymbolicLinkSubsystem<Platform>);
+        try_metadata!(IoCompletionSubsystem<Platform>);
+        try_metadata!(LpcPortSubsystem<Platform>);
+        try_metadata!(TimerSubsystem<Platform>);
+        try_metadata!(WaitCompletionPacketSubsystem<Platform>);
+        try_metadata!(WorkerFactorySubsystem<Platform>);
+        try_metadata!(SectionSubsystem<Platform>);
+        try_metadata!(TokenSubsystem);
+        try_metadata!(ThreadSubsystem<Platform>);
+
+        Err(NtStatus::INVALID_HANDLE)
+    }
+
+    fn try_get_handle_metadata_for_subsystem<Subsystem>(
+        &self,
+        handle: syscalls::Handle,
+    ) -> Option<Result<WindowsHandleMetadata, NtStatus>>
+    where
+        Subsystem: WindowsHandleSubsystem,
+    {
+        let typed = match self.typed_handle::<Subsystem>(handle) {
+            Ok(typed) => typed,
+            Err(NtStatus::OBJECT_TYPE_MISMATCH) => return None,
+            Err(status) => return Some(Err(status)),
+        };
+        Some(self.typed_handle_metadata(&typed))
+    }
+
+    fn set_handle_attributes(
+        &self,
+        handle: syscalls::Handle,
+        mask: HandleAttributes,
+        attributes: HandleAttributes,
+    ) -> Result<(), NtStatus> {
+        macro_rules! try_set_attributes {
+            ($subsystem:ty) => {
+                if let Some(result) =
+                    self.try_set_handle_attributes::<$subsystem>(handle, mask, attributes)
+                {
+                    return result;
+                }
+            };
+        }
+
+        try_set_attributes!(FileObjectSubsystem<FS>);
+        try_set_attributes!(RegistryKeySubsystem<Platform>);
+        try_set_attributes!(EventSubsystem<Platform>);
+        try_set_attributes!(SemaphoreSubsystem<Platform>);
+        try_set_attributes!(DirectoryObjectSubsystem<Platform>);
+        try_set_attributes!(SymbolicLinkSubsystem<Platform>);
+        try_set_attributes!(IoCompletionSubsystem<Platform>);
+        try_set_attributes!(LpcPortSubsystem<Platform>);
+        try_set_attributes!(TimerSubsystem<Platform>);
+        try_set_attributes!(WaitCompletionPacketSubsystem<Platform>);
+        try_set_attributes!(WorkerFactorySubsystem<Platform>);
+        try_set_attributes!(SectionSubsystem<Platform>);
+        try_set_attributes!(TokenSubsystem);
+        try_set_attributes!(ThreadSubsystem<Platform>);
+
+        Err(NtStatus::INVALID_HANDLE)
+    }
+
+    fn try_set_handle_attributes<Subsystem>(
+        &self,
+        handle: syscalls::Handle,
+        mask: HandleAttributes,
+        attributes: HandleAttributes,
+    ) -> Option<Result<(), NtStatus>>
+    where
+        Subsystem: WindowsHandleSubsystem,
+    {
+        let typed = match self.typed_handle::<Subsystem>(handle) {
+            Ok(typed) => typed,
+            Err(NtStatus::OBJECT_TYPE_MISMATCH) => return None,
+            Err(status) => return Some(Err(status)),
+        };
+        Some(
+            self.global
+                .litebox
+                .descriptor_table_mut()
+                .with_metadata_mut::<Subsystem, WindowsHandleMetadata, _>(&typed, |metadata| {
+                    metadata.attributes.remove(mask);
+                    metadata.attributes.insert(attributes & mask);
+                })
+                .map_err(|_| NtStatus::INVALID_HANDLE),
+        )
     }
 
     #[expect(

--- a/litebox_shim_windows/src/syscalls/mod.rs
+++ b/litebox_shim_windows/src/syscalls/mod.rs
@@ -656,6 +656,19 @@ pub(crate) enum SyscallRequest<Platform: RawPointerProvider> {
         section_information_length: usize,
         return_length: Option<Platform::RawMutPointer<usize>>,
     },
+    NtQueryObject {
+        handle: Handle,
+        object_information_class: u32,
+        object_information: Platform::RawMutPointer<u8>,
+        object_information_length: u32,
+        return_length: Option<Platform::RawMutPointer<u32>>,
+    },
+    NtSetInformationObject {
+        handle: Handle,
+        object_information_class: u32,
+        object_information: Platform::RawConstPointer<u8>,
+        object_information_length: u32,
+    },
     NtQueryInformationProcess {
         process_handle: ProcessHandle,
         process_information_class: u32,
@@ -1412,6 +1425,19 @@ impl<Platform: RawPointerProvider> SyscallRequest<Platform> {
                 section_information:*,
                 section_information_length,
                 return_length:*,
+            })),
+            NtSysno::NtQueryObject => Some(sys_req!(NtQueryObject {
+                handle: { Handle::from_raw },
+                object_information_class,
+                object_information:*,
+                object_information_length,
+                return_length:*,
+            })),
+            NtSysno::NtSetInformationObject => Some(sys_req!(NtSetInformationObject {
+                handle: { Handle::from_raw },
+                object_information_class,
+                object_information:*,
+                object_information_length,
             })),
             NtSysno::NtQueryInformationProcess => Some(sys_req!(NtQueryInformationProcess {
                 process_handle: { ProcessHandle::from_raw },

--- a/litebox_shim_windows/src/syscalls/object_manager.rs
+++ b/litebox_shim_windows/src/syscalls/object_manager.rs
@@ -1552,7 +1552,6 @@ mod tests {
     use alloc::sync::Arc;
     use core::mem::size_of;
 
-    use litebox::utils::TruncateExt as _;
     use litebox_common_windows::nt_status::NtStatus;
 
     use super::*;

--- a/litebox_shim_windows/src/syscalls/object_manager.rs
+++ b/litebox_shim_windows/src/syscalls/object_manager.rs
@@ -12,8 +12,10 @@ use core::hash::{Hash, Hasher};
 use core::marker::PhantomData;
 use core::mem::size_of;
 
+use int_enum::IntEnum;
 use litebox::fd::{FdEnabledSubsystem, FdEnabledSubsystemEntry};
 use litebox::platform::{RawConstPointer as _, RawMutPointer as _, RawPointerProvider};
+use litebox::utils::TruncateExt as _;
 use litebox_common_windows::nt_status::NtStatus;
 use zerocopy::{FromBytes, Immutable, IntoBytes};
 
@@ -36,6 +38,49 @@ const STANDARD_RIGHTS_REQUIRED: u32 = AccessMask::DELETE.bits()
     | AccessMask::READ_CONTROL.bits()
     | AccessMask::WRITE_DAC.bits()
     | AccessMask::WRITE_OWNER.bits();
+
+#[repr(u32)]
+#[derive(Clone, Copy, Debug, Eq, IntEnum, PartialEq)]
+enum ObjectInformationClass {
+    Basic = 0,
+    Name = 1,
+    Type = 2,
+    Types = 3,
+    HandleFlag = 4,
+    Session = 5,
+    SessionObject = 6,
+    SetRefTrace = 7,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, FromBytes, Immutable, IntoBytes)]
+struct ObjectHandleFlagInformation {
+    inherit: u8,
+    protect_from_close: u8,
+}
+
+impl From<crate::HandleAttributes> for ObjectHandleFlagInformation {
+    fn from(attributes: crate::HandleAttributes) -> Self {
+        Self {
+            inherit: u8::from(attributes.contains(crate::HandleAttributes::INHERIT)),
+            protect_from_close: u8::from(
+                attributes.contains(crate::HandleAttributes::PROTECT_FROM_CLOSE),
+            ),
+        }
+    }
+}
+
+impl From<ObjectHandleFlagInformation> for crate::HandleAttributes {
+    fn from(information: ObjectHandleFlagInformation) -> Self {
+        let mut attributes = Self::empty();
+        attributes.set(Self::INHERIT, information.inherit != 0);
+        attributes.set(
+            Self::PROTECT_FROM_CLOSE,
+            information.protect_from_close != 0,
+        );
+        attributes
+    }
+}
 
 // Wine's server seeds these object-manager directories during init_directories/create_session;
 // ReactOS initializes the same root-style namespace through ObpRootDirectoryObject.
@@ -1043,6 +1088,85 @@ fn write_directory_records<Platform: RawPointerProvider>(
 }
 
 impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
+    pub(crate) fn sys_nt_query_object(
+        &self,
+        handle: Handle,
+        object_information_class: u32,
+        object_information: MutPtr<Platform, u8>,
+        object_information_length: u32,
+        return_length: Option<MutPtr<Platform, u32>>,
+    ) -> NtStatus {
+        match ObjectInformationClass::try_from(object_information_class) {
+            Ok(ObjectInformationClass::HandleFlag) => {}
+            Ok(_) => {
+                litebox_util_log::debug!(
+                    object_information_class = object_information_class;
+                    "Unsupported NtQueryObject class"
+                );
+                return NtStatus::NOT_IMPLEMENTED;
+            }
+            Err(_) => return NtStatus::INVALID_INFO_CLASS,
+        }
+        let required_length = size_of::<ObjectHandleFlagInformation>().trunc();
+        if object_information_length < required_length {
+            return NtStatus::INFO_LENGTH_MISMATCH;
+        }
+        let metadata = match self.handle_metadata(handle) {
+            Ok(metadata) => metadata,
+            Err(status) => return status,
+        };
+        if let Some(return_length) = return_length
+            && return_length.write_at_offset(0, required_length).is_none()
+        {
+            return NtStatus::ACCESS_VIOLATION;
+        }
+        let information = MutPtr::<Platform, ObjectHandleFlagInformation>::from_usize(
+            object_information.as_usize(),
+        );
+        if information
+            .write_at_offset(0, ObjectHandleFlagInformation::from(metadata.attributes))
+            .is_none()
+        {
+            return NtStatus::ACCESS_VIOLATION;
+        }
+        NtStatus::SUCCESS
+    }
+
+    pub(crate) fn sys_nt_set_information_object(
+        &self,
+        handle: Handle,
+        object_information_class: u32,
+        object_information: ConstPtr<Platform, u8>,
+        object_information_length: u32,
+    ) -> NtStatus {
+        match ObjectInformationClass::try_from(object_information_class) {
+            Ok(ObjectInformationClass::HandleFlag) => {}
+            Ok(_) => {
+                litebox_util_log::debug!(
+                    object_information_class = object_information_class;
+                    "Unsupported NtSetInformationObject class"
+                );
+                return NtStatus::NOT_IMPLEMENTED;
+            }
+            Err(_) => return NtStatus::INVALID_INFO_CLASS,
+        }
+        if object_information_length != size_of::<ObjectHandleFlagInformation>().trunc() {
+            return NtStatus::INFO_LENGTH_MISMATCH;
+        }
+        let information = ConstPtr::<Platform, ObjectHandleFlagInformation>::from_usize(
+            object_information.as_usize(),
+        );
+        let Some(information) = information.read_at_offset(0) else {
+            return NtStatus::ACCESS_VIOLATION;
+        };
+        let attributes = crate::HandleAttributes::from(information);
+        let mask = crate::HandleAttributes::INHERIT | crate::HandleAttributes::PROTECT_FROM_CLOSE;
+        match self.set_handle_attributes(handle, mask, attributes) {
+            Ok(()) => NtStatus::SUCCESS,
+            Err(status) => status,
+        }
+    }
+
     fn directory_entry(
         &self,
         handle: Handle,
@@ -1438,13 +1562,87 @@ mod tests {
         load_time_windows_shared_section,
     };
     use crate::tests::{
-        TestPlatform, const_ptr, mut_ptr, null_mut_ptr, object_attributes,
+        TestPlatform, const_ptr, mut_byte_ptr, mut_ptr, null_mut_ptr, object_attributes,
         run_with_test_platform_pointers, test_task, unicode_string, utf16_units,
     };
 
     const DIRECTORY_QUERY: u32 = 0x0000_0001;
     const DIRECTORY_TRAVERSE: u32 = 0x0000_0002;
     const DIRECTORY_ALL_ACCESS: u32 = 0x000f_000f;
+
+    #[test]
+    fn nt_object_handle_flags_round_trip() {
+        run_with_test_platform_pointers(|| {
+            let task = test_task();
+            let mut handle = Handle::default();
+            assert_eq!(
+                task.sys_nt_create_directory_object(
+                    mut_ptr(&mut handle),
+                    DIRECTORY_ALL_ACCESS,
+                    None,
+                    Handle::default(),
+                    0,
+                ),
+                NtStatus::SUCCESS
+            );
+
+            let set_information = ObjectHandleFlagInformation {
+                inherit: 1,
+                protect_from_close: 1,
+            };
+            let set_information =
+                ConstPtr::<TestPlatform, u8>::from_usize(const_ptr(&set_information).as_usize());
+            assert_eq!(
+                task.sys_nt_set_information_object(
+                    handle,
+                    ObjectInformationClass::HandleFlag as u32,
+                    set_information,
+                    size_of::<ObjectHandleFlagInformation>().trunc(),
+                ),
+                NtStatus::SUCCESS
+            );
+
+            let mut queried_information = ObjectHandleFlagInformation {
+                inherit: 0,
+                protect_from_close: 0,
+            };
+            let mut return_length = 0;
+            assert_eq!(
+                task.sys_nt_query_object(
+                    handle,
+                    ObjectInformationClass::HandleFlag as u32,
+                    mut_byte_ptr(&mut queried_information),
+                    size_of::<ObjectHandleFlagInformation>().trunc(),
+                    Some(mut_ptr(&mut return_length)),
+                ),
+                NtStatus::SUCCESS
+            );
+            assert_eq!(queried_information.inherit, 1);
+            assert_eq!(queried_information.protect_from_close, 1);
+            assert_eq!(
+                return_length,
+                size_of::<ObjectHandleFlagInformation>().trunc()
+            );
+            assert_eq!(task.sys_nt_close(handle), NtStatus::HANDLE_NOT_CLOSABLE);
+
+            let clear_information = ObjectHandleFlagInformation {
+                inherit: 0,
+                protect_from_close: 0,
+            };
+            let clear_information =
+                ConstPtr::<TestPlatform, u8>::from_usize(const_ptr(&clear_information).as_usize());
+            assert_eq!(
+                task.sys_nt_set_information_object(
+                    handle,
+                    ObjectInformationClass::HandleFlag as u32,
+                    clear_information,
+                    size_of::<ObjectHandleFlagInformation>().trunc(),
+                ),
+                NtStatus::SUCCESS
+            );
+            assert_eq!(task.sys_nt_close(handle), NtStatus::SUCCESS);
+        });
+    }
 
     #[derive(Clone, Debug, Eq, PartialEq)]
     struct ParsedDirectoryInformation {


### PR DESCRIPTION
Implement `NtQueryObject` and `NtSetInformationObject`.