### PR TITLE
Use broker-local streams for guest TCP

### DIFF
--- a/litebox/src/net/broker_socket.rs
+++ b/litebox/src/net/broker_socket.rs
@@ -3,7 +3,7 @@
 
 use alloc::sync::{Arc, Weak};
 use core::{
-    net::{Ipv4Addr, SocketAddr, SocketAddrV4},
+    net::{SocketAddr, SocketAddrV4},
     sync::atomic::{AtomicBool, Ordering},
 };
 
@@ -32,14 +32,6 @@ use crate::{
 };
 
 const _: () = assert!(MAX_SOCKET_PEEK_SIZE as usize == super::SOCKET_RECEIVE_OPERATION_SIZE);
-
-fn normalize_tcp_connect_address(address: SocketAddrV4) -> SocketAddrV4 {
-    if address.ip().is_unspecified() && address.port() != 0 {
-        SocketAddrV4::new(Ipv4Addr::LOCALHOST, address.port())
-    } else {
-        address
-    }
-}
 
 struct BrokerTcpSocketState {
     connection: SocketConnectionStatus,
@@ -192,7 +184,6 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
     }
 
     pub(super) fn start_connect(&self, address: SocketAddrV4) -> Result<(), ConnectError> {
-        let address = normalize_tcp_connect_address(address);
         let previous = self.state.lock().connection;
         let outcome = self
             .broker
@@ -1194,22 +1185,6 @@ impl From<BrokerSocketError> for SocketAsyncError {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn tcp_connect_normalizes_nonzero_unspecified_destination() {
-        assert_eq!(
-            normalize_tcp_connect_address(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 8080)),
-            SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8080)
-        );
-        assert_eq!(
-            normalize_tcp_connect_address(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0)),
-            SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0)
-        );
-        assert_eq!(
-            normalize_tcp_connect_address(SocketAddrV4::new(Ipv4Addr::new(10, 0, 2, 15), 8080)),
-            SocketAddrV4::new(Ipv4Addr::new(10, 0, 2, 15), 8080)
-        );
-    }
 
     #[test]
     fn restored_udp_error_precedes_prefetched_successor() {

--- a/litebox/src/net/broker_socket.rs
+++ b/litebox/src/net/broker_socket.rs
@@ -3,7 +3,7 @@
 
 use alloc::sync::{Arc, Weak};
 use core::{
-    net::{SocketAddr, SocketAddrV4},
+    net::{Ipv4Addr, SocketAddr, SocketAddrV4},
     sync::atomic::{AtomicBool, Ordering},
 };
 
@@ -32,6 +32,14 @@ use crate::{
 };
 
 const _: () = assert!(MAX_SOCKET_PEEK_SIZE as usize == super::SOCKET_RECEIVE_OPERATION_SIZE);
+
+fn normalize_tcp_connect_address(address: SocketAddrV4) -> SocketAddrV4 {
+    if address.ip().is_unspecified() && address.port() != 0 {
+        SocketAddrV4::new(Ipv4Addr::LOCALHOST, address.port())
+    } else {
+        address
+    }
+}
 
 struct BrokerTcpSocketState {
     connection: SocketConnectionStatus,
@@ -184,6 +192,7 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
     }
 
     pub(super) fn start_connect(&self, address: SocketAddrV4) -> Result<(), ConnectError> {
+        let address = normalize_tcp_connect_address(address);
         let previous = self.state.lock().connection;
         let outcome = self
             .broker
@@ -1185,6 +1194,22 @@ impl From<BrokerSocketError> for SocketAsyncError {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn tcp_connect_normalizes_nonzero_unspecified_destination() {
+        assert_eq!(
+            normalize_tcp_connect_address(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 8080)),
+            SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8080)
+        );
+        assert_eq!(
+            normalize_tcp_connect_address(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0)),
+            SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0)
+        );
+        assert_eq!(
+            normalize_tcp_connect_address(SocketAddrV4::new(Ipv4Addr::new(10, 0, 2, 15), 8080)),
+            SocketAddrV4::new(Ipv4Addr::new(10, 0, 2, 15), 8080)
+        );
+    }
 
     #[test]
     fn restored_udp_error_precedes_prefetched_successor() {

--- a/litebox_broker_core/src/socket.rs
+++ b/litebox_broker_core/src/socket.rs
@@ -167,6 +167,9 @@ impl GuestBindingReservation {
         }
     }
 
+    /// Retains a TCP source binding across queued and accepted connection lifetimes.
+    ///
+    /// UDP datagrams snapshot source metadata when sent and need no lease.
     fn guest_source_lease(&self, destination: SocketAddrV4) -> Option<GuestSourceLease> {
         if self.inner.transport != GuestTransport::Tcp {
             return None;

--- a/litebox_broker_core/src/socket.rs
+++ b/litebox_broker_core/src/socket.rs
@@ -368,15 +368,7 @@ pub struct AcceptedPlatformSocket {
     pub socket: Arc<dyn PlatformSocket>,
     /// Exact guest destination reached by the connector.
     pub local_address: SocketAddrV4,
-    /// Guest-visible peer endpoint of the accepted connection.
-    ///
-    /// For a guest-to-guest connection, this must be the connector's
-    /// guest-namespace endpoint; broker-internal native routing endpoints must
-    /// not be exposed.
-    pub remote_address: SocketAddrV4,
-    /// Retains the connecting peer's source binding.
-    ///
-    /// Its source endpoint must equal the accepted socket's `remote_address`.
+    /// Retains and identifies the connecting peer's guest-visible source.
     pub guest_source_lease: GuestSourceLease,
 }
 
@@ -932,46 +924,42 @@ pub fn accept(
         readiness_sink,
         Arc::clone(&quota),
     );
+    let accepted = match listener_resource.accept(readiness.clone()) {
+        Ok(SocketOutcome::Completed(accepted)) => accepted,
+        Ok(SocketOutcome::Failed(error)) => {
+            readiness.retire();
+            return Ok(SocketOutcome::Failed(error));
+        }
+        Err(error) => {
+            readiness.retire();
+            return Err(error);
+        }
+    };
+    let AcceptedPlatformSocket {
+        socket,
+        local_address,
+        guest_source_lease,
+    } = accepted;
+    if !listener_resource.port_binding_covers(local_address) {
+        socket.retire();
+        readiness.retire();
+        return Err(BrokerError::Internal);
+    }
+    let remote_address = guest_source_lease.source_address();
     let resource = Arc::new(SocketResource {
         platform_socket: Once::new(),
         readiness,
         _quota: quota,
         port_binding: Mutex::new(None),
-        guest_source_lease: Mutex::new(None),
+        guest_source_lease: Mutex::new(Some(guest_source_lease)),
     });
-    let accepted = match listener_resource.accept(resource.readiness.clone()) {
-        Ok(SocketOutcome::Completed(accepted)) => accepted,
-        Ok(SocketOutcome::Failed(error)) => {
-            resource.readiness.retire();
-            return Ok(SocketOutcome::Failed(error));
-        }
-        Err(error) => {
-            resource.readiness.retire();
-            return Err(error);
-        }
-    };
-    if !listener_resource.port_binding_covers(accepted.local_address)
-        || accepted.guest_source_lease.source_address() != accepted.remote_address
-    {
-        accepted.socket.retire();
-        resource.readiness.retire();
-        return Err(BrokerError::Internal);
-    }
-    if let Err(guest_source_lease) = resource.set_accepted_source_lease(accepted.guest_source_lease)
-    {
-        accepted.socket.retire();
-        resource.readiness.retire();
-        drop(guest_source_lease);
-        return Err(BrokerError::Internal);
-    }
-    resource.platform_socket.call_once(|| accepted.socket);
-    let accepted_socket =
-        SocketObject::new_connected(resource, create_request, accepted.local_address);
+    resource.platform_socket.call_once(|| socket);
+    let accepted_socket = SocketObject::new_connected(resource, create_request, local_address);
     let handle = reference.commit(ObjectEntry::Socket(accepted_socket))?;
     Ok(SocketOutcome::Completed(AcceptedBrokerSocket {
         handle,
-        local_address: accepted.local_address,
-        remote_address: accepted.remote_address,
+        local_address,
+        remote_address,
     }))
 }
 
@@ -1909,18 +1897,6 @@ impl SocketResource {
         Ok(())
     }
 
-    fn set_accepted_source_lease(
-        &self,
-        lease: GuestSourceLease,
-    ) -> core::result::Result<(), GuestSourceLease> {
-        let mut slot = self.guest_source_lease.lock();
-        if slot.is_some() {
-            return Err(lease);
-        }
-        *slot = Some(lease);
-        Ok(())
-    }
-
     fn port_binding_covers(&self, address: SocketAddrV4) -> bool {
         self.port_binding
             .lock()
@@ -2397,7 +2373,6 @@ pub(crate) mod tests {
         failed_readiness: StdMutex<Option<ReadinessRegistration>>,
         live_readiness: StdMutex<Option<ReadinessRegistration>>,
         queue_next_guest_connect: core::sync::atomic::AtomicBool,
-        accepted_remote_address: StdMutex<Option<SocketAddrV4>>,
         pending_accept: StdMutex<Option<PendingAcceptedConnection>>,
     }
 
@@ -2441,8 +2416,7 @@ pub(crate) mod tests {
             self.state.retain_next_socket.store(true, Ordering::Relaxed);
         }
 
-        fn queue_next_guest_connect(&self, remote_address: Option<SocketAddrV4>) {
-            *self.state.accepted_remote_address.lock().unwrap() = remote_address;
+        fn queue_next_guest_connect(&self) {
             self.state
                 .queue_next_guest_connect
                 .store(true, Ordering::Relaxed);
@@ -2557,13 +2531,6 @@ pub(crate) mod tests {
             let Some(pending) = self.state.pending_accept.lock().unwrap().take() else {
                 return Err(BrokerError::WouldBlock);
             };
-            let remote_address = self
-                .state
-                .accepted_remote_address
-                .lock()
-                .unwrap()
-                .take()
-                .unwrap_or_else(|| pending.guest_source_lease.source_address());
             let socket = Arc::new(TestPlatformSocket {
                 state: Arc::clone(&self.state),
                 readiness,
@@ -2575,7 +2542,6 @@ pub(crate) mod tests {
             Ok(SocketOutcome::Completed(AcceptedPlatformSocket {
                 socket,
                 local_address: pending.destination,
-                remote_address,
                 guest_source_lease: pending.guest_source_lease,
             }))
         }
@@ -2780,7 +2746,7 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn accepted_guest_source_lease_is_validated_and_retained() {
+    fn accepted_guest_source_lease_is_retained() {
         let provider = Arc::new(TestSocketProvider::default());
         let broker = test_broker(Arc::clone(&provider) as Arc<dyn SocketProvider>);
         let listener_session = broker
@@ -2805,44 +2771,6 @@ pub(crate) mod tests {
             Ok(SocketOutcome::Completed(listener_address))
         );
 
-        let mismatched_source = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 44001);
-        let connector = create(
-            &connector_session,
-            create_request(),
-            Arc::new(TestReadinessSink::default()),
-        )
-        .unwrap();
-        assert_eq!(
-            bind(&connector_session, connector, mismatched_source),
-            Ok(SocketOutcome::Completed(mismatched_source))
-        );
-        provider.queue_next_guest_connect(Some(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 44999)));
-        assert_eq!(
-            connect(&connector_session, connector, listener_address),
-            Ok(SocketOutcome::Completed(SocketConnectionStatus::Connecting))
-        );
-        connector_session.close_object_reference(connector).unwrap();
-        assert!(matches!(
-            broker
-                .socket_ports
-                .reserve(create_request(), mismatched_source),
-            Ok(SocketOutcome::Failed(SocketError::AddressInUse))
-        ));
-        assert!(matches!(
-            accept(
-                &listener_session,
-                listener,
-                Arc::new(TestReadinessSink::default())
-            ),
-            Err(BrokerError::Internal)
-        ));
-        assert!(matches!(
-            broker
-                .socket_ports
-                .reserve(create_request(), mismatched_source),
-            Ok(SocketOutcome::Completed(_))
-        ));
-
         let wildcard_source = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 44002);
         let concrete_source = SocketAddrV4::new(Ipv4Addr::LOCALHOST, wildcard_source.port());
         let connector = create(
@@ -2855,7 +2783,7 @@ pub(crate) mod tests {
             bind(&connector_session, connector, wildcard_source),
             Ok(SocketOutcome::Completed(wildcard_source))
         );
-        provider.queue_next_guest_connect(None);
+        provider.queue_next_guest_connect();
         assert_eq!(
             connect(&connector_session, connector, listener_address),
             Ok(SocketOutcome::Completed(SocketConnectionStatus::Connecting))

--- a/litebox_broker_core/src/socket.rs
+++ b/litebox_broker_core/src/socket.rs
@@ -169,7 +169,7 @@ impl GuestPortBinding {
     /// Retains a TCP source binding across queued and accepted connection lifetimes.
     ///
     /// UDP datagrams snapshot source metadata when sent and need no lease.
-    fn guest_source_lease(self: &Arc<Self>, destination: SocketAddrV4) -> Option<GuestSourceLease> {
+    fn source_lease_for(self: &Arc<Self>, destination: SocketAddrV4) -> Option<GuestSourceLease> {
         if self.transport != GuestTransport::Tcp {
             return None;
         }
@@ -374,9 +374,9 @@ pub struct AcceptedPlatformSocket {
     /// guest-namespace endpoint; broker-internal native routing endpoints must
     /// not be exposed.
     pub remote_address: SocketAddrV4,
-    /// Guest TCP source lease returned with a guest-local accepted connection.
+    /// Retains the connecting peer's source binding.
     ///
-    /// Its exact source endpoint must equal `remote_address`.
+    /// Its source endpoint must equal the accepted socket's `remote_address`.
     pub guest_source_lease: GuestSourceLease,
 }
 
@@ -732,7 +732,7 @@ pub fn connect(
             }
         }
     }
-    let guest_source_lease = match resource.guest_source_lease(address) {
+    let guest_source_lease = match resource.source_lease_for_connect(address) {
         Ok(lease) => lease,
         Err(error) => {
             finish_retired_connect(&object);
@@ -957,7 +957,8 @@ pub fn accept(
         resource.readiness.retire();
         return Err(BrokerError::Internal);
     }
-    if let Err(guest_source_lease) = resource.set_guest_source_lease(accepted.guest_source_lease) {
+    if let Err(guest_source_lease) = resource.set_accepted_source_lease(accepted.guest_source_lease)
+    {
         accepted.socket.retire();
         resource.readiness.retire();
         drop(guest_source_lease);
@@ -1908,7 +1909,7 @@ impl SocketResource {
         Ok(())
     }
 
-    fn set_guest_source_lease(
+    fn set_accepted_source_lease(
         &self,
         lease: GuestSourceLease,
     ) -> core::result::Result<(), GuestSourceLease> {
@@ -1949,7 +1950,10 @@ impl SocketResource {
         self.platform_socket().connect(address, guest_source_lease)
     }
 
-    fn guest_source_lease(&self, destination: SocketAddrV4) -> Result<Option<GuestSourceLease>> {
+    fn source_lease_for_connect(
+        &self,
+        destination: SocketAddrV4,
+    ) -> Result<Option<GuestSourceLease>> {
         if destination.port() == 0 {
             return Ok(None);
         }
@@ -1964,7 +1968,7 @@ impl SocketResource {
         self.port_binding
             .lock()
             .as_ref()
-            .and_then(|binding| binding.guest_source_lease(destination))
+            .and_then(|binding| binding.source_lease_for(destination))
             .map(Some)
             .ok_or(BrokerError::Internal)
     }
@@ -2293,7 +2297,7 @@ pub(crate) mod tests {
         else {
             panic!("wildcard port binding failed");
         };
-        let lease = port_binding.guest_source_lease(loopback).unwrap();
+        let lease = port_binding.source_lease_for(loopback).unwrap();
         assert_eq!(lease.source_address(), loopback);
         drop(port_binding);
         assert!(matches!(
@@ -2313,7 +2317,7 @@ pub(crate) mod tests {
         else {
             panic!("exact port binding failed");
         };
-        let lease = port_binding.guest_source_lease(loopback_address()).unwrap();
+        let lease = port_binding.source_lease_for(loopback_address()).unwrap();
         assert_eq!(lease.source_address(), exact);
         drop(port_binding);
         assert!(matches!(
@@ -2342,8 +2346,8 @@ pub(crate) mod tests {
         else {
             panic!("wildcard port binding failed");
         };
-        let loopback_lease = port_binding.guest_source_lease(loopback).unwrap();
-        let private_lease = port_binding.guest_source_lease(private).unwrap();
+        let loopback_lease = port_binding.source_lease_for(loopback).unwrap();
+        let private_lease = port_binding.source_lease_for(private).unwrap();
         assert_eq!(loopback_lease.source_address(), loopback);
         assert_eq!(private_lease.source_address(), private);
 

--- a/litebox_broker_core/src/socket.rs
+++ b/litebox_broker_core/src/socket.rs
@@ -135,33 +135,32 @@ enum GuestBindingKey {
     Exact(SocketAddrV4),
 }
 
-struct GuestBindingReservation {
-    inner: Arc<GuestBindingReservationInner>,
-}
-
-struct GuestBindingReservationInner {
+/// Shared registration for one guest transport port.
+///
+/// The final owner removes the binding from the broker-wide namespace.
+struct GuestPortBinding {
     ports: BrokerSocketPorts,
     transport: GuestTransport,
     key: GuestBindingKey,
 }
 
-impl GuestBindingReservation {
+impl GuestPortBinding {
     fn is_wildcard(&self) -> bool {
-        matches!(self.inner.key, GuestBindingKey::Wildcard(_))
+        matches!(self.key, GuestBindingKey::Wildcard(_))
     }
 
     fn covers(&self, address: SocketAddrV4) -> bool {
         if address.port() == 0 || !is_guest_network_address(*address.ip()) {
             return false;
         }
-        match self.inner.key {
+        match self.key {
             GuestBindingKey::Wildcard(port) => address.port() == port,
             GuestBindingKey::Exact(reserved) => reserved == address,
         }
     }
 
     fn requested_address(&self) -> SocketAddrV4 {
-        match self.inner.key {
+        match self.key {
             GuestBindingKey::Wildcard(port) => SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, port),
             GuestBindingKey::Exact(address) => address,
         }
@@ -170,13 +169,13 @@ impl GuestBindingReservation {
     /// Retains a TCP source binding across queued and accepted connection lifetimes.
     ///
     /// UDP datagrams snapshot source metadata when sent and need no lease.
-    fn guest_source_lease(&self, destination: SocketAddrV4) -> Option<GuestSourceLease> {
-        if self.inner.transport != GuestTransport::Tcp {
+    fn guest_source_lease(self: &Arc<Self>, destination: SocketAddrV4) -> Option<GuestSourceLease> {
+        if self.transport != GuestTransport::Tcp {
             return None;
         }
         let source_address = GuestSocketBinding::new(self).guest_source_address(destination)?;
         Some(GuestSourceLease {
-            _reservation: Arc::clone(&self.inner),
+            _binding: Arc::clone(self),
             source_address,
         })
     }
@@ -198,7 +197,7 @@ impl BrokerSocketPorts {
         &self,
         request: CreateSocketRequest,
         requested_address: SocketAddrV4,
-    ) -> Result<SocketOutcome<(SocketAddrV4, GuestBindingReservation)>> {
+    ) -> Result<SocketOutcome<(SocketAddrV4, Arc<GuestPortBinding>)>> {
         if !guest_binding_address_is_valid(requested_address) {
             return Ok(SocketOutcome::Failed(SocketError::AddressNotAvailable));
         }
@@ -227,13 +226,11 @@ impl BrokerSocketPorts {
         drop(state);
         Ok(SocketOutcome::Completed((
             local_address,
-            GuestBindingReservation {
-                inner: Arc::new(GuestBindingReservationInner {
-                    ports: self.clone(),
-                    transport,
-                    key,
-                }),
-            },
+            Arc::new(GuestPortBinding {
+                ports: self.clone(),
+                transport,
+                key,
+            }),
         )))
     }
 }
@@ -242,7 +239,7 @@ fn guest_binding_address_is_valid(address: SocketAddrV4) -> bool {
     address.ip().is_unspecified() || is_guest_network_address(*address.ip())
 }
 
-impl Drop for GuestBindingReservationInner {
+impl Drop for GuestPortBinding {
     fn drop(&mut self) {
         let mut state = self.ports.state.lock();
         let ports = match self.transport {
@@ -250,7 +247,7 @@ impl Drop for GuestBindingReservationInner {
             GuestTransport::Udp => &mut state.guest_udp,
         };
         let removed = ports.remove(self.key);
-        debug_assert!(removed, "live guest binding reservation must be registered");
+        debug_assert!(removed, "live guest port binding must be registered");
     }
 }
 
@@ -262,10 +259,10 @@ pub struct GuestSocketBinding {
 }
 
 impl GuestSocketBinding {
-    fn new(reservation: &GuestBindingReservation) -> Self {
+    fn new(binding: &GuestPortBinding) -> Self {
         Self {
-            requested: reservation.requested_address(),
-            transport: reservation.inner.transport,
+            requested: binding.requested_address(),
+            transport: binding.transport,
         }
     }
 
@@ -350,10 +347,10 @@ impl Eq for GuestSocketBinding {}
 /// Core creates this value from a live guest binding when a TCP connection
 /// targets the guest namespace. It grants no bind or listen authority. A
 /// platform may move the lease through a queued guest-local connection and
-/// return it from [`PlatformSocket::accept`]; dropping the final lease or
-/// binding reservation releases the original namespace reservation.
+/// return it from [`PlatformSocket::accept`]. Dropping the final binding
+/// reference releases the namespace entry.
 pub struct GuestSourceLease {
-    _reservation: Arc<GuestBindingReservationInner>,
+    _binding: Arc<GuestPortBinding>,
     source_address: SocketAddrV4,
 }
 
@@ -624,7 +621,7 @@ pub fn create(
         platform_socket: Once::new(),
         readiness,
         _quota: quota,
-        port_reservation: Mutex::new(None),
+        port_binding: Mutex::new(None),
         guest_source_lease: Mutex::new(None),
     });
     let platform_socket = match session.core.socket_provider.create(
@@ -721,8 +718,8 @@ pub fn connect(
                 }
             };
         match binding {
-            ReserveAndBindOutcome::Completed(local_address, reservation) => {
-                attach_binding(&object, local_address, reservation)?;
+            ReserveAndBindOutcome::Completed(local_address, port_binding) => {
+                attach_binding(&object, local_address, port_binding)?;
             }
             ReserveAndBindOutcome::Failed(error) => {
                 finish_connect(&object, SocketConnectionStatus::Unconnected);
@@ -796,8 +793,8 @@ pub fn bind(
         return Err(BrokerError::Internal);
     }
     match reserve_and_bind(session, create_request, &resource, address) {
-        Ok(ReserveAndBindOutcome::Completed(local_address, reservation)) => {
-            finish_configuration(&object, Some(local_address), Some(reservation), false)?;
+        Ok(ReserveAndBindOutcome::Completed(local_address, port_binding)) => {
+            finish_configuration(&object, Some(local_address), Some(port_binding), false)?;
             Ok(SocketOutcome::Completed(local_address))
         }
         Ok(ReserveAndBindOutcome::Failed(error)) => {
@@ -852,7 +849,7 @@ pub fn listen(
     };
 
     let mut local_address = existing_local_address;
-    let mut port_reservation = None;
+    let mut port_binding = None;
     if local_address.is_none() {
         let binding = match reserve_and_bind(
             session,
@@ -867,9 +864,9 @@ pub fn listen(
             }
         };
         match binding {
-            ReserveAndBindOutcome::Completed(address, reservation) => {
+            ReserveAndBindOutcome::Completed(address, binding) => {
                 local_address = Some(address);
-                port_reservation = Some(reservation);
+                port_binding = Some(binding);
             }
             ReserveAndBindOutcome::Failed(error) => {
                 finish_configuration(&object, None, None, false)?;
@@ -886,19 +883,19 @@ pub fn listen(
     match resource.listen(backlog) {
         Ok(SocketOutcome::Completed(address)) => {
             if local_address != Some(address) {
-                finish_retired_configuration(&object, local_address, port_reservation)?;
+                finish_retired_configuration(&object, local_address, port_binding)?;
                 resource.retire();
                 return Err(BrokerError::Internal);
             }
-            finish_configuration(&object, local_address, port_reservation, true)?;
+            finish_configuration(&object, local_address, port_binding, true)?;
             Ok(SocketOutcome::Completed(address))
         }
         Ok(SocketOutcome::Failed(error)) => {
-            finish_configuration(&object, local_address, port_reservation, false)?;
+            finish_configuration(&object, local_address, port_binding, false)?;
             Ok(SocketOutcome::Failed(error))
         }
         Err(error) => {
-            finish_configuration(&object, local_address, port_reservation, false)?;
+            finish_configuration(&object, local_address, port_binding, false)?;
             Err(error)
         }
     }
@@ -939,7 +936,7 @@ pub fn accept(
         platform_socket: Once::new(),
         readiness,
         _quota: quota,
-        port_reservation: Mutex::new(None),
+        port_binding: Mutex::new(None),
         guest_source_lease: Mutex::new(None),
     });
     let accepted = match listener_resource.accept(resource.readiness.clone()) {
@@ -953,7 +950,7 @@ pub fn accept(
             return Err(error);
         }
     };
-    if !listener_resource.port_reservation_covers(accepted.local_address)
+    if !listener_resource.port_binding_covers(accepted.local_address)
         || accepted.guest_source_lease.source_address() != accepted.remote_address
     {
         accepted.socket.retire();
@@ -1072,8 +1069,8 @@ pub fn send_to(
             &resource,
             DEFAULT_UDP_LOCAL_ADDRESS,
         ) {
-            Ok(ReserveAndBindOutcome::Completed(local_address, reservation)) => {
-                finish_configuration(&object, Some(local_address), Some(reservation), false)?;
+            Ok(ReserveAndBindOutcome::Completed(local_address, port_binding)) => {
+                finish_configuration(&object, Some(local_address), Some(port_binding), false)?;
             }
             Ok(ReserveAndBindOutcome::Failed(error)) => {
                 finish_configuration(&object, None, None, false)?;
@@ -1399,7 +1396,7 @@ fn datagram_status(object: &spin::RwLock<ObjectEntry>) -> Result<SocketStatusRes
             socket.configuration_in_flight,
             socket.datagram_connect_generation,
             socket.resource_retired,
-            socket.resource.port_reservation_is_wildcard(),
+            socket.resource.port_binding_is_wildcard(),
         )
     };
     if configuration_in_flight || resource_retired {
@@ -1545,7 +1542,7 @@ fn socket_state(
 }
 
 enum ReserveAndBindOutcome {
-    Completed(SocketAddrV4, GuestBindingReservation),
+    Completed(SocketAddrV4, Arc<GuestPortBinding>),
     Failed(SocketError),
     Retired,
 }
@@ -1556,7 +1553,7 @@ fn reserve_and_bind(
     resource: &SocketResource,
     requested_address: SocketAddrV4,
 ) -> Result<ReserveAndBindOutcome> {
-    let (local_address, reservation) = match session
+    let (local_address, port_binding) = match session
         .core
         .socket_ports
         .reserve(create_request, requested_address)?
@@ -1564,11 +1561,11 @@ fn reserve_and_bind(
         SocketOutcome::Completed(binding) => binding,
         SocketOutcome::Failed(error) => return Ok(ReserveAndBindOutcome::Failed(error)),
     };
-    let binding = GuestSocketBinding::new(&reservation);
+    let binding = GuestSocketBinding::new(&port_binding);
     match resource.bind(binding)? {
-        SocketOutcome::Completed(bound_address) if bound_address == local_address => {
-            Ok(ReserveAndBindOutcome::Completed(local_address, reservation))
-        }
+        SocketOutcome::Completed(bound_address) if bound_address == local_address => Ok(
+            ReserveAndBindOutcome::Completed(local_address, port_binding),
+        ),
         SocketOutcome::Completed(_) => Ok(ReserveAndBindOutcome::Retired),
         SocketOutcome::Failed(error) => Ok(ReserveAndBindOutcome::Failed(error)),
     }
@@ -1612,8 +1609,8 @@ fn connect_datagram(
             }
         };
         match binding {
-            ReserveAndBindOutcome::Completed(local_address, reservation) => {
-                attach_datagram_binding(object, local_address, reservation)?;
+            ReserveAndBindOutcome::Completed(local_address, port_binding) => {
+                attach_datagram_binding(object, local_address, port_binding)?;
             }
             ReserveAndBindOutcome::Failed(error) => {
                 finish_datagram_connect(object, previous_status, false);
@@ -1655,7 +1652,7 @@ fn connect_datagram(
 fn attach_datagram_binding(
     object: &spin::RwLock<ObjectEntry>,
     local_address: SocketAddrV4,
-    port_reservation: GuestBindingReservation,
+    port_binding: Arc<GuestPortBinding>,
 ) -> Result<()> {
     let duplicate = {
         let mut object = object.write();
@@ -1663,21 +1660,21 @@ fn attach_datagram_binding(
             return Err(BrokerError::Internal);
         };
         if socket.local_address.is_some() {
-            Some((Arc::clone(&socket.resource), port_reservation))
+            Some((Arc::clone(&socket.resource), port_binding))
         } else {
-            match socket.resource.set_port_reservation(port_reservation) {
+            match socket.resource.set_port_binding(port_binding) {
                 Ok(()) => {
                     socket.local_address = Some(local_address);
                     None
                 }
-                Err(port_reservation) => Some((Arc::clone(&socket.resource), port_reservation)),
+                Err(port_binding) => Some((Arc::clone(&socket.resource), port_binding)),
             }
         }
     };
-    if let Some((resource, port_reservation)) = duplicate {
+    if let Some((resource, port_binding)) = duplicate {
         finish_retired_datagram_connect(object);
         resource.retire();
-        drop(port_reservation);
+        drop(port_binding);
         return Err(BrokerError::Internal);
     }
     Ok(())
@@ -1732,29 +1729,29 @@ fn finish_retired_connect(object: &spin::RwLock<ObjectEntry>) {
 fn attach_binding(
     object: &spin::RwLock<ObjectEntry>,
     local_address: SocketAddrV4,
-    port_reservation: GuestBindingReservation,
+    port_binding: Arc<GuestPortBinding>,
 ) -> Result<()> {
     let duplicate = {
         let mut object = object.write();
         let ObjectEntry::Socket(socket) = &mut *object else {
             return Err(BrokerError::Internal);
         };
-        match socket.resource.set_port_reservation(port_reservation) {
+        match socket.resource.set_port_binding(port_binding) {
             Ok(()) => {
                 socket.local_address = Some(local_address);
                 None
             }
-            Err(port_reservation) => {
+            Err(port_binding) => {
                 socket.connect_in_flight = false;
                 socket.connection_status = SocketConnectionStatus::Failed(SocketError::Other);
                 socket.resource_retired = true;
-                Some((Arc::clone(&socket.resource), port_reservation))
+                Some((Arc::clone(&socket.resource), port_binding))
             }
         }
     };
-    if let Some((resource, port_reservation)) = duplicate {
+    if let Some((resource, port_binding)) = duplicate {
         resource.retire();
-        drop(port_reservation);
+        drop(port_binding);
         return Err(BrokerError::Internal);
     }
     Ok(())
@@ -1763,7 +1760,7 @@ fn attach_binding(
 fn finish_configuration(
     object: &spin::RwLock<ObjectEntry>,
     local_address: Option<SocketAddrV4>,
-    port_reservation: Option<GuestBindingReservation>,
+    port_binding: Option<Arc<GuestPortBinding>>,
     listening: bool,
 ) -> Result<()> {
     let duplicate = {
@@ -1772,12 +1769,12 @@ fn finish_configuration(
             return Err(BrokerError::Internal);
         };
         socket.configuration_in_flight = false;
-        let duplicate = port_reservation.and_then(|port_reservation| {
+        let duplicate = port_binding.and_then(|port_binding| {
             socket
                 .resource
-                .set_port_reservation(port_reservation)
+                .set_port_binding(port_binding)
                 .err()
-                .map(|port_reservation| (Arc::clone(&socket.resource), port_reservation))
+                .map(|port_binding| (Arc::clone(&socket.resource), port_binding))
         });
         if duplicate.is_some() {
             socket.listening = false;
@@ -1793,9 +1790,9 @@ fn finish_configuration(
         }
         duplicate
     };
-    if let Some((resource, port_reservation)) = duplicate {
+    if let Some((resource, port_binding)) = duplicate {
         resource.retire();
-        drop(port_reservation);
+        drop(port_binding);
         return Err(BrokerError::Internal);
     }
     Ok(())
@@ -1804,7 +1801,7 @@ fn finish_configuration(
 fn finish_retired_configuration(
     object: &spin::RwLock<ObjectEntry>,
     local_address: Option<SocketAddrV4>,
-    port_reservation: Option<GuestBindingReservation>,
+    port_binding: Option<Arc<GuestPortBinding>>,
 ) -> Result<()> {
     let duplicate = {
         let mut object = object.write();
@@ -1812,12 +1809,12 @@ fn finish_retired_configuration(
             return Err(BrokerError::Internal);
         };
         socket.configuration_in_flight = false;
-        let duplicate = port_reservation.and_then(|port_reservation| {
+        let duplicate = port_binding.and_then(|port_binding| {
             socket
                 .resource
-                .set_port_reservation(port_reservation)
+                .set_port_binding(port_binding)
                 .err()
-                .map(|port_reservation| (Arc::clone(&socket.resource), port_reservation))
+                .map(|port_binding| (Arc::clone(&socket.resource), port_binding))
         });
         socket.local_address = socket.local_address.or(local_address);
         socket.listening = false;
@@ -1828,9 +1825,9 @@ fn finish_retired_configuration(
         socket.resource_retired = true;
         duplicate
     };
-    if let Some((resource, port_reservation)) = duplicate {
+    if let Some((resource, port_binding)) = duplicate {
         resource.retire();
-        drop(port_reservation);
+        drop(port_binding);
         return Err(BrokerError::Internal);
     }
     Ok(())
@@ -1894,20 +1891,20 @@ pub(crate) struct SocketResource {
     platform_socket: Once<Arc<dyn PlatformSocket>>,
     readiness: ReadinessRegistration,
     _quota: Arc<SocketQuotaReservation>,
-    port_reservation: Mutex<Option<GuestBindingReservation>>,
+    port_binding: Mutex<Option<Arc<GuestPortBinding>>>,
     guest_source_lease: Mutex<Option<GuestSourceLease>>,
 }
 
 impl SocketResource {
-    fn set_port_reservation(
+    fn set_port_binding(
         &self,
-        reservation: GuestBindingReservation,
-    ) -> core::result::Result<(), GuestBindingReservation> {
-        let mut slot = self.port_reservation.lock();
+        binding: Arc<GuestPortBinding>,
+    ) -> core::result::Result<(), Arc<GuestPortBinding>> {
+        let mut slot = self.port_binding.lock();
         if slot.is_some() {
-            return Err(reservation);
+            return Err(binding);
         }
-        *slot = Some(reservation);
+        *slot = Some(binding);
         Ok(())
     }
 
@@ -1923,18 +1920,18 @@ impl SocketResource {
         Ok(())
     }
 
-    fn port_reservation_covers(&self, address: SocketAddrV4) -> bool {
-        self.port_reservation
+    fn port_binding_covers(&self, address: SocketAddrV4) -> bool {
+        self.port_binding
             .lock()
             .as_ref()
-            .is_some_and(|reservation| reservation.covers(address))
+            .is_some_and(|binding| binding.covers(address))
     }
 
-    fn port_reservation_is_wildcard(&self) -> bool {
-        self.port_reservation
+    fn port_binding_is_wildcard(&self) -> bool {
+        self.port_binding
             .lock()
             .as_ref()
-            .is_some_and(GuestBindingReservation::is_wildcard)
+            .is_some_and(|binding| binding.is_wildcard())
     }
 
     fn platform_socket(&self) -> &dyn PlatformSocket {
@@ -1964,10 +1961,10 @@ impl SocketResource {
         if !is_guest_network_address(*destination.ip()) {
             return Ok(None);
         }
-        self.port_reservation
+        self.port_binding
             .lock()
             .as_ref()
-            .and_then(|reservation| reservation.guest_source_lease(destination))
+            .and_then(|binding| binding.guest_source_lease(destination))
             .map(Some)
             .ok_or(BrokerError::Internal)
     }
@@ -1982,9 +1979,9 @@ impl SocketResource {
 
     fn retire(&self) {
         self.platform_socket().retire();
-        let port_reservation = self.port_reservation.lock().take();
+        let port_binding = self.port_binding.lock().take();
         let guest_source_lease = self.guest_source_lease.lock().take();
-        drop(port_reservation);
+        drop(port_binding);
         drop(guest_source_lease);
     }
 
@@ -2077,9 +2074,9 @@ impl Drop for SocketResource {
         if let Some(platform_socket) = self.platform_socket.get() {
             platform_socket.retire();
         }
-        let port_reservation = self.port_reservation.lock().take();
+        let port_binding = self.port_binding.lock().take();
         let guest_source_lease = self.guest_source_lease.lock().take();
-        drop(port_reservation);
+        drop(port_binding);
         drop(guest_source_lease);
         self.readiness.retire();
     }
@@ -2147,26 +2144,26 @@ pub(crate) mod tests {
         let ports = BrokerSocketPorts::default();
         let address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 80);
 
-        let SocketOutcome::Completed((_, first_reservation)) =
+        let SocketOutcome::Completed((_, first_binding)) =
             ports.reserve(create_request(), address).unwrap()
         else {
-            panic!("first TCP reservation failed");
+            panic!("first TCP port binding failed");
         };
         assert!(matches!(
             ports.reserve(create_request(), address),
             Ok(SocketOutcome::Failed(SocketError::AddressInUse))
         ));
-        let SocketOutcome::Completed((_, udp_reservation)) =
+        let SocketOutcome::Completed((_, udp_binding)) =
             ports.reserve(create_udp_request(), address).unwrap()
         else {
-            panic!("UDP reservation must be independent from TCP");
+            panic!("UDP port binding must be independent from TCP");
         };
         assert!(matches!(
             ports.reserve(create_udp_request(), address),
             Ok(SocketOutcome::Failed(SocketError::AddressInUse))
         ));
 
-        drop(first_reservation);
+        drop(first_binding);
         assert!(matches!(
             ports.reserve(create_request(), address),
             Ok(SocketOutcome::Completed(_))
@@ -2175,7 +2172,7 @@ pub(crate) mod tests {
             ports.reserve(create_udp_request(), address),
             Ok(SocketOutcome::Failed(SocketError::AddressInUse))
         ));
-        drop(udp_reservation);
+        drop(udp_binding);
         assert!(matches!(
             ports.reserve(create_udp_request(), address),
             Ok(SocketOutcome::Completed(_))
@@ -2190,33 +2187,33 @@ pub(crate) mod tests {
         let private = SocketAddrV4::new(GUEST_IPV4_ADDRESS, 8080);
         let wildcard = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 8080);
 
-        let SocketOutcome::Completed((_, first_lease)) =
+        let SocketOutcome::Completed((_, first_binding)) =
             ports.reserve(create_request(), first).unwrap()
         else {
-            panic!("first exact reservation failed");
+            panic!("first exact port binding failed");
         };
-        let SocketOutcome::Completed((_, second_lease)) =
+        let SocketOutcome::Completed((_, second_binding)) =
             ports.reserve(create_request(), second).unwrap()
         else {
-            panic!("second exact reservation failed");
+            panic!("second exact port binding failed");
         };
-        let SocketOutcome::Completed((_, private_lease)) =
+        let SocketOutcome::Completed((_, private_binding)) =
             ports.reserve(create_request(), private).unwrap()
         else {
-            panic!("private exact reservation failed");
+            panic!("private exact port binding failed");
         };
         assert!(matches!(
             ports.reserve(create_request(), wildcard),
             Ok(SocketOutcome::Failed(SocketError::AddressInUse))
         ));
 
-        drop(first_lease);
-        drop(second_lease);
-        drop(private_lease);
-        let SocketOutcome::Completed((_, wildcard_lease)) =
+        drop(first_binding);
+        drop(second_binding);
+        drop(private_binding);
+        let SocketOutcome::Completed((_, wildcard_binding)) =
             ports.reserve(create_request(), wildcard).unwrap()
         else {
-            panic!("wildcard reservation failed");
+            panic!("wildcard port binding failed");
         };
         assert!(matches!(
             ports.reserve(create_request(), first),
@@ -2226,10 +2223,10 @@ pub(crate) mod tests {
             ports.reserve(create_request(), private),
             Ok(SocketOutcome::Failed(SocketError::AddressInUse))
         ));
-        assert!(wildcard_lease.covers(first));
-        assert!(wildcard_lease.covers(second));
-        assert!(wildcard_lease.covers(private));
-        let binding = GuestSocketBinding::new(&wildcard_lease);
+        assert!(wildcard_binding.covers(first));
+        assert!(wildcard_binding.covers(second));
+        assert!(wildcard_binding.covers(private));
+        let binding = GuestSocketBinding::new(&wildcard_binding);
         assert_eq!(
             binding.guest_source_address(first),
             Some(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8080))
@@ -2247,36 +2244,36 @@ pub(crate) mod tests {
         ));
 
         let occupied = SocketAddrV4::new(Ipv4Addr::LOCALHOST, FIRST_EPHEMERAL_PORT);
-        let SocketOutcome::Completed((_, occupied_lease)) =
+        let SocketOutcome::Completed((_, occupied_binding)) =
             ports.reserve(create_request(), occupied).unwrap()
         else {
-            panic!("exact reservation failed");
+            panic!("exact port binding failed");
         };
-        let SocketOutcome::Completed((wildcard, wildcard_lease)) = ports
+        let SocketOutcome::Completed((wildcard, wildcard_binding)) = ports
             .reserve(
                 create_request(),
                 SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0),
             )
             .unwrap()
         else {
-            panic!("wildcard ephemeral reservation failed");
+            panic!("wildcard ephemeral port binding failed");
         };
         assert_eq!(wildcard.port(), FIRST_EPHEMERAL_PORT + 1);
-        drop(occupied_lease);
-        drop(wildcard_lease);
+        drop(occupied_binding);
+        drop(wildcard_binding);
     }
 
     #[test]
-    fn provider_binding_metadata_does_not_own_the_reservation() {
+    fn provider_binding_metadata_does_not_own_the_port_binding() {
         let ports = BrokerSocketPorts::default();
         let address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8080);
-        let SocketOutcome::Completed((_, reservation)) =
+        let SocketOutcome::Completed((_, port_binding)) =
             ports.reserve(create_request(), address).unwrap()
         else {
-            panic!("reservation failed");
+            panic!("port binding failed");
         };
-        let binding = GuestSocketBinding::new(&reservation);
-        drop(reservation);
+        let binding = GuestSocketBinding::new(&port_binding);
+        drop(port_binding);
         assert!(binding.is_valid());
         assert!(binding.covers(address));
         assert!(matches!(
@@ -2291,14 +2288,14 @@ pub(crate) mod tests {
         let wildcard = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 8081);
         let loopback = SocketAddrV4::new(Ipv4Addr::LOCALHOST, wildcard.port());
         let private = SocketAddrV4::new(GUEST_IPV4_ADDRESS, wildcard.port());
-        let SocketOutcome::Completed((_, reservation)) =
+        let SocketOutcome::Completed((_, port_binding)) =
             ports.reserve(create_request(), wildcard).unwrap()
         else {
-            panic!("wildcard reservation failed");
+            panic!("wildcard port binding failed");
         };
-        let lease = reservation.guest_source_lease(loopback).unwrap();
+        let lease = port_binding.guest_source_lease(loopback).unwrap();
         assert_eq!(lease.source_address(), loopback);
-        drop(reservation);
+        drop(port_binding);
         assert!(matches!(
             ports.reserve(create_request(), private),
             Ok(SocketOutcome::Failed(SocketError::AddressInUse))
@@ -2311,14 +2308,14 @@ pub(crate) mod tests {
 
         let exact = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8082);
         let other_exact = SocketAddrV4::new(GUEST_IPV4_ADDRESS, exact.port());
-        let SocketOutcome::Completed((_, reservation)) =
+        let SocketOutcome::Completed((_, port_binding)) =
             ports.reserve(create_request(), exact).unwrap()
         else {
-            panic!("exact reservation failed");
+            panic!("exact port binding failed");
         };
-        let lease = reservation.guest_source_lease(loopback_address()).unwrap();
+        let lease = port_binding.guest_source_lease(loopback_address()).unwrap();
         assert_eq!(lease.source_address(), exact);
-        drop(reservation);
+        drop(port_binding);
         assert!(matches!(
             ports.reserve(create_request(), exact),
             Ok(SocketOutcome::Failed(SocketError::AddressInUse))
@@ -2340,17 +2337,17 @@ pub(crate) mod tests {
         let wildcard = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 8083);
         let loopback = SocketAddrV4::new(Ipv4Addr::LOCALHOST, wildcard.port());
         let private = SocketAddrV4::new(GUEST_IPV4_ADDRESS, wildcard.port());
-        let SocketOutcome::Completed((_, reservation)) =
+        let SocketOutcome::Completed((_, port_binding)) =
             ports.reserve(create_request(), wildcard).unwrap()
         else {
-            panic!("wildcard reservation failed");
+            panic!("wildcard port binding failed");
         };
-        let loopback_lease = reservation.guest_source_lease(loopback).unwrap();
-        let private_lease = reservation.guest_source_lease(private).unwrap();
+        let loopback_lease = port_binding.guest_source_lease(loopback).unwrap();
+        let private_lease = port_binding.guest_source_lease(private).unwrap();
         assert_eq!(loopback_lease.source_address(), loopback);
         assert_eq!(private_lease.source_address(), private);
 
-        drop(reservation);
+        drop(port_binding);
         drop(loopback_lease);
         assert!(matches!(
             ports.reserve(create_request(), private),
@@ -2940,7 +2937,7 @@ pub(crate) mod tests {
         check_platform_socket_retires_before_last_arc_drop(broker, provider);
         check_socket_quotas(broker);
         check_invalid_bind_response_retires_socket(broker, provider);
-        check_duplicate_port_reservation_retires_socket(broker, provider);
+        check_duplicate_port_binding_retires_socket(broker, provider);
     }
 
     fn check_platform_socket_retires_before_last_arc_drop(
@@ -3100,7 +3097,7 @@ pub(crate) mod tests {
         );
     }
 
-    fn check_duplicate_port_reservation_retires_socket(
+    fn check_duplicate_port_binding_retires_socket(
         broker: &BrokerCore,
         provider: &TestSocketProvider,
     ) {
@@ -3121,18 +3118,18 @@ pub(crate) mod tests {
 
         let duplicate_ports = BrokerSocketPorts::default();
         let duplicate_address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 42002);
-        let SocketOutcome::Completed((duplicate_address, duplicate_reservation)) = duplicate_ports
+        let SocketOutcome::Completed((duplicate_address, duplicate_binding)) = duplicate_ports
             .reserve(create_request(), duplicate_address)
             .unwrap()
         else {
-            panic!("duplicate-reservation test could not reserve a port");
+            panic!("duplicate-binding test could not reserve a port");
         };
         let object = session
             .authorized_object(handle, ObjectRights::WRITE)
             .unwrap();
         let retired_before = provider.state.retired_sockets.load(Ordering::Relaxed);
         assert_eq!(
-            attach_binding(&object, duplicate_address, duplicate_reservation),
+            attach_binding(&object, duplicate_address, duplicate_binding),
             Err(BrokerError::Internal)
         );
         assert_eq!(

--- a/litebox_broker_core/src/socket.rs
+++ b/litebox_broker_core/src/socket.rs
@@ -136,6 +136,10 @@ enum GuestBindingKey {
 }
 
 struct GuestBindingReservation {
+    inner: Arc<GuestBindingReservationInner>,
+}
+
+struct GuestBindingReservationInner {
     ports: BrokerSocketPorts,
     transport: GuestTransport,
     key: GuestBindingKey,
@@ -143,24 +147,35 @@ struct GuestBindingReservation {
 
 impl GuestBindingReservation {
     fn is_wildcard(&self) -> bool {
-        matches!(self.key, GuestBindingKey::Wildcard(_))
+        matches!(self.inner.key, GuestBindingKey::Wildcard(_))
     }
 
     fn covers(&self, address: SocketAddrV4) -> bool {
         if address.port() == 0 || !is_guest_network_address(*address.ip()) {
             return false;
         }
-        match self.key {
+        match self.inner.key {
             GuestBindingKey::Wildcard(port) => address.port() == port,
             GuestBindingKey::Exact(reserved) => reserved == address,
         }
     }
 
     fn requested_address(&self) -> SocketAddrV4 {
-        match self.key {
+        match self.inner.key {
             GuestBindingKey::Wildcard(port) => SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, port),
             GuestBindingKey::Exact(address) => address,
         }
+    }
+
+    fn guest_source_lease(&self, destination: SocketAddrV4) -> Option<GuestSourceLease> {
+        if self.inner.transport != GuestTransport::Tcp {
+            return None;
+        }
+        let source_address = GuestSocketBinding::new(self).guest_source_address(destination)?;
+        Some(GuestSourceLease {
+            _reservation: Arc::clone(&self.inner),
+            source_address,
+        })
     }
 }
 
@@ -210,9 +225,11 @@ impl BrokerSocketPorts {
         Ok(SocketOutcome::Completed((
             local_address,
             GuestBindingReservation {
-                ports: self.clone(),
-                transport,
-                key,
+                inner: Arc::new(GuestBindingReservationInner {
+                    ports: self.clone(),
+                    transport,
+                    key,
+                }),
             },
         )))
     }
@@ -222,7 +239,7 @@ fn guest_binding_address_is_valid(address: SocketAddrV4) -> bool {
     address.ip().is_unspecified() || is_guest_network_address(*address.ip())
 }
 
-impl Drop for GuestBindingReservation {
+impl Drop for GuestBindingReservationInner {
     fn drop(&mut self) {
         let mut state = self.ports.state.lock();
         let ports = match self.transport {
@@ -245,7 +262,7 @@ impl GuestSocketBinding {
     fn new(reservation: &GuestBindingReservation) -> Self {
         Self {
             requested: reservation.requested_address(),
-            transport: reservation.transport,
+            transport: reservation.inner.transport,
         }
     }
 
@@ -325,6 +342,26 @@ impl PartialEq for GuestSocketBinding {
 
 impl Eq for GuestSocketBinding {}
 
+/// Lease retaining one exact guest TCP source endpoint.
+///
+/// Core creates this value from a live guest binding when a TCP connection
+/// targets the guest namespace. It grants no bind or listen authority. A
+/// platform may move the lease through a queued guest-local connection and
+/// return it from [`PlatformSocket::accept`]; dropping the final lease or
+/// binding reservation releases the original namespace reservation.
+pub struct GuestSourceLease {
+    _reservation: Arc<GuestBindingReservationInner>,
+    source_address: SocketAddrV4,
+}
+
+impl GuestSourceLease {
+    /// Returns the exact guest-visible source endpoint retained by this lease.
+    #[must_use]
+    pub const fn source_address(&self) -> SocketAddrV4 {
+        self.source_address
+    }
+}
+
 /// Platform socket and endpoint metadata returned by an accept operation.
 pub struct AcceptedPlatformSocket {
     /// Accepted, connected nonblocking platform socket.
@@ -337,6 +374,10 @@ pub struct AcceptedPlatformSocket {
     /// guest-namespace endpoint; broker-internal native routing endpoints must
     /// not be exposed.
     pub remote_address: SocketAddrV4,
+    /// Guest TCP source lease returned with a guest-local accepted connection.
+    ///
+    /// Its exact source endpoint must equal `remote_address`.
+    pub guest_source_lease: GuestSourceLease,
 }
 
 /// Broker failure from a platform connect operation.
@@ -454,10 +495,16 @@ pub trait PlatformSocket: Send + Sync {
     /// unchanged from one whose state is indeterminate. Once a native connect
     /// may have started, implementations must retain enough platform state to
     /// settle or conservatively retire it without reconstructing its lifecycle
-    /// during teardown.
+    /// during teardown. A guest TCP attempt receives a source lease. A
+    /// guest-local path must move it through to [`AcceptedPlatformSocket`];
+    /// native paths may drop it. Returning
+    /// [`PlatformConnectError::PeerUnchanged`] requires releasing the lease;
+    /// [`PlatformSocket::retire`] must release one retained by an indeterminate
+    /// or in-progress operation.
     fn connect(
         &self,
         address: SocketAddrV4,
+        guest_source_lease: Option<GuestSourceLease>,
     ) -> core::result::Result<SocketConnectionStatus, PlatformConnectError>;
 
     /// Sends bytes without waiting for platform readiness.
@@ -575,6 +622,7 @@ pub fn create(
         readiness,
         _quota: quota,
         port_reservation: Mutex::new(None),
+        guest_source_lease: Mutex::new(None),
     });
     let platform_socket = match session.core.socket_provider.create(
         session.session_id,
@@ -684,7 +732,15 @@ pub fn connect(
             }
         }
     }
-    let status = match resource.connect(address) {
+    let guest_source_lease = match resource.guest_source_lease(address) {
+        Ok(lease) => lease,
+        Err(error) => {
+            finish_retired_connect(&object);
+            resource.retire();
+            return Err(error);
+        }
+    };
+    let status = match resource.connect(address, guest_source_lease) {
         Ok(SocketConnectionStatus::Unconnected) => {
             finish_retired_connect(&object);
             resource.retire();
@@ -881,6 +937,7 @@ pub fn accept(
         readiness,
         _quota: quota,
         port_reservation: Mutex::new(None),
+        guest_source_lease: Mutex::new(None),
     });
     let accepted = match listener_resource.accept(resource.readiness.clone()) {
         Ok(SocketOutcome::Completed(accepted)) => accepted,
@@ -893,9 +950,17 @@ pub fn accept(
             return Err(error);
         }
     };
-    if !listener_resource.port_reservation_covers(accepted.local_address) {
+    if !listener_resource.port_reservation_covers(accepted.local_address)
+        || accepted.guest_source_lease.source_address() != accepted.remote_address
+    {
         accepted.socket.retire();
         resource.readiness.retire();
+        return Err(BrokerError::Internal);
+    }
+    if let Err(guest_source_lease) = resource.set_guest_source_lease(accepted.guest_source_lease) {
+        accepted.socket.retire();
+        resource.readiness.retire();
+        drop(guest_source_lease);
         return Err(BrokerError::Internal);
     }
     resource.platform_socket.call_once(|| accepted.socket);
@@ -1558,7 +1623,7 @@ fn connect_datagram(
             }
         }
     }
-    match resource.connect(address) {
+    match resource.connect(address, None) {
         Ok(SocketConnectionStatus::Connected) => {
             finish_datagram_connect(object, SocketConnectionStatus::Connected, true);
             Ok(SocketOutcome::Completed(SocketConnectionStatus::Connected))
@@ -1827,6 +1892,7 @@ pub(crate) struct SocketResource {
     readiness: ReadinessRegistration,
     _quota: Arc<SocketQuotaReservation>,
     port_reservation: Mutex<Option<GuestBindingReservation>>,
+    guest_source_lease: Mutex<Option<GuestSourceLease>>,
 }
 
 impl SocketResource {
@@ -1839,6 +1905,18 @@ impl SocketResource {
             return Err(reservation);
         }
         *slot = Some(reservation);
+        Ok(())
+    }
+
+    fn set_guest_source_lease(
+        &self,
+        lease: GuestSourceLease,
+    ) -> core::result::Result<(), GuestSourceLease> {
+        let mut slot = self.guest_source_lease.lock();
+        if slot.is_some() {
+            return Err(lease);
+        }
+        *slot = Some(lease);
         Ok(())
     }
 
@@ -1866,8 +1944,29 @@ impl SocketResource {
     fn connect(
         &self,
         address: SocketAddrV4,
+        guest_source_lease: Option<GuestSourceLease>,
     ) -> core::result::Result<SocketConnectionStatus, PlatformConnectError> {
-        self.platform_socket().connect(address)
+        self.platform_socket().connect(address, guest_source_lease)
+    }
+
+    fn guest_source_lease(&self, destination: SocketAddrV4) -> Result<Option<GuestSourceLease>> {
+        if destination.port() == 0 {
+            return Ok(None);
+        }
+        let destination = if destination.ip().is_unspecified() {
+            SocketAddrV4::new(Ipv4Addr::LOCALHOST, destination.port())
+        } else {
+            destination
+        };
+        if !is_guest_network_address(*destination.ip()) {
+            return Ok(None);
+        }
+        self.port_reservation
+            .lock()
+            .as_ref()
+            .and_then(|reservation| reservation.guest_source_lease(destination))
+            .map(Some)
+            .ok_or(BrokerError::Internal)
     }
 
     fn bind(&self, binding: GuestSocketBinding) -> Result<SocketOutcome<SocketAddrV4>> {
@@ -1880,7 +1979,10 @@ impl SocketResource {
 
     fn retire(&self) {
         self.platform_socket().retire();
-        drop(self.port_reservation.lock().take());
+        let port_reservation = self.port_reservation.lock().take();
+        let guest_source_lease = self.guest_source_lease.lock().take();
+        drop(port_reservation);
+        drop(guest_source_lease);
     }
 
     fn accept(
@@ -1972,7 +2074,10 @@ impl Drop for SocketResource {
         if let Some(platform_socket) = self.platform_socket.get() {
             platform_socket.retire();
         }
-        drop(self.port_reservation.lock().take());
+        let port_reservation = self.port_reservation.lock().take();
+        let guest_source_lease = self.guest_source_lease.lock().take();
+        drop(port_reservation);
+        drop(guest_source_lease);
         self.readiness.retire();
     }
 }
@@ -2177,6 +2282,84 @@ pub(crate) mod tests {
         ));
     }
 
+    #[test]
+    fn guest_source_lease_retains_the_original_binding_key() {
+        let ports = BrokerSocketPorts::default();
+        let wildcard = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 8081);
+        let loopback = SocketAddrV4::new(Ipv4Addr::LOCALHOST, wildcard.port());
+        let private = SocketAddrV4::new(GUEST_IPV4_ADDRESS, wildcard.port());
+        let SocketOutcome::Completed((_, reservation)) =
+            ports.reserve(create_request(), wildcard).unwrap()
+        else {
+            panic!("wildcard reservation failed");
+        };
+        let lease = reservation.guest_source_lease(loopback).unwrap();
+        assert_eq!(lease.source_address(), loopback);
+        drop(reservation);
+        assert!(matches!(
+            ports.reserve(create_request(), private),
+            Ok(SocketOutcome::Failed(SocketError::AddressInUse))
+        ));
+        drop(lease);
+        assert!(matches!(
+            ports.reserve(create_request(), wildcard),
+            Ok(SocketOutcome::Completed(_))
+        ));
+
+        let exact = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8082);
+        let other_exact = SocketAddrV4::new(GUEST_IPV4_ADDRESS, exact.port());
+        let SocketOutcome::Completed((_, reservation)) =
+            ports.reserve(create_request(), exact).unwrap()
+        else {
+            panic!("exact reservation failed");
+        };
+        let lease = reservation.guest_source_lease(loopback_address()).unwrap();
+        assert_eq!(lease.source_address(), exact);
+        drop(reservation);
+        assert!(matches!(
+            ports.reserve(create_request(), exact),
+            Ok(SocketOutcome::Failed(SocketError::AddressInUse))
+        ));
+        assert!(matches!(
+            ports.reserve(create_request(), other_exact),
+            Ok(SocketOutcome::Completed(_))
+        ));
+        drop(lease);
+        assert!(matches!(
+            ports.reserve(create_request(), exact),
+            Ok(SocketOutcome::Completed(_))
+        ));
+    }
+
+    #[test]
+    fn guest_source_leases_release_after_the_last_owner() {
+        let ports = BrokerSocketPorts::default();
+        let wildcard = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 8083);
+        let loopback = SocketAddrV4::new(Ipv4Addr::LOCALHOST, wildcard.port());
+        let private = SocketAddrV4::new(GUEST_IPV4_ADDRESS, wildcard.port());
+        let SocketOutcome::Completed((_, reservation)) =
+            ports.reserve(create_request(), wildcard).unwrap()
+        else {
+            panic!("wildcard reservation failed");
+        };
+        let loopback_lease = reservation.guest_source_lease(loopback).unwrap();
+        let private_lease = reservation.guest_source_lease(private).unwrap();
+        assert_eq!(loopback_lease.source_address(), loopback);
+        assert_eq!(private_lease.source_address(), private);
+
+        drop(reservation);
+        drop(loopback_lease);
+        assert!(matches!(
+            ports.reserve(create_request(), private),
+            Ok(SocketOutcome::Failed(SocketError::AddressInUse))
+        ));
+        drop(private_lease);
+        assert!(matches!(
+            ports.reserve(create_request(), wildcard),
+            Ok(SocketOutcome::Completed(_))
+        ));
+    }
+
     #[derive(Clone, Default)]
     pub(crate) struct TestSocketProvider {
         state: Arc<TestSocketState>,
@@ -2188,6 +2371,7 @@ pub(crate) mod tests {
         closed_sessions: StdMutex<std::vec::Vec<SessionId>>,
         sent: StdMutex<std::vec::Vec<u8>>,
         connect_calls: AtomicUsize,
+        connect_source_addresses: StdMutex<std::vec::Vec<Option<SocketAddrV4>>>,
         status_calls: AtomicUsize,
         status_responses: StdMutex<std::collections::VecDeque<PlatformSocketStatus>>,
         status_block: StdMutex<Option<(mpsc::Sender<()>, mpsc::Receiver<()>)>>,
@@ -2208,6 +2392,14 @@ pub(crate) mod tests {
         tcp_option_sets: StdMutex<std::vec::Vec<TcpOptionValue>>,
         failed_readiness: StdMutex<Option<ReadinessRegistration>>,
         live_readiness: StdMutex<Option<ReadinessRegistration>>,
+        queue_next_guest_connect: core::sync::atomic::AtomicBool,
+        accepted_remote_address: StdMutex<Option<SocketAddrV4>>,
+        pending_accept: StdMutex<Option<PendingAcceptedConnection>>,
+    }
+
+    struct PendingAcceptedConnection {
+        destination: SocketAddrV4,
+        guest_source_lease: GuestSourceLease,
     }
 
     impl TestSocketProvider {
@@ -2243,6 +2435,13 @@ pub(crate) mod tests {
 
         fn retain_next_socket(&self) {
             self.state.retain_next_socket.store(true, Ordering::Relaxed);
+        }
+
+        fn queue_next_guest_connect(&self, remote_address: Option<SocketAddrV4>) {
+            *self.state.accepted_remote_address.lock().unwrap() = remote_address;
+            self.state
+                .queue_next_guest_connect
+                .store(true, Ordering::Relaxed);
         }
     }
 
@@ -2349,16 +2548,45 @@ pub(crate) mod tests {
 
         fn accept(
             &self,
-            _readiness: ReadinessRegistration,
+            readiness: ReadinessRegistration,
         ) -> Result<SocketOutcome<AcceptedPlatformSocket>> {
-            Err(BrokerError::WouldBlock)
+            let Some(pending) = self.state.pending_accept.lock().unwrap().take() else {
+                return Err(BrokerError::WouldBlock);
+            };
+            let remote_address = self
+                .state
+                .accepted_remote_address
+                .lock()
+                .unwrap()
+                .take()
+                .unwrap_or_else(|| pending.guest_source_lease.source_address());
+            let socket = Arc::new(TestPlatformSocket {
+                state: Arc::clone(&self.state),
+                readiness,
+                create_request: self.create_request,
+                tcp_options: StdMutex::new(TestTcpOptions::default()),
+                guest_local_address: StdMutex::new(Some(pending.destination)),
+                active: core::sync::atomic::AtomicBool::new(true),
+            });
+            Ok(SocketOutcome::Completed(AcceptedPlatformSocket {
+                socket,
+                local_address: pending.destination,
+                remote_address,
+                guest_source_lease: pending.guest_source_lease,
+            }))
         }
 
         fn connect(
             &self,
-            _address: SocketAddrV4,
+            address: SocketAddrV4,
+            guest_source_lease: Option<GuestSourceLease>,
         ) -> core::result::Result<SocketConnectionStatus, PlatformConnectError> {
             self.state.connect_calls.fetch_add(1, Ordering::Relaxed);
+            self.state.connect_source_addresses.lock().unwrap().push(
+                guest_source_lease
+                    .as_ref()
+                    .map(GuestSourceLease::source_address),
+            );
             if self.state.fail_connect.swap(false, Ordering::Relaxed) {
                 return Err(PlatformConnectError::PeerUnchanged(BrokerError::Internal));
             }
@@ -2384,6 +2612,27 @@ pub(crate) mod tests {
             if is_udp(self.create_request) {
                 Ok(SocketConnectionStatus::Connected)
             } else {
+                if self
+                    .state
+                    .queue_next_guest_connect
+                    .swap(false, Ordering::Relaxed)
+                {
+                    let Some(guest_source_lease) = guest_source_lease else {
+                        return Err(PlatformConnectError::PeerIndeterminate(
+                            BrokerError::Internal,
+                        ));
+                    };
+                    let mut pending = self.state.pending_accept.lock().unwrap();
+                    if pending.is_some() {
+                        return Err(PlatformConnectError::PeerIndeterminate(
+                            BrokerError::Internal,
+                        ));
+                    }
+                    *pending = Some(PendingAcceptedConnection {
+                        destination: address,
+                        guest_source_lease,
+                    });
+                }
                 Ok(SocketConnectionStatus::Connecting)
             }
         }
@@ -2493,6 +2742,179 @@ pub(crate) mod tests {
         fn drop(&mut self) {
             self.retire();
             self.state.dropped_sockets.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    #[test]
+    fn zero_port_guest_destination_does_not_require_a_source_lease() {
+        let provider = Arc::new(TestSocketProvider::default());
+        let broker = test_broker(Arc::clone(&provider) as Arc<dyn SocketProvider>);
+        let session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let socket = create(
+            &session,
+            create_request(),
+            Arc::new(TestReadinessSink::default()),
+        )
+        .unwrap();
+
+        assert_eq!(
+            connect(&session, socket, SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0),),
+            Ok(SocketOutcome::Completed(SocketConnectionStatus::Connecting))
+        );
+        assert_eq!(
+            provider
+                .state
+                .connect_source_addresses
+                .lock()
+                .unwrap()
+                .as_slice(),
+            &[None]
+        );
+        assert_eq!(provider.state.retired_sockets.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn accepted_guest_source_lease_is_validated_and_retained() {
+        let provider = Arc::new(TestSocketProvider::default());
+        let broker = test_broker(Arc::clone(&provider) as Arc<dyn SocketProvider>);
+        let listener_session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let connector_session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let listener = create(
+            &listener_session,
+            create_request(),
+            Arc::new(TestReadinessSink::default()),
+        )
+        .unwrap();
+        let listener_address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 44000);
+        assert_eq!(
+            bind(&listener_session, listener, listener_address),
+            Ok(SocketOutcome::Completed(listener_address))
+        );
+        assert_eq!(
+            listen(&listener_session, listener, 1),
+            Ok(SocketOutcome::Completed(listener_address))
+        );
+
+        let mismatched_source = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 44001);
+        let connector = create(
+            &connector_session,
+            create_request(),
+            Arc::new(TestReadinessSink::default()),
+        )
+        .unwrap();
+        assert_eq!(
+            bind(&connector_session, connector, mismatched_source),
+            Ok(SocketOutcome::Completed(mismatched_source))
+        );
+        provider.queue_next_guest_connect(Some(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 44999)));
+        assert_eq!(
+            connect(&connector_session, connector, listener_address),
+            Ok(SocketOutcome::Completed(SocketConnectionStatus::Connecting))
+        );
+        connector_session.close_object_reference(connector).unwrap();
+        assert!(matches!(
+            broker
+                .socket_ports
+                .reserve(create_request(), mismatched_source),
+            Ok(SocketOutcome::Failed(SocketError::AddressInUse))
+        ));
+        assert!(matches!(
+            accept(
+                &listener_session,
+                listener,
+                Arc::new(TestReadinessSink::default())
+            ),
+            Err(BrokerError::Internal)
+        ));
+        assert!(matches!(
+            broker
+                .socket_ports
+                .reserve(create_request(), mismatched_source),
+            Ok(SocketOutcome::Completed(_))
+        ));
+
+        let wildcard_source = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 44002);
+        let concrete_source = SocketAddrV4::new(Ipv4Addr::LOCALHOST, wildcard_source.port());
+        let connector = create(
+            &connector_session,
+            create_request(),
+            Arc::new(TestReadinessSink::default()),
+        )
+        .unwrap();
+        assert_eq!(
+            bind(&connector_session, connector, wildcard_source),
+            Ok(SocketOutcome::Completed(wildcard_source))
+        );
+        provider.queue_next_guest_connect(None);
+        assert_eq!(
+            connect(&connector_session, connector, listener_address),
+            Ok(SocketOutcome::Completed(SocketConnectionStatus::Connecting))
+        );
+        connector_session.close_object_reference(connector).unwrap();
+        assert!(matches!(
+            broker.socket_ports.reserve(
+                create_request(),
+                SocketAddrV4::new(GUEST_IPV4_ADDRESS, wildcard_source.port())
+            ),
+            Ok(SocketOutcome::Failed(SocketError::AddressInUse))
+        ));
+
+        let SocketOutcome::Completed(accepted) = accept(
+            &listener_session,
+            listener,
+            Arc::new(TestReadinessSink::default()),
+        )
+        .unwrap() else {
+            panic!("guest-local accept failed");
+        };
+        assert_eq!(accepted.local_address, listener_address);
+        assert_eq!(accepted.remote_address, concrete_source);
+        listener_session.close_object_reference(listener).unwrap();
+        assert!(matches!(
+            broker
+                .socket_ports
+                .reserve(create_request(), listener_address),
+            Ok(SocketOutcome::Completed(_))
+        ));
+        assert!(matches!(
+            broker.socket_ports.reserve(
+                create_request(),
+                SocketAddrV4::new(GUEST_IPV4_ADDRESS, wildcard_source.port())
+            ),
+            Ok(SocketOutcome::Failed(SocketError::AddressInUse))
+        ));
+        listener_session
+            .close_object_reference(accepted.handle)
+            .unwrap();
+        assert!(matches!(
+            broker
+                .socket_ports
+                .reserve(create_request(), wildcard_source),
+            Ok(SocketOutcome::Completed(_))
+        ));
+    }
+
+    fn test_broker(socket_provider: Arc<dyn SocketProvider>) -> BrokerCore {
+        BrokerCore {
+            policy: Arc::new(
+                crate::PolicyEngine::with_unauthenticated_rights(crate::ObjectRights::all())
+                    .with_socket_policy(crate::SocketPolicy::guest_network()),
+            ),
+            limits: crate::BrokerCoreLimits::new_with_all_limits(16, 4, 8, 8),
+            next_session_id: Arc::new(spin::RwLock::new(1)),
+            next_reference_handle: Arc::new(spin::RwLock::new(1)),
+            references: Arc::new(spin::RwLock::new(hashbrown::HashMap::new())),
+            pending_references: Arc::new(AtomicUsize::new(0)),
+            reserved_pipe_capacity: Arc::new(AtomicUsize::new(0)),
+            reserved_sockets: Arc::new(AtomicUsize::new(0)),
+            socket_provider,
+            socket_ports: BrokerSocketPorts::default(),
         }
     }
 
@@ -2784,6 +3206,15 @@ pub(crate) mod tests {
             .last()
             .expect("automatic TCP bind was not recorded");
         assert_eq!(
+            provider
+                .state
+                .connect_source_addresses
+                .lock()
+                .unwrap()
+                .last(),
+            Some(&Some(local_address))
+        );
+        assert_eq!(
             readiness.published.lock().unwrap().as_slice(),
             [(handle, ReadinessFlags::WRITE)]
         );
@@ -2948,11 +3379,26 @@ pub(crate) mod tests {
             .expect("automatic private TCP bind was not recorded");
         assert_eq!(*bound_address.ip(), GUEST_IPV4_ADDRESS);
         assert_ne!(bound_address.port(), 0);
+        assert_eq!(
+            provider
+                .state
+                .connect_source_addresses
+                .lock()
+                .unwrap()
+                .last(),
+            Some(&Some(bound_address))
+        );
         session.close_object_reference(handle).unwrap();
     }
 
     fn check_udp_socket_operations(broker: &BrokerCore, provider: &TestSocketProvider) {
         let connect_calls_before = provider.state.connect_calls.load(Ordering::Relaxed);
+        let connect_sources_before = provider
+            .state
+            .connect_source_addresses
+            .lock()
+            .unwrap()
+            .len();
         let session = broker
             .create_session(CallerCredential::Unauthenticated)
             .unwrap();
@@ -3103,6 +3549,11 @@ pub(crate) mod tests {
         assert_eq!(
             provider.state.connect_calls.load(Ordering::Relaxed),
             connect_calls_before + 3
+        );
+        assert!(
+            provider.state.connect_source_addresses.lock().unwrap()[connect_sources_before..]
+                .iter()
+                .all(Option::is_none)
         );
     }
 

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -819,6 +819,7 @@ mod tests {
         fn connect(
             &self,
             _address: SocketAddrV4,
+            _guest_source_lease: Option<litebox_broker_core::socket::GuestSourceLease>,
         ) -> core::result::Result<SocketConnectionStatus, PlatformConnectError> {
             self.readiness
                 .publish(litebox_broker_protocol::readiness::ReadinessFlags::WRITE)

--- a/litebox_broker_platform_linux_userland/src/socket.rs
+++ b/litebox_broker_platform_linux_userland/src/socket.rs
@@ -12,14 +12,13 @@ use std::sync::atomic::{AtomicU8, AtomicU64, Ordering};
 use std::sync::mpsc::{Receiver, SyncSender, TryRecvError, sync_channel};
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
-use std::time::Instant;
-
 #[cfg(test)]
 use std::time::Duration;
 
 use litebox_broker_core::socket::{
-    AcceptedPlatformSocket, GuestSocketBinding, PlatformConnectError, PlatformDatagramReceive,
-    PlatformSocket, PlatformSocketStatus, PlatformStreamReceive, SocketProvider,
+    AcceptedPlatformSocket, GuestSocketBinding, GuestSourceLease, PlatformConnectError,
+    PlatformDatagramReceive, PlatformSocket, PlatformSocketStatus, PlatformStreamReceive,
+    SocketProvider,
 };
 use litebox_broker_core::{BrokerError, Result as BrokerResult, SessionId};
 use litebox_broker_protocol::readiness::ReadinessFlags;
@@ -29,7 +28,7 @@ use litebox_broker_protocol::socket::{
     SocketType, TcpOptionName, TcpOptionValue,
 };
 use rustix::buffer::spare_capacity;
-use rustix::event::{EventfdFlags, Timespec, epoll, eventfd};
+use rustix::event::{EventfdFlags, epoll, eventfd};
 use rustix::io::{Errno, read, write};
 use rustix::net::{getsockname, sockopt};
 
@@ -40,14 +39,11 @@ use litebox_broker_protocol::socket::{MAX_SOCKET_TRANSFER_SIZE, SocketStatusResp
 mod tcp;
 mod udp;
 
+#[cfg(test)]
+use tcp::TcpDescriptor;
 use tcp::{
     AcceptedEndpoints, ReactorReceiveOutcome, ReactorTcpState, TcpSocketState,
-    create_tcp_transport, handle_socket_event,
-};
-#[cfg(test)]
-use tcp::{
-    MAX_UNMATCHED_ACCEPTS_PER_COMMAND, PENDING_CONNECT_DISCARD_LIFETIME,
-    PendingGuestConnectionMatch, PendingGuestTcpConnection,
+    consume_pending_guest_reset, create_tcp_transport, guest_reset_pending, handle_socket_event,
 };
 use udp::{
     ReactorUdpBinding, ReactorUdpPeer, ReactorUdpState, UDP_EVENT_TOKEN_FLAG, UdpReceiveOrigin,
@@ -274,6 +270,7 @@ impl PlatformSocket for LinuxSocket {
                     socket,
                     local_address: accepted.local_address,
                     remote_address: accepted.remote_address,
+                    guest_source_lease: accepted.guest_source_lease,
                 }))
             }
             SocketOutcome::Failed(error) => Ok(SocketOutcome::Failed(error)),
@@ -283,8 +280,9 @@ impl PlatformSocket for LinuxSocket {
     fn connect(
         &self,
         address: SocketAddrV4,
+        guest_source_lease: Option<GuestSourceLease>,
     ) -> core::result::Result<SocketConnectionStatus, PlatformConnectError> {
-        self.reactor.connect(self.id, address)
+        self.reactor.connect(self.id, address, guest_source_lease)
     }
 
     fn send(&self, data: Vec<u8>, _flags: SendFlags) -> BrokerResult<SocketOutcome<usize>> {
@@ -525,11 +523,13 @@ impl ReactorClient {
         &self,
         id: u64,
         address: SocketAddrV4,
+        guest_source_lease: Option<GuestSourceLease>,
     ) -> core::result::Result<SocketConnectionStatus, PlatformConnectError> {
         let (response, receive) = sync_channel(1);
         let command = ReactorCommand::Connect {
             id,
             address,
+            guest_source_lease,
             response,
         };
         // Block until the reactor has queue space (see `request`): a transiently
@@ -578,20 +578,20 @@ impl ReactorClient {
     }
 
     #[cfg(test)]
-    fn pending_guest_connection_count(&self) -> usize {
+    fn queued_guest_connection_count(&self) -> usize {
         let (response, receive) = sync_channel(1);
         self.commands
-            .send(ReactorCommand::PendingGuestConnectionCount { response })
+            .send(ReactorCommand::QueuedGuestConnectionCount { response })
             .unwrap();
         self.signal().unwrap();
         receive.recv().unwrap()
     }
 
     #[cfg(test)]
-    fn retained_connector_count(&self) -> usize {
+    fn tcp_descriptor_counts(&self) -> (usize, usize, usize) {
         let (response, receive) = sync_channel(1);
         self.commands
-            .send(ReactorCommand::RetainedConnectorCount { response })
+            .send(ReactorCommand::TcpDescriptorCounts { response })
             .unwrap();
         self.signal().unwrap();
         receive.recv().unwrap()
@@ -693,32 +693,6 @@ impl ReactorClient {
         receive.recv().unwrap();
     }
 
-    #[cfg(test)]
-    fn expire_pending_guest_connections(&self) {
-        let (response, receive) = sync_channel(1);
-        self.commands
-            .send(ReactorCommand::ExpireDeadlinedState {
-                now: Instant::now() + PENDING_CONNECT_DISCARD_LIFETIME + Duration::from_secs(1),
-                response,
-            })
-            .unwrap();
-        self.signal().unwrap();
-        receive.recv().unwrap();
-    }
-
-    #[cfg(test)]
-    fn defer_untracked_guest_connection(&self, guest_port: u16) {
-        let (response, receive) = sync_channel(1);
-        self.commands
-            .send(ReactorCommand::DeferUntrackedGuestConnection {
-                guest_port,
-                response,
-            })
-            .unwrap();
-        self.signal().unwrap();
-        receive.recv().unwrap();
-    }
-
     fn close_session(&self, session_id: SessionId) {
         let (response, receive) = sync_channel(1);
         if self
@@ -792,6 +766,7 @@ enum ReactorCommand {
     Connect {
         id: u64,
         address: SocketAddrV4,
+        guest_source_lease: Option<GuestSourceLease>,
         response: SyncSender<core::result::Result<SocketConnectionStatus, PlatformConnectError>>,
     },
     Bind {
@@ -870,12 +845,12 @@ enum ReactorCommand {
         response: SyncSender<Option<SocketAddrV4>>,
     },
     #[cfg(test)]
-    PendingGuestConnectionCount {
+    QueuedGuestConnectionCount {
         response: SyncSender<usize>,
     },
     #[cfg(test)]
-    RetainedConnectorCount {
-        response: SyncSender<usize>,
+    TcpDescriptorCounts {
+        response: SyncSender<(usize, usize, usize)>,
     },
     #[cfg(test)]
     UdpQueuedDatagramCount {
@@ -919,16 +894,6 @@ enum ReactorCommand {
     },
     #[cfg(test)]
     ExhaustUdpEventTokens {
-        response: SyncSender<()>,
-    },
-    #[cfg(test)]
-    ExpireDeadlinedState {
-        now: Instant,
-        response: SyncSender<()>,
-    },
-    #[cfg(test)]
-    DeferUntrackedGuestConnection {
-        guest_port: u16,
         response: SyncSender<()>,
     },
     Stop {
@@ -1000,14 +965,13 @@ impl SocketEntry {
     }
 }
 
-/// Reactor-side per-session socket, retained-descriptor, and teardown state.
+/// Reactor-side per-session socket and teardown state.
 ///
 /// Sessions are ownership domains, not guest network namespaces.
 #[derive(Default)]
 struct ReactorSessionState {
     live_socket_count: usize,
     pending_guest_connection_count: usize,
-    retained_connector_count: usize,
     udp_external_peer_count: usize,
     udp_queued_datagrams: usize,
     udp_queued_bytes: usize,
@@ -1024,7 +988,6 @@ fn retain_session_state(state: &ReactorSessionState) -> bool {
     !state.closing
         || state.live_socket_count != 0
         || state.pending_guest_connection_count != 0
-        || state.retained_connector_count != 0
         || state.udp_external_peer_count != 0
         || state.udp_queued_datagrams != 0
         || state.udp_queued_bytes != 0
@@ -1120,6 +1083,7 @@ impl Reactor {
         &mut self,
         id: u64,
         guest_address: SocketAddrV4,
+        guest_source_lease: Option<GuestSourceLease>,
     ) -> core::result::Result<SocketConnectionStatus, PlatformConnectError> {
         let kind = self.sockets.get(&id).map(SocketEntry::kind).ok_or(
             PlatformConnectError::PeerIndeterminate(BrokerError::Internal),
@@ -1239,7 +1203,7 @@ impl Reactor {
                 .map_err(PlatformConnectError::PeerIndeterminate)?;
             return Ok(SocketConnectionStatus::Connected);
         }
-        self.connect_tcp_guest(id, guest_address)
+        self.connect_tcp_guest(id, guest_address, guest_source_lease)
     }
 
     fn send_to_socket(
@@ -1493,15 +1457,7 @@ impl Reactor {
         loop {
             let mut events = core::mem::take(&mut self.events);
             events.clear();
-            let now = Instant::now();
-            let timeout = self.next_cleanup_deadline().map(|deadline| {
-                let duration = deadline.saturating_duration_since(now);
-                Timespec {
-                    tv_sec: i64::try_from(duration.as_secs()).unwrap_or(i64::MAX),
-                    tv_nsec: i64::from(duration.subsec_nanos()),
-                }
-            });
-            match epoll::wait(&self.epoll, spare_capacity(&mut events), timeout.as_ref()) {
+            match epoll::wait(&self.epoll, spare_capacity(&mut events), None) {
                 Ok(_) => {}
                 Err(Errno::INTR) => {
                     self.events = events;
@@ -1509,8 +1465,6 @@ impl Reactor {
                 }
                 Err(error) => return Err(ReactorFailure::Io(error)),
             }
-            self.expire_deadlined_state(Instant::now());
-
             // Apply readiness observed by this wait before commands. A command
             // that then reaches EAGAIN records the newer authoritative state.
             let mut wake = false;
@@ -1521,25 +1475,8 @@ impl Reactor {
                 } else if id & UDP_EVENT_TOKEN_FLAG != 0 {
                     self.handle_udp_endpoint_event(id, event.flags)
                         .map_err(ReactorFailure::Broker)?;
-                } else {
-                    let failed_connection = if let Some(socket) = self.sockets.get_mut(&id) {
-                        if handle_socket_event(socket, event.flags)
-                            .map_err(ReactorFailure::Broker)?
-                        {
-                            socket
-                                .tcp_state()
-                                .ok()
-                                .and_then(|tcp| tcp.host_connection)
-                                .map(|connection| (connection, socket.session_id))
-                        } else {
-                            None
-                        }
-                    } else {
-                        None
-                    };
-                    if let Some((connection, session_id)) = failed_connection {
-                        self.discard_pending_guest_connection(connection, session_id);
-                    }
+                } else if let Some(socket) = self.sockets.get_mut(&id) {
+                    handle_socket_event(socket, event.flags).map_err(ReactorFailure::Broker)?;
                 }
             }
             self.events = events;
@@ -1593,10 +1530,20 @@ impl Reactor {
                 ReactorCommand::Connect {
                     id,
                     address,
+                    guest_source_lease,
                     response,
                 } => {
-                    let outcome = self.connect_socket(id, address);
-                    let _ = response.send(outcome);
+                    let outcome = self.connect_socket(id, address, guest_source_lease);
+                    let peer_may_have_changed =
+                        !matches!(&outcome, Err(PlatformConnectError::PeerUnchanged(_)));
+                    if response.send(outcome).is_err() && peer_may_have_changed {
+                        if let Some(socket) = self.sockets.get_mut(&id)
+                            && let Ok(tcp) = socket.tcp_state_mut()
+                        {
+                            tcp.abortive_close = true;
+                        }
+                        self.remove_socket(id);
+                    }
                 }
                 ReactorCommand::Bind {
                     id,
@@ -1638,6 +1585,11 @@ impl Reactor {
                         Ok(SocketOutcome::Completed(AcceptedEndpoints { .. }))
                     );
                     if response.send(outcome).is_err() && accepted {
+                        if let Some(socket) = self.sockets.get_mut(&accepted_id)
+                            && let Ok(tcp) = socket.tcp_state_mut()
+                        {
+                            tcp.abortive_close = true;
+                        }
                         self.remove_socket(accepted_id);
                         lifecycle.reactor_removed();
                     }
@@ -1714,7 +1666,7 @@ impl Reactor {
                     {
                         self.remove_socket(id);
                     }
-                    self.retire_session_connectors(session_id);
+                    self.purge_connector_session_queues(session_id);
                     self.sessions
                         .retain(|_, session| retain_session_state(session));
                     let _ = response.send(());
@@ -1725,28 +1677,37 @@ impl Reactor {
                     response,
                 } => {
                     let host_address = self
-                        .tcp
+                        .udp
                         .bindings
                         .get(guest_port)
-                        .and_then(|binding| binding.host_address)
-                        .or_else(|| {
-                            self.udp
-                                .bindings
-                                .get(guest_port)
-                                .and_then(|binding| self.sockets.get(&binding.socket_id))
-                                .and_then(|socket| socket.udp_state().ok())
-                                .and_then(|udp| udp.native_endpoint.as_ref())
-                                .map(|endpoint| endpoint.host_address)
-                        });
+                        .and_then(|binding| self.sockets.get(&binding.socket_id))
+                        .and_then(|socket| socket.udp_state().ok())
+                        .and_then(|udp| udp.native_endpoint.as_ref())
+                        .map(|endpoint| endpoint.host_address);
                     let _ = response.send(host_address);
                 }
                 #[cfg(test)]
-                ReactorCommand::PendingGuestConnectionCount { response } => {
-                    let _ = response.send(self.tcp.pending_guest_connections.len());
+                ReactorCommand::QueuedGuestConnectionCount { response } => {
+                    let _ = response.send(self.tcp.queued_guest_connection_count);
                 }
                 #[cfg(test)]
-                ReactorCommand::RetainedConnectorCount { response } => {
-                    let _ = response.send(self.tcp.retained_connector_count);
+                ReactorCommand::TcpDescriptorCounts { response } => {
+                    let mut unrealized = 0;
+                    let mut native = 0;
+                    let mut guest = 0;
+                    for descriptor in self
+                        .sockets
+                        .values()
+                        .filter_map(|socket| socket.tcp_state().ok())
+                        .map(|tcp| &tcp.descriptor)
+                    {
+                        match descriptor {
+                            TcpDescriptor::Unrealized => unrealized += 1,
+                            TcpDescriptor::NativeInet(_) => native += 1,
+                            TcpDescriptor::GuestUnix(_) => guest += 1,
+                        }
+                    }
+                    let _ = response.send((unrealized, native, guest));
                 }
                 #[cfg(test)]
                 ReactorCommand::UdpQueuedDatagramCount { response } => {
@@ -1858,28 +1819,6 @@ impl Reactor {
                     self.udp.next_event_token = UDP_EVENT_TOKEN_FLAG - 1;
                     let _ = response.send(());
                 }
-                #[cfg(test)]
-                ReactorCommand::ExpireDeadlinedState { now, response } => {
-                    self.expire_deadlined_state(now);
-                    let _ = response.send(());
-                }
-                #[cfg(test)]
-                ReactorCommand::DeferUntrackedGuestConnection {
-                    guest_port,
-                    response,
-                } => {
-                    let listener_id = self
-                        .tcp
-                        .bindings
-                        .get(guest_port)
-                        .expect("test guest listener binding missing")
-                        .socket_id;
-                    self.tcp.defer_untracked_connection(
-                        listener_id,
-                        Instant::now() + PENDING_CONNECT_DISCARD_LIFETIME,
-                    );
-                    let _ = response.send(());
-                }
                 ReactorCommand::Stop { response } => {
                     while let Some(id) = self.sockets.keys().next().copied() {
                         self.remove_socket(id);
@@ -1907,7 +1846,7 @@ impl Reactor {
         if self
             .sockets
             .len()
-            .checked_add(self.tcp.retained_connector_count)
+            .checked_add(self.tcp.queued_guest_connection_count)
             .is_none_or(|count| count >= self.max_sockets)
         {
             return Err(BrokerError::ResourceExhausted);
@@ -1927,16 +1866,13 @@ impl Reactor {
         }
         if session
             .live_socket_count
-            .checked_add(session.retained_connector_count)
+            .checked_add(session.pending_guest_connection_count)
             .is_none_or(|count| count >= self.max_sockets_per_session)
         {
             return Err(BrokerError::ResourceExhausted);
         }
         let (transport, initial_readiness) = match kind {
-            SocketKind::Tcp => (
-                create_tcp_transport(&self.epoll, id)?,
-                ReadinessFlags::default(),
-            ),
+            SocketKind::Tcp => (create_tcp_transport(), ReadinessFlags::default()),
             SocketKind::Udp => (
                 SocketTransportState::Udp(UdpSocketState::default()),
                 ReadinessFlags::WRITE,
@@ -2003,7 +1939,11 @@ fn zeroed_vec(length: usize) -> BrokerResult<Vec<u8>> {
 }
 
 fn take_socket_error(socket: &SocketEntry) -> BrokerResult<Option<SocketError>> {
-    let native_socket = &socket.tcp_state()?.socket;
+    let tcp = socket.tcp_state()?;
+    if !tcp.descriptor.is_native() {
+        return Ok(None);
+    }
+    let native_socket = tcp.descriptor.socket()?;
     match sockopt::socket_error(native_socket) {
         Ok(Ok(())) => Ok(None),
         Ok(Err(error)) | Err(error) => socket_operation_error_from_errno(error).map(Some),
@@ -2031,12 +1971,19 @@ fn status_socket(socket: &mut SocketEntry) -> BrokerResult<PlatformSocketStatus>
     } else {
         None
     };
+    let pending_guest_reset = guest_reset_pending(socket)?;
     let (response, readiness, republish_error) = {
         let mut snapshot = socket
             .snapshot
             .lock()
             .expect("Linux socket snapshot mutex poisoned");
         let cached_error = snapshot.pending_error.take();
+        let socket_error =
+            if pending_guest_reset && cached_error != Some(SocketError::ConnectionReset) {
+                Some(SocketError::ConnectionReset)
+            } else {
+                socket_error
+            };
         let (pending_error, next_pending_error) = shift_pending_error(cached_error, socket_error);
         snapshot.pending_error = next_pending_error;
         if pending_error.is_some() && next_pending_error.is_none() {
@@ -2052,6 +1999,12 @@ fn status_socket(socket: &mut SocketEntry) -> BrokerResult<PlatformSocketStatus>
             next_pending_error.is_some(),
         )
     };
+    if pending_guest_reset
+        && response.pending_error == Some(SocketError::ConnectionReset)
+        && !consume_pending_guest_reset(socket)?
+    {
+        return Err(BrokerError::Internal);
+    }
     let publication = if republish_error {
         socket.readiness.republish(readiness)
     } else if response.pending_error.is_some() {

--- a/litebox_broker_platform_linux_userland/src/socket.rs
+++ b/litebox_broker_platform_linux_userland/src/socket.rs
@@ -269,7 +269,6 @@ impl PlatformSocket for LinuxSocket {
                 Ok(SocketOutcome::Completed(AcceptedPlatformSocket {
                     socket,
                     local_address: accepted.local_address,
-                    remote_address: accepted.remote_address,
                     guest_source_lease: accepted.guest_source_lease,
                 }))
             }

--- a/litebox_broker_platform_linux_userland/src/socket/tcp.rs
+++ b/litebox_broker_platform_linux_userland/src/socket/tcp.rs
@@ -58,11 +58,23 @@ pub(super) struct TcpSocketState {
     pub(super) listener: Option<GuestTcpListenerState>,
     pub(super) guest_endpoint: Option<GuestTcpEndpoint>,
     pub(super) peek_waitall_threshold: Option<usize>,
-    /// Bytes queued before logical guest read shutdown that may still be read.
-    pub(super) guest_read_shutdown_remaining: Option<usize>,
+    guest_read_shutdown: Option<GuestTcpReadShutdown>,
     pub(super) abortive_close: bool,
     pub(super) no_delay: bool,
     pub(super) keep_alive: bool,
+}
+
+/// Pre-shutdown bytes preserved while later guest data is discarded.
+struct GuestTcpReadShutdown {
+    queued: Vec<u8>,
+    consumed: usize,
+    discarded_data: bool,
+}
+
+impl GuestTcpReadShutdown {
+    fn has_unread_data(&self) -> bool {
+        self.consumed < self.queued.len() || self.discarded_data
+    }
 }
 
 pub(super) enum TcpDescriptor {
@@ -136,7 +148,7 @@ pub(super) fn create_tcp_transport() -> SocketTransportState {
         listener: None,
         guest_endpoint: None,
         peek_waitall_threshold: None,
-        guest_read_shutdown_remaining: None,
+        guest_read_shutdown: None,
         abortive_close: false,
         no_delay: false,
         keep_alive: false,
@@ -556,11 +568,17 @@ pub(super) fn receive_socket(
     if socket.kind() != SocketKind::Tcp {
         return Ok(ReactorReceiveOutcome::Failed(SocketError::InvalidArgument));
     }
-    let guest_read_shutdown_remaining = socket.tcp_state()?.guest_read_shutdown_remaining;
-    if guest_read_shutdown_remaining == Some(0) {
-        return Ok(ReactorReceiveOutcome::EndOfStream);
+    if socket.tcp_state()?.guest_read_shutdown.is_some() {
+        if !flags.contains(ReceiveFlags::PEEK)
+            && peek_cache
+                .as_ref()
+                .is_some_and(|cache| cache.socket_id == socket_id)
+        {
+            *peek_cache = None;
+        }
+        return receive_guest_read_shutdown(socket, length, flags, peek_offset, peek_length);
     }
-    if guest_read_shutdown_remaining.is_none() && guest_reset_pending(socket)? {
+    if guest_reset_pending(socket)? {
         let available = ioctl_fionread(socket.tcp_state()?.descriptor.socket()?)
             .map_err(broker_error_from_errno)?;
         if available == 0 {
@@ -701,9 +719,6 @@ fn receive_socket_once(
     mut data: Vec<u8>,
     flags: LinuxRecvFlags,
 ) -> BrokerResult<ReactorReceiveOutcome> {
-    if let Some(remaining) = socket.tcp_state()?.guest_read_shutdown_remaining {
-        data.truncate(data.len().min(remaining));
-    }
     loop {
         match recv(
             socket.tcp_state()?.descriptor.socket()?,
@@ -723,16 +738,6 @@ fn receive_socket_once(
             Ok((_buffer, received)) => {
                 confirm_tcp_connected(socket);
                 data.truncate(received);
-                if !flags.contains(LinuxRecvFlags::PEEK)
-                    && let Some(remaining) = socket
-                        .tcp_state_mut()?
-                        .guest_read_shutdown_remaining
-                        .as_mut()
-                {
-                    *remaining = remaining
-                        .checked_sub(received)
-                        .ok_or(BrokerError::Internal)?;
-                }
                 let terminal_readable = socket.read_shutdown
                     || socket
                         .snapshot
@@ -762,6 +767,125 @@ fn receive_socket_once(
             }
         }
     }
+}
+
+fn receive_guest_read_shutdown(
+    socket: &mut SocketEntry,
+    length: usize,
+    flags: ReceiveFlags,
+    peek_offset: usize,
+    peek_length: usize,
+) -> BrokerResult<ReactorReceiveOutcome> {
+    let peek = flags.contains(ReceiveFlags::PEEK);
+    let (relative_start, relative_end) = if peek {
+        let peek_end = peek_offset
+            .checked_add(length)
+            .ok_or(BrokerError::UnsupportedOperation)?;
+        let canonical_length = peek_length
+            .checked_sub(peek_offset)
+            .map(|remaining| remaining.min(MAX_SOCKET_TRANSFER_SIZE as usize));
+        if !peek_offset.is_multiple_of(MAX_SOCKET_TRANSFER_SIZE as usize)
+            || canonical_length != Some(length)
+            || peek_length < peek_end
+            || peek_length > MAX_SOCKET_PEEK_SIZE as usize
+        {
+            return Err(BrokerError::UnsupportedOperation);
+        }
+        (peek_offset, peek_end)
+    } else {
+        if peek_offset != 0 || peek_length != 0 {
+            return Err(BrokerError::UnsupportedOperation);
+        }
+        (0, length)
+    };
+
+    let shutdown = socket
+        .tcp_state_mut()?
+        .guest_read_shutdown
+        .as_mut()
+        .ok_or(BrokerError::Internal)?;
+    let start = shutdown
+        .consumed
+        .checked_add(relative_start)
+        .ok_or(BrokerError::Internal)?;
+    if start >= shutdown.queued.len() {
+        return Ok(ReactorReceiveOutcome::EndOfStream);
+    }
+    let end = shutdown
+        .consumed
+        .checked_add(relative_end)
+        .ok_or(BrokerError::Internal)?
+        .min(shutdown.queued.len());
+    let mut data = Vec::new();
+    data.try_reserve_exact(end - start)
+        .map_err(|_| BrokerError::OutOfMemory)?;
+    data.extend_from_slice(&shutdown.queued[start..end]);
+    if !peek {
+        shutdown.consumed = end;
+        if shutdown.consumed == shutdown.queued.len() {
+            shutdown.queued = Vec::new();
+            shutdown.consumed = 0;
+        }
+    }
+    Ok(ReactorReceiveOutcome::Received(data))
+}
+
+fn capture_guest_read_shutdown(
+    socket: &SocketEntry,
+    mut queued: Vec<u8>,
+) -> BrokerResult<GuestTcpReadShutdown> {
+    let mut received = 0;
+    while received < queued.len() {
+        match recv(
+            socket.tcp_state()?.descriptor.socket()?,
+            &mut queued[received..],
+            LinuxRecvFlags::WAITALL,
+        ) {
+            Ok((_buffer, 0)) => return Err(BrokerError::Internal),
+            Ok((_buffer, count)) => {
+                received = received.checked_add(count).ok_or(BrokerError::Internal)?;
+            }
+            Err(Errno::INTR) => {}
+            Err(_) => return Err(BrokerError::Internal),
+        }
+    }
+    Ok(GuestTcpReadShutdown {
+        queued,
+        consumed: 0,
+        discarded_data: false,
+    })
+}
+
+fn discard_guest_read_shutdown_data(socket: &mut SocketEntry) -> BrokerResult<()> {
+    if socket.tcp_state()?.guest_read_shutdown.is_none() {
+        return Ok(());
+    }
+    let mut data = [0_u8; 8192];
+    let mut discarded_data = false;
+    loop {
+        match recv(
+            socket.tcp_state()?.descriptor.socket()?,
+            &mut data,
+            LinuxRecvFlags::empty(),
+        ) {
+            Ok((_, 0)) | Err(Errno::AGAIN) => break,
+            Ok((_buffer, _)) => discarded_data = true,
+            Err(Errno::INTR) => {}
+            Err(error) => {
+                socket_operation_error_from_errno(error)?;
+                break;
+            }
+        }
+    }
+    if discarded_data {
+        socket
+            .tcp_state_mut()?
+            .guest_read_shutdown
+            .as_mut()
+            .ok_or(BrokerError::Internal)?
+            .discarded_data = true;
+    }
+    Ok(())
 }
 
 pub(super) fn set_tcp_option(socket: &mut SocketEntry, value: TcpOptionValue) -> BrokerResult<()> {
@@ -879,17 +1003,15 @@ pub(super) fn shutdown_tcp_socket(
         ),
         _ => return Err(BrokerError::UnsupportedOperation),
     };
-    let guest_read_shutdown_remaining: Option<usize> =
-        if guest_endpoint && shuts_down_read && !socket.read_shutdown {
-            Some(
-                ioctl_fionread(socket.tcp_state()?.descriptor.socket()?)
-                    .map_err(broker_error_from_errno)?
-                    .try_into()
-                    .map_err(|_| BrokerError::Internal)?,
-            )
-        } else {
-            None
-        };
+    let guest_read_shutdown_buffer = if guest_endpoint && shuts_down_read && !socket.read_shutdown {
+        let available: usize = ioctl_fionread(socket.tcp_state()?.descriptor.socket()?)
+            .map_err(broker_error_from_errno)?
+            .try_into()
+            .map_err(|_| BrokerError::Internal)?;
+        Some(zeroed_vec(available)?)
+    } else {
+        None
+    };
     if let Some(kernel_shutdown) = kernel_shutdown {
         loop {
             match shutdown(socket.tcp_state()?.descriptor.socket()?, kernel_shutdown) {
@@ -907,8 +1029,9 @@ pub(super) fn shutdown_tcp_socket(
             }
         }
     }
-    if let Some(remaining) = guest_read_shutdown_remaining {
-        socket.tcp_state_mut()?.guest_read_shutdown_remaining = Some(remaining);
+    if let Some(queued) = guest_read_shutdown_buffer {
+        let shutdown = capture_guest_read_shutdown(socket, queued)?;
+        socket.tcp_state_mut()?.guest_read_shutdown = Some(shutdown);
     }
     socket.read_shutdown |= shuts_down_read;
     socket.write_shutdown |= shuts_down_write;
@@ -948,6 +1071,9 @@ pub(super) fn handle_socket_event(
     if socket.kind() == SocketKind::Udp {
         let _ = update_snapshot(socket, None, readiness_from_epoll(socket, events));
         return Ok(());
+    }
+    if events.contains(epoll::EventFlags::IN) {
+        discard_guest_read_shutdown_data(socket)?;
     }
     let republish_readiness = if events.contains(epoll::EventFlags::IN)
         && let Some(threshold) = socket
@@ -1471,14 +1597,17 @@ impl Reactor {
                 .is_some_and(|tcp| {
                     tcp.abortive_close
                         || tcp.descriptor.is_guest()
-                            && match ioctl_fionread(
-                                tcp.descriptor
-                                    .socket()
-                                    .expect("guest endpoint descriptor missing"),
-                            ) {
-                                Ok(0) => false,
-                                Ok(_) | Err(_) => true,
-                            }
+                            && tcp.guest_read_shutdown.as_ref().map_or_else(
+                                || match ioctl_fionread(
+                                    tcp.descriptor
+                                        .socket()
+                                        .expect("guest endpoint descriptor missing"),
+                                ) {
+                                    Ok(0) => false,
+                                    Ok(_) | Err(_) => true,
+                                },
+                                GuestTcpReadShutdown::has_unread_data,
+                            )
                 });
         let socket = self
             .sockets
@@ -1943,7 +2072,7 @@ impl Reactor {
                         reset_state: GuestTcpResetState::None,
                     }),
                     peek_waitall_threshold: None,
-                    guest_read_shutdown_remaining: None,
+                    guest_read_shutdown: None,
                     abortive_close: false,
                     no_delay: listener_tcp_no_delay,
                     keep_alive: listener_tcp_keep_alive,

--- a/litebox_broker_platform_linux_userland/src/socket/tcp.rs
+++ b/litebox_broker_platform_linux_userland/src/socket/tcp.rs
@@ -103,15 +103,8 @@ pub(super) struct QueuedGuestTcpConnection {
     pub(super) guest_source_lease: GuestSourceLease,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(super) enum GuestTcpSide {
-    Connector,
-    Accepted,
-}
-
 pub(super) struct GuestTcpEndpoint {
     pub(super) connection_id: u64,
-    pub(super) side: GuestTcpSide,
     pub(super) queued_listener_id: Option<u64>,
     reset_state: GuestTcpResetState,
 }
@@ -184,10 +177,6 @@ impl ReactorTcpBindings {
 
     pub(super) fn values(&self) -> impl Iterator<Item = &ReactorTcpBinding> {
         self.wildcard.values().chain(self.exact.values())
-    }
-
-    fn values_mut(&mut self) -> impl Iterator<Item = &mut ReactorTcpBinding> {
-        self.wildcard.values_mut().chain(self.exact.values_mut())
     }
 }
 
@@ -286,7 +275,6 @@ fn consume_synchronous_error(socket: &SocketEntry) -> BrokerResult<()> {
 pub(super) struct ReactorTcpBinding {
     pub(super) socket_id: u64,
     pub(super) guest_binding: GuestSocketBinding,
-    pub(super) listening: bool,
 }
 
 enum ResolvedTcpDestination {
@@ -383,30 +371,6 @@ impl ReactorTcpState {
             .values()
             .find(|binding| binding.socket_id == socket_id)
             .cloned()
-    }
-
-    pub(super) fn mark_listening(&mut self, port: u16, socket_id: u64) -> BrokerResult<()> {
-        let binding = self
-            .bindings
-            .values_mut()
-            .find(|binding| {
-                binding.socket_id == socket_id && binding.guest_binding.requested().port() == port
-            })
-            .ok_or(BrokerError::Internal)?;
-        binding.listening = true;
-        Ok(())
-    }
-
-    pub(super) fn stop_listening(&mut self, port: u16, socket_id: u64) -> BrokerResult<()> {
-        let binding = self
-            .bindings
-            .values_mut()
-            .find(|binding| {
-                binding.socket_id == socket_id && binding.guest_binding.requested().port() == port
-            })
-            .ok_or(BrokerError::Internal)?;
-        binding.listening = false;
-        Ok(())
     }
 }
 
@@ -1163,7 +1127,7 @@ impl Reactor {
                     .and_then(|tcp| tcp.listener.as_ref())
                     .is_some_and(|listener| listener.listening)
             });
-        let mut outcome = shutdown_tcp_socket(
+        let outcome = shutdown_tcp_socket(
             self.sockets.get_mut(&id).ok_or(BrokerError::Internal)?,
             mode,
         );
@@ -1174,15 +1138,6 @@ impl Reactor {
         }
         if was_listening && outcome == Ok(SocketOutcome::Completed(())) {
             self.purge_listener_queue(id);
-            let update = self
-                .sockets
-                .get(&id)
-                .and_then(|socket| socket.guest_local_address)
-                .ok_or(BrokerError::Internal)
-                .and_then(|address| self.tcp.stop_listening(address.port(), id));
-            if let Err(error) = update {
-                outcome = Err(error);
-            }
         }
         outcome
     }
@@ -1200,7 +1155,6 @@ impl Reactor {
         self.tcp.insert_binding(ReactorTcpBinding {
             socket_id: id,
             guest_binding: binding,
-            listening: false,
         })?;
         let socket = self.sockets.get_mut(&id).ok_or(BrokerError::Internal)?;
         socket.guest_local_address = Some(guest_address);
@@ -1441,7 +1395,6 @@ impl Reactor {
             tcp.descriptor = TcpDescriptor::GuestUnix(connector_socket);
             tcp.guest_endpoint = Some(GuestTcpEndpoint {
                 connection_id,
-                side: GuestTcpSide::Connector,
                 queued_listener_id: Some(listener_id),
                 reset_state: GuestTcpResetState::None,
             });
@@ -1515,9 +1468,8 @@ impl Reactor {
             .and_then(|socket| socket.tcp_state().ok())
             .and_then(|tcp| {
                 tcp.guest_endpoint.as_ref().and_then(|endpoint| {
-                    (endpoint.side == GuestTcpSide::Connector)
-                        .then_some(endpoint.queued_listener_id)
-                        .flatten()
+                    endpoint
+                        .queued_listener_id
                         .map(|listener_id| (listener_id, endpoint.connection_id))
                 })
             });
@@ -1814,13 +1766,12 @@ impl Reactor {
             address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, address.port());
         }
         if let Some(binding) = self.tcp.guest_binding(address) {
-            let listener_live = binding.listening
-                && self
-                    .sockets
-                    .get(&binding.socket_id)
-                    .and_then(|listener| listener.tcp_state().ok())
-                    .and_then(|tcp| tcp.listener.as_ref())
-                    .is_some_and(|listener| listener.listening);
+            let listener_live = self
+                .sockets
+                .get(&binding.socket_id)
+                .and_then(|listener| listener.tcp_state().ok())
+                .and_then(|tcp| tcp.listener.as_ref())
+                .is_some_and(|listener| listener.listening);
             if !listener_live {
                 return SocketOutcome::Failed(SocketError::ConnectionRefused);
             }
@@ -1853,6 +1804,10 @@ impl Reactor {
             return Ok(SocketOutcome::Failed(SocketError::InvalidArgument));
         }
         let guest_address = guest_address.ok_or(BrokerError::Internal)?;
+        self.tcp
+            .binding_for_socket(id)
+            .filter(|binding| binding.guest_binding.requested() == guest_address)
+            .ok_or(BrokerError::Internal)?;
         let backlog = usize::try_from(backlog)
             .map_err(|_| BrokerError::UnsupportedOperation)?
             .max(1);
@@ -1875,7 +1830,6 @@ impl Reactor {
                 });
             }
         }
-        self.tcp.mark_listening(guest_address.port(), id)?;
         Ok(SocketOutcome::Completed(guest_address))
     }
 
@@ -2031,7 +1985,6 @@ impl Reactor {
                     listener: None,
                     guest_endpoint: Some(GuestTcpEndpoint {
                         connection_id,
-                        side: GuestTcpSide::Accepted,
                         queued_listener_id: None,
                         reset_state: GuestTcpResetState::None,
                     }),

--- a/litebox_broker_platform_linux_userland/src/socket/tcp.rs
+++ b/litebox_broker_platform_linux_userland/src/socket/tcp.rs
@@ -58,6 +58,8 @@ pub(super) struct TcpSocketState {
     pub(super) listener: Option<GuestTcpListenerState>,
     pub(super) guest_endpoint: Option<GuestTcpEndpoint>,
     pub(super) peek_waitall_threshold: Option<usize>,
+    /// Bytes queued before logical guest read shutdown that may still be read.
+    pub(super) guest_read_shutdown_remaining: Option<usize>,
     pub(super) abortive_close: bool,
     pub(super) no_delay: bool,
     pub(super) keep_alive: bool,
@@ -134,6 +136,7 @@ pub(super) fn create_tcp_transport() -> SocketTransportState {
         listener: None,
         guest_endpoint: None,
         peek_waitall_threshold: None,
+        guest_read_shutdown_remaining: None,
         abortive_close: false,
         no_delay: false,
         keep_alive: false,
@@ -553,10 +556,11 @@ pub(super) fn receive_socket(
     if socket.kind() != SocketKind::Tcp {
         return Ok(ReactorReceiveOutcome::Failed(SocketError::InvalidArgument));
     }
-    if socket.read_shutdown && socket.tcp_state()?.descriptor.is_guest() {
+    let guest_read_shutdown_remaining = socket.tcp_state()?.guest_read_shutdown_remaining;
+    if guest_read_shutdown_remaining == Some(0) {
         return Ok(ReactorReceiveOutcome::EndOfStream);
     }
-    if guest_reset_pending(socket)? {
+    if guest_read_shutdown_remaining.is_none() && guest_reset_pending(socket)? {
         let available = ioctl_fionread(socket.tcp_state()?.descriptor.socket()?)
             .map_err(broker_error_from_errno)?;
         if available == 0 {
@@ -697,6 +701,9 @@ fn receive_socket_once(
     mut data: Vec<u8>,
     flags: LinuxRecvFlags,
 ) -> BrokerResult<ReactorReceiveOutcome> {
+    if let Some(remaining) = socket.tcp_state()?.guest_read_shutdown_remaining {
+        data.truncate(data.len().min(remaining));
+    }
     loop {
         match recv(
             socket.tcp_state()?.descriptor.socket()?,
@@ -716,6 +723,16 @@ fn receive_socket_once(
             Ok((_buffer, received)) => {
                 confirm_tcp_connected(socket);
                 data.truncate(received);
+                if !flags.contains(LinuxRecvFlags::PEEK)
+                    && let Some(remaining) = socket
+                        .tcp_state_mut()?
+                        .guest_read_shutdown_remaining
+                        .as_mut()
+                {
+                    *remaining = remaining
+                        .checked_sub(received)
+                        .ok_or(BrokerError::Internal)?;
+                }
                 let terminal_readable = socket.read_shutdown
                     || socket
                         .snapshot
@@ -862,6 +879,17 @@ pub(super) fn shutdown_tcp_socket(
         ),
         _ => return Err(BrokerError::UnsupportedOperation),
     };
+    let guest_read_shutdown_remaining: Option<usize> =
+        if guest_endpoint && shuts_down_read && !socket.read_shutdown {
+            Some(
+                ioctl_fionread(socket.tcp_state()?.descriptor.socket()?)
+                    .map_err(broker_error_from_errno)?
+                    .try_into()
+                    .map_err(|_| BrokerError::Internal)?,
+            )
+        } else {
+            None
+        };
     if let Some(kernel_shutdown) = kernel_shutdown {
         loop {
             match shutdown(socket.tcp_state()?.descriptor.socket()?, kernel_shutdown) {
@@ -878,6 +906,9 @@ pub(super) fn shutdown_tcp_socket(
                 }
             }
         }
+    }
+    if let Some(remaining) = guest_read_shutdown_remaining {
+        socket.tcp_state_mut()?.guest_read_shutdown_remaining = Some(remaining);
     }
     socket.read_shutdown |= shuts_down_read;
     socket.write_shutdown |= shuts_down_write;
@@ -1086,29 +1117,10 @@ impl Reactor {
             self.discard_queued_guest_connections(queued, true);
             return Ok(SocketOutcome::Completed(()));
         }
-        let queued_connection = (mode == ShutdownMode::Abort)
-            .then(|| {
-                self.sockets
-                    .get(&id)
-                    .and_then(|socket| socket.tcp_state().ok())
-                    .and_then(|tcp| tcp.guest_endpoint.as_ref())
-                    .and_then(|endpoint| {
-                        endpoint
-                            .queued_listener_id
-                            .map(|listener_id| (listener_id, endpoint.connector_socket_id))
-                    })
-            })
-            .flatten();
-        let outcome = shutdown_tcp_socket(
+        shutdown_tcp_socket(
             self.sockets.get_mut(&id).ok_or(BrokerError::Internal)?,
             mode,
-        );
-        if outcome == Ok(SocketOutcome::Completed(()))
-            && let Some((listener_id, connector_socket_id)) = queued_connection
-        {
-            self.remove_queued_guest_connection(listener_id, connector_socket_id, false);
-        }
-        outcome
+        )
     }
 
     pub(super) fn bind_tcp_socket(
@@ -1931,6 +1943,7 @@ impl Reactor {
                         reset_state: GuestTcpResetState::None,
                     }),
                     peek_waitall_threshold: None,
+                    guest_read_shutdown_remaining: None,
                     abortive_close: false,
                     no_delay: listener_tcp_no_delay,
                     keep_alive: listener_tcp_keep_alive,

--- a/litebox_broker_platform_linux_userland/src/socket/tcp.rs
+++ b/litebox_broker_platform_linux_userland/src/socket/tcp.rs
@@ -91,6 +91,21 @@ fn guest_tcp_has_unread_data(tcp: &TcpSocketState) -> bool {
         }
 }
 
+#[cfg(test)]
+impl TcpSocketState {
+    pub(super) fn install_empty_guest_read_shutdown_for_test(&mut self) {
+        self.guest_read_shutdown = Some(GuestTcpReadShutdown {
+            queued: Vec::new(),
+            consumed: 0,
+            discarded_data: false,
+        });
+    }
+
+    pub(super) fn has_guest_unread_data_for_test(&self) -> bool {
+        guest_tcp_has_unread_data(self)
+    }
+}
+
 pub(super) enum TcpDescriptor {
     Unrealized,
     NativeInet(OwnedFd),
@@ -2163,32 +2178,4 @@ pub(super) fn consume_pending_guest_reset(socket: &mut SocketEntry) -> BrokerRes
         }
     }
     Ok(consumed)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn guest_read_shutdown_detects_data_awaiting_discard() {
-        let (socket, peer) = socketpair(
-            rustix::net::AddressFamily::UNIX,
-            rustix::net::SocketType::STREAM,
-            LinuxSocketFlags::CLOEXEC | LinuxSocketFlags::NONBLOCK,
-            None,
-        )
-        .unwrap();
-        let SocketTransportState::Tcp(mut tcp) = create_tcp_transport() else {
-            unreachable!();
-        };
-        tcp.descriptor = TcpDescriptor::GuestUnix(socket);
-        tcp.guest_read_shutdown = Some(GuestTcpReadShutdown {
-            queued: Vec::new(),
-            consumed: 0,
-            discarded_data: false,
-        });
-
-        assert_eq!(send(&peer, b"x", LinuxSendFlags::NOSIGNAL).unwrap(), 1);
-        assert!(guest_tcp_has_unread_data(&tcp));
-    }
 }

--- a/litebox_broker_platform_linux_userland/src/socket/tcp.rs
+++ b/litebox_broker_platform_linux_userland/src/socket/tcp.rs
@@ -96,7 +96,7 @@ pub(super) struct GuestTcpListenerState {
 pub(super) struct QueuedGuestTcpConnection {
     pub(super) socket: OwnedFd,
     pub(super) connection_id: u64,
-    pub(super) connector_id: u64,
+    pub(super) connector_socket_id: u64,
     pub(super) connector_session_id: SessionId,
     pub(super) local_address: SocketAddrV4,
     pub(super) remote_address: SocketAddrV4,
@@ -877,7 +877,9 @@ pub(super) fn shutdown_tcp_socket(
         return Ok(SocketOutcome::Failed(SocketError::NotConnected));
     }
     let guest_endpoint = socket.tcp_state()?.descriptor.is_guest();
-    let (kernel_mode, add, clear, shuts_down_read, shuts_down_write) = match mode {
+    // AF_UNIX read shutdown changes peer write behavior, so guest read
+    // shutdown remains logical while write shutdown reaches the kernel.
+    let (kernel_shutdown, add, clear, shuts_down_read, shuts_down_write) = match mode {
         ShutdownMode::Read => (
             (!guest_endpoint).then_some(LinuxShutdown::Read),
             ReadinessFlags::READ,
@@ -905,9 +907,9 @@ pub(super) fn shutdown_tcp_socket(
         ),
         _ => return Err(BrokerError::UnsupportedOperation),
     };
-    if let Some(kernel_mode) = kernel_mode {
+    if let Some(kernel_shutdown) = kernel_shutdown {
         loop {
-            match shutdown(socket.tcp_state()?.descriptor.socket()?, kernel_mode) {
+            match shutdown(socket.tcp_state()?.descriptor.socket()?, kernel_shutdown) {
                 Ok(()) => break,
                 Err(Errno::INTR) => {}
                 Err(Errno::NOTCONN) => {
@@ -1277,7 +1279,7 @@ impl Reactor {
 
     fn connect_guest_tcp_socketpair(
         &mut self,
-        connector_id: u64,
+        connector_socket_id: u64,
         connector_session_id: SessionId,
         listener_id: u64,
         local_address: SocketAddrV4,
@@ -1318,7 +1320,7 @@ impl Reactor {
         {
             let connector = self
                 .sockets
-                .get(&connector_id)
+                .get(&connector_socket_id)
                 .ok_or(PlatformConnectError::PeerUnchanged(BrokerError::Internal))?;
             if connector.connection_status != SocketConnectionStatus::Unconnected
                 || !matches!(
@@ -1347,7 +1349,7 @@ impl Reactor {
                 let status = SocketConnectionStatus::Failed(SocketError::ConnectionRefused);
                 let connector = self
                     .sockets
-                    .get_mut(&connector_id)
+                    .get_mut(&connector_socket_id)
                     .ok_or(PlatformConnectError::PeerUnchanged(BrokerError::Internal))?;
                 connector.connection_status = status;
                 update_snapshot(connector, Some(status), ReadinessFlags::ERROR)
@@ -1380,13 +1382,13 @@ impl Reactor {
         epoll::add(
             &self.epoll,
             &connector_socket,
-            epoll::EventData::new_u64(connector_id),
+            epoll::EventData::new_u64(connector_socket_id),
             active_epoll_events(),
         )
         .map_err(|error| PlatformConnectError::PeerUnchanged(broker_error_from_errno(error)))?;
 
         {
-            let connector = self.sockets.get_mut(&connector_id).ok_or(
+            let connector = self.sockets.get_mut(&connector_socket_id).ok_or(
                 PlatformConnectError::PeerIndeterminate(BrokerError::Internal),
             )?;
             let tcp = connector
@@ -1418,7 +1420,7 @@ impl Reactor {
             .push_back(QueuedGuestTcpConnection {
                 socket: accepted_socket,
                 connection_id,
-                connector_id,
+                connector_socket_id,
                 connector_session_id,
                 local_address,
                 remote_address,
@@ -1431,11 +1433,9 @@ impl Reactor {
             .pending_guest_connection_count = next_pending_count;
 
         if let Err(error) = update_snapshot(
-            self.sockets
-                .get(&connector_id)
-                .ok_or(PlatformConnectError::PeerIndeterminate(
-                    BrokerError::Internal,
-                ))?,
+            self.sockets.get(&connector_socket_id).ok_or(
+                PlatformConnectError::PeerIndeterminate(BrokerError::Internal),
+            )?,
             Some(SocketConnectionStatus::Connected),
             ReadinessFlags::WRITE,
         ) {
@@ -1571,7 +1571,7 @@ impl Reactor {
     ) {
         for connection in queued {
             self.release_queued_guest_connection(connection.connector_session_id);
-            if let Some(connector) = self.sockets.get_mut(&connection.connector_id)
+            if let Some(connector) = self.sockets.get_mut(&connection.connector_socket_id)
                 && let Ok(tcp) = connector.tcp_state_mut()
                 && let Some(endpoint) = tcp.guest_endpoint.as_mut()
                 && endpoint.connection_id == connection.connection_id
@@ -1579,7 +1579,7 @@ impl Reactor {
                 endpoint.queued_listener_id = None;
             }
             if reset_connectors {
-                self.mark_guest_socket_reset(connection.connector_id);
+                self.mark_guest_socket_reset(connection.connector_socket_id);
             }
         }
         self.sessions
@@ -1644,7 +1644,7 @@ impl Reactor {
             return false;
         };
         self.release_queued_guest_connection(connection.connector_session_id);
-        if let Some(connector) = self.sockets.get_mut(&connection.connector_id)
+        if let Some(connector) = self.sockets.get_mut(&connection.connector_socket_id)
             && let Ok(tcp) = connector.tcp_state_mut()
             && let Some(endpoint) = tcp.guest_endpoint.as_mut()
             && endpoint.connection_id == connection_id
@@ -1652,7 +1652,7 @@ impl Reactor {
             endpoint.queued_listener_id = None;
         }
         if reset_connector {
-            self.mark_guest_socket_reset(connection.connector_id);
+            self.mark_guest_socket_reset(connection.connector_socket_id);
         }
         let _ = self.publish_listener_queue_readiness(listener_id);
         self.sessions
@@ -1962,14 +1962,14 @@ impl Reactor {
         let QueuedGuestTcpConnection {
             socket,
             connection_id,
-            connector_id,
+            connector_socket_id,
             connector_session_id,
             local_address,
             remote_address,
             guest_source_lease,
         } = queued;
         self.release_queued_guest_connection(connector_session_id);
-        if let Some(connector) = self.sockets.get_mut(&connector_id)
+        if let Some(connector) = self.sockets.get_mut(&connector_socket_id)
             && let Ok(tcp) = connector.tcp_state_mut()
             && let Some(endpoint) = tcp.guest_endpoint.as_mut()
             && endpoint.connection_id == connection_id
@@ -2038,15 +2038,28 @@ pub(super) fn consume_pending_guest_reset(socket: &mut SocketEntry) -> BrokerRes
         true
     };
     if consumed {
-        let mut snapshot = socket
-            .snapshot
-            .lock()
-            .expect("Linux socket snapshot mutex poisoned");
-        if snapshot.pending_error == Some(SocketError::ConnectionReset) {
-            snapshot.pending_error = None;
-        }
-        if snapshot.pending_error.is_none() {
-            snapshot.readiness = ReadinessFlags(snapshot.readiness.0 & !ReadinessFlags::ERROR.0);
+        let cleared_readiness = {
+            let mut snapshot = socket
+                .snapshot
+                .lock()
+                .expect("Linux socket snapshot mutex poisoned");
+            if snapshot.pending_error == Some(SocketError::ConnectionReset) {
+                snapshot.pending_error = None;
+            }
+            if snapshot.pending_error.is_none()
+                && snapshot.readiness.contains(ReadinessFlags::ERROR)
+            {
+                snapshot.readiness =
+                    ReadinessFlags(snapshot.readiness.0 & !ReadinessFlags::ERROR.0);
+                Some(snapshot.readiness)
+            } else {
+                None
+            }
+        };
+        if let Some(readiness) = cleared_readiness {
+            // The synchronous operation reports the reset even if its
+            // readiness notification cannot be delivered.
+            let _ = socket.readiness.publish(readiness);
         }
     }
     Ok(consumed)

--- a/litebox_broker_platform_linux_userland/src/socket/tcp.rs
+++ b/litebox_broker_platform_linux_userland/src/socket/tcp.rs
@@ -37,7 +37,6 @@ use super::{
 
 pub(super) struct AcceptedEndpoints {
     pub(super) local_address: SocketAddrV4,
-    pub(super) remote_address: SocketAddrV4,
     pub(super) guest_source_lease: GuestSourceLease,
 }
 
@@ -88,23 +87,20 @@ impl TcpDescriptor {
 }
 
 pub(super) struct GuestTcpListenerState {
-    pub(super) listening: bool,
     pub(super) backlog: usize,
     pub(super) queue: VecDeque<QueuedGuestTcpConnection>,
 }
 
 pub(super) struct QueuedGuestTcpConnection {
     pub(super) socket: OwnedFd,
-    pub(super) connection_id: u64,
     pub(super) connector_socket_id: u64,
     pub(super) connector_session_id: SessionId,
     pub(super) local_address: SocketAddrV4,
-    pub(super) remote_address: SocketAddrV4,
     pub(super) guest_source_lease: GuestSourceLease,
 }
 
 pub(super) struct GuestTcpEndpoint {
-    pub(super) connection_id: u64,
+    pub(super) connector_socket_id: u64,
     pub(super) queued_listener_id: Option<u64>,
     reset_state: GuestTcpResetState,
 }
@@ -145,22 +141,11 @@ pub(super) fn create_tcp_transport() -> SocketTransportState {
 }
 
 /// Reactor-owned realization of guest TCP bindings and queued connections.
+#[derive(Default)]
 pub(super) struct ReactorTcpState {
     pub(super) bindings: ReactorTcpBindings,
     pub(super) queued_guest_connection_count: usize,
-    next_guest_connection_id: u64,
     pub(super) peek_cache: Option<PeekCache>,
-}
-
-impl Default for ReactorTcpState {
-    fn default() -> Self {
-        Self {
-            bindings: ReactorTcpBindings::default(),
-            queued_guest_connection_count: 0,
-            next_guest_connection_id: 1,
-            peek_cache: None,
-        }
-    }
 }
 
 #[derive(Default)]
@@ -290,12 +275,6 @@ impl ReactorTcpState {
         self.bindings.clear();
         self.queued_guest_connection_count = 0;
         self.peek_cache = None;
-    }
-
-    fn allocate_guest_connection_id(&mut self) -> BrokerResult<u64> {
-        let id = self.next_guest_connection_id;
-        self.next_guest_connection_id = id.checked_add(1).ok_or(BrokerError::ResourceExhausted)?;
-        Ok(id)
     }
 
     pub(super) fn insert_binding(&mut self, binding: ReactorTcpBinding) -> BrokerResult<()> {
@@ -843,35 +822,11 @@ pub(super) fn shutdown_tcp_socket(
         socket.tcp_state_mut()?.abortive_close = true;
         return Ok(SocketOutcome::Completed(()));
     }
-    let stop_listening = mode == ShutdownMode::StopListening;
-    let listening = socket
-        .tcp_state()?
-        .listener
-        .as_ref()
-        .is_some_and(|listener| listener.listening);
-    if stop_listening {
-        if !listening {
-            return Ok(SocketOutcome::Failed(SocketError::NotConnected));
-        }
-    } else if listening {
-        return Ok(SocketOutcome::Failed(SocketError::NotConnected));
+    if mode == ShutdownMode::StopListening {
+        return Err(BrokerError::Internal);
     }
-    if stop_listening {
-        socket
-            .tcp_state_mut()?
-            .listener
-            .as_mut()
-            .ok_or(BrokerError::Internal)?
-            .listening = false;
-        socket.tcp_state_mut()?.peek_waitall_threshold = None;
-        socket.read_shutdown = true;
-        socket.connection_status = SocketConnectionStatus::Failed(SocketError::NotConnected);
-        let _ = update_snapshot(
-            socket,
-            Some(SocketConnectionStatus::Failed(SocketError::NotConnected)),
-            ReadinessFlags::WRITE | ReadinessFlags::HANGUP,
-        );
-        return Ok(SocketOutcome::Completed(()));
+    if socket.tcp_state()?.listener.is_some() {
+        return Ok(SocketOutcome::Failed(SocketError::NotConnected));
     }
     if matches!(socket.tcp_state()?.descriptor, TcpDescriptor::Unrealized) {
         return Ok(SocketOutcome::Failed(SocketError::NotConnected));
@@ -1108,6 +1063,29 @@ impl Reactor {
         {
             self.tcp.peek_cache = None;
         }
+        if mode == ShutdownMode::StopListening {
+            let queued = {
+                let socket = self.sockets.get_mut(&id).ok_or(BrokerError::Internal)?;
+                if socket.kind() != SocketKind::Tcp {
+                    return Err(BrokerError::Internal);
+                }
+                let Some(listener) = socket.tcp_state_mut()?.listener.take() else {
+                    return Ok(SocketOutcome::Failed(SocketError::NotConnected));
+                };
+                socket.tcp_state_mut()?.peek_waitall_threshold = None;
+                socket.read_shutdown = true;
+                socket.connection_status =
+                    SocketConnectionStatus::Failed(SocketError::NotConnected);
+                let _ = update_snapshot(
+                    socket,
+                    Some(SocketConnectionStatus::Failed(SocketError::NotConnected)),
+                    ReadinessFlags::WRITE | ReadinessFlags::HANGUP,
+                );
+                listener.queue
+            };
+            self.discard_queued_guest_connections(queued, true);
+            return Ok(SocketOutcome::Completed(()));
+        }
         let queued_connection = (mode == ShutdownMode::Abort)
             .then(|| {
                 self.sockets
@@ -1117,29 +1095,18 @@ impl Reactor {
                     .and_then(|endpoint| {
                         endpoint
                             .queued_listener_id
-                            .map(|listener_id| (listener_id, endpoint.connection_id))
+                            .map(|listener_id| (listener_id, endpoint.connector_socket_id))
                     })
             })
             .flatten();
-        let was_listening = mode == ShutdownMode::StopListening
-            && self.sockets.get(&id).is_some_and(|socket| {
-                socket
-                    .tcp_state()
-                    .ok()
-                    .and_then(|tcp| tcp.listener.as_ref())
-                    .is_some_and(|listener| listener.listening)
-            });
         let outcome = shutdown_tcp_socket(
             self.sockets.get_mut(&id).ok_or(BrokerError::Internal)?,
             mode,
         );
         if outcome == Ok(SocketOutcome::Completed(()))
-            && let Some((listener_id, connection_id)) = queued_connection
+            && let Some((listener_id, connector_socket_id)) = queued_connection
         {
-            self.remove_queued_guest_connection(listener_id, connection_id, false);
-        }
-        if was_listening && outcome == Ok(SocketOutcome::Completed(())) {
-            self.purge_listener_queue(id);
+            self.remove_queued_guest_connection(listener_id, connector_socket_id, false);
         }
         outcome
     }
@@ -1219,7 +1186,6 @@ impl Reactor {
                 session_id,
                 listener_id,
                 concrete_address,
-                source_address,
                 guest_source_lease,
             );
         }
@@ -1283,9 +1249,9 @@ impl Reactor {
         connector_session_id: SessionId,
         listener_id: u64,
         local_address: SocketAddrV4,
-        remote_address: SocketAddrV4,
         guest_source_lease: GuestSourceLease,
     ) -> core::result::Result<SocketConnectionStatus, PlatformConnectError> {
+        let source_address = guest_source_lease.source_address();
         let combined_count = self
             .sockets
             .len()
@@ -1342,7 +1308,6 @@ impl Reactor {
                 .map_err(PlatformConnectError::PeerUnchanged)?
                 .listener
                 .as_ref()
-                .filter(|listener| listener.listening)
                 .ok_or(PlatformConnectError::PeerUnchanged(BrokerError::Internal))?;
             if listener.queue.len() >= listener.backlog {
                 drop(guest_source_lease);
@@ -1368,10 +1333,6 @@ impl Reactor {
             .queue
             .try_reserve(1)
             .map_err(|_| PlatformConnectError::PeerUnchanged(BrokerError::OutOfMemory))?;
-        let connection_id = self
-            .tcp
-            .allocate_guest_connection_id()
-            .map_err(PlatformConnectError::PeerUnchanged)?;
         let (connector_socket, accepted_socket) = socketpair(
             rustix::net::AddressFamily::UNIX,
             rustix::net::SocketType::STREAM,
@@ -1396,17 +1357,17 @@ impl Reactor {
                 .map_err(PlatformConnectError::PeerIndeterminate)?;
             tcp.descriptor = TcpDescriptor::GuestUnix(connector_socket);
             tcp.guest_endpoint = Some(GuestTcpEndpoint {
-                connection_id,
+                connector_socket_id,
                 queued_listener_id: Some(listener_id),
                 reset_state: GuestTcpResetState::None,
             });
-            connector.guest_local_address = Some(remote_address);
+            connector.guest_local_address = Some(source_address);
             connector.connection_status = SocketConnectionStatus::Connected;
             connector
                 .snapshot
                 .lock()
                 .expect("Linux socket snapshot mutex poisoned")
-                .local_address = Some(remote_address);
+                .local_address = Some(source_address);
         }
         self.sockets
             .get_mut(&listener_id)
@@ -1419,11 +1380,9 @@ impl Reactor {
             .queue
             .push_back(QueuedGuestTcpConnection {
                 socket: accepted_socket,
-                connection_id,
                 connector_socket_id,
                 connector_session_id,
                 local_address,
-                remote_address,
                 guest_source_lease,
             });
         self.tcp.queued_guest_connection_count = combined_count - self.sockets.len();
@@ -1439,11 +1398,11 @@ impl Reactor {
             Some(SocketConnectionStatus::Connected),
             ReadinessFlags::WRITE,
         ) {
-            self.remove_queued_guest_connection(listener_id, connection_id, false);
+            self.remove_queued_guest_connection(listener_id, connector_socket_id, false);
             return Err(PlatformConnectError::PeerIndeterminate(error));
         }
         if let Err(error) = self.publish_listener_queue_readiness(listener_id) {
-            self.remove_queued_guest_connection(listener_id, connection_id, false);
+            self.remove_queued_guest_connection(listener_id, connector_socket_id, false);
             return Err(PlatformConnectError::PeerIndeterminate(error));
         }
         Ok(SocketConnectionStatus::Connected)
@@ -1470,7 +1429,7 @@ impl Reactor {
                 tcp.guest_endpoint.as_ref().and_then(|endpoint| {
                     endpoint
                         .queued_listener_id
-                        .map(|listener_id| (listener_id, endpoint.connection_id))
+                        .map(|listener_id| (listener_id, endpoint.connector_socket_id))
                 })
             });
         let abortive_close = self
@@ -1479,20 +1438,20 @@ impl Reactor {
             .and_then(|socket| socket.tcp_state().ok())
             .is_some_and(|tcp| tcp.abortive_close);
         if (session_closing || abortive_close)
-            && let Some((listener_id, connection_id)) = queued_connection
+            && let Some((listener_id, connector_socket_id)) = queued_connection
         {
-            self.remove_queued_guest_connection(listener_id, connection_id, false);
+            self.remove_queued_guest_connection(listener_id, connector_socket_id, false);
         }
-        let guest_connection = self
+        let guest_connector_socket_id = self
             .sockets
             .get(&id)
             .and_then(|socket| socket.tcp_state().ok())
             .and_then(|tcp| {
                 tcp.guest_endpoint
                     .as_ref()
-                    .map(|endpoint| endpoint.connection_id)
+                    .map(|endpoint| endpoint.connector_socket_id)
             });
-        let reset_peer = guest_connection.is_some()
+        let reset_peer = guest_connector_socket_id.is_some()
             && self
                 .sockets
                 .get(&id)
@@ -1531,12 +1490,11 @@ impl Reactor {
         if let Some(address) = guest_local_address {
             self.tcp.remove_binding(address.port(), id);
         }
-        if let Some(listener) = tcp.listener.as_mut() {
-            let queued = core::mem::take(&mut listener.queue);
-            self.discard_queued_guest_connections(queued, true);
+        if let Some(listener) = tcp.listener.take() {
+            self.discard_queued_guest_connections(listener.queue, true);
         }
-        if reset_peer && let Some(connection_id) = guest_connection {
-            self.mark_guest_peer_reset(connection_id, id);
+        if reset_peer && let Some(connector_socket_id) = guest_connector_socket_id {
+            self.mark_guest_peer_reset(connector_socket_id, id);
         }
         if let Some(session) = self.sessions.get_mut(&session_id) {
             session.live_socket_count = session
@@ -1574,7 +1532,7 @@ impl Reactor {
             if let Some(connector) = self.sockets.get_mut(&connection.connector_socket_id)
                 && let Ok(tcp) = connector.tcp_state_mut()
                 && let Some(endpoint) = tcp.guest_endpoint.as_mut()
-                && endpoint.connection_id == connection.connection_id
+                && endpoint.connector_socket_id == connection.connector_socket_id
             {
                 endpoint.queued_listener_id = None;
             }
@@ -1584,18 +1542,6 @@ impl Reactor {
         }
         self.sessions
             .retain(|_, session| retain_session_state(session));
-    }
-
-    fn purge_listener_queue(&mut self, listener_id: u64) {
-        let queued = self
-            .sockets
-            .get_mut(&listener_id)
-            .and_then(|listener| listener.tcp_state_mut().ok())
-            .and_then(|tcp| tcp.listener.as_mut())
-            .map(|listener| core::mem::take(&mut listener.queue))
-            .unwrap_or_default();
-        self.discard_queued_guest_connections(queued, true);
-        let _ = self.publish_listener_queue_readiness(listener_id);
     }
 
     pub(super) fn purge_connector_session_queues(&mut self, session_id: SessionId) {
@@ -1611,12 +1557,12 @@ impl Reactor {
                             .iter()
                             .find(|connection| connection.connector_session_id == session_id)
                     })
-                    .map(|connection| (*listener_id, connection.connection_id))
+                    .map(|connection| (*listener_id, connection.connector_socket_id))
             });
-            let Some((listener_id, connection_id)) = queued else {
+            let Some((listener_id, connector_socket_id)) = queued else {
                 break;
             };
-            if !self.remove_queued_guest_connection(listener_id, connection_id, false) {
+            if !self.remove_queued_guest_connection(listener_id, connector_socket_id, false) {
                 break;
             }
         }
@@ -1625,7 +1571,7 @@ impl Reactor {
     fn remove_queued_guest_connection(
         &mut self,
         listener_id: u64,
-        connection_id: u64,
+        connector_socket_id: u64,
         reset_connector: bool,
     ) -> bool {
         let connection = self
@@ -1637,7 +1583,7 @@ impl Reactor {
                 listener
                     .queue
                     .iter()
-                    .position(|connection| connection.connection_id == connection_id)
+                    .position(|connection| connection.connector_socket_id == connector_socket_id)
                     .and_then(|index| listener.queue.remove(index))
             });
         let Some(connection) = connection else {
@@ -1647,7 +1593,7 @@ impl Reactor {
         if let Some(connector) = self.sockets.get_mut(&connection.connector_socket_id)
             && let Ok(tcp) = connector.tcp_state_mut()
             && let Some(endpoint) = tcp.guest_endpoint.as_mut()
-            && endpoint.connection_id == connection_id
+            && endpoint.connector_socket_id == connector_socket_id
         {
             endpoint.queued_listener_id = None;
         }
@@ -1660,14 +1606,14 @@ impl Reactor {
         true
     }
 
-    fn mark_guest_peer_reset(&mut self, connection_id: u64, excluded_id: u64) {
+    fn mark_guest_peer_reset(&mut self, connector_socket_id: u64, excluded_id: u64) {
         let peer_id = self.sockets.iter().find_map(|(id, socket)| {
             (*id != excluded_id
                 && socket
                     .tcp_state()
                     .ok()
                     .and_then(|tcp| tcp.guest_endpoint.as_ref())
-                    .is_some_and(|endpoint| endpoint.connection_id == connection_id))
+                    .is_some_and(|endpoint| endpoint.connector_socket_id == connector_socket_id))
             .then_some(*id)
         });
         if let Some(peer_id) = peer_id {
@@ -1739,7 +1685,7 @@ impl Reactor {
         }
     }
 
-    fn purge_failed_accept_setup(&mut self, listener_id: u64, connection_id: u64) {
+    fn purge_failed_accept_setup(&mut self, listener_id: u64, connector_socket_id: u64) {
         if let Some(socket) = self
             .sockets
             .get(&listener_id)
@@ -1749,13 +1695,13 @@ impl Reactor {
                 listener
                     .queue
                     .iter()
-                    .find(|connection| connection.connection_id == connection_id)
+                    .find(|connection| connection.connector_socket_id == connector_socket_id)
             })
             .map(|connection| &connection.socket)
         {
             let _ = epoll::delete(&self.epoll, socket);
         }
-        self.remove_queued_guest_connection(listener_id, connection_id, true);
+        self.remove_queued_guest_connection(listener_id, connector_socket_id, true);
     }
 
     fn resolve_guest_destination(
@@ -1771,7 +1717,7 @@ impl Reactor {
                 .get(&binding.socket_id)
                 .and_then(|listener| listener.tcp_state().ok())
                 .and_then(|tcp| tcp.listener.as_ref())
-                .is_some_and(|listener| listener.listening);
+                .is_some();
             if !listener_live {
                 return SocketOutcome::Failed(SocketError::ConnectionRefused);
             }
@@ -1819,12 +1765,10 @@ impl Reactor {
         }
         match socket.tcp_state_mut()?.listener.as_mut() {
             Some(listener) => {
-                listener.listening = true;
                 listener.backlog = backlog;
             }
             None => {
                 socket.tcp_state_mut()?.listener = Some(GuestTcpListenerState {
-                    listening: true,
                     backlog,
                     queue: VecDeque::new(),
                 });
@@ -1850,7 +1794,7 @@ impl Reactor {
             listener_tcp_keep_alive,
             queue_length,
             accepted_local_address,
-            accepted_connection_id,
+            accepted_connector_socket_id,
             accepted_connector_session_id,
         ) = {
             let listener = self
@@ -1858,8 +1802,7 @@ impl Reactor {
                 .get(&listener_id)
                 .ok_or(BrokerError::Internal)?;
             let tcp = listener.tcp_state()?;
-            let Some(listener_state) = tcp.listener.as_ref().filter(|listener| listener.listening)
-            else {
+            let Some(listener_state) = tcp.listener.as_ref() else {
                 return Ok(SocketOutcome::Failed(SocketError::NotConnected));
             };
             (
@@ -1874,7 +1817,7 @@ impl Reactor {
                 listener_state
                     .queue
                     .front()
-                    .map(|queued| queued.connection_id),
+                    .map(|queued| queued.connector_socket_id),
                 listener_state
                     .queue
                     .front()
@@ -1885,7 +1828,8 @@ impl Reactor {
             self.publish_listener_queue_readiness(listener_id)?;
             return Err(BrokerError::WouldBlock);
         }
-        let accepted_connection_id = accepted_connection_id.ok_or(BrokerError::Internal)?;
+        let accepted_connector_socket_id =
+            accepted_connector_socket_id.ok_or(BrokerError::Internal)?;
         let accepted_connector_session_id =
             accepted_connector_session_id.ok_or(BrokerError::Internal)?;
         let listener_session = self
@@ -1922,7 +1866,7 @@ impl Reactor {
                 active_epoll_events(),
             ) {
                 let error = broker_error_from_errno(error);
-                self.purge_failed_accept_setup(listener_id, accepted_connection_id);
+                self.purge_failed_accept_setup(listener_id, accepted_connector_socket_id);
                 return Err(error);
             }
         }
@@ -1935,17 +1879,17 @@ impl Reactor {
             snapshot.readiness = ReadinessFlags::WRITE;
         }
         if let Err(error) = readiness.publish(ReadinessFlags::WRITE) {
-            self.purge_failed_accept_setup(listener_id, accepted_connection_id);
+            self.purge_failed_accept_setup(listener_id, accepted_connector_socket_id);
             return Err(error);
         }
         if queue_length > 1
             && let Err(error) = self.publish_listener_queue_readiness(listener_id)
         {
-            self.purge_failed_accept_setup(listener_id, accepted_connection_id);
+            self.purge_failed_accept_setup(listener_id, accepted_connector_socket_id);
             return Err(error);
         }
         if !lifecycle.activate() {
-            self.purge_failed_accept_setup(listener_id, accepted_connection_id);
+            self.purge_failed_accept_setup(listener_id, accepted_connector_socket_id);
             return Err(BrokerError::Internal);
         }
         let queued = self
@@ -1961,18 +1905,16 @@ impl Reactor {
             .ok_or(BrokerError::Internal)?;
         let QueuedGuestTcpConnection {
             socket,
-            connection_id,
             connector_socket_id,
             connector_session_id,
             local_address,
-            remote_address,
             guest_source_lease,
         } = queued;
         self.release_queued_guest_connection(connector_session_id);
         if let Some(connector) = self.sockets.get_mut(&connector_socket_id)
             && let Ok(tcp) = connector.tcp_state_mut()
             && let Some(endpoint) = tcp.guest_endpoint.as_mut()
-            && endpoint.connection_id == connection_id
+            && endpoint.connector_socket_id == connector_socket_id
         {
             endpoint.queued_listener_id = None;
         }
@@ -1984,7 +1926,7 @@ impl Reactor {
                     descriptor: TcpDescriptor::GuestUnix(socket),
                     listener: None,
                     guest_endpoint: Some(GuestTcpEndpoint {
-                        connection_id,
+                        connector_socket_id,
                         queued_listener_id: None,
                         reset_state: GuestTcpResetState::None,
                     }),
@@ -2011,7 +1953,6 @@ impl Reactor {
         }
         Ok(SocketOutcome::Completed(AcceptedEndpoints {
             local_address,
-            remote_address,
             guest_source_lease,
         }))
     }

--- a/litebox_broker_platform_linux_userland/src/socket/tcp.rs
+++ b/litebox_broker_platform_linux_userland/src/socket/tcp.rs
@@ -590,7 +590,18 @@ pub(super) fn receive_socket(
         {
             *peek_cache = None;
         }
-        return receive_guest_read_shutdown(socket, length, flags, peek_offset, peek_length);
+        if let Some(outcome) =
+            receive_guest_read_shutdown(socket, length, flags, peek_offset, peek_length)?
+        {
+            return Ok(outcome);
+        }
+        if guest_reset_pending(socket)? {
+            if !consume_pending_guest_reset(socket)? {
+                return Err(BrokerError::Internal);
+            }
+            return Ok(ReactorReceiveOutcome::Failed(SocketError::ConnectionReset));
+        }
+        return Ok(ReactorReceiveOutcome::EndOfStream);
     }
     if guest_reset_pending(socket)? {
         let available = ioctl_fionread(socket.tcp_state()?.descriptor.socket()?)
@@ -789,7 +800,7 @@ fn receive_guest_read_shutdown(
     flags: ReceiveFlags,
     peek_offset: usize,
     peek_length: usize,
-) -> BrokerResult<ReactorReceiveOutcome> {
+) -> BrokerResult<Option<ReactorReceiveOutcome>> {
     let peek = flags.contains(ReceiveFlags::PEEK);
     let (relative_start, relative_end) = if peek {
         let peek_end = peek_offset
@@ -818,12 +829,15 @@ fn receive_guest_read_shutdown(
         .guest_read_shutdown
         .as_mut()
         .ok_or(BrokerError::Internal)?;
+    if shutdown.queued.is_empty() {
+        return Ok(None);
+    }
     let start = shutdown
         .consumed
         .checked_add(relative_start)
         .ok_or(BrokerError::Internal)?;
     if start >= shutdown.queued.len() {
-        return Ok(ReactorReceiveOutcome::EndOfStream);
+        return Ok(Some(ReactorReceiveOutcome::EndOfStream));
     }
     let end = shutdown
         .consumed
@@ -841,7 +855,7 @@ fn receive_guest_read_shutdown(
             shutdown.consumed = 0;
         }
     }
-    Ok(ReactorReceiveOutcome::Received(data))
+    Ok(Some(ReactorReceiveOutcome::Received(data)))
 }
 
 fn capture_guest_read_shutdown(

--- a/litebox_broker_platform_linux_userland/src/socket/tcp.rs
+++ b/litebox_broker_platform_linux_userland/src/socket/tcp.rs
@@ -3,42 +3,42 @@
 
 //! Linux TCP reactor state and transport-specific helpers.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::net::{Ipv4Addr, SocketAddrV4};
 use std::os::fd::OwnedFd;
 use std::sync::{Arc, Mutex};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use litebox_broker_core::readiness::ReadinessRegistration;
-use litebox_broker_core::socket::{GUEST_IPV4_ADDRESS, GuestSocketBinding, PlatformConnectError};
+use litebox_broker_core::socket::{
+    GUEST_IPV4_ADDRESS, GuestSocketBinding, GuestSourceLease, PlatformConnectError,
+};
 use litebox_broker_core::{BrokerError, Result as BrokerResult, SessionId};
 use litebox_broker_protocol::readiness::ReadinessFlags;
 use litebox_broker_protocol::socket::{
     MAX_SOCKET_PEEK_SIZE, MAX_SOCKET_TRANSFER_SIZE, ReceiveFlags, ShutdownMode,
     SocketConnectionStatus, SocketError, SocketOutcome, TcpOptionName, TcpOptionValue,
 };
-use rustix::event::{PollFd, PollFlags, Timespec, epoll, poll};
+use rustix::event::epoll;
 use rustix::io::{Errno, ioctl_fionread};
 use rustix::net::ipproto;
 use rustix::net::{
     RecvFlags as LinuxRecvFlags, SendFlags as LinuxSendFlags, Shutdown as LinuxShutdown,
-    SocketFlags as LinuxSocketFlags, acceptfrom_with, bind, connect, listen, recv, send, shutdown,
-    socket_with, sockopt,
+    SocketFlags as LinuxSocketFlags, connect, recv, send, shutdown, socket_with, socketpair,
+    sockopt,
 };
 
 use super::{
     Reactor, SocketEntry, SocketKind, SocketLifecycle, SocketSnapshot, SocketTransportState,
-    broker_error_from_errno, can_consume_synchronous_error, local_socket_address,
-    retain_session_state, socket_error_from_errno, socket_operation_error_from_errno,
-    take_socket_error, update_snapshot, zeroed_vec,
+    broker_error_from_errno, can_consume_synchronous_error, retain_session_state,
+    socket_error_from_errno, socket_operation_error_from_errno, take_socket_error, update_snapshot,
+    zeroed_vec,
 };
-
-pub(super) const MAX_UNMATCHED_ACCEPTS_PER_COMMAND: usize = 64;
-pub(super) const PENDING_CONNECT_DISCARD_LIFETIME: Duration = Duration::from_mins(5);
 
 pub(super) struct AcceptedEndpoints {
     pub(super) local_address: SocketAddrV4,
     pub(super) remote_address: SocketAddrV4,
+    pub(super) guest_source_lease: GuestSourceLease,
 }
 
 pub(super) enum ReactorReceiveOutcome {
@@ -54,20 +54,73 @@ pub(super) struct PeekCache {
 }
 
 /// Reactor-owned TCP descriptor and transport-specific lifecycle state.
-#[expect(
-    clippy::struct_excessive_bools,
-    reason = "TCP lifecycle and option flags are independent"
-)]
 pub(super) struct TcpSocketState {
-    pub(super) socket: OwnedFd,
-    pub(super) untracked_guest_listener_id: Option<u64>,
+    pub(super) descriptor: TcpDescriptor,
+    pub(super) listener: Option<GuestTcpListenerState>,
+    pub(super) guest_endpoint: Option<GuestTcpEndpoint>,
     pub(super) peek_waitall_threshold: Option<usize>,
-    pub(super) listening: bool,
-    pub(super) was_listener: bool,
     pub(super) abortive_close: bool,
-    pub(super) host_connection: Option<(SocketAddrV4, SocketAddrV4)>,
     pub(super) no_delay: bool,
     pub(super) keep_alive: bool,
+}
+
+pub(super) enum TcpDescriptor {
+    Unrealized,
+    NativeInet(OwnedFd),
+    GuestUnix(OwnedFd),
+}
+
+impl TcpDescriptor {
+    pub(super) fn socket(&self) -> BrokerResult<&OwnedFd> {
+        match self {
+            Self::NativeInet(socket) | Self::GuestUnix(socket) => Ok(socket),
+            Self::Unrealized => Err(BrokerError::Internal),
+        }
+    }
+
+    pub(super) fn is_native(&self) -> bool {
+        matches!(self, Self::NativeInet(_))
+    }
+
+    fn is_guest(&self) -> bool {
+        matches!(self, Self::GuestUnix(_))
+    }
+}
+
+pub(super) struct GuestTcpListenerState {
+    pub(super) listening: bool,
+    pub(super) backlog: usize,
+    pub(super) queue: VecDeque<QueuedGuestTcpConnection>,
+}
+
+pub(super) struct QueuedGuestTcpConnection {
+    pub(super) socket: OwnedFd,
+    pub(super) connection_id: u64,
+    pub(super) connector_id: u64,
+    pub(super) connector_session_id: SessionId,
+    pub(super) local_address: SocketAddrV4,
+    pub(super) remote_address: SocketAddrV4,
+    pub(super) guest_source_lease: GuestSourceLease,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum GuestTcpSide {
+    Connector,
+    Accepted,
+}
+
+pub(super) struct GuestTcpEndpoint {
+    pub(super) connection_id: u64,
+    pub(super) side: GuestTcpSide,
+    pub(super) queued_listener_id: Option<u64>,
+    reset_state: GuestTcpResetState,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum GuestTcpResetState {
+    None,
+    Pending,
+    Reported,
 }
 
 impl SocketEntry {
@@ -86,45 +139,35 @@ impl SocketEntry {
     }
 }
 
-pub(super) fn create_tcp_transport(
-    epoll_fd: &OwnedFd,
-    id: u64,
-) -> BrokerResult<SocketTransportState> {
-    let socket = socket_with(
-        rustix::net::AddressFamily::INET,
-        rustix::net::SocketType::STREAM,
-        LinuxSocketFlags::CLOEXEC | LinuxSocketFlags::NONBLOCK,
-        Some(ipproto::TCP),
-    )
-    .map_err(broker_error_from_errno)?;
-    epoll::add(
-        epoll_fd,
-        &socket,
-        epoll::EventData::new_u64(id),
-        idle_epoll_events(),
-    )
-    .map_err(broker_error_from_errno)?;
-    Ok(SocketTransportState::Tcp(TcpSocketState {
-        socket,
-        untracked_guest_listener_id: None,
+pub(super) fn create_tcp_transport() -> SocketTransportState {
+    SocketTransportState::Tcp(TcpSocketState {
+        descriptor: TcpDescriptor::Unrealized,
+        listener: None,
+        guest_endpoint: None,
         peek_waitall_threshold: None,
-        listening: false,
-        was_listener: false,
         abortive_close: false,
-        host_connection: None,
         no_delay: false,
         keep_alive: false,
-    }))
+    })
 }
 
-/// Reactor-owned realization of guest TCP bindings and pending connections.
-#[derive(Default)]
+/// Reactor-owned realization of guest TCP bindings and queued connections.
 pub(super) struct ReactorTcpState {
     pub(super) bindings: ReactorTcpBindings,
-    pub(super) pending_guest_connections:
-        HashMap<(SocketAddrV4, SocketAddrV4), PendingGuestTcpConnection>,
-    pub(super) retained_connector_count: usize,
+    pub(super) queued_guest_connection_count: usize,
+    next_guest_connection_id: u64,
     pub(super) peek_cache: Option<PeekCache>,
+}
+
+impl Default for ReactorTcpState {
+    fn default() -> Self {
+        Self {
+            bindings: ReactorTcpBindings::default(),
+            queued_guest_connection_count: 0,
+            next_guest_connection_id: 1,
+            peek_cache: None,
+        }
+    }
 }
 
 #[derive(Default)]
@@ -145,15 +188,6 @@ impl ReactorTcpBindings {
 
     fn values_mut(&mut self) -> impl Iterator<Item = &mut ReactorTcpBinding> {
         self.wildcard.values_mut().chain(self.exact.values_mut())
-    }
-
-    #[cfg(test)]
-    pub(super) fn get(&self, port: u16) -> Option<&ReactorTcpBinding> {
-        self.wildcard.get(&port).or_else(|| {
-            self.exact
-                .iter()
-                .find_map(|(address, binding)| (address.port() == port).then_some(binding))
-        })
     }
 }
 
@@ -180,10 +214,6 @@ fn readiness_from_epoll(socket: &SocketEntry, events: epoll::EventFlags) -> Read
         .expect("Linux socket snapshot mutex poisoned")
         .readiness;
     ReadinessFlags(readiness.0 | previous.0)
-}
-
-fn idle_epoll_events() -> epoll::EventFlags {
-    epoll::EventFlags::RDHUP | epoll::EventFlags::ET
 }
 
 fn active_epoll_events() -> epoll::EventFlags {
@@ -252,38 +282,32 @@ fn consume_synchronous_error(socket: &SocketEntry) -> BrokerResult<()> {
     Ok(())
 }
 
-pub(super) struct PendingGuestTcpConnection {
-    pub(super) session_id: super::SessionId,
-    pub(super) guest_address: SocketAddrV4,
-    pub(super) local_address: SocketAddrV4,
-    pub(super) listener_id: u64,
-    pub(super) discard_on_accept: bool,
-    pub(super) discard_until_deadline: bool,
-    pub(super) discard_deadline: Option<Instant>,
-    pub(super) retained_connector: Option<OwnedFd>,
-}
-
-pub(super) enum PendingGuestConnectionMatch {
-    PersistentDiscard,
-    Take(PendingGuestTcpConnection),
-}
-
 #[derive(Clone)]
 pub(super) struct ReactorTcpBinding {
     pub(super) socket_id: u64,
     pub(super) guest_binding: GuestSocketBinding,
-    pub(super) host_address: Option<SocketAddrV4>,
     pub(super) listening: bool,
-    pub(super) requires_backlog_drain: bool,
-    pub(super) untracked_connection_deadline: Option<Instant>,
+}
+
+enum ResolvedTcpDestination {
+    Guest {
+        listener_id: u64,
+        concrete_address: SocketAddrV4,
+    },
+    Native(SocketAddrV4),
 }
 
 impl ReactorTcpState {
     pub(super) fn clear_live_state(&mut self) {
         self.bindings.clear();
-        self.pending_guest_connections.clear();
-        self.retained_connector_count = 0;
+        self.queued_guest_connection_count = 0;
         self.peek_cache = None;
+    }
+
+    fn allocate_guest_connection_id(&mut self) -> BrokerResult<u64> {
+        let id = self.next_guest_connection_id;
+        self.next_guest_connection_id = id.checked_add(1).ok_or(BrokerError::ResourceExhausted)?;
+        Ok(id)
     }
 
     pub(super) fn insert_binding(&mut self, binding: ReactorTcpBinding) -> BrokerResult<()> {
@@ -361,23 +385,6 @@ impl ReactorTcpState {
             .cloned()
     }
 
-    pub(super) fn set_host_address(
-        &mut self,
-        port: u16,
-        socket_id: u64,
-        host_address: SocketAddrV4,
-    ) -> BrokerResult<()> {
-        let binding = self
-            .bindings
-            .values_mut()
-            .find(|binding| {
-                binding.socket_id == socket_id && binding.guest_binding.requested().port() == port
-            })
-            .ok_or(BrokerError::Internal)?;
-        binding.host_address = Some(host_address);
-        Ok(())
-    }
-
     pub(super) fn mark_listening(&mut self, port: u16, socket_id: u64) -> BrokerResult<()> {
         let binding = self
             .bindings
@@ -386,9 +393,6 @@ impl ReactorTcpState {
                 binding.socket_id == socket_id && binding.guest_binding.requested().port() == port
             })
             .ok_or(BrokerError::Internal)?;
-        if binding.host_address.is_none() {
-            return Err(BrokerError::Internal);
-        }
         binding.listening = true;
         Ok(())
     }
@@ -402,118 +406,7 @@ impl ReactorTcpState {
             })
             .ok_or(BrokerError::Internal)?;
         binding.listening = false;
-        binding.requires_backlog_drain = false;
-        binding.untracked_connection_deadline = None;
         Ok(())
-    }
-
-    pub(super) fn defer_untracked_connection(&mut self, listener_id: u64, deadline: Instant) {
-        let binding = self
-            .bindings
-            .values_mut()
-            .find(|binding| binding.socket_id == listener_id)
-            .expect("untracked guest connection listener binding missing");
-        binding.untracked_connection_deadline = Some(
-            binding
-                .untracked_connection_deadline
-                .map_or(deadline, |current| current.max(deadline)),
-        );
-    }
-
-    pub(super) fn persist_discard_marker_for_collision(
-        &mut self,
-        connection: (SocketAddrV4, SocketAddrV4),
-        listener_id: u64,
-        deadline: Instant,
-    ) -> bool {
-        let Some(pending) = self.pending_guest_connections.get_mut(&connection) else {
-            return false;
-        };
-        if !pending.discard_on_accept || pending.listener_id != listener_id {
-            return false;
-        }
-        // A collision can represent both the old ambiguous child and the new
-        // one. Keep dropping this tuple until the refreshed deadline instead
-        // of blocking unrelated connections to the listener. The marker stays
-        // charged to its original session even when another session refreshes
-        // it; identity protection is broker-wide and adds no new record.
-        pending.discard_until_deadline = true;
-        pending.discard_deadline = Some(deadline);
-        true
-    }
-
-    pub(super) fn finish_listener_backlog_drain(&mut self, listener_id: u64) -> BrokerResult<()> {
-        let binding = self
-            .bindings
-            .values_mut()
-            .find(|binding| binding.socket_id == listener_id)
-            .ok_or(BrokerError::Internal)?;
-        // A tuple-unknown connect can still complete after an empty drain
-        // observation, so only its maturation deadline may release that block.
-        binding.requires_backlog_drain = false;
-        Ok(())
-    }
-
-    pub(super) fn take_pending_guest_connection(
-        &mut self,
-        remote_address: SocketAddrV4,
-        local_address: SocketAddrV4,
-    ) -> Option<PendingGuestConnectionMatch> {
-        if self
-            .pending_guest_connections
-            .get(&(remote_address, local_address))
-            .is_some_and(|connection| {
-                connection.discard_on_accept && connection.discard_until_deadline
-            })
-        {
-            return Some(PendingGuestConnectionMatch::PersistentDiscard);
-        }
-        self.pending_guest_connections
-            .remove(&(remote_address, local_address))
-            .map(PendingGuestConnectionMatch::Take)
-    }
-
-    pub(super) fn insert_pending_guest_connection(
-        &mut self,
-        connection: (SocketAddrV4, SocketAddrV4),
-        pending: PendingGuestTcpConnection,
-    ) -> BrokerResult<()> {
-        if self.pending_guest_connections.contains_key(&connection) {
-            return Err(BrokerError::ResourceExhausted);
-        }
-        self.pending_guest_connections.insert(connection, pending);
-        Ok(())
-    }
-}
-
-pub(super) fn listener_backlog_is_nonempty(
-    sockets: &HashMap<u64, SocketEntry>,
-    listener_id: u64,
-) -> bool {
-    let Some(listener) = sockets.get(&listener_id) else {
-        return false;
-    };
-    let Ok(tcp) = listener.tcp_state() else {
-        return false;
-    };
-    if !tcp.listening {
-        return false;
-    }
-    socket_backlog_is_nonempty(&tcp.socket)
-}
-
-fn socket_backlog_is_nonempty(socket: &OwnedFd) -> bool {
-    let no_wait = Timespec {
-        tv_sec: 0,
-        tv_nsec: 0,
-    };
-    loop {
-        let mut poll_fd = [PollFd::new(socket, PollFlags::IN)];
-        match poll(&mut poll_fd, Some(&no_wait)) {
-            Ok(_) => return !poll_fd[0].revents().is_empty(),
-            Err(Errno::INTR) => {}
-            Err(_) => return true,
-        }
     }
 }
 
@@ -533,10 +426,6 @@ fn confirm_tcp_connected(socket: &mut SocketEntry) {
 }
 
 /// Records a terminal native operation while a connect is pending.
-///
-/// A reactor command that can call this helper must subsequently invoke
-/// `Reactor::discard_failed_connect_after_command` after releasing its socket
-/// table borrow.
 fn fail_connect(socket: &mut SocketEntry, error: SocketError) {
     if socket.kind() != SocketKind::Tcp
         || socket.connection_status != SocketConnectionStatus::Connecting
@@ -562,38 +451,52 @@ pub(super) fn connect_tcp_socket(
     id: u64,
     socket: &mut SocketEntry,
     address: SocketAddrV4,
-    guest_listener_id: Option<u64>,
 ) -> core::result::Result<(SocketConnectionStatus, ReadinessFlags), PlatformConnectError> {
-    if let Err(error) = epoll::modify(
-        epoll_fd,
-        &socket
-            .tcp_state()
-            .map_err(PlatformConnectError::PeerUnchanged)?
-            .socket,
-        epoll::EventData::new_u64(id),
-        active_epoll_events(),
-    ) {
-        return Err(PlatformConnectError::PeerUnchanged(
-            broker_error_from_errno(error),
-        ));
-    }
     if socket.connection_status != SocketConnectionStatus::Unconnected {
         return Err(PlatformConnectError::PeerUnchanged(BrokerError::Internal));
     }
-    // Record the first half of the native transition before connect(2). Any
-    // later failure can then be settled or conservatively retired without
-    // reconstructing whether a SYN may have reached a guest listener.
-    socket.connection_status = SocketConnectionStatus::Connecting;
+    let (no_delay, keep_alive, unrealized) = {
+        let tcp = socket
+            .tcp_state()
+            .map_err(PlatformConnectError::PeerUnchanged)?;
+        (
+            tcp.no_delay,
+            tcp.keep_alive,
+            matches!(tcp.descriptor, TcpDescriptor::Unrealized),
+        )
+    };
+    if !unrealized {
+        return Err(PlatformConnectError::PeerUnchanged(BrokerError::Internal));
+    }
+    let native_socket = socket_with(
+        rustix::net::AddressFamily::INET,
+        rustix::net::SocketType::STREAM,
+        LinuxSocketFlags::CLOEXEC | LinuxSocketFlags::NONBLOCK,
+        Some(ipproto::TCP),
+    )
+    .map_err(|error| PlatformConnectError::PeerUnchanged(broker_error_from_errno(error)))?;
+    apply_tcp_options(&native_socket, no_delay, keep_alive)
+        .map_err(PlatformConnectError::PeerUnchanged)?;
+    epoll::add(
+        epoll_fd,
+        &native_socket,
+        epoll::EventData::new_u64(id),
+        active_epoll_events(),
+    )
+    .map_err(|error| PlatformConnectError::PeerUnchanged(broker_error_from_errno(error)))?;
     socket
         .tcp_state_mut()
         .map_err(PlatformConnectError::PeerUnchanged)?
-        .untracked_guest_listener_id = guest_listener_id;
+        .descriptor = TcpDescriptor::NativeInet(native_socket);
+    socket.connection_status = SocketConnectionStatus::Connecting;
     let status = loop {
         match connect(
-            &socket
+            socket
                 .tcp_state()
                 .map_err(PlatformConnectError::PeerIndeterminate)?
-                .socket,
+                .descriptor
+                .socket()
+                .map_err(PlatformConnectError::PeerIndeterminate)?,
             &address,
         ) {
             Ok(()) | Err(Errno::ISCONN) => break SocketConnectionStatus::Connected,
@@ -621,12 +524,6 @@ pub(super) fn connect_tcp_socket(
         }
     };
     socket.connection_status = status;
-    if matches!(status, SocketConnectionStatus::Failed(_)) {
-        socket
-            .tcp_state_mut()
-            .map_err(PlatformConnectError::PeerIndeterminate)?
-            .untracked_guest_listener_id = None;
-    }
     let readiness = match status {
         SocketConnectionStatus::Connected | SocketConnectionStatus::Connecting => {
             if socket.guest_local_address.is_none() {
@@ -651,79 +548,6 @@ pub(super) fn connect_tcp_socket(
     Ok((status, readiness))
 }
 
-pub(super) fn bind_host_socket(
-    socket: &mut SocketEntry,
-    address: SocketAddrV4,
-) -> BrokerResult<SocketOutcome<SocketAddrV4>> {
-    loop {
-        match bind(&socket.tcp_state()?.socket, &address) {
-            Ok(()) => {
-                let local_address = local_socket_address(&socket.tcp_state()?.socket)?;
-                return Ok(SocketOutcome::Completed(local_address));
-            }
-            Err(Errno::INTR) => {}
-            Err(error) => {
-                return Ok(SocketOutcome::Failed(socket_operation_error_from_errno(
-                    error,
-                )?));
-            }
-        }
-    }
-}
-
-pub(super) fn listen_tcp_socket(
-    epoll_fd: &OwnedFd,
-    id: u64,
-    socket: &mut SocketEntry,
-    backlog: u32,
-) -> BrokerResult<SocketOutcome<()>> {
-    if socket.kind() != SocketKind::Tcp {
-        return Ok(SocketOutcome::Failed(SocketError::InvalidArgument));
-    }
-    let backlog = i32::try_from(backlog).map_err(|_| BrokerError::UnsupportedOperation)?;
-    let was_listening = socket.tcp_state()?.listening;
-    if !was_listening {
-        epoll::modify(
-            epoll_fd,
-            &socket.tcp_state()?.socket,
-            epoll::EventData::new_u64(id),
-            active_epoll_events(),
-        )
-        .map_err(broker_error_from_errno)?;
-    }
-    loop {
-        match listen(&socket.tcp_state()?.socket, backlog) {
-            Ok(()) => break,
-            Err(Errno::INTR) => {}
-            Err(error) => {
-                if !was_listening {
-                    epoll::modify(
-                        epoll_fd,
-                        &socket.tcp_state()?.socket,
-                        epoll::EventData::new_u64(id),
-                        idle_epoll_events(),
-                    )
-                    .map_err(broker_error_from_errno)?;
-                }
-                return Ok(SocketOutcome::Failed(socket_operation_error_from_errno(
-                    error,
-                )?));
-            }
-        }
-    }
-    let tcp = socket.tcp_state_mut()?;
-    tcp.listening = true;
-    tcp.was_listener = true;
-    let mut snapshot = socket
-        .snapshot
-        .lock()
-        .expect("Linux socket snapshot mutex poisoned");
-    if !was_listening {
-        snapshot.readiness = ReadinessFlags::default();
-    }
-    Ok(SocketOutcome::Completed(()))
-}
-
 pub(super) fn send_socket(
     socket: &mut SocketEntry,
     data: &[u8],
@@ -734,8 +558,25 @@ pub(super) fn send_socket(
     if socket.write_shutdown {
         return Ok(SocketOutcome::Failed(SocketError::Other));
     }
+    if guest_reset_pending(socket)? {
+        if !consume_pending_guest_reset(socket)? {
+            return Err(BrokerError::Internal);
+        }
+        return Ok(SocketOutcome::Failed(SocketError::ConnectionReset));
+    }
+    match socket.connection_status {
+        SocketConnectionStatus::Unconnected => {
+            return Ok(SocketOutcome::Failed(SocketError::NotConnected));
+        }
+        SocketConnectionStatus::Failed(error) => return Ok(SocketOutcome::Failed(error)),
+        _ => {}
+    }
     loop {
-        match send(&socket.tcp_state()?.socket, data, LinuxSendFlags::NOSIGNAL) {
+        match send(
+            socket.tcp_state()?.descriptor.socket()?,
+            data,
+            LinuxSendFlags::NOSIGNAL,
+        ) {
             Ok(sent) => {
                 if sent != 0 {
                     confirm_tcp_connected(socket);
@@ -768,6 +609,28 @@ pub(super) fn receive_socket(
 ) -> BrokerResult<ReactorReceiveOutcome> {
     if socket.kind() != SocketKind::Tcp {
         return Ok(ReactorReceiveOutcome::Failed(SocketError::InvalidArgument));
+    }
+    if socket.read_shutdown && socket.tcp_state()?.descriptor.is_guest() {
+        return Ok(ReactorReceiveOutcome::EndOfStream);
+    }
+    if guest_reset_pending(socket)? {
+        let available = ioctl_fionread(socket.tcp_state()?.descriptor.socket()?)
+            .map_err(broker_error_from_errno)?;
+        if available == 0 {
+            if !consume_pending_guest_reset(socket)? {
+                return Err(BrokerError::Internal);
+            }
+            return Ok(ReactorReceiveOutcome::Failed(SocketError::ConnectionReset));
+        }
+    }
+    match socket.connection_status {
+        SocketConnectionStatus::Unconnected => {
+            return Ok(ReactorReceiveOutcome::Failed(SocketError::NotConnected));
+        }
+        SocketConnectionStatus::Failed(error) => {
+            return Ok(ReactorReceiveOutcome::Failed(error));
+        }
+        _ => {}
     }
     let peek = flags.contains(ReceiveFlags::PEEK);
     if !peek {
@@ -806,7 +669,8 @@ pub(super) fn receive_socket(
             || snapshot.readiness.contains(ReadinessFlags::ERROR);
         if socket.connection_status == SocketConnectionStatus::Connected
             && !terminal
-            && ioctl_fionread(&socket.tcp_state()?.socket).map_err(broker_error_from_errno)?
+            && ioctl_fionread(socket.tcp_state()?.descriptor.socket()?)
+                .map_err(broker_error_from_errno)?
                 < peek_length.try_into().map_err(|_| BrokerError::Internal)?
         {
             let tcp = socket.tcp_state_mut()?;
@@ -825,7 +689,8 @@ pub(super) fn receive_socket(
                 && cache.data.len() <= peek_offset =>
         {
             usize::try_from(
-                ioctl_fionread(&socket.tcp_state()?.socket).map_err(broker_error_from_errno)?,
+                ioctl_fionread(socket.tcp_state()?.descriptor.socket()?)
+                    .map_err(broker_error_from_errno)?,
             )
             .map_err(|_| BrokerError::Internal)?
                 > cache.data.len()
@@ -890,7 +755,11 @@ fn receive_socket_once(
     flags: LinuxRecvFlags,
 ) -> BrokerResult<ReactorReceiveOutcome> {
     loop {
-        match recv(&socket.tcp_state()?.socket, data.as_mut_slice(), flags) {
+        match recv(
+            socket.tcp_state()?.descriptor.socket()?,
+            data.as_mut_slice(),
+            flags,
+        ) {
             Ok((_buffer, 0)) => {
                 confirm_tcp_connected(socket);
                 let readiness = if socket.read_shutdown {
@@ -912,7 +781,7 @@ fn receive_socket_once(
                         .readiness
                         .contains(ReadinessFlags::HANGUP);
                 if !flags.contains(LinuxRecvFlags::PEEK) && !terminal_readable {
-                    let no_queued_data = ioctl_fionread(&socket.tcp_state()?.socket)
+                    let no_queued_data = ioctl_fionread(socket.tcp_state()?.descriptor.socket()?)
                         .is_ok_and(|available| available == 0);
                     if no_queued_data {
                         let _ = clear_readiness(socket, ReadinessFlags::READ);
@@ -941,13 +810,17 @@ pub(super) fn set_tcp_option(socket: &mut SocketEntry, value: TcpOptionValue) ->
     }
     match value {
         TcpOptionValue::NoDelay(value) => {
-            sockopt::set_tcp_nodelay(&socket.tcp_state()?.socket, value)
-                .map_err(broker_error_from_errno)?;
+            if socket.tcp_state()?.descriptor.is_native() {
+                sockopt::set_tcp_nodelay(socket.tcp_state()?.descriptor.socket()?, value)
+                    .map_err(broker_error_from_errno)?;
+            }
             socket.tcp_state_mut()?.no_delay = value;
         }
         TcpOptionValue::KeepAlive(value) => {
-            sockopt::set_socket_keepalive(&socket.tcp_state()?.socket, value)
-                .map_err(broker_error_from_errno)?;
+            if socket.tcp_state()?.descriptor.is_native() {
+                sockopt::set_socket_keepalive(socket.tcp_state()?.descriptor.socket()?, value)
+                    .map_err(broker_error_from_errno)?;
+            }
             socket.tcp_state_mut()?.keep_alive = value;
         }
         _ => return Err(BrokerError::UnsupportedOperation),
@@ -972,12 +845,18 @@ pub(super) fn get_tcp_option(
         return Err(BrokerError::UnsupportedOperation);
     }
     match name {
-        TcpOptionName::NoDelay => sockopt::tcp_nodelay(&socket.tcp_state()?.socket)
-            .map(TcpOptionValue::NoDelay)
-            .map_err(broker_error_from_errno),
-        TcpOptionName::KeepAlive => sockopt::socket_keepalive(&socket.tcp_state()?.socket)
-            .map(TcpOptionValue::KeepAlive)
-            .map_err(broker_error_from_errno),
+        TcpOptionName::NoDelay if socket.tcp_state()?.descriptor.is_native() => {
+            sockopt::tcp_nodelay(socket.tcp_state()?.descriptor.socket()?)
+                .map(TcpOptionValue::NoDelay)
+                .map_err(broker_error_from_errno)
+        }
+        TcpOptionName::NoDelay => Ok(TcpOptionValue::NoDelay(socket.tcp_state()?.no_delay)),
+        TcpOptionName::KeepAlive if socket.tcp_state()?.descriptor.is_native() => {
+            sockopt::socket_keepalive(socket.tcp_state()?.descriptor.socket()?)
+                .map(TcpOptionValue::KeepAlive)
+                .map_err(broker_error_from_errno)
+        }
+        TcpOptionName::KeepAlive => Ok(TcpOptionValue::KeepAlive(socket.tcp_state()?.keep_alive)),
         _ => Err(BrokerError::UnsupportedOperation),
     }
 }
@@ -990,13 +869,22 @@ pub(super) fn shutdown_tcp_socket(
         return Err(BrokerError::Internal);
     }
     if mode == ShutdownMode::Abort {
-        sockopt::set_socket_linger(&socket.tcp_state()?.socket, Some(Duration::ZERO))
+        if socket.tcp_state()?.descriptor.is_native() {
+            sockopt::set_socket_linger(
+                socket.tcp_state()?.descriptor.socket()?,
+                Some(Duration::ZERO),
+            )
             .map_err(broker_error_from_errno)?;
+        }
         socket.tcp_state_mut()?.abortive_close = true;
         return Ok(SocketOutcome::Completed(()));
     }
     let stop_listening = mode == ShutdownMode::StopListening;
-    let listening = socket.tcp_state()?.listening;
+    let listening = socket
+        .tcp_state()?
+        .listener
+        .as_ref()
+        .is_some_and(|listener| listener.listening);
     if stop_listening {
         if !listening {
             return Ok(SocketOutcome::Failed(SocketError::NotConnected));
@@ -1004,95 +892,98 @@ pub(super) fn shutdown_tcp_socket(
     } else if listening {
         return Ok(SocketOutcome::Failed(SocketError::NotConnected));
     }
-    let (mode, add, clear, shuts_down_read, shuts_down_write) = match mode {
+    if stop_listening {
+        socket
+            .tcp_state_mut()?
+            .listener
+            .as_mut()
+            .ok_or(BrokerError::Internal)?
+            .listening = false;
+        socket.tcp_state_mut()?.peek_waitall_threshold = None;
+        socket.read_shutdown = true;
+        socket.connection_status = SocketConnectionStatus::Failed(SocketError::NotConnected);
+        let _ = update_snapshot(
+            socket,
+            Some(SocketConnectionStatus::Failed(SocketError::NotConnected)),
+            ReadinessFlags::WRITE | ReadinessFlags::HANGUP,
+        );
+        return Ok(SocketOutcome::Completed(()));
+    }
+    if matches!(socket.tcp_state()?.descriptor, TcpDescriptor::Unrealized) {
+        return Ok(SocketOutcome::Failed(SocketError::NotConnected));
+    }
+    let guest_endpoint = socket.tcp_state()?.descriptor.is_guest();
+    let (kernel_mode, add, clear, shuts_down_read, shuts_down_write) = match mode {
         ShutdownMode::Read => (
-            LinuxShutdown::Read,
+            (!guest_endpoint).then_some(LinuxShutdown::Read),
             ReadinessFlags::READ,
             ReadinessFlags::default(),
             true,
             false,
         ),
         ShutdownMode::Write => (
-            LinuxShutdown::Write,
+            Some(LinuxShutdown::Write),
             ReadinessFlags::default(),
             ReadinessFlags::WRITE,
             false,
             true,
         ),
         ShutdownMode::Both => (
-            LinuxShutdown::Both,
+            Some(if guest_endpoint {
+                LinuxShutdown::Write
+            } else {
+                LinuxShutdown::Both
+            }),
             ReadinessFlags::READ,
             ReadinessFlags::WRITE,
             true,
             true,
         ),
-        ShutdownMode::StopListening => (
-            LinuxShutdown::Read,
-            ReadinessFlags::default(),
-            ReadinessFlags::default(),
-            true,
-            false,
-        ),
         _ => return Err(BrokerError::UnsupportedOperation),
     };
-    loop {
-        match shutdown(&socket.tcp_state()?.socket, mode) {
-            Ok(()) => {}
-            Err(Errno::INTR) => continue,
-            Err(Errno::NOTCONN) => {
-                fail_connect(socket, SocketError::NotConnected);
-                return Ok(SocketOutcome::Failed(SocketError::NotConnected));
+    if let Some(kernel_mode) = kernel_mode {
+        loop {
+            match shutdown(socket.tcp_state()?.descriptor.socket()?, kernel_mode) {
+                Ok(()) => break,
+                Err(Errno::INTR) => {}
+                Err(Errno::NOTCONN) => {
+                    fail_connect(socket, SocketError::NotConnected);
+                    return Ok(SocketOutcome::Failed(SocketError::NotConnected));
+                }
+                Err(error) => {
+                    let error = socket_operation_error_from_errno(error)?;
+                    fail_connect(socket, error);
+                    return Ok(SocketOutcome::Failed(error));
+                }
             }
-            Err(error) => {
-                let error = socket_operation_error_from_errno(error)?;
-                fail_connect(socket, error);
-                return Ok(SocketOutcome::Failed(error));
-            }
         }
-        if stop_listening {
-            let tcp = socket.tcp_state_mut()?;
-            tcp.listening = false;
-            tcp.peek_waitall_threshold = None;
-            socket.read_shutdown = true;
-            socket.connection_status = SocketConnectionStatus::Failed(SocketError::NotConnected);
-            // The native transition is complete and the cached terminal
-            // snapshot is authoritative even if its notification cannot be
-            // published. Acknowledge completion so core listener state cannot
-            // diverge from the platform.
-            let _ = update_snapshot(
-                socket,
-                Some(SocketConnectionStatus::Failed(SocketError::NotConnected)),
-                ReadinessFlags::WRITE | ReadinessFlags::HANGUP,
-            );
-            return Ok(SocketOutcome::Completed(()));
-        }
-        socket.read_shutdown |= shuts_down_read;
-        socket.write_shutdown |= shuts_down_write;
-        let republish_readiness = shuts_down_read
-            && socket
-                .tcp_state_mut()?
-                .peek_waitall_threshold
-                .take()
-                .is_some();
-        let current = socket
-            .snapshot
-            .lock()
-            .expect("Linux socket snapshot mutex poisoned")
-            .readiness;
-        let readiness = ReadinessFlags((current.0 & !clear.0) | add.0);
-        // Native shutdown and the cached directional state are committed.
-        let _ = update_snapshot(socket, None, readiness);
-        if republish_readiness {
-            let _ = socket.readiness.republish(readiness);
-        }
-        return Ok(SocketOutcome::Completed(()));
     }
+    socket.read_shutdown |= shuts_down_read;
+    socket.write_shutdown |= shuts_down_write;
+    let republish_readiness = shuts_down_read
+        && socket
+            .tcp_state_mut()?
+            .peek_waitall_threshold
+            .take()
+            .is_some();
+    let current = socket
+        .snapshot
+        .lock()
+        .expect("Linux socket snapshot mutex poisoned")
+        .readiness;
+    let readiness = ReadinessFlags((current.0 & !clear.0) | add.0);
+    // Native shutdown and the cached directional state are committed.
+    let _ = update_snapshot(socket, None, readiness);
+    if republish_readiness {
+        let _ = socket.readiness.republish(readiness);
+    }
+    Ok(SocketOutcome::Completed(()))
 }
 
 pub(super) fn handle_socket_event(
     socket: &mut SocketEntry,
     events: epoll::EventFlags,
-) -> BrokerResult<bool> {
+) -> BrokerResult<()> {
     // Readiness publication is best-effort on the shared reactor path: a single
     // association's publication failure must not fail the reactor for every
     // other session using it (this mirrors the UDP endpoint handler).
@@ -1102,13 +993,9 @@ pub(super) fn handle_socket_event(
     // bounds live readiness registrations to the sink's capacity at association
     // setup, so this only absorbs a synthetic sink fault. Genuine host-syscall
     // or internal-consistency errors still propagate and remain fatal.
-    if socket.tcp_state().is_ok_and(|tcp| tcp.listening) {
-        let _ = update_snapshot(socket, None, readiness_from_epoll(socket, events));
-        return Ok(false);
-    }
     if socket.kind() == SocketKind::Udp {
         let _ = update_snapshot(socket, None, readiness_from_epoll(socket, events));
-        return Ok(false);
+        return Ok(());
     }
     let republish_readiness = if events.contains(epoll::EventFlags::IN)
         && let Some(threshold) = socket
@@ -1118,7 +1005,9 @@ pub(super) fn handle_socket_event(
     {
         let threshold_reached = socket
             .tcp_state()
-            .and_then(|tcp| ioctl_fionread(&tcp.socket).map_err(broker_error_from_errno))
+            .and_then(|tcp| {
+                ioctl_fionread(tcp.descriptor.socket()?).map_err(broker_error_from_errno)
+            })
             .ok()
             .and_then(|available| usize::try_from(available).ok())
             .is_none_or(|available| available >= threshold);
@@ -1129,28 +1018,21 @@ pub(super) fn handle_socket_event(
     } else {
         false
     };
-    let failed_connector = match socket.connection_status {
-        SocketConnectionStatus::Unconnected => false,
+    match socket.connection_status {
         SocketConnectionStatus::Connecting => {
-            matches!(
-                complete_connect(socket, events)?,
-                SocketConnectionStatus::Failed(_)
-            )
+            complete_connect(socket, events)?;
         }
         SocketConnectionStatus::Connected => {
             let _ = update_snapshot(socket, None, readiness_from_epoll(socket, events));
-            false
         }
         SocketConnectionStatus::Failed(SocketError::NotConnected) if socket.read_shutdown => {
             let _ = update_snapshot(socket, None, ReadinessFlags::WRITE | ReadinessFlags::HANGUP);
-            false
         }
         SocketConnectionStatus::Failed(_) => {
             let _ = update_snapshot(socket, None, ReadinessFlags::ERROR);
-            false
         }
         _ => return Err(BrokerError::Internal),
-    };
+    }
     if republish_readiness {
         let readiness = socket
             .snapshot
@@ -1159,7 +1041,7 @@ pub(super) fn handle_socket_event(
             .readiness;
         let _ = socket.readiness.republish(readiness);
     }
-    Ok(failed_connector)
+    Ok(())
 }
 
 fn complete_connect(
@@ -1168,7 +1050,10 @@ fn complete_connect(
 ) -> BrokerResult<SocketConnectionStatus> {
     // Epoll re-polls the descriptor when waiting, so OUT here reflects the
     // current post-connect state rather than readiness cached before connect.
-    let status = match sockopt::socket_error(&socket.tcp_state()?.socket) {
+    if !socket.tcp_state()?.descriptor.is_native() {
+        return Err(BrokerError::Internal);
+    }
+    let status = match sockopt::socket_error(socket.tcp_state()?.descriptor.socket()?) {
         Ok(Ok(())) if events.contains(epoll::EventFlags::OUT) => SocketConnectionStatus::Connected,
         Ok(Ok(())) => SocketConnectionStatus::Connecting,
         Ok(Err(error)) | Err(error) => {
@@ -1194,17 +1079,10 @@ impl Reactor {
         id: u64,
         data: &[u8],
     ) -> BrokerResult<SocketOutcome<usize>> {
-        let was_connecting = self
-            .sockets
-            .get(&id)
-            .is_some_and(|socket| socket.connection_status == SocketConnectionStatus::Connecting);
-        let outcome = self
-            .sockets
+        self.sockets
             .get_mut(&id)
             .ok_or(BrokerError::Internal)
-            .and_then(|socket| send_socket(socket, data));
-        self.discard_failed_connect_after_command(id, was_connecting);
-        outcome
+            .and_then(|socket| send_socket(socket, data))
     }
 
     pub(super) fn receive_tcp_socket(
@@ -1215,11 +1093,7 @@ impl Reactor {
         peek_offset: usize,
         peek_length: usize,
     ) -> BrokerResult<ReactorReceiveOutcome> {
-        let was_connecting = self
-            .sockets
-            .get(&id)
-            .is_some_and(|socket| socket.connection_status == SocketConnectionStatus::Connecting);
-        let outcome = match self.sockets.get_mut(&id) {
+        match self.sockets.get_mut(&id) {
             Some(socket) => receive_socket(
                 socket,
                 &mut self.tcp.peek_cache,
@@ -1230,9 +1104,7 @@ impl Reactor {
                 peek_length,
             ),
             None => Err(BrokerError::Internal),
-        };
-        self.discard_failed_connect_after_command(id, was_connecting);
-        outcome
+        }
     }
 
     pub(super) fn set_tcp_socket_option(
@@ -1270,26 +1142,38 @@ impl Reactor {
         {
             self.tcp.peek_cache = None;
         }
+        let queued_connection = (mode == ShutdownMode::Abort)
+            .then(|| {
+                self.sockets
+                    .get(&id)
+                    .and_then(|socket| socket.tcp_state().ok())
+                    .and_then(|tcp| tcp.guest_endpoint.as_ref())
+                    .and_then(|endpoint| {
+                        endpoint
+                            .queued_listener_id
+                            .map(|listener_id| (listener_id, endpoint.connection_id))
+                    })
+            })
+            .flatten();
         let was_listening = mode == ShutdownMode::StopListening
-            && self
-                .sockets
-                .get(&id)
-                .is_some_and(|socket| socket.tcp_state().is_ok_and(|tcp| tcp.listening));
-        let was_connecting = self
-            .sockets
-            .get(&id)
-            .is_some_and(|socket| socket.connection_status == SocketConnectionStatus::Connecting);
+            && self.sockets.get(&id).is_some_and(|socket| {
+                socket
+                    .tcp_state()
+                    .ok()
+                    .and_then(|tcp| tcp.listener.as_ref())
+                    .is_some_and(|listener| listener.listening)
+            });
         let mut outcome = shutdown_tcp_socket(
             self.sockets.get_mut(&id).ok_or(BrokerError::Internal)?,
             mode,
         );
-        let stopped_listening = was_listening
-            && self
-                .sockets
-                .get(&id)
-                .is_some_and(|socket| socket.tcp_state().is_ok_and(|tcp| !tcp.listening));
-        if stopped_listening {
-            self.remove_pending_guest_connections_for_listener(id);
+        if outcome == Ok(SocketOutcome::Completed(()))
+            && let Some((listener_id, connection_id)) = queued_connection
+        {
+            self.remove_queued_guest_connection(listener_id, connection_id, false);
+        }
+        if was_listening && outcome == Ok(SocketOutcome::Completed(())) {
+            self.purge_listener_queue(id);
             let update = self
                 .sockets
                 .get(&id)
@@ -1300,7 +1184,6 @@ impl Reactor {
                 outcome = Err(error);
             }
         }
-        self.discard_failed_connect_after_command(id, was_connecting);
         outcome
     }
 
@@ -1317,10 +1200,7 @@ impl Reactor {
         self.tcp.insert_binding(ReactorTcpBinding {
             socket_id: id,
             guest_binding: binding,
-            host_address: None,
             listening: false,
-            requires_backlog_drain: false,
-            untracked_connection_deadline: None,
         })?;
         let socket = self.sockets.get_mut(&id).ok_or(BrokerError::Internal)?;
         socket.guest_local_address = Some(guest_address);
@@ -1336,6 +1216,7 @@ impl Reactor {
         &mut self,
         id: u64,
         guest_address: SocketAddrV4,
+        guest_source_lease: Option<GuestSourceLease>,
     ) -> core::result::Result<SocketConnectionStatus, PlatformConnectError> {
         let (session_id, reserved_local_address) = self
             .sockets
@@ -1346,45 +1227,50 @@ impl Reactor {
                     .map(|address| (socket.session_id, address))
             })
             .ok_or(PlatformConnectError::PeerUnchanged(BrokerError::Internal))?;
-        let concrete_guest_destination = if guest_address.ip().is_unspecified() {
-            SocketAddrV4::new(Ipv4Addr::LOCALHOST, guest_address.port())
-        } else {
-            guest_address
-        };
         let binding = self
             .tcp
             .binding_for_socket(id)
             .ok_or(PlatformConnectError::PeerUnchanged(BrokerError::Internal))?;
-        let (network_address, guest_listener_id) =
-            match self.resolve_guest_destination(guest_address) {
-                SocketOutcome::Completed(destination) => destination,
-                SocketOutcome::Failed(error) => {
-                    let status = SocketConnectionStatus::Failed(error);
-                    let socket = self
-                        .sockets
-                        .get_mut(&id)
-                        .ok_or(PlatformConnectError::PeerUnchanged(BrokerError::Internal))?;
-                    socket.connection_status = status;
-                    update_snapshot(socket, Some(status), ReadinessFlags::ERROR)
-                        .map_err(PlatformConnectError::PeerIndeterminate)?;
-                    return Ok(status);
-                }
-            };
-        let local_guest_address = if guest_listener_id.is_some() {
-            binding
-                .guest_binding
-                .guest_source_address(concrete_guest_destination)
-                .ok_or(PlatformConnectError::PeerUnchanged(BrokerError::Internal))?
-        } else if binding.guest_binding.is_wildcard() {
-            SocketAddrV4::new(Ipv4Addr::LOCALHOST, reserved_local_address.port())
-        } else {
-            reserved_local_address
+        let destination = match self.resolve_guest_destination(guest_address) {
+            SocketOutcome::Completed(destination) => destination,
+            SocketOutcome::Failed(error) => {
+                drop(guest_source_lease);
+                let status = SocketConnectionStatus::Failed(error);
+                let socket = self
+                    .sockets
+                    .get_mut(&id)
+                    .ok_or(PlatformConnectError::PeerUnchanged(BrokerError::Internal))?;
+                socket.connection_status = status;
+                update_snapshot(socket, Some(status), ReadinessFlags::ERROR)
+                    .map_err(PlatformConnectError::PeerIndeterminate)?;
+                return Ok(status);
+            }
         };
-        if guest_listener_id.is_some() {
-            self.expire_deadlined_state(Instant::now());
-            self.reserve_pending_guest_connection(session_id)
-                .map_err(PlatformConnectError::PeerUnchanged)?;
+        if let ResolvedTcpDestination::Guest {
+            listener_id,
+            concrete_address,
+        } = destination
+        {
+            let source_address = binding
+                .guest_binding
+                .guest_source_address(concrete_address)
+                .ok_or(PlatformConnectError::PeerUnchanged(BrokerError::Internal))?;
+            let guest_source_lease = guest_source_lease
+                .filter(|lease| lease.source_address() == source_address)
+                .ok_or(PlatformConnectError::PeerUnchanged(BrokerError::Internal))?;
+            return self.connect_guest_tcp_socketpair(
+                id,
+                session_id,
+                listener_id,
+                concrete_address,
+                source_address,
+                guest_source_lease,
+            );
         }
+        drop(guest_source_lease);
+        let ResolvedTcpDestination::Native(network_address) = destination else {
+            unreachable!("guest destination handled above");
+        };
         let (status, readiness) = connect_tcp_socket(
             &self.epoll,
             id,
@@ -1392,82 +1278,37 @@ impl Reactor {
                 .get_mut(&id)
                 .ok_or(PlatformConnectError::PeerUnchanged(BrokerError::Internal))?,
             network_address,
-            guest_listener_id,
         )?;
+        let local_guest_address = if matches!(
+            status,
+            SocketConnectionStatus::Connecting | SocketConnectionStatus::Connected
+        ) {
+            if binding.guest_binding.is_wildcard() {
+                SocketAddrV4::new(Ipv4Addr::LOCALHOST, reserved_local_address.port())
+            } else {
+                reserved_local_address
+            }
+        } else {
+            reserved_local_address
+        };
         if matches!(
             status,
             SocketConnectionStatus::Connecting | SocketConnectionStatus::Connected
         ) {
-            let host_address = local_socket_address(
-                &self
-                    .sockets
-                    .get(&id)
+            let socket =
+                self.sockets
+                    .get_mut(&id)
                     .ok_or(PlatformConnectError::PeerIndeterminate(
                         BrokerError::Internal,
-                    ))?
-                    .tcp_state()
-                    .map_err(PlatformConnectError::PeerIndeterminate)?
-                    .socket,
-            )
-            .map_err(PlatformConnectError::PeerIndeterminate)?;
-            self.tcp
-                .set_host_address(local_guest_address.port(), id, host_address)
-                .map_err(PlatformConnectError::PeerIndeterminate)?;
-            {
-                let socket =
-                    self.sockets
-                        .get_mut(&id)
-                        .ok_or(PlatformConnectError::PeerIndeterminate(
-                            BrokerError::Internal,
-                        ))?;
-                socket.guest_local_address = Some(local_guest_address);
-                socket
-                    .snapshot
-                    .lock()
-                    .expect("Linux socket snapshot mutex poisoned")
-                    .local_address = Some(local_guest_address);
-            }
-            if let Some(listener_id) = guest_listener_id {
-                let connection = (host_address, network_address);
-                if self.tcp.persist_discard_marker_for_collision(
-                    connection,
-                    listener_id,
-                    Instant::now() + PENDING_CONNECT_DISCARD_LIFETIME,
-                ) {
-                    self.sockets
-                        .get_mut(&id)
-                        .ok_or(PlatformConnectError::PeerIndeterminate(
-                            BrokerError::Internal,
-                        ))?
-                        .tcp_state_mut()
-                        .map_err(PlatformConnectError::PeerIndeterminate)?
-                        .untracked_guest_listener_id = None;
-                    return Err(PlatformConnectError::PeerIndeterminate(
-                        BrokerError::ResourceExhausted,
-                    ));
-                }
-                self.insert_pending_guest_connection(
-                    session_id,
-                    connection,
-                    local_guest_address,
-                    concrete_guest_destination,
-                    listener_id,
-                )
-                .map_err(PlatformConnectError::PeerIndeterminate)?;
-                let socket =
-                    self.sockets
-                        .get_mut(&id)
-                        .ok_or(PlatformConnectError::PeerIndeterminate(
-                            BrokerError::Internal,
-                        ))?;
-                let tcp = socket
-                    .tcp_state_mut()
-                    .map_err(PlatformConnectError::PeerIndeterminate)?;
-                tcp.host_connection = Some(connection);
-                tcp.untracked_guest_listener_id = None;
-            }
+                    ))?;
+            socket.guest_local_address = Some(local_guest_address);
+            socket
+                .snapshot
+                .lock()
+                .expect("Linux socket snapshot mutex poisoned")
+                .local_address = Some(local_guest_address);
         }
-        if let Err(error) = update_snapshot(
+        update_snapshot(
             self.sockets
                 .get(&id)
                 .ok_or(PlatformConnectError::PeerIndeterminate(
@@ -1475,17 +1316,184 @@ impl Reactor {
                 ))?,
             Some(status),
             readiness,
-        ) {
-            if let Some(connection) = self
+        )
+        .map_err(PlatformConnectError::PeerIndeterminate)?;
+        Ok(status)
+    }
+
+    fn connect_guest_tcp_socketpair(
+        &mut self,
+        connector_id: u64,
+        connector_session_id: SessionId,
+        listener_id: u64,
+        local_address: SocketAddrV4,
+        remote_address: SocketAddrV4,
+        guest_source_lease: GuestSourceLease,
+    ) -> core::result::Result<SocketConnectionStatus, PlatformConnectError> {
+        let combined_count = self
+            .sockets
+            .len()
+            .checked_add(self.tcp.queued_guest_connection_count)
+            .and_then(|count| count.checked_add(1))
+            .ok_or(PlatformConnectError::PeerUnchanged(
+                BrokerError::ResourceExhausted,
+            ))?;
+        let session = self
+            .sessions
+            .get(&connector_session_id)
+            .ok_or(PlatformConnectError::PeerUnchanged(BrokerError::Internal))?;
+        let next_pending_count = session
+            .pending_guest_connection_count
+            .checked_add(1)
+            .ok_or(PlatformConnectError::PeerUnchanged(
+                BrokerError::ResourceExhausted,
+            ))?;
+        let connector_session_count = session
+            .live_socket_count
+            .checked_add(next_pending_count)
+            .ok_or(PlatformConnectError::PeerUnchanged(
+                BrokerError::ResourceExhausted,
+            ))?;
+        if combined_count > self.max_sockets
+            || connector_session_count > self.max_sockets_per_session
+        {
+            return Err(PlatformConnectError::PeerUnchanged(
+                BrokerError::ResourceExhausted,
+            ));
+        }
+        {
+            let connector = self
                 .sockets
-                .get(&id)
-                .and_then(|socket| socket.tcp_state().ok().and_then(|tcp| tcp.host_connection))
+                .get(&connector_id)
+                .ok_or(PlatformConnectError::PeerUnchanged(BrokerError::Internal))?;
+            if connector.connection_status != SocketConnectionStatus::Unconnected
+                || !matches!(
+                    connector
+                        .tcp_state()
+                        .map_err(PlatformConnectError::PeerUnchanged)?
+                        .descriptor,
+                    TcpDescriptor::Unrealized
+                )
             {
-                self.discard_pending_guest_connection(connection, session_id);
+                return Err(PlatformConnectError::PeerUnchanged(BrokerError::Internal));
             }
+            let listener = self
+                .sockets
+                .get(&listener_id)
+                .ok_or(PlatformConnectError::PeerUnchanged(BrokerError::Internal))?;
+            let listener = listener
+                .tcp_state()
+                .map_err(PlatformConnectError::PeerUnchanged)?
+                .listener
+                .as_ref()
+                .filter(|listener| listener.listening)
+                .ok_or(PlatformConnectError::PeerUnchanged(BrokerError::Internal))?;
+            if listener.queue.len() >= listener.backlog {
+                drop(guest_source_lease);
+                let status = SocketConnectionStatus::Failed(SocketError::ConnectionRefused);
+                let connector = self
+                    .sockets
+                    .get_mut(&connector_id)
+                    .ok_or(PlatformConnectError::PeerUnchanged(BrokerError::Internal))?;
+                connector.connection_status = status;
+                update_snapshot(connector, Some(status), ReadinessFlags::ERROR)
+                    .map_err(PlatformConnectError::PeerIndeterminate)?;
+                return Ok(status);
+            }
+        }
+        self.sockets
+            .get_mut(&listener_id)
+            .ok_or(PlatformConnectError::PeerUnchanged(BrokerError::Internal))?
+            .tcp_state_mut()
+            .map_err(PlatformConnectError::PeerUnchanged)?
+            .listener
+            .as_mut()
+            .ok_or(PlatformConnectError::PeerUnchanged(BrokerError::Internal))?
+            .queue
+            .try_reserve(1)
+            .map_err(|_| PlatformConnectError::PeerUnchanged(BrokerError::OutOfMemory))?;
+        let connection_id = self
+            .tcp
+            .allocate_guest_connection_id()
+            .map_err(PlatformConnectError::PeerUnchanged)?;
+        let (connector_socket, accepted_socket) = socketpair(
+            rustix::net::AddressFamily::UNIX,
+            rustix::net::SocketType::STREAM,
+            LinuxSocketFlags::CLOEXEC | LinuxSocketFlags::NONBLOCK,
+            None,
+        )
+        .map_err(|error| PlatformConnectError::PeerUnchanged(broker_error_from_errno(error)))?;
+        epoll::add(
+            &self.epoll,
+            &connector_socket,
+            epoll::EventData::new_u64(connector_id),
+            active_epoll_events(),
+        )
+        .map_err(|error| PlatformConnectError::PeerUnchanged(broker_error_from_errno(error)))?;
+
+        {
+            let connector = self.sockets.get_mut(&connector_id).ok_or(
+                PlatformConnectError::PeerIndeterminate(BrokerError::Internal),
+            )?;
+            let tcp = connector
+                .tcp_state_mut()
+                .map_err(PlatformConnectError::PeerIndeterminate)?;
+            tcp.descriptor = TcpDescriptor::GuestUnix(connector_socket);
+            tcp.guest_endpoint = Some(GuestTcpEndpoint {
+                connection_id,
+                side: GuestTcpSide::Connector,
+                queued_listener_id: Some(listener_id),
+                reset_state: GuestTcpResetState::None,
+            });
+            connector.guest_local_address = Some(remote_address);
+            connector.connection_status = SocketConnectionStatus::Connected;
+            connector
+                .snapshot
+                .lock()
+                .expect("Linux socket snapshot mutex poisoned")
+                .local_address = Some(remote_address);
+        }
+        self.sockets
+            .get_mut(&listener_id)
+            .expect("validated guest listener missing")
+            .tcp_state_mut()
+            .expect("validated guest listener changed transport")
+            .listener
+            .as_mut()
+            .expect("validated guest listener stopped")
+            .queue
+            .push_back(QueuedGuestTcpConnection {
+                socket: accepted_socket,
+                connection_id,
+                connector_id,
+                connector_session_id,
+                local_address,
+                remote_address,
+                guest_source_lease,
+            });
+        self.tcp.queued_guest_connection_count = combined_count - self.sockets.len();
+        self.sessions
+            .get_mut(&connector_session_id)
+            .expect("validated connector session missing")
+            .pending_guest_connection_count = next_pending_count;
+
+        if let Err(error) = update_snapshot(
+            self.sockets
+                .get(&connector_id)
+                .ok_or(PlatformConnectError::PeerIndeterminate(
+                    BrokerError::Internal,
+                ))?,
+            Some(SocketConnectionStatus::Connected),
+            ReadinessFlags::WRITE,
+        ) {
+            self.remove_queued_guest_connection(listener_id, connection_id, false);
             return Err(PlatformConnectError::PeerIndeterminate(error));
         }
-        Ok(status)
+        if let Err(error) = self.publish_listener_queue_readiness(listener_id) {
+            self.remove_queued_guest_connection(listener_id, connection_id, false);
+            return Err(PlatformConnectError::PeerIndeterminate(error));
+        }
+        Ok(SocketConnectionStatus::Connected)
     }
 
     pub(super) fn remove_tcp_socket(&mut self, id: u64, session_id: SessionId) {
@@ -1497,473 +1505,329 @@ impl Reactor {
         {
             self.tcp.peek_cache = None;
         }
+        let session_closing = self
+            .sessions
+            .get(&session_id)
+            .is_some_and(|session| session.closing);
+        let queued_connection = self
+            .sockets
+            .get(&id)
+            .and_then(|socket| socket.tcp_state().ok())
+            .and_then(|tcp| {
+                tcp.guest_endpoint.as_ref().and_then(|endpoint| {
+                    (endpoint.side == GuestTcpSide::Connector)
+                        .then_some(endpoint.queued_listener_id)
+                        .flatten()
+                        .map(|listener_id| (listener_id, endpoint.connection_id))
+                })
+            });
+        let abortive_close = self
+            .sockets
+            .get(&id)
+            .and_then(|socket| socket.tcp_state().ok())
+            .is_some_and(|tcp| tcp.abortive_close);
+        if (session_closing || abortive_close)
+            && let Some((listener_id, connection_id)) = queued_connection
+        {
+            self.remove_queued_guest_connection(listener_id, connection_id, false);
+        }
+        let guest_connection = self
+            .sockets
+            .get(&id)
+            .and_then(|socket| socket.tcp_state().ok())
+            .and_then(|tcp| {
+                tcp.guest_endpoint
+                    .as_ref()
+                    .map(|endpoint| endpoint.connection_id)
+            });
+        let reset_peer = guest_connection.is_some()
+            && self
+                .sockets
+                .get(&id)
+                .and_then(|socket| socket.tcp_state().ok())
+                .is_some_and(|tcp| {
+                    tcp.abortive_close
+                        || tcp.descriptor.is_guest()
+                            && match ioctl_fionread(
+                                tcp.descriptor
+                                    .socket()
+                                    .expect("guest endpoint descriptor missing"),
+                            ) {
+                                Ok(0) => false,
+                                Ok(_) | Err(_) => true,
+                            }
+                });
         let socket = self
             .sockets
             .remove(&id)
             .expect("checked TCP socket missing");
         let SocketEntry {
             transport,
-            connection_status,
             guest_local_address,
             ..
         } = socket;
-        let SocketTransportState::Tcp(TcpSocketState {
-            socket,
-            untracked_guest_listener_id,
-            was_listener,
-            abortive_close,
-            host_connection,
-            ..
-        }) = transport
-        else {
+        let SocketTransportState::Tcp(mut tcp) = transport else {
             unreachable!("checked TCP socket changed transport");
         };
-        let guest_connector = untracked_guest_listener_id.is_some()
-            || host_connection.is_some_and(|connection| {
-                self.tcp
-                    .pending_guest_connections
-                    .get(&connection)
-                    .is_some_and(|pending| pending.session_id == session_id)
-            });
-        if was_listener {
-            self.remove_pending_guest_connections_for_listener(id);
+        if tcp.abortive_close
+            && let TcpDescriptor::NativeInet(socket) = &tcp.descriptor
+        {
+            // Abort may be requested before lazy native realization or after
+            // the response receiver disappears, so enforce it again at close.
+            let _ = sockopt::set_socket_linger(socket, Some(Duration::ZERO));
         }
         if let Some(address) = guest_local_address {
             self.tcp.remove_binding(address.port(), id);
         }
-
-        let mut socket = Some(socket);
-        if !abortive_close
-            && guest_connector
-            && matches!(
-                connection_status,
-                SocketConnectionStatus::Connecting | SocketConnectionStatus::Connected
-            )
-        {
-            let _ = shutdown(
-                socket.as_ref().expect("connector descriptor missing"),
-                LinuxShutdown::Both,
-            );
+        if let Some(listener) = tcp.listener.as_mut() {
+            let queued = core::mem::take(&mut listener.queue);
+            self.discard_queued_guest_connections(queued, true);
         }
-        if let Some(connection) = host_connection
-            && let Some(pending) = self.tcp.pending_guest_connections.get_mut(&connection)
-            && pending.session_id == session_id
-        {
-            let retain = !abortive_close
-                && connection_status == SocketConnectionStatus::Connected
-                && !pending.discard_on_accept;
-            // A close that wins before native completion is observed is
-            // deliberately non-deliverable; teardown never re-infers it.
-            pending.discard_on_accept = !retain;
-            pending.discard_deadline =
-                (!retain).then(|| Instant::now() + PENDING_CONNECT_DISCARD_LIFETIME);
-            if retain {
-                pending.retained_connector = socket.take();
-                self.tcp.retained_connector_count = self
-                    .tcp
-                    .retained_connector_count
-                    .checked_add(1)
-                    .expect("reactor retained connector count overflow");
-                let session = self
-                    .sessions
-                    .get_mut(&session_id)
-                    .expect("socket session state missing");
-                session.retained_connector_count = session
-                    .retained_connector_count
-                    .checked_add(1)
-                    .expect("session retained connector count overflow");
-            }
+        if reset_peer && let Some(connection_id) = guest_connection {
+            self.mark_guest_peer_reset(connection_id, id);
         }
-        if let Some(listener_id) = untracked_guest_listener_id
-            && self
-                .tcp
-                .bindings
-                .values()
-                .any(|binding| binding.socket_id == listener_id)
-        {
-            // No tuple exists to key a discard marker. Block later routes for
-            // the same bounded maturation period, then probe the listener just
-            // like an expiring keyed marker.
-            self.tcp.defer_untracked_connection(
-                listener_id,
-                Instant::now() + PENDING_CONNECT_DISCARD_LIFETIME,
-            );
-        }
-        drop(socket);
         if let Some(session) = self.sessions.get_mut(&session_id) {
             session.live_socket_count = session
                 .live_socket_count
                 .checked_sub(1)
                 .expect("session socket count underflow");
         }
-        if self
-            .sessions
-            .get(&session_id)
-            .is_some_and(|session| session.closing)
-        {
-            self.retire_session_connectors(session_id);
-        }
         self.sessions
             .retain(|_, session| retain_session_state(session));
     }
 
-    pub(super) fn discard_failed_connect_after_command(&mut self, id: u64, was_connecting: bool) {
-        if !was_connecting {
-            return;
-        }
-        let failed_connection = self.sockets.get(&id).and_then(|socket| {
-            matches!(socket.connection_status, SocketConnectionStatus::Failed(_))
-                .then(|| {
-                    socket
-                        .tcp_state()
-                        .ok()
-                        .and_then(|tcp| tcp.host_connection)
-                        .map(|connection| (connection, socket.session_id))
-                })
-                .flatten()
-        });
-        if let Some((connection, session_id)) = failed_connection {
-            self.discard_pending_guest_connection(connection, session_id);
-        }
-    }
-
-    pub(super) fn reserve_pending_guest_connection(
-        &mut self,
-        session_id: SessionId,
-    ) -> BrokerResult<()> {
+    fn release_queued_guest_connection(&mut self, connector_session_id: SessionId) {
+        self.tcp.queued_guest_connection_count = self
+            .tcp
+            .queued_guest_connection_count
+            .checked_sub(1)
+            .expect("reactor queued guest connection count underflow");
         let session = self
             .sessions
-            .get(&session_id)
-            .ok_or(BrokerError::Internal)?;
-        // Pending records can outlive connector descriptors, so bound this
-        // metadata independently using the configured socket budgets.
-        if session.pending_guest_connection_count >= self.max_sockets_per_session
-            || self.tcp.pending_guest_connections.len() >= self.max_sockets
-        {
-            return Err(BrokerError::ResourceExhausted);
-        }
-        self.tcp
-            .pending_guest_connections
-            .try_reserve(1)
-            .map_err(|_| BrokerError::OutOfMemory)
-    }
-
-    fn finish_removed_pending_guest_connection(&mut self, connection: &PendingGuestTcpConnection) {
-        let session = self
-            .sessions
-            .get_mut(&connection.session_id)
-            .expect("pending guest connection session state missing");
+            .get_mut(&connector_session_id)
+            .expect("queued guest connection session state missing");
         session.pending_guest_connection_count = session
             .pending_guest_connection_count
             .checked_sub(1)
-            .expect("session pending guest connection count underflow");
-        if connection.retained_connector.is_some() {
-            self.tcp.retained_connector_count = self
-                .tcp
-                .retained_connector_count
-                .checked_sub(1)
-                .expect("reactor retained connector count underflow");
-            session.retained_connector_count = session
-                .retained_connector_count
-                .checked_sub(1)
-                .expect("session retained connector count underflow");
-        }
+            .expect("session queued guest connection count underflow");
     }
 
-    pub(super) fn insert_pending_guest_connection(
+    fn discard_queued_guest_connections(
         &mut self,
-        session_id: SessionId,
-        connection: (SocketAddrV4, SocketAddrV4),
-        guest_address: SocketAddrV4,
-        local_address: SocketAddrV4,
-        listener_id: u64,
-    ) -> BrokerResult<()> {
-        let pending_count = self
-            .sessions
-            .get(&session_id)
-            .ok_or(BrokerError::Internal)?
-            .pending_guest_connection_count
-            .checked_add(1)
-            .ok_or(BrokerError::ResourceExhausted)?;
-        self.tcp.insert_pending_guest_connection(
-            connection,
-            PendingGuestTcpConnection {
-                session_id,
-                guest_address,
-                local_address,
-                listener_id,
-                discard_on_accept: false,
-                discard_until_deadline: false,
-                discard_deadline: None,
-                retained_connector: None,
-            },
-        )?;
-        self.sessions
-            .get_mut(&session_id)
-            .expect("pending guest connection session state missing")
-            .pending_guest_connection_count = pending_count;
-        Ok(())
-    }
-
-    pub(super) fn discard_pending_guest_connection(
-        &mut self,
-        connection: (SocketAddrV4, SocketAddrV4),
-        session_id: SessionId,
+        queued: VecDeque<QueuedGuestTcpConnection>,
+        reset_connectors: bool,
     ) {
-        if let Some(pending) = self.tcp.pending_guest_connections.get_mut(&connection)
-            && pending.session_id == session_id
-        {
-            // The descriptor remains open and pins the native tuple. Final
-            // close starts the bounded discard deadline.
-            pending.discard_on_accept = true;
-            pending.discard_deadline = None;
-        }
-    }
-
-    pub(super) fn remove_pending_guest_connections_for_listener(&mut self, listener_id: u64) {
-        let Reactor { tcp, sessions, .. } = self;
-        let ReactorTcpState {
-            pending_guest_connections,
-            retained_connector_count,
-            ..
-        } = tcp;
-        pending_guest_connections.retain(|_, connection| {
-            let retain = connection.listener_id != listener_id;
-            if !retain {
-                let session = sessions
-                    .get_mut(&connection.session_id)
-                    .expect("pending guest connection session state missing");
-                session.pending_guest_connection_count = session
-                    .pending_guest_connection_count
-                    .checked_sub(1)
-                    .expect("session pending guest connection count underflow");
-                if connection.retained_connector.is_some() {
-                    session.retained_connector_count = session
-                        .retained_connector_count
-                        .checked_sub(1)
-                        .expect("session retained connector count underflow");
-                    *retained_connector_count = retained_connector_count
-                        .checked_sub(1)
-                        .expect("reactor retained connector count underflow");
-                }
-            }
-            retain
-        });
-        sessions.retain(|_, session| retain_session_state(session));
-    }
-
-    pub(super) fn retire_session_connectors(&mut self, session_id: SessionId) {
-        let discard_deadline = Instant::now() + PENDING_CONNECT_DISCARD_LIFETIME;
-        let mut released = 0;
-        for connection in self
-            .tcp
-            .pending_guest_connections
-            .values_mut()
-            .filter(|connection| connection.session_id == session_id)
-        {
-            if let Some(connector) = connection.retained_connector.take() {
-                let _ = sockopt::set_socket_linger(&connector, None);
-                drop(connector);
-                connection.discard_on_accept = true;
-                connection.discard_deadline = Some(discard_deadline);
-                released += 1;
-            }
-        }
-        self.tcp.retained_connector_count = self
-            .tcp
-            .retained_connector_count
-            .checked_sub(released)
-            .expect("reactor retained connector count underflow");
-        if let Some(session) = self.sessions.get_mut(&session_id) {
-            session.retained_connector_count = session
-                .retained_connector_count
-                .checked_sub(released)
-                .expect("session retained connector count underflow");
-        }
-    }
-
-    pub(super) fn next_cleanup_deadline(&self) -> Option<Instant> {
-        self.tcp
-            .pending_guest_connections
-            .values()
-            .filter_map(|connection| connection.discard_deadline)
-            .chain(
-                self.tcp
-                    .bindings
-                    .values()
-                    .filter_map(|binding| binding.untracked_connection_deadline),
-            )
-            .min()
-    }
-
-    pub(super) fn expire_deadlined_state(&mut self, now: Instant) {
-        let Reactor {
-            tcp,
-            sockets,
-            sessions,
-            ..
-        } = self;
-        let ReactorTcpState {
-            bindings,
-            pending_guest_connections,
-            retained_connector_count,
-            ..
-        } = tcp;
-        for binding in bindings.values_mut() {
-            if binding
-                .untracked_connection_deadline
-                .is_some_and(|deadline| deadline <= now)
+        for connection in queued {
+            self.release_queued_guest_connection(connection.connector_session_id);
+            if let Some(connector) = self.sockets.get_mut(&connection.connector_id)
+                && let Ok(tcp) = connector.tcp_state_mut()
+                && let Some(endpoint) = tcp.guest_endpoint.as_mut()
+                && endpoint.connection_id == connection.connection_id
             {
-                if listener_backlog_is_nonempty(sockets, binding.socket_id) {
-                    binding.requires_backlog_drain = true;
-                }
-                binding.untracked_connection_deadline = None;
+                endpoint.queued_listener_id = None;
+            }
+            if reset_connectors {
+                self.mark_guest_socket_reset(connection.connector_id);
             }
         }
-        for connection in pending_guest_connections.values().filter(|connection| {
-            connection.discard_on_accept
-                && connection
-                    .discard_deadline
-                    .is_some_and(|deadline| deadline <= now)
-        }) {
-            if listener_backlog_is_nonempty(sockets, connection.listener_id) {
-                bindings
-                    .values_mut()
-                    .find(|binding| binding.socket_id == connection.listener_id)
-                    .expect("pending guest connection listener binding missing")
-                    .requires_backlog_drain = true;
-            }
-        }
-        pending_guest_connections.retain(|_, connection| {
-            let retain = !connection.discard_on_accept
-                || connection
-                    .discard_deadline
-                    .is_none_or(|deadline| deadline > now);
-            if !retain {
-                let session = sessions
-                    .get_mut(&connection.session_id)
-                    .expect("pending guest connection session state missing");
-                session.pending_guest_connection_count = session
-                    .pending_guest_connection_count
-                    .checked_sub(1)
-                    .expect("session pending guest connection count underflow");
-                if connection.retained_connector.is_some() {
-                    session.retained_connector_count = session
-                        .retained_connector_count
-                        .checked_sub(1)
-                        .expect("session retained connector count underflow");
-                    *retained_connector_count = retained_connector_count
-                        .checked_sub(1)
-                        .expect("reactor retained connector count underflow");
-                }
-            }
-            retain
-        });
-        sessions.retain(|_, session| retain_session_state(session));
-    }
-
-    fn take_pending_guest_connection_for_accept(
-        &mut self,
-        listener_id: u64,
-        remote_address: SocketAddrV4,
-        local_address: SocketAddrV4,
-    ) -> Option<(SocketAddrV4, SocketAddrV4)> {
-        let PendingGuestConnectionMatch::Take(mut connection) = self
-            .tcp
-            .take_pending_guest_connection(remote_address, local_address)?
-        else {
-            return None;
-        };
-        self.finish_removed_pending_guest_connection(&connection);
-        drop(connection.retained_connector.take());
-        let addresses = (!connection.discard_on_accept && connection.listener_id == listener_id)
-            .then_some((connection.guest_address, connection.local_address));
         self.sessions
             .retain(|_, session| retain_session_state(session));
-        addresses
     }
 
-    fn has_accept_capacity(
-        &self,
-        listener_id: u64,
-        listener_session_id: SessionId,
-    ) -> BrokerResult<bool> {
-        let global_at_limit = self
+    fn purge_listener_queue(&mut self, listener_id: u64) {
+        let queued = self
             .sockets
-            .len()
-            .checked_add(self.tcp.retained_connector_count)
-            .is_none_or(|count| count >= self.max_sockets);
-        let listener_session = self
-            .sessions
-            .get(&listener_session_id)
-            .ok_or(BrokerError::Internal)?;
-        let session_at_limit = listener_session
-            .live_socket_count
-            .checked_add(listener_session.retained_connector_count)
-            .is_none_or(|count| count >= self.max_sockets_per_session);
-        if !global_at_limit && !session_at_limit {
-            return Ok(true);
-        }
+            .get_mut(&listener_id)
+            .and_then(|listener| listener.tcp_state_mut().ok())
+            .and_then(|tcp| tcp.listener.as_mut())
+            .map(|listener| core::mem::take(&mut listener.queue))
+            .unwrap_or_default();
+        self.discard_queued_guest_connections(queued, true);
+        let _ = self.publish_listener_queue_readiness(listener_id);
+    }
 
-        for connection in self
-            .tcp
-            .pending_guest_connections
-            .values()
-            .filter(|connection| connection.listener_id == listener_id)
-            .filter(|connection| !connection.discard_on_accept)
+    pub(super) fn purge_connector_session_queues(&mut self, session_id: SessionId) {
+        loop {
+            let queued = self.sockets.iter().find_map(|(listener_id, socket)| {
+                socket
+                    .tcp_state()
+                    .ok()
+                    .and_then(|tcp| tcp.listener.as_ref())
+                    .and_then(|listener| {
+                        listener
+                            .queue
+                            .iter()
+                            .find(|connection| connection.connector_session_id == session_id)
+                    })
+                    .map(|connection| (*listener_id, connection.connection_id))
+            });
+            let Some((listener_id, connection_id)) = queued else {
+                break;
+            };
+            if !self.remove_queued_guest_connection(listener_id, connection_id, false) {
+                break;
+            }
+        }
+    }
+
+    fn remove_queued_guest_connection(
+        &mut self,
+        listener_id: u64,
+        connection_id: u64,
+        reset_connector: bool,
+    ) -> bool {
+        let connection = self
+            .sockets
+            .get_mut(&listener_id)
+            .and_then(|listener| listener.tcp_state_mut().ok())
+            .and_then(|tcp| tcp.listener.as_mut())
+            .and_then(|listener| {
+                listener
+                    .queue
+                    .iter()
+                    .position(|connection| connection.connection_id == connection_id)
+                    .and_then(|index| listener.queue.remove(index))
+            });
+        let Some(connection) = connection else {
+            return false;
+        };
+        self.release_queued_guest_connection(connection.connector_session_id);
+        if let Some(connector) = self.sockets.get_mut(&connection.connector_id)
+            && let Ok(tcp) = connector.tcp_state_mut()
+            && let Some(endpoint) = tcp.guest_endpoint.as_mut()
+            && endpoint.connection_id == connection_id
         {
-            if global_at_limit && connection.retained_connector.is_none() {
-                return Ok(false);
-            }
-            if session_at_limit
-                && (connection.session_id != listener_session_id
-                    || connection.retained_connector.is_none())
-            {
-                return Ok(false);
-            }
+            endpoint.queued_listener_id = None;
         }
-        Ok(true)
+        if reset_connector {
+            self.mark_guest_socket_reset(connection.connector_id);
+        }
+        let _ = self.publish_listener_queue_readiness(listener_id);
+        self.sessions
+            .retain(|_, session| retain_session_state(session));
+        true
     }
 
-    fn is_private_tcp_host_endpoint(&self, address: SocketAddrV4) -> bool {
-        self.tcp
-            .bindings
-            .values()
-            .filter_map(|binding| binding.host_address)
-            .any(|host_address| host_address == address)
+    fn mark_guest_peer_reset(&mut self, connection_id: u64, excluded_id: u64) {
+        let peer_id = self.sockets.iter().find_map(|(id, socket)| {
+            (*id != excluded_id
+                && socket
+                    .tcp_state()
+                    .ok()
+                    .and_then(|tcp| tcp.guest_endpoint.as_ref())
+                    .is_some_and(|endpoint| endpoint.connection_id == connection_id))
+            .then_some(*id)
+        });
+        if let Some(peer_id) = peer_id {
+            self.mark_guest_socket_reset(peer_id);
+        }
     }
 
-    /// Reports whether an address names a live broker-private native UDP endpoint.
-    ///
-    /// Native UDP endpoints reserve their host port through an initial wildcard
-    /// bind, so a local address plus a registered host port identifies the
-    /// endpoint. Guest routing must check its namespace first because guest and
-    /// native ports may numerically collide.
-    pub(super) fn resolve_guest_destination(
+    fn mark_guest_socket_reset(&mut self, id: u64) {
+        let Some(socket) = self.sockets.get_mut(&id) else {
+            return;
+        };
+        let Ok(tcp) = socket.tcp_state_mut() else {
+            return;
+        };
+        let Some(endpoint) = tcp.guest_endpoint.as_mut() else {
+            return;
+        };
+        match endpoint.reset_state {
+            GuestTcpResetState::None => endpoint.reset_state = GuestTcpResetState::Pending,
+            GuestTcpResetState::Pending => {}
+            GuestTcpResetState::Reported => return,
+        }
+        let readiness = {
+            let mut snapshot = socket
+                .snapshot
+                .lock()
+                .expect("Linux socket snapshot mutex poisoned");
+            if snapshot.pending_error.is_none() {
+                snapshot.pending_error = Some(SocketError::ConnectionReset);
+            }
+            snapshot.readiness = snapshot.readiness
+                | ReadinessFlags::READ
+                | ReadinessFlags::ERROR
+                | ReadinessFlags::HANGUP;
+            snapshot.readiness
+        };
+        let _ = socket.readiness.publish(readiness);
+    }
+
+    fn publish_listener_queue_readiness(&self, listener_id: u64) -> BrokerResult<()> {
+        let listener = self
+            .sockets
+            .get(&listener_id)
+            .ok_or(BrokerError::Internal)?;
+        let queue_nonempty = listener
+            .tcp_state()?
+            .listener
+            .as_ref()
+            .is_some_and(|state| !state.queue.is_empty());
+        let current = listener
+            .snapshot
+            .lock()
+            .expect("Linux socket snapshot mutex poisoned")
+            .readiness;
+        if queue_nonempty {
+            if current.contains(ReadinessFlags::READ) {
+                listener.readiness.republish(current)
+            } else {
+                update_snapshot(listener, None, current | ReadinessFlags::READ)
+            }
+        } else if current.contains(ReadinessFlags::READ) {
+            update_snapshot(
+                listener,
+                None,
+                ReadinessFlags(current.0 & !ReadinessFlags::READ.0),
+            )
+        } else {
+            Ok(())
+        }
+    }
+
+    fn purge_failed_accept_setup(&mut self, listener_id: u64, connection_id: u64) {
+        if let Some(socket) = self
+            .sockets
+            .get(&listener_id)
+            .and_then(|listener| listener.tcp_state().ok())
+            .and_then(|tcp| tcp.listener.as_ref())
+            .and_then(|listener| {
+                listener
+                    .queue
+                    .iter()
+                    .find(|connection| connection.connection_id == connection_id)
+            })
+            .map(|connection| &connection.socket)
+        {
+            let _ = epoll::delete(&self.epoll, socket);
+        }
+        self.remove_queued_guest_connection(listener_id, connection_id, true);
+    }
+
+    fn resolve_guest_destination(
         &self,
         mut address: SocketAddrV4,
-    ) -> SocketOutcome<(SocketAddrV4, Option<u64>)> {
+    ) -> SocketOutcome<ResolvedTcpDestination> {
         if address.ip().is_unspecified() {
             address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, address.port());
         }
         if let Some(binding) = self.tcp.guest_binding(address) {
-            // A live guest binding owns this destination port broker-wide;
-            // only a listener with a fully classified backlog may receive
-            // new guest connections through it.
-            if !binding.listening
-                || binding.requires_backlog_drain
-                // Defence in depth for failures after connect(2) but before a
-                // complete host tuple can be recorded.
-                || binding.untracked_connection_deadline.is_some()
-            {
+            let listener_live = binding.listening
+                && self
+                    .sockets
+                    .get(&binding.socket_id)
+                    .and_then(|listener| listener.tcp_state().ok())
+                    .and_then(|tcp| tcp.listener.as_ref())
+                    .is_some_and(|listener| listener.listening);
+            if !listener_live {
                 return SocketOutcome::Failed(SocketError::ConnectionRefused);
             }
-            return match binding.host_address {
-                Some(host_address) => {
-                    SocketOutcome::Completed((host_address, Some(binding.socket_id)))
-                }
-                None => SocketOutcome::Failed(SocketError::ConnectionRefused),
-            };
+            return SocketOutcome::Completed(ResolvedTcpDestination::Guest {
+                listener_id: binding.socket_id,
+                concrete_address: address,
+            });
         }
         // TODO: Once gateway routing replaces host-loopback fallback, fail all
         // unmatched guest-network destinations closed.
@@ -1972,11 +1836,7 @@ impl Reactor {
         {
             return SocketOutcome::Failed(SocketError::ConnectionRefused);
         }
-        if self.is_private_tcp_host_endpoint(address) {
-            SocketOutcome::Failed(SocketError::ConnectionRefused)
-        } else {
-            SocketOutcome::Completed((address, None))
-        }
+        SocketOutcome::Completed(ResolvedTcpDestination::Native(address))
     }
 
     pub(super) fn listen_socket(
@@ -1993,38 +1853,30 @@ impl Reactor {
             return Ok(SocketOutcome::Failed(SocketError::InvalidArgument));
         }
         let guest_address = guest_address.ok_or(BrokerError::Internal)?;
-        let needs_host_bind = local_socket_address(
-            &self
-                .sockets
-                .get(&id)
-                .ok_or(BrokerError::Internal)?
-                .tcp_state()?
-                .socket,
-        )?
-        .port()
-            == 0;
-        if needs_host_bind {
-            let socket = self.sockets.get_mut(&id).ok_or(BrokerError::Internal)?;
-            let host_address =
-                match bind_host_socket(socket, SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0))? {
-                    SocketOutcome::Completed(address) => address,
-                    SocketOutcome::Failed(error) => return Ok(SocketOutcome::Failed(error)),
-                };
-            self.tcp
-                .set_host_address(guest_address.port(), id, host_address)?;
+        let backlog = usize::try_from(backlog)
+            .map_err(|_| BrokerError::UnsupportedOperation)?
+            .max(1);
+        let socket = self.sockets.get_mut(&id).ok_or(BrokerError::Internal)?;
+        if socket.connection_status != SocketConnectionStatus::Unconnected
+            || !matches!(socket.tcp_state()?.descriptor, TcpDescriptor::Unrealized)
+        {
+            return Ok(SocketOutcome::Failed(SocketError::InvalidArgument));
         }
-        match listen_tcp_socket(
-            &self.epoll,
-            id,
-            self.sockets.get_mut(&id).ok_or(BrokerError::Internal)?,
-            backlog,
-        )? {
-            SocketOutcome::Completed(()) => {
-                self.tcp.mark_listening(guest_address.port(), id)?;
-                Ok(SocketOutcome::Completed(guest_address))
+        match socket.tcp_state_mut()?.listener.as_mut() {
+            Some(listener) => {
+                listener.listening = true;
+                listener.backlog = backlog;
             }
-            SocketOutcome::Failed(error) => Ok(SocketOutcome::Failed(error)),
+            None => {
+                socket.tcp_state_mut()?.listener = Some(GuestTcpListenerState {
+                    listening: true,
+                    backlog,
+                    queue: VecDeque::new(),
+                });
+            }
         }
+        self.tcp.mark_listening(guest_address.port(), id)?;
+        Ok(SocketOutcome::Completed(guest_address))
     }
 
     pub(super) fn accept_socket(
@@ -2038,129 +1890,88 @@ impl Reactor {
         if self.sockets.contains_key(&accepted_id) {
             return Err(BrokerError::Internal);
         }
-        let (listener_session_id, listener_tcp_no_delay, listener_tcp_keep_alive) = {
+        let (
+            listener_session_id,
+            listener_tcp_no_delay,
+            listener_tcp_keep_alive,
+            queue_length,
+            accepted_local_address,
+            accepted_connection_id,
+            accepted_connector_session_id,
+        ) = {
             let listener = self
                 .sockets
                 .get(&listener_id)
                 .ok_or(BrokerError::Internal)?;
-            if listener.kind() != SocketKind::Tcp || !listener.tcp_state()?.listening {
+            let tcp = listener.tcp_state()?;
+            let Some(listener_state) = tcp.listener.as_ref().filter(|listener| listener.listening)
+            else {
                 return Ok(SocketOutcome::Failed(SocketError::NotConnected));
-            }
+            };
             (
                 listener.session_id,
-                listener.tcp_state()?.no_delay,
-                listener.tcp_state()?.keep_alive,
+                tcp.no_delay,
+                tcp.keep_alive,
+                listener_state.queue.len(),
+                listener_state.queue.front().map_or(
+                    listener.guest_local_address.ok_or(BrokerError::Internal)?,
+                    |queued| queued.local_address,
+                ),
+                listener_state
+                    .queue
+                    .front()
+                    .map(|queued| queued.connection_id),
+                listener_state
+                    .queue
+                    .front()
+                    .map(|queued| queued.connector_session_id),
             )
         };
-        self.expire_deadlined_state(Instant::now());
-        if !self.has_accept_capacity(listener_id, listener_session_id)? {
-            return Err(BrokerError::ResourceExhausted);
+        if queue_length == 0 {
+            self.publish_listener_queue_readiness(listener_id)?;
+            return Err(BrokerError::WouldBlock);
         }
-        let mut unmatched_accept_count = 0;
-        let (socket, remote_address, accepted_local_address) = loop {
-            let (socket, remote_address) = loop {
-                let listener = self
-                    .sockets
-                    .get_mut(&listener_id)
-                    .ok_or(BrokerError::Internal)?;
-                match acceptfrom_with(
-                    &listener.tcp_state()?.socket,
-                    LinuxSocketFlags::CLOEXEC | LinuxSocketFlags::NONBLOCK,
-                ) {
-                    Ok((socket, address)) => break (socket, address),
-                    Err(Errno::INTR) => {}
-                    Err(Errno::AGAIN) => {
-                        clear_readiness(listener, ReadinessFlags::READ)?;
-                        self.tcp.finish_listener_backlog_drain(listener_id)?;
-                        return Err(BrokerError::WouldBlock);
-                    }
-                    Err(error) => {
-                        return Ok(SocketOutcome::Failed(socket_operation_error_from_errno(
-                            error,
-                        )?));
-                    }
-                }
-            };
-            let remote_address =
-                SocketAddrV4::try_from(remote_address.ok_or(BrokerError::Internal)?)
-                    .map_err(|_| BrokerError::Internal)?;
-            let host_local_address = local_socket_address(&socket)?;
-            if let Some((guest_address, guest_local_address)) = self
-                .take_pending_guest_connection_for_accept(
-                    listener_id,
-                    remote_address,
-                    host_local_address,
-                )
-            {
-                break (socket, guest_address, guest_local_address);
-            }
-            drop(socket);
-            unmatched_accept_count += 1;
-            if unmatched_accept_count >= MAX_UNMATCHED_ACCEPTS_PER_COMMAND {
-                let listener = self
-                    .sockets
-                    .get(&listener_id)
-                    .ok_or(BrokerError::Internal)?;
-                let readiness = listener
-                    .snapshot
-                    .lock()
-                    .expect("Linux socket snapshot mutex poisoned")
-                    .readiness;
-                // Edge-triggered epoll will not report connections that remain
-                // queued, so wake a blocking accept waiter to continue draining.
-                listener.readiness.republish(readiness)?;
-                return Err(BrokerError::WouldBlock);
-            }
-        };
+        let accepted_connection_id = accepted_connection_id.ok_or(BrokerError::Internal)?;
+        let accepted_connector_session_id =
+            accepted_connector_session_id.ok_or(BrokerError::Internal)?;
         let listener_session = self
             .sessions
             .get(&listener_session_id)
             .ok_or(BrokerError::Internal)?;
-        if self
-            .sockets
-            .len()
-            .checked_add(self.tcp.retained_connector_count)
-            .is_none_or(|count| count >= self.max_sockets)
-            || listener_session
-                .live_socket_count
-                .checked_add(listener_session.retained_connector_count)
-                .is_none_or(|count| count >= self.max_sockets_per_session)
-        {
+        let next_listener_live_count = listener_session
+            .live_socket_count
+            .checked_add(1)
+            .ok_or(BrokerError::ResourceExhausted)?;
+        let transferred_pending = usize::from(accepted_connector_session_id == listener_session_id);
+        let next_listener_total = next_listener_live_count
+            .checked_add(listener_session.pending_guest_connection_count)
+            .and_then(|count| count.checked_sub(transferred_pending))
+            .ok_or(BrokerError::Internal)?;
+        if next_listener_total > self.max_sockets_per_session {
             return Err(BrokerError::ResourceExhausted);
         }
-        apply_tcp_options(&socket, listener_tcp_no_delay, listener_tcp_keep_alive)?;
-        let backlog_empty = {
+        {
             let listener = self
                 .sockets
-                .get_mut(&listener_id)
+                .get(&listener_id)
                 .ok_or(BrokerError::Internal)?;
-            let no_wait = Timespec {
-                tv_sec: 0,
-                tv_nsec: 0,
-            };
-            loop {
-                let mut poll_fd = [PollFd::new(&listener.tcp_state()?.socket, PollFlags::IN)];
-                match poll(&mut poll_fd, Some(&no_wait)) {
-                    Ok(_) if poll_fd[0].revents().contains(PollFlags::IN) => break false,
-                    Ok(_) => {
-                        clear_readiness(listener, ReadinessFlags::READ)?;
-                        break true;
-                    }
-                    Err(Errno::INTR) => {}
-                    Err(error) => return Err(broker_error_from_errno(error)),
-                }
+            let queued = listener
+                .tcp_state()?
+                .listener
+                .as_ref()
+                .and_then(|listener| listener.queue.front())
+                .ok_or(BrokerError::Internal)?;
+            if let Err(error) = epoll::add(
+                &self.epoll,
+                &queued.socket,
+                epoll::EventData::new_u64(accepted_id),
+                active_epoll_events(),
+            ) {
+                let error = broker_error_from_errno(error);
+                self.purge_failed_accept_setup(listener_id, accepted_connection_id);
+                return Err(error);
             }
-        };
-        if backlog_empty {
-            self.tcp.finish_listener_backlog_drain(listener_id)?;
         }
-        epoll::add(
-            &self.epoll,
-            &socket,
-            epoll::EventData::new_u64(accepted_id),
-            active_epoll_events(),
-        )
-        .map_err(broker_error_from_errno)?;
         {
             let mut snapshot = snapshot
                 .lock()
@@ -2169,22 +1980,63 @@ impl Reactor {
             snapshot.local_address = Some(accepted_local_address);
             snapshot.readiness = ReadinessFlags::WRITE;
         }
-        readiness.publish(ReadinessFlags::WRITE)?;
+        if let Err(error) = readiness.publish(ReadinessFlags::WRITE) {
+            self.purge_failed_accept_setup(listener_id, accepted_connection_id);
+            return Err(error);
+        }
+        if queue_length > 1
+            && let Err(error) = self.publish_listener_queue_readiness(listener_id)
+        {
+            self.purge_failed_accept_setup(listener_id, accepted_connection_id);
+            return Err(error);
+        }
         if !lifecycle.activate() {
+            self.purge_failed_accept_setup(listener_id, accepted_connection_id);
             return Err(BrokerError::Internal);
+        }
+        let queued = self
+            .sockets
+            .get_mut(&listener_id)
+            .ok_or(BrokerError::Internal)?
+            .tcp_state_mut()?
+            .listener
+            .as_mut()
+            .ok_or(BrokerError::Internal)?
+            .queue
+            .pop_front()
+            .ok_or(BrokerError::Internal)?;
+        let QueuedGuestTcpConnection {
+            socket,
+            connection_id,
+            connector_id,
+            connector_session_id,
+            local_address,
+            remote_address,
+            guest_source_lease,
+        } = queued;
+        self.release_queued_guest_connection(connector_session_id);
+        if let Some(connector) = self.sockets.get_mut(&connector_id)
+            && let Ok(tcp) = connector.tcp_state_mut()
+            && let Some(endpoint) = tcp.guest_endpoint.as_mut()
+            && endpoint.connection_id == connection_id
+        {
+            endpoint.queued_listener_id = None;
         }
         self.sockets.insert(
             accepted_id,
             SocketEntry {
                 session_id: listener_session_id,
                 transport: SocketTransportState::Tcp(TcpSocketState {
-                    socket,
-                    untracked_guest_listener_id: None,
+                    descriptor: TcpDescriptor::GuestUnix(socket),
+                    listener: None,
+                    guest_endpoint: Some(GuestTcpEndpoint {
+                        connection_id,
+                        side: GuestTcpSide::Accepted,
+                        queued_listener_id: None,
+                        reset_state: GuestTcpResetState::None,
+                    }),
                     peek_waitall_threshold: None,
-                    listening: false,
-                    was_listener: false,
                     abortive_close: false,
-                    host_connection: None,
                     no_delay: listener_tcp_no_delay,
                     keep_alive: listener_tcp_keep_alive,
                 }),
@@ -2193,20 +2045,56 @@ impl Reactor {
                 connection_status: SocketConnectionStatus::Connected,
                 read_shutdown: false,
                 write_shutdown: false,
-                guest_local_address: Some(accepted_local_address),
+                guest_local_address: Some(local_address),
             },
         );
         let session = self
             .sessions
             .get_mut(&listener_session_id)
             .ok_or(BrokerError::Internal)?;
-        session.live_socket_count = session
-            .live_socket_count
-            .checked_add(1)
-            .ok_or(BrokerError::ResourceExhausted)?;
+        session.live_socket_count = next_listener_live_count;
+        if queue_length == 1 {
+            let _ = self.publish_listener_queue_readiness(listener_id);
+        }
         Ok(SocketOutcome::Completed(AcceptedEndpoints {
-            local_address: accepted_local_address,
+            local_address,
             remote_address,
+            guest_source_lease,
         }))
     }
+}
+
+pub(super) fn guest_reset_pending(socket: &SocketEntry) -> BrokerResult<bool> {
+    Ok(socket
+        .tcp_state()?
+        .guest_endpoint
+        .as_ref()
+        .is_some_and(|endpoint| endpoint.reset_state == GuestTcpResetState::Pending))
+}
+
+pub(super) fn consume_pending_guest_reset(socket: &mut SocketEntry) -> BrokerResult<bool> {
+    let consumed = {
+        let tcp = socket.tcp_state_mut()?;
+        let Some(endpoint) = tcp.guest_endpoint.as_mut() else {
+            return Ok(false);
+        };
+        if endpoint.reset_state != GuestTcpResetState::Pending {
+            return Ok(false);
+        }
+        endpoint.reset_state = GuestTcpResetState::Reported;
+        true
+    };
+    if consumed {
+        let mut snapshot = socket
+            .snapshot
+            .lock()
+            .expect("Linux socket snapshot mutex poisoned");
+        if snapshot.pending_error == Some(SocketError::ConnectionReset) {
+            snapshot.pending_error = None;
+        }
+        if snapshot.pending_error.is_none() {
+            snapshot.readiness = ReadinessFlags(snapshot.readiness.0 & !ReadinessFlags::ERROR.0);
+        }
+    }
+    Ok(consumed)
 }

--- a/litebox_broker_platform_linux_userland/src/socket/tcp.rs
+++ b/litebox_broker_platform_linux_userland/src/socket/tcp.rs
@@ -77,6 +77,20 @@ impl GuestTcpReadShutdown {
     }
 }
 
+fn guest_tcp_has_unread_data(tcp: &TcpSocketState) -> bool {
+    tcp.guest_read_shutdown
+        .as_ref()
+        .is_some_and(GuestTcpReadShutdown::has_unread_data)
+        || match ioctl_fionread(
+            tcp.descriptor
+                .socket()
+                .expect("guest endpoint descriptor missing"),
+        ) {
+            Ok(0) => false,
+            Ok(_) | Err(_) => true,
+        }
+}
+
 pub(super) enum TcpDescriptor {
     Unrealized,
     NativeInet(OwnedFd),
@@ -1596,18 +1610,7 @@ impl Reactor {
                 .and_then(|socket| socket.tcp_state().ok())
                 .is_some_and(|tcp| {
                     tcp.abortive_close
-                        || tcp.descriptor.is_guest()
-                            && tcp.guest_read_shutdown.as_ref().map_or_else(
-                                || match ioctl_fionread(
-                                    tcp.descriptor
-                                        .socket()
-                                        .expect("guest endpoint descriptor missing"),
-                                ) {
-                                    Ok(0) => false,
-                                    Ok(_) | Err(_) => true,
-                                },
-                                GuestTcpReadShutdown::has_unread_data,
-                            )
+                        || tcp.descriptor.is_guest() && guest_tcp_has_unread_data(tcp)
                 });
         let socket = self
             .sockets
@@ -2146,4 +2149,32 @@ pub(super) fn consume_pending_guest_reset(socket: &mut SocketEntry) -> BrokerRes
         }
     }
     Ok(consumed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn guest_read_shutdown_detects_data_awaiting_discard() {
+        let (socket, peer) = socketpair(
+            rustix::net::AddressFamily::UNIX,
+            rustix::net::SocketType::STREAM,
+            LinuxSocketFlags::CLOEXEC | LinuxSocketFlags::NONBLOCK,
+            None,
+        )
+        .unwrap();
+        let SocketTransportState::Tcp(mut tcp) = create_tcp_transport() else {
+            unreachable!();
+        };
+        tcp.descriptor = TcpDescriptor::GuestUnix(socket);
+        tcp.guest_read_shutdown = Some(GuestTcpReadShutdown {
+            queued: Vec::new(),
+            consumed: 0,
+            discarded_data: false,
+        });
+
+        assert_eq!(send(&peer, b"x", LinuxSendFlags::NOSIGNAL).unwrap(), 1);
+        assert!(guest_tcp_has_unread_data(&tcp));
+    }
 }

--- a/litebox_broker_platform_linux_userland/src/socket/tests/mod.rs
+++ b/litebox_broker_platform_linux_userland/src/socket/tests/mod.rs
@@ -371,7 +371,10 @@ fn non_loopback_local_ipv4() -> Option<Ipv4Addr> {
     let probe = UdpSocket::bind((Ipv4Addr::UNSPECIFIED, 0)).ok()?;
     probe.connect((Ipv4Addr::new(192, 0, 2, 1), 9)).ok()?;
     let address = socket_address_v4(probe.local_addr().ok()?);
-    (!address.ip().is_unspecified() && !address.ip().is_loopback()).then_some(*address.ip())
+    (!address.ip().is_unspecified()
+        && !address.ip().is_loopback()
+        && *address.ip() != GUEST_IPV4_ADDRESS)
+        .then_some(*address.ip())
 }
 
 fn create_socket(
@@ -485,6 +488,23 @@ fn wait_for_readiness(
         readiness,
         Instant::now() + TEST_TIMEOUT,
     );
+}
+
+fn wait_for_readiness_publication(
+    publications: &Receiver<(ObjectHandle, ReadinessFlags)>,
+    handle: ObjectHandle,
+    readiness: ReadinessFlags,
+) {
+    let deadline = Instant::now() + TEST_TIMEOUT;
+    loop {
+        let remaining = deadline
+            .checked_duration_since(Instant::now())
+            .expect("timed out waiting for socket readiness publication");
+        let (published_handle, published) = publications.recv_timeout(remaining).unwrap();
+        if published_handle == handle && published.contains(readiness) {
+            return;
+        }
+    }
 }
 
 fn wait_until_ready(

--- a/litebox_broker_platform_linux_userland/src/socket/tests/mod.rs
+++ b/litebox_broker_platform_linux_userland/src/socket/tests/mod.rs
@@ -513,7 +513,22 @@ fn wait_until_ready(
     handle: ObjectHandle,
     readiness: ReadinessFlags,
 ) {
-    let deadline = Instant::now() + TEST_TIMEOUT;
+    wait_until_ready_until(
+        session,
+        publications,
+        handle,
+        readiness,
+        Instant::now() + TEST_TIMEOUT,
+    );
+}
+
+fn wait_until_ready_until(
+    session: &litebox_broker_core::BrokerSession,
+    publications: &Receiver<(ObjectHandle, ReadinessFlags)>,
+    handle: ObjectHandle,
+    readiness: ReadinessFlags,
+    deadline: Instant,
+) {
     loop {
         if session.check_readiness(handle).unwrap().contains(readiness) {
             return;

--- a/litebox_broker_platform_linux_userland/src/socket/tests/mod.rs
+++ b/litebox_broker_platform_linux_userland/src/socket/tests/mod.rs
@@ -3,7 +3,7 @@
 
 use std::io::{Read as _, Write as _};
 use std::net::Ipv4Addr;
-use std::net::{Shutdown, TcpListener, TcpStream, UdpSocket};
+use std::net::{Shutdown, TcpListener, UdpSocket};
 use std::sync::mpsc::{Receiver, Sender, channel};
 use std::time::{Duration, Instant};
 
@@ -211,7 +211,7 @@ impl ReadinessSink for TestReadinessSink {
 }
 
 struct PendingPublishFailure {
-    handle: ObjectHandle,
+    handle: Option<ObjectHandle>,
     required: ReadinessFlags,
     forbidden: ReadinessFlags,
 }
@@ -237,7 +237,15 @@ impl FailingReadinessSink {
         forbidden: ReadinessFlags,
     ) {
         *self.fail_next_publish.lock().unwrap() = Some(PendingPublishFailure {
-            handle,
+            handle: Some(handle),
+            required,
+            forbidden,
+        });
+    }
+
+    fn fail_next_publish_matching_any(&self, required: ReadinessFlags, forbidden: ReadinessFlags) {
+        *self.fail_next_publish.lock().unwrap() = Some(PendingPublishFailure {
+            handle: None,
             required,
             forbidden,
         });
@@ -270,7 +278,7 @@ impl ReadinessSink for FailingReadinessSink {
     fn publish(&self, handle: ObjectHandle, readiness: ReadinessFlags) -> BrokerResult<()> {
         let mut fail_next_publish = self.fail_next_publish.lock().unwrap();
         let should_fail = fail_next_publish.as_ref().is_some_and(|failure| {
-            failure.handle == handle
+            failure.handle.is_none_or(|failed| failed == handle)
                 && readiness.contains(failure.required)
                 && readiness.0 & failure.forbidden.0 == 0
         });

--- a/litebox_broker_platform_linux_userland/src/socket/tests/tcp.rs
+++ b/litebox_broker_platform_linux_userland/src/socket/tests/tcp.rs
@@ -273,12 +273,7 @@ fn reactor_drives_a_loopback_tcp_socket() {
     read_shutdown_data_received
         .recv_timeout(TEST_TIMEOUT)
         .unwrap();
-    wait_until_ready(
-        &session,
-        &publications,
-        read_shutdown_handle,
-        ReadinessFlags::READ,
-    );
+    wait_for_readiness_publication(&publications, read_shutdown_handle, ReadinessFlags::READ);
     let mut read_shutdown_peek = [0_u8; 2];
     assert_eq!(
         receive_into(
@@ -295,12 +290,7 @@ fn reactor_drives_a_loopback_tcp_socket() {
         litebox_broker_core::socket::shutdown(&session, read_shutdown_handle, ShutdownMode::Read,),
         Ok(SocketOutcome::Completed(()))
     );
-    wait_until_ready(
-        &session,
-        &publications,
-        read_shutdown_handle,
-        ReadinessFlags::READ,
-    );
+    wait_for_readiness_publication(&publications, read_shutdown_handle, ReadinessFlags::READ);
     assert_eq!(
         receive_into(
             &session,
@@ -1069,11 +1059,13 @@ fn accepted_guest_tcp_close_with_unread_data_preserves_reset() {
 
     connector_session.close_object_reference(connector).unwrap();
     assert_eq!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), connector);
-    wait_until_ready(
-        &listener_session,
-        &publications,
-        accepted,
-        ReadinessFlags::READ | ReadinessFlags::ERROR | ReadinessFlags::HANGUP,
+    let reset_readiness = ReadinessFlags::READ | ReadinessFlags::ERROR | ReadinessFlags::HANGUP;
+    wait_for_readiness_publication(&publications, accepted, reset_readiness);
+    assert!(
+        listener_session
+            .check_readiness(accepted)
+            .unwrap()
+            .contains(reset_readiness)
     );
     let mut byte = [0_u8; 1];
     assert_eq!(
@@ -1106,11 +1098,12 @@ fn accepted_guest_tcp_close_with_unread_data_preserves_reset() {
     );
     connector_session.close_object_reference(aborting).unwrap();
     assert_eq!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), aborting);
-    wait_until_ready(
-        &listener_session,
-        &publications,
-        abort_peer.handle,
-        ReadinessFlags::ERROR,
+    wait_for_readiness_publication(&publications, abort_peer.handle, reset_readiness);
+    assert!(
+        listener_session
+            .check_readiness(abort_peer.handle)
+            .unwrap()
+            .contains(reset_readiness)
     );
     assert_eq!(
         receive_into(
@@ -2092,12 +2085,7 @@ fn guest_tcp_stream_preserves_options_peek_waitall_and_half_close() {
         send_bytes(&connector_session, connector, b"a", SendFlags::NONE),
         Ok(SocketOutcome::Completed(1))
     );
-    wait_until_ready(
-        &listener_session,
-        &publications,
-        accepted.handle,
-        ReadinessFlags::READ,
-    );
+    wait_for_readiness_publication(&publications, accepted.handle, ReadinessFlags::READ);
     let mut peeked = [0_u8; 2];
     assert_eq!(
         receive_into(
@@ -2114,12 +2102,7 @@ fn guest_tcp_stream_preserves_options_peek_waitall_and_half_close() {
         send_bytes(&connector_session, connector, b"b", SendFlags::NONE),
         Ok(SocketOutcome::Completed(1))
     );
-    wait_until_ready(
-        &listener_session,
-        &publications,
-        accepted.handle,
-        ReadinessFlags::READ,
-    );
+    wait_for_readiness_publication(&publications, accepted.handle, ReadinessFlags::READ);
     assert_eq!(
         receive_into(
             &listener_session,
@@ -2447,8 +2430,7 @@ fn queued_guest_accept_transfers_capacity_without_global_growth() {
     let readiness = Arc::new(TestReadinessSink { published, retired });
     let address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8095);
     let listener = create_socket(&listener_session, readiness.clone());
-    let first_listener_capacity = create_socket(&listener_session, readiness.clone());
-    let second_listener_capacity = create_socket(&listener_session, readiness.clone());
+    let _listener_capacity = create_socket(&listener_session, readiness.clone());
     assert_eq!(
         litebox_broker_core::socket::bind(&listener_session, listener, address),
         Ok(SocketOutcome::Completed(address))
@@ -2466,6 +2448,7 @@ fn queued_guest_accept_transfers_capacity_without_global_growth() {
     let capacity_session = broker
         .create_session(CallerCredential::Unauthenticated)
         .unwrap();
+    let _global_capacity = create_socket(&capacity_session, readiness.clone());
     assert_eq!(
         litebox_broker_core::socket::create(
             &capacity_session,
@@ -2479,6 +2462,50 @@ fn queued_guest_accept_transfers_capacity_without_global_growth() {
         Err(BrokerError::ResourceExhausted)
     );
     assert_ne!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), listener);
+
+    let accepted =
+        litebox_broker_core::socket::accept(&listener_session, listener, readiness).unwrap();
+    assert!(matches!(accepted, SocketOutcome::Completed(_)));
+    assert_eq!(provider.reactor.queued_guest_connection_count(), 0);
+}
+
+#[test]
+fn queued_guest_accept_rejects_exhausted_listener_session_capacity() {
+    let provider = Arc::new(LinuxSocketProvider::new(6, 3).unwrap());
+    let broker = BrokerCore::new_with_limits(
+        PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
+            .with_socket_policy(SocketPolicy::guest_network()),
+        BrokerCoreLimits::new_with_all_limits(10, 0, 6, 6),
+        provider.clone(),
+    )
+    .unwrap();
+    let listener_session = broker
+        .create_session(CallerCredential::Unauthenticated)
+        .unwrap();
+    let connector_session = broker
+        .create_session(CallerCredential::Unauthenticated)
+        .unwrap();
+    let (published, _publications) = channel();
+    let (retired, retirements) = channel();
+    let readiness = Arc::new(TestReadinessSink { published, retired });
+    let address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8097);
+    let listener = create_socket(&listener_session, readiness.clone());
+    let listener_capacity = create_socket(&listener_session, readiness.clone());
+    let _second_listener_capacity = create_socket(&listener_session, readiness.clone());
+    assert_eq!(
+        litebox_broker_core::socket::bind(&listener_session, listener, address),
+        Ok(SocketOutcome::Completed(address))
+    );
+    assert_eq!(
+        litebox_broker_core::socket::listen(&listener_session, listener, 1),
+        Ok(SocketOutcome::Completed(address))
+    );
+    let connector = create_socket(&connector_session, readiness.clone());
+    assert_eq!(
+        litebox_broker_core::socket::connect(&connector_session, connector, address),
+        Ok(SocketOutcome::Completed(SocketConnectionStatus::Connected))
+    );
+    assert_eq!(provider.reactor.queued_guest_connection_count(), 1);
     assert!(matches!(
         litebox_broker_core::socket::accept(&listener_session, listener, readiness.clone(),),
         Err(BrokerError::ResourceExhausted)
@@ -2487,19 +2514,16 @@ fn queued_guest_accept_transfers_capacity_without_global_growth() {
     assert_ne!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), listener);
 
     listener_session
-        .close_object_reference(first_listener_capacity)
+        .close_object_reference(listener_capacity)
         .unwrap();
     assert_eq!(
         retirements.recv_timeout(TEST_TIMEOUT).unwrap(),
-        first_listener_capacity
+        listener_capacity
     );
     let accepted =
         litebox_broker_core::socket::accept(&listener_session, listener, readiness).unwrap();
     assert!(matches!(accepted, SocketOutcome::Completed(_)));
     assert_eq!(provider.reactor.queued_guest_connection_count(), 0);
-    listener_session
-        .close_object_reference(second_listener_capacity)
-        .unwrap();
 }
 
 #[test]

--- a/litebox_broker_platform_linux_userland/src/socket/tests/tcp.rs
+++ b/litebox_broker_platform_linux_userland/src/socket/tests/tcp.rs
@@ -62,6 +62,24 @@ fn connected_guest_tcp_pair(port: u16) -> GuestTcpPair {
     }
 }
 
+fn abort_and_close_accepted_peer(pair: &GuestTcpPair) {
+    assert_eq!(
+        litebox_broker_core::socket::shutdown(
+            &pair.listener_session,
+            pair.accepted,
+            ShutdownMode::Abort,
+        ),
+        Ok(SocketOutcome::Completed(()))
+    );
+    pair.listener_session
+        .close_object_reference(pair.accepted)
+        .unwrap();
+    assert_eq!(
+        pair.retirements.recv_timeout(TEST_TIMEOUT).unwrap(),
+        pair.accepted
+    );
+}
+
 #[test]
 fn reactor_drives_a_loopback_tcp_socket() {
     assert_eq!(
@@ -1110,21 +1128,7 @@ fn accepted_guest_tcp_close_with_unread_data_preserves_reset() {
 #[test]
 fn guest_tcp_direct_receive_reports_reset_once_then_eof() {
     let pair = connected_guest_tcp_pair(8101);
-    assert_eq!(
-        litebox_broker_core::socket::shutdown(
-            &pair.listener_session,
-            pair.accepted,
-            ShutdownMode::Abort,
-        ),
-        Ok(SocketOutcome::Completed(()))
-    );
-    pair.listener_session
-        .close_object_reference(pair.accepted)
-        .unwrap();
-    assert_eq!(
-        pair.retirements.recv_timeout(TEST_TIMEOUT).unwrap(),
-        pair.accepted
-    );
+    abort_and_close_accepted_peer(&pair);
     wait_until_ready(
         &pair.connector_session,
         &pair.publications,
@@ -1197,21 +1201,7 @@ fn guest_tcp_status_consumes_reset_before_buffered_data() {
         pair.connector,
         ReadinessFlags::READ,
     );
-    assert_eq!(
-        litebox_broker_core::socket::shutdown(
-            &pair.listener_session,
-            pair.accepted,
-            ShutdownMode::Abort,
-        ),
-        Ok(SocketOutcome::Completed(()))
-    );
-    pair.listener_session
-        .close_object_reference(pair.accepted)
-        .unwrap();
-    assert_eq!(
-        pair.retirements.recv_timeout(TEST_TIMEOUT).unwrap(),
-        pair.accepted
-    );
+    abort_and_close_accepted_peer(&pair);
     wait_until_ready(
         &pair.connector_session,
         &pair.publications,
@@ -1279,21 +1269,7 @@ fn guest_tcp_buffered_data_precedes_direct_reset_and_eof() {
         pair.connector,
         ReadinessFlags::READ,
     );
-    assert_eq!(
-        litebox_broker_core::socket::shutdown(
-            &pair.listener_session,
-            pair.accepted,
-            ShutdownMode::Abort,
-        ),
-        Ok(SocketOutcome::Completed(()))
-    );
-    pair.listener_session
-        .close_object_reference(pair.accepted)
-        .unwrap();
-    assert_eq!(
-        pair.retirements.recv_timeout(TEST_TIMEOUT).unwrap(),
-        pair.accepted
-    );
+    abort_and_close_accepted_peer(&pair);
 
     let mut buffered = [0_u8; 8];
     assert_eq!(
@@ -1362,8 +1338,6 @@ fn guest_tcp_namespace_routes_across_sessions_and_hides_private_backend() {
         litebox_broker_core::socket::bind(&listener_session, listener, guest_address),
         Ok(SocketOutcome::Completed(guest_address))
     );
-    assert_eq!(provider.reactor.host_address(guest_address.port()), None);
-
     let early_client = create_socket(&client_session, readiness.clone());
     assert_eq!(
         litebox_broker_core::socket::connect(&client_session, early_client, claimed_port_miss,),
@@ -1408,7 +1382,6 @@ fn guest_tcp_namespace_routes_across_sessions_and_hides_private_backend() {
         litebox_broker_core::socket::listen(&listener_session, listener, 3),
         Ok(SocketOutcome::Completed(guest_address))
     );
-    assert_eq!(provider.reactor.host_address(guest_address.port()), None);
     assert_eq!(provider.reactor.tcp_descriptor_counts(), (1, 0, 0));
     let client = create_socket(&client_session, readiness.clone());
     assert!(matches!(
@@ -1424,7 +1397,6 @@ fn guest_tcp_namespace_routes_across_sessions_and_hides_private_backend() {
         .local_address
         .unwrap();
     assert_eq!(*client_address.ip(), GUEST_IPV4_ADDRESS);
-    assert_eq!(provider.reactor.host_address(client_address.port()), None);
     wait_until_ready(
         &listener_session,
         &publications,
@@ -2610,8 +2582,6 @@ fn stop_listening_cleanup_survives_readiness_failure() {
         litebox_broker_core::socket::listen(&listener_session, listener, 1),
         Ok(SocketOutcome::Completed(guest_address))
     );
-    assert_eq!(provider.reactor.host_address(guest_address.port()), None);
-
     let connector = create_socket(&connector_session, readiness.clone());
     assert!(matches!(
         litebox_broker_core::socket::connect(&connector_session, connector, guest_address,),
@@ -2645,7 +2615,6 @@ fn stop_listening_cleanup_survives_readiness_failure() {
     assert!(listener_readiness.contains(ReadinessFlags::HANGUP));
     assert!(!listener_readiness.contains(ReadinessFlags::READ));
     assert_eq!(provider.reactor.queued_guest_connection_count(), 0);
-    assert_eq!(provider.reactor.host_address(guest_address.port()), None);
     assert_eq!(
         litebox_broker_core::socket::listen(&listener_session, listener, 1),
         Ok(SocketOutcome::Failed(SocketError::InvalidArgument))
@@ -2663,7 +2632,6 @@ fn stop_listening_cleanup_survives_readiness_failure() {
     listener_session.close_object_reference(listener).unwrap();
     assert_eq!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), listener);
     assert_eq!(provider.reactor.queued_guest_connection_count(), 0);
-    assert_eq!(provider.reactor.host_address(guest_address.port()), None);
 }
 
 #[test]
@@ -2691,7 +2659,6 @@ fn reactor_drives_a_loopback_tcp_listener() {
     };
     assert!(local_address.ip().is_loopback());
     assert_ne!(local_address.port(), 0);
-    assert_eq!(provider.reactor.host_address(local_address.port()), None);
     assert_eq!(
         litebox_broker_core::socket::shutdown(&session, listener, ShutdownMode::Write),
         Ok(SocketOutcome::Failed(SocketError::NotConnected))

--- a/litebox_broker_platform_linux_userland/src/socket/tests/tcp.rs
+++ b/litebox_broker_platform_linux_userland/src/socket/tests/tcp.rs
@@ -2161,6 +2161,21 @@ fn guest_tcp_stream_preserves_options_peek_waitall_and_half_close() {
 fn guest_tcp_read_shutdown_is_logical_and_unread_close_resets_peer() {
     let pair = connected_guest_tcp_pair(8105);
     assert_eq!(
+        send_bytes(
+            &pair.listener_session,
+            pair.accepted,
+            b"queued",
+            SendFlags::NONE,
+        ),
+        Ok(SocketOutcome::Completed(6))
+    );
+    wait_until_ready(
+        &pair.connector_session,
+        &pair.publications,
+        pair.connector,
+        ReadinessFlags::READ,
+    );
+    assert_eq!(
         litebox_broker_core::socket::shutdown(
             &pair.connector_session,
             pair.connector,
@@ -2177,7 +2192,31 @@ fn guest_tcp_read_shutdown_is_logical_and_unread_close_resets_peer() {
         ),
         Ok(SocketOutcome::Completed(6))
     );
-    let mut data = [0_u8; 6];
+    let mut data = [0_u8; 12];
+    assert_eq!(
+        receive_into(
+            &pair.connector_session,
+            pair.connector,
+            &mut data,
+            ReceiveFlags(ReceiveFlags::PEEK.0 | ReceiveFlags::WAITALL.0),
+            0,
+            12,
+        ),
+        Ok(SocketOutcome::Completed(ReceiveSocketResponse::Received(6)))
+    );
+    assert_eq!(&data[..6], b"queued");
+    assert_eq!(
+        receive_into(
+            &pair.connector_session,
+            pair.connector,
+            &mut data,
+            ReceiveFlags::NONE,
+            0,
+            0,
+        ),
+        Ok(SocketOutcome::Completed(ReceiveSocketResponse::Received(6)))
+    );
+    assert_eq!(&data[..6], b"queued");
     assert_eq!(
         receive_into(
             &pair.connector_session,
@@ -2215,6 +2254,21 @@ fn guest_tcp_read_shutdown_is_logical_and_unread_close_resets_peer() {
 fn guest_tcp_both_shutdown_keeps_peer_send_open_and_closes_write_half() {
     let pair = connected_guest_tcp_pair(8106);
     assert_eq!(
+        send_bytes(
+            &pair.listener_session,
+            pair.accepted,
+            b"queued",
+            SendFlags::NONE,
+        ),
+        Ok(SocketOutcome::Completed(6))
+    );
+    wait_until_ready(
+        &pair.connector_session,
+        &pair.publications,
+        pair.connector,
+        ReadinessFlags::READ,
+    );
+    assert_eq!(
         litebox_broker_core::socket::shutdown(
             &pair.connector_session,
             pair.connector,
@@ -2232,7 +2286,19 @@ fn guest_tcp_both_shutdown_keeps_peer_send_open_and_closes_write_half() {
         ),
         Ok(SocketOutcome::Completed(6))
     );
-    let mut data = [0_u8; 6];
+    let mut data = [0_u8; 12];
+    assert_eq!(
+        receive_into(
+            &pair.connector_session,
+            pair.connector,
+            &mut data,
+            ReceiveFlags::NONE,
+            0,
+            0,
+        ),
+        Ok(SocketOutcome::Completed(ReceiveSocketResponse::Received(6)))
+    );
+    assert_eq!(&data[..6], b"queued");
     assert_eq!(
         receive_into(
             &pair.connector_session,
@@ -2545,8 +2611,32 @@ fn abortive_connector_close_releases_descriptor_capacity() {
         litebox_broker_core::socket::shutdown(&connector_session, connector, ShutdownMode::Abort,),
         Ok(SocketOutcome::Completed(()))
     );
+    assert_eq!(provider.reactor.queued_guest_connection_count(), 1);
+    let accepted =
+        match litebox_broker_core::socket::accept(&listener_session, listener, readiness.clone())
+            .unwrap()
+        {
+            SocketOutcome::Completed(accepted) => accepted.handle,
+            SocketOutcome::Failed(error) => panic!("accept after Abort failed: {error:?}"),
+        };
+    assert_eq!(provider.reactor.queued_guest_connection_count(), 0);
     connector_session.close_object_reference(connector).unwrap();
     assert_eq!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), connector);
+    wait_for_guest_reset(&listener_session, &publications, accepted);
+    let mut byte = [0_u8; 1];
+    assert_eq!(
+        receive_into(
+            &listener_session,
+            accepted,
+            &mut byte,
+            ReceiveFlags::NONE,
+            0,
+            0,
+        ),
+        Ok(SocketOutcome::Failed(SocketError::ConnectionReset))
+    );
+    listener_session.close_object_reference(accepted).unwrap();
+    assert_eq!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), accepted);
     assert_eq!(provider.reactor.queued_guest_connection_count(), 0);
 
     let replacement = create_socket(&connector_session, readiness);

--- a/litebox_broker_platform_linux_userland/src/socket/tests/tcp.rs
+++ b/litebox_broker_platform_linux_userland/src/socket/tests/tcp.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+use super::super::tcp::{TcpDescriptor, create_tcp_transport};
 use super::*;
 use std::collections::VecDeque;
 
@@ -2365,6 +2366,28 @@ fn guest_tcp_read_shutdown_is_logical_and_unread_close_resets_peer() {
         ),
         Ok(SocketOutcome::Failed(SocketError::ConnectionReset))
     );
+}
+
+#[test]
+fn guest_read_shutdown_detects_data_awaiting_discard() {
+    let (socket, peer) = rustix::net::socketpair(
+        rustix::net::AddressFamily::UNIX,
+        rustix::net::SocketType::STREAM,
+        rustix::net::SocketFlags::CLOEXEC | rustix::net::SocketFlags::NONBLOCK,
+        None,
+    )
+    .unwrap();
+    let SocketTransportState::Tcp(mut tcp) = create_tcp_transport() else {
+        unreachable!();
+    };
+    tcp.descriptor = TcpDescriptor::GuestUnix(socket);
+    tcp.install_empty_guest_read_shutdown_for_test();
+
+    assert_eq!(
+        rustix::net::send(&peer, b"x", rustix::net::SendFlags::NOSIGNAL).unwrap(),
+        1
+    );
+    assert!(tcp.has_guest_unread_data_for_test());
 }
 
 #[test]

--- a/litebox_broker_platform_linux_userland/src/socket/tests/tcp.rs
+++ b/litebox_broker_platform_linux_userland/src/socket/tests/tcp.rs
@@ -2185,6 +2185,36 @@ fn guest_tcp_read_shutdown_is_logical_and_unread_close_resets_peer() {
     );
     assert_eq!(
         send_bytes(
+            &pair.connector_session,
+            pair.connector,
+            b"write remains open",
+            SendFlags::NONE,
+        ),
+        Ok(SocketOutcome::Completed(18))
+    );
+    wait_until_ready(
+        &pair.listener_session,
+        &pair.publications,
+        pair.accepted,
+        ReadinessFlags::READ,
+    );
+    let mut write_response = [0_u8; 18];
+    assert_eq!(
+        receive_into(
+            &pair.listener_session,
+            pair.accepted,
+            &mut write_response,
+            ReceiveFlags::NONE,
+            0,
+            0,
+        ),
+        Ok(SocketOutcome::Completed(ReceiveSocketResponse::Received(
+            18
+        )))
+    );
+    assert_eq!(&write_response, b"write remains open");
+    assert_eq!(
+        send_bytes(
             &pair.listener_session,
             pair.accepted,
             b"unread",
@@ -2194,6 +2224,7 @@ fn guest_tcp_read_shutdown_is_logical_and_unread_close_resets_peer() {
     );
     let payload = vec![0_u8; MAX_SOCKET_TRANSFER_SIZE as usize];
     let mut sent = 0;
+    let send_deadline = Instant::now() + TEST_TIMEOUT;
     while sent < 2 * 1024 * 1024 {
         match send_bytes(
             &pair.listener_session,
@@ -2202,6 +2233,13 @@ fn guest_tcp_read_shutdown_is_logical_and_unread_close_resets_peer() {
             SendFlags::NONE,
         ) {
             Ok(SocketOutcome::Completed(count)) if count != 0 => sent += count,
+            Err(BrokerError::WouldBlock) => wait_until_ready_until(
+                &pair.listener_session,
+                &pair.publications,
+                pair.accepted,
+                ReadinessFlags::WRITE,
+                send_deadline,
+            ),
             outcome => panic!("post-shutdown send stopped making progress: {outcome:?}"),
         }
     }

--- a/litebox_broker_platform_linux_userland/src/socket/tests/tcp.rs
+++ b/litebox_broker_platform_linux_userland/src/socket/tests/tcp.rs
@@ -2192,6 +2192,19 @@ fn guest_tcp_read_shutdown_is_logical_and_unread_close_resets_peer() {
         ),
         Ok(SocketOutcome::Completed(6))
     );
+    let payload = vec![0_u8; MAX_SOCKET_TRANSFER_SIZE as usize];
+    let mut sent = 0;
+    while sent < 2 * 1024 * 1024 {
+        match send_bytes(
+            &pair.listener_session,
+            pair.accepted,
+            &payload,
+            SendFlags::NONE,
+        ) {
+            Ok(SocketOutcome::Completed(count)) if count != 0 => sent += count,
+            outcome => panic!("post-shutdown send stopped making progress: {outcome:?}"),
+        }
+    }
     let mut data = [0_u8; 12];
     assert_eq!(
         receive_into(

--- a/litebox_broker_platform_linux_userland/src/socket/tests/tcp.rs
+++ b/litebox_broker_platform_linux_userland/src/socket/tests/tcp.rs
@@ -1148,6 +1148,15 @@ fn guest_tcp_direct_receive_reports_reset_once_then_eof() {
         ),
         Ok(SocketOutcome::Failed(SocketError::ConnectionReset))
     );
+    loop {
+        let (handle, readiness) = pair.publications.recv_timeout(TEST_TIMEOUT).unwrap();
+        if handle == pair.connector
+            && readiness.contains(ReadinessFlags::READ | ReadinessFlags::HANGUP)
+            && !readiness.contains(ReadinessFlags::ERROR)
+        {
+            break;
+        }
+    }
     let readiness = pair
         .connector_session
         .check_readiness(pair.connector)

--- a/litebox_broker_platform_linux_userland/src/socket/tests/tcp.rs
+++ b/litebox_broker_platform_linux_userland/src/socket/tests/tcp.rs
@@ -2384,6 +2384,63 @@ fn guest_tcp_both_shutdown_keeps_peer_send_open_and_closes_write_half() {
 }
 
 #[test]
+fn drained_guest_read_shutdown_close_delivers_end_of_stream() {
+    let pair = connected_guest_tcp_pair(8107);
+    assert_eq!(
+        litebox_broker_core::socket::shutdown(
+            &pair.connector_session,
+            pair.connector,
+            ShutdownMode::Read,
+        ),
+        Ok(SocketOutcome::Completed(()))
+    );
+    assert_eq!(
+        send_bytes(
+            &pair.connector_session,
+            pair.connector,
+            b"drained",
+            SendFlags::NONE,
+        ),
+        Ok(SocketOutcome::Completed(7))
+    );
+    wait_until_ready(
+        &pair.listener_session,
+        &pair.publications,
+        pair.accepted,
+        ReadinessFlags::READ,
+    );
+    let mut data = [0_u8; 7];
+    assert_eq!(
+        receive_into(
+            &pair.listener_session,
+            pair.accepted,
+            &mut data,
+            ReceiveFlags::NONE,
+            0,
+            0,
+        ),
+        Ok(SocketOutcome::Completed(ReceiveSocketResponse::Received(7)))
+    );
+    assert_eq!(&data, b"drained");
+
+    pair.connector_session
+        .close_object_reference(pair.connector)
+        .unwrap();
+    assert_eq!(
+        pair.retirements.recv_timeout(TEST_TIMEOUT).unwrap(),
+        pair.connector
+    );
+    wait_for_end_of_stream(&pair.listener_session, pair.accepted, &pair.publications);
+    assert!(
+        !pair
+            .listener_session
+            .check_readiness(pair.accepted)
+            .unwrap()
+            .contains(ReadinessFlags::ERROR)
+    );
+}
+
+#[test]
 fn guest_tcp_connect_publication_failure_purges_committed_queue() {
     let provider = Arc::new(LinuxSocketProvider::new(4, 3).unwrap());
     let broker = BrokerCore::new_with_limits(

--- a/litebox_broker_platform_linux_userland/src/socket/tests/tcp.rs
+++ b/litebox_broker_platform_linux_userland/src/socket/tests/tcp.rs
@@ -1308,6 +1308,72 @@ fn guest_tcp_buffered_data_precedes_direct_reset_and_eof() {
 }
 
 #[test]
+fn guest_read_shutdown_buffer_precedes_reset_and_eof() {
+    let pair = connected_guest_tcp_pair(8108);
+    assert_eq!(
+        send_bytes(
+            &pair.listener_session,
+            pair.accepted,
+            b"queued",
+            SendFlags::NONE,
+        ),
+        Ok(SocketOutcome::Completed(6))
+    );
+    wait_until_ready(
+        &pair.connector_session,
+        &pair.publications,
+        pair.connector,
+        ReadinessFlags::READ,
+    );
+    assert_eq!(
+        litebox_broker_core::socket::shutdown(
+            &pair.connector_session,
+            pair.connector,
+            ShutdownMode::Read,
+        ),
+        Ok(SocketOutcome::Completed(()))
+    );
+    abort_and_close_accepted_peer(&pair);
+    wait_for_guest_reset(&pair.connector_session, &pair.publications, pair.connector);
+
+    let mut data = [0_u8; 6];
+    assert_eq!(
+        receive_into(
+            &pair.connector_session,
+            pair.connector,
+            &mut data,
+            ReceiveFlags::NONE,
+            0,
+            0,
+        ),
+        Ok(SocketOutcome::Completed(ReceiveSocketResponse::Received(6)))
+    );
+    assert_eq!(&data, b"queued");
+    assert_eq!(
+        receive_into(
+            &pair.connector_session,
+            pair.connector,
+            &mut data,
+            ReceiveFlags::NONE,
+            0,
+            0,
+        ),
+        Ok(SocketOutcome::Failed(SocketError::ConnectionReset))
+    );
+    assert_eq!(
+        receive_into(
+            &pair.connector_session,
+            pair.connector,
+            &mut data,
+            ReceiveFlags::NONE,
+            0,
+            0,
+        ),
+        Ok(SocketOutcome::Completed(ReceiveSocketResponse::EndOfStream))
+    );
+}
+
+#[test]
 fn guest_tcp_namespace_routes_across_sessions_and_hides_private_backend() {
     let provider = Arc::new(LinuxSocketProvider::new(5, 3).unwrap());
     let broker = BrokerCore::new_with_limits(

--- a/litebox_broker_platform_linux_userland/src/socket/tests/tcp.rs
+++ b/litebox_broker_platform_linux_userland/src/socket/tests/tcp.rs
@@ -80,6 +80,16 @@ fn abort_and_close_accepted_peer(pair: &GuestTcpPair) {
     );
 }
 
+fn wait_for_guest_reset(
+    session: &BrokerSession,
+    publications: &Receiver<(ObjectHandle, ReadinessFlags)>,
+    handle: ObjectHandle,
+) {
+    let readiness = ReadinessFlags::READ | ReadinessFlags::ERROR | ReadinessFlags::HANGUP;
+    wait_for_readiness_publication(publications, handle, readiness);
+    assert!(session.check_readiness(handle).unwrap().contains(readiness));
+}
+
 #[test]
 fn reactor_drives_a_loopback_tcp_socket() {
     assert_eq!(
@@ -955,19 +965,29 @@ fn exhausted_tcp_peek_cache_refreshes_before_terminal_eof() {
 
     let peek_length = MAX_SOCKET_TRANSFER_SIZE * 2;
     let mut first = vec![0_u8; chunk];
-    assert_eq!(
-        receive_into(
+    let deadline = Instant::now() + TEST_TIMEOUT;
+    loop {
+        match receive_into(
             &session,
             handle,
             &mut first,
             ReceiveFlags::PEEK,
             0,
             peek_length,
-        ),
-        Ok(SocketOutcome::Completed(ReceiveSocketResponse::Received(
-            MAX_SOCKET_TRANSFER_SIZE
-        )))
-    );
+        ) {
+            Ok(SocketOutcome::Completed(ReceiveSocketResponse::Received(
+                MAX_SOCKET_TRANSFER_SIZE,
+            ))) => break,
+            Ok(SocketOutcome::Completed(ReceiveSocketResponse::Received(_)))
+            | Err(BrokerError::WouldBlock) => {
+                deadline
+                    .checked_duration_since(Instant::now())
+                    .expect("timed out waiting for the first TCP peek chunk");
+                thread::yield_now();
+            }
+            outcome => panic!("unexpected first peek outcome: {outcome:?}"),
+        }
+    }
     assert!(first.iter().all(|byte| *byte == 0x41));
 
     send_second_chunk.send(()).unwrap();
@@ -1059,14 +1079,7 @@ fn accepted_guest_tcp_close_with_unread_data_preserves_reset() {
 
     connector_session.close_object_reference(connector).unwrap();
     assert_eq!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), connector);
-    let reset_readiness = ReadinessFlags::READ | ReadinessFlags::ERROR | ReadinessFlags::HANGUP;
-    wait_for_readiness_publication(&publications, accepted, reset_readiness);
-    assert!(
-        listener_session
-            .check_readiness(accepted)
-            .unwrap()
-            .contains(reset_readiness)
-    );
+    wait_for_guest_reset(&listener_session, &publications, accepted);
     let mut byte = [0_u8; 1];
     assert_eq!(
         receive_into(
@@ -1098,13 +1111,7 @@ fn accepted_guest_tcp_close_with_unread_data_preserves_reset() {
     );
     connector_session.close_object_reference(aborting).unwrap();
     assert_eq!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), aborting);
-    wait_for_readiness_publication(&publications, abort_peer.handle, reset_readiness);
-    assert!(
-        listener_session
-            .check_readiness(abort_peer.handle)
-            .unwrap()
-            .contains(reset_readiness)
-    );
+    wait_for_guest_reset(&listener_session, &publications, abort_peer.handle);
     assert_eq!(
         receive_into(
             &listener_session,
@@ -1122,12 +1129,7 @@ fn accepted_guest_tcp_close_with_unread_data_preserves_reset() {
 fn guest_tcp_direct_receive_reports_reset_once_then_eof() {
     let pair = connected_guest_tcp_pair(8101);
     abort_and_close_accepted_peer(&pair);
-    wait_until_ready(
-        &pair.connector_session,
-        &pair.publications,
-        pair.connector,
-        ReadinessFlags::ERROR,
-    );
+    wait_for_guest_reset(&pair.connector_session, &pair.publications, pair.connector);
 
     let mut byte = [0_u8; 1];
     assert_eq!(
@@ -1204,12 +1206,7 @@ fn guest_tcp_status_consumes_reset_before_buffered_data() {
         ReadinessFlags::READ,
     );
     abort_and_close_accepted_peer(&pair);
-    wait_until_ready(
-        &pair.connector_session,
-        &pair.publications,
-        pair.connector,
-        ReadinessFlags::ERROR,
-    );
+    wait_for_guest_reset(&pair.connector_session, &pair.publications, pair.connector);
 
     let status =
         litebox_broker_core::socket::status(&pair.connector_session, pair.connector).unwrap();
@@ -1689,12 +1686,7 @@ fn connector_and_session_teardown_clean_bounded_pending_state() {
     listener_session.close_object_reference(listener).unwrap();
     assert_eq!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), listener);
     assert_eq!(provider.reactor.queued_guest_connection_count(), 0);
-    wait_until_ready(
-        &final_connector_session,
-        &publications,
-        final_connector,
-        ReadinessFlags::ERROR,
-    );
+    wait_for_guest_reset(&final_connector_session, &publications, final_connector);
     let mut byte = [0_u8; 1];
     assert_eq!(
         receive_into(
@@ -2205,12 +2197,7 @@ fn guest_tcp_read_shutdown_is_logical_and_unread_close_resets_peer() {
         pair.retirements.recv_timeout(TEST_TIMEOUT).unwrap(),
         pair.connector
     );
-    wait_until_ready(
-        &pair.listener_session,
-        &pair.publications,
-        pair.accepted,
-        ReadinessFlags::ERROR,
-    );
+    wait_for_guest_reset(&pair.listener_session, &pair.publications, pair.accepted);
     assert_eq!(
         receive_into(
             &pair.listener_session,
@@ -2265,12 +2252,7 @@ fn guest_tcp_both_shutdown_keeps_peer_send_open_and_closes_write_half() {
         pair.retirements.recv_timeout(TEST_TIMEOUT).unwrap(),
         pair.connector
     );
-    wait_until_ready(
-        &pair.listener_session,
-        &pair.publications,
-        pair.accepted,
-        ReadinessFlags::ERROR,
-    );
+    wait_for_guest_reset(&pair.listener_session, &pair.publications, pair.accepted);
     assert_eq!(
         receive_into(
             &pair.listener_session,
@@ -2389,12 +2371,7 @@ fn guest_tcp_accept_publication_failure_purges_registered_endpoint() {
             .unwrap()
             .contains(ReadinessFlags::READ)
     );
-    wait_until_ready(
-        &connector_session,
-        &publications,
-        connector,
-        ReadinessFlags::ERROR,
-    );
+    wait_for_guest_reset(&connector_session, &publications, connector);
     let mut byte = [0_u8; 1];
     assert_eq!(
         receive_into(

--- a/litebox_broker_platform_linux_userland/src/socket/tests/tcp.rs
+++ b/litebox_broker_platform_linux_userland/src/socket/tests/tcp.rs
@@ -2,126 +2,24 @@
 // Licensed under the MIT license.
 
 use super::*;
+use std::collections::VecDeque;
 
-#[test]
-fn pending_guest_connections_are_keyed_by_complete_host_tuple() {
-    let remote_address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 40000);
-    let first_listener = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 5000);
-    let second_listener = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 5001);
-    let first_guest = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 1000);
-    let second_guest = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 1001);
-    let mut tcp = ReactorTcpState::default();
-    for (listener, guest) in [
-        (first_listener, first_guest),
-        (second_listener, second_guest),
-    ] {
-        tcp.insert_pending_guest_connection(
-            (remote_address, listener),
-            PendingGuestTcpConnection {
-                session_id: SessionId(7),
-                guest_address: guest,
-                local_address: listener,
-                listener_id: 1,
-                discard_on_accept: false,
-                discard_until_deadline: false,
-                discard_deadline: None,
-                retained_connector: None,
-            },
-        )
-        .unwrap();
-    }
-    assert_eq!(
-        tcp.insert_pending_guest_connection(
-            (remote_address, first_listener),
-            PendingGuestTcpConnection {
-                session_id: SessionId(8),
-                guest_address: SocketAddrV4::new(Ipv4Addr::LOCALHOST, 1002),
-                local_address: first_listener,
-                listener_id: 1,
-                discard_on_accept: false,
-                discard_until_deadline: false,
-                discard_deadline: None,
-                retained_connector: None,
-            },
-        ),
-        Err(BrokerError::ResourceExhausted)
-    );
-
-    assert_eq!(
-        match tcp
-            .take_pending_guest_connection(remote_address, second_listener)
-            .unwrap()
-        {
-            PendingGuestConnectionMatch::Take(connection) => connection.guest_address,
-            PendingGuestConnectionMatch::PersistentDiscard => {
-                panic!("deliverable connection became a discard marker")
-            }
-        },
-        second_guest
-    );
-    assert_eq!(
-        match tcp
-            .take_pending_guest_connection(remote_address, first_listener)
-            .unwrap()
-        {
-            PendingGuestConnectionMatch::Take(connection) => connection.guest_address,
-            PendingGuestConnectionMatch::PersistentDiscard => {
-                panic!("deliverable connection became a discard marker")
-            }
-        },
-        first_guest
-    );
-    assert!(tcp.pending_guest_connections.is_empty());
+struct GuestTcpPair {
+    listener_session: BrokerSession,
+    connector_session: BrokerSession,
+    connector: ObjectHandle,
+    accepted: ObjectHandle,
+    publications: Receiver<(ObjectHandle, ReadinessFlags)>,
+    retirements: Receiver<ObjectHandle>,
 }
 
-#[test]
-fn tuple_collision_persists_its_discard_marker() {
-    let guest_address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 5000);
-    let remote_address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 40000);
-    let host_address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 41000);
-    let connection = (remote_address, host_address);
-    let deadline = Instant::now() + PENDING_CONNECT_DISCARD_LIFETIME;
-    let mut tcp = ReactorTcpState::default();
-    assert!(!tcp.persist_discard_marker_for_collision(connection, 1, deadline));
-    tcp.insert_pending_guest_connection(
-        connection,
-        PendingGuestTcpConnection {
-            session_id: SessionId(7),
-            guest_address,
-            local_address: guest_address,
-            listener_id: 1,
-            discard_on_accept: false,
-            discard_until_deadline: false,
-            discard_deadline: Some(Instant::now()),
-            retained_connector: None,
-        },
-    )
-    .unwrap();
-    assert!(!tcp.persist_discard_marker_for_collision(connection, 1, deadline));
-    tcp.pending_guest_connections
-        .get_mut(&connection)
-        .unwrap()
-        .discard_on_accept = true;
-
-    assert!(tcp.persist_discard_marker_for_collision(connection, 1, deadline));
-    let marker = tcp.pending_guest_connections.get(&connection).unwrap();
-    assert!(marker.discard_until_deadline);
-    assert_eq!(marker.discard_deadline, Some(deadline));
-    assert!(matches!(
-        tcp.take_pending_guest_connection(remote_address, host_address),
-        Some(PendingGuestConnectionMatch::PersistentDiscard)
-    ));
-    assert!(tcp.pending_guest_connections.contains_key(&connection));
-}
-
-#[test]
-fn untracked_guest_connection_cleanup_is_bounded_and_drains_backlog() {
-    let provider = Arc::new(LinuxSocketProvider::new(6, 3).unwrap());
+fn connected_guest_tcp_pair(port: u16) -> GuestTcpPair {
+    let provider = Arc::new(LinuxSocketProvider::new(4, 3).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
             .with_socket_policy(SocketPolicy::guest_network()),
-        BrokerCoreLimits::new_with_all_limits(12, 0, 6, 6),
-        provider.clone(),
+        BrokerCoreLimits::new_with_all_limits(8, 0, 4, 4),
+        provider,
     )
     .unwrap();
     let listener_session = broker
@@ -133,85 +31,35 @@ fn untracked_guest_connection_cleanup_is_bounded_and_drains_backlog() {
     let (published, publications) = channel();
     let (retired, retirements) = channel();
     let readiness = Arc::new(TestReadinessSink { published, retired });
-    let guest_address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8090);
+    let address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, port);
     let listener = create_socket(&listener_session, readiness.clone());
     assert_eq!(
-        litebox_broker_core::socket::bind(&listener_session, listener, guest_address),
-        Ok(SocketOutcome::Completed(guest_address))
+        litebox_broker_core::socket::bind(&listener_session, listener, address),
+        Ok(SocketOutcome::Completed(address))
     );
     assert_eq!(
-        litebox_broker_core::socket::listen(&listener_session, listener, 4),
-        Ok(SocketOutcome::Completed(guest_address))
+        litebox_broker_core::socket::listen(&listener_session, listener, 1),
+        Ok(SocketOutcome::Completed(address))
     );
-
-    provider
-        .reactor
-        .defer_untracked_guest_connection(guest_address.port());
-    let blocked = create_socket(&connector_session, readiness.clone());
-    assert_eq!(
-        litebox_broker_core::socket::connect(&connector_session, blocked, guest_address),
-        Ok(SocketOutcome::Completed(SocketConnectionStatus::Failed(
-            SocketError::ConnectionRefused
-        )))
-    );
-    connector_session.close_object_reference(blocked).unwrap();
-    assert_eq!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), blocked);
-
-    provider.reactor.expire_pending_guest_connections();
     let connector = create_socket(&connector_session, readiness.clone());
-    assert!(matches!(
-        litebox_broker_core::socket::connect(&connector_session, connector, guest_address),
-        Ok(SocketOutcome::Completed(
-            SocketConnectionStatus::Connecting | SocketConnectionStatus::Connected
-        ))
-    ));
-    wait_until_connected(&connector_session, connector, &publications);
-    wait_until_ready(
-        &listener_session,
-        &publications,
-        listener,
-        ReadinessFlags::READ,
-    );
-    let accepted =
-        match litebox_broker_core::socket::accept(&listener_session, listener, readiness.clone())
-            .unwrap()
-        {
-            SocketOutcome::Completed(accepted) => accepted.handle,
-            SocketOutcome::Failed(error) => panic!("guest accept failed: {error:?}"),
-        };
-    listener_session.close_object_reference(accepted).unwrap();
-    assert_eq!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), accepted);
-    connector_session.close_object_reference(connector).unwrap();
-    assert_eq!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), connector);
-
-    let private_address = provider.reactor.host_address(guest_address.port()).unwrap();
-    let _unmatched = TcpStream::connect(private_address).unwrap();
-    provider
-        .reactor
-        .defer_untracked_guest_connection(guest_address.port());
-    provider.reactor.expire_pending_guest_connections();
-
-    let gated = create_socket(&connector_session, readiness.clone());
     assert_eq!(
-        litebox_broker_core::socket::connect(&connector_session, gated, guest_address),
-        Ok(SocketOutcome::Completed(SocketConnectionStatus::Failed(
-            SocketError::ConnectionRefused
-        )))
+        litebox_broker_core::socket::connect(&connector_session, connector, address),
+        Ok(SocketOutcome::Completed(SocketConnectionStatus::Connected))
     );
-    connector_session.close_object_reference(gated).unwrap();
-    assert_eq!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), gated);
-    assert!(matches!(
-        litebox_broker_core::socket::accept(&listener_session, listener, readiness.clone(),),
-        Err(BrokerError::WouldBlock)
-    ));
-
-    let final_connector = create_socket(&connector_session, readiness);
-    assert!(matches!(
-        litebox_broker_core::socket::connect(&connector_session, final_connector, guest_address,),
-        Ok(SocketOutcome::Completed(
-            SocketConnectionStatus::Connecting | SocketConnectionStatus::Connected
-        ))
-    ));
+    let SocketOutcome::Completed(accepted) =
+        litebox_broker_core::socket::accept(&listener_session, listener, readiness)
+            .expect("guest accept failed")
+    else {
+        panic!("guest accept returned a socket failure");
+    };
+    GuestTcpPair {
+        listener_session,
+        connector_session,
+        connector,
+        accepted: accepted.handle,
+        publications,
+        retirements,
+    }
 }
 
 #[test]
@@ -273,7 +121,7 @@ fn reactor_drives_a_loopback_tcp_socket() {
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
             .with_socket_policy(SocketPolicy::guest_network()),
         BrokerCoreLimits::new_with_all_limits(16, 0, 8, 8),
-        provider,
+        provider.clone(),
     )
     .unwrap();
     let session = broker
@@ -283,6 +131,7 @@ fn reactor_drives_a_loopback_tcp_socket() {
     let (retired, retirements) = channel();
     let readiness = Arc::new(TestReadinessSink { published, retired });
     let handle = create_socket(&session, readiness.clone());
+    assert_eq!(provider.reactor.tcp_descriptor_counts(), (1, 0, 0));
     let connect =
         litebox_broker_core::socket::connect(&session, handle, socket_address_v4(address)).unwrap();
     assert!(matches!(
@@ -292,6 +141,7 @@ fn reactor_drives_a_loopback_tcp_socket() {
         )
     ));
     wait_until_connected(&session, handle, &publications);
+    assert_eq!(provider.reactor.tcp_descriptor_counts(), (0, 1, 0));
     let status = litebox_broker_core::socket::status(&session, handle).unwrap();
     assert_eq!(status.status, SocketConnectionStatus::Connected);
     let local_address = status
@@ -586,6 +436,149 @@ fn reactor_drives_a_loopback_tcp_socket() {
     release_read_shutdown_server.send(()).unwrap();
     read_shutdown_server.join().unwrap();
     server.join().unwrap();
+}
+
+#[test]
+fn native_tcp_deferred_abortive_close_resets_peer() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = socket_address_v4(listener.local_addr().unwrap());
+    let (accepted, wait_for_accept) = channel();
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        stream.set_read_timeout(Some(TEST_TIMEOUT)).unwrap();
+        accepted.send(()).unwrap();
+        let error = stream.read(&mut [0]).unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::ConnectionReset);
+    });
+
+    let provider = Arc::new(LinuxSocketProvider::new(1, 1).unwrap());
+    let broker = BrokerCore::new_with_limits(
+        PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
+            .with_socket_policy(SocketPolicy::guest_network()),
+        BrokerCoreLimits::new_with_all_limits(2, 0, 1, 1),
+        provider,
+    )
+    .unwrap();
+    let session = broker
+        .create_session(CallerCredential::Unauthenticated)
+        .unwrap();
+    let (published, publications) = channel();
+    let (retired, retirements) = channel();
+    let readiness = Arc::new(TestReadinessSink { published, retired });
+    let socket = create_socket(&session, readiness);
+
+    assert_eq!(
+        litebox_broker_core::socket::shutdown(&session, socket, ShutdownMode::Abort),
+        Ok(SocketOutcome::Completed(()))
+    );
+    assert!(matches!(
+        litebox_broker_core::socket::connect(&session, socket, address),
+        Ok(SocketOutcome::Completed(
+            SocketConnectionStatus::Connecting | SocketConnectionStatus::Connected
+        ))
+    ));
+    wait_until_connected(&session, socket, &publications);
+    wait_for_accept.recv_timeout(TEST_TIMEOUT).unwrap();
+    session.close_object_reference(socket).unwrap();
+    assert_eq!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), socket);
+    server.join().unwrap();
+}
+
+#[test]
+fn native_tcp_wildcard_binding_keeps_guest_loopback_identity() {
+    let local_ip = non_loopback_local_ipv4();
+    if std::env::var_os("CI").is_some() {
+        assert!(
+            local_ip.is_some(),
+            "CI runner must provide a routable non-loopback IPv4 address"
+        );
+    }
+    let Some(local_ip) = local_ip else {
+        return;
+    };
+    let listener = TcpListener::bind((local_ip, 0)).unwrap();
+    let destination = socket_address_v4(listener.local_addr().unwrap());
+    let policy = SocketPolicy::deny()
+        .with_tcp_destination_rules(&[DestinationRule::new(
+            CallerCredential::Unauthenticated,
+            Ipv4Cidr::new(Ipv4Address(local_ip.octets()), 32).unwrap(),
+            DestinationPortRange::new(Port(destination.port()), Port(destination.port())).unwrap(),
+        )])
+        .unwrap();
+    let provider = Arc::new(LinuxSocketProvider::new(1, 1).unwrap());
+    let broker = BrokerCore::new_with_limits(
+        PolicyEngine::with_unauthenticated_rights(ObjectRights::all()).with_socket_policy(policy),
+        BrokerCoreLimits::new_with_all_limits(2, 0, 1, 1),
+        provider,
+    )
+    .unwrap();
+    let session = broker
+        .create_session(CallerCredential::Unauthenticated)
+        .unwrap();
+    let (published, publications) = channel();
+    let (retired, _retirements) = channel();
+    let readiness = Arc::new(TestReadinessSink { published, retired });
+    let socket = create_socket(&session, readiness);
+    let SocketOutcome::Completed(binding) = litebox_broker_core::socket::bind(
+        &session,
+        socket,
+        SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0),
+    )
+    .unwrap() else {
+        panic!("wildcard bind failed");
+    };
+    assert!(matches!(
+        litebox_broker_core::socket::connect(&session, socket, destination),
+        Ok(SocketOutcome::Completed(
+            SocketConnectionStatus::Connecting | SocketConnectionStatus::Connected
+        ))
+    ));
+    wait_until_connected(&session, socket, &publications);
+
+    let status = litebox_broker_core::socket::status(&session, socket).unwrap();
+    assert_eq!(status.status, SocketConnectionStatus::Connected);
+    assert_eq!(
+        status.local_address,
+        Some(SocketAddrV4::new(Ipv4Addr::LOCALHOST, binding.port()))
+    );
+    assert_ne!(status.local_address.unwrap().ip(), &local_ip);
+    assert_eq!(
+        litebox_broker_core::socket::status(&session, socket)
+            .unwrap()
+            .local_address,
+        status.local_address
+    );
+}
+
+#[test]
+fn tcp_connect_to_zero_port_returns_an_ordinary_socket_outcome() {
+    let provider = Arc::new(LinuxSocketProvider::new(1, 1).unwrap());
+    let broker = BrokerCore::new_with_limits(
+        PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
+            .with_socket_policy(SocketPolicy::guest_network()),
+        BrokerCoreLimits::new_with_all_limits(2, 0, 1, 1),
+        provider,
+    )
+    .unwrap();
+    let session = broker
+        .create_session(CallerCredential::Unauthenticated)
+        .unwrap();
+    let (published, _publications) = channel();
+    let (retired, _retirements) = channel();
+    let socket = create_socket(&session, Arc::new(TestReadinessSink { published, retired }));
+
+    assert!(matches!(
+        litebox_broker_core::socket::connect(
+            &session,
+            socket,
+            SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0),
+        ),
+        Ok(SocketOutcome::Completed(
+            SocketConnectionStatus::Connecting
+                | SocketConnectionStatus::Connected
+                | SocketConnectionStatus::Failed(_)
+        ))
+    ));
 }
 
 #[test]
@@ -1038,12 +1031,13 @@ fn accepted_guest_tcp_close_with_unread_data_preserves_reset() {
         listener,
         ReadinessFlags::READ,
     );
-    let accepted = match litebox_broker_core::socket::accept(&listener_session, listener, readiness)
-        .unwrap()
-    {
-        SocketOutcome::Completed(accepted) => accepted.handle,
-        SocketOutcome::Failed(error) => panic!("guest accept failed: {error:?}"),
-    };
+    let accepted =
+        match litebox_broker_core::socket::accept(&listener_session, listener, readiness.clone())
+            .unwrap()
+        {
+            SocketOutcome::Completed(accepted) => accepted.handle,
+            SocketOutcome::Failed(error) => panic!("guest accept failed: {error:?}"),
+        };
     assert_eq!(
         send_bytes(&listener_session, accepted, b"unread", SendFlags::NONE,),
         Ok(SocketOutcome::Completed(6))
@@ -1074,6 +1068,267 @@ fn accepted_guest_tcp_close_with_unread_data_preserves_reset() {
             0,
         ),
         Ok(SocketOutcome::Failed(SocketError::ConnectionReset))
+    );
+    listener_session.close_object_reference(accepted).unwrap();
+    assert_eq!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), accepted);
+
+    let aborting = create_socket(&connector_session, readiness.clone());
+    assert_eq!(
+        litebox_broker_core::socket::connect(&connector_session, aborting, guest_address),
+        Ok(SocketOutcome::Completed(SocketConnectionStatus::Connected))
+    );
+    let abort_peer =
+        litebox_broker_core::socket::accept(&listener_session, listener, readiness).unwrap();
+    let SocketOutcome::Completed(abort_peer) = abort_peer else {
+        panic!("second guest accept failed");
+    };
+    assert_eq!(
+        litebox_broker_core::socket::shutdown(&connector_session, aborting, ShutdownMode::Abort,),
+        Ok(SocketOutcome::Completed(()))
+    );
+    connector_session.close_object_reference(aborting).unwrap();
+    assert_eq!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), aborting);
+    wait_until_ready(
+        &listener_session,
+        &publications,
+        abort_peer.handle,
+        ReadinessFlags::ERROR,
+    );
+    assert_eq!(
+        receive_into(
+            &listener_session,
+            abort_peer.handle,
+            &mut byte,
+            ReceiveFlags::NONE,
+            0,
+            0,
+        ),
+        Ok(SocketOutcome::Failed(SocketError::ConnectionReset))
+    );
+}
+
+#[test]
+fn guest_tcp_direct_receive_reports_reset_once_then_eof() {
+    let pair = connected_guest_tcp_pair(8101);
+    assert_eq!(
+        litebox_broker_core::socket::shutdown(
+            &pair.listener_session,
+            pair.accepted,
+            ShutdownMode::Abort,
+        ),
+        Ok(SocketOutcome::Completed(()))
+    );
+    pair.listener_session
+        .close_object_reference(pair.accepted)
+        .unwrap();
+    assert_eq!(
+        pair.retirements.recv_timeout(TEST_TIMEOUT).unwrap(),
+        pair.accepted
+    );
+    wait_until_ready(
+        &pair.connector_session,
+        &pair.publications,
+        pair.connector,
+        ReadinessFlags::ERROR,
+    );
+
+    let mut byte = [0_u8; 1];
+    assert_eq!(
+        receive_into(
+            &pair.connector_session,
+            pair.connector,
+            &mut byte,
+            ReceiveFlags::NONE,
+            0,
+            0,
+        ),
+        Ok(SocketOutcome::Failed(SocketError::ConnectionReset))
+    );
+    let readiness = pair
+        .connector_session
+        .check_readiness(pair.connector)
+        .unwrap();
+    assert!(readiness.contains(ReadinessFlags::READ));
+    assert!(readiness.contains(ReadinessFlags::HANGUP));
+    assert!(!readiness.contains(ReadinessFlags::ERROR));
+    assert_eq!(
+        receive_into(
+            &pair.connector_session,
+            pair.connector,
+            &mut byte,
+            ReceiveFlags::NONE,
+            0,
+            0,
+        ),
+        Ok(SocketOutcome::Completed(ReceiveSocketResponse::EndOfStream))
+    );
+    assert_eq!(
+        litebox_broker_core::socket::status(&pair.connector_session, pair.connector)
+            .unwrap()
+            .pending_error,
+        None
+    );
+    assert!(matches!(
+        send_bytes(
+            &pair.connector_session,
+            pair.connector,
+            b"after reset",
+            SendFlags::NONE,
+        ),
+        Ok(SocketOutcome::Failed(_))
+    ));
+}
+
+#[test]
+fn guest_tcp_status_consumes_reset_before_buffered_data() {
+    let pair = connected_guest_tcp_pair(8102);
+    assert_eq!(
+        send_bytes(
+            &pair.listener_session,
+            pair.accepted,
+            b"buffered",
+            SendFlags::NONE,
+        ),
+        Ok(SocketOutcome::Completed(8))
+    );
+    wait_until_ready(
+        &pair.connector_session,
+        &pair.publications,
+        pair.connector,
+        ReadinessFlags::READ,
+    );
+    assert_eq!(
+        litebox_broker_core::socket::shutdown(
+            &pair.listener_session,
+            pair.accepted,
+            ShutdownMode::Abort,
+        ),
+        Ok(SocketOutcome::Completed(()))
+    );
+    pair.listener_session
+        .close_object_reference(pair.accepted)
+        .unwrap();
+    assert_eq!(
+        pair.retirements.recv_timeout(TEST_TIMEOUT).unwrap(),
+        pair.accepted
+    );
+    wait_until_ready(
+        &pair.connector_session,
+        &pair.publications,
+        pair.connector,
+        ReadinessFlags::ERROR,
+    );
+
+    let status =
+        litebox_broker_core::socket::status(&pair.connector_session, pair.connector).unwrap();
+    assert_eq!(status.pending_error, Some(SocketError::ConnectionReset));
+    let readiness = pair
+        .connector_session
+        .check_readiness(pair.connector)
+        .unwrap();
+    assert!(readiness.contains(ReadinessFlags::READ));
+    assert!(readiness.contains(ReadinessFlags::HANGUP));
+    assert!(!readiness.contains(ReadinessFlags::ERROR));
+    let mut buffered = [0_u8; 8];
+    assert_eq!(
+        receive_into(
+            &pair.connector_session,
+            pair.connector,
+            &mut buffered,
+            ReceiveFlags::NONE,
+            0,
+            0,
+        ),
+        Ok(SocketOutcome::Completed(ReceiveSocketResponse::Received(8)))
+    );
+    assert_eq!(&buffered, b"buffered");
+    assert_eq!(
+        receive_into(
+            &pair.connector_session,
+            pair.connector,
+            &mut buffered,
+            ReceiveFlags::NONE,
+            0,
+            0,
+        ),
+        Ok(SocketOutcome::Completed(ReceiveSocketResponse::EndOfStream))
+    );
+    assert_eq!(
+        litebox_broker_core::socket::status(&pair.connector_session, pair.connector)
+            .unwrap()
+            .pending_error,
+        None
+    );
+}
+
+#[test]
+fn guest_tcp_buffered_data_precedes_direct_reset_and_eof() {
+    let pair = connected_guest_tcp_pair(8103);
+    assert_eq!(
+        send_bytes(
+            &pair.listener_session,
+            pair.accepted,
+            b"buffered",
+            SendFlags::NONE,
+        ),
+        Ok(SocketOutcome::Completed(8))
+    );
+    wait_until_ready(
+        &pair.connector_session,
+        &pair.publications,
+        pair.connector,
+        ReadinessFlags::READ,
+    );
+    assert_eq!(
+        litebox_broker_core::socket::shutdown(
+            &pair.listener_session,
+            pair.accepted,
+            ShutdownMode::Abort,
+        ),
+        Ok(SocketOutcome::Completed(()))
+    );
+    pair.listener_session
+        .close_object_reference(pair.accepted)
+        .unwrap();
+    assert_eq!(
+        pair.retirements.recv_timeout(TEST_TIMEOUT).unwrap(),
+        pair.accepted
+    );
+
+    let mut buffered = [0_u8; 8];
+    assert_eq!(
+        receive_into(
+            &pair.connector_session,
+            pair.connector,
+            &mut buffered,
+            ReceiveFlags::NONE,
+            0,
+            0,
+        ),
+        Ok(SocketOutcome::Completed(ReceiveSocketResponse::Received(8)))
+    );
+    assert_eq!(&buffered, b"buffered");
+    assert_eq!(
+        receive_into(
+            &pair.connector_session,
+            pair.connector,
+            &mut buffered,
+            ReceiveFlags::NONE,
+            0,
+            0,
+        ),
+        Ok(SocketOutcome::Failed(SocketError::ConnectionReset))
+    );
+    assert_eq!(
+        receive_into(
+            &pair.connector_session,
+            pair.connector,
+            &mut buffered,
+            ReceiveFlags::NONE,
+            0,
+            0,
+        ),
+        Ok(SocketOutcome::Completed(ReceiveSocketResponse::EndOfStream))
     );
 }
 
@@ -1153,30 +1408,8 @@ fn guest_tcp_namespace_routes_across_sessions_and_hides_private_backend() {
         litebox_broker_core::socket::listen(&listener_session, listener, 3),
         Ok(SocketOutcome::Completed(guest_address))
     );
-    let private_address = provider
-        .reactor
-        .host_address(guest_address.port())
-        .expect("listener backend must be realized");
-    assert!(private_address.ip().is_loopback());
-    assert_ne!(private_address, guest_address);
-
-    let direct_client = create_socket(&client_session, readiness.clone());
-    assert_eq!(
-        litebox_broker_core::socket::connect(&client_session, direct_client, private_address,),
-        Ok(SocketOutcome::Completed(SocketConnectionStatus::Failed(
-            SocketError::ConnectionRefused,
-        )))
-    );
-    client_session
-        .close_object_reference(direct_client)
-        .unwrap();
-    assert_eq!(
-        retirements.recv_timeout(TEST_TIMEOUT).unwrap(),
-        direct_client
-    );
-
-    let native_client = TcpStream::connect(private_address).unwrap();
-    wait_for_readiness(&publications, listener, ReadinessFlags::READ);
+    assert_eq!(provider.reactor.host_address(guest_address.port()), None);
+    assert_eq!(provider.reactor.tcp_descriptor_counts(), (1, 0, 0));
     let client = create_socket(&client_session, readiness.clone());
     assert!(matches!(
         litebox_broker_core::socket::connect(&client_session, client, guest_destination),
@@ -1185,34 +1418,13 @@ fn guest_tcp_namespace_routes_across_sessions_and_hides_private_backend() {
         ))
     ));
     wait_until_connected(&client_session, client, &publications);
+    assert_eq!(provider.reactor.tcp_descriptor_counts(), (1, 0, 1));
     let client_address = litebox_broker_core::socket::status(&client_session, client)
         .unwrap()
         .local_address
         .unwrap();
     assert_eq!(*client_address.ip(), GUEST_IPV4_ADDRESS);
-    let connector_private_address = provider
-        .reactor
-        .host_address(client_address.port())
-        .expect("connector backend must be realized");
-    assert_ne!(connector_private_address, client_address);
-    let connector_probe = create_socket(&client_session, readiness.clone());
-    assert_eq!(
-        litebox_broker_core::socket::connect(
-            &client_session,
-            connector_probe,
-            connector_private_address,
-        ),
-        Ok(SocketOutcome::Completed(SocketConnectionStatus::Failed(
-            SocketError::ConnectionRefused,
-        )))
-    );
-    client_session
-        .close_object_reference(connector_probe)
-        .unwrap();
-    assert_eq!(
-        retirements.recv_timeout(TEST_TIMEOUT).unwrap(),
-        connector_probe
-    );
+    assert_eq!(provider.reactor.host_address(client_address.port()), None);
     wait_until_ready(
         &listener_session,
         &publications,
@@ -1228,8 +1440,8 @@ fn guest_tcp_namespace_routes_across_sessions_and_hides_private_backend() {
         };
     assert_eq!(accepted.local_address, guest_address);
     assert_eq!(accepted.remote_address, client_address);
-    assert_eq!(provider.reactor.pending_guest_connection_count(), 0);
-    assert_eq!(provider.reactor.retained_connector_count(), 0);
+    assert_eq!(provider.reactor.queued_guest_connection_count(), 0);
+    assert_eq!(provider.reactor.tcp_descriptor_counts(), (1, 0, 2));
 
     assert_eq!(
         send_bytes(&client_session, client, b"x", SendFlags::NONE),
@@ -1258,7 +1470,6 @@ fn guest_tcp_namespace_routes_across_sessions_and_hides_private_backend() {
         shadowed_host_listener.accept().unwrap_err().kind(),
         ErrorKind::WouldBlock
     );
-    drop(native_client);
 }
 
 #[test]
@@ -1411,45 +1622,15 @@ fn tcp_exact_bindings_coexist_and_wildcard_accepts_concrete_destinations() {
         accepted.remote_address,
         SocketAddrV4::new(GUEST_IPV4_ADDRESS, connector_binding.port())
     );
-
-    let unspecified_connector = create_socket(&connector_session, readiness.clone());
-    assert!(matches!(
-        litebox_broker_core::socket::connect(
-            &connector_session,
-            unspecified_connector,
-            SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, wildcard_address.port()),
-        ),
-        Ok(SocketOutcome::Completed(
-            SocketConnectionStatus::Connecting | SocketConnectionStatus::Connected
-        ))
-    ));
-    wait_until_connected(&connector_session, unspecified_connector, &publications);
-    wait_until_ready(
-        &listener_session,
-        &publications,
-        wildcard_listener,
-        ReadinessFlags::READ,
-    );
-    let accepted =
-        match litebox_broker_core::socket::accept(&listener_session, wildcard_listener, readiness)
-            .unwrap()
-        {
-            SocketOutcome::Completed(accepted) => accepted,
-            SocketOutcome::Failed(error) => panic!("unspecified accept failed: {error:?}"),
-        };
-    assert_eq!(
-        accepted.local_address,
-        SocketAddrV4::new(Ipv4Addr::LOCALHOST, wildcard_address.port())
-    );
 }
 
 #[test]
 fn connector_and_session_teardown_clean_bounded_pending_state() {
-    let provider = Arc::new(LinuxSocketProvider::new(3, 1).unwrap());
+    let provider = Arc::new(LinuxSocketProvider::new(4, 2).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
             .with_socket_policy(SocketPolicy::guest_network()),
-        BrokerCoreLimits::new_with_all_limits(8, 0, 3, 3),
+        BrokerCoreLimits::new_with_all_limits(8, 0, 4, 4),
         provider.clone(),
     )
     .unwrap();
@@ -1483,8 +1664,8 @@ fn connector_and_session_teardown_clean_bounded_pending_state() {
     wait_until_connected(&connector_session, connector, &publications);
     connector_session.close_object_reference(connector).unwrap();
     assert_eq!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), connector);
-    assert_eq!(provider.reactor.pending_guest_connection_count(), 1);
-    assert_eq!(provider.reactor.retained_connector_count(), 1);
+    assert_eq!(provider.reactor.queued_guest_connection_count(), 1);
+    let capacity = create_socket(&connector_session, readiness.clone());
     assert_eq!(
         litebox_broker_core::socket::create(
             &connector_session,
@@ -1497,41 +1678,17 @@ fn connector_and_session_teardown_clean_bounded_pending_state() {
         ),
         Err(BrokerError::ResourceExhausted)
     );
-    assert_ne!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), listener);
+    assert_ne!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), capacity);
+    connector_session.close_object_reference(capacity).unwrap();
+    assert_eq!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), capacity);
 
     drop(connector_session);
-    assert_eq!(provider.reactor.pending_guest_connection_count(), 1);
-    assert_eq!(provider.reactor.retained_connector_count(), 0);
-    provider.reactor.expire_pending_guest_connections();
-    assert_eq!(provider.reactor.pending_guest_connection_count(), 0);
-
-    let blocked_connector_session = broker
-        .create_session(CallerCredential::Unauthenticated)
-        .unwrap();
-    let blocked_connector = create_socket(&blocked_connector_session, readiness.clone());
-    assert_eq!(
-        litebox_broker_core::socket::connect(
-            &blocked_connector_session,
-            blocked_connector,
-            guest_address,
-        ),
-        Ok(SocketOutcome::Completed(SocketConnectionStatus::Failed(
-            SocketError::ConnectionRefused
-        )))
-    );
-    blocked_connector_session
-        .close_object_reference(blocked_connector)
-        .unwrap();
-    assert_eq!(
-        retirements.recv_timeout(TEST_TIMEOUT).unwrap(),
-        blocked_connector
-    );
-
-    wait_until_ready(
-        &listener_session,
-        &publications,
-        listener,
-        ReadinessFlags::READ,
+    assert_eq!(provider.reactor.queued_guest_connection_count(), 0);
+    assert!(
+        !listener_session
+            .check_readiness(listener)
+            .unwrap()
+            .contains(ReadinessFlags::READ)
     );
     assert!(matches!(
         litebox_broker_core::socket::accept(&listener_session, listener, readiness.clone(),),
@@ -1554,11 +1711,28 @@ fn connector_and_session_teardown_clean_bounded_pending_state() {
         ))
     ));
     wait_until_connected(&final_connector_session, final_connector, &publications);
-    assert_eq!(provider.reactor.pending_guest_connection_count(), 1);
+    assert_eq!(provider.reactor.queued_guest_connection_count(), 1);
     listener_session.close_object_reference(listener).unwrap();
     assert_eq!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), listener);
-    assert_eq!(provider.reactor.pending_guest_connection_count(), 0);
-    assert_eq!(provider.reactor.retained_connector_count(), 0);
+    assert_eq!(provider.reactor.queued_guest_connection_count(), 0);
+    wait_until_ready(
+        &final_connector_session,
+        &publications,
+        final_connector,
+        ReadinessFlags::ERROR,
+    );
+    let mut byte = [0_u8; 1];
+    assert_eq!(
+        receive_into(
+            &final_connector_session,
+            final_connector,
+            &mut byte,
+            ReceiveFlags::NONE,
+            0,
+            0,
+        ),
+        Ok(SocketOutcome::Failed(SocketError::ConnectionReset))
+    );
 }
 
 #[test]
@@ -1603,10 +1777,14 @@ fn graceful_connector_close_preserves_late_accept_and_eof() {
         .unwrap()
         .local_address
         .unwrap();
+    assert_eq!(
+        send_bytes(&connector_session, connector, b"queued", SendFlags::NONE,),
+        Ok(SocketOutcome::Completed(6))
+    );
 
     connector_session.close_object_reference(connector).unwrap();
     assert_eq!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), connector);
-    assert_eq!(provider.reactor.retained_connector_count(), 1);
+    assert_eq!(provider.reactor.queued_guest_connection_count(), 1);
     wait_until_ready(
         &listener_session,
         &publications,
@@ -1621,14 +1799,731 @@ fn graceful_connector_close_preserves_late_accept_and_eof() {
         SocketOutcome::Failed(error) => panic!("late accept failed: {error:?}"),
     };
     assert_eq!(accepted.remote_address, connector_address);
-    assert_eq!(provider.reactor.pending_guest_connection_count(), 0);
-    assert_eq!(provider.reactor.retained_connector_count(), 0);
+    assert_eq!(provider.reactor.queued_guest_connection_count(), 0);
+    wait_until_ready(
+        &listener_session,
+        &publications,
+        accepted.handle,
+        ReadinessFlags::READ,
+    );
+    let mut queued = [0_u8; 6];
+    assert_eq!(
+        receive_into(
+            &listener_session,
+            accepted.handle,
+            &mut queued,
+            ReceiveFlags::NONE,
+            0,
+            0,
+        ),
+        Ok(SocketOutcome::Completed(ReceiveSocketResponse::Received(6)))
+    );
+    assert_eq!(&queued, b"queued");
     wait_for_end_of_stream(&listener_session, accepted.handle, &publications);
 }
 
 #[test]
+fn guest_tcp_zero_backlog_accepts_one_unspecified_destination() {
+    let port = 8104;
+    let policy = SocketPolicy::guest_network()
+        .with_tcp_destination_rules(&[DestinationRule::new(
+            CallerCredential::Unauthenticated,
+            Ipv4Cidr::new(Ipv4Address(Ipv4Addr::UNSPECIFIED.octets()), 32).unwrap(),
+            DestinationPortRange::new(Port(port), Port(port)).unwrap(),
+        )])
+        .unwrap();
+    let provider = Arc::new(LinuxSocketProvider::new(6, 4).unwrap());
+    let broker = BrokerCore::new_with_limits(
+        PolicyEngine::with_unauthenticated_rights(ObjectRights::all()).with_socket_policy(policy),
+        BrokerCoreLimits::new_with_all_limits(10, 0, 6, 6),
+        provider,
+    )
+    .unwrap();
+    let listener_session = broker
+        .create_session(CallerCredential::Unauthenticated)
+        .unwrap();
+    let connector_session = broker
+        .create_session(CallerCredential::Unauthenticated)
+        .unwrap();
+    let (published, _publications) = channel();
+    let (retired, retirements) = channel();
+    let readiness = Arc::new(TestReadinessSink { published, retired });
+    let wildcard_listener = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, port);
+    let concrete_listener = SocketAddrV4::new(Ipv4Addr::LOCALHOST, port);
+    let listener = create_socket(&listener_session, readiness.clone());
+    assert_eq!(
+        litebox_broker_core::socket::bind(&listener_session, listener, wildcard_listener),
+        Ok(SocketOutcome::Completed(wildcard_listener))
+    );
+    assert_eq!(
+        litebox_broker_core::socket::listen(&listener_session, listener, 0),
+        Ok(SocketOutcome::Completed(wildcard_listener))
+    );
+
+    let connector = create_socket(&connector_session, readiness.clone());
+    let SocketOutcome::Completed(connector_binding) = litebox_broker_core::socket::bind(
+        &connector_session,
+        connector,
+        SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0),
+    )
+    .unwrap() else {
+        panic!("wildcard connector bind failed");
+    };
+    assert_eq!(
+        litebox_broker_core::socket::connect(&connector_session, connector, wildcard_listener,),
+        Ok(SocketOutcome::Completed(SocketConnectionStatus::Connected))
+    );
+    let concrete_connector = SocketAddrV4::new(Ipv4Addr::LOCALHOST, connector_binding.port());
+    assert_eq!(
+        litebox_broker_core::socket::status(&connector_session, connector)
+            .unwrap()
+            .local_address,
+        Some(concrete_connector)
+    );
+
+    let full = create_socket(&connector_session, readiness.clone());
+    assert_eq!(
+        litebox_broker_core::socket::connect(&connector_session, full, wildcard_listener),
+        Ok(SocketOutcome::Completed(SocketConnectionStatus::Failed(
+            SocketError::ConnectionRefused,
+        )))
+    );
+    let SocketOutcome::Completed(accepted) =
+        litebox_broker_core::socket::accept(&listener_session, listener, readiness.clone())
+            .unwrap()
+    else {
+        panic!("zero-backlog listener did not accept its queued connection");
+    };
+    assert_eq!(accepted.local_address, concrete_listener);
+    assert_eq!(accepted.remote_address, concrete_connector);
+
+    connector_session.close_object_reference(connector).unwrap();
+    assert_eq!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), connector);
+    let contender = create_socket(&connector_session, readiness);
+    assert_eq!(
+        litebox_broker_core::socket::bind(&connector_session, contender, concrete_connector,),
+        Ok(SocketOutcome::Failed(SocketError::AddressInUse))
+    );
+    listener_session
+        .close_object_reference(accepted.handle)
+        .unwrap();
+    assert_eq!(
+        retirements.recv_timeout(TEST_TIMEOUT).unwrap(),
+        accepted.handle
+    );
+    assert_eq!(
+        litebox_broker_core::socket::bind(&connector_session, contender, concrete_connector,),
+        Ok(SocketOutcome::Completed(concrete_connector))
+    );
+}
+
+#[test]
+fn guest_tcp_backlog_relisten_and_fifo_are_bounded() {
+    let provider = Arc::new(LinuxSocketProvider::new(10, 8).unwrap());
+    let broker = BrokerCore::new_with_limits(
+        PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
+            .with_socket_policy(SocketPolicy::guest_network()),
+        BrokerCoreLimits::new_with_all_limits(16, 0, 10, 10),
+        provider.clone(),
+    )
+    .unwrap();
+    let listener_session = broker
+        .create_session(CallerCredential::Unauthenticated)
+        .unwrap();
+    let connector_session = broker
+        .create_session(CallerCredential::Unauthenticated)
+        .unwrap();
+    let (published, publications) = channel();
+    let (retired, _retirements) = channel();
+    let readiness = Arc::new(TestReadinessSink { published, retired });
+    let address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8092);
+    let listener = create_socket(&listener_session, readiness.clone());
+    assert_eq!(
+        litebox_broker_core::socket::bind(&listener_session, listener, address),
+        Ok(SocketOutcome::Completed(address))
+    );
+    assert_eq!(
+        litebox_broker_core::socket::listen(&listener_session, listener, 2),
+        Ok(SocketOutcome::Completed(address))
+    );
+
+    let first = create_socket(&connector_session, readiness.clone());
+    let second = create_socket(&connector_session, readiness.clone());
+    let mut expected = VecDeque::new();
+    for connector in [first, second] {
+        assert_eq!(
+            litebox_broker_core::socket::connect(&connector_session, connector, address),
+            Ok(SocketOutcome::Completed(SocketConnectionStatus::Connected))
+        );
+        expected.push_back(
+            litebox_broker_core::socket::status(&connector_session, connector)
+                .unwrap()
+                .local_address
+                .unwrap(),
+        );
+    }
+    assert_eq!(provider.reactor.queued_guest_connection_count(), 2);
+    let full = create_socket(&connector_session, readiness.clone());
+    assert_eq!(
+        litebox_broker_core::socket::connect(&connector_session, full, address),
+        Ok(SocketOutcome::Completed(SocketConnectionStatus::Failed(
+            SocketError::ConnectionRefused,
+        )))
+    );
+    assert_eq!(
+        litebox_broker_core::socket::listen(&listener_session, listener, 1),
+        Ok(SocketOutcome::Completed(address))
+    );
+    assert_eq!(provider.reactor.queued_guest_connection_count(), 2);
+
+    wait_until_ready(
+        &listener_session,
+        &publications,
+        listener,
+        ReadinessFlags::READ,
+    );
+    let accepted =
+        litebox_broker_core::socket::accept(&listener_session, listener, readiness.clone())
+            .unwrap();
+    let SocketOutcome::Completed(accepted) = accepted else {
+        panic!("first FIFO accept failed");
+    };
+    assert_eq!(accepted.remote_address, expected.pop_front().unwrap());
+    assert!(
+        listener_session
+            .check_readiness(listener)
+            .unwrap()
+            .contains(ReadinessFlags::READ)
+    );
+
+    let still_full = create_socket(&connector_session, readiness.clone());
+    assert_eq!(
+        litebox_broker_core::socket::connect(&connector_session, still_full, address),
+        Ok(SocketOutcome::Completed(SocketConnectionStatus::Failed(
+            SocketError::ConnectionRefused,
+        )))
+    );
+    assert_eq!(
+        litebox_broker_core::socket::listen(&listener_session, listener, 3),
+        Ok(SocketOutcome::Completed(address))
+    );
+    let third = create_socket(&connector_session, readiness.clone());
+    assert_eq!(
+        litebox_broker_core::socket::connect(&connector_session, third, address),
+        Ok(SocketOutcome::Completed(SocketConnectionStatus::Connected))
+    );
+    expected.push_back(
+        litebox_broker_core::socket::status(&connector_session, third)
+            .unwrap()
+            .local_address
+            .unwrap(),
+    );
+    for expected_remote in expected {
+        let accepted =
+            litebox_broker_core::socket::accept(&listener_session, listener, readiness.clone())
+                .unwrap();
+        let SocketOutcome::Completed(accepted) = accepted else {
+            panic!("later FIFO accept failed");
+        };
+        assert_eq!(accepted.remote_address, expected_remote);
+    }
+    assert_eq!(provider.reactor.queued_guest_connection_count(), 0);
+    assert!(
+        !listener_session
+            .check_readiness(listener)
+            .unwrap()
+            .contains(ReadinessFlags::READ)
+    );
+}
+
+#[test]
+fn guest_tcp_stream_preserves_options_peek_waitall_and_half_close() {
+    let provider = Arc::new(LinuxSocketProvider::new(6, 4).unwrap());
+    let broker = BrokerCore::new_with_limits(
+        PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
+            .with_socket_policy(SocketPolicy::guest_network()),
+        BrokerCoreLimits::new_with_all_limits(12, 0, 6, 6),
+        provider,
+    )
+    .unwrap();
+    let listener_session = broker
+        .create_session(CallerCredential::Unauthenticated)
+        .unwrap();
+    let connector_session = broker
+        .create_session(CallerCredential::Unauthenticated)
+        .unwrap();
+    let (published, publications) = channel();
+    let (retired, retirements) = channel();
+    let readiness = Arc::new(TestReadinessSink { published, retired });
+    let address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8093);
+    let listener = create_socket(&listener_session, readiness.clone());
+    assert_eq!(
+        litebox_broker_core::socket::bind(&listener_session, listener, address),
+        Ok(SocketOutcome::Completed(address))
+    );
+    litebox_broker_core::socket::set_tcp_option(
+        &listener_session,
+        listener,
+        TcpOptionValue::NoDelay(true),
+    )
+    .unwrap();
+    litebox_broker_core::socket::set_tcp_option(
+        &listener_session,
+        listener,
+        TcpOptionValue::KeepAlive(true),
+    )
+    .unwrap();
+    assert_eq!(
+        litebox_broker_core::socket::listen(&listener_session, listener, 1),
+        Ok(SocketOutcome::Completed(address))
+    );
+    let connector = create_socket(&connector_session, readiness.clone());
+    assert_eq!(
+        litebox_broker_core::socket::connect(&connector_session, connector, address),
+        Ok(SocketOutcome::Completed(SocketConnectionStatus::Connected))
+    );
+    let accepted =
+        litebox_broker_core::socket::accept(&listener_session, listener, readiness.clone())
+            .unwrap();
+    let SocketOutcome::Completed(accepted) = accepted else {
+        panic!("guest accept failed");
+    };
+    assert_eq!(
+        litebox_broker_core::socket::get_tcp_option(
+            &listener_session,
+            accepted.handle,
+            TcpOptionName::NoDelay,
+        ),
+        Ok(TcpOptionValue::NoDelay(true))
+    );
+    assert_eq!(
+        litebox_broker_core::socket::get_tcp_option(
+            &listener_session,
+            accepted.handle,
+            TcpOptionName::KeepAlive,
+        ),
+        Ok(TcpOptionValue::KeepAlive(true))
+    );
+    listener_session.close_object_reference(listener).unwrap();
+    assert_eq!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), listener);
+
+    assert_eq!(
+        send_bytes(&connector_session, connector, b"a", SendFlags::NONE),
+        Ok(SocketOutcome::Completed(1))
+    );
+    wait_until_ready(
+        &listener_session,
+        &publications,
+        accepted.handle,
+        ReadinessFlags::READ,
+    );
+    let mut peeked = [0_u8; 2];
+    assert_eq!(
+        receive_into(
+            &listener_session,
+            accepted.handle,
+            &mut peeked,
+            ReceiveFlags(ReceiveFlags::PEEK.0 | ReceiveFlags::WAITALL.0),
+            0,
+            2,
+        ),
+        Err(BrokerError::WouldBlock)
+    );
+    assert_eq!(
+        send_bytes(&connector_session, connector, b"b", SendFlags::NONE),
+        Ok(SocketOutcome::Completed(1))
+    );
+    wait_until_ready(
+        &listener_session,
+        &publications,
+        accepted.handle,
+        ReadinessFlags::READ,
+    );
+    assert_eq!(
+        receive_into(
+            &listener_session,
+            accepted.handle,
+            &mut peeked,
+            ReceiveFlags(ReceiveFlags::PEEK.0 | ReceiveFlags::WAITALL.0),
+            0,
+            2,
+        ),
+        Ok(SocketOutcome::Completed(ReceiveSocketResponse::Received(2)))
+    );
+    assert_eq!(&peeked, b"ab");
+    let mut received = [0_u8; 2];
+    assert_eq!(
+        receive_into(
+            &listener_session,
+            accepted.handle,
+            &mut received,
+            ReceiveFlags::NONE,
+            0,
+            0,
+        ),
+        Ok(SocketOutcome::Completed(ReceiveSocketResponse::Received(2)))
+    );
+    assert_eq!(&received, b"ab");
+    assert_eq!(
+        litebox_broker_core::socket::shutdown(&connector_session, connector, ShutdownMode::Write,),
+        Ok(SocketOutcome::Completed(()))
+    );
+    wait_for_end_of_stream(&listener_session, accepted.handle, &publications);
+    assert_eq!(
+        send_bytes(
+            &listener_session,
+            accepted.handle,
+            b"response",
+            SendFlags::NONE,
+        ),
+        Ok(SocketOutcome::Completed(8))
+    );
+    let mut response = [0_u8; 8];
+    loop {
+        match receive_into(
+            &connector_session,
+            connector,
+            &mut response,
+            ReceiveFlags::NONE,
+            0,
+            0,
+        ) {
+            Ok(SocketOutcome::Completed(ReceiveSocketResponse::Received(8))) => break,
+            Err(BrokerError::WouldBlock) => wait_until_ready(
+                &connector_session,
+                &publications,
+                connector,
+                ReadinessFlags::READ,
+            ),
+            outcome => panic!("unexpected half-close receive outcome: {outcome:?}"),
+        }
+    }
+    assert_eq!(&response, b"response");
+}
+
+#[test]
+fn guest_tcp_read_shutdown_is_logical_and_unread_close_resets_peer() {
+    let pair = connected_guest_tcp_pair(8105);
+    assert_eq!(
+        litebox_broker_core::socket::shutdown(
+            &pair.connector_session,
+            pair.connector,
+            ShutdownMode::Read,
+        ),
+        Ok(SocketOutcome::Completed(()))
+    );
+    assert_eq!(
+        send_bytes(
+            &pair.listener_session,
+            pair.accepted,
+            b"unread",
+            SendFlags::NONE,
+        ),
+        Ok(SocketOutcome::Completed(6))
+    );
+    let mut data = [0_u8; 6];
+    assert_eq!(
+        receive_into(
+            &pair.connector_session,
+            pair.connector,
+            &mut data,
+            ReceiveFlags::NONE,
+            0,
+            0,
+        ),
+        Ok(SocketOutcome::Completed(ReceiveSocketResponse::EndOfStream))
+    );
+
+    pair.connector_session
+        .close_object_reference(pair.connector)
+        .unwrap();
+    assert_eq!(
+        pair.retirements.recv_timeout(TEST_TIMEOUT).unwrap(),
+        pair.connector
+    );
+    wait_until_ready(
+        &pair.listener_session,
+        &pair.publications,
+        pair.accepted,
+        ReadinessFlags::ERROR,
+    );
+    assert_eq!(
+        receive_into(
+            &pair.listener_session,
+            pair.accepted,
+            &mut data,
+            ReceiveFlags::NONE,
+            0,
+            0,
+        ),
+        Ok(SocketOutcome::Failed(SocketError::ConnectionReset))
+    );
+}
+
+#[test]
+fn guest_tcp_both_shutdown_keeps_peer_send_open_and_closes_write_half() {
+    let pair = connected_guest_tcp_pair(8106);
+    assert_eq!(
+        litebox_broker_core::socket::shutdown(
+            &pair.connector_session,
+            pair.connector,
+            ShutdownMode::Both,
+        ),
+        Ok(SocketOutcome::Completed(()))
+    );
+    wait_for_end_of_stream(&pair.listener_session, pair.accepted, &pair.publications);
+    assert_eq!(
+        send_bytes(
+            &pair.listener_session,
+            pair.accepted,
+            b"unread",
+            SendFlags::NONE,
+        ),
+        Ok(SocketOutcome::Completed(6))
+    );
+    let mut data = [0_u8; 6];
+    assert_eq!(
+        receive_into(
+            &pair.connector_session,
+            pair.connector,
+            &mut data,
+            ReceiveFlags::NONE,
+            0,
+            0,
+        ),
+        Ok(SocketOutcome::Completed(ReceiveSocketResponse::EndOfStream))
+    );
+
+    pair.connector_session
+        .close_object_reference(pair.connector)
+        .unwrap();
+    assert_eq!(
+        pair.retirements.recv_timeout(TEST_TIMEOUT).unwrap(),
+        pair.connector
+    );
+    wait_until_ready(
+        &pair.listener_session,
+        &pair.publications,
+        pair.accepted,
+        ReadinessFlags::ERROR,
+    );
+    assert_eq!(
+        receive_into(
+            &pair.listener_session,
+            pair.accepted,
+            &mut data,
+            ReceiveFlags::NONE,
+            0,
+            0,
+        ),
+        Ok(SocketOutcome::Failed(SocketError::ConnectionReset))
+    );
+}
+
+#[test]
+fn guest_tcp_connect_publication_failure_purges_committed_queue() {
+    let provider = Arc::new(LinuxSocketProvider::new(4, 3).unwrap());
+    let broker = BrokerCore::new_with_limits(
+        PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
+            .with_socket_policy(SocketPolicy::guest_network()),
+        BrokerCoreLimits::new_with_all_limits(8, 0, 4, 4),
+        provider.clone(),
+    )
+    .unwrap();
+    let listener_session = broker
+        .create_session(CallerCredential::Unauthenticated)
+        .unwrap();
+    let connector_session = broker
+        .create_session(CallerCredential::Unauthenticated)
+        .unwrap();
+    let (published, _publications) = channel();
+    let (retired, retirements) = channel();
+    let readiness = Arc::new(FailingReadinessSink {
+        inner: TestReadinessSink { published, retired },
+        fail_next_publish: Mutex::new(None),
+    });
+    let address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8094);
+    let listener = create_socket(&listener_session, readiness.clone());
+    assert_eq!(
+        litebox_broker_core::socket::bind(&listener_session, listener, address),
+        Ok(SocketOutcome::Completed(address))
+    );
+    assert_eq!(
+        litebox_broker_core::socket::listen(&listener_session, listener, 1),
+        Ok(SocketOutcome::Completed(address))
+    );
+    let connector = create_socket(&connector_session, readiness.clone());
+    readiness.fail_next_publish_matching(listener, ReadinessFlags::READ, ReadinessFlags::default());
+    assert_eq!(
+        litebox_broker_core::socket::connect(&connector_session, connector, address),
+        Err(BrokerError::ResourceExhausted)
+    );
+    readiness.assert_no_pending_publish_failure();
+    assert_eq!(provider.reactor.queued_guest_connection_count(), 0);
+    assert!(
+        !listener_session
+            .check_readiness(listener)
+            .unwrap()
+            .contains(ReadinessFlags::READ)
+    );
+    assert!(matches!(
+        litebox_broker_core::socket::accept(&listener_session, listener, readiness),
+        Err(BrokerError::WouldBlock)
+    ));
+    assert_ne!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), listener);
+    connector_session.close_object_reference(connector).unwrap();
+    assert_eq!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), connector);
+}
+
+#[test]
+fn guest_tcp_accept_publication_failure_purges_registered_endpoint() {
+    let provider = Arc::new(LinuxSocketProvider::new(4, 3).unwrap());
+    let broker = BrokerCore::new_with_limits(
+        PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
+            .with_socket_policy(SocketPolicy::guest_network()),
+        BrokerCoreLimits::new_with_all_limits(8, 0, 4, 4),
+        provider.clone(),
+    )
+    .unwrap();
+    let listener_session = broker
+        .create_session(CallerCredential::Unauthenticated)
+        .unwrap();
+    let connector_session = broker
+        .create_session(CallerCredential::Unauthenticated)
+        .unwrap();
+    let (published, publications) = channel();
+    let (retired, _retirements) = channel();
+    let readiness = Arc::new(FailingReadinessSink {
+        inner: TestReadinessSink { published, retired },
+        fail_next_publish: Mutex::new(None),
+    });
+    let address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8096);
+    let listener = create_socket(&listener_session, readiness.clone());
+    assert_eq!(
+        litebox_broker_core::socket::bind(&listener_session, listener, address),
+        Ok(SocketOutcome::Completed(address))
+    );
+    assert_eq!(
+        litebox_broker_core::socket::listen(&listener_session, listener, 1),
+        Ok(SocketOutcome::Completed(address))
+    );
+    let connector = create_socket(&connector_session, readiness.clone());
+    assert_eq!(
+        litebox_broker_core::socket::connect(&connector_session, connector, address),
+        Ok(SocketOutcome::Completed(SocketConnectionStatus::Connected))
+    );
+    readiness.fail_next_publish_matching_any(ReadinessFlags::WRITE, ReadinessFlags::READ);
+    assert!(matches!(
+        litebox_broker_core::socket::accept(&listener_session, listener, readiness.clone()),
+        Err(BrokerError::ResourceExhausted)
+    ));
+    readiness.assert_no_pending_publish_failure();
+    assert_eq!(provider.reactor.queued_guest_connection_count(), 0);
+    assert!(
+        !listener_session
+            .check_readiness(listener)
+            .unwrap()
+            .contains(ReadinessFlags::READ)
+    );
+    wait_until_ready(
+        &connector_session,
+        &publications,
+        connector,
+        ReadinessFlags::ERROR,
+    );
+    let mut byte = [0_u8; 1];
+    assert_eq!(
+        receive_into(
+            &connector_session,
+            connector,
+            &mut byte,
+            ReceiveFlags::NONE,
+            0,
+            0,
+        ),
+        Ok(SocketOutcome::Failed(SocketError::ConnectionReset))
+    );
+}
+
+#[test]
+fn queued_guest_accept_transfers_capacity_without_global_growth() {
+    let provider = Arc::new(LinuxSocketProvider::new(5, 3).unwrap());
+    let broker = BrokerCore::new_with_limits(
+        PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
+            .with_socket_policy(SocketPolicy::guest_network()),
+        BrokerCoreLimits::new_with_all_limits(10, 0, 5, 5),
+        provider.clone(),
+    )
+    .unwrap();
+    let listener_session = broker
+        .create_session(CallerCredential::Unauthenticated)
+        .unwrap();
+    let connector_session = broker
+        .create_session(CallerCredential::Unauthenticated)
+        .unwrap();
+    let (published, _publications) = channel();
+    let (retired, retirements) = channel();
+    let readiness = Arc::new(TestReadinessSink { published, retired });
+    let address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8095);
+    let listener = create_socket(&listener_session, readiness.clone());
+    let first_listener_capacity = create_socket(&listener_session, readiness.clone());
+    let second_listener_capacity = create_socket(&listener_session, readiness.clone());
+    assert_eq!(
+        litebox_broker_core::socket::bind(&listener_session, listener, address),
+        Ok(SocketOutcome::Completed(address))
+    );
+    assert_eq!(
+        litebox_broker_core::socket::listen(&listener_session, listener, 1),
+        Ok(SocketOutcome::Completed(address))
+    );
+    let connector = create_socket(&connector_session, readiness.clone());
+    assert_eq!(
+        litebox_broker_core::socket::connect(&connector_session, connector, address),
+        Ok(SocketOutcome::Completed(SocketConnectionStatus::Connected))
+    );
+    assert_eq!(provider.reactor.queued_guest_connection_count(), 1);
+    let capacity_session = broker
+        .create_session(CallerCredential::Unauthenticated)
+        .unwrap();
+    assert_eq!(
+        litebox_broker_core::socket::create(
+            &capacity_session,
+            CreateSocketRequest {
+                address_family: AddressFamily::Ipv4,
+                socket_type: SocketType::Stream,
+                protocol: IpProtocol::Tcp,
+            },
+            readiness.clone(),
+        ),
+        Err(BrokerError::ResourceExhausted)
+    );
+    assert_ne!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), listener);
+    assert!(matches!(
+        litebox_broker_core::socket::accept(&listener_session, listener, readiness.clone(),),
+        Err(BrokerError::ResourceExhausted)
+    ));
+    assert_eq!(provider.reactor.queued_guest_connection_count(), 1);
+    assert_ne!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), listener);
+
+    listener_session
+        .close_object_reference(first_listener_capacity)
+        .unwrap();
+    assert_eq!(
+        retirements.recv_timeout(TEST_TIMEOUT).unwrap(),
+        first_listener_capacity
+    );
+    let accepted =
+        litebox_broker_core::socket::accept(&listener_session, listener, readiness).unwrap();
+    assert!(matches!(accepted, SocketOutcome::Completed(_)));
+    assert_eq!(provider.reactor.queued_guest_connection_count(), 0);
+    listener_session
+        .close_object_reference(second_listener_capacity)
+        .unwrap();
+}
+
+#[test]
 fn abortive_connector_close_releases_descriptor_capacity() {
-    let provider = Arc::new(LinuxSocketProvider::new(3, 1).unwrap());
+    let provider = Arc::new(LinuxSocketProvider::new(3, 2).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
             .with_socket_policy(SocketPolicy::guest_network()),
@@ -1670,237 +2565,22 @@ fn abortive_connector_close_releases_descriptor_capacity() {
     );
     connector_session.close_object_reference(connector).unwrap();
     assert_eq!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), connector);
-    assert_eq!(provider.reactor.pending_guest_connection_count(), 1);
-    assert_eq!(provider.reactor.retained_connector_count(), 0);
+    assert_eq!(provider.reactor.queued_guest_connection_count(), 0);
 
-    provider.reactor.expire_pending_guest_connections();
-    assert_eq!(provider.reactor.pending_guest_connection_count(), 0);
-    assert_eq!(provider.reactor.retained_connector_count(), 0);
-
-    let replacement = create_socket(&connector_session, readiness.clone());
-    assert_eq!(
+    let replacement = create_socket(&connector_session, readiness);
+    assert!(matches!(
         litebox_broker_core::socket::connect(&connector_session, replacement, guest_address,),
-        Ok(SocketOutcome::Completed(SocketConnectionStatus::Failed(
-            SocketError::ConnectionRefused
-        )))
-    );
-    connector_session
-        .close_object_reference(replacement)
-        .unwrap();
-    assert_eq!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), replacement);
-
-    loop {
-        match litebox_broker_core::socket::accept(&listener_session, listener, readiness.clone()) {
-            Err(BrokerError::WouldBlock) => break,
-            Ok(SocketOutcome::Failed(
-                SocketError::ConnectionAborted | SocketError::ConnectionReset,
-            )) => {}
-            _ => panic!("unexpected stale accept outcome"),
-        }
-    }
-
-    let final_connector = create_socket(&connector_session, readiness);
-    assert!(matches!(
-        litebox_broker_core::socket::connect(&connector_session, final_connector, guest_address,),
         Ok(SocketOutcome::Completed(
             SocketConnectionStatus::Connecting | SocketConnectionStatus::Connected
         ))
     ));
-    wait_until_connected(&connector_session, final_connector, &publications);
-}
-
-#[test]
-fn accept_bounds_unmatched_private_connections_per_command() {
-    let provider = Arc::new(LinuxSocketProvider::new(3, 2).unwrap());
-    let broker = BrokerCore::new_with_limits(
-        PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::guest_network()),
-        BrokerCoreLimits::new_with_all_limits(8, 0, 3, 3),
-        provider.clone(),
-    )
-    .unwrap();
-    let listener_session = broker
-        .create_session(CallerCredential::Unauthenticated)
-        .unwrap();
-    let connector_session = broker
-        .create_session(CallerCredential::Unauthenticated)
-        .unwrap();
-    let (published, publications) = channel();
-    let (retired, _retirements) = channel();
-    let readiness = Arc::new(TestReadinessSink { published, retired });
-    let guest_address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8087);
-    let listener = create_socket(&listener_session, readiness.clone());
-    assert_eq!(
-        litebox_broker_core::socket::bind(&listener_session, listener, guest_address),
-        Ok(SocketOutcome::Completed(guest_address))
-    );
-    let unmatched_connection_count = MAX_UNMATCHED_ACCEPTS_PER_COMMAND;
-    assert_eq!(
-        litebox_broker_core::socket::listen(
-            &listener_session,
-            listener,
-            u32::try_from(unmatched_connection_count + 2).unwrap(),
-        ),
-        Ok(SocketOutcome::Completed(guest_address))
-    );
-    let private_address = provider.reactor.host_address(guest_address.port()).unwrap();
-    let _unmatched_connections = (0..unmatched_connection_count)
-        .map(|_| TcpStream::connect(private_address).unwrap())
-        .collect::<Vec<_>>();
-
-    let connector = create_socket(&connector_session, readiness.clone());
-    assert!(matches!(
-        litebox_broker_core::socket::connect(&connector_session, connector, guest_address,),
-        Ok(SocketOutcome::Completed(
-            SocketConnectionStatus::Connecting | SocketConnectionStatus::Connected
-        ))
-    ));
-    wait_until_connected(&connector_session, connector, &publications);
-    let connector_address = litebox_broker_core::socket::status(&connector_session, connector)
-        .unwrap()
-        .local_address
-        .unwrap();
-    wait_until_ready(
-        &listener_session,
-        &publications,
-        listener,
-        ReadinessFlags::READ,
-    );
-    assert_eq!(provider.reactor.pending_guest_connection_count(), 1);
-    while publications.try_recv().is_ok() {}
-
-    assert!(matches!(
-        litebox_broker_core::socket::accept(&listener_session, listener, readiness.clone(),),
-        Err(BrokerError::WouldBlock)
-    ));
-    assert!(
-        listener_session
-            .check_readiness(listener)
-            .unwrap()
-            .contains(ReadinessFlags::READ)
-    );
-    wait_for_readiness(&publications, listener, ReadinessFlags::READ);
-    let accepted = match litebox_broker_core::socket::accept(&listener_session, listener, readiness)
-        .unwrap()
-    {
-        SocketOutcome::Completed(accepted) => accepted,
-        SocketOutcome::Failed(error) => panic!("guest accept failed: {error:?}"),
-    };
-    assert_eq!(accepted.remote_address, connector_address);
-}
-
-#[test]
-fn accept_preserves_a_queued_connection_when_retained_capacity_is_unrelated() {
-    let provider = Arc::new(LinuxSocketProvider::new(4, 4).unwrap());
-    let broker = BrokerCore::new_with_limits(
-        PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
-            .with_socket_policy(SocketPolicy::guest_network()),
-        BrokerCoreLimits::new_with_all_limits(8, 0, 5, 5),
-        provider.clone(),
-    )
-    .unwrap();
-    let target_listener_session = broker
-        .create_session(CallerCredential::Unauthenticated)
-        .unwrap();
-    let target_connector_session = broker
-        .create_session(CallerCredential::Unauthenticated)
-        .unwrap();
-    let other_listener_session = broker
-        .create_session(CallerCredential::Unauthenticated)
-        .unwrap();
-    let other_connector_session = broker
-        .create_session(CallerCredential::Unauthenticated)
-        .unwrap();
-    let (published, publications) = channel();
-    let (retired, _retirements) = channel();
-    let readiness = Arc::new(TestReadinessSink { published, retired });
-    let target_address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8084);
-    let other_address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8085);
-
-    let target_listener = create_socket(&target_listener_session, readiness.clone());
-    let other_listener = create_socket(&other_listener_session, readiness.clone());
-    for (session, listener, address) in [
-        (&target_listener_session, target_listener, target_address),
-        (&other_listener_session, other_listener, other_address),
-    ] {
-        assert_eq!(
-            litebox_broker_core::socket::bind(session, listener, address),
-            Ok(SocketOutcome::Completed(address))
-        );
-        assert_eq!(
-            litebox_broker_core::socket::listen(session, listener, 1),
-            Ok(SocketOutcome::Completed(address))
-        );
-    }
-
-    let target_connector = create_socket(&target_connector_session, readiness.clone());
-    let other_connector = create_socket(&other_connector_session, readiness.clone());
-    for (session, connector, address) in [
-        (&target_connector_session, target_connector, target_address),
-        (&other_connector_session, other_connector, other_address),
-    ] {
-        assert!(matches!(
-            litebox_broker_core::socket::connect(session, connector, address),
-            Ok(SocketOutcome::Completed(
-                SocketConnectionStatus::Connecting | SocketConnectionStatus::Connected
-            ))
-        ));
-        wait_until_connected(session, connector, &publications);
-    }
-    let target_connector_address =
-        litebox_broker_core::socket::status(&target_connector_session, target_connector)
-            .unwrap()
-            .local_address
-            .unwrap();
-    other_connector_session
-        .close_object_reference(other_connector)
-        .unwrap();
-    assert_eq!(provider.reactor.pending_guest_connection_count(), 2);
-    assert_eq!(provider.reactor.retained_connector_count(), 1);
-
-    let deadline = Instant::now() + TEST_TIMEOUT;
-    while !target_listener_session
-        .check_readiness(target_listener)
-        .unwrap()
-        .contains(ReadinessFlags::READ)
-    {
-        assert!(
-            Instant::now() < deadline,
-            "target listener did not become ready"
-        );
-        std::thread::yield_now();
-    }
-    assert!(matches!(
-        litebox_broker_core::socket::accept(
-            &target_listener_session,
-            target_listener,
-            readiness.clone(),
-        ),
-        Err(BrokerError::ResourceExhausted)
-    ));
-    assert_eq!(provider.reactor.pending_guest_connection_count(), 2);
-
-    other_listener_session
-        .close_object_reference(other_listener)
-        .unwrap();
-    assert_eq!(provider.reactor.pending_guest_connection_count(), 1);
-    assert_eq!(provider.reactor.retained_connector_count(), 0);
-    let accepted = match litebox_broker_core::socket::accept(
-        &target_listener_session,
-        target_listener,
-        readiness,
-    )
-    .unwrap()
-    {
-        SocketOutcome::Completed(accepted) => accepted,
-        SocketOutcome::Failed(error) => panic!("target accept failed: {error:?}"),
-    };
-    assert_eq!(accepted.remote_address, target_connector_address);
+    wait_until_connected(&connector_session, replacement, &publications);
+    assert_eq!(provider.reactor.queued_guest_connection_count(), 1);
 }
 
 #[test]
 fn stop_listening_cleanup_survives_readiness_failure() {
-    let provider = Arc::new(LinuxSocketProvider::new(3, 1).unwrap());
+    let provider = Arc::new(LinuxSocketProvider::new(3, 2).unwrap());
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
             .with_socket_policy(SocketPolicy::guest_network()),
@@ -1930,7 +2610,7 @@ fn stop_listening_cleanup_survives_readiness_failure() {
         litebox_broker_core::socket::listen(&listener_session, listener, 1),
         Ok(SocketOutcome::Completed(guest_address))
     );
-    let private_address = provider.reactor.host_address(guest_address.port()).unwrap();
+    assert_eq!(provider.reactor.host_address(guest_address.port()), None);
 
     let connector = create_socket(&connector_session, readiness.clone());
     assert!(matches!(
@@ -1948,8 +2628,7 @@ fn stop_listening_cleanup_survives_readiness_failure() {
     );
     connector_session.close_object_reference(connector).unwrap();
     assert_eq!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), connector);
-    assert_eq!(provider.reactor.pending_guest_connection_count(), 1);
-    assert_eq!(provider.reactor.retained_connector_count(), 1);
+    assert_eq!(provider.reactor.queued_guest_connection_count(), 1);
 
     readiness.fail_next_publish_matching(listener, ReadinessFlags::HANGUP, ReadinessFlags::READ);
     assert_eq!(
@@ -1965,12 +2644,8 @@ fn stop_listening_cleanup_survives_readiness_failure() {
     assert!(listener_readiness.contains(ReadinessFlags::WRITE));
     assert!(listener_readiness.contains(ReadinessFlags::HANGUP));
     assert!(!listener_readiness.contains(ReadinessFlags::READ));
-    assert_eq!(provider.reactor.pending_guest_connection_count(), 0);
-    assert_eq!(provider.reactor.retained_connector_count(), 0);
-    assert_eq!(
-        provider.reactor.host_address(guest_address.port()),
-        Some(private_address)
-    );
+    assert_eq!(provider.reactor.queued_guest_connection_count(), 0);
+    assert_eq!(provider.reactor.host_address(guest_address.port()), None);
     assert_eq!(
         litebox_broker_core::socket::listen(&listener_session, listener, 1),
         Ok(SocketOutcome::Failed(SocketError::InvalidArgument))
@@ -1987,8 +2662,7 @@ fn stop_listening_cleanup_survives_readiness_failure() {
     assert_eq!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), refused);
     listener_session.close_object_reference(listener).unwrap();
     assert_eq!(retirements.recv_timeout(TEST_TIMEOUT).unwrap(), listener);
-    assert_eq!(provider.reactor.pending_guest_connection_count(), 0);
-    assert_eq!(provider.reactor.retained_connector_count(), 0);
+    assert_eq!(provider.reactor.queued_guest_connection_count(), 0);
     assert_eq!(provider.reactor.host_address(guest_address.port()), None);
 }
 
@@ -2017,12 +2691,7 @@ fn reactor_drives_a_loopback_tcp_listener() {
     };
     assert!(local_address.ip().is_loopback());
     assert_ne!(local_address.port(), 0);
-    let private_address = provider
-        .reactor
-        .host_address(local_address.port())
-        .expect("listening socket must have a private host endpoint");
-    assert!(private_address.ip().is_loopback());
-    assert_ne!(private_address.port(), 0);
+    assert_eq!(provider.reactor.host_address(local_address.port()), None);
     assert_eq!(
         litebox_broker_core::socket::shutdown(&session, listener, ShutdownMode::Write),
         Ok(SocketOutcome::Failed(SocketError::NotConnected))


### PR DESCRIPTION
This PR routes matched guest TCP connections through bounded anonymous nonblocking Unix stream pairs instead of private host-loopback endpoints. Core-issued source leases preserve guest address and port identity across queued and accepted lifetimes, while reactor-owned listener queues provide FIFO backlog, readiness, and per-session/global accounting; native IPv4 sockets are created lazily only for unmatched-loopback fallback and other native destinations. The direct path preserves close-before-accept, half-close, peek and wait-all, TCP option, publication-failure, and session-teardown semantics, including buffered data followed by one reset and then EOF after logical read shutdown. Final fail-closed loopback routing and the 10.0.2.1 host gateway remain follow-up work.