### PR TITLE
Route /dev/urandom through the broker

### DIFF
--- a/litebox/src/fs/devices.rs
+++ b/litebox/src/fs/devices.rs
@@ -387,19 +387,15 @@ mod tests {
     fn urandom_requires_broker_only_for_nonempty_reads() {
         let litebox = LiteBox::new(MockPlatform::new());
         let devices = Devices::new(&litebox, InodeAllocator::standalone());
-        let urandom = open_urandom(&devices);
+        let urandom = devices
+            .open_file_at(devices.root(), "urandom", OFlags::RDONLY)
+            .unwrap()
+            .item;
 
         assert_eq!(devices.read(&urandom, &mut [], 0).unwrap(), 0);
         assert!(matches!(
             devices.read(&urandom, &mut [0], 0),
             Err(ReadError::Io)
         ));
-    }
-
-    fn open_urandom(devices: &Devices<MockPlatform>) -> FileHandle {
-        devices
-            .open_file_at(devices.root(), "urandom", OFlags::RDONLY)
-            .unwrap()
-            .item
     }
 }

--- a/litebox/src/fs/devices.rs
+++ b/litebox/src/fs/devices.rs
@@ -8,6 +8,7 @@
 use alloc::string::String;
 use alloc::vec;
 use alloc::vec::Vec;
+use litebox_broker_protocol::random::MAX_RANDOM_TRANSFER_SIZE;
 
 use crate::LiteBox;
 use crate::sync::RawSyncPrimitivesProvider;
@@ -113,10 +114,7 @@ impl Device {
 /// A [`super::backend::Backend`] that supports Unix-y devices.
 pub struct Devices<Platform>
 where
-    Platform: RawSyncPrimitivesProvider
-        + crate::platform::StdioProvider
-        + crate::platform::CrngProvider
-        + 'static,
+    Platform: RawSyncPrimitivesProvider + crate::platform::StdioProvider + 'static,
 {
     litebox: LiteBox<Platform>,
     /// Stable inode info for this backend's root directory.
@@ -126,10 +124,7 @@ where
 
 impl<Platform> Devices<Platform>
 where
-    Platform: RawSyncPrimitivesProvider
-        + crate::platform::StdioProvider
-        + crate::platform::CrngProvider
-        + 'static,
+    Platform: RawSyncPrimitivesProvider + crate::platform::StdioProvider + 'static,
 {
     /// Construct a new `Devices` backend.
     #[must_use]
@@ -156,19 +151,13 @@ pub struct DeviceFileHandle {
 pub struct DeviceDirHandle;
 
 impl<Platform> super::backend::private::Sealed for Devices<Platform> where
-    Platform: RawSyncPrimitivesProvider
-        + crate::platform::StdioProvider
-        + crate::platform::CrngProvider
-        + 'static
+    Platform: RawSyncPrimitivesProvider + crate::platform::StdioProvider + 'static
 {
 }
 
 impl<Platform> BackendHandles for Devices<Platform>
 where
-    Platform: RawSyncPrimitivesProvider
-        + crate::platform::StdioProvider
-        + crate::platform::CrngProvider
-        + 'static,
+    Platform: RawSyncPrimitivesProvider + crate::platform::StdioProvider + 'static,
 {
     type WalkingDirHandle<'a> = DeviceDirHandle;
     type FileHandle = DeviceFileHandle;
@@ -177,10 +166,7 @@ where
 
 impl<Platform> Backend for Devices<Platform>
 where
-    Platform: RawSyncPrimitivesProvider
-        + crate::platform::StdioProvider
-        + crate::platform::CrngProvider
-        + 'static,
+    Platform: RawSyncPrimitivesProvider + crate::platform::StdioProvider + 'static,
 {
     fn root(&self) -> WalkingDirHandle<'_> {
         WalkingDirHandle::from_typed::<Self>(DeviceDirHandle)
@@ -293,7 +279,9 @@ where
                 Ok(0)
             }
             Device::URandom => {
-                self.litebox.x.platform.fill_bytes_crng(buf);
+                for chunk in buf.chunks_mut(MAX_RANDOM_TRANSFER_SIZE as usize) {
+                    self.litebox.fill_random(chunk).map_err(|_| ReadError::Io)?;
+                }
                 Ok(buf.len())
             }
         }
@@ -387,5 +375,31 @@ where
         _group: Option<u16>,
     ) -> Result<(), ChownError> {
         Err(ChownError::ReadOnlyFileSystem)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::platform::mock::MockPlatform;
+
+    #[test]
+    fn urandom_requires_broker_only_for_nonempty_reads() {
+        let litebox = LiteBox::new(MockPlatform::new());
+        let devices = Devices::new(&litebox, InodeAllocator::standalone());
+        let urandom = open_urandom(&devices);
+
+        assert_eq!(devices.read(&urandom, &mut [], 0).unwrap(), 0);
+        assert!(matches!(
+            devices.read(&urandom, &mut [0], 0),
+            Err(ReadError::Io)
+        ));
+    }
+
+    fn open_urandom(devices: &Devices<MockPlatform>) -> FileHandle {
+        devices
+            .open_file_at(devices.root(), "urandom", OFlags::RDONLY)
+            .unwrap()
+            .item
     }
 }

--- a/litebox_runner_linux_userland/tests/run.rs
+++ b/litebox_runner_linux_userland/tests/run.rs
@@ -43,6 +43,7 @@ const BROKER_ONLY_C_TESTS: &[&str] = &[
     "tcp_broker_server.c",
     "udp_broker.c",
     "udp_broker_namespace.c",
+    "urandom_broker.c",
 ];
 
 #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
@@ -613,13 +614,19 @@ console.log(content);
         false,
         false,
     );
+    let urandom_target = common::compile(
+        "./tests/urandom_broker.c",
+        "broker_urandom_rewriter",
+        false,
+        false,
+    );
     let control_socket_path = unique_test_socket_path("runner-broker-control");
     let broker_thread = spawn_test_broker(
         &control_socket_path,
         litebox_broker_core::PolicyEngine::with_host_guaranteed_rights(
             litebox_broker_core::ObjectRights::all(),
         ),
-        4,
+        5,
     );
 
     Runner::new(&true_path, "broker_true_rewriter")
@@ -638,6 +645,11 @@ console.log(content);
         .run();
     // pipe_broker.c creates five pipes; each endpoint owns one broker object.
     assert_eq!(broker_thread.next_close_object_count(), 10);
+
+    Runner::new(&urandom_target, "broker_urandom_rewriter")
+        .broker_socket(&control_socket_path)
+        .run();
+    assert_eq!(broker_thread.next_close_object_count(), 0);
 
     Runner::new(&node_path, "hello_node_broker_rewriter")
         .broker_socket(&control_socket_path)

--- a/litebox_runner_linux_userland/tests/urandom_broker.c
+++ b/litebox_runner_linux_userland/tests/urandom_broker.c
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include <fcntl.h>
+#include <string.h>
+#include <unistd.h>
+
+int main(void) {
+    unsigned char buffer[531];
+    memset(buffer, 0xa5, sizeof(buffer));
+
+    int fd = open("/dev/urandom", O_RDONLY);
+    if (fd < 0) {
+        return 1;
+    }
+    if (read(fd, &buffer[1], 529) != 529) {
+        return 2;
+    }
+    if (buffer[0] != 0xa5 || buffer[530] != 0xa5) {
+        return 3;
+    }
+    for (size_t i = 1; i < 530; ++i) {
+        if (buffer[i] != 0x5a) {
+            return 4;
+        }
+    }
+    return close(fd) == 0 ? 0 : 5;
+}


### PR DESCRIPTION
This PR routes nonempty `/dev/urandom` reads through the mandatory broker in 256-byte shared-buffer chunks, preserves brokerless zero-length reads, maps broker failures to filesystem I/O errors, removes the `CrngProvider` requirement from the LiteBox device backend, and adds deterministic multi-chunk integration coverage.