### PR TITLE
Route OP-TEE stack canaries through the broker

### DIFF
--- a/litebox_shim_optee/src/lib.rs
+++ b/litebox_shim_optee/src/lib.rs
@@ -810,8 +810,10 @@ impl Task {
             crate::loader::ta_stack::allocate_stack(self, self.get_ta_stack_base_addr()).ok_or(
                 ElfLoaderError::MappingError(litebox::mm::linux::MappingError::OutOfMemory),
             )?;
+        let mut stack_canary = [0; 16];
+        self.global.litebox.fill_random(&mut stack_canary)?;
         ta_stack
-            .init(self.global.platform, params)
+            .init(params, stack_canary)
             .ok_or(ElfLoaderError::InvalidStackAddr)?;
 
         Ok(ThreadInitState::Ta {

--- a/litebox_shim_optee/src/loader/elf.rs
+++ b/litebox_shim_optee/src/loader/elf.rs
@@ -287,6 +287,8 @@ pub enum ElfLoaderError {
     MappingError(#[from] MappingError),
     #[error("TA binary UUID does not match expected UUID")]
     InvalidUuid,
+    #[error("failed to generate stack canary")]
+    StackCanaryError(#[from] litebox::random::FillRandomError),
 }
 
 impl From<ElfLoaderError> for litebox_common_linux::errno::Errno {
@@ -299,6 +301,7 @@ impl From<ElfLoaderError> for litebox_common_linux::errno::Errno {
             }
             ElfLoaderError::LoadError(e) => e.into(),
             ElfLoaderError::InvalidUuid => litebox_common_linux::errno::Errno::EINVAL,
+            ElfLoaderError::StackCanaryError(_) => litebox_common_linux::errno::Errno::EIO,
         }
     }
 }

--- a/litebox_shim_optee/src/loader/ta_stack.rs
+++ b/litebox_shim_optee/src/loader/ta_stack.rs
@@ -10,7 +10,7 @@ use litebox::{
 use litebox_common_optee::{LdelfArg, TeeParamType, UteeParamOwned, UteeParams};
 use zerocopy::IntoBytes;
 
-use crate::{Platform, UserMutPtr};
+use crate::UserMutPtr;
 
 #[inline]
 fn align_down(addr: usize, align: usize) -> usize {
@@ -223,7 +223,7 @@ impl TaStack {
         Some(())
     }
 
-    pub(crate) fn init(&mut self, platform: &Platform, params: &[UteeParamOwned]) -> Option<()> {
+    pub(crate) fn init(&mut self, params: &[UteeParamOwned], stack_canary: [u8; 16]) -> Option<()> {
         if params.len() > UteeParams::TEE_NUM_PARAMS {
             return None;
         }
@@ -256,10 +256,7 @@ impl TaStack {
 
         self.set_utee_params()?;
 
-        // Random 16-byte stack canary
-        let mut canary = [0u8; 16];
-        <Platform as litebox::platform::CrngProvider>::fill_bytes_crng(platform, &mut canary);
-        self.push_bytes(&canary)?;
+        self.push_bytes(&stack_canary)?;
 
         // `reenter_thread` *jumps* into the TA entry point (which is a function) rather than
         // calls it. Adjust the stack pointer to ensure post-call stack alignment.


### PR DESCRIPTION
This PR routes OP-TEE TA stack-canary generation through mandatory broker randomness, reports failures through a dedicated loader error mapped to EIO, and removes the OP-TEE shim's remaining CrngProvider use. Because every TA entry initializes a canary, OP-TEE over LVBS will not work until a kernel broker platform is implemented.