### PR TITLE
Fix the OOM handling of page-sized memory allocation

### DIFF
--- a/litebox/src/mm/allocator.rs
+++ b/litebox/src/mm/allocator.rs
@@ -162,14 +162,18 @@ unsafe impl<const ORDER: usize, M: MemoryProvider> GlobalAlloc
             Self::BASE_PAGE_SIZE => {
                 // Best to use the underlying backend directly to allocate pages
                 // to avoid fragmentation
-                self.allocate_pages(Self::BASE_PAGE_SIZE_ORDER)
-                    .expect("allocate page")
+                let Some(ptr) = self.allocate_pages(Self::BASE_PAGE_SIZE_ORDER) else {
+                    return core::ptr::null_mut();
+                };
+                ptr
             }
             Self::LARGE_PAGE_SIZE => {
                 // Best to use the underlying backend directly to allocate large pages
                 // to avoid fragmentation
-                self.allocate_pages(Self::LARGE_PAGE_SIZE_ORDER)
-                    .expect("allocate large page")
+                let Some(ptr) = self.allocate_pages(Self::LARGE_PAGE_SIZE_ORDER) else {
+                    return core::ptr::null_mut();
+                };
+                ptr
             }
             0..=ZoneAllocator::MAX_ALLOC_SIZE => {
                 let mut zone_allocator = self.slab_allocator.lock();


### PR DESCRIPTION
This PR fixes the out-of-memory (OOM) handling of page-sized memory allocation. Currently, LiteBox's allocator panics when its page-sized memory allocation fails. This prevents us from using fallible APIs like `try_reserve` which expect the allocator reports OOM by returning `null`.