### PR TITLE
Fix Linux guest signal exit code reporting

### DIFF
--- a/litebox_runner_linux_userland/src/lib.rs
+++ b/litebox_runner_linux_userland/src/lib.rs
@@ -397,7 +397,7 @@ pub fn run(cli_args: CliArgs) -> Result<()> {
         shutdown.store(true, core::sync::atomic::Ordering::Relaxed);
         net_worker.join().unwrap();
     }
-    std::process::exit(program.process.wait())
+    std::process::exit(program.process.wait_for_unix_shell_exit_code())
 }
 
 /// Pin the current thread to a specific CPU core

--- a/litebox_shim_linux/src/lib.rs
+++ b/litebox_shim_linux/src/lib.rs
@@ -359,6 +359,14 @@ impl<Platform: ShimPlatform> LinuxShimProcess<Platform> {
             syscalls::process::ExitStatus::Signal(signal) => signal.as_i32() + 256,
         }
     }
+
+    /// Wait for the process to exit, returning an exit code suitable for a Unix shell.
+    pub fn wait_for_unix_shell_exit_code(&self) -> i32 {
+        match self.0.wait_for_exit() {
+            syscalls::process::ExitStatus::Exit(v) => i32::from(v) & 0xff,
+            syscalls::process::ExitStatus::Signal(signal) => signal.as_i32() + 128,
+        }
+    }
 }
 
 /// Create the default file system with the given in-memory layer and tar data.


### PR DESCRIPTION
 This PR fixes Linux guest signal exit code reporting in the Linux userland runner. LiteBox currently passes `signal + 256` to `std::process::exit()` whereas the shell convention is `signal + 128`.