### PR TITLE
Route Linux getrandom through the broker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1689,7 +1689,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
- "getrandom 0.3.4",
  "glob",
  "libc",
  "litebox",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1478,6 +1478,7 @@ name = "litebox_broker_userland"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "getrandom 0.3.4",
  "litebox_broker_core",
  "litebox_broker_host",
  "litebox_broker_local",
@@ -1688,6 +1689,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "getrandom 0.3.4",
  "glob",
  "libc",
  "litebox",

--- a/litebox/src/broker/mod.rs
+++ b/litebox/src/broker/mod.rs
@@ -13,6 +13,7 @@ use litebox_broker_protocol::ObjectHandle;
 use litebox_broker_protocol::error::ErrorCode;
 use litebox_broker_protocol::event::{ConsumeEventResponse, EventConsumeMode};
 use litebox_broker_protocol::pipe::{CreatePipeResponse, MAX_PIPE_TRANSFER_SIZE};
+use litebox_broker_protocol::random::MAX_RANDOM_TRANSFER_SIZE;
 use litebox_broker_protocol::readiness::ReadinessFlags;
 use litebox_broker_protocol::socket::{
     AcceptSocketResponse, MAX_SOCKET_TRANSFER_SIZE, MAX_UDP_DATAGRAM_SIZE,
@@ -41,6 +42,8 @@ use shared_buffer::{SlotAllocator, SlotLease};
 /// Longer-term broker integrations should move away from blocking control calls
 /// once the local-core wait and notification model supports that shape.
 pub(crate) trait BrokerControl: Send + Sync {
+    fn fill_random(&self, output: &mut [u8]) -> core::result::Result<(), BrokerControlError>;
+
     fn create_tcp_socket(&self) -> core::result::Result<ObjectHandle, BrokerControlError>;
 
     fn create_udp_socket(&self) -> core::result::Result<ObjectHandle, BrokerControlError>;
@@ -300,6 +303,16 @@ where
     Platform: RawSyncPrimitivesProvider + TimeProvider,
     Channel: LocalCallChannel + Send + Sync,
 {
+    fn fill_random(&self, output: &mut [u8]) -> core::result::Result<(), BrokerControlError> {
+        if output.len() > MAX_RANDOM_TRANSFER_SIZE as usize {
+            return Err(BrokerControlError::Broker(ErrorCode::ResourceExhausted));
+        }
+        let length =
+            u32::try_from(output.len()).expect("validated random transfer length must fit in u32");
+        let lease = self.acquire_shared_buffer(length)?;
+        self.request(|local| local.fill_random(lease.descriptor(), output))
+    }
+
     fn create_tcp_socket(&self) -> core::result::Result<ObjectHandle, BrokerControlError> {
         self.request(BrokerLocal::create_tcp_socket)
     }

--- a/litebox/src/event/counter.rs
+++ b/litebox/src/event/counter.rs
@@ -487,7 +487,8 @@ mod tests {
                 }
                 request @ (BrokerOperation::Event(_)
                 | BrokerOperation::Pipe(_)
-                | BrokerOperation::Socket(_)) => {
+                | BrokerOperation::Socket(_)
+                | BrokerOperation::FillRandom(_)) => {
                     panic!("unexpected broker request: {request:?}")
                 }
             };

--- a/litebox/src/lib.rs
+++ b/litebox/src/lib.rs
@@ -24,6 +24,7 @@ pub mod net;
 pub mod path;
 pub mod pipes;
 pub mod platform;
+pub mod random;
 pub mod shim;
 pub mod sync;
 pub mod tls;

--- a/litebox/src/pipes.rs
+++ b/litebox/src/pipes.rs
@@ -1199,7 +1199,8 @@ mod tests {
                 }
                 request @ (BrokerOperation::Pipe(_)
                 | BrokerOperation::Event(_)
-                | BrokerOperation::Socket(_)) => {
+                | BrokerOperation::Socket(_)
+                | BrokerOperation::FillRandom(_)) => {
                     panic!("unexpected broker request: {request:?}")
                 }
             };

--- a/litebox/src/random.rs
+++ b/litebox/src/random.rs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//! Broker-provided cryptographic randomness.
+
+use thiserror::Error;
+
+use crate::{LiteBox, sync::RawSyncPrimitivesProvider};
+
+/// A broker could not fill a random-byte request.
+#[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
+#[error("brokered random source is unavailable")]
+pub struct FillRandomError;
+
+impl<Platform: RawSyncPrimitivesProvider> LiteBox<Platform> {
+    /// Fills `output` completely with cryptographically secure random bytes.
+    ///
+    /// Non-empty requests require a negotiated broker and may contain at most
+    /// 256 bytes.
+    pub fn fill_random(&self, output: &mut [u8]) -> Result<(), FillRandomError> {
+        if output.is_empty() {
+            return Ok(());
+        }
+        self.broker_control()
+            .ok_or(FillRandomError)?
+            .fill_random(output)
+            .map_err(|_| FillRandomError)
+    }
+}

--- a/litebox_broker_core/src/lib.rs
+++ b/litebox_broker_core/src/lib.rs
@@ -22,6 +22,7 @@ mod error;
 pub mod event;
 pub mod pipe;
 mod policy;
+pub mod random;
 pub mod readiness;
 mod session;
 pub mod socket;
@@ -38,6 +39,7 @@ pub use policy::{
     DestinationPortRange, DestinationRule, Ipv4Cidr, MAX_DESTINATION_RULES, PolicyEngine,
     PolicyProfile, SocketPolicy, SocketPolicyError,
 };
+use random::RandomProvider;
 use session::ObjectReference;
 pub use session::{BrokerSession, CallerCredential, ObjectRights, SessionId};
 use socket::{BrokerSocketPorts, SocketProvider};
@@ -116,6 +118,7 @@ pub struct BrokerCore {
     pub(crate) pending_references: Arc<AtomicUsize>,
     pub(crate) reserved_pipe_capacity: Arc<AtomicUsize>,
     pub(crate) reserved_sockets: Arc<AtomicUsize>,
+    pub(crate) random_provider: Arc<dyn RandomProvider>,
     pub(crate) socket_provider: Arc<dyn SocketProvider>,
     pub(crate) socket_ports: BrokerSocketPorts,
 }
@@ -124,8 +127,17 @@ static BROKER_CORE_CREATED: AtomicBool = AtomicBool::new(false);
 
 impl BrokerCore {
     /// Creates the broker core with a broker-wide platform socket provider.
-    pub fn new(policy: PolicyEngine, socket_provider: Arc<dyn SocketProvider>) -> Result<Self> {
-        Self::new_with_limits(policy, BrokerCoreLimits::DEFAULT, socket_provider)
+    pub fn new(
+        policy: PolicyEngine,
+        socket_provider: Arc<dyn SocketProvider>,
+        random_provider: Arc<dyn RandomProvider>,
+    ) -> Result<Self> {
+        Self::new_with_limits(
+            policy,
+            BrokerCoreLimits::DEFAULT,
+            socket_provider,
+            random_provider,
+        )
     }
 
     /// Creates the broker core with explicit limits and a socket provider.
@@ -133,6 +145,7 @@ impl BrokerCore {
         policy: PolicyEngine,
         limits: BrokerCoreLimits,
         socket_provider: Arc<dyn SocketProvider>,
+        random_provider: Arc<dyn RandomProvider>,
     ) -> Result<Self> {
         BROKER_CORE_CREATED
             .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
@@ -147,6 +160,7 @@ impl BrokerCore {
             pending_references: Arc::new(AtomicUsize::new(0)),
             reserved_pipe_capacity: Arc::new(AtomicUsize::new(0)),
             reserved_sockets: Arc::new(AtomicUsize::new(0)),
+            random_provider,
             socket_provider,
             socket_ports: BrokerSocketPorts::default(),
         })

--- a/litebox_broker_core/src/random.rs
+++ b/litebox_broker_core/src/random.rs
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//! Broker-authoritative cryptographic randomness.
+
+use litebox_broker_protocol::random::MAX_RANDOM_TRANSFER_SIZE;
+use thiserror::Error;
+
+use crate::{BrokerError, BrokerSession, Result};
+
+/// Failure reported by a trusted random provider.
+#[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
+#[error("trusted random provider failed")]
+pub struct RandomProviderError;
+
+/// Trusted source of cryptographically secure random bytes.
+///
+/// A successful call must overwrite every byte in `output` with fresh,
+/// cryptographically secure output. Concurrent calls must be safe and
+/// cryptographically independent. Implementations must not cache userspace
+/// generator state that could be reused after a process fork or VM snapshot.
+pub trait RandomProvider: Send + Sync {
+    /// Fills `output` completely with cryptographically secure random bytes.
+    fn fill(&self, output: &mut [u8]) -> core::result::Result<(), RandomProviderError>;
+}
+
+#[cfg(test)]
+pub(crate) struct TestRandomProvider;
+
+#[cfg(test)]
+impl RandomProvider for TestRandomProvider {
+    fn fill(&self, output: &mut [u8]) -> core::result::Result<(), RandomProviderError> {
+        output.fill(0x5a);
+        Ok(())
+    }
+}
+
+/// Fills `output` from the random provider configured for this broker.
+pub fn fill(session: &BrokerSession, output: &mut [u8]) -> Result<()> {
+    if output.len() > MAX_RANDOM_TRANSFER_SIZE as usize {
+        return Err(BrokerError::ResourceExhausted);
+    }
+    if output.is_empty() {
+        return Ok(());
+    }
+    session
+        .core
+        .random_provider
+        .fill(output)
+        .map_err(|_| BrokerError::Internal)
+}

--- a/litebox_broker_core/src/session.rs
+++ b/litebox_broker_core/src/session.rs
@@ -544,6 +544,7 @@ mod tests {
                 .with_socket_policy(SocketPolicy::guest_network()),
             BrokerCoreLimits::new_with_all_limits(2, 4, 2, 1),
             socket_provider.clone(),
+            Arc::new(crate::random::TestRandomProvider),
         )
         .unwrap();
 

--- a/litebox_broker_core/src/socket/tests.rs
+++ b/litebox_broker_core/src/socket/tests.rs
@@ -1327,6 +1327,7 @@ fn test_broker_with_policy(
         pending_references: Arc::new(AtomicUsize::new(0)),
         reserved_pipe_capacity: Arc::new(AtomicUsize::new(0)),
         reserved_sockets: Arc::new(AtomicUsize::new(0)),
+        random_provider: Arc::new(crate::random::TestRandomProvider),
         socket_provider,
         socket_ports: BrokerSocketPorts::default(),
     }

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -34,7 +34,7 @@ use litebox_broker_protocol::message::{
 use litebox_broker_protocol::pipe::{
     CreatePipeResponse, MAX_PIPE_TRANSFER_SIZE, ReadPipeResponse, WritePipeResponse,
 };
-use litebox_broker_protocol::random::{FillRandomRequest, MAX_RANDOM_TRANSFER_SIZE};
+use litebox_broker_protocol::random::MAX_RANDOM_TRANSFER_SIZE;
 use litebox_broker_protocol::shared_buffer::{
     SHARED_BUFFER_LAYOUT, SHARED_BUFFER_SLOT_COUNT, SharedBufferDescriptor, SharedBufferSlotIndex,
 };
@@ -91,7 +91,7 @@ impl<Memory: SharedMemory> BrokerHostAssociation<'_, Memory> {
             operation,
         } = request;
         let buffer_descriptor = match &operation {
-            BrokerOperation::FillRandom(request) => Some(request.buffer),
+            BrokerOperation::FillRandom(buffer) => Some(*buffer),
             BrokerOperation::Pipe(PipeRequest::Read(request)) => Some(request.buffer),
             BrokerOperation::Pipe(PipeRequest::Write(request)) => Some(request.buffer),
             BrokerOperation::Socket(SocketRequest::Send(request)) => Some(request.buffer),
@@ -356,28 +356,20 @@ fn handle_request<Memory: SharedMemory>(
             handle_socket_request(session, request, shared_buffers, readiness_sink)
                 .map(BrokerResult::Socket)
         }
-        BrokerOperation::FillRandom(request) => {
-            handle_fill_random_request(session, request, shared_buffers)
+        BrokerOperation::FillRandom(buffer) => {
+            if buffer.length > MAX_RANDOM_TRANSFER_SIZE {
+                return Err(RequestFailure::Abort(ErrorCode::MalformedRequest));
+            }
+            let length = buffer.length as usize;
+            let mut data = [0u8; MAX_RANDOM_TRANSFER_SIZE as usize];
+            let data = &mut data[..length];
+            litebox_broker_core::random::fill(session, data).map_err(RequestFailure::from)?;
+            shared_buffers
+                .write(buffer.slot_index, data)
+                .map_err(|_| RequestFailure::Abort(ErrorCode::Internal))?;
+            Ok(BrokerResult::RandomFilled)
         }
     }
-}
-
-fn handle_fill_random_request<Memory: SharedMemory>(
-    session: &BrokerSession,
-    request: FillRandomRequest,
-    shared_buffers: &SharedBufferPool<Memory>,
-) -> RequestResult<BrokerResult> {
-    if request.buffer.length > MAX_RANDOM_TRANSFER_SIZE {
-        return Err(RequestFailure::Abort(ErrorCode::MalformedRequest));
-    }
-    let length = request.buffer.length as usize;
-    let mut data = [0u8; MAX_RANDOM_TRANSFER_SIZE as usize];
-    let data = &mut data[..length];
-    litebox_broker_core::random::fill(session, data).map_err(RequestFailure::from)?;
-    shared_buffers
-        .write(request.buffer.slot_index, data)
-        .map_err(|_| RequestFailure::Abort(ErrorCode::Internal))?;
-    Ok(BrokerResult::RandomFilled)
 }
 
 fn handle_socket_request<Memory: SharedMemory>(
@@ -730,7 +722,7 @@ mod tests {
     };
     use litebox_broker_protocol::message::BrokerHandshakeRequest;
     use litebox_broker_protocol::pipe::{CreatePipeRequest, ReadPipeRequest, WritePipeRequest};
-    use litebox_broker_protocol::random::{FillRandomRequest, MAX_RANDOM_TRANSFER_SIZE};
+    use litebox_broker_protocol::random::MAX_RANDOM_TRANSFER_SIZE;
     use litebox_broker_protocol::shared_buffer::{
         SHARED_BUFFER_LAYOUT, SHARED_BUFFER_POOL_SIZE, SHARED_BUFFER_SLOT_SIZE,
         SharedBufferDescriptor,
@@ -745,11 +737,7 @@ mod tests {
     };
     use litebox_broker_protocol::{ObjectHandle, ProtocolVersion, RequestId};
     use litebox_broker_transport::shared_memory::{SharedBufferPool, SharedMemoryError};
-    use std::sync::{
-        Arc, Condvar, Mutex,
-        atomic::{AtomicBool, Ordering},
-        mpsc,
-    };
+    use std::sync::{Arc, Condvar, Mutex, mpsc};
     use std::time::Duration;
 
     struct TestReadinessSink;
@@ -803,14 +791,11 @@ mod tests {
         fn close_session(&self, _session_id: SessionId) {}
     }
 
-    #[derive(Default)]
-    struct TestRandomProvider {
-        fail: AtomicBool,
-    }
+    struct TestRandomProvider;
 
     impl RandomProvider for TestRandomProvider {
         fn fill(&self, output: &mut [u8]) -> core::result::Result<(), RandomProviderError> {
-            if self.fail.load(Ordering::SeqCst) {
+            if output.len() == 2 {
                 output.fill(0xcc);
                 return Err(RandomProviderError);
             }
@@ -968,12 +953,11 @@ mod tests {
 
     #[test]
     fn host_request_handling_uses_one_broker_core() {
-        let random_provider = Arc::new(TestRandomProvider::default());
         let broker = BrokerCore::new(
             PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
                 .with_socket_policy(SocketPolicy::guest_network()),
             Arc::new(TestSocketProvider),
-            random_provider.clone(),
+            Arc::new(TestRandomProvider),
         )
         .unwrap();
 
@@ -991,17 +975,14 @@ mod tests {
         active_request_closes_object_reference(&broker);
         association_shared_buffer_descriptors_stage_pipe_data(&broker);
         association_shared_buffer_descriptors_stage_socket_data(&broker);
-        association_shared_buffer_descriptor_stages_random_data(&broker, &random_provider);
+        association_shared_buffer_descriptor_stages_random_data(&broker);
         shared_buffer_usage_rejects_invalid_descriptors();
         association_executes_distinct_slots_concurrently(&broker);
         association_allows_slot_reuse_during_response_emission(&broker);
         association_allows_out_of_order_responses(&broker);
     }
 
-    fn association_shared_buffer_descriptor_stages_random_data(
-        broker: &BrokerCore,
-        random_provider: &TestRandomProvider,
-    ) {
+    fn association_shared_buffer_descriptor_stages_random_data(broker: &BrokerCore) {
         let session = broker
             .create_session(CallerCredential::Unauthenticated)
             .unwrap();
@@ -1013,9 +994,7 @@ mod tests {
         assert_eq!(
             handle_test_request_with_buffers(
                 &session,
-                BrokerOperation::FillRandom(FillRandomRequest {
-                    buffer: descriptor(3, 3),
-                }),
+                BrokerOperation::FillRandom(descriptor(3, 3)),
                 &shared_buffers,
             ),
             BrokerResult::RandomFilled
@@ -1029,9 +1008,7 @@ mod tests {
         assert_eq!(
             handle_request(
                 &session,
-                BrokerOperation::FillRandom(FillRandomRequest {
-                    buffer: descriptor(3, MAX_RANDOM_TRANSFER_SIZE + 1),
-                }),
+                BrokerOperation::FillRandom(descriptor(3, MAX_RANDOM_TRANSFER_SIZE + 1)),
                 &shared_buffers,
                 &test_readiness_sink(),
             ),
@@ -1039,25 +1016,22 @@ mod tests {
         );
 
         shared_buffers
-            .write(SharedBufferSlotIndex(3), &[0xa5; 3])
+            .write(SharedBufferSlotIndex(3), &[0xa5; 2])
             .unwrap();
-        random_provider.fail.store(true, Ordering::SeqCst);
         assert_eq!(
             handle_request(
                 &session,
-                BrokerOperation::FillRandom(FillRandomRequest {
-                    buffer: descriptor(3, 3),
-                }),
+                BrokerOperation::FillRandom(descriptor(3, 2)),
                 &shared_buffers,
                 &test_readiness_sink(),
             ),
             Err(RequestFailure::Abort(ErrorCode::Internal))
         );
-        let mut output = [0u8; 3];
+        let mut output = [0u8; 2];
         shared_buffers
             .read(SharedBufferSlotIndex(3), &mut output)
             .unwrap();
-        assert_eq!(output, [0xa5; 3]);
+        assert_eq!(output, [0xa5; 2]);
     }
 
     fn test_channel_negotiates_routes_one_request_and_returns_peer_closed(broker: &BrokerCore) {

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -34,6 +34,7 @@ use litebox_broker_protocol::message::{
 use litebox_broker_protocol::pipe::{
     CreatePipeResponse, MAX_PIPE_TRANSFER_SIZE, ReadPipeResponse, WritePipeResponse,
 };
+use litebox_broker_protocol::random::{FillRandomRequest, MAX_RANDOM_TRANSFER_SIZE};
 use litebox_broker_protocol::shared_buffer::{
     SHARED_BUFFER_LAYOUT, SHARED_BUFFER_SLOT_COUNT, SharedBufferDescriptor, SharedBufferSlotIndex,
 };
@@ -90,6 +91,7 @@ impl<Memory: SharedMemory> BrokerHostAssociation<'_, Memory> {
             operation,
         } = request;
         let buffer_descriptor = match &operation {
+            BrokerOperation::FillRandom(request) => Some(request.buffer),
             BrokerOperation::Pipe(PipeRequest::Read(request)) => Some(request.buffer),
             BrokerOperation::Pipe(PipeRequest::Write(request)) => Some(request.buffer),
             BrokerOperation::Socket(SocketRequest::Send(request)) => Some(request.buffer),
@@ -354,7 +356,28 @@ fn handle_request<Memory: SharedMemory>(
             handle_socket_request(session, request, shared_buffers, readiness_sink)
                 .map(BrokerResult::Socket)
         }
+        BrokerOperation::FillRandom(request) => {
+            handle_fill_random_request(session, request, shared_buffers)
+        }
     }
+}
+
+fn handle_fill_random_request<Memory: SharedMemory>(
+    session: &BrokerSession,
+    request: FillRandomRequest,
+    shared_buffers: &SharedBufferPool<Memory>,
+) -> RequestResult<BrokerResult> {
+    if request.buffer.length > MAX_RANDOM_TRANSFER_SIZE {
+        return Err(RequestFailure::Abort(ErrorCode::MalformedRequest));
+    }
+    let length = request.buffer.length as usize;
+    let mut data = [0u8; MAX_RANDOM_TRANSFER_SIZE as usize];
+    let data = &mut data[..length];
+    litebox_broker_core::random::fill(session, data).map_err(RequestFailure::from)?;
+    shared_buffers
+        .write(request.buffer.slot_index, data)
+        .map_err(|_| RequestFailure::Abort(ErrorCode::Internal))?;
+    Ok(BrokerResult::RandomFilled)
 }
 
 fn handle_socket_request<Memory: SharedMemory>(
@@ -695,6 +718,7 @@ mod tests {
     use super::*;
     use core::cell::Cell;
     use core::net::{Ipv4Addr, SocketAddrV4};
+    use litebox_broker_core::random::{RandomProvider, RandomProviderError};
     use litebox_broker_core::readiness::ReadinessRegistration;
     use litebox_broker_core::socket::{
         AcceptedPlatformSocket, PlatformConnectError, PlatformDatagramReceive, PlatformSocket,
@@ -706,6 +730,7 @@ mod tests {
     };
     use litebox_broker_protocol::message::BrokerHandshakeRequest;
     use litebox_broker_protocol::pipe::{CreatePipeRequest, ReadPipeRequest, WritePipeRequest};
+    use litebox_broker_protocol::random::{FillRandomRequest, MAX_RANDOM_TRANSFER_SIZE};
     use litebox_broker_protocol::shared_buffer::{
         SHARED_BUFFER_LAYOUT, SHARED_BUFFER_POOL_SIZE, SHARED_BUFFER_SLOT_SIZE,
         SharedBufferDescriptor,
@@ -720,7 +745,11 @@ mod tests {
     };
     use litebox_broker_protocol::{ObjectHandle, ProtocolVersion, RequestId};
     use litebox_broker_transport::shared_memory::{SharedBufferPool, SharedMemoryError};
-    use std::sync::{Arc, Condvar, Mutex, mpsc};
+    use std::sync::{
+        Arc, Condvar, Mutex,
+        atomic::{AtomicBool, Ordering},
+        mpsc,
+    };
     use std::time::Duration;
 
     struct TestReadinessSink;
@@ -772,6 +801,22 @@ mod tests {
         }
 
         fn close_session(&self, _session_id: SessionId) {}
+    }
+
+    #[derive(Default)]
+    struct TestRandomProvider {
+        fail: AtomicBool,
+    }
+
+    impl RandomProvider for TestRandomProvider {
+        fn fill(&self, output: &mut [u8]) -> core::result::Result<(), RandomProviderError> {
+            if self.fail.load(Ordering::SeqCst) {
+                output.fill(0xcc);
+                return Err(RandomProviderError);
+            }
+            output.fill(0x5a);
+            Ok(())
+        }
     }
 
     struct TestPlatformSocket {
@@ -923,10 +968,12 @@ mod tests {
 
     #[test]
     fn host_request_handling_uses_one_broker_core() {
+        let random_provider = Arc::new(TestRandomProvider::default());
         let broker = BrokerCore::new(
             PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
                 .with_socket_policy(SocketPolicy::guest_network()),
             Arc::new(TestSocketProvider),
+            random_provider.clone(),
         )
         .unwrap();
 
@@ -944,10 +991,73 @@ mod tests {
         active_request_closes_object_reference(&broker);
         association_shared_buffer_descriptors_stage_pipe_data(&broker);
         association_shared_buffer_descriptors_stage_socket_data(&broker);
+        association_shared_buffer_descriptor_stages_random_data(&broker, &random_provider);
         shared_buffer_usage_rejects_invalid_descriptors();
         association_executes_distinct_slots_concurrently(&broker);
         association_allows_slot_reuse_during_response_emission(&broker);
         association_allows_out_of_order_responses(&broker);
+    }
+
+    fn association_shared_buffer_descriptor_stages_random_data(
+        broker: &BrokerCore,
+        random_provider: &TestRandomProvider,
+    ) {
+        let session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let shared_buffers = test_shared_buffers();
+        shared_buffers
+            .write(SharedBufferSlotIndex(3), &[0xa5; 4])
+            .unwrap();
+
+        assert_eq!(
+            handle_test_request_with_buffers(
+                &session,
+                BrokerOperation::FillRandom(FillRandomRequest {
+                    buffer: descriptor(3, 3),
+                }),
+                &shared_buffers,
+            ),
+            BrokerResult::RandomFilled
+        );
+        let mut output = [0u8; 4];
+        shared_buffers
+            .read(SharedBufferSlotIndex(3), &mut output)
+            .unwrap();
+        assert_eq!(output, [0x5a, 0x5a, 0x5a, 0xa5]);
+
+        assert_eq!(
+            handle_request(
+                &session,
+                BrokerOperation::FillRandom(FillRandomRequest {
+                    buffer: descriptor(3, MAX_RANDOM_TRANSFER_SIZE + 1),
+                }),
+                &shared_buffers,
+                &test_readiness_sink(),
+            ),
+            Err(RequestFailure::Abort(ErrorCode::MalformedRequest))
+        );
+
+        shared_buffers
+            .write(SharedBufferSlotIndex(3), &[0xa5; 3])
+            .unwrap();
+        random_provider.fail.store(true, Ordering::SeqCst);
+        assert_eq!(
+            handle_request(
+                &session,
+                BrokerOperation::FillRandom(FillRandomRequest {
+                    buffer: descriptor(3, 3),
+                }),
+                &shared_buffers,
+                &test_readiness_sink(),
+            ),
+            Err(RequestFailure::Abort(ErrorCode::Internal))
+        );
+        let mut output = [0u8; 3];
+        shared_buffers
+            .read(SharedBufferSlotIndex(3), &mut output)
+            .unwrap();
+        assert_eq!(output, [0xa5; 3]);
     }
 
     fn test_channel_negotiates_routes_one_request_and_returns_peer_closed(broker: &BrokerCore) {

--- a/litebox_broker_local/src/event.rs
+++ b/litebox_broker_local/src/event.rs
@@ -74,11 +74,7 @@ impl<Channel: LocalCallChannel> BrokerLocal<Channel> {
         match self.request(BrokerOperation::Event(request))? {
             BrokerResult::Event(response) => Ok(response),
             BrokerResult::Error(error) => Err(BrokerLocalError::Broker(error)),
-            response @ (BrokerResult::ObjectClosed
-            | BrokerResult::Readiness(_)
-            | BrokerResult::Pipe(_)
-            | BrokerResult::Socket(_)
-            | BrokerResult::RandomFilled) => {
+            response => {
                 panic!("broker returned unexpected event response: {response:?}");
             }
         }

--- a/litebox_broker_local/src/event.rs
+++ b/litebox_broker_local/src/event.rs
@@ -77,7 +77,8 @@ impl<Channel: LocalCallChannel> BrokerLocal<Channel> {
             response @ (BrokerResult::ObjectClosed
             | BrokerResult::Readiness(_)
             | BrokerResult::Pipe(_)
-            | BrokerResult::Socket(_)) => {
+            | BrokerResult::Socket(_)
+            | BrokerResult::RandomFilled) => {
                 panic!("broker returned unexpected event response: {response:?}");
             }
         }

--- a/litebox_broker_local/src/lib.rs
+++ b/litebox_broker_local/src/lib.rs
@@ -180,12 +180,7 @@ impl<Channel: LocalCallChannel> BrokerLocal<Channel> {
                 | ErrorCode::Internal => panic!("broker returned unrecoverable error: {error}"),
                 _ => panic!("broker returned unsupported error: {error}"),
             },
-            result @ (BrokerResult::Event(_)
-            | BrokerResult::Pipe(_)
-            | BrokerResult::Socket(_)
-            | BrokerResult::ObjectClosed
-            | BrokerResult::Readiness(_)
-            | BrokerResult::RandomFilled) => Ok(result),
+            result => Ok(result),
         }
     }
 
@@ -213,11 +208,7 @@ impl<Channel: LocalCallChannel> BrokerLocal<Channel> {
         match self.request(BrokerOperation::CloseObject(handle))? {
             BrokerResult::ObjectClosed => Ok(()),
             BrokerResult::Error(error) => Err(BrokerLocalError::Broker(error)),
-            response @ (BrokerResult::Event(_)
-            | BrokerResult::Pipe(_)
-            | BrokerResult::Socket(_)
-            | BrokerResult::Readiness(_)
-            | BrokerResult::RandomFilled) => {
+            response => {
                 panic!("broker returned unexpected close response: {response:?}");
             }
         }

--- a/litebox_broker_local/src/lib.rs
+++ b/litebox_broker_local/src/lib.rs
@@ -23,6 +23,7 @@ extern crate std;
 mod error;
 mod event;
 mod pipe;
+mod random;
 mod socket;
 
 use alloc::sync::Arc;
@@ -183,7 +184,8 @@ impl<Channel: LocalCallChannel> BrokerLocal<Channel> {
             | BrokerResult::Pipe(_)
             | BrokerResult::Socket(_)
             | BrokerResult::ObjectClosed
-            | BrokerResult::Readiness(_)) => Ok(result),
+            | BrokerResult::Readiness(_)
+            | BrokerResult::RandomFilled) => Ok(result),
         }
     }
 
@@ -214,7 +216,8 @@ impl<Channel: LocalCallChannel> BrokerLocal<Channel> {
             response @ (BrokerResult::Event(_)
             | BrokerResult::Pipe(_)
             | BrokerResult::Socket(_)
-            | BrokerResult::Readiness(_)) => {
+            | BrokerResult::Readiness(_)
+            | BrokerResult::RandomFilled) => {
                 panic!("broker returned unexpected close response: {response:?}");
             }
         }

--- a/litebox_broker_local/src/pipe.rs
+++ b/litebox_broker_local/src/pipe.rs
@@ -130,7 +130,8 @@ impl<Channel: LocalCallChannel> BrokerLocal<Channel> {
             response @ (BrokerResult::ObjectClosed
             | BrokerResult::Readiness(_)
             | BrokerResult::Event(_)
-            | BrokerResult::Socket(_)) => {
+            | BrokerResult::Socket(_)
+            | BrokerResult::RandomFilled) => {
                 panic!("broker returned unexpected pipe response: {response:?}");
             }
         }

--- a/litebox_broker_local/src/pipe.rs
+++ b/litebox_broker_local/src/pipe.rs
@@ -127,11 +127,7 @@ impl<Channel: LocalCallChannel> BrokerLocal<Channel> {
         match self.request(BrokerOperation::Pipe(request))? {
             BrokerResult::Pipe(response) => Ok(response),
             BrokerResult::Error(error) => Err(BrokerLocalError::Broker(error)),
-            response @ (BrokerResult::ObjectClosed
-            | BrokerResult::Readiness(_)
-            | BrokerResult::Event(_)
-            | BrokerResult::Socket(_)
-            | BrokerResult::RandomFilled) => {
+            response => {
                 panic!("broker returned unexpected pipe response: {response:?}");
             }
         }

--- a/litebox_broker_local/src/random.rs
+++ b/litebox_broker_local/src/random.rs
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+use litebox_broker_protocol::message::{BrokerOperation, BrokerResult};
+use litebox_broker_protocol::random::{FillRandomRequest, MAX_RANDOM_TRANSFER_SIZE};
+use litebox_broker_protocol::shared_buffer::SharedBufferDescriptor;
+use litebox_broker_transport::channel::LocalCallChannel;
+
+use crate::{BrokerLocal, BrokerLocalError, Result};
+
+impl<Channel: LocalCallChannel> BrokerLocal<Channel> {
+    /// Fills `output` from a broker-provided random source.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `output` does not match the shared-buffer descriptor or the
+    /// broker returns a response for a different operation.
+    pub fn fill_random(
+        &self,
+        buffer: SharedBufferDescriptor,
+        output: &mut [u8],
+    ) -> Result<(), Channel::Error> {
+        assert!(
+            buffer.length <= MAX_RANDOM_TRANSFER_SIZE,
+            "shared random descriptor exceeds the transfer limit"
+        );
+        assert_eq!(
+            output.len(),
+            buffer.length as usize,
+            "random destination length must match its shared-buffer descriptor"
+        );
+        self.shared_buffers
+            .layout()
+            .range(buffer.slot_index, output.len())
+            .expect("shared random descriptor must identify a valid slot range");
+        match self.request(BrokerOperation::FillRandom(FillRandomRequest { buffer }))? {
+            BrokerResult::RandomFilled => {
+                self.shared_buffers
+                    .read(buffer.slot_index, output)
+                    .expect("validated random shared-buffer read must fit its slot");
+                Ok(())
+            }
+            BrokerResult::Error(error) => Err(BrokerLocalError::Broker(error)),
+            response => panic!("broker returned unexpected random response: {response:?}"),
+        }
+    }
+}

--- a/litebox_broker_local/src/random.rs
+++ b/litebox_broker_local/src/random.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 use litebox_broker_protocol::message::{BrokerOperation, BrokerResult};
-use litebox_broker_protocol::random::{FillRandomRequest, MAX_RANDOM_TRANSFER_SIZE};
+use litebox_broker_protocol::random::MAX_RANDOM_TRANSFER_SIZE;
 use litebox_broker_protocol::shared_buffer::SharedBufferDescriptor;
 use litebox_broker_transport::channel::LocalCallChannel;
 
@@ -33,7 +33,7 @@ impl<Channel: LocalCallChannel> BrokerLocal<Channel> {
             .layout()
             .range(buffer.slot_index, output.len())
             .expect("shared random descriptor must identify a valid slot range");
-        match self.request(BrokerOperation::FillRandom(FillRandomRequest { buffer }))? {
+        match self.request(BrokerOperation::FillRandom(buffer))? {
             BrokerResult::RandomFilled => {
                 self.shared_buffers
                     .read(buffer.slot_index, output)

--- a/litebox_broker_local/src/socket.rs
+++ b/litebox_broker_local/src/socket.rs
@@ -663,11 +663,7 @@ impl<Channel: LocalCallChannel> BrokerLocal<Channel> {
         match self.request(BrokerOperation::Socket(request))? {
             BrokerResult::Socket(response) => Ok(response),
             BrokerResult::Error(error) => Err(BrokerLocalError::Broker(error)),
-            response @ (BrokerResult::ObjectClosed
-            | BrokerResult::Readiness(_)
-            | BrokerResult::Event(_)
-            | BrokerResult::Pipe(_)
-            | BrokerResult::RandomFilled) => {
+            response => {
                 panic!("broker returned unexpected socket response: {response:?}");
             }
         }

--- a/litebox_broker_local/src/socket.rs
+++ b/litebox_broker_local/src/socket.rs
@@ -666,7 +666,8 @@ impl<Channel: LocalCallChannel> BrokerLocal<Channel> {
             response @ (BrokerResult::ObjectClosed
             | BrokerResult::Readiness(_)
             | BrokerResult::Event(_)
-            | BrokerResult::Pipe(_)) => {
+            | BrokerResult::Pipe(_)
+            | BrokerResult::RandomFilled) => {
                 panic!("broker returned unexpected socket response: {response:?}");
             }
         }

--- a/litebox_broker_platform_linux_userland/src/socket/tests/mod.rs
+++ b/litebox_broker_platform_linux_userland/src/socket/tests/mod.rs
@@ -8,6 +8,7 @@ use std::sync::mpsc::{Receiver, Sender, channel};
 use std::time::{Duration, Instant};
 
 use super::*;
+use litebox_broker_core::random::{RandomProvider, RandomProviderError};
 use litebox_broker_core::readiness::ReadinessSink;
 use litebox_broker_core::socket::{GUEST_IPV4_ADDRESS, HOST_GATEWAY_IPV4_ADDRESS};
 use litebox_broker_core::{
@@ -27,6 +28,28 @@ mod tcp;
 mod udp;
 
 const TEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+struct TestRandomProvider;
+
+impl RandomProvider for TestRandomProvider {
+    fn fill(&self, output: &mut [u8]) -> Result<(), RandomProviderError> {
+        output.fill(0x5a);
+        Ok(())
+    }
+}
+
+fn test_broker_core(
+    policy: PolicyEngine,
+    limits: BrokerCoreLimits,
+    socket_provider: Arc<LinuxSocketProvider>,
+) -> litebox_broker_core::Result<BrokerCore> {
+    BrokerCore::new_with_limits(
+        policy,
+        limits,
+        socket_provider,
+        Arc::new(TestRandomProvider),
+    )
+}
 
 #[test]
 fn tcp_pending_errors_preserve_order_and_source() {
@@ -358,7 +381,7 @@ fn directional_shutdown_survives_readiness_publication_failure() {
     });
 
     let provider = Arc::new(LinuxSocketProvider::new(2, 2).unwrap());
-    let broker = BrokerCore::new_with_limits(
+    let broker = test_broker_core(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
             .with_socket_policy(gateway_tcp_policy()),
         BrokerCoreLimits::new_with_all_limits(4, 0, 2, 2),

--- a/litebox_broker_platform_linux_userland/src/socket/tests/tcp.rs
+++ b/litebox_broker_platform_linux_userland/src/socket/tests/tcp.rs
@@ -16,7 +16,7 @@ struct GuestTcpPair {
 
 fn connected_guest_tcp_pair(port: u16) -> GuestTcpPair {
     let provider = Arc::new(LinuxSocketProvider::new(4, 3).unwrap());
-    let broker = BrokerCore::new_with_limits(
+    let broker = test_broker_core(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
             .with_socket_policy(SocketPolicy::guest_network()),
         BrokerCoreLimits::new_with_all_limits(8, 0, 4, 4),
@@ -146,7 +146,7 @@ fn reactor_drives_a_loopback_tcp_socket() {
     });
 
     let provider = Arc::new(LinuxSocketProvider::new(8, 8).unwrap());
-    let broker = BrokerCore::new_with_limits(
+    let broker = test_broker_core(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
             .with_socket_policy(gateway_tcp_policy()),
         BrokerCoreLimits::new_with_all_limits(16, 0, 8, 8),
@@ -475,7 +475,7 @@ fn external_tcp_deferred_abortive_close_resets_peer() {
     });
 
     let provider = Arc::new(LinuxSocketProvider::new(1, 1).unwrap());
-    let broker = BrokerCore::new_with_limits(
+    let broker = test_broker_core(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
             .with_socket_policy(gateway_tcp_policy()),
         BrokerCoreLimits::new_with_all_limits(2, 0, 1, 1),
@@ -521,7 +521,7 @@ fn external_tcp_gateway_uses_host_loopback_and_keeps_guest_identity() {
         )])
         .unwrap();
     let provider = Arc::new(LinuxSocketProvider::new(2, 2).unwrap());
-    let broker = BrokerCore::new_with_limits(
+    let broker = test_broker_core(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all()).with_socket_policy(policy),
         BrokerCoreLimits::new_with_all_limits(3, 0, 2, 2),
         provider,
@@ -597,7 +597,7 @@ fn external_tcp_route_keeps_guest_private_identity() {
         )])
         .unwrap();
     let provider = Arc::new(LinuxSocketProvider::new(1, 1).unwrap());
-    let broker = BrokerCore::new_with_limits(
+    let broker = test_broker_core(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all()).with_socket_policy(policy),
         BrokerCoreLimits::new_with_all_limits(2, 0, 1, 1),
         provider,
@@ -637,7 +637,7 @@ fn external_tcp_route_keeps_guest_private_identity() {
 #[test]
 fn tcp_connect_to_zero_port_returns_an_ordinary_socket_outcome() {
     let provider = Arc::new(LinuxSocketProvider::new(1, 1).unwrap());
-    let broker = BrokerCore::new_with_limits(
+    let broker = test_broker_core(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
             .with_socket_policy(SocketPolicy::guest_network()),
         BrokerCoreLimits::new_with_all_limits(2, 0, 1, 1),
@@ -675,7 +675,7 @@ fn tcp_receive_survives_readiness_publication_failure() {
     });
 
     let provider = Arc::new(LinuxSocketProvider::new(1, 1).unwrap());
-    let broker = BrokerCore::new_with_limits(
+    let broker = test_broker_core(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
             .with_socket_policy(gateway_tcp_policy()),
         BrokerCoreLimits::new_with_all_limits(2, 0, 1, 1),
@@ -737,7 +737,7 @@ fn tcp_status_publication_failure_preserves_consumed_error() {
     });
 
     let provider = Arc::new(LinuxSocketProvider::new(1, 1).unwrap());
-    let broker = BrokerCore::new_with_limits(
+    let broker = test_broker_core(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
             .with_socket_policy(gateway_tcp_policy()),
         BrokerCoreLimits::new_with_all_limits(2, 0, 1, 1),
@@ -810,7 +810,7 @@ fn external_tcp_readiness_failure_does_not_fail_shared_reactor() {
     });
 
     let provider = Arc::new(LinuxSocketProvider::new(2, 2).unwrap());
-    let broker = BrokerCore::new_with_limits(
+    let broker = test_broker_core(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
             .with_socket_policy(gateway_tcp_policy()),
         BrokerCoreLimits::new_with_all_limits(4, 0, 2, 2),
@@ -934,7 +934,7 @@ fn external_tcp_connect_completion_readiness_failure_does_not_fail_shared_reacto
     });
 
     let provider = Arc::new(LinuxSocketProvider::new(1, 1).unwrap());
-    let broker = BrokerCore::new_with_limits(
+    let broker = test_broker_core(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
             .with_socket_policy(gateway_tcp_policy()),
         BrokerCoreLimits::new_with_all_limits(2, 0, 1, 1),
@@ -1021,7 +1021,7 @@ fn exhausted_tcp_peek_cache_refreshes_before_terminal_eof() {
     });
 
     let provider = Arc::new(LinuxSocketProvider::new(1, 1).unwrap());
-    let broker = BrokerCore::new_with_limits(
+    let broker = test_broker_core(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
             .with_socket_policy(gateway_tcp_policy()),
         BrokerCoreLimits::new_with_all_limits(2, 0, 1, 1),
@@ -1104,7 +1104,7 @@ fn exhausted_tcp_peek_cache_refreshes_before_terminal_eof() {
 #[test]
 fn accepted_guest_tcp_close_with_unread_data_preserves_reset() {
     let provider = Arc::new(LinuxSocketProvider::new(3, 2).unwrap());
-    let broker = BrokerCore::new_with_limits(
+    let broker = test_broker_core(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
             .with_socket_policy(SocketPolicy::guest_network()),
         BrokerCoreLimits::new_with_all_limits(6, 0, 3, 3),
@@ -1462,7 +1462,7 @@ fn guest_read_shutdown_buffer_precedes_reset_and_eof() {
 #[test]
 fn guest_tcp_namespace_routes_across_sessions_and_hides_private_backend() {
     let provider = Arc::new(LinuxSocketProvider::new(5, 3).unwrap());
-    let broker = BrokerCore::new_with_limits(
+    let broker = test_broker_core(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
             .with_socket_policy(SocketPolicy::guest_network()),
         BrokerCoreLimits::new_with_all_limits(8, 0, 5, 4),
@@ -1605,7 +1605,7 @@ fn tcp_exact_bindings_coexist_and_wildcard_accepts_concrete_destinations() {
             DestinationPortRange::new(Port(1), Port(u16::MAX)).unwrap(),
         )])
         .unwrap();
-    let broker = BrokerCore::new_with_limits(
+    let broker = test_broker_core(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all()).with_socket_policy(policy),
         BrokerCoreLimits::new_with_all_limits(20, 0, 12, 12),
         provider,
@@ -1756,7 +1756,7 @@ fn tcp_exact_bindings_coexist_and_wildcard_accepts_concrete_destinations() {
 #[test]
 fn connector_and_session_teardown_clean_bounded_pending_state() {
     let provider = Arc::new(LinuxSocketProvider::new(4, 2).unwrap());
-    let broker = BrokerCore::new_with_limits(
+    let broker = test_broker_core(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
             .with_socket_policy(SocketPolicy::guest_network()),
         BrokerCoreLimits::new_with_all_limits(8, 0, 4, 4),
@@ -1862,7 +1862,7 @@ fn connector_and_session_teardown_clean_bounded_pending_state() {
 #[test]
 fn graceful_connector_close_preserves_late_accept_and_eof() {
     let provider = Arc::new(LinuxSocketProvider::new(4, 2).unwrap());
-    let broker = BrokerCore::new_with_limits(
+    let broker = test_broker_core(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
             .with_socket_policy(SocketPolicy::guest_network()),
         BrokerCoreLimits::new_with_all_limits(8, 0, 4, 4),
@@ -1957,7 +1957,7 @@ fn guest_tcp_zero_backlog_accepts_one_unspecified_destination() {
         )])
         .unwrap();
     let provider = Arc::new(LinuxSocketProvider::new(6, 4).unwrap());
-    let broker = BrokerCore::new_with_limits(
+    let broker = test_broker_core(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all()).with_socket_policy(policy),
         BrokerCoreLimits::new_with_all_limits(10, 0, 6, 6),
         provider,
@@ -2044,7 +2044,7 @@ fn guest_tcp_zero_backlog_accepts_one_unspecified_destination() {
 #[test]
 fn guest_tcp_backlog_relisten_and_fifo_are_bounded() {
     let provider = Arc::new(LinuxSocketProvider::new(10, 8).unwrap());
-    let broker = BrokerCore::new_with_limits(
+    let broker = test_broker_core(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
             .with_socket_policy(SocketPolicy::guest_network()),
         BrokerCoreLimits::new_with_all_limits(16, 0, 10, 10),
@@ -2163,7 +2163,7 @@ fn guest_tcp_backlog_relisten_and_fifo_are_bounded() {
 #[test]
 fn guest_tcp_stream_preserves_options_peek_waitall_and_half_close() {
     let provider = Arc::new(LinuxSocketProvider::new(6, 4).unwrap());
-    let broker = BrokerCore::new_with_limits(
+    let broker = test_broker_core(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
             .with_socket_policy(SocketPolicy::guest_network()),
         BrokerCoreLimits::new_with_all_limits(12, 0, 6, 6),
@@ -2623,7 +2623,7 @@ fn drained_guest_read_shutdown_close_delivers_end_of_stream() {
 #[test]
 fn guest_tcp_connect_publication_failure_purges_committed_queue() {
     let provider = Arc::new(LinuxSocketProvider::new(4, 3).unwrap());
-    let broker = BrokerCore::new_with_limits(
+    let broker = test_broker_core(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
             .with_socket_policy(SocketPolicy::guest_network()),
         BrokerCoreLimits::new_with_all_limits(8, 0, 4, 4),
@@ -2678,7 +2678,7 @@ fn guest_tcp_connect_publication_failure_purges_committed_queue() {
 #[test]
 fn guest_tcp_accept_publication_failure_purges_registered_endpoint() {
     let provider = Arc::new(LinuxSocketProvider::new(4, 3).unwrap());
-    let broker = BrokerCore::new_with_limits(
+    let broker = test_broker_core(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
             .with_socket_policy(SocketPolicy::guest_network()),
         BrokerCoreLimits::new_with_all_limits(8, 0, 4, 4),
@@ -2743,7 +2743,7 @@ fn guest_tcp_accept_publication_failure_purges_registered_endpoint() {
 #[test]
 fn queued_guest_accept_transfers_capacity_without_global_growth() {
     let provider = Arc::new(LinuxSocketProvider::new(5, 3).unwrap());
-    let broker = BrokerCore::new_with_limits(
+    let broker = test_broker_core(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
             .with_socket_policy(SocketPolicy::guest_network()),
         BrokerCoreLimits::new_with_all_limits(10, 0, 5, 5),
@@ -2803,7 +2803,7 @@ fn queued_guest_accept_transfers_capacity_without_global_growth() {
 #[test]
 fn queued_guest_accept_rejects_exhausted_listener_session_capacity() {
     let provider = Arc::new(LinuxSocketProvider::new(6, 3).unwrap());
-    let broker = BrokerCore::new_with_limits(
+    let broker = test_broker_core(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
             .with_socket_policy(SocketPolicy::guest_network()),
         BrokerCoreLimits::new_with_all_limits(10, 0, 6, 6),
@@ -2860,7 +2860,7 @@ fn queued_guest_accept_rejects_exhausted_listener_session_capacity() {
 #[test]
 fn abortive_connector_close_releases_descriptor_capacity() {
     let provider = Arc::new(LinuxSocketProvider::new(3, 2).unwrap());
-    let broker = BrokerCore::new_with_limits(
+    let broker = test_broker_core(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
             .with_socket_policy(SocketPolicy::guest_network()),
         BrokerCoreLimits::new_with_all_limits(8, 0, 3, 3),
@@ -2941,7 +2941,7 @@ fn abortive_connector_close_releases_descriptor_capacity() {
 #[test]
 fn stop_listening_cleanup_survives_readiness_failure() {
     let provider = Arc::new(LinuxSocketProvider::new(3, 2).unwrap());
-    let broker = BrokerCore::new_with_limits(
+    let broker = test_broker_core(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
             .with_socket_policy(SocketPolicy::guest_network()),
         BrokerCoreLimits::new_with_all_limits(8, 0, 3, 3),
@@ -3025,7 +3025,7 @@ fn stop_listening_cleanup_survives_readiness_failure() {
 #[test]
 fn reactor_drives_a_loopback_tcp_listener() {
     let provider = Arc::new(LinuxSocketProvider::new(6, 6).unwrap());
-    let broker = BrokerCore::new_with_limits(
+    let broker = test_broker_core(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
             .with_socket_policy(SocketPolicy::guest_network()),
         BrokerCoreLimits::new_with_all_limits(8, 0, 6, 6),

--- a/litebox_broker_platform_linux_userland/src/socket/tests/udp.rs
+++ b/litebox_broker_platform_linux_userland/src/socket/tests/udp.rs
@@ -40,7 +40,7 @@ fn udp_gateway_translates_sources_filters_spoofing_and_reuses_endpoint() {
             ),
         ])
         .unwrap();
-    let broker = BrokerCore::new_with_limits(
+    let broker = test_broker_core(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
             .with_socket_policy(socket_policy),
         BrokerCoreLimits::new_with_all_limits(2, 0, 1, 1),
@@ -125,7 +125,7 @@ fn udp_gateway_translates_sources_filters_spoofing_and_reuses_endpoint() {
 #[test]
 fn connected_udp_gateway_preserves_guest_visible_mapping() {
     let provider = Arc::new(LinuxSocketProvider::new(1, 1).unwrap());
-    let broker = BrokerCore::new_with_limits(
+    let broker = test_broker_core(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
             .with_socket_policy(gateway_udp_policy()),
         BrokerCoreLimits::new_with_all_limits(2, 0, 1, 1),
@@ -180,7 +180,7 @@ fn connected_udp_gateway_preserves_guest_visible_mapping() {
 #[test]
 fn unmatched_guest_udp_destinations_fail_closed() {
     let provider = Arc::new(LinuxSocketProvider::new(1, 1).unwrap());
-    let broker = BrokerCore::new_with_limits(
+    let broker = test_broker_core(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
             .with_socket_policy(SocketPolicy::guest_network()),
         BrokerCoreLimits::new_with_all_limits(2, 0, 1, 1),
@@ -224,7 +224,7 @@ fn unmatched_guest_udp_destinations_fail_closed() {
 #[test]
 fn failed_initial_udp_readiness_does_not_retain_session_state() {
     let provider = Arc::new(LinuxSocketProvider::new(1, 1).unwrap());
-    let broker = BrokerCore::new_with_limits(
+    let broker = test_broker_core(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
             .with_socket_policy(SocketPolicy::guest_network()),
         BrokerCoreLimits::new_with_all_limits(2, 0, 1, 1),
@@ -260,7 +260,7 @@ fn failed_initial_udp_readiness_does_not_retain_session_state() {
 #[test]
 fn guest_udp_readiness_failure_rolls_back_enqueue() {
     let provider = Arc::new(LinuxSocketProvider::new(2, 1).unwrap());
-    let broker = BrokerCore::new_with_limits(
+    let broker = test_broker_core(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
             .with_socket_policy(SocketPolicy::guest_network()),
         BrokerCoreLimits::new_with_all_limits(4, 0, 2, 1),
@@ -357,7 +357,7 @@ fn guest_udp_readiness_failure_rolls_back_enqueue() {
 #[test]
 fn external_udp_readiness_failure_does_not_fail_shared_reactor() {
     let provider = Arc::new(LinuxSocketProvider::new(2, 2).unwrap());
-    let broker = BrokerCore::new_with_limits(
+    let broker = test_broker_core(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
             .with_socket_policy(gateway_udp_policy()),
         BrokerCoreLimits::new_with_all_limits(4, 0, 2, 2),
@@ -469,7 +469,7 @@ fn external_udp_readiness_failure_does_not_fail_shared_reactor() {
 #[test]
 fn udp_status_publication_failure_still_rearms_native_endpoint() {
     let provider = Arc::new(LinuxSocketProvider::new(1, 1).unwrap());
-    let broker = BrokerCore::new_with_limits(
+    let broker = test_broker_core(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
             .with_socket_policy(gateway_udp_policy()),
         BrokerCoreLimits::new_with_all_limits(2, 0, 1, 1),
@@ -542,7 +542,7 @@ fn udp_status_publication_failure_still_rearms_native_endpoint() {
 #[test]
 fn udp_status_republishes_when_another_error_remains_pending() {
     let provider = Arc::new(LinuxSocketProvider::new(1, 1).unwrap());
-    let broker = BrokerCore::new_with_limits(
+    let broker = test_broker_core(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
             .with_socket_policy(gateway_udp_policy()),
         BrokerCoreLimits::new_with_all_limits(2, 0, 1, 1),
@@ -594,7 +594,7 @@ fn udp_status_republishes_when_another_error_remains_pending() {
 #[test]
 fn guest_udp_queue_pressure_drops_new_datagrams_successfully() {
     let provider = Arc::new(LinuxSocketProvider::new(2, 1).unwrap());
-    let broker = BrokerCore::new_with_limits(
+    let broker = test_broker_core(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
             .with_socket_policy(SocketPolicy::guest_network()),
         BrokerCoreLimits::new_with_all_limits(4, 0, 2, 1),
@@ -685,7 +685,7 @@ fn guest_udp_queue_pressure_drops_new_datagrams_successfully() {
 #[test]
 fn udp_external_peer_authorization_is_bounded_without_eviction() {
     let provider = Arc::new(LinuxSocketProvider::new(1, 1).unwrap());
-    let broker = BrokerCore::new_with_limits(
+    let broker = test_broker_core(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
             .with_socket_policy(gateway_udp_policy()),
         BrokerCoreLimits::new_with_all_limits(2, 0, 1, 1),
@@ -777,7 +777,7 @@ fn reactor_preserves_udp_datagram_semantics() {
             ),
         ])
         .unwrap();
-    let broker = BrokerCore::new_with_limits(
+    let broker = test_broker_core(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
             .with_socket_policy(socket_policy),
         BrokerCoreLimits::new_with_all_limits(4, 0, 2, 2),
@@ -1131,7 +1131,7 @@ fn reactor_preserves_udp_datagram_semantics() {
 #[test]
 fn guest_udp_namespace_routes_across_sessions_and_filters_private_endpoints() {
     let provider = Arc::new(LinuxSocketProvider::new(6, 3).unwrap());
-    let broker = BrokerCore::new_with_limits(
+    let broker = test_broker_core(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
             .with_socket_policy(gateway_udp_policy()),
         BrokerCoreLimits::new_with_all_limits(8, 0, 6, 3),
@@ -1395,7 +1395,7 @@ fn guest_udp_namespace_routes_across_sessions_and_filters_private_endpoints() {
 #[test]
 fn udp_exact_bindings_coexist_and_wildcard_covers_guest_addresses() {
     let provider = Arc::new(LinuxSocketProvider::new(8, 5).unwrap());
-    let broker = BrokerCore::new_with_limits(
+    let broker = test_broker_core(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
             .with_socket_policy(SocketPolicy::guest_network()),
         BrokerCoreLimits::new_with_all_limits(12, 0, 8, 8),
@@ -1583,7 +1583,7 @@ fn udp_exact_bindings_coexist_and_wildcard_covers_guest_addresses() {
 #[test]
 fn udp_native_endpoint_is_reused_and_retired() {
     let provider = Arc::new(LinuxSocketProvider::new(2, 2).unwrap());
-    let broker = BrokerCore::new_with_limits(
+    let broker = test_broker_core(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
             .with_socket_policy(gateway_udp_policy()),
         BrokerCoreLimits::new_with_all_limits(4, 0, 2, 2),
@@ -1648,7 +1648,7 @@ fn udp_native_endpoint_is_reused_and_retired() {
 #[test]
 fn udp_endpoint_staging_error_rolls_back_external_peer_reservation() {
     let provider = Arc::new(LinuxSocketProvider::new(2, 2).unwrap());
-    let broker = BrokerCore::new_with_limits(
+    let broker = test_broker_core(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
             .with_socket_policy(gateway_udp_policy()),
         BrokerCoreLimits::new_with_all_limits(4, 0, 2, 2),
@@ -1686,7 +1686,7 @@ fn udp_endpoint_staging_error_rolls_back_external_peer_reservation() {
 #[test]
 fn stale_udp_datagrams_are_not_relabelled_after_guest_port_reuse() {
     let provider = Arc::new(LinuxSocketProvider::new(5, 3).unwrap());
-    let broker = BrokerCore::new_with_limits(
+    let broker = test_broker_core(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
             .with_socket_policy(SocketPolicy::guest_network()),
         BrokerCoreLimits::new_with_all_limits(8, 0, 5, 3),
@@ -1793,7 +1793,7 @@ fn stale_udp_datagrams_are_not_relabelled_after_guest_port_reuse() {
 #[test]
 fn udp_queued_datagrams_survive_source_session_teardown() {
     let provider = Arc::new(LinuxSocketProvider::new(3, 1).unwrap());
-    let broker = BrokerCore::new_with_limits(
+    let broker = test_broker_core(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
             .with_socket_policy(SocketPolicy::guest_network()),
         BrokerCoreLimits::new_with_all_limits(6, 0, 3, 1),
@@ -1926,7 +1926,7 @@ fn udp_queued_datagrams_survive_source_session_teardown() {
 #[test]
 fn connected_guest_udp_enforces_barriers_peek_and_peer_generations() {
     let provider = Arc::new(LinuxSocketProvider::new(4, 2).unwrap());
-    let broker = BrokerCore::new_with_limits(
+    let broker = test_broker_core(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
             .with_socket_policy(SocketPolicy::guest_network()),
         BrokerCoreLimits::new_with_all_limits(8, 0, 4, 2),
@@ -2058,7 +2058,7 @@ fn connected_guest_udp_enforces_barriers_peek_and_peer_generations() {
 #[test]
 fn connected_guest_udp_filters_other_wildcard_peer_aliases() {
     let provider = Arc::new(LinuxSocketProvider::new(2, 2).unwrap());
-    let broker = BrokerCore::new_with_limits(
+    let broker = test_broker_core(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
             .with_socket_policy(SocketPolicy::guest_network()),
         BrokerCoreLimits::new_with_all_limits(4, 0, 2, 2),
@@ -2137,7 +2137,7 @@ fn connected_guest_udp_filters_other_wildcard_peer_aliases() {
 #[test]
 fn wildcard_udp_reconnect_updates_guest_source_identity() {
     let provider = Arc::new(LinuxSocketProvider::new(3, 3).unwrap());
-    let broker = BrokerCore::new_with_limits(
+    let broker = test_broker_core(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
             .with_socket_policy(SocketPolicy::guest_network()),
         BrokerCoreLimits::new_with_all_limits(6, 0, 3, 3),
@@ -2225,7 +2225,7 @@ fn externally_connected_udp_preserves_guest_routing_identity() {
             ),
         ])
         .unwrap();
-    let broker = BrokerCore::new_with_limits(
+    let broker = test_broker_core(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all()).with_socket_policy(policy),
         BrokerCoreLimits::new_with_all_limits(6, 0, 4, 2),
         provider.clone(),
@@ -2334,7 +2334,7 @@ fn externally_connected_udp_preserves_guest_routing_identity() {
 #[test]
 fn internally_connected_udp_drains_external_datagrams_without_delivering_them() {
     let provider = Arc::new(LinuxSocketProvider::new(4, 2).unwrap());
-    let broker = BrokerCore::new_with_limits(
+    let broker = test_broker_core(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
             .with_socket_policy(gateway_udp_policy()),
         BrokerCoreLimits::new_with_all_limits(8, 0, 4, 2),

--- a/litebox_broker_protocol/src/lib.rs
+++ b/litebox_broker_protocol/src/lib.rs
@@ -20,6 +20,7 @@ pub mod error;
 pub mod event;
 pub mod message;
 pub mod pipe;
+pub mod random;
 pub mod readiness;
 pub mod shared_buffer;
 pub mod socket;

--- a/litebox_broker_protocol/src/message.rs
+++ b/litebox_broker_protocol/src/message.rs
@@ -10,8 +10,8 @@ use crate::pipe::{
     CreatePipeRequest, CreatePipeResponse, ReadPipeRequest, ReadPipeResponse, WritePipeRequest,
     WritePipeResponse,
 };
-use crate::random::FillRandomRequest;
 use crate::readiness::ReadinessFlags;
+use crate::shared_buffer::SharedBufferDescriptor;
 use crate::socket::{
     AcceptSocketRequest, AcceptSocketResponse, BindSocketRequest, BindSocketResponse,
     ConnectSocketRequest, ConnectSocketResponse, CreateSocketRequest, CreateSocketResponse,
@@ -44,7 +44,7 @@ pub enum BrokerOperation {
     /// Socket object request family.
     Socket(SocketRequest),
     /// Fill a shared buffer with cryptographically secure random bytes.
-    FillRandom(FillRandomRequest),
+    FillRandom(SharedBufferDescriptor),
 }
 
 /// Request sent over an active broker control channel.

--- a/litebox_broker_protocol/src/message.rs
+++ b/litebox_broker_protocol/src/message.rs
@@ -10,6 +10,7 @@ use crate::pipe::{
     CreatePipeRequest, CreatePipeResponse, ReadPipeRequest, ReadPipeResponse, WritePipeRequest,
     WritePipeResponse,
 };
+use crate::random::FillRandomRequest;
 use crate::readiness::ReadinessFlags;
 use crate::socket::{
     AcceptSocketRequest, AcceptSocketResponse, BindSocketRequest, BindSocketResponse,
@@ -42,6 +43,8 @@ pub enum BrokerOperation {
     Pipe(PipeRequest),
     /// Socket object request family.
     Socket(SocketRequest),
+    /// Fill a shared buffer with cryptographically secure random bytes.
+    FillRandom(FillRandomRequest),
 }
 
 /// Request sent over an active broker control channel.
@@ -143,6 +146,8 @@ pub enum BrokerResult {
     Pipe(PipeResponse),
     /// Socket object response family.
     Socket(SocketResponse),
+    /// The requested shared buffer was filled with random bytes.
+    RandomFilled,
     /// Operation failed with an ABI-neutral broker error.
     Error(ErrorCode),
 }

--- a/litebox_broker_protocol/src/random.rs
+++ b/litebox_broker_protocol/src/random.rs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//! Broker-provided cryptographic randomness.
+
+use crate::shared_buffer::SharedBufferDescriptor;
+
+/// Maximum number of random bytes transferred by one broker operation.
+pub const MAX_RANDOM_TRANSFER_SIZE: u32 = 256;
+
+/// Fills a shared buffer with cryptographically secure random bytes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct FillRandomRequest {
+    /// Shared output buffer to fill completely.
+    pub buffer: SharedBufferDescriptor,
+}

--- a/litebox_broker_protocol/src/random.rs
+++ b/litebox_broker_protocol/src/random.rs
@@ -3,14 +3,5 @@
 
 //! Broker-provided cryptographic randomness.
 
-use crate::shared_buffer::SharedBufferDescriptor;
-
 /// Maximum number of random bytes transferred by one broker operation.
 pub const MAX_RANDOM_TRANSFER_SIZE: u32 = 256;
-
-/// Fills a shared buffer with cryptographically secure random bytes.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct FillRandomRequest {
-    /// Shared output buffer to fill completely.
-    pub buffer: SharedBufferDescriptor,
-}

--- a/litebox_broker_protocol/src/wire.rs
+++ b/litebox_broker_protocol/src/wire.rs
@@ -40,16 +40,19 @@ const REQUEST_TAG_CHECK_READINESS: u8 = 4;
 const REQUEST_TAG_SOCKET: u8 = 5;
 const REQUEST_TAG_FILL_RANDOM: u8 = 6;
 
+// Paired request and successful-response tags intentionally share values.
 const RESPONSE_TAG_NEGOTIATED: u8 = 0;
 const RESPONSE_TAG_EVENT: u8 = 1;
-const RESPONSE_TAG_HANDSHAKE_ERROR: u8 = 2;
-const RESPONSE_TAG_VERSION_MISMATCH: u8 = 3;
-const RESPONSE_TAG_OBJECT_CLOSED: u8 = 4;
-const RESPONSE_TAG_PIPE: u8 = 5;
-const RESPONSE_TAG_READINESS: u8 = 6;
-const RESPONSE_TAG_ERROR: u8 = 7;
-const RESPONSE_TAG_SOCKET: u8 = 8;
-const RESPONSE_TAG_RANDOM_FILLED: u8 = 9;
+const RESPONSE_TAG_OBJECT_CLOSED: u8 = 2;
+const RESPONSE_TAG_PIPE: u8 = 3;
+const RESPONSE_TAG_READINESS: u8 = 4;
+const RESPONSE_TAG_SOCKET: u8 = 5;
+const RESPONSE_TAG_RANDOM_FILLED: u8 = 6;
+
+// Reserve the top of the tag space for responses without paired requests.
+const RESPONSE_TAG_ERROR: u8 = 253;
+const RESPONSE_TAG_HANDSHAKE_ERROR: u8 = 254;
+const RESPONSE_TAG_VERSION_MISMATCH: u8 = 255;
 
 const NOTIFICATION_TAG_READINESS: u8 = 0;
 
@@ -389,6 +392,38 @@ mod tests {
             local_address: None,
             pending_error: None,
         }
+    }
+
+    #[test]
+    fn successful_response_tags_match_request_tags() {
+        assert_eq!(
+            [
+                RESPONSE_TAG_NEGOTIATED,
+                RESPONSE_TAG_EVENT,
+                RESPONSE_TAG_OBJECT_CLOSED,
+                RESPONSE_TAG_PIPE,
+                RESPONSE_TAG_READINESS,
+                RESPONSE_TAG_SOCKET,
+                RESPONSE_TAG_RANDOM_FILLED,
+            ],
+            [
+                REQUEST_TAG_NEGOTIATE,
+                REQUEST_TAG_EVENT,
+                REQUEST_TAG_CLOSE_OBJECT,
+                REQUEST_TAG_PIPE,
+                REQUEST_TAG_CHECK_READINESS,
+                REQUEST_TAG_SOCKET,
+                REQUEST_TAG_FILL_RANDOM,
+            ]
+        );
+        assert_eq!(
+            [
+                RESPONSE_TAG_ERROR,
+                RESPONSE_TAG_HANDSHAKE_ERROR,
+                RESPONSE_TAG_VERSION_MISMATCH,
+            ],
+            [253, 254, 255]
+        );
     }
 
     #[test]
@@ -1116,7 +1151,7 @@ mod tests {
     #[test]
     fn decode_rejects_malformed_handshake_response_frames() {
         assert_eq!(
-            decode_handshake_response(&[0xff, 1, 2, 3]),
+            decode_handshake_response(&[0xfc, 1, 2, 3]),
             Err(WireError::InvalidTag)
         );
         assert_eq!(
@@ -1124,7 +1159,7 @@ mod tests {
             Err(WireError::TruncatedFrame)
         );
         assert_eq!(
-            decode_handshake_response(&[2, 0xff, 0xff]),
+            decode_handshake_response(&[254, 0xff, 0xff]),
             Err(WireError::InvalidTag)
         );
         assert_eq!(
@@ -1164,7 +1199,7 @@ mod tests {
     #[test]
     fn decode_rejects_malformed_response_frames() {
         assert_eq!(
-            decode_response(&[0xff, 1, 2, 3]),
+            decode_response(&[0xfc, 1, 2, 3]),
             Err(WireError::InvalidTag)
         );
         for response in [
@@ -1308,7 +1343,7 @@ mod tests {
                 request_id: RequestId(13),
                 result: BrokerResult::Socket(SocketResponse::Failed(SocketError::ConnectionReset,)),
             }),
-            [8, 13, 0, 0, 0, 0, 0, 0, 0, 6, 2]
+            [5, 13, 0, 0, 0, 0, 0, 0, 0, 6, 2]
         );
     }
 
@@ -1324,7 +1359,7 @@ mod tests {
                 })),
             }),
             [
-                8, 13, 0, 0, 0, 0, 0, 0, 0, 9, 9, 0, 0, 0, 0, 0, 0, 0, 127, 0, 0, 1, 0, 192, 203,
+                5, 13, 0, 0, 0, 0, 0, 0, 0, 9, 9, 0, 0, 0, 0, 0, 0, 0, 127, 0, 0, 1, 0, 192, 203,
                 0, 113, 7, 187, 1,
             ]
         );

--- a/litebox_broker_protocol/src/wire.rs
+++ b/litebox_broker_protocol/src/wire.rs
@@ -23,7 +23,9 @@ use crate::message::{
     BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerNotification, BrokerOperation,
     BrokerRequest, BrokerResponse, BrokerResult, ReadinessNotification,
 };
+use crate::random::FillRandomRequest;
 use crate::readiness::ReadinessFlags;
+use crate::shared_buffer::{SharedBufferDescriptor, SharedBufferSlotIndex};
 
 use primitive::{Decoder, Encoder};
 
@@ -38,6 +40,7 @@ const REQUEST_TAG_CLOSE_OBJECT: u8 = 2;
 const REQUEST_TAG_PIPE: u8 = 3;
 const REQUEST_TAG_CHECK_READINESS: u8 = 4;
 const REQUEST_TAG_SOCKET: u8 = 5;
+const REQUEST_TAG_FILL_RANDOM: u8 = 6;
 
 const RESPONSE_TAG_NEGOTIATED: u8 = 0;
 const RESPONSE_TAG_EVENT: u8 = 1;
@@ -48,6 +51,7 @@ const RESPONSE_TAG_PIPE: u8 = 5;
 const RESPONSE_TAG_READINESS: u8 = 6;
 const RESPONSE_TAG_ERROR: u8 = 7;
 const RESPONSE_TAG_SOCKET: u8 = 8;
+const RESPONSE_TAG_RANDOM_FILLED: u8 = 9;
 
 const NOTIFICATION_TAG_READINESS: u8 = 0;
 
@@ -96,7 +100,8 @@ pub fn decode_handshake_request(frame: &[u8]) -> Result<BrokerHandshakeRequest, 
         | REQUEST_TAG_CLOSE_OBJECT
         | REQUEST_TAG_PIPE
         | REQUEST_TAG_CHECK_READINESS
-        | REQUEST_TAG_SOCKET => {
+        | REQUEST_TAG_SOCKET
+        | REQUEST_TAG_FILL_RANDOM => {
             return Err(WireError::WrongMessagePhase);
         }
         _ => return Err(WireError::InvalidTag),
@@ -141,6 +146,12 @@ pub fn encode_request(request: BrokerRequest) -> Vec<u8> {
             encoder.request_id(request_id);
             socket::encode_socket_request(&mut encoder, request);
         }
+        BrokerOperation::FillRandom(request) => {
+            encoder.u8(REQUEST_TAG_FILL_RANDOM);
+            encoder.request_id(request_id);
+            encoder.u32(request.buffer.slot_index.0);
+            encoder.u32(request.buffer.length);
+        }
     }
     encoder.finish()
 }
@@ -155,7 +166,8 @@ pub fn decode_request(frame: &[u8]) -> Result<BrokerRequest, WireError> {
         | REQUEST_TAG_CHECK_READINESS
         | REQUEST_TAG_EVENT
         | REQUEST_TAG_PIPE
-        | REQUEST_TAG_SOCKET => {}
+        | REQUEST_TAG_SOCKET
+        | REQUEST_TAG_FILL_RANDOM => {}
         _ => return Err(WireError::InvalidTag),
     }
     let request_id = decoder.request_id()?;
@@ -165,6 +177,12 @@ pub fn decode_request(frame: &[u8]) -> Result<BrokerRequest, WireError> {
         REQUEST_TAG_EVENT => BrokerOperation::Event(event::decode_event_request(&mut decoder)?),
         REQUEST_TAG_PIPE => BrokerOperation::Pipe(pipe::decode_pipe_request(&mut decoder)?),
         REQUEST_TAG_SOCKET => BrokerOperation::Socket(socket::decode_socket_request(&mut decoder)?),
+        REQUEST_TAG_FILL_RANDOM => BrokerOperation::FillRandom(FillRandomRequest {
+            buffer: SharedBufferDescriptor {
+                slot_index: SharedBufferSlotIndex(decoder.u32()?),
+                length: decoder.u32()?,
+            },
+        }),
         _ => unreachable!("active request tag was validated"),
     };
     decoder.finish()?;
@@ -214,7 +232,8 @@ pub fn decode_handshake_response(frame: &[u8]) -> Result<BrokerHandshakeResponse
         | RESPONSE_TAG_PIPE
         | RESPONSE_TAG_READINESS
         | RESPONSE_TAG_ERROR
-        | RESPONSE_TAG_SOCKET => {
+        | RESPONSE_TAG_SOCKET
+        | RESPONSE_TAG_RANDOM_FILLED => {
             return Err(WireError::WrongMessagePhase);
         }
         RESPONSE_TAG_VERSION_MISMATCH => BrokerHandshakeResponse::VersionMismatch {
@@ -262,6 +281,10 @@ pub fn encode_response(response: BrokerResponse) -> Vec<u8> {
             encoder.request_id(request_id);
             socket::encode_socket_response(&mut encoder, response);
         }
+        BrokerResult::RandomFilled => {
+            encoder.u8(RESPONSE_TAG_RANDOM_FILLED);
+            encoder.request_id(request_id);
+        }
         BrokerResult::Error(error) => {
             encoder.u8(RESPONSE_TAG_ERROR);
             encoder.request_id(request_id);
@@ -284,7 +307,8 @@ pub fn decode_response(frame: &[u8]) -> Result<BrokerResponse, WireError> {
         | RESPONSE_TAG_PIPE
         | RESPONSE_TAG_READINESS
         | RESPONSE_TAG_ERROR
-        | RESPONSE_TAG_SOCKET => {}
+        | RESPONSE_TAG_SOCKET
+        | RESPONSE_TAG_RANDOM_FILLED => {}
         _ => return Err(WireError::InvalidTag),
     }
     let request_id = decoder.request_id()?;
@@ -298,6 +322,7 @@ pub fn decode_response(frame: &[u8]) -> Result<BrokerResponse, WireError> {
         }
         RESPONSE_TAG_OBJECT_CLOSED => BrokerResult::ObjectClosed,
         RESPONSE_TAG_READINESS => BrokerResult::Readiness(ReadinessFlags(decoder.u32()?)),
+        RESPONSE_TAG_RANDOM_FILLED => BrokerResult::RandomFilled,
         _ => unreachable!("active response tag was validated"),
     };
     decoder.finish()?;
@@ -349,6 +374,7 @@ mod tests {
         CreatePipeRequest, CreatePipeResponse, ReadPipeRequest, ReadPipeResponse, WritePipeRequest,
         WritePipeResponse,
     };
+    use crate::random::FillRandomRequest;
     use crate::shared_buffer::{SharedBufferDescriptor, SharedBufferSlotIndex};
     use crate::socket::{
         AcceptSocketRequest, AcceptSocketResponse, AddressFamily, BindSocketRequest,
@@ -427,6 +453,12 @@ mod tests {
                     length: 3,
                 },
             })),
+            BrokerOperation::FillRandom(FillRandomRequest {
+                buffer: SharedBufferDescriptor {
+                    slot_index: SharedBufferSlotIndex(7),
+                    length: 256,
+                },
+            }),
             BrokerOperation::Socket(SocketRequest::Create(CreateSocketRequest {
                 address_family: AddressFamily::Ipv4,
                 socket_type: SocketType::Stream,
@@ -760,6 +792,7 @@ mod tests {
                 SocketConnectionStatus::Failed(SocketError::TimedOut),
             ))),
             BrokerResult::Socket(SocketResponse::Failed(SocketError::ConnectionReset)),
+            BrokerResult::RandomFilled,
             BrokerResult::Error(ErrorCode::PolicyDenied),
             BrokerResult::Error(ErrorCode::WouldBlock),
             BrokerResult::Error(ErrorCode::PeerClosed),

--- a/litebox_broker_protocol/src/wire.rs
+++ b/litebox_broker_protocol/src/wire.rs
@@ -23,9 +23,7 @@ use crate::message::{
     BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerNotification, BrokerOperation,
     BrokerRequest, BrokerResponse, BrokerResult, ReadinessNotification,
 };
-use crate::random::FillRandomRequest;
 use crate::readiness::ReadinessFlags;
-use crate::shared_buffer::{SharedBufferDescriptor, SharedBufferSlotIndex};
 
 use primitive::{Decoder, Encoder};
 
@@ -146,11 +144,10 @@ pub fn encode_request(request: BrokerRequest) -> Vec<u8> {
             encoder.request_id(request_id);
             socket::encode_socket_request(&mut encoder, request);
         }
-        BrokerOperation::FillRandom(request) => {
+        BrokerOperation::FillRandom(buffer) => {
             encoder.u8(REQUEST_TAG_FILL_RANDOM);
             encoder.request_id(request_id);
-            encoder.u32(request.buffer.slot_index.0);
-            encoder.u32(request.buffer.length);
+            encoder.shared_buffer_descriptor(buffer);
         }
     }
     encoder.finish()
@@ -177,12 +174,7 @@ pub fn decode_request(frame: &[u8]) -> Result<BrokerRequest, WireError> {
         REQUEST_TAG_EVENT => BrokerOperation::Event(event::decode_event_request(&mut decoder)?),
         REQUEST_TAG_PIPE => BrokerOperation::Pipe(pipe::decode_pipe_request(&mut decoder)?),
         REQUEST_TAG_SOCKET => BrokerOperation::Socket(socket::decode_socket_request(&mut decoder)?),
-        REQUEST_TAG_FILL_RANDOM => BrokerOperation::FillRandom(FillRandomRequest {
-            buffer: SharedBufferDescriptor {
-                slot_index: SharedBufferSlotIndex(decoder.u32()?),
-                length: decoder.u32()?,
-            },
-        }),
+        REQUEST_TAG_FILL_RANDOM => BrokerOperation::FillRandom(decoder.shared_buffer_descriptor()?),
         _ => unreachable!("active request tag was validated"),
     };
     decoder.finish()?;
@@ -374,7 +366,6 @@ mod tests {
         CreatePipeRequest, CreatePipeResponse, ReadPipeRequest, ReadPipeResponse, WritePipeRequest,
         WritePipeResponse,
     };
-    use crate::random::FillRandomRequest;
     use crate::shared_buffer::{SharedBufferDescriptor, SharedBufferSlotIndex};
     use crate::socket::{
         AcceptSocketRequest, AcceptSocketResponse, AddressFamily, BindSocketRequest,
@@ -453,11 +444,9 @@ mod tests {
                     length: 3,
                 },
             })),
-            BrokerOperation::FillRandom(FillRandomRequest {
-                buffer: SharedBufferDescriptor {
-                    slot_index: SharedBufferSlotIndex(7),
-                    length: 256,
-                },
+            BrokerOperation::FillRandom(SharedBufferDescriptor {
+                slot_index: SharedBufferSlotIndex(7),
+                length: 256,
             }),
             BrokerOperation::Socket(SocketRequest::Create(CreateSocketRequest {
                 address_family: AddressFamily::Ipv4,

--- a/litebox_broker_protocol/src/wire/pipe.rs
+++ b/litebox_broker_protocol/src/wire/pipe.rs
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+use super::WireError;
+use super::primitive::{Decoder, Encoder};
 use crate::message::{PipeRequest, PipeResponse};
 use crate::pipe::{
     CreatePipeRequest, CreatePipeResponse, ReadPipeRequest, ReadPipeResponse, WritePipeRequest,
     WritePipeResponse,
 };
-use crate::shared_buffer::{SharedBufferDescriptor, SharedBufferSlotIndex};
-
-use super::WireError;
-use super::primitive::{Decoder, Encoder};
 
 const PIPE_REQUEST_TAG_CREATE: u8 = 0;
 const PIPE_REQUEST_TAG_READ: u8 = 1;
@@ -29,12 +27,12 @@ pub(super) fn encode_pipe_request(encoder: &mut Encoder, request: PipeRequest) {
         PipeRequest::Read(request) => {
             encoder.u8(PIPE_REQUEST_TAG_READ);
             encoder.handle(request.handle);
-            encode_shared_buffer_descriptor(encoder, request.buffer);
+            encoder.shared_buffer_descriptor(request.buffer);
         }
         PipeRequest::Write(request) => {
             encoder.u8(PIPE_REQUEST_TAG_WRITE);
             encoder.handle(request.handle);
-            encode_shared_buffer_descriptor(encoder, request.buffer);
+            encoder.shared_buffer_descriptor(request.buffer);
         }
     }
 }
@@ -47,28 +45,14 @@ pub(super) fn decode_pipe_request(decoder: &mut Decoder<'_>) -> Result<PipeReque
         })),
         PIPE_REQUEST_TAG_READ => Ok(PipeRequest::Read(ReadPipeRequest {
             handle: decoder.handle()?,
-            buffer: decode_shared_buffer_descriptor(decoder)?,
+            buffer: decoder.shared_buffer_descriptor()?,
         })),
         PIPE_REQUEST_TAG_WRITE => Ok(PipeRequest::Write(WritePipeRequest {
             handle: decoder.handle()?,
-            buffer: decode_shared_buffer_descriptor(decoder)?,
+            buffer: decoder.shared_buffer_descriptor()?,
         })),
         _ => Err(WireError::InvalidTag),
     }
-}
-
-fn encode_shared_buffer_descriptor(encoder: &mut Encoder, descriptor: SharedBufferDescriptor) {
-    encoder.u32(descriptor.slot_index.0);
-    encoder.u32(descriptor.length);
-}
-
-fn decode_shared_buffer_descriptor(
-    decoder: &mut Decoder<'_>,
-) -> Result<SharedBufferDescriptor, WireError> {
-    Ok(SharedBufferDescriptor {
-        slot_index: SharedBufferSlotIndex(decoder.u32()?),
-        length: decoder.u32()?,
-    })
 }
 
 pub(super) fn encode_pipe_response(encoder: &mut Encoder, response: PipeResponse) {

--- a/litebox_broker_protocol/src/wire/primitive.rs
+++ b/litebox_broker_protocol/src/wire/primitive.rs
@@ -3,6 +3,7 @@
 
 use alloc::vec::Vec;
 
+use crate::shared_buffer::{SharedBufferDescriptor, SharedBufferSlotIndex};
 use crate::{ObjectHandle, ProtocolVersion, RequestId};
 
 use super::WireError;
@@ -43,6 +44,11 @@ impl Encoder {
 
     pub(super) fn request_id(&mut self, request_id: RequestId) {
         self.u64(request_id.0);
+    }
+
+    pub(super) fn shared_buffer_descriptor(&mut self, descriptor: SharedBufferDescriptor) {
+        self.u32(descriptor.slot_index.0);
+        self.u32(descriptor.length);
     }
 }
 
@@ -96,6 +102,13 @@ impl<'a> Decoder<'a> {
 
     pub(super) fn request_id(&mut self) -> Result<RequestId, WireError> {
         Ok(RequestId(self.u64()?))
+    }
+
+    pub(super) fn shared_buffer_descriptor(&mut self) -> Result<SharedBufferDescriptor, WireError> {
+        Ok(SharedBufferDescriptor {
+            slot_index: SharedBufferSlotIndex(self.u32()?),
+            length: self.u32()?,
+        })
     }
 
     fn take(&mut self, len: usize) -> Result<&'a [u8], WireError> {

--- a/litebox_broker_protocol/src/wire/socket.rs
+++ b/litebox_broker_protocol/src/wire/socket.rs
@@ -4,7 +4,6 @@
 use core::net::{Ipv4Addr, SocketAddrV4};
 
 use crate::message::{SocketRequest, SocketResponse};
-use crate::shared_buffer::{SharedBufferDescriptor, SharedBufferSlotIndex};
 use crate::socket::{
     AcceptSocketRequest, AcceptSocketResponse, AddressFamily, BindSocketRequest,
     BindSocketResponse, ConnectSocketRequest, ConnectSocketResponse, CreateSocketRequest,
@@ -98,20 +97,20 @@ pub(super) fn encode_socket_request(encoder: &mut Encoder, request: SocketReques
         SocketRequest::Send(request) => {
             encoder.u8(SOCKET_TAG_SEND);
             encoder.handle(request.handle);
-            encode_shared_buffer_descriptor(encoder, request.buffer);
+            encoder.shared_buffer_descriptor(request.buffer);
             encoder.u32(request.flags.0);
         }
         SocketRequest::SendTo(request) => {
             encoder.u8(SOCKET_TAG_SEND_TO);
             encoder.handle(request.handle);
-            encode_shared_buffer_descriptor(encoder, request.buffer);
+            encoder.shared_buffer_descriptor(request.buffer);
             encoder.u32(request.flags.0);
             encode_optional_address(encoder, request.destination);
         }
         SocketRequest::Receive(request) => {
             encoder.u8(SOCKET_TAG_RECEIVE);
             encoder.handle(request.handle);
-            encode_shared_buffer_descriptor(encoder, request.buffer);
+            encoder.shared_buffer_descriptor(request.buffer);
             encoder.u32(request.flags.0);
             encoder.u32(request.peek_offset);
             encoder.u32(request.peek_length);
@@ -119,7 +118,7 @@ pub(super) fn encode_socket_request(encoder: &mut Encoder, request: SocketReques
         SocketRequest::ReceiveFrom(request) => {
             encoder.u8(SOCKET_TAG_RECEIVE_FROM);
             encoder.handle(request.handle);
-            encode_shared_buffer_descriptor(encoder, request.buffer);
+            encoder.shared_buffer_descriptor(request.buffer);
             encoder.u32(request.flags.0);
         }
         SocketRequest::Shutdown(request) => {
@@ -185,25 +184,25 @@ pub(super) fn decode_socket_request(decoder: &mut Decoder<'_>) -> Result<SocketR
         })),
         SOCKET_TAG_SEND => Ok(SocketRequest::Send(SendSocketRequest {
             handle: decoder.handle()?,
-            buffer: decode_shared_buffer_descriptor(decoder)?,
+            buffer: decoder.shared_buffer_descriptor()?,
             flags: SendFlags(decoder.u32()?),
         })),
         SOCKET_TAG_SEND_TO => Ok(SocketRequest::SendTo(SendToSocketRequest {
             handle: decoder.handle()?,
-            buffer: decode_shared_buffer_descriptor(decoder)?,
+            buffer: decoder.shared_buffer_descriptor()?,
             flags: SendFlags(decoder.u32()?),
             destination: decode_optional_address(decoder)?,
         })),
         SOCKET_TAG_RECEIVE => Ok(SocketRequest::Receive(ReceiveSocketRequest {
             handle: decoder.handle()?,
-            buffer: decode_shared_buffer_descriptor(decoder)?,
+            buffer: decoder.shared_buffer_descriptor()?,
             flags: ReceiveFlags(decoder.u32()?),
             peek_offset: decoder.u32()?,
             peek_length: decoder.u32()?,
         })),
         SOCKET_TAG_RECEIVE_FROM => Ok(SocketRequest::ReceiveFrom(ReceiveFromSocketRequest {
             handle: decoder.handle()?,
-            buffer: decode_shared_buffer_descriptor(decoder)?,
+            buffer: decoder.shared_buffer_descriptor()?,
             flags: ReceiveFromFlags(decoder.u32()?),
         })),
         SOCKET_TAG_SHUTDOWN => Ok(SocketRequest::Shutdown(ShutdownSocketRequest {
@@ -474,18 +473,4 @@ fn decode_optional_socket_error(
         1 => decode_socket_error(decoder).map(Some),
         _ => Err(WireError::InvalidTag),
     }
-}
-
-fn encode_shared_buffer_descriptor(encoder: &mut Encoder, descriptor: SharedBufferDescriptor) {
-    encoder.u32(descriptor.slot_index.0);
-    encoder.u32(descriptor.length);
-}
-
-fn decode_shared_buffer_descriptor(
-    decoder: &mut Decoder<'_>,
-) -> Result<SharedBufferDescriptor, WireError> {
-    Ok(SharedBufferDescriptor {
-        slot_index: SharedBufferSlotIndex(decoder.u32()?),
-        length: decoder.u32()?,
-    })
 }

--- a/litebox_broker_userland/Cargo.toml
+++ b/litebox_broker_userland/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 clap = { version = "4.5.33", features = ["derive"] }
+getrandom = { version = "0.3.4", default-features = false }
 litebox_broker_core = { path = "../litebox_broker_core", version = "0.1.0" }
 litebox_broker_host = { path = "../litebox_broker_host", version = "0.1.0" }
 litebox_broker_protocol = { path = "../litebox_broker_protocol", version = "0.1.0" }

--- a/litebox_broker_userland/src/linux.rs
+++ b/litebox_broker_userland/src/linux.rs
@@ -79,6 +79,7 @@ pub(super) fn run(mut args: super::CliArgs) -> Result<(), Box<dyn Error>> {
             limits.max_sockets,
             limits.max_sockets_per_session,
         )?),
+        Arc::new(super::UserlandRandomProvider),
     )?;
 
     crate::run_runner_process(

--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -16,6 +16,7 @@ use std::sync::{
 use std::time::{Duration, Instant};
 
 use clap::Parser;
+use litebox_broker_core::random::{RandomProvider, RandomProviderError};
 use litebox_broker_core::{
     BrokerCore, CallerCredential, DestinationPortRange, DestinationRule, Ipv4Cidr, SocketPolicy,
     SocketPolicyError,
@@ -39,6 +40,14 @@ const SETUP_TIMEOUT: Duration = Duration::from_secs(5);
 const ACCEPT_RETRY_DELAY: Duration = Duration::from_millis(10);
 const REQUEST_QUEUE_CAPACITY: usize = 64;
 const WORKER_COUNT: usize = 8;
+
+struct UserlandRandomProvider;
+
+impl RandomProvider for UserlandRandomProvider {
+    fn fill(&self, output: &mut [u8]) -> Result<(), RandomProviderError> {
+        getrandom::fill(output).map_err(|_| RandomProviderError)
+    }
+}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct AllowedDestination {
@@ -769,6 +778,7 @@ mod tests {
             let broker = BrokerCore::new(
                 PolicyEngine::with_host_guaranteed_rights(ObjectRights::all()),
                 Arc::new(UnsupportedSocketProvider),
+                Arc::new(UserlandRandomProvider),
             )
             .unwrap();
             let shared_memory = MemfdSharedMemory::create(SHARED_BUFFER_POOL_SIZE).unwrap();

--- a/litebox_broker_userland/src/windows.rs
+++ b/litebox_broker_userland/src/windows.rs
@@ -56,6 +56,7 @@ pub(super) fn run(args: super::CliArgs) -> Result<(), Box<dyn Error>> {
             configured_socket_policy(&args.allow_tcp_destination, &args.allow_udp_destination)?,
         ),
         Arc::new(UnsupportedSocketProvider),
+        Arc::new(super::UserlandRandomProvider),
     )?;
 
     crate::run_runner_process(&args, &control_pipe, None, |runner, runner_process_id| {

--- a/litebox_broker_userland/tests/notification_runtime.rs
+++ b/litebox_broker_userland/tests/notification_runtime.rs
@@ -3,10 +3,19 @@
 
 use std::os::unix::net::UnixStream;
 use std::sync::Arc;
+
+struct FailingRandomProvider;
+
+impl RandomProvider for FailingRandomProvider {
+    fn fill(&self, _output: &mut [u8]) -> Result<(), RandomProviderError> {
+        Err(RandomProviderError)
+    }
+}
 use std::sync::mpsc::{Receiver, channel};
 use std::thread::JoinHandle;
 use std::time::Duration;
 
+use litebox_broker_core::random::{RandomProvider, RandomProviderError};
 use litebox_broker_core::socket::UnsupportedSocketProvider;
 use litebox_broker_core::{BrokerCore, ObjectRights, PolicyEngine};
 use litebox_broker_host::{ConnectionTermination, setup_connection};
@@ -49,6 +58,7 @@ fn spawn_host(
         let broker = BrokerCore::new(
             PolicyEngine::with_unauthenticated_rights(ObjectRights::all()),
             Arc::new(UnsupportedSocketProvider),
+            Arc::new(FailingRandomProvider),
         )
         .unwrap();
         let shared_memory = MemfdSharedMemory::create(SHARED_BUFFER_POOL_SIZE).unwrap();
@@ -131,6 +141,7 @@ fn host_serves_control_requests_and_notifications_over_shared_rings() {
     let broker = BrokerCore::new(
         PolicyEngine::with_unauthenticated_rights(ObjectRights::all()),
         Arc::new(UnsupportedSocketProvider),
+        Arc::new(FailingRandomProvider),
     )
     .unwrap();
     let (local_control, host_control) = UnixStream::pair().unwrap();

--- a/litebox_runner_linux_userland/Cargo.toml
+++ b/litebox_runner_linux_userland/Cargo.toml
@@ -21,6 +21,7 @@ tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
 litebox_util_log = { version = "0.1.0", path = "../litebox_util_log", features = ["backend_tracing"] }
 
 [dev-dependencies]
+getrandom = { version = "0.3.4", default-features = false }
 sha2 = "0.10"
 walkdir = "2.0"
 glob = "0.3"

--- a/litebox_runner_linux_userland/Cargo.toml
+++ b/litebox_runner_linux_userland/Cargo.toml
@@ -21,7 +21,6 @@ tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
 litebox_util_log = { version = "0.1.0", path = "../litebox_util_log", features = ["backend_tracing"] }
 
 [dev-dependencies]
-getrandom = { version = "0.3.4", default-features = false }
 sha2 = "0.10"
 walkdir = "2.0"
 glob = "0.3"

--- a/litebox_runner_linux_userland/tests/getrandom_broker.c
+++ b/litebox_runner_linux_userland/tests/getrandom_broker.c
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include <string.h>
+#include <sys/random.h>
+
+int main(void) {
+    unsigned char buffer[259];
+    memset(buffer, 0xa5, sizeof(buffer));
+
+    if (getrandom(&buffer[1], 257, 0) != 257) {
+        return 1;
+    }
+    if (buffer[0] != 0xa5 || buffer[258] != 0xa5) {
+        return 2;
+    }
+    return 0;
+}

--- a/litebox_runner_linux_userland/tests/run.rs
+++ b/litebox_runner_linux_userland/tests/run.rs
@@ -21,7 +21,8 @@ impl litebox_broker_core::random::RandomProvider for TestRandomProvider {
         &self,
         output: &mut [u8],
     ) -> Result<(), litebox_broker_core::random::RandomProviderError> {
-        getrandom::fill(output).map_err(|_| litebox_broker_core::random::RandomProviderError)
+        output.fill(0x5a);
+        Ok(())
     }
 }
 // Dedicated fixtures build static binaries concurrently; exclude them to avoid

--- a/litebox_runner_linux_userland/tests/run.rs
+++ b/litebox_runner_linux_userland/tests/run.rs
@@ -1185,6 +1185,8 @@ fn python_runner(unique_name: &str) -> Runner {
             // LiteBox does not support timestamp yet, so pre-compiled .pyc files are not usable.
             // Avoid creating .pyc files as tar filesystem is read-only.
             "PYTHONDONTWRITEBYTECODE=1",
+            // These tests run without a broker and do not exercise Python hash randomization.
+            "PYTHONHASHSEED=0",
         ])
         .with_fs_path(|out_dir| {
             for source_path in &paths_to_stage {

--- a/litebox_runner_linux_userland/tests/run.rs
+++ b/litebox_runner_linux_userland/tests/run.rs
@@ -11,6 +11,19 @@ use std::{
 
 #[cfg(target_arch = "x86_64")]
 const BROKER_HELPER_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+#[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+struct TestRandomProvider;
+
+#[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+impl litebox_broker_core::random::RandomProvider for TestRandomProvider {
+    fn fill(
+        &self,
+        output: &mut [u8],
+    ) -> Result<(), litebox_broker_core::random::RandomProviderError> {
+        getrandom::fill(output).map_err(|_| litebox_broker_core::random::RandomProviderError)
+    }
+}
 // Dedicated fixtures build static binaries concurrently; exclude them to avoid
 // colliding with this sweep's dynamic `<stem>_rewriter` outputs.
 const DEDICATED_C_TESTS: &[&str] = &[
@@ -23,6 +36,7 @@ const DEDICATED_C_TESTS: &[&str] = &[
 
 const BROKER_ONLY_C_TESTS: &[&str] = &[
     "eventfd.c",
+    "getrandom_broker.c",
     "pipe_broker.c",
     "tcp_broker.c",
     "tcp_broker_server.c",
@@ -71,6 +85,8 @@ struct Runner {
     cmd_args: Vec<OsString>,
     #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
     managed_proxy_hosts: Vec<OsString>,
+    #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+    use_userland_broker: bool,
     has_run: bool,
 }
 
@@ -129,6 +145,8 @@ impl Runner {
             cmd_args: Vec::new(),
             #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
             managed_proxy_hosts: Vec::new(),
+            #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+            use_userland_broker: false,
             has_run: false,
             unique_name: unique_name.to_owned(),
         }
@@ -208,7 +226,7 @@ impl Runner {
             .args(&self.cmd_args);
 
         #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
-        if !self.managed_proxy_hosts.is_empty() {
+        if self.use_userland_broker || !self.managed_proxy_hosts.is_empty() {
             let runner = self.command.get_program().to_os_string();
             let runner_arguments = self
                 .command
@@ -219,11 +237,17 @@ impl Runner {
             let broker = Path::new(&runner).with_file_name("litebox-broker-userland");
             let proxy = Path::new(&runner).with_file_name("litebox_egress_proxy");
             assert!(
-                broker.is_file() && proxy.is_file(),
-                "managed proxy tests require a workspace build producing {} and {}",
-                broker.display(),
-                proxy.display()
+                broker.is_file(),
+                "userland broker tests require a workspace build producing {}",
+                broker.display()
             );
+            if !self.managed_proxy_hosts.is_empty() {
+                assert!(
+                    proxy.is_file(),
+                    "managed proxy tests require a workspace build producing {}",
+                    proxy.display()
+                );
+            }
             let mut command = std::process::Command::new(broker);
             for host in &self.managed_proxy_hosts {
                 command.arg("--allow-host").arg(host);
@@ -437,6 +461,7 @@ fn spawn_test_broker_with_mode(
                     )
                     .expect("failed to create broker test socket provider"),
                 ),
+                std::sync::Arc::new(TestRandomProvider),
             )
             .expect("failed to create broker core");
             ready_tx.send(()).expect("failed to report broker ready");
@@ -623,6 +648,20 @@ console.log(content);
     assert!(broker_thread.next_close_object_count() > 0);
 
     broker_thread.join();
+}
+
+#[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+#[test]
+fn brokered_getrandom() {
+    let target = common::compile(
+        "./tests/getrandom_broker.c",
+        "brokered_getrandom",
+        false,
+        false,
+    );
+    let mut runner = Runner::new(&target, "brokered_getrandom");
+    runner.use_userland_broker = true;
+    runner.run();
 }
 
 #[cfg(all(target_arch = "x86_64", target_os = "linux"))]

--- a/litebox_shim_linux/src/syscalls/misc.rs
+++ b/litebox_shim_linux/src/syscalls/misc.rs
@@ -26,7 +26,10 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
         while offset < count {
             let len = (count - offset).min(kbuf.len());
             let kbuf = &mut kbuf[..len];
-            <_ as litebox::platform::CrngProvider>::fill_bytes_crng(self.global.platform, kbuf);
+            self.global
+                .litebox
+                .fill_random(kbuf)
+                .map_err(|_| Errno::EIO)?;
             buf.copy_from_slice::<Platform>(offset, kbuf)
                 .ok_or(Errno::EFAULT)?;
             offset += len;
@@ -166,26 +169,28 @@ impl<Platform: ShimPlatform, FS: ShimFS> Task<Platform, FS> {
 #[cfg(test)]
 mod tests {
     use crate::syscalls::tests::init_platform;
+    use litebox_common_linux::errno::Errno;
     use litebox_common_linux::user_pointers::UserPtrMut;
     use zerocopy::FromZeros as _;
 
     #[test]
-    fn test_getrandom() {
+    fn test_getrandom_requires_broker() {
         use litebox_common_linux::RngFlags;
 
         let task = init_platform();
 
         let mut buf = [0u8; 16];
         let ptr = UserPtrMut::from_ptr(buf.as_mut_ptr());
-        let count = task
-            .sys_getrandom(ptr, buf.len() - 1, RngFlags::empty())
-            .expect("getrandom failed");
-        assert_eq!(count, buf.len() - 1);
-        assert!(
-            !buf.iter().all(|&b| b == 0),
-            "buffer should not be all zeros"
+        assert_eq!(
+            task.sys_getrandom(ptr, 0, RngFlags::empty()),
+            Ok(0),
+            "zero-length getrandom must not require a broker"
         );
-        assert!(buf[buf.len() - 1] == 0, "last byte should stay zero");
+        assert_eq!(
+            task.sys_getrandom(ptr, buf.len() - 1, RngFlags::empty()),
+            Err(Errno::EIO)
+        );
+        assert_eq!(buf, [0; 16]);
     }
 
     #[test]


### PR DESCRIPTION
This PR routes nonempty Linux `getrandom` calls through a mandatory broker using bounded shared-buffer requests, adds a broker-core random provider backed by host OS randomness in the Linux and Windows userland brokers, aligns successful request and response tags while reserving response-only error tags, preserves zero-length and flag behavior, maps broker failures to `EIO`, and adds failure-path and end-to-end coverage.