### PR TITLE
Add per-session reference and pipe quotas

### DIFF
--- a/litebox_broker_core/src/lib.rs
+++ b/litebox_broker_core/src/lib.rs
@@ -51,15 +51,19 @@ use stdio::StdioProvider;
 /// BrokerCore result type.
 pub type Result<T> = core::result::Result<T, BrokerError>;
 
-/// Resource limits for broker-owned authority state.
+/// Broker-wide ceilings and per-session quotas for broker-owned authority state.
 ///
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct BrokerCoreLimits {
-    /// Maximum live object references.
+    /// Maximum live object references across all sessions.
     pub max_references: usize,
-    /// Maximum total capacity in bytes reserved by live pipes.
+    /// Maximum live object references owned by one session.
+    pub max_references_per_session: usize,
+    /// Maximum total capacity in bytes reserved by live pipes across all sessions.
     pub max_total_pipe_capacity: usize,
+    /// Maximum capacity in bytes reserved by live pipes created by one session.
+    pub max_pipe_capacity_per_session: usize,
     /// Maximum live platform socket resources across all sessions.
     pub max_sockets: usize,
     /// Maximum live platform socket resources owned by one session.
@@ -67,25 +71,36 @@ pub struct BrokerCoreLimits {
 }
 
 impl BrokerCoreLimits {
-    /// Conservative default limits for initial broker deployments.
+    /// Conservative default limits that allow four sessions to reach each
+    /// broker-wide ceiling only when all four spend their full quotas.
     pub const DEFAULT: Self = Self {
         max_references: 4096,
+        max_references_per_session: 1024,
         max_total_pipe_capacity: 64 * 1024 * 1024,
+        max_pipe_capacity_per_session: 16 * 1024 * 1024,
         max_sockets: 1024,
         max_sockets_per_session: 256,
     };
 
     /// Creates a broker core limit set.
+    ///
+    /// The reference and pipe-capacity session quotas initially match their
+    /// broker-wide limits. Use [`Self::with_session_quotas`] to override them.
     pub const fn new(max_references: usize, max_total_pipe_capacity: usize) -> Self {
         Self {
             max_references,
+            max_references_per_session: max_references,
             max_total_pipe_capacity,
+            max_pipe_capacity_per_session: max_total_pipe_capacity,
             max_sockets: Self::DEFAULT.max_sockets,
             max_sockets_per_session: Self::DEFAULT.max_sockets_per_session,
         }
     }
 
-    /// Creates a broker core limit set with every limit specified explicitly.
+    /// Creates a broker core limit set with explicit socket limits.
+    ///
+    /// The reference and pipe-capacity session quotas initially match their
+    /// broker-wide limits. Use [`Self::with_session_quotas`] to override them.
     pub const fn new_with_all_limits(
         max_references: usize,
         max_total_pipe_capacity: usize,
@@ -94,9 +109,28 @@ impl BrokerCoreLimits {
     ) -> Self {
         Self {
             max_references,
+            max_references_per_session: max_references,
             max_total_pipe_capacity,
+            max_pipe_capacity_per_session: max_total_pipe_capacity,
             max_sockets,
             max_sockets_per_session,
+        }
+    }
+
+    /// Returns these limits with explicit per-session reference and pipe-capacity quotas.
+    ///
+    /// A quota above its broker-wide limit is accepted; the broker-wide limit
+    /// still applies, so the effective limit is the smaller value.
+    #[must_use]
+    pub const fn with_session_quotas(
+        self,
+        max_references_per_session: usize,
+        max_pipe_capacity_per_session: usize,
+    ) -> Self {
+        Self {
+            max_references_per_session,
+            max_pipe_capacity_per_session,
+            ..self
         }
     }
 }

--- a/litebox_broker_core/src/pipe.rs
+++ b/litebox_broker_core/src/pipe.rs
@@ -191,58 +191,54 @@ enum PipeEndpoint {
 }
 
 struct PipeCapacityReservation {
-    broker_reserved_capacity: Arc<AtomicUsize>,
-    session_reserved_capacity: Arc<AtomicUsize>,
-    capacity: usize,
+    global_counter: Arc<AtomicUsize>,
+    session_counter: Arc<AtomicUsize>,
+    amount: usize,
 }
 
 impl PipeCapacityReservation {
-    fn new(session: &BrokerSession, capacity: usize) -> Result<Self> {
-        let broker_reserved_capacity = Arc::clone(&session.core.reserved_pipe_capacity);
+    fn new(session: &BrokerSession, amount: usize) -> Result<Self> {
         reserve_pipe_capacity(
-            &broker_reserved_capacity,
-            capacity,
+            &session.core.reserved_pipe_capacity,
+            amount,
             session.core.limits.max_total_pipe_capacity,
         )?;
-        let session_reserved_capacity = Arc::clone(&session.reserved_pipe_capacity);
         if let Err(error) = reserve_pipe_capacity(
-            &session_reserved_capacity,
-            capacity,
+            &session.reserved_pipe_capacity,
+            amount,
             session.core.limits.max_pipe_capacity_per_session,
         ) {
-            release_pipe_capacity(&broker_reserved_capacity, capacity);
+            release_pipe_capacity(&session.core.reserved_pipe_capacity, amount);
             return Err(error);
         }
         Ok(Self {
-            broker_reserved_capacity,
-            session_reserved_capacity,
-            capacity,
+            global_counter: Arc::clone(&session.core.reserved_pipe_capacity),
+            session_counter: Arc::clone(&session.reserved_pipe_capacity),
+            amount,
         })
     }
 }
 
 impl Drop for PipeCapacityReservation {
     fn drop(&mut self) {
-        release_pipe_capacity(&self.session_reserved_capacity, self.capacity);
-        release_pipe_capacity(&self.broker_reserved_capacity, self.capacity);
+        release_pipe_capacity(&self.session_counter, self.amount);
+        release_pipe_capacity(&self.global_counter, self.amount);
     }
 }
 
-fn reserve_pipe_capacity(counter: &AtomicUsize, capacity: usize, limit: usize) -> Result<()> {
+fn reserve_pipe_capacity(counter: &AtomicUsize, amount: usize, limit: usize) -> Result<()> {
     counter
-        .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |reserved| {
-            reserved
-                .checked_add(capacity)
-                .filter(|total| *total <= limit)
+        .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+            current.checked_add(amount).filter(|next| *next <= limit)
         })
         .map(|_| ())
         .map_err(|_| BrokerError::ResourceExhausted)
 }
 
-fn release_pipe_capacity(counter: &AtomicUsize, capacity: usize) {
+fn release_pipe_capacity(counter: &AtomicUsize, amount: usize) {
     counter
-        .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |reserved| {
-            reserved.checked_sub(capacity)
+        .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+            current.checked_sub(amount)
         })
         .expect("reserved pipe capacity must include every live pipe");
 }

--- a/litebox_broker_core/src/pipe.rs
+++ b/litebox_broker_core/src/pipe.rs
@@ -190,59 +190,61 @@ enum PipeEndpoint {
     Write,
 }
 
-struct CapacityCharge {
-    reserved_capacity: Arc<AtomicUsize>,
-    capacity: usize,
-}
-
-impl CapacityCharge {
-    fn new(reserved_capacity: Arc<AtomicUsize>, capacity: usize, limit: usize) -> Result<Self> {
-        reserved_capacity
-            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |reserved| {
-                reserved
-                    .checked_add(capacity)
-                    .filter(|total| *total <= limit)
-            })
-            .map_err(|_| BrokerError::ResourceExhausted)?;
-        Ok(Self {
-            reserved_capacity,
-            capacity,
-        })
-    }
-}
-
-impl Drop for CapacityCharge {
-    fn drop(&mut self) {
-        self.reserved_capacity
-            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |reserved| {
-                reserved.checked_sub(self.capacity)
-            })
-            .expect("reserved pipe capacity must include every live pipe");
-    }
-}
-
 struct PipeCapacityReservation {
-    _session: CapacityCharge,
-    _broker: CapacityCharge,
+    broker_reserved_capacity: Arc<AtomicUsize>,
+    session_reserved_capacity: Arc<AtomicUsize>,
+    capacity: usize,
 }
 
 impl PipeCapacityReservation {
     fn new(session: &BrokerSession, capacity: usize) -> Result<Self> {
-        let broker_charge = CapacityCharge::new(
-            Arc::clone(&session.core.reserved_pipe_capacity),
+        let broker_reserved_capacity = Arc::clone(&session.core.reserved_pipe_capacity);
+        reserve_pipe_capacity(
+            &broker_reserved_capacity,
             capacity,
             session.core.limits.max_total_pipe_capacity,
         )?;
-        let session_charge = CapacityCharge::new(
-            Arc::clone(&session.reserved_pipe_capacity),
+        let session_reserved_capacity = Arc::clone(&session.reserved_pipe_capacity);
+        if let Err(error) = reserve_pipe_capacity(
+            &session_reserved_capacity,
             capacity,
             session.core.limits.max_pipe_capacity_per_session,
-        )?;
+        ) {
+            release_pipe_capacity(&broker_reserved_capacity, capacity);
+            return Err(error);
+        }
         Ok(Self {
-            _session: session_charge,
-            _broker: broker_charge,
+            broker_reserved_capacity,
+            session_reserved_capacity,
+            capacity,
         })
     }
+}
+
+impl Drop for PipeCapacityReservation {
+    fn drop(&mut self) {
+        release_pipe_capacity(&self.session_reserved_capacity, self.capacity);
+        release_pipe_capacity(&self.broker_reserved_capacity, self.capacity);
+    }
+}
+
+fn reserve_pipe_capacity(counter: &AtomicUsize, capacity: usize, limit: usize) -> Result<()> {
+    counter
+        .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |reserved| {
+            reserved
+                .checked_add(capacity)
+                .filter(|total| *total <= limit)
+        })
+        .map(|_| ())
+        .map_err(|_| BrokerError::ResourceExhausted)
+}
+
+fn release_pipe_capacity(counter: &AtomicUsize, capacity: usize) {
+    counter
+        .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |reserved| {
+            reserved.checked_sub(capacity)
+        })
+        .expect("reserved pipe capacity must include every live pipe");
 }
 
 struct PipeState {

--- a/litebox_broker_core/src/pipe.rs
+++ b/litebox_broker_core/src/pipe.rs
@@ -193,54 +193,57 @@ enum PipeEndpoint {
 struct PipeCapacityReservation {
     global_counter: Arc<AtomicUsize>,
     session_counter: Arc<AtomicUsize>,
-    amount: usize,
+    capacity: usize,
 }
 
 impl PipeCapacityReservation {
-    fn new(session: &BrokerSession, amount: usize) -> Result<Self> {
-        reserve_pipe_capacity(
-            &session.core.reserved_pipe_capacity,
-            amount,
-            session.core.limits.max_total_pipe_capacity,
-        )?;
-        if let Err(error) = reserve_pipe_capacity(
-            &session.reserved_pipe_capacity,
-            amount,
-            session.core.limits.max_pipe_capacity_per_session,
-        ) {
-            release_pipe_capacity(&session.core.reserved_pipe_capacity, amount);
-            return Err(error);
+    fn new(session: &BrokerSession, capacity: usize) -> Result<Self> {
+        let global_counter = Arc::clone(&session.core.reserved_pipe_capacity);
+        global_counter
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |reserved| {
+                reserved
+                    .checked_add(capacity)
+                    .filter(|total| *total <= session.core.limits.max_total_pipe_capacity)
+            })
+            .map_err(|_| BrokerError::ResourceExhausted)?;
+
+        let session_counter = Arc::clone(&session.reserved_pipe_capacity);
+        if session_counter
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |reserved| {
+                reserved
+                    .checked_add(capacity)
+                    .filter(|total| *total <= session.core.limits.max_pipe_capacity_per_session)
+            })
+            .is_err()
+        {
+            global_counter
+                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |reserved| {
+                    reserved.checked_sub(capacity)
+                })
+                .expect("reserved broker pipe capacity must include the pending pipe");
+            return Err(BrokerError::ResourceExhausted);
         }
         Ok(Self {
-            global_counter: Arc::clone(&session.core.reserved_pipe_capacity),
-            session_counter: Arc::clone(&session.reserved_pipe_capacity),
-            amount,
+            global_counter,
+            session_counter,
+            capacity,
         })
     }
 }
 
 impl Drop for PipeCapacityReservation {
     fn drop(&mut self) {
-        release_pipe_capacity(&self.session_counter, self.amount);
-        release_pipe_capacity(&self.global_counter, self.amount);
+        self.session_counter
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |reserved| {
+                reserved.checked_sub(self.capacity)
+            })
+            .expect("reserved session pipe capacity must include every live pipe");
+        self.global_counter
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |reserved| {
+                reserved.checked_sub(self.capacity)
+            })
+            .expect("reserved broker pipe capacity must include every live pipe");
     }
-}
-
-fn reserve_pipe_capacity(counter: &AtomicUsize, amount: usize, limit: usize) -> Result<()> {
-    counter
-        .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
-            current.checked_add(amount).filter(|next| *next <= limit)
-        })
-        .map(|_| ())
-        .map_err(|_| BrokerError::ResourceExhausted)
-}
-
-fn release_pipe_capacity(counter: &AtomicUsize, amount: usize) {
-    counter
-        .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
-            current.checked_sub(amount)
-        })
-        .expect("reserved pipe capacity must include every live pipe");
 }
 
 struct PipeState {

--- a/litebox_broker_core/src/pipe.rs
+++ b/litebox_broker_core/src/pipe.rs
@@ -190,19 +190,18 @@ enum PipeEndpoint {
     Write,
 }
 
-struct PipeCapacityReservation {
+struct CapacityCharge {
     reserved_capacity: Arc<AtomicUsize>,
     capacity: usize,
 }
 
-impl PipeCapacityReservation {
-    fn new(session: &BrokerSession, capacity: usize) -> Result<Self> {
-        let reserved_capacity = Arc::clone(&session.core.reserved_pipe_capacity);
+impl CapacityCharge {
+    fn new(reserved_capacity: Arc<AtomicUsize>, capacity: usize, limit: usize) -> Result<Self> {
         reserved_capacity
             .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |reserved| {
                 reserved
                     .checked_add(capacity)
-                    .filter(|total| *total <= session.core.limits.max_total_pipe_capacity)
+                    .filter(|total| *total <= limit)
             })
             .map_err(|_| BrokerError::ResourceExhausted)?;
         Ok(Self {
@@ -212,13 +211,37 @@ impl PipeCapacityReservation {
     }
 }
 
-impl Drop for PipeCapacityReservation {
+impl Drop for CapacityCharge {
     fn drop(&mut self) {
         self.reserved_capacity
             .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |reserved| {
                 reserved.checked_sub(self.capacity)
             })
             .expect("reserved pipe capacity must include every live pipe");
+    }
+}
+
+struct PipeCapacityReservation {
+    _session: CapacityCharge,
+    _broker: CapacityCharge,
+}
+
+impl PipeCapacityReservation {
+    fn new(session: &BrokerSession, capacity: usize) -> Result<Self> {
+        let broker_charge = CapacityCharge::new(
+            Arc::clone(&session.core.reserved_pipe_capacity),
+            capacity,
+            session.core.limits.max_total_pipe_capacity,
+        )?;
+        let session_charge = CapacityCharge::new(
+            Arc::clone(&session.reserved_pipe_capacity),
+            capacity,
+            session.core.limits.max_pipe_capacity_per_session,
+        )?;
+        Ok(Self {
+            _session: session_charge,
+            _broker: broker_charge,
+        })
     }
 }
 

--- a/litebox_broker_core/src/session.rs
+++ b/litebox_broker_core/src/session.rs
@@ -93,6 +93,8 @@ pub struct BrokerSession {
     pub(crate) caller_credential: CallerCredential,
     /// Handles of the live object references owned by this session.
     references: Mutex<SessionReferences>,
+    /// Pipe capacity charged to this session by live pipe objects.
+    pub(crate) reserved_pipe_capacity: Arc<AtomicUsize>,
     /// Socket quota held by pending, live, and closing in-flight resources.
     pub(crate) reserved_sockets: Arc<AtomicUsize>,
     /// Cancellation state for potentially blocking operations in this session.
@@ -114,6 +116,7 @@ impl BrokerSession {
                 handles: Vec::new(),
                 pending_handles: 0,
             }),
+            reserved_pipe_capacity: Arc::new(AtomicUsize::new(0)),
             reserved_sockets: Arc::new(AtomicUsize::new(0)),
             cancellation: AssociationCancellation::default(),
         }
@@ -132,13 +135,7 @@ impl BrokerSession {
             .principal_object_rights(self.caller_credential)?;
         let object = Arc::new(RwLock::new(object));
         let mut session_references = self.references.lock();
-        let additional = session_references
-            .pending_handles
-            .checked_add(1)
-            .ok_or(BrokerError::ResourceExhausted)?;
-        if session_references.handles.try_reserve(additional).is_err() {
-            return Err(BrokerError::OutOfMemory);
-        }
+        self.prepare_session_references(&mut session_references, 1)?;
         let mut references = self.core.references.write();
         let preparation = (|| {
             let pending = self.core.pending_references.load(Ordering::Relaxed);
@@ -193,13 +190,7 @@ impl BrokerSession {
         let first = Arc::new(RwLock::new(first));
         let second = Arc::new(RwLock::new(second));
         let mut session_references = self.references.lock();
-        let additional = session_references
-            .pending_handles
-            .checked_add(2)
-            .ok_or(BrokerError::ResourceExhausted)?;
-        if session_references.handles.try_reserve(additional).is_err() {
-            return Err(BrokerError::OutOfMemory);
-        }
+        self.prepare_session_references(&mut session_references, 2)?;
         let mut references = self.core.references.write();
         let preparation = (|| {
             let pending = self.core.pending_references.load(Ordering::Relaxed);
@@ -253,14 +244,7 @@ impl BrokerSession {
     ) -> Result<PendingObjectReference<'_>> {
         let object = Arc::new(RwLock::new(ObjectEntry::Reserved));
         let mut session_references = self.references.lock();
-        let next_session_pending = session_references
-            .pending_handles
-            .checked_add(1)
-            .ok_or(BrokerError::ResourceExhausted)?;
-        session_references
-            .handles
-            .try_reserve(next_session_pending)
-            .map_err(|_| BrokerError::OutOfMemory)?;
+        let next_session_pending = self.prepare_session_references(&mut session_references, 1)?;
         let mut references = self.core.references.write();
         let pending_references = self.core.pending_references.load(Ordering::Relaxed);
         if references
@@ -295,6 +279,30 @@ impl BrokerSession {
             object,
             active: true,
         })
+    }
+
+    fn prepare_session_references(
+        &self,
+        session_references: &mut SessionReferences,
+        additional: usize,
+    ) -> Result<usize> {
+        let pending_and_additional = session_references
+            .pending_handles
+            .checked_add(additional)
+            .ok_or(BrokerError::ResourceExhausted)?;
+        if session_references
+            .handles
+            .len()
+            .checked_add(pending_and_additional)
+            .is_none_or(|count| count > self.core.limits.max_references_per_session)
+        {
+            return Err(BrokerError::ResourceExhausted);
+        }
+        session_references
+            .handles
+            .try_reserve(pending_and_additional)
+            .map_err(|_| BrokerError::OutOfMemory)?;
+        Ok(pending_and_additional)
     }
 
     fn insert_object_reference(
@@ -541,6 +549,11 @@ mod tests {
     use litebox_broker_protocol::readiness::ReadinessFlags;
     use std::{sync::Arc, vec::Vec};
 
+    const TEST_MAX_REFERENCES: usize = 4;
+    const TEST_MAX_PIPE_CAPACITY: usize = 8;
+    const TEST_MAX_REFERENCES_PER_SESSION: usize = 2;
+    const TEST_MAX_PIPE_CAPACITY_PER_SESSION: usize = 4;
+
     #[test]
     fn pending_reference_release_checks_both_counters() {
         let core_pending_references = AtomicUsize::new(1);
@@ -569,7 +582,16 @@ mod tests {
         let broker = BrokerCore::new_with_limits(
             PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
                 .with_socket_policy(SocketPolicy::guest_network()),
-            BrokerCoreLimits::new_with_all_limits(2, 4, 2, 1),
+            BrokerCoreLimits::new_with_all_limits(
+                TEST_MAX_REFERENCES,
+                TEST_MAX_PIPE_CAPACITY,
+                2,
+                1,
+            )
+            .with_session_quotas(
+                TEST_MAX_REFERENCES_PER_SESSION,
+                TEST_MAX_PIPE_CAPACITY_PER_SESSION,
+            ),
             socket_provider.clone(),
             Arc::new(crate::random::TestRandomProvider),
             Arc::new(crate::stdio::UnsupportedStdioProvider),
@@ -582,10 +604,16 @@ mod tests {
         check_pipe_reader_closure(&broker);
         check_corrupt_index_fails_without_mutation(&broker);
         check_corrupt_index_does_not_break_teardown(&broker);
+        check_reference_quota_is_per_session(&broker);
+        check_pending_references_count_toward_session_quota(&broker);
+        check_pipe_capacity_quota_is_per_session(&broker);
+        check_pipe_capacity_is_released_when_reference_creation_fails(&broker);
+        check_pipe_capacity_outlives_session_for_in_flight_object(&broker);
         crate::socket::tests::check_socket_lifecycle(&broker, &socket_provider);
         check_pair_handle_exhaustion(&broker);
 
         assert!(broker.references.read().is_empty());
+        assert_eq!(broker.reserved_pipe_capacity.load(Ordering::Relaxed), 0);
     }
 
     fn check_event_reference_lifecycle(broker: &BrokerCore) {
@@ -768,6 +796,168 @@ mod tests {
         drop(session);
 
         assert!(broker.references.read().is_empty());
+    }
+
+    fn check_reference_quota_is_per_session(broker: &BrokerCore) {
+        let greedy = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let neighbor = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+
+        let greedy_first = crate::event::create(&greedy, 0).unwrap();
+        let greedy_second = crate::event::create(&greedy, 0).unwrap();
+        assert_eq!(
+            crate::event::create(&greedy, 0),
+            Err(BrokerError::ResourceExhausted)
+        );
+
+        let neighbor_first = crate::event::create(&neighbor, 0).unwrap();
+        let neighbor_second = crate::event::create(&neighbor, 0).unwrap();
+        assert_eq!(broker.references.read().len(), TEST_MAX_REFERENCES);
+
+        let latecomer = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        assert_eq!(
+            crate::event::create(&latecomer, 0),
+            Err(BrokerError::ResourceExhausted)
+        );
+
+        assert_eq!(greedy.close_object_reference(greedy_first), Ok(()));
+        let latecomer_handle = crate::event::create(&latecomer, 0).unwrap();
+
+        assert_eq!(greedy.close_object_reference(greedy_second), Ok(()));
+        assert_eq!(neighbor.close_object_reference(neighbor_first), Ok(()));
+        assert_eq!(neighbor.close_object_reference(neighbor_second), Ok(()));
+        assert_eq!(latecomer.close_object_reference(latecomer_handle), Ok(()));
+        assert!(broker.references.read().is_empty());
+    }
+
+    fn check_pending_references_count_toward_session_quota(broker: &BrokerCore) {
+        let session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let neighbor = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+
+        let first = session
+            .reserve_object_reference(ObjectRights::WAIT)
+            .unwrap();
+        let second = session
+            .reserve_object_reference(ObjectRights::WAIT)
+            .unwrap();
+        assert!(matches!(
+            session.reserve_object_reference(ObjectRights::WAIT),
+            Err(BrokerError::ResourceExhausted)
+        ));
+
+        let neighbor_handle = crate::event::create(&neighbor, 0).unwrap();
+        drop(first);
+        let session_handle = crate::event::create(&session, 0).unwrap();
+        assert_eq!(
+            crate::event::create(&session, 0),
+            Err(BrokerError::ResourceExhausted)
+        );
+
+        drop(second);
+        assert_eq!(session.close_object_reference(session_handle), Ok(()));
+        assert_eq!(neighbor.close_object_reference(neighbor_handle), Ok(()));
+        assert!(broker.references.read().is_empty());
+        assert_eq!(broker.pending_references.load(Ordering::Relaxed), 0);
+    }
+
+    fn check_pipe_capacity_quota_is_per_session(broker: &BrokerCore) {
+        let greedy = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let neighbor = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+
+        let (greedy_reader, greedy_writer) =
+            crate::pipe::create(&greedy, TEST_MAX_PIPE_CAPACITY_PER_SESSION as u64, 2).unwrap();
+        assert_eq!(
+            crate::pipe::create(&greedy, 1, 1),
+            Err(BrokerError::ResourceExhausted)
+        );
+        assert_eq!(
+            greedy.reserved_pipe_capacity.load(Ordering::Relaxed),
+            TEST_MAX_PIPE_CAPACITY_PER_SESSION
+        );
+
+        let (neighbor_reader, neighbor_writer) =
+            crate::pipe::create(&neighbor, TEST_MAX_PIPE_CAPACITY_PER_SESSION as u64, 2).unwrap();
+        assert_eq!(
+            broker.reserved_pipe_capacity.load(Ordering::Relaxed),
+            TEST_MAX_PIPE_CAPACITY
+        );
+
+        let latecomer = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        assert_eq!(
+            crate::pipe::create(&latecomer, 1, 1),
+            Err(BrokerError::ResourceExhausted)
+        );
+        assert_eq!(latecomer.reserved_pipe_capacity.load(Ordering::Relaxed), 0);
+
+        assert_eq!(greedy.close_object_reference(greedy_reader), Ok(()));
+        assert_eq!(greedy.close_object_reference(greedy_writer), Ok(()));
+        let (latecomer_reader, latecomer_writer) = crate::pipe::create(&latecomer, 1, 1).unwrap();
+
+        assert_eq!(neighbor.close_object_reference(neighbor_reader), Ok(()));
+        assert_eq!(neighbor.close_object_reference(neighbor_writer), Ok(()));
+        assert_eq!(latecomer.close_object_reference(latecomer_reader), Ok(()));
+        assert_eq!(latecomer.close_object_reference(latecomer_writer), Ok(()));
+        assert_eq!(broker.reserved_pipe_capacity.load(Ordering::Relaxed), 0);
+    }
+
+    fn check_pipe_capacity_is_released_when_reference_creation_fails(broker: &BrokerCore) {
+        let session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let handle = crate::event::create(&session, 0).unwrap();
+
+        assert_eq!(
+            crate::pipe::create(&session, TEST_MAX_PIPE_CAPACITY_PER_SESSION as u64, 2),
+            Err(BrokerError::ResourceExhausted)
+        );
+        assert_eq!(session.reserved_pipe_capacity.load(Ordering::Relaxed), 0);
+        assert_eq!(broker.reserved_pipe_capacity.load(Ordering::Relaxed), 0);
+
+        assert_eq!(session.close_object_reference(handle), Ok(()));
+    }
+
+    fn check_pipe_capacity_outlives_session_for_in_flight_object(broker: &BrokerCore) {
+        let session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let (reader, _writer) =
+            crate::pipe::create(&session, TEST_MAX_PIPE_CAPACITY_PER_SESSION as u64, 2).unwrap();
+        let object = session
+            .authorized_object(reader, ObjectRights::WAIT)
+            .unwrap();
+        let session_capacity = Arc::clone(&session.reserved_pipe_capacity);
+
+        drop(session);
+
+        assert!(broker.references.read().is_empty());
+        assert_eq!(
+            session_capacity.load(Ordering::Relaxed),
+            TEST_MAX_PIPE_CAPACITY_PER_SESSION
+        );
+        assert_eq!(
+            broker.reserved_pipe_capacity.load(Ordering::Relaxed),
+            TEST_MAX_PIPE_CAPACITY_PER_SESSION
+        );
+
+        drop(object);
+
+        assert_eq!(session_capacity.load(Ordering::Relaxed), 0);
+        assert_eq!(broker.reserved_pipe_capacity.load(Ordering::Relaxed), 0);
     }
 
     fn check_pair_handle_exhaustion(broker: &BrokerCore) {

--- a/litebox_broker_core/src/session.rs
+++ b/litebox_broker_core/src/session.rs
@@ -607,7 +607,6 @@ mod tests {
         check_reference_quota_is_per_session(&broker);
         check_pending_references_count_toward_session_quota(&broker);
         check_pipe_capacity_quota_is_per_session(&broker);
-        check_pipe_capacity_is_released_when_reference_creation_fails(&broker);
         check_pipe_capacity_outlives_session_for_in_flight_object(&broker);
         crate::socket::tests::check_socket_lifecycle(&broker, &socket_provider);
         check_pair_handle_exhaustion(&broker);
@@ -658,6 +657,7 @@ mod tests {
             crate::pipe::create(&session, 4, 2),
             Err(BrokerError::ResourceExhausted)
         );
+        assert_eq!(session.reserved_pipe_capacity.load(Ordering::Relaxed), 0);
         assert_eq!(broker.reserved_pipe_capacity.load(Ordering::Relaxed), 0);
         // Closing the older handle exercises swap-removing a non-last entry.
         assert_eq!(session.close_object_reference(handle), Ok(()));
@@ -856,14 +856,7 @@ mod tests {
 
         let neighbor_handle = crate::event::create(&neighbor, 0).unwrap();
         drop(first);
-        let session_handle = crate::event::create(&session, 0).unwrap();
-        assert_eq!(
-            crate::event::create(&session, 0),
-            Err(BrokerError::ResourceExhausted)
-        );
-
         drop(second);
-        assert_eq!(session.close_object_reference(session_handle), Ok(()));
         assert_eq!(neighbor.close_object_reference(neighbor_handle), Ok(()));
         assert!(broker.references.read().is_empty());
         assert_eq!(broker.pending_references.load(Ordering::Relaxed), 0);
@@ -906,29 +899,12 @@ mod tests {
 
         assert_eq!(greedy.close_object_reference(greedy_reader), Ok(()));
         assert_eq!(greedy.close_object_reference(greedy_writer), Ok(()));
-        let (latecomer_reader, latecomer_writer) = crate::pipe::create(&latecomer, 1, 1).unwrap();
+        assert_eq!(greedy.reserved_pipe_capacity.load(Ordering::Relaxed), 0);
 
         assert_eq!(neighbor.close_object_reference(neighbor_reader), Ok(()));
         assert_eq!(neighbor.close_object_reference(neighbor_writer), Ok(()));
-        assert_eq!(latecomer.close_object_reference(latecomer_reader), Ok(()));
-        assert_eq!(latecomer.close_object_reference(latecomer_writer), Ok(()));
+        assert_eq!(neighbor.reserved_pipe_capacity.load(Ordering::Relaxed), 0);
         assert_eq!(broker.reserved_pipe_capacity.load(Ordering::Relaxed), 0);
-    }
-
-    fn check_pipe_capacity_is_released_when_reference_creation_fails(broker: &BrokerCore) {
-        let session = broker
-            .create_session(CallerCredential::Unauthenticated)
-            .unwrap();
-        let handle = crate::event::create(&session, 0).unwrap();
-
-        assert_eq!(
-            crate::pipe::create(&session, TEST_MAX_PIPE_CAPACITY_PER_SESSION as u64, 2),
-            Err(BrokerError::ResourceExhausted)
-        );
-        assert_eq!(session.reserved_pipe_capacity.load(Ordering::Relaxed), 0);
-        assert_eq!(broker.reserved_pipe_capacity.load(Ordering::Relaxed), 0);
-
-        assert_eq!(session.close_object_reference(handle), Ok(()));
     }
 
     fn check_pipe_capacity_outlives_session_for_in_flight_object(broker: &BrokerCore) {

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -24,7 +24,7 @@ extern crate std;
 use alloc::{sync::Arc, vec::Vec};
 
 use litebox_broker_core::readiness::ReadinessSink;
-use litebox_broker_core::{BrokerCore, BrokerSession, CallerCredential};
+use litebox_broker_core::{BrokerCore, BrokerCoreLimits, BrokerSession, CallerCredential};
 use litebox_broker_protocol::error::ErrorCode;
 use litebox_broker_protocol::event::{AddEventResponse, CreateEventResponse};
 use litebox_broker_protocol::message::{
@@ -195,10 +195,7 @@ where
     // Sockets are currently the only externally backed objects. Add future
     // resource limits here so every live registration fits in the
     // association's shared readiness sink.
-    let max_live_readiness_registrations = limits
-        .max_references
-        .min(limits.max_sockets)
-        .min(limits.max_sockets_per_session);
+    let max_live_readiness_registrations = max_live_readiness_registrations(limits);
     if max_live_readiness_registrations > readiness_sink.max_tracked_objects() {
         return Err(BrokerHostError::Broker(ErrorCode::ResourceExhausted));
     }
@@ -764,6 +761,14 @@ fn handle_event_request(
     }
 }
 
+fn max_live_readiness_registrations(limits: BrokerCoreLimits) -> usize {
+    limits
+        .max_references
+        .min(limits.max_references_per_session)
+        .min(limits.max_sockets)
+        .min(limits.max_sockets_per_session)
+}
+
 /// Terminal outcome after processing one broker connection.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[non_exhaustive]
@@ -838,6 +843,14 @@ mod tests {
         }
 
         fn retire(&self, _handle: ObjectHandle) {}
+    }
+
+    #[test]
+    fn readiness_capacity_uses_the_smallest_per_session_limit() {
+        let limits = BrokerCoreLimits::new_with_all_limits(10_000, 4, 10_000, 10_000)
+            .with_session_quotas(100, 4);
+
+        assert_eq!(max_live_readiness_registrations(limits), 100);
     }
 
     fn test_readiness_sink() -> Arc<dyn ReadinessSink> {

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -24,7 +24,7 @@ extern crate std;
 use alloc::{sync::Arc, vec::Vec};
 
 use litebox_broker_core::readiness::ReadinessSink;
-use litebox_broker_core::{BrokerCore, BrokerCoreLimits, BrokerSession, CallerCredential};
+use litebox_broker_core::{BrokerCore, BrokerSession, CallerCredential};
 use litebox_broker_protocol::error::ErrorCode;
 use litebox_broker_protocol::event::{AddEventResponse, CreateEventResponse};
 use litebox_broker_protocol::message::{
@@ -195,7 +195,11 @@ where
     // Sockets are currently the only externally backed objects. Add future
     // resource limits here so every live registration fits in the
     // association's shared readiness sink.
-    let max_live_readiness_registrations = max_live_readiness_registrations(limits);
+    let max_live_readiness_registrations = limits
+        .max_references
+        .min(limits.max_references_per_session)
+        .min(limits.max_sockets)
+        .min(limits.max_sockets_per_session);
     if max_live_readiness_registrations > readiness_sink.max_tracked_objects() {
         return Err(BrokerHostError::Broker(ErrorCode::ResourceExhausted));
     }
@@ -761,14 +765,6 @@ fn handle_event_request(
     }
 }
 
-fn max_live_readiness_registrations(limits: BrokerCoreLimits) -> usize {
-    limits
-        .max_references
-        .min(limits.max_references_per_session)
-        .min(limits.max_sockets)
-        .min(limits.max_sockets_per_session)
-}
-
 /// Terminal outcome after processing one broker connection.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[non_exhaustive]
@@ -843,14 +839,6 @@ mod tests {
         }
 
         fn retire(&self, _handle: ObjectHandle) {}
-    }
-
-    #[test]
-    fn readiness_capacity_uses_the_smallest_per_session_limit() {
-        let limits = BrokerCoreLimits::new_with_all_limits(10_000, 4, 10_000, 10_000)
-            .with_session_quotas(100, 4);
-
-        assert_eq!(max_live_readiness_registrations(limits), 100);
     }
 
     fn test_readiness_sink() -> Arc<dyn ReadinessSink> {

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -195,11 +195,7 @@ where
     // Sockets are currently the only externally backed objects. Add future
     // resource limits here so every live registration fits in the
     // association's shared readiness sink.
-    let max_live_readiness_registrations = limits
-        .max_references
-        .min(limits.max_references_per_session)
-        .min(limits.max_sockets)
-        .min(limits.max_sockets_per_session);
+    let max_live_readiness_registrations = limits.max_sockets.min(limits.max_sockets_per_session);
     if max_live_readiness_registrations > readiness_sink.max_tracked_objects() {
         return Err(BrokerHostError::Broker(ErrorCode::ResourceExhausted));
     }

--- a/litebox_broker_host/src/readiness.rs
+++ b/litebox_broker_host/src/readiness.rs
@@ -41,10 +41,10 @@ use thiserror::Error;
 
 /// Maximum number of objects one association tracks readiness for.
 ///
-/// This matches the default broker-core reference limit, so a source that
-/// retires an object as its backend resource is released stays well inside it.
-/// It exists so that a source which does not, or a deployment that raises the
-/// core limit, cannot grow publication state without limit.
+/// This is above the default per-session broker-core reference quota, so a
+/// source that retires an object as its backend resource is released stays
+/// well inside it. It exists so that a source which does not, or a deployment
+/// that raises the session quota, cannot grow publication state without limit.
 pub const MAX_TRACKED_READINESS_OBJECTS: usize = 4096;
 
 /// Error returned when readiness state cannot record an update.

--- a/litebox_broker_host/src/readiness.rs
+++ b/litebox_broker_host/src/readiness.rs
@@ -41,10 +41,10 @@ use thiserror::Error;
 
 /// Maximum number of objects one association tracks readiness for.
 ///
-/// This is above the default per-session broker-core reference quota, so a
-/// source that retires an object as its backend resource is released stays
-/// well inside it. It exists so that a source which does not, or a deployment
-/// that raises the session quota, cannot grow publication state without limit.
+/// Connection setup rejects configurations whose effective externally backed
+/// object limit exceeds this value. This independently bounds publication
+/// state if a readiness source does not retire an object when releasing its
+/// backend resource.
 pub const MAX_TRACKED_READINESS_OBJECTS: usize = 4096;
 
 /// Error returned when readiness state cannot record an update.


### PR DESCRIPTION
This PR adds per-session object-reference and pipe-capacity quotas alongside the broker-wide ceilings, accounts for live and pending references during admission, retains pipe capacity charges through the underlying object lifetime, and sizes per-association readiness tracking from socket quotas.