### PR TITLE
Remove obsolete platform standard I/O provider

### DIFF
--- a/litebox/src/fs/devices.rs
+++ b/litebox/src/fs/devices.rs
@@ -115,7 +115,7 @@ impl Device {
 /// A [`super::backend::Backend`] that supports Unix-y devices.
 pub struct Devices<Platform>
 where
-    Platform: RawSyncPrimitivesProvider + crate::platform::StdioProvider + 'static,
+    Platform: RawSyncPrimitivesProvider + 'static,
 {
     litebox: LiteBox<Platform>,
     /// Stable inode info for this backend's root directory.
@@ -125,7 +125,7 @@ where
 
 impl<Platform> Devices<Platform>
 where
-    Platform: RawSyncPrimitivesProvider + crate::platform::StdioProvider + 'static,
+    Platform: RawSyncPrimitivesProvider + 'static,
 {
     /// Construct a new `Devices` backend.
     #[must_use]
@@ -152,13 +152,13 @@ pub struct DeviceFileHandle {
 pub struct DeviceDirHandle;
 
 impl<Platform> super::backend::private::Sealed for Devices<Platform> where
-    Platform: RawSyncPrimitivesProvider + crate::platform::StdioProvider + 'static
+    Platform: RawSyncPrimitivesProvider + 'static
 {
 }
 
 impl<Platform> BackendHandles for Devices<Platform>
 where
-    Platform: RawSyncPrimitivesProvider + crate::platform::StdioProvider + 'static,
+    Platform: RawSyncPrimitivesProvider + 'static,
 {
     type WalkingDirHandle<'a> = DeviceDirHandle;
     type FileHandle = DeviceFileHandle;
@@ -167,7 +167,7 @@ where
 
 impl<Platform> Backend for Devices<Platform>
 where
-    Platform: RawSyncPrimitivesProvider + crate::platform::StdioProvider + 'static,
+    Platform: RawSyncPrimitivesProvider + 'static,
 {
     fn root(&self) -> WalkingDirHandle<'_> {
         WalkingDirHandle::from_typed::<Self>(DeviceDirHandle)

--- a/litebox/src/fs/tests.rs
+++ b/litebox/src/fs/tests.rs
@@ -2133,7 +2133,8 @@ mod stdio {
     #[test]
     fn stdio_requires_broker() {
         let ctx = crate::fs::resolver::Context::new();
-        let litebox = LiteBox::new(MockPlatform::new());
+        let platform = MockPlatform::new();
+        let litebox = LiteBox::new(platform);
         let fs = Resolver::new(
             &litebox,
             crate::fs::composer::Composer::builder()
@@ -2233,7 +2234,8 @@ mod composed_stdio {
     #[test]
     fn stdio_requires_broker() {
         let ctx = crate::fs::resolver::Context::new();
-        let litebox = LiteBox::new(MockPlatform::new());
+        let platform = MockPlatform::new();
+        let litebox = LiteBox::new(platform);
         let fs = composed_fs(&litebox);
 
         let fd_stdout = fs

--- a/litebox/src/fs/tests.rs
+++ b/litebox/src/fs/tests.rs
@@ -2133,8 +2133,7 @@ mod stdio {
     #[test]
     fn stdio_requires_broker() {
         let ctx = crate::fs::resolver::Context::new();
-        let platform = MockPlatform::new();
-        let litebox = LiteBox::new(platform);
+        let litebox = LiteBox::new(MockPlatform::new());
         let fs = Resolver::new(
             &litebox,
             crate::fs::composer::Composer::builder()
@@ -2163,11 +2162,6 @@ mod stdio {
         ));
         fs.close(&fd_stderr).expect("Failed to close /dev/stderr");
 
-        platform
-            .stdin_queue
-            .write()
-            .unwrap()
-            .push_back(b"Hello, stdin!".to_vec());
         let fd_stdin = fs
             .open(&ctx, "/dev/stdin", OFlags::RDONLY, Mode::empty())
             .expect("Failed to open /dev/stdin");
@@ -2177,10 +2171,6 @@ mod stdio {
             fs.read(&fd_stdin, &mut buffer, None),
             Err(ReadError::Io)
         ));
-        assert_eq!(
-            platform.stdin_queue.read().unwrap().front().unwrap(),
-            b"Hello, stdin!"
-        );
         fs.close(&fd_stdin).expect("Failed to close /dev/stdin");
     }
 
@@ -2243,8 +2233,7 @@ mod composed_stdio {
     #[test]
     fn stdio_requires_broker() {
         let ctx = crate::fs::resolver::Context::new();
-        let platform = MockPlatform::new();
-        let litebox = LiteBox::new(platform);
+        let litebox = LiteBox::new(MockPlatform::new());
         let fs = composed_fs(&litebox);
 
         let fd_stdout = fs
@@ -2267,11 +2256,6 @@ mod composed_stdio {
         ));
         fs.close(&fd_stderr).expect("Failed to close /dev/stderr");
 
-        platform
-            .stdin_queue
-            .write()
-            .unwrap()
-            .push_back(b"Hello, composed stdin!".to_vec());
         let fd_stdin = fs
             .open(&ctx, "/dev/stdin", OFlags::RDONLY, Mode::empty())
             .expect("Failed to open /dev/stdin");
@@ -2281,10 +2265,6 @@ mod composed_stdio {
             fs.read(&fd_stdin, &mut buffer, None),
             Err(ReadError::Io)
         ));
-        assert_eq!(
-            platform.stdin_queue.read().unwrap().front().unwrap(),
-            b"Hello, composed stdin!"
-        );
         fs.close(&fd_stdin).expect("Failed to close /dev/stdin");
     }
 

--- a/litebox/src/platform/mock.rs
+++ b/litebox/src/platform/mock.rs
@@ -12,10 +12,7 @@
 extern crate std;
 
 use core::sync::atomic::AtomicU32;
-use std::collections::VecDeque;
-use std::sync::RwLock;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::vec::Vec;
 
 use super::*;
 
@@ -27,14 +24,9 @@ use super::*;
 /// - Full determinism
 ///   + time moves at one millisecond per "now" call
 /// - Debuging output goes to stderr
-/// - Can pre-fill stdin and check stdout easily between invocations (see [`Self::stdin_queue`],
-///   [`Self::stdout_queue`], and [`Self::stderr_queue`])
 /// - It will not mock you for using it during tests
 pub(crate) struct MockPlatform {
     current_time: AtomicU64,
-    pub(crate) stdin_queue: RwLock<VecDeque<Vec<u8>>>,
-    pub(crate) stdout_queue: RwLock<VecDeque<Vec<u8>>>,
-    pub(crate) stderr_queue: RwLock<VecDeque<Vec<u8>>>,
 }
 
 impl MockPlatform {
@@ -43,9 +35,6 @@ impl MockPlatform {
         //  order to give ourselves a statically lived platform easily.
         alloc::boxed::Box::leak(alloc::boxed::Box::new(MockPlatform {
             current_time: AtomicU64::new(0),
-            stdin_queue: RwLock::new(VecDeque::new()),
-            stdout_queue: RwLock::new(VecDeque::new()),
-            stderr_queue: RwLock::new(VecDeque::new()),
         }))
     }
 }
@@ -260,38 +249,6 @@ impl RawPointerProvider for MockPlatform {
     type RawConstPointer<T: zerocopy::FromBytes> = super::trivial_providers::TransparentConstPtr<T>;
     type RawMutPointer<T: zerocopy::FromBytes + zerocopy::IntoBytes> =
         super::trivial_providers::TransparentMutPtr<T>;
-}
-
-impl StdioProvider for MockPlatform {
-    fn read_from_stdin(&self, buf: &mut [u8]) -> Result<usize, StdioReadError> {
-        let Some(front) = self.stdin_queue.write().unwrap().pop_front() else {
-            return Err(StdioReadError::Closed);
-        };
-        let len = front.len().min(buf.len());
-        buf[..len].copy_from_slice(&front[..len]);
-        if front.len() > len {
-            self.stdin_queue
-                .write()
-                .unwrap()
-                .push_front(front.into_iter().skip(len).collect());
-        }
-        Ok(len)
-    }
-
-    fn write_to(&self, stream: StdioOutStream, buf: &[u8]) -> Result<usize, StdioWriteError> {
-        match stream {
-            StdioOutStream::Stdout => &self.stdout_queue,
-            StdioOutStream::Stderr => &self.stderr_queue,
-        }
-        .write()
-        .unwrap()
-        .push_back(buf.to_vec());
-        Ok(buf.len())
-    }
-
-    fn is_a_tty(&self, _stream: StdioStream) -> bool {
-        false
-    }
 }
 
 std::thread_local! {

--- a/litebox/src/platform/mod.rs
+++ b/litebox/src/platform/mod.rs
@@ -431,54 +431,6 @@ where
     }
 }
 
-/// A non-exhaustive list of errors that can be thrown by [`StdioProvider::read_from_stdin`].
-#[derive(Error, Debug)]
-#[non_exhaustive]
-pub enum StdioReadError {
-    #[error("input stream has been closed")]
-    Closed,
-}
-
-/// A non-exhaustive list of errors that can be thrown by [`StdioProvider::write_to`].
-#[derive(Error, Debug)]
-#[non_exhaustive]
-pub enum StdioWriteError {
-    #[error("output stream has been closed")]
-    Closed,
-}
-
-/// Possible standard output/error streams
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub enum StdioOutStream {
-    /// Standard output
-    Stdout,
-    /// Standard error
-    Stderr,
-}
-
-/// Possible standard input/output streams
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub enum StdioStream {
-    /// Standard input
-    Stdin = 0,
-    /// Standard output
-    Stdout = 1,
-    /// Standard error
-    Stderr = 2,
-}
-
-/// A provider of standard input/output functionality.
-pub trait StdioProvider {
-    /// Read from standard input. Returns number of bytes read.
-    fn read_from_stdin(&self, buf: &mut [u8]) -> Result<usize, StdioReadError>;
-
-    /// Write to stdout/stderr. Returns number of bytes written.
-    fn write_to(&self, stream: StdioOutStream, buf: &[u8]) -> Result<usize, StdioWriteError>;
-
-    /// Check if a stream is connected to a TTY.
-    fn is_a_tty(&self, stream: StdioStream) -> bool;
-}
-
 /// A provider for system information.
 pub trait SystemInfoProvider {
     /// Returns the address of the syscall entry point for the platform.

--- a/litebox_platform_linux_kernel/src/host/mock.rs
+++ b/litebox_platform_linux_kernel/src/host/mock.rs
@@ -81,17 +81,6 @@ impl HostInterface for MockHostInterface {
         todo!()
     }
 
-    fn read_from_stdin(_buf: &mut [u8]) -> Result<usize, litebox_common_linux::errno::Errno> {
-        todo!()
-    }
-
-    fn write_to(
-        _stream: litebox::platform::StdioOutStream,
-        _buf: &[u8],
-    ) -> Result<usize, litebox_common_linux::errno::Errno> {
-        todo!()
-    }
-
     fn current_system_time() -> core::time::Duration {
         let mut t = litebox_common_linux::Timespec::default();
         let ret = unsafe {

--- a/litebox_platform_linux_kernel/src/host/snp/snp_impl.rs
+++ b/litebox_platform_linux_kernel/src/host/snp/snp_impl.rs
@@ -325,8 +325,6 @@ const PAGE_SIZE: u64 = litebox::mm::linux::PAGE_SIZE as u64;
 const PHYS_ADDR_MAX: u64 = 0x10_0000_0000u64; // 64GB
 
 const NR_SYSCALL_FUTEX: u32 = 202;
-const NR_SYSCALL_READ: u32 = 0;
-const NR_SYSCALL_WRITE: u32 = 1;
 const NR_SYSCALL_EXIT: u32 = 60;
 const NR_SYSCALL_EXIT_GROUP: u32 = 231;
 const NR_SYSCALL_CLONE3: u32 = 435;
@@ -512,36 +510,6 @@ impl HostInterface for HostSnpInterface {
             ],
         })
         .map(|_| ())
-    }
-
-    fn read_from_stdin(buf: &mut [u8]) -> Result<usize, Errno> {
-        Self::syscalls(SyscallN::<3, NR_SYSCALL_READ> {
-            args: [
-                litebox_common_linux::STDIN_FILENO as u64,
-                buf.as_mut_ptr() as u64,
-                buf.len() as u64,
-            ],
-        })
-    }
-
-    fn write_to(stream: litebox::platform::StdioOutStream, buf: &[u8]) -> Result<usize, Errno> {
-        Self::syscalls(SyscallN::<3, NR_SYSCALL_WRITE> {
-            args: [
-                u64::from(
-                    match stream {
-                        litebox::platform::StdioOutStream::Stdout => {
-                            litebox_common_linux::STDOUT_FILENO
-                        }
-                        litebox::platform::StdioOutStream::Stderr => {
-                            litebox_common_linux::STDERR_FILENO
-                        }
-                    }
-                    .reinterpret_as_unsigned(),
-                ),
-                buf.as_ptr() as u64,
-                buf.len() as u64,
-            ],
-        })
     }
 
     fn current_system_time() -> core::time::Duration {

--- a/litebox_platform_linux_kernel/src/lib.rs
+++ b/litebox_platform_linux_kernel/src/lib.rs
@@ -284,30 +284,6 @@ impl litebox::platform::SystemTime for SystemTime {
     }
 }
 
-impl<Host: HostInterface> litebox::platform::StdioProvider for LinuxKernel<Host> {
-    fn read_from_stdin(&self, buf: &mut [u8]) -> Result<usize, litebox::platform::StdioReadError> {
-        Host::read_from_stdin(buf).map_err(|err| match err {
-            Errno::EPIPE => litebox::platform::StdioReadError::Closed,
-            _ => panic!("unhandled error {err}"),
-        })
-    }
-
-    fn write_to(
-        &self,
-        stream: litebox::platform::StdioOutStream,
-        buf: &[u8],
-    ) -> Result<usize, litebox::platform::StdioWriteError> {
-        Host::write_to(stream, buf).map_err(|err| match err {
-            Errno::EPIPE => litebox::platform::StdioWriteError::Closed,
-            _ => panic!("unhandled error {err}"),
-        })
-    }
-
-    fn is_a_tty(&self, _stream: litebox::platform::StdioStream) -> bool {
-        false
-    }
-}
-
 /// Platform-Host Interface
 pub trait HostInterface: 'static {
     /// Page allocation from host.
@@ -342,11 +318,6 @@ pub trait HostInterface: 'static {
 
     /// Terminate the current process.
     fn terminate_process(code: i32) -> !;
-
-    // For Stdio
-    fn read_from_stdin(buf: &mut [u8]) -> Result<usize, Errno>;
-
-    fn write_to(stream: litebox::platform::StdioOutStream, buf: &[u8]) -> Result<usize, Errno>;
 
     /// Returns the current system time as a [`Duration`](core::time::Duration) since the
     /// UNIX epoch.

--- a/litebox_platform_linux_userland/src/lib.rs
+++ b/litebox_platform_linux_userland/src/lib.rs
@@ -9,7 +9,6 @@
 ))]
 
 use std::cell::Cell;
-use std::io::IsTerminal as _;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicI32, AtomicU32, Ordering};
 use std::time::Duration;
@@ -129,7 +128,6 @@ pub struct LinuxUserland {
     /// is persistent across multiple process executions, however, it is ephemeral across true
     /// reboots.
     boot_id: std::sync::OnceLock<Vec<u8>>,
-    stdio_is_tty: [bool; 3],
 }
 
 impl core::fmt::Debug for LinuxUserland {
@@ -160,11 +158,6 @@ impl LinuxUserland {
             reserved_pages,
             cow_regions: std::sync::RwLock::new(std::collections::BTreeMap::new()),
             boot_id: std::sync::OnceLock::new(),
-            stdio_is_tty: [
-                std::io::stdin().is_terminal(),
-                std::io::stdout().is_terminal(),
-                std::io::stderr().is_terminal(),
-            ],
         };
         Box::leak(Box::new(platform))
     }
@@ -1715,54 +1708,6 @@ impl<const ALIGN: usize> litebox::platform::PageManagementProvider<ALIGN> for Li
             Ok(ptr) => Ok(UserMutPtr::from_usize(ptr)),
             Err(_) => Err(CowAllocationError::InternalFailure),
         }
-    }
-}
-
-impl litebox::platform::StdioProvider for LinuxUserland {
-    fn read_from_stdin(&self, buf: &mut [u8]) -> Result<usize, litebox::platform::StdioReadError> {
-        unsafe {
-            syscalls::syscall3(
-                syscalls::Sysno::read,
-                usize::try_from(litebox_common_linux::STDIN_FILENO).unwrap(),
-                buf.as_ptr() as usize,
-                buf.len(),
-            )
-        }
-        .map_err(|err| match err {
-            syscalls::Errno::EPIPE => litebox::platform::StdioReadError::Closed,
-            _ => panic!("unhandled error {err}"),
-        })
-    }
-
-    fn write_to(
-        &self,
-        stream: litebox::platform::StdioOutStream,
-        buf: &[u8],
-    ) -> Result<usize, litebox::platform::StdioWriteError> {
-        unsafe {
-            syscalls::syscall3(
-                syscalls::Sysno::write,
-                usize::try_from(match stream {
-                    litebox::platform::StdioOutStream::Stdout => {
-                        litebox_common_linux::STDOUT_FILENO
-                    }
-                    litebox::platform::StdioOutStream::Stderr => {
-                        litebox_common_linux::STDERR_FILENO
-                    }
-                })
-                .unwrap(),
-                buf.as_ptr() as usize,
-                buf.len(),
-            )
-        }
-        .map_err(|err| match err {
-            syscalls::Errno::EPIPE => litebox::platform::StdioWriteError::Closed,
-            _ => panic!("unhandled error {err}"),
-        })
-    }
-
-    fn is_a_tty(&self, stream: litebox::platform::StdioStream) -> bool {
-        self.stdio_is_tty[stream as usize]
     }
 }
 

--- a/litebox_platform_lvbs/src/lib.rs
+++ b/litebox_platform_lvbs/src/lib.rs
@@ -11,8 +11,8 @@ use core::sync::atomic::AtomicU32;
 use hashbrown::HashMap;
 use litebox::platform::{
     ArchSpecificError, ArchSpecificProvider, ArchSpecificRegister, ImmediatelyWokenUp,
-    PageManagementProvider, RawMutex as _, RawMutexProvider, RawPointerProvider, StdioProvider,
-    TimeProvider, UnblockedOrTimedOut, page_mgmt::DeallocationError,
+    PageManagementProvider, RawMutex as _, RawMutexProvider, RawPointerProvider, TimeProvider,
+    UnblockedOrTimedOut, page_mgmt::DeallocationError,
 };
 use litebox::{
     mm::linux::{PAGE_SIZE, PageRange},
@@ -1040,24 +1040,6 @@ impl<Host: HostInterface> litebox::mm::linux::VmemPageFaultHandler for LinuxKern
 
     fn access_error(error_code: u64, flags: litebox::mm::linux::VmFlags) -> bool {
         mm::PageTable::<PAGE_SIZE>::access_error(error_code, flags)
-    }
-}
-
-impl<Host: HostInterface> StdioProvider for LinuxKernel<Host> {
-    fn read_from_stdin(&self, _buf: &mut [u8]) -> Result<usize, litebox::platform::StdioReadError> {
-        unimplemented!()
-    }
-
-    fn write_to(
-        &self,
-        _stream: litebox::platform::StdioOutStream,
-        _buf: &[u8],
-    ) -> Result<usize, litebox::platform::StdioWriteError> {
-        unimplemented!()
-    }
-
-    fn is_a_tty(&self, _stream: litebox::platform::StdioStream) -> bool {
-        unimplemented!()
     }
 }
 

--- a/litebox_platform_windows_userland/src/lib.rs
+++ b/litebox_platform_windows_userland/src/lib.rs
@@ -1837,57 +1837,6 @@ impl<const ALIGN: usize> litebox::platform::PageManagementProvider<ALIGN> for Wi
     }
 }
 
-impl litebox::platform::StdioProvider for WindowsUserland {
-    fn read_from_stdin(&self, buf: &mut [u8]) -> Result<usize, litebox::platform::StdioReadError> {
-        use std::io::Read as _;
-        std::io::stdin().read(buf).map_err(|err| {
-            if err.kind() == std::io::ErrorKind::BrokenPipe {
-                litebox::platform::StdioReadError::Closed
-            } else {
-                panic!("unhandled error {err}")
-            }
-        })
-    }
-
-    fn write_to(
-        &self,
-        stream: litebox::platform::StdioOutStream,
-        buf: &[u8],
-    ) -> Result<usize, litebox::platform::StdioWriteError> {
-        use std::io::Write as _;
-        match stream {
-            litebox::platform::StdioOutStream::Stdout => {
-                std::io::stdout().write(buf).map_err(|err| {
-                    if err.kind() == std::io::ErrorKind::BrokenPipe {
-                        litebox::platform::StdioWriteError::Closed
-                    } else {
-                        panic!("unhandled error {err}")
-                    }
-                })
-            }
-            litebox::platform::StdioOutStream::Stderr => {
-                std::io::stderr().write(buf).map_err(|err| {
-                    if err.kind() == std::io::ErrorKind::BrokenPipe {
-                        litebox::platform::StdioWriteError::Closed
-                    } else {
-                        panic!("unhandled error {err}")
-                    }
-                })
-            }
-        }
-    }
-
-    fn is_a_tty(&self, stream: litebox::platform::StdioStream) -> bool {
-        use litebox::platform::StdioStream;
-        use std::io::IsTerminal as _;
-        match stream {
-            StdioStream::Stdin => std::io::stdin().is_terminal(),
-            StdioStream::Stdout => std::io::stdout().is_terminal(),
-            StdioStream::Stderr => std::io::stderr().is_terminal(),
-        }
-    }
-}
-
 #[global_allocator]
 static SLAB_ALLOC: litebox::mm::allocator::SafeZoneAllocator<'static, 28, WindowsUserland> =
     litebox::mm::allocator::SafeZoneAllocator::new();

--- a/litebox_shim_linux/src/lib.rs
+++ b/litebox_shim_linux/src/lib.rs
@@ -81,7 +81,6 @@ pub trait ShimPlatform:
     + litebox::platform::RawMutexProvider
     + litebox::sync::RawSyncPrimitivesProvider
     + litebox::platform::SystemInfoProvider
-    + litebox::platform::StdioProvider
     + litebox::platform::ArchSpecificProvider
     + litebox::platform::ThreadProvider<ExecutionContext = litebox_common_linux::PtRegs>
     + litebox::platform::TimerProvider<Signal = litebox_common_linux::signal::Signal>
@@ -98,7 +97,6 @@ impl<T> ShimPlatform for T where
         + litebox::platform::RawMutexProvider
         + litebox::sync::RawSyncPrimitivesProvider
         + litebox::platform::SystemInfoProvider
-        + litebox::platform::StdioProvider
         + litebox::platform::ArchSpecificProvider
         + litebox::platform::ThreadProvider<ExecutionContext = litebox_common_linux::PtRegs>
         + litebox::platform::TimerProvider<Signal = litebox_common_linux::signal::Signal>

--- a/litebox_shim_windows/src/lib.rs
+++ b/litebox_shim_windows/src/lib.rs
@@ -23,7 +23,7 @@ use litebox::LiteBox;
 use litebox::mm::PageManager;
 use litebox::platform::{
     ArchSpecificProvider, ArchSpecificRegister, PageManagementProvider, RawConstPointer as _,
-    RawMutPointer as _, RawPointerProvider, StdioProvider, SystemInfoProvider, TimeProvider,
+    RawMutPointer as _, RawPointerProvider, SystemInfoProvider, TimeProvider,
 };
 use litebox::shim::{ContinueOperation, EnterShim, ExceptionInfo};
 use litebox::sync::{Mutex, RawSyncPrimitivesProvider};
@@ -423,10 +423,7 @@ impl<Platform: ShimPlatform> WindowsShimBuilder<Platform> {
         &self,
         in_mem: litebox::fs::in_mem::InMem<Platform>,
         tar_data: Cow<'static, [u8]>,
-    ) -> DefaultFS<Platform>
-    where
-        Platform: StdioProvider,
-    {
+    ) -> DefaultFS<Platform> {
         default_fs(&self.litebox, in_mem, tar_data)
     }
 
@@ -3192,7 +3189,7 @@ fn default_fs<Platform>(
     tar_data: Cow<'static, [u8]>,
 ) -> WindowsFS<Platform>
 where
-    Platform: ShimPlatform + StdioProvider,
+    Platform: ShimPlatform,
 {
     litebox::fs::resolver::Resolver::new(
         litebox,


### PR DESCRIPTION
This PR removes the obsolete platform StdioProvider API, stream and error types, platform and Linux-kernel host implementations, mock state, and redundant filesystem and shim bounds now that standard input, output, and terminal queries are broker-authoritative.