### PR TITLE
Support remaining AArch64 x18/SP pair instructions

### DIFF
--- a/litebox_runner_linux_userland/tests/x18_virtualization.S
+++ b/litebox_runner_linux_userland/tests/x18_virtualization.S
@@ -56,6 +56,39 @@ _start:
     cmp x21, x0
     b.ne fail
 
+    // Exercise the remaining non-exclusive integer pair operations with x18
+    // in Rt2, whose encoding is independent of Rt.
+    sub sp, sp, #16
+    mov x21, #0x2121
+    mov x18, #0x1818
+    stnp x21, x18, [sp]
+    mov x21, xzr
+    mov x18, xzr
+    ldnp x21, x18, [sp]
+    mov x0, #0x2121
+    cmp x21, x0
+    b.ne fail_pair_stack
+    mov x0, #0x1818
+    cmp x18, x0
+    b.ne fail_pair_stack
+
+    // LDPSW sign-extends both 32-bit words into its X-register destinations.
+    mov w21, #0x2121
+    mov w0, #-2
+    str w21, [sp]
+    str w0, [sp, #4]
+    mov x21, xzr
+    mov x18, xzr
+    ldpsw x21, x18, [sp]
+    mov x0, #0x2121
+    cmp x21, x0
+    b.ne fail_pair_stack
+    cmn x18, #2
+    b.ne fail_pair_stack
+    add sp, sp, #16
+    cmp sp, x19
+    b.ne fail
+
     mov x27, #15
     mov x0, #0x5050
     mov x1, #0x5151
@@ -261,6 +294,9 @@ success:
     mov x8, #93
     svc #0
 
+fail_pair_stack:
+    add sp, sp, #16
+    b fail
 fail_stack:
     add sp, sp, #16
 fail:

--- a/litebox_syscall_rewriter/src/aarch64.rs
+++ b/litebox_syscall_rewriter/src/aarch64.rs
@@ -1234,7 +1234,11 @@ fn substitute_x18(word: u32, replacement: u8) -> Option<u32> {
                     (_, 1)
                         if matches!(
                             instruction.opcode,
-                            DecodedOpcode::STP | DecodedOpcode::LDP
+                            DecodedOpcode::STP
+                                | DecodedOpcode::LDP
+                                | DecodedOpcode::STNP
+                                | DecodedOpcode::LDNP
+                                | DecodedOpcode::LDPSW
                         ) =>
                     {
                         RT2_SHIFT
@@ -5231,7 +5235,10 @@ mod tests {
             (0x0b12_0063, 0x0b11_0063), // ADD Rm
             (0xf940_0642, 0xf940_0622), // memory base
             (0xf832_7824, 0xf831_7824), // memory index
-            (0xa906_4bee, 0xa906_47ee), // Rt2
+            (0xa906_4bee, 0xa906_47ee), // STP Rt2
+            (0xa801_480e, 0xa801_440e), // STNP Rt2
+            (0xa841_480e, 0xa841_440e), // LDNP Rt2
+            (0x6942_480e, 0x6942_440e), // LDPSW Rt2
             (0x9b08_486b, 0x9b08_446b), // MADD Ra
             (0x9b12_8c41, 0x9b11_8c41), // MSUB Rm
             (0x9b25_48a4, 0x9b25_44a4), // SMADDL Ra


### PR DESCRIPTION
This PR adds support for rewriting remaining AArch64 x18/SP pair instructions including `STNP`, `LDNP`, and `LDPSW`.