### PR TITLE
Wire broker file RPCs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1487,6 +1487,7 @@ dependencies = [
  "litebox_broker_core",
  "litebox_broker_protocol",
  "litebox_broker_transport",
+ "litebox_platform",
  "spin 0.9.8",
  "thiserror",
 ]

--- a/litebox_broker_host/Cargo.toml
+++ b/litebox_broker_host/Cargo.toml
@@ -11,5 +11,8 @@ litebox_broker_transport = { path = "../litebox_broker_transport", version = "0.
 spin = { version = "0.9.8", default-features = false, features = ["spin_mutex"] }
 thiserror = { version = "2.0.6", default-features = false }
 
+[dev-dependencies]
+litebox_platform = { path = "../litebox_platform", version = "0.1.0" }
+
 [lints]
 workspace = true

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -27,10 +27,17 @@ use litebox_broker_core::readiness::ReadinessSink;
 use litebox_broker_core::{BrokerCore, BrokerSession, CallerCredential};
 use litebox_broker_protocol::error::ErrorCode;
 use litebox_broker_protocol::event::{AddEventResponse, CreateEventResponse};
+use litebox_broker_protocol::fs::{
+    ChmodFileRequest, ChownFileRequest, DirectoryChunkError, FileError, HandleFileStatusRequest,
+    MAX_FILE_TRANSFER_SIZE, MkdirFileRequest, OpenFileRequest, OpenFileResponse,
+    PathFileStatusRequest, ReadDirectoryRequest, ReadDirectoryResponse, ReadFileRequest,
+    ReadFileResponse, RmdirFileRequest, SeekFileRequest, SeekFileResponse, TruncateFileRequest,
+    UnlinkFileRequest, WriteFileRequest, WriteFileResponse, encode_directory_entries_chunk,
+};
 use litebox_broker_protocol::message::{
     BrokerHandshakeResponse, BrokerOperation, BrokerRequest, BrokerResponse, BrokerResult,
-    EventRequest, EventResponse, PipeRequest, PipeResponse, SocketRequest, SocketResponse,
-    StdioRequest, StdioResponse,
+    EventRequest, EventResponse, FileRequest, FileResponse, PipeRequest, PipeResponse,
+    SocketRequest, SocketResponse, StdioRequest, StdioResponse,
 };
 use litebox_broker_protocol::pipe::{
     CreatePipeResponse, MAX_PIPE_TRANSFER_SIZE, ReadPipeResponse, WritePipeResponse,
@@ -111,13 +118,27 @@ impl<Memory: SharedMemory> BrokerHostAssociation<'_, Memory> {
             | BrokerOperation::Stdio(
                 StdioRequest::Read(ReadStdioRequest { buffer })
                 | StdioRequest::Write(WriteStdioRequest { buffer, .. }),
+            )
+            | BrokerOperation::File(
+                FileRequest::Open(OpenFileRequest { path: buffer, .. })
+                | FileRequest::Read(ReadFileRequest { buffer, .. })
+                | FileRequest::Write(WriteFileRequest { buffer, .. })
+                | FileRequest::ReadDirectory(ReadDirectoryRequest { buffer, .. })
+                | FileRequest::PathStatus(PathFileStatusRequest { path: buffer, .. })
+                | FileRequest::Chmod(ChmodFileRequest { path: buffer, .. })
+                | FileRequest::Chown(ChownFileRequest { path: buffer, .. })
+                | FileRequest::Unlink(UnlinkFileRequest { path: buffer, .. })
+                | FileRequest::Mkdir(MkdirFileRequest { path: buffer, .. })
+                | FileRequest::Rmdir(RmdirFileRequest { path: buffer, .. }),
             ) => Some(*buffer),
             BrokerOperation::CloseObject(_)
             | BrokerOperation::CheckReadiness(_)
             | BrokerOperation::Event(_)
-            | BrokerOperation::File(_)
             | BrokerOperation::Pipe(PipeRequest::Create(_))
             | BrokerOperation::Stdio(StdioRequest::IsTerminal(_))
+            | BrokerOperation::File(
+                FileRequest::Seek(_) | FileRequest::Truncate(_) | FileRequest::HandleStatus(_),
+            )
             | BrokerOperation::Socket(
                 SocketRequest::Create(_)
                 | SocketRequest::Connect(_)
@@ -385,8 +406,251 @@ fn handle_request<Memory: SharedMemory>(
         BrokerOperation::Stdio(request) => {
             handle_stdio_request(session, request, shared_buffers).map(BrokerResult::Stdio)
         }
-        BrokerOperation::File(_) => Err(RequestFailure::Respond(ErrorCode::UnsupportedOperation)),
+        BrokerOperation::File(request) => {
+            handle_file_request(session, request, shared_buffers).map(BrokerResult::File)
+        }
     }
+}
+
+fn handle_file_request<Memory: SharedMemory>(
+    session: &BrokerSession,
+    request: FileRequest,
+    shared_buffers: &SharedBufferPool<Memory>,
+) -> RequestResult<FileResponse> {
+    match request {
+        FileRequest::Open(OpenFileRequest {
+            path,
+            user,
+            access,
+            flags,
+            mode,
+        }) => {
+            let path = read_file_path(shared_buffers, path)?;
+            match litebox_broker_core::fs::open(session, &path, user, access, flags, mode)
+                .map_err(RequestFailure::from)?
+            {
+                Ok(handle) => Ok(FileResponse::Open(OpenFileResponse { handle })),
+                Err(error) => Ok(FileResponse::Failed(error)),
+            }
+        }
+        FileRequest::Read(ReadFileRequest {
+            handle,
+            buffer,
+            offset,
+        }) => {
+            validate_file_buffer(buffer)?;
+            let mut data = allocate_zeroed(buffer.length)?;
+            match litebox_broker_core::fs::read(session, handle, &mut data, offset)
+                .map_err(RequestFailure::from)?
+            {
+                Ok(read) => {
+                    shared_buffers
+                        .write(buffer.slot_index, &data[..read])
+                        .map_err(|_| RequestFailure::Abort(ErrorCode::Internal))?;
+                    Ok(FileResponse::Read(ReadFileResponse {
+                        read: u32::try_from(read)
+                            .expect("validated file read length must fit in u32"),
+                    }))
+                }
+                Err(error) => Ok(FileResponse::Failed(error)),
+            }
+        }
+        FileRequest::Write(WriteFileRequest {
+            handle,
+            buffer,
+            offset,
+        }) => {
+            let data = read_file_buffer(shared_buffers, buffer)?;
+            match litebox_broker_core::fs::write(session, handle, &data, offset)
+                .map_err(RequestFailure::from)?
+            {
+                Ok(written) => Ok(FileResponse::Write(WriteFileResponse {
+                    written: u32::try_from(written)
+                        .expect("validated file write length must fit in u32"),
+                })),
+                Err(error) => Ok(FileResponse::Failed(error)),
+            }
+        }
+        FileRequest::Seek(SeekFileRequest {
+            handle,
+            offset,
+            whence,
+        }) => match litebox_broker_core::fs::seek(session, handle, offset, whence)
+            .map_err(RequestFailure::from)?
+        {
+            Ok(offset) => Ok(FileResponse::Seek(SeekFileResponse { offset })),
+            Err(error) => Ok(FileResponse::Failed(error)),
+        },
+        FileRequest::Truncate(TruncateFileRequest {
+            handle,
+            length,
+            reset_offset,
+        }) => {
+            match litebox_broker_core::fs::truncate(session, handle, length, reset_offset)
+                .map_err(RequestFailure::from)?
+            {
+                Ok(()) => Ok(FileResponse::Truncate),
+                Err(error) => Ok(FileResponse::Failed(error)),
+            }
+        }
+        FileRequest::ReadDirectory(ReadDirectoryRequest {
+            handle,
+            buffer,
+            start_index,
+        }) => {
+            validate_file_buffer(buffer)?;
+            let entries = match litebox_broker_core::fs::read_directory(session, handle)
+                .map_err(RequestFailure::from)?
+            {
+                Ok(entries) => entries,
+                Err(error) => return Ok(FileResponse::Failed(error)),
+            };
+            let start_index = match usize::try_from(start_index) {
+                // Directory pages are fresh enumerations. If entries disappear
+                // between requests, a stale continuation beyond the new end is EOF.
+                Ok(start_index) => start_index.min(entries.len()),
+                Err(_) => return Ok(FileResponse::Failed(FileError::InvalidOffset)),
+            };
+            let (payload, next_index) =
+                match encode_directory_entries_chunk(&entries, start_index, buffer.length as usize)
+                {
+                    Ok(page) => page,
+                    Err(DirectoryChunkError::TooLarge) => {
+                        return Ok(FileResponse::Failed(FileError::Io));
+                    }
+                    Err(DirectoryChunkError::OutOfMemory) => {
+                        return Err(RequestFailure::Respond(ErrorCode::OutOfMemory));
+                    }
+                };
+            shared_buffers
+                .write(buffer.slot_index, &payload)
+                .map_err(|_| RequestFailure::Abort(ErrorCode::Internal))?;
+            Ok(FileResponse::ReadDirectory(ReadDirectoryResponse {
+                length: u32::try_from(payload.len())
+                    .expect("directory payload must fit its shared-buffer descriptor"),
+                next_index,
+            }))
+        }
+        FileRequest::PathStatus(PathFileStatusRequest { path, user }) => {
+            let path = read_file_path(shared_buffers, path)?;
+            Ok(
+                match litebox_broker_core::fs::path_status(session, &path, user)
+                    .map_err(RequestFailure::from)?
+                {
+                    Ok(status) => FileResponse::PathStatus(status),
+                    Err(error) => FileResponse::Failed(error),
+                },
+            )
+        }
+        FileRequest::HandleStatus(HandleFileStatusRequest { handle }) => {
+            match litebox_broker_core::fs::handle_status(session, handle)
+                .map_err(RequestFailure::from)?
+            {
+                Ok(status) => Ok(FileResponse::HandleStatus(status)),
+                Err(error) => Ok(FileResponse::Failed(error)),
+            }
+        }
+        FileRequest::Chmod(ChmodFileRequest { path, user, mode }) => {
+            let path = read_file_path(shared_buffers, path)?;
+            Ok(
+                match litebox_broker_core::fs::chmod(session, &path, user, mode)
+                    .map_err(RequestFailure::from)?
+                {
+                    Ok(()) => FileResponse::Chmod,
+                    Err(error) => FileResponse::Failed(error),
+                },
+            )
+        }
+        FileRequest::Chown(ChownFileRequest {
+            path,
+            acting_user,
+            user,
+            group,
+        }) => {
+            let path = read_file_path(shared_buffers, path)?;
+            Ok(
+                match litebox_broker_core::fs::chown(session, &path, acting_user, user, group)
+                    .map_err(RequestFailure::from)?
+                {
+                    Ok(()) => FileResponse::Chown,
+                    Err(error) => FileResponse::Failed(error),
+                },
+            )
+        }
+        FileRequest::Unlink(UnlinkFileRequest { path, user }) => {
+            let path = read_file_path(shared_buffers, path)?;
+            Ok(
+                match litebox_broker_core::fs::unlink(session, &path, user)
+                    .map_err(RequestFailure::from)?
+                {
+                    Ok(()) => FileResponse::Unlink,
+                    Err(error) => FileResponse::Failed(error),
+                },
+            )
+        }
+        FileRequest::Mkdir(MkdirFileRequest { path, user, mode }) => {
+            let path = read_file_path(shared_buffers, path)?;
+            Ok(
+                match litebox_broker_core::fs::mkdir(session, &path, user, mode)
+                    .map_err(RequestFailure::from)?
+                {
+                    Ok(()) => FileResponse::Mkdir,
+                    Err(error) => FileResponse::Failed(error),
+                },
+            )
+        }
+        FileRequest::Rmdir(RmdirFileRequest { path, user }) => {
+            let path = read_file_path(shared_buffers, path)?;
+            Ok(
+                match litebox_broker_core::fs::rmdir(session, &path, user)
+                    .map_err(RequestFailure::from)?
+                {
+                    Ok(()) => FileResponse::Rmdir,
+                    Err(error) => FileResponse::Failed(error),
+                },
+            )
+        }
+    }
+}
+
+fn validate_file_buffer(buffer: SharedBufferDescriptor) -> RequestResult<()> {
+    if buffer.length > MAX_FILE_TRANSFER_SIZE {
+        return Err(RequestFailure::Abort(ErrorCode::MalformedRequest));
+    }
+    Ok(())
+}
+
+fn allocate_zeroed(length: u32) -> RequestResult<Vec<u8>> {
+    let mut data = Vec::new();
+    data.try_reserve_exact(length as usize)
+        .map_err(|_| RequestFailure::Respond(ErrorCode::OutOfMemory))?;
+    data.resize(length as usize, 0);
+    Ok(data)
+}
+
+fn read_file_buffer<Memory: SharedMemory>(
+    shared_buffers: &SharedBufferPool<Memory>,
+    buffer: SharedBufferDescriptor,
+) -> RequestResult<Vec<u8>> {
+    validate_file_buffer(buffer)?;
+    let mut data = allocate_zeroed(buffer.length)?;
+    shared_buffers
+        .read(buffer.slot_index, &mut data)
+        .map_err(|_| RequestFailure::Abort(ErrorCode::Internal))?;
+    Ok(data)
+}
+
+fn read_file_path<Memory: SharedMemory>(
+    shared_buffers: &SharedBufferPool<Memory>,
+    buffer: SharedBufferDescriptor,
+) -> RequestResult<alloc::string::String> {
+    let data = read_file_buffer(shared_buffers, buffer)?;
+    let path = alloc::string::String::from_utf8(data)
+        .map_err(|_| RequestFailure::Abort(ErrorCode::MalformedRequest))?;
+    if !path.starts_with('/') {
+        return Err(RequestFailure::Abort(ErrorCode::MalformedRequest));
+    }
+    Ok(path)
 }
 
 fn handle_stdio_request<Memory: SharedMemory>(
@@ -778,6 +1042,7 @@ mod tests {
     use super::*;
     use core::cell::Cell;
     use core::net::{Ipv4Addr, SocketAddrV4};
+    use core::sync::atomic::{AtomicU32, Ordering};
     use litebox_broker_core::random::{RandomProvider, RandomProviderError};
     use litebox_broker_core::readiness::ReadinessRegistration;
     use litebox_broker_core::socket::{
@@ -790,6 +1055,11 @@ mod tests {
     };
     use litebox_broker_protocol::event::{
         AddEventRequest, ConsumeEventRequest, CreateEventRequest, EventConsumeMode,
+    };
+    use litebox_broker_protocol::fs::{
+        FileAccessMode, FileMode, FileOpenFlags, FileSeekWhence, FileType, FileUser,
+        OpenFileRequest, ReadDirectoryRequest, ReadFileRequest, SeekFileRequest, WriteFileRequest,
+        decode_directory_entries,
     };
     use litebox_broker_protocol::message::BrokerHandshakeRequest;
     use litebox_broker_protocol::pipe::{CreatePipeRequest, ReadPipeRequest, WritePipeRequest};
@@ -809,9 +1079,78 @@ mod tests {
     use litebox_broker_protocol::stdio::{StdioOutputStream, StdioStream};
     use litebox_broker_protocol::{ObjectHandle, ProtocolVersion, RequestId};
     use litebox_broker_transport::shared_memory::{SharedBufferPool, SharedMemoryError};
+    use litebox_platform::sync::{
+        ImmediatelyWokenUp, RawMutex, RawMutexProvider, UnblockedOrTimedOut,
+    };
     use std::collections::VecDeque;
     use std::sync::{Arc, Condvar, Mutex, mpsc};
     use std::time::Duration;
+
+    const ROOT: FileUser = FileUser { user: 0, group: 0 };
+
+    struct TestRawMutex {
+        state: AtomicU32,
+        waiters: Mutex<()>,
+        wake: Condvar,
+    }
+
+    impl RawMutex for TestRawMutex {
+        const INIT: Self = Self {
+            state: AtomicU32::new(0),
+            waiters: Mutex::new(()),
+            wake: Condvar::new(),
+        };
+
+        fn underlying_atomic(&self) -> &AtomicU32 {
+            &self.state
+        }
+
+        fn wake_many(&self, count: usize) -> usize {
+            let _waiters = self.waiters.lock().unwrap();
+            self.wake.notify_all();
+            count
+        }
+
+        fn block(&self, expected: u32) -> core::result::Result<(), ImmediatelyWokenUp> {
+            let waiters = self.waiters.lock().unwrap();
+            if self.state.load(Ordering::Acquire) != expected {
+                return Err(ImmediatelyWokenUp);
+            }
+            let _waiters = self
+                .wake
+                .wait_while(waiters, |()| self.state.load(Ordering::Acquire) == expected)
+                .unwrap();
+            Ok(())
+        }
+
+        fn block_or_timeout(
+            &self,
+            expected: u32,
+            timeout: Duration,
+        ) -> core::result::Result<UnblockedOrTimedOut, ImmediatelyWokenUp> {
+            let waiters = self.waiters.lock().unwrap();
+            if self.state.load(Ordering::Acquire) != expected {
+                return Err(ImmediatelyWokenUp);
+            }
+            let (_waiters, result) = self
+                .wake
+                .wait_timeout_while(waiters, timeout, |()| {
+                    self.state.load(Ordering::Acquire) == expected
+                })
+                .unwrap();
+            Ok(if result.timed_out() {
+                UnblockedOrTimedOut::TimedOut
+            } else {
+                UnblockedOrTimedOut::Unblocked
+            })
+        }
+    }
+
+    struct TestSync;
+
+    impl RawMutexProvider for TestSync {
+        type RawMutex = TestRawMutex;
+    }
 
     struct TestReadinessSink;
 
@@ -1067,13 +1406,16 @@ mod tests {
     #[test]
     fn host_request_handling_uses_one_broker_core() {
         let stdio_provider = Arc::new(TestStdioProvider::default());
+        let fs = litebox_broker_core::fs::in_mem::InMem::<TestSync>::new(
+            litebox_broker_core::fs::inode_allocator::InodeAllocator::standalone(),
+        );
         let broker = BrokerCore::new(
             PolicyEngine::with_unauthenticated_rights(ObjectRights::all())
                 .with_socket_policy(SocketPolicy::guest_network()),
             Arc::new(TestSocketProvider),
             Arc::new(TestRandomProvider),
             Arc::clone(&stdio_provider) as Arc<dyn StdioProvider>,
-            Arc::new(litebox_broker_core::fs::UnsupportedFileService),
+            Arc::new(litebox_broker_core::fs::resolver::Resolver::<TestSync, _>::new(fs)),
         )
         .unwrap();
 
@@ -1093,10 +1435,123 @@ mod tests {
         association_shared_buffer_descriptors_stage_socket_data(&broker);
         association_shared_buffer_descriptor_stages_random_data(&broker);
         association_shared_buffer_descriptor_stages_stdio_data(&broker, &stdio_provider);
+        association_shared_buffer_descriptors_stage_file_data(&broker);
         shared_buffer_usage_rejects_invalid_descriptors();
         association_executes_distinct_slots_concurrently(&broker);
         association_allows_slot_reuse_during_response_emission(&broker);
         association_allows_out_of_order_responses(&broker);
+    }
+
+    fn association_shared_buffer_descriptors_stage_file_data(broker: &BrokerCore) {
+        let session = broker
+            .create_session(CallerCredential::Unauthenticated)
+            .unwrap();
+        let shared_buffers = test_shared_buffers();
+        shared_buffers
+            .write(SharedBufferSlotIndex(0), b"/file")
+            .unwrap();
+        let opened = handle_test_request_with_buffers(
+            &session,
+            BrokerOperation::File(FileRequest::Open(OpenFileRequest {
+                path: descriptor(0, 5),
+                user: ROOT,
+                access: FileAccessMode::ReadWrite,
+                flags: FileOpenFlags::CREATE,
+                mode: FileMode::from_bits(0o600).unwrap(),
+            })),
+            &shared_buffers,
+        );
+        let BrokerResult::File(FileResponse::Open(opened)) = opened else {
+            panic!("expected successful file open");
+        };
+
+        shared_buffers
+            .write(SharedBufferSlotIndex(1), b"abc")
+            .unwrap();
+        assert_eq!(
+            handle_test_request_with_buffers(
+                &session,
+                BrokerOperation::File(FileRequest::Write(WriteFileRequest {
+                    handle: opened.handle,
+                    buffer: descriptor(1, 3),
+                    offset: None,
+                })),
+                &shared_buffers,
+            ),
+            BrokerResult::File(FileResponse::Write(WriteFileResponse { written: 3 }))
+        );
+        assert_eq!(
+            handle_test_request_with_buffers(
+                &session,
+                BrokerOperation::File(FileRequest::Seek(SeekFileRequest {
+                    handle: opened.handle,
+                    offset: 0,
+                    whence: FileSeekWhence::Beginning,
+                })),
+                &shared_buffers,
+            ),
+            BrokerResult::File(FileResponse::Seek(SeekFileResponse { offset: 0 }))
+        );
+        assert_eq!(
+            handle_test_request_with_buffers(
+                &session,
+                BrokerOperation::File(FileRequest::Read(ReadFileRequest {
+                    handle: opened.handle,
+                    buffer: descriptor(2, 3),
+                    offset: None,
+                })),
+                &shared_buffers,
+            ),
+            BrokerResult::File(FileResponse::Read(ReadFileResponse { read: 3 }))
+        );
+        let mut data = [0; 3];
+        shared_buffers
+            .read(SharedBufferSlotIndex(2), &mut data)
+            .unwrap();
+        assert_eq!(data, *b"abc");
+
+        shared_buffers
+            .write(SharedBufferSlotIndex(3), b"/")
+            .unwrap();
+        let directory = handle_test_request_with_buffers(
+            &session,
+            BrokerOperation::File(FileRequest::Open(OpenFileRequest {
+                path: descriptor(3, 1),
+                user: ROOT,
+                access: FileAccessMode::ReadOnly,
+                flags: FileOpenFlags::DIRECTORY,
+                mode: FileMode::default(),
+            })),
+            &shared_buffers,
+        );
+        let BrokerResult::File(FileResponse::Open(directory)) = directory else {
+            panic!("expected successful directory open");
+        };
+        let response = handle_test_request_with_buffers(
+            &session,
+            BrokerOperation::File(FileRequest::ReadDirectory(ReadDirectoryRequest {
+                handle: directory.handle,
+                buffer: descriptor(4, 64),
+                start_index: 0,
+            })),
+            &shared_buffers,
+        );
+        let BrokerResult::File(FileResponse::ReadDirectory(response)) = response else {
+            panic!("expected successful directory read");
+        };
+        let mut payload = std::vec![0; response.length as usize];
+        shared_buffers
+            .read(SharedBufferSlotIndex(4), &mut payload)
+            .unwrap();
+        let entries = decode_directory_entries(&payload).unwrap();
+        assert!(
+            entries
+                .iter()
+                .any(|entry| entry.name == "file" && entry.file_type == FileType::RegularFile)
+        );
+
+        session.close_object_reference(opened.handle).unwrap();
+        session.close_object_reference(directory.handle).unwrap();
     }
 
     fn association_shared_buffer_descriptor_stages_random_data(broker: &BrokerCore) {

--- a/litebox_broker_host/src/lib.rs
+++ b/litebox_broker_host/src/lib.rs
@@ -28,11 +28,12 @@ use litebox_broker_core::{BrokerCore, BrokerSession, CallerCredential};
 use litebox_broker_protocol::error::ErrorCode;
 use litebox_broker_protocol::event::{AddEventResponse, CreateEventResponse};
 use litebox_broker_protocol::fs::{
-    ChmodFileRequest, ChownFileRequest, DirectoryChunkError, FileError, HandleFileStatusRequest,
-    MAX_FILE_TRANSFER_SIZE, MkdirFileRequest, OpenFileRequest, OpenFileResponse,
-    PathFileStatusRequest, ReadDirectoryRequest, ReadDirectoryResponse, ReadFileRequest,
-    ReadFileResponse, RmdirFileRequest, SeekFileRequest, SeekFileResponse, TruncateFileRequest,
-    UnlinkFileRequest, WriteFileRequest, WriteFileResponse, encode_directory_entries_chunk,
+    ChmodFileRequest, ChownFileRequest, DirectoryPayloadError, DirectoryTransferError, FileError,
+    HandleFileStatusRequest, MAX_FILE_TRANSFER_SIZE, MkdirFileRequest, OpenFileRequest,
+    OpenFileResponse, PathFileStatusRequest, ReadDirectoryRequest, ReadDirectoryResponse,
+    ReadFileRequest, ReadFileResponse, RmdirFileRequest, SeekFileRequest, SeekFileResponse,
+    TruncateFileRequest, UnlinkFileRequest, WriteFileRequest, WriteFileResponse,
+    encode_directory_entries_chunk,
 };
 use litebox_broker_protocol::message::{
     BrokerHandshakeResponse, BrokerOperation, BrokerRequest, BrokerResponse, BrokerResult,
@@ -515,11 +516,15 @@ fn handle_file_request<Memory: SharedMemory>(
                 match encode_directory_entries_chunk(&entries, start_index, buffer.length as usize)
                 {
                     Ok(page) => page,
-                    Err(DirectoryChunkError::TooLarge) => {
-                        return Ok(FileResponse::Failed(FileError::Io));
-                    }
-                    Err(DirectoryChunkError::OutOfMemory) => {
+                    Err(DirectoryTransferError::Payload(
+                        DirectoryPayloadError::Malformed | DirectoryPayloadError::TooLarge,
+                    )) => return Ok(FileResponse::Failed(FileError::Io)),
+                    Err(DirectoryTransferError::OutOfMemory) => {
                         return Err(RequestFailure::Respond(ErrorCode::OutOfMemory));
+                    }
+                    Err(error) => {
+                        let _ = error;
+                        return Err(RequestFailure::Abort(ErrorCode::Internal));
                     }
                 };
             shared_buffers

--- a/litebox_broker_local/src/fs.rs
+++ b/litebox_broker_local/src/fs.rs
@@ -1,0 +1,699 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+use alloc::vec::Vec;
+
+use litebox_broker_protocol::ObjectHandle;
+use litebox_broker_protocol::error::ErrorCode;
+use litebox_broker_protocol::fs::{
+    ChmodFileRequest, ChownFileRequest, DirectoryPayloadError, FileAccessMode, FileDirectoryEntry,
+    FileError, FileMode, FileOpenFlags, FileSeekWhence, FileStatus, FileUser,
+    HandleFileStatusRequest, MAX_FILE_TRANSFER_SIZE, MkdirFileRequest, OpenFileRequest,
+    PathFileStatusRequest, ReadDirectoryRequest, ReadFileRequest, RmdirFileRequest,
+    SeekFileRequest, TruncateFileRequest, UnlinkFileRequest, WriteFileRequest,
+    decode_directory_entries,
+};
+use litebox_broker_protocol::message::{BrokerOperation, BrokerResult, FileRequest, FileResponse};
+use litebox_broker_protocol::shared_buffer::SharedBufferDescriptor;
+use litebox_broker_transport::channel::LocalCallChannel;
+
+use crate::{BrokerLocal, BrokerLocalError, Result};
+
+type FileOperationResult<T> = core::result::Result<T, FileError>;
+type DirectoryReadResult = FileOperationResult<(Vec<FileDirectoryEntry>, Option<u64>)>;
+
+impl<Channel: LocalCallChannel> BrokerLocal<Channel> {
+    /// Opens an absolute fs path.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the buffer descriptor is inconsistent or the broker returns
+    /// a response for another file operation.
+    pub fn open_file(
+        &self,
+        path_buffer: SharedBufferDescriptor,
+        path: &str,
+        user: FileUser,
+        access: FileAccessMode,
+        flags: FileOpenFlags,
+        mode: FileMode,
+    ) -> Result<FileOperationResult<ObjectHandle>, Channel::Error> {
+        self.write_file_buffer(path_buffer, path.as_bytes())?;
+        match self.request_file(FileRequest::Open(OpenFileRequest {
+            path: path_buffer,
+            user,
+            access,
+            flags,
+            mode,
+        }))? {
+            FileResponse::Open(response) => Ok(Ok(response.handle)),
+            FileResponse::Failed(error) => Ok(Err(error)),
+            response => panic!("broker returned unexpected file open response: {response:?}"),
+        }
+    }
+}
+
+#[cfg(test)]
+#[expect(
+    clippy::items_after_test_module,
+    reason = "the test module must access private adapter state while the production methods stay grouped"
+)]
+mod tests {
+    use super::*;
+    use alloc::sync::Arc;
+    use core::{cell::RefCell, convert::Infallible};
+    use litebox_broker_protocol::BROKER_PROTOCOL_VERSION;
+    use litebox_broker_protocol::fs::{
+        FileNodeInfo, FileType, OpenFileResponse, ReadDirectoryResponse, ReadFileResponse,
+        SeekFileResponse, WriteFileResponse, encode_directory_entries,
+    };
+    use litebox_broker_protocol::message::{
+        BrokerHandshakeRequest, BrokerHandshakeResponse, BrokerRequest, BrokerResponse,
+    };
+    use litebox_broker_protocol::shared_buffer::{
+        SHARED_BUFFER_POOL_SIZE, SHARED_BUFFER_SLOT_SIZE, SharedBufferSlotIndex,
+    };
+    use litebox_broker_transport::channel::LocalSetupChannel;
+    use litebox_broker_transport::shared_memory::{SharedMemory, SharedMemoryError};
+    use std::collections::VecDeque;
+    use std::sync::Mutex;
+
+    const ROOT: FileUser = FileUser { user: 0, group: 0 };
+
+    #[test]
+    fn file_calls_stage_shared_data_and_preserve_file_errors() {
+        let handle = ObjectHandle(7);
+        let status = FileStatus {
+            file_type: FileType::RegularFile,
+            mode: FileMode::from_bits(0o600).unwrap(),
+            size: 3,
+            owner: ROOT,
+            node_info: FileNodeInfo {
+                dev: 1,
+                ino: 2,
+                rdev: None,
+            },
+            block_size: 4096,
+        };
+        let entries = [FileDirectoryEntry {
+            name: "file".into(),
+            file_type: FileType::RegularFile,
+            node_info: None,
+        }];
+        let directory_payload = encode_directory_entries(&entries).unwrap();
+        let channel = ScriptedChannel::new([
+            BrokerResult::File(FileResponse::Open(OpenFileResponse { handle })),
+            BrokerResult::File(FileResponse::Write(WriteFileResponse { written: 3 })),
+            BrokerResult::File(FileResponse::Read(ReadFileResponse { read: 2 })),
+            BrokerResult::File(FileResponse::Seek(SeekFileResponse { offset: 0 })),
+            BrokerResult::File(FileResponse::PathStatus(status)),
+            BrokerResult::File(FileResponse::ReadDirectory(ReadDirectoryResponse {
+                length: u32::try_from(directory_payload.len()).unwrap(),
+                next_index: None,
+            })),
+            BrokerResult::File(FileResponse::Failed(FileError::NotForReading)),
+        ]);
+        let memory = Arc::new(TestSharedMemory::new(SHARED_BUFFER_POOL_SIZE));
+        memory
+            .write(2 * SHARED_BUFFER_SLOT_SIZE as usize, &[4, 5])
+            .unwrap();
+        memory
+            .write(4 * SHARED_BUFFER_SLOT_SIZE as usize, &directory_payload)
+            .unwrap();
+        let (local, ()) =
+            BrokerLocal::negotiate(channel, |channel| Ok((channel, memory.clone(), ()))).unwrap();
+
+        assert_eq!(
+            local
+                .open_file(
+                    descriptor(0, 5),
+                    "/file",
+                    ROOT,
+                    FileAccessMode::ReadWrite,
+                    FileOpenFlags::CREATE,
+                    FileMode::from_bits(0o600).unwrap(),
+                )
+                .unwrap(),
+            Ok(handle)
+        );
+        assert_eq!(
+            local
+                .write_file(handle, descriptor(1, 3), b"abc", None)
+                .unwrap(),
+            Ok(3)
+        );
+        let mut staged = [0; 3];
+        memory
+            .read(SHARED_BUFFER_SLOT_SIZE as usize, &mut staged)
+            .unwrap();
+        assert_eq!(staged, *b"abc");
+
+        let mut output = [0; 2];
+        assert_eq!(
+            local
+                .read_file(handle, descriptor(2, 2), &mut output, Some(1))
+                .unwrap(),
+            Ok(2)
+        );
+        assert_eq!(output, [4, 5]);
+        assert_eq!(
+            local
+                .seek_file(handle, 0, FileSeekWhence::Beginning)
+                .unwrap(),
+            Ok(0)
+        );
+        assert_eq!(
+            local
+                .path_file_status(descriptor(3, 5), "/file", ROOT)
+                .unwrap(),
+            Ok(status)
+        );
+        assert_eq!(
+            local
+                .read_directory(
+                    handle,
+                    descriptor(4, u32::try_from(directory_payload.len()).unwrap()),
+                    0,
+                )
+                .unwrap(),
+            Ok((entries.into(), None))
+        );
+        assert_eq!(
+            local.handle_file_status(handle).unwrap(),
+            Err(FileError::NotForReading)
+        );
+
+        assert!(matches!(
+            local.channel.sent_operations.borrow().as_slice(),
+            [
+                BrokerOperation::File(FileRequest::Open(_)),
+                BrokerOperation::File(FileRequest::Write(_)),
+                BrokerOperation::File(FileRequest::Read(_)),
+                BrokerOperation::File(FileRequest::Seek(_)),
+                BrokerOperation::File(FileRequest::PathStatus(_)),
+                BrokerOperation::File(FileRequest::ReadDirectory(_)),
+                BrokerOperation::File(FileRequest::HandleStatus(_)),
+            ]
+        ));
+    }
+
+    #[test]
+    fn file_calls_reject_oversized_transfers_before_request() {
+        let channel = ScriptedChannel::new([]);
+        let memory = Arc::new(TestSharedMemory::new(SHARED_BUFFER_POOL_SIZE));
+        let (local, ()) =
+            BrokerLocal::negotiate(channel, |channel| Ok((channel, memory, ()))).unwrap();
+        let oversized = descriptor(0, MAX_FILE_TRANSFER_SIZE + 1);
+
+        assert!(matches!(
+            local.read_file(ObjectHandle(1), oversized, &mut [], None),
+            Err(BrokerLocalError::Broker(ErrorCode::ResourceExhausted))
+        ));
+        assert!(matches!(
+            local.write_file(ObjectHandle(1), oversized, &[], None),
+            Err(BrokerLocalError::Broker(ErrorCode::ResourceExhausted))
+        ));
+        assert!(local.channel.sent_operations.borrow().is_empty());
+    }
+
+    const fn descriptor(slot: u32, length: u32) -> SharedBufferDescriptor {
+        SharedBufferDescriptor {
+            slot_index: SharedBufferSlotIndex(slot),
+            length,
+        }
+    }
+
+    #[derive(Clone)]
+    struct TestSharedMemory(Arc<Mutex<std::vec::Vec<u8>>>);
+
+    impl TestSharedMemory {
+        fn new(length: usize) -> Self {
+            Self(Arc::new(Mutex::new(std::vec![0; length])))
+        }
+    }
+
+    impl SharedMemory for TestSharedMemory {
+        fn len(&self) -> usize {
+            self.0.lock().unwrap().len()
+        }
+
+        fn read(
+            &self,
+            offset: usize,
+            destination: &mut [u8],
+        ) -> core::result::Result<(), SharedMemoryError> {
+            let memory = self.0.lock().unwrap();
+            let end = offset
+                .checked_add(destination.len())
+                .ok_or(SharedMemoryError::InvalidRange)?;
+            destination.copy_from_slice(
+                memory
+                    .get(offset..end)
+                    .ok_or(SharedMemoryError::InvalidRange)?,
+            );
+            Ok(())
+        }
+
+        fn write(
+            &self,
+            offset: usize,
+            source: &[u8],
+        ) -> core::result::Result<(), SharedMemoryError> {
+            let mut memory = self.0.lock().unwrap();
+            let end = offset
+                .checked_add(source.len())
+                .ok_or(SharedMemoryError::InvalidRange)?;
+            memory
+                .get_mut(offset..end)
+                .ok_or(SharedMemoryError::InvalidRange)?
+                .copy_from_slice(source);
+            Ok(())
+        }
+    }
+
+    struct ScriptedChannel {
+        results: RefCell<VecDeque<BrokerResult>>,
+        sent_operations: RefCell<std::vec::Vec<BrokerOperation>>,
+    }
+
+    impl ScriptedChannel {
+        fn new(results: impl IntoIterator<Item = BrokerResult>) -> Self {
+            Self {
+                results: RefCell::new(results.into_iter().collect()),
+                sent_operations: RefCell::new(std::vec::Vec::new()),
+            }
+        }
+    }
+
+    impl LocalSetupChannel for ScriptedChannel {
+        type Error = Infallible;
+
+        fn send_handshake_request(
+            &mut self,
+            request: &BrokerHandshakeRequest,
+        ) -> core::result::Result<(), Self::Error> {
+            assert_eq!(request.protocol_version, BROKER_PROTOCOL_VERSION);
+            Ok(())
+        }
+
+        fn recv_handshake_response(
+            &mut self,
+        ) -> core::result::Result<Option<BrokerHandshakeResponse>, Self::Error> {
+            Ok(Some(BrokerHandshakeResponse::Negotiated {
+                broker_protocol_version: BROKER_PROTOCOL_VERSION,
+            }))
+        }
+    }
+
+    impl LocalCallChannel for ScriptedChannel {
+        type Error = Infallible;
+
+        fn call(
+            &self,
+            request: BrokerRequest,
+        ) -> core::result::Result<BrokerResponse, Self::Error> {
+            self.sent_operations.borrow_mut().push(request.operation);
+            Ok(BrokerResponse {
+                request_id: request.request_id,
+                result: self.results.borrow_mut().pop_front().unwrap(),
+            })
+        }
+    }
+}
+
+impl<Channel: LocalCallChannel> BrokerLocal<Channel> {
+    /// Reads from an open file.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the buffer descriptor is inconsistent or the broker returns
+    /// an invalid response.
+    pub fn read_file(
+        &self,
+        handle: ObjectHandle,
+        buffer: SharedBufferDescriptor,
+        destination: &mut [u8],
+        offset: Option<u64>,
+    ) -> Result<FileOperationResult<usize>, Channel::Error> {
+        self.validate_file_buffer(buffer, destination.len())?;
+        match self.request_file(FileRequest::Read(ReadFileRequest {
+            handle,
+            buffer,
+            offset,
+        }))? {
+            FileResponse::Read(response) => {
+                assert!(
+                    response.read <= buffer.length,
+                    "broker returned oversized file read"
+                );
+                let read = response.read as usize;
+                self.shared_buffers
+                    .read(buffer.slot_index, &mut destination[..read])
+                    .expect("validated shared file read range must be accessible");
+                Ok(Ok(read))
+            }
+            FileResponse::Failed(error) => Ok(Err(error)),
+            response => panic!("broker returned unexpected file read response: {response:?}"),
+        }
+    }
+
+    /// Writes to an open file.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the buffer descriptor is inconsistent or the broker returns
+    /// an invalid response.
+    pub fn write_file(
+        &self,
+        handle: ObjectHandle,
+        buffer: SharedBufferDescriptor,
+        data: &[u8],
+        offset: Option<u64>,
+    ) -> Result<FileOperationResult<usize>, Channel::Error> {
+        self.write_file_buffer(buffer, data)?;
+        match self.request_file(FileRequest::Write(WriteFileRequest {
+            handle,
+            buffer,
+            offset,
+        }))? {
+            FileResponse::Write(response) => {
+                assert!(
+                    response.written <= buffer.length,
+                    "broker returned oversized file write"
+                );
+                Ok(Ok(response.written as usize))
+            }
+            FileResponse::Failed(error) => Ok(Err(error)),
+            response => panic!("broker returned unexpected file write response: {response:?}"),
+        }
+    }
+
+    /// Repositions an open file.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the broker returns a response for another file operation.
+    pub fn seek_file(
+        &self,
+        handle: ObjectHandle,
+        offset: i64,
+        whence: FileSeekWhence,
+    ) -> Result<FileOperationResult<u64>, Channel::Error> {
+        match self.request_file(FileRequest::Seek(SeekFileRequest {
+            handle,
+            offset,
+            whence,
+        }))? {
+            FileResponse::Seek(response) => Ok(Ok(response.offset)),
+            FileResponse::Failed(error) => Ok(Err(error)),
+            response => panic!("broker returned unexpected file seek response: {response:?}"),
+        }
+    }
+
+    /// Truncates an open file.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the broker returns a response for another file operation.
+    pub fn truncate_file(
+        &self,
+        handle: ObjectHandle,
+        length: u64,
+        reset_offset: bool,
+    ) -> Result<FileOperationResult<()>, Channel::Error> {
+        match self.request_file(FileRequest::Truncate(TruncateFileRequest {
+            handle,
+            length,
+            reset_offset,
+        }))? {
+            FileResponse::Truncate => Ok(Ok(())),
+            FileResponse::Failed(error) => Ok(Err(error)),
+            response => panic!("broker returned unexpected file truncate response: {response:?}"),
+        }
+    }
+
+    /// Reads one encoded page of directory entries.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the buffer descriptor is inconsistent or the broker returns
+    /// an invalid response or directory payload.
+    pub fn read_directory(
+        &self,
+        handle: ObjectHandle,
+        buffer: SharedBufferDescriptor,
+        start_index: u64,
+    ) -> Result<DirectoryReadResult, Channel::Error> {
+        self.validate_file_buffer(buffer, buffer.length as usize)?;
+        match self.request_file(FileRequest::ReadDirectory(ReadDirectoryRequest {
+            handle,
+            buffer,
+            start_index,
+        }))? {
+            FileResponse::ReadDirectory(response) => {
+                assert!(
+                    response.length <= buffer.length,
+                    "broker returned oversized file directory payload"
+                );
+                let mut payload = Vec::new();
+                payload
+                    .try_reserve_exact(response.length as usize)
+                    .map_err(|_| BrokerLocalError::Broker(ErrorCode::OutOfMemory))?;
+                payload.resize(response.length as usize, 0);
+                self.shared_buffers
+                    .read(buffer.slot_index, &mut payload)
+                    .expect("validated shared file directory range must be accessible");
+                let entries = match decode_directory_entries(&payload) {
+                    Ok(entries) => entries,
+                    Err(DirectoryPayloadError::OutOfMemory) => {
+                        return Err(BrokerLocalError::Broker(ErrorCode::OutOfMemory));
+                    }
+                    Err(DirectoryPayloadError::Malformed | DirectoryPayloadError::TooLarge) => {
+                        panic!("broker returned malformed file directory payload");
+                    }
+                };
+                if let Some(next_index) = response.next_index {
+                    let expected_next_index = start_index
+                        .checked_add(u64::try_from(entries.len()).unwrap())
+                        .expect("file directory index overflow");
+                    assert!(
+                        !entries.is_empty() && next_index == expected_next_index,
+                        "broker returned inconsistent file directory continuation"
+                    );
+                }
+                Ok(Ok((entries, response.next_index)))
+            }
+            FileResponse::Failed(error) => Ok(Err(error)),
+            response => {
+                panic!("broker returned unexpected file directory response: {response:?}")
+            }
+        }
+    }
+
+    /// Returns status for an absolute path.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the buffer descriptor is inconsistent or the broker returns
+    /// a response for another file operation.
+    pub fn path_file_status(
+        &self,
+        path_buffer: SharedBufferDescriptor,
+        path: &str,
+        user: FileUser,
+    ) -> Result<FileOperationResult<FileStatus>, Channel::Error> {
+        self.write_file_buffer(path_buffer, path.as_bytes())?;
+        match self.request_file(FileRequest::PathStatus(PathFileStatusRequest {
+            path: path_buffer,
+            user,
+        }))? {
+            FileResponse::PathStatus(status) => Ok(Ok(status)),
+            FileResponse::Failed(error) => Ok(Err(error)),
+            response => {
+                panic!("broker returned unexpected file path-status response: {response:?}")
+            }
+        }
+    }
+
+    /// Returns status for an open file.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the broker returns a response for another file operation.
+    pub fn handle_file_status(
+        &self,
+        handle: ObjectHandle,
+    ) -> Result<FileOperationResult<FileStatus>, Channel::Error> {
+        match self.request_file(FileRequest::HandleStatus(HandleFileStatusRequest {
+            handle,
+        }))? {
+            FileResponse::HandleStatus(status) => Ok(Ok(status)),
+            FileResponse::Failed(error) => Ok(Err(error)),
+            response => {
+                panic!("broker returned unexpected file handle-status response: {response:?}")
+            }
+        }
+    }
+
+    /// Changes mode bits for an absolute path.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the buffer descriptor is inconsistent or the broker returns
+    /// a response for another file operation.
+    pub fn chmod_file(
+        &self,
+        path_buffer: SharedBufferDescriptor,
+        path: &str,
+        user: FileUser,
+        mode: FileMode,
+    ) -> Result<FileOperationResult<()>, Channel::Error> {
+        self.write_file_buffer(path_buffer, path.as_bytes())?;
+        match self.request_file(FileRequest::Chmod(ChmodFileRequest {
+            path: path_buffer,
+            user,
+            mode,
+        }))? {
+            FileResponse::Chmod => Ok(Ok(())),
+            FileResponse::Failed(error) => Ok(Err(error)),
+            response => panic!("broker returned unexpected file chmod response: {response:?}"),
+        }
+    }
+
+    /// Changes ownership for an absolute path.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the buffer descriptor is inconsistent or the broker returns
+    /// a response for another file operation.
+    pub fn chown_file(
+        &self,
+        path_buffer: SharedBufferDescriptor,
+        path: &str,
+        acting_user: FileUser,
+        user: Option<u16>,
+        group: Option<u16>,
+    ) -> Result<FileOperationResult<()>, Channel::Error> {
+        self.write_file_buffer(path_buffer, path.as_bytes())?;
+        match self.request_file(FileRequest::Chown(ChownFileRequest {
+            path: path_buffer,
+            acting_user,
+            user,
+            group,
+        }))? {
+            FileResponse::Chown => Ok(Ok(())),
+            FileResponse::Failed(error) => Ok(Err(error)),
+            response => panic!("broker returned unexpected file chown response: {response:?}"),
+        }
+    }
+
+    /// Removes a file at an absolute path.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the buffer descriptor is inconsistent or the broker returns
+    /// a response for another file operation.
+    pub fn unlink_file(
+        &self,
+        path_buffer: SharedBufferDescriptor,
+        path: &str,
+        user: FileUser,
+    ) -> Result<FileOperationResult<()>, Channel::Error> {
+        self.write_file_buffer(path_buffer, path.as_bytes())?;
+        match self.request_file(FileRequest::Unlink(UnlinkFileRequest {
+            path: path_buffer,
+            user,
+        }))? {
+            FileResponse::Unlink => Ok(Ok(())),
+            FileResponse::Failed(error) => Ok(Err(error)),
+            response => panic!("broker returned unexpected file unlink response: {response:?}"),
+        }
+    }
+
+    /// Creates a directory at an absolute path.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the buffer descriptor is inconsistent or the broker returns
+    /// a response for another file operation.
+    pub fn mkdir_file(
+        &self,
+        path_buffer: SharedBufferDescriptor,
+        path: &str,
+        user: FileUser,
+        mode: FileMode,
+    ) -> Result<FileOperationResult<()>, Channel::Error> {
+        self.write_file_buffer(path_buffer, path.as_bytes())?;
+        match self.request_file(FileRequest::Mkdir(MkdirFileRequest {
+            path: path_buffer,
+            user,
+            mode,
+        }))? {
+            FileResponse::Mkdir => Ok(Ok(())),
+            FileResponse::Failed(error) => Ok(Err(error)),
+            response => panic!("broker returned unexpected file mkdir response: {response:?}"),
+        }
+    }
+
+    /// Removes a directory at an absolute path.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the buffer descriptor is inconsistent or the broker returns
+    /// a response for another file operation.
+    pub fn rmdir_file(
+        &self,
+        path_buffer: SharedBufferDescriptor,
+        path: &str,
+        user: FileUser,
+    ) -> Result<FileOperationResult<()>, Channel::Error> {
+        self.write_file_buffer(path_buffer, path.as_bytes())?;
+        match self.request_file(FileRequest::Rmdir(RmdirFileRequest {
+            path: path_buffer,
+            user,
+        }))? {
+            FileResponse::Rmdir => Ok(Ok(())),
+            FileResponse::Failed(error) => Ok(Err(error)),
+            response => panic!("broker returned unexpected file rmdir response: {response:?}"),
+        }
+    }
+
+    fn validate_file_buffer(
+        &self,
+        buffer: SharedBufferDescriptor,
+        expected_length: usize,
+    ) -> Result<(), Channel::Error> {
+        if buffer.length > MAX_FILE_TRANSFER_SIZE {
+            return Err(BrokerLocalError::Broker(ErrorCode::ResourceExhausted));
+        }
+        assert_eq!(
+            expected_length, buffer.length as usize,
+            "shared file data must match its descriptor"
+        );
+        self.shared_buffers
+            .layout()
+            .range(buffer.slot_index, expected_length)
+            .expect("shared file descriptor must identify a valid slot range");
+        Ok(())
+    }
+
+    fn write_file_buffer(
+        &self,
+        buffer: SharedBufferDescriptor,
+        data: &[u8],
+    ) -> Result<(), Channel::Error> {
+        self.validate_file_buffer(buffer, data.len())?;
+        self.shared_buffers
+            .write(buffer.slot_index, data)
+            .expect("validated shared file write range must be accessible");
+        Ok(())
+    }
+
+    fn request_file(&self, request: FileRequest) -> Result<FileResponse, Channel::Error> {
+        match self.request(BrokerOperation::File(request))? {
+            BrokerResult::File(response) => Ok(response),
+            BrokerResult::Error(error) => Err(BrokerLocalError::Broker(error)),
+            response => panic!("broker returned unexpected file response: {response:?}"),
+        }
+    }
+}

--- a/litebox_broker_local/src/fs.rs
+++ b/litebox_broker_local/src/fs.rs
@@ -6,12 +6,12 @@ use alloc::vec::Vec;
 use litebox_broker_protocol::ObjectHandle;
 use litebox_broker_protocol::error::ErrorCode;
 use litebox_broker_protocol::fs::{
-    ChmodFileRequest, ChownFileRequest, DirectoryPayloadError, FileAccessMode, FileDirectoryEntry,
-    FileError, FileMode, FileOpenFlags, FileSeekWhence, FileStatus, FileUser,
-    HandleFileStatusRequest, MAX_FILE_TRANSFER_SIZE, MkdirFileRequest, OpenFileRequest,
-    PathFileStatusRequest, ReadDirectoryRequest, ReadFileRequest, RmdirFileRequest,
-    SeekFileRequest, TruncateFileRequest, UnlinkFileRequest, WriteFileRequest,
-    decode_directory_entries,
+    ChmodFileRequest, ChownFileRequest, DirectoryPayloadError, DirectoryTransferError,
+    FileAccessMode, FileDirectoryEntry, FileError, FileMode, FileOpenFlags, FileSeekWhence,
+    FileStatus, FileUser, HandleFileStatusRequest, MAX_FILE_TRANSFER_SIZE, MkdirFileRequest,
+    OpenFileRequest, PathFileStatusRequest, ReadDirectoryRequest, ReadFileRequest,
+    RmdirFileRequest, SeekFileRequest, TruncateFileRequest, UnlinkFileRequest, WriteFileRequest,
+    try_decode_directory_entries,
 };
 use litebox_broker_protocol::message::{BrokerOperation, BrokerResult, FileRequest, FileResponse};
 use litebox_broker_protocol::shared_buffer::SharedBufferDescriptor;
@@ -51,13 +51,387 @@ impl<Channel: LocalCallChannel> BrokerLocal<Channel> {
             response => panic!("broker returned unexpected file open response: {response:?}"),
         }
     }
+
+    /// Reads from an open file.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the buffer descriptor is inconsistent or the broker returns
+    /// an invalid response.
+    pub fn read_file(
+        &self,
+        handle: ObjectHandle,
+        buffer: SharedBufferDescriptor,
+        destination: &mut [u8],
+        offset: Option<u64>,
+    ) -> Result<FileOperationResult<usize>, Channel::Error> {
+        self.validate_file_buffer(buffer, destination.len())?;
+        match self.request_file(FileRequest::Read(ReadFileRequest {
+            handle,
+            buffer,
+            offset,
+        }))? {
+            FileResponse::Read(response) => {
+                assert!(
+                    response.read <= buffer.length,
+                    "broker returned oversized file read"
+                );
+                let read = response.read as usize;
+                self.shared_buffers
+                    .read(buffer.slot_index, &mut destination[..read])
+                    .expect("validated shared file read range must be accessible");
+                Ok(Ok(read))
+            }
+            FileResponse::Failed(error) => Ok(Err(error)),
+            response => panic!("broker returned unexpected file read response: {response:?}"),
+        }
+    }
+
+    /// Writes to an open file.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the buffer descriptor is inconsistent or the broker returns
+    /// an invalid response.
+    pub fn write_file(
+        &self,
+        handle: ObjectHandle,
+        buffer: SharedBufferDescriptor,
+        data: &[u8],
+        offset: Option<u64>,
+    ) -> Result<FileOperationResult<usize>, Channel::Error> {
+        self.write_file_buffer(buffer, data)?;
+        match self.request_file(FileRequest::Write(WriteFileRequest {
+            handle,
+            buffer,
+            offset,
+        }))? {
+            FileResponse::Write(response) => {
+                assert!(
+                    response.written <= buffer.length,
+                    "broker returned oversized file write"
+                );
+                Ok(Ok(response.written as usize))
+            }
+            FileResponse::Failed(error) => Ok(Err(error)),
+            response => panic!("broker returned unexpected file write response: {response:?}"),
+        }
+    }
+
+    /// Repositions an open file.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the broker returns a response for another file operation.
+    pub fn seek_file(
+        &self,
+        handle: ObjectHandle,
+        offset: i64,
+        whence: FileSeekWhence,
+    ) -> Result<FileOperationResult<u64>, Channel::Error> {
+        match self.request_file(FileRequest::Seek(SeekFileRequest {
+            handle,
+            offset,
+            whence,
+        }))? {
+            FileResponse::Seek(response) => Ok(Ok(response.offset)),
+            FileResponse::Failed(error) => Ok(Err(error)),
+            response => panic!("broker returned unexpected file seek response: {response:?}"),
+        }
+    }
+
+    /// Truncates an open file.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the broker returns a response for another file operation.
+    pub fn truncate_file(
+        &self,
+        handle: ObjectHandle,
+        length: u64,
+        reset_offset: bool,
+    ) -> Result<FileOperationResult<()>, Channel::Error> {
+        match self.request_file(FileRequest::Truncate(TruncateFileRequest {
+            handle,
+            length,
+            reset_offset,
+        }))? {
+            FileResponse::Truncate => Ok(Ok(())),
+            FileResponse::Failed(error) => Ok(Err(error)),
+            response => panic!("broker returned unexpected file truncate response: {response:?}"),
+        }
+    }
+
+    /// Reads one encoded page of directory entries.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the buffer descriptor is inconsistent or the broker returns
+    /// an invalid response or directory payload.
+    pub fn read_directory(
+        &self,
+        handle: ObjectHandle,
+        buffer: SharedBufferDescriptor,
+        start_index: u64,
+    ) -> Result<DirectoryReadResult, Channel::Error> {
+        self.validate_file_buffer(buffer, buffer.length as usize)?;
+        match self.request_file(FileRequest::ReadDirectory(ReadDirectoryRequest {
+            handle,
+            buffer,
+            start_index,
+        }))? {
+            FileResponse::ReadDirectory(response) => {
+                assert!(
+                    response.length <= buffer.length,
+                    "broker returned oversized file directory payload"
+                );
+                let mut payload = Vec::new();
+                payload
+                    .try_reserve_exact(response.length as usize)
+                    .map_err(|_| BrokerLocalError::Broker(ErrorCode::OutOfMemory))?;
+                payload.resize(response.length as usize, 0);
+                self.shared_buffers
+                    .read(buffer.slot_index, &mut payload)
+                    .expect("validated shared file directory range must be accessible");
+                let entries = match try_decode_directory_entries(&payload) {
+                    Ok(entries) => entries,
+                    Err(DirectoryTransferError::OutOfMemory) => {
+                        return Err(BrokerLocalError::Broker(ErrorCode::OutOfMemory));
+                    }
+                    Err(DirectoryTransferError::Payload(
+                        DirectoryPayloadError::Malformed | DirectoryPayloadError::TooLarge,
+                    )) => panic!("broker returned malformed file directory payload"),
+                    Err(error) => {
+                        panic!("broker returned unsupported file directory payload error: {error}")
+                    }
+                };
+                if let Some(next_index) = response.next_index {
+                    let expected_next_index = start_index
+                        .checked_add(u64::try_from(entries.len()).unwrap())
+                        .expect("file directory index overflow");
+                    assert!(
+                        !entries.is_empty() && next_index == expected_next_index,
+                        "broker returned inconsistent file directory continuation"
+                    );
+                }
+                Ok(Ok((entries, response.next_index)))
+            }
+            FileResponse::Failed(error) => Ok(Err(error)),
+            response => {
+                panic!("broker returned unexpected file directory response: {response:?}")
+            }
+        }
+    }
+
+    /// Returns status for an absolute path.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the buffer descriptor is inconsistent or the broker returns
+    /// a response for another file operation.
+    pub fn path_file_status(
+        &self,
+        path_buffer: SharedBufferDescriptor,
+        path: &str,
+        user: FileUser,
+    ) -> Result<FileOperationResult<FileStatus>, Channel::Error> {
+        self.write_file_buffer(path_buffer, path.as_bytes())?;
+        match self.request_file(FileRequest::PathStatus(PathFileStatusRequest {
+            path: path_buffer,
+            user,
+        }))? {
+            FileResponse::PathStatus(status) => Ok(Ok(status)),
+            FileResponse::Failed(error) => Ok(Err(error)),
+            response => {
+                panic!("broker returned unexpected file path-status response: {response:?}")
+            }
+        }
+    }
+
+    /// Returns status for an open file.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the broker returns a response for another file operation.
+    pub fn handle_file_status(
+        &self,
+        handle: ObjectHandle,
+    ) -> Result<FileOperationResult<FileStatus>, Channel::Error> {
+        match self.request_file(FileRequest::HandleStatus(HandleFileStatusRequest {
+            handle,
+        }))? {
+            FileResponse::HandleStatus(status) => Ok(Ok(status)),
+            FileResponse::Failed(error) => Ok(Err(error)),
+            response => {
+                panic!("broker returned unexpected file handle-status response: {response:?}")
+            }
+        }
+    }
+
+    /// Changes mode bits for an absolute path.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the buffer descriptor is inconsistent or the broker returns
+    /// a response for another file operation.
+    pub fn chmod_file(
+        &self,
+        path_buffer: SharedBufferDescriptor,
+        path: &str,
+        user: FileUser,
+        mode: FileMode,
+    ) -> Result<FileOperationResult<()>, Channel::Error> {
+        self.write_file_buffer(path_buffer, path.as_bytes())?;
+        match self.request_file(FileRequest::Chmod(ChmodFileRequest {
+            path: path_buffer,
+            user,
+            mode,
+        }))? {
+            FileResponse::Chmod => Ok(Ok(())),
+            FileResponse::Failed(error) => Ok(Err(error)),
+            response => panic!("broker returned unexpected file chmod response: {response:?}"),
+        }
+    }
+
+    /// Changes ownership for an absolute path.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the buffer descriptor is inconsistent or the broker returns
+    /// a response for another file operation.
+    pub fn chown_file(
+        &self,
+        path_buffer: SharedBufferDescriptor,
+        path: &str,
+        acting_user: FileUser,
+        user: Option<u16>,
+        group: Option<u16>,
+    ) -> Result<FileOperationResult<()>, Channel::Error> {
+        self.write_file_buffer(path_buffer, path.as_bytes())?;
+        match self.request_file(FileRequest::Chown(ChownFileRequest {
+            path: path_buffer,
+            acting_user,
+            user,
+            group,
+        }))? {
+            FileResponse::Chown => Ok(Ok(())),
+            FileResponse::Failed(error) => Ok(Err(error)),
+            response => panic!("broker returned unexpected file chown response: {response:?}"),
+        }
+    }
+
+    /// Removes a file at an absolute path.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the buffer descriptor is inconsistent or the broker returns
+    /// a response for another file operation.
+    pub fn unlink_file(
+        &self,
+        path_buffer: SharedBufferDescriptor,
+        path: &str,
+        user: FileUser,
+    ) -> Result<FileOperationResult<()>, Channel::Error> {
+        self.write_file_buffer(path_buffer, path.as_bytes())?;
+        match self.request_file(FileRequest::Unlink(UnlinkFileRequest {
+            path: path_buffer,
+            user,
+        }))? {
+            FileResponse::Unlink => Ok(Ok(())),
+            FileResponse::Failed(error) => Ok(Err(error)),
+            response => panic!("broker returned unexpected file unlink response: {response:?}"),
+        }
+    }
+
+    /// Creates a directory at an absolute path.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the buffer descriptor is inconsistent or the broker returns
+    /// a response for another file operation.
+    pub fn mkdir_file(
+        &self,
+        path_buffer: SharedBufferDescriptor,
+        path: &str,
+        user: FileUser,
+        mode: FileMode,
+    ) -> Result<FileOperationResult<()>, Channel::Error> {
+        self.write_file_buffer(path_buffer, path.as_bytes())?;
+        match self.request_file(FileRequest::Mkdir(MkdirFileRequest {
+            path: path_buffer,
+            user,
+            mode,
+        }))? {
+            FileResponse::Mkdir => Ok(Ok(())),
+            FileResponse::Failed(error) => Ok(Err(error)),
+            response => panic!("broker returned unexpected file mkdir response: {response:?}"),
+        }
+    }
+
+    /// Removes a directory at an absolute path.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the buffer descriptor is inconsistent or the broker returns
+    /// a response for another file operation.
+    pub fn rmdir_file(
+        &self,
+        path_buffer: SharedBufferDescriptor,
+        path: &str,
+        user: FileUser,
+    ) -> Result<FileOperationResult<()>, Channel::Error> {
+        self.write_file_buffer(path_buffer, path.as_bytes())?;
+        match self.request_file(FileRequest::Rmdir(RmdirFileRequest {
+            path: path_buffer,
+            user,
+        }))? {
+            FileResponse::Rmdir => Ok(Ok(())),
+            FileResponse::Failed(error) => Ok(Err(error)),
+            response => panic!("broker returned unexpected file rmdir response: {response:?}"),
+        }
+    }
+
+    fn validate_file_buffer(
+        &self,
+        buffer: SharedBufferDescriptor,
+        expected_length: usize,
+    ) -> Result<(), Channel::Error> {
+        if buffer.length > MAX_FILE_TRANSFER_SIZE {
+            return Err(BrokerLocalError::Broker(ErrorCode::ResourceExhausted));
+        }
+        assert_eq!(
+            expected_length, buffer.length as usize,
+            "shared file data must match its descriptor"
+        );
+        self.shared_buffers
+            .layout()
+            .range(buffer.slot_index, expected_length)
+            .expect("shared file descriptor must identify a valid slot range");
+        Ok(())
+    }
+
+    fn write_file_buffer(
+        &self,
+        buffer: SharedBufferDescriptor,
+        data: &[u8],
+    ) -> Result<(), Channel::Error> {
+        self.validate_file_buffer(buffer, data.len())?;
+        self.shared_buffers
+            .write(buffer.slot_index, data)
+            .expect("validated shared file write range must be accessible");
+        Ok(())
+    }
+
+    fn request_file(&self, request: FileRequest) -> Result<FileResponse, Channel::Error> {
+        match self.request(BrokerOperation::File(request))? {
+            BrokerResult::File(response) => Ok(response),
+            BrokerResult::Error(error) => Err(BrokerLocalError::Broker(error)),
+            response => panic!("broker returned unexpected file response: {response:?}"),
+        }
+    }
 }
 
 #[cfg(test)]
-#[expect(
-    clippy::items_after_test_module,
-    reason = "the test module must access private adapter state while the production methods stay grouped"
-)]
 mod tests {
     use super::*;
     use alloc::sync::Arc;
@@ -317,383 +691,6 @@ mod tests {
                 request_id: request.request_id,
                 result: self.results.borrow_mut().pop_front().unwrap(),
             })
-        }
-    }
-}
-
-impl<Channel: LocalCallChannel> BrokerLocal<Channel> {
-    /// Reads from an open file.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the buffer descriptor is inconsistent or the broker returns
-    /// an invalid response.
-    pub fn read_file(
-        &self,
-        handle: ObjectHandle,
-        buffer: SharedBufferDescriptor,
-        destination: &mut [u8],
-        offset: Option<u64>,
-    ) -> Result<FileOperationResult<usize>, Channel::Error> {
-        self.validate_file_buffer(buffer, destination.len())?;
-        match self.request_file(FileRequest::Read(ReadFileRequest {
-            handle,
-            buffer,
-            offset,
-        }))? {
-            FileResponse::Read(response) => {
-                assert!(
-                    response.read <= buffer.length,
-                    "broker returned oversized file read"
-                );
-                let read = response.read as usize;
-                self.shared_buffers
-                    .read(buffer.slot_index, &mut destination[..read])
-                    .expect("validated shared file read range must be accessible");
-                Ok(Ok(read))
-            }
-            FileResponse::Failed(error) => Ok(Err(error)),
-            response => panic!("broker returned unexpected file read response: {response:?}"),
-        }
-    }
-
-    /// Writes to an open file.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the buffer descriptor is inconsistent or the broker returns
-    /// an invalid response.
-    pub fn write_file(
-        &self,
-        handle: ObjectHandle,
-        buffer: SharedBufferDescriptor,
-        data: &[u8],
-        offset: Option<u64>,
-    ) -> Result<FileOperationResult<usize>, Channel::Error> {
-        self.write_file_buffer(buffer, data)?;
-        match self.request_file(FileRequest::Write(WriteFileRequest {
-            handle,
-            buffer,
-            offset,
-        }))? {
-            FileResponse::Write(response) => {
-                assert!(
-                    response.written <= buffer.length,
-                    "broker returned oversized file write"
-                );
-                Ok(Ok(response.written as usize))
-            }
-            FileResponse::Failed(error) => Ok(Err(error)),
-            response => panic!("broker returned unexpected file write response: {response:?}"),
-        }
-    }
-
-    /// Repositions an open file.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the broker returns a response for another file operation.
-    pub fn seek_file(
-        &self,
-        handle: ObjectHandle,
-        offset: i64,
-        whence: FileSeekWhence,
-    ) -> Result<FileOperationResult<u64>, Channel::Error> {
-        match self.request_file(FileRequest::Seek(SeekFileRequest {
-            handle,
-            offset,
-            whence,
-        }))? {
-            FileResponse::Seek(response) => Ok(Ok(response.offset)),
-            FileResponse::Failed(error) => Ok(Err(error)),
-            response => panic!("broker returned unexpected file seek response: {response:?}"),
-        }
-    }
-
-    /// Truncates an open file.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the broker returns a response for another file operation.
-    pub fn truncate_file(
-        &self,
-        handle: ObjectHandle,
-        length: u64,
-        reset_offset: bool,
-    ) -> Result<FileOperationResult<()>, Channel::Error> {
-        match self.request_file(FileRequest::Truncate(TruncateFileRequest {
-            handle,
-            length,
-            reset_offset,
-        }))? {
-            FileResponse::Truncate => Ok(Ok(())),
-            FileResponse::Failed(error) => Ok(Err(error)),
-            response => panic!("broker returned unexpected file truncate response: {response:?}"),
-        }
-    }
-
-    /// Reads one encoded page of directory entries.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the buffer descriptor is inconsistent or the broker returns
-    /// an invalid response or directory payload.
-    pub fn read_directory(
-        &self,
-        handle: ObjectHandle,
-        buffer: SharedBufferDescriptor,
-        start_index: u64,
-    ) -> Result<DirectoryReadResult, Channel::Error> {
-        self.validate_file_buffer(buffer, buffer.length as usize)?;
-        match self.request_file(FileRequest::ReadDirectory(ReadDirectoryRequest {
-            handle,
-            buffer,
-            start_index,
-        }))? {
-            FileResponse::ReadDirectory(response) => {
-                assert!(
-                    response.length <= buffer.length,
-                    "broker returned oversized file directory payload"
-                );
-                let mut payload = Vec::new();
-                payload
-                    .try_reserve_exact(response.length as usize)
-                    .map_err(|_| BrokerLocalError::Broker(ErrorCode::OutOfMemory))?;
-                payload.resize(response.length as usize, 0);
-                self.shared_buffers
-                    .read(buffer.slot_index, &mut payload)
-                    .expect("validated shared file directory range must be accessible");
-                let entries = match decode_directory_entries(&payload) {
-                    Ok(entries) => entries,
-                    Err(DirectoryPayloadError::OutOfMemory) => {
-                        return Err(BrokerLocalError::Broker(ErrorCode::OutOfMemory));
-                    }
-                    Err(DirectoryPayloadError::Malformed | DirectoryPayloadError::TooLarge) => {
-                        panic!("broker returned malformed file directory payload");
-                    }
-                };
-                if let Some(next_index) = response.next_index {
-                    let expected_next_index = start_index
-                        .checked_add(u64::try_from(entries.len()).unwrap())
-                        .expect("file directory index overflow");
-                    assert!(
-                        !entries.is_empty() && next_index == expected_next_index,
-                        "broker returned inconsistent file directory continuation"
-                    );
-                }
-                Ok(Ok((entries, response.next_index)))
-            }
-            FileResponse::Failed(error) => Ok(Err(error)),
-            response => {
-                panic!("broker returned unexpected file directory response: {response:?}")
-            }
-        }
-    }
-
-    /// Returns status for an absolute path.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the buffer descriptor is inconsistent or the broker returns
-    /// a response for another file operation.
-    pub fn path_file_status(
-        &self,
-        path_buffer: SharedBufferDescriptor,
-        path: &str,
-        user: FileUser,
-    ) -> Result<FileOperationResult<FileStatus>, Channel::Error> {
-        self.write_file_buffer(path_buffer, path.as_bytes())?;
-        match self.request_file(FileRequest::PathStatus(PathFileStatusRequest {
-            path: path_buffer,
-            user,
-        }))? {
-            FileResponse::PathStatus(status) => Ok(Ok(status)),
-            FileResponse::Failed(error) => Ok(Err(error)),
-            response => {
-                panic!("broker returned unexpected file path-status response: {response:?}")
-            }
-        }
-    }
-
-    /// Returns status for an open file.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the broker returns a response for another file operation.
-    pub fn handle_file_status(
-        &self,
-        handle: ObjectHandle,
-    ) -> Result<FileOperationResult<FileStatus>, Channel::Error> {
-        match self.request_file(FileRequest::HandleStatus(HandleFileStatusRequest {
-            handle,
-        }))? {
-            FileResponse::HandleStatus(status) => Ok(Ok(status)),
-            FileResponse::Failed(error) => Ok(Err(error)),
-            response => {
-                panic!("broker returned unexpected file handle-status response: {response:?}")
-            }
-        }
-    }
-
-    /// Changes mode bits for an absolute path.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the buffer descriptor is inconsistent or the broker returns
-    /// a response for another file operation.
-    pub fn chmod_file(
-        &self,
-        path_buffer: SharedBufferDescriptor,
-        path: &str,
-        user: FileUser,
-        mode: FileMode,
-    ) -> Result<FileOperationResult<()>, Channel::Error> {
-        self.write_file_buffer(path_buffer, path.as_bytes())?;
-        match self.request_file(FileRequest::Chmod(ChmodFileRequest {
-            path: path_buffer,
-            user,
-            mode,
-        }))? {
-            FileResponse::Chmod => Ok(Ok(())),
-            FileResponse::Failed(error) => Ok(Err(error)),
-            response => panic!("broker returned unexpected file chmod response: {response:?}"),
-        }
-    }
-
-    /// Changes ownership for an absolute path.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the buffer descriptor is inconsistent or the broker returns
-    /// a response for another file operation.
-    pub fn chown_file(
-        &self,
-        path_buffer: SharedBufferDescriptor,
-        path: &str,
-        acting_user: FileUser,
-        user: Option<u16>,
-        group: Option<u16>,
-    ) -> Result<FileOperationResult<()>, Channel::Error> {
-        self.write_file_buffer(path_buffer, path.as_bytes())?;
-        match self.request_file(FileRequest::Chown(ChownFileRequest {
-            path: path_buffer,
-            acting_user,
-            user,
-            group,
-        }))? {
-            FileResponse::Chown => Ok(Ok(())),
-            FileResponse::Failed(error) => Ok(Err(error)),
-            response => panic!("broker returned unexpected file chown response: {response:?}"),
-        }
-    }
-
-    /// Removes a file at an absolute path.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the buffer descriptor is inconsistent or the broker returns
-    /// a response for another file operation.
-    pub fn unlink_file(
-        &self,
-        path_buffer: SharedBufferDescriptor,
-        path: &str,
-        user: FileUser,
-    ) -> Result<FileOperationResult<()>, Channel::Error> {
-        self.write_file_buffer(path_buffer, path.as_bytes())?;
-        match self.request_file(FileRequest::Unlink(UnlinkFileRequest {
-            path: path_buffer,
-            user,
-        }))? {
-            FileResponse::Unlink => Ok(Ok(())),
-            FileResponse::Failed(error) => Ok(Err(error)),
-            response => panic!("broker returned unexpected file unlink response: {response:?}"),
-        }
-    }
-
-    /// Creates a directory at an absolute path.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the buffer descriptor is inconsistent or the broker returns
-    /// a response for another file operation.
-    pub fn mkdir_file(
-        &self,
-        path_buffer: SharedBufferDescriptor,
-        path: &str,
-        user: FileUser,
-        mode: FileMode,
-    ) -> Result<FileOperationResult<()>, Channel::Error> {
-        self.write_file_buffer(path_buffer, path.as_bytes())?;
-        match self.request_file(FileRequest::Mkdir(MkdirFileRequest {
-            path: path_buffer,
-            user,
-            mode,
-        }))? {
-            FileResponse::Mkdir => Ok(Ok(())),
-            FileResponse::Failed(error) => Ok(Err(error)),
-            response => panic!("broker returned unexpected file mkdir response: {response:?}"),
-        }
-    }
-
-    /// Removes a directory at an absolute path.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the buffer descriptor is inconsistent or the broker returns
-    /// a response for another file operation.
-    pub fn rmdir_file(
-        &self,
-        path_buffer: SharedBufferDescriptor,
-        path: &str,
-        user: FileUser,
-    ) -> Result<FileOperationResult<()>, Channel::Error> {
-        self.write_file_buffer(path_buffer, path.as_bytes())?;
-        match self.request_file(FileRequest::Rmdir(RmdirFileRequest {
-            path: path_buffer,
-            user,
-        }))? {
-            FileResponse::Rmdir => Ok(Ok(())),
-            FileResponse::Failed(error) => Ok(Err(error)),
-            response => panic!("broker returned unexpected file rmdir response: {response:?}"),
-        }
-    }
-
-    fn validate_file_buffer(
-        &self,
-        buffer: SharedBufferDescriptor,
-        expected_length: usize,
-    ) -> Result<(), Channel::Error> {
-        if buffer.length > MAX_FILE_TRANSFER_SIZE {
-            return Err(BrokerLocalError::Broker(ErrorCode::ResourceExhausted));
-        }
-        assert_eq!(
-            expected_length, buffer.length as usize,
-            "shared file data must match its descriptor"
-        );
-        self.shared_buffers
-            .layout()
-            .range(buffer.slot_index, expected_length)
-            .expect("shared file descriptor must identify a valid slot range");
-        Ok(())
-    }
-
-    fn write_file_buffer(
-        &self,
-        buffer: SharedBufferDescriptor,
-        data: &[u8],
-    ) -> Result<(), Channel::Error> {
-        self.validate_file_buffer(buffer, data.len())?;
-        self.shared_buffers
-            .write(buffer.slot_index, data)
-            .expect("validated shared file write range must be accessible");
-        Ok(())
-    }
-
-    fn request_file(&self, request: FileRequest) -> Result<FileResponse, Channel::Error> {
-        match self.request(BrokerOperation::File(request))? {
-            BrokerResult::File(response) => Ok(response),
-            BrokerResult::Error(error) => Err(BrokerLocalError::Broker(error)),
-            response => panic!("broker returned unexpected file response: {response:?}"),
         }
     }
 }

--- a/litebox_broker_local/src/lib.rs
+++ b/litebox_broker_local/src/lib.rs
@@ -22,6 +22,7 @@ extern crate std;
 
 mod error;
 mod event;
+mod fs;
 mod pipe;
 mod random;
 mod socket;

--- a/litebox_broker_protocol/src/fs.rs
+++ b/litebox_broker_protocol/src/fs.rs
@@ -3,7 +3,7 @@
 
 //! Broker fs requests, responses, and ABI-neutral values.
 
-use alloc::string::{String, ToString};
+use alloc::string::String;
 use alloc::vec::Vec;
 
 use thiserror::Error;
@@ -443,27 +443,63 @@ pub enum DirectoryPayloadError {
     Malformed,
     #[error("directory payload exceeds one fs transfer")]
     TooLarge,
+    #[error("directory payload allocation failed")]
+    OutOfMemory,
+}
+
+/// Error while encoding one bounded directory payload chunk.
+#[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
+pub enum DirectoryChunkError {
+    #[error("directory payload chunk exceeds its transfer limit")]
+    TooLarge,
+    #[error("directory payload chunk allocation failed")]
+    OutOfMemory,
 }
 
 /// Encodes directory entries for one fs shared-buffer transfer.
 pub fn encode_directory_entries(
     entries: &[FileDirectoryEntry],
 ) -> Result<Vec<u8>, DirectoryPayloadError> {
-    let mut output = Vec::new();
-    output.extend_from_slice(&0u32.to_le_bytes());
-    for entry in entries {
-        let encoded_length = output
-            .len()
-            .checked_add(encoded_directory_entry_length(entry)?)
-            .ok_or(DirectoryPayloadError::TooLarge)?;
-        if encoded_length > MAX_FILE_TRANSFER_SIZE as usize {
-            return Err(DirectoryPayloadError::TooLarge);
-        }
-        encode_directory_entry(&mut output, entry)?;
+    let (payload, next_index) =
+        encode_directory_entries_chunk(entries, 0, MAX_FILE_TRANSFER_SIZE as usize).map_err(
+            |error| match error {
+                DirectoryChunkError::TooLarge => DirectoryPayloadError::TooLarge,
+                DirectoryChunkError::OutOfMemory => DirectoryPayloadError::OutOfMemory,
+            },
+        )?;
+    if next_index.is_some() {
+        return Err(DirectoryPayloadError::TooLarge);
     }
-    let count = u32::try_from(entries.len()).map_err(|_| DirectoryPayloadError::TooLarge)?;
+    Ok(payload)
+}
+
+/// Encodes one directory-entry chunk no longer than `maximum_length`.
+///
+/// `start_index` and the returned continuation index count entries, not bytes.
+pub fn encode_directory_entries_chunk(
+    entries: &[FileDirectoryEntry],
+    start_index: usize,
+    maximum_length: usize,
+) -> Result<(Vec<u8>, Option<u64>), DirectoryChunkError> {
+    let (end_index, encoded_length) =
+        directory_entries_chunk_end(entries, start_index, maximum_length)?;
+    let mut output = Vec::new();
+    output
+        .try_reserve_exact(encoded_length)
+        .map_err(|_| DirectoryChunkError::OutOfMemory)?;
+    output.extend_from_slice(&0u32.to_le_bytes());
+    for entry in &entries[start_index..end_index] {
+        encode_directory_entry(&mut output, entry).map_err(|_| DirectoryChunkError::TooLarge)?;
+    }
+    let count =
+        u32::try_from(end_index - start_index).map_err(|_| DirectoryChunkError::TooLarge)?;
     output[..size_of::<u32>()].copy_from_slice(&count.to_le_bytes());
-    Ok(output)
+    let next_index = if end_index == entries.len() {
+        None
+    } else {
+        Some(u64::try_from(end_index).map_err(|_| DirectoryChunkError::TooLarge)?)
+    };
+    Ok((output, next_index))
 }
 
 /// Decodes directory entries from one fs shared-buffer transfer.
@@ -483,12 +519,15 @@ pub fn decode_directory_entries(
     let mut entries = Vec::new();
     entries
         .try_reserve_exact(count)
-        .map_err(|_| DirectoryPayloadError::TooLarge)?;
+        .map_err(|_| DirectoryPayloadError::OutOfMemory)?;
     for _ in 0..count {
         let name_len = decoder.u32()? as usize;
-        let name = core::str::from_utf8(decoder.take(name_len)?)
-            .map_err(|_| DirectoryPayloadError::Malformed)?
-            .to_string();
+        let encoded_name = core::str::from_utf8(decoder.take(name_len)?)
+            .map_err(|_| DirectoryPayloadError::Malformed)?;
+        let mut name = String::new();
+        name.try_reserve_exact(encoded_name.len())
+            .map_err(|_| DirectoryPayloadError::OutOfMemory)?;
+        name.push_str(encoded_name);
         let file_type =
             file_type_from_raw(decoder.u8()?).ok_or(DirectoryPayloadError::Malformed)?;
         let node_info = match decoder.u8()? {
@@ -553,6 +592,37 @@ fn encoded_directory_entry_length(
             })
         })
         .ok_or(DirectoryPayloadError::TooLarge)
+}
+
+fn directory_entries_chunk_end(
+    entries: &[FileDirectoryEntry],
+    start_index: usize,
+    maximum_length: usize,
+) -> Result<(usize, usize), DirectoryChunkError> {
+    if start_index > entries.len()
+        || !(size_of::<u32>()..=MAX_FILE_TRANSFER_SIZE as usize).contains(&maximum_length)
+    {
+        return Err(DirectoryChunkError::TooLarge);
+    }
+    let mut encoded_length = size_of::<u32>();
+    let mut end_index = start_index;
+    while let Some(entry) = entries.get(end_index) {
+        encoded_length = encoded_length
+            .checked_add(
+                encoded_directory_entry_length(entry).map_err(|_| DirectoryChunkError::TooLarge)?,
+            )
+            .ok_or(DirectoryChunkError::TooLarge)?;
+        if encoded_length > maximum_length {
+            if end_index == start_index {
+                return Err(DirectoryChunkError::TooLarge);
+            }
+            encoded_length -=
+                encoded_directory_entry_length(entry).map_err(|_| DirectoryChunkError::TooLarge)?;
+            break;
+        }
+        end_index += 1;
+    }
+    Ok((end_index, encoded_length))
 }
 
 fn encode_directory_entry(
@@ -672,6 +742,38 @@ mod tests {
                 1, 5, 0, 0, 0, 0, 0, 0, 0,
             ]
         );
+    }
+
+    #[test]
+    fn directory_payload_chunks_use_entry_indexes() {
+        let entries = [
+            FileDirectoryEntry {
+                name: "first".into(),
+                file_type: FileType::RegularFile,
+                node_info: None,
+            },
+            FileDirectoryEntry {
+                name: "second".into(),
+                file_type: FileType::Directory,
+                node_info: None,
+            },
+            FileDirectoryEntry {
+                name: "third".into(),
+                file_type: FileType::CharacterDevice,
+                node_info: None,
+            },
+        ];
+        let first_two_length = encode_directory_entries(&entries[..2]).unwrap().len();
+
+        let (first, next_index) =
+            encode_directory_entries_chunk(&entries, 0, first_two_length).unwrap();
+        assert_eq!(decode_directory_entries(&first).unwrap(), entries[..2]);
+        assert_eq!(next_index, Some(2));
+
+        let (last, next_index) =
+            encode_directory_entries_chunk(&entries, 2, first_two_length).unwrap();
+        assert_eq!(decode_directory_entries(&last).unwrap(), entries[2..]);
+        assert_eq!(next_index, None);
     }
 
     #[test]

--- a/litebox_broker_protocol/src/fs.rs
+++ b/litebox_broker_protocol/src/fs.rs
@@ -443,30 +443,37 @@ pub enum DirectoryPayloadError {
     Malformed,
     #[error("directory payload exceeds one fs transfer")]
     TooLarge,
+}
+
+/// Error while processing a directory payload for an fs transfer.
+#[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum DirectoryTransferError {
+    #[error(transparent)]
+    Payload(#[from] DirectoryPayloadError),
     #[error("directory payload allocation failed")]
     OutOfMemory,
 }
 
-/// Error while encoding one bounded directory payload chunk.
-#[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
-pub enum DirectoryChunkError {
-    #[error("directory payload chunk exceeds its transfer limit")]
-    TooLarge,
-    #[error("directory payload chunk allocation failed")]
-    OutOfMemory,
+impl DirectoryTransferError {
+    fn into_payload_error(self) -> DirectoryPayloadError {
+        match self {
+            Self::Payload(error) => error,
+            Self::OutOfMemory => DirectoryPayloadError::TooLarge,
+        }
+    }
 }
 
 /// Encodes directory entries for one fs shared-buffer transfer.
+///
+/// Allocation failures are reported as [`DirectoryPayloadError::TooLarge`] for
+/// compatibility with the original codec API.
 pub fn encode_directory_entries(
     entries: &[FileDirectoryEntry],
 ) -> Result<Vec<u8>, DirectoryPayloadError> {
     let (payload, next_index) =
-        encode_directory_entries_chunk(entries, 0, MAX_FILE_TRANSFER_SIZE as usize).map_err(
-            |error| match error {
-                DirectoryChunkError::TooLarge => DirectoryPayloadError::TooLarge,
-                DirectoryChunkError::OutOfMemory => DirectoryPayloadError::OutOfMemory,
-            },
-        )?;
+        encode_directory_entries_chunk(entries, 0, MAX_FILE_TRANSFER_SIZE as usize)
+            .map_err(DirectoryTransferError::into_payload_error)?;
     if next_index.is_some() {
         return Err(DirectoryPayloadError::TooLarge);
     }
@@ -480,53 +487,63 @@ pub fn encode_directory_entries_chunk(
     entries: &[FileDirectoryEntry],
     start_index: usize,
     maximum_length: usize,
-) -> Result<(Vec<u8>, Option<u64>), DirectoryChunkError> {
+) -> Result<(Vec<u8>, Option<u64>), DirectoryTransferError> {
     let (end_index, encoded_length) =
         directory_entries_chunk_end(entries, start_index, maximum_length)?;
     let mut output = Vec::new();
     output
         .try_reserve_exact(encoded_length)
-        .map_err(|_| DirectoryChunkError::OutOfMemory)?;
+        .map_err(|_| DirectoryTransferError::OutOfMemory)?;
     output.extend_from_slice(&0u32.to_le_bytes());
     for entry in &entries[start_index..end_index] {
-        encode_directory_entry(&mut output, entry).map_err(|_| DirectoryChunkError::TooLarge)?;
+        encode_directory_entry(&mut output, entry)?;
     }
     let count =
-        u32::try_from(end_index - start_index).map_err(|_| DirectoryChunkError::TooLarge)?;
+        u32::try_from(end_index - start_index).map_err(|_| DirectoryPayloadError::TooLarge)?;
     output[..size_of::<u32>()].copy_from_slice(&count.to_le_bytes());
     let next_index = if end_index == entries.len() {
         None
     } else {
-        Some(u64::try_from(end_index).map_err(|_| DirectoryChunkError::TooLarge)?)
+        Some(u64::try_from(end_index).map_err(|_| DirectoryPayloadError::TooLarge)?)
     };
     Ok((output, next_index))
 }
 
 /// Decodes directory entries from one fs shared-buffer transfer.
+///
+/// Allocation failures are reported as [`DirectoryPayloadError::TooLarge`] for
+/// compatibility with the original codec API.
 pub fn decode_directory_entries(
     payload: &[u8],
 ) -> Result<Vec<FileDirectoryEntry>, DirectoryPayloadError> {
+    try_decode_directory_entries(payload).map_err(DirectoryTransferError::into_payload_error)
+}
+
+/// Decodes directory entries while distinguishing allocation failure.
+pub fn try_decode_directory_entries(
+    payload: &[u8],
+) -> Result<Vec<FileDirectoryEntry>, DirectoryTransferError> {
     const MINIMUM_ENTRY_LENGTH: usize = size_of::<u32>() + 2;
 
     if payload.len() > MAX_FILE_TRANSFER_SIZE as usize {
-        return Err(DirectoryPayloadError::TooLarge);
+        return Err(DirectoryPayloadError::TooLarge.into());
     }
     let mut decoder = DirectoryPayloadDecoder { payload, offset: 0 };
     let count = decoder.u32()? as usize;
     if count > (decoder.payload.len() - decoder.offset) / MINIMUM_ENTRY_LENGTH {
-        return Err(DirectoryPayloadError::Malformed);
+        return Err(DirectoryPayloadError::Malformed.into());
     }
     let mut entries = Vec::new();
     entries
         .try_reserve_exact(count)
-        .map_err(|_| DirectoryPayloadError::OutOfMemory)?;
+        .map_err(|_| DirectoryTransferError::OutOfMemory)?;
     for _ in 0..count {
         let name_len = decoder.u32()? as usize;
         let encoded_name = core::str::from_utf8(decoder.take(name_len)?)
             .map_err(|_| DirectoryPayloadError::Malformed)?;
         let mut name = String::new();
         name.try_reserve_exact(encoded_name.len())
-            .map_err(|_| DirectoryPayloadError::OutOfMemory)?;
+            .map_err(|_| DirectoryTransferError::OutOfMemory)?;
         name.push_str(encoded_name);
         let file_type =
             file_type_from_raw(decoder.u8()?).ok_or(DirectoryPayloadError::Malformed)?;
@@ -538,11 +555,11 @@ pub fn decode_directory_entries(
                 let rdev = match decoder.u8()? {
                     0 => None,
                     1 => Some(decoder.u64()?),
-                    _ => return Err(DirectoryPayloadError::Malformed),
+                    _ => return Err(DirectoryPayloadError::Malformed.into()),
                 };
                 Some(FileNodeInfo { dev, ino, rdev })
             }
-            _ => return Err(DirectoryPayloadError::Malformed),
+            _ => return Err(DirectoryPayloadError::Malformed.into()),
         };
         entries.push(FileDirectoryEntry {
             name,
@@ -551,7 +568,7 @@ pub fn decode_directory_entries(
         });
     }
     if decoder.offset != payload.len() {
-        return Err(DirectoryPayloadError::Malformed);
+        return Err(DirectoryPayloadError::Malformed.into());
     }
     Ok(entries)
 }
@@ -598,26 +615,23 @@ fn directory_entries_chunk_end(
     entries: &[FileDirectoryEntry],
     start_index: usize,
     maximum_length: usize,
-) -> Result<(usize, usize), DirectoryChunkError> {
+) -> Result<(usize, usize), DirectoryPayloadError> {
     if start_index > entries.len()
         || !(size_of::<u32>()..=MAX_FILE_TRANSFER_SIZE as usize).contains(&maximum_length)
     {
-        return Err(DirectoryChunkError::TooLarge);
+        return Err(DirectoryPayloadError::TooLarge);
     }
     let mut encoded_length = size_of::<u32>();
     let mut end_index = start_index;
     while let Some(entry) = entries.get(end_index) {
         encoded_length = encoded_length
-            .checked_add(
-                encoded_directory_entry_length(entry).map_err(|_| DirectoryChunkError::TooLarge)?,
-            )
-            .ok_or(DirectoryChunkError::TooLarge)?;
+            .checked_add(encoded_directory_entry_length(entry)?)
+            .ok_or(DirectoryPayloadError::TooLarge)?;
         if encoded_length > maximum_length {
             if end_index == start_index {
-                return Err(DirectoryChunkError::TooLarge);
+                return Err(DirectoryPayloadError::TooLarge);
             }
-            encoded_length -=
-                encoded_directory_entry_length(entry).map_err(|_| DirectoryChunkError::TooLarge)?;
+            encoded_length -= encoded_directory_entry_length(entry)?;
             break;
         }
         end_index += 1;


### PR DESCRIPTION
This PR wires the existing broker file ABI through broker-host request dispatch and typed broker-local calls, integrates file shared-buffer descriptors with association slot lifecycle tracking, and adds bounded, fallible directory-page encoding and decoding with focused protocol, local-adapter, and host/core integration coverage.