### PR TITLE
Keep epoll interest alive while a duplicate of the registered fd survives

### DIFF
--- a/litebox/src/fd/mod.rs
+++ b/litebox/src/fd/mod.rs
@@ -146,11 +146,33 @@ impl<Platform: RawSyncPrimitivesProvider> Descriptors<Platform> {
             // Unique, so we can just return it if allowed.
             if can_close_immediately(old.x.entry.read().as_subsystem::<Subsystem>()) {
                 fd.x.mark_as_closed();
-                let entry = Arc::into_inner(old.x)
-                    .map(|shared| RwLock::into_inner(shared.entry))
-                    .map(DescriptorEntry::into_subsystem_entry::<Subsystem>)
-                    .unwrap();
-                Some(CloseResult::Closed(entry))
+                match Arc::try_unwrap(old.x) {
+                    Ok(shared) => {
+                        let entry = DescriptorEntry::into_subsystem_entry::<Subsystem>(
+                            RwLock::into_inner(shared.entry),
+                        );
+                        Some(CloseResult::Closed(entry))
+                    }
+                    Err(x) => {
+                        // The strong count was 1 above, but a lock-free
+                        // `WeakEntryHandle::upgrade` on another thread (e.g. an
+                        // epoll re-poll of a still-registered interest) can
+                        // transiently re-share the entry before we take
+                        // ownership. Fall back to the shared path: duplicate the
+                        // descriptor so it is closed once that reference drops,
+                        // rather than dropping the entry without an orderly
+                        // close.
+                        let replaced = self.entries[idx].replace(IndividualEntry {
+                            x,
+                            metadata: old.metadata,
+                        });
+                        assert!(replaced.is_none());
+                        Some(CloseResult::Duplicated(TypedFd {
+                            _phantom: PhantomData,
+                            x: OwnedFd::new(idx),
+                        }))
+                    }
+                }
             } else {
                 // Put it back
                 let old = self.entries[idx].replace(old);

--- a/litebox/src/fd/mod.rs
+++ b/litebox/src/fd/mod.rs
@@ -9,6 +9,7 @@
 )]
 
 use alloc::sync::Arc;
+use alloc::sync::Weak;
 use alloc::vec;
 use alloc::vec::Vec;
 use core::marker::PhantomData;
@@ -555,6 +556,77 @@ impl<Platform: RawSyncPrimitivesProvider, Subsystem: FdEnabledSubsystem>
 
     pub fn with_entry_mut<R>(&self, f: impl FnOnce(&mut Subsystem::Entry) -> R) -> R {
         f(self.0.entry.write().as_subsystem_mut::<Subsystem>())
+    }
+
+    /// Runs `f` with the aliased (open-file-description-level) metadata of type
+    /// `T`, if present.
+    ///
+    /// This reads the metadata stored via [`Descriptors::set_entry_metadata`],
+    /// which is shared by every descriptor referring to the same open file
+    /// description. Returns `None` if no such metadata exists.
+    pub fn with_shared_metadata<T, R>(&self, f: impl FnOnce(&T) -> R) -> Option<R>
+    where
+        T: core::any::Any + Clone + Send + Sync,
+    {
+        self.0.entry.read().metadata.get::<T>().map(f)
+    }
+
+    /// The address of the shared open file description this handle refers to.
+    ///
+    /// Duplicates of a descriptor share one open file description, so this
+    /// address is stable across `dup` and uniquely identifies the description
+    /// for as long as any duplicate keeps it alive.
+    #[must_use]
+    pub fn as_ptr(&self) -> *const () {
+        Arc::as_ptr(&self.0).cast()
+    }
+
+    /// Downgrades to a [`WeakEntryHandle`] that survives `dup`.
+    ///
+    /// The resulting handle upgrades for as long as *any* descriptor referring
+    /// to the same open file description remains open, even after the specific
+    /// descriptor this handle was obtained from has been closed.
+    #[must_use]
+    pub fn downgrade(&self) -> WeakEntryHandle<Platform, Subsystem> {
+        WeakEntryHandle(Arc::downgrade(&self.0), PhantomData)
+    }
+}
+
+/// A durable, `dup`-surviving weak reference to a descriptor's open file
+/// description.
+///
+/// Unlike a [`TypedFd`], which is tied to one descriptor slot, this upgrades as
+/// long as *any* descriptor referring to the same open file description is
+/// open. It is the correct anchor for interest that must outlive the closure of
+/// the specific descriptor it was registered against (for example, epoll
+/// interest, per Linux `epoll(7)` semantics).
+pub struct WeakEntryHandle<Platform: RawSyncPrimitivesProvider, Subsystem: FdEnabledSubsystem>(
+    Weak<SharedEntry<Platform>>,
+    PhantomData<fn(Subsystem) -> Subsystem>,
+);
+
+impl<Platform: RawSyncPrimitivesProvider, Subsystem: FdEnabledSubsystem>
+    WeakEntryHandle<Platform, Subsystem>
+{
+    /// Upgrades to a strong [`EntryHandle`] if the open file description is
+    /// still alive (i.e. at least one duplicate remains open).
+    #[must_use]
+    pub fn upgrade(&self) -> Option<EntryHandle<Platform, Subsystem>> {
+        self.0
+            .upgrade()
+            .map(|entry| EntryHandle(entry, PhantomData))
+    }
+
+    /// The address of the shared open file description, stable across `dup`.
+    ///
+    /// This is safe to use as a durable identity key. A [`WeakEntryHandle`]
+    /// keeps the underlying allocation reserved even after the open file
+    /// description is closed (every strong reference dropped), so this address
+    /// is never recycled for a different open file description while this handle
+    /// exists. The pointer is only ever compared, never dereferenced.
+    #[must_use]
+    pub fn as_ptr(&self) -> *const () {
+        self.0.as_ptr().cast()
     }
 }
 

--- a/litebox/src/fd/mod.rs
+++ b/litebox/src/fd/mod.rs
@@ -541,11 +541,20 @@ impl<Platform: RawSyncPrimitivesProvider> Descriptors<Platform> {
     }
 }
 
+/// An opaque, stable identity for a descriptor's entry (its open file
+/// description).
+///
+/// Equal keys denote the same entry. A key is stable across `dup` and for the
+/// entry's lifetime, so it can identify an entry (for example as a map key)
+/// without dereferencing anything.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct EntryStableKey(usize);
+
 /// A handle to a descriptor entry (via [`Descriptors::entry_handle`]) that can be used without
 /// maintaining access to the descriptor table itself.
 pub struct EntryHandle<Platform: RawSyncPrimitivesProvider, Subsystem: FdEnabledSubsystem>(
     Arc<SharedEntry<Platform>>,
-    PhantomData<Subsystem>,
+    PhantomData<fn(Subsystem) -> Subsystem>,
 );
 impl<Platform: RawSyncPrimitivesProvider, Subsystem: FdEnabledSubsystem>
     EntryHandle<Platform, Subsystem>
@@ -580,48 +589,31 @@ impl<Platform: RawSyncPrimitivesProvider, Subsystem: FdEnabledSubsystem>
         f(self.0.entry.write().as_subsystem_mut::<Subsystem>())
     }
 
-    /// Runs `f` with the aliased (open-file-description-level) metadata of type
-    /// `T`, if present.
+    /// Apply `f` on metadata at the entry, if it exists.
     ///
-    /// This reads the metadata stored via [`Descriptors::set_entry_metadata`],
-    /// which is shared by every descriptor referring to the same open file
-    /// description. Returns `None` if no such metadata exists.
-    pub fn with_shared_metadata<T, R>(&self, f: impl FnOnce(&T) -> R) -> Option<R>
+    /// In contrast to [`Descriptors::with_metadata`], this obtains entry-level metadata.
+    /// For FD-specific metadata, one necessarily needs the specific FD.
+    pub fn with_entry_metadata<T, R>(&self, f: impl FnOnce(&T) -> R) -> Option<R>
     where
         T: core::any::Any + Clone + Send + Sync,
     {
         self.0.entry.read().metadata.get::<T>().map(f)
     }
 
-    /// The address of the shared open file description this handle refers to.
-    ///
-    /// Duplicates of a descriptor share one open file description, so this
-    /// address is stable across `dup` and uniquely identifies the description
-    /// for as long as any duplicate keeps it alive.
+    /// An opaque, stable identity for this entry (see [`EntryStableKey`]).
     #[must_use]
-    pub fn as_ptr(&self) -> *const () {
-        Arc::as_ptr(&self.0).cast()
+    pub fn stable_key(&self) -> EntryStableKey {
+        EntryStableKey(Arc::as_ptr(&self.0).addr())
     }
 
-    /// Downgrades to a [`WeakEntryHandle`] that survives `dup`.
-    ///
-    /// The resulting handle upgrades for as long as *any* descriptor referring
-    /// to the same open file description remains open, even after the specific
-    /// descriptor this handle was obtained from has been closed.
+    /// Obtains a non-owning [`WeakEntryHandle`] to this entry.
     #[must_use]
     pub fn downgrade(&self) -> WeakEntryHandle<Platform, Subsystem> {
         WeakEntryHandle(Arc::downgrade(&self.0), PhantomData)
     }
 }
 
-/// A durable, `dup`-surviving weak reference to a descriptor's open file
-/// description.
-///
-/// Unlike a [`TypedFd`], which is tied to one descriptor slot, this upgrades as
-/// long as *any* descriptor referring to the same open file description is
-/// open. It is the correct anchor for interest that must outlive the closure of
-/// the specific descriptor it was registered against (for example, epoll
-/// interest, per Linux `epoll(7)` semantics).
+/// A weak reference to a descriptor entry.
 pub struct WeakEntryHandle<Platform: RawSyncPrimitivesProvider, Subsystem: FdEnabledSubsystem>(
     Weak<SharedEntry<Platform>>,
     PhantomData<fn(Subsystem) -> Subsystem>,
@@ -630,8 +622,7 @@ pub struct WeakEntryHandle<Platform: RawSyncPrimitivesProvider, Subsystem: FdEna
 impl<Platform: RawSyncPrimitivesProvider, Subsystem: FdEnabledSubsystem>
     WeakEntryHandle<Platform, Subsystem>
 {
-    /// Upgrades to a strong [`EntryHandle`] if the open file description is
-    /// still alive (i.e. at least one duplicate remains open).
+    /// Upgrades to a strong [`EntryHandle`] if the entry is still alive.
     #[must_use]
     pub fn upgrade(&self) -> Option<EntryHandle<Platform, Subsystem>> {
         self.0
@@ -639,16 +630,14 @@ impl<Platform: RawSyncPrimitivesProvider, Subsystem: FdEnabledSubsystem>
             .map(|entry| EntryHandle(entry, PhantomData))
     }
 
-    /// The address of the shared open file description, stable across `dup`.
+    /// An opaque, stable identity for this entry (see [`EntryStableKey`]).
     ///
-    /// This is safe to use as a durable identity key. A [`WeakEntryHandle`]
-    /// keeps the underlying allocation reserved even after the open file
-    /// description is closed (every strong reference dropped), so this address
-    /// is never recycled for a different open file description while this handle
-    /// exists. The pointer is only ever compared, never dereferenced.
+    /// A [`WeakEntryHandle`] keeps the underlying allocation reserved even after
+    /// the entry is closed, so this key is never reused for a different entry
+    /// while this handle exists.
     #[must_use]
-    pub fn as_ptr(&self) -> *const () {
-        self.0.as_ptr().cast()
+    pub fn stable_key(&self) -> EntryStableKey {
+        EntryStableKey(self.0.as_ptr().addr())
     }
 }
 

--- a/litebox/src/pipes.rs
+++ b/litebox/src/pipes.rs
@@ -729,3 +729,18 @@ crate::fd::enable_fds_for_subsystem! {
     PipeEnd<Platform>;
     -> PipeFd<Platform>;
 }
+
+impl<Platform: RawSyncPrimitivesProvider + TimeProvider> DescriptorEntry<Platform> {
+    /// Runs `f` with the [`IOPollable`] backing this pipe end.
+    ///
+    /// This lets a holder of a durable entry handle poll the pipe without a
+    /// live per-descriptor [`PipeFd`], which is required so that an epoll
+    /// interest survives closing the registered descriptor while a duplicate
+    /// referring to the same open file description remains open.
+    pub fn with_iopollable<R>(&self, f: impl FnOnce(&dyn IOPollable) -> R) -> R {
+        match &self.entry {
+            PipeEnd::Receiver(receiver) => f(receiver.as_ref()),
+            PipeEnd::Sender(sender) => f(sender.as_ref()),
+        }
+    }
+}

--- a/litebox/src/pipes.rs
+++ b/litebox/src/pipes.rs
@@ -732,11 +732,6 @@ crate::fd::enable_fds_for_subsystem! {
 
 impl<Platform: RawSyncPrimitivesProvider + TimeProvider> DescriptorEntry<Platform> {
     /// Runs `f` with the [`IOPollable`] backing this pipe end.
-    ///
-    /// This lets a holder of a durable entry handle poll the pipe without a
-    /// live per-descriptor [`PipeFd`], which is required so that an epoll
-    /// interest survives closing the registered descriptor while a duplicate
-    /// referring to the same open file description remains open.
     pub fn with_iopollable<R>(&self, f: impl FnOnce(&dyn IOPollable) -> R) -> R {
         match &self.entry {
             PipeEnd::Receiver(receiver) => f(receiver.as_ref()),

--- a/litebox_runner_linux_userland/tests/epoll_dup.c
+++ b/litebox_runner_linux_userland/tests/epoll_dup.c
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// Tests: an epoll interest survives closing the registered fd as long as a
+// duplicate referring to the same open file description remains open, matching
+// Linux epoll(7) semantics ("a file descriptor is removed from an interest
+// list only after all the file descriptors referring to the underlying open
+// file description have been closed").
+
+#define _GNU_SOURCE
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/epoll.h>
+#include <sys/eventfd.h>
+#include <unistd.h>
+
+#define TEST_ASSERT(cond, msg)                                                \
+    do {                                                                      \
+        if (!(cond)) {                                                        \
+            fprintf(stderr, "FAIL: %s (line %d): %s (errno=%d: %s)\n",        \
+                    __func__, __LINE__, msg, errno, strerror(errno));         \
+            return 1;                                                         \
+        }                                                                     \
+    } while (0)
+
+int main(void) {
+    int efd = eventfd(0, EFD_CLOEXEC);
+    TEST_ASSERT(efd >= 0, "eventfd failed");
+
+    int epfd = epoll_create1(EPOLL_CLOEXEC);
+    TEST_ASSERT(epfd >= 0, "epoll_create1 failed");
+
+    struct epoll_event ev;
+    memset(&ev, 0, sizeof(ev));
+    ev.events = EPOLLIN;
+    ev.data.u64 = 0x42;
+    TEST_ASSERT(epoll_ctl(epfd, EPOLL_CTL_ADD, efd, &ev) == 0,
+                "epoll_ctl ADD failed");
+
+    // The duplicate shares the same open file description as efd.
+    int dupfd = dup(efd);
+    TEST_ASSERT(dupfd >= 0, "dup failed");
+
+    // Close the originally-registered fd. The interest must survive because
+    // dupfd still refers to the same open file description.
+    TEST_ASSERT(close(efd) == 0, "close original failed");
+
+    // Make the description readable through the surviving duplicate.
+    uint64_t one = 1;
+    TEST_ASSERT(write(dupfd, &one, sizeof(one)) == (ssize_t)sizeof(one),
+                "write via dup failed");
+
+    // The registration must still be reported, carrying its original data.
+    struct epoll_event out[4];
+    memset(out, 0, sizeof(out));
+    int n = epoll_wait(epfd, out, 4, 1000);
+    TEST_ASSERT(n == 1, "epoll_wait should report the surviving registration");
+    TEST_ASSERT((out[0].events & EPOLLIN) != 0, "expected EPOLLIN");
+    TEST_ASSERT(out[0].data.u64 == 0x42, "event data mismatch");
+
+    // The registration is durable: after draining and re-arming through the
+    // duplicate, a second wait still reports it.
+    uint64_t val = 0;
+    TEST_ASSERT(read(dupfd, &val, sizeof(val)) == (ssize_t)sizeof(val),
+                "read via dup failed");
+    TEST_ASSERT(val == 1, "unexpected eventfd value");
+    TEST_ASSERT(write(dupfd, &one, sizeof(one)) == (ssize_t)sizeof(one),
+                "second write via dup failed");
+    memset(out, 0, sizeof(out));
+    n = epoll_wait(epfd, out, 4, 1000);
+    TEST_ASSERT(n == 1, "epoll_wait should still report after re-arm");
+    TEST_ASSERT(out[0].data.u64 == 0x42, "event data mismatch after re-arm");
+
+    TEST_ASSERT(close(dupfd) == 0, "close dup failed");
+    TEST_ASSERT(close(epfd) == 0, "close epoll failed");
+
+    printf("epoll dup-survival: PASS\n");
+    return 0;
+}

--- a/litebox_shim_linux/src/syscalls/epoll.rs
+++ b/litebox_shim_linux/src/syscalls/epoll.rs
@@ -15,7 +15,7 @@ use litebox::{
         polling::{Pollee, TryOpError},
         wait::{WaitContext, WaitError, Waker},
     },
-    fd::{FdEnabledSubsystem, FdEnabledSubsystemEntry, TypedFd},
+    fd::{FdEnabledSubsystem, FdEnabledSubsystemEntry, TypedFd, WeakEntryHandle},
     utils::ReinterpretUnsignedExt,
 };
 use litebox_common_linux::{EpollEvent, EpollOp, errno::Errno};
@@ -80,35 +80,108 @@ impl<Platform: ShimPlatform, FS: ShimFS> EpollDescriptor<Platform, FS> {
     }
 }
 
+/// A durable, `dup`-surviving reference to an epoll target's open file
+/// description.
+///
+/// Each variant holds a [`WeakEntryHandle`], which upgrades for as long as any
+/// descriptor referring to the same open file description remains open. This is
+/// what lets an epoll interest outlive closing the descriptor it was registered
+/// against, matching Linux `epoll(7)` semantics.
 enum DescriptorRef<Platform: ShimPlatform, FS: ShimFS> {
-    Eventfd(Weak<TypedFd<super::eventfd::EventfdSubsystem<Platform>>>),
-    Epoll(Weak<TypedFd<super::epoll::EpollSubsystem<Platform, FS>>>),
-    File(Weak<crate::FileFd<FS>>),
-    Socket(Weak<super::net::SocketFd<Platform>>),
-    Pipe(Weak<litebox::pipes::PipeFd<Platform>>),
-    Unix(Weak<TypedFd<crate::syscalls::unix::UnixSocketSubsystem<Platform, FS>>>),
+    Eventfd(WeakEntryHandle<Platform, super::eventfd::EventfdSubsystem<Platform>>),
+    Epoll(WeakEntryHandle<Platform, super::epoll::EpollSubsystem<Platform, FS>>),
+    File(WeakEntryHandle<Platform, FS>),
+    Socket(WeakEntryHandle<Platform, crate::Network<Platform>>),
+    Pipe(WeakEntryHandle<Platform, litebox::pipes::Pipes<Platform>>),
+    Unix(WeakEntryHandle<Platform, crate::syscalls::unix::UnixSocketSubsystem<Platform, FS>>),
 }
 
 impl<Platform: ShimPlatform, FS: ShimFS> DescriptorRef<Platform, FS> {
-    fn from(value: &EpollDescriptor<Platform, FS>) -> Self {
-        match value {
-            EpollDescriptor::Eventfd(file) => Self::Eventfd(Arc::downgrade(file)),
-            EpollDescriptor::Epoll(file) => Self::Epoll(Arc::downgrade(file)),
-            EpollDescriptor::File(file) => Self::File(Arc::downgrade(file)),
-            EpollDescriptor::Socket(socket) => Self::Socket(Arc::downgrade(socket)),
-            EpollDescriptor::Pipe(pipe) => Self::Pipe(Arc::downgrade(pipe)),
-            EpollDescriptor::Unix(unix) => Self::Unix(Arc::downgrade(unix)),
+    /// Derives a durable reference to `desc`'s open file description.
+    ///
+    /// Returns `None` if the descriptor has already been closed.
+    fn new(
+        global: &GlobalState<Platform, FS>,
+        desc: &EpollDescriptor<Platform, FS>,
+    ) -> Option<Self> {
+        let dt = global.litebox.descriptor_table();
+        Some(match desc {
+            EpollDescriptor::Eventfd(fd) => Self::Eventfd(dt.entry_handle(fd)?.downgrade()),
+            EpollDescriptor::Epoll(fd) => Self::Epoll(dt.entry_handle(fd)?.downgrade()),
+            EpollDescriptor::File(fd) => Self::File(dt.entry_handle(fd)?.downgrade()),
+            EpollDescriptor::Socket(fd) => Self::Socket(dt.entry_handle(fd)?.downgrade()),
+            EpollDescriptor::Pipe(fd) => Self::Pipe(dt.entry_handle(fd)?.downgrade()),
+            EpollDescriptor::Unix(fd) => Self::Unix(dt.entry_handle(fd)?.downgrade()),
+        })
+    }
+
+    /// The address of the shared open file description, stable across `dup`.
+    fn as_ptr(&self) -> usize {
+        match self {
+            DescriptorRef::Eventfd(handle) => handle.as_ptr().addr(),
+            DescriptorRef::Epoll(handle) => handle.as_ptr().addr(),
+            DescriptorRef::File(handle) => handle.as_ptr().addr(),
+            DescriptorRef::Socket(handle) => handle.as_ptr().addr(),
+            DescriptorRef::Pipe(handle) => handle.as_ptr().addr(),
+            DescriptorRef::Unix(handle) => handle.as_ptr().addr(),
         }
     }
 
-    fn upgrade(&self) -> Option<EpollDescriptor<Platform, FS>> {
+    /// Whether the open file description is still alive (some duplicate remains
+    /// open).
+    fn is_alive(&self) -> bool {
         match self {
-            DescriptorRef::Eventfd(eventfd) => eventfd.upgrade().map(EpollDescriptor::Eventfd),
-            DescriptorRef::Epoll(epoll) => epoll.upgrade().map(EpollDescriptor::Epoll),
-            DescriptorRef::File(file) => file.upgrade().map(EpollDescriptor::File),
-            DescriptorRef::Socket(socket) => socket.upgrade().map(EpollDescriptor::Socket),
-            DescriptorRef::Pipe(pipe) => pipe.upgrade().map(EpollDescriptor::Pipe),
-            DescriptorRef::Unix(unix) => unix.upgrade().map(EpollDescriptor::Unix),
+            DescriptorRef::Eventfd(handle) => handle.upgrade().is_some(),
+            DescriptorRef::Epoll(handle) => handle.upgrade().is_some(),
+            DescriptorRef::File(handle) => handle.upgrade().is_some(),
+            DescriptorRef::Socket(handle) => handle.upgrade().is_some(),
+            DescriptorRef::Pipe(handle) => handle.upgrade().is_some(),
+            DescriptorRef::Unix(handle) => handle.upgrade().is_some(),
+        }
+    }
+
+    /// Checks the currently-ready events, polling through the shared open file
+    /// description rather than a per-descriptor handle.
+    ///
+    /// Returns `None` once every descriptor referring to the open file
+    /// description has been closed.
+    fn poll(&self, _global: &GlobalState<Platform, FS>, mask: Events) -> Option<Events> {
+        let check = |iop: &dyn IOPollable| iop.check_io_events() & (mask | Events::ALWAYS_POLLED);
+        match self {
+            DescriptorRef::Eventfd(handle) => {
+                Some(handle.upgrade()?.with_entry(|entry| check(entry)))
+            }
+            DescriptorRef::Unix(handle) => Some(handle.upgrade()?.with_entry(|entry| check(entry))),
+            DescriptorRef::Pipe(handle) => Some(
+                handle
+                    .upgrade()?
+                    .with_entry(|entry| entry.with_iopollable(check)),
+            ),
+            DescriptorRef::Socket(handle) => {
+                let proxy = handle
+                    .upgrade()?
+                    .with_shared_metadata::<crate::syscalls::net::SocketProxy<Platform>, _>(
+                        |crate::syscalls::net::SocketProxy(proxy)| proxy.clone(),
+                    )?;
+                Some(check(&proxy))
+            }
+            DescriptorRef::File(handle) => {
+                // File polling returns dummy events, distinguishing stdio enough
+                // for REPLs (mirrors `EpollDescriptor::poll`).
+                let handle = handle.upgrade()?;
+                let events = match handle
+                    .with_shared_metadata::<litebox::platform::StdioStream, _>(|stream| *stream)
+                {
+                    Some(litebox::platform::StdioStream::Stdin) => Events::IN,
+                    Some(
+                        litebox::platform::StdioStream::Stdout
+                        | litebox::platform::StdioStream::Stderr,
+                    )
+                    | None => Events::OUT,
+                };
+                Some(events & mask)
+            }
+            DescriptorRef::Epoll(_handle) => unimplemented!(),
         }
     }
 }
@@ -222,10 +295,9 @@ impl<Platform: ShimPlatform, FS: ShimFS> EpollFile<Platform, FS> {
                 Err(Errno::EINVAL)
             }
             EpollOp::EpollCtlDel => {
+                let key = EpollEntryKey::new(global, fd, file).ok_or(Errno::EBADF)?;
                 let mut interests = self.interests.lock();
-                let _ = interests
-                    .remove(&EpollEntryKey::new(fd, file))
-                    .ok_or(Errno::ENOENT)?;
+                let _ = interests.remove(&key).ok_or(Errno::ENOENT)?;
                 Ok(())
             }
         }
@@ -238,10 +310,11 @@ impl<Platform: ShimPlatform, FS: ShimFS> EpollFile<Platform, FS> {
         file: &EpollDescriptor<Platform, FS>,
         event: EpollEvent,
     ) -> Result<(), Errno> {
+        let desc = DescriptorRef::new(global, file).ok_or(Errno::EBADF)?;
+        let key = EpollEntryKey(fd, desc.as_ptr());
         let mut interests = self.interests.lock();
-        let key = EpollEntryKey::new(fd, file);
         if let Some(entry) = interests.get(&key)
-            && entry.desc.upgrade().is_some()
+            && entry.desc.is_alive()
         {
             return Err(Errno::EEXIST);
         }
@@ -250,7 +323,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> EpollFile<Platform, FS> {
 
         let mask = Events::from_bits_truncate(event.events);
         let entry = EpollEntry::new(
-            DescriptorRef::from(file),
+            desc,
             mask,
             EpollFlags::from_bits_truncate(event.events),
             event.data,
@@ -282,10 +355,10 @@ impl<Platform: ShimPlatform, FS: ShimFS> EpollFile<Platform, FS> {
         }
 
         let mut interests = self.interests.lock();
-        let key = EpollEntryKey::new(fd, file);
+        let key = EpollEntryKey::new(global, fd, file).ok_or(Errno::EBADF)?;
         let entry = interests.get(&key).ok_or(Errno::ENOENT)?;
-        if entry.desc.upgrade().is_none() {
-            // The file descriptor is closed, remove the entry
+        if !entry.desc.is_alive() {
+            // The open file description is closed, remove the entry
             interests.remove(&key);
             return Err(Errno::ENOENT);
         }
@@ -329,19 +402,17 @@ impl<Platform: ShimPlatform, FS: ShimFS> EpollFile<Platform, FS> {
 #[derive(PartialEq, Eq, PartialOrd, Ord)]
 struct EpollEntryKey(u32, usize);
 impl EpollEntryKey {
+    /// Builds the key `(fd, open-file-description address)`.
+    ///
+    /// The address is stable across `dup`, so an interest registered against one
+    /// descriptor is found again while any duplicate of its open file
+    /// description remains open. Returns `None` if the descriptor is closed.
     fn new<Platform: ShimPlatform, FS: ShimFS>(
+        global: &GlobalState<Platform, FS>,
         fd: u32,
         desc: &EpollDescriptor<Platform, FS>,
-    ) -> Self {
-        let ptr = match desc {
-            EpollDescriptor::Eventfd(file) => Arc::as_ptr(file).addr(),
-            EpollDescriptor::Epoll(file) => Arc::as_ptr(file).addr(),
-            EpollDescriptor::File(file) => Arc::as_ptr(file).addr(),
-            EpollDescriptor::Socket(socket_fd) => Arc::as_ptr(socket_fd).addr(),
-            EpollDescriptor::Pipe(pipe_fd) => Arc::as_ptr(pipe_fd).addr(),
-            EpollDescriptor::Unix(unix) => Arc::as_ptr(unix).addr(),
-        };
-        Self(fd, ptr)
+    ) -> Option<Self> {
+        Some(Self(fd, DescriptorRef::new(global, desc)?.as_ptr()))
     }
 }
 
@@ -379,7 +450,6 @@ impl<Platform: ShimPlatform, FS: ShimFS> EpollEntry<Platform, FS> {
     }
 
     fn poll(&self, global: &GlobalState<Platform, FS>) -> Option<(Option<EpollEvent>, bool)> {
-        let file = self.desc.upgrade()?;
         let inner = self.inner.lock();
 
         if !self.is_enabled.load(core::sync::atomic::Ordering::Relaxed) {
@@ -387,7 +457,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> EpollEntry<Platform, FS> {
             return None;
         }
 
-        let events = file.poll(global, inner.mask, None)?;
+        let events = self.desc.poll(global, inner.mask)?;
         if events.is_empty() {
             Some((None, false))
         } else {

--- a/litebox_shim_linux/src/syscalls/epoll.rs
+++ b/litebox_shim_linux/src/syscalls/epoll.rs
@@ -15,7 +15,7 @@ use litebox::{
         polling::{Pollee, TryOpError},
         wait::{WaitContext, WaitError, Waker},
     },
-    fd::{FdEnabledSubsystem, FdEnabledSubsystemEntry, TypedFd, WeakEntryHandle},
+    fd::{EntryStableKey, FdEnabledSubsystem, FdEnabledSubsystemEntry, TypedFd, WeakEntryHandle},
     utils::ReinterpretUnsignedExt,
 };
 use litebox_common_linux::{EpollEvent, EpollOp, errno::Errno};
@@ -110,15 +110,15 @@ impl<Platform: ShimPlatform> DescriptorRef<Platform> {
         })
     }
 
-    /// The address of the shared open file description, stable across `dup`.
-    fn as_ptr(&self) -> usize {
+    /// An opaque, stable identity for the entry, used to key interests.
+    fn stable_key(&self) -> EntryStableKey {
         match self {
-            DescriptorRef::Eventfd(handle) => handle.as_ptr().addr(),
-            DescriptorRef::Epoll(handle) => handle.as_ptr().addr(),
-            DescriptorRef::File(handle) => handle.as_ptr().addr(),
-            DescriptorRef::Socket(handle) => handle.as_ptr().addr(),
-            DescriptorRef::Pipe(handle) => handle.as_ptr().addr(),
-            DescriptorRef::Unix(handle) => handle.as_ptr().addr(),
+            DescriptorRef::Eventfd(handle) => handle.stable_key(),
+            DescriptorRef::Epoll(handle) => handle.stable_key(),
+            DescriptorRef::File(handle) => handle.stable_key(),
+            DescriptorRef::Socket(handle) => handle.stable_key(),
+            DescriptorRef::Pipe(handle) => handle.stable_key(),
+            DescriptorRef::Unix(handle) => handle.stable_key(),
         }
     }
 
@@ -155,7 +155,7 @@ impl<Platform: ShimPlatform> DescriptorRef<Platform> {
             DescriptorRef::Socket(handle) => {
                 let proxy = handle
                     .upgrade()?
-                    .with_shared_metadata::<crate::syscalls::net::SocketProxy<Platform>, _>(
+                    .with_entry_metadata::<crate::syscalls::net::SocketProxy<Platform>, _>(
                         |crate::syscalls::net::SocketProxy(proxy)| proxy.clone(),
                     )?;
                 Some(check(&proxy))
@@ -165,7 +165,7 @@ impl<Platform: ShimPlatform> DescriptorRef<Platform> {
                 // for REPLs (mirrors `EpollDescriptor::poll`).
                 let handle = handle.upgrade()?;
                 let events = match handle
-                    .with_shared_metadata::<litebox::platform::StdioStream, _>(|stream| *stream)
+                    .with_entry_metadata::<litebox::platform::StdioStream, _>(|stream| *stream)
                 {
                     Some(litebox::platform::StdioStream::Stdin) => Events::IN,
                     Some(
@@ -306,7 +306,7 @@ impl<Platform: ShimPlatform> EpollFile<Platform> {
         event: EpollEvent,
     ) -> Result<(), Errno> {
         let desc = DescriptorRef::new(global, file).ok_or(Errno::EBADF)?;
-        let key = EpollEntryKey(fd, desc.as_ptr());
+        let key = EpollEntryKey(fd, desc.stable_key());
         let mut interests = self.interests.lock();
         if let Some(entry) = interests.get(&key)
             && entry.desc.is_alive()
@@ -395,19 +395,20 @@ impl<Platform: ShimPlatform> EpollFile<Platform> {
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord)]
-struct EpollEntryKey(u32, usize);
+struct EpollEntryKey(u32, EntryStableKey);
 impl EpollEntryKey {
-    /// Builds the key `(fd, open-file-description address)`.
+    /// Builds the key `(fd, entry identity)`.
     ///
-    /// The address is stable across `dup`, so an interest registered against one
-    /// descriptor is found again while any duplicate of its open file
-    /// description remains open. Returns `None` if the descriptor is closed.
+    /// The entry identity is stable across `dup`, so an interest registered
+    /// against one descriptor is found again while any duplicate of its open
+    /// file description remains open. Returns `None` if the descriptor is
+    /// closed.
     fn new<Platform: ShimPlatform>(
         global: &GlobalState<Platform>,
         fd: u32,
         desc: &EpollDescriptor<Platform>,
     ) -> Option<Self> {
-        Some(Self(fd, DescriptorRef::new(global, desc)?.as_ptr()))
+        Some(Self(fd, DescriptorRef::new(global, desc)?.stable_key()))
     }
 }
 


### PR DESCRIPTION
## Problem

Linux `epoll(7)` removes a descriptor from an interest list only after *every* descriptor referring to the underlying open file description (OFD) has been closed. The shim instead anchored each interest to the per-descriptor `TypedFd`, so closing the registered descriptor dropped the interest even when a `dup` referring to the same OFD was still open — `EpollEntry::poll` bailed on a dead `Weak<TypedFd>` and readiness was never delivered.

## Fix

Anchor epoll interest to the open file description:

- Add `WeakEntryHandle` to `litebox::fd` — a durable, `dup`-surviving weak reference to a descriptor's shared entry, plus `EntryHandle::downgrade`/`as_ptr`/`with_shared_metadata`.
- Re-point epoll's `DescriptorRef` at a per-subsystem `WeakEntryHandle`, key interests by the OFD's stable address, and re-poll through the shared entry (eventfd/unix/pipe via the entry's `IOPollable`, socket/file via aliased metadata). Observer registration is unchanged; it already targets the shared pollable.
- Expose `with_iopollable` on the pipe entry so a pipe can be polled without a live per-descriptor `PipeFd`.

Covers all six epoll-able fd types on `main` (eventfd, unix, pipe, socket, file, and the pre-existing epoll-on-epoll `unimplemented!()`), via exhaustive matches.

## Test

`tests/epoll_dup.c`: register an eventfd, `dup` it, close the original, and verify the interest still delivers events and survives re-arming. Passes natively, fails without this change under Litebox, and passes with it.