### PR TITLE
Support AArch64 x18/SP-writeback pair instructions

### DIFF
--- a/litebox_platform_linux_userland/src/aarch64.rs
+++ b/litebox_platform_linux_userland/src/aarch64.rs
@@ -2746,6 +2746,144 @@ mod tests {
 
     #[test]
     #[cfg(feature = "aarch64_virtualize_x18")]
+    fn x18_stack_writeback_gate_canonicalization_boundary_table() {
+        const SITE: usize = 0x1000;
+        const SLOT: usize = 0x400010;
+        const FRAME: usize = 0x8000;
+        const ORIGINAL_SP: usize = FRAME + 32;
+        const RESULT_SP: usize = ORIGINAL_SP - 16;
+        const LOGICAL_X18: usize = 0x1818_1818_1818_1818;
+        const SAVED_SCRATCH: usize = 0x1717_1717_1717_1717;
+        const SAVED_ANCHOR: usize = 0x1616_1616_1616_1616;
+
+        let options = litebox_syscall_rewriter::RewriteOptions::new(
+            litebox_syscall_rewriter::TargetHost::Linux,
+            true,
+        );
+        // stp x18, x19, [sp, #-16]!
+        let mut code = 0xa9bf_4ff2u32.to_le_bytes().to_vec();
+        let (trampoline, trapped) = litebox_syscall_rewriter::patch_code_segment_with_options(
+            &mut code,
+            SITE as u64,
+            0x400000,
+            0,
+            options,
+        )
+        .unwrap();
+        assert!(trapped.is_empty());
+
+        let gate =
+            litebox_syscall_rewriter::aarch64::classify_gate_pc(&trampoline, 0x400000, SLOT as u64)
+                .unwrap();
+        let litebox_syscall_rewriter::aarch64::GateMetadata::X18StackWriteback { scratch } =
+            gate.metadata()
+        else {
+            panic!("expected an x18 stack-writeback gate");
+        };
+        let anchor = gate.anchor_scratch().unwrap();
+        assert_eq!(gate.stack_writeback(), Some((-16, 32)));
+
+        let mut saved = PtRegs::default();
+        saved.regs[usize::from(scratch)] = SAVED_SCRATCH;
+        saved.regs[usize::from(anchor)] = SAVED_ANCHOR;
+        let mut frame = [0u8; 32];
+        frame[..8].copy_from_slice(&SAVED_SCRATCH.to_ne_bytes());
+        frame[8..16].copy_from_slice(&SAVED_ANCHOR.to_ne_bytes());
+        let mut slots = [0u8; 16];
+        slots[8..].copy_from_slice(&LOGICAL_X18.to_ne_bytes());
+
+        for offset in (0usize..=48).step_by(4) {
+            let completed = offset >= 28;
+            let mut context: libc::ucontext_t = unsafe { core::mem::zeroed() };
+            context.uc_mcontext.pc = (SLOT + offset) as u64;
+            context.uc_mcontext.sp = match offset {
+                0 | 24 => ORIGINAL_SP as u64,
+                28 => RESULT_SP as u64,
+                48 => RESULT_SP as u64,
+                _ => FRAME as u64,
+            };
+            context.uc_mcontext.regs[usize::from(scratch)] = if matches!(offset, 16..=40) {
+                LOGICAL_X18 as u64
+            } else {
+                SAVED_SCRATCH as u64
+            };
+            context.uc_mcontext.regs[usize::from(anchor)] = if matches!(offset, 20 | 24 | 28 | 32) {
+                FRAME as u64
+            } else {
+                SAVED_ANCHOR as u64
+            };
+
+            let result = canonicalize_aarch64_gate_signal_context(
+                &context,
+                &saved,
+                0x500000,
+                0,
+                0,
+                fixture_reader(&code, &trampoline, &frame, &slots),
+            );
+            let Aarch64GateSignalResult::Canonicalized(regs) = result else {
+                panic!("x18 stack writeback +{offset} did not canonicalize");
+            };
+            assert_eq!(
+                regs.pc,
+                if completed { SITE + 4 } else { SITE },
+                "+{offset}: PC"
+            );
+            assert_eq!(
+                regs.sp,
+                if completed { RESULT_SP } else { ORIGINAL_SP },
+                "+{offset}: SP"
+            );
+            assert_eq!(
+                regs.regs[usize::from(scratch)],
+                SAVED_SCRATCH,
+                "+{offset}: scratch"
+            );
+            assert_eq!(
+                regs.regs[usize::from(anchor)],
+                SAVED_ANCHOR,
+                "+{offset}: anchor"
+            );
+            assert_eq!(regs.regs[18], LOGICAL_X18, "+{offset}: logical x18");
+        }
+
+        // A synchronous fault can be attributed to the guest only while its
+        // transformed pair instruction is current.
+        for (offset, accepted) in [(24usize, true), (12, false), (40, false)] {
+            let mut context: libc::ucontext_t = unsafe { core::mem::zeroed() };
+            context.uc_mcontext.pc = (SLOT + offset) as u64;
+            context.uc_mcontext.sp = if offset == 24 {
+                ORIGINAL_SP as u64
+            } else {
+                FRAME as u64
+            };
+            context.uc_mcontext.regs[usize::from(scratch)] = LOGICAL_X18 as u64;
+            context.uc_mcontext.regs[usize::from(anchor)] = if offset == 24 {
+                FRAME as u64
+            } else {
+                SAVED_ANCHOR as u64
+            };
+            let result = canonicalize_aarch64_gate_signal_context_with_kind(
+                &context,
+                &saved,
+                GateRuntimeState {
+                    guest_thread_pointer_addr: 0x500000,
+                    expected_outbound_stub: 0,
+                    expected_outbound_pc: 0,
+                },
+                GateInterruption::Synchronous,
+                fixture_reader(&code, &trampoline, &frame, &slots),
+            );
+            assert_eq!(
+                matches!(result, Aarch64GateSignalResult::Canonicalized(_)),
+                accepted,
+                "+{offset}: synchronous attribution"
+            );
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "aarch64_virtualize_x18")]
     fn indirect_x18_gates_resume_with_the_expected_link_register() {
         const SITE: usize = 0x1000;
         const SLOT: usize = 0x400010;

--- a/litebox_platform_linux_userland/src/aarch64.rs
+++ b/litebox_platform_linux_userland/src/aarch64.rs
@@ -2798,8 +2798,7 @@ mod tests {
             context.uc_mcontext.pc = (SLOT + offset) as u64;
             context.uc_mcontext.sp = match offset {
                 0 | 24 => ORIGINAL_SP as u64,
-                28 => RESULT_SP as u64,
-                48 => RESULT_SP as u64,
+                28 | 48 => RESULT_SP as u64,
                 _ => FRAME as u64,
             };
             context.uc_mcontext.regs[usize::from(scratch)] = if matches!(offset, 16..=40) {

--- a/litebox_platform_linux_userland/src/aarch64.rs
+++ b/litebox_platform_linux_userland/src/aarch64.rs
@@ -1794,7 +1794,8 @@ fn canonicalize_aarch64_gate_signal_context_with_kind(
             let restored = match plan.frame {
                 X18StackWritebackFrameState::AtSpRestoreRegisters
                 | X18StackWritebackFrameState::AtAnchorRestoreRegisters => {
-                    let mut words = [[0u8; size_of::<usize>()]; 2];
+                    const SCRATCH_REGISTER_COUNT: usize = 2;
+                    let mut words = [[0u8; size_of::<usize>()]; SCRATCH_REGISTER_COUNT];
                     if !read(frame.unwrap(), words.as_flattened_mut()) {
                         return Aarch64GateSignalResult::InvalidRuntimeState;
                     }

--- a/litebox_platform_linux_userland/src/aarch64.rs
+++ b/litebox_platform_linux_userland/src/aarch64.rs
@@ -14,8 +14,9 @@ use litebox_syscall_rewriter::aarch64::{
 };
 #[cfg(feature = "aarch64_virtualize_x18")]
 use litebox_syscall_rewriter::aarch64::{
-    X18_FRAME_BYTES, X18AdrOffset, X18CompareBranchOffset, X18FrameState, X18GateOffset, X18Resume,
-    X18ValueSource, x18_branch_recovery_plan,
+    X18_FRAME_BYTES, X18AdrOffset, X18CompareBranchOffset, X18FaultAttribution, X18FrameState,
+    X18GateOffset, X18Resume, X18StackWritebackFrameState, X18StackWritebackOffset,
+    X18StackWritebackSpSource, X18ValueSource, x18_branch_recovery_plan,
 };
 
 /// Overwrites the destination with the TLS control-block address derived from
@@ -1764,6 +1765,87 @@ fn canonicalize_aarch64_gate_signal_context_with_kind(
             );
         }
         #[cfg(feature = "aarch64_virtualize_x18")]
+        GateMetadata::X18StackWriteback { scratch } => {
+            let Some(plan) = X18StackWritebackOffset::from_offset(offset)
+                .and_then(X18StackWritebackOffset::recovery_plan)
+            else {
+                return Aarch64GateSignalResult::InvalidRuntimeState;
+            };
+            let Some((delta, frame_bytes)) = gate.stack_writeback() else {
+                return Aarch64GateSignalResult::InvalidRuntimeState;
+            };
+            if interruption == GateInterruption::Synchronous
+                && plan.fault_attribution != X18FaultAttribution::GuestInstruction
+            {
+                return Aarch64GateSignalResult::InvalidRuntimeState;
+            }
+
+            let anchor = gate.anchor_scratch().unwrap();
+            let frame_bytes = usize::from(frame_bytes);
+            let frame = match plan.frame {
+                X18StackWritebackFrameState::Absent => None,
+                X18StackWritebackFrameState::AtSpRegistersLive
+                | X18StackWritebackFrameState::AtSpRestoreRegisters
+                | X18StackWritebackFrameState::AtSpRegistersRestored => Some(canonical.sp),
+                X18StackWritebackFrameState::AtAnchorRestoreRegisters => {
+                    Some(context.uc_mcontext.regs[usize::from(anchor)].trunc())
+                }
+            };
+            let restored = match plan.frame {
+                X18StackWritebackFrameState::AtSpRestoreRegisters
+                | X18StackWritebackFrameState::AtAnchorRestoreRegisters => {
+                    let mut words = [[0u8; size_of::<usize>()]; 2];
+                    if !read(frame.unwrap(), words.as_flattened_mut()) {
+                        return Aarch64GateSignalResult::InvalidRuntimeState;
+                    }
+                    Some(words.map(usize::from_ne_bytes))
+                }
+                X18StackWritebackFrameState::Absent
+                | X18StackWritebackFrameState::AtSpRegistersLive
+                | X18StackWritebackFrameState::AtSpRegistersRestored => None,
+            };
+            let guest_sp = match plan.sp {
+                X18StackWritebackSpSource::Signal => canonical.sp,
+                X18StackWritebackSpSource::FramePlusOriginal => {
+                    frame.unwrap().wrapping_add(frame_bytes)
+                }
+                X18StackWritebackSpSource::FramePlusResult => frame
+                    .unwrap()
+                    .wrapping_add(frame_bytes)
+                    .wrapping_add_signed(isize::from(delta)),
+            };
+            let guest_x18 = match plan.value {
+                X18ValueSource::Scratch => {
+                    // At the transformed instruction this is the exact value
+                    // reported by hardware; no completion inference is made.
+                    context.uc_mcontext.regs[usize::from(scratch)].trunc()
+                }
+                X18ValueSource::Slot => {
+                    let Some(value) = read_usize(
+                        &mut read,
+                        runtime.guest_thread_pointer_addr
+                            + litebox_syscall_rewriter::aarch64::GUEST_X18_OFFSET_FROM_GUEST_TP,
+                    ) else {
+                        return Aarch64GateSignalResult::InvalidRuntimeState;
+                    };
+                    value
+                }
+            };
+            let Some(resume_pc) = resolve_x18_recovery_pc(plan.resume, site, guest_x18, None)
+            else {
+                return Aarch64GateSignalResult::InvalidRuntimeState;
+            };
+            apply_x18_recovery(
+                &mut canonical,
+                scratch,
+                anchor,
+                restored,
+                guest_sp,
+                guest_x18,
+                resume_pc,
+            );
+        }
+        #[cfg(feature = "aarch64_virtualize_x18")]
         GateMetadata::X18CompareBranch { scratch } => {
             let Some(stage) = X18CompareBranchOffset::from_offset(offset) else {
                 return Aarch64GateSignalResult::InvalidRuntimeState;
@@ -1883,6 +1965,7 @@ fn canonicalize_aarch64_gate_signal_context_with_kind(
         }
         #[cfg(not(feature = "aarch64_virtualize_x18"))]
         GateMetadata::X18 { .. }
+        | GateMetadata::X18StackWriteback { .. }
         | GateMetadata::X18CompareBranch { .. }
         | GateMetadata::X18Adr { .. }
         | GateMetadata::X18Branch { .. } => return Aarch64GateSignalResult::NotGate,

--- a/litebox_platform_linux_userland/src/lib.rs
+++ b/litebox_platform_linux_userland/src/lib.rs
@@ -2015,6 +2015,7 @@ fn register_exception_handlers() {
         for &sig in exception_signals {
             unsafe {
                 let mut sa: libc::sigaction = core::mem::zeroed();
+                // Keep signal frames off gate scratch storage below guest SP.
                 sa.sa_flags = libc::SA_SIGINFO | libc::SA_ONSTACK;
                 // `SA_NODEFER`: the gate classifier probes memory around a guest
                 // PC that may be unmapped, and reaching the exception-table

--- a/litebox_runner_linux_userland/tests/x18_virtualization.S
+++ b/litebox_runner_linux_userland/tests/x18_virtualization.S
@@ -36,6 +36,26 @@ _start:
     cmp x17, x0
     b.ne fail
 
+    // Exercise x18 virtualization together with native SP writeback. The
+    // store/load round trip independently checks the memory values and SP.
+    mov x18, #0x1818
+    mov x21, #0x2121
+    stp x18, x21, [sp, #-16]!
+    sub x0, x19, #16
+    cmp sp, x0
+    b.ne fail
+    mov x18, xzr
+    mov x21, xzr
+    ldp x18, x21, [sp], #16
+    cmp sp, x19
+    b.ne fail
+    mov x0, #0x1818
+    cmp x18, x0
+    b.ne fail
+    mov x0, #0x2121
+    cmp x21, x0
+    b.ne fail
+
     mov x27, #15
     mov x0, #0x5050
     mov x1, #0x5151

--- a/litebox_syscall_rewriter/src/aarch64.rs
+++ b/litebox_syscall_rewriter/src/aarch64.rs
@@ -60,9 +60,10 @@
 //! exclusive sequences.
 //!
 //! X18 gates require writable stack below SP. SP-writeback pairs may spill as
-//! deep as `align_up(16 + max(0, -writeback), 16)` and can fault near guard
-//! pages. Arbitrary-register aliasing is unsupported; SP-pair accesses are
-//! checked not to overlap the spill.
+//! deep as `align_up(16 + max(0, -writeback), 16)`. This extra spill can fault
+//! even when the native guest instruction would succeed; such a runtime spill
+//! fault is not attributed to the guest instruction. Arbitrary-register
+//! aliasing is unsupported; SP-pair accesses are checked not to overlap it.
 //!
 //! ## `X16` is preserved across an `SVC`
 //!
@@ -5608,6 +5609,32 @@ mod tests {
     }
 
     #[test]
+    fn sp_writeback_pair_variants_preserve_scaled_displacements() {
+        // Cover pre/post indexing, positive/negative displacements, and both
+        // integer element widths. The expected values come from the ISA, not
+        // from the gate's frame-size calculation.
+        for (word, expected_delta, expected_frame, expected_final_add) in [
+            (0xa9bf_4ff2, -16, 32, 16), // stp x18, x19, [sp, #-16]!
+            (0xa8c1_4ff2, 16, 16, 32),  // ldp x18, x19, [sp], #16
+            (0x29bf_4ff2, -8, 32, 24),  // stp w18, w19, [sp, #-8]!
+            (0x28c1_4ff2, 8, 16, 24),   // ldp w18, w19, [sp], #8
+        ] {
+            let pair = classify_x18_stack_writeback(word).unwrap();
+            assert_eq!(pair.layout.delta, expected_delta);
+            assert_eq!(pair.layout.frame_bytes, expected_frame);
+
+            let (_patched, outcome) =
+                hook_words_opt_with_config(&[word], 0x1000, 0x400000, x18_config(Host::Linux));
+            let outcome = outcome.unwrap();
+            let gate = &outcome.trampoline[GATES_START_OFFSET..];
+            assert_eq!(
+                word_at(gate, X18StackWritebackOffset::FinalSp.as_usize()),
+                Insn::AddSp(expected_final_add).encode().unwrap()
+            );
+        }
+    }
+
+    #[test]
     fn sp_writeback_recovery_plan_attributes_only_the_pair_to_guest() {
         for offset in (0..X18StackWritebackOffset::ExecutableEnd.as_usize()).step_by(INSN_BYTES) {
             let stage = X18StackWritebackOffset::from_offset(offset).unwrap();
@@ -6878,6 +6905,7 @@ mod tests {
     fn classifier_finds_every_x18_gate_kind() {
         let words = [
             0xaa00_03f2, // mov x18, x0
+            0xa9bf_4ff2, // stp x18, x19, [sp, #-16]!
             0x3500_0332, // cbnz w18, +0x64
             0x1000_0072, // adr x18, +0xc
             0xd61f_0240, // br x18
@@ -6889,13 +6917,22 @@ mod tests {
 
         for (index, (start, size)) in [
             (16usize, X18_SLOT_BYTES),
-            (16 + X18_SLOT_BYTES, X18_COMPARE_BRANCH_SLOT_BYTES),
+            (16 + X18_SLOT_BYTES, X18_STACK_WRITEBACK_SLOT_BYTES),
             (
-                16 + X18_SLOT_BYTES + X18_COMPARE_BRANCH_SLOT_BYTES,
+                16 + X18_SLOT_BYTES + X18_STACK_WRITEBACK_SLOT_BYTES,
+                X18_COMPARE_BRANCH_SLOT_BYTES,
+            ),
+            (
+                16 + X18_SLOT_BYTES
+                    + X18_STACK_WRITEBACK_SLOT_BYTES
+                    + X18_COMPARE_BRANCH_SLOT_BYTES,
                 X18_ADR_SLOT_BYTES,
             ),
             (
-                16 + X18_SLOT_BYTES + X18_COMPARE_BRANCH_SLOT_BYTES + X18_ADR_SLOT_BYTES,
+                16 + X18_SLOT_BYTES
+                    + X18_STACK_WRITEBACK_SLOT_BYTES
+                    + X18_COMPARE_BRANCH_SLOT_BYTES
+                    + X18_ADR_SLOT_BYTES,
                 X18_BRANCH_SLOT_BYTES,
             ),
         ]
@@ -6911,9 +6948,10 @@ mod tests {
             .unwrap();
             assert!(match index {
                 0 => matches!(metadata, GateMetadata::X18 { .. }),
-                1 => matches!(metadata, GateMetadata::X18CompareBranch { .. }),
-                2 => matches!(metadata, GateMetadata::X18Adr { .. }),
-                3 => matches!(metadata, GateMetadata::X18Branch { .. }),
+                1 => matches!(metadata, GateMetadata::X18StackWriteback { .. }),
+                2 => matches!(metadata, GateMetadata::X18CompareBranch { .. }),
+                3 => matches!(metadata, GateMetadata::X18Adr { .. }),
+                4 => matches!(metadata, GateMetadata::X18Branch { .. }),
                 _ => unreachable!(),
             });
             for offset in (0..metadata.executable_end()).step_by(INSN_BYTES) {
@@ -6958,6 +6996,32 @@ mod tests {
                 assert_eq!(classified.slot_size(), u8::try_from(size).unwrap());
                 assert_eq!(classified.metadata(), metadata);
             }
+        }
+
+        let (_patched, outcome) = hook_words_opt_with_config(
+            &[0xa9bf_4ff2], // stp x18, x19, [sp, #-16]!
+            0x1000,
+            base,
+            x18_config(Host::Linux),
+        );
+        let trampoline = outcome.unwrap().trampoline;
+        let slot = &trampoline[GATES_START_OFFSET..];
+        for offset in (0..X18StackWritebackOffset::ExecutableEnd.as_usize()).step_by(INSN_BYTES) {
+            let classified = classify_copied_gate_slot(
+                slot,
+                base + GATES_START_OFFSET as u64,
+                base + (GATES_START_OFFSET + offset) as u64,
+            )
+            .expect("emitted x18 stack-writeback slot must classify");
+            assert_eq!(classified.slot_offset(), 0);
+            assert_eq!(
+                classified.slot_size(),
+                u8::try_from(X18_STACK_WRITEBACK_SLOT_BYTES).unwrap()
+            );
+            assert!(matches!(
+                classified.metadata(),
+                GateMetadata::X18StackWriteback { .. }
+            ));
         }
     }
 

--- a/litebox_syscall_rewriter/src/aarch64.rs
+++ b/litebox_syscall_rewriter/src/aarch64.rs
@@ -629,6 +629,7 @@ const SP: u8 = 31;
 const XZR: u8 = 31;
 
 const X18: u16 = 18;
+const X18_ENCODED: u8 = 18;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum X18Classification {
@@ -727,7 +728,8 @@ fn decode_x18_stack_writeback(word: u32) -> Option<X18StackWritebackLayout> {
         return None;
     }
     let element_bytes = if word >> 31 == 0 { 4 } else { 8 };
-    let imm7 = (((word >> IMM7_SHIFT) & u32::from(IMM7_MASK)) as i16) << 9 >> 9;
+    let encoded_imm7 = ((word >> IMM7_SHIFT) & u32::from(IMM7_MASK)).to_le_bytes()[0];
+    let imm7 = i16::from(encoded_imm7) << 9 >> 9;
     let delta = imm7.checked_mul(element_bytes)?;
     let depth = 16u16.checked_add(if delta < 0 { delta.unsigned_abs() } else { 0 })?;
     Some(X18StackWritebackLayout {
@@ -741,7 +743,7 @@ fn decode_x18_stack_writeback(word: u32) -> Option<X18StackWritebackLayout> {
 
 fn classify_x18_stack_writeback(word: u32) -> Option<X18StackWriteback> {
     let layout = decode_x18_stack_writeback(word)?;
-    if layout.rt != X18 as u8 && layout.rt2 != X18 as u8 {
+    if layout.rt != X18_ENCODED && layout.rt2 != X18_ENCODED {
         return None;
     }
     let instruction = decode_instruction(word)?;

--- a/litebox_syscall_rewriter/src/aarch64.rs
+++ b/litebox_syscall_rewriter/src/aarch64.rs
@@ -731,7 +731,7 @@ fn decode_x18_stack_writeback(word: u32) -> Option<X18StackWritebackLayout> {
     let encoded_imm7 = ((word >> IMM7_SHIFT) & u32::from(IMM7_MASK)).to_le_bytes()[0];
     let imm7 = i16::from(encoded_imm7) << 9 >> 9;
     let delta = imm7.checked_mul(element_bytes)?;
-    let depth = 16u16.checked_add(if delta < 0 { delta.unsigned_abs() } else { 0 })?;
+    let depth = X18_FRAME_BYTES.checked_add(if delta < 0 { delta.unsigned_abs() } else { 0 })?;
     Some(X18StackWritebackLayout {
         rt: (word & REG_MASK) as u8,
         rt2: ((word >> RT2_SHIFT) & REG_MASK) as u8,

--- a/litebox_syscall_rewriter/src/aarch64.rs
+++ b/litebox_syscall_rewriter/src/aarch64.rs
@@ -59,9 +59,10 @@
 //! store. TODO: use function metadata and control flow to cover noncontiguous
 //! exclusive sequences.
 //!
-//! The x18 gates spill below the guest SP. A guest memory operand that aliases
-//! that live spill area through an arbitrary register cannot be detected
-//! statically and is outside the supported gate semantics.
+//! X18 gates require writable stack below SP. SP-writeback pairs may spill as
+//! deep as `align_up(16 + max(0, -writeback), 16)` and can fault near guard
+//! pages. Arbitrary-register aliasing is unsupported; SP-pair accesses are
+//! checked not to overlap the spill.
 //!
 //! ## `X16` is preserved across an `SVC`
 //!
@@ -416,6 +417,8 @@ const X18_SLOT_BYTES: usize = 48;
 const X18_COMPARE_BRANCH_SLOT_BYTES: usize = 48;
 /// Byte size of a self-contained `ADR X18` gate slot.
 const X18_ADR_SLOT_BYTES: usize = 32;
+/// Byte size of an immediate SP-writeback pair x18 gate slot.
+const X18_STACK_WRITEBACK_SLOT_BYTES: usize = 64;
 /// Byte size of a terminal `BR X18` trap gate slot.
 const X18_BRANCH_SLOT_BYTES: usize = 16;
 /// Distinct compact-slot sizes probed by classifiers and finalizers. Metadata
@@ -427,8 +430,8 @@ pub const GATE_SLOT_SIZES: [usize; 4] = [
     SVC_SLOT_BYTES,
 ];
 /// Candidate starts required to cover the largest executable gate body:
-/// `max(ceil(executable_end / GATE_ALIGNMENT))`, currently `ceil(48 / 16)`.
-pub const GATE_PC_CANDIDATE_COUNT: usize = 3;
+/// `max(ceil(executable_end / GATE_ALIGNMENT))`, currently `ceil(52 / 16)`.
+pub const GATE_PC_CANDIDATE_COUNT: usize = 4;
 const NOP: u32 = 0xD503_201F;
 
 const GATE_METADATA_MAGIC: u32 = 0xB807;
@@ -455,6 +458,7 @@ enum GateKind {
     X18CompareBranch = 4,
     X18Adr = 5,
     X18Branch = 6,
+    X18StackWriteback = 7,
 }
 
 impl GateKind {
@@ -471,6 +475,7 @@ impl GateKind {
             Self::X18CompareBranch,
             Self::X18Adr,
             Self::X18Branch,
+            Self::X18StackWriteback,
         ]
         .into_iter()
         .find(|kind| kind.bits() == bits)
@@ -517,6 +522,8 @@ pub enum GateMetadata {
     },
     /// An indirect branch through logical x18 emulated by the exception handler.
     X18Branch { kind: X18IndirectBranchKind },
+    /// An immediate, SP-based `STP`/`LDP` with pre/post-index writeback.
+    X18StackWriteback { scratch: u8 },
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -550,6 +557,7 @@ impl EncodedGateMetadata {
             GateMetadata::X18CompareBranch { scratch } => (GateKind::X18CompareBranch, scratch),
             GateMetadata::X18Adr { scratch } => (GateKind::X18Adr, scratch),
             GateMetadata::X18Branch { kind } => (GateKind::X18Branch, kind as u8),
+            GateMetadata::X18StackWriteback { scratch } => (GateKind::X18StackWriteback, scratch),
         };
         if register > MAX_REGISTER {
             return None;
@@ -596,6 +604,9 @@ impl EncodedGateMetadata {
                     _ => return None,
                 },
             }),
+            GateKind::X18StackWriteback if register != XZR => {
+                Some(GateMetadata::X18StackWriteback { scratch: register })
+            }
             _ => None,
         }
     }
@@ -648,6 +659,15 @@ struct X18Substitution {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct X18StackWriteback {
+    word: u32,
+    scratch: u8,
+    anchor_scratch: u8,
+    delta: i16,
+    frame_bytes: u16,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum X18PcRelative {
     Adr(u64),
     Adrp(u64),
@@ -685,6 +705,44 @@ enum X18Unsupported {
     ExclusiveAtomic,
     EncodingLayout,
     DecodeFailure,
+}
+
+/// Decodes the deliberately narrow pair family supported by the
+/// displacement-aware x18 gate. This is also used to validate persisted gates.
+fn decode_x18_stack_writeback(word: u32) -> Option<(u8, u8, i16, u16)> {
+    // Integer STP/LDP (32- or 64-bit), immediate pre/post-index, SP base.
+    if word & 0x7e00_0000 != 0x2800_0000 || (word >> RN_SHIFT) & REG_MASK != u32::from(SP) {
+        return None;
+    }
+    let mode = (word >> 23) & 3;
+    if !matches!(mode, 1 | 3) {
+        return None;
+    }
+    let element_bytes = if word >> 31 == 0 { 4 } else { 8 };
+    let imm7 = (((word >> IMM7_SHIFT) & u32::from(IMM7_MASK)) as i16) << 9 >> 9;
+    let delta = imm7.checked_mul(element_bytes)?;
+    let rt = (word & REG_MASK) as u8;
+    let rt2 = ((word >> RT2_SHIFT) & REG_MASK) as u8;
+    Some((rt, rt2, delta, element_bytes.cast_unsigned()))
+}
+
+fn classify_x18_stack_writeback(word: u32) -> Option<X18StackWriteback> {
+    let (rt, rt2, delta, _element_bytes) = decode_x18_stack_writeback(word)?;
+    if rt != X18 as u8 && rt2 != X18 as u8 {
+        return None;
+    }
+    let instruction = decode_instruction(word)?;
+    let (scratch, anchor_scratch) = select_x18_scratches(&instruction)?;
+    let transformed = substitute_x18(word, scratch)?;
+    let depth = 16u16.checked_add(if delta < 0 { delta.unsigned_abs() } else { 0 })?;
+    let frame_bytes = depth.checked_add(15)? & !15;
+    Some(X18StackWriteback {
+        word: transformed,
+        scratch,
+        anchor_scratch,
+        delta,
+        frame_bytes,
+    })
 }
 
 fn decode_instruction(word: u32) -> Option<DecodedInstruction> {
@@ -1353,6 +1411,224 @@ pub enum X18GateOffset {
     Return = 40,
     /// First byte after the executable gate body.
     ExecutableEnd = 44,
+}
+
+/// Instruction boundaries in the displacement-aware SP-writeback pair gate.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum X18StackWritebackOffset {
+    Entry = 0,
+    Spill = 4,
+    FirstAnchor = 8,
+    SlotLoad = 12,
+    FrameAddress = 16,
+    RestoreOriginalSp = 20,
+    Transform = 24,
+    RestoreFrameSp = 28,
+    SecondAnchor = 32,
+    SlotStore = 36,
+    RestoreRegisters = 40,
+    FinalSp = 44,
+    Return = 48,
+    ExecutableEnd = 52,
+}
+
+/// Location and validity of the scratch payload at an SP-writeback boundary.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum X18StackWritebackFrameState {
+    Absent,
+    AtSpRegistersLive,
+    AtSpRestoreRegisters,
+    AtAnchorRestoreRegisters,
+    AtSpRegistersRestored,
+}
+
+/// How recovery reconstructs the guest-visible SP.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum X18StackWritebackSpSource {
+    Signal,
+    FramePlusOriginal,
+    FramePlusResult,
+}
+
+/// Whether a synchronous exception belongs to the guest pair or gate runtime.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum X18FaultAttribution {
+    GuestInstruction,
+    Runtime,
+}
+
+/// Host-neutral recovery semantics for one SP-writeback gate boundary.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct X18StackWritebackRecoveryPlan {
+    pub frame: X18StackWritebackFrameState,
+    pub sp: X18StackWritebackSpSource,
+    pub value: X18ValueSource,
+    pub resume: X18Resume,
+    pub runtime_access: RuntimeAccess,
+    pub fault_attribution: X18FaultAttribution,
+}
+
+impl X18StackWritebackRecoveryPlan {
+    const fn new(
+        frame: X18StackWritebackFrameState,
+        sp: X18StackWritebackSpSource,
+        value: X18ValueSource,
+        resume: X18Resume,
+        runtime_access: RuntimeAccess,
+        fault_attribution: X18FaultAttribution,
+    ) -> Self {
+        Self {
+            frame,
+            sp,
+            value,
+            resume,
+            runtime_access,
+            fault_attribution,
+        }
+    }
+}
+
+impl X18StackWritebackOffset {
+    const fn as_usize(self) -> usize {
+        self as u8 as usize
+    }
+
+    pub fn from_offset(offset: usize) -> Option<Self> {
+        Some(match offset {
+            0 => Self::Entry,
+            4 => Self::Spill,
+            8 => Self::FirstAnchor,
+            12 => Self::SlotLoad,
+            16 => Self::FrameAddress,
+            20 => Self::RestoreOriginalSp,
+            24 => Self::Transform,
+            28 => Self::RestoreFrameSp,
+            32 => Self::SecondAnchor,
+            36 => Self::SlotStore,
+            40 => Self::RestoreRegisters,
+            44 => Self::FinalSp,
+            48 => Self::Return,
+            _ => return None,
+        })
+    }
+
+    /// Returns the recovery semantics for this instruction boundary.
+    pub const fn recovery_plan(self) -> Option<X18StackWritebackRecoveryPlan> {
+        use RuntimeAccess::{Memory, NoAccess};
+        use X18FaultAttribution::{GuestInstruction, Runtime};
+        use X18Resume::{Next, Original};
+        use X18StackWritebackFrameState::{
+            Absent, AtAnchorRestoreRegisters, AtSpRegistersLive, AtSpRegistersRestored,
+            AtSpRestoreRegisters,
+        };
+        use X18StackWritebackSpSource::{FramePlusOriginal, FramePlusResult, Signal};
+        use X18ValueSource::{Scratch, Slot};
+
+        Some(match self {
+            Self::Entry => Self::plan(Absent, Signal, Slot, Original, NoAccess, Runtime),
+            Self::Spill => Self::plan(
+                AtSpRegistersLive,
+                FramePlusOriginal,
+                Slot,
+                Original,
+                Memory,
+                Runtime,
+            ),
+            Self::FirstAnchor => Self::plan(
+                AtSpRestoreRegisters,
+                FramePlusOriginal,
+                Slot,
+                Original,
+                NoAccess,
+                Runtime,
+            ),
+            Self::SlotLoad => Self::plan(
+                AtSpRestoreRegisters,
+                FramePlusOriginal,
+                Slot,
+                Original,
+                Memory,
+                Runtime,
+            ),
+            Self::FrameAddress | Self::RestoreOriginalSp => Self::plan(
+                AtSpRestoreRegisters,
+                FramePlusOriginal,
+                Slot,
+                Original,
+                NoAccess,
+                Runtime,
+            ),
+            Self::Transform => Self::plan(
+                AtAnchorRestoreRegisters,
+                Signal,
+                Scratch,
+                Original,
+                NoAccess,
+                GuestInstruction,
+            ),
+            Self::RestoreFrameSp => Self::plan(
+                AtAnchorRestoreRegisters,
+                Signal,
+                Scratch,
+                Next,
+                NoAccess,
+                Runtime,
+            ),
+            Self::SecondAnchor => Self::plan(
+                AtSpRestoreRegisters,
+                FramePlusResult,
+                Scratch,
+                Next,
+                NoAccess,
+                Runtime,
+            ),
+            Self::SlotStore => Self::plan(
+                AtSpRestoreRegisters,
+                FramePlusResult,
+                Scratch,
+                Next,
+                Memory,
+                Runtime,
+            ),
+            Self::RestoreRegisters => Self::plan(
+                AtSpRestoreRegisters,
+                FramePlusResult,
+                Scratch,
+                Next,
+                Memory,
+                Runtime,
+            ),
+            Self::FinalSp => Self::plan(
+                AtSpRegistersRestored,
+                FramePlusResult,
+                Slot,
+                Next,
+                NoAccess,
+                Runtime,
+            ),
+            Self::Return => Self::plan(Absent, Signal, Slot, Next, NoAccess, Runtime),
+            Self::ExecutableEnd => return None,
+        })
+    }
+
+    const fn plan(
+        frame: X18StackWritebackFrameState,
+        sp: X18StackWritebackSpSource,
+        value: X18ValueSource,
+        resume: X18Resume,
+        runtime_access: RuntimeAccess,
+        fault_attribution: X18FaultAttribution,
+    ) -> X18StackWritebackRecoveryPlan {
+        X18StackWritebackRecoveryPlan::new(
+            frame,
+            sp,
+            value,
+            resume,
+            runtime_access,
+            fault_attribution,
+        )
+    }
 }
 
 impl X18GateOffset {
@@ -2461,6 +2737,8 @@ enum PatchKind {
     MrsTpidr(u8),
     /// An x18 use detected under explicit virtualization.
     X18(X18TransformResult),
+    /// Immediate SP-based pair operation whose native instruction writes SP.
+    X18StackWriteback(X18StackWriteback),
     /// A compare/test branch (`CBZ`/`CBNZ`/`TBZ`/`TBNZ`) on logical x18.
     X18CompareBranch(X18CompareBranch),
     /// An `ADR X18` with its original absolute target.
@@ -2592,7 +2870,9 @@ fn find_patch_sites_with_code_ranges(
                     PatchKind::MrsTpidr(rd)
                 }
             } else if config.virtualize_x18 && known_code {
-                if let Some(branch) = classify_x18_conditional_branch(insn, vaddr) {
+                if let Some(pair) = classify_x18_stack_writeback(insn) {
+                    PatchKind::X18StackWriteback(pair)
+                } else if let Some(branch) = classify_x18_conditional_branch(insn, vaddr) {
                     PatchKind::X18CompareBranch(branch)
                 } else if let Some(adr) = classify_adr_x18(insn, vaddr) {
                     PatchKind::X18Adr(adr)
@@ -2612,6 +2892,7 @@ fn find_patch_sites_with_code_ranges(
                 && matches!(
                     kind,
                     PatchKind::X18(_)
+                        | PatchKind::X18StackWriteback(_)
                         | PatchKind::X18CompareBranch(_)
                         | PatchKind::X18Adr(_)
                         | PatchKind::X18Branch(_)
@@ -2758,6 +3039,14 @@ pub(crate) fn hook_syscalls_aarch64_with_code_ranges(
                     config.host,
                 )?,
                 PatchKind::X18(X18TransformResult::Unsupported(_)) => GateBuild::Unreachable,
+                PatchKind::X18StackWriteback(pair) => emit_x18_stack_writeback_gate(
+                    &mut trampoline_data,
+                    gate_offset,
+                    trampoline_base_addr,
+                    site,
+                    pair,
+                    config.host,
+                )?,
                 PatchKind::X18CompareBranch(branch) => emit_x18_compare_branch_gate(
                     &mut trampoline_data,
                     gate_offset,
@@ -3197,6 +3486,77 @@ fn emit_x18_gate(
         gate_vaddr,
         GateMetadata::X18 { scratch },
         X18_SLOT_BYTES,
+    )?;
+    Ok(GateBuild::Emitted)
+}
+
+fn emit_x18_stack_writeback_gate(
+    trampoline_data: &mut Vec<u8>,
+    gate_offset: usize,
+    trampoline_base_addr: u64,
+    site: &PatchSite,
+    pair: X18StackWriteback,
+    host: Host,
+) -> Result<GateBuild> {
+    let gate_vaddr = checked_add_u64(
+        trampoline_base_addr,
+        gate_offset as u64,
+        "x18 SP-writeback gate",
+    )?;
+    let mut asm = Asm::new(gate_vaddr);
+    asm.emit(Insn::SubSp(pair.frame_bytes));
+    asm.emit(Insn::Stp {
+        rt: pair.scratch,
+        rt2: pair.anchor_scratch,
+        rn: SP,
+        imm_bytes: 0,
+    });
+    asm.emit(host.anchor_read(pair.anchor_scratch));
+    asm.emit(Insn::LdrUimm {
+        rt: pair.scratch,
+        rn: pair.anchor_scratch,
+        imm_bytes: GUEST_X18_OFFSET_PLACEHOLDER,
+    });
+    asm.emit(Insn::AddImm {
+        rd: pair.anchor_scratch,
+        rn: SP,
+        imm12: 0,
+    });
+    asm.emit(Insn::AddSp(pair.frame_bytes));
+    asm.push_word(pair.word);
+    asm.emit(Insn::AddImm {
+        rd: SP,
+        rn: pair.anchor_scratch,
+        imm12: 0,
+    });
+    asm.emit(host.anchor_read(pair.anchor_scratch));
+    asm.emit(Insn::StrUimm {
+        rt: pair.scratch,
+        rn: pair.anchor_scratch,
+        imm_bytes: GUEST_X18_OFFSET_PLACEHOLDER,
+    });
+    asm.emit(Insn::Ldp {
+        rt: pair.scratch,
+        rt2: pair.anchor_scratch,
+        rn: SP,
+        imm_bytes: 0,
+    });
+    let final_adjustment = u16::try_from(i32::from(pair.frame_bytes) + i32::from(pair.delta))
+        .map_err(|_| Error::AddressOverflow("x18 SP-writeback adjustment".into()))?;
+    asm.emit(Insn::AddSp(final_adjustment));
+    let return_addr = checked_add_u64(site.vaddr, INSN_BYTES_U64, "x18 SP-writeback return")?;
+    if !asm.branch_to(return_addr)? {
+        return Ok(GateBuild::Unreachable);
+    }
+    append_gate_slot(
+        trampoline_data,
+        asm.finish(),
+        trampoline_base_addr,
+        gate_vaddr,
+        GateMetadata::X18StackWriteback {
+            scratch: pair.scratch,
+        },
+        X18_STACK_WRITEBACK_SLOT_BYTES,
     )?;
     Ok(GateBuild::Emitted)
 }
@@ -3699,6 +4059,100 @@ fn validate_gate_slot_inner_for_host(
                 && word(X18GateOffset::Return.as_usize()) & OPCODE_TOP6_MASK == Opcode::B.bits()
                 && padding_is_nops(X18GateOffset::ExecutableEnd.as_usize())
         }
+        GateMetadata::X18StackWriteback { scratch } => {
+            let anchor_scratch = ((word(4) >> RT2_SHIFT) & REG_MASK) as u8;
+            let transformed = word(X18StackWritebackOffset::Transform.as_usize());
+            let Some((rt, rt2, delta, element_bytes)) = decode_x18_stack_writeback(transformed)
+            else {
+                return false;
+            };
+            let depth = 16u16
+                .checked_add(if delta < 0 { delta.unsigned_abs() } else { 0 })
+                .and_then(|depth| depth.checked_add(15))
+                .map(|depth| depth & !15);
+            let Some(frame_bytes) = depth else {
+                return false;
+            };
+            // Revalidate the original operand layout and scratch choices.
+            let mut original = transformed;
+            if rt == scratch {
+                original = (original & !REG_MASK) | u32::from(X18);
+            }
+            if rt2 == scratch {
+                original = (original & !(REG_MASK << RT2_SHIFT)) | (u32::from(X18) << RT2_SHIFT);
+            }
+            let Some(derived) = classify_x18_stack_writeback(original) else {
+                return false;
+            };
+            let mode = (transformed >> 23) & 3;
+            let access_start = if mode == 3 { i32::from(delta) } else { 0 };
+            let access_end = access_start + i32::from(element_bytes) * 2;
+            let frame_start = -i32::from(frame_bytes);
+            let frame_end = frame_start + i32::from(X18_FRAME_BYTES);
+            let disjoint = access_end <= frame_start || access_start >= frame_end;
+            if !(7..=17).contains(&scratch)
+                || !(7..=17).contains(&anchor_scratch)
+                || anchor_scratch == scratch
+                || (rt != scratch && rt2 != scratch)
+                || rt == anchor_scratch
+                || rt2 == anchor_scratch
+                || derived.word != transformed
+                || derived.scratch != scratch
+                || derived.anchor_scratch != anchor_scratch
+                || derived.delta != delta
+                || derived.frame_bytes != frame_bytes
+                || !disjoint
+            {
+                return false;
+            }
+            exact(0, Insn::SubSp(frame_bytes))
+                && exact(
+                    4,
+                    Insn::Stp {
+                        rt: scratch,
+                        rt2: anchor_scratch,
+                        rn: SP,
+                        imm_bytes: 0,
+                    },
+                )
+                && is_host_anchor_read(word(8), anchor_scratch, host)
+                && is_x18_access(word(12), Opcode::LdrUimm, scratch, anchor_scratch)
+                && exact(
+                    16,
+                    Insn::AddImm {
+                        rd: anchor_scratch,
+                        rn: SP,
+                        imm12: 0,
+                    },
+                )
+                && exact(20, Insn::AddSp(frame_bytes))
+                && exact(
+                    28,
+                    Insn::AddImm {
+                        rd: SP,
+                        rn: anchor_scratch,
+                        imm12: 0,
+                    },
+                )
+                && is_host_anchor_read(word(32), anchor_scratch, host)
+                && word(8) == word(32)
+                && is_x18_access(word(36), Opcode::StrUimm, scratch, anchor_scratch)
+                && exact(
+                    40,
+                    Insn::Ldp {
+                        rt: scratch,
+                        rt2: anchor_scratch,
+                        rn: SP,
+                        imm_bytes: 0,
+                    },
+                )
+                && exact(
+                    44,
+                    Insn::AddSp(u16::try_from(i32::from(frame_bytes) + i32::from(delta)).unwrap()),
+                )
+                && word(48) & OPCODE_TOP6_MASK == Opcode::B.bits()
+                && padding_is_nops(52)
+        }
         GateMetadata::X18CompareBranch { scratch } => {
             let anchor_scratch = ((word(4) >> RT2_SHIFT) & REG_MASK) as u8;
             if !(7..=17).contains(&anchor_scratch) || anchor_scratch == scratch {
@@ -3819,6 +4273,7 @@ impl GateMetadata {
             GateMetadata::MrsTpidr { .. } => MRS_SLOT_BYTES,
             GateMetadata::MsrTpidr { .. } => MSR_SLOT_BYTES,
             GateMetadata::X18 { .. } => X18_SLOT_BYTES,
+            GateMetadata::X18StackWriteback { .. } => X18_STACK_WRITEBACK_SLOT_BYTES,
             GateMetadata::X18CompareBranch { .. } => X18_COMPARE_BRANCH_SLOT_BYTES,
             GateMetadata::X18Adr { .. } => X18_ADR_SLOT_BYTES,
             GateMetadata::X18Branch { .. } => X18_BRANCH_SLOT_BYTES,
@@ -3836,6 +4291,9 @@ impl GateMetadata {
             GateMetadata::MrsTpidr { .. } => MrsTpidrGateOffset::ExecutableEnd.as_usize(),
             GateMetadata::MsrTpidr { .. } => MsrTpidrGateOffset::ExecutableEnd.as_usize(),
             GateMetadata::X18 { .. } => X18GateOffset::ExecutableEnd.as_usize(),
+            GateMetadata::X18StackWriteback { .. } => {
+                X18StackWritebackOffset::ExecutableEnd.as_usize()
+            }
             GateMetadata::X18CompareBranch { .. } => {
                 X18CompareBranchOffset::ExecutableEnd.as_usize()
             }
@@ -3852,6 +4310,7 @@ impl GateMetadata {
             GateMetadata::MrsTpidr { .. } => MrsTpidrGateOffset::Return.as_usize(),
             GateMetadata::MsrTpidr { .. } => MsrTpidrGateOffset::Return.as_usize(),
             GateMetadata::X18 { .. } => X18GateOffset::Return.as_usize(),
+            GateMetadata::X18StackWriteback { .. } => X18StackWritebackOffset::Return.as_usize(),
             GateMetadata::X18CompareBranch { .. } => {
                 X18CompareBranchOffset::FallthroughBranch.as_usize()
             }
@@ -3874,6 +4333,8 @@ pub struct ClassifiedGate {
     slot_offset: usize,
     slot_size: u8,
     anchor_scratch: u8,
+    stack_delta: i16,
+    stack_frame_bytes: u16,
     original_site: u64,
     conditional_target: u64,
     metadata: GateMetadata,
@@ -3894,10 +4355,17 @@ impl ClassifiedGate {
         matches!(
             self.metadata,
             GateMetadata::X18 { .. }
+                | GateMetadata::X18StackWriteback { .. }
                 | GateMetadata::X18CompareBranch { .. }
                 | GateMetadata::X18Adr { .. }
         )
         .then_some(self.anchor_scratch)
+    }
+
+    /// `(writeback displacement, scratch-frame depth)` for an SP-writeback pair.
+    pub fn stack_writeback(self) -> Option<(i16, u16)> {
+        matches!(self.metadata, GateMetadata::X18StackWriteback { .. })
+            .then_some((self.stack_delta, self.stack_frame_bytes))
     }
 
     /// Original guest instruction address recovered from the return branch.
@@ -3965,6 +4433,7 @@ pub fn classify_copied_gate_slot(slot: &[u8], slot_vaddr: u64, pc: u64) -> Optio
         GateMetadata::MrsTpidr { .. }
         | GateMetadata::MsrTpidr { .. }
         | GateMetadata::X18 { .. }
+        | GateMetadata::X18StackWriteback { .. }
         | GateMetadata::X18CompareBranch { .. }
         | GateMetadata::X18Adr { .. }
         | GateMetadata::X18Branch { .. } => 0,
@@ -4006,15 +4475,34 @@ pub fn classify_copied_gate_slot(slot: &[u8], slot_vaddr: u64, pc: u64) -> Optio
     } else {
         0
     };
+    let (stack_delta, stack_frame_bytes) =
+        if matches!(metadata, GateMetadata::X18StackWriteback { .. }) {
+            let (_, _, delta, _) = decode_x18_stack_writeback(u32::from_le_bytes(
+                slot[X18StackWritebackOffset::Transform.as_usize()
+                    ..X18StackWritebackOffset::Transform.as_usize() + 4]
+                    .try_into()
+                    .ok()?,
+            ))?;
+            let frame = (16u16
+                .checked_add(if delta < 0 { delta.unsigned_abs() } else { 0 })?
+                .checked_add(15)?)
+                & !15;
+            (delta, frame)
+        } else {
+            (0, 0)
+        };
     Some(ClassifiedGate {
         slot_offset: 0,
         slot_size: u8::try_from(slot.len()).ok()?,
         anchor_scratch: match metadata {
             GateMetadata::X18 { .. }
+            | GateMetadata::X18StackWriteback { .. }
             | GateMetadata::X18CompareBranch { .. }
             | GateMetadata::X18Adr { .. } => x18_anchor_scratch(slot, metadata)?,
             _ => 0,
         },
+        stack_delta,
+        stack_frame_bytes,
         original_site: return_target.checked_sub(4)?,
         conditional_target,
         metadata,
@@ -4086,15 +4574,34 @@ fn classify_gate_pc_with_candidates<const N: usize>(
             } else {
                 0
             };
+            let (stack_delta, stack_frame_bytes) =
+                if matches!(metadata, GateMetadata::X18StackWriteback { .. }) {
+                    let transform_offset = X18StackWritebackOffset::Transform.as_usize();
+                    let (_, _, delta, _) = decode_x18_stack_writeback(u32::from_le_bytes(
+                        slot[transform_offset..transform_offset + INSN_BYTES]
+                            .try_into()
+                            .ok()?,
+                    ))?;
+                    let frame = (16u16
+                        .checked_add(if delta < 0 { delta.unsigned_abs() } else { 0 })?
+                        .checked_add(15)?)
+                        & !15;
+                    (delta, frame)
+                } else {
+                    (0, 0)
+                };
             match_found = Some(ClassifiedGate {
                 slot_offset: start,
                 slot_size: u8::try_from(slot_size).ok()?,
                 anchor_scratch: match metadata {
                     GateMetadata::X18 { .. }
+                    | GateMetadata::X18StackWriteback { .. }
                     | GateMetadata::X18CompareBranch { .. }
                     | GateMetadata::X18Adr { .. } => x18_anchor_scratch(slot, metadata)?,
                     _ => 0,
                 },
+                stack_delta,
+                stack_frame_bytes,
                 original_site: return_target.checked_sub(4)?,
                 conditional_target,
                 metadata,
@@ -4134,7 +4641,7 @@ fn is_host_anchor_read(word: u32, register: u8, host: Option<Host>) -> bool {
 fn x18_anchor_scratch(slot: &[u8], metadata: GateMetadata) -> Option<u8> {
     let offset = match metadata {
         GateMetadata::X18 { .. } | GateMetadata::X18Adr { .. } => 0,
-        GateMetadata::X18CompareBranch { .. } => 4,
+        GateMetadata::X18StackWriteback { .. } | GateMetadata::X18CompareBranch { .. } => 4,
         _ => return None,
     };
     Some(
@@ -4443,6 +4950,7 @@ fn validate_trampoline_and_collect_offsets(
         has_x18_gate |= matches!(
             metadata,
             GateMetadata::X18 { .. }
+                | GateMetadata::X18StackWriteback { .. }
                 | GateMetadata::X18CompareBranch { .. }
                 | GateMetadata::X18Adr { .. }
                 | GateMetadata::X18Branch { .. }
@@ -4453,6 +4961,10 @@ fn validate_trampoline_and_collect_offsets(
             (GateMetadata::X18 { .. }, true) => &[
                 cursor + X18GateOffset::SlotLoad.as_usize(),
                 cursor + X18GateOffset::SlotStore.as_usize(),
+            ],
+            (GateMetadata::X18StackWriteback { .. }, true) => &[
+                cursor + X18StackWritebackOffset::SlotLoad.as_usize(),
+                cursor + X18StackWritebackOffset::SlotStore.as_usize(),
             ],
             (GateMetadata::X18CompareBranch { .. }, true) => &[cursor + 12],
             (GateMetadata::X18Adr { .. }, true) => &[cursor + 16],
@@ -5116,6 +5628,77 @@ mod tests {
     }
 
     #[test]
+    fn sp_writeback_pair_uses_displacement_aware_x18_gate() {
+        // stp x18, x19, [sp, #-16]!
+        let original = 0xa9bf_4ff2;
+        let pair = classify_x18_stack_writeback(original).unwrap();
+        assert_eq!(pair.delta, -16);
+        assert_eq!(pair.frame_bytes, 32);
+        let (patched, outcome) = hook_words_opt_with_config(
+            &[original],
+            0x1000,
+            0x400000,
+            RewriteConfig {
+                host: Host::Linux,
+                virtualize_x18: true,
+            },
+        );
+        let mut outcome = outcome.unwrap();
+        assert!(outcome.trapped_sites.is_empty());
+        assert_ne!(u32::from_le_bytes(patched.try_into().unwrap()), original);
+        let gate = &outcome.trampoline[GATES_START_OFFSET..];
+        assert_eq!(gate.len(), X18_STACK_WRITEBACK_SLOT_BYTES);
+        let metadata = EncodedGateMetadata(u32::from_le_bytes(
+            gate[gate.len() - 4..].try_into().unwrap(),
+        ))
+        .decode()
+        .unwrap();
+        assert_eq!(
+            metadata,
+            GateMetadata::X18StackWriteback {
+                scratch: pair.scratch
+            }
+        );
+        assert!(validate_gate_slot(
+            gate,
+            0x400000,
+            0x400000 + GATES_START_OFFSET as u64,
+            metadata,
+        ));
+        assert_eq!(word_at(gate, 0), Insn::SubSp(32).encode().unwrap());
+        assert_eq!(word_at(gate, 44), Insn::AddSp(16).encode().unwrap());
+        finalize_trampoline_gates_with_x18(&mut outcome.trampoline, 96, 104).unwrap();
+    }
+
+    #[test]
+    fn sp_writeback_recovery_plan_attributes_only_the_pair_to_guest() {
+        for offset in (0..X18StackWritebackOffset::ExecutableEnd.as_usize()).step_by(INSN_BYTES) {
+            let stage = X18StackWritebackOffset::from_offset(offset).unwrap();
+            let plan = stage.recovery_plan().unwrap();
+            assert_eq!(
+                plan.fault_attribution,
+                if stage == X18StackWritebackOffset::Transform {
+                    X18FaultAttribution::GuestInstruction
+                } else {
+                    X18FaultAttribution::Runtime
+                }
+            );
+        }
+        let transform = X18StackWritebackOffset::Transform.recovery_plan().unwrap();
+        assert_eq!(transform.sp, X18StackWritebackSpSource::Signal);
+        assert_eq!(transform.value, X18ValueSource::Scratch);
+        assert_eq!(transform.resume, X18Resume::Original);
+        assert_eq!(
+            transform.frame,
+            X18StackWritebackFrameState::AtAnchorRestoreRegisters
+        );
+        let completed = X18StackWritebackOffset::FinalSp.recovery_plan().unwrap();
+        assert_eq!(completed.sp, X18StackWritebackSpSource::FramePlusResult);
+        assert_eq!(completed.value, X18ValueSource::Slot);
+        assert_eq!(completed.resume, X18Resume::Next);
+    }
+
+    #[test]
     fn x18_gate_uses_each_hosts_exact_anchor_read() {
         for (host, anchor_word) in [
             (Host::Linux, 0xd53b_d050),
@@ -5168,6 +5751,7 @@ mod tests {
             GateMetadata::MrsTpidr { destination: 9 },
             GateMetadata::MsrTpidr { source: 9 },
             GateMetadata::X18 { scratch: 17 },
+            GateMetadata::X18StackWriteback { scratch: 17 },
             GateMetadata::X18CompareBranch { scratch: 17 },
             GateMetadata::X18Adr { scratch: 17 },
             GateMetadata::X18Branch {
@@ -6112,6 +6696,10 @@ mod tests {
             }),
             0x0261b807
         );
+        assert_eq!(
+            word(GateMetadata::X18StackWriteback { scratch: 17 }),
+            0x1171b807
+        );
     }
 
     #[test]
@@ -6141,7 +6729,7 @@ mod tests {
                 );
             }
         }
-        for kind in 7..16 {
+        for kind in 8..16 {
             let invalid = (valid & !GATE_METADATA_KIND_MASK) | (kind << GATE_METADATA_KIND_SHIFT);
             assert_eq!(EncodedGateMetadata(invalid).decode(), None, "kind {kind}");
         }
@@ -6275,7 +6863,7 @@ mod tests {
                 );
             }
         }
-        for kind in 7..16 {
+        for kind in 8..16 {
             let word = (valid & !GATE_METADATA_KIND_MASK) | (kind << GATE_METADATA_KIND_SHIFT);
             assert_eq!(EncodedGateMetadata(word).decode(), None, "kind {kind}");
         }
@@ -6323,12 +6911,15 @@ mod tests {
                         slot_offset: start,
                         slot_size: u8::try_from(size).unwrap(),
                         anchor_scratch: 0,
+                        stack_delta: 0,
+                        stack_frame_bytes: 0,
                         original_site: 0x1000
                             + match metadata {
                                 GateMetadata::MrsTpidr { .. } => 0,
                                 GateMetadata::MsrTpidr { .. } => 4,
                                 GateMetadata::Svc => 8,
                                 GateMetadata::X18 { .. }
+                                | GateMetadata::X18StackWriteback { .. }
                                 | GateMetadata::X18CompareBranch { .. }
                                 | GateMetadata::X18Adr { .. }
                                 | GateMetadata::X18Branch { .. } => unreachable!(),

--- a/litebox_syscall_rewriter/src/aarch64.rs
+++ b/litebox_syscall_rewriter/src/aarch64.rs
@@ -663,7 +663,15 @@ struct X18StackWriteback {
     word: u32,
     scratch: u8,
     anchor_scratch: u8,
+    layout: X18StackWritebackLayout,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct X18StackWritebackLayout {
+    rt: u8,
+    rt2: u8,
     delta: i16,
+    element_bytes: u16,
     frame_bytes: u16,
 }
 
@@ -709,7 +717,7 @@ enum X18Unsupported {
 
 /// Decodes the deliberately narrow pair family supported by the
 /// displacement-aware x18 gate. This is also used to validate persisted gates.
-fn decode_x18_stack_writeback(word: u32) -> Option<(u8, u8, i16, u16)> {
+fn decode_x18_stack_writeback(word: u32) -> Option<X18StackWritebackLayout> {
     // Integer STP/LDP (32- or 64-bit), immediate pre/post-index, SP base.
     if word & 0x7e00_0000 != 0x2800_0000 || (word >> RN_SHIFT) & REG_MASK != u32::from(SP) {
         return None;
@@ -721,27 +729,28 @@ fn decode_x18_stack_writeback(word: u32) -> Option<(u8, u8, i16, u16)> {
     let element_bytes = if word >> 31 == 0 { 4 } else { 8 };
     let imm7 = (((word >> IMM7_SHIFT) & u32::from(IMM7_MASK)) as i16) << 9 >> 9;
     let delta = imm7.checked_mul(element_bytes)?;
-    let rt = (word & REG_MASK) as u8;
-    let rt2 = ((word >> RT2_SHIFT) & REG_MASK) as u8;
-    Some((rt, rt2, delta, element_bytes.cast_unsigned()))
+    let depth = 16u16.checked_add(if delta < 0 { delta.unsigned_abs() } else { 0 })?;
+    Some(X18StackWritebackLayout {
+        rt: (word & REG_MASK) as u8,
+        rt2: ((word >> RT2_SHIFT) & REG_MASK) as u8,
+        delta,
+        element_bytes: element_bytes.cast_unsigned(),
+        frame_bytes: depth.checked_add(15)? & !15,
+    })
 }
 
 fn classify_x18_stack_writeback(word: u32) -> Option<X18StackWriteback> {
-    let (rt, rt2, delta, _element_bytes) = decode_x18_stack_writeback(word)?;
-    if rt != X18 as u8 && rt2 != X18 as u8 {
+    let layout = decode_x18_stack_writeback(word)?;
+    if layout.rt != X18 as u8 && layout.rt2 != X18 as u8 {
         return None;
     }
     let instruction = decode_instruction(word)?;
     let (scratch, anchor_scratch) = select_x18_scratches(&instruction)?;
-    let transformed = substitute_x18(word, scratch)?;
-    let depth = 16u16.checked_add(if delta < 0 { delta.unsigned_abs() } else { 0 })?;
-    let frame_bytes = depth.checked_add(15)? & !15;
     Some(X18StackWriteback {
-        word: transformed,
+        word: substitute_x18(word, scratch)?,
         scratch,
         anchor_scratch,
-        delta,
-        frame_bytes,
+        layout,
     })
 }
 
@@ -1465,7 +1474,6 @@ pub struct X18StackWritebackRecoveryPlan {
     pub sp: X18StackWritebackSpSource,
     pub value: X18ValueSource,
     pub resume: X18Resume,
-    pub runtime_access: RuntimeAccess,
     pub fault_attribution: X18FaultAttribution,
 }
 
@@ -1475,7 +1483,6 @@ impl X18StackWritebackRecoveryPlan {
         sp: X18StackWritebackSpSource,
         value: X18ValueSource,
         resume: X18Resume,
-        runtime_access: RuntimeAccess,
         fault_attribution: X18FaultAttribution,
     ) -> Self {
         Self {
@@ -1483,7 +1490,6 @@ impl X18StackWritebackRecoveryPlan {
             sp,
             value,
             resume,
-            runtime_access,
             fault_attribution,
         }
     }
@@ -1515,7 +1521,6 @@ impl X18StackWritebackOffset {
 
     /// Returns the recovery semantics for this instruction boundary.
     pub const fn recovery_plan(self) -> Option<X18StackWritebackRecoveryPlan> {
-        use RuntimeAccess::{Memory, NoAccess};
         use X18FaultAttribution::{GuestInstruction, Runtime};
         use X18Resume::{Next, Original};
         use X18StackWritebackFrameState::{
@@ -1526,88 +1531,44 @@ impl X18StackWritebackOffset {
         use X18ValueSource::{Scratch, Slot};
 
         Some(match self {
-            Self::Entry => Self::plan(Absent, Signal, Slot, Original, NoAccess, Runtime),
+            Self::Entry => Self::plan(Absent, Signal, Slot, Original, Runtime),
             Self::Spill => Self::plan(
                 AtSpRegistersLive,
                 FramePlusOriginal,
                 Slot,
                 Original,
-                Memory,
                 Runtime,
             ),
-            Self::FirstAnchor => Self::plan(
-                AtSpRestoreRegisters,
-                FramePlusOriginal,
-                Slot,
-                Original,
-                NoAccess,
-                Runtime,
-            ),
-            Self::SlotLoad => Self::plan(
-                AtSpRestoreRegisters,
-                FramePlusOriginal,
-                Slot,
-                Original,
-                Memory,
-                Runtime,
-            ),
-            Self::FrameAddress | Self::RestoreOriginalSp => Self::plan(
-                AtSpRestoreRegisters,
-                FramePlusOriginal,
-                Slot,
-                Original,
-                NoAccess,
-                Runtime,
-            ),
+            Self::FirstAnchor | Self::SlotLoad | Self::FrameAddress | Self::RestoreOriginalSp => {
+                Self::plan(
+                    AtSpRestoreRegisters,
+                    FramePlusOriginal,
+                    Slot,
+                    Original,
+                    Runtime,
+                )
+            }
             Self::Transform => Self::plan(
                 AtAnchorRestoreRegisters,
                 Signal,
                 Scratch,
                 Original,
-                NoAccess,
                 GuestInstruction,
             ),
-            Self::RestoreFrameSp => Self::plan(
-                AtAnchorRestoreRegisters,
-                Signal,
-                Scratch,
-                Next,
-                NoAccess,
-                Runtime,
-            ),
-            Self::SecondAnchor => Self::plan(
+            Self::RestoreFrameSp => {
+                Self::plan(AtAnchorRestoreRegisters, Signal, Scratch, Next, Runtime)
+            }
+            Self::SecondAnchor | Self::SlotStore | Self::RestoreRegisters => Self::plan(
                 AtSpRestoreRegisters,
                 FramePlusResult,
                 Scratch,
                 Next,
-                NoAccess,
                 Runtime,
             ),
-            Self::SlotStore => Self::plan(
-                AtSpRestoreRegisters,
-                FramePlusResult,
-                Scratch,
-                Next,
-                Memory,
-                Runtime,
-            ),
-            Self::RestoreRegisters => Self::plan(
-                AtSpRestoreRegisters,
-                FramePlusResult,
-                Scratch,
-                Next,
-                Memory,
-                Runtime,
-            ),
-            Self::FinalSp => Self::plan(
-                AtSpRegistersRestored,
-                FramePlusResult,
-                Slot,
-                Next,
-                NoAccess,
-                Runtime,
-            ),
-            Self::Return => Self::plan(Absent, Signal, Slot, Next, NoAccess, Runtime),
+            Self::FinalSp => {
+                Self::plan(AtSpRegistersRestored, FramePlusResult, Slot, Next, Runtime)
+            }
+            Self::Return => Self::plan(Absent, Signal, Slot, Next, Runtime),
             Self::ExecutableEnd => return None,
         })
     }
@@ -1617,17 +1578,9 @@ impl X18StackWritebackOffset {
         sp: X18StackWritebackSpSource,
         value: X18ValueSource,
         resume: X18Resume,
-        runtime_access: RuntimeAccess,
         fault_attribution: X18FaultAttribution,
     ) -> X18StackWritebackRecoveryPlan {
-        X18StackWritebackRecoveryPlan::new(
-            frame,
-            sp,
-            value,
-            resume,
-            runtime_access,
-            fault_attribution,
-        )
+        X18StackWritebackRecoveryPlan::new(frame, sp, value, resume, fault_attribution)
     }
 }
 
@@ -3504,7 +3457,7 @@ fn emit_x18_stack_writeback_gate(
         "x18 SP-writeback gate",
     )?;
     let mut asm = Asm::new(gate_vaddr);
-    asm.emit(Insn::SubSp(pair.frame_bytes));
+    asm.emit(Insn::SubSp(pair.layout.frame_bytes));
     asm.emit(Insn::Stp {
         rt: pair.scratch,
         rt2: pair.anchor_scratch,
@@ -3522,7 +3475,7 @@ fn emit_x18_stack_writeback_gate(
         rn: SP,
         imm12: 0,
     });
-    asm.emit(Insn::AddSp(pair.frame_bytes));
+    asm.emit(Insn::AddSp(pair.layout.frame_bytes));
     asm.push_word(pair.word);
     asm.emit(Insn::AddImm {
         rd: SP,
@@ -3541,8 +3494,9 @@ fn emit_x18_stack_writeback_gate(
         rn: SP,
         imm_bytes: 0,
     });
-    let final_adjustment = u16::try_from(i32::from(pair.frame_bytes) + i32::from(pair.delta))
-        .map_err(|_| Error::AddressOverflow("x18 SP-writeback adjustment".into()))?;
+    let final_adjustment =
+        u16::try_from(i32::from(pair.layout.frame_bytes) + i32::from(pair.layout.delta))
+            .map_err(|_| Error::AddressOverflow("x18 SP-writeback adjustment".into()))?;
     asm.emit(Insn::AddSp(final_adjustment));
     let return_addr = checked_add_u64(site.vaddr, INSN_BYTES_U64, "x18 SP-writeback return")?;
     if !asm.branch_to(return_addr)? {
@@ -4062,50 +4016,47 @@ fn validate_gate_slot_inner_for_host(
         GateMetadata::X18StackWriteback { scratch } => {
             let anchor_scratch = ((word(4) >> RT2_SHIFT) & REG_MASK) as u8;
             let transformed = word(X18StackWritebackOffset::Transform.as_usize());
-            let Some((rt, rt2, delta, element_bytes)) = decode_x18_stack_writeback(transformed)
-            else {
-                return false;
-            };
-            let depth = 16u16
-                .checked_add(if delta < 0 { delta.unsigned_abs() } else { 0 })
-                .and_then(|depth| depth.checked_add(15))
-                .map(|depth| depth & !15);
-            let Some(frame_bytes) = depth else {
+            let Some(layout) = decode_x18_stack_writeback(transformed) else {
                 return false;
             };
             // Revalidate the original operand layout and scratch choices.
             let mut original = transformed;
-            if rt == scratch {
+            if layout.rt == scratch {
                 original = (original & !REG_MASK) | u32::from(X18);
             }
-            if rt2 == scratch {
+            if layout.rt2 == scratch {
                 original = (original & !(REG_MASK << RT2_SHIFT)) | (u32::from(X18) << RT2_SHIFT);
             }
             let Some(derived) = classify_x18_stack_writeback(original) else {
                 return false;
             };
             let mode = (transformed >> 23) & 3;
-            let access_start = if mode == 3 { i32::from(delta) } else { 0 };
-            let access_end = access_start + i32::from(element_bytes) * 2;
-            let frame_start = -i32::from(frame_bytes);
+            let access_start = if mode == 3 {
+                i32::from(layout.delta)
+            } else {
+                0
+            };
+            let access_end = access_start + i32::from(layout.element_bytes) * 2;
+            let frame_start = -i32::from(layout.frame_bytes);
             let frame_end = frame_start + i32::from(X18_FRAME_BYTES);
             let disjoint = access_end <= frame_start || access_start >= frame_end;
             if !(7..=17).contains(&scratch)
                 || !(7..=17).contains(&anchor_scratch)
                 || anchor_scratch == scratch
-                || (rt != scratch && rt2 != scratch)
-                || rt == anchor_scratch
-                || rt2 == anchor_scratch
+                || (layout.rt != scratch && layout.rt2 != scratch)
+                || layout.rt == anchor_scratch
+                || layout.rt2 == anchor_scratch
                 || derived.word != transformed
                 || derived.scratch != scratch
                 || derived.anchor_scratch != anchor_scratch
-                || derived.delta != delta
-                || derived.frame_bytes != frame_bytes
+                || derived.layout.delta != layout.delta
+                || derived.layout.element_bytes != layout.element_bytes
+                || derived.layout.frame_bytes != layout.frame_bytes
                 || !disjoint
             {
                 return false;
             }
-            exact(0, Insn::SubSp(frame_bytes))
+            exact(0, Insn::SubSp(layout.frame_bytes))
                 && exact(
                     4,
                     Insn::Stp {
@@ -4125,7 +4076,7 @@ fn validate_gate_slot_inner_for_host(
                         imm12: 0,
                     },
                 )
-                && exact(20, Insn::AddSp(frame_bytes))
+                && exact(20, Insn::AddSp(layout.frame_bytes))
                 && exact(
                     28,
                     Insn::AddImm {
@@ -4148,7 +4099,10 @@ fn validate_gate_slot_inner_for_host(
                 )
                 && exact(
                     44,
-                    Insn::AddSp(u16::try_from(i32::from(frame_bytes) + i32::from(delta)).unwrap()),
+                    Insn::AddSp(
+                        u16::try_from(i32::from(layout.frame_bytes) + i32::from(layout.delta))
+                            .unwrap(),
+                    ),
                 )
                 && word(48) & OPCODE_TOP6_MASK == Opcode::B.bits()
                 && padding_is_nops(52)
@@ -4475,22 +4429,7 @@ pub fn classify_copied_gate_slot(slot: &[u8], slot_vaddr: u64, pc: u64) -> Optio
     } else {
         0
     };
-    let (stack_delta, stack_frame_bytes) =
-        if matches!(metadata, GateMetadata::X18StackWriteback { .. }) {
-            let (_, _, delta, _) = decode_x18_stack_writeback(u32::from_le_bytes(
-                slot[X18StackWritebackOffset::Transform.as_usize()
-                    ..X18StackWritebackOffset::Transform.as_usize() + 4]
-                    .try_into()
-                    .ok()?,
-            ))?;
-            let frame = (16u16
-                .checked_add(if delta < 0 { delta.unsigned_abs() } else { 0 })?
-                .checked_add(15)?)
-                & !15;
-            (delta, frame)
-        } else {
-            (0, 0)
-        };
+    let (stack_delta, stack_frame_bytes) = stack_writeback_state(slot, metadata)?;
     Some(ClassifiedGate {
         slot_offset: 0,
         slot_size: u8::try_from(slot.len()).ok()?,
@@ -4574,22 +4513,7 @@ fn classify_gate_pc_with_candidates<const N: usize>(
             } else {
                 0
             };
-            let (stack_delta, stack_frame_bytes) =
-                if matches!(metadata, GateMetadata::X18StackWriteback { .. }) {
-                    let transform_offset = X18StackWritebackOffset::Transform.as_usize();
-                    let (_, _, delta, _) = decode_x18_stack_writeback(u32::from_le_bytes(
-                        slot[transform_offset..transform_offset + INSN_BYTES]
-                            .try_into()
-                            .ok()?,
-                    ))?;
-                    let frame = (16u16
-                        .checked_add(if delta < 0 { delta.unsigned_abs() } else { 0 })?
-                        .checked_add(15)?)
-                        & !15;
-                    (delta, frame)
-                } else {
-                    (0, 0)
-                };
+            let (stack_delta, stack_frame_bytes) = stack_writeback_state(slot, metadata)?;
             match_found = Some(ClassifiedGate {
                 slot_offset: start,
                 slot_size: u8::try_from(slot_size).ok()?,
@@ -4636,6 +4560,17 @@ fn is_host_anchor_read(word: u32, register: u8, host: Option<Host>) -> bool {
         },
         |host| host.anchor_read(register).encode() == Some(word),
     )
+}
+
+fn stack_writeback_state(slot: &[u8], metadata: GateMetadata) -> Option<(i16, u16)> {
+    if !matches!(metadata, GateMetadata::X18StackWriteback { .. }) {
+        return Some((0, 0));
+    }
+    let offset = X18StackWritebackOffset::Transform.as_usize();
+    let layout = decode_x18_stack_writeback(u32::from_le_bytes(
+        slot.get(offset..offset + INSN_BYTES)?.try_into().ok()?,
+    ))?;
+    Some((layout.delta, layout.frame_bytes))
 }
 
 fn x18_anchor_scratch(slot: &[u8], metadata: GateMetadata) -> Option<u8> {
@@ -5632,8 +5567,8 @@ mod tests {
         // stp x18, x19, [sp, #-16]!
         let original = 0xa9bf_4ff2;
         let pair = classify_x18_stack_writeback(original).unwrap();
-        assert_eq!(pair.delta, -16);
-        assert_eq!(pair.frame_bytes, 32);
+        assert_eq!(pair.layout.delta, -16);
+        assert_eq!(pair.layout.frame_bytes, 32);
         let (patched, outcome) = hook_words_opt_with_config(
             &[original],
             0x1000,


### PR DESCRIPTION
This PR adds support for rewriting AArch64 instructions (`STP`/`LDP`) which can use x18 while updating the stack pointer (SP). The existing x18 gates do not support them because they restore the original SP after execution. A new x18 stack writeback gate preserves the updated SP.