### PR TITLE
Add same-process userland broker connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1509,7 +1509,6 @@ dependencies = [
  "litebox_broker_transport_linux_userland",
  "litebox_broker_transport_windows_userland",
  "litebox_broker_userland",
- "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1502,11 +1502,14 @@ name = "litebox_broker_local_userland"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "litebox_broker_core",
  "litebox_broker_local",
  "litebox_broker_protocol",
  "litebox_broker_transport",
  "litebox_broker_transport_linux_userland",
  "litebox_broker_transport_windows_userland",
+ "litebox_broker_userland",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/litebox_broker_local_userland/Cargo.toml
+++ b/litebox_broker_local_userland/Cargo.toml
@@ -16,7 +16,6 @@ litebox_broker_transport_linux_userland = { path = "../litebox_broker_transport_
 
 [target.'cfg(all(windows, target_arch = "x86_64"))'.dependencies]
 litebox_broker_transport_windows_userland = { path = "../litebox_broker_transport_windows_userland", version = "0.1.0" }
-windows-sys = { version = "0.60.2", default-features = false, features = ["Win32_System_Threading"] }
 
 [lints]
 workspace = true

--- a/litebox_broker_local_userland/Cargo.toml
+++ b/litebox_broker_local_userland/Cargo.toml
@@ -5,15 +5,18 @@ edition = "2024"
 
 [dependencies]
 anyhow = { version = "1.0.97", default-features = false }
+litebox_broker_core = { path = "../litebox_broker_core", version = "0.1.0" }
 litebox_broker_local = { path = "../litebox_broker_local", version = "0.1.0" }
 litebox_broker_protocol = { path = "../litebox_broker_protocol", version = "0.1.0" }
 litebox_broker_transport = { path = "../litebox_broker_transport", version = "0.1.0" }
+litebox_broker_userland = { path = "../litebox_broker_userland", version = "0.1.0" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 litebox_broker_transport_linux_userland = { path = "../litebox_broker_transport_linux_userland", version = "0.1.0" }
 
 [target.'cfg(all(windows, target_arch = "x86_64"))'.dependencies]
 litebox_broker_transport_windows_userland = { path = "../litebox_broker_transport_windows_userland", version = "0.1.0" }
+windows-sys = { version = "0.60.2", default-features = false, features = ["Win32_System_Threading"] }
 
 [lints]
 workspace = true

--- a/litebox_broker_local_userland/src/in_process.rs
+++ b/litebox_broker_local_userland/src/in_process.rs
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+use std::io::{Error, Result as IoResult};
+use std::sync::Mutex;
+use std::thread::JoinHandle;
+
+pub(crate) struct InProcessHostThread {
+    thread: Mutex<Option<JoinHandle<IoResult<()>>>>,
+}
+
+impl InProcessHostThread {
+    pub(crate) const fn new(thread: JoinHandle<IoResult<()>>) -> Self {
+        Self {
+            thread: Mutex::new(Some(thread)),
+        }
+    }
+
+    pub(crate) fn join(&self) -> IoResult<()> {
+        let mut thread = self
+            .thread
+            .lock()
+            .map_err(|_| Error::other("in-process broker host thread mutex poisoned"))?;
+        let Some(thread) = thread.take() else {
+            return Ok(());
+        };
+        thread
+            .join()
+            .map_err(|_| Error::other("in-process broker host thread panicked"))?
+    }
+
+    pub(crate) fn join_and_report(&self) {
+        if let Err(error) = self.join() {
+            eprintln!("in-process broker host failed: {error}");
+        }
+    }
+}
+
+impl Drop for InProcessHostThread {
+    fn drop(&mut self) {
+        if let Err(error) = self.join() {
+            eprintln!("in-process broker host failed: {error}");
+        }
+    }
+}

--- a/litebox_broker_local_userland/src/lib.rs
+++ b/litebox_broker_local_userland/src/lib.rs
@@ -1,18 +1,22 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-//! Hosted userland bindings for the portable broker local endpoint.
+//! Userland bindings for connecting the portable broker local endpoint to an
+//! external or same-process broker host.
 
 #![cfg(any(target_os = "linux", all(windows, target_arch = "x86_64")))]
+
+mod in_process;
 
 #[cfg(target_os = "linux")]
 mod linux;
 #[cfg(target_os = "linux")]
 pub use linux::{
-    BrokerAssociationFailureCoordinator, BrokerConnection, connect, start_notification_receiver,
+    BrokerAssociationFailureCoordinator, BrokerConnection, connect, connect_in_process,
+    start_notification_receiver,
 };
 
 #[cfg(all(windows, target_arch = "x86_64"))]
 mod windows;
 #[cfg(all(windows, target_arch = "x86_64"))]
-pub use windows::{BrokerConnection, connect, start_notification_receiver};
+pub use windows::{BrokerConnection, connect, connect_in_process, start_notification_receiver};

--- a/litebox_broker_local_userland/src/linux.rs
+++ b/litebox_broker_local_userland/src/linux.rs
@@ -3,6 +3,7 @@
 
 use std::{
     os::fd::{AsFd, AsRawFd, RawFd},
+    os::unix::net::UnixStream,
     path::Path,
     sync::{
         Arc, Mutex,
@@ -12,14 +13,21 @@ use std::{
 };
 
 use anyhow::{Context as _, Result};
+use litebox_broker_core::BrokerCore;
 use litebox_broker_local::{BrokerLocal, BrokerNotifications};
 use litebox_broker_protocol::message::BrokerNotification;
 use litebox_broker_protocol::shared_buffer::SHARED_BUFFER_POOL_SIZE;
 use litebox_broker_transport::control_ring::ControlRing;
+use litebox_broker_transport_linux_userland::memfd::MemfdSharedMemory;
 use litebox_broker_transport_linux_userland::unix_socket::{
     UnixControlRingLocalCallChannel, UnixControlRingLocalNotificationChannel,
     UnixControlRingLocalShutdown, UnixStreamLocalSetupChannel,
 };
+use litebox_broker_transport_linux_userland::unix_socket::{
+    UnixStreamHostSetupChannel, validate_peer_process,
+};
+
+use crate::in_process::InProcessHostThread;
 
 const SETUP_TIMEOUT: Duration = Duration::from_secs(5);
 const RETRY_DELAY: Duration = Duration::from_millis(20);
@@ -53,6 +61,69 @@ pub fn connect(control_socket_path: &Path) -> Result<BrokerConnection> {
             control_socket_path.display()
         )
     })?;
+    negotiate(setup_channel, setup_deadline, None)
+}
+
+/// Connects to a broker core hosted in this process over the production Linux
+/// Unix-socket, memfd, and control-ring transport.
+///
+/// This mode is intended for tests and explicitly non-secure development
+/// deployments. The broker host thread is not covered by the runner thread's
+/// seccomp filter; secure Linux deployments must keep the broker and runner in
+/// separate processes. Active-association failure shuts down the transport and
+/// joins the broker host thread before failure handling returns.
+pub fn connect_in_process(broker: &BrokerCore) -> Result<BrokerConnection> {
+    let setup_deadline = Instant::now() + SETUP_TIMEOUT;
+    let (local_stream, host_stream) =
+        UnixStream::pair().context("failed to create in-process broker control socket")?;
+    validate_peer_process(&host_stream, std::process::id())
+        .context("failed to authenticate in-process broker peer")?;
+
+    let broker = broker.clone();
+    let host_thread = Arc::new(InProcessHostThread::new(
+        std::thread::Builder::new()
+            .name("litebox-broker-host".to_owned())
+            .spawn(move || {
+                let control_channel =
+                    UnixStreamHostSetupChannel::from_host_guaranteed(host_stream, setup_deadline);
+                litebox_broker_userland::runtime::serve_association(
+                    &broker,
+                    control_channel,
+                    || MemfdSharedMemory::create(SHARED_BUFFER_POOL_SIZE),
+                    MemfdSharedMemory::create_control_ring,
+                    |channel, shared_memory, control_memory| {
+                        channel.send_memfd(shared_memory, Some(setup_deadline))?;
+                        channel.send_memfd(control_memory, Some(setup_deadline))
+                    },
+                    UnixStreamHostSetupChannel::into_active,
+                )
+            })
+            .context("failed to start in-process broker host")?,
+    ));
+    let setup_channel = UnixStreamLocalSetupChannel::from_connected_with_setup_deadline(
+        local_stream,
+        setup_deadline,
+    );
+    match negotiate(
+        setup_channel,
+        setup_deadline,
+        Some(Arc::clone(&host_thread)),
+    ) {
+        Ok(connection) => Ok(connection),
+        Err(error) => match host_thread.join() {
+            Ok(()) => Err(error),
+            Err(host_error) => {
+                Err(error.context(format!("in-process broker host failed: {host_error}")))
+            }
+        },
+    }
+}
+
+fn negotiate(
+    setup_channel: UnixStreamLocalSetupChannel,
+    setup_deadline: Instant,
+    host_thread: Option<Arc<InProcessHostThread>>,
+) -> Result<BrokerConnection> {
     let association_coordinator = Arc::new(BrokerAssociationFailureCoordinator::new());
     let (local, (notification_channel, positional_io_fds, shutdown_fd)) =
         BrokerLocal::negotiate(setup_channel, |mut setup| {
@@ -70,10 +141,14 @@ pub fn connect(control_socket_path: &Path) -> Result<BrokerConnection> {
                 )
             })?;
             let weak_association_coordinator = Arc::downgrade(&association_coordinator);
+            let host_thread = host_thread.clone();
             let (call_channel, notification_channel, association_shutdown) =
                 setup.into_active(control_ring, move || {
                     if let Some(association_coordinator) = weak_association_coordinator.upgrade() {
                         association_coordinator.report_failure();
+                    }
+                    if let Some(host_thread) = &host_thread {
+                        host_thread.join_and_report();
                     }
                 })?;
             let shutdown_fd = association_shutdown.as_fd().as_raw_fd();

--- a/litebox_broker_local_userland/src/windows.rs
+++ b/litebox_broker_local_userland/src/windows.rs
@@ -20,7 +20,6 @@ use litebox_broker_transport_windows_userland::named_pipe::{
     WindowsNamedPipeStream, validate_client_process,
 };
 use litebox_broker_transport_windows_userland::shared_memory::WindowsSharedMemory;
-use windows_sys::Win32::System::Threading::GetCurrentProcess;
 
 use crate::in_process::InProcessHostThread;
 
@@ -70,17 +69,14 @@ pub fn connect_in_process(broker: &BrokerCore) -> Result<BrokerConnection> {
                     control_stream,
                     deadline,
                 );
-                // SAFETY: GetCurrentProcess returns the documented pseudo-handle
-                // for the current process and does not transfer ownership.
-                let current_process = unsafe { GetCurrentProcess() };
                 litebox_broker_userland::runtime::serve_association(
                     &broker,
                     control_channel,
                     || WindowsSharedMemory::create(SHARED_BUFFER_POOL_SIZE),
                     WindowsSharedMemory::create_control_ring,
                     |channel, shared_memory, control_memory| {
-                        channel.send_shared_memory(shared_memory, current_process)?;
-                        channel.send_shared_memory(control_memory, current_process)
+                        channel.send_shared_memory_to_current_process(shared_memory)?;
+                        channel.send_shared_memory_to_current_process(control_memory)
                     },
                     WindowsNamedPipeHostSetupChannel::into_active,
                 )

--- a/litebox_broker_local_userland/src/windows.rs
+++ b/litebox_broker_local_userland/src/windows.rs
@@ -1,11 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-use std::ffi::OsStr;
+use std::ffi::{OsStr, OsString};
+use std::io::{Error, ErrorKind, Result as IoResult};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use anyhow::{Context as _, Result};
+use litebox_broker_core::BrokerCore;
 use litebox_broker_local::{BrokerLocal, BrokerNotifications};
 use litebox_broker_protocol::message::BrokerNotification;
 use litebox_broker_protocol::shared_buffer::SHARED_BUFFER_POOL_SIZE;
@@ -13,9 +15,17 @@ use litebox_broker_transport::control_ring::ControlRing;
 use litebox_broker_transport_windows_userland::control_ring::{
     WindowsControlRingLocalCallChannel, WindowsControlRingLocalNotificationChannel,
 };
-use litebox_broker_transport_windows_userland::named_pipe::WindowsNamedPipeLocalSetupChannel;
+use litebox_broker_transport_windows_userland::named_pipe::{
+    WindowsNamedPipeHostSetupChannel, WindowsNamedPipeListener, WindowsNamedPipeLocalSetupChannel,
+    WindowsNamedPipeStream, validate_client_process,
+};
+use litebox_broker_transport_windows_userland::shared_memory::WindowsSharedMemory;
+use windows_sys::Win32::System::Threading::GetCurrentProcess;
+
+use crate::in_process::InProcessHostThread;
 
 const SETUP_TIMEOUT: Duration = Duration::from_secs(5);
+const ACCEPT_RETRY_DELAY: Duration = Duration::from_millis(10);
 
 /// An active Windows-userland broker association.
 pub struct BrokerConnection {
@@ -36,6 +46,66 @@ pub fn connect(control_pipe: &OsStr) -> Result<BrokerConnection> {
                     std::path::Path::new(control_pipe).display()
                 )
             })?;
+    negotiate(setup, None)
+}
+
+/// Connects to a broker core hosted in this process over the production
+/// Windows named-pipe, shared-section, and control-ring transport.
+///
+/// Active-association failure shuts down the transport and joins the broker
+/// host thread before failure handling returns.
+pub fn connect_in_process(broker: &BrokerCore) -> Result<BrokerConnection> {
+    let deadline = Instant::now() + SETUP_TIMEOUT;
+    let pipe_name = unique_control_pipe_name();
+    let listener = WindowsNamedPipeListener::bind(&pipe_name)
+        .context("failed to create in-process broker control pipe")?;
+    let broker = broker.clone();
+    let host_thread = Arc::new(InProcessHostThread::new(
+        std::thread::Builder::new()
+            .name("litebox-broker-host".to_owned())
+            .spawn(move || {
+                let control_stream = accept_in_process_client(listener, deadline)?;
+                validate_client_process(&control_stream, std::process::id())?;
+                let control_channel = WindowsNamedPipeHostSetupChannel::from_host_guaranteed(
+                    control_stream,
+                    deadline,
+                );
+                // SAFETY: GetCurrentProcess returns the documented pseudo-handle
+                // for the current process and does not transfer ownership.
+                let current_process = unsafe { GetCurrentProcess() };
+                litebox_broker_userland::runtime::serve_association(
+                    &broker,
+                    control_channel,
+                    || WindowsSharedMemory::create(SHARED_BUFFER_POOL_SIZE),
+                    WindowsSharedMemory::create_control_ring,
+                    |channel, shared_memory, control_memory| {
+                        channel.send_shared_memory(shared_memory, current_process)?;
+                        channel.send_shared_memory(control_memory, current_process)
+                    },
+                    WindowsNamedPipeHostSetupChannel::into_active,
+                )
+            })
+            .context("failed to start in-process broker host")?,
+    ));
+    let connection =
+        WindowsNamedPipeLocalSetupChannel::connect_with_setup_deadline(&pipe_name, deadline)
+            .context("failed to connect to in-process broker")
+            .and_then(|setup| negotiate(setup, Some(Arc::clone(&host_thread))));
+    match connection {
+        Ok(connection) => Ok(connection),
+        Err(error) => match host_thread.join() {
+            Ok(()) => Err(error),
+            Err(host_error) => {
+                Err(error.context(format!("in-process broker host failed: {host_error}")))
+            }
+        },
+    }
+}
+
+fn negotiate(
+    setup: WindowsNamedPipeLocalSetupChannel,
+    host_thread: Option<Arc<InProcessHostThread>>,
+) -> Result<BrokerConnection> {
     let (local, notifications) = BrokerLocal::negotiate(setup, |mut setup| {
         let shared_memory = Arc::new(setup.receive_shared_memory(SHARED_BUFFER_POOL_SIZE)?);
         let control_memory = setup.receive_control_ring()?;
@@ -45,7 +115,12 @@ pub fn connect(control_pipe: &OsStr) -> Result<BrokerConnection> {
                 format!("invalid broker control ring: {error:?}"),
             )
         })?;
-        let (calls, notifications) = setup.into_active(control_ring)?;
+        let (calls, notifications) =
+            setup.into_active_with_failure_handler(control_ring, move || {
+                if let Some(host_thread) = &host_thread {
+                    host_thread.join_and_report();
+                }
+            })?;
         Ok((calls, shared_memory, notifications))
     })
     .context("broker negotiation failed")?;
@@ -53,6 +128,41 @@ pub fn connect(control_pipe: &OsStr) -> Result<BrokerConnection> {
         local,
         notifications: BrokerNotifications::new(notifications),
     })
+}
+
+fn accept_in_process_client(
+    mut listener: WindowsNamedPipeListener,
+    deadline: Instant,
+) -> IoResult<WindowsNamedPipeStream> {
+    loop {
+        match listener.try_accept() {
+            Ok(stream) => return Ok(stream),
+            Err(error) if error.kind() == ErrorKind::WouldBlock && Instant::now() < deadline => {
+                std::thread::sleep(
+                    ACCEPT_RETRY_DELAY.min(deadline.saturating_duration_since(Instant::now())),
+                );
+            }
+            Err(error) if error.kind() == ErrorKind::WouldBlock => {
+                return Err(Error::new(
+                    ErrorKind::TimedOut,
+                    "timed out accepting in-process broker connection",
+                ));
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+fn unique_control_pipe_name() -> OsString {
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    format!(
+        r"\\.\pipe\litebox-in-process-broker-{}-{nonce}",
+        std::process::id()
+    )
+    .into()
 }
 
 /// Starts the broker notification receiver for an active association.

--- a/litebox_broker_local_userland/tests/in_process.rs
+++ b/litebox_broker_local_userland/tests/in_process.rs
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#![cfg(any(target_os = "linux", all(windows, target_arch = "x86_64")))]
+
+use std::sync::{Arc, Barrier};
+
+use litebox_broker_core::{ObjectRights, PolicyEngine};
+use litebox_broker_local_userland::connect_in_process;
+use litebox_broker_protocol::readiness::ReadinessFlags;
+use litebox_broker_userland::builder::BrokerCoreBuilder;
+
+#[test]
+fn in_process_connection_serves_concurrent_requests_and_shuts_down() {
+    let broker = BrokerCoreBuilder::new(PolicyEngine::with_host_guaranteed_rights(
+        ObjectRights::all(),
+    ))
+    .build()
+    .unwrap();
+    let connection = connect_in_process(&broker).unwrap();
+    let local = Arc::new(connection.local);
+    let mut notifications = connection.notifications;
+
+    let start = Arc::new(Barrier::new(9));
+    let callers = (0..8)
+        .map(|initial_count| {
+            let local = Arc::clone(&local);
+            let start = Arc::clone(&start);
+            std::thread::spawn(move || {
+                start.wait();
+                local.create_event_with_count(initial_count)
+            })
+        })
+        .collect::<Vec<_>>();
+    start.wait();
+
+    for (initial_count, caller) in callers.into_iter().enumerate() {
+        let handle = caller.join().unwrap().unwrap();
+        let readiness = local.check_readiness(handle).unwrap();
+        assert_eq!(readiness.contains(ReadinessFlags::READ), initial_count != 0);
+        local.close_object(handle).unwrap();
+    }
+
+    let notification_receiver = std::thread::spawn(move || {
+        loop {
+            match notifications.recv_notification() {
+                Ok(Some(_)) => {}
+                terminal => return terminal,
+            }
+        }
+    });
+    drop(local);
+    assert!(
+        notification_receiver.join().unwrap().is_err(),
+        "association shutdown must fail the blocked notification receiver"
+    );
+}

--- a/litebox_broker_transport_linux_userland/src/unix_socket/local.rs
+++ b/litebox_broker_transport_linux_userland/src/unix_socket/local.rs
@@ -94,6 +94,16 @@ impl UnixStreamLocalSetupChannel {
         }
     }
 
+    /// Creates a local setup channel from an already-connected Unix stream and
+    /// bounds all setup I/O by `deadline`.
+    pub const fn from_connected_with_setup_deadline(stream: UnixStream, deadline: Instant) -> Self {
+        Self {
+            stream,
+            setup_deadline: Some(deadline),
+            negotiated: false,
+        }
+    }
+
     /// Connects to a userland broker Unix socket.
     pub fn connect(path: impl AsRef<Path>) -> IoResult<Self> {
         UnixStream::connect(path).map(Self::from_connected)

--- a/litebox_broker_transport_windows_userland/src/host.rs
+++ b/litebox_broker_transport_windows_userland/src/host.rs
@@ -26,6 +26,7 @@ use litebox_broker_transport::control_ring::{
 };
 use windows_sys::Win32::Foundation::HANDLE;
 use windows_sys::Win32::System::Pipes::GetNamedPipeClientProcessId;
+use windows_sys::Win32::System::Threading::GetCurrentProcess;
 
 use crate::control_ring::PipeLiveness;
 use crate::named_pipe::{TRANSFER_FRAME_TAG, WindowsNamedPipeStream};
@@ -107,6 +108,17 @@ impl WindowsNamedPipeHostSetupChannel {
             &encode_transfer(&transfer)?,
             self.setup_deadline,
         )
+    }
+
+    /// Duplicates one shared-memory object into this process and sends its
+    /// handle values to a same-process local endpoint.
+    pub fn send_shared_memory_to_current_process(
+        &mut self,
+        memory: &WindowsSharedMemory,
+    ) -> IoResult<()> {
+        // SAFETY: GetCurrentProcess returns the documented pseudo-handle for
+        // the current process and does not transfer ownership.
+        self.send_shared_memory(memory, unsafe { GetCurrentProcess() })
     }
 
     /// Activates host request, response, and notification control-ring endpoints.

--- a/litebox_broker_transport_windows_userland/src/local.rs
+++ b/litebox_broker_transport_windows_userland/src/local.rs
@@ -62,6 +62,7 @@ struct LocalRingAssociation {
     request_producer: Mutex<ControlRingProducer<WindowsSharedMemory>>,
     pending_calls: Arc<PendingCalls>,
     liveness: PipeLiveness,
+    on_failure: Arc<dyn Fn() + Send + Sync>,
     request_wake: ControlRingWakeHandle<WindowsSharedMemory>,
     response_wake: ControlRingWakeHandle<WindowsSharedMemory>,
     notification_wake: ControlRingWakeHandle<WindowsSharedMemory>,
@@ -139,7 +140,26 @@ impl WindowsNamedPipeLocalSetupChannel {
         WindowsControlRingLocalCallChannel,
         WindowsControlRingLocalNotificationChannel,
     )> {
-        activate_local(self.stream, self.negotiated, self.setup_deadline, ring)
+        self.into_active_with_failure_handler(ring, || {})
+    }
+
+    /// Activates calls and notifications and invokes `on_failure` once after
+    /// the active association first fails and its waits have been interrupted.
+    pub fn into_active_with_failure_handler(
+        self,
+        ring: ControlRing<WindowsSharedMemory>,
+        on_failure: impl Fn() + Send + Sync + 'static,
+    ) -> IoResult<(
+        WindowsControlRingLocalCallChannel,
+        WindowsControlRingLocalNotificationChannel,
+    )> {
+        activate_local(
+            self.stream,
+            self.negotiated,
+            self.setup_deadline,
+            ring,
+            Arc::new(on_failure),
+        )
     }
 }
 
@@ -168,6 +188,7 @@ fn activate_local(
     negotiated: bool,
     setup_deadline: Option<Instant>,
     ring: ControlRing<WindowsSharedMemory>,
+    on_failure: Arc<dyn Fn() + Send + Sync>,
 ) -> IoResult<(
     WindowsControlRingLocalCallChannel,
     WindowsControlRingLocalNotificationChannel,
@@ -199,6 +220,7 @@ fn activate_local(
     let stream = Arc::new(stream);
     let association = Arc::new(LocalRingAssociation {
         liveness: PipeLiveness::new(Arc::clone(&stream), false)?,
+        on_failure,
         request_wake: request_producer.wake_handle(),
         request_producer: Mutex::new(request_producer),
         response_wake: response_consumer.wake_handle(),
@@ -338,12 +360,17 @@ impl LocalRingAssociation {
     }
 
     fn fail(&self, error: Error) -> IoResult<()> {
-        self.pending_calls.record_failure(Arc::new(error));
-        self.request_wake
+        let first_failure = self.pending_calls.record_failure(Arc::new(error));
+        let result = self
+            .request_wake
             .interrupt_wait()
             .and(self.response_wake.interrupt_wait())
             .and(self.notification_wake.interrupt_wait())
-            .and(self.liveness.shutdown())
+            .and(self.liveness.shutdown());
+        if first_failure {
+            (self.on_failure)();
+        }
+        result
     }
 }
 


### PR DESCRIPTION
This PR adds `connect_in_process(&BrokerCore)` to `litebox_broker_local_userland`, composing the existing Linux Unix-socket/memfd and Windows named-pipe/shared-section transports with the reusable broker association runtime, authenticating the same-process peer, joining the broker host thread during association failure teardown, and covering concurrent requests and shutdown through the resulting production `BrokerConnection`.