### PR TITLE
Preallocate AArch64 trampolines using ELF rewrite-site scan

### DIFF
--- a/litebox_shim_linux/src/syscalls/mm.rs
+++ b/litebox_shim_linux/src/syscalls/mm.rs
@@ -29,7 +29,7 @@ use litebox::utils::ReinterpretUnsignedExt as _;
 use litebox::utils::TruncateExt as _;
 use object::elf::{ET_DYN, FileHeader64, PT_LOAD, ProgramHeader64};
 use object::endian::LittleEndian;
-#[cfg(all(target_arch = "aarch64", feature = "aarch64_virtualize_x18"))]
+#[cfg(target_arch = "aarch64")]
 use zerocopy::FromZeros as _;
 
 #[cfg(not(target_pointer_width = "64"))]
@@ -106,8 +106,11 @@ pub(crate) struct ElfPatchState {
     runtime_patches_committed: bool,
     #[cfg(target_arch = "aarch64")]
     trampoline_invalidated: bool,
-    #[cfg(all(target_arch = "aarch64", feature = "aarch64_virtualize_x18"))]
+    #[cfg(target_arch = "aarch64")]
     code_metadata: Option<litebox_syscall_rewriter::aarch64::ElfCodeMetadata>,
+    /// Pre-scanned, page-aligned trampoline capacity.
+    #[cfg(target_arch = "aarch64")]
+    trampoline_capacity: usize,
     /// Tracks file-backed mappings for this fd as (vaddr, len) pairs.
     /// Used to find mappings that need patching when mprotect adds PROT_EXEC.
     /// Cleared on munmap to allow re-patching.
@@ -803,43 +806,57 @@ impl<Platform: ShimPlatform> Task<Platform> {
         let (pre_patched, tramp_file_offset, tramp_vaddr, tramp_file_size) =
             self.check_trampoline_magic(fd);
 
-        #[cfg(all(target_arch = "aarch64", feature = "aarch64_virtualize_x18"))]
-        let code_metadata = if pre_patched {
-            None
+        #[cfg(target_arch = "aarch64")]
+        let (code_metadata, trampoline_capacity) = if pre_patched {
+            (None, 0)
         } else {
-            self.sys_fstat(fd).ok().and_then(|stat| {
+            let scanned = self.sys_fstat(fd).ok().and_then(|stat| {
                 let file_size: usize = stat.st_size.reinterpret_as_unsigned().trunc();
                 let word_len = file_size.div_ceil(8);
                 let mut words = u64::new_vec_zeroed(word_len).ok()?;
                 let bytes = zerocopy::IntoBytes::as_mut_bytes(words.as_mut_slice());
                 match self.sys_read(fd, &mut bytes[..file_size], Some(0)) {
                     Ok(n) if n == file_size => {
-                        litebox_syscall_rewriter::aarch64::ElfCodeMetadata::parse_aligned_in_place(
+                        let metadata = litebox_syscall_rewriter::aarch64::ElfCodeMetadata::parse_aligned_in_place(
                             &mut words, file_size,
-                        )
-                        .ok()
+                        ).ok()?;
+                        let upper_bound = metadata
+                            .trampoline_size_upper_bound(
+                                &zerocopy::IntoBytes::as_bytes(words.as_slice())[..file_size],
+                                crate::aarch64_rewrite_options(),
+                            )
+                            .ok();
+                        Some((metadata, upper_bound))
                     }
                     _ => None,
                 }
-            })
-        };
-        #[cfg(all(target_arch = "aarch64", feature = "aarch64_virtualize_x18"))]
-        if !pre_patched {
-            if let Some(metadata) = &code_metadata {
+            });
+            if let Some((metadata, upper_bound)) = scanned {
                 let (executable_bytes, identified_bytes) = metadata.coverage_bytes();
+                let initial_cursor = litebox_syscall_rewriter::TRAMPOLINE_ENTRY_POINT_BYTES
+                    .checked_next_multiple_of(litebox_syscall_rewriter::TRAMPOLINE_CURSOR_ALIGN);
+                let capacity = upper_bound
+                    .zip(initial_cursor)
+                    .and_then(|(bound, cursor)| bound.checked_add(cursor))
+                    .and_then(|bound| bound.checked_next_multiple_of(PAGE_SIZE))
+                    .unwrap_or(PAGE_SIZE);
                 litebox_util_log::debug!(
                     fd:? = fd,
                     executable_bytes:? = executable_bytes,
-                    identified_bytes:? = identified_bytes;
-                    "collected AArch64 code metadata"
+                    identified_bytes:? = identified_bytes,
+                    trampoline_upper_bound:? = upper_bound,
+                    trampoline_capacity:? = capacity;
+                    "pre-scanned AArch64 ELF for runtime rewriting"
                 );
+                (Some(metadata), capacity)
             } else {
                 litebox_util_log::warn!(
                     fd:? = fd;
-                    "AArch64 code metadata unavailable; falling back to whole-mapping x18 scan"
+                    "AArch64 ELF pre-scan unavailable; using one-page trampoline with incremental fallback"
                 );
+                (None, PAGE_SIZE)
             }
-        }
+        };
 
         // Compute the trampoline virtual address.
         // - Pre-patched: use the exact address from the trampoline header (the
@@ -910,8 +927,10 @@ impl<Platform: ShimPlatform> Task<Platform> {
             runtime_patches_committed: false,
             #[cfg(target_arch = "aarch64")]
             trampoline_invalidated: false,
-            #[cfg(all(target_arch = "aarch64", feature = "aarch64_virtualize_x18"))]
+            #[cfg(target_arch = "aarch64")]
             code_metadata,
+            #[cfg(target_arch = "aarch64")]
+            trampoline_capacity,
             file_mappings: BTreeSet::new(),
             patched_ranges: BTreeSet::new(),
         });
@@ -1214,15 +1233,13 @@ impl<Platform: ShimPlatform> Task<Platform> {
 
         // ── Runtime patching path (unpatched binaries) ───────────────
 
-        #[cfg(all(target_arch = "aarch64", feature = "aarch64_virtualize_x18"))]
+        #[cfg(target_arch = "aarch64")]
         let scan_ranges = file_offset.and_then(|file_offset| {
             state
                 .code_metadata
                 .as_ref()
                 .and_then(|metadata| metadata.ranges_for_mapping(file_offset as u64, len).ok())
         });
-        #[cfg(all(target_arch = "aarch64", not(feature = "aarch64_virtualize_x18")))]
-        let scan_ranges: Option<litebox_syscall_rewriter::aarch64::CodeScanRanges> = None;
         #[cfg(target_arch = "aarch64")]
         let apply_trap_fallback = |mapped_addr, len, already_rw| {
             self.apply_aarch64_trap_fallback(mapped_addr, len, already_rw, scan_ranges.as_ref());
@@ -1236,34 +1253,55 @@ impl<Platform: ShimPlatform> Task<Platform> {
         let addr_usize = mapped_addr.as_usize();
         if !state.trampoline_mapped {
             let tramp_addr = state.trampoline_addr;
+            #[cfg(target_arch = "aarch64")]
+            let initial_trampoline_len = state.trampoline_capacity.max(PAGE_SIZE);
+            #[cfg(target_arch = "x86_64")]
+            let initial_trampoline_len = PAGE_SIZE;
 
-            // Try MAP_FIXED_NOREPLACE first — works when the preferred
-            // trampoline address is available. If that fails, let the VM
-            // manager choose a free address and validate that it is still
-            // within JMP rel32 range below.
-            let actual_addr = self
-                .do_mmap_anonymous(
-                    Some(tramp_addr),
-                    PAGE_SIZE,
-                    ProtFlags::PROT_READ | ProtFlags::PROT_WRITE,
-                    MapFlags::MAP_ANONYMOUS | MapFlags::MAP_PRIVATE | MapFlags::MAP_FIXED_NOREPLACE,
-                )
-                .or_else(|_| {
-                    self.do_mmap_anonymous(
-                        None,
-                        PAGE_SIZE,
-                        ProtFlags::PROT_READ | ProtFlags::PROT_WRITE,
-                        MapFlags::MAP_ANONYMOUS | MapFlags::MAP_PRIVATE,
-                    )
+            let map_preferred = |reservation_len| match self.do_mmap_anonymous(
+                Some(tramp_addr),
+                reservation_len,
+                ProtFlags::PROT_READ | ProtFlags::PROT_WRITE,
+                MapFlags::MAP_ANONYMOUS | MapFlags::MAP_PRIVATE | MapFlags::MAP_FIXED_NOREPLACE,
+            ) {
+                Ok(ptr) => {
+                    if ptr.as_usize() == tramp_addr {
+                        Some(ptr)
+                    } else {
+                        let _ = self.sys_munmap_raw(ptr, reservation_len);
+                        None
+                    }
+                }
+                Err(_) => None,
+            };
+            let preferred = map_preferred(initial_trampoline_len)
+                .map(|ptr| (ptr, initial_trampoline_len))
+                .or_else(|| {
+                    if initial_trampoline_len > PAGE_SIZE {
+                        map_preferred(PAGE_SIZE).map(|ptr| (ptr, PAGE_SIZE))
+                    } else {
+                        None
+                    }
                 });
-            let Ok(actual_addr_ptr) = actual_addr else {
-                litebox_util_log::warn!("failed to allocate trampoline region");
-                apply_trap_fallback(mapped_addr, len, false);
-                return true;
+            let (actual_addr_ptr, reservation_len) = if let Some(preferred) = preferred {
+                preferred
+            } else {
+                let Ok(ptr) = self.do_mmap_anonymous(
+                    None,
+                    initial_trampoline_len,
+                    ProtFlags::PROT_READ | ProtFlags::PROT_WRITE,
+                    MapFlags::MAP_ANONYMOUS | MapFlags::MAP_PRIVATE,
+                ) else {
+                    litebox_util_log::warn!("failed to allocate trampoline region");
+                    apply_trap_fallback(mapped_addr, len, false);
+                    return true;
+                };
+                (ptr, initial_trampoline_len)
             };
             let actual_addr = actual_addr_ptr.as_usize();
 
             let far_end = addr_usize.saturating_add(len);
+            // Individual gates perform their own reach checks.
             let distance = actual_addr
                 .abs_diff(addr_usize)
                 .max(actual_addr.abs_diff(far_end));
@@ -1272,7 +1310,8 @@ impl<Platform: ShimPlatform> Task<Platform> {
                     distance:? = distance;
                     "trampoline too far from code segment, skipping patching"
                 );
-                let _ = self.sys_munmap_raw(UserPtrMut::<u8>::from_usize(actual_addr), PAGE_SIZE);
+                let _ =
+                    self.sys_munmap_raw(UserPtrMut::<u8>::from_usize(actual_addr), reservation_len);
                 apply_trap_fallback(mapped_addr, len, false);
                 return true;
             }
@@ -1286,8 +1325,8 @@ impl<Platform: ShimPlatform> Task<Platform> {
                     .is_none()
                 {
                     litebox_util_log::warn!("failed to write syscall entry point to trampoline");
-                    let _ =
-                        self.sys_munmap_raw(UserPtrMut::<u8>::from_usize(actual_addr), PAGE_SIZE);
+                    let _ = self
+                        .sys_munmap_raw(UserPtrMut::<u8>::from_usize(actual_addr), reservation_len);
                     apply_trap_fallback(mapped_addr, len, false);
                     return true;
                 }
@@ -1296,7 +1335,7 @@ impl<Platform: ShimPlatform> Task<Platform> {
                 state.trampoline_cursor = 0;
             }
             state.trampoline_mapped = true;
-            state.trampoline_mapped_len = PAGE_SIZE;
+            state.trampoline_mapped_len = reservation_len;
         }
 
         // Performance guard: skip if this exact range was already patched.

--- a/litebox_syscall_rewriter/src/aarch64.rs
+++ b/litebox_syscall_rewriter/src/aarch64.rs
@@ -115,7 +115,7 @@ use alloc::format;
 use alloc::string::ToString as _;
 use alloc::vec::Vec;
 use core::ops::Range;
-use object::read::{Object as _, ObjectSection as _, ObjectSymbol as _};
+use object::read::{Object as _, ObjectSection as _, ObjectSegment as _, ObjectSymbol as _};
 use yaxpeax_arch::{Decoder, U8Reader};
 use yaxpeax_arm::armv8::a64::{
     InstDecoder, Instruction as DecodedInstruction, Opcode as DecodedOpcode, Operand,
@@ -198,6 +198,39 @@ impl ElfCodeMetadata {
         })
     }
 
+    /// Bounds gates at this ELF's file addresses. Remapping, load bias, or
+    /// runtime rescans may still require growth.
+    pub fn trampoline_size_upper_bound(
+        &self,
+        elf: &[u8],
+        options: crate::RewriteOptions,
+    ) -> Result<usize> {
+        let sites = find_patch_sites_with_code_ranges(
+            &self.executable,
+            &self.identified,
+            elf,
+            RewriteConfig::new(options.target_host(), options.effective_virtualize_x18()),
+        )?;
+        sites.into_iter().try_fold(0usize, |total, site| {
+            let gate_bytes = match site.kind {
+                PatchKind::Svc => SVC_SLOT_BYTES,
+                PatchKind::MsrTpidr(_) => MSR_SLOT_BYTES,
+                PatchKind::MrsTpidr(_) => MRS_SLOT_BYTES,
+                PatchKind::X18(X18TransformResult::Supported(_)) => X18_SLOT_BYTES,
+                PatchKind::X18(X18TransformResult::Unsupported(_)) => 0,
+                PatchKind::X18StackWriteback(_) => X18_STACK_WRITEBACK_SLOT_BYTES,
+                PatchKind::X18CompareBranch(_) => X18_COMPARE_BRANCH_SLOT_BYTES,
+                PatchKind::X18Adr(_) => X18_ADR_SLOT_BYTES,
+                PatchKind::X18Branch(_) => X18_BRANCH_SLOT_BYTES,
+            };
+            // One prologue per site covers separate mapping batches.
+            total
+                .checked_add(GATES_START_OFFSET)
+                .and_then(|total| total.checked_add(gate_bytes))
+                .ok_or_else(|| Error::AddressOverflow("AArch64 trampoline size".into()))
+        })
+    }
+
     /// Total executable and identified-code bytes represented by this metadata.
     pub fn coverage_bytes(&self) -> (u64, u64) {
         let total = |ranges: &[TextSectionInfo]| {
@@ -212,12 +245,43 @@ impl ElfCodeMetadata {
 pub(crate) fn elf_code_metadata(
     file: &object::File<'_>,
 ) -> core::result::Result<ElfCodeMetadata, InternalError> {
-    let executable = text_sections(file)?;
+    // Stripped ELFs may expose code only through executable PT_LOAD segments.
+    let executable = match text_sections(file) {
+        Ok(sections) => sections,
+        Err(InternalError::NoTextSectionFound) => executable_segments(file)?,
+        Err(error) => return Err(error),
+    };
     let identified = code_sections(file, &executable);
     Ok(ElfCodeMetadata {
         executable,
         identified,
     })
+}
+
+fn executable_segments(
+    file: &object::File<'_>,
+) -> core::result::Result<Vec<TextSectionInfo>, InternalError> {
+    let executable = file
+        .segments()
+        .filter_map(|segment| {
+            let object::SegmentFlags::Elf { p_flags } = segment.flags() else {
+                return None;
+            };
+            if p_flags & object::elf::PF_X == 0 {
+                return None;
+            }
+            let (file_offset, size) = segment.file_range();
+            (size != 0).then_some(TextSectionInfo {
+                vaddr: segment.address(),
+                file_offset,
+                size,
+            })
+        })
+        .collect::<Vec<_>>();
+    if executable.is_empty() {
+        return Err(InternalError::NoTextSectionFound);
+    }
+    Ok(executable)
 }
 
 #[expect(
@@ -6083,6 +6147,71 @@ mod tests {
         assert_eq!(ranges[0].vaddr, 0x1000);
         assert_eq!(ranges[0].file_offset, 0x200);
         assert_eq!(ranges[0].size, 0xc);
+    }
+
+    #[test]
+    fn trampoline_size_upper_bound_accounts_for_per_mapping_prologues() {
+        let words = [
+            SVC_0,
+            msr_tpidr_el0(5),
+            Insn::MrsTpidrEl0(9).encode().unwrap(),
+        ];
+        let bytes = words
+            .iter()
+            .flat_map(|word| word.to_le_bytes())
+            .collect::<Vec<_>>();
+        let metadata = ElfCodeMetadata {
+            executable: vec![TextSectionInfo {
+                vaddr: 0x1000,
+                file_offset: 0,
+                size: bytes.len() as u64,
+            }],
+            identified: vec![TextSectionInfo {
+                vaddr: 0x1000,
+                file_offset: 0,
+                size: bytes.len() as u64,
+            }],
+        };
+
+        let bound = metadata
+            .trampoline_size_upper_bound(&bytes, crate::RewriteOptions::default())
+            .unwrap();
+        let emitted = words
+            .iter()
+            .enumerate()
+            .map(|(index, word)| {
+                hook_words(&[*word], 0x1000 + (index * INSN_BYTES) as u64, 0x400000)
+                    .1
+                    .len()
+            })
+            .sum::<usize>();
+
+        assert_eq!(
+            bound,
+            3 * GATES_START_OFFSET + SVC_SLOT_BYTES + MSR_SLOT_BYTES + MRS_SLOT_BYTES
+        );
+        assert_eq!(emitted, bound);
+    }
+
+    #[test]
+    fn no_patch_sites_have_zero_trampoline_size_upper_bound() {
+        let bytes = NOP.to_le_bytes();
+        let section = TextSectionInfo {
+            vaddr: 0x1000,
+            file_offset: 0,
+            size: bytes.len() as u64,
+        };
+        let metadata = ElfCodeMetadata {
+            executable: vec![section],
+            identified: vec![section],
+        };
+
+        assert_eq!(
+            metadata
+                .trampoline_size_upper_bound(&bytes, crate::RewriteOptions::default())
+                .unwrap(),
+            0
+        );
     }
 
     #[test]

--- a/litebox_syscall_rewriter/src/aarch64.rs
+++ b/litebox_syscall_rewriter/src/aarch64.rs
@@ -6194,27 +6194,6 @@ mod tests {
     }
 
     #[test]
-    fn no_patch_sites_have_zero_trampoline_size_upper_bound() {
-        let bytes = NOP.to_le_bytes();
-        let section = TextSectionInfo {
-            vaddr: 0x1000,
-            file_offset: 0,
-            size: bytes.len() as u64,
-        };
-        let metadata = ElfCodeMetadata {
-            executable: vec![section],
-            identified: vec![section],
-        };
-
-        assert_eq!(
-            metadata
-                .trampoline_size_upper_bound(&bytes, crate::RewriteOptions::default())
-                .unwrap(),
-            0
-        );
-    }
-
-    #[test]
     fn no_patch_sites_emit_no_trampoline() {
         // No patch sites: a NOP-only section yields no trampoline at all, so the
         // caller emits a size-0 sentinel (matching the x86-64 path).

--- a/litebox_syscall_rewriter/src/lib.rs
+++ b/litebox_syscall_rewriter/src/lib.rs
@@ -38,12 +38,10 @@ pub const TRAMPOLINE_ENTRY_POINT_BYTES: usize = size_of::<u64>();
 #[cfg(target_arch = "aarch64")]
 pub const TRAMPOLINE_ENTRY_POINT_BYTES: usize = 0;
 
-/// Furthest a trampoline may sit from any byte of the code segment reaching it.
+/// Furthest preferred trampoline base from the code segment.
 ///
-/// A rewritten site branches to its stub with a single direct branch, so a
-/// trampoline beyond this displacement cannot be reached and the site has to
-/// fall back to a trap. Each architecture's value is its direct-branch range
-/// less a margin for the last stub in the trampoline.
+/// AArch64 runtime reservations may exceed the nominal tail margin; each gate
+/// performs its own reach check.
 #[cfg(target_arch = "x86_64")]
 pub const MAX_TRAMPOLINE_DISPLACEMENT: usize = 0x7FFF_0000;
 #[cfg(target_arch = "aarch64")]

--- a/litebox_syscall_rewriter/tests/aarch64_tests.rs
+++ b/litebox_syscall_rewriter/tests/aarch64_tests.rs
@@ -235,6 +235,56 @@ fn aarch64_metadata_projects_text_into_file_mapping() {
 }
 
 #[test]
+fn aarch64_trampoline_size_bound_covers_emitted_fixture() {
+    let mut aligned = vec![0u64; HELLO_AARCH64.len().div_ceil(8)];
+    zerocopy::IntoBytes::as_mut_bytes(aligned.as_mut_slice())[..HELLO_AARCH64.len()]
+        .copy_from_slice(HELLO_AARCH64);
+    let metadata = litebox_syscall_rewriter::aarch64::ElfCodeMetadata::parse_aligned_in_place(
+        &mut aligned,
+        HELLO_AARCH64.len(),
+    )
+    .unwrap();
+    let bound = metadata
+        .trampoline_size_upper_bound(
+            &zerocopy::IntoBytes::as_bytes(aligned.as_slice())[..HELLO_AARCH64.len()],
+            RewriteOptions::default(),
+        )
+        .unwrap();
+
+    let out = hook_syscalls_in_elf(HELLO_AARCH64, Some(0)).unwrap();
+    let (_, _, emitted) = trampoline_header(&out);
+    assert!(emitted > 0, "fixture must emit a trampoline");
+    assert!(emitted <= bound as u64, "{emitted:#x} > {bound:#x}");
+}
+
+#[test]
+fn aarch64_metadata_falls_back_to_executable_segments_without_sections() {
+    let mut elf = HELLO_AARCH64.to_vec();
+    elf[40..48].fill(0); // e_shoff
+    elf[58..64].fill(0); // e_shentsize, e_shnum, e_shstrndx
+    let mut aligned = vec![0u64; elf.len().div_ceil(8)];
+    zerocopy::IntoBytes::as_mut_bytes(aligned.as_mut_slice())[..elf.len()].copy_from_slice(&elf);
+
+    let metadata = litebox_syscall_rewriter::aarch64::ElfCodeMetadata::parse_aligned_in_place(
+        &mut aligned,
+        elf.len(),
+    )
+    .unwrap();
+    let (executable, identified) = metadata.coverage_bytes();
+    assert!(executable > 0);
+    assert_eq!(identified, executable);
+    assert!(
+        metadata
+            .trampoline_size_upper_bound(
+                &zerocopy::IntoBytes::as_bytes(aligned.as_slice())[..elf.len()],
+                RewriteOptions::default(),
+            )
+            .unwrap()
+            > 0
+    );
+}
+
+#[test]
 fn aarch64_text_section_confirms_x18_code_without_symbols_or_fdes() {
     let mut elf = HELLO_AARCH64.to_vec();
     let sections = exec_sections(&elf);


### PR DESCRIPTION
This PR allows the AArch64 loader to preallocate trampolines by estimating their sizes from ELF rewrite-site scans. Currently, the loader solely relies on incremental trampoline resizing, which can fail if gaps for placing trampolines are too small. It still supports the incremental resizing for runtime remap/rescan.