### PR TITLE
Implement mutant objects and thread basic queries for Windows shim

### DIFF
--- a/litebox_common_windows/src/nt_status.rs
+++ b/litebox_common_windows/src/nt_status.rs
@@ -86,6 +86,7 @@ impl NtStatus {
             0x00000003 => {
                 "STATUS_WAIT_3: Caller specified WaitAny and one of the dispatcher objects was set"
             }
+            0x00000080 => "STATUS_ABANDONED_WAIT_0: An abandoned mutant satisfied the wait",
             0x00000101 => "STATUS_ALERTED: The delay completed because the thread was alerted",
             0x00000102 => "STATUS_TIMEOUT: The given timeout interval expired",
             0x00000103 => "STATUS_PENDING: The operation that was requested is pending completion",
@@ -249,6 +250,9 @@ impl NtStatus {
 
     /// STATUS_WAIT_3
     pub const WAIT_3: Self = Self::from_raw(0x00000003);
+
+    /// STATUS_ABANDONED_WAIT_0
+    pub const ABANDONED_WAIT_0: Self = Self::from_raw(0x00000080);
 
     /// STATUS_ALERTED
     pub const ALERTED: Self = Self::from_raw(0x00000101);

--- a/litebox_shim_windows/src/lib.rs
+++ b/litebox_shim_windows/src/lib.rs
@@ -36,6 +36,7 @@ use crate::syscalls::event::{EventHandleObject, EventSubsystem};
 use crate::syscalls::file::{FileObject, FileObjectSubsystem};
 use crate::syscalls::iocp::{IoCompletionHandleObject, IoCompletionSubsystem};
 use crate::syscalls::lpc::{LpcPortHandleObject, LpcPortSubsystem};
+use crate::syscalls::mutant::{MutantHandleObject, MutantSubsystem};
 use crate::syscalls::object_manager::{
     DirectoryHandleObject, DirectoryObjectSubsystem, ObjectManager,
 };
@@ -541,7 +542,10 @@ impl<Platform: ShimPlatform, FS: ShimFS> WindowsShim<Platform, FS> {
         process.ntdll = load_info.ntdll;
         process.peb_address = load_info.environment.peb;
         let process = Arc::new(process);
-        let thread_object = Arc::new(syscalls::thread::ThreadObject::new());
+        let thread_object = Arc::new(syscalls::thread::ThreadObject::new(
+            syscalls::process::INITIAL_THREAD_ID,
+            load_info.environment.teb,
+        ));
         let attached = process.attach_thread(syscalls::process::INITIAL_THREAD_ID, &thread_object);
         debug_assert!(attached, "a freshly created process cannot be exiting");
         Ok(LoadedProgram {
@@ -553,9 +557,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> WindowsShim<Platform, FS> {
                     wait_state: wait::WaitState::new(self.0.platform),
                     entry_point: load_info.entry_point,
                     stack_top: load_info.stack_top,
-                    teb_address: load_info.environment.teb,
                     context: load_info.environment.context,
-                    thread_id: syscalls::process::INITIAL_THREAD_ID,
                     thread_object,
                 },
                 _not_send: PhantomData,
@@ -721,17 +723,16 @@ struct Task<Platform: ShimPlatform, FS: ShimFS> {
     entry_point: usize,
     stack_top: usize,
     context: usize,
-    teb_address: usize,
-    /// The NT thread ID of this task, used as its key in [`ProcessThreads`].
-    thread_id: usize,
     /// The NT thread object backing this task.
     thread_object: Arc<syscalls::thread::ThreadObject<Platform>>,
 }
 
 impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
     fn complete_current_thread(&self) {
+        let thread_id = self.thread_object.thread_id();
         self.thread_object.complete(|| {
-            self.process.detach_thread(self.thread_id);
+            self.thread_object.abandon_owned_mutants(thread_id);
+            self.process.detach_thread(thread_id);
         });
     }
 
@@ -761,7 +762,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
     fn exit_other_threads(&self, exit_status: i32) {
         let threads = self.process.threads.read();
         for (thread_id, thread) in &threads.threads {
-            if *thread_id != self.thread_id {
+            if *thread_id != self.thread_object.thread_id() {
                 thread.begin_exit(exit_status);
             }
         }
@@ -772,7 +773,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         // the thread itself, because the handle captures the current platform
         // thread.
         self.publish_thread_handle();
-        if !set_guest_teb(self.global.platform, self.teb_address) {
+        if !set_guest_teb(self.global.platform, self.thread_object.teb_address()) {
             self.exit_thread(NtStatus::ACCESS_VIOLATION.as_raw());
             return;
         }
@@ -1038,6 +1039,17 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                 object_attributes,
                 event_type,
                 initial_state,
+            ),
+            SyscallRequest::NtCreateMutant {
+                mutant_handle,
+                desired_access,
+                object_attributes,
+                initial_owner,
+            } => self.sys_nt_create_mutant(
+                mutant_handle,
+                desired_access,
+                object_attributes,
+                initial_owner,
             ),
             SyscallRequest::NtCreateSemaphore {
                 semaphore_handle,
@@ -1326,11 +1338,20 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                 desired_access,
                 object_attributes,
             } => self.sys_nt_open_event(event_handle, desired_access, object_attributes),
+            SyscallRequest::NtOpenMutant {
+                mutant_handle,
+                desired_access,
+                object_attributes,
+            } => self.sys_nt_open_mutant(mutant_handle, desired_access, object_attributes),
             SyscallRequest::NtOpenSemaphore {
                 semaphore_handle,
                 desired_access,
                 object_attributes,
             } => self.sys_nt_open_semaphore(semaphore_handle, desired_access, object_attributes),
+            SyscallRequest::NtReleaseMutant {
+                mutant_handle,
+                previous_count,
+            } => self.sys_nt_release_mutant(mutant_handle, previous_count),
             SyscallRequest::NtReleaseSemaphore {
                 semaphore_handle,
                 release_count,
@@ -1360,6 +1381,19 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                 event_information_class,
                 event_information,
                 event_information_length,
+                return_length,
+            ),
+            SyscallRequest::NtQueryMutant {
+                mutant_handle,
+                mutant_information_class,
+                mutant_information,
+                mutant_information_length,
+                return_length,
+            } => self.sys_nt_query_mutant(
+                mutant_handle,
+                mutant_information_class,
+                mutant_information,
+                mutant_information_length,
                 return_length,
             ),
             SyscallRequest::NtSetEventBoostPriority { event_handle } => {
@@ -2392,6 +2426,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         try_metadata!(FileObjectSubsystem<FS>);
         try_metadata!(RegistryKeySubsystem<Platform>);
         try_metadata!(EventSubsystem<Platform>);
+        try_metadata!(MutantSubsystem<Platform>);
         try_metadata!(SemaphoreSubsystem<Platform>);
         try_metadata!(DirectoryObjectSubsystem<Platform>);
         try_metadata!(SymbolicLinkSubsystem<Platform>);
@@ -2441,6 +2476,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         try_set_attributes!(FileObjectSubsystem<FS>);
         try_set_attributes!(RegistryKeySubsystem<Platform>);
         try_set_attributes!(EventSubsystem<Platform>);
+        try_set_attributes!(MutantSubsystem<Platform>);
         try_set_attributes!(SemaphoreSubsystem<Platform>);
         try_set_attributes!(DirectoryObjectSubsystem<Platform>);
         try_set_attributes!(SymbolicLinkSubsystem<Platform>);
@@ -2586,6 +2622,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         try_duplicate!(FileObjectSubsystem<FS>);
         try_duplicate!(RegistryKeySubsystem<Platform>);
         try_duplicate!(EventSubsystem<Platform>);
+        try_duplicate!(MutantSubsystem<Platform>);
         try_duplicate!(SemaphoreSubsystem<Platform>);
         try_duplicate!(DirectoryObjectSubsystem<Platform>);
         try_duplicate!(SymbolicLinkSubsystem<Platform>);
@@ -2695,6 +2732,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         try_close!(FileObjectSubsystem<FS>, file);
         try_close!(RegistryKeySubsystem<Platform>, registry_key);
         try_close!(EventSubsystem<Platform>, event);
+        try_close!(MutantSubsystem<Platform>, mutant);
         try_close!(SemaphoreSubsystem<Platform>, semaphore);
         try_close!(DirectoryObjectSubsystem<Platform>, directory);
         try_close!(SymbolicLinkSubsystem<Platform>, symbolic_link);
@@ -2863,6 +2901,8 @@ trait RawHandleVisitor<Platform: ShimPlatform, FS: ShimFS> {
 
     fn event(&self, event: EventHandleObject<Platform>);
 
+    fn mutant(&self, mutant: MutantHandleObject<Platform>);
+
     fn semaphore(&self, semaphore: SemaphoreHandleObject<Platform>);
 
     fn directory(&self, directory: DirectoryHandleObject<Platform>);
@@ -2906,6 +2946,10 @@ impl<Platform: ShimPlatform, FS: ShimFS> RawHandleVisitor<Platform, FS>
 
     fn event(&self, event: EventHandleObject<Platform>) {
         Task::<Platform, FS>::close_event(event);
+    }
+
+    fn mutant(&self, mutant: MutantHandleObject<Platform>) {
+        Task::<Platform, FS>::close_mutant(mutant);
     }
 
     fn semaphore(&self, semaphore: SemaphoreHandleObject<Platform>) {

--- a/litebox_shim_windows/src/syscalls/event.rs
+++ b/litebox_shim_windows/src/syscalls/event.rs
@@ -17,7 +17,6 @@ use zerocopy::{FromBytes, Immutable, IntoBytes};
 
 use crate::nt_types::{AccessMask, ObjectAttributes, ObjectAttributesFlags};
 use crate::syscalls::Handle;
-use crate::syscalls::object_manager::read_dispatcher_object_attributes;
 use crate::{ConstPtr, MutPtr, ShimFS, Task, probe_guest_output_preserving_value};
 
 #[repr(u32)]
@@ -226,7 +225,7 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         }
 
         let (object_attributes, event_name) =
-            match read_dispatcher_object_attributes::<Platform>(object_attributes, false) {
+            match self.read_dispatcher_object_attributes(object_attributes, false) {
                 Ok(value) => value,
                 Err(status) => return status,
             };
@@ -288,12 +287,11 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         if let Err(status) = probe_guest_output_preserving_value::<Platform, _>(event_handle) {
             return status;
         }
-        let event_name =
-            match read_dispatcher_object_attributes::<Platform>(object_attributes, true) {
-                Ok((_, Some(event_name))) => event_name,
-                Ok((_, None)) => return NtStatus::OBJECT_NAME_INVALID,
-                Err(status) => return status,
-            };
+        let event_name = match self.read_dispatcher_object_attributes(object_attributes, true) {
+            Ok((_, Some(event_name))) => event_name,
+            Ok((_, None)) => return NtStatus::OBJECT_NAME_INVALID,
+            Err(status) => return status,
+        };
         let event = match self.process.object_manager.resolve_event(&event_name) {
             Ok(event) => event,
             Err(status) => return status,

--- a/litebox_shim_windows/src/syscalls/mod.rs
+++ b/litebox_shim_windows/src/syscalls/mod.rs
@@ -12,6 +12,7 @@ pub(crate) mod ksecdd;
 pub(crate) mod license;
 pub(crate) mod lpc;
 pub(crate) mod mm;
+pub(crate) mod mutant;
 pub(crate) mod nls;
 pub(crate) mod object_manager;
 pub(crate) mod process;

--- a/litebox_shim_windows/src/syscalls/mod.rs
+++ b/litebox_shim_windows/src/syscalls/mod.rs
@@ -376,7 +376,7 @@ pub(crate) enum SyscallRequest<Platform: RawPointerProvider> {
     NtQueryMutant {
         mutant_handle: Handle,
         mutant_information_class: u32,
-        mutant_information: Platform::RawMutPointer<mutant::MutantBasicInformation>,
+        mutant_information: Platform::RawMutPointer<u8>,
         mutant_information_length: u32,
         return_length: Option<Platform::RawMutPointer<u32>>,
     },

--- a/litebox_shim_windows/src/syscalls/mod.rs
+++ b/litebox_shim_windows/src/syscalls/mod.rs
@@ -38,6 +38,11 @@ use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 use crate::nt_types;
 
+pub(crate) enum WaitAcquireResult {
+    Acquired,
+    Abandoned,
+}
+
 const FIRST_STACK_ARGUMENT_OFFSET: usize = 0x28;
 const HANDLE_SHIFT: u32 = 2;
 const HANDLE_TAG_MASK: usize = (1usize << HANDLE_SHIFT) - 1;
@@ -130,6 +135,11 @@ impl ThreadHandle {
     pub(crate) fn is_null(self) -> bool {
         self.0.is_null()
     }
+
+    #[must_use]
+    pub(crate) const fn as_handle(self) -> Handle {
+        self.0
+    }
 }
 
 #[allow(clippy::enum_variant_names)]
@@ -153,6 +163,12 @@ pub(crate) enum SyscallRequest<Platform: RawPointerProvider> {
         object_attributes: Option<Platform::RawConstPointer<nt_types::ObjectAttributes>>,
         event_type: u32,
         initial_state: u8,
+    },
+    NtCreateMutant {
+        mutant_handle: Platform::RawMutPointer<Handle>,
+        desired_access: u32,
+        object_attributes: Option<Platform::RawConstPointer<nt_types::ObjectAttributes>>,
+        initial_owner: u8,
     },
     NtCreateSemaphore {
         semaphore_handle: Platform::RawMutPointer<Handle>,
@@ -316,10 +332,19 @@ pub(crate) enum SyscallRequest<Platform: RawPointerProvider> {
         desired_access: u32,
         object_attributes: Option<Platform::RawConstPointer<nt_types::ObjectAttributes>>,
     },
+    NtOpenMutant {
+        mutant_handle: Platform::RawMutPointer<Handle>,
+        desired_access: u32,
+        object_attributes: Option<Platform::RawConstPointer<nt_types::ObjectAttributes>>,
+    },
     NtOpenSemaphore {
         semaphore_handle: Platform::RawMutPointer<Handle>,
         desired_access: u32,
         object_attributes: Option<Platform::RawConstPointer<nt_types::ObjectAttributes>>,
+    },
+    NtReleaseMutant {
+        mutant_handle: Handle,
+        previous_count: Option<Platform::RawMutPointer<i32>>,
     },
     NtReleaseSemaphore {
         semaphore_handle: Handle,
@@ -346,6 +371,13 @@ pub(crate) enum SyscallRequest<Platform: RawPointerProvider> {
         event_information_class: u32,
         event_information: Platform::RawMutPointer<event::EventBasicInformation>,
         event_information_length: u32,
+        return_length: Option<Platform::RawMutPointer<u32>>,
+    },
+    NtQueryMutant {
+        mutant_handle: Handle,
+        mutant_information_class: u32,
+        mutant_information: Platform::RawMutPointer<mutant::MutantBasicInformation>,
+        mutant_information_length: u32,
         return_length: Option<Platform::RawMutPointer<u32>>,
     },
     NtSetEventBoostPriority {
@@ -917,6 +949,12 @@ impl<Platform: RawPointerProvider> SyscallRequest<Platform> {
                 event_type,
                 initial_state,
             })),
+            NtSysno::NtCreateMutant => Some(sys_req!(NtCreateMutant {
+                mutant_handle:*,
+                desired_access,
+                object_attributes:*,
+                initial_owner,
+            })),
             NtSysno::NtCreateSemaphore => Some(sys_req!(NtCreateSemaphore {
                 semaphore_handle:*,
                 desired_access,
@@ -1083,10 +1121,19 @@ impl<Platform: RawPointerProvider> SyscallRequest<Platform> {
                 desired_access,
                 object_attributes:*,
             })),
+            NtSysno::NtOpenMutant => Some(sys_req!(NtOpenMutant {
+                mutant_handle:*,
+                desired_access,
+                object_attributes:*,
+            })),
             NtSysno::NtOpenSemaphore => Some(sys_req!(NtOpenSemaphore {
                 semaphore_handle:*,
                 desired_access,
                 object_attributes:*,
+            })),
+            NtSysno::NtReleaseMutant => Some(sys_req!(NtReleaseMutant {
+                mutant_handle:{Handle::from_raw},
+                previous_count:*,
             })),
             NtSysno::NtReleaseSemaphore => Some(sys_req!(NtReleaseSemaphore {
                 semaphore_handle:{Handle::from_raw},
@@ -1113,6 +1160,13 @@ impl<Platform: RawPointerProvider> SyscallRequest<Platform> {
                 event_information_class,
                 event_information:*,
                 event_information_length,
+                return_length:*,
+            })),
+            NtSysno::NtQueryMutant => Some(sys_req!(NtQueryMutant {
+                mutant_handle:{Handle::from_raw},
+                mutant_information_class,
+                mutant_information:*,
+                mutant_information_length,
                 return_length:*,
             })),
             NtSysno::NtSetEventBoostPriority => Some(sys_req!(NtSetEventBoostPriority {

--- a/litebox_shim_windows/src/syscalls/mutant.rs
+++ b/litebox_shim_windows/src/syscalls/mutant.rs
@@ -6,7 +6,9 @@
 use alloc::sync::{Arc, Weak};
 use core::marker::PhantomData;
 use core::mem::size_of;
+use litebox::utils::TruncateExt;
 
+use int_enum::IntEnum;
 use litebox::event::{Events, IOPollable, observer::Observer, polling::Pollee};
 use litebox::fd::{FdEnabledSubsystem, FdEnabledSubsystemEntry};
 use litebox::platform::RawMutPointer as _;
@@ -14,7 +16,7 @@ use litebox::sync::Mutex;
 use litebox_common_windows::nt_status::NtStatus;
 use zerocopy::{FromBytes, Immutable, IntoBytes};
 
-use crate::nt_types::{AccessMask, ObjectAttributes, ObjectAttributesFlags};
+use crate::nt_types::{AccessMask, ClientId, ObjectAttributes, ObjectAttributesFlags};
 use crate::syscalls::thread::ThreadObject;
 use crate::syscalls::{Handle, WaitAcquireResult};
 use crate::{ConstPtr, MutPtr, ShimFS, Task, probe_guest_output_preserving_value};
@@ -64,6 +66,13 @@ impl<Platform: crate::ShimPlatform> crate::WindowsHandleSubsystem for MutantSubs
 
 pub(crate) struct MutantHandleObject<Platform: crate::ShimPlatform> {
     pub(crate) mutant: Arc<MutantObject<Platform>>,
+}
+
+#[repr(u32)]
+#[derive(Clone, Copy, Debug, Eq, IntEnum, PartialEq)]
+enum MutantInformationClass {
+    Basic = 0,
+    Owner = 1,
 }
 
 struct MutantState {
@@ -156,13 +165,29 @@ impl<Platform: crate::ShimPlatform> MutantObject<Platform> {
         self.pollee.notify_observers(Events::IN);
     }
 
-    fn query(&self, thread_id: usize) -> MutantBasicInformation {
+    fn query_basic(&self, thread_id: usize) -> MutantBasicInformation {
         let state = self.state.lock();
         MutantBasicInformation {
             current_count: state.current_count,
             owned_by_caller: u8::from(state.owner == Some(thread_id)),
             abandoned_state: u8::from(state.abandoned),
             padding: [0; 2],
+        }
+    }
+
+    fn query_owner(&self, process_id: usize) -> MutantOwnerInformation {
+        let state = self.state.lock();
+        MutantOwnerInformation {
+            client_id: match state.owner {
+                Some(thread_id) => ClientId {
+                    unique_process: process_id,
+                    unique_thread: thread_id,
+                },
+                None => ClientId {
+                    unique_process: 0,
+                    unique_thread: 0,
+                },
+            },
         }
     }
 }
@@ -188,6 +213,12 @@ pub(crate) struct MutantBasicInformation {
     owned_by_caller: u8,
     abandoned_state: u8,
     padding: [u8; 2],
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, FromBytes, Immutable, IntoBytes, PartialEq)]
+struct MutantOwnerInformation {
+    client_id: ClientId,
 }
 
 impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
@@ -323,18 +354,24 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         &self,
         mutant_handle: Handle,
         mutant_information_class: u32,
-        mutant_information: MutPtr<Platform, MutantBasicInformation>,
+        mutant_information: MutPtr<Platform, u8>,
         mutant_information_length: u32,
         return_length: Option<MutPtr<Platform, u32>>,
     ) -> NtStatus {
-        if mutant_information_class != 0 {
+        let Ok(mutant_information_class) =
+            MutantInformationClass::try_from(mutant_information_class)
+        else {
             return NtStatus::INVALID_INFO_CLASS;
-        }
-        let required_length = u32::try_from(size_of::<MutantBasicInformation>()).unwrap();
+        };
+        let required_length = match mutant_information_class {
+            MutantInformationClass::Basic => size_of::<MutantBasicInformation>(),
+            MutantInformationClass::Owner => size_of::<MutantOwnerInformation>(),
+        };
+        let required_length: u32 = required_length.trunc();
         if mutant_information_length != required_length {
             return NtStatus::INFO_LENGTH_MISMATCH;
         }
-        if let Err(status) = probe_guest_output_preserving_value::<Platform, _>(mutant_information)
+        if let Err(status) = probe_guest_output_preserving_value::<Platform, u8>(mutant_information)
         {
             return status;
         }
@@ -350,13 +387,26 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             Ok(entry) => entry,
             Err(status) => return status,
         };
-        let information =
-            entry.with_entry(|entry| entry.mutant.query(self.thread_object.thread_id()));
-        if mutant_information.write_at_offset(0, information).is_none()
-            || return_length.is_some_and(|return_length| {
-                return_length.write_at_offset(0, required_length).is_none()
-            })
-        {
+        let written = entry.with_entry(|entry| match mutant_information_class {
+            MutantInformationClass::Basic => mutant_information
+                .write_slice_at_offset(
+                    0,
+                    entry
+                        .mutant
+                        .query_basic(self.thread_object.thread_id())
+                        .as_bytes(),
+                )
+                .is_some(),
+            MutantInformationClass::Owner => mutant_information
+                .write_slice_at_offset(0, entry.mutant.query_owner(self.process.id).as_bytes())
+                .is_some(),
+        });
+        if !written {
+            return NtStatus::ACCESS_VIOLATION;
+        }
+        if return_length.is_some_and(|return_length| {
+            return_length.write_at_offset(0, required_length).is_none()
+        }) {
             return NtStatus::ACCESS_VIOLATION;
         }
         NtStatus::SUCCESS
@@ -401,156 +451,11 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
 mod tests {
     extern crate std;
 
-    use core::mem::size_of_val;
+    use super::*;
+    use crate::tests::{const_ptr, mut_ptr, run_with_test_platform_pointers, test_task};
     use core::time::Duration;
 
-    use litebox::platform::RawConstPointer as _;
-    use litebox_common_windows::NtSysno;
-
-    use super::*;
-    use crate::syscalls::ProcessHandle;
-    use crate::tests::{const_ptr, mut_ptr, run_with_test_platform_pointers, test_task};
-
     const MUTANT_ALL_ACCESS: u32 = 0x001f_0001;
-
-    #[test]
-    fn mutant_waits_are_recursive_and_release_restores_signal() {
-        run_with_test_platform_pointers(|| {
-            let task = test_task();
-            let mut handle = Handle::default();
-            assert_eq!(
-                task.sys_nt_create_mutant(mut_ptr(&mut handle), MUTANT_ALL_ACCESS, None, 0),
-                NtStatus::SUCCESS
-            );
-
-            let timeout = 0i64;
-            assert_eq!(
-                task.sys_nt_wait_for_single_object(handle, false, Some(const_ptr(&timeout))),
-                NtStatus::SUCCESS
-            );
-            assert_eq!(
-                task.sys_nt_wait_for_single_object(handle, false, Some(const_ptr(&timeout))),
-                NtStatus::SUCCESS
-            );
-
-            let mut previous_count = i32::MAX;
-            assert_eq!(
-                task.sys_nt_release_mutant(handle, Some(mut_ptr(&mut previous_count))),
-                NtStatus::SUCCESS
-            );
-            assert_eq!(previous_count, -1);
-            assert_eq!(task.sys_nt_release_mutant(handle, None), NtStatus::SUCCESS);
-            assert_eq!(task.sys_nt_close(handle), NtStatus::SUCCESS);
-        });
-    }
-
-    #[test]
-    fn mutant_query_reports_current_thread_ownership() {
-        run_with_test_platform_pointers(|| {
-            let task = test_task();
-            let mut handle = Handle::default();
-            assert_eq!(
-                task.sys_nt_create_mutant(mut_ptr(&mut handle), MUTANT_ALL_ACCESS, None, 1),
-                NtStatus::SUCCESS
-            );
-            let mut information = MutantBasicInformation {
-                current_count: i32::MAX,
-                owned_by_caller: 0,
-                abandoned_state: u8::MAX,
-                padding: [u8::MAX; 2],
-            };
-            let mut return_length = 0;
-            assert_eq!(
-                task.sys_nt_query_mutant(
-                    handle,
-                    0,
-                    mut_ptr(&mut information),
-                    size_of_val(&information).try_into().unwrap(),
-                    Some(mut_ptr(&mut return_length)),
-                ),
-                NtStatus::SUCCESS
-            );
-            assert_eq!(information.current_count, 0);
-            assert_eq!(information.owned_by_caller, 1);
-            assert_eq!(information.abandoned_state, 0);
-            assert_eq!(return_length as usize, size_of_val(&information));
-
-            let mut duplicate = Handle::default();
-            assert_eq!(
-                task.sys_nt_duplicate_object(
-                    ProcessHandle::CURRENT,
-                    handle,
-                    ProcessHandle::CURRENT,
-                    Some(mut_ptr(&mut duplicate)),
-                    0,
-                    0,
-                    2,
-                ),
-                NtStatus::SUCCESS
-            );
-            assert_eq!(task.sys_nt_close(duplicate), NtStatus::SUCCESS);
-            assert_eq!(task.sys_nt_close(handle), NtStatus::SUCCESS);
-        });
-    }
-
-    #[test]
-    fn owner_exit_abandons_mutant_for_next_waiter() {
-        run_with_test_platform_pointers(|| {
-            let owner = test_task();
-            let waiter = owner.clone_for_test().expect("process is live");
-            let mut handle = Handle::default();
-            assert_eq!(
-                owner.sys_nt_create_mutant(mut_ptr(&mut handle), MUTANT_ALL_ACCESS, None, 1),
-                NtStatus::SUCCESS
-            );
-
-            owner.complete_current_thread();
-
-            let mut information = MutantBasicInformation {
-                current_count: i32::MIN,
-                owned_by_caller: u8::MAX,
-                abandoned_state: 0,
-                padding: [u8::MAX; 2],
-            };
-            assert_eq!(
-                waiter.sys_nt_query_mutant(
-                    handle,
-                    0,
-                    mut_ptr(&mut information),
-                    size_of_val(&information).try_into().unwrap(),
-                    None,
-                ),
-                NtStatus::SUCCESS
-            );
-            assert_eq!(information.current_count, 1);
-            assert_eq!(information.owned_by_caller, 0);
-            assert_eq!(information.abandoned_state, 1);
-
-            let timeout = 0i64;
-            assert_eq!(
-                waiter.sys_nt_wait_for_single_object(handle, false, Some(const_ptr(&timeout)),),
-                NtStatus::ABANDONED_WAIT_0
-            );
-            assert_eq!(
-                waiter.sys_nt_query_mutant(
-                    handle,
-                    0,
-                    mut_ptr(&mut information),
-                    size_of_val(&information).try_into().unwrap(),
-                    None,
-                ),
-                NtStatus::SUCCESS
-            );
-            assert_eq!(information.current_count, 0);
-            assert_eq!(information.owned_by_caller, 1);
-            assert_eq!(information.abandoned_state, 0);
-            assert_eq!(
-                waiter.sys_nt_release_mutant(handle, None),
-                NtStatus::SUCCESS
-            );
-            assert_eq!(waiter.sys_nt_close(handle), NtStatus::SUCCESS);
-        });
-    }
 
     #[test]
     fn owner_exit_wakes_blocked_waiter_as_abandoned() {
@@ -586,32 +491,6 @@ mod tests {
                 NtStatus::ABANDONED_WAIT_0
             );
             thread.join().unwrap();
-        });
-    }
-
-    #[test]
-    fn create_and_release_are_reachable_through_syscall_dispatch() {
-        run_with_test_platform_pointers(|| {
-            let task = test_task();
-            let mut handle = Handle::default();
-            let mut context = litebox_common_linux::PtRegs {
-                orig_rax: NtSysno::NtCreateMutant.as_raw() as usize,
-                r10: mut_ptr(&mut handle).as_usize(),
-                rdx: MUTANT_ALL_ACCESS as usize,
-                r9: 1,
-                ..Default::default()
-            };
-
-            task.handle_syscall_request(&mut context);
-            assert_eq!(context.rax, NtStatus::SUCCESS.to_usize());
-            assert_ne!(handle, Handle::default());
-
-            context.orig_rax = NtSysno::NtReleaseMutant.as_raw() as usize;
-            context.r10 = handle.as_raw();
-            context.rdx = 0;
-            task.handle_syscall_request(&mut context);
-            assert_eq!(context.rax, NtStatus::SUCCESS.to_usize());
-            assert_eq!(task.sys_nt_close(handle), NtStatus::SUCCESS);
         });
     }
 }

--- a/litebox_shim_windows/src/syscalls/mutant.rs
+++ b/litebox_shim_windows/src/syscalls/mutant.rs
@@ -15,7 +15,8 @@ use litebox_common_windows::nt_status::NtStatus;
 use zerocopy::{FromBytes, Immutable, IntoBytes};
 
 use crate::nt_types::{AccessMask, ObjectAttributes, ObjectAttributesFlags};
-use crate::syscalls::Handle;
+use crate::syscalls::thread::ThreadObject;
+use crate::syscalls::{Handle, WaitAcquireResult};
 use crate::{ConstPtr, MutPtr, ShimFS, Task, probe_guest_output_preserving_value};
 
 bitflags::bitflags! {
@@ -68,6 +69,7 @@ pub(crate) struct MutantHandleObject<Platform: crate::ShimPlatform> {
 struct MutantState {
     owner: Option<usize>,
     current_count: i32,
+    abandoned: bool,
 }
 
 pub(crate) struct MutantObject<Platform: crate::ShimPlatform> {
@@ -82,37 +84,51 @@ impl<Platform: crate::ShimPlatform> MutantObject<Platform> {
                 MutantState {
                     owner: Some(thread_id),
                     current_count: 0,
+                    abandoned: false,
                 }
             } else {
                 MutantState {
                     owner: None,
                     current_count: 1,
+                    abandoned: false,
                 }
             }),
             pollee: Pollee::new(),
         }
     }
 
-    pub(crate) fn try_acquire(&self, thread_id: usize) -> bool {
+    pub(crate) fn try_acquire(
+        self: &Arc<Self>,
+        thread_id: usize,
+        thread: &ThreadObject<Platform>,
+    ) -> Option<WaitAcquireResult> {
         let mut state = self.state.lock();
         match state.owner {
             None => {
                 state.owner = Some(thread_id);
                 state.current_count = 0;
-                true
+                let abandoned = core::mem::take(&mut state.abandoned);
+                drop(state);
+                thread.register_owned_mutant(self);
+                if abandoned {
+                    Some(WaitAcquireResult::Abandoned)
+                } else {
+                    Some(WaitAcquireResult::Acquired)
+                }
             }
             Some(owner) if owner == thread_id => {
-                let Some(current_count) = state.current_count.checked_sub(1) else {
-                    return false;
-                };
-                state.current_count = current_count;
-                true
+                state.current_count = state.current_count.checked_sub(1)?;
+                Some(WaitAcquireResult::Acquired)
             }
-            Some(_) => false,
+            Some(_) => None,
         }
     }
 
-    fn release(&self, thread_id: usize) -> Result<i32, NtStatus> {
+    fn release(
+        self: &Arc<Self>,
+        thread_id: usize,
+        thread: &ThreadObject<Platform>,
+    ) -> Result<i32, NtStatus> {
         let mut state = self.state.lock();
         if state.owner != Some(thread_id) {
             return Err(NtStatus::MUTANT_NOT_OWNED);
@@ -122,9 +138,22 @@ impl<Platform: crate::ShimPlatform> MutantObject<Platform> {
         if state.current_count == 1 {
             state.owner = None;
             drop(state);
+            thread.unregister_owned_mutant(self);
             self.pollee.notify_observers(Events::IN);
         }
         Ok(previous_count)
+    }
+
+    pub(crate) fn abandon(&self, thread_id: usize) {
+        let mut state = self.state.lock();
+        if state.owner != Some(thread_id) {
+            return;
+        }
+        state.owner = None;
+        state.current_count = 1;
+        state.abandoned = true;
+        drop(state);
+        self.pollee.notify_observers(Events::IN);
     }
 
     fn query(&self, thread_id: usize) -> MutantBasicInformation {
@@ -132,7 +161,7 @@ impl<Platform: crate::ShimPlatform> MutantObject<Platform> {
         MutantBasicInformation {
             current_count: state.current_count,
             owned_by_caller: u8::from(state.owner == Some(thread_id)),
-            abandoned_state: 0,
+            abandoned_state: u8::from(state.abandoned),
             padding: [0; 2],
         }
     }
@@ -197,7 +226,10 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
 
         if let Some(mutant_name) = mutant_name {
             litebox_util_log::debug!(mutant_name:% = mutant_name; "Creating named mutant");
-            let mutant = Arc::new(MutantObject::new(initial_owner != 0, self.thread_id));
+            let mutant = Arc::new(MutantObject::new(
+                initial_owner != 0,
+                self.thread_object.thread_id(),
+            ));
             return self.process.object_manager.create_mutant(
                 &mutant_name,
                 &mutant,
@@ -214,15 +246,21 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                         .map_or_else(|status| status, |()| NtStatus::OBJECT_NAME_EXISTS)
                 },
                 || {
-                    self.write_new_mutant_handle(mutant_handle, Arc::clone(&mutant), granted_access)
-                        .map_or_else(|status| status, |()| NtStatus::SUCCESS)
+                    self.write_created_mutant_handle(
+                        mutant_handle,
+                        Arc::clone(&mutant),
+                        granted_access,
+                        initial_owner != 0,
+                    )
                 },
             );
         }
 
-        let mutant = Arc::new(MutantObject::new(initial_owner != 0, self.thread_id));
-        self.write_new_mutant_handle(mutant_handle, mutant, granted_access)
-            .map_or_else(|status| status, |()| NtStatus::SUCCESS)
+        let mutant = Arc::new(MutantObject::new(
+            initial_owner != 0,
+            self.thread_object.thread_id(),
+        ));
+        self.write_created_mutant_handle(mutant_handle, mutant, granted_access, initial_owner != 0)
     }
 
     pub(crate) fn sys_nt_open_mutant(
@@ -265,7 +303,11 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             Ok(entry) => entry,
             Err(status) => return status,
         };
-        let previous = match entry.with_entry(|entry| entry.mutant.release(self.thread_id)) {
+        let previous = match entry.with_entry(|entry| {
+            entry
+                .mutant
+                .release(self.thread_object.thread_id(), &self.thread_object)
+        }) {
             Ok(previous) => previous,
             Err(status) => return status,
         };
@@ -308,7 +350,8 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             Ok(entry) => entry,
             Err(status) => return status,
         };
-        let information = entry.with_entry(|entry| entry.mutant.query(self.thread_id));
+        let information =
+            entry.with_entry(|entry| entry.mutant.query(self.thread_object.thread_id()));
         if mutant_information.write_at_offset(0, information).is_none()
             || return_length.is_some_and(|return_length| {
                 return_length.write_at_offset(0, required_length).is_none()
@@ -317,6 +360,24 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             return NtStatus::ACCESS_VIOLATION;
         }
         NtStatus::SUCCESS
+    }
+
+    fn write_created_mutant_handle(
+        &self,
+        output: MutPtr<Platform, Handle>,
+        mutant: Arc<MutantObject<Platform>>,
+        granted_access: MutantAccess,
+        initial_owner: bool,
+    ) -> NtStatus {
+        match self.write_new_mutant_handle(output, Arc::clone(&mutant), granted_access) {
+            Ok(()) => {
+                if initial_owner {
+                    self.thread_object.register_owned_mutant(&mutant);
+                }
+                NtStatus::SUCCESS
+            }
+            Err(status) => status,
+        }
     }
 
     fn write_new_mutant_handle(
@@ -338,69 +399,219 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
 
 #[cfg(test)]
 mod tests {
+    extern crate std;
+
     use core::mem::size_of_val;
+    use core::time::Duration;
+
+    use litebox::platform::RawConstPointer as _;
+    use litebox_common_windows::NtSysno;
 
     use super::*;
-    use crate::tests::{const_ptr, mut_ptr, test_task};
+    use crate::syscalls::ProcessHandle;
+    use crate::tests::{const_ptr, mut_ptr, run_with_test_platform_pointers, test_task};
 
     const MUTANT_ALL_ACCESS: u32 = 0x001f_0001;
 
     #[test]
     fn mutant_waits_are_recursive_and_release_restores_signal() {
-        let task = test_task();
-        let mut handle = Handle::default();
-        assert_eq!(
-            task.sys_nt_create_mutant(mut_ptr(&mut handle), MUTANT_ALL_ACCESS, None, 0),
-            NtStatus::SUCCESS
-        );
+        run_with_test_platform_pointers(|| {
+            let task = test_task();
+            let mut handle = Handle::default();
+            assert_eq!(
+                task.sys_nt_create_mutant(mut_ptr(&mut handle), MUTANT_ALL_ACCESS, None, 0),
+                NtStatus::SUCCESS
+            );
 
-        let timeout = 0i64;
-        assert_eq!(
-            task.sys_nt_wait_for_single_object(handle, false, Some(const_ptr(&timeout))),
-            NtStatus::SUCCESS
-        );
-        assert_eq!(
-            task.sys_nt_wait_for_single_object(handle, false, Some(const_ptr(&timeout))),
-            NtStatus::SUCCESS
-        );
+            let timeout = 0i64;
+            assert_eq!(
+                task.sys_nt_wait_for_single_object(handle, false, Some(const_ptr(&timeout))),
+                NtStatus::SUCCESS
+            );
+            assert_eq!(
+                task.sys_nt_wait_for_single_object(handle, false, Some(const_ptr(&timeout))),
+                NtStatus::SUCCESS
+            );
 
-        let mut previous_count = i32::MAX;
-        assert_eq!(
-            task.sys_nt_release_mutant(handle, Some(mut_ptr(&mut previous_count))),
-            NtStatus::SUCCESS
-        );
-        assert_eq!(previous_count, -1);
-        assert_eq!(task.sys_nt_release_mutant(handle, None), NtStatus::SUCCESS);
+            let mut previous_count = i32::MAX;
+            assert_eq!(
+                task.sys_nt_release_mutant(handle, Some(mut_ptr(&mut previous_count))),
+                NtStatus::SUCCESS
+            );
+            assert_eq!(previous_count, -1);
+            assert_eq!(task.sys_nt_release_mutant(handle, None), NtStatus::SUCCESS);
+            assert_eq!(task.sys_nt_close(handle), NtStatus::SUCCESS);
+        });
     }
 
     #[test]
     fn mutant_query_reports_current_thread_ownership() {
-        let task = test_task();
-        let mut handle = Handle::default();
-        assert_eq!(
-            task.sys_nt_create_mutant(mut_ptr(&mut handle), MUTANT_ALL_ACCESS, None, 1),
-            NtStatus::SUCCESS
-        );
-        let mut information = MutantBasicInformation {
-            current_count: i32::MAX,
-            owned_by_caller: 0,
-            abandoned_state: u8::MAX,
-            padding: [u8::MAX; 2],
-        };
-        let mut return_length = 0;
-        assert_eq!(
-            task.sys_nt_query_mutant(
-                handle,
-                0,
-                mut_ptr(&mut information),
-                size_of_val(&information).try_into().unwrap(),
-                Some(mut_ptr(&mut return_length)),
-            ),
-            NtStatus::SUCCESS
-        );
-        assert_eq!(information.current_count, 0);
-        assert_eq!(information.owned_by_caller, 1);
-        assert_eq!(information.abandoned_state, 0);
-        assert_eq!(return_length as usize, size_of_val(&information));
+        run_with_test_platform_pointers(|| {
+            let task = test_task();
+            let mut handle = Handle::default();
+            assert_eq!(
+                task.sys_nt_create_mutant(mut_ptr(&mut handle), MUTANT_ALL_ACCESS, None, 1),
+                NtStatus::SUCCESS
+            );
+            let mut information = MutantBasicInformation {
+                current_count: i32::MAX,
+                owned_by_caller: 0,
+                abandoned_state: u8::MAX,
+                padding: [u8::MAX; 2],
+            };
+            let mut return_length = 0;
+            assert_eq!(
+                task.sys_nt_query_mutant(
+                    handle,
+                    0,
+                    mut_ptr(&mut information),
+                    size_of_val(&information).try_into().unwrap(),
+                    Some(mut_ptr(&mut return_length)),
+                ),
+                NtStatus::SUCCESS
+            );
+            assert_eq!(information.current_count, 0);
+            assert_eq!(information.owned_by_caller, 1);
+            assert_eq!(information.abandoned_state, 0);
+            assert_eq!(return_length as usize, size_of_val(&information));
+
+            let mut duplicate = Handle::default();
+            assert_eq!(
+                task.sys_nt_duplicate_object(
+                    ProcessHandle::CURRENT,
+                    handle,
+                    ProcessHandle::CURRENT,
+                    Some(mut_ptr(&mut duplicate)),
+                    0,
+                    0,
+                    2,
+                ),
+                NtStatus::SUCCESS
+            );
+            assert_eq!(task.sys_nt_close(duplicate), NtStatus::SUCCESS);
+            assert_eq!(task.sys_nt_close(handle), NtStatus::SUCCESS);
+        });
+    }
+
+    #[test]
+    fn owner_exit_abandons_mutant_for_next_waiter() {
+        run_with_test_platform_pointers(|| {
+            let owner = test_task();
+            let waiter = owner.clone_for_test().expect("process is live");
+            let mut handle = Handle::default();
+            assert_eq!(
+                owner.sys_nt_create_mutant(mut_ptr(&mut handle), MUTANT_ALL_ACCESS, None, 1),
+                NtStatus::SUCCESS
+            );
+
+            owner.complete_current_thread();
+
+            let mut information = MutantBasicInformation {
+                current_count: i32::MIN,
+                owned_by_caller: u8::MAX,
+                abandoned_state: 0,
+                padding: [u8::MAX; 2],
+            };
+            assert_eq!(
+                waiter.sys_nt_query_mutant(
+                    handle,
+                    0,
+                    mut_ptr(&mut information),
+                    size_of_val(&information).try_into().unwrap(),
+                    None,
+                ),
+                NtStatus::SUCCESS
+            );
+            assert_eq!(information.current_count, 1);
+            assert_eq!(information.owned_by_caller, 0);
+            assert_eq!(information.abandoned_state, 1);
+
+            let timeout = 0i64;
+            assert_eq!(
+                waiter.sys_nt_wait_for_single_object(handle, false, Some(const_ptr(&timeout)),),
+                NtStatus::ABANDONED_WAIT_0
+            );
+            assert_eq!(
+                waiter.sys_nt_query_mutant(
+                    handle,
+                    0,
+                    mut_ptr(&mut information),
+                    size_of_val(&information).try_into().unwrap(),
+                    None,
+                ),
+                NtStatus::SUCCESS
+            );
+            assert_eq!(information.current_count, 0);
+            assert_eq!(information.owned_by_caller, 1);
+            assert_eq!(information.abandoned_state, 0);
+            assert_eq!(
+                waiter.sys_nt_release_mutant(handle, None),
+                NtStatus::SUCCESS
+            );
+            assert_eq!(waiter.sys_nt_close(handle), NtStatus::SUCCESS);
+        });
+    }
+
+    #[test]
+    fn owner_exit_wakes_blocked_waiter_as_abandoned() {
+        run_with_test_platform_pointers(|| {
+            let owner = test_task();
+            let waiter = owner.clone_for_test().expect("process is live");
+            let mut handle = Handle::default();
+            assert_eq!(
+                owner.sys_nt_create_mutant(mut_ptr(&mut handle), MUTANT_ALL_ACCESS, None, 1),
+                NtStatus::SUCCESS
+            );
+
+            let (started_tx, started_rx) = std::sync::mpsc::channel();
+            let (result_tx, result_rx) = std::sync::mpsc::channel();
+            let thread = std::thread::spawn(move || {
+                let timeout = -10_000_000i64;
+                started_tx.send(()).unwrap();
+                let status =
+                    waiter.sys_nt_wait_for_single_object(handle, false, Some(const_ptr(&timeout)));
+                result_tx.send(status).unwrap();
+                assert_eq!(
+                    waiter.sys_nt_release_mutant(handle, None),
+                    NtStatus::SUCCESS
+                );
+                assert_eq!(waiter.sys_nt_close(handle), NtStatus::SUCCESS);
+            });
+
+            started_rx.recv().unwrap();
+            std::thread::sleep(Duration::from_millis(20));
+            owner.complete_current_thread();
+            assert_eq!(
+                result_rx.recv_timeout(Duration::from_secs(2)).unwrap(),
+                NtStatus::ABANDONED_WAIT_0
+            );
+            thread.join().unwrap();
+        });
+    }
+
+    #[test]
+    fn create_and_release_are_reachable_through_syscall_dispatch() {
+        run_with_test_platform_pointers(|| {
+            let task = test_task();
+            let mut handle = Handle::default();
+            let mut context = litebox_common_linux::PtRegs {
+                orig_rax: NtSysno::NtCreateMutant.as_raw() as usize,
+                r10: mut_ptr(&mut handle).as_usize(),
+                rdx: MUTANT_ALL_ACCESS as usize,
+                r9: 1,
+                ..Default::default()
+            };
+
+            task.handle_syscall_request(&mut context);
+            assert_eq!(context.rax, NtStatus::SUCCESS.to_usize());
+            assert_ne!(handle, Handle::default());
+
+            context.orig_rax = NtSysno::NtReleaseMutant.as_raw() as usize;
+            context.r10 = handle.as_raw();
+            context.rdx = 0;
+            task.handle_syscall_request(&mut context);
+            assert_eq!(context.rax, NtStatus::SUCCESS.to_usize());
+            assert_eq!(task.sys_nt_close(handle), NtStatus::SUCCESS);
+        });
     }
 }

--- a/litebox_shim_windows/src/syscalls/mutant.rs
+++ b/litebox_shim_windows/src/syscalls/mutant.rs
@@ -1,0 +1,406 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//! Windows NT mutant object syscalls.
+
+use alloc::sync::{Arc, Weak};
+use core::marker::PhantomData;
+use core::mem::size_of;
+
+use litebox::event::{Events, IOPollable, observer::Observer, polling::Pollee};
+use litebox::fd::{FdEnabledSubsystem, FdEnabledSubsystemEntry};
+use litebox::platform::RawMutPointer as _;
+use litebox::sync::Mutex;
+use litebox_common_windows::nt_status::NtStatus;
+use zerocopy::{FromBytes, Immutable, IntoBytes};
+
+use crate::nt_types::{AccessMask, ObjectAttributes, ObjectAttributesFlags};
+use crate::syscalls::Handle;
+use crate::{ConstPtr, MutPtr, ShimFS, Task, probe_guest_output_preserving_value};
+
+bitflags::bitflags! {
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    pub(crate) struct MutantAccess: u32 {
+        const QUERY_STATE = 0x0001;
+
+        const READ = AccessMask::STANDARD_RIGHTS_READ.bits() | Self::QUERY_STATE.bits();
+        const WRITE = AccessMask::STANDARD_RIGHTS_WRITE.bits();
+        const EXECUTE = AccessMask::STANDARD_RIGHTS_EXECUTE.bits()
+            | AccessMask::SYNCHRONIZE.bits();
+        const ALL_ACCESS = AccessMask::STANDARD_RIGHTS_ALL.bits()
+            | AccessMask::SYNCHRONIZE.bits()
+            | Self::QUERY_STATE.bits();
+
+        const _ = !0;
+    }
+}
+
+impl MutantAccess {
+    fn from_desired_access(desired_access: u32) -> Self {
+        Self::from_bits_retain(AccessMask::expand_generic_access(
+            desired_access,
+            Self::READ.bits(),
+            Self::WRITE.bits(),
+            Self::EXECUTE.bits(),
+            Self::ALL_ACCESS.bits(),
+        ))
+    }
+}
+
+pub(crate) struct MutantSubsystem<Platform>(PhantomData<fn(Platform)>);
+
+impl<Platform: crate::ShimPlatform> FdEnabledSubsystem for MutantSubsystem<Platform> {
+    type Entry = MutantHandleObject<Platform>;
+}
+
+impl<Platform: crate::ShimPlatform> FdEnabledSubsystemEntry for MutantHandleObject<Platform> {}
+
+impl<Platform: crate::ShimPlatform> crate::WindowsHandleSubsystem for MutantSubsystem<Platform> {
+    fn normalize_desired_access(desired_access: u32) -> u32 {
+        MutantAccess::from_desired_access(desired_access).bits()
+    }
+}
+
+pub(crate) struct MutantHandleObject<Platform: crate::ShimPlatform> {
+    pub(crate) mutant: Arc<MutantObject<Platform>>,
+}
+
+struct MutantState {
+    owner: Option<usize>,
+    current_count: i32,
+}
+
+pub(crate) struct MutantObject<Platform: crate::ShimPlatform> {
+    state: Mutex<Platform, MutantState>,
+    pollee: Pollee<Platform>,
+}
+
+impl<Platform: crate::ShimPlatform> MutantObject<Platform> {
+    fn new(initial_owner: bool, thread_id: usize) -> Self {
+        Self {
+            state: Mutex::new(if initial_owner {
+                MutantState {
+                    owner: Some(thread_id),
+                    current_count: 0,
+                }
+            } else {
+                MutantState {
+                    owner: None,
+                    current_count: 1,
+                }
+            }),
+            pollee: Pollee::new(),
+        }
+    }
+
+    pub(crate) fn try_acquire(&self, thread_id: usize) -> bool {
+        let mut state = self.state.lock();
+        match state.owner {
+            None => {
+                state.owner = Some(thread_id);
+                state.current_count = 0;
+                true
+            }
+            Some(owner) if owner == thread_id => {
+                let Some(current_count) = state.current_count.checked_sub(1) else {
+                    return false;
+                };
+                state.current_count = current_count;
+                true
+            }
+            Some(_) => false,
+        }
+    }
+
+    fn release(&self, thread_id: usize) -> Result<i32, NtStatus> {
+        let mut state = self.state.lock();
+        if state.owner != Some(thread_id) {
+            return Err(NtStatus::MUTANT_NOT_OWNED);
+        }
+        let previous_count = state.current_count;
+        state.current_count += 1;
+        if state.current_count == 1 {
+            state.owner = None;
+            drop(state);
+            self.pollee.notify_observers(Events::IN);
+        }
+        Ok(previous_count)
+    }
+
+    fn query(&self, thread_id: usize) -> MutantBasicInformation {
+        let state = self.state.lock();
+        MutantBasicInformation {
+            current_count: state.current_count,
+            owned_by_caller: u8::from(state.owner == Some(thread_id)),
+            abandoned_state: 0,
+            padding: [0; 2],
+        }
+    }
+}
+
+impl<Platform: crate::ShimPlatform> IOPollable for MutantObject<Platform> {
+    fn register_observer(&self, observer: Weak<dyn Observer<Events>>, mask: Events) {
+        self.pollee.register_observer(observer, mask);
+    }
+
+    fn check_io_events(&self) -> Events {
+        if self.state.lock().owner.is_none() {
+            Events::IN
+        } else {
+            Events::empty()
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, FromBytes, Immutable, IntoBytes, PartialEq)]
+pub(crate) struct MutantBasicInformation {
+    current_count: i32,
+    owned_by_caller: u8,
+    abandoned_state: u8,
+    padding: [u8; 2],
+}
+
+impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
+    fn insert_mutant_handle(
+        &self,
+        mutant: Arc<MutantObject<Platform>>,
+        granted_access: MutantAccess,
+    ) -> Result<Handle, NtStatus> {
+        self.insert_typed_handle::<MutantSubsystem<Platform>>(
+            MutantHandleObject { mutant },
+            granted_access.bits(),
+            drop,
+        )
+    }
+
+    pub(crate) fn close_mutant(mutant: MutantHandleObject<Platform>) {
+        drop(mutant);
+    }
+
+    pub(crate) fn sys_nt_create_mutant(
+        &self,
+        mutant_handle: MutPtr<Platform, Handle>,
+        desired_access: u32,
+        object_attributes: Option<ConstPtr<Platform, ObjectAttributes>>,
+        initial_owner: u8,
+    ) -> NtStatus {
+        if let Err(status) = probe_guest_output_preserving_value::<Platform, _>(mutant_handle) {
+            return status;
+        }
+        let (object_attributes, mutant_name) =
+            match self.read_dispatcher_object_attributes(object_attributes, false) {
+                Ok(value) => value,
+                Err(status) => return status,
+            };
+        let granted_access = MutantAccess::from_desired_access(desired_access);
+
+        if let Some(mutant_name) = mutant_name {
+            litebox_util_log::debug!(mutant_name:% = mutant_name; "Creating named mutant");
+            let mutant = Arc::new(MutantObject::new(initial_owner != 0, self.thread_id));
+            return self.process.object_manager.create_mutant(
+                &mutant_name,
+                &mutant,
+                |mutant| {
+                    let Some(object_attributes) = object_attributes else {
+                        return NtStatus::INVALID_PARAMETER;
+                    };
+                    if !ObjectAttributesFlags::from_bits_retain(object_attributes.attributes)
+                        .contains(ObjectAttributesFlags::OPENIF)
+                    {
+                        return NtStatus::OBJECT_NAME_COLLISION;
+                    }
+                    self.write_new_mutant_handle(mutant_handle, mutant, granted_access)
+                        .map_or_else(|status| status, |()| NtStatus::OBJECT_NAME_EXISTS)
+                },
+                || {
+                    self.write_new_mutant_handle(mutant_handle, Arc::clone(&mutant), granted_access)
+                        .map_or_else(|status| status, |()| NtStatus::SUCCESS)
+                },
+            );
+        }
+
+        let mutant = Arc::new(MutantObject::new(initial_owner != 0, self.thread_id));
+        self.write_new_mutant_handle(mutant_handle, mutant, granted_access)
+            .map_or_else(|status| status, |()| NtStatus::SUCCESS)
+    }
+
+    pub(crate) fn sys_nt_open_mutant(
+        &self,
+        mutant_handle: MutPtr<Platform, Handle>,
+        desired_access: u32,
+        object_attributes: Option<ConstPtr<Platform, ObjectAttributes>>,
+    ) -> NtStatus {
+        if let Err(status) = probe_guest_output_preserving_value::<Platform, _>(mutant_handle) {
+            return status;
+        }
+        let mutant_name = match self.read_dispatcher_object_attributes(object_attributes, true) {
+            Ok((_, Some(mutant_name))) => mutant_name,
+            Ok((_, None)) => return NtStatus::OBJECT_NAME_INVALID,
+            Err(status) => return status,
+        };
+        let mutant = match self.process.object_manager.resolve_mutant(&mutant_name) {
+            Ok(mutant) => mutant,
+            Err(status) => return status,
+        };
+        self.write_new_mutant_handle(
+            mutant_handle,
+            mutant,
+            MutantAccess::from_desired_access(desired_access),
+        )
+        .map_or_else(|status| status, |()| NtStatus::SUCCESS)
+    }
+
+    pub(crate) fn sys_nt_release_mutant(
+        &self,
+        mutant_handle: Handle,
+        previous_count: Option<MutPtr<Platform, i32>>,
+    ) -> NtStatus {
+        if let Some(previous_count) = previous_count
+            && let Err(status) = probe_guest_output_preserving_value::<Platform, _>(previous_count)
+        {
+            return status;
+        }
+        let entry = match self.typed_handle_entry::<MutantSubsystem<Platform>>(mutant_handle) {
+            Ok(entry) => entry,
+            Err(status) => return status,
+        };
+        let previous = match entry.with_entry(|entry| entry.mutant.release(self.thread_id)) {
+            Ok(previous) => previous,
+            Err(status) => return status,
+        };
+        if let Some(previous_count) = previous_count
+            && previous_count.write_at_offset(0, previous).is_none()
+        {
+            return NtStatus::ACCESS_VIOLATION;
+        }
+        NtStatus::SUCCESS
+    }
+
+    pub(crate) fn sys_nt_query_mutant(
+        &self,
+        mutant_handle: Handle,
+        mutant_information_class: u32,
+        mutant_information: MutPtr<Platform, MutantBasicInformation>,
+        mutant_information_length: u32,
+        return_length: Option<MutPtr<Platform, u32>>,
+    ) -> NtStatus {
+        if mutant_information_class != 0 {
+            return NtStatus::INVALID_INFO_CLASS;
+        }
+        let required_length = u32::try_from(size_of::<MutantBasicInformation>()).unwrap();
+        if mutant_information_length != required_length {
+            return NtStatus::INFO_LENGTH_MISMATCH;
+        }
+        if let Err(status) = probe_guest_output_preserving_value::<Platform, _>(mutant_information)
+        {
+            return status;
+        }
+        if let Some(return_length) = return_length
+            && let Err(status) = probe_guest_output_preserving_value::<Platform, _>(return_length)
+        {
+            return status;
+        }
+        let entry = match self.typed_handle_entry_with_access::<MutantSubsystem<Platform>>(
+            mutant_handle,
+            MutantAccess::QUERY_STATE.bits(),
+        ) {
+            Ok(entry) => entry,
+            Err(status) => return status,
+        };
+        let information = entry.with_entry(|entry| entry.mutant.query(self.thread_id));
+        if mutant_information.write_at_offset(0, information).is_none()
+            || return_length.is_some_and(|return_length| {
+                return_length.write_at_offset(0, required_length).is_none()
+            })
+        {
+            return NtStatus::ACCESS_VIOLATION;
+        }
+        NtStatus::SUCCESS
+    }
+
+    fn write_new_mutant_handle(
+        &self,
+        output: MutPtr<Platform, Handle>,
+        mutant: Arc<MutantObject<Platform>>,
+        granted_access: MutantAccess,
+    ) -> Result<(), NtStatus> {
+        let handle = self
+            .insert_mutant_handle(mutant, granted_access)
+            .map_err(|_| NtStatus::QUOTA_EXCEEDED)?;
+        if output.write_at_offset(0, handle).is_none() {
+            self.close_typed_handle::<MutantSubsystem<Platform>>(handle, drop);
+            return Err(NtStatus::ACCESS_VIOLATION);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::mem::size_of_val;
+
+    use super::*;
+    use crate::tests::{const_ptr, mut_ptr, test_task};
+
+    const MUTANT_ALL_ACCESS: u32 = 0x001f_0001;
+
+    #[test]
+    fn mutant_waits_are_recursive_and_release_restores_signal() {
+        let task = test_task();
+        let mut handle = Handle::default();
+        assert_eq!(
+            task.sys_nt_create_mutant(mut_ptr(&mut handle), MUTANT_ALL_ACCESS, None, 0),
+            NtStatus::SUCCESS
+        );
+
+        let timeout = 0i64;
+        assert_eq!(
+            task.sys_nt_wait_for_single_object(handle, false, Some(const_ptr(&timeout))),
+            NtStatus::SUCCESS
+        );
+        assert_eq!(
+            task.sys_nt_wait_for_single_object(handle, false, Some(const_ptr(&timeout))),
+            NtStatus::SUCCESS
+        );
+
+        let mut previous_count = i32::MAX;
+        assert_eq!(
+            task.sys_nt_release_mutant(handle, Some(mut_ptr(&mut previous_count))),
+            NtStatus::SUCCESS
+        );
+        assert_eq!(previous_count, -1);
+        assert_eq!(task.sys_nt_release_mutant(handle, None), NtStatus::SUCCESS);
+    }
+
+    #[test]
+    fn mutant_query_reports_current_thread_ownership() {
+        let task = test_task();
+        let mut handle = Handle::default();
+        assert_eq!(
+            task.sys_nt_create_mutant(mut_ptr(&mut handle), MUTANT_ALL_ACCESS, None, 1),
+            NtStatus::SUCCESS
+        );
+        let mut information = MutantBasicInformation {
+            current_count: i32::MAX,
+            owned_by_caller: 0,
+            abandoned_state: u8::MAX,
+            padding: [u8::MAX; 2],
+        };
+        let mut return_length = 0;
+        assert_eq!(
+            task.sys_nt_query_mutant(
+                handle,
+                0,
+                mut_ptr(&mut information),
+                size_of_val(&information).try_into().unwrap(),
+                Some(mut_ptr(&mut return_length)),
+            ),
+            NtStatus::SUCCESS
+        );
+        assert_eq!(information.current_count, 0);
+        assert_eq!(information.owned_by_caller, 1);
+        assert_eq!(information.abandoned_state, 0);
+        assert_eq!(return_length as usize, size_of_val(&information));
+    }
+}

--- a/litebox_shim_windows/src/syscalls/object_manager.rs
+++ b/litebox_shim_windows/src/syscalls/object_manager.rs
@@ -24,6 +24,7 @@ use crate::nt_types::{
 };
 use crate::syscalls::Handle;
 use crate::syscalls::event::EventObject;
+use crate::syscalls::mutant::MutantObject;
 use crate::syscalls::section::{
     SectionObject, WINDOWS_SESSION_SHARED_SECTION_OBJECT, WINDOWS_SHARED_SECTION_OBJECT,
 };
@@ -88,6 +89,7 @@ const SEEDED_DIRECTORY_PATHS: &[&str] = &[
     r"\",
     r"\??",
     r"\BaseNamedObjects",
+    r"\BaseNamedObjects\Local",
     r"\Device",
     r"\Driver",
     r"\KnownDlls",
@@ -97,6 +99,7 @@ const SEEDED_DIRECTORY_PATHS: &[&str] = &[
     r"\Sessions",
     r"\Sessions\0",
     r"\Sessions\0\BaseNamedObjects",
+    r"\Sessions\0\BaseNamedObjects\Local",
     r"\Sessions\0\DosDevices",
     r"\Sessions\0\Windows",
     r"\Sessions\0\Windows\WindowStations",
@@ -207,6 +210,9 @@ enum NamedObject<Platform: crate::ShimPlatform> {
     },
     Event {
         event: Weak<EventObject<Platform>>,
+    },
+    Mutant {
+        mutant: Weak<MutantObject<Platform>>,
     },
     Semaphore {
         semaphore: Weak<SemaphoreObject<Platform>>,
@@ -385,6 +391,7 @@ impl<Platform: crate::ShimPlatform> ObjectNode<Platform> {
         new_directory() => NamedObject::Directory { children: BTreeMap::new() };
         new_symlink(target: String) => NamedObject::Symlink { target };
         new_event(event: Weak<EventObject<Platform>>) => NamedObject::Event { event };
+        new_mutant(mutant: Weak<MutantObject<Platform>>) => NamedObject::Mutant { mutant };
         new_semaphore(semaphore: Weak<SemaphoreObject<Platform>>) => NamedObject::Semaphore { semaphore };
         new_section(section: Weak<SectionObject<Platform>>) => NamedObject::Section { section };
         new_file_device(device: FileDeviceObject) => NamedObject::FileDevice { device };
@@ -431,6 +438,7 @@ impl<Platform: crate::ShimPlatform> ObjectNode<Platform> {
         directory_object, ObjectLeafLookup<()>, NamedObject::Directory { .. } => ObjectLeafLookup::Live(());
         pub(super) symlink_target, ObjectLeafLookup<String>, NamedObject::Symlink { target } => ObjectLeafLookup::Live(target.clone());
         event_object, ObjectLeafLookup<Arc<EventObject<Platform>>>, NamedObject::Event { event } => ObjectLeafLookup::from_weak(event);
+        mutant_object, ObjectLeafLookup<Arc<MutantObject<Platform>>>, NamedObject::Mutant { mutant } => ObjectLeafLookup::from_weak(mutant);
         semaphore_object, ObjectLeafLookup<Arc<SemaphoreObject<Platform>>>, NamedObject::Semaphore { semaphore } => ObjectLeafLookup::from_weak(semaphore);
         section_object, ObjectLeafLookup<Arc<SectionObject<Platform>>>, NamedObject::Section { section } => ObjectLeafLookup::from_weak(section);
         file_device_object, ObjectLeafLookup<FileDeviceObject>, NamedObject::FileDevice { device } => ObjectLeafLookup::Live(device.clone());
@@ -442,6 +450,7 @@ impl<Platform: crate::ShimPlatform> ObjectNode<Platform> {
             NamedObject::Directory { .. } => Some("Directory"),
             NamedObject::Symlink { .. } => Some("SymbolicLink"),
             NamedObject::Event { event } => event.upgrade().map(|_| "Event"),
+            NamedObject::Mutant { mutant } => mutant.upgrade().map(|_| "Mutant"),
             NamedObject::Semaphore { semaphore } => semaphore.upgrade().map(|_| "Semaphore"),
             NamedObject::Section { section } => section.upgrade().map(|_| "Section"),
             NamedObject::FileDevice { .. } => Some("Device"),
@@ -534,6 +543,24 @@ impl<Platform: crate::ShimPlatform> ObjectManager<Platform> {
             path,
             |node| node.event_object(),
             |path, parent, name| ObjectNode::new_event(path, parent, name, event),
+            NtStatus::OBJECT_TYPE_MISMATCH,
+            on_exists,
+            |_| on_created(),
+        )
+    }
+
+    pub(super) fn create_mutant(
+        &self,
+        path: &str,
+        mutant: &Arc<MutantObject<Platform>>,
+        on_exists: impl FnOnce(Arc<MutantObject<Platform>>) -> NtStatus,
+        on_created: impl FnOnce() -> NtStatus,
+    ) -> NtStatus {
+        let mutant = Arc::downgrade(mutant);
+        self.create_child(
+            path,
+            |node| node.mutant_object(),
+            |path, parent, name| ObjectNode::new_mutant(path, parent, name, mutant),
             NtStatus::OBJECT_TYPE_MISMATCH,
             on_exists,
             |_| on_created(),
@@ -685,6 +712,13 @@ impl<Platform: crate::ShimPlatform> ObjectManager<Platform> {
 
     pub(super) fn resolve_event(&self, path: &str) -> Result<Arc<EventObject<Platform>>, NtStatus> {
         self.resolve_object_leaf(path, false, |node| node.event_object())
+    }
+
+    pub(super) fn resolve_mutant(
+        &self,
+        path: &str,
+    ) -> Result<Arc<MutantObject<Platform>>, NtStatus> {
+        self.resolve_object_leaf(path, false, |node| node.mutant_object())
     }
 
     pub(super) fn resolve_semaphore(
@@ -922,46 +956,6 @@ fn read_directory_name_string<Platform: RawPointerProvider>(
         return Err(NtStatus::ACCESS_VIOLATION);
     }
     Ok(Some(unicode_string.read_string::<Platform>()?))
-}
-
-pub(super) fn read_dispatcher_object_attributes<Platform: RawPointerProvider>(
-    object_attributes: Option<ConstPtr<Platform, ObjectAttributes>>,
-    require_name: bool,
-) -> Result<(Option<ObjectAttributes>, Option<String>), NtStatus> {
-    let Some(object_attributes_ptr) = object_attributes else {
-        if require_name {
-            return Err(NtStatus::INVALID_PARAMETER);
-        }
-        return Ok((None, None));
-    };
-    let object_attributes = read_object_attributes::<Platform>(object_attributes_ptr)?;
-    if ObjectAttributesFlags::from_bits_retain(object_attributes.attributes)
-        .contains(ObjectAttributesFlags::OPENLINK)
-    {
-        return Err(NtStatus::INVALID_PARAMETER);
-    }
-    if object_attributes.object_name == 0 {
-        if !object_attributes.root_directory.is_null() {
-            return Err(NtStatus::OBJECT_NAME_INVALID);
-        }
-        if require_name {
-            return Err(NtStatus::OBJECT_NAME_INVALID);
-        }
-        return Ok((Some(object_attributes), None));
-    }
-    if !object_attributes.root_directory.is_null() {
-        return Err(NtStatus::OBJECT_PATH_NOT_FOUND);
-    }
-
-    let Some(original_path) =
-        read_directory_name_string::<Platform>(object_attributes.object_name)?
-    else {
-        return Err(NtStatus::OBJECT_NAME_INVALID);
-    };
-    if original_path.is_empty() {
-        return Err(NtStatus::OBJECT_NAME_INVALID);
-    }
-    Ok((Some(object_attributes), Some(original_path)))
 }
 
 fn utf16_byte_len(value: &str) -> Result<usize, NtStatus> {
@@ -1244,6 +1238,31 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         Ok((
             Some(object_attributes),
             Some(DirectoryName { original_path }),
+        ))
+    }
+
+    pub(super) fn read_dispatcher_object_attributes(
+        &self,
+        object_attributes: Option<ConstPtr<Platform, ObjectAttributes>>,
+        require_name: bool,
+    ) -> Result<(Option<ObjectAttributes>, Option<String>), NtStatus> {
+        let Some(object_attributes_ptr) = object_attributes else {
+            if require_name {
+                return Err(NtStatus::INVALID_PARAMETER);
+            }
+            return Ok((None, None));
+        };
+        let (object_attributes, name) =
+            self.read_directory_object_attributes(Some(object_attributes_ptr), require_name)?;
+        if object_attributes.is_some_and(|object_attributes| {
+            ObjectAttributesFlags::from_bits_retain(object_attributes.attributes)
+                .contains(ObjectAttributesFlags::OPENLINK)
+        }) {
+            return Err(NtStatus::INVALID_PARAMETER);
+        }
+        Ok((
+            object_attributes,
+            name.map(|DirectoryName { original_path }| original_path),
         ))
     }
 
@@ -2168,14 +2187,26 @@ mod tests {
     fn directory_lookup_is_case_insensitive_and_case_preserving() {
         run_with_test_platform_pointers(|| {
             let task = test_task();
-            let mixed = create_named_directory(&task, r"\BaseNamedObjects\LiteBoxCaseMixed");
-            let lower_open = open_named_directory(&task, r"\basenamedobjects\liteboxcasemixed");
-            let trailing_open = open_named_directory(&task, r"\BaseNamedObjects\LiteBoxCaseMixed\");
-            let lower_created =
-                create_named_directory(&task, r"\BaseNamedObjects\liteboxcaselower");
-            let upper_open = open_named_directory(&task, r"\BASENAMEDOBJECTS\LITEBOXCASELOWER");
+            let case_root = create_named_directory(&task, r"\BaseNamedObjects\LiteBoxCaseRoot");
+            let mixed = create_named_directory(
+                &task,
+                r"\BaseNamedObjects\LiteBoxCaseRoot\LiteBoxCaseMixed",
+            );
+            let lower_open =
+                open_named_directory(&task, r"\basenamedobjects\liteboxcaseroot\liteboxcasemixed");
+            let trailing_open = open_named_directory(
+                &task,
+                r"\BaseNamedObjects\LiteBoxCaseRoot\LiteBoxCaseMixed\",
+            );
+            let lower_created = create_named_directory(
+                &task,
+                r"\BaseNamedObjects\LiteBoxCaseRoot\liteboxcaselower",
+            );
+            let upper_open =
+                open_named_directory(&task, r"\BASENAMEDOBJECTS\LITEBOXCASEROOT\LITEBOXCASELOWER");
 
-            let duplicate_units = utf16_units(r"\basenamedobjects\liteboxcasemixed\");
+            let duplicate_units =
+                utf16_units(r"\basenamedobjects\liteboxcaseroot\liteboxcasemixed\");
             let duplicate_name = unicode_string(&duplicate_units);
             let duplicate_attrs = object_attributes(
                 &duplicate_name,
@@ -2194,7 +2225,7 @@ mod tests {
             );
             assert_eq!(duplicate, Handle::default());
 
-            let parent = open_named_directory(&task, r"\BaseNamedObjects");
+            let parent = open_named_directory(&task, r"\BaseNamedObjects\LiteBoxCaseRoot");
             let mut buffer = [0u8; 512];
             let mut context = 0u32;
             let mut return_length = 0u32;
@@ -2247,6 +2278,7 @@ mod tests {
             assert_eq!(task.sys_nt_close(trailing_open), NtStatus::SUCCESS);
             assert_eq!(task.sys_nt_close(lower_open), NtStatus::SUCCESS);
             assert_eq!(task.sys_nt_close(mixed), NtStatus::SUCCESS);
+            assert_eq!(task.sys_nt_close(case_root), NtStatus::SUCCESS);
         });
     }
 
@@ -2404,18 +2436,7 @@ mod tests {
     fn query_empty_directory_reports_no_more_entries() {
         run_with_test_platform_pointers(|| {
             let task = test_task();
-            let name_units = utf16_units(r"\BaseNamedObjects");
-            let name = unicode_string(&name_units);
-            let attrs = object_attributes(&name, ObjectAttributesFlags::CASE_INSENSITIVE.bits());
-            let mut handle = Handle::default();
-            assert_eq!(
-                task.sys_nt_open_directory_object(
-                    mut_ptr(&mut handle),
-                    DIRECTORY_QUERY,
-                    Some(const_ptr(&attrs)),
-                ),
-                NtStatus::SUCCESS
-            );
+            let handle = create_named_directory(&task, r"\BaseNamedObjects\LiteBoxEmpty");
 
             let mut buffer = [0xffu8; 32];
             let mut context = 99u32;
@@ -2443,9 +2464,11 @@ mod tests {
     fn query_directory_enumerates_children_in_stable_order() {
         run_with_test_platform_pointers(|| {
             let task = test_task();
-            let first = create_named_directory(&task, r"\BaseNamedObjects\LiteBoxEnumB");
-            let second = create_named_directory(&task, r"\BaseNamedObjects\LiteBoxEnumA");
-            let handle = open_named_directory(&task, r"\BaseNamedObjects");
+            let handle = create_named_directory(&task, r"\BaseNamedObjects\LiteBoxEnumRoot");
+            let first =
+                create_named_directory(&task, r"\BaseNamedObjects\LiteBoxEnumRoot\LiteBoxEnumB");
+            let second =
+                create_named_directory(&task, r"\BaseNamedObjects\LiteBoxEnumRoot\LiteBoxEnumA");
             let mut buffer = [0u8; 512];
             let mut context = u32::MAX;
             let mut return_length = 0u32;
@@ -2502,9 +2525,15 @@ mod tests {
     fn query_directory_single_entry_uses_context_cookie() {
         run_with_test_platform_pointers(|| {
             let task = test_task();
-            let first = create_named_directory(&task, r"\BaseNamedObjects\LiteBoxSingleA");
-            let second = create_named_directory(&task, r"\BaseNamedObjects\LiteBoxSingleB");
-            let handle = open_named_directory(&task, r"\BaseNamedObjects");
+            let handle = create_named_directory(&task, r"\BaseNamedObjects\LiteBoxSingleRoot");
+            let first = create_named_directory(
+                &task,
+                r"\BaseNamedObjects\LiteBoxSingleRoot\LiteBoxSingleA",
+            );
+            let second = create_named_directory(
+                &task,
+                r"\BaseNamedObjects\LiteBoxSingleRoot\LiteBoxSingleB",
+            );
             let mut buffer = [0u8; 256];
             let mut context = 123u32;
             let mut return_length = 0u32;
@@ -2562,8 +2591,9 @@ mod tests {
     fn query_directory_too_small_reports_required_length_without_advancing_context() {
         run_with_test_platform_pointers(|| {
             let task = test_task();
-            let child = create_named_directory(&task, r"\BaseNamedObjects\LiteBoxSmall");
-            let handle = open_named_directory(&task, r"\BaseNamedObjects");
+            let handle = create_named_directory(&task, r"\BaseNamedObjects\LiteBoxSmallRoot");
+            let child =
+                create_named_directory(&task, r"\BaseNamedObjects\LiteBoxSmallRoot\LiteBoxSmall");
             let mut buffer = [0xffu8; 8];
             let mut context = 99u32;
             let mut return_length = 0u32;

--- a/litebox_shim_windows/src/syscalls/process.rs
+++ b/litebox_shim_windows/src/syscalls/process.rs
@@ -517,7 +517,9 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                 return NtStatus::ACCESS_VIOLATION;
             };
             // TODO(multi-thread-tls): read ith thread's tls
-            let teb = MutPtr::<Platform, ThreadEnvironmentBlock>::from_usize(self.teb_address);
+            let teb = MutPtr::<Platform, ThreadEnvironmentBlock>::from_usize(
+                self.thread_object.teb_address(),
+            );
             let Some(old_tls_data) = Self::read_teb_tls_pointer(teb) else {
                 return NtStatus::ACCESS_VIOLATION;
             };
@@ -571,7 +573,9 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                 return NtStatus::ACCESS_VIOLATION;
             };
             // TODO(multi-thread-tls): read ith thread's tls
-            let teb = ConstPtr::<Platform, ThreadEnvironmentBlock>::from_usize(self.teb_address);
+            let teb = ConstPtr::<Platform, ThreadEnvironmentBlock>::from_usize(
+                self.thread_object.teb_address(),
+            );
             let Some(tls_array) = Self::read_teb_tls_pointer(teb) else {
                 return NtStatus::ACCESS_VIOLATION;
             };
@@ -608,12 +612,10 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
     }
 
     fn guest_visible_old_tls_vector(&self, old_tls_data: usize) -> usize {
+        let teb_address = self.thread_object.teb_address();
         if old_tls_data > 0x10010
-            && old_tls_data >= self.teb_address
-            && old_tls_data
-                < self
-                    .teb_address
-                    .saturating_add(size_of::<ThreadEnvironmentBlock>())
+            && old_tls_data >= teb_address
+            && old_tls_data < teb_address.saturating_add(size_of::<ThreadEnvironmentBlock>())
         {
             // The loader frees the returned old vector. The initial vector lives inside
             // TEB.tls_slots, so report no heap-backed vector instead of exposing TEB memory.
@@ -632,7 +634,8 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             return Ok(());
         }
         let initial_tls_slots = self
-            .teb_address
+            .thread_object
+            .teb_address()
             .checked_add(offset_of!(ThreadEnvironmentBlock, tls_slots))
             .ok_or(NtStatus::INVALID_PARAMETER)?;
         if old_tls_data != initial_tls_slots {

--- a/litebox_shim_windows/src/syscalls/semaphore.rs
+++ b/litebox_shim_windows/src/syscalls/semaphore.rs
@@ -286,7 +286,6 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
 }
 
 // TODO(semaphore-query): Implement NtQuerySemaphore.
-// TODO(mutants): Implement NT mutant dispatcher objects and syscalls.
 
 #[cfg(test)]
 mod tests {

--- a/litebox_shim_windows/src/syscalls/semaphore.rs
+++ b/litebox_shim_windows/src/syscalls/semaphore.rs
@@ -14,7 +14,6 @@ use litebox_common_windows::nt_status::NtStatus;
 
 use crate::nt_types::{AccessMask, ObjectAttributes, ObjectAttributesFlags};
 use crate::syscalls::Handle;
-use crate::syscalls::object_manager::read_dispatcher_object_attributes;
 use crate::{ConstPtr, MutPtr, ShimFS, Task, probe_guest_output_preserving_value};
 
 bitflags::bitflags! {
@@ -160,7 +159,7 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         }
 
         let (object_attributes, semaphore_name) =
-            match read_dispatcher_object_attributes::<Platform>(object_attributes, false) {
+            match self.read_dispatcher_object_attributes(object_attributes, false) {
                 Ok(value) => value,
                 Err(status) => return status,
             };
@@ -224,12 +223,11 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         if let Err(status) = probe_guest_output_preserving_value::<Platform, _>(semaphore_handle) {
             return status;
         }
-        let semaphore_name =
-            match read_dispatcher_object_attributes::<Platform>(object_attributes, true) {
-                Ok((_, Some(semaphore_name))) => semaphore_name,
-                Ok((_, None)) => return NtStatus::OBJECT_NAME_INVALID,
-                Err(status) => return status,
-            };
+        let semaphore_name = match self.read_dispatcher_object_attributes(object_attributes, true) {
+            Ok((_, Some(semaphore_name))) => semaphore_name,
+            Ok((_, None)) => return NtStatus::OBJECT_NAME_INVALID,
+            Err(status) => return status,
+        };
         let semaphore = match self
             .process
             .object_manager

--- a/litebox_shim_windows/src/syscalls/thread.rs
+++ b/litebox_shim_windows/src/syscalls/thread.rs
@@ -643,21 +643,6 @@ mod tests {
     type TestPlatform = crate::tests::TestPlatform;
     type TestTask = Task<TestPlatform, crate::tests::TestFS>;
 
-    fn empty_thread_basic_information() -> ThreadBasicInformation {
-        ThreadBasicInformation {
-            exit_status: i32::MIN,
-            _padding0: u32::MAX,
-            teb_base_address: usize::MAX,
-            client_id: ClientId {
-                unique_process: usize::MAX,
-                unique_thread: usize::MAX,
-            },
-            affinity_mask: usize::MAX,
-            priority: i32::MIN,
-            base_priority: i32::MIN,
-        }
-    }
-
     fn const_byte_ptr<T>(value: &T) -> ConstPtr<TestPlatform, u8> {
         ConstPtr::<TestPlatform, u8>::from_usize(core::ptr::from_ref(value).cast::<u8>() as usize)
     }
@@ -717,100 +702,6 @@ mod tests {
             assert_eq!(is_last_thread, 1);
             assert_eq!(return_length as usize, size_of::<u32>());
             assert_eq!(parent.process.live_thread_count(), 1);
-        });
-    }
-
-    #[test]
-    fn basic_information_reports_running_and_completed_thread_status() {
-        run_with_test_platform_pointers(|| {
-            let parent = crate::tests::test_task();
-            let mut information = empty_thread_basic_information();
-            let mut return_length = 0;
-            assert_eq!(
-                parent.sys_nt_query_information_thread(
-                    ThreadHandle::CURRENT,
-                    QueryThreadInformationClass::BasicInformation as u32,
-                    mut_byte_ptr(&mut information),
-                    size_of::<ThreadBasicInformation>().trunc(),
-                    Some(mut_ptr(&mut return_length)),
-                ),
-                NtStatus::SUCCESS
-            );
-            assert_eq!(information.exit_status, NtStatus::PENDING.as_raw());
-            assert_eq!(
-                information.teb_base_address,
-                parent.thread_object.teb_address()
-            );
-            assert_eq!(information.client_id.unique_process, parent.process.id);
-            assert_eq!(
-                information.client_id.unique_thread,
-                parent.thread_object.thread_id()
-            );
-            assert_eq!(return_length as usize, size_of::<ThreadBasicInformation>());
-
-            information = empty_thread_basic_information();
-            assert_eq!(
-                parent.sys_nt_query_information_thread(
-                    ThreadHandle::CURRENT,
-                    QueryThreadInformationClass::BasicInformation as u32,
-                    mut_byte_ptr(&mut information),
-                    (size_of::<ThreadBasicInformation>() - 1).trunc(),
-                    None,
-                ),
-                NtStatus::INFO_LENGTH_MISMATCH
-            );
-            assert_eq!(information, empty_thread_basic_information());
-
-            let child = parent.clone_for_test().expect("process is live");
-            let child_id = child.thread_object.thread_id();
-            let child_thread = Arc::clone(&child.thread_object);
-            let handle = parent
-                .insert_typed_handle::<ThreadSubsystem<TestPlatform>>(
-                    ThreadHandleObject {
-                        thread: Arc::clone(&child_thread),
-                    },
-                    ThreadAccess::QUERY_INFORMATION.bits(),
-                    drop,
-                )
-                .expect("thread handle insertion should succeed");
-            child_thread.exit_thread(NtStatus::UNSUCCESSFUL.as_raw());
-            child.complete_current_thread();
-
-            information = empty_thread_basic_information();
-            assert_eq!(
-                parent.sys_nt_query_information_thread(
-                    ThreadHandle::from_raw(handle.as_raw()),
-                    QueryThreadInformationClass::BasicInformation as u32,
-                    mut_byte_ptr(&mut information),
-                    size_of::<ThreadBasicInformation>().trunc(),
-                    None,
-                ),
-                NtStatus::SUCCESS
-            );
-            assert_eq!(information.exit_status, NtStatus::UNSUCCESSFUL.as_raw());
-            assert_eq!(information.client_id.unique_thread, child_id);
-            assert_eq!(parent.sys_nt_close(handle), NtStatus::SUCCESS);
-
-            let handle = parent
-                .insert_typed_handle::<ThreadSubsystem<TestPlatform>>(
-                    ThreadHandleObject {
-                        thread: child_thread,
-                    },
-                    AccessMask::SYNCHRONIZE.bits(),
-                    drop,
-                )
-                .expect("thread handle insertion should succeed");
-            assert_eq!(
-                parent.sys_nt_query_information_thread(
-                    ThreadHandle::from_raw(handle.as_raw()),
-                    QueryThreadInformationClass::BasicInformation as u32,
-                    mut_byte_ptr(&mut information),
-                    size_of::<ThreadBasicInformation>().trunc(),
-                    None,
-                ),
-                NtStatus::ACCESS_DENIED
-            );
-            assert_eq!(parent.sys_nt_close(handle), NtStatus::SUCCESS);
         });
     }
 

--- a/litebox_shim_windows/src/syscalls/thread.rs
+++ b/litebox_shim_windows/src/syscalls/thread.rs
@@ -3,6 +3,7 @@
 
 use alloc::boxed::Box;
 use alloc::sync::{Arc, Weak};
+use alloc::vec::Vec;
 use core::marker::PhantomData;
 use core::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 
@@ -10,13 +11,15 @@ use int_enum::IntEnum;
 use litebox::event::{Events, IOPollable, observer::Observer, polling::Pollee};
 use litebox::fd::{FdEnabledSubsystem, FdEnabledSubsystemEntry};
 use litebox::platform::{RawConstPointer as _, RawMutPointer as _};
+use litebox::sync::Mutex;
 use litebox::utils::TruncateExt as _;
 use litebox_common_windows::nt_status::NtStatus;
-use zerocopy::{FromBytes, Immutable};
+use zerocopy::{FromBytes, Immutable, IntoBytes};
 
 use crate::loader::create_thread_environment;
 use crate::nt_types::{AccessMask, ClientId, ObjectAttributes, X64Context};
 use crate::syscalls::ProcessHandle;
+use crate::syscalls::mutant::MutantObject;
 use crate::syscalls::{Handle, ThreadHandle};
 use crate::{
     ConstPtr, MutPtr, ShimFS, ShimPlatform, Task, WindowsShimEntrypoints,
@@ -101,6 +104,8 @@ pub(crate) struct ThreadHandleObject<Platform: ShimPlatform> {
 }
 
 pub(crate) struct ThreadObject<Platform: ShimPlatform> {
+    thread_id: usize,
+    teb_address: usize,
     completion_state: AtomicU8,
     exit_status: core::sync::atomic::AtomicI32,
     pollee: Pollee<Platform>,
@@ -110,6 +115,7 @@ pub(crate) struct ThreadObject<Platform: ShimPlatform> {
     /// Handle used to interrupt the thread, published once by the thread itself
     /// when it starts running. Empty until then.
     wait_handle: once_cell::race::OnceBox<litebox::event::wait::ThreadHandle<Platform>>,
+    owned_mutants: Mutex<Platform, Vec<Weak<MutantObject<Platform>>>>,
 }
 
 impl<Platform: ShimPlatform> ThreadObject<Platform> {
@@ -117,13 +123,52 @@ impl<Platform: ShimPlatform> ThreadObject<Platform> {
     const COMPLETING: u8 = 1;
     const COMPLETE: u8 = 2;
 
-    pub(crate) fn new() -> Self {
+    pub(crate) fn new(thread_id: usize, teb_address: usize) -> Self {
         Self {
+            thread_id,
+            teb_address,
             completion_state: AtomicU8::new(Self::RUNNING),
-            exit_status: core::sync::atomic::AtomicI32::new(0),
+            exit_status: core::sync::atomic::AtomicI32::new(NtStatus::PENDING.as_raw()),
             pollee: Pollee::new(),
             is_exiting: AtomicBool::new(false),
             wait_handle: once_cell::race::OnceBox::new(),
+            owned_mutants: Mutex::new(Vec::new()),
+        }
+    }
+
+    pub(crate) fn thread_id(&self) -> usize {
+        self.thread_id
+    }
+
+    pub(crate) fn teb_address(&self) -> usize {
+        self.teb_address
+    }
+
+    pub(crate) fn register_owned_mutant(&self, mutant: &Arc<MutantObject<Platform>>) {
+        let mutant_ptr = Arc::as_ptr(mutant);
+        let mut owned_mutants = self.owned_mutants.lock();
+        owned_mutants.retain(|owned| owned.strong_count() != 0);
+        if !owned_mutants
+            .iter()
+            .any(|owned| owned.as_ptr() == mutant_ptr)
+        {
+            owned_mutants.push(Arc::downgrade(mutant));
+        }
+    }
+
+    pub(crate) fn unregister_owned_mutant(&self, mutant: &Arc<MutantObject<Platform>>) {
+        let mutant_ptr = Arc::as_ptr(mutant);
+        self.owned_mutants
+            .lock()
+            .retain(|owned| owned.strong_count() != 0 && owned.as_ptr() != mutant_ptr);
+    }
+
+    pub(crate) fn abandon_owned_mutants(&self, thread_id: usize) {
+        let owned_mutants = core::mem::take(&mut *self.owned_mutants.lock());
+        for mutant in owned_mutants {
+            if let Some(mutant) = mutant.upgrade() {
+                mutant.abandon(thread_id);
+            }
         }
     }
 
@@ -227,7 +272,20 @@ enum ThreadInformationClass {
 #[repr(u32)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, IntEnum)]
 enum QueryThreadInformationClass {
+    BasicInformation = 0,
     AmILastThread = 12,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, FromBytes, Immutable, IntoBytes, PartialEq)]
+struct ThreadBasicInformation {
+    exit_status: i32,
+    _padding0: u32,
+    teb_base_address: usize,
+    client_id: ClientId,
+    affinity_mask: usize,
+    priority: i32,
+    base_priority: i32,
 }
 
 #[repr(C)]
@@ -331,7 +389,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         child_ctx.rcx = environment.context;
         child_ctx.rdx = ntdll.mapping.base_addr;
 
-        let thread = Arc::new(ThreadObject::new());
+        let thread = Arc::new(ThreadObject::new(thread_id, environment.teb));
         if !self.process.attach_thread(thread_id, &thread) {
             // The process is tearing down; refuse to start another thread.
             return NtStatus::PROCESS_IS_TERMINATING;
@@ -358,8 +416,6 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             entry_point: ntdll.ldr_initialize_thunk,
             stack_top: environment.stack_top,
             context: environment.context,
-            teb_address: environment.teb,
-            thread_id,
             thread_object: thread,
         };
         // SAFETY: `child_ctx` points at mapped guest code and stack created above, and the
@@ -389,27 +445,83 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         thread_information_length: u32,
         return_length: Option<MutPtr<Platform, u32>>,
     ) -> NtStatus {
-        let Ok(QueryThreadInformationClass::AmILastThread) =
+        let Ok(thread_information_class) =
             QueryThreadInformationClass::try_from(thread_information_class)
         else {
+            litebox_util_log::debug!(
+                thread_information_class = thread_information_class;
+                "Unsupported NtQueryInformationThread class"
+            );
             return NtStatus::INVALID_INFO_CLASS;
         };
-        if thread_information_length as usize != core::mem::size_of::<u32>() {
+
+        match thread_information_class {
+            QueryThreadInformationClass::BasicInformation => {
+                let thread = if thread_handle.is_current() {
+                    Arc::clone(&self.thread_object)
+                } else {
+                    let entry = match self
+                        .typed_handle_entry_with_access::<ThreadSubsystem<Platform>>(
+                            thread_handle.as_handle(),
+                            ThreadAccess::QUERY_INFORMATION.bits(),
+                        ) {
+                        Ok(entry) => entry,
+                        Err(status) => return status,
+                    };
+                    entry.with_entry(|entry| Arc::clone(&entry.thread))
+                };
+                let information = ThreadBasicInformation {
+                    exit_status: thread.exit_status(),
+                    _padding0: 0,
+                    teb_base_address: thread.teb_address,
+                    client_id: ClientId {
+                        unique_process: self.process.id,
+                        unique_thread: thread.thread_id,
+                    },
+                    affinity_mask: 1,
+                    priority: 8,
+                    base_priority: 8,
+                };
+                Self::write_thread_information(
+                    thread_information,
+                    thread_information_length,
+                    return_length,
+                    &information,
+                )
+            }
+            QueryThreadInformationClass::AmILastThread => {
+                if !thread_handle.is_current() {
+                    return NtStatus::NOT_SUPPORTED;
+                }
+                let is_last_thread = u32::from(self.process.live_thread_count() == 1);
+                Self::write_thread_information(
+                    thread_information,
+                    thread_information_length,
+                    return_length,
+                    &is_last_thread,
+                )
+            }
+        }
+    }
+
+    fn write_thread_information<T: Immutable + IntoBytes>(
+        thread_information: MutPtr<Platform, u8>,
+        thread_information_length: u32,
+        return_length: Option<MutPtr<Platform, u32>>,
+        information: &T,
+    ) -> NtStatus {
+        let required_length = size_of::<T>().trunc();
+        if thread_information_length < required_length {
             return NtStatus::INFO_LENGTH_MISMATCH;
         }
-        if !thread_handle.is_current() {
-            return NtStatus::NOT_SUPPORTED;
-        }
-
-        let is_last_thread = u32::from(self.process.live_thread_count() == 1);
-        let output = MutPtr::<Platform, u32>::from_usize(thread_information.as_usize());
-        if output.write_at_offset(0, is_last_thread).is_none() {
+        if thread_information
+            .write_slice_at_offset(0, information.as_bytes())
+            .is_none()
+        {
             return NtStatus::ACCESS_VIOLATION;
         }
         if let Some(return_length) = return_length
-            && return_length
-                .write_at_offset(0, core::mem::size_of::<u32>().trunc())
-                .is_none()
+            && return_length.write_at_offset(0, required_length).is_none()
         {
             return NtStatus::ACCESS_VIOLATION;
         }
@@ -531,6 +643,21 @@ mod tests {
     type TestPlatform = crate::tests::TestPlatform;
     type TestTask = Task<TestPlatform, crate::tests::TestFS>;
 
+    fn empty_thread_basic_information() -> ThreadBasicInformation {
+        ThreadBasicInformation {
+            exit_status: i32::MIN,
+            _padding0: u32::MAX,
+            teb_base_address: usize::MAX,
+            client_id: ClientId {
+                unique_process: usize::MAX,
+                unique_thread: usize::MAX,
+            },
+            affinity_mask: usize::MAX,
+            priority: i32::MIN,
+            base_priority: i32::MIN,
+        }
+    }
+
     fn const_byte_ptr<T>(value: &T) -> ConstPtr<TestPlatform, u8> {
         ConstPtr::<TestPlatform, u8>::from_usize(core::ptr::from_ref(value).cast::<u8>() as usize)
     }
@@ -590,6 +717,100 @@ mod tests {
             assert_eq!(is_last_thread, 1);
             assert_eq!(return_length as usize, size_of::<u32>());
             assert_eq!(parent.process.live_thread_count(), 1);
+        });
+    }
+
+    #[test]
+    fn basic_information_reports_running_and_completed_thread_status() {
+        run_with_test_platform_pointers(|| {
+            let parent = crate::tests::test_task();
+            let mut information = empty_thread_basic_information();
+            let mut return_length = 0;
+            assert_eq!(
+                parent.sys_nt_query_information_thread(
+                    ThreadHandle::CURRENT,
+                    QueryThreadInformationClass::BasicInformation as u32,
+                    mut_byte_ptr(&mut information),
+                    size_of::<ThreadBasicInformation>().trunc(),
+                    Some(mut_ptr(&mut return_length)),
+                ),
+                NtStatus::SUCCESS
+            );
+            assert_eq!(information.exit_status, NtStatus::PENDING.as_raw());
+            assert_eq!(
+                information.teb_base_address,
+                parent.thread_object.teb_address()
+            );
+            assert_eq!(information.client_id.unique_process, parent.process.id);
+            assert_eq!(
+                information.client_id.unique_thread,
+                parent.thread_object.thread_id()
+            );
+            assert_eq!(return_length as usize, size_of::<ThreadBasicInformation>());
+
+            information = empty_thread_basic_information();
+            assert_eq!(
+                parent.sys_nt_query_information_thread(
+                    ThreadHandle::CURRENT,
+                    QueryThreadInformationClass::BasicInformation as u32,
+                    mut_byte_ptr(&mut information),
+                    (size_of::<ThreadBasicInformation>() - 1).trunc(),
+                    None,
+                ),
+                NtStatus::INFO_LENGTH_MISMATCH
+            );
+            assert_eq!(information, empty_thread_basic_information());
+
+            let child = parent.clone_for_test().expect("process is live");
+            let child_id = child.thread_object.thread_id();
+            let child_thread = Arc::clone(&child.thread_object);
+            let handle = parent
+                .insert_typed_handle::<ThreadSubsystem<TestPlatform>>(
+                    ThreadHandleObject {
+                        thread: Arc::clone(&child_thread),
+                    },
+                    ThreadAccess::QUERY_INFORMATION.bits(),
+                    drop,
+                )
+                .expect("thread handle insertion should succeed");
+            child_thread.exit_thread(NtStatus::UNSUCCESSFUL.as_raw());
+            child.complete_current_thread();
+
+            information = empty_thread_basic_information();
+            assert_eq!(
+                parent.sys_nt_query_information_thread(
+                    ThreadHandle::from_raw(handle.as_raw()),
+                    QueryThreadInformationClass::BasicInformation as u32,
+                    mut_byte_ptr(&mut information),
+                    size_of::<ThreadBasicInformation>().trunc(),
+                    None,
+                ),
+                NtStatus::SUCCESS
+            );
+            assert_eq!(information.exit_status, NtStatus::UNSUCCESSFUL.as_raw());
+            assert_eq!(information.client_id.unique_thread, child_id);
+            assert_eq!(parent.sys_nt_close(handle), NtStatus::SUCCESS);
+
+            let handle = parent
+                .insert_typed_handle::<ThreadSubsystem<TestPlatform>>(
+                    ThreadHandleObject {
+                        thread: child_thread,
+                    },
+                    AccessMask::SYNCHRONIZE.bits(),
+                    drop,
+                )
+                .expect("thread handle insertion should succeed");
+            assert_eq!(
+                parent.sys_nt_query_information_thread(
+                    ThreadHandle::from_raw(handle.as_raw()),
+                    QueryThreadInformationClass::BasicInformation as u32,
+                    mut_byte_ptr(&mut information),
+                    size_of::<ThreadBasicInformation>().trunc(),
+                    None,
+                ),
+                NtStatus::ACCESS_DENIED
+            );
+            assert_eq!(parent.sys_nt_close(handle), NtStatus::SUCCESS);
         });
     }
 

--- a/litebox_shim_windows/src/syscalls/wait.rs
+++ b/litebox_shim_windows/src/syscalls/wait.rs
@@ -13,11 +13,11 @@ use litebox::platform::{RawConstPointer as _, SystemTime as _};
 use litebox_common_windows::nt_status::NtStatus;
 
 use crate::nt_types::AccessMask;
-use crate::syscalls::Handle;
 use crate::syscalls::event::{EventObject, EventSubsystem};
 use crate::syscalls::mutant::{MutantObject, MutantSubsystem};
 use crate::syscalls::semaphore::{SemaphoreObject, SemaphoreSubsystem};
 use crate::syscalls::thread::{ThreadObject, ThreadSubsystem};
+use crate::syscalls::{Handle, WaitAcquireResult};
 use crate::{ConstPtr, ShimFS, ShimPlatform, Task};
 
 /// A dispatcher object that a guest thread can block on.
@@ -40,14 +40,23 @@ impl<Platform: ShimPlatform> WaitableObject<Platform> {
     }
 
     /// Attempts to satisfy a wait, consuming the signal if the object
-    /// auto-resets. Returns `false` while the object is nonsignaled.
-    fn try_acquire(&self, thread_id: usize) -> bool {
+    /// auto-resets. Returns `None` while the object is nonsignaled.
+    fn try_acquire(
+        &self,
+        thread_id: usize,
+        thread: &ThreadObject<Platform>,
+    ) -> Option<WaitAcquireResult> {
         match self {
             // Thread completion is terminal, so readiness is enough.
-            Self::Thread(thread) => thread.check_io_events().contains(Events::IN),
-            Self::Event(event) => event.try_acquire(),
-            Self::Mutant(mutant) => mutant.try_acquire(thread_id),
-            Self::Semaphore(semaphore) => semaphore.try_acquire(),
+            Self::Thread(thread) => thread
+                .check_io_events()
+                .contains(Events::IN)
+                .then_some(WaitAcquireResult::Acquired),
+            Self::Event(event) => event.try_acquire().then_some(WaitAcquireResult::Acquired),
+            Self::Mutant(mutant) => mutant.try_acquire(thread_id, thread),
+            Self::Semaphore(semaphore) => semaphore
+                .try_acquire()
+                .then_some(WaitAcquireResult::Acquired),
         }
     }
 }
@@ -79,7 +88,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         try_wait!(MutantSubsystem<Platform>, Mutant, mutant);
         try_wait!(SemaphoreSubsystem<Platform>, Semaphore, semaphore);
 
-        // TODO(waitable-objects): timers, mutants, processes and
+        // TODO(waitable-objects): timers, processes and
         // I/O completion ports are waitable on the host but not yet modeled.
         litebox_util_log::debug!(
             handle:? = handle;
@@ -121,27 +130,15 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                 Ok(())
             },
             || {
-                if object.try_acquire(self.thread_id) {
-                    Ok(())
-                } else {
-                    Err(TryOpError::<NtStatus>::TryAgain)
-                }
+                object
+                    .try_acquire(self.thread_object.thread_id(), &self.thread_object)
+                    .ok_or(TryOpError::<NtStatus>::TryAgain)
             },
         ) {
-            Ok(()) => {
-                match &object {
-                    WaitableObject::Thread(thread) => litebox_util_log::debug!(
-                        exit_status = thread.exit_status();
-                        "Thread wait completed"
-                    ),
-                    WaitableObject::Event(_) => litebox_util_log::debug!("Event wait completed"),
-                    WaitableObject::Mutant(_) => litebox_util_log::debug!("Mutant wait completed"),
-                    WaitableObject::Semaphore(_) => {
-                        litebox_util_log::debug!("Semaphore wait completed");
-                    }
-                }
-                NtStatus::SUCCESS
-            }
+            Ok(acquire_result) => match acquire_result {
+                WaitAcquireResult::Acquired => NtStatus::SUCCESS,
+                WaitAcquireResult::Abandoned => NtStatus::ABANDONED_WAIT_0,
+            },
             Err(TryOpError::WaitError(WaitError::TimedOut)) => NtStatus::TIMEOUT,
             Err(TryOpError::WaitError(WaitError::Interrupted)) => NtStatus::ALERTED,
             Err(TryOpError::TryAgain) => unreachable!("blocking wait cannot return TryAgain"),

--- a/litebox_shim_windows/src/syscalls/wait.rs
+++ b/litebox_shim_windows/src/syscalls/wait.rs
@@ -15,6 +15,7 @@ use litebox_common_windows::nt_status::NtStatus;
 use crate::nt_types::AccessMask;
 use crate::syscalls::Handle;
 use crate::syscalls::event::{EventObject, EventSubsystem};
+use crate::syscalls::mutant::{MutantObject, MutantSubsystem};
 use crate::syscalls::semaphore::{SemaphoreObject, SemaphoreSubsystem};
 use crate::syscalls::thread::{ThreadObject, ThreadSubsystem};
 use crate::{ConstPtr, ShimFS, ShimPlatform, Task};
@@ -23,6 +24,7 @@ use crate::{ConstPtr, ShimFS, ShimPlatform, Task};
 enum WaitableObject<Platform: ShimPlatform> {
     Thread(Arc<ThreadObject<Platform>>),
     Event(Arc<EventObject<Platform>>),
+    Mutant(Arc<MutantObject<Platform>>),
     Semaphore(Arc<SemaphoreObject<Platform>>),
 }
 
@@ -32,17 +34,19 @@ impl<Platform: ShimPlatform> WaitableObject<Platform> {
         match self {
             Self::Thread(thread) => thread.register_observer(observer, mask),
             Self::Event(event) => event.register_observer(observer, mask),
+            Self::Mutant(mutant) => mutant.register_observer(observer, mask),
             Self::Semaphore(semaphore) => semaphore.register_observer(observer, mask),
         }
     }
 
     /// Attempts to satisfy a wait, consuming the signal if the object
     /// auto-resets. Returns `false` while the object is nonsignaled.
-    fn try_acquire(&self) -> bool {
+    fn try_acquire(&self, thread_id: usize) -> bool {
         match self {
             // Thread completion is terminal, so readiness is enough.
             Self::Thread(thread) => thread.check_io_events().contains(Events::IN),
             Self::Event(event) => event.try_acquire(),
+            Self::Mutant(mutant) => mutant.try_acquire(thread_id),
             Self::Semaphore(semaphore) => semaphore.try_acquire(),
         }
     }
@@ -72,6 +76,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
 
         try_wait!(ThreadSubsystem<Platform>, Thread, thread);
         try_wait!(EventSubsystem<Platform>, Event, event);
+        try_wait!(MutantSubsystem<Platform>, Mutant, mutant);
         try_wait!(SemaphoreSubsystem<Platform>, Semaphore, semaphore);
 
         // TODO(waitable-objects): timers, mutants, processes and
@@ -116,7 +121,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                 Ok(())
             },
             || {
-                if object.try_acquire() {
+                if object.try_acquire(self.thread_id) {
                     Ok(())
                 } else {
                     Err(TryOpError::<NtStatus>::TryAgain)
@@ -130,6 +135,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                         "Thread wait completed"
                     ),
                     WaitableObject::Event(_) => litebox_util_log::debug!("Event wait completed"),
+                    WaitableObject::Mutant(_) => litebox_util_log::debug!("Mutant wait completed"),
                     WaitableObject::Semaphore(_) => {
                         litebox_util_log::debug!("Semaphore wait completed");
                     }

--- a/litebox_shim_windows/src/tests.rs
+++ b/litebox_shim_windows/src/tests.rs
@@ -163,7 +163,10 @@ pub(crate) fn test_task_with_nls_files(nls_files: &[(&str, &[u8])]) -> Task<Test
         crate::syscalls::section::load_time_windows_shared_section(windows_shared_section_base);
 
     let process = Arc::new(Process::default(None, windows_shared_section));
-    let thread_object = Arc::new(crate::syscalls::thread::ThreadObject::new());
+    let thread_object = Arc::new(crate::syscalls::thread::ThreadObject::new(
+        crate::syscalls::process::INITIAL_THREAD_ID,
+        0,
+    ));
     assert!(process.attach_thread(crate::syscalls::process::INITIAL_THREAD_ID, &thread_object));
 
     Task {
@@ -174,8 +177,6 @@ pub(crate) fn test_task_with_nls_files(nls_files: &[(&str, &[u8])]) -> Task<Test
         entry_point: 0,
         stack_top: 0,
         context: 0,
-        teb_address: 0,
-        thread_id: crate::syscalls::process::INITIAL_THREAD_ID,
         thread_object,
     }
 }
@@ -195,7 +196,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
     /// zeroed because such a task never runs guest code.
     pub(crate) fn clone_for_test(&self) -> Option<Self> {
         let thread_id = self.process.allocate_thread_id();
-        let thread_object = Arc::new(crate::syscalls::thread::ThreadObject::new());
+        let thread_object = Arc::new(crate::syscalls::thread::ThreadObject::new(thread_id, 0));
         if !self.process.attach_thread(thread_id, &thread_object) {
             return None;
         }
@@ -207,8 +208,6 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             entry_point: 0,
             stack_top: 0,
             context: 0,
-            teb_address: 0,
-            thread_id,
             thread_object,
         })
     }


### PR DESCRIPTION
Implement `NtCreateMutant`, `NtOpenMutant`, `NtReleaseMutant`, and `NtQueryMutant`.