### PR TITLE
Fix flaky AArch64 trampoline allocation

### DIFF
--- a/litebox_shim_linux/src/syscalls/mm.rs
+++ b/litebox_shim_linux/src/syscalls/mm.rs
@@ -171,7 +171,7 @@ fn align_down(addr: usize, align: usize) -> usize {
     addr & !(align - 1)
 }
 
-/// Returns the first reservation, preferring capacity over address locality.
+/// Tries preferred-full, anywhere-full, then preferred-one-page.
 fn choose_trampoline_reservation<T>(
     capacity: usize,
     page_size: usize,
@@ -1294,6 +1294,12 @@ impl<Platform: ShimPlatform> Task<Platform> {
                 Err(_) => None,
             };
             let far_end = addr_usize.saturating_add(len);
+            let trampoline_distance = |actual_addr: usize| {
+                actual_addr
+                    .abs_diff(addr_usize)
+                    .max(actual_addr.abs_diff(far_end))
+            };
+            let mut rejected_distance = None;
             let reservation = choose_trampoline_reservation(
                 initial_trampoline_len,
                 PAGE_SIZE,
@@ -1307,34 +1313,37 @@ impl<Platform: ShimPlatform> Task<Platform> {
                     )
                     .ok()
                     .and_then(|ptr| {
-                        let actual_addr = ptr.as_usize();
-                        let distance = actual_addr
-                            .abs_diff(addr_usize)
-                            .max(actual_addr.abs_diff(far_end));
-                        if distance <= litebox_syscall_rewriter::MAX_TRAMPOLINE_DISPLACEMENT {
-                            Some(ptr)
-                        } else {
-                            litebox_util_log::warn!(
+                        let distance = trampoline_distance(ptr.as_usize());
+                        if distance > litebox_syscall_rewriter::MAX_TRAMPOLINE_DISPLACEMENT {
+                            rejected_distance = Some(distance);
+                            litebox_util_log::debug!(
                                 distance:? = distance;
-                                "trampoline too far from code segment, skipping patching"
+                                "rejecting arbitrary trampoline reservation outside branch range"
                             );
                             let _ = self.sys_munmap_raw(ptr, reservation_len);
                             None
+                        } else {
+                            Some(ptr)
                         }
                     })
                 },
             );
             let Some((actual_addr_ptr, reservation_len)) = reservation else {
-                litebox_util_log::warn!("failed to allocate trampoline region");
+                if let Some(distance) = rejected_distance {
+                    litebox_util_log::warn!(
+                        distance:? = distance;
+                        "trampoline too far from code segment, skipping patching"
+                    );
+                } else {
+                    litebox_util_log::warn!("failed to allocate trampoline region");
+                }
                 apply_trap_fallback(mapped_addr, len, false);
                 return true;
             };
             let actual_addr = actual_addr_ptr.as_usize();
 
             // Defend the preferred paths; individual gates also check reach.
-            let distance = actual_addr
-                .abs_diff(addr_usize)
-                .max(actual_addr.abs_diff(far_end));
+            let distance = trampoline_distance(actual_addr);
             if distance > litebox_syscall_rewriter::MAX_TRAMPOLINE_DISPLACEMENT {
                 litebox_util_log::warn!(
                     distance:? = distance;

--- a/litebox_shim_linux/src/syscalls/mm.rs
+++ b/litebox_shim_linux/src/syscalls/mm.rs
@@ -171,6 +171,25 @@ fn align_down(addr: usize, align: usize) -> usize {
     addr & !(align - 1)
 }
 
+/// Returns the first reservation, preferring capacity over address locality.
+fn choose_trampoline_reservation<T>(
+    capacity: usize,
+    page_size: usize,
+    mut map_preferred: impl FnMut(usize) -> Option<T>,
+    mut map_anywhere: impl FnMut(usize) -> Option<T>,
+) -> Option<(T, usize)> {
+    map_preferred(capacity)
+        .map(|reservation| (reservation, capacity))
+        .or_else(|| map_anywhere(capacity).map(|reservation| (reservation, capacity)))
+        .or_else(|| {
+            if capacity > page_size {
+                map_preferred(page_size).map(|reservation| (reservation, page_size))
+            } else {
+                None
+            }
+        })
+}
+
 impl<Platform: ShimPlatform> Task<Platform> {
     #[inline]
     fn do_mmap(
@@ -1274,34 +1293,45 @@ impl<Platform: ShimPlatform> Task<Platform> {
                 }
                 Err(_) => None,
             };
-            let preferred = map_preferred(initial_trampoline_len)
-                .map(|ptr| (ptr, initial_trampoline_len))
-                .or_else(|| {
-                    if initial_trampoline_len > PAGE_SIZE {
-                        map_preferred(PAGE_SIZE).map(|ptr| (ptr, PAGE_SIZE))
-                    } else {
-                        None
-                    }
-                });
-            let (actual_addr_ptr, reservation_len) = if let Some(preferred) = preferred {
-                preferred
-            } else {
-                let Ok(ptr) = self.do_mmap_anonymous(
-                    None,
-                    initial_trampoline_len,
-                    ProtFlags::PROT_READ | ProtFlags::PROT_WRITE,
-                    MapFlags::MAP_ANONYMOUS | MapFlags::MAP_PRIVATE,
-                ) else {
-                    litebox_util_log::warn!("failed to allocate trampoline region");
-                    apply_trap_fallback(mapped_addr, len, false);
-                    return true;
-                };
-                (ptr, initial_trampoline_len)
+            let far_end = addr_usize.saturating_add(len);
+            let reservation = choose_trampoline_reservation(
+                initial_trampoline_len,
+                PAGE_SIZE,
+                map_preferred,
+                |reservation_len| {
+                    self.do_mmap_anonymous(
+                        None,
+                        reservation_len,
+                        ProtFlags::PROT_READ | ProtFlags::PROT_WRITE,
+                        MapFlags::MAP_ANONYMOUS | MapFlags::MAP_PRIVATE,
+                    )
+                    .ok()
+                    .and_then(|ptr| {
+                        let actual_addr = ptr.as_usize();
+                        let distance = actual_addr
+                            .abs_diff(addr_usize)
+                            .max(actual_addr.abs_diff(far_end));
+                        if distance <= litebox_syscall_rewriter::MAX_TRAMPOLINE_DISPLACEMENT {
+                            Some(ptr)
+                        } else {
+                            litebox_util_log::warn!(
+                                distance:? = distance;
+                                "trampoline too far from code segment, skipping patching"
+                            );
+                            let _ = self.sys_munmap_raw(ptr, reservation_len);
+                            None
+                        }
+                    })
+                },
+            );
+            let Some((actual_addr_ptr, reservation_len)) = reservation else {
+                litebox_util_log::warn!("failed to allocate trampoline region");
+                apply_trap_fallback(mapped_addr, len, false);
+                return true;
             };
             let actual_addr = actual_addr_ptr.as_usize();
 
-            let far_end = addr_usize.saturating_add(len);
-            // Individual gates perform their own reach checks.
+            // Defend the preferred paths; individual gates also check reach.
             let distance = actual_addr
                 .abs_diff(addr_usize)
                 .max(actual_addr.abs_diff(far_end));
@@ -1579,6 +1609,7 @@ impl<Platform: ShimPlatform> Task<Platform> {
 
 #[cfg(test)]
 mod tests {
+    use super::PAGE_SIZE;
     use litebox::{
         fs::{Mode, OFlags},
         platform::PageManagementProvider,
@@ -1587,6 +1618,29 @@ mod tests {
 
     use crate::syscalls::tests::TestPlatform as Platform;
     use crate::{UserPtrMut, syscalls::tests::init_platform};
+
+    #[test]
+    fn full_capacity_anywhere_precedes_preferred_one_page() {
+        let calls = core::cell::RefCell::new(alloc::vec::Vec::new());
+        let reservation = super::choose_trampoline_reservation(
+            7 * PAGE_SIZE,
+            PAGE_SIZE,
+            |len| {
+                calls.borrow_mut().push(("preferred", len));
+                None
+            },
+            |len| {
+                calls.borrow_mut().push(("anywhere", len));
+                Some("full capacity")
+            },
+        );
+
+        assert_eq!(reservation, Some(("full capacity", 7 * PAGE_SIZE)));
+        assert_eq!(
+            calls.into_inner(),
+            alloc::vec![("preferred", 7 * PAGE_SIZE), ("anywhere", 7 * PAGE_SIZE),]
+        );
+    }
 
     /// Fail closed: an unpatched placeholder executes silently.
     #[cfg(target_arch = "aarch64")]


### PR DESCRIPTION
This PR avoids transient AArch64 trampoline allocation failures due to host memory layout changes by prioritizing trampoline capacity over address locality.