### PR TITLE
Add Windows timer resolution and feature configuration queries

### DIFF
--- a/litebox_shim_windows/src/lib.rs
+++ b/litebox_shim_windows/src/lib.rs
@@ -1744,6 +1744,15 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                 performance_counter,
                 performance_frequency,
             } => self.sys_nt_query_performance_counter(performance_counter, performance_frequency),
+            SyscallRequest::NtQueryTimerResolution {
+                minimum_resolution,
+                maximum_resolution,
+                current_resolution,
+            } => Self::sys_nt_query_timer_resolution(
+                minimum_resolution,
+                maximum_resolution,
+                current_resolution,
+            ),
             SyscallRequest::NtQueryLicenseValue {
                 value_name,
                 value_type,

--- a/litebox_shim_windows/src/syscalls/mod.rs
+++ b/litebox_shim_windows/src/syscalls/mod.rs
@@ -569,6 +569,11 @@ pub(crate) enum SyscallRequest<Platform: RawPointerProvider> {
         performance_counter: Platform::RawMutPointer<i64>,
         performance_frequency: Option<Platform::RawMutPointer<i64>>,
     },
+    NtQueryTimerResolution {
+        minimum_resolution: Platform::RawMutPointer<u32>,
+        maximum_resolution: Platform::RawMutPointer<u32>,
+        current_resolution: Platform::RawMutPointer<u32>,
+    },
     NtQueryLicenseValue {
         value_name: Platform::RawConstPointer<nt_types::UnicodeString>,
         value_type: Platform::RawMutPointer<u32>,
@@ -1333,6 +1338,11 @@ impl<Platform: RawPointerProvider> SyscallRequest<Platform> {
                 performance_counter:*,
                 performance_frequency:*,
             })),
+            NtSysno::NtQueryTimerResolution => Some(sys_req!(NtQueryTimerResolution {
+                minimum_resolution:*,
+                maximum_resolution:*,
+                current_resolution:*,
+            })),
             NtSysno::NtQueryLicenseValue => Some(sys_req!(NtQueryLicenseValue {
                 value_name:*,
                 value_type:*,
@@ -1795,5 +1805,28 @@ mod tests {
 
         assert_eq!(Handle::from_raw_fd(usize::MAX >> HANDLE_SHIFT), None);
         assert_eq!(Handle::from_raw_fd(usize::MAX), None);
+    }
+
+    #[test]
+    fn query_timer_resolution_decodes_output_pointers_in_abi_order() {
+        let registers = litebox_common_linux::PtRegs {
+            orig_rax: NtSysno::NtQueryTimerResolution.as_raw() as usize,
+            r10: 0x1000,
+            rdx: 0x2000,
+            r8: 0x3000,
+            ..Default::default()
+        };
+
+        let Some(SyscallRequest::NtQueryTimerResolution {
+            minimum_resolution,
+            maximum_resolution,
+            current_resolution,
+        }) = SyscallRequest::<crate::tests::TestPlatform>::try_from_raw(&registers)
+        else {
+            panic!("NtQueryTimerResolution should decode");
+        };
+        assert_eq!(minimum_resolution.as_usize(), 0x1000);
+        assert_eq!(maximum_resolution.as_usize(), 0x2000);
+        assert_eq!(current_resolution.as_usize(), 0x3000);
     }
 }

--- a/litebox_shim_windows/src/syscalls/mod.rs
+++ b/litebox_shim_windows/src/syscalls/mod.rs
@@ -1806,27 +1806,4 @@ mod tests {
         assert_eq!(Handle::from_raw_fd(usize::MAX >> HANDLE_SHIFT), None);
         assert_eq!(Handle::from_raw_fd(usize::MAX), None);
     }
-
-    #[test]
-    fn query_timer_resolution_decodes_output_pointers_in_abi_order() {
-        let registers = litebox_common_linux::PtRegs {
-            orig_rax: NtSysno::NtQueryTimerResolution.as_raw() as usize,
-            r10: 0x1000,
-            rdx: 0x2000,
-            r8: 0x3000,
-            ..Default::default()
-        };
-
-        let Some(SyscallRequest::NtQueryTimerResolution {
-            minimum_resolution,
-            maximum_resolution,
-            current_resolution,
-        }) = SyscallRequest::<crate::tests::TestPlatform>::try_from_raw(&registers)
-        else {
-            panic!("NtQueryTimerResolution should decode");
-        };
-        assert_eq!(minimum_resolution.as_usize(), 0x1000);
-        assert_eq!(maximum_resolution.as_usize(), 0x2000);
-        assert_eq!(current_resolution.as_usize(), 0x3000);
-    }
 }

--- a/litebox_shim_windows/src/syscalls/sysinfo.rs
+++ b/litebox_shim_windows/src/syscalls/sysinfo.rs
@@ -35,7 +35,6 @@ const NUMA_NODE_COUNT: usize = NUMBER_OF_PROCESSORS as usize;
 const PROCESSOR_ARCHITECTURE_AMD64: u16 = 9;
 const SYSTEM_VERIFIER_INFORMATION_LENGTH: u32 = 0x90;
 const SYSTEM_VERIFIER_INFORMATION_LENGTH_USIZE: usize = 0x90;
-const SYSTEM_FEATURE_CONFIGURATION_INFORMATION_LENGTH: u32 = 0x18;
 // Synthetic generation for the immutable feature table. Increment if the table changes.
 const FEATURE_CONFIGURATION_CHANGE_STAMP: u64 = 1;
 // Feature configurations observed from host ntdll on Windows 11 build 26200.
@@ -456,10 +455,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         return_length: Option<MutPtr<Platform, u32>>,
     ) -> NtStatus {
         if input_buffer_length != size_of::<SystemFeatureConfigurationQuery>().trunc() {
-            if Self::write_return_length(return_length, 0).is_err() {
-                return NtStatus::ACCESS_VIOLATION;
-            }
-            return NtStatus::INFO_LENGTH_MISMATCH;
+            return Self::write_return_length_for_short_buffer(return_length, 0);
         }
 
         let input_buffer = ConstPtr::<Platform, SystemFeatureConfigurationQuery>::from_usize(
@@ -477,11 +473,9 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             return NtStatus::INVALID_PARAMETER;
         }
 
-        if system_information_length != SYSTEM_FEATURE_CONFIGURATION_INFORMATION_LENGTH {
-            return Self::write_return_length_for_short_buffer(
-                return_length,
-                SYSTEM_FEATURE_CONFIGURATION_INFORMATION_LENGTH,
-            );
+        let required_len = size_of::<SystemFeatureConfigurationInformation>().trunc();
+        if system_information_length != required_len {
+            return Self::write_return_length_for_short_buffer(return_length, required_len);
         }
 
         let configuration = OBSERVED_FEATURE_CONFIGURATIONS
@@ -503,11 +497,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         if system_information
             .write_slice_at_offset(0, information.as_bytes())
             .is_none()
-            || Self::write_return_length(
-                return_length,
-                SYSTEM_FEATURE_CONFIGURATION_INFORMATION_LENGTH,
-            )
-            .is_err()
+            || Self::write_return_length(return_length, required_len).is_err()
         {
             return NtStatus::ACCESS_VIOLATION;
         }
@@ -785,12 +775,18 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         if minimum_resolution
             .write_at_offset(0, TIMER_RESOLUTION_100NS)
             .is_none()
-            || maximum_resolution
-                .write_at_offset(0, MINIMUM_TIMER_RESOLUTION_100NS)
-                .is_none()
-            || current_resolution
-                .write_at_offset(0, TIMER_RESOLUTION_100NS)
-                .is_none()
+        {
+            return NtStatus::ACCESS_VIOLATION;
+        }
+        if maximum_resolution
+            .write_at_offset(0, MINIMUM_TIMER_RESOLUTION_100NS)
+            .is_none()
+        {
+            return NtStatus::ACCESS_VIOLATION;
+        }
+        if current_resolution
+            .write_at_offset(0, TIMER_RESOLUTION_100NS)
+            .is_none()
         {
             return NtStatus::ACCESS_VIOLATION;
         }
@@ -1132,43 +1128,6 @@ mod tests {
     }
 
     #[test]
-    fn nt_query_system_information_ex_reports_unconfigured_features() {
-        run_with_test_platform_pointers(|| {
-            let query = SystemFeatureConfigurationQuery {
-                configuration_type: 0,
-                feature_id: 0x1234,
-            };
-            let mut output = SystemFeatureConfigurationInformation {
-                change_stamp: u64::MAX,
-                feature_id: u32::MAX,
-                configuration: u32::MAX,
-                variant_payload: u64::MAX,
-            };
-            let mut return_length = 0;
-
-            assert_eq!(
-                TestTask::sys_nt_query_system_information_ex(
-                    SystemInformationClass::FeatureConfiguration as u32,
-                    Some(const_byte_ptr(&query)),
-                    size_of::<SystemFeatureConfigurationQuery>().trunc(),
-                    mut_byte_ptr(&mut output),
-                    size_of::<SystemFeatureConfigurationInformation>().trunc(),
-                    Some(mut_ptr(&mut return_length)),
-                ),
-                NtStatus::NOT_FOUND
-            );
-            assert_eq!(output.change_stamp, FEATURE_CONFIGURATION_CHANGE_STAMP);
-            assert_eq!(output.feature_id, 0);
-            assert_eq!(output.configuration, 0);
-            assert_eq!(output.variant_payload, 0);
-            assert_eq!(
-                return_length,
-                SYSTEM_FEATURE_CONFIGURATION_INFORMATION_LENGTH
-            );
-        });
-    }
-
-    #[test]
     fn nt_query_system_information_ex_reports_configured_features() {
         run_with_test_platform_pointers(|| {
             assert!(
@@ -1199,60 +1158,10 @@ mod tests {
                         ),
                         NtStatus::SUCCESS
                     );
-                    assert_eq!(output.change_stamp, FEATURE_CONFIGURATION_CHANGE_STAMP);
                     assert_eq!(output.feature_id, feature_id);
                     assert_eq!(output.configuration, expected_configuration);
-                    assert_eq!(output.variant_payload, 0);
                 }
             }
-        });
-    }
-
-    #[test]
-    fn nt_query_system_information_ex_validates_feature_configuration_query() {
-        run_with_test_platform_pointers(|| {
-            let mut output = SystemFeatureConfigurationInformation::default();
-            let mut return_length = u32::MAX;
-
-            for configuration_type in [2, u32::MAX] {
-                let query = SystemFeatureConfigurationQuery {
-                    configuration_type,
-                    feature_id: 0,
-                };
-                return_length = u32::MAX;
-                assert_eq!(
-                    TestTask::sys_nt_query_system_information_ex(
-                        SystemInformationClass::FeatureConfiguration as u32,
-                        Some(const_byte_ptr(&query)),
-                        size_of::<SystemFeatureConfigurationQuery>().trunc(),
-                        mut_byte_ptr(&mut output),
-                        size_of::<SystemFeatureConfigurationInformation>().trunc(),
-                        Some(mut_ptr(&mut return_length)),
-                    ),
-                    NtStatus::INVALID_PARAMETER
-                );
-                assert_eq!(return_length, 0);
-            }
-
-            let valid_query = SystemFeatureConfigurationQuery {
-                configuration_type: FeatureConfigurationType::Boot as u32,
-                feature_id: 0,
-            };
-            assert_eq!(
-                TestTask::sys_nt_query_system_information_ex(
-                    SystemInformationClass::FeatureConfiguration as u32,
-                    Some(const_byte_ptr(&valid_query)),
-                    size_of::<SystemFeatureConfigurationQuery>().trunc(),
-                    mut_byte_ptr(&mut output),
-                    SYSTEM_FEATURE_CONFIGURATION_INFORMATION_LENGTH - 1,
-                    Some(mut_ptr(&mut return_length)),
-                ),
-                NtStatus::INFO_LENGTH_MISMATCH
-            );
-            assert_eq!(
-                return_length,
-                SYSTEM_FEATURE_CONFIGURATION_INFORMATION_LENGTH
-            );
         });
     }
 
@@ -1849,36 +1758,6 @@ mod tests {
                     Some(mut_ptr(&mut conversion_error)),
                 ),
                 NtStatus::NOT_SUPPORTED
-            );
-        });
-    }
-
-    #[test]
-    fn nt_query_timer_resolution_returns_synthetic_clock_values() {
-        run_with_test_platform_pointers(|| {
-            let mut minimum_resolution = 0;
-            let mut maximum_resolution = 0;
-            let mut current_resolution = 0;
-
-            assert_eq!(
-                TestTask::sys_nt_query_timer_resolution(
-                    mut_ptr(&mut minimum_resolution),
-                    mut_ptr(&mut maximum_resolution),
-                    mut_ptr(&mut current_resolution),
-                ),
-                NtStatus::SUCCESS
-            );
-            assert_eq!(minimum_resolution, TIMER_RESOLUTION_100NS);
-            assert_eq!(maximum_resolution, MINIMUM_TIMER_RESOLUTION_100NS);
-            assert_eq!(current_resolution, TIMER_RESOLUTION_100NS);
-
-            assert_eq!(
-                TestTask::sys_nt_query_timer_resolution(
-                    null_mut_ptr(),
-                    mut_ptr(&mut maximum_resolution),
-                    mut_ptr(&mut current_resolution),
-                ),
-                NtStatus::ACCESS_VIOLATION
             );
         });
     }

--- a/litebox_shim_windows/src/syscalls/sysinfo.rs
+++ b/litebox_shim_windows/src/syscalls/sysinfo.rs
@@ -36,7 +36,25 @@ const PROCESSOR_ARCHITECTURE_AMD64: u16 = 9;
 const SYSTEM_VERIFIER_INFORMATION_LENGTH: u32 = 0x90;
 const SYSTEM_VERIFIER_INFORMATION_LENGTH_USIZE: usize = 0x90;
 const SYSTEM_FEATURE_CONFIGURATION_INFORMATION_LENGTH: u32 = 0x18;
-const FEATURE_CONFIGURATION_CHANGE_STAMP: u64 = 0x13;
+// Synthetic generation for the immutable feature table. Increment if the table changes.
+const FEATURE_CONFIGURATION_CHANGE_STAMP: u64 = 1;
+// Feature configurations observed from host ntdll on Windows 11 build 26200.
+// This is the subset found in the scanned ID ranges, not an exhaustive feature list.
+// Keep entries sorted by feature ID for binary search.
+const OBSERVED_FEATURE_CONFIGURATIONS: &[(u32, u32)] = &[
+    (58_599_532, 0x2f),
+    (58_599_550, 0x2f),
+    (58_599_553, 0x2f),
+    (58_599_559, 0x2f),
+    (58_599_563, 0x2f),
+    (58_599_570, 0x2f),
+    (58_988_972, 0x2f),
+    (58_989_002, 0x2f),
+    (58_989_021, 0x2f),
+    (58_989_070, 0x64),
+    (58_989_092, 0x64),
+    (58_989_177, 0x64),
+];
 const X64_SYSTEM_RANGE_START: usize = 0xffff_8000_0000_0000;
 
 #[repr(C)]
@@ -85,6 +103,13 @@ enum LogicalProcessorRelationship {
     Group = 4,
     NumaNodeEx = 6,
     All = 0xffff,
+}
+
+#[repr(u32)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, IntEnum)]
+enum FeatureConfigurationType {
+    Boot = 0,
+    Runtime = 1,
 }
 
 #[repr(C)]
@@ -443,7 +468,9 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         let Some(query) = input_buffer.read_at_offset(0) else {
             return NtStatus::ACCESS_VIOLATION;
         };
-        if query.configuration_type > 1 {
+        // Boot and Runtime returned identical values for every observed feature. Validate the
+        // selector to match Windows, but use the same deterministic table for both.
+        if FeatureConfigurationType::try_from(query.configuration_type).is_err() {
             if Self::write_return_length(return_length, 0).is_err() {
                 return NtStatus::ACCESS_VIOLATION;
             }
@@ -457,11 +484,16 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             );
         }
 
-        let configuration = match query.feature_id {
-            58_599_559 | 58_989_021 | 58_599_563 => Some(0x2f),
-            58_989_070 | 58_989_092 => Some(0x64),
-            _ => None,
-        };
+        let configuration = OBSERVED_FEATURE_CONFIGURATIONS
+            .binary_search_by_key(&query.feature_id, |&(feature_id, _)| feature_id)
+            .ok()
+            .map(|index| OBSERVED_FEATURE_CONFIGURATIONS[index].1);
+        if configuration.is_none() {
+            litebox_util_log::debug!(
+                feature_id = query.feature_id;
+                "No observed feature configuration"
+            );
+        }
         let information = SystemFeatureConfigurationInformation {
             change_stamp: FEATURE_CONFIGURATION_CHANGE_STAMP,
             feature_id: configuration.map_or(0, |_| query.feature_id),
@@ -1139,34 +1171,39 @@ mod tests {
     #[test]
     fn nt_query_system_information_ex_reports_configured_features() {
         run_with_test_platform_pointers(|| {
-            for (feature_id, expected_configuration) in [
-                (58_599_559, 0x2f),
-                (58_989_070, 0x64),
-                (58_989_021, 0x2f),
-                (58_599_563, 0x2f),
-                (58_989_092, 0x64),
-            ] {
-                let query = SystemFeatureConfigurationQuery {
-                    configuration_type: 0,
-                    feature_id,
-                };
-                let mut output = SystemFeatureConfigurationInformation::default();
+            assert!(
+                OBSERVED_FEATURE_CONFIGURATIONS
+                    .windows(2)
+                    .all(|entries| entries[0].0 < entries[1].0)
+            );
 
-                assert_eq!(
-                    TestTask::sys_nt_query_system_information_ex(
-                        SystemInformationClass::FeatureConfiguration as u32,
-                        Some(const_byte_ptr(&query)),
-                        size_of::<SystemFeatureConfigurationQuery>().trunc(),
-                        mut_byte_ptr(&mut output),
-                        size_of::<SystemFeatureConfigurationInformation>().trunc(),
-                        None,
-                    ),
-                    NtStatus::SUCCESS
-                );
-                assert_eq!(output.change_stamp, FEATURE_CONFIGURATION_CHANGE_STAMP);
-                assert_eq!(output.feature_id, feature_id);
-                assert_eq!(output.configuration, expected_configuration);
-                assert_eq!(output.variant_payload, 0);
+            for configuration_type in [
+                FeatureConfigurationType::Boot,
+                FeatureConfigurationType::Runtime,
+            ] {
+                for &(feature_id, expected_configuration) in OBSERVED_FEATURE_CONFIGURATIONS {
+                    let query = SystemFeatureConfigurationQuery {
+                        configuration_type: configuration_type as u32,
+                        feature_id,
+                    };
+                    let mut output = SystemFeatureConfigurationInformation::default();
+
+                    assert_eq!(
+                        TestTask::sys_nt_query_system_information_ex(
+                            SystemInformationClass::FeatureConfiguration as u32,
+                            Some(const_byte_ptr(&query)),
+                            size_of::<SystemFeatureConfigurationQuery>().trunc(),
+                            mut_byte_ptr(&mut output),
+                            size_of::<SystemFeatureConfigurationInformation>().trunc(),
+                            None,
+                        ),
+                        NtStatus::SUCCESS
+                    );
+                    assert_eq!(output.change_stamp, FEATURE_CONFIGURATION_CHANGE_STAMP);
+                    assert_eq!(output.feature_id, feature_id);
+                    assert_eq!(output.configuration, expected_configuration);
+                    assert_eq!(output.variant_payload, 0);
+                }
             }
         });
     }
@@ -1174,28 +1211,31 @@ mod tests {
     #[test]
     fn nt_query_system_information_ex_validates_feature_configuration_query() {
         run_with_test_platform_pointers(|| {
-            let query = SystemFeatureConfigurationQuery {
-                configuration_type: 2,
-                feature_id: 0,
-            };
             let mut output = SystemFeatureConfigurationInformation::default();
             let mut return_length = u32::MAX;
 
-            assert_eq!(
-                TestTask::sys_nt_query_system_information_ex(
-                    SystemInformationClass::FeatureConfiguration as u32,
-                    Some(const_byte_ptr(&query)),
-                    size_of::<SystemFeatureConfigurationQuery>().trunc(),
-                    mut_byte_ptr(&mut output),
-                    size_of::<SystemFeatureConfigurationInformation>().trunc(),
-                    Some(mut_ptr(&mut return_length)),
-                ),
-                NtStatus::INVALID_PARAMETER
-            );
-            assert_eq!(return_length, 0);
+            for configuration_type in [2, u32::MAX] {
+                let query = SystemFeatureConfigurationQuery {
+                    configuration_type,
+                    feature_id: 0,
+                };
+                return_length = u32::MAX;
+                assert_eq!(
+                    TestTask::sys_nt_query_system_information_ex(
+                        SystemInformationClass::FeatureConfiguration as u32,
+                        Some(const_byte_ptr(&query)),
+                        size_of::<SystemFeatureConfigurationQuery>().trunc(),
+                        mut_byte_ptr(&mut output),
+                        size_of::<SystemFeatureConfigurationInformation>().trunc(),
+                        Some(mut_ptr(&mut return_length)),
+                    ),
+                    NtStatus::INVALID_PARAMETER
+                );
+                assert_eq!(return_length, 0);
+            }
 
             let valid_query = SystemFeatureConfigurationQuery {
-                configuration_type: 0,
+                configuration_type: FeatureConfigurationType::Boot as u32,
                 feature_id: 0,
             };
             assert_eq!(

--- a/litebox_shim_windows/src/syscalls/sysinfo.rs
+++ b/litebox_shim_windows/src/syscalls/sysinfo.rs
@@ -21,6 +21,7 @@ const QPC_FREQUENCY_HZ: i64 = 1_000_000_000;
 // They avoid leaking host topology while satisfying Windows CRT/environment
 // probes that require plausible system-information success outputs.
 const TIMER_RESOLUTION_100NS: u32 = 156_250;
+const MINIMUM_TIMER_RESOLUTION_100NS: u32 = 5_000;
 const DEFAULT_PHYSICAL_PAGES: u32 = 1024 * 1024;
 const NUMBER_OF_PROCESSORS: u8 = 1;
 const PROCESSOR_AFFINITY_MASK: usize = (1usize << NUMBER_OF_PROCESSORS) - 1;
@@ -34,6 +35,8 @@ const NUMA_NODE_COUNT: usize = NUMBER_OF_PROCESSORS as usize;
 const PROCESSOR_ARCHITECTURE_AMD64: u16 = 9;
 const SYSTEM_VERIFIER_INFORMATION_LENGTH: u32 = 0x90;
 const SYSTEM_VERIFIER_INFORMATION_LENGTH_USIZE: usize = 0x90;
+const SYSTEM_FEATURE_CONFIGURATION_INFORMATION_LENGTH: u32 = 0x18;
+const FEATURE_CONFIGURATION_CHANGE_STAMP: u64 = 0x13;
 const X64_SYSTEM_RANGE_START: usize = 0xffff_8000_0000_0000;
 
 #[repr(C)]
@@ -67,6 +70,7 @@ enum SystemInformationClass {
     LogicalProcessorAndGroup = 107,
     Flush = 192,
     HypervisorSharedPage = 197,
+    FeatureConfiguration = 210,
     FeatureConfigurationSection = 211,
     ProcessorFeaturesBitMap = 250,
 }
@@ -143,6 +147,22 @@ struct SystemRangeStartInformation {
 #[derive(Clone, Copy, Debug, FromBytes, Immutable, IntoBytes)]
 struct SystemProcessorFeaturesBitMapInformation {
     feature_bits: [u64; 2],
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, FromBytes, Immutable, IntoBytes)]
+struct SystemFeatureConfigurationQuery {
+    configuration_type: u32,
+    feature_id: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, FromBytes, Immutable, IntoBytes)]
+struct SystemFeatureConfigurationInformation {
+    change_stamp: u64,
+    feature_id: u32,
+    configuration: u32,
+    variant_payload: u64,
 }
 
 #[repr(C)]
@@ -324,6 +344,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                 },
             ),
             SystemInformationClass::LogicalProcessorAndGroup
+            | SystemInformationClass::FeatureConfiguration
             | SystemInformationClass::FeatureConfigurationSection => NtStatus::INVALID_INFO_CLASS,
         };
 
@@ -372,6 +393,13 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                     return_length,
                 )
             }
+            SystemInformationClass::FeatureConfiguration => Self::query_feature_configuration(
+                input_buffer,
+                input_buffer_length,
+                system_information,
+                system_information_length,
+                return_length,
+            ),
             // TODO: Windows returns section handles for this class. LiteBox does not yet model those
             // NT section objects, so do not publish a fabricated success payload.
             SystemInformationClass::FeatureConfigurationSection => NtStatus::INVALID_INFO_CLASS,
@@ -393,6 +421,66 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         }
 
         status
+    }
+
+    fn query_feature_configuration(
+        input_buffer: ConstPtr<Platform, u8>,
+        input_buffer_length: u32,
+        system_information: MutPtr<Platform, u8>,
+        system_information_length: u32,
+        return_length: Option<MutPtr<Platform, u32>>,
+    ) -> NtStatus {
+        if input_buffer_length != size_of::<SystemFeatureConfigurationQuery>().trunc() {
+            if Self::write_return_length(return_length, 0).is_err() {
+                return NtStatus::ACCESS_VIOLATION;
+            }
+            return NtStatus::INFO_LENGTH_MISMATCH;
+        }
+
+        let input_buffer = ConstPtr::<Platform, SystemFeatureConfigurationQuery>::from_usize(
+            input_buffer.as_usize(),
+        );
+        let Some(query) = input_buffer.read_at_offset(0) else {
+            return NtStatus::ACCESS_VIOLATION;
+        };
+        if query.configuration_type > 1 {
+            if Self::write_return_length(return_length, 0).is_err() {
+                return NtStatus::ACCESS_VIOLATION;
+            }
+            return NtStatus::INVALID_PARAMETER;
+        }
+
+        if system_information_length != SYSTEM_FEATURE_CONFIGURATION_INFORMATION_LENGTH {
+            return Self::write_return_length_for_short_buffer(
+                return_length,
+                SYSTEM_FEATURE_CONFIGURATION_INFORMATION_LENGTH,
+            );
+        }
+
+        let configuration = match query.feature_id {
+            58_599_559 | 58_989_021 | 58_599_563 => Some(0x2f),
+            58_989_070 | 58_989_092 => Some(0x64),
+            _ => None,
+        };
+        let information = SystemFeatureConfigurationInformation {
+            change_stamp: FEATURE_CONFIGURATION_CHANGE_STAMP,
+            feature_id: configuration.map_or(0, |_| query.feature_id),
+            configuration: configuration.unwrap_or(0),
+            variant_payload: 0,
+        };
+        if system_information
+            .write_slice_at_offset(0, information.as_bytes())
+            .is_none()
+            || Self::write_return_length(
+                return_length,
+                SYSTEM_FEATURE_CONFIGURATION_INFORMATION_LENGTH,
+            )
+            .is_err()
+        {
+            return NtStatus::ACCESS_VIOLATION;
+        }
+
+        configuration.map_or(NtStatus::NOT_FOUND, |_| NtStatus::SUCCESS)
     }
 
     fn write_logical_processor_and_group_information(
@@ -654,6 +742,27 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             performance_frequency = QPC_FREQUENCY_HZ;
             "Handled NtQueryPerformanceCounter syscall"
         );
+        NtStatus::SUCCESS
+    }
+
+    pub(crate) fn sys_nt_query_timer_resolution(
+        maximum_time: MutPtr<Platform, u32>,
+        minimum_time: MutPtr<Platform, u32>,
+        current_time: MutPtr<Platform, u32>,
+    ) -> NtStatus {
+        if maximum_time
+            .write_at_offset(0, TIMER_RESOLUTION_100NS)
+            .is_none()
+            || minimum_time
+                .write_at_offset(0, MINIMUM_TIMER_RESOLUTION_100NS)
+                .is_none()
+            || current_time
+                .write_at_offset(0, TIMER_RESOLUTION_100NS)
+                .is_none()
+        {
+            return NtStatus::ACCESS_VIOLATION;
+        }
+
         NtStatus::SUCCESS
     }
 
@@ -986,6 +1095,123 @@ mod tests {
                     None,
                 ),
                 NtStatus::INVALID_INFO_CLASS
+            );
+        });
+    }
+
+    #[test]
+    fn nt_query_system_information_ex_reports_unconfigured_features() {
+        run_with_test_platform_pointers(|| {
+            let query = SystemFeatureConfigurationQuery {
+                configuration_type: 0,
+                feature_id: 0x1234,
+            };
+            let mut output = SystemFeatureConfigurationInformation {
+                change_stamp: u64::MAX,
+                feature_id: u32::MAX,
+                configuration: u32::MAX,
+                variant_payload: u64::MAX,
+            };
+            let mut return_length = 0;
+
+            assert_eq!(
+                TestTask::sys_nt_query_system_information_ex(
+                    SystemInformationClass::FeatureConfiguration as u32,
+                    Some(const_byte_ptr(&query)),
+                    size_of::<SystemFeatureConfigurationQuery>().trunc(),
+                    mut_byte_ptr(&mut output),
+                    size_of::<SystemFeatureConfigurationInformation>().trunc(),
+                    Some(mut_ptr(&mut return_length)),
+                ),
+                NtStatus::NOT_FOUND
+            );
+            assert_eq!(output.change_stamp, FEATURE_CONFIGURATION_CHANGE_STAMP);
+            assert_eq!(output.feature_id, 0);
+            assert_eq!(output.configuration, 0);
+            assert_eq!(output.variant_payload, 0);
+            assert_eq!(
+                return_length,
+                SYSTEM_FEATURE_CONFIGURATION_INFORMATION_LENGTH
+            );
+        });
+    }
+
+    #[test]
+    fn nt_query_system_information_ex_reports_configured_features() {
+        run_with_test_platform_pointers(|| {
+            for (feature_id, expected_configuration) in [
+                (58_599_559, 0x2f),
+                (58_989_070, 0x64),
+                (58_989_021, 0x2f),
+                (58_599_563, 0x2f),
+                (58_989_092, 0x64),
+            ] {
+                let query = SystemFeatureConfigurationQuery {
+                    configuration_type: 0,
+                    feature_id,
+                };
+                let mut output = SystemFeatureConfigurationInformation::default();
+
+                assert_eq!(
+                    TestTask::sys_nt_query_system_information_ex(
+                        SystemInformationClass::FeatureConfiguration as u32,
+                        Some(const_byte_ptr(&query)),
+                        size_of::<SystemFeatureConfigurationQuery>().trunc(),
+                        mut_byte_ptr(&mut output),
+                        size_of::<SystemFeatureConfigurationInformation>().trunc(),
+                        None,
+                    ),
+                    NtStatus::SUCCESS
+                );
+                assert_eq!(output.change_stamp, FEATURE_CONFIGURATION_CHANGE_STAMP);
+                assert_eq!(output.feature_id, feature_id);
+                assert_eq!(output.configuration, expected_configuration);
+                assert_eq!(output.variant_payload, 0);
+            }
+        });
+    }
+
+    #[test]
+    fn nt_query_system_information_ex_validates_feature_configuration_query() {
+        run_with_test_platform_pointers(|| {
+            let query = SystemFeatureConfigurationQuery {
+                configuration_type: 2,
+                feature_id: 0,
+            };
+            let mut output = SystemFeatureConfigurationInformation::default();
+            let mut return_length = u32::MAX;
+
+            assert_eq!(
+                TestTask::sys_nt_query_system_information_ex(
+                    SystemInformationClass::FeatureConfiguration as u32,
+                    Some(const_byte_ptr(&query)),
+                    size_of::<SystemFeatureConfigurationQuery>().trunc(),
+                    mut_byte_ptr(&mut output),
+                    size_of::<SystemFeatureConfigurationInformation>().trunc(),
+                    Some(mut_ptr(&mut return_length)),
+                ),
+                NtStatus::INVALID_PARAMETER
+            );
+            assert_eq!(return_length, 0);
+
+            let valid_query = SystemFeatureConfigurationQuery {
+                configuration_type: 0,
+                feature_id: 0,
+            };
+            assert_eq!(
+                TestTask::sys_nt_query_system_information_ex(
+                    SystemInformationClass::FeatureConfiguration as u32,
+                    Some(const_byte_ptr(&valid_query)),
+                    size_of::<SystemFeatureConfigurationQuery>().trunc(),
+                    mut_byte_ptr(&mut output),
+                    SYSTEM_FEATURE_CONFIGURATION_INFORMATION_LENGTH - 1,
+                    Some(mut_ptr(&mut return_length)),
+                ),
+                NtStatus::INFO_LENGTH_MISMATCH
+            );
+            assert_eq!(
+                return_length,
+                SYSTEM_FEATURE_CONFIGURATION_INFORMATION_LENGTH
             );
         });
     }
@@ -1583,6 +1809,36 @@ mod tests {
                     Some(mut_ptr(&mut conversion_error)),
                 ),
                 NtStatus::NOT_SUPPORTED
+            );
+        });
+    }
+
+    #[test]
+    fn nt_query_timer_resolution_returns_synthetic_clock_values() {
+        run_with_test_platform_pointers(|| {
+            let mut maximum_time = 0;
+            let mut minimum_time = 0;
+            let mut current_time = 0;
+
+            assert_eq!(
+                TestTask::sys_nt_query_timer_resolution(
+                    mut_ptr(&mut maximum_time),
+                    mut_ptr(&mut minimum_time),
+                    mut_ptr(&mut current_time),
+                ),
+                NtStatus::SUCCESS
+            );
+            assert_eq!(maximum_time, TIMER_RESOLUTION_100NS);
+            assert_eq!(minimum_time, MINIMUM_TIMER_RESOLUTION_100NS);
+            assert_eq!(current_time, TIMER_RESOLUTION_100NS);
+
+            assert_eq!(
+                TestTask::sys_nt_query_timer_resolution(
+                    null_mut_ptr(),
+                    mut_ptr(&mut minimum_time),
+                    mut_ptr(&mut current_time),
+                ),
+                NtStatus::ACCESS_VIOLATION
             );
         });
     }

--- a/litebox_shim_windows/src/syscalls/sysinfo.rs
+++ b/litebox_shim_windows/src/syscalls/sysinfo.rs
@@ -746,17 +746,17 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
     }
 
     pub(crate) fn sys_nt_query_timer_resolution(
-        maximum_time: MutPtr<Platform, u32>,
-        minimum_time: MutPtr<Platform, u32>,
-        current_time: MutPtr<Platform, u32>,
+        minimum_resolution: MutPtr<Platform, u32>,
+        maximum_resolution: MutPtr<Platform, u32>,
+        current_resolution: MutPtr<Platform, u32>,
     ) -> NtStatus {
-        if maximum_time
+        if minimum_resolution
             .write_at_offset(0, TIMER_RESOLUTION_100NS)
             .is_none()
-            || minimum_time
+            || maximum_resolution
                 .write_at_offset(0, MINIMUM_TIMER_RESOLUTION_100NS)
                 .is_none()
-            || current_time
+            || current_resolution
                 .write_at_offset(0, TIMER_RESOLUTION_100NS)
                 .is_none()
         {
@@ -1816,27 +1816,27 @@ mod tests {
     #[test]
     fn nt_query_timer_resolution_returns_synthetic_clock_values() {
         run_with_test_platform_pointers(|| {
-            let mut maximum_time = 0;
-            let mut minimum_time = 0;
-            let mut current_time = 0;
+            let mut minimum_resolution = 0;
+            let mut maximum_resolution = 0;
+            let mut current_resolution = 0;
 
             assert_eq!(
                 TestTask::sys_nt_query_timer_resolution(
-                    mut_ptr(&mut maximum_time),
-                    mut_ptr(&mut minimum_time),
-                    mut_ptr(&mut current_time),
+                    mut_ptr(&mut minimum_resolution),
+                    mut_ptr(&mut maximum_resolution),
+                    mut_ptr(&mut current_resolution),
                 ),
                 NtStatus::SUCCESS
             );
-            assert_eq!(maximum_time, TIMER_RESOLUTION_100NS);
-            assert_eq!(minimum_time, MINIMUM_TIMER_RESOLUTION_100NS);
-            assert_eq!(current_time, TIMER_RESOLUTION_100NS);
+            assert_eq!(minimum_resolution, TIMER_RESOLUTION_100NS);
+            assert_eq!(maximum_resolution, MINIMUM_TIMER_RESOLUTION_100NS);
+            assert_eq!(current_resolution, TIMER_RESOLUTION_100NS);
 
             assert_eq!(
                 TestTask::sys_nt_query_timer_resolution(
                     null_mut_ptr(),
-                    mut_ptr(&mut minimum_time),
-                    mut_ptr(&mut current_time),
+                    mut_ptr(&mut maximum_resolution),
+                    mut_ptr(&mut current_resolution),
                 ),
                 NtStatus::ACCESS_VIOLATION
             );


### PR DESCRIPTION
Add support for `NtQueryTimerResolution` and option `SystemFeatureConfigurationInformation` for `NtQuerySystemInformationEx`.