### PR TITLE
Route standard-stream terminal queries through the broker

### DIFF
--- a/litebox/src/broker/mod.rs
+++ b/litebox/src/broker/mod.rs
@@ -21,7 +21,7 @@ use litebox_broker_protocol::socket::{
     ReceiveFromSocketResponse, ReceiveSocketResponse, SendFlags as BrokerSendFlags, ShutdownMode,
     SocketConnectionStatus, SocketOutcome, SocketStatusResponse, TcpOptionName, TcpOptionValue,
 };
-use litebox_broker_protocol::stdio::{MAX_STDIO_TRANSFER_SIZE, StdioOutputStream};
+use litebox_broker_protocol::stdio::{MAX_STDIO_TRANSFER_SIZE, StdioOutputStream, StdioStream};
 use litebox_broker_transport::channel::LocalCallChannel;
 
 use crate::event::{Events, polling::Pollee};
@@ -44,6 +44,11 @@ use shared_buffer::{SlotAllocator, SlotLease};
 /// once the local-core wait and notification model supports that shape.
 pub(crate) trait BrokerControl: Send + Sync {
     fn fill_random(&self, output: &mut [u8]) -> core::result::Result<(), BrokerControlError>;
+
+    fn is_stdio_terminal(
+        &self,
+        stream: StdioStream,
+    ) -> core::result::Result<bool, BrokerControlError>;
 
     fn read_stdio(&self, data: &mut [u8]) -> core::result::Result<usize, BrokerControlError>;
 
@@ -322,6 +327,13 @@ where
             u32::try_from(output.len()).expect("validated random transfer length must fit in u32");
         let lease = self.acquire_shared_buffer(length)?;
         self.request(|local| local.fill_random(lease.descriptor(), output))
+    }
+
+    fn is_stdio_terminal(
+        &self,
+        stream: StdioStream,
+    ) -> core::result::Result<bool, BrokerControlError> {
+        self.request(|local| local.is_stdio_terminal(stream))
     }
 
     fn read_stdio(&self, data: &mut [u8]) -> core::result::Result<usize, BrokerControlError> {

--- a/litebox/src/stdio.rs
+++ b/litebox/src/stdio.rs
@@ -4,7 +4,7 @@
 //! Broker-provided standard I/O.
 
 use litebox_broker_protocol::stdio::MAX_STDIO_TRANSFER_SIZE;
-pub use litebox_broker_protocol::stdio::StdioOutputStream;
+pub use litebox_broker_protocol::stdio::{StdioOutputStream, StdioStream};
 use thiserror::Error;
 
 use crate::{LiteBox, sync::RawSyncPrimitivesProvider};
@@ -19,7 +19,23 @@ pub struct ReadStdioError;
 #[error("brokered standard output is unavailable")]
 pub struct WriteStdioError;
 
+/// A broker could not determine whether a standard stream is connected to a
+/// terminal.
+#[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
+#[error("brokered standard-stream terminal query is unavailable")]
+pub struct StdioTerminalError;
+
 impl<Platform: RawSyncPrimitivesProvider> LiteBox<Platform> {
+    /// Determines whether a standard stream is connected to a terminal.
+    ///
+    /// This query requires a negotiated broker.
+    pub fn is_stdio_terminal(&self, stream: StdioStream) -> Result<bool, StdioTerminalError> {
+        self.broker_control()
+            .ok_or(StdioTerminalError)?
+            .is_stdio_terminal(stream)
+            .map_err(|_| StdioTerminalError)
+    }
+
     /// Reads bytes from standard input.
     ///
     /// Empty reads succeed without a broker. Non-empty reads require a

--- a/litebox_broker_core/src/stdio.rs
+++ b/litebox_broker_core/src/stdio.rs
@@ -3,7 +3,7 @@
 
 //! Broker-authoritative standard I/O.
 
-use litebox_broker_protocol::stdio::{MAX_STDIO_TRANSFER_SIZE, StdioOutputStream};
+use litebox_broker_protocol::stdio::{MAX_STDIO_TRANSFER_SIZE, StdioOutputStream, StdioStream};
 use thiserror::Error;
 
 use crate::{AssociationCancellation, BrokerError, BrokerSession, Result};
@@ -55,6 +55,10 @@ pub trait StdioProvider: Send + Sync {
         stream: StdioOutputStream,
         input: &[u8],
     ) -> core::result::Result<usize, StdioProviderError>;
+
+    /// Determines whether the selected standard stream is connected to a
+    /// terminal.
+    fn is_terminal(&self, stream: StdioStream) -> core::result::Result<bool, StdioProviderError>;
 }
 
 /// Standard-I/O provider for deployments that do not expose standard streams.
@@ -75,6 +79,10 @@ impl StdioProvider for UnsupportedStdioProvider {
         _stream: StdioOutputStream,
         _input: &[u8],
     ) -> core::result::Result<usize, StdioProviderError> {
+        Err(StdioProviderError::Unsupported)
+    }
+
+    fn is_terminal(&self, _stream: StdioStream) -> core::result::Result<bool, StdioProviderError> {
         Err(StdioProviderError::Unsupported)
     }
 }
@@ -113,4 +121,13 @@ pub fn write(session: &BrokerSession, stream: StdioOutputStream, input: &[u8]) -
         return Err(BrokerError::Internal);
     }
     Ok(written)
+}
+
+/// Determines whether a standard stream is connected to a terminal.
+pub fn is_terminal(session: &BrokerSession, stream: StdioStream) -> Result<bool> {
+    session
+        .core
+        .stdio_provider
+        .is_terminal(stream)
+        .map_err(Into::into)
 }

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -46,8 +46,8 @@ use litebox_broker_protocol::socket::{
     SendSocketResponse, SendToSocketResponse, SocketOutcome,
 };
 use litebox_broker_protocol::stdio::{
-    MAX_STDIO_TRANSFER_SIZE, ReadStdioRequest, ReadStdioResponse, WriteStdioRequest,
-    WriteStdioResponse,
+    IsTerminalStdioRequest, IsTerminalStdioResponse, MAX_STDIO_TRANSFER_SIZE, ReadStdioRequest,
+    ReadStdioResponse, WriteStdioRequest, WriteStdioResponse,
 };
 use litebox_broker_protocol::{BROKER_PROTOCOL_VERSION, RequestId};
 use litebox_broker_transport::channel::{HostReceive, HostSetupChannel, PeerCredential};
@@ -116,6 +116,7 @@ impl<Memory: SharedMemory> BrokerHostAssociation<'_, Memory> {
             | BrokerOperation::CheckReadiness(_)
             | BrokerOperation::Event(_)
             | BrokerOperation::Pipe(PipeRequest::Create(_))
+            | BrokerOperation::Stdio(StdioRequest::IsTerminal(_))
             | BrokerOperation::Socket(
                 SocketRequest::Create(_)
                 | SocketRequest::Connect(_)
@@ -428,6 +429,13 @@ fn handle_stdio_request<Memory: SharedMemory>(
             Ok(StdioResponse::Write(WriteStdioResponse {
                 written: u32::try_from(written)
                     .expect("validated stdio write length must fit in u32"),
+            }))
+        }
+        StdioRequest::IsTerminal(IsTerminalStdioRequest { stream }) => {
+            let is_terminal = litebox_broker_core::stdio::is_terminal(session, stream)
+                .map_err(RequestFailure::from)?;
+            Ok(StdioResponse::IsTerminal(IsTerminalStdioResponse {
+                is_terminal,
             }))
         }
     }
@@ -799,7 +807,7 @@ mod tests {
         SocketError, SocketStatusRequest, SocketStatusResponse, SocketType, TcpOptionName,
         TcpOptionValue,
     };
-    use litebox_broker_protocol::stdio::StdioOutputStream;
+    use litebox_broker_protocol::stdio::{StdioOutputStream, StdioStream};
     use litebox_broker_protocol::{ObjectHandle, ProtocolVersion, RequestId};
     use litebox_broker_transport::shared_memory::{SharedBufferPool, SharedMemoryError};
     use std::collections::VecDeque;
@@ -874,6 +882,7 @@ mod tests {
     struct TestStdioProvider {
         input: Mutex<VecDeque<u8>>,
         writes: Mutex<Vec<(StdioOutputStream, Vec<u8>)>>,
+        terminal_queries: Mutex<Vec<StdioStream>>,
     }
 
     impl StdioProvider for TestStdioProvider {
@@ -898,6 +907,14 @@ mod tests {
         ) -> core::result::Result<usize, StdioProviderError> {
             self.writes.lock().unwrap().push((stream, input.to_vec()));
             Ok(input.len())
+        }
+
+        fn is_terminal(
+            &self,
+            stream: StdioStream,
+        ) -> core::result::Result<bool, StdioProviderError> {
+            self.terminal_queries.lock().unwrap().push(stream);
+            Ok(stream == StdioStream::Stderr)
         }
     }
 
@@ -1215,6 +1232,22 @@ mod tests {
         assert_eq!(
             provider.writes.lock().unwrap().as_slice(),
             [(StdioOutputStream::Stderr, b"error".to_vec())]
+        );
+        assert_eq!(
+            handle_test_request_with_buffers(
+                &session,
+                BrokerOperation::Stdio(StdioRequest::IsTerminal(IsTerminalStdioRequest {
+                    stream: StdioStream::Stderr,
+                })),
+                &shared_buffers,
+            ),
+            BrokerResult::Stdio(StdioResponse::IsTerminal(IsTerminalStdioResponse {
+                is_terminal: true,
+            }))
+        );
+        assert_eq!(
+            provider.terminal_queries.lock().unwrap().as_slice(),
+            [StdioStream::Stderr]
         );
         assert_eq!(
             handle_request(

--- a/litebox_broker_local/src/lib.rs
+++ b/litebox_broker_local/src/lib.rs
@@ -243,8 +243,8 @@ mod tests {
     use litebox_broker_protocol::readiness::ReadinessFlags;
     use litebox_broker_protocol::shared_buffer::{SharedBufferDescriptor, SharedBufferSlotIndex};
     use litebox_broker_protocol::stdio::{
-        ReadStdioRequest, ReadStdioResponse, StdioOutputStream, WriteStdioRequest,
-        WriteStdioResponse,
+        IsTerminalStdioRequest, IsTerminalStdioResponse, ReadStdioRequest, ReadStdioResponse,
+        StdioOutputStream, StdioStream, WriteStdioRequest, WriteStdioResponse,
     };
     use litebox_broker_transport::channel::LocalNotificationChannel;
     use std::sync::Mutex;
@@ -362,6 +362,34 @@ mod tests {
                 operation: BrokerOperation::Stdio(StdioRequest::Read(ReadStdioRequest {
                     buffer: descriptor,
                 })),
+            })
+        );
+    }
+
+    #[test]
+    fn stdio_terminal_query_requests_the_selected_stream() {
+        let channel = FakeControlChannel::new(
+            None,
+            Some(BrokerResult::Stdio(StdioResponse::IsTerminal(
+                IsTerminalStdioResponse { is_terminal: true },
+            ))),
+        );
+        let local = BrokerLocal {
+            channel,
+            shared_buffers: noop_shared_buffers(),
+            next_request_id: AtomicU64::new(0),
+        };
+
+        assert!(local.is_stdio_terminal(StdioStream::Stderr).unwrap());
+        assert_eq!(
+            local.channel.sent_request.borrow().clone(),
+            Some(BrokerRequest {
+                request_id: RequestId(0),
+                operation: BrokerOperation::Stdio(StdioRequest::IsTerminal(
+                    IsTerminalStdioRequest {
+                        stream: StdioStream::Stderr,
+                    },
+                )),
             })
         );
     }

--- a/litebox_broker_local/src/stdio.rs
+++ b/litebox_broker_local/src/stdio.rs
@@ -6,13 +6,30 @@ use litebox_broker_protocol::message::{
 };
 use litebox_broker_protocol::shared_buffer::SharedBufferDescriptor;
 use litebox_broker_protocol::stdio::{
-    MAX_STDIO_TRANSFER_SIZE, ReadStdioRequest, StdioOutputStream, WriteStdioRequest,
+    IsTerminalStdioRequest, MAX_STDIO_TRANSFER_SIZE, ReadStdioRequest, StdioOutputStream,
+    StdioStream, WriteStdioRequest,
 };
 use litebox_broker_transport::channel::LocalCallChannel;
 
 use crate::{BrokerLocal, BrokerLocalError, Result};
 
 impl<Channel: LocalCallChannel> BrokerLocal<Channel> {
+    /// Determines whether a standard stream is connected to a terminal.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the broker reports an unrecoverable error or returns a
+    /// response for a different operation.
+    pub fn is_stdio_terminal(&self, stream: StdioStream) -> Result<bool, Channel::Error> {
+        match self.request(BrokerOperation::Stdio(StdioRequest::IsTerminal(
+            IsTerminalStdioRequest { stream },
+        )))? {
+            BrokerResult::Stdio(StdioResponse::IsTerminal(response)) => Ok(response.is_terminal),
+            BrokerResult::Error(error) => Err(BrokerLocalError::Broker(error)),
+            response => panic!("broker returned unexpected stdio response: {response:?}"),
+        }
+    }
+
     /// Reads standard input into an operation-scoped shared-buffer lease.
     ///
     /// The caller must retain exclusive ownership of the descriptor's slot

--- a/litebox_broker_protocol/src/message.rs
+++ b/litebox_broker_protocol/src/message.rs
@@ -21,7 +21,10 @@ use crate::socket::{
     SendToSocketResponse, SetTcpOptionRequest, ShutdownSocketRequest, SocketError,
     SocketStatusRequest, SocketStatusResponse,
 };
-use crate::stdio::{ReadStdioRequest, ReadStdioResponse, WriteStdioRequest, WriteStdioResponse};
+use crate::stdio::{
+    IsTerminalStdioRequest, IsTerminalStdioResponse, ReadStdioRequest, ReadStdioResponse,
+    WriteStdioRequest, WriteStdioResponse,
+};
 use crate::{ObjectHandle, ProtocolVersion, RequestId};
 
 /// Broker handshake request sent before the control channel is active.
@@ -235,6 +238,8 @@ pub enum StdioRequest {
     Read(ReadStdioRequest),
     /// Write bytes to a standard output stream.
     Write(WriteStdioRequest),
+    /// Determine whether a standard stream is connected to a terminal.
+    IsTerminal(IsTerminalStdioRequest),
 }
 
 /// Standard-I/O response.
@@ -244,6 +249,8 @@ pub enum StdioResponse {
     Read(ReadStdioResponse),
     /// Standard output write response.
     Write(WriteStdioResponse),
+    /// Standard-stream terminal capability response.
+    IsTerminal(IsTerminalStdioResponse),
 }
 
 /// Broker-initiated asynchronous notification.

--- a/litebox_broker_protocol/src/stdio.rs
+++ b/litebox_broker_protocol/src/stdio.rs
@@ -8,6 +8,17 @@ pub const MAX_STDIO_TRANSFER_SIZE: u32 = 32 * 1024;
 
 const _: () = assert!(MAX_STDIO_TRANSFER_SIZE <= SHARED_BUFFER_SLOT_SIZE);
 
+/// Standard stream selected by a capability query.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum StdioStream {
+    /// Process standard input.
+    Stdin,
+    /// Process standard output.
+    Stdout,
+    /// Process standard error.
+    Stderr,
+}
+
 /// Standard output stream selected by a write request.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum StdioOutputStream {
@@ -45,4 +56,18 @@ pub struct WriteStdioRequest {
 pub struct WriteStdioResponse {
     /// Number of bytes written to the selected stream.
     pub written: u32,
+}
+
+/// Request to determine whether a standard stream is connected to a terminal.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct IsTerminalStdioRequest {
+    /// Standard stream to query.
+    pub stream: StdioStream,
+}
+
+/// Response describing whether a standard stream is connected to a terminal.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct IsTerminalStdioResponse {
+    /// Whether the selected stream is connected to a terminal.
+    pub is_terminal: bool,
 }

--- a/litebox_broker_protocol/src/wire.rs
+++ b/litebox_broker_protocol/src/wire.rs
@@ -402,8 +402,8 @@ mod tests {
         SocketStatusResponse, SocketType, TcpOptionName, TcpOptionValue,
     };
     use crate::stdio::{
-        ReadStdioRequest, ReadStdioResponse, StdioOutputStream, WriteStdioRequest,
-        WriteStdioResponse,
+        IsTerminalStdioRequest, IsTerminalStdioResponse, ReadStdioRequest, ReadStdioResponse,
+        StdioOutputStream, StdioStream, WriteStdioRequest, WriteStdioResponse,
     };
     use crate::{ObjectHandle, ProtocolVersion, RequestId};
     use core::net::{Ipv4Addr, SocketAddrV4};
@@ -528,6 +528,15 @@ mod tests {
                     slot_index: SharedBufferSlotIndex(5),
                     length: 23,
                 },
+            })),
+            BrokerOperation::Stdio(StdioRequest::IsTerminal(IsTerminalStdioRequest {
+                stream: StdioStream::Stdin,
+            })),
+            BrokerOperation::Stdio(StdioRequest::IsTerminal(IsTerminalStdioRequest {
+                stream: StdioStream::Stdout,
+            })),
+            BrokerOperation::Stdio(StdioRequest::IsTerminal(IsTerminalStdioRequest {
+                stream: StdioStream::Stderr,
             })),
             BrokerOperation::Socket(SocketRequest::Create(CreateSocketRequest {
                 address_family: AddressFamily::Ipv4,
@@ -865,6 +874,12 @@ mod tests {
             BrokerResult::RandomFilled,
             BrokerResult::Stdio(StdioResponse::Read(ReadStdioResponse { read: 11 })),
             BrokerResult::Stdio(StdioResponse::Write(WriteStdioResponse { written: 17 })),
+            BrokerResult::Stdio(StdioResponse::IsTerminal(IsTerminalStdioResponse {
+                is_terminal: false,
+            })),
+            BrokerResult::Stdio(StdioResponse::IsTerminal(IsTerminalStdioResponse {
+                is_terminal: true,
+            })),
             BrokerResult::Error(ErrorCode::PolicyDenied),
             BrokerResult::Error(ErrorCode::WouldBlock),
             BrokerResult::Error(ErrorCode::PeerClosed),
@@ -1038,6 +1053,23 @@ mod tests {
             decode_request(&read[..read.len() - 1]),
             Err(WireError::TruncatedFrame)
         );
+
+        let terminal = encode_request(BrokerRequest {
+            request_id: TEST_REQUEST_ID,
+            operation: BrokerOperation::Stdio(StdioRequest::IsTerminal(IsTerminalStdioRequest {
+                stream: StdioStream::Stdin,
+            })),
+        });
+        let mut unknown_terminal_stream = terminal.clone();
+        *unknown_terminal_stream.last_mut().unwrap() = 0xff;
+        assert_eq!(
+            decode_request(&unknown_terminal_stream),
+            Err(WireError::InvalidTag)
+        );
+        assert_eq!(
+            decode_request(&terminal[..terminal.len() - 1]),
+            Err(WireError::TruncatedFrame)
+        );
     }
 
     #[test]
@@ -1066,6 +1098,23 @@ mod tests {
         });
         assert_eq!(
             decode_response(&read[..read.len() - 1]),
+            Err(WireError::TruncatedFrame)
+        );
+
+        let terminal = encode_response(BrokerResponse {
+            request_id: TEST_REQUEST_ID,
+            result: BrokerResult::Stdio(StdioResponse::IsTerminal(IsTerminalStdioResponse {
+                is_terminal: true,
+            })),
+        });
+        let mut unknown_terminal_value = terminal.clone();
+        *unknown_terminal_value.last_mut().unwrap() = 0xff;
+        assert_eq!(
+            decode_response(&unknown_terminal_value),
+            Err(WireError::InvalidTag)
+        );
+        assert_eq!(
+            decode_response(&terminal[..terminal.len() - 1]),
             Err(WireError::TruncatedFrame)
         );
     }

--- a/litebox_broker_protocol/src/wire/stdio.rs
+++ b/litebox_broker_protocol/src/wire/stdio.rs
@@ -3,7 +3,8 @@
 
 use crate::message::{StdioRequest, StdioResponse};
 use crate::stdio::{
-    ReadStdioRequest, ReadStdioResponse, StdioOutputStream, WriteStdioRequest, WriteStdioResponse,
+    IsTerminalStdioRequest, IsTerminalStdioResponse, ReadStdioRequest, ReadStdioResponse,
+    StdioOutputStream, StdioStream, WriteStdioRequest, WriteStdioResponse,
 };
 
 use super::{
@@ -13,11 +14,17 @@ use super::{
 
 const REQUEST_TAG_READ: u8 = 0;
 const REQUEST_TAG_WRITE: u8 = 1;
+const REQUEST_TAG_IS_TERMINAL: u8 = 2;
 const RESPONSE_TAG_READ: u8 = 0;
 const RESPONSE_TAG_WRITE: u8 = 1;
+const RESPONSE_TAG_IS_TERMINAL: u8 = 2;
 
 const OUTPUT_STREAM_TAG_STDOUT: u8 = 0;
 const OUTPUT_STREAM_TAG_STDERR: u8 = 1;
+
+const STREAM_TAG_STDIN: u8 = 0;
+const STREAM_TAG_STDOUT: u8 = 1;
+const STREAM_TAG_STDERR: u8 = 2;
 
 pub(super) fn encode_stdio_request(encoder: &mut Encoder, request: StdioRequest) {
     match request {
@@ -30,6 +37,10 @@ pub(super) fn encode_stdio_request(encoder: &mut Encoder, request: StdioRequest)
             encode_output_stream(encoder, request.stream);
             encoder.shared_buffer_descriptor(request.buffer);
         }
+        StdioRequest::IsTerminal(request) => {
+            encoder.u8(REQUEST_TAG_IS_TERMINAL);
+            encode_stream(encoder, request.stream);
+        }
     }
 }
 
@@ -41,6 +52,9 @@ pub(super) fn decode_stdio_request(decoder: &mut Decoder<'_>) -> Result<StdioReq
         REQUEST_TAG_WRITE => Ok(StdioRequest::Write(WriteStdioRequest {
             stream: decode_output_stream(decoder)?,
             buffer: decoder.shared_buffer_descriptor()?,
+        })),
+        REQUEST_TAG_IS_TERMINAL => Ok(StdioRequest::IsTerminal(IsTerminalStdioRequest {
+            stream: decode_stream(decoder)?,
         })),
         _ => Err(WireError::InvalidTag),
     }
@@ -56,6 +70,10 @@ pub(super) fn encode_stdio_response(encoder: &mut Encoder, response: StdioRespon
             encoder.u8(RESPONSE_TAG_WRITE);
             encoder.u32(response.written);
         }
+        StdioResponse::IsTerminal(response) => {
+            encoder.u8(RESPONSE_TAG_IS_TERMINAL);
+            encoder.u8(u8::from(response.is_terminal));
+        }
     }
 }
 
@@ -66,6 +84,13 @@ pub(super) fn decode_stdio_response(decoder: &mut Decoder<'_>) -> Result<StdioRe
         })),
         RESPONSE_TAG_WRITE => Ok(StdioResponse::Write(WriteStdioResponse {
             written: decoder.u32()?,
+        })),
+        RESPONSE_TAG_IS_TERMINAL => Ok(StdioResponse::IsTerminal(IsTerminalStdioResponse {
+            is_terminal: match decoder.u8()? {
+                0 => false,
+                1 => true,
+                _ => return Err(WireError::InvalidTag),
+            },
         })),
         _ => Err(WireError::InvalidTag),
     }
@@ -82,6 +107,23 @@ fn decode_output_stream(decoder: &mut Decoder<'_>) -> Result<StdioOutputStream, 
     match decoder.u8()? {
         OUTPUT_STREAM_TAG_STDOUT => Ok(StdioOutputStream::Stdout),
         OUTPUT_STREAM_TAG_STDERR => Ok(StdioOutputStream::Stderr),
+        _ => Err(WireError::InvalidTag),
+    }
+}
+
+fn encode_stream(encoder: &mut Encoder, stream: StdioStream) {
+    encoder.u8(match stream {
+        StdioStream::Stdin => STREAM_TAG_STDIN,
+        StdioStream::Stdout => STREAM_TAG_STDOUT,
+        StdioStream::Stderr => STREAM_TAG_STDERR,
+    });
+}
+
+fn decode_stream(decoder: &mut Decoder<'_>) -> Result<StdioStream, WireError> {
+    match decoder.u8()? {
+        STREAM_TAG_STDIN => Ok(StdioStream::Stdin),
+        STREAM_TAG_STDOUT => Ok(StdioStream::Stdout),
+        STREAM_TAG_STDERR => Ok(StdioStream::Stderr),
         _ => Err(WireError::InvalidTag),
     }
 }

--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -907,6 +907,13 @@ mod tests {
     }
 
     impl StdioProvider for BlockingStdioProvider {
+        fn is_terminal(
+            &self,
+            _stream: litebox_broker_protocol::stdio::StdioStream,
+        ) -> Result<bool, StdioProviderError> {
+            Err(StdioProviderError::Unsupported)
+        }
+
         fn read(
             &self,
             cancellation: &AssociationCancellation,

--- a/litebox_broker_userland/src/stdio.rs
+++ b/litebox_broker_userland/src/stdio.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 
 use litebox_broker_core::AssociationCancellation;
 use litebox_broker_core::stdio::{StdioProvider, StdioProviderError};
-use litebox_broker_protocol::stdio::{MAX_STDIO_TRANSFER_SIZE, StdioOutputStream};
+use litebox_broker_protocol::stdio::{MAX_STDIO_TRANSFER_SIZE, StdioOutputStream, StdioStream};
 
 const CANCELLATION_POLL_INTERVAL: Duration = Duration::from_millis(50);
 const WRITE_RETRY_DELAY: Duration = Duration::from_millis(1);
@@ -65,6 +65,16 @@ impl UserlandStdioProvider {
 }
 
 impl StdioProvider for UserlandStdioProvider {
+    fn is_terminal(&self, stream: StdioStream) -> Result<bool, StdioProviderError> {
+        use std::io::IsTerminal as _;
+
+        Ok(match stream {
+            StdioStream::Stdin => std::io::stdin().is_terminal(),
+            StdioStream::Stdout => std::io::stdout().is_terminal(),
+            StdioStream::Stderr => std::io::stderr().is_terminal(),
+        })
+    }
+
     fn read(
         &self,
         cancellation: &AssociationCancellation,

--- a/litebox_runner_linux_userland/tests/run.rs
+++ b/litebox_runner_linux_userland/tests/run.rs
@@ -33,6 +33,13 @@ struct CapturingStdioProvider {
 
 #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
 impl litebox_broker_core::stdio::StdioProvider for CapturingStdioProvider {
+    fn is_terminal(
+        &self,
+        _stream: litebox_broker_protocol::stdio::StdioStream,
+    ) -> Result<bool, litebox_broker_core::stdio::StdioProviderError> {
+        Err(litebox_broker_core::stdio::StdioProviderError::Unsupported)
+    }
+
     fn read(
         &self,
         _cancellation: &litebox_broker_core::AssociationCancellation,

--- a/litebox_shim_linux/src/lib.rs
+++ b/litebox_shim_linux/src/lib.rs
@@ -424,9 +424,9 @@ impl<Platform: ShimPlatform> syscalls::file::FilesState<Platform> {
         let mut dt = global.litebox.descriptor_table_mut();
         let mut rds = self.raw_descriptor_store.write();
         for (raw_fd, fd, stream) in [
-            (0, stdin, litebox::platform::StdioStream::Stdin),
-            (1, stdout, litebox::platform::StdioStream::Stdout),
-            (2, stderr, litebox::platform::StdioStream::Stderr),
+            (0, stdin, litebox::stdio::StdioStream::Stdin),
+            (1, stdout, litebox::stdio::StdioStream::Stdout),
+            (2, stderr, litebox::stdio::StdioStream::Stderr),
         ] {
             let status_flags = OFlags::APPEND | OFlags::RDWR;
             debug_assert_eq!(OFlags::STATUS_FLAGS_MASK & status_flags, status_flags);

--- a/litebox_shim_linux/src/stdio.rs
+++ b/litebox_shim_linux/src/stdio.rs
@@ -8,9 +8,23 @@ mod tests {
     use core::ffi::CStr;
 
     use litebox::fs::{Mode, OFlags};
-    use litebox_common_linux::{FcntlArg, FileDescriptorFlags};
+    use litebox_common_linux::{FcntlArg, FileDescriptorFlags, IoctlArg, Termios, errno::Errno};
 
-    use crate::syscalls::tests::init_platform;
+    use crate::{
+        UserPtrMut,
+        syscalls::tests::{init_platform, init_platform_with_pipe_broker},
+    };
+
+    fn termios() -> Termios {
+        Termios {
+            c_iflag: 0,
+            c_oflag: 0,
+            c_cflag: 0,
+            c_lflag: 0,
+            c_line: 0,
+            c_cc: [0; 19],
+        }
+    }
 
     #[test]
     fn test_stdio() {
@@ -110,6 +124,32 @@ mod tests {
         assert_eq!(
             FileDescriptorFlags::empty().bits(),
             task.sys_fcntl(stdin3, FcntlArg::GETFD).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_stdio_terminal_query_requires_broker() {
+        let task = init_platform();
+        let mut termios = termios();
+
+        assert_eq!(
+            task.sys_ioctl(1, IoctlArg::TCGETS(UserPtrMut::from_ptr(&raw mut termios)),),
+            Err(Errno::EIO)
+        );
+    }
+
+    #[test]
+    fn test_stdio_terminal_query_uses_broker() {
+        let task = init_platform_with_pipe_broker();
+        let mut termios = termios();
+
+        assert_eq!(
+            task.sys_ioctl(1, IoctlArg::TCGETS(UserPtrMut::from_ptr(&raw mut termios)),),
+            Ok(0)
+        );
+        assert_eq!(
+            task.sys_ioctl(0, IoctlArg::TCGETS(UserPtrMut::from_ptr(&raw mut termios)),),
+            Err(Errno::ENOTTY)
         );
     }
 }

--- a/litebox_shim_linux/src/stdio.rs
+++ b/litebox_shim_linux/src/stdio.rs
@@ -151,5 +151,18 @@ mod tests {
             task.sys_ioctl(0, IoctlArg::TCGETS(UserPtrMut::from_ptr(&raw mut termios)),),
             Err(Errno::ENOTTY)
         );
+
+        for (path, flags, expected) in [
+            ("/dev/stdin", OFlags::RDONLY, Err(Errno::ENOTTY)),
+            ("/dev/stdout", OFlags::WRONLY, Ok(0)),
+            ("/dev/stderr", OFlags::WRONLY, Err(Errno::ENOTTY)),
+            ("/dev/./stdout", OFlags::WRONLY, Ok(0)),
+        ] {
+            let fd = i32::try_from(task.sys_open(path, flags, Mode::empty()).unwrap()).unwrap();
+            assert_eq!(
+                task.sys_ioctl(fd, IoctlArg::TCGETS(UserPtrMut::from_ptr(&raw mut termios)),),
+                expected
+            );
+        }
     }
 }

--- a/litebox_shim_linux/src/stdio.rs
+++ b/litebox_shim_linux/src/stdio.rs
@@ -12,7 +12,7 @@ mod tests {
 
     use crate::{
         UserPtrMut,
-        syscalls::tests::{init_platform, init_platform_with_pipe_broker},
+        syscalls::tests::{init_platform, init_platform_with_broker},
     };
 
     fn termios() -> Termios {
@@ -140,7 +140,7 @@ mod tests {
 
     #[test]
     fn test_stdio_terminal_query_uses_broker() {
-        let task = init_platform_with_pipe_broker();
+        let task = init_platform_with_broker();
         let mut termios = termios();
 
         assert_eq!(

--- a/litebox_shim_linux/src/syscalls/epoll.rs
+++ b/litebox_shim_linux/src/syscalls/epoll.rs
@@ -137,12 +137,11 @@ impl<Platform: ShimPlatform> EpollDescriptor<Platform> {
                 let events = match global
                     .litebox
                     .descriptor_table()
-                    .with_metadata(file, |stream: &litebox::platform::StdioStream| *stream)
+                    .with_metadata(file, |stream: &litebox::stdio::StdioStream| *stream)
                 {
-                    Ok(litebox::platform::StdioStream::Stdin) => Events::IN,
+                    Ok(litebox::stdio::StdioStream::Stdin) => Events::IN,
                     Ok(
-                        litebox::platform::StdioStream::Stdout
-                        | litebox::platform::StdioStream::Stderr,
+                        litebox::stdio::StdioStream::Stdout | litebox::stdio::StdioStream::Stderr,
                     )
                     | Err(_) => Events::OUT,
                 };

--- a/litebox_shim_linux/src/syscalls/epoll.rs
+++ b/litebox_shim_linux/src/syscalls/epoll.rs
@@ -643,7 +643,7 @@ mod test {
     }
 
     fn setup_epoll() -> (crate::Task<TestPlatform>, EpollFile<TestPlatform>) {
-        let task = crate::syscalls::tests::init_platform_with_pipe_broker();
+        let task = crate::syscalls::tests::init_platform_with_broker();
 
         let epoll = EpollFile::new();
         (task, epoll)
@@ -694,7 +694,7 @@ mod test {
 
     #[test]
     fn test_poll() {
-        let task = crate::syscalls::tests::init_platform_with_pipe_broker();
+        let task = crate::syscalls::tests::init_platform_with_broker();
 
         let mut set = super::PollSet::with_capacity(0);
         let (rfd_u, wfd_u) = task
@@ -750,7 +750,7 @@ mod test {
 
     #[test]
     fn test_pselect() {
-        let task = crate::syscalls::tests::init_platform_with_pipe_broker();
+        let task = crate::syscalls::tests::init_platform_with_broker();
 
         let (rfd_u, wfd_u) = task
             .sys_pipe2(litebox::fs::OFlags::empty())
@@ -790,7 +790,7 @@ mod test {
 
     #[test]
     fn test_pselect_read_hup() {
-        let task = crate::syscalls::tests::init_platform_with_pipe_broker();
+        let task = crate::syscalls::tests::init_platform_with_broker();
 
         let (rfd_u, wfd_u) = task
             .sys_pipe2(litebox::fs::OFlags::empty())

--- a/litebox_shim_linux/src/syscalls/file.rs
+++ b/litebox_shim_linux/src/syscalls/file.rs
@@ -282,13 +282,42 @@ impl<Platform: ShimPlatform> Task<Platform> {
         mode: Mode,
     ) -> Result<FileFd<Platform>, Errno> {
         let mode = mode & !self.get_umask();
-        let files = self.files.borrow();
-        let fs = self.fs.borrow();
-        let context = fs.context.read();
-        files
-            .fs
-            .open(&context, path, flags - OFlags::CLOEXEC, mode)
-            .map_err(Errno::from)
+        // TODO: Have the device backend attach stream identity once backends can set descriptor
+        // metadata for newly opened files.
+        let stream = path
+            .normalized_components()
+            .ok()
+            .and_then(|mut components| {
+                match (
+                    components.next(),
+                    components.next(),
+                    components.next(),
+                    components.next(),
+                ) {
+                    (Some(""), Some("dev"), Some("stdin"), None) => Some(StdioStream::Stdin),
+                    (Some(""), Some("dev"), Some("stdout"), None) => Some(StdioStream::Stdout),
+                    (Some(""), Some("dev"), Some("stderr"), None) => Some(StdioStream::Stderr),
+                    _ => None,
+                }
+            });
+        let file = {
+            let files = self.files.borrow();
+            let fs = self.fs.borrow();
+            let context = fs.context.read();
+            files
+                .fs
+                .open(&context, &path, flags - OFlags::CLOEXEC, mode)
+                .map_err(Errno::from)
+        }?;
+        if let Some(stream) = stream {
+            let old = self
+                .global
+                .litebox
+                .descriptor_table_mut()
+                .set_entry_metadata(&file, stream);
+            assert!(old.is_none());
+        }
+        Ok(file)
     }
 
     fn do_openat(
@@ -2192,14 +2221,10 @@ impl<Platform: ShimPlatform> Task<Platform> {
                             .descriptor_table()
                             .with_metadata(fd, |stream: &StdioStream| *stream)
                             .map_err(|_| {
-                                // TODO: Handle missing `StdioStream` metadata (could happen if
-                                // `/dev/stdin`, `/dev/stdout`, or `/dev/stderr` was reopened).
-                                // XXX(jayb): likely we might want to have some backend-specific
-                                // metadata layer in our file system?
                                 litebox_util_log::error!(
                                     "standard stream is missing StdioStream metadata"
                                 );
-                                Errno::ENOTTY
+                                Errno::EIO
                             })?;
                         if self
                             .global

--- a/litebox_shim_linux/src/syscalls/file.rs
+++ b/litebox_shim_linux/src/syscalls/file.rs
@@ -14,7 +14,7 @@ use litebox::{
     fs::{Mode, OFlags, SeekWhence},
     mm::linux::PAGE_SIZE,
     path,
-    platform::StdioStream,
+    stdio::StdioStream,
     utils::{ReinterpretSignedExt as _, ReinterpretUnsignedExt as _, TruncateExt as _},
 };
 use litebox_common_linux::{
@@ -2201,7 +2201,12 @@ impl<Platform: ShimPlatform> Task<Platform> {
                                 );
                                 Errno::ENOTTY
                             })?;
-                        if self.global.platform.is_a_tty(stream) {
+                        if self
+                            .global
+                            .litebox
+                            .is_stdio_terminal(stream)
+                            .map_err(|_| Errno::EIO)?
+                        {
                             self.stdio_ioctl(&arg)
                         } else {
                             Err(Errno::ENOTTY)

--- a/litebox_shim_linux/src/syscalls/tests.rs
+++ b/litebox_shim_linux/src/syscalls/tests.rs
@@ -103,9 +103,9 @@ pub(crate) fn init_platform() -> crate::Task<TestPlatform> {
 }
 
 #[must_use]
-pub(crate) fn init_platform_with_pipe_broker() -> crate::Task<TestPlatform> {
+pub(crate) fn init_platform_with_broker() -> crate::Task<TestPlatform> {
     let platform = test_platform();
-    let setup = PipeBrokerSetup::new();
+    let setup = TestBrokerSetup::new();
     let (broker_local, ()) = BrokerLocal::negotiate(setup, |setup| {
         let memory: alloc::sync::Arc<dyn SharedMemory> = setup.memory.clone();
         Ok((setup.activate(), memory, ()))
@@ -129,12 +129,12 @@ fn init_platform_with_builder(
     shim_builder.build().0.new_test_task(fs)
 }
 
-struct PipeBrokerSetup {
+struct TestBrokerSetup {
     memory: alloc::sync::Arc<TestSharedMemory>,
     session: BrokerSession,
 }
 
-impl PipeBrokerSetup {
+impl TestBrokerSetup {
     fn new() -> Self {
         Self {
             memory: alloc::sync::Arc::new(TestSharedMemory::new()),
@@ -144,16 +144,16 @@ impl PipeBrokerSetup {
         }
     }
 
-    fn activate(self) -> PipeBrokerChannel {
+    fn activate(self) -> TestBrokerChannel {
         let shared_buffers = SharedBufferPool::new(self.memory, SHARED_BUFFER_LAYOUT).unwrap();
-        PipeBrokerChannel {
+        TestBrokerChannel {
             session: self.session,
             shared_buffers,
         }
     }
 }
 
-impl LocalSetupChannel for PipeBrokerSetup {
+impl LocalSetupChannel for TestBrokerSetup {
     type Error = core::convert::Infallible;
 
     fn send_handshake_request(
@@ -173,12 +173,12 @@ impl LocalSetupChannel for PipeBrokerSetup {
     }
 }
 
-struct PipeBrokerChannel {
+struct TestBrokerChannel {
     session: BrokerSession,
     shared_buffers: SharedBufferPool<alloc::sync::Arc<TestSharedMemory>>,
 }
 
-impl PipeBrokerChannel {
+impl TestBrokerChannel {
     fn execute(&self, operation: BrokerOperation) -> litebox_broker_core::Result<BrokerResult> {
         match operation {
             BrokerOperation::CloseObject(handle) => self
@@ -242,7 +242,7 @@ impl PipeBrokerChannel {
     }
 }
 
-impl LocalCallChannel for PipeBrokerChannel {
+impl LocalCallChannel for TestBrokerChannel {
     type Error = core::convert::Infallible;
 
     fn call(&self, request: BrokerRequest) -> core::result::Result<BrokerResponse, Self::Error> {
@@ -415,7 +415,7 @@ fn exceptions_queue_their_corresponding_signals() {
 
 #[test]
 fn test_fcntl() {
-    let task = init_platform_with_pipe_broker();
+    let task = init_platform_with_broker();
 
     let check = |fd: i32, flags1: OFlags, flags2: OFlags| {
         assert_eq!(
@@ -483,7 +483,7 @@ fn test_pipe2_requires_broker() {
 
 #[test]
 fn test_pipe2_race_with_concurrent_close() {
-    let task = init_platform_with_pipe_broker();
+    let task = init_platform_with_broker();
     task.files.borrow().set_max_fd(4);
 
     let stop = alloc::sync::Arc::new(core::sync::atomic::AtomicBool::new(false));

--- a/litebox_shim_linux/src/syscalls/tests.rs
+++ b/litebox_shim_linux/src/syscalls/tests.rs
@@ -3,23 +3,24 @@
 
 use litebox::fs::{Mode, OFlags};
 use litebox_broker_core::{
-    BrokerCore, BrokerError, BrokerSession, CallerCredential, ObjectRights, PolicyEngine,
-    SessionId,
+    AssociationCancellation, BrokerCore, BrokerError, BrokerSession, CallerCredential,
+    ObjectRights, PolicyEngine, SessionId,
     random::{RandomProvider, RandomProviderError},
     readiness::ReadinessRegistration,
     socket::{PlatformSocket, SocketProvider},
-    stdio::UnsupportedStdioProvider,
+    stdio::{StdioProvider, StdioProviderError},
 };
 use litebox_broker_local::BrokerLocal;
 use litebox_broker_protocol::{
     BROKER_PROTOCOL_VERSION,
     message::{
         BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerOperation, BrokerRequest,
-        BrokerResponse, BrokerResult, PipeRequest, PipeResponse,
+        BrokerResponse, BrokerResult, PipeRequest, PipeResponse, StdioRequest, StdioResponse,
     },
     pipe::{CreatePipeResponse, ReadPipeResponse, WritePipeResponse},
     shared_buffer::{SHARED_BUFFER_LAYOUT, SHARED_BUFFER_POOL_SIZE},
     socket::CreateSocketRequest,
+    stdio::{IsTerminalStdioResponse, StdioOutputStream, StdioStream},
 };
 use litebox_broker_transport::{
     channel::{LocalCallChannel, LocalSetupChannel},
@@ -63,10 +64,35 @@ fn test_broker() -> &'static BrokerCore {
             PolicyEngine::with_unauthenticated_rights(ObjectRights::all()),
             alloc::sync::Arc::new(PipeOnlySocketProvider),
             alloc::sync::Arc::new(UnusedRandomProvider),
-            alloc::sync::Arc::new(UnsupportedStdioProvider),
+            alloc::sync::Arc::new(TestStdioProvider),
         )
         .unwrap()
     })
+}
+
+struct TestStdioProvider;
+
+impl StdioProvider for TestStdioProvider {
+    fn read(
+        &self,
+        _cancellation: &AssociationCancellation,
+        _output: &mut [u8],
+    ) -> core::result::Result<usize, StdioProviderError> {
+        Err(StdioProviderError::Unsupported)
+    }
+
+    fn write(
+        &self,
+        _cancellation: &AssociationCancellation,
+        _stream: StdioOutputStream,
+        _input: &[u8],
+    ) -> core::result::Result<usize, StdioProviderError> {
+        Err(StdioProviderError::Unsupported)
+    }
+
+    fn is_terminal(&self, stream: StdioStream) -> core::result::Result<bool, StdioProviderError> {
+        Ok(stream == StdioStream::Stdout)
+    }
 }
 
 #[must_use]
@@ -198,6 +224,15 @@ impl PipeBrokerChannel {
                     |written| {
                         BrokerResult::Pipe(PipeResponse::Write(WritePipeResponse {
                             written: u32::try_from(written).unwrap(),
+                        }))
+                    },
+                )
+            }
+            BrokerOperation::Stdio(StdioRequest::IsTerminal(request)) => {
+                litebox_broker_core::stdio::is_terminal(&self.session, request.stream).map(
+                    |is_terminal| {
+                        BrokerResult::Stdio(StdioResponse::IsTerminal(IsTerminalStdioResponse {
+                            is_terminal,
                         }))
                     },
                 )


### PR DESCRIPTION
This PR routes Linux ioctl terminal capability queries for stdin, stdout, and stderr through the mandatory broker without a platform fallback, adds strict wire encoding and broker plumbing for terminal status, reports inherited-handle status from the Linux and Windows userland brokers, maps broker failures to EIO and confirmed non-terminals to ENOTTY, and preserves broker-owned stream identity when standard devices are reopened.