### PR TITLE
Route standard input through the broker

### DIFF
--- a/litebox/src/broker/mod.rs
+++ b/litebox/src/broker/mod.rs
@@ -45,6 +45,8 @@ use shared_buffer::{SlotAllocator, SlotLease};
 pub(crate) trait BrokerControl: Send + Sync {
     fn fill_random(&self, output: &mut [u8]) -> core::result::Result<(), BrokerControlError>;
 
+    fn read_stdio(&self, data: &mut [u8]) -> core::result::Result<usize, BrokerControlError>;
+
     fn write_stdio(
         &self,
         stream: StdioOutputStream,
@@ -251,6 +253,7 @@ pub(crate) struct BrokerLocalControl<
     local: Mutex<Platform, Option<Arc<BrokerLocal<Channel>>>>,
     pollable_registry: Arc<BrokerPollableRegistry<Platform>>,
     slot_allocator: SlotAllocator<Platform>,
+    stdio_read_lock: Mutex<Platform, ()>,
 }
 
 impl<Platform, Channel> BrokerLocalControl<Platform, Channel>
@@ -266,6 +269,7 @@ where
             local: Mutex::new(Some(Arc::new(local))),
             pollable_registry,
             slot_allocator: SlotAllocator::new(),
+            stdio_read_lock: Mutex::new(()),
         }
     }
 
@@ -318,6 +322,19 @@ where
             u32::try_from(output.len()).expect("validated random transfer length must fit in u32");
         let lease = self.acquire_shared_buffer(length)?;
         self.request(|local| local.fill_random(lease.descriptor(), output))
+    }
+
+    fn read_stdio(&self, data: &mut [u8]) -> core::result::Result<usize, BrokerControlError> {
+        if data.len() > MAX_STDIO_TRANSFER_SIZE as usize {
+            return Err(BrokerControlError::Broker(ErrorCode::ResourceExhausted));
+        }
+        // Keep blocking stdin reads from consuming the broker's shared worker
+        // pool when multiple guest threads read concurrently.
+        let _read_guard = self.stdio_read_lock.lock();
+        let length = u32::try_from(data.len())
+            .expect("validated shared stdio transfer length must fit in u32");
+        let lease = self.acquire_shared_buffer(length)?;
+        self.request(|local| local.read_stdio(lease.descriptor(), data))
     }
 
     fn write_stdio(

--- a/litebox/src/fs/devices.rs
+++ b/litebox/src/fs/devices.rs
@@ -266,14 +266,7 @@ where
     fn read(&self, h: &FileHandle, buf: &mut [u8], _offset: usize) -> Result<usize, ReadError> {
         let h = h.get_typed::<Self>();
         match h.device {
-            Device::Stdin => self
-                .litebox
-                .x
-                .platform
-                .read_from_stdin(buf)
-                .map_err(|e| match e {
-                    crate::platform::StdioReadError::Closed => ReadError::Io,
-                }),
+            Device::Stdin => self.litebox.read_stdio(buf).map_err(|_| ReadError::Io),
             Device::Stdout | Device::Stderr => Err(ReadError::NotForReading),
             Device::Null => {
                 // /dev/null read returns EOF

--- a/litebox/src/fs/tests.rs
+++ b/litebox/src/fs/tests.rs
@@ -1946,7 +1946,7 @@ mod overlay {
 mod stdio {
     use crate::LiteBox;
     use crate::fs::devices::Devices;
-    use crate::fs::errors::WriteError;
+    use crate::fs::errors::{ReadError, WriteError};
     use crate::fs::resolver::Resolver;
     use crate::fs::{Mode, OFlags};
     use crate::platform::mock::MockPlatform;
@@ -1954,7 +1954,7 @@ mod stdio {
     extern crate std;
 
     #[test]
-    fn stdio_open_read_without_brokered_output() {
+    fn stdio_requires_broker() {
         let platform = MockPlatform::new();
         let litebox = LiteBox::new(platform);
         let fs = Resolver::new(
@@ -1998,12 +1998,16 @@ mod stdio {
         let fd_stdin = fs
             .open("/dev/stdin", OFlags::RDONLY, Mode::empty())
             .expect("Failed to open /dev/stdin");
+        assert!(matches!(fs.read(&fd_stdin, &mut [], None), Ok(0)));
         let mut buffer = vec![0; 13];
-        let bytes_read = fs
-            .read(&fd_stdin, &mut buffer, None)
-            .expect("Failed to read from /dev/stdin");
-        assert_eq!(bytes_read, 13);
-        assert_eq!(&buffer, b"Hello, stdin!");
+        assert!(matches!(
+            fs.read(&fd_stdin, &mut buffer, None),
+            Err(ReadError::Io)
+        ));
+        assert_eq!(
+            platform.stdin_queue.read().unwrap().front().unwrap(),
+            b"Hello, stdin!"
+        );
         fs.close(&fd_stdin).expect("Failed to close /dev/stdin");
     }
 
@@ -2033,7 +2037,7 @@ mod composed_stdio {
     use crate::LiteBox;
     use crate::fs::composer::Composer;
     use crate::fs::devices::Devices;
-    use crate::fs::errors::WriteError;
+    use crate::fs::errors::{ReadError, WriteError};
     use crate::fs::in_mem::{InMem, InitialNode};
     use crate::fs::resolver::Resolver;
     use crate::fs::{Mode, OFlags, UserInfo};
@@ -2063,7 +2067,7 @@ mod composed_stdio {
     }
 
     #[test]
-    fn stdio_open_read_without_brokered_output() {
+    fn stdio_requires_broker() {
         let platform = MockPlatform::new();
         let litebox = LiteBox::new(platform);
         let fs = composed_fs(&litebox);
@@ -2101,11 +2105,16 @@ mod composed_stdio {
         let fd_stdin = fs
             .open("/dev/stdin", OFlags::RDONLY, Mode::empty())
             .expect("Failed to open /dev/stdin");
+        assert!(matches!(fs.read(&fd_stdin, &mut [], None), Ok(0)));
         let mut buffer = vec![0; 1024];
-        let bytes_read = fs
-            .read(&fd_stdin, &mut buffer, None)
-            .expect("Failed to read from /dev/stdin");
-        assert_eq!(&buffer[..bytes_read], b"Hello, composed stdin!");
+        assert!(matches!(
+            fs.read(&fd_stdin, &mut buffer, None),
+            Err(ReadError::Io)
+        ));
+        assert_eq!(
+            platform.stdin_queue.read().unwrap().front().unwrap(),
+            b"Hello, composed stdin!"
+        );
         fs.close(&fd_stdin).expect("Failed to close /dev/stdin");
     }
 

--- a/litebox/src/stdio.rs
+++ b/litebox/src/stdio.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-//! Broker-provided standard output.
+//! Broker-provided standard I/O.
 
 use litebox_broker_protocol::stdio::MAX_STDIO_TRANSFER_SIZE;
 pub use litebox_broker_protocol::stdio::StdioOutputStream;
@@ -9,12 +9,33 @@ use thiserror::Error;
 
 use crate::{LiteBox, sync::RawSyncPrimitivesProvider};
 
+/// A broker could not read from standard input.
+#[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
+#[error("brokered standard input is unavailable")]
+pub struct ReadStdioError;
+
 /// A broker could not write to a standard output stream.
 #[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
 #[error("brokered standard output is unavailable")]
 pub struct WriteStdioError;
 
 impl<Platform: RawSyncPrimitivesProvider> LiteBox<Platform> {
+    /// Reads bytes from standard input.
+    ///
+    /// Empty reads succeed without a broker. Non-empty reads require a
+    /// negotiated broker, block until input or end-of-file, and may read at
+    /// most one broker transfer.
+    pub fn read_stdio(&self, output: &mut [u8]) -> Result<usize, ReadStdioError> {
+        if output.is_empty() {
+            return Ok(0);
+        }
+        let broker = self.broker_control().ok_or(ReadStdioError)?;
+        let length = output.len().min(MAX_STDIO_TRANSFER_SIZE as usize);
+        broker
+            .read_stdio(&mut output[..length])
+            .map_err(|_| ReadStdioError)
+    }
+
     /// Writes bytes to the selected standard output stream.
     ///
     /// Empty writes succeed without a broker. Non-empty writes require a

--- a/litebox_broker_core/src/lib.rs
+++ b/litebox_broker_core/src/lib.rs
@@ -42,7 +42,9 @@ pub use policy::{
 };
 use random::RandomProvider;
 use session::ObjectReference;
-pub use session::{BrokerSession, CallerCredential, ObjectRights, SessionId};
+pub use session::{
+    AssociationCancellation, BrokerSession, CallerCredential, ObjectRights, SessionId,
+};
 use socket::{BrokerSocketPorts, SocketProvider};
 use stdio::StdioProvider;
 

--- a/litebox_broker_core/src/session.rs
+++ b/litebox_broker_core/src/session.rs
@@ -119,9 +119,9 @@ impl BrokerSession {
         }
     }
 
-    /// Cancels potentially blocking operations because this association is
-    /// ending.
-    pub fn cancel_pending_operations(&self) {
+    /// Requests cooperative cancellation of potentially blocking operations
+    /// because this association is ending.
+    pub fn request_cancellation(&self) {
         self.cancellation.cancel();
     }
 

--- a/litebox_broker_core/src/session.rs
+++ b/litebox_broker_core/src/session.rs
@@ -7,6 +7,7 @@ use core::sync::atomic::{AtomicUsize, Ordering};
 use crate::event::EventObject;
 use crate::pipe::PipeObject;
 use crate::socket::SocketObject;
+use crate::stdio::StdioReadCancellation;
 use crate::{BrokerCore, BrokerError, Result};
 use hashbrown::HashMap;
 use litebox_broker_protocol::ObjectHandle;
@@ -77,6 +78,8 @@ pub struct BrokerSession {
     references: Mutex<SessionReferences>,
     /// Socket quota held by pending, live, and closing in-flight resources.
     pub(crate) reserved_sockets: Arc<AtomicUsize>,
+    /// Cancellation state for standard-input reads in this session.
+    pub(crate) stdio_read_cancellation: StdioReadCancellation,
 }
 
 impl BrokerSession {
@@ -95,6 +98,7 @@ impl BrokerSession {
                 pending_handles: 0,
             }),
             reserved_sockets: Arc::new(AtomicUsize::new(0)),
+            stdio_read_cancellation: StdioReadCancellation::default(),
         }
     }
 

--- a/litebox_broker_core/src/session.rs
+++ b/litebox_broker_core/src/session.rs
@@ -2,12 +2,11 @@
 // Licensed under the MIT license.
 
 use alloc::{sync::Arc, vec::Vec};
-use core::sync::atomic::{AtomicUsize, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 use crate::event::EventObject;
 use crate::pipe::PipeObject;
 use crate::socket::SocketObject;
-use crate::stdio::StdioReadCancellation;
 use crate::{BrokerCore, BrokerError, Result};
 use hashbrown::HashMap;
 use litebox_broker_protocol::ObjectHandle;
@@ -32,6 +31,24 @@ pub enum CallerCredential {
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SessionId(pub u64);
+
+/// Cancellation state shared by potentially blocking operations in one broker
+/// association.
+#[derive(Debug, Default)]
+pub struct AssociationCancellation {
+    cancelled: AtomicBool,
+}
+
+impl AssociationCancellation {
+    /// Returns whether the broker association is ending.
+    pub fn is_cancelled(&self) -> bool {
+        self.cancelled.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn cancel(&self) {
+        self.cancelled.store(true, Ordering::Release);
+    }
+}
 
 bitflags::bitflags! {
     /// Broker rights attached to an object reference.
@@ -78,8 +95,8 @@ pub struct BrokerSession {
     references: Mutex<SessionReferences>,
     /// Socket quota held by pending, live, and closing in-flight resources.
     pub(crate) reserved_sockets: Arc<AtomicUsize>,
-    /// Cancellation state for standard-input reads in this session.
-    pub(crate) stdio_read_cancellation: StdioReadCancellation,
+    /// Cancellation state for potentially blocking operations in this session.
+    pub(crate) cancellation: AssociationCancellation,
 }
 
 impl BrokerSession {
@@ -98,8 +115,14 @@ impl BrokerSession {
                 pending_handles: 0,
             }),
             reserved_sockets: Arc::new(AtomicUsize::new(0)),
-            stdio_read_cancellation: StdioReadCancellation::default(),
+            cancellation: AssociationCancellation::default(),
         }
+    }
+
+    /// Cancels potentially blocking operations because this association is
+    /// ending.
+    pub fn cancel_pending_operations(&self) {
+        self.cancellation.cancel();
     }
 
     pub(crate) fn create_object_reference(&self, object: ObjectEntry) -> Result<ObjectHandle> {

--- a/litebox_broker_core/src/stdio.rs
+++ b/litebox_broker_core/src/stdio.rs
@@ -3,6 +3,8 @@
 
 //! Broker-authoritative standard I/O.
 
+use core::sync::atomic::{AtomicBool, Ordering};
+
 use litebox_broker_protocol::stdio::{MAX_STDIO_TRANSFER_SIZE, StdioOutputStream};
 use thiserror::Error;
 
@@ -11,8 +13,8 @@ use crate::{BrokerError, BrokerSession, Result};
 /// Failure reported by a trusted standard-I/O provider.
 #[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
 pub enum StdioProviderError {
-    /// The selected output stream is closed.
-    #[error("standard output stream is closed")]
+    /// The selected standard stream is closed.
+    #[error("standard stream is closed")]
     Closed,
     /// The host standard-I/O operation failed internally.
     #[error("trusted standard-I/O provider failed")]
@@ -22,8 +24,40 @@ pub enum StdioProviderError {
     Unsupported,
 }
 
+/// Per-session cancellation state for standard-input reads.
+#[derive(Debug, Default)]
+pub struct StdioReadCancellation {
+    cancelled: AtomicBool,
+}
+
+impl StdioReadCancellation {
+    /// Returns whether the broker session is ending.
+    pub fn is_cancelled(&self) -> bool {
+        self.cancelled.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn cancel(&self) {
+        self.cancelled.store(true, Ordering::Release);
+    }
+}
+
 /// Trusted provider of standard-I/O operations.
 pub trait StdioProvider: Send + Sync {
+    /// Blocks until bytes can be read from standard input, returning zero at
+    /// end-of-file.
+    ///
+    /// Blocking implementations must periodically check `cancellation` and
+    /// return promptly when it becomes cancelled.
+    fn read(
+        &self,
+        cancellation: &StdioReadCancellation,
+        output: &mut [u8],
+    ) -> core::result::Result<usize, StdioProviderError> {
+        let _ = cancellation;
+        let _ = output;
+        Err(StdioProviderError::Unsupported)
+    }
+
     /// Writes bytes to the selected standard output stream.
     fn write(
         &self,
@@ -36,6 +70,14 @@ pub trait StdioProvider: Send + Sync {
 pub struct UnsupportedStdioProvider;
 
 impl StdioProvider for UnsupportedStdioProvider {
+    fn read(
+        &self,
+        _cancellation: &StdioReadCancellation,
+        _output: &mut [u8],
+    ) -> core::result::Result<usize, StdioProviderError> {
+        Err(StdioProviderError::Unsupported)
+    }
+
     fn write(
         &self,
         _stream: StdioOutputStream,
@@ -43,6 +85,31 @@ impl StdioProvider for UnsupportedStdioProvider {
     ) -> core::result::Result<usize, StdioProviderError> {
         Err(StdioProviderError::Unsupported)
     }
+}
+
+/// Reads standard input through the provider configured for this broker.
+pub fn read(session: &BrokerSession, output: &mut [u8]) -> Result<usize> {
+    if output.len() > MAX_STDIO_TRANSFER_SIZE as usize {
+        return Err(BrokerError::ResourceExhausted);
+    }
+    if output.is_empty() {
+        return Ok(0);
+    }
+    let read = session
+        .core
+        .stdio_provider
+        .read(&session.stdio_read_cancellation, output)
+        .map_err(map_provider_error)?;
+    if read > output.len() {
+        return Err(BrokerError::Internal);
+    }
+    Ok(read)
+}
+
+/// Cancels standard-input reads that are still pending for an ending
+/// association.
+pub fn cancel_pending_reads(session: &BrokerSession) {
+    session.stdio_read_cancellation.cancel();
 }
 
 /// Writes `input` through the standard-I/O provider configured for this broker.
@@ -53,18 +120,21 @@ pub fn write(session: &BrokerSession, stream: StdioOutputStream, input: &[u8]) -
     if input.is_empty() {
         return Ok(0);
     }
-    let written =
-        session
-            .core
-            .stdio_provider
-            .write(stream, input)
-            .map_err(|error| match error {
-                StdioProviderError::Closed => BrokerError::PeerClosed,
-                StdioProviderError::Failed => BrokerError::Internal,
-                StdioProviderError::Unsupported => BrokerError::UnsupportedOperation,
-            })?;
+    let written = session
+        .core
+        .stdio_provider
+        .write(stream, input)
+        .map_err(map_provider_error)?;
     if written > input.len() {
         return Err(BrokerError::Internal);
     }
     Ok(written)
+}
+
+fn map_provider_error(error: StdioProviderError) -> BrokerError {
+    match error {
+        StdioProviderError::Closed => BrokerError::PeerClosed,
+        StdioProviderError::Failed => BrokerError::Internal,
+        StdioProviderError::Unsupported => BrokerError::UnsupportedOperation,
+    }
 }

--- a/litebox_broker_core/src/stdio.rs
+++ b/litebox_broker_core/src/stdio.rs
@@ -22,6 +22,16 @@ pub enum StdioProviderError {
     Unsupported,
 }
 
+impl From<StdioProviderError> for BrokerError {
+    fn from(error: StdioProviderError) -> Self {
+        match error {
+            StdioProviderError::Closed => Self::PeerClosed,
+            StdioProviderError::Failed => Self::Internal,
+            StdioProviderError::Unsupported => Self::UnsupportedOperation,
+        }
+    }
+}
+
 /// Trusted provider of standard-I/O operations.
 pub trait StdioProvider: Send + Sync {
     /// Blocks until bytes can be read from standard input, returning zero at
@@ -80,8 +90,7 @@ pub fn read(session: &BrokerSession, output: &mut [u8]) -> Result<usize> {
     let read = session
         .core
         .stdio_provider
-        .read(&session.cancellation, output)
-        .map_err(map_provider_error)?;
+        .read(&session.cancellation, output)?;
     if read > output.len() {
         return Err(BrokerError::Internal);
     }
@@ -99,18 +108,9 @@ pub fn write(session: &BrokerSession, stream: StdioOutputStream, input: &[u8]) -
     let written = session
         .core
         .stdio_provider
-        .write(&session.cancellation, stream, input)
-        .map_err(map_provider_error)?;
+        .write(&session.cancellation, stream, input)?;
     if written > input.len() {
         return Err(BrokerError::Internal);
     }
     Ok(written)
-}
-
-fn map_provider_error(error: StdioProviderError) -> BrokerError {
-    match error {
-        StdioProviderError::Closed => BrokerError::PeerClosed,
-        StdioProviderError::Failed => BrokerError::Internal,
-        StdioProviderError::Unsupported => BrokerError::UnsupportedOperation,
-    }
 }

--- a/litebox_broker_core/src/stdio.rs
+++ b/litebox_broker_core/src/stdio.rs
@@ -33,11 +33,7 @@ pub trait StdioProvider: Send + Sync {
         &self,
         cancellation: &AssociationCancellation,
         output: &mut [u8],
-    ) -> core::result::Result<usize, StdioProviderError> {
-        let _ = cancellation;
-        let _ = output;
-        Err(StdioProviderError::Unsupported)
-    }
+    ) -> core::result::Result<usize, StdioProviderError>;
 
     /// Writes bytes to the selected standard output stream.
     ///

--- a/litebox_broker_core/src/stdio.rs
+++ b/litebox_broker_core/src/stdio.rs
@@ -3,12 +3,10 @@
 
 //! Broker-authoritative standard I/O.
 
-use core::sync::atomic::{AtomicBool, Ordering};
-
 use litebox_broker_protocol::stdio::{MAX_STDIO_TRANSFER_SIZE, StdioOutputStream};
 use thiserror::Error;
 
-use crate::{BrokerError, BrokerSession, Result};
+use crate::{AssociationCancellation, BrokerError, BrokerSession, Result};
 
 /// Failure reported by a trusted standard-I/O provider.
 #[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
@@ -24,23 +22,6 @@ pub enum StdioProviderError {
     Unsupported,
 }
 
-/// Per-session cancellation state for standard-input reads.
-#[derive(Debug, Default)]
-pub struct StdioReadCancellation {
-    cancelled: AtomicBool,
-}
-
-impl StdioReadCancellation {
-    /// Returns whether the broker session is ending.
-    pub fn is_cancelled(&self) -> bool {
-        self.cancelled.load(Ordering::Acquire)
-    }
-
-    pub(crate) fn cancel(&self) {
-        self.cancelled.store(true, Ordering::Release);
-    }
-}
-
 /// Trusted provider of standard-I/O operations.
 pub trait StdioProvider: Send + Sync {
     /// Blocks until bytes can be read from standard input, returning zero at
@@ -50,7 +31,7 @@ pub trait StdioProvider: Send + Sync {
     /// return promptly when it becomes cancelled.
     fn read(
         &self,
-        cancellation: &StdioReadCancellation,
+        cancellation: &AssociationCancellation,
         output: &mut [u8],
     ) -> core::result::Result<usize, StdioProviderError> {
         let _ = cancellation;
@@ -59,8 +40,12 @@ pub trait StdioProvider: Send + Sync {
     }
 
     /// Writes bytes to the selected standard output stream.
+    ///
+    /// Blocking implementations must periodically check `cancellation` and
+    /// return promptly when it becomes cancelled.
     fn write(
         &self,
+        cancellation: &AssociationCancellation,
         stream: StdioOutputStream,
         input: &[u8],
     ) -> core::result::Result<usize, StdioProviderError>;
@@ -72,7 +57,7 @@ pub struct UnsupportedStdioProvider;
 impl StdioProvider for UnsupportedStdioProvider {
     fn read(
         &self,
-        _cancellation: &StdioReadCancellation,
+        _cancellation: &AssociationCancellation,
         _output: &mut [u8],
     ) -> core::result::Result<usize, StdioProviderError> {
         Err(StdioProviderError::Unsupported)
@@ -80,6 +65,7 @@ impl StdioProvider for UnsupportedStdioProvider {
 
     fn write(
         &self,
+        _cancellation: &AssociationCancellation,
         _stream: StdioOutputStream,
         _input: &[u8],
     ) -> core::result::Result<usize, StdioProviderError> {
@@ -98,18 +84,12 @@ pub fn read(session: &BrokerSession, output: &mut [u8]) -> Result<usize> {
     let read = session
         .core
         .stdio_provider
-        .read(&session.stdio_read_cancellation, output)
+        .read(&session.cancellation, output)
         .map_err(map_provider_error)?;
     if read > output.len() {
         return Err(BrokerError::Internal);
     }
     Ok(read)
-}
-
-/// Cancels standard-input reads that are still pending for an ending
-/// association.
-pub fn cancel_pending_reads(session: &BrokerSession) {
-    session.stdio_read_cancellation.cancel();
 }
 
 /// Writes `input` through the standard-I/O provider configured for this broker.
@@ -123,7 +103,7 @@ pub fn write(session: &BrokerSession, stream: StdioOutputStream, input: &[u8]) -
     let written = session
         .core
         .stdio_provider
-        .write(stream, input)
+        .write(&session.cancellation, stream, input)
         .map_err(map_provider_error)?;
     if written > input.len() {
         return Err(BrokerError::Internal);

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -81,9 +81,9 @@ struct AssociationState {
 }
 
 impl<Memory: SharedMemory> BrokerHostAssociation<'_, Memory> {
-    /// Cancels provider operations that may block after the peer disconnects.
-    pub fn cancel_pending_requests(&self) {
-        self.session.cancel_pending_operations();
+    /// Requests cancellation of provider operations after the peer disconnects.
+    pub fn request_cancellation(&self) {
+        self.session.request_cancellation();
     }
 
     /// Executes one active request and emits its response.

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -46,7 +46,8 @@ use litebox_broker_protocol::socket::{
     SendSocketResponse, SendToSocketResponse, SocketOutcome,
 };
 use litebox_broker_protocol::stdio::{
-    MAX_STDIO_TRANSFER_SIZE, WriteStdioRequest, WriteStdioResponse,
+    MAX_STDIO_TRANSFER_SIZE, ReadStdioRequest, ReadStdioResponse, WriteStdioRequest,
+    WriteStdioResponse,
 };
 use litebox_broker_protocol::{BROKER_PROTOCOL_VERSION, RequestId};
 use litebox_broker_transport::channel::{HostReceive, HostSetupChannel, PeerCredential};
@@ -80,6 +81,11 @@ struct AssociationState {
 }
 
 impl<Memory: SharedMemory> BrokerHostAssociation<'_, Memory> {
+    /// Cancels provider operations that may block after the peer disconnects.
+    pub fn cancel_pending_requests(&self) {
+        litebox_broker_core::stdio::cancel_pending_reads(&self.session);
+    }
+
     /// Executes one active request and emits its response.
     ///
     /// Any fatal broker or response-channel error permanently fails this
@@ -95,14 +101,17 @@ impl<Memory: SharedMemory> BrokerHostAssociation<'_, Memory> {
             operation,
         } = request;
         let buffer_descriptor = match &operation {
-            BrokerOperation::FillRandom(buffer) => Some(*buffer),
             BrokerOperation::Pipe(PipeRequest::Read(request)) => Some(request.buffer),
             BrokerOperation::Pipe(PipeRequest::Write(request)) => Some(request.buffer),
             BrokerOperation::Socket(SocketRequest::Send(request)) => Some(request.buffer),
             BrokerOperation::Socket(SocketRequest::SendTo(request)) => Some(request.buffer),
             BrokerOperation::Socket(SocketRequest::Receive(request)) => Some(request.buffer),
             BrokerOperation::Socket(SocketRequest::ReceiveFrom(request)) => Some(request.buffer),
-            BrokerOperation::Stdio(StdioRequest::Write(request)) => Some(request.buffer),
+            BrokerOperation::FillRandom(buffer)
+            | BrokerOperation::Stdio(
+                StdioRequest::Read(ReadStdioRequest { buffer })
+                | StdioRequest::Write(WriteStdioRequest { buffer, .. }),
+            ) => Some(*buffer),
             BrokerOperation::CloseObject(_)
             | BrokerOperation::CheckReadiness(_)
             | BrokerOperation::Event(_)
@@ -386,6 +395,23 @@ fn handle_stdio_request<Memory: SharedMemory>(
     shared_buffers: &SharedBufferPool<Memory>,
 ) -> RequestResult<StdioResponse> {
     match request {
+        StdioRequest::Read(ReadStdioRequest { buffer }) => {
+            if buffer.length > MAX_STDIO_TRANSFER_SIZE {
+                return Err(RequestFailure::Abort(ErrorCode::MalformedRequest));
+            }
+            let mut data = Vec::new();
+            data.try_reserve_exact(buffer.length as usize)
+                .map_err(|_| RequestFailure::Respond(ErrorCode::OutOfMemory))?;
+            data.resize(buffer.length as usize, 0);
+            let read = litebox_broker_core::stdio::read(session, &mut data)
+                .map_err(RequestFailure::from)?;
+            shared_buffers
+                .write(buffer.slot_index, &data[..read])
+                .map_err(|_| RequestFailure::Abort(ErrorCode::Internal))?;
+            Ok(StdioResponse::Read(ReadStdioResponse {
+                read: u32::try_from(read).expect("validated stdio read length must fit in u32"),
+            }))
+        }
         StdioRequest::Write(WriteStdioRequest { stream, buffer }) => {
             if buffer.length > MAX_STDIO_TRANSFER_SIZE {
                 return Err(RequestFailure::Abort(ErrorCode::MalformedRequest));
@@ -751,7 +777,7 @@ mod tests {
         AcceptedPlatformSocket, PlatformConnectError, PlatformDatagramReceive, PlatformSocket,
         PlatformSocketStatus, PlatformStreamReceive, SocketProvider,
     };
-    use litebox_broker_core::stdio::{StdioProvider, StdioProviderError};
+    use litebox_broker_core::stdio::{StdioProvider, StdioProviderError, StdioReadCancellation};
     use litebox_broker_core::{ObjectRights, PolicyEngine, SessionId, SocketPolicy};
     use litebox_broker_protocol::event::{
         AddEventRequest, ConsumeEventRequest, CreateEventRequest, EventConsumeMode,
@@ -774,6 +800,7 @@ mod tests {
     use litebox_broker_protocol::stdio::StdioOutputStream;
     use litebox_broker_protocol::{ObjectHandle, ProtocolVersion, RequestId};
     use litebox_broker_transport::shared_memory::{SharedBufferPool, SharedMemoryError};
+    use std::collections::VecDeque;
     use std::sync::{Arc, Condvar, Mutex, mpsc};
     use std::time::Duration;
 
@@ -843,10 +870,24 @@ mod tests {
 
     #[derive(Default)]
     struct TestStdioProvider {
+        input: Mutex<VecDeque<u8>>,
         writes: Mutex<Vec<(StdioOutputStream, Vec<u8>)>>,
     }
 
     impl StdioProvider for TestStdioProvider {
+        fn read(
+            &self,
+            _cancellation: &StdioReadCancellation,
+            output: &mut [u8],
+        ) -> core::result::Result<usize, StdioProviderError> {
+            let mut input = self.input.lock().unwrap();
+            let read = input.len().min(output.len());
+            for (destination, source) in output.iter_mut().zip(input.drain(..read)) {
+                *destination = source;
+            }
+            Ok(read)
+        }
+
         fn write(
             &self,
             stream: StdioOutputStream,
@@ -1101,6 +1142,61 @@ mod tests {
         shared_buffers
             .write(SharedBufferSlotIndex(7), b"error")
             .unwrap();
+        provider.input.lock().unwrap().extend(b"input");
+
+        assert_eq!(
+            handle_test_request_with_buffers(
+                &session,
+                BrokerOperation::Stdio(StdioRequest::Read(ReadStdioRequest {
+                    buffer: descriptor(6, 3),
+                })),
+                &shared_buffers,
+            ),
+            BrokerResult::Stdio(StdioResponse::Read(ReadStdioResponse { read: 3 }))
+        );
+        let mut input = [0u8; 3];
+        shared_buffers
+            .read(SharedBufferSlotIndex(6), &mut input)
+            .unwrap();
+        assert_eq!(&input, b"inp");
+
+        shared_buffers
+            .write(SharedBufferSlotIndex(6), &[0xa5; 4])
+            .unwrap();
+        assert_eq!(
+            handle_test_request_with_buffers(
+                &session,
+                BrokerOperation::Stdio(StdioRequest::Read(ReadStdioRequest {
+                    buffer: descriptor(6, 4),
+                })),
+                &shared_buffers,
+            ),
+            BrokerResult::Stdio(StdioResponse::Read(ReadStdioResponse { read: 2 }))
+        );
+        let mut partial_input = [0u8; 4];
+        shared_buffers
+            .read(SharedBufferSlotIndex(6), &mut partial_input)
+            .unwrap();
+        assert_eq!(&partial_input, b"ut\xa5\xa5");
+
+        shared_buffers
+            .write(SharedBufferSlotIndex(6), &[0xa5; 4])
+            .unwrap();
+        assert_eq!(
+            handle_test_request_with_buffers(
+                &session,
+                BrokerOperation::Stdio(StdioRequest::Read(ReadStdioRequest {
+                    buffer: descriptor(6, 4),
+                })),
+                &shared_buffers,
+            ),
+            BrokerResult::Stdio(StdioResponse::Read(ReadStdioResponse { read: 0 }))
+        );
+        let mut eof_input = [0u8; 4];
+        shared_buffers
+            .read(SharedBufferSlotIndex(6), &mut eof_input)
+            .unwrap();
+        assert_eq!(eof_input, [0xa5; 4]);
 
         assert_eq!(
             handle_test_request_with_buffers(
@@ -1122,6 +1218,17 @@ mod tests {
                 &session,
                 BrokerOperation::Stdio(StdioRequest::Write(WriteStdioRequest {
                     stream: StdioOutputStream::Stdout,
+                    buffer: descriptor(7, MAX_STDIO_TRANSFER_SIZE + 1),
+                })),
+                &shared_buffers,
+                &test_readiness_sink(),
+            ),
+            Err(RequestFailure::Abort(ErrorCode::MalformedRequest))
+        );
+        assert_eq!(
+            handle_request(
+                &session,
+                BrokerOperation::Stdio(StdioRequest::Read(ReadStdioRequest {
                     buffer: descriptor(7, MAX_STDIO_TRANSFER_SIZE + 1),
                 })),
                 &shared_buffers,

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -83,7 +83,7 @@ struct AssociationState {
 impl<Memory: SharedMemory> BrokerHostAssociation<'_, Memory> {
     /// Cancels provider operations that may block after the peer disconnects.
     pub fn cancel_pending_requests(&self) {
-        litebox_broker_core::stdio::cancel_pending_reads(&self.session);
+        self.session.cancel_pending_operations();
     }
 
     /// Executes one active request and emits its response.
@@ -777,8 +777,10 @@ mod tests {
         AcceptedPlatformSocket, PlatformConnectError, PlatformDatagramReceive, PlatformSocket,
         PlatformSocketStatus, PlatformStreamReceive, SocketProvider,
     };
-    use litebox_broker_core::stdio::{StdioProvider, StdioProviderError, StdioReadCancellation};
-    use litebox_broker_core::{ObjectRights, PolicyEngine, SessionId, SocketPolicy};
+    use litebox_broker_core::stdio::{StdioProvider, StdioProviderError};
+    use litebox_broker_core::{
+        AssociationCancellation, ObjectRights, PolicyEngine, SessionId, SocketPolicy,
+    };
     use litebox_broker_protocol::event::{
         AddEventRequest, ConsumeEventRequest, CreateEventRequest, EventConsumeMode,
     };
@@ -877,7 +879,7 @@ mod tests {
     impl StdioProvider for TestStdioProvider {
         fn read(
             &self,
-            _cancellation: &StdioReadCancellation,
+            _cancellation: &AssociationCancellation,
             output: &mut [u8],
         ) -> core::result::Result<usize, StdioProviderError> {
             let mut input = self.input.lock().unwrap();
@@ -890,6 +892,7 @@ mod tests {
 
         fn write(
             &self,
+            _cancellation: &AssociationCancellation,
             stream: StdioOutputStream,
             input: &[u8],
         ) -> core::result::Result<usize, StdioProviderError> {

--- a/litebox_broker_local/src/lib.rs
+++ b/litebox_broker_local/src/lib.rs
@@ -243,7 +243,8 @@ mod tests {
     use litebox_broker_protocol::readiness::ReadinessFlags;
     use litebox_broker_protocol::shared_buffer::{SharedBufferDescriptor, SharedBufferSlotIndex};
     use litebox_broker_protocol::stdio::{
-        StdioOutputStream, WriteStdioRequest, WriteStdioResponse,
+        ReadStdioRequest, ReadStdioResponse, StdioOutputStream, WriteStdioRequest,
+        WriteStdioResponse,
     };
     use litebox_broker_transport::channel::LocalNotificationChannel;
     use std::sync::Mutex;
@@ -327,6 +328,38 @@ mod tests {
                 request_id: RequestId(0),
                 operation: BrokerOperation::Stdio(StdioRequest::Write(WriteStdioRequest {
                     stream: StdioOutputStream::Stderr,
+                    buffer: descriptor,
+                })),
+            })
+        );
+    }
+
+    #[test]
+    fn read_stdio_requests_and_reads_the_shared_buffer() {
+        let descriptor = SharedBufferDescriptor {
+            slot_index: SharedBufferSlotIndex(2),
+            length: 3,
+        };
+        let channel = FakeControlChannel::new(
+            None,
+            Some(BrokerResult::Stdio(StdioResponse::Read(
+                ReadStdioResponse { read: 2 },
+            ))),
+        );
+        let local = BrokerLocal {
+            channel,
+            shared_buffers: noop_shared_buffers(),
+            next_request_id: AtomicU64::new(0),
+        };
+        let mut output = [0xff; 3];
+
+        assert_eq!(local.read_stdio(descriptor, &mut output).unwrap(), 2);
+        assert_eq!(output, [0, 0, 0xff]);
+        assert_eq!(
+            local.channel.sent_request.borrow().clone(),
+            Some(BrokerRequest {
+                request_id: RequestId(0),
+                operation: BrokerOperation::Stdio(StdioRequest::Read(ReadStdioRequest {
                     buffer: descriptor,
                 })),
             })

--- a/litebox_broker_local/src/stdio.rs
+++ b/litebox_broker_local/src/stdio.rs
@@ -6,13 +6,60 @@ use litebox_broker_protocol::message::{
 };
 use litebox_broker_protocol::shared_buffer::SharedBufferDescriptor;
 use litebox_broker_protocol::stdio::{
-    MAX_STDIO_TRANSFER_SIZE, StdioOutputStream, WriteStdioRequest,
+    MAX_STDIO_TRANSFER_SIZE, ReadStdioRequest, StdioOutputStream, WriteStdioRequest,
 };
 use litebox_broker_transport::channel::LocalCallChannel;
 
 use crate::{BrokerLocal, BrokerLocalError, Result};
 
 impl<Channel: LocalCallChannel> BrokerLocal<Channel> {
+    /// Reads standard input into an operation-scoped shared-buffer lease.
+    ///
+    /// The caller must retain exclusive ownership of the descriptor's slot
+    /// until this method returns.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the broker reports an unrecoverable error, returns a response
+    /// for a different operation, or reports an oversized read.
+    pub fn read_stdio(
+        &self,
+        buffer: SharedBufferDescriptor,
+        destination: &mut [u8],
+    ) -> Result<usize, Channel::Error> {
+        if buffer.length > MAX_STDIO_TRANSFER_SIZE {
+            return Err(BrokerLocalError::Broker(
+                litebox_broker_protocol::error::ErrorCode::ResourceExhausted,
+            ));
+        }
+        assert_eq!(
+            destination.len(),
+            buffer.length as usize,
+            "shared stdio read destination must match its descriptor"
+        );
+        self.shared_buffers
+            .layout()
+            .range(buffer.slot_index, destination.len())
+            .expect("shared stdio read descriptor must identify a valid slot range");
+        match self.request(BrokerOperation::Stdio(StdioRequest::Read(
+            ReadStdioRequest { buffer },
+        )))? {
+            BrokerResult::Stdio(StdioResponse::Read(response)) => {
+                assert!(
+                    response.read <= buffer.length,
+                    "broker returned oversized shared stdio read"
+                );
+                let read = response.read as usize;
+                self.shared_buffers
+                    .read(buffer.slot_index, &mut destination[..read])
+                    .expect("validated shared stdio read range must be accessible");
+                Ok(read)
+            }
+            BrokerResult::Error(error) => Err(BrokerLocalError::Broker(error)),
+            response => panic!("broker returned unexpected stdio response: {response:?}"),
+        }
+    }
+
     /// Writes bytes staged in an operation-scoped shared-buffer lease to a
     /// standard output stream.
     ///

--- a/litebox_broker_protocol/src/message.rs
+++ b/litebox_broker_protocol/src/message.rs
@@ -21,7 +21,7 @@ use crate::socket::{
     SendToSocketResponse, SetTcpOptionRequest, ShutdownSocketRequest, SocketError,
     SocketStatusRequest, SocketStatusResponse,
 };
-use crate::stdio::{WriteStdioRequest, WriteStdioResponse};
+use crate::stdio::{ReadStdioRequest, ReadStdioResponse, WriteStdioRequest, WriteStdioResponse};
 use crate::{ObjectHandle, ProtocolVersion, RequestId};
 
 /// Broker handshake request sent before the control channel is active.
@@ -231,6 +231,8 @@ pub enum SocketResponse {
 /// Standard-I/O request.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum StdioRequest {
+    /// Read bytes from standard input.
+    Read(ReadStdioRequest),
     /// Write bytes to a standard output stream.
     Write(WriteStdioRequest),
 }
@@ -238,6 +240,8 @@ pub enum StdioRequest {
 /// Standard-I/O response.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum StdioResponse {
+    /// Standard input read response.
+    Read(ReadStdioResponse),
     /// Standard output write response.
     Write(WriteStdioResponse),
 }

--- a/litebox_broker_protocol/src/stdio.rs
+++ b/litebox_broker_protocol/src/stdio.rs
@@ -3,7 +3,7 @@
 
 use crate::shared_buffer::{SHARED_BUFFER_SLOT_SIZE, SharedBufferDescriptor};
 
-/// Maximum standard-output bytes transferred by one broker request.
+/// Maximum standard-I/O bytes transferred by one broker request.
 pub const MAX_STDIO_TRANSFER_SIZE: u32 = 32 * 1024;
 
 const _: () = assert!(MAX_STDIO_TRANSFER_SIZE <= SHARED_BUFFER_SLOT_SIZE);
@@ -15,6 +15,20 @@ pub enum StdioOutputStream {
     Stdout,
     /// Process standard error.
     Stderr,
+}
+
+/// Request to read standard input into a leased shared-buffer region.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ReadStdioRequest {
+    /// Leased shared-buffer region that receives the input bytes.
+    pub buffer: SharedBufferDescriptor,
+}
+
+/// Response describing a completed standard-input read.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ReadStdioResponse {
+    /// Number of bytes read, or zero if standard input reached end-of-file.
+    pub read: u32,
 }
 
 /// Request to write bytes staged in shared memory to a standard output stream.

--- a/litebox_broker_protocol/src/wire.rs
+++ b/litebox_broker_protocol/src/wire.rs
@@ -401,7 +401,10 @@ mod tests {
         ShutdownSocketRequest, SocketConnectionStatus, SocketError, SocketStatusRequest,
         SocketStatusResponse, SocketType, TcpOptionName, TcpOptionValue,
     };
-    use crate::stdio::{StdioOutputStream, WriteStdioRequest, WriteStdioResponse};
+    use crate::stdio::{
+        ReadStdioRequest, ReadStdioResponse, StdioOutputStream, WriteStdioRequest,
+        WriteStdioResponse,
+    };
     use crate::{ObjectHandle, ProtocolVersion, RequestId};
     use core::net::{Ipv4Addr, SocketAddrV4};
 
@@ -506,6 +509,12 @@ mod tests {
                 slot_index: SharedBufferSlotIndex(7),
                 length: 256,
             }),
+            BrokerOperation::Stdio(StdioRequest::Read(ReadStdioRequest {
+                buffer: SharedBufferDescriptor {
+                    slot_index: SharedBufferSlotIndex(4),
+                    length: 31,
+                },
+            })),
             BrokerOperation::Stdio(StdioRequest::Write(WriteStdioRequest {
                 stream: StdioOutputStream::Stdout,
                 buffer: SharedBufferDescriptor {
@@ -854,6 +863,7 @@ mod tests {
             ))),
             BrokerResult::Socket(SocketResponse::Failed(SocketError::ConnectionReset)),
             BrokerResult::RandomFilled,
+            BrokerResult::Stdio(StdioResponse::Read(ReadStdioResponse { read: 11 })),
             BrokerResult::Stdio(StdioResponse::Write(WriteStdioResponse { written: 17 })),
             BrokerResult::Error(ErrorCode::PolicyDenied),
             BrokerResult::Error(ErrorCode::WouldBlock),
@@ -1014,6 +1024,20 @@ mod tests {
             decode_request(&frame[..frame.len() - 1]),
             Err(WireError::TruncatedFrame)
         );
+
+        let read = encode_request(BrokerRequest {
+            request_id: TEST_REQUEST_ID,
+            operation: BrokerOperation::Stdio(StdioRequest::Read(ReadStdioRequest {
+                buffer: SharedBufferDescriptor {
+                    slot_index: SharedBufferSlotIndex(1),
+                    length: 9,
+                },
+            })),
+        });
+        assert_eq!(
+            decode_request(&read[..read.len() - 1]),
+            Err(WireError::TruncatedFrame)
+        );
     }
 
     #[test]
@@ -1033,6 +1057,15 @@ mod tests {
         let frame = encode_response(response);
         assert_eq!(
             decode_response(&frame[..frame.len() - 1]),
+            Err(WireError::TruncatedFrame)
+        );
+
+        let read = encode_response(BrokerResponse {
+            request_id: TEST_REQUEST_ID,
+            result: BrokerResult::Stdio(StdioResponse::Read(ReadStdioResponse { read: 9 })),
+        });
+        assert_eq!(
+            decode_response(&read[..read.len() - 1]),
             Err(WireError::TruncatedFrame)
         );
     }

--- a/litebox_broker_protocol/src/wire/stdio.rs
+++ b/litebox_broker_protocol/src/wire/stdio.rs
@@ -11,10 +11,10 @@ use super::{
     primitive::{Decoder, Encoder},
 };
 
-const REQUEST_TAG_WRITE: u8 = 0;
-const REQUEST_TAG_READ: u8 = 1;
-const RESPONSE_TAG_WRITE: u8 = 0;
-const RESPONSE_TAG_READ: u8 = 1;
+const REQUEST_TAG_READ: u8 = 0;
+const REQUEST_TAG_WRITE: u8 = 1;
+const RESPONSE_TAG_READ: u8 = 0;
+const RESPONSE_TAG_WRITE: u8 = 1;
 
 const OUTPUT_STREAM_TAG_STDOUT: u8 = 0;
 const OUTPUT_STREAM_TAG_STDERR: u8 = 1;

--- a/litebox_broker_protocol/src/wire/stdio.rs
+++ b/litebox_broker_protocol/src/wire/stdio.rs
@@ -2,7 +2,9 @@
 // Licensed under the MIT license.
 
 use crate::message::{StdioRequest, StdioResponse};
-use crate::stdio::{StdioOutputStream, WriteStdioRequest, WriteStdioResponse};
+use crate::stdio::{
+    ReadStdioRequest, ReadStdioResponse, StdioOutputStream, WriteStdioRequest, WriteStdioResponse,
+};
 
 use super::{
     WireError,
@@ -10,13 +12,19 @@ use super::{
 };
 
 const REQUEST_TAG_WRITE: u8 = 0;
+const REQUEST_TAG_READ: u8 = 1;
 const RESPONSE_TAG_WRITE: u8 = 0;
+const RESPONSE_TAG_READ: u8 = 1;
 
 const OUTPUT_STREAM_TAG_STDOUT: u8 = 0;
 const OUTPUT_STREAM_TAG_STDERR: u8 = 1;
 
 pub(super) fn encode_stdio_request(encoder: &mut Encoder, request: StdioRequest) {
     match request {
+        StdioRequest::Read(request) => {
+            encoder.u8(REQUEST_TAG_READ);
+            encoder.shared_buffer_descriptor(request.buffer);
+        }
         StdioRequest::Write(request) => {
             encoder.u8(REQUEST_TAG_WRITE);
             encode_output_stream(encoder, request.stream);
@@ -27,6 +35,9 @@ pub(super) fn encode_stdio_request(encoder: &mut Encoder, request: StdioRequest)
 
 pub(super) fn decode_stdio_request(decoder: &mut Decoder<'_>) -> Result<StdioRequest, WireError> {
     match decoder.u8()? {
+        REQUEST_TAG_READ => Ok(StdioRequest::Read(ReadStdioRequest {
+            buffer: decoder.shared_buffer_descriptor()?,
+        })),
         REQUEST_TAG_WRITE => Ok(StdioRequest::Write(WriteStdioRequest {
             stream: decode_output_stream(decoder)?,
             buffer: decoder.shared_buffer_descriptor()?,
@@ -37,6 +48,10 @@ pub(super) fn decode_stdio_request(decoder: &mut Decoder<'_>) -> Result<StdioReq
 
 pub(super) fn encode_stdio_response(encoder: &mut Encoder, response: StdioResponse) {
     match response {
+        StdioResponse::Read(response) => {
+            encoder.u8(RESPONSE_TAG_READ);
+            encoder.u32(response.read);
+        }
         StdioResponse::Write(response) => {
             encoder.u8(RESPONSE_TAG_WRITE);
             encoder.u32(response.written);
@@ -46,6 +61,9 @@ pub(super) fn encode_stdio_response(encoder: &mut Encoder, response: StdioRespon
 
 pub(super) fn decode_stdio_response(decoder: &mut Decoder<'_>) -> Result<StdioResponse, WireError> {
     match decoder.u8()? {
+        RESPONSE_TAG_READ => Ok(StdioResponse::Read(ReadStdioResponse {
+            read: decoder.u32()?,
+        })),
         RESPONSE_TAG_WRITE => Ok(StdioResponse::Write(WriteStdioResponse {
             written: decoder.u32()?,
         })),

--- a/litebox_broker_userland/src/linux.rs
+++ b/litebox_broker_userland/src/linux.rs
@@ -81,7 +81,7 @@ pub(super) fn run(mut args: super::CliArgs) -> Result<(), Box<dyn Error>> {
             limits.max_sockets_per_session,
         )?),
         Arc::new(UserlandRandomProvider),
-        Arc::new(UserlandStdioProvider::new(super::WORKER_COUNT)?),
+        Arc::new(UserlandStdioProvider::new()?),
     )?;
 
     crate::run_runner_process(

--- a/litebox_broker_userland/src/linux.rs
+++ b/litebox_broker_userland/src/linux.rs
@@ -80,7 +80,7 @@ pub(super) fn run(mut args: super::CliArgs) -> Result<(), Box<dyn Error>> {
             limits.max_sockets_per_session,
         )?),
         Arc::new(super::UserlandRandomProvider),
-        Arc::new(super::UserlandStdioProvider),
+        Arc::new(super::UserlandStdioProvider::new()?),
     )?;
 
     crate::run_runner_process(

--- a/litebox_broker_userland/src/linux.rs
+++ b/litebox_broker_userland/src/linux.rs
@@ -26,6 +26,7 @@ use super::{
     HostAssociationShutdown, HostRequestSource, HostResponseSink, SETUP_TIMEOUT,
     configured_socket_policy,
 };
+use super::{random::UserlandRandomProvider, stdio::UserlandStdioProvider};
 
 const PROXY_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 
@@ -79,8 +80,8 @@ pub(super) fn run(mut args: super::CliArgs) -> Result<(), Box<dyn Error>> {
             limits.max_sockets,
             limits.max_sockets_per_session,
         )?),
-        Arc::new(super::UserlandRandomProvider),
-        Arc::new(super::UserlandStdioProvider::new()?),
+        Arc::new(UserlandRandomProvider),
+        Arc::new(UserlandStdioProvider::new(super::WORKER_COUNT)?),
     )?;
 
     crate::run_runner_process(

--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -893,40 +893,26 @@ mod tests {
         started: SyncSender<()>,
     }
 
+    impl BlockingStdioProvider {
+        fn block_until_cancelled(
+            &self,
+            cancellation: &AssociationCancellation,
+        ) -> Result<usize, StdioProviderError> {
+            self.started.send(()).unwrap();
+            while !cancellation.is_cancelled() {
+                std::thread::sleep(TEST_CANCELLATION_POLL_INTERVAL);
+            }
+            Err(StdioProviderError::Closed)
+        }
+    }
+
     impl StdioProvider for BlockingStdioProvider {
         fn read(
             &self,
             cancellation: &AssociationCancellation,
             _output: &mut [u8],
         ) -> Result<usize, StdioProviderError> {
-            self.started.send(()).unwrap();
-            while !cancellation.is_cancelled() {
-                std::thread::sleep(TEST_CANCELLATION_POLL_INTERVAL);
-            }
-            Err(StdioProviderError::Closed)
-        }
-
-        fn write(
-            &self,
-            _cancellation: &AssociationCancellation,
-            _stream: StdioOutputStream,
-            _input: &[u8],
-        ) -> Result<usize, StdioProviderError> {
-            Err(StdioProviderError::Unsupported)
-        }
-    }
-
-    struct BlockingWriteStdioProvider {
-        started: SyncSender<()>,
-    }
-
-    impl StdioProvider for BlockingWriteStdioProvider {
-        fn read(
-            &self,
-            _cancellation: &AssociationCancellation,
-            _output: &mut [u8],
-        ) -> Result<usize, StdioProviderError> {
-            Err(StdioProviderError::Unsupported)
+            self.block_until_cancelled(cancellation)
         }
 
         fn write(
@@ -935,11 +921,7 @@ mod tests {
             _stream: StdioOutputStream,
             _input: &[u8],
         ) -> Result<usize, StdioProviderError> {
-            self.started.send(()).unwrap();
-            while !cancellation.is_cancelled() {
-                std::thread::sleep(TEST_CANCELLATION_POLL_INTERVAL);
-            }
-            Err(StdioProviderError::Closed)
+            self.block_until_cancelled(cancellation)
         }
     }
 
@@ -1219,7 +1201,7 @@ mod tests {
     fn association_teardown_cancels_a_blocked_stdout_write() {
         let readiness = Arc::new(ReadinessPublisherRuntime::new());
         let (started_sender, started_receiver) = sync_channel(1);
-        let provider = Arc::new(BlockingWriteStdioProvider {
+        let provider = Arc::new(BlockingStdioProvider {
             started: started_sender,
         });
         let (local, notifications, shutdown, outcome, host) = spawn_dispatch(readiness, provider);

--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -18,10 +18,10 @@ use std::time::{Duration, Instant};
 
 use clap::Parser;
 use litebox_broker_core::random::{RandomProvider, RandomProviderError};
-use litebox_broker_core::stdio::{StdioProvider, StdioProviderError, StdioReadCancellation};
+use litebox_broker_core::stdio::{StdioProvider, StdioProviderError};
 use litebox_broker_core::{
-    BrokerCore, CallerCredential, DestinationPortRange, DestinationRule, Ipv4Cidr, SocketPolicy,
-    SocketPolicyError,
+    AssociationCancellation, BrokerCore, CallerCredential, DestinationPortRange, DestinationRule,
+    Ipv4Cidr, SocketPolicy, SocketPolicyError,
 };
 use litebox_broker_host::{BrokerHostAssociation, ConnectionTermination, setup_connection};
 use litebox_broker_protocol::message::{BrokerRequest, BrokerResponse};
@@ -41,7 +41,8 @@ mod windows;
 
 const SETUP_TIMEOUT: Duration = Duration::from_secs(5);
 const ACCEPT_RETRY_DELAY: Duration = Duration::from_millis(10);
-const STDIN_CANCEL_POLL_INTERVAL: Duration = Duration::from_millis(50);
+const STDIO_CANCEL_POLL_INTERVAL: Duration = Duration::from_millis(50);
+const STDIO_WRITE_RETRY_DELAY: Duration = Duration::from_millis(1);
 const REQUEST_QUEUE_CAPACITY: usize = 64;
 const REQUEST_QUEUE_RETRY_DELAY: Duration = Duration::from_millis(1);
 const REQUEST_QUEUE_STALL_TIMEOUT: Duration = Duration::from_secs(5);
@@ -62,6 +63,8 @@ impl RandomProvider for UserlandRandomProvider {
 /// endpoints instead of sharing process-wide standard streams.
 struct UserlandStdioProvider {
     stdin: Mutex<UserlandStdin>,
+    stdout: SyncSender<StdioWriteRequest>,
+    stderr: SyncSender<StdioWriteRequest>,
 }
 
 struct UserlandStdin {
@@ -76,18 +79,33 @@ enum StdinReadResult {
     Error(StdioProviderError),
 }
 
+struct StdioWriteRequest {
+    input: Vec<u8>,
+    completion: SyncSender<Result<usize, StdioProviderError>>,
+}
+
 impl UserlandStdioProvider {
     fn new() -> IoResult<Self> {
-        let (sender, receiver) = sync_channel(1);
+        let (stdin_sender, stdin_receiver) = sync_channel(1);
         std::thread::Builder::new()
             .name("litebox-broker-stdin".to_owned())
-            .spawn(move || pump_stdin(sender))?;
+            .spawn(move || pump_stdin(stdin_sender))?;
+        let (stdout, stdout_receiver) = sync_channel(WORKER_COUNT);
+        std::thread::Builder::new()
+            .name("litebox-broker-stdout".to_owned())
+            .spawn(move || pump_stdout(stdout_receiver))?;
+        let (stderr, stderr_receiver) = sync_channel(WORKER_COUNT);
+        std::thread::Builder::new()
+            .name("litebox-broker-stderr".to_owned())
+            .spawn(move || pump_stderr(stderr_receiver))?;
         Ok(Self {
             stdin: Mutex::new(UserlandStdin {
-                receiver,
+                receiver: stdin_receiver,
                 buffered: VecDeque::new(),
                 eof: false,
             }),
+            stdout,
+            stderr,
         })
     }
 }
@@ -95,7 +113,7 @@ impl UserlandStdioProvider {
 impl StdioProvider for UserlandStdioProvider {
     fn read(
         &self,
-        cancellation: &StdioReadCancellation,
+        cancellation: &AssociationCancellation,
         output: &mut [u8],
     ) -> Result<usize, StdioProviderError> {
         if output.is_empty() {
@@ -119,7 +137,7 @@ impl StdioProvider for UserlandStdioProvider {
             if stdin.eof {
                 return Ok(0);
             }
-            match stdin.receiver.recv_timeout(STDIN_CANCEL_POLL_INTERVAL) {
+            match stdin.receiver.recv_timeout(STDIO_CANCEL_POLL_INTERVAL) {
                 Ok(StdinReadResult::Data(data)) => stdin.buffered.extend(data),
                 Ok(StdinReadResult::Eof) => stdin.eof = true,
                 Ok(StdinReadResult::Error(error)) => return Err(error),
@@ -129,12 +147,46 @@ impl StdioProvider for UserlandStdioProvider {
         }
     }
 
-    fn write(&self, stream: StdioOutputStream, input: &[u8]) -> Result<usize, StdioProviderError> {
-        let result = match stream {
-            StdioOutputStream::Stdout => write_and_flush(std::io::stdout().lock(), input),
-            StdioOutputStream::Stderr => write_and_flush(std::io::stderr().lock(), input),
+    fn write(
+        &self,
+        cancellation: &AssociationCancellation,
+        stream: StdioOutputStream,
+        input: &[u8],
+    ) -> Result<usize, StdioProviderError> {
+        let sender = match stream {
+            StdioOutputStream::Stdout => &self.stdout,
+            StdioOutputStream::Stderr => &self.stderr,
         };
-        result.map_err(map_stdio_error)
+        let (completion, completed) = sync_channel(1);
+        let mut request = StdioWriteRequest {
+            input: input.to_vec(),
+            completion,
+        };
+        loop {
+            if cancellation.is_cancelled() {
+                return Err(StdioProviderError::Closed);
+            }
+            match sender.try_send(request) {
+                Ok(()) => break,
+                Err(TrySendError::Full(pending)) => request = pending,
+                Err(TrySendError::Disconnected(_)) => {
+                    return Err(StdioProviderError::Failed);
+                }
+            }
+            std::thread::sleep(STDIO_WRITE_RETRY_DELAY);
+        }
+        loop {
+            match completed.recv_timeout(STDIO_CANCEL_POLL_INTERVAL) {
+                Ok(result) => return result,
+                Err(RecvTimeoutError::Timeout) if cancellation.is_cancelled() => {
+                    return Err(StdioProviderError::Closed);
+                }
+                Err(RecvTimeoutError::Timeout) => {}
+                Err(RecvTimeoutError::Disconnected) => {
+                    return Err(StdioProviderError::Failed);
+                }
+            }
+        }
     }
 }
 
@@ -152,6 +204,21 @@ fn pump_stdin(sender: SyncSender<StdinReadResult>) {
         if sender.send(result).is_err() || finished {
             return;
         }
+    }
+}
+
+fn pump_stdout(receiver: Receiver<StdioWriteRequest>) {
+    pump_output(std::io::stdout(), receiver);
+}
+
+fn pump_stderr(receiver: Receiver<StdioWriteRequest>) {
+    pump_output(std::io::stderr(), receiver);
+}
+
+fn pump_output(mut output: impl std::io::Write, receiver: Receiver<StdioWriteRequest>) {
+    while let Ok(request) = receiver.recv() {
+        let result = write_and_flush(&mut output, &request.input).map_err(map_stdio_error);
+        let _ = request.completion.send(result);
     }
 }
 
@@ -751,13 +818,36 @@ fn main() {}
 mod cli_tests {
     use super::*;
 
+    #[derive(Default)]
+    struct RecordingOutput {
+        bytes: Arc<Mutex<Vec<u8>>>,
+        flushes: Arc<Mutex<usize>>,
+    }
+
+    impl std::io::Write for RecordingOutput {
+        fn write(&mut self, input: &[u8]) -> IoResult<usize> {
+            let written = input.len().min(3);
+            self.bytes.lock().unwrap().extend(&input[..written]);
+            Ok(written)
+        }
+
+        fn flush(&mut self) -> IoResult<()> {
+            *self.flushes.lock().unwrap() += 1;
+            Ok(())
+        }
+    }
+
     fn test_stdio_provider(receiver: Receiver<StdinReadResult>) -> UserlandStdioProvider {
+        let (stdout, _stdout_receiver) = sync_channel(1);
+        let (stderr, _stderr_receiver) = sync_channel(1);
         UserlandStdioProvider {
             stdin: Mutex::new(UserlandStdin {
                 receiver,
                 buffered: VecDeque::new(),
                 eof: false,
             }),
+            stdout,
+            stderr,
         }
     }
 
@@ -837,7 +927,7 @@ mod cli_tests {
             .unwrap();
         sender.send(StdinReadResult::Eof).unwrap();
         let provider = test_stdio_provider(receiver);
-        let cancellation = StdioReadCancellation::default();
+        let cancellation = AssociationCancellation::default();
 
         let mut first = [0xa5; 3];
         assert_eq!(provider.read(&cancellation, &mut first), Ok(3));
@@ -847,6 +937,43 @@ mod cli_tests {
         assert_eq!(provider.read(&cancellation, &mut second), Ok(2));
         assert_eq!(&second, b"ut\xa5\xa5");
         assert_eq!(provider.read(&cancellation, &mut second), Ok(0));
+    }
+
+    #[test]
+    fn stdio_provider_waits_for_output_write_and_flush() {
+        let bytes = Arc::new(Mutex::new(Vec::new()));
+        let flushes = Arc::new(Mutex::new(0));
+        let (stdout, stdout_receiver) = sync_channel(1);
+        let output = RecordingOutput {
+            bytes: Arc::clone(&bytes),
+            flushes: Arc::clone(&flushes),
+        };
+        let writer = std::thread::spawn(move || pump_output(output, stdout_receiver));
+        let (_stdin_sender, stdin_receiver) = sync_channel(1);
+        let (stderr, _stderr_receiver) = sync_channel(1);
+        let provider = UserlandStdioProvider {
+            stdin: Mutex::new(UserlandStdin {
+                receiver: stdin_receiver,
+                buffered: VecDeque::new(),
+                eof: false,
+            }),
+            stdout,
+            stderr,
+        };
+
+        assert_eq!(
+            provider.write(
+                &AssociationCancellation::default(),
+                StdioOutputStream::Stdout,
+                b"prompt",
+            ),
+            Ok(3)
+        );
+
+        drop(provider);
+        writer.join().unwrap();
+        assert_eq!(*bytes.lock().unwrap(), b"pro");
+        assert_eq!(*flushes.lock().unwrap(), 1);
     }
 }
 
@@ -1048,22 +1175,42 @@ mod tests {
     impl StdioProvider for BlockingStdioProvider {
         fn read(
             &self,
-            cancellation: &StdioReadCancellation,
+            cancellation: &AssociationCancellation,
             _output: &mut [u8],
         ) -> Result<usize, StdioProviderError> {
             self.started.send(()).unwrap();
             while !cancellation.is_cancelled() {
-                std::thread::sleep(STDIN_CANCEL_POLL_INTERVAL);
+                std::thread::sleep(STDIO_CANCEL_POLL_INTERVAL);
             }
             Err(StdioProviderError::Closed)
         }
 
         fn write(
             &self,
+            _cancellation: &AssociationCancellation,
             _stream: StdioOutputStream,
             _input: &[u8],
         ) -> Result<usize, StdioProviderError> {
             Err(StdioProviderError::Unsupported)
+        }
+    }
+
+    struct BlockingWriteStdioProvider {
+        started: SyncSender<()>,
+    }
+
+    impl StdioProvider for BlockingWriteStdioProvider {
+        fn write(
+            &self,
+            cancellation: &AssociationCancellation,
+            _stream: StdioOutputStream,
+            _input: &[u8],
+        ) -> Result<usize, StdioProviderError> {
+            self.started.send(()).unwrap();
+            while !cancellation.is_cancelled() {
+                std::thread::sleep(STDIO_CANCEL_POLL_INTERVAL);
+            }
+            Err(StdioProviderError::Closed)
         }
     }
 
@@ -1336,6 +1483,39 @@ mod tests {
             .expect("association teardown did not cancel the stdin read");
         assert!(dispatch_result.is_err());
         assert!(reader.join().unwrap().is_err());
+        host.join().unwrap();
+    }
+
+    #[test]
+    fn association_teardown_cancels_a_blocked_stdout_write() {
+        let readiness = Arc::new(ReadinessPublisherRuntime::new());
+        let (started_sender, started_receiver) = sync_channel(1);
+        let provider = Arc::new(BlockingWriteStdioProvider {
+            started: started_sender,
+        });
+        let (local, notifications, shutdown, outcome, host) = spawn_dispatch(readiness, provider);
+        let writer = std::thread::spawn(move || {
+            local.write_stdio(
+                StdioOutputStream::Stdout,
+                SharedBufferDescriptor {
+                    slot_index: SharedBufferSlotIndex(0),
+                    length: 1,
+                },
+                b"x",
+            )
+        });
+        started_receiver
+            .recv_timeout(SETUP_TIMEOUT)
+            .expect("broker stdout provider did not start writing");
+
+        shutdown.shutdown().unwrap();
+        drop(notifications);
+
+        let dispatch_result = outcome
+            .recv_timeout(SETUP_TIMEOUT)
+            .expect("association teardown did not cancel the stdout write");
+        assert!(dispatch_result.is_err());
+        assert!(writer.join().unwrap().is_err());
         host.join().unwrap();
     }
 }

--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -1,14 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+use std::collections::VecDeque;
 use std::error::Error;
 use std::ffi::{OsStr, OsString};
-use std::io::{Error as IoError, ErrorKind, Result as IoResult};
+use std::io::{Error as IoError, ErrorKind, Read as _, Result as IoResult};
 use std::net::Ipv4Addr;
 use std::path::PathBuf;
 use std::process::{Child, Command};
 use std::str::FromStr;
-use std::sync::mpsc::{Receiver, SyncSender, sync_channel};
+use std::sync::mpsc::{Receiver, RecvTimeoutError, SyncSender, TrySendError, sync_channel};
 use std::sync::{
     Arc, Mutex,
     atomic::{AtomicBool, Ordering},
@@ -17,7 +18,7 @@ use std::time::{Duration, Instant};
 
 use clap::Parser;
 use litebox_broker_core::random::{RandomProvider, RandomProviderError};
-use litebox_broker_core::stdio::{StdioProvider, StdioProviderError};
+use litebox_broker_core::stdio::{StdioProvider, StdioProviderError, StdioReadCancellation};
 use litebox_broker_core::{
     BrokerCore, CallerCredential, DestinationPortRange, DestinationRule, Ipv4Cidr, SocketPolicy,
     SocketPolicyError,
@@ -26,7 +27,7 @@ use litebox_broker_host::{BrokerHostAssociation, ConnectionTermination, setup_co
 use litebox_broker_protocol::message::{BrokerRequest, BrokerResponse};
 use litebox_broker_protocol::shared_buffer::SHARED_BUFFER_LAYOUT;
 use litebox_broker_protocol::socket::{Ipv4Address, Port};
-use litebox_broker_protocol::stdio::StdioOutputStream;
+use litebox_broker_protocol::stdio::{MAX_STDIO_TRANSFER_SIZE, StdioOutputStream};
 use litebox_broker_transport::channel::{HostNotificationChannel, HostReceive, HostSetupChannel};
 use litebox_broker_transport::control_ring::ControlRing;
 use litebox_broker_transport::shared_memory::{ControlRingMemory, SharedBufferPool, SharedMemory};
@@ -40,7 +41,10 @@ mod windows;
 
 const SETUP_TIMEOUT: Duration = Duration::from_secs(5);
 const ACCEPT_RETRY_DELAY: Duration = Duration::from_millis(10);
+const STDIN_CANCEL_POLL_INTERVAL: Duration = Duration::from_millis(50);
 const REQUEST_QUEUE_CAPACITY: usize = 64;
+const REQUEST_QUEUE_RETRY_DELAY: Duration = Duration::from_millis(1);
+const REQUEST_QUEUE_STALL_TIMEOUT: Duration = Duration::from_secs(5);
 const WORKER_COUNT: usize = 8;
 
 struct UserlandRandomProvider;
@@ -51,25 +55,111 @@ impl RandomProvider for UserlandRandomProvider {
     }
 }
 
-/// Routes output from the broker's single child runner to inherited streams.
+/// Routes standard I/O for the broker's single child runner through inherited
+/// streams.
 ///
-/// A broker serving multiple runners will need association-specific output
-/// destinations instead of sharing process-wide standard streams.
-struct UserlandStdioProvider;
+/// A broker serving multiple runners will need association-specific stream
+/// endpoints instead of sharing process-wide standard streams.
+struct UserlandStdioProvider {
+    stdin: Mutex<UserlandStdin>,
+}
+
+struct UserlandStdin {
+    receiver: Receiver<StdinReadResult>,
+    buffered: VecDeque<u8>,
+    eof: bool,
+}
+
+enum StdinReadResult {
+    Data(Vec<u8>),
+    Eof,
+    Error(StdioProviderError),
+}
+
+impl UserlandStdioProvider {
+    fn new() -> IoResult<Self> {
+        let (sender, receiver) = sync_channel(1);
+        std::thread::Builder::new()
+            .name("litebox-broker-stdin".to_owned())
+            .spawn(move || pump_stdin(sender))?;
+        Ok(Self {
+            stdin: Mutex::new(UserlandStdin {
+                receiver,
+                buffered: VecDeque::new(),
+                eof: false,
+            }),
+        })
+    }
+}
 
 impl StdioProvider for UserlandStdioProvider {
+    fn read(
+        &self,
+        cancellation: &StdioReadCancellation,
+        output: &mut [u8],
+    ) -> Result<usize, StdioProviderError> {
+        if output.is_empty() {
+            return Ok(0);
+        }
+        let mut stdin = self.stdin.lock().map_err(|_| StdioProviderError::Failed)?;
+        loop {
+            if cancellation.is_cancelled() {
+                return Err(StdioProviderError::Closed);
+            }
+            if !stdin.buffered.is_empty() {
+                let read = output.len().min(stdin.buffered.len());
+                for destination in &mut output[..read] {
+                    *destination = stdin
+                        .buffered
+                        .pop_front()
+                        .expect("buffered stdin length was checked");
+                }
+                return Ok(read);
+            }
+            if stdin.eof {
+                return Ok(0);
+            }
+            match stdin.receiver.recv_timeout(STDIN_CANCEL_POLL_INTERVAL) {
+                Ok(StdinReadResult::Data(data)) => stdin.buffered.extend(data),
+                Ok(StdinReadResult::Eof) => stdin.eof = true,
+                Ok(StdinReadResult::Error(error)) => return Err(error),
+                Err(RecvTimeoutError::Timeout) => {}
+                Err(RecvTimeoutError::Disconnected) => return Err(StdioProviderError::Failed),
+            }
+        }
+    }
+
     fn write(&self, stream: StdioOutputStream, input: &[u8]) -> Result<usize, StdioProviderError> {
         let result = match stream {
             StdioOutputStream::Stdout => write_and_flush(std::io::stdout().lock(), input),
             StdioOutputStream::Stderr => write_and_flush(std::io::stderr().lock(), input),
         };
-        result.map_err(|error| {
-            if error.kind() == ErrorKind::BrokenPipe {
-                StdioProviderError::Closed
-            } else {
-                StdioProviderError::Failed
-            }
-        })
+        result.map_err(map_stdio_error)
+    }
+}
+
+fn pump_stdin(sender: SyncSender<StdinReadResult>) {
+    let stdin = std::io::stdin();
+    let mut stdin = stdin.lock();
+    let mut buffer = vec![0; MAX_STDIO_TRANSFER_SIZE as usize];
+    loop {
+        let (result, finished) = match stdin.read(&mut buffer) {
+            Ok(0) => (StdinReadResult::Eof, true),
+            Ok(read) => (StdinReadResult::Data(buffer[..read].to_vec()), false),
+            Err(error) if error.kind() == ErrorKind::Interrupted => continue,
+            Err(error) => (StdinReadResult::Error(map_stdio_error(error)), true),
+        };
+        if sender.send(result).is_err() || finished {
+            return;
+        }
+    }
+}
+
+fn map_stdio_error(error: IoError) -> StdioProviderError {
+    if error.kind() == ErrorKind::BrokenPipe {
+        StdioProviderError::Closed
+    } else {
+        StdioProviderError::Failed
     }
 }
 
@@ -378,6 +468,17 @@ impl<Shutdown: HostAssociationShutdown> Drop for ReadinessPublicationGuard<'_, S
     }
 }
 
+/// Cancels blocking provider work before an association scope joins its workers.
+struct PendingRequestCancellationGuard<'association, 'memory, Memory: SharedMemory> {
+    association: &'association BrokerHostAssociation<'memory, Memory>,
+}
+
+impl<Memory: SharedMemory> Drop for PendingRequestCancellationGuard<'_, '_, Memory> {
+    fn drop(&mut self) {
+        self.association.cancel_pending_requests();
+    }
+}
+
 /// Serves one association until it ends, then reports its first failure.
 ///
 /// `readiness` is created by the caller rather than here so readiness sources
@@ -437,6 +538,9 @@ where
             readiness: &readiness,
             failure_coordinator: &failure_coordinator,
         };
+        let pending_requests = PendingRequestCancellationGuard {
+            association: &association,
+        };
 
         let mut workers = Vec::with_capacity(WORKER_COUNT);
         for worker_id in 0..WORKER_COUNT {
@@ -463,6 +567,7 @@ where
         }
 
         read_requests(&mut request_source, request_sender, &failure_coordinator);
+        drop(pending_requests);
         for worker in workers {
             if worker.join().is_err() {
                 failure_coordinator.report(IoError::other("broker request worker panicked"));
@@ -504,11 +609,12 @@ fn read_requests<RequestSource, Shutdown>(
         }
         match request_source.recv_request() {
             Ok(HostReceive::Message(request)) => {
-                if request_sender.send(request).is_err() {
-                    failure_coordinator.report(IoError::new(
-                        ErrorKind::BrokenPipe,
-                        "broker request workers stopped",
-                    ));
+                if !enqueue_request(
+                    &request_sender,
+                    request,
+                    failure_coordinator,
+                    REQUEST_QUEUE_STALL_TIMEOUT,
+                ) {
                     break;
                 }
             }
@@ -523,6 +629,44 @@ fn read_requests<RequestSource, Shutdown>(
             Err(error) => {
                 failure_coordinator.report(error);
                 break;
+            }
+        }
+    }
+}
+
+fn enqueue_request<Shutdown>(
+    request_sender: &SyncSender<BrokerRequest>,
+    mut request: BrokerRequest,
+    failure_coordinator: &HostAssociationFailureCoordinator<Shutdown>,
+    stall_timeout: Duration,
+) -> bool
+where
+    Shutdown: HostAssociationShutdown,
+{
+    let started = Instant::now();
+    loop {
+        match request_sender.try_send(request) {
+            Ok(()) => return true,
+            Err(TrySendError::Disconnected(_)) => {
+                failure_coordinator.report(IoError::new(
+                    ErrorKind::BrokenPipe,
+                    "broker request workers stopped",
+                ));
+                return false;
+            }
+            Err(TrySendError::Full(pending)) => {
+                request = pending;
+                if failure_coordinator.failed() {
+                    return false;
+                }
+                if started.elapsed() >= stall_timeout {
+                    failure_coordinator.report(IoError::new(
+                        ErrorKind::TimedOut,
+                        "broker request queue remained full",
+                    ));
+                    return false;
+                }
+                std::thread::sleep(REQUEST_QUEUE_RETRY_DELAY);
             }
         }
     }
@@ -607,6 +751,16 @@ fn main() {}
 mod cli_tests {
     use super::*;
 
+    fn test_stdio_provider(receiver: Receiver<StdinReadResult>) -> UserlandStdioProvider {
+        UserlandStdioProvider {
+            stdin: Mutex::new(UserlandStdin {
+                receiver,
+                buffered: VecDeque::new(),
+                eof: false,
+            }),
+        }
+    }
+
     #[test]
     fn cli_accepts_tcp_and_udp_destination_arguments() {
         let args = CliArgs::try_parse_from([
@@ -674,6 +828,26 @@ mod cli_tests {
             DestinationRule::new(CallerCredential::HostGuaranteed, udp.destination, udp.ports,)
         );
     }
+
+    #[test]
+    fn stdio_provider_preserves_partial_reads_and_eof() {
+        let (sender, receiver) = sync_channel(2);
+        sender
+            .send(StdinReadResult::Data(b"input".to_vec()))
+            .unwrap();
+        sender.send(StdinReadResult::Eof).unwrap();
+        let provider = test_stdio_provider(receiver);
+        let cancellation = StdioReadCancellation::default();
+
+        let mut first = [0xa5; 3];
+        assert_eq!(provider.read(&cancellation, &mut first), Ok(3));
+        assert_eq!(&first, b"inp");
+
+        let mut second = [0xa5; 4];
+        assert_eq!(provider.read(&cancellation, &mut second), Ok(2));
+        assert_eq!(&second, b"ut\xa5\xa5");
+        assert_eq!(provider.read(&cancellation, &mut second), Ok(0));
+    }
 }
 
 #[cfg(all(test, target_os = "linux"))]
@@ -682,15 +856,22 @@ mod tests {
     use std::os::fd::AsFd;
     use std::os::unix::net::UnixStream;
     use std::sync::Arc;
-    use std::sync::mpsc::{Receiver, sync_channel};
+    use std::sync::mpsc::{Receiver, SyncSender, sync_channel};
     use std::time::{Duration, Instant};
 
     use litebox_broker_core::socket::UnsupportedSocketProvider;
+    use litebox_broker_core::stdio::{StdioProvider, StdioProviderError, UnsupportedStdioProvider};
     use litebox_broker_core::{BrokerCore, ObjectRights, PolicyEngine};
     use litebox_broker_host::setup_connection;
     use litebox_broker_protocol::BROKER_PROTOCOL_VERSION;
-    use litebox_broker_protocol::message::{BrokerHandshakeResponse, BrokerNotification};
-    use litebox_broker_protocol::shared_buffer::{SHARED_BUFFER_LAYOUT, SHARED_BUFFER_POOL_SIZE};
+    use litebox_broker_protocol::RequestId;
+    use litebox_broker_protocol::message::{
+        BrokerHandshakeResponse, BrokerNotification, BrokerOperation,
+    };
+    use litebox_broker_protocol::shared_buffer::{
+        SHARED_BUFFER_LAYOUT, SHARED_BUFFER_POOL_SIZE, SharedBufferDescriptor,
+        SharedBufferSlotIndex,
+    };
     use litebox_broker_transport::channel::{
         HostNotificationChannel, HostReceive, HostSetupChannel, LocalSetupChannel,
     };
@@ -767,8 +948,9 @@ mod tests {
     ) -> (
         litebox_broker_local::BrokerLocal<UnixControlRingLocalCallChannel>,
         UnixControlRingLocalNotificationChannel,
+        UnixControlRingLocalShutdown,
     ) {
-        litebox_broker_local::BrokerLocal::negotiate(
+        let (local, (notifications, shutdown)) = litebox_broker_local::BrokerLocal::negotiate(
             UnixStreamLocalSetupChannel::from_connected(stream),
             |mut setup| {
                 let shared_memory = setup.receive_memfd(SHARED_BUFFER_POOL_SIZE, None)?;
@@ -779,12 +961,17 @@ mod tests {
                         format!("invalid test control ring: {error:?}"),
                     )
                 })?;
-                let (call_channel, notifications, _shutdown) =
+                let (call_channel, notifications, shutdown) =
                     setup.into_active(control_ring, || {})?;
-                Ok((call_channel, Arc::new(shared_memory), notifications))
+                Ok((
+                    call_channel,
+                    Arc::new(shared_memory),
+                    (notifications, shutdown),
+                ))
             },
         )
-        .unwrap()
+        .unwrap();
+        (local, notifications, shutdown)
     }
 
     /// One association served by `dispatch_requests` exactly as production serves it.
@@ -795,9 +982,11 @@ mod tests {
     /// publisher that fails immediately cannot race activation.
     fn spawn_dispatch(
         readiness: Arc<ReadinessPublisherRuntime>,
+        stdio_provider: Arc<dyn StdioProvider>,
     ) -> (
         litebox_broker_local::BrokerLocal<UnixControlRingLocalCallChannel>,
         UnixControlRingLocalNotificationChannel,
+        UnixControlRingLocalShutdown,
         Receiver<IoResult<()>>,
         std::thread::JoinHandle<()>,
     ) {
@@ -809,7 +998,7 @@ mod tests {
                 PolicyEngine::with_host_guaranteed_rights(ObjectRights::all()),
                 Arc::new(UnsupportedSocketProvider),
                 Arc::new(UserlandRandomProvider),
-                Arc::new(UserlandStdioProvider),
+                stdio_provider,
             )
             .unwrap();
             let shared_memory = MemfdSharedMemory::create(SHARED_BUFFER_POOL_SIZE).unwrap();
@@ -847,9 +1036,44 @@ mod tests {
                 ))
                 .unwrap();
         });
-        let (local, notifications) = negotiate_local(local_stream);
+        let (local, notifications, shutdown) = negotiate_local(local_stream);
         start.send(()).unwrap();
-        (local, notifications, outcome, host)
+        (local, notifications, shutdown, outcome, host)
+    }
+
+    struct BlockingStdioProvider {
+        started: SyncSender<()>,
+    }
+
+    impl StdioProvider for BlockingStdioProvider {
+        fn read(
+            &self,
+            cancellation: &StdioReadCancellation,
+            _output: &mut [u8],
+        ) -> Result<usize, StdioProviderError> {
+            self.started.send(()).unwrap();
+            while !cancellation.is_cancelled() {
+                std::thread::sleep(STDIN_CANCEL_POLL_INTERVAL);
+            }
+            Err(StdioProviderError::Closed)
+        }
+
+        fn write(
+            &self,
+            _stream: StdioOutputStream,
+            _input: &[u8],
+        ) -> Result<usize, StdioProviderError> {
+            Err(StdioProviderError::Unsupported)
+        }
+    }
+
+    struct RecordingShutdown(Arc<AtomicBool>);
+
+    impl HostAssociationShutdown for RecordingShutdown {
+        fn shutdown(&self) -> IoResult<()> {
+            self.0.store(true, Ordering::Release);
+            Ok(())
+        }
     }
 
     #[test]
@@ -988,6 +1212,35 @@ mod tests {
     }
 
     #[test]
+    fn a_stalled_request_queue_fails_after_its_deadline() {
+        let request = |request_id| BrokerRequest {
+            request_id: RequestId(request_id),
+            operation: BrokerOperation::FillRandom(SharedBufferDescriptor {
+                slot_index: SharedBufferSlotIndex(0),
+                length: 1,
+            }),
+        };
+        let shutdown_called = Arc::new(AtomicBool::new(false));
+        let failure_coordinator =
+            HostAssociationFailureCoordinator::new(RecordingShutdown(Arc::clone(&shutdown_called)));
+        let (request_sender, _request_receiver) = sync_channel(1);
+        request_sender.send(request(1)).unwrap();
+
+        assert!(!enqueue_request(
+            &request_sender,
+            request(2),
+            &failure_coordinator,
+            Duration::ZERO,
+        ));
+
+        assert!(shutdown_called.load(Ordering::Acquire));
+        assert_eq!(
+            failure_coordinator.take_error().unwrap().kind(),
+            ErrorKind::TimedOut
+        );
+    }
+
+    #[test]
     fn dispatching_requests_publishes_readiness_until_the_association_ends() {
         use litebox_broker_protocol::ObjectHandle;
         use litebox_broker_protocol::message::ReadinessNotification;
@@ -997,7 +1250,8 @@ mod tests {
         const HANDLE: ObjectHandle = ObjectHandle(11);
         let expected = ReadinessFlags::READ | ReadinessFlags::WRITE;
         let readiness = Arc::new(ReadinessPublisherRuntime::new());
-        let (local, mut notifications, outcome, host) = spawn_dispatch(Arc::clone(&readiness));
+        let (local, mut notifications, _shutdown, outcome, host) =
+            spawn_dispatch(Arc::clone(&readiness), Arc::new(UnsupportedStdioProvider));
 
         readiness.publish(HANDLE, expected).unwrap();
 
@@ -1042,13 +1296,46 @@ mod tests {
 
         // The local half stays connected and idle, so nothing but the panic can
         // release the request reader that owns association termination.
-        let (local, _notifications, outcome, host) = spawn_dispatch(Arc::clone(&readiness));
+        let (local, _notifications, _shutdown, outcome, host) =
+            spawn_dispatch(Arc::clone(&readiness), Arc::new(UnsupportedStdioProvider));
         let error = outcome
             .recv_timeout(SETUP_TIMEOUT)
             .expect("a panicking publisher must end dispatch")
             .expect_err("a panicking publisher must fail the association");
         assert_eq!(error.to_string(), "broker readiness publisher panicked");
         drop(local);
+        host.join().unwrap();
+    }
+
+    #[test]
+    fn association_teardown_cancels_a_blocked_stdin_read() {
+        let readiness = Arc::new(ReadinessPublisherRuntime::new());
+        let (started_sender, started_receiver) = sync_channel(1);
+        let provider = Arc::new(BlockingStdioProvider {
+            started: started_sender,
+        });
+        let (local, notifications, shutdown, outcome, host) = spawn_dispatch(readiness, provider);
+        let reader = std::thread::spawn(move || {
+            local.read_stdio(
+                SharedBufferDescriptor {
+                    slot_index: SharedBufferSlotIndex(0),
+                    length: 1,
+                },
+                &mut [0],
+            )
+        });
+        started_receiver
+            .recv_timeout(SETUP_TIMEOUT)
+            .expect("broker stdin provider did not start reading");
+
+        shutdown.shutdown().unwrap();
+        drop(notifications);
+
+        let dispatch_result = outcome
+            .recv_timeout(SETUP_TIMEOUT)
+            .expect("association teardown did not cancel the stdin read");
+        assert!(dispatch_result.is_err());
+        assert!(reader.join().unwrap().is_err());
         host.join().unwrap();
     }
 }

--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -1200,6 +1200,14 @@ mod tests {
     }
 
     impl StdioProvider for BlockingWriteStdioProvider {
+        fn read(
+            &self,
+            _cancellation: &AssociationCancellation,
+            _output: &mut [u8],
+        ) -> Result<usize, StdioProviderError> {
+            Err(StdioProviderError::Unsupported)
+        }
+
         fn write(
             &self,
             cancellation: &AssociationCancellation,

--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -535,14 +535,14 @@ impl<Shutdown: HostAssociationShutdown> Drop for ReadinessPublicationGuard<'_, S
     }
 }
 
-/// Cancels blocking provider work before an association scope joins its workers.
-struct PendingRequestCancellationGuard<'association, 'memory, Memory: SharedMemory> {
+/// Requests cancellation before an association scope joins its workers.
+struct AssociationCancellationGuard<'association, 'memory, Memory: SharedMemory> {
     association: &'association BrokerHostAssociation<'memory, Memory>,
 }
 
-impl<Memory: SharedMemory> Drop for PendingRequestCancellationGuard<'_, '_, Memory> {
+impl<Memory: SharedMemory> Drop for AssociationCancellationGuard<'_, '_, Memory> {
     fn drop(&mut self) {
-        self.association.cancel_pending_requests();
+        self.association.request_cancellation();
     }
 }
 
@@ -605,7 +605,7 @@ where
             readiness: &readiness,
             failure_coordinator: &failure_coordinator,
         };
-        let pending_requests = PendingRequestCancellationGuard {
+        let cancellation = AssociationCancellationGuard {
             association: &association,
         };
 
@@ -634,7 +634,7 @@ where
         }
 
         read_requests(&mut request_source, request_sender, &failure_coordinator);
-        drop(pending_requests);
+        drop(cancellation);
         for worker in workers {
             if worker.join().is_err() {
                 failure_coordinator.report(IoError::other("broker request worker panicked"));

--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -1,15 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-use std::collections::VecDeque;
 use std::error::Error;
 use std::ffi::{OsStr, OsString};
-use std::io::{Error as IoError, ErrorKind, Read as _, Result as IoResult};
+use std::io::{Error as IoError, ErrorKind, Result as IoResult};
 use std::net::Ipv4Addr;
 use std::path::PathBuf;
 use std::process::{Child, Command};
 use std::str::FromStr;
-use std::sync::mpsc::{Receiver, RecvTimeoutError, SyncSender, TrySendError, sync_channel};
+use std::sync::mpsc::{Receiver, SyncSender, TrySendError, sync_channel};
 use std::sync::{
     Arc, Mutex,
     atomic::{AtomicBool, Ordering},
@@ -17,17 +16,14 @@ use std::sync::{
 use std::time::{Duration, Instant};
 
 use clap::Parser;
-use litebox_broker_core::random::{RandomProvider, RandomProviderError};
-use litebox_broker_core::stdio::{StdioProvider, StdioProviderError};
 use litebox_broker_core::{
-    AssociationCancellation, BrokerCore, CallerCredential, DestinationPortRange, DestinationRule,
-    Ipv4Cidr, SocketPolicy, SocketPolicyError,
+    BrokerCore, CallerCredential, DestinationPortRange, DestinationRule, Ipv4Cidr, SocketPolicy,
+    SocketPolicyError,
 };
 use litebox_broker_host::{BrokerHostAssociation, ConnectionTermination, setup_connection};
 use litebox_broker_protocol::message::{BrokerRequest, BrokerResponse};
 use litebox_broker_protocol::shared_buffer::SHARED_BUFFER_LAYOUT;
 use litebox_broker_protocol::socket::{Ipv4Address, Port};
-use litebox_broker_protocol::stdio::{MAX_STDIO_TRANSFER_SIZE, StdioOutputStream};
 use litebox_broker_transport::channel::{HostNotificationChannel, HostReceive, HostSetupChannel};
 use litebox_broker_transport::control_ring::ControlRing;
 use litebox_broker_transport::shared_memory::{ControlRingMemory, SharedBufferPool, SharedMemory};
@@ -36,205 +32,17 @@ use litebox_broker_userland::readiness::ReadinessPublisherRuntime;
 
 #[cfg(target_os = "linux")]
 mod linux;
+mod random;
+mod stdio;
 #[cfg(all(windows, target_arch = "x86_64"))]
 mod windows;
 
 const SETUP_TIMEOUT: Duration = Duration::from_secs(5);
 const ACCEPT_RETRY_DELAY: Duration = Duration::from_millis(10);
-const STDIO_CANCEL_POLL_INTERVAL: Duration = Duration::from_millis(50);
-const STDIO_WRITE_RETRY_DELAY: Duration = Duration::from_millis(1);
 const REQUEST_QUEUE_CAPACITY: usize = 64;
 const REQUEST_QUEUE_RETRY_DELAY: Duration = Duration::from_millis(1);
 const REQUEST_QUEUE_STALL_TIMEOUT: Duration = Duration::from_secs(5);
 const WORKER_COUNT: usize = 8;
-
-struct UserlandRandomProvider;
-
-impl RandomProvider for UserlandRandomProvider {
-    fn fill(&self, output: &mut [u8]) -> Result<(), RandomProviderError> {
-        getrandom::fill(output).map_err(|_| RandomProviderError)
-    }
-}
-
-/// Routes standard I/O for the broker's single child runner through inherited
-/// streams.
-///
-/// A broker serving multiple runners will need association-specific stream
-/// endpoints instead of sharing process-wide standard streams.
-struct UserlandStdioProvider {
-    stdin: Mutex<UserlandStdin>,
-    stdout: SyncSender<StdioWriteRequest>,
-    stderr: SyncSender<StdioWriteRequest>,
-}
-
-struct UserlandStdin {
-    receiver: Receiver<StdinReadResult>,
-    buffered: VecDeque<u8>,
-    eof: bool,
-}
-
-enum StdinReadResult {
-    Data(Vec<u8>),
-    Eof,
-    Error(StdioProviderError),
-}
-
-struct StdioWriteRequest {
-    input: Vec<u8>,
-    completion: SyncSender<Result<usize, StdioProviderError>>,
-}
-
-impl UserlandStdioProvider {
-    fn new() -> IoResult<Self> {
-        let (stdin_sender, stdin_receiver) = sync_channel(1);
-        std::thread::Builder::new()
-            .name("litebox-broker-stdin".to_owned())
-            .spawn(move || pump_stdin(stdin_sender))?;
-        let (stdout, stdout_receiver) = sync_channel(WORKER_COUNT);
-        std::thread::Builder::new()
-            .name("litebox-broker-stdout".to_owned())
-            .spawn(move || pump_stdout(stdout_receiver))?;
-        let (stderr, stderr_receiver) = sync_channel(WORKER_COUNT);
-        std::thread::Builder::new()
-            .name("litebox-broker-stderr".to_owned())
-            .spawn(move || pump_stderr(stderr_receiver))?;
-        Ok(Self {
-            stdin: Mutex::new(UserlandStdin {
-                receiver: stdin_receiver,
-                buffered: VecDeque::new(),
-                eof: false,
-            }),
-            stdout,
-            stderr,
-        })
-    }
-}
-
-impl StdioProvider for UserlandStdioProvider {
-    fn read(
-        &self,
-        cancellation: &AssociationCancellation,
-        output: &mut [u8],
-    ) -> Result<usize, StdioProviderError> {
-        if output.is_empty() {
-            return Ok(0);
-        }
-        let mut stdin = self.stdin.lock().map_err(|_| StdioProviderError::Failed)?;
-        loop {
-            if cancellation.is_cancelled() {
-                return Err(StdioProviderError::Closed);
-            }
-            if !stdin.buffered.is_empty() {
-                let read = output.len().min(stdin.buffered.len());
-                for destination in &mut output[..read] {
-                    *destination = stdin
-                        .buffered
-                        .pop_front()
-                        .expect("buffered stdin length was checked");
-                }
-                return Ok(read);
-            }
-            if stdin.eof {
-                return Ok(0);
-            }
-            match stdin.receiver.recv_timeout(STDIO_CANCEL_POLL_INTERVAL) {
-                Ok(StdinReadResult::Data(data)) => stdin.buffered.extend(data),
-                Ok(StdinReadResult::Eof) => stdin.eof = true,
-                Ok(StdinReadResult::Error(error)) => return Err(error),
-                Err(RecvTimeoutError::Timeout) => {}
-                Err(RecvTimeoutError::Disconnected) => return Err(StdioProviderError::Failed),
-            }
-        }
-    }
-
-    fn write(
-        &self,
-        cancellation: &AssociationCancellation,
-        stream: StdioOutputStream,
-        input: &[u8],
-    ) -> Result<usize, StdioProviderError> {
-        let sender = match stream {
-            StdioOutputStream::Stdout => &self.stdout,
-            StdioOutputStream::Stderr => &self.stderr,
-        };
-        let (completion, completed) = sync_channel(1);
-        let mut request = StdioWriteRequest {
-            input: input.to_vec(),
-            completion,
-        };
-        loop {
-            if cancellation.is_cancelled() {
-                return Err(StdioProviderError::Closed);
-            }
-            match sender.try_send(request) {
-                Ok(()) => break,
-                Err(TrySendError::Full(pending)) => request = pending,
-                Err(TrySendError::Disconnected(_)) => {
-                    return Err(StdioProviderError::Failed);
-                }
-            }
-            std::thread::sleep(STDIO_WRITE_RETRY_DELAY);
-        }
-        loop {
-            match completed.recv_timeout(STDIO_CANCEL_POLL_INTERVAL) {
-                Ok(result) => return result,
-                Err(RecvTimeoutError::Timeout) if cancellation.is_cancelled() => {
-                    return Err(StdioProviderError::Closed);
-                }
-                Err(RecvTimeoutError::Timeout) => {}
-                Err(RecvTimeoutError::Disconnected) => {
-                    return Err(StdioProviderError::Failed);
-                }
-            }
-        }
-    }
-}
-
-fn pump_stdin(sender: SyncSender<StdinReadResult>) {
-    let stdin = std::io::stdin();
-    let mut stdin = stdin.lock();
-    let mut buffer = vec![0; MAX_STDIO_TRANSFER_SIZE as usize];
-    loop {
-        let (result, finished) = match stdin.read(&mut buffer) {
-            Ok(0) => (StdinReadResult::Eof, true),
-            Ok(read) => (StdinReadResult::Data(buffer[..read].to_vec()), false),
-            Err(error) if error.kind() == ErrorKind::Interrupted => continue,
-            Err(error) => (StdinReadResult::Error(map_stdio_error(error)), true),
-        };
-        if sender.send(result).is_err() || finished {
-            return;
-        }
-    }
-}
-
-fn pump_stdout(receiver: Receiver<StdioWriteRequest>) {
-    pump_output(std::io::stdout(), receiver);
-}
-
-fn pump_stderr(receiver: Receiver<StdioWriteRequest>) {
-    pump_output(std::io::stderr(), receiver);
-}
-
-fn pump_output(mut output: impl std::io::Write, receiver: Receiver<StdioWriteRequest>) {
-    while let Ok(request) = receiver.recv() {
-        let result = write_and_flush(&mut output, &request.input).map_err(map_stdio_error);
-        let _ = request.completion.send(result);
-    }
-}
-
-fn map_stdio_error(error: IoError) -> StdioProviderError {
-    if error.kind() == ErrorKind::BrokenPipe {
-        StdioProviderError::Closed
-    } else {
-        StdioProviderError::Failed
-    }
-}
-
-fn write_and_flush(mut output: impl std::io::Write, input: &[u8]) -> IoResult<usize> {
-    let written = output.write(input)?;
-    output.flush()?;
-    Ok(written)
-}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct AllowedDestination {
@@ -818,39 +626,6 @@ fn main() {}
 mod cli_tests {
     use super::*;
 
-    #[derive(Default)]
-    struct RecordingOutput {
-        bytes: Arc<Mutex<Vec<u8>>>,
-        flushes: Arc<Mutex<usize>>,
-    }
-
-    impl std::io::Write for RecordingOutput {
-        fn write(&mut self, input: &[u8]) -> IoResult<usize> {
-            let written = input.len().min(3);
-            self.bytes.lock().unwrap().extend(&input[..written]);
-            Ok(written)
-        }
-
-        fn flush(&mut self) -> IoResult<()> {
-            *self.flushes.lock().unwrap() += 1;
-            Ok(())
-        }
-    }
-
-    fn test_stdio_provider(receiver: Receiver<StdinReadResult>) -> UserlandStdioProvider {
-        let (stdout, _stdout_receiver) = sync_channel(1);
-        let (stderr, _stderr_receiver) = sync_channel(1);
-        UserlandStdioProvider {
-            stdin: Mutex::new(UserlandStdin {
-                receiver,
-                buffered: VecDeque::new(),
-                eof: false,
-            }),
-            stdout,
-            stderr,
-        }
-    }
-
     #[test]
     fn cli_accepts_tcp_and_udp_destination_arguments() {
         let args = CliArgs::try_parse_from([
@@ -918,63 +693,6 @@ mod cli_tests {
             DestinationRule::new(CallerCredential::HostGuaranteed, udp.destination, udp.ports,)
         );
     }
-
-    #[test]
-    fn stdio_provider_preserves_partial_reads_and_eof() {
-        let (sender, receiver) = sync_channel(2);
-        sender
-            .send(StdinReadResult::Data(b"input".to_vec()))
-            .unwrap();
-        sender.send(StdinReadResult::Eof).unwrap();
-        let provider = test_stdio_provider(receiver);
-        let cancellation = AssociationCancellation::default();
-
-        let mut first = [0xa5; 3];
-        assert_eq!(provider.read(&cancellation, &mut first), Ok(3));
-        assert_eq!(&first, b"inp");
-
-        let mut second = [0xa5; 4];
-        assert_eq!(provider.read(&cancellation, &mut second), Ok(2));
-        assert_eq!(&second, b"ut\xa5\xa5");
-        assert_eq!(provider.read(&cancellation, &mut second), Ok(0));
-    }
-
-    #[test]
-    fn stdio_provider_waits_for_output_write_and_flush() {
-        let bytes = Arc::new(Mutex::new(Vec::new()));
-        let flushes = Arc::new(Mutex::new(0));
-        let (stdout, stdout_receiver) = sync_channel(1);
-        let output = RecordingOutput {
-            bytes: Arc::clone(&bytes),
-            flushes: Arc::clone(&flushes),
-        };
-        let writer = std::thread::spawn(move || pump_output(output, stdout_receiver));
-        let (_stdin_sender, stdin_receiver) = sync_channel(1);
-        let (stderr, _stderr_receiver) = sync_channel(1);
-        let provider = UserlandStdioProvider {
-            stdin: Mutex::new(UserlandStdin {
-                receiver: stdin_receiver,
-                buffered: VecDeque::new(),
-                eof: false,
-            }),
-            stdout,
-            stderr,
-        };
-
-        assert_eq!(
-            provider.write(
-                &AssociationCancellation::default(),
-                StdioOutputStream::Stdout,
-                b"prompt",
-            ),
-            Ok(3)
-        );
-
-        drop(provider);
-        writer.join().unwrap();
-        assert_eq!(*bytes.lock().unwrap(), b"pro");
-        assert_eq!(*flushes.lock().unwrap(), 1);
-    }
 }
 
 #[cfg(all(test, target_os = "linux"))]
@@ -988,7 +706,7 @@ mod tests {
 
     use litebox_broker_core::socket::UnsupportedSocketProvider;
     use litebox_broker_core::stdio::{StdioProvider, StdioProviderError, UnsupportedStdioProvider};
-    use litebox_broker_core::{BrokerCore, ObjectRights, PolicyEngine};
+    use litebox_broker_core::{AssociationCancellation, BrokerCore, ObjectRights, PolicyEngine};
     use litebox_broker_host::setup_connection;
     use litebox_broker_protocol::BROKER_PROTOCOL_VERSION;
     use litebox_broker_protocol::RequestId;
@@ -999,6 +717,7 @@ mod tests {
         SHARED_BUFFER_LAYOUT, SHARED_BUFFER_POOL_SIZE, SharedBufferDescriptor,
         SharedBufferSlotIndex,
     };
+    use litebox_broker_protocol::stdio::StdioOutputStream;
     use litebox_broker_transport::channel::{
         HostNotificationChannel, HostReceive, HostSetupChannel, LocalSetupChannel,
     };
@@ -1013,6 +732,8 @@ mod tests {
     };
 
     use super::*;
+
+    const TEST_CANCELLATION_POLL_INTERVAL: Duration = Duration::from_millis(10);
 
     /// One live host association: the endpoints teardown acts on, and the rest
     /// held open so the association stays up for the duration of a test.
@@ -1124,7 +845,7 @@ mod tests {
             let broker = BrokerCore::new(
                 PolicyEngine::with_host_guaranteed_rights(ObjectRights::all()),
                 Arc::new(UnsupportedSocketProvider),
-                Arc::new(UserlandRandomProvider),
+                Arc::new(random::UserlandRandomProvider),
                 stdio_provider,
             )
             .unwrap();
@@ -1180,7 +901,7 @@ mod tests {
         ) -> Result<usize, StdioProviderError> {
             self.started.send(()).unwrap();
             while !cancellation.is_cancelled() {
-                std::thread::sleep(STDIO_CANCEL_POLL_INTERVAL);
+                std::thread::sleep(TEST_CANCELLATION_POLL_INTERVAL);
             }
             Err(StdioProviderError::Closed)
         }
@@ -1216,7 +937,7 @@ mod tests {
         ) -> Result<usize, StdioProviderError> {
             self.started.send(()).unwrap();
             while !cancellation.is_cancelled() {
-                std::thread::sleep(STDIO_CANCEL_POLL_INTERVAL);
+                std::thread::sleep(TEST_CANCELLATION_POLL_INTERVAL);
             }
             Err(StdioProviderError::Closed)
         }

--- a/litebox_broker_userland/src/random.rs
+++ b/litebox_broker_userland/src/random.rs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+use litebox_broker_core::random::{RandomProvider, RandomProviderError};
+
+pub(super) struct UserlandRandomProvider;
+
+impl RandomProvider for UserlandRandomProvider {
+    fn fill(&self, output: &mut [u8]) -> Result<(), RandomProviderError> {
+        getrandom::fill(output).map_err(|_| RandomProviderError)
+    }
+}

--- a/litebox_broker_userland/src/stdio.rs
+++ b/litebox_broker_userland/src/stdio.rs
@@ -20,12 +20,12 @@ const WRITE_RETRY_DELAY: Duration = Duration::from_millis(1);
 /// A broker serving multiple runners will need association-specific stream
 /// endpoints instead of sharing process-wide standard streams.
 pub(super) struct UserlandStdioProvider {
-    stdin: Mutex<UserlandStdin>,
-    stdout: SyncSender<StdioWriteRequest>,
-    stderr: SyncSender<StdioWriteRequest>,
+    stdin: Mutex<StdinState>,
+    stdout: SyncSender<StdioWriteOperation>,
+    stderr: SyncSender<StdioWriteOperation>,
 }
 
-struct UserlandStdin {
+struct StdinState {
     receiver: Receiver<StdinReadResult>,
     buffered: VecDeque<u8>,
     eof: bool,
@@ -37,27 +37,27 @@ enum StdinReadResult {
     Error(StdioProviderError),
 }
 
-struct StdioWriteRequest {
+struct StdioWriteOperation {
     input: Vec<u8>,
     completion: SyncSender<Result<usize, StdioProviderError>>,
 }
 
 impl UserlandStdioProvider {
-    pub(super) fn new(max_concurrent_writes: usize) -> IoResult<Self> {
+    pub(super) fn new() -> IoResult<Self> {
         let (stdin_sender, stdin_receiver) = sync_channel(1);
         std::thread::Builder::new()
             .name("litebox-broker-stdin".to_owned())
             .spawn(move || pump_stdin(stdin_sender))?;
-        let (stdout, stdout_receiver) = sync_channel(max_concurrent_writes);
+        let (stdout, stdout_receiver) = sync_channel(super::WORKER_COUNT);
         std::thread::Builder::new()
             .name("litebox-broker-stdout".to_owned())
             .spawn(move || pump_stdout(stdout_receiver))?;
-        let (stderr, stderr_receiver) = sync_channel(max_concurrent_writes);
+        let (stderr, stderr_receiver) = sync_channel(super::WORKER_COUNT);
         std::thread::Builder::new()
             .name("litebox-broker-stderr".to_owned())
             .spawn(move || pump_stderr(stderr_receiver))?;
         Ok(Self {
-            stdin: Mutex::new(UserlandStdin {
+            stdin: Mutex::new(StdinState {
                 receiver: stdin_receiver,
                 buffered: VecDeque::new(),
                 eof: false,
@@ -116,7 +116,7 @@ impl StdioProvider for UserlandStdioProvider {
             StdioOutputStream::Stderr => &self.stderr,
         };
         let (completion, completed) = sync_channel(1);
-        let mut request = StdioWriteRequest {
+        let mut request = StdioWriteOperation {
             input: input.to_vec(),
             completion,
         };
@@ -165,15 +165,15 @@ fn pump_stdin(sender: SyncSender<StdinReadResult>) {
     }
 }
 
-fn pump_stdout(receiver: Receiver<StdioWriteRequest>) {
+fn pump_stdout(receiver: Receiver<StdioWriteOperation>) {
     pump_output(std::io::stdout(), receiver);
 }
 
-fn pump_stderr(receiver: Receiver<StdioWriteRequest>) {
+fn pump_stderr(receiver: Receiver<StdioWriteOperation>) {
     pump_output(std::io::stderr(), receiver);
 }
 
-fn pump_output(mut output: impl std::io::Write, receiver: Receiver<StdioWriteRequest>) {
+fn pump_output(mut output: impl std::io::Write, receiver: Receiver<StdioWriteOperation>) {
     while let Ok(request) = receiver.recv() {
         let result = write_and_flush(&mut output, &request.input).map_err(map_stdio_error);
         let _ = request.completion.send(result);
@@ -223,7 +223,7 @@ mod tests {
         let (stdout, _stdout_receiver) = sync_channel(1);
         let (stderr, _stderr_receiver) = sync_channel(1);
         UserlandStdioProvider {
-            stdin: Mutex::new(UserlandStdin {
+            stdin: Mutex::new(StdinState {
                 receiver,
                 buffered: VecDeque::new(),
                 eof: false,
@@ -266,7 +266,7 @@ mod tests {
         let (_stdin_sender, stdin_receiver) = sync_channel(1);
         let (stderr, _stderr_receiver) = sync_channel(1);
         let provider = UserlandStdioProvider {
-            stdin: Mutex::new(UserlandStdin {
+            stdin: Mutex::new(StdinState {
                 receiver: stdin_receiver,
                 buffered: VecDeque::new(),
                 eof: false,

--- a/litebox_broker_userland/src/stdio.rs
+++ b/litebox_broker_userland/src/stdio.rs
@@ -1,0 +1,292 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+use std::collections::VecDeque;
+use std::io::{Error as IoError, ErrorKind, Read as _, Result as IoResult};
+use std::sync::Mutex;
+use std::sync::mpsc::{Receiver, RecvTimeoutError, SyncSender, TrySendError, sync_channel};
+use std::time::Duration;
+
+use litebox_broker_core::AssociationCancellation;
+use litebox_broker_core::stdio::{StdioProvider, StdioProviderError};
+use litebox_broker_protocol::stdio::{MAX_STDIO_TRANSFER_SIZE, StdioOutputStream};
+
+const CANCELLATION_POLL_INTERVAL: Duration = Duration::from_millis(50);
+const WRITE_RETRY_DELAY: Duration = Duration::from_millis(1);
+
+/// Routes standard I/O for the broker's single child runner through inherited
+/// streams.
+///
+/// A broker serving multiple runners will need association-specific stream
+/// endpoints instead of sharing process-wide standard streams.
+pub(super) struct UserlandStdioProvider {
+    stdin: Mutex<UserlandStdin>,
+    stdout: SyncSender<StdioWriteRequest>,
+    stderr: SyncSender<StdioWriteRequest>,
+}
+
+struct UserlandStdin {
+    receiver: Receiver<StdinReadResult>,
+    buffered: VecDeque<u8>,
+    eof: bool,
+}
+
+enum StdinReadResult {
+    Data(Vec<u8>),
+    Eof,
+    Error(StdioProviderError),
+}
+
+struct StdioWriteRequest {
+    input: Vec<u8>,
+    completion: SyncSender<Result<usize, StdioProviderError>>,
+}
+
+impl UserlandStdioProvider {
+    pub(super) fn new(max_concurrent_writes: usize) -> IoResult<Self> {
+        let (stdin_sender, stdin_receiver) = sync_channel(1);
+        std::thread::Builder::new()
+            .name("litebox-broker-stdin".to_owned())
+            .spawn(move || pump_stdin(stdin_sender))?;
+        let (stdout, stdout_receiver) = sync_channel(max_concurrent_writes);
+        std::thread::Builder::new()
+            .name("litebox-broker-stdout".to_owned())
+            .spawn(move || pump_stdout(stdout_receiver))?;
+        let (stderr, stderr_receiver) = sync_channel(max_concurrent_writes);
+        std::thread::Builder::new()
+            .name("litebox-broker-stderr".to_owned())
+            .spawn(move || pump_stderr(stderr_receiver))?;
+        Ok(Self {
+            stdin: Mutex::new(UserlandStdin {
+                receiver: stdin_receiver,
+                buffered: VecDeque::new(),
+                eof: false,
+            }),
+            stdout,
+            stderr,
+        })
+    }
+}
+
+impl StdioProvider for UserlandStdioProvider {
+    fn read(
+        &self,
+        cancellation: &AssociationCancellation,
+        output: &mut [u8],
+    ) -> Result<usize, StdioProviderError> {
+        if output.is_empty() {
+            return Ok(0);
+        }
+        let mut stdin = self.stdin.lock().map_err(|_| StdioProviderError::Failed)?;
+        loop {
+            if cancellation.is_cancelled() {
+                return Err(StdioProviderError::Closed);
+            }
+            if !stdin.buffered.is_empty() {
+                let read = output.len().min(stdin.buffered.len());
+                for destination in &mut output[..read] {
+                    *destination = stdin
+                        .buffered
+                        .pop_front()
+                        .expect("buffered stdin length was checked");
+                }
+                return Ok(read);
+            }
+            if stdin.eof {
+                return Ok(0);
+            }
+            match stdin.receiver.recv_timeout(CANCELLATION_POLL_INTERVAL) {
+                Ok(StdinReadResult::Data(data)) => stdin.buffered.extend(data),
+                Ok(StdinReadResult::Eof) => stdin.eof = true,
+                Ok(StdinReadResult::Error(error)) => return Err(error),
+                Err(RecvTimeoutError::Timeout) => {}
+                Err(RecvTimeoutError::Disconnected) => return Err(StdioProviderError::Failed),
+            }
+        }
+    }
+
+    fn write(
+        &self,
+        cancellation: &AssociationCancellation,
+        stream: StdioOutputStream,
+        input: &[u8],
+    ) -> Result<usize, StdioProviderError> {
+        let sender = match stream {
+            StdioOutputStream::Stdout => &self.stdout,
+            StdioOutputStream::Stderr => &self.stderr,
+        };
+        let (completion, completed) = sync_channel(1);
+        let mut request = StdioWriteRequest {
+            input: input.to_vec(),
+            completion,
+        };
+        loop {
+            if cancellation.is_cancelled() {
+                return Err(StdioProviderError::Closed);
+            }
+            match sender.try_send(request) {
+                Ok(()) => break,
+                Err(TrySendError::Full(pending)) => request = pending,
+                Err(TrySendError::Disconnected(_)) => {
+                    return Err(StdioProviderError::Failed);
+                }
+            }
+            std::thread::sleep(WRITE_RETRY_DELAY);
+        }
+        loop {
+            match completed.recv_timeout(CANCELLATION_POLL_INTERVAL) {
+                Ok(result) => return result,
+                Err(RecvTimeoutError::Timeout) if cancellation.is_cancelled() => {
+                    return Err(StdioProviderError::Closed);
+                }
+                Err(RecvTimeoutError::Timeout) => {}
+                Err(RecvTimeoutError::Disconnected) => {
+                    return Err(StdioProviderError::Failed);
+                }
+            }
+        }
+    }
+}
+
+fn pump_stdin(sender: SyncSender<StdinReadResult>) {
+    let stdin = std::io::stdin();
+    let mut stdin = stdin.lock();
+    let mut buffer = vec![0; MAX_STDIO_TRANSFER_SIZE as usize];
+    loop {
+        let (result, finished) = match stdin.read(&mut buffer) {
+            Ok(0) => (StdinReadResult::Eof, true),
+            Ok(read) => (StdinReadResult::Data(buffer[..read].to_vec()), false),
+            Err(error) if error.kind() == ErrorKind::Interrupted => continue,
+            Err(error) => (StdinReadResult::Error(map_stdio_error(error)), true),
+        };
+        if sender.send(result).is_err() || finished {
+            return;
+        }
+    }
+}
+
+fn pump_stdout(receiver: Receiver<StdioWriteRequest>) {
+    pump_output(std::io::stdout(), receiver);
+}
+
+fn pump_stderr(receiver: Receiver<StdioWriteRequest>) {
+    pump_output(std::io::stderr(), receiver);
+}
+
+fn pump_output(mut output: impl std::io::Write, receiver: Receiver<StdioWriteRequest>) {
+    while let Ok(request) = receiver.recv() {
+        let result = write_and_flush(&mut output, &request.input).map_err(map_stdio_error);
+        let _ = request.completion.send(result);
+    }
+}
+
+fn map_stdio_error(error: IoError) -> StdioProviderError {
+    if error.kind() == ErrorKind::BrokenPipe {
+        StdioProviderError::Closed
+    } else {
+        StdioProviderError::Failed
+    }
+}
+
+fn write_and_flush(mut output: impl std::io::Write, input: &[u8]) -> IoResult<usize> {
+    let written = output.write(input)?;
+    output.flush()?;
+    Ok(written)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+
+    #[derive(Default)]
+    struct RecordingOutput {
+        bytes: Arc<Mutex<Vec<u8>>>,
+        flushes: Arc<Mutex<usize>>,
+    }
+
+    impl std::io::Write for RecordingOutput {
+        fn write(&mut self, input: &[u8]) -> IoResult<usize> {
+            let written = input.len().min(3);
+            self.bytes.lock().unwrap().extend(&input[..written]);
+            Ok(written)
+        }
+
+        fn flush(&mut self) -> IoResult<()> {
+            *self.flushes.lock().unwrap() += 1;
+            Ok(())
+        }
+    }
+
+    fn test_stdio_provider(receiver: Receiver<StdinReadResult>) -> UserlandStdioProvider {
+        let (stdout, _stdout_receiver) = sync_channel(1);
+        let (stderr, _stderr_receiver) = sync_channel(1);
+        UserlandStdioProvider {
+            stdin: Mutex::new(UserlandStdin {
+                receiver,
+                buffered: VecDeque::new(),
+                eof: false,
+            }),
+            stdout,
+            stderr,
+        }
+    }
+
+    #[test]
+    fn provider_preserves_partial_reads_and_eof() {
+        let (sender, receiver) = sync_channel(2);
+        sender
+            .send(StdinReadResult::Data(b"input".to_vec()))
+            .unwrap();
+        sender.send(StdinReadResult::Eof).unwrap();
+        let provider = test_stdio_provider(receiver);
+        let cancellation = AssociationCancellation::default();
+
+        let mut first = [0xa5; 3];
+        assert_eq!(provider.read(&cancellation, &mut first), Ok(3));
+        assert_eq!(&first, b"inp");
+
+        let mut second = [0xa5; 4];
+        assert_eq!(provider.read(&cancellation, &mut second), Ok(2));
+        assert_eq!(&second, b"ut\xa5\xa5");
+        assert_eq!(provider.read(&cancellation, &mut second), Ok(0));
+    }
+
+    #[test]
+    fn provider_waits_for_output_write_and_flush() {
+        let bytes = Arc::new(Mutex::new(Vec::new()));
+        let flushes = Arc::new(Mutex::new(0));
+        let (stdout, stdout_receiver) = sync_channel(1);
+        let output = RecordingOutput {
+            bytes: Arc::clone(&bytes),
+            flushes: Arc::clone(&flushes),
+        };
+        let writer = std::thread::spawn(move || pump_output(output, stdout_receiver));
+        let (_stdin_sender, stdin_receiver) = sync_channel(1);
+        let (stderr, _stderr_receiver) = sync_channel(1);
+        let provider = UserlandStdioProvider {
+            stdin: Mutex::new(UserlandStdin {
+                receiver: stdin_receiver,
+                buffered: VecDeque::new(),
+                eof: false,
+            }),
+            stdout,
+            stderr,
+        };
+
+        assert_eq!(
+            provider.write(
+                &AssociationCancellation::default(),
+                StdioOutputStream::Stdout,
+                b"prompt",
+            ),
+            Ok(3)
+        );
+
+        drop(provider);
+        writer.join().unwrap();
+        assert_eq!(*bytes.lock().unwrap(), b"pro");
+        assert_eq!(*flushes.lock().unwrap(), 1);
+    }
+}

--- a/litebox_broker_userland/src/stdio.rs
+++ b/litebox_broker_userland/src/stdio.rs
@@ -26,7 +26,7 @@ pub(super) struct UserlandStdioProvider {
 }
 
 struct StdinState {
-    receiver: Receiver<StdinReadResult>,
+    receiver: Option<Receiver<StdinReadResult>>,
     buffered: VecDeque<u8>,
     eof: bool,
 }
@@ -44,10 +44,6 @@ struct StdioWriteOperation {
 
 impl UserlandStdioProvider {
     pub(super) fn new() -> IoResult<Self> {
-        let (stdin_sender, stdin_receiver) = sync_channel(1);
-        std::thread::Builder::new()
-            .name("litebox-broker-stdin".to_owned())
-            .spawn(move || pump_stdin(stdin_sender))?;
         let (stdout, stdout_receiver) = sync_channel(super::WORKER_COUNT);
         std::thread::Builder::new()
             .name("litebox-broker-stdout".to_owned())
@@ -58,7 +54,7 @@ impl UserlandStdioProvider {
             .spawn(move || pump_stderr(stderr_receiver))?;
         Ok(Self {
             stdin: Mutex::new(StdinState {
-                receiver: stdin_receiver,
+                receiver: None,
                 buffered: VecDeque::new(),
                 eof: false,
             }),
@@ -95,7 +91,20 @@ impl StdioProvider for UserlandStdioProvider {
             if stdin.eof {
                 return Ok(0);
             }
-            match stdin.receiver.recv_timeout(CANCELLATION_POLL_INTERVAL) {
+            if stdin.receiver.is_none() {
+                let (sender, receiver) = sync_channel(1);
+                std::thread::Builder::new()
+                    .name("litebox-broker-stdin".to_owned())
+                    .spawn(move || pump_stdin(sender))
+                    .map_err(|_| StdioProviderError::Failed)?;
+                stdin.receiver = Some(receiver);
+            }
+            match stdin
+                .receiver
+                .as_ref()
+                .expect("stdin pump was started")
+                .recv_timeout(CANCELLATION_POLL_INTERVAL)
+            {
                 Ok(StdinReadResult::Data(data)) => stdin.buffered.extend(data),
                 Ok(StdinReadResult::Eof) => stdin.eof = true,
                 Ok(StdinReadResult::Error(error)) => return Err(error),
@@ -224,13 +233,20 @@ mod tests {
         let (stderr, _stderr_receiver) = sync_channel(1);
         UserlandStdioProvider {
             stdin: Mutex::new(StdinState {
-                receiver,
+                receiver: Some(receiver),
                 buffered: VecDeque::new(),
                 eof: false,
             }),
             stdout,
             stderr,
         }
+    }
+
+    #[test]
+    fn provider_defers_stdin_pump_until_read() {
+        let provider = UserlandStdioProvider::new().unwrap();
+
+        assert!(provider.stdin.lock().unwrap().receiver.is_none());
     }
 
     #[test]
@@ -267,7 +283,7 @@ mod tests {
         let (stderr, _stderr_receiver) = sync_channel(1);
         let provider = UserlandStdioProvider {
             stdin: Mutex::new(StdinState {
-                receiver: stdin_receiver,
+                receiver: Some(stdin_receiver),
                 buffered: VecDeque::new(),
                 eof: false,
             }),

--- a/litebox_broker_userland/src/windows.rs
+++ b/litebox_broker_userland/src/windows.rs
@@ -57,7 +57,7 @@ pub(super) fn run(args: super::CliArgs) -> Result<(), Box<dyn Error>> {
         ),
         Arc::new(UnsupportedSocketProvider),
         Arc::new(super::UserlandRandomProvider),
-        Arc::new(super::UserlandStdioProvider),
+        Arc::new(super::UserlandStdioProvider::new()?),
     )?;
 
     crate::run_runner_process(&args, &control_pipe, None, |runner, runner_process_id| {

--- a/litebox_broker_userland/src/windows.rs
+++ b/litebox_broker_userland/src/windows.rs
@@ -58,7 +58,7 @@ pub(super) fn run(args: super::CliArgs) -> Result<(), Box<dyn Error>> {
         ),
         Arc::new(UnsupportedSocketProvider),
         Arc::new(UserlandRandomProvider),
-        Arc::new(UserlandStdioProvider::new(super::WORKER_COUNT)?),
+        Arc::new(UserlandStdioProvider::new()?),
     )?;
 
     crate::run_runner_process(&args, &control_pipe, None, |runner, runner_process_id| {

--- a/litebox_broker_userland/src/windows.rs
+++ b/litebox_broker_userland/src/windows.rs
@@ -29,6 +29,7 @@ use super::{
     HostAssociationShutdown, HostRequestSource, HostResponseSink, SETUP_TIMEOUT,
     configured_socket_policy,
 };
+use super::{random::UserlandRandomProvider, stdio::UserlandStdioProvider};
 
 impl HostRequestSource for WindowsControlRingHostRequestSource {
     fn recv_request(&mut self) -> IoResult<HostReceive<BrokerRequest>> {
@@ -56,8 +57,8 @@ pub(super) fn run(args: super::CliArgs) -> Result<(), Box<dyn Error>> {
             configured_socket_policy(&args.allow_tcp_destination, &args.allow_udp_destination)?,
         ),
         Arc::new(UnsupportedSocketProvider),
-        Arc::new(super::UserlandRandomProvider),
-        Arc::new(super::UserlandStdioProvider::new()?),
+        Arc::new(UserlandRandomProvider),
+        Arc::new(UserlandStdioProvider::new(super::WORKER_COUNT)?),
     )?;
 
     crate::run_runner_process(&args, &control_pipe, None, |runner, runner_process_id| {

--- a/litebox_runner_linux_userland/tests/run.rs
+++ b/litebox_runner_linux_userland/tests/run.rs
@@ -33,6 +33,14 @@ struct CapturingStdioProvider {
 
 #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
 impl litebox_broker_core::stdio::StdioProvider for CapturingStdioProvider {
+    fn read(
+        &self,
+        _cancellation: &litebox_broker_core::AssociationCancellation,
+        _output: &mut [u8],
+    ) -> Result<usize, litebox_broker_core::stdio::StdioProviderError> {
+        Err(litebox_broker_core::stdio::StdioProviderError::Unsupported)
+    }
+
     fn write(
         &self,
         _cancellation: &litebox_broker_core::AssociationCancellation,

--- a/litebox_runner_linux_userland/tests/run.rs
+++ b/litebox_runner_linux_userland/tests/run.rs
@@ -35,6 +35,7 @@ struct CapturingStdioProvider {
 impl litebox_broker_core::stdio::StdioProvider for CapturingStdioProvider {
     fn write(
         &self,
+        _cancellation: &litebox_broker_core::AssociationCancellation,
         stream: litebox_broker_protocol::stdio::StdioOutputStream,
         input: &[u8],
     ) -> Result<usize, litebox_broker_core::stdio::StdioProviderError> {

--- a/litebox_runner_lvbs/README.md
+++ b/litebox_runner_lvbs/README.md
@@ -3,5 +3,5 @@
 > [!WARNING]
 > This crate is work in progress. Broker-backed services are unavailable on
 > LVBS until a kernel broker platform is implemented. This includes standard
-> output and cryptographic randomness, so workloads that require either service
+> I/O and cryptographic randomness, so workloads that require either service
 > cannot run on LVBS.


### PR DESCRIPTION
This PR routes standard input through the mandatory broker using bounded shared-memory transfers with partial-read and EOF semantics, and makes inherited standard I/O on Linux and Windows teardown-safe through lazy stdin startup, per-stream output pumps, serialized guest reads, synchronous write-and-flush completion, and association-scoped cooperative cancellation.