### PR TITLE
Add support for direct memory copy between VTL0 and VTL1-userspace

### DIFF
--- a/litebox/src/platform/common_providers/userspace_pointers.rs
+++ b/litebox/src/platform/common_providers/userspace_pointers.rs
@@ -110,6 +110,24 @@ impl<V: ValidateAccess, T> UserConstPtr<V, T> {
         }
     }
 
+    /// Copy data from userspace to a raw pointer.
+    ///
+    /// # Safety
+    ///
+    /// `dst` must be either non-Rust memory or Rust memory with exclusive access.
+    pub unsafe fn copy_to_raw(self, dst: *mut T, len: usize) -> Option<()> {
+        if len == 0 {
+            return Some(());
+        }
+        let byte_len = len.checked_mul(core::mem::size_of::<T>())?;
+        self.inner.checked_add(byte_len)?;
+        let src =
+            V::validate_slice(core::ptr::slice_from_raw_parts(self.as_ptr(), len).cast_mut())?
+                .cast_const();
+        V::with_user_memory_access(|| unsafe { memcpy_fallible(dst.cast(), src.cast(), byte_len) })
+            .ok()
+    }
+
     /// Explicitly-private function.  This particular function exists because we
     /// store the `*const T` that would be stored in this struct instead as a
     /// `usize`.  We store `inner` as a `usize` to support
@@ -255,6 +273,22 @@ impl<V: ValidateAccess, T> UserMutPtr<V, T> {
             _phantom_ptr: core::marker::PhantomData,
             _validator: core::marker::PhantomData,
         }
+    }
+
+    /// Copy data from a raw pointer to userspace.
+    ///
+    /// # Safety
+    ///
+    /// `src` must be either non-Rust memory or Rust memory without concurrent modification.
+    pub unsafe fn copy_from_raw(self, src: *const T, len: usize) -> Option<()> {
+        if len == 0 {
+            return Some(());
+        }
+        let byte_len = len.checked_mul(core::mem::size_of::<T>())?;
+        self.inner.checked_add(byte_len)?;
+        let dst = V::validate_slice(core::ptr::slice_from_raw_parts_mut(self.as_ptr(), len))?;
+        V::with_user_memory_access(|| unsafe { memcpy_fallible(dst.cast(), src.cast(), byte_len) })
+            .ok()
     }
 
     /// Explicitly-private function.  See equivalent [`UserConstPtr::as_ptr`]

--- a/litebox/src/platform/common_providers/userspace_pointers.rs
+++ b/litebox/src/platform/common_providers/userspace_pointers.rs
@@ -115,7 +115,10 @@ impl<V: ValidateAccess, T> UserConstPtr<V, T> {
     /// # Safety
     ///
     /// `dst` must be either non-Rust memory or Rust memory with exclusive access.
-    pub unsafe fn copy_to_raw(self, dst: *mut T, len: usize) -> Option<()> {
+    pub unsafe fn copy_to_raw(self, dst: *mut T, len: usize) -> Option<()>
+    where
+        T: FromBytes,
+    {
         if len == 0 {
             return Some(());
         }
@@ -280,7 +283,10 @@ impl<V: ValidateAccess, T> UserMutPtr<V, T> {
     /// # Safety
     ///
     /// `src` must be either non-Rust memory or Rust memory without concurrent modification.
-    pub unsafe fn copy_from_raw(self, src: *const T, len: usize) -> Option<()> {
+    pub unsafe fn copy_from_raw(self, src: *const T, len: usize) -> Option<()>
+    where
+        T: FromBytes + IntoBytes,
+    {
         if len == 0 {
             return Some(());
         }

--- a/litebox_common_linux/src/physical_pointers.rs
+++ b/litebox_common_linux/src/physical_pointers.rs
@@ -38,6 +38,9 @@ use crate::vmap::{
     VmapManager,
 };
 use core::marker::PhantomData;
+use litebox::platform::common_providers::userspace_pointers::{
+    UserConstPtr, UserMutPtr, ValidateAccess,
+};
 use zerocopy::{FromBytes, IntoBytes};
 
 /// The concrete [`PhysPageMapInfo`] produced by the `VmapManager` behind a [`GlobalVmapManager`].
@@ -358,6 +361,47 @@ where
     }
 }
 
+impl<const ALIGN: usize, V> PhysMutPtr<u8, ALIGN, V>
+where
+    V: GlobalVmapManager<ALIGN>,
+{
+    /// Copy data to non-Rust userspace memory.
+    pub fn copy_to_user<U: ValidateAccess>(
+        &self,
+        dst: UserMutPtr<U, u8>,
+        len: usize,
+    ) -> Result<(), PhysPointerError> {
+        if len > self.count {
+            return Err(PhysPointerError::IndexOutOfBounds(len, self.count));
+        }
+        if len == 0 {
+            return Ok(());
+        }
+        let guard = self.map_and_get_ptr_guard(0, len, PhysPageMapPermissions::READ)?;
+        guard.copy_to_user(dst)
+    }
+
+    /// Copy data from non-Rust userspace memory.
+    pub fn copy_from_user<U: ValidateAccess>(
+        &self,
+        src: UserConstPtr<U, u8>,
+        len: usize,
+    ) -> Result<(), PhysPointerError> {
+        if len > self.count {
+            return Err(PhysPointerError::IndexOutOfBounds(len, self.count));
+        }
+        if len == 0 {
+            return Ok(());
+        }
+        let guard = self.map_and_get_ptr_guard(
+            0,
+            len,
+            PhysPageMapPermissions::READ | PhysPageMapPermissions::WRITE,
+        )?;
+        guard.copy_from_user(src)
+    }
+}
+
 /// RAII guard that unmaps physical pages when dropped.
 ///
 /// Created by `map_and_get_ptr_guard`. Its lifetime is tied to the parent
@@ -377,6 +421,24 @@ struct MappedGuard<'a, T, const ALIGN: usize, V: GlobalVmapManager<ALIGN>> {
 }
 
 impl<T, const ALIGN: usize, V: GlobalVmapManager<ALIGN>> MappedGuard<'_, T, ALIGN, V> {
+    fn copy_to_user<U: ValidateAccess>(
+        &self,
+        dst: UserMutPtr<U, u8>,
+    ) -> Result<(), PhysPointerError> {
+        // SAFETY: `PhysConstPtr`/`PhysMutPtr` only point to non-Rust memory.
+        unsafe { dst.copy_from_raw(self.ptr.cast::<u8>().cast_const(), self.size) }
+            .ok_or(PhysPointerError::CopyFailed)
+    }
+
+    fn copy_from_user<U: ValidateAccess>(
+        &self,
+        src: UserConstPtr<U, u8>,
+    ) -> Result<(), PhysPointerError> {
+        // SAFETY: `PhysMutPtr` only points to non-Rust memory.
+        unsafe { src.copy_to_raw(self.ptr.cast::<u8>(), self.size) }
+            .ok_or(PhysPointerError::CopyFailed)
+    }
+
     /// Copy the `self.size` mapped bytes out into `dst`.
     ///
     /// This is the only path through which the raw mapped pointer is dereferenced.
@@ -499,6 +561,20 @@ where
         T: FromBytes,
     {
         self.inner.read_slice_at_offset(count, values)
+    }
+}
+
+impl<const ALIGN: usize, V> PhysConstPtr<u8, ALIGN, V>
+where
+    V: GlobalVmapManager<ALIGN>,
+{
+    /// Copy data to non-Rust userspace memory.
+    pub fn copy_to_user<U: ValidateAccess>(
+        &self,
+        dst: UserMutPtr<U, u8>,
+        len: usize,
+    ) -> Result<(), PhysPointerError> {
+        self.inner.copy_to_user(dst, len)
     }
 }
 


### PR DESCRIPTION
This PR enables direct memory copy between VTL0 (normal world) and VTL1 (secure world) userspace. Currently, we should use in-VTL1-kernel (in-LiteBox) bounce buffers to copy data between these two foreign memory domains regardless of whether the kernel/LiteBox checks the content. This results in pure time delay and memory pressure. Note that this direct memory copy does not affect LiteBox's memory safety because both source and destination are not Rust (kernel) memory.