### PR TITLE
Normalize Windows target cfg predicates

### DIFF
--- a/litebox/Cargo.toml
+++ b/litebox/Cargo.toml
@@ -21,7 +21,7 @@ litebox_broker_protocol = { version = "0.1.0", path = "../litebox_broker_protoco
 litebox_broker_transport = { version = "0.1.0", path = "../litebox_broker_transport" }
 litebox_platform = { version = "0.1.0", path = "../litebox_platform" }
 
-[target.'cfg(windows)'.dependencies]
+[target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { version = "0.60.2", features = [
     "Win32_Foundation",
     "Win32_System_Diagnostics_Debug",

--- a/litebox/src/mm/exception_table.rs
+++ b/litebox/src/mm/exception_table.rs
@@ -347,7 +347,7 @@ fn exception_table() -> &'static [ExceptionTableEntry] {
 ///
 /// However, Rust/LLVM inline asm (but not global asm) seems to drop the '$', so
 /// this doesn't work. So, we use a different technique.
-#[cfg(windows)]
+#[cfg(target_os = "windows")]
 #[expect(clippy::cast_ptr_alignment)]
 fn exception_table() -> &'static [ExceptionTableEntry] {
     use crate::utils::ReinterpretUnsignedExt as _;

--- a/litebox_broker_local_userland/Cargo.toml
+++ b/litebox_broker_local_userland/Cargo.toml
@@ -12,7 +12,7 @@ litebox_broker_transport = { path = "../litebox_broker_transport", version = "0.
 [target.'cfg(target_os = "linux")'.dependencies]
 litebox_broker_transport_linux_userland = { path = "../litebox_broker_transport_linux_userland", version = "0.1.0" }
 
-[target.'cfg(all(windows, target_arch = "x86_64"))'.dependencies]
+[target.'cfg(all(target_os = "windows", target_arch = "x86_64"))'.dependencies]
 litebox_broker_transport_windows_userland = { path = "../litebox_broker_transport_windows_userland", version = "0.1.0" }
 
 [lints]

--- a/litebox_broker_local_userland/src/lib.rs
+++ b/litebox_broker_local_userland/src/lib.rs
@@ -3,7 +3,10 @@
 
 //! Hosted userland bindings for the portable broker local endpoint.
 
-#![cfg(any(target_os = "linux", all(windows, target_arch = "x86_64")))]
+#![cfg(any(
+    target_os = "linux",
+    all(target_os = "windows", target_arch = "x86_64")
+))]
 
 #[cfg(target_os = "linux")]
 mod linux;
@@ -12,7 +15,7 @@ pub use linux::{
     BrokerAssociationFailureCoordinator, BrokerConnection, connect, start_notification_receiver,
 };
 
-#[cfg(all(windows, target_arch = "x86_64"))]
+#[cfg(all(target_os = "windows", target_arch = "x86_64"))]
 mod windows;
-#[cfg(all(windows, target_arch = "x86_64"))]
+#[cfg(all(target_os = "windows", target_arch = "x86_64"))]
 pub use windows::{BrokerConnection, connect, start_notification_receiver};

--- a/litebox_broker_transport_windows_userland/Cargo.toml
+++ b/litebox_broker_transport_windows_userland/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 litebox_broker_protocol = { path = "../litebox_broker_protocol", version = "0.1.0" }
 litebox_broker_transport = { path = "../litebox_broker_transport", version = "0.1.0" }
 
-[target.'cfg(windows)'.dependencies]
+[target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { version = "0.60.2", features = [
     "Win32_Foundation",
     "Win32_Security",

--- a/litebox_broker_transport_windows_userland/src/lib.rs
+++ b/litebox_broker_transport_windows_userland/src/lib.rs
@@ -6,7 +6,7 @@
 //! Portable protocol and control-ring state live in `litebox_broker_transport`.
 //! This crate supplies Windows file-mapping and IPC bindings for hosted deployments.
 
-#![cfg(all(windows, target_arch = "x86_64"))]
+#![cfg(all(target_os = "windows", target_arch = "x86_64"))]
 
 pub mod control_ring;
 mod host;

--- a/litebox_broker_userland/Cargo.toml
+++ b/litebox_broker_userland/Cargo.toml
@@ -17,7 +17,7 @@ litebox_broker_platform_linux_userland = { path = "../litebox_broker_platform_li
 litebox_broker_transport_linux_userland = { path = "../litebox_broker_transport_linux_userland", version = "0.1.0" }
 tempfile = { version = "3", default-features = false }
 
-[target.'cfg(all(windows, target_arch = "x86_64"))'.dependencies]
+[target.'cfg(all(target_os = "windows", target_arch = "x86_64"))'.dependencies]
 litebox_broker_transport_windows_userland = { path = "../litebox_broker_transport_windows_userland", version = "0.1.0" }
 
 [features]

--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -19,7 +19,7 @@ use litebox_broker_protocol::socket::{Ipv4Address, Port};
 
 #[cfg(target_os = "linux")]
 mod linux;
-#[cfg(all(windows, target_arch = "x86_64"))]
+#[cfg(all(target_os = "windows", target_arch = "x86_64"))]
 mod windows;
 
 const SETUP_TIMEOUT: Duration = Duration::from_secs(5);
@@ -185,12 +185,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     linux::run(CliArgs::parse())
 }
 
-#[cfg(all(windows, target_arch = "x86_64"))]
+#[cfg(all(target_os = "windows", target_arch = "x86_64"))]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     windows::run(CliArgs::parse())
 }
 
-#[cfg(not(any(target_os = "linux", all(windows, target_arch = "x86_64"))))]
+#[cfg(not(any(
+    target_os = "linux",
+    all(target_os = "windows", target_arch = "x86_64")
+)))]
 fn main() {}
 
 #[cfg(test)]

--- a/litebox_platform_windows_userland/Cargo.toml
+++ b/litebox_platform_windows_userland/Cargo.toml
@@ -3,7 +3,7 @@ name = "litebox_platform_windows_userland"
 version = "0.1.0"
 edition = "2024"
 
-[target.'cfg(windows)'.dependencies]
+[target.'cfg(target_os = "windows")'.dependencies]
 litebox = { path = "../litebox/", version = "0.1.0" }
 litebox_common_linux = { path = "../litebox_common_linux", version = "0.1.0" }
 litebox_platform = { path = "../litebox_platform", version = "0.1.0" }

--- a/litebox_syscall_rewriter/src/main.rs
+++ b/litebox_syscall_rewriter/src/main.rs
@@ -59,7 +59,7 @@ fn copy_file_permissions(
             input_file.metadata()?.mode(),
         ))?;
     }
-    #[cfg(windows)]
+    #[cfg(target_os = "windows")]
     {
         let input_metadata = input_file.metadata()?;
         let perms = input_metadata.permissions();


### PR DESCRIPTION
This PR replaces the remaining Windows cfg aliases with explicit `target_os = "windows"` predicates in Rust attributes and target-specific Cargo dependency sections while preserving the existing x86-64 restrictions.