### PR TITLE
Implement Windows thread suspension and alertable waits

### DIFF
--- a/litebox_shim_windows/src/lib.rs
+++ b/litebox_shim_windows/src/lib.rs
@@ -676,6 +676,13 @@ impl<Platform: ShimPlatform> Process<Platform> {
             .collect()
     }
 
+    fn thread_by_id(
+        &self,
+        thread_id: usize,
+    ) -> Option<Arc<syscalls::thread::ThreadObject<Platform>>> {
+        self.threads.read().threads.get(&thread_id).cloned()
+    }
+
     /// Wait for the process to exit, returning its exit code.
     ///
     /// Currently a placeholder that returns a fixed exit code immediately.

--- a/litebox_shim_windows/src/lib.rs
+++ b/litebox_shim_windows/src/lib.rs
@@ -2106,6 +2106,19 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                 maximum_stack_size,
                 attribute_list,
             ),
+            SyscallRequest::NtResumeThread {
+                thread_handle,
+                previous_suspend_count,
+            } => self.sys_nt_resume_thread(thread_handle, previous_suspend_count),
+            SyscallRequest::NtWaitForAlertByThreadId { address, timeout } => {
+                self.sys_nt_wait_for_alert_by_thread_id(address, timeout)
+            }
+            SyscallRequest::NtAlertThreadByThreadIdEx { thread_id, address } => {
+                self.sys_nt_alert_thread_by_thread_id_ex(thread_id, address)
+            }
+            SyscallRequest::NtAlertThreadByThreadId { thread_id } => {
+                self.sys_nt_alert_thread_by_thread_id(thread_id)
+            }
             SyscallRequest::NtWaitForSingleObject {
                 handle,
                 alertable,
@@ -2674,6 +2687,32 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         handle_attributes: u32,
         options: DuplicateOptions,
     ) -> Result<syscalls::Handle, NtStatus> {
+        if syscalls::ThreadHandle::from_raw(source_handle.as_raw()).is_current() {
+            let duplicate_access = if options.contains(DuplicateOptions::SAME_ACCESS) {
+                u32::MAX
+            } else {
+                <ThreadSubsystem<Platform> as WindowsHandleSubsystem>::normalize_desired_access(
+                    desired_access,
+                )
+            };
+            let duplicate_attributes = HandleAttributes::from_duplicate_attributes(
+                if options.contains(DuplicateOptions::SAME_ATTRIBUTES) {
+                    0
+                } else {
+                    handle_attributes
+                },
+            )
+            .ok_or(NtStatus::INVALID_PARAMETER)?;
+            return self.insert_typed_handle_with_attributes::<ThreadSubsystem<Platform>>(
+                ThreadHandleObject {
+                    thread: self.thread_object.clone(),
+                },
+                duplicate_access,
+                duplicate_attributes,
+                drop,
+            );
+        }
+
         macro_rules! try_duplicate {
             ($subsystem:ty) => {
                 if let Some(result) = self.try_duplicate_handle::<$subsystem>(
@@ -2701,6 +2740,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         try_duplicate!(WorkerFactorySubsystem<Platform>);
         try_duplicate!(SectionSubsystem<Platform>);
         try_duplicate!(TokenSubsystem);
+        try_duplicate!(ThreadSubsystem<Platform>);
 
         Err(NtStatus::INVALID_HANDLE)
     }

--- a/litebox_shim_windows/src/lib.rs
+++ b/litebox_shim_windows/src/lib.rs
@@ -2110,6 +2110,9 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                 thread_handle,
                 previous_suspend_count,
             } => self.sys_nt_resume_thread(thread_handle, previous_suspend_count),
+            SyscallRequest::NtAlertThread { thread_handle } => {
+                self.sys_nt_alert_thread(thread_handle)
+            }
             SyscallRequest::NtWaitForAlertByThreadId { address, timeout } => {
                 self.sys_nt_wait_for_alert_by_thread_id(address, timeout)
             }
@@ -2353,7 +2356,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             SyscallRequest::NtContinue {
                 context,
                 test_alert,
-            } => match Self::sys_nt_continue(ctx, context, test_alert) {
+            } => match self.sys_nt_continue(ctx, context, test_alert) {
                 Ok(()) => return,
                 Err(status) => status,
             },
@@ -2407,10 +2410,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                     NtStatus::SUCCESS
                 }
             }
-            SyscallRequest::NtTestAlert => {
-                Self::test_alert();
-                NtStatus::SUCCESS
-            }
+            SyscallRequest::NtTestAlert => self.test_alert(),
             SyscallRequest::NtManageHotPatch => NtStatus::NOT_IMPLEMENTED,
         };
 
@@ -2418,6 +2418,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
     }
 
     fn sys_nt_continue(
+        &self,
         ctx: &mut litebox_common_linux::PtRegs,
         context: ConstPtr<Platform, nt_types::X64Context>,
         test_alert: bool,
@@ -2430,7 +2431,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             .ok_or(NtStatus::ACCESS_VIOLATION)?;
 
         if test_alert {
-            Self::test_alert();
+            self.test_alert();
         }
 
         let context_flags = nt_types::ContextFlags::from_bits_retain(context.context_flags);
@@ -2481,12 +2482,13 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         Ok(())
     }
 
-    fn test_alert() {
-        // TODO(apc-model): Deliver queued user-mode APCs once thread alert and APC state
-        // are modeled.
-        litebox_util_log::debug!(
-            "NtTestAlert is a no-op; user-mode APC delivery is not yet modeled"
-        );
+    fn test_alert(&self) -> NtStatus {
+        // TODO(windows-apc): Deliver queued user-mode APCs here.
+        if self.thread_object.take_pending_thread_alert() {
+            NtStatus::ALERTED
+        } else {
+            NtStatus::SUCCESS
+        }
     }
 
     pub(crate) fn sys_nt_close(&self, handle: syscalls::Handle) -> NtStatus {

--- a/litebox_shim_windows/src/lib.rs
+++ b/litebox_shim_windows/src/lib.rs
@@ -48,7 +48,7 @@ use crate::syscalls::section::{
 };
 use crate::syscalls::semaphore::{SemaphoreHandleObject, SemaphoreSubsystem};
 use crate::syscalls::symlink::{SymbolicLinkHandleObject, SymbolicLinkSubsystem};
-use crate::syscalls::thread::{ThreadHandleObject, ThreadSubsystem};
+use crate::syscalls::thread::{ThreadAccess, ThreadHandleObject, ThreadSubsystem};
 use crate::syscalls::timer::{TimerCreateParameters, TimerHandleObject, TimerSubsystem};
 use crate::syscalls::token::{TokenHandleObject, TokenObject, TokenSubsystem};
 use crate::syscalls::wait_completion_packet::{
@@ -2689,7 +2689,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
     ) -> Result<syscalls::Handle, NtStatus> {
         if syscalls::ThreadHandle::from_raw(source_handle.as_raw()).is_current() {
             let duplicate_access = if options.contains(DuplicateOptions::SAME_ACCESS) {
-                u32::MAX
+                ThreadAccess::ALL_ACCESS.bits()
             } else {
                 <ThreadSubsystem<Platform> as WindowsHandleSubsystem>::normalize_desired_access(
                     desired_access,

--- a/litebox_shim_windows/src/syscalls/iocp.rs
+++ b/litebox_shim_windows/src/syscalls/iocp.rs
@@ -451,41 +451,43 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         };
         let port = entry.with_entry(IoCompletionHandleObject::port);
         let already_associated = self.prepare_io_completion_wait(&port);
-        if alertable {
-            // TODO(windows-apc): Interrupt alertable IOCP waits to deliver queued user APCs.
-            litebox_util_log::debug!("Treating alertable IOCP wait as non-alertable");
-        }
 
         match self.wait_on_events(
             false,
+            alertable,
             timeout,
             Events::IN,
             |observer, mask| {
                 port.register_observer(observer, mask);
                 Ok(())
             },
-            || match port.remove_with_capacity(
-                self.thread_object.thread_id(),
-                count as usize,
-                |index, packet| {
-                    io_completion_information
-                        .write_at_offset(index.cast_signed(), packet)
-                        .ok_or(NtStatus::ACCESS_VIOLATION)
-                },
-                |removed| {
-                    num_entries_removed
-                        .write_at_offset(0, removed)
-                        .ok_or(NtStatus::ACCESS_VIOLATION)
-                },
-            ) {
-                Ok(true) => {
-                    if !already_associated {
-                        self.associate_io_completion_worker(&port);
-                    }
-                    Ok(())
+            || {
+                if alertable && self.thread_object.take_pending_thread_alert() {
+                    return Err(TryOpError::WaitError(WaitError::Interrupted));
                 }
-                Ok(false) => Err(TryOpError::TryAgain),
-                Err(status) => Err(TryOpError::Other(status)),
+                match port.remove_with_capacity(
+                    self.thread_object.thread_id(),
+                    count as usize,
+                    |index, packet| {
+                        io_completion_information
+                            .write_at_offset(index.cast_signed(), packet)
+                            .ok_or(NtStatus::ACCESS_VIOLATION)
+                    },
+                    |removed| {
+                        num_entries_removed
+                            .write_at_offset(0, removed)
+                            .ok_or(NtStatus::ACCESS_VIOLATION)
+                    },
+                ) {
+                    Ok(true) => {
+                        if !already_associated {
+                            self.associate_io_completion_worker(&port);
+                        }
+                        Ok(())
+                    }
+                    Ok(false) => Err(TryOpError::TryAgain),
+                    Err(status) => Err(TryOpError::Other(status)),
+                }
             },
         ) {
             Ok(()) => NtStatus::SUCCESS,
@@ -611,6 +613,7 @@ mod tests {
 
         let nonblocking_result: Result<(), TryOpError<NtStatus>> = task.wait_on_events(
             true,
+            false,
             None,
             Events::IN,
             |_, _| unreachable!("a nonblocking wait must not register an observer"),
@@ -625,6 +628,7 @@ mod tests {
         assert!(!task.io_completion_worker.lock().suspended);
 
         let result: Result<(), TryOpError<NtStatus>> = task.wait_on_events(
+            false,
             false,
             Some(core::time::Duration::ZERO),
             Events::IN,

--- a/litebox_shim_windows/src/syscalls/mod.rs
+++ b/litebox_shim_windows/src/syscalls/mod.rs
@@ -775,6 +775,9 @@ pub(crate) enum SyscallRequest<Platform: RawPointerProvider> {
         thread_handle: ThreadHandle,
         previous_suspend_count: Option<Platform::RawMutPointer<u32>>,
     },
+    NtAlertThread {
+        thread_handle: ThreadHandle,
+    },
     NtWaitForAlertByThreadId {
         address: usize,
         timeout: Option<Platform::RawConstPointer<i64>>,
@@ -1610,6 +1613,9 @@ impl<Platform: RawPointerProvider> SyscallRequest<Platform> {
             NtSysno::NtResumeThread => Some(sys_req!(NtResumeThread {
                 thread_handle: { ThreadHandle::from_raw },
                 previous_suspend_count:*,
+            })),
+            NtSysno::NtAlertThread => Some(sys_req!(NtAlertThread {
+                thread_handle: { ThreadHandle::from_raw },
             })),
             NtSysno::NtWaitForAlertByThreadId => Some(sys_req!(NtWaitForAlertByThreadId {
                 address,

--- a/litebox_shim_windows/src/syscalls/mod.rs
+++ b/litebox_shim_windows/src/syscalls/mod.rs
@@ -771,6 +771,21 @@ pub(crate) enum SyscallRequest<Platform: RawPointerProvider> {
         maximum_stack_size: usize,
         attribute_list: Option<Platform::RawConstPointer<u8>>,
     },
+    NtResumeThread {
+        thread_handle: ThreadHandle,
+        previous_suspend_count: Option<Platform::RawMutPointer<u32>>,
+    },
+    NtWaitForAlertByThreadId {
+        address: usize,
+        timeout: Option<Platform::RawConstPointer<i64>>,
+    },
+    NtAlertThreadByThreadIdEx {
+        thread_id: usize,
+        address: usize,
+    },
+    NtAlertThreadByThreadId {
+        thread_id: usize,
+    },
     NtWaitForSingleObject {
         handle: Handle,
         alertable: bool,
@@ -1592,6 +1607,20 @@ impl<Platform: RawPointerProvider> SyscallRequest<Platform> {
                 maximum_stack_size,
                 attribute_list:*,
             })),
+            NtSysno::NtResumeThread => Some(sys_req!(NtResumeThread {
+                thread_handle: { ThreadHandle::from_raw },
+                previous_suspend_count:*,
+            })),
+            NtSysno::NtWaitForAlertByThreadId => Some(sys_req!(NtWaitForAlertByThreadId {
+                address,
+                timeout:*,
+            })),
+            NtSysno::NtAlertThreadByThreadIdEx => {
+                Some(sys_req!(NtAlertThreadByThreadIdEx { thread_id, address }))
+            }
+            NtSysno::NtAlertThreadByThreadId => {
+                Some(sys_req!(NtAlertThreadByThreadId { thread_id }))
+            }
             NtSysno::NtWaitForSingleObject => Some(sys_req!(NtWaitForSingleObject {
                 handle: { Handle::from_raw },
                 alertable: { |value: u8| value != 0 },

--- a/litebox_shim_windows/src/syscalls/registry.rs
+++ b/litebox_shim_windows/src/syscalls/registry.rs
@@ -1485,6 +1485,7 @@ impl<Platform: crate::ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             );
             let wait_result = self.wait_on_events(
                 false,
+                false,
                 None,
                 Events::IN,
                 |observer, mask| {

--- a/litebox_shim_windows/src/syscalls/thread.rs
+++ b/litebox_shim_windows/src/syscalls/thread.rs
@@ -186,7 +186,7 @@ impl<Platform: ShimPlatform> ThreadObject<Platform> {
         }
     }
 
-    fn new_suspended(thread_id: usize, teb_address: usize) -> Self {
+    pub(crate) fn new_suspended(thread_id: usize, teb_address: usize) -> Self {
         Self::new_with_suspend_count(thread_id, teb_address, 1)
     }
 
@@ -535,14 +535,18 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         {
             return status;
         }
-        let entry = match self.typed_handle_entry_with_access::<ThreadSubsystem<Platform>>(
-            thread_handle.as_handle(),
-            ThreadAccess::SUSPEND_RESUME.bits(),
-        ) {
-            Ok(entry) => entry,
-            Err(status) => return status,
+        let previous = if thread_handle.is_current() {
+            self.thread_object.resume()
+        } else {
+            let entry = match self.typed_handle_entry_with_access::<ThreadSubsystem<Platform>>(
+                thread_handle.as_handle(),
+                ThreadAccess::SUSPEND_RESUME.bits(),
+            ) {
+                Ok(entry) => entry,
+                Err(status) => return status,
+            };
+            entry.with_entry(|entry| entry.thread.resume())
         };
-        let previous = entry.with_entry(|entry| entry.thread.resume());
         if let Some(previous_suspend_count) = previous_suspend_count
             && previous_suspend_count
                 .write_at_offset(0, previous)
@@ -796,9 +800,15 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
 
 #[cfg(test)]
 mod tests {
+    extern crate std;
+
     use super::*;
-    use crate::tests::{mut_byte_ptr, mut_ptr, null_const_ptr, run_with_test_platform_pointers};
+    use crate::tests::{
+        const_ptr, mut_byte_ptr, mut_ptr, null_const_ptr, run_with_test_platform_pointers,
+    };
     use litebox::shim::{ContinueOperation, EnterShim, Exception, ExceptionInfo};
+    use std::sync::mpsc::TryRecvError;
+    use std::time::{Duration, Instant};
 
     type TestPlatform = crate::tests::TestPlatform;
     type TestTask = Task<TestPlatform, crate::tests::TestFS>;
@@ -866,31 +876,108 @@ mod tests {
     }
 
     #[test]
-    fn alert_thread_by_id_ex_filters_by_wait_address() {
+    fn wait_for_alert_by_thread_id_blocks_until_matching_alert() {
         run_with_test_platform_pointers(|| {
-            let task = crate::tests::test_task();
-            let thread_id = task.thread_object.thread_id();
+            let alerter = crate::tests::test_task();
+            let waiter = alerter
+                .clone_for_test()
+                .expect("a live process should accept another thread");
+            let waiter_thread = Arc::clone(&waiter.thread_object);
+            let thread_id = waiter_thread.thread_id();
             let wait_address = 0x1234;
+            let (result_tx, result_rx) = std::sync::mpsc::channel();
+            let thread = std::thread::spawn(move || {
+                run_with_test_platform_pointers(|| {
+                    waiter.publish_thread_handle();
+                    let timeout = -10_000_000i64;
+                    result_tx
+                        .send(waiter.sys_nt_wait_for_alert_by_thread_id(
+                            wait_address,
+                            Some(const_ptr(&timeout)),
+                        ))
+                        .unwrap();
+                });
+            });
 
-            task.thread_object.begin_alert_wait(wait_address);
+            let deadline = Instant::now() + Duration::from_secs(2);
+            while waiter_thread.alert_state.lock().wait_address != Some(wait_address) {
+                assert!(Instant::now() < deadline, "waiter did not enter alert wait");
+                std::thread::yield_now();
+            }
+            assert_eq!(result_rx.try_recv(), Err(TryRecvError::Empty));
             assert_eq!(
-                task.sys_nt_alert_thread_by_thread_id_ex(thread_id, 0x5678),
+                alerter.sys_nt_alert_thread_by_thread_id_ex(thread_id, wait_address),
                 NtStatus::SUCCESS
             );
-            assert!(!task.thread_object.take_alert(wait_address));
-
             assert_eq!(
-                task.sys_nt_alert_thread_by_thread_id_ex(thread_id, wait_address),
+                result_rx.recv_timeout(Duration::from_secs(2)).unwrap(),
+                NtStatus::ALERTED
+            );
+            thread.join().unwrap();
+
+            let timeout = 0i64;
+            assert_eq!(
+                alerter
+                    .sys_nt_wait_for_alert_by_thread_id(wait_address, Some(const_ptr(&timeout)),),
+                NtStatus::TIMEOUT
+            );
+        });
+    }
+
+    #[test]
+    fn suspended_thread_does_not_enter_guest_until_resumed() {
+        run_with_test_platform_pointers(|| {
+            let parent = crate::tests::test_task();
+            let child = parent
+                .clone_for_test()
+                .expect("a live process should accept another thread");
+            let handle = parent
+                .insert_typed_handle::<ThreadSubsystem<_>>(
+                    ThreadHandleObject {
+                        thread: Arc::clone(&child.thread_object),
+                    },
+                    ThreadAccess::SUSPEND_RESUME.bits(),
+                    drop,
+                )
+                .unwrap();
+            let handle = ThreadHandle::from_raw(handle.as_raw());
+            child
+                .thread_object
+                .suspend_count
+                .store(1, Ordering::Release);
+            let suspended_thread = Arc::clone(&child.thread_object);
+            let (started_tx, started_rx) = std::sync::mpsc::channel();
+            let (result_tx, result_rx) = std::sync::mpsc::channel();
+            let thread = std::thread::spawn(move || {
+                run_with_test_platform_pointers(|| {
+                    child.publish_thread_handle();
+                    started_tx.send(()).unwrap();
+                    let mut ctx = litebox_common_linux::PtRegs::default();
+                    let ready = child.prepare_to_run_guest(&mut ctx);
+                    result_tx.send(ready).unwrap();
+                });
+            });
+
+            started_rx.recv().unwrap();
+            let deadline = Instant::now() + Duration::from_secs(2);
+            while suspended_thread.wait_handle.get().is_none() {
+                assert!(
+                    Instant::now() < deadline,
+                    "child did not publish wait handle"
+                );
+                std::thread::yield_now();
+            }
+            assert_eq!(result_rx.try_recv(), Err(TryRecvError::Empty));
+            let mut previous_suspend_count = u32::MAX;
+            assert_eq!(
+                parent.sys_nt_resume_thread(handle, Some(mut_ptr(&mut previous_suspend_count))),
                 NtStatus::SUCCESS
             );
-            assert!(task.thread_object.take_alert(wait_address));
-
-            assert_eq!(
-                task.sys_nt_alert_thread_by_thread_id(thread_id),
-                NtStatus::SUCCESS
-            );
-            assert!(task.thread_object.take_alert(wait_address));
-            assert!(!task.thread_object.end_alert_wait(wait_address));
+            assert_eq!(previous_suspend_count, 1);
+            assert!(result_rx.recv_timeout(Duration::from_secs(2)).unwrap());
+            thread.join().unwrap();
+            assert!(!suspended_thread.is_suspended());
+            assert_eq!(parent.sys_nt_close(handle.as_handle()), NtStatus::SUCCESS);
         });
     }
 

--- a/litebox_shim_windows/src/syscalls/thread.rs
+++ b/litebox_shim_windows/src/syscalls/thread.rs
@@ -47,6 +47,7 @@ bitflags::bitflags! {
     pub(crate) struct ThreadAccess: u32 {
         const TERMINATE = 0x0001;
         const SUSPEND_RESUME = 0x0002;
+        const ALERT = 0x0004;
         const GET_CONTEXT = 0x0008;
         const SET_CONTEXT = 0x0010;
         const SET_INFORMATION = 0x0020;
@@ -104,7 +105,7 @@ pub(crate) struct ThreadHandleObject<Platform: ShimPlatform> {
 }
 
 #[derive(Default)]
-struct ThreadAlertState {
+struct KeyedAlertState {
     wait_address: Option<usize>,
     pending: bool,
 }
@@ -122,7 +123,8 @@ pub(crate) struct ThreadObject<Platform: ShimPlatform> {
     /// Handle used to interrupt the thread, published once by the thread itself
     /// when it starts running. Empty until then.
     wait_handle: once_cell::race::OnceBox<litebox::event::wait::ThreadHandle<Platform>>,
-    alert_state: Mutex<Platform, ThreadAlertState>,
+    thread_alert_pending: AtomicBool,
+    keyed_alert_state: Mutex<Platform, KeyedAlertState>,
     owned_mutants: Mutex<Platform, Vec<Weak<MutantObject<Platform>>>>,
 }
 
@@ -145,7 +147,8 @@ impl<Platform: ShimPlatform> ThreadObject<Platform> {
             is_exiting: AtomicBool::new(false),
             suspend_count: AtomicU32::new(suspend_count),
             wait_handle: once_cell::race::OnceBox::new(),
-            alert_state: Mutex::new(ThreadAlertState::default()),
+            thread_alert_pending: AtomicBool::new(false),
+            keyed_alert_state: Mutex::new(KeyedAlertState::default()),
             owned_mutants: Mutex::new(Vec::new()),
         }
     }
@@ -219,32 +222,43 @@ impl<Platform: ShimPlatform> ThreadObject<Platform> {
         }
     }
 
-    fn begin_alert_wait(&self, address: usize) {
-        let mut state = self.alert_state.lock();
+    fn begin_keyed_alert_wait(&self, address: usize) {
+        let mut state = self.keyed_alert_state.lock();
         debug_assert!(state.wait_address.is_none());
         state.wait_address = Some(address);
     }
 
-    fn take_alert(&self, address: usize) -> bool {
-        let mut state = self.alert_state.lock();
+    fn take_keyed_alert(&self, address: usize) -> bool {
+        let mut state = self.keyed_alert_state.lock();
         debug_assert_eq!(state.wait_address, Some(address));
         core::mem::take(&mut state.pending)
     }
 
-    fn end_alert_wait(&self, address: usize) -> bool {
-        let mut state = self.alert_state.lock();
+    fn end_keyed_alert_wait(&self, address: usize) -> bool {
+        let mut state = self.keyed_alert_state.lock();
         debug_assert_eq!(state.wait_address, Some(address));
         state.wait_address = None;
         core::mem::take(&mut state.pending)
     }
 
-    fn alert(&self, address: Option<usize>) {
-        let mut state = self.alert_state.lock();
+    fn alert_keyed_wait(&self, address: Option<usize>) {
+        let mut state = self.keyed_alert_state.lock();
         if address.is_some() && state.wait_address != address {
             return;
         }
         state.pending = true;
         drop(state);
+        if let Some(handle) = self.wait_handle.get() {
+            handle.interrupt();
+        }
+    }
+
+    pub(crate) fn take_pending_thread_alert(&self) -> bool {
+        self.thread_alert_pending.swap(false, Ordering::AcqRel)
+    }
+
+    fn set_thread_alert(&self) {
+        self.thread_alert_pending.store(true, Ordering::Release);
         if let Some(handle) = self.wait_handle.get() {
             handle.interrupt();
         }
@@ -557,6 +571,22 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         NtStatus::SUCCESS
     }
 
+    pub(crate) fn sys_nt_alert_thread(&self, thread_handle: ThreadHandle) -> NtStatus {
+        if thread_handle.is_current() {
+            self.thread_object.set_thread_alert();
+        } else {
+            let entry = match self.typed_handle_entry_with_access::<ThreadSubsystem<Platform>>(
+                thread_handle.as_handle(),
+                ThreadAccess::ALERT.bits(),
+            ) {
+                Ok(entry) => entry,
+                Err(status) => return status,
+            };
+            entry.with_entry(|entry| entry.thread.set_thread_alert());
+        }
+        NtStatus::SUCCESS
+    }
+
     pub(crate) fn sys_nt_wait_for_alert_by_thread_id(
         &self,
         address: usize,
@@ -569,9 +599,9 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             },
             None => None,
         };
-        self.thread_object.begin_alert_wait(address);
-        let result = self.wait_until(timeout, || self.thread_object.take_alert(address));
-        let alert_raced_with_completion = self.thread_object.end_alert_wait(address);
+        self.thread_object.begin_keyed_alert_wait(address);
+        let result = self.wait_until(timeout, || self.thread_object.take_keyed_alert(address));
+        let alert_raced_with_completion = self.thread_object.end_keyed_alert_wait(address);
         match result {
             Ok(()) | Err(litebox::event::wait::WaitError::Interrupted) => NtStatus::ALERTED,
             Err(litebox::event::wait::WaitError::TimedOut) if alert_raced_with_completion => {
@@ -589,7 +619,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         let Some(thread) = self.process.thread_by_id(thread_id) else {
             return NtStatus::INVALID_CID;
         };
-        thread.alert(Some(address));
+        thread.alert_keyed_wait(Some(address));
         NtStatus::SUCCESS
     }
 
@@ -597,7 +627,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         let Some(thread) = self.process.thread_by_id(thread_id) else {
             return NtStatus::INVALID_CID;
         };
-        thread.alert(None);
+        thread.alert_keyed_wait(None);
         NtStatus::SUCCESS
     }
 
@@ -806,6 +836,8 @@ mod tests {
     use crate::tests::{
         const_ptr, mut_byte_ptr, mut_ptr, null_const_ptr, run_with_test_platform_pointers,
     };
+    use litebox::event::polling::TryOpError;
+    use litebox::event::wait::WaitError;
     use litebox::shim::{ContinueOperation, EnterShim, Exception, ExceptionInfo};
     use std::sync::mpsc::TryRecvError;
     use std::time::{Duration, Instant};
@@ -900,7 +932,7 @@ mod tests {
             });
 
             let deadline = Instant::now() + Duration::from_secs(2);
-            while waiter_thread.alert_state.lock().wait_address != Some(wait_address) {
+            while waiter_thread.keyed_alert_state.lock().wait_address != Some(wait_address) {
                 assert!(Instant::now() < deadline, "waiter did not enter alert wait");
                 std::thread::yield_now();
             }
@@ -921,6 +953,98 @@ mod tests {
                     .sys_nt_wait_for_alert_by_thread_id(wait_address, Some(const_ptr(&timeout)),),
                 NtStatus::TIMEOUT
             );
+        });
+    }
+
+    #[test]
+    fn alert_wakes_an_alertable_wait() {
+        run_with_test_platform_pointers(|| {
+            let parent = crate::tests::test_task();
+            let waiter = parent
+                .clone_for_test()
+                .expect("a live process should accept another thread");
+            let waiter_thread = Arc::clone(&waiter.thread_object);
+            let (registered_tx, registered_rx) = std::sync::mpsc::channel();
+            let (result_tx, result_rx) = std::sync::mpsc::channel();
+            let thread = std::thread::spawn(move || {
+                run_with_test_platform_pointers(|| {
+                    waiter.publish_thread_handle();
+                    let result: Result<(), TryOpError<NtStatus>> = waiter.wait_on_events(
+                        false,
+                        true,
+                        None,
+                        Events::IN,
+                        |_, _| {
+                            registered_tx.send(()).unwrap();
+                            Ok(())
+                        },
+                        || Err(TryOpError::TryAgain),
+                    );
+                    result_tx.send(result).unwrap();
+                });
+            });
+
+            registered_rx.recv().unwrap();
+            waiter_thread.set_thread_alert();
+            assert!(matches!(
+                result_rx.recv_timeout(Duration::from_secs(2)).unwrap(),
+                Err(TryOpError::WaitError(WaitError::Interrupted))
+            ));
+            thread.join().unwrap();
+            assert!(!waiter_thread.take_pending_thread_alert());
+        });
+    }
+
+    #[test]
+    fn non_alertable_wait_preserves_pending_alert() {
+        run_with_test_platform_pointers(|| {
+            let parent = crate::tests::test_task();
+            let waiter = parent
+                .clone_for_test()
+                .expect("a live process should accept another thread");
+            let waiter_thread = Arc::clone(&waiter.thread_object);
+            let ready = Arc::new(AtomicBool::new(false));
+            let wait_ready = Arc::clone(&ready);
+            let (registered_tx, registered_rx) = std::sync::mpsc::channel();
+            let (result_tx, result_rx) = std::sync::mpsc::channel();
+            let thread = std::thread::spawn(move || {
+                run_with_test_platform_pointers(|| {
+                    waiter.publish_thread_handle();
+                    let result: Result<(), TryOpError<NtStatus>> = waiter.wait_on_events(
+                        false,
+                        false,
+                        None,
+                        Events::IN,
+                        |observer, _| {
+                            registered_tx.send(observer).unwrap();
+                            Ok(())
+                        },
+                        || {
+                            if wait_ready.load(Ordering::Acquire) {
+                                Ok(())
+                            } else {
+                                Err(TryOpError::TryAgain)
+                            }
+                        },
+                    );
+                    result_tx.send(result).unwrap();
+                });
+            });
+
+            let observer = registered_rx.recv().unwrap();
+            waiter_thread.set_thread_alert();
+            assert!(matches!(result_rx.try_recv(), Err(TryRecvError::Empty)));
+            ready.store(true, Ordering::Release);
+            observer.upgrade().unwrap().on_events(&Events::IN);
+            assert!(
+                result_rx
+                    .recv_timeout(Duration::from_secs(2))
+                    .unwrap()
+                    .is_ok()
+            );
+            thread.join().unwrap();
+            assert!(waiter_thread.take_pending_thread_alert());
+            assert!(!waiter_thread.take_pending_thread_alert());
         });
     }
 

--- a/litebox_shim_windows/src/syscalls/thread.rs
+++ b/litebox_shim_windows/src/syscalls/thread.rs
@@ -5,7 +5,7 @@ use alloc::boxed::Box;
 use alloc::sync::{Arc, Weak};
 use alloc::vec::Vec;
 use core::marker::PhantomData;
-use core::sync::atomic::{AtomicBool, AtomicU8, AtomicU32, AtomicUsize, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicU8, AtomicU32, Ordering};
 
 use int_enum::IntEnum;
 use litebox::event::{Events, IOPollable, observer::Observer, polling::Pollee};
@@ -103,6 +103,12 @@ pub(crate) struct ThreadHandleObject<Platform: ShimPlatform> {
     pub(crate) thread: Arc<ThreadObject<Platform>>,
 }
 
+#[derive(Default)]
+struct ThreadAlertState {
+    wait_address: Option<usize>,
+    pending: bool,
+}
+
 pub(crate) struct ThreadObject<Platform: ShimPlatform> {
     thread_id: usize,
     teb_address: usize,
@@ -113,11 +119,10 @@ pub(crate) struct ThreadObject<Platform: ShimPlatform> {
     /// termination request or by a process-wide exit.
     is_exiting: AtomicBool,
     suspend_count: AtomicU32,
-    alert_address: AtomicUsize,
-    alerted: AtomicBool,
     /// Handle used to interrupt the thread, published once by the thread itself
     /// when it starts running. Empty until then.
     wait_handle: once_cell::race::OnceBox<litebox::event::wait::ThreadHandle<Platform>>,
+    alert_state: Mutex<Platform, ThreadAlertState>,
     owned_mutants: Mutex<Platform, Vec<Weak<MutantObject<Platform>>>>,
 }
 
@@ -139,9 +144,8 @@ impl<Platform: ShimPlatform> ThreadObject<Platform> {
             pollee: Pollee::new(),
             is_exiting: AtomicBool::new(false),
             suspend_count: AtomicU32::new(suspend_count),
-            alert_address: AtomicUsize::new(0),
-            alerted: AtomicBool::new(false),
             wait_handle: once_cell::race::OnceBox::new(),
+            alert_state: Mutex::new(ThreadAlertState::default()),
             owned_mutants: Mutex::new(Vec::new()),
         }
     }
@@ -216,21 +220,31 @@ impl<Platform: ShimPlatform> ThreadObject<Platform> {
     }
 
     fn begin_alert_wait(&self, address: usize) {
-        self.alert_address.store(address, Ordering::Release);
+        let mut state = self.alert_state.lock();
+        debug_assert!(state.wait_address.is_none());
+        state.wait_address = Some(address);
     }
 
-    fn take_alert(&self, _address: usize) -> bool {
-        self.alerted.swap(false, Ordering::AcqRel)
+    fn take_alert(&self, address: usize) -> bool {
+        let mut state = self.alert_state.lock();
+        debug_assert_eq!(state.wait_address, Some(address));
+        core::mem::take(&mut state.pending)
     }
 
-    fn end_alert_wait(&self, address: usize) {
-        let _ =
-            self.alert_address
-                .compare_exchange(address, 0, Ordering::AcqRel, Ordering::Acquire);
+    fn end_alert_wait(&self, address: usize) -> bool {
+        let mut state = self.alert_state.lock();
+        debug_assert_eq!(state.wait_address, Some(address));
+        state.wait_address = None;
+        core::mem::take(&mut state.pending)
     }
 
-    fn alert(&self) {
-        self.alerted.store(true, Ordering::Release);
+    fn alert(&self, address: Option<usize>) {
+        let mut state = self.alert_state.lock();
+        if address.is_some() && state.wait_address != address {
+            return;
+        }
+        state.pending = true;
+        drop(state);
         if let Some(handle) = self.wait_handle.get() {
             handle.interrupt();
         }
@@ -552,11 +566,13 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             None => None,
         };
         self.thread_object.begin_alert_wait(address);
-        let result = self
-            .wait_until(timeout, || self.thread_object.take_alert(address));
-        self.thread_object.end_alert_wait(address);
+        let result = self.wait_until(timeout, || self.thread_object.take_alert(address));
+        let alert_raced_with_completion = self.thread_object.end_alert_wait(address);
         match result {
             Ok(()) | Err(litebox::event::wait::WaitError::Interrupted) => NtStatus::ALERTED,
+            Err(litebox::event::wait::WaitError::TimedOut) if alert_raced_with_completion => {
+                NtStatus::ALERTED
+            }
             Err(litebox::event::wait::WaitError::TimedOut) => NtStatus::TIMEOUT,
         }
     }
@@ -564,12 +580,12 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
     pub(crate) fn sys_nt_alert_thread_by_thread_id_ex(
         &self,
         thread_id: usize,
-        _lock: usize,
+        address: usize,
     ) -> NtStatus {
         let Some(thread) = self.process.thread_by_id(thread_id) else {
             return NtStatus::INVALID_CID;
         };
-        thread.alert();
+        thread.alert(Some(address));
         NtStatus::SUCCESS
     }
 
@@ -577,7 +593,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         let Some(thread) = self.process.thread_by_id(thread_id) else {
             return NtStatus::INVALID_CID;
         };
-        thread.alert();
+        thread.alert(None);
         NtStatus::SUCCESS
     }
 
@@ -846,6 +862,35 @@ mod tests {
             assert_eq!(is_last_thread, 1);
             assert_eq!(return_length as usize, size_of::<u32>());
             assert_eq!(parent.process.live_thread_count(), 1);
+        });
+    }
+
+    #[test]
+    fn alert_thread_by_id_ex_filters_by_wait_address() {
+        run_with_test_platform_pointers(|| {
+            let task = crate::tests::test_task();
+            let thread_id = task.thread_object.thread_id();
+            let wait_address = 0x1234;
+
+            task.thread_object.begin_alert_wait(wait_address);
+            assert_eq!(
+                task.sys_nt_alert_thread_by_thread_id_ex(thread_id, 0x5678),
+                NtStatus::SUCCESS
+            );
+            assert!(!task.thread_object.take_alert(wait_address));
+
+            assert_eq!(
+                task.sys_nt_alert_thread_by_thread_id_ex(thread_id, wait_address),
+                NtStatus::SUCCESS
+            );
+            assert!(task.thread_object.take_alert(wait_address));
+
+            assert_eq!(
+                task.sys_nt_alert_thread_by_thread_id(thread_id),
+                NtStatus::SUCCESS
+            );
+            assert!(task.thread_object.take_alert(wait_address));
+            assert!(!task.thread_object.end_alert_wait(wait_address));
         });
     }
 

--- a/litebox_shim_windows/src/syscalls/thread.rs
+++ b/litebox_shim_windows/src/syscalls/thread.rs
@@ -5,7 +5,7 @@ use alloc::boxed::Box;
 use alloc::sync::{Arc, Weak};
 use alloc::vec::Vec;
 use core::marker::PhantomData;
-use core::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicU8, AtomicU32, AtomicUsize, Ordering};
 
 use int_enum::IntEnum;
 use litebox::event::{Events, IOPollable, observer::Observer, polling::Pollee};
@@ -112,6 +112,9 @@ pub(crate) struct ThreadObject<Platform: ShimPlatform> {
     /// Set when the thread has been asked to exit, either by its own
     /// termination request or by a process-wide exit.
     is_exiting: AtomicBool,
+    suspend_count: AtomicU32,
+    alert_address: AtomicUsize,
+    alerted: AtomicBool,
     /// Handle used to interrupt the thread, published once by the thread itself
     /// when it starts running. Empty until then.
     wait_handle: once_cell::race::OnceBox<litebox::event::wait::ThreadHandle<Platform>>,
@@ -124,6 +127,10 @@ impl<Platform: ShimPlatform> ThreadObject<Platform> {
     const COMPLETE: u8 = 2;
 
     pub(crate) fn new(thread_id: usize, teb_address: usize) -> Self {
+        Self::new_with_suspend_count(thread_id, teb_address, 0)
+    }
+
+    fn new_with_suspend_count(thread_id: usize, teb_address: usize, suspend_count: u32) -> Self {
         Self {
             thread_id,
             teb_address,
@@ -131,6 +138,9 @@ impl<Platform: ShimPlatform> ThreadObject<Platform> {
             exit_status: core::sync::atomic::AtomicI32::new(NtStatus::PENDING.as_raw()),
             pollee: Pollee::new(),
             is_exiting: AtomicBool::new(false),
+            suspend_count: AtomicU32::new(suspend_count),
+            alert_address: AtomicUsize::new(0),
+            alerted: AtomicBool::new(false),
             wait_handle: once_cell::race::OnceBox::new(),
             owned_mutants: Mutex::new(Vec::new()),
         }
@@ -169,6 +179,60 @@ impl<Platform: ShimPlatform> ThreadObject<Platform> {
             if let Some(mutant) = mutant.upgrade() {
                 mutant.abandon(thread_id);
             }
+        }
+    }
+
+    fn new_suspended(thread_id: usize, teb_address: usize) -> Self {
+        Self::new_with_suspend_count(thread_id, teb_address, 1)
+    }
+
+    pub(crate) fn is_suspended(&self) -> bool {
+        self.suspend_count.load(Ordering::Acquire) != 0
+    }
+
+    fn resume(&self) -> u32 {
+        let mut previous = self.suspend_count.load(Ordering::Acquire);
+        loop {
+            if previous == 0 {
+                return 0;
+            }
+            match self.suspend_count.compare_exchange_weak(
+                previous,
+                previous - 1,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => {
+                    if previous == 1
+                        && let Some(handle) = self.wait_handle.get()
+                    {
+                        handle.interrupt();
+                    }
+                    return previous;
+                }
+                Err(current) => previous = current,
+            }
+        }
+    }
+
+    fn begin_alert_wait(&self, address: usize) {
+        self.alert_address.store(address, Ordering::Release);
+    }
+
+    fn take_alert(&self, _address: usize) -> bool {
+        self.alerted.swap(false, Ordering::AcqRel)
+    }
+
+    fn end_alert_wait(&self, address: usize) {
+        let _ =
+            self.alert_address
+                .compare_exchange(address, 0, Ordering::AcqRel, Ordering::Acquire);
+    }
+
+    fn alert(&self) {
+        self.alerted.store(true, Ordering::Release);
+        if let Some(handle) = self.wait_handle.get() {
+            handle.interrupt();
         }
     }
 
@@ -325,8 +389,10 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             return NtStatus::INVALID_HANDLE;
         }
         let create_flags = ThreadCreateFlags::from_bits_retain(create_flags);
-        if !create_flags.is_empty() {
-            // TODO(thread-model): support suspended creation and the remaining native flags.
+        if !create_flags
+            .difference(ThreadCreateFlags::CREATE_SUSPENDED)
+            .is_empty()
+        {
             litebox_util_log::debug!(
                 create_flags:? = create_flags;
                 "Rejecting NtCreateThreadEx with unsupported creation flags"
@@ -389,7 +455,13 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         child_ctx.rcx = environment.context;
         child_ctx.rdx = ntdll.mapping.base_addr;
 
-        let thread = Arc::new(ThreadObject::new(thread_id, environment.teb));
+        let thread = Arc::new(
+            if create_flags.contains(ThreadCreateFlags::CREATE_SUSPENDED) {
+                ThreadObject::new_suspended(thread_id, environment.teb)
+            } else {
+                ThreadObject::new(thread_id, environment.teb)
+            },
+        );
         if !self.process.attach_thread(thread_id, &thread) {
             // The process is tearing down; refuse to start another thread.
             return NtStatus::PROCESS_IS_TERMINATING;
@@ -435,6 +507,77 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         if thread_handle.write_at_offset(0, handle).is_none() {
             return NtStatus::ACCESS_VIOLATION;
         }
+        NtStatus::SUCCESS
+    }
+
+    pub(crate) fn sys_nt_resume_thread(
+        &self,
+        thread_handle: ThreadHandle,
+        previous_suspend_count: Option<MutPtr<Platform, u32>>,
+    ) -> NtStatus {
+        if let Some(previous_suspend_count) = previous_suspend_count
+            && let Err(status) =
+                probe_guest_output_preserving_value::<Platform, _>(previous_suspend_count)
+        {
+            return status;
+        }
+        let entry = match self.typed_handle_entry_with_access::<ThreadSubsystem<Platform>>(
+            thread_handle.as_handle(),
+            ThreadAccess::SUSPEND_RESUME.bits(),
+        ) {
+            Ok(entry) => entry,
+            Err(status) => return status,
+        };
+        let previous = entry.with_entry(|entry| entry.thread.resume());
+        if let Some(previous_suspend_count) = previous_suspend_count
+            && previous_suspend_count
+                .write_at_offset(0, previous)
+                .is_none()
+        {
+            return NtStatus::ACCESS_VIOLATION;
+        }
+        NtStatus::SUCCESS
+    }
+
+    pub(crate) fn sys_nt_wait_for_alert_by_thread_id(
+        &self,
+        address: usize,
+        timeout: Option<ConstPtr<Platform, i64>>,
+    ) -> NtStatus {
+        let timeout = match timeout {
+            Some(timeout) => match timeout.read_at_offset(0) {
+                Some(timeout) => Some(self.wait_timeout_duration(timeout)),
+                None => return NtStatus::ACCESS_VIOLATION,
+            },
+            None => None,
+        };
+        self.thread_object.begin_alert_wait(address);
+        let result = self
+            .wait_until(timeout, || self.thread_object.take_alert(address));
+        self.thread_object.end_alert_wait(address);
+        match result {
+            Ok(()) | Err(litebox::event::wait::WaitError::Interrupted) => NtStatus::ALERTED,
+            Err(litebox::event::wait::WaitError::TimedOut) => NtStatus::TIMEOUT,
+        }
+    }
+
+    pub(crate) fn sys_nt_alert_thread_by_thread_id_ex(
+        &self,
+        thread_id: usize,
+        _lock: usize,
+    ) -> NtStatus {
+        let Some(thread) = self.process.thread_by_id(thread_id) else {
+            return NtStatus::INVALID_CID;
+        };
+        thread.alert();
+        NtStatus::SUCCESS
+    }
+
+    pub(crate) fn sys_nt_alert_thread_by_thread_id(&self, thread_id: usize) -> NtStatus {
+        let Some(thread) = self.process.thread_by_id(thread_id) else {
+            return NtStatus::INVALID_CID;
+        };
+        thread.alert();
         NtStatus::SUCCESS
     }
 

--- a/litebox_shim_windows/src/syscalls/wait.rs
+++ b/litebox_shim_windows/src/syscalls/wait.rs
@@ -116,13 +116,9 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             }
             None => None,
         };
-        if alertable {
-            // TODO(windows-apc): interrupt alertable waits when user APC delivery is modeled.
-            litebox_util_log::debug!("Treating alertable wait as non-alertable");
-        }
-
         match self.wait_on_events(
             false,
+            alertable,
             timeout,
             Events::IN,
             |observer, mask| {
@@ -130,6 +126,9 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
                 Ok(())
             },
             || {
+                if alertable && self.thread_object.take_pending_thread_alert() {
+                    return Err(TryOpError::WaitError(WaitError::Interrupted));
+                }
                 object
                     .try_acquire(self.thread_object.thread_id(), &self.thread_object)
                     .ok_or(TryOpError::<NtStatus>::TryAgain)

--- a/litebox_shim_windows/src/tests.rs
+++ b/litebox_shim_windows/src/tests.rs
@@ -13,6 +13,7 @@ use litebox::utils::TruncateExt as _;
 
 use crate::nt_types::{ObjectAttributes, UnicodeString};
 use crate::syscalls::Handle;
+use crate::syscalls::thread::{ThreadAccess, ThreadSubsystem};
 use crate::{ConstPtr, DefaultFS, MutPtr, Process, ShimFS, ShimPlatform, Task, WindowsShim};
 
 #[cfg(target_os = "linux")]
@@ -294,6 +295,15 @@ fn nt_duplicate_object_materializes_current_thread_pseudo_handle() {
         litebox_common_windows::nt_status::NtStatus::SUCCESS
     );
     assert!(!duplicate.is_null());
+    let typed = task
+        .typed_handle::<ThreadSubsystem<TestPlatform>>(duplicate)
+        .expect("duplicate should be a thread handle");
+    assert_eq!(
+        task.typed_handle_metadata(&typed)
+            .expect("duplicate should have handle metadata")
+            .granted_access,
+        ThreadAccess::ALL_ACCESS.bits()
+    );
 
     let timeout = 0;
     assert_eq!(

--- a/litebox_shim_windows/src/tests.rs
+++ b/litebox_shim_windows/src/tests.rs
@@ -277,6 +277,36 @@ fn nt_duplicate_object_preserves_identity_with_independent_access() {
 }
 
 #[test]
+fn nt_duplicate_object_materializes_current_thread_pseudo_handle() {
+    let task = test_task();
+    let mut duplicate = Handle::default();
+
+    assert_eq!(
+        task.sys_nt_duplicate_object(
+            crate::syscalls::ProcessHandle::CURRENT,
+            Handle::from_raw(usize::MAX - 1),
+            crate::syscalls::ProcessHandle::CURRENT,
+            Some(mut_ptr(&mut duplicate)),
+            0,
+            0,
+            DUPLICATE_SAME_ACCESS,
+        ),
+        litebox_common_windows::nt_status::NtStatus::SUCCESS
+    );
+    assert!(!duplicate.is_null());
+
+    let timeout = 0;
+    assert_eq!(
+        task.sys_nt_wait_for_single_object(duplicate, false, Some(const_ptr(&timeout))),
+        litebox_common_windows::nt_status::NtStatus::TIMEOUT
+    );
+    assert_eq!(
+        task.sys_nt_close(duplicate),
+        litebox_common_windows::nt_status::NtStatus::SUCCESS
+    );
+}
+
+#[test]
 fn nt_duplicate_object_can_atomically_replace_the_source_handle() {
     let task = test_task();
     let source = create_event(&task, EVENT_MODIFY_STATE);

--- a/litebox_shim_windows/src/wait.rs
+++ b/litebox_shim_windows/src/wait.rs
@@ -23,6 +23,11 @@ impl<Platform: ShimPlatform> WaitState<Platform> {
 }
 
 impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
+    /// Returns a wait context to use to perform interruptible waits.
+    fn wait_cx(&self) -> litebox::event::wait::WaitContext<'_, Platform> {
+        self.wait_state.0.context().with_check_for_interrupt(self)
+    }
+
     pub(crate) fn wait_on_events<R, E>(
         &self,
         nonblock: bool,
@@ -42,12 +47,24 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         self.suspend_io_completion_worker();
         let _resume_worker = litebox::utils::defer(|| self.resume_io_completion_worker());
         let wait_context = self
-            .wait_state
-            .0
-            .context()
-            .with_check_for_interrupt(self)
+            .wait_cx()
             .with_timeout(timeout);
         wait_context.wait_on_events(false, events, register_observer, try_op)
+    }
+
+    pub(crate) fn wait_until(
+        &self,
+        timeout: Option<core::time::Duration>,
+        mut ready: impl FnMut() -> bool,
+    ) -> Result<(), litebox::event::wait::WaitError> {
+        if ready() {
+            return Ok(());
+        }
+        self.suspend_io_completion_worker();
+        let _resume_worker = litebox::utils::defer(|| self.resume_io_completion_worker());
+        self.wait_cx()
+            .with_timeout(timeout)
+            .wait_until(ready)
     }
 
     /// Publishes the handle used by other threads to interrupt this one.
@@ -67,6 +84,11 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
     /// exit instead.
     #[must_use]
     pub(crate) fn prepare_to_run_guest(&self, _ctx: &mut litebox_common_linux::PtRegs) -> bool {
+        if self.thread_object.is_suspended() {
+            self.publish_thread_handle();
+            let _ = self
+                .wait_until(None, || !self.thread_object.is_suspended());
+        }
         self.wait_state.0.prepare_to_run_guest(|| {
             // TODO(windows-apc): deliver pending user-mode APCs and alerts here.
             !self.thread_object.is_exiting()

--- a/litebox_shim_windows/src/wait.rs
+++ b/litebox_shim_windows/src/wait.rs
@@ -14,6 +14,20 @@ use litebox::event::polling::TryOpError;
 
 use crate::{ShimFS, ShimPlatform, Task};
 
+struct WaitInterrupt<'a, Platform: ShimPlatform, FS: ShimFS> {
+    task: &'a Task<Platform, FS>,
+    alertable: bool,
+}
+
+impl<Platform: ShimPlatform, FS: ShimFS> litebox::event::wait::CheckForInterrupt
+    for WaitInterrupt<'_, Platform, FS>
+{
+    fn check_for_interrupt(&self) -> bool {
+        self.task.thread_object.is_exiting()
+            || (self.alertable && self.task.thread_object.take_pending_thread_alert())
+    }
+}
+
 pub(crate) struct WaitState<Platform: ShimPlatform>(litebox::event::wait::WaitState<Platform>);
 
 impl<Platform: ShimPlatform> WaitState<Platform> {
@@ -24,13 +38,20 @@ impl<Platform: ShimPlatform> WaitState<Platform> {
 
 impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
     /// Returns a wait context to use to perform interruptible waits.
-    fn wait_cx(&self) -> litebox::event::wait::WaitContext<'_, Platform> {
-        self.wait_state.0.context().with_check_for_interrupt(self)
+    fn wait_cx<'a>(
+        &'a self,
+        interrupt: &'a WaitInterrupt<'a, Platform, FS>,
+    ) -> litebox::event::wait::WaitContext<'a, Platform> {
+        self.wait_state
+            .0
+            .context()
+            .with_check_for_interrupt(interrupt)
     }
 
     pub(crate) fn wait_on_events<R, E>(
         &self,
         nonblock: bool,
+        alertable: bool,
         timeout: Option<core::time::Duration>,
         events: Events,
         register_observer: impl FnOnce(Weak<dyn Observer<Events>>, Events) -> Result<(), E>,
@@ -46,7 +67,11 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         // around WaitContext's platform block; keep this approximation local to the Windows shim.
         self.suspend_io_completion_worker();
         let _resume_worker = litebox::utils::defer(|| self.resume_io_completion_worker());
-        let wait_context = self.wait_cx().with_timeout(timeout);
+        let interrupt = WaitInterrupt {
+            task: self,
+            alertable,
+        };
+        let wait_context = self.wait_cx(&interrupt).with_timeout(timeout);
         wait_context.wait_on_events(false, events, register_observer, try_op)
     }
 
@@ -60,7 +85,13 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         }
         self.suspend_io_completion_worker();
         let _resume_worker = litebox::utils::defer(|| self.resume_io_completion_worker());
-        self.wait_cx().with_timeout(timeout).wait_until(ready)
+        let interrupt = WaitInterrupt {
+            task: self,
+            alertable: false,
+        };
+        self.wait_cx(&interrupt)
+            .with_timeout(timeout)
+            .wait_until(ready)
     }
 
     /// Publishes the handle used by other threads to interrupt this one.
@@ -84,16 +115,8 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
             let _ = self.wait_until(None, || !self.thread_object.is_suspended());
         }
         self.wait_state.0.prepare_to_run_guest(|| {
-            // TODO(windows-apc): deliver pending user-mode APCs and alerts here.
+            // TODO(windows-apc): deliver pending user-mode APCs here.
             !self.thread_object.is_exiting()
         })
-    }
-}
-
-impl<Platform: ShimPlatform, FS: ShimFS> litebox::event::wait::CheckForInterrupt
-    for Task<Platform, FS>
-{
-    fn check_for_interrupt(&self) -> bool {
-        self.thread_object.is_exiting()
     }
 }

--- a/litebox_shim_windows/src/wait.rs
+++ b/litebox_shim_windows/src/wait.rs
@@ -46,9 +46,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         // around WaitContext's platform block; keep this approximation local to the Windows shim.
         self.suspend_io_completion_worker();
         let _resume_worker = litebox::utils::defer(|| self.resume_io_completion_worker());
-        let wait_context = self
-            .wait_cx()
-            .with_timeout(timeout);
+        let wait_context = self.wait_cx().with_timeout(timeout);
         wait_context.wait_on_events(false, events, register_observer, try_op)
     }
 
@@ -62,9 +60,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         }
         self.suspend_io_completion_worker();
         let _resume_worker = litebox::utils::defer(|| self.resume_io_completion_worker());
-        self.wait_cx()
-            .with_timeout(timeout)
-            .wait_until(ready)
+        self.wait_cx().with_timeout(timeout).wait_until(ready)
     }
 
     /// Publishes the handle used by other threads to interrupt this one.
@@ -85,9 +81,7 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
     #[must_use]
     pub(crate) fn prepare_to_run_guest(&self, _ctx: &mut litebox_common_linux::PtRegs) -> bool {
         if self.thread_object.is_suspended() {
-            self.publish_thread_handle();
-            let _ = self
-                .wait_until(None, || !self.thread_object.is_suspended());
+            let _ = self.wait_until(None, || !self.thread_object.is_suspended());
         }
         self.wait_state.0.prepare_to_run_guest(|| {
             // TODO(windows-apc): deliver pending user-mode APCs and alerts here.


### PR DESCRIPTION
Implement classic and keyed thread alerts, including `NtAlertThread`, `NtWaitForAlertByThreadId`, `NtAlertThreadByThreadId`, `NtAlertThreadByThreadIdEx`, `NtTestAlert`. Also fix `NtWaitForSingleObject` and `NtRemoveIoCompletionEx` to support non-alertable waits.