### PR TITLE
Fix Windows classic and thread-ID alert wait semantics

### DIFF
--- a/litebox_shim_windows/src/lib.rs
+++ b/litebox_shim_windows/src/lib.rs
@@ -2120,8 +2120,8 @@ impl<Platform: ShimPlatform> Task<Platform> {
             SyscallRequest::NtWaitForAlertByThreadId { address, timeout } => {
                 self.sys_nt_wait_for_alert_by_thread_id(address, timeout)
             }
-            SyscallRequest::NtAlertThreadByThreadIdEx { thread_id, address } => {
-                self.sys_nt_alert_thread_by_thread_id_ex(thread_id, address)
+            SyscallRequest::NtAlertThreadByThreadIdEx { thread_id, lock } => {
+                self.sys_nt_alert_thread_by_thread_id_ex(thread_id, lock)
             }
             SyscallRequest::NtAlertThreadByThreadId { thread_id } => {
                 self.sys_nt_alert_thread_by_thread_id(thread_id)
@@ -2492,7 +2492,7 @@ impl<Platform: ShimPlatform> Task<Platform> {
 
     fn test_alert(&self) -> NtStatus {
         // TODO(windows-apc): Deliver queued user-mode APCs here.
-        if self.thread_object.take_pending_thread_alert() {
+        if self.thread_object.take_pending_classic_alert() {
             NtStatus::ALERTED
         } else {
             NtStatus::SUCCESS

--- a/litebox_shim_windows/src/syscalls/iocp.rs
+++ b/litebox_shim_windows/src/syscalls/iocp.rs
@@ -462,7 +462,7 @@ impl<Platform: crate::ShimPlatform> Task<Platform> {
                 Ok(())
             },
             || {
-                if alertable && self.thread_object.take_pending_thread_alert() {
+                if alertable && self.thread_object.take_pending_classic_alert() {
                     return Err(TryOpError::WaitError(WaitError::Interrupted));
                 }
                 match port.remove_with_capacity(

--- a/litebox_shim_windows/src/syscalls/mod.rs
+++ b/litebox_shim_windows/src/syscalls/mod.rs
@@ -794,7 +794,7 @@ pub(crate) enum SyscallRequest<Platform: RawPointerProvider> {
     },
     NtAlertThreadByThreadIdEx {
         thread_id: usize,
-        address: usize,
+        lock: usize,
     },
     NtAlertThreadByThreadId {
         thread_id: usize,
@@ -1646,7 +1646,7 @@ impl<Platform: RawPointerProvider> SyscallRequest<Platform> {
                 timeout:*,
             })),
             NtSysno::NtAlertThreadByThreadIdEx => {
-                Some(sys_req!(NtAlertThreadByThreadIdEx { thread_id, address }))
+                Some(sys_req!(NtAlertThreadByThreadIdEx { thread_id, lock }))
             }
             NtSysno::NtAlertThreadByThreadId => {
                 Some(sys_req!(NtAlertThreadByThreadId { thread_id }))

--- a/litebox_shim_windows/src/syscalls/thread.rs
+++ b/litebox_shim_windows/src/syscalls/thread.rs
@@ -934,26 +934,19 @@ mod tests {
     fn wait_for_alert_by_thread_id_blocks_until_alert() {
         run_with_test_platform_pointers(|| {
             let alerter = crate::tests::test_task();
-            let waiter = alerter
-                .clone_for_test()
-                .expect("a live process should accept another thread");
-            let waiter_thread = Arc::clone(&waiter.thread_object);
-            let thread_id = waiter_thread.thread_id();
             let wait_address = 0x1234;
             let (result_tx, result_rx) = std::sync::mpsc::channel();
-            let thread = std::thread::spawn(move || {
-                run_with_test_platform_pointers(|| {
-                    waiter.publish_thread_handle();
-                    let timeout = -10_000_000i64;
-                    result_tx
-                        .send(waiter.sys_nt_wait_for_alert_by_thread_id(
-                            wait_address,
-                            Some(const_ptr(&timeout)),
-                        ))
-                        .unwrap();
-                });
+            let (thread, waiter_thread) = alerter.spawn_clone_for_test(move |waiter| {
+                let timeout = -10_000_000i64;
+                result_tx
+                    .send(waiter.sys_nt_wait_for_alert_by_thread_id(
+                        wait_address,
+                        Some(const_ptr(&timeout)),
+                    ))
+                    .unwrap();
             });
 
+            let thread_id = waiter_thread.thread_id();
             let deadline = Instant::now() + Duration::from_secs(2);
             while !waiter_thread.thread_id_alert_state.lock().waiting {
                 assert!(Instant::now() < deadline, "waiter did not enter alert wait");
@@ -980,57 +973,18 @@ mod tests {
     }
 
     #[test]
-    fn alerts_before_wait_coalesce() {
-        run_with_test_platform_pointers(|| {
-            let alerter = crate::tests::test_task();
-            let waiter = alerter
-                .clone_for_test()
-                .expect("a live process should accept another thread");
-            let thread_id = waiter.thread_object.thread_id();
-            let alert_lock = 0;
-
-            assert_eq!(
-                alerter.sys_nt_alert_thread_by_thread_id_ex(thread_id, alert_lock),
-                NtStatus::SUCCESS
-            );
-            assert_eq!(
-                alerter.sys_nt_alert_thread_by_thread_id_ex(thread_id, alert_lock),
-                NtStatus::SUCCESS
-            );
-            let timeout = 0i64;
-            assert_eq!(
-                waiter.sys_nt_wait_for_alert_by_thread_id(0x1234, Some(const_ptr(&timeout))),
-                NtStatus::ALERTED
-            );
-            assert_eq!(
-                waiter.sys_nt_wait_for_alert_by_thread_id(0x5678, Some(const_ptr(&timeout))),
-                NtStatus::TIMEOUT
-            );
-        });
-    }
-
-    #[test]
     fn classic_alert_does_not_satisfy_thread_id_alert_wait() {
         run_with_test_platform_pointers(|| {
             let alerter = crate::tests::test_task();
-            let waiter = alerter
-                .clone_for_test()
-                .expect("a live process should accept another thread");
-            let waiter_thread = Arc::clone(&waiter.thread_object);
-            let thread_id = waiter_thread.thread_id();
             let (result_tx, result_rx) = std::sync::mpsc::channel();
-            let thread = std::thread::spawn(move || {
-                run_with_test_platform_pointers(|| {
-                    waiter.publish_thread_handle();
-                    let timeout = -10_000_000i64;
-                    result_tx
-                        .send(
-                            waiter.sys_nt_wait_for_alert_by_thread_id(0, Some(const_ptr(&timeout))),
-                        )
-                        .unwrap();
-                });
+            let (thread, waiter_thread) = alerter.spawn_clone_for_test(move |waiter| {
+                let timeout = -10_000_000i64;
+                result_tx
+                    .send(waiter.sys_nt_wait_for_alert_by_thread_id(0, Some(const_ptr(&timeout))))
+                    .unwrap();
             });
 
+            let thread_id = waiter_thread.thread_id();
             let deadline = Instant::now() + Duration::from_secs(2);
             while !waiter_thread.thread_id_alert_state.lock().waiting {
                 assert!(Instant::now() < deadline, "waiter did not enter alert wait");
@@ -1058,28 +1012,21 @@ mod tests {
     fn alert_wakes_an_alertable_wait() {
         run_with_test_platform_pointers(|| {
             let parent = crate::tests::test_task();
-            let waiter = parent
-                .clone_for_test()
-                .expect("a live process should accept another thread");
-            let waiter_thread = Arc::clone(&waiter.thread_object);
             let (registered_tx, registered_rx) = std::sync::mpsc::channel();
             let (result_tx, result_rx) = std::sync::mpsc::channel();
-            let thread = std::thread::spawn(move || {
-                run_with_test_platform_pointers(|| {
-                    waiter.publish_thread_handle();
-                    let result: Result<(), TryOpError<NtStatus>> = waiter.wait_on_events(
-                        false,
-                        true,
-                        None,
-                        Events::IN,
-                        |_, _| {
-                            registered_tx.send(()).unwrap();
-                            Ok(())
-                        },
-                        || Err(TryOpError::TryAgain),
-                    );
-                    result_tx.send(result).unwrap();
-                });
+            let (thread, waiter_thread) = parent.spawn_clone_for_test(move |waiter| {
+                let result: Result<(), TryOpError<NtStatus>> = waiter.wait_on_events(
+                    false,
+                    true,
+                    None,
+                    Events::IN,
+                    |_, _| {
+                        registered_tx.send(()).unwrap();
+                        Ok(())
+                    },
+                    || Err(TryOpError::TryAgain),
+                );
+                result_tx.send(result).unwrap();
             });
 
             registered_rx.recv().unwrap();
@@ -1097,36 +1044,29 @@ mod tests {
     fn non_alertable_wait_preserves_pending_alert() {
         run_with_test_platform_pointers(|| {
             let parent = crate::tests::test_task();
-            let waiter = parent
-                .clone_for_test()
-                .expect("a live process should accept another thread");
-            let waiter_thread = Arc::clone(&waiter.thread_object);
             let ready = Arc::new(AtomicBool::new(false));
             let wait_ready = Arc::clone(&ready);
             let (registered_tx, registered_rx) = std::sync::mpsc::channel();
             let (result_tx, result_rx) = std::sync::mpsc::channel();
-            let thread = std::thread::spawn(move || {
-                run_with_test_platform_pointers(|| {
-                    waiter.publish_thread_handle();
-                    let result: Result<(), TryOpError<NtStatus>> = waiter.wait_on_events(
-                        false,
-                        false,
-                        None,
-                        Events::IN,
-                        |observer, _| {
-                            registered_tx.send(observer).unwrap();
+            let (thread, waiter_thread) = parent.spawn_clone_for_test(move |waiter| {
+                let result: Result<(), TryOpError<NtStatus>> = waiter.wait_on_events(
+                    false,
+                    false,
+                    None,
+                    Events::IN,
+                    |observer, _| {
+                        registered_tx.send(observer).unwrap();
+                        Ok(())
+                    },
+                    || {
+                        if wait_ready.load(Ordering::Acquire) {
                             Ok(())
-                        },
-                        || {
-                            if wait_ready.load(Ordering::Acquire) {
-                                Ok(())
-                            } else {
-                                Err(TryOpError::TryAgain)
-                            }
-                        },
-                    );
-                    result_tx.send(result).unwrap();
-                });
+                        } else {
+                            Err(TryOpError::TryAgain)
+                        }
+                    },
+                );
+                result_tx.send(result).unwrap();
             });
 
             let observer = registered_rx.recv().unwrap();
@@ -1150,45 +1090,31 @@ mod tests {
     fn suspended_thread_does_not_enter_guest_until_resumed() {
         run_with_test_platform_pointers(|| {
             let parent = crate::tests::test_task();
-            let child = parent
-                .clone_for_test()
-                .expect("a live process should accept another thread");
+            let (started_tx, started_rx) = std::sync::mpsc::channel();
+            let (result_tx, result_rx) = std::sync::mpsc::channel();
+            let (thread, suspended_thread) = parent.spawn_clone_for_test(move |child| {
+                child
+                    .thread_object
+                    .suspend_count
+                    .store(1, Ordering::Release);
+                started_tx.send(()).unwrap();
+                let mut ctx = litebox_common_linux::PtRegs::default();
+                let ready = child.prepare_to_run_guest(&mut ctx);
+                result_tx.send(ready).unwrap();
+            });
+
+            started_rx.recv().unwrap();
+            assert!(suspended_thread.wait_handle.get().is_some());
             let handle = parent
                 .insert_typed_handle::<ThreadSubsystem<_>>(
                     ThreadHandleObject {
-                        thread: Arc::clone(&child.thread_object),
+                        thread: Arc::clone(&suspended_thread),
                     },
                     ThreadAccess::SUSPEND_RESUME.bits(),
                     drop,
                 )
                 .unwrap();
             let handle = ThreadHandle::from_raw(handle.as_raw());
-            child
-                .thread_object
-                .suspend_count
-                .store(1, Ordering::Release);
-            let suspended_thread = Arc::clone(&child.thread_object);
-            let (started_tx, started_rx) = std::sync::mpsc::channel();
-            let (result_tx, result_rx) = std::sync::mpsc::channel();
-            let thread = std::thread::spawn(move || {
-                run_with_test_platform_pointers(|| {
-                    child.publish_thread_handle();
-                    started_tx.send(()).unwrap();
-                    let mut ctx = litebox_common_linux::PtRegs::default();
-                    let ready = child.prepare_to_run_guest(&mut ctx);
-                    result_tx.send(ready).unwrap();
-                });
-            });
-
-            started_rx.recv().unwrap();
-            let deadline = Instant::now() + Duration::from_secs(2);
-            while suspended_thread.wait_handle.get().is_none() {
-                assert!(
-                    Instant::now() < deadline,
-                    "child did not publish wait handle"
-                );
-                std::thread::yield_now();
-            }
             assert_eq!(result_rx.try_recv(), Err(TryRecvError::Empty));
             let mut previous_suspend_count = u32::MAX;
             assert_eq!(

--- a/litebox_shim_windows/src/syscalls/thread.rs
+++ b/litebox_shim_windows/src/syscalls/thread.rs
@@ -105,9 +105,30 @@ pub(crate) struct ThreadHandleObject<Platform: ShimPlatform> {
 }
 
 #[derive(Default)]
-struct KeyedAlertState {
-    wait_address: Option<usize>,
+struct AlertState {
+    waiting: bool,
     pending: bool,
+}
+
+impl AlertState {
+    fn begin_wait(&mut self) {
+        debug_assert!(!self.waiting);
+        self.waiting = true;
+    }
+
+    fn take_pending(&mut self) -> bool {
+        core::mem::take(&mut self.pending)
+    }
+
+    fn end_wait(&mut self) {
+        debug_assert!(self.waiting);
+        self.waiting = false;
+    }
+
+    fn set_pending(&mut self) -> bool {
+        self.pending = true;
+        self.waiting
+    }
 }
 
 pub(crate) struct ThreadObject<Platform: ShimPlatform> {
@@ -123,8 +144,8 @@ pub(crate) struct ThreadObject<Platform: ShimPlatform> {
     /// Handle used to interrupt the thread, published once by the thread itself
     /// when it starts running. Empty until then.
     wait_handle: once_cell::race::OnceBox<litebox::event::wait::ThreadHandle<Platform>>,
-    thread_alert_pending: AtomicBool,
-    keyed_alert_state: Mutex<Platform, KeyedAlertState>,
+    alert_state: Mutex<Platform, AlertState>,
+    thread_id_alert_state: Mutex<Platform, AlertState>,
     owned_mutants: Mutex<Platform, Vec<Weak<MutantObject<Platform>>>>,
 }
 
@@ -147,8 +168,8 @@ impl<Platform: ShimPlatform> ThreadObject<Platform> {
             is_exiting: AtomicBool::new(false),
             suspend_count: AtomicU32::new(suspend_count),
             wait_handle: once_cell::race::OnceBox::new(),
-            thread_alert_pending: AtomicBool::new(false),
-            keyed_alert_state: Mutex::new(KeyedAlertState::default()),
+            alert_state: Mutex::new(AlertState::default()),
+            thread_id_alert_state: Mutex::new(AlertState::default()),
             owned_mutants: Mutex::new(Vec::new()),
         }
     }
@@ -222,44 +243,44 @@ impl<Platform: ShimPlatform> ThreadObject<Platform> {
         }
     }
 
-    fn begin_keyed_alert_wait(&self, address: usize) {
-        let mut state = self.keyed_alert_state.lock();
-        debug_assert!(state.wait_address.is_none());
-        state.wait_address = Some(address);
+    fn begin_thread_id_alert_wait(&self) {
+        self.thread_id_alert_state.lock().begin_wait();
     }
 
-    fn take_keyed_alert(&self, address: usize) -> bool {
-        let mut state = self.keyed_alert_state.lock();
-        debug_assert_eq!(state.wait_address, Some(address));
-        core::mem::take(&mut state.pending)
+    fn take_thread_id_alert(&self) -> bool {
+        let mut state = self.thread_id_alert_state.lock();
+        debug_assert!(state.waiting);
+        state.take_pending()
     }
 
-    fn end_keyed_alert_wait(&self, address: usize) -> bool {
-        let mut state = self.keyed_alert_state.lock();
-        debug_assert_eq!(state.wait_address, Some(address));
-        state.wait_address = None;
-        core::mem::take(&mut state.pending)
+    fn end_thread_id_alert_wait(&self) -> bool {
+        let mut state = self.thread_id_alert_state.lock();
+        state.end_wait();
+        state.take_pending()
     }
 
-    fn alert_keyed_wait(&self, address: Option<usize>) {
-        let mut state = self.keyed_alert_state.lock();
-        if address.is_some() && state.wait_address != address {
-            return;
-        }
-        state.pending = true;
-        drop(state);
-        if let Some(handle) = self.wait_handle.get() {
+    fn set_thread_id_alert(&self) {
+        let waiting = self.thread_id_alert_state.lock().set_pending();
+        if waiting && let Some(handle) = self.wait_handle.get() {
             handle.interrupt();
         }
     }
 
-    pub(crate) fn take_pending_thread_alert(&self) -> bool {
-        self.thread_alert_pending.swap(false, Ordering::AcqRel)
+    pub(crate) fn begin_classic_alert_wait(&self) {
+        self.alert_state.lock().begin_wait();
     }
 
-    fn set_thread_alert(&self) {
-        self.thread_alert_pending.store(true, Ordering::Release);
-        if let Some(handle) = self.wait_handle.get() {
+    pub(crate) fn end_classic_alert_wait(&self) {
+        self.alert_state.lock().end_wait();
+    }
+
+    pub(crate) fn take_pending_classic_alert(&self) -> bool {
+        self.alert_state.lock().take_pending()
+    }
+
+    fn set_classic_alert(&self) {
+        let waiting = self.alert_state.lock().set_pending();
+        if waiting && let Some(handle) = self.wait_handle.get() {
             handle.interrupt();
         }
     }
@@ -574,7 +595,7 @@ impl<Platform: ShimPlatform> Task<Platform> {
 
     pub(crate) fn sys_nt_alert_thread(&self, thread_handle: ThreadHandle) -> NtStatus {
         if thread_handle.is_current() {
-            self.thread_object.set_thread_alert();
+            self.thread_object.set_classic_alert();
         } else {
             let entry = match self.typed_handle_entry_with_access::<ThreadSubsystem<Platform>>(
                 thread_handle.as_handle(),
@@ -583,14 +604,14 @@ impl<Platform: ShimPlatform> Task<Platform> {
                 Ok(entry) => entry,
                 Err(status) => return status,
             };
-            entry.with_entry(|entry| entry.thread.set_thread_alert());
+            entry.with_entry(|entry| entry.thread.set_classic_alert());
         }
         NtStatus::SUCCESS
     }
 
     pub(crate) fn sys_nt_wait_for_alert_by_thread_id(
         &self,
-        address: usize,
+        _address: usize,
         timeout: Option<ConstPtr<Platform, i64>>,
     ) -> NtStatus {
         let timeout = match timeout {
@@ -600,9 +621,9 @@ impl<Platform: ShimPlatform> Task<Platform> {
             },
             None => None,
         };
-        self.thread_object.begin_keyed_alert_wait(address);
-        let result = self.wait_until(timeout, || self.thread_object.take_keyed_alert(address));
-        let alert_raced_with_completion = self.thread_object.end_keyed_alert_wait(address);
+        self.thread_object.begin_thread_id_alert_wait();
+        let result = self.wait_until(timeout, || self.thread_object.take_thread_id_alert());
+        let alert_raced_with_completion = self.thread_object.end_thread_id_alert_wait();
         match result {
             Ok(()) | Err(litebox::event::wait::WaitError::Interrupted) => NtStatus::ALERTED,
             Err(litebox::event::wait::WaitError::TimedOut) if alert_raced_with_completion => {
@@ -615,12 +636,13 @@ impl<Platform: ShimPlatform> Task<Platform> {
     pub(crate) fn sys_nt_alert_thread_by_thread_id_ex(
         &self,
         thread_id: usize,
-        address: usize,
+        _lock: usize,
     ) -> NtStatus {
+        // TODO(thread-alert-autoboost): Model the optional SRW lock's AutoBoost bookkeeping.
         let Some(thread) = self.process.thread_by_id(thread_id) else {
             return NtStatus::INVALID_CID;
         };
-        thread.alert_keyed_wait(Some(address));
+        thread.set_thread_id_alert();
         NtStatus::SUCCESS
     }
 
@@ -628,7 +650,7 @@ impl<Platform: ShimPlatform> Task<Platform> {
         let Some(thread) = self.process.thread_by_id(thread_id) else {
             return NtStatus::INVALID_CID;
         };
-        thread.alert_keyed_wait(None);
+        thread.set_thread_id_alert();
         NtStatus::SUCCESS
     }
 
@@ -909,7 +931,7 @@ mod tests {
     }
 
     #[test]
-    fn wait_for_alert_by_thread_id_blocks_until_matching_alert() {
+    fn wait_for_alert_by_thread_id_blocks_until_alert() {
         run_with_test_platform_pointers(|| {
             let alerter = crate::tests::test_task();
             let waiter = alerter
@@ -933,13 +955,13 @@ mod tests {
             });
 
             let deadline = Instant::now() + Duration::from_secs(2);
-            while waiter_thread.keyed_alert_state.lock().wait_address != Some(wait_address) {
+            while !waiter_thread.thread_id_alert_state.lock().waiting {
                 assert!(Instant::now() < deadline, "waiter did not enter alert wait");
                 std::thread::yield_now();
             }
             assert_eq!(result_rx.try_recv(), Err(TryRecvError::Empty));
             assert_eq!(
-                alerter.sys_nt_alert_thread_by_thread_id_ex(thread_id, wait_address),
+                alerter.sys_nt_alert_thread_by_thread_id_ex(thread_id, 0),
                 NtStatus::SUCCESS
             );
             assert_eq!(
@@ -954,6 +976,81 @@ mod tests {
                     .sys_nt_wait_for_alert_by_thread_id(wait_address, Some(const_ptr(&timeout)),),
                 NtStatus::TIMEOUT
             );
+        });
+    }
+
+    #[test]
+    fn alerts_before_wait_coalesce() {
+        run_with_test_platform_pointers(|| {
+            let alerter = crate::tests::test_task();
+            let waiter = alerter
+                .clone_for_test()
+                .expect("a live process should accept another thread");
+            let thread_id = waiter.thread_object.thread_id();
+            let alert_lock = 0;
+
+            assert_eq!(
+                alerter.sys_nt_alert_thread_by_thread_id_ex(thread_id, alert_lock),
+                NtStatus::SUCCESS
+            );
+            assert_eq!(
+                alerter.sys_nt_alert_thread_by_thread_id_ex(thread_id, alert_lock),
+                NtStatus::SUCCESS
+            );
+            let timeout = 0i64;
+            assert_eq!(
+                waiter.sys_nt_wait_for_alert_by_thread_id(0x1234, Some(const_ptr(&timeout))),
+                NtStatus::ALERTED
+            );
+            assert_eq!(
+                waiter.sys_nt_wait_for_alert_by_thread_id(0x5678, Some(const_ptr(&timeout))),
+                NtStatus::TIMEOUT
+            );
+        });
+    }
+
+    #[test]
+    fn classic_alert_does_not_satisfy_thread_id_alert_wait() {
+        run_with_test_platform_pointers(|| {
+            let alerter = crate::tests::test_task();
+            let waiter = alerter
+                .clone_for_test()
+                .expect("a live process should accept another thread");
+            let waiter_thread = Arc::clone(&waiter.thread_object);
+            let thread_id = waiter_thread.thread_id();
+            let (result_tx, result_rx) = std::sync::mpsc::channel();
+            let thread = std::thread::spawn(move || {
+                run_with_test_platform_pointers(|| {
+                    waiter.publish_thread_handle();
+                    let timeout = -10_000_000i64;
+                    result_tx
+                        .send(
+                            waiter.sys_nt_wait_for_alert_by_thread_id(0, Some(const_ptr(&timeout))),
+                        )
+                        .unwrap();
+                });
+            });
+
+            let deadline = Instant::now() + Duration::from_secs(2);
+            while !waiter_thread.thread_id_alert_state.lock().waiting {
+                assert!(Instant::now() < deadline, "waiter did not enter alert wait");
+                std::thread::yield_now();
+            }
+            waiter_thread.set_classic_alert();
+            assert_eq!(
+                result_rx.recv_timeout(Duration::from_millis(50)),
+                Err(std::sync::mpsc::RecvTimeoutError::Timeout)
+            );
+            assert_eq!(
+                alerter.sys_nt_alert_thread_by_thread_id(thread_id),
+                NtStatus::SUCCESS
+            );
+            assert_eq!(
+                result_rx.recv_timeout(Duration::from_secs(2)).unwrap(),
+                NtStatus::ALERTED
+            );
+            thread.join().unwrap();
+            assert!(waiter_thread.take_pending_classic_alert());
         });
     }
 
@@ -986,13 +1083,13 @@ mod tests {
             });
 
             registered_rx.recv().unwrap();
-            waiter_thread.set_thread_alert();
+            waiter_thread.set_classic_alert();
             assert!(matches!(
                 result_rx.recv_timeout(Duration::from_secs(2)).unwrap(),
                 Err(TryOpError::WaitError(WaitError::Interrupted))
             ));
             thread.join().unwrap();
-            assert!(!waiter_thread.take_pending_thread_alert());
+            assert!(!waiter_thread.take_pending_classic_alert());
         });
     }
 
@@ -1033,7 +1130,7 @@ mod tests {
             });
 
             let observer = registered_rx.recv().unwrap();
-            waiter_thread.set_thread_alert();
+            waiter_thread.set_classic_alert();
             assert!(matches!(result_rx.try_recv(), Err(TryRecvError::Empty)));
             ready.store(true, Ordering::Release);
             observer.upgrade().unwrap().on_events(&Events::IN);
@@ -1044,8 +1141,8 @@ mod tests {
                     .is_ok()
             );
             thread.join().unwrap();
-            assert!(waiter_thread.take_pending_thread_alert());
-            assert!(!waiter_thread.take_pending_thread_alert());
+            assert!(waiter_thread.take_pending_classic_alert());
+            assert!(!waiter_thread.take_pending_classic_alert());
         });
     }
 

--- a/litebox_shim_windows/src/syscalls/wait.rs
+++ b/litebox_shim_windows/src/syscalls/wait.rs
@@ -127,7 +127,7 @@ impl<Platform: ShimPlatform> Task<Platform> {
                 Ok(())
             },
             || {
-                if alertable && self.thread_object.take_pending_thread_alert() {
+                if alertable && self.thread_object.take_pending_classic_alert() {
                     return Err(TryOpError::WaitError(WaitError::Interrupted));
                 }
                 object
@@ -155,7 +155,7 @@ impl<Platform: ShimPlatform> Task<Platform> {
             return NtStatus::ACCESS_VIOLATION;
         };
         // TODO(windows-apc): deliver user APCs during alertable delays.
-        if alertable && self.thread_object.take_pending_thread_alert() {
+        if alertable && self.thread_object.take_pending_classic_alert() {
             return NtStatus::ALERTED;
         }
 

--- a/litebox_shim_windows/src/tests.rs
+++ b/litebox_shim_windows/src/tests.rs
@@ -12,7 +12,7 @@ use litebox::utils::TruncateExt as _;
 
 use crate::nt_types::{ObjectAttributes, UnicodeString};
 use crate::syscalls::Handle;
-use crate::syscalls::thread::{ThreadAccess, ThreadSubsystem};
+use crate::syscalls::thread::{ThreadAccess, ThreadObject, ThreadSubsystem};
 use crate::{ConstPtr, MutPtr, Process, ShimPlatform, Task, WindowsShim};
 
 #[cfg(target_os = "linux")]
@@ -218,6 +218,34 @@ impl<Platform: ShimPlatform> Task<Platform> {
     /// zeroed because such a task never runs guest code.
     pub(crate) fn clone_for_test(&self) -> Option<Self> {
         self.clone_for_test_with_teb(0)
+    }
+
+    /// Spawns a sibling task with platform test-thread state and its interrupt handle initialized.
+    ///
+    /// Returns its join handle and shared thread object. Initialization happens on the spawned
+    /// thread before `run`, so returning does not guarantee the thread has started or is waiting.
+    ///
+    /// # Panics
+    /// Panics if the test process is already terminating.
+    #[must_use]
+    pub(crate) fn spawn_clone_for_test<R>(
+        &self,
+        run: impl 'static + Send + FnOnce(Task<Platform>) -> R,
+    ) -> (std::thread::JoinHandle<R>, Arc<ThreadObject<Platform>>)
+    where
+        R: 'static + Send,
+    {
+        let task = self
+            .clone_for_test()
+            .expect("a live process should accept another thread");
+        let thread_object = Arc::clone(&task.thread_object);
+        let thread = std::thread::spawn(move || {
+            <Platform as litebox::platform::ThreadProvider>::run_test_thread(|| {
+                task.publish_thread_handle();
+                run(task)
+            })
+        });
+        (thread, thread_object)
     }
 
     pub(crate) fn clone_for_test_with_teb(&self, teb_address: usize) -> Option<Self> {

--- a/litebox_shim_windows/src/wait.rs
+++ b/litebox_shim_windows/src/wait.rs
@@ -24,7 +24,7 @@ impl<Platform: ShimPlatform> litebox::event::wait::CheckForInterrupt
 {
     fn check_for_interrupt(&self) -> bool {
         self.task.thread_object.is_exiting()
-            || (self.alertable && self.task.thread_object.take_pending_thread_alert())
+            || (self.alertable && self.task.thread_object.take_pending_classic_alert())
     }
 }
 
@@ -71,6 +71,14 @@ impl<Platform: ShimPlatform> Task<Platform> {
         // The core helper probes again before blocking, so readiness racing with this point can
         // briefly release the IOCP slot without a host block. Exact accounting requires a hook
         // around WaitContext's platform block; keep this approximation local to the Windows shim.
+        if alertable {
+            self.thread_object.begin_classic_alert_wait();
+        }
+        let _end_alert_wait = litebox::utils::defer(|| {
+            if alertable {
+                self.thread_object.end_classic_alert_wait();
+            }
+        });
         self.with_io_completion_worker_suspended(|| {
             let interrupt = WaitInterrupt {
                 task: self,
@@ -105,6 +113,14 @@ impl<Platform: ShimPlatform> Task<Platform> {
         alertable: bool,
         timeout: core::time::Duration,
     ) -> litebox::event::wait::WaitError {
+        if alertable {
+            self.thread_object.begin_classic_alert_wait();
+        }
+        let _end_alert_wait = litebox::utils::defer(|| {
+            if alertable {
+                self.thread_object.end_classic_alert_wait();
+            }
+        });
         self.with_io_completion_worker_suspended(|| {
             let interrupt = WaitInterrupt {
                 task: self,


### PR DESCRIPTION
The previous implementation conflated classic and thread-ID alerts and incorrectly tied thread-ID alerts to an address. This could cause incorrect wakeups and alert consumption.