### PR TITLE
LVBS: Use reference counters for page tables

### DIFF
--- a/litebox_platform_lvbs/src/host/per_cpu_variables.rs
+++ b/litebox_platform_lvbs/src/host/per_cpu_variables.rs
@@ -248,7 +248,7 @@ impl PerCpuVariables {
         &self,
         page_table_id: usize,
     ) -> Option<Arc<crate::mm::PageTable<PAGE_SIZE>>> {
-        // SAFETY: This field is private to the current core.
+        // Safety: This field is private to the current core.
         unsafe { &*self.active_page_table.get() }
             .as_ref()
             .filter(|(id, _)| *id == page_table_id)
@@ -264,7 +264,8 @@ impl PerCpuVariables {
         page_table: Option<(usize, Arc<crate::mm::PageTable<PAGE_SIZE>>)>,
     ) {
         x86_64::instructions::interrupts::without_interrupts(|| {
-            // SAFETY: Guaranteed by the caller and per-CPU allocation.
+            // Safety: Only this core accesses the field, interrupts are disabled,
+            // and the update cannot fault.
             unsafe { *self.active_page_table.get() = page_table }
         });
     }

--- a/litebox_platform_lvbs/src/host/per_cpu_variables.rs
+++ b/litebox_platform_lvbs/src/host/per_cpu_variables.rs
@@ -11,7 +11,7 @@ use crate::{
     },
 };
 use aligned_vec::avec;
-use alloc::boxed::Box;
+use alloc::{boxed::Box, sync::Arc};
 use core::cell::{Cell, UnsafeCell};
 use core::mem::offset_of;
 use litebox::utils::TruncateExt;
@@ -64,6 +64,8 @@ pub struct PerCpuVariables {
     pub(crate) preemption_armed: Cell<bool>,
     /// Set when a preemption timer killed user-mode code.
     pub(crate) preemption_timeout_killed_user: Cell<bool>,
+    /// Reference to the currently loaded page table (`None`: the base page table).
+    active_page_table: UnsafeCell<Option<(usize, Arc<crate::mm::PageTable<PAGE_SIZE>>)>>,
 }
 
 // These Hyper-V pages must be page-aligned.
@@ -239,6 +241,32 @@ impl PerCpuVariables {
         pcv_asm.set_vtl1_kernel_xsave_area_addr(vtl1_kernel_xsave_area.as_ptr() as usize);
         pcv_asm.set_vtl1_user_xsave_area_addr(vtl1_user_xsave_area.as_ptr() as usize);
         pcv_asm.set_vtl1_xsave_mask(vtl1_xsave_mask);
+    }
+
+    /// Returns the active task page table matching `page_table_id`.
+    pub(crate) fn active_page_table(
+        &self,
+        page_table_id: usize,
+    ) -> Option<Arc<crate::mm::PageTable<PAGE_SIZE>>> {
+        // SAFETY: This field is private to the current core.
+        unsafe { &*self.active_page_table.get() }
+            .as_ref()
+            .filter(|(id, _)| *id == page_table_id)
+            .map(|(_, page_table)| Arc::clone(page_table))
+    }
+
+    /// # Safety
+    ///
+    /// CR3 must no longer reference the previous table. A new ID must match
+    /// CR3. Must not be called from interrupt or exception context.
+    pub(crate) unsafe fn set_active_page_table(
+        &self,
+        page_table: Option<(usize, Arc<crate::mm::PageTable<PAGE_SIZE>>)>,
+    ) {
+        x86_64::instructions::interrupts::without_interrupts(|| {
+            // SAFETY: Guaranteed by the caller and per-CPU allocation.
+            unsafe { *self.active_page_table.get() = page_table }
+        });
     }
 }
 
@@ -493,6 +521,7 @@ pub fn allocate_per_cpu_variables() {
     let per_cpu_variables = unsafe {
         let ptr = per_cpu_variables.as_mut_ptr();
         ptr.write_bytes(0, 1);
+        core::ptr::addr_of_mut!((*ptr).active_page_table).write(UnsafeCell::new(None));
         // Set the "uninitialized" sentinel for vp_index (0 is a valid VP index).
         core::ptr::addr_of_mut!((*ptr).vp_index).write(Cell::new(u32::MAX));
         per_cpu_variables.assume_init()

--- a/litebox_platform_lvbs/src/host/per_cpu_variables.rs
+++ b/litebox_platform_lvbs/src/host/per_cpu_variables.rs
@@ -258,16 +258,14 @@ impl PerCpuVariables {
     /// # Safety
     ///
     /// CR3 must no longer reference the previous table. A new ID must match
-    /// CR3. Must not be called from interrupt or exception context.
+    /// CR3. Interrupts must be disabled, and this must not run in exception context.
     pub(crate) unsafe fn set_active_page_table(
         &self,
         page_table: Option<(usize, Arc<crate::mm::PageTable<PAGE_SIZE>>)>,
     ) {
-        x86_64::instructions::interrupts::without_interrupts(|| {
-            // Safety: Only this core accesses the field, interrupts are disabled,
-            // and the update cannot fault.
-            unsafe { *self.active_page_table.get() = page_table }
-        });
+        // Safety: Only this core accesses the field, interrupts are disabled,
+        // and the update cannot fault.
+        unsafe { *self.active_page_table.get() = page_table }
     }
 }
 

--- a/litebox_platform_lvbs/src/lib.rs
+++ b/litebox_platform_lvbs/src/lib.rs
@@ -247,12 +247,6 @@ impl PageTableManager {
             return PageTableHandle::task(pt);
         }
 
-        // The anchor can lag CR3 briefly while switching page tables.
-        let task_pts = self.task_page_tables.read();
-        if let Some(pt) = task_pts.get(&cr3_id) {
-            return PageTableHandle::task(Arc::clone(pt));
-        }
-
         // CR3 doesn't match any known page table - this shouldn't happen
         unreachable!(
             "CR3 contains unknown page table: {:?}",
@@ -298,11 +292,13 @@ impl PageTableManager {
     ///   after the switch (including the code being executed and stack)
     /// - No references to user-space memory are held across the switch
     pub unsafe fn load_base(&self) {
-        // Release task ownership only after switching CR3.
-        self.base_page_table.load();
-        with_per_cpu_variables(|pcv| {
-            // Safety: CR3 now references the base page table.
-            unsafe { pcv.set_active_page_table(None) }
+        x86_64::instructions::interrupts::without_interrupts(|| {
+            // Keep the previous page table alive until after switching CR3.
+            self.base_page_table.load();
+            with_per_cpu_variables(|pcv| {
+                // Safety: CR3 now references the base page table and interrupts are disabled.
+                unsafe { pcv.set_active_page_table(None) }
+            });
         });
     }
 
@@ -331,11 +327,13 @@ impl PageTableManager {
             Arc::clone(task_pts.get(&task_pt_id).ok_or(Errno::ENOENT)?)
         };
 
-        // Keep both page tables owned across the CR3 switch.
-        pt.load();
-        with_per_cpu_variables(|pcv| {
-            // Safety: CR3 now references `pt`.
-            unsafe { pcv.set_active_page_table(Some((task_pt_id, pt))) }
+        x86_64::instructions::interrupts::without_interrupts(|| {
+            // Keep the previous page table alive until after switching CR3.
+            pt.load();
+            with_per_cpu_variables(|pcv| {
+                // Safety: CR3 now references `pt` and interrupts are disabled.
+                unsafe { pcv.set_active_page_table(Some((task_pt_id, pt))) }
+            });
         });
         Ok(())
     }

--- a/litebox_platform_lvbs/src/lib.rs
+++ b/litebox_platform_lvbs/src/lib.rs
@@ -6,7 +6,8 @@
 #![cfg(target_arch = "x86_64")]
 #![no_std]
 
-use crate::host::per_cpu_variables::PerCpuVariablesAsm;
+use crate::host::per_cpu_variables::{PerCpuVariablesAsm, with_per_cpu_variables};
+use alloc::sync::Arc;
 use core::sync::atomic::AtomicU32;
 use hashbrown::HashMap;
 use litebox::platform::{
@@ -167,11 +168,11 @@ const USER_ADDR_MIN: usize = 0x0000_0000_0001_0000;
 /// exposed to user TAs, mitigating potential side-channel attacks.
 pub struct PageTableManager {
     /// The base page table, containing only VTL1 kernel mappings (no user-space).
-    base_page_table: mm::PageTable<PAGE_SIZE>,
+    base_page_table: Arc<mm::PageTable<PAGE_SIZE>>,
     /// Cached physical frame of the base page table (for fast CR3 comparison).
     base_page_table_frame: PhysFrame<Size4KiB>,
     /// Task page tables keyed by their P4 frame start address (the page table ID).
-    task_page_tables: spin::Mutex<HashMap<usize, alloc::boxed::Box<mm::PageTable<PAGE_SIZE>>>>,
+    task_page_tables: spin::RwLock<HashMap<usize, Arc<mm::PageTable<PAGE_SIZE>>>>,
 }
 
 impl PageTableManager {
@@ -184,13 +185,13 @@ impl PageTableManager {
     fn new(base_pt: mm::PageTable<PAGE_SIZE>) -> Self {
         let base_frame = base_pt.get_physical_frame();
         Self {
-            base_page_table: base_pt,
+            base_page_table: Arc::new(base_pt),
             base_page_table_frame: base_frame,
-            task_page_tables: spin::Mutex::new(HashMap::new()),
+            task_page_tables: spin::RwLock::new(HashMap::new()),
         }
     }
 
-    /// Returns a reference to the current page table based on the CR3 register.
+    /// Returns a shared handle to the current page table.
     ///
     /// This reads the current CR3 value and finds the matching page table.
     /// If CR3 matches the base page table, returns that. Otherwise, it
@@ -201,26 +202,23 @@ impl PageTableManager {
     /// Panics if CR3 contains an unknown page table address (should never happen
     /// in normal operation).
     #[inline]
-    pub fn current_page_table(&self) -> &mm::PageTable<PAGE_SIZE> {
+    pub fn current_page_table(&self) -> Arc<mm::PageTable<PAGE_SIZE>> {
         let (cr3_frame, _) = x86_64::registers::control::Cr3::read();
 
         // Fast path: check base page table first (most common case)
         if self.base_page_table_frame == cr3_frame {
-            return &self.base_page_table;
+            return Arc::clone(&self.base_page_table);
         }
 
         let cr3_id: usize = cr3_frame.start_address().as_u64().trunc();
-        let task_pts = self.task_page_tables.lock();
+        if let Some(pt) = with_per_cpu_variables(|pcv| pcv.active_page_table(cr3_id)) {
+            return pt;
+        }
+
+        // The anchor can lag CR3 briefly while switching page tables.
+        let task_pts = self.task_page_tables.read();
         if let Some(pt) = task_pts.get(&cr3_id) {
-            // SAFETY: Three invariants guarantee this reference remains valid:
-            // 1. The PageTable is Box-allocated, so HashMap rehashing does not
-            //    move the PageTable itself (only the Box pointer moves).
-            // 2. This page table is the current CR3, so `delete_task_page_table`
-            //    will refuse to remove it (returns EBUSY).
-            // 3. The PageTableManager is 'static, so neither it nor the HashMap
-            //    will be deallocated.
-            let pt_ref: &mm::PageTable<PAGE_SIZE> = pt;
-            return unsafe { &*core::ptr::from_ref(pt_ref) };
+            return Arc::clone(pt);
         }
 
         // CR3 doesn't match any known page table - this shouldn't happen
@@ -268,7 +266,12 @@ impl PageTableManager {
     ///   after the switch (including the code being executed and stack)
     /// - No references to user-space memory are held across the switch
     pub unsafe fn load_base(&self) {
+        // The active table must remain owned until CR3 no longer references it.
         self.base_page_table.load();
+        with_per_cpu_variables(|pcv| {
+            // Safety: CR3 now references the base page table.
+            unsafe { pcv.set_active_page_table(None) }
+        });
     }
 
     /// Loads the specified task page table by updating CR3.
@@ -291,13 +294,18 @@ impl PageTableManager {
             return Err(Errno::EINVAL);
         }
 
-        let task_pts = self.task_page_tables.lock();
-        if let Some(pt) = task_pts.get(&task_pt_id) {
-            pt.load();
-            Ok(())
-        } else {
-            Err(Errno::ENOENT)
-        }
+        let pt = {
+            let task_pts = self.task_page_tables.read();
+            Arc::clone(task_pts.get(&task_pt_id).ok_or(Errno::ENOENT)?)
+        };
+
+        // Keep both page tables owned across the CR3 switch.
+        pt.load();
+        with_per_cpu_variables(|pcv| {
+            // Safety: CR3 now references `pt`.
+            unsafe { pcv.set_active_page_table(Some((task_pt_id, pt))) }
+        });
+        Ok(())
     }
 
     /// Creates a new task page table and returns its ID.
@@ -319,10 +327,10 @@ impl PageTableManager {
         // fixed after boot; lower slots are not shared (see `copy_pml4_entries_from`).
         pt.copy_pml4_entries_from(&self.base_page_table);
 
-        let pt = alloc::boxed::Box::new(pt);
+        let pt = Arc::new(pt);
         let task_pt_id: usize = pt.get_physical_frame().start_address().as_u64().trunc();
 
-        let mut task_pts = self.task_page_tables.lock();
+        let mut task_pts = self.task_page_tables.write();
         task_pts.insert(task_pt_id, pt);
 
         Ok(task_pt_id)
@@ -349,15 +357,15 @@ impl PageTableManager {
     /// - `Ok(())` if the page table was successfully deleted
     /// - `Err(Errno::EINVAL)` if the page table ID is the base page table
     /// - `Err(Errno::ENOENT)` if the page table ID does not exist
-    /// - `Err(Errno::EBUSY)` if the page table is currently active (switch away first)
+    /// - `Err(Errno::EBUSY)` if the page table is active or has outstanding handles
     pub unsafe fn delete_task_page_table(&self, task_pt_id: usize) -> Result<(), Errno> {
         if task_pt_id == BASE_PAGE_TABLE_ID {
             return Err(Errno::EINVAL);
         }
 
-        let mut task_pts = self.task_page_tables.lock();
+        let mut task_pts = self.task_page_tables.write();
 
-        // Check CR3 under the same lock to avoid TOCTOU with the removal below.
+        // Fast path for the page table active on this core.
         let (cr3_frame, _) = x86_64::registers::control::Cr3::read();
         let cr3_id: usize = cr3_frame.start_address().as_u64().trunc();
         if cr3_id == task_pt_id {
@@ -365,13 +373,18 @@ impl PageTableManager {
         }
 
         if let Some(pt) = task_pts.remove(&task_pt_id) {
+            // An active CR3 retains a per-CPU Arc.
+            let pt = match Arc::try_unwrap(pt) {
+                Ok(pt) => pt,
+                Err(pt) => {
+                    task_pts.insert(task_pt_id, pt);
+                    return Err(Errno::EBUSY);
+                }
+            };
             drop(task_pts);
 
-            // Safety: We're about to delete this page table, so it's safe to
-            // free the task-owned intermediate page table frames (user,
-            // direct-map, and vmap slots). The kernel slots are shared with the
-            // base page table and are deliberately left untouched, so its
-            // P3/P2/P1 frames are not freed.
+            // Safety: successful unwrap proves the table is neither active nor
+            // borrowed. Kernel slots are base-owned and must not be freed.
             unsafe {
                 pt.cleanup_page_table_frames();
             }
@@ -712,7 +725,7 @@ impl<Host: HostInterface> LinuxKernel<Host> {
     /// - `Ok(())` if successful
     /// - `Err(Errno::EINVAL)` if the page table is the base page table
     /// - `Err(Errno::ENOENT)` if the page table doesn't exist
-    /// - `Err(Errno::EBUSY)` if the page table is currently active
+    /// - `Err(Errno::EBUSY)` if the page table is active or has outstanding handles
     pub unsafe fn delete_task_page_table(&self, task_pt_id: usize) -> Result<(), Errno> {
         // Safety: caller guarantees no dangling references
         unsafe { self.page_table_manager.delete_task_page_table(task_pt_id) }

--- a/litebox_platform_lvbs/src/lib.rs
+++ b/litebox_platform_lvbs/src/lib.rs
@@ -225,19 +225,16 @@ impl PageTableManager {
 
     /// Returns a handle to the current page table.
     ///
-    /// This reads the current CR3 value and finds the matching page table.
-    /// If CR3 matches the base page table, returns that. Otherwise, it
-    /// looks up the task page table by physical frame.
+    /// This returns the base page table or the task page table retained by the
+    /// current core.
     ///
     /// # Panics
     ///
-    /// Panics if CR3 contains an unknown page table address (should never happen
-    /// in normal operation).
+    /// Panics if CR3 does not match the current core's retained page table.
     #[inline]
     pub fn current_page_table(&self) -> PageTableHandle<'_> {
         let (cr3_frame, _) = x86_64::registers::control::Cr3::read();
 
-        // Fast path: check base page table first (most common case)
         if self.base_page_table_frame == cr3_frame {
             return PageTableHandle::base(&self.base_page_table);
         }
@@ -247,9 +244,8 @@ impl PageTableManager {
             return PageTableHandle::task(pt);
         }
 
-        // CR3 doesn't match any known page table - this shouldn't happen
         unreachable!(
-            "CR3 contains unknown page table: {:?}",
+            "CR3 does not match the per-CPU page table: {:?}",
             cr3_frame.start_address()
         );
     }

--- a/litebox_platform_lvbs/src/lib.rs
+++ b/litebox_platform_lvbs/src/lib.rs
@@ -289,7 +289,8 @@ impl PageTableManager {
     /// - No references to user-space memory are held across the switch
     pub unsafe fn load_base(&self) {
         x86_64::instructions::interrupts::without_interrupts(|| {
-            // Keep the previous page table alive until after switching CR3.
+            // Ensure decreasing/dropping `Arc` for the previous page table (`set_active_page_table()`)
+            // only after switching CR3 (`mm::PageTable::load()`).
             self.base_page_table.load();
             with_per_cpu_variables(|pcv| {
                 // Safety: CR3 now references the base page table and interrupts are disabled.
@@ -324,7 +325,8 @@ impl PageTableManager {
         };
 
         x86_64::instructions::interrupts::without_interrupts(|| {
-            // Keep the previous page table alive until after switching CR3.
+            // Ensure decreasing/dropping `Arc` for the previous page table (`set_active_page_table()`)
+            // only after switching CR3 (`mm::PageTable::load()`).
             pt.load();
             with_per_cpu_variables(|pcv| {
                 // Safety: CR3 now references `pt` and interrupts are disabled.

--- a/litebox_platform_lvbs/src/lib.rs
+++ b/litebox_platform_lvbs/src/lib.rs
@@ -149,6 +149,38 @@ const USER_ADDR_MAX: usize = 0x0000_7FFF_FFFF_F000;
 /// <https://cateee.net/lkddb/web-lkddb/LSM_MMAP_MIN_ADDR.html>
 const USER_ADDR_MIN: usize = 0x0000_0000_0001_0000;
 
+/// Provide access to a page table
+pub struct PageTableHandle<'a>(PageTableHandleInner<'a>);
+
+enum PageTableHandleInner<'a> {
+    Base(&'a mm::PageTable<PAGE_SIZE>),
+    Task(Arc<mm::PageTable<PAGE_SIZE>>),
+}
+
+impl<'a> PageTableHandle<'a> {
+    #[inline]
+    fn base(page_table: &'a mm::PageTable<PAGE_SIZE>) -> Self {
+        Self(PageTableHandleInner::Base(page_table))
+    }
+
+    #[inline]
+    fn task(page_table: Arc<mm::PageTable<PAGE_SIZE>>) -> Self {
+        Self(PageTableHandleInner::Task(page_table))
+    }
+}
+
+impl core::ops::Deref for PageTableHandle<'_> {
+    type Target = mm::PageTable<PAGE_SIZE>;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        match &self.0 {
+            PageTableHandleInner::Base(page_table) => page_table,
+            PageTableHandleInner::Task(page_table) => page_table,
+        }
+    }
+}
+
 /// Manages base and task page tables.
 ///
 /// This struct maintains:
@@ -168,7 +200,7 @@ const USER_ADDR_MIN: usize = 0x0000_0000_0001_0000;
 /// exposed to user TAs, mitigating potential side-channel attacks.
 pub struct PageTableManager {
     /// The base page table, containing only VTL1 kernel mappings (no user-space).
-    base_page_table: Arc<mm::PageTable<PAGE_SIZE>>,
+    base_page_table: mm::PageTable<PAGE_SIZE>,
     /// Cached physical frame of the base page table (for fast CR3 comparison).
     base_page_table_frame: PhysFrame<Size4KiB>,
     /// Task page tables keyed by their P4 frame start address (the page table ID).
@@ -185,13 +217,13 @@ impl PageTableManager {
     fn new(base_pt: mm::PageTable<PAGE_SIZE>) -> Self {
         let base_frame = base_pt.get_physical_frame();
         Self {
-            base_page_table: Arc::new(base_pt),
+            base_page_table: base_pt,
             base_page_table_frame: base_frame,
             task_page_tables: spin::RwLock::new(HashMap::new()),
         }
     }
 
-    /// Returns a shared handle to the current page table.
+    /// Returns a handle to the current page table.
     ///
     /// This reads the current CR3 value and finds the matching page table.
     /// If CR3 matches the base page table, returns that. Otherwise, it
@@ -202,23 +234,23 @@ impl PageTableManager {
     /// Panics if CR3 contains an unknown page table address (should never happen
     /// in normal operation).
     #[inline]
-    pub fn current_page_table(&self) -> Arc<mm::PageTable<PAGE_SIZE>> {
+    pub fn current_page_table(&self) -> PageTableHandle<'_> {
         let (cr3_frame, _) = x86_64::registers::control::Cr3::read();
 
         // Fast path: check base page table first (most common case)
         if self.base_page_table_frame == cr3_frame {
-            return Arc::clone(&self.base_page_table);
+            return PageTableHandle::base(&self.base_page_table);
         }
 
         let cr3_id: usize = cr3_frame.start_address().as_u64().trunc();
         if let Some(pt) = with_per_cpu_variables(|pcv| pcv.active_page_table(cr3_id)) {
-            return pt;
+            return PageTableHandle::task(pt);
         }
 
         // The anchor can lag CR3 briefly while switching page tables.
         let task_pts = self.task_page_tables.read();
         if let Some(pt) = task_pts.get(&cr3_id) {
-            return Arc::clone(pt);
+            return PageTableHandle::task(Arc::clone(pt));
         }
 
         // CR3 doesn't match any known page table - this shouldn't happen
@@ -266,7 +298,7 @@ impl PageTableManager {
     ///   after the switch (including the code being executed and stack)
     /// - No references to user-space memory are held across the switch
     pub unsafe fn load_base(&self) {
-        // The active table must remain owned until CR3 no longer references it.
+        // Release task ownership only after switching CR3.
         self.base_page_table.load();
         with_per_cpu_variables(|pcv| {
             // Safety: CR3 now references the base page table.

--- a/litebox_runner_lvbs/src/lib.rs
+++ b/litebox_runner_lvbs/src/lib.rs
@@ -408,13 +408,11 @@ unsafe fn switch_to_task_page_table(task_pt_id: usize) -> Result<(), OpteeSmcRet
 /// The caller must ensure that no references or pointers to memory mapped
 /// by this page table are held after deletion.
 #[inline]
-unsafe fn delete_task_page_table(task_pt_id: usize) -> Result<(), OpteeSmcReturnCode> {
+unsafe fn delete_task_page_table(task_pt_id: usize) {
     let platform = litebox_platform_multiplex::platform();
     // Safety: caller guarantees no dangling references
-    unsafe {
-        platform
-            .delete_task_page_table(task_pt_id)
-            .map_err(|_| OpteeSmcReturnCode::EBadCmd)
+    if let Err(error) = unsafe { platform.delete_task_page_table(task_pt_id) } {
+        log::error!("failed to delete TA page table: {error:?}");
     }
 }
 
@@ -459,8 +457,7 @@ unsafe fn teardown_ta_page_table(shim: &litebox_shim_optee::OpteeShim, task_pt_i
         // still be on the TA's page table.
         shim.release_user_mappings();
         switch_to_base_page_table();
-        // Now delete the TA's page table without memory leak.
-        let _ = delete_task_page_table(task_pt_id);
+        delete_task_page_table(task_pt_id);
     }
 }
 
@@ -803,7 +800,7 @@ fn open_session_new_instance(
 
     let _task_pt_guard = TaskPageTableGuard::enter(task_pt_id).inspect_err(|_| {
         // Safety: switch_to_task_page_table failed, so task page table is not active.
-        let _ = unsafe { delete_task_page_table(task_pt_id) };
+        unsafe { delete_task_page_table(task_pt_id) };
     })?;
 
     // Load ldelf and TA - Box immediately to keep at fixed heap address

--- a/litebox_runner_lvbs/src/lib.rs
+++ b/litebox_runner_lvbs/src/lib.rs
@@ -408,11 +408,13 @@ unsafe fn switch_to_task_page_table(task_pt_id: usize) -> Result<(), OpteeSmcRet
 /// The caller must ensure that no references or pointers to memory mapped
 /// by this page table are held after deletion.
 #[inline]
-unsafe fn delete_task_page_table(task_pt_id: usize) {
+unsafe fn delete_task_page_table(task_pt_id: usize) -> Result<(), OpteeSmcReturnCode> {
     let platform = litebox_platform_multiplex::platform();
     // Safety: caller guarantees no dangling references
-    if let Err(error) = unsafe { platform.delete_task_page_table(task_pt_id) } {
-        log::error!("failed to delete TA page table: {error:?}");
+    unsafe {
+        platform
+            .delete_task_page_table(task_pt_id)
+            .map_err(|_| OpteeSmcReturnCode::EBadCmd)
     }
 }
 
@@ -457,7 +459,8 @@ unsafe fn teardown_ta_page_table(shim: &litebox_shim_optee::OpteeShim, task_pt_i
         // still be on the TA's page table.
         shim.release_user_mappings();
         switch_to_base_page_table();
-        delete_task_page_table(task_pt_id);
+        // Now delete the TA's page table without memory leak.
+        let _ = delete_task_page_table(task_pt_id);
     }
 }
 
@@ -800,7 +803,7 @@ fn open_session_new_instance(
 
     let _task_pt_guard = TaskPageTableGuard::enter(task_pt_id).inspect_err(|_| {
         // Safety: switch_to_task_page_table failed, so task page table is not active.
-        unsafe { delete_task_page_table(task_pt_id) };
+        let _ = unsafe { delete_task_page_table(task_pt_id) };
     })?;
 
     // Load ldelf and TA - Box immediately to keep at fixed heap address


### PR DESCRIPTION
This PR uses `Arc` reference counters for LVBS/OP-TEE page tables to safely share them across cores. In particular, it makes the page-table lifetime/ownership explicit rather than relies on session-level serialization.