### PR TITLE
Retain consecutive TCP asynchronous errors

### DIFF
--- a/litebox/src/net/broker_socket.rs
+++ b/litebox/src/net/broker_socket.rs
@@ -58,24 +58,20 @@ impl BrokerTcpSocketState {
         }
     }
 
+    fn matching_synchronous_error_index(
+        errors: &[Option<SocketAsyncError>],
+        synchronous_error: SocketAsyncError,
+    ) -> Option<usize> {
+        errors
+            .iter()
+            .rposition(|error| *error == Some(synchronous_error))
+    }
+
     fn take_async_error(&mut self) -> u32 {
         let error = self.async_error;
         self.async_error = self.next_async_error;
         self.next_async_error = 0;
         error
-    }
-
-    fn remove_async_error(&mut self, error: SocketAsyncError) -> bool {
-        let error = error as u32;
-        if self.async_error == error {
-            self.take_async_error();
-            true
-        } else if self.next_async_error == error {
-            self.next_async_error = 0;
-            true
-        } else {
-            false
-        }
     }
 
     fn update_connection(&mut self, connection: SocketConnectionStatus) -> SocketConnectionStatus {
@@ -225,6 +221,7 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
     }
 
     pub(super) fn start_connect(&self, address: SocketAddrV4) -> Result<(), ConnectError> {
+        let configuration = self.configuration_lock.lock();
         let previous = self.state.lock().connection;
         let outcome = self
             .broker
@@ -236,12 +233,38 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
             SocketOutcome::Completed(status) => status,
             SocketOutcome::Failed(error) => {
                 let error = error.into();
-                self.consume_synchronous_error(error);
+                let failed = self.consume_synchronous_error_locked(error, None);
+                drop(configuration);
+                self.notify_synchronous_error_consumed(failed);
                 return Err(ConnectError::OperationFailed(error));
             }
         };
         let remote_address = (previous == SocketConnectionStatus::Unconnected).then_some(address);
-        self.handle_connect_status(status, remote_address)
+        let status = {
+            let mut state = self.state.lock();
+            let status = state.update_connection(status);
+            if state.remote_address.is_none() {
+                state.remote_address = remote_address;
+            }
+            status
+        };
+        let result = match status {
+            SocketConnectionStatus::Connected => Ok(()),
+            SocketConnectionStatus::Connecting => Err(ConnectError::InProgress),
+            SocketConnectionStatus::Failed(error) => {
+                let error = error.into();
+                let failed = self.consume_synchronous_error_locked(error, None);
+                drop(configuration);
+                self.notify_synchronous_error_consumed(failed);
+                return Err(ConnectError::OperationFailed(error));
+            }
+            SocketConnectionStatus::Unconnected => Err(ConnectError::InvalidState),
+            _ => Err(ConnectError::OperationFailed(
+                SocketAsyncError::BackendFailure,
+            )),
+        };
+        drop(configuration);
+        result
     }
 
     pub(super) fn check_connect_progress(&self) -> Result<(), ConnectError> {
@@ -250,16 +273,23 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
             ConnectError::OperationFailed(BrokerObjectError::from(error).into())
         })?;
         let status = response.status;
-        self.apply_socket_status(response);
         if let SocketConnectionStatus::Failed(error) = status {
             let error = error.into();
-            let failed = self.consume_synchronous_error_locked(error);
+            let failed = self.consume_synchronous_error_locked(error, Some(response));
             drop(configuration);
             self.notify_synchronous_error_consumed(failed);
             return Err(ConnectError::OperationFailed(error));
         }
+        self.apply_socket_status(response);
         drop(configuration);
-        self.handle_connect_status(status, None)
+        match status {
+            SocketConnectionStatus::Connected => Ok(()),
+            SocketConnectionStatus::Connecting => Err(ConnectError::InProgress),
+            SocketConnectionStatus::Unconnected => Err(ConnectError::InvalidState),
+            _ => Err(ConnectError::OperationFailed(
+                SocketAsyncError::BackendFailure,
+            )),
+        }
     }
 
     pub(super) fn remote_addr(&self) -> Result<SocketAddr, RemoteAddrError> {
@@ -447,6 +477,7 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
             return Ok(0);
         }
         let _receive = self.receive_lock.lock();
+        let configuration = self.configuration_lock.lock();
         let discard = flags.contains(ReceiveFlags::DISCARD);
         let mut broker_flags = BrokerReceiveFlags::NONE;
         let peek = flags.contains(ReceiveFlags::PEEK);
@@ -515,7 +546,9 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
                 }
                 SocketOutcome::Failed(error) => {
                     let error = error.into();
-                    self.consume_synchronous_error(error);
+                    let failed = self.consume_synchronous_error_locked(error, None);
+                    drop(configuration);
+                    self.notify_synchronous_error_consumed(failed);
                     if offset != 0 {
                         self.set_async_error(error);
                         return Ok(offset);
@@ -533,6 +566,7 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
         if self.write_shutdown.load(Ordering::Acquire) {
             return Err(ChannelWriteError::WriteShutdown);
         }
+        let configuration = self.configuration_lock.lock();
         let length = buffer.len().min(MAX_SOCKET_TRANSFER_SIZE as usize);
         let outcome = self
             .broker
@@ -548,37 +582,11 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
             SocketOutcome::Completed(sent) => Ok(sent),
             SocketOutcome::Failed(error) => {
                 let error = error.into();
-                self.consume_synchronous_error(error);
+                let failed = self.consume_synchronous_error_locked(error, None);
+                drop(configuration);
+                self.notify_synchronous_error_consumed(failed);
                 Err(ChannelWriteError::Socket(error))
             }
-        }
-    }
-
-    fn handle_connect_status(
-        &self,
-        status: SocketConnectionStatus,
-        remote_address: Option<SocketAddrV4>,
-    ) -> Result<(), ConnectError> {
-        let status = {
-            let mut state = self.state.lock();
-            let status = state.update_connection(status);
-            if state.remote_address.is_none() {
-                state.remote_address = remote_address;
-            }
-            status
-        };
-        match status {
-            SocketConnectionStatus::Connected => Ok(()),
-            SocketConnectionStatus::Connecting => Err(ConnectError::InProgress),
-            SocketConnectionStatus::Failed(error) => {
-                let error = error.into();
-                self.consume_synchronous_error(error);
-                Err(ConnectError::OperationFailed(error))
-            }
-            SocketConnectionStatus::Unconnected => Err(ConnectError::InvalidState),
-            _ => Err(ConnectError::OperationFailed(
-                SocketAsyncError::BackendFailure,
-            )),
         }
     }
 
@@ -614,6 +622,12 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
     }
 
     fn apply_socket_status(&self, response: SocketStatusResponse) {
+        if let Some(error) = self.update_socket_status(response) {
+            self.state.lock().append_async_error(error);
+        }
+    }
+
+    fn update_socket_status(&self, response: SocketStatusResponse) -> Option<SocketAsyncError> {
         let mut state = self.state.lock();
         let previous_connection = state.connection;
         let connection = state.update_connection(response.status);
@@ -628,73 +642,61 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
             state.local_address = Some(address);
         }
 
-        if let Some(error) = response.pending_error {
-            state.append_async_error(error.into());
-        } else if let Some(error) = connection_error {
-            state.append_async_error(error.into());
-        }
+        response
+            .pending_error
+            .map(SocketAsyncError::from)
+            .or_else(|| connection_error.map(SocketAsyncError::from))
     }
 
-    fn consume_synchronous_error(&self, synchronous_error: SocketAsyncError) {
-        let configuration = self.configuration_lock.lock();
-        let failed = self.consume_synchronous_error_locked(synchronous_error);
-        drop(configuration);
-        self.notify_synchronous_error_consumed(failed);
-    }
-
-    fn consume_synchronous_error_locked(&self, synchronous_error: SocketAsyncError) -> bool {
-        let mut matched = self.state.lock().remove_async_error(synchronous_error);
+    fn consume_synchronous_error_locked(
+        &self,
+        synchronous_error: SocketAsyncError,
+        mut initial_response: Option<SocketStatusResponse>,
+    ) -> bool {
+        let mut fetched_errors = [None; 2];
+        let mut fetched_count = 0;
         for _ in 0..2 {
             if self.closed.load(Ordering::Acquire) {
                 break;
             }
-            let connection = self.state.lock().connection;
-            if !matches!(
-                connection,
-                SocketConnectionStatus::Connecting | SocketConnectionStatus::Connected
-            ) {
-                break;
-            }
-            let response = match self.broker.socket_status(self.handle) {
-                Ok(response) => response,
-                Err(error) if !self.closed.load(Ordering::Acquire) => {
-                    self.state
-                        .lock()
-                        .append_async_error(BrokerObjectError::from(error).into());
+            let response = if let Some(response) = initial_response.take() {
+                response
+            } else {
+                let connection = self.state.lock().connection;
+                if !matches!(
+                    connection,
+                    SocketConnectionStatus::Connecting | SocketConnectionStatus::Connected
+                ) {
                     break;
                 }
-                Err(_) => break,
+                match self.broker.socket_status(self.handle) {
+                    Ok(response) => response,
+                    Err(error) if !self.closed.load(Ordering::Acquire) => {
+                        self.state
+                            .lock()
+                            .append_async_error(BrokerObjectError::from(error).into());
+                        break;
+                    }
+                    Err(_) => break,
+                }
             };
-            let mut state = self.state.lock();
-            let previous_connection = state.connection;
-            let connection = state.update_connection(response.status);
-            let connection_error = match (previous_connection, connection) {
-                (
-                    SocketConnectionStatus::Unconnected | SocketConnectionStatus::Connecting,
-                    SocketConnectionStatus::Failed(error),
-                ) => Some(SocketAsyncError::from(error)),
-                _ => None,
-            };
-            if let Some(address) = response.local_address {
-                state.local_address = Some(address);
-            }
-            let pending_error = response
-                .pending_error
-                .map(SocketAsyncError::from)
-                .or(connection_error);
-            let Some(pending_error) = pending_error else {
+            let Some(pending_error) = self.update_socket_status(response) else {
                 break;
             };
-            if !matched && pending_error == synchronous_error {
-                matched = true;
-            } else {
-                state.append_async_error(pending_error);
+            fetched_errors[fetched_count] = Some(pending_error);
+            fetched_count += 1;
+        }
+        let matching_index = BrokerTcpSocketState::matching_synchronous_error_index(
+            &fetched_errors[..fetched_count],
+            synchronous_error,
+        );
+        let mut state = self.state.lock();
+        for (index, error) in fetched_errors[..fetched_count].iter().enumerate() {
+            if Some(index) != matching_index {
+                state.append_async_error(error.expect("fetched TCP error must be present"));
             }
         }
-        let state = self.state.lock();
-        let failed = matches!(state.connection, SocketConnectionStatus::Failed(_));
-        drop(state);
-        failed
+        matches!(state.connection, SocketConnectionStatus::Failed(_))
     }
 
     fn notify_synchronous_error_consumed(&self, failed: bool) {
@@ -1391,39 +1393,25 @@ mod tests {
     }
 
     #[test]
-    fn removing_synchronous_tcp_error_preserves_unrelated_cached_error() {
-        let mut state = BrokerTcpSocketState {
-            connection: SocketConnectionStatus::Connected,
-            local_address: None,
-            remote_address: None,
-            async_error: SocketAsyncError::NetworkUnreachable as u32,
-            next_async_error: SocketAsyncError::ConnectionRefused as u32,
-            listening: false,
-        };
+    fn newest_matching_tcp_status_error_is_synchronous_duplicate() {
+        let errors = [
+            Some(SocketAsyncError::ConnectionReset),
+            Some(SocketAsyncError::ConnectionReset),
+        ];
 
-        assert!(state.remove_async_error(SocketAsyncError::ConnectionRefused));
         assert_eq!(
-            SocketAsyncError::from_u32(state.take_async_error()),
-            Some(SocketAsyncError::NetworkUnreachable)
+            BrokerTcpSocketState::matching_synchronous_error_index(
+                &errors,
+                SocketAsyncError::ConnectionReset
+            ),
+            Some(1)
         );
-        assert_eq!(state.take_async_error(), 0);
-    }
-
-    #[test]
-    fn nonmatching_synchronous_tcp_error_does_not_consume_cached_error() {
-        let mut state = BrokerTcpSocketState {
-            connection: SocketConnectionStatus::Connected,
-            local_address: None,
-            remote_address: None,
-            async_error: SocketAsyncError::NetworkUnreachable as u32,
-            next_async_error: 0,
-            listening: false,
-        };
-
-        assert!(!state.remove_async_error(SocketAsyncError::ConnectionRefused));
         assert_eq!(
-            SocketAsyncError::from_u32(state.take_async_error()),
-            Some(SocketAsyncError::NetworkUnreachable)
+            BrokerTcpSocketState::matching_synchronous_error_index(
+                &errors,
+                SocketAsyncError::TimedOut
+            ),
+            None
         );
     }
 

--- a/litebox/src/net/broker_socket.rs
+++ b/litebox/src/net/broker_socket.rs
@@ -39,6 +39,8 @@ struct BrokerTcpSocketState {
     remote_address: Option<SocketAddrV4>,
     async_error: u32,
     next_async_error: u32,
+    async_error_is_connection_failure: bool,
+    next_async_error_is_connection_failure: bool,
     listening: bool,
 }
 
@@ -46,32 +48,46 @@ impl BrokerTcpSocketState {
     fn prepend_async_error(&mut self, error: SocketAsyncError) {
         if self.async_error != 0 {
             self.next_async_error = self.async_error;
+            self.next_async_error_is_connection_failure = self.async_error_is_connection_failure;
         }
         self.async_error = error as u32;
+        self.async_error_is_connection_failure = false;
     }
 
     fn append_async_error(&mut self, error: SocketAsyncError) {
-        if self.async_error == 0 {
-            self.async_error = error as u32;
-        } else if self.next_async_error == 0 {
-            self.next_async_error = error as u32;
-        }
+        self.append_async_error_with_source(error, false);
     }
 
-    fn matching_synchronous_error_index(
-        errors: &[Option<SocketAsyncError>],
-        synchronous_error: SocketAsyncError,
-    ) -> Option<usize> {
-        errors
-            .iter()
-            .rposition(|error| *error == Some(synchronous_error))
+    fn append_async_error_with_source(
+        &mut self,
+        error: SocketAsyncError,
+        is_connection_failure: bool,
+    ) {
+        if self.async_error == 0 {
+            self.async_error = error as u32;
+            self.async_error_is_connection_failure = is_connection_failure;
+        } else if self.next_async_error == 0 {
+            self.next_async_error = error as u32;
+            self.next_async_error_is_connection_failure = is_connection_failure;
+        }
     }
 
     fn take_async_error(&mut self) -> u32 {
         let error = self.async_error;
         self.async_error = self.next_async_error;
+        self.async_error_is_connection_failure = self.next_async_error_is_connection_failure;
         self.next_async_error = 0;
+        self.next_async_error_is_connection_failure = false;
         error
+    }
+
+    fn take_connection_failure(&mut self) {
+        if self.next_async_error_is_connection_failure {
+            self.next_async_error = 0;
+            self.next_async_error_is_connection_failure = false;
+        } else if self.async_error_is_connection_failure {
+            self.take_async_error();
+        }
     }
 
     fn update_connection(&mut self, connection: SocketConnectionStatus) -> SocketConnectionStatus {
@@ -120,6 +136,8 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
                 remote_address: None,
                 async_error: 0,
                 next_async_error: 0,
+                async_error_is_connection_failure: false,
+                next_async_error_is_connection_failure: false,
                 listening: false,
             }),
             write_shutdown: AtomicBool::new(false),
@@ -149,6 +167,8 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
                 remote_address: Some(accepted.remote_address),
                 async_error: 0,
                 next_async_error: 0,
+                async_error_is_connection_failure: false,
+                next_async_error_is_connection_failure: false,
                 listening: false,
             }),
             write_shutdown: AtomicBool::new(false),
@@ -233,9 +253,6 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
             SocketOutcome::Completed(status) => status,
             SocketOutcome::Failed(error) => {
                 let error = error.into();
-                let failed = self.consume_synchronous_error_locked(error, None);
-                drop(configuration);
-                self.notify_synchronous_error_consumed(failed);
                 return Err(ConnectError::OperationFailed(error));
             }
         };
@@ -253,9 +270,6 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
             SocketConnectionStatus::Connecting => Err(ConnectError::InProgress),
             SocketConnectionStatus::Failed(error) => {
                 let error = error.into();
-                let failed = self.consume_synchronous_error_locked(error, None);
-                drop(configuration);
-                self.notify_synchronous_error_consumed(failed);
                 return Err(ConnectError::OperationFailed(error));
             }
             SocketConnectionStatus::Unconnected => Err(ConnectError::InvalidState),
@@ -275,9 +289,12 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
         let status = response.status;
         if let SocketConnectionStatus::Failed(error) = status {
             let error = error.into();
-            let failed = self.consume_synchronous_error_locked(error, Some(response));
+            self.apply_socket_status(response);
+            self.state.lock().take_connection_failure();
             drop(configuration);
-            self.notify_synchronous_error_consumed(failed);
+            self.pollee.wake_observers();
+            self.pollee
+                .notify_observers(Events::IN | Events::OUT | Events::HUP);
             return Err(ConnectError::OperationFailed(error));
         }
         self.apply_socket_status(response);
@@ -477,7 +494,6 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
             return Ok(0);
         }
         let _receive = self.receive_lock.lock();
-        let configuration = self.configuration_lock.lock();
         let discard = flags.contains(ReceiveFlags::DISCARD);
         let mut broker_flags = BrokerReceiveFlags::NONE;
         let peek = flags.contains(ReceiveFlags::PEEK);
@@ -546,9 +562,7 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
                 }
                 SocketOutcome::Failed(error) => {
                     let error = error.into();
-                    let failed = self.consume_synchronous_error_locked(error, None);
-                    drop(configuration);
-                    self.notify_synchronous_error_consumed(failed);
+                    self.refresh_after_synchronous_error();
                     if offset != 0 {
                         self.set_async_error(error);
                         return Ok(offset);
@@ -566,7 +580,6 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
         if self.write_shutdown.load(Ordering::Acquire) {
             return Err(ChannelWriteError::WriteShutdown);
         }
-        let configuration = self.configuration_lock.lock();
         let length = buffer.len().min(MAX_SOCKET_TRANSFER_SIZE as usize);
         let outcome = self
             .broker
@@ -582,9 +595,7 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
             SocketOutcome::Completed(sent) => Ok(sent),
             SocketOutcome::Failed(error) => {
                 let error = error.into();
-                let failed = self.consume_synchronous_error_locked(error, None);
-                drop(configuration);
-                self.notify_synchronous_error_consumed(failed);
+                self.refresh_after_synchronous_error();
                 Err(ChannelWriteError::Socket(error))
             }
         }
@@ -622,12 +633,17 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
     }
 
     fn apply_socket_status(&self, response: SocketStatusResponse) {
-        if let Some(error) = self.update_socket_status(response) {
-            self.state.lock().append_async_error(error);
+        if let Some((error, is_connection_failure)) = self.update_socket_status(response) {
+            self.state
+                .lock()
+                .append_async_error_with_source(error, is_connection_failure);
         }
     }
 
-    fn update_socket_status(&self, response: SocketStatusResponse) -> Option<SocketAsyncError> {
+    fn update_socket_status(
+        &self,
+        response: SocketStatusResponse,
+    ) -> Option<(SocketAsyncError, bool)> {
         let mut state = self.state.lock();
         let previous_connection = state.connection;
         let connection = state.update_connection(response.status);
@@ -645,61 +661,46 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
         response
             .pending_error
             .map(SocketAsyncError::from)
-            .or_else(|| connection_error.map(SocketAsyncError::from))
+            .map(|error| (error, false))
+            .or_else(|| connection_error.map(|error| (error.into(), true)))
     }
 
-    fn consume_synchronous_error_locked(
-        &self,
-        synchronous_error: SocketAsyncError,
-        mut initial_response: Option<SocketStatusResponse>,
-    ) -> bool {
-        let mut fetched_errors = [None; 2];
-        let mut fetched_count = 0;
+    fn refresh_after_synchronous_error(&self) {
+        let configuration = self.configuration_lock.lock();
         for _ in 0..2 {
             if self.closed.load(Ordering::Acquire) {
                 break;
             }
-            let response = if let Some(response) = initial_response.take() {
-                response
-            } else {
-                let connection = self.state.lock().connection;
-                if !matches!(
-                    connection,
-                    SocketConnectionStatus::Connecting | SocketConnectionStatus::Connected
-                ) {
+            let connection = self.state.lock().connection;
+            if !matches!(
+                connection,
+                SocketConnectionStatus::Connecting | SocketConnectionStatus::Connected
+            ) {
+                break;
+            }
+            let response = match self.broker.socket_status(self.handle) {
+                Ok(response) => response,
+                Err(error) if !self.closed.load(Ordering::Acquire) => {
+                    self.state
+                        .lock()
+                        .append_async_error(BrokerObjectError::from(error).into());
                     break;
                 }
-                match self.broker.socket_status(self.handle) {
-                    Ok(response) => response,
-                    Err(error) if !self.closed.load(Ordering::Acquire) => {
-                        self.state
-                            .lock()
-                            .append_async_error(BrokerObjectError::from(error).into());
-                        break;
-                    }
-                    Err(_) => break,
-                }
+                Err(_) => break,
             };
-            let Some(pending_error) = self.update_socket_status(response) else {
+            let Some((pending_error, is_connection_failure)) = self.update_socket_status(response)
+            else {
                 break;
             };
-            fetched_errors[fetched_count] = Some(pending_error);
-            fetched_count += 1;
+            self.state
+                .lock()
+                .append_async_error_with_source(pending_error, is_connection_failure);
         }
-        let matching_index = BrokerTcpSocketState::matching_synchronous_error_index(
-            &fetched_errors[..fetched_count],
-            synchronous_error,
+        let failed = matches!(
+            self.state.lock().connection,
+            SocketConnectionStatus::Failed(_)
         );
-        let mut state = self.state.lock();
-        for (index, error) in fetched_errors[..fetched_count].iter().enumerate() {
-            if Some(index) != matching_index {
-                state.append_async_error(error.expect("fetched TCP error must be present"));
-            }
-        }
-        matches!(state.connection, SocketConnectionStatus::Failed(_))
-    }
-
-    fn notify_synchronous_error_consumed(&self, failed: bool) {
+        drop(configuration);
         self.pollee.wake_observers();
         if failed {
             self.pollee
@@ -1328,6 +1329,8 @@ mod tests {
             remote_address: None,
             async_error: SocketAsyncError::NetworkUnreachable as u32,
             next_async_error: 0,
+            async_error_is_connection_failure: false,
+            next_async_error_is_connection_failure: false,
             listening: false,
         };
 
@@ -1351,6 +1354,8 @@ mod tests {
             remote_address: None,
             async_error: 0,
             next_async_error: 0,
+            async_error_is_connection_failure: false,
+            next_async_error_is_connection_failure: false,
             listening: false,
         };
 
@@ -1377,6 +1382,8 @@ mod tests {
             remote_address: None,
             async_error: SocketAsyncError::NetworkUnreachable as u32,
             next_async_error: 0,
+            async_error_is_connection_failure: false,
+            next_async_error_is_connection_failure: false,
             listening: false,
         };
 
@@ -1393,26 +1400,25 @@ mod tests {
     }
 
     #[test]
-    fn newest_matching_tcp_status_error_is_synchronous_duplicate() {
-        let errors = [
-            Some(SocketAsyncError::ConnectionReset),
-            Some(SocketAsyncError::ConnectionReset),
-        ];
+    fn cached_connect_failure_is_removed_by_source() {
+        let mut state = BrokerTcpSocketState {
+            connection: SocketConnectionStatus::Failed(BrokerSocketError::ConnectionRefused),
+            local_address: None,
+            remote_address: None,
+            async_error: SocketAsyncError::ConnectionRefused as u32,
+            next_async_error: SocketAsyncError::ConnectionRefused as u32,
+            async_error_is_connection_failure: false,
+            next_async_error_is_connection_failure: true,
+            listening: false,
+        };
+
+        state.take_connection_failure();
 
         assert_eq!(
-            BrokerTcpSocketState::matching_synchronous_error_index(
-                &errors,
-                SocketAsyncError::ConnectionReset
-            ),
-            Some(1)
+            SocketAsyncError::from_u32(state.take_async_error()),
+            Some(SocketAsyncError::ConnectionRefused)
         );
-        assert_eq!(
-            BrokerTcpSocketState::matching_synchronous_error_index(
-                &errors,
-                SocketAsyncError::TimedOut
-            ),
-            None
-        );
+        assert_eq!(state.take_async_error(), 0);
     }
 
     #[test]

--- a/litebox/src/net/broker_socket.rs
+++ b/litebox/src/net/broker_socket.rs
@@ -50,11 +50,32 @@ impl BrokerTcpSocketState {
         self.async_error = error as u32;
     }
 
+    fn append_async_error(&mut self, error: SocketAsyncError) {
+        if self.async_error == 0 {
+            self.async_error = error as u32;
+        } else if self.next_async_error == 0 {
+            self.next_async_error = error as u32;
+        }
+    }
+
     fn take_async_error(&mut self) -> u32 {
         let error = self.async_error;
         self.async_error = self.next_async_error;
         self.next_async_error = 0;
         error
+    }
+
+    fn remove_async_error(&mut self, error: SocketAsyncError) -> bool {
+        let error = error as u32;
+        if self.async_error == error {
+            self.take_async_error();
+            true
+        } else if self.next_async_error == error {
+            self.next_async_error = 0;
+            true
+        } else {
+            false
+        }
     }
 
     fn update_connection(&mut self, connection: SocketConnectionStatus) -> SocketConnectionStatus {
@@ -75,6 +96,7 @@ pub struct BrokerTcpSocket<Platform: RawSyncPrimitivesProvider + TimeProvider> {
     handle: ObjectHandle,
     pollable_registry: Arc<BrokerPollableRegistry<Platform>>,
     pollee: Arc<Pollee<Platform>>,
+    configuration_lock: Mutex<Platform, ()>,
     receive_lock: Mutex<Platform, ()>,
     state: Mutex<Platform, BrokerTcpSocketState>,
     write_shutdown: AtomicBool,
@@ -94,6 +116,7 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
             handle,
             pollable_registry,
             pollee: Arc::new(Pollee::new()),
+            configuration_lock: Mutex::new(()),
             receive_lock: Mutex::new(()),
             state: Mutex::new(BrokerTcpSocketState {
                 connection: SocketConnectionStatus::Unconnected,
@@ -122,6 +145,7 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
             handle: accepted.handle,
             pollable_registry,
             pollee: Arc::new(Pollee::new()),
+            configuration_lock: Mutex::new(()),
             receive_lock: Mutex::new(()),
             state: Mutex::new(BrokerTcpSocketState {
                 connection: SocketConnectionStatus::Connected,
@@ -212,7 +236,7 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
             SocketOutcome::Completed(status) => status,
             SocketOutcome::Failed(error) => {
                 let error = error.into();
-                self.consume_synchronous_error();
+                self.consume_synchronous_error(error);
                 return Err(ConnectError::OperationFailed(error));
             }
         };
@@ -221,11 +245,13 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
     }
 
     pub(super) fn check_connect_progress(&self) -> Result<(), ConnectError> {
+        let configuration = self.configuration_lock.lock();
         let response = self.broker.socket_status(self.handle).map_err(|error| {
             ConnectError::OperationFailed(BrokerObjectError::from(error).into())
         })?;
         let status = response.status;
         self.apply_socket_status(response);
+        drop(configuration);
         self.handle_connect_status(status, None)
     }
 
@@ -364,14 +390,18 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
         if self.closed.load(Ordering::Acquire) {
             return;
         }
+        let configuration = self.configuration_lock.lock();
         self.state.lock().prepend_async_error(error);
+        drop(configuration);
+        self.pollee.notify_observers(Events::ERR);
     }
 
     pub(super) fn get_async_error(&self, clear: bool) -> Option<SocketAsyncError> {
         if self.closed.load(Ordering::Acquire) {
             return None;
         }
-        self.refresh_connection_status(true);
+        let configuration = self.configuration_lock.lock();
+        self.refresh_connection_status_locked(true);
         let mut state = self.state.lock();
         let raw = state.async_error;
         if clear {
@@ -382,8 +412,9 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
         drop(state);
         if clear && raw != 0 {
             if needs_refill {
-                self.refresh_connection_status(true);
+                self.refresh_connection_status_locked(true);
             }
+            drop(configuration);
             self.pollee.wake_observers();
             if failed {
                 self.pollee
@@ -477,7 +508,7 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
                 }
                 SocketOutcome::Failed(error) => {
                     let error = error.into();
-                    self.consume_synchronous_error();
+                    self.consume_synchronous_error(error);
                     if offset != 0 {
                         self.set_async_error(error);
                         return Ok(offset);
@@ -510,7 +541,7 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
             SocketOutcome::Completed(sent) => Ok(sent),
             SocketOutcome::Failed(error) => {
                 let error = error.into();
-                self.consume_synchronous_error();
+                self.consume_synchronous_error(error);
                 Err(ChannelWriteError::Socket(error))
             }
         }
@@ -534,7 +565,7 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
             SocketConnectionStatus::Connecting => Err(ConnectError::InProgress),
             SocketConnectionStatus::Failed(error) => {
                 let error = error.into();
-                self.consume_synchronous_error();
+                self.consume_synchronous_error(error);
                 Err(ConnectError::OperationFailed(error))
             }
             SocketConnectionStatus::Unconnected => Err(ConnectError::InvalidState),
@@ -545,6 +576,11 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
     }
 
     fn refresh_connection_status(&self, include_connected: bool) {
+        let _configuration = self.configuration_lock.lock();
+        self.refresh_connection_status_locked(include_connected);
+    }
+
+    fn refresh_connection_status_locked(&self, include_connected: bool) {
         if self.closed.load(Ordering::Acquire) {
             return;
         }
@@ -562,7 +598,9 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
         match self.broker.socket_status(self.handle) {
             Ok(response) => self.apply_socket_status(response),
             Err(error) if !self.closed.load(Ordering::Acquire) => {
-                self.set_async_error(BrokerObjectError::from(error).into());
+                self.state
+                    .lock()
+                    .prepend_async_error(BrokerObjectError::from(error).into());
             }
             Err(_) => {}
         }
@@ -583,21 +621,68 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
             state.local_address = Some(address);
         }
 
-        if state.async_error == 0 {
-            if let Some(error) = response.pending_error {
-                state.async_error = SocketAsyncError::from(error) as u32;
-            } else if let Some(error) = connection_error {
-                state.async_error = SocketAsyncError::from(error) as u32;
-            }
+        if let Some(error) = response.pending_error {
+            state.append_async_error(error.into());
+        } else if let Some(error) = connection_error {
+            state.append_async_error(error.into());
         }
     }
 
-    fn consume_synchronous_error(&self) {
-        self.refresh_connection_status(true);
-        let mut state = self.state.lock();
-        state.take_async_error();
+    fn consume_synchronous_error(&self, synchronous_error: SocketAsyncError) {
+        let configuration = self.configuration_lock.lock();
+        let mut matched = self.state.lock().remove_async_error(synchronous_error);
+        for _ in 0..2 {
+            if self.closed.load(Ordering::Acquire) {
+                break;
+            }
+            let connection = self.state.lock().connection;
+            if !matches!(
+                connection,
+                SocketConnectionStatus::Connecting | SocketConnectionStatus::Connected
+            ) {
+                break;
+            }
+            let response = match self.broker.socket_status(self.handle) {
+                Ok(response) => response,
+                Err(error) if !self.closed.load(Ordering::Acquire) => {
+                    self.state
+                        .lock()
+                        .append_async_error(BrokerObjectError::from(error).into());
+                    break;
+                }
+                Err(_) => break,
+            };
+            let mut state = self.state.lock();
+            let previous_connection = state.connection;
+            let connection = state.update_connection(response.status);
+            let connection_error = match (previous_connection, connection) {
+                (
+                    SocketConnectionStatus::Unconnected | SocketConnectionStatus::Connecting,
+                    SocketConnectionStatus::Failed(error),
+                ) => Some(SocketAsyncError::from(error)),
+                _ => None,
+            };
+            if let Some(address) = response.local_address {
+                state.local_address = Some(address);
+            }
+            let pending_error = response
+                .pending_error
+                .map(SocketAsyncError::from)
+                .or(connection_error);
+            let Some(pending_error) = pending_error else {
+                break;
+            };
+            if !matched && pending_error == synchronous_error {
+                matched = true;
+            } else {
+                state.append_async_error(pending_error);
+            }
+        }
+        let state = self.state.lock();
         let failed = matches!(state.connection, SocketConnectionStatus::Failed(_));
         drop(state);
+        drop(configuration);
+        self.pollee.wake_observers();
         if failed {
             self.pollee
                 .notify_observers(Events::IN | Events::OUT | Events::HUP);
@@ -1264,6 +1349,66 @@ mod tests {
             Some(SocketAsyncError::ConnectionRefused)
         );
         assert_eq!(state.take_async_error(), 0);
+    }
+
+    #[test]
+    fn tcp_status_error_is_appended_after_cached_error() {
+        let mut state = BrokerTcpSocketState {
+            connection: SocketConnectionStatus::Connected,
+            local_address: None,
+            remote_address: None,
+            async_error: SocketAsyncError::NetworkUnreachable as u32,
+            next_async_error: 0,
+            listening: false,
+        };
+
+        state.append_async_error(SocketAsyncError::ConnectionRefused);
+
+        assert_eq!(
+            SocketAsyncError::from_u32(state.take_async_error()),
+            Some(SocketAsyncError::NetworkUnreachable)
+        );
+        assert_eq!(
+            SocketAsyncError::from_u32(state.take_async_error()),
+            Some(SocketAsyncError::ConnectionRefused)
+        );
+    }
+
+    #[test]
+    fn removing_synchronous_tcp_error_preserves_unrelated_cached_error() {
+        let mut state = BrokerTcpSocketState {
+            connection: SocketConnectionStatus::Connected,
+            local_address: None,
+            remote_address: None,
+            async_error: SocketAsyncError::NetworkUnreachable as u32,
+            next_async_error: SocketAsyncError::ConnectionRefused as u32,
+            listening: false,
+        };
+
+        assert!(state.remove_async_error(SocketAsyncError::ConnectionRefused));
+        assert_eq!(
+            SocketAsyncError::from_u32(state.take_async_error()),
+            Some(SocketAsyncError::NetworkUnreachable)
+        );
+        assert_eq!(state.take_async_error(), 0);
+    }
+
+    #[test]
+    fn nonmatching_synchronous_tcp_error_does_not_consume_cached_error() {
+        let mut state = BrokerTcpSocketState {
+            connection: SocketConnectionStatus::Connected,
+            local_address: None,
+            remote_address: None,
+            async_error: SocketAsyncError::NetworkUnreachable as u32,
+            next_async_error: 0,
+            listening: false,
+        };
+
+        assert!(!state.remove_async_error(SocketAsyncError::ConnectionRefused));
+        assert_eq!(
+            SocketAsyncError::from_u32(state.take_async_error()),
+            Some(SocketAsyncError::NetworkUnreachable)
+        );
     }
 
     #[test]

--- a/litebox/src/net/broker_socket.rs
+++ b/litebox/src/net/broker_socket.rs
@@ -37,55 +37,60 @@ struct BrokerTcpSocketState {
     connection: SocketConnectionStatus,
     local_address: Option<SocketAddrV4>,
     remote_address: Option<SocketAddrV4>,
-    async_error: u32,
-    next_async_error: u32,
-    async_error_is_connection_failure: bool,
-    next_async_error_is_connection_failure: bool,
+    async_error: Option<BrokerTcpAsyncError>,
+    next_async_error: Option<BrokerTcpAsyncError>,
     listening: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum BrokerTcpAsyncError {
+    Other(SocketAsyncError),
+    ConnectionFailure(SocketAsyncError),
+}
+
+impl BrokerTcpAsyncError {
+    fn error(self) -> SocketAsyncError {
+        match self {
+            Self::Other(error) | Self::ConnectionFailure(error) => error,
+        }
+    }
 }
 
 impl BrokerTcpSocketState {
     fn prepend_async_error(&mut self, error: SocketAsyncError) {
-        if self.async_error != 0 {
-            self.next_async_error = self.async_error;
-            self.next_async_error_is_connection_failure = self.async_error_is_connection_failure;
-        }
-        self.async_error = error as u32;
-        self.async_error_is_connection_failure = false;
+        self.next_async_error = self.async_error;
+        self.async_error = Some(BrokerTcpAsyncError::Other(error));
     }
 
     fn append_async_error(&mut self, error: SocketAsyncError) {
-        self.append_async_error_with_source(error, false);
+        self.append_retained_error(BrokerTcpAsyncError::Other(error));
     }
 
-    fn append_async_error_with_source(
-        &mut self,
-        error: SocketAsyncError,
-        is_connection_failure: bool,
-    ) {
-        if self.async_error == 0 {
-            self.async_error = error as u32;
-            self.async_error_is_connection_failure = is_connection_failure;
-        } else if self.next_async_error == 0 {
-            self.next_async_error = error as u32;
-            self.next_async_error_is_connection_failure = is_connection_failure;
+    fn append_retained_error(&mut self, error: BrokerTcpAsyncError) {
+        let error = Some(error);
+        if self.async_error.is_none() {
+            self.async_error = error;
+        } else if self.next_async_error.is_none() {
+            self.next_async_error = error;
         }
     }
 
-    fn take_async_error(&mut self) -> u32 {
-        let error = self.async_error;
-        self.async_error = self.next_async_error;
-        self.async_error_is_connection_failure = self.next_async_error_is_connection_failure;
-        self.next_async_error = 0;
-        self.next_async_error_is_connection_failure = false;
-        error
+    fn take_async_error(&mut self) -> Option<SocketAsyncError> {
+        let error = self.async_error.take();
+        self.async_error = self.next_async_error.take();
+        error.map(BrokerTcpAsyncError::error)
     }
 
     fn take_connection_failure(&mut self) {
-        if self.next_async_error_is_connection_failure {
-            self.next_async_error = 0;
-            self.next_async_error_is_connection_failure = false;
-        } else if self.async_error_is_connection_failure {
+        if self
+            .next_async_error
+            .is_some_and(|error| matches!(error, BrokerTcpAsyncError::ConnectionFailure(_)))
+        {
+            self.next_async_error = None;
+        } else if self
+            .async_error
+            .is_some_and(|error| matches!(error, BrokerTcpAsyncError::ConnectionFailure(_)))
+        {
             self.take_async_error();
         }
     }
@@ -134,10 +139,8 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
                 connection: SocketConnectionStatus::Unconnected,
                 local_address: None,
                 remote_address: None,
-                async_error: 0,
-                next_async_error: 0,
-                async_error_is_connection_failure: false,
-                next_async_error_is_connection_failure: false,
+                async_error: None,
+                next_async_error: None,
                 listening: false,
             }),
             write_shutdown: AtomicBool::new(false),
@@ -165,10 +168,8 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
                 connection: SocketConnectionStatus::Connected,
                 local_address: Some(accepted.local_address),
                 remote_address: Some(accepted.remote_address),
-                async_error: 0,
-                next_async_error: 0,
-                async_error_is_connection_failure: false,
-                next_async_error_is_connection_failure: false,
+                async_error: None,
+                next_async_error: None,
                 listening: false,
             }),
             write_shutdown: AtomicBool::new(false),
@@ -462,14 +463,15 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
         let configuration = self.configuration_lock.lock();
         self.refresh_connection_status_locked(true);
         let mut state = self.state.lock();
-        let raw = state.async_error;
-        if clear {
-            state.take_async_error();
-        }
-        let needs_refill = clear && raw != 0 && state.async_error == 0;
+        let error = if clear {
+            state.take_async_error()
+        } else {
+            state.async_error.map(BrokerTcpAsyncError::error)
+        };
+        let needs_refill = clear && error.is_some() && state.async_error.is_none();
         let failed = matches!(state.connection, SocketConnectionStatus::Failed(_));
         drop(state);
-        if clear && raw != 0 {
+        if clear && error.is_some() {
             if needs_refill {
                 self.refresh_connection_status_locked(true);
             }
@@ -480,7 +482,7 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
                     .notify_observers(Events::IN | Events::OUT | Events::HUP);
             }
         }
-        SocketAsyncError::from_u32(raw)
+        error
     }
 
     pub(super) fn try_read(
@@ -616,7 +618,7 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
             return;
         }
         let state = self.state.lock();
-        if state.async_error != 0 {
+        if state.async_error.is_some() {
             return;
         }
         let connection = state.connection;
@@ -638,17 +640,12 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
     }
 
     fn apply_socket_status(&self, response: SocketStatusResponse) {
-        if let Some((error, is_connection_failure)) = self.update_socket_status(response) {
-            self.state
-                .lock()
-                .append_async_error_with_source(error, is_connection_failure);
+        if let Some(error) = self.update_socket_status(response) {
+            self.state.lock().append_retained_error(error);
         }
     }
 
-    fn update_socket_status(
-        &self,
-        response: SocketStatusResponse,
-    ) -> Option<(SocketAsyncError, bool)> {
+    fn update_socket_status(&self, response: SocketStatusResponse) -> Option<BrokerTcpAsyncError> {
         let mut state = self.state.lock();
         let previous_connection = state.connection;
         let connection = state.update_connection(response.status);
@@ -666,8 +663,12 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
         response
             .pending_error
             .map(SocketAsyncError::from)
-            .map(|error| (error, false))
-            .or_else(|| connection_error.map(|error| (error.into(), true)))
+            .map(BrokerTcpAsyncError::Other)
+            .or_else(|| {
+                connection_error
+                    .map(SocketAsyncError::from)
+                    .map(BrokerTcpAsyncError::ConnectionFailure)
+            })
     }
 
     fn refresh_after_synchronous_error(&self) {
@@ -693,13 +694,10 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
                 }
                 Err(_) => break,
             };
-            let Some((pending_error, is_connection_failure)) = self.update_socket_status(response)
-            else {
+            let Some(pending_error) = self.update_socket_status(response) else {
                 break;
             };
-            self.state
-                .lock()
-                .append_async_error_with_source(pending_error, is_connection_failure);
+            self.state.lock().append_retained_error(pending_error);
         }
         let failed = matches!(
             self.state.lock().connection,
@@ -754,7 +752,7 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> IOPollable for BrokerTc
         }
         let state = self.state.lock();
         let connection = state.connection;
-        let has_async_error = state.async_error != 0;
+        let has_async_error = state.async_error.is_some();
         drop(state);
         if has_async_error {
             events.insert(Events::ERR);
@@ -1333,21 +1331,21 @@ mod tests {
             connection: SocketConnectionStatus::Connected,
             local_address: None,
             remote_address: None,
-            async_error: SocketAsyncError::NetworkUnreachable as u32,
-            next_async_error: 0,
-            async_error_is_connection_failure: false,
-            next_async_error_is_connection_failure: false,
+            async_error: Some(BrokerTcpAsyncError::Other(
+                SocketAsyncError::NetworkUnreachable,
+            )),
+            next_async_error: None,
             listening: false,
         };
 
         state.prepend_async_error(SocketAsyncError::ConnectionRefused);
 
         assert_eq!(
-            SocketAsyncError::from_u32(state.take_async_error()),
+            state.take_async_error(),
             Some(SocketAsyncError::ConnectionRefused)
         );
         assert_eq!(
-            SocketAsyncError::from_u32(state.take_async_error()),
+            state.take_async_error(),
             Some(SocketAsyncError::NetworkUnreachable)
         );
     }
@@ -1358,10 +1356,8 @@ mod tests {
             connection: SocketConnectionStatus::Connected,
             local_address: None,
             remote_address: None,
-            async_error: 0,
-            next_async_error: 0,
-            async_error_is_connection_failure: false,
-            next_async_error_is_connection_failure: false,
+            async_error: None,
+            next_async_error: None,
             listening: false,
         };
 
@@ -1369,15 +1365,12 @@ mod tests {
         state.prepend_async_error(SocketAsyncError::ConnectionRefused);
         state.prepend_async_error(SocketAsyncError::TimedOut);
 
+        assert_eq!(state.take_async_error(), Some(SocketAsyncError::TimedOut));
         assert_eq!(
-            SocketAsyncError::from_u32(state.take_async_error()),
-            Some(SocketAsyncError::TimedOut)
-        );
-        assert_eq!(
-            SocketAsyncError::from_u32(state.take_async_error()),
+            state.take_async_error(),
             Some(SocketAsyncError::ConnectionRefused)
         );
-        assert_eq!(state.take_async_error(), 0);
+        assert_eq!(state.take_async_error(), None);
     }
 
     #[test]
@@ -1386,21 +1379,21 @@ mod tests {
             connection: SocketConnectionStatus::Connected,
             local_address: None,
             remote_address: None,
-            async_error: SocketAsyncError::NetworkUnreachable as u32,
-            next_async_error: 0,
-            async_error_is_connection_failure: false,
-            next_async_error_is_connection_failure: false,
+            async_error: Some(BrokerTcpAsyncError::Other(
+                SocketAsyncError::NetworkUnreachable,
+            )),
+            next_async_error: None,
             listening: false,
         };
 
         state.append_async_error(SocketAsyncError::ConnectionRefused);
 
         assert_eq!(
-            SocketAsyncError::from_u32(state.take_async_error()),
+            state.take_async_error(),
             Some(SocketAsyncError::NetworkUnreachable)
         );
         assert_eq!(
-            SocketAsyncError::from_u32(state.take_async_error()),
+            state.take_async_error(),
             Some(SocketAsyncError::ConnectionRefused)
         );
     }
@@ -1411,20 +1404,22 @@ mod tests {
             connection: SocketConnectionStatus::Failed(BrokerSocketError::ConnectionRefused),
             local_address: None,
             remote_address: None,
-            async_error: SocketAsyncError::ConnectionRefused as u32,
-            next_async_error: SocketAsyncError::ConnectionRefused as u32,
-            async_error_is_connection_failure: false,
-            next_async_error_is_connection_failure: true,
+            async_error: Some(BrokerTcpAsyncError::Other(
+                SocketAsyncError::ConnectionRefused,
+            )),
+            next_async_error: Some(BrokerTcpAsyncError::ConnectionFailure(
+                SocketAsyncError::ConnectionRefused,
+            )),
             listening: false,
         };
 
         state.take_connection_failure();
 
         assert_eq!(
-            SocketAsyncError::from_u32(state.take_async_error()),
+            state.take_async_error(),
             Some(SocketAsyncError::ConnectionRefused)
         );
-        assert_eq!(state.take_async_error(), 0);
+        assert_eq!(state.take_async_error(), None);
     }
 
     #[test]

--- a/litebox/src/net/broker_socket.rs
+++ b/litebox/src/net/broker_socket.rs
@@ -1325,31 +1325,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn restored_tcp_error_precedes_retained_predecessor() {
-        let mut state = BrokerTcpSocketState {
-            connection: SocketConnectionStatus::Connected,
-            local_address: None,
-            remote_address: None,
-            async_error: Some(BrokerTcpAsyncError::Other(
-                SocketAsyncError::NetworkUnreachable,
-            )),
-            next_async_error: None,
-            listening: false,
-        };
-
-        state.prepend_async_error(SocketAsyncError::ConnectionRefused);
-
-        assert_eq!(
-            state.take_async_error(),
-            Some(SocketAsyncError::ConnectionRefused)
-        );
-        assert_eq!(
-            state.take_async_error(),
-            Some(SocketAsyncError::NetworkUnreachable)
-        );
-    }
-
-    #[test]
     fn tcp_error_retention_is_bounded_to_current_and_predecessor() {
         let mut state = BrokerTcpSocketState {
             connection: SocketConnectionStatus::Connected,

--- a/litebox/src/net/broker_socket.rs
+++ b/litebox/src/net/broker_socket.rs
@@ -109,7 +109,7 @@ pub struct BrokerTcpSocket<Platform: RawSyncPrimitivesProvider + TimeProvider> {
     handle: ObjectHandle,
     pollable_registry: Arc<BrokerPollableRegistry<Platform>>,
     pollee: Arc<Pollee<Platform>>,
-    configuration_lock: Mutex<Platform, ()>,
+    status_lock: Mutex<Platform, ()>,
     receive_lock: Mutex<Platform, ()>,
     state: Mutex<Platform, BrokerTcpSocketState>,
     write_shutdown: AtomicBool,
@@ -129,7 +129,7 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
             handle,
             pollable_registry,
             pollee: Arc::new(Pollee::new()),
-            configuration_lock: Mutex::new(()),
+            status_lock: Mutex::new(()),
             receive_lock: Mutex::new(()),
             state: Mutex::new(BrokerTcpSocketState {
                 connection: SocketConnectionStatus::Unconnected,
@@ -158,7 +158,7 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
             handle: accepted.handle,
             pollable_registry,
             pollee: Arc::new(Pollee::new()),
-            configuration_lock: Mutex::new(()),
+            status_lock: Mutex::new(()),
             receive_lock: Mutex::new(()),
             state: Mutex::new(BrokerTcpSocketState {
                 connection: SocketConnectionStatus::Connected,
@@ -238,7 +238,7 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
     }
 
     pub(super) fn start_connect(&self, address: SocketAddrV4) -> Result<(), ConnectError> {
-        let configuration = self.configuration_lock.lock();
+        let status_guard = self.status_lock.lock();
         let previous = self.state.lock().connection;
         let outcome = self
             .broker
@@ -268,7 +268,7 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
             SocketConnectionStatus::Failed(error) => {
                 let error = error.into();
                 self.state.lock().take_connection_failure();
-                drop(configuration);
+                drop(status_guard);
                 self.pollee.wake_observers();
                 self.pollee
                     .notify_observers(Events::IN | Events::OUT | Events::HUP);
@@ -279,12 +279,12 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
                 SocketAsyncError::BackendFailure,
             )),
         };
-        drop(configuration);
+        drop(status_guard);
         result
     }
 
     pub(super) fn check_connect_progress(&self) -> Result<(), ConnectError> {
-        let configuration = self.configuration_lock.lock();
+        let status_guard = self.status_lock.lock();
         let response = self.broker.socket_status(self.handle).map_err(|error| {
             ConnectError::OperationFailed(BrokerObjectError::from(error).into())
         })?;
@@ -293,14 +293,14 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
             let error = error.into();
             self.apply_socket_status(response);
             self.state.lock().take_connection_failure();
-            drop(configuration);
+            drop(status_guard);
             self.pollee.wake_observers();
             self.pollee
                 .notify_observers(Events::IN | Events::OUT | Events::HUP);
             return Err(ConnectError::OperationFailed(error));
         }
         self.apply_socket_status(response);
-        drop(configuration);
+        drop(status_guard);
         match status {
             SocketConnectionStatus::Connected => Ok(()),
             SocketConnectionStatus::Connecting => Err(ConnectError::InProgress),
@@ -446,9 +446,9 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
         if self.closed.load(Ordering::Acquire) {
             return;
         }
-        let configuration = self.configuration_lock.lock();
+        let status_guard = self.status_lock.lock();
         self.state.lock().prepend_async_error(error);
-        drop(configuration);
+        drop(status_guard);
         self.pollee.notify_observers(Events::ERR);
     }
 
@@ -456,7 +456,7 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
         if self.closed.load(Ordering::Acquire) {
             return None;
         }
-        let configuration = self.configuration_lock.lock();
+        let status_guard = self.status_lock.lock();
         self.refresh_connection_status_locked(true);
         let mut state = self.state.lock();
         let error = if clear {
@@ -471,7 +471,7 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
             if needs_refill {
                 self.refresh_connection_status_locked(true);
             }
-            drop(configuration);
+            drop(status_guard);
             self.pollee.wake_observers();
             if failed {
                 self.pollee
@@ -605,7 +605,7 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
     }
 
     fn refresh_connection_status(&self, include_connected: bool) {
-        let _configuration = self.configuration_lock.lock();
+        let _status_guard = self.status_lock.lock();
         self.refresh_connection_status_locked(include_connected);
     }
 
@@ -668,7 +668,7 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
     }
 
     fn refresh_after_synchronous_error(&self) {
-        let configuration = self.configuration_lock.lock();
+        let status_guard = self.status_lock.lock();
         for _ in 0..2 {
             if self.closed.load(Ordering::Acquire) {
                 break;
@@ -702,7 +702,7 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
             SocketConnectionStatus::Failed(_)
         );
         self.state.lock().take_connection_failure();
-        drop(configuration);
+        drop(status_guard);
         self.pollee.wake_observers();
         if failed {
             self.pollee

--- a/litebox/src/net/broker_socket.rs
+++ b/litebox/src/net/broker_socket.rs
@@ -62,10 +62,6 @@ impl BrokerTcpSocketState {
         self.async_error = Some(BrokerTcpAsyncError::Other(error));
     }
 
-    fn append_async_error(&mut self, error: SocketAsyncError) {
-        self.append_retained_error(BrokerTcpAsyncError::Other(error));
-    }
-
     fn append_retained_error(&mut self, error: BrokerTcpAsyncError) {
         let error = Some(error);
         if self.async_error.is_none() {
@@ -689,7 +685,9 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
                 Err(error) if !self.closed.load(Ordering::Acquire) => {
                     self.state
                         .lock()
-                        .append_async_error(BrokerObjectError::from(error).into());
+                        .append_retained_error(BrokerTcpAsyncError::Other(
+                            BrokerObjectError::from(error).into(),
+                        ));
                     break;
                 }
                 Err(_) => break,
@@ -1386,7 +1384,9 @@ mod tests {
             listening: false,
         };
 
-        state.append_async_error(SocketAsyncError::ConnectionRefused);
+        state.append_retained_error(BrokerTcpAsyncError::Other(
+            SocketAsyncError::ConnectionRefused,
+        ));
 
         assert_eq!(
             state.take_async_error(),

--- a/litebox/src/net/broker_socket.rs
+++ b/litebox/src/net/broker_socket.rs
@@ -667,6 +667,7 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
             })
     }
 
+    /// Refreshes status after a synchronous failure, draining both backend error slots.
     fn refresh_after_synchronous_error(&self) {
         let status_guard = self.status_lock.lock();
         for _ in 0..2 {

--- a/litebox/src/net/broker_socket.rs
+++ b/litebox/src/net/broker_socket.rs
@@ -270,6 +270,11 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
             SocketConnectionStatus::Connecting => Err(ConnectError::InProgress),
             SocketConnectionStatus::Failed(error) => {
                 let error = error.into();
+                self.state.lock().take_connection_failure();
+                drop(configuration);
+                self.pollee.wake_observers();
+                self.pollee
+                    .notify_observers(Events::IN | Events::OUT | Events::HUP);
                 return Err(ConnectError::OperationFailed(error));
             }
             SocketConnectionStatus::Unconnected => Err(ConnectError::InvalidState),
@@ -700,6 +705,7 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
             self.state.lock().connection,
             SocketConnectionStatus::Failed(_)
         );
+        self.state.lock().take_connection_failure();
         drop(configuration);
         self.pollee.wake_observers();
         if failed {

--- a/litebox/src/net/broker_socket.rs
+++ b/litebox/src/net/broker_socket.rs
@@ -38,10 +38,25 @@ struct BrokerTcpSocketState {
     local_address: Option<SocketAddrV4>,
     remote_address: Option<SocketAddrV4>,
     async_error: u32,
+    next_async_error: u32,
     listening: bool,
 }
 
 impl BrokerTcpSocketState {
+    fn prepend_async_error(&mut self, error: SocketAsyncError) {
+        if self.async_error != 0 {
+            self.next_async_error = self.async_error;
+        }
+        self.async_error = error as u32;
+    }
+
+    fn take_async_error(&mut self) -> u32 {
+        let error = self.async_error;
+        self.async_error = self.next_async_error;
+        self.next_async_error = 0;
+        error
+    }
+
     fn update_connection(&mut self, connection: SocketConnectionStatus) -> SocketConnectionStatus {
         if matches!(
             self.connection,
@@ -85,6 +100,7 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
                 local_address: None,
                 remote_address: None,
                 async_error: 0,
+                next_async_error: 0,
                 listening: false,
             }),
             write_shutdown: AtomicBool::new(false),
@@ -112,6 +128,7 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
                 local_address: Some(accepted.local_address),
                 remote_address: Some(accepted.remote_address),
                 async_error: 0,
+                next_async_error: 0,
                 listening: false,
             }),
             write_shutdown: AtomicBool::new(false),
@@ -347,7 +364,7 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
         if self.closed.load(Ordering::Acquire) {
             return;
         }
-        self.state.lock().async_error = error as u32;
+        self.state.lock().prepend_async_error(error);
     }
 
     pub(super) fn get_async_error(&self, clear: bool) -> Option<SocketAsyncError> {
@@ -358,13 +375,20 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
         let mut state = self.state.lock();
         let raw = state.async_error;
         if clear {
-            state.async_error = 0;
+            state.take_async_error();
         }
+        let needs_refill = clear && raw != 0 && state.async_error == 0;
         let failed = matches!(state.connection, SocketConnectionStatus::Failed(_));
         drop(state);
-        if clear && raw != 0 && failed {
-            self.pollee
-                .notify_observers(Events::IN | Events::OUT | Events::HUP);
+        if clear && raw != 0 {
+            if needs_refill {
+                self.refresh_connection_status(true);
+            }
+            self.pollee.wake_observers();
+            if failed {
+                self.pollee
+                    .notify_observers(Events::IN | Events::OUT | Events::HUP);
+            }
         }
         SocketAsyncError::from_u32(raw)
     }
@@ -524,7 +548,12 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
         if self.closed.load(Ordering::Acquire) {
             return;
         }
-        let connection = self.state.lock().connection;
+        let state = self.state.lock();
+        if state.async_error != 0 {
+            return;
+        }
+        let connection = state.connection;
+        drop(state);
         if connection != SocketConnectionStatus::Connecting
             && !(include_connected && connection == SocketConnectionStatus::Connected)
         {
@@ -554,17 +583,19 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
             state.local_address = Some(address);
         }
 
-        if let Some(error) = response.pending_error {
-            state.async_error = SocketAsyncError::from(error) as u32;
-        } else if let Some(error) = connection_error {
-            state.async_error = SocketAsyncError::from(error) as u32;
+        if state.async_error == 0 {
+            if let Some(error) = response.pending_error {
+                state.async_error = SocketAsyncError::from(error) as u32;
+            } else if let Some(error) = connection_error {
+                state.async_error = SocketAsyncError::from(error) as u32;
+            }
         }
     }
 
     fn consume_synchronous_error(&self) {
         self.refresh_connection_status(true);
         let mut state = self.state.lock();
-        state.async_error = 0;
+        state.take_async_error();
         let failed = matches!(state.connection, SocketConnectionStatus::Failed(_));
         drop(state);
         if failed {
@@ -1185,6 +1216,55 @@ impl From<BrokerSocketError> for SocketAsyncError {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn restored_tcp_error_precedes_retained_predecessor() {
+        let mut state = BrokerTcpSocketState {
+            connection: SocketConnectionStatus::Connected,
+            local_address: None,
+            remote_address: None,
+            async_error: SocketAsyncError::NetworkUnreachable as u32,
+            next_async_error: 0,
+            listening: false,
+        };
+
+        state.prepend_async_error(SocketAsyncError::ConnectionRefused);
+
+        assert_eq!(
+            SocketAsyncError::from_u32(state.take_async_error()),
+            Some(SocketAsyncError::ConnectionRefused)
+        );
+        assert_eq!(
+            SocketAsyncError::from_u32(state.take_async_error()),
+            Some(SocketAsyncError::NetworkUnreachable)
+        );
+    }
+
+    #[test]
+    fn tcp_error_retention_is_bounded_to_current_and_predecessor() {
+        let mut state = BrokerTcpSocketState {
+            connection: SocketConnectionStatus::Connected,
+            local_address: None,
+            remote_address: None,
+            async_error: 0,
+            next_async_error: 0,
+            listening: false,
+        };
+
+        state.prepend_async_error(SocketAsyncError::NetworkUnreachable);
+        state.prepend_async_error(SocketAsyncError::ConnectionRefused);
+        state.prepend_async_error(SocketAsyncError::TimedOut);
+
+        assert_eq!(
+            SocketAsyncError::from_u32(state.take_async_error()),
+            Some(SocketAsyncError::TimedOut)
+        );
+        assert_eq!(
+            SocketAsyncError::from_u32(state.take_async_error()),
+            Some(SocketAsyncError::ConnectionRefused)
+        );
+        assert_eq!(state.take_async_error(), 0);
+    }
 
     #[test]
     fn restored_udp_error_precedes_prefetched_successor() {

--- a/litebox/src/net/broker_socket.rs
+++ b/litebox/src/net/broker_socket.rs
@@ -251,6 +251,13 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
         })?;
         let status = response.status;
         self.apply_socket_status(response);
+        if let SocketConnectionStatus::Failed(error) = status {
+            let error = error.into();
+            let failed = self.consume_synchronous_error_locked(error);
+            drop(configuration);
+            self.notify_synchronous_error_consumed(failed);
+            return Err(ConnectError::OperationFailed(error));
+        }
         drop(configuration);
         self.handle_connect_status(status, None)
     }
@@ -630,6 +637,12 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
 
     fn consume_synchronous_error(&self, synchronous_error: SocketAsyncError) {
         let configuration = self.configuration_lock.lock();
+        let failed = self.consume_synchronous_error_locked(synchronous_error);
+        drop(configuration);
+        self.notify_synchronous_error_consumed(failed);
+    }
+
+    fn consume_synchronous_error_locked(&self, synchronous_error: SocketAsyncError) -> bool {
         let mut matched = self.state.lock().remove_async_error(synchronous_error);
         for _ in 0..2 {
             if self.closed.load(Ordering::Acquire) {
@@ -681,7 +694,10 @@ impl<Platform: RawSyncPrimitivesProvider + TimeProvider> BrokerTcpSocket<Platfor
         let state = self.state.lock();
         let failed = matches!(state.connection, SocketConnectionStatus::Failed(_));
         drop(state);
-        drop(configuration);
+        failed
+    }
+
+    fn notify_synchronous_error_consumed(&self, failed: bool) {
         self.pollee.wake_observers();
         if failed {
             self.pollee

--- a/litebox_broker_platform_linux_userland/src/socket.rs
+++ b/litebox_broker_platform_linux_userland/src/socket.rs
@@ -1955,25 +1955,30 @@ fn local_socket_address(socket: &OwnedFd) -> BrokerResult<SocketAddrV4> {
 fn status_socket(socket: &mut SocketEntry) -> BrokerResult<PlatformSocketStatus> {
     let query_socket_error = socket.connection_status == SocketConnectionStatus::Connected
         && socket.snapshot.load().contains(ReadinessFlags::ERROR);
-    let socket_error = if query_socket_error {
-        take_socket_error(socket)?
-    } else {
-        None
-    };
+    if query_socket_error && let Some(error) = take_socket_error(socket)? {
+        if socket.pending_error.is_none() {
+            socket.pending_error = Some(error);
+        } else if socket.tcp_state()?.next_pending_error.is_none() {
+            socket.tcp_state_mut()?.next_pending_error = Some(error);
+        }
+    }
     let pending_guest_reset = guest_reset_pending(socket)?;
     let status = socket.connection_status;
     let local_address = socket.guest_local_address;
-    let cached_error = socket.pending_error.take();
-    let socket_error = if pending_guest_reset && cached_error != Some(SocketError::ConnectionReset)
+    if pending_guest_reset
+        && socket.pending_error != Some(SocketError::ConnectionReset)
+        && socket.tcp_state()?.next_pending_error != Some(SocketError::ConnectionReset)
     {
-        Some(SocketError::ConnectionReset)
-    } else {
-        socket_error
-    };
-    let (pending_error, next_pending_error) = shift_pending_error(cached_error, socket_error);
-    socket.pending_error = next_pending_error;
+        if socket.pending_error.is_none() {
+            socket.pending_error = Some(SocketError::ConnectionReset);
+        } else if socket.tcp_state()?.next_pending_error.is_none() {
+            socket.tcp_state_mut()?.next_pending_error = Some(SocketError::ConnectionReset);
+        }
+    }
+    let pending_error = socket.pending_error.take();
+    socket.pending_error = socket.tcp_state_mut()?.next_pending_error.take();
     let mut readiness = socket.snapshot.load();
-    if pending_error.is_some() && next_pending_error.is_none() {
+    if pending_error.is_some() && socket.pending_error.is_none() {
         readiness = ReadinessFlags(readiness.0 & !ReadinessFlags::ERROR.0);
         socket.snapshot.store(readiness);
     }
@@ -1982,10 +1987,10 @@ fn status_socket(socket: &mut SocketEntry) -> BrokerResult<PlatformSocketStatus>
         local_address,
         pending_error,
     };
-    let republish_error = next_pending_error.is_some();
+    let republish_error = socket.pending_error.is_some();
     if pending_guest_reset
         && response.pending_error == Some(SocketError::ConnectionReset)
-        && !consume_pending_guest_reset(socket)?
+        && !consume_pending_guest_reset(socket, false)?
     {
         return Err(BrokerError::Internal);
     }
@@ -2001,16 +2006,6 @@ fn status_socket(socket: &mut SocketEntry) -> BrokerResult<PlatformSocketStatus>
     // caller's only observation of that error.
     let _ = publication;
     Ok(response)
-}
-
-fn shift_pending_error(
-    cached_error: Option<SocketError>,
-    socket_error: Option<SocketError>,
-) -> (Option<SocketError>, Option<SocketError>) {
-    match cached_error {
-        Some(error) => (Some(error), socket_error),
-        None => (socket_error, None),
-    }
 }
 
 const fn socket_kind(request: CreateSocketRequest) -> Option<SocketKind> {

--- a/litebox_broker_platform_linux_userland/src/socket.rs
+++ b/litebox_broker_platform_linux_userland/src/socket.rs
@@ -42,7 +42,7 @@ mod udp;
 #[cfg(test)]
 use tcp::TcpDescriptor;
 use tcp::{
-    AcceptedEndpoints, ReactorReceiveOutcome, ReactorTcpState, TcpSocketState,
+    AcceptedEndpoints, ReactorReceiveOutcome, ReactorTcpState, TcpPendingError, TcpSocketState,
     consume_pending_guest_reset, create_tcp_transport, guest_reset_pending, handle_socket_event,
 };
 use udp::{
@@ -1956,40 +1956,34 @@ fn status_socket(socket: &mut SocketEntry) -> BrokerResult<PlatformSocketStatus>
     let query_socket_error = socket.connection_status == SocketConnectionStatus::Connected
         && socket.snapshot.load().contains(ReadinessFlags::ERROR);
     if query_socket_error && let Some(error) = take_socket_error(socket)? {
-        if socket.pending_error.is_none() {
-            socket.pending_error = Some(error);
-        } else if socket.tcp_state()?.next_pending_error.is_none() {
-            socket.tcp_state_mut()?.next_pending_error = Some(error);
-        }
+        socket
+            .tcp_state_mut()?
+            .pending_errors
+            .append(TcpPendingError::Socket(error));
     }
     let pending_guest_reset = guest_reset_pending(socket)?;
     let status = socket.connection_status;
     let local_address = socket.guest_local_address;
-    if pending_guest_reset
-        && socket.pending_error != Some(SocketError::ConnectionReset)
-        && socket.tcp_state()?.next_pending_error != Some(SocketError::ConnectionReset)
-    {
-        if socket.pending_error.is_none() {
-            socket.pending_error = Some(SocketError::ConnectionReset);
-        } else if socket.tcp_state()?.next_pending_error.is_none() {
-            socket.tcp_state_mut()?.next_pending_error = Some(SocketError::ConnectionReset);
-        }
+    if pending_guest_reset && !socket.tcp_state()?.pending_errors.contains_guest_reset() {
+        socket
+            .tcp_state_mut()?
+            .pending_errors
+            .append(TcpPendingError::GuestReset);
     }
-    let pending_error = socket.pending_error.take();
-    socket.pending_error = socket.tcp_state_mut()?.next_pending_error.take();
+    let pending_error = socket.tcp_state_mut()?.pending_errors.take();
     let mut readiness = socket.snapshot.load();
-    if pending_error.is_some() && socket.pending_error.is_none() {
+    if pending_error.is_some() && socket.tcp_state()?.pending_errors.is_empty() {
         readiness = ReadinessFlags(readiness.0 & !ReadinessFlags::ERROR.0);
         socket.snapshot.store(readiness);
     }
     let response = PlatformSocketStatus {
         status,
         local_address,
-        pending_error,
+        pending_error: pending_error.map(TcpPendingError::error),
     };
-    let republish_error = socket.pending_error.is_some();
+    let republish_error = !socket.tcp_state()?.pending_errors.is_empty();
     if pending_guest_reset
-        && response.pending_error == Some(SocketError::ConnectionReset)
+        && matches!(pending_error, Some(TcpPendingError::GuestReset))
         && !consume_pending_guest_reset(socket, false)?
     {
         return Err(BrokerError::Internal);

--- a/litebox_broker_platform_linux_userland/src/socket/tcp.rs
+++ b/litebox_broker_platform_linux_userland/src/socket/tcp.rs
@@ -59,6 +59,7 @@ pub(super) struct TcpSocketState {
     pub(super) listener: Option<GuestTcpListenerState>,
     pub(super) guest_endpoint: Option<GuestTcpEndpoint>,
     pub(super) peek_waitall_threshold: Option<usize>,
+    pub(super) next_pending_error: Option<SocketError>,
     guest_read_shutdown: Option<GuestTcpReadShutdown>,
     pub(super) abortive_close: bool,
     pub(super) no_delay: bool,
@@ -178,6 +179,7 @@ pub(super) fn create_tcp_transport() -> SocketTransportState {
         listener: None,
         guest_endpoint: None,
         peek_waitall_threshold: None,
+        next_pending_error: None,
         guest_read_shutdown: None,
         abortive_close: false,
         no_delay: false,
@@ -250,19 +252,29 @@ fn clear_readiness(socket: &SocketEntry, readiness: ReadinessFlags) -> BrokerRes
     update_snapshot(socket, ReadinessFlags(current.0 & !readiness.0))
 }
 
-fn consume_synchronous_error(socket: &mut SocketEntry) -> BrokerResult<()> {
+fn consume_synchronous_error(
+    socket: &mut SocketEntry,
+    synchronous_error: SocketError,
+) -> BrokerResult<()> {
     if !can_consume_synchronous_error(socket.connection_status) {
         return Ok(());
     }
-    if socket.pending_error.is_none() {
-        socket.pending_error = take_socket_error(socket)?;
+    if let Some(error) = take_socket_error(socket)?
+        && error != synchronous_error
+    {
+        if socket.pending_error.is_none() {
+            socket.pending_error = Some(error);
+        } else if socket.tcp_state()?.next_pending_error.is_none() {
+            socket.tcp_state_mut()?.next_pending_error = Some(error);
+        }
     }
     let current = socket.snapshot.load();
-    let readiness = if socket.pending_error.is_some() {
-        current | ReadinessFlags::ERROR
-    } else {
-        ReadinessFlags(current.0 & !ReadinessFlags::ERROR.0)
-    };
+    let readiness =
+        if socket.pending_error.is_some() || socket.tcp_state()?.next_pending_error.is_some() {
+            current | ReadinessFlags::ERROR
+        } else {
+            ReadinessFlags(current.0 & !ReadinessFlags::ERROR.0)
+        };
     update_snapshot(socket, readiness)
 }
 
@@ -473,7 +485,7 @@ pub(super) fn send_socket(
         return Ok(SocketOutcome::Failed(SocketError::Other));
     }
     if guest_reset_pending(socket)? {
-        if !consume_pending_guest_reset(socket)? {
+        if !consume_pending_guest_reset(socket, true)? {
             return Err(BrokerError::Internal);
         }
         return Ok(SocketOutcome::Failed(SocketError::ConnectionReset));
@@ -505,7 +517,7 @@ pub(super) fn send_socket(
             Err(error) => {
                 let error = socket_operation_error_from_errno(error)?;
                 fail_connect(socket, error);
-                let _ = consume_synchronous_error(socket);
+                let _ = consume_synchronous_error(socket, error);
                 return Ok(SocketOutcome::Failed(error));
             }
         }
@@ -558,7 +570,7 @@ pub(super) fn receive_socket(
             return Ok(outcome);
         }
         if guest_reset_pending(socket)? {
-            if !consume_pending_guest_reset(socket)? {
+            if !consume_pending_guest_reset(socket, true)? {
                 return Err(BrokerError::Internal);
             }
             return Ok(ReactorReceiveOutcome::Failed(SocketError::ConnectionReset));
@@ -569,7 +581,7 @@ pub(super) fn receive_socket(
         let available = ioctl_fionread(socket.tcp_state()?.descriptor.socket()?)
             .map_err(broker_error_from_errno)?;
         if available == 0 {
-            if !consume_pending_guest_reset(socket)? {
+            if !consume_pending_guest_reset(socket, true)? {
                 return Err(BrokerError::Internal);
             }
             return Ok(ReactorReceiveOutcome::Failed(SocketError::ConnectionReset));
@@ -724,7 +736,7 @@ fn receive_socket_once(
             Err(error) => {
                 let error = socket_operation_error_from_errno(error)?;
                 fail_connect(socket, error);
-                let _ = consume_synchronous_error(socket);
+                let _ = consume_synchronous_error(socket, error);
                 return Ok(ReactorReceiveOutcome::Failed(error));
             }
         }
@@ -1956,6 +1968,7 @@ impl Reactor {
                         reset_state: GuestTcpResetState::None,
                     }),
                     peek_waitall_threshold: None,
+                    next_pending_error: None,
                     guest_read_shutdown: None,
                     abortive_close: false,
                     no_delay: listener_tcp_no_delay,
@@ -1993,7 +2006,10 @@ pub(super) fn guest_reset_pending(socket: &SocketEntry) -> BrokerResult<bool> {
         .is_some_and(|endpoint| endpoint.reset_state == GuestTcpResetState::Pending))
 }
 
-pub(super) fn consume_pending_guest_reset(socket: &mut SocketEntry) -> BrokerResult<bool> {
+pub(super) fn consume_pending_guest_reset(
+    socket: &mut SocketEntry,
+    remove_queued_error: bool,
+) -> BrokerResult<bool> {
     let consumed = {
         let tcp = socket.tcp_state_mut()?;
         let Some(endpoint) = tcp.guest_endpoint.as_mut() else {
@@ -2005,13 +2021,20 @@ pub(super) fn consume_pending_guest_reset(socket: &mut SocketEntry) -> BrokerRes
         endpoint.reset_state = GuestTcpResetState::Reported;
         true
     };
-    if consumed {
-        if socket.pending_error == Some(SocketError::ConnectionReset) {
-            socket.pending_error = None;
+    if consumed && remove_queued_error {
+        if socket.tcp_state()?.next_pending_error == Some(SocketError::ConnectionReset) {
+            socket.tcp_state_mut()?.next_pending_error = None;
+        } else if socket.pending_error == Some(SocketError::ConnectionReset) {
+            socket.pending_error = socket.tcp_state_mut()?.next_pending_error.take();
         }
+    }
+    if consumed {
         let cleared_readiness = {
             let readiness = socket.snapshot.load();
-            if socket.pending_error.is_none() && readiness.contains(ReadinessFlags::ERROR) {
+            if socket.pending_error.is_none()
+                && socket.tcp_state()?.next_pending_error.is_none()
+                && readiness.contains(ReadinessFlags::ERROR)
+            {
                 let readiness = ReadinessFlags(readiness.0 & !ReadinessFlags::ERROR.0);
                 socket.snapshot.store(readiness);
                 Some(readiness)

--- a/litebox_broker_platform_linux_userland/src/socket/tcp.rs
+++ b/litebox_broker_platform_linux_userland/src/socket/tcp.rs
@@ -53,6 +53,8 @@ pub(super) struct PeekCache {
     pub(super) data: Vec<u8>,
 }
 
+/// Retains an error's source so a guest reset remains distinguishable from an
+/// independent socket `ConnectionReset` even though both have the same public value.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) enum TcpPendingError {
     Socket(SocketError),

--- a/litebox_broker_platform_linux_userland/src/socket/tcp.rs
+++ b/litebox_broker_platform_linux_userland/src/socket/tcp.rs
@@ -252,16 +252,11 @@ fn clear_readiness(socket: &SocketEntry, readiness: ReadinessFlags) -> BrokerRes
     update_snapshot(socket, ReadinessFlags(current.0 & !readiness.0))
 }
 
-fn consume_synchronous_error(
-    socket: &mut SocketEntry,
-    synchronous_error: SocketError,
-) -> BrokerResult<()> {
+fn consume_synchronous_error(socket: &mut SocketEntry) -> BrokerResult<()> {
     if !can_consume_synchronous_error(socket.connection_status) {
         return Ok(());
     }
-    if let Some(error) = take_socket_error(socket)?
-        && error != synchronous_error
-    {
+    if let Some(error) = take_socket_error(socket)? {
         if socket.pending_error.is_none() {
             socket.pending_error = Some(error);
         } else if socket.tcp_state()?.next_pending_error.is_none() {
@@ -517,7 +512,7 @@ pub(super) fn send_socket(
             Err(error) => {
                 let error = socket_operation_error_from_errno(error)?;
                 fail_connect(socket, error);
-                let _ = consume_synchronous_error(socket, error);
+                let _ = consume_synchronous_error(socket);
                 return Ok(SocketOutcome::Failed(error));
             }
         }
@@ -736,7 +731,7 @@ fn receive_socket_once(
             Err(error) => {
                 let error = socket_operation_error_from_errno(error)?;
                 fail_connect(socket, error);
-                let _ = consume_synchronous_error(socket, error);
+                let _ = consume_synchronous_error(socket);
                 return Ok(ReactorReceiveOutcome::Failed(error));
             }
         }

--- a/litebox_broker_platform_linux_userland/src/socket/tcp.rs
+++ b/litebox_broker_platform_linux_userland/src/socket/tcp.rs
@@ -53,13 +53,70 @@ pub(super) struct PeekCache {
     pub(super) data: Vec<u8>,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum TcpPendingError {
+    Socket(SocketError),
+    GuestReset,
+}
+
+impl TcpPendingError {
+    pub(super) fn error(self) -> SocketError {
+        match self {
+            Self::Socket(error) => error,
+            Self::GuestReset => SocketError::ConnectionReset,
+        }
+    }
+}
+
+#[derive(Default)]
+pub(super) struct TcpPendingErrors {
+    current: Option<TcpPendingError>,
+    next: Option<TcpPendingError>,
+}
+
+impl TcpPendingErrors {
+    pub(super) fn append(&mut self, error: TcpPendingError) {
+        if error == TcpPendingError::GuestReset && self.contains_guest_reset() {
+            return;
+        }
+        if self.current.is_none() {
+            self.current = Some(error);
+        } else if self.next.is_none() {
+            self.next = Some(error);
+        }
+    }
+
+    pub(super) fn take(&mut self) -> Option<TcpPendingError> {
+        let error = self.current.take();
+        self.current = self.next.take();
+        error
+    }
+
+    pub(super) fn contains_guest_reset(&self) -> bool {
+        matches!(self.current, Some(TcpPendingError::GuestReset))
+            || matches!(self.next, Some(TcpPendingError::GuestReset))
+    }
+
+    pub(super) fn remove_guest_reset(&mut self) {
+        if matches!(self.next, Some(TcpPendingError::GuestReset)) {
+            self.next = None;
+        } else if matches!(self.current, Some(TcpPendingError::GuestReset)) {
+            self.take();
+        }
+    }
+
+    pub(super) fn is_empty(&self) -> bool {
+        self.current.is_none()
+    }
+}
+
 /// Reactor-owned TCP descriptor and transport-specific lifecycle state.
 pub(super) struct TcpSocketState {
     pub(super) descriptor: TcpDescriptor,
     pub(super) listener: Option<GuestTcpListenerState>,
     pub(super) guest_endpoint: Option<GuestTcpEndpoint>,
     pub(super) peek_waitall_threshold: Option<usize>,
-    pub(super) next_pending_error: Option<SocketError>,
+    pub(super) pending_errors: TcpPendingErrors,
     guest_read_shutdown: Option<GuestTcpReadShutdown>,
     pub(super) abortive_close: bool,
     pub(super) no_delay: bool,
@@ -179,7 +236,7 @@ pub(super) fn create_tcp_transport() -> SocketTransportState {
         listener: None,
         guest_endpoint: None,
         peek_waitall_threshold: None,
-        next_pending_error: None,
+        pending_errors: TcpPendingErrors::default(),
         guest_read_shutdown: None,
         abortive_close: false,
         no_delay: false,
@@ -257,19 +314,17 @@ fn consume_synchronous_error(socket: &mut SocketEntry) -> BrokerResult<()> {
         return Ok(());
     }
     if let Some(error) = take_socket_error(socket)? {
-        if socket.pending_error.is_none() {
-            socket.pending_error = Some(error);
-        } else if socket.tcp_state()?.next_pending_error.is_none() {
-            socket.tcp_state_mut()?.next_pending_error = Some(error);
-        }
+        socket
+            .tcp_state_mut()?
+            .pending_errors
+            .append(TcpPendingError::Socket(error));
     }
     let current = socket.snapshot.load();
-    let readiness =
-        if socket.pending_error.is_some() || socket.tcp_state()?.next_pending_error.is_some() {
-            current | ReadinessFlags::ERROR
-        } else {
-            ReadinessFlags(current.0 & !ReadinessFlags::ERROR.0)
-        };
+    let readiness = if socket.tcp_state()?.pending_errors.is_empty() {
+        ReadinessFlags(current.0 & !ReadinessFlags::ERROR.0)
+    } else {
+        current | ReadinessFlags::ERROR
+    };
     update_snapshot(socket, readiness)
 }
 
@@ -1692,9 +1747,7 @@ impl Reactor {
             GuestTcpResetState::Pending => {}
             GuestTcpResetState::Reported => return,
         }
-        if socket.pending_error.is_none() {
-            socket.pending_error = Some(SocketError::ConnectionReset);
-        }
+        tcp.pending_errors.append(TcpPendingError::GuestReset);
         let current = socket.snapshot.load();
         let readiness =
             current | ReadinessFlags::READ | ReadinessFlags::ERROR | ReadinessFlags::HANGUP;
@@ -1963,7 +2016,7 @@ impl Reactor {
                         reset_state: GuestTcpResetState::None,
                     }),
                     peek_waitall_threshold: None,
-                    next_pending_error: None,
+                    pending_errors: TcpPendingErrors::default(),
                     guest_read_shutdown: None,
                     abortive_close: false,
                     no_delay: listener_tcp_no_delay,
@@ -2017,17 +2070,12 @@ pub(super) fn consume_pending_guest_reset(
         true
     };
     if consumed && remove_queued_error {
-        if socket.tcp_state()?.next_pending_error == Some(SocketError::ConnectionReset) {
-            socket.tcp_state_mut()?.next_pending_error = None;
-        } else if socket.pending_error == Some(SocketError::ConnectionReset) {
-            socket.pending_error = socket.tcp_state_mut()?.next_pending_error.take();
-        }
+        socket.tcp_state_mut()?.pending_errors.remove_guest_reset();
     }
     if consumed {
         let cleared_readiness = {
             let readiness = socket.snapshot.load();
-            if socket.pending_error.is_none()
-                && socket.tcp_state()?.next_pending_error.is_none()
+            if socket.tcp_state()?.pending_errors.is_empty()
                 && readiness.contains(ReadinessFlags::ERROR)
             {
                 let readiness = ReadinessFlags(readiness.0 & !ReadinessFlags::ERROR.0);

--- a/litebox_broker_platform_linux_userland/src/socket/tests/mod.rs
+++ b/litebox_broker_platform_linux_userland/src/socket/tests/mod.rs
@@ -207,24 +207,6 @@ fn receive_datagram_into(
 }
 
 #[test]
-fn cached_socket_error_precedes_a_new_kernel_error() {
-    assert_eq!(
-        shift_pending_error(
-            Some(SocketError::ConnectionRefused),
-            Some(SocketError::NetworkUnreachable),
-        ),
-        (
-            Some(SocketError::ConnectionRefused),
-            Some(SocketError::NetworkUnreachable),
-        )
-    );
-    assert_eq!(
-        shift_pending_error(None, Some(SocketError::NetworkUnreachable)),
-        (Some(SocketError::NetworkUnreachable), None)
-    );
-}
-
-#[test]
 fn synchronous_errors_do_not_consume_tcp_connect_status() {
     assert!(!can_consume_synchronous_error(
         SocketConnectionStatus::Connecting,

--- a/litebox_broker_platform_linux_userland/src/socket/tests/mod.rs
+++ b/litebox_broker_platform_linux_userland/src/socket/tests/mod.rs
@@ -17,6 +17,7 @@ use litebox_broker_core::{
 use litebox_broker_protocol::ObjectHandle;
 use litebox_broker_protocol::socket::{Ipv4Address, Port, ReceiveSocketResponse};
 
+use super::tcp::TcpPendingErrors;
 use super::udp::{
     MAX_REJECTED_UDP_DATAGRAMS_PER_COMMAND, MAX_UDP_EXTERNAL_PEERS_PER_SOCKET,
     MAX_UDP_NATIVE_RECEIVE_BUFFER, MAX_UDP_QUEUE_DATAGRAMS_PER_SOURCE,
@@ -26,6 +27,22 @@ mod tcp;
 mod udp;
 
 const TEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[test]
+fn tcp_pending_errors_preserve_order_and_source() {
+    let mut errors = TcpPendingErrors::default();
+    errors.append(TcpPendingError::Socket(SocketError::ConnectionReset));
+    errors.append(TcpPendingError::GuestReset);
+    errors.append(TcpPendingError::GuestReset);
+
+    assert!(errors.contains_guest_reset());
+    assert_eq!(
+        errors.take(),
+        Some(TcpPendingError::Socket(SocketError::ConnectionReset))
+    );
+    assert_eq!(errors.take(), Some(TcpPendingError::GuestReset));
+    assert!(errors.is_empty());
+}
 
 fn gateway_tcp_policy() -> SocketPolicy {
     SocketPolicy::guest_network()


### PR DESCRIPTION
This PR preserves consecutive TCP asynchronous socket errors in bounded FIFO queues across LiteBox and the Linux broker backend, keeps equal-valued connection and socket error occurrences distinct where their source affects handling, and serializes destructive status reconciliation without blocking full-duplex reads and writes.