### PR TITLE
Route OP-TEE random generation through the broker

### DIFF
--- a/litebox/src/random.rs
+++ b/litebox/src/random.rs
@@ -3,6 +3,7 @@
 
 //! Broker-provided cryptographic randomness.
 
+use litebox_broker_protocol::random::MAX_RANDOM_TRANSFER_SIZE;
 use thiserror::Error;
 
 use crate::{LiteBox, sync::RawSyncPrimitivesProvider};
@@ -15,15 +16,15 @@ pub struct FillRandomError;
 impl<Platform: RawSyncPrimitivesProvider> LiteBox<Platform> {
     /// Fills `output` completely with cryptographically secure random bytes.
     ///
-    /// Non-empty requests require a negotiated broker and may contain at most
-    /// 256 bytes.
+    /// Non-empty requests require a negotiated broker.
     pub fn fill_random(&self, output: &mut [u8]) -> Result<(), FillRandomError> {
         if output.is_empty() {
             return Ok(());
         }
-        self.broker_control()
-            .ok_or(FillRandomError)?
-            .fill_random(output)
-            .map_err(|_| FillRandomError)
+        let broker = self.broker_control().ok_or(FillRandomError)?;
+        for chunk in output.chunks_mut(MAX_RANDOM_TRANSFER_SIZE as usize) {
+            broker.fill_random(chunk).map_err(|_| FillRandomError)?;
+        }
+        Ok(())
     }
 }

--- a/litebox_runner_optee_on_linux_userland/tests/random-ta-cmds.json
+++ b/litebox_runner_optee_on_linux_userland/tests/random-ta-cmds.json
@@ -11,7 +11,7 @@
     "args": [
       {
         "param_type": "memref_output",
-        "buffer_size": 64
+        "buffer_size": 1024
       }
     ]
   },
@@ -19,4 +19,3 @@
     "func_id": "close_session"
   }
 ]
-

--- a/litebox_shim_optee/src/lib.rs
+++ b/litebox_shim_optee/src/lib.rs
@@ -148,7 +148,7 @@ impl OpteeShimBuilder {
             platform: self.platform,
             boot_instant: TimeProvider::now(self.platform),
             pm: PageManager::new(&self.litebox),
-            _litebox: self.litebox,
+            litebox: self.litebox,
             ta_uuid_map: TaUuidMap::new(),
             pta_busy: spin::mutex::SpinMutex::new(HashSet::new()),
         });
@@ -167,7 +167,7 @@ struct GlobalState {
     /// The page manager for managing virtual memory.
     pm: litebox::mm::PageManager<Platform, { PAGE_SIZE }>,
     /// The LiteBox instance used throughout the shim.
-    _litebox: litebox::LiteBox<Platform>,
+    litebox: litebox::LiteBox<Platform>,
     /// The TA UUID to binary map for TA loading.
     ta_uuid_map: TaUuidMap,
     /// Tracks which non-concurrent PTAs (i.e., PTAs w/o `TaFlags::CONCURRENT`)

--- a/litebox_shim_optee/src/syscalls/cryp.rs
+++ b/litebox_shim_optee/src/syscalls/cryp.rs
@@ -304,15 +304,11 @@ impl Task {
         Ok(())
     }
 
-    #[allow(clippy::unnecessary_wraps)]
     pub(crate) fn sys_cryp_random_number_generate(&self, buf: &mut [u8]) -> Result<(), TeeResult> {
-        if !buf.is_empty() {
-            <crate::Platform as litebox::platform::CrngProvider>::fill_bytes_crng(
-                self.global.platform,
-                buf,
-            );
-        }
-        Ok(())
+        self.global
+            .litebox
+            .fill_random(buf)
+            .map_err(|_| TeeResult::CommunicationError)
     }
 }
 

--- a/litebox_shim_optee/src/syscalls/tests.rs
+++ b/litebox_shim_optee/src/syscalls/tests.rs
@@ -31,11 +31,19 @@ fn test_sys_log() {
 }
 
 #[test]
-fn test_cryp_random_number_generate() {
+fn test_cryp_random_number_generate_requires_broker() {
     let task = init_platform();
     let mut buf = [0u8; 16];
-    let result = task.sys_cryp_random_number_generate(&mut buf);
-    assert!(result.is_ok() && buf != [0u8; 16]);
+    assert_eq!(
+        task.sys_cryp_random_number_generate(&mut []),
+        Ok(()),
+        "zero-length random generation must not require a broker"
+    );
+    assert_eq!(
+        task.sys_cryp_random_number_generate(&mut buf),
+        Err(litebox_common_optee::TeeResult::CommunicationError)
+    );
+    assert_eq!(buf, [0; 16]);
 }
 
 #[test]


### PR DESCRIPTION
This PR routes OP-TEE random-number syscalls through the mandatory broker, teaches LiteBox to split arbitrary random fills into broker-sized transfers, maps broker failures to TEE_ERROR_COMMUNICATION while preserving zero-length success, and expands the random TA scenario to exercise a multi-transfer request.