### PR TITLE
Add in-process runner mode to the userland broker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1568,6 +1568,8 @@ dependencies = [
  "litebox_broker_transport_linux_userland",
  "litebox_broker_transport_windows_userland",
  "litebox_platform",
+ "litebox_runner_linux_userland",
+ "litebox_runner_windows_userland",
  "tempfile",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1568,6 +1568,7 @@ dependencies = [
  "litebox_broker_transport_linux_userland",
  "litebox_broker_transport_windows_userland",
  "litebox_platform",
+ "litebox_platform_linux_userland",
  "litebox_runner_linux_userland",
  "litebox_runner_windows_userland",
  "tempfile",

--- a/litebox_broker_transport_windows_userland/src/host.rs
+++ b/litebox_broker_transport_windows_userland/src/host.rs
@@ -26,6 +26,7 @@ use litebox_broker_transport::control_ring::{
 };
 use windows_sys::Win32::Foundation::HANDLE;
 use windows_sys::Win32::System::Pipes::GetNamedPipeClientProcessId;
+use windows_sys::Win32::System::Threading::GetCurrentProcess;
 
 use crate::control_ring::PipeLiveness;
 use crate::named_pipe::{TRANSFER_FRAME_TAG, WindowsNamedPipeStream};
@@ -107,6 +108,16 @@ impl WindowsNamedPipeHostSetupChannel {
             &encode_transfer(&transfer)?,
             self.setup_deadline,
         )
+    }
+
+    /// Duplicates one shared-memory object into this process and sends its handle values.
+    pub fn send_shared_memory_to_current_process(
+        &mut self,
+        memory: &WindowsSharedMemory,
+    ) -> IoResult<()> {
+        // SAFETY: GetCurrentProcess returns a pseudo-handle that remains valid
+        // for the lifetime of this process and must not be closed.
+        self.send_shared_memory(memory, unsafe { GetCurrentProcess() })
     }
 
     /// Activates host request, response, and notification control-ring endpoints.

--- a/litebox_broker_transport_windows_userland/src/named_pipe.rs
+++ b/litebox_broker_transport_windows_userland/src/named_pipe.rs
@@ -155,7 +155,7 @@ mod tests {
     };
     use litebox_broker_transport::control_ring::ControlRing;
     use litebox_broker_transport::shared_memory::SharedMemory as _;
-    use windows_sys::Win32::System::Threading::{GetCurrentProcess, GetCurrentProcessId};
+    use windows_sys::Win32::System::Threading::GetCurrentProcessId;
 
     const ACCEPT_RETRY_DELAY: Duration = Duration::from_millis(10);
 
@@ -298,8 +298,7 @@ mod tests {
             .unwrap();
             let memory = WindowsSharedMemory::create(4096).unwrap();
             memory.write(0, b"shared").unwrap();
-            host.send_shared_memory(&memory, unsafe { GetCurrentProcess() })
-                .unwrap();
+            host.send_shared_memory_to_current_process(&memory).unwrap();
         });
         let deadline = Instant::now() + Duration::from_secs(5);
         let mut local =

--- a/litebox_broker_userland/Cargo.toml
+++ b/litebox_broker_userland/Cargo.toml
@@ -15,16 +15,20 @@ litebox_platform = { path = "../litebox_platform", version = "0.1.0" }
 [target.'cfg(target_os = "linux")'.dependencies]
 litebox_broker_platform_linux_userland = { path = "../litebox_broker_platform_linux_userland", version = "0.1.0" }
 litebox_broker_transport_linux_userland = { path = "../litebox_broker_transport_linux_userland", version = "0.1.0" }
+litebox_runner_linux_userland = { path = "../litebox_runner_linux_userland", version = "0.1.0" }
 tempfile = { version = "3", default-features = false }
 
 [target.'cfg(all(windows, target_arch = "x86_64"))'.dependencies]
 litebox_broker_transport_windows_userland = { path = "../litebox_broker_transport_windows_userland", version = "0.1.0" }
+litebox_runner_windows_userland = { path = "../litebox_runner_windows_userland", version = "0.1.0" }
 
 [features]
 lock_tracing = [
     "litebox_platform/lock_tracing",
     "litebox_broker_platform_linux_userland/lock_tracing",
+    "litebox_runner_linux_userland/lock_tracing",
 ]
+aarch64_virtualize_x18 = ["litebox_runner_linux_userland/aarch64_virtualize_x18"]
 
 [[bin]]
 name = "litebox-broker-userland"

--- a/litebox_broker_userland/Cargo.toml
+++ b/litebox_broker_userland/Cargo.toml
@@ -28,7 +28,6 @@ lock_tracing = [
     "litebox_broker_platform_linux_userland/lock_tracing",
     "litebox_runner_linux_userland/lock_tracing",
 ]
-aarch64_virtualize_x18 = ["litebox_runner_linux_userland/aarch64_virtualize_x18"]
 
 [[bin]]
 name = "litebox-broker-userland"

--- a/litebox_broker_userland/Cargo.toml
+++ b/litebox_broker_userland/Cargo.toml
@@ -15,6 +15,7 @@ litebox_platform = { path = "../litebox_platform", version = "0.1.0" }
 [target.'cfg(target_os = "linux")'.dependencies]
 litebox_broker_platform_linux_userland = { path = "../litebox_broker_platform_linux_userland", version = "0.1.0" }
 litebox_broker_transport_linux_userland = { path = "../litebox_broker_transport_linux_userland", version = "0.1.0" }
+litebox_platform_linux_userland = { path = "../litebox_platform_linux_userland", version = "0.1.0" }
 litebox_runner_linux_userland = { path = "../litebox_runner_linux_userland", version = "0.1.0" }
 tempfile = { version = "3", default-features = false }
 

--- a/litebox_broker_userland/src/lib.rs
+++ b/litebox_broker_userland/src/lib.rs
@@ -9,11 +9,10 @@
 //! runtime that serves one association from setup through
 //! teardown ([`runtime`]), and threaded readiness publication
 //! ([`readiness`]). The `litebox-broker-userland` binary composes these with
-//! CLI parsing, launching and supervising the separate LiteBox runner process,
-//! and the platform-specific transport endpoints from
+//! CLI parsing, launching and supervising a separate or explicitly non-secure
+//! in-process LiteBox runner, and the platform-specific transport endpoints from
 //! `litebox_broker_transport_linux_userland` and
-//! `litebox_broker_transport_windows_userland`; an in-process caller can use
-//! the same builder and runtime directly instead.
+//! `litebox_broker_transport_windows_userland`.
 
 pub mod builder;
 pub mod readiness;

--- a/litebox_broker_userland/src/linux.rs
+++ b/litebox_broker_userland/src/linux.rs
@@ -47,12 +47,15 @@ pub(super) fn run(mut args: super::CliArgs) -> Result<(), Box<dyn Error>> {
     let control_socket_path = socket_dir.path().join("broker.sock");
     let control_listener = UnixListener::bind(&control_socket_path)?;
     control_listener.set_nonblocking(true)?;
-    let broker = BrokerCoreBuilder::new(
-        PolicyEngine::with_host_guaranteed_rights(ObjectRights::all()).with_socket_policy(
-            configured_socket_policy(&args.allow_tcp_destination, &args.allow_udp_destination)?,
-        ),
-    )
-    .build()?;
+    let policy = PolicyEngine::with_host_guaranteed_rights(ObjectRights::all()).with_socket_policy(
+        configured_socket_policy(&args.allow_tcp_destination, &args.allow_udp_destination)?,
+    );
+    let build_broker = || BrokerCoreBuilder::new(policy).build();
+    let broker = if args.in_process_runner {
+        litebox_platform_linux_userland::with_guest_signals_blocked(build_broker)?
+    } else {
+        build_broker()?
+    };
 
     if args.in_process_runner {
         debug_assert!(args.unstable);
@@ -187,13 +190,17 @@ fn run_runner_in_process(
             crate::runner_command_arguments(args, control_socket_path, proxy_url),
         ),
     )?;
-    let runner = std::thread::Builder::new()
-        .name("litebox-runner".to_owned())
-        .spawn(move || {
-            litebox_runner_linux_userland::run(runner_args).map_err(|error| format!("{error:#}"))
-        })?;
-    let association_result = serve_runner_in_process(broker, control_listener, &runner);
-    crate::finish_in_process_runner(runner, association_result)
+    litebox_platform_linux_userland::with_guest_signals_blocked(|| {
+        let runner = std::thread::Builder::new()
+            .name("litebox-runner".to_owned())
+            .spawn(move || {
+                litebox_platform_linux_userland::unblock_guest_signals();
+                litebox_runner_linux_userland::run(runner_args)
+                    .map_err(|error| format!("{error:#}"))
+            })?;
+        let association_result = serve_runner_in_process(broker, control_listener, &runner);
+        crate::finish_in_process_runner(runner, association_result)
+    })
 }
 
 fn serve_runner_process(

--- a/litebox_broker_userland/src/linux.rs
+++ b/litebox_broker_userland/src/linux.rs
@@ -2,13 +2,16 @@
 // Licensed under the MIT license.
 
 use std::error::Error;
+use std::ffi::OsString;
 use std::io::{BufRead, BufReader, Error as IoError, ErrorKind, Result as IoResult};
 use std::net::{Ipv4Addr, SocketAddrV4};
-use std::os::unix::net::UnixListener;
+use std::os::unix::net::{UnixListener, UnixStream};
 use std::process::{Child, ChildStdout, Command, Stdio};
 use std::sync::mpsc::{RecvTimeoutError, sync_channel};
+use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
+use clap::Parser as _;
 use litebox_broker_core::socket::HOST_GATEWAY_IPV4_ADDRESS;
 use litebox_broker_core::{BrokerCore, ObjectRights, PolicyEngine};
 use litebox_broker_protocol::shared_buffer::SHARED_BUFFER_POOL_SIZE;
@@ -51,14 +54,26 @@ pub(super) fn run(mut args: super::CliArgs) -> Result<(), Box<dyn Error>> {
     )
     .build()?;
 
-    crate::run_runner_process(
-        &args,
-        control_socket_path.as_os_str(),
-        proxy_url.as_deref(),
-        |runner, runner_process_id| {
-            serve_runner(&broker, &control_listener, runner, runner_process_id)
-        },
-    )
+    if args.in_process_runner {
+        debug_assert!(args.unstable);
+        run_runner_in_process(
+            &args,
+            control_socket_path.as_os_str(),
+            proxy_url.as_deref(),
+            &broker,
+            &control_listener,
+        )
+    } else {
+        crate::run_runner_process(
+            &args,
+            control_socket_path.as_os_str(),
+            proxy_url.as_deref(),
+            |runner, runner_process_id| {
+                serve_runner_process(&broker, &control_listener, runner, runner_process_id)?;
+                Ok(())
+            },
+        )
+    }
 }
 
 struct ManagedEgressProxy {
@@ -160,17 +175,69 @@ fn read_proxy_ready(stdout: ChildStdout) -> IoResult<SocketAddrV4> {
         .ok_or_else(|| IoError::new(ErrorKind::InvalidData, "invalid egress proxy readiness"))
 }
 
-fn serve_runner(
+fn run_runner_in_process(
+    args: &super::CliArgs,
+    control_socket_path: &std::ffi::OsStr,
+    proxy_url: Option<&str>,
+    broker: &BrokerCore,
+    control_listener: &UnixListener,
+) -> Result<(), Box<dyn Error>> {
+    let runner_args = litebox_runner_linux_userland::CliArgs::try_parse_from(
+        std::iter::once(OsString::from("litebox-runner-linux-userland")).chain(
+            crate::runner_command_arguments(args, control_socket_path, proxy_url),
+        ),
+    )?;
+    let runner = std::thread::Builder::new()
+        .name("litebox-runner".to_owned())
+        .spawn(move || {
+            litebox_runner_linux_userland::run(runner_args).map_err(|error| format!("{error:#}"))
+        })?;
+    let association_result = serve_runner_in_process(broker, control_listener, &runner);
+    crate::finish_in_process_runner(runner, association_result)
+}
+
+fn serve_runner_process(
     broker: &BrokerCore,
     control_listener: &UnixListener,
     runner: &mut Child,
     runner_process_id: u32,
-) -> Result<(), Box<dyn Error>> {
+) -> IoResult<()> {
     let setup_deadline = Instant::now() + SETUP_TIMEOUT;
-    let control_stream = crate::accept_runner_channel(runner, setup_deadline, "control", || {
-        control_listener.accept().map(|(stream, _)| stream)
-    })?;
+    let control_stream = crate::accept_runner_channel(
+        setup_deadline,
+        "control",
+        || {
+            runner
+                .try_wait()
+                .map(|status| status.map(|status| format!("exited with {status}")))
+        },
+        || control_listener.accept().map(|(stream, _)| stream),
+    )?;
     validate_peer_process(&control_stream, runner_process_id)?;
+    serve_control_stream(broker, control_stream, setup_deadline)
+}
+
+fn serve_runner_in_process(
+    broker: &BrokerCore,
+    control_listener: &UnixListener,
+    runner: &JoinHandle<super::InProcessRunnerResult>,
+) -> IoResult<()> {
+    let setup_deadline = Instant::now() + SETUP_TIMEOUT;
+    let control_stream = crate::accept_runner_channel(
+        setup_deadline,
+        "control",
+        || Ok(runner.is_finished().then(|| "thread stopped".to_owned())),
+        || control_listener.accept().map(|(stream, _)| stream),
+    )?;
+    validate_peer_process(&control_stream, std::process::id())?;
+    serve_control_stream(broker, control_stream, setup_deadline)
+}
+
+fn serve_control_stream(
+    broker: &BrokerCore,
+    control_stream: UnixStream,
+    setup_deadline: Instant,
+) -> IoResult<()> {
     let control_channel =
         UnixStreamHostSetupChannel::from_host_guaranteed(control_stream, setup_deadline);
     litebox_broker_userland::runtime::serve_association(
@@ -184,6 +251,5 @@ fn serve_runner(
             Ok(())
         },
         UnixStreamHostSetupChannel::into_active,
-    )?;
-    Ok(())
+    )
 }

--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -8,6 +8,7 @@ use std::net::Ipv4Addr;
 use std::path::PathBuf;
 use std::process::{Child, Command};
 use std::str::FromStr;
+use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
 use clap::Parser;
@@ -86,12 +87,45 @@ struct CliArgs {
     /// `0.0.0.0/0:1-65535` permits every nonzero IPv4 UDP destination.
     #[arg(long, value_name = "CIDR:PORT[-PORT]")]
     allow_udp_destination: Vec<AllowedDestination>,
+    /// Allow using unstable options.
+    #[arg(short = 'Z', long = "unstable")]
+    unstable: bool,
+    /// Run the host-native runner as a thread in this broker process.
+    ///
+    /// This mode does not provide a security boundary between the runner and
+    /// broker and is intended only for testing and development.
+    #[arg(long, hide = true, requires = "unstable", conflicts_with = "runner")]
+    in_process_runner: bool,
     /// Local runner executable to launch.
-    #[arg(long, value_name = "PATH", value_hint = clap::ValueHint::ExecutablePath)]
-    runner: PathBuf,
+    #[arg(
+        long,
+        value_name = "PATH",
+        value_hint = clap::ValueHint::ExecutablePath,
+        required_unless_present = "in_process_runner",
+        conflicts_with = "in_process_runner"
+    )]
+    runner: Option<PathBuf>,
     /// Arguments to pass to the local runner.
     #[arg(required = true, trailing_var_arg = true, allow_hyphen_values = true, value_hint = clap::ValueHint::CommandWithArguments)]
     runner_arguments: Vec<OsString>,
+}
+
+fn runner_command_arguments(
+    args: &CliArgs,
+    control_channel: &OsStr,
+    proxy_url: Option<&str>,
+) -> Vec<OsString> {
+    let mut runner_arguments = vec![
+        OsString::from("--unstable"),
+        OsString::from("--broker-control-channel"),
+        control_channel.to_os_string(),
+    ];
+    if let Some(proxy_url) = proxy_url {
+        runner_arguments.push(OsString::from("--broker-proxy-url"));
+        runner_arguments.push(OsString::from(proxy_url));
+    }
+    runner_arguments.extend(args.runner_arguments.iter().cloned());
+    runner_arguments
 }
 
 fn run_runner_process(
@@ -100,15 +134,15 @@ fn run_runner_process(
     proxy_url: Option<&str>,
     serve: impl FnOnce(&mut Child, u32) -> Result<(), Box<dyn Error>>,
 ) -> Result<(), Box<dyn Error>> {
-    let mut command = Command::new(&args.runner);
-    command
-        .arg("--unstable")
-        .arg("--broker-control-channel")
-        .arg(control_channel);
-    if let Some(proxy_url) = proxy_url {
-        command.arg("--broker-proxy-url").arg(proxy_url);
-    }
-    let mut runner = command.args(&args.runner_arguments).spawn()?;
+    let runner_path = args.runner.as_ref().ok_or_else(|| {
+        IoError::new(
+            ErrorKind::InvalidInput,
+            "--runner is required outside in-process mode",
+        )
+    })?;
+    let mut runner = Command::new(runner_path)
+        .args(runner_command_arguments(args, control_channel, proxy_url))
+        .spawn()?;
     let runner_process_id = runner.id();
     let association_result = serve(&mut runner, runner_process_id);
     if association_result.is_err() {
@@ -120,6 +154,46 @@ fn run_runner_process(
         return Err(IoError::other(format!("runner exited with {runner_status}")).into());
     }
     Ok(())
+}
+
+type InProcessRunnerResult = Result<i32, String>;
+
+fn finish_in_process_runner(
+    runner: JoinHandle<InProcessRunnerResult>,
+    association_result: IoResult<()>,
+) -> Result<(), Box<dyn Error>> {
+    if let Err(error) = &association_result
+        && !runner.is_finished()
+    {
+        return Err(
+            IoError::new(error.kind(), format!("broker association failed: {error}")).into(),
+        );
+    }
+
+    let runner_result = runner
+        .join()
+        .map_err(|_| IoError::other("in-process runner thread panicked"))?;
+    match (runner_result, association_result) {
+        (Ok(0), Ok(())) => Ok(()),
+        (Ok(exit_code), Ok(())) => Err(IoError::other(format!(
+            "in-process runner exited with status code {exit_code}"
+        ))
+        .into()),
+        (Err(runner_error), Ok(())) => {
+            Err(IoError::other(format!("in-process runner failed: {runner_error}")).into())
+        }
+        (Ok(0), Err(association_error)) => Err(association_error.into()),
+        (Ok(exit_code), Err(association_error)) => Err(IoError::other(format!(
+            "in-process runner exited with status code {exit_code}; \
+             broker association failed: {association_error}"
+        ))
+        .into()),
+        (Err(runner_error), Err(association_error)) => Err(IoError::other(format!(
+            "in-process runner failed: {runner_error}; \
+             broker association failed: {association_error}"
+        ))
+        .into()),
+    }
 }
 
 fn configured_socket_policy(
@@ -152,9 +226,9 @@ fn destination_rules(allowed_destinations: &[AllowedDestination]) -> Vec<Destina
 }
 
 fn accept_runner_channel<Channel>(
-    runner: &mut Child,
     deadline: Instant,
     channel_name: &'static str,
+    mut runner_status: impl FnMut() -> IoResult<Option<String>>,
     mut try_accept: impl FnMut() -> IoResult<Channel>,
 ) -> IoResult<Channel> {
     loop {
@@ -165,10 +239,10 @@ fn accept_runner_channel<Channel>(
                 format!("timed out waiting for runner {channel_name} channel"),
             ));
         }
-        if let Some(status) = runner.try_wait()? {
+        if let Some(status) = runner_status()? {
             return Err(IoError::new(
                 ErrorKind::BrokenPipe,
-                format!("runner exited with {status} before connecting its {channel_name} channel"),
+                format!("runner {status} before connecting its {channel_name} channel"),
             ));
         }
         match try_accept() {
@@ -213,6 +287,46 @@ mod cli_tests {
 
         assert_eq!(args.allow_tcp_destination.len(), 1);
         assert_eq!(args.allow_udp_destination.len(), 1);
+    }
+
+    #[test]
+    fn cli_accepts_unstable_in_process_runner() {
+        let args = CliArgs::try_parse_from([
+            "litebox-broker-userland",
+            "--unstable",
+            "--in-process-runner",
+            "guest",
+        ])
+        .unwrap();
+
+        assert!(args.unstable);
+        assert!(args.in_process_runner);
+        assert!(args.runner.is_none());
+    }
+
+    #[test]
+    fn cli_rejects_invalid_runner_modes() {
+        assert!(
+            CliArgs::try_parse_from(["litebox-broker-userland", "guest"]).is_err(),
+            "a separate-process runner path should be required"
+        );
+        assert!(
+            CliArgs::try_parse_from(["litebox-broker-userland", "--in-process-runner", "guest"])
+                .is_err(),
+            "in-process mode should require --unstable"
+        );
+        assert!(
+            CliArgs::try_parse_from([
+                "litebox-broker-userland",
+                "--unstable",
+                "--in-process-runner",
+                "--runner",
+                "runner",
+                "guest"
+            ])
+            .is_err(),
+            "in-process mode should conflict with --runner"
+        );
     }
 
     #[test]

--- a/litebox_broker_userland/src/main.rs
+++ b/litebox_broker_userland/src/main.rs
@@ -90,7 +90,7 @@ struct CliArgs {
     /// Allow using unstable options.
     #[arg(short = 'Z', long = "unstable")]
     unstable: bool,
-    /// Run the host-native runner as a thread in this broker process.
+    /// Run the runner library for this platform as a thread in this broker process.
     ///
     /// This mode does not provide a security boundary between the runner and
     /// broker and is intended only for testing and development.
@@ -287,46 +287,6 @@ mod cli_tests {
 
         assert_eq!(args.allow_tcp_destination.len(), 1);
         assert_eq!(args.allow_udp_destination.len(), 1);
-    }
-
-    #[test]
-    fn cli_accepts_unstable_in_process_runner() {
-        let args = CliArgs::try_parse_from([
-            "litebox-broker-userland",
-            "--unstable",
-            "--in-process-runner",
-            "guest",
-        ])
-        .unwrap();
-
-        assert!(args.unstable);
-        assert!(args.in_process_runner);
-        assert!(args.runner.is_none());
-    }
-
-    #[test]
-    fn cli_rejects_invalid_runner_modes() {
-        assert!(
-            CliArgs::try_parse_from(["litebox-broker-userland", "guest"]).is_err(),
-            "a separate-process runner path should be required"
-        );
-        assert!(
-            CliArgs::try_parse_from(["litebox-broker-userland", "--in-process-runner", "guest"])
-                .is_err(),
-            "in-process mode should require --unstable"
-        );
-        assert!(
-            CliArgs::try_parse_from([
-                "litebox-broker-userland",
-                "--unstable",
-                "--in-process-runner",
-                "--runner",
-                "runner",
-                "guest"
-            ])
-            .is_err(),
-            "in-process mode should conflict with --runner"
-        );
     }
 
     #[test]

--- a/litebox_broker_userland/src/windows.rs
+++ b/litebox_broker_userland/src/windows.rs
@@ -5,14 +5,18 @@
 
 use std::error::Error;
 use std::ffi::OsString;
+use std::io::Result as IoResult;
 use std::os::windows::io::AsRawHandle;
 use std::process::Child;
+use std::thread::JoinHandle;
 use std::time::Instant;
 
+use clap::Parser as _;
 use litebox_broker_core::{BrokerCore, ObjectRights, PolicyEngine};
 use litebox_broker_protocol::shared_buffer::SHARED_BUFFER_POOL_SIZE;
 use litebox_broker_transport_windows_userland::named_pipe::{
-    WindowsNamedPipeHostSetupChannel, WindowsNamedPipeListener, validate_client_process,
+    WindowsNamedPipeHostSetupChannel, WindowsNamedPipeListener, WindowsNamedPipeStream,
+    validate_client_process,
 };
 use litebox_broker_transport_windows_userland::shared_memory::WindowsSharedMemory;
 use litebox_broker_userland::builder::BrokerCoreBuilder;
@@ -29,37 +33,110 @@ pub(super) fn run(args: super::CliArgs) -> Result<(), Box<dyn Error>> {
     )
     .build()?;
 
-    crate::run_runner_process(&args, &control_pipe, None, |runner, runner_process_id| {
-        serve_runner(&broker, control_listener, runner, runner_process_id)
-    })
+    if args.in_process_runner {
+        debug_assert!(args.unstable);
+        run_runner_in_process(&args, &control_pipe, &broker, control_listener)
+    } else {
+        crate::run_runner_process(&args, &control_pipe, None, |runner, runner_process_id| {
+            serve_runner_process(&broker, control_listener, runner, runner_process_id)?;
+            Ok(())
+        })
+    }
 }
 
-fn serve_runner(
+fn run_runner_in_process(
+    args: &super::CliArgs,
+    control_pipe: &std::ffi::OsStr,
+    broker: &BrokerCore,
+    control_listener: WindowsNamedPipeListener,
+) -> Result<(), Box<dyn Error>> {
+    let runner_args = litebox_runner_windows_userland::CliArgs::try_parse_from(
+        std::iter::once(OsString::from("litebox-runner-windows-userland"))
+            .chain(crate::runner_command_arguments(args, control_pipe, None)),
+    )?;
+    let runner = std::thread::Builder::new()
+        .name("litebox-runner".to_owned())
+        .spawn(move || {
+            litebox_runner_windows_userland::run(runner_args).map_err(|error| format!("{error:#}"))
+        })?;
+    let association_result = serve_runner_in_process(broker, control_listener, &runner);
+    crate::finish_in_process_runner(runner, association_result)
+}
+
+fn serve_runner_process(
     broker: &BrokerCore,
     mut control_listener: WindowsNamedPipeListener,
     runner: &mut Child,
     runner_process_id: u32,
-) -> Result<(), Box<dyn Error>> {
+) -> IoResult<()> {
     let setup_deadline = Instant::now() + SETUP_TIMEOUT;
-    let control_stream = crate::accept_runner_channel(runner, setup_deadline, "control", || {
-        control_listener.try_accept()
-    })?;
+    let control_stream = crate::accept_runner_channel(
+        setup_deadline,
+        "control",
+        || {
+            runner
+                .try_wait()
+                .map(|status| status.map(|status| format!("exited with {status}")))
+        },
+        || control_listener.try_accept(),
+    )?;
     validate_client_process(&control_stream, runner_process_id)?;
+    let runner_process = runner.as_raw_handle();
+    serve_control_stream(
+        broker,
+        control_stream,
+        setup_deadline,
+        |channel, shared_memory, control_memory| {
+            channel.send_shared_memory(shared_memory, runner_process)?;
+            channel.send_shared_memory(control_memory, runner_process)
+        },
+    )
+}
+
+fn serve_runner_in_process(
+    broker: &BrokerCore,
+    mut control_listener: WindowsNamedPipeListener,
+    runner: &JoinHandle<super::InProcessRunnerResult>,
+) -> IoResult<()> {
+    let setup_deadline = Instant::now() + SETUP_TIMEOUT;
+    let control_stream = crate::accept_runner_channel(
+        setup_deadline,
+        "control",
+        || Ok(runner.is_finished().then(|| "thread stopped".to_owned())),
+        || control_listener.try_accept(),
+    )?;
+    validate_client_process(&control_stream, std::process::id())?;
+    serve_control_stream(
+        broker,
+        control_stream,
+        setup_deadline,
+        |channel, shared_memory, control_memory| {
+            channel.send_shared_memory_to_current_process(shared_memory)?;
+            channel.send_shared_memory_to_current_process(control_memory)
+        },
+    )
+}
+
+fn serve_control_stream(
+    broker: &BrokerCore,
+    control_stream: WindowsNamedPipeStream,
+    setup_deadline: Instant,
+    send_shared_memory: impl FnOnce(
+        &mut WindowsNamedPipeHostSetupChannel,
+        &WindowsSharedMemory,
+        &WindowsSharedMemory,
+    ) -> IoResult<()>,
+) -> IoResult<()> {
     let control_channel =
         WindowsNamedPipeHostSetupChannel::from_host_guaranteed(control_stream, setup_deadline);
-    let runner_process = runner.as_raw_handle();
     litebox_broker_userland::runtime::serve_association(
         broker,
         control_channel,
         || WindowsSharedMemory::create(SHARED_BUFFER_POOL_SIZE),
         WindowsSharedMemory::create_control_ring,
-        |channel, shared_memory, control_memory| {
-            channel.send_shared_memory(shared_memory, runner_process)?;
-            channel.send_shared_memory(control_memory, runner_process)
-        },
+        send_shared_memory,
         WindowsNamedPipeHostSetupChannel::into_active,
-    )?;
-    Ok(())
+    )
 }
 
 fn unique_control_pipe_name() -> OsString {

--- a/litebox_platform_linux_userland/src/lib.rs
+++ b/litebox_platform_linux_userland/src/lib.rs
@@ -924,18 +924,66 @@ unsafe extern "C" fn switch_to_guest(ctx: &litebox_common_linux::PtRegs) -> ! {
     );
 }
 
-/// Non-guest threads (e.g., network workers, background tasks) should call this
-/// function at the start of their execution so the kernel only delivers
-/// `SIGALRM` / `SIGINT` to guest threads, which have the proper signal-handler
-/// context to re-enter the shim.
-fn block_guest_signals() {
+fn guest_signal_set() -> libc::sigset_t {
     unsafe {
         let mut set: libc::sigset_t = std::mem::zeroed();
         libc::sigemptyset(&raw mut set);
         libc::sigaddset(&raw mut set, libc::SIGALRM);
         libc::sigaddset(&raw mut set, libc::SIGINT);
-        libc::pthread_sigmask(libc::SIG_BLOCK, &raw const set, std::ptr::null_mut());
+        set
     }
+}
+
+struct GuestSignalMaskGuard {
+    previous: libc::sigset_t,
+}
+
+impl Drop for GuestSignalMaskGuard {
+    fn drop(&mut self) {
+        // SAFETY: `previous` was populated by `pthread_sigmask` for this
+        // thread and remains valid for the lifetime of the guard.
+        let result = unsafe {
+            libc::pthread_sigmask(
+                libc::SIG_SETMASK,
+                &raw const self.previous,
+                std::ptr::null_mut(),
+            )
+        };
+        debug_assert_eq!(result, 0, "failed to restore the thread signal mask");
+    }
+}
+
+/// Runs `f` while blocking signals reserved for delivery to guest threads.
+///
+/// Threads spawned by `f` inherit the blocked mask. The calling thread's
+/// previous mask is restored when `f` returns or unwinds.
+///
+/// # Panics
+///
+/// Panics if the calling thread's signal mask cannot be changed.
+pub fn with_guest_signals_blocked<T>(f: impl FnOnce() -> T) -> T {
+    let set = guest_signal_set();
+    let mut previous = unsafe { std::mem::zeroed() };
+    // SAFETY: `set` and `previous` are valid signal sets owned by this thread.
+    let result =
+        unsafe { libc::pthread_sigmask(libc::SIG_BLOCK, &raw const set, &raw mut previous) };
+    assert_eq!(result, 0, "failed to block guest signals");
+    let _guard = GuestSignalMaskGuard { previous };
+    f()
+}
+
+/// Unblocks signals reserved for delivery to guest threads on the calling thread.
+///
+/// # Panics
+///
+/// Panics if the calling thread's signal mask cannot be changed.
+pub fn unblock_guest_signals() {
+    let set = guest_signal_set();
+    // SAFETY: `set` is a valid signal set and the null third argument means
+    // the previous mask is not requested.
+    let result =
+        unsafe { libc::pthread_sigmask(libc::SIG_UNBLOCK, &raw const set, std::ptr::null_mut()) };
+    assert_eq!(result, 0, "failed to unblock guest signals");
 }
 
 /// Spawn a non-guest ("host") thread that automatically blocks guest interrupt
@@ -958,10 +1006,7 @@ where
     F: FnOnce() -> T + Send + 'static,
     T: Send + 'static,
 {
-    std::thread::spawn(move || {
-        block_guest_signals();
-        f()
-    })
+    with_guest_signals_blocked(|| std::thread::spawn(f))
 }
 
 fn thread_start(

--- a/litebox_runner_linux_userland/src/lib.rs
+++ b/litebox_runner_linux_userland/src/lib.rs
@@ -25,7 +25,7 @@ const MANAGED_PROXY_ENV_KEYS: [&str; 5] = [
     "NO_PROXY",
 ];
 
-/// Run Linux programs with LiteBox on unmodified Linux
+/// Runs a Linux program with LiteBox on unmodified Linux and returns its exit code.
 ///
 /// Detailed logging can be controlled via the `LITEBOX_LOG` environment variable. For example:
 /// - `LITEBOX_LOG=debug` to show debug and higher level logs
@@ -131,7 +131,7 @@ fn mmapped_file(path: impl AsRef<Path>) -> Result<MmappedFile> {
 /// Can panic if any particulars of the environment are not set up as expected. Ideally, would not
 /// panic. If it does actually panic, then ping the authors of LiteBox, and likely a better error
 /// message could be thrown instead.
-pub fn run(cli_args: CliArgs) -> Result<()> {
+pub fn run(cli_args: CliArgs) -> Result<i32> {
     if cli_args.broker_proxy_url.is_some() && cli_args.broker_control_channel.is_none() {
         return Err(anyhow!(
             "--broker-proxy-url requires --broker-control-channel"
@@ -423,7 +423,7 @@ pub fn run(cli_args: CliArgs) -> Result<()> {
         }
     }
 
-    std::process::exit(program.process.wait())
+    Ok(program.process.wait())
 }
 
 fn apply_broker_proxy_environment(environment: &mut Vec<String>, proxy_url: Option<&str>) {

--- a/litebox_runner_linux_userland/src/lib.rs
+++ b/litebox_runner_linux_userland/src/lib.rs
@@ -165,7 +165,11 @@ pub fn run(cli_args: CliArgs) -> Result<i32> {
     }
 
     let broker_connection = match cli_args.broker_control_channel.as_deref() {
-        Some(control_socket_path) => Some(broker::connect(control_socket_path)?),
+        Some(control_socket_path) => {
+            Some(litebox_platform_linux_userland::with_guest_signals_blocked(
+                || broker::connect(control_socket_path),
+            )?)
+        }
         None => None,
     };
 
@@ -257,11 +261,13 @@ pub fn run(cli_args: CliArgs) -> Result<i32> {
         broker_shutdown_fds.push(shutdown_fd);
         let litebox = litebox::LiteBox::new_with_broker_local(platform, broker_local);
         broker_association_coordinator.install_dispatch(litebox.broker_failure_dispatcher());
-        broker::start_notification_receiver(
-            broker_notifications,
-            broker_association_coordinator,
-            litebox.broker_notification_dispatcher(),
-        )?;
+        litebox_platform_linux_userland::with_guest_signals_blocked(|| {
+            broker::start_notification_receiver(
+                broker_notifications,
+                broker_association_coordinator,
+                litebox.broker_notification_dispatcher(),
+            )
+        })?;
         litebox_shim_linux::LinuxShimBuilder::new_with_litebox(platform, litebox)
     } else {
         litebox_shim_linux::LinuxShimBuilder::new(platform)

--- a/litebox_runner_linux_userland/src/main.rs
+++ b/litebox_runner_linux_userland/src/main.rs
@@ -5,5 +5,6 @@ use clap::Parser as _;
 use litebox_runner_linux_userland::CliArgs;
 
 fn main() -> anyhow::Result<()> {
-    litebox_runner_linux_userland::run(CliArgs::parse())
+    let exit_code = litebox_runner_linux_userland::run(CliArgs::parse())?;
+    std::process::exit(exit_code)
 }

--- a/litebox_runner_linux_userland/tests/run.rs
+++ b/litebox_runner_linux_userland/tests/run.rs
@@ -128,7 +128,7 @@ struct Runner {
     #[cfg(target_os = "linux")]
     use_userland_broker: bool,
     #[cfg(target_os = "linux")]
-    in_process_broker: bool,
+    in_process_mode: bool,
     has_run: bool,
 }
 
@@ -190,7 +190,7 @@ impl Runner {
             #[cfg(target_os = "linux")]
             use_userland_broker: true,
             #[cfg(target_os = "linux")]
-            in_process_broker: false,
+            in_process_mode: false,
             has_run: false,
             unique_name: unique_name.to_owned(),
         }
@@ -238,10 +238,10 @@ impl Runner {
         self
     }
 
-    #[cfg(target_os = "linux")]
-    fn in_process_broker(&mut self) -> &mut Self {
+    #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+    fn use_in_process_runner(&mut self) -> &mut Self {
         self.use_userland_broker = true;
-        self.in_process_broker = true;
+        self.in_process_mode = true;
         self
     }
 
@@ -304,7 +304,7 @@ impl Runner {
             for host in &self.managed_proxy_hosts {
                 command.arg("--allow-host").arg(host);
             }
-            if self.in_process_broker {
+            if self.in_process_mode {
                 command.args(["--unstable", "--in-process-runner"]);
             } else {
                 command.arg("--runner").arg(runner);
@@ -792,7 +792,7 @@ fn brokered_getrandom() {
         false,
     );
     let mut runner = Runner::new(&target, "brokered_getrandom");
-    runner.in_process_broker();
+    runner.use_in_process_runner();
     runner.run();
 }
 

--- a/litebox_runner_linux_userland/tests/run.rs
+++ b/litebox_runner_linux_userland/tests/run.rs
@@ -127,6 +127,8 @@ struct Runner {
     managed_proxy_hosts: Vec<OsString>,
     #[cfg(target_os = "linux")]
     use_userland_broker: bool,
+    #[cfg(target_os = "linux")]
+    in_process_broker: bool,
     has_run: bool,
 }
 
@@ -187,6 +189,8 @@ impl Runner {
             managed_proxy_hosts: Vec::new(),
             #[cfg(target_os = "linux")]
             use_userland_broker: true,
+            #[cfg(target_os = "linux")]
+            in_process_broker: false,
             has_run: false,
             unique_name: unique_name.to_owned(),
         }
@@ -231,6 +235,13 @@ impl Runner {
         self.command
             .arg("--broker-control-channel")
             .arg(control_socket_path);
+        self
+    }
+
+    #[cfg(target_os = "linux")]
+    fn in_process_broker(&mut self) -> &mut Self {
+        self.use_userland_broker = true;
+        self.in_process_broker = true;
         self
     }
 
@@ -293,7 +304,12 @@ impl Runner {
             for host in &self.managed_proxy_hosts {
                 command.arg("--allow-host").arg(host);
             }
-            command.arg("--runner").arg(runner).args(runner_arguments);
+            if self.in_process_broker {
+                command.args(["--unstable", "--in-process-runner"]);
+            } else {
+                command.arg("--runner").arg(runner);
+            }
+            command.args(runner_arguments);
             self.command = command;
         }
     }
@@ -776,7 +792,7 @@ fn brokered_getrandom() {
         false,
     );
     let mut runner = Runner::new(&target, "brokered_getrandom");
-    runner.use_userland_broker = true;
+    runner.in_process_broker();
     runner.run();
 }
 

--- a/litebox_runner_windows_userland/src/lib.rs
+++ b/litebox_runner_windows_userland/src/lib.rs
@@ -31,7 +31,7 @@ fn mmapped_file(path: impl AsRef<Path>) -> Result<&'static [u8]> {
     Ok(data)
 }
 
-/// Run Windows PE programs with LiteBox on unmodified Windows.
+/// Runs a Windows PE program with LiteBox on unmodified Windows and returns its exit code.
 ///
 /// The program binary and any initial filesystem contents must be provided inside a tar archive via
 /// `--initial-files`. The program path refers to a path inside the tar archive.
@@ -71,7 +71,7 @@ pub struct CliArgs {
 ///
 /// Panics if the initial in-memory file system fails to create `/tmp` — those
 /// operations cannot fail against a freshly-constructed file system.
-pub fn run(cli_args: CliArgs) -> Result<()> {
+pub fn run(cli_args: CliArgs) -> Result<i32> {
     tracing_subscriber::fmt()
         .with_timer(tracing_subscriber::fmt::time::uptime())
         .with_level(true)
@@ -164,7 +164,7 @@ pub fn run(cli_args: CliArgs) -> Result<()> {
             &mut litebox_common_linux::PtRegs::default(),
         );
     }
-    std::process::exit(program.process.wait())
+    Ok(program.process.wait())
 }
 
 fn to_cstring(s: &str) -> Result<std::ffi::CString> {

--- a/litebox_runner_windows_userland/src/main.rs
+++ b/litebox_runner_windows_userland/src/main.rs
@@ -5,7 +5,8 @@
 fn main() -> anyhow::Result<()> {
     use clap::Parser as _;
     use litebox_runner_windows_userland::CliArgs;
-    litebox_runner_windows_userland::run(CliArgs::parse())
+    let exit_code = litebox_runner_windows_userland::run(CliArgs::parse())?;
+    std::process::exit(exit_code)
 }
 
 #[cfg(not(all(target_os = "windows", target_arch = "x86_64")))]

--- a/litebox_runner_windows_userland/tests/run.rs
+++ b/litebox_runner_windows_userland/tests/run.rs
@@ -20,32 +20,42 @@ fn run_hello_world_pe() {
         std::path::PathBuf::from(env!("CARGO_TARGET_TMPDIR")).join("kernel32_import.tar");
     create_tar_with_dir(&test_dir, &tar_path);
 
-    let mut command = brokered_windows_runner_command();
-    // Verbose log for failure triage; not load-bearing for any assertion.
-    command.env("LITEBOX_LOG", "debug");
-    command.args([
-        "--initial-files",
-        tar_path.to_str().unwrap(),
-        "/kernel32_import.exe",
-    ]);
-    println!("Running `{command:?}`");
-    let output = command
-        .output()
-        .expect("failed to run litebox_runner_windows_userland");
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
+    let (broker, runner) = build_windows_broker();
+    let mut separate_process = std::process::Command::new(&broker);
+    separate_process.arg("--runner").arg(runner);
+    let mut in_process = std::process::Command::new(broker);
+    in_process.args(["--unstable", "--in-process-runner"]);
 
-    assert!(
-        output.status.success(),
-        "runner failed to run kernel32-import PE; status {:?}\nstdout:\n{}\nstderr:\n{}",
-        output.status.code(),
-        stdout,
-        stderr
-    );
-    assert!(
-        stdout.contains("hello world\n"),
-        "guest output was not captured\nstdout:\n{stdout}\nstderr:\n{stderr}"
-    );
+    for (mode, mut command) in [
+        ("separate-process", separate_process),
+        ("in-process", in_process),
+    ] {
+        // Verbose log for failure triage; not load-bearing for any assertion.
+        command.env("LITEBOX_LOG", "debug");
+        command.args([
+            "--initial-files",
+            tar_path.to_str().unwrap(),
+            "/kernel32_import.exe",
+        ]);
+        println!("Running {mode} `{command:?}`");
+        let output = command
+            .output()
+            .expect("failed to run litebox_runner_windows_userland");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        assert!(
+            output.status.success(),
+            "{mode} runner failed to run kernel32-import PE; status {:?}\nstdout:\n{}\nstderr:\n{}",
+            output.status.code(),
+            stdout,
+            stderr
+        );
+        assert!(
+            stdout.contains("hello world\n"),
+            "{mode} guest output was not captured\nstdout:\n{stdout}\nstderr:\n{stderr}"
+        );
+    }
 }
 
 /// Runs a guest PE through the broker that creates and joins a child thread.


### PR DESCRIPTION
This PR adds a hidden `--in-process-runner` mode to the userland broker, gated by `--unstable`, that runs the Linux or Windows runner library in the broker process while reusing the existing Unix-socket or named-pipe transport, peer validation, shared-memory setup, control ring, and association runtime; runner libraries now return guest exit codes to their binary wrappers, and Linux guest-signal masking keeps broker threads from consuming guest-directed signals.