### PR TITLE
Integrate egress proxy with Linux userland broker

### DIFF
--- a/litebox_broker_userland/src/linux.rs
+++ b/litebox_broker_userland/src/linux.rs
@@ -140,7 +140,7 @@ impl ManagedEgressProxy {
         if reader.join().is_err() {
             return Err(IoError::other("egress proxy readiness reader panicked"));
         }
-        let address = parse_proxy_ready(&readiness?)?;
+        let address = readiness?;
         match proxy.child.try_wait() {
             Ok(None) => {}
             Ok(Some(status)) => {
@@ -159,11 +159,23 @@ impl ManagedEgressProxy {
 
 impl Drop for ManagedEgressProxy {
     fn drop(&mut self) {
-        stop_proxy(&mut self.child);
+        self.child.stdin.take();
+        let deadline = Instant::now() + PROXY_SHUTDOWN_TIMEOUT;
+        loop {
+            match self.child.try_wait() {
+                Ok(Some(_status)) => return,
+                Ok(None) if Instant::now() < deadline => {
+                    std::thread::sleep(Duration::from_millis(10));
+                }
+                Ok(None) | Err(_) => break,
+            }
+        }
+        let _ = self.child.kill();
+        let _ = self.child.wait();
     }
 }
 
-fn read_proxy_ready(stdout: ChildStdout) -> IoResult<String> {
+fn read_proxy_ready(stdout: ChildStdout) -> IoResult<SocketAddrV4> {
     let mut reader = BufReader::new(stdout);
     let mut line = String::new();
     if reader.read_line(&mut line)? == 0 {
@@ -172,32 +184,10 @@ fn read_proxy_ready(stdout: ChildStdout) -> IoResult<String> {
             "egress proxy exited before reporting readiness",
         ));
     }
-    Ok(line)
-}
-
-fn parse_proxy_ready(line: &str) -> IoResult<SocketAddrV4> {
-    let address = line
-        .strip_prefix("READY ")
+    line.strip_prefix("READY ")
         .and_then(|value| value.trim_end().parse::<SocketAddrV4>().ok())
         .filter(|address| *address.ip() == Ipv4Addr::LOCALHOST && address.port() != 0)
-        .ok_or_else(|| IoError::new(ErrorKind::InvalidData, "invalid egress proxy readiness"))?;
-    Ok(address)
-}
-
-fn stop_proxy(child: &mut Child) {
-    child.stdin.take();
-    let deadline = Instant::now() + PROXY_SHUTDOWN_TIMEOUT;
-    loop {
-        match child.try_wait() {
-            Ok(Some(_status)) => return,
-            Ok(None) if Instant::now() < deadline => {
-                std::thread::sleep(Duration::from_millis(10));
-            }
-            Ok(None) | Err(_) => break,
-        }
-    }
-    let _ = child.kill();
-    let _ = child.wait();
+        .ok_or_else(|| IoError::new(ErrorKind::InvalidData, "invalid egress proxy readiness"))
 }
 
 fn serve_runner(

--- a/litebox_broker_userland/src/linux.rs
+++ b/litebox_broker_userland/src/linux.rs
@@ -47,16 +47,15 @@ impl HostAssociationShutdown for UnixControlRingHostShutdown {
     }
 }
 
-pub(super) fn run(args: super::CliArgs) -> Result<(), Box<dyn Error>> {
+pub(super) fn run(mut args: super::CliArgs) -> Result<(), Box<dyn Error>> {
     let proxy = if args.allow_host.is_empty() {
         None
     } else {
         Some(ManagedEgressProxy::start(&args.allow_host)?)
     };
-    let proxy_destination = proxy
-        .as_ref()
-        .map(ManagedEgressProxy::guest_destination)
-        .transpose()?;
+    if let Some(proxy) = &proxy {
+        args.allow_tcp_destination.push(proxy.guest_destination()?);
+    }
     let proxy_url = proxy.as_ref().map(ManagedEgressProxy::guest_url);
 
     let socket_dir = tempfile::Builder::new()
@@ -68,11 +67,7 @@ pub(super) fn run(args: super::CliArgs) -> Result<(), Box<dyn Error>> {
     let limits = BrokerCoreLimits::DEFAULT;
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_host_guaranteed_rights(ObjectRights::all()).with_socket_policy(
-            configured_socket_policy(
-                &args.allow_tcp_destination,
-                &args.allow_udp_destination,
-                proxy_destination,
-            )?,
+            configured_socket_policy(&args.allow_tcp_destination, &args.allow_udp_destination)?,
         ),
         limits,
         Arc::new(LinuxSocketProvider::new(

--- a/litebox_broker_userland/src/linux.rs
+++ b/litebox_broker_userland/src/linux.rs
@@ -23,8 +23,8 @@ use litebox_broker_transport_linux_userland::unix_socket::{
 };
 
 use super::{
-    AllowedDestination, HostAssociationShutdown, HostRequestSource, HostResponseSink,
-    SETUP_TIMEOUT, configured_socket_policy,
+    HostAssociationShutdown, HostRequestSource, HostResponseSink, SETUP_TIMEOUT,
+    configured_socket_policy,
 };
 
 const PROXY_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
@@ -54,9 +54,14 @@ pub(super) fn run(mut args: super::CliArgs) -> Result<(), Box<dyn Error>> {
         Some(ManagedEgressProxy::start(&args.allow_host)?)
     };
     if let Some(proxy) = &proxy {
-        args.allow_tcp_destination.push(proxy.guest_destination()?);
+        let proxy_destination = format!("{HOST_GATEWAY_IPV4_ADDRESS}/32:{}", proxy.port)
+            .parse()
+            .map_err(|error: String| IoError::new(ErrorKind::InvalidData, error))?;
+        args.allow_tcp_destination.push(proxy_destination);
     }
-    let proxy_url = proxy.as_ref().map(ManagedEgressProxy::guest_url);
+    let proxy_url = proxy
+        .as_ref()
+        .map(|proxy| format!("http://{HOST_GATEWAY_IPV4_ADDRESS}:{}", proxy.port));
 
     let socket_dir = tempfile::Builder::new()
         .prefix("litebox-broker-userland-")
@@ -149,16 +154,6 @@ impl ManagedEgressProxy {
 
         proxy.port = address.port();
         Ok(proxy)
-    }
-
-    fn guest_destination(&self) -> IoResult<AllowedDestination> {
-        format!("{HOST_GATEWAY_IPV4_ADDRESS}/32:{}", self.port)
-            .parse()
-            .map_err(|error: String| IoError::new(ErrorKind::InvalidData, error))
-    }
-
-    fn guest_url(&self) -> String {
-        format!("http://{HOST_GATEWAY_IPV4_ADDRESS}:{}", self.port)
     }
 }
 

--- a/litebox_broker_userland/src/linux.rs
+++ b/litebox_broker_userland/src/linux.rs
@@ -2,12 +2,15 @@
 // Licensed under the MIT license.
 
 use std::error::Error;
-use std::io::Result as IoResult;
+use std::io::{BufRead, BufReader, Error as IoError, ErrorKind, Result as IoResult};
+use std::net::{Ipv4Addr, SocketAddrV4};
 use std::os::unix::net::UnixListener;
-use std::process::Child;
+use std::process::{Child, ChildStdout, Command, Stdio};
 use std::sync::Arc;
-use std::time::Instant;
+use std::sync::mpsc::{RecvTimeoutError, sync_channel};
+use std::time::{Duration, Instant};
 
+use litebox_broker_core::socket::HOST_GATEWAY_IPV4_ADDRESS;
 use litebox_broker_core::{BrokerCore, BrokerCoreLimits, ObjectRights, PolicyEngine};
 use litebox_broker_platform_linux_userland::LinuxSocketProvider;
 use litebox_broker_protocol::message::{BrokerRequest, BrokerResponse};
@@ -20,9 +23,11 @@ use litebox_broker_transport_linux_userland::unix_socket::{
 };
 
 use super::{
-    HostAssociationShutdown, HostRequestSource, HostResponseSink, SETUP_TIMEOUT,
-    configured_socket_policy,
+    AllowedDestination, HostAssociationShutdown, HostRequestSource, HostResponseSink,
+    SETUP_TIMEOUT, configured_socket_policy,
 };
+
+const PROXY_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 
 impl HostRequestSource for UnixControlRingHostRequestSource {
     fn recv_request(&mut self) -> IoResult<HostReceive<BrokerRequest>> {
@@ -43,6 +48,17 @@ impl HostAssociationShutdown for UnixControlRingHostShutdown {
 }
 
 pub(super) fn run(args: super::CliArgs) -> Result<(), Box<dyn Error>> {
+    let proxy = if args.allow_host.is_empty() {
+        None
+    } else {
+        Some(ManagedEgressProxy::start(&args.allow_host)?)
+    };
+    let proxy_destination = proxy
+        .as_ref()
+        .map(ManagedEgressProxy::guest_destination)
+        .transpose()?;
+    let proxy_url = proxy.as_ref().map(ManagedEgressProxy::guest_url);
+
     let socket_dir = tempfile::Builder::new()
         .prefix("litebox-broker-userland-")
         .tempdir()?;
@@ -52,7 +68,11 @@ pub(super) fn run(args: super::CliArgs) -> Result<(), Box<dyn Error>> {
     let limits = BrokerCoreLimits::DEFAULT;
     let broker = BrokerCore::new_with_limits(
         PolicyEngine::with_host_guaranteed_rights(ObjectRights::all()).with_socket_policy(
-            configured_socket_policy(&args.allow_tcp_destination, &args.allow_udp_destination)?,
+            configured_socket_policy(
+                &args.allow_tcp_destination,
+                &args.allow_udp_destination,
+                proxy_destination,
+            )?,
         ),
         limits,
         Arc::new(LinuxSocketProvider::new(
@@ -64,10 +84,130 @@ pub(super) fn run(args: super::CliArgs) -> Result<(), Box<dyn Error>> {
     crate::run_runner_process(
         &args,
         control_socket_path.as_os_str(),
+        proxy_url.as_deref(),
         |runner, runner_process_id| {
             serve_runner(&broker, &control_listener, runner, runner_process_id)
         },
     )
+}
+
+struct ManagedEgressProxy {
+    child: Child,
+    port: u16,
+}
+
+impl ManagedEgressProxy {
+    fn start(allowed_hosts: &[String]) -> IoResult<Self> {
+        let executable = std::env::current_exe()?.with_file_name("litebox_egress_proxy");
+        let mut command = Command::new(executable);
+        command
+            .arg("--listen")
+            .arg("127.0.0.1:0")
+            .arg("--exit-on-stdin-close")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit());
+        for allowed_host in allowed_hosts {
+            command.arg("--allow-host").arg(allowed_host);
+        }
+
+        let mut proxy = Self {
+            child: command.spawn()?,
+            port: 0,
+        };
+        let stdout = proxy
+            .child
+            .stdout
+            .take()
+            .ok_or_else(|| IoError::other("egress proxy stdout was not piped"))?;
+        let (sender, receiver) = sync_channel(1);
+        let reader = std::thread::spawn(move || {
+            let _ = sender.send(read_proxy_ready(stdout));
+        });
+
+        let readiness = match receiver.recv_timeout(SETUP_TIMEOUT) {
+            Ok(readiness) => readiness,
+            Err(RecvTimeoutError::Timeout) => {
+                return Err(IoError::new(
+                    ErrorKind::TimedOut,
+                    "timed out waiting for egress proxy readiness",
+                ));
+            }
+            Err(RecvTimeoutError::Disconnected) => {
+                return Err(IoError::other("egress proxy readiness reader stopped"));
+            }
+        };
+        if reader.join().is_err() {
+            return Err(IoError::other("egress proxy readiness reader panicked"));
+        }
+        let address = parse_proxy_ready(&readiness?)?;
+        match proxy.child.try_wait() {
+            Ok(None) => {}
+            Ok(Some(status)) => {
+                return Err(IoError::new(
+                    ErrorKind::BrokenPipe,
+                    format!("egress proxy exited after reporting readiness with {status}"),
+                ));
+            }
+            Err(error) => return Err(error),
+        }
+
+        proxy.port = address.port();
+        Ok(proxy)
+    }
+
+    fn guest_destination(&self) -> IoResult<AllowedDestination> {
+        format!("{HOST_GATEWAY_IPV4_ADDRESS}/32:{}", self.port)
+            .parse()
+            .map_err(|error: String| IoError::new(ErrorKind::InvalidData, error))
+    }
+
+    fn guest_url(&self) -> String {
+        format!("http://{HOST_GATEWAY_IPV4_ADDRESS}:{}", self.port)
+    }
+}
+
+impl Drop for ManagedEgressProxy {
+    fn drop(&mut self) {
+        stop_proxy(&mut self.child);
+    }
+}
+
+fn read_proxy_ready(stdout: ChildStdout) -> IoResult<String> {
+    let mut reader = BufReader::new(stdout);
+    let mut line = String::new();
+    if reader.read_line(&mut line)? == 0 {
+        return Err(IoError::new(
+            ErrorKind::UnexpectedEof,
+            "egress proxy exited before reporting readiness",
+        ));
+    }
+    Ok(line)
+}
+
+fn parse_proxy_ready(line: &str) -> IoResult<SocketAddrV4> {
+    let address = line
+        .strip_prefix("READY ")
+        .and_then(|value| value.trim_end().parse::<SocketAddrV4>().ok())
+        .filter(|address| *address.ip() == Ipv4Addr::LOCALHOST && address.port() != 0)
+        .ok_or_else(|| IoError::new(ErrorKind::InvalidData, "invalid egress proxy readiness"))?;
+    Ok(address)
+}
+
+fn stop_proxy(child: &mut Child) {
+    child.stdin.take();
+    let deadline = Instant::now() + PROXY_SHUTDOWN_TIMEOUT;
+    loop {
+        match child.try_wait() {
+            Ok(Some(_status)) => return,
+            Ok(None) if Instant::now() < deadline => {
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            Ok(None) | Err(_) => break,
+        }
+    }
+    let _ = child.kill();
+    let _ = child.wait();
 }
 
 fn serve_runner(

--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -586,22 +586,6 @@ mod cli_tests {
         assert_eq!(args.allow_udp_destination.len(), 1);
     }
 
-    #[cfg(target_os = "linux")]
-    #[test]
-    fn cli_accepts_hostname_proxy_arguments() {
-        let args = CliArgs::try_parse_from([
-            "litebox-broker-userland",
-            "--allow-host",
-            "example.com:443",
-            "--runner",
-            "runner",
-            "guest",
-        ])
-        .unwrap();
-
-        assert_eq!(args.allow_host, ["example.com:443"]);
-    }
-
     #[test]
     fn destination_argument_parses_canonical_cidr_and_ports() {
         let allowed = "203.0.113.0/24:443-444"

--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -39,7 +39,6 @@ const SETUP_TIMEOUT: Duration = Duration::from_secs(5);
 const ACCEPT_RETRY_DELAY: Duration = Duration::from_millis(10);
 const REQUEST_QUEUE_CAPACITY: usize = 64;
 const WORKER_COUNT: usize = 8;
-const BROKER_PROXY_URL_ENV: &str = "LITEBOX_BROKER_PROXY_URL";
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct AllowedDestination {
@@ -122,9 +121,7 @@ fn run_runner_process(
         .arg("--broker-control-channel")
         .arg(control_channel);
     if let Some(proxy_url) = proxy_url {
-        command.env(BROKER_PROXY_URL_ENV, proxy_url);
-    } else {
-        command.env_remove(BROKER_PROXY_URL_ENV);
+        command.arg("--broker-proxy-url").arg(proxy_url);
     }
     let mut runner = command.args(&args.runner_arguments).spawn()?;
     let runner_process_id = runner.id();
@@ -143,14 +140,10 @@ fn run_runner_process(
 fn configured_socket_policy(
     allowed_tcp_destinations: &[AllowedDestination],
     allowed_udp_destinations: &[AllowedDestination],
-    proxy_destination: Option<AllowedDestination>,
 ) -> Result<SocketPolicy, SocketPolicyError> {
     let mut policy = SocketPolicy::guest_network();
-    if !allowed_tcp_destinations.is_empty() || proxy_destination.is_some() {
-        let mut rules = destination_rules(allowed_tcp_destinations);
-        if let Some(proxy_destination) = proxy_destination {
-            rules.extend(destination_rules(&[proxy_destination]));
-        }
+    if !allowed_tcp_destinations.is_empty() {
+        let rules = destination_rules(allowed_tcp_destinations);
         policy = policy.with_tcp_destination_rules(&rules)?;
     }
     if !allowed_udp_destinations.is_empty() {
@@ -629,14 +622,14 @@ mod cli_tests {
     #[test]
     fn destination_arguments_extend_the_guest_network_default_by_protocol() {
         assert_eq!(
-            configured_socket_policy(&[], &[], None).unwrap(),
+            configured_socket_policy(&[], &[]).unwrap(),
             SocketPolicy::guest_network()
         );
 
         let tcp = "0.0.0.0/0:80".parse::<AllowedDestination>().unwrap();
         let udp = "10.0.2.1/32:53".parse::<AllowedDestination>().unwrap();
         let proxy = "10.0.2.1/32:3128".parse::<AllowedDestination>().unwrap();
-        let policy = configured_socket_policy(&[tcp], &[udp], Some(proxy)).unwrap();
+        let policy = configured_socket_policy(&[tcp, proxy], &[udp]).unwrap();
         let tcp_rules = policy.tcp_destination_rules().unwrap();
         assert_eq!(tcp_rules.len(), 2);
         assert_eq!(

--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -39,6 +39,7 @@ const SETUP_TIMEOUT: Duration = Duration::from_secs(5);
 const ACCEPT_RETRY_DELAY: Duration = Duration::from_millis(10);
 const REQUEST_QUEUE_CAPACITY: usize = 64;
 const WORKER_COUNT: usize = 8;
+const BROKER_PROXY_URL_ENV: &str = "LITEBOX_BROKER_PROXY_URL";
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct AllowedDestination {
@@ -85,6 +86,10 @@ impl FromStr for AllowedDestination {
 
 #[derive(Parser, Debug)]
 struct CliArgs {
+    /// Permit HTTP and HTTPS proxy requests to a hostname and destination ports.
+    #[cfg(target_os = "linux")]
+    #[arg(long = "allow-host", value_name = "HOST:PORT[-PORT]")]
+    allow_host: Vec<String>,
     /// Permit outbound TCP connections to a destination CIDR and port range.
     ///
     /// May be repeated to extend the default guest-network policy for TCP.
@@ -108,14 +113,20 @@ struct CliArgs {
 fn run_runner_process(
     args: &CliArgs,
     control_channel: &OsStr,
+    proxy_url: Option<&str>,
     serve: impl FnOnce(&mut Child, u32) -> Result<(), Box<dyn Error>>,
 ) -> Result<(), Box<dyn Error>> {
-    let mut runner = Command::new(&args.runner)
+    let mut command = Command::new(&args.runner);
+    command
         .arg("--unstable")
         .arg("--broker-control-channel")
-        .arg(control_channel)
-        .args(&args.runner_arguments)
-        .spawn()?;
+        .arg(control_channel);
+    if let Some(proxy_url) = proxy_url {
+        command.env(BROKER_PROXY_URL_ENV, proxy_url);
+    } else {
+        command.env_remove(BROKER_PROXY_URL_ENV);
+    }
+    let mut runner = command.args(&args.runner_arguments).spawn()?;
     let runner_process_id = runner.id();
     let association_result = serve(&mut runner, runner_process_id);
     if association_result.is_err() {
@@ -132,10 +143,14 @@ fn run_runner_process(
 fn configured_socket_policy(
     allowed_tcp_destinations: &[AllowedDestination],
     allowed_udp_destinations: &[AllowedDestination],
+    proxy_destination: Option<AllowedDestination>,
 ) -> Result<SocketPolicy, SocketPolicyError> {
     let mut policy = SocketPolicy::guest_network();
-    if !allowed_tcp_destinations.is_empty() {
-        let rules = destination_rules(allowed_tcp_destinations);
+    if !allowed_tcp_destinations.is_empty() || proxy_destination.is_some() {
+        let mut rules = destination_rules(allowed_tcp_destinations);
+        if let Some(proxy_destination) = proxy_destination {
+            rules.extend(destination_rules(&[proxy_destination]));
+        }
         policy = policy.with_tcp_destination_rules(&rules)?;
     }
     if !allowed_udp_destinations.is_empty() {
@@ -578,6 +593,22 @@ mod cli_tests {
         assert_eq!(args.allow_udp_destination.len(), 1);
     }
 
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn cli_accepts_hostname_proxy_arguments() {
+        let args = CliArgs::try_parse_from([
+            "litebox-broker-userland",
+            "--allow-host",
+            "example.com:443",
+            "--runner",
+            "runner",
+            "guest",
+        ])
+        .unwrap();
+
+        assert_eq!(args.allow_host, ["example.com:443"]);
+    }
+
     #[test]
     fn destination_argument_parses_canonical_cidr_and_ports() {
         let allowed = "203.0.113.0/24:443-444"
@@ -598,18 +629,27 @@ mod cli_tests {
     #[test]
     fn destination_arguments_extend_the_guest_network_default_by_protocol() {
         assert_eq!(
-            configured_socket_policy(&[], &[]).unwrap(),
+            configured_socket_policy(&[], &[], None).unwrap(),
             SocketPolicy::guest_network()
         );
 
         let tcp = "0.0.0.0/0:80".parse::<AllowedDestination>().unwrap();
         let udp = "10.0.2.1/32:53".parse::<AllowedDestination>().unwrap();
-        let policy = configured_socket_policy(&[tcp], &[udp]).unwrap();
+        let proxy = "10.0.2.1/32:3128".parse::<AllowedDestination>().unwrap();
+        let policy = configured_socket_policy(&[tcp], &[udp], Some(proxy)).unwrap();
         let tcp_rules = policy.tcp_destination_rules().unwrap();
-        assert_eq!(tcp_rules.len(), 1);
+        assert_eq!(tcp_rules.len(), 2);
         assert_eq!(
             tcp_rules[0],
             DestinationRule::new(CallerCredential::HostGuaranteed, tcp.destination, tcp.ports,)
+        );
+        assert_eq!(
+            tcp_rules[1],
+            DestinationRule::new(
+                CallerCredential::HostGuaranteed,
+                proxy.destination,
+                proxy.ports,
+            )
         );
         let udp_rules = policy.udp_destination_rules().unwrap();
         assert_eq!(udp_rules.len(), 1);

--- a/litebox_broker_userland/src/windows.rs
+++ b/litebox_broker_userland/src/windows.rs
@@ -53,11 +53,7 @@ pub(super) fn run(args: super::CliArgs) -> Result<(), Box<dyn Error>> {
     let control_listener = WindowsNamedPipeListener::bind(&control_pipe)?;
     let broker = BrokerCore::new(
         PolicyEngine::with_host_guaranteed_rights(ObjectRights::all()).with_socket_policy(
-            configured_socket_policy(
-                &args.allow_tcp_destination,
-                &args.allow_udp_destination,
-                None,
-            )?,
+            configured_socket_policy(&args.allow_tcp_destination, &args.allow_udp_destination)?,
         ),
         Arc::new(UnsupportedSocketProvider),
     )?;

--- a/litebox_broker_userland/src/windows.rs
+++ b/litebox_broker_userland/src/windows.rs
@@ -53,12 +53,16 @@ pub(super) fn run(args: super::CliArgs) -> Result<(), Box<dyn Error>> {
     let control_listener = WindowsNamedPipeListener::bind(&control_pipe)?;
     let broker = BrokerCore::new(
         PolicyEngine::with_host_guaranteed_rights(ObjectRights::all()).with_socket_policy(
-            configured_socket_policy(&args.allow_tcp_destination, &args.allow_udp_destination)?,
+            configured_socket_policy(
+                &args.allow_tcp_destination,
+                &args.allow_udp_destination,
+                None,
+            )?,
         ),
         Arc::new(UnsupportedSocketProvider),
     )?;
 
-    crate::run_runner_process(&args, &control_pipe, |runner, runner_process_id| {
+    crate::run_runner_process(&args, &control_pipe, None, |runner, runner_process_id| {
         serve_runner(&broker, control_listener, runner, runner_process_id)
     })
 }

--- a/litebox_egress_proxy/Cargo.toml
+++ b/litebox_egress_proxy/Cargo.toml
@@ -24,6 +24,7 @@ hyper-util = { version = "0.1.20", default-features = false, features = [
 thiserror = { version = "2.0", default-features = false }
 tokio = { version = "1.50", default-features = false, features = [
     "io-util",
+    "macros",
     "net",
     "rt",
     "sync",

--- a/litebox_egress_proxy/src/config.rs
+++ b/litebox_egress_proxy/src/config.rs
@@ -24,6 +24,10 @@ pub struct Cli {
     /// Allowed hostname and destination ports, repeatable.
     #[arg(long = "allow-host", value_name = "HOST:PORT[-PORT]")]
     allow_host: Vec<String>,
+
+    /// Exit when standard input closes.
+    #[arg(long, hide = true)]
+    exit_on_stdin_close: bool,
 }
 
 /// Reason the arguments were rejected.
@@ -47,6 +51,8 @@ pub struct ProxyConfig {
     pub listen: SocketAddrV4,
     /// The immutable hostname policy.
     pub policy: HostPolicy,
+    /// Whether parent-process lifetime is signaled through standard input.
+    pub exit_on_stdin_close: bool,
 }
 
 impl Cli {
@@ -55,7 +61,11 @@ impl Cli {
         let listen = parse_listen_address(&self.listen)?;
         let policy = HostPolicy::from_rules(&self.allow_host)?;
 
-        Ok(ProxyConfig { listen, policy })
+        Ok(ProxyConfig {
+            listen,
+            policy,
+            exit_on_stdin_close: self.exit_on_stdin_close,
+        })
     }
 }
 
@@ -92,6 +102,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(config.listen, SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0));
+        assert!(!config.exit_on_stdin_close);
 
         let host = Hostname::parse("example.com").unwrap();
         assert!(config.policy.allows(&host, 443));

--- a/litebox_egress_proxy/src/lib.rs
+++ b/litebox_egress_proxy/src/lib.rs
@@ -44,7 +44,12 @@ pub async fn run(config: ProxyConfig) -> io::Result<()> {
     }
 
     if config.exit_on_stdin_close {
-        let stdin_closed = watch_stdin_close();
+        let (sender, stdin_closed) = oneshot::channel();
+        std::thread::spawn(move || {
+            let mut stdin = io::stdin().lock();
+            let result = io::copy(&mut stdin, &mut io::sink()).map(|_read| ());
+            let _ = sender.send(result);
+        });
         tokio::select! {
             result = proxy::serve(listener, state) => result?,
             result = stdin_closed => {
@@ -55,14 +60,4 @@ pub async fn run(config: ProxyConfig) -> io::Result<()> {
         proxy::serve(listener, state).await?;
     }
     Ok(())
-}
-
-fn watch_stdin_close() -> oneshot::Receiver<io::Result<()>> {
-    let (sender, receiver) = oneshot::channel();
-    std::thread::spawn(move || {
-        let mut stdin = io::stdin().lock();
-        let result = io::copy(&mut stdin, &mut io::sink()).map(|_read| ());
-        let _ = sender.send(result);
-    });
-    receiver
 }

--- a/litebox_egress_proxy/src/lib.rs
+++ b/litebox_egress_proxy/src/lib.rs
@@ -22,6 +22,7 @@ use std::io::{self, Write};
 use std::sync::Arc;
 
 use tokio::net::TcpListener;
+use tokio::sync::oneshot;
 
 use crate::config::ProxyConfig;
 use crate::connector::TcpUpstreamConnector;
@@ -42,6 +43,26 @@ pub async fn run(config: ProxyConfig) -> io::Result<()> {
         stdout.flush()?;
     }
 
-    proxy::serve(listener, state).await?;
+    if config.exit_on_stdin_close {
+        let stdin_closed = watch_stdin_close();
+        tokio::select! {
+            result = proxy::serve(listener, state) => result?,
+            result = stdin_closed => {
+                result.map_err(|_| io::Error::other("standard input watcher stopped"))??;
+            }
+        }
+    } else {
+        proxy::serve(listener, state).await?;
+    }
     Ok(())
+}
+
+fn watch_stdin_close() -> oneshot::Receiver<io::Result<()>> {
+    let (sender, receiver) = oneshot::channel();
+    std::thread::spawn(move || {
+        let mut stdin = io::stdin().lock();
+        let result = io::copy(&mut stdin, &mut io::sink()).map(|_read| ());
+        let _ = sender.send(result);
+    });
+    receiver
 }

--- a/litebox_runner_linux_userland/src/lib.rs
+++ b/litebox_runner_linux_userland/src/lib.rs
@@ -17,6 +17,19 @@ extern crate alloc;
 // credentials aligned with the in-memory filesystem default user and avoids truncating high host IDs.
 const DEFAULT_GUEST_UID: u16 = 1000;
 const DEFAULT_GUEST_GID: u16 = 1000;
+const BROKER_PROXY_URL_ENV: &str = "LITEBOX_BROKER_PROXY_URL";
+const MANAGED_PROXY_ENV_KEYS: [&str; 10] = [
+    "HTTP_PROXY",
+    "http_proxy",
+    "HTTPS_PROXY",
+    "https_proxy",
+    "ALL_PROXY",
+    "all_proxy",
+    "FTP_PROXY",
+    "ftp_proxy",
+    "NO_PROXY",
+    "no_proxy",
+];
 
 /// Run Linux programs with LiteBox on unmodified Linux
 ///
@@ -365,21 +378,20 @@ pub fn run(cli_args: CliArgs) -> Result<()> {
         .iter()
         .map(|x| std::ffi::CString::new(x.bytes().collect::<Vec<u8>>()).unwrap())
         .collect();
-    let envp: Vec<_> = cli_args
-        .environment_variables
-        .iter()
-        .map(|x| std::ffi::CString::new(x.bytes().collect::<Vec<u8>>()).unwrap())
-        .collect();
-    let envp = if cli_args.forward_environment_variables {
-        envp.into_iter()
-            .chain(std::env::vars().map(|(k, v)| {
-                std::ffi::CString::new(k.bytes().chain(*b"=").chain(v.bytes()).collect::<Vec<u8>>())
-                    .unwrap()
-            }))
-            .collect()
+    let mut environment = cli_args.environment_variables.clone();
+    if cli_args.forward_environment_variables {
+        environment.extend(std::env::vars().map(|(key, value)| format!("{key}={value}")));
+    }
+    let proxy_url = if cli_args.broker_control_channel.is_some() {
+        std::env::var(BROKER_PROXY_URL_ENV).ok()
     } else {
-        envp
+        None
     };
+    apply_broker_proxy_environment(&mut environment, proxy_url.as_deref());
+    let envp = environment
+        .iter()
+        .map(|value| std::ffi::CString::new(value.as_bytes()).unwrap())
+        .collect();
 
     litebox_platform_linux_userland::LinuxUserland::enable_seccomp_filter(
         &broker_positional_io_fds,
@@ -413,4 +425,56 @@ pub fn run(cli_args: CliArgs) -> Result<()> {
     }
 
     std::process::exit(program.process.wait())
+}
+
+fn apply_broker_proxy_environment(environment: &mut Vec<String>, proxy_url: Option<&str>) {
+    environment.retain(|entry| {
+        let key = entry
+            .split_once('=')
+            .map_or(entry.as_str(), |(key, _value)| key);
+        key != BROKER_PROXY_URL_ENV
+            && (proxy_url.is_none()
+                || !MANAGED_PROXY_ENV_KEYS
+                    .iter()
+                    .any(|managed| managed.eq_ignore_ascii_case(key)))
+    });
+
+    if let Some(proxy_url) = proxy_url {
+        for key in ["HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy"] {
+            environment.push(format!("{key}={proxy_url}"));
+        }
+        environment.push("NO_PROXY=".to_owned());
+        environment.push("no_proxy=".to_owned());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn broker_proxy_replaces_proxy_environment() {
+        let mut environment = vec![
+            "PATH=/bin".to_owned(),
+            "HTTPS_PROXY=http://wrong.example:8080".to_owned(),
+            "No_Proxy=*".to_owned(),
+            "ALL_PROXY=http://wrong.example:8080".to_owned(),
+            format!("{BROKER_PROXY_URL_ENV}=internal"),
+        ];
+
+        apply_broker_proxy_environment(&mut environment, Some("http://10.0.2.1:49152"));
+
+        assert_eq!(
+            environment,
+            [
+                "PATH=/bin",
+                "HTTP_PROXY=http://10.0.2.1:49152",
+                "http_proxy=http://10.0.2.1:49152",
+                "HTTPS_PROXY=http://10.0.2.1:49152",
+                "https_proxy=http://10.0.2.1:49152",
+                "NO_PROXY=",
+                "no_proxy=",
+            ]
+        );
+    }
 }

--- a/litebox_runner_linux_userland/src/lib.rs
+++ b/litebox_runner_linux_userland/src/lib.rs
@@ -132,6 +132,12 @@ fn mmapped_file(path: impl AsRef<Path>) -> Result<MmappedFile> {
 /// panic. If it does actually panic, then ping the authors of LiteBox, and likely a better error
 /// message could be thrown instead.
 pub fn run(cli_args: CliArgs) -> Result<()> {
+    if cli_args.broker_proxy_url.is_some() && cli_args.broker_control_channel.is_none() {
+        return Err(anyhow!(
+            "--broker-proxy-url requires --broker-control-channel"
+        ));
+    }
+
     tracing_subscriber::fmt()
         .with_timer(tracing_subscriber::fmt::time::uptime())
         .with_level(true)
@@ -449,6 +455,19 @@ fn apply_broker_proxy_environment(environment: &mut Vec<String>, proxy_url: Opti
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn programmatic_proxy_url_requires_broker_channel() {
+        let mut args = CliArgs::try_parse_from(["runner", "/bin/true"]).unwrap();
+        args.broker_proxy_url = Some("http://10.0.2.1:49152".to_owned());
+
+        let error = run(args).unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "--broker-proxy-url requires --broker-control-channel"
+        );
+    }
 
     #[test]
     fn broker_proxy_replaces_proxy_environment() {

--- a/litebox_runner_linux_userland/src/lib.rs
+++ b/litebox_runner_linux_userland/src/lib.rs
@@ -17,18 +17,12 @@ extern crate alloc;
 // credentials aligned with the in-memory filesystem default user and avoids truncating high host IDs.
 const DEFAULT_GUEST_UID: u16 = 1000;
 const DEFAULT_GUEST_GID: u16 = 1000;
-const BROKER_PROXY_URL_ENV: &str = "LITEBOX_BROKER_PROXY_URL";
-const MANAGED_PROXY_ENV_KEYS: [&str; 10] = [
+const MANAGED_PROXY_ENV_KEYS: [&str; 5] = [
     "HTTP_PROXY",
-    "http_proxy",
     "HTTPS_PROXY",
-    "https_proxy",
     "ALL_PROXY",
-    "all_proxy",
     "FTP_PROXY",
-    "ftp_proxy",
     "NO_PROXY",
-    "no_proxy",
 ];
 
 /// Run Linux programs with LiteBox on unmodified Linux
@@ -95,6 +89,15 @@ pub struct CliArgs {
         help_heading = "Unstable Options"
     )]
     pub broker_control_channel: Option<PathBuf>,
+    /// Broker-supplied proxy URL for managed HTTP and HTTPS egress.
+    #[arg(
+        long = "broker-proxy-url",
+        value_name = "URL",
+        hide = true,
+        requires = "broker_control_channel",
+        help_heading = "Unstable Options"
+    )]
+    pub broker_proxy_url: Option<String>,
 }
 
 struct MmappedFile {
@@ -378,15 +381,11 @@ pub fn run(cli_args: CliArgs) -> Result<()> {
         .iter()
         .map(|x| std::ffi::CString::new(x.bytes().collect::<Vec<u8>>()).unwrap())
         .collect();
-    let mut environment = cli_args.environment_variables.clone();
+    let proxy_url = cli_args.broker_proxy_url;
+    let mut environment = cli_args.environment_variables;
     if cli_args.forward_environment_variables {
         environment.extend(std::env::vars().map(|(key, value)| format!("{key}={value}")));
     }
-    let proxy_url = if cli_args.broker_control_channel.is_some() {
-        std::env::var(BROKER_PROXY_URL_ENV).ok()
-    } else {
-        None
-    };
     apply_broker_proxy_environment(&mut environment, proxy_url.as_deref());
     let envp = environment
         .iter()
@@ -432,11 +431,10 @@ fn apply_broker_proxy_environment(environment: &mut Vec<String>, proxy_url: Opti
         let key = entry
             .split_once('=')
             .map_or(entry.as_str(), |(key, _value)| key);
-        key != BROKER_PROXY_URL_ENV
-            && (proxy_url.is_none()
-                || !MANAGED_PROXY_ENV_KEYS
-                    .iter()
-                    .any(|managed| managed.eq_ignore_ascii_case(key)))
+        proxy_url.is_none()
+            || !MANAGED_PROXY_ENV_KEYS
+                .iter()
+                .any(|managed| managed.eq_ignore_ascii_case(key))
     });
 
     if let Some(proxy_url) = proxy_url {
@@ -459,7 +457,6 @@ mod tests {
             "HTTPS_PROXY=http://wrong.example:8080".to_owned(),
             "No_Proxy=*".to_owned(),
             "ALL_PROXY=http://wrong.example:8080".to_owned(),
-            format!("{BROKER_PROXY_URL_ENV}=internal"),
         ];
 
         apply_broker_proxy_environment(&mut environment, Some("http://10.0.2.1:49152"));

--- a/litebox_runner_linux_userland/tests/run.rs
+++ b/litebox_runner_linux_userland/tests/run.rs
@@ -69,6 +69,8 @@ struct Runner {
     unique_name: String,
     cmd_path: PathBuf,
     cmd_args: Vec<OsString>,
+    #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+    managed_proxy_hosts: Vec<OsString>,
     has_run: bool,
 }
 
@@ -125,6 +127,8 @@ impl Runner {
             tar_dir,
             cmd_path: target_guest_path,
             cmd_args: Vec::new(),
+            #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+            managed_proxy_hosts: Vec::new(),
             has_run: false,
             unique_name: unique_name.to_owned(),
         }
@@ -171,6 +175,19 @@ impl Runner {
         self
     }
 
+    #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+    fn managed_proxy(
+        &mut self,
+        allowed_hosts: impl IntoIterator<Item = impl AsRef<std::ffi::OsStr>>,
+    ) -> &mut Self {
+        self.managed_proxy_hosts.extend(
+            allowed_hosts
+                .into_iter()
+                .map(|host| host.as_ref().to_os_string()),
+        );
+        self
+    }
+
     fn with_fs_path(&mut self, f: impl FnOnce(&Path)) -> &mut Self {
         f(&self.tar_dir);
         self
@@ -202,6 +219,31 @@ impl Runner {
             .arg(tar_file)
             .arg(&self.cmd_path)
             .args(&self.cmd_args);
+
+        #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+        if !self.managed_proxy_hosts.is_empty() {
+            let runner = self.command.get_program().to_os_string();
+            let runner_arguments = self
+                .command
+                .get_args()
+                .filter(|argument| *argument != "--unstable")
+                .map(std::ffi::OsStr::to_os_string)
+                .collect::<Vec<_>>();
+            let broker = Path::new(&runner).with_file_name("litebox-broker-userland");
+            let proxy = Path::new(&runner).with_file_name("litebox_egress_proxy");
+            assert!(
+                broker.is_file() && proxy.is_file(),
+                "managed proxy tests require a workspace build producing {} and {}",
+                broker.display(),
+                proxy.display()
+            );
+            let mut command = std::process::Command::new(broker);
+            for host in &self.managed_proxy_hosts {
+                command.arg("--allow-host").arg(host);
+            }
+            command.arg("--runner").arg(runner).args(runner_arguments);
+            self.command = command;
+        }
     }
 
     fn run_inner(&mut self, capture_stdout: bool) -> Vec<u8> {
@@ -1319,6 +1361,61 @@ fn test_broker_with_curl() {
 
     let output_str = String::from_utf8_lossy(&output);
     assert!(output_str.contains(RESPONSE_BODY), "Unexpected curl output");
+}
+
+#[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+#[test]
+fn test_managed_egress_proxy_with_curl() {
+    const CA_BUNDLE: &str = "/etc/ssl/certs/ca-certificates.crt";
+
+    let probe = std::net::UdpSocket::bind((std::net::Ipv4Addr::UNSPECIFIED, 0))
+        .expect("failed to create IPv4 route probe");
+    if let Err(error) = probe.connect((std::net::Ipv4Addr::new(192, 0, 2, 1), 9)) {
+        if error.kind() == std::io::ErrorKind::NetworkUnreachable {
+            eprintln!("skipping managed egress proxy test: IPv4 route unavailable: {error}");
+            return;
+        }
+        panic!("IPv4 route probe failed: {error}");
+    }
+
+    assert!(
+        Path::new(CA_BUNDLE).is_file(),
+        "system CA bundle is unavailable at {CA_BUNDLE}"
+    );
+
+    let curl_path = run_which("curl");
+    let mut runner = Runner::new(&curl_path, "managed_egress_proxy_curl");
+    runner
+        .env("HTTPS_PROXY=http://wrong.example:8080")
+        .env("NO_PROXY=*")
+        .with_fs_path(|root| {
+            let destination = root.join(CA_BUNDLE.trim_start_matches('/'));
+            std::fs::create_dir_all(destination.parent().unwrap()).unwrap();
+            std::fs::copy(CA_BUNDLE, destination).unwrap();
+        })
+        .managed_proxy(["bing.com:443"])
+        .args([
+            "--silent",
+            "--show-error",
+            "--output",
+            "/dev/null",
+            "--write-out",
+            "%{http_code}",
+            "--connect-timeout",
+            "10",
+            "--max-time",
+            "30",
+            "--cacert",
+            CA_BUNDLE,
+            "https://bing.com/",
+        ]);
+
+    let output = runner.output();
+    let status = String::from_utf8(output).expect("curl emitted non-UTF-8 status");
+    assert!(
+        status.len() == 3 && status.bytes().all(|byte| byte.is_ascii_digit()) && status != "000",
+        "curl did not receive an HTTPS response from bing.com: {status:?}"
+    );
 }
 
 /// Exercises sustained brokered TCP traffic and backpressure with iperf3.

--- a/litebox_runner_linux_userland/tests/run.rs
+++ b/litebox_runner_linux_userland/tests/run.rs
@@ -175,19 +175,6 @@ impl Runner {
         self
     }
 
-    #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
-    fn managed_proxy(
-        &mut self,
-        allowed_hosts: impl IntoIterator<Item = impl AsRef<std::ffi::OsStr>>,
-    ) -> &mut Self {
-        self.managed_proxy_hosts.extend(
-            allowed_hosts
-                .into_iter()
-                .map(|host| host.as_ref().to_os_string()),
-        );
-        self
-    }
-
     fn with_fs_path(&mut self, f: impl FnOnce(&Path)) -> &mut Self {
         f(&self.tar_dir);
         self
@@ -1385,6 +1372,7 @@ fn test_managed_egress_proxy_with_curl() {
 
     let curl_path = run_which("curl");
     let mut runner = Runner::new(&curl_path, "managed_egress_proxy_curl");
+    runner.managed_proxy_hosts.push("bing.com:443".into());
     runner
         .env("HTTPS_PROXY=http://wrong.example:8080")
         .env("NO_PROXY=*")
@@ -1393,7 +1381,6 @@ fn test_managed_egress_proxy_with_curl() {
             std::fs::create_dir_all(destination.parent().unwrap()).unwrap();
             std::fs::copy(CA_BUNDLE, destination).unwrap();
         })
-        .managed_proxy(["bing.com:443"])
         .args([
             "--silent",
             "--show-error",


### PR DESCRIPTION
This PR integrates the hostname-filtered egress proxy with the Linux userland broker by launching and managing a sibling proxy for explicit `--allow-host` rules, authorizing only its OS-selected guest-gateway port, injecting sanitized HTTP and HTTPS proxy variables into the LiteBox workload, and covering the complete path with a TLS-verified request to `https://bing.com`.