### PR TITLE
Cherry-pick Validate clone3 stack arguments before publishing parent TID (#1280) to ulitebox

### DIFF
--- a/litebox_shim_linux/src/syscalls/process.rs
+++ b/litebox_shim_linux/src/syscalls/process.rs
@@ -643,6 +643,10 @@ impl<Platform: ShimPlatform> Task<Platform> {
             return Err(Errno::EINVAL);
         }
 
+        if (stack == 0 && stack_size != 0) || (stack != 0 && clone3 && stack_size == 0) {
+            return Err(Errno::EINVAL);
+        }
+
         let explicit_tls = if flags.contains(CloneFlags::SETTLS) {
             let addr = tls.trunc();
             // Validate the user-controlled TLS base before spawning the thread.
@@ -703,9 +707,6 @@ impl<Platform: ShimPlatform> Task<Platform> {
             let _ = parent_tid_ptr.write_at_offset::<Platform>(0, child_tid);
         }
 
-        if (stack == 0 && stack_size != 0) || (stack != 0 && clone3 && stack_size == 0) {
-            return Err(Errno::EINVAL);
-        }
         let sp = if stack != 0 {
             let stack: usize = stack.trunc();
             Some(stack.wrapping_add(stack_size.trunc()))


### PR DESCRIPTION
Cherry-picks 15344cfad9db880caaf2a61f309142939b4d10bb from main to ulitebox.